### PR TITLE
Match 107 functions across arm9-main + 19 overlays (verified, rebased on 63.9%)

### DIFF
--- a/src/DotVec3.c
+++ b/src/DotVec3.c
@@ -1,0 +1,14 @@
+/* DotVec3 at 0x0205380c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int Fix12i;
+typedef struct Vector3 { Fix12i x, y, z; } Vector3;
+
+Fix12i DotVec3(const Vector3 *a, const Vector3 *b)
+{
+    long long sum = (long long)a->x * b->x
+                  + (long long)a->y * b->y
+                  + (long long)a->z * b->z;
+    return (Fix12i)((sum + 0x800) >> 12);
+}

--- a/src/_ZN21ExtendingMeshCollider9GetNormalEsR7Vector3.c
+++ b/src/_ZN21ExtendingMeshCollider9GetNormalEsR7Vector3.c
@@ -1,0 +1,27 @@
+/* _ZN21ExtendingMeshCollider9GetNormalEsR7Vector3 at 0x0203a4dc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int Fix12i;
+struct Vector3 { int x, y, z; };
+extern void NormalizeVec3(struct Vector3 *src, struct Vector3 *dst);
+extern void func_02039db8(void *thiz, struct Vector3 *vec, struct Vector3 *res);
+
+void _ZN21ExtendingMeshCollider9GetNormalEsR7Vector3(char *c, int idx, struct Vector3 *res) {
+    char *p = *(char **)(c + 0x20);
+    char *ip = *(char **)(p + 8);
+    char *verts = *(char **)(p + 4);
+    unsigned short n = *(unsigned short *)(ip + idx*16 + 6);
+    short *v = (short *)(verts + n*6);
+    struct Vector3 tmp;
+    Fix12i sy;
+    tmp.x = v[0] << 2;
+    tmp.y = v[1] << 2;
+    tmp.z = v[2] << 2;
+    sy = *(Fix12i*)(c + 0x1c8);
+    tmp.x = (Fix12i)(((long long)tmp.x * sy + 0x800) >> 12);
+    sy = *(Fix12i*)(c + 0x1c8);
+    tmp.z = (Fix12i)(((long long)tmp.z * sy + 0x800) >> 12);
+    NormalizeVec3(&tmp, &tmp);
+    func_02039db8(c, &tmp, res);
+}

--- a/src/_ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE.cpp
+++ b/src/_ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE.cpp
@@ -1,0 +1,58 @@
+//cpp
+// _ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE at 0x0204e40c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+extern "C" {
+
+struct MemoryNode {
+  unsigned short tag;
+  unsigned short pad;
+  int size;
+  int prev;
+  int next;
+};
+
+struct Target {
+  int start;
+  int end;
+};
+
+extern void* _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(void* c, MemoryNode* node);
+extern MemoryNode* _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(Target* t, unsigned short tt);
+extern void* _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(void* c, MemoryNode* node, MemoryNode* r2);
+
+int _ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE(int* c, Target* node, void* target) {
+  Target tgt = *node;
+
+  MemoryNode* below = 0;
+  MemoryNode* p = (MemoryNode*)c[0];
+  while (p) {
+    if ((unsigned)p < (unsigned)node->start) {
+      below = p;
+    } else {
+      if ((unsigned)p == (unsigned)node->end) {
+        tgt.end = p->size + ((int)p + 0x10);
+        _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(c, p);
+      }
+      break;
+    }
+    p = (MemoryNode*)p->next;
+  }
+
+  if (below) {
+    int e = below->size + ((int)below + 0x10);
+    if (e == node->start) {
+      tgt.start = (int)below;
+      below = (MemoryNode*)_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(c, below);
+    }
+  }
+
+  if ((unsigned)(tgt.end - tgt.start) < 0x10u) {
+    return 0;
+  }
+
+  MemoryNode* nn = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&tgt, 0x4652);
+  _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(c, nn, below);
+  return 1;
+}
+
+}

--- a/src/_ZN3HUD17RenderHealthMeterEv.cpp
+++ b/src/_ZN3HUD17RenderHealthMeterEv.cpp
@@ -1,0 +1,54 @@
+//cpp
+// _ZN3HUD17RenderHealthMeterEv at 0x020fcfec
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+struct OamAttr;
+
+extern "C" {
+
+extern unsigned char data_0209f250[];
+extern void* data_0209f394[];
+extern unsigned char data_ov002_0211117c[];
+
+extern struct OamAttr* data_ov002_0210c254[];
+extern struct OamAttr* data_ov002_0210c278[];
+extern struct OamAttr* data_ov002_0210c230[];
+extern int data_ov002_0210c29c[];
+
+extern struct OamAttr data_ov002_0210d5d0;
+extern struct OamAttr data_ov002_0210d4f0;
+extern struct OamAttr data_ov002_0210c690;
+
+extern short data_ov002_0210c310[];
+
+extern int _ZN6Player16IsInsideOfCannonEv(void* thisptr);
+extern int GetOwnerLanguage(void);
+extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+    int a, struct OamAttr* attr, int x, int y, int e, int f, int g, int h, int i, int j);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
+
+void _ZN3HUD17RenderHealthMeterEv(void* thisptr)
+{
+    if (_ZN6Player16IsInsideOfCannonEv(data_0209f394[data_0209f250[0]])) return;
+
+    if (GetOwnerLanguage() == 5) {
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, data_ov002_0210c254[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, &data_ov002_0210d5d0, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+    } else if (GetOwnerLanguage() == 4 || GetOwnerLanguage() == 2) {
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, data_ov002_0210c278[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, &data_ov002_0210d4f0, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+    } else {
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, data_ov002_0210c230[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+            0, &data_ov002_0210c690, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+    }
+
+    _ZN2GX11LoadOBJPlttEPKvjj(
+        &data_ov002_0210c310[data_ov002_0210c29c[data_ov002_0211117c[0]]], 0x60, 0x20);
+}
+
+}

--- a/src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c
+++ b/src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c
@@ -1,0 +1,49 @@
+/* _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b at 0x02039488
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int func_02037e78(int *p);
+extern int func_0203547c(unsigned char *p);
+extern int func_02037e20(int *p);
+extern int func_0203543c(unsigned char *p);
+extern int func_02037e2c(int *p);
+extern int func_0203545c(unsigned char *p);
+extern int func_02037e14(int *p);
+extern int func_02037e38(int *p);
+extern int func_02035408(unsigned char *p);
+extern int func_020353d4(unsigned char *p);
+extern int func_020354b0(unsigned char *p);
+
+int _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(void *p, int *clps, unsigned char *bg, int flag)
+{
+    int r4 = 0;
+
+    if (func_02037e78(clps)) {
+        r4 = 1;
+        if (func_0203547c(bg) == 0) return r4;
+    }
+    if (func_02037e20(clps)) {
+        r4 = 1;
+        if (func_0203543c(bg) == 0) return r4;
+    }
+    if (func_02037e2c(clps)) {
+        r4 = 1;
+        if (func_0203545c(bg) != 0) return r4;
+    }
+    if (func_02037e14(clps)) {
+        r4 = 1;
+        if (func_0203545c(bg) == 0) return r4;
+    }
+    if (func_02037e38(clps) == 0x11) {
+        r4 = 1;
+        if (func_02035408(bg) != 0) return r4;
+    }
+    if (flag != 0 && func_02037e38(clps) == 0x14) {
+        r4 = 1;
+        if (func_020353d4(bg) != 0) return r4;
+    }
+    if (r4 == 0) {
+        if (func_020354b0(bg) == 0) return 1;
+    }
+    return 0;
+}

--- a/src/_ZN4cstd5atan2E5Fix12IiES1_.c
+++ b/src/_ZN4cstd5atan2E5Fix12IiES1_.c
@@ -1,0 +1,50 @@
+/* _ZN4cstd5atan2E5Fix12IiES1_ at 0x0203b4dc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int s32;
+typedef short s16;
+
+extern s32 _ZN4cstd4fdivEii(s32 num, s32 den);
+extern s32 func_01ffa4bc(s32 a);
+extern s32 func_01ff98f4(s32 a, s32 b);
+extern unsigned short data_020994e0[];
+
+s16 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x)
+{
+    s32 r;
+    if (y == 0) {
+        if (x >= 0)
+            r = 0;
+        else
+            r = 0x8000;
+    } else if (x == 0) {
+        if (y >= 0)
+            r = 0x4000;
+        else
+            r = 0xc000;
+    } else if (y >= 0) {
+        if (x >= 0) {
+            if (x >= y)
+                r = data_020994e0[_ZN4cstd4fdivEii(y, x) >> 2];
+            else
+                r = 0x4000 - data_020994e0[_ZN4cstd4fdivEii(x, y) >> 2];
+        } else {
+            if (-x < y)
+                r = data_020994e0[_ZN4cstd4fdivEii(-x, y) >> 2] + 0x4000;
+            else
+                r = 0x8000 - data_020994e0[_ZN4cstd4fdivEii(y, -x) >> 2];
+        }
+    } else if (func_01ff98f4(func_01ffa4bc(x), 0)) {
+        if (x <= y)
+            r = data_020994e0[_ZN4cstd4fdivEii(-y, -x) >> 2] + 0x8000;
+        else
+            r = 0xc000 - data_020994e0[_ZN4cstd4fdivEii(-x, -y) >> 2];
+    } else {
+        if (x < -y)
+            r = data_020994e0[_ZN4cstd4fdivEii(x, -y) >> 2] + 0xc000;
+        else
+            r = -data_020994e0[_ZN4cstd4fdivEii(-y, x) >> 2];
+    }
+    return (s16)r;
+}

--- a/src/_ZN5Stage12RenderNumberEhiibi.cpp
+++ b/src/_ZN5Stage12RenderNumberEhiibi.cpp
@@ -1,0 +1,45 @@
+//cpp
+// _ZN5Stage12RenderNumberEhiibi at 0x020250d0
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+struct OamAttr;
+struct Matrix2x2;
+
+class OAM {
+public:
+    static void Render(bool sub, OamAttr *data, int x, int y, int a, int b, Matrix2x2 *mtx);
+};
+
+class Stage {
+public:
+    static void RenderNumber(unsigned char num, int x, int y, bool b, int p5);
+};
+
+extern "C" int __aeabi_idiv(int, int);
+extern unsigned char data_020755b8[];
+extern OamAttr *func_020aba70[];
+
+void Stage::RenderNumber(unsigned char num, int x, int y, bool b, int p5)
+{
+    int leading = 0;
+    Matrix2x2 *mtx = 0;
+    int i;
+
+    for (i = 0; i < 3; i++)
+    {
+        int digit = __aeabi_idiv(num, data_020755b8[i]);
+        if (digit != 0 || leading != 0 || i == 2)
+        {
+            if (b == 0)
+            {
+                OAM::Render(true, func_020aba70[digit], x, y, p5, -1, mtx);
+            }
+            else
+            {
+                OAM::Render(false, func_020aba70[digit], x, y, p5, -1, 0);
+            }
+            leading = 1;
+            x += 9;
+        }
+        num = num % data_020755b8[i];
+    }
+}

--- a/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
+++ b/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
@@ -1,0 +1,42 @@
+//cpp
+// _ZN5Stage20RenderBouncingArrowsEv at 0x02023be0
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+extern "C" {
+extern int data_0208ee44;
+extern int data_020a0db0;
+extern unsigned char data_0209f2c4;
+extern unsigned char data_0209f284;
+extern unsigned char data_0209f2d8;
+extern unsigned char data_0209f248;
+extern void func_020abd88(void);
+int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
+
+void _ZN5Stage20RenderBouncingArrowsEv(void) {
+    int r4;
+    unsigned char A;
+    if (data_0208ee44 == 1) {
+        r4 = (data_020a0db0 & 0x10) ? 0xae : 0xb0;
+    } else {
+        r4 = (data_020a0db0 & 8) ? 0xae : 0xb0;
+    }
+    A = data_0209f2c4;
+    if (A == 0 && data_0209f284 != 0) {
+        int t = (data_0209f2d8 == 1);
+        if (t == 0) goto draw1;
+    }
+    if (A == 0) goto draw2;
+    {
+        unsigned char d = data_0209f248;
+        if ((unsigned char)(d + 0xf7) > 2u) goto draw2;
+    }
+draw1:
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0x40, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0x80, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xc0, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    return;
+draw2:
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xc, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xf4, r4, -1, -1, 0x1000, 0x1000, 0, -1);
+    return;
+}
+}

--- a/src/_ZN5Stage21RenderVsModeCountdownEv.cpp
+++ b/src/_ZN5Stage21RenderVsModeCountdownEv.cpp
@@ -1,0 +1,65 @@
+//cpp
+// _ZN5Stage21RenderVsModeCountdownEv at 0x0202a168
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+struct Base {
+    virtual void v0(); virtual void v1(); virtual void v2();
+    virtual void v3(); virtual void v4(); virtual int m();
+};
+extern "C" {
+extern unsigned char* data_0209f394[4];
+extern Base* data_0209f5bc;
+extern unsigned char data_0209fc50;
+extern unsigned char data_0209f2bc;
+extern unsigned short data_0209f304;
+extern int data_ov002_0210d008;
+extern int data_ov002_0210d098;
+extern int data_ov002_0210d130;
+extern int data_ov002_0210d1c8;
+extern int data_ov002_0210d210;
+extern void* data_ov002_0210ca0c[];
+extern int data_ov002_0210d378;
+extern int data_ov002_0210d3a0;
+extern int data_ov002_0210d3c0;
+extern int data_ov002_0210d3e0;
+extern int data_ov002_0210d420;
+int GetOwnerLanguage(void);
+int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
+}
+
+extern "C" void _ZN5Stage21RenderVsModeCountdownEv(void) {
+    int count = 0;
+    int i;
+    for (i = 0; i < 4; i++) {
+        if (data_0209f394[i]) {
+            int t = (data_0209f394[i][0x711] != 0);
+            if (t == 1) count++;
+        }
+    }
+    if (data_0209f5bc->m() == 0) return;
+    if (count < data_0209fc50) return;
+    if (data_0209f2bc != 0) {
+        if (GetOwnerLanguage() == 5)
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d008, 0x80, 0x30, -1,-1,0x1000,0x1000,0,-1);
+        else if (GetOwnerLanguage() == 4)
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d098, 0x80, 0x30, -1,-1,0x1000,0x1000,0,-1);
+        else if (GetOwnerLanguage() == 3)
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d130, 0x80, 0x30, -1,-1,0x1000,0x1000,0,-1);
+        else if (GetOwnerLanguage() == 2)
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d1c8, 0x80, 0x30, -1,-1,0x1000,0x1000,0,-1);
+        else
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d210, 0x80, 0x30, -1,-1,0x1000,0x1000,0,-1);
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov002_0210ca0c[3 - data_0209f2bc], 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+        return;
+    }
+    if (data_0209f304 == 0) return;
+    if (GetOwnerLanguage() == 5)
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d378, 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+    else if (GetOwnerLanguage() == 4)
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d3a0, 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+    else if (GetOwnerLanguage() == 3)
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d3c0, 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+    else if (GetOwnerLanguage() == 2)
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d3e0, 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+    else
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)&data_ov002_0210d420, 0x80, 0x50, -1,-1,0x1000,0x1000,0,-1);
+}

--- a/src/_ZN6Player12Unk_020c9e5cEh.c
+++ b/src/_ZN6Player12Unk_020c9e5cEh.c
@@ -1,0 +1,74 @@
+struct State { int a; int b; };
+extern int _ZN6Player7IsStateERNS_5StateE(void *c, struct State *s);
+extern struct State data_ov002_0211022c;
+
+int _ZN6Player12Unk_020c9e5cEh(void *c, unsigned char h){
+  if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211022c)) return 0;
+  if(*(unsigned char*)((char*)c+0x70a) != h) return 0;
+  switch(h){
+  case 0:
+  case 3:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==1) return 1; }
+    break;
+  case 0x11:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==0x18) return 1; }
+    /* fallthrough */
+  case 1:
+  case 2:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==2 || (unsigned char)(s+0xec)<=1) return 1; }
+    break;
+  case 4:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==3) return 1; }
+    break;
+  case 5:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xfc)<=1) return 1; }
+    break;
+  case 6:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==6) return 1; }
+    break;
+  case 7:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xf9)<=1) return 1; }
+    break;
+  case 8:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==9 || (unsigned char)(s+0xec)<=1) return 1; }
+    break;
+  case 9:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xf5)<=2) return 1; }
+    break;
+  case 0xa:
+  case 0xc:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xf2)<=1) return 1; }
+    break;
+  case 0xb:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==0x10) return 1; }
+    break;
+  case 0xd:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==0x11) return 1; }
+    break;
+  case 0xe:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if(s==0x12) return 1; }
+    break;
+  case 0xf:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xea)<=1) return 1; }
+    break;
+  case 0x10:
+    { unsigned char s = *(unsigned char*)((char*)c+0x6e3);
+      if((unsigned char)(s+0xe8)<=1) return 1; }
+    break;
+  }
+  return 0;
+}

--- a/src/_ZN7Clipper13Func_0201559CEv.c
+++ b/src/_ZN7Clipper13Func_0201559CEv.c
@@ -1,0 +1,43 @@
+/* _ZN7Clipper13Func_0201559CEv at 0x0201559c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int s32;
+typedef s32 Fix12i;
+typedef struct { s32 x, y, z; } Vector3;
+
+struct Clipper {
+    char pad0[4];        /* 0x00 */
+    Vector3 v[4];        /* 0x04, 0x10, 0x1c, 0x28 */
+    char pad1[0x18];     /* 0x34 .. 0x4b */
+    s32 m4c;             /* 0x4c */
+    s32 m50;             /* 0x50 */
+    char pad2[4];        /* 0x54 */
+    unsigned short m58;  /* 0x58 */
+};
+
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern void CrossVec3(Vector3* a, Vector3* b, Vector3* result);
+extern void NormalizeVec3(Vector3* src, Vector3* dst);
+extern short data_02082214[];
+
+void _ZN7Clipper13Func_0201559CEv(struct Clipper* thiz)
+{
+    int idx = (int)thiz->m58 >> 4;
+    int q = _ZN4cstd4fdivEii(data_02082214[2 * idx], data_02082214[2 * idx + 1]);
+    Fix12i b = (Fix12i)(((long long)thiz->m50 * q + 0x800) >> 12);
+    Fix12i c = (Fix12i)(((long long)thiz->m4c * b + 0x800) >> 12);
+    Vector3 v0, v1, v2, v3;
+    v0.x = -c; v0.y = -b; v0.z = -thiz->m50;
+    v1.x = -c; v1.y = b;  v1.z = -thiz->m50;
+    v2.x = c;  v2.y = b;  v2.z = -thiz->m50;
+    v3.x = c;  v3.y = -b; v3.z = -thiz->m50;
+    CrossVec3(&v1, &v0, &thiz->v[0]);
+    CrossVec3(&v2, &v1, &thiz->v[1]);
+    CrossVec3(&v3, &v2, &thiz->v[2]);
+    CrossVec3(&v0, &v3, &thiz->v[3]);
+    NormalizeVec3(&thiz->v[0], &thiz->v[0]);
+    NormalizeVec3(&thiz->v[1], &thiz->v[1]);
+    NormalizeVec3(&thiz->v[2], &thiz->v[2]);
+    NormalizeVec3(&thiz->v[3], &thiz->v[3]);
+}

--- a/src/__sinit_ov036_0211279c.c
+++ b/src/__sinit_ov036_0211279c.c
@@ -1,0 +1,52 @@
+/* __sinit_ov036_0211279c at 0x0211279c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov036).
+ */
+extern void func_02017acc();
+extern void func_020731dc();
+extern void func_02017b4c();
+extern int func_02017ab4[];
+extern int func_02017b34[];
+extern int data_ov036_0211411c[];
+extern int data_ov036_02114178[];
+extern int data_ov036_021140fc[];
+extern int data_ov036_02114184[];
+extern int data_ov036_021140e4[];
+extern int data_ov036_02114124[];
+extern int data_ov036_02114104[];
+extern int data_ov036_02114130[];
+extern int data_ov036_0211410c[];
+extern int data_ov036_0211413c[];
+extern int data_ov036_021140f4[];
+extern int data_ov036_02114148[];
+extern int data_ov036_021140d4[];
+extern int data_ov036_02114154[];
+extern int data_ov036_021140ec[];
+extern int data_ov036_02114160[];
+extern int data_ov036_02114114[];
+extern int data_ov036_0211416c[];
+extern int data_ov036_021140dc[];
+extern int data_ov036_02114190[];
+void __sinit_ov036_0211279c(void)
+{
+    func_02017acc(data_ov036_0211411c, 0x69a);
+    func_020731dc(data_ov036_0211411c, func_02017ab4, data_ov036_02114178);
+    func_02017acc(data_ov036_021140fc, 0x69c);
+    func_020731dc(data_ov036_021140fc, func_02017ab4, data_ov036_02114184);
+    func_02017acc(data_ov036_021140e4, 0x69e);
+    func_020731dc(data_ov036_021140e4, func_02017ab4, data_ov036_02114124);
+    func_02017acc(data_ov036_02114104, 0x6a0);
+    func_020731dc(data_ov036_02114104, func_02017ab4, data_ov036_02114130);
+    func_02017acc(data_ov036_0211410c, 0x6a2);
+    func_020731dc(data_ov036_0211410c, func_02017ab4, data_ov036_0211413c);
+    func_02017b4c(data_ov036_021140f4, 0x69b);
+    func_020731dc(data_ov036_021140f4, func_02017b34, data_ov036_02114148);
+    func_02017b4c(data_ov036_021140d4, 0x69d);
+    func_020731dc(data_ov036_021140d4, func_02017b34, data_ov036_02114154);
+    func_02017b4c(data_ov036_021140ec, 0x69f);
+    func_020731dc(data_ov036_021140ec, func_02017b34, data_ov036_02114160);
+    func_02017b4c(data_ov036_02114114, 0x6a1);
+    func_020731dc(data_ov036_02114114, func_02017b34, data_ov036_0211416c);
+    func_02017b4c(data_ov036_021140dc, 0x6a3);
+    func_020731dc(data_ov036_021140dc, func_02017b34, data_ov036_02114190);
+}

