### PR TITLE
Add opt-in relocation-destination check to the verify path

### DIFF
--- a/notes/reloc-verification-gap.md
+++ b/notes/reloc-verification-gap.md
@@ -1,0 +1,167 @@
+# Relocation-destination verification gap
+
+**Status:** measured, fix prototyped (opt-in). Decision needed on rollout.
+**Tools:** `tools/reloc_audit.py` (measurement), `tools/match.py --strict-relocs` (gate fix).
+
+## TL;DR
+
+The match gate wildcards every relocated word without checking *where* the
+relocation points, so a function can be banked as "matched" while its source
+calls the wrong callee or reads the wrong global. I built an audit that checks
+every banked match's reloc destinations against `config/**/relocs.txt`.
+
+Corpus result (6,316 banked matches, all of which still reproduce):
+
+| verdict | count | meaning |
+|---|---:|---|
+| CLEAN | 4,472 | every reloc destination verified correct |
+| UNRESOLVED | 1,701 | source uses invented names; **destination unverifiable by any static tool** |
+| WRONG-DEST | 107 | candidate relocation points at a different address than config |
+| EXTRA | 28 | candidate relocates a word config does not |
+| MISSING | 8 | config relocates a word the candidate does not |
+
+Of the 107 WRONG-DEST, after filtering byte-identical duplicates and
+interworking veneers (both behaviorally harmless), **83 are genuine concerns**
+(68 of them same-module, high-confidence). That's ~1.8% of the 4,625 matches
+whose destinations are checkable, ~1.3% of the corpus.
+
+**The reviewer's theoretical gap is real and confirmed. The empirical blast
+radius is moderate (tens of genuinely-wrong matches), not catastrophic — but it
+is unmeasurable by the existing gate, and 1,701 matches sit in a permanent blind
+spot that only a link-based check could close.**
+
+## The gap
+
+`tools/match.py:compare()` (the core verifier, also used by
+`tools/reverify_corpus.py:97`) compares the candidate object to the ROM
+word-by-word, but at every offset where the *candidate* emitted a relocation it
+forces `match = True`:
+
+```python
+if i in relocs:           # match.py:102
+    match = True          # wildcard — destination never examined
+```
+
+`extract_func()` (`match.py:84-87`) keeps only the word offset and throws away
+the relocation's target symbol, kind, and module. Neither `match.py` nor
+`reverify_corpus.py` ever reads `config/**/relocs.txt`. So the gate cannot tell
+`bl correct_fn` from `bl wrong_fn`: both are zero-filled + relocated in the
+unlinked object, both get wildcarded.
+
+The wildcard itself is *necessary* — the object is unlinked, so the slot is
+genuinely zero and can't be byte-compared. The bug is that nothing checks the
+destination by another route, even though the route exists: `tools/relocs.py`
+already has a module-aware `(module, addr)` resolver and is used by
+`clone/swarm/sweep/triage`, just never by the verifier.
+
+## What the audit does
+
+For each banked match `tools/reloc_audit.py`:
+
+1. Recompiles the committed source exactly as reverify does and grabs the object
+   that reproduces the ROM bytes.
+2. Reads each relocation the object emits inside the function → target symbol →
+   resolved destination address (from `func_<addr>` names, or the symbol index).
+3. Looks up the ground-truth relocation at the same source address in
+   `config/<module>/relocs.txt` (module-aware, via `relocs.py`).
+4. Compares destination addresses and buckets the result.
+
+It changes nothing in the match path. Run it:
+
+```
+python tools/reloc_audit.py                 # whole corpus (~50s)
+python tools/reloc_audit.py --module ov006
+python tools/reloc_audit.py --json out.json # full per-reloc detail
+```
+
+The audit was validated three ways: it reports CLEAN on a hand-traced
+known-good function, it catches a deliberately corrupted config destination
+(`WRONG-DEST`), and it buckets a deleted config reloc as `EXTRA`.
+
+## Accuracy — what this can and cannot see
+
+This section matters as much as the numbers; the audit has real limits and an
+earlier revision was wrong.
+
+**Confirmed-real examples (hand-verified):**
+- `func_02007fcc` calls `ReadUnalignedInt` (`0x0200e748`); ROM relocates to
+  `0x0200e728`. The two are *byte-identical duplicates*, so this one is benign —
+  the source comment even names the correct address. Classified **twin**.
+- `_ZN8CapEnemyD2Ev` calls `_ZN5EnemyD2Ev` (`0x020aed74`); ROM relocates to
+  `0x020aed18`, a *different* destructor variant (bytes differ by the inner BL).
+  Genuine wrong-target. Classified **genuine**.
+
+**Three things the audit deliberately does NOT count as problems:**
+- **twin** — candidate and config addresses hold byte-identical code (duplicate
+  function). Behaviorally identical. 24 of the 107.
+- **veneer** — config's target is a 12-byte ARM/Thumb interworking trampoline
+  (`LDR ip,[pc]; BX ip; .word real`) that jumps to the address the source names.
+  The source is correct; the linker inserts the veneer. Common for
+  `operator delete` (`_ZdlPv`).
+- **UNRESOLVED (1,701)** — the source declares the target with an *invented*
+  name (`someFunc`, `ApproachLinear`, `CAM_DEF_A`, `Camera_vtable`, …) that
+  isn't in `symbols.txt` and encodes no address. No static tool can verify these
+  — not the gate, not reverify, not this audit. They are the true residual blind
+  spot; only linking the object and comparing linked bytes would cover them.
+
+**The correction worth flagging:** an earlier version of the audit also emitted a
+`WRONG-MODULE` verdict (~110 matches) when a candidate's address matched config
+but the *overlay module* of the symbol's name differed. Those proved to be
+almost entirely **name-aliasing noise** — e.g. a C++ name like `_ZN5EnemyC2Ev`
+is defined only in ov007, but an ov002 function legitimately relocates to the
+same address in ov002's own image. The candidate pins an *address*, not a
+module; when the address matches config, there is no observable error. That
+verdict was removed (`reloc_audit.py:classify`). A genuine wrong-overlay target
+still surfaces — as a `WRONG-DEST` address mismatch, not a same-address module
+disagreement. **Net effect: the honest headline is 83 genuine concerns, not the
+~180 an over-eager classifier would report.**
+
+So treat the numbers as: 83 credible (68 high-confidence same-module), 1,701
+unverifiable, the rest clean. The genuine cases cluster on two C++ ABI hazards —
+destructor variants (D0/D1/D2) and `operator delete` — plus a tail of wrong-data
+and wrong-callee references in `func_*` source.
+
+## The fix (prototyped, opt-in)
+
+`tools/match.py --strict-relocs` adds destination verification on top of the
+byte compare, reusing the audit's checker (`reloc_audit.check_destinations`).
+When the bytes match but a reloc points at the wrong address, the match is
+rejected:
+
+```
+$ python tools/match.py --c src/func_02013a88.c --func func_02013a88 \
+      --addr 0x02013a88 --size 0x4c --module arm9 --strict-relocs --brief
+  1.2/sp2p3: bytes match but 1 reloc destination(s) WRONG -- not a real match
+MATCHING VERSIONS: none
+```
+
+A clean function still reports MATCH. Default behavior is unchanged unless
+`--strict-relocs` is passed.
+
+**What it covers:** every reloc whose candidate target resolves to an address
+(canonical names and `func_<addr>`/`data_<addr>` names) — the same set the audit
+can see (CLEAN covers 4,472 of 6,316 matches fully).
+**What it does NOT cover:** the UNRESOLVED invented-name slots. Closing those
+needs the heavier fix below.
+
+**The complete fix** (not built): link the candidate object against the module's
+symbol table and compare *linked* bytes to the ROM. That checks every
+destination including invented names, models veneers correctly, and removes the
+wildcard entirely. It's a bigger change (needs a linker step / address binding
+for the local symbol set) and is the right long-term direction if false matches
+are deemed worth eliminating wholesale.
+
+## Recommendation
+
+1. **Adopt `--strict-relocs` in reverify** as a reporting pass first (don't
+   relabel the ledger yet): run the audit, review the 83 genuine cases, fix or
+   re-bank them. Several are likely quick (wrong destructor variant, off-by-one
+   data symbol).
+2. **Decide on the 1,701 UNRESOLVED.** They are matches whose correctness rests
+   entirely on the author having declared the right thing, with zero automated
+   check. If byte-exact link reproduction is a project goal, the link-based fix
+   is the only thing that closes this.
+3. Relative to the other two review items: the progress-ledger and
+   `ingest_batch` issues are hygiene/dead-code; **this is the one that affects
+   whether the headline match count can be trusted.** The measurement now exists
+   — the open question is policy, not detection.

