### PR TITLE
Match 13 functions across arm9-main and overlays (constructor/init vein)

### DIFF
--- a/src/_ZN5Scene20Initialise3dGraphicsEv.c
+++ b/src/_ZN5Scene20Initialise3dGraphicsEv.c
@@ -1,0 +1,16 @@
+extern void _ZN5Scene22ResetHardwareRegistersEv(void);
+extern void func_0205583c(void);
+extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
+extern void Initialise3dGraphics(int arg);
+
+void _ZN5Scene20Initialise3dGraphicsEv(void)
+{
+    _ZN5Scene22ResetHardwareRegistersEv();
+    func_0205583c();
+    _ZN2GX15SetGraphicsModeEiii(1, 0, 1);
+    *(volatile unsigned int*)0x40004c8 = 0x296a5800;
+    *(volatile unsigned int*)0x40004cc = 0x7fff;
+    *(volatile unsigned int*)0x40004c0 = 0x7fff;
+    *(volatile unsigned int*)0x40004c4 = 0;
+    Initialise3dGraphics(0);
+}

--- a/src/__sinit_ov009_02112458.c
+++ b/src/__sinit_ov009_02112458.c
@@ -1,0 +1,28 @@
+extern void func_02017acc(void*, int);
+extern void func_020731dc(void*, void*, void*);
+extern void _ZN13SharedFilePtr9ConstructEj(void*, unsigned int);
+extern int func_02017ab4[];
+extern int func_02017984[];
+extern int data_ov009_02113c20[];
+extern int data_ov009_02113c28[];
+extern int data_ov009_02113c30[];
+extern int data_ov009_02113c3c[];
+struct S8 { int a, b; };
+extern struct S8 data_ov009_02113c48;
+extern struct S8 data_ov009_02113914;
+extern struct S8 data_ov009_0211390c;
+extern struct S8 data_ov009_021138fc;
+extern struct S8 data_ov009_02113904;
+
+void __sinit_ov009_02112458(void)
+{
+    struct S8 *d = &data_ov009_02113c48;
+    func_02017acc(data_ov009_02113c20, 0x438);
+    func_020731dc(data_ov009_02113c20, func_02017ab4, data_ov009_02113c30);
+    _ZN13SharedFilePtr9ConstructEj(data_ov009_02113c28, 0x439);
+    func_020731dc(data_ov009_02113c28, func_02017984, data_ov009_02113c3c);
+    d[0] = data_ov009_02113914;
+    d[1] = data_ov009_0211390c;
+    d[2] = data_ov009_021138fc;
+    d[3] = data_ov009_02113904;
+}

--- a/src/func_0205532c.c
+++ b/src/func_0205532c.c
@@ -1,0 +1,10 @@
+extern void Copy36Bytes(int *src, int *dst);
+
+void func_0205532c(int *a, int *v)
+{
+    *(volatile unsigned int *)0x4000400 = 0x19;
+    Copy36Bytes(a, (int *)0x4000400);
+    *(volatile unsigned int *)0x4000400 = v[0];
+    *(volatile unsigned int *)0x4000400 = v[1];
+    *(volatile unsigned int *)0x4000400 = v[2];
+}

--- a/src/func_02066fec.c
+++ b/src/func_02066fec.c
@@ -1,0 +1,12 @@
+typedef unsigned int u32;
+
+extern int *data_020a9db8;
+int func_02065edc(u32 x);
+int func_02066fb0(int a, int b, int c);
+
+int func_02066fec(u32 a, int b, int c) {
+    if (func_02065edc(a)) {
+        *(int *)((char *)data_020a9db8 + (a - 1) * 4 + 0x14e8) = b;
+    }
+    return func_02066fb0(a, b, c);
+}

