### PR TITLE
Match 32 functions byte-identical (sibling batch #2)

### DIFF
--- a/src/Vec3_AsrInPlace.c
+++ b/src/Vec3_AsrInPlace.c
@@ -1,0 +1,7 @@
+int *Vec3_AsrInPlace(int *v, int sh)
+{
+    v[0] >>= sh;
+    *(int *)(((long long)(int)(v + 1)) & 0xFFFFFFFFFFFFFFFFLL) >>= sh;
+    *(int *)(((long long)(int)(v + 2)) & 0xFFFFFFFFFFFFFFFFLL) >>= sh;
+    return v;
+}

--- a/src/_ZN10FaderColor11AdvanceFadeEv.cpp
+++ b/src/_ZN10FaderColor11AdvanceFadeEv.cpp
@@ -1,0 +1,26 @@
+//cpp
+extern "C" {
+
+void _ZN5Fader13AdvanceInterpEv(void* thiz);
+void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short* p, unsigned short a, int b);
+
+void _ZN10FaderColor11AdvanceFadeEv(char* thiz)
+{
+    int old = *(int*)(thiz + 4);
+    _ZN5Fader13AdvanceInterpEv(thiz);
+    if (*(int*)(thiz + 4) == old) return;
+    {
+        unsigned short color = *(unsigned short*)(thiz + 0xc);
+        int m = color ? 0x10 : -0x10;
+        int r = (*(int*)(thiz + 4) * m) >> 12;
+        if (r != 0) {
+            _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4000050, 0x3f, r);
+            _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4001050, 0x3f, r);
+        } else {
+            *(unsigned short*)0x4000050 = 0;
+            *(unsigned short*)0x4001050 = 0;
+        }
+    }
+}
+
+}

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -1,0 +1,34 @@
+//cpp
+extern "C" {
+
+typedef unsigned int u32;
+
+extern void _ZN18NestedHeapIteratorC1Ej(void* self, u32 off);
+extern void* _ZN18NestedHeapIterator10FindNestedEPv(void* ptr);
+extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void* iter, void* node);
+
+extern int _ZN6Memory25isRootHeapIterInitializedE;
+extern char _ZN6Memory16rootHeapIteratorE;
+
+void _ZN13HeapAllocatorC1EjPvPvj(char* self, u32 magic, void* a, void* b, unsigned short size) {
+    *(u32*)self = magic;
+    *(void**)(self + 0x18) = a;
+    *(void**)(self + 0x1c) = b;
+    *(u32*)(self + 0x20) = 0;
+    {
+        u32* p = (u32*)(((long long)(int)(self + 0x20)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p &= ~0xffu;
+        *p |= (size & 0xffu);
+    }
+    _ZN18NestedHeapIteratorC1Ej(self + 0xc, 4);
+    if (_ZN6Memory25isRootHeapIterInitializedE == 0) {
+        _ZN18NestedHeapIteratorC1Ej(&_ZN6Memory16rootHeapIteratorE, 4);
+        _ZN6Memory25isRootHeapIterInitializedE = 1;
+    }
+    {
+        void* it = _ZN18NestedHeapIterator10FindNestedEPv(self);
+        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(it, self);
+    }
+}
+
+}

--- a/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
+++ b/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
@@ -1,0 +1,34 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+struct Actor;
+struct ClsnResult { int x, y, z; };
+
+struct MeshColliderBase {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void v5();
+    virtual void v6();
+    virtual void v7();
+    virtual void v8();
+    virtual void v9();
+    virtual void v10();
+    virtual int GetAngularVelY();
+};
+
+extern "C" void _ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(
+    MeshColliderBase* self, Actor* a2, ClsnResult* a3, Vector3* a4, Vector3_16* a5, Vector3_16* a6)
+{
+    int angY = self->GetAngularVelY();
+    if (a6) {
+        short* py = (short*)(((long long)(int)&a6->y) & 0xFFFFFFFFFFFFFFFFLL);
+        *py = *py + angY;
+    }
+    if (a5) {
+        short* py = (short*)(((long long)(int)&a5->y) & 0xFFFFFFFFFFFFFFFFLL);
+        *py = *py + angY;
+    }
+}

--- a/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
+++ b/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
@@ -1,0 +1,11 @@
+//cpp
+extern "C" {
+int _ZN6Player22St_SwingPlayer_CleanupEv(char* c){
+  char* p = *(char**)(c + 0x358);
+  if (p) {
+    *(unsigned int*)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800;
+  }
+  *(short*)(c + 0x94) = *(short*)(c + 0x8e);
+  return 1;
+}
+}

--- a/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+void _ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3(char* ed, char* p, int* vec){
+  vec[0] += (int)*(short*)(ed+0);
+  *(int*)(((long long)(int)(vec+1)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+2);
+  *(int*)(((long long)(int)(vec+2)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+4);
+}
+}

--- a/src/func_0200f760.c
+++ b/src/func_0200f760.c
@@ -1,0 +1,16 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern unsigned char *_ZN5Actor13ClosestPlayerEv(void *self);
+
+void func_0200f760(void *self, char *actor)
+{
+    unsigned char *p;
+
+    *(u32 *)(((int)actor + 0x18) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    p = _ZN5Actor13ClosestPlayerEv(self);
+    if (p == 0) return;
+    if (p[0x6fb] != 0) {
+        *(u32 *)(((int)(actor + 0x18)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    }
+}

--- a/src/func_02037318.c
+++ b/src/func_02037318.c
@@ -1,0 +1,20 @@
+typedef unsigned int u32;
+
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+extern int _ZN6Player7IsInAirEv(void *player);
+
+void func_02037318(char *self)
+{
+    const int *src;
+
+    *(u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(self) == 0)
+        return;
+    if (_ZN6Player7IsInAirEv(*(void **)(self + 0x14)))
+        return;
+    *(u32 *)(((int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+    src = (const int *)(((int)self + 0x11c) & 0xFFFFFFFFFFFFFFFFLL);
+    *(int *)(self + 0x1ac) = src[0];
+    *(int *)(self + 0x1b0) = src[1];
+    *(int *)(self + 0x1b4) = src[2];
+}

--- a/src/func_02041c64.c
+++ b/src/func_02041c64.c
@@ -1,0 +1,25 @@
+struct ListNode;
+extern struct ListNode *func_02041b60(char *base);
+extern void func_020423c8(void);
+
+struct ListNode *func_02041c64(char *base, int a, int b)
+{
+    struct ListNode *node;
+    node = *(struct ListNode **)((base + 0x2000) + 0x708);
+    while (node != 0) {
+        if (*(int *)((char *)node + 0x7c) == 1
+            && *(int *)((char *)node + 0x8c) == a
+            && *(int *)((char *)node + 0x90) == b) {
+            break;
+        }
+        node = *(struct ListNode **)node;
+    }
+    if (node == 0) {
+        node = func_02041b60(base);
+        *(int *)((char *)node + 0x80) = 0;
+        *(int *)((char *)node + 0x8c) = a;
+        *(int *)((char *)node + 0x90) = b;
+        func_020423c8();
+    }
+    return node;
+}

--- a/src/func_02046088.c
+++ b/src/func_02046088.c
@@ -1,0 +1,30 @@
+typedef unsigned int u32;
+
+typedef struct Sub Sub;
+struct Sub {
+    char _pad[0x24];
+    int count; /* 0x24 */
+};
+
+typedef struct Obj Obj;
+struct Obj {
+    Sub *sub;   /* 0x00 */
+    char *data; /* 0x04 */
+};
+
+void func_02046088(Obj *self, int a, int b)
+{
+    int i;
+    int n = self->sub->count;
+
+    for (i = 0; i < n; i++)
+    {
+        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p &= 0xc0ffff0f;
+        *p |= b << 24;
+        *p |= 0x80;
+        *p |= 0x30;
+        *p &= ~0x1f0000;
+        *p |= a << 16;
+    }
+}

--- a/src/func_020587e4.c
+++ b/src/func_020587e4.c
@@ -1,0 +1,38 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+
+struct MsgQueue {
+    u16 queueSend;      /* 0x00 */
+    u16 queueReceive;   /* 0x02 */
+    u32 *msgArray;      /* 0x04 */
+    int msgCount;       /* 0x08 */
+    int firstIndex;     /* 0x0c */
+    int usedCount;      /* 0x10 */
+};
+
+u32 _ZN3IRQ7DisableEv(void);
+void _ZN3IRQ7RestoreEj(u32 state);
+void func_020580f0(u16 *self);
+void func_0205807c(u16 *self);
+
+int func_020587e4(struct MsgQueue *self, u32 *msg, int flags) {
+    u32 enabled = _ZN3IRQ7DisableEv();
+
+    while (self->usedCount == 0) {
+        if ((flags & 1) == 0) {
+            _ZN3IRQ7RestoreEj(enabled);
+            return 0;
+        }
+        func_020580f0(&self->queueReceive);
+    }
+
+    if (msg != 0) {
+        *msg = self->msgArray[self->firstIndex];
+    }
+    self->firstIndex = (self->firstIndex + 1) % self->msgCount;
+    *(int *)(((long long)(int)&self->usedCount) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    func_0205807c(&self->queueSend);
+
+    _ZN3IRQ7RestoreEj(enabled);
+    return 1;
+}

--- a/src/func_0205cfa4.c
+++ b/src/func_0205cfa4.c
@@ -1,0 +1,35 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+
+extern u32 _ZN3IRQ7DisableEv(void);
+extern void _ZN3IRQ7RestoreEj(u32 saved);
+extern void func_0205807c(u16 *p);
+extern int func_0205c5e4(void *self, int a);
+extern void *func_0205d044(void *pool);
+
+typedef struct Node {
+    char pad0[8];
+    void *pool;      /* 0x8 */
+    u32 flags;       /* 0xc */
+    int f10;         /* 0x10 */
+    char pad14[4];   /* 0x14 */
+    u16 f18;         /* 0x18 */
+} Node;
+
+void func_0205cfa4(Node *self)
+{
+    void *pool = self->pool;
+    if (self == 0) return;
+    do {
+        u32 saved = _ZN3IRQ7DisableEv();
+        int b = (int)((self->flags & 4) != 0);
+        if (b != 0) {
+            func_0205807c(&self->f18);
+            return;
+        }
+        *(u32 *)(((u32)self + 0xc) & 0xFFFFFFFFFFFFFFFFull) |= 8u;
+        _ZN3IRQ7RestoreEj(saved);
+        if (func_0205c5e4(self, self->f10) == 6) return;
+        self = (Node *)func_0205d044(pool);
+    } while (self != 0);
+}

--- a/src/func_0205d568.c
+++ b/src/func_0205d568.c
@@ -1,0 +1,34 @@
+typedef struct Node Node;
+
+struct Node {
+    char _pad0[0x8];
+    int field8;
+    unsigned int fieldC;
+    char _pad10[0x2C - 0x10];
+    int field2C;
+    int field30;
+};
+
+extern int func_0205cdf4(Node *node, int a, int b, int c);
+
+int func_0205d568(Node *node, int b, ...)
+{
+    unsigned int *p;
+    if (b == 0) {
+        return 0;
+    }
+    node->field8 = b;
+    {
+        int b2 = b;
+        int c = *(int *)((char *)&b + 4);
+        node->field2C = b2;
+        node->field30 = c;
+        if (func_0205cdf4(node, 6, c, b2) == 0) {
+            return 0;
+        }
+    }
+    p = (unsigned int *)(((long long)(int)((char *)node + 0xc)) & 0xFFFFFFFFFFFFFFFFLL);
+    *p |= 0x10;
+    *p &= ~0x20;
+    return 1;
+}

--- a/src/func_02060228.c
+++ b/src/func_02060228.c
@@ -1,0 +1,29 @@
+extern char data_020a8180[];
+extern int data_020a6134[];
+extern int func_02057e7c(int *p);
+extern int func_02057e84(void *node, int value);
+extern void func_02058048(void *self);
+
+void func_02060228(void *fn)
+{
+    char *base = data_020a8180;
+    int v = *(int *)(base + 0x38);
+    switch (v) {
+    case 0x20:
+        v = func_02057e7c((int *)data_020a6134[2]);
+        if (v != 0) v -= 1;
+        break;
+    case 0x21:
+        v = func_02057e7c((int *)data_020a6134[2]);
+        if ((unsigned int)v < 0x1f) v += 1;
+        break;
+    }
+    func_02057e84(base + 0x3c, v);
+    *(void **)(base + 0xd0) = base + 0x3c;
+    *(void **)(base + 0x30) = fn;
+    {
+        unsigned int *fp = (unsigned int *)(((long long)(int)(base + 0x34)) & 0xFFFFFFFFFFFFFFFFLL);
+        *fp |= 8;
+    }
+    func_02058048(base + 0x3c);
+}

--- a/src/func_02060e38.c
+++ b/src/func_02060e38.c
@@ -1,0 +1,53 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+
+struct Obj {
+    char pad[0x64];
+    u32 unk64;
+};
+
+typedef struct {
+    u32 *f0;            /* 0x00 */
+    char pad4[0x24];    /* 0x04 */
+    void (*cb)(void *); /* 0x28 */
+    void *cb_arg;       /* 0x2c */
+    char pad30[4];      /* 0x30 */
+    u32 flags;          /* 0x34 */
+    char pad38[4];      /* 0x38 */
+    struct Obj obj;     /* 0x3c */
+    char pada4[0x30];   /* 0xa4 */
+    u16 fd4;            /* 0xd4 */
+} G;
+
+extern G data_020a8180;
+
+u32 _ZN3IRQ7DisableEv(void);
+void _ZN3IRQ7RestoreEj(u32 state);
+void func_0205807c(u16 *self);
+void func_02058048(struct Obj *self);
+
+void func_02060e38(void) {
+    int gi = (int)&data_020a8180;
+    G *g = (G *)gi;
+    void (*cb)(void *) = g->cb;
+    void *arg = g->cb_arg;
+    u32 s;
+    u32 *pf;
+
+    *g->f0 = 0;
+    s = _ZN3IRQ7DisableEv();
+    pf = (u32 *)((gi + 0x34) & 0xFFFFFFFFFFFFFFFF);
+    {
+        u32 val = *pf;
+        val &= ~0xc;
+        *pf = val;
+    }
+    func_0205807c(&g->fd4);
+    if (g->flags & 0x10) {
+        func_02058048(&g->obj);
+    }
+    _ZN3IRQ7RestoreEj(s);
+    if (cb) {
+        cb(arg);
+    }
+}

--- a/src/func_02064888.c
+++ b/src/func_02064888.c
@@ -1,0 +1,42 @@
+struct Node
+{
+  int key;
+  char pad[0x24];
+  struct Node *next;
+  char *data;
+};
+
+extern struct Node *func_02065ae0(void);
+extern int func_02065bc0(void);
+
+char *func_02064888(unsigned int id, int idx)
+{
+  struct Node *node = func_02065ae0();
+
+  if (id < 0x3e8)
+  {
+    unsigned int i = 0;
+    for (;;)
+    {
+      if (i == id)
+        return (char *)node + idx * func_02065bc0();
+      i++;
+      if (node != 0)
+        node = node->next;
+      else
+        return 0;
+    }
+  }
+
+  while (node != 0)
+  {
+    if (node->key == id)
+    {
+      char *base = node->data;
+      return base + idx * func_02065bc0();
+    }
+    node = node->next;
+  }
+
+  return 0;
+}

--- a/src/func_0206d8c4.c
+++ b/src/func_0206d8c4.c
@@ -1,0 +1,28 @@
+extern void _ZN4cstd8__assertEPKcPKcPKci(const char *, const char *, const char *, int);
+extern const char data_020868fc;
+extern const char data_02086a08;
+
+struct Elem {
+    int a, b, c, d;
+};
+
+struct Arr {
+    unsigned int count;
+    int pad[3];
+    struct Elem elems[1];
+};
+
+void func_0206d8c4(struct Arr *s, unsigned int index) {
+    unsigned int n;
+    if (index >= s->count) {
+        _ZN4cstd8__assertEPKcPKcPKci(&data_020868fc, (const char *)0x55, &data_02086a08, 1);
+    }
+    s->count--;
+    n = s->count;
+    goto test;
+loop:
+    s->elems[index] = s->elems[index + 1];
+    index++;
+test:
+    if (index < n) goto loop;
+}

--- a/src/func_ov002_020af7cc.c
+++ b/src/func_ov002_020af7cc.c
@@ -1,0 +1,12 @@
+void func_ov002_020af7cc(char* c)
+{
+    *(unsigned char*)(c + 0x38e) = 1;
+    if (*(int*)(c + 0x60) >= *(int*)(c + 0x37c) + 0x64000) return;
+    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x5000;
+    if (*(int*)(c + 0x60) < *(int*)(c + 0x37c) + 0x64000) return;
+    *(int*)(c + 0x60) = *(int*)(c + 0x37c) + 0x64000;
+    *(int*)(c + 0x384) = 0;
+    *(int*)(c + 0x388) = 0;
+    *(unsigned short*)(c + 0x100) = 0xffff;
+    *(unsigned short*)(c + 0x38c) = 0xffff;
+}

--- a/src/func_ov002_020b4714.c
+++ b/src/func_ov002_020b4714.c
@@ -1,0 +1,28 @@
+struct Vector3 { int x, y, z; };
+extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* from);
+extern void _ZN5Actor13LandingDustAtER7Vector3b(char* thiz, struct Vector3* v, int flag);
+extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vector3* pos, void* rot, int e, int f);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(char* thiz);
+
+void func_ov002_020b4714(char* a) {
+    char* b;
+    b = _ZN5Actor15FindWithActorIDEjPS_(0x13f, 0);
+    while (b) {
+        if (*(unsigned char*)(a + 0x109) == *(unsigned char*)(b + 0x109)) {
+            struct Vector3 v;
+            struct Vector3* p;
+            char* spawned;
+            p = (struct Vector3*)(((long long)(int)(b + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            v.x = p->x;
+            v.y = p->y;
+            v.z = p->z;
+            _ZN5Actor13LandingDustAtER7Vector3b(a, &v, 1);
+            spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x115, 0xd, (struct Vector3*)(b + 0x5c), 0, *(signed char*)(a + 0xcc), -1);
+            *(int*)(spawned + 0xa8) = 0x28000;
+            _ZN5Actor24KillAndTrackInDeathTableEv(b);
+            _ZN5Actor24KillAndTrackInDeathTableEv(a);
+            return;
+        }
+        b = _ZN5Actor15FindWithActorIDEjPS_(0x13f, b);
+    }
+}

--- a/src/func_ov002_020b7c30.c
+++ b/src/func_ov002_020b7c30.c
@@ -1,0 +1,26 @@
+extern int _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
+extern int _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void*, void*, unsigned int);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
+extern int func_ov002_020b6fcc(void*);
+extern int _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void*, int, int, int, int);
+extern int _ZN8SaveData13PlayerLoseCapEv(void);
+extern int _ZN9ActorBase18MarkForDestructionEv(void*);
+extern int data_02092138;
+
+int func_ov002_020b7c30(void* c) {
+  if (*(int*)((char*)c + 0x9c) != 0) {
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char*)c + 0x110);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (char*)c + 0x144, 0);
+    *(unsigned*)(((long long)(int)((char*)c + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char*)c + 0x144)) {
+      *(int*)((char*)c + 0x98) = 0;
+      func_ov002_020b6fcc(c);
+      _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, 0x32000, 0x32000, 0x1000000, 0x1000000);
+    }
+  }
+  if (data_02092138 > *(int*)((char*)c + 0x60)) {
+    _ZN8SaveData13PlayerLoseCapEv();
+    _ZN9ActorBase18MarkForDestructionEv(c);
+  }
+  return 1;
+}

--- a/src/func_ov002_020c7cbc.c
+++ b/src/func_ov002_020c7cbc.c
@@ -1,0 +1,29 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+typedef int Fix12i;
+
+extern u8 data_0209f2fc;
+extern signed char data_02092124;
+extern void LoadKeyModels(int idx);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, u32 a, int b, Fix12i c, u32 d);
+
+int func_ov002_020c7cbc(char* self)
+{
+    if (data_0209f2fc == 1) {
+        switch (data_02092124) {
+        case 0x24: *(u8*)(self + 0x719) = 0; break;
+        case 0x26: *(u8*)(self + 0x719) = 1; break;
+        case 0x2d: *(u8*)(self + 0x719) = 2; break;
+        case 0x2f: *(u8*)(self + 0x719) = 3; break;
+        case 0x31: *(u8*)(self + 0x719) = 4; break;
+        }
+
+        if (*(signed char*)(self + 0x719) >= 0) {
+            LoadKeyModels(*(signed char*)(self + 0x719));
+            *(u8*)(((long long)(int)(self + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+            _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x53, 0x40000000, 0x1000, 0);
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020c9c4c.c
+++ b/src/func_ov002_020c9c4c.c
@@ -1,0 +1,14 @@
+typedef int Fix12i;
+extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+extern unsigned int data_ov002_020ff118[];
+
+void func_ov002_020c9c4c(char* c) {
+    _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff118[*(unsigned char*)(c+0x6e3)], 0x40000000, 0x1000, 0);
+    *(unsigned char*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFFLL) += 7;
+    *(char*)(c+0x743) = 1;
+    *(char*)(c+0x716) = 1;
+    *(char*)(c+0x713) = 0;
+    *(int*)(c+0x9c) = 0;
+    *(int*)(c+0x98) = 0;
+    *(int*)(c+0xa8) = 0;
+}

--- a/src/func_ov002_020f05f4.c
+++ b/src/func_ov002_020f05f4.c
@@ -1,0 +1,29 @@
+typedef struct { int x, y, z; } Vector3;
+
+extern void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* prev);
+extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* v, void* w, int e, int f);
+extern void _ZN9PowerStar13AddStarMarkerEv(void* thiz);
+
+void func_ov002_020f05f4(char* c)
+{
+    char* a = 0;
+    for (;;) {
+        a = (char*)_ZN5Actor15FindWithActorIDEjPS_(0xb4, a);
+        if (a == 0) return;
+        if (*(unsigned char*)(c + 0x10d) == *(unsigned char*)(a + 0x1d9)) {
+            int* base = (int*)(((long long)(int)(a + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            Vector3 pos;
+            pos.x = base[0];
+            pos.y = base[1];
+            pos.z = base[2];
+            pos.y += 0x12c000;
+            {
+                char* p = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, (*(unsigned char*)(c + 0x10d)) | 0x40, &pos, 0, *(signed char*)(c + 0xcc), -1);
+                if (p != 0) {
+                    _ZN9PowerStar13AddStarMarkerEv(p);
+                }
+            }
+            return;
+        }
+    }
+}

--- a/src/func_ov004_020b3834.c
+++ b/src/func_ov004_020b3834.c
@@ -1,0 +1,13 @@
+extern int _Z15ApproachLinear2Rsss(short* v, short t, short s);
+extern void func_ov004_020b37f0(int* obj);
+
+void func_ov004_020b3834(int* obj){
+    char* c = (char*)obj;
+    if (*(int*)(c + 0x24) < 0x30){
+        *(unsigned*)(((long long)(int)(c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        return;
+    }
+    if (_Z15ApproachLinear2Rsss((short*)(c + 0x12), *(short*)(c + 0x16), 0x10)){
+        func_ov004_020b37f0(obj);
+    }
+}

--- a/src/func_ov006_020c0b74.c
+++ b/src/func_ov006_020c0b74.c
@@ -1,0 +1,26 @@
+extern int _ZN9Animation8FinishedEv(char *self);
+extern int _ZNK9Animation12WillHitFrameEi(char *self, int frame);
+extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(char *self, void *file, int a, int b, int c, unsigned short d);
+extern void func_ov006_020c1764(char *p);
+
+typedef struct {
+    char _pad[0x1d8];
+    short field_1d8;
+} Obj;
+
+void func_ov006_020c0b74(char *p) {
+    if (*(void **)(p + 0x7c) == *(void **)(p + 0x244) && _ZN9Animation8FinishedEv(p + 0x6c)) {
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(p + 0x1c, *(void **)(p + 0x24c), 0, 0, 0x800, 0);
+        return;
+    }
+    if (*(void **)(p + 0x7c) == *(void **)(p + 0x24c) && _ZNK9Animation12WillHitFrameEi(p + 0x6c, 0)) {
+        *(short *)((long long)(int)(p + 0x1d8) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        if (((Obj *)p)->field_1d8 == 0) {
+            _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(p + 0x1c, *(void **)(p + 0x254), 0, 0x40000000, 0x800, 0);
+            return;
+        }
+    }
+    if (*(void **)(p + 0x7c) == *(void **)(p + 0x254) && _ZN9Animation8FinishedEv(p + 0x6c)) {
+        func_ov006_020c1764(p);
+    }
+}

--- a/src/func_ov006_020c7ba4.c
+++ b/src/func_ov006_020c7ba4.c
@@ -1,0 +1,26 @@
+typedef struct { int x, y, z; } Vec3;
+extern void Vec3_Sub(Vec3 *out, Vec3 *a, Vec3 *b);
+extern int NormalizeVec3IfNonZero(Vec3 *v);
+extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int a, int b, unsigned int u);
+extern void func_ov006_020e6df0(int a0, char *a1, void *a2);
+struct G { int w[2]; };
+extern int data_ov006_02140408[];
+extern struct G data_ov006_0213b028;
+
+void func_ov006_020c7ba4(char *p) {
+    Vec3 v;
+    Vec3_Sub(&v, (Vec3 *)(p + 0x14), (Vec3 *)(p + 4));
+    if (NormalizeVec3IfNonZero(&v) != 0) {
+        *(int *)(p + 0x20) = v.x;
+        *(int *)(p + 0x24) = v.y;
+        *(int *)(p + 0x28) = v.z;
+    } else {
+        *(int *)(p + 0x20) = -*(int *)(p + 0x20);
+        *(int *)(p + 0x24) = -*(int *)(p + 0x24);
+    }
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(p + 0x4c, (void *)data_ov006_02140408[0], 0x40000000, 0x800, 0);
+    *(int *)(p + 0xa4) = 0;
+    func_ov006_020e6df0(0, (char *)6, *(void **)(p + 0x14));
+    *(short *)(p + 0x32) = 0x20;
+    *(struct G *)(p + 0x3c) = data_ov006_0213b028;
+}

--- a/src/func_ov006_02106bc0.c
+++ b/src/func_ov006_02106bc0.c
@@ -1,0 +1,32 @@
+// func_ov006_02106bc0 at 0x02106bc0 (ov006)
+struct Pmf { int off; int adj; };
+typedef void (*PmfFn)(void *, int);
+
+extern struct Pmf data_ov006_02142840[];
+extern void func_ov004_020b0a54(int arg);
+extern void func_ov006_02104ea8(char *c);
+
+void func_ov006_02106bc0(char *c) {
+    int i;
+    for (i = 0; i < *(int *)(c + 0x4cb8); i++) {
+        unsigned char idx = *(unsigned char *)(c + i + 0x4efa);
+        struct Pmf *e = &data_ov006_02142840[idx];
+        int adj = e->adj;
+        char *thisp = c + (adj >> 1);
+        PmfFn fn;
+        if (adj & 1) {
+            fn = *(PmfFn *)(*(char **)thisp + e->off);
+        } else {
+            fn = (PmfFn)e->off;
+        }
+        fn(thisp, i);
+    }
+    if (*(unsigned short *)(c + 0x4ec0) == 0) return;
+    *(unsigned short *)(((long long)(int)(c + 0x4ec0)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    if (*(short *)(c + 0x4ec0) > 0) return;
+    *(unsigned short *)(c + 0x4ec0) = 0;
+    func_ov004_020b0a54(0x12);
+    *(unsigned char *)(c + 0xc3) = 0;
+    *(unsigned char *)(c + 0x4fe3) = 0;
+    func_ov006_02104ea8(c);
+}

--- a/src/func_ov006_02121fa4.c
+++ b/src/func_ov006_02121fa4.c
@@ -1,0 +1,69 @@
+extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *reg,
+    unsigned short a, unsigned short b, int c, unsigned short d);
+extern void func_ov006_020cd424(unsigned int n, int arg1);
+extern void func_ov006_020d0b04(int a);
+extern void func_ov006_02120ca0(void);
+extern int func_ov004_020ad674(void);
+extern void func_ov006_020c8a9c(int a0, int a1);
+extern void func_ov006_02120a44(char *p);
+extern int RandomIntInternal(int *seed);
+extern void func_ov006_02121750(char *c, short v);
+extern int func_02054d88(void);
+extern void MultiStore16(unsigned short val, char *dst, int nbytes);
+extern void func_ov006_02121f04(char *o);
+
+extern volatile short data_020a0dbc[];
+extern int data_ov006_02142f60;
+extern int data_ov006_0213fb18[];
+extern int data_0209e650;
+
+void func_ov006_02121fa4(char *o)
+{
+    volatile unsigned short fill;
+    int q;
+
+    _ZN3G2x13SetBlendAlphaEPVttttt((volatile void *)0x4000050, 1, 0x3e, 0x10, 0x10);
+
+    *(short *)(o + 0x5db4) = data_020a0dbc[0];
+    *(short *)(o + 0x5db6) = data_020a0dbc[1];
+    *(short *)(o + 0x5db0) = data_020a0dbc[0];
+    *(short *)(o + 0x5db2) = data_020a0dbc[1];
+
+    data_ov006_02142f60 = 0;
+    *(int *)(o + 0xbc) = 0;
+    if ((unsigned int)*(int *)(o + 0xbc) > 0x270e)
+        *(int *)(o + 0xbc) = 0x270e;
+    q = (((*(int *)(o + 0xbc) % 5) << 12)) / 4;
+    *(int *)(o + 0x5d94) =
+        (int)(((long long)(0x1000 - q) * 0x20 + 0x800) >> 12) +
+        (int)(((long long)q * 0x50 + 0x800) >> 12);
+    *(int *)(o + 0x5d98) = *(int *)(o + 0x5d94);
+    *(int *)(o + 0x5d9c) = 0;
+    func_ov006_020cd424(*(int *)(o + 0xbc), *(int *)(o + 0x5d94));
+
+    func_ov006_020d0b04(*(int *)(o + 0xbc));
+    func_ov006_02120ca0();
+    func_ov006_020c8a9c(0, data_ov006_0213fb18[func_ov004_020ad674()]);
+
+    func_ov006_02120a44(o + 0x5d84);
+
+    *(short *)(o + 0x5db8) = 0;
+    *(short *)(o + 0x5dc2) = 0;
+    *(short *)(o + 0x5dbc) =
+        (((int)(((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13)
+            * 0x2d0) >> 12) + 0x2d0;
+    *(short *)(o + 0x5dbe) = 0;
+    *(short *)(o + 0x5dc0) = 1;
+    *(int *)(o + 0x5da4) = 0;
+    *(int *)(o + 0x5da8) = 0;
+
+    func_ov006_02121750(o, 0);
+
+    {
+        char *dst = (char *)func_02054d88();
+        fill = 0;
+        MultiStore16(fill, dst, 0x6000);
+    }
+
+    func_ov006_02121f04(o);
+}

--- a/src/func_ov007_020bc7dc.c
+++ b/src/func_ov007_020bc7dc.c
@@ -1,0 +1,28 @@
+extern int _ZN4cstd3divEii(int a, int b);
+extern void func_ov007_020c9110(void* p);
+extern void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(void* model, void* bca, int frame);
+extern void func_0204531c(void* model, int x);
+
+void func_ov007_020bc7dc(char* c)
+{
+    void* model = *(void**)c;
+    void* p = *(void**)(c + 0x88);
+    void* entry = *(void**)(*(char**)(c + 0x14) + *(short*)((char*)p + 0xc) * 4);
+    int quot = _ZN4cstd3divEii(*(short*)(c + 0x8c) << 12, *(short*)(c + 0x8e));
+
+    if (*(int*)(c + 0x98) != 0)
+        func_ov007_020c9110(*(void**)(c + 0x88));
+
+    p = *(void**)(c + 0x88);
+    if (*(short*)((char*)p + 0xc) != -1)
+        _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(model, entry, *(unsigned short*)((char*)p + 0x10));
+
+    func_0204531c(model, quot);
+
+    if (*(int*)(c + 0x98) == 0)
+        return;
+
+    *(short*)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    if (*(short*)(c + 0x8c) <= 0)
+        *(short*)(c + 0x8c) = 0;
+}

--- a/src/func_ov062_021181a0.c
+++ b/src/func_ov062_021181a0.c
@@ -1,0 +1,24 @@
+extern int _Z14ApproachLinearRiii(int *, int, int);
+extern int _ZN9Animation8FinishedEv(void *);
+extern int RandomIntInternal(int *seed);
+extern void func_ov062_02117994(char *c, int idx);
+extern int data_0209e650;
+
+void func_ov062_021181a0(char *c) {
+    if (*(int*)(c + 0x390) == 2) {
+        _Z14ApproachLinearRiii((int*)(c + 0x98), 0x2000, 0x4cc);
+    } else {
+        _Z14ApproachLinearRiii((int*)(c + 0x98), 0x3000, 0x4cc);
+    }
+    if (_ZN9Animation8FinishedEv(c + 0x350) == 0) return;
+    {
+        unsigned short *p = (unsigned short*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF);
+        *p = (unsigned short)(*p + 1);
+    }
+    {
+        char *b = c + 0x300;
+        *(unsigned short*)(b + 0xc6) =
+            (unsigned short)(((unsigned int)RandomIntInternal(&data_0209e650) >> 0x10) % 70 + 30);
+    }
+    func_ov062_02117994(c, 1);
+}

--- a/src/func_ov064_0211915c.c
+++ b/src/func_ov064_0211915c.c
@@ -1,0 +1,19 @@
+typedef unsigned char u8;
+
+extern int _ZN5Actor13DistToCPlayerEv(void *self);
+
+int func_ov064_0211915c(char *a)
+{
+    switch (*(u8 *)(a + 0xd5)) {
+    case 0:
+        if (*(u8 *)(a + 0xd4) == 3) {
+            if (_ZN5Actor13DistToCPlayerEv(a) < 0x3e8000) {
+                (*(u8 *)(((int)a + 0xd5) & 0xFFFFFFFFFFFFFFFF))++;
+            }
+        }
+        break;
+    case 1:
+        break;
+    }
+    return 1;
+}

--- a/src/func_ov077_02125830.c
+++ b/src/func_ov077_02125830.c
@@ -1,0 +1,26 @@
+extern void func_ov077_02125e94(void *c, int v);
+
+int func_ov077_02125830(char *c)
+{
+    if (((*(int *)(c + 0xb0) & 0x40000) ? 1 : 0) != 0)
+    {
+        char *p = *(char **)(c + 0xd0);
+        int *src = (int *)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(c + 0x5c) = src[0];
+        *(int *)(c + 0x60) = src[1];
+        *(int *)(c + 0x64) = src[2];
+    }
+    {
+        int flags = *(int *)(c + 0xb0);
+        if (((flags & 0x80000) ? 1 : 0) != 0)
+        {
+            func_ov077_02125e94(c, 4);
+        }
+        else if (((flags & 0x20000) ? 1 : 0) == 0 && ((flags & 0x40000) ? 1 : 0) == 0)
+        {
+            *(int *)(c + 0xd0) = 0;
+            func_ov077_02125e94(c, 1);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
32 byte-identical matches, each re-verified via the match oracle (bytes + reloc dests), cut clean from tangosdev/main. Includes Vec3_AsrInPlace and 4 C++ methods. Companion to #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)