### PR TITLE
Match Particle::CheckWaterCallback::OnUpdate (_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb)

### DIFF
--- a/src/_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb.cpp
@@ -1,0 +1,23 @@
+//cpp
+extern "C" int data_0209f32c;
+struct Node { struct Node* next; char pad[8]; int field0c; char pad2[8]; int field18; char pad3[0x10]; unsigned short field2c; unsigned short field2e; };
+struct System { char pad8[8]; struct Node* head; char pad[0x10]; int field1c; };
+extern "C" int _ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb(void* thiz, System* sys, int b);
+int _ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb(void* thiz, System* sys, int b) {
+    Node* node = sys->head;
+    if (b) {
+        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        *flags &= ~2;
+    } else {
+        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        *flags |= 2;
+        if (node == 0) return 0;
+    }
+    while (node != 0) {
+        if (((node->field18 + node->field0c) << 3) > data_0209f32c) {
+            node->field2e = node->field2c;
+        }
+        node = node->next;
+    }
+    return 1;
+}


### PR DESCRIPTION
Matches one small arm9 function (0x7c) byte-for-byte.

`Particle::CheckWaterCallback::OnUpdate(System&, bool)` — toggles bit 2 of the system flag word at `+0x1c` (clears it when the bool is set, sets it when clear; early-returns `0` if the particle list is empty in the clear path), then walks the particle `Node` list copying the unsigned-short `field2c` → `field2e` for every node whose `(field18 + field0c) << 3` exceeds the global threshold `data_0209f32c`; returns `1`. Scaffolded from the already-matched `FitWaterCallback::OnUpdate` sibling (0.79 opcode similarity).

**Verification:** `abverify` MATCH (byte-identical to ROM after relocations) and `linkcheck` VERIFIED (0 diffs, all relocation destinations correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)