--- a/src/__sinit_ov091_021346e8.c
+++ b/src/__sinit_ov091_021346e8.c
@@ -1,0 +1,67 @@
+/* __sinit_ov091_021346e8 at 0x021346e8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov091).
+ */
+extern int func_02017acc();
+extern void func_020731dc();
+extern int func_02017b4c();
+extern char data_ov091_02135520[];
+extern char data_ov091_02135598[];
+extern char data_ov091_02135538[];
+extern char data_ov091_021355b0[];
+extern char data_ov091_02135560[];
+extern char data_ov091_021355c8[];
+extern char data_ov091_021354f8[];
+extern char data_ov091_021355f8[];
+extern char data_ov091_02135528[];
+extern char data_ov091_021355e0[];
+extern char data_ov091_02135518[];
+extern char data_ov091_021355ec[];
+extern char data_ov091_02135558[];
+extern char data_ov091_02135568[];
+extern char data_ov091_02135550[];
+extern char data_ov091_021355a4[];
+extern char data_ov091_02135510[];
+extern char data_ov091_02135574[];
+extern char data_ov091_02135540[];
+extern char data_ov091_02135580[];
+extern char data_ov091_02135548[];
+extern char data_ov091_0213558c[];
+extern char data_ov091_02135500[];
+extern char data_ov091_021355bc[];
+extern char data_ov091_02135508[];
+extern char data_ov091_021355d4[];
+extern char data_ov091_02135530[];
+extern char data_ov091_02135604[];
+extern void func_02017ab4(void);
+extern void func_02017b34(void);
+void __sinit_ov091_021346e8(void) {
+    func_02017acc(data_ov091_02135520, 0x647);
+    func_020731dc(data_ov091_02135520, func_02017ab4, data_ov091_02135598);
+    func_02017b4c(data_ov091_02135538, 0x648);
+    func_020731dc(data_ov091_02135538, func_02017b34, data_ov091_021355b0);
+    func_02017acc(data_ov091_02135560, 0x679);
+    func_020731dc(data_ov091_02135560, func_02017ab4, data_ov091_021355c8);
+    func_02017b4c(data_ov091_021354f8, 0x67a);
+    func_020731dc(data_ov091_021354f8, func_02017b34, data_ov091_021355f8);
+    func_02017acc(data_ov091_02135528, 0x67b);
+    func_020731dc(data_ov091_02135528, func_02017ab4, data_ov091_021355e0);
+    func_02017b4c(data_ov091_02135518, 0x67c);
+    func_020731dc(data_ov091_02135518, func_02017b34, data_ov091_021355ec);
+    func_02017acc(data_ov091_02135558, 0x6a9);
+    func_020731dc(data_ov091_02135558, func_02017ab4, data_ov091_02135568);
+    func_02017b4c(data_ov091_02135550, 0x6aa);
+    func_020731dc(data_ov091_02135550, func_02017b34, data_ov091_021355a4);
+    func_02017acc(data_ov091_02135510, 0x665);
+    func_020731dc(data_ov091_02135510, func_02017ab4, data_ov091_02135574);
+    func_02017b4c(data_ov091_02135540, 0x666);
+    func_020731dc(data_ov091_02135540, func_02017b34, data_ov091_02135580);
+    func_02017acc(data_ov091_02135548, 0x667);
+    func_020731dc(data_ov091_02135548, func_02017ab4, data_ov091_0213558c);
+    func_02017b4c(data_ov091_02135500, 0x668);
+    func_020731dc(data_ov091_02135500, func_02017b34, data_ov091_021355bc);
+    func_02017acc(data_ov091_02135508, 0x59f);
+    func_020731dc(data_ov091_02135508, func_02017ab4, data_ov091_021355d4);
+    func_02017b4c(data_ov091_02135530, 0x5a0);
+    func_020731dc(data_ov091_02135530, func_02017b34, data_ov091_02135604);
+}

--- a/src/__sinit_ov102_0214d714.c
+++ b/src/__sinit_ov102_0214d714.c
@@ -1,0 +1,62 @@
+/* __sinit_ov102_0214d714 at 0x0214d714
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov102).
+ */
+extern void func_02017acc();
+extern void func_020731dc();
+extern void func_02017b4c();
+extern void func_02017ab4(void);
+extern void func_02017b34(void);
+
+extern char data_ov102_0214e710[];
+extern char data_ov102_0214e788[];
+extern char data_ov102_0214e6e8[];
+extern char data_ov102_0214e7a0[];
+extern char data_ov102_0214e700[];
+extern char data_ov102_0214e7ac[];
+extern char data_ov102_0214e718[];
+extern char data_ov102_0214e740[];
+extern char data_ov102_0214e730[];
+extern char data_ov102_0214e794[];
+extern char data_ov102_0214e720[];
+extern char data_ov102_0214e758[];
+extern char data_ov102_0214e738[];
+extern char data_ov102_0214e764[];
+extern char data_ov102_0214e6f0[];
+extern char data_ov102_0214e770[];
+extern char data_ov102_0214e6e0[];
+extern char data_ov102_0214e7c4[];
+extern char data_ov102_0214e6f8[];
+extern char data_ov102_0214e77c[];
+extern char data_ov102_0214e708[];
+extern char data_ov102_0214e7b8[];
+extern char data_ov102_0214e728[];
+extern char data_ov102_0214e74c[];
+
+void __sinit_ov102_0214d714(void)
+{
+    func_02017acc(data_ov102_0214e710, 0x643);
+    func_020731dc(data_ov102_0214e710, func_02017ab4, data_ov102_0214e788);
+    func_02017acc(data_ov102_0214e6e8, 0x63f);
+    func_020731dc(data_ov102_0214e6e8, func_02017ab4, data_ov102_0214e7a0);
+    func_02017acc(data_ov102_0214e700, 0x59d);
+    func_020731dc(data_ov102_0214e700, func_02017ab4, data_ov102_0214e7ac);
+    func_02017acc(data_ov102_0214e718, 0x461);
+    func_020731dc(data_ov102_0214e718, func_02017ab4, data_ov102_0214e740);
+    func_02017acc(data_ov102_0214e730, 0x68b);
+    func_020731dc(data_ov102_0214e730, func_02017ab4, data_ov102_0214e794);
+    func_02017acc(data_ov102_0214e720, 0x68f);
+    func_020731dc(data_ov102_0214e720, func_02017ab4, data_ov102_0214e758);
+    func_02017b4c(data_ov102_0214e738, 0x644);
+    func_020731dc(data_ov102_0214e738, func_02017b34, data_ov102_0214e764);
+    func_02017b4c(data_ov102_0214e6f0, 0x640);
+    func_020731dc(data_ov102_0214e6f0, func_02017b34, data_ov102_0214e770);
+    func_02017b4c(data_ov102_0214e6e0, 0x59e);
+    func_020731dc(data_ov102_0214e6e0, func_02017b34, data_ov102_0214e7c4);
+    func_02017b4c(data_ov102_0214e6f8, 0x462);
+    func_020731dc(data_ov102_0214e6f8, func_02017b34, data_ov102_0214e77c);
+    func_02017b4c(data_ov102_0214e708, 0x68c);
+    func_020731dc(data_ov102_0214e708, func_02017b34, data_ov102_0214e7b8);
+    func_02017b4c(data_ov102_0214e728, 0x690);
+    func_020731dc(data_ov102_0214e728, func_02017b34, data_ov102_0214e74c);
+}

--- a/src/func_02007698.c
+++ b/src/func_02007698.c
@@ -1,0 +1,63 @@
+/* func_02007698 at 0x02007698
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int Fix12i;
+
+typedef struct Vector3 {
+    Fix12i x, y, z;
+} Vector3;
+
+typedef struct Vector3_16 {
+    short x, y, z;
+} Vector3_16;
+
+typedef struct Actor {
+    char _pad0[0x5c];
+    Vector3 pos;        // 0x5c
+    char _pad1[0x8c - (0x5c + 0xc)];
+    Vector3_16 ang;     // 0x8c
+} Actor;
+
+typedef struct Camera {
+    char _pad0[0x80];
+    Vector3 field_0x80; // 0x80
+    Vector3 field_0x8c; // 0x8c
+    char _pad1[0x110 - (0x8c + 0xc)];
+    Actor* owner;       // 0x110
+} Camera;
+
+extern short ReadUnalignedShort(const char* from);
+extern void Vec3_RotateYAndTranslate(Vector3* res, const Vector3* translation,
+                                     short angY, const Vector3* v);
+
+int func_02007698(Camera* self, const char* rec) {
+    Vector3 v;
+    Vector3 w;
+    Actor* owner;
+    short angle;
+    Vector3* pos;
+    int vx, vy, vz;
+    int wx, wy, wz;
+
+    vz = (Fix12i)ReadUnalignedShort(rec + 4) << 12;
+    vy = (Fix12i)ReadUnalignedShort(rec + 2) << 12;
+    vx = (Fix12i)ReadUnalignedShort(rec + 0) << 12;
+    v.x = vx;
+    v.y = vy;
+    v.z = vz;
+
+    wz = (Fix12i)ReadUnalignedShort(rec + 0xa) << 12;
+    wy = (Fix12i)ReadUnalignedShort(rec + 8) << 12;
+    wx = (Fix12i)ReadUnalignedShort(rec + 6) << 12;
+    w.x = wx;
+    w.y = wy;
+    w.z = wz;
+
+    owner = self->owner;
+    pos = &owner->pos;
+    angle = owner->ang.y + 0x8000;
+    Vec3_RotateYAndTranslate(&self->field_0x80, pos, angle, &v);
+    Vec3_RotateYAndTranslate(&self->field_0x8c, pos, angle, &w);
+    return 1;
+}

--- a/src/func_0200814c.c
+++ b/src/func_0200814c.c
@@ -1,0 +1,32 @@
+/* func_0200814c at 0x0200814c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef struct Vec3 { int x, y, z; } Vec3;
+
+extern struct Actor *func_0200e6d8(unsigned int arg0);
+extern void Vec3_RotateYAndTranslate(Vec3 *out, const Vec3 *trans, short ang, const Vec3 *add);
+
+int func_0200814c(int self)
+{
+    struct Actor *a;
+    int diff, absdiff, val;
+    Vec3 v;
+
+    a = func_0200e6d8(0);
+    diff = *(int *)((char *)a + 0x60) - *(int *)(self + 0x90);
+    v.x = 0;
+    v.y = 0x50000;
+    v.z = diff;
+    absdiff = diff < 0 ? -diff : diff;
+    val = (int)(((long long)absdiff * -0x199 + 0x800) >> 12);
+    v.z = val;
+    if (val > -0x64000)
+        v.z = -0x64000;
+    if (diff > -0x300000)
+        Vec3_RotateYAndTranslate((Vec3 *)(self + 0x80),
+                                 (const Vec3 *)((char *)a + 0x5c),
+                                 *(short *)((char *)a + 0x8e),
+                                 &v);
+    return 1;
+}

--- a/src/func_02011dcc.c
+++ b/src/func_02011dcc.c
@@ -1,0 +1,23 @@
+/* func_02011dcc at 0x02011dcc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int func_02051fb4(int *g, int x);
+extern void func_02049764(void);
+extern void func_02013078(void);
+extern void func_0204921c(int *g, int v);
+extern int data_0209b4a0[];
+extern int data_0208e438;
+
+int func_02011dcc(int *g, int x)
+{
+    int r4 = func_02051fb4(g, x);
+    if (r4 != 0 && g == data_0209b4a0) {
+        func_02049764();
+        func_02013078();
+        if (data_0208e438 >= 0) {
+            func_0204921c(g, data_0208e438);
+        }
+    }
+    return r4;
+}

--- a/src/func_0201818c.c
+++ b/src/func_0201818c.c
@@ -1,0 +1,48 @@
+/* func_0201818c at 0x0201818c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct Obj { char pad[0x20]; unsigned int cur; unsigned int end; char pad2[0x1c]; };
+
+extern int func_020186c0(unsigned int val);
+extern int func_02018568(int a);
+extern unsigned func_02018ac4(unsigned *p);
+extern int _ZN6Memory8AllocateEj(unsigned int);
+extern void DecompressLZ16(void *src, void *dst);
+extern void func_020185c0(void *buf, int x);
+extern void func_0205d4cc(void *a);
+extern int _ZN6Memory8AllocateEji(unsigned int, int);
+extern void func_0205a61c(int a, int b, unsigned int c);
+extern void func_02018770(void);
+extern void _ZN4CP1514FlushDataCacheEjj(unsigned int a, unsigned int b);
+extern unsigned int func_02018a24(unsigned int i);
+extern int func_0201834c(void *buf, int x);
+
+int func_0201818c(unsigned int arg0, int arg1)
+{
+    struct Obj obj;
+    char buf[0x44];
+    int p = func_020186c0(arg0);
+    if (p != 0) {
+        unsigned int size;
+        int mem;
+        if (func_02018568(p)) {
+            unsigned int *q = (unsigned int *)(p + 4);
+            size = func_02018ac4(q);
+            mem = _ZN6Memory8AllocateEj(size);
+            DecompressLZ16(q, (void *)mem);
+        } else {
+            func_020185c0(&obj, arg0);
+            size = obj.end - obj.cur;
+            func_0205d4cc(&obj);
+            mem = _ZN6Memory8AllocateEji(size, 0x20);
+            func_0205a61c(p, mem, size);
+        }
+        func_02018770();
+        if (arg1 != 0)
+            _ZN4CP1514FlushDataCacheEjj(mem, size);
+        return mem;
+    }
+    func_020185c0(buf, func_02018a24(arg0));
+    return func_0201834c(buf, arg1);
+}

--- a/src/func_0201834c.c
+++ b/src/func_0201834c.c
@@ -1,0 +1,46 @@
+/* func_0201834c at 0x0201834c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct Obj { char pad[0x20]; unsigned int cur; unsigned int end; };
+
+extern void *_ZN6Memory8AllocateEji(unsigned int size, int align);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int a, unsigned int b);
+extern int func_02018d48(struct Obj *a, void *b, unsigned int c);
+extern int func_02018568(void *a);
+extern unsigned int func_02018ac4(void *p);
+extern void *_ZN6Memory8AllocateEj(unsigned int size);
+extern void DecompressLZ16(void *src, void *dst);
+extern void func_0205a61c(void *a, void *b, unsigned int c);
+extern void _ZN6Memory10DeallocateEPv(void *p);
+extern void Crash(void);
+extern void func_0205d4cc(struct Obj *a);
+extern void func_02018770(void);
+extern void _ZN4CP1514FlushDataCacheEjj(unsigned int a, unsigned int b);
+
+unsigned int func_0201834c(struct Obj *self, int flag)
+{
+    unsigned int result = 0;
+    unsigned int len = self->end - self->cur;
+    if (len > 8) {
+        void *buf = _ZN6Memory8AllocateEji(len, -4);
+        _ZN4CP1527FlushAndInvalidateDataCacheEjj((unsigned int)buf, len);
+        int r = func_02018d48(self, buf, len);
+        if (r != len) return result;
+        if (func_02018568(buf) != 0) {
+            len = func_02018ac4((void *)((char *)buf + 4));
+            result = (unsigned int)_ZN6Memory8AllocateEj(len);
+            DecompressLZ16((void *)((char *)buf + 4), (void *)result);
+        } else {
+            result = (unsigned int)_ZN6Memory8AllocateEj(len);
+            func_0205a61c(buf, (void *)result, len);
+        }
+        _ZN6Memory10DeallocateEPv(buf);
+    } else {
+        Crash();
+    }
+    func_0205d4cc(self);
+    func_02018770();
+    if (flag != 0) _ZN4CP1514FlushDataCacheEjj(result, len);
+    return result;
+}

--- a/src/func_02018474.c
+++ b/src/func_02018474.c
@@ -1,0 +1,21 @@
+/* func_02018474 at 0x02018474
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct V2 { int x, y; };
+
+extern void func_0205d874(int *s);
+extern int func_02018dc4(int buf, struct V2 ab);
+extern void Crash(void);
+extern int func_020184e0(int *buf, unsigned int c, unsigned int d);
+
+int func_02018474(int a, int b, int c, int d, ...)
+{
+    int buf[0x11];
+    func_0205d874(buf);
+    if (func_02018dc4((int)buf, *(struct V2 *)&a) == 0) {
+        Crash();
+        return 0;
+    }
+    return func_020184e0(buf, c, d);
+}

--- a/src/func_02018934.c
+++ b/src/func_02018934.c
@@ -1,0 +1,39 @@
+/* func_02018934 at 0x02018934
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned int u32;
+
+extern void func_0205d874(int *s);
+extern int func_02018d98(int *s, int a);
+extern void *_ZN4Heap9_AllocateEji(void *heap, u32 size, int align);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
+extern int func_02018d48(int *s, void *buf, int n);
+extern int func_0204ee40(void *a, void *b, void *c);
+extern void _ZN4Heap11_DeallocateEPv(void *heap, void *ptr);
+extern void func_0205d4cc(int *s);
+
+void *func_02018934(void *arg0, int arg1, void *heap)
+{
+    int buf[0x11];
+    void *result = 0;
+    void *ptr;
+    void *p60;
+    int diff, aligned;
+
+    func_0205d874(buf);
+    func_02018d98(buf, arg1);
+    diff = buf[9] - buf[8];
+    aligned = (diff + 0xf) & ~0xf;
+    ptr = _ZN4Heap9_AllocateEji(heap, aligned + 0x60, -0x10);
+    p60 = (char *)ptr + 0x60;
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)p60, aligned);
+    if (func_02018d48(buf, p60, diff) == diff &&
+        func_0204ee40(ptr, arg0, p60)) {
+        result = ptr;
+    } else {
+        _ZN4Heap11_DeallocateEPv(heap, ptr);
+    }
+    func_0205d4cc(buf);
+    return result;
+}

--- a/src/func_0201a2f8.c
+++ b/src/func_0201a2f8.c
@@ -1,0 +1,57 @@
+/* func_0201a2f8 at 0x0201a2f8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_0201fec8(void);
+extern void func_02018aa4(void);
+extern void func_020134c8(void);
+extern int GetSoundMode(void);
+extern void SetSoundMode(int mode);
+extern int func_0205d94c(int a, int b);
+extern void* _ZN6Memory8AllocateEj(unsigned int);
+extern void LoadOverlay(int id);
+extern void func_020aa420(void);
+extern void UnloadOverlay(int id);
+extern void func_0205d23c(void* p, int n);
+extern void func_0205c91c(void);
+extern void _ZN6Memory10DeallocateEPv(void*);
+extern void _ZN5Sound19LoadGroupAndSetBankEii(int a, int b);
+extern void _ZN5Sound16LoadInitialGroupEi(int group);
+extern void LoadFont(int id);
+
+extern int overlay_0;
+extern int overlay_1;
+extern int data_0208ee5c;
+
+void func_0201a2f8(void) {
+    int cond = (*(unsigned short*)0x27ffc40 == 2);
+    void* ptr;
+    if (cond) {
+        func_0201fec8();
+        func_02018aa4();
+        func_020134c8();
+        SetSoundMode(GetSoundMode());
+    }
+    ptr = 0;
+    if (!cond) {
+        int size = func_0205d94c(0, 0);
+        ptr = _ZN6Memory8AllocateEj(size);
+        func_0205d94c((int)ptr, size);
+    }
+    LoadOverlay((int)&overlay_0);
+    func_020aa420();
+    UnloadOverlay((int)&overlay_0);
+    if (ptr != 0) {
+        func_0205d23c(&data_0208ee5c, 3);
+        func_0205c91c();
+        _ZN6Memory10DeallocateEPv(ptr);
+    }
+    LoadOverlay((int)&overlay_1);
+    if (cond) {
+        _ZN5Sound19LoadGroupAndSetBankEii(0x2f, 0x36);
+    } else {
+        _ZN5Sound16LoadInitialGroupEi(0);
+    }
+    if (cond) return;
+    LoadFont(0);
+}

--- a/src/func_0201aca4.c
+++ b/src/func_0201aca4.c
@@ -1,0 +1,52 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern u8 NumStars(void);
+extern int func_020138dc(void);
+extern int _ZN8SaveData22NumGlowingRabbitsFoundEv(void);
+extern int __aeabi_idiv(int, int);
+extern void _ZN7Message7AddCharEc(int c);
+
+struct MsgTextChar {
+    u8 unk0;
+    u8 unk1;
+    u8 unk2;
+    u8 indexHi;  /* 3 */
+    u8 indexLo;  /* 4 */
+    u8 mode;     /* 5 */
+    u8 base;     /* 6 */
+};
+
+extern struct MsgTextChar* data_0209d6f4;
+extern u8 data_0208ee74[];
+extern u16 data_0208ee64[];
+
+void func_0201aca4(void) {
+    struct MsgTextChar* state = data_0209d6f4;
+    u16 idx = state->indexLo | (state->indexHi << 8);
+    switch (idx) {
+        case 0: {
+            u8 mode = state->mode;
+            u8 num = 0;
+            int leading = 0;
+            u8 base = state->base;
+            int i;
+            switch (mode) {
+                case 0: num = base - NumStars(); break;
+                case 1: num = func_020138dc(); break;
+                case 2: num = base - _ZN8SaveData22NumGlowingRabbitsFoundEv(); break;
+            }
+            for (i = 0; i < 3; i++) {
+                int q = __aeabi_idiv(num, data_0208ee64[i]);
+                if (q != 0 || leading != 0 || i == 2) {
+                    _ZN7Message7AddCharEc(data_0208ee74[q]);
+                    leading = 1;
+                }
+                num = num % data_0208ee64[i];
+            }
+            break;
+        }
+        case 1:
+            break;
+    }
+}

