### PR TITLE
Match 327 functions across ov002, ov006, arm9, ov034

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -23,3 +23,4 @@ it is fair to take over: ping the claimant first.
 | ov034 .text 0x021111a0-0x02113820 | claude-agent | 2026-06-20 | paused (easy leaves done; residue is logic) |
 | ov006 (small unmatched leaf/logic sweep) | claude-agent | 2026-06-20 | active (91 matched; residue is codegen walls) |
 | arm9/main (small <=0x40 leaf sweep) | claude-agent | 2026-06-20 | active |
+| ov002 (small unmatched leaf/logic sweep) | claude-agent | 2026-06-20 | active |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,3 +20,4 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov034 .text 0x021111a0-0x02113820 | claude-agent | 2026-06-20 | active |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -21,4 +21,5 @@ it is fair to take over: ping the claimant first.
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
 | ov034 .text 0x021111a0-0x02113820 | claude-agent | 2026-06-20 | paused (easy leaves done; residue is logic) |
-| ov006 (small unmatched leaf/logic sweep) | claude-agent | 2026-06-20 | active |
+| ov006 (small unmatched leaf/logic sweep) | claude-agent | 2026-06-20 | active (91 matched; residue is codegen walls) |
+| arm9/main (small <=0x40 leaf sweep) | claude-agent | 2026-06-20 | active |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,4 +20,5 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
-| ov034 .text 0x021111a0-0x02113820 | claude-agent | 2026-06-20 | active |
+| ov034 .text 0x021111a0-0x02113820 | claude-agent | 2026-06-20 | paused (easy leaves done; residue is logic) |
+| ov006 (small unmatched leaf/logic sweep) | claude-agent | 2026-06-20 | active |

--- a/src/AngleDiff.c
+++ b/src/AngleDiff.c
@@ -1,0 +1,10 @@
+/* AngleDiff at 0x0203b0e8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+int AngleDiff(int a, int b) {
+    short d = (short)(a - b);
+    if (d < 0) return -d;
+    return d;
+}

--- a/src/GetLevelPart.c
+++ b/src/GetLevelPart.c
@@ -1,0 +1,9 @@
+/* GetLevelPart at 0x02013548
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern signed char data_02075264[];
+signed char GetLevelPart(int idx) {
+    return data_02075264[idx];
+}

--- a/src/GetTeleportDestObj.c
+++ b/src/GetTeleportDestObj.c
@@ -1,0 +1,10 @@
+/* GetTeleportDestObj at 0x0202b07c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern int *data_0209f330;
+
+int *GetTeleportDestObj(int idx) {
+    return data_0209f330 + idx * 2;
+}

--- a/src/LinkSilverStarAndStarMarker.c
+++ b/src/LinkSilverStarAndStarMarker.c
@@ -1,0 +1,18 @@
+/* LinkSilverStarAndStarMarker at 0x020e71d4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void LinkSilverStarAndStarMarker(char *o, char *star) {
+    if (star != 0) {
+        *(int *)(o + 0x1cc) = *(int *)(star + 4);
+        *(char *)(o + 0x1da) = *(int *)(star + 0x440);
+        short v = *(short *)(star + 0xce);
+        if (v >= 0) {
+            *(short *)(o + 0x1d6) = v;
+        }
+        return;
+    }
+    *(short *)(o + 0x1d6) = -1;
+    *(int *)(o + 0x1cc) = 0;
+}

--- a/src/_Z11LoadObjectsRN11LVL_Overlay8ObjTableEij.cpp
+++ b/src/_Z11LoadObjectsRN11LVL_Overlay8ObjTableEij.cpp
@@ -1,0 +1,26 @@
+//cpp
+typedef void (*ObjFunc)(void *, int, unsigned int);
+
+extern ObjFunc data_ov002_0210cbb8[];
+extern unsigned char data_0209f220;
+
+struct LVL_Overlay {
+    struct ObjTable {
+        unsigned short count;
+        unsigned char pad[2];
+        unsigned char *entries;
+    };
+};
+
+extern "C" void _Z11LoadObjectsRN11LVL_Overlay8ObjTableEij(LVL_Overlay::ObjTable &tbl, int a, unsigned int b) {
+    unsigned char *e = tbl.entries;
+    int i;
+    for (i = 0; i < (int)tbl.count; i++, e += 8) {
+        unsigned char v = e[0];
+        int group = (v >> 5) & 7;
+        if (group == 0 || group == data_0209f220) {
+            ObjFunc fp = data_ov002_0210cbb8[v & 0x1f];
+            if (fp != 0) fp(e, a, b);
+        }
+    }
+}

--- a/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.c
+++ b/src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.c
@@ -1,0 +1,14 @@
+/* _Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij at 0x020fe3cc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct ObjSubTable {
+    int a;
+    int **p;
+};
+extern int *data_02092134;
+
+void _Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij(struct ObjSubTable *r0, int b, unsigned int c) {
+    data_02092134 = *r0->p;
+}

--- a/src/_ZN11RaycastLine4Line3SetERK7Vector3S3_.c
+++ b/src/_ZN11RaycastLine4Line3SetERK7Vector3S3_.c
@@ -1,0 +1,17 @@
+/* _ZN11RaycastLine4Line3SetERK7Vector3S3_ at 0x020fea84
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef struct { int x, y, z; } Vector3;
+
+typedef struct { Vector3 a, b; } Line;
+
+void _ZN11RaycastLine4Line3SetERK7Vector3S3_(Line *self, const Vector3 *p, const Vector3 *q) {
+    self->a.x = p->x;
+    self->a.y = p->y;
+    self->a.z = p->z;
+    self->b.x = q->x;
+    self->b.y = q->y;
+    self->b.z = q->z;
+}

--- a/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.c
+++ b/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.c
@@ -1,0 +1,10 @@
+/* _ZN18MovingCylinderClsn10GetOwnerIDEv at 0x0201493c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct Owner { char pad[4]; int id; };
+struct MovingCylinderClsn { char pad[0x30]; struct Owner *owner; };
+int _ZN18MovingCylinderClsn10GetOwnerIDEv(struct MovingCylinderClsn *this) {
+    return this->owner->id;
+}

--- a/src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.c
@@ -1,0 +1,11 @@
+/* _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb at 0x02022630
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct System { char pad[0x3a]; short val; };
+struct SimpleCallback { char pad[4]; short out; };
+int _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb(struct SimpleCallback *this, struct System *sys, char b) {
+    this->out = sys->val;
+    return 1;
+}

--- a/src/__sinit_ov002_021014e4.c
+++ b/src/__sinit_ov002_021014e4.c
@@ -1,0 +1,34 @@
+/* __sinit_ov002_021014e4 at 0x021014e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef struct { int a, b; } Pair;
+
+extern Pair data_ov002_02109758;
+extern Pair data_ov002_02109768;
+extern Pair data_ov002_02109750;
+extern Pair data_ov002_02109748;
+extern Pair data_ov002_02109740;
+extern Pair data_ov002_02109760;
+
+struct Dest {
+    Pair p0;   // 0x00
+    Pair p1;   // 0x08
+    int  gap0; // 0x10
+    Pair p2;   // 0x14
+    Pair p3;   // 0x1c
+    int  gap1; // 0x24
+    Pair p4;   // 0x28
+    Pair p5;   // 0x30
+};
+extern struct Dest data_ov002_021097bc;
+
+void __sinit_ov002_021014e4(void) {
+    data_ov002_021097bc.p0 = data_ov002_02109758;
+    data_ov002_021097bc.p1 = data_ov002_02109768;
+    data_ov002_021097bc.p2 = data_ov002_02109750;
+    data_ov002_021097bc.p3 = data_ov002_02109748;
+    data_ov002_021097bc.p4 = data_ov002_02109740;
+    data_ov002_021097bc.p5 = data_ov002_02109760;
+}

--- a/src/__sinit_ov002_02101900.c
+++ b/src/__sinit_ov002_02101900.c
@@ -1,0 +1,22 @@
+/* __sinit_ov002_02101900 at 0x02101900
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern char data_ov002_0210e104;
+extern char data_ov002_0210e10c;
+extern char data_ov002_0210e0fc;
+extern char data_ov002_0210e118;
+extern void func_02017ab4(void);
+extern void func_02017984(void);
+
+extern void func_02017acc(void *p, int x);
+extern void func_020731dc(void *a, void (*b)(void), void *c);
+extern void _ZN13SharedFilePtr9ConstructEj(void *t, unsigned int x);
+
+void __sinit_ov002_02101900(void) {
+    func_02017acc(&data_ov002_0210e104, 0x470);
+    func_020731dc(&data_ov002_0210e104, func_02017ab4, &data_ov002_0210e10c);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov002_0210e0fc, 0x471);
+    func_020731dc(&data_ov002_0210e0fc, func_02017984, &data_ov002_0210e118);
+}

--- a/src/__sinit_ov002_0210804c.c
+++ b/src/__sinit_ov002_0210804c.c
@@ -1,0 +1,16 @@
+/* __sinit_ov002_0210804c at 0x0210804c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int data_ov002_0211116c[3];
+extern void func_020072c0(void);
+extern int data_ov002_02111160;
+extern void func_020731dc(void *a, void *b, void *c, int d);
+
+void __sinit_ov002_0210804c(void) {
+    data_ov002_0211116c[0] = 0x80000;
+    data_ov002_0211116c[1] = 0;
+    data_ov002_0211116c[2] = 0x60000;
+    func_020731dc(data_ov002_0211116c, (void*)func_020072c0, &data_ov002_02111160, 0x60000);
+}

--- a/src/func_02018ac4.c
+++ b/src/func_02018ac4.c
@@ -1,0 +1,8 @@
+/* func_02018ac4 at 0x02018ac4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+unsigned func_02018ac4(unsigned *p) {
+    return *p >> 8;
+}

--- a/src/func_02037940.c
+++ b/src/func_02037940.c
@@ -1,0 +1,8 @@
+/* func_02037940 at 0x02037940
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+void func_02037940(void *p, int val) {
+    *(unsigned char *)((char *)p + 0x70) = val & ~0x1c;
+}

--- a/src/func_02037fc0.c
+++ b/src/func_02037fc0.c
@@ -1,0 +1,8 @@
+/* func_02037fc0 at 0x02037fc0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+int func_02037fc0(void *p) {
+    return *(unsigned short *)((char *)p + 0x1a) != 0x18;
+}

--- a/src/func_020396c0.c
+++ b/src/func_020396c0.c
@@ -1,0 +1,9 @@
+/* func_020396c0 at 0x020396c0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+void func_020396c0(void *p, int v) {
+    if (v < 0) v = 0;
+    *(int *)((char *)p + 0x48) = v;
+}

--- a/src/func_020396dc.c
+++ b/src/func_020396dc.c
@@ -1,0 +1,11 @@
+/* func_020396dc at 0x020396dc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct Inner { char pad[8]; unsigned int v; };
+struct Outer { char pad[0x20]; struct Inner *p; };
+
+unsigned int func_020396dc(struct Outer *o, unsigned int x) {
+    return (x - o->p->v) >> 4;
+}

--- a/src/func_0203ad44.c
+++ b/src/func_0203ad44.c
@@ -1,0 +1,8 @@
+/* func_0203ad44 at 0x0203ad44
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+int func_0203ad44(unsigned char **p) {
+    return (*p)[5] & 0x7f;
+}

--- a/src/func_0203ad54.c
+++ b/src/func_0203ad54.c
@@ -1,0 +1,11 @@
+/* func_0203ad54 at 0x0203ad54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct Inner { char pad[4]; unsigned char b; };
+struct Outer { struct Inner *p; };
+
+unsigned char func_0203ad54(struct Outer *o) {
+    return o->p->b;
+}

--- a/src/func_0203db3c.c
+++ b/src/func_0203db3c.c
@@ -1,0 +1,9 @@
+/* func_0203db3c at 0x0203db3c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern unsigned char data_020a1052[];
+void func_0203db3c(int idx, unsigned char val) {
+    data_020a1052[idx] = val;
+}

--- a/src/func_0204f914.c
+++ b/src/func_0204f914.c
@@ -1,0 +1,12 @@
+/* func_0204f914 at 0x0204f914
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct S { char pad[0x40]; unsigned char flag; };
+
+void func_0204f914(struct S **pp, unsigned char v) {
+    struct S *p = *pp;
+    if (p != 0)
+        p->flag = v;
+}

--- a/src/func_0204f924.c
+++ b/src/func_0204f924.c
@@ -1,0 +1,10 @@
+/* func_0204f924 at 0x0204f924
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+struct S { unsigned char b[0x42]; };
+void func_0204f924(struct S **pp, unsigned char v) {
+    struct S *p = *pp;
+    if (p) p->b[0x41] = v;
+}

--- a/src/func_0205ff00.c
+++ b/src/func_0205ff00.c
@@ -1,0 +1,8 @@
+/* func_0205ff00 at 0x0205ff00
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+void func_0205ff00(int r0, int *r1) {
+    *r1 = r0;
+}

--- a/src/func_02065a84.c
+++ b/src/func_02065a84.c
@@ -1,0 +1,9 @@
+/* func_02065a84 at 0x02065a84
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern void *data_0209a074;
+void func_02065a84(void *p) {
+    data_0209a074 = p;
+}

--- a/src/func_02065ef8.c
+++ b/src/func_02065ef8.c
@@ -1,0 +1,9 @@
+/* func_02065ef8 at 0x02065ef8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+unsigned int func_02065ef8(unsigned int a, unsigned int b) {
+    if (b <= a) b = a;
+    return b;
+}

--- a/src/func_ov002_020afde4.cpp
+++ b/src/func_ov002_020afde4.cpp
@@ -1,0 +1,24 @@
+//cpp
+extern "C" {
+struct Actor;
+Actor *_ZN5Actor13ClosestPlayerEv(Actor *self);
+short Vec3_HorzAngle(const void *a, const void *b);
+void func_ov002_020af3a8(Actor *self);
+int _ZNK12WithMeshClsn8IsOnWallEv(void *clsn);
+int _ZN5Actor15IsPlayerInRangeEi(Actor *self, int r);
+}
+
+extern "C" void func_ov002_020afde4(Actor *self) {
+    char *p = (char *)self;
+    Actor *cp = _ZN5Actor13ClosestPlayerEv(self);
+    if (cp) {
+        *(short *)(p + 0x94) = Vec3_HorzAngle(p + 0x5c, (char *)cp + 0x5c) + 0x8000;
+    }
+    func_ov002_020af3a8(self);
+    if (_ZNK12WithMeshClsn8IsOnWallEv(p + 0x144)) {
+        *(int *)(p + 0x388) = 2;
+    }
+    if (_ZN5Actor15IsPlayerInRangeEi(self, 0xbb8) == 0) {
+        *(int *)(p + 0x388) = 2;
+    }
+}

--- a/src/func_ov002_020affe8.cpp
+++ b/src/func_ov002_020affe8.cpp
@@ -1,0 +1,30 @@
+//cpp
+typedef int Fix12i;
+struct SharedFilePtr { void Release(); };
+namespace Particle {
+struct System {
+    static System *NewSimple(unsigned int, Fix12i, Fix12i, Fix12i);
+};
+}
+extern "C" {
+extern SharedFilePtr data_ov002_0210d9d8;
+extern SharedFilePtr data_ov002_0210da30;
+
+int func_ov002_020affe8(char *self)
+{
+    unsigned int v = *(unsigned int *)(self + 0x384);
+    if (v != 0xb && v != 0xc) {
+        int isLoad = (*(unsigned short *)(self + 0xc) == 0x114);
+        if (isLoad)
+            data_ov002_0210d9d8.Release();
+        else
+            data_ov002_0210da30.Release();
+    }
+    if (*(unsigned int *)(self + 0x384) - 0xb <= 1)
+        Particle::System::NewSimple(0xd2,
+                                    *(Fix12i *)(self + 0x5c),
+                                    *(Fix12i *)(self + 0x60) + 0x28000,
+                                    *(Fix12i *)(self + 0x64));
+    return 1;
+}
+}

--- a/src/func_ov002_020b0070.cpp
+++ b/src/func_ov002_020b0070.cpp
@@ -1,0 +1,29 @@
+//cpp
+struct Obj {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void func5(int x);
+};
+
+extern "C" {
+
+unsigned int func_ov002_020b0070(char *self)
+{
+    if (*(unsigned char *)(self + 0x38e) == 0 || *(unsigned char *)(self + 0x38f) == 0)
+        return 1;
+    {
+        int b = (*(unsigned int *)(self + 0xb0) & 0x40000) ? 1 : 0;
+        if (b)
+            return 1;
+    }
+    {
+        Obj *o = (Obj *)(self + 0x300);
+        o->func5(0);
+    }
+    return 1;
+}
+
+}

--- a/src/func_ov002_020b0a0c.c
+++ b/src/func_ov002_020b0a0c.c
@@ -1,0 +1,30 @@
+/* func_ov002_020b0a0c at 0x020b0a0c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef signed char s8;
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern void LoadLevel(s8 levelID, u8 entranceID, s8 starID, u32 d, s8 e);
+extern u8 data_0209f2c0[];
+
+struct Obj {
+    char pad[8];
+    u32 f8;
+    char pad2[0x90 - 0xc];
+    short f90;
+};
+
+void func_ov002_020b0a0c(struct Obj *self)
+{
+    data_0209f2c0[0] = (u8)self->f90;
+    {
+        u32 v = self->f8;
+        u32 hi = v >> 0x18;
+        u32 mid = (v >> 8) & 0xff;
+        if (mid == 0xff) mid = -1;
+        LoadLevel((s8)hi, (u8)(v >> 0x10), -1, 0, (s8)mid);
+    }
+}

--- a/src/func_ov002_020b1884.cpp
+++ b/src/func_ov002_020b1884.cpp
@@ -1,0 +1,35 @@
+//cpp
+struct Vector3 { int x, y, z; };
+
+extern "C" void GiveCoins(unsigned int, int);
+
+struct Sound {
+    static void PlayBank3(unsigned int, const Vector3 &);
+};
+
+struct Player {
+    char pad[0x6d8];
+    unsigned char f6d8;       /* +0x6d8 */
+    char pad2[0x706 - 0x6d9];
+    unsigned char f706;       /* +0x706 */
+    void Heal(int);
+};
+
+struct Actor {
+    char pad[0x74];
+    Vector3 pos;             /* +0x74 */
+    char pad2[0x3a8 - 0x80];
+    short f3a8;              /* +0x3a8 */
+    void KillAndTrackInDeathTable();
+};
+
+extern "C" void func_ov002_020b1884(Actor *self, Player *player) {
+    self->f3a8 = 0;
+    self->KillAndTrackInDeathTable();
+    if (player->f706 != 0)
+        Sound::PlayBank3(0x12, self->pos);
+    else
+        Sound::PlayBank3(0x11, self->pos);
+    GiveCoins(player->f6d8, 1);
+    player->Heal(0x100);
+}

--- a/src/func_ov002_020b19dc.c
+++ b/src/func_ov002_020b19dc.c
@@ -1,0 +1,30 @@
+/* func_ov002_020b19dc at 0x020b19dc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern void func_ov002_020b16c4(char *self);
+extern void func_ov002_020b1674(char *self, char *p);
+extern void func_ov002_020b1884(char *self);
+
+int func_ov002_020b19dc(char *self)
+{
+    unsigned int id = *(unsigned int *)(self + 0x19c);
+    if (id != 0) {
+        char *p = (char *)_ZN5Actor10FindWithIDEj(id);
+        if (p != 0) {
+            if (*(int *)(self + 0x198) & 0x400000) {
+                *(unsigned short *)(self + 0x3a8) = 0;
+                if (*(int *)(self + 0x3a0) == 1)
+                    func_ov002_020b16c4(self);
+                else if (*(int *)(self + 0x3a0) == 2)
+                    func_ov002_020b1674(self, p);
+                else
+                    func_ov002_020b1884(self);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020b36dc.cpp
+++ b/src/func_ov002_020b36dc.cpp
@@ -1,0 +1,57 @@
+//cpp
+struct Obj {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5();
+    virtual void v6();
+    virtual void v7();
+    virtual void v8();
+    virtual void v9();
+    virtual void v10();
+    virtual void v11();
+    virtual void v12();
+    virtual void v13();
+    virtual void v14();
+    virtual void v15();
+    virtual void v16();
+    virtual void v17();
+    virtual void v18();
+    virtual void v19();
+    virtual void v20();
+    virtual void v21();
+    virtual void v22();
+    virtual void v23();
+    virtual void v24();
+    virtual void v25();
+    virtual void v26();
+    virtual void v27();
+    virtual void v28();
+    virtual void v29();
+    virtual void v30();
+    virtual void v31(); // offset 0x7c
+    char pad[8];
+    unsigned short kind; // 0xc relative... need check
+};
+
+extern "C" void func_ov002_020b36dc(Obj* self, struct Msg* msg);
+struct Msg { char pad[8]; int code; };
+
+extern "C" void func_ov002_020b36dc(Obj* self, Msg* msg)
+{
+    int t = (self->kind == 0x2e) ? 1 : 0;
+    if (t) {
+        self->v31();
+    }
+    int code = msg->code;
+    if (code == 3) return;
+    int u = (self->kind == 0x11) ? 1 : 0;
+    if (u) {
+        if (code != 2) return;
+        self->v31();
+        return;
+    }
+    self->v31();
+}

--- a/src/func_ov002_020b3788.cpp
+++ b/src/func_ov002_020b3788.cpp
@@ -1,0 +1,22 @@
+//cpp
+struct Arg { char pad[8]; int kind; };
+struct C {
+    virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
+    virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();
+    virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual void v29(); virtual void v30(); virtual void target();
+};
+
+extern "C" void func_ov002_020b3788(C *self, Arg *a) {
+    int eq = (*(unsigned short*)((char*)self + 0xc) == 0x11);
+    if (eq) {
+        if (a->kind != 2) return;
+        self->target();
+        return;
+    }
+    self->target();
+}

--- a/src/func_ov002_020b382c.cpp
+++ b/src/func_ov002_020b382c.cpp
@@ -1,0 +1,25 @@
+//cpp
+struct Arg { int pad[2]; int f8; };
+
+struct Vt;
+
+struct Obj {
+    Vt *vt;
+};
+
+struct Vt {
+    void (*slots[33])(Obj *);
+};
+
+extern "C" void func_ov002_020b382c(Obj *self, Arg *a)
+{
+    if (a->f8 == 3) return;
+    unsigned short c = *(unsigned short *)((char *)self + 0xc);
+    int b = (c == 0x11) ? 1 : 0;
+    if (b != 0) {
+        if (a->f8 != 2) return;
+        self->vt->slots[0x7c / 4](self);
+    } else {
+        self->vt->slots[0x7c / 4](self);
+    }
+}

--- a/src/func_ov002_020b3ab0.cpp
+++ b/src/func_ov002_020b3ab0.cpp
@@ -1,0 +1,38 @@
+//cpp
+
+extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *self);
+extern "C" void _ZN16MeshColliderBase7DisableEv(void *self);
+extern "C" void _ZN13SharedFilePtr7ReleaseEv(void *self);
+
+struct MeshColliderBase {
+    int IsEnabled() { return _ZN16MeshColliderBase9IsEnabledEv(this); }
+    void Disable() { _ZN16MeshColliderBase7DisableEv(this); }
+};
+
+struct SharedFilePtr {
+    void Release() { _ZN13SharedFilePtr7ReleaseEv(this); }
+};
+
+struct FileEntry {
+    SharedFilePtr *fileptr;  // 0x0
+    char pad[0xc - 4];
+};
+
+extern "C" FileEntry data_ov002_02108ab0[];  // wildcard address
+extern "C" FileEntry data_ov002_02108ab4[];
+
+struct Obj {
+    char pad124[0x124];
+    MeshColliderBase collider;   // 0x124
+    char pad328[0x32c - 0x124 - (int)sizeof(MeshColliderBase)];
+    unsigned char f32c;          // 0x32c
+};
+
+extern "C" int func_ov002_020b3ab0(Obj *self) {
+    if (self->collider.IsEnabled()) {
+        self->collider.Disable();
+    }
+    data_ov002_02108ab0[self->f32c].fileptr->Release();
+    data_ov002_02108ab4[self->f32c].fileptr->Release();
+    return 1;
+}

--- a/src/func_ov002_020b4394.cpp
+++ b/src/func_ov002_020b4394.cpp
@@ -1,0 +1,28 @@
+//cpp
+struct SharedFilePtr { void Release(); };
+extern void UnloadSilverStarAndNumber(void);
+
+extern SharedFilePtr data_ov002_0210d9d8;
+extern SharedFilePtr data_ov002_0210da30;
+extern SharedFilePtr data_ov002_0210da18;
+
+struct Obj { char pad[0xc]; unsigned short id; };
+
+extern "C" int func_ov002_020b4394(Obj* self)
+{
+    switch (self->id) {
+    default: break;
+    case 0x141:
+        data_ov002_0210d9d8.Release();
+        break;
+    case 0x142:
+        data_ov002_0210da30.Release();
+        break;
+    case 0x143:
+        data_ov002_0210da18.Release();
+        break;
+    case 0x144:
+        UnloadSilverStarAndNumber();
+    }
+    return 1;
+}

--- a/src/func_ov002_020b4af8.c
+++ b/src/func_ov002_020b4af8.c
@@ -1,0 +1,22 @@
+/* func_ov002_020b4af8 at 0x020b4af8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void *data_ov002_02108d94;
+extern void *data_ov002_0210ae38;
+extern void _ZN18MovingMeshColliderD1Ev(void *t);
+extern void _ZN5ModelD1Ev(void *t);
+extern void _ZN5ActorD1Ev(void *t);
+extern void func_0207328c(void *base, int count, int stride, void (*dtor)(void *));
+
+void *func_ov002_020b4af8(char *self) {
+    *(void **)self = &data_ov002_02108d94;
+    func_0207328c(self + 0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(self + 0x320, 5, 0x50, _ZN5ModelD1Ev);
+    *(void **)self = &data_ov002_0210ae38;
+    _ZN18MovingMeshColliderD1Ev(self + 0x124);
+    _ZN5ModelD1Ev(self + 0xd4);
+    _ZN5ActorD1Ev(self);
+    return self;
+}

--- a/src/func_ov002_020b4ed8.cpp
+++ b/src/func_ov002_020b4ed8.cpp
@@ -1,0 +1,19 @@
+//cpp
+extern "C" void _ZN9ModelAnimD1Ev(void*);
+extern "C" void _ZN18MovingMeshColliderD1Ev(void*);
+extern "C" void _ZN5ModelD1Ev(void*);
+extern "C" void _ZN5ActorD1Ev(void*);
+extern void *data_ov002_02108e5c;
+extern void *data_ov002_0210ae38;
+extern "C" void *func_ov002_020b4ed8(void *self) {
+    char *b = (char*)self;
+    *(void**)b = &data_ov002_02108e5c;
+    _ZN9ModelAnimD1Ev(b + 0x6b4);
+    _ZN18MovingMeshColliderD1Ev(b + 0x4ec);
+    _ZN18MovingMeshColliderD1Ev(b + 0x324);
+    *(void**)b = &data_ov002_0210ae38;
+    _ZN18MovingMeshColliderD1Ev(b + 0x124);
+    _ZN5ModelD1Ev(b + 0xd4);
+    _ZN5ActorD1Ev(self);
+    return self;
+}

--- a/src/func_ov002_020b4f44.cpp
+++ b/src/func_ov002_020b4f44.cpp
@@ -1,0 +1,23 @@
+//cpp
+struct ModelAnim { ~ModelAnim(); };
+struct MovingMeshCollider { ~MovingMeshCollider(); };
+struct Model { ~Model(); };
+struct Actor { ~Actor(); };
+struct Heap;
+namespace Memory { void Deallocate(void*, Heap*); }
+extern void* data_ov002_02108e5c;
+extern void* data_ov002_0210ae38;
+extern Heap* data_020a0eac;
+extern "C" void* func_ov002_020b4f44(void* self) {
+    char* p = (char*)self;
+    *(void**)p = &data_ov002_02108e5c;
+    ((ModelAnim*)(p + 0x6b4))->~ModelAnim();
+    ((MovingMeshCollider*)(p + 0x4ec))->~MovingMeshCollider();
+    ((MovingMeshCollider*)(p + 0x324))->~MovingMeshCollider();
+    *(void**)p = &data_ov002_0210ae38;
+    ((MovingMeshCollider*)(p + 0x124))->~MovingMeshCollider();
+    ((Model*)(p + 0xd4))->~Model();
+    ((Actor*)p)->~Actor();
+    Memory::Deallocate(self, data_020a0eac);
+    return self;
+}

--- a/src/func_ov002_020b4fd0.cpp
+++ b/src/func_ov002_020b4fd0.cpp
@@ -1,0 +1,28 @@
+//cpp
+struct Actor;
+struct MeshColliderBase {
+    int IsEnabled();
+    void Disable();
+    void Enable(Actor *);
+};
+
+struct Obj {
+    char pad[0xb0];
+    unsigned int fb0;            /* +0xb0 */
+    char pad2[0x320 - 0xb4];
+    MeshColliderBase *f320;      /* +0x320 */
+};
+
+extern "C" int func_ov002_020b4fd0(Obj *self) {
+    int on = (self->fb0 & 8) ? 1 : 0;
+    if (on) {
+        if (self->f320->IsEnabled()) {
+            self->f320->Disable();
+        }
+        return 1;
+    }
+    if (!self->f320->IsEnabled()) {
+        self->f320->Enable((Actor *)self);
+    }
+    return 0;
+}

