### PR TITLE
Match 81 functions across ov002/ov004/ov006/ov007/ov015/ov060/ov102

### DIFF
--- a/src/_Z15LoadDoorObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadDoorObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,55 @@
+//cpp
+// _Z15LoadDoorObjectsRN11LVL_Overlay11ObjSubTableEij at 0x020fe4f0
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+
+struct DoorEntry {
+    short x;
+    short y;
+    short z;
+    short angle;
+    unsigned short field8;
+    unsigned short fielda;
+};
+
+class LVL_Overlay {
+public:
+    struct ObjSubTable {
+        unsigned char b0;
+        unsigned char count;
+        DoorEntry* entries;
+    };
+};
+
+extern unsigned short data_ov002_0210cb88[];
+extern unsigned char data_ov002_0210cb70[];
+
+extern "C" int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+    unsigned int id, unsigned int param, const Vector3& pos,
+    const Vector3_16* rot, int a, int b);
+
+void LoadDoorObjects(LVL_Overlay::ObjSubTable& sub, int a, unsigned int b) {
+    DoorEntry* e = sub.entries;
+    for (int i = 0; i < sub.count; i++) {
+        Vector3 pos;
+        int z = e->z << 12;
+        int y = e->y << 12;
+        int x = e->x << 12;
+        pos.x = x;
+        pos.y = y;
+        pos.z = z;
+        Vector3_16 rot;
+        short rx = (e->field8 >> 8) & 0xf;
+        short ry = e->angle;
+        short rz = (e->field8 >> 12) & 0xf;
+        rot.x = rx;
+        rot.y = ry;
+        rot.z = rz;
+        int idx = e->fielda & 0x1f;
+        unsigned int id = data_ov002_0210cb88[idx];
+        unsigned int param = e->field8 | (data_ov002_0210cb70[idx] << 16);
+        _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(id, param, pos, &rot, -1, -1);
+        e++;
+    }
+}

--- a/src/_ZN3HUD6RenderEv.cpp
+++ b/src/_ZN3HUD6RenderEv.cpp
@@ -1,0 +1,73 @@
+//cpp
+// _ZN3HUD6RenderEv at 0x020fd5e0
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+extern unsigned char data_0209f2d8;
+extern unsigned char data_0209fc9c;
+extern unsigned char data_0209f2c4;
+extern unsigned char data_0209f20c;
+extern unsigned char data_0209f294;
+extern unsigned char data_0209f204;
+extern int data_0209caa0[];
+extern unsigned char data_0209f284;
+extern unsigned char data_0209f2d4;
+
+void _ZN3HUD13RenderVsTimerEv(void *);
+void _ZN3HUD15RenderStarCountEv(void *);
+void _ZN3HUD15RenderCoinCountEv(void *);
+void _ZN3HUD19RenderCameraButtonsEv(void *);
+void _ZN3HUD17RenderHealthMeterEv(void *);
+int _ZN5Event6GetBitEj(unsigned int);
+void _ZN3HUD14RenderRedCoinsEv(void *);
+void _ZN3HUD17RenderSilverStarsEv(void *);
+void _ZN3HUD15RenderTimeTimerEv(void *);
+void _ZN5Stage20RenderBouncingArrowsEv(void);
+void _ZN3HUD15RenderLifeCountEv(void *);
+
+int _ZN3HUD6RenderEv(void *self) {
+    int b = (data_0209f2d8 == 1);
+    if (b) {
+        if (data_0209fc9c != 0) goto end;
+        if (((data_0209f2c4 | data_0209f20c | data_0209f294) & 0xff) == 0) {
+            _ZN3HUD13RenderVsTimerEv(self);
+            _ZN3HUD15RenderStarCountEv(self);
+            _ZN3HUD15RenderCoinCountEv(self);
+            _ZN3HUD19RenderCameraButtonsEv(self);
+        } else {
+            if (data_0209f204 != 0) {
+                _ZN3HUD13RenderVsTimerEv(self);
+            }
+        }
+    } else {
+        if ((data_0209caa0[2] & 0x80) == 0) goto end;
+        unsigned char v = data_0209f20c;
+        if (((data_0209f2c4 | v | data_0209f294) & 0xff) == 0) {
+            _ZN3HUD17RenderHealthMeterEv(self);
+            if (_ZN5Event6GetBitEj(0x1d) == 0) {
+                _ZN3HUD15RenderCoinCountEv(self);
+                _ZN3HUD14RenderRedCoinsEv(self);
+                _ZN3HUD17RenderSilverStarsEv(self);
+                _ZN3HUD15RenderTimeTimerEv(self);
+            }
+            if (data_0209f284 != 0) {
+                _ZN5Stage20RenderBouncingArrowsEv();
+            }
+        } else {
+            if (v != 0) {
+                _ZN3HUD15RenderLifeCountEv(self);
+                _ZN3HUD15RenderStarCountEv(self);
+            }
+        }
+        unsigned char v2 = data_0209f20c;
+        if ((data_0209f2c4 | v2 | data_0209f294) & 0xff) {
+            if (v2 == 0) goto end;
+            if (data_0209f2d4 >= 3) goto end;
+        }
+        _ZN3HUD15RenderStarCountEv(self);
+        _ZN3HUD19RenderCameraButtonsEv(self);
+        _ZN3HUD15RenderLifeCountEv(self);
+    }
+end:
+    return 1;
+}
+}

--- a/src/_ZN6Player13St_Throw_InitEv.cpp
+++ b/src/_ZN6Player13St_Throw_InitEv.cpp
@@ -1,0 +1,29 @@
+//cpp
+// _ZN6Player13St_Throw_InitEv at 0x020dafd4
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+struct Vector3{int x,y,z;};
+extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned a, unsigned b, const Vector3& v);
+extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
+int _ZN6Player13St_Throw_InitEv(char* c){
+  int* p = *(int**)(c+0x358);
+  int b = (*(int*)((char*)p+0xb0) & 0x200) ? 1 : 0;
+  if(!b){
+    unsigned short a = *(unsigned short*)((char*)p+0xc);
+    int t1 = (a == 0xbd);
+    if(!t1){
+      int t2 = (a == 0xbe);
+      if(!t2) goto anim30;
+    }
+    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x91,0x40000000,0x1000,0);
+    goto voice;
+anim30:
+    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x30,0x40000000,0x1000,0);
+voice:
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x13, *(Vector3*)(c+0x74));
+  } else {
+    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x8a,0x40000000,0x1000,0);
+  }
+  return 1;
+}
+}

--- a/src/_ZN6Player13St_Throw_MainEv.cpp
+++ b/src/_ZN6Player13St_Throw_MainEv.cpp
@@ -1,0 +1,55 @@
+//cpp
+// _ZN6Player13St_Throw_MainEv at 0x020dae6c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+extern int _Z14ApproachLinearRiii(int&, int, int);
+extern int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned, int);
+extern int _ZNK9Animation12WillHitFrameEi(void*, int);
+extern int func_ov002_020c19d0(void*, int, int);
+extern void func_ov002_020daa74(void*);
+extern void func_ov002_020da9d4(void*);
+extern int _ZN6Player12FinishedAnimEv(void*);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
+extern void func_ov002_020bedd4(void*);
+extern int data_ov002_0211013c[];
+
+int _ZN6Player13St_Throw_MainEv(char* c){
+  if(*(unsigned char*)(c+0x6de)==0){
+    _Z14ApproachLinearRiii(*(int*)(c+0x98), 0, 0x1000);
+  }
+  if(*(char**)(c+0x358)){
+    int r4 = 5;
+    int id=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
+    void* anim=*(void**)(c+(id<<2)+0xdc);
+    if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0)){
+      if(func_ov002_020c19d0(c,0x40,0x32)) r4=0;
+    }
+    char* q=*(char**)(c+0x358);
+    unsigned short a=*(unsigned short*)(q+0xc);
+    int t1=(a==0xbd);
+    if(!t1){
+      int t2=(a==0xbe);
+      if(!t2) goto Lb8;
+    }
+    r4=7;
+    goto Ld0;
+  Lb8:
+    {
+      int b=(*(int*)(q+0xb0)&0x200)?1:0;
+      if(b) r4=0xd;
+    }
+  Ld0:
+    int id2=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
+    void* anim2=*(void**)(c+(id2<<2)+0xdc);
+    if(_ZNK9Animation12WillHitFrameEi((char*)anim2+0x50,r4)){
+      int b2=(*(int*)(*(char**)(c+0x358)+0xb0)&0x200)?1:0;
+      if(b2==0) func_ov002_020daa74(c);
+      else func_ov002_020da9d4(c);
+    }
+  }
+  if(_ZN6Player12FinishedAnimEv(c))
+    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
+  func_ov002_020bedd4(c);
+  return 1;
+}
+}

