### PR TITLE
Match ov023 func_ov023_021113b0

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -42,6 +42,7 @@ it is fair to take over: ping the claimant first.
 | ov001 func_ov001_020ab110 (0x020ab110, size 0x118) | lunavyqo | 2026-07-06 | done - verified byte-identical |
 | ov017 func_ov017_021112c4 (0x021112c4-0x021113c0) | lunavyqo | 2026-07-07 | done - verified byte-identical |
 | ov014 func_ov014_02111a6c (0x02111a6c, size 0x84) | lunavyqo | 2026-07-08 | done - verified byte-identical |
+| ov023 func_ov023_021113b0 (0x021113b0-0x02111670) | lunavyqo | 2026-07-09 | done - verified byte-identical, PR #159 open; API claim kept active |
 | ov043 small wrappers: func_ov043_021114b0, 021115cc, 021115e0, 02111744, 02111758 | lunavyqo | 2026-07-08 | done - verified byte-identical, PR open |
 | ov035 func_ov035_0211195c (0x0211195c-0x02111a98) | lunavyqo | 2026-07-08 | done - verified byte-identical |
 | ov013 func_ov013_021112a8 (0x021112a8-0x0211133c) | lunavyqo | 2026-07-08 | done - verified byte-identical |

--- a/src/func_ov023_021113b0.c
+++ b/src/func_ov023_021113b0.c
@@ -1,0 +1,94 @@
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned char u8;
+
+struct Vec3 { int x, y, z; };
+
+extern int _ZN5Actor13DistToCPlayerEv(char *self);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, struct Vec3 *v);
+extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *self, struct Vec3 *v, int f);
+extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+extern void func_0200fa04();
+extern void func_ov023_02111308(char *t);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
+extern int func_ov023_0211124c(char *c);
+extern short data_02082214[];
+
+int func_ov023_021113b0(char *c)
+{
+    switch (*(u8 *)(c + 0x322)) {
+    case 0:
+        if (_ZN5Actor13DistToCPlayerEv(c) < 0x3e8000) {
+            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x43, (struct Vec3 *)(c + 0x74));
+        }
+        break;
+    case 1:
+        *(s16 *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF) -= 0x40;
+        if (*(s16 *)(c + 0x31e) <= -0x1000) {
+            *(s16 *)(c + 0x31e) = -0x1000;
+        }
+        *(s16 *)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF) += *(s16 *)(c + 0x31e);
+        if (*(s16 *)(c + 0x8c) <= -0x4000) {
+            struct Vec3 off;
+            struct Vec3 pos;
+            int tmp[3];
+            int s0, s1;
+
+            *(s16 *)(c + 0x8c) = -0x4000;
+            *(s16 *)(c + 0x31e) = 0;
+            *(s16 *)(c + 0x320) = 0;
+
+            pos.x = *(int *)(c + 0x5c);
+            pos.y = *(int *)(c + 0x60);
+            pos.z = *(int *)(c + 0x64);
+            _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, &pos, 0x4000000);
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x44, (struct Vec3 *)(c + 0x74));
+
+            s0 = data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2];
+            off.x = (int)(((long long)s0 * -0x190000 + 0x800) >> 12);
+            s1 = data_02082214[(*(u16 *)(c + 0x8e) >> 4) * 2 + 1];
+            off.z = (int)(((long long)s1 * -0x190000 + 0x800) >> 12);
+            AddVec3(&off, (struct Vec3 *)(c + 0x5c), &off);
+
+            tmp[0] = off.x;
+            tmp[1] = off.y;
+            tmp[2] = off.z;
+            func_0200fa04(c, tmp, 1);
+
+            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+        }
+        break;
+    case 2:
+        if (*(u16 *)(c + 0x320) >= 0x3c) {
+            u8 *st = (u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF);
+            *(s16 *)(c + 0x31e) = 0x80;
+            (*st)++;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x45, (struct Vec3 *)(c + 0x74));
+        } else {
+            (*(u16 *)(((int)c + 0x320) & 0xFFFFFFFFFFFFFFFF))++;
+        }
+        break;
+    case 3:
+        *(s16 *)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF) += *(s16 *)(c + 0x31e);
+        if (*(s16 *)(c + 0x8c) >= 0) {
+            *(s16 *)(c + 0x31e) = 0;
+            *(s16 *)(c + 0x8c) = 0;
+            *(s16 *)(c + 0x320) = 0;
+            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+        }
+        break;
+    case 4:
+        if (*(u16 *)(c + 0x320) >= 0x3c) {
+            *(u8 *)(c + 0x322) = 0;
+        } else {
+            (*(u16 *)(((int)c + 0x320) & 0xFFFFFFFFFFFFFFFF))++;
+        }
+        break;
+    }
+
+    func_ov023_02111308(c);
+    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    func_ov023_0211124c(c);
+    return 1;
+}


### PR DESCRIPTION
## Summary
- Match `func_ov023_021113b0` in `ov023` (`0x021113b0`, size `0x2c0`).
- Add the C source for the matched function.

## Verification
- `/Users/mrbebra/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 tools/match.py --c src/func_ov023_021113b0.c --func func_ov023_021113b0 --addr 0x21113b0 --size 0x2c0 --version 1.2/sp2p3 --module ov023 --brief`
- `/Users/mrbebra/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 tools/linkcheck.py --name func_ov023_021113b0 --addr 0x21113b0 --size 0x2c0 --module ov023`
