### PR TITLE
Add ov001 touch helper near-misses

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -40,6 +40,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
+| ov001 func_ov001_020ab3c4 + func_ov001_020ab450 (0x020ab3c4-0x020ab54c) | lunavyqo | 2026-07-07 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -40,7 +40,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
-| ov001 func_ov001_020ab3c4 + func_ov001_020ab450 (0x020ab3c4-0x020ab54c) | lunavyqo | 2026-07-07 | in progress |
+| ov001 func_ov001_020ab3c4 + func_ov001_020ab450 (0x020ab3c4-0x020ab54c) | lunavyqo | 2026-07-07 | NONMATCHING submitted - div=4 and div=13 |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov001_020ab3c4.c
+++ b/src/func_ov001_020ab3c4.c
@@ -1,15 +1,10 @@
-// NONMATCHING: base materialization / addressing (div=4). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern int data_ov001_020ad470;
+// NONMATCHING: materialized byte-RMW tail has r1/r0 where ROM uses r2/r1 (div=4).
+extern int data_ov001_020ad470[];
 
-void func_ov001_020ab3c4(void *r0) {
-    char *ptr = (char *)r0;
-    *(int *)ptr = (int)&data_ov001_020ad470;
-    *(int *)(ptr + 0xc) = 0;
-    *(int *)(ptr + 0x10) = 0;
-    
-    char *r2 = &ptr[0x1b];
-    unsigned char r1 = *r2;
-    *r2 = r1 | 4;
+void func_ov001_020ab3c4(char *c)
+{
+    *(int **)c = data_ov001_020ad470;
+    *(int *)(c + 0xc) = 0;
+    *(int *)(c + 0x10) = 0;
+    *(unsigned char *)(((long long)(int)(c + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
 }

--- a/src/func_ov001_020ab450.c
+++ b/src/func_ov001_020ab450.c
@@ -1,0 +1,50 @@
+// NONMATCHING: geometry block register-coloring rotation, logic/control flow match (div=13).
+extern int func_0203da9c(void);
+
+extern unsigned char data_020a0de8[][4];
+extern unsigned char data_020a0de9[][4];
+extern unsigned char data_020a0dea[][4];
+extern unsigned char data_020a0deb[][4];
+
+int func_ov001_020ab450(char *self, int arg)
+{
+    int result;
+    int ret;
+
+    if (*(unsigned char *)(self + 0x11) == 0)
+        return 0;
+    if (arg < 0)
+        arg = func_0203da9c();
+    ret = 0;
+    result = 0;
+    if (data_020a0de8[arg][0] != 0) {
+        int s8 = *(short *)(self + 8);
+        int dx = data_020a0dea[arg][0] - *(short *)(self + 4);
+        int dy = data_020a0deb[arg][0] - *(short *)(self + 6);
+
+        if (dx >= -s8 && dx <= s8) {
+            int sa = *(short *)(self + 0xa);
+
+            if (dy >= -sa && dy <= sa)
+                result = 1;
+        }
+    }
+    if (result != 0) {
+        int st = *(int *)(self + 0x14);
+
+        if (st == 1) {
+            if (data_020a0de9[arg][0] != 0)
+                goto win;
+        }
+        if (st == 2) {
+            if (*(unsigned char *)(self + 0x12) == 0)
+                goto win;
+        }
+    }
+    goto done;
+win:
+    ret = 1;
+done:
+    *(unsigned char *)(self + 0x12) = (unsigned char)result;
+    return ret;
+}


### PR DESCRIPTION
## Summary

- Adds a `NONMATCHING` draft for `func_ov001_020ab450` at `0x020ab450`.
- Reworks the existing `func_ov001_020ab3c4` draft at `0x020ab3c4` to the closest laundered form.
- Updates `CLAIMS.md` to record the submitted nonmatching state for the claimed ov001 range.

## Notes

These are not byte-identical yet. I iterated from the near-miss drafts and stopped at stable register-coloring residuals:

- `func_ov001_020ab3c4`: div=4, materialized byte-RMW tail colors as `r1/r0` where the ROM uses `r2/r1`.
- `func_ov001_020ab450`: div=13, logic/control flow and pool layout line up, with the remaining gap isolated to the geometry block register rotation.

The external claims API returned 401 for both requested locks, so this PR uses the repository `CLAIMS.md` coordination row.

## Verification

Using mwccarm `1.2/sp2p3` with the project default C flags:

```sh
.venv/bin/python tools/match.py --c src/func_ov001_020ab3c4.c --func func_ov001_020ab3c4 --addr 0x020ab3c4 --size 0x2c --version 1.2/sp2p3 --brief --bin extracted/dsd/arm9_overlays/ov001.bin --base 0x020aa420
# 4 word(s) differ

.venv/bin/python tools/match.py --c src/func_ov001_020ab450.c --func func_ov001_020ab450 --addr 0x020ab450 --size 0xfc --version 1.2/sp2p3 --brief --bin extracted/dsd/arm9_overlays/ov001.bin --base 0x020aa420
# 13 word(s) differ
```
