### PR TITLE
Match 24 functions: arm9-main getters/serializers + ov006 single-loop updaters

### DIFF
--- a/src/GetSceneOverlayID.c
+++ b/src/GetSceneOverlayID.c
@@ -1,0 +1,31 @@
+extern int IsMinigameActorID(unsigned int id);
+
+extern int overlay_2;
+extern int overlay_3;
+extern int overlay_5;
+extern int overlay_6;
+extern int overlay_7;
+
+int GetSceneOverlayID(int id)
+{
+    if (IsMinigameActorID(id))
+        return (int)&overlay_6;
+
+    switch (id) {
+    case 3:
+    case 6:
+    case 7:
+        return (int)&overlay_2;
+    case 5:
+        return (int)&overlay_5;
+    case 1:
+        return (int)&overlay_7;
+    case 2:
+    case 4:
+    case 8:
+        return (int)&overlay_3;
+    case 0x168:
+        break;
+    }
+    return -1;
+}

--- a/src/func_02007e5c.c
+++ b/src/func_02007e5c.c
@@ -1,0 +1,48 @@
+typedef int Fix12i;
+
+struct Data {
+    short x;   /* 0 */
+    short y;   /* 2 */
+    short z;   /* 4 */
+    short rx;  /* 6 */
+    short ry;  /* 8 */
+    short rz;  /* 0xa */
+};
+
+struct Obj {
+    char pad[0x8c];
+    Fix12i px; /* 0x8c */
+    Fix12i py; /* 0x90 */
+    Fix12i pz; /* 0x94 */
+};
+
+extern short ReadUnalignedShort(const void *p);
+extern void Math_Function_0203b0fc(int *dest, int target, int scale, int max);
+
+int func_02007e5c(struct Obj *self, struct Data *data) {
+    int pos[3];
+    int rot[3];
+    int *pp, *rp;
+    Fix12i px, py, pz;
+    int rx, ry, rz;
+    pz = ReadUnalignedShort(&data->z) << 12;
+    py = ReadUnalignedShort(&data->y) << 12;
+    px = ReadUnalignedShort(&data->x) << 12;
+    pos[0] = px;
+    pos[1] = py;
+    pos[2] = pz;
+    rz = ReadUnalignedShort(&data->rz);
+    ry = ReadUnalignedShort(&data->ry);
+    rx = ReadUnalignedShort(&data->rx);
+    rot[0] = rx;
+    rot[1] = ry;
+    rot[2] = rz;
+    pp = pos;
+    rp = rot;
+    Math_Function_0203b0fc(&self->px, pp[0], rp[0], 0x7fffffff);
+    pp++; rp++;
+    Math_Function_0203b0fc(&self->py, pp[0], rp[0], 0x7fffffff);
+    pp++; rp++;
+    Math_Function_0203b0fc(&self->pz, pp[0], rp[0], 0x7fffffff);
+    return 1;
+}

--- a/src/func_02046564.c
+++ b/src/func_02046564.c
@@ -1,0 +1,4 @@
+struct S { int pad0; int a; char p8[0x24-8]; int c; char p28[0x30-0x28]; int b; };
+struct A { char x[0x30]; };
+int func_02046564(struct S *p){ int a=p->a; int b=p->b; int c=p->c;
+ int t=(int)&((struct A*)0)[a+b]; t+=c*0x30; t+=a*0x34; return t; }

--- a/src/func_0205dc0c.c
+++ b/src/func_0205dc0c.c
@@ -1,0 +1,12 @@
+extern int func_0205df40(void *buf, int a, int b);
+extern int func_0205dc60(void *t);
+
+int func_0205dc0c(int a, int b) {
+    char buf[0x24];
+    if (func_0205df40(buf, a, b)) {
+        if (func_0205dc60(buf)) goto ret1;
+    }
+    return 0;
+ret1:
+    return 1;
+}

--- a/src/func_02064a28.c
+++ b/src/func_02064a28.c
@@ -1,0 +1,14 @@
+extern void func_0205a61c(const void *src, int off, int size);
+
+int func_02064a28(int off, short v, char b)
+{
+    unsigned char tag = 0xb;
+    short val = v;
+    int c1, c2;
+    func_0205a61c(&tag, off, 1);
+    c1 = off + 1;
+    func_0205a61c(&val, c1, 2);
+    c2 = c1 + 2;
+    func_0205a61c(&b, c2, 1);
+    return c2 + 1 - off;
+}

