### PR TITLE
Match 10 PMF-dispatch functions across ov002/ov006 (two-stage Sonnet→Opus batch)

### DIFF
--- a/src/func_ov002_020f3740.cpp
+++ b/src/func_ov002_020f3740.cpp
@@ -1,0 +1,9 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+extern PMF data_ov002_02110e9c[];
+
+extern "C" void func_ov002_020f3740(C* self, int idx) {
+    unsigned char sel = *((unsigned char*)((char*)self + idx * 0x30 + 0x15e));
+    (self->*data_ov002_02110e9c[sel])(idx);
+}

--- a/src/func_ov006_020d65c8.cpp
+++ b/src/func_ov006_020d65c8.cpp
@@ -1,0 +1,19 @@
+//cpp
+typedef unsigned char u8;
+class C;
+typedef void (C::*PMF)(int);
+class C { public: int dummy; };
+struct Row { u8 d[0x10]; };
+
+extern "C" PMF data_ov006_02141680[];
+
+extern "C" void func_ov006_020d65c8(C *self)
+{
+    Row *rows = (Row *)self;
+    for (int i = 0; i < 2; i++) {
+        if (rows[i].d[0x626d]) {
+            u8 k = rows[i].d[0x626c];
+            (self->*data_ov006_02141680[k])(i);
+        }
+    }
+}

--- a/src/func_ov006_020d7c00.cpp
+++ b/src/func_ov006_020d7c00.cpp
@@ -1,0 +1,12 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+struct Entry { PMF pmf; };
+extern "C" Entry data_ov006_02141708[];
+struct Elem { char pad[0x40]; };
+struct C {};
+extern "C" void func_ov006_020d7c00(C* c, int i){
+  Elem* e = (Elem*)c + i;
+  unsigned char idx = *((unsigned char*)e + 0x469b);
+  (c->*(data_ov006_02141708[idx].pmf))(i);
+}

--- a/src/func_ov006_020e1214.cpp
+++ b/src/func_ov006_020e1214.cpp
@@ -1,0 +1,13 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+struct Entry { PMF pmf; };
+extern "C" Entry data_ov006_021418f0[];
+
+#define F1E(b,i) (*(unsigned char*)((char*)(b) + 0x47aa + (i)*0x24))
+
+extern "C" void func_ov006_020e1214(char *base, int idx)
+{
+    unsigned char state = F1E(base, idx);
+    (((C*)base)->*data_ov006_021418f0[state].pmf)(idx);
+}

--- a/src/func_ov006_020e4744.cpp
+++ b/src/func_ov006_020e4744.cpp
@@ -1,0 +1,10 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+extern "C" PMF data_ov006_021419b8[];
+
+extern "C" void func_ov006_020e4744(char *o, int i)
+{
+    unsigned char idx = *(unsigned char *)(o + i * 0x24 + 0x48de);
+    (((C *)o)->*data_ov006_021419b8[idx])(i);
+}

--- a/src/func_ov006_020e8a44.cpp
+++ b/src/func_ov006_020e8a44.cpp
@@ -1,0 +1,19 @@
+//cpp
+typedef unsigned char u8;
+class C;
+typedef void (C::*PMF)(int);
+class C { public: int dummy; };
+struct Row { u8 d[0x20]; };
+
+extern "C" PMF data_ov006_02141f1c[];
+
+extern "C" void func_ov006_020e8a44(C *self)
+{
+    Row *rows = (Row *)self;
+    for (int i = 0; i < 0x14; i++) {
+        if (rows[i].d[0x52d4]) {
+            u8 k = rows[i].d[0x52d9];
+            (self->*data_ov006_02141f1c[k])(i);
+        }
+    }
+}

--- a/src/func_ov006_020f0ba0.cpp
+++ b/src/func_ov006_020f0ba0.cpp
@@ -1,0 +1,10 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+struct Entry { PMF pmf; };
+extern "C" Entry data_ov006_0214221c[];
+struct Row { unsigned char tag; char pad[0x17]; };
+struct C { char pad[0x47b7]; Row rows[1]; };
+extern "C" void func_ov006_020f0ba0(C* c, int i){
+  (c->*(data_ov006_0214221c[c->rows[i].tag].pmf))(i);
+}

