### PR TITLE
Match 15 functions across arm9 + overlays, document a codegen wall

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -87,6 +87,21 @@ up - the logic is the same but the codegen differs:
 - **`add` folds into the addressing mode.** For `*(T*)(p+off) = 0`, don't model an explicit
   `add` - emit the store and let CW pick add-vs-direct by whether `off` fits the immediate.
   Tracking an effective offset through an `add rT,rB,#big` is enough; the compiler chooses.
+- **WALL: the *materialized*-`add` flag read-modify-write is NOT C-reproducible.** A large
+  cluster of single-flag setters appears in the ROM as a frameless 5-instruction form that
+  computes the address into its own register first and shares it for the load and store:
+  `add rA,rB,#off ; ldr/ldrb rV,[rA] ; orr/bic rV,rV,#bit ; str/strb rV,[rA] ; bx lr`
+  (e.g. the whole `BgCh::Start/StopDetecting*` family at `this+4`; the int-flag family at
+  `obj+0x154`: `func_02009d30`, `func_0200ca14`, `func_020050dc`). The corresponding C
+  (`*(T*)(base+off) |= bit`) ALWAYS folds the address into the offset and emits the tighter
+  4-instruction `ldrb [rB,#off]; orr; strb [rB,#off]; bx` instead - the ROM's form is the
+  *less*-optimized one, which `-O4,p` never produces. Confirmed unreachable: swept 6 source
+  idioms (deref/ptr-var/index/ref/volatile/split-RMW) x all 11 mwccarm versions x 7 opt
+  levels - every optimized build folds, `-O0` adds a stack frame, nothing lands the 5-instr
+  shape. No `-opt nopeephole` knob changes it (it's instruction selection, not a peephole).
+  These are not asm-hatch material either (clean compiled-code shape, no hand-asm tell).
+  Treat the whole flag-RMW-materialized cluster as shape-blocked; flag and move on
+  (2026-06-27).
 - **Repeated global -> one pool word.** If the same global is referenced several times, CW
   loads it once. Emitting distinct extern names per use inflates the pool and breaks the size.
   Dedup globals by reloc-target identity.

--- a/src/func_02010304.cpp
+++ b/src/func_02010304.cpp
@@ -1,0 +1,18 @@
+//cpp
+// func_02010304 at 0x02010304
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+extern "C" {
+extern void *_ZN5Actor10FindWithIDEj(unsigned);
+extern int _ZN6Player7TryGrabER5Actor(void *, void *);
+
+void *func_02010304(void *target, char *p) {
+    unsigned id = *(unsigned *)(p + 0x24);
+    void *found;
+    if (id != 0 && (found = _ZN5Actor10FindWithIDEj(id)) != 0 && (*(int *)(p + 0x20) & 0x1000)) {
+        int t = *(unsigned short *)((char *)found + 0xc) == 0xbf;
+        if (t && _ZN6Player7TryGrabER5Actor(found, target))
+            return found;
+    }
+    return 0;
+}
+}

--- a/src/func_020421b4.c
+++ b/src/func_020421b4.c
@@ -1,0 +1,18 @@
+/* func_020421b4 at 0x020421b4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern char data_020a11e4[];
+extern int func_02058158(void *p);
+extern void func_02058048(void *p);
+extern void func_0205816c(void *p);
+
+void func_020421b4(void)
+{
+    char *base = (char *)(int)data_020a11e4;
+    if (func_02058158(base + 0x400)) return;
+    do {
+        func_02058048(base + 0x400);
+        func_0205816c(base + 0x400);
+    } while (!func_02058158(base + 0x400));
+}

--- a/src/func_0204f9c4.c
+++ b/src/func_0204f9c4.c
@@ -1,0 +1,30 @@
+/* func_0204f9c4 at 0x0204f9c4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned char u8;
+
+extern void func_0204f5a0(u8 *thiz, int arg1);
+
+extern u8 data_020a4d6c[];
+
+struct S {
+    char pad0[4];
+    u8 *ptr;
+    char pad8[0x24];
+    u8 active;
+    char pad2d[0x17];
+};
+
+extern struct S data_020a50ec[16];
+
+void func_0204f9c4(int idx, int arg1) {
+    int i;
+    struct S *p = data_020a50ec;
+    u8 *thiz = &data_020a4d6c[idx * 0x1c];
+    for (i = 0; i < 16; i++, p++) {
+        if (p->active != 0 && p->ptr == thiz) {
+            func_0204f5a0((u8 *)p, arg1);
+        }
+    }
+}

--- a/src/func_0204ff48.c
+++ b/src/func_0204ff48.c
@@ -1,0 +1,17 @@
+/* func_0204ff48 at 0x0204ff48
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern void func_0205abb8(int a, int b, int c, int d);
+extern void *func_0205afb4(void);
+extern void func_0205b070(int);
+extern void func_0205afe0(unsigned);
+
+void func_0204ff48(char *p) {
+    if (!((*(int *)(p + 0xc) << 30) >> 31)) return;
+    func_0205abb8(*(int *)(p + 0x2c), 0, 1 << *(int *)(p + 0x28), 0);
+    void *x = func_0205afb4();
+    func_0205b070(1);
+    func_0205afe0((unsigned)x);
+}

--- a/src/func_02052208.c
+++ b/src/func_02052208.c
@@ -1,0 +1,13 @@
+/* func_02052208 at 0x02052208
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern void func_0204ff9c(void *o);
+extern void func_0205212c(void *o);
+
+void func_02052208(void *obj) {
+    int v = *(int *)((char *)obj + 0xf0);
+    if ((v << 30) >> 31) func_0204ff9c(obj);
+    func_0205212c(obj);
+}

--- a/src/func_0205ae64.c
+++ b/src/func_0205ae64.c
@@ -1,0 +1,19 @@
+/* func_0205ae64 at 0x0205ae64
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern void func_0205ba64(int a, void *p);
+extern int func_020587dc(void);
+extern int func_0205ba3c(int bit, int word);
+extern void func_02059d8c(int n);
+extern void func_0205aed0(void);
+
+void func_0205ae64(void) {
+    func_0205ba64(7, (void *)func_0205aed0);
+    if (func_020587dc()) return;
+    if (func_0205ba3c(7, 1)) return;
+    do {
+        func_02059d8c(0x64);
+    } while (!func_0205ba3c(7, 1));
+}

--- a/src/func_0206a37c.c
+++ b/src/func_0206a37c.c
@@ -1,0 +1,12 @@
+/* func_0206a37c at 0x0206a37c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+
+extern void func_02057014(int a);
+extern void _ZN3IRQ7RestoreEj(unsigned int);
+
+void func_0206a37c(int a, int *p) {
+    if (p[0] == 0) func_02057014(a);
+    _ZN3IRQ7RestoreEj(p[1]);
+}

--- a/src/func_ov002_020d4d88.c
+++ b/src/func_ov002_020d4d88.c
@@ -1,0 +1,16 @@
+/* func_ov002_020d4d88 at 0x020d4d88
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+extern int _Z14ApproachLinearRiii(int *, int, int);
+extern int func_ov002_020c04e0(void *);
+
+int func_ov002_020d4d88(char *this, int a, int b, int c)
+{
+    _Z14ApproachLinearRiii((int *)(this + 0x98), a, b);
+    if (a != 0 || (unsigned short)(*(unsigned short *)(this + 0x600 + 0xce) & 1)) {
+        func_ov002_020c04e0(this);
+        return 1;
+    }
+    return 0;
+}

--- a/src/func_ov006_020ced84.c
+++ b/src/func_ov006_020ced84.c
@@ -1,0 +1,18 @@
+/* func_ov006_020ced84 at 0x020ced84
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern int data_ov006_02140838;
+extern char *data_ov006_0214082c;
+extern void func_ov006_020ce988(char *c);
+
+void func_ov006_020ced84(void)
+{
+    int i;
+    for (i = 0; i < data_ov006_02140838; i++)
+    {
+        char *p = data_ov006_0214082c + i * 0x1d0;
+        if (*(int *)(p + 0x84) != 0)
+            func_ov006_020ce988(p);
+    }
+}

--- a/src/func_ov006_020dcc48.c
+++ b/src/func_ov006_020dcc48.c
@@ -1,0 +1,20 @@
+/* func_ov006_020dcc48 at 0x020dcc48
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern int data_ov006_021341ec;
+extern int data_ov006_0212e364[];
+extern void func_ov004_020b0380(int a, int b, int c, int d);
+
+void func_ov006_020dcc48(void) {
+    int i;
+    int s, v, j;
+    for (i = 0; i < 3; i++) {
+        v = data_ov006_0212e364[i];
+        s = 0x10;
+        for (j = 0; j < 0x10; j++) {
+            func_ov004_020b0380(data_ov006_021341ec, s, v, 0);
+            s += 0x20;
+        }
+    }
+}

--- a/src/func_ov007_020c27b4.c
+++ b/src/func_ov007_020c27b4.c
@@ -1,0 +1,24 @@
+/* func_ov007_020c27b4 at 0x020c27b4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void func_ov007_020c2d44(void *a, int i);
+
+struct S {
+    int state;          // +0
+    int pad;            // +4
+    unsigned short count; // +8
+};
+
+void func_ov007_020c27b4(struct S *s)
+{
+    int i;
+    switch (s->state) {
+    case 0:
+        for (i = 0; i < s->count; i++)
+            func_ov007_020c2d44(s, i);
+        break;
+    case 1:
+        break;
+    }
+}

--- a/src/func_ov007_020c2bf8.c
+++ b/src/func_ov007_020c2bf8.c
@@ -1,0 +1,38 @@
+/* func_ov007_020c2bf8 at 0x020c2bf8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void _ZN6Player17St_EndingFly_MainEv(void *);
+
+struct S {
+    int state;        /* +0 */
+    int flags;        /* +4 */
+    int pad08;
+    int pad0c;
+    int pad10;
+    int pad14;
+    void *p18;        /* +0x18 */
+    void *p1c;        /* +0x1c */
+    void *p20;        /* +0x20 */
+    void *p24;        /* +0x24 */
+    void *p28;        /* +0x28 */
+    void *p2c;        /* +0x2c */
+};
+
+void func_ov007_020c2bf8(struct S *s)
+{
+    switch (s->state) {
+    case 0:
+        _ZN6Player17St_EndingFly_MainEv(s->p24);
+        _ZN6Player17St_EndingFly_MainEv(s->p28);
+        _ZN6Player17St_EndingFly_MainEv(s->p1c);
+        break;
+    case 1:
+        _ZN6Player17St_EndingFly_MainEv(s->p2c);
+        break;
+    }
+    _ZN6Player17St_EndingFly_MainEv(s->p18);
+    if (s->flags & 1)
+        _ZN6Player17St_EndingFly_MainEv(s->p20);
+    _ZN6Player17St_EndingFly_MainEv(s);
+}

