### PR TITLE
Match 17 functions via Sonnet->Opus->Fable cascade (0x280-0x400 band)

### DIFF
--- a/src/_ZN10SphereClsn10DetectClsnEv.cpp
+++ b/src/_ZN10SphereClsn10DetectClsnEv.cpp
@@ -1,0 +1,113 @@
+//cpp
+
+extern "C" {
+int func_020393b4(void *p);
+int func_020393ac(void *p);
+int func_0203939c(void *p);
+int func_0203938c(void *p);
+int func_02035354(void *a, void *b);
+void func_02037fec(void *c, int p1, int p2, int p3, void *e);
+void func_020379d0(void *c, int p1, int p2, int p3, void *e);
+void func_0203799c(void *c, int p1, int p2, int p3, void *e);
+void func_02037968(void *c, int p1, int p2, int p3, void *e);
+void func_02037a38(void *o);
+int Vec3_Dist(const void *a, const void *b);
+}
+
+extern void *data_020a0c80[];
+
+class C {
+public:
+    virtual int v0();
+    virtual int v1();
+    virtual int v2();
+    virtual int v3();
+    virtual int v4();
+    virtual int v5();
+    virtual int v6();
+    virtual int v7();
+    virtual int v8(void *arg);
+};
+
+struct Vec3 { int x, y, z; };
+
+struct Info {
+    char pad0[0x5c];
+    Vec3 pos;
+    char pad1[0xb0 - 0x68];
+    int pB0;
+    int pB4;
+    int pB8;
+};
+
+class SphereClsn {
+public:
+    int DetectClsn();
+};
+
+int SphereClsn::DetectClsn()
+{
+    int result = 0;
+    int mask;
+    char *e = (char *)data_020a0c80[0];
+    if (e != 0) {
+        if (func_02035354(this, (void *)func_020393b4(e)) == 0) {
+            mask = ((C *)e)->v8(this);
+            if (mask != 0) {
+                func_02037fec((char *)this + 0x10, 0, func_020393ac(e), func_020393b4(e), e);
+                if (mask & 1)
+                    func_020379d0(this, 0, func_020393ac(e), func_020393b4(e), e);
+                if (mask & 2)
+                    func_0203799c(this, 0, func_020393ac(e), func_020393b4(e), e);
+                if (mask & 4)
+                    func_02037968(this, 0, func_020393ac(e), func_020393b4(e), e);
+                result = 1;
+            }
+        }
+    }
+
+    e = (char *)this + 0x3c;
+    int threshold = *(int *)((char *)this + 0x48) + 0x1000;
+    for (int i = 1; i < 0x18; i++) {
+        C *o = (C *)data_020a0c80[i];
+        if (o == 0) continue;
+        Info *info = (Info *)func_020393b4(o);
+        if (func_02035354(this, info) != 0) continue;
+        if (info != 0) {
+            int active = (info->pB0 & 2) ? 1 : 0;
+            if (active != 0) {
+                Vec3 v;
+                Vec3 *src = (Vec3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                v.x = src->x;
+                v.y = src->y;
+                v.z = src->z;
+                mask = func_0203939c(o);
+                if (mask == -0x1000) {
+                    int b4 = info->pB4;
+                    int b8 = info->pB8;
+                    v.y += b4;
+                    mask = b8 << 3;
+                } else {
+                    v.y += func_0203938c(o);
+                }
+                if (Vec3_Dist(e, &v) > mask + threshold)
+                    continue;
+            }
+        }
+        {
+            { int t = o->v8(this); mask = t; }
+            if (mask != 0) {
+                func_02037fec((char *)this + 0x10, i, func_020393ac(o), func_020393b4(o), o);
+                if (mask & 1)
+                    func_020379d0(this, i, func_020393ac(o), func_020393b4(o), o);
+                if (mask & 2)
+                    func_0203799c(this, i, func_020393ac(o), func_020393b4(o), o);
+                if (mask & 4)
+                    func_02037968(this, i, func_020393ac(o), func_020393b4(o), o);
+                result = 1;
+            }
+        }
+    }
+    func_02037a38(this);
+    return result;
+}

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -1,0 +1,125 @@
+//cpp
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef s32 Fix12;
+
+extern "C" {
+extern int func_ov002_020c0434(void* c);
+extern void func_ov002_020c0364(void* c, u32 arg);
+extern void func_ov002_020c06fc(void* c, u32 arg);
+extern void func_ov002_020e04a4(void* c);
+extern int func_ov002_020e3078(void* c, void* s);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+extern int _ZN6Player6IsAnimEj(void* c, u32 a);
+extern int func_ov002_020d5c6c(void* c);
+extern int func_ov002_020dde74(void* c);
+extern int func_ov002_020bf30c(void* c, int a);
+extern int func_ov002_020bf224(void* c, int a, int b);
+extern void _Z14ApproachLinearRiii(int* a, int b, int c);
+extern int _ZN6Player12FinishedAnimEv(void* c);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern int AngleDiff(int a, int b);
+extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
+extern void func_ov002_020bedd4(void* c);
+
+extern u8 data_020a0e40;
+extern u16 data_0209f49e[];
+extern u16 data_0209f49c[];
+extern s16 data_0209f4a0[];
+extern int data_ov002_0211055c[];
+extern int data_ov002_0211019c[];
+extern int data_ov002_0211052c[];
+extern int data_ov002_0211013c[];
+}
+
+extern "C" int _ZN6Player12St_Land_MainEv(char* c)
+{
+    if (func_ov002_020c0434(c)) {
+        func_ov002_020c0364(c, 3);
+        func_ov002_020c06fc(c, 0x4000);
+        return 1;
+    }
+
+    func_ov002_020e04a4(c);
+    u16 temp_r3 = *(u16*)(c + 0x6ce);
+
+    if ((u16)(temp_r3 & 0x40) == 0) {
+        if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2)
+            || (u16)(temp_r3 & 0x100) != 0) {
+            *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
+            if (func_ov002_020e3078(c, data_ov002_0211055c) != 0
+                && (*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 0x400)
+                && *(int*)(c + 0x98) >= 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211055c);
+                return 1;
+            }
+            if (_ZN6Player6IsAnimEj(c, 0x4e) != 0) {
+                *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+            }
+            int v = (*(int*)(c + 0x358) != 0);
+            if (v != 0) {
+                *(s16*)(c + 0x6a8) = 0;
+            }
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+            return 1;
+        }
+        if (func_ov002_020d5c6c(c) != 0) {
+            return 1;
+        }
+        if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 1) {
+            return func_ov002_020dde74(c);
+        }
+    } else {
+        *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
+    }
+
+    _Z14ApproachLinearRiii((int*)(c + 0x98),
+        func_ov002_020bf224(c, func_ov002_020bf30c(c, 0x20000), 0),
+        0x4000);
+
+    if (func_ov002_020e3078(c, data_ov002_0211052c) != 0) {
+        *(int*)(c + 0x98) = 0;
+    }
+
+    if (*(u16*)(c + 0x6a4) != 0) {
+        goto tail;
+    }
+
+    if ((*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0)
+        || (_ZN6Player12FinishedAnimEv(c) != 0)) {
+        if (_ZN6Player6IsAnimEj(c, 0x1b) != 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2e, 0x40000000, 0x1000, 0);
+            goto tail;
+        }
+        if (_ZN6Player6IsAnimEj(c, 0x4e) != 0) {
+            *(s16*)(c + 0x8e) = (s16)(*(s16*)(c + 0x8e) + 0x8000);
+        }
+        if ((*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0)
+            && AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x94)) >= 0x4000) {
+            if (AngleDiff(*(s16*)(c + 0x6d2), *(s16*)(c + 0x8e)) >= 0x4000) {
+                *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+            } else {
+                *(int*)(c + 0x98) = 0 - *(int*)(c + 0x98);
+            }
+        }
+        *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211013c) != 0
+            && *(u8*)(c + 0x6e3) != 0
+            && *(int*)(c + 0x98) >= func_ov002_020bf30c(c, 0x1c000)) {
+            *(s16*)(c + 0x760) = 0x4000;
+        }
+        return 1;
+    }
+
+    if (func_ov002_020e3078(c, data_ov002_0211019c) == 0) {
+        *(int*)(c + 0x98) = 0;
+    }
+
+tail:
+    func_ov002_020bedd4(c);
+    return 1;
+}

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -1,0 +1,120 @@
+//cpp
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef s32 Fix12;
+
+extern "C" {
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+extern int func_ov002_020c5244(void);
+extern int func_ov002_020d36d8(void* c, int a);
+extern void func_ov002_020d45c0(void* c);
+extern int func_ov002_020d3b9c(void* c);
+extern void func_ov002_020d413c(void* c, short arg);
+extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
+extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
+extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, short a5);
+extern int _ZN6Player12FinishedAnimEv(void* c);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void func_ov002_020d4540(void* c);
+extern void func_ov002_020cabe0(void* c);
+extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
+extern int _ZN9Animation8GetFlagsEv(void* anim);
+extern void func_ov002_020d4748(void* c);
+extern void func_ov002_020bedd4(void* c);
+
+extern u8 data_020a0e40;
+extern u8 data_0209f4ae[];
+extern s16 data_0209f4a0[];
+extern int data_ov002_02110154[];
+}
+
+extern "C" int _ZN6Player12St_Walk_MainEv(char* c)
+{
+    if ((u16)(*(u16*)(c + 0x6ce) & 0x800)) {
+        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+        return 1;
+    }
+    if (func_ov002_020c5244()) return 1;
+    if (func_ov002_020d36d8(c, 0)) return 1;
+
+    func_ov002_020d45c0(c);
+    short r5 = *(short*)(c + 0x94);
+    if (func_ov002_020d3b9c(c)) return 1;
+
+    func_ov002_020d413c(c, r5);
+
+    if (*(int*)(c + 0x98) == 0) {
+        *(short*)(c + 0x8e) = *(short*)(c + 0x94);
+    } else {
+        ApproachAngle((short*)(c + 0x8e), *(short*)(c + 0x94), 4, 0x2000, 0x800);
+    }
+
+    if (*(u8*)(c + 0x6e0) != 0) {
+        if (!_ZN6Player6IsAnimEj(c, 0x37)) {
+            int result = func_0201226c(*(int*)(c + 0x620), 0, *(int*)(c + 0x66c) + 0xe2, (int)(c + 0x74), *(int*)(c + 0x98), 0);
+            *(int*)(c + 0x620) = result;
+        }
+        if (_ZN6Player12FinishedAnimEv(c)) {
+            if (_ZN6Player6IsAnimEj(c, 0x36)) {
+                if (*(int*)(c + 0x98) == 0) {
+                    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x37, 0x40000000, 0x1000, 0);
+                }
+            } else {
+                if (_ZN6Player6IsAnimEj(c, 0x37)) {
+                    func_ov002_020d4540(c);
+                }
+            }
+        }
+        goto end;
+    }
+
+    if (*(int*)(c + 0x98) != 0) goto label_29c;
+
+    {
+        u8 idx = data_020a0e40;
+        int off = idx * 0x18;
+        u8 b = data_0209f4ae[off];
+        int thresh = (b != 2) ? 0x471 : 0x555;
+        u8 v710 = *(u8*)(c + 0x710);
+        int rhs = thresh - (v710 << 7);
+        short lhs = *(s16*)((char*)data_0209f4a0 + off);
+        if (lhs < rhs) goto label_1f0;
+        if ((u16)(*(u16*)(c + 0x6ce) & 0xc) == 0) goto label_29c;
+    }
+
+label_1f0:
+    if (*(u8*)(c + 0x703) != 0) {
+        if (_ZN6Player12FinishedAnimEv(c) && _ZN6Player6IsAnimEj(c, 0x9d)) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+            *(u8*)(c + 0x6e5) = 1;
+            func_ov002_020cabe0(c);
+        }
+        goto end;
+    }
+
+    if (_ZN6Player12FinishedAnimEv(c)) goto label_27c;
+
+    {
+        u32 arg = (u8)*(int*)(c + 8);
+        int modelIdx = _ZNK6Player14GetBodyModelIDEjb(c, arg, 0);
+        char* anim = *(char**)(c + modelIdx * 4 + 0xdc) + 0x50;
+        if (_ZN9Animation8GetFlagsEv(anim)) goto end;
+    }
+
+label_27c:
+    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+    *(u8*)(c + 0x6e5) = 1;
+    func_ov002_020cabe0(c);
+    goto end;
+
+label_29c:
+    func_ov002_020d4748(c);
+    *(u8*)(c + 0x6e5) = 1;
+
+end:
+    func_ov002_020bedd4(c);
+    return 1;
+}

