### PR TITLE
Match 4 ov025 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov025: _ZN11PyramidLift13InitResourcesEv (0x02112498), _ZN11PyramidLift8BehaviorEv (0x02112288), 021119f4 (0x021119f4), 02111a84 (0x02111a84), 02112288, 02112498 | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #226 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN11PyramidLift13InitResourcesEv.c
+++ b/src/_ZN11PyramidLift13InitResourcesEv.c
@@ -1,6 +1,4 @@
-// NONMATCHING: different op / idiom (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_strength_reduction off
 typedef int Fix12;
 typedef struct { int w[2]; } SharedFilePtr;
 typedef struct BMD_File BMD_File;
@@ -18,36 +16,45 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, i
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 extern KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12 f, short s, CLPS_Block* b);
-extern void func_020393d4(int* p, int v);
-extern void func_020393c4(int* p, int v);
-
-struct E12 { int a, b, c; };
+extern void func_020393d4(void* p, void* v);
+extern void func_020393c4(void* p, void* v);
 
 int _ZN11PyramidLift13InitResourcesEv(char* c) {
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov025_02113ae0), 1, -1);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x320, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0), 1, -1);
+    BMD_File* bmd;
+    KCL_File* kcl;
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov025_02113ae0);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, bmd, 1, -1);
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x320, bmd, 1, -1);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov025_02113ad8);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c+0x124, _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov025_02113ad8),
-        (Matrix4x3*)(c+0x2ec), 0x199, *(short*)(c+0x8e), &data_ov025_02112d08);
-    func_020393d4((int*)(c+0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    func_020393c4((int*)(c+0x124), (int)&func_ov025_021125dc);
-    *(int*)(c+0x370) = *(int*)(c+0x5c);
-    *(int*)(c+0x374) = *(int*)(c+0x60);
-    *(int*)(c+0x378) = *(int*)(c+0x64);
-    *(unsigned char*)(c+0x3f6) = 0;
-    *(unsigned char*)(c+0x3f7) = 0;
+        c+0x124, kcl, (Matrix4x3*)(c+0x2ec), 0x199, *(short*)(c+0x8e), &data_ov025_02112d08);
+    func_020393d4(c+0x124, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    func_020393c4(c+0x124, &func_ov025_021125dc);
     {
-        char* ip = c;
-        int n = 0;
-        int k = 0x1cc000;
+        int n;
+        char *ip;
+        int k;
+        *(int*)(c+0x370) = *(int*)(c+0x5c);
+        n = 0;
+        *(int*)(c+0x374) = *(int*)(c+0x60);
+        ip = c;
+        *(int*)(c+0x378) = *(int*)(c+0x64);
+        *(unsigned char*)(c+0x3f6) = (unsigned char)n;
+        *(unsigned char*)(c+0x3f7) = (unsigned char)n;
+        k = 0x1cc000;
         do {
-            n++;
+            int *py;
+            int prod;
+            n = n + 1;
             *(int*)(ip+0x37c) = *(int*)(c+0x5c);
             *(int*)(ip+0x380) = *(int*)(c+0x60);
+            prod = n * k;
             *(int*)(ip+0x384) = *(int*)(c+0x64);
-            *(int*)(ip+0x380) -= n*k;
-            ip += 0xc;
+            py = (int*)(((int)ip + 0x380) & 0xFFFFFFFFFFFFFFFFLL);
+            *py = *py - prod;
+            ip = ip + 0xc;
         } while (n < 10);
     }
     return 1;

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -1,15 +1,11 @@
 //cpp
-// NONMATCHING: register allocation (div=52). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern short data_02082214[];
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-}
 
-extern "C" int _ZN11PyramidLift8BehaviorEv(char* c)
+int _ZN11PyramidLift8BehaviorEv(char* c)
 {
     switch (*(unsigned char*)(c + 0x3f6)) {
     case 0:
@@ -19,17 +15,20 @@ extern "C" int _ZN11PyramidLift8BehaviorEv(char* c)
         }
         break;
     case 1: {
-        unsigned short* pa = (unsigned short*)(c + 0x3f4);
-        int idx = (int)(*pa << 0x1c) >> 0x10;
-        idx = (int)((unsigned)(idx << 0x10) >> 0x10) >> 4;
-        int s = data_02082214[idx << 1];
+        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
+        int idx = t >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
         *(int*)(c + 0x60) = *(int*)(c + 0x374) + d;
-        if (*pa == 8) {
+        if (*(unsigned short*)(c + 0x3f4) == 8) {
             *(unsigned char*)(c + 0x3f6) = 2;
             *(int*)(c + 0xa8) = -0xa000;
         }
-        *pa = *pa + 1;
+        {
+            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            *pa = *pa + 1;
+        }
         break;
     }
     case 2: {
@@ -38,9 +37,13 @@ extern "C" int _ZN11PyramidLift8BehaviorEv(char* c)
         int* p = (int*)(c + idx * 0xc + 0x380);
         int lim = *p + 0x14000;
         if (v <= lim) {
-            *(unsigned char*)(c + 0x3f8) = *(unsigned char*)(c + 0x3f8) + 1;
+            unsigned char *pb = (unsigned char*)(((int)c + 0x3f8) & 0xFFFFFFFFFFFFFFFFLL);
+            *pb = *pb + 1;
         }
-        *(int*)(c + 0x60) = *(int*)(c + 0x60) + *(int*)(c + 0xa8);
+        {
+            int *py = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            *py = *py + *(int*)(c + 0xa8);
+        }
         if (*(int*)(c + 0x60) < 0x80000) {
             *(int*)(c + 0x60) = 0x80000;
             *(unsigned char*)(c + 0x3f6) = 3;
@@ -49,22 +52,28 @@ extern "C" int _ZN11PyramidLift8BehaviorEv(char* c)
         break;
     }
     case 3: {
-        int idx = (int)(*(unsigned short*)(c + 0x3f4) << 0x1c) >> 0x10;
-        idx = (int)((unsigned)(idx << 0x10) >> 0x10) >> 4;
-        int s = data_02082214[idx << 1];
+        int z = 0;
+        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
+        int idx = t >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
         *(int*)(c + 0x60) = d + 0x80000;
-        if (*(unsigned short*)(c + 0x3f4) >= 8) {
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x60) = 0x80000;
+        {
+            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            if (*(unsigned short*)(c + 0x3f4) >= 8) {
+                *(int*)(c + 0xa8) = z;
+                *(int*)(c + 0x60) = 0x80000;
+            }
+            *pa = *pa + 1;
         }
-        *(unsigned short*)(c + 0x3f4) = *(unsigned short*)(c + 0x3f4) + 1;
-        _ZN8Platform21UpdateModelPosAndRotYEv(c);
-        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-            _ZN8Platform19UpdateClsnPosAndRotEv(c);
-        *(unsigned char*)(c + 0x3f7) = 0;
         break;
     }
     }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    *(unsigned char*)(c + 0x3f7) = 0;
     return 1;
+}
 }

--- a/src/func_ov025_021119f4.c
+++ b/src/func_ov025_021119f4.c
@@ -1,33 +1,19 @@
-// NONMATCHING: different op / idiom (div=6). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 
+typedef unsigned char u8;
+typedef short s16;
+typedef int s32;
 extern int func_0201267c(int a, void *b);
 void func_ov025_021119f4(char *c)
 {
-  char *new_var3;
-  int new_var2;
-  unsigned char *new_var;
-  unsigned char *p = (unsigned char *) (c - -0x39e);
-  int new_var4;
-  *new_var = (new_var2 = (*p) - 1);
-  new_var = p;
-  if (*((unsigned char *) (c + (0x39e & 0xFFFFFFFFu))))
-  {
-    return;
-  }
-  new_var4 = 0x39c;
-  if (((*((unsigned char *) (c + 0x39f))) != 4) & 0xFFFFFFFF)
-  {
-    *((int *) (c + 0x398)) = 5;
-    *((int *) (c + 0xa8)) = 0x3c000;
-    if (c)
-    {
+    *(u8*)(((int)c + 0x39e) & 0xFFFFFFFFFFFFFFFFLL) =
+        *(u8*)(((int)c + 0x39e) & 0xFFFFFFFFFFFFFFFFLL) - 1;
+    if (*(u8 *)(c + 0x39e) != 0) return;
+    if (*(u8 *)(c + 0x39f) != 4) {
+        *(s32 *)(c + 0x398) = 5;
+        *(s32 *)(c + 0xa8) = 0x3c000;
+        func_0201267c(0xf4, c + 0x74);
+        return;
     }
-    func_0201267c(0xf4, c + 0x74);
-    return;
-  }
-  *((int *) (c + 0x398)) = 7;
-  new_var3 = c + new_var4;
-  *((short *) new_var3) = (*((short *) (c + 0x8e))) + 0x8000;
+    *(s32 *)(c + 0x398) = 7;
+    *(s16 *)(c + 0x39c) = (s16)(*(s16 *)(c + 0x8e) + 0x8000);
 }

--- a/src/func_ov025_02111a84.c
+++ b/src/func_ov025_02111a84.c
@@ -1,37 +1,35 @@
 //cpp
-// NONMATCHING: different op / idiom (div=13). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" {
 struct Vector3 { int x, y, z; };
+extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* cc);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* thiz, const Vector3& v, int f);
-extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, Vector3 v);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int x, int y, int z);
 extern void func_0201267c(int a, void* v);
 
 void func_ov025_02111a84(char* c)
 {
+    Vector3 v[2];
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
     if (*(int*)(c + 0xa8) >= 0)
         *(int*)(c + 0x9c) = -0x4000;
     else
         *(int*)(c + 0x9c) = -0x8000;
-    if (*(int*)(c + 0x60) > *(int*)(c + 0x394)) return;
+    if (*(int*)(c + 0x60) > *(int*)(c + 0x394))
+        return;
     *(int*)(c + 0x60) = *(int*)(c + 0x394);
-    Vector3 ps;
-    Vector3 eq;
-    eq.x = *(int*)(c + 0x5c);
-    eq.y = *(int*)(c + 0x60);
-    eq.z = *(int*)(c + 0x64);
-    _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, eq, 0x7d0000);
+    v[1].x = *(int*)(c + 0x5c);
+    v[1].y = *(int*)(c + 0x60);
+    v[1].z = *(int*)(c + 0x64);
+    _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, v[1], 0x7d0000);
     *(unsigned char*)(c + 0x39e) = 0x3c;
