### PR TITLE
Match 5 pre-sync orphan functions (ov025/ov072/ov079/ov081/ov091)

### DIFF
--- a/src/func_ov025_02111fa0.cpp
+++ b/src/func_ov025_02111fa0.cpp
@@ -1,0 +1,52 @@
+//cpp
+typedef short s16;
+struct SharedFilePtr { int x; }; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
+extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+extern "C" {
+struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
+void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, struct BMD_File *f, int a, int b);
+void func_ov025_02111e30(char *t);
+void func_ov025_02111dec(char *c);
+struct KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
+void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+    void *self, struct KCL_File *k, struct Matrix4x3 &m, int fx, short s, struct CLPS_Block &c);
+void func_020393d4(int *p, int v);
+extern struct SharedFilePtr data_ov025_02113ab8;
+extern struct SharedFilePtr data_ov025_02113ab0;
+extern struct CLPS_Block data_ov025_02112ce8;
+
+int func_ov025_02111fa0(char *self){
+    struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov025_02113ab8);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0x320, bmd, 1, -1);
+    func_ov025_02111e30(self);
+    func_ov025_02111dec(self);
+    {
+        struct KCL_File *kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov025_02113ab0);
+        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+            self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x374), 0x1000,
+            *(s16 *)(self + 0x8e), data_ov025_02112ce8);
+    }
+    func_020393d4((int *)(self + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    {
+        int v = 0x5000;
+        int k = *(int*)(self + 8) & 3;
+        *(int*)(self + 0xa8) = -v;
+        *(unsigned char*)(self + 0x372) = 0;
+        *(s16*)(self + 0x370) = 0;
+        switch (k) {
+        case 0:
+            break;
+        case 1:
+            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0xfa000;
+            *(unsigned short*)(((int)self + 0x370) & 0xFFFFFFFFFFFFFFFF) += 0x32;
+            break;
+        case 2:
+            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x1f4000;
+            *(unsigned char*)(self + 0x372) = 1;
+            *(int*)(self + 0xa8) = v;
+            break;
+        }
+    }
+    return 1;
+}
+}

--- a/src/func_ov072_02120e50.cpp
+++ b/src/func_ov072_02120e50.cpp
@@ -1,0 +1,35 @@
+//cpp
+struct Actor {
+    char pad[0xc];
+    unsigned short type;
+    static Actor* FindWithID(unsigned int id);
+};
+struct Player {
+    char pad[0xb0];
+    int f0b0;
+    char pad2[0x180-0xb4];
+    int f0180;
+    int f0184;
+    char pad3[0x360-0x188];
+    Actor* f0360;
+    bool TryGrab(Actor& a);
+};
+extern "C" void func_ov072_02121d50(Player* p, int kind);
+extern "C" int func_ov072_02120e50(Player* self)
+{
+    Actor* a;
+    int isType;
+    int flag;
+    if (self->f0184 == 0) return 0;
+    a = Actor::FindWithID(self->f0184);
+    if (a == 0 || (isType = (a->type == 0xbf)) == 0) return 0;
+    flag = ((self->f0b0 & 0x20000) != 0);
+    if (flag) {
+        self->f0360 = a;
+        func_ov072_02121d50(self, 4);
+    } else if ((self->f0180 & 0x1000) && ((Player*)a)->TryGrab(*(Actor*)self)) {
+        self->f0360 = a;
+        func_ov072_02121d50(self, 2);
+    }
+    return 1;
+}

