### PR TITLE
Match func_ov045_021114a8

### DIFF
--- a/src/func_ov045_021114a8.c
+++ b/src/func_ov045_021114a8.c
@@ -1,0 +1,1 @@
+void func_ov045_021114a8(char *r0, char *r1) {     int cond = *(unsigned short*)(r1 + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(r0 + 0x326) = 1;     } }

--- a/src/func_ov045_021114a8.c
+++ b/src/func_ov045_021114a8.c
@@ -1,1 +1,7 @@
-void func_ov045_021114a8(char *r0, char *r1) {     int cond = *(unsigned short*)(r1 + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(r0 + 0x326) = 1;     } }
+void func_ov045_021114a8(char *r0, char *r1) {
+    int cond = *(unsigned short*)(r1 + 0xc);
+    cond = (cond == 0xbf);
+    if (cond) {
+        *(r0 + 0x326) = 1;
+    }
+}


### PR DESCRIPTION
Byte-exact match for `func_ov045_021114a8` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov045_021114a8 @ 0x021114a8 size 0x20  bytes: bc10d1e1bf0051e30110a0030010a013000051e30110a0132613c0151eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov045
- Address: 0x021114a8
- Size: 0x20