--- a/src/func_ov007_020c4f50.c
+++ b/src/func_ov007_020c4f50.c
@@ -1,0 +1,28 @@
+/* func_ov007_020c4f50 at 0x020c4f50
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void func_ov007_020c4fcc(int r0, int r1);
+extern void func_ov007_020c19cc(int r0, int r1, int r2, int r3);
+
+struct S {
+    char pad0[8];
+    int count;       /* +8 */
+    char pad1[0x14]; /* up to 0x20 */
+    void *a;         /* +0x20 */
+    int b;           /* +0x24 */
+    int *arr;        /* +0x28 */
+    char pad2[0xc];  /* up to 0x38 */
+    void **parr;     /* +0x38 */
+};
+
+void func_ov007_020c4f50(struct S *r7, int r6, int r2, int r3)
+{
+    int i;
+    int *r4 = r7->arr;
+    func_ov007_020c4fcc(r2, r3);
+    for (i = 0; i < r7->count; i++) {
+        func_ov007_020c19cc(*(unsigned short *)((char *)r7->parr[i] + 8), r4[i], r6, 0x1000);
+    }
+    func_ov007_020c19cc(*(unsigned short *)((char *)r7->a + 8), r7->b, r6, 0x1000);
+}

--- a/src/func_ov060_02115a30.cpp
+++ b/src/func_ov060_02115a30.cpp
@@ -1,0 +1,17 @@
+//cpp
+// func_ov060_02115a30 at 0x02115a30 -- matched byte-for-byte with mwccarm 1.2/sp2p3 (ov060).
+class Animation {
+public:
+    int Finished();
+    int GetFrameCount() const;
+    int WillHitFrame(int) const;
+};
+
+struct Obj {
+    char pad[0x124];
+    Animation anim;
+};
+
+extern "C" bool func_ov060_02115a30(Obj* o) {
+    return o->anim.Finished() || o->anim.WillHitFrame((unsigned short)(o->anim.GetFrameCount() - 1));
+}

