### PR TITLE
Match func_ov063_02116dbc

### DIFF
--- a/src/func_ov063_02116dbc.cpp
+++ b/src/func_ov063_02116dbc.cpp
@@ -1,0 +1,1 @@
+//cpp class ActorBase { public:     void MarkForDestruction(); };  extern int func_ov063_0211a3d0(void *c); extern void func_0201267c(int a, void *b);  extern "C" void func_ov063_02116dbc(void *c) {     if (func_ov063_0211a3d0(c) == 0) return;     ((ActorBase *)c)->MarkForDestruction();     func_0201267c(0xd5, (char *)c + 0x74); }

--- a/src/func_ov063_02116dbc.cpp
+++ b/src/func_ov063_02116dbc.cpp
@@ -1,1 +1,14 @@
-//cpp class ActorBase { public:     void MarkForDestruction(); };  extern int func_ov063_0211a3d0(void *c); extern void func_0201267c(int a, void *b);  extern "C" void func_ov063_02116dbc(void *c) {     if (func_ov063_0211a3d0(c) == 0) return;     ((ActorBase *)c)->MarkForDestruction();     func_0201267c(0xd5, (char *)c + 0x74); }
+//cpp
+class ActorBase {
+public:
+    void MarkForDestruction();
+};
+
+extern int func_ov063_0211a3d0(void *c);
+extern void func_0201267c(int a, void *b);
+
+extern "C" void func_ov063_02116dbc(void *c) {
+    if (func_ov063_0211a3d0(c) == 0) return;
+    ((ActorBase *)c)->MarkForDestruction();
+    func_0201267c(0xd5, (char *)c + 0x74);
+}


### PR DESCRIPTION
Byte-exact match for `func_ov063_02116dbc` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov063_02116dbc @ 0x02116dbc size 0x34  bytes: 10402de90040a0e1810d00eb000050e31040bd081eff2f010400a0e191b2fceb741084e2d500a0e324eefbeb1040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov063
- Address: 0x02116dbc
- Size: 0x34