### PR TITLE
Match 11 functions via coddog fuzzy-similarity scheduling (arm9 + 5 overlays)

### DIFF
--- a/src/__sinit_ov065_0211c110.c
+++ b/src/__sinit_ov065_0211c110.c
@@ -1,0 +1,31 @@
+extern void func_02017acc();
+extern void func_020731dc();
+extern void _ZN13SharedFilePtr9ConstructEj();
+extern void func_02017ab4();
+extern void func_02017984();
+
+typedef struct { int a, b; } S8;
+
+extern S8 data_ov065_0211d610, data_ov065_0211d618, data_ov065_0211d600, data_ov065_0211d608;
+extern S8 data_ov065_0211d644, data_ov065_0211d620, data_ov065_0211d62c, data_ov065_0211d638;
+
+extern S8 data_ov065_0211d670[2], data_ov065_0211d680[2], data_ov065_0211d650[2], data_ov065_0211d660[2];
+extern S8 data_ov065_0211cb30, data_ov065_0211cb58, data_ov065_0211cb20, data_ov065_0211cb40;
+extern S8 data_ov065_0211cb28, data_ov065_0211cb50, data_ov065_0211cb38, data_ov065_0211cb48;
+
+void __sinit_ov065_0211c110(void)
+{
+    func_02017acc(&data_ov065_0211d610, 0x42f);
+    func_020731dc(&data_ov065_0211d610, func_02017ab4, &data_ov065_0211d644);
+    func_02017acc(&data_ov065_0211d618, 0x42d);
+    func_020731dc(&data_ov065_0211d618, func_02017ab4, &data_ov065_0211d620);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov065_0211d600, 0x430);
+    func_020731dc(&data_ov065_0211d600, func_02017984, &data_ov065_0211d62c);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov065_0211d608, 0x42e);
+    func_020731dc(&data_ov065_0211d608, func_02017984, &data_ov065_0211d638);
+
+    data_ov065_0211d670[0] = data_ov065_0211cb30; data_ov065_0211d670[1] = data_ov065_0211cb58;
+    data_ov065_0211d680[0] = data_ov065_0211cb20; data_ov065_0211d680[1] = data_ov065_0211cb40;
+    data_ov065_0211d650[0] = data_ov065_0211cb28; data_ov065_0211d650[1] = data_ov065_0211cb50;
+    data_ov065_0211d660[0] = data_ov065_0211cb38; data_ov065_0211d660[1] = data_ov065_0211cb48;
+}

--- a/src/__sinit_ov065_0211c2a8.c
+++ b/src/__sinit_ov065_0211c2a8.c
@@ -1,0 +1,31 @@
+extern void func_02017acc();
+extern void func_020731dc();
+extern void _ZN13SharedFilePtr9ConstructEj();
+extern void func_02017ab4();
+extern void func_02017984();
+
+typedef struct { int a, b; } S8;
+
+extern S8 data_ov065_0211d698, data_ov065_0211d6a8, data_ov065_0211d690, data_ov065_0211d6a0;
+extern S8 data_ov065_0211d6d4, data_ov065_0211d6b0, data_ov065_0211d6bc, data_ov065_0211d6c8;
+
+extern S8 data_ov065_0211d700[2], data_ov065_0211d710[2], data_ov065_0211d6e0[2], data_ov065_0211d6f0[2];
+extern S8 data_ov065_0211cc30, data_ov065_0211cc50, data_ov065_0211cc20, data_ov065_0211cc40;
+extern S8 data_ov065_0211cc28, data_ov065_0211cc38, data_ov065_0211cc58, data_ov065_0211cc48;
+
+void __sinit_ov065_0211c2a8(void)
+{
+    func_02017acc(&data_ov065_0211d698, 0x298);
+    func_020731dc(&data_ov065_0211d698, func_02017ab4, &data_ov065_0211d6d4);
+    func_02017acc(&data_ov065_0211d6a8, 0x29b);
+    func_020731dc(&data_ov065_0211d6a8, func_02017ab4, &data_ov065_0211d6b0);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov065_0211d690, 0x299);
+    func_020731dc(&data_ov065_0211d690, func_02017984, &data_ov065_0211d6bc);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov065_0211d6a0, 0x29a);
+    func_020731dc(&data_ov065_0211d6a0, func_02017984, &data_ov065_0211d6c8);
+
+    data_ov065_0211d700[0] = data_ov065_0211cc30; data_ov065_0211d700[1] = data_ov065_0211cc50;
+    data_ov065_0211d710[0] = data_ov065_0211cc20; data_ov065_0211d710[1] = data_ov065_0211cc40;
+    data_ov065_0211d6e0[0] = data_ov065_0211cc28; data_ov065_0211d6e0[1] = data_ov065_0211cc38;
+    data_ov065_0211d6f0[0] = data_ov065_0211cc58; data_ov065_0211d6f0[1] = data_ov065_0211cc48;
+}