--- a/src/func_ov079_02123804.c
+++ b/src/func_ov079_02123804.c
@@ -1,0 +1,92 @@
+typedef signed char s8;
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Vector3 { int x, y, z; };
+
+extern s16 data_02082214[];
+extern int* data_ov079_021275ec[];
+
+extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
+extern int AngleDiff(int a, int b);
+extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char* self, const struct Vector3* pos, u32 n, int fix, s16 s);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* self, void* bca, int n, int fix, u32 flags);
+
+void func_ov079_02123804(char* self, char* other)
+{
+    struct Vector3 v;
+    int idx;
+    s16 cosv, sinv;
+    int ang;
+
+    {
+        int* q = (int*)(((int)other + 0x68) & 0xFFFFFFFFFFFFFFFFLL);
+        v.x = q[0];
+        v.y = q[1];
+        v.z = q[2];
+    }
+
+    idx = *(u16*)(other + 0x94) >> 4;
+    cosv = data_02082214[idx * 2];
+    sinv = data_02082214[idx * 2 + 1];
+    v.x = v.x - cosv * 0x50;
+    v.z = v.z - sinv * 0x50;
+
+    ang = Vec3_HorzAngle((struct Vector3*)(self + 0x5c), &v);
+
+    if (AngleDiff(ang, (s16)(*(s16*)(self + 0x8e) + *(s16*)(self + 0x3e2))) < 0x3c00) {
+        int r1 = *(int*)(self + 0x3b0);
+        if (r1 == 1 || r1 == 2 || r1 == 7 || r1 == 0xa) goto action1;
+        if (r1 != 0) return;
+        if (*(u8*)(self + 0x414) != 0) {
+            if (*(u8*)(self + 0x40c) != 0) return;
+        }
+    action1:
+        if (*(int*)(self + 0x3b0) != 0xa) {
+            *(int*)(self + 0x3b4) = *(volatile int*)(self + 0x3b0);
+            *(s16*)(self + 0x3fe) = *(u16*)(self + 0x100);
+            *(u8*)(self + 0x40d) = *(u8*)(self + 0x40c);
+        }
+        *(u8*)(self + 0x400) = 0x5a;
+        *(int*)(self + 0x98) = 0;
+        *(int*)(self + 0x3b0) = 0xa;
+        *(u8*)(self + 0x40b) = 1;
+        return;
+    }
+
+    if (AngleDiff(ang, (s16)(*(s16*)(self + 0x8e) + *(s16*)(self + 0x3e2))) <= 0x4400) return;
+
+    {
+        int r1 = *(int*)(self + 0x3b0);
+        if (r1 == 1 || r1 == 2 || r1 == 7 || r1 == 0xa) goto action2;
+        if (r1 != 0) return;
+        if (*(u8*)(self + 0x414) != 0) {
+            if (*(u8*)(self + 0x40c) != 0) return;
+        }
+    action2:
+        if (*(int*)(self + 0x3b0) != 0xa) {
+            *(int*)(self + 0x3b4) = *(volatile int*)(self + 0x3b0);
+            *(s16*)(self + 0x3fe) = *(u16*)(self + 0x100);
+            *(u8*)(self + 0x40d) = *(u8*)(self + 0x40c);
+        }
+        {
+            struct Vector3 pos;
+            int* q = (int*)(((int)other + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            pos.x = q[0];
+            pos.y = q[1];
+            pos.z = q[2];
+            _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(self, &pos, 1, 0, 0);
+        }
+        *(int*)(self + 0x98) = 0;
+        {
+            int* bca = data_ov079_021275ec[*(u8*)(self + 0x414) * 5];
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x2cc, (void*)bca[1], 0x40000000, 0x1000, 0);
+        }
+        *(int*)(self + 0x328) = 0x4000;
+        *(int*)(self + 0x3b0) = 0xb;
+        *(u8*)(self + 0x40b) = 1;
+        return;
+    }
+}

--- a/src/func_ov081_02127240.cpp
+++ b/src/func_ov081_02127240.cpp
@@ -1,0 +1,37 @@
+//cpp
+extern "C" {
+extern void func_0201267c(int, void*);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void*);
+extern void func_ov081_021265c8(void*);
+extern void _ZN9Animation7AdvanceEv(void*);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
+extern int func_ov081_02126950(void*, void*);
+extern void func_ov081_02126758(void*);
+extern void _ZN12CylinderClsn5ClearEv(void*);
+extern void _ZN12CylinderClsn6UpdateEv(void*);
+int func_ov081_02127240(char* c){
+  switch(*(unsigned char*)(c+0x3f1)){
+  case 0:
+    if((((unsigned int)*(int*)(c+0x12c))<<4)>>16 == 7){
+      *(int*)(c+0x98)=0x12000;
+      *(int*)(c+0xa8)=0x1e000;
+      func_0201267c(0x77, c+0x74);
+      (*(unsigned char*)(((int)c + 0x3f1) & 0xFFFFFFFFFFFFFFFF))++;
+    }
+    break;
+  case 1:
+    if(_ZNK12WithMeshClsn13JustHitGroundEv(c+0x1e4)){
+      func_0201267c(0x71, c+0x74);
+      func_ov081_021265c8(c);
+    }
+    break;
+  }
+  _ZN9Animation7AdvanceEv(c+0x124);
+  _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x1b0);
+  func_ov081_02126950(c, c+0x1e4);
+  func_ov081_02126758(c);
+  _ZN12CylinderClsn5ClearEv(c+0x1b0);
+  _ZN12CylinderClsn6UpdateEv(c+0x1b0);
+  return 1;
+}
+}

