### PR TITLE
Match 5 ov032 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov032: __sinit_ov032_02112c10 (0x02112c10), 02111254 (0x02111254), 02111620 (0x02111620), 02111830 (0x02111830), 02111e24 (0x02111e24) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #222 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/__sinit_ov032_02112c10.c
+++ b/src/__sinit_ov032_02112c10.c
@@ -1,0 +1,50 @@
+extern int func_02017acc(int *p, int n);
+extern void func_020731dc(int *a, void *b, void *node);
+extern void _ZN13SharedFilePtr9ConstructEj(int *p, unsigned int n);
+extern void func_02017ab4(void);
+extern void func_02017984(void);
+
+extern int data_ov032_02113a40[];
+extern int data_ov032_02113a64[];
+extern int data_ov032_02113a50[];
+extern int data_ov032_02113a70[];
+extern int data_ov032_02113a48[];
+extern int data_ov032_02113a58[];
+
+struct P2 { int a, b; };
+struct P4 { struct P2 lo, hi; };
+
+extern struct P4 data_ov032_02113a8c;
+extern struct P2 data_ov032_0211377c;
+extern struct P2 data_ov032_021137ac;
+extern struct P4 data_ov032_02113a9c;
+extern struct P2 data_ov032_021137b4;
+extern struct P2 data_ov032_021137a4;
+extern struct P4 data_ov032_02113aac;
+extern struct P2 data_ov032_0211379c;
+extern struct P2 data_ov032_021137c4;
+extern struct P4 data_ov032_02113abc;
+extern struct P2 data_ov032_02113784;
+extern struct P2 data_ov032_0211378c;
+extern struct P4 data_ov032_02113a7c;
+extern struct P2 data_ov032_02113794;
+extern struct P2 data_ov032_021137bc;
+
+void __sinit_ov032_02112c10(void) {
+    func_02017acc(data_ov032_02113a40, 0x295);
+    func_020731dc(data_ov032_02113a40, func_02017ab4, data_ov032_02113a64);
+    _ZN13SharedFilePtr9ConstructEj(data_ov032_02113a50, 0x297);
+    func_020731dc(data_ov032_02113a50, func_02017984, data_ov032_02113a70);
+    _ZN13SharedFilePtr9ConstructEj(data_ov032_02113a48, 0x296);
+    func_020731dc(data_ov032_02113a48, func_02017984, data_ov032_02113a58);
+    data_ov032_02113a8c.lo = data_ov032_0211377c;
+    data_ov032_02113a8c.hi = data_ov032_021137ac;
+    data_ov032_02113a9c.lo = data_ov032_021137b4;
+    data_ov032_02113a9c.hi = data_ov032_021137a4;
+    data_ov032_02113aac.lo = data_ov032_0211379c;
+    data_ov032_02113aac.hi = data_ov032_021137c4;
+    data_ov032_02113abc.lo = data_ov032_02113784;
+    data_ov032_02113abc.hi = data_ov032_0211378c;
+    data_ov032_02113a7c.lo = data_ov032_02113794;
+    data_ov032_02113a7c.hi = data_ov032_021137bc;
+}

--- a/src/func_ov032_02111254.c
+++ b/src/func_ov032_02111254.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern char* ClosestPlayer(char* c);
 extern int Vec3_HorzDist(void* a, void* b);
 extern int data_ov032_02113abc[];