--- a/src/__sinit_ov080_021278c0.c
+++ b/src/__sinit_ov080_021278c0.c
@@ -1,0 +1,50 @@
+extern int func_02017acc(void*, int);
+extern void func_020731dc(void*, void*, void**);
+extern int _ZN13SharedFilePtr9ConstructEj(void*, int);
+extern void func_02017ab4(void);
+extern void func_02017984(void);
+
+extern void* data_ov080_021283c0;
+extern void* data_ov080_02128408;
+extern void* data_ov080_021283c8;
+extern void* data_ov080_02128420;
+extern void* data_ov080_021283e8;
+extern void* data_ov080_0212842c;
+extern void* data_ov080_021283d0;
+extern void* data_ov080_02128414;
+extern void* data_ov080_021283d8;
+extern void* data_ov080_021283f0;
+extern void* data_ov080_021283e0;
+extern void* data_ov080_021283fc;
+
+struct S2 { int w[2]; };
+extern struct S2 data_ov080_02127fa0;
+extern struct S2 data_ov080_02127f88;
+extern struct S2 data_ov080_02127fa8;
+extern struct S2 data_ov080_02127f80;
+extern struct S2 data_ov080_02127f98;
+extern struct S2 data_ov080_02127f90;
+struct D { struct S2 a, b, c, d, e, f; };
+extern struct D data_ov080_02128438;
+
+void __sinit_ov080_021278c0(void)
+{
+    func_02017acc(&data_ov080_021283c0, 0x2d1);
+    func_020731dc(&data_ov080_021283c0, (void*)&func_02017ab4, (void**)&data_ov080_02128408);
+    func_02017acc(&data_ov080_021283c8, 0x2d6);
+    func_020731dc(&data_ov080_021283c8, (void*)&func_02017ab4, (void**)&data_ov080_02128420);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov080_021283e8, 0x2d2);
+    func_020731dc(&data_ov080_021283e8, (void*)&func_02017984, (void**)&data_ov080_0212842c);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov080_021283d0, 0x2d3);
+    func_020731dc(&data_ov080_021283d0, (void*)&func_02017984, (void**)&data_ov080_02128414);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov080_021283d8, 0x2d4);
+    func_020731dc(&data_ov080_021283d8, (void*)&func_02017984, (void**)&data_ov080_021283f0);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov080_021283e0, 0x2d5);
+    func_020731dc(&data_ov080_021283e0, (void*)&func_02017984, (void**)&data_ov080_021283fc);
+    data_ov080_02128438.a = data_ov080_02127fa0;
+    data_ov080_02128438.b = data_ov080_02127f88;
+    data_ov080_02128438.c = data_ov080_02127fa8;
+    data_ov080_02128438.d = data_ov080_02127f80;
+    data_ov080_02128438.e = data_ov080_02127f98;
+    data_ov080_02128438.f = data_ov080_02127f90;
+}

--- a/src/__sinit_ov090_02133ce8.c
+++ b/src/__sinit_ov090_02133ce8.c
@@ -1,0 +1,36 @@
+extern void func_02017acc();
+extern void func_020731dc();
+extern void _ZN13SharedFilePtr9ConstructEj();
+extern void func_02017ab4();
+extern void func_02017984();
+
+typedef struct { int a, b; } S8;
+
+extern S8 g_a0;
+extern S8 g_88;
+extern S8 g_80;
+extern S8 g_90;
+extern S8 g_98;
+extern S8 g_c0, g_d8, g_a8, g_cc, g_b4;
+
+extern S8 g_f4[2], g_504[2], g_514[2], g_e4[2];
+extern S8 g_110, g_108, g_118, g_f8, g_e8, g_e0, g_f0, g_100;
+
+void __sinit_ov090_02133ce8(void)
+{
+    func_02017acc(&g_a0, 0x39f);
+    func_020731dc(&g_a0, func_02017ab4, &g_c0);
+    _ZN13SharedFilePtr9ConstructEj(&g_88, 0x3a0);
+    func_020731dc(&g_88, func_02017984, &g_d8);
+    _ZN13SharedFilePtr9ConstructEj(&g_80, 0x3a1);
+    func_020731dc(&g_80, func_02017984, &g_a8);
+    _ZN13SharedFilePtr9ConstructEj(&g_90, 0x3a2);
+    func_020731dc(&g_90, func_02017984, &g_cc);
+    _ZN13SharedFilePtr9ConstructEj(&g_98, 0x3a3);
+    func_020731dc(&g_98, func_02017984, &g_b4);
+
+    g_f4[0] = g_110; g_f4[1] = g_108;
+    g_504[0] = g_118; g_504[1] = g_f8;
+    g_514[0] = g_e8; g_514[1] = g_e0;
+    g_e4[0] = g_f0; g_e4[1] = g_100;
+}

