### PR TITLE
Match __sinit_ov081_02128154

### DIFF
--- a/src/__sinit_ov081_02128154.c
+++ b/src/__sinit_ov081_02128154.c
@@ -1,0 +1,94 @@
+extern int func_02017acc(void*, int);
+extern void func_020731dc(void*, void*, void**);
+extern int _ZN13SharedFilePtr9ConstructEj(void*, int);
+extern void func_02017ab4(void);
+extern void func_02017984(void);
+
+extern void* data_ov081_02128d90;
+extern void* data_ov081_02128dc0;
+extern void* data_ov081_02128db0;
+extern void* data_ov081_02128dcc;
+extern void* data_ov081_02128d98;
+extern void* data_ov081_02128dd8;
+extern void* data_ov081_02128db8;
+extern void* data_ov081_02128de4;
+extern void* data_ov081_02128da8;
+extern void* data_ov081_02128df0;
+extern void* data_ov081_02128d88;
+extern void* data_ov081_02128e08;
+extern void* data_ov081_02128da0;
+extern void* data_ov081_02128dfc;
+
+typedef struct { int a, b; } S8;
+typedef struct { S8 x, y; } S16;
+
+extern S16 data_ov081_02128e54;
+extern S16 data_ov081_02128e74;
+extern S16 data_ov081_02128e84;
+extern S16 data_ov081_02128ea4;
+extern S16 data_ov081_02128e14;
+extern S16 data_ov081_02128e34;
+extern S16 data_ov081_02128e44;
+extern S16 data_ov081_02128e64;
+extern S16 data_ov081_02128e94;
+extern S16 data_ov081_02128e24;
+
+extern S8 data_ov081_02128938;
+extern S8 data_ov081_02128930;
+extern S8 data_ov081_02128940;
+extern S8 data_ov081_02128980;
+extern S8 data_ov081_02128948;
+extern S8 data_ov081_02128918;
+extern S8 data_ov081_02128920;
+extern S8 data_ov081_02128900;
+extern S8 data_ov081_02128910;
+extern S8 data_ov081_021288f8;
+extern S8 data_ov081_02128958;
+extern S8 data_ov081_02128960;
+extern S8 data_ov081_02128928;
+extern S8 data_ov081_02128990;
+extern S8 data_ov081_02128978;
+extern S8 data_ov081_02128970;
+extern S8 data_ov081_02128988;
+extern S8 data_ov081_02128968;
+extern S8 data_ov081_02128908;
+extern S8 data_ov081_02128950;
+
+void __sinit_ov081_02128154(void)
+{
+    func_02017acc(&data_ov081_02128d90, 0x424);
+    func_020731dc(&data_ov081_02128d90, (void*)&func_02017ab4, (void**)&data_ov081_02128dc0);
+    func_02017acc(&data_ov081_02128db0, 0x420);
+    func_020731dc(&data_ov081_02128db0, (void*)&func_02017ab4, (void**)&data_ov081_02128dcc);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov081_02128d98, 0x423);
+    func_020731dc(&data_ov081_02128d98, (void*)&func_02017984, (void**)&data_ov081_02128dd8);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov081_02128db8, 0x422);
+    func_020731dc(&data_ov081_02128db8, (void*)&func_02017984, (void**)&data_ov081_02128de4);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov081_02128da8, 0x421);
+    func_020731dc(&data_ov081_02128da8, (void*)&func_02017984, (void**)&data_ov081_02128df0);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov081_02128d88, 0x41f);
+    func_020731dc(&data_ov081_02128d88, (void*)&func_02017984, (void**)&data_ov081_02128e08);
+    _ZN13SharedFilePtr9ConstructEj(&data_ov081_02128da0, 0x41e);
+    func_020731dc(&data_ov081_02128da0, (void*)&func_02017984, (void**)&data_ov081_02128dfc);
+
+    data_ov081_02128e54.x = data_ov081_02128938;
+    data_ov081_02128e54.y = data_ov081_02128930;
+    data_ov081_02128e74.x = data_ov081_02128940;
+    data_ov081_02128e74.y = data_ov081_02128980;
+    data_ov081_02128e84.x = data_ov081_02128948;
+    data_ov081_02128e84.y = data_ov081_02128918;
+    data_ov081_02128ea4.x = data_ov081_02128920;
+    data_ov081_02128ea4.y = data_ov081_02128900;
+    data_ov081_02128e14.x = data_ov081_02128910;
+    data_ov081_02128e14.y = data_ov081_021288f8;
+    data_ov081_02128e34.x = data_ov081_02128958;
+    data_ov081_02128e34.y = data_ov081_02128960;
+    data_ov081_02128e44.x = data_ov081_02128928;
+    data_ov081_02128e44.y = data_ov081_02128990;
+    data_ov081_02128e64.x = data_ov081_02128978;
+    data_ov081_02128e64.y = data_ov081_02128970;
+    data_ov081_02128e94.x = data_ov081_02128988;
+    data_ov081_02128e94.y = data_ov081_02128968;
+    data_ov081_02128e24.x = data_ov081_02128908;
+    data_ov081_02128e24.y = data_ov081_02128950;
+}


### PR DESCRIPTION
One function, src-only: `__sinit_ov081_02128154` (ov081 static initializer, 0x94 bytes).

From a claims-coordinated coddog batch in the 0x280-0x400 band (locked/released via the live API, fully disjoint from your concurrent batch). Byte-MATCH verified independently at bank time, relocation destinations checked against config/**/relocs.txt (0 WRONG-DEST).

Tooling/workflow changes from tonight are coming separately on another branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)