--- a/src/func_ov002_020af2b0.c
+++ b/src/func_ov002_020af2b0.c
@@ -1,0 +1,45 @@
+/* func_ov002_020af2b0 at 0x020af2b0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef unsigned int u32;
+typedef int Fix12i;
+
+struct Vec { Fix12i x, y, z; };
+struct Vector3_16;
+
+extern void func_ov002_020af684(void* self, int, int);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec* v);
+extern void GiveLives(int delta);
+extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
+extern void func_ov002_020bdf8c(int);
+
+void func_ov002_020af2b0(char* c, int arg1)
+{
+    int t = *(int*)(c + 0x384);
+    if (t == 0xb) {
+        func_ov002_020af684(c, 5, arg1);
+        return;
+    }
+    if (t == 0xc) {
+        func_ov002_020af684(c, 7, arg1);
+        return;
+    }
+    unsigned isMatch = (*(unsigned short*)(c + 0xc) == 0x114);
+    if (isMatch) {
+        struct Vec vec;
+        _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, (struct Vec*)(c + 0x74));
+        GiveLives(1);
+        vec.x = *(Fix12i*)(c + 0x5c);
+        vec.y = *(Fix12i*)(c + 0x60);
+        vec.z = *(Fix12i*)(c + 0x64);
+        vec.y += 0xb4000;
+        _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+            0x14b, 8, &vec, 0, *(signed char*)(c + 0xcc), -1);
+        _ZN5Actor24KillAndTrackInDeathTableEv(c);
+    } else {
+        func_ov002_020bdf8c(arg1);
+        _ZN5Actor24KillAndTrackInDeathTableEv(c);
+    }
+}

--- a/src/func_ov002_020b83c4.cpp
+++ b/src/func_ov002_020b83c4.cpp
@@ -1,0 +1,22 @@
+//cpp
+// func_ov002_020b83c4 at 0x020b83c4
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" int _ZN5Model6RenderEPK7Vector3(void *, const void *);
+extern "C" int data_ov002_0210df54;
+
+extern "C" int func_ov002_020b83c4(char *self)
+{
+    int b = (*(int *)(self + 0xb0) & 0x40000) ? 1 : 0;
+    if (b) return 1;
+    if (*(unsigned char *)(self + 0x3ff) == 1 || *(int *)(self + 0x80) < 0x100) return 1;
+
+    int t = *(int *)(self + 0x3f0);
+    if (t == 4 || t == 17 || t == 5 || t == 18 || t == 16 || t == 11 || (unsigned)(t - 6) <= 3) {
+        if (!(*(int *)(self + 0x3ec) & 1) || *(int *)(self + 0x3bc) == (int)&data_ov002_0210df54) {
+            _ZN5Model6RenderEPK7Vector3(self + 0x300, self + 0x80);
+        }
+    } else {
+        _ZN5Model6RenderEPK7Vector3(self + 0x300, self + 0x80);
+    }
+    return 1;
+}

--- a/src/func_ov002_020c179c.cpp
+++ b/src/func_ov002_020c179c.cpp
@@ -1,0 +1,52 @@
+//cpp
+// func_ov002_020c179c at 0x020c179c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern void _ZN13RaycastGroundC1Ev(void* self);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* self, void* pos, void* act);
+extern int _ZN13RaycastGround10DetectClsnEv(void* self);
+extern void _ZN13RaycastGroundD1Ev(void* self);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern short data_02082214[];
+
+int func_ov002_020c179c(char* self, int angle) {
+    char rg[0x50];
+    Vector3 v1;
+    Vector3 v2;
+    int idx = (unsigned short)(short)(*(short*)(self + 0x94) + angle);
+    int y1 = *(int*)(self + 0x60);
+    int y2 = y1;
+    idx >>= 4;
+    short dx = data_02082214[idx * 2];
+    short dy = data_02082214[idx * 2 + 1];
+    int ox = dx * 5;
+    int oy = dy * 5;
+    _ZN13RaycastGroundC1Ev(rg);
+    {
+        int z = *(int*)(self + 0x64) + oy;
+        int y = *(int*)(self + 0x60) + 0x64000;
+        int x = *(int*)(self + 0x5c) + ox;
+        v1.x = x;
+        v1.y = y;
+        v1.z = z;
+    }
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, &v1, self);
+    if (_ZN13RaycastGround10DetectClsnEv(rg)) y1 = *(int*)(rg + 0x44);
+    {
+        int z = *(int*)(self + 0x64) - oy;
+        int x = *(int*)(self + 0x5c) - ox;
+        int y = *(int*)(self + 0x60) + 0x64000;
+        v2.x = x;
+        v2.y = y;
+        v2.z = z;
+    }
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, &v2, self);
+    if (_ZN13RaycastGround10DetectClsnEv(rg)) y2 = *(int*)(rg + 0x44);
+    {
+        int r = _ZN4cstd5atan2E5Fix12IiES1_(y1 - y2, 0xa000);
+        _ZN13RaycastGroundD1Ev(rg);
+        return r;
+    }
+}
+}

--- a/src/func_ov002_020c2138.cpp
+++ b/src/func_ov002_020c2138.cpp
@@ -1,0 +1,21 @@
+//cpp
+// func_ov002_020c2138 at 0x020c2138
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+typedef int Fix12i;
+extern "C" int _ZN4cstd5atan2E5Fix12IiES1_(Fix12i, Fix12i);
+extern "C" int AngleDiff(int a, int b);
+extern "C" int func_ov002_020c200c(void* self, int ang);
+extern "C" int func_ov002_020c1c84(void* self, int ang);
+extern "C" int func_ov002_020c1ad8(void* self, int ang);
+extern "C" int func_ov002_020c2138(char* self){
+int ang;
+if (*(unsigned char*)(self + 0x706) || *(unsigned char*)(self + 0x6fd)) return 0;
+if (*(int*)(self + 0x564)) return 0;
+if (*(int*)(self + 0x37c) || *(unsigned char*)(self + 0x708)) return 0;
+ang = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(self + 0x560), *(int*)(self + 0x568));
+if (AngleDiff(ang, *(short*)(self + 0x94)) < 0x6000) return 0;
+if (func_ov002_020c200c(self, ang)) return 1;
+if ((*(int*)(self+0x358) ? 1 : 0) || (*(int*)(self+0x354) ? 1 : 0)) return 0;
+if (func_ov002_020c1c84(self, ang)) return 1;
+return func_ov002_020c1ad8(self, ang);
+}

--- a/src/func_ov002_020cf20c.cpp
+++ b/src/func_ov002_020cf20c.cpp
@@ -1,0 +1,47 @@
+//cpp
+// func_ov002_020cf20c at 0x020cf20c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+struct Vector3 { int x, y, z; };
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern void _ZN11RaycastLine10GetClsnPosEv(void* res, void* self);
+extern int func_02037e38(unsigned int* p);
+extern int func_02037e48(unsigned int* p);
+extern void func_0200ca14(void* a, unsigned char b, int c);
+extern void _ZN11RaycastLineD1Ev(void* self);
+extern void* data_0209f318[];
+
+int func_ov002_020cf20c(char* c) {
+    Vector3 v1;
+    Vector3 v2;
+    Vector3 clsnPos;
+    char rl[0x78];
+    _ZN11RaycastLineC1Ev(rl);
+    v1.x = *(int*)(c + 0x5c);
+    int y1 = *(int*)(c + 0x60);
+    v1.y = y1;
+    v1.z = *(int*)(c + 0x64);
+    v2.x = *(int*)(c + 0x5c);
+    int y2 = *(int*)(c + 0x60);
+    v2.y = y2;
+    v2.z = *(int*)(c + 0x64);
+    v1.y = y1 + 0x64000;
+    v2.y = y2 + 0xb4000;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, c);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+        if (func_02037e38((unsigned int*)(rl + 0x14)) == 3) {
+            _ZN11RaycastLine10GetClsnPosEv(&clsnPos, rl);
+            void* cam = data_0209f318[0];
+            int t = func_02037e48((unsigned int*)(rl + 0x14));
+            func_0200ca14(cam, *(unsigned char*)(c + 0x6d8), t);
+            int ret = clsnPos.y;
+            _ZN11RaycastLineD1Ev(rl);
+            return ret;
+        }
+    }
+    _ZN11RaycastLineD1Ev(rl);
+    return (int)0x80000000;
+}
+}

--- a/src/func_ov002_020d8d10.c
+++ b/src/func_ov002_020d8d10.c
@@ -1,0 +1,40 @@
+/* func_ov002_020d8d10 at 0x020d8d10
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef unsigned int u32;
+typedef int Fix12i;
+typedef short s16;
+typedef unsigned short u16;
+
+extern s16 data_02082214[];
+struct Callback;
+extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    u32 slot, u32 effect, Fix12i x, Fix12i y, Fix12i z, const void* rot, struct Callback* cb);
+
+struct Vector3_16f { s16 x, y, z; };
+struct Vec { Fix12i x, y, z; };
+struct Self { char pad0[8]; int state; char pad2[0x82]; s16 angle; };
+
+void func_ov002_020d8d10(struct Self* self, struct Vec* pos)
+{
+    struct Vector3_16f vec;
+
+    vec.x = data_02082214[((unsigned short)(short)(self->angle + 0x8000) >> 4) * 2];
+    vec.y = 0;
+    vec.z = data_02082214[(((unsigned short)(short)(self->angle + 0x8000) >> 4) * 2) + 1];
+
+    if (self->state != 2) {
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            0, 0xbf, pos->x, pos->y, pos->z, &vec, 0);
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            0, 0xc0, pos->x, pos->y, pos->z, 0, 0);
+    } else {
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            0, 0x12f, pos->x, pos->y, pos->z, &vec, 0);
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            0, 0x130, pos->x, pos->y, pos->z, &vec, 0);
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            0, 0x131, pos->x, pos->y, pos->z, 0, 0);
+    }
+}

--- a/src/func_ov002_020dc09c.c
+++ b/src/func_ov002_020dc09c.c
@@ -1,0 +1,39 @@
+/* func_ov002_020dc09c at 0x020dc09c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+struct V3 { int a, b, c; };
+extern void func_ov002_020dc174(char* c, struct V3* r1, int r2, int r3, unsigned int a5, unsigned int a6);
+void func_ov002_020dc09c(char* c){
+  struct V3 v;
+  int r2, r3;
+  if(*(unsigned char*)(c+0x703) == 0){
+    if(*(unsigned short*)(c+0x6a4) & 1){
+      r3 = 0x28000;
+      v.a = 0;
+      v.b = 0x28000;
+      v.c = 0x87000;
+      r2 = 0x3c000;
+    }else{
+      r3 = 0x50000;
+      v.a = 0;
+      v.b = 0x28000;
+      v.c = 0x10e000;
+      r2 = 0x50000;
+    }
+  }else{
+    r2 = 0x80000;
+    if(*(unsigned short*)(c+0x6a4) & 1){
+      v.a = 0;
+      v.b = 0x80000;
+      v.c = 0xc0000;
+      r3 = 0x80000;
+    }else{
+      v.a = 0;
+      v.b = 0x80000;
+      v.c = 0x1c0000;
+      r3 = 0x100000;
+    }
+  }
+  func_ov002_020dc174(c, &v, r2, r3, 0x40000, 0);
+}

--- a/src/func_ov002_020dcafc.c
+++ b/src/func_ov002_020dcafc.c
@@ -1,0 +1,33 @@
+/* func_ov002_020dcafc at 0x020dcafc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef short s16;
+
+extern int AngleDiff(int a, int b);
+extern int ApproachAngle(void* p, int a, int b, int c, int d);
+extern unsigned char data_020a0e40[];
+extern short data_0209f4a2[];
+extern short data_0209f4a4[];
+
+void func_ov002_020dcafc(char* c) {
+    s16 v5 = 0, v4 = 0;
+    int idx;
+    s16 a, b;
+
+    if (*(int*)(c + 0x98) != 0) {
+        idx = data_020a0e40[0] * 0x18;
+        a = *(short*)((char*)data_0209f4a2 + idx);
+        b = *(short*)((char*)data_0209f4a4 + idx);
+        v5 = (s16)(((long long)a * 0xaab + 0x800) >> 12);
+        v4 = (s16)(((long long)(-b) * 0x1555 + 0x800) >> 12);
+    }
+
+    if (AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x94)) >= 0x4000) {
+        v5 = (s16)(-v5);
+        v4 = (s16)(-v4);
+    }
+
+    ApproachAngle(c + 0x75e, v5, 8, 0x200, 0x20);
+    ApproachAngle(c + 0x760, v4, 8, 0x200, 0x20);
+}

--- a/src/func_ov002_020e930c.c
+++ b/src/func_ov002_020e930c.c
@@ -1,0 +1,42 @@
+/* func_ov002_020e930c at 0x020e930c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef unsigned char u8;
+
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern int _ZN5Event6GetBitEj(unsigned int bit);
+extern int func_ov002_020e8ef0(void* a, void* b);
+extern void func_ov002_020e7d84(void);
+
+void func_ov002_020e930c(void* self) {
+    char* a = (char*)self;
+    void* o;
+    char* b;
+    int flags;
+    unsigned int id;
+
+    id = *(unsigned int*)(a + 0x134);
+    if (id == 0) return;
+    o = _ZN5Actor10FindWithIDEj(id);
+    if (o == 0) return;
+    b = (char*)o;
+
+    flags = *(int*)(a + 0x130);
+    if (flags & 0x400000) {
+        if (*(u8*)(b + 0x709) != 0) return;
+        if (_ZN5Event6GetBitEj(0x1e) != 0) return;
+        if (func_ov002_020e8ef0(self, o) == 0) return;
+        if (*(int*)(a + 0x43c) != 6) return;
+        if (_ZN5Actor10FindWithIDEj(*(unsigned int*)(a + 0x434)) == 0) return;
+        func_ov002_020e7d84();
+    } else {
+        if (flags & 0x8000) {
+            if (*(u8*)(b + 0x709) != 0) return;
+            if (_ZN5Event6GetBitEj(0x1e) != 0) return;
+            if (*(int*)(a + 0x43c) != 6) return;
+            if (_ZN5Actor10FindWithIDEj(*(unsigned int*)(a + 0x434)) == 0) return;
+            func_ov002_020e7d84();
+        }
+    }
+}

--- a/src/func_ov002_020eddc4.c
+++ b/src/func_ov002_020eddc4.c
@@ -1,0 +1,76 @@
+/* func_ov002_020eddc4 at 0x020eddc4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Actor;
+struct Vector3 { int x, y, z; };
+
+extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
+extern int func_ov002_020ed63c(char* c, int i);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Actor* self, const struct Vector3* pos, u32 a, int fix, u32 b, u32 c, u32 d);
+extern void func_ov002_020edca4(char* c);
+extern void func_ov002_020ec728(char* c);
+
+int func_ov002_020eddc4(char* self)
+{
+    struct Actor* actor;
+    struct Actor* other;
+    u32 id;
+    u32 flags;
+    u16 type;
+
+    id = *(u32*)(self + 0x134);
+    if (id == 0) goto fail;
+
+    actor = _ZN5Actor10FindWithIDEj(id);
+    if (actor == 0) goto fail;
+
+    if (actor == *(struct Actor**)(self + 0x38c)) goto fail;
+
+    {
+        int t = (int)(*(u16*)((char*)actor + 0xc) == 0xbf);
+        if (t != 0) {
+            flags = *(u32*)(self + 0x130);
+            if (flags & 0x8000) {
+                func_ov002_020ed63c(self, 3);
+                return 1;
+            }
+            if (!(flags & 0x26fe0)) {
+                struct Vector3 pos;
+                pos.x = *(int*)(self + 0x5c);
+                pos.y = *(int*)(self + 0x60);
+                pos.z = *(int*)(self + 0x64);
+                _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(actor, &pos, 1, 0xc000, 1, 0, 1);
+            }
+        }
+    }
+
+    type = *(u16*)((char*)actor + 0xc);
+    switch (type) {
+    case 0xbd:
+    case 0xbe:
+    case 0xc6:
+    case 0xca:
+    case 0xdb:
+    case 0x151:
+        func_ov002_020edca4(self);
+        return 1;
+    }
+
+    other = 0;
+    id = *(u32*)(self + 0x410);
+    if (id != 0) {
+        other = _ZN5Actor10FindWithIDEj(id);
+    }
+    if (other != actor) goto fail;
+
+    func_ov002_020ec728(self);
+    func_ov002_020ed63c(self, 1);
+    return 1;
+
+fail:
+    return 0;
+}

--- a/src/func_ov004_020aff38.cpp
+++ b/src/func_ov004_020aff38.cpp
@@ -1,0 +1,37 @@
+//cpp
+// func_ov004_020aff38 at 0x020aff38
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+extern "C" {
+struct OamAttr;
+extern char* data_ov004_020beb68;
+extern int data_ov004_020beb6c;
+}
+typedef int Fix12i;
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(
+    int show, struct OamAttr* attr, int a, int b, int c, int d, Fix12i e, int f);
+
+extern "C" int func_ov004_020aff38(struct OamAttr* a0, int a1, int a2, int a3, int a4, Fix12i a5, int a6)
+{
+    char* g = data_ov004_020beb68;
+    if (g == 0) return 0;
+    if (*(int*)(g + 0x4628) == 0 && (*(int(**)(char*))(*(char**)g + 0x68))(g) == 2) {
+        if (*(unsigned short*)(data_ov004_020beb68 + 0x4664) == 1) {
+            int hp = data_ov004_020beb6c;
+            if (a2 >= -0x100 - hp && a2 < -hp) {
+                return _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(0, a0, a1, a2 + 0xc0 + hp, a3, a4, a5, a6);
+            }
+            if (a2 >= -0x40 && a2 < 0xc0) {
+                return _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(0, a0, a1, a2, a3, a4, a5, a6);
+            }
+        }
+    } else {
+        int hp = data_ov004_020beb6c;
+        if (a2 >= -0x100 - hp && a2 < -hp) {
+            return _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(0, a0, a1, a2 + 0xc0 + hp, a3, a4, a5, a6);
+        }
+        if (a2 >= -0x40 && a2 < 0xc0) {
+            return _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(1, a0, a1, a2, a3, a4, a5, a6);
+        }
+    }
+    return 0;
+}

--- a/src/func_ov004_020b0104.cpp
+++ b/src/func_ov004_020b0104.cpp
@@ -1,0 +1,28 @@
+//cpp
+// func_ov004_020b0104 at 0x020b0104
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+extern "C" {
+extern char* data_ov004_020beb68;
+extern int data_ov004_020beb6c;
+int _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int, void*, int, int, int, int, void*);
+typedef int (*GetFn)(void*);
+void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5){
+  char* g = data_ov004_020beb68;
+  if(g == 0) return;
+  if(*(int*)(g+0x4628) == 0){
+    void** vt = *(void***)g;
+    GetFn f = (GetFn)vt[0x1a];
+    if(f(g) == 2){
+      char* g2 = data_ov004_020beb68;
+      if(*(unsigned short*)(g2+0x4664) == 1){
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, a3, a4, a5);
+        return;
+      }
+      _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2, a3, a4, a5);
+      return;
+    }
+  }
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, a3, a4, a5);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, a0, a1, a2, a3, a4, a5);
+}
+}

--- a/src/func_ov004_020b023c.cpp
+++ b/src/func_ov004_020b023c.cpp
@@ -1,0 +1,28 @@
+//cpp
+// func_ov004_020b023c at 0x020b023c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+extern "C" {
+extern char* data_ov004_020beb68;
+extern int data_ov004_020beb6c;
+int _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int, void*, int, int, int, int, void*);
+typedef int (*GetFn)(void*);
+void func_ov004_020b023c(void* a0, int a1, int a2, int a3, void* a4){
+  char* g = data_ov004_020beb68;
+  if(g == 0) return;
+  if(*(int*)(g+0x4628) == 0){
+    void** vt = *(void***)g;
+    GetFn f = (GetFn)vt[0x1a];
+    if(f(g) == 2){
+      char* g2 = data_ov004_020beb68;
+      if(*(unsigned short*)(g2+0x4664) == 1){
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, a3, -1, a4);
+        return;
+      }
+      _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2, a3, -1, a4);
+      return;
+    }
+  }
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, a3, -1, a4);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, a0, a1, a2, a3, -1, a4);
+}
+}

--- a/src/func_ov004_020b0380.cpp
+++ b/src/func_ov004_020b0380.cpp
@@ -1,0 +1,28 @@
+//cpp
+// func_ov004_020b0380 at 0x020b0380
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+extern "C" {
+extern char* data_ov004_020beb68;
+extern int data_ov004_020beb6c;
+int _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int, void*, int, int, int, int, void*);
+typedef int (*GetFn)(void*);
+void func_ov004_020b0380(void* a0, int a1, int a2, void* a3){
+  char* g = data_ov004_020beb68;
+  if(g == 0) return;
+  if(*(int*)(g+0x4628) == 0){
+    void** vt = *(void***)g;
+    GetFn f = (GetFn)vt[0x1a];
+    if(f(g) == 2){
+      char* g2 = data_ov004_020beb68;
+      if(*(unsigned short*)(g2+0x4664) == 1){
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, -1, -1, a3);
+        return;
+      }
+      _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2, -1, -1, a3);
+      return;
+    }
+  }
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, a0, a1, a2 + 0xc0 + data_ov004_020beb6c, -1, -1, a3);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, a0, a1, a2, -1, -1, a3);
+}
+}

--- a/src/func_ov004_020b369c.c
+++ b/src/func_ov004_020b369c.c
@@ -1,0 +1,36 @@
+/* func_ov004_020b369c at 0x020b369c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+ */
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+
+extern s16 data_02082214[];
+struct M { int _00, _01, _10, _11; };
+extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, struct M* a5);
+
+void func_ov004_020b369c(char* self) {
+    char* el = self + 0x34;
+    int angle = (u16)*(int*)(self + 0x24);
+    struct M m;
+    u16 flag;
+    do {
+        int s0 = data_02082214[(angle >> 4) * 2];
+        int mm = (int)(((s64)s0 * 0x800 + 0x800) >> 12);
+        int idx = (u16)mm >> 4;
+        int cos1 = data_02082214[idx * 2 + 1];
+        int sin1 = data_02082214[idx * 2];
+        int fc = (int)(((s64)cos1 * 0x1000 + 0x800) >> 12);
+        int fs = (int)(((s64)sin1 * 0x1000 + 0x800) >> 12);
+        m._00 = fc;
+        m._11 = fc;
+        m._01 = fs;
+        m._10 = -fs;
+        func_ov004_020b1c68(el, *(s16*)(self + 0x10), *(s16*)(self + 0x12),
+                            *(int*)(self + 0x1c), *(int*)(self + 0x18), &m);
+        angle = (u16)(angle + 0x4000);
+        flag = *(u16*)(el + 6);
+        el += 8;
+    } while (flag != 0xffff);
+}