--- a/src/func_02064cd8.c
+++ b/src/func_02064cd8.c
@@ -1,0 +1,18 @@
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+
+int func_02064cd8(unsigned char *dst, unsigned short a1, unsigned char a2, unsigned int a3, unsigned int a4)
+{
+    unsigned char hdr = 6;
+    unsigned short s = a1;
+    unsigned char *p1, *p2, *p3, *p4;
+    func_0205a61c(&hdr, dst, 1);
+    p1 = dst + 1;
+    func_0205a61c(&s, p1, 2);
+    p2 = p1 + 2;
+    func_0205a61c(&a2, p2, 1);
+    p3 = p2 + 1;
+    func_0205a61c(&a3, p3, 4);
+    p4 = p3 + 4;
+    func_0205a61c(&a4, p4, 4);
+    return (p4 + 4) - dst;
+}

--- a/src/func_02064e18.c
+++ b/src/func_02064e18.c
@@ -1,0 +1,18 @@
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+
+int func_02064e18(unsigned char *dst, unsigned short a1, unsigned char a2, unsigned int a3, unsigned int a4)
+{
+    unsigned char hdr = 4;
+    unsigned short s = a1;
+    unsigned char *p1, *p2, *p3, *p4;
+    func_0205a61c(&hdr, dst, 1);
+    p1 = dst + 1;
+    func_0205a61c(&s, p1, 2);
+    p2 = p1 + 2;
+    func_0205a61c(&a2, p2, 1);
+    p3 = p2 + 1;
+    func_0205a61c(&a3, p3, 4);
+    p4 = p3 + 4;
+    func_0205a61c(&a4, p4, 4);
+    return (p4 + 4) - dst;
+}

--- a/src/func_02064f54.c
+++ b/src/func_02064f54.c
@@ -1,0 +1,18 @@
+extern void func_0205a61c(const void *src, int off, int size);
+
+int func_02064f54(int off, short b, int c, int d, int e)
+{
+    unsigned char tag = 2;
+    short val = b;
+    int c1, c2, c3, c4;
+    func_0205a61c(&tag, off, 1);
+    c1 = off + 1;
+    func_0205a61c(&val, c1, 2);
+    c2 = c1 + 2;
+    func_0205a61c(&c, c2, 1);
+    c3 = c2 + 1;
+    func_0205a61c(&d, c3, 2);
+    c4 = c3 + 2;
+    func_0205a61c(&e, c4, 2);
+    return c4 + 2 - off;
+}

--- a/src/func_ov002_020c5444.cpp
+++ b/src/func_ov002_020c5444.cpp
@@ -1,0 +1,24 @@
+//cpp
+struct VecFx32 { int x, y, z; };
+extern "C" {
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+}
+extern "C" void func_ov002_020c5444(char* c){
+  VecFx32 v;
+  ((int*)&v)[0] = *(int*)(c + 0x5c);
+  ((int*)&v)[1] = *(int*)(c + 0x60);
+  ((int*)&v)[2] = *(int*)(c + 0x64);
+  ((int*)&v)[1] = *(int*)(c + 0x60) + 0x14000;
+  unsigned char b = *(unsigned char*)(c + 0x70c);
+  if (b == 0) {
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xdb, v.x, v.y, v.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xdc, v.x, v.y, v.z);
+    return;
+  }
+  if (b == 1) {
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd8, v.x, v.y, v.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd9, v.x, v.y, v.z);
+    return;
+  }
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xc7, v.x, v.y, v.z);
+}