--- a/src/func_ov006_02119eec.cpp
+++ b/src/func_ov006_02119eec.cpp
@@ -1,0 +1,19 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+struct Entry { PMF pmf; };
+extern "C" Entry data_ov006_02142db0[];
+
+struct Elem {
+  unsigned char idx;
+  char pad[0x23];
+};
+
+struct C {
+  char pad[0x51d1];
+  Elem arr[1];
+};
+
+extern "C" void func_ov006_02119eec(C* c, int i){
+  (c->*(data_ov006_02142db0[c->arr[i].idx].pmf))(i);
+}

--- a/src/func_ov006_0211a0d8.cpp
+++ b/src/func_ov006_0211a0d8.cpp
@@ -1,0 +1,13 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+struct Entry { PMF pmf; };
+extern "C" Entry data_ov006_02142d08[];
+struct Sub { unsigned char idx; char pad[0x23]; };
+struct C {
+  char pad[0x51d1];
+  Sub arr[1];
+};
+extern "C" void func_ov006_0211a0d8(C* c, int i){
+  (c->*(data_ov006_02142d08[c->arr[i].idx].pmf))(i);
+}

--- a/src/func_ov006_0211a2c4.cpp
+++ b/src/func_ov006_0211a2c4.cpp
@@ -1,0 +1,8 @@
+//cpp
+struct C;
+typedef void (C::*PMF)(int);
+extern PMF data_ov006_02142cc0[];
+extern "C" void func_ov006_0211a2c4(C* c, int i){
+  unsigned char sel = *((unsigned char*)((char*)c + i*0x24 + 0x51d1));
+  (c->*data_ov006_02142cc0[sel])(i);
+}


### PR DESCRIPTION
Ten functions, src-only, +132/-0, all in the PMF-table-dispatch family from the 0x40-0x100 high-sim band. All byte-MATCH (independent oracle re-verify) and linkcheck-VERIFIED, 0 wrong destinations. Claims-coordinated: all 15 ranges in the batch locked per-function before dispatch, released after landing.

ov006 (9): `020d65c8`, `020d7c00`, `020e1214`, `020e4744`, `020e8a44`, `020f0ba0`, `02119eec`, `0211a0d8`, `0211a2c4` — ov002 (1): `020f3740`.

## The idiom that cracked this family (worth a codegen-notes line)
Several agents had filed these as the documented regperm floor — instruction stream byte-identical, registers consistently shifted (`r1/r2/r3` vs the ROM's `r2/r3/ip`). It's not a floor here: **declare the PMF as `void (C::*)(int)` and forward the index — `(c->*table[idx].pmf)(i)`**. Keeping `i` live in r1 through the `blx` forces the address temps into `r2/r3/ip`, matching the ROM exactly. Proven 7 times in this batch across both overlays. The zero-arg PMF variants (4 ov002 twins at div=11, where there's no argument to pin r1) are ingested in the near-miss DB.

## Two-stage batch economics
Sonnet 5 first pass: 6/15 at 67K tokens/landed. Then, **after banking those 6**, an Opus retry on the 9 failures: 4/9 at 69K/landed — the retry agents found the freshly-banked twins in `src/` and copied the int-param idiom (one agent cited `func_ov002_020f3740.cpp` by name). Retrying failures *after* the round's solutions land is a cheap second harvest; retrying before would have re-proven "walls."

Heads-up (details on PR #64): during this batch, `clone.py` and then `paramclone.py` each auto-banked the same 10 byte-identical ov006 dispatchers with wrong PMF-table symbols — 20/20 linkcheck-WRONG, all reverted. None of those are in this PR; the 10 here are the verified agent matches only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DL5gbYkvGdYWYJHiBdv4De