--- a/src/func_ov004_020b65e4.c
+++ b/src/func_ov004_020b65e4.c
@@ -1,0 +1,43 @@
+/* func_ov004_020b65e4 at 0x020b65e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+ */
+extern int data_ov004_020bf9ec;
+extern int data_ov004_020bfa18;
+extern unsigned char data_020a0e40;
+extern unsigned char data_020a0de8[][4];
+extern unsigned char data_020a0de9[][4];
+extern unsigned char data_020a0dea[][4];
+extern unsigned char data_020a0deb[][4];
+extern unsigned char data_ov004_020bfa34[];
+extern void (*data_ov004_020bfa20)(void);
+
+extern void func_ov004_020b6234(void);
+extern void func_ov004_020b52fc(void *c);
+
+void func_ov004_020b65e4(void) {
+    int i;
+    unsigned char *p;
+
+    if (data_ov004_020bf9ec == 0 && data_ov004_020bfa18 != 0) {
+        int idx = data_020a0e40;
+        int flag = data_020a0de8[idx][0] != 0 && data_020a0de9[idx][0] != 0;
+        if (flag) {
+            int a = data_020a0dea[idx][0];
+            int b = data_020a0deb[idx][0];
+            if (a < 0x40 && b < 0x50) {
+                func_ov004_020b6234();
+            }
+        }
+    }
+
+    p = data_ov004_020bfa34;
+    for (i = 0; i < 0x14; i++) {
+        func_ov004_020b52fc(p);
+        p += 0x24;
+    }
+
+    if (data_ov004_020bfa20 != 0) {
+        data_ov004_020bfa20();
+    }
+}

