### PR TITLE
Match 4 functions across arm9-main and overlays

### DIFF
--- a/src/func_0205ffd0.c
+++ b/src/func_0205ffd0.c
@@ -1,0 +1,17 @@
+extern unsigned int _ZN3IRQ7DisableEv(void);
+extern void _ZN3IRQ7RestoreEj(unsigned int savedState);
+extern void func_020580f0(void *);
+extern char data_020a8180[];
+
+int func_0205ffd0(void)
+{
+    int *g = (int *)data_020a8180;
+    unsigned int saved = _ZN3IRQ7DisableEv();
+    if (g[13] & 4) {
+        do {
+            func_020580f0((char *)g + 0xd4);
+        } while (g[13] & 4);
+    }
+    _ZN3IRQ7RestoreEj(saved);
+    return *(int *)g[0] == 0;
+}

--- a/src/func_ov024_021112c0.c
+++ b/src/func_ov024_021112c0.c
@@ -1,0 +1,21 @@
+struct V3 { int x, y, z; };
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+extern void _ZN9ActorBase18MarkForDestructionEv(void *);
+extern void _ZN5Event6SetBitEj(unsigned int);
+extern void _ZN7Minimap19UpdateLevelSpecificEv(void);
+
+void func_ov024_021112c0(char *c)
+{
+    struct V3 v;
+    v.x = *(int *)(c + 0x5c);
+    v.y = *(int *)(c + 0x60);
+    v.z = *(int *)(c + 0x64);
+    v.y += 0xfa000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x1f, v.x, v.y, v.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x20, *(volatile int *)&v.x, *(volatile int *)&v.y, *(volatile int *)&v.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x21, *(volatile int *)&v.x, *(volatile int *)&v.y, *(volatile int *)&v.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x22, *(volatile int *)&v.x, *(volatile int *)&v.y, *(volatile int *)&v.z);
+    _ZN9ActorBase18MarkForDestructionEv(c);
+    _ZN5Event6SetBitEj(0xe);
+    _ZN7Minimap19UpdateLevelSpecificEv();
+}

--- a/src/func_ov025_0211123c.cpp
+++ b/src/func_ov025_0211123c.cpp
@@ -1,0 +1,36 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor {
+    virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
+    virtual void f04(); virtual void f05(); virtual void f06(); virtual void f07();
+    virtual void f08(); virtual void f09(); virtual void f10(); virtual void f11();
+    virtual void f12(); virtual void f13(); virtual void f14(); virtual void f15();
+    virtual void f16(); virtual void f17(); virtual void f18(); virtual void f19();
+    virtual void f20(); virtual void f21(); virtual void f22(); virtual void f23();
+    virtual void f24(); virtual void f25(); virtual void f26(); virtual void f27();
+    virtual void f28(); virtual int f29();
+};
+extern "C" {
+extern void* _ZN5Actor18ClosestWithActorIDEj(void*, unsigned int);
+extern int Vec3_Dist(void*, void*);
+extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
+extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
+
+int func_ov025_0211123c(char* c) {
+    void* p = _ZN5Actor18ClosestWithActorIDEj(c, 9);
+    if (p != 0) {
+        volatile struct Vector3 v;
+        v.x = *(int*)(c + 0x5c);
+        v.y = *(int*)(c + 0x60);
+        v.z = *(int*)(c + 0x64);
+        v.y = v.y + ((Actor*)c)->f29();
+        if (Vec3_Dist((char*)c + 0x5c, (char*)p + 0x5c) < (*(int*)(c + 0xb8) << 3)) {
+            if (!_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
+                _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+}

--- a/src/func_ov084_0212c9f0.c
+++ b/src/func_ov084_0212c9f0.c
@@ -1,0 +1,17 @@
+typedef short s16;
+struct Vector3 { int x, y, z; };
+extern void func_02012694(int a, void* p, int c);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* ab, unsigned int id, const struct Vector3* v, unsigned int a, unsigned int b);
+
+void func_ov084_0212c9f0(char* c, int arg1, unsigned int arg2) {
+  void* player = *(void**)(c + 0x194);
+  struct Vector3 v;
+  int x = *(int*)(c + 0x5c);
+  int z = *(int*)(c + 0x64);
+  int y = *(int*)(c + 0x60) + 0x32000;
+  v.x = x;
+  v.y = y;
+  v.z = z;
+  func_02012694(0x108, c + 0x74, arg2);
+  _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(player, c, (s16)arg1, &v, arg2, 0);
+}


### PR DESCRIPTION
Hand-matched 4 functions, all byte-identical with mwccarm 1.2/sp2p3 and reloc-verified via `tools/linkcheck.py` (verdict VERIFIED — 0 blind / 0 wrong relocations).

| Module | Function | Notes |
|---|---|---|
| arm9-main | `func_0205ffd0` | `IRQ::Disable` / spin-while-flag / `IRQ::Restore` wrapper, returns `(*base[0] == 0)` |
| ov024 | `func_ov024_021112c0` | particle spawn + `MarkForDestruction` |
| ov025 | `func_ov025_0211123c` | `ClosestWithActorID` range check + `MeshCollider` enable (parallel-array twin of `func_ov091_02132dc0`) |
| ov084 | `func_ov084_0212c9f0` | `Player::ShowMessage` with a built `Vector3` |

Verification: each `src/` file compiled with mwccarm 1.2/sp2p3 and reloc-aware byte-compared to the ROM target (MATCH), then link-verified (linked bytes equal the ROM, every relocation resolves to the correct symbol). Net diff is 4 added `src/` files, nothing else.