### PR TITLE
Match 4 ov018 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov018: 02111368 (0x02111368), 021116b4 (0x021116b4), 02111804 (0x02111804), 02111bf0 (0x02111bf0) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #224 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov018_02111368.c
+++ b/src/func_ov018_02111368.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: base materialization / addressing (div=27). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
@@ -107,28 +104,28 @@ extern "C" int func_ov018_02111368(char* self)
         }
 
         if (reached) {
-            int& curIdxR = *(int*)(self + 0x33c);
-            curIdxR += *(int*)(self + 0x34c);
+            int* pIdx = (int*)((long long)(int)(self + 0x33c) & 0xFFFFFFFFFFFFFFFFLL);
+            *pIdx = *pIdx + *(int*)(self + 0x34c);
             if (*(int*)(self + 0x33c) < 0) {
                 if (_ZNK7PathPtr5LoopsEv(&path) != 0) {
                     *(int*)(self + 0x33c) = *(int*)(self + 0x338) - 1;
                 } else {
-                    int& curIdxR2 = *(int*)(self + 0x33c);
                     *(u8*)(self + 0x331) = 0x3c;
                     *(u8*)(self + 0x330) = 0;
                     *(int*)(self + 0x34c) = 1;
-                    curIdxR2 += *(int*)(self + 0x34c) * 2;
+                    int* pIdx2 = (int*)((long long)(unsigned int)(self + 0x33c) & 0xFFFFFFFFFFFFFFFFLL);
+                    *pIdx2 = *pIdx2 + (*(int*)(self + 0x34c) * 2);
                 }
             }
             if (*(int*)(self + 0x33c) >= *(int*)(self + 0x338)) {
                 if (_ZNK7PathPtr5LoopsEv(&path) != 0) {
                     *(int*)(self + 0x33c) = 0;
                 } else {
-                    int& curIdxR3 = *(int*)(self + 0x33c);
                     *(u8*)(self + 0x331) = 0x3c;
                     *(u8*)(self + 0x330) = 0;
                     *(int*)(self + 0x34c) = -1;
-                    curIdxR3 += *(int*)(self + 0x34c) * 2;
+                    int* pIdx3 = (int*)((long long)(int)((unsigned)(int)self + 0x33c) & 0xFFFFFFFFFFFFFFFFLL);
+                    *pIdx3 = *pIdx3 + (*(int*)(self + 0x34c) * 2);
                 }
             }
         }

