### PR TITLE
Match 3 ChainChomp functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov014: _ZN10ChainChomp13InitResourcesEv (0x02112b14), 021115ec (0x021115ec), 02111b70 (0x02111b70) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #225 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN10ChainChomp13InitResourcesEv.cpp
+++ b/src/_ZN10ChainChomp13InitResourcesEv.cpp
@@ -1,47 +1,54 @@
 //cpp
-// NONMATCHING: register allocation (div=38). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" void *Model_LoadFile(void *fp);
-extern "C" void ModelBase_SetFile(void *self, void *bmd, int a, int b);
-extern "C" void *Animation_LoadFile(void *fp);
-extern "C" void ShadowModel_InitCylinder(void *self);
-extern "C" void MovingCylinderClsnWithPos_Init(void *self, void *actor, void *pos, int fix, int t, unsigned int a, unsigned int b);
+extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
+extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
+extern "C" void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
+extern "C" void _ZN11ShadowModel12InitCylinderEv(void *self);
+extern "C" void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *pos, int fix, int t, unsigned int a, unsigned int b);
 extern "C" void func_ov014_02111ebc(void *c, int i);
-extern "C" void *Actor_Spawn(unsigned int a, unsigned int b, void *pos, void *v16, int e, int f);
+extern "C" void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *v16, int e, int f);
 
-extern void *data_ov014_02114968;
-extern void *data_ov014_02114978;
-extern void *data_ov014_02114980;
-extern void *data_ov014_02114970;
+extern char data_ov014_02114968;
+extern char data_ov014_02114978;
+extern char data_ov014_02114980;
+extern char data_ov014_02114970;
 extern int data_ov014_02114700[];
 
 extern "C" int _ZN10ChainChomp13InitResourcesEv(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
     void *f;
-    int i;
+        int i;
     unsigned char *p;
-    void *sp;
-    int *q;
+    void *spawned;
+    int *px;
+    int *py;
+    int *pz;
+    int one;
 
-    f = Model_LoadFile(&data_ov014_02114968);
-    ModelBase_SetFile(c + 0x150, f, 1, 1);
-    Model_LoadFile(&data_ov014_02114978);
-    Animation_LoadFile(&data_ov014_02114980);
-    Animation_LoadFile(&data_ov014_02114970);
+
+    f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov014_02114968);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x150, f, 1, 1);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov014_02114978);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov014_02114980);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov014_02114970);
 
     p = c + 0x1dc;
-    for (i = 0; i < 7; i++) {
-        ModelBase_SetFile(p, (&data_ov014_02114978)[1], 1, 1);
-        p += 0x50;
-    }
+    i = 0;
+    do {
+        _ZN9ModelBase7SetFileEP8BMD_Fileii(p, *(void **)((char *)&data_ov014_02114978 + 4), 1, 1);
+        i = i + 1;
+        p = p + 0x50;
+    } while (i < 7);
 
-    ShadowModel_InitCylinder(c + 0x1b4);
-    p = c + 0x40c;
-    for (i = 0; i < 7; i++) {
-        ShadowModel_InitCylinder(p);
-        p += 0x28;
+    _ZN11ShadowModel12InitCylinderEv(c + 0x1b4);
+    {
+    int si; unsigned char *sp;
+    si = 0; sp = c + 0x40c;
+    do {
+        _ZN11ShadowModel12InitCylinderEv(sp);
+        si = si + 1;
+        sp = sp + 0x28;
+    } while (si < 7);
     }
 
     *(int *)(c + 0x9c) = -0x2000;
@@ -52,37 +59,46 @@ extern "C" int _ZN10ChainChomp13InitResourcesEv(void *thiz)
         v[0] = data_ov014_02114700[0];
         v[1] = data_ov014_02114700[1];
         v[2] = data_ov014_02114700[2];
-        MovingCylinderClsnWithPos_Init(c + 0x110, c, v, 0x96000, 0x12c000, 0x200004, 0x26ff0);
+        _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
+            c + 0x110, c, v, 0x96000, 0x12c000, 0x200004, 0x26ff0);
     }
 
     func_ov014_02111ebc(c, 1);
 
