### PR TITLE
Match 4 ov094 HootTheOwl functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov094: _ZN10HootTheOwl13InitResourcesEv (0x02136634), 021359d8 (0x021359d8), 02136024 (0x02136024), 021362e0 (0x021362e0) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #223 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN10HootTheOwl13InitResourcesEv.c
+++ b/src/_ZN10HootTheOwl13InitResourcesEv.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=33). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN11ShadowModel12InitCylinderEv(void*);
@@ -18,9 +15,15 @@ extern int data_ov094_02136a1c[];
 extern void* data_ov094_02136b40;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
+#define LA(p) ((int*)(unsigned)(((long long)(unsigned)(unsigned)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
 int _ZN10HootTheOwl13InitResourcesEv(char* c) {
     int v0[3];
     void* f;
+    int zero = 0;
+    int* fl;
+    int grav = 0x1e000;
+
     f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov094_02136ae0);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x30c, f, 1, -1);
     _ZN11ShadowModel12InitCylinderEv(c+0x370);
@@ -31,20 +34,25 @@ int _ZN10HootTheOwl13InitResourcesEv(char* c) {
     v0[1] = data_ov094_02136a1c[1];
     v0[2] = data_ov094_02136a1c[2];
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c+0x110, c, v0, 0x64000, 0x64000, 0x800004, 0);
+
+    *(int*)(c+0x3cc) = zero;
+    fl = LA(c+0x128);
     {
-        int zero = 0;
-        int* fl = (int*)(c+0x128);
-        *(int*)(c+0x3cc) = zero;
-        *fl = *fl | 2;
-        *(int*)(c+0xa0) = -0x1e000;
-        *(int*)(c+0x3f0) = 0x1000;
-        *(unsigned char*)(c+0x3e4) = 0x1f;
-        _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x150, c, 0x50000, 0x64000, (void*)zero, zero);
+        int t = *fl;
+        *fl = t | 2;
     }
+    *(int*)(c+0xa0) = -grav;
+    *(int*)(c+0x3f0) = 0x1000;
+    *(unsigned char*)(c+0x3e4) = 0x1f;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x150, c, 0x50000, 0x64000, (void*)zero, zero);
     func_ov094_02136188(c, &data_ov094_02136b40);
-    if (data_0209f2f8 != 7) return 1;
-    if (data_0209f220 == 1) return 1;
-    if (IsStarCollectedInCurLevel(1) != 0) return 1;
+
+    if (data_0209f2f8 != 7) goto ret1;
+    if (data_0209f220 != 1) {
+        if (IsStarCollectedInCurLevel(1) != 0) goto ret1;
+    }
     _ZN9ActorBase18MarkForDestructionEv(c);
     return 0;
+ret1:
+    return 1;
 }

--- a/src/func_ov094_021359d8.cpp
+++ b/src/func_ov094_021359d8.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: push-set / frame (div=60). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" void ModelAnim_SetAnim(void *self, void *bca, int a, int fix, unsigned int b);
 extern "C" int Sound_PlayLong(unsigned int a, unsigned int b, unsigned int cc, void *pos, unsigned int d);
 extern "C" int func_ov002_020df7f4(void *c);
@@ -20,6 +17,7 @@ extern void *data_ov094_02136b30;
 extern "C" int func_ov094_021359d8(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
+    void *rider;
 
     if (*(unsigned short *)(c + 0x100) == 1) {
         ModelAnim_SetAnim(c + 0x30c, (&data_ov094_02136ae8)[1], 0, 0x1000, 0);
@@ -41,7 +39,8 @@ extern "C" int func_ov094_021359d8(void *thiz)
         }
     }
 