@@ -13,7 +10,7 @@ int func_ov032_02111254(char *c) {
     int d;
     if (pl == 0 || *(unsigned short*)(c+0x400+0x2a) != 0)
         return 0;
-    s = (int*)(pl + 0x5c);
+    s = (int*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
     *(int*)(c+0x418) = s[0];
     *(int*)(c+0x41c) = s[1];
     *(int*)(c+0x420) = s[2];
@@ -26,9 +23,9 @@ int func_ov032_02111254(char *c) {
     if (d < 0) d = -d;
     if (d < 0xb4000)
         return 0;
-    if (t == data_ov032_02113abc || t == data_ov032_02113a7c)
-        return 1;
-    if (Vec3_HorzDist(c+0x40c, c+0x418) > 0x4b0000)
-        return 0;
+    if (t != data_ov032_02113abc && t != data_ov032_02113a7c) {
+        if (Vec3_HorzDist(c+0x40c, c+0x418) > 0x4b0000)
+            return 0;
+    }
     return 1;
 }

--- a/src/func_ov032_02111620.cpp
+++ b/src/func_ov032_02111620.cpp
@@ -1,22 +1,20 @@
 //cpp
-// NONMATCHING: different op / idiom (div=58). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" void *Actor_ClosestPlayer(void *self);
+typedef struct { int x, y, z; } Vector3;
+extern "C" void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern "C" int func_ov032_02111350(void *c);
 extern "C" int func_ov032_02111254(void *c);
-extern "C" void Matrix4x3_FromRotationY(void *m, int angle);
-extern "C" void Matrix4x3_ApplyInPlaceToRotationX(void *m, int angX);
+extern "C" void Matrix4x3_FromRotationY(void *m, short angle);
+extern "C" void Matrix4x3_ApplyInPlaceToRotationX(void *m, short angX);
 extern "C" void MulVec3Mat4x3(void *in, void *m, void *out);
-extern "C" int Animation_Finished(void *self);
-extern "C" int ApproachLinear(short *p, int target, int step);
-extern "C" int AngleDiff(int a, int b);
-extern "C" void ModelAnim_SetAnim(void *self, void *bca, int a, int fix, unsigned int b);
+extern "C" int _ZN9Animation8FinishedEv(void *self);
+extern "C" int _Z14ApproachLinearRsss(short *p, short target, short step);
+extern "C" int AngleDiff(short a, short b);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
 extern "C" void func_ov032_02111ff4(void *c, void *p);
 extern "C" short Vec3_VertAngle(void *a, void *b);
 
 extern int data_020a0e68;
-extern void **data_ov032_02113a50;
+extern void *data_ov032_02113a50[];
 extern void *data_ov032_02113a8c;
 extern int data_0209f32c;
 
@@ -25,65 +23,75 @@ extern "C" int func_ov032_02111620(void *thiz)
     unsigned char *c = (unsigned char *)thiz;
     unsigned char *r5;
 
-    r5 = (unsigned char *)Actor_ClosestPlayer(c);
+    r5 = (unsigned char *)_ZN5Actor13ClosestPlayerEv(c);
     if (r5 == 0)
         return 1;
 
     if (func_ov032_02111350(c) == 1)
         goto zeroblock;
-    if (func_ov032_02111254(c) != 0) {
-        int in[3];
-        int out[3];
-        in[2] = 0;
-        in[2] = 0x14000;
-        in[0] = 0; in[1] = 0; out[0] = 0; out[1] = 0; out[2] = 0;
-        Matrix4x3_FromRotationY(&data_020a0e68, *(short *)(c + 0x8e));
-        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short *)(c + 0x8c));
-        MulVec3Mat4x3(in, &data_020a0e68, out);
-        *(int *)(c + 0xa8) = out[1];
-        goto afterblock;
-    }
+    if (func_ov032_02111254(c) != 0)
+        goto matrixblock;
 zeroblock:
     *(int *)(c + 0x98) = 0;
     *(int *)(c + 0xa4) = 0;
     *(int *)(c + 0xa8) = 0;
     *(int *)(c + 0xac) = 0;