--- a/src/func_02038324.cpp
+++ b/src/func_02038324.cpp
@@ -1,0 +1,37 @@
+//cpp
+// func_02038324 at 0x02038324
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+extern "C" {
+int func_02037fc0(void *p);
+int func_02037f54(void *p);
+int func_020393cc(void *p);
+int func_02038298(void *p);
+int func_020393b4(void *p);
+}
+extern void *data_020a0c80[];
+
+struct Obj {
+    virtual void m0();
+    virtual void m1();
+    virtual void m2();
+    virtual void m3();
+    virtual void m4();
+    virtual void m5();
+    virtual void m6();
+    virtual void m7();
+    virtual void m8();
+    virtual void m9(void *a, int v, int b, int c, int d);
+};
+
+extern "C" void func_02038324(void *arg, int b, int c, int d)
+{
+    int idx;
+    Obj *obj;
+    if (func_02037fc0(arg) == 0) return;
+    idx = func_02037f54(arg);
+    obj = (Obj *)data_020a0c80[idx];
+    if (obj == 0) return;
+    if (func_020393cc(obj) == 0) return;
+    if (func_02038298(arg) == 0) return;
+    obj->m9(arg, func_020393b4(data_020a0c80[idx]), b, c, d);
+}

--- a/src/func_0203859c.cpp
+++ b/src/func_0203859c.cpp
@@ -1,0 +1,37 @@
+//cpp
+// func_0203859c at 0x0203859c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+extern "C" int func_020393b4(void *p);
+extern "C" int func_02035354(void *a, void *b);
+extern "C" int func_020393ac(void *p);
+extern "C" void func_02037fec(void *c, int p1, int p2, int p3, void *e);
+extern void *data_020a0c80[];
+
+class C {
+public:
+    virtual int v0();
+    virtual int v1();
+    virtual int v2();
+    virtual int v3();
+    virtual int v4();
+    virtual int v5();
+    virtual int v6();
+    virtual int v7(void *arg);
+};
+
+extern "C" int func_0203859c(void *obj)
+{
+    C *e = (C *)data_020a0c80[0];
+    int result = 0;
+    if (e != 0) {
+        if (func_02035354(obj, (void *)func_020393b4(e)) == 0) {
+            if (e->v7(obj) != 0) {
+                int a = func_020393ac(e);
+                int b = func_020393b4(e);
+                func_02037fec((char *)obj + 0x10, 0, a, b, e);
+                result = 1;
+            }
+        }
+    }
+    return result;
+}

--- a/src/func_02038a38.cpp
+++ b/src/func_02038a38.cpp
@@ -1,0 +1,45 @@
+//cpp
+// func_02038a38 at 0x02038a38
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+struct A {
+    virtual int f0();
+    virtual int f1();
+    virtual int f2();
+    virtual int f3();
+    virtual int f4();
+    virtual int f5();
+    virtual int f6();
+    virtual int f7();
+    virtual int f8(void*);
+};
+
+extern "C" int func_020393b4(struct A *p);
+extern "C" int func_020393ac(struct A *p);
+extern "C" int func_02035354(void *a, int b);
+extern "C" void func_02037fec(char *c, int p1, int p2, int p3, struct A *p4);
+extern "C" void func_020379d0(void *c, int b, int d, int e, struct A *f);
+extern "C" void func_0203799c(void *c, int b, int d, int e, struct A *f);
+extern "C" void func_02037968(void *c, int b, int d, int e, struct A *f);
+extern "C" void func_02037a38(void *o);
+
+extern "C" struct A *data_020a0c80;
+
+extern "C" int func_02038a38(void *arg0)
+{
+    struct A *o = data_020a0c80;
+    int ret = 0;
+    int flags;
+    if (o != 0 && func_02035354(arg0, func_020393b4(o)) == 0
+        && (flags = o->f8(arg0)) != 0) {
+        func_02037fec((char*)arg0 + 0x10, 0, func_020393ac(o), func_020393b4(o), o);
+        if (flags & 1)
+            func_020379d0(arg0, 0, func_020393ac(o), func_020393b4(o), o);
+        if (flags & 2)
+            func_0203799c(arg0, 0, func_020393ac(o), func_020393b4(o), o);
+        if (flags & 4)
+            func_02037968(arg0, 0, func_020393ac(o), func_020393b4(o), o);
+        ret = 1;
+    }
+    func_02037a38(arg0);
+    return ret;
+}

--- a/src/func_020431c4.c
+++ b/src/func_020431c4.c
@@ -1,0 +1,17 @@
+struct Node;
+extern void *func_0203b358(struct Node *thiz);
+extern void *func_0203b394(struct Node *thiz);
+struct Sub { unsigned char pad[0xe]; unsigned char fe; };
+struct Elem { unsigned char pad[0x10]; struct Sub *f10; };
+int func_020431c4(void *thiz){
+ struct Node *base = (struct Node *)((char *)thiz + 0x14);
+ void *end = func_0203b358(base);
+ struct Elem *node = *(struct Elem **)((char *)base + 4);
+ int t;
+ while (node != 0 && (void*)node != end) {
+   t = !node->f10->fe;
+   if (t != 0) return 1;
+   node = (struct Elem*)func_0203b394((struct Node*)node);
+ }
+ return 0;
+}

--- a/src/func_0204405c.c
+++ b/src/func_0204405c.c
@@ -1,0 +1,41 @@
+/* func_0204405c at 0x0204405c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct N {
+    struct N *prev;
+    struct N *next;
+    int pad8;
+    volatile unsigned short c;
+};
+struct L {
+    struct N *head;
+    struct N *tail;
+};
+
+extern int func_0203b244(struct L *l, struct N *n);
+extern int func_0203b2ec(struct L *l, struct N *n, struct N *p);
+
+int func_0204405c(struct L *l, struct N *n)
+{
+    struct N *node;
+    struct N *next;
+    node = l->head;
+    if (n == 0)
+        return 0;
+    if (node == 0)
+        return func_0203b244(l, n);
+    if (node->c > n->c)
+        return func_0203b2ec(l, n, 0);
+    goto enter;
+advance:
+    node = next;
+enter:
+    next = node->next;
+    if (next == 0)
+        goto done;
+    if (next->c <= n->c)
+        goto advance;
+done:
+    return func_0203b2ec(l, n, node);
+}

--- a/src/func_020441cc.cpp
+++ b/src/func_020441cc.cpp
@@ -1,0 +1,30 @@
+//cpp
+// func_020441cc at 0x020441cc
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+class Obj { public: int dummy; };
+typedef void (Obj::*PMF)();
+
+struct Node {
+    char pad[0x10];
+    Obj *obj;     // 0x10
+};
+
+struct Thing {
+    Node *head;   // 0
+    PMF callback; // 4
+};
+
+extern "C" void *func_0203b394(Node *n);
+
+extern "C" void *func_020441cc(Thing *thiz)
+{
+    Node *node;
+    if (thiz->callback == 0) return (void *)1;
+    node = thiz->head;
+    while (node) {
+        Node *next = (Node *)func_0203b394(node);
+        (node->obj->*thiz->callback)();
+        node = next;
+    }
+    return (void *)1;
+}

--- a/src/func_02044dc4.c
+++ b/src/func_02044dc4.c
@@ -1,0 +1,19 @@
+/* func_02044dc4 at 0x02044dc4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct Self;
+extern void func_02044e50(struct Self *self, int count, int base, int *out);
+
+void func_02044dc4(struct Self *self) {
+    unsigned int i;
+    int r7;
+    char *r6;
+    r6 = *(char**)self;
+    r7 = *(int*)(r6 + 4) * 0x30 + *(int*)((char*)self + 0xc);
+    for (i = 0; i < *(unsigned int*)(r6 + 0x30); i++) {
+        unsigned short *arr = *(unsigned short**)(*(char**)(r6 + 0x34) + 8);
+        func_02044e50(self, arr[2*i], arr[2*i+1], (int*)r7);
+        r7 += 0x30;
+    }
+}

--- a/src/func_02048908.c
+++ b/src/func_02048908.c
@@ -1,0 +1,61 @@
+/* func_02048908 at 0x02048908
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int data_02099fa8;
+extern int data_02099fac;
+extern u16 data_02099fa4;
+void func_0204f924(void* obj, int v);
+void func_0204f7cc(void* obj, int a, int b);
+extern int __aeabi_idiv(int a, int b);
+
+void func_02048908(void* obj, int* p)
+{
+    int num = data_02099fac;
+    int den = data_02099fa8;
+    int a = 0x7f;
+    int b = 0;
+    int* s;
+    int typ, val;
+    int cur, arg;
+    int half;
+
+    if (obj == 0) return;
+    s = *(int**)obj;
+    if (s == 0) return;
+
+    typ = *(u16*)((char*)s + 0x38);
+    val = *(u16*)((char*)s + 0x3a);
+
+    if (typ == 3) {
+        if (val >= 0x4b && val <= 0x4c) {
+            num = 0x384;
+            den = 0xc8;
+            b = 0x28;
+        } else if (val == 0x28) {
+            b = 0x78;
+            a = 0x7f;
+        }
+    } else if (typ == 1) {
+        if (val >= 0x2a && val <= 0x2b) {
+            num = 0x44c;
+            den = 0xc8;
+        }
+    }
+
+    cur = ((int*)obj)[1];
+    if ((unsigned)cur < (unsigned)den)
+        arg = a;
+    else
+        arg = b + __aeabi_idiv((a - b) * (num - cur), num - den);
+    func_0204f924(obj, arg);
+
+    half = *p >> 12;
+    half = half / 2;
+    if (half > 0x3f) half = 0x3f;
+    else if (half < -0x40) half = -0x40;
+    func_0204f7cc(obj, data_02099fa4, half);
+}

--- a/src/func_02049f58.c
+++ b/src/func_02049f58.c
@@ -1,0 +1,61 @@
+/* func_02049f58 at 0x02049f58
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern void func_0204a730(void* o, void* n);
+extern int func_0204d8e8(void* p, void* n);
+extern void func_0204d9a0(void* p, int v);
+
+typedef struct Sub {
+    u32 b_lo : 14;
+    u32 b14 : 1;        /* bit 14 */
+    u32 b_hi : 17;
+    char pad0[0x24];
+    u16 f28;            /* 0x28 */
+} Sub;
+
+typedef struct Node {
+    struct Node* next;  /* 0x0 */
+    char pad0[0x8];
+    int fc;             /* 0xc */
+    char pad1[0x4];
+    int f14;            /* 0x14 */
+    Sub** f18;          /* 0x18 */
+    u32 b0 : 1;         /* 0x1c bit 0 */
+    u32 b1 : 1;
+    u32 b2 : 1;         /* bit 2 */
+    u32 b_rest : 29;
+    char pad2[0x18];
+    u16 f38;            /* 0x38 */
+} Node;
+
+typedef struct Obj {
+    int f0;
+    Node* f4;           /* 0x4 */
+    char pad0[0x4];
+    int fc;             /* 0xc */
+} Obj;
+
+void func_02049f58(Obj* o)
+{
+    Node* n = o->f4;
+    Node* next;
+    if (n == 0) return;
+    do {
+        Sub* s = *n->f18;
+        next = n->next;
+        if (n->b2 == 0) {
+            func_0204a730(o, n);
+        }
+        if ((s->b14 != 0 && s->f28 != 0 && n->f38 > s->f28) || n->b0 != 0) {
+            if (n->fc == 0 && n->f14 == 0) {
+                int r = func_0204d8e8(&o->f4, n);
+                func_0204d9a0(&o->fc, r);
+            }
+        }
+        n = next;
+    } while (next != 0);
+}

