### PR TITLE
Match func_ov062_02116238

### DIFF
--- a/src/func_ov062_02116238.cpp
+++ b/src/func_ov062_02116238.cpp
@@ -1,1 +1,14 @@
-//cpp struct BCA_File; struct ModelAnim {     void SetAnim(BCA_File *, int, int, unsigned int); };  extern int data_ov062_0211de08;  extern "C" int func_ov062_02116238(char *c) {     unsigned int flags = 0;     BCA_File *file = (BCA_File *)(((int *)&data_ov062_0211de08)[1]);     ((ModelAnim *)(c + 0x300))->SetAnim(file, 0x40000000, 0x1000, flags);     return 1; }
+//cpp
+struct BCA_File;
+struct ModelAnim {
+    void SetAnim(BCA_File *, int, int, unsigned int);
+};
+
+extern int data_ov062_0211de08;
+
+extern "C" int func_ov062_02116238(char *c) {
+    unsigned int flags = 0;
+    BCA_File *file = (BCA_File *)(((int *)&data_ov062_0211de08)[1]);
+    ((ModelAnim *)(c + 0x300))->SetAnim(file, 0x40000000, 0x1000, flags);
+    return 1;
+}

--- a/src/func_ov062_02116238.cpp
+++ b/src/func_ov062_02116238.cpp
@@ -1,0 +1,1 @@
+//cpp struct BCA_File; struct ModelAnim {     void SetAnim(BCA_File *, int, int, unsigned int); };  extern int data_ov062_0211de08;  extern "C" int func_ov062_02116238(char *c) {     unsigned int flags = 0;     BCA_File *file = (BCA_File *)(((int *)&data_ov062_0211de08)[1]);     ((ModelAnim *)(c + 0x300))->SetAnim(file, 0x40000000, 0x1000, flags);     return 1; }


### PR DESCRIPTION
Byte-exact match for `func_ov062_02116238` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov062_02116238 @ 0x02116238 size 0x3c  bytes: 00402de904d04de20020a0e324109fe500208de5041091e5030c80e20121a0e3013aa0e33901fceb0100a0e304d08de20040bde81eff2fe108de1102
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov062
- Address: 0x02116238
- Size: 0x3c