--- a/src/func_ov091_02132108.cpp
+++ b/src/func_ov091_02132108.cpp
@@ -1,0 +1,41 @@
+//cpp
+typedef void (*PMFholder);
+struct Platform {
+    void UpdateModelPosAndRotY();
+    int IsClsnInRange(int a, int b);
+    void UpdateClsnPosAndRot();
+};
+struct PmfEntry;
+extern "C" void func_020393d4(void *p, void *v);
+extern "C" void ApproachLinearI(int *dst, int target, int rate);
+extern "C" void UpdatePosWithVelocitySym();
+
+typedef void (Platform::*PMF)();
+struct PmfRow { PMF pmf; };
+extern "C" PmfRow data_ov091_021354e0[];
+
+extern "C" int func_ov091_02132108(Platform *self)
+{
+    char *s = (char*)self;
+    int old = *(int*)(s + 0x320);
+    (self->*data_ov091_021354e0[old].pmf)();
+    *(unsigned short*)(((int)s + 0x354) & 0xFFFFFFFFFFFFFFFF) += 1;
+    if (old != *(int*)(s + 0x320)) {
+        *(short*)(s + 0x354) = 0;
+        func_020393d4(s + 0x124, 0);
+    } else {
+        func_020393d4(s + 0x124, (void*)&UpdatePosWithVelocitySym);
+    }
+    if (*(unsigned char*)(s + 0x352) == 0) {
+        int rate = 0x5000;
+        int saved = *(int*)(s + 0x60);
+        ApproachLinearI((int*)(s + 0x34c), (*(unsigned char*)(s + 0x356) != 0) ? 0x1e000 : 0, rate);
+        *(int*)(((int)s + 0x60) & 0xFFFFFFFFFFFFFFFF) -= *(int*)(s + 0x34c);
+        *(int*)(s + 0x60) = saved;
+    }
+    self->UpdateModelPosAndRotY();
+    if (self->IsClsnInRange(0, 0) != 0)
+        self->UpdateClsnPosAndRot();
+    *(unsigned char*)(s + 0x356) = 0;
+    return 1;
+}


### PR DESCRIPTION
Five matches made in earlier sessions that never reached a PR and are still unmatched upstream. Recovered and re-verified against current `main`:

- `func_ov025_02111fa0` — MATCH / link VERIFIED
- `func_ov072_02120e50` — MATCH / link VERIFIED
- `func_ov079_02123804` — MATCH / link VERIFIED (the div 22→0 high-div Fable warm-up)
- `func_ov081_02127240` — MATCH / link VERIFIED
- `func_ov091_02132108` — MATCH / link BLIND-3 (3 unresolvable reloc slots, zero byte diffs — benign)

All five pass `abverify` (byte-exact vs ROM) and the reconstruct-linked-bytes link gate. src-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)