--- a/src/func_0204f8cc.c
+++ b/src/func_0204f8cc.c
@@ -1,0 +1,12 @@
+/* func_0204f8cc at 0x0204f8cc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_02052494(void *o, int a, int b);
+
+void func_0204f8cc(char **c, int a, int b) {
+    char *p = *c;
+    if (p == 0) return;
+    if (*(unsigned char *)(p + 0x2c) == 2) return;
+    func_02052494(p + 0x1c, a << 8, b);
+}

--- a/src/func_0204f958.c
+++ b/src/func_0204f958.c
@@ -1,0 +1,20 @@
+/* func_0204f958 at 0x0204f958
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned char u8;
+extern u8 *_ZN18NestedHeapIterator4NextEP13HeapAllocator(void *iter, void *alloc);
+extern void func_0204f558(u8 *thiz, int val);
+extern char data_020a4d6c[];
+void func_0204f958(int idx, int val) {
+    u8 *cur;
+    u8 *next;
+    char *iter = &data_020a4d6c[idx * 0x1c];
+    cur = _ZN18NestedHeapIterator4NextEP13HeapAllocator(iter, 0);
+    if (cur == 0) return;
+    do {
+        next = _ZN18NestedHeapIterator4NextEP13HeapAllocator(iter, cur);
+        func_0204f558(cur, val);
+        cur = next;
+    } while (cur != 0);
+}

--- a/src/func_020507e0.c
+++ b/src/func_020507e0.c
@@ -1,0 +1,23 @@
+/* func_020507e0 at 0x020507e0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_02050798(void);
+extern void MultiStore_Int(int val, int *dst, int len);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int a, unsigned int b);
+extern int func_020503a4(int a0, int a1, int a2, int a3,
+                         int s0, int s1, int s2, int s3, int s4, int s5,
+                         int s6, int s7, int s8, int s9, int s10);
+extern int data_020a5634[];
+
+int func_020507e0(int a0, unsigned int a1, int a2, int a3, int a4, int a5, int a6)
+{
+    volatile int z;
+    func_02050798();
+    if (data_020a5634[0] != 0) return 0;
+    z = 0;
+    MultiStore_Int(z, (int *)a0, a1);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj((unsigned int)a0, a1);
+    return func_020503a4(1, a0, a0 + (a1 >> 1), a1 >> 1,
+                         a2, 0, 0, 1, a3, 0x7f, 0, 0x7f, a4, a5, a6);
+}

--- a/src/func_020509d8.c
+++ b/src/func_020509d8.c
@@ -1,0 +1,28 @@
+/* func_020509d8 at 0x020509d8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void *data_020a5bb8;
+extern int func_0205d368(int *o, int r1, int sel);
+extern int func_0205d3d4(int *o, int a1, unsigned int len);
+
+int func_020509d8(unsigned int idx, int a1, unsigned int len, unsigned int off)
+{
+    char *G = (char *)data_020a5bb8;
+    char *T = *(char **)(G + 0x7c);
+    char *entry;
+    unsigned int avail;
+
+    if (idx >= *(unsigned int *)(T + 8))
+        return -1;
+
+    entry = T + 0xc + idx * 16;
+    avail = *(unsigned int *)(entry + 4) - off;
+    if (len > avail)
+        len = avail;
+
+    if (func_0205d368((int *)(G + 0x30), *(int *)entry + off, 0) == 0)
+        return -1;
+
+    return func_0205d3d4((int *)(G + 0x30), a1, len);
+}

--- a/src/func_02051454.c
+++ b/src/func_02051454.c
@@ -1,0 +1,21 @@
+/* func_02051454 at 0x02051454
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern unsigned int _ZN3IRQ7DisableEv(void);
+extern int func_02050d3c(int v);
+extern int func_020509b0(unsigned int i);
+extern void func_02050994(int i, int val);
+extern void _ZN3IRQ7RestoreEj(unsigned int);
+
+void func_02051454(int a, int b, unsigned int c) {
+    int t;
+    unsigned int irq;
+    irq = _ZN3IRQ7DisableEv();
+    t = func_02050d3c(b);
+    if (a == func_020509b0(c)) {
+        func_02050994(c, 0);
+    }
+    func_02050d3c(t);
+    _ZN3IRQ7RestoreEj(irq);
+}

--- a/src/func_020516d4.c
+++ b/src/func_020516d4.c
@@ -1,0 +1,46 @@
+/* func_020516d4 at 0x020516d4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct Entry {
+    int field0;
+    unsigned short ids[4];
+};
+
+extern struct Entry *_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(unsigned int id);
+extern int func_02051514(int a, int b);
+extern int *func_02050b4c(unsigned int id);
+extern int func_020514b4(int a, int b);
+extern void func_0205b78c(int base, int index, int arg);
+
+int func_020516d4(unsigned int id, int flags, int c) {
+    struct Entry *entry;
+    int base;
+    int i;
+
+    base = 0;
+    entry = _ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(id);
+    if (entry == 0) return 0;
+
+    if (flags & 2) {
+        base = func_02051514(entry->field0, c);
+        if (base == 0) return 0;
+    }
+
+    if (flags & 4) {
+        for (i = 0; i < 4; i++) {
+            if (entry->ids[i] != 0xffff) {
+                int *p;
+                int arg;
+                p = func_02050b4c(entry->ids[i]);
+                if (p == 0) return 0;
+                arg = func_020514b4(*p, c);
+                if (arg == 0) return 0;
+                if (base != 0) {
+                    func_0205b78c(base, i, arg);
+                }
+            }
+        }
+    }
+    return 1;
+}

--- a/src/func_02051a98.c
+++ b/src/func_02051a98.c
@@ -1,0 +1,75 @@
+/* func_02051a98 at 0x02051a98
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+struct Entry7 {
+    unsigned int f0;
+    unsigned short ids[6];
+};
+
+struct P4 {
+    int f0;
+    short pad;
+    unsigned char f6;
+    unsigned char f7;
+};
+
+struct P5 {
+    char pad[0x18];
+    int off18;
+};
+
+extern struct Entry7 *_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(unsigned int id);
+extern void *func_0204f63c(void *p, void *idx, void *arg);
+extern void *func_020509b0(unsigned int i);
+extern void func_0204f630(void *p);
+extern unsigned int *func_02050b4c(unsigned int id);
+extern void func_0205b78c(void *base, int index, void *arg);
+extern void func_0204f600(void *thiz, void *p, int v, void *node);
+extern void func_0204f914(void *p, unsigned char v);
+extern void func_0204f89c(void *p, unsigned char v);
+extern void func_0204f6f8(void *o, int a, int b);
+
+int func_02051a98(void *p0, void *p1, unsigned int p2, void *p3,
+                  struct P4 *p4, struct P5 *p5, int p6, int p7)
+{
+    struct Entry7 *e7;
+    void *r6;
+    void *r5;
+    int i;
+
+    e7 = _ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(p2);
+    if (e7 == 0)
+        return 0;
+    r6 = func_0204f63c(p0, p1, p3);
+    if (r6 == 0)
+        return 0;
+    r5 = func_020509b0(e7->f0);
+    if (r5 == 0) {
+        func_0204f630(r6);
+        return 0;
+    }
+    for (i = 0; i < 4; i++) {
+        unsigned int id = e7->ids[i];
+        unsigned int *ent;
+        void *node;
+        if (id != 0xffff) {
+            ent = func_02050b4c(id);
+            if (ent == 0) {
+                func_0204f630(r6);
+                return 0;
+            }
+            node = func_020509b0(*ent);
+            if (node == 0) {
+                func_0204f630(r6);
+                return 0;
+            }
+            func_0205b78c(r5, i, node);
+        }
+    }
+    func_0204f600(r6, (char *)p5 + p5->off18, p4->f0, r5);
+    func_0204f914(p0, p4->f6);
+    func_0204f89c(p0, p4->f7);
+    func_0204f6f8(p0, p6, p7);
+    return 1;
+}

--- a/src/func_02051bd0.c
+++ b/src/func_02051bd0.c
@@ -1,0 +1,85 @@
+/* func_02051bd0 at 0x02051bd0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern int *_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(unsigned int id);
+extern int func_0204f63c(void **p, int idx, int r7);
+extern int func_020509b0(unsigned int i);
+extern void *func_02051a28(int index, void *unk);
+extern void func_0204f630(int r7);
+extern void *func_02051634(unsigned int a0, unsigned int a1, unsigned int a2, unsigned int a3, void *owner);
+extern void *func_02050b4c(unsigned int id);
+extern void func_0205b78c(int base, int index, int arg);
+extern int func_0204f600(int thiz, int p1, int p2, int p3);
+extern void func_0204f914(void **p, unsigned char v);
+extern void func_0204f89c(void **c, unsigned char v);
+extern void func_0204f720(void *pp, int v);
+extern void func_02051a68();
+extern void func_02051a48();
+extern void func_02051a88();
+
+struct Bank { int f0; u16 ids[4]; };
+struct A4 { int f0; u16 pad4; u8 b6; u8 b7; };
+
+int func_02051bd0(void **p, int a1, unsigned int a2, int a3, struct A4 *a4, int a5)
+{
+    struct Bank *bank;
+    void *node;
+    int r7;
+    void *r6 = 0;
+    int r5;
+    int i;
+    void *np;
+
+    bank = (struct Bank *)_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(a2);
+    if (bank == 0) return 0;
+
+    r7 = func_0204f63c(p, a1, a3);
+    if (r7 == 0) return 0;
+
+    r5 = func_020509b0(bank->f0);
+    if (r5 == 0) {
+        r6 = func_02051a28(a1, (void *)r7);
+        if (r6 == 0) { func_0204f630(r7); return 0; }
+        r5 = (int)func_02051634(bank->f0, (unsigned int)&func_02051a68, 0, 0, r6);
+        if (r5 == 0) { func_0204f630(r7); return 0; }
+    }
+
+    for (i = 0; i < 4; i++) {
+        u16 v = bank->ids[i];
+        if (v != 0xffff) {
+            int q;
+            node = func_02050b4c(v);
+            if (node == 0) { func_0204f630(r7); return 0; }
+            q = func_020509b0(*(unsigned int *)node);
+            if (q == 0) {
+                if (r6 == 0) {
+                    r6 = func_02051a28(a1, (void *)r7);
+                    if (r6 == 0) { func_0204f630(r7); return 0; }
+                }
+                q = (int)func_02051634(*(unsigned int *)node, (unsigned int)&func_02051a48, 0, 0, r6);
+                if (q == 0) { func_0204f630(r7); return 0; }
+            }
+            func_0205b78c(r5, i, q);
+        }
+    }
+
+    np = (void *)func_020509b0((unsigned int)a4->f0);
+    if (np == 0) {
+        if (r6 == 0) {
+            r6 = func_02051a28(a1, (void *)r7);
+            if (r6 == 0) { func_0204f630(r7); return 0; }
+        }
+        np = func_02051634((unsigned int)a4->f0, (unsigned int)&func_02051a88, 0, 0, r6);
+        if (np == 0) { func_0204f630(r7); return 0; }
+    }
+
+    func_0204f600(r7, (int)((char *)np + *(int *)((char *)np + 0x18)), 0, r5);
+    func_0204f914(p, a4->b6);
+    func_0204f89c(p, a4->b7);
+    func_0204f720(p, a5);
+    return 1;
+}

--- a/src/func_020538b8.c
+++ b/src/func_020538b8.c
@@ -1,0 +1,51 @@
+/* func_020538b8 at 0x020538b8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef int s32;
+typedef short s16;
+typedef unsigned short u16;
+
+extern s32 _ZN4cstd4fdivEii(s32 numerator, s32 denominator);
+extern s16 data_02086214[];
+
+int func_020538b8(int x, int y)
+{
+    int num, denom, off, add;
+    if (x > 0) {
+        if (y > 0) {
+            if (y > x) { num = x; denom = y; off = 0; add = 1; }
+            else if (y < x) { num = y; denom = x; off = 0x4000; add = 0; }
+            else return 0x2000;
+        } else if (y < 0) {
+            y = -y;
+            if (y < x) { num = y; denom = x; off = 0x4000; add = 1; }
+            else if (y > x) { num = x; denom = y; off = 0x8000; add = 0; }
+            else return 0x6000;
+        } else {
+            return 0x4000;
+        }
+    } else if (x < 0) {
+        int nx = -x;
+        if (y < 0) {
+            y = -y;
+            if (y > nx) { num = nx; denom = y; off = -0x8000; add = 1; }
+            else if (y < nx) { num = y; denom = nx; off = -0x4000; add = 0; }
+            else return 0xa000;
+        } else if (y > 0) {
+            if (y < nx) { num = y; denom = nx; off = -0x4000; add = 1; }
+            else if (y > nx) { num = nx; denom = y; off = 0; add = 0; }
+            else return 0xe000;
+        } else {
+            return 0xc000;
+        }
+    } else {
+        return (y >= 0) ? 0 : 0x8000;
+    }
+
+    if (denom == 0) return 0;
+    if (add)
+        return (u16)(off + data_02086214[_ZN4cstd4fdivEii(num, denom) >> 5]);
+    else
+        return (u16)(off - data_02086214[_ZN4cstd4fdivEii(num, denom) >> 5]);
+}

--- a/src/func_0205db2c.c
+++ b/src/func_0205db2c.c
@@ -1,0 +1,13 @@
+/* func_0205db2c at 0x0205db2c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern unsigned int data_020a8060;
+extern int func_0205db78(void);
+extern int func_02060918(int a0, int a1, int a2, int a3, void *a4, int a5, int a6);
+
+int func_0205db2c(int a, int b, int c, int d)
+{
+    func_02060918(data_020a8060, c, b, d, (void *)&func_0205db78, a, 1);
+    return 6;
+}

--- a/src/func_0205f1e4.c
+++ b/src/func_0205f1e4.c
@@ -1,0 +1,13 @@
+/* func_0205f1e4 at 0x0205f1e4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int func_0205eb58(int a0, int s58, int s5a, int b5c, int b5d, int s5e, int s60, int b62, int b63);
+typedef struct { char pad[0x58]; unsigned short s58; unsigned short s5a; unsigned char b5c; unsigned char b5d; unsigned short s5e; unsigned short s60; unsigned char b62; unsigned char b63; } S;
+int func_0205f1e4(int a0){
+ S *p=(S*)0x027ffc80;
+ unsigned short s58,s5a,s5e,s60; unsigned char b5c,b5d,b62,b63;
+ s58=p->s58; s5a=p->s5a; b5c=p->b5c; b5d=p->b5d; s5e=p->s5e; s60=p->s60; b62=p->b62; b63=p->b63;
+ if(s58==0&&s5e==0&&s5a==0&&s60==0){return 0;}
+ return func_0205eb58(a0,s58,s5a,b5c,b5d,s5e,s60,b62,b63)==0;
+}

--- a/src/func_02062428.c
+++ b/src/func_02062428.c
@@ -1,0 +1,45 @@
+/* func_02062428 at 0x02062428
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int *func_02061548(void);
+extern int func_02061428(int count, ...);
+extern int func_02061558(int a, int b, int c, int d, int e, int f, int g, int h, int i);
+extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int len);
+extern void _ZN4CP1514FlushDataCacheEjj(unsigned int addr, unsigned int len);
+
+int func_02062428(int p0, int p1, int p2, int p3, unsigned short p4, unsigned short p5, unsigned short p6) {
+    int a;
+    int x;
+    int *handle;
+    int ret;
+    int val184;
+    int flag;
+
+    x = 1;
+    handle = func_02061548();
+    ret = func_02061428(2, 9, 0xa);
+    if (ret != 0) return ret;
+
+    _ZN4CP1519InvalidateDataCacheEjj(handle[1] + 0x18e, 2);
+    a = *(unsigned short *)(handle[1] + 0x18e);
+    _ZN4CP1519InvalidateDataCacheEjj(handle[1] + 0x184, 2);
+
+    val184 = *(unsigned short *)(handle[1] + 0x184);
+    flag = (val184 == 0) ? x : 0;
+    if (flag == 1) {
+        _ZN4CP1519InvalidateDataCacheEjj(handle[1] + 0x17e, 2);
+        x = *(unsigned short *)(handle[1] + 0x17e);
+        _ZN4CP1519InvalidateDataCacheEjj(handle[1] + 0x86, 2);
+    }
+
+    if (p2 == 0) return 6;
+    if (x == 0) return 7;
+    if (p3 + (flag != 0 ? 4 : 2) > a) return 6;
+    if (p3 == 0) return 6;
+
+    _ZN4CP1514FlushDataCacheEjj(p2, p3);
+    ret = func_02061558(0xf, 7, p2, p3, p4, p5, p6, p0, p1);
+    if (ret == 0) return 2;
+    return ret;
+}

--- a/src/func_020625fc.c
+++ b/src/func_020625fc.c
@@ -1,0 +1,44 @@
+/* func_020625fc at 0x020625fc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern int *func_02061548(void);
+extern int func_02061428(int a, int b, int c);
+extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int n);
+extern int func_02061ab0(void);
+extern int func_02061b9c(void);
+extern void func_0206165c(int i, int val);
+extern int func_02061558(int a, int b, int c, int d, int e, int f, int g,
+                         int h, int i, int j, int k, int l);
+
+int func_020625fc(int arg0, int arg1, int arg2, int arg3, u16 arg4, u16 arg5,
+                  u16 arg6, int arg7, int arg8, int arg9, int arg10)
+{
+    int *base;
+    int r;
+
+    base = func_02061548();
+    r = func_02061428(2, 7, 8);
+    if (r != 0)
+        return r;
+    _ZN4CP1519InvalidateDataCacheEjj((unsigned int)(base[1] + 0x10), 4);
+    if (((int *)base[1])[4] == 1)
+        return 3;
+    if (arg2 < func_02061ab0())
+        return 6;
+    if (arg2 & 0x3f)
+        return 6;
+    if (arg4 < func_02061b9c())
+        return 6;
+    if (arg4 & 0x1f)
+        return 6;
+    func_0206165c(0xe, arg0);
+    r = func_02061558(0xe, 0xa, arg1, (unsigned int)arg2 >> 1,
+                      arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+    if (r == 0)
+        r = 2;
+    return r;
+}

--- a/src/func_02063980.c
+++ b/src/func_02063980.c
@@ -1,0 +1,69 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+typedef struct Sub {
+    u8 pad[0x68];
+} Sub;
+
+typedef struct S {
+    int f0;            /* 0x00 */
+    int pad04;         /* 0x04 */
+    u16 f8;            /* 0x08 */
+    u16 padA;          /* 0x0a */
+    u8 fC;             /* 0x0c */
+    u8 padD[7];        /* 0x0d */
+    u32 f14;           /* 0x14 */
+    u8 pad18[5];       /* 0x18 */
+    u8 f1d;            /* 0x1d */
+    u8 pad1e[0x1f8 - 0x1e]; /* 0x1e */
+    Sub elems[16];     /* 0x1f8 */
+} S;
+
+extern int func_02065bc0(void);
+extern int func_02065bd0(void);
+extern int func_02064f54(u8 *dst, u16 a1, u8 a2, int a3, int a4);
+extern int func_0206470c(Sub *e);
+extern int func_02064bac(u8 *dst, u16 a1, u8 a2, u32 a3);
+extern int func_02064e18(u8 *dst, u16 a1, u8 a2, u32 a3, int a4);
+extern int func_02064cd8(u8 *dst, u16 a1, u8 a2, u32 a3, int a4);
+extern int func_02064a94(u8 *dst, u16 a1, u8 a2, u32 *a3, u8 a4);
+
+int func_02063980(S *s, u8 *dst)
+{
+    int ret = 0;
+    int i;
+
+    switch (s->f0) {
+    case 2:
+        ret = func_02064f54(dst, s->f8, s->fC, func_02065bc0(), func_02065bd0());
+        break;
+    case 4:
+    case 6:
+    {
+        Sub *e = s->elems;
+        for (i = 0; i < 16; i++, e++) {
+            int bit = 1 << i;
+            if (s->f8 & (u16)bit) {
+                int v = func_0206470c(e);
+                if (v == -1) {
+                    ret = func_02064bac(dst, (u16)bit, s->fC, s->f14);
+                } else {
+                    u16 mask = s->f8;
+                    if (s->f0 == 4)
+                        ret = func_02064e18(dst, mask, s->fC, s->f14, v);
+                    else
+                        ret = func_02064cd8(dst, mask, s->fC, s->f14, v);
+                }
+                if (ret != 0)
+                    return ret;
+            }
+        }
+    }
+        break;
+    case 10:
+        ret = func_02064a94(dst, s->f8, s->fC, &s->f14, s->f1d);
+        break;
+    }
+    return ret;
+}

--- a/src/func_02064674.c
+++ b/src/func_02064674.c
@@ -1,0 +1,27 @@
+/* func_02064674 at 0x02064674
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int func_02065bd0(void);
+extern void func_0205a61c(int a, int b, int c);
+
+int func_02064674(int *p, int idx, int dst)
+{
+    int n = func_02065bd0();
+    int cnt = p[1];
+    int base = p[6];
+    if (idx < cnt) {
+        if (idx == cnt - 1) {
+            int rem = p[0] % n;
+            if (rem != 0)
+                func_0205a61c(dst, idx * n + base, rem);
+            else
+                func_0205a61c(dst, idx * n + base, n);
+        } else {
+            func_0205a61c(dst, idx * n + base, n);
+        }
+    } else {
+        return 0;
+    }
+    return 1;
+}

--- a/src/func_02064b2c.c
+++ b/src/func_02064b2c.c
@@ -1,0 +1,20 @@
+/* func_02064b2c at 0x02064b2c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_0205a61c(const void *src, int off, int size);
+
+int func_02064b2c(int off, short b, int c, int d)
+{
+    unsigned char tag = 9;
+    short val = b;
+    int c1, c2, c3;
+    func_0205a61c(&tag, off, 1);
+    c1 = off + 1;
+    func_0205a61c(&val, c1, 2);
+    c2 = c1 + 2;
+    func_0205a61c(&c, c2, 1);
+    c3 = c2 + 1;
+    func_0205a61c(&d, c3, 4);
+    return c3 + 4 - off;
+}

--- a/src/func_02064bac.c
+++ b/src/func_02064bac.c
@@ -1,0 +1,20 @@
+/* func_02064bac at 0x02064bac
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+
+int func_02064bac(unsigned char *dst, unsigned short a1, unsigned char a2, unsigned int a3)
+{
+    unsigned char hdr = 8;
+    unsigned short s = a1;
+    unsigned char *p1, *p2, *p3;
+    func_0205a61c(&hdr, dst, 1);
+    p1 = dst + 1;
+    func_0205a61c(&s, p1, 2);
+    p2 = p1 + 2;
+    func_0205a61c(&a2, p2, 1);
+    p3 = p2 + 1;
+    func_0205a61c(&a3, p3, 4);
+    return (p3 + 4) - dst;
+}

--- a/src/func_02064fe8.c
+++ b/src/func_02064fe8.c
@@ -1,0 +1,19 @@
+/* func_02064fe8 at 0x02064fe8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+
+int func_02064fe8(void *dst, short b, char c)
+{
+    char *p;
+    char *q;
+    unsigned char one = 1;
+    short s = b;
+    func_0205a61c(&one, dst, 1);
+    p = (char *)dst + 1;
+    func_0205a61c(&s, p, 2);
+    q = p + 2;
+    func_0205a61c(&c, q, 1);
+    return q + 1 - (char *)dst;
+}

--- a/src/func_02065f78.c
+++ b/src/func_02065f78.c
@@ -1,0 +1,56 @@
+/* func_02065f78 at 0x02065f78
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int *data_020a9db8;
+
+extern void MultiStore16(unsigned short val, char *dst, int nbytes);
+extern int func_02066470(unsigned char x, unsigned arg1);
+extern int func_020662c0(unsigned arg);
+extern int func_0206610c(void);
+
+void func_02065f78(void)
+{
+    unsigned short buf[6];
+    unsigned short i;
+    int result;
+
+    buf[0] = 0;
+    MultiStore16(buf[0], (char *)&buf[1], 10);
+
+    for (i = 1; i <= 0xf; i++) {
+        switch (*(int *)((char *)(data_020a9db8 + (i - 1)) + 0x1000 + 0x4e8)) {
+        case 2:
+            buf[1] |= (1 << i);
+            break;
+        case 5:
+            buf[2] |= (1 << i);
+            break;
+        case 4:
+            buf[3] |= (1 << i);
+            break;
+        case 8:
+            buf[4] |= (1 << i);
+            break;
+        case 11:
+            buf[5] |= (1 << i);
+            break;
+        }
+    }
+
+    if (buf[4])
+        result = func_02066470(5, buf[4]);
+    else if (buf[1])
+        result = func_02066470(1, buf[1]);
+    else if (buf[5])
+        result = func_02066470(6, buf[5]);
+    else if (buf[3])
+        result = func_02066470(2, buf[3]);
+    else if (buf[2])
+        result = func_020662c0(buf[2]);
+    else
+        result = func_0206610c();
+
+    if (result == 0x15)
+        func_02066470(0, 0xffff);
+}

--- a/src/func_02066fb0.c
+++ b/src/func_02066fb0.c
@@ -1,0 +1,10 @@
+/* func_02066fb0 at 0x02066fb0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern int data_020a9db8;
+
+int func_02066fb0(int a, int b, int c) {
+    int (*fn)(int, int, int) = *(int (**)(int, int, int))(data_020a9db8 + 0x14e4);
+    if (fn) return fn(a, b, c);
+}

--- a/src/func_0206736c.c
+++ b/src/func_0206736c.c
@@ -1,0 +1,30 @@
+/* func_0206736c at 0x0206736c
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef unsigned int u32;
+extern u32 data_0208685c[];
+extern int func_02067480(u32 idx, u32 addr, u32 size);
+
+int func_0206736c(u32 idx, u32 addr, u32 size)
+{
+    switch (data_0208685c[idx]) {
+    case 0:
+    case 2:
+        return func_02067480(idx, addr, size);
+    case 1:
+        if (addr >= 0x2000000 && addr < 0x23fe800) {
+            u32 end = addr + size;
+            if (addr < 0x2300000 && end > 0x2300000) return 0;
+            if (end <= 0x2300000) return 1;
+            if (end < 0x23fe800 && size <= 0x40000) return 1;
+            return 0;
+        }
+        if (addr >= 0x37f8000 && addr < 0x380f000) return addr + size <= 0x380f000;
+        goto fail;
+    default:
+        return 0;
+    }
+fail:
+    return 0;
+}

--- a/src/func_02067b68.c
+++ b/src/func_02067b68.c
@@ -1,0 +1,20 @@
+/* func_02067b68 at 0x02067b68
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern void func_0205a588(void *dst, int val, unsigned int size);
+extern void func_0205a61c(void *a, void *b, unsigned int size);
+struct S { unsigned int f0; unsigned char *f4; unsigned char *f8; unsigned int fc; };
+void func_02067b68(struct S *s, unsigned int start, unsigned int end, int flag) {
+    unsigned int f0 = s->f0;
+    unsigned int fc = s->fc;
+    unsigned int top;
+    if (start < 0x4000) start = 0x4000;
+    if (end > 0x8000) end = 0x8000;
+    if (start < f0) start = f0;
+    top = f0 + fc;
+    if (end > top) end = top;
+    if (start >= end) return;
+    if (flag) func_0205a588(s->f8 + start, 0, end - start);
+    else func_0205a61c(s->f4 + start, s->f8 + start, end - start);
+}

--- a/src/func_0206c90c.c
+++ b/src/func_0206c90c.c
@@ -1,0 +1,11 @@
+typedef unsigned short u16;
+typedef struct { int a, b, c, d; } S;
+int func_0206c90c(S s){
+    char* q = (char*)&s + 7;
+    int hi;
+    if ((int)q & 1)
+        hi = (*(u16*)(q - 1) & 0xff00) >> 8;
+    else
+        hi = *(u16*)q & 0xff;
+    return hi & 0x80;
+}

--- a/src/func_0206df14.c
+++ b/src/func_0206df14.c
@@ -1,0 +1,21 @@
+/* func_0206df14 at 0x0206df14
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+extern char data_0209a330[];
+extern int func_0206e06c(void *);
+
+int func_0206df14(void) {
+    int result = 0;
+    char *p = data_0209a330;
+    int i = 1;
+    do {
+        if (((unsigned int)*(int *)(p + 4) << 22) >> 29) {
+            if (func_0206e06c(p)) {
+                result = -1;
+            }
+        }
+        p = (i < 3) ? (data_0209a330 + i++ * 0x4c) : 0;
+    } while (p);
+    return result;
+}

--- a/src/func_02071f88.c
+++ b/src/func_02071f88.c
@@ -1,0 +1,29 @@
+/* func_02071f88 at 0x02071f88
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
+ */
+typedef struct {
+    unsigned int count;
+    int pad4;
+    int pad8;
+    unsigned char *data;
+} List;
+
+extern int func_02072fcc(void *a, unsigned int val, void *out);
+
+int func_02071f88(void *a, List *list)
+{
+    unsigned char *p;
+    unsigned int i;
+    unsigned int buf[2];
+
+    p = list->data;
+    for (i = 0; i < list->count; i++) {
+        unsigned int val = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+        buf[0] = val;
+        if (func_02072fcc(a, val, &buf[1]))
+            return 1;
+        p += 4;
+    }
+    return 0;
+}

