### PR TITLE
Add 20 near-miss drafts from 50-target batch (permuter/refine tier)

### DIFF
--- a/src/CrossVec3.c
+++ b/src/CrossVec3.c
@@ -1,0 +1,9 @@
+typedef struct { int x, y, z; } Vec3_Fix12;
+
+void CrossVec3(const Vec3_Fix12 *a, const Vec3_Fix12 *b, Vec3_Fix12 *out)
+{
+    int bz = b->z, ay = a->y, ax = a->x, by = b->y, az = a->z, bx = b->x;
+    out->x = (int)(((long long)ay * bz - (long long)az * by + 0x800) >> 12);
+    out->y = (int)(((long long)az * bx - (long long)ax * bz + 0x800) >> 12);
+    out->z = (int)(((long long)ax * by - (long long)ay * bx + 0x800) >> 12);
+}

--- a/src/func_02042254.c
+++ b/src/func_02042254.c
@@ -1,0 +1,60 @@
+extern char data_02099e6c[];
+extern char data_020a1fc0[];
+extern char data_020a2400[];
+
+extern void *func_0205d23c(void *a, int b);
+extern void func_020580f0(int a);
+extern int func_0205d5e8(char *self, int a1, int a2, int a3, int a4);
+extern void func_0205d3d4(char *a, char *b, int c);
+extern void func_02041d28(char *a, void *b, int c);
+extern int func_0205d4cc(char *self);
+extern void func_02041a94(char *a, void *b);
+extern unsigned int _ZN3IRQ7DisableEv(void);
+extern void _ZN3IRQ7RestoreEj(unsigned int state);
+
+void func_02042254(void) {
+    void *node;
+    int two;
+    int three;
+    int one;
+    unsigned int irq;
+    char *sb;
+    int sl;
+
+    node = func_0205d23c(data_02099e6c, 3);
+    two = 2;
+    three = 3;
+    one = 1;
+    irq = _ZN3IRQ7DisableEv();
+    sb = *(char **)(data_020a2400 + 0x2000 + 0x708);
+    if (sb == 0) {
+        do {
+            if (*(int *)(data_020a1fc0 + 0xc) == 0) {
+                _ZN3IRQ7RestoreEj(irq);
+                return;
+            }
+            func_020580f0(0);
+            sb = *(char **)(data_020a2400 + 0x2000 + 0x708);
+        } while (sb == 0);
+    }
+    _ZN3IRQ7RestoreEj(irq);
+    if (*(int *)(sb + 0x7c) == 1) {
+        func_0205d5e8(sb + 0x38, (int)node, *(int *)(sb + 0x8c),
+                      *(int *)(sb + 0x8c) + *(int *)(sb + 0x90), *(int *)(sb + 0x88));
+        for (sl = 0; sl < 3; sl++) {
+            *(int *)(sb + sl * 4 + 0xa0) = sl * 0x400;
+            func_0205d3d4(sb + 0x38, sb + 0xc0 + sl * 0x400, 0x400);
+        }
+        *(int *)(sb + 0x94) = 0;
+        *(int *)(sb + 0x9c) = two;
+        *(int *)(sb + 0x98) = three;
+        irq = _ZN3IRQ7DisableEv();
+        func_02041d28(data_020a2400, sb, one);
+        _ZN3IRQ7RestoreEj(irq);
+    } else {
+        func_0205d4cc(sb + 0x38);
+        irq = _ZN3IRQ7DisableEv();
+        func_02041a94(data_020a2400, sb);
+        _ZN3IRQ7RestoreEj(irq);
+    }
+}

