### PR TITLE
Automate the README progress bar with a GitHub Action

### DIFF
--- a/.github/workflows/update-progress.yml
+++ b/.github/workflows/update-progress.yml
@@ -1,0 +1,53 @@
+name: Update progress bar
+
+# Keeps the README "## Progress" bar in sync with the committed function
+# corpus. progress/matched.jsonl is git-ignored (local-only, per-contributor,
+# and known to drift stale), so it never reaches this runner - instead
+# tools/progress.py --write-readme derives the matched set purely from
+# committed data: config/**/symbols.txt (every declared function) cross-
+# referenced against which of those names have a src/<name>.c[pp] file.
+#
+# Does NOT regenerate the treemap (docs/index.html, docs/progress-treemap.svg)
+# - that needs extracted/ files derived from a ROM dump, which never exists on
+# a hosted runner. Refresh the treemap locally with `python tools/treemap.py
+# --out docs/index.html --svg docs/progress-treemap.svg` and commit it by hand.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "config/**/symbols.txt"
+      - "src/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-progress
+  cancel-in-progress: false
+
+jobs:
+  update-progress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Refresh README progress bar
+        run: python tools/progress.py --write-readme
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "No progress change, nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "Refresh README progress bar"
+          git push

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 ## Progress
 
+<!-- progress:start -->
 ```
-Functions  ████████████████████░░░░░░░░░░  67.1%   7,648 / 11,390
-Code size  ███████████░░░░░░░░░░░░░░░░░░░  35.4%   789,964 / 2,234,028 bytes
+Functions  ████████████████████░░░░░░░░░░  67.4%   7,679 / 11,390
+Code size  ███████████░░░░░░░░░░░░░░░░░░░  35.6%   794,656 / 2,234,028 bytes
 ```
+<!-- progress:end -->
 
 Every arm-mode function in the game, drawn as a treemap. Each rectangle is one
 function sized by its byte count, green for matched and gray for unmatched, grouped

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -5,8 +5,17 @@ Matched functions are recorded in progress/matched.jsonl (one JSON object per
 line: {"addr","name","size","module","versions"}). De-duped by addr.
 
 Usage:
-    python tools/progress.py            # full report
-    python tools/progress.py --bar      # ready-to-paste README "## Progress" block
+    python tools/progress.py               # full report (uses the local ledger)
+    python tools/progress.py --bar         # ready-to-paste README "## Progress" block
+    python tools/progress.py --write-readme  # rewrite that block in place in README.md
+
+--bar and --write-readme deliberately do NOT use progress/matched.jsonl: that
+ledger is git-ignored (local-only, per-contributor, and known to drift stale -
+see notes/agent-decomp-knowledge-base.md). Instead they derive the matched set
+from committed data alone (config/**/symbols.txt cross-referenced against which
+functions have a src/<name>.c[pp] file), so the number is reproducible on a
+fresh checkout with no ROM and no local state - which is what the hosted
+update-progress.yml workflow needs.
 """
 import json
 import pathlib
@@ -15,9 +24,14 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
+SRC = REPO / "src"
 MATCHED = REPO / "progress" / "matched.jsonl"
+README = REPO / "README.md"
+README_START = "<!-- progress:start -->"
+README_END = "<!-- progress:end -->"
 
 FUNC_RE = re.compile(r"kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\)")
+FUNC_NAME_RE = re.compile(r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\)")
 
 
 def totals():
@@ -39,6 +53,25 @@ def totals():
             n += m_n
             total_bytes += m_b
     return n, total_bytes, per_module
+
+
+def synced_from_src():
+    """Matched set derived only from committed data: a function counts as
+    matched if config declares it and src/<name>.c or src/<name>.cpp exists.
+    Returns (done_n, done_b, n, total_bytes)."""
+    n = total_bytes = done_n = done_b = 0
+    for sym in CONFIG.rglob("symbols.txt"):
+        for line in sym.read_text(errors="ignore").splitlines():
+            m = FUNC_NAME_RE.match(line)
+            if not m:
+                continue
+            name, sz = m.group(1), int(m.group(2), 16)
+            n += 1
+            total_bytes += sz
+            if (SRC / f"{name}.c").is_file() or (SRC / f"{name}.cpp").is_file():
+                done_n += 1
+                done_b += sz
+    return done_n, done_b, n, total_bytes
 
 
 def matched():
@@ -66,15 +99,38 @@ def bar(done, tot, width=30):
     return "█" * filled + "░" * (width - filled)
 
 
+def bar_block(done_n, n, done_b, tb):
+    """The fenced ``` block shown under the README "## Progress" heading."""
+    lines = [
+        "```",
+        f"Functions  {bar(done_n, n)}  {100*done_n/n:4.1f}%   {done_n:,} / {n:,}",
+        f"Code size  {bar(done_b, tb)}  {100*done_b/tb:4.1f}%   {done_b:,} / {tb:,} bytes",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def write_readme(done_n, n, done_b, tb):
+    """Replace the text between the progress markers in README.md in place."""
+    text = README.read_text(encoding="utf-8")
+    start = text.index(README_START) + len(README_START)
+    end = text.index(README_END)
+    new_text = text[:start] + "\n" + bar_block(done_n, n, done_b, tb) + "\n" + text[end:]
+    if new_text != text:
+        README.write_text(new_text, encoding="utf-8")
+        return True
+    return False
+
+
 def main():
