### PR TITLE
Restore original sources for func_02063d3c and func_ov026_02111d4c

### DIFF
--- a/src/func_02063d3c.c
+++ b/src/func_02063d3c.c
@@ -1,14 +1,15 @@
-#pragma opt_propagation off
-extern int func_02064a28(int off, int v, int b);
+extern int func_02064a28(int off, unsigned short v, unsigned char b);
 
-int func_02063d3c(char *obj, int idx, int off)
+#pragma opt_propagation off
+
+int func_02063d3c(char* c, int idx, int arg2)
 {
-    unsigned char *p = (unsigned char *)(obj + 0x1d4 + idx * 0x68);
-    int mask = (unsigned short)(1 << idx);
+    unsigned char* base = (unsigned char*)(c + 0x1d4 + idx * 0x68);
+    unsigned short mask = (unsigned short)(1 << idx);
     int ret = 0;
-    if (p[0] != 2) return ret;
-    if (p[1] != 0xa) return ret;
-    ret = func_02064a28(off, mask, p[2]);
-    p[0] = 1;
+    if (base[0] != 2) return ret;
+    if (base[1] != 0xa) return ret;
+    ret = func_02064a28(arg2, mask, base[2]);
+    base[0] = 1;
     return ret;
 }

--- a/src/func_ov026_02111d4c.cpp
+++ b/src/func_ov026_02111d4c.cpp
@@ -1,5 +1,4 @@
 //cpp
-#pragma opt_propagation off
 struct Vector3 { int x, y, z; };
 
 struct Player {
@@ -45,12 +44,12 @@ extern "C" int func_ov026_02111d4c(char* c)
         if (pl->flag6f9 == 0) {
             int dd = Vec3_Dist((Vector3*)(c + 0x1a8), &v);
             if (dd < 0x44c000) {
-                int q;
-                int t;
                 Vector3 m;
                 Vector3 out;
-                t = 0x44c000 - dd;
-                q = t / 35;
+                int q;
+                q = 0x44c000;
+                q -= dd;
+                q = q / 35;
                 m.x = 0;
                 m.y = 0;
                 m.z = q;


### PR DESCRIPTION
Reverts the redundant replacement of two already-matched files that #189 picked up from stale nearmiss DB entries. Both restored originals re-verified byte-reproducing with the match oracle. Net matched count is unchanged; #189's genuinely new matches (func_ov002_020d71ec, func_ov006_020cdc8c, func_ov007_020b78d0, and the func_ov006_020d6d7c NONMATCHING upgrade) are untouched.

Built with Claude Code