--- a/src/__sinit_ov096_0213770c.c
+++ b/src/__sinit_ov096_0213770c.c
@@ -1,0 +1,44 @@
+extern void func_02017acc();
+extern void func_020731dc();
+extern int func_02017ab4[];
+
+extern int data_ov096_02137b20[];
+extern int data_ov096_02137b30[];
+extern int data_ov096_02137b28[];
+extern int data_ov096_02137b3c[];
+
+struct P { int a, b; };
+extern struct P data_ov096_02137948;
+extern struct P data_ov096_02137940;
+extern struct P data_ov096_02137950;
+extern struct P data_ov096_02137928;
+extern struct P data_ov096_02137930;
+extern struct P data_ov096_02137920;
+extern struct P data_ov096_02137978;
+extern struct P data_ov096_02137970;
+extern struct P data_ov096_02137938;
+extern struct P data_ov096_02137968;
+extern struct P data_ov096_02137960;
+extern struct P data_ov096_02137958;
+extern struct P data_ov096_02137b48[12];
+
+void __sinit_ov096_0213770c(void)
+{
+    func_02017acc(data_ov096_02137b20, 0x41b);
+    func_020731dc(data_ov096_02137b20, func_02017ab4, data_ov096_02137b30);
+    func_02017acc(data_ov096_02137b28, 0x41a);
+    func_020731dc(data_ov096_02137b28, func_02017ab4, data_ov096_02137b3c);
+
+    data_ov096_02137b48[0] = data_ov096_02137948;
+    data_ov096_02137b48[1] = data_ov096_02137940;
+    data_ov096_02137b48[2] = data_ov096_02137950;
+    data_ov096_02137b48[3] = data_ov096_02137928;
+    data_ov096_02137b48[4] = data_ov096_02137930;
+    data_ov096_02137b48[5] = data_ov096_02137920;
+    data_ov096_02137b48[6] = data_ov096_02137978;
+    data_ov096_02137b48[7] = data_ov096_02137970;
+    data_ov096_02137b48[8] = data_ov096_02137938;
+    data_ov096_02137b48[9] = data_ov096_02137968;
+    data_ov096_02137b48[10] = data_ov096_02137960;
+    data_ov096_02137b48[11] = data_ov096_02137958;
+}

--- a/src/__sinit_ov100_02147bc0.c
+++ b/src/__sinit_ov100_02147bc0.c
@@ -1,0 +1,52 @@
+extern int func_02017acc();
+extern void func_020731dc();
+extern int _ZN13SharedFilePtr9ConstructEj();
+extern void func_02017ab4(void);
+extern void func_02017984(void);
+
+extern char data_ov100_021489a4[];
+extern char data_ov100_021489d4[];
+extern char data_ov100_021489bc[];
+extern char data_ov100_021489e0[];
+extern char data_ov100_021489b4[];
+extern char data_ov100_021489ec[];
+extern char data_ov100_021489c4[];
+extern char data_ov100_021489f8[];
+extern char data_ov100_021489cc[];
+extern char data_ov100_02148a04[];
+extern char data_ov100_021489ac[];
+extern char data_ov100_02148a10[];
+
+struct P2 { int a, b; };
+extern struct P2 data_ov100_02148a1c[];
+extern struct P2 data_ov100_02148450;
+extern struct P2 data_ov100_02148460;
+extern struct P2 data_ov100_02148448;
+extern struct P2 data_ov100_02148468;
+extern struct P2 data_ov100_02148458;
+extern struct P2 data_ov100_02148470;
+extern struct P2 data_ov100_02148478;
+
+void __sinit_ov100_02147bc0(void)
+{
+    func_02017acc(data_ov100_021489a4, 0x447);
+    func_020731dc(data_ov100_021489a4, func_02017ab4, data_ov100_021489d4);
+    func_02017acc(data_ov100_021489bc, 0x448);
+    func_020731dc(data_ov100_021489bc, func_02017ab4, data_ov100_021489e0);
+    func_02017acc(data_ov100_021489b4, 0x44a);
+    func_020731dc(data_ov100_021489b4, func_02017ab4, data_ov100_021489ec);
+    _ZN13SharedFilePtr9ConstructEj(data_ov100_021489c4, 0x44b);
+    func_020731dc(data_ov100_021489c4, func_02017984, data_ov100_021489f8);
+    _ZN13SharedFilePtr9ConstructEj(data_ov100_021489cc, 0x44c);
+    func_020731dc(data_ov100_021489cc, func_02017984, data_ov100_02148a04);
+    _ZN13SharedFilePtr9ConstructEj(data_ov100_021489ac, 0x449);
+    func_020731dc(data_ov100_021489ac, func_02017984, data_ov100_02148a10);
+
+    data_ov100_02148a1c[0] = data_ov100_02148450;
+    data_ov100_02148a1c[1] = data_ov100_02148460;
+    data_ov100_02148a1c[2] = data_ov100_02148448;
+    data_ov100_02148a1c[3] = data_ov100_02148468;
+    data_ov100_02148a1c[4] = data_ov100_02148458;
+    data_ov100_02148a1c[5] = data_ov100_02148470;
+    data_ov100_02148a1c[6] = data_ov100_02148478;
+}

