### PR TITLE
Match 7 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Actor15GivePlayerCoinsER6Playerhj.c
+++ b/src/_ZN5Actor15GivePlayerCoinsER6Playerhj.c
@@ -1,40 +1,63 @@
-// NONMATCHING: register allocation (div=18). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef short s16;
-struct Vector3 { s32 x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+struct Vector3
+{
+  s32 x;
+  s32 y;
+  s32 z;
+};
+struct Vector3_16
+{
+  s16 x;
+  s16 y;
+  s16 z;
+};
 extern u32 data_02075238[];
 extern u16 data_02075230[];
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vector3 *v);
 extern void GiveCoins(s32 a, s32 b);
 extern void _ZN6Player4HealEi(void *p, s32 amt);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 param, struct Vector3 *v, struct Vector3_16 *vr, s32 a, s32 b);
-void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *c, void *p, unsigned char h, u32 j){
-    s32 amt;
-    void *spawned;
-    struct Vector3 vec;
-    struct Vector3 *src;
-    if (p == 0) return;
-    if (h == 0) return;
-    if (j >= 3) return;
-    if (*(unsigned char*)((char*)p+0x706) != 0)
-        _ZN5Sound9PlayBank3EjRK7Vector3(0x12, (struct Vector3*)((char*)c+0x74));
-    else
-        _ZN5Sound9PlayBank3EjRK7Vector3(0x11, (struct Vector3*)((char*)c+0x74));
-    amt = h * data_02075238[j];
-    GiveCoins(*(unsigned char*)((char*)p+0x6d8), amt);
-    _ZN6Player4HealEi(p, amt << 8);
-    src = (struct Vector3*)((char*)p+0x5c);
-    vec.x = src->x;
-    vec.y = src->y;
-    vec.z = src->z;
-    vec.y = vec.y + 0x96000;
-    spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        data_02075230[j], 8, &vec, (struct Vector3_16*)0,
-        *(signed char*)((char*)p+0xcc), -1);
-    if (spawned != 0) *(void**)((char*)spawned+0x39c) = p;
+void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *c, void *p, unsigned char h, u32 j)
+{
+  s32 amt;
+  void *spawned;
+  struct Vector3 vec;
+  struct Vector3 *src;
+  if (p == 0)
+  {
+    return;
+  }
+  if (h == 0)
+  {
+    return;
+  }
+  if (j >= 3)
+  {
+    return;
+  }
+  if ((*((unsigned char *) (((char *) p) + 0x706))) != 0)
+  {
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x12, (struct Vector3 *) (((char *) c) + 0x74));
+  }
+  else
+  {
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x11, (struct Vector3 *) (((char *) c) + 0x74));
+  }
+  amt = h * data_02075238[j];
+  GiveCoins(*((unsigned char *) (((char *) p) + 0x6d8)), amt);
+  _ZN6Player4HealEi(p, amt << 8);
+  src = (struct Vector3 *) (((int) p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+  vec.x = src->x;
+  vec.y = src->y;
+  vec.z = src->z;
+  vec.y = vec.y + 0x96000;
+  spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(data_02075230[j], 8, &vec, (struct Vector3_16 *) 0, *((signed char *) (((char *) p) + 0xcc)), -1);
+  if (spawned != 0)
+  {
+    *((void **) (((char *) spawned) + 0x39c)) = p;
+  }
 }

--- a/src/func_02057078.c
+++ b/src/func_02057078.c
@@ -1,0 +1,15 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
+// NitroSDK OS_ReleaseLockID sibling of func_02057020 (OS_GetLockID) - SDK ships these as asm functions.
+asm void func_02057078(int lockID) {
+    ldr r3, =0x027fffb0
+    cmp r0, #0x60
+    addpl r3, r3, #4
+    subpl r0, r0, #0x60
+    submi r0, r0, #0x40
+    mov r1, #0x80000000
+    mov r1, r1, lsr r0
+    ldr r2, [r3]
+    orr r2, r2, r1
+    str r2, [r3]
+    bx lr
+}

--- a/src/func_ov006_020c9aa0.cpp
+++ b/src/func_ov006_020c9aa0.cpp
@@ -1,0 +1,96 @@
+//cpp
+struct V3 { int x, y, z; };
+
+extern "C" {
+int DotVec3(const V3 *a, const V3 *b);
+void Vec3_MulScalar(V3 *out, const V3 *in, int scale);
+void SubVec3(V3 *a, V3 *b, V3 *c);
+void AddVec3(V3 *a, V3 *b, V3 *c);
+int _ZN4cstd4fdivEii(int a, int b);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fix, unsigned int flags);
+void func_ov006_020e6df0(int a0, int a1, int a2);
+void func_ov006_020c97bc(char *c);
+}
+
+extern int data_ov006_02140574;
+extern void *data_ov006_0213b22c[];
+extern int data_ov006_021405b0;
+extern int data_ov006_0213b1b4[2];
+
+struct VtObj {
+    virtual void d0();
+    virtual void d1();
+    virtual void d2();
+    virtual void d3();
+    virtual void m4();
+};
+
+extern "C" void func_ov006_020c9aa0(char *c)
+{
+    V3 tmp;
+    V3 tmp2;
+    V3 tmp3;
+    int r5v;
+    int r4v;
+    int dot;
+    int scale;
+    int fdivr;
+    int vx;
+
+    r5v = *(int *)(c + 0x10);
+    r4v = *(int *)(c + 0x14);
+    if (r5v < 0) r5v = -r5v;
+    {
+        int *src = (int *)(((long long)(int)(c + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+        tmp.x = src[0];
+        tmp.y = src[1];
+        tmp.z = src[2];
+    }
+
+    dot = DotVec3((V3 *)(c + 0x3c), &tmp);
+    scale = (int)(((long long)dot * 0x1200 + 0x800) >> 12);
+    Vec3_MulScalar(&tmp2, &tmp, scale);
+    SubVec3((V3 *)(c + 0x3c), &tmp2, (V3 *)(c + 0x3c));
+
+    fdivr = _ZN4cstd4fdivEii(r4v, r4v + r5v);
+    scale = (int)(((long long)data_ov006_02140574 * fdivr + 0x800) >> 12);
+    Vec3_MulScalar(&tmp3, &tmp, scale);
+    AddVec3((V3 *)(c + 0x3c), &tmp3, (V3 *)(c + 0x3c));
+
+    vx = *(int *)(c + 0x3c);
+    if (vx < -0x2800) vx = -0x2800;
+    else if (vx > 0x2800) vx = 0x2800;
+    *(int *)(c + 0x3c) = vx;
+
+    {
+        int fx = (int)(((long long)data_ov006_02140574 * 0x600 + 0x800) >> 12);
+        int cur = *(int *)(c + 0x40);
+        if (cur >= fx) fx = cur;
+        *(int *)(c + 0x40) = fx;
+    }
+
+    *(int *)(c + 0x48) = data_ov006_021405b0;
+    ((VtObj *)c)->m4();
+
+    *(int *)(c + 0x64) = 0;
+    if (*(int *)(c + 0x60) != 0) {
+        *(int *)(c + 0x60) = 0;
+    } else {
+        *(int *)(c + 0x60) = 1;
+    }
+
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void *)(c + 0x78),
+        *(void **)data_ov006_0213b22c[*(int *)(c + 0x60)], 0x40000000, 0x800, 0);
+
+    *(int *)(c + 0xd0) = 0;
+    func_ov006_020e6df0(0, *(int *)(c + 0x60), *(int *)(c + 0x24));
+
+    {
+        int a = data_ov006_0213b1b4[0];
+        int b = data_ov006_0213b1b4[1];
+        a = b ? a : a;
+        *(int *)(c + 0x70) = a;
+        *(int *)(c + 0x74) = b;
+    }
+    func_ov006_020c97bc(c);
+}

--- a/src/func_ov007_020be0dc.c
+++ b/src/func_ov007_020be0dc.c
@@ -1,0 +1,129 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern char **data_ov007_02104bc0;
+extern int data_ov007_02103230;
+extern char *data_ov007_0210342c;
+extern u16 data_ov007_020d7c58[];
+
+int func_ov007_020be850(void);
+void func_ov007_020c108c(void *c, int a, int b, int d, int e);
+void func_ov007_020bfd70(void *a0, void *a1, int *o1, int *o2);
+int func_020538b8(int x, int y);
+int _ZN4cstd3divEii(int a, int b);
+int func_ov007_020b7690(int i);
+void func_ov007_020be684(void *a0, void *ctx);
+void func_ov007_020c3fe4(void *p);
+
+#define G1 (*data_ov007_02104bc0)
+#define BASE1 (*(char **)(*(char **)(*(char **)(ev + 4)) + 0xc))
+
+int func_ov007_020be0dc(void)
+{
+    int endflag = 0;
+    char *actor;
+    int r6 = 0;
+    char *ev;
+    int val;
+    int sp4, sp8;
+
+    actor = *(char **)(*(char **)(G1 + 0xc));
+    ev = (char *)func_ov007_020be850();
+
+    if (ev == 0) {
+        val = data_ov007_02103230;
+    } else {
+        u8 kind = *(u8 *)(ev + 1);
+        int *coll;
+
+        switch (kind) {
+        case 0:
+            if (*(u8 *)(actor + 0x1d) != 0)
+                func_ov007_020c108c(actor, 0, 1, 0, 0);
+            break;
+        case 1:
+            {
+                char *y = *(char **)(*(char **)(ev + 4) + 0x18);
+                int idv = *(u16 *)(y + 0x10);
+                if (idv >= 0x226) {
+                    if (*(u8 *)(actor + 0x1d) != 1)
+                        func_ov007_020c108c(actor, 1, 1, 0, 0);
+                } else {
+                    if (*(u8 *)(actor + 0x1d) != 0)
+                        func_ov007_020c108c(actor, 0, 1, 0, 0);
+                }
+            }
+            break;
+        }
+
+        coll = (int *)(BASE1 + 0x24);
+        func_ov007_020bfd70((void *)*(int *)(data_ov007_0210342c + 0x30), coll, &sp4, &sp8);
+
+        {
+            char *P = data_ov007_0210342c;
+            if (*(int *)(P + 0x24) == 4) {
+                sp8 += 0x14b;
+            } else {
+                sp8 += data_ov007_020d7c58[*(int *)(P + 0xec)];
+            }
+        }
+
+        {
+            int t0 = (short)sp4 << 0xc;
+            int t1 = (short)sp8 << 0xc;
+            *(int *)(actor) = t0;
+            *(int *)(actor + 4) = t1;
+        }
+
+        {
+            int *pp = (int *)(((int)BASE1 + 0x18) & 0xFFFFFFFFFFFFFFFF);
+            int d = func_020538b8(pp[0], pp[2]);
+            int e = _ZN4cstd3divEii(d << 0xc, 0xffff);
+            unsigned int scale = ((e * 0x12) >> 0xc) & 0xff;
+            if (scale >= 0x12)
+                scale = 0x11;
+            if (*(u8 *)(actor + 0x1d) == 0)
+                func_ov007_020c108c(actor, 0, 0, 0, (int)scale);
+        }
+
+        if (*(u8 *)(actor + 0x1d) == 0)
+            *(u8 *)(actor + 0x15) = 0xf;
+        else
+            *(char *)(actor + 0x15) = -1;
+
+        if (coll[2] > 0)
+            *(u8 *)(actor + 0x14) = 0;
+        else
+            *(u8 *)(actor + 0x14) = 3;
+
+        endflag = *(int *)(*(char **)(ev + 4) + 0x94);
+        val = *(u8 *)(ev + 2);
+    }
+
+    data_ov007_02103230 = val;
+    if (val != -1)
+        r6 = func_ov007_020b7690(val);
+
+    if (r6 != 0) {
+        char *q = *(char **)(G1 + 4);
+        if (*(int *)(q + 8) == 0)
+            *(int *)(q + 8) = 1;
+        func_ov007_020be684((void *)r6, (void *)G1);
+    } else {
+        char *q = *(char **)(G1 + 4);
+        if (*(int *)(q + 8) != 0)
+            *(int *)(q + 8) = 0;
+    }
+
+    func_ov007_020c3fe4(*(char **)(G1 + 0xc));
+
+    {
+        int r0 = *(int *)(actor + 8);
+        if (r0 != 0 && endflag != 0)
+            r0 = 1;
+        else
+            r0 = 0;
+        *(int *)(actor + 8) = r0;
+        return r0;
+    }
+}

--- a/src/func_ov007_020c65bc.c
+++ b/src/func_ov007_020c65bc.c
@@ -1,0 +1,55 @@
+
+extern int func_ov007_020c25fc(void *a, int b, int c, int d, int e, int f);
+extern void func_ov007_020bfe4c(void *a, int b, int c, int d, int e);
+struct G
+{
+  char p8[8];
+  int f8;
+  int fc;
+  int f10;
+};
+struct B
+{
+  char p8[8];
+  unsigned short f8;
+  char p[0x16];
+  int *f20;
+  int *f24;
+  int *f28;
+};
+struct T
+{
+  char p10[0x10];
+  int f10;
+  int f14;
+  char p18[4];
+  struct G *f1c;
+  struct B *f20;
+  int f24;
+  char pad[0x80];
+  char *fa8;
+};
+int func_ov007_020c65bc(struct T *t, int a1, int a2, int a3)
+{
+  int ret = 0;
+  struct B *b = t->f20;
+  if (t->f14 < t->f10)
+  {
+    int m = b->f8 - 1;
+    struct G *g = t->f1c;
+    if (func_ov007_020c25fc(b, a1 << 12, a2 << 12, g->f8, g->fc, g->f10) != 0)
+    {
+      int idx = m + 1;
+      int *p = (int *)(((int)t + 0x14) & 0xFFFFFFFFFFFFFFFF);
+      b->f20[idx] = a3;
+      *p = *p + 1;
+      func_ov007_020bfe4c(t->fa8, b->f24[idx], b->f28[idx], -(*((int *) (t->fa8 + 0x2c))), t->f24 + (idx * 0xc));
+      ret = 1;
+    }
+  }
+  else
+  {
+    ret = 2;
+  }
+  return ret;
+}

--- a/src/func_ov060_02113ff4.c
+++ b/src/func_ov060_02113ff4.c
@@ -1,0 +1,32 @@
+extern void func_ov060_02111cc0(void *c, int a, int b);
+extern int func_ov060_02115a30(void *c);
+
+int func_ov060_02113ff4(char *c, unsigned short arg1, int arg2)
+{
+    int r;
+    unsigned char f = *(unsigned char *)(c + 0x423);
+    if (f == 0) {
+        func_ov060_02111cc0(c, 0x13, 0x40000000);
+        if (func_ov060_02115a30(c) != 0) {
+            unsigned char *p = (unsigned char *)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            *p = *p + 1;
+        }
+    } else if (f == 1) {
+        func_ov060_02111cc0(c, 0x12, 0x40000000);
+        if (func_ov060_02115a30(c) != 0) {
+            unsigned char *p = (unsigned char *)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            *p = *p + 1;
+        }
+    } else {
+        func_ov060_02111cc0(c, 0x10, 0);
+    }
+    r = 0;
+    *(int *)(c + 0x98) = 0;
+    {
+        short *q = (short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        *q += arg2;
+    }
+    if (*(unsigned short *)(c + 0x3fc) >= arg1)
+        r = 1;
+    return r;
+}

--- a/src/func_ov063_02119a50.c
+++ b/src/func_ov063_02119a50.c
@@ -1,17 +1,15 @@
-// NONMATCHING: register allocation (div=11). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void func_ov063_0211a964(void);
+#pragma optimize_for_size on
+extern void func_ov063_0211a964(char *c, int arg1);
 extern void func_ov063_02119b1c(void *);
 
 void func_ov063_02119a50(char *c) {
-    *(unsigned short *)(c + 0x5d4) &= ~0x40;
+    *(unsigned short *)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~0x40;
     if (*(unsigned short *)(c + 0x100) >= 0x1e) {
         *(unsigned char *)(c + 0x5cc) = 1;
     } else {
         *(int *)(c + 0xa8) = 0;
         *(int *)(c + 0x98) = 0x7ccc;
-        func_ov063_0211a964();
+        func_ov063_0211a964(c, 0);
     }
     func_ov063_02119b1c(c);
 }


### PR DESCRIPTION
Fable refine wave over fresh sub-12-div near-miss drafts: 7 of 12 landed, every file independently re-verified by the land pipeline's link gate (VERIFIED, 0 blind).

- New: func_ov007_020c65bc, func_ov007_020be0dc, func_ov060_02113ff4, func_ov006_020c9aa0, func_02057078
- NONMATCHING-parked upgrades (both previously marked not byte-matchable from C): func_ov063_02119a50 (div=11), _ZN5Actor15GivePlayerCoinsER6Playerhj (div=18)
- func_02057078 is NitroSDK OS_ReleaseLockID, hand-written asm in the SDK; matched via asm block following the committed func_02057020 (OS_GetLockID) precedent.

An eighth agent-claimed match (_ZN3IRQ13DmaTimHandlerEv) failed independent re-verify and was NOT included; it remains parked.

Built with Claude Code