--- a/src/func_ov004_020b6948.c
+++ b/src/func_ov004_020b6948.c
@@ -1,0 +1,34 @@
+/* func_ov004_020b6948 at 0x020b6948
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
+ */
+extern void *data_ov004_020beb68;
+extern int data_ov004_020bc85c;
+extern int data_ov004_020bc870;
+extern unsigned char *data_ov004_020bca44[];
+extern int func_ov004_020adbc0(void);
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020b2444(int a, int b, int c, int d, int e, int f, int g);
+extern void func_ov004_020af948(void *a, int b, int c, int d);
+
+void func_ov004_020b6948(void) {
+    unsigned int r;
+    int idx;
+
+    if (data_ov004_020beb68 == 0) return;
+
+    r = func_ov004_020adbc0();
+    func_ov004_020b2444(data_ov004_020bc85c + 4, data_ov004_020bc870, r / 100, -1, -1, 1, 0);
+
+    r = func_ov004_020adbc0();
+    func_ov004_020b2444(data_ov004_020bc85c + 0x1c, data_ov004_020bc870, r % 100 / 10, -1, -1, 1, 0);
+
+    r = func_ov004_020adbc0();
+    func_ov004_020b2444(data_ov004_020bc85c + 0x2c, data_ov004_020bc870, r % 10, -1, -1, 1, 0);
+
+    idx = func_ov004_020ad674();
+    func_ov004_020af948((void *)*(int *)(data_ov004_020bca44[idx] + 0xc), data_ov004_020bc85c - 0x24, data_ov004_020bc870, 0);
+
+    idx = func_ov004_020ad674();
+    func_ov004_020af948((void *)*(int *)(data_ov004_020bca44[idx] + 0x1c), data_ov004_020bc85c + 0x10, data_ov004_020bc870, 0);
+}

