### PR TITLE
Match func_ov063_021163d0

### DIFF
--- a/src/func_ov063_021163d0.cpp
+++ b/src/func_ov063_021163d0.cpp
@@ -1,0 +1,1 @@
+//cpp extern "C" void *_ZN5Actor10FindWithIDEj(unsigned int id);  extern "C" unsigned char func_ov063_021163d0(char *c) {     unsigned int id = *(unsigned int *)(c + 0x498);     if (id == 0) return 0;     char *actor = (char *)_ZN5Actor10FindWithIDEj(id);     if (actor == 0) return 0;     return *(unsigned char *)(actor + 0x153); }

--- a/src/func_ov063_021163d0.cpp
+++ b/src/func_ov063_021163d0.cpp
@@ -1,1 +1,10 @@
-//cpp extern "C" void *_ZN5Actor10FindWithIDEj(unsigned int id);  extern "C" unsigned char func_ov063_021163d0(char *c) {     unsigned int id = *(unsigned int *)(c + 0x498);     if (id == 0) return 0;     char *actor = (char *)_ZN5Actor10FindWithIDEj(id);     if (actor == 0) return 0;     return *(unsigned char *)(actor + 0x153); }
+//cpp
+extern "C" void *_ZN5Actor10FindWithIDEj(unsigned int id);
+
+extern "C" unsigned char func_ov063_021163d0(char *c) {
+    unsigned int id = *(unsigned int *)(c + 0x498);
+    if (id == 0) return 0;
+    char *actor = (char *)_ZN5Actor10FindWithIDEj(id);
+    if (actor == 0) return 0;
+    return *(unsigned char *)(actor + 0x153);
+}


### PR DESCRIPTION
Byte-exact match for `func_ov063_021163d0` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov063_021163d0 @ 0x021163d0 size 0x3c  bytes: 00402de904d04de2980490e5000050e304d08d020000a0030040bd081eff2f01d1eafbeb000050e30000a0035301d01504d08de20040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov063
- Address: 0x021163d0
- Size: 0x3c