### PR TITLE
Match ov022 Platform state handlers (func_ov022_02111ad0, func_ov022_021112ac)

### DIFF
--- a/src/func_ov022_021112ac.c
+++ b/src/func_ov022_021112ac.c
@@ -56,7 +56,7 @@ int func_ov022_021112ac(void *thiz)
             *(void **)((unsigned char *)s + 0x10c) = c;
             *(int *)((unsigned char *)s + 0x118) = *(int *)(c + 0x60);
             {
-                unsigned short *t = (unsigned short *)(c + 0x324);
+                unsigned short *t = (unsigned short *)((long long)(int)(c + 0x324) & 0xFFFFFFFFFFFFFFFFLL);
                 *t = *t + 1;
             }
             *(unsigned char *)(c + 0x31f) = 2;
@@ -64,7 +64,7 @@ int func_ov022_021112ac(void *thiz)
         break;
     }
 
-    ip = (short *)(c + 0x94);
+    ip = (short *)((long long)(int)(c + 0x94) & 0xFFFFFFFFFFFFFFFFLL);
     *ip = (short)(*ip + *(short *)(c + 0x96));
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     func_020393a4(c + 0x124, 0x780000);

--- a/src/func_ov022_02111ad0.c
+++ b/src/func_ov022_02111ad0.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=39). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void* v);
 extern void func_ov022_02111a1c(char* t);
@@ -11,7 +8,7 @@ int func_ov022_02111ad0(char* c)
 {
     if (DecIfAbove0_Byte((unsigned char*)c + 0x31e) == 0) {
         if (*(unsigned char*)(c + 0x31f) == 0) {
-            short* p = (short*)(c + 0x96);
+            short* p = (short*)((long long)(int)(c + 0x96) & 0xFFFFFFFFFFFFFFFFLL);
             *p = *p - 0x100;
             if (*(short*)(c + 0x96) <= -0x2000) {
                 *(short*)(c + 0x96) = -0x2000;
@@ -19,7 +16,7 @@ int func_ov022_02111ad0(char* c)
                 *(unsigned char*)(c + 0x31f) = 1;
             }
         } else {
-            short* p = (short*)(c + 0x96);
+            short* p = (short*)((long long)(int)(c + 0x96) & 0xFFFFFFFFFFFFFFFFLL);
             *p = *p + 0x100;
             if (*(short*)(c + 0x96) >= 0) {
                 *(short*)(c + 0x96) = 0;


### PR DESCRIPTION
Upgrades two previously **NONMATCHING** ov022 drafts to byte-identical matches against the EU retail ROM.

The logic in both drafts was already correct. The only gap was addressing-mode selection: the ROM materializes the address of a halfword field into its own register (`add rX, r4, #off`) and shares that register across the load+store of an accumulator, whereas plain C folds the (encodable) offset into `[r4, #off]`.

Applying the established u64-mask laundering idiom — `short *p = (short*)((long long)(int)(c + off) & 0xFFFFFFFFFFFFFFFFLL);` — routes the address through 64-bit arithmetic so mwccarm cannot fold it into the addressing mode, reproducing the materialized form exactly.

| Function | Address | Size | Laundered fields | div |
|---|---|---|---|---|
| func_ov022_02111ad0 | 0x2111ad0 | 0x10c | both `c+0x96` accumulator pointers (one per velocity branch) | 39 → 0 |
| func_ov022_021112ac | 0x21112ac | 0x1f0 | `c+0x94` accumulator and `c+0x324` spawn counter | 19 → 0 |

**Compiler:** mwccarm 1.2/sp2p3
**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Verified with `tools/match.py --module ov022` — both report MATCHING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)