### PR TITLE
Match func_ov091_02132360

### DIFF
--- a/src/func_ov091_02132360.c
+++ b/src/func_ov091_02132360.c
@@ -1,0 +1,1 @@
+void func_ov091_02132360(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x356) = 1;     } }

--- a/src/func_ov091_02132360.c
+++ b/src/func_ov091_02132360.c
@@ -1,1 +1,7 @@
-void func_ov091_02132360(char *a, char *b) {     int cond = *(unsigned short*)(b + 0xc);     cond = (cond == 0xbf);     if (cond) {         *(a + 0x356) = 1;     } }
+void func_ov091_02132360(char *a, char *b) {
+    int cond = *(unsigned short*)(b + 0xc);
+    cond = (cond == 0xbf);
+    if (cond) {
+        *(a + 0x356) = 1;
+    }
+}


### PR DESCRIPTION
Byte-exact match for `func_ov091_02132360` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov091_02132360 @ 0x02132360 size 0x20  bytes: bc10d1e1bf0051e30110a0030010a013000051e30110a0135613c0151eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov091
- Address: 0x02132360
- Size: 0x20