### PR TITLE
Match 6 functions (ov002, ov006, ov065, ov080)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,5 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
+| ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -1,0 +1,22 @@
+//cpp
+/* _ZN6Player19St_CrazedCrate_InitEv at 0x020e0fac (ov002), size 0x74
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+extern "C" {
+extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
+extern void func_ov002_020e0f38(void* c, unsigned char a);
+int _ZN6Player19St_CrazedCrate_InitEv(char* c){
+  *(unsigned char*)(c+0x71b) = 0;
+  *(unsigned char*)(c+0x712) = 1;
+  *(unsigned char*)(c+0x70d) = 0;
+  *(unsigned char*)(c+0x6e1) = 0;
+  *(unsigned char*)(c+0x6de) = 1;
+  *(unsigned char*)(c+0x6df) = 0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x43, 0x40000000, 0x1000, 0);
+  func_ov002_020e0f38(c, *(unsigned char*)(c+0x6e1));
+  *(unsigned short*)(c+0x94) = *(short*)(c+0x8e);
+  *(int*)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+  return 1;
+}
+}

--- a/src/func_ov002_020cec2c.c
+++ b/src/func_ov002_020cec2c.c
@@ -1,0 +1,69 @@
+/* func_ov002_020cec2c at 0x020cec2c (ov002), size 0x184
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef signed char s8;
+
+struct Vector3 { int x, y, z; };
+
+extern int func_ov002_020ceb54(char *p);
+extern void _ZN6Player4HealEi(char *self, int a);
+extern int _ZN6Player9GetHealthEv(char *self);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vector3 *v, unsigned int d);
+extern int func_ov002_020d91e0(char *thiz, int damage, int doPre);
+extern void func_ov002_020da9d4(char *c);
+extern int func_ov002_020c5dec(char *c, int r1);
+
+extern s8 data_0209f2f8;
+
+int func_ov002_020cec2c(char *self)
+{
+    int flag;
+    int thresh;
+
+    if (*(u8 *)(self + 0x709) != 0 ||
+        *(u8 *)(self + 0x6f9) != 0 ||
+        *(u8 *)(self + 0x703) != 0 ||
+        *(u8 *)(self + 0x708) != 0)
+        return 0;
+
+    flag = 0;
+    if (data_0209f2f8 == 0x13 || data_0209f2f8 == 0x14 || data_0209f2f8 == 0x30)
+        flag = 1;
+
+    if (func_ov002_020ceb54(self) == 0 && flag == 0) {
+        *(u16 *)(self + 0x6ca) = 0;
+        if (*(u16 *)(self + 0x6b8) == 0) {
+            _ZN6Player4HealEi(self, 0x100);
+            *(u16 *)(self + 0x6b8) = 0xf;
+        }
+        return 0;
+    }
+
+    thresh = 0xf0;
+    if (flag != 0) thresh = 0x50;
+
+    if (_ZN6Player9GetHealthEv(self) <= 2) {
+        *(unsigned int *)(self + 0x624) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+            *(unsigned int *)(self + 0x624), 2, 0x27, (struct Vector3 *)(self + 0x74), 0);
+    }
+
+    {
+        u16 *p = (u16 *)(((long long)(int)(self + 0x6ca)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p = *p + 1;
+    }
+
+    if (*(u16 *)(self + 0x6ca) < thresh) goto ret0;
+
+    *(u16 *)(self + 0x6ca) = 0;
+    if (func_ov002_020d91e0(self, 0x100, 0) == 0) goto ret0;
+
+    func_ov002_020da9d4(self);
+    func_ov002_020c5dec(self, 7);
+    return 1;
+
+ret0:
+    return 0;
+}

--- a/src/func_ov006_020c87d0.cpp
+++ b/src/func_ov006_020c87d0.cpp
@@ -1,0 +1,67 @@
+//cpp
+/* func_ov006_020c87d0 at 0x020c87d0 (ov006), size 0x16c
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+typedef struct { int w[2]; } SharedFilePtr;
+typedef unsigned short u16;
+
+extern "C" {
+
+extern SharedFilePtr data_ov006_02140450;
+extern SharedFilePtr data_ov006_02140460;
+extern SharedFilePtr data_ov006_02140468;
+extern SharedFilePtr data_ov006_02140458;
+extern SharedFilePtr data_ov006_02140438;
+extern SharedFilePtr data_ov006_02140440;
+extern SharedFilePtr data_ov006_02140448;
+
+extern void* data_ov006_02140430;
+extern void* data_ov006_0214040c;
+extern void* data_ov006_0214041c;
+extern void* data_ov006_02140424;
+extern void* data_ov006_02140408;
+extern void* data_ov006_0214042c;
+
+extern char* data_ov006_02141a40;
+extern void* data_0209f5c0;
+
+extern int func_020179b4(SharedFilePtr* f, void* model, int a);
+extern void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+extern void func_ov006_020bfec0(char* p, void* q, short* s);
+extern void func_02016a14(void* self, int a);
+extern void func_02016a04(void* self, int a);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* file, int a, int b, unsigned c);
+extern void func_ov006_020c8658(void* c);
+
+int func_ov006_020c87d0(char* c)
+{
+    int t;
+
+    if (func_020179b4(&data_ov006_02140450, c + 0x4c, 1) == 0)
+        return 0;
+
+    data_ov006_02140430 = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140460);
+    data_ov006_0214040c = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140468);
+    data_ov006_0214041c = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140458);
+    data_ov006_02140424 = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140438);
+    data_ov006_02140408 = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140440);
+    data_ov006_0214042c = _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov006_02140448);
+
+    *(int*)(c + 0x44) = 0;
+    if (data_ov006_02141a40 != 0)
+        func_ov006_020bfec0(data_ov006_02141a40, c + 0x14, (short*)(c + 0x36));
+
+    t = *(u16*)((char*)data_0209f5c0 + 0xc) == 0x175;
+    if (t != false) {
+        func_02016a14(c + 0x4c, 0x7fff);
+        func_02016a04(c + 0x4c, 0x210);
+    }
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
+        c + 0x4c, data_ov006_02140430, 0x40000000, 0x800, 0);
+
+    func_ov006_020c8658(c);
+    return 1;
+}
+
+}

--- a/src/func_ov006_020ef794.c
+++ b/src/func_ov006_020ef794.c
@@ -1,0 +1,26 @@
+/* func_ov006_020ef794 at 0x020ef794 (ov006), size 0x64
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+typedef unsigned char u8;
+typedef short s16;
+
+extern void func_ov006_020c7490(void);
+extern void func_ov006_020ef768(char *self);
+extern void func_ov006_020c42bc(void);
+
+void func_ov006_020ef794(char *self)
+{
+    s16 *p = (s16 *)(((int)self + 0x5a74) & 0xFFFFFFFFFFFFFFFF);
+    *p = *p - 1;
+    if (*(s16 *)(self + 0x5a74) == 0) {
+        if (*(u8 *)(self + 0xc4) == 0) {
+            *(u8 *)(self + 0xc3) = 1;
+            *(u8 *)(self + 0xc4) = 1;
+            *(s16 *)(self + 0xc0) = 0;
+        }
+        func_ov006_020c7490();
+        func_ov006_020ef768(self);
+    }
+    func_ov006_020c42bc();
+}

--- a/src/func_ov065_0211a6d0.c
+++ b/src/func_ov065_0211a6d0.c
@@ -1,0 +1,62 @@
+/* func_ov065_0211a6d0 at 0x0211a6d0 (ov065), size 0x1a0
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern void func_020393c4(int* p, int v);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
+extern int func_020393bc(int* p);
+extern int _Z14ApproachLinearRiii(int* r, int t, int step);
+extern u16 DecIfAbove0_Short(u16* p);
+extern int RandomIntInternal(int* seed);
+extern void _ZN9Animation7AdvanceEv(void* a);
+extern void* _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int d);
+extern int func_ov065_0211a550(char* c);
+
+extern u8 data_0209f2c0;
+extern int func_ov065_0211aacc;
+extern int data_0209e650;
+extern int data_ov065_0211c0b8[];
+
+int func_ov065_0211a6d0(char* c)
+{
+    if (data_0209f2c0 == 3) {
+        func_020393c4((int*)(c + 0x124), 0);
+        _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
+    } else {
+        if (((*(int*)(c + 0xb0) & 8) ? 1 : 0) == 0) {
+            if (func_020393bc((int*)(c + 0x124)) == 0) {
+                func_020393c4((int*)(c + 0x124), (int)&func_ov065_0211aacc);
+            }
+
+            if (data_0209f2c0 == 2) {
+                if (_Z14ApproachLinearRiii((int*)(c + 0x38c), *(int*)(c + 0x390), 0xcc) != 0
+                    && DecIfAbove0_Short((u16*)(c + 0x39c)) == 0) {
+                    unsigned int r = (u16)((unsigned int)RandomIntInternal(&data_0209e650) >> 0x10);
+                    *(s16*)(c + 0x300 + 0x9c) = (s16)(((int)r % 7) * 0x14 + 0xa);
+                    if (r >= 0x7fff) {
+                        *(int*)(c + 0x390) = 0x1000;
+                    } else {
+                        *(int*)(c + 0x390) = -0x1000;
+                    }
+                }
+            } else {
+                *(int*)(c + 0x38c) = data_ov065_0211c0b8[data_0209f2c0];
+            }
+
+            *(int*)(c + 0x32c) = *(int*)(c + 0x38c);
+            _ZN9Animation7AdvanceEv(c + 0x320);
+            if (*(int*)(c + 0x38c) != 0) {
+                *(int*)(c + 0x398) = (int)_ZN5Sound8PlayLongEjjjRK7Vector3j(*(int*)(c + 0x398), 3, 0x88, c + 0x74, 0);
+            }
+        }
+
+        _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
+    }
+
+    func_ov065_0211a550(c);
+    return 1;
+}

--- a/src/func_ov080_02123fcc.cpp
+++ b/src/func_ov080_02123fcc.cpp
@@ -1,0 +1,35 @@
+//cpp
+/* func_ov080_02123fcc at 0x02123fcc (ov080), size 0xbc
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+struct Actor;
+extern "C" Actor* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, Actor* after);
+
+extern "C" void func_ov080_02123fcc(char* thiz)
+{
+    char* c = thiz;
+    {
+        int* p150 = (int*)(((int)c + 0x150) & 0xFFFFFFFFFFFFFFFF);
+        int* pb0 = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+        *p150 = *p150 | 1;
+        *pb0 = *pb0 & ~0x10000000;
+    }
+    if (*(unsigned char*)(c + 0x180) != 0) {
+        Actor* a = 0;
+        while (1) {
+            a = _ZN5Actor15FindWithActorIDEjPS_(0x136, a);
+            if (a == 0) break;
+            if (a != (Actor*)c) {
+                if (*(unsigned char*)(c + 0x182) == *(unsigned char*)((char*)a + 0x182)) {
+                    *(int*)(c + *(unsigned char*)(c + 0x183) * 4 + 0x16c) = *(int*)((char*)a + 4);
+                    (*(unsigned char*)(c + 0x183))++;
+                    if (*(unsigned char*)(c + 0x183) == 4) break;
+                }
+            }
+        }
+        *(int*)(c + 0x17c) = 1;
+        return;
+    }
+    *(int*)(c + 0x17c) = 1;
+}


### PR DESCRIPTION
Six functions matched byte-for-byte with **mwccarm 1.2/sp2p3** (flags `-O4,p -enum int -lang c99/c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`). Each verified relocation-aware against the ROM bytes.

| function | module | addr | size | key |
|---|---|---|---|---|
| `func_ov006_020ef794` | ov006 | 0x020ef794 | 0x64 | tail calls belong inside the `counter==0` branch |
| `_ZN6Player19St_CrazedCrate_InitEv` | ov002 | 0x020e0fac | 0x74 | u64-mask launder for the materialized `+0x2ec` base |
| `func_ov080_02123fcc` | ov080 | 0x02123fcc | 0xbc | loop-exit epilogue grouping (`a==0` joins the `0x183==4` exit; `c+0x180==0` separate) |
| `func_ov006_020c87d0` | ov006 | 0x020c87d0 | 0x16c | `SetAnim` runs unconditionally after the `id==0x175` guard |
| `func_ov002_020cec2c` | ov002 | 0x020cec2c | 0x184 | `0x6b8=0xf` store belongs inside the `==0` guard |
| `func_ov065_0211a6d0` | ov065 | 0x0211a6d0 | 0x1a0 | shared `func_ov065_0211a550` tail via if/else |

Started from the near-miss DB div=1 drafts; each residual was a single control-flow/base-materialization fix. CLAIMS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)