### PR TITLE
Match ov043 small wrappers

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -42,7 +42,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
-| ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | in progress |
+| ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -42,6 +42,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
+| ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov043_021114b0.c
+++ b/src/func_ov043_021114b0.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);
+extern struct Arg data_ov043_02112344;
+
+int func_ov043_021114b0(u8 *self)
+{
+    return func_ov002_020b6ac8(self, &data_ov043_02112344);
+}

--- a/src/func_ov043_021115cc.c
+++ b/src/func_ov043_021115cc.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b68b0(u8 *self, struct Arg *arg);
+extern struct Arg data_ov043_02112418;
+
+int func_ov043_021115cc(u8 *self)
+{
+    return func_ov002_020b68b0(self, &data_ov043_02112418);
+}

--- a/src/func_ov043_021115e0.c
+++ b/src/func_ov043_021115e0.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b6958(u8 *self, struct Arg *arg);
+extern struct Arg data_ov043_02112418;
+
+int func_ov043_021115e0(u8 *self)
+{
+    return func_ov002_020b6958(self, &data_ov043_02112418);
+}

--- a/src/func_ov043_02111744.c
+++ b/src/func_ov043_02111744.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
+extern struct Arg data_ov043_02112518;
+
+int func_ov043_02111744(u8 *self)
+{
+    return func_ov002_020b4b6c(self, &data_ov043_02112518);
+}

--- a/src/func_ov043_02111758.c
+++ b/src/func_ov043_02111758.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
+extern struct Arg data_ov043_02112518;
+
+int func_ov043_02111758(u8 *self)
+{
+    return func_ov002_020b4d58(self, &data_ov043_02112518);
+}


### PR DESCRIPTION
## Summary

Matches five ov043 tail-call wrapper functions byte-for-byte:

- `func_ov043_021114b0` at `0x021114b0`
- `func_ov043_021115cc` at `0x021115cc`
- `func_ov043_021115e0` at `0x021115e0`
- `func_ov043_02111744` at `0x02111744`
- `func_ov043_02111758` at `0x02111758`

These mirror the existing ov047 wrapper pattern and tail-call into the ov002 helpers with the ov043 data tables.

## Matching Toolchain

`mwccarm 1.2/sp2p3`

Flags:

```sh
-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
```

## Verification

Each function was verified with strict reloc checking:

```sh
.venv/bin/python tools/match.py --c src/func_ov043_021114b0.c --func func_ov043_021114b0 --addr 0x021114b0 --size 0x14 --version 1.2/sp2p3 --module ov043 --brief
.venv/bin/python tools/match.py --c src/func_ov043_021115cc.c --func func_ov043_021115cc --addr 0x021115cc --size 0x14 --version 1.2/sp2p3 --module ov043 --brief
.venv/bin/python tools/match.py --c src/func_ov043_021115e0.c --func func_ov043_021115e0 --addr 0x021115e0 --size 0x14 --version 1.2/sp2p3 --module ov043 --brief
.venv/bin/python tools/match.py --c src/func_ov043_02111744.c --func func_ov043_02111744 --addr 0x02111744 --size 0x14 --version 1.2/sp2p3 --module ov043 --brief
.venv/bin/python tools/match.py --c src/func_ov043_02111758.c --func func_ov043_02111758 --addr 0x02111758 --size 0x14 --version 1.2/sp2p3 --module ov043 --brief
```

All reported `MATCHING VERSIONS: 1.2/sp2p3`.

Per-name linkcheck also returned `VERIFIED` with no diffs and no blind reloc slots for all five functions.
