### PR TITLE
Match 3 functions across arm9-main and ov004 (constructor/init vein)

### DIFF
--- a/src/_ZN9FaderWipe11AdvanceFadeEv.c
+++ b/src/_ZN9FaderWipe11AdvanceFadeEv.c
@@ -1,0 +1,46 @@
+typedef unsigned short u16;
+typedef int Fix12i;
+
+void _ZN5Fader13AdvanceInterpEv(void* thiz);
+void _ZN3G2x18SetBlendBrightnessEPVtts(volatile u16* p, u16 a, int b);
+void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToScale(void* m, Fix12i x, Fix12i y, Fix12i z);
+void Matrix4x3_ApplyInPlaceToRotationX(void* m, short ang);
+void _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(void* thiz, void* mtx, void* vec);
+extern int data_020a0e68[];
+
+void _ZN9FaderWipe11AdvanceFadeEv(char* thiz)
+{
+    Fix12i old = *(Fix12i*)(thiz + 4);
+    Fix12i cur;
+    _ZN5Fader13AdvanceInterpEv(thiz);
+    cur = *(Fix12i*)(thiz + 4);
+    if (cur == 0 && cur == old) return;
+    if (cur == 0x1000) {
+        _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4000050, 0x3f, -0x10);
+    } else {
+        if (*(Fix12i*)(thiz + 8) != 0) {
+            if (old != 0x1000) *(u16*)0x4000050 = 0;
+        }
+        if (*(Fix12i*)(thiz + 4) != 0) {
+            Fix12i scale = (Fix12i)(((long long)(0x1000 - *(Fix12i*)(thiz + 4)) * 0x20000 + 0x800) >> 12);
+            Matrix4x3_FromTranslation(data_020a0e68, 0, 0, -0x1000);
+            Matrix4x3_ApplyInPlaceToScale(data_020a0e68, scale, scale, scale);
+            Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, 0x4000);
+            _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(thiz + 0x18, data_020a0e68, 0);
+        }
+    }
+    if (*(Fix12i*)(thiz + 4) == old) return;
+    {
+        u16 color = *(u16*)(thiz + 0xc);
+        int m = color ? 0x10 : -0x10;
+        int prod = *(Fix12i*)(thiz + 4) * m;
+        int r = prod >> 12;
+        if (r != 0) {
+            _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4001050, 0x3f, r);
+        } else {
+            *(u16*)0x4000050 = 0;
+            *(u16*)0x4001050 = 0;
+        }
+    }
+}

--- a/src/func_020072c4.c
+++ b/src/func_020072c4.c
@@ -1,0 +1,13 @@
+extern void _Z14ApproachLinearRiii(int *p, int value, int speed);
+
+int func_020072c4(char *self)
+{
+    _Z14ApproachLinearRiii((int *)(self + 0x174), 0xf000, 0x199);
+    _Z14ApproachLinearRiii((int *)(self + 0xb0), 0x7d0000, *(int *)(self + 0x174));
+    _Z14ApproachLinearRiii((int *)(self + 0xb4), 0x4b0000, *(int *)(self + 0x174) / 10);
+    _Z14ApproachLinearRiii((int *)(self + 0xb8), 0x3e8000, *(int *)(self + 0x174) / 10);
+    _Z14ApproachLinearRiii((int *)(self + 0xbc), 0, *(int *)(self + 0x174));
+    _Z14ApproachLinearRiii((int *)(self + 0xc0), 0x4b0000, *(int *)(self + 0x174) >> 1);
+    _Z14ApproachLinearRiii((int *)(self + 0xc4), 0x3e8000, *(int *)(self + 0x174) * 10 / 15);
+    return 1;
+}

--- a/src/func_ov004_020aea78.cpp
+++ b/src/func_ov004_020aea78.cpp
@@ -1,0 +1,46 @@
+//cpp
+struct C {
+    virtual int f0();
+    virtual int f1();
+    virtual int f2();
+    virtual int f3();
+    virtual int f4();
+    virtual int f5();
+    virtual int f6();
+    virtual int f7();
+    virtual int f8();
+    virtual int f9();
+    virtual int f10();
+    virtual int f11();
+    virtual int f12();
+    virtual int f13();
+    virtual int f14();
+    virtual int f15();
+    virtual int f16();
+    virtual int f17();
+    virtual int f18();
+    virtual int f19();
+    virtual int f20();
+    virtual int f21();
+    virtual int f22();
+    virtual int f23();
+    virtual int f24();
+    virtual int f25();
+    virtual int f26();
+};
+extern "C" {
+extern C* data_ov004_020beb68;
+extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, int a5);
+}
+
+struct BF { unsigned int lo:10; unsigned int hi:22; };
+struct S { int x; BF y; };
+
+extern "C" void func_ov004_020aea78(S* self, int a1, int a2, int a3)
+{
+    S v = *self;
+    if (data_ov004_020beb68->f26() == 2) {
+        v.y.lo = (self->y.lo - 0x200) & 0x3ff;
+    }
+    func_ov004_020b1c68(&v, a1, a2, 0, -1, a3);
+}


### PR DESCRIPTION
Three more byte-matched functions from the T4 constructor/init vein, all off current `main`.

| Function | Module | Shape |
|---|---|---|
| `func_020072c4` | arm9-main | `ApproachLinear` driver — 7 field interpolations |
| `_ZN9FaderWipe11AdvanceFadeEv` | arm9-main | fade / blend-brightness + model render |
| `func_ov004_020aea78` | ov004 | init/setup (C++) |

**Verification:** all 3 byte-identical under mwccarm 1.2/sp2p3 and linkcheck `VERIFIED` (0 wrong-dest, 0 unresolved relocs). src-only, self-contained, no `#include`s. +105/-0, 0 non-src files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)