--- a/src/func_ov004_020b2574.c
+++ b/src/func_ov004_020b2574.c
@@ -1,0 +1,23 @@
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020afcf8(void *arg0, void *arg1, int arg2, void *arg3);
+extern void func_ov004_020b2444(int a1, int a2, int num, int a4, int a5, int sel, int idx);
+extern void func_ov004_020af948(void *a, int b, int c, void *m);
+extern void **data_ov004_020bbfa8[];
+
+void func_ov004_020b2574(int arg0, int arg1)
+{
+    void **table = data_ov004_020bbfa8[func_ov004_020ad674()];
+    void *sb = table[0];
+    int b = 12;
+    if (arg1 != 1) {
+        func_ov004_020afcf8(sb, (void *)b, b, 0);
+        func_ov004_020afcf8(data_ov004_020bbfa8[func_ov004_020ad674()][1], (void *)30, b, 0);
+        func_ov004_020b2444(0x30, b, arg0, 1, -1, 2, 0);
+    } else {
+        int i;
+        for (i = 0; i < arg0; i++) {
+            func_ov004_020af948(sb, b, 12, 0);
+            b += 16;
+        }
+    }
+}

--- a/src/func_ov006_020d6098.c
+++ b/src/func_ov006_020d6098.c
@@ -1,0 +1,25 @@
+extern void func_ov004_020af68c(void* a0, int a1, int a2, int a3, int a4);
+extern int data_ov006_021344ec[];
+
+typedef struct {
+    int x;              /* 0x00 */
+    int y;              /* 0x04 */
+    char pad[7];
+    unsigned char idx;  /* 0x0f */
+} Rec;
+
+typedef struct {
+    char head[0x6280];
+    Rec recs[2];
+} Obj;
+
+void func_ov006_020d6098(Obj* a0) {
+    int i;
+    for (i = 0; i < 2; i++) {
+        int xv = a0->recs[i].x >> 12;
+        int yv = a0->recs[i].y >> 12;
+        int k = a0->recs[i].idx;
+        if (i != 0) k += 5;
+        func_ov004_020af68c((void*)data_ov006_021344ec[k], xv, yv, -1, -1);
+    }
+}

--- a/src/func_ov006_020dd594.c
+++ b/src/func_ov006_020dd594.c
@@ -1,0 +1,42 @@
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern unsigned short data_ov006_0212e314[];
+extern void* data_ov006_0213bf0c[];
+
+typedef struct {
+    int f0;
+    int f4;
+    char pad8[0xd];
+    unsigned char b15;
+    unsigned char b16;
+    char pad17;
+    unsigned char b18;
+    char pad19[3];
+} E;
+
+typedef struct {
+    char pad0[0x4660];
+    E e[40];
+    char pad1[0x708];
+    int f51c8;
+    int f51cc;
+} Self;
+
+void func_ov006_020dd594(Self* self) {
+    int i;
+    if (self->f51c8 == 5 && self->f51cc == 0) return;
+    for (i = 0; i < 0x28; i++) {
+        if (self->e[i].b16 == 0) continue;
+        {
+            unsigned int flag = self->e[i].b15;
+            int v0 = self->e[i].f0;
+            int v4 = self->e[i].f4;
+            int a1, a2, a4;
+            unsigned short idx;
+            a1 = v0 >> 12;
+            a2 = v4 >> 12;
+            a4 = (flag >= 3) ? 1 : 0;
+            idx = data_ov006_0212e314[self->e[i].b18];
+            func_ov004_020b0104(data_ov006_0213bf0c[idx], a1, a2, -1, a4, 0);
+        }
+    }
+}

--- a/src/func_ov006_020e1554.c
+++ b/src/func_ov006_020e1554.c
@@ -1,0 +1,33 @@
+extern void func_ov004_020b2444(int a1, int a2, int num, int a4, int a5, int sel, int idx);
+extern int func_ov004_020adbc0(void);
+extern void func_ov004_020b2220(int a1, int a2, int a3, int a4, int a5, int a6, int a7);
+
+typedef struct {
+    int a;
+    int b;
+    unsigned short c;
+    unsigned char p0[3];
+    unsigned char flag;
+    unsigned char p1[2];
+} Elem;
+
+typedef struct {
+    unsigned char _pad[0x473c];
+    Elem arr[5];
+    unsigned char _pad2[0x4ee8 - 0x473c - 5*16];
+    unsigned char go;
+} Obj;
+
+void func_ov006_020e1554(Obj *o)
+{
+    int i;
+    for (i = 0; i < 5; i++) {
+        if (o->arr[i].flag != 0) {
+            func_ov004_020b2444(o->arr[i].a >> 12, o->arr[i].b >> 12, o->arr[i].c, -1, -1, 0, 0);
+        }
+    }
+    if (o->go != 0) {
+        int r = func_ov004_020adbc0();
+        func_ov004_020b2220(0x80, 0x60, r, 1, 0, 0x800, 0);
+    }
+}

