### PR TITLE
Reloc-destination gates: bank-time (harvest/bank-matches), source-level (clone/paramclone), whole-run link sweep

### DIFF
--- a/tools/bank_harvest.py
+++ b/tools/bank_harvest.py
@@ -1,6 +1,9 @@
 """Central harvest banker. Collects {name,c_source} JSONL produced by fan-out agents,
-INDEPENDENTLY re-verifies each via the oracle (never trusts agent say-so), and banks the
-real byte-matches to src/<name>.c(pp) + progress/matched.jsonl (tag 'harvest'). Resilient
+INDEPENDENTLY re-verifies each via the oracle (never trusts agent say-so), checks that
+every relocation the object emits points where config/**/relocs.txt says (the byte
+compare wildcards reloc slots, so a wrong same-shaped callee would otherwise pass --
+--no-strict skips this), and banks the real byte-matches to src/<name>.c(pp) +
+progress/matched.jsonl (tag 'harvest'). Resilient
 to agents that died mid-run -- it banks whatever verified lines they saved.
 
 Dry-run by default; pass --apply to bank.
@@ -14,6 +17,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import swarm as S
 import nearmiss_db as NM
 import ledger as L
+import reloc_audit as RA
 
 
 def main():
@@ -22,6 +26,8 @@ def main():
     ap.add_argument("--apply", action="store_true", help="bank the verified matches")
     ap.add_argument("--dry-run", action="store_true",
                     help="no-op; dry-run is the default (kept for compatibility)")
+    ap.add_argument("--no-strict", action="store_true",
+                    help="skip the reloc-destination gate (bytes-only banking)")
     args = ap.parse_args()
     do_apply = args.apply and not args.dry_run
 
@@ -51,11 +57,19 @@ def main():
         if L.make_key(module, addr) in done:
             dup += 1; continue
         try:
-            ok = S.oracle_ok(src, name, bytes.fromhex(thex))
+            ok, obj = S.oracle_check(src, name, bytes.fromhex(thex))
         except Exception as e:
             rejected.append((name, f"exc {e}")); continue
         if not ok:
             rejected.append((name, "oracle FALSE")); continue
+        if not args.no_strict:
+            # the byte oracle wildcards reloc slots; refuse a candidate whose
+            # relocations point somewhere other than config/**/relocs.txt records
+            bad = RA.gate_wrong_dests(obj, name, L.norm_addr(addr), size, module)
+            if bad:
+                rejected.append((name, f"WRONG-DEST reloc: {bad[0]['cand']} "
+                                       f"({bad[0]['cand_addr']}) != config {bad[0]['cfg']}"))
+                continue
         if do_apply:
             status = L.bank({"addr": addr, "name": name, "size": size,
                              "module": module, "versions": ["harvest"]}, src)

--- a/tools/clone.py
+++ b/tools/clone.py
@@ -7,6 +7,14 @@ so the call/data targets may differ). When that holds, the verified source of th
 matched function, retargeted to the clone's name, matches the clone too. No model
 is involved: we retarget and re-run the oracle, banking only what passes.
 
+One more check, because the oracle wildcards reloc slots: the retargeted source
+still names the TEMPLATE's callees and globals, so the clone only genuinely
+matches when config/**/relocs.txt records the SAME destination at every slot for
+both functions. Byte-identical PMF/table dispatchers fail exactly there (each
+sibling reads its own table) -- 24 of them byte-passed and banked wrong across
+two machines on 2026-07-02. The gate compares the two config reloc maps directly
+(no compile) and rejects mismatches before the oracle ever runs.
+
 This compounds: every function the LLM loop lands becomes a template for its
 byte-clones, so re-running clone.py after each bank harvests the new clones for
 free. Run it as the cheap first pass before spending tokens on a fan-out.
@@ -93,22 +101,34 @@ def main():
             ins = list(S.md.disasm(raw, 0))
             if not ins or S.is_thunk(ins):
                 continue
+            # config-recorded destination address at each reloc slot, in slot
+            # order (k[2] slots exist in the map by norm_key construction)
+            dests = tuple(relocs[addr + o][1] for o in k[2])
             if (label, addr) in matched_keys:
                 if k not in matched:
                     src = read_src(name)
                     if src:
-                        matched[k] = (name, src, raw)
+                        matched[k] = (name, src, raw, dests)
             elif (label, addr) not in done:
-                unmatched.append((k, label, addr, size, name, raw))
+                unmatched.append((k, label, addr, size, name, raw, dests))
 
     print(f"matched templates: {len(matched)}   unmatched in range: {len(unmatched)}")
 
     passed, rejects = [], []
-    for k, label, addr, size, name, tb in unmatched:
+    for k, label, addr, size, name, tb, dests in unmatched:
         tpl = matched.get(k)
         if not tpl:
             continue
-        old_name, old_src, _ = tpl
+        old_name, old_src, _, tpl_dests = tpl
+        if dests != tpl_dests:
+            # the retargeted source would link to the template's destinations,
+            # not this function's -- byte-"match" with wrong relocs. Refuse.
+            bad = next((o, d, td) for o, d, td in
+                       zip(k[2], dests, tpl_dests) if d != td)
+            rejects.append((name, f"wrong-dest vs template {old_name}: "
+                                  f"+0x{bad[0]:x} needs 0x{bad[1]:08x}, "
+                                  f"template links 0x{bad[2]:08x}"))
+            continue
         cand = retarget(old_src, old_name, name)
         try:
             ok = S.oracle_ok(cand, name, tb)

--- a/tools/crackloop.py
+++ b/tools/crackloop.py
@@ -119,18 +119,64 @@ def refine(a):
 
 
 def land(a):
+    # snapshot the done-set so the link-gate sweep below can tell exactly what
+    # this run banked, whichever tier banked it
+    try:
+        sys.path.insert(0, str(TOOLS))
+        import ledger as L
+        pre = L.matched_set()
+    except Exception:
+        pre = None
     wl = str(REPO / "progress" / ("wl_refine.jsonl" if a.refine else f"wl_{a.tag}.jsonl"))
     bank = ["--output", a.output, "--wl", a.wl or wl]
     if a.refine:
         bank.append("--no-park")
     run("bank_run.py", *bank, check=False)
-    # Free tiers run DRY (report only) until the blocking reloc-destination gate
-    # (PR #64) is in ledger.bank: clone/paramclone retarget byte-identical siblings
-    # but can carry the source's reloc symbols - 14 wrong-table PMF clones banked
-    # 2026-07-02 that only linkcheck caught (all reverted). Bank clone candidates
-    # by hand only after linkcheck verifies them.
-    run("clone.py", check=False)
-    run("paramclone.py", check=False)
+    # Free tiers bank again: clone/paramclone now refuse a template whose config
+    # reloc destinations differ from the candidate's (PR #64) - the wrong-symbol
+    # class that put 24 wrong-table PMF clones in two trees on 2026-07-02. They
+    # stay dry-run by default, so land passes --apply explicitly.
+    run("clone.py", "--apply", check=False)
+    run("paramclone.py", "--apply", check=False)
+    # Whole-run link gate: sweep EVERYTHING banked in this run, whichever tier
+    # banked it. bank_run linkchecks only its own sources; this is the backstop
+    # that catches any banker the source-level gates miss (decision on PR #64).
+    if pre is not None:
+        try:
+            import ledger as L
+            import linkcheck as LC
+            import reloc_audit as RA
+            new_rows, seen = [], set()
+            for r in L.read_records(L.MATCHED):
+                try:
+                    key = L.key_of(r)
+                except Exception:
+                    continue
+                if key in pre or key in seen:
+                    continue
+                seen.add(key)
+                new_rows.append(r)
+            if new_rows:
+                print('\n'
+                      f"link-gate sweep: {len(new_rows)} function(s) banked this run")
+                ni = RA.build_name_index()
+                wrong = []
+                for r in new_rows:
+                    mod, addr = L.key_of(r)
+                    size = r["size"] if isinstance(r["size"], int) else int(r["size"], 0)
+                    v = LC.linkcheck(r["name"], addr, size, mod, ni)
+                    print(f"  {v['verdict']:>10}  {mod}  {r['name']}")
+                    if v["verdict"] == "WRONG":
+                        wrong.append(r["name"])
+                        for d in v["diffs"]:
+                            print(f"        {d['off']}: {d['sym']} -> {d['target']}")
+                if wrong:
+                    print('\n'
+                          f"*** LINK GATE: {len(wrong)} WRONG bank(s) this run: "
+                          f"{', '.join(wrong)} -- unbank (remove src/<name>.c[pp] and "
+                          f"the matched.jsonl rows) before committing ***")
+        except Exception as e:
+            print(f"link-gate sweep failed ({e}); run tools/linkcheck.py by hand")
     try:
         sys.path.insert(0, str(TOOLS))
         import claims

--- a/tools/nearmiss_db.py
+++ b/tools/nearmiss_db.py
@@ -258,6 +258,17 @@ def bank_matches(args):
     banked, banked_keys, rescored = 0, [], {}
     for key, r in list(db.items()):
         div, ok = evaluate(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
+        if ok and not getattr(args, "no_strict", False):
+            # the byte oracle wildcards reloc slots; refuse a draft whose relocations
+            # point somewhere other than the config/**/relocs.txt records
+            import reloc_audit as RA
+            _, obj = S.oracle_check(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
+            bad = (RA.gate_wrong_dests(obj, r["name"], L.norm_addr(r["addr"]),
+                                       r["size"], r["module"]) if obj else None)
+            if bad:
+                print(f"  SKIP {r['name']}: bytes match but {len(bad)} reloc "
+                      f"destination(s) WRONG (e.g. {bad[0]['cand']} != {bad[0]['cfg']})")
+                continue
         if ok:
             st = L.bank({"addr": r["addr"], "name": r["name"], "size": r["size"],
                          "module": r["module"], "versions": ["nearmiss-db"]},
@@ -293,7 +304,10 @@ def main():
                    help="comma list of category substrings to keep (e.g. "
                         "'register allocation,instruction reorder' for permuter seeds)")
     p.set_defaults(fn=export_close)
-    p = sub.add_parser("bank-matches"); p.set_defaults(fn=bank_matches)
+    p = sub.add_parser("bank-matches")
+    p.add_argument("--no-strict", action="store_true",
+                   help="skip the reloc-destination gate (bytes-only banking)")
+    p.set_defaults(fn=bank_matches)
     args = ap.parse_args()
     args.fn(args)
 

--- a/tools/paramclone.py
+++ b/tools/paramclone.py
@@ -9,7 +9,11 @@ by substituting M's immediates with U's and re-checks against the ROM.
 The immediates that vary across an idiom family are field offsets, shift amounts,
 and non-relocation pool constants -- exactly what distinguishes, say, one actor's
 cleanup from another's. Relocation slots (call/data symbol references) are already
-wildcarded by the oracle, so symbol names need no substitution.
+wildcarded by the oracle, so symbol names need no substitution -- which is exactly
+why the rewritten source can name a WRONG callee or table and still byte-pass.
+Before compiling, a template is skipped unless config/**/relocs.txt records the
+same destination at every reloc slot the two functions share (the clone.py gate,
+same incident: 24 wrong-table PMF paramclones on 2026-07-02).
 
 Nothing is trusted: every rewritten candidate is compiled and byte-compared. A bad
 substitution simply fails the oracle and is dropped, so the pass is always safe.
@@ -132,21 +136,27 @@ def main():
             if not ins or S.is_thunk(ins):
                 continue
             skel, vals = analyze(addr, ins, raw, relocs)
+            # config-recorded reloc destinations, keyed by slot offset
+            rd = {o: relocs[addr + o][1] for o in range(0, size, 4)
+                  if (addr + o) in relocs}
             if (label, addr) in matched_keys:
                 bucket = templates.setdefault(skel, [])
                 if len(bucket) < args.per_skel:
                     src = CL.read_src(name)
                     if src:
-                        bucket.append((name, src, vals))
+                        bucket.append((name, src, vals, rd))
             elif (label, addr) not in done:
-                unmatched.append((skel, vals, label, addr, size, name, raw))
+                unmatched.append((skel, vals, label, addr, size, name, raw, rd))
 
     print(f"skeleton templates: {len(templates)}   unmatched in range: {len(unmatched)}")
 
-    passed, tried = [], 0
-    for skel, uvals, label, addr, size, name, tb in unmatched:
-        for old_name, old_src, mvals in templates.get(skel, []):
+    passed, tried, gated = [], 0, 0
+    for skel, uvals, label, addr, size, name, tb, rd in unmatched:
+        for old_name, old_src, mvals, mrd in templates.get(skel, []):
             if len(mvals) != len(uvals):
+                continue
+            if any(mrd[o] != d for o, d in rd.items() if o in mrd):
+                gated += 1     # template links a different destination: skip it
                 continue
             cand = substitute(old_src, mvals, uvals)
             if cand is None:
@@ -160,7 +170,8 @@ def main():
             except Exception:
                 continue
 
-    print(f"parameterized clones VERIFIED {len(passed)} (candidates tried {tried})")
+    print(f"parameterized clones VERIFIED {len(passed)} (candidates tried {tried}, "
+          f"dest-gated {gated})")
     if not do_apply:
         for name, addr, size, mod, _ in passed[:30]:
             print(f"  would bank {mod} {name} (0x{size:x})")

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -221,6 +221,25 @@ def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym
     return rows, missing
 
 
+_GATE_IDX = None
+
+
+def gate_wrong_dests(obj, sym, addr, size, mod):
+    """Bank-gate wrapper around check_destinations: WRONG-DEST rows only, with the
+    three config indexes built once and cached for the process. Returns [] when the
+    object's reloc destinations agree with config, None when the symbol is absent
+    from the object (callers treat that as a verification failure)."""
+    global _GATE_IDX
+    if _GATE_IDX is None:
+        _GATE_IDX = (build_name_index(), build_config_relocs(), R.load_all_syms())
+    name_index, config_relocs, sym_index = _GATE_IDX
+    rows, _missing = check_destinations(obj, sym, addr, size, mod,
+                                        name_index, config_relocs, sym_index)
+    if rows is None:
+        return None
+    return [r for r in rows if r["verdict"] == "WRONG-DEST"]
+
+
 def audit_entry(entry, name_index, config_relocs, sym_index):
     name = entry["name"]
     addr = int(entry["addr"], 16) if isinstance(entry["addr"], str) else entry["addr"]

--- a/tools/swarm.py
+++ b/tools/swarm.py
@@ -1789,20 +1789,27 @@ RULES = [rule_empty, rule_ret_const, rule_ret_arg, rule_load, rule_load_mask,
 CPP_FLAGS = M.DEFAULT_FLAGS.replace("-lang c99", "-lang c++")
 
 
-def oracle_ok(c_source, name, target):
-    """Compile candidate C/C++ and relocation-aware byte-diff against the ROM."""
+def oracle_check(c_source, name, target):
+    """Compile candidate C/C++ and relocation-aware byte-diff against the ROM.
+    Returns (ok, obj) so callers can also audit the object's relocation
+    destinations -- the byte compare wildcards reloc slots."""
     cpp = c_source.startswith("//cpp")
     with tempfile.TemporaryDirectory() as td:
         cfile = pathlib.Path(td) / ("cand.cpp" if cpp else "cand.c")
         cfile.write_text(c_source)
         obj = M.compile_c(cfile, M.CANONICAL, CPP_FLAGS if cpp else M.DEFAULT_FLAGS)
     if obj is None:
-        return False
+        return False, None
     code, relocs = M.extract_func(obj, name)
     if code is None:
-        return False
+        return False, obj
     ok, _ = M.compare(target, code, relocs, verbose=False)
-    return ok
+    return ok, obj
+
+
+def oracle_ok(c_source, name, target):
+    """Compile candidate C/C++ and relocation-aware byte-diff against the ROM."""
+    return oracle_check(c_source, name, target)[0]
 
 
 # ----------------------------------------------------------------------------- main


### PR DESCRIPTION
Restructured to the (1)+(3) decision — the ledger.bank version that briefly replaced this was pushed before I saw the decision comment (13 minutes apart, my miss) and is gone. Two commits off current main (abad87b), 6 files, +137/-24:

## Commit 1 — the original bank-time gate, rebased (`bank_harvest`, `bank-matches`)

Unchanged in substance from the draft: `swarm.oracle_check` returns the compiled object alongside the verdict (`oracle_ok` delegates, all callers untouched), `reloc_audit.gate_wrong_dests` wraps `check_destinations` with cached config indexes, and both bank paths reject on WRONG-DEST rows before `ledger.bank`. `--no-strict` restores bytes-only banking. The 88712ce dup-filter commit is dropped per your note (main already banks against `matched_set`).

## Commit 2 — source-level gates for clone/paramclone (no recompile) + whole-run link sweep

- **clone.py**: the structural key already carries every reloc slot offset, so the gate is a pure config-map comparison — refuse when `config/**/relocs.txt` records a different destination for candidate vs template at any slot. Zero compiles spent on refused candidates.
- **paramclone.py**: same comparison over the slots the two functions share, applied per template before substitute/compile; other templates in the skeleton bucket still get their chance.
- **crackloop land**: snapshots `matched_set()` at entry, then linkchecks **everything any tier banked during the run** and shouts WRONG banks with unbank instructions — the backstop for any banker the source gates miss. Free tiers run with `--apply` again now that they're gated.

## Evidence (all rerun on this branch)

- Wrong-callee `func_02064a94` byte-passes the oracle, rejected with 5 WRONG-DEST relocs; genuine source passes with 0.
- `clone.py --min 0x40 --max 0x100` dry-run rejects **exactly the 10 ov006 PMF siblings from the incident** (`func_ov006_0211a4b0`…`0211b590`), each pinned to its distinct table pool word at `+0x4c` — before the oracle ever compiles them.
- `paramclone.py --min 0x40 --max 0x80` dest-gates all 40 PMF template pairings (10 siblings × 4 templates), candidates tried: 0.
- Sweep plumbing: `linkcheck()` on a known-banked function returns VERIFIED through the exact call path `land` uses.
- py_compile clean on all six files.

Thanks for the sec 6e credit and the 6g pointer — will re-run the zero-arg PMF twins (div=11) against the u64-mask laundering idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgKJraYsbg7Gg967B8dCpc
