### PR TITLE
Match 14 ARM9 BIOS SVC stub functions

### DIFF
--- a/src/BitUnPack.c
+++ b/src/BitUnPack.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void BitUnPack(void) {
+    swi 0x10
+    bx lr
+}

--- a/src/CpuFastSet.c
+++ b/src/CpuFastSet.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void CpuFastSet(void) {
+    swi 0x0c
+    bx lr
+}

--- a/src/CpuSet.c
+++ b/src/CpuSet.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void CpuSet(void) {
+    swi 0x0b
+    bx lr
+}

--- a/src/Div.c
+++ b/src/Div.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void Div(void) {
+    swi 0x09
+    bx lr
+}

--- a/src/GetCRC16.c
+++ b/src/GetCRC16.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void GetCRC16(void) {
+    swi 0x0e
+    bx lr
+}

--- a/src/Halt.c
+++ b/src/Halt.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void Halt(void) {
+    swi 0x06
+    bx lr
+}

--- a/src/HuffUnCompReadByCallback.c
+++ b/src/HuffUnCompReadByCallback.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void HuffUnCompReadByCallback(void) {
+    swi 0x13
+    bx lr
+}

--- a/src/IntrWait.c
+++ b/src/IntrWait.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void IntrWait(void) {
+    swi 0x04
+    bx lr
+}

--- a/src/IsDebugger.c
+++ b/src/IsDebugger.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void IsDebugger(void) {
+    swi 0x0f
+    bx lr
+}

--- a/src/LZ77UnCompReadNormalWrite8bit.c
+++ b/src/LZ77UnCompReadNormalWrite8bit.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void LZ77UnCompReadNormalWrite8bit(void) {
+    swi 0x11
+    bx lr
+}

--- a/src/RLUnCompReadByCallbackWrite16bit.c
+++ b/src/RLUnCompReadByCallbackWrite16bit.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void RLUnCompReadByCallbackWrite16bit(void) {
+    swi 0x15
+    bx lr
+}

--- a/src/RLUnCompReadNormalWrite8bit.c
+++ b/src/RLUnCompReadNormalWrite8bit.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void RLUnCompReadNormalWrite8bit(void) {
+    swi 0x14
+    bx lr
+}

--- a/src/SoftReset.c
+++ b/src/SoftReset.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void SoftReset(void) {
+    swi 0x00
+    bx lr
+}

--- a/src/Sqrt.c
+++ b/src/Sqrt.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void Sqrt(void) {
+    swi 0x0d
+    bx lr
+}


### PR DESCRIPTION
Byte-matching Thumb wrappers around NitroSDK BIOS system calls (`swi #N; bx lr`), each verified byte-exact against the EU retail ROM (14/14) and following the existing `HAND-ASM PRIMITIVE` asm-block convention.

| Function | SVC | 
|---|---|
| SoftReset | 0x00 |
| IntrWait | 0x04 |
| Halt | 0x06 |
| Div | 0x09 |
| CpuSet | 0x0b |
| CpuFastSet | 0x0c |
| Sqrt | 0x0d |
| GetCRC16 | 0x0e |
| IsDebugger | 0x0f |
| BitUnPack | 0x10 |
| LZ77UnCompReadNormalWrite8bit | 0x11 |
| HuffUnCompReadByCallback | 0x13 |
| RLUnCompReadNormalWrite8bit | 0x14 |
| RLUnCompReadByCallbackWrite16bit | 0x15 |

SVC numbers are region-independent and cross-checked against the stubs present in the ROM.

?? Generated with [Claude Code](https://claude.com/claude-code)