### PR TITLE
Match func_ov014_02111fb8

### DIFF
--- a/src/func_ov014_02111fb8.cpp
+++ b/src/func_ov014_02111fb8.cpp
@@ -1,0 +1,1 @@
+//cpp struct Actor {     void HugeLandingDust(bool); };  extern "C" int func_0201267c(unsigned int, void *);  extern "C" int func_ov014_02111fb8(char *c) {     func_0201267c(0x39, c + 0x74);     ((Actor *)c)->HugeLandingDust(1); }

--- a/src/func_ov014_02111fb8.cpp
+++ b/src/func_ov014_02111fb8.cpp
@@ -1,1 +1,11 @@
-//cpp struct Actor {     void HugeLandingDust(bool); };  extern "C" int func_0201267c(unsigned int, void *);  extern "C" int func_ov014_02111fb8(char *c) {     func_0201267c(0x39, c + 0x74);     ((Actor *)c)->HugeLandingDust(1); }
+//cpp
+struct Actor {
+    void HugeLandingDust(bool);
+};
+
+extern "C" int func_0201267c(unsigned int, void *);
+
+extern "C" int func_ov014_02111fb8(char *c) {
+    func_0201267c(0x39, c + 0x74);
+    ((Actor *)c)->HugeLandingDust(1);
+}


### PR DESCRIPTION
Byte-exact match for `func_ov014_02111fb8` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov014_02111fb8 @ 0x02111fb8 size 0x28  bytes: 10402de90040a0e1741084e23900a0e3ab01fceb0400a0e10110a0e3dcf6fbeb1040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov014
- Address: 0x02111fb8
- Size: 0x28