--- a/src/func_ov018_021116b4.c
+++ b/src/func_ov018_021116b4.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: base materialization / addressing (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct PathPtr { char b[8]; };
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
@@ -20,6 +17,7 @@ extern int data_ov018_02113bc0[];
 extern int data_ov018_02112f48[];
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
 extern int func_ov018_02111804[];
+
 int func_ov018_021116b4(char* c){
   *(int*)(c+0x334) = *(int*)(c+8) & 0xff;
   if(*(int*)(c+0x334) == 0xff) return 0;
@@ -32,16 +30,22 @@ int func_ov018_021116b4(char* c){
   func_020393d4((int*)(c+0x124), (int)_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
   func_020393c4((int*)(c+0x124), (int)func_ov018_02111804);
   *(char*)(c+0x331) = 0x3c;
+  PathPtr p;
   *(int*)(c+0x324) = *(int*)(c+0x5c);
   *(int*)(c+0x328) = *(int*)(c+0x60);
   *(int*)(c+0x32c) = *(int*)(c+0x64);
-  *(short*)(c+0x8e) = *(short*)(c+0x8e) - 0x4000;
-  PathPtr p;
+  {
+    short* ang = (short*)((long long)(int)(c + 0x8e) & 0xFFFFFFFFFFFFFFFFLL);
+    *ang = *ang - 0x4000;
+  }
   _ZN7PathPtrC1Ev(&p);
   _ZN7PathPtr6FromIDEj(&p, *(int*)(c+0x334));
   *(int*)(c+0x338) = _ZNK7PathPtr8NumNodesEv(&p);
   *(int*)(c+0x34c) = 1;
-  *(int*)(c+0x33c) = *(int*)(c+0x33c) + *(int*)(c+0x34c);
+  {
+    int* ip = (int*)((long long)(int)(c + 0x33c) & 0xFFFFFFFFFFFFFFFFLL);
+    *ip = *ip + *(int*)(c + 0x34c);
+  }
   *(int*)(c+0x320) = 0;
   return 1;
 }

--- a/src/func_ov018_02111804.c
+++ b/src/func_ov018_02111804.c
@@ -1,0 +1,6 @@
+extern int func_ov018_021117e8(int a, int b);
+
+int func_ov018_02111804(void* self, int a, int b)
+{
+    return func_ov018_021117e8(a, b);
+}

--- a/src/func_ov018_02111bf0.c
+++ b/src/func_ov018_02111bf0.c
@@ -1,14 +1,11 @@
 //cpp
-// NONMATCHING: different op / idiom (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 typedef struct { int x, y, z; } Vector3;
 typedef struct WithMeshClsn WithMeshClsn;
 struct SurfaceInfo {
-  int a, b, c, d, e;      // +0..+0x10 (5 ints)
-  unsigned short f, g;    // +0x14,+0x16
-  int h, i, j;            // +0x18,+0x1c,+0x20
+  int a, b, c, d, e;
+  unsigned short f, g;
+  int h, i, j;
 };
 struct ClsnResult {
   void* vt;
@@ -38,10 +35,27 @@ void func_ov018_02111bf0(char* c, WithMeshClsn* w){
   if (_ZNK12WithMeshClsn8IsOnWallEv(w) != 0) {
     struct ClsnResult* src = _ZNK12WithMeshClsn13GetWallResultEv(w);
     struct ClsnResult cr;
-    struct SurfaceInfo* dst = &cr.info;
-    *dst = src->info;
-    cr.vt = &data_02099368;
     Vector3 wn;
+    struct SurfaceInfo* dst = &cr.info;
+    // demand a first (should get r4), then b (r1), then dst (r2)
+    int a = *(int*)((char*)src + 4);
+    int b = *(int*)((char*)src + 8);
+    *(int*)((char*)dst + 0) = b ? a : a;
+    *(int*)((char*)dst + 4) = b;
+    int t = *(int*)((char*)src + 0xc);
+    void* vt = &data_02099368;
+    *(int*)((char*)dst + 8) = t;
+    t = *(int*)((char*)src + 0x10);
+    *(int*)((char*)dst + 0xc) = t;
+    t = *(int*)((char*)src + 0x14);
+    *(int*)((char*)dst + 0x10) = t;
+    cr.vt = vt;
+    // remaining via cr members for sp-relative
+    cr.info.f = *(unsigned short*)((char*)src + 0x18);
+    cr.info.g = *(unsigned short*)((char*)src + 0x1a);
+    cr.info.h = *(int*)((char*)src + 0x1c);
+    cr.info.i = *(int*)((char*)src + 0x20);
+    cr.info.j = *(int*)((char*)src + 0x24);
     _ZNK11SurfaceInfo12CopyNormalToER7Vector3(dst, &wn);
     _ZN10ClsnResultD1Ev(&cr);
   }


### PR DESCRIPTION
## Summary

Byte-identical matches for four ov018 functions (promotes three former NONMATCHING drafts + one new thunk).

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov018_02111368` | `0x02111368` | `0x34c` | Path platform update; u64-mask rematerializes `self+0x33c` at three sites |
| `func_ov018_021116b4` | `0x021116b4` | `0x134` | Path platform init; u64 launder for `+0x8e` ang and `+0x33c` idx |
| `func_ov018_02111804` | `0x02111804` | `0x14` | Arg-swap thunk → `func_ov018_021117e8` |
| `func_ov018_02111bf0` | `0x02111bf0` | `0x138` | Floor/wall mesh response; hybrid SurfaceInfo copy interleave |

**Compiler:** mwccarm `1.2/sp2p3`  
**Flags (C):** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`  
**Flags (C++):** same with `-lang c++` (`//cpp` first line)

Locally verified with:
```
python tools/match.py --c src/<name>.c --func <name> --addr 0x... --size 0x... --version 1.2/sp2p3 --module ov018
```
each reports `MATCHING VERSIONS: 1.2/sp2p3`.

### Not in this PR
`func_ov018_02111fac` @ `0x02111fac` (0x230) — closest draft is size-matched at **12 residual diffs** (register coloring on `Actor::Spawn` arg setup after `GetTalkState() == -1`; `-1` lands in `ip` instead of `r1`, and arg demand order differs). Best draft kept locally in scratch for refine.

## Test plan
- [ ] CI `validate` green on all four files
- [ ] Confirm no WRONG-DEST on relocs