### PR TITLE
Match func_ov085_0212aaec (ov085, 0x0212aaec)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -22,3 +22,4 @@ it is fair to take over: ping the claimant first.
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
+| ov085 func_ov085_0212aaec (0x0212aaec, size 0x150) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov085_0212aaec.c
+++ b/src/func_ov085_0212aaec.c
@@ -1,0 +1,62 @@
+typedef short s16;
+typedef int Fix12;
+struct Vector3 { int x, y, z; };
+
+extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
+extern int _ZN6Player12GetTalkStateEv(void *p);
+extern int _Z14ApproachLinearRsss(s16 *p, s16 a, s16 b);
+extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12 dist, int loop);
+extern void _ZN7Message11PrepareTalkEv(void);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *self, void *ab, unsigned int id, const struct Vector3 *v, unsigned int a, unsigned int b);
+extern void _ZN7Message7EndTalkEv(void);
+extern int func_ov085_0212bc78(void *c, void *p);
+
+extern int data_ov085_021306bc[];
+
+int func_ov085_0212aaec(char *self)
+{
+    void *player;
+    int *pq;
+    struct Vector3 pos;
+    struct Vector3 pp;
+    s16 angle;
+    unsigned int id;
+
+    player = *(void **)(self + 0x460);
+    pq = (int *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    pos.x = *(int *)(self + 0x5c);
+    pos.y = *(int *)(self + 0x60);
+    pos.z = *(int *)(self + 0x64);
+    pp.x = pq[0];
+    pp.y = pq[1];
+    pp.z = pq[2];
+    angle = Vec3_HorzAngle((struct Vector3 *)(self + 0x5c), &pp);
+
+    id = 0x139;
+    switch (_ZN6Player12GetTalkStateEv(player)) {
+    case 0:
+        pos.y = pos.y + 0x46000;
+        if (*(int *)(self + 0x43c) == 7) {
+            id = 0x13d;
+        }
+        if (*(int *)(self + 0x43c) == 6) {
+            id = 0x13a;
+        }
+        if (_Z14ApproachLinearRsss((s16 *)(self + 0x94), angle, 0x800)) {
+            if (_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x26, 0x12, 0x7f, 0x15ccc, 0)) {
+                _ZN7Message11PrepareTalkEv();
+                _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(player, self, id, &pos, 0, 0);
+            }
+        }
+        break;
+    case 1:
+        break;
+    default:
+        if (_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x26, 0x7f, 0, 0x7444, 0)) {
+            _ZN7Message7EndTalkEv();
+            func_ov085_0212bc78(self, data_ov085_021306bc);
+        }
+        break;
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary

Matches \unc_ov085_0212aaec\ in overlay **ov085** at **0x0212aaec** (size **0x150**).

Talk-state handler for an ov085 actor: copies the linked player's position into a stack \Vector3\, runs \Vec3_HorzAngle\, then switches on \Player::GetTalkState\ to drive approach-angle, sound, and message begin/end paths.

## Compiler

- **mwccarm 1.2/sp2p3**
- Flags: \-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc\

## Verification

\python tools/fdiff.py --c src/func_ov085_0212aaec.c --name func_ov085_0212aaec --module ov085 --addr 0x0212aaec --size 0x150\ reports **MATCH** (0 mismatches / 84 words).

## Matching note

The player-position copy requires the u64-mask pointer idiom on \player + 0x5c\ so mwccarm keeps the materialized \dd r3, r5, #0x5c\ base and loads \pp.x\ via \ldr r2, [r3]\ instead of folding to \ldr r2, [r5, #0x5c]\.