--- a/src/func_ov006_020e507c.c
+++ b/src/func_ov006_020e507c.c
@@ -1,0 +1,22 @@
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern int data_ov006_0213c44c;
+extern int data_ov006_0213c3fc;
+extern int data_ov006_0213c454;
+
+void func_ov006_020e507c(char* a0) {
+    int x, y;
+    int i;
+    for (i = 0; i < 0xb; i++) {
+        void* d;
+        if (*(unsigned char*)(a0 + 0x4689) == 0) goto next;
+        if (*(unsigned char*)(a0 + 0x468a) == 0) goto next;
+        x = *(int*)(a0 + 0x4660) >> 12;
+        y = *(int*)(a0 + 0x4664) >> 12;
+        if (*(unsigned char*)(a0 + 0x468d) != 0) d = &data_ov006_0213c44c;
+        else d = &data_ov006_0213c3fc;
+        func_ov004_020b0104(d, x, y, -1, 1, 0);
+        func_ov004_020b0104(&data_ov006_0213c454, x, y + 8, -1, 2, 0);
+    next:
+        a0 += 0x30;
+    }
+}

--- a/src/func_ov006_020e8354.c
+++ b/src/func_ov006_020e8354.c
@@ -1,0 +1,26 @@
+extern void func_ov004_020af948(void* a, int b, int c, void* m);
+extern void* data_ov006_02133a3c[];
+
+typedef struct {
+    int x;                  /* 0x00 */
+    int y;                  /* 0x04 */
+    char _0[0x13];          /* 0x08..0x1a */
+    unsigned char type;     /* 0x1b */
+    unsigned char enable;   /* 0x1c */
+    char _1[3];             /* -> size 0x20 */
+} Slot;
+
+typedef struct {
+    char _0[0x52bc];
+    Slot slots[20];
+} Outer;
+
+void func_ov006_020e8354(Outer* a) {
+    int i;
+    for (i = 0; i < 20; i++) {
+        if (a->slots[i].enable) {
+            func_ov004_020af948(data_ov006_02133a3c[a->slots[i].type],
+                                a->slots[i].x >> 12, a->slots[i].y >> 12, 0);
+        }
+    }
+}

--- a/src/func_ov006_02105ab4.c
+++ b/src/func_ov006_02105ab4.c
@@ -1,0 +1,76 @@
+extern void func_ov004_020af868(void *a0, int a1, int a2, int a3, int a4, void *a5);
+extern void func_ov004_020afcf8(void *a0, int a1, int a2, int a3);
+extern void *data_ov006_021427d4[];
+extern unsigned char data_ov006_0213dd34[];
+
+typedef struct Obj
+{
+    char _p0[0x4ca8];
+    int mode;                                  /* 0x4ca8 */
+    char _p1[0x4cb8 - 0x4ca8 - 4];
+    int count;                                 /* 0x4cb8 */
+    char _p2[0x4cc4 - 0x4cb8 - 4];
+    int xarr[(0x4d54 - 0x4cc4) / 4];           /* 0x4cc4 */
+    int yarr[(0x4de8 - 0x4d54) / 4];           /* 0x4d54 */
+    unsigned short harr[(0x4efa - 0x4de8) / 2];/* 0x4de8 */
+    unsigned char tarr[0x4f1e - 0x4efa];       /* 0x4efa */
+    unsigned char karr[0x4f42 - 0x4f1e];       /* 0x4f1e */
+    unsigned char parr[0x4f66 - 0x4f42];       /* 0x4f42 */
+    unsigned char flagarr[0x4fe8 - 0x4f66];    /* 0x4f66 */
+    unsigned char q;                           /* 0x4fe8 */
+} Obj;
+
+void func_ov006_02105ab4(Obj *o)
+{
+    int x;
+    int y;
+    int v;
+    int t;
+    int k;
+    int idx;
+    int a4base = 0;
+    int negone = -1;
+    int z2 = 0;
+    int z3 = 0;
+    void *nullp = 0;
+    int i;
+
+    for (i = 0; i < o->count; i++)
+    {
+        if (o->flagarr[i] != 0)
+        {
+            v = a4base;
+
+            if (o->mode == 6)
+            {
+                v = 1;
+            }
+
+            t = o->tarr[i];
+            k = o->karr[i];
+            x = o->xarr[i] >> 12;
+            y = o->yarr[i] >> 12;
+
+            idx = k * 3;
+            if (t == 1)
+            {
+                int h = o->harr[i];
+                idx = data_ov006_0213dd34[k * 5 + h];
+            }
+
+            func_ov004_020af868(data_ov006_021427d4[idx], x, y, negone, v, nullp);
+
+            if (o->mode == 1)
+            {
+                int p = o->parr[i];
+                int q = o->q;
+                func_ov004_020afcf8(data_ov006_021427d4[p * 3 + q], x, y, z2);
+            }
+            else
+            {
+                int p = o->parr[i];
+                func_ov004_020afcf8(data_ov006_021427d4[p * 3], x, y, z3);
+            }
+        }
+    }
+}