--- a/src/_ZN6Player14St_Crouch_MainEv.cpp
+++ b/src/_ZN6Player14St_Crouch_MainEv.cpp
@@ -1,0 +1,94 @@
+//cpp
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef s32 Fix12;
+
+extern "C" {
+extern void func_ov002_020bf90c(void* c);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+extern int _ZN6Player6IsAnimEj(void* c, u32 a);
+extern int _ZN6Player12FinishedAnimEv(void* c);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern int func_ov002_020d12b0(void* c);
+extern int func_ov002_020d1204(void* c);
+extern int func_ov002_020d1164(void* c);
+extern void func_ov002_020c06fc(void* c, u32 a);
+extern int func_ov002_020dd2f4(void* c);
+extern void func_ov002_020c0364(void* c, u32 a);
+extern void func_ov002_020bedd4(void* c);
+
+extern u16 data_0209f49c[];
+extern u8 data_020a0e40;
+extern s16 data_0209f4a0[];
+extern int data_ov002_021101b4[];
+extern int data_ov002_02110514[];
+extern int data_ov002_0211013c[];
+}
+
+extern "C" int _ZN6Player14St_Crouch_MainEv(char* c)
+{
+    func_ov002_020bf90c(c);
+
+    if (*(u8*)(c + 0x6de) != 0) {
+        int d = *(int*)(c + 0x60) - *(int*)(c + 0x644);
+        if (d >= 0x32000) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            return 1;
+        }
+    }
+
+    switch (*(u8*)(c + 0x6e3)) {
+    case 0:
+        if (_ZN6Player6IsAnimEj(c, 0x2d) && _ZN6Player12FinishedAnimEv(c)) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2c, 0, 0x1000, 0);
+            *(u8*)(c + 0x6e3) = 1;
+        }
+        if (func_ov002_020d12b0(c))
+            return 1;
+        func_ov002_020d1204(c);
+        break;
+    case 1:
+        if ((*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 0x400) != 0
+            || *(int*)(c + 0x98) != 0
+            || func_ov002_020d1164(c) != 0) {
+            if (*(int*)(c + 0x98) != 0) {
+                func_ov002_020c06fc(c, 0x4000);
+                func_ov002_020dd2f4(c);
+            } else {
+                if (*(u8*)(c + 0x703) == 0) {
+                    if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) >= 0x200) {
+                        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110514);
+                        return 1;
+                    }
+                }
+            }
+            u16 bit = *(u16*)(c + 0x6ce) & 1;
+            if (bit != 0) {
+                func_ov002_020c0364(c, 1);
+                return 1;
+            }
+        } else {
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2e, 0x40000000, 0x1000, 0);
+            *(u8*)(c + 0x6e3) = 2;
+        }
+        if (func_ov002_020d12b0(c))
+            return 1;
+        if (func_ov002_020d1204(c) != 0)
+            return 1;
+        break;
+    case 2:
+        if (_ZN6Player6IsAnimEj(c, 0x2e) && _ZN6Player12FinishedAnimEv(c)) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+            *(u16*)(c + 0x6b0) = 0xa;
+        } else {
+            func_ov002_020d1204(c);
+        }
+        break;
+    }
+
+    func_ov002_020bedd4(c);
+    return 1;
+}

--- a/src/func_02033bb8.c
+++ b/src/func_02033bb8.c
@@ -1,0 +1,114 @@
+#pragma opt_strength_reduction off
+#pragma opt_common_subs off
+extern short data_0209fce8;
+extern unsigned char data_0209fc9c;
+extern unsigned char data_0209fc94;
+extern unsigned char data_0209fc78;
+extern unsigned char data_0209fcdc;
+extern unsigned char data_0209fc88;
+
+extern void func_02034504(void);
+extern int _ZN3G2S13GetBG0CharPtrEv(void);
+extern void MultiStore_Int(int val, int *dst, int len);
+extern int _ZN3G2S12GetBG0ScrPtrEv(void);
+extern void MultiStore16(unsigned short val, char *dst, int nbytes);
+extern void func_02034098(void);
+extern int _ZN2G212GetBG2ScrPtrEv(void);
+extern void func_02033e50(int a, int b);
+extern void func_020341a8(int a, int b);
+
+void func_02033bb8(int param0)
+{
+    volatile int li;
+    volatile unsigned short sv;
+    int n, m, i;
+    short *scr;
+
+    data_0209fce8 = (short)param0;
+    data_0209fc9c = 0;
+    func_02034504();
+
+    data_0209fc94 = 1;
+    data_0209fc78 = 0;
+    data_0209fcdc = 0;
+
+    {
+        int cp = _ZN3G2S13GetBG0CharPtrEv() + 0x4000;
+        li = 0;
+        MultiStore_Int(li, (int*)cp, 0x2000);
+    }
+
+    {
+        int sp2 = _ZN3G2S12GetBG0ScrPtrEv();
+        sv = 0x2ff;
+        MultiStore16(sv, (char*)sp2, 0x800);
+    }
+
+    func_02034098();
+    n = data_0209fc88;
+    m = (n + 7) / 8;
+    scr = (short*)(_ZN2G212GetBG2ScrPtrEv() + 0x40 + (16 - m / 2) * 2);
+    i = 0;
+    if (m > 0) {
+        int v2 = m + 0x280;
+        do {
+            scr[i] = (short)(i + 0x280);
+            *(short*)((char*)&scr[i] + 0x40) = (short)v2;
+            v2++;
+            i++;
+        } while (i < m);
+    }
+    func_02033e50(0xa9, 0x70);
+
+    data_0209fce8++;
+    func_02034098();
+    n = data_0209fc88;
+    m = (n + 7) / 8;
+    {
+        int base = _ZN2G212GetBG2ScrPtrEv();
+        scr = (short*)(base + 0x840 + (16 - m / 2) * 2);
+    }
+    i = 0;
+    if (m > 0) {
+        int mm = (n + 7) / 8;
+        int d = data_0209fcdc;
+        int v1 = d - mm * 2 + 0x280;
+        int v2 = d - mm + 0x280;
+        do {
+            scr[i] = (short)v1;
+            *(short*)((char*)&scr[i] + 0x40) = (short)v2;
+            v1++;
+            v2++;
+            i++;
+        } while (i < mm);
+    }
+    func_02033e50(0x149, 0x70);
+
+    data_0209fce8++;
+    func_02034098();
+    n = data_0209fc88;
+    m = (n + 7) / 8;
+    {
+        int base = _ZN2G212GetBG2ScrPtrEv();
+        scr = (short*)(base + 0x1040 + (16 - m / 2) * 2);
+    }
+    i = 0;
+    if (m > 0) {
+        int mm = (n + 7) / 8;
+        int d = data_0209fcdc;
+        int v1 = d - mm * 2 + 0x280;
+        int v2 = d - mm + 0x280;
+        do {
+            scr[i] = (short)v1;
+            *(short*)((char*)&scr[i] + 0x40) = (short)v2;
+            v1++;
+            v2++;
+            i++;
+        } while (i < mm);
+    }
+    func_02033e50(0x1e9, 0x70);
+
+    data_0209fc78 = (unsigned char)(data_0209fc78 << 1);
+    data_0209fce8++;
+    func_020341a8(0x280, 0x20);
+}

