### PR TITLE
Match ov012 platform handler cluster (0211123c, 02111370, 02111574)

### DIFF
--- a/src/func_ov012_0211123c.c
+++ b/src/func_ov012_0211123c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: extra logic (you do more) (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(char* t);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char* t);
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
@@ -9,7 +6,7 @@ void func_ov012_0211123c(char* c) {
     int* q;
     char* p;
     if (*(unsigned char*)(c+0x31e)) return;
-    q = (int*)(c+0x60);
+    q = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
     *q -= 0x64000;
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov012_02111370.c
+++ b/src/func_ov012_02111370.c
@@ -1,26 +1,27 @@
-// NONMATCHING: base materialization / addressing (div=15). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
-extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
+typedef int Fix12;
+extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
-extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
+extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
+extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int data_ov012_021124a8[];
 extern int data_0209caa0[];
 extern int data_ov012_021124a0[];
 extern int data_ov012_02111cd0[];
+
 int func_ov012_02111370(char* c){
-  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124a8);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)c+0xd4, m, 1, -1);
+  void* mdl;
+  void* kcl;
+  mdl = _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124a8);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, mdl, 1, -1);
   if(data_0209caa0[2] & 0x80000){
-    *(int*)((char*)c+0x60) -= 0x64000;
-    *(char*)((char*)c+0x31e) = 1;
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x64000;
+    *(char*)(c+0x31e) = 1;
   }
-  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov012_021124a0);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)c+0x124, k, (char*)c+0x2ec, 0x199, *(short*)((char*)c+0x8e), (void*)data_ov012_02111cd0);
+  _ZN8Platform21UpdateModelPosAndRotYEv(c);
+  _ZN8Platform19UpdateClsnPosAndRotEv(c);
+  kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov012_021124a0);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, kcl, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov012_02111cd0);
   return 1;
 }

--- a/src/func_ov012_02111574.c
+++ b/src/func_ov012_02111574.c
@@ -1,11 +1,5 @@
-//cpp
-// NONMATCHING: base materialization / addressing (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" {
-struct Vector3 { int x, y, z; };
 extern void _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, unsigned short* p);
-extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, const Vector3& v, unsigned int e);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, void* v, unsigned int e);
 extern void _ZN7Minimap19UpdateLevelSpecificEv(void);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* thiz);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
@@ -21,8 +15,8 @@ int func_ov012_02111574(char* c)
         *(int*)(c + 0x60) = *(int*)(c + 0x334);
     } else if (*(int*)((char*)data_0209caa0 + 8) & 0x80000) {
         *(unsigned int*)(c + 0x338) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
-            *(unsigned int*)(c + 0x338), 3, 0x96, *(Vector3*)(c + 0x74), 0);
-        *(int*)(c + 0x60) -= 0x5000;
+            *(unsigned int*)(c + 0x338), 3, 0x96, (void*)(c + 0x74), 0);
+        *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x5000;
         *(unsigned char*)(c + 0x33e) = 1;
         if (*(int*)(c + 0x60) <= *(int*)(c + 0x334)) {
             *(int*)(c + 0x60) = *(int*)(c + 0x334);
@@ -33,7 +27,6 @@ int func_ov012_02111574(char* c)
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
     *(int*)(c + 0x32c) = 0x1000;
-    _ZN9Animation7AdvanceEv(c + 0x320);
+    _ZN9Animation7AdvanceEv((char*)c + 0x320);
     return 1;
-}
 }


### PR DESCRIPTION
Matches three consecutive ov012 actor/platform handlers byte-for-byte (relocation-aware, verified with `tools/match.py`).

| function | addr | size |
|---|---|---|
| `func_ov012_0211123c` | `0x0211123c` | `0xb0` |
| `func_ov012_02111370` | `0x02111370` | `0xb0` |
| `func_ov012_02111574` | `0x02111574` | `0xd8` |

### What changed vs the parked NONMATCHING drafts
- **Materialized-base RMW at `this+0x60`.** All three emit `add rX,this,#0x60; ldr [rX]; sub; str [rX]` (shared base for load+store). Plain C folds `+0x60` into the addressing mode; closed with the u64-mask address-laundering idiom `*(int*)(((long long)(int)(c+0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= K`.
- **`func_ov012_02111370`:** the two `Platform::Update*` calls run **unconditionally** — the `beq` on the `data_0209caa0` flag skips only the RMW + flag store. Moved the calls out of the guard. Also mirrored the matched sibling `func_ov012_02112e1c`/`func_ov036_02111eb0` type shape (`void*`/`Fix12`/`short`).
- **`func_ov012_02111574`:** rewritten as plain C — the `const Vector3&` argument to `Sound::PlayLong` is a plain pointer pass (`add r3,this,#0x74`), so no C++ is required.

### Build / verify
- Compiler: **mwccarm 1.2/sp2p3**
- Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

All three report `MATCHING VERSIONS: 1.2/sp2p3`.