### PR TITLE
Match 4 functions (ov002 HUD, ov004, ov060, ov078)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,5 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| batch3 matched: func_ov078_02125c98, func_ov060_021146d0, func_ov004_020b7cd0, _ZN3HUD15RenderCoinCountEv | ruspecial (Claude-assisted) | 2026-07-06 | done - 4 verified byte-identical |
+| batch3 NONMATCHING near-misses: func_ov079_02126a84 (div2), func_ov095_021365d8 (div3) | ruspecial (Claude-assisted) | 2026-07-06 | scheduling residuals (arg-setup / store-hoist emission order) |

--- a/src/_ZN3HUD15RenderCoinCountEv.cpp
+++ b/src/_ZN3HUD15RenderCoinCountEv.cpp
@@ -1,0 +1,62 @@
+//cpp
+/* _ZN3HUD15RenderCoinCountEv at 0x020fc81c (ov002), size 0x1fc
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+struct Matrix2x2;
+struct OamAttr;
+
+extern "C" {
+extern unsigned char data_0209f2d8;
+extern unsigned char data_0209f250;
+extern unsigned short data_0209f358[];
+extern signed char data_0209f2f8;
+extern OamAttr* func_020aba70[];
+extern OamAttr func_020ab9c8;
+extern OamAttr func_020abad8;
+extern int SublevelToLevel(int i);
+}
+
+struct HUD {
+    char pad[0x74];
+    signed char digits[3];
+    void CalculateDigits(unsigned short n);
+    void RenderCoinCount();
+};
+
+namespace OAM {
+    void Render(bool vis, OamAttr* attr, int x, int y, int a, int b, Matrix2x2* m);
+}
+
+void HUD::RenderCoinCount()
+{
+    int t = (data_0209f2d8 == 1);
+    if (t != false) {
+        int sb = 0xf0;
+        CalculateDigits(data_0209f358[data_0209f250]);
+        for (int i = 2; i >= 0; i--) {
+            signed char d = digits[i];
+            if (d >= 0) {
+                OAM::Render(true, func_020aba70[d], sb, 2, -1, 1, 0);
+                sb -= 9;
+            }
+        }
+        OAM::Render(true, &func_020ab9c8, sb, 0xa, -1, 1, 0);
+        OAM::Render(true, &func_020abad8, sb - 0x10, 2, -1, 1, 0);
+    } else {
+        if (SublevelToLevel(data_0209f2f8) == 0x1d)
+            return;
+        int i;
+        int sb = 0xf0;
+        CalculateDigits(data_0209f358[data_0209f250]);
+        for (i = 2; i >= 0; i--) {
+            signed char d = digits[i];
+            if (d >= 0) {
+                OAM::Render(false, func_020aba70[d], sb, 2, -1, 1, 0);
+                sb -= 9;
+            }
+        }
+        OAM::Render(false, &func_020ab9c8, sb, 0xa, -1, 1, 0);
+        OAM::Render(false, &func_020abad8, sb - 0x10, 2, -1, 1, 0);
+    }
+}

--- a/src/func_ov004_020b7cd0.cpp
+++ b/src/func_ov004_020b7cd0.cpp
@@ -1,0 +1,66 @@
+//cpp
+/* func_ov004_020b7cd0 at 0x020b7cd0 (ov004), size 0x168
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+struct Base {
+  virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
+  virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();
+  virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11();
+  virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+  virtual void v16(); virtual void v17(); virtual void v18();
+  virtual int m_4c(void* arg);   /* slot 19 -> 0x4c */
+};
+extern "C" void func_ov004_020ae20c(void);
+extern "C" void func_ov004_020b0aa0(int arg);
+extern "C" void func_ov004_020ae2c8(void);
+extern "C" void func_ov004_020b29a0(Base* c, void* arg);
+extern Base* data_ov004_020beb68;
+extern void* data_ov004_020bc7d4;
+extern void* data_ov004_020bfa24;
+struct Pair { int a; int b; };
+extern struct Pair data_ov004_020bc904;
+
+extern "C" void func_ov004_020b7cd0(char* c){
+  int state = *(int*)(c + 0x1c);
+  if (state > 0x64)
+    return;
+  Base* p = data_ov004_020beb68;
+  int a8 = (p != 0) ? *(int*)((char*)p + 0xa8) : 0;
+  if (a8 == 0) {
+    if (state != 0)
+      return;
+    Base* q = data_ov004_020beb68;
+    if (q == 0)
+      return;
+    if (q->m_4c(*(void**)(c + 0x18)) == 0)
+      return;
+    data_ov004_020bc7d4 = 0;
+    data_ov004_020bfa24 = 0;
+    func_ov004_020ae20c();
+    func_ov004_020b0aa0(0x1d);
+    *(int*)(c + 0x1c) = 0xb4;
+    {
+        int a = data_ov004_020bc904.a;
+        int b = data_ov004_020bc904.b;
+        *(int*)(c + 8) = b ? a : a;
+        *(int*)(c + 0xc) = b;
+    }
+  } else {
+    if (state != 0)
+      return;
+    Base* r5 = data_ov004_020beb68;
+    if (r5 == 0)
+      return;
+    if (r5->m_4c(*(void**)(c + 0x18)) == 0)
+      return;
+    func_ov004_020b0aa0(0x1d);
+    func_ov004_020ae20c();
+    func_ov004_020ae2c8();
+    func_ov004_020b29a0(r5, *(void**)(c + 0x18));
+    *(int*)(c + 0x1c) = 0;
+    *(int*)(c + 0x18) = -1;
+    *(int*)(c + 0x20) = 0;
+    *(int*)(c + 0x24) = 0;
+  }
+}

