### PR TITLE
Match func_ov034_02112330

### DIFF
--- a/src/func_ov034_02112330.c
+++ b/src/func_ov034_02112330.c
@@ -1,0 +1,1 @@
+extern void* _ZN5Actor13ClosestPlayerEv(void);  struct ActorObj {     char pad[0x8c8];     void* closestPlayer; };  void func_ov034_02112330(char* c) {     void* player = _ZN5Actor13ClosestPlayerEv();     ((struct ActorObj*)c)->closestPlayer = player; }

--- a/src/func_ov034_02112330.c
+++ b/src/func_ov034_02112330.c
@@ -1,1 +1,11 @@
-extern void* _ZN5Actor13ClosestPlayerEv(void);  struct ActorObj {     char pad[0x8c8];     void* closestPlayer; };  void func_ov034_02112330(char* c) {     void* player = _ZN5Actor13ClosestPlayerEv();     ((struct ActorObj*)c)->closestPlayer = player; }
+extern void* _ZN5Actor13ClosestPlayerEv(void);
+
+struct ActorObj {
+    char pad[0x8c8];
+    void* closestPlayer;
+};
+
+void func_ov034_02112330(char* c) {
+    void* player = _ZN5Actor13ClosestPlayerEv();
+    ((struct ActorObj*)c)->closestPlayer = player;
+}


### PR DESCRIPTION
Byte-exact match for `func_ov034_02112330` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov034_02112330 @ 0x02112330 size 0x18  bytes: 10402de90040a0e1e6f9fbebc80884e51040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov034
- Address: 0x02112330
- Size: 0x18