### PR TITLE
Match func_ov084_02129498

### DIFF
--- a/src/func_ov084_02129498.cpp
+++ b/src/func_ov084_02129498.cpp
@@ -1,0 +1,1 @@
+//cpp class ActorBase { public:     void MarkForDestruction(); };  class Actor { public:     void KillAndTrackInDeathTable(); };  extern "C" void func_ov084_02129498(char *r0) {     if ((*(unsigned char *)(r0 + 0x113) & 0xf) < 6) {         ((ActorBase *)r0)->MarkForDestruction();     } else {         ((Actor *)r0)->KillAndTrackInDeathTable();     } }

--- a/src/func_ov084_02129498.cpp
+++ b/src/func_ov084_02129498.cpp
@@ -1,1 +1,18 @@
-//cpp class ActorBase { public:     void MarkForDestruction(); };  class Actor { public:     void KillAndTrackInDeathTable(); };  extern "C" void func_ov084_02129498(char *r0) {     if ((*(unsigned char *)(r0 + 0x113) & 0xf) < 6) {         ((ActorBase *)r0)->MarkForDestruction();     } else {         ((Actor *)r0)->KillAndTrackInDeathTable();     } }
+//cpp
+class ActorBase {
+public:
+    void MarkForDestruction();
+};
+
+class Actor {
+public:
+    void KillAndTrackInDeathTable();
+};
+
+extern "C" void func_ov084_02129498(char *r0) {
+    if ((*(unsigned char *)(r0 + 0x113) & 0xf) < 6) {
+        ((ActorBase *)r0)->MarkForDestruction();
+    } else {
+        ((Actor *)r0)->KillAndTrackInDeathTable();
+    }
+}


### PR DESCRIPTION
Byte-exact match for `func_ov084_02129498` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov084_02129498 @ 0x02129498 size 0x38  bytes: 00402de904d04de21311d0e50f1001e2060051e3030000aadb68fceb04d08de20040bde81eff2fe13c99fbeb04d08de20040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov084
- Address: 0x02129498
- Size: 0x38