### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov024_02111350.c
+++ b/src/func_ov024_02111350.c
@@ -1,38 +1,39 @@
-//cpp
-// NONMATCHING: different op / idiom (div=34). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef short s16;
-struct V3_16f;
-extern "C" {
-int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+typedef unsigned short u16;
+
+#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+
+extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int c, int d, int e, void* v, void* cb);
 extern short data_02082214[];
 
+#pragma opt_common_subs off
+
 void func_ov024_02111350(char* c){
-    char* g = c + 0x300;
-    int a1 = ((int)((unsigned int)*(unsigned short*)(g + 0xb2) << 0x1e)) >> 0x10;
-    *(int*)(c + 0x5c) = (short)data_02082214[((unsigned short)a1 >> 4) * 2] * (short)0x28 + *(int*)(c + 0x3a0);
-    if ((unsigned short)*(unsigned short*)(g + 0xb2) < 0x3c) {
-        int a2 = ((int)((unsigned int)*(unsigned short*)(g + 0xb2) << 0x1d)) >> 0x10;
-        int m = (short)data_02082214[((unsigned short)a2 >> 4) * 2] * (short)0xa;
+    s16* tbl = (s16*)(int)M(data_02082214);
+    int a1 = ((int)((unsigned int)*(u16*)(c + 0x300 + 0xb2) << 0x1e)) >> 0x10;
+    *(int*)(c + 0x5c) = tbl[((u16)a1 >> 4) * 2] * (s16)0x28 + *(int*)(c + 0x3a0);
+    if ((u16)*(u16*)(c + 0x300 + 0xb2) < 0x3c) {
+        int a2 = ((int)((unsigned int)*(u16*)(c + 0x300 + 0xb2) << 0x1d)) >> 0x10;
+        int m = tbl[((u16)a2 >> 4) * 2] * (s16)0xa;
         if (m < 0) m = -m;
         *(int*)(c + 0x60) = *(int*)(c + 0x3a4) + m;
     } else {
-        short* w = (short*)(c + 0x3b0);
+        short* w = (short*)M(c + 0x3b0);
+        int* q;
         *w = *w + 0x100;
-        if (*(short*)(g + 0xb0) > 0x1800) {
-            *(short*)(g + 0xb0) = 0x1800;
+        if (*(short*)(c + 0x300 + 0xb0) > 0x1800) {
+            *(short*)(c + 0x300 + 0xb0) = 0x1800;
             *(int*)(c + 0xa8) = 0x5000;
         }
-        *(short*)(c + 0x8e) = *(short*)(c + 0x8e) + *(short*)(g + 0xb0);
-        *(int*)(c + 0x60) = *(int*)(c + 0x60) + *(int*)(c + 0xa8);
+        *(short*)M(c + 0x8e) += *(short*)(c + 0x300 + 0xb0);
+        q = (int*)M(c + 0x60);
+        *q = *q + *(int*)(c + 0xa8);
     }
     *(int*)(c + 0x3ac) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(unsigned int*)(c + 0x3ac), 0x23, *(int*)(c + 0x5c), *(int*)(c + 0x60),
         *(int*)(c + 0x64), (void*)0, (void*)0);
-    if (*(unsigned short*)(c + 0x3b2) == 0x96) {
+    if (*(u16*)(c + 0x3b2) == 0x96) {
         *(unsigned char*)(c + 0x3b7) = 2;
     }
-}
 }

--- a/src/func_ov024_02111568.c
+++ b/src/func_ov024_02111568.c
@@ -1,0 +1,43 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* actor, void* pt);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bank, void* pos);
+extern void func_ov024_02111350(char* c);
+extern void func_ov024_021112c0(char* c);
+extern void func_ov024_021114c4(char* c);
+extern void func_ov024_02111480(char* c);
+
+int func_ov024_02111568(char* c)
+{
+    u8 state = *(u8*)(c + 0x3b7);
+    switch (state) {
+    case 0:
+        if (*(u8*)(c + 0x3b6) == 4) {
+            (*(u8*)(((long long)(int)(c + 0x3b7)) & 0xffffffffffffffffLL))++;
+        }
+        break;
+    case 1:
+        _ZN5Sound15PlaySecretSoundEP5ActorPt(c, (void*)(c + 0x3b4));
+        if (*(u16*)(c + 0x3b2) == 0) {
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x4b, (void*)(c + 0x74));
+        }
+        func_ov024_02111350(c);
+        break;
+    case 2:
+        if (_ZN5Sound15PlaySecretSoundEP5ActorPt(c, (void*)(c + 0x3b4))) {
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x4c, (void*)(c + 0x74));
+            func_ov024_021112c0(c);
+        } else {
+            func_ov024_02111350(c);
+        }
+        break;
+    }
+    (*(u16*)(((long long)(int)(c + 0x3b2)) & 0xffffffffffffffffLL))++;
+    if (state != *(u8*)(c + 0x3b7)) {
+        *(u16*)(c + 0x3b2) = 0;
+    }
+    func_ov024_021114c4(c);
+    func_ov024_02111480(c);
+    return 1;
+}


### PR DESCRIPTION
ov024: func_ov024_02111568 (0x100), func_ov024_02111350 (0x130). Both verified byte-exact by the match oracle at 1.2/sp2p3.

func_ov024_02111350 was previously committed as a //cpp NONMATCHING draft ("not byte-matchable from C"); that verdict was wrong. Cracked via #pragma opt_common_subs off (EBB-local CSE -> per-EBB base rematerialization)
+ u64-mask laundering of the RMW sites and of the pooled table-global's address to fix its register class.


Claude-Session: https://claude.ai/code/session_01HNsk5PRb9yknbWYxXfC9R8