--- a/src/func_ov060_021146d0.c
+++ b/src/func_ov060_021146d0.c
@@ -1,0 +1,62 @@
+/* func_ov060_021146d0 at 0x021146d0 (ov060), size 0x188
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef signed char s8;
+
+extern void func_02012694(int a, void *b);
+extern void func_ov060_02111cc0(char *c, int idx, int m);
+extern void func_ov060_02115a84(char *c, char *arg);
+extern int func_ov060_02115a30(char *c);
+
+void func_ov060_021146d0(char *c) {
+    if (*(u16*)(c + 0x300 + 0xfc) == 0) {
+        *(int*)(c + 0x98) = -0x1c000;
+        *(int*)(c + 0xa8) = 0x50000;
+        *(s16*)(c + 0x8e) = *(s16*)(c + 0x400 + 8) + 0x8000;
+        *(u8*)(c + 0x422) = 1;
+        *(s16*)(c + 0x8c) = -0xc00;
+        func_02012694(0xb1, c + 0x74);
+    } else {
+        if (*(u16*)(c + 0x8c) > 0xc00) {
+            s16 *p8c = (s16*)(((long long)(int)((char*)c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p8c = *p8c - 0xc00;
+        } else {
+            *(u16*)(c + 0x8c) = 0;
+        }
+    }
+    {
+        u8 st = *(u8*)(c + 0x423);
+        if (st == 0) {
+            func_ov060_02111cc0(c, 1, 0x40000000);
+            {
+                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p = *p + 1;
+            }
+            *(u16*)(c + 0x300 + 0xfe) = 0;
+            return;
+        }
+        if (st == 1) {
+            func_ov060_02115a84(c, c + 0x3fe);
+            if (*(u16*)(c + 0x300 + 0xfe) == 1)
+                func_ov060_02111cc0(c, 2, 0x40000000);
+            if (*(u16*)(c + 0x300 + 0xfe) < 3) return;
+            *(int*)(c + 0xa8) = 0;
+            *(int*)(c + 0x98) = 0;
+            {
+                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p = *p + 1;
+            }
+            return;
+        }
+        if (st != 2) return;
+        if (func_ov060_02115a30(c) != 0) {
+            if (*(s8*)(c + 0x400 + 0x1e) == 1) *(int*)(c + 0x40c) = 3;
+            else *(int*)(c + 0x40c) = 0;
+        }
+        *(u8*)(c + 0x422) = 0;
+    }
+}

--- a/src/func_ov078_02125c98.cpp
+++ b/src/func_ov078_02125c98.cpp
@@ -1,0 +1,50 @@
+//cpp
+/* func_ov078_02125c98 at 0x02125c98 (ov078), size 0x148
+ * Matched byte-for-byte with mwccarm 1.2/sp2p3.
+ * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
+ */
+struct Vector3;
+struct Actor;
+struct RaycastGround {
+  char pad[0x44];
+  int result;
+  char pad2[8];
+  RaycastGround();
+  ~RaycastGround();
+  void SetObjAndPos(const Vector3& pos, Actor* a);
+  int DetectClsn();
+};
+struct Mtx { int w[12]; };
+extern "C" {
+int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, int fix, int t, unsigned int j);
+}
+extern Mtx data_02082128;
+
+extern "C" void func_ov078_02125c98(char* c) {
+  int h = *(int*)(c+0x60);
+  if (_ZNK12WithMeshClsn10IsOnGroundEv(c+0x110) == 0) {
+    RaycastGround rg;
+    rg.SetObjAndPos(*(const Vector3*)(c+0x5c), 0);
+    if (rg.DetectClsn() != 0)
+      h = rg.result;
+  }
+  int b = (*(int*)(c+0xb0) & 0x4000) != 0;
+  if (b) {
+    char* p = *(char**)(c+0x494);
+    if (p != 0)
+      h = *(int*)(p+0x60);
+  }
+  int ip = *(int*)(c+0x60) - h;
+  if (ip <= 0x1000)
+    ip = 0x1000;
+  int r8 = 0x15e000 - (int)(((long long)ip * 0x180 + 0x800) >> 12);
+  if (r8 < 0xa000)
+    r8 = 0xa000;
+  *(Mtx*)(c+0x434) = data_02082128;
+  *(int*)(c+0x458) = *(int*)(c+0x5c) >> 3;
+  *(int*)(c+0x45c) = *(int*)(c+0x60) >> 3;
+  *(int*)(c+0x460) = *(int*)(c+0x64) >> 3;
+  _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
+      c, c+0x3f8, c+0x434, r8, ip + 0x28000, 0xf);
+}


### PR DESCRIPTION
Four functions matched byte-for-byte with **mwccarm 1.2/sp2p3**, relocation-aware.

| function | module | addr | size | key |
|---|---|---|---|---|
| `HUD::RenderCoinCount` | ov002 | 0x020fc81c | 0x1fc | the `sb -= 9` step belongs *inside* the `digit >= 0` guard (both render loops) |
| `func_ov004_020b7cd0` | ov004 | 0x020b7cd0 | 0x168 | fake-dependency `b ? a : a` idiom to batch the two-word struct-copy loads ahead of the stores (notes 6e) |
| `func_ov060_021146d0` | ov060 | 0x021146d0 | 0x188 | `*(c+0x422)=0` is unconditional (after the `if`), producing the shared-tail branch instead of a duplicated epilogue |
| `func_ov078_02125c98` | ov078 | 0x02125c98 | 0x148 | the `RaycastGround` stack object is 0x50 bytes, not 0x54, so the frame is 0x58 |

Started from the near-miss DB div=2 drafts. CLAIMS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)