--- a/src/func_ov002_020b503c.cpp
+++ b/src/func_ov002_020b503c.cpp
@@ -1,0 +1,27 @@
+//cpp
+struct Matrix4x3 { int m[12]; };
+
+struct MovingMeshCollider {
+    void Transform(const Matrix4x3 &, short);
+};
+
+struct Obj {
+    char pad[0x5c];
+    int f5c, f60, f64;            /* +0x5c */
+    char pad2[0x8e - 0x68];
+    short f8e;                    /* +0x8e */
+    char pad3[0x2ec - 0x90];
+    Matrix4x3 mDst;              /* +0x2ec, translation row at +0x310 */
+    char pad6[0x320 - (0x2ec + 48)];
+    MovingMeshCollider *f320;    /* +0x320 */
+    char pad7[0x6d0 - 0x324];
+    Matrix4x3 mSrc;              /* +0x6d0 */
+};
+
+extern "C" void func_ov002_020b503c(Obj *self) {
+    self->mDst = self->mSrc;
+    self->mDst.m[9] = self->f5c;
+    self->mDst.m[10] = self->f60;
+    self->mDst.m[11] = self->f64;
+    self->f320->Transform(self->mDst, self->f8e);
+}

--- a/src/func_ov002_020b9a1c.cpp
+++ b/src/func_ov002_020b9a1c.cpp
@@ -1,0 +1,24 @@
+//cpp
+struct Matrix4x3 { int m[12]; };
+extern "C" void Matrix4x3_FromRotationY(Matrix4x3 *mtx, short angle);
+
+struct Obj {
+    char pad0[0x5c];
+    int posx;     // 0x5c
+    int posy;     // 0x60
+    int posz;     // 0x64
+    char pad1[0x8e - 0x68];
+    short angle;  // 0x8e
+    char pad2[0xf0 - 0x90];
+    Matrix4x3 dst; // 0xf0
+    char pad3[0x140 - 0xf0 - sizeof(Matrix4x3)];
+    Matrix4x3 mtx; // 0x140
+};
+
+extern "C" void func_ov002_020b9a1c(Obj *self) {
+    Matrix4x3_FromRotationY(&self->mtx, self->angle);
+    self->mtx.m[9] = self->posx >> 3;
+    self->mtx.m[10] = self->posy >> 3;
+    self->mtx.m[11] = self->posz >> 3;
+    self->dst = self->mtx;
+}

--- a/src/func_ov002_020b9f00.c
+++ b/src/func_ov002_020b9f00.c
@@ -1,0 +1,37 @@
+/* func_ov002_020b9f00 at 0x020b9f00
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Actor;
+extern struct Actor *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, struct Actor *prev);
+
+struct Obj {
+    char pad0[0x344];
+    struct Actor *found;     // 0x344
+    char pad1[0x351 - 0x348];
+    unsigned char tag;       // 0x351
+};
+
+struct Actor {
+    char pad0[4];
+    void *next;              // 0x4
+    char pad1[0x49d - 0x8];
+    unsigned char tag;       // 0x49d
+};
+
+int func_ov002_020b9f00(struct Obj *self) {
+    struct Actor *a;
+    if (self->found != 0) {
+        return 0;
+    }
+    a = _ZN5Actor15FindWithActorIDEjPS_(0xb2, 0);
+    while (a != 0) {
+        if (self->tag == a->tag) {
+            self->found = (struct Actor *)a->next;
+            return 1;
+        }
+        a = _ZN5Actor15FindWithActorIDEjPS_(0xb2, a);
+    }
+    return 0;
+}

--- a/src/func_ov002_020b9f80.cpp
+++ b/src/func_ov002_020b9f80.cpp
@@ -1,0 +1,16 @@
+//cpp
+struct Matrix4x3 {
+    int m[12];
+};
+struct MovingMeshCollider {
+    void Transform(const Matrix4x3 &mtx, short s);
+};
+
+extern "C" void func_ov002_020b9f80(char *self) {
+    *(Matrix4x3 *)(self + 0x2ec) = *(Matrix4x3 *)(self + 0xf0);
+    *(int *)(self + 0x310) = *(int *)(self + 0x5c);
+    *(int *)(self + 0x314) = *(int *)(self + 0x60) - *(int *)(self + 0x32c);
+    *(int *)(self + 0x318) = *(int *)(self + 0x64);
+    ((MovingMeshCollider *)(self + 0x124))->Transform(*(Matrix4x3 *)(self + 0x2ec),
+        *(short *)(self + 0x8e));
+}

--- a/src/func_ov002_020baa2c.c
+++ b/src/func_ov002_020baa2c.c
@@ -1,0 +1,25 @@
+/* func_ov002_020baa2c at 0x020baa2c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef int s32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+struct Vector3;
+extern s32 Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
+
+void func_ov002_020baa2c(void* self, void* other) {
+    char* o = (char*)other;
+    char* s = (char*)self;
+    unsigned int eq = (*(u16*)(o + 0xc) == 0xbf);
+    if (eq == 0) return;
+    if (*(u8*)(o + 0x706) != 0) {
+        if (*(u8*)(o + 0x6f9) == 0) {
+            if (*(u8*)(o + 0x703) == 0) return;
+        }
+    }
+    if (Vec3_Dist((struct Vector3*)(s + 0x5c), (struct Vector3*)(o + 0x5c)) < 0x98000)
+        *(u8*)(s + 0x350) = 1;
+}

--- a/src/func_ov002_020bbe30.cpp
+++ b/src/func_ov002_020bbe30.cpp
@@ -1,0 +1,45 @@
+//cpp
+
+extern "C" void func_ov002_020bb060(void *self);
+
+struct Sub {
+    char pad[0xc8];
+    int fc8;     // 0xc8
+};
+
+struct Model {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void f14(int a);   // vtable slot 5 (0x14)
+};
+
+struct Obj {
+    char pad0[0xb0];
+    int fb0;          // 0xb0
+    char pad1[0xd4 - 0xb4];
+    Model model_d4;   // 0xd4 (subobject with vtable as first word)
+    char pad2[0x590 - 0xd4 - sizeof(Model)];
+    unsigned char f590;   // 0x590
+    char pad3[0x59c - 0x591];
+    Sub *f59c;        // 0x59c
+};
+
+extern "C" int func_ov002_020bbe30(Obj *self) {
+    if (self->f590) {
+        return 1;
+    }
+    Sub *s = self->f59c;
+    if (s != 0) {
+        int ok = (self->fb0 & 0x4000) ? 1 : 0;
+        if (ok != 0) {
+            if (s->fc8 != 0) {
+                func_ov002_020bb060(self);
+            }
+        }
+    }
+    self->model_d4.f14(0);
+    return 1;
+}

--- a/src/func_ov002_020bc540.cpp
+++ b/src/func_ov002_020bc540.cpp
@@ -1,0 +1,29 @@
+//cpp
+struct SharedFilePtr {};
+struct BMD_File {};
+struct BCA_File {};
+struct Model {
+    static BMD_File *LoadFile(SharedFilePtr &f);
+};
+struct Animation {
+    static BCA_File *LoadFile(SharedFilePtr &f);
+};
+struct ModelBase {
+    void SetFile(BMD_File *f, int a, int b);
+};
+struct ModelAnim {
+    void SetAnim(BCA_File *f, int a, int b, unsigned int c);
+};
+
+extern SharedFilePtr data_ov002_0210e0dc;
+extern SharedFilePtr data_ov002_0210e0d4;
+extern "C" void func_ov002_020bc488(char *t);
+
+extern "C" int func_ov002_020bc540(char *self) {
+    BMD_File *m = Model::LoadFile(data_ov002_0210e0dc);
+    ((ModelBase *)(self + 0xd4))->SetFile(m, 1, -1);
+    BCA_File *a = Animation::LoadFile(data_ov002_0210e0d4);
+    ((ModelAnim *)(self + 0xd4))->SetAnim(a, 0, 0x1000, 0);
+    func_ov002_020bc488(self);
+    return 1;
+}

--- a/src/func_ov002_020bc9f4.cpp
+++ b/src/func_ov002_020bc9f4.cpp
@@ -1,0 +1,30 @@
+//cpp
+extern signed char data_0209f2f8;
+extern unsigned char data_0209f220;
+
+struct Sub {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void m5(int);   /* vtable+0x14 */
+};
+
+struct Obj {
+    char pad8[8];
+    unsigned int state;       /* +8 */
+    char pad[0xd4 - 0xc];
+    Sub sub;                  /* +0xd4 */
+    char pad2[0x32e - 0xd8];
+    unsigned char f32e;       /* +0x32e */
+};
+
+extern "C" int func_ov002_020bc9f4(Obj *self) {
+    if (data_0209f2f8 == 6 && data_0209f220 == 1 && (self->state & 0xff) == 1)
+        return 1;
+    if (self->f32e != 0)
+        return 1;
+    self->sub.m5(0);
+    return 1;
+}

--- a/src/func_ov002_020bd354.c
+++ b/src/func_ov002_020bd354.c
@@ -1,0 +1,18 @@
+/* func_ov002_020bd354 at 0x020bd354
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern unsigned short data_0209b274;
+
+int func_ov002_020bd354(char *o, int unused, int r2) {
+    if (r2 == data_0209b274) {
+        *(unsigned char *)(o + 0x6ff) = 1;
+        if (*(unsigned short *)(o + 0x6ae) == 0) {
+            *(unsigned short *)(o + 0x6ae) = 0x198;
+        }
+    }
+    *(int *)(o + 0xa8) = -0x20000;
+    *(int *)(o + 0x684) = *(int *)(o + 0x60);
+    return 1;
+}

--- a/src/func_ov002_020bd600.c
+++ b/src/func_ov002_020bd600.c
@@ -1,0 +1,29 @@
+/* func_ov002_020bd600 at 0x020bd600
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern short ReadUnalignedShort(unsigned char *p);
+
+struct Obj {
+    char pad5c[0x5c];
+    int f5c;      /* +0x5c */
+    int f60;      /* +0x60 */
+    int f64;      /* +0x64 */
+    char pad8e[0x8e - 0x68];
+    short f8e;    /* +0x8e */
+    char pad94[0x94 - 0x90];
+    short f94;    /* +0x94 */
+};
+
+int func_ov002_020bd600(struct Obj *self, unsigned char *p) {
+    int f60, f64;
+    f64 = ReadUnalignedShort(p + 4) << 12;
+    f60 = ReadUnalignedShort(p + 2) << 12;
+    self->f5c = ReadUnalignedShort(p) << 12;
+    self->f60 = f60;
+    self->f64 = f64;
+    self->f8e = ReadUnalignedShort(p + 6);
+    self->f94 = self->f8e;
+    return 1;
+}

--- a/src/func_ov002_020bd984.c
+++ b/src/func_ov002_020bd984.c
@@ -1,0 +1,30 @@
+/* func_ov002_020bd984 at 0x020bd984
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN5Sound8EndMusicEjj(unsigned int, unsigned int);
+extern void _ZN5Sound8SetMusicEjj(unsigned int, unsigned int);
+
+struct Obj {
+    char pad[0x678];
+    unsigned int f678;
+    unsigned int f67c;
+    unsigned int f680;
+    char pad2[0x6d8 - 0x684];
+    unsigned char f6d8;
+};
+
+void func_ov002_020bd984(struct Obj *self, unsigned int arg)
+{
+    unsigned int v = self->f67c;
+    if (v == 0) {
+        _ZN5Sound8EndMusicEjj(self->f6d8, arg);
+        self->f680 = 0;
+    } else if (self->f680 == arg && v != arg) {
+        _ZN5Sound8EndMusicEjj(self->f6d8, arg);
+        _ZN5Sound8SetMusicEjj(self->f6d8, self->f67c);
+        self->f680 = self->f67c;
+    }
+    self->f678 = 0;
+}

--- a/src/func_ov002_020bda48.c
+++ b/src/func_ov002_020bda48.c
@@ -1,0 +1,24 @@
+/* func_ov002_020bda48 at 0x020bda48
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020e032c(void *r0);
+extern void func_ov002_020bdef0(char *c);
+extern void func_ov002_020bdd9c(void *r0);
+extern void func_ov002_020d80d0(char *r0);
+extern void func_ov002_020bdd2c(void *r0);
+extern void func_ov002_020cc1f4(void *p);
+extern void func_ov002_020de968(void *r0);
+
+void func_ov002_020bda48(char *self)
+{
+    *(short *)(self + 0x600 + 0xae) = 0;
+    func_ov002_020e032c(self);
+    func_ov002_020bdef0(self);
+    func_ov002_020bdd9c(self);
+    func_ov002_020d80d0(self);
+    func_ov002_020bdd2c(self);
+    func_ov002_020cc1f4(self);
+    func_ov002_020de968(self);
+}

--- a/src/func_ov002_020bdd9c.cpp
+++ b/src/func_ov002_020bdd9c.cpp
@@ -1,0 +1,26 @@
+//cpp
+struct ModelAnim2 {
+    void Copy(const ModelAnim2 &, char *, unsigned int);
+};
+struct Player {
+    unsigned int GetBodyModelID(unsigned int, bool) const;
+};
+extern "C" {
+extern void *data_ov002_020ff480[];
+extern void func_ov002_020bd984(void *self, unsigned int arg);
+
+void func_ov002_020bdd9c(void *self)
+{
+    char *s = (char *)self;
+    if (*(unsigned char *)(s + 0x6f9) != 1)
+        return;
+    *(unsigned char *)(s + 0x6f9) = 0;
+    unsigned int r5 = *(unsigned int *)(s + 8);
+    unsigned int id = ((Player *)self)->GetBodyModelID(r5 & 0xff, false);
+    void *tbl = data_ov002_020ff480[*(unsigned int *)(s + 0x63c) + r5];
+    ModelAnim2 *dst = *(ModelAnim2 **)(s + 0xdc + (id << 2));
+    dst->Copy(*(const ModelAnim2 *)(*(char **)(s + 0xec)),
+              *(char **)((char *)tbl + 4), 0);
+    func_ov002_020bd984(self, 0x34);
+}
+}

--- a/src/func_ov002_020beabc.cpp
+++ b/src/func_ov002_020beabc.cpp
@@ -1,0 +1,20 @@
+//cpp
+struct Model { void SetPolygonMode(int); };
+struct Player {
+    unsigned int GetBodyModelID(unsigned int, bool) const;
+};
+extern "C" int func_ov002_020becf4(Player *self, unsigned int a, int b);
+
+extern "C" void func_ov002_020beabc(Player *self)
+{
+    char *p = (char *)self;
+    *(short *)(p + 0x73c) = 5;
+    *(short *)(p + 0x73e) = 0x2f;
+    *(short *)(p + 0x740) = 0x1000;
+    *(unsigned char *)(p + 0x6dc) = *(unsigned char *)(p + 0x6d9);
+    *(unsigned char *)(p + 0x6dd) = *(unsigned char *)(p + 0x6dc);
+    unsigned int id = self->GetBodyModelID(*(unsigned char *)(p + 0x6d9), 0);
+    ((Model *)*(int *)(p + (id << 2) + 0xdc))->SetPolygonMode(2);
+    unsigned int id2 = func_ov002_020becf4(self, *(int *)(p + 8) & 0xff, 0);
+    ((Model *)*(int *)(p + (id2 << 2) + 0x154))->SetPolygonMode(2);
+}

--- a/src/func_ov002_020bf56c.c
+++ b/src/func_ov002_020bf56c.c
@@ -1,0 +1,29 @@
+/* func_ov002_020bf56c at 0x020bf56c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020c031c(void *c);
+
+int func_ov002_020bf56c(void *unused, int x)
+{
+    int v;
+    switch (func_ov002_020c031c(unused)) {
+    case 4:
+    case 5:
+        v = 0x199;
+        break;
+    case 3:
+        v = 0x599;
+        break;
+    default:
+    case 0:
+        v = 0x1000;
+        break;
+    case 1:
+    case 2:
+        v = 0x1000;
+        break;
+    }
+    return (int)(((long long)x * v + 0x800) >> 12);
+}

--- a/src/func_ov002_020bf88c.cpp
+++ b/src/func_ov002_020bf88c.cpp
@@ -1,0 +1,25 @@
+//cpp
+typedef int Fix12i;
+namespace Particle {
+void RunningSlidingDustAt(Fix12i, Fix12i, Fix12i);
+}
+extern "C" {
+extern void func_02022b04(Fix12i x, Fix12i y, Fix12i z);
+extern int data_0208e430;
+
+void func_ov002_020bf88c(char *self)
+{
+    if (*(unsigned char *)(self + 0x707))
+        return;
+    if (data_0208e430 == 0x2e)
+        return;
+    if (*(unsigned char *)(self + 0x703))
+        Particle::RunningSlidingDustAt(*(Fix12i *)(self + 0x5c),
+                                       *(Fix12i *)(self + 0x60),
+                                       *(Fix12i *)(self + 0x64));
+    else
+        func_02022b04(*(Fix12i *)(self + 0x5c),
+                      *(Fix12i *)(self + 0x60),
+                      *(Fix12i *)(self + 0x64));
+}
+}

--- a/src/func_ov002_020c0688.c
+++ b/src/func_ov002_020c0688.c
@@ -1,0 +1,26 @@
+/* func_ov002_020c0688 at 0x020c0688
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020c0688(char *self) {
+    int r1, r2;
+    if (*(unsigned char *)(self + 0x6de) == 0) return 1;
+    if (*(unsigned char *)(self + 0x70e) != 0) {
+        r2 = *(int *)(self + 0x644);
+        r1 = *(int *)(self + 0x60) - r2;
+        if (r1 >= 0xb4000) goto ret0;
+        if (r1 < 0) goto ret0;
+        *(int *)(self + 0x60) = r2;
+        return 1;
+    }
+    if (*(unsigned char *)(self + 0x6e4) == 0) goto ret0;
+    r2 = *(int *)(self + 0x644);
+    r1 = *(int *)(self + 0x60) - r2;
+    if (r1 < 0x28000) {
+        *(int *)(self + 0x60) = r2;
+        return 1;
+    }
+ret0:
+    return 0;
+}

--- a/src/func_ov002_020c1e44.c
+++ b/src/func_ov002_020c1e44.c
@@ -1,0 +1,14 @@
+/* func_ov002_020c1e44 at 0x020c1e44
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020c1e44(char *self, int a) {
+    short *h = (short*)(self + 0x94);
+    *h = (short)((a << 1) - *h + 0x8000);
+    *(int*)(self + 0x98) = (int)(((long long)*(int*)(self + 0x98) * 0xe00 + 0x800) >> 12);
+    if (*(int*)(self + 0x98) < 0x4000) {
+        *(int*)(self + 0x98) = 0x4000;
+    }
+    return 1;
+}

--- a/src/func_ov002_020c3ea0.c
+++ b/src/func_ov002_020c3ea0.c
@@ -1,0 +1,11 @@
+/* func_ov002_020c3ea0 at 0x020c3ea0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, int c, unsigned int d);
+
+void func_ov002_020c3ea0(char *self) {
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 0xb3, 0x40000000, 0x1000, 0);
+    *(unsigned char*)(self + 0x6e3) = 2;
+}

--- a/src/func_ov002_020c51d0.c
+++ b/src/func_ov002_020c51d0.c
@@ -1,0 +1,20 @@
+/* func_ov002_020c51d0 at 0x020c51d0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);
+extern char data_ov002_0211046c[];
+
+int func_ov002_020c51d0(char *self, int *arg)
+{
+    if (!_ZN6Player7IsStateERNS_5StateE(self, data_ov002_0211046c))
+        return 0;
+    if (*(unsigned char *)(self + 0x6e3))
+        return 0;
+    *(int *)(self + 0x744) = arg[0];
+    *(int *)(self + 0x748) = arg[1];
+    *(int *)(self + 0x74c) = arg[2];
+    *(unsigned char *)(self + 0x6e5) = 1;
+    return 1;
+}

--- a/src/func_ov002_020c5cd8.c
+++ b/src/func_ov002_020c5cd8.c
@@ -1,0 +1,14 @@
+/* func_ov002_020c5cd8 at 0x020c5cd8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020c5dec(void *this, int x);
+
+int func_ov002_020c5cd8(void *this, int val) {
+    if (func_ov002_020c5dec(this, 6)) {
+        *(int *)((char *)this + 0x364) = val;
+        return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020c5dec.c
+++ b/src/func_ov002_020c5dec.c
@@ -1,0 +1,16 @@
+/* func_ov002_020c5dec at 0x020c5dec
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern char data_ov002_02110124[];
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+
+int func_ov002_020c5dec(char *self, int mode) {
+    if (mode != 1) {
+        if (*(unsigned char *)(self + 0x709) != 0) return 0;
+    }
+    *(unsigned char *)(self + 0x6e3) = (unsigned char)mode;
+    _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_02110124);
+    return 1;
+}

--- a/src/func_ov002_020c7194.c
+++ b/src/func_ov002_020c7194.c
@@ -1,0 +1,21 @@
+/* func_ov002_020c7194 at 0x020c7194
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN6Player12FinishedAnimEv(void *self);
+extern int func_ov002_020c44c4(void *self);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+extern char data_ov002_02110214;
+
+void func_ov002_020c7194(char *r0) {
+    char *r4 = r0;
+    if (_ZN6Player12FinishedAnimEv(r4) == 0) {
+        return;
+    }
+    *(unsigned char*)(r4 + 0x6e3) = 1;
+    if (func_ov002_020c44c4(r4) != 0) {
+        return;
+    }
+    _ZN6Player11ChangeStateERNS_5StateE(r4, &data_ov002_02110214);
+}

--- a/src/func_ov002_020c8b54.c
+++ b/src/func_ov002_020c8b54.c
@@ -1,0 +1,12 @@
+/* func_ov002_020c8b54 at 0x020c8b54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020c8b54(char *r0) {
+    if (*(unsigned short*)(r0 + 0x6a4) == 0) {
+        *(unsigned*)(r0 + 0x98) = 0xa000;
+        *(unsigned char*)(r0 + 0x6e3) = 0xf;
+    }
+    return 0;
+}

--- a/src/func_ov002_020c8cb0.cpp
+++ b/src/func_ov002_020c8cb0.cpp
@@ -1,0 +1,21 @@
+//cpp
+extern "C" {
+struct Player;
+int _ZN6Player12FinishedAnimEv(Player *self);
+void func_ov002_020ca108(char *r0);
+void _ZN6Player7SetAnimEji5Fix12IiEj(Player *self, unsigned int a, int b, int c, unsigned int d);
+}
+extern signed char data_02092110;
+
+extern "C" int func_ov002_020c8cb0(Player *self) {
+    char *p = (char *)self;
+    if (_ZN6Player12FinishedAnimEv(self)) {
+        if (data_02092110 >= 0) {
+            *(unsigned char *)(p + 0x70b) = 1;
+        }
+        func_ov002_020ca108(p);
+        *(unsigned char *)(p + 0x743) = 0;
+        _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x47, 0, 0x1000, 0);
+    }
+    return 0;
+}

--- a/src/func_ov002_020c924c.c
+++ b/src/func_ov002_020c924c.c
@@ -1,0 +1,15 @@
+/* func_ov002_020c924c at 0x020c924c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_0201f32c(int r0);
+
+int func_ov002_020c924c(char *r0) {
+    char *r4 = r0;
+    if (*(unsigned short*)(r4 + 0x600 + 0xa4) == 0) {
+        func_0201f32c((int)(short)*(int*)(r4 + 0x688));
+        *(unsigned char*)(r4 + 0x6e3) = 0x15;
+    }
+    return 0;
+}

--- a/src/func_ov002_020c9288.cpp
+++ b/src/func_ov002_020c9288.cpp
@@ -1,0 +1,21 @@
+//cpp
+extern "C" {
+extern int data_ov002_0211067c[];
+extern int data_ov002_0211013c[];
+extern int func_ov002_020bea7c(char* c);
+extern void func_ov002_020c43c4(char* self, int n);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
+int func_ov002_020c9288(char* self){
+  if(!func_ov002_020bea7c(self)){
+    if(*(unsigned char*)(self+0x6e6)==0){
+      func_ov002_020c43c4(self,6);
+      *(unsigned char*)(self+0x6e6)=1;
+    }else if(*(unsigned char*)(self+0x706)){
+      _ZN6Player11ChangeStateERNS_5StateE(self,data_ov002_0211067c);
+    }else{
+      _ZN6Player11ChangeStateERNS_5StateE(self,data_ov002_0211013c);
+    }
+  }
+  return 0;
+}
+}

--- a/src/func_ov002_020c9718.c
+++ b/src/func_ov002_020c9718.c
@@ -1,0 +1,20 @@
+/* func_ov002_020c9718 at 0x020c9718
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020ceaf4(unsigned char *self);
+extern int data_0209f32c;
+
+void func_ov002_020c9718(unsigned char *self)
+{
+    int r2;
+    if (self[0x706] == 0)
+        return;
+    *(int *)(self + 0xa8) = func_ov002_020ceaf4(self);
+    r2 = data_0209f32c - 0x50000;
+    if (*(int *)(self + 0x60) < r2)
+        return;
+    if (*(int *)(self + 0xa8) >= 0)
+        *(int *)(self + 0x60) = r2;
+}

--- a/src/func_ov002_020c97f8.c
+++ b/src/func_ov002_020c97f8.c
@@ -1,0 +1,15 @@
+/* func_ov002_020c97f8 at 0x020c97f8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, int fix, unsigned int e);
+
+void func_ov002_020c97f8(char *r0) {
+    char *r4 = r0;
+    *(unsigned char*)(r4 + 0x6e3) = 0x1a;
+    *(unsigned short*)(r4 + 0x600 + 0x9c) = 0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(r4, 0x47, 0, 0x1000, 0);
+    *(int*)(r4 + 0x98) = 0;
+    *(int*)(r4 + 0xa8) = 0;
+}

--- a/src/func_ov002_020c9840.cpp
+++ b/src/func_ov002_020c9840.cpp
@@ -1,0 +1,19 @@
+//cpp
+struct Vector3 {};
+struct Player {
+    void SetAnim(unsigned int a, int b, int c, unsigned int d);
+};
+namespace Sound {
+    void PlayCharVoice(unsigned int a, unsigned int b, const Vector3 &v);
+}
+
+extern "C" void func_ov002_020c9840(char *self) {
+    *(unsigned char *)(self + 0x71a) = 0;
+    *(unsigned char *)(self + 0x6e3) = 0x18;
+    ((Player *)self)->SetAnim(0x47, 0, 0x1000, 0);
+    *(unsigned short *)(self + 0x6a4) = 2;
+    *(int *)(self + 0x98) = 0;
+    *(int *)(self + 0xa8) = 0;
+    *(unsigned char *)(self + 0x70c) = 0;
+    Sound::PlayCharVoice(*(unsigned char *)(self + 0x6d9), 4, *(Vector3 *)(self + 0x74));
+}

--- a/src/func_ov002_020c98a4.cpp
+++ b/src/func_ov002_020c98a4.cpp
@@ -1,0 +1,28 @@
+//cpp
+
+struct Camera;
+extern Camera *data_0209f318;
+extern "C" void func_0200d148(Camera *thiz, unsigned char playerID);
+
+struct Player {
+    char pad[0x6d8];
+    unsigned char f6d8;        // 0x6d8
+    char pad2[0x6e3 - 0x6d9];
+    unsigned char f6e3;        // 0x6e3
+    char pad3[0x70c - 0x6e4];
+    unsigned char f70c;        // 0x70c
+    char pad4[0x71a - 0x70d];
+    unsigned char f71a;        // 0x71a
+    void SetAnim(unsigned int a, int b, int c, unsigned int d);
+};
+
+extern "C" void func_ov002_020c98a4(Player *self) {
+    self->f71a = 0;
+    self->f6e3 = 0x18;
+    self->SetAnim(0x47, 0, 0x1000, 0);
+    *(short *)((char *)self + 0x6a4) = 2;
+    *(int *)((char *)self + 0x98) = 0;
+    *(int *)((char *)self + 0xa8) = 0;
+    self->f70c = 0;
+    func_0200d148(data_0209f318, self->f6d8);
+}

--- a/src/func_ov002_020c9998.cpp
+++ b/src/func_ov002_020c9998.cpp
@@ -1,0 +1,31 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+
+struct Actor {
+    static void Spawn(unsigned int, unsigned int, const Vector3 &, const Vector3_16 *, int, int);
+};
+
+struct Player {
+    char pad[0x5c];
+    Vector3 f5c;             /* +0x5c */
+    char pad2[0x8c - 0x68];
+    Vector3_16 f8c;          /* +0x8c */
+    char pad3[0x98 - 0x92];
+    int f98;                 /* +0x98 */
+    char pad4[0xa8 - 0x9c];
+    int fa8;                 /* +0xa8 */
+    char pad5[0xcc - 0xac];
+    signed char fcc;         /* +0xcc */
+    char pad6[0x6e3 - 0xcd];
+    unsigned char f6e3;      /* +0x6e3 */
+    void SetAnim(unsigned int, int, int, unsigned int);
+};
+
+extern "C" void func_ov002_020c9998(Player *self) {
+    self->f6e3 = 0x12;
+    self->SetAnim(0x92, 0x40000000, 0x1000, 0);
+    Actor::Spawn(0xb2, 0xffff, self->f5c, &self->f8c, self->fcc, -1);
+    self->f98 = 0;
+    self->fa8 = 0;
+}