--- a/src/func_ov002_020af3a8.c
+++ b/src/func_ov002_020af3a8.c
@@ -1,0 +1,43 @@
+/* func_ov002_020af3a8 at 0x020af3a8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+typedef unsigned int u32;
+typedef int Fix12i;
+
+struct Vec { Fix12i x, y, z; };
+struct Vector3_16;
+
+extern int func_ov002_020af1dc(char* c);
+extern void func_ov002_020bdf8c(int);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec* v);
+extern void GiveLives(int delta);
+extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
+
+void func_ov002_020af3a8(char* c)
+{
+    int r = func_ov002_020af1dc(c);
+    if (r == 0)
+        return;
+
+    unsigned short h = *(unsigned short*)(c + 0xc);
+    unsigned is115 = (h == 0x115);
+    if (is115) {
+        func_ov002_020bdf8c(r);
+    } else {
+        unsigned is114 = (h == 0x114);
+        if (is114) {
+            struct Vec vec;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, (struct Vec*)(c + 0x74));
+            GiveLives(1);
+            vec.x = *(Fix12i*)(c + 0x5c);
+            vec.y = *(Fix12i*)(c + 0x60);
+            vec.z = *(Fix12i*)(c + 0x64);
+            vec.y += 0xb4000;
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0x14b, 8, &vec, 0, *(signed char*)(c + 0xcc), -1);
+        }
+    }
+    _ZN5Actor24KillAndTrackInDeathTableEv(c);
+}

--- a/src/func_ov002_020bf9d4.cpp
+++ b/src/func_ov002_020bf9d4.cpp
@@ -1,0 +1,27 @@
+//cpp
+// func_ov002_020bf9d4 at 0x020bf9d4
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+struct VecFx32 { int x, y, z; };
+extern "C" {
+int func_0200fccc(char* s, int r1);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+extern int data_0208e430;
+}
+extern "C" void func_ov002_020bf9d4(char* c){
+  VecFx32 v;
+  if (data_0208e430 == 0x2e) return;
+  if (*(unsigned char*)(c + 0x703) == 0){
+    func_0200fccc(c, 0);
+    return;
+  }
+  ((int*)&v)[0] = *(int*)(c + 0x5c);
+  ((int*)&v)[1] = *(int*)(c + 0x60);
+  ((int*)&v)[2] = *(int*)(c + 0x64);
+  if (*(unsigned char*)(c + 0x707) != 0){
+    v.y += 0x19000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x5c, v.x, v.y, v.z);
+  } else {
+    v.y += 0x23000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x5b, v.x, v.y, v.z);
+  }
+}

--- a/src/func_ov002_020c647c.cpp
+++ b/src/func_ov002_020c647c.cpp
@@ -1,0 +1,40 @@
+//cpp
+// func_ov002_020c647c at 0x020c647c
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+struct Vector3 { int x, y, z; };
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern void _ZN11RaycastLine10GetClsnPosEv(void* res, void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+
+int func_ov002_020c647c(char* c, int arg1) {
+    Vector3 v1;
+    Vector3 v2;
+    Vector3 clsnPos;
+    char rl[0x78];
+    _ZN11RaycastLineC1Ev(rl);
+    int z1 = *(int*)(c + 0x64);
+    int x1 = *(int*)(c + 0x5c);
+    v1.x = x1;
+    v1.y = arg1 - 0x1e000;
+    v1.z = z1;
+    int x2 = *(int*)(c + 0x5c);
+    int z2 = *(int*)(c + 0x64);
+    v2.x = x2;
+    v2.z = z2;
+    v2.y = arg1 + 0xaa000;
+    int r5 = -64;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, c);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, rl);
+        int d = (clsnPos.y - *(int*)(c + 0x60)) / 0x1000;
+        if (d > 0xa0) d = 0xa0;
+        if (d < 0) d = 0;
+        r5 = d;
+    }
+    _ZN11RaycastLineD1Ev(rl);
+    return r5;
+}
+}

--- a/src/func_ov002_020c6e14.c
+++ b/src/func_ov002_020c6e14.c
@@ -1,0 +1,39 @@
+/* func_ov002_020c6e14 at 0x020c6e14
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+ */
+extern unsigned char data_0209f2ac;
+extern short data_ov002_020ff1a0[];
+extern void* data_0209f318[];
+
+extern int NumStars(void);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const void* pos, unsigned int a, unsigned int b);
+extern void _ZN6Camera9SetFlag_3Ev(void* cam);
+
+int func_ov002_020c6e14(void* actor)
+{
+    int idx;
+
+    if (data_0209f2ac != 0) {
+        idx = -1;
+        switch (NumStars()) {
+        case 1:  idx = 0; break;
+        case 3:  idx = 1; break;
+        case 8:  idx = 2; break;
+        case 12: idx = 3; break;
+        case 30: idx = 4; break;
+        case 50: idx = 5; break;
+        case 80: idx = 6; break;
+        }
+
+        if (idx == -1)
+            return 0;
+
+        if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(actor, actor, data_ov002_020ff1a0[idx], 0, 0, 2)) {
+            _ZN6Camera9SetFlag_3Ev(data_0209f318[0]);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/src/func_ov002_020cfd84.cpp
+++ b/src/func_ov002_020cfd84.cpp
@@ -1,0 +1,39 @@
+//cpp
+// func_ov002_020cfd84 at 0x020cfd84
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+struct CRData { int a,b,c,d,e; unsigned short f,g; int h,i,j; };
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN10ClsnResultC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern int _ZNK10ClsnResult9GetClsnIDEv(void* self);
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern void _ZN10ClsnResultD1Ev(void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+
+int func_ov002_020cfd84(void* actor, void* a, void* b) {
+    char rl[0x78];
+    char res[0x28];
+    _ZN11RaycastLineC1Ev(rl);
+    _ZN10ClsnResultC1Ev(res);
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, a, b, actor);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+        *(CRData*)(res + 4) = *(CRData*)(rl + 0x14);
+        if (_ZNK10ClsnResult9GetClsnIDEv(res) != -1) {
+            void* act = _ZN5Actor10FindWithIDEj((unsigned int)_ZNK10ClsnResult9GetClsnIDEv(res));
+            if (act != 0) {
+                int t = (*(unsigned short*)((char*)act + 0xc) == 0x12a);
+                if (t == 0) {
+                    _ZN10ClsnResultD1Ev(res);
+                    _ZN11RaycastLineD1Ev(rl);
+                    return 1;
+                }
+            }
+        }
+    }
+    _ZN10ClsnResultD1Ev(res);
+    _ZN11RaycastLineD1Ev(rl);
+    return 0;
+}
+}

--- a/src/func_ov002_020e4990.c
+++ b/src/func_ov002_020e4990.c
@@ -1,0 +1,30 @@
+extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, unsigned int a, int b);
+extern int _ZN6Player6IsAnimEj(void* thiz, unsigned int a);
+extern void func_0201628c(int a, int b);
+extern void func_020162a4(int a, int b);
+
+int func_ov002_020e4990(char* c)
+{
+    int id;
+    int b;
+    id = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c + 8) & 0xff, 0);
+    func_0201628c(((int*)(c + 0xdc))[id], 8);
+    b = *(int*)(c + 0x358) ? 1 : 0;
+    if (b == 0)
+        return 0;
+    if (_ZN6Player6IsAnimEj(c, 0x30) || _ZN6Player6IsAnimEj(c, 0x2f) ||
+        _ZN6Player6IsAnimEj(c, 0x33) || _ZN6Player6IsAnimEj(c, 0x18) ||
+        _ZN6Player6IsAnimEj(c, 0x8a) || _ZN6Player6IsAnimEj(c, 0x87) ||
+        _ZN6Player6IsAnimEj(c, 0x8b) || _ZN6Player6IsAnimEj(c, 0x6d) ||
+        _ZN6Player6IsAnimEj(c, 0x6f) || _ZN6Player6IsAnimEj(c, 0x6c) ||
+        _ZN6Player6IsAnimEj(c, 0x91) || _ZN6Player6IsAnimEj(c, 0x8e) ||
+        _ZN6Player6IsAnimEj(c, 0x90) || _ZN6Player6IsAnimEj(c, 0x8f) ||
+        _ZN6Player6IsAnimEj(c, 0x43) || _ZN6Player6IsAnimEj(c, 0x5b) ||
+        _ZN6Player6IsAnimEj(c, 0x58) || _ZN6Player6IsAnimEj(c, 0x81) ||
+        _ZN6Player6IsAnimEj(c, 0x80) || _ZN6Player6IsAnimEj(c, 0xaf) ||
+        _ZN6Player6IsAnimEj(c, 0xb0))
+        return 0;
+    id = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c + 8) & 0xff, 0);
+    func_020162a4(((int*)(c + 0xdc))[id], 8);
+    return 1;
+}

--- a/src/func_ov002_020e73ac.cpp
+++ b/src/func_ov002_020e73ac.cpp
@@ -1,0 +1,41 @@
+//cpp
+// func_ov002_020e73ac at 0x020e73ac
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
+extern "C" {
+int func_ov002_020e9630(char*);
+}
+
+extern unsigned char data_0209f2d8;
+
+extern "C" int func_ov002_020e73ac(char* arg) {
+    int c, a, b;
+    unsigned char r2 = *(unsigned char*)(arg + 0x49d);
+    if (r2 == 8) {
+        return 3;
+    }
+
+    a = data_0209f2d8 == 1;
+    if (a != false) {
+        goto ret2;
+    }
+    b = *(unsigned short*)(arg + 0xc) == 0xb3;
+    if (b != false) {
+        goto ret2;
+    }
+    c = *(int*)(arg + 0x444);
+    if (c == 9) {
+ret2:
+        return 2;
+    }
+
+    if (r2 == 0) {
+        goto ret1;
+    }
+    if (func_ov002_020e9630(arg) == 0) {
+        goto ret0;
+    }
+ret1:
+    return 1;
+ret0:
+    return 0;
+}

--- a/src/func_ov002_020e7934.cpp
+++ b/src/func_ov002_020e7934.cpp
@@ -1,0 +1,95 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor;
+
+extern "C" {
+extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, const Vector3* v);
+extern void _ZN6Camera6SetPosERK7Vector3(void* cam, const Vector3* v);
+extern int Vec3_Dist(const Vector3* a, const Vector3* b);
+extern unsigned char IsAreaShowing(int idx);
+extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
+extern short data_02082214[];
+}
+
+struct RaycastLine {
+    char pad[0x78];
+    RaycastLine();
+    ~RaycastLine();
+    int DetectClsn();
+    void SetObjAndLine(const Vector3& a, const Vector3& b, Actor* obj);
+};
+
+extern "C" void func_ov002_020e7934(char* self, void* cam)
+{
+    Vector3 vec[2];
+    int flag;
+    int dist;
+    unsigned int r6 = 0;
+
+    vec[0].x = *(int*)(self + 0x5c);
+    vec[0].y = *(int*)(self + 0x60);
+    vec[0].z = *(int*)(self + 0x64);
+    _ZN6Camera9SetLookAtERK7Vector3(cam, &vec[0]);
+
+    vec[0].y += 0xc8000;
+    vec[1] = vec[0];
+    dist = Vec3_Dist(&vec[0], (Vector3*)(self + 0x46c));
+
+    unsigned short mode = *(unsigned short*)(self + 0x496);
+    flag = (((mode == 100 && (dist > 0x3e8000 || dist < 0x1f4000)) ||
+             (mode != 100 && dist > 0x3e8000)) &&
+            IsAreaShowing(*(signed char*)(self + 0x499))) ? 1 : 0;
+
+    while (1) {
+        if (r6 >= 0x10)
+            vec[0].y -= 0x258000;
+        else if (r6 >= 0xc)
+            vec[0].y -= 0x12c000;
+        else if (r6 >= 8)
+            vec[0].y += 0x258000;
+        else if (r6 >= 4)
+            vec[0].y += 0x12c000;
+
+        if (flag) {
+            short ang = Vec3_HorzAngle(&vec[0], (Vector3*)(self + 0x46c));
+            int k = (unsigned short)(short)(ang + ((r6 & 3) << 14)) >> 4;
+            vec[0].x = data_02082214[k * 2] * 1000 + vec[0].x;
+            vec[0].z = data_02082214[k * 2 + 1] * 1000 + vec[0].z;
+            _ZN6Camera6SetPosERK7Vector3(cam, &vec[0]);
+        } else {
+            if (!IsAreaShowing(*(signed char*)(self + 0xcc)))
+                return;
+            short ang = Vec3_HorzAngle(&vec[0], (Vector3*)(self + 0x46c));
+            int k = (unsigned short)(short)(ang + ((r6 & 3) << 14)) >> 4;
+            vec[0].x += (int)(((long long)dist * data_02082214[k * 2] + 0x800) >> 12);
+            vec[0].z += (int)(((long long)dist * data_02082214[k * 2 + 1] + 0x800) >> 12);
+            _ZN6Camera6SetPosERK7Vector3(cam, &vec[0]);
+        }
+
+        if (!IsAreaShowing(*(signed char*)(self + 0xcc)))
+            return;
+
+        {
+            RaycastLine rl;
+            Vector3 a;
+            Vector3 b;
+            a.x = *(int*)(self + 0x5c);
+            a.y = *(int*)(self + 0x60);
+            a.z = *(int*)(self + 0x64);
+            b.x = vec[0].x;
+            b.y = vec[0].y;
+            b.z = vec[0].z;
+            rl.SetObjAndLine(a, b, (Actor*)self);
+            if (rl.DetectClsn()) {
+                r6 = (r6 + 1) & 0xff;
+                vec[0] = vec[1];
+                if (r6 >= 0x14) {
+                    _ZN6Camera6SetPosERK7Vector3(cam, (Vector3*)(self + 0x46c));
+                    return;
+                }
+                continue;
+            }
+            return;
+        }
+    }
+}

--- a/src/func_ov003_020ae0b0.c
+++ b/src/func_ov003_020ae0b0.c
@@ -1,0 +1,40 @@
+int SublevelToLevel(int i);
+unsigned char NumStars(void);
+void func_ov003_020ae1a4(void *sl, int r);
+void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, void *attr, int x, int y, int a, int cc, void *m);
+extern signed char data_02092110[];
+extern void *func_020aba70[];
+extern void *func_020ab9c8;
+extern void *func_020abad0;
+void func_ov003_020ae0b0(char *sl)
+{
+  int sb;
+  int r8;
+  if (SublevelToLevel(data_02092110[0]) >= 0xf)
+  {
+    r8 = 0xa0;
+    sb = 0xb8;
+  }
+  else
+  {
+    r8 = 0xac;
+    sb = 0xf4;
+  }
+  func_ov003_020ae1a4(sl, NumStars());
+  {
+    int i = 2;
+    do
+    {
+      signed char d = *((signed char *) ((sl + i) + 0x121));
+      if (d >= 0)
+      {
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[d], sb, r8, 8, -1, 0);
+        sb -= 9;
+      }
+      i--;
+    }
+    while (i >= 0);
+  }
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, sb, r8 + 8, -1, -1, 0);
+  _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, sb - 0x10, r8 + 8, -1, -1, 0);
+}

--- a/src/func_ov006_020d5c88.c
+++ b/src/func_ov006_020d5c88.c
@@ -1,0 +1,33 @@
+extern void func_ov004_020af68c(void *a0, int a1, int a2, int a3, int a4);
+extern void *data_ov006_02133ae0[];
+extern void *data_ov006_02133a70[];
+
+struct S {
+    int x;                  /* 0x00 */
+    int y;                  /* 0x04 */
+    unsigned char pad[5];   /* 0x08 */
+    unsigned char active;   /* 0x0d */
+    unsigned char idx;      /* 0x0e */
+    unsigned char pad2;     /* 0x0f */
+};
+
+struct Big {
+    unsigned char pad[0x62b0];
+    struct S subs[2];
+};
+
+void func_ov006_020d5c88(struct Big *b) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        if (b->subs[i].active != 0) {
+            int xv = b->subs[i].x;
+            int yv = b->subs[i].y;
+            int idx = b->subs[i].idx;
+            int a1 = xv >> 12;
+            int a2 = yv >> 12;
+            func_ov004_020af68c((i != 0) ? data_ov006_02133a70[idx]
+                                         : data_ov006_02133ae0[idx],
+                                a1, a2, -1, 1);
+        }
+    }
+}

--- a/src/func_ov006_020d63d4.c
+++ b/src/func_ov006_020d63d4.c
@@ -1,0 +1,29 @@
+extern void func_ov004_020af68c(void* a0, int a1, int a2, int a3, int a4);
+extern int data_ov006_021342bc[];
+extern int data_ov006_021343b0[];
+
+typedef struct {
+    int x;              /* 0x00 */
+    int y;              /* 0x04 */
+    char pad2[6];
+    unsigned char flag; /* 0x0e */
+    unsigned char idx;  /* 0x0f */
+} Rec;
+
+typedef struct {
+    char head[0x6260];
+    Rec recs[2];
+} Obj;
+
+void func_ov006_020d63d4(Obj* a0) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        if (a0->recs[i].flag != 0) {
+            int xv = a0->recs[i].x >> 12;
+            int yv = a0->recs[i].y >> 12;
+            int k = a0->recs[i].idx;
+            int v = (i == 0) ? data_ov006_021343b0[k] : data_ov006_021342bc[k];
+            func_ov004_020af68c((void*)v, xv, yv, -1, 1);
+        }
+    }
+}

--- a/src/func_ov006_020d9a14.c
+++ b/src/func_ov006_020d9a14.c
@@ -1,0 +1,34 @@
+extern void func_ov004_020af68c(void *a0, int a1, int a2, int a3, int a4);
+extern int func_ov006_020da834(char *p);
+extern int func_ov006_020da860(char *p, int v);
+extern void **data_ov006_0213bd30[];
+extern void *data_ov006_0213406c[];
+
+#define F(off) (*(short *)(this + 0x5300 + (off)))
+
+void func_ov006_020d9a14(char *this)
+{
+    short v = F(0x88);
+    if (v > 3 && v < 0x11) {
+        int sb = 0xb0;
+        int i;
+        for (i = 0; i < 6; i++) {
+            int sel = 0;
+            if ((i == F(0x92) && i == F(0x8e)) || (i == F(0x94) && i == F(0x90))) {
+                if (F(0x96) & 0x10) sel = 1; else sel = 2;
+            } else if (i == F(0x92) || i == F(0x94)) {
+                if (F(0x96) & 0x10) sel = 2;
+            } else if (i == F(0x8e) || i == F(0x90)) {
+                if (F(0x96) & 0x10) sel = 1;
+            }
+            func_ov004_020af68c(data_ov006_0213bd30[i][sel], 0x14, sb, -1, -1);
+            sb -= 0x10;
+        }
+    }
+    if (F(0x88) != 4) return;
+    if (func_ov006_020da834(this + 0x51a8) == 0) return;
+    if (func_ov006_020da860(this + 0x51a8, 2) == 0)
+        func_ov004_020af68c(data_ov006_0213406c[0], 0x80, 0x58, -1, -1);
+    else
+        func_ov004_020af68c(data_ov006_0213406c[1], 0x80, 0x58, -1, -1);
+}

--- a/src/func_ov006_020ea670.c
+++ b/src/func_ov006_020ea670.c
@@ -1,0 +1,31 @@
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020af948(void* a, int b, int c, void* m);
+
+typedef struct {
+    int x;
+    int y;
+    unsigned char pad0[7];
+    unsigned char flag;
+    int pad1;
+} Ent;
+
+extern Ent data_ov006_02142044[];
+extern char data_ov006_02137cd8[];
+extern void* data_ov006_0213ca9c[];
+
+void func_ov006_020ea670(void){
+    void *a=0, *b=0, *c=0;
+    int i;
+    for(i=0;i<16;i++){
+        Ent *e = &data_ov006_02142044[i];
+        if(e->flag!=0){
+            int sb=e->x>>12;
+            int r8=e->y>>12;
+            int idx=func_ov004_020ad674();
+            void *obj=data_ov006_0213ca9c[idx];
+            func_ov004_020af948(*(void**)((char*)obj+0x38), sb-0x10, r8, a);
+            func_ov004_020af948(*(void**)(data_ov006_02137cd8+0xa4), sb, r8, b);
+            func_ov004_020af948(*(void**)(data_ov006_02137cd8+0xa0), sb+0x10, r8, c);
+        }
+    }
+}

--- a/src/func_ov006_020ef05c.c
+++ b/src/func_ov006_020ef05c.c
@@ -1,0 +1,16 @@
+struct Elem { char _0[0x20]; short f20; short _22; };
+
+extern void func_ov006_020eee3c(struct Elem *thiz, int a1, int a2, int a3);
+extern int data_ov006_021421bc;
+extern struct Elem *data_ov006_021421b0;
+
+void func_ov006_020ef05c(int p0, int p1, int p2)
+{
+    int i;
+    for (i = data_ov006_021421bc - 1; i >= 0; i--) {
+        if (data_ov006_021421b0[i].f20 == 0) {
+            func_ov006_020eee3c(&data_ov006_021421b0[i], p0, p1, p2);
+            return;
+        }
+    }
+}

