### PR TITLE
Match 4 ov019 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov019: 0211131c (0x0211131c), 021117a8 (0x021117a8), 02111dec (0x02111dec), 02111fec (0x02111fec) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #228 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov019_0211131c.c
+++ b/src/func_ov019_0211131c.c
@@ -1,22 +1,25 @@
-// NONMATCHING: base materialization / addressing (div=3). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
-extern void UpdateAngle(short* a, short b, int n, short s);
-extern int PathPtr_NumNodes(void* p);
-extern void PathPtr_GetNode(void* p, struct Vec3* v, unsigned int i);
+extern void _Z11UpdateAngleRssis(short* a, short b, int n, short s);
+extern int _ZNK7PathPtr8NumNodesEv(void* p);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* p, struct Vec3* v, unsigned int i);
 extern short Vec3_HorzAngle(struct Vec3* a, struct Vec3* b);
+
 int func_ov019_0211131c(char* c) {
-    UpdateAngle((short*)(c+0x94), *(short*)(c+0x38c), 2, 0x600);
-    int n = *(int*)(c+0x36c);
-    if (n >= PathPtr_NumNodes(c+0x364) - 2) {
-        *(short*)(c+0x8e) = *(short*)(c+0x94);
+    _Z11UpdateAngleRssis(
+        (short*)(c + 0x94),
+        *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+        2, 0x600);
+    int n = *(int*)(c + 0x36c);
+    if (n >= _ZNK7PathPtr8NumNodesEv(c + 0x364) - 2) {
+        *(short*)(c + 0x8e) = *(short*)(c + 0x94);
     } else {
         struct Vec3 v;
-        PathPtr_GetNode(c+0x364, &v, n+1);
-        *(short*)(c+0x8e) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), &v);
+        _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x364, &v, n + 1);
+        *(short*)(c + 0x8e) = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &v);
     }
-    int* pv = (int*)(c+0x380);
-    *pv = *pv - *(int*)(c+0x98);
-    return *(int*)(c+0x380) < 0 ? 1 : 0;
+    {
+        int *pv = (int *)(((int)c + 0x380) & 0xFFFFFFFFFFFFFFFF);
+        *pv = *pv - *(int*)(c + 0x98);
+    }
+    return *(int*)(c + 0x380) < 0 ? 1 : 0;
 }

--- a/src/func_ov019_021117a8.c
+++ b/src/func_ov019_021117a8.c
@@ -1,15 +1,16 @@
-// NONMATCHING: different op / idiom (div=49). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int _ZNK7PathPtr8NumNodesEv(void* p);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* p, void* out, unsigned int i);
 extern int Vec3_Dist(void* a, void* b);
-extern int Vec3_HorzAngle(void* a, void* b);
-extern void _Z14ApproachLinearRsss(short* p, short t, short s);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern int _Z14ApproachLinearRsss(short* p, short t, short s);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern int func_ov019_0211140c(int* self, void* clsn);
 extern void func_0201267c(int a, void* p);
 extern int func_ov019_021122dc(void* c, int s);
