### PR TITLE
Claim: arm9 main, ov002, ov006 ranges (active matching)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,3 +20,6 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| arm9 main 0x02005000-0x02072000 | andrewboudreau | 2026-06-28 | Claimed |
+| ov002 0x020ad000-0x020fd000 | andrewboudreau | 2026-06-28 | Claimed |
+| ov006 0x020c0000-0x0212a000 | andrewboudreau | 2026-06-28 | Claimed |


### PR DESCRIPTION
Claiming three regions I'm actively matching this session so they don't get double-worked:

- `arm9 main 0x02005000-0x02072000`
- `ov002 0x020ad000-0x020fd000`
- `ov006 0x020c0000-0x0212a000`

**What I'm taking:** the matchable read-and-forward and single-loop shapes in these ranges (getters, alloc/load wrappers, guard-chains, small dispatch loops), via a verified compile-and-compare fan-out — everything is checked byte-identical to the ROM and reloc-destination audited before it's committed.

**How far I expect to get:** a few dozen functions per region this pass. The residue is register-permutation / CSE-hoist codegen walls that I leave for the permuter rather than grind. I'll flip the status to `Done` (or remove the rows) when I stop, so the ranges free up.

PR #50 already landed 73 functions from these regions; this reserves the follow-on work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6B5dmA7MZqEp3bsWuKGsK
