### PR TITLE
Match func_ov022_02112560

### DIFF
--- a/src/func_ov022_02112560.c
+++ b/src/func_ov022_02112560.c
@@ -1,1 +1,8 @@
-extern void func_020393a4(int *p, int v); extern int func_ov080_0212714c(char *c, int *d); extern int data_ov022_02112c98;  int func_ov022_02112560(char *c) {     func_020393a4((int *)(c + 0x124), 0x500000);     return func_ov080_0212714c(c, &data_ov022_02112c98) & 0xff; }
+extern void func_020393a4(int *p, int v);
+extern int func_ov080_0212714c(char *c, int *d);
+extern int data_ov022_02112c98;
+
+int func_ov022_02112560(char *c) {
+    func_020393a4((int *)(c + 0x124), 0x500000);
+    return func_ov080_0212714c(c, &data_ov022_02112c98) & 0xff;
+}

--- a/src/func_ov022_02112560.c
+++ b/src/func_ov022_02112560.c
@@ -1,0 +1,1 @@
+extern void func_020393a4(int *p, int v); extern int func_ov080_0212714c(char *c, int *d); extern int data_ov022_02112c98;  int func_ov022_02112560(char *c) {     func_020393a4((int *)(c + 0x124), 0x500000);     return func_ov080_0212714c(c, &data_ov022_02112c98) & 0xff; }


### PR DESCRIPTION
Byte-exact match for `func_ov022_02112560` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov022_02112560 @ 0x02112560 size 0x30  bytes: 10402de90040a0e1490f84e20516a0e38b9bfceb10109fe50400a0e1f25200ebff0000e21040bde81eff2fe1982c1102
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov022
- Address: 0x02112560
- Size: 0x30