### PR TITLE
Match func_ov010_021112b4 and func_ov078_021250d0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,794 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,924 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,795 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,964 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,794 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,924 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/src/func_ov010_021112b4.c
+++ b/src/func_ov010_021112b4.c
@@ -1,0 +1,25 @@
+extern char *func_ov010_0211139c(char *c);
+
+#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+
+void func_ov010_021112b4(char *c)
+{
+    char *p = func_ov010_0211139c(c);
+    short *a;
+    short *b;
+    int limit;
+
+    if (p == 0) return;
+
+    *(unsigned char *)(p + 0x3aa) = 0;
+    a = (short *)LAUNDER_ADDR(c + 0x3a8);
+    b = (short *)LAUNDER_ADDR(c + 0x90);
+    limit = 0x3d00;
+    *a = *a - 0x100;
+    *b = *b + *(volatile short *)(c + 0x300 + 0xa8);
+
+    if (*(volatile short *)(c + 0x90) < -limit) {
+        *(short *)(c + 0x90) = -limit;
+        *(int *)(c + 0x3a0) = 2;
+    }
+}

--- a/src/func_ov078_021250d0.c
+++ b/src/func_ov078_021250d0.c
@@ -1,0 +1,11 @@
+#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+
+int func_ov078_021250d0(char *c)
+{
+    int *flags = (int *)LAUNDER_ADDR(c + 0x354);
+    *flags |= 2;
+    *(int *)(c + 0x9c) = 0;
+    *(int *)(c + 0x98) = 0;
+    *(unsigned char *)(c + 0x499) = 0;
+    return 1;
+}


### PR DESCRIPTION
## Summary

Matches two functions:

- `func_ov010_021112b4` in overlay **ov010** at **0x021112b4** (size **0x6c**)
- `func_ov078_021250d0` in overlay **ov078** at **0x021250d0** (size **0x28**)

`func_ov010_021112b4` clears the linked actor flag, adjusts the `0x3a8`/`0x90` halfword fields, clamps the result at `-0x3d00`, and switches state to `2` on clamp.

`func_ov078_021250d0` sets a `0x354` flag bit, clears movement fields at `0x98`/`0x9c`, clears byte `0x499`, and returns `1`.

## Compiler

- **mwccarm 1.2/sp2p3**
- Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Verification

`python tools/match.py --c C:\tmp\sm64ds-pr-match-ov010-021112b4\src\func_ov010_021112b4.c --func func_ov010_021112b4 --addr 0x021112b4 --size 0x6c --bin extracted\overlays\overlay_0010.bin --base 0x021111a0 --module ov010 --strict-relocs --brief` reports **MATCH**.

`python tools/match.py --c C:\tmp\sm64ds-pr-match-ov010-021112b4\src\func_ov078_021250d0.c --func func_ov078_021250d0 --addr 0x021250d0 --size 0x28 --bin extracted\overlays\overlay_0078.bin --base 0x02123740 --module ov078 --strict-relocs --brief` reports **MATCH**.

`python tools/linkcheck.py --name func_ov010_021112b4 --addr 0x021112b4 --size 0x6c --module ov010` reports **VERIFIED** with no diffs and `blind: 0`.

`python tools/linkcheck.py --name func_ov078_021250d0 --addr 0x021250d0 --size 0x28 --module ov078` reports **VERIFIED** with no diffs and `blind: 0`.

`git diff --check` passes.

## Matching note

Both functions use the u64-mask pointer laundering idiom where the ROM materializes an address base that mwccarm otherwise tends to fold into direct `[base, #offset]` accesses.
