### PR TITLE
Match ov045 Platform function batch (9 functions)

### DIFF
--- a/src/func_ov045_0211129c.c
+++ b/src/func_ov045_0211129c.c
@@ -1,0 +1,51 @@
+extern int _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
+extern int _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
+int func_ov045_0211129c(char *c)
+{
+    switch (*(unsigned char*)(c + 0x327)) {
+    case 0:
+        if (*(unsigned char*)(c + 0x326) != 0)
+            *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
+                *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
+        break;
+    case 1:
+        if (*(unsigned short*)(c + 0x324) >= 0x14) {
+            int lim;
+            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+                *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + 0xa000;
+            lim = *(int*)(c + 0x320) + 0x5dc000;
+            if (*(int*)(c + 0x60) >= lim) {
+                *(int*)(c + 0x60) = lim;
+                *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
+                    *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
+                *(unsigned short*)(c + 0x324) = 0;
+            }
+        } else {
+            *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
+                *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) + 1;
+        }
+        break;
+    case 2:
+        if (*(unsigned short*)(c + 0x324) >= 0x14) {
+            int lim;
+            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+                *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) - 0xa000;
+            lim = *(int*)(c + 0x320);
+            if (*(int*)(c + 0x60) <= lim) {
+                *(int*)(c + 0x60) = lim;
+                *(unsigned char*)(c + 0x327) = 0;
+                *(unsigned short*)(c + 0x324) = 0;
+            }
+        } else {
+            *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
+                *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) + 1;
+        }
+        break;
+    }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0x1f4000, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    *(unsigned char*)(c + 0x326) = 0;
+    return 1;
+}

--- a/src/func_ov045_021114c8.c
+++ b/src/func_ov045_021114c8.c
@@ -1,0 +1,5 @@
+extern void func_ov045_021114a8(void *a, void *b);
+void func_ov045_021114c8(void *self, void *a, void *b)
+{
+    func_ov045_021114a8(a, b);
+}

--- a/src/func_ov045_02111618.c
+++ b/src/func_ov045_02111618.c
@@ -1,0 +1,30 @@
+typedef int Fix12;
+extern void _ZN12CylinderClsn5ClearEv(void *self);
+extern void _ZN12CylinderClsn6UpdateEv(void *self);
+extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
+extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, Fix12 a, int b);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
+extern short data_02082214[];
+int func_ov045_02111618(char *c)
+{
+    _ZN12CylinderClsn5ClearEv(c + 0x320);
+    _ZN12CylinderClsn6UpdateEv(c + 0x320);
+    if (*(unsigned int*)(c + 8) != 0xffff) {
+        int idx = *(unsigned short*)(c + 0x354) >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
+        *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + (int)(((long long)s * 0x7000 + 0x800) >> 12);
+    } else {
+        int idx = *(unsigned short*)(c + 0x354) >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
+        *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) - (int)(((long long)s * 0x3000 + 0x800) >> 12);
+    }
+    *(short*)(((int)c + 0x354) & 0xFFFFFFFFFFFFFFFF) =
+        *(short*)(((int)c + 0x354) & 0xFFFFFFFFFFFFFFFF) + 0x100;
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    if (_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x400000, 0)) {
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    }
+    return 1;
+}

--- a/src/func_ov045_02111bc8.c
+++ b/src/func_ov045_02111bc8.c
@@ -1,0 +1,6 @@
+extern int func_020b6424(void *self, void *data);
+extern int data_ov045_02112f08[];
+int func_ov045_02111bc8(void *self)
+{
+    return func_020b6424(self, data_ov045_02112f08);
+}

--- a/src/func_ov045_02111bdc.c
+++ b/src/func_ov045_02111bdc.c
@@ -1,0 +1,6 @@
+extern int func_020b6584(void *self, void *data, int n);
+extern int data_ov045_02112f08[];
+int func_ov045_02111bdc(void *self)
+{
+    return func_020b6584(self, data_ov045_02112f08, 0xf50);
+}

--- a/src/func_ov045_02111ce4.c
+++ b/src/func_ov045_02111ce4.c
@@ -1,0 +1,6 @@
+extern int func_020b60fc(void *self, void *data);
+extern int data_ov045_02112fdc[];
+int func_ov045_02111ce4(void *self)
+{
+    return func_020b60fc(self, data_ov045_02112fdc);
+}

--- a/src/func_ov045_02111cf8.c
+++ b/src/func_ov045_02111cf8.c
@@ -1,0 +1,6 @@
+extern int func_020b6244(void *self, void *data);
+extern int data_ov045_02112fdc[];
+int func_ov045_02111cf8(void *self)
+{
+    return func_020b6244(self, data_ov045_02112fdc);
+}

--- a/src/func_ov045_02111dfc.c
+++ b/src/func_ov045_02111dfc.c
@@ -1,0 +1,6 @@
+extern int func_0213a2cc(void *self, void *data);
+extern int data_ov045_021130ac[];
+int func_ov045_02111dfc(void *self)
+{
+    return func_0213a2cc(self, data_ov045_021130ac);
+}

--- a/src/func_ov045_02111e10.c
+++ b/src/func_ov045_02111e10.c
@@ -1,0 +1,6 @@
+extern int func_0213a794(void *self, void *data);
+extern int data_ov045_021130ac[];
+int func_ov045_02111e10(void *self)
+{
+    return func_0213a794(self, data_ov045_021130ac);
+}


### PR DESCRIPTION
Matches 9 functions in `ov045`, all verified byte-identical against the EU retail ROM.

**Compiler:** mwccarm `1.2/sp2p3`
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

### Tail-call thunks
| function | addr | size |
|---|---|---|
| `func_ov045_02111e10` | 0x02111e10 | 0x14 |
| `func_ov045_02111dfc` | 0x02111dfc | 0x14 |
| `func_ov045_02111cf8` | 0x02111cf8 | 0x14 |
| `func_ov045_02111ce4` | 0x02111ce4 | 0x14 |
| `func_ov045_02111bdc` | 0x02111bdc | 0x18 |
| `func_ov045_02111bc8` | 0x02111bc8 | 0x14 |
| `func_ov045_021114c8` | 0x021114c8 | 0x14 |

### Platform state / update functions
| function | addr | size |
|---|---|---|
| `func_ov045_02111618` | 0x02111618 | 0x120 |
| `func_ov045_0211129c` | 0x0211129c | 0x150 |

The two update functions use the u64-mask address-laundering idiom (see `notes/mwccarm-codegen.md` sec 6e/6g) to reproduce the ROM's materialized-base read-modify-write sites (`pos`, the state byte, and the u16 timer).

Each function was verified with `tools/match.py --version 1.2/sp2p3` (relocation-aware, strict reloc check) reporting identical bytes.