--- a/src/func_ov006_020c0134.c
+++ b/src/func_ov006_020c0134.c
@@ -1,0 +1,68 @@
+/* func_ov006_020c0134 at 0x020c0134
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+typedef int s32;
+
+struct Vector3 { int x, y, z; };
+struct Matrix4x3 { int data[12]; };
+
+struct Camera {
+    struct Matrix4x3 viewMat;  /* 0x00 */
+    char pad30[0x30];          /* 0x30 */
+    struct Matrix4x3 projMat;  /* 0x60 */
+    char pad90[0x10];          /* 0x90 */
+    struct Vector3 eye;        /* 0xa0 */
+    struct Vector3 target;     /* 0xac */
+    short angle;               /* 0xb8 */
+};
+
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int NormalizeVec3IfNonZero(struct Vector3 *v);
+extern void func_0203cebc(struct Vector3 *out, struct Vector3 *tmp, struct Vector3 *a, struct Vector3 *b);
+extern int _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(int,int,int,int,int,int,int,struct Matrix4x3 *);
+extern int _ZN3G3i7LookAt_EPK7Vector3S2_S2_bP9Matrix4x3(struct Vector3 *,struct Vector3 *,struct Vector3 *,int,struct Matrix4x3 *);
+extern void _Z13CopyToViewMatPK9Matrix4x3(struct Matrix4x3 *);
+extern int _ZN7Clipper13Func_020156DCEv(void *,int,int,int,int);
+
+extern short data_02082214[];
+extern char data_0209f43c[];
+
+void func_ov006_020c0134(struct Camera *self)
+{
+    struct Vector3 up;
+    struct Vector3 v1c;
+    struct Vector3 v28;
+    struct Vector3 v34;
+    struct Vector3 v40;
+    int idx;
+
+    up.x = 0;
+    up.y = 0x1000;
+    up.z = 0;
+
+    SubVec3(&self->eye, &self->target, &v1c);
+    if (NormalizeVec3IfNonZero(&v1c)) {
+        func_0203cebc(&v34, &v28, &v1c, &up);
+        if (NormalizeVec3IfNonZero(&v28)) {
+            func_0203cebc(&v40, &up, &v28, &v1c);
+        } else {
+            up.x = 0;
+            up.y = 0;
+            up.z = 0x1000;
+        }
+    }
+
+    idx = (self->angle >> 4) * 2;
+    _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(
+        data_02082214[idx], data_02082214[idx + 1],
+        0x1555, 0x1000, 0x1388000, 0x1000, 1, &self->projMat);
+
+    _ZN3G3i7LookAt_EPK7Vector3S2_S2_bP9Matrix4x3(
+        &self->target, &up, &self->eye, 1, &self->viewMat);
+
+    _Z13CopyToViewMatPK9Matrix4x3(&self->viewMat);
+
+    _ZN7Clipper13Func_020156DCEv(
+        data_0209f43c, 0x1555, self->angle, 0x1000, 0x1388000);
+}

