### PR TITLE
Match func_ov001_020ab550, func_ov002_020ec0a4, func_02008080

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -22,3 +22,6 @@ it is fair to take over: ping the claimant first.
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
+| ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |
+| ov002 func_ov002_020ec0a4 (0x020ec0a4, size 0x134) | Cursor/Grok | 2026-07-02 | done |
+| arm9 func_02008080 (0x02008080, size 0x30) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_02008080.c
+++ b/src/func_02008080.c
@@ -1,15 +1,13 @@
-// NONMATCHING: base materialization / addressing (div=3). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Actor;
-
 extern struct Actor *func_0200e55c(unsigned int ownerID);
 
 int func_02008080(void *param_1)
 {
-    struct Actor *a = func_0200e55c(0x13);
-    unsigned int *dst = (unsigned int *)((unsigned char *)param_1 + 0x90);
-    unsigned int val = *(unsigned int *)((unsigned char *)a + 0x60);
-    *dst = *dst + val;
+    struct Actor *a;
+    int *dst;
+
+    a = func_0200e55c(0x13);
+    dst = (int *)(((int)param_1 + 0x90) & 0xFFFFFFFFFFFFFFFF);
+    *dst = *dst + *(int *)((char *)a + 0x60);
     return 1;
 }

--- a/src/func_ov001_020ab550.c
+++ b/src/func_ov001_020ab550.c
@@ -1,0 +1,26 @@
+extern int data_0208ee44;
+
+void func_ov001_020ab550(char *c)
+{
+    int v;
+    int *p;
+
+    v = *(int *)(c + 0xc);
+    if (v <= 0) {
+        return;
+    }
+    p = (int *)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+    *p = *p - data_0208ee44;
+    v = *(int *)(c + 0xc);
+    if (v > 0) {
+        return;
+    }
+    if (*(unsigned char *)(c + 0x10) != 0) {
+        *(unsigned char *)(c + 0x10) = 0;
+    } else {
+        *(unsigned char *)(c + 0x10) = 1;
+    }
+    if (*(int *)(c + 0x14) >= 1) {
+        *(unsigned char *)(c + 0x11) = 1;
+    }
+}

--- a/src/func_ov002_020ec0a4.cpp
+++ b/src/func_ov002_020ec0a4.cpp
@@ -1,0 +1,63 @@
+//cpp
+extern "C" {
+struct Vec3 { int x, y, z; };
+extern int data_ov002_02110a48;
+extern int data_0209f318;
+extern int data_0209f43c;
+extern int data_0209b3ec;
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern int _ZN7Clipper13Func_02015560ER9Matrix4x3R7Vector35Fix12IiES3_(void *a, void *b, void *c, int d, void *e);
+extern void _ZN9ModelBase12ApplyOpacityEj(void *self, unsigned int op, int z);
+}
+
+struct ModelBase {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void m(int arg);
+};
+
+extern "C" int func_ov002_020ec0a4(char *self)
+{
+    char *base = (char *)data_0209f318;
+    int *iter = &data_ov002_02110a48;
+    char *sl = self + 0xd4;
+    int i = 0;
+    int z5 = 0;
+    int z4 = 0;
+    int c1f = 0x1f;
+    int c1e000 = 0x1e000;
+    Vec3 buf;
+    int *sb;
+    char *r8;
+    char *r0;
+
+    do {
+        r8 = sl + 0x1c;
+        Matrix4x3_FromRotationY(r8, *(short *)(base + 0x17c));
+        sb = (int *)*iter;
+        while (sb != 0) {
+            int v = _ZN7Clipper13Func_02015560ER9Matrix4x3R7Vector35Fix12IiES3_(
+                        &data_0209f43c, &data_0209b3ec, sb, c1e000, &buf);
+            if (v > 0x11000 && v < 0x578000) {
+                int op = c1f;
+                if (v < 0x2f000) {
+                    op = ((v - 0x10000) >> 12) & 0xff;
+                }
+                _ZN9ModelBase12ApplyOpacityEj(sl, op, z5);
+                r0 = sl;
+                *(int *)(r8 + 0x24) = sb[0];
+                *(int *)(r8 + 0x28) = sb[1] - 0x1e000;
+                *(int *)(r8 + 0x2c) = sb[2];
+                ((ModelBase *)r0)->m(z4);
+            }
+            sb = (int *)sb[0x12];
+        }
+        sl += 0x50;
+        i++;
+        iter++;
+    } while (i < 5);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Three byte-identical matches, all verified with **mwccarm 1.2/sp2p3** and flags \-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc\.

| Function | Module | Address | Size | Verify |
|---|---|---|---|---|
| \unc_ov001_020ab550\ | ov001 | 0x020ab550 | 0x60 | 0/24 mismatches |
| \unc_ov002_020ec0a4\ | ov002 | 0x020ec0a4 | 0x134 | 0/77 mismatches |
| \unc_02008080\ | arm9 | 0x02008080 | 0x30 | 0/12 mismatches |

## Notes

- **func_ov001_020ab550**: Leaf decrement/toggle on timer fields. Materialized \dd r3,r0,#0xc\ via u64-mask pointer idiom on \c+0xc\.
- **func_ov002_020ec0a4**: Clipper-driven opacity application loop over five model slots. Vtable call at offset 0x14 matched with \//cpp\ dummy-slot \ModelBase::m(int)\ virtual dispatch (not C fn-pointer cast).
- **func_02008080**: Adds owner actor Y (\unc_0200e55c(0x13)\ + 0x60) into \param+0x90\. Replaces prior NONMATCHING src; materialized \dd r3,r4,#0x90\ via u64-mask on \param+0x90\.