### PR TITLE
Match func_ov029_02111e40

### DIFF
--- a/src/func_ov029_02111e40.c
+++ b/src/func_ov029_02111e40.c
@@ -1,0 +1,1 @@
+void func_ov029_02111e40(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x32a) = 1;     } }

--- a/src/func_ov029_02111e40.c
+++ b/src/func_ov029_02111e40.c
@@ -1,1 +1,7 @@
-void func_ov029_02111e40(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x32a) = 1;     } }
+void func_ov029_02111e40(char *a, char *b) {
+    int cond = *(unsigned short*)(b + 0xc);
+    cond = (cond == 0xbf);
+    if (cond) {
+        *(a + 0x32a) = 1;
+    }
+}


### PR DESCRIPTION
Byte-exact match for `func_ov029_02111e40` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov029_02111e40 @ 0x02111e40 size 0x20  bytes: bc10d1e1bf0051e30110a0030010a013000051e30110a0132a13c0151eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov029
- Address: 0x02111e40
- Size: 0x20