--- a/src/func_ov002_020c9ac0.cpp
+++ b/src/func_ov002_020c9ac0.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct Player {
+    void SetAnim(unsigned int, int, int, unsigned int);
+};
+
+extern "C" void func_ov002_020c9ac0(unsigned char *self)
+{
+    Player *p = (Player *)self;
+    self[0x743] = 1;
+    self[0x716] = 1;
+    self[0x713] = 0;
+    *(int *)(self + 0x9c) = 0;
+    *(int *)(self + 0x98) = 0;
+    *(int *)(self + 0xa8) = 0;
+    self[0x6e3] = 0x10;
+    p->SetAnim(0x93, 0x40000000, 0x1000, 0);
+}

--- a/src/func_ov002_020c9b10.cpp
+++ b/src/func_ov002_020c9b10.cpp
@@ -1,0 +1,18 @@
+//cpp
+struct Fix12 { int v; };
+struct Player;
+extern "C" {
+
+void _ZN6Player7SetAnimEji5Fix12IiEj(Player* self, unsigned int a, int b, int c, unsigned int d);
+
+void func_ov002_020c9b10(Player* self)
+{
+    char* p = (char*)self;
+    *(unsigned char*)(p + 0x6e3) = 0xe;
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x47, 0, 0x1000, 0);
+    *(unsigned short*)(p + 0x6a4) = 0x14;
+    *(int*)(p + 0x98) = 0;
+    *(int*)(p + 0xa8) = 0;
+}
+
+}

--- a/src/func_ov002_020c9c00.cpp
+++ b/src/func_ov002_020c9c00.cpp
@@ -1,0 +1,13 @@
+//cpp
+struct Player {
+    void SetAnim(unsigned int, int, int, unsigned int);
+};
+
+extern "C" void func_ov002_020c9c00(Player *self) {
+    if (*(unsigned char*)((char*)self + 0x6de)) {
+        self->SetAnim(0x54, 0x40000000, 0x1000, 0);
+    }
+    *(unsigned char*)((char*)self + 0x6e3) = 0;
+    *(int*)((char*)self + 0x98) = 0;
+    *(int*)((char*)self + 0xa8) = 0;
+}

--- a/src/func_ov002_020c9cc0.c
+++ b/src/func_ov002_020c9cc0.c
@@ -1,0 +1,24 @@
+/* func_ov002_020c9cc0 at 0x020c9cc0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern signed char data_02092110;
+
+void func_ov002_020c9cc0(unsigned char* p) {
+    int v;
+    *(unsigned short*)(p + 0x600 + 0xa6) = 3;
+    p[0x6e3] = 6;
+    p[0x716] = 1;
+    p[0x713] = 0;
+    v = *(int*)(p + 0xa8);
+    if (v >= 0x14000) {
+        *(int*)(p + 0xa8) = 0x14000;
+    }
+    {
+        signed char g = data_02092110;
+        if (g == 0x26 || g == 0x12) {
+            p[0x6f5] = 0;
+        }
+    }
+}

--- a/src/func_ov002_020c9d1c.cpp
+++ b/src/func_ov002_020c9d1c.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct Player;
+extern "C" {
+
+void _ZN6Player7SetAnimEji5Fix12IiEj(Player* self, unsigned int a, int b, int c, unsigned int d);
+
+void func_ov002_020c9d1c(Player* self)
+{
+    char* p = (char*)self;
+    *(unsigned char*)(p + 0x6e3) = 4;
+    *(unsigned short*)(p + 0x69c) = 0x4000;
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x47, 0, 0x1000, 0);
+    *(int*)(p + 0x98) = 0;
+    *(int*)(p + 0xa8) = 0;
+}
+
+}

--- a/src/func_ov002_020c9d68.cpp
+++ b/src/func_ov002_020c9d68.cpp
@@ -1,0 +1,37 @@
+//cpp
+struct Player {
+    char pad0[0x8e];
+    short f8e;       // 0x8e
+    char pad1[0x94 - 0x90];
+    short f94;       // 0x94
+    char pad2[0x98 - 0x96];
+    int f98;         // 0x98
+    char pad3[0x354 - 0x9c];
+    int f354;        // 0x354
+    char pad4[0x6d8 - 0x358];
+    unsigned char f6d8;  // 0x6d8
+    char pad5[0x6de - 0x6d9];
+    unsigned char f6de;  // 0x6de
+    char pad6[0x6e3 - 0x6df];
+    unsigned char f6e3;  // 0x6e3
+    char pad7[0x70c - 0x6e4];
+    unsigned char f70c;  // 0x70c
+    void SetAnim(unsigned int, int, int, unsigned int);
+};
+
+extern "C" int GetAngleToCamera(unsigned char);
+
+extern "C" void func_ov002_020c9d68(Player *self) {
+    if (self->f6de == 0) {
+        int ok = (self->f354 != 0);
+        if (!ok)
+            goto skip;
+    }
+    self->SetAnim(0x54, 0x40000000, 0x1000, 0);
+skip:;
+    self->f8e = (short)GetAngleToCamera(self->f6d8);
+    self->f94 = self->f8e;
+    self->f6e3 = 0;
+    self->f70c = 0;
+    self->f98 = 0;
+}

--- a/src/func_ov002_020c9de4.c
+++ b/src/func_ov002_020c9de4.c
@@ -1,0 +1,18 @@
+/* func_ov002_020c9de4 at 0x020c9de4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020bdd9c(void *);
+extern void func_ov002_020bdef0(void *);
+extern void func_ov002_020bdd2c(void *);
+extern void func_ov002_020d80d0(void *);
+extern void func_ov002_020c9d68(void *);
+
+void func_ov002_020c9de4(void *self) {
+    func_ov002_020bdd9c(self);
+    func_ov002_020bdef0(self);
+    func_ov002_020bdd2c(self);
+    func_ov002_020d80d0(self);
+    func_ov002_020c9d68(self);
+}

--- a/src/func_ov002_020ca108.cpp
+++ b/src/func_ov002_020ca108.cpp
@@ -1,0 +1,12 @@
+//cpp
+extern "C" {
+extern int data_ov002_0211013c[];
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+void func_ov002_020ca108(char *r0) {
+    if (*(unsigned char*)(r0 + 0x70b)) {
+        *(unsigned char*)(r0 + 0x6e3) = 0x13;
+        return;
+    }
+    _ZN6Player11ChangeStateERNS_5StateE(r0, data_ov002_0211013c);
+}
+}

--- a/src/func_ov002_020ca270.c
+++ b/src/func_ov002_020ca270.c
@@ -1,0 +1,19 @@
+/* func_ov002_020ca270 at 0x020ca270
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Obj {
+    char pad[0x6e3];
+    unsigned char f6e3;
+};
+
+extern int _ZN6Player7IsStateERNS_5StateE(struct Obj *self, void *state);
+extern void *data_ov002_02110124;
+
+int func_ov002_020ca270(struct Obj *self) {
+    if (_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110124)) {
+        if (self->f6e3 == 1) return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020cabe0.c
+++ b/src/func_ov002_020cabe0.c
@@ -1,0 +1,15 @@
+/* func_ov002_020cabe0 at 0x020cabe0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct State;
+extern struct State data_ov002_0211064c;
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, struct State *s);
+
+void func_ov002_020cabe0(char *r0) {
+    unsigned short f = *(unsigned short*)(r0 + 0x600 + 0xce) & 4;
+    if (f) {
+        _ZN6Player11ChangeStateERNS_5StateE(r0, &data_ov002_0211064c);
+    }
+}

--- a/src/func_ov002_020cb400.c
+++ b/src/func_ov002_020cb400.c
@@ -1,0 +1,23 @@
+/* func_ov002_020cb400 at 0x020cb400
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Vector3 { int x, y, z; };
+
+extern void* func_02012194(void* a, int b, int c, int d, int e, void* f, int g);
+
+void* func_ov002_020cb400(char* self)
+{
+    int v = *(short*)(self + 0x69c);
+    int n = v / 16;
+    if (n >= 0x100)
+        n = 0x100;
+    int id = 0x107;
+    if (*(int*)(*(int*)(self + 0x37c) + 0x18) & 0x1000000)
+        id = 0x105;
+    void* r = func_02012194(
+        *(void**)(self + 0x620), 0, id, 3, n, (struct Vector3*)(self + 0x74), 0);
+    *(void**)(self + 0x620) = r;
+    return r;
+}

--- a/src/func_ov002_020cc01c.c
+++ b/src/func_ov002_020cc01c.c
@@ -1,0 +1,13 @@
+/* func_ov002_020cc01c at 0x020cc01c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern char data_ov002_021101b4[];
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+
+int func_ov002_020cc01c(char *self) {
+    if (*(unsigned short *)(self + 0x6b8) == 0) return 0;
+    _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_021101b4);
+    return 1;
+}

--- a/src/func_ov002_020cc1f4.cpp
+++ b/src/func_ov002_020cc1f4.cpp
@@ -1,0 +1,13 @@
+//cpp
+struct State;
+struct Player {
+    void St_Shell_Cleanup();
+    void ChangeState(State &);
+};
+extern State data_ov002_0211013c;
+
+extern "C" void func_ov002_020cc1f4(Player *p) {
+    if (*(int *)((char *)p + 0x354) == 0) return;
+    p->St_Shell_Cleanup();
+    p->ChangeState(data_ov002_0211013c);
+}

--- a/src/func_ov002_020cd190.c
+++ b/src/func_ov002_020cd190.c
@@ -1,0 +1,13 @@
+/* func_ov002_020cd190 at 0x020cd190
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int data_0209f32c;
+extern void func_ov002_020ce8bc(char *self, int v);
+
+void func_ov002_020cd190(char *self) {
+    if (*(unsigned char *)(self + 0x703) == 0) return;
+    if (*(int *)(self + 0x60) + 0x180000 <= data_0209f32c) return;
+    func_ov002_020ce8bc(self, *(int *)(self + 0x98));
+}

--- a/src/func_ov002_020cd218.c
+++ b/src/func_ov002_020cd218.c
@@ -1,0 +1,14 @@
+/* func_ov002_020cd218 at 0x020cd218
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern short data_02082214[];
+
+void func_ov002_020cd218(char* self, int r1, int* outA, int* outB)
+{
+    int idx = (*(unsigned short*)(self + 0x92)) >> 4;
+    *outA = (int)(((long long)r1 * data_02082214[idx * 2 + 1] + 0x800) >> 12);
+    int idx2 = (*(unsigned short*)(self + 0x92)) >> 4;
+    *outB = -(int)(((long long)r1 * data_02082214[idx2 * 2] + 0x800) >> 12);
+}

--- a/src/func_ov002_020cd28c.c
+++ b/src/func_ov002_020cd28c.c
@@ -1,0 +1,13 @@
+/* func_ov002_020cd28c at 0x020cd28c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef int Fix12;
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, Fix12 c, unsigned int d);
+
+void func_ov002_020cd28c(char *r0) {
+    char *r4 = r0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(r0, 0xaf, 0x40000000, 0x1000, 0);
+    *(unsigned char*)(r4 + 0x6e3) = 7;
+}

--- a/src/func_ov002_020cd2c4.c
+++ b/src/func_ov002_020cd2c4.c
@@ -1,0 +1,13 @@
+/* func_ov002_020cd2c4 at 0x020cd2c4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, int c, unsigned int d);
+
+void func_ov002_020cd2c4(char *r0) {
+    char *r4 = r0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(r0, 0xab, 0x40000000, 0x1000, 0);
+    *(unsigned char*)(r4 + 0x6e3) = 1;
+    *(unsigned short*)(r4 + 0x600 + 0xa4) = 0;
+}

--- a/src/func_ov002_020cd364.c
+++ b/src/func_ov002_020cd364.c
@@ -1,0 +1,16 @@
+/* func_ov002_020cd364 at 0x020cd364
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020dc020(void *self);
+extern void _ZN12CylinderClsn5ClearEv(void *self);
+extern void _ZN12CylinderClsn6UpdateEv(void *self);
+
+void func_ov002_020cd364(char *self) {
+    func_ov002_020dc020(self);
+    _ZN12CylinderClsn5ClearEv(self + 0x314);
+    _ZN12CylinderClsn6UpdateEv(self + 0x314);
+    *(short *)(self + 0x6a4) = 2;
+    *(unsigned char *)(self + 0x6e3) = 5;
+}

--- a/src/func_ov002_020cd39c.cpp
+++ b/src/func_ov002_020cd39c.cpp
@@ -1,0 +1,10 @@
+//cpp
+extern "C" {
+extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned, int, int, unsigned);
+void func_ov002_020cd39c(char *r0) {
+    char *r4 = r0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(r0, 0xaa, 0x40000000, 0x1000, 0);
+    *(unsigned char*)(r4 + 0x6e3) = 4;
+    *(unsigned short*)(r4 + 0x600 + 0xa4) = 7;
+}
+}

--- a/src/func_ov002_020ceaf4.c
+++ b/src/func_ov002_020ceaf4.c
@@ -1,0 +1,15 @@
+/* func_ov002_020ceaf4 at 0x020ceaf4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int data_0209f32c;
+extern int data_ov002_020ff1e0[];
+
+int func_ov002_020ceaf4(char *self) {
+    int v = data_0209f32c - 0x50000 - *(int *)(self + 0x60);
+    if (v < 0x1f4000)
+        return 0x1800;
+    int val = data_ov002_020ff1e0[*(int *)(self + 8)];
+    return -(int)((((long long)val << 13) + 0x800) >> 12);
+}

--- a/src/func_ov002_020ceb54.c
+++ b/src/func_ov002_020ceb54.c
@@ -1,0 +1,11 @@
+/* func_ov002_020ceb54 at 0x020ceb54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int data_0209f32c;
+
+int func_ov002_020ceb54(char *r0) {
+    int a = *(int *)(r0 + 0x60);
+    return (data_0209f32c - 0x50000) >= (a + 0x3c000);
+}

--- a/src/func_ov002_020cedb0.c
+++ b/src/func_ov002_020cedb0.c
@@ -1,0 +1,11 @@
+/* func_ov002_020cedb0 at 0x020cedb0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern unsigned short data_ov002_020ff158[];
+
+int func_ov002_020cedb0(int *r0, int r1) {
+    unsigned t = data_ov002_020ff158[r0[2]];
+    return (int)(((long long)r1 * (int)t + 0x800) >> 12);
+}

--- a/src/func_ov002_020d225c.c
+++ b/src/func_ov002_020d225c.c
@@ -1,0 +1,12 @@
+/* func_ov002_020d225c at 0x020d225c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020d225c(int r0) {
+    if (*(int*)(r0 + 8) == 3 &&
+        *(unsigned char*)(r0 + 0x721) == 2 &&
+        *(unsigned char*)(r0 + 0x6e6) == 0)
+        return 1;
+    return 0;
+}

--- a/src/func_ov002_020d228c.cpp
+++ b/src/func_ov002_020d228c.cpp
@@ -1,0 +1,23 @@
+//cpp
+struct Player;
+struct State;
+extern "C" {
+
+void _ZN6Player11ChangeStateERNS_5StateE(Player *self, State *st);
+void _ZN6Player7SetAnimEji5Fix12IiEj(Player *self, unsigned int a, int b, int c, unsigned int d);
+extern State data_ov002_02110154;
+
+void func_ov002_020d228c(Player *self)
+{
+    char *p = (char *)self;
+    _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_02110154);
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 9, 0, 0x1000, 0);
+    *(char *)(p + 0x6e3) = 4;
+    *(int *)(p + 0x56c) = 0;
+    *(int *)(p + 0x570) = 0;
+    *(int *)(p + 0x574) = 0;
+    *(char *)(p + 0x721) = 2;
+    *(char *)(p + 0x70c) = 0;
+}
+
+}

--- a/src/func_ov002_020d3498.c
+++ b/src/func_ov002_020d3498.c
@@ -1,0 +1,10 @@
+/* func_ov002_020d3498 at 0x020d3498
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020d3498(char *r0) {
+    *(int *)(r0 + 0x98) = -*(int *)(r0 + 0x98);
+    *(short *)(r0 + 0x8e) = *(short *)(r0 + 0x8e) + 0x8000;
+    *(short *)(r0 + 0x94) = *(short *)(r0 + 0x8e);
+}

--- a/src/func_ov002_020d454c.cpp
+++ b/src/func_ov002_020d454c.cpp
@@ -1,0 +1,22 @@
+//cpp
+struct Player;
+extern "C" int func_ov002_020bf30c(Player *self, int a);
+extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(Player *self, unsigned int id, int b, int c, unsigned int d);
+
+struct Player {
+    char pad0[0x98];
+    int v98;        // 0x98
+    char pad1[0x6de - 0x9c];
+    unsigned char b6de;  // 0x6de
+    unsigned char b6df;
+    unsigned char b6e0;  // 0x6e0
+};
+
+extern "C" void func_ov002_020d454c(Player *self) {
+    if (self->b6de != 0) return;
+    if (self->v98 > func_ov002_020bf30c(self, 0x10000)) {
+        self->v98 = func_ov002_020bf30c(self, 0x10000);
+    }
+    self->b6e0 = 1;
+    _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x36, 0x40000000, 0x1000, 0);
+}

--- a/src/func_ov002_020d5338.cpp
+++ b/src/func_ov002_020d5338.cpp
@@ -1,0 +1,22 @@
+//cpp
+struct State;
+struct Player {
+    bool IsState(State &);
+    void ChangeState(State &);
+};
+extern "C" {
+extern State data_ov002_02110304;
+extern State data_ov002_02110484;
+extern State data_ov002_021100f4;
+
+int func_ov002_020d5338(Player *self)
+{
+    if (self->IsState(data_ov002_02110304) ||
+        self->IsState(data_ov002_02110484) ||
+        *(unsigned char *)((char *)self + 0x6f9) ||
+        *(unsigned char *)((char *)self + 0x709))
+        return 0;
+    self->ChangeState(data_ov002_021100f4);
+    return 1;
+}
+}

--- a/src/func_ov002_020d5ed0.c
+++ b/src/func_ov002_020d5ed0.c
@@ -1,0 +1,24 @@
+/* func_ov002_020d5ed0 at 0x020d5ed0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct State;
+extern struct State data_ov002_02110064;
+extern struct State data_ov002_0211013c;
+
+struct Player;
+extern int _ZN6Player7IsStateERNS_5StateE(struct Player* self, struct State* s);
+extern void _ZN6Player11ChangeStateERNS_5StateE(struct Player* self, struct State* s);
+
+int func_ov002_020d5ed0(struct Player* self) {
+    if (!_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110064)) {
+        *(int*)((char*)self + 0xd0) = 0;
+        _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_0211013c);
+        return 0;
+    }
+    *(unsigned char*)((char*)self + 0x6e3) = 1;
+    *(short*)((char*)self + 0x600 + 0xa4) = 0x5a;
+    *(unsigned char*)((char*)self + 0x6f5) = 0;
+    return 1;
+}

--- a/src/func_ov002_020d5f34.cpp
+++ b/src/func_ov002_020d5f34.cpp
@@ -1,0 +1,21 @@
+//cpp
+struct State;
+extern State data_ov002_02110064;
+
+struct Player {
+    char pad[0xd0];
+    int fd0;                 /* +0xd0 */
+    char pad2[0x6e3 - 0xd4];
+    unsigned char f6e3;      /* +0x6e3 */
+    void SetAnim(unsigned int, int, int, unsigned int);
+    void ChangeState(State &);
+};
+
+extern "C" int func_ov002_020d5f34(Player *self, int anim) {
+    if (self->fd0 != 0) return 0;
+    self->fd0 = anim;
+    self->SetAnim(0x3f, 0, 0x3000, 0);
+    self->f6e3 = 0;
+    self->ChangeState(data_ov002_02110064);
+    return 1;
+}