--- a/src/func_ov002_020c2270.cpp
+++ b/src/func_ov002_020c2270.cpp
@@ -1,0 +1,30 @@
+//cpp
+extern "C" {
+struct Vector3 { int x, y, z; };
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern int func_02037e58(unsigned int* p);
+extern void _ZN11RaycastLine10GetClsnPosEv(void* res, void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+
+int func_ov002_020c2270(void* c, void* p1, void* p2) {
+    char rl[0x78];
+    Vector3 clsnPos;
+    _ZN11RaycastLineC1Ev(rl);
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, p1, p2, c);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+        if (func_02037e58((unsigned int*)(rl + 0x14)) == 1) {
+            _ZN11RaycastLine10GetClsnPosEv(&clsnPos, rl);
+            *(int*)((char*)c + 0x5c) = clsnPos.x;
+            *(int*)((char*)c + 0x60) = clsnPos.y;
+            *(int*)((char*)c + 0x64) = clsnPos.z;
+            *((unsigned char*)c + 0x70f) = 1;
+            _ZN11RaycastLineD1Ev(rl);
+            return 1;
+        }
+    }
+    _ZN11RaycastLineD1Ev(rl);
+    return 0;
+}
+}

--- a/src/func_ov002_020c9a04.c
+++ b/src/func_ov002_020c9a04.c
@@ -1,0 +1,23 @@
+struct V3 { int x, y, z; };
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, unsigned int a, int b, int f, unsigned int g);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+
+void func_ov002_020c9a04(char *c)
+{
+    struct V3 v;
+
+    *(unsigned char *)(c + 0x6e3) = 0x11;
+    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9a, 0x40000000, 0x1000, 0);
+
+    *(int *)(c + 0x98) = 0;
+    *(int *)(c + 0xa8) = 0;
+
+    v.x = *(int *)(c + 0x5c);
+    v.y = *(int *)(c + 0x60);
+    v.z = *(int *)(c + 0x64);
+    v.y = *(int *)(c + 0x60) + 0x28000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x5f, v.x, v.y, v.z);
+
+    v.y = *(int *)(c + 0x60) + (int)(((long long)*(int *)(c + 0x84) * 0x50000 + 0x800) >> 12);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x60, v.x, v.y, *(volatile int *)&v.z);
+}

--- a/src/func_ov004_020b6f14.c
+++ b/src/func_ov004_020b6f14.c
@@ -1,0 +1,12 @@
+extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, int arg6);
+extern void func_ov004_020ad90c(void);
+struct P2 { int a, b; };
+extern struct P2 data_ov004_020bc9cc;
+extern struct P2 data_ov004_020bca2c;
+void func_ov004_020b6f14(char* c) {
+  func_ov004_020b0cac(7, 0x80, 0x14, -1, -1, 0xd);
+  *(int*)(c+0x1c) = 0x12c;
+  *(struct P2*)(c+8) = data_ov004_020bc9cc;
+  *(struct P2*)(c+0x10) = data_ov004_020bca2c;
+  func_ov004_020ad90c();
+}

--- a/src/func_ov060_02117c30.c
+++ b/src/func_ov060_02117c30.c
@@ -1,0 +1,30 @@
+typedef int Fix12;
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
+extern void func_ov060_02117a64(void*);
+extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
+extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
+extern int func_020393d4(void*, void*);
+extern int _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
+extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+
+extern void* data_ov060_0211affc;
+extern void* data_ov060_0211aff4;
+extern void func_021115bc(void);
+
+int func_ov060_02117c30(char* c) {
+  void* mdl;
+  void* kcl;
+  mdl = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211affc);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x324, mdl, 1, -1);
+  func_ov060_02117a64(c);
+  kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov060_0211aff4);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x374, kcl, c+0x2ec, 0x1000, *(short*)(c+0x8e), &func_021115bc);
+  func_020393d4(c+0x374, &_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  _ZN16MeshColliderBase6EnableEP5Actor(c+0x374, c);
+  *(short*)(c+0x31e) = 0;
+  *(short*)(c+0x320) = 0;
+  *(short*)(c+0x322) = 0;
+  *(int*)(c+0x56c) = 0;
+  return 1;
+}

