### PR TITLE
Match 12 high-divergence structural functions (Fable refine, div 19-25)

### DIFF
--- a/src/func_0205c9b8.c
+++ b/src/func_0205c9b8.c
@@ -1,6 +1,3 @@
-// NONMATCHING: missing logic (ROM does more) (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_0205d874(int *s);
 extern void func_0205d5e8(int *s, void *this, int a, int b, int e);
 extern void func_0205d3d4(int *s, int x, int n);
@@ -13,7 +10,7 @@ unsigned int func_0205c9b8(char *thiz, int arg1, unsigned int arg2) {
     int r4;
     int sz;
     sz = *(int*)(thiz + 0x24) + *(int*)(thiz + 0x2c) + 0x20;
-    r5 = (sz + 0x1f) & ~0x1f;
+    r5 = ((unsigned int)(sz & 0xFFFFFFFFFFFFFFFF) + 0x1f) & ~0x1f;
     if (r5 > arg2) goto done;
     r4 = (arg1 + 0x1f) & ~0x1f;
     func_0205d874(s);
@@ -28,9 +25,9 @@ unsigned int func_0205c9b8(char *thiz, int arg1, unsigned int arg2) {
     func_0205d3d4(s, r4, *(int*)(thiz + 0x2c));
     func_0205d4cc(s);
     *(int*)(thiz + 0x28) = r4;
-    *(int(**)(void))(thiz + 0x44) = func_0205d28c;
     *(int*)(thiz + 0x38) = arg1;
-    *(int*)(thiz + 0x10) |= 4;
+    *(int(**)(void))(thiz + 0x44) = func_0205d28c;
+    *(int *)(((int)thiz + 0x10) & 0xFFFFFFFFFFFFFFFF) |= 4;
 done:
     return r5;
 }

--- a/src/func_02070b98.c
+++ b/src/func_02070b98.c
@@ -1,11 +1,9 @@
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef short s16;
 void func_02070c68(void* x);
 void func_020715e0(void* thiz, int val);
 
+#pragma opt_strength_reduction off
 void func_02070b98(void* a0, int a1, int a2, void* d)
 {
     int n;
@@ -17,12 +15,12 @@ void func_02070b98(void* a0, int a1, int a2, void* d)
     if (n > 0x20) n = 0x20;
     func_020715e0(c, n);
     while (*(u8*)(c + 4) < n) {
-        c[5 + *(u8*)(c + 4)] = 0;
+        int t = *(u8*)(c + 4);
         *(u8*)(c + 4) += 1;
+        (c + t)[5] = 0;
     }
-    *(s16*)(c + 2) -= *(u8*)(c + 4) - 1;
-    if (*(u8*)(c + 4) <= 0) return;
+    *(s16*)(((int)c + 2) & 0xFFFFFFFFFFFFFFFF) -= *(u8*)(c + 4) - 1;
     for (i = 0; i < *(u8*)(c + 4); i++) {
-        *(u8*)(c + i + 5) += 0x30;
+        *(u8*)(((int)c + i + 5) & 0xFFFFFFFFFFFFFFFF) += 0x30;
     }
 }

--- a/src/func_ov013_021114cc.c
+++ b/src/func_ov013_021114cc.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int IsAreaShowing(int);
 extern void func_ov013_02111430(char* t);
 extern signed char data_02092110[];
@@ -8,16 +5,16 @@ extern short data_ov013_021116ac[];
 extern unsigned char data_0209f2c0[];
 int func_ov013_021114cc(char* c){
   if (data_02092110[0] <= 0) {
-    short* p = (short*)(c+0x90);
+    short* p = (short*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF);
     *p = *p + data_ov013_021116ac[*(unsigned char*)(c+0x124)];
   } else if (IsAreaShowing(*(signed char*)(c+0xcc)) && *(unsigned char*)(c+0x124) == 0) {
     unsigned short d = (unsigned short)(-*(short*)(c+0x90));
     if (d < 0x2000) data_0209f2c0[0] = 3;
-    else if (d < 0x6000) { if (d >= 0x2000) data_0209f2c0[0] = 0; }
-    else if (d < 0xa000) { if (d >= 0x6000) data_0209f2c0[0] = 2; }
-    else if (d < 0xe000) { if (d >= 0xa000) data_0209f2c0[0] = 1; }
-    else data_0209f2c0[0] = 3;
-    func_ov013_02111430(c);
+    else if (d < 0x6000 && d >= 0x2000) data_0209f2c0[0] = 0;
+    else if (d < 0xa000 && d >= 0x6000) data_0209f2c0[0] = 2;
+    else if (d < 0xe000 && d >= 0xa000) data_0209f2c0[0] = 1;
+    else if (d >= 0xe000) data_0209f2c0[0] = 3;
   }
+  func_ov013_02111430(c);
   return 1;
 }

--- a/src/func_ov016_0211276c.c
+++ b/src/func_ov016_0211276c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int _ZN16MeshColliderBase9IsEnabledEv(void* m);
 extern int _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* a);
 extern void func_020393a4(int* p, int v);