--- a/src/func_0204488c.c
+++ b/src/func_0204488c.c
@@ -1,0 +1,114 @@
+typedef int Fix12i;
+struct Vector3 { Fix12i x, y, z; };
+struct Matrix3x3_Vecs { struct Vector3 v0, v1, v2; };
+
+struct Part {
+    int count;
+    unsigned char* cmd;
+    int f8;
+    int fc;
+};
+struct Entry {
+    int count;
+    struct Part* parts;
+};
+
+extern void Geometry_MatrixMultiply3x3(void* m);
+extern void func_020458a8(struct Matrix3x3_Vecs* dst, struct Matrix3x3_Vecs* src);
+extern void func_020553a4(void* m);
+extern void func_02055388(void* m);
+extern void MulMat3x3Mat3x3(void* a, void* b, void* c);
+extern void func_02052514(void* dst, void* src);
+extern void func_02055998(int* m);
+extern void func_01ffde98(int a, int b, int c);
+
+extern void* data_020a4bd0;
+extern int data_020a4bd4;
+extern unsigned char data_020a4bbc;
+extern short data_020a4bc0;
+extern short data_020a4bc4;
+
+void func_0204488c(char* self, int index, int* color)
+{
+    int M[9];
+    int N[16];
+    int i;
+    struct Part* part;
+    struct Entry* e;
+    int j;
+    int fp_index;
+    unsigned char* cmd;
+    void* partMtx;
+    void* lastMat;
+    volatile int* mtxScale;
+
+    e = &(*(struct Entry**)(*(char**)self + 0x10))[index];
+    part = e->parts;
+
+    mtxScale = (volatile int*)0x400046c;
+
+    for (i = 0; i < e->count; i++, part++) {
+        cmd = part->cmd;
+        for (j = 0; j < part->count; j++, cmd++) {
+            unsigned char b = *cmd;
+            int check;
+            if (b == 0xff)
+                continue;
+
+            fp_index = (*(unsigned short**)(*(char**)self + 0x2c))[b];
+            partMtx = (char*)*(void**)(self + 0xc) + fp_index * 0x30;
+
+            *(volatile int*)0x4000440 = 2;
+            *(volatile int*)0x4000454 = 0;
+            Geometry_MatrixMultiply3x3(data_020a4bd0);
+
+            check = *(unsigned short*)((char*)*(void**)(self + 8) + fp_index * 0x34 + 0x18);
+            if (check) {
+                func_020458a8((struct Matrix3x3_Vecs*)partMtx, (struct Matrix3x3_Vecs*)M);
+                Geometry_MatrixMultiply3x3(M);
+                lastMat = M;
+            } else {
+                Geometry_MatrixMultiply3x3(partMtx);
+                lastMat = partMtx;
+            }
+
+            *(volatile int*)0x4000440 = 1;
+            func_020553a4(data_020a4bd0);
+            if (color) {
+                int c2 = color[2];
+                int c1 = color[1];
+                int c0 = color[0];
+                *mtxScale = c0;
+                *mtxScale = c1;
+                *mtxScale = c2;
+            }
+            func_02055388(partMtx);
+            {
+                int white = data_020a4bd4;
+                *mtxScale = white;
+                *mtxScale = white;
+                *mtxScale = white;
+            }
+            *(volatile int*)0x400044c = j;
+        }
+
+        if (data_020a4bbc == 2) {
+            int sx;
+            int sy;
+            MulMat3x3Mat3x3(lastMat, data_020a4bd0, M);
+            func_02052514(M, N);
+            sx = data_020a4bc0;
+            N[0] = M[0] * sx;
+            N[4] = M[3] * sx;
+            N[8] = M[6] * sx;
+            sy = data_020a4bc4;
+            N[1] = M[1] * sy;
+            N[5] = M[4] * sy;
+            N[9] = M[7] * sy;
+            func_02055998(N);
+            *(volatile int*)0x400044c = 0;
+        }
+
+        func_01ffde98(3, part->fc, part->f8);
+    }
+}

--- a/src/func_ov002_020b01c0.cpp
+++ b/src/func_ov002_020b01c0.cpp
@@ -1,0 +1,102 @@
+//cpp
+typedef int Fix12;
+typedef struct { int w[2]; } SharedFilePtr;
+typedef struct { short x, y, z; } Vector3_16;
+typedef struct BMD_File BMD_File;
+typedef struct Actor Actor;
+
+struct ModelCache { int pad0; BMD_File* file; };
+
+extern ModelCache data_ov002_0210d9b8;
+extern SharedFilePtr data_ov002_0210d9d8;
+extern SharedFilePtr data_ov002_0210da30;
+extern unsigned char data_ov002_020ff040[];
+extern unsigned char data_ov002_020ff050[];
+extern signed char data_0209f2f8;
+extern unsigned char data_0209f220;
+
+extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, int b);
+extern "C" int _ZN11ShadowModel12InitCylinderEv(void* self);
+extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Fix12 q);
+extern "C" void _ZN12WithMeshClsn13SetLimMovFlagEv(void* self);
+extern "C" int IsStarCollectedInCurLevel(int a);
+extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* self);
+
+extern "C" int func_ov002_020b01c0(char* c)
+{
+    BMD_File* f;
+    int isKind0, isKind115;
+
+    *(int*)(c + 0x384) = *(int*)(c + 8) & 0xf;
+
+    isKind0 = (*(unsigned short*)(c + 0xc) == 0x114);
+    if (isKind0) {
+        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
+                return 0;
+        } else {
+            f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9d8);
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, f, 1, 1) == 0)
+                return 0;
+        }
+    } else {
+        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
+                return 0;
+        } else {
+            f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da30);
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, f, 1, 1) == 0)
+                return 0;
+        }
+    }
+
+    if (_ZN11ShadowModel12InitCylinderEv(c + 0x350) == 0)
+        return 0;
+
+    if (*(int*)(c + 0x384) == 6 || *(int*)(c + 0x384) == 8 || (unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x64000, 0x40000, 0x100002, 0);
+        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
+            *(int*)((long long)(c + 0x12c) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+        }
+    } else {
+        isKind115 = (*(unsigned short*)(c + 0xc) == 0x115);
+        if (isKind115) {
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x41000, 0x41000, 0x100002, 0);
+        } else {
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x32000, 0x32000, 0x100002, 0);
+        }
+    }
+
+    *(int*)(c + 0x388) = 0;
+    if (data_ov002_020ff040[*(int*)(c + 0x384)] == 0) {
+        *(int*)((long long)(c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    }
+    if (data_ov002_020ff050[*(int*)(c + 0x384)] == 0) {
+        *(int*)((long long)(c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    }
+    if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
+        *(unsigned char*)(c + 0x38e) = 1;
+    } else {
+        *(unsigned char*)(c + 0x38e) = 0;
+    }
+    *(unsigned char*)(c + 0x38f) = 1;
+    *(int*)(c + 0x390) = ((unsigned int)*(int*)(c + 8) >> 4) & 0xf;
+    *(int*)(c + 0x378) = *(int*)(c + 0x5c);
+    *(int*)(c + 0x37c) = *(int*)(c + 0x60);
+    *(int*)(c + 0x380) = *(int*)(c + 0x64);
+    *(int*)(c + 0x9c) = -0x2000;
+    *(int*)(c + 0xa0) = -0x32000;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x144, (Actor*)c, 0x32000, 0x32000, 0, 0);
+    _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x144);
+    *(int*)(c + 0x394) = 0;
+
+    if (data_0209f2f8 == 7 && *(int*)(c + 0x60) == 0xdac000 && *(int*)(c + 0x64) == 0
+        && (data_0209f220 == 1 || IsStarCollectedInCurLevel(1) == 0)) {
+        _ZN9ActorBase18MarkForDestructionEv(c);
+        return 0;
+    }
+
+    return 1;
+}

--- a/src/func_ov002_020e444c.c
+++ b/src/func_ov002_020e444c.c
@@ -1,0 +1,104 @@
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int Fix12i;
+
+struct Mtx43 { int w[12]; };
+
+extern int func_ov002_020e3f90(void);
+extern void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
+extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
+extern void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx43 *mF, s16 angY);
+extern void Matrix4x3_ApplyInPlaceToRotationX(struct Mtx43 *mF, s16 angX);
+extern void Matrix4x3_ApplyInPlaceToRotationZ(struct Mtx43 *mF, s16 angZ);
+extern int _ZNK6Player14GetBodyModelIDEjb(void *self, u32 unk, int b);
+extern int func_ov002_020becf4(void *self, u32 v, int arg2);
+extern int func_ov002_020d225c(void *o);
+extern void Matrix4x3_ApplyInPlaceToTranslation(struct Mtx43 *mF, Fix12i x, Fix12i y, Fix12i z);
+extern void func_ov002_020e4374(void *c, int *p1, int *p2);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
+extern int _ZNK10ClsnResult9GetClsnIDEv(void *self);
+extern void *_ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *self, void *sm, void *mtx, Fix12i a, Fix12i b, u32 flags);
+
+extern struct Mtx43 data_020a0e68;
+
+void func_ov002_020e444c(char *c)
+{
+    int sp8, spC;
+    int b;
+
+    if (func_ov002_020e3f90() == 0) {
+        int y = *(int *)(c + 0x690) + (*(int *)(c + 0x60) - *(int *)(c + 0x68c)) + 0xf000;
+        if (*(u8 *)(c + 0x6fd) != 0)
+            y -= 0x70000;
+        Matrix4x3_FromTranslation(&data_020a0e68, *(int *)(c + 0x5c) >> 3, y >> 3, *(int *)(c + 0x64) >> 3);
+        *(struct Mtx43 *)(c + 0x5bc) = data_020a0e68;
+
+        {
+            int out[3];
+            int src[3];
+            int v694 = *(int *)(c + 0x694);
+            src[1] = *(int *)(c + 0x690) - *(int *)(c + 0x68c);
+            src[2] = v694;
+            src[0] = 0;
+            Vec3_RotateYAndTranslate(out, (int *)(c + 0x5c), *(s16 *)(c + 0x8e), src);
+            Matrix4x3_FromTranslation(&data_020a0e68, out[0] >> 3, out[1] >> 3, out[2] >> 3);
+        }
+
+        Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(s16 *)(c + 0x8e));
+        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16 *)(c + 0x8c));
+        Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(s16 *)(c + 0x90));
+
+        if (*(u8 *)(c + 0x6fd) == 0) {
+            int bodyID = _ZNK6Player14GetBodyModelIDEjb(c, *(u32 *)(c + 8) & 0xff, 0);
+            char *p = *(char **)(c + bodyID * 4 + 0xdc);
+            *(struct Mtx43 *)(p + 0x1c) = data_020a0e68;
+            *(struct Mtx43 *)(c + 0x190) = data_020a0e68;
+        } else {
+            *(struct Mtx43 *)(c + 0x10c) = data_020a0e68;
+        }
+
+        {
+            int r0 = func_ov002_020becf4(c, *(u32 *)(c + 8) & 0xff, 0);
+            if (r0 != 9 && r0 != 8) {
+                char *q = *(char **)(c + r0 * 4 + 0x154);
+                if (q != 0) {
+                    *(struct Mtx43 *)(q + 0x1c) = data_020a0e68;
+                }
+            }
+        }
+
+        if (func_ov002_020d225c(c) != 0) {
+            int z = (int)(((long long)(*(int *)(c + 0x574)) * 0x2400 + 0x800) >> 12) + 0xc000;
+            Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, 0x7000, z);
+            char *p = *(char **)(c + 0x1d8);
+            *(struct Mtx43 *)(p + 0x1c) = data_020a0e68;
+        }
+    }
+
+    func_ov002_020e4374(c, &sp8, &spC);
+
+    if ((*(u8 *)(c + 0x6f5) | *(u8 *)(c + 0x6fb)) == 0)
+        *(u8 *)(c + 0x717) = 1;
+
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380) != 0) {
+        void *fr = _ZNK12WithMeshClsn14GetFloorResultEv(c + 0x380);
+        if (_ZNK10ClsnResult9GetClsnIDEv(fr) != -1) {
+            void *a = _ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(fr));
+            if (a != 0) {
+                b = (int)(*(u16 *)((char *)a + 0xc) == 0xa1);
+                if (b != 0) {
+                    sp8 += 0x3c000;
+                }
+            }
+        }
+    }
+
+    if (*(u8 *)(c + 0x717) != 0)
+        return;
+
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0x2ac, c + 0x5bc, spC, sp8, 0xf);
+}