--- a/src/func_ov002_020d5f98.c
+++ b/src/func_ov002_020d5f98.c
@@ -1,0 +1,21 @@
+/* func_ov002_020d5f98 at 0x020d5f98
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);
+extern int RandomIntInternal(void *r);
+extern char data_ov002_02110064[];
+extern char data_ov002_0210e160[];
+
+int func_ov002_020d5f98(char *self, unsigned char *out0, unsigned char *out1)
+{
+    if (_ZN6Player7IsStateERNS_5StateE(self, data_ov002_02110064)
+        && *(unsigned char *)(self + 0x6e3) == 3
+        && *(unsigned char *)(self + 0x6e5) != 0) {
+        *out0 = ((unsigned int)RandomIntInternal(data_ov002_0210e160) >> 4) & 3;
+        *out1 = *(unsigned char *)(self + 0x6e5);
+        return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020d600c.c
+++ b/src/func_ov002_020d600c.c
@@ -1,0 +1,16 @@
+/* func_ov002_020d600c at 0x020d600c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *st);
+extern char data_ov002_02110064;
+
+int func_ov002_020d600c(char *self) {
+    if (_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110064)) {
+        if (*(unsigned char*)(self + 0x6e3) == 1) {
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020d6048.c
+++ b/src/func_ov002_020d6048.c
@@ -1,0 +1,16 @@
+/* func_ov002_020d6048 at 0x020d6048
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct State;
+extern struct State data_ov002_02110064;
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, struct State *s);
+
+int func_ov002_020d6048(char *r0) {
+    char *r4 = r0;
+    if (_ZN6Player7IsStateERNS_5StateE(r0, &data_ov002_02110064)) {
+        if (*(unsigned char*)(r4 + 0x6e3) == 3) return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020d674c.c
+++ b/src/func_ov002_020d674c.c
@@ -1,0 +1,17 @@
+/* func_ov002_020d674c at 0x020d674c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Obj;
+struct Vtbl { char pad[0x48]; int (*f48)(struct Obj*); };
+struct Obj { struct Vtbl* vt; };
+
+int func_ov002_020d674c(unsigned char* p) {
+    struct Obj* o = *(struct Obj**)(p + 0x360);
+    if (o == 0) {
+        return 0;
+    } else {
+        return o->vt->f48(o) == 6;
+    }
+}

--- a/src/func_ov002_020d71a0.c
+++ b/src/func_ov002_020d71a0.c
@@ -1,0 +1,14 @@
+/* func_ov002_020d71a0 at 0x020d71a0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void *data_ov002_0210eb88;
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int id, int fix, unsigned int j);
+
+void func_ov002_020d71a0(char *self)
+{
+    *(char *)(self + 0x714) = 0;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void **)(self + 0x160), *(void **)((char *)&data_ov002_0210eb88 + 4), 0x40000000, 0x1000, 0);
+    *(int *)(*(char **)(self + 0x160) + 0x58) = 0;
+}

--- a/src/func_ov002_020d80d0.c
+++ b/src/func_ov002_020d80d0.c
@@ -1,0 +1,15 @@
+/* func_ov002_020d80d0 at 0x020d80d0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020bd984(char *r0, int r1);
+
+void func_ov002_020d80d0(char *r0) {
+    if (*(unsigned char*)(r0 + 0x6f8) != 1) return;
+    *(unsigned short*)(r0 + 0x600 + 0xbe) = 0;
+    *(unsigned char*)(r0 + 0x6f8) = 0;
+    *(unsigned char*)(r0 + 0x6f4) = 0;
+    *(unsigned char*)(r0 + 0x714) = 0;
+    func_ov002_020bd984(r0, 0x32);
+}

--- a/src/func_ov002_020d8118.c
+++ b/src/func_ov002_020d8118.c
@@ -1,0 +1,17 @@
+/* func_ov002_020d8118 at 0x020d8118
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020bda48(void *self);
+extern void func_ov002_020bd9ec(char *c, unsigned int r4);
+extern void func_ov002_020c43c4(void *self, int a);
+
+void func_ov002_020d8118(char *r0) {
+    char *r4 = r0;
+    func_ov002_020bda48(r4);
+    *(unsigned short*)(r4 + 0x600 + 0xbe) = 0x258;
+    func_ov002_020bd9ec(r4, 0x32);
+    func_ov002_020c43c4(r4, 5);
+    *(unsigned char*)(r4 + 0x6f8) = 1;
+}

--- a/src/func_ov002_020db5f4.cpp
+++ b/src/func_ov002_020db5f4.cpp
@@ -1,0 +1,29 @@
+//cpp
+struct State {};
+
+struct Arg {
+    char pad[0xc];
+    unsigned short f0c; // 0xc
+};
+
+struct Player {
+    char pad[0x35c];
+    void *f35c; // 0x35c
+    void ChangeState(State &);
+};
+
+extern "C" int func_ov002_020d82f0(Player *);
+extern State data_ov002_0211016c;
+
+extern "C" int func_ov002_020db5f4(Player *self, Arg *arg) {
+    int isbf = (arg->f0c == 0xbf);
+    if (!isbf) {
+        if (!func_ov002_020d82f0(self))
+            return 0;
+    }
+    if (self->f35c != 0)
+        return 0;
+    self->f35c = arg;
+    self->ChangeState(data_ov002_0211016c);
+    return 1;
+}

--- a/src/func_ov002_020db8bc.c
+++ b/src/func_ov002_020db8bc.c
@@ -1,0 +1,10 @@
+/* func_ov002_020db8bc at 0x020db8bc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020db8bc(char *r0, char r1) {
+    r0[0x6f2] = 1;
+    *(short *)(r0 + 0x6b2) = 0;
+    r0[0x6f3] = r1;
+}

--- a/src/func_ov002_020dc020.cpp
+++ b/src/func_ov002_020dc020.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern void func_ov002_020dc174(char* self, const Vector3& v, int fix, int d, unsigned int stackA, unsigned int stackB);
+void func_ov002_020dc020(char* self){
+  Vector3 v;
+  int fix, d;
+  if(!*(unsigned char*)(self+0x703)){
+    v.x=0; v.y=0xa000; v.z=0x3c000;
+    d=0x46000; fix=0x28000;
+  }else{
+    v.x=0; v.y=0x40000; v.z=0xc0000;
+    d=0x100000; fix=0x80000;
+  }
+  func_ov002_020dc174(self, v, fix, d, 0x1000, 0);
+}
+}

--- a/src/func_ov002_020dc174.cpp
+++ b/src/func_ov002_020dc174.cpp
@@ -1,0 +1,21 @@
+//cpp
+struct Actor;
+struct Vector3;
+struct MovingCylinderClsnWithPos;
+
+extern "C" {
+
+void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
+    MovingCylinderClsnWithPos* self, Actor* actor, const Vector3& v,
+    int fix, int d, unsigned int e, unsigned int f);
+
+void func_ov002_020dc174(char* self, const Vector3& v, int fix, int d,
+                         unsigned int stackA, unsigned int stackB)
+{
+    unsigned int flags = *(unsigned char*)(self + 0x703) ? 0x10 : 0;
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
+        (MovingCylinderClsnWithPos*)(self + 0x314), (Actor*)self, v, fix, d,
+        stackA | 2 | flags, stackB);
+}
+
+}

--- a/src/func_ov002_020dd8b8.c
+++ b/src/func_ov002_020dd8b8.c
@@ -1,0 +1,15 @@
+/* func_ov002_020dd8b8 at 0x020dd8b8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);
+extern char data_ov002_021105a4;
+
+int func_ov002_020dd8b8(char *r0) {
+    char *r4 = r0;
+    if (_ZN6Player7IsStateERNS_5StateE(r4, &data_ov002_021105a4) == 0) {
+        return 0;
+    }
+    return *(unsigned char*)(r4 + 0x6e3) == 0 ? 1 : 0;
+}

--- a/src/func_ov002_020de33c.cpp
+++ b/src/func_ov002_020de33c.cpp
@@ -1,0 +1,19 @@
+//cpp
+extern "C" {
+extern int data_ov002_021102bc[];
+extern int data_ov002_02110484[];
+extern int _ZN6Player7IsStateERNS_5StateE(void*,void*);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
+int func_ov002_020de33c(char* self, int a1){
+  if(!*(unsigned char*)(self+0x709)){
+    if(!_ZN6Player7IsStateERNS_5StateE(self,data_ov002_021102bc)){
+      if(!_ZN6Player7IsStateERNS_5StateE(self,data_ov002_02110484)) goto ok;
+    }
+  }
+  return 0;
+ok:
+  *(int*)(self+0x364)=a1;
+  _ZN6Player11ChangeStateERNS_5StateE(self,data_ov002_021102bc);
+  return 1;
+}
+}

--- a/src/func_ov002_020de3d0.c
+++ b/src/func_ov002_020de3d0.c
@@ -1,0 +1,12 @@
+/* func_ov002_020de3d0 at 0x020de3d0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020de3d0(void *unused, short *a, short *b) {
+    if (*b >= 0x100) *b -= 0x20;
+    if (*b <= -0x100) *b += 0x20;
+    if (*a < 0) *b += 0x10;
+    else *b -= 0x10;
+    *a = *a + *b;
+}

--- a/src/func_ov002_020de428.c
+++ b/src/func_ov002_020de428.c
@@ -1,0 +1,13 @@
+/* func_ov002_020de428 at 0x020de428
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Vector3 { int x, y, z; };
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int a, const struct Vector3 *v);
+
+void func_ov002_020de428(unsigned char *p) {
+    if (p[0x70c] != 0) return;
+    _ZN5Sound9PlayBank0EjRK7Vector3(0xbd, (struct Vector3*)(p + 0x74));
+    p[0x70c] = 0x1e;
+}

--- a/src/func_ov002_020df300.c
+++ b/src/func_ov002_020df300.c
@@ -1,0 +1,17 @@
+/* func_ov002_020df300 at 0x020df300
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Camera;
+extern void *data_0209f318;
+extern void func_0200d438(void *thiz, unsigned char playerID);
+
+int func_ov002_020df300(unsigned char *self)
+{
+    if (self[0x6e3] != 0)
+        return 0;
+    self[0x6e3] = 1;
+    func_0200d438(*(void **)&data_0209f318, self[0x6d8]);
+    return 1;
+}

--- a/src/func_ov002_020df34c.cpp
+++ b/src/func_ov002_020df34c.cpp
@@ -1,0 +1,19 @@
+//cpp
+struct State {};
+struct Camera {};
+struct Player { int IsState(State& s); void ChangeState(State& s); };
+extern "C" int func_ov002_020e0478(void* c);
+extern "C" void func_0200d474(Camera* thiz, unsigned char playerID);
+extern State data_ov002_0210ffec;
+extern State data_ov002_021102d4;
+extern Camera* data_0209f318;
+extern "C" int func_ov002_020df34c(Player* self) {
+    unsigned char* p = (unsigned char*)self;
+    if (p[0x709] != 0 || func_ov002_020e0478(self) != 0 || self->IsState(data_ov002_0210ffec) != 0) {
+        return 0;
+    }
+    p[0x6e3] = 0;
+    self->ChangeState(data_ov002_021102d4);
+    func_0200d474(data_0209f318, p[0x6d8]);
+    return 1;
+}

--- a/src/func_ov002_020df7ac.cpp
+++ b/src/func_ov002_020df7ac.cpp
@@ -1,0 +1,16 @@
+//cpp
+extern "C" {
+extern int data_ov002_02110244[];
+extern int data_ov002_021101b4[];
+extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);
+extern void _ZN6Player14St_Owl_CleanupEv(void *self);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+int func_ov002_020df7ac(char *r0) {
+    char *r4 = r0;
+    if (_ZN6Player7IsStateERNS_5StateE(r0, data_ov002_02110244) == 0)
+        return 0;
+    _ZN6Player14St_Owl_CleanupEv(r4);
+    _ZN6Player11ChangeStateERNS_5StateE(r4, data_ov002_021101b4);
+    return 1;
+}
+}

--- a/src/func_ov002_020df7f4.cpp
+++ b/src/func_ov002_020df7f4.cpp
@@ -1,0 +1,14 @@
+//cpp
+struct State {};
+struct Player { int IsState(State &); };
+extern State data_ov002_02110244;
+
+extern "C" int func_ov002_020df7f4(Player *self) {
+    if (self->IsState(data_ov002_02110244)) {
+        if (*(int *)((char *)self + 0x358) != 0)
+            goto tail;
+    }
+    return -1;
+tail:
+    return *(unsigned char *)((char *)self + 0x6e3) ? 1 : 0;
+}

--- a/src/func_ov002_020e0a64.c
+++ b/src/func_ov002_020e0a64.c
@@ -1,0 +1,21 @@
+/* func_ov002_020e0a64 at 0x020e0a64
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Obj {
+    char pad[1];
+};
+
+extern int _ZN6Player6IsAnimEj(struct Obj *self, unsigned int anim);
+extern int data_ov002_0210a5b4[];
+
+int func_ov002_020e0a64(struct Obj *self) {
+    if (!_ZN6Player6IsAnimEj(self, 0x54)) {
+        *(unsigned short *)((char*)self + 0x600 + 0xa8) = 8;
+    }
+    if (*(unsigned char *)((char*)self + 0x703) != 0) {
+        return 0x9b;
+    }
+    return data_ov002_0210a5b4[*(unsigned char *)((char*)self + 0x6e1)];
+}

--- a/src/func_ov002_020e0ccc.cpp
+++ b/src/func_ov002_020e0ccc.cpp
@@ -1,0 +1,14 @@
+//cpp
+struct State { char pad[0xc]; unsigned short id; };
+struct Player {
+    void ChangeState(State &);
+};
+extern State data_ov002_02110484;
+
+extern "C" int func_ov002_020e0ccc(Player *self, State *s) {
+    if (s == 0) return 0;
+    int ok = s->id == 0xc1;
+    if (!ok) return 0;
+    self->ChangeState(data_ov002_02110484);
+    return 1;
+}

--- a/src/func_ov002_020e0f38.cpp
+++ b/src/func_ov002_020e0f38.cpp
@@ -1,0 +1,14 @@
+//cpp
+extern "C" {
+extern int data_ov002_020ff17c[];
+extern int data_ov002_020ff188[];
+extern void _ZN5Actor11LandingDustEb(void* self, int b);
+extern void func_0201267c(int a, void* p);
+void func_ov002_020e0f38(char* self, int type){
+  *(int*)(self+0xa8)=data_ov002_020ff17c[type];
+  *(int*)(self+0x98)=data_ov002_020ff188[type];
+  if(type!=0) _ZN5Actor11LandingDustEb(self,1);
+  if(type!=2) func_0201267c(0x6c, self+0x74);
+  else func_0201267c(0x6d, self+0x74);
+}
+}

--- a/src/func_ov002_020e2b6c.c
+++ b/src/func_ov002_020e2b6c.c
@@ -1,0 +1,16 @@
+/* func_ov002_020e2b6c at 0x020e2b6c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct State;
+extern struct State data_ov002_021104cc;
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, struct State *s);
+
+int func_ov002_020e2b6c(char *r0) {
+    if (*(int*)(r0 + 0x68c) < 0xb000) {
+        return 0;
+    }
+    _ZN6Player11ChangeStateERNS_5StateE(r0, &data_ov002_021104cc);
+    return 1;
+}

--- a/src/func_ov002_020e2ba8.cpp
+++ b/src/func_ov002_020e2ba8.cpp
@@ -1,0 +1,11 @@
+//cpp
+extern "C" {
+extern int data_ov002_0211019c[];
+extern void _ZN6Player11ChangeStateERNS_5StateE(void *self, void *state);
+int func_ov002_020e2ba8(char *r0) {
+    if (*(unsigned char*)(r0 + 0x703) == 0)
+        return 0;
+    _ZN6Player11ChangeStateERNS_5StateE(r0, data_ov002_0211019c);
+    return 1;
+}
+}

--- a/src/func_ov002_020e301c.c
+++ b/src/func_ov002_020e301c.c
@@ -1,0 +1,17 @@
+/* func_ov002_020e301c at 0x020e301c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Camera;
+struct Vector3;
+extern void func_0200d8c8(struct Camera* cam, const struct Vector3* v, int strength);
+extern void* data_0209f318;
+
+void func_ov002_020e301c(int* self)
+{
+    if (self[2] != 2) return;
+    if (self[0x684/4] - self[0x60/4] < 0x190000) return;
+    func_0200d8c8((struct Camera*)data_0209f318,
+                  (const struct Vector3*)((char*)self + 0x5c), 0x320000);
+}

--- a/src/func_ov002_020e3078.c
+++ b/src/func_ov002_020e3078.c
@@ -1,0 +1,8 @@
+/* func_ov002_020e3078 at 0x020e3078
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020e3078(char *r0, int r1) {
+    return *(int *)(r0 + 0x374) == r1;
+}

--- a/src/func_ov002_020e496c.c
+++ b/src/func_ov002_020e496c.c
@@ -1,0 +1,11 @@
+/* func_ov002_020e496c at 0x020e496c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZNK6Player14GetBodyModelIDEjb(void *thisp, unsigned int a, int b);
+
+int func_ov002_020e496c(unsigned char *p) {
+    int id = _ZNK6Player14GetBodyModelIDEjb(p, p[0x6db], 1);
+    return *(int*)(p + 0xdc + (id << 2));
+}

--- a/src/func_ov002_020e6350.c
+++ b/src/func_ov002_020e6350.c
@@ -1,0 +1,13 @@
+/* func_ov002_020e6350 at 0x020e6350
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern unsigned char data_0209f2d8;
+extern unsigned char data_ov002_020ff0f4[];
+extern void func_02011ee4(int c);
+void func_ov002_020e6350(int *p) {
+    int b = (data_0209f2d8 == 1);
+    switch(b){case 0: break; default: return;}
+    func_02011ee4(data_ov002_020ff0f4[p[2] & 3]);
+}

--- a/src/func_ov002_020e63a4.cpp
+++ b/src/func_ov002_020e63a4.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor;
+struct MovingCylinderClsnWithPos {
+    void Init(Actor *a, const Vector3 &pos, int r, int s, unsigned int t, unsigned int u);
+};
+
+extern const Vector3 data_ov002_0210f92c;
+
+extern "C" void func_ov002_020e63a4(Actor *self) {
+    Vector3 v;
+    v.x = data_ov002_0210f92c.x;
+    v.y = data_ov002_0210f92c.y;
+    v.z = data_ov002_0210f92c.z;
+    ((MovingCylinderClsnWithPos *)((char *)self + 0x2d4))->Init(
+        self, v, 0x28000, 0x96000, 0x400008, 0x4f3ffe0);
+}

--- a/src/func_ov002_020e6a78.c
+++ b/src/func_ov002_020e6a78.c
@@ -1,0 +1,20 @@
+/* func_ov002_020e6a78 at 0x020e6a78
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern unsigned short Color_Interp(void *self, unsigned short a, unsigned short b, int t);
+extern void func_020555a4(void *p);
+extern unsigned short data_ov002_0210a760[];
+
+void func_ov002_020e6a78(void *self, int arg)
+{
+    unsigned short *src = (unsigned short *)self;
+    unsigned short *d = data_ov002_0210a760;
+    unsigned short *dst = (unsigned short *)((char *)self + 0x40);
+    int i;
+    for (i = 0; i < 0x20; i++) {
+        *dst++ = Color_Interp(self, *src++, *d++, arg);
+    }
+    func_020555a4((char *)self + 0x40);
+}

--- a/src/func_ov002_020e6fbc.cpp
+++ b/src/func_ov002_020e6fbc.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct Actor;
+struct SoundObj { int f4; };
+struct Actor { SoundObj *SpawnSoundObj(unsigned int); };
+extern "C" int func_ov002_020ea3a4(void *);
+
+extern "C" void func_ov002_020e6fbc(Actor *self, int arg) {
+    if (*(int *)((char *)self + 0x430) != 0) return;
+    SoundObj *s = self->SpawnSoundObj(4);
+    if (s == 0) return;
+    *(int *)((char *)self + 0x430) = *(int *)((char *)s + 4);
+    int r = func_ov002_020ea3a4(self);
+    *(int *)((char *)s + 0xd4) = r;
+    *(int *)((char *)s + 0xd8) = arg;
+}

--- a/src/func_ov002_020e7c90.cpp
+++ b/src/func_ov002_020e7c90.cpp
@@ -1,0 +1,29 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor {
+    char pad[8];
+    unsigned int actorFlags; // 0x8
+    char pad2[0x5c-0xc];
+    Vector3 pos; // 0x5c
+    static Actor* FindWithActorID(unsigned int id, Actor* prev);
+};
+struct Camera {
+    void SetLookAt(const Vector3& v);
+    void SetPos(const Vector3& v);
+};
+
+extern "C" int func_ov002_020e7c90(void* self, Camera* cam)
+{
+    unsigned int id = 0xb1;
+    Actor* a = 0;
+    for (;;) {
+        a = Actor::FindWithActorID(id, a);
+        if (a == 0) break;
+        if (*(unsigned char*)((char*)self + 0x49d) == (a->actorFlags & 0xf)) {
+            cam->SetLookAt(*(Vector3*)((char*)self + 0x5c));
+            cam->SetPos(a->pos);
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020e7d08.cpp
+++ b/src/func_ov002_020e7d08.cpp
@@ -1,0 +1,33 @@
+//cpp
+typedef int Fix12;
+struct Vector3 { int x, y, z; };
+struct Actor;
+
+struct RaycastGround {
+    char pad0[0x54];
+    RaycastGround();
+    ~RaycastGround();
+    void SetObjAndPos(const Vector3& pos, Actor* actor);
+    int DetectClsn();
+};
+
+struct Self {
+    char pad[0x5c];
+    int x, y, z; // 0x5c,0x60,0x64
+};
+
+extern "C" void func_ov002_020e7d08(Self* self)
+{
+    RaycastGround rc;
+    Vector3 v;
+    v.x = self->x;
+    v.y = self->y;
+    v.z = self->z;
+    v.y += 0x32000;
+    rc.SetObjAndPos(v, 0);
+    *(int*)((char*)&rc + 0x4c) = 0x3e8000;
+    if (rc.DetectClsn())
+        *(int*)((char*)self + 0x42c) = *(int*)((char*)&rc + 0x44);
+    else
+        *(int*)((char*)self + 0x42c) = 0x7fffffff;
+}

--- a/src/func_ov002_020e7e14.c
+++ b/src/func_ov002_020e7e14.c
@@ -1,0 +1,9 @@
+/* func_ov002_020e7e14 at 0x020e7e14
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020e7e14(char *r0) {
+    *(unsigned char *)(r0 + 0x49e) = 0xff;
+    return 1;
+}

--- a/src/func_ov002_020e7e24.c
+++ b/src/func_ov002_020e7e24.c
@@ -1,0 +1,16 @@
+/* func_ov002_020e7e24 at 0x020e7e24
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN5Actor13SpawnSoundObjEj(void *self, unsigned int id);
+
+void func_ov002_020e7e24(char *r0) {
+    char *r4 = r0;
+    if (*(unsigned char*)(r4 + 0x49e) != 0xff) {
+        return;
+    }
+    if (_ZN5Actor13SpawnSoundObjEj(r4, 6) != 0) {
+        *(unsigned char*)(r4 + 0x49e) = 0x78;
+    }
+}

--- a/src/func_ov002_020e7e58.cpp
+++ b/src/func_ov002_020e7e58.cpp
@@ -1,0 +1,25 @@
+//cpp
+struct Actor;
+struct ActorBase {
+    void MarkForDestruction();
+};
+
+struct Actor {
+    static Actor *FindWithID(unsigned int);
+};
+
+extern "C" void func_ov002_020e7e58(unsigned char *self)
+{
+    if (self[0x49c] == 0) return;
+    unsigned int id = *(unsigned int *)(self + 0x430);
+    if (id == 0) return;
+    Actor *found = Actor::FindWithID(id);
+    if (found != 0) {
+        if (self[0x49c] == 1) {
+            *(unsigned short *)((char *)found + 0xde) = 0;
+        } else {
+            ((ActorBase *)found)->MarkForDestruction();
+        }
+    }
+    *(unsigned int *)(self + 0x430) = 0;
+}

--- a/src/func_ov002_020e7eb8.cpp
+++ b/src/func_ov002_020e7eb8.cpp
@@ -1,0 +1,25 @@
+//cpp
+typedef int Fix12;
+struct Vector3_16f { Fix12 x, y, z; };
+struct Callback;
+namespace Particle {
+struct System {
+    static System *New(unsigned int, unsigned int, Fix12, Fix12, Fix12,
+                       const Vector3_16f *, Callback *);
+};
+}
+extern "C" {
+extern void func_ov002_020e8244(Vector3_16f *out, void *self);
+
+void func_ov002_020e7eb8(void *self)
+{
+    Vector3_16f v;
+    int ok = (*(unsigned short *)((char *)self + 0xc) == 0xb3);
+    if (!ok)
+        return;
+    func_ov002_020e8244(&v, self);
+    *(void **)((char *)self + 0x4c0) =
+        Particle::System::New(*(unsigned int *)((char *)self + 0x4c0),
+                              0x10e, v.x, v.y, v.z, 0, 0);
+}
+}

--- a/src/func_ov002_020e81e0.cpp
+++ b/src/func_ov002_020e81e0.cpp
@@ -1,0 +1,32 @@
+//cpp
+
+struct Vector3_16f { int x, y, z; };
+
+struct Obj {
+    char pad5c[0x5c];
+    int f5c;
+    int f60;
+    int f64;
+    char pad68[0x4b4 - 0x68];
+    void *f4b4;
+};
+
+namespace Particle {
+struct Callback;
+struct System {
+    static System *New(unsigned int a, unsigned int b, int c, int d, int e,
+                       const Vector3_16f *p, Callback *cb);
+};
+}
+
+extern "C" void func_ov002_020e81e0(Obj *self) {
+    Vector3_16f v;
+    v.x = self->f5c;
+    v.y = self->f60;
+    v.z = self->f64;
+    v.y += 0xd000;
+    self->f4b4 = Particle::System::New(*(volatile unsigned int *)&self->f4b4, 0x113,
+                                       *(volatile int *)&v.x,
+                                       *(volatile int *)&v.y,
+                                       v.z, 0, 0);
+}

--- a/src/func_ov002_020e9448.c
+++ b/src/func_ov002_020e9448.c
@@ -1,0 +1,9 @@
+/* func_ov002_020e9448 at 0x020e9448
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020e9448(int r0) {
+    *(int*)(r0 + 0x9c) = -0x1600;
+    *(int*)(r0 + 0xa0) = -0x20000;
+}

--- a/src/func_ov002_020e9630.c
+++ b/src/func_ov002_020e9630.c
@@ -1,0 +1,16 @@
+/* func_ov002_020e9630 at 0x020e9630
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int SublevelToLevel(int i);
+extern signed char data_0209f2f8;
+
+int func_ov002_020e9630(void) {
+    int level = SublevelToLevel(data_0209f2f8);
+    if (level == 0xf || level == 0x10 || level == 0x11 || level == 0x12 ||
+        level == 0x13 || level == 0x14 || level == 0x1d) {
+        return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020e9804.c
+++ b/src/func_ov002_020e9804.c
@@ -1,0 +1,19 @@
+/* func_ov002_020e9804 at 0x020e9804
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Obj { char pad[1]; };
+
+extern void _ZN9Animation7AdvanceEv(void *anim);
+extern void func_ov002_020e7fcc(struct Obj *self);
+extern int _ZN9Animation8FinishedEv(void *anim);
+extern void _ZN9ActorBase18MarkForDestructionEv(struct Obj *self);
+
+void func_ov002_020e9804(struct Obj *self) {
+    _ZN9Animation7AdvanceEv((char*)self + 0x35c);
+    func_ov002_020e7fcc(self);
+    if (_ZN9Animation8FinishedEv((char*)self + 0x35c)) {
+        _ZN9ActorBase18MarkForDestructionEv(self);
+    }
+}

--- a/src/func_ov002_020eab8c.c
+++ b/src/func_ov002_020eab8c.c
@@ -1,0 +1,15 @@
+/* func_ov002_020eab8c at 0x020eab8c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern void DeathTable_ClearBit(int id);
+
+void func_ov002_020eab8c(char *r0) {
+    char *r4 = r0;
+    void *a = _ZN5Actor10FindWithIDEj(*(unsigned int*)(r4 + 0x1cc));
+    if (a == 0) return;
+    if (*(short*)((char*)a + 0xce) >= 0) return;
+    DeathTable_ClearBit(*(short*)(r4 + 0x100 + 0xd6));
+}

--- a/src/func_ov002_020eabcc.cpp
+++ b/src/func_ov002_020eabcc.cpp
@@ -1,0 +1,22 @@
+//cpp
+struct SharedFilePtr;
+extern "C" {
+
+void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr* self);
+
+extern SharedFilePtr data_ov002_0211092c;
+extern SharedFilePtr data_ov002_0210d9a8;
+extern SharedFilePtr data_ov002_0211093c;
+
+unsigned int func_ov002_020eabcc(char* self)
+{
+    if (*(unsigned char*)(self + 0x1d8)) {
+        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211092c);
+        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9a8);
+    } else {
+        _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211093c);
+    }
+    return 1;
+}
+
+}

--- a/src/func_ov002_020eacb8.cpp
+++ b/src/func_ov002_020eacb8.cpp
@@ -1,0 +1,18 @@
+//cpp
+struct Sub {
+    virtual void f0();
+    virtual void f1();
+    virtual void f2();
+    virtual void f3();
+    virtual void f4();
+    virtual void g(int);  // vtable offset 0x14
+};
+
+extern "C" int func_ov002_020eacb8(char *self) {
+    unsigned char b = *(unsigned char *)(self + 0x1db);
+    if (((unsigned)(b << 30)) >> 31) {
+        Sub *s = (Sub *)(self + 0x114);
+        s->g(0);
+    }
+    return 1;
+}

--- a/src/func_ov002_020eacf4.cpp
+++ b/src/func_ov002_020eacf4.cpp
@@ -1,0 +1,42 @@
+//cpp
+struct Thing { int x; };
+
+struct Sub {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void m5(Thing *t);
+};
+
+struct Obj {
+    char pad80[0x80];
+    Thing arg80;          /* +0x80 (passed by address) */
+    char padb0[0xb0 - 0x84];
+    unsigned int fb0;      /* +0xb0 */
+    char pad30c[0x30c - 0xb4];
+    Sub sub30c;            /* +0x30c */
+    char pad370[0x370 - 0x310];
+    Sub sub370;            /* +0x370 */
+    char pad4a2[0x4a2 - 0x374];
+    unsigned short b0 : 1;  /* +0x4a2 bit 0 */
+    unsigned short b1 : 1;  /* bit 1 */
+    unsigned short b2 : 1;  /* bit 2 */
+};
+
+extern "C" int func_ov002_020eacf4(Obj *self) {
+    int locked;
+    if (self->arg80.x == 0) goto done;
+    locked = (self->fb0 & 0x40000) != 0;
+    if (locked) goto done;
+    if (self->b1) goto callit;
+done:
+    return 1;
+callit:
+    if (!self->b2)
+        self->sub30c.m5(&self->arg80);
+    else
+        self->sub370.m5(&self->arg80);
+    return 1;
+}

--- a/src/func_ov002_020ebe5c.cpp
+++ b/src/func_ov002_020ebe5c.cpp
@@ -1,0 +1,10 @@
+//cpp
+extern "C" {
+extern void* _ZN9ActorBasenwEj(unsigned);
+extern void* _ZN5ActorC1Ev(void*);
+void* func_ov002_020ebe5c(void){
+  void* c = _ZN9ActorBasenwEj(0xd4);
+  if(!c) return c;
+  return _ZN5ActorC1Ev(c);
+}
+}