--- a/src/func_ov006_020fb74c.c
+++ b/src/func_ov006_020fb74c.c
@@ -1,0 +1,21 @@
+extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
+extern int data_ov006_02133e7c[];
+extern int data_ov006_02133e10[];
+
+void func_ov006_020fb74c(void* base) {
+    int i;
+    char* p = (char*)base;
+    for (i = 0; i < 30; i++, p += 0x14) {
+        if (*(unsigned char*)(p + 0x5966)) {
+            int type = *(unsigned char*)(p + 0x5967);
+            int x = *(int*)(p + 0x5958) >> 12;
+            int y = *(int*)(p + 0x595c) >> 12;
+            int idx = *(unsigned char*)(p + 0x5965);
+            if (type != 2) {
+                func_ov004_020afdd0((void*)data_ov006_02133e10[idx], x, y, -1, -1);
+            } else {
+                func_ov004_020afdd0((void*)data_ov006_02133e7c[idx], x, y, -1, -1);
+            }
+        }
+    }
+}

--- a/src/func_ov006_0210246c.cpp
+++ b/src/func_ov006_0210246c.cpp
@@ -1,0 +1,18 @@
+//cpp
+typedef unsigned char u8;
+class C;
+typedef void (C::*PMF)(int);
+class C { public: int dummy; };
+struct Row { u8 d[0x40]; };
+extern "C" void func_ov006_0210076c(C *self, int i);
+extern "C" PMF data_ov006_02142734[];
+extern "C" void func_ov006_0210246c(C *self)
+{
+    Row *rows = (Row *)self;
+    for (int i = 0; i < 3; i++) {
+        if (rows[i].d[0x5294]) {
+            (self->*data_ov006_02142734[rows[i].d[0x5296]])(i);
+            func_ov006_0210076c(self, i);
+        }
+    }
+}

--- a/src/func_ov006_0210dbb0.c
+++ b/src/func_ov006_0210dbb0.c
@@ -1,0 +1,52 @@
+extern long long func_0203d5bc(int* p);
+extern int func_ov006_02114590(int a0, int* p, int* q0, int* q1, int* q2);
+
+typedef struct {
+    char _0[8];
+    int x, y;        /* 0x8, 0xc */
+    char _10[0x30];  /* 0x10..0x3f */
+    int f40;         /* 0x40 */
+    char _44[4];     /* 0x44 */
+    int verts[16];   /* 0x48 */
+} State;
+
+int func_ov006_0210dbb0(State* s, int* p) {
+    int v[2];
+    int b2p[2], b2q0[2], b2q1[2], b2q2[2];
+    int b3p[2], b3q0[2], b3q1[2], b3q2[2];
+    int b4p[2], b4q0[2], b4q1[2], b4q2[2];
+    int b5p[2], b5q0[2], b5q1[2], b5q2[2];
+
+    if (s->f40 <= 1 && p[1] < s->y + 0x8000) {
+        v[0] = p[0];
+        v[1] = p[1];
+        v[0] -= s->x;
+        v[1] -= s->y;
+        v[1] -= 0x8000;
+        if (func_0203d5bc(v) < 0x100000) return 1;
+    }
+
+    b2p[0] = p[0]; b2p[1] = p[1];
+    b2q0[0] = s->verts[0]; b2q0[1] = s->verts[1];
+    b2q1[0] = s->verts[2]; b2q1[1] = s->verts[3];
+    b2q2[0] = s->verts[4]; b2q2[1] = s->verts[5];
+    if (func_ov006_02114590((int)s, b2p, b2q0, b2q1, b2q2)) return 1;
+
+    b3p[0] = p[0]; b3p[1] = p[1];
+    b3q0[0] = s->verts[2]; b3q0[1] = s->verts[3];
+    b3q1[0] = s->verts[4]; b3q1[1] = s->verts[5];
+    b3q2[0] = s->verts[6]; b3q2[1] = s->verts[7];
+    if (func_ov006_02114590((int)s, b3p, b3q0, b3q1, b3q2)) return 1;
+
+    b4p[0] = p[0]; b4p[1] = p[1];
+    b4q0[0] = s->verts[8];  b4q0[1] = s->verts[9];
+    b4q1[0] = s->verts[10]; b4q1[1] = s->verts[11];
+    b4q2[0] = s->verts[12]; b4q2[1] = s->verts[13];
+    if (func_ov006_02114590((int)s, b4p, b4q0, b4q1, b4q2)) return 1;
+
+    b5p[0] = p[0]; b5p[1] = p[1];
+    b5q0[0] = s->verts[10]; b5q0[1] = s->verts[11];
+    b5q1[0] = s->verts[12]; b5q1[1] = s->verts[13];
+    b5q2[0] = s->verts[14]; b5q2[1] = s->verts[15];
+    return func_ov006_02114590((int)s, b5p, b5q0, b5q1, b5q2);
+}

--- a/src/func_ov006_0210ddf0.c
+++ b/src/func_ov006_0210ddf0.c
@@ -1,0 +1,46 @@
+typedef int s32;
+typedef int Fix12i;
+
+struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
+
+extern void *data_ov006_02137994[];
+extern struct OamAttri *data_ov006_02137684[];
+
+extern void func_ov004_020afdd0(void *a0, int a1, int a2, int a3, int a4);
+
+extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+    int sub, struct OamAttri *data,
+    s32 x, s32 y,
+    s32 palette, s32 priority,
+    Fix12i scaleX, Fix12i scaleY,
+    s32 rotation, s32 mode);
+
+void func_ov006_0210ddf0(char *c)
+{
+    if (*(int *)(c + 0x40) <= 1) {
+        func_ov004_020afdd0(data_ov006_02137994[0],
+            *(int *)(c + 8) >> 12, *(int *)(c + 0xc) >> 12, -1, 1);
+        func_ov004_020afdd0(data_ov006_02137994[1],
+            *(int *)(c + 8) >> 12, (*(int *)(c + 0xc) >> 12) + 5, -1, 2);
+    }
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+        0, data_ov006_02137684[0],
+        (*(int *)(c + 8) >> 12) - 0x10, (*(int *)(c + 0xc) >> 12) + 0x118,
+        -1, 1, 0x1000, 0x1000,
+        (unsigned short)(short)(-0x4000 - *(short *)(c + 0x32)), -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+        0, data_ov006_02137684[0],
+        (*(int *)(c + 8) >> 12) + 0x10, (*(int *)(c + 0xc) >> 12) + 0x118,
+        -1, 1, 0x1000, 0x1000,
+        (unsigned short)(short)(*(short *)(c + 0x32) - 0x4000), -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+        0, data_ov006_02137684[1],
+        (*(int *)(c + 8) >> 12) - 0x10, (*(int *)(c + 0xc) >> 12) + 0x11d,
+        -1, 2, 0x1000, 0x1000,
+        (unsigned short)(short)(-0x4000 - *(short *)(c + 0x32)), -1);
+    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
+        0, data_ov006_02137684[1],
+        (*(int *)(c + 8) >> 12) + 0x10, (*(int *)(c + 0xc) >> 12) + 0x11d,
+        -1, 2, 0x1000, 0x1000,
+        (unsigned short)(short)(*(short *)(c + 0x32) - 0x4000), -1);
+}

--- a/src/func_ov006_021104c0.c
+++ b/src/func_ov006_021104c0.c
@@ -1,0 +1,45 @@
+/* func_ov006_021104c0 at 0x021104c0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern int _ZN4cstd4fdivEii(int, int);
+extern short data_02082214[];
+extern void* data_ov006_02137630[];
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
+
+void func_ov006_021104c0(char* self)
+{
+    if (*(unsigned char*)(self + 0x30) == 0) return;
+    {
+        int f38 = *(int*)(self + 0x38);
+        if (f38 > 0) {
+            int scale;
+            int idx = 1;
+            int b, a;
+            struct { int _00, _01, _10, _11; } vec;
+            if (f38 < 0x20) {
+                scale = _ZN4cstd4fdivEii(0x20000, f38 << 12);
+            } else {
+                scale = 0x1000;
+                if ((f38 - 0x20) % 16 < 4) idx = 0;
+            }
+            b = (int)((((long long)data_02082214[1] * scale) + 0x800) >> 12);
+            a = (int)((((long long)data_02082214[0] * scale) + 0x800) >> 12);
+            vec._00 = b;
+            vec._01 = a;
+            vec._10 = -a;
+            vec._11 = b;
+            func_ov004_020b0104(data_ov006_02137630[idx], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 0, &vec);
+            func_ov004_020b0104(data_ov006_02137630[2], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2, &vec);
+        } else {
+            if (*(unsigned char*)(self + 0x31) != 0) {
+                func_ov004_020afdd0(data_ov006_02137630[0], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 0);
+                func_ov004_020afdd0(data_ov006_02137630[2], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2);
+            } else {
+                func_ov004_020afdd0(data_ov006_02137630[1], *(int*)(self + 8) >> 12, *(int*)(self + 0xc) >> 12, -1, 0);
+                func_ov004_020afdd0(data_ov006_02137630[2], *(int*)(self + 8) >> 12, (*(int*)(self + 0xc) >> 12) + 5, -1, 2);
+            }
+        }
+    }
+}

--- a/src/func_ov006_02110c08.c
+++ b/src/func_ov006_02110c08.c
@@ -1,0 +1,42 @@
+struct S { int a, b; };
+
+extern long long func_0203d5bc(int *p);
+extern int func_ov006_02114590(void *a0, struct S *p, struct S *q0, struct S *q1, struct S *q2);
+
+int func_ov006_02110c08(char *self, struct S *p) {
+    struct S d;
+    struct S s0, s1, s2, s3;
+    struct S t0, t1, t2, t3;
+    struct S u0, u1, u2, u3;
+    struct S v0, v1, v2, v3;
+
+    d.a = p->a;
+    d.b = p->b;
+    d.a -= *(int *)(self + 0x8);
+    d.b -= *(int *)(self + 0xc);
+    if (func_0203d5bc(&d.a) >= 0x400000) return 0;
+
+    s0.a = p->a; s0.b = p->b;
+    s1.a = *(int *)(self + 0x38); s1.b = *(int *)(self + 0x3c);
+    s2.a = *(int *)(self + 0x40); s2.b = *(int *)(self + 0x44);
+    s3.a = *(int *)(self + 0x48); s3.b = *(int *)(self + 0x4c);
+    if (func_ov006_02114590(self, &s0, &s1, &s2, &s3)) return 1;
+
+    t0.a = p->a; t0.b = p->b;
+    t1.a = *(int *)(self + 0x50); t1.b = *(int *)(self + 0x54);
+    t2.a = *(int *)(self + 0x40); t2.b = *(int *)(self + 0x44);
+    t3.a = *(int *)(self + 0x48); t3.b = *(int *)(self + 0x4c);
+    if (func_ov006_02114590(self, &t0, &t1, &t2, &t3)) return 1;
+
+    u0.a = p->a; u0.b = p->b;
+    u1.a = *(int *)(self + 0x58); u1.b = *(int *)(self + 0x5c);
+    u2.a = *(int *)(self + 0x60); u2.b = *(int *)(self + 0x64);
+    u3.a = *(int *)(self + 0x68); u3.b = *(int *)(self + 0x6c);
+    if (func_ov006_02114590(self, &u0, &u1, &u2, &u3)) return 1;
+
+    v0.a = p->a; v0.b = p->b;
+    v1.a = *(int *)(self + 0x70); v1.b = *(int *)(self + 0x74);
+    v2.a = *(int *)(self + 0x60); v2.b = *(int *)(self + 0x64);
+    v3.a = *(int *)(self + 0x68); v3.b = *(int *)(self + 0x6c);
+    return func_ov006_02114590(self, &v0, &v1, &v2, &v3) != 0;
+}

--- a/src/func_ov006_021122e0.c
+++ b/src/func_ov006_021122e0.c
@@ -1,0 +1,40 @@
+/* func_ov006_021122e0 at 0x021122e0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+struct S { int a, b; };
+
+extern int func_ov006_02114590(void *a0, struct S *p, struct S *q0, struct S *q1, struct S *q2);
+extern void func_ov006_02115680(int x, int y);
+
+int func_ov006_021122e0(char *self, struct S *arg) {
+    struct S p, q0, q1, q2;
+    struct S d, e, f, g;
+    if (arg->b >= 0) return 0;
+    if (arg->a >= 0x8000 && arg->a < 0x28000) {
+        if (arg->b >= -0x90000 && arg->b < -0x88000) {
+            func_ov006_02115680(*(int *)(self + 4), 0);
+            return 1;
+        }
+        p.a = arg->a; p.b = arg->b;
+        q0.a = 0x8000;  q0.b = -0x92000;
+        q1.a = 0x8000;  q1.b = -0x90000;
+        q2.a = 0x28000; q2.b = -0x90000;
+        if (func_ov006_02114590(self, &p, &q0, &q1, &q2)) {
+            func_ov006_02115680(*(int *)(self + 4), 0);
+            return 1;
+        }
+    }
+    if (*(unsigned char *)(self + 0x129) == 1 && *(int *)(self + 0x24) >= 0 &&
+        arg->a >= 0xd0000 && arg->a < 0xf8000) {
+        d.a = arg->a; d.b = arg->b;
+        e.a = 0xd8000; e.b = -0x80000;
+        f.a = 0xf8000; f.b = -0x80000;
+        g.a = 0xf8000; g.b = -0x88000;
+        if (func_ov006_02114590(self, &d, &e, &f, &g)) {
+            func_ov006_02115680(*(int *)(self + 4), 1);
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov006_0211eb90.c
+++ b/src/func_ov006_0211eb90.c
@@ -1,0 +1,14 @@
+/* func_ov006_0211eb90 at 0x0211eb90
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
+ */
+extern void func_ov006_0211f454(char *c, int i);
+extern void func_ov006_0211f34c(char *c, int i);
+
+void func_ov006_0211eb90(char *c, int i) {
+    if (*(unsigned char *)(c + i * 0x24 + 0x467f) == 0) {
+        return;
+    }
+    func_ov006_0211f454(c, i);
+    func_ov006_0211f34c(c, i);
+}

--- a/src/func_ov006_02129690.c
+++ b/src/func_ov006_02129690.c
@@ -1,0 +1,37 @@
+typedef signed char s8;
+typedef unsigned char u8;
+typedef int s32;
+
+extern void func_ov004_020af948(void* a, int b, int c, void* m);
+extern void func_ov004_020afcf8(void* a, int b, int c, void* m);
+extern void* data_ov006_02139c6c[];
+
+typedef struct {
+    s32 a;        /* 0x00 */
+    s32 b;        /* 0x04 */
+    u8 pad[0x16]; /* 0x08 */
+    u8 f1e;       /* 0x1e */
+    u8 f1f;       /* 0x1f */
+    u8 f20;       /* 0x20 */
+    u8 pad2[3];   /* 0x21 */
+} Elem;
+
+typedef struct {
+    u8 head[0xab6c];
+    s32 fixed;                  /* 0xab6c */
+    u8 mid[0xbe94 - 0xab70];
+    Elem arr[50];               /* 0xbe94 */
+} Obj;
+
+void func_ov006_02129690(Obj* a)
+{
+    int i;
+    for (i = 0; i < 50; i++) {
+        if (a->arr[i].f1e != 0) {
+            int bb = a->arr[i].a >> 12;
+            int cc = (a->arr[i].b - a->fixed) >> 12;
+            func_ov004_020af948(data_ov006_02139c6c[a->arr[i].f1f], bb, cc, 0);
+            func_ov004_020afcf8(data_ov006_02139c6c[a->arr[i].f20], bb, cc, 0);
+        }
+    }
+}

--- a/src/func_ov007_020ae070.c
+++ b/src/func_ov007_020ae070.c
@@ -1,0 +1,39 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+extern u8 data_ov007_0210342c[];
+extern void func_ov007_020c108c(char *c, int r1, int r2, int r3, int sp0);
+
+void func_ov007_020ae070(char *self)
+{
+    int *p = *(int**)self;
+    u16 state = *(u16*)p;
+    int ip2 = *(int*)((char*)*(int**)((char*)p + 4) + 0xc);
+    int *g = *(int**)data_ov007_0210342c;
+    short idx = *(short*)(*(int**)((char*)g + 0xc));
+
+    if (state != 1) return;
+    if (ip2 != 0) return;
+
+    switch (idx) {
+    case 3:  func_ov007_020c108c(*(char**)((char*)self + 4), 0, 0, 0, 0); break;
+    case 14: func_ov007_020c108c(*(char**)((char*)self + 4), 3, 0, 0, 0); break;
+    case 4:  func_ov007_020c108c(*(char**)((char*)self + 4), 2, 0, 0, 0); break;
+    case 5:  func_ov007_020c108c(*(char**)((char*)self + 4), 1, 0, 0, 0); break;
+    case 7:
+        if (*(int*)((char*)g + 0x20) == 1)
+            func_ov007_020c108c(*(char**)((char*)self + 4), 1, 0, 0, 0);
+        else
+            func_ov007_020c108c(*(char**)((char*)self + 4), 2, 0, 0, 0);
+        break;
+    case 8:  func_ov007_020c108c(*(char**)((char*)self + 4), 4, 0, 0, 0); break;
+    case 9:  func_ov007_020c108c(*(char**)((char*)self + 4), 5, 0, 0, 0); break;
+    case 10: func_ov007_020c108c(*(char**)((char*)self + 4), 6, 0, 0, 0); break;
+    case 12:
+        if (*(int*)((char*)g + 0x58) == -1)
+            func_ov007_020c108c(*(char**)((char*)self + 4), 7, 0, 0, 0);
+        else
+            func_ov007_020c108c(*(char**)((char*)self + 4), 8, 0, 0, 0);
+        break;
+    case 13: func_ov007_020c108c(*(char**)((char*)self + 4), 9, 0, 0, 0); break;
+    }
+}

--- a/src/func_ov007_020bcba8.c
+++ b/src/func_ov007_020bcba8.c
@@ -1,0 +1,75 @@
+/* func_ov007_020bcba8 at 0x020bcba8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov007).
+ */
+extern void* func_ov007_020b3f20(int n);
+extern void* func_02054ea8(void);
+extern unsigned int func_02054e88(void);
+extern int func_02054d88(void);
+extern void func_ov007_020b8548(int a0, void* a1, int a2, void* a3, unsigned int a4, int a5, int a6);
+extern void _ZN2GX7LoadOBJEPKvjj(const void*, unsigned int, unsigned int);
+extern void func_ov007_020c32e8(char* c, int sel, unsigned int n, int off);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void*, unsigned int, unsigned int);
+extern void func_ov007_020b3edc(int r0);
+extern void func_02056014(const void* src, unsigned int offset, unsigned int count);
+extern void _ZN2GX10LoadBGPlttEPKvjj(const void*, unsigned int, unsigned int);
+extern void func_ov007_020bcdb8(int idx);
+extern void func_ov007_020c33d0(char* c, int sel, unsigned int off);
+extern void func_ov007_020b850c(void);
+extern char* data_ov007_0210342c;
+
+void func_ov007_020bcba8(int idx)
+{
+    char* g = data_ov007_0210342c;
+    char* s = *(char**)(g + 0x74);
+
+    switch (idx) {
+    case 0:
+        return;
+    case 1:
+        {
+            void* a1 = func_ov007_020b3f20(0x25);
+            void* a3 = func_02054ea8();
+            unsigned int a4 = func_02054e88();
+            int a6 = *(int*)(*(char**)(*(char**)(g + 0x28)) + 0x9c);
+            int idx2;
+            func_ov007_020b8548(0, a1, 0, a3, a4, 0, a6);
+
+            _ZN2GX7LoadOBJEPKvjj(*(void**)(*(char**)(*(char**)(s + 0x24) + 4)), 0, 0x2000);
+            func_ov007_020c32e8(*(char**)(*(char**)(s + 0x2c) + 4), 0, 0, 0);
+            _ZN2GX7LoadOBJEPKvjj(func_ov007_020b3f20(0x2c), 0x2000, 0x2000);
+            _ZN2GX11LoadOBJPlttEPKvjj((char*)func_ov007_020b3f20(0x2d) + 0xc0, 0x1e0, 0x20);
+            func_ov007_020b3edc(0x2c);
+            func_ov007_020b3edc(0x2d);
+
+            idx2 = *(unsigned char*)(*(char**)(data_ov007_0210342c + 0x28) + 0x3a) + 0x25;
+            func_02056014(func_ov007_020b3f20(idx2), 0, 0x4000);
+            _ZN2GX10LoadBGPlttEPKvjj(func_ov007_020b3f20(0x2b), 0, 0x200);
+            func_ov007_020b3edc(idx2);
+            func_ov007_020b3edc(0x2b);
+
+            func_ov007_020bcdb8(1);
+            func_ov007_020c33d0(*(char**)(*(char**)(s + 0x24)), 8, 0);
+            func_ov007_020c32e8(*(char**)(*(char**)(s + 0x2c)), 3, 0, 0);
+            func_ov007_020b850c();
+        }
+        break;
+    case 3:
+        {
+            void* a1 = func_ov007_020b3f20(0x25);
+            void* a3 = func_02054ea8();
+            unsigned int a4 = func_02054e88();
+            int a5 = func_02054d88();
+            int a6 = *(int*)(*(char**)(*(char**)(g + 0x28)) + 0x9c);
+            func_ov007_020b8548(0, a1, 0, a3, a4, a5, a6);
+
+            func_ov007_020bcdb8(2);
+            func_ov007_020c33d0(*(char**)(*(char**)(s + 0x24) + 0xc), 9, 0);
+            func_ov007_020c32e8(*(char**)(*(char**)(s + 0x2c) + 8), 3, 0, 0);
+            func_ov007_020b850c();
+        }
+        break;
+    case 2:
+        break;
+    }
+}

