### PR TITLE
Match func_0205d304, func_0206df90 via refine batch

### DIFF
--- a/src/func_0205d304.c
+++ b/src/func_0205d304.c
@@ -1,23 +1,21 @@
-// NONMATCHING: loop-setup scheduling: `shift=0` (mov r3,lr) is emitted before the `while(i<n)` entry guard, but the ROM schedules it after the guard. Declaration order and loop-form permutations do not move it. (div=3)
-/* func_0205d304 at 0x0205d304 (arm9), size 0x64
- * Compiler mwccarm 1.2/sp2p3, flags:
- * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
 int func_0205d304(unsigned char* s, int n)
 {
     int result = 0;
     if (n <= 3) {
         int i = 0;
-        int shift = 0;
-        while (i < n) {
-            unsigned int c = s[i];
-            unsigned int t;
-            if (c == 0) break;
-            t = c - 0x41;
-            if (t <= 0x19) t = t + 0x61;
-            else t = t + 0x41;
-            result |= t << shift;
-            i++;
-            shift += 8;
+        if (n > 0) {
+            int shift = 0;
+            do {
+                unsigned int c = s[i];
+                unsigned int t;
+                if (c == 0) break;
+                t = c - 0x41;
+                if (t <= 0x19) t = t + 0x61;
+                else t = t + 0x41;
+                i++;
+                result |= t << shift;
+                shift += 8;
+            } while (i < n);
         }
     }
     return result;

--- a/src/func_0206df90.c
+++ b/src/func_0206df90.c
@@ -1,6 +1,3 @@
-// NONMATCHING: extra logic (you do more) (div=2). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 
 void func_0206e068(int a, int *b);
 void func_0206e030(void *p);
@@ -22,12 +19,12 @@ int func_0206df90(char *thiz, int *out)
     {
       *out = *((int *) (thiz + 0x28));
     }
-    new_var = thiz + 0x18;
     if (r != 0)
     {
       return r;
     }
-    *((int *) new_var) += *((int *) (thiz + 0x28));
+    new_var = thiz + 0x18;
+    *(int *)(((unsigned long long)(int)new_var) & 0xFFFFFFFFFFFFFFFFULL) += *((int *) (thiz + 0x28));
   }
   func_0206e030(thiz);
   return 0;


### PR DESCRIPTION
## Summary
- `func_0205d304`: loop rotation — `while(i<n)` restructured into an `if(n>0)` guard + `do{...}while`, with `i++` reordered before the shift-accumulate to match the ROM's schedule (was NONMATCHING div=3, scheduling residual).
- `func_0206df90`: moved a tail-increment after the `r!=0` early-return, then applied u64-mask laundering on the resulting pointer to force base rematerialization shared across the load/store (was NONMATCHING div=2).

Both came out of a `crackloop.py refine --max-div 6` batch against the committed near-miss DB.

## Verification
- Both byte-MATCH (`verify_one.py`) with 0 divergence.
- Link-gate VERIFIED (no reloc destination issues).
- src-only diff: 2 files changed, +16/-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqGpe2ragHjV8pRDLtTweE