--- a/src/func_ov006_020c97bc.cpp
+++ b/src/func_ov006_020c97bc.cpp
@@ -1,0 +1,128 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern "C" {
+void func_ov006_020ca2ec(void *c);
+void func_ov006_020bfec0(void *a0, void *a1, short *a2);
+int _Z14ApproachLinearRiii(int *v, int step, int rate);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fix, unsigned int flags);
+void func_ov006_020e6df0(int a0, int a1, int a2);
+int _Z14ApproachLinearRsss(short *v, short step, short rate);
+}
+
+extern void *data_ov006_02141a40;
+extern int data_ov006_02140574;
+extern int data_ov006_021405a8;
+extern void *data_ov006_0213b22c[];
+extern int data_ov006_021405b4;
+
+struct VtObj {
+    virtual void d0();
+    virtual void d1();
+    virtual void d2();
+    virtual void d3();
+    virtual void m4();
+};
+
+extern "C" void func_ov006_020c97bc(char *c)
+{
+    int v24;
+
+    if (*(int *)(c + 0x40) <= 0) {
+        func_ov006_020ca2ec(c);
+        return;
+    }
+
+    func_ov006_020bfec0(data_ov006_02141a40, (void *)(c + 0x24), (short *)(c + 0x56));
+
+    v24 = *(int *)(c + 0x24);
+
+    if (v24 >= -0x68000) goto L5c;
+    if (*(int *)(c + 0x3c) < 0) goto L70;
+
+L5c:
+    if (v24 <= 0x68000) goto L230;
+    if (*(int *)(c + 0x3c) <= 0) goto L230;
+
+L70:
+    {
+        int v = v24;
+        if (v < -0x90000) v = -0x90000;
+        else if (v > 0x90000) v = 0x90000;
+        *(int *)(c + 0x24) = v;
+    }
+
+    if (*(s16 *)(c + 0x22) != 0) goto L1a4;
+    if (_Z14ApproachLinearRiii((int *)(c + 0x64), 5, 1) != 0) goto L1a4;
+    {
+        int t = (int)(((long long)(-*(int *)(c + 0x3c)) * 0x1200 + 0x800) >> 12);
+        int v40;
+
+        if (t < -0x1400) t = -0x1400;
+        else if (t > 0x1400) t = 0x1400;
+        *(int *)(c + 0x3c) = t;
+
+        *(int *)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFF) +=
+            (int)(((long long)data_ov006_02140574 * 0x400 + 0x800) >> 12);
+
+        v40 = data_ov006_021405a8;
+        if (*(int *)(c + 0x40) <= v40) v40 = *(int *)(c + 0x40);
+        *(int *)(c + 0x40) = v40;
+
+        *(int *)(c + 0x60) = 2;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void *)(c + 0x78),
+            *(void **)data_ov006_0213b22c[*(int *)(c + 0x60)], 0x40000000, 0x800, 0);
+
+        *(int *)(c + 0xd0) = 0;
+        func_ov006_020e6df0(0, *(int *)(c + 0x60), *(int *)(c + 0x24));
+    }
+    goto L260;
+
+L1a4:
+    {
+        int t = (int)(((long long)(-*(int *)(c + 0x3c)) * 0xf00 + 0x800) >> 12);
+        int pos;
+        int hi;
+        int lo;
+        int v40;
+
+        *(int *)(c + 0x3c) = t;
+
+        pos = *(int *)(c + 0x24);
+        if (pos < -0x68000) pos = -0x68000;
+        else if (pos > 0x68000) pos = 0x68000;
+        *(int *)(c + 0x24) = pos;
+
+        hi = data_ov006_021405a8;
+        lo = data_ov006_021405b4;
+        v40 = *(int *)(c + 0x40);
+        if (v40 < lo) {
+            v40 = lo;
+        } else {
+            if (v40 <= hi) hi = v40;
+            v40 = hi;
+        }
+        *(int *)(c + 0x40) = v40;
+    }
+    goto L260;
+
+L230:
+    if (*(u16 *)(c + 0x18) == 3) {
+        ((VtObj *)c)->m4();
+        *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF) *= -1;
+    }
+
+L260:
+    {
+        int v = *(int *)(c + 0x3c);
+        if (v > 0x2000) {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), 0x2000, 0xc00);
+        } else if (v < -0x2000) {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), -0x2000, 0xc00);
+        } else {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), (short)v, 0xc00);
+        }
+    }
+}

--- a/src/func_ov006_020e9e70.cpp
+++ b/src/func_ov006_020e9e70.cpp
@@ -1,0 +1,129 @@
+//cpp
+extern "C" {
+int _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
+void InitialiseVramGlobals(void);
+void func_ov004_020b04d0(int v);
+void func_ov006_020c0134(void* self);
+int func_020179b4(void* r0, void* r1, int r2);
+void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* bmd, void* bta);
+void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* self, void* bta, int a, int b, unsigned int d);
+int func_ov006_020e7fe8(char* c);
+int LoadFile(int handle);
+unsigned func_02054de8(void);
+void DecompressLZ16(int src, void* dst);
+void Deallocate(void* p);
+void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
+void func_02056374(const void* src, unsigned int offset, unsigned int count);
+void _ZN3GXS11LoadOBJPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
+void func_ov006_020e8aac(char* c);
+void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
+
+extern unsigned char data_0209d45c;
+extern unsigned char data_0209d454;
+extern void* data_ov006_02141e9c;
+extern void* data_ov006_0213c844;
+extern void* data_ov006_02141e74;
+extern int data_ov004_020bc880;
+extern int data_ov004_020bc884;
+}
+
+struct M48 { int w[12]; };
+extern volatile M48 data_ov006_0213c88c;
+
+struct Obj {
+    virtual void v00(); virtual void v04(); virtual void v08(); virtual void v0c();
+    virtual void v10(); virtual void v14(); virtual void v18(); virtual void v1c();
+    virtual void v20(); virtual void v24(); virtual void v28(); virtual void v2c();
+    virtual void v30(); virtual void v34(); virtual void v38(); virtual void v3c();
+    virtual void v40(); virtual void v44();
+    virtual void v48(int arg);
+};
+
+extern "C" int func_ov006_020e9e70(void* arg0)
+{
+    char* c = (char*)arg0;
+    M48 tmp;
+    int zero;
+    int f;
+    int r5v;
+    int r4v;
+
+    data_0209d45c = 0x11;
+    data_0209d454 = 0x10;
+    _ZN3G3X6SetFogEbiii(0, 0, 2, 0x1000);
+    InitialiseVramGlobals();
+
+    *(volatile unsigned short*)0x4000008 = (*(volatile unsigned short*)0x4000008 & ~3) | 1;
+    func_ov004_020b04d0(0x10);
+
+    *(int*)(c + 0x4000 + 0x700) = 0;
+    *(int*)(c + 0x4000 + 0x704) = 0xd0000;
+    *(int*)(c + 0x4000 + 0x708) = 0x40000;
+    *(int*)(c + 0x4000 + 0x70c) = 0xffed3000;
+    *(int*)(c + 0x4000 + 0x710) = 0xe0000;
+    *(int*)(c + 0x4000 + 0x714) = 0x40000;
+    *(volatile unsigned short*)(c + 0x4700 + 0x18) = 0xc00;
+    func_ov006_020c0134((void*)(c + 0x4660));
+
+    if (func_020179b4(&data_ov006_02141e9c, (void*)(c + 0x4f38), 1) == 0) return 0;
+
+    _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*((void**)&data_ov006_02141e9c + 1), &data_ov006_0213c844);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x51f4, &data_ov006_0213c844, 0, 0x1000, 0);
+
+    if (func_ov006_020e7fe8((char*)(c + 0x4fd8)) == 0) return 0;
+
+    if (func_020179b4(&data_ov006_02141e74, (void*)(c + 0x4f88), 1) == 0) return 0;
+
+    tmp = (M48&)data_ov006_0213c88c;
+    *(M48*)(c + 0x4f54) = (M48&)data_ov006_0213c88c;
+    *(M48*)(c + 0x4fa4) = tmp;
+
+    data_0209d454 |= 4;
+    *(volatile unsigned short*)0x400100c &= ~3;
+    *(volatile unsigned short*)0x400100c &= ~0x40;
+    zero = 0;
+    *(volatile unsigned int*)0x4001018 = zero;
+    *(volatile unsigned short*)0x400100c = (*(volatile unsigned short*)0x400100c & 0x43) | 0x210;
+
+    f = LoadFile(0x12);
+    DecompressLZ16(f, (void*)(func_02054de8() + 0x4000));
+    Deallocate((void*)f);
+
+    f = LoadFile(0x13);
+    _ZN3GXS10LoadBGPlttEPKvjj((const void*)f, 0x1e0, 0x20);
+    Deallocate((void*)f);
+
+    f = LoadFile(0x14);
+    func_02056374((const void*)f, zero, 0x800);
+    Deallocate((void*)f);
+
+    r5v = LoadFile(8);
+    r4v = LoadFile(9);
+    DecompressLZ16(r5v, (void*)0x6600000);
+    _ZN3GXS11LoadOBJPlttEPKvjj((const void*)r4v, zero, 0x100);
+    Deallocate((void*)r5v);
+    Deallocate((void*)r4v);
+
+    func_ov004_020b04d0(0x20);
+
+    ((Obj*)c)->v48(-1);
+
+    *(unsigned short*)(c + 0x5500 + 0x48) = 0x40;
+
+    *(int*)(c + 0xa8) = 3;
+    *(int*)(c + 0xac) = *(int*)(c + 0xa8);
+    *(int*)(c + 0x5000 + 0x53c) = 1;
+
+    func_ov006_020e8aac(c);
+
+    *(int*)(c + 0xa4) = 1;
+
+    func_ov004_020b0cac(0xd, 0x80, 0xa8, 1, -1, 0xd);
+
+    data_ov004_020bc880 = 0x80;
+    data_ov004_020bc884 = ~0x3f;
+
+    *(int*)(c + 0xb4) = zero;
+
+    return 1;
+}

