### PR TITLE
Match func_ov034_02111588

### DIFF
--- a/src/func_ov034_02111588.c
+++ b/src/func_ov034_02111588.c
@@ -1,0 +1,1 @@
+extern unsigned char DecIfAbove0_Byte(unsigned char *p); extern void func_ov034_021125b8(char *c, int i);  void func_ov034_02111588(char *c) {     if (DecIfAbove0_Byte((unsigned char *)(c + 0x8da)) != 0) return;     func_ov034_021125b8(c, 0xa); }

--- a/src/func_ov034_02111588.c
+++ b/src/func_ov034_02111588.c
@@ -1,1 +1,7 @@
-extern unsigned char DecIfAbove0_Byte(unsigned char *p); extern void func_ov034_021125b8(char *c, int i);  void func_ov034_02111588(char *c) {     if (DecIfAbove0_Byte((unsigned char *)(c + 0x8da)) != 0) return;     func_ov034_021125b8(c, 0xa); }
+extern unsigned char DecIfAbove0_Byte(unsigned char *p);
+extern void func_ov034_021125b8(char *c, int i);
+
+void func_ov034_02111588(char *c) {
+    if (DecIfAbove0_Byte((unsigned char *)(c + 0x8da)) != 0) return;
+    func_ov034_021125b8(c, 0xa);
+}


### PR DESCRIPTION
Byte-exact match for `func_ov034_02111588` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov034_02111588 @ 0x02111588 size 0x38  bytes: 10402de928109fe50040a0e1010084e00da6fceb000050e31040bd181eff2f110400a0e10a10a0e3000400eb1040bde81eff2fe1da080000
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov034
- Address: 0x02111588
- Size: 0x38