### PR TITLE
Match 6 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02063d3c.c
+++ b/src/func_02063d3c.c
@@ -1,15 +1,14 @@
-extern int func_02064a28(int off, unsigned short v, unsigned char b);
-
 #pragma opt_propagation off
+extern int func_02064a28(int off, int v, int b);
 
-int func_02063d3c(char* c, int idx, int arg2)
+int func_02063d3c(char *obj, int idx, int off)
 {
-    unsigned char* base = (unsigned char*)(c + 0x1d4 + idx * 0x68);
-    unsigned short mask = (unsigned short)(1 << idx);
+    unsigned char *p = (unsigned char *)(obj + 0x1d4 + idx * 0x68);
+    int mask = (unsigned short)(1 << idx);
     int ret = 0;
-    if (base[0] != 2) return ret;
-    if (base[1] != 0xa) return ret;
-    ret = func_02064a28(arg2, mask, base[2]);
-    base[0] = 1;
+    if (p[0] != 2) return ret;
+    if (p[1] != 0xa) return ret;
+    ret = func_02064a28(off, mask, p[2]);
+    p[0] = 1;
     return ret;
 }

--- a/src/func_ov002_020d71ec.c
+++ b/src/func_ov002_020d71ec.c
@@ -1,0 +1,54 @@
+#pragma opt_propagation off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct P2 { int a, b; };
+
+extern int _ZNK6Player14GetBodyModelIDEjb(void* self, u32 a, int b);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, int b, u32 d);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* ma, void* file, int a, int b, u32 d);
+
+extern struct P2 data_ov002_0210a34c;
+extern struct P2 data_ov002_0210a084;
+extern struct P2 data_ov002_0210eb88;
+extern u8 data_ov002_020ff0f8[];
+
+void func_ov002_020d71ec(char* p, int arg1)
+{
+    int arr[4];
+    char* model;
+    char* sub;
+    u32 shifted;
+    int val;
+
+    if (arg1 != 2) {
+        model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+        sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+        shifted = ((u32)*(int*)(sub + 8) << 4) >> 0x10;
+        *(struct P2*)&arr[0] = data_ov002_0210a34c;
+        *(struct P2*)&arr[2] = data_ov002_0210a084;
+        _ZN6Player7SetAnimEji5Fix12IiEj(p, arr[arg1], 0x40000000, 0x1000, 0);
+
+        if (*(u8*)(p + 0x714) == 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(p + 0x160), *(void**)((char*)(&arr[2])[arg1] + 4), 0x40000000, 0x1000, 0);
+        }
+
+        if (arg1 == 1) {
+            val = data_ov002_020ff0f8[shifted];
+            model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
+            sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+            val = ((u32)val << 0x10) >> 4;
+            *(int*)(sub + 8) = val;
+            *(int*)(*(int*)(p + 0x160) + 0x58) = val;
+        }
+
+        *(u8*)(p + 0x6e3) = 1;
+        return;
+    }
+
+    _ZN6Player7SetAnimEji5Fix12IiEj(p, 0x6c, 0x40000000, -0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(p + 0x160), *(void**)((char*)&data_ov002_0210eb88 + 4), 0x40000000, -0x1000, 0);
+    *(u8*)(p + 0x6e3) = 2;
+    *(u16*)(p + 0x6a4) = 0xa;
+}

--- a/src/func_ov006_020cdc8c.c
+++ b/src/func_ov006_020cdc8c.c
@@ -1,0 +1,25 @@
+#pragma opt_propagation off
+typedef int s32;
+typedef unsigned short u16;
+
+extern int _ZN4cstd4fdivEii(int a, int b);
+
+void func_ov006_020cdc8c(char *self)
+{
+    int d;
+    int v;
+    int base = 0x400;
+    u16 *pa = (u16 *)(((long long)(int)(self + 0x9a)) & 0xFFFFFFFFFFFFFFFFLL);
+
+    *pa = *pa + 0x40;
+
+    d = *(s32 *)(self + 0xc) - 0x74000;
+    if (d < 0)
+        d = -d;
+    v = (_ZN4cstd4fdivEii(d, 0x4c000) >> 3) + base;
+
+    if (*(u16 *)(self + 0x9a) & 0x4000)
+        *(s32 *)(self + 0x2c) = v;
+    else
+        *(s32 *)(self + 0x2c) = -v;
+}

--- a/src/func_ov006_020d6d7c.c
+++ b/src/func_ov006_020d6d7c.c
@@ -1,6 +1,4 @@
-// NONMATCHING: different op / idiom (div=7). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_propagation off
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;

--- a/src/func_ov007_020b78d0.c
+++ b/src/func_ov007_020b78d0.c
@@ -1,0 +1,14 @@
+#pragma opt_common_subs off
+extern int data_ov007_02103444;
+extern int data_ov007_02103448;
+int func_ov007_020b78d0(int x){
+  int r3 = x << 1;
+  int r0 = x & ~3;
+  int b = data_ov007_02103448;
+  int a = data_ov007_02103444;
+  int t = r3 - r0;
+  int st = a + t;
+  int rv = b + a;
+  data_ov007_02103444 = st;
+  return rv;
+}

--- a/src/func_ov026_02111d4c.cpp
+++ b/src/func_ov026_02111d4c.cpp
@@ -1,4 +1,5 @@
 //cpp
+#pragma opt_propagation off
 struct Vector3 { int x, y, z; };
 
 struct Player {
@@ -44,12 +45,12 @@ extern "C" int func_ov026_02111d4c(char* c)
         if (pl->flag6f9 == 0) {
             int dd = Vec3_Dist((Vector3*)(c + 0x1a8), &v);
             if (dd < 0x44c000) {
+                int q;
+                int t;
                 Vector3 m;
                 Vector3 out;
-                int q;
-                q = 0x44c000;
-                q -= dd;
-                q = q / 35;
+                t = 0x44c000 - dd;
+                q = t / 35;
                 m.x = 0;
                 m.y = 0;
                 m.z = q;


### PR DESCRIPTION
Six functions recovered from the near-miss DB by a mechanical (no-LLM) lever sweep over all 265 sub-10-divergence drafts: each draft was recompiled under the validated pragma and launder-spelling variants and re-scored with the reloc-aware oracle.

- pragma opt_propagation off: func_ov002_020d71ec, func_02063d3c, func_ov006_020d6d7c, func_ov026_02111d4c, func_ov006_020cdc8c
- pragma opt_common_subs off: func_ov007_020b78d0

All six verified locally: match oracle MATCH on 1.2/sp2p3 and linkcheck VERIFIED with 0 blind slots.

Built with Claude Code