-    p = c;
-    for (i = 0; i < 7; i++) {
-        *(int *)(p + 0x524) = *(int *)(c + 0x5c);
-        *(int *)(p + 0x528) = *(int *)(c + 0x60);
-        *(int *)(p + 0x52c) = *(int *)(c + 0x64);
-        p += 0xc;
+        {
+        int cnt = 0;
+        unsigned char *dst = c;
+        do {
+            *(int *)(dst + 0x524) = *(int *)(c + 0x5c);
+            cnt = cnt + 1;
+            *(int *)(dst + 0x528) = *(int *)(c + 0x60);
+            *(int *)(dst + 0x52c) = *(int *)(c + 0x64);
+            dst = dst + 0xc;
+        } while (cnt < 7);
     }
+
 
     *(int *)(c + 0x5ec) = *(int *)(c + 0x5c);
     *(int *)(c + 0x5f0) = *(int *)(c + 0x60);
     *(int *)(c + 0x5f4) = *(int *)(c + 0x64);
 
-    sp = Actor_Spawn(0x1b, 0x11, c + 0x5c, 0, *(signed char *)(c + 0xcc), -1);
-    *(int *)(c + 0x608) = *(int *)((unsigned char *)sp + 4);
-    *(unsigned char *)((unsigned char *)sp + 0x320) = 1;
+    spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+        0x1b, 0x11, c + 0x5c, 0, *(signed char *)(c + 0xcc), -1);
+    *(int *)(c + 0x608) = *(int *)((unsigned char *)spawned + 4);
+    one = 1;
+    *(unsigned char *)((unsigned char *)spawned + 0x320) = (unsigned char)one;
     *(int *)(c + 0x60c) = 0;
 