--- a/src/func_ov062_0211c594.c
+++ b/src/func_ov062_0211c594.c
@@ -1,0 +1,33 @@
+typedef struct { int x, y, z; } Vector3;
+struct Matrix4x3 { int m[12]; };
+
+extern void Matrix4x3_FromRotationY(struct Matrix4x3 *m, short angY);
+extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *m, short angX);
+extern void MulVec3Mat4x3(const Vector3 *v, const struct Matrix4x3 *m, Vector3 *out);
+extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void*, void*, int, int, int, unsigned short);
+
+extern struct Matrix4x3 data_020a0e68;
+extern void* data_ov062_0211e104[];
+
+int func_ov062_0211c594(char *c) {
+    Vector3 in;
+    Vector3 out;
+
+    *(int*)(c + 0xa4) = 0;
+    *(int*)(c + 0xa8) = 0;
+    *(int*)(c + 0xac) = 0;
+
+    if (*(unsigned char*)(c + 0x446) == 1) {
+        in.x = 0; in.y = 0; in.z = 0;
+        out.x = 0; out.y = 0; out.z = 0;
+        in.z = 0x14000;
+        Matrix4x3_FromRotationY(&data_020a0e68, *(short*)(c + 0x8e));
+        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, -0x4000);
+        MulVec3Mat4x3(&in, &data_020a0e68, &out);
+        *(int*)(c + 0xa8) = out.y;
+        *(unsigned short*)(c + 0x100) = 0x3c;
+    }
+
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(c + 0x334, data_ov062_0211e104[1], 4, 0, 0x1000, 0);
+    return 1;
+}

--- a/src/func_ov073_02122034.cpp
+++ b/src/func_ov073_02122034.cpp
@@ -1,0 +1,24 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+extern int func_02012694(int, const Vector3&);
+}
+extern "C" int func_ov073_02122034(char* c);
+int func_ov073_02122034(char* c) {
+    Vector3 pos;
+    int t;
+    *(short*)(c + 0x332) = 0;
+    ((int*)&pos)[0] = *(int*)(c + 0x5c);
+    ((int*)&pos)[1] = *(int*)(c + 0x60);
+    ((int*)&pos)[2] = *(int*)(c + 0x64);
+    ((int*)&pos)[0] = *(int*)(c + 0x5c);
+    t = *(int*)(c + 0x60);
+    ((int*)&pos)[1] = t;
+    ((int*)&pos)[2] = *(int*)(c + 0x64);
+    ((int*)&pos)[1] = t - 0x12c000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x8b, ((int*)&pos)[0], ((int*)&pos)[1], ((int*)&pos)[2]);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x8c, ((int*)&pos)[0], ((int*)&pos)[1], ((int*)&pos)[2]);
+    func_02012694(0x172, *(Vector3*)(c + 0x74));
+    return 1;
+}

--- a/src/func_ov085_0212a788.c
+++ b/src/func_ov085_0212a788.c
@@ -1,0 +1,32 @@
+typedef struct Vector3 { int x, y, z; } Vector3;
+struct RG { char a[0x14]; int detect[16]; };
+extern void _ZN13RaycastGroundC1Ev(struct RG*);
+extern void _ZN4BgCh19StartDetectingWaterEv(struct RG*);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG*, const Vector3*, void*);
+extern int _ZN13RaycastGround10DetectClsnEv(struct RG*);
+extern int func_02037e78(int* p);
+extern void _ZN13RaycastGroundD1Ev(struct RG*);
+
+int func_ov085_0212a788(char* c){
+  struct RG rg;
+  Vector3 v;
+  _ZN13RaycastGroundC1Ev(&rg);
+  _ZN4BgCh19StartDetectingWaterEv(&rg);
+  int x = *(int*)(c+0x5c);
+  int y = *(int*)(c+0x60);
+  int z = *(int*)(c+0x64);
+  int yk = y + 0xc8000;
+  v.x = x;
+  v.y = yk;
+  v.z = z;
+  _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &v, c);
+  if (_ZN13RaycastGround10DetectClsnEv(&rg)) {
+    *(int*)(c+0x464) = rg.detect[12];
+    if (func_02037e78(rg.detect)) {
+      _ZN13RaycastGroundD1Ev(&rg);
+      return 1;
+    }
+  }
+  _ZN13RaycastGroundD1Ev(&rg);
+  return 0;
+}

