### PR TITLE
[codex] Match func_ov001_020aadac

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | in progress |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,4 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
-| ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | in progress |
+| ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |

--- a/src/func_ov001_020aadac.c
+++ b/src/func_ov001_020aadac.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=48). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov001_020aa6cc(int r0);
 extern void func_ov001_020aa6b0(int* r0, int r1);
 extern void* _ZN5Actor10FindWithIDEj(unsigned id);
@@ -13,6 +10,8 @@ extern int data_0209f3e8[];
 extern unsigned char data_ov001_020ad62c[];
 extern int* data_ov001_020ad634[];
 
+#define LAUNDER_U8_PTR(p) ((unsigned char*)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
 void func_ov001_020aadac(void) {
     char* fp = data_0209f394;
     int* sl;
@@ -23,7 +22,7 @@ void func_ov001_020aadac(void) {
         func_ov001_020aa6cc(i1);
         sl = data_ov001_020ad634[i1];
         while (sl != 0) {
-            unsigned char* fl = (unsigned char*)sl + 0x1b;
+            unsigned char* fl = LAUNDER_U8_PTR((char*)sl + 0x1b);
             *fl &= ~2;
             if (sl[0x14/4] != -1) {
                 func_ov001_020aa6b0(sl, 0);
@@ -37,20 +36,22 @@ void func_ov001_020aadac(void) {
     }
 
     for (i2 = 0; i2 < 3; i2 = (i2 + 1) & 0xff) {
+        unsigned char* flags;
         int* o;
-        if (data_ov001_020ad62c[i2] & 2) continue;
+        flags = &data_ov001_020ad62c[i2];
+        if (*flags & 2) continue;
         o = data_ov001_020ad634[i2];
         if (o == 0) continue;
         do {
             void* fw = _ZN5Actor10FindWithIDEj(o[8/4]);
-            if (fw == 0) {
-                if ((int)fw != o[4/4] && *(unsigned char*)((char*)o + 0x19) == 4) {
-                    unsigned char* fl = (unsigned char*)o + 0x1b;
+            if (fw != 0 || (int)fw != o[4/4]) {
+                if (*(unsigned char*)((char*)o + 0x19) == 4) {
+                    unsigned char* fl = LAUNDER_U8_PTR((char*)o + 0x1b);
                     *fl |= 2;
                     o[0x14/4] = func_0202a8e0(o[4/4], *(unsigned char*)((char*)o + 0x18));
                     func_ov001_020aa6b0(o, 1);
                     func_ov001_020aa6e4(i2, *(unsigned char*)((char*)o + 0x19), 0);
-                    data_ov001_020ad62c[i2] |= 2;
+                    *flags |= 2;
                 }
             } else {
                 func_ov001_020ab110(o);


### PR DESCRIPTION
## Summary
- Match `func_ov001_020aadac` in `ov001` at `0x020aadac` (`0x194` bytes).
- Replace the previous `NONMATCHING` draft with byte-identical C.
- Mark the local claim row done after verification.

## Matching details
- Compiler: `mwccarm 1.2/sp2p3`
- Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`
- Notes: uses the documented u64-mask pointer laundering idiom to force the ROM's materialized `+0x1b` byte RMW shape.

## Verification
- `.venv/bin/python tools/match.py --c src/func_ov001_020aadac.c --func func_ov001_020aadac --addr 0x020aadac --size 0x194 --version 1.2/sp2p3 --brief --bin extracted/overlays/overlay_0001.bin --base 0x020aa420 --strict-relocs --module ov001`
  - `MATCHING VERSIONS: 1.2/sp2p3`
- `.venv/bin/python tools/linkcheck.py --name func_ov001_020aadac --addr 0x020aadac --size 0x194 --module ov001`
  - `VERIFIED`, `blind: 0`
- `git diff --check`
