### PR TITLE
Match func_ov018_021117e8

### DIFF
--- a/src/func_ov018_021117e8.c
+++ b/src/func_ov018_021117e8.c
@@ -1,1 +1,7 @@
-void func_ov018_021117e8(char* c, char* a) {     int val = *(unsigned short*)(a + 0xc);     val = (val == 0xbf);     if (val) {         *(char**)(c + 0x320) = a;     } }
+void func_ov018_021117e8(char* c, char* a) {
+    int val = *(unsigned short*)(a + 0xc);
+    val = (val == 0xbf);
+    if (val) {
+        *(char**)(c + 0x320) = a;
+    }
+}

--- a/src/func_ov018_021117e8.c
+++ b/src/func_ov018_021117e8.c
@@ -1,0 +1,1 @@
+void func_ov018_021117e8(char* c, char* a) {     int val = *(unsigned short*)(a + 0xc);     val = (val == 0xbf);     if (val) {         *(char**)(c + 0x320) = a;     } }


### PR DESCRIPTION
Byte-exact match for `func_ov018_021117e8` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov018_021117e8 @ 0x021117e8 size 0x1c  bytes: bc20d1e1bf0052e30120a0030020a013000052e3201380151eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov018
- Address: 0x021117e8
- Size: 0x1c