### PR TITLE
PR-validate: render validation comment as markdown (per-file verdict table)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -82,8 +82,10 @@ jobs:
             const marker = '<!-- pr-link-validation -->';
             let body = `${marker}\n### ${icon} PR link validation — ${STATUS}\n\n${SUMMARY || ''}`;
             if (DETAILS && DETAILS.trim()) {
-              body += `\n\n<details><summary>details</summary>\n\n\`\`\`\n${DETAILS}\n\`\`\`\n</details>`;
+              // DETAILS is a pre-rendered markdown table from pr_linkcheck --md; drop it in as-is.
+              body += `\n\n${DETAILS.trim()}`;
             }
+            body += `\n\n<sub>Each changed \`src/*.c|*.cpp\` is compiled with mwccarm and its relocated bytes compared to the retail ROM on the maintainer's build box. Passing requires every changed file to reproduce the ROM byte-for-byte with correct relocation targets — this catches WRONG-DEST relocations and non-reproducing near-misses that ledger-scoped linkcheck skips.</sub>`;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -85,7 +85,7 @@ jobs:
               // DETAILS is a pre-rendered markdown table from pr_linkcheck --md; drop it in as-is.
               body += `\n\n${DETAILS.trim()}`;
             }
-            body += `\n\n<sub>Each changed \`src/*.c|*.cpp\` is compiled with mwccarm and its relocated bytes compared to the retail ROM on the maintainer's build box. Passing requires every changed file to reproduce the ROM byte-for-byte with correct relocation targets — this catches WRONG-DEST relocations and non-reproducing near-misses that ledger-scoped linkcheck skips.</sub>`;
+            body += `\n\n<sub>Each changed \`src/*.c|*.cpp\` is compiled and its relocated bytes compared to the binary data on a private build box. Passing requires every changed file to reproduce the ROM byte-for-byte with correct relocation targets — this catches WRONG-DEST relocations and non-reproducing near-misses that ledger-scoped linkcheck skips.</sub>`;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });


### PR DESCRIPTION
Follow-up to the PR link-validation workflow. The build-box worker now runs `pr_linkcheck --md`, which emits a **per-file verdict table** (verified / near-miss / wrong-dest) instead of raw stdout. This change renders that markdown in the sticky comment rather than wrapping it in a code fence, and adds a one-line footer explaining what a pass proves.

Also fixes: the old comment dumped raw stdout which leaked a local `C:\...\Temp\prval-*.json` path.

Pairs with a worker-side fix (not in this repo) so that a **non-reproducing near-miss now fails** validation instead of passing — `--fail` previously only tripped on WRONG-DEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)