-    *(unsigned char*)(c + 0x39f) += 1;
+    *(unsigned char*)(((int)c + 0x39f) & 0xFFFFFFFFFFFFFFFFLL) =
+        *(unsigned char*)(((int)c + 0x39f) & 0xFFFFFFFFFFFFFFFFLL) + 1;
     *(int*)(c + 0x398) = 6;
-    ps.x = *(int*)(c + 0x5c);
-    ps.y = *(int*)(c + 0x60);
-    ps.z = *(int*)(c + 0x64);
-    ps.y = *(int*)(c + 0x60) + 0x3c000;
-    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x2e, ps);
+    v[0].x = *(int*)(c + 0x5c);
+    v[0].y = *(int*)(c + 0x60);
+    v[0].z = *(int*)(c + 0x64);
+    v[0].y = v[0].y + 0x3c000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x2e, v[0].x, v[0].y, v[0].z);
     func_0201267c(0xc7, c + 0x74);
 }
 }

--- a/src/func_ov025_02112288.cpp
+++ b/src/func_ov025_02112288.cpp
@@ -1,15 +1,11 @@
 //cpp
-// NONMATCHING: register allocation (div=52). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern short data_02082214[];
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-}
 
-extern "C" int func_ov025_02112288(char* c)
+int _ZN11PyramidLift8BehaviorEv(char* c)
 {
     switch (*(unsigned char*)(c + 0x3f6)) {
     case 0:
@@ -19,17 +15,20 @@ extern "C" int func_ov025_02112288(char* c)
         }
         break;
     case 1: {
-        unsigned short* pa = (unsigned short*)(c + 0x3f4);
-        int idx = (int)(*pa << 0x1c) >> 0x10;
-        idx = (int)((unsigned)(idx << 0x10) >> 0x10) >> 4;
-        int s = data_02082214[idx << 1];
+        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
+        int idx = t >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
         *(int*)(c + 0x60) = *(int*)(c + 0x374) + d;
-        if (*pa == 8) {
+        if (*(unsigned short*)(c + 0x3f4) == 8) {
             *(unsigned char*)(c + 0x3f6) = 2;
             *(int*)(c + 0xa8) = -0xa000;
         }
-        *pa = *pa + 1;
+        {
+            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            *pa = *pa + 1;
+        }
         break;
     }
     case 2: {
@@ -38,9 +37,13 @@ extern "C" int func_ov025_02112288(char* c)
         int* p = (int*)(c + idx * 0xc + 0x380);
         int lim = *p + 0x14000;
         if (v <= lim) {
-            *(unsigned char*)(c + 0x3f8) = *(unsigned char*)(c + 0x3f8) + 1;
+            unsigned char *pb = (unsigned char*)(((int)c + 0x3f8) & 0xFFFFFFFFFFFFFFFFLL);
+            *pb = *pb + 1;
         }
-        *(int*)(c + 0x60) = *(int*)(c + 0x60) + *(int*)(c + 0xa8);
+        {
+            int *py = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            *py = *py + *(int*)(c + 0xa8);
+        }
         if (*(int*)(c + 0x60) < 0x80000) {
             *(int*)(c + 0x60) = 0x80000;
             *(unsigned char*)(c + 0x3f6) = 3;
@@ -49,22 +52,28 @@ extern "C" int func_ov025_02112288(char* c)
         break;
     }
     case 3: {
-        int idx = (int)(*(unsigned short*)(c + 0x3f4) << 0x1c) >> 0x10;
-        idx = (int)((unsigned)(idx << 0x10) >> 0x10) >> 4;
-        int s = data_02082214[idx << 1];
+        int z = 0;
+        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
+        int idx = t >> 4;
+        int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
         *(int*)(c + 0x60) = d + 0x80000;
-        if (*(unsigned short*)(c + 0x3f4) >= 8) {
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x60) = 0x80000;
+        {
+            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            if (*(unsigned short*)(c + 0x3f4) >= 8) {
+                *(int*)(c + 0xa8) = z;
+                *(int*)(c + 0x60) = 0x80000;
+            }
+            *pa = *pa + 1;
         }
-        *(unsigned short*)(c + 0x3f4) = *(unsigned short*)(c + 0x3f4) + 1;
-        _ZN8Platform21UpdateModelPosAndRotYEv(c);
-        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-            _ZN8Platform19UpdateClsnPosAndRotEv(c);
-        *(unsigned char*)(c + 0x3f7) = 0;
         break;
     }
     }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    *(unsigned char*)(c + 0x3f7) = 0;
     return 1;
+}
 }

