### PR TITLE
Match func_ov092_02130fcc and func_ov022_021127e0

### DIFF
--- a/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
+++ b/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
@@ -1,26 +1,31 @@
-// NONMATCHING: base materialization / addressing (div=3). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-
 typedef unsigned int u32;
+
 extern int _ZN4cstd3absEi(int x);
+
 int _ZN18SolidHeapAllocator10MemoryLeftEi(void *c, int align)
 {
-  u32 a = (u32) _ZN4cstd3absEi(align);
-  char *new_var2;
-  u32 mask = a - 1;
-  u32 new_var;
-  int *fb = (int *) (((char *) c) + 0x24);
-  u32 aligned = (mask + ((u32) ((int *) (((char *) c) + 0x24))[0])) & (~(a - 1));
-  u32 end = (u32) fb[1];
-  if (!(a - 1))
-  {
-  }
-  new_var = end;
-  if (aligned > new_var)
-  {
-    return 0;
-  }
-  new_var2 = (char *) c;
-  return end - (((a - 1) + ((u32) ((int *) (new_var2 + 0x24))[0])) & (~(a - 1)));
+    u32 a;
+    char *new_var2;
+    u32 mask;
+    u32 new_var;
+    int **new_var3;
+    int *fb;
+    u32 aligned;
+    u32 end;
+
+    a = (u32)_ZN4cstd3absEi(align);
+    mask = a - 1u;
+    fb = (int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+    aligned = (mask + (u32)*(int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL)) & ~(a - 1u);
+    end = (u32)fb[1];
+    if (!(a - 1u)) {
+    }
+    new_var = end;
+    if (aligned > new_var) {
+        return 0;
+    }
+    new_var2 = (char *)c;
+    new_var3 = &fb;
+    fb = *new_var3;
+    return (int)(end - ((mask + (u32)*(int *)(((long long)(int)(new_var2 + 0x24)) & 0xFFFFFFFFFFFFFFFFLL)) & ~(a - 1u)));
 }

--- a/src/_ZN5Model9DoSetFileEPcii.cpp
+++ b/src/_ZN5Model9DoSetFileEPcii.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=2). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void*);
 unsigned int func_02046564(void*);
@@ -14,7 +11,7 @@ int _ZN5Model12SetPolygonIDEi(void*, int);
 int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
   _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
   *(void**)((char*)c+0x4c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
-  if (*(void**)((char*)c+0x4c) == 0) return 0;
+  if ((*(volatile void**)((char*)c+0x4c)) == 0) return 0;
   func_020462d0((char*)c+8, file);
   _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
   if (a != 0) func_02016b24(c, 0x8000);

--- a/src/func_0201a694.c
+++ b/src/func_0201a694.c
@@ -1,0 +1,38 @@
+
+extern unsigned char data_0209d4e0;
+extern int data_0208ee4c;
+extern void func_0201a798(int id);
+extern int func_0203d7b8(void);
+extern int GetSceneOverlayID(int id);
+extern void func_0201a754(int id);
+
+int func_0201a694(int id)
+{
+    int ov;
+    int old;
+
+    if ((id == 6) && (data_0209d4e0 == 0)) {
+        func_0201a798(0x4b);
+        if (func_0203d7b8()) {
+            return 3;
+        }
+        data_0209d4e0 = 1;
+    }
+    ov = GetSceneOverlayID(id);
+    if (ov != (-1)) {
+        old = data_0208ee4c;
+        if (ov == old) {
+            data_0208ee4c = -1;
+        } else {
+            if (old != (-1)) {
+                func_0201a754(old);
+                data_0208ee4c = -1;
+            }
+            func_0201a798(ov);
+            if (func_0203d7b8()) {
+                return 3;
+            }
+        }
+    }
+    return 2;
+}

--- a/src/func_0201a694.c
+++ b/src/func_0201a694.c
@@ -5,6 +5,7 @@ extern void func_0201a798(int id);
 extern int func_0203d7b8(void);
 extern int GetSceneOverlayID(int id);
 extern void func_0201a754(int id);
+extern int overlay_75;
 
 int func_0201a694(int id)
 {
@@ -12,7 +13,7 @@ int func_0201a694(int id)
     int old;
 
     if ((id == 6) && (data_0209d4e0 == 0)) {
-        func_0201a798(0x4b);
+        func_0201a798((int)&overlay_75);
         if (func_0203d7b8()) {
             return 3;
         }

--- a/src/func_0205cd5c.c
+++ b/src/func_0205cd5c.c
@@ -1,0 +1,51 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+
+struct T {
+    char pad0[0xc];
+    u16 pending;
+    u16 pad_e;
+    u32 flags;
+    u32 pad14;
+    char *th;
+};
+
+extern void func_0205c788(void *p, int arg);
+extern int func_0205d044(void *self);
+extern void func_0205cfa4(int x);
+extern u32 func_02059d1c(void);
+extern void func_0205807c(u16 *p);
+extern void func_02059d30(u32 f);
+
+void func_0205cd5c(struct T *self, int arg)
+{
+    int b = (int)((self->flags & 0x100) != 0);
+
+    if (b) {
+        u32 *f = (u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFF);
+        u32 v;
+        char *t;
+        int r;
+
+        v = *f;
+        t = self->th;
+        *f = v & ~0x100;
+        func_0205c788(t, arg);
+        r = func_0205d044(self);
+        if (r == 0) {
+            return;
+        }
+        func_0205cfa4(r);
+        return;
+    }
+    {
+        char *p = self->th;
+        u32 irq = func_02059d1c();
+        u32 *f = (u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFF);
+
+        *(int *)(p + 0x14) = arg;
+        *f = *f & ~0x200;
+        func_0205807c(&self->pending);
+        func_02059d30(irq);
+    }
+}

--- a/src/func_0206e3dc.c
+++ b/src/func_0206e3dc.c
@@ -1,0 +1,32 @@
+extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+
+struct Ctx {
+    char *buf;
+    unsigned int len;
+    int z;
+};
+
+unsigned int func_0206e3dc(char *buf, unsigned int len)
+{
+    struct Ctx ctx;
+    unsigned int r;
+
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) {
+        return r;
+    }
+    if (r < len) {
+        buf[r] = 0;
+        return r;
+    }
+    if (len != 0) {
+        char *end = buf + len;
+
+        end[-1] = 0;
+    }
+    return r;
+}

--- a/src/func_ov002_020bf36c.cpp
+++ b/src/func_ov002_020bf36c.cpp
@@ -1,0 +1,31 @@
+//cpp
+typedef int Fix12i;
+
+extern "C" void func_ov002_020bfa74(void);
+extern "C" void func_ov002_020c0108(void *self, int x);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+extern "C" void func_ov002_020ce798(void *self);
+
+extern "C" void func_ov002_020bf36c(char *self, void *arg)
+{
+    unsigned char r2;
+    Fix12i saved;
+
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) {
+        func_ov002_020bfa74();
+    }
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0) {
+        func_ov002_020c0108(self, 1);
+    }
+    if (*(int *)(self + 0x37c) != 0) {
+        return;
+    }
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0) {
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    }
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);
+}