--- a/src/func_ov002_020ebf8c.cpp
+++ b/src/func_ov002_020ebf8c.cpp
@@ -1,0 +1,14 @@
+//cpp
+extern "C" {
+extern void *data_ov002_0210ac00;
+extern void _ZN5ModelD1Ev(void *self);
+extern void func_0207328c(void *p, int a, int b, void *fn);
+extern void _ZN5ActorD1Ev(void *self);
+void *func_ov002_020ebf8c(char *r0) {
+    char *r4 = r0;
+    *(void**)r4 = &data_ov002_0210ac00;
+    func_0207328c(r4 + 0xd4, 5, 0x50, (void*)&_ZN5ModelD1Ev);
+    _ZN5ActorD1Ev(r4);
+    return r4;
+}
+}

--- a/src/func_ov002_020ebfcc.cpp
+++ b/src/func_ov002_020ebfcc.cpp
@@ -1,0 +1,23 @@
+//cpp
+struct Heap;
+struct Actor;
+extern void* data_ov002_0210ac00;
+extern void _ZN5ModelD1Ev();
+extern Heap* data_020a0eac;
+extern "C" {
+
+void func_0207328c(void* p, int a, int b, void* fn);
+void _ZN5ActorD1Ev(Actor* self);
+void _ZN6Memory10DeallocateEPvP4Heap(void* p, Heap* h);
+
+void* func_ov002_020ebfcc(Actor* self)
+{
+    char* p = (char*)self;
+    *(void**)p = (void*)&data_ov002_0210ac00;
+    func_0207328c(p + 0xd4, 5, 0x50, (void*)_ZN5ModelD1Ev);
+    _ZN5ActorD1Ev(self);
+    _ZN6Memory10DeallocateEPvP4Heap(self, data_020a0eac);
+    return self;
+}
+
+}

--- a/src/func_ov002_020ec020.cpp
+++ b/src/func_ov002_020ec020.cpp
@@ -1,0 +1,24 @@
+//cpp
+extern "C" {
+extern void* data_ov002_02110a48[];
+extern void _ZN19CylinderClsnWithPosD1Ev(void* self);
+extern void _ZN6Memory16operator_delete2EPv(void* p);
+int func_ov002_020ec020(char* self){
+  char* base=self+0xd4;
+  void** pp=data_ov002_02110a48;
+  int i;
+  for(i=0;i<5;i++,base+=0x50,pp++){
+    if(*(void**)(base+0x4c)){
+      char* node;
+      while((node=(char*)*pp)!=0){
+        *pp=*(void**)(node+0x48);
+        if(node){
+          _ZN19CylinderClsnWithPosD1Ev(node+0xc);
+          _ZN6Memory16operator_delete2EPv(node);
+        }
+      }
+    }
+  }
+  return 1;
+}
+}

--- a/src/func_ov002_020ec1d8.cpp
+++ b/src/func_ov002_020ec1d8.cpp
@@ -1,0 +1,26 @@
+//cpp
+struct CylinderClsn;
+struct Node;
+extern "C" {
+
+void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
+void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
+extern Node *data_ov002_02110a48[5];
+
+unsigned int func_ov002_020ec1d8(void)
+{
+    Node **a = data_ov002_02110a48;
+    int i;
+    for (i = 0; i < 5; i++) {
+        char *p = (char *)*a;
+        while (p) {
+            _ZN12CylinderClsn5ClearEv((CylinderClsn *)(p + 0xc));
+            _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(p + 0xc));
+            p = *(char **)(p + 0x48);
+        }
+        a++;
+    }
+    return 1;
+}
+
+}

--- a/src/func_ov002_020ec32c.cpp
+++ b/src/func_ov002_020ec32c.cpp
@@ -1,0 +1,24 @@
+//cpp
+extern "C" {
+
+void* _ZN9ActorBasenwEj(unsigned int sz);
+void _ZN5ActorC2Ev(void* self);
+void _ZN5ModelD1Ev();
+void _ZN5ModelC1Ev();
+void func_020733a8(void* base, unsigned int count, unsigned int sz,
+                   void (*ctor)(), void (*dtor)());
+
+extern void* data_ov002_0210ac00;
+
+void* func_ov002_020ec32c()
+{
+    char* self = (char*)_ZN9ActorBasenwEj(0x264);
+    if (self) {
+        _ZN5ActorC2Ev(self);
+        *(void**)self = &data_ov002_0210ac00;
+        func_020733a8(self + 0xd4, 5, 0x50, _ZN5ModelC1Ev, _ZN5ModelD1Ev);
+    }
+    return self;
+}
+
+}

--- a/src/func_ov002_020ec610.c
+++ b/src/func_ov002_020ec610.c
@@ -1,0 +1,9 @@
+/* func_ov002_020ec610 at 0x020ec610
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020ec610(int r0) {
+    int v = *(unsigned char*)(r0 + 0x428);
+    return ((v >> 7) & 1) != 0;
+}

--- a/src/func_ov002_020ec628.c
+++ b/src/func_ov002_020ec628.c
@@ -1,0 +1,10 @@
+/* func_ov002_020ec628 at 0x020ec628
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020ec628(char *r0) {
+    int x = *(unsigned char*)(r0 + 0x428);
+    x = (x >> 6) & 1;
+    return x ? 1 : 0;
+}

--- a/src/func_ov002_020ec640.c
+++ b/src/func_ov002_020ec640.c
@@ -1,0 +1,8 @@
+/* func_ov002_020ec640 at 0x020ec640
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+unsigned char func_ov002_020ec640(unsigned char *r0) {
+    return (r0[0x428] >> 2) & 0xf;
+}

--- a/src/func_ov002_020ec654.c
+++ b/src/func_ov002_020ec654.c
@@ -1,0 +1,10 @@
+/* func_ov002_020ec654 at 0x020ec654
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020ec654(char *r0) {
+    int x = *(unsigned char*)(r0 + 0x428);
+    x = ((x & 3) - 1) & 1;
+    return x ? 1 : 0;
+}

--- a/src/func_ov002_020ec978.cpp
+++ b/src/func_ov002_020ec978.cpp
@@ -1,0 +1,16 @@
+//cpp
+struct BCA_File;
+struct ModelAnim {
+    void SetAnim(BCA_File *, int, int, unsigned int);
+};
+struct Obj {
+    char pad[0x300];
+    ModelAnim anim;
+};
+extern BCA_File *data_ov002_0210eb78[];
+
+extern "C" void func_ov002_020ec978(Obj *self) {
+    self->anim.SetAnim(data_ov002_0210eb78[1], 0, 0x1000, 0);
+    *(int*)((char*)self + 0x98) = 0;
+    *(int*)((char*)self + 0x9c) = -0x2000;
+}

--- a/src/func_ov002_020ecad4.c
+++ b/src/func_ov002_020ecad4.c
@@ -1,0 +1,12 @@
+/* func_ov002_020ecad4 at 0x020ecad4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *file, int a, int fix, unsigned int e);
+extern void *data_ov002_0210eb78[];
+
+void func_ov002_020ecad4(char *r0) {
+    *(int*)(r0 + 0x98) = 0;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(r0 + 0x300, data_ov002_0210eb78[1], 0, 0x1000, 0);
+}

--- a/src/func_ov002_020ecf94.c
+++ b/src/func_ov002_020ecf94.c
@@ -1,0 +1,16 @@
+/* func_ov002_020ecf94 at 0x020ecf94
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020ec654(void *r0);
+extern void func_ov002_020ecb0c(void *r0);
+extern void func_ov002_020ecd18(void *r0);
+
+void func_ov002_020ecf94(void *r0) {
+    if (func_ov002_020ec654(r0)) {
+        func_ov002_020ecb0c(r0);
+    } else {
+        func_ov002_020ecd18(r0);
+    }
+}

--- a/src/func_ov002_020ed6cc.cpp
+++ b/src/func_ov002_020ed6cc.cpp
@@ -1,0 +1,27 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" int Vec3_HorzDist(const Vector3 *a, const Vector3 *b);
+extern "C" int DecIfAbove0_Byte(unsigned char *p);
+
+struct Obj {
+    char pad5c[0x5c];
+    Vector3 v5c;        /* +0x5c */
+    char pad3cc[0x3cc - 0x68];
+    Vector3 v3cc;       /* +0x3cc */
+    char pad41f[0x41f - 0x3d8];
+    unsigned char f41f; /* +0x41f */
+};
+
+extern "C" int func_ov002_020ed6cc(Obj *self) {
+    int dist = Vec3_HorzDist(&self->v3cc, &self->v5c);
+    self->v3cc.x = self->v5c.x;
+    self->v3cc.y = self->v5c.y;
+    self->v3cc.z = self->v5c.z;
+    if (dist < 0x32000) {
+        if (DecIfAbove0_Byte(&self->f41f) != 0) goto ret0;
+        return 1;
+    }
+    self->f41f = 0xf;
+ret0:
+    return 0;
+}

--- a/src/func_ov002_020edf54.c
+++ b/src/func_ov002_020edf54.c
@@ -1,0 +1,19 @@
+/* func_ov002_020edf54 at 0x020edf54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN13SharedFilePtr7ReleaseEv(void *self);
+extern int func_ov002_020ec628(char *r0);
+extern void UnloadBlueCoinModel(char *r0);
+extern char data_ov002_0210e6b0;
+extern char data_ov002_0210eb78;
+
+int func_ov002_020edf54(char *self) {
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210e6b0);
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210eb78);
+    if (func_ov002_020ec628(self)) {
+        UnloadBlueCoinModel(self);
+    }
+    return 1;
+}

--- a/src/func_ov002_020edf98.cpp
+++ b/src/func_ov002_020edf98.cpp
@@ -1,0 +1,30 @@
+//cpp
+struct Player;
+extern "C" int _ZN6Player16IsInsideOfCannonEv(Player *self);
+
+struct Sub {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5(int a);   // vtable+0x14
+};
+
+struct Player {
+    char pad0[0xb0];
+    unsigned int flags;     // 0xb0
+    char pad1[0x300 - 0xb4];
+    Sub sub;                // 0x300 (embedded)
+    char pad2[0x38c - 0x304];
+    Player *other;          // 0x38c
+};
+
+extern "C" int func_ov002_020edf98(Player *self) {
+    int inAir = (self->flags & 0x40000) ? 1 : 0;
+    if (inAir != 0) return 1;
+    if (_ZN6Player16IsInsideOfCannonEv(self->other) != 0) return 1;
+    if (*(unsigned char *)((char *)self->other + 0x6f5) < 1) return 1;
+    self->sub.v5(0);
+    return 1;
+}

--- a/src/func_ov002_020eeca8.cpp
+++ b/src/func_ov002_020eeca8.cpp
@@ -1,0 +1,32 @@
+//cpp
+extern "C" int func_02035638(unsigned char *p);
+extern "C" int func_0203567c(int p);
+struct ClsnResult { int GetClsnID() const; };
+extern "C" int _ZNK10ClsnResult9GetClsnIDEv(ClsnResult *self);
+
+struct Actor {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(int a); // +0x70
+};
+extern "C" Actor *_ZN5Actor10FindWithIDEj(unsigned int id);
+
+extern "C" int func_ov002_020eeca8(unsigned char *self, int arg) {
+    if (func_02035638(self) != 0) {
+        ClsnResult *cr = (ClsnResult *)func_0203567c((int)self);
+        if (_ZNK10ClsnResult9GetClsnIDEv(cr) != -1) {
+            int id = _ZNK10ClsnResult9GetClsnIDEv(cr);
+            Actor *a = _ZN5Actor10FindWithIDEj((unsigned int)id);
+            if (a != 0) {
+                a->v28(arg);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020eedc0.cpp
+++ b/src/func_ov002_020eedc0.cpp
@@ -1,0 +1,32 @@
+//cpp
+struct ClsnResult {
+    int GetClsnID() const;
+};
+struct WithMeshClsn {
+    bool IsOnWall() const;
+    ClsnResult *GetWallResult() const;
+};
+struct Actor {
+    static Actor *FindWithID(unsigned int);
+    virtual void v0();
+};
+extern "C" {
+
+int func_ov002_020eedc0(WithMeshClsn *self, int arg)
+{
+    Actor *a;
+    ClsnResult *res;
+    if (!self->IsOnWall())
+        goto fail;
+    res = self->GetWallResult();
+    if (res->GetClsnID() == -1)
+        goto fail;
+    a = Actor::FindWithID(res->GetClsnID());
+    if (!a)
+        goto fail;
+    (*(void (**)(Actor *, int))(*(void ***)a + 0x68 / 4))(a, arg);
+    return 1;
+fail:
+    return 0;
+}
+}

--- a/src/func_ov002_020eee3c.cpp
+++ b/src/func_ov002_020eee3c.cpp
@@ -1,0 +1,25 @@
+//cpp
+struct ClsnResult { unsigned int GetClsnID() const; };
+struct WithMeshClsn {
+    bool IsOnWall() const;
+    ClsnResult *GetWallResult() const;
+};
+struct Actor {
+    static Actor *FindWithID(unsigned int);
+    virtual void v0();
+};
+
+extern "C" int func_ov002_020eee3c(WithMeshClsn *self, void *arg)
+{
+    if (self->IsOnWall()) {
+        ClsnResult *res = self->GetWallResult();
+        if ((int)res->GetClsnID() != -1) {
+            Actor *a = Actor::FindWithID(res->GetClsnID());
+            if (a != 0) {
+                (*(void (**)(Actor *, void *))(*(int *)a + 0x64))(a, arg);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020ef228.cpp
+++ b/src/func_ov002_020ef228.cpp
@@ -1,0 +1,30 @@
+//cpp
+struct ClsnResult {
+    int GetClsnID() const;
+};
+
+struct WithMeshClsn {
+    int IsOnWall() const;
+    ClsnResult *GetWallResult() const;
+};
+
+typedef void (*VFn)(void *, void *);
+
+struct Actor {
+    static Actor *FindWithID(unsigned int);
+};
+
+extern "C" int func_ov002_020ef228(WithMeshClsn *self, void *other) {
+    if (self->IsOnWall()) {
+        ClsnResult *r = self->GetWallResult();
+        if (r->GetClsnID() != -1) {
+            Actor *a = Actor::FindWithID(r->GetClsnID());
+            if (a) {
+                VFn fn = *(VFn *)(*(char **)a + 0x58);
+                fn(a, other);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020ef2a4.cpp
+++ b/src/func_ov002_020ef2a4.cpp
@@ -1,0 +1,22 @@
+//cpp
+extern "C" {
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+extern void* _ZNK12WithMeshClsn14GetFloorResultEv(void* self);
+extern int _ZNK10ClsnResult9GetClsnIDEv(void* self);
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+int func_ov002_020ef2a4(void* self, void* arg){
+  void* fr;
+  void* actor;
+  if(_ZNK12WithMeshClsn10IsOnGroundEv(self)){
+    fr=_ZNK12WithMeshClsn14GetFloorResultEv(self);
+    if(_ZNK10ClsnResult9GetClsnIDEv(fr)!=-1){
+      actor=_ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(fr));
+      if(actor){
+        (*(void(***)(void*,void*))actor)[0x54/4](actor,arg);
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+}

--- a/src/func_ov002_020efa54.cpp
+++ b/src/func_ov002_020efa54.cpp
@@ -1,0 +1,18 @@
+//cpp
+struct Class {
+    char pad[0x44c];
+    int sel;
+};
+
+struct Entry {
+    void (Class::*pmf)();
+    int extra[3];
+};
+
+extern Entry data_ov002_0210af2c[];
+
+extern "C" void func_ov002_020efa54(Class *self, int sel) {
+    self->sel = sel;
+    int idx = self->sel;
+    (self->*(data_ov002_0210af2c[idx].pmf))();
+}

--- a/src/func_ov002_020efc74.cpp
+++ b/src/func_ov002_020efc74.cpp
@@ -1,0 +1,25 @@
+//cpp
+struct Vec3 { int x, y, z; };
+struct Obj {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5(Vec3* p);
+};
+extern "C" int func_ov002_020efe9c(int* self);
+extern Vec3 data_ov002_0210af00;
+extern "C" void func_ov002_020efc74(void* self) {
+    char* p = (char*)self;
+    if (func_ov002_020efe9c((int*)self) == 0) return;
+    if (*(int*)(p + 0x44c) == 2) return;
+    int i = 0;
+    Obj* obj = (Obj*)(p + 0x320);
+    do {
+        Vec3 local = data_ov002_0210af00;
+        obj->v5(&local);
+        i++;
+        obj = (Obj*)((char*)obj + 0x50);
+    } while (i < 3);
+}

--- a/src/func_ov002_020efe7c.c
+++ b/src/func_ov002_020efe7c.c
@@ -1,0 +1,9 @@
+/* func_ov002_020efe7c at 0x020efe7c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020efe7c(char *r0) {
+    unsigned char v = *(unsigned *)(r0 + 8) >> 0xa & 3;
+    return v == 1;
+}

--- a/src/func_ov002_020efe9c.c
+++ b/src/func_ov002_020efe9c.c
@@ -1,0 +1,9 @@
+/* func_ov002_020efe9c at 0x020efe9c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020efe9c(int *r0) {
+    unsigned char v = ((unsigned int)r0[2] >> 0xc) & 3;
+    return (v == 1) ? 1 : 0;
+}

--- a/src/func_ov002_020efebc.c
+++ b/src/func_ov002_020efebc.c
@@ -1,0 +1,9 @@
+/* func_ov002_020efebc at 0x020efebc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020efebc(char *r0) {
+    unsigned char v = (*(unsigned *)(r0 + 8) >> 8) & 3;
+    return v == 2;
+}

--- a/src/func_ov002_020efedc.c
+++ b/src/func_ov002_020efedc.c
@@ -1,0 +1,12 @@
+/* func_ov002_020efedc at 0x020efedc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020efedc(int *r0) {
+    int result = 1;
+    unsigned char v = ((unsigned int)r0[2] >> 8) & 3;
+    if (v == 1) return result;
+    if (v != 2) result = 0;
+    return result;
+}

--- a/src/func_ov002_020eff04.c
+++ b/src/func_ov002_020eff04.c
@@ -1,0 +1,8 @@
+/* func_ov002_020eff04 at 0x020eff04
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020eff04(char *r0) {
+    return *(unsigned char *)(r0 + 0x42c) != 0;
+}

--- a/src/func_ov002_020eff90.cpp
+++ b/src/func_ov002_020eff90.cpp
@@ -1,0 +1,40 @@
+//cpp
+struct Obj {
+    virtual void v00();
+    virtual void v04();
+    virtual void v08();
+    virtual void v0c();
+    virtual void v10();
+    virtual void v14();
+    virtual void v18();
+    virtual void v1c();
+    virtual void v20();
+    virtual void v24();
+    virtual void v28();
+    virtual void v2c();
+    virtual void v30();
+    virtual void v34();
+    virtual void v38();
+    virtual void v3c();
+    virtual void v40();
+    virtual void v44();
+    virtual void v48();
+    virtual void v4c();
+    virtual void v50();
+    virtual void v54();
+    virtual void v58();
+    virtual void v5c();
+    virtual void v60();
+    virtual void v64();
+    virtual void v68();
+    virtual void v6c();
+    virtual void v70();
+    virtual void v74();
+    virtual void v78();
+    virtual void v7c();
+    virtual int vfn80(int a);
+};
+
+extern "C" int func_ov002_020eff90(void *unused, Obj *obj, int arg) {
+    return obj->vfn80(arg);
+}

--- a/src/func_ov002_020f035c.c
+++ b/src/func_ov002_020f035c.c
@@ -1,0 +1,28 @@
+/* func_ov002_020f035c at 0x020f035c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020f035c(int r0, int r1) {
+    int v;
+    switch (r0) {
+    case 4:
+        v = 0xff0;
+        break;
+    case 5:
+        v = 0xfff;
+        break;
+    case 3:
+        v = 0xfc1;
+        break;
+    case 0:
+    default:
+        v = 0xf74;
+        break;
+    case 1:
+    case 2:
+        v = 0xf08;
+        break;
+    }
+    return r1 <= v;
+}

--- a/src/func_ov002_020f07dc.cpp
+++ b/src/func_ov002_020f07dc.cpp
@@ -1,0 +1,34 @@
+//cpp
+typedef int Fix12;
+struct Actor;
+struct SharedFilePtr;
+
+struct MovingCylinderClsn {
+    void Init(Actor* actor, Fix12 a, Fix12 b, unsigned int c, unsigned int d);
+};
+
+namespace Model {
+    void LoadFile(SharedFilePtr& f);
+}
+
+extern SharedFilePtr data_ov002_0210d9a8;
+
+struct Self {
+    char pad0[8];
+    unsigned int flags; // 0x8
+    char pad1[0xc8];
+    MovingCylinderClsn clsn; // 0xd4
+};
+
+extern "C" int func_ov002_020f07dc(Self* self)
+{
+    self->clsn.Init((Actor*)self, 0x64000, 0x40000, 0x800002, 0);
+    *(unsigned char*)((char*)self + 0x10d) = self->flags & 0xf;
+    *(unsigned char*)((char*)self + 0x10e) = (self->flags >> 8) & 0xf;
+    *(unsigned char*)((char*)self + 0x10f) = 0;
+    *(int*)((char*)self + 0x108) = 0;
+    *(unsigned char*)((char*)self + 0x110) = 0;
+    *(unsigned char*)((char*)self + 0x113) = 0;
+    Model::LoadFile(data_ov002_0210d9a8);
+    return 1;
+}

--- a/src/func_ov002_020f0918.c
+++ b/src/func_ov002_020f0918.c
@@ -1,0 +1,10 @@
+/* func_ov002_020f0918 at 0x020f0918
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f0918(char *r0, char *r1) {
+    if (r1 == 0) return;
+    *(int *)(r0 + 0x138) = *(int *)(r1 + 4);
+    *(int *)(r0 + 0x148) = *(int *)(r0 + 0x60) - *(int *)(r1 + 0x60);
+}

--- a/src/func_ov002_020f093c.cpp
+++ b/src/func_ov002_020f093c.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct SharedFilePtr { void Release(); };
+extern SharedFilePtr data_ov002_0210da28;
+extern SharedFilePtr data_ov002_0210da08;
+extern SharedFilePtr data_ov002_0210d9a8;
+extern SharedFilePtr data_ov002_0210d9e8;
+
+extern "C" int func_ov002_020f093c(char *self) {
+    if (*(int *)(self + 8) & 0x10) {
+        data_ov002_0210da28.Release();
+        data_ov002_0210da08.Release();
+    } else {
+        data_ov002_0210d9a8.Release();
+        data_ov002_0210d9e8.Release();
+    }
+    return 1;
+}

--- a/src/func_ov002_020f0e54.c
+++ b/src/func_ov002_020f0e54.c
@@ -1,0 +1,10 @@
+/* func_ov002_020f0e54 at 0x020f0e54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f0e54(int *r0, int *r1) {
+    if (r1 == 0) return;
+    r0[0x138 / 4] = r1[1];
+    r0[0x148 / 4] = r0[0x60 / 4] - r1[0x60 / 4];
+}

--- a/src/func_ov002_020f1290.cpp
+++ b/src/func_ov002_020f1290.cpp
@@ -1,0 +1,25 @@
+//cpp
+struct Sub {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void m5(int);   // vtable +0x14
+};
+
+struct Obj {
+    char pad[0x60];
+    int a;                  // 0x60
+    char pad2[0xd4 - 0x64];
+    Sub sub;                // 0xd4
+    char pad3[0x320 - (0xd4 + sizeof(Sub))];
+    int b;                  // 0x320
+};
+
+extern "C" int func_ov002_020f1290(Obj *p) {
+    if (p->a > p->b) {
+        p->sub.m5(0);
+    }
+    return 1;
+}

--- a/src/func_ov002_020f1578.c
+++ b/src/func_ov002_020f1578.c
@@ -1,0 +1,20 @@
+/* func_ov002_020f1578 at 0x020f1578
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020dd8b8(char *r0);
+
+int func_ov002_020f1578(char *self, char *p) {
+    int ok = (*(unsigned short*)(p + 0xc) == 0xbf);
+    int r;
+    if (!ok) {
+        return ok;
+    }
+    r = func_ov002_020dd8b8(p);
+    if (r) {
+        r = 1;
+        *(unsigned char*)(self + 0x32c) = 1;
+    }
+    return r;
+}

--- a/src/func_ov002_020f16cc.c
+++ b/src/func_ov002_020f16cc.c
@@ -1,0 +1,11 @@
+/* func_ov002_020f16cc at 0x020f16cc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN5Event8ClearBitEj(unsigned int x);
+
+int func_ov002_020f16cc(unsigned char *p) {
+    _ZN5Event8ClearBitEj(p[0x10d]);
+    return 1;
+}

--- a/src/func_ov002_020f16ec.cpp
+++ b/src/func_ov002_020f16ec.cpp
@@ -1,0 +1,33 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+
+struct Event { static int GetBit(unsigned int); };
+struct Actor { static void *Spawn(unsigned int, unsigned int, Vector3 const &, Vector3_16 const *, int, int); };
+
+struct Obj {
+    char pad0[0x5c];
+    Vector3 v5c;      // 0x5c
+    char pad1[0x92 - 0x68];
+    Vector3_16 v92;   // 0x92
+    char pad2[0xcc - 0x98];
+    signed char cc;   // 0xcc
+    char pad3[0xd4 - 0xcd];
+    unsigned short d4; // 0xd4
+    char pad4[0xd8 - 0xd6];
+    int d8;           // 0xd8
+    unsigned char dc; // 0xdc
+};
+
+extern "C" void func_ov102_0214ad14(void *);
+
+extern "C" int func_ov002_020f16ec(Obj *self) {
+    if (Event::GetBit(self->dc) && self->d8 == 0) {
+        void *a = Actor::Spawn(self->d4, 4, self->v5c, &self->v92, self->cc, -1);
+        if (a != 0) {
+            func_ov102_0214ad14(a);
+        }
+    }
+    self->d8 = Event::GetBit(self->dc);
+    return 1;
+}

--- a/src/func_ov002_020f1838.c
+++ b/src/func_ov002_020f1838.c
@@ -1,0 +1,18 @@
+/* func_ov002_020f1838 at 0x020f1838
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct SharedFilePtr;
+extern struct SharedFilePtr data_ov002_0210d9e0;
+extern int _ZN5Event6GetBitEj(unsigned int n);
+extern void _ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr *p);
+
+int func_ov002_020f1838(char *r0) {
+    char *r4 = r0;
+    *(unsigned short*)(r4 + 0xd4) = 0xce;
+    *(unsigned char*)(r4 + 0xdc) = (short)*(short*)(r4 + 0x90) & 0x1f;
+    *(int*)(r4 + 0xd8) = _ZN5Event6GetBitEj(*(unsigned char*)(r4 + 0xdc));
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9e0);
+    return 1;
+}

--- a/src/func_ov002_020f1c20.c
+++ b/src/func_ov002_020f1c20.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f1c20 at 0x020f1c20
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern signed char data_ov002_02110af0;
+extern signed char data_02092120;
+extern int data_ov002_02110af8;
+int func_ov002_020f1c20(void) {
+    if (data_ov002_02110af0 == data_02092120) {
+        return data_ov002_02110af8;
+    }
+    return 0;
+}

--- a/src/func_ov002_020f2340.c
+++ b/src/func_ov002_020f2340.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f2340 at 0x020f2340
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN3OAM9RenderSubEP7OamAttrii(void *oam, int a, int b);
+extern char data_ov002_0210bddc;
+
+void func_ov002_020f2340(char *self) {
+    char *p = *(char**)(self + 0xd4);
+    _ZN3OAM9RenderSubEP7OamAttrii(&data_ov002_0210bddc, 0x80, *(unsigned short*)(p + 8));
+    p = *(char**)(self + 0xd4);
+    _ZN3OAM9RenderSubEP7OamAttrii(&data_ov002_0210bddc, 0x80, *(unsigned short*)(p + 0xa));
+}

--- a/src/func_ov002_020f26c4.c
+++ b/src/func_ov002_020f26c4.c
@@ -1,0 +1,9 @@
+/* func_ov002_020f26c4 at 0x020f26c4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020f26c4(char *r0, unsigned char *r1) {
+    *(unsigned char *)(r0 + 0x100) = *r1;
+    return 1;
+}

--- a/src/func_ov002_020f2790.cpp
+++ b/src/func_ov002_020f2790.cpp
@@ -1,0 +1,27 @@
+//cpp
+struct Fix12 { int v; };
+struct Vector3_16f;
+namespace Particle {
+struct Callback;
+struct System {
+    static System* New(unsigned int a, unsigned int b, int c, int d, int e,
+                       const Vector3_16f* f, Callback* g);
+};
+}
+
+extern "C" {
+
+void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
+
+void func_ov002_020f2790(char* self, int r1, int r2, void* r3, short s)
+{
+    *(void**)(self + 0x508) = r3;
+    *(short*)(self + 0x50c) = s;
+    *(void**)(self + 0x1fc) =
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned int*)(self + 0x1fc), 0x3e, r1 << 12, r2 << 12, 0,
+            0, (void*)(self + 0x200));
+}
+
+}

--- a/src/func_ov002_020f2958.c
+++ b/src/func_ov002_020f2958.c
@@ -1,0 +1,12 @@
+/* func_ov002_020f2958 at 0x020f2958
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f2958(char *r0) {
+    *(unsigned char *)(r0 + 0x1ed) = 1;
+    *(int *)(r0 + 0x1e4) = 0x199;
+    *(short *)(r0 + 0x1e8) = 0x199;
+    *(unsigned char *)(r0 + 0x1ec) = 0;
+    *(short *)(r0 + 0x1ea) = 0;
+}

--- a/src/func_ov002_020f2a78.c
+++ b/src/func_ov002_020f2a78.c
@@ -1,0 +1,8 @@
+/* func_ov002_020f2a78 at 0x020f2a78
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f2a78(char *r0, int r1) {
+    *(unsigned char *)(r0 + r1 * 8 + 0x1c8) = 0;
+}

--- a/src/func_ov002_020f2e30.c
+++ b/src/func_ov002_020f2e30.c
@@ -1,0 +1,33 @@
+/* func_ov002_020f2e30 at 0x020f2e30
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_0201f108(void);
+extern void func_0201ef50(unsigned int x);
+extern unsigned char data_0209d454;
+
+struct Obj {
+    char pad1c4[0x1c4];
+    unsigned short f1c4;   /* +0x1c4 */
+    unsigned short f1c6;   /* +0x1c6 */
+    unsigned char f1c8;    /* +0x1c8 */
+    unsigned char f1c9;    /* +0x1c9 */
+    unsigned char f1ca;    /* +0x1ca */
+    unsigned char f1cb;    /* +0x1cb */
+};
+
+void func_ov002_020f2e30(struct Obj *self, int n) {
+    if (n == 0) return;
+    if (n == 0x15) return;
+    self->f1c8 = 1;
+    self->f1c9 = 0;
+    self->f1c4 = 0;
+    self->f1c6 = 0;
+    self->f1ca = 0;
+    n = (n - 1) << 1;
+    self->f1cb = (unsigned char)n;
+    func_0201f108();
+    func_0201ef50(n & 0xff);
+    data_0209d454 |= 1;
+}