+    goto afterblock;
+matrixblock:
+    {
+        int in[3];
+        int out[3];
+        in[2] = 0;
+        in[2] = 0x14000;
+        in[0] = 0;
+        in[1] = 0;
+        out[0] = 0;
+        out[1] = 0;
+        out[2] = 0;
+        Matrix4x3_FromRotationY(&data_020a0e68, *(short *)(c + 0x8e));
+        Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short *)(c + 0x8c));
+        MulVec3Mat4x3(in, &data_020a0e68, out);
+        *(int *)(c + 0xa8) = out[1];
+    }
 afterblock: ;
 
     if (*(int *)(c + 0x424) == 0) {
-        if (Animation_Finished(c + 0x39c) != 0) {
-            ApproachLinear((short *)(c + 0x92), 0, 0x200);
-            *(int *)(c + 0x424) = 1;
-            *(unsigned char *)(c + 0x428) = 0;
-            if (AngleDiff(*(short *)(c + 0x92), 0) < 0x200) {
-                *(short *)(c + 0x92) = 0;
-                *(short *)(c + 0x400 + 0x2a) = 0x64;
-                *(short *)(c + 0x400 + 0x30) = *(short *)(c + 0x8e);
-                *(int *)(c + 0xb0) = 3;
-                ModelAnim_SetAnim(c + 0x34c, (&data_ov032_02113a50)[1], 0, 0x1000, 0);
-                func_ov032_02111ff4(c, &data_ov032_02113a8c);
-            }
-        }
-    } else {
+        if (_ZN9Animation8FinishedEv(c + 0x39c) == 0)
+            goto player_path;
+    }
+
+    _Z14ApproachLinearRsss((short *)(c + 0x92), 0, 0x200);
+    *(int *)(c + 0x424) = 1;
+    *(unsigned char *)(c + 0x428) = 0;
+    if (AngleDiff(*(short *)(c + 0x92), 0) < 0x200) {
+        *(short *)(c + 0x92) = 0;
+        *(short *)(c + 0x400 + 0x2a) = 0x64;
+        *(short *)(c + 0x400 + 0x30) = *(short *)(c + 0x8e);
+        *(int *)(c + 0xb0) = 3;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x34c, data_ov032_02113a50[1], 0, 0x1000, 0);
+        func_ov032_02111ff4(c, &data_ov032_02113a8c);
+    }
+    goto end;
+
+player_path:
+    {
         int vec[3];
         unsigned int n;
-        int *p = (int *)(r5 + 0x5c);
+        int *p = (int *)(((int)r5 + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
         vec[0] = p[0];
         vec[1] = p[1];
         vec[2] = p[2];
         if (data_0209f32c > *(int *)(c + 0x60)) {
-            ApproachLinear((short *)(c + 0x92), 0, 0x200);
+            _Z14ApproachLinearRsss((short *)(c + 0x92), 0, 0x200);
         } else {
-            ApproachLinear((short *)(c + 0x92), Vec3_VertAngle(c + 0x5c, vec), 0x200);
+            _Z14ApproachLinearRsss((short *)(c + 0x92), Vec3_VertAngle(c + 0x5c, vec), 0x200);
         }
         n = (unsigned int)(*(int *)(c + 0x3a4) << 4) >> 0x10;
-        if (n <= 0x14) {
-            *(unsigned char *)(c + 0x428) = 0;
-        } else if (n < 0x3c) {
+        if (n > 0x14 && n < 0x3c)
             *(unsigned char *)(c + 0x428) = 1;
-        } else {
+        else
             *(unsigned char *)(c + 0x428) = 0;
-        }
     }
+end:
     return 1;
 }

--- a/src/func_ov032_02111830.c
+++ b/src/func_ov032_02111830.c
@@ -1,23 +1,16 @@
-// NONMATCHING: different op / idiom (div=58). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 typedef short s16;
-typedef unsigned short u16;
 typedef unsigned int u32;
 typedef int Fix12i;
-typedef struct { int x, y, z; } Vector3;
-struct Matrix4x3 { int m[12]; };
-
 extern int data_0209f32c;
-extern struct Matrix4x3 data_020a0e68;
-extern int data_ov032_02113a50[];
-extern void* data_ov032_02113a8c;
-
-extern void Matrix4x3_FromRotationY(struct Matrix4x3 *m, s16 angY);
-extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *m, s16 angX);
-extern void MulVec3Mat4x3(const Vector3 *v, const struct Matrix4x3 *m, Vector3 *out);
-extern u32 func_02022c80(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void *dir);
-extern u32 func_02022d00(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, void *dir);
+extern int data_020a0e68;
+extern void *data_ov032_02113a50[];
+extern void *data_ov032_02113a8c;
+extern void Matrix4x3_FromRotationY(void *m, s16 angY);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, s16 angX);
+extern void MulVec3Mat4x3(void *v, void *m, void *out);
+extern u32 func_02022c80(u32, u32, Fix12i, Fix12i, Fix12i, const void *);
+extern u32 func_02022d00(u32, u32, Fix12i, Fix12i, Fix12i, void *);
 extern int func_ov032_02111350(char *c);
 extern int func_ov032_02111254(void *c);
 extern void _Z14ApproachLinearRsss(s16* p, s16 target, s16 step);