--- a/src/func_ov006_0210bdb0.cpp
+++ b/src/func_ov006_0210bdb0.cpp
@@ -1,0 +1,154 @@
+//cpp
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern "C" {
+
+extern int func_02054d88(void);
+extern u32 LoadCompressedFileAt(u16 fileID, void *target);
+extern int LoadFile(int handle);
+extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void Deallocate(void *ptr);
+extern void *_ZN2G212GetBG1ScrPtrEv(void);
+extern void *_ZN2G212GetBG2ScrPtrEv(void);
+extern void func_02056314(void *dst, u32 offset, u32 len);
+extern void *func_02054de8(void);
+extern void *_ZN3G2S12GetBG2ScrPtrEv(void);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *p, u16 a, u16 b, u16 c, u16 d);
+extern void func_ov006_020c2154(char *c);
+extern void func_ov006_020c1eb4(char *c);
+extern int RandomIntInternal(int *seed);
+extern void func_ov004_020b04d0(int v);
+
+extern u8 data_0209d45c;
+extern u8 data_0209d454;
+extern int data_0209e650;
+extern int data_0208ee44;
+extern int func_020bc88c;
+extern int func_020bc878;
+extern int func_020bc8b8;
+extern int func_020bc888;
+extern int func_020bc860;
+extern int func_020bc890;
+extern int func_020bc8b4;
+extern int func_020bc864;
+
+}
+
+struct Obj {
+    virtual void m00();
+    virtual void m04();
+    virtual void m08();
+    virtual void m0c();
+    virtual void m10();
+    virtual void m14();
+    virtual void m18();
+    virtual void m1c();
+    virtual void m20();
+    virtual void m24();
+    virtual void m28();
+    virtual void m2c();
+    virtual void m30();
+    virtual void m34();
+    virtual void m38();
+    virtual void m3c();
+    virtual void m40();
+    virtual void m44();
+    virtual void m48(int a);
+};
+
+extern "C" int func_ov006_0210bdb0(void *arg0)
+{
+    char *c = (char *)arg0;
+
+    *(volatile u16 *)0x400000a = (*(volatile u16 *)0x400000a & 0x43) | 0x1118;
+    *(volatile u16 *)0x400000a = *(volatile u16 *)0x400000a & ~0x40;
+    *(volatile u16 *)0x400000c = (*(volatile u16 *)0x400000c & 0x43) | 0x1218;
+    *(volatile u16 *)0x400000c = *(volatile u16 *)0x400000c & ~0x40;
+    *(volatile u16 *)0x400000e = (*(volatile u16 *)0x400000e & 0x43) | 0x1418;
+    *(volatile u16 *)0x400000e = *(volatile u16 *)0x400000e & ~0x40;
+
+    *(volatile u16 *)0x4000008 = *(volatile u16 *)0x4000008 & ~3;
+    *(volatile u16 *)0x400000a = *(volatile u16 *)0x400000a & ~3;
+    *(volatile u16 *)0x400000c = (*(volatile u16 *)0x400000c & ~3) | 1;
+    *(volatile u16 *)0x400000e = (*(volatile u16 *)0x400000e & ~3) | 3;
+
+    LoadCompressedFileAt(0x77, (void *)func_02054d88());
+
+    {
+        int h = LoadFile(0x78);
+        _ZN2GX10LoadBGPlttEPKvjj((const void *)h, 0x60, 0x1a0);
+        _ZN3GXS10LoadBGPlttEPKvjj((const void *)h, 0x60, 0x1a0);
+        Deallocate((void *)h);
+    }
+
+    LoadCompressedFileAt(0x75, _ZN2G212GetBG1ScrPtrEv());
+    LoadCompressedFileAt(0x7a, _ZN2G212GetBG2ScrPtrEv());
+
+    {
+        int h = LoadFile(0x79);
+        func_02056314((void *)h, 0, 0x800);
+        Deallocate((void *)h);
+    }
+
+    LoadCompressedFileAt(0xeb, (void *)0x6400000);
+
+    data_0209d45c = 0x1f;
+    *(volatile u16 *)0x400100c = (*(volatile u16 *)0x400100c & ~3) | 3;
+    *(volatile u16 *)0x400100c = (*(volatile u16 *)0x400100c & 0x43) | 0x1218;
+    *(volatile u16 *)0x400100c = *(volatile u16 *)0x400100c & ~0x40;
+
+    LoadCompressedFileAt(0x77, func_02054de8());
+    LoadCompressedFileAt(0x76, _ZN3G2S12GetBG2ScrPtrEv());
+    LoadCompressedFileAt(0xeb, (void *)0x6600000);
+
+    {
+        int h = LoadFile(0xec);
+        _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)h, 0xe0);
+        _ZN2GX11LoadOBJPlttEPKvjj((const void *)h, 0, 0xe0);
+        _ZN3GXS11LoadOBJPlttEPKvjj((const void *)h, 0, 0xe0);
+        Deallocate((void *)h);
+    }
+
+    data_0209d454 = 0x14;
+    _ZN3G2x13SetBlendAlphaEPVttttt((volatile u16 *)0x4000050, 0, 0xc, 0xc, 4);
+
+    func_ov006_020c2154(c + 0x4f38);
+    func_ov006_020c1eb4(c + 0x4660);
+
+    *(int *)(c + 0x5004) = *(int *)(c + 0xbc);
+
+    ((struct Obj *)c)->m48(3);
+
+    *(u8 *)(c + 0x5000 + 0x3b) = *(u8 *)(c + 0x5000 + 0x3c);
+    *(int *)(c + 0x5000 + 0xc) = 0;
+
+    for (int i = 0; i < 3; i++) {
+        int rnd = RandomIntInternal(&data_0209e650);
+        u32 divisor = *(u8 *)(c + 0x5000 + 0x3a);
+        u32 val = ((u32)rnd >> 16) % divisor;
+        ((u32 *)(c + 0x4fe4))[i] = val * 0x50000;
+    }
+
+    func_020bc88c = 0x80;
+    func_020bc860 = 0xa0;
+    func_020bc878 = 0x80;
+    func_020bc890 = 0xa0;
+    func_020bc8b8 = 0x80;
+    func_020bc8b4 = 0x60;
+    func_020bc888 = 0x80;
+    func_020bc864 = ~0x1b;
+
+    func_ov004_020b04d0(0x20);
+
+    data_0208ee44 = 1;
+
+    *(u16 *)(c + 0x5018) = 0;
+    *(u16 *)(c + 0x501a) = 0;
+    return 1;
+}

--- a/src/func_ov006_02129268.c
+++ b/src/func_ov006_02129268.c
@@ -1,0 +1,109 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef volatile unsigned int vu32;
+typedef volatile unsigned short vu16;
+
+extern void *_ZN2G213GetBG2CharPtrEv(void);
+extern unsigned func_02054de8(void);
+extern void *func_02054fb0(void);
+extern void *_ZN3G2S12GetBG3ScrPtrEv(void);
+extern u32 LoadCompressedFileAt(u16 fileID, void *target);
+
+extern void *func_020adc74(void *p);
+extern void func_ov004_020adc5c(void *p);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(void *p, u32 sz);
+extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void DecompressLZ16(void *src, void *dst);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3G3X6SetFogEbiii(int enable, int a, int b, int c);
+extern void InitialiseVramGlobals(void);
+extern void _ZN5Model17UpdateFileOffsetsER8BMD_File(void *file);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisPtr, void *file, int a, int b);
+extern void func_ov006_021279b0(void *p);
+extern void func_ov006_02126ee4(void *p);
+extern void func_ov006_02126a98(void *p);
+
+extern int data_0208ee44;
+extern u8 data_0209d45c;
+extern u8 data_0209d454;
+extern char data_ov006_0214009c;
+extern char data_ov006_021400bc;
+extern char data_ov006_021400dc;
+extern char data_ov006_021400fc;
+
+int func_ov006_02129268(void *arg0)
+{
+    u8 *r4 = (u8 *)arg0;
+    void *buf;
+
+    data_0208ee44 = 1;
+    *(vu16 *)0x4000304 &= ~0x8000;
+    *(r4 + 0xb9f8) = 1;
+
+    *(vu16 *)0x400000c = (*(vu16 *)0x400000c & 0x43) | 0x5214;
+    *(vu16 *)0x400000c &= ~0x40;
+    *(vu32 *)0x4000018 = 0;
+    *(vu16 *)0x400000c = (*(vu16 *)0x400000c & ~3) | 2;
+
+    *(vu16 *)0x400100c = (*(vu16 *)0x400100c & 0x43) | 0x5214;
+    *(vu16 *)0x400100c &= ~0x40;
+    *(vu32 *)0x4001018 = 0;
+    *(vu16 *)0x400100c = (*(vu16 *)0x400100c & ~3) | 2;
+
+    *(vu16 *)0x400000e = (*(vu16 *)0x400000e & 0x43) | 0x1614;
+    *(vu16 *)0x400000e &= ~0x40;
+    *(vu32 *)0x400001c = 0;
+    *(vu16 *)0x400000e = (*(vu16 *)0x400000e & ~3) | 3;
+
+    *(vu16 *)0x400100e = (*(vu16 *)0x400100e & 0x43) | 0x1614;
+    *(vu16 *)0x400100e &= ~0x40;
+    *(vu32 *)0x400101c = 0;
+    *(vu16 *)0x400100e = (*(vu16 *)0x400100e & ~3) | 3;
+
+    LoadCompressedFileAt(0xad, (u8 *)_ZN2G213GetBG2CharPtrEv() + 0x4000);
+    LoadCompressedFileAt(0xad, (void *)(func_02054de8() + 0x4000));
+    LoadCompressedFileAt(0xac, func_02054fb0());
+    LoadCompressedFileAt(0xac, _ZN3G2S12GetBG3ScrPtrEv());
+
+    data_0209d45c |= 0xc;
+    data_0209d454 |= 0xc;
+
+    buf = func_020adc74(&data_ov006_0214009c);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(buf, 0x100);
+    _ZN2GX10LoadBGPlttEPKvjj(buf, 0x100, 0x100);
+    _ZN3GXS10LoadBGPlttEPKvjj(buf, 0x100, 0x100);
+    func_ov004_020adc5c(buf);
+
+    buf = func_020adc74(&data_ov006_021400bc);
+    DecompressLZ16(buf, (void *)0x6400000);
+    DecompressLZ16(buf, (void *)0x6600000);
+    func_ov004_020adc5c(buf);
+
+    buf = func_020adc74(&data_ov006_021400dc);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(buf, 0x100);
+    _ZN2GX11LoadOBJPlttEPKvjj(buf, 0, 0x100);
+    _ZN3GXS11LoadOBJPlttEPKvjj(buf, 0, 0x100);
+    func_ov004_020adc5c(buf);
+
+    *(vu16 *)0x4000008 = (*(vu16 *)0x4000008 & ~3) | 1;
+    _ZN3G3X6SetFogEbiii(0, 0, 2, 0x1000);
+    *(vu16 *)0x4000060 = (*(vu16 *)0x4000060 & ~0x3000) | 8;
+    InitialiseVramGlobals();
+
+    *(void **)(r4 + 0xabf4) = func_020adc74(&data_ov006_021400fc);
+    _ZN5Model17UpdateFileOffsetsER8BMD_File(*(void **)(r4 + 0xabf4));
+
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(r4 + 0xaba4, *(void **)(r4 + 0xabf4), 1, -1) == 0)
+        return 0;
+
+    *(vu16 *)0x4000008 = (*(vu16 *)0x4000008 & ~3) | 1;
+    data_0209d45c |= 1;
+
+    func_ov006_021279b0(arg0);
+    func_ov006_02126ee4(arg0);
+    func_ov006_02126a98(arg0);
+    return 1;
+}