--- a/src/func_ov002_020f30d4.c
+++ b/src/func_ov002_020f30d4.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f30d4 at 0x020f30d4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f30d4(char *r0) {
+    int i = 0;
+    do {
+        r0[0x170] = 0;
+        i++;
+        r0[0x171] = 0;
+        r0 += 0x14;
+    } while (i < 5);
+}

--- a/src/func_ov002_020f32e4.c
+++ b/src/func_ov002_020f32e4.c
@@ -1,0 +1,12 @@
+/* func_ov002_020f32e4 at 0x020f32e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f32e4(int *r0, int r1) {
+    int *base = (int *)((char *)r0 + r1 * 0x30);
+    *(unsigned short *)((char *)base + 0x100 + 0x58) = 0x10;
+    base[0x150 / 4] = 0x1800;
+    base[0x154 / 4] = 0x1800;
+    *((unsigned char *)base + 0x15e) = 1;
+}

--- a/src/func_ov002_020f378c.c
+++ b/src/func_ov002_020f378c.c
@@ -1,0 +1,9 @@
+/* func_ov002_020f378c at 0x020f378c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f378c(unsigned char *r0, int r1) {
+    unsigned char *base = r0 + r1 * 0x30;
+    base[0x15e] = 0;
+}

--- a/src/func_ov002_020f37a0.cpp
+++ b/src/func_ov002_020f37a0.cpp
@@ -1,0 +1,13 @@
+//cpp
+struct Class {
+    char pad[0x15c];
+    unsigned char guard;
+    unsigned char idx;
+};
+
+extern void (Class::*data_ov002_02110e4c[])(int);
+
+extern "C" void func_ov002_020f37a0(Class *self) {
+    if (self->guard == 0) return;
+    (self->*(data_ov002_02110e4c[self->idx]))(0);
+}

--- a/src/func_ov002_020f37fc.c
+++ b/src/func_ov002_020f37fc.c
@@ -1,0 +1,13 @@
+/* func_ov002_020f37fc at 0x020f37fc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020f3828(void *this);
+
+void func_ov002_020f37fc(void *this) {
+    func_ov002_020f3828(this);
+    *((unsigned char *)this + 0x15c) = 1;
+    *((unsigned char *)this + 0x15d) = 2;
+    *((unsigned char *)this + 0x15e) = 0;
+}

--- a/src/func_ov002_020f3978.cpp
+++ b/src/func_ov002_020f3978.cpp
@@ -1,0 +1,17 @@
+//cpp
+struct OamAttr;
+struct Matrix2x2;
+extern "C" {
+extern int data_ov002_0210b998[];
+extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int a, OamAttr* attr, int x, int y, int p4, int p5, Matrix2x2* m);
+void func_ov002_020f3978(char* self){
+  int i;
+  char* p=self;
+  for(i=0;i<4;i++,p+=0x4c){
+    if(*(unsigned char*)(p+0x45)){
+      _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1,(OamAttr*)data_ov002_0210b998[i],
+        *(int*)p>>12,*(int*)(p+4)>>12,-1,1,0);
+    }
+  }
+}
+}

--- a/src/func_ov002_020f3d38.c
+++ b/src/func_ov002_020f3d38.c
@@ -1,0 +1,23 @@
+/* func_ov002_020f3d38 at 0x020f3d38
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f3d38(char *r0, int r1) {
+    int ip = r1 * 0x4c;
+    unsigned short h = *(unsigned short *)(r0 + 0x30 + ip);
+    char *r3 = r0 + 0x30 + ip;
+    if (h != 0) {
+        *(unsigned short *)r3 = h - 1;
+        return;
+    }
+    *(int *)(r0 + ip) = -0x10000;
+    *(int *)(r0 + ip + 4) = -0x10000;
+    *(int *)(r0 + ip + 8) = 0x2000;
+    *(unsigned short *)(r0 + ip + 0x2e) = 0;
+    *(unsigned short *)r3 = 0;
+    {
+        unsigned char *b = (unsigned char *)(r0 + 0x47);
+        b[ip] = b[ip] + 1;
+    }
+}

--- a/src/func_ov002_020f55b4.cpp
+++ b/src/func_ov002_020f55b4.cpp
@@ -1,0 +1,16 @@
+//cpp
+extern unsigned short data_ov002_021000d8[];
+
+extern "C" void func_ov002_020f55b4(char *base, int idx) {
+    char *e = base + idx * 0x4c;
+    if (*(unsigned short *)(e + 0x3a) != 0x10) return;
+    *(unsigned char *)(base + 0x47 + idx * 0x4c) = *(unsigned char *)(base + 0x47 + idx * 0x4c) + 1;
+    *(int *)(e + 0x10) = 0x38000;
+    *(unsigned short *)(e + 0x2e) = data_ov002_021000d8[idx];
+    *(unsigned char *)(e + 0x48) = 0;
+    *(unsigned short *)(e + 0x3c) = 0;
+    *(int *)(e + 0x24) = 0;
+    *(unsigned short *)(e + 0x42) = 0x200;
+    *(int *)(e + 0x28) = 0x1000;
+    *(unsigned short *)(e + 0x2c) = 0x200;
+}

--- a/src/func_ov002_020f5678.c
+++ b/src/func_ov002_020f5678.c
@@ -1,0 +1,10 @@
+/* func_ov002_020f5678 at 0x020f5678
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5678(int r0, int r1) {
+    int p = r0 + r1 * 0x4c;
+    *(int*)(p + 0x28) = 0xccc;
+    *(short*)(p + 0x2c) = 0x155;
+}

--- a/src/func_ov002_020f57c0.c
+++ b/src/func_ov002_020f57c0.c
@@ -1,0 +1,39 @@
+/* func_ov002_020f57c0 at 0x020f57c0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int data_ov002_02100170[];
+
+struct Elem {
+    char pad8[8];
+    int f8;            /* +0x08 */
+    int fc;            /* +0x0c */
+    char pad30[0x30 - 0x10];
+    unsigned short f30; /* +0x30 */
+    unsigned short f32; /* +0x32 */
+    char pad3a[0x3a - 0x34];
+    unsigned short f3a; /* +0x3a */
+    char pad45[0x45 - 0x3c];
+    unsigned char f45;  /* +0x45 */
+    char pad47[0x47 - 0x46];
+    unsigned char f47;  /* +0x47 */
+    char pad49[0x49 - 0x48];
+    unsigned char f49;  /* +0x49 */
+};
+
+void func_ov002_020f57c0(struct Elem *base, int idx) {
+    int off = idx * 0x4c;
+    struct Elem *e = (struct Elem *)((char *)base + off);
+    unsigned char *b47;
+    if (e->f3a != 0) return;
+    if (e->f32 != 0) return;
+    e->f49 = 1;
+    e->f45 = 1;
+    b47 = (unsigned char *)base + 0x47;
+    b47[off] = b47[off] + 1;
+    e->f8 = data_ov002_02100170[idx * 2];
+    e->fc = data_ov002_02100170[idx * 2 + 1];
+    if (idx == 0) e->f30 = 0x78;
+    else e->f30 = 0x20;
+}

--- a/src/func_ov002_020f5a6c.c
+++ b/src/func_ov002_020f5a6c.c
@@ -1,0 +1,15 @@
+/* func_ov002_020f5a6c at 0x020f5a6c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5a6c(unsigned char* r0) {
+    int i = 0;
+    do {
+        r0[0x44] = 0;
+        r0[0x45] = 0;
+        r0[0x4a] = 0;
+        i++;
+        r0 += 0x4c;
+    } while (i < 4);
+}

--- a/src/func_ov002_020f5a94.c
+++ b/src/func_ov002_020f5a94.c
@@ -1,0 +1,18 @@
+/* func_ov002_020f5a94 at 0x020f5a94
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int _ZN8SaveData19IsCharacterUnlockedEj(unsigned int c);
+
+int func_ov002_020f5a94(void) {
+    unsigned char count = 0;
+    int i = 0;
+    do {
+        if (_ZN8SaveData19IsCharacterUnlockedEj(i)) {
+            count = count + 1;
+        }
+        i++;
+    } while (i < 4);
+    return count;
+}

--- a/src/func_ov002_020f5ad4.c
+++ b/src/func_ov002_020f5ad4.c
@@ -1,0 +1,25 @@
+/* func_ov002_020f5ad4 at 0x020f5ad4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020f5a6c(unsigned char* p);
+extern void func_ov002_020f396c(char* p);
+extern void func_ov002_020f30d4(char* p);
+extern void func_ov002_020f2ea0(char* p);
+extern void func_ov002_020f2a68(char* p);
+extern void func_ov002_020f2984(char* p);
+
+void func_ov002_020f5ad4(char* self)
+{
+    *(int*)(self + 0x1f0) = 0;
+    *(int*)(self + 0x1f4) = 0;
+    *(int*)(self + 0x1f8) = 0;
+    *(unsigned char*)(self + 0x514) = 0;
+    func_ov002_020f5a6c((unsigned char*)self);
+    func_ov002_020f396c(self);
+    func_ov002_020f30d4(self);
+    func_ov002_020f2ea0(self);
+    func_ov002_020f2a68(self);
+    func_ov002_020f2984(self);
+}

--- a/src/func_ov002_020f5b98.c
+++ b/src/func_ov002_020f5b98.c
@@ -1,0 +1,26 @@
+/* func_ov002_020f5b98 at 0x020f5b98
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct E {
+    unsigned char pad44[2];
+    unsigned char f46;
+    unsigned char f47;
+    unsigned char pad48[2];
+    unsigned char f4a;
+    unsigned char pad[0x4c - 0x4b];
+};
+
+void func_ov002_020f5b98(unsigned char *p) {
+    int i = 0;
+    do {
+        if (p[0x44]) {
+            p[0x46] = 2;
+            p[0x47] = 0;
+            p[0x4a] = 0;
+        }
+        i++;
+        p += 0x4c;
+    } while (i < 4);
+}

--- a/src/func_ov002_020f5bcc.c
+++ b/src/func_ov002_020f5bcc.c
@@ -1,0 +1,15 @@
+/* func_ov002_020f5bcc at 0x020f5bcc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5bcc(char *r0) {
+    int i = 0;
+    do {
+        i++;
+        if (*(unsigned char*)(r0 + 0x44) != 0) {
+            *(unsigned char*)(r0 + 0x4a) = 1;
+        }
+        r0 += 0x4c;
+    } while (i < 4);
+}

--- a/src/func_ov002_020f5bf4.c
+++ b/src/func_ov002_020f5bf4.c
@@ -1,0 +1,15 @@
+/* func_ov002_020f5bf4 at 0x020f5bf4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5bf4(void *this) {
+    char *p = (char *)this;
+    if (*(unsigned char *)(p + 0x128) == 0) return;
+    *(int *)(p + 0xe4) = 0x80000;
+    *(int *)(p + 0xe8) = 0x60000;
+    *(short *)(p + 0x114) = 0;
+    *(unsigned char *)(p + 0x12a) = 1;
+    *(int *)(p + 0x10c) = 0xccc;
+    *(short *)(p + 0x110) = 0x155;
+}

--- a/src/func_ov002_020f5c40.c
+++ b/src/func_ov002_020f5c40.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f5c40 at 0x020f5c40
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5c40(unsigned char *p) {
+    if (p[0xdc] == 0) return;
+    *(int*)(p + 0x98) = 0x80000;
+    *(int*)(p + 0x9c) = 0x60000;
+    *(short*)(p + 0xc8) = 0;
+    p[0xde] = 1;
+    *(int*)(p + 0xc0) = 0xccc;
+    *(short*)(p + 0xc4) = 0x155;
+}

--- a/src/func_ov002_020f5c88.c
+++ b/src/func_ov002_020f5c88.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f5c88 at 0x020f5c88
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+void func_ov002_020f5c88(unsigned char *p) {
+    if (!p[0x90]) return;
+    *(int*)(p + 0x4c) = 0x80000;
+    *(int*)(p + 0x50) = 0x60000;
+    *(unsigned short*)(p + 0x7c) = 0;
+    p[0x92] = 1;
+    *(int*)(p + 0x74) = 0xccc;
+    *(unsigned short*)(p + 0x78) = 0x155;
+}

--- a/src/func_ov002_020f5dd8.cpp
+++ b/src/func_ov002_020f5dd8.cpp
@@ -1,0 +1,8 @@
+//cpp
+struct C;
+typedef void (C::*PMF)();
+extern PMF data_ov002_02110f34[];
+
+extern "C" void func_ov002_020f5dd8(C *self, int i) {
+    (self->*data_ov002_02110f34[i])();
+}

--- a/src/func_ov002_020f5f0c.cpp
+++ b/src/func_ov002_020f5f0c.cpp
@@ -1,0 +1,12 @@
+//cpp
+struct Obj;
+typedef void (Obj::*PMF)();
+
+extern PMF data_ov002_02110f9c[];
+extern "C" void func_ov002_020f2e30(Obj *self, unsigned int idx);
+
+extern "C" void func_ov002_020f5f0c(Obj *self, unsigned int idx)
+{
+    (self->*data_ov002_02110f9c[idx])();
+    func_ov002_020f2e30(self, idx);
+}

--- a/src/func_ov002_020f5f60.c
+++ b/src/func_ov002_020f5f60.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f5f60 at 0x020f5f60
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void _ZN6Memory16operator_delete2EPv(void *p);
+
+void func_ov002_020f5f60(void *self) {
+    void *p = *(void **)((char *)self + 0x510);
+    if (p) {
+        _ZN6Memory16operator_delete2EPv(p);
+        *(void **)((char *)self + 0x510) = 0;
+    }
+}

--- a/src/func_ov002_020f63a0.cpp
+++ b/src/func_ov002_020f63a0.cpp
@@ -1,0 +1,14 @@
+//cpp
+extern "C" {
+extern void func_ov002_020f5f60(void *self);
+extern void _ZN6Memory16operator_delete2EPv(void *p);
+int func_ov002_020f63a0(char *r0) {
+    char *r4 = r0;
+    func_ov002_020f5f60(*(void**)(r4 + 0xd8));
+    if (*(void**)(r4 + 0xd8) != 0) {
+        _ZN6Memory16operator_delete2EPv(*(void**)(r4 + 0xd8));
+        *(void**)(r4 + 0xd8) = 0;
+    }
+    return 1;
+}
+}

--- a/src/func_ov002_020f63d4.c
+++ b/src/func_ov002_020f63d4.c
@@ -1,0 +1,13 @@
+/* func_ov002_020f63d4 at 0x020f63d4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020f5fb8(void* c);
+extern int func_ov002_020f5f8c(void* c);
+
+int func_ov002_020f63d4(unsigned char* p) {
+    func_ov002_020f5fb8(*(void**)(p + 0xd8));
+    func_ov002_020f5f8c(*(void**)(p + 0xd8));
+    return 1;
+}

--- a/src/func_ov002_020f63f8.c
+++ b/src/func_ov002_020f63f8.c
@@ -1,0 +1,13 @@
+/* func_ov002_020f63f8 at 0x020f63f8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020f5dd8(int a, unsigned char b);
+
+int func_ov002_020f63f8(char *r0, unsigned char *r1) {
+    unsigned char v = *r1;
+    r0[0x100] = v;
+    func_ov002_020f5dd8(*(int *)(r0 + 0xd8), *(unsigned char *)(r0 + 0x100));
+    return 1;
+}

--- a/src/func_ov002_020f6424.c
+++ b/src/func_ov002_020f6424.c
@@ -1,0 +1,11 @@
+/* func_ov002_020f6424 at 0x020f6424
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_ov002_020f5f0c(int arg0, unsigned char arg1);
+
+int func_ov002_020f6424(char *o) {
+    func_ov002_020f5f0c(*(int *)(o + 0xd8), *(unsigned char *)(o + 0x100));
+    return 1;
+}

--- a/src/func_ov002_020f6448.cpp
+++ b/src/func_ov002_020f6448.cpp
@@ -1,0 +1,24 @@
+//cpp
+void *operator new(unsigned long);
+extern "C" void func_02022298(void *);
+extern "C" void func_ov002_020f5fe4(void);
+extern "C" int func_ov002_020f6424(char *o);
+
+struct Obj {
+    char pad[0xd8];
+    void *fd8;                   /* +0xd8 */
+    char pad2[0x100 - 0xdc];
+    unsigned char f100;          /* +0x100 */
+};
+
+extern "C" int func_ov002_020f6448(Obj *self, unsigned char *src) {
+    self->f100 = *src;
+    char *m = (char *)operator new(0x518);
+    if (m)
+        func_02022298(m + 0x200);
+    self->fd8 = m;
+    if (self->fd8 == 0)
+        return 0;
+    func_ov002_020f5fe4();
+    return func_ov002_020f6424((char *)self);
+}

--- a/src/func_ov002_020f64ac.cpp
+++ b/src/func_ov002_020f64ac.cpp
@@ -1,0 +1,19 @@
+//cpp
+extern "C" {
+void _ZN9Animation7AdvanceEv(void *anim);
+int _ZN9Animation8FinishedEv(void *anim);
+void func_ov002_020f6514(void *self, void *r1, unsigned int r2);
+}
+
+extern "C" void func_ov002_020f64ac(char *self, char *r1) {
+    _ZN9Animation7AdvanceEv(self + 0x50);
+    if (_ZN9Animation8FinishedEv(self + 0x50) == 0) {
+        return;
+    }
+    unsigned int idx = *(unsigned char *)(self + 0x82);
+    signed char v = *(signed char *)(r1 + (idx << 2) + 3);
+    if (v < 0) {
+        return;
+    }
+    func_ov002_020f6514(self, r1, (unsigned char)v);
+}

--- a/src/func_ov002_020f65b8.c
+++ b/src/func_ov002_020f65b8.c
@@ -1,0 +1,17 @@
+/* func_ov002_020f65b8 at 0x020f65b8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Obj {
+    char pad[0x7c];
+    void *seq;   // 0x7c
+};
+
+extern void _ZN15TextureSequence6UpdateER15ModelComponents(void *self, void *mc);
+
+void func_ov002_020f65b8(struct Obj *self) {
+    void *seq = self->seq;
+    if (seq == 0) return;
+    _ZN15TextureSequence6UpdateER15ModelComponents(seq, (char*)self + 8);
+}

--- a/src/func_ov002_020f65ec.c
+++ b/src/func_ov002_020f65ec.c
@@ -1,0 +1,13 @@
+/* func_ov002_020f65ec at 0x020f65ec
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Anim { int dummy; };
+extern void _ZN9Animation7AdvanceEv(void *a);
+
+void func_ov002_020f65ec(unsigned char *p) {
+    void *a = *(void**)(p + 0x7c);
+    if (a == 0) return;
+    _ZN9Animation7AdvanceEv(a);
+}

--- a/src/func_ov002_020f6960.c
+++ b/src/func_ov002_020f6960.c
@@ -1,0 +1,17 @@
+/* func_ov002_020f6960 at 0x020f6960
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void *self);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
+
+int func_ov002_020f6960(char *self, void *fp, int c) {
+    void *bmd;
+    *(void**)(self + 0x5c) = fp;
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(*(void**)(self + 0x5c));
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(self, bmd, 1, c)) {
+        return 1;
+    }
+    return 0;
+}

--- a/src/func_ov002_020f69a8.cpp
+++ b/src/func_ov002_020f69a8.cpp
@@ -1,0 +1,26 @@
+//cpp
+struct SharedFilePtr;
+struct Model;
+extern void* data_ov002_0210bae4;
+extern void func_020072c0();
+extern "C" {
+
+void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr* self);
+void _ZN5ModelD2Ev(Model* self);
+void func_0207328c(void* p, int a, int b, void* fn);
+void _ZN6Memory16operator_delete2EPv(void* p);
+
+void* func_ov002_020f69a8(Model* self)
+{
+    char* p = (char*)self;
+    *(void**)p = (void*)&data_ov002_0210bae4;
+    SharedFilePtr* sfp = *(SharedFilePtr**)(p + 0x5c);
+    if (sfp)
+        _ZN13SharedFilePtr7ReleaseEv(sfp);
+    _ZN5ModelD2Ev(self);
+    func_0207328c(p + 0x50, 1, 0xc, (void*)func_020072c0);
+    _ZN6Memory16operator_delete2EPv(self);
+    return self;
+}
+
+}

--- a/src/func_ov002_020f6a00.cpp
+++ b/src/func_ov002_020f6a00.cpp
@@ -1,0 +1,19 @@
+//cpp
+struct SharedFilePtr { void Release(); };
+struct Model { ~Model(); };
+extern int data_ov002_0210bae4;
+extern "C" void func_020072c0(void);
+extern "C" void func_0207328c(void *p, int a, int b, void (*fn)(void));
+
+struct Obj {
+    void *vtable;
+};
+
+extern "C" void *func_ov002_020f6a00(Obj *self) {
+    *(void**)self = &data_ov002_0210bae4;
+    SharedFilePtr *sfp = *(SharedFilePtr**)((char*)self + 0x5c);
+    if (sfp != 0) sfp->Release();
+    ((Model*)self)->~Model();
+    func_0207328c((char*)self + 0x50, 1, 0xc, func_020072c0);
+    return self;
+}

--- a/src/func_ov002_020f6a50.c
+++ b/src/func_ov002_020f6a50.c
@@ -1,0 +1,17 @@
+/* func_ov002_020f6a50 at 0x020f6a50
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern void func_020072c0(void);
+extern void func_0203d384(void);
+extern void func_020733a8(void* self, int a, int b, void* fn, void* fn2);
+
+void* func_ov002_020f6a50(int* self)
+{
+    func_020733a8(self, 1, 0xc, (void*)func_0203d384, (void*)func_020072c0);
+    self[0] = 0;
+    self[1] = 0;
+    self[2] = 0;
+    return self;
+}

--- a/src/func_ov002_020f6ab8.c
+++ b/src/func_ov002_020f6ab8.c
@@ -1,0 +1,14 @@
+/* func_ov002_020f6ab8 at 0x020f6ab8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Vector3 { int x, y, z; };
+extern unsigned int ReadUnalignedInt(unsigned char *p);
+extern int _ZN5Sound4PlayEjjRK7Vector3(unsigned int a, unsigned int b, const struct Vector3 *v);
+
+int func_ov002_020f6ab8(unsigned char *p, unsigned char *q) {
+    unsigned int v = ReadUnalignedInt(q);
+    _ZN5Sound4PlayEjjRK7Vector3(1, v, (struct Vector3*)(p + 0x74));
+    return 1;
+}

--- a/src/func_ov002_020f6ae4.c
+++ b/src/func_ov002_020f6ae4.c
@@ -1,0 +1,16 @@
+/* func_ov002_020f6ae4 at 0x020f6ae4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+struct Vector3;
+extern unsigned int ReadUnalignedInt(unsigned char *p);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, struct Vector3 *v, unsigned int d);
+
+int func_ov002_020f6ae4(char *r0, unsigned char *r1) {
+    char *r4 = r0;
+    unsigned int v = ReadUnalignedInt(r1);
+    *(unsigned int*)(r4 + 0xe4) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+        *(unsigned int*)(r4 + 0xe4), 3, v, (struct Vector3*)(r4 + 0x74), 0);
+    return 1;
+}

--- a/src/func_ov002_020f6b4c.c
+++ b/src/func_ov002_020f6b4c.c
@@ -1,0 +1,36 @@
+/* func_ov002_020f6b4c at 0x020f6b4c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+typedef short s16;
+
+struct Vector3 { int z, y, x; };
+
+extern short ReadUnalignedShort(unsigned char *p);
+extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
+
+struct Obj {
+    char pad5c[0x5c];
+    struct Vector3 v5c;   /* +0x5c */
+    char pad8e[0x8e - (0x5c + 0xc)];
+    s16 f8e;              /* +0x8e */
+    char pad94[0x94 - 0x90];
+    s16 f94;              /* +0x94 */
+    char pad98[0x98 - 0x96];
+    int f98;             /* +0x98 */
+};
+
+int func_ov002_020f6b4c(struct Obj *self, unsigned char *p) {
+    struct Vector3 v;
+    int y, x;
+    x = ReadUnalignedShort(p + 4) << 12;
+    y = ReadUnalignedShort(p + 2) << 12;
+    v.z = ReadUnalignedShort(p) << 12;
+    v.y = y;
+    v.x = x;
+    self->f8e = Vec3_HorzAngle(&self->v5c, &v);
+    self->f94 = self->f8e;
+    self->f98 = ReadUnalignedShort(p + 6);
+    return 1;
+}

