### PR TITLE
Match 5 functions via high-sim coddog batch (0x40-0x100), with a Sonnet-vs-Opus A/B

### DIFF
--- a/src/_ZN6PlayerD2Ev.cpp
+++ b/src/_ZN6PlayerD2Ev.cpp
@@ -1,0 +1,26 @@
+//cpp
+extern "C" {
+extern int _ZN12WithMeshClsnD1Ev(void*);
+extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
+extern int _ZN11ShadowModelD1Ev(void*);
+extern int func_0207328c(void*, int, int, void*);
+extern int _ZN9ModelAnimD1Ev(void*);
+extern int _ZN5ActorD1Ev(void*);
+extern void _ZN15TextureSequenceD1Ev(void);
+extern void _ZN15MaterialChangerD1Ev(void);
+extern void* data_ov002_0210a83c[];
+void* _ZN6PlayerD2Ev(void* c) {
+  *(void***)c = data_ov002_0210a83c;
+  _ZN12WithMeshClsnD1Ev((char*)c+0x380);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x314);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x2d4);
+  _ZN11ShadowModelD1Ev((char*)c+0x2ac);
+  func_0207328c((char*)c+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  func_0207328c((char*)c+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
+  func_0207328c((char*)c+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  _ZN9ModelAnimD1Ev((char*)c+0x174);
+  _ZN9ModelAnimD1Ev((char*)c+0xf0);
+  _ZN5ActorD1Ev(c);
+  return c;
+}
+}

--- a/src/func_ov006_020d6278.cpp
+++ b/src/func_ov006_020d6278.cpp
@@ -1,0 +1,19 @@
+//cpp
+typedef unsigned char u8;
+class C;
+typedef void (C::*PMF)(int);
+class C { public: int dummy; };
+struct Row { u8 d[0x10]; };
+
+extern "C" PMF data_ov006_021416c0[];
+
+extern "C" void func_ov006_020d6278(C *self)
+{
+    Row *rows = (Row *)self;
+    for (int i = 0; i < 2; i++) {
+        if (rows[i].d[0x628d]) {
+            u8 k = rows[i].d[0x628c];
+            (self->*data_ov006_021416c0[k])(i);
+        }
+    }
+}

--- a/src/func_ov007_020bfc54.c
+++ b/src/func_ov007_020bfc54.c
@@ -1,0 +1,28 @@
+extern void func_ov007_020b3edc(int size);
+extern void func_ov007_020c8b04(void *p);
+extern void func_ov007_020bc53c(void *p);
+extern void _ZN6Player17St_EndingFly_MainEv(void *p);
+
+extern char *data_ov007_02104bd8;
+
+void func_ov007_020bfc54(void)
+{
+    func_ov007_020b3edc(0x24);
+
+    if (*(void **)data_ov007_02104bd8 != 0) {
+        func_ov007_020c8b04(*(void **)data_ov007_02104bd8);
+        *(int *)data_ov007_02104bd8 = 0;
+    }
+
+    if (*(void **)(data_ov007_02104bd8 + 4) != 0) {
+        func_ov007_020bc53c(*(void **)(data_ov007_02104bd8 + 4));
+        *(int *)(data_ov007_02104bd8 + 4) = 0;
+    }
+
+    if (data_ov007_02104bd8 == 0) {
+        return;
+    }
+
+    _ZN6Player17St_EndingFly_MainEv(data_ov007_02104bd8);
+    data_ov007_02104bd8 = 0;
+}

--- a/src/func_ov090_02133200.c
+++ b/src/func_ov090_02133200.c
@@ -1,0 +1,23 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+
+extern s32 Vec3_Dist(void* a, void* b);
+extern s16 Vec3_HorzAngle(void* a, void* b);
+extern int ApproachAngle(s16* angle, int target, int invFactor, int maxDelta, int minDelta);
+extern int func_ov090_021332e8(void* c, void* p);
+
+extern int data_ov090_02134584[];
+
+int func_ov090_02133200(char* c)
+{
+    if (Vec3_Dist(c + 0x5c, c + 0x374) > 0x3e8000) {
+        *(u16*)(c + 0x100) = 0x32;
+        *(s16*)(c + 0x384) = Vec3_HorzAngle(c + 0x5c, c + 0x374);
+    }
+    ApproachAngle((s16*)(c + 0x94), *(s16*)(c + 0x384), 1, 0x100, 0x200);
+    if (*(u16*)(c + 0x100) == 0)
+        func_ov090_021332e8(c, data_ov090_02134584);
+    return 1;
+}

--- a/src/func_ov098_0213a17c.cpp
+++ b/src/func_ov098_0213a17c.cpp
@@ -1,0 +1,32 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+}
+extern "C" void func_ov098_0213a17c(char* c);
+void func_ov098_0213a17c(char* c) {
+    Vector3 vec;
+    Vector3 vec2;
+    vec.x = *(int*)(c + 0x5c);
+    vec.y = *(int*)(c + 0x60);
+    vec.z = *(int*)(c + 0x64);
+    vec.y += 0x32000;
+    unsigned int id = 0x48;
+    int flag = (*(unsigned short*)(c + 0xc) == 0x8b);
+    if (flag) {
+        id = 0x49;
+    }
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(id, vec.x, vec.y, vec.z);
+    ((int*)&vec2)[0] = ((int*)&vec)[0];
+    ((int*)&vec2)[1] = ((int*)&vec)[1];
+    ((int*)&vec2)[2] = ((int*)&vec)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(c, vec2);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(c + 0x74));
+    *(short*)(c + 0x33a) = 0x1e;
+    *(int*)(c + 0x5c) = *(int*)(c + 0x320);
+    *(int*)(c + 0x60) = *(int*)(c + 0x324);
+    *(int*)(c + 0x64) = *(int*)(c + 0x328);
+    *(char*)(c + 0x340) = 0;
+}