--- a/src/func_ov006_0212b480.c
+++ b/src/func_ov006_0212b480.c
@@ -1,0 +1,124 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern int func_ov004_020ad8b8(void);
+extern void *func_020adc74(void *arg);
+extern char *_ZN2G213GetBG2CharPtrEv(void);
+extern void DecompressLZ16(int src, void *dst);
+extern void func_ov004_020adc5c(int handle);
+extern void *func_02054de8(void);
+extern char *_ZN2G212GetBG2ScrPtrEv(void);
+extern char *_ZN3G2S12GetBG2ScrPtrEv(void);
+extern char *_ZN3G2S12GetBG3ScrPtrEv(void);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
+extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *p, u16 a, u16 b, u16 c, u16 d);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void func_ov006_0212a764(void *arg);
+extern void func_ov006_020c3d88(char *c);
+extern void func_ov006_020c3b2c(void *arg);
+
+extern int data_0208ee44;
+extern u8 data_0209d45c;
+extern u8 data_0209d454;
+extern int data_ov006_021401d0;
+extern int data_ov006_021401f4;
+extern int data_ov006_02140218;
+extern int data_ov006_0214023c;
+extern int data_ov006_02140260;
+extern int data_ov006_02140284;
+extern int data_ov006_021402a8;
+extern int data_ov006_021402c4;
+extern int func_020bc8a8;
+extern int func_020bc898;
+extern int func_020bc86c;
+extern int func_020bc8a4;
+
+int func_ov006_0212b480(void *arg0)
+{
+    char *c = (char *)arg0;
+    int h;
+
+    *(int *)(c + 0x5ff0) = func_ov004_020ad8b8();
+
+    data_0208ee44 = 1;
+
+    *(volatile u16 *)0x400000c = (*(volatile u16 *)0x400000c & 0x43) | 0x1414;
+    *(volatile u16 *)0x400000c &= ~0x40;
+    *(volatile u32 *)0x4000018 = 0;
+    *(volatile u16 *)0x400000c = (*(volatile u16 *)0x400000c & ~3) | 3;
+
+    *(volatile u16 *)0x400100c = (*(volatile u16 *)0x400100c & 0x43) | 0x1414;
+    *(volatile u16 *)0x400100c &= ~0x40;
+    *(volatile u32 *)0x4001018 = 0;
+    *(volatile u16 *)0x400100c = (*(volatile u16 *)0x400100c & ~3) | 3;
+
+    *(volatile u16 *)0x400100e = (*(volatile u16 *)0x400100e & 0x43) | 0x1414;
+    *(volatile u16 *)0x400100e &= ~0x40;
+    *(volatile u32 *)0x400101c = 0;
+    *(volatile u16 *)0x400100e = (*(volatile u16 *)0x400100e & ~3) | 3;
+
+    h = (int)func_020adc74(&data_ov006_021401d0);
+    DecompressLZ16(h, _ZN2G213GetBG2CharPtrEv());
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_021401f4);
+    DecompressLZ16(h, func_02054de8());
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_02140218);
+    DecompressLZ16(h, _ZN2G212GetBG2ScrPtrEv());
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_0214023c);
+    DecompressLZ16(h, _ZN3G2S12GetBG2ScrPtrEv());
+    DecompressLZ16(h, _ZN3G2S12GetBG3ScrPtrEv());
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_02140260);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(h, 0x1a0);
+    _ZN2GX10LoadBGPlttEPKvjj((const void *)h, 0x60, 0x1a0);
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_02140284);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(h, 0x1a0);
+    _ZN3GXS10LoadBGPlttEPKvjj((const void *)h, 0x60, 0x1a0);
+    func_ov004_020adc5c(h);
+
+    *(volatile u16 *)0x4000050 = 0;
+    _ZN3G2x13SetBlendAlphaEPVttttt((volatile u16 *)0x4001050, 4, 8, 6, 0xa);
+
+    data_0209d45c |= 4;
+    data_0209d454 |= 0xc;
+
+    h = (int)func_020adc74(&data_ov006_021402a8);
+    DecompressLZ16(h, (void *)0x6400000);
+    DecompressLZ16(h, (void *)0x6600000);
+    func_ov004_020adc5c(h);
+
+    h = (int)func_020adc74(&data_ov006_021402c4);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(h, 0x100);
+    _ZN2GX11LoadOBJPlttEPKvjj((const void *)h, 0, 0x100);
+    _ZN3GXS11LoadOBJPlttEPKvjj((const void *)h, 0, 0x100);
+    func_ov004_020adc5c(h);
+
+    func_020bc8a8 = 0x40;
+    func_020bc898 = 0xa0;
+    func_020bc86c = 0xc0;
+    func_020bc8a4 = 0xa0;
+
+    *(int *)(c + 0x5fdc) = 0;
+    *(int *)(c + 0x5fe0) = 0;
+    *(int *)(c + 0x5fe4) = 0;
+    func_ov006_0212a764(c);
+
+    data_0209d45c |= 1;
+    *(volatile u16 *)0x4000008 = (*(volatile u16 *)0x4000008 & ~3) | 1;
+    func_ov006_020c3d88(c + 0x51f8);
+    func_ov006_020c3b2c(c + 0x4660);
+
+    return 1;
+}

