### PR TITLE
Match 11 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/LZ77UnCompReadByCallbackWrite16bit.c
+++ b/src/LZ77UnCompReadByCallbackWrite16bit.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void LZ77UnCompReadByCallbackWrite16bit(void) {
+    swi 0x12
+    bx lr
+}

--- a/src/VBlankIntrWait.c
+++ b/src/VBlankIntrWait.c
@@ -1,0 +1,10 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void VBlankIntrWait(void) {
+    mov r2, #0
+    swi 0x05
+    bx lr
+}

--- a/src/WaitByLoop.c
+++ b/src/WaitByLoop.c
@@ -1,0 +1,9 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
+// in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
+// switch, etc.), so there is no C to decompile it to -- the asm block is the
+// faithful source. Counts as matched (asm-primitive policy), not a C transcription.
+#pragma thumb on
+asm void WaitByLoop(void) {
+    swi 0x03
+    bx lr
+}

--- a/src/func_0203842c.cpp
+++ b/src/func_0203842c.cpp
@@ -1,0 +1,86 @@
+//cpp
+
+extern "C" {
+int func_020393b4(void *p);
+int func_020393ac(void *p);
+int func_0203939c(void *p);
+int func_0203938c(void *p);
+int func_02035354(void *a, void *b);
+void func_02037fec(void *c, int p1, int p2, int p3, void *e);
+int Vec3_Dist(const void *a, const void *b);
+}
+
+extern void *data_020a0c80[];
+
+class C {
+public:
+    virtual int v0();
+    virtual int v1();
+    virtual int v2();
+    virtual int v3();
+    virtual int v4();
+    virtual int v5();
+    virtual int v6();
+    virtual int v7(void *arg);
+};
+
+struct Vec3 { int x, y, z; };
+
+struct Info {
+    char pad0[0x5c];
+    Vec3 pos;
+    char pad1[0xb0 - 0x68];
+    int pB0;
+    int pB4;
+    int pB8;
+};
+
+extern "C" int func_0203842c(char *self)
+{
+    int result = 0;
+    int i;
+    C *o;
+    Info *info;
+    int m;
+    char *base;
+    int threshold;
+
+    char *p64 = self + 0x64;
+    base = p64 + 4;
+    threshold = *(int *)(p64 + 0x10);
+    for (i = 1; i < 0x18; i++) {
+        o = (C *)data_020a0c80[i];
+        if (o == 0) continue;
+        info = (Info *)func_020393b4(o);
+        if (func_02035354(self, info) != 0) continue;
+        if (info != 0) {
+            int active = (info->pB0 & 2) ? 1 : 0;
+            if (active != 0) {
+                Vec3 v;
+                Vec3 *src = (Vec3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                v.x = src->x;
+                v.y = src->y;
+                v.z = src->z;
+                m = func_0203939c(o);
+                if (m == -0x1000) {
+                    int b4 = info->pB4;
+                    int b8 = info->pB8;
+                    v.y += b4;
+                    m = b8 << 3;
+                } else {
+                    v.y += func_0203938c(o);
+                }
+                if (Vec3_Dist(base, &v) > m + threshold)
+                    continue;
+            }
+        }
+        {
+            int mask = o->v7(self);
+            if (mask != 0) {
+                func_02037fec(self + 0x10, i, func_020393ac(o), func_020393b4(o), o);
+                result = 1;
+            }
+        }
+    }
+    return result;
+}

--- a/src/func_0206d940.c
+++ b/src/func_0206d940.c
@@ -1,0 +1,32 @@
+extern void _ZN4cstd8__assertEPKcPKcPKci(const char *, const char *, const char *, int);
+extern const char data_020868fc;
+extern const char data_02086a30;
+
+struct Elem {
+    int a, b, c, d;
+};
+
+struct Arr {
+    unsigned int count;
+    int pad[3];
+    struct Elem elems[1];
+};
+
+void func_0206d940(struct Arr *s, unsigned int index) {
+    unsigned int n;
+    int i;
+    if (index > s->count) {
+        _ZN4cstd8__assertEPKcPKcPKci(&data_020868fc, (const char *)0x42, &data_02086a30, 1);
+    }
+    n = s->count;
+    if (n - index != 0) {
+        i = (int)n - 1;
+        goto test;
+    loop:
+        s->elems[i + 1] = s->elems[i];
+        i--;
+    test:
+        if (i >= (int)index) goto loop;
+    }
+    s->count++;
+}

--- a/src/func_ov002_020b9450.cpp
+++ b/src/func_ov002_020b9450.cpp
@@ -1,0 +1,26 @@
+//cpp
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
+extern int func_02012694(unsigned int id, const Vector3 *v);
+extern char *data_0209f318;
+}
+
+extern "C" void func_ov002_020b9450(char *c);
+void func_ov002_020b9450(char *c)
+{
+    Vector3 pos;
+    int x = *(int *)(c + 0x5c);
+    int y = *(int *)(c + 0x60) + 0x82000;
+    int z = *(int *)(c + 0x64);
+    ((int *)&pos)[0] = x;
+    ((int *)&pos)[1] = y;
+    ((int *)&pos)[2] = z;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(
+        0x102, ((int *)&pos)[0], ((int *)&pos)[1], ((int *)&pos)[2]);
+    func_02012694(0x7d, (const Vector3 *)(c + 0x74));
+    *(int *)(c + 0x3c4) = 0;
+    *(short *)(c + 0x8e) = *(short *)(data_0209f318 + 0x17c);
+    *(char *)(c + 0x3cb) = 0x1b;
+}

--- a/src/func_ov077_021242f0.c
+++ b/src/func_ov077_021242f0.c
@@ -1,0 +1,25 @@
+extern void func_ov077_0212478c(void *c, int v);
+
+int func_ov077_021242f0(char *c)
+{
+    if (((*(int *)(c + 0xb0) & 0x40000) ? 1 : 0) != 0)
+    {
+        char *p = *(char **)(c + 0xd0);
+        int *src = (int *)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(c + 0x5c) = src[0];
+        *(int *)(c + 0x60) = src[1];
+        *(int *)(c + 0x64) = src[2];
+    }
+    {
+        int flags = *(int *)(c + 0xb0);
+        if (((flags & 0x80000) ? 1 : 0) != 0)
+        {
+            func_ov077_0212478c(c, 3);
+        }
+        else if (((flags & 0x20000) ? 1 : 0) == 0 && ((flags & 0x40000) ? 1 : 0) == 0)
+        {
+            func_ov077_0212478c(c, 0);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
Matched 11 functions byte-identical to the ROM (relocation-aware) at **mwccarm 1.2/sp2p3**. `src/` additions only.

**arm9**
- `VBlankIntrWait`, `WaitByLoop`, `LZ77UnCompReadByCallbackWrite16bit` — Thumb SVC asm-primitives
- `_ZThn80_N9AnimationD0Ev`, `_ZThn80_N9AnimationD1Ev` — offset-80 this-adjusting virtual-destructor thunks
- `func_02063d3c` — bitmask dispatch
- `func_0206d940` — array element insert with bounds assert
- `func_0203842c` — collision scan loop

**ov077**
- `func_ov077_021242f0` — flag-gated field copy + dispatch

**ov002**
- `func_ov002_020b9450` — particle spawn
- `func_ov002_020d5ab4` — actor spawn

Each file verified locally with the match oracle (0 mismatches; only relocs wildcarded). The `validate` bot's per-file table is the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFWPXyXZ3BSs5D4HALND7z
