### PR TITLE
Match func_ov045_021118c4

### DIFF
--- a/src/func_ov045_021118c4.c
+++ b/src/func_ov045_021118c4.c
@@ -1,1 +1,8 @@
-extern void Matrix4x3_FromRotationY(void *, int);  void func_ov045_021118c4(char *c) {     Matrix4x3_FromRotationY(c + 0x128, *(short *)(c + 0x8e));     *(int *)(c + 0x14c) = *(int *)(c + 0x5c);     *(int *)(c + 0x150) = *(int *)(c + 0x60);     *(int *)(c + 0x154) = *(int *)(c + 0x64); }
+extern void Matrix4x3_FromRotationY(void *, int);
+
+void func_ov045_021118c4(char *c) {
+    Matrix4x3_FromRotationY(c + 0x128, *(short *)(c + 0x8e));
+    *(int *)(c + 0x14c) = *(int *)(c + 0x5c);
+    *(int *)(c + 0x150) = *(int *)(c + 0x60);
+    *(int *)(c + 0x154) = *(int *)(c + 0x64);
+}

--- a/src/func_ov045_021118c4.c
+++ b/src/func_ov045_021118c4.c
@@ -1,0 +1,1 @@
+extern void Matrix4x3_FromRotationY(void *, int);  void func_ov045_021118c4(char *c) {     Matrix4x3_FromRotationY(c + 0x128, *(short *)(c + 0x8e));     *(int *)(c + 0x14c) = *(int *)(c + 0x5c);     *(int *)(c + 0x150) = *(int *)(c + 0x60);     *(int *)(c + 0x154) = *(int *)(c + 0x64); }


### PR DESCRIPTION
Byte-exact match for `func_ov045_021118c4` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov045_021118c4 @ 0x021118c4 size 0x34  bytes: 10402de90040a0e1fe18d4e14a0f84e224a9fceb5c0094e54c0184e5600094e5500184e5640094e5540184e51040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov045
- Address: 0x021118c4
- Size: 0x34