### PR TITLE
Match ov036 Platform update funcs (021112f0, 02111a64)

### DIFF
--- a/src/func_ov036_021112f0.c
+++ b/src/func_ov036_021112f0.c
@@ -1,20 +1,22 @@
-// NONMATCHING: base materialization / addressing (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int func_ov036_0211123c(char *t);
-extern int IsClsnInRange(char *c, int a, int b);
-extern int UpdateClsnPosAndRot(char *c);
-int func_ov036_021112f0(char *c) {
-    if (*(short*)(c+0x90) >= 0) {
-        short *p = (short*)(c + 0x31e);
-        *p = *p - 4;
-    } else {
-        short *p = (short*)(c + 0x31e);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
+extern int _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
+
+int func_ov036_021112f0(char *c)
+{
+    if (*(short *)(c + 0x90) < 0) {
+        short *p = (short *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
         *p = *p + 4;
+    } else {
+        short *p = (short *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
+        *p = *p - 4;
     }
-    *(short*)(c+0x90) = (short)(*(short*)(c+0x90) + *(short*)(c+0x300+0x1e));
+    {
+        short *q = (short *)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF);
+        *q = *q + ((short *)(c + 0x300))[15];
+    }
     func_ov036_0211123c(c);
-    if (IsClsnInRange(c, 0, 0))
-        UpdateClsnPosAndRot(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
     return 1;
 }

--- a/src/func_ov036_02111a64.c
+++ b/src/func_ov036_02111a64.c
@@ -1,0 +1,56 @@
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
+void func_020383fc(void* p);
+int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
+int _ZN5Actor13DistToCPlayerEv(void* p);
+void _ZN5Actor14TriplePoofDustEv(void* p);
+int _ZN16MeshColliderBase9IsEnabledEv(void* p);
+void _ZN16MeshColliderBase7DisableEv(void* p);
+void _ZN8Platform21UpdateModelPosAndRotYEv(void* p);
+int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, int a, int b);
+void _ZN8Platform19UpdateClsnPosAndRotEv(void* p);
+
+int func_ov036_02111a64(char* c) {
+    switch (*(unsigned char*)(c + 0x4ea)) {
+    case 0:
+        if (*(unsigned char*)(c + 0x4e8) == 0) {
+            *(unsigned char*)(c + 0x4e9) = 0;
+        } else {
+            unsigned char* pc9 = (unsigned char*)(((int)c + 0x4e9) & 0xFFFFFFFFFFFFFFFF);
+            *pc9 = *pc9 + 1;
+            *(unsigned char*)(c + 0x4e8) = 0;
+        }
+        if (*(unsigned char*)(c + 0x4e9) >= 0xf) *(unsigned char*)(c + 0x4ea) = 1;
+        break;
+    case 1:
+        _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+        func_020383fc(c + 0x320);
+        if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320) == 0) {
+            if (_ZN5Actor13DistToCPlayerEv(c) <= 0x9c4000) break;
+        }
+        _ZN5Actor14TriplePoofDustEv(c);
+        if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124) != 0) _ZN16MeshColliderBase7DisableEv(c + 0x124);
+        *(int*)(c + 0x5c) = *(int*)(c + 0x4dc);
+        *(int*)(c + 0x60) = *(int*)(c + 0x4e0);
+        *(int*)(c + 0x64) = *(int*)(c + 0x4e4);
+        *(unsigned char*)(c + 0x4ea) = 2;
+        break;
+    case 2: {
+        int d = _ZN5Actor13DistToCPlayerEv(c);
+        if (d <= 0x3e8000) break;
+        if (d < 0x7d0000) {
+            *(int*)(c + 0xa8) = 0;
+            *(unsigned char*)(c + 0x4e9) = 0;
+            *(unsigned char*)(c + 0x4e8) = 0;
+            *(unsigned char*)(c + 0x4ea) = 0;
+        }
+        break;
+    }
+    }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    if (*(unsigned char*)(c + 0x4ea) != 2) {
+        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0x5dc000, 0) != 0) {
+            _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
Two ov036 `Platform` per-frame update routines, byte-identical to the EU retail ROM.

**Compiler:** mwccarm 1.2/sp2p3
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

| function | addr | size | notes |
|---|---|---|---|
| `func_ov036_021112f0` | 0x021112f0 | 0x8c | rotation/step update — upgrades the stored NONMATCHING draft (div=17) to a full match |
| `func_ov036_02111a64` | 0x02111a64 | 0x154 | state-machine update — started from the stored near-miss draft |

**Matching notes**

- `021112f0`: the `0x31e` read-modify-write and the reload/store at `0x90` are routed through 64-bit arithmetic (`((int)c + OFF) & 0xFFFFFFFFFFFFFFFF`) so mwccarm materializes the base register (`ldr` a pooled `0x31e`, `add r3,r4,#0x90`) instead of folding the offset into a load displacement — the ROM's shape. The condition polarity (`< 0`) is chosen so the `-4` arm is the predicated inline block.
- `02111a64`: same 64-bit-mask base laundering on the case-0 counter RMW (materializes `c+0x4e9` only on the increment path while the zero-store and re-read use `r4`+displacement), plus a control-flow correction — `Actor::TriplePoofDust` is called after the `WithMeshClsn::IsOnGround` block, not nested inside it, matching the ROM's `bne` target.

Both verified byte-identical (relocation-aware, reloc-destination checked) with `tools/match.py --version 1.2/sp2p3 --module ov036`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)