### PR TITLE
Match func_ov022_0211191c

### DIFF
--- a/src/func_ov022_0211191c.c
+++ b/src/func_ov022_0211191c.c
@@ -1,1 +1,7 @@
-void func_ov022_0211191c(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x324) = 1;     } }
+void func_ov022_0211191c(char *a, char *b) {
+    int cond = *(unsigned short*)(b + 0xc);
+    cond = (cond == 0xbf);
+    if (cond) {
+        *(a + 0x324) = 1;
+    }
+}

--- a/src/func_ov022_0211191c.c
+++ b/src/func_ov022_0211191c.c
@@ -1,0 +1,1 @@
+void func_ov022_0211191c(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x324) = 1;     } }


### PR DESCRIPTION
Byte-exact match for `func_ov022_0211191c` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov022_0211191c @ 0x0211191c size 0x20  bytes: bc10d1e1bf0051e30110a0030010a013000051e30110a0132413c0151eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov022
- Address: 0x0211191c
- Size: 0x20