### PR TITLE
Match func_ov035_0211195c

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -43,6 +43,7 @@ it is fair to take over: ping the claimant first.
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
+| ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -43,7 +43,7 @@ it is fair to take over: ping the claimant first.
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
-| ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | in progress |
+| ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov035_0211195c.c
+++ b/src/func_ov035_0211195c.c
@@ -1,19 +1,15 @@
-//cpp
-// NONMATCHING: different op / idiom (div=30). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" int DecIfAbove0_Short(char *p);
-extern "C" int RandomIntInternal(char *p);
-extern "C" void func_020393a4(int *p, int v);
-extern "C" void func_02039394(int *p, int v);
-extern "C" void func_ov035_021118a8(char *t);
-extern "C" int func_ov035_02111798(char *c);
-extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
-extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
+extern int DecIfAbove0_Short(char *p);
+extern int RandomIntInternal(char *p);
+extern void func_020393a4(int *p, int v);
+extern void func_02039394(int *p, int v);
+extern void func_ov035_021118a8(char *t);
+extern int func_ov035_02111798(char *c);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
 extern unsigned char data_0209f2c0[];
 extern short data_ov035_02112b80[];
 extern int data_0209e650[];
-extern "C" int func_ov035_0211195c(char *c) {
+int func_ov035_0211195c(char *c) {
     unsigned char idx = data_0209f2c0[0];
     *(short*)(c+0x92) = data_ov035_02112b80[idx];
     if (idx == 2) {
@@ -24,18 +20,18 @@ extern "C" int func_ov035_0211195c(char *c) {
             *(short*)(c+0x320) = (short)((r % 4 + 1) * 0x1e);
             *(unsigned short*)(c+0x322) = *(unsigned short*)(c+0x320);
         } else {
-            if ((int)*(unsigned short*)(c+0x320) >= (int)*(unsigned short*)(c+0x322) - 5) {
-                *(short*)(c+0x92) = 0;
-            } else {
-                short *q = (short*)(c+0x92);
+            if ((int)*(unsigned short*)(c+0x320) < (int)*(unsigned short*)(c+0x322) - 5) {
+                short *q = (short*)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFF);
                 *q = (short)(*q * *(signed char*)(c+0x31e));
+            } else {
+                *(short*)(c+0x92) = 0;
             }
         }
     }
     func_020393a4((int*)(c+0x124), 0x180000);
     func_02039394((int*)(c+0x124), 0x1000);
     {
-        short *s = (short*)(c+0x8c);
+        short *s = (short*)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF);
         *s = (short)(*s + *(short*)(c+0x92));
     }
     func_ov035_021118a8(c);


### PR DESCRIPTION
## Summary

- Match `func_ov035_0211195c` at `0x0211195c` (`ov035`, size `0x13c`).
- Replace the previous `NONMATCHING` draft with byte-identical C.
- Mark the local `CLAIMS.md` row done.

## Matching notes

The final source keeps this as C and uses the `<`-direction range check to make mwccarm emit the ROM's explicit `bge` over the multiply block. The laundered halfword pointers preserve the materialized-address shape for the `0x92` and `0x8c` updates.

Compiler: `mwccarm 1.2/sp2p3`

Flags:

```sh
-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
```

## Verification

```sh
.venv/bin/python tools/match.py --c src/func_ov035_0211195c.c --func func_ov035_0211195c --addr 0x211195c --size 0x13c --version 1.2/sp2p3 --module ov035 --brief
# MATCHING VERSIONS: 1.2/sp2p3

.venv/bin/python tools/fdiff.py --c src/func_ov035_0211195c.c --name func_ov035_0211195c --module ov035 --addr 0x211195c --size 0x13c --quiet
# RESULT match=True mismatches=0/79

.venv/bin/python tools/linkcheck.py --name func_ov035_0211195c --addr 0x0211195c --size 0x13c --module ov035
# verdict: VERIFIED
```
