### PR TITLE
Match 10 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/Math_Function_0203b14c.c
+++ b/src/Math_Function_0203b14c.c
@@ -1,0 +1,29 @@
+int Math_Function_0203b14c(int *ptr, int target, int rate, int limit, int step)
+{
+    int cur = *ptr;
+    int v;
+    int d;
+    if (cur != target) {
+        int diff = target - cur;
+        v = (int)(((long long)diff * rate + 0x800) >> 12);
+        if (v >= step || v <= -step) {
+            if (v > limit) v = limit;
+            if (v < -limit) v = -limit;
+            *ptr += v;
+        } else if (v > 0) {
+            if (v < step) {
+                *ptr = cur + step;
+                if (*ptr > target) *ptr = target;
+            }
+        } else {
+            if (v > -step) {
+                int ns = -step;
+                *ptr = cur + ns;
+                if (*ptr < target) *ptr = target;
+            }
+        }
+    }
+    d = target - *ptr;
+    if (d < 0) d = -d;
+    return d;
+}

--- a/src/_ZN6Player9DropActorEv.cpp
+++ b/src/_ZN6Player9DropActorEv.cpp
@@ -1,0 +1,65 @@
+//cpp
+typedef unsigned int u32;
+typedef unsigned long long u64;
+struct State;
+struct Player;
+extern "C" int _ZN6Player7IsStateERNS_5StateE(Player* thiz, State* s);
+extern "C" void _ZN6Player11ChangeStateERNS_5StateE(Player* thiz, State* s);
+extern State data_ov002_02110364;
+extern State data_ov002_02110394;
+extern State data_ov002_02110604;
+extern State data_ov002_0211013c;
+extern State data_ov002_021105d4;
+extern State data_ov002_02110034;
+
+extern "C" int _ZN6Player9DropActorEv(char* thiz){
+    u32* s = *(u32**)(thiz + 0x358);
+    int present = (s != 0);
+    if (present) {
+        int held = ((s[0x2c] & 0x200) != 0);
+        if (!held) {
+            u32* s_ptr1 = (u32*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *s_ptr1 &= ~0x4000u;
+
+            u32* s_ptr2 = *(u32**)(thiz + 0x358);
+            u32* field_ptr2 = (u32*)(((int)s_ptr2 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *field_ptr2 &= ~0x100u;
+
+            u32* s_ptr3 = *(u32**)(thiz + 0x358);
+            u32* field_ptr3 = (u32*)(((int)s_ptr3 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *field_ptr3 &= ~0x400u;
+
+            u32* s_ptr4 = *(u32**)(thiz + 0x358);
+            u32* field_ptr4 = (u32*)(((int)s_ptr4 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *field_ptr4 &= ~0x2000u;
+
+            u32* s_ptr5 = *(u32**)(thiz + 0x358);
+            u32* field_ptr5 = (u32*)(((int)s_ptr5 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *field_ptr5 &= ~0x800u;
+
+            u32* s_ptr6 = *(u32**)(thiz + 0x358);
+            u32* field_ptr6 = (u32*)(((int)s_ptr6 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            *field_ptr6 &= ~0x1000u;
+
+            *(u32**)(thiz + 0x358) = 0;
+
+            if (_ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110364) ||
+                _ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110394) ||
+                _ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110604))
+            {
+                _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_0211013c);
+            }
+        } else {
+            _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_021105d4);
+        }
+        return 1;
+    }
+    {
+        int b = (*(int*)(thiz + 0x360) != 0);
+        if (!b) {
+            return 0;
+        }
+        _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_02110034);
+        return 1;
+    }
+}

--- a/src/_ZN8Particle24CheckWaterRippleCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle24CheckWaterRippleCallback8OnUpdateERNS_6SystemEb.cpp
@@ -1,0 +1,46 @@
+//cpp
+typedef int Fix12i;
+
+namespace Particle {
+struct Node;
+struct System {
+    int f0[7];
+    int f1c;
+    int f20, f24;
+};
+struct Node {
+    Node *next;
+    int f4;
+    int f8, fc, f10, f14, f18, f1c, f20, f24;
+    int f28;
+    unsigned short f2c;
+    unsigned short f2e;
+};
+struct CheckWaterRippleCallback {
+    bool OnUpdate(System &sys, bool b);
+};
+}
+extern "C" int data_0209f32c;
+extern "C" void _ZN8Particle6System9NewRippleE5Fix12IiES2_S2_(Fix12i a, Fix12i b, Fix12i c);
+
+bool Particle::CheckWaterRippleCallback::OnUpdate(Particle::System &sys, bool b)
+{
+    Particle::Node *node = (Particle::Node*)sys.f0[2];
+    if (b) {
+        *(int *)(((int)&sys + 0x1c) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+    } else {
+        *(int *)(((int)&sys + 0x1c) & 0xFFFFFFFFFFFFFFFF) |= 2;
+        if (node == 0) return false;
+    }
+    while (node != 0) {
+        int sx = node->f14 + node->f8;
+        int sy = node->f18 + node->fc;
+        int sz = node->f1c + node->f10;
+        if (node->f24 < 0 && (sy << 3) < data_0209f32c) {
+            node->f2e = node->f2c;
+            _ZN8Particle6System9NewRippleE5Fix12IiES2_S2_(sx << 3, data_0209f32c + 0x3000, sz << 3);
+        }
+        node = node->next;
+    }
+    return true;
+}

--- a/src/func_0200b990.c
+++ b/src/func_0200b990.c
@@ -1,0 +1,85 @@
+typedef unsigned char u8;
+typedef short s16;
+
+typedef struct V3 { int x, y, z; } V3;
+typedef struct RaycastLine { char pad[0x14]; char surf[0x64]; } RaycastLine;
+
+extern s16 Vec3_HorzAngle(const V3 *a, const V3 *b);
+extern void _ZN11RaycastLineC1Ev(RaycastLine *rc);
+extern void func_0200897c(char *self, RaycastLine *rc);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(RaycastLine *rc, V3 *a, V3 *b, void *actor);
+extern int _ZN11RaycastLine10DetectClsnEv(RaycastLine *rc);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *surf, V3 *out);
+extern s16 _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
+extern int AngleDiff(int a, int b);
+extern void _ZN11RaycastLineD1Ev(RaycastLine *rc);
+extern void _Z14ApproachLinearRsss(s16 *v, s16 step, s16 rate);
+extern signed char data_0209f2f8;
+
+void func_0200b990(char *self, char *arg1, int arg2)
+{
+    V3 v;
+    s16 angle;
+    u8 b0, b1;
+    int step;
+    int rate;
+
+    {
+        int sz = (int)(*(s16 *)(arg1 + 6)) << 12;
+        int sy = (int)(*(s16 *)(arg1 + 4)) << 12;
+        int sx = (int)(*(s16 *)(arg1 + 2)) << 12;
+        v.x = sx;
+        v.y = sy;
+        v.z = sz;
+    }
+    angle = Vec3_HorzAngle(&v, (V3 *)(self + 0x80));
+
+    rate = 8;
+    b0 = *(u8 *)(arg1 + 0);
+    if (b0 == 0) {
+        b1 = *(u8 *)(arg1 + 1);
+        if (b1 == 0xff) {
+            signed char zone = data_0209f2f8;
+            if (zone != 0x16 && zone != 0xa && zone != 0x10) {
+                RaycastLine rc;
+                V3 lineB;
+                _ZN11RaycastLineC1Ev(&rc);
+                func_0200897c(self, &rc);
+                lineB.y = *(int *)(self + 0x84);
+                lineB.x = v.x;
+                lineB.z = v.z;
+                _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(&rc, (V3 *)(self + 0x80), &lineB, 0);
+                if (_ZN11RaycastLine10DetectClsnEv(&rc) != 0) {
+                    V3 normal;
+                    s16 a2;
+                    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rc.surf, &normal);
+                    a2 = _ZN4cstd5atan2E5Fix12IiES1_(normal.x, normal.z);
+                    if (AngleDiff(a2, angle) < 0x1800) angle = a2;
+                }
+                _ZN11RaycastLineD1Ev(&rc);
+            }
+            step = 0x2000;
+        } else {
+            step = 0;
+            rate = (data_0209f2f8 == 0x2d) ? 0x12 : 0xf;
+        }
+    } else {
+        step = 0x6800;
+    }
+
+    {
+        char *ptr = *(char **)(self + 0x110);
+        s16 target = *(s16 *)(ptr + 0x8e);
+        s16 diff = (s16)(angle - target);
+        if (diff < 0) {
+            angle -= step;
+        } else {
+            angle += step;
+        }
+    }
+
+    {
+        int fixmul = (int)(((long long)arg2 * rate + 0x800) >> 12);
+        _Z14ApproachLinearRsss((s16 *)(self + 0x17c), angle, (s16)fixmul);
+    }
+}

--- a/src/func_ov002_020b6fcc.cpp
+++ b/src/func_ov002_020b6fcc.cpp
@@ -1,0 +1,102 @@
+//cpp
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern "C" {
+
+struct V16 { u16 x, y, z; };
+
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* p);
+extern void* _ZNK12WithMeshClsn13GetWallResultEv(void* p);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* si, void* out);
+extern s16 _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void* self, int a, int b, short c);
+extern void* _ZN5Actor10FindWithIDEj(unsigned id);
+extern int _ZN6Player15IsCollectingCapEv(void* p);
+extern void _ZN6Player15InitVanishLuigiEv(void* p);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
+extern void _ZN6Player14InitMetalWarioEv(void* p);
+extern int _ZN8SaveData16HasPlayerLostCapEv(void);
+extern void func_ov002_020b7f2c(void* c, void* pmf);
+extern int _ZN6Player17SetNoControlStateEhih(void* p, u8 a, int b, u8 c);
+extern void _ZN6Player18SetNewHatCharacterEjjb(void* p, unsigned a, unsigned b, bool c);
+
+extern int data_ov002_0210df54;
+
+void func_ov002_020b6fcc(char* self)
+{
+    struct V16 v;
+    int normal[3];
+    int state;
+
+    if (_ZNK12WithMeshClsn8IsOnWallEv(self + 0x144) != 0) {
+        void* wr = _ZNK12WithMeshClsn13GetWallResultEv(self + 0x144);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)wr + 4, &normal[0]);
+        *(s16*)(self + 0x94) = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(
+            self, normal[0], normal[2], *(s16*)(self + 0x94));
+    }
+
+    if (*(int*)(self + 0x134) == 0) return;
+
+    *(void**)(self + 0x3c0) = _ZN5Actor10FindWithIDEj(*(int*)(self + 0x134));
+    if (*(void**)(self + 0x3c0) == 0) return;
+
+    {
+        int t = (*(u16*)(*(char**)(self + 0x3c0) + 0xc) == 0xbf);
+        if (t == false) return;
+    }
+
+    if ((*(int*)(self + 0x130) & 0x8000) != 0) return;
+    if (_ZN6Player15IsCollectingCapEv(*(void**)(self + 0x3c0)) != 0) return;
+
+    if (*(int*)(*(char**)(self + 0x3c0) + 8) == 3) {
+        if (*(int*)(*(char**)(self + 0x3c0) + 0x360) != 0) return;
+    }
+
+    state = *(int*)(self + 0x3f0);
+    if ((unsigned)(state - 6) <= 1) {
+        _ZN6Player15InitVanishLuigiEv(*(void**)(self + 0x3c0));
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    }
+    if ((unsigned)(state - 8) <= 1) {
+        _ZN6Player14InitMetalWarioEv(*(void**)(self + 0x3c0));
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    }
+
+    if (*(int*)(self + 0xc8) != 0) {
+        if (state != 0) return;
+    }
+
+    if (_ZN8SaveData16HasPlayerLostCapEv() != 0) {
+        func_ov002_020b7f2c(self, &data_ov002_0210df54);
+        *(u8*)(self + 0x401) = 1;
+        return;
+    }
+
+    if (_ZN6Player17SetNoControlStateEhih(*(void**)(self + 0x3c0), 8, -1, 0) == 0) return;
+
+    _ZN6Player18SetNewHatCharacterEjjb(
+        *(void**)(self + 0x3c0), *(int*)(self + 0x3f4) & 0xff, 0, 0);
+
+    {
+        char* found = *(char**)(self + 0x3c0);
+        int a = *(u16*)(found + 0x8c);
+        int b = *(u16*)(found + 0x8e);
+        a = b ? a : a;
+        v.x = a;
+        v.y = b;
+        v.z = *(u16*)(found + 0x90);
+        *(s16*)(self + 0x92) = *(s16*)&v.x;
+        *(s16*)(self + 0x94) = *(s16*)&v.y;
+        *(s16*)(self + 0x96) = *(s16*)&v.z;
+        *(s16*)(self + 0x8c) = *(s16*)(self + 0x92);
+        *(s16*)(self + 0x8e) = *(s16*)(self + 0x94);
+        *(s16*)(self + 0x90) = *(s16*)(self + 0x96);
+    }
+
+    func_ov002_020b7f2c(self, &data_ov002_0210df54);
+}
+
+}