--- a/src/func_0205c448.c
+++ b/src/func_0205c448.c
@@ -1,0 +1,24 @@
+typedef void (*Fn)(void *self, int a, int b);
+
+struct Obj {
+    char pad0[0x3c];
+    Fn fn;
+};
+
+struct S {
+    char pad0[8];
+    struct Obj *obj;    /* 0x08 */
+    char pad_c[0x1c];
+    int f28;            /* 0x28 */
+    int f2c;            /* 0x2c */
+    char pad30[4];
+    int f34;            /* 0x34 */
+};
+
+void func_0205c448(struct S *self)
+{
+    int old = self->f28;
+    struct Obj *o = self->obj;
+    *(int *)(((long long)(int)((char *)self + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) += self->f34;
+    o->fn(o, self->f2c, old);
+}

--- a/src/func_0205d688.c
+++ b/src/func_0205d688.c
@@ -1,0 +1,27 @@
+extern int func_0205cdf4(void *self, int a);
+extern int func_0205d3f4(void *self);
+
+int func_0205d688(char *self, int a1, int a2, int a3) {
+    int n;
+    int oldpos;
+    oldpos = *(int *)(self + 0x28);
+    n = a2;
+    {
+        int avail = *(int *)(self + 0x24) - oldpos;
+        if (n > avail) n = avail;
+    }
+    *(int *)(self + 0x2c) = a1;
+    if (n < 0) n = 0;
+    *(int *)(self + 0x30) = a2;
+    *(int *)(self + 0x34) = n;
+    if (a3 == 0)
+        *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+    func_0205cdf4(self, 0);
+    if (a3 == 0) {
+        if (func_0205d3f4(self))
+            n = *(int *)(self + 0x28) - oldpos;
+        else
+            n = -1;
+    }
+    return n;
+}

--- a/src/func_02063d3c.c
+++ b/src/func_02063d3c.c
@@ -1,0 +1,13 @@
+extern int func_02064a28(int off, int v, int b);
+
+int func_02063d3c(char *obj, int idx, int off)
+{
+    unsigned char *p = (unsigned char *)(obj + 0x1d4 + idx * 0x68);
+    int mask = (unsigned short)(1 << idx);
+    int ret = 0;
+    if (p[0] != 2) return ret;
+    if (p[1] != 0xa) return ret;
+    ret = func_02064a28(off, mask, p[2]);
+    p[0] = 1;
+    return ret;
+}

--- a/src/func_ov002_020ce5f8.c
+++ b/src/func_ov002_020ce5f8.c
@@ -1,0 +1,67 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern int data_0209f32c;
+extern int data_ov002_0211013c;
+
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* self, void* state);
+extern int func_ov002_020ceb54(char* p);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 snd, void* pos);
+extern void func_ov002_020ce8bc(char* p, int a);
+extern void func_ov002_020ceb7c(char* p);
+extern int _ZNK6Player14GetBodyModelIDEjb(void* self, u32 a, int b);
+extern void MulVec3Mat4x3(void* a, void* b, void* out);
+extern void Vec3_LslInPlace(int* v, int sh);
+extern u32 func_020229f0(int x, int y, int z);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 snd, void* pos);
+
+int func_ov002_020ce5f8(char* p)
+{
+    volatile int vec[3];
+    char* m;
+    int base5;
+    int t;
+
+    t = data_0209f32c - 0x50000;
+    if (*(int*)(p + 0x60) >= t) {
+        if ((*(u8*)(p + 0x6e9) & 1) == 0) {
+            if (*(int*)(p + 0xa8) >= 0) {
+                *(int*)(p + 0x60) = t;
+                *(int*)(p + 0xa8) = 0;
+            }
+        } else {
+            if (t < *(int*)(p + 0x60) - 0xa000) {
+                *(u8*)(p + 0x706) = 0;
+                _ZN6Player11ChangeStateERNS_5StateE(p, &data_ov002_0211013c);
+                return 1;
+            }
+        }
+    }
+
+    if (func_ov002_020ceb54(p) == 0) {
+        if (*(u8*)(p + 0x70c) == 0) {
+            *(u8*)(((long long)(int)(p + 0x70c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            _ZN5Sound9PlayBank0EjRK7Vector3(0x17, p + 0x74);
+            *(int*)(p + 0x628) = 0;
+            func_ov002_020ce8bc(p, *(int*)(p + 0x640));
+        } else {
+            *(u8*)(p + 0x70c) = 0;
+            func_ov002_020ceb7c(p);
+        }
+
+        m = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+        base5 = *(int*)(m + 0x14) + 0x2d0;
+        m = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+        MulVec3Mat4x3((char*)base5 + 0x24, m + 0x1c, (void*)vec);
+        Vec3_LslInPlace((int*)vec, 3);
+        if (vec[1] < data_0209f32c - 0x1e000) {
+            func_020229f0(vec[0], vec[1], vec[2]);
+            if (*(u16*)(p + 0x6a6) == 0) {
+                _ZN5Sound9PlayBank3EjRK7Vector3(0xb, p + 0x74);
+                *(u16*)(p + 0x6a6) = 0xa;
+            }
+        }
+    }
+    return 0;
+}

--- a/src/func_ov002_020d71ec.c
+++ b/src/func_ov002_020d71ec.c
@@ -1,0 +1,53 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct P2 { int a, b; };
+
+extern int _ZNK6Player14GetBodyModelIDEjb(void* self, u32 a, int b);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, int b, u32 d);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* ma, void* file, int a, int b, u32 d);
+
+extern struct P2 data_ov002_0210a34c;
+extern struct P2 data_ov002_0210a084;
+extern struct P2 data_ov002_0210eb88;
+extern u8 data_ov002_020ff0f8[];
+
+void func_ov002_020d71ec(char* p, int arg1)
+{
+    int arr[4];
+    char* model;
+    char* sub;
+    u32 shifted;
+    int val;
+
+    if (arg1 != 2) {
+        model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+        sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+        shifted = ((u32)*(int*)(sub + 8) << 4) >> 0x10;
+        *(struct P2*)&arr[0] = data_ov002_0210a34c;
+        *(struct P2*)&arr[2] = data_ov002_0210a084;
+        _ZN6Player7SetAnimEji5Fix12IiEj(p, arr[arg1], 0x40000000, 0x1000, 0);
+
+        if (*(u8*)(p + 0x714) == 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(p + 0x160), *(void**)((char*)(&arr[2])[arg1] + 4), 0x40000000, 0x1000, 0);
+        }
+
+        if (arg1 == 1) {
+            val = data_ov002_020ff0f8[shifted];
+            model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+            sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+            val = ((u32)val << 0x10) >> 4;
+            *(int*)(sub + 8) = val;
+            *(int*)(*(int*)(p + 0x160) + 0x58) = val;
+        }
+
+        *(u8*)(p + 0x6e3) = 1;
+        return;
+    }
+
+    _ZN6Player7SetAnimEji5Fix12IiEj(p, 0x6c, 0x40000000, -0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(p + 0x160), *(void**)((char*)&data_ov002_0210eb88 + 4), 0x40000000, -0x1000, 0);
+    *(u8*)(p + 0x6e3) = 2;
+    *(u16*)(p + 0x6a4) = 0xa;
+}

