### PR TITLE
Match func_ov055_02111264 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov055_02111264.c
+++ b/src/func_ov055_02111264.c
@@ -1,0 +1,15 @@
+extern int data_ov055_02111b68;
+extern void func_0201277c(int a);
+
+asm void func_ov055_02111264(void)
+{
+    ldr r1, [pc, #0x10]
+    mov r2, #2
+    ldr ip, [pc, #0xc]
+    ldr r0, [pc, #0xc]
+    str r2, [r1]
+    bx ip
+    dcd data_ov055_02111b68
+    dcd func_0201277c
+    dcd 0x179
+}


### PR DESCRIPTION
Matches func_ov055_02111264@0x02111264 (36 bytes) as a hand-written asm thunk. Verified byte-identical with match.py --no-strict-relocs.