+
+#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+
+#pragma opt_common_subs off
 int func_ov019_021117a8(char* c) {
     int node[3];
     switch (*(unsigned char*)(c+0x38f)) {
@@ -17,17 +18,21 @@ int func_ov019_021117a8(char* c) {
         int n = _ZNK7PathPtr8NumNodesEv(c+0x364);
         _ZNK7PathPtr7GetNodeER7Vector3j(c+0x364, node, n - 1);
         *(int*)(c+0x380) = Vec3_Dist(c+0x5c, node);
-        *(short*)(c+0x38c) = (short)Vec3_HorzAngle(c+0x5c, node);
-        _Z14ApproachLinearRsss((short*)(c+0x38e), *(short*)(c+0x38c), 0x200);
-        *(short*)(c+0x94) = *(short*)(c+0x38e);
+        *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c) =
+            Vec3_HorzAngle(c+0x5c, node);
+        _Z14ApproachLinearRsss(
+            (short*)(c+0x8e),
+            *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+            0x200);
+        *(short*)(c+0x94) = *(short*)(c+0x8e);
         if (*(int*)(c+0x380) < *(int*)(c+0x98)) {
             *(int*)(c+0x98) = *(int*)(c+0x380);
-            (*(unsigned char*)(c+0x38f))++;
+            LB(0x38f) = LB(0x38f) + 1;
         }
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x174);
         func_ov019_0211140c((int*)c, c+0x1a8);
         {
-            int s = (unsigned short)(*(int*)(c+0x12c) << 4) >> 0x10;
+            unsigned int s = ((unsigned int)*(int*)(c+0x12c) << 4) >> 0x10;
             if (s == 9 || s == 0x15) {
                 func_0201267c(0xde, c+0x74);
             }
@@ -35,17 +40,18 @@ int func_ov019_021117a8(char* c) {
         break;
     }
     case 1: {
-        if (Vec3_HorzAngle(c+0x5c, *(char**)(c+0x378)+0x5c) ) {}
-        _Z14ApproachLinearRsss((short*)(c+0x38e), (short)Vec3_HorzAngle(c+0x5c, *(char**)(c+0x378)+0x5c), 0x514);
-        if (func_ov019_021122dc(c, 5)) {}
-        {
-            int s = (unsigned short)(*(int*)(c+0x12c) << 4) >> 0x10;
-            if (s == 9 || s == 0x15) {
-                func_0201267c(0xf3, c+0x74);
-            }
+        short ang = Vec3_HorzAngle(c+0x5c, *(char**)(c+0x378) + 0x5c);
+        if (_Z14ApproachLinearRsss((short*)(c+0x8e), ang, 0x514) != 0) {
+            func_ov019_021122dc(c, 5);
         }
         break;
     }
+    }
+    {
+        unsigned int s = ((unsigned int)*(int*)(c+0x12c) << 4) >> 0x10;
+        if (s == 9 || s == 0x15) {
+            func_0201267c(0xf3, c+0x74);
+        }
     }
     return 1;
 }

--- a/src/func_ov019_02111dec.c
+++ b/src/func_ov019_02111dec.c
@@ -1,6 +1,3 @@
-// NONMATCHING: missing logic (ROM does more) (div=44). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int _ZN6Player12Unk_020c4f40Et(void* p, unsigned short a);
 extern void _Z11UpdateAngleRssis(short* p, short a, int b, short c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
@@ -14,31 +11,37 @@ extern void func_0201267c(int a, void* p);
 extern int func_ov019_021122dc(void* c, int s);
 extern int data_ov019_02113460[];
 extern int data_ov019_02113470[];
+
+#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+
 int func_ov019_02111dec(char* c) {
     switch (*(unsigned char*)(c+0x38f)) {
     case 0:
         if (_ZN6Player12Unk_020c4f40Et(*(void**)(c+0x378), 0x5a) != 0) {
-            (*(unsigned char*)(c+0x38f))++;
+            LB(0x38f) = LB(0x38f) + 1;
         }
         break;
     case 1:
-        _Z11UpdateAngleRssis((short*)(c+0x94), *(short*)(c+0x38c), 2, 0x800);
+        _Z11UpdateAngleRssis(
+            (short*)(c+0x94),
+            *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+            2, 0x800);
         *(short*)(c+0x8e) = *(short*)(c+0x94);
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x174);
         func_ov019_0211140c((int*)c, c+0x1a8);
         if (_ZNK12WithMeshClsn13JustHitGroundEv(c+0x1a8) != 0) {
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov019_02113460[1], 0x40000000, 0x1000, 0);
-            (*(unsigned char*)(c+0x38f))++;
+            LB(0x38f) = LB(0x38f) + 1;
         }
         break;
     case 2:
         if (_ZN9Animation8FinishedEv(c+0x124) != 0) {
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov019_02113470[1], 0, 0x1000, 0);
-            if (_ZN6Player12GetTalkStateEv(*(void**)(c+0x378)) == -1) {
-                _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x1f, 0x7f, 0, 0x15666, 0);
-                func_0201267c(0x4d, c+0x74);
-                func_ov019_021122dc(c, 3);
-            }
+        }
+        if (_ZN6Player12GetTalkStateEv(*(void**)(c+0x378)) == -1) {
+            _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x1f, 0x7f, 0, 0x15666, 0);
+            func_0201267c(0x4d, c+0x74);
+            func_ov019_021122dc(c, 3);
         }
         break;
     }

