### PR TITLE
Match func_ov010_021112b4 and func_ov078_021250d0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,794 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,924 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,795 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,964 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,795 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,964 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A from-scratch effort to decompile **Super Mario 64 DS** into matching C.
 
 <!-- progress:start -->
 ```
-Functions  █████████████████████░░░░░░░░░  68.4%   7,793 / 11,390
-Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,816 / 2,234,028 bytes
+Functions  █████████████████████░░░░░░░░░  68.4%   7,794 / 11,390
+Code size  ████████████░░░░░░░░░░░░░░░░░░  39.7%   885,924 / 2,234,028 bytes
 ```
 <!-- progress:end -->
 

--- a/src/func_ov010_021112b4.c
+++ b/src/func_ov010_021112b4.c
@@ -1,0 +1,25 @@
+extern char *func_ov010_0211139c(char *c);
+
+#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+
+void func_ov010_021112b4(char *c)
+{
+    char *p = func_ov010_0211139c(c);
+    short *a;
+    short *b;
+    int limit;
+
+    if (p == 0) return;
+
+    *(unsigned char *)(p + 0x3aa) = 0;
+    a = (short *)LAUNDER_ADDR(c + 0x3a8);
+    b = (short *)LAUNDER_ADDR(c + 0x90);
+    limit = 0x3d00;
+    *a = *a - 0x100;
+    *b = *b + *(volatile short *)(c + 0x300 + 0xa8);
+
+    if (*(volatile short *)(c + 0x90) < -limit) {
+        *(short *)(c + 0x90) = -limit;
+        *(int *)(c + 0x3a0) = 2;
+    }
+}

--- a/src/func_ov078_021250d0.c
+++ b/src/func_ov078_021250d0.c
@@ -1,0 +1,11 @@
+#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+
+int func_ov078_021250d0(char *c)
+{
+    int *flags = (int *)LAUNDER_ADDR(c + 0x354);
+    *flags |= 2;
+    *(int *)(c + 0x9c) = 0;
+    *(int *)(c + 0x98) = 0;
+    *(unsigned char *)(c + 0x499) = 0;
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Add a source match for func_ov010_021112b4 in ov010.
- Add a source match for func_ov078_021250d0 in ov078.
- Refresh the README progress block after adding the two matches.

## Verification
- python tools\match.py --c src\func_ov010_021112b4.c --func func_ov010_021112b4 --addr 0x021112b4 --size 0x6c --bin extracted\overlays\overlay_0010.bin --base 0x021111a0 --module ov010 --strict-relocs --brief
- python tools\linkcheck.py --name func_ov010_021112b4 --addr 0x021112b4 --size 0x6c --module ov010
- python tools\match.py --c src\func_ov078_021250d0.c --func func_ov078_021250d0 --addr 0x021250d0 --size 0x28 --bin extracted\overlays\overlay_0078.bin --base 0x02123740 --module ov078 --strict-relocs --brief
- python tools\linkcheck.py --name func_ov078_021250d0 --addr 0x021250d0 --size 0x28 --module ov078
- git diff --check origin/main...HEAD

Supersedes closed PR #76, which was closed without merge.