-    q = (int *)(c + 0x5c);
-    *q += 0xc8000;
-    q = (int *)(c + 0x60);
-    *q += 0xc8000;
-    q = (int *)(c + 0x64);
-    *q += 0xc8000;
+    px = (int *)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    *px = *px + 0xc8000;
+    py = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    *py = *py + 0xc8000;
+    pz = (int *)(((long long)(int)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    *pz = *pz + 0xc8000;
+
     *(int *)(c + 0x5f8) = 0x50000;
     *(int *)(c + 0x80) = 0x1000;
     *(int *)(c + 0x84) = 0x1000;
     *(int *)(c + 0x88) = 0x1000;
-    return 1;
+    return one;
 }

--- a/src/func_ov014_021115ec.cpp
+++ b/src/func_ov014_021115ec.cpp
@@ -1,0 +1,160 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+struct Vector3 { s32 x, y, z; };
+extern "C" {
+    void _ZN5Sound15PlaySecretSoundEP5ActorPt(void *actor, u16 *snd);
+    void *_ZN5Actor10FindWithIDEj(unsigned id);
+    void ApproachAngle(void *self, s32 a, s32 b, s32 c, s32 d);
+    s16 _ZN5Actor18HorzAngleToCPlayerEv(void *self);
+    s16 Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+    s32 _Z14ApproachLinearRsss(void *dst, s32 target, s32 step);
+    u16 DecIfAbove0_Short(void *p);
+    s32 _Z14ApproachLinearRiii(void *dst, s32 target, s32 step);
+    void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, s32 a, s32 fix, unsigned b);
+    s32 Vec3_ApproachHorz(Vector3 *out, Vector3 *target, s32 maxStep);
+    void func_ov014_02112ea8(void *actor);
+    void _ZN6Camera9SetFlag_3Ev(void *cam);
+    void *_ZN5Actor13ClosestPlayerEv(void *self);
+    s32 _ZN6Player12Unk_020ca150Eh(void *player, u8 a);
+    void _ZN6Camera9SetLookAtERK7Vector3(void *cam, const Vector3 *v);
+    void _ZN9ActorBase18MarkForDestructionEv(void *self);
+    void _ZN9Animation7AdvanceEv(void *self);
+    extern s16 data_02082214[];
+    extern void *data_0209f318;
+    extern void *data_ov014_02114970[];
+    extern void *data_ov014_02114980[];
+}
+static inline void inc604(u8 *self) {
+    u8 *p = (u8 *)(((long long)(int)(self + 0x604)) & 0xFFFFFFFFFFFFFFFFLL);
+    *p = (u8)(*p + 1);
+}
+extern "C" void func_ov014_021115ec(u8 *self)
+{
+    Vector3 sp4;
+    u8 *r4; s16 r7; s16 r6; u8 *r8;
+    _ZN5Sound15PlaySecretSoundEP5ActorPt(self, (u16 *)(self + 0x5fe));
+    r4 = (u8 *)_ZN5Actor10FindWithIDEj(*(unsigned *)(self + 0x60c));
+    {
+        s32 *src = (s32 *)(((long long)(int)(r4 + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        s32 fifth = 0x80;
+        sp4.x = src[0];
+        void *ap = self + 0x8c;
+        sp4.y = src[1];
+        s32 z = 0;
+        sp4.z = src[2];
+        ApproachAngle(ap, z, 4, 0x200, fifth);
+    }
+    r8 = *(u8 **)&data_0209f318;
+    r7 = _ZN5Actor18HorzAngleToCPlayerEv(self);
+    r6 = Vec3_HorzAngle((Vector3 *)(self + 0x5c), (Vector3 *)(self + 0x5ec));
+    switch (*(u8 *)(self + 0x604)) {
+    case 0:
+        *(u8 **)(r8 + 0x118) = self;
+        if (_Z14ApproachLinearRsss(self + 0x8e, r7, 0x320) != 0 && DecIfAbove0_Short(self + 0x5fc) == 0)
+            inc604(self);
+        *(s16 *)(self + 0x94) = *(s16 *)(self + 0x8e);
+        break;
+    case 1: case 2: case 3: case 4:
+        *(u8 **)(r8 + 0x118) = self;
+        _Z14ApproachLinearRiii(self + 0x98, 0, 0x400);
+        if (*(u8 *)(self + 0x61c) != 0) {
+            *(s16 *)(self + 0x94) = (s16)(r6 + 0x2000);
+            *(s16 *)(self + 0x8e) = *(s16 *)(self + 0x94);
+            *(s32 *)(self + 0xa8) = 0x32000;
+            *(s32 *)(self + 0x98) = 0x1e000;
+            inc604(self);
+        }
+        break;
+    case 5:
+        *(u8 **)(r8 + 0x118) = self;
+        _Z14ApproachLinearRiii(self + 0x98, 0, 0x400);
+        if (*(u8 *)(self + 0x61c) != 0) {
+            *(s16 *)(self + 0x94) = r6;
+            *(s16 *)(self + 0x8e) = *(s16 *)(self + 0x94);
+            *(s32 *)(self + 0xa8) = 0x32000;
+            *(s32 *)(self + 0x98) = 0x1e000;
+            inc604(self);
+            if (*(u8 *)(r4 + 0x31e) != 0) *(u8 *)(self + 0x604) = 7;
+        }
+        break;
+    case 6: {
+        *(u8 **)(r8 + 0x118) = self;
+        _Z14ApproachLinearRiii(self + 0x618, 0x1000, 0x400);
+        if (*(u8 *)(self + 0x61c) != 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x150, data_ov014_02114970[1], 0, 0x1000, 0);
+            *(s16 *)(self + 0x8e) = Vec3_HorzAngle((Vector3 *)(self + 0x5c), &sp4);
+            *(s16 *)(self + 0x94) = *(s16 *)(self + 0x8e);
+            *(s32 *)(self + 0xa8) = 0x14000;
+            *(s32 *)(self + 0x618) = 0x64000;
+        }
+        {
+            Vector3 target;
+            s32 x = sp4.x;
+            target.x = x;
+            s32 z = sp4.z;
+            target.z = z;
+            s32 y = sp4.y;
+            target.y = y;
+            {
+                s16 *tbl = data_02082214;
+                u16 ang = *(u16 *)(r4 + 0x8e);
+                s32 s = tbl[(ang >> 4) << 1];
+                s32 add = (s32)(((((long long)s) * 0x96000) + 0x800) >> 12);
+                target.x = x + add;
+            }
+            {
+                s16 *tbl = data_02082214;
+                u16 ang = *(u16 *)(r4 + 0x8e);
+                s32 s = tbl[(((ang >> 4) << 1) + 1)];
+                s32 add = (s32)(((((long long)s) * 0x96000) + 0x800) >> 12);
+                target.z = z + add;
+            }
+            if (Vec3_ApproachHorz((Vector3 *)(self + 0x5c), &target, *(s32 *)(self + 0x618)) != 0) {
+                inc604(self);
+                *(s16 *)(self + 0x94) = (s16)(Vec3_HorzAngle((Vector3 *)(self + 0x5c), &sp4) + 0x8000);
+                *(s32 *)(self + 0x98) = 0x28000;
+                *(s32 *)(self + 0xa8) = 0xa000;
+                func_ov014_02112ea8(r4);
+            }
+        }
+        break;
+    }
+    case 7:
+        if (*(u8 *)(self + 0x61c) != 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x150, data_ov014_02114980[1], 0, 0x1000, 0);
+            *(s16 *)(self + 0x94) = Vec3_HorzAngle((Vector3 *)(self + 0x5c), &sp4);
+            *(u16 *)(self + 0x5fc) = 0x3c;
+            *(s16 *)(self + 0x8e) = *(s16 *)(self + 0x94);
+            if (*(u8 *)(r4 + 0x31e) != 0) {
+                *(s32 *)(self + 0x98) = 0x28000; *(s32 *)(self + 0xa8) = 0x5a000;
+            } else {
+                *(s32 *)(self + 0x98) = 0x1e000; *(s32 *)(self + 0xa8) = 0x50000;
+            }
+            _ZN6Camera9SetFlag_3Ev(r8);
+            inc604(self);
+        }
+        break;
+    case 8:
+        if (DecIfAbove0_Short(self + 0x5fc) == 0) {
+            {
+                unsigned *flag = (unsigned *)(((long long)(int)(r8 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL);
+                *flag &= ~8u;
+            }
+            if (_ZN6Player12Unk_020ca150Eh(_ZN5Actor13ClosestPlayerEv(self), 4) != 0) {
+                inc604(self);
+                *(u16 *)(self + 0x5fc) = 0x3c;
+            }
+        } else {
+            _ZN6Camera9SetLookAtERK7Vector3(r8, (Vector3 *)(self + 0x5c));
+        }
+        break;
+    case 9:
+        if (DecIfAbove0_Short(self + 0x5fc) == 0)
+            _ZN9ActorBase18MarkForDestructionEv(self);
+        break;
+    }
+    _ZN9Animation7AdvanceEv(self + 0x1a0);
+}

--- a/src/func_ov014_02111b70.c
+++ b/src/func_ov014_02111b70.c
@@ -1,46 +1,43 @@
-// NONMATCHING: register allocation (div=6). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-
 extern int func_0201267c(int, void *, int);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *, void *, int, int, unsigned);
 extern void *_ZN5Actor13ClosestPlayerEv(void *);
 extern short Vec3_VertAngle(const void *, const void *);
 extern int data_ov014_02114970[];
 extern short data_02082214[];
+
 void func_ov014_02111b70(char *c)
 {
-  int new_var;
-  int new_var2;
-  int new_var3;
-  *((int *) (c + 0x9c)) = 0;
-  func_0201267c(0x3a, ((char *) c) + 0x74, 0);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *) c) + 0x150, (void *) data_ov014_02114970[1], 0, 0x1000, 0);
-  char *p = (char *) _ZN5Actor13ClosestPlayerEv(c);
-  int tgt[3];
-  new_var3 = 0x5c;
-  new_var = *((int *) (p + 0x64));
-  new_var2 = *((int *) (p + new_var3));
-  tgt[1] = (*((int *) (p + 0x60))) + 0x50000;
-  tgt[0] = new_var2;
-  tgt[2] = new_var;
-  int a = (unsigned short) Vec3_VertAngle(tgt, (const void *) (c + 0x5c));
-  int i = (a >> 4) << 1;
-  *((int *) (c + 0xa8)) = -((int) (((((long long) data_02082214[i]) * 0x8c000) + 0x800) >> 12));
-  int v = *((int *) (c + 0xa8));
-  if (v < 0x5000)
-  {
-    v = 0x5000;
-  }
-  else
-    if (v > 0x2d000)
-  {
-    v = 0x2d000;
-  }
-  *((int *) (c + 0xa8)) = v;
-  if (((!c) && (!c)) && (!c))
-  {
-  }
-  *((int *) (c + 0x98)) = (int) (((((long long) data_02082214[i + 1]) * 0x8c000) + 0x800) >> 12);
-  *((short *) ((c + 0x500) + 0xfc)) = 0x3c;
+    int tgt[3];
+    char *p;
+    int a;
+    int i;
+    int v;
+
+    *((int *)(c + 0x9c)) = 0;
+    func_0201267c(0x3a, c + 0x74, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x150, (void *)data_ov014_02114970[1], 0, 0x1000, 0);
+    p = (char *)_ZN5Actor13ClosestPlayerEv(c);
+
+    /* ROM load order: y, z, x — then y+0x50000, store x, setup call, store y/z */
+    {
+        int y = *((int *)(p + 0x60));
+        int z = *((int *)(p + 0x64));
+        int x = *((int *)(p + 0x5c));
+        tgt[0] = x;
+        tgt[1] = y + 0x50000;
+        tgt[2] = z;
+    }
+
+    a = (unsigned short)Vec3_VertAngle(c + 0x5c, tgt);
+    i = (a >> 4) << 1;
+    *((int *)(c + 0xa8)) = -((int)(((((long long)data_02082214[i]) * 0x8c000) + 0x800) >> 12));
+    v = *((int *)(c + 0xa8));
+    if (v < 0x5000) {
+        v = 0x5000;
+    } else if (v > 0x2d000) {
+        v = 0x2d000;
+    }
+    *((int *)(c + 0xa8)) = v;
+    *((int *)(c + 0x98)) = (int)(((((long long)data_02082214[i + 1]) * 0x8c000) + 0x800) >> 12);
+    *((short *)(c + 0x5fc)) = 0x3c;
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for three ov014 ChainChomp-related functions against EU retail:

| Function | Address | Size |
|---|---|---|
| `func_ov014_021115ec` | `0x021115ec` | `0x480` |
| `func_ov014_02111b70` | `0x02111b70` | `0x138` |
| `ChainChomp::InitResources` | `0x02112b14` | `0x208` |

**Compiler:** mwccarm `1.2/sp2p3`  
**Flags (C):** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`  
**Flags (C++):** same with `-lang c++` (`//cpp` sources)

Verified locally with `tools/match.py --module ov014` (relocation-aware).

`func_ov014_02111b70` and `InitResources` replace prior NONMATCHING drafts in `src/`.

## Test plan

- [x] `tools/match.py` reports MATCH for each function on 1.2/sp2p3
- [ ] CI `validate` green