--- a/src/func_ov006_02112504.c
+++ b/src/func_ov006_02112504.c
@@ -1,0 +1,36 @@
+extern unsigned short func_ov006_0211507c(unsigned char* base, int* pos);
+
+int func_ov006_02112504(unsigned char** obj, int* p)
+{
+    int local[2];
+    unsigned short v;
+    int x, z, diff;
+
+    local[0] = p[0];
+    local[1] = p[1];
+    v = func_ov006_0211507c(obj[1], local);
+
+    if (v == 0x24d) {
+        z = (p[1] >> 12) & 7;
+        x = (p[0] >> 12) & 7;
+        diff = x - z;
+        if (x + z >= 8 && diff >= 0) return 1;
+    } else if (v == 0x24e) {
+        z = (p[1] >> 12) & 7;
+        x = (p[0] >> 12) & 7;
+        diff = x - z;
+        if (x + z < 8 && diff < 0) return 1;
+    } else if (v == 0x24f) {
+        z = (p[1] >> 12) & 7;
+        x = (p[0] >> 12) & 7;
+        diff = x - z;
+        if (x + z >= 4 && x + z < 12 && diff >= -4 && diff < 4) return 1;
+    } else if (v == 0x28f) {
+        x = (p[0] >> 12) & 7;
+        if (x >= 1 && x < 7) return 1;
+    } else if (v == 0x2af) {
+        x = (p[0] >> 12) & 7;
+        if (x >= 1 && x < 7) return 1;
+    }
+    return 0;
+}

--- a/src/func_ov006_0211e118.c
+++ b/src/func_ov006_0211e118.c
@@ -1,0 +1,26 @@
+extern void func_ov004_020af68c(void* a0, int a1, int a2, int a3, int a4);
+extern void* data_ov006_02134210[];
+
+struct Elem {
+    int x;
+    int y;
+    int unk8;
+    unsigned char idx;
+    unsigned char unkd;
+    unsigned char flag;
+    unsigned char unkf;
+};
+
+struct Foo {
+    char pad[0x4960];
+    struct Elem arr[16];
+};
+
+void func_ov006_0211e118(struct Foo* a0) {
+    int i;
+    for (i = 0; i < 16; i++) {
+        if (a0->arr[i].flag) {
+            func_ov004_020af68c(data_ov006_02134210[a0->arr[i].idx], a0->arr[i].x >> 12, a0->arr[i].y >> 12, -1, -1);
+        }
+    }
+}