@@ -28,25 +21,27 @@ extern int func_ov032_02111ff4(void*, void*);
 int func_ov032_02111830(char *c)
 {
     s16 speed;
-
     speed = 0x3000;
     if (data_0209f32c - 0x64000 > *(int*)(c + 0x60))
         speed = 0;
-
-    if (*(int*)(c + 0x424) == 0 && data_0209f32c > *(int*)(c + 0x60)) {
-        if (*(s16*)(c + 0x430) > 0)
-            *(int*)(c + 0x424) = 1;
+    if (*(int*)(c + 0x424) == 0) {
+        if (data_0209f32c > *(int*)(c + 0x60)) {
+            if (*(s16*)(c + 0x400 + 0x30) > 0)
+                *(int*)(c + 0x424) = 1;
+        }
     }
-
     if (*(int*)(c + 0x424) > 0 && *(int*)(c + 0x424) < 5) {
-        (*(int*)(c + 0x424))++;
+        int *p424 = (int*)(((int)c + 0x424) & 0xFFFFFFFFFFFFFFFFLL);
+        (*p424)++;
         if (*(int*)(c + 0x424) == 4) {
-            Vector3 v[3];
 
+            typedef struct { int x,y,z; } V3;
+            V3 v[3];
             v[0].x = *(int*)(c + 0x5c);
             v[0].y = *(int*)(c + 0x60);
             v[0].z = *(int*)(c + 0x64);
-            v[1].x = 0; v[1].y = 0; v[1].z = 0;
+            v[1].z = 0;
+            v[1].x = 0; v[1].y = 0;
             v[2].x = 0; v[2].y = 0; v[2].z = 0;
             v[1].z = 0xa0000;
             Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(c + 0x8e));
@@ -57,54 +52,62 @@ int func_ov032_02111830(char *c)
             *(int*)(c + 0x42c) = func_02022d00(*(int*)(c + 0x42c), 0x56, v[0].x, data_0209f32c, v[0].z, 0);
             v[0].y += 0x4b000;
             func_02022c80(0, 0x54, v[0].x, v[0].y, v[0].z, 0);
+
         }
     }
 
-    if (func_ov032_02111350(c) == 1 || func_ov032_02111254(c) == 0) {
-        speed = 0;
-        *(int*)(c + 0x98) = 0;
-        *(int*)(c + 0xa4) = 0;
-        *(int*)(c + 0xa8) = 0;
-        *(int*)(c + 0xac) = 0;
-    } else {
-        Vector3 in2;
-        Vector3 out2;
-
-        in2.x = 0; in2.y = 0; in2.z = 0;
-        out2.x = 0; out2.y = 0; out2.z = 0;
-        in2.z = 0x14000;
+    if (func_ov032_02111350(c) == 1)
+        goto zeroblock;
+    if (func_ov032_02111254(c) != 0)
+        goto matrixblock;
+zeroblock:
+    speed = 0;
+    *(int*)(c + 0x98) = 0;
+    *(int*)(c + 0xa4) = 0;
+    *(int*)(c + 0xa8) = 0;
+    *(int*)(c + 0xac) = 0;
+    goto afterblock;
+matrixblock:
+    {
+        int in2[3];
+        int out2[3];
+        in2[2] = 0;
+        in2[2] = 0x14000;
+        in2[0] = 0;
+        in2[1] = 0;
+        out2[0] = 0;
+        out2[1] = 0;
+        out2[2] = 0;
         Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(c + 0x8e));
         Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16*)(c + 0x8c));
-        MulVec3Mat4x3(&in2, &data_020a0e68, &out2);
-        *(int*)(c + 0xa8) = out2.y;
+        MulVec3Mat4x3(in2, &data_020a0e68, out2);
+        *(int*)(c + 0xa8) = out2[1];
     }
-
+afterblock: ;
     _Z14ApproachLinearRsss((s16*)(c + 0x430), speed, 0x200);
-    _Z14ApproachLinearRsss((s16*)(c + 0x92), *(s16*)(c + 0x430), 0x200);
-
+    _Z14ApproachLinearRsss((s16*)(c + 0x92), *(s16*)(c + 0x400 + 0x30), 0x200);
     if (_ZN9Animation8FinishedEv(c + 0x39c) != 0) {
         *(unsigned char*)(c + 0x428) = 0;
         if (speed == 0) {
             s16 a = *(s16*)(c + 0x92);
             if (a < 0) a = -a;
             if (a < 0x100) {
-                *(s16*)(c + 0x42a) = 0x64;
-                *(s16*)(c + 0x430) = *(s16*)(c + 0x8e);
+                *(s16*)(c + 0x400 + 0x2a) = 0x64;
+                *(s16*)(c + 0x400 + 0x30) = *(s16*)(c + 0x8e);
                 *(int*)(c + 0xb0) = 3;
-                *(int*)(c + 0x128) &= ~2;
-                *(int*)(c + 0x168) &= ~2;
-                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x34c, (void*)data_ov032_02113a50[1], 0, 0x1000, 0);
+                *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+                *(int*)(((int)c + 0x168) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x34c, data_ov032_02113a50[1], 0, 0x1000, 0);
                 func_ov032_02111ff4(c, &data_ov032_02113a8c);
                 return 1;
             }
         }
     } else {
-        u16 t = (u16)(*(int*)(c + 0x3a4) >> 12);
+        unsigned int t = (unsigned int)(*(int*)(c + 0x3a4) << 4) >> 0x10;
         if (t > 0x14 && t < 0x3c)
             *(unsigned char*)(c + 0x428) = 1;
         else
             *(unsigned char*)(c + 0x428) = 0;
     }
