### PR TITLE
Match ov036 small wrapper batch

### DIFF
--- a/src/func_ov036_021114f8.c
+++ b/src/func_ov036_021114f8.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b66a8(u8 *self, struct Arg *arg);
+extern struct Arg data_ov036_02113b2c;
+
+int func_ov036_021114f8(u8 *self)
+{
+    return func_ov002_020b66a8(self, &data_ov036_02113b2c);
+}

--- a/src/func_ov036_02111cc4.c
+++ b/src/func_ov036_02111cc4.c
@@ -1,0 +1,6 @@
+extern int func_ov036_02111ca4(void *a, void *b);
+
+int func_ov036_02111cc4(void *self, void *a, void *b)
+{
+    return func_ov036_02111ca4(a, b);
+}

--- a/src/func_ov036_021120a0.c
+++ b/src/func_ov036_021120a0.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);
+extern struct Arg data_ov036_02113e88;
+
+int func_ov036_021120a0(u8 *self)
+{
+    return func_ov002_020b4b6c(self, &data_ov036_02113e88);
+}

--- a/src/func_ov036_021120b4.c
+++ b/src/func_ov036_021120b4.c
@@ -1,0 +1,10 @@
+typedef unsigned char u8;
+struct Arg { void *m[3]; };
+
+extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);
+extern struct Arg data_ov036_02113e88;
+
+int func_ov036_021120b4(u8 *self)
+{
+    return func_ov002_020b4d58(self, &data_ov036_02113e88);
+}


### PR DESCRIPTION
Match four small ov036 tail-call wrappers, byte-identical to the EU retail ROM.

**Compiler:** mwccarm 1.2/sp2p3
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

| function | addr | size | shape |
|---|---|---|---|
| `func_ov036_021120b4` | 0x021120b4 | 0x14 | tail-call `func_ov002_020b4d58(self, &data_ov036_02113e88)` |
| `func_ov036_021120a0` | 0x021120a0 | 0x14 | tail-call `func_ov002_020b4b6c(self, &data_ov036_02113e88)` |
| `func_ov036_021114f8` | 0x021114f8 | 0x14 | tail-call `func_ov002_020b66a8(self, &data_ov036_02113b2c)` |
| `func_ov036_02111cc4` | 0x02111cc4 | 0x14 | arg-shuffle thunk `func_ov036_02111ca4(a, b)` |

The first three mirror the `func_ov002_*` dispatch-wrapper idiom already used by the ov047 small wrapper batch (#134). Each verified byte-identical (relocation-aware) with `tools/match.py --version 1.2/sp2p3 --module ov036`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)