--- a/src/func_ov006_021212fc.c
+++ b/src/func_ov006_021212fc.c
@@ -1,0 +1,70 @@
+extern void func_ov006_0212093c(short* obj, int arg1);
+extern void func_ov006_02120c08(void);
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020afcf8(void* a0, void* a1, int a2, void* a3);
+extern int func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b1a5c(int a0, int a1);
+extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
+extern void func_ov006_020cd270(void);
+extern void func_ov006_020d09e0(void);
+
+extern int data_ov006_0213b0ec;
+extern int* data_ov006_0213fb04[];
+extern int data_ov006_02134ecc;
+extern int data_ov006_02140588;
+extern int data_ov006_0212f0c8[];
+extern void* data_ov006_02134f08;
+extern void* data_ov006_02134f00[];
+
+int func_ov006_021212fc(int self)
+{
+    int count;
+    int a1v;
+    int i;
+    int aa;
+    int r6, r5;
+    int t;
+
+    func_ov006_0212093c((short*)(self + 0x5d84), *(int*)(self + 0x5d94));
+    func_ov006_02120c08();
+
+    if (*(unsigned short*)(self + 0x4664) == 1) {
+        count = data_ov006_0213b0ec;
+        a1v = 0x6e;
+        for (i = 0; i < 3; i++) {
+            if (i >= count) {
+                int idx = func_ov004_020ad674();
+                func_ov004_020afcf8((void*)data_ov006_0213fb04[idx][1], (void*)a1v, 0xc, (void*)0);
+            } else {
+                func_ov004_020afa20(data_ov006_02134ecc, a1v, 0xc, -1, -1);
+            }
+            a1v += 0x12;
+        }
+    }
+
+    func_ov004_020b1a5c(data_ov006_02140588, 4);
+
+    aa = *(short*)(self + 0x5dba);
+    r6 = 1;
+    r5 = 1;
+    if (aa == 0) {
+        if (*(short*)(self + 0x5dc0) != 0) r6 = 0;
+    }
+    if (aa != 0) {
+        if (*(short*)(self + 0x5dc0) != 0) r5 = 0;
+    }
+
+    t = data_ov006_0212f0c8[0] - (*(int*)(self + 0x5d94) + *(int*)(self + 0x5da0));
+    func_ov004_020afdd0(data_ov006_02134f08, *(int*)(self + 0x5da4) + 0xf0, t, -1, 2);
+    func_ov004_020afdd0(data_ov006_02134f00[r6], 0xf0, t - 0x20, -1, 2);
+
+    t = data_ov006_0212f0c8[1] - (*(int*)(self + 0x5d94) + *(int*)(self + 0x5da0));
+    func_ov004_020afdd0(data_ov006_02134f08, *(int*)(self + 0x5da8) + 0xf0, t, -1, 2);
+    func_ov004_020afdd0(data_ov006_02134f00[r5], 0xf0, t - 0x20, -1, 2);
+
+    if (*(short*)(self + 0x5dc2) == 0) {
+        func_ov006_020cd270();
+        func_ov006_020d09e0();
+    }
+    return 1;
+}

