### PR TITLE
Match 37 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN3HUD15RenderStarCountEv.cpp
+++ b/src/_ZN3HUD15RenderStarCountEv.cpp
@@ -1,0 +1,92 @@
+//cpp
+// _ZN3HUD15RenderStarCountEv at 0x020fc458 (ov002)
+struct OamAttr;
+struct Matrix2x2;
+
+typedef struct HUD_s {
+    char pad[0x70];
+    short unk70;
+    short unk72;
+    signed char digits[3];
+} HUD_s;
+
+extern "C" {
+
+extern unsigned char data_0209f2d8;
+extern unsigned char data_0209f250;
+extern signed char data_0209f310[];
+extern unsigned char data_0209f2fc;
+extern unsigned char data_ov002_02111178;
+extern unsigned char data_0209f2ac;
+extern unsigned char data_0209f2d4;
+extern int data_020a0db0;
+
+extern struct OamAttr* func_020aba70[];
+extern struct OamAttr func_020ab9c8;
+extern struct OamAttr func_020abad0;
+
+extern unsigned char NumStars(void);
+extern void _ZN3HUD15CalculateDigitsEt(HUD_s* thisptr, unsigned short n);
+extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int b, struct OamAttr* attr, int x, int y, int a, int c, struct Matrix2x2* m);
+
+void _ZN3HUD15RenderStarCountEv(HUD_s* thisptr)
+{
+    int x = thisptr->unk70;
+    int b = (data_0209f2d8 == 1);
+    int i;
+
+    if (b) {
+        _ZN3HUD15CalculateDigitsEt(thisptr, (unsigned short)data_0209f310[data_0209f250]);
+        for (i = 2; i >= 0; i--) {
+            if (thisptr->digits[i] >= 0) {
+                _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[thisptr->digits[i]], x, 2, -1, 1, 0);
+                x -= 9;
+            }
+        }
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, x, 10, -1, 1, 0);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, x - 16, 10, -1, 1, 0);
+        return;
+    }
+
+    _ZN3HUD15CalculateDigitsEt(thisptr, NumStars());
+
+    {
+        unsigned char m = data_0209f2fc;
+        if ((m != 2 && data_ov002_02111178 == 4) ||
+            (m == 1 && data_ov002_02111178 >= 3 && data_ov002_02111178 < 6)) {
+            int flag;
+            if (data_0209f2ac != 0) {
+                if (data_0209f2d4 == 3 && (data_020a0db0 & 0x18) == 0) {
+                    flag = 0;
+                } else {
+                    flag = 1;
+                }
+            } else {
+                flag = 1;
+            }
+            if (flag == 0) {
+                return;
+            }
+            for (i = 2; i >= 0; i--) {
+                if (thisptr->digits[i] >= 0) {
+                    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, func_020aba70[thisptr->digits[i]], x, 2, -1, 1, 0);
+                    x -= 9;
+                }
+            }
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020ab9c8, x, 10, -1, 1, 0);
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &func_020abad0, x - 16, 10, -1, 1, 0);
+            return;
+        }
+    }
+
+    for (i = 2; i >= 0; i--) {
+        if (thisptr->digits[i] >= 0) {
+            _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, func_020aba70[thisptr->digits[i]], x, 2, -1, 1, 0);
+            x -= 9;
+        }
+    }
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &func_020ab9c8, x, 10, -1, 1, 0);
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, &func_020abad0, x - 16, 10, -1, 1, 0);
+}
+
+}