--- a/src/func_ov018_02111a48.c
+++ b/src/func_ov018_02111a48.c
@@ -1,0 +1,50 @@
+/* func_ov018_02111a48 at 0x02111a48
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov018).
+ */
+typedef int Fix12i;
+typedef short s16;
+typedef struct { Fix12i x, y, z; } Vector3;
+
+extern Fix12i Vec3_HorzDist(const Vector3* a, const Vector3* b);
+extern s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
+extern int AngleDiff(int a, int b);
+extern s16 Vec3_VertAngle(const Vector3* v1, const Vector3* v0);
+extern void _Z14ApproachLinearRsss(s16* dst, s16 target, s16 step);
+
+void func_ov018_02111a48(char* a, char* b)
+{
+    Fix12i dist;
+    s16 horzAngle;
+    s16 delta, vert;
+    Vector3 v0;
+    Vector3 v1;
+    char* q;
+    Fix12i tx, ty, tz;
+
+    if (b == 0) return;
+
+    dist = Vec3_HorzDist((Vector3*)(a + 0x5c), (Vector3*)(b + 0x5c));
+    horzAngle = Vec3_HorzAngle((Vector3*)(a + 0x5c), (Vector3*)(b + 0x5c));
+
+    if (dist < 0x1c2000 && AngleDiff(horzAngle, *(s16*)(a + 0x8e)) < 0x1400) {
+        tz = *(Fix12i*)(b + 0x64);
+        ty = *(Fix12i*)(b + 0x60) + 0x640000;
+        tx = *(Fix12i*)(b + 0x5c);
+        v0.x = tx;
+        v0.z = tz;
+        v0.y = ty;
+        q = *(char**)(a + 0xe8) + 0xf0;
+        v1.x = *(Fix12i*)(q + 0x24);
+        v1.y = *(Fix12i*)(q + 0x28);
+        v1.z = *(Fix12i*)(q + 0x2c);
+        vert = Vec3_VertAngle(&v1, &v0);
+        delta = horzAngle - *(s16*)(a + 0x8e);
+    } else {
+        vert = 0;
+        delta = 0;
+    }
+
+    _Z14ApproachLinearRsss((s16*)(a + 0x382), delta, 0x250);
+    _Z14ApproachLinearRsss((s16*)(a + 0x380), vert, 0x250);
+}

--- a/src/func_ov018_02112234.c
+++ b/src/func_ov018_02112234.c
@@ -1,0 +1,37 @@
+/* func_ov018_02112234 at 0x02112234
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov018).
+ */
+extern void func_ov018_02111b3c(char* c);
+extern void* func_ov018_021118fc(char* c);
+extern void func_ov018_02111968(char* c, void* a, int v);
+extern char* _ZN5Actor13ClosestPlayerEv(char* thisptr);
+extern void func_ov018_02111a48(char* c, char* p);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* thisptr, char* clsn);
+extern void func_ov018_02111bf0(char* c, char* p);
+extern void func_0201267c(int a, char* p);
+
+int func_ov018_02112234(char* c) {
+    void* a;
+    int v;
+    char* p;
+    if (*(unsigned char*)(c + 0x386) != 0)
+        func_ov018_02111b3c(c);
+    a = func_ov018_021118fc(c);
+    v = 0;
+    if (a != 0) {
+        if (*(int*)((char*)a + 8) != 3)
+            v = *(int*)((char*)a + 0x358);
+        func_ov018_02111968(c, a, v);
+    }
+    p = _ZN5Actor13ClosestPlayerEv(c);
+    func_ov018_02111a48(c, p);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x174);
+    func_ov018_02111bf0(c, c + 0x1a8);
+    if (*(unsigned char*)(c + 0x386) == 0 && *(unsigned char*)(c + 0x387) == 0) {
+        unsigned int x = ((unsigned int)*(int*)(c + 0x12c) << 4) >> 16;
+        if (x == 0x10 || x == 0x25)
+            func_0201267c(0xdf, c + 0x74);
+    }
+    return 1;
+}

--- a/src/func_ov062_021163b0.c
+++ b/src/func_ov062_021163b0.c
@@ -1,0 +1,40 @@
+/* func_ov062_021163b0 at 0x021163b0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov062).
+ */
+typedef unsigned char u8;
+typedef int Fix12i;
+typedef struct { int x, y, z; } Vector3;
+
+extern int _ZN5Actor24KillAndTrackInDeathTableEv(void* c);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
+extern int _ZN5Actor14TriplePoofDustEv(void* c);
+extern int func_02012694(int a, void* p);
+extern void func_0200d8c8(void* cam, void* v, int strength);
+extern int _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void* a, Vector3* v, unsigned n, Fix12i f, short s);
+extern int data_02092138;
+extern void* data_0209f318;
+
+int func_ov062_021163b0(char* c)
+{
+    Vector3 v[2];
+    if (data_02092138 > *(int*)(c + 0x60)) {
+        _ZN5Actor24KillAndTrackInDeathTableEv(c);
+        return 1;
+    }
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144) != 0) {
+        _ZN5Actor14TriplePoofDustEv(c);
+        _ZN5Actor24KillAndTrackInDeathTableEv(c);
+        func_02012694(0x125, c + 0x74);
+        func_0200d8c8(data_0209f318, c + 0x5c, 0x7d0000);
+        v[0].x = *(int*)(c + 0x5c);
+        v[0].y = *(int*)(c + 0x60);
+        v[0].z = *(int*)(c + 0x64);
+        v[0].y += 0x32000;
+        v[1].x = *(int*)(c + 0x5c);
+        v[1].y = *(int*)(c + 0x60);
+        v[1].z = *(int*)(c + 0x64);
+        _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, &v[1], *(u8*)(c + 0x10a) + 1, 0xa000, 0);
+    }
+    return 1;
+}

--- a/src/func_ov063_02116190.c
+++ b/src/func_ov063_02116190.c
@@ -1,0 +1,28 @@
+/* func_ov063_02116190 at 0x02116190
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov063).
+ */
+extern void* _ZN5Actor13ClosestPlayerEv(void* self);
+extern int Vec3_HorzDist(const void* a, const void* b);
+
+struct Flags { unsigned short bit0 : 1; };
+
+int func_ov063_02116190(char* self)
+{
+    int vec[3];
+    void* p;
+
+    if (((struct Flags*)(self + 0x5d4))->bit0) {
+        p = _ZN5Actor13ClosestPlayerEv(self);
+        if (p != 0 && *(int*)((char*)p + 0x64) >= 0x3e8000)
+            return 1;
+    } else if (*(int*)(self + 0x60) <= (int)0xff768000) {
+        p = _ZN5Actor13ClosestPlayerEv(self);
+        vec[0] = -0xbe000;
+        vec[1] = (int)0xff66e000;
+        vec[2] = 0xbe000;
+        if (Vec3_HorzDist(vec, (char*)p + 0x5c) >= 0x73a000)
+            return 1;
+    }
+    return 0;
+}

--- a/src/func_ov064_02118480.c
+++ b/src/func_ov064_02118480.c
@@ -1,0 +1,32 @@
+extern void* data_ov064_0211adbc[];
+extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
+extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
+extern void _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(void* thiz, void* v, int f1, int f2, unsigned int a, unsigned int b);
+extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* thiz);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
+extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
+extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
+extern void func_020393d4(int* p, int v);
+
+int func_ov064_02118480(char* c) {
+    int i;
+    char* p;
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4,
+        _ZN5Model8LoadFileER13SharedFilePtr(data_ov064_0211adbc[0]), 1, -1);
+    p = c + 0x360;
+    for (i = 0; i < 8; i++) {
+        _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(p, c + 0x5c, 0x4b000, 0x96000, 0x200002, 0);
+        p += 0x3c;
+    }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+        c + 0x124,
+        _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov064_0211adbc[1]),
+        c + 0x2ec, 0x199, *(short*)(c + 0x8e), data_ov064_0211adbc[2]);
+    func_020393d4((int*)(c + 0x124),
+        (int)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    return 1;
+}

--- a/src/func_ov072_0211f280.c
+++ b/src/func_ov072_0211f280.c
@@ -1,0 +1,41 @@
+/* func_ov072_0211f280 at 0x0211f280
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov072).
+ */
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Actor;
+struct Vector3 { int x, y, z; };
+
+extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Actor* actor, const struct Vector3* pos, u32 a, int fix, u32 b, u32 c, u32 d);
+
+int func_ov072_0211f280(char* self)
+{
+    struct Actor* actor;
+    u32 id;
+    int t;
+    struct Vector3 pos;
+
+    id = *(u32*)(self + 0x170);
+    if (id == 0) return 0;
+
+    actor = _ZN5Actor10FindWithIDEj(id);
+    if (actor == 0) goto fail;
+
+    t = (int)(*(u16*)((char*)actor + 0xc) == 0xbf);
+    if (t != 0) goto body;
+
+fail:
+    return 0;
+
+body:
+    if (*(u32*)(self + 0x98) != 0) {
+        pos.x = *(int*)(self + 0x5c);
+        pos.y = *(int*)(self + 0x60);
+        pos.z = *(int*)(self + 0x64);
+        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(actor, &pos, 2, 0xc000, 1, 0, 1);
+    }
+    return 1;
+}

--- a/src/func_ov073_021223f4.cpp
+++ b/src/func_ov073_021223f4.cpp
@@ -1,0 +1,24 @@
+//cpp
+// func_ov073_021223f4 at 0x021223f4
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov073).
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+}
+extern "C" void func_ov073_021223f4(char* c);
+void func_ov073_021223f4(char* c) {
+    Vector3 vec;
+    Vector3 vec2;
+    vec.x = *(int*)(c + 0x5c);
+    vec.y = *(int*)(c + 0x60);
+    vec.z = *(int*)(c + 0x64);
+    vec.y += 0x32000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xa, vec.x, vec.y, vec.z);
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(c, vec2);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(c + 0x74));
+}

--- a/src/func_ov074_0211f154.c
+++ b/src/func_ov074_0211f154.c
@@ -1,0 +1,36 @@
+/* func_ov074_0211f154 at 0x0211f154
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov074).
+ */
+struct Vector3 { int x, y, z; };
+extern void _ZN6Camera9SetFlag_3Ev(void* cam);
+extern void Matrix4x3_FromRotationY(void* m, short ang);
+extern void MulVec3Mat4x3(void* a, void* m, void* b);
+extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, struct Vector3* v);
+extern void _ZN6Camera6SetPosERK7Vector3(void* cam, struct Vector3* v);
+extern void* data_0209f318;
+extern int data_020a0e68[];
+
+void func_ov074_0211f154(char* c) {
+    struct Vector3 look, pos, in, out;
+    void* cam;
+    cam = data_0209f318;
+    _ZN6Camera9SetFlag_3Ev(cam);
+    in.x = 0; in.y = 0; in.z = 0;
+    out.x = 0; out.y = 0; out.z = 0;
+    look.x = *(int*)(c + 0x5c);
+    look.y = *(int*)(c + 0x60);
+    look.z = *(int*)(c + 0x64);
+    pos.x = *(int*)(c + 0x5c);
+    pos.y = *(int*)(c + 0x60);
+    pos.z = *(int*)(c + 0x64);
+    look.y += 0x1a0000;
+    in.z = 0x59c000;
+    Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c + 0x8e));
+    MulVec3Mat4x3(&in, data_020a0e68, &out);
+    pos.x = pos.x + out.x;
+    pos.y = pos.y + 0x300000;
+    pos.z = pos.z + out.z;
+    _ZN6Camera9SetLookAtERK7Vector3(cam, &look);
+    _ZN6Camera6SetPosERK7Vector3(cam, &pos);
+}

--- a/src/func_ov080_02125318.cpp
+++ b/src/func_ov080_02125318.cpp
@@ -1,0 +1,35 @@
+//cpp
+// func_ov080_02125318 at 0x02125318
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov080).
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+int _ZN6Player15IsCollectingCapEv(void* player);
+void _ZN5Actor15GivePlayerCoinsER6Playerhj(void* self, void* player, unsigned char a, unsigned int b);
+void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+void _ZN9ActorBase18MarkForDestructionEv(void* self);
+}
+
+extern "C" void func_ov080_02125318(char* self, void* player);
+void func_ov080_02125318(char* self, void* player) {
+    if (_ZN6Player15IsCollectingCapEv(player)) {
+        _ZN5Actor15GivePlayerCoinsER6Playerhj(self, player, 5, 0);
+    }
+    Vector3 vec;
+    Vector3 vec2;
+    int x = *(int*)(self + 0x5c);
+    int z = *(int*)(self + 0x64);
+    int y = *(int*)(self + 0x60) + 0xb4000;
+    vec.x = x;
+    vec.y = y;
+    vec.z = z;
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(self, vec2);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(6, vec.x, vec.y, vec.z);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(self + 0x74));
+    _ZN9ActorBase18MarkForDestructionEv(self);
+}

--- a/src/func_ov080_02125bb0.c
+++ b/src/func_ov080_02125bb0.c
@@ -1,0 +1,51 @@
+/* func_ov080_02125bb0 at 0x02125bb0
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov080).
+ */
+typedef int Fix12i;
+
+extern int func_ov080_02125d08(void *self, int frames);
+extern int func_ov080_02125cd4(void *c, int n);
+extern Fix12i _ZN4cstd4fdivEii(Fix12i a, Fix12i b);
+extern int __aeabi_idiv(int a, int b);
+
+extern short data_02082214[];
+
+int func_ov080_02125bb0(void *self, int arg1)
+{
+    char *r7 = (char *)self;
+    int r6 = arg1;
+    unsigned short r4 = *(unsigned short *)(r7 + 0x1b6);
+    int *obj;
+    int r5res, r4res, sum, idx;
+    Fix12i f;
+    short tv;
+    long long prod;
+
+    if (r4 == 0)
+        return 0;
+
+    if (((unsigned char)((*(unsigned int *)(r7 + 8) >> 13) & 3)) == 0) {
+        obj = *(int **)(r7 + 0x1ac);
+        {
+            int a = __aeabi_idiv(0xffff, obj[1]);
+            int b = __aeabi_idiv(obj[2], a);
+            if (r6 > b * (obj[4] - r4))
+                return 0;
+        }
+    }
+
+    r5res = func_ov080_02125d08(self, r6);
+    r4res = func_ov080_02125cd4(self, *(int *)((char *)*(int **)(r7 + 0x1ac) + 0x10) - *(unsigned short *)(r7 + 0x1b6));
+
+    f = _ZN4cstd4fdivEii(r4res, *(int *)((char *)*(int **)(r7 + 0x1ac) + 0xc));
+    prod = (long long)(-f) * (long long)r6;
+    sum = r4res + (int)((prod + 0x800) >> 12);
+    if (sum < 0)
+        sum = 0;
+
+    idx = (unsigned short)r5res >> 4;
+    tv = *(short *)((char *)data_02082214 + (idx << 2));
+    prod = (long long)tv * (long long)sum;
+    return (int)((prod + 0x800) >> 12);
+}

--- a/src/func_ov081_021237ec.cpp
+++ b/src/func_ov081_021237ec.cpp
@@ -1,0 +1,52 @@
+//cpp
+// func_ov081_021237ec at 0x021237ec
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
+typedef struct { int x, y, z; } Vector3;
+struct Mtx43 { int m[12]; };
+
+extern "C" {
+void _ZN5Actor10PoofDustAtERK7Vector3(void* c, const Vector3& v);
+int _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void* c, Vector3* v, unsigned int n, int f, short s);
+void Matrix4x3_FromTranslation(struct Mtx43* m, int x, int y, int z);
+void MulMat4x3Mat4x3(struct Mtx43* dst, struct Mtx43* a, struct Mtx43* b);
+void SubVec3(Vector3* a, Vector3* b, Vector3* c);
+void Vec3_LslInPlace(Vector3* v, int n);
+void AddVec3(Vector3* a, Vector3* b, Vector3* c);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
+void func_0201267c(int a, void* b);
+void _ZN5Actor24KillAndTrackInDeathTableEv(void* c);
+extern struct Mtx43 data_020a0e68;
+}
+
+extern "C" void func_ov081_021237ec(char* c)
+{
+    Vector3 t;
+    Vector3 v;
+    Vector3 b;
+
+    t.x = *(int*)(c + 0x5c);
+    t.y = *(int*)(c + 0x60);
+    t.z = *(int*)(c + 0x64);
+    t.y += *(int*)(c + 0x1a4) - 0x50000;
+    v = t;
+    _ZN5Actor10PoofDustAtERK7Vector3(c, v);
+
+    b.x = *(int*)(c + 0x5c);
+    b.y = *(int*)(c + 0x60);
+    b.z = *(int*)(c + 0x64);
+    _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, &b, 3, 0xa000, 0);
+
+    Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
+    MulMat4x3Mat4x3((struct Mtx43*)(*(char**)(c + 0x124) + 0x30), &data_020a0e68, &data_020a0e68);
+
+    t.x = data_020a0e68.m[9];
+    t.y = data_020a0e68.m[10];
+    t.z = data_020a0e68.m[11];
+    SubVec3(&t, (Vector3*)(c + 0x5c), &t);
+    Vec3_LslInPlace(&t, 3);
+    AddVec3(&t, (Vector3*)(c + 0x5c), &t);
+
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x53, t.x, t.y, t.z);
+    func_0201267c(0xd5, c + 0x74);
+    _ZN5Actor24KillAndTrackInDeathTableEv(c);
+}

--- a/src/func_ov081_021250c8.c
+++ b/src/func_ov081_021250c8.c
@@ -1,0 +1,57 @@
+/* func_ov081_021250c8 at 0x021250c8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
+ */
+struct Vec3 { int x, y, z; };
+struct PathPtr { int a, b; };
+
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+extern void func_02012694(int a, void *b);
+extern int func_ov081_02125488(void *c, void *p);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
+extern void _ZN7PathPtrC1Ev(struct PathPtr *self);
+extern void _ZN7PathPtr6FromIDEj(struct PathPtr *self, unsigned int id);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vec3 *v, unsigned int i);
+extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
+extern int LenVec3(struct Vec3 *v);
+extern short Vec3_HorzAngle(struct Vec3 *a, struct Vec3 *b);
+extern void ApproachAngle(void *p, int a, int b, int c, int d);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern void Vec3_MulScalar(struct Vec3 *out, struct Vec3 *in, int s);
+extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+extern char data_ov081_02128e54[];
+extern char data_ov081_02128da0[];
+
+int func_ov081_021250c8(char *c) {
+    struct PathPtr p;
+    struct Vec3 node;
+    struct Vec3 diff;
+    struct Vec3 scaled;
+    int len;
+
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x150)) {
+        func_02012694(0xe5, c + 0x74);
+        func_ov081_02125488(c, data_ov081_02128e54);
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x30c, *(void**)(data_ov081_02128da0 + 4), 0x40000000, 0x1000, 0);
+        return 1;
+    }
+
+    _ZN7PathPtrC1Ev(&p);
+    _ZN7PathPtr6FromIDEj(&p, *(unsigned int*)(c + 0x418));
+    _ZNK7PathPtr7GetNodeER7Vector3j(&p, &node, *(unsigned int*)(c + 0x424));
+    node.y = *(int*)(c + 0x60);
+    Vec3_Sub(&diff, (struct Vec3*)(c + 0x5c), &node);
+    len = LenVec3(&diff);
+    ApproachAngle(c + 0x94, Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &node), 1, 0x1000, 0x500);
+    if (len == 0) goto epi;
+    if (len > *(int*)(c + 0x458)) goto work;
+epi:
+    return 1;
+work:
+    {
+        int q = _ZN4cstd4fdivEii(*(int*)(c + 0x458), len);
+        Vec3_MulScalar(&scaled, &diff, q);
+        SubVec3((struct Vec3*)(c + 0x5c), &scaled, (struct Vec3*)(c + 0x5c));
+    }
+    return 1;
+}