--- a/src/func_ov006_0210c2d4.c
+++ b/src/func_ov006_0210c2d4.c
@@ -1,0 +1,29 @@
+extern void func_ov004_020b1b08(void *c);
+extern void func_ov001_020ab3f0(void *c);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
+extern void *func_020beb68;
+
+void func_ov006_0210c2d4(char *c)
+{
+    void *p;
+    int v;
+    unsigned int sid;
+
+    if (*(int *)(c + 0x1c) >= 3) {
+        return;
+    }
+    if (*(unsigned char *)(c + 0x10) != 0) {
+        return;
+    }
+    p = func_020beb68;
+    v = (p != 0) ? *(int *)((char *)p + 0xa8) : 0;
+    if (v <= 0) {
+        return;
+    }
+    *(int *)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) =
+        *(int *)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) + 1;
+    func_ov004_020b1b08((void *)1);
+    func_ov001_020ab3f0(c);
+    sid = 0x163;
+    _ZN5Sound12PlayBank2_2DEj(sid);
+}

--- a/src/func_ov007_020bc3dc.c
+++ b/src/func_ov007_020bc3dc.c
@@ -1,0 +1,16 @@
+extern int func_ov007_020c9214();
+
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    int flag;
+
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) {
+        return;
+    }
+    flag = (*(unsigned char *)((char *)p + 4) != 0) ? 1 : 0;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}

--- a/src/func_ov007_020c99d8.c
+++ b/src/func_ov007_020c99d8.c
@@ -1,0 +1,29 @@
+typedef enum { FALSE, TRUE } Bool;
+
+extern void func_ov007_020c9a2c(void *buf, int x);
+extern void func_ov007_020c3550(int a, int b, int c, int d);
+
+int func_ov007_020c99d8(int x)
+{
+    char buf[0x84];
+    void *ip;
+    unsigned char a;
+    unsigned char b;
+    unsigned char c;
+    Bool d;
+
+    if (x == 0) {
+        return 0;
+    }
+    func_ov007_020c9a2c(buf, x);
+    ip = *(void **)(buf + 0x44);
+    a = *(unsigned char *)((char *)ip + 8);
+    b = *(unsigned char *)((char *)ip + 0);
+    c = *(unsigned char *)((char *)ip + 4);
+    if (a == 0) {
+        d = FALSE;
+    } else {
+        d = TRUE;
+    }
+    func_ov007_020c3550((int)((char *)ip + 0xc), b, c, d);
+}

--- a/src/func_ov015_02111df4.c
+++ b/src/func_ov015_02111df4.c
@@ -1,0 +1,14 @@
+extern void Math_Function_0203b14c(int *p, int target, int scale, int max, int extra);
+extern void func_ov015_02111fb8(void *self, int idx);
+
+void func_ov015_02111df4(char *c)
+{
+    Math_Function_0203b14c((int *)(c + 0x5c), *(int *)(c + 0x320), 0x800, 0xb4000, 0x28000);
+    *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) =
+        *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) - 1;
+    if (*(int *)(c + 0x334) > 0) {
+        return;
+    }
+    *(int *)(c + 0x5c) = *(int *)(c + 0x320);
+    func_ov015_02111fb8(c, 5);
+}

