### PR TITLE
Match func_ov001_020aa420 (ov001, 0x020aa420)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,4 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
-| ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | in progress |
+| ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | done - verified byte-identical |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | in progress |

--- a/src/func_ov001_020aa420.c
+++ b/src/func_ov001_020aa420.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=82). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -68,16 +65,15 @@ void func_ov001_020aa420(void) {
 
     for (; i < 3; i++) {
         best = 0;
-        handled = (int)best;
-
         node = data_ov001_020ad634[i];
+        handled = (int)best;
         flagByte = &data_ov001_020ad628[i];
         reqFlag = data_ov001_020ad628[i];
 
         if (reqFlag == 0) {
             if (node != 0) {
                 do {
-                    node->flags.b1 = 0;
+                    *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
                     if (node->field19 == 1) {
                         *flagByte = 1;
                     }
@@ -91,7 +87,7 @@ void func_ov001_020aa420(void) {
             }
         }
 
-        node = data_ov001_020ad634[i];
+        node = *(CapNode *volatile *)&data_ov001_020ad634[i];
 
         if (func_ov001_020aa79c(i) != 0) continue;
         if (*flagByte == 2) continue;
@@ -100,11 +96,11 @@ void func_ov001_020aa420(void) {
         if (node != 0) {
             do {
                 found = _ZN5Actor10FindWithIDEj(node->field8);
-                if (found != 0 || node->field4 != 0) {
+                if (found != 0 || (int)found != node->field4) {
                     if (node->flags.b0) {
                         if (node->soundHandle == -1) {
                             node->soundHandle = func_0202a8e0(node->field4, node->field18);
-                            node->flags.b1 = 1;
+                            *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
                             func_ov001_020aa6b0(node, 1);
                         }
                         handled = 1;
@@ -118,7 +114,7 @@ void func_ov001_020aa420(void) {
                         if (node->flags.b3) {
                             best = node;
                         } else {
-                            node->flags.b3 = 1;
+                            *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
                         }
                     }
                 } else {
@@ -129,7 +125,7 @@ void func_ov001_020aa420(void) {
         }
 
         if (func_ov001_020aa7b8(i, best) != 0) {
-            best->flags.b1 = 1;
+            *(u8 *)(((long long)(int)((char *)best + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
             best->soundHandle = func_0202a8e0(best->field4, best->field18);
             func_ov001_020aa6b0(best, 1);
             func_ov001_020aa6e4(i, best->field19, best);


### PR DESCRIPTION
Finishes the stored near-miss draft (div=82) for `func_ov001_020aa420` into a verified byte-identical match.

**Function:** `func_ov001_020aa420` @ `0x020aa420` (ov001), size `0x290`
**Compiler:** mwccarm 1.2/sp2p3
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Verified relocation-aware against the EU retail ov001 overlay:

```
tools/match.py --c src/func_ov001_020aa420.c --func func_ov001_020aa420 \
  --addr 0x020aa420 --size 0x290 --version 1.2/sp2p3 \
  --bin extracted/overlays/overlay_0001.bin --base 0x020aa420
=> MATCHING VERSIONS: 1.2/sp2p3
```

What closed the 82-div gap (all levers already documented in notes/mwccarm-codegen.md):
- u64-mask laundering (6g, wrapped-address spelling) for the four materialized flag-RMW sites at `node+0x1b` (`add rX,base,#0x1b; ldrb; orr/bic; strb`) that plain bitfield writes always fold.
- A `volatile`-qualified second load of `data_ov001_020ad634[i]` to defeat the head-pointer CSE (the ROM reloads through the same pool slot).
- Known-zero register reuse: `(int)found != node->field4` for the ROM's `cmp r0, r1`.
- Header statement order: the node load must precede `handled = (int)best` — fixes both the scheduler order and the literal-pool slot order (swept all 24 orderings; 4 match).

Also updates the CLAIMS.md row to done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)