--- a/src/func_ov025_02112498.c
+++ b/src/func_ov025_02112498.c
@@ -1,6 +1,4 @@
-// NONMATCHING: different op / idiom (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_strength_reduction off
 typedef int Fix12;
 typedef struct { int w[2]; } SharedFilePtr;
 typedef struct BMD_File BMD_File;
@@ -18,36 +16,45 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a, i
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 extern KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, KCL_File* k, Matrix4x3* m, Fix12 f, short s, CLPS_Block* b);
-extern void func_020393d4(int* p, int v);
-extern void func_020393c4(int* p, int v);
-
-struct E12 { int a, b, c; };
+extern void func_020393d4(void* p, void* v);
+extern void func_020393c4(void* p, void* v);
 
 int _ZN11PyramidLift13InitResourcesEv(char* c) {
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov025_02113ae0), 1, -1);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x320, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0), 1, -1);
+    BMD_File* bmd;
+    KCL_File* kcl;
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov025_02113ae0);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, bmd, 1, -1);
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x320, bmd, 1, -1);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov025_02113ad8);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c+0x124, _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov025_02113ad8),
-        (Matrix4x3*)(c+0x2ec), 0x199, *(short*)(c+0x8e), &data_ov025_02112d08);
-    func_020393d4((int*)(c+0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    func_020393c4((int*)(c+0x124), (int)&func_ov025_021125dc);
-    *(int*)(c+0x370) = *(int*)(c+0x5c);
-    *(int*)(c+0x374) = *(int*)(c+0x60);
-    *(int*)(c+0x378) = *(int*)(c+0x64);
-    *(unsigned char*)(c+0x3f6) = 0;
-    *(unsigned char*)(c+0x3f7) = 0;
+        c+0x124, kcl, (Matrix4x3*)(c+0x2ec), 0x199, *(short*)(c+0x8e), &data_ov025_02112d08);
+    func_020393d4(c+0x124, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    func_020393c4(c+0x124, &func_ov025_021125dc);
     {
-        char* ip = c;
-        int n = 0;
-        int k = 0x1cc000;
+        int n;
+        char *ip;
+        int k;
+        *(int*)(c+0x370) = *(int*)(c+0x5c);
+        n = 0;
+        *(int*)(c+0x374) = *(int*)(c+0x60);
+        ip = c;
+        *(int*)(c+0x378) = *(int*)(c+0x64);
+        *(unsigned char*)(c+0x3f6) = (unsigned char)n;
+        *(unsigned char*)(c+0x3f7) = (unsigned char)n;
+        k = 0x1cc000;
         do {
-            n++;
+            int *py;
+            int prod;
+            n = n + 1;
             *(int*)(ip+0x37c) = *(int*)(c+0x5c);
             *(int*)(ip+0x380) = *(int*)(c+0x60);
+            prod = n * k;
             *(int*)(ip+0x384) = *(int*)(c+0x64);
-            *(int*)(ip+0x380) -= n*k;
-            ip += 0xc;
+            py = (int*)(((int)ip + 0x380) & 0xFFFFFFFFFFFFFFFFLL);
+            *py = *py - prod;
+            ip = ip + 0xc;
         } while (n < 10);
     }
     return 1;


### PR DESCRIPTION
## Summary

Byte-identical matches for four ov025 functions, verified with `tools/match.py` against the EU retail overlay:

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov025_021119f4` | `0x021119f4` | `0x90` | u64-mask launder for large-offset byte RMW |
| `func_ov025_02111a84` | `0x02111a84` | `0xe0` | `Vector3 v[2]` stack frame + launder on `0x39f++` |
| `_ZN11PyramidLift8BehaviorEv` | `0x02112288` | `0x210` | shared switch tail, launders, angle cast for reg color |
| `_ZN11PyramidLift13InitResourcesEv` | `0x02112498` | `0x124` | `#pragma opt_strength_reduction off`, loop `mul` |

Also updates name aliases `func_ov025_02112288` / `func_ov025_02112498`.

**Compiler:** mwccarm `1.2/sp2p3`  
**Flags:** `-O4,p -enum int -lang c99` (C) / `-lang c++` (`//cpp`) `-char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Still open

- `func_ov025_021113f0` @ `0x021113f0` (1004 bytes, 131-div seed) — not finished this pass.

## Test plan

- [x] match.py for all four functions with `--module ov025` / C++ flags where needed
- [ ] CI `validate` green