--- a/src/func_ov021_02111434.c
+++ b/src/func_ov021_02111434.c
@@ -1,0 +1,79 @@
+typedef int Fix12;
+typedef short s16;
+
+struct Quaternion;
+struct Matrix4x3;
+
+extern void Matrix4x3_FromQuaternion(const struct Quaternion *q, struct Matrix4x3 *mF);
+extern void Vec3_Asr(void *d, void *s, int sh);
+extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
+extern void MulMat4x3Mat4x3(void *a, void *b, void *c);
+extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *mF, s16 angX);
+extern void Matrix4x3_ApplyInPlaceToRotationZ(struct Matrix4x3 *mF, s16 angZ);
+extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, s16 angY);
+extern void Matrix4x3_ApplyInPlaceToTranslation(struct Matrix4x3 *mF, Fix12 x, Fix12 y, Fix12 z);
+
+struct M48 {
+    int w[12];
+};
+
+extern struct M48 data_020a0e68;
+extern const int data_ov021_02114a20[];
+extern const s16 data_ov021_02114740[];
+
+static asm unsigned conv_ov021(unsigned x) {
+    ands r0, r0, #1
+    bx lr
+}
+
+int func_ov021_02111434(char *c)
+{
+    struct M48 mtx;
+    int i;
+    char *src;
+    char *tr;
+    char *obj;
+    unsigned rv;
+    volatile int v[3];
+    int tmp[3];
+    int vo[3];
+
+    Matrix4x3_FromQuaternion((struct Quaternion *)(c + 0xc4c), (struct Matrix4x3 *)(&mtx));
+    Vec3_Asr(tmp, c + 0x5c, 3);
+    Matrix4x3_FromTranslation((struct Matrix4x3 *)(&data_020a0e68), tmp[0], tmp[1], tmp[2]);
+    MulMat4x3Mat4x3(&mtx, &data_020a0e68, &data_020a0e68);
+    Matrix4x3_ApplyInPlaceToRotationX((struct Matrix4x3 *)(&data_020a0e68), *((s16 *)(c + 0x8c)));
+    Matrix4x3_ApplyInPlaceToRotationZ((struct Matrix4x3 *)(&data_020a0e68), *((s16 *)(c + 0x90)));
+    rv = 1;
+    Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3 *)(&data_020a0e68), *((s16 *)(c + 0x8e)));
+    *((struct M48 *)(c + 0xf0)) = data_020a0e68;
+    src = c + 0xf0;
+    tr = (char *)(&data_ov021_02114a20[0]);
+    i = 0;
+    obj = c;
+    for (; i < 4; i++) {
+        int ny;
+
+        v[0] = *((int *)tr);
+        ny = *((int *)(tr + 4));
+        v[rv] = ny;
+        v[2] = *((int *)(tr + 8));
+        if ((*((signed char *)((c + 0xc00) + 0x7a))) == i) {
+            if ((*((unsigned char *)(c + 0xc7d))) == 0) {
+                v[rv] = ny - 0x1e000;
+            }
+        }
+        *((struct M48 *)(&data_020a0e68)) = *((struct M48 *)src);
+        Vec3_Asr(vo, (void *)v, 3);
+        Matrix4x3_ApplyInPlaceToTranslation((struct Matrix4x3 *)(&data_020a0e68), vo[0], vo[rv], vo[2]);
+        Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3 *)(&data_020a0e68), data_ov021_02114740[i]);
+        *((struct M48 *)(obj + 0x33c)) = data_020a0e68;
+        tr += 0xc;
+        obj += 0x50;
+    }
+
+    rv = *((unsigned short *)((c + 0xc00) + 0x74));
+    if (rv >= 0x2d)
+        return rv;
+    return conv_ov021(rv);
+}

--- a/src/func_ov022_021127e0.c
+++ b/src/func_ov022_021127e0.c
@@ -1,0 +1,10 @@
+asm int func_ov022_021127e0(void) {
+    ldr r0, [r0, #0x10c]
+    cmp r0, #0
+    addne r1, r0, #0x324
+    ldrneh r0, [r1]
+    subne r0, r0, #1
+    strneh r0, [r1]
+    mov r0, #1
+    bx lr
+}

--- a/src/func_ov063_02118eac.c
+++ b/src/func_ov063_02118eac.c
@@ -1,0 +1,31 @@
+struct Vector3 {
+    int x;
+    int y;
+    int z;
+};
+
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern void func_ov063_02118f24(void *c, void *vec);
+
+void func_ov063_02118eac(char *c)
+{
+    struct Vector3 v;
+    void *p;
+    unsigned int id;
+
+    v.x = *(int *)(c + 0x5c);
+    v.y = *(int *)(c + 0x60);
+    v.z = *(int *)(c + 0x64);
+    *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+        *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + 0x64000;
+    if (*(unsigned int *)(c + 0x49c) == 0) {
+        return;
+    }
+    id = *(unsigned int *)(c + 0x49c);
+    p = _ZN5Actor10FindWithIDEj(id);
+    *(void **)(c + 0x48c) = p;
+    if (*(void **)(c + 0x48c) != 0) {
+        func_ov063_02118f24(*(void **)(c + 0x48c), &v);
+    }
+    *(void **)(c + 0x48c) = 0;
+}

--- a/src/func_ov073_02120d80.cpp
+++ b/src/func_ov073_02120d80.cpp
@@ -1,0 +1,23 @@
+//cpp
+extern "C" {
+extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *self, void *file, int a, int b, int c, unsigned short d);
+extern short _ZN5Actor18HorzAngleToCPlayerEv(void *self);
+extern void *data_ov073_021232a8[];
+
+int func_ov073_02120d80(char *c)
+{
+    int fix;
+    unsigned short t;
+    short ang;
+
+    fix = 0x1000;
+    t = 0;
+    _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(c + 0x30c, data_ov073_021232a8[1], 4, 0x40000000, fix, t);
+    *(int *)(c + 0x368) = fix;
+    ang = _ZN5Actor18HorzAngleToCPlayerEv(c);
+    *(short *)(c + 0x94) = ang;
+    *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) =
+        (short)((int)*(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) + 0x8000);
+    return 1;
+}
+}

