### PR TITLE
Match 64 functions (arm9 flag setters, thunks, misc helpers; ov002 cleanups)

### DIFF
--- a/src/_ZN11ShadowModel9DoSetFileEPcii.c
+++ b/src/_ZN11ShadowModel9DoSetFileEPcii.c
@@ -1,0 +1,37 @@
+struct ModelComponents {
+    void *modelFile;
+    void *materials;
+    void *bones;
+    void *transforms;
+    void *unk10;
+};
+
+struct Material { char pad[0x24]; unsigned int flags; char pad2[0x30 - 0x24 - 4]; };
+struct ModelFile { char pad[0x24]; int materialCount; };
+
+extern struct ModelComponents *func_02016e70(void *file);
+extern void _ZN15ModelComponents21UpdateVertsUsingBonesEv(struct ModelComponents *data);
+
+int _ZN11ShadowModel9DoSetFileEPcii(char *self, void *file, int flag)
+{
+    *(struct ModelComponents **)(self + 8) = func_02016e70(file);
+
+    if (*(struct ModelComponents **)(self + 8) == 0)
+        return 0;
+
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv(*(struct ModelComponents **)(self + 8));
+
+    if (flag != 0) {
+        struct ModelComponents *data = *(struct ModelComponents **)(self + 8);
+        struct ModelFile *mf = (struct ModelFile *)data->modelFile;
+        unsigned int n = mf->materialCount;
+        struct Material *mat = (struct Material *)data->materials;
+
+        for (unsigned int i = 0; i < n; i++) {
+            *(unsigned int *)(((long long)(int)&mat->flags) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+            mat = (struct Material *)((char *)mat + 0x30);
+        }
+    }
+
+    return 1;
+}

--- a/src/_ZN12WithMeshClsn13SetGroundFlagEv.c
+++ b/src/_ZN12WithMeshClsn13SetGroundFlagEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn13SetGroundFlagEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+}

--- a/src/_ZN12WithMeshClsn13SetLimMovFlagEv.c
+++ b/src/_ZN12WithMeshClsn13SetLimMovFlagEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn13SetLimMovFlagEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
+}

--- a/src/_ZN12WithMeshClsn15ClearGroundFlagEv.c
+++ b/src/_ZN12WithMeshClsn15ClearGroundFlagEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn15ClearGroundFlagEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10;
+}

--- a/src/_ZN12WithMeshClsn15ClearLimMovFlagEv.c
+++ b/src/_ZN12WithMeshClsn15ClearLimMovFlagEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn15ClearLimMovFlagEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80;
+}

--- a/src/_ZN12WithMeshClsn19ClearAllGroundFlagsEv.c
+++ b/src/_ZN12WithMeshClsn19ClearAllGroundFlagsEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x70;
+}

--- a/src/_ZN12WithMeshClsn22ClearJustHitGroundFlagEv.c
+++ b/src/_ZN12WithMeshClsn22ClearJustHitGroundFlagEv.c
@@ -1,0 +1,4 @@
+void _ZN12WithMeshClsn22ClearJustHitGroundFlagEv(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+}