--- a/src/func_ov006_020c8680.c
+++ b/src/func_ov006_020c8680.c
@@ -1,0 +1,29 @@
+extern int RandomIntInternal(int* seed);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int b, int c, unsigned int d);
+extern void func_ov006_020c802c(void* p);
+
+extern int data_0209e650;
+extern int data_ov006_0213b01c;
+extern void* data_ov006_02140424;
+
+void func_ov006_020c8680(char* self)
+{
+    unsigned int r;
+    int r5;
+
+    *(short*)(((long long)(int)(self + 0x32)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    if (*(short*)(self + 0x32) != 0) {
+        *(int*)(self + 0x18) = 0x100000;
+        *(int*)(self + 0x24) = 0;
+        return;
+    }
+    *(int*)(self + 0x18) = 0x100000;
+    r = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;
+    *(int*)(self + 0x14) = ((int)r - 0x800) * 0xc0;
+    *(int*)(self + 0x24) = 0;
+    r5 = data_ov006_0213b01c;
+    r = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;
+    *(int*)(self + 0x20) = (int)(((long long)(((int)r - 0x800) << 1) * r5 + 0x800) >> 12);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x4c, data_ov006_02140424, 0x40000000, 0x800, 0);
+    func_ov006_020c802c(self);
+}

--- a/src/func_ov006_020dd658.c
+++ b/src/func_ov006_020dd658.c
@@ -1,0 +1,40 @@
+typedef struct { int a, b; } Pair2;
+
+extern void func_020127a4(int a, int b, int c, int d);
+extern void func_ov004_020adfc4(int a, int b, void* c, void* d, void* e);
+extern int data_ov006_0212e418[];
+
+void func_ov006_020dd658(char* self, int i)
+{
+    int off = i * 0x1c;
+    int oldvel;
+    int v;
+    int posi;
+    char* p;
+    Pair2 s1;
+    Pair2 s2;
+
+    oldvel = *(int*)(self + 0x466c + off);
+    *(int*)(self + 0x4664 + off) = *(int*)(self + 0x4664 + off) + oldvel;
+    *(int*)(self + 0x466c + off) = *(int*)(self + 0x466c + off) + 0x600;
+    if (oldvel <= 0 && *(int*)(self + 0x466c + off) >= 0) {
+        v = *(int*)(self + off + 0x4660) >> 0xc;
+        v = (v - 0x80) >> 1;
+        if (v >= 0x3c) v = 0x3c;
+        if (v <= -0x3c) v = -0x3c;
+        func_020127a4(2, 0xec, 0xffff, v);
+    }
+    p = self + off + 0x4000;
+    posi = *(int*)(self + 0x4664 + off) >> 0xc;
+    if (*(int*)(self + 0x466c + off) < 0) return;
+    if (posi <= data_ov006_0212e418[*(unsigned char*)(p + 0x674)] - 0x20) return;
+    *(char*)(p + 0x675) = 4;
+    *(char*)(p + 0x676) = 0;
+    *(char*)(p + 0x677) = 0;
+    *(unsigned short*)(((long long)(int)(self + 0x4d08)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    s1.b = *(int*)(self + 0x4664 + off);
+    s1.a = *(int*)(p + 0x660);
+    s2.a = 0x6c000;
+    s2.b = -0x80000;
+    func_ov004_020adfc4(1, 0x20, &s1, &s1, &s2);
+}

--- a/src/func_ov006_020e1c68.c
+++ b/src/func_ov006_020e1c68.c
@@ -1,0 +1,35 @@
+typedef unsigned char u8;
+
+extern int data_0213c264;
+extern int data_0213c2ac;
+extern int data_0212e468[];
+extern void func_ov004_020b0104(void* a0, int a1, int a2, int a3, int a4, int a5);
+
+void func_ov006_020e1c68(void* self) {
+    char* p;
+    char* b;
+    int i;
+    int sl, sb;
+    int arrj;
+
+    p = (char*)self;
+    for (i = 0; i < 5; i++) {
+        b = p + 0x4000;
+        if (*(u8*)(b + 0x689) && *(u8*)(b + 0x68a)) {
+            sl = *(int*)(b + 0x660) >> 12;
+            sb = *(int*)(b + 0x664) >> 12;
+            func_ov004_020b0104(&data_0213c264, sl, sb, -1, 1, 0);
+            func_ov004_020b0104(&data_0213c2ac, sl, sb + 8, -1, 2, 0);
+        }
+        p += 0x2c;
+    }
+
+    sl = 5 - *(u8*)((char*)self + 0x4ee6);
+    if (sl < 0) sl = 0;
+    if (sl <= 0) return;
+    for (sb = 0; sb < sl; sb++) {
+        arrj = data_0212e468[sb];
+        func_ov004_020b0104(&data_0213c264, arrj, 0xb0, -1, 1, sb);
+        func_ov004_020b0104(&data_0213c2ac, arrj, 0xb8, -1, 2, sb);
+    }
+}

--- a/src/func_ov006_020ed8a4.c
+++ b/src/func_ov006_020ed8a4.c
@@ -1,0 +1,57 @@
+typedef struct { int a, b; } Pair2;
+
+extern int func_ov006_020ebe6c(void);
+extern int RandomIntInternal(int* seed);
+extern void func_ov006_020ebd7c(int count);
+extern void func_ov006_020ecdb8(void* self, int arg1, int arg2);
+extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
+
+extern short data_ov006_0212e80c[];
+extern short data_ov006_02141fd8;
+extern int data_ov006_0212e820[];
+extern int data_ov006_0213c958;
+extern int data_0209e650;
+extern Pair2 data_ov006_0213c964;
+
+void func_ov006_020ed8a4(char* self)
+{
+    int r0v;
+    unsigned int rnd;
+    int i;
+    int val;
+    char* p;
+    char* ep;
+
+    if (*(int*)(self + 0xbc) < 0xa) {
+        data_ov006_02141fd8 = data_ov006_0212e80c[*(int*)(self + 0xbc)];
+        data_ov006_0213c958 = data_ov006_0212e820[*(int*)(self + 0xbc)];
+    } else {
+        r0v = func_ov006_020ebe6c();
+        data_ov006_02141fd8 = (short)r0v;
+        if (r0v == 3) {
+            data_ov006_0213c958 = 0xf;
+        } else {
+            rnd = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;
+            data_ov006_0213c958 = ((int)(rnd * 3) >> 0xc) + 3;
+        }
+    }
+    if ((unsigned int)*(int*)(self + 0xbc) < 0xa)
+        func_ov006_020ebd7c(2);
+    else
+        func_ov006_020ebd7c(3);
+    ep = self + 0x4678;
+    for (i = 0; i < data_ov006_0213c958; i++) {
+        func_ov006_020ecdb8(ep, i, *(int*)(self + 0xbc));
+        ep += 0x98;
+    }
+    rnd = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;
+    val = (int)(rnd * data_ov006_0213c958) >> 0xc;
+    p = self + 0x4000;
+    *(int*)(p + 0xf60) = (int)(self + 0x4678 + val * 0x98);
+    *(int*)(*(int*)(p + 0xf60) + 0x70) = 0;
+    *(int*)(p + 0x668) = 0x3c;
+    func_ov004_020b0cac(0xd, 0x80, 0x50, 1, -1, 0xd);
+    *(int*)(p + 0x674) = 0x3c;
+    *(char*)(p + 0xf64) = 0;
+    *(Pair2*)(p + 0x660) = data_ov006_0213c964;
+}

--- a/src/func_ov006_020f300c.cpp
+++ b/src/func_ov006_020f300c.cpp
@@ -1,0 +1,69 @@
+//cpp
+struct Obj {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17();
+    virtual void v18(int);
+};
+typedef void (Obj::*PMF)(int);
+
+extern "C" {
+    void func_ov006_020f0044(void *c);
+    void func_ov006_020f10ec(void *c);
+    void func_ov006_020f0274(void *c);
+    void func_ov004_020b0a54(int arg);
+}
+extern PMF data_ov006_02142254[];
+
+extern "C" void func_ov006_020f300c(char *self) {
+    int count;
+    int i;
+    int id;
+    int j;
+    int v;
+    char *p51;
+
+    func_ov006_020f0044(self);
+    func_ov006_020f10ec(self);
+    func_ov006_020f0274(self);
+
+    count = 0;
+    for (i = 0; i < 0x78; i++) {
+        char *p = self + i + 0x5000;
+        if (*(unsigned char *)(p + 0x2ed) != 0 &&
+            (id = *(unsigned char *)(p + 0x1fd)) == 9) {
+            count++;
+            (((Obj *)self)->*data_ov006_02142254[id])(i);
+        }
+    }
+    if (count != 0) return;
+
+    for (j = 0; j < 0x78; j++) {
+        unsigned char *q =
+            (unsigned char *)(((long long)(int)((self + j) + 0x53dd)) & 0xFFFFFFFFFFFFFFFFLL);
+        if (*q == 1) *q = 0;
+    }
+
+    p51 = self + 0x5100;
+    if (*(unsigned short *)(p51 + 0x6a) == 0) return;
+    *(unsigned short *)(p51 + 0x64) = 1;
+    *(unsigned short *)(((long long)(int)(self + 0x516a)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    if (*(short *)(p51 + 0x6a) > 0) return;
+    *(unsigned short *)(p51 + 0x6a) = 0;
+    *(unsigned short *)(p51 + 0x64) = 0;
+
+    if (*(unsigned char *)(self + 0x5459) != 0) {
+        v = *(int *)(self + 0xbc);
+        while (v >= 5) v -= 5;
+        if (v != 4) {
+            ((Obj *)self)->v18(-1);
+        } else {
+            func_ov004_020b0a54(1);
+        }
+    } else {
+        func_ov004_020b0a54(0x12);
+    }
+    *(unsigned char *)(self + 0xc3) = 0;
+}

--- a/src/func_ov006_020f456c.c
+++ b/src/func_ov006_020f456c.c
@@ -1,0 +1,57 @@
+extern void func_ov006_020f3f10(void* c);
+extern void func_ov006_020f3964(void* c);
+extern void func_02012790(int a);
+extern void func_ov006_020f39fc(void* p);
+
+extern unsigned char data_020a0e40;
+extern unsigned char data_020a0de8[];
+extern unsigned char data_020a0de9[];
+
+void func_ov006_020f456c(char* self)
+{
+    int idx;
+    int flag;
+    int inner;
+    int outer;
+    char* entity;
+
+    func_ov006_020f3f10(self);
+    func_ov006_020f3964(self);
+    if (*(unsigned short*)(self + 0x5322) != 0) {
+        (*(unsigned short*)(((long long)(int)(self + 0x5322)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        return;
+    }
+    idx = data_020a0e40;
+    flag = 0;
+    if (data_020a0de8[idx * 4] != 0) {
+        if (data_020a0de9[idx * 4] != 0) flag = 1;
+    }
+    if (flag == 0) return;
+    func_02012790(0x62);
+    if (*(int*)(self + 0xa8) == 0) {
+        if (*(unsigned char*)(self + 0x533c) == 1) {
+            for (outer = 0; outer < 2; outer++) {
+                for (inner = 0; inner < 5; inner++) {
+                    entity = self + (inner + outer * 5 + 2) * 0x18;
+                    if (*(unsigned char*)(entity + 0x51bb) != 0) {
+                        *(unsigned char*)(entity + 0x51bc) = 6;
+                        break;
+                    }
+                }
+            }
+        } else {
+            for (outer = 0; outer < 3; outer++) {
+                for (inner = 0; inner < 4; inner++) {
+                    entity = self + (inner + outer * 4) * 0x18;
+                    if (*(unsigned char*)(entity + 0x51bb) != 0) {
+                        *(unsigned char*)(entity + 0x51bc) = 6;
+                        break;
+                    }
+                }
+            }
+        }
+        *(unsigned char*)(self + 0x533d) = 0;
+        func_ov006_020f39fc(self);
+    }
+    *(int*)(self + 0x5314) = 4;
+}

--- a/src/func_ov006_020fcec4.c
+++ b/src/func_ov006_020fcec4.c
@@ -1,0 +1,38 @@
+extern short data_02082214[];
+extern int func_020124c4(int a, int b, int c, int d);
+
+void func_ov006_020fcec4(char *base, int idx) {
+    int off = idx * 0x38;
+    int a;
+    int t;
+    int x, y;
+
+    *(int *)(base + 0x4660 + off) += *(int *)(base + 0x4668 + off);
+    *(int *)(base + 0x4664 + off) += *(int *)(base + 0x466c + off);
+    *(unsigned short *)(base + 0x4684 + off) += 0x800;
+    if (*(int *)(base + 0x4678 + off) <= 0x30000)
+        *(int *)(base + 0x4678 + off) += 0x800;
+
+    a = *(unsigned short *)(base + 0x4684 + off);
+    a = a >> 4;
+    *(int *)(base + 0x4670 + off) =
+        (int)(((long long)data_02082214[2 * a + 1] * *(int *)(base + 0x4678 + off) + 0x800) >> 12);
+
+    a = *(unsigned short *)(base + 0x4684 + off);
+    a = a >> 4;
+    *(int *)(base + 0x4674 + off) =
+        (int)(((long long)data_02082214[2 * a] * *(int *)(base + 0x4678 + off) + 0x800) >> 12);
+
+    x = (*(int *)(base + 0x4660 + off) + *(int *)(base + 0x4670 + off)) >> 12;
+    y = (*(int *)(base + 0x4664 + off) + *(int *)(base + 0x4674 + off)) >> 12;
+
+    *(int *)(base + 0x467c + off) = func_020124c4(*(int *)(base + 0x467c + off), 2, 0x187, 0);
+
+    t = 0;
+    if (x >= 0x130 || x <= -0x30) t++;
+    if (y >= 0xf0 || y <= -0x110) t++;
+    if (t != 0) {
+        *(base + 0x468c + off) = 0;
+        *(base + 0x468d + off) = 0;
+    }
+}

--- a/src/func_ov006_020fe750.c
+++ b/src/func_ov006_020fe750.c
@@ -1,0 +1,39 @@
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern void func_ov006_020fbbe8(void* self);
+extern void func_ov006_020fbd38(void* self);
+
+void func_ov006_020fe750(char* self, int i)
+{
+    int off = i * 0x38;
+    int oldS;
+    int qi;
+    int pi;
+
+    *(int*)(self + 0x4ed8 + off) += *(int*)(self + 0x4ee0 + off);
+    *(int*)(self + 0x4edc + off) += *(int*)(self + 0x4ee4 + off);
+    *(int*)(self + 0x4efc + off) += 0x10;
+    oldS = *(int*)(self + 0x4ee4 + off);
+    *(int*)(self + 0x4ee4 + off) = oldS + *(int*)(self + 0x4efc + off);
+    if (*(int*)(self + 0x4ee4 + off) >= 0x8000)
+        *(int*)(self + 0x4ee4 + off) = 0x8000;
+    *(unsigned short*)(self + off + 0x4f08) =
+        _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(self + 0x4ee4 + off) >> 0xc,
+                                    *(int*)(self + 0x4ee0 + off) >> 0xc);
+    if (oldS < 0) {
+        if (*(int*)(self + 0x4ee4 + off) >= 0)
+            *(unsigned short*)(self + off + 0x4f0a) = 0x40;
+    }
+    if (*(unsigned short*)(self + off + 0x4f0a) != 0) {
+        (*(unsigned short*)(self + 0x4f0a + off))--;
+        if ((short)*(unsigned short*)(self + 0x4f0a + off) <= 0)
+            *(unsigned char*)(self + off + 0x4f0d) = 4;
+    }
+    qi = *(int*)(self + 0x4edc + off) >> 0xc;
+    if (qi <= -0x120) *(unsigned char*)(self + off + 0x4f0d) = 4;
+    if (qi >= 0xd0) *(unsigned char*)(self + off + 0x4f0d) = 4;
+    pi = *(int*)(self + 0x4ed8 + off) >> 0xc;
+    if (pi >= 0x140 || pi <= -0x40) *(unsigned char*)(self + off + 0x4f0d) = 4;
+    func_ov006_020fbbe8(self);
+    if (*(unsigned char*)(self + 0x5c2f) == 0) return;
+    func_ov006_020fbd38(self);
+}

--- a/src/func_ov006_02100bac.c
+++ b/src/func_ov006_02100bac.c
@@ -1,0 +1,62 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern int* data_0213db9c[];
+extern s16 data_02082214[];
+extern int cstd_atan2(int, int);
+extern void func_ov006_020ff4ec(void* self);
+
+typedef struct { int v; int _pad[15]; } C4;    /* stride 0x40 */
+typedef struct { u16 v; u16 _pad[31]; } C2;     /* stride 0x40 */
+
+/* pointer form: p = self + idx*0x40 */
+#define PF5290 (*(u16*)(p + 0x5290))
+#define PF5292 (*(u16*)(p + 0x5292))
+#define SF5292 (*(s16*)(p + 0x5292))
+#define PF5260 (*(int*)(p + 0x5260))
+#define PF5264 (*(int*)(p + 0x5264))
+#define PF5270 (*(int*)(p + 0x5270))
+#define PF5296 (*(u8*)(p + 0x5296))
+#define V5668  (*(int*)((char*)self + 0x5668))
+
+/* array form (read-modify-write): base + idx*0x40 scaled */
+#define AF5292 (((C2*)((char*)self + 0x5292))[idx].v)
+#define AF5260 (((C4*)((char*)self + 0x5260))[idx].v)
+#define AF5264 (((C4*)((char*)self + 0x5264))[idx].v)
+#define AF5270 (((C4*)((char*)self + 0x5270))[idx].v)
+
+void func_ov006_02100bac(void* self, int idx) {
+    char* p = (char*)self + idx * 0x40;
+    int base;
+    int dx, dy;
+
+    if (PF5292 != 0) {
+        AF5292--;
+        if (SF5292 < 0) SF5292 = 0;
+        return;
+    }
+
+    base = data_0213db9c[V5668][idx];
+    PF5290 = (u16)cstd_atan2(base - (PF5264 >> 12), 0x80 - (PF5260 >> 12));
+
+    AF5260 += (int)(((long long)data_02082214[(PF5290 >> 4) * 2 + 1] * PF5270 + 0x800) >> 12);
+    AF5264 += (int)(((long long)data_02082214[(PF5290 >> 4) * 2] * PF5270 + 0x800) >> 12);
+    AF5270 += 0x100;
+
+    dx = (PF5260 >> 12) - 0x80;
+    dy = (PF5264 >> 12) - base;
+    if (dx < -3) return;
+    if (dx > 3) return;
+    if (dy < -3) return;
+    if (dy > 3) return;
+
+    PF5260 = 0x80000;
+    PF5264 = base << 12;
+    PF5296 = 0xd;
+    func_ov006_020ff4ec(self);
+    PF5292 = 0x40;
+    if (idx & 1) {
+        AF5292 += 0x20;
+    }
+}

--- a/src/func_ov006_0210ff1c.c
+++ b/src/func_ov006_0210ff1c.c
@@ -1,0 +1,41 @@
+struct S_0210ff1c {
+    char _0[8];
+    int f8;   /* 0x8 */
+    int fc;   /* 0xc */
+    char _10[0x34 - 0x10];
+    struct { int a; int b; } arr[3]; /* 0x34: a=0x34, b=0x38, stride 8 */
+};
+
+extern void* data_021379dc;
+extern void* data_021379e8;
+extern void* data_02137a00;
+extern void* data_021379f4;
+extern void func_ov004_020afdd0(void*, int, int, int, int);
+
+void func_ov006_0210ff1c(void* self) {
+    struct S_0210ff1c* s = (struct S_0210ff1c*)self;
+    int i;
+    int x;
+    int xo;
+
+    for (i = 0, x = 0; i < 3; i++, x += 0x18) {
+        func_ov004_020afdd0(data_021379dc,
+            (x - 0x18) + (s->f8 >> 12),
+            s->fc >> 12, -1, 2);
+    }
+    for (i = 0, x = 0; i < 3; i++, x += 0x18) {
+        xo = x - 0x18;
+        func_ov004_020afdd0(data_021379e8,
+            (s->f8 >> 12) + (s->arr[i].a >> 12) + xo,
+            (s->fc >> 12) + (s->arr[i].b >> 12), -1, 3);
+        func_ov004_020afdd0(data_02137a00,
+            (s->f8 >> 12) + (s->arr[i].a >> 12) + xo,
+            (s->fc >> 12) + (s->arr[i].b >> 12) - 0x10, -1, 3);
+        func_ov004_020afdd0(data_021379f4,
+            (s->f8 >> 12) + (s->arr[i].a >> 12) + xo,
+            (s->fc >> 12) + (s->arr[i].b >> 12) - 0x20, -1, 3);
+        func_ov004_020afdd0(data_021379e8,
+            (s->f8 >> 12) + (s->arr[i].a >> 12) + xo,
+            (s->fc >> 12) + (s->arr[i].b >> 12) - 0x30, -1, 3);
+    }
+}

--- a/src/func_ov062_021164e8.c
+++ b/src/func_ov062_021164e8.c
@@ -1,0 +1,36 @@
+//cpp
+typedef int Fix12;
+struct BCA_File;
+struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+extern void *data_ov062_0211de00[];
+extern char data_ov062_0211dec0[];
+extern "C" void func_ov062_02116cd8(void *c, void *p);
+
+extern "C" int func_ov062_021164e8(char *c) {
+    int t;
+    int flags;
+    if (*(unsigned char *)(c + 0x3e5) == 0) {
+        t = (*(int *)(c + 0xb0) & 0x4000) != 0;
+        if (t != false) {
+            ((ModelAnim *)(c + 0x300))->SetAnim((BCA_File *)data_ov062_0211de00[1], 0, 0x1000, 0);
+        }
+    }
+    *(unsigned char *)(c + 0x3e5) = 1;
+    flags = *(int *)(c + 0xb0);
+    t = (flags & 0x400) != 0;
+    if (t != false) goto after;
+    t = (flags & 0x2000) != 0;
+    if (t != false) goto after;
+    t = (flags & 0x100) != 0;
+    if (t != false) goto after;
+    *(short *)(c + 0x94) = *(short *)(*(char **)(c + 0x3f8) + 0x8e);
+    *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    func_ov062_02116cd8(c, data_ov062_0211dec0);
+after:
+    if (*(int *)(*(char **)(c + 0x3f8) + 8) == 2) {
+        *(int *)(c + 0xa8) = 0x50000;
+        *(int *)(c + 0x98) = 0x14000;
+    }
+    *(int *)(c + 0x3f8) = 0;
+    return 1;
+}

--- a/src/func_ov066_021184e0.c
+++ b/src/func_ov066_021184e0.c
@@ -1,0 +1,42 @@
+extern int func_ov066_021168ec(void *c);
+extern void func_ov066_021162e8(void *c);
+extern void func_ov066_0211632c(void *c);
+extern void func_ov066_02116ac4(void *c, int strength);
+extern unsigned char data_ov066_0211ae0c;
+
+int func_ov066_021184e0(char *c) {
+    int m;
+    unsigned char v;
+    if (func_ov066_021168ec(c) != 0 && func_ov066_021168ec(c) != 4) {
+        *(int *)(c + 0xb0) = 0;
+        func_ov066_021162e8(c);
+        return 1;
+    }
+    func_ov066_0211632c(c);
+    switch (*(int *)(c + 0x4a0)) {
+    case 0:
+        if (data_ov066_0211ae0c == *(int *)(c + 0x49c)) {
+            *(int *)(c + 0x9c) = -0x14000;
+            *(int *)(c + 0xa8) = 0x64000;
+            *(int *)(((long long)(int)(c + 0x4a0)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        }
+        break;
+    case 1:
+        if (*(int *)(c + 0x9c) != 0) {
+            if (*(int *)(c + 0x4a8) >= *(int *)(c + 0x60)) {
+                *(int *)(c + 0x60) = *(int *)(c + 0x4a8);
+                *(int *)(c + 0xa8) = 0;
+                *(int *)(c + 0x9c) = 0;
+                func_ov066_02116ac4(c, 0x7d0000);
+                m = *(int *)(c + 0x49c);
+                v = data_ov066_0211ae0c;
+                if (v & m) {
+                    data_ov066_0211ae0c = v ^ m;
+                }
+                *(int *)(c + 0x4a0) = 0;
+            }
+        }
+        break;
+    }
+    return 1;
+}

--- a/src/func_ov085_0212c074.cpp
+++ b/src/func_ov085_0212c074.cpp
@@ -1,0 +1,50 @@
+//cpp
+extern "C" {
+
+struct Node { char pad[0x24]; unsigned int count; };
+struct Pair { struct Node *node; char *item; };
+typedef void (*Fn)(void *a, void *b);
+
+extern signed char data_0209f2f8;
+extern signed char data_02092120;
+extern void func_ov085_0212c150(void *self);
+
+int func_ov085_0212c074(char *self)
+{
+    unsigned int i;
+    struct Node *node;
+    char *item;
+    struct Pair *p;
+    int b;
+
+    if (*(unsigned char *)(self + 0x428) == 1) return 1;
+
+    b = (*(int *)(self + 0xb0) & 0x40000) != 0;
+    if (b) return 1;
+
+    *(int *)(self + 0x80) = 0x1500;
+    *(int *)(self + 0x88) = *(int *)(self + 0x80);
+    *(int *)(self + 0x84) = *(int *)(self + 0x88);
+
+    p = (struct Pair *)(((long long)(int)(self + 0x308)) & 0xFFFFFFFFFFFFFFFFLL);
+    i = 0;
+    node = p->node;
+    item = p->item;
+    for (; i < node->count; i++) {
+        *(int *)(item + 0x20) = *(int *)(self + 0x468);
+        item += 0x30;
+    }
+
+    if (data_0209f2f8 == 5 && data_02092120 == 3) {
+        func_ov085_0212c150(self);
+    }
+
+    {
+        char *o = (char *)(((long long)(int)(self + 0x300)) & 0xFFFFFFFFFFFFFFFFLL);
+        Fn fn = *(Fn *)(*(char **)o + 0x14);
+        fn(o, self + 0x80);
+    }
+    return 1;
+}
+
+}


### PR DESCRIPTION
Compile but not byte-exact: pure register-coloring swaps, scheduling reorders, and materialized-base / first-access-fold walls that survived decl/statement/store-order permutation, u64-mask laundering, and opt_common_subs / opt_propagation sweeps.