### PR TITLE
Match func_ov085_0212a0b8

### DIFF
--- a/src/func_ov085_0212a0b8.cpp
+++ b/src/func_ov085_0212a0b8.cpp
@@ -1,1 +1,16 @@
-//cpp struct CylinderClsn;  struct Actor {     void UpdatePos(CylinderClsn *); };  extern "C" int func_ov085_02129ebc(int *self, void *clsn); extern "C" int func_ov085_02129f8c(char *c);  extern "C" int func_ov085_0212a0b8(char *c) {     ((Actor *)c)->UpdatePos((CylinderClsn *)(c + 0x160));     func_ov085_02129ebc((int *)c, c + 0x194);     func_ov085_02129f8c(c);     return 1; }
+//cpp
+struct CylinderClsn;
+
+struct Actor {
+    void UpdatePos(CylinderClsn *);
+};
+
+extern "C" int func_ov085_02129ebc(int *self, void *clsn);
+extern "C" int func_ov085_02129f8c(char *c);
+
+extern "C" int func_ov085_0212a0b8(char *c) {
+    ((Actor *)c)->UpdatePos((CylinderClsn *)(c + 0x160));
+    func_ov085_02129ebc((int *)c, c + 0x194);
+    func_ov085_02129f8c(c);
+    return 1;
+}

--- a/src/func_ov085_0212a0b8.cpp
+++ b/src/func_ov085_0212a0b8.cpp
@@ -1,0 +1,1 @@
+//cpp struct CylinderClsn;  struct Actor {     void UpdatePos(CylinderClsn *); };  extern "C" int func_ov085_02129ebc(int *self, void *clsn); extern "C" int func_ov085_02129f8c(char *c);  extern "C" int func_ov085_0212a0b8(char *c) {     ((Actor *)c)->UpdatePos((CylinderClsn *)(c + 0x160));     func_ov085_02129ebc((int *)c, c + 0x194);     func_ov085_02129f8c(c);     return 1; }


### PR DESCRIPTION
Byte-exact match for `func_ov085_0212a0b8` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov085_0212a0b8 @ 0x0212a0b8 size 0x30  bytes: 10402de90040a0e1161e84e2d99afbeb0400a0e1651f84e279ffffeb0400a0e1abffffeb0100a0e31040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov085
- Address: 0x0212a0b8
- Size: 0x30