### PR TITLE
NONMATCHING near-misses: 5 functions (div 2-3)

### DIFF
--- a/src/_ZN16MeshColliderBase6EnableEP5Actor.cpp
+++ b/src/_ZN16MeshColliderBase6EnableEP5Actor.cpp
@@ -1,0 +1,32 @@
+//cpp
+// NONMATCHING: regperm: the pooled base data_020a0c80 colors into r1 (`ldr r1;ldr r0,[r1,r4,lsl#2]`) but the ROM uses r2. Occupying r1 (e.g. passing the dead `a` param) forces r2 but changes a call arg; no zero-cost lever found. (div=2)
+/* _ZN16MeshColliderBase6EnableEP5Actor at 0x02039184 (arm9), size 0x6c
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
+typedef int s32;
+
+extern void func_020395fc(void* c);
+extern void func_020393fc(void* p, int v);
+extern void* data_020a0c80[];
+
+struct Actor;
+
+struct MeshColliderBase {
+    int Enable(Actor* a);
+};
+
+int MeshColliderBase::Enable(Actor* a)
+{
+    s32 i = 0;
+    for (;;) {
+        if (data_020a0c80[i] == 0) {
+            func_020395fc(this);
+            func_020393fc(this, i);
+            data_020a0c80[i] = this;
+            return 1;
+        }
+        i++;
+        if (i >= 0x18) break;
+    }
+    return 0;
+}

--- a/src/func_0205d304.c
+++ b/src/func_0205d304.c
@@ -1,0 +1,24 @@
+// NONMATCHING: loop-setup scheduling: `shift=0` (mov r3,lr) is emitted before the `while(i<n)` entry guard, but the ROM schedules it after the guard. Declaration order and loop-form permutations do not move it. (div=3)
+/* func_0205d304 at 0x0205d304 (arm9), size 0x64
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
+int func_0205d304(unsigned char* s, int n)
+{
+    int result = 0;
+    if (n <= 3) {
+        int i = 0;
+        int shift = 0;
+        while (i < n) {
+            unsigned int c = s[i];
+            unsigned int t;
+            if (c == 0) break;
+            t = c - 0x41;
+            if (t <= 0x19) t = t + 0x61;
+            else t = t + 0x41;
+            result |= t << shift;
+            i++;
+            shift += 8;
+        }
+    }
+    return result;
+}

--- a/src/func_0206e3dc.c
+++ b/src/func_0206e3dc.c
@@ -1,32 +1,24 @@
-﻿/* NONMATCHING: register allocation (div=2). ctx.z=0 uses r2; ROM uses ip. */
+// NONMATCHING: ip-coloring: `ctx.z=0` colors into r2 (`mov r2,#0;str r2,[sp,#8]`) but the ROM uses ip (`mov ip,#0;str ip,[sp,#8]`). Field-order, aggregate-init, and named-temp forms do not select ip. (div=2)
+/* func_0206e3dc at 0x0206e3dc (arm9), size 0x74
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
 extern void func_0206e450(void);
-extern unsigned int func_0206e4a4(void (*fn)(void), void *ctx);
-
-struct Ctx {
-    char *buf;
-    unsigned int len;
-    int z;
-};
-
-unsigned int func_0206e3dc(char *buf, unsigned int len)
-{
+extern unsigned int func_0206e4a4(void (*fn)(void), void* ctx);
+struct Ctx { char* buf; unsigned int len; int z; };
+unsigned int func_0206e3dc(char* buf, unsigned int len) {
     struct Ctx ctx;
     unsigned int r;
-
     ctx.buf = buf;
     ctx.len = len;
     ctx.z = 0;
     r = func_0206e4a4(func_0206e450, &ctx);
-    if (buf == 0) {
-        return r;
-    }
+    if (buf == 0) return r;
     if (r < len) {
         buf[r] = 0;
         return r;
     }
     if (len != 0) {
-        char *end = buf + len;
-
+        char* end = buf + len;
         end[-1] = 0;
     }
     return r;

--- a/src/func_ov002_020bf224.c
+++ b/src/func_ov002_020bf224.c
@@ -1,0 +1,11 @@
+// NONMATCHING: predicated-select register/direction: `if(r<c) r=c` emits `movge r2,r1;mov r0,r2` but ROM has `movlt r1,r2;mov r0,r1`. The fixed-point result stays in r1 in the ROM; every clamp phrasing (ternary, override, early-return) either collapses the mov (in-place r0) or picks r2. (div=2)
+/* func_ov002_020bf224 at 0x020bf224 (ov002), size 0x58
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
+extern unsigned char data_020a0e40[];
+extern short data_0209f4a0[];
+int func_ov002_020bf224(int a, int b, int c) {
+  long long p = (long long)b * *(short*)((char*)data_0209f4a0 + data_020a0e40[0]*0x18);
+  int r = (int)((p + 0x800) >> 12);
+  return r < c ? c : r;
+}

--- a/src/func_ov007_020bc3dc.c
+++ b/src/func_ov007_020bc3dc.c
@@ -1,21 +1,13 @@
+// NONMATCHING: materialized-bool emission order: `flag=(p[4]!=0)` emits `movne lr,#1;moveq lr,#0` but ROM emits `moveq lr,#0;movne lr,#1` (eq-first). No ternary/compare-direction/type spelling flips the predicated-mov order. (div=2)
+/* func_ov007_020bc3dc at 0x020bc3dc (ov007), size 0x58
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
 extern int func_ov007_020c9214();
-
-/* NONMATCHING: instruction reorder (div=2). moveq/movne lr order at +0x34/+0x38. */
-void func_ov007_020bc3dc(void *c, int i, int a2)
-{
-    unsigned short **arr;
-    unsigned short *p;
-    int lr;
-
-    arr = *(unsigned short ***)((char *)c + 0x14);
-    p = arr[i];
-    if (p == 0) {
-        return;
-    }
-    if (*(unsigned char *)((char *)p + 4) == 0) {
-        lr = 0;
-    } else {
-        lr = 1;
-    }
-    func_ov007_020c9214(*(void **)((char *)c + 0x18), i, lr, *(unsigned short *)((char *)p + 2), a2, 0x1000);
+void func_ov007_020bc3dc(void* c, int i, int a2){
+  unsigned short** arr = *(unsigned short***)((char*)c+0x14);
+  unsigned short* p = arr[i];
+  int flag;
+  if(p==0) return;
+  flag = (*(unsigned char*)((char*)p+4) != 0) ? 1 : 0;
+  func_ov007_020c9214(*(void**)((char*)c+0x18), i, flag, *(unsigned short*)((char*)p+2), a2, 0x1000);
 }


### PR DESCRIPTION
Closest compiling drafts for five functions, each 2-3 instructions from matching with **mwccarm 1.2/sp2p3**. Every residual was verified to be a register-allocation / emission-order wall (not wrong logic); each file's `// NONMATCHING` header records the exact divergence and the levers already tried, for the refine tier.

| function | module | div | wall |
|---|---|---|---|
| `func_ov002_020bf224` | ov002 | 2 | predicated clamp colors to `movge r2,r1;mov r0,r2`; ROM has `movlt r1,r2;mov r0,r1`. In-place phrasings collapse the final `mov`; no phrasing keeps the value in r1 with the override direction. |
| `func_ov007_020bc3dc` | ov007 | 2 | materialized bool emits `movne lr,#1;moveq lr,#0`; ROM is eq-first (`moveq;movne`). No ternary/compare-direction/type spelling flips the order. |
| `func_0205d304` | arm9 | 3 | `shift=0` (`mov r3,lr`) schedules before the `while(i<n)` entry guard; ROM emits it after. Decl-order/loop-form permutations don't move it. |
| `_ZN16MeshColliderBase6EnableEP5Actor` | arm9 | 2 | pooled base colors to r1; ROM uses r2. Occupying r1 forces r2 but only by changing a call arg. |
| `func_0206e3dc` | arm9 | 2 | `ctx.z=0` colors to r2; ROM uses `ip`. Field-order/aggregate-init/named-temp don't select ip. |

These match the existing near-miss DB entries; the added value is the src/ drafts plus the documented wall analysis. (`func_ov063_0211640c`, also in this batch, stays at its existing div=1 near-miss PR #92 — the `s16*-1`→`rsb` vs `smulbb` wall is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)