--- a/src/func_ov006_020cdf3c.c
+++ b/src/func_ov006_020cdf3c.c
@@ -1,0 +1,36 @@
+/* func_ov006_020cdf3c at 0x020cdf3c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern int _Z14ApproachLinearRiii(int* a, int b, int c);
+extern void func_ov006_020cdeec(char* c);
+extern void func_ov006_020cde7c(char* c);
+extern void func_ov006_020cde28(char* c);
+extern void func_ov006_020cdf20(char* c);
+extern void func_ov006_020cdce4(char* c);
+extern void func_ov006_020cdc68(char* c);
+extern void func_ov006_020cdad0(char* c);
+extern void func_ov006_020cdc14(char* c);
+extern void func_ov006_020cd98c(char* c);
+
+void func_ov006_020cdf3c(char* c)
+{
+    int a = _Z14ApproachLinearRiii((int*)(c + 0x6c), 0x1000, 0xc0);
+    int b = _Z14ApproachLinearRiii((int*)(c + 0x68), 0x1000, 0x180);
+    int d = _Z14ApproachLinearRiii((int*)(c + 0x70), 0x1000, 0x180);
+    int e = _Z14ApproachLinearRiii((int*)(c + 0x88), 0x800, 0x60);
+    if (a == 0) return;
+    if (b == 0) return;
+    if ((d & e) == 0) return;
+    switch (*(short*)(c + 0x98)) {
+    case 1: func_ov006_020cdeec(c); break;
+    case 2: func_ov006_020cde7c(c); break;
+    case 3: func_ov006_020cde28(c); break;
+    case 0: func_ov006_020cdf20(c); break;
+    case 4: func_ov006_020cdce4(c); break;
+    case 6: func_ov006_020cdc68(c); break;
+    case 8: func_ov006_020cdad0(c); break;
+    case 5: func_ov006_020cdc14(c); break;
+    case 7: func_ov006_020cd98c(c); break;
+    }
+}

--- a/src/func_ov006_020d7524.c
+++ b/src/func_ov006_020d7524.c
@@ -1,0 +1,38 @@
+/* func_ov006_020d7524 at 0x020d7524
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
+extern unsigned char* data_ov006_0213bb18[];
+extern unsigned char* data_ov006_0213bb28[];
+extern void* data_ov006_0213bb4c[];
+typedef struct { int f660; int f664; char pad08[0x2c]; unsigned char b694; unsigned char b695; unsigned char b696; unsigned char b697; unsigned char pad38; unsigned char b699; unsigned char pad3a; unsigned char b69b; char pad3c[4]; } E;
+typedef struct { char pad0[0x4660]; E e[112]; char pad1[0x7c]; int f62dc; } Self;
+void func_ov006_020d7524(Self* self) {
+    int i;
+    for (i = 0; i < 0x70; i++) {
+        if (self->e[i].b699 == 0) continue;
+        {
+            int b694 = self->e[i].b694;
+            int a4 = 1;
+            int b695, b696;
+            unsigned char idx;
+            int b697;
+            int f664;
+            int a1, a2;
+            if (b694 == 3) a4 = 0;
+            b696 = self->e[i].b696;
+            b695 = self->e[i].b695;
+            if (b696 != 0) { idx = data_ov006_0213bb28[b694][b695]; }
+            else { idx = data_ov006_0213bb18[b694][b695]; }
+            b697 = self->e[i].b697;
+            a1 = self->e[i].f660 >> 12;
+            f664 = self->e[i].f664;
+            a2 = f664 >> 12;
+            if (b697 == 6) {
+                if (self->e[i].b69b == 4) { a2 = (f664 - self->f62dc) >> 12; }
+            }
+            func_ov004_020afdd0(data_ov006_0213bb4c[idx], a1, a2, -1, a4);
+        }
+    }
+}

--- a/src/func_ov006_02100554.c
+++ b/src/func_ov006_02100554.c
@@ -1,0 +1,37 @@
+/* func_ov006_02100554 at 0x02100554
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+typedef unsigned char u8;
+
+extern int func_ov004_020adbe0(void);
+extern void func_ov006_021004f4(void *c, int a);
+extern void func_ov006_021006f4(void *c);
+
+void func_ov006_02100554(void *self) {
+    char *s = (char *)self;
+    int count;
+    int i;
+
+    if (*(u8 *)(s + 0x5299) && *(u8 *)(s + 0x5294)) return;
+    if (*(u8 *)(s + 0x52d9) && *(u8 *)(s + 0x52d4)) return;
+    if (*(u8 *)(s + 0x5319) && *(u8 *)(s + 0x5314)) return;
+    if (*(u8 *)(s + 0x5296) != 0xd && *(u8 *)(s + 0x5294)) return;
+    if (*(u8 *)(s + 0x52d6) != 0xd && *(u8 *)(s + 0x52d4)) return;
+    if (*(u8 *)(s + 0x5316) != 0xd && *(u8 *)(s + 0x5314)) return;
+
+    count = 0;
+    for (i = 0; i < 0x30; i++) {
+        if (((u8 (*)[0x40])(s + 0x4698))[i][0]) {
+            count++;
+            break;
+        }
+    }
+    if (count) return;
+
+    if (func_ov004_020adbe0())
+        func_ov006_021004f4(self, 1);
+    else
+        func_ov006_021004f4(self, 0);
+    func_ov006_021006f4(self);
+}

--- a/src/func_ov006_02107c50.c
+++ b/src/func_ov006_02107c50.c
@@ -1,0 +1,27 @@
+/* func_ov006_02107c50 at 0x02107c50
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020af68c(void* a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern void func_ov004_020b2444(int a, int b, int c, int d, int e, int f, int g);
+
+extern void* data_ov006_0213e320[];
+extern int data_ov006_0212ed14[];
+extern void* data_ov006_02138c3c;
+
+void func_ov006_02107c50(short* a0, int a1)
+{
+    int idx = func_ov004_020ad674();
+    void* p = *(void**)((char*)data_ov006_0213e320[idx] + 0x50);
+    func_ov004_020af68c(p, 0xc, a1, -1, -1);
+
+    func_ov004_020b2444(0x1e, a1, data_ov006_0212ed14[*(short*)((char*)a0 + 0x14)], 0, -1, 2, 0);
+
+    {
+        int b = a1 + 0x10;
+        func_ov004_020b0104(data_ov006_02138c3c, 0x20, b, -1, 1, (void*)0);
+        func_ov004_020b2444(0x2e, b, *(short*)((char*)a0 + 0x16), 0, -1, 1, 0);
+    }
+}

--- a/src/func_ov006_0210e120.c
+++ b/src/func_ov006_0210e120.c
@@ -1,0 +1,25 @@
+/* func_ov006_0210e120 at 0x0210e120
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+typedef struct { int x, y; } Vec2;
+extern void func_ov006_0211470c(int *a, int *b);
+extern int func_0203d614(Vec2 *v);
+int func_ov006_0210e120(int *self)
+{
+    int i;
+    Vec2 delta, pos;
+    for (i = 0; i < *(int *)((char *)self[1] + 0x4668); i++) {
+        int *o  = (i >= 13) ? 0 : ((int **)((char *)self[1] + 0x4688))[i];
+        if (*(unsigned char *)((char *)o + 0x30) != 0) {
+            int *o2 = (i >= 13) ? 0 : ((int **)((char *)self[1] + 0x4688))[i];
+            func_ov006_0211470c((int *)&pos, o2);
+            delta = pos;
+            delta.x -= self[2];
+            delta.y -= self[3];
+            if (func_0203d614(&delta) < 0x12000)
+                return 0;
+        }
+    }
+    return 1;
+}

--- a/src/func_ov006_0211102c.c
+++ b/src/func_ov006_0211102c.c
@@ -1,0 +1,23 @@
+/* func_ov006_0211102c at 0x0211102c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern short data_02082214[];
+extern void* data_ov006_02138a08[];
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+
+void func_ov006_0211102c(char* self)
+{
+    int b = (short)((((long long)data_02082214[(*(unsigned short*)(self + 0x32) >> 4) * 2 + 1] << 12) + 0x800) >> 12);
+    int a;
+    int vec[4];
+
+    vec[0] = b;
+    a = (short)((((long long)data_02082214[(*(unsigned short*)(self + 0x32) >> 4) * 2] << 12) + 0x800) >> 12);
+    vec[3] = b;
+    vec[1] = a;
+    vec[2] = -a;
+
+    func_ov004_020b0104(data_ov006_02138a08[0], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 1, vec);
+    func_ov004_020b0104(data_ov006_02138a08[1], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2, vec);
+}

--- a/src/func_ov006_021117bc.c
+++ b/src/func_ov006_021117bc.c
@@ -1,0 +1,37 @@
+/* func_ov006_021117bc at 0x021117bc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern short data_02082214[];
+extern void* data_ov006_0213765c[];
+extern void* data_ov006_02137674[];
+extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern int _ZN4cstd4fdivEii(int, int);
+
+void func_ov006_021117bc(char* self)
+{
+    switch (*(int*)(self + 0x34)) {
+    case 0:
+        func_ov004_020afdd0(data_ov006_0213765c[0], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 1);
+        func_ov004_020afdd0(data_ov006_0213765c[1], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2);
+        break;
+    case 1:
+        {
+            int d;
+            int b, a;
+            int vec[4];
+            if (*(int*)(self + 0x28) < 0x1000) return;
+            d = _ZN4cstd4fdivEii(0x7000, *(int*)(self + 0x28));
+            b = (int)(((long long)data_02082214[1] * d + 0x800) >> 12);
+            a = (int)(((long long)data_02082214[0] * d + 0x800) >> 12);
+            vec[0] = b;
+            vec[1] = a;
+            vec[2] = -a;
+            vec[3] = b;
+            func_ov004_020b0104(data_ov006_02137674[0], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 1, vec);
+            func_ov004_020b0104(data_ov006_02137674[1], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2, vec);
+        }
+        break;
+    }
+}

--- a/src/func_ov006_02114590.c
+++ b/src/func_ov006_02114590.c
@@ -1,0 +1,22 @@
+/* func_ov006_02114590 at 0x02114590
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern void func_0203d6d0(int* o, int* a, int* b);
+extern int func_0203d4d0(void* p, int* a, int* b);
+
+int func_ov006_02114590(int a0, int* p, int* q0, int* q1, int* q2){
+  int v0[2], v1[2], v2[2];
+  int t0[2], t1[2], t2[2];
+  long long d0, d1, d2;
+  func_0203d6d0(t0, p, q0);
+  v0[0] = t0[0]; v0[1] = t0[1];
+  func_0203d6d0(t1, p, q1);
+  v1[0] = t1[0]; v1[1] = t1[1];
+  func_0203d6d0(t2, p, q2);
+  v2[0] = t2[0]; v2[1] = t2[1];
+  d0 = func_0203d4d0(p, v0, v1);
+  d1 = func_0203d4d0(p, v1, v2);
+  d2 = func_0203d4d0(p, v2, v0);
+  return (d0 >= 0 && d1 >= 0 && d2 >= 0) || (d0 <= 0 && d1 <= 0 && d2 <= 0);
+}

--- a/src/func_ov006_02114ec0.c
+++ b/src/func_ov006_02114ec0.c
@@ -1,0 +1,19 @@
+/* func_ov006_02114ec0 at 0x02114ec0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern void func_ov006_02111e7c(int *o);
+extern void func_ov006_0211470c(int *a, int *b);
+extern void func_02012718(void *a, int b);
+typedef struct { int *p[13]; } Arr;
+static inline int *get(char *self, int i){ return i >= 13 ? 0 : ((Arr*)(self + 0x4688))->p[i]; }
+void func_ov006_02114ec0(char *self){
+    int t[3]; int n = *(int *)(self + 0x4668); int i;
+    for (i = 0; i < n; i++) {
+        if (*(unsigned char *)((char *)get(self, i) + 0x30) == 0) continue;
+        if (*(unsigned char *)((char *)get(self, i) + 0x121) != 0) continue;
+        func_ov006_02111e7c(get(self, i));
+        func_ov006_0211470c(t, get(self, i));
+        func_02012718((void *)0x1a5, t[0]); return;
+    }
+}

--- a/src/func_ov007_020b10dc.c
+++ b/src/func_ov007_020b10dc.c
@@ -1,0 +1,36 @@
+/* func_ov007_020b10dc at 0x020b10dc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void func_ov007_020bdeb0(int x);
+extern void func_ov007_020bfacc(int a, int b, void* p);
+extern void func_ov007_020b1fa4(int self);
+extern void func_ov007_020b2764(int x);
+extern char data_ov007_0210342c[];
+extern char func_ov007_020b16f0[];
+
+void func_ov007_020b10dc(void) {
+    char* g = *(char**)data_ov007_0210342c;
+    int t = *(int*)(*(char**)(g + 8) + 0xc);
+    if (t == 0) {
+        (*(void(**)(int))(g + 0x2c))(0x11);
+    }
+    switch (*(int*)(*(char**)data_ov007_0210342c + 0xec)) {
+    case 0:
+        if (t == 0x1e) func_ov007_020bdeb0(0x2b);
+        else if (t == 0x80) func_ov007_020bdeb0(0x2d);
+        break;
+    case 1:
+        if (t == 0x1e) func_ov007_020bdeb0(0x2c);
+        else if (t == 0x7a) func_ov007_020bdeb0(0x2e);
+        break;
+    }
+    if (t == 0x3c) {
+        func_ov007_020bfacc(5, 3, func_ov007_020b16f0);
+        func_ov007_020b1fa4(1);
+        return;
+    }
+    if (t == 0x3d) {
+        func_ov007_020b2764(0x1000);
+    }
+}

--- a/src/func_ov007_020b45b0.c
+++ b/src/func_ov007_020b45b0.c
@@ -1,0 +1,41 @@
+/* func_ov007_020b45b0 at 0x020b45b0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+struct DataEntry { int flags; int b; int c; };
+extern struct DataEntry data_ov007_020d77dc[];
+extern int func_ov007_020b79e4(void);
+extern int func_ov007_020b63e4(void *t);
+
+void func_ov007_020b45b0(void *t) {
+    char *p = *(char**)t;
+    int call_it = 0;
+    int t0 = 0;
+    int b6 = 0;
+
+    if (*(*(short**)(p + 4)) == 0) {
+        if (*(int*)(p + 0x10) >= 0x1000 ||
+            (data_ov007_020d77dc[**(unsigned short**)t].flags & 2))
+            b6 = 1;
+    }
+    if (b6) {
+        if (!(data_ov007_020d77dc[**(unsigned short**)t].flags & 1))
+            t0 = 1;
+    }
+    if (t0) {
+        int ok = 1;
+        if (func_ov007_020b79e4()) {
+            int special = 0;
+            if (func_ov007_020b79e4()) {
+                unsigned short id2 = **(unsigned short**)t;
+                int x = ok;
+                if (id2 != 0x16 && id2 != 0x17) x = special;
+                if (x) special = 1;
+            }
+            if (!special) ok = 0;
+        }
+        if (ok) call_it = 1;
+    }
+    if (!call_it) return;
+    func_ov007_020b63e4(t);
+}

--- a/src/func_ov007_020b8070.c
+++ b/src/func_ov007_020b8070.c
@@ -1,0 +1,31 @@
+/* func_ov007_020b8070 at 0x020b8070
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern int* data_ov007_02103478[];
+extern int data_ov007_020d7a5c[];
+extern void MultiCopy32Bytes(int* src, int* dst, int len);
+extern void MultiStore32Bytes(unsigned val, int* dst, int len);
+
+void func_ov007_020b8070(int n){
+  volatile int z1, z2, z3, z4;
+  if(n < 0x17){
+    int b, a;
+    a = 0x17 - n;
+    b = 0x24 - a;
+    if(b >= 0x17) b = 0x16;
+    MultiCopy32Bytes(data_ov007_02103478[2], data_ov007_02103478[1] + n*0x100, a*0x400);
+    z1 = 0;
+    MultiStore32Bytes((unsigned)z1, data_ov007_02103478[1], n*0x400);
+    MultiCopy32Bytes(data_ov007_02103478[2] + a*0x100, data_ov007_02103478[0] + 0x100, b*0x400);
+    z2 = 0;
+    MultiStore32Bytes((unsigned)z2, data_ov007_02103478[0] + (b+1)*0x100, (0x17-b)*0x400);
+  } else {
+    int a = n - 0x16;
+    z4 = 0;
+    MultiStore32Bytes((unsigned)z4, data_ov007_02103478[1], data_ov007_020d7a5c[1]);
+    z3 = 0;
+    MultiStore32Bytes((unsigned)z3, data_ov007_02103478[0], a*0x400);
+    MultiCopy32Bytes(data_ov007_02103478[2], data_ov007_02103478[0] + a*0x100, (0x17-a)*0x400);
+  }
+}

--- a/src/func_ov007_020bda8c.c
+++ b/src/func_ov007_020bda8c.c
@@ -1,0 +1,43 @@
+/* func_ov007_020bda8c at 0x020bda8c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern int _ZN4cstd3divEii(int a, int b);
+extern void func_0204f8cc(void* obj, int a, int b);
+extern void func_ov007_020bde2c(int idx);
+extern void func_0204f79c(void* obj, int a, int b);
+extern void func_0204f76c(void* obj, int a, int b);
+extern char* data_ov007_02104bbc;
+
+static inline int scale_div(int v, int range, int scale)
+{
+    int q;
+    if (v <= 0)
+        q = 0;
+    else if (v >= range)
+        q = 0x1000;
+    else
+        q = _ZN4cstd3divEii(v << 12, range);
+    return (q * scale) >> 12;
+}
+
+void func_ov007_020bda8c(int a, int b)
+{
+    char* obj = data_ov007_02104bbc + 0xd8;
+    int r4, r6;
+
+    if (b == 0) {
+        r4 = scale_div(a, 0xb4, 0x7f);
+        r6 = scale_div(a, 0x78, 0x23) + 5;
+    } else {
+        int v = 0x1e - a;
+        r4 = scale_div(v, 0x1e, 0x7f);
+        r6 = scale_div(v, 0x1e, 0x23) + 5;
+        if (a == 0) {
+            func_0204f8cc(obj, 0, 0x1e);
+        }
+    }
+    func_ov007_020bde2c(0x36);
+    func_0204f79c(obj, 0xf, r4);
+    func_0204f76c(obj, 0xf, r6);
+}

--- a/src/func_ov007_020c0b78.c
+++ b/src/func_ov007_020c0b78.c
@@ -1,0 +1,52 @@
+/* func_ov007_020c0b78 at 0x020c0b78
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+struct E8 { int a, b; };
+
+extern int func_ov007_020c0eb0(struct E8*, int, int, int, int, int, int, int);
+extern void func_ov007_020c0d70(void*, void*);
+extern int func_ov007_020c0b78(struct E8* p, void* s, int x, int y, int a4, unsigned char a5, int a6, int sb);
+
+int func_ov007_020c0b78(struct E8* p, void* s, int x, int y, int a4, unsigned char a5, int a6, int sb){
+  char* sp = (char*)s;
+  int u, t, sum24, sum28;
+  unsigned char b5 = a5;
+
+  sum24 = *(int*)(sp + 0x00) + x;
+  sum28 = *(int*)(sp + 0x04) + y;
+
+  if (b5 > 3) b5 = *(unsigned char*)(sp + 0x14);
+
+  if (*(int*)(sp + 0x10) != 0 || a6 != 0) t = 1; else t = 0;
+
+  if (*(int*)(sp + 0x08) != 0 && a4 != 0) u = 1; else u = 0;
+
+  if (u) {
+    if (*(unsigned char*)(sp + 0x1c)) {
+      void* r8 = ((void**)*(void***)(sp + 0x18))[*(unsigned char*)(sp + 0x1d)];
+      if (r8) {
+        int i;
+        void* r6 = ((void**)*(void***)r8)[*(short*)(sp + 0x2c)];
+        for (i = 0; i < *(int*)((char*)r6 + 4); i++) {
+          func_ov007_020c0eb0(
+            &p[sb],
+            *(int*)r6 + i * 6,
+            (sum24 >> 12) + *(unsigned short*)((char*)r8 + 8),
+            (sum28 >> 12) + *(unsigned short*)((char*)r8 + 0xa),
+            b5,
+            *(int*)(sp + 0x0c),
+            t,
+            *(signed char*)(sp + 0x15));
+          sb++;
+        }
+        func_ov007_020c0d70(s, r8);
+      }
+    }
+  }
+
+  if (*(void**)(sp + 0x3c)) sb = func_ov007_020c0b78(p, *(void**)(sp + 0x3c), x, y, a4, a5, a6, sb);
+  if (*(void**)(sp + 0x38)) sb = func_ov007_020c0b78(p, *(void**)(sp + 0x38), sum24, sum28, u, b5, t, sb);
+
+  return sb;
+}

--- a/src/func_ov007_020c33d0.cpp
+++ b/src/func_ov007_020c33d0.cpp
@@ -1,0 +1,52 @@
+//cpp
+// func_ov007_020c33d0 at 0x020c33d0
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+extern "C" {
+void _ZN2GX7LoadOBJEPKvjj(const void* p, unsigned int a, unsigned int b);
+void _ZN2GX11LoadBG0CharEPKvjj(const void* p, unsigned int a, unsigned int b);
+void _ZN2GX11LoadBG1CharEPKvjj(const void* p, unsigned int a, unsigned int b);
+void func_020560d4(const void* p, unsigned int a, unsigned int b);
+void func_02056014(const void* p, unsigned int a, unsigned int b);
+void func_020565b4(const void* p, unsigned int a, unsigned int b);
+void _ZN3GXS11LoadBG0CharEPKvjj(const void* p, unsigned int a, unsigned int b);
+void _ZN3GXS11LoadBG1CharEPKvjj(const void* p, unsigned int a, unsigned int b);
+void func_02056074(const void* p, unsigned int a, unsigned int b);
+void func_02055fb4(const void* p, unsigned int a, unsigned int b);
+}
+
+extern "C" void func_ov007_020c33d0(char* c, int sel, unsigned int off){
+    unsigned int n = *(int*)(c+4) == 0 ? 0x20 : 0x40;
+    unsigned int size = (unsigned int)*(unsigned char*)(c+8) * *(unsigned char*)(c+9) * n;
+    switch (sel) {
+    case 0:
+        _ZN2GX7LoadOBJEPKvjj(*(void**)c, off, size);
+        break;
+    case 1:
+        _ZN2GX11LoadBG0CharEPKvjj(*(void**)c, off, size);
+        break;
+    case 2:
+        _ZN2GX11LoadBG1CharEPKvjj(*(void**)c, off, size);
+        break;
+    case 3:
+        func_020560d4(*(void**)c, off, size);
+        break;
+    case 4:
+        func_02056014(*(void**)c, off, size);
+        break;
+    case 5:
+        func_020565b4(*(void**)c, off, size);
+        break;
+    case 6:
+        _ZN3GXS11LoadBG0CharEPKvjj(*(void**)c, off, size);
+        break;
+    case 7:
+        _ZN3GXS11LoadBG1CharEPKvjj(*(void**)c, off, size);
+        break;
+    case 8:
+        func_02056074(*(void**)c, off, size);
+        break;
+    case 9:
+        func_02055fb4(*(void**)c, off, size);
+        break;
+    }
+}

--- a/src/func_ov007_020c7804.c
+++ b/src/func_ov007_020c7804.c
@@ -1,0 +1,43 @@
+/* func_ov007_020c7804 at 0x020c7804
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void func_ov007_020c8010(void* a, void* b, void* c);
+
+struct Obj {
+    void** field0;   // 0x0
+    int count;       // 0x4
+    void** field8;   // 0x8
+    int field_c;     // 0xc
+    int field_10;    // 0x10
+};
+
+void func_ov007_020c7804(struct Obj* self) {
+    int count = self->count;
+    int n;
+    int i;
+
+    if (count <= 1) {
+        n = 0;
+    } else {
+        n = count - !(self->field_c & 2);
+    }
+
+    switch (self->field_10) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+        for (i = 0; i < n; i++) {
+            int j;
+            if (i < self->count - 1)
+                j = i + 1;
+            else
+                j = 0;
+            func_ov007_020c8010(self->field8[i], self->field0[i], self->field0[j]);
+        }
+        break;
+    default:
+        break;
+    }
+}

--- a/src/func_ov015_02111c3c.cpp
+++ b/src/func_ov015_02111c3c.cpp
@@ -1,0 +1,28 @@
+//cpp
+// func_ov015_02111c3c at 0x02111c3c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov015).
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+void _ZN9ActorBase18MarkForDestructionEv(void* self);
+}
+
+extern "C" void func_ov015_02111c3c(char* self);
+void func_ov015_02111c3c(char* self) {
+    Vector3 vec;
+    Vector3 vec2;
+    vec.x = *(int*)(self + 0x5c);
+    vec.y = *(int*)(self + 0x60);
+    vec.z = *(int*)(self + 0x64);
+    vec.y += 0xc8000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x10a, vec.x, vec.y, vec.z);
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(self, vec2);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(self + 0x74));
+    _ZN9ActorBase18MarkForDestructionEv(self);
+}

--- a/src/func_ov060_02118970.c
+++ b/src/func_ov060_02118970.c
@@ -1,0 +1,43 @@
+/* func_ov060_02118970 at 0x02118970
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov060).
+ */
+enum Bool { FALSE, TRUE };
+
+struct Vector3 { int x, y, z; };
+
+extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void func_02012694(int a, void* b);
+extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, struct Vector3* v, int f);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, struct Vector3* v, unsigned int b, int c, unsigned int d, unsigned int e, unsigned int f);
+extern void func_ov060_021184bc(char* c);
+
+void func_ov060_02118970(char* c)
+{
+    char* a;
+    struct Vector3 v1, v2;
+    enum Bool isType;
+    unsigned int id;
+    id = *(unsigned int*)(c + 0x148);
+    if (id == 0) return;
+    a = _ZN5Actor10FindWithIDEj(id);
+    if (a == 0) return;
+    isType = (enum Bool)(*(unsigned short*)(a + 0xc) == 0xbf);
+    if (!isType) return;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xa8, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xa9, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xaa, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xab, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xac, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    func_02012694(0x2f, c + 0x74);
+    v1.x = *(int*)(c + 0x5c);
+    v1.y = *(int*)(c + 0x60);
+    v1.z = *(int*)(c + 0x64);
+    _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, &v1, 0x7d0000);
+    v2.x = *(int*)(c + 0x5c);
+    v2.y = *(int*)(c + 0x60);
+    v2.z = *(int*)(c + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(a, &v2, 2, 0xc000, 1, 0, 1);
+    func_ov060_021184bc(c);
+}

