### PR TITLE
Match ov014 func_ov014_02111a6c

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -41,7 +41,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
-| ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | in progress |
+| ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -41,6 +41,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020aadac (0x020aadac-0x020aaf40) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
+| ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov014_02111a6c.cpp
+++ b/src/func_ov014_02111a6c.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: base materialization / addressing (div=4). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct BCA_File;
 struct ModelAnim { void SetAnim(BCA_File*, int, int, unsigned int); };
 struct S { int a; BCA_File* b; };
@@ -14,6 +11,6 @@ extern "C" void func_ov014_02111a6c(char* c){
   *(char*)(c+0x604)=0;
   *(short*)(c+0x600)=0;
   *(short*)(c+0x500+0xfc)=0x3c;
-  {int *q=(int*)(c+0xb0); *q=*q & ~3;}
+  *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~3;
   *(int*)(c+0x60)=*(int*)(c+0x5f0)+0xc8000;
 }


### PR DESCRIPTION
## Summary
- Match `ov014 func_ov014_02111a6c` at `0x02111a6c` (`size 0x84`).
- Replace the nonmatching direct pointer RMW with the u64 address-laundering form so mwccarm materializes `c + 0xb0` like the retail binary.
- Mark the local claim row done.

## Verification
- `.venv/bin/python tools/match.py --c src/func_ov014_02111a6c.cpp --func func_ov014_02111a6c --addr 0x02111a6c --size 0x84 --version 1.2/sp2p3 --module ov014 --brief`
  - Reports `MATCHING VERSIONS: 1.2/sp2p3`.
- `.venv/bin/python tools/fdiff.py --c src/func_ov014_02111a6c.cpp --name func_ov014_02111a6c --module ov014 --addr 0x02111a6c --size 0x84 --quiet`
  - Reports `RESULT match=True mismatches=0/33`.
- `.venv/bin/python tools/linkcheck.py --name func_ov014_02111a6c --addr 0x02111a6c --size 0x84 --module ov014`
  - Reports `BLIND-1` with no linked-byte diffs.