--- a/src/func_ov102_0214bcc8.c
+++ b/src/func_ov102_0214bcc8.c
@@ -1,0 +1,21 @@
+/* func_ov102_0214bcc8 at 0x0214bcc8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov102).
+ */
+extern void func_ov102_0214b3b8(void *c);
+extern void func_ov102_0214c0b8(char *c);
+extern void _ZN9Animation7AdvanceEv(void *a);
+
+void func_ov102_0214bcc8(char *c) {
+    int f = *(int *)(c + 0xb0);
+    int a = (f & 0x400) ? 1 : 0;
+    if (a != 0) {
+        func_ov102_0214b3b8(c);
+    } else {
+        int b = (f & 0x100) ? 1 : 0;
+        if (b == 0) {
+            func_ov102_0214c0b8(c);
+        }
+    }
+    _ZN9Animation7AdvanceEv(c + 0x350);
+}


### PR DESCRIPTION
15 hand/agent-matched functions, each verified byte-for-byte (relocation-aware) with `tools/match.py` across the mwccarm 1.2 trio (base/sp2/sp2p3). Plus a `notes/mwccarm-codegen.md` entry documenting a shape wall.

**arm9 (7):** `func_0206a37c`, `func_02052208`, `func_02010304`, `func_0204ff48`, `func_0205ae64`, `func_0204f9c4`, `func_020421b4` — guard/forward chains, a guarded grab, a signed-bit guard, retry loops, and a table callback.

**overlays (8):** `func_ov002_020d4d88` (ApproachLinear + OR-guard), `func_ov006_020ced84` / `func_ov006_020dcc48` (counted loops over strided arrays), `func_ov007_020c27b4` (switch + loop), `func_ov007_020c2bf8` (state machine), `func_ov007_020c4f50` (forward + counted loop), `func_ov060_02115a30` (Animation `||` short-circuit), `func_ov102_0214bcc8` (bit-flag dispatch).

**notes:** documents the materialized-flag-RMW wall — a cluster of flag setters (`BgCh::Start/StopDetecting*` at `this+4`; the `obj+0x154` int-flag family) that the straightforward C always folds to a tighter form the ROM doesn't use; not reproducible across 6 idioms × 11 versions × 7 opt levels. Recorded so nobody re-grinds it from C.

Still mostly Claude-driven with me (an active decomp learner) in the loop — happy to adjust anything that's off-base or that collides with your unpushed work.