--- a/src/_ZN13SharedFilePtr7ReleaseEv.c
+++ b/src/_ZN13SharedFilePtr7ReleaseEv.c
@@ -1,0 +1,19 @@
+struct SharedFilePtr { unsigned short fileID; unsigned char numRefs; void *filePtr; };
+
+extern unsigned int data_0209d3bc;
+extern void func_02017c24(struct SharedFilePtr *self);
+
+void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self)
+{
+    data_0209d3bc = self->fileID;
+
+    if (self->numRefs == 0)
+        return;
+
+    *(unsigned char *)(((long long)(int)((char *)self + 2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+
+    if (self->numRefs != 0)
+        return;
+
+    func_02017c24(self);
+}

--- a/src/_ZN13SharedFilePtr8LoadFileEv.c
+++ b/src/_ZN13SharedFilePtr8LoadFileEv.c
@@ -1,0 +1,21 @@
+struct SharedFilePtr { unsigned short fileID; unsigned char numRefs; void *filePtr; };
+
+extern unsigned int data_0209d3bc;
+extern int _ZN13SharedFilePtr4LoadEv(struct SharedFilePtr *self);
+
+void *_ZN13SharedFilePtr8LoadFileEv(struct SharedFilePtr *self)
+{
+    data_0209d3bc = self->fileID;
+
+    if (self->numRefs == 0) {
+        if (!_ZN13SharedFilePtr4LoadEv(self))
+            return 0;
+    }
+
+    if (self->numRefs >= 0xff) {
+        return 0;
+    }
+
+    *(unsigned char *)(((long long)(int)((char *)self + 2)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    return self->filePtr;
+}

--- a/src/_ZN14BlendModelAnim7AdvanceEv.c
+++ b/src/_ZN14BlendModelAnim7AdvanceEv.c
@@ -1,0 +1,9 @@
+extern void _ZN9Animation7AdvanceEv(char *self);
+
+void _ZN14BlendModelAnim7AdvanceEv(char *self)
+{
+    _ZN9Animation7AdvanceEv(self + 0x50);
+    if (*(int *)(self + 0x64) < 0x1000) {
+        *(int *)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(self + 0x68);
+    }
+}

--- a/src/_ZN4BgCh18StopDetectingWaterEv.c
+++ b/src/_ZN4BgCh18StopDetectingWaterEv.c
@@ -1,0 +1,4 @@
+void _ZN4BgCh18StopDetectingWaterEv(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+}

--- a/src/_ZN4BgCh19StartDetectingToxicEv.c
+++ b/src/_ZN4BgCh19StartDetectingToxicEv.c
@@ -1,0 +1,4 @@
+void _ZN4BgCh19StartDetectingToxicEv(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+}

--- a/src/_ZN4BgCh19StartDetectingWaterEv.c
+++ b/src/_ZN4BgCh19StartDetectingWaterEv.c
@@ -1,0 +1,4 @@
+void _ZN4BgCh19StartDetectingWaterEv(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+}

--- a/src/_ZN4BgCh21StopDetectingOrdinaryEv.c
+++ b/src/_ZN4BgCh21StopDetectingOrdinaryEv.c
@@ -1,0 +1,4 @@
+void _ZN4BgCh21StopDetectingOrdinaryEv(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+}

--- a/src/_ZN5Actor18AfterInitResourcesEj.c
+++ b/src/_ZN5Actor18AfterInitResourcesEj.c
@@ -1,0 +1,10 @@
+typedef unsigned int u32;
+typedef struct ActorDerived { char pad[0]; } ActorDerived;
+
+extern void _ZN12ActorDerived18AfterInitResourcesEj(ActorDerived *self, u32 result);
+
+void _ZN5Actor18AfterInitResourcesEj(char *self, u32 result)
+{
+    _ZN12ActorDerived18AfterInitResourcesEj((ActorDerived *)self, result);
+    *(int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x38;
+}

--- a/src/_ZN6Player17St_Squish_CleanupEv.c
+++ b/src/_ZN6Player17St_Squish_CleanupEv.c
@@ -1,0 +1,13 @@
+int _ZN6Player17St_Squish_CleanupEv(char *self)
+{
+    int val = 0x1000;
+    if (*(unsigned char *)(self + 0x703) != 0)
+        val = 0x3000;
+
+    *(int *)(self + 0x80) = val;
+    *(int *)(self + 0x84) = val;
+    *(int *)(self + 0x88) = val;
+
+    *(int *)(((long long)(int)(self + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+    return 1;
+}

--- a/src/_ZN6Player21St_CameraZoom_CleanupEv.c
+++ b/src/_ZN6Player21St_CameraZoom_CleanupEv.c
@@ -1,0 +1,6 @@
+int _ZN6Player21St_CameraZoom_CleanupEv(char *self)
+{
+    *(unsigned short *)(((long long)(int)(self + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+    *(unsigned char *)(self + 0x715) = 0;
+    return 1;
+}

--- a/src/_ZThn80_N9AnimationD0Ev.cpp
+++ b/src/_ZThn80_N9AnimationD0Ev.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct Base1 {
+    char pad[0x50 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Animation : Base1, Base2 {
+    virtual ~Animation();
+};
+Animation::~Animation() {}

--- a/src/_ZThn80_N9AnimationD1Ev.cpp
+++ b/src/_ZThn80_N9AnimationD1Ev.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct Base1 {
+    char pad[0x50 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Animation : Base1, Base2 {
+    virtual ~Animation();
+};
+Animation::~Animation() {}

--- a/src/func_02007484.c
+++ b/src/func_02007484.c
@@ -1,0 +1,18 @@
+extern void _Z14ApproachLinearRiii(int *v, int target, int rate);
+extern void Math_Function_0203b0fc(int *p, int target, int scale, int max);
+
+int func_02007484(char *self)
+{
+    _Z14ApproachLinearRiii((int *)(self + 0xb8), 0, 0x2000);
+
+    *(int *)(self + 0xb0) = 0;
+
+    char *info = *(char **)(self + 0x110);
+
+    int *sub = (int *)(((long long)(int)(info + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+
+    Math_Function_0203b0fc((int *)(self + 0x8c), sub[0], 0x28, 0x7fffffff);
+    Math_Function_0203b0fc((int *)(self + 0x94), sub[2], 0x28, 0x7fffffff);
+
+    return 1;
+}

--- a/src/func_020080b0.c
+++ b/src/func_020080b0.c
@@ -1,0 +1,17 @@
+struct Actor;
+extern struct Actor *func_0200e55c(unsigned int ownerID);
+
+int func_020080b0(char *c)
+{
+    struct Actor *obj = func_0200e55c(0x13);
+    char *base = (char *)(((long long)(int)((char *)obj + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+
+    int z = *(int *)(base + 8);
+    int y = *(int *)(base + 4) + *(int *)(c + 0x170);
+    int x = *(int *)(base + 0);
+
+    *(int *)(c + 0x80) = x;
+    *(int *)(c + 0x84) = y;
+    *(int *)(c + 0x88) = z;
+    return 1;
+}

--- a/src/func_0200cbe0.c
+++ b/src/func_0200cbe0.c
@@ -1,0 +1,26 @@
+struct Vector3;
+struct Vec3 { int x, y, z; };
+
+extern int func_020092c4(void *self, struct Vec3 *out, struct Vec3 *target);
+extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
+extern short Vec3_VertAngle(const struct Vector3 *v1, const struct Vector3 *v0);
+
+void func_0200cbe0(void *self)
+{
+    int r1 = func_020092c4(self, (struct Vec3 *)((char *)self + 0x80), (struct Vec3 *)((char *)self + 0xb0));
+    int r2 = func_020092c4(self, (struct Vec3 *)((char *)self + 0x8c), (struct Vec3 *)((char *)self + 0xbc));
+
+    if (r2 != 0) {
+        if (r1 != 0) {
+            *(int *)(((long long)(int)((char *)self + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x8000;
+        }
+    }
+
+    short h = Vec3_HorzAngle((const struct Vector3 *)((char *)self + 0x80),
+                             (const struct Vector3 *)((char *)self + 0x8c));
+    *((short *)((char *)self + 0x100 + 0x7c)) = h;
+
+    short v = Vec3_VertAngle((const struct Vector3 *)((char *)self + 0x80),
+                             (const struct Vector3 *)((char *)self + 0x8c));
+    *((short *)((char *)self + 0x100 + 0x7e)) = v;
+}

--- a/src/func_0200d1e4.c
+++ b/src/func_0200d1e4.c
@@ -1,0 +1,56 @@
+typedef unsigned int u32;
+typedef int s32;
+
+extern unsigned int func_020093f4(void *p, int x);
+extern unsigned int func_020093d4(void *p, int a);
+extern void Vec3_RotateYAndTranslate(void *dst, void *src, short angle, void *unk);
+extern void ChangeArea(int areaID);
+
+extern s32 data_02086f2c[3];
+extern s32 data_02086f14[3];
+
+void func_0200d1e4(char *self)
+{
+    char *info = *(char **)(self + 0x110);
+    char *base = (char *)(((long long)(int)(info + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+
+    *(s32 *)(self + 0x98) = *(s32 *)(base + 0);
+    *(s32 *)(self + 0x9c) = *(s32 *)(base + 4);
+    *(s32 *)(self + 0xa0) = *(s32 *)(base + 8);
+
+    int v1 = *(s32 *)(*(char **)(self + 0x13c) + 0x14);
+    unsigned int r0 = func_020093f4(self, v1);
+
+    s32 temp1[3];
+    temp1[0] = data_02086f2c[0];
+    temp1[1] = data_02086f2c[1];
+    temp1[2] = r0;
+    data_02086f2c[2] = r0;
+
+    short angle = *(short *)(*(char **)(self + 0x110) + 0x8e);
+    Vec3_RotateYAndTranslate(self + 0x80, self + 0x98, angle, temp1);
+
+    int v2 = *(s32 *)(*(char **)(self + 0x13c) + 0x10);
+    unsigned int dResult = func_020093d4(self, v2);
+    *(s32 *)(((long long)(int)(self + 0x84)) & 0xFFFFFFFFFFFFFFFFLL) += dResult;
+
+    int v3 = *(s32 *)(*(char **)(self + 0x13c) + 0x20);
+    unsigned int r0b = func_020093f4(self, v3);
+
+    s32 temp2[3];
+    data_02086f14[2] = r0b;
+    temp2[0] = data_02086f14[0];
+    temp2[1] = data_02086f14[1];
+    temp2[2] = r0b;
+
+    angle = *(short *)(*(char **)(self + 0x110) + 0x8e);
+    Vec3_RotateYAndTranslate(self + 0x8c, self + 0x80, angle, temp2);
+
+    *(s32 *)(((long long)(int)(self + 0x90)) & 0xFFFFFFFFFFFFFFFFLL) += (int)(dResult - 0x8b000);
+
+    *(s32 *)(self + 0xa4) = 0;
+    *(s32 *)(self + 0xa8) = 0xc3f9d;
+    *(s32 *)(self + 0xac) = 0;
+
+    ChangeArea(*(signed char *)(*(char **)(self + 0x110) + 0xcc));
+}

--- a/src/func_0200f2cc.c
+++ b/src/func_0200f2cc.c
@@ -1,0 +1,43 @@
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern void _ZN2GX15DisableAllBanksEv(void);
+extern void _ZN2GX13SetBankForTexEt(u16 v);
+extern void _ZN2GX17SetBankForTexPlttEt(u16 v);
+extern void _ZN2GX12SetBankForBGEt(u16 v);
+extern void _ZN2GX13SetBankForOBJEt(u16 v);
+extern void _ZN2GX15SetBankForSubBGEt(u16 v);
+extern void _ZN2GX16SetBankForSubOBJEt(u16 v);
+extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
+extern void _ZN3GXS15SetGraphicsModeEi(int a);
+
+void func_0200f2cc(void)
+{
+    _ZN2GX15DisableAllBanksEv();
+    _ZN2GX13SetBankForTexEt(3);
+    _ZN2GX17SetBankForTexPlttEt(0x10);
+    _ZN2GX12SetBankForBGEt(4);
+    _ZN2GX13SetBankForOBJEt(0x60);
+    _ZN2GX15SetBankForSubBGEt(0x180);
+    _ZN2GX16SetBankForSubOBJEt(8);
+
+    *(volatile u32 *)0x4000000 &= ~0x7000000;
+    *(volatile u32 *)0x4000000 &= ~0x38000000;
+    *(volatile u16 *)0x4000304 |= 0x8000;
+    _ZN2GX15SetGraphicsModeEiii(1, 0, 1);
+
+    *(volatile u32 *)0x4000000 &= 0xffcfffef;
+    *(volatile u16 *)0x400000e = (u16)((*(volatile u16 *)0x400000e & 0x43) | 0x10);
+    *(volatile u16 *)0x400000e &= ~0x40;
+    *(volatile u16 *)0x400000c = (u16)((*(volatile u16 *)0x400000c & 0x43) | 0xc108);
+    *(volatile u16 *)0x400000c &= ~0x40;
+    _ZN3GXS15SetGraphicsModeEi(0);
+
+    *(volatile u32 *)0x4001000 &= 0xffcfffef;
+    *(volatile u16 *)0x4001008 = (u16)((*(volatile u16 *)0x4001008 & 0x43) | 4);
+    *(volatile u16 *)0x4001008 &= ~0x40;
+    *(volatile u16 *)0x400100c = (u16)((*(volatile u16 *)0x400100c & 0x43) | 0x104);
+    *(volatile u16 *)0x400100c &= ~0x40;
+    *(volatile u16 *)0x400100e = (u16)((*(volatile u16 *)0x400100e & 0x43) | 0x704);
+    *(volatile u16 *)0x400100e &= ~0x40;
+}

--- a/src/func_02016acc.c
+++ b/src/func_02016acc.c
@@ -1,0 +1,12 @@
+void func_02016acc(char *a0, unsigned int mask)
+{
+    char *p = *(char **)(a0 + 8);
+    unsigned int n = *(unsigned int *)(p + 0x24);
+    char *q = *(char **)(a0 + 0xc);
+
+    for (unsigned int i = 0; i < n; i++) {
+        unsigned int nmask = ~mask;
+        *(unsigned int *)(((long long)(int)(q + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) &= nmask;
+        q += 0x30;
+    }
+}

--- a/src/func_02021cd4.c
+++ b/src/func_02021cd4.c
@@ -1,0 +1,21 @@
+extern void *data_0209ee74;
+
+void func_02021cd4(char *self)
+{
+    int idx = *(int *)(self + 4);
+    unsigned short val = *(unsigned short *)(self + 8);
+
+    char *a = *(char **)((char *)data_0209ee74 + 4);
+    char *b = *(char **)(a + 0x1c);
+    char *elem = *(char **)(b + idx * 32);
+    *(unsigned short *)(elem + 0x28) = val;
+
+    char *field = *(char **)(self + 0xc);
+    int *flagAddr = (int *)(((long long)(int)(field + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int v = *flagAddr;
+    v &= ~1;
+    v |= 1;
+    *flagAddr = v;
+
+    *(int *)self = 0;
+}

--- a/src/func_020353e0.c
+++ b/src/func_020353e0.c
@@ -1,0 +1,4 @@
+void func_020353e0(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x40;
+}

--- a/src/func_020353f4.c
+++ b/src/func_020353f4.c
@@ -1,0 +1,4 @@
+void func_020353f4(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+}

--- a/src/func_02035414.c
+++ b/src/func_02035414.c
@@ -1,0 +1,4 @@
+void func_02035414(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+}

--- a/src/func_02035428.c
+++ b/src/func_02035428.c
@@ -1,0 +1,4 @@
+void func_02035428(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+}

--- a/src/func_02035468.c
+++ b/src/func_02035468.c
@@ -1,0 +1,4 @@
+void func_02035468(char *self)
+{
+    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+}

--- a/src/func_02035550.c
+++ b/src/func_02035550.c
@@ -1,0 +1,4 @@
+void func_02035550(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
+}

--- a/src/func_0203558c.c
+++ b/src/func_0203558c.c
@@ -1,0 +1,4 @@
+void func_0203558c(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x1000;
+}

--- a/src/func_020355b4.c
+++ b/src/func_020355b4.c
@@ -1,0 +1,4 @@
+void func_020355b4(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800;
+}

--- a/src/func_020355c8.c
+++ b/src/func_020355c8.c
@@ -1,0 +1,4 @@
+void func_020355c8(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800;
+}

--- a/src/func_020355e8.c
+++ b/src/func_020355e8.c
@@ -1,0 +1,4 @@
+void func_020355e8(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x400;
+}

--- a/src/func_020355fc.c
+++ b/src/func_020355fc.c
@@ -1,0 +1,4 @@
+void func_020355fc(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x400;
+}

--- a/src/func_020356d4.c
+++ b/src/func_020356d4.c
@@ -1,0 +1,4 @@
+void func_020356d4(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+}

--- a/src/func_0203573c.c
+++ b/src/func_0203573c.c
@@ -1,0 +1,4 @@
+void func_0203573c(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+}

--- a/src/func_02035770.c
+++ b/src/func_02035770.c
@@ -1,0 +1,4 @@
+void func_02035770(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x200;
+}

--- a/src/func_02035784.c
+++ b/src/func_02035784.c
@@ -1,0 +1,4 @@
+void func_02035784(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+}

--- a/src/func_020375b0.cpp
+++ b/src/func_020375b0.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x10). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x10 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x10 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_0203780c.cpp
+++ b/src/func_0203780c.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x10). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x10 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x10 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_02037d84.cpp
+++ b/src/func_02037d84.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x10). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x10 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x10 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_02037da4.cpp
+++ b/src/func_02037da4.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x38). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x38 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x38 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_02045e44.c
+++ b/src/func_02045e44.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x1c]; unsigned int flags; char pad2[0x30 - 0x1c - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02045e44(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= ~0xc0000000;
+    *flags |= value << 30;
+}

--- a/src/func_02045ec4.c
+++ b/src/func_02045ec4.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x2c]; unsigned int flags; char pad2[0x30 - 0x2c - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02045ec4(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= 0xffff;
+    *flags |= value << 16;
+}

--- a/src/func_02045f4c.c
+++ b/src/func_02045f4c.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x28]; unsigned int flags; char pad2[0x30 - 0x28 - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02045f4c(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= 0xffff;
+    *flags |= value << 16;
+}

--- a/src/func_02045fd4.c
+++ b/src/func_02045fd4.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x28]; unsigned int flags; char pad2[0x30 - 0x28 - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02045fd4(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= 0xffff8000;
+    *flags |= value;
+}

--- a/src/func_0204605c.c
+++ b/src/func_0204605c.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x24]; unsigned int flags; char pad2[0x30 - 0x24 - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_0204605c(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= ~0x3f000000;
+    *flags |= value << 24;
+}

--- a/src/func_02046208.c
+++ b/src/func_02046208.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x24]; unsigned int flags; char pad2[0x30 - 0x24 - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02046208(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= ~0x1f0000;
+    *flags |= value << 16;
+}

--- a/src/func_02046288.c
+++ b/src/func_02046288.c
@@ -1,0 +1,10 @@
+struct Element { char pad[0x24]; unsigned int flags; char pad2[0x30 - 0x24 - 4]; };
+struct Obj { void *pad0; struct Element *arr; };
+
+void func_02046288(struct Obj *self, unsigned int value, int index)
+{
+    struct Element *e = &self->arr[index];
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags &= ~0x30;
+    *flags |= value << 4;
+}

--- a/src/func_0204dc84.c
+++ b/src/func_0204dc84.c
@@ -1,0 +1,11 @@
+void func_0204dc84(char *self)
+{
+    unsigned char *flags6 = (unsigned char *)(((long long)(int)(self + 6)) & 0xFFFFFFFFFFFFFFFFLL);
+    *flags6 &= ~3;
+    *flags6 &= ~4;
+    *(short *)(self + 4) = 0;
+    *(unsigned char *)(self + 7) = 0;
+    *(short *)(self + 2) = 0;
+    *(short *)(self) = *(short *)(self + 2);
+    *(int *)(self + 8) = 0;
+}

--- a/src/func_0204ffcc.c
+++ b/src/func_0204ffcc.c
@@ -1,0 +1,7 @@
+extern void func_0205ac28(void *a, int b, int c, int d);
+
+void func_0204ffcc(char *self)
+{
+    func_0205ac28(*(void **)(self + 0x2c), 0, 1 << *(int *)(self + 0x28), 0);
+    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+}

--- a/src/func_020520dc.c
+++ b/src/func_020520dc.c
@@ -1,0 +1,15 @@
+struct Obj1;
+extern void func_02050008(struct Obj1 *o);
+
+void func_020520dc(char *self)
+{
+    if (*(int *)(self + 0x100) == 0)
+        return;
+
+    *(int *)(((long long)(int)(self + 0x100)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+
+    if (*(int *)(self + 0x100) != 0)
+        return;
+
+    func_02050008((struct Obj1 *)self);
+}

--- a/src/func_02052438.c
+++ b/src/func_02052438.c
@@ -1,0 +1,6 @@
+void func_02052438(char *self)
+{
+    if (*(int *)(self + 8) < *(int *)(self + 0xc)) {
+        *(int *)(((long long)(int)(self + 8)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    }
+}

--- a/src/func_02057e00.c
+++ b/src/func_02057e00.c
@@ -1,0 +1,9 @@
+void func_02057e00(char *self, unsigned char value)
+{
+    if (*(int *)self != 0) {
+        *(unsigned char *)(*(char **)(self + 4)) = value;
+        *(int *)self -= 1;
+    }
+
+    *(int *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+}

--- a/src/func_02059f58.c
+++ b/src/func_02059f58.c
@@ -1,0 +1,14 @@
+extern unsigned int _ZN3IRQ7DisableEv(void);
+extern void _ZN3IRQ7RestoreEj(unsigned int savedState);
+
+void func_02059f58(int channel)
+{
+    unsigned int saved = _ZN3IRQ7DisableEv();
+    int idx = channel * 6 + 5;
+    volatile unsigned short *reg = (volatile unsigned short *)(((long long)(int)(0x40000b0 + idx * 2)) & 0xFFFFFFFFFFFFFFFFLL);
+    *reg &= ~0x3a00;
+    *reg &= ~0x8000;
+    (void)*reg;
+    (void)*reg;
+    _ZN3IRQ7RestoreEj(saved);
+}

--- a/src/func_0205c4e4.c
+++ b/src/func_0205c4e4.c
@@ -1,0 +1,11 @@
+extern int func_0205c5e4(void *self, int mode);
+
+void func_0205c4e4(char *self, unsigned short value)
+{
+    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+    *(int *)(self + 0x2c) = *(int *)(self + 8);
+    *(int *)(self + 0x34) = 0;
+    *(unsigned short *)(self + 0x32) = 0;
+    *(unsigned short *)(self + 0x30) = value;
+    func_0205c5e4(self, 2);
+}

--- a/src/func_0205c788.c
+++ b/src/func_0205c788.c
@@ -1,0 +1,11 @@
+struct Node;
+extern void func_0205d920(struct Node *node);
+extern void func_0205807c(unsigned short *self);
+
+void func_0205c788(char *self, int arg)
+{
+    func_0205d920((struct Node *)self);
+    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xf;
+    *(int *)(self + 0x14) = arg;
+    func_0205807c((unsigned short *)(self + 0x18));
+}

--- a/src/func_0205d4cc.c
+++ b/src/func_0205d4cc.c
@@ -1,0 +1,12 @@
+extern int func_0205cdf4(void *self, int arg);
+
+int func_0205d4cc(char *self)
+{
+    if (func_0205cdf4(self, 8) == 0)
+        return 0;
+
+    *(int *)(self + 8) = 0;
+    *(int *)(self + 0x10) = 0xc;
+    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x30;
+    return 1;
+}

--- a/src/func_020647a4.c
+++ b/src/func_020647a4.c
@@ -1,0 +1,10 @@
+void func_020647a4(char *self, int value)
+{
+    *(int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int *)(self + 0xc) = value;
+
+    int *arr = *(int **)(self + 0x14);
+    int idx = value >> 5;
+    int bit = value & 0x1f;
+    arr[idx] |= (1 << bit);
+}

--- a/src/func_0206a424.c
+++ b/src/func_0206a424.c
@@ -1,0 +1,6 @@
+void func_0206a424(int *self)
+{
+    volatile unsigned short *reg = (volatile unsigned short *)(((long long)0x4000204) & 0xFFFFFFFFFFFFFFFFLL);
+    *reg = (self[0] << 2) | (*reg & ~0xc);
+    *reg = (self[1] << 4) | (*reg & ~0x10);
+}

--- a/src/func_0206e030.c
+++ b/src/func_0206e030.c
@@ -1,0 +1,8 @@
+void func_0206e030(char *self)
+{
+    *(int *)(self + 0x24) = *(int *)(self + 0x1c);
+    *(int *)(self + 0x28) = *(int *)(self + 0x20);
+    *(int *)(((long long)(int)(self + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) -=
+        (*(int *)(self + 0x18) & *(int *)(self + 0x2c));
+    *(int *)(self + 0x34) = *(int *)(self + 0x18);
+}


### PR DESCRIPTION
Matched 64 functions, all verified byte-identical against mwccarm 1.2/sp2p3

- BgCh/WithMeshClsn single-bit flag setter/clearer family (25 funcs,
  0x02035xxx range)
- Bitfield-packing siblings around 0x02045e44-0x02046288
- This-adjusting virtual-destructor thunks at 0x02037[5b0,80c,d84,da4]
- ShadowModel::DoSetFile, SharedFilePtr::Release/LoadFile,
  BlendModelAnim::Advance, Actor::AfterInitResources
- Misc small arm9 helpers: func_020080b0, func_0200cbe0, func_0200f2cc,
  func_0200d1e4, func_02016acc, func_02021cd4, func_02007484,
  func_0204dc84, func_0204ffcc, func_020520dc, func_02052438,
  func_02057e00, func_02059f58, func_0205c4e4, func_0205c788,
  func_0205d4cc, func_020647a4, func_0206a424, func_0206e030
- ov002: Player::St_Squish_Cleanup, Player::St_CameraZoom_Cleanup