### PR TITLE
Match func_ov026_02112280

### DIFF
--- a/src/func_ov026_02112280.cpp
+++ b/src/func_ov026_02112280.cpp
@@ -1,1 +1,11 @@
-//cpp class Actor { public:     static Actor *FindWithID(unsigned int id); };  extern "C" void func_ov026_02112280(char *c) {     unsigned int id = *(unsigned int *)(c + 0x134);     if (id == 0) return;     if (Actor::FindWithID(id) == 0) return; }
+//cpp
+class Actor {
+public:
+    static Actor *FindWithID(unsigned int id);
+};
+
+extern "C" void func_ov026_02112280(char *c) {
+    unsigned int id = *(unsigned int *)(c + 0x134);
+    if (id == 0) return;
+    if (Actor::FindWithID(id) == 0) return;
+}

--- a/src/func_ov026_02112280.cpp
+++ b/src/func_ov026_02112280.cpp
@@ -1,0 +1,1 @@
+//cpp class Actor { public:     static Actor *FindWithID(unsigned int id); };  extern "C" void func_ov026_02112280(char *c) {     unsigned int id = *(unsigned int *)(c + 0x134);     if (id == 0) return;     if (Actor::FindWithID(id) == 0) return; }


### PR DESCRIPTION
Byte-exact match for `func_ov026_02112280` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov026_02112280 @ 0x02112280 size 0x30  bytes: 00402de904d04de2340190e5000050e304d08d020040bd081eff2f0126fbfbeb000050e304d08de20040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov026
- Address: 0x02112280
- Size: 0x30