### PR TITLE
Match func_ov020_02112768

### DIFF
--- a/src/func_ov020_02112768.c
+++ b/src/func_ov020_02112768.c
@@ -1,1 +1,12 @@
-extern void _ZN5Model8LoadFileER13SharedFilePtr(void *); extern void LoadBlueCoinModel(void *); extern int G0[]; extern int G1[]; int func_ov020_02112768(char *c) {     *(short *)(c + 0xd4) = 0;     _ZN5Model8LoadFileER13SharedFilePtr(G0);     _ZN5Model8LoadFileER13SharedFilePtr(G1);     LoadBlueCoinModel(c);     return 1; }
+extern void _ZN5Model8LoadFileER13SharedFilePtr(void *);
+extern void LoadBlueCoinModel(void *);
+extern int G0[];
+extern int G1[];
+int func_ov020_02112768(char *c)
+{
+    *(short *)(c + 0xd4) = 0;
+    _ZN5Model8LoadFileER13SharedFilePtr(G0);
+    _ZN5Model8LoadFileER13SharedFilePtr(G1);
+    LoadBlueCoinModel(c);
+    return 1;
+}

--- a/src/func_ov020_02112768.c
+++ b/src/func_ov020_02112768.c
@@ -1,0 +1,1 @@
+extern void _ZN5Model8LoadFileER13SharedFilePtr(void *); extern void LoadBlueCoinModel(void *); extern int G0[]; extern int G1[]; int func_ov020_02112768(char *c) {     *(short *)(c + 0xd4) = 0;     _ZN5Model8LoadFileER13SharedFilePtr(G0);     _ZN5Model8LoadFileER13SharedFilePtr(G1);     LoadBlueCoinModel(c);     return 1; }


### PR DESCRIPTION
Byte-exact match for `func_ov020_02112768` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov020_02112768 @ 0x02112768 size 0x3c  bytes: 10402de90040a0e10010a0e320009fe5b41dc4e1ae14fceb18009fe5ac14fceb0400a0e1c2f5fbeb0100a0e31040bde81eff2fe1a04a1102b84a1102
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov020
- Address: 0x02112768
- Size: 0x3c