--- a/src/func_02054fb0.cpp
+++ b/src/func_02054fb0.cpp
@@ -1,0 +1,18 @@
+//cpp
+extern "C" void* func_02054fb0(void){
+  unsigned int mode = *(volatile unsigned int*)0x4000000 & 7;
+  unsigned short bg3cnt = *(volatile unsigned short*)0x400000e;
+  unsigned int sbase = ((*(volatile unsigned int*)0x4000000 & 0x38000000) >> 0x1b) << 0x10;
+  unsigned int off = ((unsigned int)(bg3cnt & 0x1f00)) >> 8;
+  switch(mode){
+  case 0: case 1: case 2:
+    return (void*)(0x6000000 + sbase + (off << 11));
+  case 3: case 4: case 5:
+    if(bg3cnt & 0x80) return (void*)(0x6000000 + (off << 0xe));
+    return (void*)(0x6000000 + sbase + (off << 11));
+  case 6:
+    return (void*)0;
+  default:
+    return (void*)0;
+  }
+}

--- a/src/func_02064a94.c
+++ b/src/func_02064a94.c
@@ -1,0 +1,18 @@
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+
+int func_02064a94(unsigned char *dst, unsigned short a1, unsigned char a2, const void *a3, unsigned char a4)
+{
+    unsigned char hdr = 10;
+    unsigned short s = a1;
+    unsigned char *p1, *p2, *p3, *p4;
+    func_0205a61c(&hdr, dst, 1);
+    p1 = dst + 1;
+    func_0205a61c(&s, p1, 2);
+    p2 = p1 + 2;
+    func_0205a61c(&a2, p2, 1);
+    p3 = p2 + 1;
+    func_0205a61c(&a4, p3, 1);
+    p4 = p3 + 1;
+    func_0205a61c(a3, p4, 9);
+    return (p4 + 9) - dst;
+}

--- a/src/func_ov004_020b4e78.c
+++ b/src/func_ov004_020b4e78.c
@@ -1,0 +1,36 @@
+extern void func_ov004_020b1b08(int x);
+extern int func_ov004_020b04c0(void);
+extern void func_0203d6d0(void* o, void* a, void* b);
+extern void func_0203d680(void* out, void* in, int scale);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int x);
+struct W2 { int a, b; };
+extern struct W2 data_ov004_020bc810;
+struct V2 { int x, y; };
+void func_ov004_020b4e78(char *c)
+{
+    struct V2 a;
+    struct V2 b;
+    func_ov004_020b1b08(1);
+    *(char*)(c+0x22) = 1;
+    *(int*)(c+8) = 0xc000;
+    *(int*)(c+0xc) = 0xc000;
+    *(int*)(c+0x10) = 0x80000;
+    *(int*)(c+0x14) = ((-func_ov004_020b04c0()) - 0x10) << 12;
+    func_0203d6d0(&a, c+0x10, c+8);
+    func_0203d680(&b, &a, 0xc0);
+    *(int*)(c+0x18) = b.x;
+    *(int*)(c+0x1c) = b.y;
+    {
+        int x = *(int*)(c+0x18);
+        if (x < 0) x = -x;
+        *(int*)(c+0x18) = x;
+    }
+    {
+        int y = *(int*)(c+0x1c);
+        if (y < 0) y = -y;
+        *(int*)(c+0x1c) = y;
+    }
+    *(short*)(c+0x20) = 0x14;
+    _ZN5Sound12PlayBank2_2DEj(0x14a);
+    *(struct W2*)c = data_ov004_020bc810;
+}

