### PR TITLE
Match func_ov017_021112c4

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -40,6 +40,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
+| ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -40,7 +40,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aa420 (0x020aa420, size 0x290) | lunavyqo (AI-assisted) | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
-| ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | in progress |
+| ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov017_021112c4.c
+++ b/src/func_ov017_021112c4.c
@@ -1,6 +1,3 @@
-// NONMATCHING: base materialization / addressing (div=9). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int e);
 extern int _ZN9Animation7AdvanceEv(char* t);
@@ -26,7 +23,7 @@ int func_ov017_021112c4(char* c) {
         if (d < 0x92e000) {
             int* q;
             *(int*)(c+0x33c) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int*)(c+0x33c), 3, 0x96, c+0x74, 0);
-            q = (int*)(c+0x60);
+            q = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
             *q -= 0x5000;
         }
     }


### PR DESCRIPTION
## Summary

Matches `func_ov017_021112c4` at `0x021112c4` in `ov017` byte-for-byte against the EU retail overlay.

The previous draft was structurally correct but folded the `c + 0x60` load/store address. Routing that address through the documented u64-mask materialization idiom emits the ROM's `add r1, r4, #0x60` shape, which also aligns the trailing `0x0092e000` literal pool word.

Compiler: `mwccarm 1.2/sp2p3`

Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Verification

```sh
.venv/bin/python tools/match.py --c src/func_ov017_021112c4.c --func func_ov017_021112c4 --addr 0x021112c4 --size 0xfc --version 1.2/sp2p3 --bin extracted/overlays/overlay_0017.bin --base 0x021111a0 --brief
# MATCHING VERSIONS: 1.2/sp2p3

.venv/bin/python tools/match.py --c src/func_ov017_021112c4.c --func func_ov017_021112c4 --addr 0x021112c4 --size 0xfc --version 1.2/sp2p3 --bin extracted/overlays/overlay_0017.bin --base 0x021111a0 --strict-relocs --module ov017 --brief
# MATCHING VERSIONS: 1.2/sp2p3

.venv/bin/python tools/fdiff.py --c src/func_ov017_021112c4.c --name func_ov017_021112c4 --module ov017 --addr 0x021112c4 --size 0xfc --quiet
# RESULT match=True mismatches=0/63

.venv/bin/python tools/linkcheck.py --name func_ov017_021112c4 --addr 0x021112c4 --size 0xfc --module ov017
# verdict: VERIFIED, diffs: [], blind: 0
```