@@ -15,7 +12,7 @@ int func_ov016_0211276c(char* c){
   }
   func_020393a4((int*)(c+0x124), 0x2000000);
   if(*(unsigned char*)(c+0x31e) == 0){
-    *(short*)(c+0x320) += 0xda;
+    *(short*)(((int)c + 0x320) & 0xFFFFFFFFFFFFFFFF) += 0xda;
     *(short*)(c+0x8c) = (short)((*(short*)((char*)data_02082214 + ((*(unsigned short*)(c+0x320)>>4)<<2)) << 0xa) >> 0xc);
     if(_ZN5Actor13DistToCPlayerEv(c) < 0xbb8000){
       *(int*)(c+0x324) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int*)(c+0x324), 3, 0x8b, c+0x74, 0);

--- a/src/func_ov025_02111fa0.cpp
+++ b/src/func_ov025_02111fa0.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef short s16;
 struct SharedFilePtr { int x; }; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
@@ -37,20 +34,17 @@ int func_ov025_02111fa0(char *self){
         *(unsigned char*)(self + 0x372) = 0;
         *(s16*)(self + 0x370) = 0;
         switch (k) {
-        case 1: {
-            int* p60 = (int*)(self + 0x60);
-            unsigned short* p370 = (unsigned short*)(self + 0x370);
-            *p60 -= 0xfa000;
-            *p370 += 0x32;
+        case 0:
             break;
-        }
-        case 2: {
-            int* p60 = (int*)(self + 0x60);
-            *p60 -= 0x1f4000;
+        case 1:
+            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0xfa000;
+            *(unsigned short*)(((int)self + 0x370) & 0xFFFFFFFFFFFFFFFF) += 0x32;
+            break;
+        case 2:
+            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x1f4000;
             *(unsigned char*)(self + 0x372) = 1;
             *(int*)(self + 0xa8) = v;
             break;
-        }
         }
     }
     return 1;

--- a/src/func_ov030_02111bc4.c
+++ b/src/func_ov030_02111bc4.c
@@ -1,6 +1,3 @@
-// NONMATCHING: push-set / frame (div=19). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int func_ov030_021141a8(void *a, int b);
 extern void *Actor_ClosestPlayer(void *a);
 extern void *Actor_FindWithID(unsigned int id);
@@ -9,7 +6,7 @@ extern int Player_TryGrab(void *p, void *a);
 int func_ov030_02111bc4(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
-    void *o;
+    unsigned char *r4;
     int b;
 
     b = (int)((*(int *)(c + 0xb0) & 0x20000) != 0);
@@ -26,7 +23,7 @@ int func_ov030_02111bc4(void *thiz)
         return 1;
     }
 
-    if (*(int *)(c + 0x184) == 0)
+    if (*(unsigned int *)(c + 0x184) == 0)
         return 0;
 
     if ((*(int *)(c + 0x180) & 0x40000) && *(int *)(c + 0x3b4) != 2) {
@@ -36,36 +33,31 @@ int func_ov030_02111bc4(void *thiz)
         return 1;
     }
 