--- a/src/func_ov098_021397c8.cpp
+++ b/src/func_ov098_021397c8.cpp
@@ -1,0 +1,21 @@
+//cpp
+extern "C" {
+struct M4 { int w[12]; };
+struct MMC { char p[0x124]; };
+struct Obj { char p[0x2ec]; M4 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+void func_ov098_021397c8(char* self){
+    Obj* o = (Obj*)self;
+    volatile int tmp[3];
+    tmp[0] = *(int*)(self+0x5c);
+    int origY = *(int*)(self+0x60);
+    tmp[1] = origY;
+    tmp[2] = *(int*)(self+0x64);
+    tmp[1] = origY - *(int*)(self+0x5f4);
+    o->m = *(M4*)(self + 0xf0);
+    *(int*)(self+0x310) = tmp[0];
+    *(int*)(self+0x314) = tmp[1];
+    *(int*)(self+0x318) = tmp[2];
+    _ZN18MovingMeshCollider9TransformERK9Matrix4x3s((MMC*)(self+0x124), o->m, *(short*)(self+0x8e));
+}
+}

--- a/src/func_ov102_0214bc20.c
+++ b/src/func_ov102_0214bc20.c
@@ -1,0 +1,24 @@
+extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int a, int b, unsigned int u);
+struct G { int w[2]; };
+extern struct G data_ov102_0214e9c0;
+
+typedef struct { int v[4]; } Quad;
+extern Quad data_ov102_0214e514;
+extern Quad data_ov102_0214e524;
+
+void func_ov102_0214bc20(char* c)
+{
+    Quad a1 = data_ov102_0214e514;
+    Quad a2 = data_ov102_0214e524;
+    void *p = *(void**)(c + 0x390);
+    int idx = 0;
+    if (p != 0) {
+        idx = *(int*)((char*)p + 8);
+        if ((unsigned)idx > 4) idx = 4;
+    }
+    *(int*)(c + 0x98) = a1.v[idx];
+    *(int*)(c + 0xa8) = a2.v[idx];
+    *(int*)(c + 0x3dc) = 4;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x300, (void*)data_ov102_0214e9c0.w[1], 0, 0x1000, 0);
+    *(int*)(c + 0x9c) = -0x2000;
+}


### PR DESCRIPTION
Hand-matched 13 functions with mwccarm 1.2/sp2p3, all byte-identical and reloc-verified via `tools/linkcheck.py` (verdict VERIFIED — 0 blind / 0 wrong relocations). Mostly constructor / init shapes: object field initialization, resource loaders, and one compiler-generated static initializer.

| Module | Function | Notes |
|---|---|---|
| arm9-main | `_ZN5Scene20Initialise3dGraphicsEv` | GX setup + hardware-register writes |
| arm9-main | `func_02066fec` | guarded slot store + tail call |
| arm9-main | `func_0205532c` | |
| ov002 | `func_ov002_020c2270` | RaycastLine wrapper |
| ov002 | `func_ov002_020c9a04` | Player::SetAnim + particle |
| ov004 | `func_ov004_020b6f14` | init call + struct-copy inits |
| ov009 | `__sinit_ov009_02112458` | static initializer |
| ov060 | `func_ov060_02117c30` | Model / MeshCollider load chain |
| ov062 | `func_ov062_0211c594` | |
| ov073 | `func_ov073_02122034` | particle spawn from actor position |
| ov085 | `func_ov085_0212a788` | RaycastGround ground-detect |
| ov098 | `func_ov098_021397c8` | MovingMeshCollider transform setup |
| ov102 | `func_ov102_0214bc20` | ModelAnim::SetAnim init |

Verification: each `src/` file compiled with mwccarm 1.2/sp2p3 and reloc-aware byte-compared to the ROM (MATCH), then link-verified (linked bytes equal the ROM, every relocation resolves to the correct symbol). Net diff is 13 added `src/` files, nothing else.