### PR TITLE
Match ov022 wrapper thunk batch (7 functions)

### DIFF
--- a/src/func_ov022_02111564.c
+++ b/src/func_ov022_02111564.c
@@ -1,0 +1,5 @@
+extern void func_ov022_02111558(void *a, void *b);
+void func_ov022_02111564(void *self, void *a, void *b)
+{
+    func_ov022_02111558(a, b);
+}

--- a/src/func_ov022_0211165c.c
+++ b/src/func_ov022_0211165c.c
@@ -1,0 +1,6 @@
+extern int func_020b66a8(void *self, void *data);
+extern int data_ov022_02113da4[];
+int func_ov022_0211165c(void *self)
+{
+    return func_020b66a8(self, data_ov022_02113da4);
+}

--- a/src/func_ov022_0211193c.c
+++ b/src/func_ov022_0211193c.c
@@ -1,0 +1,5 @@
+extern void func_ov022_0211191c(void *a, void *b);
+void func_ov022_0211193c(void *self, void *a, void *b)
+{
+    func_ov022_0211191c(a, b);
+}

--- a/src/func_ov022_02112434.c
+++ b/src/func_ov022_02112434.c
@@ -1,0 +1,6 @@
+extern int func_0213a2cc(void *self, void *data);
+extern int data_ov022_0211427c[];
+int func_ov022_02112434(void *self)
+{
+    return func_0213a2cc(self, data_ov022_0211427c);
+}

--- a/src/func_ov022_02112448.c
+++ b/src/func_ov022_02112448.c
@@ -1,0 +1,6 @@
+extern int func_0213a794(void *self, void *data);
+extern int data_ov022_0211427c[];
+int func_ov022_02112448(void *self)
+{
+    return func_0213a794(self, data_ov022_0211427c);
+}

--- a/src/func_ov022_0211254c.c
+++ b/src/func_ov022_0211254c.c
@@ -1,0 +1,6 @@
+extern int func_021270dc(void *self, void *data);
+extern int data_ov022_02112c9c[];
+int func_ov022_0211254c(void *self)
+{
+    return func_021270dc(self, data_ov022_02112c9c);
+}

--- a/src/func_ov022_02112590.c
+++ b/src/func_ov022_02112590.c
@@ -1,0 +1,6 @@
+extern int func_ov080_021274ac(void *self, void *data);
+extern int data_ov022_02112c9c[];
+int func_ov022_02112590(void *self)
+{
+    return func_ov080_021274ac(self, data_ov022_02112c9c);
+}


### PR DESCRIPTION
Seven tail-call veneers in overlay ov022, each verified byte-identical to the EU retail ROM.

| Function | Address | Tail call |
|---|---|---|
| func_ov022_02112590 | 0x2112590 | func_ov080_021274ac(self, data_ov022_02112c9c) |
| func_ov022_0211254c | 0x211254c | func_021270dc(self, data_ov022_02112c9c) |
| func_ov022_02112448 | 0x2112448 | func_0213a794(self, data_ov022_0211427c) |
| func_ov022_02112434 | 0x2112434 | func_0213a2cc(self, data_ov022_0211427c) |
| func_ov022_0211165c | 0x211165c | func_020b66a8(self, data_ov022_02113da4) |
| func_ov022_0211193c | 0x211193c | func_ov022_0211191c(a, b) — arg-shift |
| func_ov022_02111564 | 0x2111564 | func_ov022_02111558(a, b) — arg-shift |

Each compiles to the `ldr ip, [pc]; ...; bx ip` veneer via a last-statement tail call: `return F(self, DATA);` for the pooled-data forms, and a void arg-shift call `G(a, b);` for the two that drop `r0`.

**Compiler:** mwccarm 1.2/sp2p3
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Verified with `tools/match.py --module ov022` — all seven report MATCHING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)