### PR TITLE
Match func_ov089_02131dcc

### DIFF
--- a/src/func_ov089_02131dcc.cpp
+++ b/src/func_ov089_02131dcc.cpp
@@ -1,1 +1,18 @@
-//cpp class Event { public: static void SetBit(unsigned int); };  class ActorBase { public: void MarkForDestruction(); };  extern "C" void func_ov002_020c3dbc(int);  extern "C" void func_ov089_02131dcc(ActorBase *r4, int r1) { func_ov002_020c3dbc(r1); Event::SetBit(0x1d); r4->MarkForDestruction(); }
+//cpp
+class Event {
+public:
+static void SetBit(unsigned int);
+};
+
+class ActorBase {
+public:
+void MarkForDestruction();
+};
+
+extern "C" void func_ov002_020c3dbc(int);
+
+extern "C" void func_ov089_02131dcc(ActorBase *r4, int r1) {
+func_ov002_020c3dbc(r1);
+Event::SetBit(0x1d);
+r4->MarkForDestruction();
+}

--- a/src/func_ov089_02131dcc.cpp
+++ b/src/func_ov089_02131dcc.cpp
@@ -1,0 +1,1 @@
+//cpp class Event { public: static void SetBit(unsigned int); };  class ActorBase { public: void MarkForDestruction(); };  extern "C" void func_ov002_020c3dbc(int);  extern "C" void func_ov089_02131dcc(ActorBase *r4, int r1) { func_ov002_020c3dbc(r1); Event::SetBit(0x1d); r4->MarkForDestruction(); }


### PR DESCRIPTION
Byte-exact match for `func_ov089_02131dcc` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov089_02131dcc @ 0x02131dcc size 0x28  bytes: 10402de90040a0e10100a0e1f747feeb1d00a0e337e0fbeb0400a0e18d46fceb1040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov089
- Address: 0x02131dcc
- Size: 0x28