### PR TITLE
Match func_ov001_020ab110

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,3 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
+| ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | in progress |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -32,4 +32,4 @@ it is fair to take over: ping the claimant first.
 | ov002: func_ov002_020f3310, 020f3d98, 020f562c, 020f5848 (0x4c each) | Cursor/Grok | 2026-07-02 | done - all four verified byte-identical |
 | ov006: func_ov006_0211a4b0 (andrew, PR #74) + 0211a648/0211a7ac/0211aa44/0211abdc/0211ad44/0211af60/0211b17c (Cursor/Grok) | mixed | 2026-07-03 | done - all eight verified byte-identical |
 | arm9: func_02056674 (0x02056674, 0x68) | (already matched earlier) | 2026-07-02 | done previously; Grok edit was a no-op and was reverted |
-| ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | in progress |
+| ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |

--- a/src/func_ov001_020ab110.c
+++ b/src/func_ov001_020ab110.c
@@ -1,46 +1,59 @@
-// NONMATCHING: register allocation (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int data_0209f3e8[];
 extern int data_ov001_020ad634[];
 extern char data_ov001_020ad630[];
-extern void func_ov001_020aa6b0(int* r0, int r1);
+extern void func_ov001_020aa6b0(int *r0, int r1);
 extern void func_ov001_020aa6cc(int r0);
 
-void func_ov001_020ab110(char* r4) {
-    if ((unsigned)(*(unsigned char*)(r4+0x1b) << 0x1d) >> 0x1f) return;
-    int f14 = *(int*)(r4+0x14);
+static inline int *inline_fn(char *arg0, int arg1)
+{
+    return (int *)(arg0 + arg1);
+}
+
+static inline int inline_fn2(char *arg0)
+{
+    return (int)arg0;
+}
+
+void func_ov001_020ab110(char *r4)
+{
+    char *new_var;
+    if (((unsigned)(*((unsigned char *)(r4 + 0x1b)) << 0x1d)) >> 0x1f) {
+        return;
+    }
+    int f14 = *((int *)(r4 + 0x14));
     if (f14 != -1) {
-        if (data_0209f3e8[f14] == *(int*)(r4+4)) {
-            func_ov001_020aa6b0((int*)r4, 0);
-            data_0209f3e8[*(int*)(r4+0x14)] = 0;
+        if (data_0209f3e8[f14] == (*inline_fn(r4, 4))) {
+            func_ov001_020aa6b0((int *)r4, 0);
+            data_0209f3e8[*inline_fn(r4, 0x14)] = 0;
+            func_ov001_020aa6cc(*((unsigned char *)(r4 + 0x18)));
         }
     }
-    func_ov001_020aa6cc(*(unsigned char*)(r4+0x18));
-    int prev = *(int*)(r4+0xc);
+    int prev = *((int *)(r4 + 0xc));
     if (prev != 0) {
-        *(int*)(prev+0x10) = *(int*)(r4+0x10);
+        *((int *)(prev + 0x10)) = *inline_fn(r4, 0x10);
     } else {
-        unsigned char idx = *(unsigned char*)(r4+0x18);
-        if ((int)r4 == data_ov001_020ad634[idx]) {
-            data_ov001_020ad634[idx] = *(int*)(r4+0x10);
+        unsigned char idx = *((unsigned char *)(r4 + 0x18));
+        if (inline_fn2(r4) == data_ov001_020ad634[idx]) {
+            data_ov001_020ad634[idx] = *inline_fn(r4, 0x10);
         }
     }
-    int next = *(int*)(r4+0x10);
+    int next = *inline_fn(r4, 0x10);
     if (next != 0) {
-        *(int*)(next+0xc) = *(int*)(r4+0xc);
+        *((int *)(next + 0xc)) = *((int *)(r4 + 0xc));
     }
-    func_ov001_020aa6b0((int*)r4, 0);
-    *(int*)(r4+4) = 0;
-    *(int*)(r4+8) = 0;
-    *(int*)(r4+0xc) = 0;
-    *(int*)(r4+0x10) = 0;
-    *(int*)(r4+0x14) = -1;
-    *(unsigned char*)(r4+0x1b) = 0;
-    *(unsigned char*)(r4+0x1b) |= 4;
-    *(unsigned char*)(r4+0x18) = 3;
-    *(unsigned char*)(r4+0x19) = 0;
-    unsigned char i = *(unsigned char*)(r4+0x18);
+    func_ov001_020aa6b0((int *)r4, 0);
+    *((int *)(r4 + 4)) = 0;
+    *inline_fn(r4, 8) = 0;
+    *inline_fn(r4, 0xc) = 0;
+    *((int *)(r4 + 0x10)) = 0;
+    *inline_fn(r4, 0x14) = -1;
+    *((unsigned char *)(r4 + 0x1b)) = 0;
+    unsigned char *flag = (unsigned char *)(((long long)(int)(r4 + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL);
+    *flag |= 4;
+    new_var = r4 + 0x18;
+    *((unsigned char *)new_var) = 3;
+    *((unsigned char *)(r4 + 0x19)) = 0;
+    unsigned char i = *((unsigned char *)new_var);
     unsigned char v = data_ov001_020ad630[i];
     if (v != 0) {
         data_ov001_020ad630[i] = v - 1;


### PR DESCRIPTION
## Summary

Matches `func_ov001_020ab110` in `ov001` at `0x020ab110` (`size=0x118`) and removes the stale `NONMATCHING` header. The claim row is marked done after verification.

The final source keeps the known pointer-materialization shape for the `0x1b` flag byte and moves `func_ov001_020aa6cc` onto the successful sound-handle cleanup path, matching the retail branch layout.

## Verification

Compiler: `mwccarm 1.2/sp2p3`

Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

- `.venv/bin/python tools/match.py --c src/func_ov001_020ab110.c --func func_ov001_020ab110 --addr 0x020ab110 --size 0x118 --version 1.2/sp2p3 --bin extracted/overlays/overlay_0001.bin --base 0x020aa420 --strict-relocs --module ov001 --brief`
- `.venv/bin/python tools/fdiff.py --c src/func_ov001_020ab110.c --name func_ov001_020ab110 --module ov001 --addr 0x020ab110 --size 0x118 --quiet`
- `.venv/bin/python tools/linkcheck.py --name func_ov001_020ab110 --addr 0x020ab110 --size 0x118 --module ov001`