--- a/src/func_ov102_02149ccc.cpp
+++ b/src/func_ov102_02149ccc.cpp
@@ -1,0 +1,56 @@
+//cpp
+// func_ov102_02149ccc at 0x02149ccc
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov102).
+struct Actor;
+struct Obj {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5();
+    virtual void v6();
+    virtual void v7();
+    virtual void v8();
+    virtual void v9();
+    virtual void v10();
+    virtual void v11();
+    virtual void v12();
+    virtual void v13();
+    virtual void v14();
+    virtual void v15();
+    virtual void v16();
+    virtual void v17();
+    virtual void v18();
+    virtual void v19();
+    virtual void v20();
+    virtual void v21();
+    virtual void v22();
+    virtual void v23();
+    virtual void v24();
+    virtual void v25();
+    virtual void v26();
+    virtual void call(Actor *player);
+};
+
+extern "C" Actor *_ZN5Actor13ClosestPlayerEv(char *self);
+extern "C" int Vec3_HorzDist(const void *a, const void *b);
+extern "C" int data_0209caa0[];
+
+extern "C" void func_ov102_02149ccc(char *self)
+{
+    Actor *player;
+    if (!(data_0209caa0[1] & 0x80000000)) {
+        int b = (int)(*(unsigned short *)(self + 0xc) == 0x14);
+        if (b)
+            return;
+    }
+    player = _ZN5Actor13ClosestPlayerEv(self);
+    if (*(unsigned char *)((char *)player + 0x703) == 0)
+        return;
+    if (Vec3_HorzDist(self + 0x5c, (char *)player + 0x5c) >= 0xc8000)
+        return;
+    if (*(int *)(self + 0x60) <= *(int *)((char *)player + 0x60))
+        return;
+    ((Obj *)self)->call(player);
+}


### PR DESCRIPTION
Adds 81 byte-matched functions across seven overlays, all compiled with mwccarm 1.2 (`-O4,p -enum int -lang c99|c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).

**Per-overlay breakdown (81 total):**
- ov002 × 20 (incl. `HUD::Render`, `Platform::Kill`, `Player::St_Throw_Init`, `Player::St_Throw_Main`, `LoadDoorObjects`)
- ov004 × 11
- ov006 × 29 (incl. `__sinit_ov006_0212fc7c`)
- ov007 × 16
- ov015 × 1
- ov060 × 3
- ov102 × 1

**Verification — every function passes three gates:**
1. **Byte-identical** (relocation-aware) to the retail ROM.
2. **Trio-clean** — reproduces under all three of mwccarm `1.2/base`, `1.2/sp2`, `1.2/sp2p3` (codegen-identical).
3. **Reloc-destination clean** — every emitted relocation resolves to its ground-truth `config/**/relocs.txt` entry (no wrong-callee / wrong-global hidden behind the wildcard; see the audit in #47). Callees are declared by their exact (mangled) symbol so the destinations are verifiable, not left as unresolvable invented names.

src-only; no tooling or bookkeeping changes.