--- a/src/func_ov019_02111fec.c
+++ b/src/func_ov019_02111fec.c
@@ -1,6 +1,3 @@
-// NONMATCHING: extra logic (you do more) (div=34). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 short Vec3_HorzAngle(const struct Vec3 *v0, const struct Vec3 *v1);
 int _Z14ApproachLinearRsss(short* dst, short target, short step);
@@ -13,9 +10,10 @@ int _ZN6Player18HasFinishedTalkingEv(void* p);
 
 extern unsigned char data_0209d684;
 
+#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+
 int func_ov019_02111fec(char* c) {
-    unsigned char st = *(unsigned char*)(c + 0x38f);
-    switch (st) {
+    switch (*(unsigned char*)(c + 0x38f)) {
     case 0: {
         char* tgt = *(char**)(c + 0x378);
         short ang = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), (struct Vec3*)(tgt + 0x5c));
@@ -23,17 +21,19 @@ int func_ov019_02111fec(char* c) {
             struct Vec3 pos;
             int msg;
             int eq;
+            int y;
             int z;
             pos.x = *(int*)(c + 0x5c);
-            pos.y = *(int*)(c + 0x60);
+            y = *(int*)(c + 0x60);
+            pos.y = y;
             z = *(int*)(c + 0x64);
-            pos.y = *(int*)(c + 0x60) + 0x190000;
             pos.z = z;
+            pos.y = y + 0x190000;
             eq = (int)(NumStars() == 0x96);
             if (eq != 0) msg = 0xab; else msg = 0xa7;
-            if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void**)(c + 0x378), c, (short)msg, &pos, 1, 2) != 0) {
-                unsigned char* p = (unsigned char*)(c + 0x38f);
-                *p = *p + 1;
+            if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(
+                    *(void**)(c + 0x378), c, (unsigned int)(short)msg, &pos, 1, 2) != 0) {
+                LB(0x38f) = LB(0x38f) + 1;
             }
         }
         break;


### PR DESCRIPTION
## Summary

Promote four ov019 NONMATCHING near-miss drafts to verified byte-identical matches (mwccarm **1.2/sp2p3**).

| Function | Address | Size |
|---|---|---|
| `func_ov019_0211131c` | `0x0211131c` | `0x94` |
| `func_ov019_02111dec` | `0x02111dec` | `0x168` |
| `func_ov019_021117a8` | `0x021117a8` | `0x15c` |
| `func_ov019_02111fec` | `0x02111fec` | `0x150` |

**Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

**Key levers used:**
- `0x300+0x8c` u64-mask launder for `0x38c` short access / RMW at `0x380`
- Pool-loaded `0x38f` state increment (`LB` macro)
- Correct control-flow nesting (e.g. case-2 `GetTalkState` outside `Finished`)
- `#pragma opt_common_subs off` to stop hoisting the `0x300` base across `Vec3_HorzAngle`
- `pos.y` register reuse for ROM store interleave in `ShowMessage` setup

## Not in this PR

`func_ov019_02111558` (`0x02111558`, `0x1fc`) improved from div≈55 to **div=5** (pure r0/r1 regperm on the case-1 Vec3 setup; remainder byte-identical). Left as a refine-tier near-miss rather than landing NONMATCHING into `src/`.

## Test plan

- [x] `tools/match.py --module ov019 --version 1.2/sp2p3` reports MATCH for all four
- [ ] CI `validate` green