### PR TITLE
[codex] Remove mwccarm license setup notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ You bring your own copy of the game. Nothing copyrighted lives in this repo.
 1. **Your own SM64DS cartridge dump (`.nds`).** The symbols and addresses here are
    verified against the **EU (Europe) retail build**, so use that build. The ROM and
    anything extracted from it are git-ignored and must never be committed.
-2. **mwccarm** (Metrowerks CodeWarrior ARM) + `license.dat`. Proprietary but free; it's
-   pinned in the DS-decompilation Discord, not downloadable directly. Full instructions
-   in [`notes/setup-mwccarm.md`](notes/setup-mwccarm.md). Extract to `tools/mwccarm/`
-   (git-ignored) and set the `LM_LICENSE_FILE` environment variable.
+2. **mwccarm** (Metrowerks CodeWarrior ARM). Proprietary but free; it's pinned in
+   the DS-decompilation Discord, not downloadable directly. Full instructions are
+   in [`notes/setup-mwccarm.md`](notes/setup-mwccarm.md). Extract to
+   `tools/mwccarm/` (git-ignored).
 3. **dsd** (the ds-decomp toolkit): https://github.com/AetiasHax/ds-decomp, it drives
    the analysis config in `config/` and rebuilds the ROM from objects.
 4. **Python 3** plus a few packages:
@@ -36,7 +36,7 @@ git clone https://github.com/bmanus2-dotcom/sm64ds-decomp
 cd sm64ds-decomp
 pip install ndspy capstone pyelftools
 
-# get mwccarm + license.dat per notes/setup-mwccarm.md, then:
+# get mwccarm per notes/setup-mwccarm.md, then:
 python tools/unpack.py "path/to/your-own-sm64ds.nds"   # -> populates extracted/ (git-ignored)
 ```
 
@@ -71,8 +71,8 @@ with those habits in mind gets your first draft close and cuts iterations.
 
 ## Ground rules
 
-- **Never commit copyrighted material.** No ROM, no extracted assets, no `mwccarm`/
-  `license.dat`. The `.gitignore` already enforces this, don't override it.
+- **Never commit copyrighted material.** No ROM, no extracted assets, no `mwccarm`.
+  The `.gitignore` already enforces this, don't override it.
 - **Import knowledge, write code.** You may use community symbol names and struct/field
   offsets (see [`CREDITS.md`](CREDITS.md)), but all C in `src/` must be hand-written from
   scratch against your own ROM. Do **not** paste another project's source.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Short version:
 
 ```
 pip install ndspy capstone pyelftools
-# get mwccarm + license.dat per notes/setup-mwccarm.md, then:
+# get mwccarm per notes/setup-mwccarm.md, then:
 python tools/unpack.py "path/to/your-own-sm64ds.nds"
 ```
 
@@ -103,10 +103,10 @@ Clone https://github.com/bmanus2-dotcom/sm64ds-decomp and set up the Super Mario
 matching-decompilation toolchain on my machine. Do these in order:
 1. Read CONTRIBUTING.md and notes/setup-mwccarm.md in the repo.
 2. Install the Python dependencies: ndspy, capstone, pyelftools.
-3. mwccarm and license.dat cannot be downloaded automatically: they are in the DS-decomp
+3. mwccarm cannot be downloaded automatically: it is in the DS-decomp
    Discord (https://discord.com/invite/gwN6M3HQrA, resources channel, mwccarm.zip) and I
-   have to fetch them by hand. Wait for me to do that, then help me place them under
-   tools/mwccarm/ and set the LM_LICENSE_FILE environment variable.
+   have to fetch it by hand. Wait for me to do that, then help me place it under
+   tools/mwccarm/.
 4. Unpack my own SM64DS cartridge dump with tools/unpack.py. This writes the ARM9, ARM7,
    and overlay binaries into extracted/ (gitignored), including both the compressed
    arm9.bin and the decompressed arm9_dec.bin. Use the decompressed image for disassembly.

--- a/notes/setup-mwccarm.md
+++ b/notes/setup-mwccarm.md
@@ -13,18 +13,13 @@ Discord servers (pokediamond/pokeheartgold) have the same pinned files.
 1. **`mwccarm.zip`**, the whole set of CodeWarrior ARM compiler versions. It contains
    subfolders like `1.2/`, `2.0/` with service-pack subdirs (e.g. `sp1`, `sp2p2`),
    each holding `mwccarm.exe`, `mwldarm.exe`, `mwasmarm.exe`.
-2. **`license.dat`**, the CodeWarrior license file (often bundled in the same zip or a
-   sibling `.rar`).
-3. A **NITRO-SDK** archive if pinned (e.g. `NitroSDK-*.7z`), needed later for SDK
+2. A **NITRO-SDK** archive if pinned (e.g. `NitroSDK-*.7z`), needed later for SDK
    library headers/objects. Not required just to start matching game functions.
 
 ## Where to put it
 - Extract `mwccarm.zip` to: `tools/mwccarm/` in this repo
   (so paths look like `tools/mwccarm/2.0/sp2p2/mwccarm.exe`).
   This folder is gitignored (proprietary, not redistributable).
-- Set a Windows environment variable so the compiler finds its license:
-  `LM_LICENSE_FILE` = full path to `license.dat`.
-  (System Settings -> Environment Variables, or `setx LM_LICENSE_FILE "C:\...\license.dat"`)
 - Windows bonus: `mwccarm.exe` is a native Windows binary, so no Wine needed.
 
 ## Which version do we actually need?
@@ -35,4 +30,4 @@ with each mwccarm version, and byte-diff against the ROM in objdiff/decomp.me un
 matches. That match pins the version for the whole project.
 
 ## .gitignore
-`tools/mwccarm/` and `license.dat` must never be committed.
+`tools/mwccarm/` must never be committed.


### PR DESCRIPTION
## Summary

- remove references to fetching or configuring license.dat for mwccarm setup
- remove LM_LICENSE_FILE setup guidance
- keep the setup docs focused on placing mwccarm under tools/mwccarm/

## Validation

- reviewed the staged diff before commit
- searched the touched docs for remaining license.dat and LM_LICENSE references