--- a/src/func_ov004_020b5aac.cpp
+++ b/src/func_ov004_020b5aac.cpp
@@ -1,0 +1,42 @@
+//cpp
+extern int ApproachLinear(int&, int, int);
+extern void func_ov004_020b506c(char* c);
+namespace Sound { void PlayBank2_2D(unsigned int); }
+
+extern int data_ov004_020bf9fc;
+extern int data_ov004_020bfa04;
+extern int data_ov004_020bfa00;
+extern char data_ov004_020bfa34[];
+extern int data_ov004_020bf9f0;
+struct Obj { char pad[0xa8]; int x; };
+extern Obj* data_ov004_020beb68;
+extern int data_ov004_020bf9f4;
+extern unsigned char data_ov004_020bfa56[];
+extern void (*data_ov004_020bfa20)();
+extern void func_ov004_020b5a54();
+
+extern "C" void func_ov004_020b5aac(void)
+{
+    if (data_ov004_020bf9fc > 0) {
+        if (ApproachLinear(data_ov004_020bfa04, 0, 1) == 0)
+            return;
+        func_ov004_020b506c(&data_ov004_020bfa34[data_ov004_020bfa00 * 0x24]);
+        if (data_ov004_020bf9f0 != 0) {
+            int t = data_ov004_020beb68 ? data_ov004_020beb68->x : 0;
+            if (t == 0 && data_ov004_020bfa00 == 0)
+                Sound::PlayBank2_2D(0x14c);
+            else
+                Sound::PlayBank2_2D(0x14b);
+            data_ov004_020bf9f0 = 0;
+        }
+        data_ov004_020bf9f4 = data_ov004_020bfa00;
+        ApproachLinear(data_ov004_020bfa00, 0, 1);
+        if (ApproachLinear(data_ov004_020bf9fc, 0, 1) == 0)
+            data_ov004_020bfa04 = 0x10;
+        return;
+    }
+    if (data_ov004_020bfa56[data_ov004_020bf9f4 * 0x24] != 0)
+        return;
+    data_ov004_020bfa04 = 0x3c;
+    data_ov004_020bfa20 = func_ov004_020b5a54;
+}

--- a/src/func_ov100_02143cb0.c
+++ b/src/func_ov100_02143cb0.c
@@ -1,0 +1,17 @@
+extern void _ZN13SharedFilePtr7ReleaseEv(void *);
+extern void UnloadSilverStarAndNumber(void);
+extern int G0[];
+extern int G1[];
+extern int G2[];
+extern int G3[];
+extern int G4[];
+int func_ov100_02143cb0(void)
+{
+    _ZN13SharedFilePtr7ReleaseEv(G0);
+    _ZN13SharedFilePtr7ReleaseEv(G1);
+    _ZN13SharedFilePtr7ReleaseEv(G2);
+    _ZN13SharedFilePtr7ReleaseEv(G3);
+    _ZN13SharedFilePtr7ReleaseEv(G4);
+    UnloadSilverStarAndNumber();
+    return 1;
+}


### PR DESCRIPTION
Scheduled with the new `tools/coddog.py` fuzzy opcode-similarity scheduler — each target was paired with its closest already-matched sibling as few-shot scaffolding, then hand/agent-matched from that sibling. **11 of 15 candidates matched (73%)**, a big lift over cold scheduling on the thinning pool.

| Function | Module | Notes |
|---|---|---|
| `func_02054fb0` | arm9 | BG3 `GetScrPtr` (twin of `G2::GetBG2ScrPtr`) |
| `func_02064a94` | arm9 | save serializer (twin of `func_02064cd8`) |
| `func_ov004_020b5aac` | ov004 | state update (twin of `func_ov004_020b5c18`) |
| `func_ov004_020b4e78` | ov004 | init (twin of `func_ov004_020b506c`) |
| `func_ov100_02143cb0` | ov100 | `SharedFilePtr::Release` chain + tail call |
| `__sinit_ov065_0211c110` | ov065 | static initializer |
| `__sinit_ov065_0211c2a8` | ov065 | static initializer |
| `__sinit_ov080_021278c0` | ov080 | static initializer |
| `__sinit_ov090_02133ce8` | ov090 | static initializer |
| `__sinit_ov096_0213770c` | ov096 | static initializer |
| `__sinit_ov100_02147bc0` | ov100 | static initializer |

**Verification:** all 11 byte-identical under mwccarm 1.2/sp2p3 (independently re-verified) and linkcheck **0-WRONG** (8 VERIFIED, 3 BLIND — unresolved data-symbol relocs, benign). src-only, +375/-0, 0 non-src files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)