--- a/tools/match.py
+++ b/tools/match.py
@@ -133,7 +133,19 @@ def main():
                     help="override target binary (e.g. an overlay) instead of arm9_dec.bin")
     ap.add_argument("--base", default=None, type=lambda x: int(x, 0),
                     help="load address of --bin (required with --bin)")
+    ap.add_argument("--strict-relocs", action="store_true",
+                    help="beyond the byte compare, verify each reloc slot points at the "
+                         "destination config/<module>/relocs.txt records (catches wrong "
+                         "callee/global the wildcard would otherwise hide)")
+    ap.add_argument("--module", default="arm9",
+                    help="module name for --strict-relocs config lookup (arm9, ov006, ...)")
     args = ap.parse_args()
+
+    strict = None
+    if args.strict_relocs:
+        import reloc_audit as RA
+        import relocs as RL
+        strict = (RA, RA.build_name_index(), RA.build_config_relocs(), RL.load_all_syms())
 
     cfile = pathlib.Path(args.c)
     if args.bin:
@@ -166,6 +178,18 @@ def main():
         if not args.brief:
             print(f"\n=== mwccarm {v} ===")
         ok, ndiff = compare(tgt, code, relocs, verbose=not args.brief)
+        if ok and strict is not None:
+            RA, name_index, config_relocs, sym_index = strict
+            rows, missing = RA.check_destinations(obj, args.func, args.addr, args.size,
+                                                  args.module, name_index, config_relocs, sym_index)
+            bad = [r for r in (rows or []) if r["verdict"] == "WRONG-DEST"]
+            if bad:
+                ok = False
+                print(f"  {v}: bytes match but {len(bad)} reloc destination(s) WRONG -- "
+                      f"not a real match:")
+                for r in bad:
+                    print(f"      {r['off']:6} cand {r['cand']} ({r['cand_addr']}) "
+                          f"!= config {r['cfg']}")
         if ok:
             matched.append(v)
             if args.brief:

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -1,0 +1,308 @@
+"""Audit relocation-destination identity for every banked match.
+
+WHY THIS EXISTS
+---------------
+The match gate (tools/match.py:compare) wildcards every word that the *candidate*
+object relocates: at those offsets it forces ``match = True`` without checking
+where the relocation points. reverify_corpus.py inherits the same compare, so the
+whole corpus is verified with that blind spot. A candidate can therefore compile
+to identical instruction bytes and place a relocation at the right word offset
+while pointing it at the WRONG callee / global / overlay, and still "pass".
+
+This tool measures how often that actually happens. For each banked match it:
+  1. Recompiles the committed source the same way reverify does and grabs the
+     exact object that reproduces the ROM bytes.
+  2. Reads each relocation the object emits inside the function: word offset +
+     target symbol -> resolved destination (module, addr).
+  3. Looks up the ground-truth relocation at that same source address in the
+     checked-in config/**/relocs.txt (module-aware, via tools/relocs.py).
+  4. Compares destinations and buckets the result.
+
+It changes NOTHING in the match path; it only reports. See the buckets in
+classify() for exactly what is and isn't treated as a problem, and read
+"ACCURACY / WHAT THIS CANNOT SEE" at the bottom before trusting the headline.
+
+Usage:
+  python tools/reloc_audit.py                      # whole corpus (slow)
+  python tools/reloc_audit.py --module arm9        # one module
+  python tools/reloc_audit.py --module ov006 -j 8
+  python tools/reloc_audit.py --limit 200          # first N entries (quick sample)
+  python tools/reloc_audit.py --json out.json      # machine-readable detail
+"""
+import argparse
+import io
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+from elftools.elf.elffile import ELFFile
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import match as M          # noqa: E402
+import relocs as R         # noqa: E402
+# reverify_corpus is imported lazily inside winning_object(): it pulls in the ROM
+# and compile harness, and importing it at top level would create a cycle for
+# gate code (match/reverify) that wants only the pure checker below.
+
+# func_0202e78c  or  func_ov006_020bf1a0  -> capture (overlay_id_or_None, addr)
+_FUNC_RE = re.compile(r"func_(?:ov(\d+)_)?([0-9a-fA-F]{8})\b")
+
+
+def build_name_index():
+    """name -> (module, addr) from every checked-in symbols.txt.
+
+    Names are not globally unique (overlays reuse them), so this is a best-effort
+    fallback used only for symbols whose address is NOT encoded in the name."""
+    idx = {}
+    for module, path in R.iter_symbol_files(include_itcm_dtcm=True):
+        for (mod_addr), name in R.load_syms_file(path, module).items():
+            mod, addr = mod_addr
+            idx.setdefault(name, (mod, addr))
+    return idx
+
+
+def build_config_relocs():
+    """{module: {from_addr: (kind, to_addr, to_module)}} for every relocs.txt."""
+    out = {}
+    for module, path in R.iter_reloc_files(include_itcm_dtcm=True):
+        out.setdefault(module, {}).update(R.load_relocs_file(path))
+    return out
+
+
+def resolve_candidate(symname, name_index):
+    """Destination (module_or_None, addr) the candidate symbol refers to, or None.
+
+    Prefer the address encoded in func_<addr> / func_ov<NN>_<addr> names (these are
+    unambiguous and module-bearing); fall back to the symbols.txt name index."""
+    m = _FUNC_RE.fullmatch(symname) or _FUNC_RE.match(symname)
+    if m:
+        mod = f"ov{int(m.group(1)):03d}" if m.group(1) is not None else None
+        return (mod, int(m.group(2), 16))
+    if symname in name_index:
+        mod, addr = name_index[symname]
+        return (mod, addr)
+    return None
+
+
+def object_reloc_dests(obj, func, name_index):
+    """[(offset, symname, resolved_module, resolved_addr)] for relocs inside func.
+
+    Returns (None, reason) if the function symbol isn't in the object."""
+    elf = ELFFile(io.BytesIO(obj))
+    symtab = elf.get_section_by_name(".symtab")
+    syms = list(symtab.iter_symbols())
+    sym = next((s for s in syms if s.name == func), None)
+    if sym is None:
+        return None, "func-not-in-obj"
+    sec = elf.get_section(sym["st_shndx"])
+    start, size = sym["st_value"], sym["st_size"]
+    rel = elf.get_section_by_name(".rel" + sec.name) or elf.get_section_by_name(".rela" + sec.name)
+    dests = []
+    if rel is not None:
+        for r in rel.iter_relocations():
+            o = r["r_offset"] - start
+            if not (0 <= o < size):
+                continue
+            tsym = syms[r["r_info_sym"]]
+            res = resolve_candidate(tsym.name, name_index)
+            mod, addr = (res if res else (None, None))
+            dests.append((o & ~3, tsym.name, mod, addr))
+    return dests, size
+
+
+def winning_object(name, addr, size, mod):
+    """Reproduce the match the way reverify does, but return the object that did it.
+
+    Mirrors reverify_corpus.compiles_to so the audit measures exactly what reverify
+    blesses -- same sources, same version sweep, same any-symbol acceptance."""
+    import reverify_corpus as RV
+    import swarm as S
+    target = RV.rom_bytes(mod, addr, size)
+    if target is None:
+        return None, None, "no-module-bin"
+    for src in RV.src_texts(name, addr):
+        attempts = ([(S.CPP_FLAGS, ".cpp")] if src.startswith("//cpp")
+                    else [(M.DEFAULT_FLAGS, ".c"), (S.CPP_FLAGS, ".cpp")])
+        for flags, suf in attempts:
+            fd, tmp = tempfile.mkstemp(suffix=suf)
+            os.close(fd)
+            pathlib.Path(tmp).write_text(src)
+            try:
+                for v in RV.ALL_VERSIONS:
+                    obj = M.compile_c(pathlib.Path(tmp), v, flags)
+                    if obj is None:
+                        continue
+                    import probe_versions as PV
+                    try:
+                        candidate_syms = list(PV.funcs_in(obj).keys())
+                    except Exception:
+                        candidate_syms = [name]
+                    if name not in candidate_syms:
+                        candidate_syms = [name] + candidate_syms
+                    for sym in candidate_syms:
+                        code, relocs = M.extract_func(obj, sym)
+                        if code is None or len(code) != len(target):
+                            continue
+                        ok, _ = M.compare(target, code, relocs, verbose=False)
+                        if ok:
+                            return obj, sym, None
+            finally:
+                pathlib.Path(tmp).unlink(missing_ok=True)
+    return None, None, "no-repro"
+
+
+def classify(cand_name, cand_mod, cand_addr, cfg, sym_index):
+    """One reloc's verdict. cfg is (kind, to_addr, to_module) or None.
+
+    The only thing a candidate relocation actually pins is a DESTINATION ADDRESS
+    (encoded in a func_<addr> name, or via a named symbol's definition). So the
+    verdict is address-anchored against config's ground-truth ``to_addr``:
+
+    OK            candidate targets config's destination address (or, by name, the
+                  exact symbol config records there)
+    WRONG-DEST    candidate targets a different address than config     <-- the bug
+    EXTRA         candidate relocates a word config does not  (wildcard hides it)
+    UNRESOLVED    candidate's destination address couldn't be determined
+
+    NOTE on overlay modules: a C++ name like _ZN5EnemyC2Ev may be DEFINED in only
+    one overlay yet legitimately referenced from another that maps a different
+    function to the same address. When the candidate's address equals config's
+    address we treat it as OK -- the address is correct and the module label of a
+    name is not authoritative. A *genuine* wrong-overlay target therefore surfaces
+    as an address mismatch (WRONG-DEST), not a same-address module disagreement.
+    Earlier revisions emitted a WRONG-MODULE verdict here; it proved to be almost
+    entirely name-aliasing noise, so it was removed.
+    """
+    if cfg is None:
+        return "EXTRA"
+    _kind, to_addr, _to_module = cfg
+    cfg_mod = R.normalize_module(_to_module)
+    expected_name = sym_index.get((cfg_mod, to_addr))
+    if expected_name is not None and cand_name == expected_name:
+        return "OK"
+    if cand_addr is None:
+        return "UNRESOLVED"
+    if cand_addr == to_addr:
+        return "OK"
+    return "WRONG-DEST"
+
+
+def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym_index):
+    """Per-reloc destination verdicts for an in-hand object. Shared by the audit
+    and the match gate (match.py --strict-relocs).
+
+    Returns (rows, missing) where rows is a list of dicts (one per object reloc in
+    the function) and missing is the count of config relocs the candidate lacks.
+    Returns (None, reason) if the function symbol isn't in the object."""
+    dests, size_or_reason = object_reloc_dests(obj, sym, name_index)
+    if dests is None:
+        return None, size_or_reason
+    cfgmap = config_relocs.get(R.normalize_module(mod), {})
+    cand_offsets = {o for o, *_ in dests}
+    rows = []
+    for o, symname, cmod, caddr in dests:
+        cfg = cfgmap.get(addr + o)
+        v = classify(symname, cmod, caddr, cfg, sym_index)
+        rows.append({"off": f"+0x{o:x}", "cand": symname,
+                     "cand_addr": (f"0x{caddr:08x}" if caddr is not None else None),
+                     "cfg": (f"0x{cfg[1]:08x}:{cfg[2]}" if cfg else None),
+                     "verdict": v})
+    # config relocs inside the function that the candidate does NOT relocate:
+    # those words were NOT wildcarded, so the byte compare already had to match
+    # them literally -- lower risk, but report for completeness.
+    missing = sum(1 for from_addr in cfgmap
+                  if addr <= from_addr < addr + size and (from_addr - addr) not in cand_offsets)
+    return rows, missing
+
+
+def audit_entry(entry, name_index, config_relocs, sym_index):
+    name = entry["name"]
+    addr = int(entry["addr"], 16) if isinstance(entry["addr"], str) else entry["addr"]
+    size = entry["size"]
+    mod = entry["module"]
+    obj, sym, err = winning_object(name, addr, size, mod)
+    if obj is None:
+        return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
+                "verdict": "NO-REPRO", "reason": err, "relocs": []}
+    rows, missing = check_destinations(obj, sym, addr, size, mod,
+                                       name_index, config_relocs, sym_index)
+    if rows is None:
+        return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
+                "verdict": "NO-SYM", "reason": missing, "relocs": []}
+    worst = _worst([r["verdict"] for r in rows], missing)
+    return {"name": name, "module": mod, "addr": f"0x{addr:08x}",
+            "verdict": worst, "missing_config_relocs": missing, "relocs": rows}
+
+
+_ORDER = ["WRONG-DEST", "EXTRA", "UNRESOLVED", "OK"]
+
+
+def _worst(verdicts, missing):
+    for v in _ORDER:
+        if v in verdicts:
+            if v == "OK":
+                return "MISSING" if missing else "CLEAN"
+            return v
+    return "MISSING" if missing else "CLEAN"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--module", default=None, help="audit one module (e.g. arm9, ov006)")
+    ap.add_argument("--limit", type=int, default=None, help="first N entries only (quick sample)")
+    ap.add_argument("-j", "--jobs", type=int, default=8)
+    ap.add_argument("--json", default=None, help="write full per-reloc detail here")
+    args = ap.parse_args()
+
+    name_index = build_name_index()
+    config_relocs = build_config_relocs()
+    sym_index = R.load_all_syms()
+
+    entries = [json.loads(l) for l in (REPO / "progress" / "matched.jsonl").read_text().splitlines() if l.strip()]
+    if args.module:
+        entries = [e for e in entries if e["module"] == args.module]
+    if args.limit:
+        entries = entries[:args.limit]
+    print(f"auditing {len(entries)} banked matches with {args.jobs} workers ...", flush=True)
+
+    results = []
+    done = 0
+    with ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        futs = [ex.submit(audit_entry, e, name_index, config_relocs, sym_index) for e in entries]
+        for f in futs:
+            results.append(f.result())
+            done += 1
+            if done % 250 == 0:
+                print(f"  {done}/{len(entries)}", flush=True)
+
+    cat = Counter(r["verdict"] for r in results)
+    print("\n=== reloc-destination audit ===")
+    for k in ["CLEAN", "MISSING", "UNRESOLVED", "EXTRA", "WRONG-DEST",
+              "NO-REPRO", "NO-SYM"]:
+        if cat.get(k):
+            print(f"  {k:13} {cat[k]}")
+
+    flagged = [r for r in results if r["verdict"] == "WRONG-DEST"]
+    if flagged:
+        print(f"\n--- {len(flagged)} matches with a wrong relocation destination ---")
+        for r in flagged[:40]:
+            print(f"\n{r['module']:7} {r['addr']} {r['name']}")
+            for row in r["relocs"]:
+                if row["verdict"] == "WRONG-DEST":
+                    print(f"    {row['off']:6} cand {row['cand']} ({row['cand_addr']}) "
+                          f"!= config {row['cfg']}")
+
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(results, indent=1))
+        print(f"\nfull detail -> {args.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #46.

The verify path wildcards relocated words without checking their destination, so a match can reverify as passing while pointing at the wrong callee/global. This adds:

- **`match.py --strict-relocs`** — opt-in; after the byte compare, verifies each reloc slot points where `config/<module>/relocs.txt` says. Default behavior unchanged.
- **`tools/reloc_audit.py`** — measures the gap across the whole corpus.
- **`notes/reloc-verification-gap.md`** — method, results (4,472 clean / 1,701 unverifiable / ~83 genuine wrong-dest), and accuracy caveats (including an over-eager earlier verdict I caught and removed).

The note carries the detail and a couple of hand-verified examples, to keep this description short. Happy to take just the `--strict-relocs` change or split the tooling out — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)