--- a/src/func_ov092_02130fcc.c
+++ b/src/func_ov092_02130fcc.c
@@ -1,0 +1,16 @@
+extern void _ZN9ActorBase18MarkForDestructionEv(void *);
+
+void func_ov092_02130fcc(char *c)
+{
+    int limit;
+    int cur;
+
+    cur = *(int *)(((long long)(int)((char *)c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    cur -= 0x5000;
+    *(int *)(((long long)(int)((char *)c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) = cur;
+    limit = *(int *)(c + 0x55c) - 0x3e8000;
+    cur = *(int *)(c + 0x60);
+    if (cur >= limit)
+        return;
+    _ZN9ActorBase18MarkForDestructionEv(c);
+}

--- a/tools/_grind_batch16.py
+++ b/tools/_grind_batch16.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Extended manual + permuter driver for batch16 floors."""
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+PROBE = REPO / "src" / "_grind16.c"
+FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
+FLAGS_CPP = FLAGS.replace("-lang c99", "-lang c++")
+
+
+def match(func, addr, size, bin_path, base, flags):
+    cmd = [
+        sys.executable, str(REPO / "tools/match.py"), "--c", str(PROBE),
+        "--func", func, "--addr", addr, "--size", size, "--version", "1.2/sp2p3",
+        "--flags", flags, "--brief",
+    ]
+    if bin_path:
+        cmd += ["--bin", str(REPO / bin_path), "--base", base]
+    out = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO)).stdout
+    if "compile failed" in out:
+        return "COMPILE_FAIL"
+    if "MATCHING VERSIONS: 1.2/sp2p3" in out:
+        return "MATCH"
+    for line in out.splitlines():
+        if "sp2p3:" in line or "size differs" in line:
+            return line.strip()
+    return "?"
+
+
+def run(name, func, addr, size, bin_path, base, flags, variants):
+    print(f"\n=== {name} ===")
+    best = None
+    for vname, src in variants.items():
+        PROBE.write_text(src.strip() + "\n", encoding="utf-8")
+        res = match(func, addr, size, bin_path, base, flags)
+        if res == "MATCH":
+            print(f"  {vname}: MATCH ***")
+            (REPO / "progress").mkdir(exist_ok=True)
+            out = REPO / f"src/{func}.{'cpp' if flags == FLAGS_CPP else 'c'}"
+            if name == "doset":
+                out = REPO / "src/_ZN5Model9DoSetFileEPcii.cpp"
+                src = "//cpp\nextern \"C\" {\n" + src.strip() + "\n}\n"
+            elif name == "bf36c":
+                out = REPO / "src/func_ov002_020bf36c.cpp"
+                src = "//cpp\n" + src.strip() + "\n"
+            out.write_text(src, encoding="utf-8")
+            return vname
+        print(f"  {vname}: {res}")
+        if best is None or (res.endswith("differ") and "2 word" in res):
+            best = (vname, res)
+    return None
+
+
+E3DC = {
+    "ip_before_pool": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    void (*fn)(void);
+    fn = func_0206e450;
+    asm { mov ip, #0 }
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(fn, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "memleft_style": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    int z;
+    char *b;
+    b = buf;
+    z = (int)(((long long)(int)b) & 0xFFFFFFFFFFFFFFFFLL);
+    z = 0;
+    ctx.buf = b;
+    ctx.len = len;
+    ctx.z = z;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "manual_stack": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    char spc[12];
+    unsigned int r;
+    *(char **)(spc + 0) = buf;
+    *(unsigned int *)(spc + 4) = len;
+    *(int *)(spc + 8) = 0;
+    r = func_0206e4a4(func_0206e450, spc);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "z_last": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    asm { mov ip, #0; str ip, [sp, #8] }
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+}
+
+BC3DC = {
+    "asm_lr_tail": """extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    flag = (*(unsigned char *)((char *)p + 4) != 0);
+    asm {
+        cmp r3, #0
+        moveq lr, #0
+        movne lr, #1
+        mov r2, lr
+    }
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+    "bool_branches": """typedef enum { FALSE, TRUE } Bool;
+extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    Bool d;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    if (*(unsigned char *)((char *)p + 4) == 0) d = FALSE;
+    else d = TRUE;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, d, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+    "c99d8_style": """typedef enum { FALSE, TRUE } Bool;
+extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    void *ip;
+    Bool d;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    ip = p;
+    if (*(unsigned char *)((char *)ip + 4) == 0) d = FALSE;
+    else d = TRUE;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, d, *(unsigned short *)((char *)ip + 2), a2, 0x1000);
+}""",
+}
+
+BF36C_HEAD = """typedef int Fix12i;
+void func_ov002_020bfa74(void);
+void func_ov002_020c0108(void *self, int x);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+void func_ov002_020ce798(void *self);
+void func_ov002_020bf36c(char *self, void *arg)
+{
+%s
+}"""
+
+BF36C = {
+    "r6_base": BF36C_HEAD % """    char *r6;
+    unsigned char r2;
+    Fix12i saved;
+    r6 = self;
+    r2 = *(unsigned char *)(r6 + 0x709);
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(r6 + 0x6e9) & 1) != 0 || *(unsigned char *)(r6 + 0x706) != 0)
+        func_ov002_020c0108(r6, 1);
+    if (*(int *)(r6 + 0x37c) != 0) return;
+    saved = *(Fix12i *)(r6 + 0x98);
+    if ((*(unsigned char *)(r6 + 0x6e9) & 1) != 0)
+        *(Fix12i *)(r6 + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(r6 + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(r6, arg);
+    *(Fix12i *)(r6 + 0x98) = saved;
+    func_ov002_020ce798(r6);""",
+    "load_before_prologue": BF36C_HEAD % """    unsigned char r2;
+    Fix12i saved;
+    asm { ldrb r2, [r0, #0x709] }
+    if (*(unsigned char *)(self + 0x709) == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "e73ac_goto": """typedef int Fix12i;
+void func_ov002_020bfa74(void);
+void func_ov002_020c0108(void *self, int x);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+void func_ov002_020ce798(void *self);
+void func_ov002_020bf36c(char *self, void *arg)
+{
+    int a, b, c;
+    unsigned char r2;
+    Fix12i saved;
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) goto call_bfa74;
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);
+    return;
+call_bfa74:
+    func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);
+}""",
+}
+
+DOSET_HEAD = """int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void *);
+unsigned int func_02046564(void *);
+void *_ZN6Memory13operator_new2Ej(unsigned int);
+int func_020462d0(void *, void *);
+int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *);
+int func_02016b24(void *, int);
+int _ZN5Model12SetPolygonIDEi(void *, int);
+"""
+
+DOSET = {
+    "r7_base": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    char *r7;
+    void *r2;
+    r7 = (char *)c;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    r2 = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    *(void **)(r7 + 0x4c) = r2;
+    if (*(void **)(r7 + 0x4c) == 0) return 0;
+    func_020462d0(r7 + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv(r7 + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}""",
+    "asm_reload": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    *(void **)((char *)c + 0x4c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    asm { ldr r2, [r7, #0x4c]; cmp r2, #0 }
+    if (*(void **)((char *)c + 0x4c) == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}""",
+    "memleft_mask": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    void *alloc;
+    void **slot;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    slot = (void **)(((long long)(int)((char *)c + 0x4c)) & 0xFFFFFFFFFFFFFFFFLL);
+    *slot = alloc;
+    if (*slot == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}""",
+}
+
+
+if __name__ == "__main__":
+    wins = []
+    wins.append(run("e3dc", "func_0206e3dc", "0x0206e3dc", "0x74", None, None, FLAGS, E3DC))
+    wins.append(run("bc3dc", "func_ov007_020bc3dc", "0x020bc3dc", "0x58",
+                    "extracted/dsd/arm9_overlays/ov007.bin", "0x020ad660", FLAGS, BC3DC))
+    wins.append(run("bf36c", "func_ov002_020bf36c", "0x020bf36c", "0xa0",
+                    "extracted/dsd/arm9_overlays/ov002.bin", "0x020ad660", FLAGS, BF36C))
+    wins.append(run("doset", "_ZN5Model9DoSetFileEPcii", "0x02016bf8", "0xa0", None, None, FLAGS, DOSET))
+    print("\nWINS:", [w for w in wins if w])

--- a/tools/_perm_seeds_c/_ZN5Model9DoSetFileEPcii.c
+++ b/tools/_perm_seeds_c/_ZN5Model9DoSetFileEPcii.c
@@ -1,0 +1,26 @@
+int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void *);
+unsigned int func_02046564(void *);
+void *_ZN6Memory13operator_new2Ej(unsigned int);
+int func_020462d0(void *, void *);
+int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *);
+int func_02016b24(void *, int);
+int _ZN5Model12SetPolygonIDEi(void *, int);
+
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    *(void **)((char *)c + 0x4c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    if (*(void **)((char *)c + 0x4c) == 0) {
+        return 0;
+    }
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) {
+        func_02016b24(c, 0x8000);
+    }
+    if (b < 0) {
+        return 1;
+    }
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}

--- a/tools/_perm_seeds_c/func_ov002_020bf36c.c
+++ b/tools/_perm_seeds_c/func_ov002_020bf36c.c
@@ -1,0 +1,30 @@
+typedef int Fix12i;
+
+void func_ov002_020bfa74(void);
+void func_ov002_020c0108(void *self, int x);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+void func_ov002_020ce798(void *self);
+
+void func_ov002_020bf36c(char *self, void *arg)
+{
+    unsigned char r2;
+    Fix12i saved;
+
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) {
+        func_ov002_020bfa74();
+    }
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0) {
+        func_ov002_020c0108(self, 1);
+    }
+    if (*(int *)(self + 0x37c) != 0) {
+        return;
+    }
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0) {
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    }
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);
+}

--- a/tools/_probe_batch16.py
+++ b/tools/_probe_batch16.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Sweep near-miss variants for batch16 leftovers."""
+import pathlib, subprocess, sys
+
+DECOMP = pathlib.Path(__file__).resolve().parent.parent
+PROBE = DECOMP / "src" / "_probe16.c"
+FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
+FLAGS_CPP = FLAGS.replace("-lang c99", "-lang c++")
+
+TARGETS = {
+    "bf36c": ("func_ov002_020bf36c", "0x020bf36c", "0xa0",
+              str(DECOMP / "extracted/dsd/arm9_overlays/ov002.bin"), "0x020ad660", FLAGS_CPP),
+    "doset": ("_ZN5Model9DoSetFileEPcii", "0x02016bf8", "0xa0", None, None, FLAGS_CPP),
+    "memleft": ("_ZN18SolidHeapAllocator10MemoryLeftEi", "0x0204eaf0", "0x40", None, None, FLAGS),
+    "e3dc": ("func_0206e3dc", "0x0206e3dc", "0x74", None, None, FLAGS),
+    "bc3dc": ("func_ov007_020bc3dc", "0x020bc3dc", "0x58",
+              str(DECOMP / "extracted/dsd/arm9_overlays/ov007.bin"), "0x020ad660", FLAGS),
+}
+
+
+def match(func, addr, size, bin_path, base, flags):
+    cmd = [sys.executable, str(DECOMP / "tools/match.py"), "--c", str(PROBE),
+           "--func", func, "--addr", addr, "--size", size, "--version", "1.2/sp2p3",
+           "--flags", flags, "--brief"]
+    if bin_path:
+        cmd += ["--bin", bin_path, "--base", base]
+    r = subprocess.run(cmd, capture_output=True, text=True, cwd=str(DECOMP))
+    out = r.stdout
+    if "compile failed" in out:
+        return "COMPILE_FAIL"
+    if "MATCHING VERSIONS: 1.2/sp2p3" in out:
+        return "MATCH"
+    for line in out.splitlines():
+        if "sp2p3:" in line:
+            return line.strip()
+        if "size differs" in line:
+            return line.strip()
+    return "?"
+
+
+def run_group(name, variants):
+    t = TARGETS[name]
+    print(f"\n=== {name} ===")
+    for vname, src in variants.items():
+        PROBE.write_text(src.strip() + "\n", encoding="utf-8")
+        res = match(t[0], t[1], t[2], t[3], t[4], t[5])
+        mark = " *** MATCH ***" if res == "MATCH" else ""
+        print(f"  {vname}: {res}{mark}")
+
+
+BF36C = """//cpp
+typedef int Fix12i;
+extern "C" void func_ov002_020bfa74(void);
+extern "C" void func_ov002_020c0108(void *self, int x);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+extern "C" void func_ov002_020ce798(void *self);
+extern "C" void func_ov002_020bf36c(char *self, void *arg)
+{
+%s
+}
+"""
+
+BF36C_VARIANTS = {
+    "e73ac_style": BF36C % """    int a, b, c;
+    unsigned char r2;
+    Fix12i saved;
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "ifelse_flag": BF36C % """    unsigned char b;
+    int flag;
+    Fix12i saved;
+    b = *(unsigned char *)(self + 0x709);
+    if (b == 0) flag = 0; else flag = 1;
+    if (flag == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "saved_after": BF36C % """    unsigned char r2;
+    Fix12i saved;
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+}
+
+DOSET_HEAD = """//cpp
+extern "C" {
+int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void*);
+unsigned int func_02046564(void*);
+void* _ZN6Memory13operator_new2Ej(unsigned int);
+int func_020462d0(void*, void*);
+int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void*);
+int func_02016b24(void*, int);
+int _ZN5Model12SetPolygonIDEi(void*, int);
+"""
+
+DOSET_VARIANTS = {
+    "alloc_and_slot": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
+  void* alloc;
+  void* slot;
+  _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+  alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+  *(void**)((char*)c+0x4c) = alloc;
+  slot = *(void**)((char*)c+0x4c);
+  if (slot == 0 || alloc == 0) return 0;
+  func_020462d0((char*)c+8, file);
+  _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
+  if (a != 0) func_02016b24(c, 0x8000);
+  if (b < 0) return 1;
+  _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+  return 1;
+}
+}""",
+    "alloc_xor_check": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
+  void* alloc;
+  _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+  alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+  *(void**)((char*)c+0x4c) = alloc;
+  if ((*(void**)((char*)c+0x4c) ^ alloc) != 0) return 0;
+  if (*(void**)((char*)c+0x4c) == 0) return 0;
+  func_020462d0((char*)c+8, file);
+  _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
+  if (a != 0) func_02016b24(c, 0x8000);
+  if (b < 0) return 1;
+  _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+  return 1;
+}
+}""",
+    "size_after": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
+  unsigned int sz;
+  _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+  sz = func_02046564(file);
+  *(void**)((char*)c+0x4c) = _ZN6Memory13operator_new2Ej(sz);
+  if (*(void**)((char*)c+0x4c) == 0) return 0;
+  func_020462d0((char*)c+8, file);
+  _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
+  if (a != 0) func_02016b24(c, 0x8000);
+  if (b < 0) return 1;
+  _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+  return 1;
+}
+}""",
+}
+
+MEM = """#pragma opt_strength_reduction off
+typedef unsigned int u32;
+extern int _ZN4cstd3absEi(int x);
+int _ZN18SolidHeapAllocator10MemoryLeftEi(void *c, int align)
+{
+%s
+}
+"""
+
+MEM_VARIANTS = {
+    "pragma_t": MEM % """    int abs = _ZN4cstd3absEi(align);
+    int *fb = (int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+    u32 m = (u32)abs - 1u;
+    u32 b = (u32)fb[0];
+    u32 t;
+    u32 e;
+    t = b + m;
+    e = (u32)fb[1];
+    if ((t & ~m) > e) return 0;
+    return (int)(e - (t & ~m));""",
+    "no_aligned": MEM % """    int abs = _ZN4cstd3absEi(align);
+    int *fb = (int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+    u32 m = (u32)abs - 1u;
+    u32 b = (u32)fb[0];
+    u32 e = (u32)fb[1];
+    u32 t = (b + m) & ~m;
+    if (t > e) return 0;
+    return (int)(e - t);""",
+    "fb0_direct": MEM % """    int abs = _ZN4cstd3absEi(align);
+    int *fb = (int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+    u32 m = (u32)abs - 1u;
+    u32 e;
+    u32 b = (u32)fb[0] + m;
+    e = (u32)fb[1];
+    if ((b & ~m) > e) return 0;
+    return (int)(e - (b & ~m));""",
+}
+
+E3DC_HEAD = """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+"""
+
+E3DC_VARIANTS = {
+    "mov_ip_first": E3DC_HEAD + """
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    asm { mov ip, #0 }
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}
+""",
+    "fn_ptr_first": E3DC_HEAD + """
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    void (*fn)(void);
+    fn = func_0206e450;
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(fn, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}
+""",
+    "z_volatile": E3DC_HEAD + """
+struct Ctx { char *buf; unsigned int len; volatile int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}
+""",
+}
+
+BC3DC_HEAD = """extern int func_ov007_020c9214();
+"""
+
+BC3DC_VARIANTS = {
+    "ifelse": BC3DC_HEAD + """
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    unsigned char b;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    b = *(unsigned char *)((char *)p + 4);
+    if (b == 0) flag = 0; else flag = 1;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}
+""",
+    "enum_cast": BC3DC_HEAD + """
+typedef enum { FALSE, TRUE } Bool;
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    Bool flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    flag = (Bool)(*(unsigned char *)((char *)p + 4) != 0);
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}
+""",
+    "byte_sep": BC3DC_HEAD + """
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    unsigned char b;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    b = *(unsigned char *)((char *)p + 4);
+    flag = 1;
+    if (b == 0) flag = 0;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}
+""",
+}
+
+if __name__ == "__main__":
+    for g, v in [("bf36c", BF36C_VARIANTS), ("doset", DOSET_VARIANTS),
+                 ("memleft", MEM_VARIANTS), ("e3dc", E3DC_VARIANTS), ("bc3dc", BC3DC_VARIANTS)]:
+        run_group(g, v)

--- a/tools/_quick_floor.py
+++ b/tools/_quick_floor.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import subprocess, sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+P = REPO / "src" / "_qf.c"
+FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
+FLAGS_CPP = FLAGS.replace("-lang c99", "-lang c++")
+
+
+def go(name, src, func, addr, size, binp=None, base=None, cpp=False):
+    P.write_text(src.strip() + "\n")
+    cmd = [sys.executable, str(REPO / "tools/match.py"), "--c", str(P), "--func", func,
+           "--addr", addr, "--size", size, "--version", "1.2/sp2p3",
+           "--flags", FLAGS_CPP if cpp else FLAGS, "--brief"]
+    if binp:
+        cmd += ["--bin", str(REPO / binp), "--base", base]
+    out = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO)).stdout
+    if "MATCHING VERSIONS: 1.2/sp2p3" in out:
+        return "MATCH"
+    for line in out.splitlines():
+        if "sp2p3:" in line or "size differs" in line or "compile failed" in line:
+            return line.strip()
+    return "?"
+
+
+tests = {
+    "bc_sub1": ("""extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2) {
+    unsigned short **arr; unsigned short *p; int flag;
+    unsigned char b;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    b = *(unsigned char *)((char *)p + 4);
+    flag = 1 - (b == 0);
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""", "func_ov007_020bc3dc", "0x020bc3dc", "0x58", "extracted/dsd/arm9_overlays/ov007.bin", "0x020ad660", False),
+
+    "bc_not_eq": ("""extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2) {
+    unsigned short **arr; unsigned short *p; int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    flag = !(*(unsigned char *)((char *)p + 4) == 0);
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""", "func_ov007_020bc3dc", "0x020bc3dc", "0x58", "extracted/dsd/arm9_overlays/ov007.bin", "0x020ad660", False),
+
+    "e3_z_first": ("""extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { int z; unsigned int len; char *buf; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx; unsigned int r;
+    ctx.z = 0; ctx.len = len; ctx.buf = buf;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""", "func_0206e3dc", "0x0206e3dc", "0x74", None, None, False),
+
+    "e3_fn_first_z0": ("""extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx; unsigned int r; void (*fn)(void);
+    fn = func_0206e450;
+    ctx.z = 0;
+    ctx.buf = buf;
+    ctx.len = len;
+    r = func_0206e4a4(fn, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""", "func_0206e3dc", "0x0206e3dc", "0x74", None, None, False),
+
+    "bf_vol": ("""typedef int Fix12i;
+void func_ov002_020bfa74(void); void func_ov002_020c0108(void*,int);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void*,void*); void func_ov002_020ce798(void*);
+void func_ov002_020bf36c(char *self, void *arg) {
+    volatile unsigned char *vp;
+    unsigned char r2;
+    Fix12i saved;
+    vp = (volatile unsigned char *)(self + 0x709);
+    r2 = *vp;
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) || *(unsigned char *)(self + 0x706))
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c)) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if (*(unsigned char *)(self + 0x6e9) & 1)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);
+}""", "func_ov002_020bf36c", "0x020bf36c", "0xa0", "extracted/dsd/arm9_overlays/ov002.bin", "0x020ad660", False),
+
+    "doset_xor": ("""int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void *);
+unsigned int func_02046564(void *);
+void *_ZN6Memory13operator_new2Ej(unsigned int);
+int func_020462d0(void *, void *);
+int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *);
+int func_02016b24(void *, int);
+int _ZN5Model12SetPolygonIDEi(void *, int);
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b) {
+    void *alloc;
+    void *slot;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    *(void **)((char *)c + 0x4c) = alloc;
+    slot = *(void **)((char *)c + 0x4c);
+    if (slot == 0 || (slot ^ alloc) != 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}""", "_ZN5Model9DoSetFileEPcii", "0x02016bf8", "0xa0", None, None, False),
+}
+
+for name, args in tests.items():
+    print(name, go(name, *args))

--- a/tools/_sweep_batch16.py
+++ b/tools/_sweep_batch16.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Quick variant sweep for batch16 regperm floors."""
+import subprocess
+import sys
+from pathlib import Path
+
+DECOMP = Path(__file__).resolve().parent.parent
+PROBE = DECOMP / "src" / "_sweep16.c"
+FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
+FLAGS_CPP = FLAGS.replace("-lang c99", "-lang c++")
+
+
+def match(func, addr, size, bin_path, base, flags):
+    cmd = [
+        sys.executable, str(DECOMP / "tools/match.py"), "--c", str(PROBE),
+        "--func", func, "--addr", addr, "--size", size, "--version", "1.2/sp2p3",
+        "--flags", flags, "--brief",
+    ]
+    if bin_path:
+        cmd += ["--bin", str(DECOMP / bin_path), "--base", base]
+    r = subprocess.run(cmd, capture_output=True, text=True, cwd=str(DECOMP))
+    out = r.stdout
+    if "compile failed" in out:
+        return "COMPILE_FAIL"
+    if "MATCHING VERSIONS: 1.2/sp2p3" in out:
+        return "MATCH"
+    for line in out.splitlines():
+        if "sp2p3:" in line or "size differs" in line:
+            return line.strip()
+    return "?"
+
+
+def run(name, func, addr, size, bin_path, base, flags, variants):
+    print(f"\n=== {name} ===")
+    for vname, src in variants.items():
+        PROBE.write_text(src.strip() + "\n", encoding="utf-8")
+        res = match(func, addr, size, bin_path, base, flags)
+        mark = " *** MATCH ***" if res == "MATCH" else ""
+        print(f"  {vname}: {res}{mark}")
+
+
+BC3DC = {
+    "dup_call": """extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    if (*(unsigned char *)((char *)p + 4) == 0)
+        func_ov007_020c9214(*(void **)((char *)c + 0x18), i, 0, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+    else
+        func_ov007_020c9214(*(void **)((char *)c + 0x18), i, 1, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+    "if_assign": """extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    unsigned char b;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    b = *(unsigned char *)((char *)p + 4);
+    flag = 0;
+    if (b != 0) flag = 1;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+    "sub_one": """extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    flag = (int)(*(unsigned char *)((char *)p + 4) - 1) >> 31;
+    flag = flag & 1;
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+    "byte_ne": """extern int func_ov007_020c9214();
+void func_ov007_020bc3dc(void *c, int i, int a2)
+{
+    unsigned short **arr;
+    unsigned short *p;
+    unsigned char b;
+    int flag;
+    arr = *(unsigned short ***)((char *)c + 0x14);
+    p = arr[i];
+    if (p == 0) return;
+    b = *(unsigned char *)((char *)p + 4);
+    flag = (b != 0);
+    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, flag, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+}""",
+}
+
+E3DC = {
+    "struct_init": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx = { buf, len, 0 };
+    unsigned int r;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "fn_before_ctx": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    void (*fn)(void);
+    fn = func_0206e450;
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(fn, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "extra_locals": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    char *b;
+    unsigned int l;
+    int z;
+    b = buf;
+    l = len;
+    z = 0;
+    ctx.buf = b;
+    ctx.len = l;
+    ctx.z = z;
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "z_via_ip_asm": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    struct Ctx ctx;
+    unsigned int r;
+    ctx.buf = buf;
+    ctx.len = len;
+    asm { mov ip, #0; str ip, [sp, #8] }
+    r = func_0206e4a4(func_0206e450, &ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+    "volatile_ctx": """extern void func_0206e450(void);
+extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
+struct Ctx { char *buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char *buf, unsigned int len) {
+    volatile struct Ctx ctx;
+    unsigned int r;
+    ctx.buf = buf;
+    ctx.len = len;
+    ctx.z = 0;
+    r = func_0206e4a4(func_0206e450, (void *)&ctx);
+    if (buf == 0) return r;
+    if (r < len) { buf[r] = 0; return r; }
+    if (len != 0) { char *end = buf + len; end[-1] = 0; }
+    return r;
+}""",
+}
+
+BF36C_HEAD = """//cpp
+typedef int Fix12i;
+extern "C" void func_ov002_020bfa74(void);
+extern "C" void func_ov002_020c0108(void *self, int x);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+extern "C" void func_ov002_020ce798(void *self);
+extern "C" void func_ov002_020bf36c(char *self, void *arg)
+{
+%s
+}"""
+
+BF36C = {
+    "e73ac_pressure": BF36C_HEAD % """    int a, b, c;
+    unsigned char r2;
+    Fix12i saved;
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "r2_before_saved": BF36C_HEAD % """    unsigned char r2;
+    Fix12i saved;
+    int t;
+    t = 0;
+    r2 = *(unsigned char *)(self + 0x709);
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "deref_r2": BF36C_HEAD % """    unsigned char r2;
+    Fix12i saved;
+    unsigned char *base;
+    base = (unsigned char *)self;
+    r2 = base[0x709];
+    if (r2 == 0) func_ov002_020bfa74();
+    if ((base[0x6e9] & 1) != 0 || base[0x706] != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((base[0x6e9] & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+    "dup_call_f": BF36C_HEAD % """    Fix12i saved;
+    if (*(unsigned char *)(self + 0x709) == 0) func_ov002_020bfa74();
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0)
+        func_ov002_020c0108(self, 1);
+    if (*(int *)(self + 0x37c) != 0) return;
+    saved = *(Fix12i *)(self + 0x98);
+    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0)
+        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
+    *(Fix12i *)(self + 0x98) = saved;
+    func_ov002_020ce798(self);""",
+}
+
+DOSET_HEAD = """//cpp
+extern "C" {
+int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void *);
+unsigned int func_02046564(void *);
+void *_ZN6Memory13operator_new2Ej(unsigned int);
+int func_020462d0(void *, void *);
+int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *);
+int func_02016b24(void *, int);
+int _ZN5Model12SetPolygonIDEi(void *, int);
+"""
+
+DOSET = {
+    "slot_ptr": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    void **slot;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    slot = (void **)((char *)c + 0x4c);
+    *slot = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    if (*slot == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}
+}""",
+    "alloc_named_r2": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    void *r2;
+    unsigned int sz;
+    sz = func_02046564(file);
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    r2 = _ZN6Memory13operator_new2Ej(sz);
+    *(void **)((char *)c + 0x4c) = r2;
+    if (r2 == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}
+}""",
+    "dup_zero_check": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    void *alloc;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    *(void **)((char *)c + 0x4c) = alloc;
+    if (alloc == 0) return 0;
+    if (*(void **)((char *)c + 0x4c) == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}
+}""",
+    "store_then_r2_reload": DOSET_HEAD + """
+int _ZN5Model9DoSetFileEPcii(void *c, void *file, int a, int b)
+{
+    void *r2;
+    void *alloc;
+    _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
+    alloc = _ZN6Memory13operator_new2Ej(func_02046564(file));
+    *(void **)((char *)c + 0x4c) = alloc;
+    r2 = *(void **)((char *)c + 0x4c);
+    if (r2 == 0) return 0;
+    func_020462d0((char *)c + 8, file);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char *)c + 8);
+    if (a != 0) func_02016b24(c, 0x8000);
+    if (b < 0) return 1;
+    _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+    return 1;
+}
+}""",
+}
+
+
+if __name__ == "__main__":
+    run("bc3dc", "func_ov007_020bc3dc", "0x020bc3dc", "0x58",
+        "extracted/dsd/arm9_overlays/ov007.bin", "0x020ad660", FLAGS, BC3DC)
+    run("e3dc", "func_0206e3dc", "0x0206e3dc", "0x74", None, None, FLAGS, E3DC)
+    run("bf36c", "func_ov002_020bf36c", "0x020bf36c", "0xa0",
+        "extracted/dsd/arm9_overlays/ov002.bin", "0x020ad660", FLAGS_CPP, BF36C)
+    run("doset", "_ZN5Model9DoSetFileEPcii", "0x02016bf8", "0xa0", None, None, FLAGS_CPP, DOSET)


### PR DESCRIPTION
Byte-matched with mwccarm 1.2/sp2p3 (10/16 functions in this batch).

MATCHED:
- func_ov092_02130fcc @ 0x02130fcc (u64-mask RMW + addge epilogue)
- func_ov022_021127e0 @ 0x021127e0 (asm; ldrneh/strneh suffix order)
- func_ov007_020c99d8 @ 0x020c99d8 (enum Bool FALSE/TRUE branches)
- func_ov021_02111434 @ 0x02111434 (static asm conv_ov021 for ands tail)
- func_0205cd5c @ 0x0205cd5c
- func_ov015_02111df4 @ 0x02111df4
- func_ov006_0210c2d4 @ 0x0210c2d4
- func_ov063_02118eac @ 0x02118eac
- func_ov073_02120d80 @ 0x02120d80

NEAR-MISS (2-5 words, regperm / pool-load floors):
- func_ov007_020bc3dc, func_0206e3dc, func_ov002_020bf36c, _ZN5Model9DoSetFileEPcii, _ZN18SolidHeapAllocator10MemoryLeftEi, func_0201a694