### PR TITLE
Match _ZN6Camera16CleanupResourcesEv

### DIFF
--- a/src/_ZN6Camera16CleanupResourcesEv.cpp
+++ b/src/_ZN6Camera16CleanupResourcesEv.cpp
@@ -1,0 +1,1 @@
+//cpp extern "C" {     extern void _ZN6Memory16operator_delete2EPv(void *);     int _ZN6Camera16CleanupResourcesEv(void *thiz) {         int p = *(int *)((char *)thiz + 0x148);         if (p != 0 && p != 0) {             _ZN6Memory16operator_delete2EPv((void *)p);         }         return 1;     } }

--- a/src/_ZN6Camera16CleanupResourcesEv.cpp
+++ b/src/_ZN6Camera16CleanupResourcesEv.cpp
@@ -1,1 +1,11 @@
-//cpp extern "C" {     extern void _ZN6Memory16operator_delete2EPv(void *);     int _ZN6Camera16CleanupResourcesEv(void *thiz) {         int p = *(int *)((char *)thiz + 0x148);         if (p != 0 && p != 0) {             _ZN6Memory16operator_delete2EPv((void *)p);         }         return 1;     } }
+//cpp
+extern "C" {
+    extern void _ZN6Memory16operator_delete2EPv(void *);
+    int _ZN6Camera16CleanupResourcesEv(void *thiz) {
+        int p = *(int *)((char *)thiz + 0x148);
+        if (p != 0 && p != 0) {
+            _ZN6Memory16operator_delete2EPv((void *)p);
+        }
+        return 1;
+    }
+}


### PR DESCRIPTION
Byte-exact match for `_ZN6Camera16CleanupResourcesEv` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET _ZN6Camera16CleanupResourcesEv @ 0x0200d9d0 size 0x30  bytes: 00402de904d04de2480190e5000050e30200000a000050e30000000a76bc00eb0100a0e304d08de20040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: arm9
- Address: 0x0200d9d0
- Size: 0x30