### PR TITLE
Match func_ov013_021112a8

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -44,7 +44,7 @@ it is fair to take over: ping the claimant first.
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
 | ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | done - verified byte-identical |
-| ov013 func_ov013_021112a8 (0x021112a8-0x0211133c) | lunavyqo | 2026-07-08 | in progress |
+| ov013 func_ov013_021112a8 (0x021112a8-0x0211133c) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -44,6 +44,7 @@ it is fair to take over: ping the claimant first.
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
 | ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | done - verified byte-identical |
+| ov013 func_ov013_021112a8 (0x021112a8-0x0211133c) | lunavyqo | 2026-07-08 | in progress |
 | ov002 _ZN6Player18St_YoshiPower_MainEv (0x020d7504, 0x9cc) | ruspecial (Claude-assisted) | 2026-07-05 | done - matched byte-identical, PR open |
 | ov002/006/065/080 batch: func_ov006_020ef794, _ZN6Player19St_CrazedCrate_InitEv, func_ov080_02123fcc, func_ov006_020c87d0, func_ov002_020cec2c, func_ov065_0211a6d0 | ruspecial (Claude-assisted) | 2026-07-06 | done - 6 verified byte-identical |
 | ov063 func_ov063_0211640c (0x0211640c, 0x2a0) | ruspecial (Claude-assisted) | 2026-07-06 | NONMATCHING div=1 (ang*-1 rsb vs ROM smulbb); near-miss draft submitted |

--- a/src/func_ov013_021112a8.c
+++ b/src/func_ov013_021112a8.c
@@ -1,23 +1,23 @@
-//cpp
-// NONMATCHING: base materialization / addressing (div=10). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" {
 void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void*);
 void func_ov013_02111238(char* t);
 extern signed char data_02092110[];
-int func_ov013_021112a8(char* c){
-  if(data_02092110[0] <= 0){
-    short* p90 = (short*)(c+0x90);
-    if(*p90 > 0) *(short*)(c+0x124) -= 8;
-    else         *(short*)(c+0x124) += 8;
-    *p90 = (short)(*p90 + *(short*)(c+0x124));
-    short w = *(short*)(c+0x124);
-    if(w==0x10 || w==-0x10){
-      _ZN5Sound9PlayBank3EjRK7Vector3(0x16, c+0x74);
-      func_ov013_02111238(c);
+
+int func_ov013_021112a8(char* c)
+{
+    if (data_02092110[0] <= 0) {
+        short* p90 = (short*)(c + 0x90);
+        if (*p90 > 0) {
+            *(short*)(((long long)(int)(c + 0x124)) & 0xffffffffffffffffLL) -= 8;
+        } else {
+            *(short*)(((long long)(int)(c + 0x124)) & 0xffffffffffffffffLL) += 8;
+        }
+        *p90 = (short)(*p90 + *(short*)(c + 0x124));
+        short w = *(short*)(c + 0x124);
+        if (w == 0x10 || w == -0x10) {
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x16, c + 0x74);
+        }
     }
-  }
-  return 1;
-}
+    func_ov013_02111238(c);
+
+    return 1;
 }


### PR DESCRIPTION
## Summary

- Matches `func_ov013_021112a8` at `0x021112a8` in `ov013`.
- Replaces the stored NONMATCHING draft with byte-identical C.
- Updates the local claim row to `done - verified byte-identical`.

## Notes

The near-miss was calling `func_ov013_02111238` only on the sound-trigger path, but the retail branch targets call it on all paths. The remaining address-shape gap at `c + 0x124` is fixed with the documented u64-mask laundering idiom so mwccarm materializes `add ..., #0x124` before the halfword update.

## Verification

- `.venv/bin/python tools/match.py --c src/func_ov013_021112a8.c --func func_ov013_021112a8 --addr 0x021112a8 --size 0x94 --version 1.2/sp2p3 --module ov013`
  - `MATCHING VERSIONS: 1.2/sp2p3`
- `.venv/bin/python tools/linkcheck.py --name func_ov013_021112a8 --addr 0x021112a8 --size 0x94 --module ov013`
  - `VERIFIED`

Compiler flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.