--- a/src/_ZN3OAM7SECONDSE.cpp
+++ b/src/_ZN3OAM7SECONDSE.cpp
@@ -1,0 +1,70 @@
+//cpp
+struct UnkVtbl {
+    virtual void Virtual0();
+    virtual void Virtual4();
+};
+
+extern "C" {
+extern int data_ov006_0213e63c[][2];
+extern void* data_ov006_0213e96c[];
+extern void** data_ov006_0213e5ec[];
+extern unsigned char data_ov006_0213e4d8[];
+extern void func_ov004_020af68c(void* a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b2444(int a1, int a2, int num, int a4, int a5, int sel, int idx);
+extern void func_ov004_020af770(void* a0, int a1, int a2, int a3, int a4, int a5, unsigned short a6);
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020af868(void* a0, int a1, int a2, int a3, int a4, void* a5);
+extern void func_ov006_0210c234(unsigned char* o);
+
+#pragma opt_strength_reduction off
+int _ZN3OAM7SECONDSE(unsigned char* t)
+{
+    int i, pos, x, j;
+    unsigned char* cur = t;
+    unsigned char b;
+    for (i = 0; i < 3; i++) {
+        pos = *(t + i + 0x46ff);
+        x = data_ov006_0213e63c[i][1] - (*(int*)(t + (i << 2) + 0x46a4) >> 12);
+        for (j = 0; j < 2; j++) {
+            func_ov004_020af68c(data_ov006_0213e96c[*(cur + pos + 0x46c0)],
+                                data_ov006_0213e63c[i][0], x, -1, 3);
+            pos--;
+            x += 0x40;
+            if (pos < 0)
+                pos += 0x15;
+        }
+        cur += 0x15;
+    }
+    ((UnkVtbl*)(t + 0x4660))->Virtual4();
+    func_ov004_020b2444(0x70, 0xb0, *(int*)(t + 0xa8), 0, 1, 1, 0x14);
+    if (*(int*)(t + 0x46b4) >= 5 && (*(t + 0x470a) != 0 || (*(t + 0x470b) != 0 && *(t + 0x470b) < 3))) {
+        b = *(t + 0x470b);
+        if (b != 0 && b < 3) {
+            i = 0;
+            if ((int)b > 0) {
+                pos = 0x18;
+                do {
+                    func_ov004_020af770(data_ov006_0213e96c[0xb], pos, 0x30, -1, 2, 0x1000, 0);
+                    pos += 0x10;
+                    i++;
+                } while (i < *(t + 0x470b));
+            }
+            func_ov004_020af868(data_ov006_0213e5ec[func_ov004_020ad674()][1], 0x50, 0x30, -1, 2, 0);
+            func_ov004_020b2444(0x60, 0x30, *(t + 0x470b) * 2, 0, 2, 2, 0x14);
+        }
+        if (*(t + 0x470a) != 0) {
+            i = 0;
+            pos = 0x18;
+            for (; i < 3; i++) {
+                func_ov004_020af770(data_ov006_0213e96c[*(t + 0x4709) + 6], pos, 0x40, -1, 2, 0x1000, 0);
+                pos += 0x10;
+            }
+            func_ov004_020af868(data_ov006_0213e5ec[func_ov004_020ad674()][1], 0x50, 0x40, -1, 2, 0);
+            func_ov004_020b2444(0x60, 0x40, data_ov006_0213e4d8[*(t + 0x4709)], 0, 2, 2, 0x14);
+        }
+    }
+    func_ov006_0210c234(t + 0x4684);
+    func_ov006_0210c234(t + 0x4690);
+    return 1;
+}
+}

--- a/src/_ZN5Stage6RenderEv.cpp
+++ b/src/_ZN5Stage6RenderEv.cpp
@@ -1,0 +1,156 @@
+//cpp
+typedef unsigned char u8;
+
+struct Animation {
+    void Advance();
+};
+
+struct AnimSlot {
+    Animation* anim;
+    u8 flag;
+    u8 pad[7];
+};
+
+struct Particle {
+    struct SysTracker {
+        void Update();
+    };
+};
+
+struct ShadowModel {
+    static void RenderAll();
+};
+
+struct CylinderClsn {
+    static void Process();
+};
+
+struct OamAttr;
+struct Matrix2x2;
+
+struct OAM {
+    static int Render(bool, OamAttr*, int, int, int, int, Matrix2x2*);
+};
+
+struct Renderable {
+    virtual void v0();
+    virtual void v1();
+    virtual void v2();
+    virtual void v3();
+    virtual void v4();
+    virtual void Draw(int);
+};
+
+struct AnimMgr {
+    u8 pad[0x14];
+    u8 count;
+};
+
+extern "C" {
+    void func_020391f0(void);
+    void func_0203083c(void);
+    void func_ov001_020aaf40(void);
+    void func_0203db3c(int i, int v);
+    int SublevelToLevel(int i);
+
+    extern u8 data_0209f2c4;
+    extern u8 data_0209f20c;
+    extern u8 data_0209f294;
+    extern u8 data_0209f2d8;
+    extern u8 data_0209fc9c;
+    extern u8 data_0209f290;
+    extern u8 data_0209f21c;
+    extern u8 data_0209f2d4;
+    extern u8 data_0209f2b0;
+    extern u8 data_0209f260;
+    extern signed char data_02092124;
+    extern AnimMgr* data_0209f340;
+    extern char* data_0209f318;
+    extern char* data_0209f394[];
+    extern OamAttr func_020abad8;
+    extern OamAttr func_020ab9c8;
+}
+
+struct Stage {
+    int Render();
+    void RenderFog();
+    void RenderModel();
+    void RenderModelTransparent();
+    static void RenderVsModeCountdown();
+    static void RenderVsModeNewStar();
+    static void RenderBouncingArrows();
+    static void PS_Render();
+    static void LC_Render();
+    static void RenderNumber(u8, int, int, bool, int);
+};
+
+int Stage::Render() {
+    if (((data_0209f294 | (data_0209f2c4 | data_0209f20c)) & 0xff) == 0) {
+        AnimSlot* s = (AnimSlot*)((char*)this + 0x8bc);
+        int i;
+        for (i = 0; i < data_0209f340->count; i++, s++) {
+            if (s->flag != 0 && s->anim != 0)
+                s->anim->Advance();
+        }
+        ((Particle::SysTracker*)((char*)this + 0x50))->Update();
+    }
+    func_020391f0();
+    RenderFog();
+    {
+        Renderable* t = *(Renderable**)((char*)this + 0x9bc);
+        if (t != 0) {
+            int* dst = (int*)((char*)t + 0x1c);
+            int* src = (int*)((long long)(int)(data_0209f318 + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+            dst[9] = src[0] >> 3;
+            dst[10] = src[1] >> 3;
+            dst[11] = src[2] >> 3;
+            (*(Renderable**)((char*)this + 0x9bc))->Draw(0);
+        }
+    }
+    RenderModel();
+    ShadowModel::RenderAll();
+    RenderModelTransparent();
+    {
+        int b = (data_0209f2d8 == 1);
+        if (b) {
+            if (data_0209fc9c == 0 && data_0209f2c4 == 0) {
+                RenderVsModeCountdown();
+                RenderVsModeNewStar();
+                if (data_0209f294 != 0 && data_0209f290 != 2)
+                    RenderBouncingArrows();
+            }
+            func_0203083c();
+        }
+    }
+    CylinderClsn::Process();
+    func_ov001_020aaf40();
+    {
+        int x = 0;
+        int y = 0;
+        int j = 0;
+        int n = data_0209f21c;
+        for (; j < n; j++) {
+            char* p = data_0209f394[j];
+            if (p != 0) {
+                u8 bit = *(u8*)(p + 0x6ff);
+                int* q = (int*)((long long)(int)(p + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                x ^= (u8)(q[2] ^ (q[0] ^ q[1]));
+                y |= (u8)((bit & 1) << j);
+            }
+        }
+        func_0203db3c(0x10, x);
+        func_0203db3c(0x10, y);
+    }
+    if (data_0209f2c4 != 0) {
+        PS_Render();
+    } else if (data_0209f20c != 0 && data_0209f2d4 != 0) {
+        int v = (SublevelToLevel(data_02092124) < 0xf) ? 0x80 : 0x70;
+        if (data_0209f2b0 != 0)
+            v += 0x10;
+        OAM::Render(0, &func_020abad8, 0x68, v, -1, -1, 0);
+        OAM::Render(0, &func_020ab9c8, 0x78, v + 8, -1, -1, 0);
+        RenderNumber(data_0209f260, 0x80, v, 1, 8);
+    }
+    LC_Render();
+    return 1;
+}

--- a/src/_ZN6Player11St_Owl_MainEv.cpp
+++ b/src/_ZN6Player11St_Owl_MainEv.cpp
@@ -1,0 +1,118 @@
+//cpp
+extern "C" {
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
+extern void _Z14ApproachLinearRiii(int* p, int value, int speed);
+extern int ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
+extern void func_0201f32c(int a);
+extern void func_0200d3f8(void* thiz, unsigned char playerID, void* ptr);
+extern void func_ov002_020c9e40(char* c);
+extern void func_0200d6b4(void* thiz, unsigned char playerID);
+extern void func_ov002_020c9e18(char* c);
+extern int _ZN6Player12FinishedAnimEv(void* c);
+extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int d, unsigned int e);
+extern void func_ov002_020bedd4(void* c);
+
+extern unsigned char data_020a0e40;
+extern unsigned char data_0209f49c[];
+extern char data_0209f4a0[];
+extern int data_ov002_021101b4[];
+extern short data_02082214[];
+extern char* data_0209f318;
+extern unsigned char data_0209d660;
+
+int _ZN6Player11St_Owl_MainEv(char* c)
+{
+    unsigned char st;
+
+    *(int*)(c+0x684) = *(int*)(c+0x60);
+    st = *(unsigned char*)(c+0x6e3);
+    if (st != 2 && st != 3) {
+        if (*(int*)(c+0x358) == 0 ||
+            (*(unsigned short*)(data_0209f49c + data_020a0e40*0x18) & 2) == 0 ||
+            (*(unsigned char*)(c+0x6e9) & 2)) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            return 1;
+        }
+    }
+
+    switch (st) {
+    case 0:
+        if (*(int*)(c+0x688) <= *(int*)(c+0x60)) {
+            (*(unsigned char*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+            *(int*)(c+0x9c) = -0x2c00;
+        }
+        if (*(unsigned char*)(c+0x6de) != 0) {
+            if (*(int*)(c+0xa8) < 0) {
+                _Z14ApproachLinearRiii((int*)(c+0xa8), 0x3c000, 0x8000);
+            } else {
+                _Z14ApproachLinearRiii((int*)(c+0xa8), 0x3c000, 0x2000);
+            }
+        } else {
+            *(int*)(c+0xa8) = 0x8000;
+            *(unsigned char*)(c+0x6de) = 1;
+            *(unsigned char*)(c+0x6df) = 0;
+        }
+        ApproachAngle((short*)(c+0x8e), *(short*)(c+0x69c), 0x10, 0x100, 0);
+        break;
+
+    case 1:
+    case 4: {
+        int x = *(int*)(c+0x358);
+        short ang;
+        int i;
+        short mag = 10;
+        x = *(int*)(x + 0x364);
+        x = (unsigned short)((unsigned int)x >> 12);
+        x += 0xb;
+        ang = x * 0xccc;
+        i = (unsigned short)ang >> 4;
+        *(int*)(c+0xa8) = data_02082214[i*2+1] * mag;
+        *(int*)(c+0x98) = 0x14000;
+        if (*(short*)(data_0209f4a0 + data_020a0e40*0x18) != 0) {
+            ApproachAngle((short*)(c+0x8e), *(short*)(c+0x6d2), 0x20, 0x100, 0);
+        }
+        if (*(unsigned char*)(c+0x6e3) == 1) {
+            if (*(int*)(c+0x688) - 0xed8000 > *(int*)(c+0x60)) {
+                *(unsigned char*)(c+0x724) = 1;
+                func_0201f32c(0xa3);
+                func_0200d3f8(data_0209f318, *(unsigned char*)(c+0x6d8), 0);
+                *(int*)(c+0x9c) = 0;
+                func_ov002_020c9e40(c);
+                *(unsigned char*)(c+0x6e3) = 2;
+            }
+        } else {
+            if (*(unsigned short*)(c+0x6a4) == 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+                return 1;
+            }
+        }
+        break;
+    }
+
+    case 2:
+        *(int*)(c+0x98) = 0;
+        *(int*)(c+0xa8) = *(int*)(c+0x98);
+        if (data_0209d660 == 0) {
+            *(unsigned char*)(c+0x6e3) = 3;
+            func_0200d6b4(data_0209f318, *(unsigned char*)(c+0x6d8));
+        }
+        break;
+
+    case 3:
+        if ((*(int*)(data_0209f318 + 0x154) & 0x8000) == 0) {
+            *(unsigned char*)(c+0x6e3) = 4;
+            *(unsigned short*)(c+0x6a4) = 0x3c;
+            func_ov002_020c9e18(c);
+            *(unsigned char*)(c+0x724) = 0;
+        }
+        break;
+    }
+
+    if (_ZN6Player12FinishedAnimEv(c)) {
+        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x58, 0, 0x1000, 0);
+    }
+    *(short*)(c+0x94) = *(short*)(c+0x8e);
+    func_ov002_020bedd4(c);
+    return 1;
+}
+}

--- a/src/_ZN6Player13St_Climb_InitEv.cpp
+++ b/src/_ZN6Player13St_Climb_InitEv.cpp
@@ -1,0 +1,71 @@
+//cpp
+typedef int Fix12i;
+
+struct Vector3 {
+    int x, y, z;
+};
+
+extern int func_ov002_020dab14(char*);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
+extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, const Vector3&);
+extern int func_ov002_020e3078(void*, void*);
+extern char data_ov002_021106f4[];
+
+class Player {
+public:
+    int St_Climb_Init();
+};
+
+int Player::St_Climb_Init() {
+    char* self = (char*)this;
+    func_ov002_020dab14(self);
+
+    int* bitfield = (int*)(((int)self + 0x2ec) & 0xFFFFFFFFFFFFFFFF);
+    *bitfield |= 4;
+    *bitfield &= ~8;
+
+    if (*(int*)(self + 0x98) <= 0xa000) {
+        *(short*)(self + 0x69c) = 0;
+        _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x26, 0, (Fix12i)0x1000, 0);
+        *(unsigned char*)(self + 0x6e3) = 1;
+    } else {
+        int val = *(int*)(self + 0x98) / 16;
+        *(short*)(self + 0x69c) = (short)val;
+        if (*(short*)(self + 0x69c) >= 0x3000)
+            *(short*)(self + 0x69c) = 0x3000;
+        _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x27, 0x40000000, (Fix12i)0x1000, 0);
+        *(unsigned char*)(self + 0x6e3) = 0;
+    }
+
+    void* base = *(void**)(self + 0x37c);
+    void* vtable = *(void**)base;
+    void* (*func)(void*) = *(void* (**)(void*))((char*)vtable + 8);
+    void* res = func(base);
+
+    *(int*)(self + 0x5c) = *(int*)res;
+    *(int*)(self + 0x64) = *(int*)((char*)res + 8);
+    *(int*)(self + 0x688) = *(int*)(self + 0x60) - *(int*)((char*)res + 4);
+    *(int*)(self + 0x9c) = 0;
+    *(int*)(self + 0x98) = 0;
+    *(int*)(self + 0xa8) = 0;
+
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(self + 0x6d9), 0xd,
+                                           *(Vector3*)(self + 0x74));
+
+    *(unsigned char*)(self + 0x6e5) = 0;
+    *(short*)(self + 0x6b8) = 3;
+    *(int*)(self + 0x2dc) = 0x5a000;
+    *(unsigned char*)(self + 0x717) = 1;
+
+    {
+        char* b = *(char**)(self + 0x37c);
+        if (*(int*)(b + 0x18) & 0x1000000) {
+            if ((*(int*)(b + 8) >> 2) <= *(int*)(self + 0x688)) {
+                if (func_ov002_020e3078(self, data_ov002_021106f4) == 0) {
+                    *(short*)(self + 0x6a8) = 0xf;
+                }
+            }
+        }
+    }
+    return 1;
+}

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -1,0 +1,122 @@
+//cpp
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef s32 Fix12;
+
+extern "C" {
+extern void func_ov002_020bf90c(char* c);
+extern void func_ov002_020c06fc(char* c, u32 a);
+extern int func_ov002_020dd2f4(char* c);
+extern int func_ov002_020c0688(char* c);
+extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* s);
+extern int func_0201226c(int a0, int a1, int a2, char* a3, int a4, int a5);
+extern void func_ov002_020e25f0(char* c, int a);
+extern void func_ov002_020c18b0(char* c, int a);
+extern void func_ov002_020dcafc(char* c);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, char* v);
+extern void func_ov002_020dc560(char* c);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12 b, u32 d);
+extern int _ZN6Player12FinishedAnimEv(char* c);
+extern void func_ov002_020bedd4(char* c);
+
+extern u8 data_020a0e40;
+extern u16 data_0209f49e[];
+extern int data_ov002_0211019c[];
+extern int data_ov002_021101b4[];
+extern int data_ov002_0211013c[];
+}
+
+extern "C" int _ZN6Player17St_ButtSlide_MainEv(char* c)
+{
+    switch (*(u8*)(c + 0x6e6)) {
+    case 0:
+        func_ov002_020bf90c(c);
+        if (*(u8*)(c + 0x6de) == 0) {
+            *(u8*)(c + 0x6e4) = 1;
+            func_ov002_020c06fc(c, 0x4000);
+            func_ov002_020dd2f4(c);
+        }
+        if (*(int*)(c + 0x98) == 0) {
+            if (*(u8*)(c + 0x70e) == 0) {
+                *(u8*)(c + 0x6e6) = 2;
+                *(u8*)(c + 0x6e5) = 0;
+                break;
+            }
+            (*(u8*)(((int)c + 0x6e7) & 0xFFFFFFFFFFFFFFFF))++;
+            if (*(u8*)(c + 0x6e7) >= 0x1e) {
+                *(u8*)(c + 0x6e6) = 2;
+                *(u8*)(c + 0x6e5) = 0;
+                break;
+            }
+        } else {
+            *(u8*)(c + 0x6e7) = 0;
+        }
+        if (func_ov002_020c0688(c) != 0) {
+            if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) != 0
+                && *(u16*)(c + 0x6a6) == 0) {
+                *(u8*)(c + 0x6e1) = 0;
+                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+                return 1;
+            }
+            *(int*)(c + 0x620) = func_0201226c(*(int*)(c + 0x620), 0, *(int*)(c + 0x66c) + 0xe2, c + 0x74, *(int*)(c + 0x98), 0);
+        } else {
+            *(u8*)(c + 0x6e3) = 0;
+            *(u8*)(c + 0x6e6) = 1;
+            *(u8*)(c + 0x6e5) = 0;
+            if ((*(u8*)(c + 0x70c) | *(u8*)(c + 0x70e)) != 0)
+                *(int*)(c + 0xa8) = 0x15000;
+            func_ov002_020e25f0(c, 0);
+            *(u8*)(c + 0x6de) = 1;
+            *(u8*)(c + 0x6df) = 0;
+            break;
+        }
+        func_ov002_020c18b0(c, 0);
+        func_ov002_020dcafc(c);
+        break;
+    case 1:
+        *(s16*)(c + 0x90) = 0;
+        *(s16*)(c + 0x8c) = *(s16*)(c + 0x90);
+        if (*(u8*)(c + 0x6de) == 0) {
+            if (*(u8*)(c + 0x6df) == 0) {
+                *(u8*)(c + 0x6df) = 1;
+                _ZN5Sound9PlayBank0EjRK7Vector3(*(int*)(c + 0x66c) + 0x50, c + 0x74);
+            }
+            if (*(u8*)(c + 0x6e5) == 0 && *(int*)(c + 0x558) >= 0xfc1) {
+                *(int*)(c + 0xa8) = -*(int*)(c + 0x640) / 2;
+                (*(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
+            } else {
+                *(u8*)(c + 0x6e6) = 0;
+                *(int*)(c + 0xa8) = 0;
+                break;
+            }
+        } else {
+            func_ov002_020dc560(c);
+        }
+        (*(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+        if (*(u8*)(c + 0x6e3) > 0x1e
+            && *(int*)(c + 0x60) - *(int*)(c + 0x644) > 0x1f4000) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            return 1;
+        }
+        break;
+    case 2:
+        *(s16*)(c + 0x90) = 0;
+        *(s16*)(c + 0x8c) = *(s16*)(c + 0x90);
+        if (*(u8*)(c + 0x6e5) == 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x42, 0x40000000, 0x1000, 0);
+            *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+            *(u8*)(c + 0x6e5) = 1;
+        } else if (_ZN6Player12FinishedAnimEv(c) != 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        }
+        break;
+    }
+
+    *(int*)(c + 0x640) = *(int*)(c + 0xa8);
+    func_ov002_020bedd4(c);
+    *(u8*)(c + 0x70c) = *(u8*)(c + 0x70e);
+    return 1;
+}

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -1,0 +1,111 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+
+extern "C" {
+extern int func_ov002_020cf20c(char* c);
+extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
+extern int func_ov002_020d674c(char* c);
+extern void func_ov002_020cf384(char* c);
+extern int _ZN6Player12FinishedAnimEv(char* c);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, int b, u32 d);
+extern int _ZNK6Player14GetBodyModelIDEjb(char* c, u32 a, int b);
+extern void func_ov002_020cf2f8(char* c);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void* v);
+extern void func_ov002_020bedd4(char* c);
+
+extern u8 data_020a0e40;
+extern u16 data_0209f49c[];
+extern u16 data_0209f49e[];
+extern s16 data_0209f4a0[];
+extern u8 data_0209f4ab[];
+extern int data_ov002_0211013c;
+extern int data_ov002_0211004c;
+extern int data_ov002_021105a4;
+extern u32 data_ov002_0210a60c[];
+}
+
+extern "C" int _ZN6Player20St_CeilingGrate_MainEv(char* c)
+{
+    int r4;
+    int spd;
+
+    r4 = func_ov002_020cf20c(c);
+    if (r4 == 0x80000000) {
+        *(int*)(c + 0x5c) = *(int*)(c + 0x548);
+        *(int*)(c + 0x60) = *(int*)(c + 0x54c);
+        *(int*)(c + 0x64) = *(int*)(c + 0x550);
+        r4 = *(int*)(c + 0x60) + 0x90000;
+    }
+
+    {
+        int idx = data_020a0e40 * 0x18;
+        if ((*(u16*)((char*)data_0209f49c + idx) & 2) == 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+            return 1;
+        }
+        if (*(u16*)((char*)data_0209f49e + idx) & 0x400) {
+            if (func_ov002_020d674c(c) != 0)
+                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211004c);
+            else
+                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021105a4);
+            return 1;
+        }
+        {
+            u8* p = data_0209f4ab + idx;
+            if (*p != 0)
+                *p = 5;
+        }
+    }
+
+    switch (*(u8*)(c + 0x6e3)) {
+    case 0:
+        func_ov002_020cf384(c);
+        if (_ZN6Player12FinishedAnimEv(c) != 0) {
+            *(u8*)(c + 0x6e3) = 1;
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[*(u8*)(c + 0x6e5) & 1], 0, 0x1000, 0);
+        }
+        {
+            char* anim = (char*)(((long long)(int)(*(char**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            if ((u32)(*(int*)(anim + 8) << 4) >> 0x10 < 0x21)
+                break;
+        }
+    case 1:
+        func_ov002_020cf384(c);
+        if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
+            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+            *(u8*)(c + 0x6e3) = 2;
+            spd = *(int*)(c + 0x98) >> 3;
+            if (spd < 0x800)
+                spd = 0x800;
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[(*(u8*)(c + 0x6e5) & 1) + 2], 0x40000000, spd, 0);
+        }
+        break;
+    case 2:
+        func_ov002_020cf2f8(c);
+        spd = *(int*)(c + 0x98) >> 3;
+        if (spd < 0x800)
+            spd = 0x800;
+        {
+            char* anim = (char*)(((long long)(int)(*(char**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            *(int*)(anim + 0xc) = spd;
+        }
+        if (_ZN6Player12FinishedAnimEv(c) != 0) {
+            _ZN5Sound9PlayBank0EjRK7Vector3(0xb2, c + 0x74);
+            if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
+                *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+                _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[(*(u8*)(c + 0x6e5) & 1) + 2], 0x40000000, 0x1000, 0);
+            } else {
+                *(u8*)(c + 0x6e3) = 1;
+                _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[*(u8*)(c + 0x6e5) & 1], 0, 0x1000, 0);
+            }
+        }
+        break;
+    }
+
+    *(int*)(c + 0x60) = r4 - 0x90000;
+    func_ov002_020bedd4(c);
+    return 1;
+}

--- a/src/func_02031b84.c
+++ b/src/func_02031b84.c
@@ -1,6 +1,4 @@
-// NONMATCHING: register allocation (div=30). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 extern unsigned char data_0209fca8;
 extern void *data_0209fd10;
 extern unsigned char data_0209fcd4;
@@ -14,48 +12,56 @@ extern unsigned char data_0209fc88;
 extern unsigned char data_0209fd20[];
 unsigned int func_02054e88(void);
 int func_02054d88(void);
-
 void func_02031b84(char c)
 {
-    int i;
-    int *ip;
-    unsigned int word;
-    unsigned int masked;
-    int mask;
-    int sh;
-
-    if (data_0209fca8 == 2)
-        ip = (int *)((char *)data_0209fd10 + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
-    else if (data_0209fca8 == 1)
-        ip = (int *)((char *)func_02054e88() + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
+  int i;
+  int *ip;
+  unsigned int word;
+  unsigned int masked;
+  int mask;
+  int sh;
+  sh = data_0209fca8;
+  if (sh == 2)
+  {
+    ip = (int *) (((char *) data_0209fd10) + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
+  }
+  else
+    if (sh == 1)
+  {
+    ip = (int *) (((char *) func_02054e88()) + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
+  }
+  else
+  {
+    ip = (int *) (((char *) func_02054d88()) + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
+  }
+  mask = data_0209285c[data_0209fcd4];
+  sh = data_0209fccc;
+  for (i = 0; i < 0x10; i++)
+  {
+    word = *(ip++);
+    masked = word;
+    masked = masked & mask;
+    if (sh != 0)
+    {
+      masked = (masked >> ((8 - sh) << 2)) | (masked << (sh << 2));
+      data_0209fd5c[data_0209fd1c] = masked;
+    }
     else
-        ip = (int *)((char *)func_02054d88() + (((c & 0x1f) + ((c & 0xe0) << 1)) << 5));
-
-    mask = data_0209285c[data_0209fcd4];
-    sh = data_0209fccc;
-    for (i = 0; i < 0x10; i++)
     {
-        word = *ip++;
-        masked = word & mask;
-        if (sh != 0)
-        {
-            masked = (masked >> ((8 - sh) << 2)) | (masked << (sh << 2));
-            data_0209fd5c[data_0209fd1c] = masked;
-        }
-        else
-        {
-            data_0209fd5c[data_0209fd1c] = masked;
-        }
-        if (i == 7)
-            ip += 0xf8;
-        data_0209fd1c = data_0209fd1c + 1;
+      data_0209fd5c[data_0209fd1c] = masked;
     }
-
+    if (i == 7)
     {
-        unsigned char width = data_0208f074[c];
-        data_0209fccc = (sh + width) & 7;
-        data_0209fd20[data_0209fcd8] = width;
-        data_0209fc88 = data_0209fc88 + width;
-        data_0209fcd8 = data_0209fcd8 + 1;
+      ip += 0xf8;
     }
+    data_0209fd1c = data_0209fd1c + 1;
+  }
+
+  {
+    unsigned char width = data_0208f074[c];
+    data_0209fccc = (sh + width) & 7;
+    data_0209fd20[data_0209fcd8] = width;
+    data_0209fc88 = data_0209fc88 + width;
+    data_0209fcd8 = data_0209fcd8 + 1;
+  }
 }

--- a/src/func_02034b40.c
+++ b/src/func_02034b40.c
@@ -1,0 +1,78 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+
+extern int func_02034d34(void* thiz);
+extern void _ZN3OAM5ResetEv(void);
+extern s32 func_0200f0bc(void);
+extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(int sub, void* attr, int x, int y, int a, int cc, int fx, int mode);
+extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int sub, void* attr, int x, int y, int a, int cc, int fx0, int fy0, int rot, int mode);
+extern void _ZN3OAM9RenderSubEP7OamAttrii(void* attr, int a, int b);
+extern void func_0203083c(void);
+extern void _ZN3OAM5FlushEv(void);
+extern void _ZN3OAM4LoadEv(void);
+
+extern void* data_0208a0f8[];
+extern s16 data_02082214[];
+extern int data_0208ee44;
+
+int func_02034b40(char* self)
+{
+    if (*(void**)(self + 4) != 0)
+        func_02034d34(*(void**)(self + 4));
+    _ZN3OAM5ResetEv();
+
+    if (*(u8*)(self + 0xd) != 0) {
+        int id = func_0200f0bc();
+        void* attr = data_0208a0f8[id];
+
+        if (*(u8*)(self + 0xc) == 0) {
+            int sb = *(int*)(self + 8);
+            int x = 0x80;
+            int one = 1;
+            int arr[3];
+            arr[0] = 0;
+            arr[1] = 0;
+            arr[2] = 0;
+
+            do {
+                int y;
+                if (sb >= 0 && sb < 0x10000) {
+                    u16 t = (u16)sb;
+                    s16 ang = (s16)t;
+                    u16 t2 = (u16)ang;
+                    y = data_02082214[(t2 >> 4) * 2];
+                    y = (y >> 10) + 0x80;
+                    arr[0] = one;
+                } else {
+                    y = x;
+                }
+
+                _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(arr[1], attr, x, y, -1, -1, 0x1000, arr[1]);
+                _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(one, attr, x, y, -1, -1, 0x1000, arr[2]);
+
+                if (*(u16*)((char*)attr + 6) == 0xffff)
+                    break;
+                attr = (char*)attr + 8;
+                sb -= 0x2000;
+            } while (1);
+
+            if (*(u8*)(self + 0xe) != 0) {
+                *(int*)(((long long)(int)(self + 8)) & 0xFFFFFFFFFFFFFFFFLL) += (data_0208ee44 << 10);
+                if (arr[0] == 0)
+                    *(u8*)(self + 0xc) = 0x78;
+            }
+        } else {
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, attr, 0x80, 0x80, -1, -1, 0x1000, 0x1000, 0, -1);
+            _ZN3OAM9RenderSubEP7OamAttrii(attr, 0x80, 0x80);
+            *(unsigned char*)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+            *(int*)(self + 8) = 0;
+        }
+    }
+
+    func_0203083c();
+    _ZN3OAM5FlushEv();
+    _ZN3OAM4LoadEv();
+    return 1;
+}

--- a/src/func_0203db64.c
+++ b/src/func_0203db64.c
@@ -1,0 +1,153 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern void func_0205a61c(void *dst, void *src, int n);
+extern void func_0205a588(void *dst, int c, int n);
+extern void func_02042778(void);
+extern void func_0203df40(void);
+extern int func_02040a94(void);
+extern void func_02040724(void);
+extern void func_020580f0(u16 *self);
+extern void func_0203d854(void);
+extern int func_0203d81c(void);
+extern void func_0203d918(void);
+extern int func_0203d8fc(void);
+extern void func_02059eb0(void *dst);
+extern void func_02059f2c(void *p);
+
+typedef struct {
+    u8 lo : 4;
+    u8 hi : 4;
+    u8 b1;
+} NetCfg;
+
+extern u8 data_020a0ef0;
+extern u8 data_020a1064[];
+extern u8 data_020a0fec[];
+extern u16 data_020a1040[];
+extern u8 data_020a0fb8[];
+extern u8 data_020a0fa0[];
+extern NetCfg data_020a10fc;
+extern NetCfg data_020a10a4;
+extern u8 data_020a1154[];
+extern u8 data_020a0f08;
+extern u16 data_020a0f1c;
+extern u16 data_020a0f30;
+extern u16 data_020a0f28;
+extern u8 data_020a0f10;
+extern u8 data_02099e18;
+extern u8 data_020a0f04;
+extern u8 data_020a10fe[];
+extern u8 data_020a10a6[];
+extern u8 data_020a0f00;
+
+typedef struct {
+    u8 unk0;
+    u8 unk1;
+    u8 unk2[2];
+    u8 unk4[0x14];
+    u16 unk18;
+    u8 unk1A[0x3A];
+} SpBuf;
+
+void func_0203db64(void *arg0, void *arg1)
+{
+    SpBuf buf;
+    int b;
+
+    data_020a0ef0 = 0;
+    func_0205a61c(arg0, data_020a1064, 0x40);
+    func_0205a61c(arg1, data_020a0fec, 0x1c);
+    func_0205a588(data_020a1040, 0, 0x24);
+    func_0205a588(data_020a0fb8, 0, 0x18);
+    func_0205a588(data_020a0fa0, 0, 0x18);
+    func_0205a588(&data_020a10fc, 0, 0x58);
+    func_0205a588(&data_020a10a4, 0, 0x58);
+    func_0205a588(data_020a1154, 0, 0x90);
+    data_020a0f08 = 0;
+    data_020a0f1c = 0;
+    data_020a0f30 = 0;
+    data_020a0f28 = 0;
+    b = 1;
+    data_02099e18 = 1;
+    data_020a0f10 = 0;
+    data_020a0f04 = 0;
+    if (*(u16 *)0x27ffc40 != 2) {
+        b = 0;
+    }
+    if (b) {
+        int count;
+
+        data_020a0f04 = 2;
+        count = 0x4b0;
+        while (!(func_02040a94() == 2 && data_02099e18 == data_020a0f08 && data_020a0f08 != 0) && count != 0) {
+            data_020a0f1c |= 0x2000;
+            func_02042778();
+            func_0203df40();
+            count--;
+        }
+        if (count == 0) {
+            data_020a0f1c |= 1;
+            func_02040724();
+            func_020580f0(0);
+        }
+
+        count = 0x258;
+        data_020a1040[6] |= 1;
+        while ((data_020a1040[6] & 1) && count != 0) {
+            data_020a0f1c |= 0x2000;
+            func_02042778();
+            func_0203df40();
+            count--;
+        }
+        if (count == 0) {
+            data_020a0f1c |= 1;
+            func_02040724();
+            func_020580f0(0);
+        }
+
+        func_0203d854();
+        count = 0x258;
+        while (func_0203d81c() == 0 && count != 0) {
+            data_020a0f1c |= 0x2000;
+            func_02042778();
+            func_0203df40();
+            count--;
+        }
+        if (count == 0) {
+            data_020a0f1c |= 1;
+            func_02040724();
+            func_020580f0(0);
+        }
+
+        func_0203d918();
+        count = 0x258;
+        while (func_0203d8fc() == 0 && count != 0) {
+            data_020a0f1c |= 0x2000;
+            func_02042778();
+            func_0203df40();
+            count--;
+        }
+        if (count == 0) {
+            data_020a0f1c |= 1;
+            func_02040724();
+            func_020580f0(0);
+        }
+    } else {
+        func_02059eb0(&buf);
+        func_0205a588(&data_020a10fc, 0, 0x16);
+        data_020a10fc.lo = buf.unk1;
+        data_020a10fc.b1 = buf.unk18;
+        data_020a10a4.lo = data_020a10fc.lo;
+        data_020a10fc.hi = 0;
+        data_020a10a4.hi = data_020a10fc.hi;
+        data_020a10a4.b1 = data_020a10fc.b1;
+        func_0205a61c(buf.unk4, data_020a10fe, buf.unk18 * 2);
+        func_0205a61c(buf.unk4, data_020a10a6, buf.unk18 * 2);
+        data_020a0f00 = buf.unk0;
+        func_02059f2c(data_020a0fb8);
+        func_02059f2c(data_020a0fa0);
+    }
+    data_020a0ef0 = 1;
+}

--- a/src/func_02041e14.c
+++ b/src/func_02041e14.c
@@ -1,0 +1,151 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+typedef struct {
+    u32 kind : 4;
+    u32 chan : 4;
+    u32 flag : 24;
+    u32 word4;
+    u8 byte8;
+} Cmd;
+
+typedef struct {
+    Cmd entries[833];   /* 0x000..0x270b */
+    int f270c;
+    int f2710;
+    int f2714;
+    int f2718;
+    int f271c;
+    int f2720;
+    int f2724;
+    int f2728;
+    int f272c;
+} Sub;
+
+typedef struct {
+    int status;         /* 0x00 */
+    int pad04[9];       /* 0x04..0x27 */
+    int unk28;          /* 0x28 */
+    int unk2c;          /* 0x2c */
+    char pad30[0x410];  /* 0x30..0x43f */
+    Sub sub;            /* 0x440 */
+} Globals;
+
+extern int func_020659a0(int a, int b);
+extern int func_020656d4(u16 arg0, const void *arg1, int arg2, u32 arg3);
+extern void func_02042160();
+extern Globals data_020a1fc0;
+
+void func_02041e14(void)
+{
+    Sub *s = (Sub *)(((int)&data_020a1fc0 + 0x440) & 0xFFFFFFFFFFFFFFFF);
+    Cmd cmd;
+    Cmd cmd2;
+
+    if (data_020a1fc0.status == 0) {
+        return;
+    }
+    if (s->f2714 != 0) {
+        return;
+    }
+
+    *(int *)(((int)s + 0x270c) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
+    *(int *)(((int)s + 0x2710) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
+    *(int *)(((int)s + 0x271c) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
+    *(int *)(((int)s + 0x2728) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
+
+    if (s->f2720 != 0 && s->f2724 == 0) {
+        int v = s->f272c;
+        int a1 = data_020a1fc0.unk2c;
+        int snd;
+
+        s->f2720 = 0;
+        data_020a1fc0.unk28 = v;
+        func_020659a0(v, a1);
+
+        snd = s->f2728;
+        if (snd == 0) {
+            return;
+        }
+        cmd.kind = 1;
+        cmd.flag = 0;
+        cmd.word4 = 0;
+        cmd.chan = (u8)(data_020a1fc0.unk28 >> 8);
+        cmd.byte8 = (u8)data_020a1fc0.unk28;
+        func_020656d4((u16)snd, &cmd, 9, (u32)func_02042160);
+        s->f2714 = 1;
+        s->f2728 = 0;
+    } else {
+        int mask;
+        Cmd *found;
+        int cond;
+        int i;
+        int pri;
+        int bit;
+        Cmd *p;
+        u8 k;
+        int c;
+        int w4;
+
+        mask = s->f270c;
+        if (mask == 0) {
+            return;
+        }
+        pri = s->f2710;
+        found = 0;
+        cond = (pri != 0 && pri == (pri & mask));
+        if (cond) {
+            mask = pri;
+        } else {
+            mask &= ~pri;
+        }
+
+        p = s->entries;
+        i = 0;
+        for (;;) {
+            bit = 1 << i;
+            if (bit > mask) {
+                break;
+            }
+            if (bit & mask) {
+                if (found == 0) {
+                    found = p;
+                } else if (found->kind != p->kind || found->word4 != p->word4) {
+                    mask &= ~bit;
+                }
+            }
+            p++;
+            i++;
+        }
+
+        if (cond && mask != pri) {
+            s->f2710 = 0;
+        }
+        if (found == 0) {
+            return;
+        }
+
+        switch (found->kind) {
+        case 0:
+            found->kind = 1;
+            break;
+        case 2:
+            found->kind = 3;
+            *(int *)(((long long)(int)((char *)s + 0x271c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~mask;
+            break;
+        }
+
+        k = found->kind;
+        w4 = found->word4;
+        c = data_020a1fc0.unk28;
+        cmd2.kind = k;
+        cmd2.flag = 1;
+        cmd2.word4 = w4;
+        cmd2.chan = (u8)(c >> 8);
+        cmd2.byte8 = (u8)c;
+        func_020656d4((u16)mask, &cmd2, 9, (u32)func_02042160);
+        s->f2714 = 1;
+        *(int *)(((long long)(int)((char *)s + 0x270c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~mask;
+    }
+}

--- a/src/func_0205f0e0.c
+++ b/src/func_0205f0e0.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=30). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef short s16;
@@ -24,7 +21,7 @@ extern Glob data_020a80cc;
 void func_0205f0e0(s16 *arg)
 {
     u32 state;
-    int v;
+    unsigned long long vv;
 
     if (arg == 0) {
         data_020a80cc.field_30 = 0;
@@ -33,22 +30,20 @@ void func_0205f0e0(s16 *arg)
 
     state = _ZN3IRQ7DisableEv();
 
-    v = arg[2];
+    vv = (u32)arg[2];
     *(volatile u16 *)0x4000280 = 0;
     *(volatile u32 *)0x4000290 = 0x10000000;
-    *(volatile u32 *)0x4000298 = v;
-    *(volatile u32 *)(0x4000298 + 4) = 0;
+    *(volatile unsigned long long *)0x4000298 = vv;
     data_020a80cc.field_18 = arg[0];
     data_020a80cc.field_1c = arg[2];
     while (*(volatile u16 *)0x4000280 & 0x8000) {
     }
 
     data_020a80cc.field_20 = *(volatile u32 *)0x40002a0;
-    v = arg[3];
+    vv = (u32)arg[3];
     *(volatile u16 *)0x4000280 = 0;
     *(volatile u32 *)0x4000290 = 0x10000000;
-    *(volatile u32 *)0x4000298 = v;
-    *(volatile u32 *)(0x4000298 + 4) = 0;
+    *(volatile unsigned long long *)0x4000298 = vv;
     data_020a80cc.field_24 = arg[1];
     data_020a80cc.field_28 = arg[3];
     while (*(volatile u16 *)0x4000280 & 0x8000) {

--- a/src/func_02064470.c
+++ b/src/func_02064470.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=31). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Entry {
     char p0[2];
     unsigned char b2;
@@ -30,24 +27,24 @@ struct Self {
 
 void func_02064470(struct Self *self, int r1, int r2)
 {
-    unsigned short mask = (unsigned short)(1 << r2);
     struct Entry *e = &self->table[r2];
+    unsigned short mask = 1 << r2;
 
     self->fa = mask;
     if (self->fc != e->b2) return;
     self->fd = e->b2;
+    if ((self->f8 & mask) == 0) goto after;
     {
-        unsigned short *p8 = &self->f8;
-        if ((*p8 & mask) == 0) goto after;
+        unsigned short *p8 = (unsigned short *)(((int)self + 8) & 0xFFFFFFFFFFFFFFFF);
         *p8 = *p8 & ~mask;
     }
 
     switch (r1) {
-    case 0: case 1: case 2: case 3:
+    case 0: case 1: case 2: case 4:
     case 5: case 6: case 7: case 8:
     case 9: case 10: case 11:
         break;
-    case 4:
+    case 3:
         self->f14 = e->fa;
         self->f16 = e->f6;
         self->f18 = e->f4;

--- a/src/func_ov002_020b781c.c
+++ b/src/func_ov002_020b781c.c
@@ -1,0 +1,106 @@
+typedef signed short s16;
+typedef unsigned short u16;
+
+struct Vector3 { int x, y, z; };
+
+extern short data_02082214[];
+
+extern void func_ov002_020b6fcc(void *self);
+extern unsigned short DecIfAbove0_Short(unsigned short *p);
+extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+extern char *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *self, void *out);
+extern int func_02037e58(void *p);
+extern short _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern int func_ov002_020f02c8(int x);
+extern void func_ov002_020f030c(int x);
+extern int Vec3_HorzLen(void *v);
+extern void Vec3_MulScalarInPlace(void *v, int s);
+extern void Vec3_Add(void *out, void *a, void *b);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern short func_02010844(void *self, void *v, short angle);
+extern void _Z11UpdateAngleRssis(void *p, short a, int step, short d);
+
+int func_ov002_020b781c(char *c)
+{
+    struct Vector3 v1;
+    struct Vector3 v2;
+    struct Vector3 out;
+    int st;
+    char *fr;
+    int r6;
+    int r4v;
+    int spd;
+    short ang;
+    short a1;
+    short a2;
+    int b;
+    int j;
+    int s;
+    int co;
+
+    st = *(int *)(c + 0x3f0);
+    if (st == 4 || st == 0x11 || st == 6 || st == 8 || st == 0x10) {
+        func_ov002_020b6fcc(c);
+        return 1;
+    }
+    if (DecIfAbove0_Short((unsigned short *)(c + 0x100)) == 0)
+        return 1;
+    if (*(u16 *)(c + 0x100) == 1) {
+        b = (int)((*(int *)(c + 0xb0) & 0x60000) != 0);
+        if (b == 0) {
+            _ZN9ActorBase18MarkForDestructionEv(c);
+            return 1;
+        }
+    }
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144) == 0) {
+        *(int *)(c + 0x408) = *(int *)(c + 0x98);
+        return 1;
+    }
+    func_ov002_020b6fcc(c);
+    if (*(u16 *)(c + 0x100) < *(u16 *)(c + 0x404) >> 1) {
+        *(int *)(c + 0x3ec) = (*(u16 *)(c + 0x100) & 4) >> 2;
+        if (*(u16 *)(c + 0x100) < *(u16 *)(c + 0x404) >> 2)
+            *(int *)(c + 0x3ec) = (*(u16 *)(c + 0x100) & 2) >> 1;
+    }
+    if (*(int *)(c + 0x3f0) == 0x12) {
+        *(int *)(c + 0x98) = 0;
+        return 1;
+    }
+    fr = _ZNK12WithMeshClsn14GetFloorResultEv(c + 0x144);
+    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(fr + 4, c + 0xd4);
+    r6 = func_02037e58(fr + 4);
+    *(short *)(c + 0x3fc) = _ZN4cstd5atan2E5Fix12IiES1_(*(int *)(c + 0xd4), *(int *)(c + 0xdc));
+    r4v = func_ov002_020f02c8(r6);
+    func_ov002_020f030c(r6);
+    spd = *(int *)(c + 0x98);
+    j = (*(u16 *)(c + 0x94) >> 4) * 2;
+    s = data_02082214[j];
+    co = data_02082214[j + 1];
+    v1.x = (int)(((long long)spd * s + 0x800) >> 12);
+    v1.y = 0;
+    v1.z = (int)(((long long)spd * co + 0x800) >> 12);
+    j = (*(u16 *)(c + 0x3fc) >> 4) * 2;
+    s = data_02082214[j];
+    co = data_02082214[j + 1];
+    v2.x = (int)(((long long)r4v * s + 0x800) >> 12);
+    v2.y = 0;
+    v2.z = (int)(((long long)r4v * co + 0x800) >> 12);
+    Vec3_MulScalarInPlace(&v2, Vec3_HorzLen(c + 0xd4));
+    Vec3_Add(&out, &v1, &v2);
+    ang = _ZN4cstd5atan2E5Fix12IiES1_(out.x, out.z);
+    *(int *)(c + 0x98) = Vec3_HorzLen(&out);
+    if (*(int *)(c + 0x98) > 0xf000)
+        *(int *)(c + 0x98) = 0xf000;
+    *(short *)(c + 0x94) = ang;
+    *(int *)(c + 0xa8) = -(_ZN4cstd4fdivEii(
+        (int)(((long long)*(int *)(c + 0xd4) * *(int *)(c + 0xa4) + 0x800) >> 12)
+      + (int)(((long long)*(int *)(c + 0xdc) * *(int *)(c + 0xac) + 0x800) >> 12),
+        *(int *)(c + 0xd8)) + 0x8000);
+    a1 = func_02010844(c, c + 0xd4, *(short *)(c + 0x8e));
+    a2 = func_02010844(c, c + 0xd4, *(short *)(c + 0x8e) - 0x4000);
+    _Z11UpdateAngleRssis(c + 0x8c, a1, 4, 0x1000);
+    _Z11UpdateAngleRssis(c + 0x90, a2, 4, 0x1000);
+    return 1;
+}

--- a/src/func_ov002_020c3bdc.c
+++ b/src/func_ov002_020c3bdc.c
@@ -1,12 +1,11 @@
-// NONMATCHING: different op / idiom (div=40). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int Fix12i;
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* p, unsigned int a, int b, Fix12i c, unsigned int d);
 extern int _ZN6Player12FinishedAnimEv(void* p);
 extern void func_0200eec8(void);
 extern void func_ov002_020c3cf0(void* p);
 extern void func_ov002_020bedd4(void* p);
+
+#pragma optimize_for_size on
 void func_ov002_020c3bdc(char* c){
   if (*(unsigned char*)(c + 0x6e5) == 0){
     *(unsigned char*)(c + 0x6ff) = 1;
@@ -19,7 +18,7 @@ void func_ov002_020c3bdc(char* c){
     *(int*)(c + 0x9c) = -0x2000;
     if (*(unsigned char*)(c + 0x6de) == 0){
       _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x55, 0x40000000, 0x1000, 0);
-      *(unsigned char*)(c + 0x6e5) = *(unsigned char*)(c + 0x6e5) + 1;
+      *(unsigned char *)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) += 1;
     }
   } else {
     if (_ZN6Player12FinishedAnimEv(c)){
@@ -32,7 +31,7 @@ void func_ov002_020c3bdc(char* c){
       *(int*)(c + 0xa8) = 0;
       *(int*)(c + 0x9c) = 0;
       *(int*)(c + 0x60) = 0x15e000;
-      func_ov002_020bedd4(c);
     }
   }
+  func_ov002_020bedd4(c);
 }

--- a/src/func_ov002_020e8618.c
+++ b/src/func_ov002_020e8618.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern unsigned char data_0209f2d8;
 extern int data_0209b454;
 extern int _ZN9Animation8FinishedEv(char* a);
@@ -12,15 +9,15 @@ extern void _ZN5Event8ClearBitEj(unsigned int b);
 void func_ov002_020e8618(char* c){
   if(_ZN9Animation8FinishedEv(c+0x35c) == 0) return;
   func_ov002_020e7e58(c);
-  *(unsigned short*)(c+0x4a2) &= ~2;
+  *(unsigned short*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF) &= ~2;
   _ZN5Actor11UntrackStarERa(c, (signed char*)(c+0x498));
   if((int)(data_0209f2d8 == 1) != 0){
     _ZN9ActorBase18MarkForDestructionEv(c);
   }else{
     _ZN5Actor24KillAndTrackInDeathTableEv(c);
   }
-  *(int*)(*(char**)(c+0x438)+0xb0) &= ~0x4000000;
-  *(int*)(c+0xb0) &= ~0x4000000;
+  *(int*)(((int)*(char**)(c+0x438) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000000;
+  *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000000;
   data_0209b454 &= ~0x4000000;
   _ZN5Event8ClearBitEj(0x1e);
   _ZN5Event8ClearBitEj(0x1d);

--- a/src/func_ov002_020f3828.c
+++ b/src/func_ov002_020f3828.c
@@ -1,34 +1,27 @@
-// NONMATCHING: register allocation (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 extern void SetSubBg1Offset(int a, int b);
 extern void SetSubBg2Offset(int a, int b);
 extern unsigned char data_0209d454;
-
-void func_ov002_020f3828(int* c)
+void func_ov002_020f3828(int *c)
 {
-    c[0x140/4] = 0x80000;
-    c[0x144/4] = 0x66000;
-    c[0x148/4] = 0xfc000;
-    c[0x14c/4] = 0xbc000;
-    *(volatile unsigned int*)0x4001000 = (*(volatile unsigned int*)0x4001000 & ~0xe000) | 0x4000;
-    *(volatile unsigned short*)0x4001048 = (unsigned short)((*(volatile unsigned short*)0x4001048 & ~0x3f00) | 0x1700 | 0x2000);
-    *(volatile unsigned short*)0x400104a = (unsigned short)((*(volatile unsigned short*)0x400104a & ~0x3f) | 1 | 0x20);
-    {
-        int a = c[0x140/4];
-        int b = c[0x144/4];
-        int d = c[0x148/4];
-        int e = c[0x14c/4];
-        a >>= 12;
-        b >>= 12;
-        d >>= 12;
-        e >>= 12;
-        *(volatile unsigned short*)0x4001042 = (unsigned short)(((a << 8) & 0xff00) | (d & 0xff));
-        *(volatile unsigned short*)0x4001046 = (unsigned short)(((b << 8) & 0xff00) | (e & 0xff));
-    }
-    c[0x130/4] = -0x60000;
-    c[0x134/4] = -0x38000;
-    SetSubBg1Offset(c[0x130/4] >> 12, c[0x134/4] >> 12);
-    SetSubBg2Offset(c[0x130/4] >> 12, c[0x134/4] >> 12);
-    data_0209d454 |= 6;
+  c[0x140 / 4] = 0x80000;
+  c[0x144 / 4] = 0x66000;
+  c[0x148 / 4] = 0xfc000;
+  c[0x14c / 4] = 0xbc000;
+  *((volatile unsigned int *) 0x4001000) = ((*((volatile unsigned int *) 0x4001000)) & (~0xe000)) | 0x4000;
+  *((volatile unsigned short *) 0x4001048) = (unsigned short) (((((*((volatile unsigned short *) 0x4001048)) & (~0x3f00)) | 0x1700) & 0xFFFFFFFFFFFFFFFFull) | 0x2000);
+  *((volatile unsigned short *) 0x400104a) = (unsigned short) (((((*((volatile unsigned short *) 0x400104a)) & (~0x3f)) | 1) & 0xFFFFFFFFFFFFFFFFull) | 0x20);
+  {
+    int a = c[0x140 / 4] >> 12;
+    int d = c[0x148 / 4] >> 12;
+    int e = c[0x14c / 4] >> 12;
+    int b = c[0x144 / 4] >> 12;
+    *((volatile unsigned short *) 0x4001042) = (unsigned short) (((a << 8) & 0xff00) | (d & 0xff));
+    *((volatile unsigned short *) 0x4001046) = (unsigned short) (((b << 8) & 0xff00) | (e & 0xff));
+  }
+  c[0x130 / 4] = -0x60000;
+  c[0x134 / 4] = -0x38000;
+  SetSubBg1Offset(c[0x130 / 4] >> 12, c[0x134 / 4] >> 12);
+  SetSubBg2Offset(c[0x130 / 4] >> 12, c[0x134 / 4] >> 12);
+  data_0209d454 |= 6;
 }

--- a/src/func_ov006_020c07e8.cpp
+++ b/src/func_ov006_020c07e8.cpp
@@ -1,0 +1,62 @@
+//cpp
+typedef int s16;
+struct Vector3 { int x, y, z; };
+
+struct C;
+typedef void (C::*PMF)();
+
+struct C {
+    char pad0[0xb4];
+    PMF pmf;        // 0xb4 (2 words)
+    char pad1[0xc8 - 0xb4 - 8];
+    Vector3 v0c8;   // 0xc8
+    char pad2[0xea - 0xc8 - 12];
+    short a0ea;     // 0xea
+    char pad3[0xf0 - 0xea - 2];
+    short a0f0;     // 0xf0
+    char pad4[0xf4 - 0xf0 - 2];
+    int a0f4;       // 0xf4
+};
+
+extern "C" void _ZN14BlendModelAnim7AdvanceEv(void*);
+extern "C" s16 Vec3_HorzAngle(const Vector3*, const Vector3*);
+extern "C" void _Z11UpdateAngleRssis(short*, short, int, short);
+
+extern Vector3 data_ov006_0212b890;
+extern "C" int data_ov006_0213ac78[2];
+
+extern "C" void func_ov006_020c07e8(C* c)
+{
+    (c->*(c->pmf))();
+
+    _ZN14BlendModelAnim7AdvanceEv((char*)c + 0x18);
+
+    if (c->a0f4 != 0) {
+        Vector3 t;
+        t.x = data_ov006_0212b890.x;
+        t.y = data_ov006_0212b890.y;
+        t.z = data_ov006_0212b890.z;
+        short d;
+        int ang;
+        ang = Vec3_HorzAngle(&c->v0c8, &t);
+        d = (short)(ang - c->a0ea);
+        if (d < -0x3000) d = -0x3000;
+        else if (d > 0x3000) d = 0x3000;
+        _Z11UpdateAngleRssis(&c->a0f0, d, 8, 0x200);
+
+        {
+            int* p = (int*)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+            int* g = data_ov006_0213ac78;
+            if (p[0] == g[0]) {
+                if (p[1] == g[1])
+                    return;
+                if (*(int*)((char*)c + 0xb4) == 0)
+                    return;
+            }
+        }
+        d = (short)(ang - d);
+        _Z11UpdateAngleRssis(&c->a0ea, d, 8, 0x200);
+    } else {
+        _Z11UpdateAngleRssis(&c->a0f0, 0, 8, 0x200);
+    }
+}

--- a/src/func_ov006_020c8ba8.cpp
+++ b/src/func_ov006_020c8ba8.cpp
@@ -1,0 +1,19 @@
+//cpp
+int ApproachLinear(int&, int, int);
+int ApproachLinear2(short&, short, short);
+
+extern "C" void func_ov006_020c8ba8(char* c)
+{
+    if (*(short*)(c+0x18) == 0) return;
+    *(short*)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+    *(int*)(c+0x10) = (int)(((long long)*(int*)(c+0x10) * *(int*)(c+0x14) + 0x800) >> 12);
+    *(int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF) -= 0x40;
+    ApproachLinear(*(int*)(c+0x14), 0x800, 0x10);
+    if (ApproachLinear2(*(short*)(c+0x1e), 0, 1) != 0) {
+        if (*(short*)(c+0x1a) != 2)
+            *(short*)(c+0x18) = 0;
+    } else {
+        *(int*)(c) += *(int*)(c+0x8);
+        *(int*)(((int)c + 0x4) & 0xFFFFFFFFFFFFFFFF) += *(int*)(c+0xc);
+    }
+}

--- a/src/func_ov006_020c91ac.cpp
+++ b/src/func_ov006_020c91ac.cpp
@@ -1,0 +1,139 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern "C" {
+void func_ov006_020ca2ec(void *c);
+int _ZNK9Animation12WillHitFrameEi(void *thisPtr, int frame);
+void func_ov006_020e6e3c(int a0, int a1);
+void func_ov006_020bfec0(void *a0, void *a1, short *a2);
+int _Z14ApproachLinearRiii(int *v, int step, int rate);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fix, unsigned int flags);
+void func_ov006_020e6df0(int a0, int a1, int a2);
+int _Z14ApproachLinearRsss(short *v, short step, short rate);
+}
+
+extern int data_ov006_0214059c;
+extern void *data_ov006_02141a40;
+extern int data_ov006_02140574;
+extern int data_ov006_021405a8;
+extern void *data_ov006_0213b22c[];
+extern int data_ov006_021405b4;
+
+struct VtObj {
+    virtual void d0();
+    virtual void d1();
+    virtual void d2();
+    virtual void d3();
+    virtual void m4();
+};
+
+extern "C" void func_ov006_020c91ac(char *c)
+{
+    int v24;
+
+    if (*(int *)(c + 0x40) <= 0) {
+        func_ov006_020ca2ec(c);
+        return;
+    }
+
+    if (*(int *)(c + 0xd8) == data_ov006_0214059c) {
+        if (_ZNK9Animation12WillHitFrameEi((void *)(c + 0xc8), 0xc) != 0 ||
+            _ZNK9Animation12WillHitFrameEi((void *)(c + 0xc8), 0x18) != 0) {
+            func_ov006_020e6e3c(0x1b5, *(int *)(c + 0x24));
+        }
+    }
+
+    func_ov006_020bfec0(data_ov006_02141a40, (void *)(c + 0x24), (short *)(c + 0x56));
+
+    v24 = *(int *)(c + 0x24);
+
+    if (v24 >= -0x68000) goto L5c;
+    if (*(int *)(c + 0x3c) < 0) goto L70;
+
+L5c:
+    if (v24 <= 0x68000) goto L230;
+    if (*(int *)(c + 0x3c) <= 0) goto L230;
+
+L70:
+    {
+        int v = v24;
+        if (v < -0x90000) v = -0x90000;
+        else if (v > 0x90000) v = 0x90000;
+        *(int *)(c + 0x24) = v;
+    }
+
+    if (*(s16 *)(c + 0x22) != 0) goto L1a4;
+    if (_Z14ApproachLinearRiii((int *)(c + 0x64), 5, 1) != 0) goto L1a4;
+    {
+        int t;
+
+        *(int *)(c + 0x60) = 2;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void *)(c + 0x78),
+            *(void **)data_ov006_0213b22c[*(int *)(c + 0x60)], 0x40000000, 0x800, 0);
+
+        *(int *)(c + 0xd0) = 0;
+        func_ov006_020e6df0(0, *(int *)(c + 0x60), *(int *)(c + 0x24));
+
+        t = (int)(((long long)(-*(int *)(c + 0x3c)) * 0x1200 + 0x800) >> 12);
+        if (t < -0x1400) t = -0x1400;
+        else if (t > 0x1400) t = 0x1400;
+        *(int *)(c + 0x3c) = t;
+
+        *(int *)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFF) +=
+            (int)(((long long)data_ov006_02140574 * 0x400 + 0x800) >> 12);
+
+        {
+            int v40 = data_ov006_021405a8;
+            if (*(int *)(c + 0x40) <= v40) v40 = *(int *)(c + 0x40);
+            *(int *)(c + 0x40) = v40;
+        }
+    }
+    goto L260;
+
+L1a4:
+    {
+        int t = (int)(((long long)(-*(int *)(c + 0x3c)) * 0xf00 + 0x800) >> 12);
+        int v40;
+        int hi;
+        int lo;
+
+        *(int *)(c + 0x3c) = t;
+
+        t = *(int *)(c + 0x24);
+        if (t < -0x68000) t = -0x68000;
+        else if (t > 0x68000) t = 0x68000;
+        *(int *)(c + 0x24) = t;
+
+        hi = data_ov006_021405a8;
+        lo = data_ov006_021405b4;
+        v40 = *(int *)(c + 0x40);
+        if (v40 < lo) {
+            v40 = lo;
+        } else {
+            if (v40 <= hi) hi = v40;
+            v40 = hi;
+        }
+        *(int *)(c + 0x40) = v40;
+    }
+    goto L260;
+
+L230:
+    if (*(u16 *)(c + 0x18) == 3) {
+        ((VtObj *)c)->m4();
+        *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF) *= -1;
+    }
+
+L260:
+    {
+        int v = *(int *)(c + 0x3c);
+        if (v > 0x2000) {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), 0x2000, 0xc00);
+        } else if (v < -0x2000) {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), -0x2000, 0xc00);
+        } else {
+            _Z14ApproachLinearRsss((short *)(c + 0x52), (short)v, 0xc00);
+        }
+    }
+}

--- a/src/func_ov006_020ce108.cpp
+++ b/src/func_ov006_020ce108.cpp
@@ -1,0 +1,138 @@
+//cpp
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
+extern void Vec3_MulScalar(Vector3 *out, const Vector3 *in, int scale);
+extern void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+extern void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+extern int LenVec3(Vector3 *v);
+extern int DotVec3(const Vector3 *a, const Vector3 *b);
+extern int NormalizeVec3IfNonZero(Vector3 *v);
+extern void Vec3_MulScalarInPlace(Vector3 *v, int s);
+
+extern int data_ov006_0213b33c[2];
+extern Vector3 data_020a0ebc;
+extern int data_ov006_0212e070[];
+extern int data_ov006_021405b4[];
+extern int data_ov006_021405a8[];
+}
+
+struct Obj {
+    virtual Vector3 *m00();
+    virtual void m04();
+    virtual Vector3 *m08();
+};
+
+extern "C" void func_ov006_020ce108(char *a, Obj *o)
+{
+    Vector3 vA;
+    Vector3 vB;
+    Vector3 vC;
+    Vector3 acc;
+    Vector3 scaled;
+    Vector3 vD;
+    Vector3 diff;
+    Vector3 t1;
+    Vector3 t2;
+    Vector3 t3;
+    Vector3 *p1;
+    int dot44;
+    Vector3 *p2;
+    int lenA;
+    int lenB;
+    int dot38;
+
+    {
+        int *g = data_ov006_0213b33c;
+        int f0 = *(int *)a;
+        if (f0 == g[0]) {
+            if (*(int *)(a + 4) == g[1])
+                return;
+            if (f0 == 0)
+                return;
+        }
+    }
+
+    p1 = o->m00();
+    p2 = o->m08();
+
+    acc = data_020a0ebc;
+    Vec3_Sub(&diff, p1, (Vector3 *)(a + 8));
+    vB = diff;
+    vA = diff;
+    vC = diff;
+
+    Vec3_MulScalar(&scaled, (Vector3 *)(a + 0x44), data_ov006_0212e070[*(short *)(a + 0x96)]);
+    AddVec3(&vA, &scaled, &vA);
+    SubVec3(&vB, &scaled, &vB);
+
+    vA.y += 0xE000;
+    vB.y += 0xE000;
+    vA.y >>= 1;
+    vB.y >>= 1;
+
+    lenA = LenVec3(&vA);
+    lenB = LenVec3(&vB);
+    dot44 = DotVec3(&vC, (Vector3 *)(a + 0x44));
+    dot38 = DotVec3(&vC, (Vector3 *)(a + 0x38));
+
+    if (lenA < 0xE000 && NormalizeVec3IfNonZero(&vA) != 0) {
+        Vec3_MulScalarInPlace(&vA, 0xE000 - lenA);
+        vA.y <<= 1;
+        Vec3_MulScalar(&t1, &vA, *(int *)(a + 0x88));
+        AddVec3(p1, &t1, p1);
+        AddVec3(&acc, &vA, &acc);
+        *(short *)(((int)o + 0x22) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    } else if (lenB < 0xE000 && NormalizeVec3IfNonZero(&vB) != 0) {
+        Vec3_MulScalarInPlace(&vB, 0xE000 - lenB);
+        vB.y <<= 1;
+        Vec3_MulScalar(&t2, &vB, *(int *)(a + 0x88));
+        AddVec3(p1, &t2, p1);
+        AddVec3(&acc, &vB, &acc);
+        *(short *)(((int)o + 0x22) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    }
+
+    Vec3_MulScalar(&t3, &acc, 0x100);
+    AddVec3(p2, &t3, p2);
+
+    {
+        int x = p2->x;
+        if (x < -0x1000)
+            x = -0x1000;
+        else if (x > 0x1000)
+            x = 0x1000;
+        p2->x = x;
+    }
+
+    {
+        int mx = data_ov006_021405a8[0];
+        int mn = data_ov006_021405b4[0];
+        int y = p2->y;
+        if (y >= mn) {
+            if (y <= mx)
+                mx = y;
+            mn = mx;
+        }
+        p2->y = mn;
+    }
+
+    if ((dot38 < 0 ? -dot38 : dot38) >= 0xE000)
+        return;
+
+    if (dot44 < 0)
+        dot44 = -dot44;
+    if (dot44 >= data_ov006_0212e070[*(short *)(a + 0x96)])
+        return;
+
+    Vec3_MulScalar(&vD, (Vector3 *)(a + 0x38), 0x70);
+    if (dot38 > 0)
+        Vec3_MulScalarInPlace(&vD, -0x1000);
+    {
+        int t = vD.y;
+        if (t > 0x80)
+            t = 0x80;
+        vD.y = t;
+    }
+    AddVec3(p2, &vD, p2);
+}

--- a/src/func_ov006_020d5f2c.c
+++ b/src/func_ov006_020d5f2c.c
@@ -1,26 +1,34 @@
-// NONMATCHING: register allocation (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-void func_ov006_020d5f2c(char* c, int i){
-  char* ip = c + i*0x10 + 0x6000;
-  if ((unsigned char)*(unsigned char*)(ip + 0x2ae) >= 4) {
-    *(unsigned char*)(ip + 0x2ae) = 4;
-    *(unsigned char*)(ip + 0x2ac) = 2;
+
+void func_ov006_020d5f2c(char *c, int i)
+{
+  char *new_var2;
+  char *ip;
+  unsigned char new_var;
+  new_var2 = c + (i * 0x10);
+  if (((unsigned char) (*((unsigned char *) ((new_var2 + 0x6000) + 0x2ae)))) >= 4)
+  {
+    *((unsigned char *) ((new_var2 + 0x6000) + 0x2ae)) = 4;
+    *((unsigned char *) ((new_var2 + 0x6000) + 0x2ac)) = 2;
     return;
   }
   {
-    unsigned short* p = (unsigned short*)(c + 0x62a8 + i*0x10);
-    *p = *p + 1;
+    unsigned short *p = (unsigned short *) ((c + 0x62a8) + (i * 0x10));
+    *p = (*p) + 1;
   }
-  if (*(unsigned short*)(c + i*0x10 + 0x62a8) < 3)
-    return;
-  *(unsigned short*)(c + i*0x10 + 0x62a8) = 0;
+  if ((*((unsigned short *) (new_var2 + 0x62a8))) < 3)
   {
-    unsigned char* q = (unsigned char*)(c + 0x62ae + i*0x10);
-    *q = *q + 1;
+    return;
   }
-  if ((unsigned char)*(unsigned char*)(ip + 0x2ae) >= 4) {
-    *(unsigned char*)(ip + 0x2ae) = 4;
-    *(unsigned char*)(ip + 0x2ac) = 2;
+  *((unsigned short *) (new_var2 + 0x62a8)) = 0;
+  ip = new_var2 + 0x6000;
+  {
+    unsigned char *q = (unsigned char *) ((c + 0x62ae) + (i * 0x10));
+    *q = (*q) + 1;
+  }
+  new_var = (unsigned char) (*((unsigned char *) (ip + 0x2ae)));
+  if (new_var >= 4)
+  {
+    *((unsigned char *) ((new_var2 + 0x6000) + 0x2ae)) = 4;
+    *((unsigned char *) (ip + 0x2ac)) = 2;
   }
 }

--- a/src/func_ov006_020e1b54.c
+++ b/src/func_ov006_020e1b54.c
@@ -1,43 +1,46 @@
-// NONMATCHING: register allocation (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
-
 extern void func_02012718(void *a, int b);
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];
 extern u8 data_020a0dea[];
 extern u8 data_020a0deb[];
-
 void func_ov006_020e1b54(char *c)
 {
-    int idx = data_020a0e40;
-    int flag = 0;
-    int x, y;
-
-    if (data_020a0de8[idx * 4] != 0) {
-        if (data_020a0de9[idx * 4] != 0) flag = 1;
+  int idx;
+  int flag = 0;
+  int x;
+  int y;
+  idx = data_020a0e40;
+  if (data_020a0de8[idx * (4 & 0xFFFFFFFF)] != 0)
+  {
+    if (data_020a0de9[idx * 4] != 0)
+    {
+      flag = 1;
     }
-    if (flag == 0) return;
-
-    x = (*(int *)(c + 0x4eb0) >> 0xc) - data_020a0dea[idx * 4];
-    y = (*(int *)(c + 0x4eb4) >> 0xc) - data_020a0deb[idx * 4];
-    *(int *)(c + 0x4ec0) = x << 0xc;
-    *(int *)(c + 0x4ec4) = y << 0xc;
-    *(u8 *)(c + 0x4ee4) = 1;
-    *(u16 *)(c + 0x4ede) = 0xc000;
-
-    if (*(u8 *)(c + 0x4ee9) == 0)
-        func_02012718((void *)0x1d2, *(int *)(c + 0x4eb0));
-
-    *(u8 *)(c + 0x4ee9) = 6;
-    *(int *)(c + 0x4ecc) = 0;
-    *(int *)(c + 0x4ed0) = 0;
-    *(int *)(c + 0x4eb8) = *(int *)(c + 0x4eb0) + *(int *)(c + 0x4ec0);
-    *(int *)(c + 0x4ebc) = *(int *)(c + 0x4eb4) + *(int *)(c + 0x4ec4);
-    *(int *)(c + 0x4ed4) = 0xff;
-    *(u8 *)(c + 0x4eea) = 0;
+  }
+  if (flag == 0)
+  {
+    return;
+  }
+  x = ((*((int *) (c + 0x4eb0))) >> 0xc) - data_020a0dea[idx * 4];
+  y = ((*((int *) (c + 0x4eb4))) >> 0xc) - data_020a0deb[idx * 4];
+  *((int *) (c + 0x4ec0)) = x << 0xc;
+  *((int *) (c + 0x4ec4)) = y << 0xc;
+  *((u8 *) (c + 0x4ee4)) = 1;
+  *((u16 *) (c + 0x4ede)) = 0xc000;
+  if ((*((u8 *) (c + 0x4ee9))) == 0)
+  {
+    func_02012718((void *) 0x1d2, *((int *) (c + 0x4eb0)));
+    *((u8 *) (c + 0x4ee9)) = 6;
+  }
+  *((int *) (c + 0x4ecc)) = 0;
+  *((int *) (c + 0x4ed0)) = 0;
+  *((int *) (c + 0x4eb8)) = (*((int *) (c + 0x4eb0))) + (*((int *) (c + 0x4ec0)));
+  *((int *) (c + 0x4ebc)) = (*((int *) (c + 0x4eb4))) + (*((int *) (c + 0x4ec4)));
+  *((int *) (c + 0x4ed4)) = 0xff;
+  *((u8 *) (c + 0x4eea)) = 0;
 }

--- a/src/func_ov006_020e83bc.c
+++ b/src/func_ov006_020e83bc.c
@@ -1,20 +1,32 @@
-// NONMATCHING: register allocation (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 void func_ov006_020e83bc(char *c, int i)
 {
-    int *p = (int*)(c + i * 32 + 0x5000);
-    *(int*)(c + 0x52bc + i * 32) = *(int*)(c + 0x52bc + i * 32) + p[0xb1];
-    *(int*)(c + 0x52c0 + i * 32) = *(int*)(c + 0x52c0 + i * 32) + p[0xb2];
-    if (p[0xb1] > 0) {
-        unsigned char e = *(unsigned char*)(c + i * 32 + 0x52d5);
-        *(int*)(c + 0x52c4 + i * 32) = *(int*)(c + 0x52c4 + i * 32) - (e * 16 + 0x10);
-        if ((short)p[0xb1] < 0) p[0xb1] = 0;
-    } else if (p[0xb1] < 0) {
-        unsigned char e = *(unsigned char*)(c + i * 32 + 0x52d5);
-        *(int*)(c + 0x52c4 + i * 32) = *(int*)(c + 0x52c4 + i * 32) + (e * 16 + 0x10);
-        if ((short)p[0xb1] > 0) p[0xb1] = 0;
-    } else {
-        *(unsigned char*)(c + i * 32 + 0x52da) = 0;
+  unsigned long new_var;
+  char *b = c + (i * 32);
+  char *q = c + 0x52bc;
+  new_var = i;
+  *((int *) (q + (new_var * 32))) = (*((int *) (q + (new_var * 32)))) + (*((int *) (b + 0x52c4)));
+  *((int *) ((c + 0x52c0) + (new_var * 32))) = (*((int *) ((c + 0x52c0) + (new_var * 32)))) + (*((int *) (b + 0x52c8)));
+  if ((*((int *) (b + 0x52c4))) > 0)
+  {
+    unsigned char e = *((unsigned char *) (b + 0x52d5));
+    *((int *) ((c + 0x52c4) + (new_var * 32))) = (*((int *) ((c + 0x52c4) + (new_var * 32)))) - ((e * 16) + 0x10);
+    if (((short) (*((int *) (b + 0x52c4)))) < 0)
+    {
+      *((int *) (b + 0x52c4)) = 0;
     }
+  }
+  else
+    if ((*((int *) (b + 0x52c4))) < 0)
+  {
+    unsigned char e = *((unsigned char *) (b + 0x52d5));
+    *((int *) ((c + 0x52c4) + (new_var * 32))) = (*((int *) ((c + 0x52c4) + (new_var * 32)))) + ((e * 16) + 0x10);
+    if (((short) (*((int *) (b + 0x52c4)))) > 0)
+    {
+      *((int *) (b + 0x52c4)) = 0;
+    }
+  }
+  else
+  {
+    *((unsigned char *) (b + 0x52da)) = 0;
+  }
 }

--- a/src/func_ov006_020ed494.c
+++ b/src/func_ov006_020ed494.c
@@ -1,0 +1,166 @@
+typedef unsigned char u8;
+typedef short s16;
+
+typedef struct V2 { int x, y; } V2;
+
+typedef struct Thing
+{
+    int a;              /* 0x00 */
+    int b;              /* 0x04 */
+    char pad0[0x10];    /* 0x08 */
+    V2 pos;             /* 0x18 */
+    char pad1[0x78];    /* 0x20 */
+} Thing;                /* 0x98 */
+
+extern u8 data_020a0e40;
+extern u8 data_020a0de8[];
+extern u8 data_020a0de9[];
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+extern int data_ov006_0213ca4c[];
+extern int data_ov006_0213ca74[];
+extern int data_ov006_0213c958;
+extern s16 data_ov006_02141fd8;
+
+extern int func_ov006_020eb7b0(Thing *p);
+extern int func_ov006_020eb768(Thing *p, V2 *v);
+extern void func_02012790(int a);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int a);
+extern void func_ov006_020ea5f0(int x, int y);
+extern void func_ov006_020ed40c(char *c);
+extern int func_0203d5dc(int *a, V2 *b);
+extern void func_ov006_020eb9dc(Thing *p, int d);
+extern void func_ov006_020ea81c(int x, int y);
+extern int _Z14ApproachLinearRiii(int *r, int a, int b);
+
+void func_ov006_020ed494(char *c)
+{
+    V2 a;
+    int vec[4];
+    int b = 0;
+    int idx = data_020a0e40;
+
+    if (data_020a0de8[idx * 4] != 0 && data_020a0de9[idx * 4] != 0)
+        b = 1;
+
+    if (b != 0)
+    {
+        Thing *p;
+        V2 *src;
+        a.x = data_020a0dea[(unsigned int)idx * 4] << 12;
+        a.y = data_020a0deb[(unsigned int)idx * 4] << 12;
+        p = *(Thing **)(c + 0x4f60);
+        src = (V2 *)(int)(((long long)(int)((char *)p + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+        vec[0] = src->x;
+        vec[1] = src->y;
+
+        if (func_ov006_020eb7b0(*(Thing **)(c + 0x4f60)) != 0 &&
+            func_ov006_020eb768(*(Thing **)(c + 0x4f60), &a) != 0)
+        {
+            *(u8 *)(c + 0x4f64) = 1;
+            func_02012790(0x26);
+            p = *(Thing **)(c + 0x4f60);
+            {
+            int *g = data_ov006_0213ca4c;
+            if (p->a == g[0] &&
+                (p->b == g[1] || p->a == 0))
+                _ZN5Sound12PlayBank2_2DEj(0x1ef);
+            else
+                _ZN5Sound12PlayBank2_2DEj(0x1ee);
+            if (data_ov006_02141fd8 == 0)
+                vec[0] -= 0x28000;
+            func_ov006_020ea5f0(vec[0], vec[1]);
+            func_ov006_020ed40c(c);
+            return;
+            }
+        }
+
+        {
+            int found = -1;
+            int i = 0;
+            Thing *ptr;
+
+            if (data_ov006_0213c958 > 0)
+            {
+                ptr = (Thing *)(c + 0x4678);
+                do
+                {
+                    if (func_ov006_020eb7b0(ptr) != 0 &&
+                        func_ov006_020eb768(ptr, &a) != 0)
+                    {
+                        found = i;
+                        break;
+                    }
+                    i++;
+                    ptr++;
+                }
+                while (i < data_ov006_0213c958);
+            }
+
+            if (found != -1)
+            {
+                int j;
+                Thing *ptr2;
+                Thing *sel = (Thing *)(c + 0x4678) + found;
+                {
+                int *g2 = data_ov006_0213ca74;
+                if (sel->a == g2[0] &&
+                    (sel->b == g2[1] || sel->a == 0))
+                    _ZN5Sound12PlayBank2_2DEj(0x1eb);
+                else
+                    _ZN5Sound12PlayBank2_2DEj(0x1ed);
+                }
+
+                {
+                    j = 0;
+                    if (data_ov006_0213c958 > 0)
+                    {
+                        ptr2 = (Thing *)(c + 0x4678);
+                        do
+                        {
+                            V2 *s2 = (V2 *)(int)(((long long)(int)((char *)ptr2 + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+                            vec[0] = s2->x;
+                            vec[1] = s2->y;
+                            func_ov006_020eb9dc(ptr2, func_0203d5dc(vec, &a));
+                            j++;
+                            ptr2++;
+                        }
+                        while (j < data_ov006_0213c958);
+                    }
+                }
+
+                func_02012790(0xe);
+                {
+                    V2 *s3 = (V2 *)(int)(((long long)(int)((char *)sel + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+                    vec[2] = s3->x;
+                    vec[3] = s3->y;
+                }
+                if (data_ov006_02141fd8 == 0)
+                    vec[2] -= 0x28000;
+                func_ov006_020ea81c(vec[2], vec[3]);
+
+                {
+                    int t = *(int *)(c + 0x4670) - 10;
+                    if (t < 0)
+                        t = 0;
+                    *(int *)(c + 0x4670) = t;
+                }
+            }
+        }
+    }
+
+    if (_Z14ApproachLinearRiii((int *)(c + 0x4674), 0, 1) == 0)
+        return;
+
+    *(int *)(c + 0x4674) = 0x3c;
+    if (_Z14ApproachLinearRiii((int *)(c + 0x4670), 0, 1) != 0)
+    {
+        func_02012790(0xe);
+        func_ov006_020ed40c(c);
+    }
+
+    if (*(int *)(c + 0x4670) > 2)
+        _ZN5Sound12PlayBank2_2DEj(0xa7);
+    else
+        _ZN5Sound12PlayBank2_2DEj(0xa6);
+}

--- a/src/func_ov006_020f5744.c
+++ b/src/func_ov006_020f5744.c
@@ -1,0 +1,35 @@
+
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+extern s16 _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern s16 data_02082214[];
+void func_ov006_020f5744(char *base, int i)
+{
+  int n = i * 0x14;
+  int tx = (i << 4) + 0xc;
+  int tz = -0x2c;
+  u16 *new_var;
+  int dx;
+  int dz;
+  dx = tx - ((*((int *) ((base + 0x5388) + n))) >> 12);
+  dz = tz - ((*((int *) ((base + 0x538c) + n))) >> 12);
+  *((s16 *) ((base + 0x5394) + n)) = _ZN4cstd5atan2E5Fix12IiES1_(dz, dx);
+  *((int *) ((base + 0x5390) + n)) = (*((int *) ((base + 0x5390) + n))) + 0x200;
+  new_var = &(*((u16 *) ((base + 0x5394) + n)));
+  *((int *) ((base + 0x5388) + n)) = (*((int *) ((base + 0x5388) + n))) + ((int) (((((s64) data_02082214[(((*new_var) >> 4) << 1) + 1]) * (*((int *) ((base + 0x5390) + n)))) + 0x800) >> 0xc));
+  *((int *) ((base + 0x538c) + n)) = (*((int *) ((base + 0x538c) + n))) + ((int) (((((s64) data_02082214[((*new_var) >> 4) << 1]) * (*((int *) ((base + 0x5390) + n)))) + 0x800) >> 0xc));
+  dx = tx - ((*((int *) ((base + 0x5388) + n))) >> 12);
+  dz = tz - ((*((int *) ((base + 0x538c) + n))) >> 12);
+  if ((dx < (-3)) || (dx > 3))
+  {
+    return;
+  }
+  if ((dz < (-3)) || (dz > 3))
+  {
+    return;
+  }
+  *((int *) ((base + 0x5388) + n)) = tx << 12;
+  *((int *) ((base + 0x538c) + n)) = tz << 12;
+  *((unsigned char *) ((base + n) + 0x539a)) = 2;
+}

--- a/src/func_ov006_02100d90.c
+++ b/src/func_ov006_02100d90.c
@@ -1,0 +1,24 @@
+
+void func_ov006_02100d90(char *base, int idx)
+{
+  char *r3 = base + (idx * 0x40);
+  if ((*((unsigned short *) (r3 + 0x5292))) != 0)
+  {
+    unsigned short *h = (unsigned short *) ((base + 0x5292) + (idx * 0x40));
+    *h = (*h) - 1;
+    return;
+  }
+  char *q;
+  *((int *) ((base + 0x5264) + (idx * 0x40))) = (*((int *) ((base + 0x5264) + (idx * 0x40)))) + (*((int *) ((r3 + 0x5000) + 0x26c)));
+  *((int *) ((base + 0x526c) + (idx * 0x40))) = (*((int *) ((base + 0x526c) + (idx * 0x40)))) - 0x100;
+  int a = *((int *) ((r3 + 0x5000) + 0x280));
+  int b = *((int *) ((r3 + 0x5000) + 0x264));
+  if (a < b)
+  {
+    return;
+  }
+  *((int *) ((r3 + 0x5000) + 0x264)) = a;
+  *((unsigned char *) ((r3 + 0x5000) + (b = 0x296))) = *((unsigned char *) ((r3 + 0x5000) + 0x297));
+  *((int *) ((r3 + 0x5000) + 0x268)) = *((int *) ((r3 + 0x5000) + 0x284));
+  *((int *) ((r3 + 0x5000) + 0x26c)) = *((int *) ((r3 + 0x5000) + 0x288));
+}

--- a/src/func_ov007_020b0a20.c
+++ b/src/func_ov007_020b0a20.c
@@ -1,0 +1,186 @@
+typedef unsigned short u16;
+typedef signed short s16;
+
+typedef struct SubC {
+    int unk0;
+    char pad4[8];
+    volatile s16 unkC;
+    char padE[2];
+    u16 unk10;
+    u16 unk12;
+    int unk14;
+} SubC;
+
+typedef struct Elem {
+    char pad0[0x18];
+    SubC *unk18;
+    char pad1C[0x24];
+    int unk40;
+    int unk44;
+    int unk48;
+} Elem;
+
+typedef struct Sub100 {
+    char pad0[4];
+    Elem *unk4;
+    char pad8[0x10];
+    void *unk18;
+} Sub100;
+
+typedef struct Sub8 {
+    char pad0[2];
+    u16 unk2;
+    char pad4[8];
+    int unkC;
+} Sub8;
+
+typedef struct Sub54 {
+    u16 unk0;
+    u16 unk2;
+} Sub54;
+
+typedef struct Sub50 {
+    char pad0[0xC];
+    u16 unkC;
+    char padE[6];
+    u16 unk14;
+} Sub50;
+
+typedef struct SubX {
+    char pad0[2];
+    u16 unk2;
+} SubX;
+
+typedef struct SubW {
+    char pad0[4];
+    SubX *unk4;
+} SubW;
+
+typedef struct SubV {
+    SubW *unk0;
+} SubV;
+
+typedef struct SubE0 {
+    char pad0[4];
+    int unk4;
+} SubE0;
+
+typedef struct Game {
+    char pad0[8];
+    Sub8 *unk8;
+    char padC[0x44];
+    Sub50 *unk50;
+    Sub54 *unk54;
+    char pad58[0x6C];
+    SubV *unkC4;
+    char padC8[0x18];
+    SubE0 *unkE0;
+    char padE4[0x1C];
+    Sub100 *unk100;
+} Game;
+
+extern Game *data_ov007_0210342c;
+
+extern int func_ov007_020aebac(void);
+extern void func_ov007_020bfacc(int, int, int);
+extern void func_ov007_020b1fa4(int);
+extern void func_ov007_020b0da0(void);
+extern void func_ov007_020be980(Sub100 *, int, int);
+extern int func_ov007_020be964(Sub100 *);
+extern void func_ov007_020c0638(int, int, int, int);
+extern void func_ov007_020b797c(void);
+extern void func_ov007_020bdeb0(int);
+extern int _ZN4cstd3divEii(int, int);
+extern void func_ov007_020bde70(int, int);
+extern void func_ov007_020b131c(void);
+
+void func_ov007_020b0a20(void)
+{
+    Elem *e;
+    int mode;
+    int flag6;
+    int flag5;
+    int result;
+    Game *g;
+
+    flag6 = 0;
+    flag5 = 0;
+    g = data_ov007_0210342c;
+    e = g->unk100->unk4;
+    mode = g->unk8->unkC;
+    result = func_ov007_020aebac();
+
+    if (mode == 0) {
+        func_ov007_020bfacc(4, 6, 0);
+        func_ov007_020b1fa4(4);
+        data_ov007_0210342c->unk100->unk18 = (void *)func_ov007_020b0da0;
+        func_ov007_020be980(data_ov007_0210342c->unk100, 1, 0);
+        func_ov007_020be964(data_ov007_0210342c->unk100);
+        func_ov007_020c0638(data_ov007_0210342c->unkE0->unk4, 0, 0, 0);
+        func_ov007_020b797c();
+        e->unk48 = (func_ov007_020aebac() == 0) ? 0xDAC : 0x1770;
+        e->unk44 = e->unk48;
+        e->unk40 = e->unk44;
+    }
+    if (mode == 1) {
+        if (result != 0) {
+            func_ov007_020bdeb0(0x32);
+            data_ov007_0210342c->unkC4->unk0->unk4->unk2 = 0;
+        } else {
+            func_ov007_020bdeb0(0x33);
+        }
+    }
+    if (mode == 0x1E) {
+        func_ov007_020bfacc(7, 0x18, 0);
+    }
+    if (data_ov007_0210342c->unk100->unk18 == 0) {
+        if (e->unk18->unk0 != 0) {
+            func_ov007_020be980(data_ov007_0210342c->unk100, 1, 0);
+        } else if (result != 0) {
+            int v = e->unk18->unk10;
+            if (v <= 0x10) {
+                v = 0;
+            } else if (v >= 0x14) {
+                v = 0x1000;
+            } else {
+                v = _ZN4cstd3divEii((v - 0x10) << 12, 4);
+            }
+            e->unk48 = 0x1770 - (int)(((long long)v * 0x9C4 + 0x800) >> 12);
+            e->unk44 = e->unk48;
+            e->unk40 = e->unk44;
+        }
+    }
+    if (e->unk18->unkC != -1 && e->unk18->unk10 == e->unk18->unk12 - 0x1F) {
+        flag5 = 1;
+    } else if (e->unk18->unkC != -1 && e->unk18->unk10 == e->unk18->unk12 - 6) {
+        flag6 = 1;
+    }
+    if (((data_ov007_0210342c->unk54->unk0 & ~data_ov007_0210342c->unk54->unk2) ||
+         (data_ov007_0210342c->unk50->unkC != 0 && data_ov007_0210342c->unk50->unk14 == 0)) &&
+        mode >= 4 && result == 0 &&
+        e->unk18->unkC != -1 && e->unk18->unk10 <= e->unk18->unk12 - 0x1F)
+    {
+        flag6 = 1;
+        flag5 = 1;
+        if (result != 0) {
+            func_ov007_020bde70(0x32, 0x1E);
+        } else {
+            func_ov007_020bde70(0x33, 0x1E);
+        }
+        func_ov007_020be964(data_ov007_0210342c->unk100);
+        e->unk18->unk14 = (e->unk18->unk12 - 1) << 12;
+    }
+    if (flag5 != 0) {
+        func_ov007_020bfacc(3, 0xA, 0);
+    }
+    if (flag6 == 0) {
+        return;
+    }
+    func_ov007_020b131c();
+    data_ov007_0210342c->unk8->unk2 = 0xA;
+    data_ov007_0210342c->unk100->unk18 = 0;
+    e->unk48 = 0x1000;
+    e->unk44 = e->unk48;
+    e->unk40 = e->unk44;
+    data_ov007_0210342c->unkC4->unk0->unk4->unk2 = 1;
+}

--- a/src/func_ov007_020b58e4.c
+++ b/src/func_ov007_020b58e4.c
@@ -1,138 +1,271 @@
-// NONMATCHING: register allocation (div=27). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 extern u8 data_ov007_0210342c[];
+inline char *inline_fn(char *arg0)
+{
+  return *((char **) arg0);
+}
 
 int func_ov007_020b58e4(char *self)
 {
-    char *g = *(char**)data_ov007_0210342c;
-    char *b = *(char**)(g + 0xc);
-    int flag = *(int*)(b + 0xc);
-    char *a = *(char**)self;
-    int sel = *(short*)b;
-    char *r3ptr = *(char**)(a + 0x24);
-    int r7 = (flag == 0);
-    short *c = *(short**)(a + 4);
-    int lr_v = *(u16*)r3ptr;
-    int ip_v = *(u16*)a;
-    int ret = c[1];
-
-    switch (sel) {
+  char *g = *((char **) data_ov007_0210342c);
+  char *b = *((char **) ((*((char **) data_ov007_0210342c)) + 0xc));
+  int flag = *((int *) (b + 0xc));
+  char *a = inline_fn(self);
+  int sel = *((short *) b);
+  char *r3ptr = *((char **) (a + 0x24));
+  int r7 = flag == 0;
+  short *c = *((short **) (a + 4));
+  int lr_v = *((u16 *) r3ptr);
+  int ip_v = *((u16 *) a);
+  int ret = c[1];
+  switch (sel)
+  {
     case 0:
-        if (r7) ret = 1;
-        break;
-    case 1:
-        if (r7) {
-            int d = *(short*)((char*)b + 0xa);
-            if (d == 0xe) {
-                if (lr_v == 0) ret = 3;
-                else if (lr_v == 7) ret = 4;
-                else if (lr_v == 6) ret = 5;
-            } else {
-                if (lr_v == 0 || lr_v == 6) ret = 0;
-                else ret = 1;
-            }
-        }
-        break;
-    case 3:
-        if (r7) {
-            if (lr_v == 0) ret = 3;
-            else if (lr_v == 6) {
-                *(int*)((char*)a + 0x10) = 0;
-                ret = 5;
-            } else if (lr_v == 7) ret = 4;
-        }
-        break;
-    case 2:
-        if (r7) {
-            if (lr_v == 0 || lr_v == 6) ret = 4;
-        }
-        break;
-    case 7:
-        if (r7) {
-            if (lr_v == 2) {
-                int e = *(int*)((char*)g + 0x20);
-                if ((e == 1 && ip_v == 4) || (e == 0 && (ip_v == 3 || ip_v == 5)))
-                    ret = 3;
-                if (ip_v == 6) {
-                    int f = *(int*)((char*)g + 0xf0);
-                    ret = 3;
-                    if (f == 1)
-                        *(short*)((char*)*(int**)(self + 4) + 0x70) = 0;
-                    else
-                        *(short*)((char*)*(int**)(self + 4) + 0x70) = 0x28;
-                }
-            }
-        }
-        break;
-    case 4:
-        if (r7) {
-            if (ip_v == 3) ret = 0;
-            else if (ip_v == 5) ret = 3;
-        }
-        break;
-    case 5:
-        if (r7) {
-            if (ip_v == 4) ret = 0;
-            else if (ip_v == 5) ret = 4;
-        }
-        break;
-    case 6:
-        if (r7) {
-            if (lr_v == 2) ret = 4;
-        }
-        break;
-    case 14:
-        if (r7) {
-            if (lr_v == 0) ret = 4;
-            else if (lr_v == 7) ret = 3;
-        }
-        break;
-    case 8:
-        if (r7) {
-            int t = *(short*)((char*)*(int**)((char*)g + 8) + 0xa);
-            if (t < 0) {
-                if (lr_v == 3) ret = 0;
-                else ret = 1;
-            } else {
-                if (lr_v == 3) ret = (ip_v != 0x15) ? 5 : 3;
-                else if (lr_v == 4) ret = 4;
-            }
-        }
-        break;
-    case 9:
-        if (r7) {
-            if ((u32)(ip_v - 0xe) <= 2) ret = 6;
-            else if (ip_v == 0x15) ret = 4;
-        } else {
-            if (flag == 1) {
-                if (lr_v == 4) {
-                    int t = *(short*)((char*)b + 0xa);
-                    if (t == 8) ret = 3;
-                    else {
-                        *(int*)((char*)a + 0x10) = 0;
-                        ret = 5;
-                    }
-                }
-            }
-        }
-        break;
-    case 10:
-    case 12:
-    case 13:
-        if (r7) {
-            if (lr_v == 4) ret = 4;
-            else if ((u32)(ip_v - 0xe) <= 2) ret = 5;
-        }
-        break;
-    case 11:
-        if (r7) {
-            if ((u32)(ip_v - 0xe) <= 2) ret = 6;
-        }
-        break;
+      if (r7)
+    {
+      ret = 1;
     }
-    return ret;
+      break;
+
+    case 1:
+      if (r7)
+    {
+      int d = *((short *) (((char *) b) + 0xa));
+      if (d == 0xe)
+      {
+        if (lr_v == 0)
+        {
+          ret = 3;
+        }
+        else
+          if (lr_v == 7)
+        {
+          ret = 4;
+        }
+        else
+          if (lr_v == 6)
+        {
+          ret = 5;
+        }
+      }
+      else
+        if ((lr_v == 0) || (lr_v == 6))
+      {
+        ret = 0;
+      }
+      else
+      {
+        ret = 1;
+      }
+    }
+      break;
+
+    case 3:
+      if (r7)
+    {
+      if (lr_v == 0)
+      {
+        ret = 3;
+      }
+      else
+        if (lr_v == 6)
+      {
+        *((int *) (((char *) a) + 0x10)) = 0;
+        ret = 5;
+      }
+      else
+        if (lr_v == 7)
+      {
+        ret = 4;
+      }
+    }
+      break;
+
+    case 2:
+      if (r7)
+    {
+      if ((lr_v == 0) || (lr_v == 6))
+      {
+        ret = 4;
+      }
+    }
+      break;
+
+    case 7:
+      if (r7)
+    {
+      if (lr_v == 2)
+      {
+        int e = *((int *) (((char *) (*((char **) data_ov007_0210342c))) + 0x20));
+        if (((e == 1) && (ip_v == 4)) || ((e == 0) && ((ip_v == 3) || (ip_v == 5))))
+        {
+          ret = 3;
+        }
+        if (ip_v == 6)
+        {
+          int f = *((int *) (((char *) g) + 0xf0));
+          ret = 3;
+          if (f == 1)
+          {
+            *((short *) (((char *) (*((int **) (self + 4)))) + 0x70)) = 0;
+          }
+          else
+          {
+            *((short *) (((char *) (*((int **) (self + 4)))) + 0x70)) = 0x28;
+          }
+        }
+      }
+    }
+      break;
+
+    case 4:
+      if (r7)
+    {
+      if (ip_v == 3)
+      {
+        ret = 0;
+      }
+      else
+        if (ip_v == 5)
+      {
+        ret = 3;
+      }
+    }
+      break;
+
+    case 5:
+      if (r7)
+    {
+      if (ip_v == 4)
+      {
+        ret = 0;
+      }
+      else
+        if (ip_v == 5)
+      {
+        ret = 4;
+      }
+    }
+      break;
+
+    case 6:
+      if (r7)
+    {
+      if (lr_v == 2)
+      {
+        ret = 4;
+      }
+    }
+      break;
+
+    case 14:
+      if (r7)
+    {
+      if (lr_v == 0)
+      {
+        ret = 4;
+      }
+      else
+        if (lr_v == 7)
+      {
+        ret = 3;
+      }
+    }
+      break;
+
+    case 8:
+      if (r7)
+    {
+      int t = *((short *) (((char *) (*((int **) (((char *) (*((char **) data_ov007_0210342c))) + 8)))) + 0xa));
+      if (t < 0)
+      {
+        if (lr_v == 3)
+        {
+          ret = 0;
+        }
+        else
+        {
+          ret = 1;
+        }
+      }
+      else
+        if (lr_v == 3)
+      {
+        ret = (ip_v != 0x15) ? (5) : (3);
+      }
+      else
+        if (lr_v == 4)
+      {
+        ret = 4;
+      }
+    }
+      break;
+
+    case 9:
+      if (r7)
+    {
+      if (((u32) (ip_v - 0xe)) <= 2)
+      {
+        ret = 6;
+      }
+      else
+        if (ip_v == 0x15)
+      {
+        ret = 4;
+      }
+    }
+    else
+      if (flag == 1)
+    {
+      if (lr_v == 4)
+      {
+        int t = *((short *) (((char *) b) + 0xa));
+        if (t == 8)
+        {
+          ret = 3;
+        }
+        else
+        {
+          *((int *) (((char *) a) + 0x10)) = 0;
+          ret = 5;
+        }
+      }
+    }
+      break;
+
+    case 10:
+
+    case 12:
+
+    case 13:
+      if (r7)
+    {
+      if (lr_v == 4)
+      {
+        ret = 4;
+      }
+      else
+        if (((u32) (ip_v - 0xe)) <= 2)
+      {
+        ret = 5;
+      }
+    }
+      break;
+
+    case 11:
+      if (r7)
+    {
+      if (((u32) (ip_v - 0xe)) <= 2)
+      {
+        ret = 6;
+      }
+    }
+      break;
+
+  }
+
+  return ret;
 }

--- a/src/func_ov007_020baa10.c
+++ b/src/func_ov007_020baa10.c
@@ -1,0 +1,93 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef long long s64;
+
+extern s16 data_02082214[];
+extern char* data_ov007_02104ba0;
+
+extern void func_ov007_020c92d0(char* p);
+extern int _ZN4cstd3modEii(int a, int b);
+extern int _ZN4cstd3divEii(int a, int b);
+extern int func_ov007_020c3ba8(int d);
+
+struct V3 { int x, y, z; };
+
+void func_ov007_020baa10(void)
+{
+    char* a;
+    s16 state;
+    int dx;
+    int dy;
+    int s;
+    char* p;
+    int counter;
+
+    a = *(char**)data_ov007_02104ba0;
+    p = *(char**)(data_ov007_02104ba0 + 0x10);
+    dx = *(int*)(a + 0xc4) - *(int*)(a + 0xb8);
+    dy = *(int*)(a + 0xc8) - *(int*)(a + 0xbc);
+    func_ov007_020c92d0(p);
+    p = *(char**)(data_ov007_02104ba0 + 0x10);
+    state = *(s16*)p;
+    counter = *(int*)(p + 0xc);
+
+    switch (state) {
+    case 0:
+        if (counter == 0) {
+            *(int*)(a + 0x8c) = 0;
+            *(int*)(a + 0x88) = *(int*)(a + 0x8c);
+        }
+        return;
+    case 1:
+    case 2: {
+        int v;
+        int m = _ZN4cstd3modEii(counter, 0x3c);
+        if (m <= 0) v = 0;
+        else if (m >= 0x3c) v = 0x1000;
+        else v = _ZN4cstd3divEii(m << 12, 0x3c);
+        s = data_02082214[((u16)((v * 0xffff) >> 12) >> 4) * 2];
+        if (state == 2) {
+            *(int*)(a + 0x88) = -dx / 48 + func_ov007_020c3ba8(dx / 48 - -dx / 48);
+            *(int*)(a + 0x8c) = (int)(((s64)s * (dy / 2 - dy / 8) + 0x800) >> 12);
+        } else if (state == 1) {
+            *(int*)(a + 0x88) = (int)(((s64)s * (dx / 3) + 0x800) >> 12);
+            *(int*)(a + 0x8c) = -dy / 32 + func_ov007_020c3ba8(dy / 32 - -dy / 32);
+        }
+        return;
+    }
+    case 3:
+    case 4: {
+        int v;
+        int idx;
+        int m = _ZN4cstd3modEii(counter, 0x3c);
+        if (m <= 0) v = 0;
+        else if (m >= 0x3c) v = 0x1000;
+        else v = _ZN4cstd3divEii(m << 12, 0x3c);
+        if (*(s16*)*(char**)(data_ov007_02104ba0 + 0x10) == 4)
+            v = 0x1000 - v;
+        idx = ((u16)((v * 0xffff) >> 12) >> 4) * 2;
+        *(int*)(a + 0x88) = (int)(((s64)(dx / 4) * data_02082214[idx + 1] + 0x800) >> 12);
+        *(int*)(a + 0x8c) = (int)(((s64)(dy / 4) * data_02082214[idx] + 0x800) >> 12);
+        return;
+    }
+    case 5:
+        if (counter == 0) {
+            *(struct V3*)(a + 0x70) = *(struct V3*)(a + 0x7c);
+            *(int*)(a + 0x8c) = 0;
+            *(int*)(a + 0x88) = *(int*)(a + 0x8c);
+        }
+        return;
+    case 6:
+        if (counter == 0) {
+            int t;
+            t = -dx / 2 + func_ov007_020c3ba8(dx / 2 - -dx / 2);
+            *(int*)(a + 0x70) = (int)(((s64)t * 0x5dcLL + 0x800) >> 12);
+            t = -dy / 2 + func_ov007_020c3ba8(dy / 2 - -dy / 2);
+            *(int*)(a + 0x74) = (int)(((s64)t * 0x5dcLL + 0x800) >> 12);
+            *(int*)(a + 0x8c) = 0;
+            *(int*)(a + 0x88) = *(int*)(a + 0x8c);
+        }
+        return;
+    }
+}

--- a/src/func_ov007_020bad8c.c
+++ b/src/func_ov007_020bad8c.c
@@ -1,0 +1,148 @@
+typedef signed char s8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern u8 data_ov007_02104ba0[];
+extern u16 data_ov007_020d7b54[];
+extern short data_02082214[];
+
+extern void func_ov007_020c92d0(void *a);
+extern int _ZN4cstd3modEii(int, int);
+extern int _ZN4cstd3divEii(int, int);
+extern void func_ov007_020bbc08(int a, int b, int c);
+extern void func_ov007_020c55bc(int a, int b, int c);
+
+void func_ov007_020bad8c(void)
+{
+    char *mgr;
+    char *obj;
+    int r6;
+    int r5;
+    u16 period;
+    int var_r4;
+    int t;
+    s16 sw;
+
+    mgr = *(char **)data_ov007_02104ba0;
+    r6 = *(int *)mgr;
+    func_ov007_020c92d0(*(char **)(mgr + 0xc));
+
+    obj = *(char **)(*(char **)data_ov007_02104ba0 + 0xc);
+    r5 = *(int *)(obj + 0xc);
+    period = data_ov007_020d7b54[*(s16 *)obj];
+    t = _ZN4cstd3modEii(r5, period);
+    if (t <= 0) {
+        var_r4 = 0;
+    } else if (t >= period) {
+        var_r4 = 0x1000;
+    } else {
+        var_r4 = _ZN4cstd3divEii(t << 0xc, period);
+    }
+
+    mgr = *(char **)data_ov007_02104ba0;
+    obj = *(char **)(mgr + 0xc);
+    sw = *(s16 *)obj;
+
+    switch (sw) {
+    case 0:
+        if (r5 != 0) {
+            return;
+        }
+        func_ov007_020bbc08(1, 0, 0);
+        return;
+    case 1:
+        *(int *)(mgr + 0x1c) = 0;
+        if (_ZN4cstd3modEii(r5, 6) != 0) {
+            return;
+        }
+        {
+            int v;
+            if (var_r4 >= 0x800) {
+                v = 0x1000 - ((var_r4 - 0x800) * 2);
+            } else {
+                v = var_r4 * 2;
+            }
+            func_ov007_020bbc08(3, 0xa, (int)(((long long)v * (0x2000 - v)) >> 0xc));
+        }
+        return;
+    case 2:
+    {
+        int v;
+        int amt;
+        if (var_r4 >= 0x800) {
+            v = 0x1000 - ((var_r4 - 0x800) * 2);
+        } else {
+            v = var_r4 * 2;
+        }
+        amt = (int)(((long long)v * (0x2000 - v)) >> 0xc) + 0x1000;
+        func_ov007_020c55bc(r6, amt, amt);
+        obj = *(char **)(*(char **)data_ov007_02104ba0 + 0xc);
+        if (r5 >= data_ov007_020d7b54[*(s16 *)obj]) {
+            *(s16 *)(obj + 2) = 0;
+        }
+        if (var_r4 <= 0x800) {
+            *(int *)(*(char **)data_ov007_02104ba0 + 0x1c) = 4;
+        } else {
+            *(int *)(*(char **)data_ov007_02104ba0 + 0x1c) = 0;
+        }
+        return;
+    }
+    case 3:
+    {
+        int d;
+        u16 p3;
+        int m;
+        int var_r0;
+
+        d = r5 - 0x14;
+        if (d < 0) {
+            return;
+        }
+        if (d > data_ov007_020d7b54[sw] * 3) {
+            return;
+        }
+        p3 = data_ov007_020d7b54[3];
+        m = _ZN4cstd3modEii(d, p3);
+        if (m <= 0) {
+            var_r0 = 0;
+        } else if (m >= p3) {
+            var_r0 = 0x1000;
+        } else {
+            var_r0 = _ZN4cstd3divEii(m << 0xc, p3);
+        }
+        {
+            u32 u = (u32)(var_r0 * 0xffff);
+            int idx;
+            short tblval;
+            int amt;
+            u = u << 4;
+            u = u >> 0x10;
+            idx = (int)u >> 4;
+            tblval = data_02082214[idx * 2];
+            amt = (int)(((long long)tblval * 0x258 + 0x800) >> 0xc);
+            func_ov007_020c55bc(r6, amt + 0x1000, 0x1000 - amt);
+        }
+        *(int *)(*(char **)data_ov007_02104ba0 + 0x1c) = 2;
+        return;
+    }
+    case 4:
+    {
+        int m = _ZN4cstd3modEii(r5, 0x3c);
+        *(int *)(*(char **)data_ov007_02104ba0 + 0x1c) = 2;
+        if (m == 0) {
+            func_ov007_020bbc08(1, 0, 0);
+            return;
+        }
+        if (m != 0x1e) {
+            return;
+        }
+        func_ov007_020bbc08(3, 0x1e, (int)(((long long)var_r4 * 0x7d0 + 0x800) >> 0xc) + 0xc8);
+        return;
+    }
+    case 5:
+    default:
+        return;
+    }
+}

--- a/src/func_ov020_02111ee0.cpp
+++ b/src/func_ov020_02111ee0.cpp
@@ -1,0 +1,30 @@
+//cpp
+extern "C" {
+int func_ov020_02111418(char *c);
+int _Z14ApproachLinearRsss(void*, int, int);
+int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
+int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned);
+int _ZN5Actor9UpdatePosEP12CylinderClsn(void*,int);
+extern int data_ov020_02114aa0[];
+extern int data_ov020_02114aa8[];
+int func_ov020_02111ee0(char* c){
+  int r = func_ov020_02111418(c);
+  if(r) return r;
+  if(_Z14ApproachLinearRsss(c+0x8c, -0x2000, 0x200)){
+    int s;
+    *(int*)(c+0x98) = 0;
+    s = _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x110, data_ov020_02114aa0[1], 1, -1);
+    if(s == 0) return s;
+    *(int*)(c+0x424) = 2;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x110, data_ov020_02114aa8[1], 0x40000000, 0x1000, 0);
+    *(unsigned char*)(c+0x450) = 1;
+    *(short*)(c+0x100) = 0;
+    {
+      int* p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+      *p60 = *p60 + 0x32000;
+    }
+    *(int*)(c+0x43c) = -0x19000;
+  }
+  return _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+}
+}

--- a/src/func_ov073_02120c7c.cpp
+++ b/src/func_ov073_02120c7c.cpp
@@ -1,0 +1,59 @@
+//cpp
+typedef int Fix12i;
+struct PMF;
+extern "C" void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int c);
+extern "C" void func_ov073_0212157c(void* c, PMF* p);
+extern "C" void _Z14ApproachLinearRiii(int& v, int a, int b);
+extern "C" int _ZN9Animation8FinishedEv(void* anim);
+extern PMF data_ov073_021233c0;
+extern PMF data_ov073_021233d0;
+extern PMF data_ov073_02123360;
+
+struct C {
+    char pad0[0x8e];
+    short field_8e;
+    char pad90[0x94-0x90];
+    short field_94;
+    char pad96[0x98-0x96];
+    int field_98;
+    char pad9c[0x35c-0x9c];
+    char anim_35c;
+    char pad35d[0x4c9-0x35d];
+    unsigned char field_4c9;
+    char pad4ca[0x4cb-0x4ca];
+    unsigned char field_4cb;
+    char pad4cc[0x4d4-0x4cc];
+    int field_4d4, field_4d8, field_4dc;
+};
+
+extern "C" int func_ov073_02120c7c(C* c)
+{
+    int a = c->field_98; if (a < 0) a = -a;
+    if (a > 0xa) {
+        int i = 0;
+        C* p = c;
+        do {
+            _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(p->field_4d4, p->field_4d8, p->field_4dc);
+            i++;
+            p = (C*)((char*)p + 0xc);
+        } while (i < 2);
+    }
+    if (c->field_4c9 == 1) {
+        *(unsigned char*)(((int)c + 0x4cb) & 0xFFFFFFFFFFFFFFFFull) -= 1;
+        if (c->field_4cb != 0)
+            func_ov073_0212157c(c, &data_ov073_021233c0);
+        else
+            func_ov073_0212157c(c, &data_ov073_021233d0);
+        return 1;
+    }
+    _Z14ApproachLinearRiii(c->field_98, 0, 0x1000);
+    if (_ZN9Animation8FinishedEv(&c->anim_35c)) {
+        int b = c->field_98; if (b < 0) b = -b;
+        if (b < 0xa) {
+            c->field_98 = 0;
+            c->field_94 = c->field_8e;
+            func_ov073_0212157c(c, &data_ov073_02123360);
+        }
+    }
+    return 1;
+}

--- a/src/func_ov074_021216f4.c
+++ b/src/func_ov074_021216f4.c
@@ -1,21 +1,14 @@
-// NONMATCHING: register allocation (div=24). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *c);
 extern void ApproachAngle(short *a, short b, short c, short d, int e);
 extern short data_02082214[];
 void func_ov074_021216f4(char *c)
 {
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x40c)) {
-        char *b = c + 0x500;
-        *(short*)(c + 0x5f4) += *(short*)(b + 0xf6);
-        *(int*)(c+0x5c) = (int)(((long long)data_02082214[(*(unsigned short*)(b+0xf4) >> 4) << 1] * 0x546000 + 0x800) >> 12);
-        *(int*)(c+0x64) = (int)(((long long)data_02082214[((*(unsigned short*)(b+0xf4) >> 4) << 1) + 1] * 0x546000 + 0x800) >> 12);
-    }
-    {
-        char *b = c + 0x500;
-        ApproachAngle((short*)(c+0x8e),
-                      (short)(*(int*)(c+0x5f0) * 0x4500 + *(short*)(b+0xf4)),
-                      0xa, 0x800, 0x10);
-    }
+  if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x40c))
+  {
+    *((short *) (((int) c + 0x5f4) & 0xFFFFFFFFFFFFFFFF)) += *((short *) (c + 0x5f6));
+    *((int *) (c + 0x5c)) = (int) (((((long long) data_02082214[((*((unsigned short *) (c + 0x5f4))) >> 4) << 1]) * 0x546000) + 0x800) >> 12);
+    *((int *) (c + 0x64)) = (int) (((((long long) data_02082214[(((*((unsigned short *) (c + 0x5f4))) >> 4) << 1) + 1]) * 0x546000) + 0x800) >> 12);
+  }
+  ApproachAngle((short *) (c + 0x8e), (short) (((*((int *) (c + 0x5f0))) * 0x4500) + (*((short *) (c + 0x5f4)))), 0xa, 0x800, 0x10);
 }

--- a/src/func_ov077_02124c28.cpp
+++ b/src/func_ov077_02124c28.cpp
@@ -1,0 +1,50 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Actor;
+
+struct RaycastGround {
+    char pad0[0x14];
+    int m14[12];
+    int m44;
+    char pad48[0xc];
+};
+extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround*);
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround*, const Vector3&, Actor*);
+extern "C" void _ZN4BgCh19StartDetectingWaterEv(void*);
+extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround*);
+extern "C" int func_02037e78(int* p);
+extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround*);
+extern "C" void _ZN4BgCh18StopDetectingWaterEv(void*);
+
+extern "C" int func_ov077_02124c28(char* c)
+{
+    if (*(int*)(c + 0x3dc) == 0) {
+        RaycastGround rg;
+        Vector3 pos;
+        int r;
+        _ZN13RaycastGroundC1Ev(&rg);
+        {
+            int y = *(int*)(c + 0x60);
+            int z = *(int*)(c + 0x64);
+            int y2 = y + 0xc8000;
+            int x = *(int*)(c + 0x5c);
+            pos.x = x;
+            pos.y = y2;
+            pos.z = z;
+        }
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, pos, (Actor*)c);
+        _ZN4BgCh19StartDetectingWaterEv(&rg);
+        if (_ZN13RaycastGround10DetectClsnEv(&rg) == 0) goto fail;
+        r = func_02037e78(rg.m14);
+        if (r != 0) {
+            *(int*)(c + 0x3dc) = rg.m44;
+        } else {
+        fail:
+            _ZN13RaycastGroundD1Ev(&rg);
+            return 0;
+        }
+        _ZN4BgCh18StopDetectingWaterEv(&rg);
+        _ZN13RaycastGroundD1Ev(&rg);
+    }
+    return *(int*)(c + 0x60) - *(int*)(c + 0x3dc);
+}

--- a/src/func_ov079_02125240.cpp
+++ b/src/func_ov079_02125240.cpp
@@ -1,0 +1,41 @@
+//cpp
+struct V3 { int x, y, z; };
+struct Anim { int _pad; void *f; };
+extern struct Anim *data_ov079_021275ec[];
+extern void func_ov079_0212522c(void);
+
+extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void *thiz);
+extern "C" void func_01ffb098(void *p);
+extern "C" void func_01ffb0bc(void *p);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thiz, void *file, int a, int b, unsigned int e);
+extern "C" void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *thiz, struct V3 *v, int f);
+extern "C" void func_020393c4(int *p, int v);
+extern "C" void func_ov079_02123d4c(struct V3 *out, void *c);
+extern "C" void func_0200fa04(void *c, struct V3 *v, int b);
+extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(void *thiz, struct V3 *v, int b);
+
+extern "C" void func_ov079_02125240(char *c){
+  struct V3 v;
+  struct V3 a;
+  struct V3 b;
+  if(*(unsigned char*)(c+0x40c)) return;
+  if(!_ZNK12WithMeshClsn10IsOnGroundEv(c+0x110)) return;
+  *(int*)(c+0xa8) = 0;
+  func_01ffb098(c+0x418);
+  func_01ffb0bc(c+0x418);
+  *(unsigned char *)(((int)c + 0x40c) & 0xFFFFFFFFFFFFFFFF) += 1;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x2cc, data_ov079_021275ec[(unsigned char)c[0x414]*5+1]->f, 0x40000000, 0x1000, 0);
+  v.x = *(int*)(c+0x5c);
+  v.y = *(int*)(c+0x60);
+  v.z = *(int*)(c+0x64);
+  _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, &v, 0x7d0000);
+  *(int*)(c+0x3b0) = 6;
+  func_020393c4((int*)(c+0x418), (int)func_ov079_0212522c);
+  if(*(unsigned char*)(c+0x414) != 0){
+    func_ov079_02123d4c(&a, c);
+    func_0200fa04(c, &a, 0);
+  } else {
+    func_ov079_02123d4c(&b, c);
+    _ZN5Actor13LandingDustAtER7Vector3b(c, &b, 0);
+  }
+}


### PR DESCRIPTION
Fable night batch, three sources, all independently link-gate verified at land:

- Byte-lane fan-out (0x300-0x800, m2c drafts attached): 15 functions including _ZN5Stage6RenderEv, _ZN3HUD15RenderStarCountEv, _ZN3OAM7SECONDSE, and four Player state handlers. This lane targets the large-function byte pool (40% of remaining bytes).
- Refine wave 3 (div<=30 near-miss drafts): 16 functions, 17/17 agent hit rate on the drafts that ran before the session quota reset cut the wave short.
- Free post-pass (clone/paramclone): 6 functions including four NONMATCHING-parked upgrades.

Two files are linkcheck BLIND-n (unresolvable-in-symbols.txt slots only): their pool words were manually confirmed against the ROM (0x021106f4 data, ITCM 0x01ffb098/0x01ffb0bc callees) with canonical addr-form names, everything else in those files verified.

Built with Claude Code