### PR TITLE
Match func_ov066_02116ac4 (landing-impact dust effect)

### DIFF
--- a/src/func_ov066_02116ac4.c
+++ b/src/func_ov066_02116ac4.c
@@ -1,0 +1,22 @@
+extern void func_0200d8c8(void* cam, void* v, int strength);
+extern int data_0209f318;
+extern void _ZN5Actor15HugeLandingDustEb(void* thiz, int b);
+extern void func_02012694(int a, void* b);
+
+void func_ov066_02116ac4(char* c, int strength) {
+    volatile int s0, s1, s2;
+    func_0200d8c8((void*)data_0209f318, c + 0x5c, strength);
+    s0 = *(int*)(c + 0x5c);
+    s1 = *(int*)(c + 0x60);
+    s2 = *(int*)(c + 0x64);
+    if (*(int*)(c + 0x49c) == 1)
+        *(int*)(((long)c + 0x5c) & 0xFFFFFFFFFFFFFFFF) -= 0x80000;
+    else
+        *(int*)(((long)c + 0x5c) & 0xFFFFFFFFFFFFFFFF) += 0x80000;
+    *(int*)(((long)c + 0x64) & 0xFFFFFFFFFFFFFFFF) += 0x80000;
+    _ZN5Actor15HugeLandingDustEb(c, 1);
+    func_02012694(0x143, c + 0x74);
+    *(int*)(c + 0x5c) = s0;
+    *(int*)(c + 0x60) = s1;
+    *(int*)(c + 0x64) = s2;
+}


### PR DESCRIPTION
Matches one ov066 function (0xb4) byte-for-byte.

`func_ov066_02116ac4` — a landing-impact effect. Saves the actor's position vector (`+0x5c/0x60/0x64`), calls `func_0200d8c8` (camera shake by `strength`), displaces X by `∓0x80000` depending on flag `0x49c` and Z by `+0x80000`, spawns `Actor::HugeLandingDust(true)`, fires `func_02012694(0x143, &field74)`, then restores the saved vector. Scaffolded from `func_ov004_020b7b90`.

**Verification:** `abverify` MATCH (45/45 words byte-identical) and `linkcheck` VERIFIED (0 diffs, all relocation destinations correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)