### PR TITLE
Match 12 functions: flag-setters, pooled increments, thunks, struct-copy

### DIFF
--- a/src/_ZThn80_N9AnimationD0Ev.cpp
+++ b/src/_ZThn80_N9AnimationD0Ev.cpp
@@ -1,0 +1,5 @@
+//cpp
+struct Base1 { int pad[19]; virtual ~Base1(); virtual void f1(); };
+struct Base2 { int b; virtual ~Base2(); virtual void g1(); };
+struct Animation : Base1, Base2 { virtual ~Animation(); };
+Animation::~Animation() {}

--- a/src/_ZThn80_N9AnimationD1Ev.cpp
+++ b/src/_ZThn80_N9AnimationD1Ev.cpp
@@ -1,0 +1,5 @@
+//cpp
+struct Base1 { int pad[19]; virtual ~Base1(); virtual void f1(); };
+struct Base2 { int b; virtual ~Base2(); virtual void g1(); };
+struct Animation : Base1, Base2 { virtual ~Animation(); };
+Animation::~Animation() {}

--- a/src/func_02035860.c
+++ b/src/func_02035860.c
@@ -1,0 +1,14 @@
+struct Vec3 { int x, y, z; };
+
+void func_02035860(char *o, struct Vec3 *src)
+{
+    char *base = *(char **)(o + 0x14);
+    struct Vec3 *d1 = (struct Vec3 *)(((long long)(int)(base + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    d1->x = src->x;
+    d1->y = src->y;
+    d1->z = src->z;
+    struct Vec3 *d2 = (struct Vec3 *)(((long long)(int)(base + 0x68)) & 0xFFFFFFFFFFFFFFFFLL);
+    d2->x = src->x;
+    d2->y = src->y;
+    d2->z = src->z;
+}

--- a/src/func_ov002_020aefa4.c
+++ b/src/func_ov002_020aefa4.c
@@ -1,0 +1,4 @@
+void func_ov002_020aefa4(char *self)
+{
+    *(unsigned int *)(((long long)(int)(self + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+}

--- a/src/func_ov002_020f8838.cpp
+++ b/src/func_ov002_020f8838.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x50). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x50 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x50 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_ov002_020f8848.cpp
+++ b/src/func_ov002_020f8848.cpp
@@ -1,0 +1,18 @@
+//cpp
+// This-adjusting virtual destructor thunk (adjustment -0x50). Compiler-generated
+// as a byproduct of a class with a secondary base of size 0x50 and its own
+// out-of-line destructor; the tail-branch target is a relocation wildcard.
+struct Base1 {
+    char pad[0x50 - 4];
+    virtual ~Base1();
+    virtual void f1();
+};
+struct Base2 {
+    int x;
+    virtual ~Base2();
+    virtual void g1();
+};
+struct Derived : Base1, Base2 {
+    virtual ~Derived();
+};
+Derived::~Derived() {}

--- a/src/func_ov006_02114fd0.c
+++ b/src/func_ov006_02114fd0.c
@@ -1,0 +1,5 @@
+void func_ov006_02114fd0(char *p)
+{
+    int *a = (int *)(((long long)(int)(p + 0x5984)) & 0xFFFFFFFFFFFFFFFFLL);
+    *a = *a + 1;
+}

--- a/src/func_ov006_02114fec.c
+++ b/src/func_ov006_02114fec.c
@@ -1,0 +1,5 @@
+void func_ov006_02114fec(char *p)
+{
+    int *a = (int *)(((long long)(int)(p + 0x5980)) & 0xFFFFFFFFFFFFFFFFLL);
+    *a = *a + 1;
+}

--- a/src/func_ov006_02115008.c
+++ b/src/func_ov006_02115008.c
@@ -1,0 +1,5 @@
+void func_ov006_02115008(char *p)
+{
+    int *a = (int *)(((long long)(int)(p + 0x597c)) & 0xFFFFFFFFFFFFFFFFLL);
+    *a = *a + 1;
+}

--- a/src/func_ov006_02115024.c
+++ b/src/func_ov006_02115024.c
@@ -1,0 +1,5 @@
+void func_ov006_02115024(char *p)
+{
+    int *a = (int *)(((long long)(int)(p + 0x5978)) & 0xFFFFFFFFFFFFFFFFLL);
+    *a = *a + 1;
+}

--- a/src/func_ov006_02115060.c
+++ b/src/func_ov006_02115060.c
@@ -1,0 +1,5 @@
+void func_ov006_02115060(char *p)
+{
+    int *a = (int *)(((long long)(int)(p + 0x5964)) & 0xFFFFFFFFFFFFFFFFLL);
+    *a = *a + 1;
+}

--- a/src/func_ov071_0211f6f8.cpp
+++ b/src/func_ov071_0211f6f8.cpp
@@ -1,0 +1,37 @@
+//cpp
+extern "C" {
+struct Vector3 { int x, y, z; };
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
+extern int data_ov071_02122f88[];
+}
+
+struct Base {
+    virtual void v0();  virtual void v1();  virtual void v2();  virtual void v3();
+    virtual void v4();  virtual void v5();  virtual void v6();  virtual void v7();
+    virtual void v8();  virtual void v9();  virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual int m();   // slot 0x74/4 = 29
+};
+
+extern "C" int func_ov071_0211f6f8(char* c)
+{
+    _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
+    *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int*)(c + 0x98) = 0xa000;
+    *(int*)(c + 0xa8) = 0x28000;
+    *(short*)(c + 0x3a8) = 0x2d;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, *(void**)((char*)data_ov071_02122f88 + 4), 0, 0x1000, 0);
+    *(int*)(c + 0x130) = 0x4000;
+    Base* b = (Base*)c;
+    int r1 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x43, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r1, *(int*)(c + 0x64));
+    int r2 = b->m();
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x44, *(int*)(c + 0x5c), *(int*)(c + 0x60) + r2, *(int*)(c + 0x64));
+    *(int*)(c + 0x39c) = 8;
+    return 1;
+}


### PR DESCRIPTION
Matches 12 ARM9/overlay functions (all byte-exact at mwccarm 1.2/sp2p3):

- **func_ov006_02114fd0 / 02114fec / 02115008 / 02115024 / 02115060** — pooled-offset int increments; u64-mask laundering forces the base to materialize.
- **func_ov002_020aefa4** — base+offset flag setter (`|= 0x8000`), laundered to defeat the first-access fold.
- **func_02035860** — Vec3 double-copy to obj+0x5c and +0x68; laundered bases give `add` + pre-indexed writeback `str [r2,#0x68]!`.
- **func_ov071_0211f6f8** — state handler, adapted from sibling ov081_02126c8c.
- **_ZThn80_N9AnimationD0Ev/D1Ev, func_ov002_020f8838/020f8848** — -0x50 this-adjusting destructor thunks (//cpp dummy-inheritance idiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)