### PR TITLE
Match 7 functions via Sonnet->Opus->Fable model cascade (LARGE 0x400-0x800 band)

### DIFF
--- a/src/_ZN5Stage14LoadGraphics2DEbi.cpp
+++ b/src/_ZN5Stage14LoadGraphics2DEbi.cpp
@@ -1,0 +1,193 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern "C" {
+void SetBg0Offset(int a, int b);
+void LoadFont(u8 arg);
+int GetOwnerLanguage(void);
+char *_ZN2G213GetBG2CharPtrEv(void);
+u32 LoadCompressedFileAt(u16 fileID, void *target);
+int LoadFileAt(int handle, int dest);
+char *_ZN2G212GetBG2ScrPtrEv(void);
+void LoadControllerModeText(int a);
+void LoadFont3D(void);
+char *_ZN3G2S13GetBG0CharPtrEv(void);
+char *_ZN3G2S12GetBG0ScrPtrEv(void);
+char *_ZN3G2S12GetBG1ScrPtrEv(void);
+char *_ZN3G2S12GetBG2ScrPtrEv(void);
+void MultiStore16(u16 val, char *dst, int nbytes);
+void SetSubBg0Offset(int a, int b);
+void SetSubBg1Offset(int a, int b);
+void SetSubBg2Offset(int a, int b);
+int SublevelToLevel(int i);
+
+extern u8 data_0209f2d8;
+extern int data_0209caa0[];
+extern int data_0209fc48;
+extern u8 data_0209d454;
+extern int data_0209fc68;
+}
+
+class Stage {
+public:
+    static void LoadGraphics2D(bool b, int i);
+};
+
+#define BG2CNT     (*(volatile u16 *)0x400000c)
+#define BG3CNT     (*(volatile u16 *)0x400000e)
+#define BG0CNT_SUB (*(volatile u16 *)0x4001008)
+#define BG1CNT_SUB (*(volatile u16 *)0x400100a)
+#define BG2CNT_SUB (*(volatile u16 *)0x400100c)
+
+void Stage::LoadGraphics2D(bool b, int i)
+{
+    char *r4;
+    char *r7;
+
+    BG3CNT &= ~3;
+    BG3CNT = (BG3CNT & 0x43) | 0x1100;
+    BG3CNT &= ~0x40;
+    SetBg0Offset(0, 0);
+
+    BG2CNT = (BG2CNT & ~3) | 1;
+    BG2CNT &= ~0x40;
+    BG2CNT = (BG2CNT & 0x43) | 0xd10;
+
+    if (b == 0) {
+        LoadFont(0);
+        if (GetOwnerLanguage() == 5) {
+            LoadCompressedFileAt(0xb00f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 4) {
+            LoadCompressedFileAt(0xac0f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 3) {
+            LoadCompressedFileAt(0xa80f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 2) {
+            LoadCompressedFileAt(0xa40f, _ZN2G213GetBG2CharPtrEv());
+        } else {
+            LoadCompressedFileAt(0xa00f, _ZN2G213GetBG2CharPtrEv());
+        }
+        LoadFileAt(0x980b, 0x5000000);
+        r4 = _ZN2G212GetBG2ScrPtrEv();
+        LoadCompressedFileAt(0x9808, r4);
+        LoadCompressedFileAt(0x9809, r4 + 0x800);
+        LoadCompressedFileAt(0x980a, r4 + 0x1000);
+        LoadControllerModeText(0x280);
+    } else {
+        LoadFont3D();
+    }
+
+    if ((int)(data_0209f2d8 == 0) != 0
+        && (data_0209caa0[2] & 0x80) == 0
+        && (int)(data_0209fc48 != 0) == 0) {
+        BG0CNT_SUB &= ~3;
+        BG0CNT_SUB &= ~0x40;
+        BG0CNT_SUB = (BG0CNT_SUB & 0x43) | 0xd000;
+        BG1CNT_SUB &= ~3;
+        BG1CNT_SUB &= ~0x40;
+        BG1CNT_SUB = (BG1CNT_SUB & 0x43) | 0xd400;
+        BG1CNT_SUB &= ~3;
+        BG1CNT_SUB &= ~0x40;
+        BG2CNT_SUB = (BG2CNT_SUB & 0x43) | 0x1800;
+
+        LoadCompressedFileAt(0x239, _ZN3G2S13GetBG0CharPtrEv());
+        LoadFileAt(0x23c, 0x5000400);
+        LoadCompressedFileAt(0x23b, _ZN3G2S12GetBG0ScrPtrEv());
+        LoadCompressedFileAt(0x23a, _ZN3G2S12GetBG1ScrPtrEv());
+        LoadCompressedFileAt(0x23d, (void *)0x6600000);
+        LoadFileAt(0x23e, 0x5000600);
+        {
+            char *scr2 = _ZN3G2S12GetBG2ScrPtrEv();
+            volatile u16 sp0 = 0x10d0;
+            MultiStore16(sp0, scr2, 0x800);
+        }
+        data_0209d454 = 0x17;
+        SetSubBg0Offset(0, 0);
+        SetSubBg1Offset(0, 0);
+        SetSubBg2Offset(0, 0);
+        return;
+    }
+
+    BG0CNT_SUB &= ~3;
+    BG0CNT_SUB &= ~0x40;
+    BG0CNT_SUB = (BG0CNT_SUB & 0x43) | 0x1200;
+    BG1CNT_SUB &= ~3;
+    BG1CNT_SUB &= ~0x40;
+    BG1CNT_SUB = (BG1CNT_SUB & 0x43) | 0xc00;
+    BG2CNT_SUB = (BG2CNT_SUB & ~3) | 2;
+    BG2CNT_SUB &= ~0x40;
+    BG2CNT_SUB = (BG2CNT_SUB & 0x43) | 0x1300;
+
+    if (GetOwnerLanguage() == 5) {
+        LoadCompressedFileAt(0xb00d, _ZN3G2S13GetBG0CharPtrEv());
+    } else if (GetOwnerLanguage() == 4) {
+        LoadCompressedFileAt(0xac0d, _ZN3G2S13GetBG0CharPtrEv());
+    } else if (GetOwnerLanguage() == 3) {
+        LoadCompressedFileAt(0xa80d, _ZN3G2S13GetBG0CharPtrEv());
+    } else if (GetOwnerLanguage() == 2) {
+        LoadCompressedFileAt(0xa40d, _ZN3G2S13GetBG0CharPtrEv());
+    } else {
+        LoadCompressedFileAt(0xa00d, _ZN3G2S13GetBG0CharPtrEv());
+    }
+
+    LoadFileAt(0x9807, 0x5000400);
+    r4 = _ZN3G2S12GetBG1ScrPtrEv();
+    LoadCompressedFileAt(0x9804, r4 + 0x800);
+    LoadCompressedFileAt(0x9803, r4 + 0x1000);
+
+    if (GetOwnerLanguage() == 5) {
+        LoadCompressedFileAt(0xb009, r4 + 0x1800);
+        LoadCompressedFileAt(0xb00b, r4 + 0x2000);
+    } else if (GetOwnerLanguage() == 4) {
+        LoadCompressedFileAt(0xac09, r4 + 0x1800);
+        LoadCompressedFileAt(0xac0b, r4 + 0x2000);
+    } else if (GetOwnerLanguage() == 3) {
+        LoadCompressedFileAt(0xa809, r4 + 0x1800);
+        LoadCompressedFileAt(0xa80b, r4 + 0x2000);
+    } else if (GetOwnerLanguage() == 2) {
+        LoadCompressedFileAt(0xa409, r4 + 0x1800);
+        LoadCompressedFileAt(0xa40b, r4 + 0x2000);
+    } else {
+        LoadCompressedFileAt(0xa009, r4 + 0x1800);
+        LoadCompressedFileAt(0xa00b, r4 + 0x2000);
+    }
+
+    r7 = _ZN3G2S12GetBG2ScrPtrEv();
+    LoadCompressedFileAt(0x9805, r7);
+    LoadCompressedFileAt(0x9806, r7 + 0x1000);
+
+    if (b != 0) {
+        if (data_0209fc68 != 0) {
+            return;
+        }
+        if (GetOwnerLanguage() == 5) {
+            LoadCompressedFileAt(0xb00f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 4) {
+            LoadCompressedFileAt(0xac0f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 3) {
+            LoadCompressedFileAt(0xa80f, _ZN2G213GetBG2CharPtrEv());
+        } else if (GetOwnerLanguage() == 2) {
+            LoadCompressedFileAt(0xa40f, _ZN2G213GetBG2CharPtrEv());
+        } else {
+            LoadCompressedFileAt(0xa00f, _ZN2G213GetBG2CharPtrEv());
+        }
+        LoadFileAt(0x980b, 0x5000000);
+        LoadCompressedFileAt(0x25c, _ZN2G212GetBG2ScrPtrEv() + 0x1800);
+        LoadCompressedFileAt(0x9801, r4 + 0x2800);
+        return;
+    }
+
+    if (SublevelToLevel(i) == 0x1d) {
+        volatile u16 sp2 = 0;
+        MultiStore16(sp2, r4, 0x40);
+        LoadCompressedFileAt(0x230, r4 + 0x40);
+        LoadCompressedFileAt(0x22f, _ZN2G212GetBG2ScrPtrEv() + 0x1800);
+        LoadCompressedFileAt(0x25c, _ZN2G212GetBG2ScrPtrEv() + 0x2800);
+        LoadCompressedFileAt(0x9802, r4 + 0x2800);
+        return;
+    }
+
+    LoadCompressedFileAt(0x25c, _ZN2G212GetBG2ScrPtrEv() + 0x1800);
+    LoadCompressedFileAt(0x230, r4);
+}

--- a/src/_ZN5Stage8BehaviorEv.cpp
+++ b/src/_ZN5Stage8BehaviorEv.cpp
@@ -1,0 +1,261 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef signed char s8;
+typedef short s16;
+typedef int s32;
+
+extern "C" {
+    void ProcessKuppaScript();
+    void func_02032f54();
+    void func_020199a4();
+    void func_02019a58();
+    void func_02012790(int a);
+    void func_02011c24();
+    void func_02030a78();
+    void func_020345b0(int a);
+    int SublevelToLevel(int i);
+    int IsLevelInsideCastle(int level);
+    int IsLevelTinyHugeIslandOutside(int level);
+
+    extern u32 data_0209b454;
+    extern u32 data_0209b464;
+    extern u16 data_0209f300;
+    extern u8 data_0209f2c4;
+    extern u8 data_0209f22c;
+    extern u8 data_0209f2d8;
+    extern u8 data_0209fc9c;
+    extern u8 data_0209fcc8;
+    extern s32 data_0209fc68;
+    extern char* data_0209f394[];
+    extern u8 data_0209fc50;
+    extern u16 data_0209f304;
+    extern u8 data_0209f2bc;
+    extern s32 data_0208ee44;
+    extern u16 data_ov002_02111188;
+    extern u8 data_0209f204;
+    extern s8 data_02092110;
+    extern s32 data_0209d4b0;
+    extern u8 data_0209f294;
+    extern u8 data_0209f290;
+    extern u8 data_02092778;
+    extern s8 data_0209f2f8;
+    extern s8 data_02092118;
+    extern u8 data_0209f268;
+    extern u8 data_0209f20c;
+    extern u8 data_020a0e40;
+    extern u16 data_020a0e58[];
+    extern u16 data_020a0e5a[];
+    extern u8 data_0209d660;
+    extern s32 data_0209caa0[];
+    extern s32 data_0209fc48;
+    extern u8 data_0209f2a0;
+    extern u8 data_0209f218;
+}
+
+struct UnkVis {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual int v5();
+};
+extern UnkVis* data_0209f5bc;
+
+class Sound {
+public:
+    static void LoadAndSetMusic_Layer1(int a);
+    static void StopLoadedMusic_Layer1(unsigned int a);
+};
+class Scene {
+public:
+    static void StartSceneFade(unsigned int a, unsigned int b, unsigned short c);
+    static void SetSceneToSpawn(unsigned int a, unsigned int b);
+};
+class Timer {
+public:
+    void StopTimer();
+    u8 unk0[8];
+    u8 started;
+};
+extern Timer data_0209d4c8;
+class ShadowModel {
+public:
+    static void CleanAll();
+};
+
+class Stage {
+public:
+    static void CheckCameraInput();
+    void CheckInput();
+    static void PS_Cleanup();
+    static void UpdateMessage();
+    static void VE_Init();
+    static void VE_Update();
+    static void LC_Update();
+    static void PS_Update();
+    static int CanPause();
+    static int IsPauseDisabled();
+    static void PS_Init();
+    int Behavior();
+};
+
+static inline u32 MaskOff(u32 x, u32 m) { return x & ~m; }
+
+#pragma opt_common_subs off
+
+int Stage::Behavior()
+{
+    data_0209b464 = data_0209b454;
+    CheckCameraInput();
+    CheckInput();
+    if (data_0209f300 != 0)
+        data_0209f300 -= 1;
+    if (data_0209f2c4 == 2 && data_0209f22c == 0)
+        PS_Cleanup();
+    ProcessKuppaScript();
+    if (data_0209f5bc->v5() == 0) {
+        ShadowModel::CleanAll();
+        return 1;
+    }
+    {
+        int b = (data_0209f2d8 == 1);
+        if (b == 0) {
+            UpdateMessage();
+        } else {
+            u8 c9c = data_0209fc9c;
+            if (c9c != 0) {
+                func_02032f54();
+                if (data_0209fcc8 >= 7u)
+                    func_020199a4();
+                return 1;
+            }
+            if (data_0209fc68 != 0) {
+                int b2 = (data_0209fc68 == 6);
+                if (b2) {
+                    if (c9c == 0) {
+                        func_02019a58();
+                        func_02012790(0x123);
+                        func_02011c24();
+                        func_02030a78();
+                        func_020345b0(0x13);
+                    }
+                    return 1;
+                }
+            }
+            {
+                int cnt = 0;
+                int i;
+                for (i = 0; i < 4; i++) {
+                    char* p = data_0209f394[i];
+                    if (p != 0) {
+                        int t = (*(u8*)(p + 0x711) != 0) ? 1 : 0;
+                        if (t == 1)
+                            cnt++;
+                    }
+                }
+                if (cnt >= data_0209fc50) {
+                    if (data_0209f304 == 0x28 && data_0209f2bc == 3)
+                        func_02012790(0x2b);
+                    if (data_0209f2c4 == 0) {
+                        if (data_0209f304 != 0 || data_0209f2bc != 0) {
+                            data_0209f304 = data_0209f304 - data_0208ee44;
+                            if (data_0209f304 == 0 && data_0209f2bc != 0) {
+                                data_0209f2bc -= 1;
+                                data_0209f304 = 0x28;
+                                if (data_0209f2bc != 0) {
+                                    func_02012790(0x2b);
+                                } else {
+                                    func_02012790(0x2a);
+                                    Sound::LoadAndSetMusic_Layer1(0x4d);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (data_ov002_02111188 == 0 && data_0209f204 != 0) {
+                if (data_0209fc68 == 0) {
+                    if (data_02092110 < 0 && data_0209d4b0 == 0) {
+                        if (data_0209f294 == 0 && data_0209f290 == 0)
+                            VE_Init();
+                        else
+                            VE_Update();
+                    }
+                } else {
+                    Scene::StartSceneFade(7, 0, 0);
+                    data_02092778 = 1;
+                    data_0209d4b0 = 0;
+                }
+                Sound::StopLoadedMusic_Layer1(0x3c);
+            }
+        }
+    }
+    if (data_02092110 >= 0) {
+        int lvl = SublevelToLevel(data_02092110);
+        int lvl2 = SublevelToLevel(data_0209f2f8);
+        int bb = (data_0209f2d8 == 2);
+        if (bb == 0 && lvl <= 0xe && lvl != lvl2 && data_02092118 < 0
+            && (data_02092110 != 0xc || data_0209f268 != 4)) {
+            Scene::SetSceneToSpawn(4, 0);
+        } else {
+            Scene::SetSceneToSpawn(3, 0);
+        }
+        if ((IsLevelInsideCastle(data_0209f2f8) == 0 || IsLevelInsideCastle(data_02092110) == 0)
+            && (IsLevelTinyHugeIslandOutside(data_0209f2f8) == 0 || IsLevelTinyHugeIslandOutside(data_02092110) == 0)) {
+            int bb2 = (data_0209f2d8 == 2);
+            if (bb2 == 0)
+                Sound::StopLoadedMusic_Layer1(0x3c);
+        }
+    } else if (data_0209f20c != 0) {
+        LC_Update();
+    } else if (data_0209f2c4 != 0) {
+        PS_Update();
+    } else {
+        u32 pi = data_020a0e40;
+        u16 h1 = *(u16*)((char*)data_020a0e58 + pi * 4);
+        if ((((h1 & 0x200) == 0 && (h1 & 0x100) == 0) || (*(u16*)((char*)data_020a0e5a + pi * 4) & 8) == 0)
+            && data_0209d660 == 0 && data_0209d4b0 == 0
+            && CanPause() != 0 && IsPauseDisabled() == 0
+            && (u8)(data_0209f294 | (data_0209f2c4 | data_0209f20c)) == 0
+            && MaskOff(data_0209b454, 0) == 0) {
+            u8 st = data_0209f2d8;
+            int b1 = (st == 1);
+            if ((b1 && data_0209fc68 == 0) || (data_0209caa0[2] & 0x80)) {
+                int b2 = (st == 2);
+                if (b2 == 0) {
+                    int b3 = (data_0209fc48 != 0);
+                    if (b3 == 0) {
+                        if (data_0209f300 == 0) {
+                            u32 pj = data_020a0e40;
+                            u16 h2 = *(u16*)((char*)data_020a0e5a + pj * 4);
+                            int t8 = h2 & 8;
+                            if ((t8 != 0 && (*(u16*)((char*)data_020a0e58 + pj * 4) & 4) == 0)
+                                || (b1 == 0 && t8 == 0 && (h2 & 4) != 0)) {
+                                data_0209f2c4 = 1;
+                                func_02012790(2);
+                                if (data_0209d4c8.started != 0) {
+                                    data_0209d4c8.StopTimer();
+                                    data_0209f2a0 = 1;
+                                }
+                                if (*(u16*)((char*)data_020a0e58 + data_020a0e40 * 4) & 4)
+                                    data_0209f218 = 1;
+                                else
+                                    data_0209f218 = 0;
+                                PS_Init();
+                                PS_Update();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if ((u8)(data_0209f294 | (data_0209f2c4 | data_0209f20c)) == 0) {
+        if ((data_0209b454 & ~0x20000000) == 0)
+            ShadowModel::CleanAll();
+    }
+    return 1;
+}

--- a/src/_ZN7Minimap13InitResourcesEv.cpp
+++ b/src/_ZN7Minimap13InitResourcesEv.cpp
@@ -1,0 +1,168 @@
+//cpp
+#pragma opt_strength_reduction off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+typedef int s32;
+
+extern "C" {
+    int func_0202a980(void);
+    int LoadFile(int handle);
+    void* _ZN3G2S13GetBG3CharPtrEv(void);
+    void DecompressLZ16(int src, void* dst);
+    void Deallocate(void* ptr);
+    int func_0202a96c(void);
+    void _ZN3GXS18BeginLoadBGExtPlttEv(void);
+    void _ZN3GXS13LoadBGExtPlttEPKvjj(const void* p, u32 a, u32 b);
+    void _ZN3GXS16EndLoadBGExtPlttEv(void);
+    void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
+    void* _ZN3G2S12GetBG3ScrPtrEv(void);
+    void _ZN7Minimap19UpdateLevelSpecificEv(void);
+    int GetMinimapID(void* obj, int arg);
+    int SublevelToLevel(int i);
+    int GetMinimapScale(int idx);
+    int func_0202a958(void);
+}
+
+extern u8 data_0209f2e8;
+extern u16* data_0209f334;
+extern u8 data_0209f2d8;
+extern u8 data_0209f250;
+extern void* data_0209f394[];
+extern signed char data_0209f2f8;
+extern signed char data_ov002_02111148;
+extern u8 data_0209d454;
+extern s32 data_0209caa0[];
+extern s32 data_0209fc48;
+extern u8 data_ov002_02111150;
+
+extern "C" int _ZN7Minimap13InitResourcesEv(char *c)
+{
+    u16 *p;
+    s32 i;
+
+    *(volatile u16*)0x400100e = (*(volatile u16*)0x400100e & ~3) | 2;
+    *(volatile u16*)0x400100e = (*(volatile u16*)0x400100e & 0x43) | 0x1f10;
+    *(volatile u16*)0x400100e &= ~0x40;
+
+    {
+        int id1 = func_0202a980();
+        if (id1 != 0) {
+            int f1 = LoadFile(id1);
+            DecompressLZ16(f1, _ZN3G2S13GetBG3CharPtrEv());
+            Deallocate((void*)f1);
+        }
+    }
+
+    {
+        int id2 = func_0202a96c();
+        if (id2 != 0) {
+            int f2 = LoadFile(id2);
+            _ZN3GXS18BeginLoadBGExtPlttEv();
+            _ZN3GXS13LoadBGExtPlttEPKvjj((void*)f2, 0x6000, 0x200);
+            _ZN3GXS16EndLoadBGExtPlttEv();
+            _ZN3GXS10LoadBGPlttEPKvjj((void*)f2, 0, 2);
+            Deallocate((void*)f2);
+        }
+    }
+
+    p = data_0209f334;
+    for (i = 0; i < data_0209f2e8; i++) {
+        if (*p != 0) {
+            int f3 = LoadFile(*p);
+            DecompressLZ16(f3, (char*)_ZN3G2S12GetBG3ScrPtrEv() - (i << 11));
+            Deallocate((void*)f3);
+        }
+        p++;
+    }
+
+    {
+        int b = (data_0209f2d8 == 1);
+        if (!b) {
+            _ZN7Minimap19UpdateLevelSpecificEv();
+        }
+    }
+
+    data_ov002_02111148 = (signed char)GetMinimapID(data_0209f394[data_0209f250], -1);
+
+    if (data_ov002_02111148 >= 0) {
+        if ((SublevelToLevel(data_0209f2f8) == 0x1d && data_0209f2f8 != 1 && data_0209f2f8 != 0x33 && data_0209f2f8 != 3)
+            || SublevelToLevel(data_0209f2f8) == 4
+            || (SublevelToLevel(data_0209f2f8) == 0x13 && data_0209f2f8 == 0x2e)
+            || SublevelToLevel(data_0209f2f8) == -1)
+        {
+            *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x4010));
+            *(s32*)(c + 0x1d8) = 0x100;
+            *(s32*)(c + 0x1dc) = 0x80;
+
+            if (SublevelToLevel(data_0209f2f8) == 4) {
+                *(s32*)(c + 0x1e0) = 0x258000;
+                *(s32*)(c + 0x1e4) = 0;
+                *(s32*)(c + 0x1e8) = 0x64000;
+            } else if (SublevelToLevel(data_0209f2f8) == 0x1d && data_0209f2f8 != 1 && data_0209f2f8 != 0x33 && data_0209f2f8 != 3) {
+                *(s32*)(c + 0x1e0) = -0x2bc000;
+                *(s32*)(c + 0x1e4) = 0;
+                *(s32*)(c + 0x1e8) = -0x2bc000;
+            } else {
+                SublevelToLevel(data_0209f2f8);
+                *(s32*)(c + 0x1e0) = 0;
+                *(s32*)(c + 0x1e4) = 0;
+                *(s32*)(c + 0x1e8) = 0;
+            }
+            *(u8*)(c + 0x251) = 1;
+        } else {
+            *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x10));
+            *(s32*)(c + 0x1d8) = 0x80;
+            *(s32*)(c + 0x1dc) = 0x40;
+            *(s32*)(c + 0x1e0) = 0;
+            *(s32*)(c + 0x1e4) = 0;
+            *(s32*)(c + 0x1e8) = 0;
+            *(u8*)(c + 0x251) = 2;
+        }
+        data_0209d454 |= 8;
+    } else {
+        data_0209d454 &= ~8;
+    }
+
+    *(s32*)(c + 0x214) = GetMinimapScale(data_ov002_02111148);
+
+    {
+        int b1 = (data_0209f2d8 == 0);
+        if (b1) {
+            if (!(data_0209caa0[2] & 0x80)) {
+                int b3 = (data_0209fc48 != 0);
+                if (!b3) {
+                    *(s32*)(c + 0x218) = (*(s32*)(c + 0x214)) << 1;
+                    *(u16*)(c + 0x21c) = 0;
+                    *(u8*)(c + 0x255) = 1;
+                    goto unk218_done;
+                }
+            }
+        }
+        *(s32*)(c + 0x218) = *(s32*)(c + 0x214);
+        *(u8*)(c + 0x255) = 0;
+    unk218_done:;
+    }
+
+    data_ov002_02111150 = 0;
+    *(s32*)(c + 0x50) = 0x1000;
+    *(s32*)(c + 0x54) = 0;
+    *(s32*)(c + 0x58) = 0;
+    *(s32*)(c + 0x5c) = 0x1000;
+    *(s32*)(c + 0x200) = 0x1000;
+    *(s32*)(c + 0x204) = 0;
+    *(s32*)(c + 0x208) = 0;
+    *(s32*)(c + 0x20c) = 0x1000;
+    *(s32*)(c + 0x1ec) = 0;
+    *(s32*)(c + 0x210) = 0x1000;
+    *(s32*)(c + 0x90) = 0;
+    *(s32*)(c + 0x94) = 0;
+    *(s32*)(c + 0x98) = 0;
+    *(s32*)(c + 0x9c) = 0;
+
+    *(s32*)(c + 0x1d4) = func_0202a958();
+    *(s32*)(c + 0x1d4) = ((*(s32*)(c + 0x1d8)) << 12) / (*(s32*)(c + 0x1d4)) / 10;
+
+    return 1;
+}

--- a/src/func_ov002_020b2508.c
+++ b/src/func_ov002_020b2508.c
@@ -1,0 +1,208 @@
+#pragma opt_common_subs off
+
+#define false 0
+#define true 1
+
+typedef unsigned char u8;
+typedef signed char s8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+typedef int s32;
+
+typedef struct { void* sfp; void* bmd; } FileEntry;
+typedef struct { u32 w[12]; } Blob48;
+
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
+extern int SublevelToLevel(int i);
+extern int _ZN5Actor18GetBitInDeathTableEv(void* actor);
+extern void SetStarMarker(int i, void* actor, int v2);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, int a, int b);
+extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, s32 f1, s32 f2, u32 a, u32 b);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, s32 f1, s32 f2, void* v, s32 f3);
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void* thiz);
+extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* thiz);
+
+extern Blob48 data_02082128;
+extern s8 data_0209f2f8;
+extern u8 data_0209f220;
+extern s32 data_0209f40c[];
+extern u8 data_0209f2d8;
+extern FileEntry* data_ov002_020ff06c[];
+extern FileEntry* data_ov002_020ff060[];
+extern void* data_ov002_0210d9a8;
+
+int func_ov002_020b2508(char* c)
+{
+    s32 r5;
+    s32 r4;
+    s32 t;
+    s8 i;
+    s32 j;
+
+    *(u8*)(c + 0x3ae) = 0;
+    r5 = 0x64000;
+    t = *(s32*)(c + 8) & 0xf;
+    *(s32*)(c + 0x3a4) = t;
+    r4 = 0x40000;
+    t = *(s32*)(c + 0x3a4);
+    if (t >= 9) {
+        t = 1;
+        *(s32*)(c + 0x3a4) = t;
+    }
+    t = *(s32*)(c + 0x3a4);
+    if (t == 8) {
+        *(s32*)(c + 0xa8) = 0x14000;
+        *(s32*)(c + 0x9c) = -0x4000;
+        *(s32*)(c + 0xa0) = -0x37000;
+        *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
+            (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~0xe0) | 0x40;
+        goto shared140;
+    }
+    if (t == 1 || t == 7) {
+        goto case17;
+    }
+    if (t == 5) {
+        goto case5;
+    }
+    /* default */
+    *(s32*)(c + 0xa8) = 0x24000;
+    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    goto block_11;
+case5:
+    {
+        u32 flags = *(u32*)(c + 8);
+        if (flags & 8) {
+            *(s16*)(c + 0x94) = (s16)(((flags & 0x70) << 8) + 0x8000);
+        } else {
+            *(s16*)(c + 0x94) = (s16)((flags & 0x70) << 8);
+        }
+    }
+block_11:
+    *(s32*)(c + 0x9c) = -0x4000;
+    *(s32*)(c + 0xa0) = -0x37000;
+    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0;
+    goto shared140;
+case17:
+    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
+        (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~0xe0) | 0xe0;
+    *(s32*)(c + 0x398) = *(s32*)(c + 0x60) - 0x1f4000;
+    if (*(s32*)(c + 0x3a4) == 7) {
+        r5 = 0x32000;
+        r4 = 0x28000;
+    }
+shared140:;
+
+    *(Blob48*)(c + 0x368) = data_02082128;
+
+    *(s8*)(c + 0x3ac) = -1;
+    *(u8*)(c + 0x3ab) = 0xff;
+
+    {
+        u16 h;
+        int b;
+        h = *(u16*)(c + 0xc);
+        b = h;
+        b = (b == 0x121);
+        if (b) {
+            *(u8*)(c + 0x3ab) = (u8)((*(u32*)(c + 8) >> 4) & 7);
+            _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9a8);
+            *(s32*)(c + 0x3a0) = 1;
+            if (SublevelToLevel(data_0209f2f8) == 0x13 ||
+                *(u8*)(c + 0x3ab) == data_0209f220) {
+                if (_ZN5Actor18GetBitInDeathTableEv(c) == 0) {
+                    for (i = 0; i < 0xc; i = (s8)(i + 1)) {
+                        if (data_0209f40c[i] == 0) {
+                            SetStarMarker(i, c, 4);
+                            *(s8*)(c + 0x3ac) = i;
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            int b2;
+            b2 = h;
+            b2 = (b2 == 0x122);
+            if (b2) {
+                *(u8*)(c + 0x3ab) = (u8)((*(u32*)(c + 8) >> 4) & 7);
+                *(s32*)(c + 0x3a0) = 2;
+            } else {
+                *(s32*)(c + 0x3a0) = 0;
+            }
+        }
+    }
+
+    j = *(s32*)(c + 0x3a0);
+    if (j < 2) {
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd8, data_ov002_020ff06c[j]->bmd, 1, 1) == 0) {
+            return 0;
+        }
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x114, data_ov002_020ff060[*(s32*)(c + 0x3a0)]->bmd, 1, 1) == 0) {
+            return 0;
+        }
+    } else {
+        _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_020ff06c[j]);
+        _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_020ff060[*(s32*)(c + 0x3a0)]);
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd8, data_ov002_020ff06c[*(s32*)(c + 0x3a0)]->bmd, 1, 1) == 0) {
+            return 0;
+        }
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x114, data_ov002_020ff060[*(s32*)(c + 0x3a0)]->bmd, 1, 1) == 0) {
+            return 0;
+        }
+    }
+
+    if (_ZN11ShadowModel12InitCylinderEv(c + 0x150) == 0) {
+        return 0;
+    }
+
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x178, c, r5, r4, 0x100002, 0x8000);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1ac, c, 0x3c000, 0x3c000, 0, 0);
+    _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x1ac);
+    _ZN12WithMeshClsn19StartDetectingWaterEv(c + 0x1ac);
+
+    t = *(s32*)(c + 0x3a4);
+    if (t == 8) {
+        *(s16*)(c + 0x3a8) = 0x2d;
+        *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    } else {
+        if (t == 6) {
+            int b3;
+            b3 = data_0209f2d8;
+            b3 = (b3 == 1);
+            if (b3 == false) {
+                *(u16*)(c + 0x3a8) = 0xffffu;
+                *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+                goto after438;
+            }
+        }
+        *(s16*)(c + 0x3a8) = 0xd2;
+    after438:;
+    }
+
+    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
+        (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~1) | 1;
+
+    t = *(s32*)(c + 0x3a4);
+    if (t == 1 || t == 7) {
+        goto case17b;
+    }
+    if (t == 5) {
+        *(u8*)(c + 0x3aa) = 0;
+    } else {
+        *(u8*)(c + 0x3aa) = 0xf;
+    }
+    goto switch2end;
+case17b:
+    *(u8*)(c + 0x3aa) = 0;
+    if (*(s32*)(c + 0x3a0) == 2 && (u32)*(u8*)(c + 0x3ab) < 8) {
+        *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    }
+switch2end:;
+
+    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1c;
+    *(s32*)(c + 0xd4) = 0;
+    return 1;
+}