-    if (*(int *)(c + 0x3cc) != 0 && func_ov002_020df7f4(c) == 1) {
+    rider = *(void **)(c + 0x3cc);
+    if (rider != 0 && func_ov002_020df7f4(rider) == 1) {
         *(unsigned short *)(c + 0x100) = 0xa;
         ModelAnim_SetAnim(c + 0x30c, (&data_ov094_02136af8)[1], 0, 0x1000, 0);
     }
@@ -49,7 +48,8 @@ extern "C" int func_ov094_021359d8(void *thiz)
     ApproachAngle((short *)(c + 0x92), 0, 0xa, 0x200, 0x100);
 
     if (WithMeshClsn_IsOnWall(c + 0x150) != 0 || func_02035638(c + 0x150) != 0) {
-        if (*(int *)(c + 0x3cc) != 0 && func_ov002_020df7ac(thiz) != 0) {
+        rider = *(void **)(c + 0x3cc);
+        if (rider != 0 && func_ov002_020df7ac(rider) != 0) {
             WithMeshClsn_Unk_0203589c(c + 0x150);
             *(int *)(c + 0x3cc) = 0;
             *(int *)(c + 0x3e8) = 0;
@@ -59,13 +59,20 @@ extern "C" int func_ov094_021359d8(void *thiz)
         }
     }
 
-    if (*(int *)(c + 0x3cc) != 0) {
-        if (func_ov002_020df7f4(c) < 0) {
-            *(int *)(c + 0x3cc) = 0;
-            *(int *)(c + 0x3e8) = 0;
-            *(unsigned short *)(c + 0x100) = 0;
-            func_ov094_02136188(c, &data_ov094_02136b30);
-        }
+    rider = *(void **)(c + 0x3cc);
+    if (rider == 0) {
+        goto cleanup;
     }
+    if (rider == 0) {
+        goto end;
+    }
+    if (func_ov002_020df7f4(rider) < 0) {
+cleanup:
+        *(int *)(c + 0x3cc) = 0;
+        *(int *)(c + 0x3e8) = 0;
+        *(unsigned short *)(c + 0x100) = 0;
+        func_ov094_02136188(c, &data_ov094_02136b30);
+    }
+end:
     return 1;
 }

--- a/src/func_ov094_02136024.c
+++ b/src/func_ov094_02136024.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=35). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 typedef struct { int x, y, z; } Vec3;
 typedef struct PMF PMF;
@@ -14,19 +11,21 @@ short Vec3_HorzAngle(const Vec3* a, const Vec3* b);
 int func_ov094_02136188(void* c, PMF* p);
 extern char data_020a0e68[];
 extern PMF data_ov094_02136b60;
+#define LA(p) ((char*)(unsigned)(((long long)(unsigned)(unsigned)(p)) & 0xFFFFFFFFFFFFFFFFLL))
 
 int func_ov094_02136024(char* c){
   char* p = _ZN5Actor13ClosestPlayerEv();
   if (p != 0 && *(int*)(p+0x37c) != 0) {
-    char* ip = p + 0x5c;
+    char* ip = LA(p + 0x5c);
     Vec3 pp;
-    pp.x = *(int*)ip;
+    Vec3 d;
+    Vec3* selfpos = (Vec3*)(c + 0x5c);
+    pp.x = *(int*)(ip+0);
     pp.y = *(int*)(ip+4);
     pp.z = *(int*)(ip+8);
     *(int*)(c+0x60) = *(int*)(p+0x644) + 0x190000;
     *(int*)(c+0x3d0) = (int)p;
-    Vec3 d;
-    Vec3_Sub(&d, (Vec3*)(c+0x5c), &pp);
+    Vec3_Sub(&d, selfpos, &pp);
     if (LenVec3(&d) < 0x28000) {
       d.x = *(int*)(c+0x5c);
       d.y = *(int*)(c+0x60);
@@ -36,9 +35,14 @@ int func_ov094_02136024(char* c){
       d.z = 0x320000;
       Matrix4x3_FromRotationY(data_020a0e68, 0x4000);
       MulVec3Mat4x3(&d, data_020a0e68, (Vec3*)(c+0x3d8));
-      *(int*)(c+0x3d8) += *(int*)(c+0x5c);
-      *(int*)(c+0x3dc) += *(int*)(c+0x60);
-      *(int*)(c+0x3e0) += *(int*)(c+0x64);
+      {
+        int *px = (int*)LA(c + 0x3d8);
+        int *py = (int*)LA(c + 0x3dc);
+        int *pz = (int*)LA(c + 0x3e0);
+        *px = *px + *(int*)(c+0x5c);
+        *py = *py + *(int*)(c+0x60);
+        *pz = *pz + *(int*)(c+0x64);
+      }
       *(short*)(c+0x94) = Vec3_HorzAngle((Vec3*)(c+0x5c), (Vec3*)(c+0x3d8));
       *(short*)(c+0x8e) = *(short*)(c+0x94);
       func_ov094_02136188(c, &data_ov094_02136b60);
@@ -46,4 +50,5 @@ int func_ov094_02136024(char* c){
   }
   return 1;
 }
+
 }

--- a/src/func_ov094_021362e0.c
+++ b/src/func_ov094_021362e0.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=35). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int Fix12i;
 typedef short s16;
 
@@ -15,13 +12,14 @@ void func_ov094_021362e0(char* c)
 {
     struct Vec3 v;
     char* m;
+    int z = 0;
     if (*(int*)(c + 0x3cc) == 0) return;
-    v.x = 0;
-    v.y = 0;
-    v.z = 0;
+    *(volatile Fix12i*)&v.x = z;
+    *(volatile Fix12i*)&v.y = z;
+    *(volatile Fix12i*)&v.z = z;
     m = *(char**)(c + 0x3cc);
     data_020a0e68 = *(struct Mtx43*)(*(char**)(m + 0xc8));
-    Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0x3000, v.y, v.z);
+    Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0x3000, z, z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68, -0x6000, 0x1000, 0x4000);
     v.x = data_020a0e68.a[9];
     v.y = data_020a0e68.a[10];
@@ -30,6 +28,6 @@ void func_ov094_021362e0(char* c)
     *(int*)(c + 0x60) = v.y << 3;
     *(int*)(c + 0x64) = v.z << 3;
     *(s16*)(c + 0x94) = *(s16*)(*(char**)(c + 0x3cc) + 0x8e);
-    *(s16*)(c + 0x92) = 0;
+    *(s16*)(c + 0x92) = (s16)z;
     *(struct Mtx43*)(c + 0x328) = data_020a0e68;
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for four ov094 HootTheOwl functions (mwccarm 1.2/sp2p3):

| Function | Address | Size |
|---|---|---|
| `func_ov094_021362e0` | `0x021362e0` | `0x100` |
| `func_ov094_02136024` | `0x02136024` | `0x12c` |
| `func_ov094_021359d8` | `0x021359d8` | `0x1fc` |
| `_ZN10HootTheOwl13InitResourcesEv` | `0x02136634` | `0x164` |

Compiler flags: `-O4,p -enum int -lang c99` (C) / `-lang c++` (//cpp files) `-char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Locally verified with `tools/match.py --version 1.2/sp2p3 --module ov094` (relocation-aware).

## Test plan

- [x] `match.py` reports MATCH for each of the four functions
- [ ] CI `validate` green on this PR