### PR DESCRIPTION
Five functions, src-only, +128/-0: `func_ov006_020d6278`, `_ZN6PlayerD2Ev`, `func_ov007_020bfc54`, `func_ov098_0213a17c`, `func_ov090_02133200`. All byte-MATCH (independent oracle re-verify at bank time) and linkcheck-VERIFIED, 0 wrong destinations, 0 blind. Claims-coordinated: all 25 ranges in the batch were locked per-function before dispatch and released after landing, fully disjoint from your concurrent locks.

## Where these came from
Rescanning the small band (0x40-0x100) after this week's corpus growth surfaced fresh sim 0.70-0.94 twins — new matches keep creating new siblings, so drained-looking small bands are worth a rescan after every big merge. All five landed on the **first attempt**: at this sim level the sibling scaffold is essentially the answer (`PlayerD2Ev` is the matched `PlayerD0Ev` minus the trailing `Memory::Deallocate`; the others rode PMF-dispatch / teardown / Vector3-copy / Vec3-geometry shapes).

## Sonnet 5 vs Opus A/B (same batch, controlled)
The 25 candidates were interleaved by similarity rank into two halves, so both models saw the same difficulty profile — same worklist rows, same prompts/tooling (`sched_run.js`), same effort:

| | Sonnet 5 | Opus |
|---|---|---|
| landed / attempted | **5/13 (38%)** | 0/12 bankable (1 byte-match, see below) |
| output tokens / landed | **134K** | 874K |
| wall clock | 12.4 min | 57 min |
| attempts per land | 1.0 (all first-try) | — |

Notes on interpretation:
- **The misses were not a capability gap.** All 20 misses on both sides are the same documented mwccarm floor (materialized-RMW / regalloc, `notes/mwccarm-codegen.md`), at 1-18 divergences with correct wall diagnoses. Extra reasoning can't move a compiler floor — consistent with the runbook's claim that the floor is model-independent, and with your earlier Sonnet≈Opus finding. Small functions hit the wall proportionally more often: one un-reproducible RMW poisons the whole function, which is why a 0.9-sim band still yields "only" ~38%.
- **Opus's one byte-match was an inline-`asm` hatch** for `func_ov085_0212d8ec` (camera setup): it couldn't reproduce a phantom 0x1c stack frame from C and emitted assembly, which matches by construction. We didn't bank it — the repo's asm precedent (`ARMSaveContext`, `Copy32Bytes`, ...) covers genuine hand-asm routines, not game logic. Instead we transcribed the asm back to C and ingested it as a near-miss seed, where it scores **div=2** (top of the refine queue). Flagging in case you want a stated policy line in the runbook about asm hatches.
- Opus's wall *diagnoses* were marginally sharper (e.g. it isolated `func_ov033_0211123c` to a single value-numbering fold, div=1), so there may be a niche for it on hard-residue diagnosis — but at 6.5x the cost per landed match, Sonnet 5 stays the right default for volume matching.

The 20 near-misses (+ the div=2 transcription seed) are ingested in `nearmiss/db.jsonl` on our fork's main if you want them — kept out of this PR per the src-only convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DL5gbYkvGdYWYJHiBdv4De