### PR TITLE
Recover 6 stranded matched functions (verified)

### DIFF
--- a/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
@@ -1,0 +1,22 @@
+//cpp
+extern "C" {
+extern void func_ov002_020bdb50(char *c, int arg);
+
+int _ZN6Player20St_InYoshiMouth_InitEv(char *c)
+{
+    unsigned int r3;
+    char *slot;
+    unsigned int r1;
+
+    func_ov002_020bdb50(c, 0);
+    r3 = 0;
+    *(unsigned char *)(c + 0x6e5) = (unsigned char)r3;
+    *(unsigned char *)(c + 0x6e6) = (unsigned char)r3;
+    slot = (char *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL);
+    r1 = *(unsigned int *)slot;
+    r1 |= 2u;
+    *(unsigned int *)slot = r1;
+    *(unsigned char *)(c + 0x713) = (unsigned char)r3;
+    return 1;
+}
+}

--- a/src/func_0206a230.c
+++ b/src/func_0206a230.c
@@ -1,0 +1,40 @@
+#pragma optimize_for_size on
+
+extern char *data_020a9db4;
+
+int func_0206a230(void)
+{
+    char *r2;
+    unsigned int r0;
+    unsigned int ip;
+    unsigned int r3;
+    unsigned short r1;
+
+    r0 = 0;
+    r2 = data_020a9db4;
+    ip = 0;
+    r3 = 0;
+    r1 = *(unsigned short *)(r2 + 0x1e00 + 0x28);
+    if (r1 != 1) {
+        goto after_410;
+    }
+    if (*(unsigned char *)(r2 + 0x1000 + 0x410) == 0) {
+        r3 = 1;
+    }
+after_410:
+    if (r3 == 0) {
+        goto done;
+    }
+    r1 = *(unsigned short *)(r2 + 0x1e00 + 0x26);
+    if (r1 == 0) {
+        ip = 1;
+    }
+done:
+    if (ip != 0) {
+        r1 = *(unsigned short *)(r2 + 0x1e00 + 0x2a);
+        if (r1 != 0) {
+            r0 = 1;
+        }
+    }
+    return r0;
+}

--- a/src/func_0206cd9c.c
+++ b/src/func_0206cd9c.c
@@ -1,0 +1,32 @@
+#pragma optimize_for_size on
+#pragma opt_common_subs off
+
+extern int func_0206cf7c(int mask);
+
+struct S {
+    unsigned short f0;
+    unsigned short f2;
+    unsigned short f4;
+};
+
+void func_0206cd9c(struct S *s)
+{
+    volatile unsigned short scratch;
+
+    if (func_0206cf7c(1) != 0 && s->f4 != 0) {
+        volatile unsigned short *p27;
+        volatile unsigned short *p9fe;
+        unsigned short v2;
+
+        p27 = (volatile unsigned short *)0x27fff72;
+        p9fe = (volatile unsigned short *)0x9fe2ffe;
+        v2 = s->f2;
+        *p27 = v2;
+        v2 = s->f2;
+        *p9fe = v2;
+        scratch = *(volatile unsigned short *)0x9fe20f0;
+        scratch = *(volatile unsigned short *)0x9fe20f0;
+        scratch = *(volatile unsigned short *)0x9fe20f0;
+    }
+    *(volatile unsigned short *)0x4000204 = s->f0;
+}

--- a/src/func_ov002_020b12ec.c
+++ b/src/func_ov002_020b12ec.c
@@ -1,0 +1,25 @@
+int func_ov002_020b12ec(char *self)
+{
+    unsigned int v;
+    unsigned int flag;
+    unsigned int r3;
+    char *slot;
+    unsigned int r1;
+
+    v = *(unsigned int *)(self + 0xb0);
+    if ((v & 0xe0000) != 0) {
+        flag = 1;
+    } else {
+        flag = 0;
+    }
+    if (flag != 0) {
+        return 1;
+    }
+    r3 = 0;
+    *(unsigned int *)(self + 0xd0) = r3;
+    slot = (char *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+    r1 = *(unsigned int *)slot;
+    r1 &= ~0xe0000u;
+    *(unsigned int *)slot = r1;
+    return r3;
+}

--- a/src/func_ov002_020c9e40.c
+++ b/src/func_ov002_020c9e40.c
@@ -1,0 +1,11 @@
+void func_ov002_020c9e40(char *self)
+{
+    unsigned int tmp;
+    char *slot;
+
+    *(unsigned char *)(self + 0x709) = 1;
+    slot = (char *)(((long long)(int)(self + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL);
+    tmp = *(unsigned int *)slot;
+    tmp |= 4u;
+    *(unsigned int *)slot = tmp;
+}

--- a/src/func_ov006_020e82c8.c
+++ b/src/func_ov006_020e82c8.c
@@ -1,0 +1,16 @@
+void func_ov006_020e82c8(unsigned char *c)
+{
+    unsigned char *r2;
+    unsigned char *p;
+    unsigned char k;
+
+    r2 = c;
+    r2 += 0x5000;
+    if (r2[0x553] != 0) {
+        return;
+    }
+    p = (unsigned char *)(((long long)(int)(c + 0x5553)) & 0xFFFFFFFFFFFFFFFFLL);
+    *p = (unsigned char)(*p + 1);
+    k = 0x1f;
+    r2[0x1f2] = k;
+}


### PR DESCRIPTION
Six functions matched locally but never reached origin — stranded on local `main` and `tangos/work` after the old single-branch auto-push swept whole dirty `src/` into 'matched work' commits (mixing real matches with near-miss WIP).

Each was re-verified **strict** (reloc destinations checked) against 1.2 base/sp2/sp2p3 in a clean tree off `origin/main` before recovery:

| function | module |
|---|---|
| `func_0206a230` | arm9 |
| `func_0206cd9c` | arm9 |
| `func_ov002_020b12ec` | ov002 |
| `func_ov002_020c9e40` | ov002 |
| `func_ov006_020e82c8` | ov006 |
| `Player::St_InYoshiMouth_Init` | ov002 |

Three co-stranded near-misses (`func_02057d94`, `func_0206a29c`, `func_ov002_020e6b3c`) were verified non-matching and left out.

Built with Claude Code