### PR TITLE
Match func_ov098_02137d80

### DIFF
--- a/src/func_ov098_02137d80.cpp
+++ b/src/func_ov098_02137d80.cpp
@@ -1,0 +1,1 @@
+//cpp struct Player {     void IncMegaKillCount(); };  struct Platform {     void KillByMegaChar(Player &); };  extern "C" void func_02012694(int, void *);  extern "C" void func_ov098_02137d80(void *a, void *b) {     ((Player *)b)->IncMegaKillCount();     func_02012694(0x1e, (char *)a + 0x74);     ((Platform *)a)->KillByMegaChar(*(Player *)b); }

--- a/src/func_ov098_02137d80.cpp
+++ b/src/func_ov098_02137d80.cpp
@@ -1,1 +1,16 @@
-//cpp struct Player {     void IncMegaKillCount(); };  struct Platform {     void KillByMegaChar(Player &); };  extern "C" void func_02012694(int, void *);  extern "C" void func_ov098_02137d80(void *a, void *b) {     ((Player *)b)->IncMegaKillCount();     func_02012694(0x1e, (char *)a + 0x74);     ((Platform *)a)->KillByMegaChar(*(Player *)b); }
+//cpp
+struct Player {
+    void IncMegaKillCount();
+};
+
+struct Platform {
+    void KillByMegaChar(Player &);
+};
+
+extern "C" void func_02012694(int, void *);
+
+extern "C" void func_ov098_02137d80(void *a, void *b) {
+    ((Player *)b)->IncMegaKillCount();
+    func_02012694(0x1e, (char *)a + 0x74);
+    ((Platform *)a)->KillByMegaChar(*(Player *)b);
+}


### PR DESCRIPTION
Byte-exact match for `func_ov098_02137d80` verified with mwccarm 1.2/sp2p3.

**Oracle verification (tools/match.py):**
```
TARGET func_ov098_02137d80 @ 0x02137d80 size 0x3c  bytes: 30402de904d04de20140a0e10050a0e10400a0e1af17feeb741085e21e00a0e33b6afbeb0500a0e10410a0e1bfd9feeb04d08de23040bde81eff2fe1
  1.2/sp2p3: MATCH

========================================
MATCHING VERSIONS: 1.2/sp2p3
```

- Module: ov098
- Address: 0x02137d80
- Size: 0x3c