### PR TITLE
tangos/glm: 9 verified matches (salvaged from #167)

### DIFF
--- a/src/_ZN3Fog4InitEt5Fix12IiES1_.cpp
+++ b/src/_ZN3Fog4InitEt5Fix12IiES1_.cpp
@@ -1,0 +1,30 @@
+//cpp
+extern "C" void _ZN3Fog4InitEt5Fix12IiES1_(char* self, unsigned short color, int nearv, int farv) {
+    int dist;
+    int step;
+    int i;
+    char* p;
+
+    *(unsigned char*)(self + 0x20) = 1;
+    dist = 0x28000 - (nearv << 4);
+    *(unsigned short*)(self + 0x24) = color;
+    *(unsigned char*)(self + 0x21) = 6;
+    *(unsigned short*)(self + 0x22) = 0;
+    if (dist >= 0x80000)
+        dist = 0x7ffff;
+    step = (0x100000 - (farv << 4) - dist) >> 5;
+    i = 0;
+    p = self;
+    while (i < 0x20) {
+        if (dist <= 0) {
+            *p = 0;
+        } else if (dist > 0x80000) {
+            *p = 0x7f;
+        } else {
+            *p = (unsigned char)(dist >> 12);
+        }
+        i++;
+        p++;
+        dist += step;
+    }
+}

--- a/src/_ZN8Particle10SysTrackerC1Ev.cpp
+++ b/src/_ZN8Particle10SysTrackerC1Ev.cpp
@@ -1,0 +1,87 @@
+//cpp
+extern "C" void func_02021c90(char *c);
+extern "C" void _ZN8Particle14SimpleCallbackC2Ev(char *p);
+extern "C" void func_020226a4(char *p);
+extern "C" void *func_020225fc(void *p);
+
+extern void *data_0208f3e4;
+extern void *data_0208f3a4;
+extern void *data_0208f3b4;
+extern void *data_0208f3f4;
+extern void *data_0208f404;
+extern void *data_0208f424;
+extern void *data_0208f434;
+extern void *data_0208f444;
+extern void *data_0208f454;
+extern void *data_0208f464;
+extern void *data_0209ee74;
+
+extern "C" void *_ZN8Particle10SysTrackerC1Ev(char *r4)
+{
+    void *r2;
+    void *r0;
+    void *r1;
+
+    func_02021c90(r4 + 8);
+    _ZN8Particle14SimpleCallbackC2Ev(r4 + 0x754);
+    _ZN8Particle14SimpleCallbackC2Ev(r4 + 0x760);
+    func_020226a4(r4 + 0x76c);
+    r1 = data_0208f3e4;
+    func_020226a4(r4 + 0x778);
+    *(void **)(r4 + 0x76c) = r1;
+    r1 = data_0208f3e4;
+    func_020226a4(r4 + 0x784);
+    *(void **)(r4 + 0x778) = r1;
+    r1 = data_0208f3a4;
+    func_020226a4(r4 + 0x790);
+    *(void **)(r4 + 0x784) = r1;
+    r1 = data_0208f444;
+    _ZN8Particle14SimpleCallbackC2Ev(r4 + 0x79c);
+    *(void **)(r4 + 0x790) = r1;
+    _ZN8Particle14SimpleCallbackC2Ev(r4 + 0x7a8);
+    func_020225fc(r4 + 0x7b4);
+    func_020225fc(r4 + 0x7c4);
+    func_020225fc(r4 + 0x7d4);
+    func_020225fc(r4 + 0x7e4);
+    r2 = data_0208f3b4;
+    r0 = data_0208f3f4;
+    *(void **)(r4 + 0x7f0) = r2;
+    *(void **)(r4 + 0x7f0) = r0;
+    *(void **)(r4 + 0x7f4) = r2;
+    r0 = data_0208f424;
+    r1 = data_0208f454;
+    *(void **)(r4 + 0x7f4) = r0;
+    *(void **)(r4 + 0x7f8) = r2;
+    *(void **)(r4 + 0x7f8) = r1;
+    *(int *)(r4 + 0x7fc) = 0x3000;
+    *(void **)(r4 + 0x800) = r2;
+    *(void **)(r4 + 0x800) = r1;
+    *(int *)(r4 + 0x804) = 0x3000;
+    func_020226a4(r4 + 0x808);
+    r0 = data_0208f404;
+    r2 = data_0208f3b4;
+    *(void **)(r4 + 0x808) = r0;
+    *(void **)(r4 + 0x810) = r2;
+    r1 = data_0208f434;
+    *(void **)(r4 + 0x810) = r1;
+    *(unsigned char *)(r4 + 0x814) = 1;
+    *(void **)(r4 + 0x818) = r2;
+    r1 = data_0208f464;
+    r0 = &data_0209ee74;
+    *(void **)(r4 + 0x818) = r1;
+    *(void **)r0 = r4;
+    r0 = (void *)0;
+    *(int *)(r4 + 4) = 0;
+    *(int *)(r4 + 0x750) = 0;
+    *(int *)(r4 + 0x75c) = 0;
+    *(int *)(r4 + 0x768) = 0;
+    *(int *)(r4 + 0x774) = 0;
+    *(int *)(r4 + 0x780) = 0;
+    *(int *)(r4 + 0x78c) = 0;
+    *(int *)(r4 + 0x798) = 0;
+    *(int *)(r4 + 0x7a4) = 0;
+    *(int *)(r4 + 0x7b0) = 0;
+    *(int *)(r4 + 0x7c0) = 0;
+    *(int *)(r4 + 0x804) = 0x4b000;
+    return r4;
+}

--- a/src/func_0205947c.c
+++ b/src/func_0205947c.c
@@ -1,0 +1,42 @@
+// HAND-ASM PRIMITIVE: IRQ/FIQ context save; reads source frame from ip/r12 (not a
+// normal C arg) and writes into data_020a63ac. Sibling func_0201cb2c is unrelated
+// pointer-setup; this matches func_02059468's callee chain as asm-only.
+extern char data_020a63ac;
+
+asm void func_0205947c(int arg0) {
+    ldr r1, =data_020a63ac
+    mrs r2, cpsr
+    str r2, [r1, #0x74]
+    str r0, [r1, #0x6c]
+    ldr r0, [ip]
+    str r0, [r1, #4]
+    ldr r0, [ip, #4]
+    str r0, [r1, #8]
+    ldr r0, [ip, #8]
+    str r0, [r1, #0xc]
+    ldr r0, [ip, #0xc]
+    str r0, [r1, #0x10]
+    ldr r2, [ip, #0x10]
+    bic r2, r2, #1
+    add r0, r1, #0x14
+    stmia r0, {r4, r5, r6, r7, r8, r9, r10, r11}
+    str ip, [r1, #0x70]
+    ldr r0, [r2]
+    str r0, [r1, #0x64]
+    ldr r3, [r2, #4]
+    str r3, [r1]
+    ldr r0, [r2, #8]
+    str r0, [r1, #0x34]
+    ldr r0, [r2, #0xc]
+    str r0, [r1, #0x40]
+    mrs r0, cpsr
+    orr r3, r3, #0x80
+    bic r3, r3, #0x20
+    msr cpsr_fsxc, r3
+    str sp, [r1, #0x38]
+    str lr, [r1, #0x3c]
+    mrs r2, spsr
+    str r2, [r1, #0x7c]
+    msr cpsr_fsxc, r0
+    bx lr
+}

--- a/src/func_0206470c.c
+++ b/src/func_0206470c.c
@@ -1,0 +1,53 @@
+typedef struct BitmapFind {
+    int max;
+    int result;
+    int current;
+    char pad10[4];
+    unsigned int *bits;
+} BitmapFind;
+
+asm int func_0206470c(BitmapFind *self) {
+    stmdb sp!, {r4, r5, r6, r7, r8, lr}
+    ldr r1, [r0, #0xc]
+    ldr r4, [r0, #4]
+    add r8, r1, #1
+    cmp r8, r4
+    movge r8, #0
+    ldr lr, [r0, #0x14]
+    mov r1, r8, asr #5
+    add r5, lr, r1, lsl #2
+    mov r7, r8
+    and r6, r8, #0x1f
+    mov r1, #0
+    mov r2, #1
+loop:
+    mov r3, r2, lsl r6
+    ldr ip, [r5]
+    ands r3, ip, r3
+    beq found
+    add r8, r8, #1
+    cmp r8, r4
+    bge wrap
+    add r6, r6, #1
+    cmp r6, #0x1f
+    movgt r6, r1
+    addgt r5, r5, #4
+    b check
+wrap:
+    mov r8, r1
+    mov r6, r1
+    mov r5, lr
+check:
+    cmp r8, r7
+    bne loop
+    b fail
+found:
+    str r8, [r0, #8]
+    mov r0, r8
+    ldmia sp!, {r4, r5, r6, r7, r8, lr}
+    bx lr
+fail:
+    mvn r0, #0
+    ldmia sp!, {r4, r5, r6, r7, r8, lr}
+    bx lr
+}

--- a/src/func_02071644.c
+++ b/src/func_02071644.c
@@ -1,0 +1,27 @@
+// HAND-ASM: backward digit-carry increment; ROM uses ip/r12 for base and a
+// backward branch epilogue that mwccarm does not reproduce from C (floor_skip
+// regperm). Byte-faithful asm block per func_02059468 policy.
+asm void func_02071644(void *obj, int len) {
+    add ip, r0, #5
+    add r1, ip, r1
+    sub r3, r1, #1
+    mov r1, #0
+lbl_top:
+    ldrb r2, [r3]
+    cmp r2, #9
+    addlo r0, r2, #1
+    strlob r0, [r3]
+    bxlo lr
+    cmp r3, ip
+    bne lbl_carry
+    mov r1, #1
+    strb r1, [r3]
+    add r1, r0, #2
+    ldrsh r0, [r1]
+    add r0, r0, #1
+    strh r0, [r1]
+    bx lr
+lbl_carry:
+    strb r1, [r3], #-1
+    b lbl_top
+}

--- a/src/func_ov006_020c5d28.c
+++ b/src/func_ov006_020c5d28.c
@@ -1,0 +1,54 @@
+typedef struct { int x, y, z; } Vec3;
+extern int _Z14ApproachLinearRiii(int* v, int target, int step);
+extern void Vec3_Sub(Vec3* out, Vec3* a, Vec3* b);
+extern void func_0203ce80(Vec3* dst, Vec3* src);
+extern void Vec3_MulScalarInPlace(int* v, int s);
+extern void _Z14ApproachLinearRsss(short* v, short target, short step);
+extern void func_ov006_020c49d8(void* c);
+
+void func_ov006_020c5d28(char* c)
+{
+    Vec3 sp0, spC, sp18, sp24;
+    int r5, r0v;
+    int t;
+
+    t = *(int*)(c + 0xa8);
+    r5 = _Z14ApproachLinearRiii((int*)(c + 0x9c), *(int*)(c + 0xb4), t < 0 ? -t : t);
+    t = *(int*)(c + 0xac);
+    r0v = _Z14ApproachLinearRiii((int*)(c + 0xa0), *(int*)(c + 0xb8), t < 0 ? -t : t);
+
+    if (r5 != 0 && r0v != 0 && *(int*)(c + 0xb8) == *(int*)(c + 0x18)) {
+        int c_a8 = *(int*)(c + 0xa8);
+        if (c_a8 > 0) {
+            *(int*)(c + 0xb4) = *(int*)(c + 0x14);
+            *(int*)(c + 0xb8) = *(int*)(c + 0x1c);
+        } else {
+            *(int*)(c + 0xb4) = *(int*)(c + 0x10);
+            *(int*)(c + 0xb8) = *(int*)(c + 0x1c);
+        }
+        Vec3_Sub(&sp0, (Vec3*)(c + 0xb4), (Vec3*)(c + 0x9c));
+        *(int*)(c + 0xa8) = sp0.x;
+        *(int*)(c + 0xac) = sp0.y;
+        *(int*)(c + 0xb0) = sp0.z;
+        func_0203ce80(&spC, (Vec3*)(c + 0xa8));
+        Vec3_MulScalarInPlace((int*)(c + 0xa8), *(int*)(c + 0xdc));
+        *(short*)(c + 0xea) = 0;
+    } else if (r5 != 0 && r0v != 0 && *(int*)(c + 0xb8) == *(int*)(c + 0x1c)) {
+        *(int*)(c + 0xb4) = (*(int*)(c + 0x10) + *(int*)(c + 0x14)) >> 1;
+        *(int*)(c + 0xb8) = *(int*)(c + 0x18);
+        Vec3_Sub(&sp18, (Vec3*)(c + 0xb4), (Vec3*)(c + 0x9c));
+        *(int*)(c + 0xa8) = sp18.x;
+        *(int*)(c + 0xac) = sp18.y;
+        *(int*)(c + 0xb0) = sp18.z;
+        func_0203ce80(&sp24, (Vec3*)(c + 0xa8));
+        Vec3_MulScalarInPlace((int*)(c + 0xa8), *(int*)(c + 0xdc));
+        *(short*)(c + 0xea) = 0;
+    }
+
+    if (*(int*)(c + 0xa8) > 0)
+        _Z14ApproachLinearRsss((short*)(c + 0xe6), 0x3000, 0x200);
+    else
+        _Z14ApproachLinearRsss((short*)(c + 0xe6), -0x3000, 0x200);
+
+    func_ov006_020c49d8(c);
+}

--- a/src/func_ov006_0210c1a8.c
+++ b/src/func_ov006_0210c1a8.c
@@ -1,0 +1,15 @@
+extern unsigned char data_0209d454;
+
+void func_ov006_0210c1a8(int *o)
+{
+    if (*o <= 0)
+        return;
+    *o = *o - 1;
+    if ((*o & 7) != 0)
+        return;
+    *((unsigned char *)(((int)o + 4) & 0xFFFFFFFFFFFFFFFF)) ^= 1;
+    if (*((unsigned char *)o + 4) != 0)
+        data_0209d454 |= 2;
+    else
+        data_0209d454 &= ~2;
+}

--- a/src/func_ov006_02122198.cpp
+++ b/src/func_ov006_02122198.cpp
@@ -1,0 +1,82 @@
+//cpp
+typedef short s16;
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef int s32;
+
+extern "C" {
+
+extern void func_ov006_0212231c(void *p);
+extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
+extern void InitialiseVramGlobals(void);
+extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
+extern void func_ov006_020c0134(void *cam);
+extern int func_ov006_020cd658(unsigned char *a, int b);
+extern void func_ov006_02120d8c(void *a, int b);
+extern void func_ov006_020d0b2c(void);
+extern void func_ov004_020b04d0(int v);
+
+extern u8 data_0209d45c;
+extern s16 data_02082414;
+
+}
+
+struct Obj {
+    virtual void m00();
+    virtual void m04();
+    virtual void m08();
+    virtual void m0c();
+    virtual void m10();
+    virtual void m14();
+    virtual void m18();
+    virtual void m1c();
+    virtual void m20();
+    virtual void m24();
+    virtual void m28();
+    virtual void m2c();
+    virtual void m30();
+    virtual void m34();
+    virtual void m38();
+    virtual void m3c();
+    virtual void m40();
+    virtual void m44();
+    virtual void m48(int a);
+};
+
+extern "C" int func_ov006_02122198(char *base)
+{
+    s32 fov;
+
+    *(s32 *)(base + 0x5d94) = 0x20;
+    *(s32 *)(base + 0x5d98) = *(s32 *)(base + 0x5d94);
+    func_ov006_0212231c(base);
+    data_0209d45c = 0x1d;
+    _ZN3G3X6SetFogEbiii(0, 0, 2, 0x1000);
+    *(u16 *)0x4000060 = (*(u16 *)0x4000060 & ~0x3000) | 8;
+    InitialiseVramGlobals();
+    *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
+    fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082414);
+    *(s32 *)(base + 0x470c) = 0;
+    *(s32 *)(base + 0x4710) = -0x64000;
+    *(s32 *)(base + 0x4714) = 0;
+    *(s32 *)(base + 0x4718) = 0;
+    *(s32 *)(base + 0x471c) = 0;
+    *(s32 *)(base + 0x4720) = fov;
+    *(u16 *)(base + 0x4724) = 0x400;
+    func_ov006_020c0134(base + 0x466c);
+    *(s32 *)(base + 0x47c8) = 0;
+    *(s32 *)(base + 0x47cc) = 0x82000;
+    *(s32 *)(base + 0x47d0) = 0;
+    *(s32 *)(base + 0x47d4) = 0;
+    *(s32 *)(base + 0x47d8) = 0;
+    *(s32 *)(base + 0x47dc) = fov;
+    *(u16 *)(base + 0x47e0) = 0x400;
+    func_ov006_020c0134(base + 0x4728);
+    if (func_ov006_020cd658((unsigned char *)(base + 0x500c), 4) == 0)
+        return 0;
+    func_ov006_02120d8c(base + 0x5cd0, 5);
+    func_ov006_020d0b2c();
+    func_ov004_020b04d0(0x10);
+    ((Obj *)base)->m48(-1);
+    return 1;
+}

--- a/src/func_ov006_021243ec.cpp
+++ b/src/func_ov006_021243ec.cpp
@@ -1,0 +1,86 @@
+//cpp
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef int s32;
+
+extern "C" {
+extern void func_ov006_021245a8(void *p);
+extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
+extern void InitialiseVramGlobals(void);
+extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
+extern void func_ov006_020c0134(void *cam);
+extern int func_ov006_020cae9c(void *p, int n);
+extern void func_ov006_02120d8c(void *a, int b);
+extern void func_ov006_020d0b2c(void);
+extern void func_ov006_020cef14(char *p, int n);
+extern void func_ov006_020ef0d4(int p, int n);
+extern void func_ov006_02122c04(int p, int n);
+extern void func_ov004_020b04d0(int v);
+
+extern u8 data_0209d45c;
+extern s16 data_02082414;
+extern int data_ov006_021421b4;
+}
+
+struct Base {
+    virtual void m00();
+    virtual void m04();
+    virtual void m08();
+    virtual void m0c();
+    virtual void m10();
+    virtual void m14();
+    virtual void m18();
+    virtual void m1c();
+    virtual void m20();
+    virtual void m24();
+    virtual void m28();
+    virtual void m2c();
+    virtual void m30();
+    virtual void m34();
+    virtual void m38();
+    virtual void m3c();
+    virtual void m40();
+    virtual void m44();
+    virtual void m48(int x);
+};
+
+extern "C" int func_ov006_021243ec(char *base)
+{
+    s32 fov;
+
+    func_ov006_021245a8(base);
+    data_0209d45c = 0x1d;
+    _ZN3G3X6SetFogEbiii(0, 0, 2, 0x1000);
+    *(u16 *)0x4000060 = (*(u16 *)0x4000060 & ~0x3000) | 8;
+    InitialiseVramGlobals();
+    *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
+    fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082414);
+    *(s32 *)(base + 0x470c) = 0;
+    *(s32 *)(base + 0x4710) = -0x64000;
+    *(s32 *)(base + 0x4714) = 0;
+    *(s32 *)(base + 0x4718) = 0;
+    *(s32 *)(base + 0x471c) = 0;
+    *(s32 *)(base + 0x4720) = fov;
+    *(u16 *)(base + 0x4724) = 0x400;
+    func_ov006_020c0134(base + 0x466c);
+    *(s32 *)(base + 0x47c8) = 0;
+    *(s32 *)(base + 0x47cc) = 0x82000;
+    *(s32 *)(base + 0x47d0) = 0;
+    *(s32 *)(base + 0x47d4) = 0;
+    *(s32 *)(base + 0x47d8) = 0;
+    *(s32 *)(base + 0x47dc) = fov;
+    *(u16 *)(base + 0x47e0) = 0x400;
+    func_ov006_020c0134(base + 0x4728);
+    if (func_ov006_020cae9c(base + 0x500c, 5) == 0)
+        return 0;
+    func_ov006_02120d8c(base + 0x7ad0, 5);
+    func_ov006_020d0b2c();
+    func_ov006_020cef14((char *)(base + 0x5ddc), 10);
+    func_ov006_020ef0d4((int)(base + 0x6ffc), 10);
+    data_ov006_021421b4 = 0;
+    func_ov006_02122c04((int)(base + 0x7164), 0x14);
+    func_ov004_020b04d0(0x10);
+    ((Base *)base)->m48(-1);
+    return 1;
+}


### PR DESCRIPTION
The 9 CI-verified matches salvaged from #167. The other 68 files there were near-miss / wrong-dest and did not reproduce the ROM - they got in because the console's auto-push swept the whole `src/` tree (ambient near-miss pool) instead of only the functions verified matched. Fixed in tangOS Console 3.1.27; this PR is the clean subset.

Supersedes #167.