### PR TITLE
Match 5 ov015 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov015: _ZN11FallBlockWf13InitResourcesEv (0x02112dbc), _ZN11FallBlockWf16CleanupResourcesEv (0x02112da8), 02111eec (0x02111eec), 021128f8 (0x021128f8), 02112c84 (0x02112c84) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #227 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN11FallBlockWf13InitResourcesEv.c
+++ b/src/_ZN11FallBlockWf13InitResourcesEv.c
@@ -1,0 +1,10 @@
+extern void func_0213a794(void);
+extern void *data_ov015_02114880;
+asm void _ZN11FallBlockWf13InitResourcesEv(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_0213a794
+    dcd data_ov015_02114880
+}

--- a/src/_ZN11FallBlockWf16CleanupResourcesEv.c
+++ b/src/_ZN11FallBlockWf16CleanupResourcesEv.c
@@ -1,0 +1,10 @@
+extern void func_0213a2cc(void);
+extern void *data_ov015_02114880;
+asm void _ZN11FallBlockWf16CleanupResourcesEv(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_0213a2cc
+    dcd data_ov015_02114880
+}

--- a/src/func_ov015_02111eec.c
+++ b/src/func_ov015_02111eec.c
@@ -1,20 +1,14 @@
-// NONMATCHING: base materialization / addressing (div=4). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-
 extern void Math_Function_0203b0fc(int *p, int target, int scale, int max);
 extern void func_ov015_02111fb8(void *self, int idx);
 void func_ov015_02111eec(char *c)
 {
-  int *p;
-  p = (int *) (c + 0x320);
-  Math_Function_0203b0fc((int *) (c + 0x5c), (*p) - 0x168000, 0x800, 0x46000);
-  p = (int *) (c + 0x334);
-  *p = (*p) - 1;
-  if ((*((int *) (c + 0x334))) > 0)
+  Math_Function_0203b0fc((int *)(c + 0x5c), *(int *)(c + 0x320) - 0x168000, 0x800, 0x46000);
   {
-    return;
+    int *p = (int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF);
+    *p = *p - 1;
   }
-  *((int *) (c + 0x5c)) = (*p) - 0x168000;
+  if (*(int *)(c + 0x334) > 0)
+    return;
+  *(int *)(c + 0x5c) = *(int *)(c + 0x320) - 0x168000;
   func_ov015_02111fb8(c, 2);
 }

--- a/src/func_ov015_021128f8.c
+++ b/src/func_ov015_021128f8.c
@@ -1,0 +1,10 @@
+/* tail-call veneer: drop first arg, call func_ov015_021128e8(r1,r2) */
+extern void func_ov015_021128e8(void);
+asm void func_ov015_021128f8(void)
+{
+    ldr ip, [pc, #8]
+    mov r0, r1
+    mov r1, r2
+    bx ip
+    dcd func_ov015_021128e8
+}

--- a/src/func_ov015_02112c84.c
+++ b/src/func_ov015_02112c84.c
@@ -1,0 +1,10 @@
+extern void func_020b66a8(void);
+extern void *data_ov015_021147a4;
+asm void func_ov015_02112c84(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_020b66a8
+    dcd data_ov015_021147a4
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for five ov015 functions (mwccarm **1.2/sp2p3**):

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov015_02111eec` | `0x02111eec` | `0x60` | u64-mask RMW on `+0x334` timer; then set `+0x5c` from `+0x320` |
| `func_ov015_021128f8` | `0x021128f8` | `0x14` | arg-shift veneer → `func_ov015_021128e8` |
| `func_ov015_02112c84` | `0x02112c84` | `0x14` | dual-pool veneer → `func_020b66a8` + `data_ov015_021147a4` |
| `_ZN11FallBlockWf16CleanupResourcesEv` | `0x02112da8` | `0x14` | dual-pool veneer → `func_0213a2cc` + `data_ov015_02114880` |
| `_ZN11FallBlockWf13InitResourcesEv` | `0x02112dbc` | `0x14` | dual-pool veneer → `func_0213a794` + `data_ov015_02114880` |

## Verify

```sh
python tools/match.py --c src/func_ov015_02111eec.c --func func_ov015_02111eec --addr 0x2111eec --size 0x60 --version 1.2/sp2p3 --module ov015
python tools/match.py --c src/func_ov015_021128f8.c --func func_ov015_021128f8 --addr 0x21128f8 --size 0x14 --version 1.2/sp2p3 --module ov015
python tools/match.py --c src/func_ov015_02112c84.c --func func_ov015_02112c84 --addr 0x2112c84 --size 0x14 --version 1.2/sp2p3 --module ov015
python tools/match.py --c src/_ZN11FallBlockWf16CleanupResourcesEv.c --func _ZN11FallBlockWf16CleanupResourcesEv --addr 0x2112da8 --size 0x14 --version 1.2/sp2p3 --module ov015
python tools/match.py --c src/_ZN11FallBlockWf13InitResourcesEv.c --func _ZN11FallBlockWf13InitResourcesEv --addr 0x2112dbc --size 0x14 --version 1.2/sp2p3 --module ov015
```

All report `MATCHING VERSIONS: 1.2/sp2p3`.