--- a/src/func_ov007_020b0da0.c
+++ b/src/func_ov007_020b0da0.c
@@ -1,0 +1,138 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+
+extern short data_02082214[];
+extern void* data_ov007_0210342c;
+extern int data_ov007_02103340;
+extern int data_ov007_02103344;
+
+extern void* func_ov007_020aebac(void);
+extern void func_ov007_020bdeb0(int a);
+extern int _ZN4cstd3modEii(int a, int b);
+extern int _ZN4cstd3divEii(int a, int b);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern void Matrix4x3_LoadIdentity(void* mat);
+extern void func_ov007_020c39f8(void* mat, int rx, int ry, int rz);
+
+struct V3 { int x, y, z; };
+
+#pragma opt_common_subs off
+void func_ov007_020b0da0(void* arg0) {
+    char* self = (char*)arg0;
+    char* obj = *(char**)(self + 4);
+    char* st = *(char**)((char*)data_ov007_0210342c + 8);
+    int counter = *(int*)(st + 0xc);
+    char* mat = *(char**)(*(char**)(obj + 0) + 0xc);
+    void* ret = func_ov007_020aebac();
+
+    if (counter == 1) {
+        *(int*)(obj + 0x94) = 1;
+        *(int*)(st + 4) = 1;
+        data_ov007_02103340 = 0;
+        data_ov007_02103344 = 0;
+        if (ret == 0) {
+            *(int*)(*(char**)((char*)data_ov007_0210342c + 0x100) + 0x18) = 0;
+        }
+    }
+
+    {
+        struct V3 out;
+        out.y = 0;
+        out.x = 0;
+        out.z = 0;
+
+        if (!(*(volatile int*)(st + 4) & 2) && counter >= 4) {
+            char* rp = *(char**)((char*)data_ov007_0210342c + 0x50);
+            if (*(u16*)(rp + 0xc) != 0) {
+                int a = *(u16*)(rp + 8);
+                if (a >= 0x60 && a <= 0xa0) {
+                    int b = *(u16*)(rp + 0xa);
+                    if (b >= 0x40 && b <= 0x80) {
+                        int* pflag = (int*)(((long long)(int)(st + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+                        *pflag |= 2;
+                        data_ov007_02103340 = counter;
+                        func_ov007_020bdeb0(0x34);
+                        {
+                            char* t0 = *(char**)((char*)data_ov007_0210342c + 0xc4);
+                            char* t1 = *(char**)(t0 + 0);
+                            char* t2 = *(char**)(t1 + 4);
+                            *(short*)(t2 + 2) = 4;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (*(int*)(st + 4) & 1) {
+            int var_r4;
+            _ZN4cstd3modEii(counter, 0x28);
+            {
+                int m1 = _ZN4cstd3modEii(counter, 0x28);
+                if (m1 <= 0) {
+                    var_r4 = 0;
+                } else if (m1 >= 0x28) {
+                    var_r4 = 0x1000;
+                } else {
+                    var_r4 = _ZN4cstd3divEii(m1 << 12, 0x28);
+                }
+            }
+
+            {
+                int angle1 = (u16)((var_r4 * 0xffff) >> 12);
+                out.y = data_02082214[(angle1 >> 4) * 2] >> 2;
+            }
+
+            {
+                int var_r8;
+                int m2 = _ZN4cstd3modEii(counter, 0xa0);
+                if (m2 <= 0) {
+                    var_r8 = 0;
+                } else if (m2 >= 0xa0) {
+                    var_r8 = 0x1000;
+                } else {
+                    var_r8 = _ZN4cstd3divEii(m2 << 12, 0xa0);
+                }
+
+                Matrix4x3_LoadIdentity(mat);
+
+                {
+                    int angleA = (u16)(((var_r8 * 2 + 0x800) * 0xffff) >> 12);
+                    int valA = data_02082214[(angleA >> 4) * 2];
+                    int angleB = (u16)((var_r8 * 0xffff) >> 12);
+                    int valB = data_02082214[(angleB >> 4) * 2];
+
+                    int valBhalf = (valB + 0x2000) / 2;
+                    int term = (int)(((s64)valA * 0x82 + 0x800) >> 12);
+                    int combined = (int)(((s64)valBhalf * term + 0x800) >> 12);
+                    short rzS = (short)(0x3fff + ((combined * 0x7fff) >> 12));
+                    func_ov007_020c39f8(mat, 0, 0, (u16)rzS);
+                }
+
+                if ((*(int*)(st + 4) & 2) && (var_r4 == 0 || var_r4 == 0x800)) {
+                    *(int*)(*(char**)((char*)data_ov007_0210342c + 0x100) + 0x18) = 0;
+                }
+            }
+        }
+
+        if (*(int*)(st + 4) & 4) {
+            int diff = counter - data_ov007_02103344;
+            int ratio;
+            int sq;
+            if (diff <= 0) {
+                ratio = 0;
+            } else if (diff >= 0x50) {
+                ratio = 0x1000;
+            } else {
+                ratio = _ZN4cstd4fdivEii(diff, 0x50);
+            }
+            sq = (int)(((s64)ratio * ratio) >> 12);
+            out.y = sq * 30;
+            if (ratio >= 0x1000) {
+                *(int*)(*(char**)((char*)data_ov007_0210342c + 0x100) + 0x18) = 0;
+            }
+        }
+
+        *(struct V3*)(mat + 0x24) = out;
+    }
+}

--- a/src/func_ov007_020b5bf0.c
+++ b/src/func_ov007_020b5bf0.c
@@ -1,0 +1,161 @@
+typedef signed char s8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern short data_02082214[];
+extern u8 data_ov007_0210342c[];
+
+extern int _ZN4cstd3divEii(int, int);
+extern unsigned short func_ov007_020c3be0(int t, int a, int b);
+extern void func_ov007_020b5f64(void *a);
+extern void func_ov007_020c8f98(int a);
+
+void func_ov007_020b5bf0(char *arg0)
+{
+    char *r7 = *(char **)arg0;
+    int r6 = 0;
+    int r5 = r6;
+    int r4 = r6;
+
+    if (*(u16 *)(*(char **)(r7 + 0x24)) == 0) {
+        if (*(int *)(r7 + 0x18) > 0) {
+            int a = *(int *)(r7 + 0x18);
+            int diff = *(int *)(r7 + 0x1c) - a;
+            int sb;
+            if (diff <= 0) {
+                sb = r6;
+            } else if (diff >= *(int *)(r7 + 0x1c)) {
+                sb = 0x1000;
+            } else {
+                sb = _ZN4cstd3divEii(diff << 0xc, *(int *)(r7 + 0x1c));
+            }
+            {
+                int t1 = (sb * (*(int *)(r7 + 0x1c) * 0x48)) >> 0xc;
+                int r = _ZN4cstd3divEii(t1 << 0x10, 0x168);
+                int idx;
+                short tblval;
+                int inv;
+                u16 typeField;
+                int r2;
+                int mulfactor;
+                int result;
+
+                r = (u16)r;
+                idx = (r >> 4) * 2;
+                tblval = data_02082214[idx];
+                inv = 0x1000 - sb;
+                typeField = *(u16 *)r7;
+                r2 = (int)(((long long)tblval * inv + 0x800) >> 0xc);
+                mulfactor = (typeField == 0) ? 4 : 8;
+                result = (r2 * mulfactor) >> 0xc;
+                *(u16 *)(*(char **)(arg0 + 4) + 0x38) = _ZN4cstd3divEii(result << 0x10, 0x168);
+            }
+        } else {
+            *(u16 *)(*(char **)(arg0 + 4) + 0x38) = r6;
+        }
+    }
+
+    {
+        u16 switchVal = *(u16 *)(*(char **)(r7 + 0x24));
+        int var_r0_2;
+
+        switch (switchVal) {
+        case 0:
+        case 2:
+        case 6:
+            r5 = 1;
+            break;
+        case 4:
+        {
+            s16 v = *(s16 *)(*(char **)(*(char **)arg0 + 4));
+            if ((u32)(u16)(s16)(v - 3) <= 1u) {
+                r4 = 1;
+            } else {
+                r5 = 1;
+            }
+            break;
+        }
+        case 8:
+            r4 = 1;
+            break;
+        case 7:
+        {
+            u16 typeField = *(u16 *)r7;
+            char *obj = *(char **)(*(char **)(*(char **)data_ov007_0210342c + 0x28));
+            s16 v = *(s16 *)(*(char **)(r7 + 4));
+
+            if (v != 2) goto L_1bc;
+            if (typeField == 9) goto L_set;
+            if (typeField != 0xc) goto L_1a8;
+            if (*(u8 *)(obj + 9) != 0) goto L_set;
+        L_1a8:
+            if (typeField != 0xd) goto L_1bc;
+            if (*(u8 *)(obj + 9) == 0) goto L_set;
+        L_1bc:
+            if (typeField != 0xc) goto L_1d0;
+            if (*(u8 *)(obj + 9) == 0) goto L_set;
+        L_1d0:
+            if (typeField != 0xd) goto L_1f4;
+            if (*(u8 *)(obj + 9) == 0) goto L_1f4;
+        L_set:
+            {
+                char *m4 = *(char **)(arg0 + 4);
+                *(u16 *)(m4 + 0x70) = *(u16 *)(m4 + 0xc);
+            }
+            break;
+        L_1f4:
+            if (v == 2) break;
+            if (typeField == 9) goto L_zero;
+            if (typeField != 0xc) goto L_218;
+            if (*(u8 *)(obj + 9) != 0) goto L_zero;
+        L_218:
+            if (typeField != 0xd) break;
+            if (*(u8 *)(obj + 9) != 0) break;
+        L_zero:
+            *(u16 *)(*(char **)(arg0 + 4) + 0x70) = 0;
+            break;
+        }
+        case 3:
+        {
+            s16 v = *(s16 *)(*(char **)(*(char **)arg0 + 4));
+            if ((u32)(u16)(s16)(v - 3) <= 1u) {
+                r4 = 1;
+            } else {
+                r6 = 1;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+        var_r0_2 = (r4 != 0) ? (0x1000 - *(int *)(r7 + 0x14)) : *(int *)(r7 + 0x10);
+
+        if (r5 != 0 || r4 != 0) {
+            if (var_r0_2 >= 0x1000) {
+                *(int *)(*(char **)(arg0 + 4) + 0x50) = 0x1f000;
+            } else if (var_r0_2 <= 0) {
+                *(int *)(*(char **)(arg0 + 4) + 0x50) = 0;
+            } else {
+                *(int *)(*(char **)(arg0 + 4) + 0x50) = (int)(((long long)var_r0_2 * 0x1f000 + 0x800) >> 0xc);
+            }
+        }
+
+        if (r6 != 0) {
+            if (var_r0_2 >= 0x1000) {
+                *(u16 *)(*(char **)(arg0 + 4) + 0x44) = 0x7fff;
+            } else if (var_r0_2 <= 0) {
+                *(u16 *)(*(char **)(arg0 + 4) + 0x44) = 0x4210;
+            } else {
+                *(u16 *)(*(char **)(arg0 + 4) + 0x44) = func_ov007_020c3be0(var_r0_2, 0x4210, 0x7fff);
+            }
+        }
+    }
+
+    if ((u32)(u16)(*(u16 *)r7 + 0xfff2) <= 2u) {
+        func_ov007_020b5f64(arg0);
+    }
+    func_ov007_020c8f98(*(int *)(arg0 + 0x10));
+}

--- a/src/func_ov007_020b65e0.c
+++ b/src/func_ov007_020b65e0.c
@@ -1,0 +1,112 @@
+extern void func_ov007_020c937c(int a);
+extern void func_ov007_020c020c(void *a);
+extern void func_ov007_020c2410(int a);
+extern void func_ov007_020c2018(int a);
+extern void func_ov007_020c22f8(int a);
+extern void func_ov007_020c9080(int a);
+extern void _ZN6Player17St_EndingFly_MainEv(void *p);
+extern void func_ov007_020c1620(int a);
+extern void func_ov007_020b3edc(int a);
+extern void func_ov007_020c9460(int a);
+extern int func_ov007_020b4bd4(int *a);
+extern void func_ov007_020b6cd0(void);
+extern void func_ov007_020b283c(void);
+extern void func_ov007_020b9770(void);
+extern void func_ov007_020bf304(void);
+extern char *data_ov007_0210342c;
+
+#pragma opt_strength_reduction off
+#pragma opt_common_subs off
+void func_ov007_020b65e0(void)
+{
+    int i;
+
+    if (*(int *)(data_ov007_0210342c + 4) != 0) {
+        func_ov007_020c937c(*(int *)(data_ov007_0210342c + 4));
+        *(int *)(data_ov007_0210342c + 4) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 8) != 0) {
+        func_ov007_020c937c(*(int *)(data_ov007_0210342c + 8));
+        *(int *)(data_ov007_0210342c + 8) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0xc) != 0) {
+        func_ov007_020c937c(*(int *)(data_ov007_0210342c + 0xc));
+        *(int *)(data_ov007_0210342c + 0xc) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x30) != 0) {
+        func_ov007_020c020c((void *)*(int *)(data_ov007_0210342c + 0x30));
+        *(int *)(data_ov007_0210342c + 0x30) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x34) != 0) {
+        func_ov007_020c020c((void *)*(int *)(data_ov007_0210342c + 0x34));
+        *(int *)(data_ov007_0210342c + 0x34) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x38) != 0) {
+        func_ov007_020c2410(*(int *)(data_ov007_0210342c + 0x38));
+        *(int *)(data_ov007_0210342c + 0x38) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x3c) != 0) {
+        func_ov007_020c2410(*(int *)(data_ov007_0210342c + 0x3c));
+        *(int *)(data_ov007_0210342c + 0x3c) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x50) != 0) {
+        func_ov007_020c2018(*(int *)(data_ov007_0210342c + 0x50));
+        *(int *)(data_ov007_0210342c + 0x50) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x54) != 0) {
+        func_ov007_020c22f8(*(int *)(data_ov007_0210342c + 0x54));
+        *(int *)(data_ov007_0210342c + 0x54) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x6c) != 0) {
+        func_ov007_020c9080(*(int *)(data_ov007_0210342c + 0x6c));
+        *(int *)(data_ov007_0210342c + 0x6c) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x70) != 0) {
+        func_ov007_020c9080(*(int *)(data_ov007_0210342c + 0x70));
+        *(int *)(data_ov007_0210342c + 0x70) = 0;
+    }
+    if (*(int *)(data_ov007_0210342c + 0x28) != 0) {
+        _ZN6Player17St_EndingFly_MainEv((void *)*(int *)(data_ov007_0210342c + 0x28));
+        *(int *)(data_ov007_0210342c + 0x28) = 0;
+    }
+
+    for (i = 0; i < 0xb; i++) {
+        if (*(int *)(data_ov007_0210342c + i * 4 + 0x78) != 0) {
+            func_ov007_020c1620(*(int *)(data_ov007_0210342c + i * 4 + 0x78));
+            *(int *)(data_ov007_0210342c + i * 4 + 0x78) = 0;
+        }
+    }
+
+    func_ov007_020b3edc(0x16);
+
+    if (*(int *)(data_ov007_0210342c + 0x40) != 0) {
+        func_ov007_020c937c(*(int *)(data_ov007_0210342c + 0x40));
+        *(int *)(data_ov007_0210342c + 0x40) = 0;
+    }
+
+    for (i = 0; i < 3; i++) {
+        if (*(int *)(data_ov007_0210342c + i * 4 + 0x44) != 0) {
+            func_ov007_020c9460(*(int *)(data_ov007_0210342c + i * 4 + 0x44));
+            *(int *)(data_ov007_0210342c + i * 4 + 0x44) = 0;
+        }
+    }
+
+    for (i = 0; i < 0x18; i++) {
+        if (*(int *)(data_ov007_0210342c + i * 4 + 0x114) != 0) {
+            func_ov007_020b4bd4((int *)*(int *)(data_ov007_0210342c + i * 4 + 0x114));
+            *(int *)(data_ov007_0210342c + i * 4 + 0x114) = 0;
+        }
+    }
+
+    func_ov007_020b6cd0();
+    func_ov007_020b283c();
+    func_ov007_020b9770();
+    func_ov007_020bf304();
+
+    if (data_ov007_0210342c == 0) {
+        return;
+    }
+
+    _ZN6Player17St_EndingFly_MainEv((void *)data_ov007_0210342c);
+    data_ov007_0210342c = 0;
+}

--- a/src/func_ov007_020b7a78.c
+++ b/src/func_ov007_020b7a78.c
@@ -1,0 +1,127 @@
+struct Ddc {
+    int unk0;
+    int unk4;
+    int unk8;
+    int unkC;
+    int unk10;
+    int unk14;
+    int unk18;
+};
+
+typedef struct {
+    char pad[0x3C];
+    int unk3C;
+    int unk40;
+} Obj40;
+
+extern struct Ddc data_ov007_02102ddc;
+extern int *data_ov007_02103478;
+extern int data_ov007_020d7a5c;
+extern unsigned short data_ov007_020d7a68[];
+extern short data_ov007_020d7a84[];
+extern int data_ov007_02102dd8;
+extern int data_ov007_02103464;
+extern int data_ov007_02103468;
+extern Obj40 *data_ov007_0210346c;
+extern Obj40 *data_ov007_02103460;
+
+extern void MultiStore32Bytes(unsigned val, int *dst, int len);
+extern int func_ov007_020b8ec0(int x);
+extern int func_ov007_020c94a0(int a, unsigned int b);
+extern void func_ov007_020b8b80(void *a, int b, int c);
+extern void func_ov007_020bdeb0(int a);
+extern void func_ov007_020c1d78(int i);
+extern void func_ov007_020c1d8c(int i);
+extern void func_ov007_020b7a44(void);
+extern void func_ov007_020b883c(void);
+
+void func_ov007_020b7a78(void)
+{
+    switch (data_ov007_02102ddc.unk4) {
+    case 0:
+        if (data_ov007_02102ddc.unk10 == 0) {
+            if (data_ov007_02102ddc.unkC == 0) {
+                volatile int sp0;
+                sp0 = 0;
+                MultiStore32Bytes(sp0, data_ov007_02103478, data_ov007_020d7a5c);
+            } else if (data_ov007_02102ddc.unkC >= 0xAF0) {
+                data_ov007_02102dd8 = 0xF;
+                data_ov007_02103464 = 0x80;
+                data_ov007_02103468 = data_ov007_02102ddc.unk18;
+                func_ov007_020b8b80(0, func_ov007_020c94a0(0, func_ov007_020b8ec0(data_ov007_020d7a68[data_ov007_02102ddc.unk0])), 0);
+                data_ov007_02102ddc.unk10 = 1;
+                if (data_ov007_02102ddc.unk0 == 5) {
+                    func_ov007_020bdeb0(0x10);
+                } else if (data_ov007_02102ddc.unk0 == 0xB) {
+                    func_ov007_020bdeb0(0x11);
+                }
+            }
+        }
+        data_ov007_02102ddc.unkC += 0x100;
+        if (data_ov007_02102ddc.unkC > 0x1000) {
+            data_ov007_02102ddc.unkC = 0x1000;
+            if (data_ov007_02102ddc.unk0 == 1 || data_ov007_02102ddc.unk0 == 2 ||
+                (unsigned int)(data_ov007_02102ddc.unk0 - 6) <= 2U) {
+                data_ov007_02102ddc.unk4 = 1;
+            } else {
+                data_ov007_02102ddc.unk4 = 2;
+            }
+        }
+        break;
+    case 1:
+        data_ov007_02102ddc.unk8 += 1;
+        if (data_ov007_02102ddc.unk8 >= 0x3C) {
+            data_ov007_02102ddc.unk8 = 0;
+            data_ov007_02102ddc.unk4 = 2;
+        }
+        break;
+    case 2:
+        if (data_ov007_02102ddc.unk8 == 0 &&
+            (data_ov007_02102ddc.unk0 == 9 || data_ov007_02102ddc.unk0 == 0xC)) {
+            func_ov007_020c1d78(0);
+        }
+        {
+            short v = data_ov007_020d7a84[data_ov007_02102ddc.unk0];
+            if (v > 0) {
+                data_ov007_02102ddc.unk8 += 1;
+                if (data_ov007_02102ddc.unk8 >= v) {
+                    func_ov007_020b7a44();
+                }
+            }
+        }
+        break;
+    case 3:
+        if (data_ov007_02102ddc.unk0 == 9 || data_ov007_02102ddc.unk0 == 0xC) {
+            func_ov007_020c1d8c(0);
+        }
+        if (data_ov007_02102ddc.unk10 != 0 && data_ov007_02102ddc.unkC <= 0xAF0) {
+            volatile int sp4;
+            sp4 = 0;
+            data_ov007_02102ddc.unk10 = 0;
+            MultiStore32Bytes(sp4, data_ov007_02103478, data_ov007_020d7a5c);
+        }
+        data_ov007_02102ddc.unkC -= 0x100;
+        if (data_ov007_02102ddc.unkC < 0) {
+            data_ov007_02102ddc.unkC = 0;
+            func_ov007_020b883c();
+        }
+        break;
+    case 4:
+    default:
+        break;
+    }
+
+    if (data_ov007_02102ddc.unkC > 0) {
+        int a = data_ov007_02102ddc.unkC;
+        int result = (int)(((long long)a * (0x2000 - a)) >> 0xC);
+        data_ov007_0210346c->unk40 = result;
+        data_ov007_0210346c->unk3C = data_ov007_0210346c->unk40;
+        data_ov007_02103460->unk40 = result;
+        data_ov007_02103460->unk3C = data_ov007_02103460->unk40;
+    } else {
+        data_ov007_0210346c->unk40 = 0;
+        data_ov007_0210346c->unk3C = data_ov007_0210346c->unk40;
+        data_ov007_02103460->unk40 = 0;
+        data_ov007_02103460->unk3C = data_ov007_02103460->unk40;
+    }
+}


### PR DESCRIPTION
Three-model cascade over a fresh coddog-scheduled 0x280–0x400 worklist (18 targets). Each stage lands its matches and hands the misses to the next model — 17 of 18 matched, only one div-114 deep register-coloring floor left behind.

## Results (17 matches)

| Stage | Model | Landed | Rate | Cost/landed |
|-------|-------|--------|------|-------------|
| 1 | Sonnet 5 | 12/18 | 67% | 110K |
| 2 | Opus 4.8 | 3/6 | 50% | 141K |
| 3 | Fable 5 | 2/2 | 100% | 46K |

## Highlights

- **Player state machine** — `St_Crouch_Main`, `St_Land_Main`, `St_Walk_Main` matched off the shared `St_LedgeHang_Main` sibling scaffold (switch dispatch, De Morgan branch-layout swap, u64-mask address laundering).
- **`func_0204488c`** (Opus, div 107→0) — a 0x2a4 skinned-joint transform draw function; loaded-pointer table + guard-only loop + CSE'd color triplet into batched-load temps.
- **`_ZN10SphereClsn10DetectClsnEv`** (Fable, div 16→0) — the collision-detection loop. Surfaced a **new codegen lever**: routing a virtual-call result through a block-scoped temp `{ int t = o->vN(this); mask = t; }` flips a loop `r4/r5` coloring swap that survived every decl/statement-order permutation.

## Verification

All 17 independently oracle-verified (`abverify` → `MATCH`) and link-verified (`linkcheck` → `VERIFIED`). Branched off `origin/main`, src-only (no README/near-miss-DB churn — the local progress counter is a subset of the merged corpus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzWbWAbHmLVthVmnmNxeNR