### PR TITLE
Match 4 functions (ov006, ov020, ov062)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,5 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| batch2 matched: func_ov062_021161a8, func_ov062_02119628, func_ov020_021112b0, func_ov006_0210d6b8 | ruspecial (Claude-assisted) | 2026-07-06 | done - 4 verified byte-identical |
+| batch2 NONMATCHING near-misses: func_ov002_020bf224, func_ov007_020bc3dc, func_0205d304, _ZN16MeshColliderBase6EnableEP5Actor, func_0206e3dc | ruspecial (Claude-assisted) | 2026-07-06 | near-miss div=2-3 (regperm/predicated-order/schedule walls) |

--- a/src/func_ov006_0210d6b8.cpp
+++ b/src/func_ov006_0210d6b8.cpp
@@ -1,0 +1,29 @@
+//cpp
+/* func_ov006_0210d6b8 at 0x0210d6b8 (ov006), size 0x88
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+extern "C" {
+extern void *_ZN9ActorBasenwEj(unsigned int sz);
+extern void func_ov004_020b2adc(void *);
+extern void func_ov006_0210c2b0(char *p);
+extern void func_ov006_0210c208(char *p);
+extern void *data_ov006_0213eb40[];
+extern void *data_ov006_0213e5d4[];
+extern void func_020ad494();
+void *func_ov006_0210d6b8(void);
+void *func_ov006_0210d6b8(void) {
+    char *p = (char *)_ZN9ActorBasenwEj(0x4710);
+    if (p) {
+        func_ov004_020b2adc(p);
+        *(void ***)p = data_ov006_0213eb40;
+        char *base = (char *)(((int)p + 0x4660) & 0xFFFFFFFFFFFFFFFF);
+        *(void **)base = (void *)&func_020ad494;
+        *(void ***)base = data_ov006_0213e5d4;
+        func_ov006_0210c2b0(p + 0x4684);
+        func_ov006_0210c2b0(p + 0x4690);
+        func_ov006_0210c208(p + 0x469c);
+    }
+    return p;
+}
+}

--- a/src/func_ov020_021112b0.c
+++ b/src/func_ov020_021112b0.c
@@ -1,34 +1,27 @@
-// NONMATCHING: extra logic (you do more) (div=2). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+/* func_ov020_021112b0 at 0x021112b0 (ov020), size 0x90
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+struct Vec3 { int x, y, z; };
 
-struct Vec3
-{
-  int x;
-  int y;
-  int z;
-};
 extern char *Actor_ClosestPlayer(void *);
 extern void Vec3_Sub(struct Vec3 *d, struct Vec3 *a, struct Vec3 *b);
 extern short cstd_atan2(int, int);
 extern int Vec3_HorzLen(struct Vec3 *);
+
 void func_ov020_021112b0(char *c)
 {
-  char *new_var;
   char *p = Actor_ClosestPlayer(c);
-  new_var = p + 0x5c;
   if (!p)
-  {
     return;
-  }
-  struct Vec3 *ps = (struct Vec3 *) new_var;
+  struct Vec3 *ps = (struct Vec3 *)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
   struct Vec3 tmp;
   tmp.x = ps->x;
   tmp.y = ps->y;
   tmp.z = ps->z;
   struct Vec3 d;
-  Vec3_Sub(&d, &tmp, (struct Vec3 *) (c + 0x5c));
-  *((short *) (c + 0x446)) = cstd_atan2(d.x, d.z);
-  *((short *) (c + 0x444)) = cstd_atan2(d.y, Vec3_HorzLen(&d));
-  *((short *) (c + 0x448)) = 0x4000;
+  Vec3_Sub(&d, &tmp, (struct Vec3 *)(c + 0x5c));
+  *((short *)(c + 0x446)) = cstd_atan2(d.x, d.z);
+  *((short *)(c + 0x444)) = cstd_atan2(d.y, Vec3_HorzLen(&d));
+  *((short *)(c + 0x448)) = 0x4000;
 }

--- a/src/func_ov062_021161a8.c
+++ b/src/func_ov062_021161a8.c
@@ -1,5 +1,7 @@
-// NONMATCHING: instruction reorder (div=2). beq/add r3 order at +0x5c/+0x60.
-// if(1) block required for correct function size (0x90 vs 0x8c without it).
+/* func_ov062_021161a8 at 0x021161a8 (ov062), size 0x90
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
 extern int _ZNK9Animation12WillHitFrameEi(char *anim, int f);
 extern int func_ov002_020db54c(int p, int a, int b, int s);
 extern int func_02012694(int id, void *pos);
@@ -9,21 +11,17 @@ extern int data_ov062_0211ded0[];
 
 int func_ov062_021161a8(char *c)
 {
-    int new_var;
-    int *q;
-
-    if (*(int *)(c + 0x3f8) != 0 && _ZNK9Animation12WillHitFrameEi(c + 0x350, 0x14)) {
-        func_ov002_020db54c(*(int *)(c + 0x3f8), 0x28000, 0x50000, *(short *)(c + 0x8e));
-        *(int *)(c + 0x3f8) = 0;
-        func_02012694(0x126, c + 0x74);
-    }
-    if (1) {
-        new_var = _ZN9Animation8FinishedEv(c + 0x350);
-        q = (int *)(c + 0x128);
-    }
-    if (new_var) {
-        *q &= ~2;
-        func_ov062_02116cd8(c, data_ov062_0211ded0);
-    }
-    return 1;
+  if (*(int *)(c + 0x3f8) != 0 && _ZNK9Animation12WillHitFrameEi(c + 0x350, 0x14))
+  {
+    func_ov002_020db54c(*(int *)(c + 0x3f8), 0x28000, 0x50000, *(short *)(c + 0x8e));
+    *(int *)(c + 0x3f8) = 0;
+    func_02012694(0x126, c + 0x74);
+  }
+  if (_ZN9Animation8FinishedEv(c + 0x350))
+  {
+    int *q = (int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL);
+    *q &= ~2;
+    func_ov062_02116cd8(c, data_ov062_0211ded0);
+  }
+  return 1;
 }

--- a/src/func_ov062_02119628.cpp
+++ b/src/func_ov062_02119628.cpp
@@ -1,0 +1,31 @@
+//cpp
+/* func_ov062_02119628 at 0x02119628 (ov062), size 0x80
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+extern "C" {
+struct Actor {
+    virtual void v0();
+    virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4();
+    virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8();
+    virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12();
+    virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16();
+    virtual void v17(); virtual int Slot18();
+    char pad[0x104]; unsigned char f108;
+};
+extern int _ZN6Player15IsCollectingCapEv(void *p);
+extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, bool b, bool c);
+extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char b, unsigned int n);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
+void func_ov062_02119628(Actor *c, void *player) {
+#pragma optimize_for_size on
+    if (c->f108 == 3) {
+        if (c->Slot18() == 6 && _ZN6Player15IsCollectingCapEv(player) == 0) {
+            _ZN6Player20RegisterEggCoinCountEjbb(player, 0, 0, 1);
+        } else {
+            _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, 1, 2);
+        }
+    }
+    _ZN5Actor24KillAndTrackInDeathTableEv(c);
+}
+}


### PR DESCRIPTION
Four functions matched byte-for-byte with **mwccarm 1.2/sp2p3**, relocation-aware.

| function | module | addr | size | key |
|---|---|---|---|---|
| `func_ov062_021161a8` | ov062 | 0x021161a8 | 0x90 | u64-launder the `*(c+0x128) &= ~2` RMW so its base materializes *after* the `Finished()` branch |
| `func_ov062_02119628` | ov062 | 0x02119628 | 0x80 | `KillAndTrack` is unconditional (outside the `f108==3` block); if/else coin path; `#pragma optimize_for_size on` to share the epilogue |
| `func_ov020_021112b0` | ov020 | 0x021112b0 | 0x90 | compute `ClosestPlayer()+0x5c` after the null check, laundered for the materialized-base struct copy |
| `func_ov006_0210d6b8` | ov006 | 0x0210d6b8 | 0x88 | store `*p = vtable` before computing `base` so the literal-pool words load in ROM order |

Started from the near-miss DB drafts; each residual was a control-flow / statement-order / base-materialization fix. CLAIMS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)