--- a/src/func_ov002_020f6bc0.c
+++ b/src/func_ov002_020f6bc0.c
@@ -1,0 +1,29 @@
+/* func_ov002_020f6bc0 at 0x020f6bc0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern short ReadUnalignedShort(unsigned char *p);
+
+struct Obj {
+    char pad5c[0x5c];
+    int f5c;      /* +0x5c */
+    int f60;      /* +0x60 */
+    int f64;      /* +0x64 */
+    char pad8e[0x8e - 0x68];
+    short f8e;    /* +0x8e */
+    char pad94[0x94 - 0x90];
+    short f94;    /* +0x94 */
+};
+
+int func_ov002_020f6bc0(struct Obj *self, unsigned char *p) {
+    int f60, f64;
+    f64 = ReadUnalignedShort(p + 4) << 12;
+    f60 = ReadUnalignedShort(p + 2) << 12;
+    self->f5c = ReadUnalignedShort(p) << 12;
+    self->f60 = f60;
+    self->f64 = f64;
+    self->f8e = ReadUnalignedShort(p + 6);
+    self->f94 = self->f8e;
+    return 1;
+}

--- a/src/func_ov002_020f6c24.c
+++ b/src/func_ov002_020f6c24.c
@@ -1,0 +1,9 @@
+/* func_ov002_020f6c24 at 0x020f6c24
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020f6c24(unsigned char *r0, unsigned char *r1) {
+    r0[0x102] = *r1;
+    return 1;
+}

--- a/src/func_ov002_020f6c34.c
+++ b/src/func_ov002_020f6c34.c
@@ -1,0 +1,13 @@
+/* func_ov002_020f6c34 at 0x020f6c34
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+extern int func_ov002_020f6514(void* a, void* b, int c);
+extern unsigned char data_ov002_0210bc88;
+
+int func_ov002_020f6c34(unsigned char* p, unsigned char* q) {
+    unsigned char v = q[0];
+    func_ov002_020f6514(*(void**)(p + 0xe0), &data_ov002_0210bc88, v);
+    return 1;
+}

--- a/src/func_ov002_020f8028.cpp
+++ b/src/func_ov002_020f8028.cpp
@@ -1,0 +1,34 @@
+//cpp
+extern "C" int func_ov002_020f63a0(char *r0);
+extern "C" int func_ov002_020f23d0(void *c);
+
+struct Sub {
+    virtual void v0();
+    virtual void v1();   // vtable+4
+};
+
+struct Obj {
+    char pad0[8];
+    int kind;       // 0x8
+    char pad1[0xdc - 0xc];
+    Sub *a;         // 0xdc
+    Sub *b;         // 0xe0
+};
+
+extern "C" int func_ov002_020f8028(Obj *self) {
+    if (self->kind == 0x2e) {
+        return func_ov002_020f63a0((char *)self);
+    }
+    if (self->kind == 0x2f) {
+        return func_ov002_020f23d0(self);
+    }
+    Sub *pa = self->a;
+    if (pa != 0 && pa != 0) {
+        pa->v1();
+    }
+    Sub *pb = self->b;
+    if (pb != 0 && pb != 0) {
+        pb->v1();
+    }
+    return 1;
+}

--- a/src/func_ov002_020f92e4.c
+++ b/src/func_ov002_020f92e4.c
@@ -1,0 +1,12 @@
+/* func_ov002_020f92e4 at 0x020f92e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
+ */
+
+int func_ov002_020f92e4(int r0) {
+    unsigned char v = *(unsigned char*)(r0 + 0x36d);
+    if (v != 0) {
+        if (v != 4) return 5;
+    }
+    return 0;
+}

--- a/src/func_ov006_020d5fec.c
+++ b/src/func_ov006_020d5fec.c
@@ -1,0 +1,22 @@
+/* func_ov006_020d5fec at 0x020d5fec
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int off0; int off4; };
+extern struct Entry data_ov006_02141660[];
+
+void func_ov006_020d5fec(char *r0) {
+    if (*(unsigned char *)(r0 + 0x62ad) == 0) return;
+    unsigned char idx = *(unsigned char *)(r0 + 0x62ac);
+    struct Entry *e = &data_ov006_02141660[idx];
+    int adj = e->off4;
+    char *self = r0 + (adj >> 1);
+    void (*fn)(char *, int);
+    if (adj & 1) {
+        fn = *(void (**)(char *, int))((char *)*(int *)self + e->off0);
+    } else {
+        fn = (void (*)(char *, int))e->off0;
+    }
+    fn(self, 0);
+}

--- a/src/func_ov006_020d9998.c
+++ b/src/func_ov006_020d9998.c
@@ -1,0 +1,8 @@
+/* func_ov006_020d9998 at 0x020d9998
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020d9998(void) {
+    return -0x60000;
+}

--- a/src/func_ov006_020d9bd0.c
+++ b/src/func_ov006_020d9bd0.c
@@ -1,0 +1,8 @@
+/* func_ov006_020d9bd0 at 0x020d9bd0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020d9bd0(void) {
+    return -0x60000;
+}

--- a/src/func_ov006_020da154.c
+++ b/src/func_ov006_020da154.c
@@ -1,0 +1,13 @@
+/* func_ov006_020da154 at 0x020da154
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020da154(char *p) {
+    int i = 0;
+    do {
+        i++;
+        *(unsigned char *)(p + 0x2b) = 9;
+        p += 0x30;
+    } while (i < 5);
+}

--- a/src/func_ov006_020da834.c
+++ b/src/func_ov006_020da834.c
@@ -1,0 +1,16 @@
+/* func_ov006_020da834 at 0x020da834
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct S { char pad[0x24]; int v; };
+
+int func_ov006_020da834(struct S *r0) {
+    int i = 0;
+    do {
+        if (r0->v < 0x4000) return 0;
+        i++;
+        r0 = (struct S *)((char *)r0 + 0x30);
+    } while (i < 5);
+    return 1;
+}

--- a/src/func_ov006_020da860.c
+++ b/src/func_ov006_020da860.c
@@ -1,0 +1,16 @@
+/* func_ov006_020da860 at 0x020da860
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020da860(unsigned char *r0, int r1) {
+    int i = 0;
+    do {
+        if (r1 != r0[0x2b]) {
+            return 0;
+        }
+        i++;
+        r0 += 0x30;
+    } while (i < 5);
+    return 1;
+}

--- a/src/func_ov006_020da88c.c
+++ b/src/func_ov006_020da88c.c
@@ -1,0 +1,17 @@
+/* func_ov006_020da88c at 0x020da88c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020da88c(unsigned char *r0, int r1) {
+    int count = 0;
+    int i = 0;
+    do {
+        if (r1 == r0[0x2b]) {
+            count++;
+        }
+        i++;
+        r0 += 0x30;
+    } while (i < 5);
+    return count;
+}

--- a/src/func_ov006_020da8b8.c
+++ b/src/func_ov006_020da8b8.c
@@ -1,0 +1,16 @@
+/* func_ov006_020da8b8 at 0x020da8b8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020da8b8(unsigned char *r0, int r1) {
+    int i = 0;
+    do {
+        if (r1 == r0[0x2b]) {
+            return i;
+        }
+        i++;
+        r0 += 0x30;
+    } while (i < 5);
+    return -1;
+}

--- a/src/func_ov006_020da974.c
+++ b/src/func_ov006_020da974.c
@@ -1,0 +1,13 @@
+/* func_ov006_020da974 at 0x020da974
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern int data_ov006_0213bd18[];
+
+void func_ov006_020da974(int v) {
+    int i;
+    for (i = 0; i < 6; i++) {
+        data_ov006_0213bd18[i] = v;
+    }
+}

--- a/src/func_ov006_020dc298.c
+++ b/src/func_ov006_020dc298.c
@@ -1,0 +1,22 @@
+/* func_ov006_020dc298 at 0x020dc298
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int off0; int off4; };
+extern struct Entry data_ov006_021417c8[];
+
+void func_ov006_020dc298(char *r0) {
+    if (*(unsigned char *)(r0 + 0x51bc) == 0) return;
+    unsigned char sel = *(unsigned char *)(r0 + 0x51bf);
+    struct Entry *e = &data_ov006_021417c8[sel];
+    int adj = e->off4;
+    char *self = r0 + (adj >> 1);
+    void (*fn)(char *, int);
+    if (adj & 1) {
+        fn = *(void (**)(char *, int))(*(char **)self + e->off0);
+    } else {
+        fn = (void (*)(char *, int))e->off0;
+    }
+    fn(self, 0);
+}

--- a/src/func_ov006_020dc754.c
+++ b/src/func_ov006_020dc754.c
@@ -1,0 +1,27 @@
+/* func_ov006_020dc754 at 0x020dc754
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry {
+    /* 0x0 */ int off0;
+    /* 0x4 */ int field4;
+};
+
+extern struct Entry data_ov006_021417e8[];
+
+void func_ov006_020dc754(char *r0) {
+    if (*(unsigned char *)(r0 + 0x5000 + 0x1a0) == 0) {
+        return;
+    }
+    struct Entry *e = &data_ov006_021417e8[*(unsigned char *)(r0 + 0x5000 + 0x1a1)];
+    int f4 = e->field4;
+    int r2;
+    r0 += f4 >> 1;
+    if (f4 & 1) {
+        r2 = *(int *)(*(int *)r0 + e->off0);
+    } else {
+        r2 = e->off0;
+    }
+    ((void (*)(char *, int))r2)(r0, 0);
+}

--- a/src/func_ov006_020deac8.c
+++ b/src/func_ov006_020deac8.c
@@ -1,0 +1,15 @@
+/* func_ov006_020deac8 at 0x020deac8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_020deac8(char *p) {
+    int i = 0;
+    do {
+        if (*(unsigned char *)(p + 0x15) == 0)
+            break;
+        i++;
+        p += 0x18;
+    } while (i < 0x20);
+    return i;
+}

--- a/src/func_ov006_020dec3c.c
+++ b/src/func_ov006_020dec3c.c
@@ -1,0 +1,12 @@
+/* func_ov006_020dec3c at 0x020dec3c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020dec3c(char *p) {
+    int i;
+    for (i = 0; i < 0x20; i++) {
+        p[0x15] = 0;
+        p += 0x18;
+    }
+}

--- a/src/func_ov006_020e3b9c.c
+++ b/src/func_ov006_020e3b9c.c
@@ -1,0 +1,14 @@
+/* func_ov006_020e3b9c at 0x020e3b9c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e3b9c(char *p) {
+    int i = 0;
+    do {
+        *(p + 0x4000 + 0xff4) = 0;
+        *(p + 0x4000 + 0xff5) = 0;
+        i++;
+        p += 0x18;
+    } while (i < 0x3c);
+}

--- a/src/func_ov006_020e619c.c
+++ b/src/func_ov006_020e619c.c
@@ -1,0 +1,13 @@
+/* func_ov006_020e619c at 0x020e619c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e619c(char *p) {
+    int i = 0;
+    do {
+        i++;
+        *(unsigned char *)(p + 0x4000 + 0x68c) = 0;
+        p += 0x30;
+    } while (i < 0xb);
+}

--- a/src/func_ov006_020e7940.c
+++ b/src/func_ov006_020e7940.c
@@ -1,0 +1,8 @@
+/* func_ov006_020e7940 at 0x020e7940
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e7940(char *p, short v) {
+    *(short *)(p + 0x17c) = v;
+}

--- a/src/func_ov006_020e82fc.c
+++ b/src/func_ov006_020e82fc.c
@@ -1,0 +1,22 @@
+/* func_ov006_020e82fc at 0x020e82fc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int off0; int off4; };
+extern struct Entry data_ov006_02141f44[];
+
+void func_ov006_020e82fc(char *r0) {
+    unsigned char idx = *(unsigned char *)(r0 + 0x5552);
+    if (idx >= 3) return;
+    struct Entry *e = &data_ov006_02141f44[idx];
+    int adj = e->off4;
+    char *self = r0 + (adj >> 1);
+    void (*fn)(char *);
+    if (adj & 1) {
+        fn = *(void (**)(char *))(*(char **)self + e->off0);
+    } else {
+        fn = (void (*)(char *))e->off0;
+    }
+    fn(self);
+}

--- a/src/func_ov006_020e8c74.c
+++ b/src/func_ov006_020e8c74.c
@@ -1,0 +1,13 @@
+/* func_ov006_020e8c74 at 0x020e8c74
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e8c74(char *r0, int r1) {
+    int r3 = r1 * 0x14;
+    int *p = (int *)(r0 + 0x5288 + r3);
+    *p = *p - (*p >> 6);
+    if (*p <= 0x900) {
+        *(unsigned char *)(r0 + r3 + 0x5000 + 0x291) = 2;
+    }
+}

--- a/src/func_ov006_020e8cb0.c
+++ b/src/func_ov006_020e8cb0.c
@@ -1,0 +1,16 @@
+/* func_ov006_020e8cb0 at 0x020e8cb0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e8cb0(char *r0, int idx) {
+    short *p = (short *)(r0 + 0x528c + idx * 0x14);
+    unsigned short v = *(unsigned short *)p;
+    if (v != 0) {
+        *p = v - 1;
+        if (*p < 0) *p = 0;
+        return;
+    }
+    *(unsigned char *)(r0 + idx * 0x14 + 0x5000 + 0x292) = 1;
+    *(unsigned char *)(r0 + idx * 0x14 + 0x5000 + 0x291) = 1;
+}

--- a/src/func_ov006_020e9318.c
+++ b/src/func_ov006_020e9318.c
@@ -1,0 +1,14 @@
+/* func_ov006_020e9318 at 0x020e9318
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e9318(char *r0, int r1) {
+    if (*(unsigned char *)(r0 + 0x554e) == 1) {
+        unsigned char *p = (unsigned char *)(r0 + 0x521c + r1 * 0x18);
+        if (*p == 1) *p = 0;
+    }
+    if (*(unsigned char *)(r0 + 0x554e) >= 0x10) {
+        *(unsigned char *)(r0 + r1 * 0x18 + 0x5219) = 1;
+    }
+}

--- a/src/func_ov006_020e95a4.c
+++ b/src/func_ov006_020e95a4.c
@@ -1,0 +1,18 @@
+/* func_ov006_020e95a4 at 0x020e95a4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020e95a4(unsigned char *r0) {
+    int i;
+    for (i = 0; i < 5; i++) {
+        *(int *)(r0 + 0x5000 + 0x208) = 0;
+        *(int *)(r0 + 0x5000 + 0x20c) = 0;
+        *(short *)(r0 + 0x5200 + 0x14) = 0;
+        r0[0x5000 + 0x218] = 0;
+        r0[0x5000 + 0x21a] = 0;
+        r0[0x5000 + 0x21b] = 0;
+        r0[0x5000 + 0x21c] = 0;
+        r0 += 0x18;
+    }
+}

--- a/src/func_ov006_020ed300.c
+++ b/src/func_ov006_020ed300.c
@@ -1,0 +1,13 @@
+/* func_ov006_020ed300 at 0x020ed300
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a; int b; };
+extern struct Pair data_ov006_0213ca5c;
+
+void func_ov006_020ed300(char *p) {
+    p += 0x4000;
+    *(int *)(p + 0x66c) = 0xb4;
+    *(struct Pair *)(p + 0x660) = data_ov006_0213ca5c;
+}

--- a/src/func_ov006_020ed32c.c
+++ b/src/func_ov006_020ed32c.c
@@ -1,0 +1,12 @@
+/* func_ov006_020ed32c at 0x020ed32c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern char data_ov006_0213ca64[];
+
+struct S8 { int a; int b; };
+
+void func_ov006_020ed32c(char *p) {
+    *(struct S8 *)(p + 0x4000 + 0x660) = *(struct S8 *)data_ov006_0213ca64;
+}

--- a/src/func_ov006_020ed81c.c
+++ b/src/func_ov006_020ed81c.c
@@ -1,0 +1,12 @@
+/* func_ov006_020ed81c at 0x020ed81c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a; int b; };
+extern struct Pair data_ov006_0213c9cc;
+
+void func_ov006_020ed81c(char *p) {
+    *(int *)(p + 0x466c) = 0x4b0;
+    *(struct Pair *)(p + 0x4660) = data_ov006_0213c9cc;
+}

--- a/src/func_ov006_020ee4e0.c
+++ b/src/func_ov006_020ee4e0.c
@@ -1,0 +1,17 @@
+/* func_ov006_020ee4e0 at 0x020ee4e0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair {
+    int a;
+    int b;
+};
+
+extern struct Pair data_ov006_0213cb5c;
+
+void func_ov006_020ee4e0(char *p) {
+    p += 0x5000;
+    *(short *)(p + 0x14) = 0x20;
+    *(struct Pair *)(p + 4) = data_ov006_0213cb5c;
+}

--- a/src/func_ov006_020ee598.c
+++ b/src/func_ov006_020ee598.c
@@ -1,0 +1,11 @@
+/* func_ov006_020ee598 at 0x020ee598
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a, b; };
+extern struct Pair data_ov006_0213cb84;
+
+void func_ov006_020ee598(char *p) {
+    *(struct Pair *)(p + 0x5000 + 4) = data_ov006_0213cb84;
+}

--- a/src/func_ov006_020ee658.c
+++ b/src/func_ov006_020ee658.c
@@ -1,0 +1,15 @@
+/* func_ov006_020ee658 at 0x020ee658
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a, b; };
+extern struct Pair data_ov006_0213cb54;
+
+void func_ov006_020ee658(unsigned char *r0) {
+    r0 += 0x5000;
+    *(unsigned short *)(r0 + 0x14) = 0x78;
+    *(int *)(r0 + 0xc) = 0;
+    *(int *)(r0 + 0x10) = 0x4000;
+    *(struct Pair *)(r0 + 4) = data_ov006_0213cb54;
+}

--- a/src/func_ov006_020eeef4.c
+++ b/src/func_ov006_020eeef4.c
@@ -1,0 +1,25 @@
+/* func_ov006_020eeef4 at 0x020eeef4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern void *data_ov006_021421c0;
+
+void func_ov006_020eeef4(void **r0) {
+    void **head = (void **)&data_ov006_021421c0;
+    void **cur = (void **)*head;
+    if (cur == r0) {
+        *head = *r0;
+        return;
+    }
+    void **next = (void **)*cur;
+    if (next == 0) return;
+    do {
+        if (next == r0) {
+            *cur = *r0;
+            return;
+        }
+        cur = next;
+        next = (void **)*next;
+    } while (next != 0);
+}

--- a/src/func_ov006_020eef40.c
+++ b/src/func_ov006_020eef40.c
@@ -1,0 +1,11 @@
+/* func_ov006_020eef40 at 0x020eef40
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern void *data_ov006_021421c0;
+
+void func_ov006_020eef40(void **p) {
+    *p = data_ov006_021421c0;
+    data_ov006_021421c0 = p;
+}

--- a/src/func_ov006_020ef0d4.c
+++ b/src/func_ov006_020ef0d4.c
@@ -1,0 +1,14 @@
+/* func_ov006_020ef0d4 at 0x020ef0d4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern int data_ov006_021421b0;
+extern int data_ov006_021421bc;
+extern int data_ov006_021421b4;
+
+void func_ov006_020ef0d4(int r0, int r1) {
+    data_ov006_021421b0 = r0;
+    data_ov006_021421bc = r1;
+    data_ov006_021421b4 = 0;
+}

--- a/src/func_ov006_020ef580.c
+++ b/src/func_ov006_020ef580.c
@@ -1,0 +1,12 @@
+/* func_ov006_020ef580 at 0x020ef580
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+typedef struct { int a, b; } Pair;
+extern Pair data_ov006_0213cc9c;
+
+void func_ov006_020ef580(char *r0) {
+    *(unsigned short *)(r0 + 0x5a74) = 0x20;
+    *(Pair *)(r0 + 0x5004) = data_ov006_0213cc9c;
+}

--- a/src/func_ov006_020ef768.c
+++ b/src/func_ov006_020ef768.c
@@ -1,0 +1,12 @@
+/* func_ov006_020ef768 at 0x020ef768
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a, b; };
+extern struct Pair data_ov006_0213cc84;
+
+void func_ov006_020ef768(unsigned char *r0) {
+    *(unsigned short *)(r0 + 0x5a74) = 0xf0;
+    *(struct Pair *)(r0 + 0x5004) = data_ov006_0213cc84;
+}

--- a/src/func_ov006_020ef7f8.c
+++ b/src/func_ov006_020ef7f8.c
@@ -1,0 +1,15 @@
+/* func_ov006_020ef7f8 at 0x020ef7f8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Pair { int a, b; };
+extern struct Pair data_ov006_0213cc94;
+
+void func_ov006_020ef7f8(unsigned char *r0) {
+    *(unsigned short *)(r0 + 0x5a74) = 0x78;
+    r0 += 0x5000;
+    *(int *)(r0 + 0xa64) = 0;
+    *(int *)(r0 + 0xa68) = 0x4000;
+    *(struct Pair *)(r0 + 4) = data_ov006_0213cc94;
+}

--- a/src/func_ov006_020f002c.c
+++ b/src/func_ov006_020f002c.c
@@ -1,0 +1,8 @@
+/* func_ov006_020f002c at 0x020f002c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f002c(char *p, int i) {
+    *(int *)(p + i * 0x14 + 0x4000 + 0x7f0) = 0x1000;
+}

--- a/src/func_ov006_020f0dd8.c
+++ b/src/func_ov006_020f0dd8.c
@@ -1,0 +1,17 @@
+/* func_ov006_020f0dd8 at 0x020f0dd8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f0dd8(char *r0) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        *(unsigned char *)(r0 + 0x47b4) = 1;
+        *(unsigned char *)(r0 + 0x47b6) = 0;
+        *(short *)(r0 + 0x47b0) = 0;
+        *(short *)(r0 + 0x47b2) = 0;
+        *(unsigned char *)(r0 + 0x47b5) = 0;
+        *(unsigned char *)(r0 + 0x47b7) = 0;
+        r0 += 0x18;
+    }
+}

--- a/src/func_ov006_020f1e40.c
+++ b/src/func_ov006_020f1e40.c
@@ -1,0 +1,10 @@
+/* func_ov006_020f1e40 at 0x020f1e40
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f1e40(int *base, int i) {
+    char *p = (char *)&base[i];
+    *(int *)(p + 0x4000 + 0xbb8) = 0;
+    *(int *)(p + 0x4000 + 0xd98) = 0;
+}

--- a/src/func_ov006_020f1e58.c
+++ b/src/func_ov006_020f1e58.c
@@ -1,0 +1,14 @@
+/* func_ov006_020f1e58 at 0x020f1e58
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern unsigned char data_ov006_0213ceac[];
+
+void func_ov006_020f1e58(unsigned char *r0, int r1) {
+    unsigned short idx = *(unsigned short *)(r0 + 0x5174);
+    r0 += r1;
+    r0[0x53dd] = 1;
+    r0[0x5275] = 0;
+    r0[0x51fd] = data_ov006_0213ceac[idx] + 1;
+}

--- a/src/func_ov006_020f3414.cpp
+++ b/src/func_ov006_020f3414.cpp
@@ -1,0 +1,10 @@
+//cpp
+struct Obj;
+typedef void (Obj::*PMF)();
+extern PMF data_ov006_02142234[];
+
+extern "C" int func_ov006_020f3414(Obj *r0) {
+    int idx = *(int *)((char *)r0 + 0x4000 + 0xf78);
+    (r0->*data_ov006_02142234[idx])();
+    return 1;
+}

--- a/src/func_ov006_020f50f8.c
+++ b/src/func_ov006_020f50f8.c
@@ -1,0 +1,21 @@
+/* func_ov006_020f50f8 at 0x020f50f8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int off0; int off4; };
+extern struct Entry data_ov006_021422bc[];
+
+void func_ov006_020f50f8(char *r0) {
+    int idx = *(int *)(r0 + 0x5318);
+    struct Entry *e = &data_ov006_021422bc[idx];
+    int adj = e->off4;
+    char *self = r0 + (adj >> 1);
+    void (*fn)(char *);
+    if (adj & 1) {
+        fn = *(void (**)(char *))(*(char **)self + e->off0);
+    } else {
+        fn = (void (*)(char *))e->off0;
+    }
+    fn(self);
+}

--- a/src/func_ov006_020f51f0.c
+++ b/src/func_ov006_020f51f0.c
@@ -1,0 +1,19 @@
+/* func_ov006_020f51f0 at 0x020f51f0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f51f0(char *r0) {
+    *(unsigned char *)(r0 + 0x533c) = 0;
+    *(short *)(r0 + 0x532a) = 4;
+    int v = *(int *)(r0 + 0xb4);
+    if (v >= 0xa) {
+        *(unsigned char *)(r0 + 0x533c) = 2;
+        *(short *)(r0 + 0x532a) = 6;
+        return;
+    }
+    if (v >= 5) {
+        *(unsigned char *)(r0 + 0x533c) = 1;
+        *(short *)(r0 + 0x532a) = 5;
+    }
+}

--- a/src/func_ov006_020f71c8.c
+++ b/src/func_ov006_020f71c8.c
@@ -1,0 +1,21 @@
+/* func_ov006_020f71c8 at 0x020f71c8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int off0; int off4; };
+extern struct Entry data_ov006_021423c0[];
+
+void func_ov006_020f71c8(char *r0) {
+    int idx = *(int *)(r0 + 0x53d8);
+    struct Entry *e = &data_ov006_021423c0[idx];
+    int adj = e->off4;
+    char *self = r0 + (adj >> 1);
+    void (*fn)(char *);
+    if (adj & 1) {
+        fn = *(void (**)(char *))(*(char **)self + e->off0);
+    } else {
+        fn = (void (*)(char *))e->off0;
+    }
+    fn(self);
+}

--- a/src/func_ov006_020f72c0.c
+++ b/src/func_ov006_020f72c0.c
@@ -1,0 +1,20 @@
+/* func_ov006_020f72c0 at 0x020f72c0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f72c0(char *r0) {
+    int v;
+    *(unsigned char *)(r0 + 0x540a) = 0;
+    *(short *)(r0 + 0x53ea) = 8;
+    v = *(int *)(r0 + 0xb4);
+    if (v >= 0xa) {
+        *(unsigned char *)(r0 + 0x540a) = 2;
+        *(short *)(r0 + 0x53ea) = 0xa;
+        return;
+    }
+    if (v >= 5) {
+        *(unsigned char *)(r0 + 0x540a) = 1;
+        *(short *)(r0 + 0x53ea) = 9;
+    }
+}

--- a/src/func_ov006_020f82d0.c
+++ b/src/func_ov006_020f82d0.c
@@ -1,0 +1,16 @@
+/* func_ov006_020f82d0 at 0x020f82d0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct S {
+    /* 0x00 */ char pad0[0x28];
+    /* 0x28 */ short f28;
+    /* 0x2a */ char pad[0x2d - 0x2a];
+    /* 0x2d */ unsigned char f2d;
+};
+
+void func_ov006_020f82d0(struct S *r0, int r1) {
+    r0->f28 = (4 - (r1 % 5)) * 2;
+    r0->f2d = 5;
+}