-    o = Actor_FindWithID(*(unsigned int *)(c + 0x180));
-    if (o == 0)
+    r4 = (unsigned char *)Actor_FindWithID(*(unsigned int *)(c + 0x184));
+    if (r4 == 0 || (b = (int)(*(unsigned short *)(r4 + 0xc) == 0xbf)) == 0)
         return 0;
-    {
-        unsigned char *r4 = (unsigned char *)o;
-        b = (int)(*(unsigned short *)(r4 + 0xc) == 0xbf);
-        if (b != 0) {
-            if (*(unsigned char *)(r4 + 0x706) != 0)
-                return 0;
-            if (*(unsigned char *)(r4 + 0x6f9) != 0)
-                return 0;
-            if (*(unsigned char *)(r4 + 0x6fb) != 0)
-                return 0;
-            if (*(unsigned char *)(r4 + 0x6ff) != 0)
-                return 0;
-            if (*(int *)(c + 0x180) & 0x1000) {
-                if (Player_TryGrab(r4, c)) {
-                    *(void **)(c + 0x3a8) = r4;
-                    b = (int)(*(unsigned short *)(c + 0xc) == 0x10b);
-                    if (b != 0) {
-                        func_ov030_021141a8(c, 3);
-                    } else {
-                        b = (int)(*(unsigned short *)(c + 0xc) == 0x10c);
-                        if (b != 0)
-                            func_ov030_021141a8(c, 4);
-                    }
-                }
+
+    if (*(unsigned char *)(r4 + 0x706) != 0)
+        return 0;
+    if (*(unsigned char *)(r4 + 0x6f9) != 0)
+        return 0;
+    if (*(unsigned char *)(r4 + 0x6fb) != 0)
+        return 0;
+    if (*(unsigned char *)(r4 + 0x6ff) != 0)
+        return 0;
+
+    if (*(int *)(c + 0x180) & 0x1000) {
+        if (Player_TryGrab(r4, c)) {
+            *(void **)(c + 0x3a8) = r4;
+            b = (int)(*(unsigned short *)(c + 0xc) == 0x10b);
+            if (b != 0) {
+                func_ov030_021141a8(c, 3);
+            } else {
+                b = (int)(*(unsigned short *)(c + 0xc) == 0x10c);
+                if (b != 0)
+                    func_ov030_021141a8(c, 4);
             }
-            return 1;
         }
     }
-    return 0;
+    return 1;
 }

--- a/src/func_ov036_02111854.c
+++ b/src/func_ov036_02111854.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef short s16;
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -12,17 +9,13 @@ int func_ov036_02111854(char* c) {
   *(unsigned char*)(c+0x118) = *(unsigned int*)(c+8) & 1;
   *(unsigned char*)(c+0x119) = (*(unsigned int*)(c+8) >> 8) & 1;
   if (*(unsigned char*)(c+0x118) != 0) {
-    s16* a = (s16*)(c+0x8c);
-    s16* b = (s16*)(c+0x8e);
-    s16* d = (s16*)(c+0x90);
-    s16* e = (s16*)(c+0x100);
-    *a += 0x2400;
-    *b += 0x8000;
-    *d += 0x8000;
-    e[8] = *a;
-    e[9] = *b;
-    e[10] = *d;
-    e[11] = 0;
+    *(s16 *)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF) += 0x2400;
+    *(s16 *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
+    *(s16 *)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
   }
+  *(s16*)(c+0x110) = *(s16*)(c+0x8c);
+  *(s16*)(c+0x112) = *(s16*)(c+0x8e);
+  *(s16*)(c+0x114) = *(s16*)(c+0x90);
+  *(s16*)(c+0x116) = 0;
   return 1;
 }

--- a/src/func_ov072_02120e50.cpp
+++ b/src/func_ov072_02120e50.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: push-set / frame (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Actor {
     char pad[0xc];
     unsigned short type;
@@ -25,16 +22,12 @@ extern "C" int func_ov072_02120e50(Player* self)
     int flag;
     if (self->f0184 == 0) return 0;
     a = Actor::FindWithID(self->f0184);
-    if (a == 0) return 0;
-    isType = (a->type == 0xbf);
-    if (isType == 0) return 0;
+    if (a == 0 || (isType = (a->type == 0xbf)) == 0) return 0;
     flag = ((self->f0b0 & 0x20000) != 0);
     if (flag) {
         self->f0360 = a;
         func_ov072_02121d50(self, 4);
-        return 1;
-    }
-    if ((self->f0180 & 0x1000) && ((Player*)a)->TryGrab(*(Actor*)self)) {
+    } else if ((self->f0180 & 0x1000) && ((Player*)a)->TryGrab(*(Actor*)self)) {
         self->f0360 = a;
         func_ov072_02121d50(self, 2);
     }

--- a/src/func_ov079_02123804.c
+++ b/src/func_ov079_02123804.c
@@ -1,0 +1,92 @@
+typedef signed char s8;
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Vector3 { int x, y, z; };
+
+extern s16 data_02082214[];
+extern int* data_ov079_021275ec[];
+
+extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
+extern int AngleDiff(int a, int b);
+extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char* self, const struct Vector3* pos, u32 n, int fix, s16 s);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* self, void* bca, int n, int fix, u32 flags);
+
+void func_ov079_02123804(char* self, char* other)
+{
+    struct Vector3 v;
+    int idx;
+    s16 cosv, sinv;
+    int ang;
+
+    {
+        int* q = (int*)(((int)other + 0x68) & 0xFFFFFFFFFFFFFFFFLL);
+        v.x = q[0];
+        v.y = q[1];
+        v.z = q[2];
+    }
+
+    idx = *(u16*)(other + 0x94) >> 4;
+    cosv = data_02082214[idx * 2];
+    sinv = data_02082214[idx * 2 + 1];
+    v.x = v.x - cosv * 0x50;
+    v.z = v.z - sinv * 0x50;
+
+    ang = Vec3_HorzAngle((struct Vector3*)(self + 0x5c), &v);
+
+    if (AngleDiff(ang, (s16)(*(s16*)(self + 0x8e) + *(s16*)(self + 0x3e2))) < 0x3c00) {
+        int r1 = *(int*)(self + 0x3b0);
+        if (r1 == 1 || r1 == 2 || r1 == 7 || r1 == 0xa) goto action1;
+        if (r1 != 0) return;
+        if (*(u8*)(self + 0x414) != 0) {
+            if (*(u8*)(self + 0x40c) != 0) return;
+        }
+    action1:
+        if (*(int*)(self + 0x3b0) != 0xa) {
+            *(int*)(self + 0x3b4) = *(volatile int*)(self + 0x3b0);
+            *(s16*)(self + 0x3fe) = *(u16*)(self + 0x100);
+            *(u8*)(self + 0x40d) = *(u8*)(self + 0x40c);
+        }
+        *(u8*)(self + 0x400) = 0x5a;
+        *(int*)(self + 0x98) = 0;
+        *(int*)(self + 0x3b0) = 0xa;
+        *(u8*)(self + 0x40b) = 1;
+        return;
+    }
+
+    if (AngleDiff(ang, (s16)(*(s16*)(self + 0x8e) + *(s16*)(self + 0x3e2))) <= 0x4400) return;
+
+    {
+        int r1 = *(int*)(self + 0x3b0);
+        if (r1 == 1 || r1 == 2 || r1 == 7 || r1 == 0xa) goto action2;
+        if (r1 != 0) return;
+        if (*(u8*)(self + 0x414) != 0) {
+            if (*(u8*)(self + 0x40c) != 0) return;
+        }
+    action2:
+        if (*(int*)(self + 0x3b0) != 0xa) {
+            *(int*)(self + 0x3b4) = *(volatile int*)(self + 0x3b0);
+            *(s16*)(self + 0x3fe) = *(u16*)(self + 0x100);
+            *(u8*)(self + 0x40d) = *(u8*)(self + 0x40c);
+        }
+        {
+            struct Vector3 pos;
+            int* q = (int*)(((int)other + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            pos.x = q[0];
+            pos.y = q[1];
+            pos.z = q[2];
+            _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(self, &pos, 1, 0, 0);
+        }
+        *(int*)(self + 0x98) = 0;
+        {
+            int* bca = data_ov079_021275ec[*(u8*)(self + 0x414) * 5];
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x2cc, (void*)bca[1], 0x40000000, 0x1000, 0);
+        }
+        *(int*)(self + 0x328) = 0x4000;
+        *(int*)(self + 0x3b0) = 0xb;
+        *(u8*)(self + 0x40b) = 1;
+        return;
+    }
+}

--- a/src/func_ov081_02127240.cpp
+++ b/src/func_ov081_02127240.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: missing logic (ROM does more) (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern void func_0201267c(int, void*);
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(void*);
@@ -19,16 +16,16 @@ int func_ov081_02127240(char* c){
       *(int*)(c+0x98)=0x12000;
       *(int*)(c+0xa8)=0x1e000;
       func_0201267c(0x77, c+0x74);
-      (*(unsigned char*)(c+0x3f1))++;
+      (*(unsigned char*)(((int)c + 0x3f1) & 0xFFFFFFFFFFFFFFFF))++;
     }
     break;
   case 1:
     if(_ZNK12WithMeshClsn13JustHitGroundEv(c+0x1e4)){
       func_0201267c(0x71, c+0x74);
+      func_ov081_021265c8(c);
     }
     break;
   }
-  func_ov081_021265c8(c);
   _ZN9Animation7AdvanceEv(c+0x124);
   _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x1b0);
   func_ov081_02126950(c, c+0x1e4);

--- a/src/func_ov085_0212a220.c
+++ b/src/func_ov085_0212a220.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef short s16;
 
@@ -20,7 +17,7 @@ int func_ov085_0212a220(char* c)
     switch (*(u8*)(c + 0x368)) {
     case 0:
         if (_ZN6Player9StartTalkER9ActorBaseb(*(void**)(c + 0x35c), c, 1) != 0)
-            *(u8*)(c + 0x368) += 1;
+            *(u8*)(((int)c + 0x368) & 0xFFFFFFFFFFFFFFFF) += 1;
         break;
     case 1:
         if (_Z14ApproachLinearRsss((s16*)(c + 0x8e),
@@ -33,7 +30,7 @@ int func_ov085_0212a220(char* c)
             v.y = v.y + 0xa0000;
             if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(
                     *(void**)(c + 0x35c), c, 0xd0, &v, 0, 0) != 0)
-                *(u8*)(c + 0x368) += 1;
+                *(u8*)(((int)c + 0x368) & 0xFFFFFFFFFFFFFFFF) += 1;
         }
         break;
     case 2:

--- a/src/func_ov091_02132108.cpp
+++ b/src/func_ov091_02132108.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=34). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef void (*PMFholder);
 struct Platform {
     void UpdateModelPosAndRotY();
@@ -22,8 +19,7 @@ extern "C" int func_ov091_02132108(Platform *self)
     char *s = (char*)self;
     int old = *(int*)(s + 0x320);
     (self->*data_ov091_021354e0[old].pmf)();
-    unsigned short *cnt = (unsigned short*)(s + 0x354);
-    *cnt = *cnt + 1;
+    *(unsigned short*)(((int)s + 0x354) & 0xFFFFFFFFFFFFFFFF) += 1;
     if (old != *(int*)(s + 0x320)) {
         *(short*)(s + 0x354) = 0;
         func_020393d4(s + 0x124, 0);
@@ -31,16 +27,15 @@ extern "C" int func_ov091_02132108(Platform *self)
         func_020393d4(s + 0x124, (void*)&UpdatePosWithVelocitySym);
     }
     if (*(unsigned char*)(s + 0x352) == 0) {
-        int t = (*(unsigned char*)(s + 0x356) != 0) ? 0x1e000 : 0;
+        int rate = 0x5000;
         int saved = *(int*)(s + 0x60);
-        ApproachLinearI((int*)(s + 0x34c), t, 0x5000);
-        *(int*)(s + 0x60) = *(int*)(s + 0x60) - *(int*)(s + 0x34c);
+        ApproachLinearI((int*)(s + 0x34c), (*(unsigned char*)(s + 0x356) != 0) ? 0x1e000 : 0, rate);
+        *(int*)(((int)s + 0x60) & 0xFFFFFFFFFFFFFFFF) -= *(int*)(s + 0x34c);
         *(int*)(s + 0x60) = saved;
-        self->UpdateModelPosAndRotY();
-        if (self->IsClsnInRange(0, 0) != 0) {
-            self->UpdateClsnPosAndRot();
-            *(unsigned char*)(s + 0x356) = 0;
-        }
     }
+    self->UpdateModelPosAndRotY();
+    if (self->IsClsnInRange(0, 0) != 0)
+        self->UpdateClsnPosAndRot();
+    *(unsigned char*)(s + 0x356) = 0;
     return 1;
 }


### PR DESCRIPTION
Twelve functions matched by pointing the refine specialist at the **high-divergence** end of the near-miss backlog — the "worst to crack" band that the standard `--max-div 6` refine tier never touches. All are genuine structural misses (not codegen floor), driven to byte-match with mwccarm 1.2/sp2p3.

### Functions (12)

| module | function | lang | note |
|---|---|---|---|
| arm9 | func_02070b98 | C | increment-before-store loop order + laundered RMW addrs; strength-reduction off |
| arm9 | func_0205c9b8 | C | split-const-fold laundering + store-order swap (missing-logic) |
| ov013 | func_ov013_021114cc | C | call hoisted to shared exit + `&&` range conjuncts + laundered base |
| ov016 | func_ov016_0211276c | C | u64-mask laundering forces the `+=` RMW full-address materialization |
| ov025 | func_ov025_02111fa0 | C++ | `case 0: break;` flag-reuse zero-test + laundered case-body RMW sites |
| ov030 | func_ov030_02111bc4 | C | CSE'd null-check load pins the arg register + merged `||` guard |
| ov036 | func_ov036_02111854 | C | unconditional +0x110 store block + three laundered RMW base adds |
| ov072 | func_ov072_02120e50 | C++ | merged `||` guard chain, fall-through kills if-conversion |
| ov079 | func_ov079_02123804 | C | volatile-qualified reload defeats guard-register CSE before adjacent store |
| ov081 | func_ov081_02127240 | C++ | laundered pooled-offset materialization + callee moved into case body |
| ov085 | func_ov085_0212a220 | C | laundering forces `addne`+ldrb/strb address materialization |
| ov091 | func_ov091_02132108 | C++ | laundered counter RMW + un-nested unconditional tail (real-vtable PMF) |

Four compile as C++ (real-vtable PMF dispatch). Each replaces a `// NONMATCHING` draft stub except `func_ov079_02123804`, which is new.

### Why high-divergence

A draft at divergence 22 is almost never 22 independent problems — it's usually **one** missing or CSE-elided instruction near the first diff whose absence shifts every downstream branch offset. Fix the earliest real divergence and the rest collapse. The dominant lever across this batch was u64-mask laundering (`*(int*)(((int)base + off) & 0xFFFFFFFFFFFFFFFF)`) to force address materialization the offset-fold otherwise hides.

### Near-miss DB (second commit)

Removes the 12 now-matched functions from the shared `nearmiss/db.jsonl` backlog so they no longer surface as refine candidates.

### Verification

All 12 independently oracle re-verified and link-checked (reconstructed linked bytes): 10 VERIFIED, 2 BLIND (unresolvable invented-extern reloc slots), **0 wrong-dest**.

Commits kept separate: src-only first, DB prune second. The `--high-div` tooling and codegen/runbook notes that produced this batch are in a separate PR.