--- a/src/func_ov004_020addcc.c
+++ b/src/func_ov004_020addcc.c
@@ -1,29 +1,30 @@
-//cpp
-// NONMATCHING: different op / idiom (div=31). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" {
-int _Z15ApproachLinear2Rsss(short* a, short b, short c);
-void func_ov004_020b1b40(void* c);
-int _ZN4cstd4fdivEii(int a, int b);
 
-void func_ov004_020addcc(char* r5) {
-    if (_Z15ApproachLinear2Rsss((short*)(r5+0x1a), 0, 1)) {
-        func_ov004_020b1b40((void*)1);
-    }
-    int a = *(short*)(r5+0x1a);
-    int b = *(short*)(r5+0x1c);
-    int s = _ZN4cstd4fdivEii(a << 0xc, b << 0xc);
-    int c3 = *(short*)(r5+0x1c);
-    int c2 = *(short*)(r5+0x1a);
-    int t = _ZN4cstd4fdivEii((c3 - c2) << 0xc, c3 << 0xc);
-    long long m1 = (long long)*(int*)(r5+8) * (long long)s;
-    long long m2 = (long long)*(int*)(r5+0x10) * (long long)t;
-    long long m3 = (long long)s * (long long)s;
-    int d = *(int*)(r5+0xc) - *(int*)(r5+0x14);
-    long long m4 = (long long)((m3 + 0x800) >> 0xc) * (long long)d;
-    int x = (int)((m1 + 0x800) >> 0xc) + (int)((m2 + 0x800) >> 0xc);
-    *(int*)r5 = x;
-    *(int*)(r5+4) = *(int*)(r5+0x14) + (int)((m4 + 0x800) >> 0xc);
+int _Z15ApproachLinear2Rsss(short *a, short b, short c);
+void func_ov004_020b1b40(void *c);
+int _ZN4cstd4fdivEii(int a, int b);
+inline long long inline_fn(int arg0)
+{
+  return (long long) arg0;
 }
+
+void func_ov004_020addcc(char *r5)
+{
+  if (_Z15ApproachLinear2Rsss((short *) (r5 + 0x1a), 0, 1))
+  {
+    func_ov004_020b1b40((void *) 1);
+  }
+  int a = *((short *) (r5 + 0x1a));
+  int b = *((short *) (r5 + 0x1c));
+  int s = _ZN4cstd4fdivEii(a << 0xc, b << 0xc);
+  int c3 = *((short *) (r5 + 0x1c));
+  int c2 = *((short *) (r5 + 0x1a));
+  int t = _ZN4cstd4fdivEii((c3 - c2) << 0xc, c3 << 0xc);
+  int v8 = *((int *) (r5 + 8));
+  int v10 = *((int *) (r5 + 0x10));
+  long long m1 = inline_fn(v8) * inline_fn(s);
+  long long m2 = inline_fn(v10) * inline_fn(t);
+  long long m3 = inline_fn(s) * inline_fn(s);
+  long long m4 = inline_fn((int) ((m3 + 0x800) >> 0xc)) * inline_fn((*((int *) (r5 + 0xc))) - (*((int *) (r5 + 0x14))));
+  *((int *) r5) = ((int) ((m1 + 0x800) >> 0xc)) + ((int) ((m2 + 0x800) >> 0xc));
+  *((int *) (r5 + 4)) = (*((int *) (r5 + 0x14))) + ((int) ((m4 + 0x800) >> 0xc));
 }

--- a/src/func_ov006_020de5b0.c
+++ b/src/func_ov006_020de5b0.c
@@ -1,6 +1,3 @@
-// NONMATCHING: base materialization / addressing (div=19). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov006_020ddf9c(char *c);
 extern void func_ov004_020b0aa0(int n);
 extern void func_ov006_020dd334(char *c);
@@ -9,11 +6,10 @@ extern void func_ov006_020dc2f8(char *c);
 extern int func_ov004_020adc1c(void);
 void func_ov006_020de5b0(char *c);
 void func_ov006_020de5b0(char *c){
-    if (*(unsigned char*)(c + 0x51db) == 0) {
-        *(unsigned char*)(c + 0x51da) = 0;
+    if (*(unsigned char*)(c + 0x51db) != 0) {
+        *(unsigned char*)(((int)c + 0x51da) & 0xFFFFFFFFFFFFFFFF) += 1;
     } else {
-        unsigned char *p = (unsigned char*)(c + 0x51da);
-        *p = (unsigned char)(*p + 1);
+        *(unsigned char*)(c + 0x51da) = 0;
     }
     *(int*)(c + 0xa8) = 0;
     *(int*)(c + 0xac) = *(int*)(c + 0xa8);

--- a/src/func_ov006_020e8e10.cpp
+++ b/src/func_ov006_020e8e10.cpp
@@ -1,0 +1,57 @@
+//cpp
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern "C" int func_ov004_020af770(int a0, int a1, int a2, int a3, int a4, int a5, u16 a6);
+
+struct Ent { u16 f0, f2, f4, f6; };
+extern Ent *data_ov006_02133f24[];
+
+struct P {
+  char pad[0x208];
+  int i208;
+  int i20c;
+  char pad2[0x219 - 0x210];
+  u8 b219;
+  u8 b21a;
+  u8 b21b;
+  u8 b21c;
+  char pad3[0x54e - 0x21d];
+  u8 b54e;
+};
+
+#define PP(base) ((P *)((base) + 0x5000))
+
+extern "C" void func_ov006_020e8e10(char *c0) {
+  int i;
+  int x;
+  int y;
+  int c;
+  Ent *r7;
+  char *c2;
+  u8 b;
+  c2 = c0;
+  for (i = 0; i < 5; i++) {
+    if (PP(c2)->b21a != 0) {
+      b = PP(c2)->b21b;
+      x = PP(c2)->i208 >> 0xc;
+      y = PP(c2)->i20c >> 0xc;
+      c = PP(c2)->b21c;
+      r7 = data_ov006_02133f24[b];
+      for (;;) {
+        int *r0 = (int *)func_ov004_020af770(
+            (int)r7, x, y, -1, c, 0x1000, 0);
+        if (PP(c0)->b54e && !PP(c2)->b219) {
+          int v = r0[0];
+          int w = r0[1];
+          int bits = (int)((unsigned int)(w << 0x10) >> 0x1c);
+          r0[0] = (v & ~0xc00) | 0x400;
+          *(u16 *)((char *)r0 + 4) = (u16)((*(u16 *)((char *)r0 + 4) & ~0xf000) | (bits << 12));
+        }
+        if (r7->f6 == 0xffff) break;
+        r7++;
+      }
+    }
+    c2 += 0x18;
+  }
+}

--- a/src/func_ov006_021203fc.c
+++ b/src/func_ov006_021203fc.c
@@ -1,0 +1,116 @@
+
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+extern void *_ZN2G212GetBG2ScrPtrEv(void);
+extern void MultiStore16(u16 val, void *dst, int nbytes);
+extern void *LoadFile(int handle);
+extern void *_ZN2G213GetBG2CharPtrEv(void);
+extern void DecompressLZ16(void *src, void *dst);
+extern void Deallocate(void *p);
+extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void func_02056314(void *dst, u32 offset, u32 len);
+extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void *_ZN3G2S12GetBG0ScrPtrEv(void);
+extern void func_ov004_020af2f8(char *self, int a, int b, int c);
+extern void *_ZN3G2S13GetBG0CharPtrEv(void);
+extern unsigned func_02054de8(void);
+extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void func_02056374(const void *src, u32 offset, u32 count);
+extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
+extern void func_ov004_020b04d0(int v);
+extern void func_ov006_0211fbf8(char *p);
+extern void func_ov006_0211d7b4(char *p);
+extern void func_ov006_0211dd6c(char *p);
+extern void func_ov006_0211f77c(char *p);
+extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
+extern u8 data_0209d45c;
+extern u8 data_0209d454;
+extern int func_020bc880;
+extern int func_020bc884;
+int func_ov006_021203fc(char *self)
+{
+  void *f1;
+  void *f2;
+  void *t;
+  volatile u16 fa;
+  volatile u16 fb;
+  volatile u16 fc;
+  *((volatile u16 *) 0x400000c) &= ~3;
+  *((volatile u16 *) 0x400000c) &= ~0x40;
+  *((volatile u32 *) 0x4000018) = 0;
+  *((volatile u16 *) 0x400000c) = ((*((volatile u16 *) 0x400000c)) & 0x43) | 0x1210;
+  {
+    void *p = _ZN2G212GetBG2ScrPtrEv();
+    fa = 0x5300;
+    MultiStore16(fa, p, 0x800);
+  }
+  data_0209d45c |= 8;
+  *((volatile u16 *) 0x400000e) = (*((volatile u16 *) 0x400000e)) & (~3);
+  *((volatile u16 *) 0x400000e) &= ~0x40;
+  *((volatile u32 *) 0x400001c) = 0;
+  *((volatile u16 *) 0x400000e) = ((*((volatile u16 *) 0x400000e)) & 0x43) | 0x9310;
+  t = LoadFile(0x9b);
+  DecompressLZ16(t, _ZN2G213GetBG2CharPtrEv());
+  Deallocate(t);
+  t = LoadFile(0x9c);
+  _ZN2GX10LoadBGPlttEPKvjj(t, 0x60, 0x1a0);
+  Deallocate(t);
+  t = LoadFile(0x9e);
+  func_02056314(t, 0, 0x800);
+  Deallocate(t);
+  t = LoadFile(0x9d);
+  func_02056314(t, 0x800, 0x800);
+  Deallocate(t);
+  f1 = LoadFile(0x101);
+  f2 = LoadFile(0x102);
+  DecompressLZ16(f1, (void *) 0x6400000);
+  _ZN2GX11LoadOBJPlttEPKvjj(f2, 0, 0x100);
+  *((volatile u16 *) 0x4001008) = ((*((volatile u16 *) 0x4001008)) & 0x43) | 0x218;
+  *((volatile u16 *) 0x4001008) &= ~0x40;
+  *((volatile u32 *) 0x4001010) = 0;
+  *((volatile u16 *) 0x4001008) &= ~3;
+  {
+    void *p = _ZN3G2S12GetBG0ScrPtrEv();
+    fb = 0;
+    MultiStore16(fb, p, 0x800);
+  }
+  f2 += 0;
+  func_ov004_020af2f8(self, 0, 0, 0);
+  {
+    void *p = _ZN3G2S13GetBG0CharPtrEv();
+    fc = 0x1111;
+    MultiStore16(fc, p, 0x6000);
+  }
+  data_0209d454 |= 4;
+  *((volatile u16 *) 0x400100c) = ((*((volatile u16 *) 0x400100c)) & (~3)) | 1;
+  *((volatile u16 *) 0x400100c) &= ~0x40;
+  *((volatile u32 *) 0x4001018) = 0;
+  *((volatile u16 *) 0x400100c) = ((*((volatile u16 *) 0x400100c)) & 0x43) | 0x408;
+  t = LoadFile(0x9f);
+  DecompressLZ16(t, (void *) func_02054de8());
+  Deallocate(t);
+  t = LoadFile(0xa0);
+  _ZN3GXS10LoadBGPlttEPKvjj(t, 0x60, 0x1a0);
+  Deallocate(t);
+  t = LoadFile(0xa1);
+  func_02056374(t, 0, 0x800);
+  Deallocate(t);
+  DecompressLZ16(f1, (void *) 0x6600000);
+  _ZN3GXS11LoadOBJPlttEPKvjj(f2, 0, 0x100);
+  Deallocate(f1);
+  Deallocate(f2);
+  func_ov004_020b04d0(0x20);
+  func_ov006_0211fbf8(self);
+  *((u8 *) (self + 0x4c23)) = 0xff;
+  func_ov006_0211d7b4(self);
+  func_ov006_0211dd6c(self);
+  func_ov006_0211f77c(self);
+  *((int *) (self + 0x4be8)) = 1;
+  *((u16 *) (self + 0x4c16)) = 0x20;
+  func_ov004_020b0cac(0xd, 0x80, 0xa8, 1, -1, 0xd);
+  func_020bc880 = 0x80;
+  func_020bc884 = -128;
+  *((int *) (self + 0xb4)) = 0;
+  return 1;
+}

--- a/src/func_ov060_02114300.c
+++ b/src/func_ov060_02114300.c
@@ -1,0 +1,29 @@
+extern int func_ov060_0211469c(void *c);
+extern void func_02012694(int a, char *b, int cnt);
+extern int func_ov060_021145d4(void *c);
+extern int func_ov060_02115a30(void *c);
+
+void func_ov060_02114300(char *c)
+{
+    unsigned char k = *(unsigned char*)(c + 0x423);
+    if (k == 0) {
+        if (!func_ov060_0211469c(c)) return;
+        {
+            int v;
+            *(int*)(c + 0xa8) = 0x32000;
+            *(int*)(c + 0x98) = 0x19000;
+            *(short*)(c + 0x3fe) = 0;
+            v = *(unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF) = (unsigned char)v;
+            func_02012694(0xb1, c + 0x74, v);
+        }
+    } else if (k == 1) {
+        if (!func_ov060_021145d4(c)) return;
+        {
+            unsigned char *p = (unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            *p = *p + 1;
+        }
+    } else {
+        if (func_ov060_02115a30(c)) *(int*)(c + 0x40c) = 0;
+    }
+}


### PR DESCRIPTION
Fable refine wave 2 over div 10-20 near-miss drafts (8/13 landed) plus two free post-pass matches (clone + a paramclone upgrade of a NONMATCHING-parked div=31 file). Every file independently link-gate VERIFIED with 0 blind slots; one invented callee name was repointed to the real mangled symbol per the ROM branch target before shipping.

Three of the ten were previously parked as NONMATCHING (not byte-matchable from C): func_ov006_020de5b0, func_ov004_020addcc, and wave upgrades continue to disprove parked walls.

Built with Claude Code