--- a/src/func_ov006_020f8ed8.c
+++ b/src/func_ov006_020f8ed8.c
@@ -1,0 +1,18 @@
+/* func_ov006_020f8ed8 at 0x020f8ed8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern int data_ov006_0213d5ac;
+
+struct S {
+    void *vtbl;
+    int a;
+    int b;
+};
+
+void func_ov006_020f8ed8(struct S *p) {
+    p->vtbl = &data_ov006_0213d5ac;
+    p->a = 0;
+    p->b = 0;
+}

--- a/src/func_ov006_020f9d68.c
+++ b/src/func_ov006_020f9d68.c
@@ -1,0 +1,9 @@
+/* func_ov006_020f9d68 at 0x020f9d68
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020f9d68(char *r0, int r1) {
+    *(short *)(r0 + 0x28) = (short)((4 - r1 % 5) * 2);
+    *(unsigned char *)(r0 + 0x2d) = 5;
+}

--- a/src/func_ov006_020fa740.c
+++ b/src/func_ov006_020fa740.c
@@ -1,0 +1,18 @@
+/* func_ov006_020fa740 at 0x020fa740
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern char data_ov006_0213d728[];
+
+struct S {
+    void *a;
+    int b;
+    int c;
+};
+
+void func_ov006_020fa740(struct S *p) {
+    p->a = data_ov006_0213d728;
+    p->b = 0;
+    p->c = 0;
+}

--- a/src/func_ov006_020fa9a0.c
+++ b/src/func_ov006_020fa9a0.c
@@ -1,0 +1,14 @@
+/* func_ov006_020fa9a0 at 0x020fa9a0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020fa9a0(char *p) {
+    int i = 0;
+    do {
+        *(unsigned char *)(p + 0x4000 + 0xe6c) = 0;
+        i++;
+        *(unsigned char *)(p + 0x4000 + 0xe6d) = 0;
+        p += 0x18;
+    } while (i < 3);
+}

--- a/src/func_ov006_020fadfc.c
+++ b/src/func_ov006_020fadfc.c
@@ -1,0 +1,11 @@
+/* func_ov006_020fadfc at 0x020fadfc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern unsigned char data_0209d45c;
+
+void func_ov006_020fadfc(char *p) {
+    data_0209d45c &= ~4;
+    *(unsigned char *)(p + 0x5000 + 0xc0e) = 0;
+}

--- a/src/func_ov006_020faeec.c
+++ b/src/func_ov006_020faeec.c
@@ -1,0 +1,14 @@
+/* func_ov006_020faeec at 0x020faeec
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020faeec(char *r0) {
+    int i = 0;
+    do {
+        *(unsigned char *)(r0 + 0x5000 + 0xbd4) = 0;
+        i++;
+        *(unsigned char *)(r0 + 0x5000 + 0xbd5) = 0;
+        r0 += 0xc;
+    } while (i < 4);
+}

--- a/src/func_ov006_020fe1a8.c
+++ b/src/func_ov006_020fe1a8.c
@@ -1,0 +1,15 @@
+/* func_ov006_020fe1a8 at 0x020fe1a8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_020fe1a8(char *r0) {
+    int i = 0;
+    unsigned char v = i;
+    do {
+        *(unsigned char *)(r0 + 0x4000 + 0xf0c) = v;
+        i++;
+        *(unsigned char *)(r0 + 0x4000 + 0xf0e) = v;
+        r0 += 0x38;
+    } while (i < 0x30);
+}

--- a/src/func_ov006_020fea54.c
+++ b/src/func_ov006_020fea54.c
@@ -1,0 +1,14 @@
+/* func_ov006_020fea54 at 0x020fea54
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct E {
+    char pad[0x38];
+};
+
+void func_ov006_020fea54(struct E *base, int i) {
+    char *p = (char *)&base[i];
+    *(unsigned char *)(p + 0x4000 + 0xf0c) = 0;
+    *(unsigned char *)(p + 0x4000 + 0xf0e) = 0;
+}

--- a/src/func_ov006_02100734.c
+++ b/src/func_ov006_02100734.c
@@ -1,0 +1,15 @@
+/* func_ov006_02100734 at 0x02100734
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02100734(unsigned char *r0, int r1) {
+    unsigned char *b = r0 + (r1 << 6);
+    if (b[0x5000 + 0x294] == 0) {
+        return;
+    }
+    *(short *)(b + 0x5200 + 0x90) = 0;
+    *(int *)(b + 0x5000 + 0x270) = 0;
+    *(short *)(b + 0x5200 + 0x92) = 0x40;
+    b[0x5000 + 0x296] = 0xc;
+}

--- a/src/func_ov006_02104558.c
+++ b/src/func_ov006_02104558.c
@@ -1,0 +1,13 @@
+/* func_ov006_02104558 at 0x02104558
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02104558(unsigned char *r0) {
+    int i;
+    for (i = 0; i < 0x40; i++) {
+        r0[0x4000 + 0x6b8] = 0;
+        r0[0x4000 + 0x6bd] = 0;
+        r0 += 0x18;
+    }
+}

--- a/src/func_ov006_021048e4.c
+++ b/src/func_ov006_021048e4.c
@@ -1,0 +1,13 @@
+/* func_ov006_021048e4 at 0x021048e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern unsigned char data_0209d454[];
+
+void func_ov006_021048e4(unsigned char *r0) {
+    if (r0[0x4693] != 0) return;
+    r0[0x4693] = 1;
+    *(unsigned short *)(r0 + 0x4600 + 0x90) = 0;
+    data_0209d454[0] |= 1;
+}

--- a/src/func_ov006_02104cfc.c
+++ b/src/func_ov006_02104cfc.c
@@ -1,0 +1,14 @@
+/* func_ov006_02104cfc at 0x02104cfc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02104cfc(char *r0, int idx) {
+    *(unsigned char *)(r0 + 0x4684) = 1;
+    *(unsigned char *)(r0 + 0x4685) = 1;
+    *(int *)(r0 + 0x4678) = *(int *)(r0 + idx * 4 + 0x4cc4);
+    *(int *)(r0 + 0x467c) = *(int *)(r0 + idx * 4 + 0x4d54) + 0x8000;
+    *(short *)(r0 + 0x4680) = 0x30;
+    *(short *)(r0 + 0x4682) = 0;
+    *(unsigned char *)(r0 + 0x4686) = 0;
+}

--- a/src/func_ov006_02104e70.c
+++ b/src/func_ov006_02104e70.c
@@ -1,0 +1,9 @@
+/* func_ov006_02104e70 at 0x02104e70
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02104e70(unsigned char *p) {
+    p += 0x4000;
+    p[0x677] = p[0xfde];
+}

--- a/src/func_ov006_0210508c.c
+++ b/src/func_ov006_0210508c.c
@@ -1,0 +1,13 @@
+/* func_ov006_0210508c at 0x0210508c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0210508c(char *r0) {
+    r0 = r0 + 0x4000;
+    *(int *)(r0 + 0x660) = 0x110000;
+    *(int *)(r0 + 0x664) = 0x60000;
+    *(int *)(r0 + 0x668) = -0x3000;
+    r0[0x676] = 1;
+    r0[0x675] = 1;
+}

--- a/src/func_ov006_021050bc.c
+++ b/src/func_ov006_021050bc.c
@@ -1,0 +1,22 @@
+/* func_ov006_021050bc at 0x021050bc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Entry { int a; int b; };
+extern struct Entry data_ov006_02142860[];
+
+void func_ov006_021050bc(char *r0) {
+    if (*(unsigned char *)(r0 + 0x4674) == 0) return;
+    unsigned char idx = *(unsigned char *)(r0 + 0x4675);
+    struct Entry *e = &data_ov006_02142860[idx];
+    int b = e->b;
+    r0 = r0 + (b >> 1);
+    void (*fn)(char *);
+    if (b & 1) {
+        fn = (void (*)(char *))(*(int *)(*(int *)r0 + e->a));
+    } else {
+        fn = (void (*)(char *))e->a;
+    }
+    fn(r0);
+}

--- a/src/func_ov006_02106048.c
+++ b/src/func_ov006_02106048.c
@@ -1,0 +1,13 @@
+/* func_ov006_02106048 at 0x02106048
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02106048(unsigned char *r0) {
+    int i = 0;
+    if (*(int *)(r0 + 0x4cb8) <= 0) return;
+    do {
+        (r0 + i + 0x4000)[0xf66] = 1;
+        i++;
+    } while (i < *(int *)(r0 + 0x4cb8));
+}

--- a/src/func_ov006_02106758.c
+++ b/src/func_ov006_02106758.c
@@ -1,0 +1,15 @@
+/* func_ov006_02106758 at 0x02106758
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02106758(unsigned char *r0) {
+    int j;
+    int i;
+    for (j = 0; j < 5; j++) {
+        for (i = 0; i < 0xa; i++) {
+            *(unsigned char *)(r0 + i + 0x4000 + 0xec8) = 0xff;
+        }
+        r0 += 0xa;
+    }
+}

--- a/src/func_ov006_02106bac.c
+++ b/src/func_ov006_02106bac.c
@@ -1,0 +1,8 @@
+/* func_ov006_02106bac at 0x02106bac
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02106bac(char *p, int off) {
+    *(unsigned char *)(p + off + 0x4000 + 0xf8a) = 0;
+}

--- a/src/func_ov006_02107b70.c
+++ b/src/func_ov006_02107b70.c
@@ -1,0 +1,14 @@
+/* func_ov006_02107b70 at 0x02107b70
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern void *data_ov006_02142aa4[];
+
+void func_ov006_02107b70(int p) {
+    int i;
+    for (i = 0; i < 4; i++) {
+        data_ov006_02142aa4[i] = (void *)p;
+        p += 0x18;
+    }
+}

--- a/src/func_ov006_02107d58.c
+++ b/src/func_ov006_02107d58.c
@@ -1,0 +1,14 @@
+/* func_ov006_02107d58 at 0x02107d58
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02107d58(int *r0) {
+    int i = 0;
+    do {
+        r0[i] = 0;
+        i++;
+    } while (i < 5);
+    *(unsigned short *)((char *)r0 + 0x14) = 4;
+    *(unsigned short *)((char *)r0 + 0x16) = 0;
+}

--- a/src/func_ov006_02107d80.cpp
+++ b/src/func_ov006_02107d80.cpp
@@ -1,0 +1,8 @@
+//cpp
+struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
+struct Outer { char pad0[0x10]; Base a; char pad1[0x4c]; Base b; };
+
+extern "C" void func_ov006_02107d80(Outer *o) {
+    o->a.m(0);
+    o->b.m(0);
+}

--- a/src/func_ov006_021092a0.c
+++ b/src/func_ov006_021092a0.c
@@ -1,0 +1,33 @@
+/* func_ov006_021092a0 at 0x021092a0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct S {
+    /* 0x00 */ int a;
+    /* 0x04 */ int b;
+    /* 0x08 */ char pad8[0x10 - 0x08];
+    /* 0x10 */ int f10;
+    /* 0x14 */ int f14;
+    /* 0x18 */ int f18;
+    /* 0x1c */ int f1c;
+    /* 0x20 */ char pad20[0x28 - 0x20];
+    /* 0x28 */ int f28;
+    /* 0x2c */ short f2c;
+    /* 0x2e */ short f2e;
+    /* 0x30 */ char pad30[0x32 - 0x30];
+    /* 0x32 */ unsigned char f32;
+};
+
+void func_ov006_021092a0(struct S *r0) {
+    r0->a = 0xc000;
+    r0->b = 0xc000;
+    r0->f18 = r0->a;
+    r0->f1c = r0->b;
+    r0->f10 = 0;
+    r0->f14 = 0;
+    r0->f32 = 6;
+    r0->f2c = 0x25;
+    r0->f2e = 0;
+    r0->f28 = 1;
+}

--- a/src/func_ov006_0210c180.c
+++ b/src/func_ov006_0210c180.c
@@ -1,0 +1,12 @@
+/* func_ov006_0210c180 at 0x0210c180
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern unsigned char data_0209d454;
+
+void func_ov006_0210c180(int *r0) {
+    r0[0] = 0x48;
+    *(unsigned char *)((char *)r0 + 4) = 1;
+    data_0209d454 |= 2;
+}

--- a/src/func_ov006_0210c218.c
+++ b/src/func_ov006_0210c218.c
@@ -1,0 +1,11 @@
+/* func_ov006_0210c218 at 0x0210c218
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0210c218(void *p, short a, short b) {
+    *(short *)((char *)p + 0) = a;
+    *(short *)((char *)p + 2) = b;
+    *(int *)((char *)p + 4) = 0x48;
+    *(unsigned char *)((char *)p + 8) = 1;
+}

--- a/src/func_ov006_0210c2c0.c
+++ b/src/func_ov006_0210c2c0.c
@@ -1,0 +1,14 @@
+/* func_ov006_0210c2c0 at 0x0210c2c0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct S {
+    char pad[0x1c];
+    int a;   /* 0x1c */
+    int b;   /* 0x20 */
+};
+
+void func_ov006_0210c2c0(struct S *p, int n) {
+    p->b = (p->a * n) << 2;
+}

--- a/src/func_ov006_0210c354.c
+++ b/src/func_ov006_0210c354.c
@@ -1,0 +1,12 @@
+/* func_ov006_0210c354 at 0x0210c354
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0210c354(char *p) {
+    *(int *)(p + 0x1c) = 0;
+    *(int *)(p + 0x20) = 0;
+    if (*(int *)(p + 0x14) >= 1) {
+        *(unsigned char *)(p + 0x11) = 1;
+    }
+}

--- a/src/func_ov006_0210d898.c
+++ b/src/func_ov006_0210d898.c
@@ -1,0 +1,11 @@
+/* func_ov006_0210d898 at 0x0210d898
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_0210d898(char *p) {
+    if (*(int *)(p + 0x40) == 0) {
+        return 1;
+    }
+    return *(short *)(p + 0x32) == 0x3000;
+}

--- a/src/func_ov006_0210e4c8.c
+++ b/src/func_ov006_0210e4c8.c
@@ -1,0 +1,15 @@
+/* func_ov006_0210e4c8 at 0x0210e4c8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_0210e4c8(int *r0) {
+    int i = 0;
+    do {
+        if ((r0 + i)[0x6c / 4] > 0x168) {
+            return 1;
+        }
+        i++;
+    } while (i < 8);
+    return 0;
+}

--- a/src/func_ov006_0210fa40.c
+++ b/src/func_ov006_0210fa40.c
@@ -1,0 +1,17 @@
+/* func_ov006_0210fa40 at 0x0210fa40
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct E { int v; int pad; };
+
+int func_ov006_0210fa40(char *r0) {
+    int i = 0;
+    do {
+        if (((struct E *)(r0 + 0x50))[i].v > 0) {
+            return 0;
+        }
+        i++;
+    } while (i < 3);
+    return 1;
+}

--- a/src/func_ov006_02111d4c.c
+++ b/src/func_ov006_02111d4c.c
@@ -1,0 +1,11 @@
+/* func_ov006_02111d4c at 0x02111d4c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02111d4c(char *p) {
+    *(int *)(p + 0x108) = *(int *)(p + 8);
+    *(int *)(p + 0x10c) = *(int *)(p + 0xc);
+    *(unsigned char *)(p + 0x110) = 1;
+    *(unsigned char *)(p + 0x3b) = 1;
+}

--- a/src/func_ov006_02111d74.c
+++ b/src/func_ov006_02111d74.c
@@ -1,0 +1,21 @@
+/* func_ov006_02111d74 at 0x02111d74
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_02111d74(char *r0) {
+    if (*(unsigned char *)(r0 + 0x30) == 0)
+        return 1;
+    if (*(unsigned char *)(r0 + 0x3a) == 1)
+        return 1;
+    {
+        int v = *(int *)(r0 + 0xc);
+        if (v < -0xa0000)
+            return 1;
+        if (v < 0) {
+            if (*(int *)(r0 + 8) < 0xd0000)
+                return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov006_02111dcc.c
+++ b/src/func_ov006_02111dcc.c
@@ -1,0 +1,11 @@
+/* func_ov006_02111dcc at 0x02111dcc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_02111dcc(int *r0, int r1) {
+    if (*((unsigned char *)r0 + 0x30) == 0) return 0;
+    if (r0[0x10] > 0) return 0;
+    r0[0x10] = r1;
+    return 1;
+}

--- a/src/func_ov006_02111df4.c
+++ b/src/func_ov006_02111df4.c
@@ -1,0 +1,16 @@
+/* func_ov006_02111df4 at 0x02111df4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_02111df4(char *r0) {
+    if ((*(int *)(*(char **)(r0 + 4) + 8) & 0xff) != 0
+        && *(int *)(r0 + 8) < 0xe0000
+        && *(int *)(r0 + 0xc) >= 0x50000
+        && *(int *)(r0 + 0xc) < 0x88000
+        && *(int *)(r0 + 0x11c) >= 0x78)
+        return 1;
+    if (*(unsigned char *)(r0 + 0x121) == 0)
+        return 1;
+    return *(unsigned char *)(r0 + 0x3b);
+}

--- a/src/func_ov006_021146ac.c
+++ b/src/func_ov006_021146ac.c
@@ -1,0 +1,9 @@
+/* func_ov006_021146ac at 0x021146ac
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_021146ac(int *p) {
+    int x = p[0xa];
+    return (int)(((long long)x * x + 0x800) >> 12);
+}

--- a/src/func_ov006_02114724.c
+++ b/src/func_ov006_02114724.c
@@ -1,0 +1,9 @@
+/* func_ov006_02114724 at 0x02114724
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02114724(int *p) {
+    p[4] = p[2];
+    p[5] = p[3];
+}

--- a/src/func_ov006_02114738.c
+++ b/src/func_ov006_02114738.c
@@ -1,0 +1,11 @@
+/* func_ov006_02114738 at 0x02114738
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02114738(char *p) {
+    int b = *(int *)(p + 0x1c);
+    int a = *(int *)(p + 0x18);
+    *(int *)(p + 8) = a;
+    *(int *)(p + 0xc) = b;
+}

--- a/src/func_ov006_021147d0.c
+++ b/src/func_ov006_021147d0.c
@@ -1,0 +1,17 @@
+/* func_ov006_021147d0 at 0x021147d0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_021147d0(unsigned char *r0) {
+    int i = 0;
+    do {
+        unsigned char *p = r0 + 0x5000;
+        if (p[0x9bc] == 1) {
+            return 1;
+        }
+        i++;
+        r0 += 0x24;
+    } while (i < 0x40);
+    return 0;
+}

--- a/src/func_ov006_02114dd0.c
+++ b/src/func_ov006_02114dd0.c
@@ -1,0 +1,15 @@
+/* func_ov006_02114dd0 at 0x02114dd0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02114dd0(char *r0) {
+    int i = 0;
+    do {
+        *(unsigned char *)(r0 + 0x5000 + 0x9bc) = 0;
+        *(int *)(r0 + 0x5000 + 0x9b8) = 0;
+        i++;
+        *(int *)(r0 + 0x5000 + 0x9b4) = 0;
+        r0 += 0x24;
+    } while (i < 0x40);
+}

--- a/src/func_ov006_02115040.c
+++ b/src/func_ov006_02115040.c
@@ -1,0 +1,9 @@
+/* func_ov006_02115040 at 0x02115040
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02115040(char *p, int idx) {
+    int *arr = (int *)(p + 0x5968);
+    arr[idx - 1] = arr[idx - 1] + 1;
+}

--- a/src/func_ov006_0211ab80.c
+++ b/src/func_ov006_0211ab80.c
@@ -1,0 +1,17 @@
+/* func_ov006_0211ab80 at 0x0211ab80
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern int data_ov006_0212ee7c[];
+
+void func_ov006_0211ab80(char *r0, int idx) {
+    int n = idx * 0x24;
+    char *base = r0 + 0x51b0;
+    char *p = r0 + n;
+    *(unsigned char *)(p + 0x51cd) = 1;
+    unsigned char k = *(unsigned char *)(p + 0x51d2);
+    *(int *)(base + n) = *(int *)(base + n) + data_ov006_0212ee7c[k];
+    *(int *)(p + 0x51bc) = -0x4000;
+    *(unsigned char *)(p + 0x51d1) = 1;
+}

--- a/src/func_ov006_0211bc68.c
+++ b/src/func_ov006_0211bc68.c
@@ -1,0 +1,10 @@
+/* func_ov006_0211bc68 at 0x0211bc68
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0211bc68(char *p, int i) {
+    if (*(unsigned char *)(p + 0x5624) == 0) {
+        *(unsigned char *)(p + i * 0x14 + 0x50f4) = 3;
+    }
+}

--- a/src/func_ov006_0211cc90.c
+++ b/src/func_ov006_0211cc90.c
@@ -1,0 +1,11 @@
+/* func_ov006_0211cc90 at 0x0211cc90
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0211cc90(char *p) {
+    p += 0x4000;
+    if (*(unsigned char *)(p + 0xbe0) != 0) {
+        *(unsigned char *)(p + 0xbe5) = 1;
+    }
+}

--- a/src/func_ov006_0211de7c.c
+++ b/src/func_ov006_0211de7c.c
@@ -1,0 +1,19 @@
+/* func_ov006_0211de7c at 0x0211de7c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+int func_ov006_0211de7c(unsigned char *r0) {
+    int found = 0;
+    int i = 0;
+    do {
+        if (r0[0x4a70] != 0) {
+            if (r0[0x4a73] != 2) {
+                found++;
+            }
+        }
+        i++;
+        r0 = r0 + 0x14;
+    } while (i < 0x10);
+    return found != 0;
+}

--- a/src/func_ov006_0211f51c.c
+++ b/src/func_ov006_0211f51c.c
@@ -1,0 +1,16 @@
+/* func_ov006_0211f51c at 0x0211f51c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_0211f51c(unsigned char *r0) {
+    int i;
+    for (i = 0; i < 0x10; i++) {
+        if (r0[0x4000 + 0x677] != 0) {
+            if (r0[0x4000 + 0x678] == 1) {
+                r0[0x4000 + 0x678] = 2;
+            }
+        }
+        r0 += 0x24;
+    }
+}

--- a/src/func_ov006_02120b7c.c
+++ b/src/func_ov006_02120b7c.c
@@ -1,0 +1,28 @@
+/* func_ov006_02120b7c at 0x02120b7c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+struct Node { struct Node *next; };
+extern struct Node *data_ov006_02142f64;
+
+struct Node *func_ov006_02120b7c(struct Node *r0) {
+    struct Node *r2 = data_ov006_02142f64;
+    if (r2 == r0) {
+        r0 = r0->next;
+        data_ov006_02142f64 = r0;
+        return r0;
+    }
+    struct Node *r1 = r2->next;
+    if (r1 == 0) return r0;
+    do {
+        if (r1 == r0) {
+            r0 = r0->next;
+            r2->next = r0;
+            return r0;
+        }
+        r2 = r1;
+        r1 = r1->next;
+    } while (r1 != 0);
+    return r0;
+}

--- a/src/func_ov006_02120bc8.c
+++ b/src/func_ov006_02120bc8.c
@@ -1,0 +1,22 @@
+/* func_ov006_02120bc8 at 0x02120bc8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern void *data_ov006_02142f64;
+
+void func_ov006_02120bc8(char *r0) {
+    *(void **)r0 = data_ov006_02142f64;
+    data_ov006_02142f64 = r0;
+
+    char *r1 = *(char **)r0;
+    int v = *(int *)(r0 + 8) - 0x10000;
+    if (r1 == 0) {
+        return;
+    }
+    do {
+        *(int *)(r1 + 0x10) = v;
+        r1 = *(char **)r1;
+        v -= 0x10000;
+    } while (r1 != 0);
+}

--- a/src/func_ov006_02121750.c
+++ b/src/func_ov006_02121750.c
@@ -1,0 +1,11 @@
+/* func_ov006_02121750 at 0x02121750
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+extern short data_ov006_02140538;
+
+void func_ov006_02121750(char *p, short v) {
+    data_ov006_02140538 = v;
+    *(short *)(p + 0x5dba) = v;
+}

--- a/src/func_ov006_02121768.c
+++ b/src/func_ov006_02121768.c
@@ -1,0 +1,8 @@
+/* func_ov006_02121768 at 0x02121768
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+short func_ov006_02121768(char *p) {
+    return *(short *)(p + 0x5dba);
+}

--- a/src/func_ov006_02125994.c
+++ b/src/func_ov006_02125994.c
@@ -1,0 +1,20 @@
+/* func_ov006_02125994 at 0x02125994
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov006).
+ */
+
+void func_ov006_02125994(unsigned char *r0) {
+    int i;
+    for (i = 0; i < 0x20; i++) {
+        *(int *)(r0 + 0xb000 + 0xa14) = 0;
+        *(int *)(r0 + 0xb000 + 0xa18) = 0;
+        *(int *)(r0 + 0xb000 + 0xa1c) = 0;
+        *(int *)(r0 + 0xb000 + 0xa20) = 0;
+        *(int *)(r0 + 0xb000 + 0xa24) = 0;
+        *(int *)(r0 + 0xb000 + 0xa28) = 0;
+        *(int *)(r0 + 0xb000 + 0xa2c) = 0;
+        r0[0xb000 + 0xa34] = 0;
+        *(int *)(r0 + 0xb000 + 0xa30) = 0;
+        r0 += 0x24;
+    }
+}

--- a/src/func_ov034_02112330.c
+++ b/src/func_ov034_02112330.c
@@ -1,0 +1,11 @@
+/* func_ov034_02112330 at 0x02112330
+ *
+ * Caches the closest player actor into the +0x8c8 field.
+ */
+
+extern void *_ZN5Actor13ClosestPlayerEv(void *actor);
+
+void func_ov034_02112330(char *c)
+{
+    *(void **)(c + 0x8c8) = _ZN5Actor13ClosestPlayerEv(c);
+}

--- a/src/func_ov034_02112a5c.c
+++ b/src/func_ov034_02112a5c.c
@@ -1,0 +1,30 @@
+/* func_ov034_02112a5c at 0x02112a5c
+ *
+ * Releases all five entries of each of the seven SharedFilePtr tables this
+ * actor pulled, then returns 1.
+ */
+
+extern void _ZN13SharedFilePtr7ReleaseEv(void *self);
+
+extern void *data_ov034_02113838[];
+extern void *data_ov034_0211384c[];
+extern void *data_ov034_02113860[];
+extern void *data_ov034_02113874[];
+extern void *data_ov034_02113888[];
+extern void *data_ov034_0211389c[];
+extern void *data_ov034_021138b0[];
+
+int func_ov034_02112a5c(void)
+{
+    int i;
+    for (i = 0; i < 5; i++) {
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_02113838[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_0211384c[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_02113860[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_02113874[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_02113888[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_0211389c[i]);
+        _ZN13SharedFilePtr7ReleaseEv(data_ov034_021138b0[i]);
+    }
+    return 1;
+}


### PR DESCRIPTION
Adds **327 byte-matched functions** (233 C + 94 C++), taking the project from
**39.2% → 42.0%** function coverage. All hand-written from scratch and verified
relocation-aware against the EU retail ROM with `tools/match.py` — each ends in
`MATCHING VERSIONS: 1.2/sp2p3`.

### Breakdown by module
- **ov002 — 211**: Player/Actor state handlers (guard → `SetAnim` → set fields →
  `ChangeState`), state transitions, deleting destructor chains, `new`/ctor stubs,
  object-table & level loaders, collision/raycast setup, matrix/collider transforms,
  fixed-point math, particle/sound/music glue, static initializers, and a large
  set of C++ virtual-call / pointer-to-member dispatch stubs.
- **ov006 — 92**: constant returns, field getters/setters, struct/`.data` copies,
  bounded init/scan loops, guards, linked-list unlink/search, fixed-point clamps,
  and PMF/virtual dispatch.
- **arm9 (main) — 22**: pointer stores, masked field reads, global getters/setters,
  clamps, `AngleDiff`, small accessors.
- **ov034 — 2**: `Actor::ClosestPlayer` cache, a 7-table `SharedFilePtr` release loop.

### Verification
- Compiler: **mwccarm 1.2/sp2p3**
- Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`
  (C++ files carry a `//cpp` first line and compile with `-lang c++`)
- Every function was independently re-verified byte-for-byte under the pinned
  `-O4,p` flags before landing.

Import knowledge, write code: only community symbol names / struct field offsets
were used; all C/C++ is original, written against my own ROM dump. No ROM or
extracted data is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)