--- a/src/func_ov081_02125fb8.c
+++ b/src/func_ov081_02125fb8.c
@@ -1,0 +1,55 @@
+/* func_ov081_02125fb8 at 0x02125fb8
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
+ */
+enum Bool { FALSE, TRUE };
+
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+extern void* _ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32, int, int, int);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, const Vector3* pos, u32 a, int b, u32 c, u32 d, u32 e);
+extern void func_02012694(int a, void* b);
+
+void func_ov081_02125fb8(void* thisp) {
+    char* self = (char*)thisp;
+    void* other;
+    int flags;
+    u32 id = *(u32*)(self + 0x134);
+    if (id == 0) return;
+    other = _ZN5Actor10FindWithIDEj(id);
+    if (other == 0) return;
+    flags = *(int*)(self + 0x130);
+    if ((flags & 0x10) || (flags & 0x40000)) {
+        _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x11c, *(int*)(self+0x5c), *(int*)(self+0x60), *(int*)(self+0x64));
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    }
+    {
+        enum Bool eq = (enum Bool)(*(u16*)((char*)other + 0xc) == 0xbf);
+        if (eq != FALSE) {
+            if (*(u8*)((char*)other + 0x6fb) != 0) return;
+            if (*(u8*)((char*)other + 0x6f9) == 1) {
+                _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x11c, *(int*)(self+0x5c), *(int*)(self+0x60), *(int*)(self+0x64));
+                _ZN9ActorBase18MarkForDestructionEv(self);
+                return;
+            }
+            {
+                Vector3 pos;
+                pos.x = *(int*)(self+0x5c);
+                pos.y = *(int*)(self+0x60);
+                pos.z = *(int*)(self+0x64);
+                _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(other, &pos, 1, 0xc000, 1, 0, 1);
+                func_02012694(0x3c, self + 0x74);
+                _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x11c, *(int*)(self+0x5c), *(int*)(self+0x60), *(int*)(self+0x64));
+                _ZN9ActorBase18MarkForDestructionEv(self);
+                return;
+            }
+        }
+    }
+}

--- a/src/func_ov081_02127cf4.c
+++ b/src/func_ov081_02127cf4.c
@@ -1,0 +1,31 @@
+/* func_ov081_02127cf4 at 0x02127cf4
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
+ */
+struct Vector3 { int x, y, z; };
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* pos);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const struct Vector3* vec);
+extern void func_ov081_02127be0(void* self);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
+
+void func_ov081_02127cf4(char* c) {
+  struct Vector3 vec;
+  struct Vector3 vec2;
+  _ZN5Sound9PlayBank3EjRK7Vector3(0x41, (const struct Vector3*)(c + 0x74));
+  int x = *(int*)(c + 0x5c);
+  int y = *(int*)(c + 0x60) + 0x96000;
+  int z = *(int*)(c + 0x64);
+  vec.x = x;
+  vec.y = y;
+  vec.z = z;
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x74, vec.x, vec.y, vec.z);
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x75, vec.x, vec.y, vec.z);
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x76, vec.x, vec.y, vec.z);
+  ((int*)&vec2)[0] = ((int*)&vec)[0];
+  ((int*)&vec2)[1] = ((int*)&vec)[1];
+  ((int*)&vec2)[2] = ((int*)&vec)[2];
+  _ZN5Actor10PoofDustAtERK7Vector3(c, &vec2);
+  func_ov081_02127be0(c);
+  _ZN9ActorBase18MarkForDestructionEv(c);
+}

--- a/src/func_ov091_02132a14.cpp
+++ b/src/func_ov091_02132a14.cpp
@@ -1,0 +1,39 @@
+//cpp
+// func_ov091_02132a14 at 0x02132a14
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov091).
+struct Vector3 { int x, y, z; };
+struct VObj {
+  virtual void v0();  virtual void v1();  virtual void v2();  virtual void v3();
+  virtual void v4();  virtual void v5();  virtual void v6();  virtual void v7();
+  virtual void v8();  virtual void v9();  virtual void v10(); virtual void v11();
+  virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+  virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+  virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+  virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+  virtual void v28(); virtual int  vGet();
+};
+extern "C" {
+void _ZN6Player16IncMegaKillCountEv(void* self);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& v);
+void _ZN9ActorBase18MarkForDestructionEv(void* self);
+void func_02012694(int, void*);
+}
+
+extern "C" void func_ov091_02132a14(char* c, void* p){
+    _ZN6Player16IncMegaKillCountEv(p);
+    Vector3 vec;
+    vec.x = *(int*)(c + 0x5c);
+    vec.y = *(int*)(c + 0x60);
+    vec.z = *(int*)(c + 0x64);
+    int ret = ((VObj*)c)->vGet();
+    vec.y += ret;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x48, vec.x, vec.y, vec.z);
+    Vector3 vec2;
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(c, vec2);
+    _ZN9ActorBase18MarkForDestructionEv(c);
+    func_02012694(0x1e, c + 0x74);
+}

--- a/src/func_ov098_021384fc.cpp
+++ b/src/func_ov098_021384fc.cpp
@@ -1,0 +1,57 @@
+//cpp
+// func_ov098_021384fc at 0x021384fc
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+extern "C" {
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *, void *);
+void func_020383fc(void *);
+int func_ov098_02139228(void *);
+void func_ov098_02138b28(void *, int);
+void _Z14ApproachLinearRiii(int *, int, int);
+void func_ov098_02138e6c(void *);
+void func_ov098_021390ec(void *);
+int func_ov098_02138bb8(void *);
+void _ZN12CylinderClsn5ClearEv(void *);
+void _ZN12CylinderClsn6UpdateEv(void *);
+void func_ov098_02139850(void *);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void *);
+void func_ov098_021396a4(void *);
+int _ZN16MeshColliderBase9IsEnabledEv(void *);
+void _ZN16MeshColliderBase7DisableEv(void *);
+}
+
+struct Obj {
+    virtual void v0();   virtual void v1();   virtual void v2();   virtual void v3();
+    virtual void v4();   virtual void v5();   virtual void v6();   virtual void v7();
+    virtual void v8();   virtual void v9();   virtual void v10();  virtual void v11();
+    virtual void v12();  virtual void v13();  virtual void v14();  virtual void v15();
+    virtual void v16();  virtual void v17();  virtual void v18();  virtual void v19();
+    virtual void v20();  virtual void v21();  virtual void v22();  virtual void v23();
+    virtual void v24();  virtual void v25();  virtual void v26();  virtual void v27();
+    virtual void v28();  virtual void v29();  virtual void v30();  virtual void v31();
+};
+
+extern "C" void func_ov098_021384fc(void *c);
+void func_ov098_021384fc(void *c) {
+    char *b = (char *)c;
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, b + 0x564);
+    func_020383fc(b + 0x320);
+    if (func_ov098_02139228(c)) {
+        func_ov098_02138b28(c, 0);
+        return;
+    }
+    _Z14ApproachLinearRiii((int *)(b + 0x98), 0, 0x555);
+    func_ov098_02138e6c(c);
+    func_ov098_021390ec(c);
+    if (func_ov098_02138bb8(c)) {
+        ((Obj *)c)->v31();
+    }
+    _ZN12CylinderClsn5ClearEv(b + 0x564);
+    _ZN12CylinderClsn6UpdateEv(b + 0x564);
+    func_ov098_02139850(c);
+    if (!_ZNK12WithMeshClsn10IsOnGroundEv(b + 0x320)) {
+        func_ov098_021396a4(c);
+    }
+    if (_ZN16MeshColliderBase9IsEnabledEv(b + 0x124)) {
+        _ZN16MeshColliderBase7DisableEv(b + 0x124);
+    }
+}

--- a/src/func_ov098_02138734.cpp
+++ b/src/func_ov098_02138734.cpp
@@ -1,0 +1,57 @@
+//cpp
+// func_ov098_02138734 at 0x02138734
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+struct Obj {
+    virtual void m00(); virtual void m01(); virtual void m02(); virtual void m03();
+    virtual void m04(); virtual void m05(); virtual void m06(); virtual void m07();
+    virtual void m08(); virtual void m09(); virtual void m10(); virtual void m11();
+    virtual void m12(); virtual void m13(); virtual void m14(); virtual void m15();
+    virtual void m16(); virtual void m17(); virtual void m18(); virtual void m19();
+    virtual void m20(); virtual void m21(); virtual void m22(); virtual void m23();
+    virtual void m24(); virtual void m25(); virtual void m26(); virtual void m27();
+    virtual void m28(); virtual void m29(); virtual void m30(); virtual void m31();
+};
+
+extern "C" {
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *actor, void *cyl);
+void func_020383fc(void *p);
+int func_ov098_02139228(void *c);
+void func_ov098_02138b28(void *c, int i);
+void _Z14ApproachLinearRiii(int *a, int b, int c);
+void func_ov098_02138e6c(void *c);
+void func_ov098_021390ec(void *c);
+int func_ov098_02138bb8(void *c);
+void _ZN12CylinderClsn5ClearEv(void *cyl);
+void _ZN12CylinderClsn6UpdateEv(void *cyl);
+void func_ov098_02139850(void *c);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void *p);
+void func_ov098_021396a4(void *c);
+int _ZN16MeshColliderBase9IsEnabledEv(void *p);
+void _ZN16MeshColliderBase7DisableEv(void *p);
+void func_ov098_02138734(char *c);
+}
+
+void func_ov098_02138734(char *c)
+{
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x564);
+    func_020383fc(c + 0x320);
+    if (func_ov098_02139228(c)) {
+        func_ov098_02138b28(c, 0);
+        return;
+    }
+    _Z14ApproachLinearRiii((int *)(c + 0x98), 0, 0x555);
+    func_ov098_02138e6c(c);
+    func_ov098_021390ec(c);
+    if (func_ov098_02138bb8(c)) {
+        ((Obj *)c)->m31();
+    }
+    _ZN12CylinderClsn5ClearEv(c + 0x564);
+    _ZN12CylinderClsn6UpdateEv(c + 0x564);
+    func_ov098_02139850(c);
+    if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320)) {
+        func_ov098_021396a4(c);
+    }
+    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
+        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    }
+}

--- a/src/func_ov098_021388bc.cpp
+++ b/src/func_ov098_021388bc.cpp
@@ -1,0 +1,68 @@
+//cpp
+// func_ov098_021388bc at 0x021388bc
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+struct Obj {
+    virtual void v0();  virtual void v1();  virtual void v2();  virtual void v3();
+    virtual void v4();  virtual void v5();  virtual void v6();  virtual void v7();
+    virtual void v8();  virtual void v9();  virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual void v29(); virtual void v30(); virtual void v31();
+};
+
+extern "C" {
+void func_020383fc(void *p);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void *p);
+void *_ZNK12WithMeshClsn14GetFloorResultEv(void *p);
+int func_02037e78(int *p);
+void _ZN6Player9DropActorEv(void *p);
+void func_ov098_02138b28(void *c, int i);
+void _ZN12CylinderClsn5ClearEv(void *p);
+void func_ov098_02139850(void *c);
+void func_ov098_021396a4(void *c);
+int _ZN16MeshColliderBase9IsEnabledEv(void *p);
+void _ZN16MeshColliderBase7DisableEv(void *p);
+}
+
+extern "C" void func_ov098_021388bc(char *c)
+{
+    int flags;
+    bool t;
+
+    func_020383fc(c + 0x320);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320) != 0) {
+        if (func_02037e78((int *)((char *)_ZNK12WithMeshClsn14GetFloorResultEv(c + 0x320) + 4)) != 0) {
+            void *p = *(void **)(c + 0x5e4);
+            if (p != 0) {
+                _ZN6Player9DropActorEv(p);
+                ((Obj *)c)->v31();
+                return;
+            }
+        }
+    }
+
+    flags = *(int *)(c + 0xb0);
+    t = flags & 0x400;
+    if (t != false) {
+        func_ov098_02138b28(c, 2);
+    } else {
+        t = flags & 0x2000;
+        if (t != false) {
+            func_ov098_02138b28(c, 4);
+        } else {
+            t = flags & 0x100;
+            if (t == false) {
+                func_ov098_02138b28(c, 0);
+            }
+        }
+    }
+
+    _ZN12CylinderClsn5ClearEv(c + 0x564);
+    func_ov098_02139850(c);
+    func_ov098_021396a4(c);
+    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
+        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    }
+}

--- a/src/func_ov098_021389f8.cpp
+++ b/src/func_ov098_021389f8.cpp
@@ -1,0 +1,56 @@
+//cpp
+// func_ov098_021389f8 at 0x021389f8
+// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+extern "C" {
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
+void func_020383fc(void*);
+void func_ov098_02139228(void*);
+void func_ov098_02138e6c(void*);
+void func_ov098_021390ec(void*);
+int func_ov098_02138bb8(void*);
+int func_ov098_02138bfc(void*);
+void _ZN12CylinderClsn5ClearEv(void*);
+void _ZN12CylinderClsn6UpdateEv(void*);
+void func_ov098_02139850(void*);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
+void func_ov098_021396a4(void*);
+int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void*, int, int);
+void func_ov098_021397c8(void*);
+}
+
+struct Obj {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual void v29(); virtual void v30(); virtual void v31();
+};
+
+extern "C" void func_ov098_021389f8(char* c) {
+    int t = (*(int*)(c + 0xb0) & 8) != 0;
+    if (t != false) {
+        if (*(int*)(c + 0x98) == 0 && *(int*)(c + 0xa8) == 0) return;
+    }
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x564);
+    func_020383fc(c + 0x320);
+    func_ov098_02139228(c);
+    func_ov098_02138e6c(c);
+    func_ov098_021390ec(c);
+    if (func_ov098_02138bb8(c) || func_ov098_02138bfc(c)) {
+        ((Obj*)c)->v31();
+    }
+    _ZN12CylinderClsn5ClearEv(c + 0x564);
+    _ZN12CylinderClsn6UpdateEv(c + 0x564);
+    _ZN12CylinderClsn5ClearEv(c + 0x5a4);
+    _ZN12CylinderClsn6UpdateEv(c + 0x5a4);
+    func_ov098_02139850(c);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320) == 0) {
+        func_ov098_021396a4(c);
+    }
+    if (_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x600000, 0) != 0) {
+        func_ov098_021397c8(c);
+    }
+}

--- a/src/func_ov098_02138bfc.c
+++ b/src/func_ov098_02138bfc.c
@@ -1,0 +1,25 @@
+/* func_ov098_02138bfc at 0x02138bfc
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+ */
+typedef enum { false, true } bool;
+extern int func_02035638(unsigned char *p);
+extern int func_0203567c(int p);
+extern int _ZNK10ClsnResult9GetClsnIDEv(int self);
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+int func_ov098_02138bfc(char *c){
+ int r; void *a; unsigned short type;
+ if(!func_02035638((unsigned char*)(c+0x320))) return 0;
+ r=func_0203567c((int)(c+0x320));
+ if(_ZNK10ClsnResult9GetClsnIDEv(r)==-1) return 0;
+ a=_ZN5Actor10FindWithIDEj((unsigned int)_ZNK10ClsnResult9GetClsnIDEv(r));
+ if(!a) return 0;
+ type=*(unsigned short*)((char*)a+0xc);
+ { bool b;
+ b=(type==0x135); if(b) goto out;
+ b=(type==0xa2); if(b) goto out;
+ b=(type==0xa3); if(b) goto out;
+ b=(type==0xa1); if(b) goto out;
+ b=(type==0xa4); if(!b) return 0;
+ out: return 1; }
+}

--- a/src/func_ov098_02139070.c
+++ b/src/func_ov098_02139070.c
@@ -1,0 +1,31 @@
+/* func_ov098_02139070 at 0x02139070
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
+ */
+struct Vector3 { int x, y, z; };
+
+extern void func_ov098_02138e08(char* c);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void _ZN5Actor19DisappearPoofDustAtERK7Vector3(void* self, const struct Vector3* vec);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* pos);
+extern void func_ov098_02138b28(char* c, int i);
+
+void func_ov098_02139070(char* self) {
+    struct Vector3 vec;
+    struct Vector3 vec2;
+    int x, y, z;
+    func_ov098_02138e08(self);
+    x = *(int*)(self + 0x5c);
+    y = *(int*)(self + 0x60) + 0x28000;
+    z = *(int*)(self + 0x64);
+    vec.x = x;
+    vec.y = y;
+    vec.z = z;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xe, vec.x, vec.y, vec.z);
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor19DisappearPoofDustAtERK7Vector3(self, &vec2);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, (struct Vector3*)(self + 0x74));
+    func_ov098_02138b28(self, 6);
+}

--- a/src/func_ov100_02145c58.c
+++ b/src/func_ov100_02145c58.c
@@ -1,0 +1,62 @@
+/* func_ov100_02145c58 at 0x02145c58
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov100).
+ */
+extern int func_ov100_02145e74(char* a, char* b);
+extern unsigned char NumStars(void);
+extern int func_ov100_02144f84(void);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(char* p, char* actor, unsigned int msg, void* vec, unsigned int e, unsigned int two);
+extern void _ZN6Player11OpenBigDoorEv(char* p);
+extern int func_ov100_02145f68(char* c, void* p, char* b);
+extern int _ZN6Player13TryTalkToDoorEh(char* p, unsigned char x);
+extern void func_ov100_02145e10(char* a, char* b);
+
+struct Vec3 { int x, y, z; };
+
+extern signed char data_ov100_02148390[];
+extern char data_0209caa0[];
+extern char data_ov100_02148984[];
+extern char data_ov100_02148994[];
+
+int func_ov100_02145c58(char* a, char* b) {
+    signed char* entry;
+    int s5, lt, r6, msg;
+    int vec[3];
+
+    if (func_ov100_02145e74(a, b)) {
+        entry = data_ov100_02148390 + *(int*)(a + 8) * 6;
+        s5 = (entry[0] == 0x50);
+        lt = ((int)NumStars() < entry[0]);
+        r6 = (*(unsigned char*)(data_0209caa0 + 0x41) == 0);
+
+        if (*(int*)(data_0209caa0 + 4) & (0x8000 << entry[1]))
+            goto e10;
+        if (s5) {
+            if (*(int*)(a + 0x88) <= 0) goto e10;
+            if (!lt && r6) goto e10;
+        }
+        {
+            int t5c = *(int*)(a + 0x5c);
+            int t64 = *(int*)(a + 0x64);
+            int t60 = *(int*)(a + 0x60) + 0xb4000;
+            vec[0] = t5c;
+            vec[1] = t60;
+            vec[2] = t64;
+        }
+        if (!(r6 && !s5 && !lt)) {
+            if (func_ov100_02144f84() == 0) return 1;
+            msg = r6 ? *(short*)(entry + 2) : *(short*)(entry + 4);
+            if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(b, a, msg, vec, 0, 2) == 0) goto e10;
+            if (s5) _ZN6Player11OpenBigDoorEv(b);
+            func_ov100_02145f68(a, data_ov100_02148984, b);
+            return 1;
+        } else {
+            if (_ZN6Player13TryTalkToDoorEh(b, 1) == 0) goto e10;
+            func_ov100_02145f68(a, data_ov100_02148994, b);
+            return 1;
+        }
+    e10:
+        func_ov100_02145e10(a, b);
+    }
+    return 1;
+}

--- a/src/func_ov100_02145e10.c
+++ b/src/func_ov100_02145e10.c
@@ -1,0 +1,19 @@
+/* func_ov100_02145e10 at 0x02145e10
+ *
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov100).
+ */
+extern int _ZN6Player16TryEnterStarDoorER7Vector3s(void *player, void *vec, short s);
+extern void func_ov100_02145f68(void *c, void *p, void *a2);
+extern void SetTouchScreenDelay(void);
+extern unsigned char data_ov100_02148954[];
+
+void func_ov100_02145e10(char *self, void *player)
+{
+    int a;
+    int z = *(int*)(self + 0x88);
+    if (z < 0) a = *(short*)(self + 0x8e);
+    else a = *(short*)(self + 0x8e) + 0x8000;
+    if (_ZN6Player16TryEnterStarDoorER7Vector3s(player, self + 0x5c, a))
+        func_ov100_02145f68(self, data_ov100_02148954, player);
+    SetTouchScreenDelay();
+}

--- a/src/nds_print.c
+++ b/src/nds_print.c
@@ -1,0 +1,9 @@
+extern void func_020147bc(unsigned short* r0, int r1);
+
+void nds_print(unsigned short* dst, volatile signed char* str) {
+    while (*str != 0) {
+        func_020147bc(dst, *str);
+        ++dst;
+        ++str;
+    }
+}


### PR DESCRIPTION
Matches **107 functions** across arm9-main and 19 overlays, produced by the parallel fan-out matching harness and independently re-verified against the current `main`.

## Per-module

| module | funcs |
|---|---|
| arm9-main | 53 |
| ov006 | 14 |
| ov002 | 10 |
| ov098 | 6 |
| ov081 | 4 |
| ov007 / ov018 / ov080 / ov091 / ov100 | 2 each |
| ov003 / ov036 / ov062 / ov063 / ov064 / ov066 / ov072 / ov073 / ov074 / ov102 | 1 each |

## Verification

- **Byte-match:** all 107 recompile byte-identical (relocation-aware) to the ROM under `mwccarm 1.2/sp2p3` with the canonical flags, confirmed against this PR's merge base.
- **Reloc destinations:** link-checked — **103 VERIFIED + 4 BLIND, 0 WRONG, 0 NO-REPRO** (every resolved relocation points at the correct symbol; BLIND = relocs to symbols not yet in the delinker config, no wrong destination).

## Refreshed onto `main` @ 63.9%

Merged the latest upstream `main` (`c51439d`, 63.9%). Five functions that the upstream idiom-enriched fan-out matched in the same window were resolved in favor of upstream's copies and dropped from this PR, so it proposes **only functions `main` does not already have**: `__sinit_ov063_0211e29c`, `func_020485f0`, `func_02051918`, `func_ov004_020b6430`, `func_ov098_0213b6e0`.

src-only — no tooling, config, symbol, or notes changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