--- a/src/func_ov006_021253bc.c
+++ b/src/func_ov006_021253bc.c
@@ -1,0 +1,47 @@
+extern void func_ov006_020c0aa8(void *a0);
+extern void func_ov004_020af68c(void *a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b6430(void);
+extern void func_ov004_020b1bc8(void *a0, int a1, int a2, int a3);
+extern void func_ov004_020b1e34(void *a0, int a1, int a2, int a3);
+extern void func_ov006_020c1804(void *a0);
+
+extern void *data_ov006_0213fe8c[];
+
+typedef struct { int x, y; } Pair;
+typedef struct Obj {
+    char _a[0x4660];
+    char f4660;
+    char _b[0x4f38 - 0x4661];
+    char f4f38;
+    char _c[0x51a8 - 0x4f39];
+    Pair pos[2];
+    int count;
+    char _d[0x51ca - 0x51bc];
+    unsigned char b0[2];
+    unsigned char b1[2];
+} Obj;
+
+int func_ov006_021253bc(Obj *self) {
+    int i;
+
+    func_ov006_020c0aa8(&self->f4660);
+    if (self->count >= 1) {
+        for (i = 0; i < 2; i++) {
+            if (self->b1[i] < 3) {
+                func_ov004_020af68c(data_ov006_0213fe8c[self->b1[i]],
+                                    self->pos[i].x >> 12,
+                                    self->pos[i].y >> 12, -1, -1);
+            } else {
+                func_ov004_020af68c(
+                    data_ov006_0213fe8c[self->b1[i] + self->b0[i] * 2],
+                    self->pos[i].x >> 12,
+                    self->pos[i].y >> 12, -1, -1);
+            }
+        }
+    }
+    func_ov004_020b6430();
+    func_ov004_020b1bc8(self, 0xc, 0xc, 0);
+    func_ov004_020b1e34(self, 0xe0, 0x14, 1);
+    func_ov006_020c1804(&self->f4f38);
+    return 1;
+}

--- a/src/func_ov007_020bfe4c.c
+++ b/src/func_ov007_020bfe4c.c
@@ -1,0 +1,28 @@
+typedef struct { int x, y, z; } Vector3;
+typedef struct { int m[12]; } Matrix4x3;
+
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern int _ZN4cstd3divEii(int a, int b);
+extern void InvMat4x3(void* dst, void* out);
+extern void MulVec3Mat4x3(void* v, void* m, void* res);
+extern short data_02082214[];
+
+void func_ov007_020bfe4c(char* thiz, int a, int b, int c, Vector3* out)
+{
+    Vector3 v;
+    Matrix4x3 inv;
+    int ang, i, cosv, sinv, ac, f1;
+    v.x = a - 0x80000;
+    v.y = -(b - 0x60000);
+    v.z = c;
+    ang = (int)*(unsigned short*)(thiz + 0xd4) >> 4;
+    i = ang * 2;
+    sinv = data_02082214[i + 1];
+    cosv = data_02082214[i];
+    ac = c < 0 ? -c : c;
+    f1 = _ZN4cstd4fdivEii((int)(((long long)cosv * ac + 0x800) >> 12), sinv);
+    v.x = _ZN4cstd3divEii((int)(((long long)v.x * f1 + 0x800) >> 12), 0x60);
+    v.y = _ZN4cstd3divEii((int)(((long long)v.y * f1 + 0x800) >> 12), 0x60);
+    InvMat4x3(thiz + 0x44, &inv);
+    MulVec3Mat4x3(&v, &inv, out);
+}

--- a/src/func_ov063_0211af70.cpp
+++ b/src/func_ov063_0211af70.cpp
@@ -1,0 +1,52 @@
+//cpp
+struct Vector3;
+struct Model {
+    virtual void f0(); virtual void f1(); virtual void f2();
+    virtual void f3(); virtual void f4();
+    virtual void Render(const Vector3 *);
+};
+struct Flags { unsigned short b0:1, b1:1, b2:1, b3:1; };
+
+extern "C" {
+void _ZN8CapEnemy14RenderCapModelEPK7Vector3(void *thiz, const void *v);
+void _ZN5Model12HideMaterialEii(void *thiz, int a, int b);
+void _ZN5Model6RenderEPK7Vector3(void *thiz, const void *v);
+
+int func_ov063_0211af70(char *c)
+{
+    int b = (int)((*(int *)(c + 0xb0) & 0x40000) != 0);
+    if (b != 0)
+        return 1;
+
+    {
+        Flags *f = (Flags *)(c + 0x5d4);
+        if (!f->b3)
+            return 1;
+        if (f->b1) {
+            ((Model *)(c + 0x3e4))->Render((const Vector3 *)(c + 0x510));
+        }
+        _ZN8CapEnemy14RenderCapModelEPK7Vector3(c, 0);
+    }
+
+    if (*(unsigned char *)(c + 0x5c8) < 8)
+        return 1;
+
+    {
+        unsigned char st = *(unsigned char *)(c + 0x5cf);
+        if (st >= 0xc && st != 0xf)
+            _ZN5Model12HideMaterialEii(c + 0x380, 0, 2);
+    }
+
+    if (*(int *)(c + 0x10c) != 8 &&
+        (*(unsigned char *)(c + 0x5cc) == 3 ||
+         *(unsigned char *)(c + 0x5cc) == 3 ||
+         *(unsigned char *)(c + 0x5cc) == 3 ||
+         *(unsigned char *)(c + 0x5cc) == 3)) {
+        _ZN5Model6RenderEPK7Vector3(c + 0x380, c + 0x80);
+    } else {
+        ((Model *)(c + 0x380))->Render((const Vector3 *)(c + 0x80));
+    }
+
+    return 1;
+}
+}

--- a/src/func_ov079_02123a8c.cpp
+++ b/src/func_ov079_02123a8c.cpp
@@ -1,0 +1,41 @@
+//cpp
+struct Vec3 { int x, y, z; };
+
+struct Actor {
+    virtual void vf00();  virtual void vf01();  virtual void vf02();  virtual void vf03();
+    virtual void vf04();  virtual void vf05();  virtual void vf06();  virtual void vf07();
+    virtual void vf08();  virtual void vf09();  virtual void vf10();  virtual void vf11();
+    virtual void vf12();  virtual void vf13();  virtual void vf14();  virtual void vf15();
+    virtual void vf16();  virtual void vf17();  virtual void vf18();  virtual void vf19();
+    virtual void vf20();  virtual void vf21();  virtual void vf22();  virtual void vf23();
+    virtual void vf24();  virtual void vf25();  virtual void vf26();  virtual void vf27();
+    virtual void vf28();  virtual int  vf29();
+    Actor *ClosestWithActorID(unsigned int id);
+};
+
+extern "C" int Vec3_Dist(void* a, void* b);
+extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void* m);
+extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* actor);
+
+extern "C" int func_ov079_02123a8c(Actor *self)
+{
+    Vec3 v;
+
+    if (*(unsigned char*)((char*)self + 0x404) == 0)
+        return 0;
+
+    Actor *closest = self->ClosestWithActorID(9);
+    if (closest) {
+        v.x = *(int*)((char*)self + 0x5c);
+        v.y = *(int*)((char*)self + 0x60);
+        v.z = *(int*)((char*)self + 0x64);
+        v.y = v.y + self->vf29();
+        int dist = Vec3_Dist(&v, (char*)closest + 0x5c);
+        if (dist < (*(int*)((char*)self + 0xb8) << 3)) {
+            if (!_ZN16MeshColliderBase9IsEnabledEv((char*)self + 0x418))
+                _ZN16MeshColliderBase6EnableEP5Actor((char*)self + 0x418, self);
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov091_02132dc0.cpp
+++ b/src/func_ov091_02132dc0.cpp
@@ -1,0 +1,36 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor {
+    virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
+    virtual void f04(); virtual void f05(); virtual void f06(); virtual void f07();
+    virtual void f08(); virtual void f09(); virtual void f10(); virtual void f11();
+    virtual void f12(); virtual void f13(); virtual void f14(); virtual void f15();
+    virtual void f16(); virtual void f17(); virtual void f18(); virtual void f19();
+    virtual void f20(); virtual void f21(); virtual void f22(); virtual void f23();
+    virtual void f24(); virtual void f25(); virtual void f26(); virtual void f27();
+    virtual void f28(); virtual int f29();
+};
+extern "C" {
+extern void* _ZN5Actor18ClosestWithActorIDEj(void*, unsigned int);
+extern int Vec3_Dist(void*, void*);
+extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
+extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
+
+int func_ov091_02132dc0(char* c) {
+    void* p = _ZN5Actor18ClosestWithActorIDEj(c, 9);
+    if (p != 0) {
+        volatile struct Vector3 v;
+        v.x = *(int*)(c + 0x5c);
+        v.y = *(int*)(c + 0x60);
+        v.z = *(int*)(c + 0x64);
+        v.y = v.y + ((Actor*)c)->f29();
+        if (Vec3_Dist((char*)c + 0x5c, (char*)p + 0x5c) < (*(int*)(c + 0xb8) << 3)) {
+            if (!_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
+                _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+}


### PR DESCRIPTION
Matches **24 functions** across arm9-main and 7 overlays — no-store getters/serializers plus single-loop entity updaters — from a parallel fan-out, independently re-verified against the current `main` (64.5%).

## Per-module

| module | funcs |
|---|---|
| arm9-main | 8 |
| ov006 | 10 |
| ov002 / ov004 / ov007 / ov063 / ov079 / ov091 | 1 each |

## Verification

- **Byte-match:** all 24 recompile byte-identical (relocation-aware) to the ROM under `mwccarm 1.2/sp2p3` with the canonical flags.
- **Reloc destinations:** link-checked — **23 VERIFIED + 1 BLIND, 0 WRONG, 0 NO-REPRO**.

## Notes

- The arm9-main `func_02064*` family are save-record serializers (write tag/short/byte/word fields via a shared helper, returning bytes written); `GetSceneOverlayID` is a jump table over pooled overlay-id returns.
- The ov006 set are single-loop entity-update passes (`x>>12`/`y>>12` fixed-point + table-dispatch into ov004 render helpers).
- Fresh off `main` (`3611dd0`); **src-only** — no tooling/config/symbol/notes changes. Separate from #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