-    n, tb, per = totals()
-    done = matched()
-    done_n = len(done)
-    # ledger sizes drift between int and hex-string across writers; accept both
-    done_b = sum(int(s, 0) if isinstance(s := o.get("size", 0), str) else int(s)
-                 for o in done.values())
+    if "--write-readme" in sys.argv:
+        done_n, done_b, n, tb = synced_from_src()
+        changed = write_readme(done_n, n, done_b, tb)
+        print(f"README.md {'updated' if changed else 'already up to date'}")
+        return
 
     if "--bar" in sys.argv:
+        done_n, done_b, n, tb = synced_from_src()
         # ready-to-paste README "## Progress" block; reconfigure stdout so the
         # block characters print on a Windows (cp1252) console
         try:
@@ -82,11 +138,15 @@ def main():
         except Exception:
             pass
         print("## Progress\n")
-        print("```")
-        print(f"Functions  {bar(done_n, n)}  {100*done_n/n:4.1f}%   {done_n:,} / {n:,}")
-        print(f"Code size  {bar(done_b, tb)}  {100*done_b/tb:4.1f}%   {done_b:,} / {tb:,} bytes")
-        print("```")
+        print(bar_block(done_n, n, done_b, tb))
         return
+
+    n, tb, per = totals()
+    done = matched()
+    done_n = len(done)
+    # ledger sizes drift between int and hex-string across writers; accept both
+    done_b = sum(int(s, 0) if isinstance(s := o.get("size", 0), str) else int(s)
+                 for o in done.values())
 
     print("=== SM64DS decomp progress ===")
     print(f"  functions : {done_n:,} / {n:,}  ({100*done_n/n:.4f}%)")


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/update-progress.yml`: on every push to `main` touching `config/**/symbols.txt` or `src/**`, it runs `tools/progress.py --write-readme` to refresh the `## Progress` bar in README.md and commits the change if the numbers moved. Also runnable manually via `workflow_dispatch`.
- `tools/progress.py` gains `synced_from_src()`, used by `--bar` and `--write-readme`: it computes the matched set from `config/**/symbols.txt` cross-referenced against which functions have a `src/<name>.c[pp]` file, so it works from a plain checkout with nothing else needed. The full local report (`python tools/progress.py`, no flags) is unchanged.

## Test plan
- [x] Ran `tools/progress.py --write-readme` in a clean worktree checked out from `origin/main` with no `progress/` directory present (simulating the hosted runner) - produced correct numbers and rewrote the README block.
- [x] Confirmed idempotency: running it a second time reports "already up to date" with no further diff.
- [ ] Maintainer confirms the workflow permissions (`contents: write` via the default `GITHUB_TOKEN`) are acceptable for auto-committing to `main`.