### PR TITLE
NONMATCHING near-misses: func_ov079_02126a84, func_ov095_021365d8

### DIFF
--- a/src/func_ov079_02126a84.cpp
+++ b/src/func_ov079_02126a84.cpp
@@ -1,0 +1,110 @@
+//cpp
+// NONMATCHING: arg-setup emission order: the func_02012694(0x78, c+0x74) call emits `mov r0,#0x78; add r1,r5,#0x74` but the ROM emits the address first (`add r1; mov r0`). The same call matches elsewhere (ov060) where an interleaved store shifts the schedule; here with nothing to interleave, mwcc picks the opposite order and no arg-materialization/pointer-type phrasing flips it. (div=2)
+/* func_ov079_02126a84 at 0x02126a84 (ov079), size 0x1c0
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef int Fix12;
+
+struct Klass; typedef void (Klass::*PMF)();
+struct M { PMF pmf; };
+
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+void func_0200f760(void *self, void *cc);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *cc);
+void *_ZN5Actor10FindWithIDEj(u32 id);
+void _ZN6Player16IncMegaKillCountEv();
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32, int, int, int);
+void _ZN9ActorBase18MarkForDestructionEv(void *self);
+void func_02012694(int a, void *b);
+void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, const Vector3 *pos);
+void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, const Vector3 *pos, u32 a, Fix12 b, u32 c, u32 d, u32 e);
+void func_ov079_02126704(char *c);
+void _ZN12CylinderClsn5ClearEv(void *self);
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *self, const Vector3 *pos);
+void _ZN12CylinderClsn6UpdateEv(void *self);
+
+extern M data_ov079_021282e0[];
+}
+
+extern "C" int func_ov079_02126a84(char *c)
+{
+    int flags;
+    u32 which;
+    u32 id;
+
+    func_0200f760(c, c + 0x110);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+
+    which = *(u32 *)(c + 0x3d4);
+    {
+        M *m = &data_ov079_021282e0[which];
+        (((Klass *)c)->*(m->pmf))();
+    }
+
+    id = *(u32 *)(c + 0x134);
+    if (id != 0) {
+        flags = *(int *)(c + 0x130);
+        if (flags & 0x10) {
+            _ZN5Actor10FindWithIDEj(id);
+            _ZN6Player16IncMegaKillCountEv();
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x8f, *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));
+            _ZN9ActorBase18MarkForDestructionEv(c);
+            func_02012694(0x78, c + 0x74);
+        } else if (flags & 0x3c0) {
+            *(int *)(c + 0x3d4) = 1;
+            {
+                Vector3 *pos = (Vector3 *)(c + 0x74);
+                _ZN5Sound9PlayBank0EjRK7Vector3(0xb5, pos);
+            }
+        } else {
+            void *o = _ZN5Actor10FindWithIDEj(id);
+            if (o != 0) {
+                int eq = (*(u16 *)((char *)o + 0xc) == 0xbf);
+                if (eq != 0) {
+                    if (*(u8 *)((char *)o + 0x6fb) == 0) {
+                        Vector3 pos;
+                        pos.x = *(int *)(c + 0x5c);
+                        pos.y = *(int *)(c + 0x60);
+                        pos.z = *(int *)(c + 0x64);
+                        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(o, &pos, 3, 0xc000, 1, 0, 1);
+                        *(int *)(c + 0x3d4) = 1;
+                        {
+                            Vector3 *p2 = (Vector3 *)(c + 0x74);
+                            _ZN5Sound9PlayBank0EjRK7Vector3(0xb5, p2);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    {
+        u16 *h = (u16 *)(c + 0x100);
+        *h = *h + 1;
+        if (which != *(u32 *)(c + 0x3d4)) {
+            *h = 0;
+        }
+    }
+
+    func_ov079_02126704(c);
+
+    _ZN12CylinderClsn5ClearEv(c + 0x110);
+    {
+        Vector3 pos;
+        pos.x = 0;
+        pos.y = -0x50000;
+        pos.z = 0;
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x110, &pos);
+    }
+    _ZN12CylinderClsn6UpdateEv(c + 0x110);
+
+    *(short *)(c + 0x92) = *(short *)(c + 0x8c);
+    *(short *)(c + 0x94) = *(short *)(c + 0x8e);
+    *(short *)(c + 0x96) = *(short *)(c + 0x90);
+    return 1;
+}

--- a/src/func_ov095_021365d8.c
+++ b/src/func_ov095_021365d8.c
@@ -1,16 +1,16 @@
-// NONMATCHING: register allocation (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+// NONMATCHING: instruction scheduling: `*(c+0x346)=0` is hoisted one slot into the `add r1,r1,lsr#31` -> `asr r1,r1,#1` latency gap (the average `>>1`), but the ROM leaves the gap and emits the store after `str [c+0x33c]`. Store-order permutations, launder, fake-dep, and volatile do not stop the hoist. (div=3)
+/* func_ov095_021365d8 at 0x021365d8 (ov095), size 0x18c
+ * Compiler mwccarm 1.2/sp2p3, flags:
+ * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
+
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
-
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(int sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(int sfp);
-extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-    void *mc, void *kcl, void *mtx, int fix, short s, int clps);
+extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *mc, void *kcl, void *mtx, int fix, short s, int clps);
 extern void func_020393d4(void *p, void *v);
 extern void func_020393c4(void *p, void *v);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
@@ -18,51 +18,63 @@ extern int func_ov095_02136788;
 extern int data_ov095_02136f68[];
 extern int data_ov095_02136f74[];
 extern int data_ov095_021375a4[];
-
 int func_ov095_021365d8(char *c)
 {
-    int idx;
-    u16 t;
-    int b;
-    *(u8*)(c + 0x349) = 0;
-    t = *(u16*)(c + 0xc);
-    b = (int)(t == 0x20);
-    if (b != 0) { *(int*)(c + 0x328) = 0; goto load; }
-    b = (int)(t == 0x21);
-    if (b != 0) { *(int*)(c + 0x328) = 1; goto load; }
-    b = (int)(t == 0x83);
-    if (b != 0) { *(int*)(c + 0x328) = 2; *(u8*)(c + 0x349) = 1; goto load; }
-    return 0;
+  int idx;
+  int *new_var;
+  u16 t;
+  int b;
+  *((u8 *) (c + 0x349)) = 0;
+  t = *((u16 *) (c + 0xc));
+  b = (int) (t == 0x20);
+  if (b != 0)
+  {
+    *((int *) (c + 0x328)) = 0;
+    goto load;
+  }
+  b = (int) (t == 0x21);
+  if (b != 0)
+  {
+    *((int *) (c + 0x328)) = 1;
+    goto load;
+  }
+  b = (int) (t == 0x83);
+  if (b != 0)
+  {
+    *((int *) (c + 0x328)) = 2;
+    *((u8 *) (c + 0x349)) = 1;
+    goto load;
+  }
+  return 0;
+  load:
+  idx = *((int *) (c + 0x328));
 
-load:
-    idx = *(int*)(c + 0x328);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4,
-        _ZN5Model8LoadFileER13SharedFilePtr(data_ov095_02136f68[idx]), 1, -1);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
-    idx = *(int*)(c + 0x328);
-    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124,
-        _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov095_02136f74[idx]),
-        c + 0x2ec, 0x199, *(s16*)(c + 0x8e), data_ov095_021375a4[idx]);
-    func_020393d4(c + 0x124, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    func_020393c4(c + 0x124, &func_ov095_02136788);
-    *(int*)(c + 0x320) = 0;
-    *(int*)(c + 0x32c) = 0;
-
-    if (*(u8*)(c + 0x349) == 2) {
-        *(int*)(c + 0x334) = *(int*)(c + 0x60) + (*(u16*)(c + 0x96) << 12);
-    } else {
-        *(int*)(c + 0x334) = *(int*)(c + 0x60);
-    }
-    *(int*)(c + 0x338) = *(int*)(c + 0x334) - (*(u16*)(c + 0x92) << 12);
-    {
-        int s = *(int*)(c + 0x334) + *(int*)(c + 0x338);
-        int r = s + (int)((unsigned)s >> 31);
-        *(int*)(c + 0x33c) = r >> 1;
-    }
-    *(u8*)(c + 0x346) = 0;
-    *(u8*)(c + 0x347) = 1;
-    *(u8*)(c + 0x348) = 0;
-    *(int*)(c + 0x340) = 0;
-    return 1;
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov095_02136f68[idx]), 1, -1);
+  new_var = &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+  _ZN8Platform19UpdateClsnPosAndRotEv(c);
+  idx = *((int *) (c + 0x328));
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x124, _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov095_02136f74[idx]), c + 0x2ec, 0x199, *((s16 *) (c + 0x8e)), data_ov095_021375a4[idx]);
+  func_020393d4(c + 0x124, new_var);
+  func_020393c4(c + 0x124, &func_ov095_02136788);
+  *((int *) (c + 0x320)) = 0;
+  *((int *) (c + 0x32c)) = 0;
+  if ((*((u8 *) (c + 0x349))) == 2)
+  {
+    *((int *) (c + 0x334)) = (*((int *) (c + 0x60))) + ((*((u16 *) (c + 0x96))) << 12);
+  }
+  else
+  {
+    *((int *) (c + 0x334)) = *((int *) (c + 0x60));
+  }
+  *((int *) (c + 0x338)) = (*((int *) (c + 0x334))) - ((*((u16 *) (c + 0x92))) << 12);
+  {
+    int s = (*((int *) (c + 0x334))) + (*((int *) (c + 0x338)));
+    int r = s + ((int) (((unsigned) s) >> 31));
+    *((u8 *) (c + 0x346)) = 0;
+    *((int *) (c + 0x33c)) = r >> 1;
+  }
+  *((u8 *) (c + 0x347)) = 1;
+  *((u8 *) (c + 0x348)) = 0;
+  *((int *) (c + 0x340)) = 0;
+  return 1;
 }


### PR DESCRIPTION
Two closest compiling drafts (mwccarm 1.2/sp2p3), both scheduling-order residuals verified to be codegen emission-order (not wrong logic). Each `// NONMATCHING` header records the exact divergence and levers tried.

| function | module | div | wall |
|---|---|---|---|
| `func_ov079_02126a84` | ov079 | 2 | `func_02012694(0x78, c+0x74)` emits `mov r0,#0x78; add r1,r5,#0x74`; ROM sets the address first. The same call matches in ov060 where an interleaved store shifts the schedule; with nothing to interleave here, mwcc picks the opposite order and no arg-materialization/pointer-type phrasing flips it. |
| `func_ov095_021365d8` | ov095 | 3 | `*(c+0x346)=0` is hoisted one slot into the average `>>1` latency gap (`add …,lsr#31` -> `asr`); ROM leaves the gap. Store-order permutations, launder, fake-dep, and volatile don't stop the hoist. |

These match the existing near-miss DB entries; the added value is the src/ drafts plus the wall analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)