-
     return 1;
 }

--- a/src/func_ov032_02111e24.c
+++ b/src/func_ov032_02111e24.c
@@ -1,0 +1,57 @@
+extern void _Z14ApproachLinearRiii(int* p, int t, int s);
+extern int func_ov032_02111350(char* c);
+extern int Vec3_HorzAngle(void* a, void* b);
+extern void _Z14ApproachLinearRsss(short* p, int t, int s);
+extern int Vec3_VertAngle(void* a, void* b);
+extern void Matrix4x3_FromRotationY(void* m, short ang);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short ang);
+extern void MulVec3Mat4x3(void* in, void* m, void* out);
+extern int func_ov032_02111254(void* c);
+extern int func_ov032_02111ff4(void* c, void* p);
+extern int RandomIntInternal(int* seed);
+extern int data_020a0e68;
+extern char data_ov032_02113aac[];
+extern char data_ov032_02113a9c[];
+extern char data_ov032_02113a8c[];
+extern int data_0209e650[];
+
+int func_ov032_02111e24(char* c) {
+    int in[3];
+    int out[3];
+    int ang;
+
+    _Z14ApproachLinearRiii((int*)(c+0x98), 0x5000, 0x333);
+    if (func_ov032_02111350(c) == 1) {
+        *(short*)(c+0x100) = 0x28;
+        *(short*)(c+0x400+0x2a) = 0x28;
+        ang = Vec3_HorzAngle(c+0x5c, c+0x40c);
+        *(short*)(c+0x400+0x30) = ang;
+    }
+    _Z14ApproachLinearRsss((short*)(c+0x94), *(short*)(c+0x400+0x30), 0x100);
+    ang = Vec3_VertAngle(c+0x5c, c+0x40c);
+    _Z14ApproachLinearRsss((short*)(c+0x92), ang, 0x100);
+    in[2] = 0;
+    in[2] = 0x5000;
+    in[0] = 0;
+    in[1] = 0;
+    out[0] = 0;
+    out[1] = 0;
+    out[2] = 0;
+    Matrix4x3_FromRotationY(&data_020a0e68, *(short*)(c+0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(c+0x8c));
+    MulVec3Mat4x3(in, &data_020a0e68, out);
+    *(int*)(c+0xa8) = out[1];
+    if (func_ov032_02111254(c) == 1) {
+        func_ov032_02111ff4(c, data_ov032_02113aac);
+        return 1;
+    }
+    if (*(unsigned short*)(c+0x100) == 0) {
+        unsigned int r = (unsigned int)RandomIntInternal(data_0209e650);
+        if (((r >> 8) & 3) == 0) {
+            func_ov032_02111ff4(c, data_ov032_02113a9c);
+        } else {
+            func_ov032_02111ff4(c, data_ov032_02113a8c);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for five related ov032 functions, verified with `tools/match.py --version 1.2/sp2p3 --module ov032`.

| Function | Address | Size |
|---|---|---|
| `func_ov032_02111254` | `0x02111254` | `0xfc` |
| `func_ov032_02111620` | `0x02111620` | `0x1f4` |
| `func_ov032_02111830` | `0x02111830` | `0x320` |
| `func_ov032_02111e24` | `0x02111e24` | `0x178` |
| `__sinit_ov032_02112c10` | `0x02112c10` | `0x1ac` |

Compiler: **mwccarm 1.2/sp2p3** with `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.

Notes:
- `func_ov032_02111254`: u64-mask base materialization for player pos copy; fall-through return for state-table early-out.
- `func_ov032_02111620` / `func_ov032_02111830`: goto layout for zero/matrix and approach/player paths; stack Vector3 array for effect spawn; u64-mask for flag BIC sites.
- `func_ov032_02111e24`: HorzAngle setup only under `func_ov032_02111350==1`; matrix/ApproachLinear always run; random branch uses unsigned `>> 8`.
- `__sinit_ov032_02112c10`: SharedFilePtr construct + 5× 16-byte (P2/P4) state-table copies.

## Test plan

- [x] `python tools/match.py --c src/<file> --func <name> --addr <addr> --size <size> --version 1.2/sp2p3 --module ov032` for each of the five
- [ ] CI `validate` green