### PR TITLE
Attribute contributor matches via override file (fixes ruspecial's credit)

### DIFF
--- a/.github/workflows/update-chaos-data.yml
+++ b/.github/workflows/update-chaos-data.yml
@@ -13,6 +13,7 @@ on:
       - "nearmiss/**"
       - "tools/chaos_db_ci.py"
       - "tools/chaosviewer.config.json"
+      - "attribution.json"
   workflow_dispatch:
 
 permissions:

--- a/attribution.json
+++ b/attribution.json
@@ -1,0 +1,13 @@
+{
+  "note": "Manual match-author overrides for the contributor chart, applied by tools/chaos_db_ci.py with top priority. Use this when the git-add author is wrong -- e.g. a contributor's work landed via a maintainer's consolidating PR/squash, which records the maintainer as the commit author instead of the actual matcher.",
+  "overrides": {
+    "src/func_02035860.c": "ruspecial",
+    "src/func_ov002_020aefa4.c": "ruspecial",
+    "src/func_ov006_02114fd0.c": "ruspecial",
+    "src/func_ov006_02114fec.c": "ruspecial",
+    "src/func_ov006_02115008.c": "ruspecial",
+    "src/func_ov006_02115024.c": "ruspecial",
+    "src/func_ov006_02115060.c": "ruspecial",
+    "src/func_ov071_0211f6f8.cpp": "ruspecial"
+  }
+}

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -65,6 +65,24 @@ def src_authors() -> dict[str, str]:
     return authors
 
 
+def attribution_overrides() -> dict[str, str]:
+    """Manual {'src/name.c': github_login} for matches the git-add author gets wrong -- e.g. a
+    contributor's work that landed via a maintainer's consolidating PR/squash, which records the
+    maintainer (not the matcher) as the commit author. Applied with HIGHEST priority. Lives in
+    attribution.json at the repo root: {"overrides": {"src/x.c": "login", ...}}."""
+    p = REPO / "attribution.json"
+    if not p.is_file():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        ov = data.get("overrides", {}) if isinstance(data, dict) else {}
+        return {k: v for k, v in ov.items()
+                if isinstance(k, str) and k.startswith("src/") and isinstance(v, str) and v}
+    except Exception as e:
+        print(f"  (attribution.json skipped: {e})")
+        return {}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default="chaos-db.json")
@@ -83,6 +101,7 @@ def main():
                     continue
 
     authors = src_authors()
+    overrides = attribution_overrides()  # manual fixes, highest priority
 
     functions = []
     total_b = matched_b = matched_n = 0
@@ -108,8 +127,10 @@ def main():
                    "addr": addr, "size": size, "matched": matched}
             if src_path:
                 rec["srcPath"] = src_path
-                if matched and src_path in authors:
-                    rec["author"] = authors[src_path]
+                if matched:
+                    a = overrides.get(src_path) or authors.get(src_path)
+                    if a:
+                        rec["author"] = a
             if matched:
                 matched_b += size
                 matched_n += 1


### PR DESCRIPTION
The contributor chart credits each matched src file to its **git-add author**. When a contributor's work lands through a maintainer's consolidating PR/squash (like #115, which landed @ruspecial's 8 verified matches from #113), git records the *maintainer* as the commit author — so the real matcher gets zero credit.

This adds `attribution.json` — top-priority `{src_path: github_login}` overrides read by `chaos_db_ci.py` — and seeds it with @ruspecial's 8:
func_02035860, func_ov002_020aefa4, func_ov006_02114fd0/fec/008/024/060, func_ov071_0211f6f8.

The chaos-data workflow now also regenerates when `attribution.json` changes, so the contributor chart updates on merge. Reusable for any future misattribution.

Built with Claude Code