--- a/src/func_ov002_020b86d0.c
+++ b/src/func_ov002_020b86d0.c
@@ -1,0 +1,211 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef int s32;
+typedef signed char s8;
+
+extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *sfp);
+extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *bmd, int a, int b);
+extern int _ZN11ShadowModel12InitCylinderEv(void *thiz);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, s32 f1, s32 f2, u32 a, u32 b);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, s32 f1, s32 f2, void *v, void *w);
+extern int _ZN5Actor13ClosestPlayerEv(void *thiz);
+extern void func_ov002_020b7f2c(void *c, void *p);
+extern void func_ov002_020b7f7c(void *thiz);
+extern void func_ov001_020ab228(void *c, void *a1, int idx, int a3, int a5);
+
+extern char data_ov002_0210de50;
+extern char data_ov002_0210de60;
+extern char data_ov002_0210de48;
+extern char data_ov002_0210de28;
+extern char data_ov002_0210de08;
+extern char data_ov002_0210de20;
+extern char data_ov002_0210de40;
+extern char data_ov002_0210de10;
+extern char data_ov002_0210de00;
+extern char data_ov002_0210de58;
+extern char data_ov002_0210de18;
+extern char data_ov002_0210de30;
+extern char data_ov002_0210de38;
+extern void *data_ov002_020ff0ac[];
+extern char data_ov002_0210df64;
+extern char data_ov002_0210df84;
+extern char data_ov002_0210df04;
+extern char data_ov002_0210df24;
+extern char data_ov002_0210df54;
+extern char data_ov002_0210df74;
+extern char data_ov002_0210df14;
+extern char data_ov002_0210df44;
+extern char data_ov002_0210df34;
+
+int func_ov002_020b86d0(char *c)
+{
+    int flag;
+    int v;
+
+    *(s32 *)(c + 0x3f0) = *(u32 *)(c + 8) & 0xff;
+    *(s32 *)(c + 0x3f4) = (*(u32 *)(c + 8) >> 8) & 0xf;
+    *(u8 *)(c + 0x400) = (*(u32 *)(c + 8) >> 0xc) & 0xf;
+
+    if (*(s32 *)(c + 0x3f0) == 0xff)
+        *(s32 *)(c + 0x3f0) = 0;
+
+    if (*(s32 *)(c + 0x3f4) >= 3)
+        return 0;
+
+    if (*(s32 *)(c + 0x3f0) == 0x11 || *(s32 *)(c + 0x3f0) == 4) {
+        if (*(u8 *)(c + 0x400) > 2)
+            *(u8 *)(c + 0x400) = 0;
+    } else {
+        if (*(u8 *)(c + 0x400) > 1)
+            *(u8 *)(c + 0x400) = 0;
+    }
+
+    switch (*(s32 *)(c + 0x3f0)) {
+    case 0xf:
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de50);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de60);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de48);
+        break;
+    case 0x14:
+    case 0x15:
+    case 0x16:
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de28);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de08);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de20);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de40);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de10);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de00);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de58);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de18);
+        break;
+    case 0x10:
+    case 0x11:
+    case 0x12:
+    case 0x13:
+    default:
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de30);
+        _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov002_0210de38);
+        break;
+    }
+
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300,
+            _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_020ff0ac[*(s32 *)(c + 0x3f4)]),
+            1, -1) == 0)
+        return 0;
+
+    _ZN11ShadowModel12InitCylinderEv(c + 0x364);
+
+    *(s32 *)(c + 0x80) = 0x1000;
+    *(s32 *)(c + 0x84) = 0x1000;
+    *(s32 *)(c + 0x88) = 0x1000;
+
+    flag = 0;
+
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, c, 0x1e000, 0x1e000, 0x800002, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x144, c, 0x1e000, 0x16000, 0, 0);
+
+    *(s32 *)(c + 0x3c4) = *(s32 *)(c + 0x5c);
+    *(s32 *)(c + 0x3c8) = *(s32 *)(c + 0x60);
+    *(s32 *)(c + 0x3cc) = *(s32 *)(c + 0x64);
+
+    *(s32 *)(c + 0x9c) = -0x1000;
+    *(s32 *)(c + 0xa0) = -0x1e000;
+
+    switch (*(s32 *)(c + 0x3f0)) {
+    default:
+        break;
+    case 0:
+        *(s32 *)(((long long)(c + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+        *(u8 *)(c + 0x400) = 4;
+        func_ov002_020b7f2c(c, &data_ov002_0210df64);
+        break;
+    case 1:
+        *(u8 *)(c + 0x400) = 0xff;
+        func_ov002_020b7f2c(c, &data_ov002_0210df84);
+        break;
+    case 2:
+        *(s32 *)(((long long)(c + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+        *(u8 *)(c + 0x400) = 4;
+        func_ov002_020b7f2c(c, &data_ov002_0210df04);
+        break;
+    case 3:
+        *(u8 *)(c + 0x400) = 0xff;
+        func_ov002_020b7f2c(c, &data_ov002_0210df24);
+        break;
+    case 19:
+        *(u8 *)(c + 0x400) = 0xff;
+        *(s32 *)(c + 0x3c0) = _ZN5Actor13ClosestPlayerEv(c);
+        func_ov002_020b7f2c(c, &data_ov002_0210df54);
+        *(u8 *)(c + 0x401) = 1;
+        break;
+    case 20:
+    case 21:
+    case 22:
+        func_ov002_020b7f7c(c);
+        /* fallthrough */
+    case 10:
+    case 15:
+        *(u8 *)(c + 0x400) = 0xff;
+        func_ov002_020b7f2c(c, &data_ov002_0210df74);
+        break;
+    case 12:
+        *(u8 *)(c + 0x400) = 4;
+        func_ov002_020b7f2c(c, &data_ov002_0210df14);
+        break;
+    case 13:
+        *(u8 *)(c + 0x400) = 4;
+        func_ov002_020b7f2c(c, &data_ov002_0210df44);
+        break;
+    case 14:
+        *(u8 *)(c + 0x400) = 2;
+        *(s32 *)(c + 0x114) = 0x32000;
+        *(s32 *)(c + 0x118) = 0x32000;
+        *(u32 *)(c + 8) -= 0xa;
+        *(s32 *)(c + 0x3f0) = 4;
+        func_ov002_020b7f2c(c, &data_ov002_0210df34);
+        break;
+    case 17:
+        *(s32 *)(c + 0x114) = 0x32000;
+        *(s32 *)(c + 0x118) = 0x32000;
+        flag = 1;
+        func_ov002_020b7f2c(c, &data_ov002_0210df34);
+        break;
+    case 6:
+    case 7:
+    case 8:
+    case 9:
+        *(u8 *)(c + 0x400) = 0xff;
+        *(s32 *)(c + 0x114) = 0x32000;
+        *(s32 *)(c + 0x118) = 0x32000;
+        func_ov002_020b7f2c(c, &data_ov002_0210df34);
+        break;
+    case 5:
+    case 11:
+    case 18:
+        *(s8 *)(c + 0xcc) = -1;
+        /* fallthrough */
+    case 16:
+        *(u8 *)(c + 0x400) = 3;
+        /* fallthrough */
+    case 4:
+        *(s32 *)(c + 0x114) = 0x32000;
+        *(s32 *)(c + 0x118) = 0x32000;
+        func_ov002_020b7f2c(c, &data_ov002_0210df34);
+        break;
+    }
+
+    *(s32 *)(c + 0x35c) = 0x1000;
+
+    if (*(u8 *)(c + 0x400) != 0xff) {
+        if (flag != 0)
+            v = 1;
+        else
+            v = 0;
+        func_ov001_020ab228(c + 0x3d0, c, *(s32 *)(c + 0x3f4) & 0xff, *(u8 *)(c + 0x400), v);
+    }
+
+    *(u32 *)(c + 8) &= 0xfff;
+    return 1;
+}

--- a/src/func_ov007_020ad660.c
+++ b/src/func_ov007_020ad660.c
@@ -1,0 +1,180 @@
+typedef signed char s8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern u8 data_ov007_0210342c[];
+extern short data_02082214[];
+
+extern void func_ov007_020c92d0(void *a);
+extern void func_ov007_020c0638(void *a, int b, int c, int d);
+extern void func_ov007_020c02d8(void *a, int b, u16 c);
+extern void func_ov007_020bfacc(int a, int b, int c);
+extern void func_ov007_020c1d8c(int a);
+extern int _ZN4cstd3divEii(int, int);
+extern void func_ov007_020ada70(void);
+
+void func_ov007_020ad660(char *arg0)
+{
+    char *mgr;
+    char *temp_r5;
+    char *temp_r4;
+    char *temp_r2;
+    int temp_r1;
+    u8 state;
+
+    mgr = *(char **)data_ov007_0210342c;
+    temp_r5 = *(char **)(mgr + 4);
+    temp_r4 = *(char **)(mgr + 8);
+
+    if (*(int *)(*(char **)(arg0 + 4) + 8) == 0) {
+        return;
+    }
+
+    func_ov007_020c92d0(*(char **)arg0);
+
+    state = *(u8 *)(arg0 + 8);
+    temp_r2 = *(char **)arg0;
+    temp_r1 = *(int *)(temp_r2 + 0xc);
+
+    switch (state) {
+    case 1:
+    case 6:
+    {
+        char *m134 = *(char **)(*(char **)data_ov007_0210342c + 0x134);
+        char *obj = *(char **)m134;
+        s16 v = *(s16 *)(*(char **)(obj + 4));
+        if ((u32)(u16)(s16)(v - 3) > 1u) {
+            return;
+        }
+        {
+            s16 c2 = *(s16 *)(*(char **)(obj + 0x24) + 4);
+            int c1 = *(int *)(obj + 0xc) >> 0xc;
+            func_ov007_020c0638(*(char **)(arg0 + 4), 0, c1 - c2, 0);
+        }
+        return;
+    }
+    case 5:
+        if (*(s16 *)temp_r5 != 5) {
+            return;
+        }
+        if (*(int *)(temp_r5 + 0xc) == 0) {
+            func_ov007_020c02d8(*(char **)(*(char **)(arg0 + 4) + 0x10), 0x18, 0x300);
+        }
+        if (*(int *)(*(char **)(*(char **)data_ov007_0210342c + 0x40) + 0xc) != 0) {
+            return;
+        }
+        func_ov007_020bfacc(9, 0, (int)func_ov007_020ada70);
+        func_ov007_020c02d8(*(char **)(*(char **)(arg0 + 4) + 0x10), 0x18, 0x301);
+        *(int *)(*(char **)(arg0 + 4) + 0xc) = 1;
+        func_ov007_020c1d8c(0);
+        return;
+    case 2:
+        switch (*(s16 *)temp_r2) {
+        case 0:
+        {
+            s16 v5;
+            s16 t4;
+            v5 = *(s16 *)temp_r5;
+            if (v5 != 0) {
+                return;
+            }
+            t4 = *(s16 *)temp_r4;
+            if (t4 == 0xb && *(int *)(temp_r4 + 0xc) == 0) {
+                *(int *)(*(char **)(arg0 + 4) + 4) = 3;
+            } else if (t4 == 0xa && *(int *)(temp_r4 + 0xc) == 0) {
+                *(int *)(*(char **)(arg0 + 4) + 4) = 2;
+                *(s16 *)(*(char **)arg0 + 2) = 1;
+            }
+            if (*(int *)(*(char **)data_ov007_0210342c + 0xec) != 1) {
+                return;
+            }
+            {
+                char *a1 = *(char **)(*(char **)data_ov007_0210342c + 0xf4);
+                char *a2 = *(char **)(a1 + 0x18);
+                if (*(s16 *)(a2 + 0xc) != 0) {
+                    return;
+                }
+            }
+            {
+                char *b1 = *(char **)(*(char **)data_ov007_0210342c + 0x104);
+                char *b2 = *(char **)(b1 + 4);
+                char *b3 = *(char **)(b2 + 0x18);
+                u16 v = *(u16 *)(b3 + 0x10);
+                if (v == 0x11d || v == 0x12c || v == 0x13d || v == 0x163 || v == 0x178 || v == 0x18f) {
+                    *(s16 *)(*(char **)arg0 + 2) = 2;
+                }
+            }
+            return;
+        }
+        case 1:
+        {
+            int var_r4;
+            if (temp_r1 <= 0) {
+                var_r4 = 0;
+            } else if (temp_r1 >= 0x50) {
+                var_r4 = 0x1000;
+            } else {
+                var_r4 = _ZN4cstd3divEii(temp_r1 << 0xc, 0x50);
+            }
+            {
+                int t = (int)(((long long)var_r4 * 0xe10 + 0x800) >> 0xc);
+                int r = _ZN4cstd3divEii(t << 0x10, 0x168);
+                int inv, inv2, prod, result;
+                r = (u16)r;
+                inv = 0x1000 - var_r4;
+                inv2 = (int)(((long long)inv * inv) >> 0xc);
+                inv2 = (int)(((long long)inv2 * inv2) >> 0xc);
+                if (inv2 < 0x50) {
+                    inv2 = 0;
+                }
+                prod = data_02082214[(r >> 4) * 2] * 0x19;
+                result = (int)(((long long)inv2 * prod + 0x800) >> 0xc);
+                *(int *)(*(char **)(arg0 + 4) + 0x2c) = result;
+            }
+            if (var_r4 >= 0x1000) {
+                *(s16 *)(*(char **)arg0 + 2) = 0;
+            }
+            return;
+        }
+        case 2:
+        {
+            int var_r0;
+            if (temp_r1 <= 0) {
+                var_r0 = 0;
+            } else if (temp_r1 >= 8) {
+                var_r0 = 0x1000;
+            } else {
+                var_r0 = _ZN4cstd3divEii(temp_r1 << 0xc, 8);
+            }
+            {
+                int inv = 0x1000 - var_r0;
+                int sq = (int)(((long long)inv * inv) >> 0xc);
+                u32 t = (u32)(var_r0 * 0xffff);
+                int idx;
+                int half;
+                short tblval;
+                int temp_a;
+                int result;
+                t = t << 4;
+                t = t >> 0x10;
+                idx = (int)t >> 4;
+                half = sq / 2;
+                tblval = data_02082214[idx * 2];
+                temp_a = half + 0x800;
+                result = (int)(((long long)temp_a * tblval + 0x800) >> 0xc);
+                *(int *)(*(char **)(arg0 + 4) + 0x2c) = -result;
+            }
+            if (var_r0 >= 0x1000) {
+                *(s16 *)(*(char **)arg0 + 2) = 0;
+            }
+            return;
+        }
+        default:
+            return;
+        }
+    default:
+        return;
+    }
+}

--- a/src/func_ov007_020b9880.c
+++ b/src/func_ov007_020b9880.c
@@ -1,0 +1,134 @@
+#pragma opt_strength_reduction off
+
+typedef int s32;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef signed short s16;
+typedef unsigned char u8;
+
+extern void *func_ov007_020c3df4(int a, int b);
+extern void *func_ov007_020c690c(int a0, int a1, int a2, int a3, void *a4, void *a5);
+extern void *func_ov007_020c9388(int a);
+extern void *func_ov007_020c908c(void *r5);
+extern void *func_ov007_020c44e4(int a);
+extern void func_ov007_020c43bc(void *a, int b);
+extern void func_ov007_020c4388(char *r0, int r1);
+extern void func_ov007_020bbe60(int idx);
+
+extern char *data_ov007_02104ba0;
+extern char *data_ov007_02104b9c;
+extern char *data_ov007_0210342c;
+extern int data_ov007_020d7b60;
+extern int data_ov007_020d7b80;
+
+void func_ov007_020b9880(int a0, int a1)
+{
+    int sp14, sp18, sp10, sp1c;
+    int var_sl;
+    void *temp_sb;
+    void *temp_r4;
+    void *temp_r5;
+
+    if (data_ov007_02104ba0 != 0)
+        return;
+
+    data_ov007_02104ba0 = (char *)func_ov007_020c3df4(0, 0x4c);
+    data_ov007_02104b9c = (char *)func_ov007_020c3df4(0, 0x14);
+
+    *(void **)(data_ov007_02104ba0 + 0x0) = func_ov007_020c690c(0xc8, 0x1f4, 0x1f4,
+        *(int *)(data_ov007_0210342c + 0x30), &data_ov007_020d7b60, &data_ov007_020d7b80);
+
+    *(void **)(data_ov007_02104ba0 + 0x4) = func_ov007_020c9388(0);
+    *(void **)(data_ov007_02104ba0 + 0x8) = func_ov007_020c9388(-1);
+    *(void **)(data_ov007_02104ba0 + 0xc) = func_ov007_020c9388(0);
+    *(void **)(data_ov007_02104ba0 + 0x10) = func_ov007_020c9388(0);
+
+    *(int *)(data_ov007_02104ba0 + 0x1c) = 0;
+    *(int *)(data_ov007_02104ba0 + 0x20) = 0;
+    *(int *)(data_ov007_02104ba0 + 0x28) = 0;
+    *(int *)(data_ov007_02104ba0 + 0x24) = 0;
+    *(int *)(data_ov007_02104ba0 + 0x2c) = 0;
+    *(int *)(data_ov007_02104ba0 + 0x38) = 0;
+
+    *(void **)(data_ov007_02104ba0 + 0x44) = func_ov007_020c908c(data_ov007_02104ba0 + 0x3c);
+    *(void **)(data_ov007_02104ba0 + 0x48) = func_ov007_020c908c(data_ov007_02104ba0 + 0x40);
+
+    sp1c = 0;
+    sp14 = 0x60000;
+    sp18 = 0x100;
+    sp10 = 1;
+
+    for (var_sl = 0; var_sl < 2; var_sl++) {
+        *(void **)(data_ov007_02104b9c + 0x4 + var_sl * 4) = func_ov007_020c44e4(sp10);
+        temp_sb = *(void **)(data_ov007_02104b9c + 0x4 + var_sl * 4);
+
+        if (var_sl == 0) {
+            *(int *)(*(int **)((char *)temp_sb + 0x5c)) = *(int *)(data_ov007_0210342c + 0x84);
+            *(int *)((char *)temp_sb + 0x10) = 0xfffcdf01;
+            *(u8 *)((char *)temp_sb + 0x4e) = 0x18;
+        } else {
+            *(int *)(*(int **)((char *)temp_sb + 0x5c)) = *(int *)(data_ov007_0210342c + 0x88);
+            *(int *)((char *)temp_sb + 0x10) = -0x32000;
+            *(u8 *)((char *)temp_sb + 0x4e) = 0x17;
+        }
+
+        *(u16 *)((char *)temp_sb + 0x62) = 8;
+        *(u16 *)((char *)temp_sb + 0x60) = *(u16 *)((char *)temp_sb + 0x62);
+        *(int *)((char *)temp_sb + 0x4) = 0x80000;
+        *(int *)((char *)temp_sb + 0x8) = sp14;
+        *(s16 *)((char *)temp_sb + 0xc) = (s16)sp18;
+        *(s16 *)((char *)temp_sb + 0xe) = (s16)sp18;
+        *(int *)((char *)temp_sb + 0x50) = sp1c;
+
+        func_ov007_020c43bc(temp_sb, *(int *)(data_ov007_0210342c + 0x34));
+        func_ov007_020c4388((char *)temp_sb, *(int *)(data_ov007_0210342c + 0x34));
+    }
+
+    *(void **)(data_ov007_02104b9c + 0xc) = func_ov007_020c44e4(1);
+    temp_r5 = *(void **)(data_ov007_02104b9c + 0xc);
+    *(u16 *)((char *)temp_r5 + 0xc) = 0x48;
+    *(u16 *)((char *)temp_r5 + 0xe) = 8;
+    *(u16 *)((char *)temp_r5 + 0x4c) = 0x7f8a;
+    *(u16 *)((char *)temp_r5 + 0x46) = *(u16 *)((char *)temp_r5 + 0x4c);
+    *(u16 *)((char *)temp_r5 + 0x4a) = 0x6e02;
+    *(u16 *)((char *)temp_r5 + 0x48) = *(u16 *)((char *)temp_r5 + 0x4a);
+    *(int *)((char *)temp_r5 + 0x0) = *(int *)((char *)temp_r5 + 0x0) | 2;
+    *(u8 *)((char *)temp_r5 + 0x4e) = 0x19;
+
+    *(void **)(data_ov007_02104b9c + 0x10) = func_ov007_020c44e4(1);
+    temp_r5 = *(void **)(data_ov007_02104b9c + 0x10);
+    *(u16 *)((char *)temp_r5 + 0xc) = 0x48;
+    *(u16 *)((char *)temp_r5 + 0xe) = 8;
+    *(u16 *)((char *)temp_r5 + 0x44) = 0x294a;
+    *(int *)((char *)temp_r5 + 0x50) = 0x5000;
+    *(int *)((char *)temp_r5 + 0x0) = *(int *)((char *)temp_r5 + 0x0) | 1;
+    *(u8 *)((char *)temp_r5 + 0x4e) = 0x1a;
+
+    temp_r4 = *(void **)((char *)(*(void **)(data_ov007_0210342c + 0x128)) + 0x4);
+    *(int *)((char *)(*(void **)(data_ov007_02104b9c + 0xc)) + 0x10) = *(int *)((char *)temp_r4 + 0x10) - 0x10;
+    *(int *)((char *)(*(void **)(data_ov007_02104b9c + 0x10)) + 0x10) = *(int *)((char *)temp_r4 + 0x10) - 0xff;
+
+    func_ov007_020c43bc(*(void **)(data_ov007_02104b9c + 0xc), *(int *)(data_ov007_0210342c + 0x34));
+    func_ov007_020c43bc(*(void **)(data_ov007_02104b9c + 0x10), *(int *)(data_ov007_0210342c + 0x34));
+
+    *(int *)(data_ov007_02104ba0 + 0x34) = 0;
+    *(int *)((char *)(*(void **)(data_ov007_02104ba0 + 0x44)) + 0x18) = 0x800;
+    *(int *)(data_ov007_02104ba0 + 0x3c) = *(int *)((char *)(*(void **)(data_ov007_02104ba0 + 0x44)) + 0x18);
+
+    if (a0 != 0) {
+        if (a0 == 1) {
+            *(int *)(data_ov007_02104ba0 + 0x30) = 0;
+            *(int *)(data_ov007_02104ba0 + 0x40) = 0;
+            *(u16 *)((char *)(*(void **)(data_ov007_02104ba0 + 0x8)) + 0x2) = 0;
+        }
+    } else {
+        *(int *)(data_ov007_02104ba0 + 0x30) = 1;
+        *(int *)(data_ov007_02104ba0 + 0x40) = 0x1000;
+        *(u16 *)((char *)(*(void **)(data_ov007_02104ba0 + 0x8)) + 0x2) = 2;
+    }
+
+    if (a0 != 1)
+        return;
+
+    func_ov007_020bbe60(a1);
+}


### PR DESCRIPTION
Three-model cascade over a coddog-scheduled LARGE-band (0x400–0x800) worklist. Each stage lands its matches and hands the misses to the next, stronger/different model.

## Results (7 matches)

| Stage | Model | Landed | Functions |
|-------|-------|--------|-----------|
| 1 | Sonnet 5 | 4 | `func_ov007_020b9880`, `func_ov007_020ad660`, `_ZN5Stage14LoadGraphics2DEbi`, `func_ov002_020b86d0` |
| 2 | Opus 4.8 | 1 | `_ZN7Minimap13InitResourcesEv` |
| 3 | Fable 5 | 2 | `func_ov002_020b2508`, `_ZN5Stage8BehaviorEv` |

## Highlights

- **`_ZN7Minimap13InitResourcesEv`** (Opus) — cracked a div-16 hw-register RMW near-miss; writing the OR shift-first (`((0x1F-data)<<8) | ((*io & 0x43) | K)`) forces the early `rsb` schedule + the IO-pointer register coloring.
- **`func_ov002_020b2508`** (Fable) — div 38 → 0. Manual-CSE `u16` local fed through a self-referencing two-step bool keeps jump-threading dead under `#pragma opt_common_subs off`.
- **`_ZN5Stage8BehaviorEv`** (Fable) — div 49 → 0 on a 444-instruction C++ pause-screen dispatcher. Both this and the above broke the `opt_common_subs off` EBB-CSE wall that Sonnet and Opus had each declared a register-CSE floor.

## New codegen lever

`bics rX,rX,#0` from `x & ~m` via an inline helper / non-const local (`m = 0`): mwccarm selects `BIC` *before* constant propagation, whereas every literal `~0` form folds to `cmp`.

## Verification

All 7 independently oracle-verified (`abverify` → `MATCH`) and link-verified (`linkcheck` → `VERIFIED`). Branch is based on `origin/main`; contains only the 7 new source files (no README/near-miss-DB churn to avoid regressing the shared progress counters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzWbWAbHmLVthVmnmNxeNR