### PR TITLE
Match 7 ov096 Pokey functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov096: 02135948 (0x02135948), 02136264 (0x02136264), 02136434 (0x02136434), 02136754 (0x02136754), 02136fd4 (0x02136fd4), 02137088 (0x02137088), 021372c0 (0x021372c0) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #230 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov096_02135948.c
+++ b/src/func_ov096_02135948.c
@@ -1,0 +1,167 @@
+//cpp
+typedef short s16;
+typedef long long s64;
+
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+extern int _ZN5Actor7FindEggER12CylinderClsn(void* thiz, void* clsn);
+extern int _ZN5Actor18FindExplosionActorER12CylinderClsn(void* thiz, void* clsn);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, void* pos);
+extern void func_ov096_02135800(void* c);
+extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, const void* rot, int e, int f);
+extern void func_ov096_0213585c(void* t);
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern int Vec3_HorzDist(const void* a, const void* b);
+extern int Vec3_HorzAngle(const void* a, const void* b);
+extern s16 data_02082214[];
+extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, int f, int t1, int t2, const void* v, void* cb);
+extern unsigned _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned a, unsigned b, int f, int t1, int t2, const void* v);
+extern void func_ov096_02136928(void* c, int n);
+extern int _ZN6Player9IsOnShellEv(void* p);
+extern void _ZN6Player16IncMegaKillCountEv(void* p);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, void* v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* thiz);
+
+void func_ov096_02135948(char* c)
+{
+    unsigned int id170;
+    char* p;
+    int r150;
+    int angle;
+    int a;
+    s16 cs;
+    int dist;
+    s16 sn;
+    int dist2;
+    unsigned int flags;
+    int st38c;
+    char* q;
+    struct Vector3 pos;
+    int vv1[3];
+    int vv2[3];
+    int vv3[3];
+    int vv4[3];
+    int vv5[3];
+    int x, y, z;
+
+    if (_ZN5Actor7FindEggER12CylinderClsn(c, c + 0x14c) != 0 ||
+        _ZN5Actor18FindExplosionActorER12CylinderClsn(c, c + 0x14c) != 0) {
+        _ZN5Sound9PlayBank0EjRK7Vector3(9, c + 0x74);
+        func_ov096_02135800(c);
+        {
+            int b = (*(unsigned short*)(c + 0xc) == 0xf0);
+            if (b) {
+                _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                    0x122, 2, c + 0x5c, 0, *(signed char*)(c + 0xcc), -1);
+            }
+        }
+        func_ov096_0213585c(c);
+        return;
+    }
+
+    id170 = *(unsigned int*)(c + 0x170);
+    if (id170 == 0)
+        return;
+
+    p = (char*)_ZN5Actor10FindWithIDEj(id170);
+    if (p == 0)
+        return;
+
+    if (*(int*)(c + 0x38c) == 1) {
+        int b = (*(unsigned short*)(p + 0xc) == 0x135);
+        if (b) {
+            r150 = *(int*)(c + 0x150);
+            if (Vec3_HorzDist(c + 0x5c, p + 0x5c) < r150 + 0x1a9000) {
+                angle = Vec3_HorzAngle(p + 0x5c, c + 0x5c);
+                a = ((unsigned short)angle >> 4) * 2;
+                cs = data_02082214[a];
+                dist = *(int*)(c + 0x150) + 0x1a9000;
+                *(int*)(c + 0x5c) = *(int*)(p + 0x5c) + (int)(((s64)dist * cs + 0x800) >> 12);
+                sn = data_02082214[a + 1];
+                dist2 = *(int*)(c + 0x150) + 0x1a9000;
+                *(int*)(c + 0x64) = *(int*)(p + 0x64) + (int)(((s64)dist2 * sn + 0x800) >> 12);
+            }
+        }
+    }
+
+    {
+        int bf = (*(unsigned short*)(p + 0xc) == 0xbf);
+        if (!bf)
+            return;
+    }
+
+    flags = *(unsigned int*)(c + 0x16c);
+    if (!(flags & 0x8000)) {
+        if (flags & 0x40000) {
+            x = *(int*)(c + 0x5c);
+            z = *(int*)(c + 0x64);
+            y = *(int*)(c + 0x60) + 0x3c000;
+            ((int*)&pos)[0] = x;
+            ((int*)&pos)[1] = y;
+            ((int*)&pos)[2] = z;
+            *(unsigned*)(c + 0x3a0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                *(unsigned*)(c + 0x3a0), 0x13a, pos.x, pos.y, pos.z, 0, 0);
+            *(unsigned*)(c + 0x3a4) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+                *(unsigned*)(c + 0x3a4), 0x13b, pos.x, pos.y, pos.z, 0);
+            _ZN5Sound9PlayBank0EjRK7Vector3(9, c + 0x74);
+            *(void**)(c + 0x388) = p;
+            func_ov096_02136928(c, 2);
+        } else if ((flags & 0x26fe0) || _ZN6Player9IsOnShellEv(p) != 0 ||
+                   *(unsigned char*)(p + 0x6f9) != 0) {
+            _ZN5Sound9PlayBank0EjRK7Vector3(9, c + 0x74);
+            *(void**)(c + 0x388) = p;
+            func_ov096_02136928(c, 2);
+        } else if (*(unsigned int*)(c + 0x16c) & 0x10) {
+            *(void**)(c + 0x388) = p;
+            _ZN6Player16IncMegaKillCountEv(p);
+            func_ov096_02136928(c, 5);
+        } else {
+            st38c = *(int*)(c + 0x38c);
+            if (st38c == 0) {
+                q = *(char**)(c + 0x390);
+                if (q == 0) {
+                    if (*(int*)(c + 0xa8) == 0) {
+                        vv1[0] = *(int*)(c + 0x5c);
+                        vv1[1] = *(int*)(c + 0x60);
+                        vv1[2] = *(int*)(c + 0x64);
+                        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, vv1, 2, 0xc000, 1, 0, 1);
+                    }
+                } else if (*(int*)(c + 0xa8) == 0 && *(int*)(q + 0xa8) == 0) {
+                    vv2[0] = *(int*)(c + 0x5c);
+                    vv2[1] = *(int*)(c + 0x60);
+                    vv2[2] = *(int*)(c + 0x64);
+                    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, vv2, 2, 0xc000, 1, 0, 1);
+                }
+            } else if (st38c == 1) {
+                if (*(void**)(c + 0x390) == 0) {
+                    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x180) != 0) {
+                        vv3[0] = *(int*)(c + 0x5c);
+                        vv3[1] = *(int*)(c + 0x60);
+                        vv3[2] = *(int*)(c + 0x64);
+                        _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, vv3, 2, 0xc000, 1, 0, 1);
+                    }
+                } else if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x180) != 0 &&
+                           *(int*)(*(char**)(c + 0x390) + 0xa8) == 0) {
+                    vv4[0] = *(int*)(c + 0x5c);
+                    vv4[1] = *(int*)(c + 0x60);
+                    vv4[2] = *(int*)(c + 0x64);
+                    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, vv4, 2, 0xc000, 1, 0, 1);
+                }
+            } else {
+                vv5[0] = *(int*)(c + 0x5c);
+                vv5[1] = *(int*)(c + 0x60);
+                vv5[2] = *(int*)(c + 0x64);
+                _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, vv5, 2, 0xc000, 1, 0, 1);
+            }
+        }
+    }
+
+    {
+        int t = (*(unsigned int*)(c + 0xb0) & 0x20000) != 0;
+        if (t) {
+            func_ov096_02136928(c, 3);
+        }
+    }
+}
+}

--- a/src/func_ov096_02136264.c
+++ b/src/func_ov096_02136264.c
@@ -1,0 +1,57 @@
+
+typedef unsigned short u16;
+typedef short s16;
+typedef long long s64;
+extern s16 data_02082214[];
+extern void func_ov096_02136928(char* c, int n);
+extern void func_ov096_02135948(char* c);
+extern void _ZN12CylinderClsn5ClearEv(char* p);
+extern void _ZN12CylinderClsn6UpdateEv(char* p);
+
+int func_ov096_02136264(char* self)
+{
+    char *other = *(char**)(self + 0x394);
+    if (!other) {
+        func_ov096_02136928(self, 1);
+    } else {
+        int velx, r, sp, t, z, b;
+        s64 prod;
+        s16 *tbl, c, sn;
+        u16 ang;
+
+        velx = *(int*)(other + 0x80);
+        prod = (s64)velx * 0x6e000;
+        *(int*)(self + 0x5c) = *(int*)(other + 0x5c);
+        r = (int)((prod + 0x800) >> 12);
+        other = *(char**)(self + 0x394);
+        *(int*)(self + 0x60) = r + *(int*)(other + 0x60);
+        other = *(char**)(self + 0x394);
+        t = *(int*)(other + 0x64);
+        tbl = data_02082214;
+        *(int*)(self + 0x64) = t;
+        other = *(char**)(self + 0x394);
+        sp = 0xe000;
+        c = *(s16*)(other + 0x8e);
+        *(s16*)(self + 0x8e) = c;
+        other = *(char**)(self + 0x394);
+        other = other + 0x300;
+        c = *(s16*)(other + 0xaa);
+        c = (s16)(c + 0x13000);
+        *(s16*)(self + 0x3aa) = c;
+        ang = *(u16*)(self + 0x3aa);
+        c = tbl[(ang >> 4) * 2];
+        b = 0x800;
+        z = 0;
+        *(int*)(self + 0x378) = (int)(((s64)c * sp + b) >> 12);
+        *(int*)(self + 0x37c) = z;
+        ang = *(u16*)(self + 0x3aa);
+        sn = tbl[(ang >> 4) * 2 + 1];
+        *(int*)(self + 0x380) = (int)(((s64)sn * sp + b) >> 12);
+        if (r == 0x6e000)
+            func_ov096_02136928(self, 0);
+    }
+    func_ov096_02135948(self);
+    _ZN12CylinderClsn5ClearEv(self + 0x14c);
+    _ZN12CylinderClsn6UpdateEv(self + 0x14c);
+    return 1;
+}

--- a/src/func_ov096_02136434.c
+++ b/src/func_ov096_02136434.c
@@ -1,38 +1,40 @@
 //cpp
-// NONMATCHING: different op / idiom (div=18). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
-struct V3 { int x, y, z; };
-extern void Actor_UpdatePos(void *c, void *clsn);
-extern void *Particle_System_New(unsigned int a, unsigned int b, int f, int t1, int t2, void *v, void *cb);
-extern void *Particle_System_NewUnkCallback818(unsigned int a, unsigned int b, int f, int t1, int t2, void *v);
-extern void *Particle_System_FromUniqueID(unsigned int id);
+struct Vector3 { int x, y, z; };
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *clsn);
+extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, int f, int t1, int t2, const void *v, void *cb);
+extern unsigned _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned a, unsigned b, int f, int t1, int t2, const void *v);
+extern void *_ZN8Particle6System12FromUniqueIDEj(unsigned id);
 extern void func_02038414(void *p);
-extern int WithMeshClsn_JustHitGround(void *p);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *p);
 extern void func_ov096_0213585c(void *t);
 
 int func_ov096_02136434(void *c)
 {
-    Actor_UpdatePos(c, (char*)c+0x14c);
-    if (*(int*)((char*)c+0x3a0) != 0 && *(int*)((char*)c+0x3a4) != 0) {
-        volatile struct V3 pos;
-        void *p0;
-        void *p1;
-        pos.x = *(int*)((char*)c+0x5c);
-        pos.y = *(int*)((char*)c+0x60) + 0x3c000;
-        pos.z = *(int*)((char*)c+0x64);
-        *(void**)((char*)c+0x3a0) = Particle_System_New(*(int*)((char*)c+0x3a0), 0x13a, pos.x, pos.y, pos.z, 0, 0);
-        *(void**)((char*)c+0x3a4) = Particle_System_NewUnkCallback818(*(int*)((char*)c+0x3a4), 0x13b, pos.x, pos.y, pos.z, 0);
-        p0 = Particle_System_FromUniqueID(*(int*)((char*)c+0x3a0));
-        p1 = Particle_System_FromUniqueID(*(int*)((char*)c+0x3a4));
+    char *s = (char*)c;
+    struct Vector3 pos;
+    void *p0, *p1;
+    int x, y, z;
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, s+0x14c);
+    if (*(unsigned*)(s+0x3a0) != 0 && *(unsigned*)(s+0x3a4) != 0) {
+        x = *(int*)(s+0x5c);
+        z = *(int*)(s+0x64);
+        y = *(int*)(s+0x60) + 0x3c000;
+        ((int*)&pos)[0] = x;
+        ((int*)&pos)[1] = y;
+        ((int*)&pos)[2] = z;
+        *(unsigned*)(s+0x3a0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned*)(s+0x3a0), 0x13a, pos.x, pos.y, pos.z, 0, 0);
+        *(unsigned*)(s+0x3a4) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+            *(unsigned*)(s+0x3a4), 0x13b, pos.x, pos.y, pos.z, 0);
+        p0 = _ZN8Particle6System12FromUniqueIDEj(*(unsigned*)(s+0x3a0));
+        p1 = _ZN8Particle6System12FromUniqueIDEj(*(unsigned*)(s+0x3a4));
         if (p0) *(int*)((char*)p0+0x50) = 0x7fff;
         if (p1) *(int*)((char*)p1+0x50) = 0x7fff;
     }
-    func_02038414((char*)c+0x180);
-    if (WithMeshClsn_JustHitGround((char*)c+0x180) != 0) {
+    func_02038414(s+0x180);
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(s+0x180) != 0)
         func_ov096_0213585c(c);
-    }
     return 1;
 }
 }

--- a/src/func_ov096_02136754.c
+++ b/src/func_ov096_02136754.c
@@ -1,0 +1,64 @@
+typedef unsigned short u16;
+typedef short s16;
+typedef long long s64;
+extern s16 data_02082214[];
+extern void func_ov096_02136928(char* c, int n);
+extern void func_ov096_02135948(char* c);
+extern void _ZN12CylinderClsn5ClearEv(char* p);
+extern void _ZN12CylinderClsn6UpdateEv(char* p);
+
+int func_ov096_02136754(char* self)
+{
+    char *other = *(char**)(self + 0x394);
+    if (!other) {
+        func_ov096_02136928(self, 1);
+    } else {
+
+        char *p = self + 0x60;
+        int sp, t, a0, z, lim, b;
+        s16 *tbl, c, sn;
+        u16 ang;
+
+        *(int*)(self+0x5c) = *(int*)(other+0x5c);
+        other = *(char**)(self+0x394);
+        t = *(int*)(other+0x64);
+        sp = 0xe000;
+        *(int*)(self+0x64) = t;
+
+        t = *(int*)(self+0xa8) - 0x2000;
+        a0 = *(int*)(self+0xa0);
+        if (t >= a0) a0 = t;
+        *(int*)(self+0xa8) = a0;
+        *(int*)p += *(int*)(self+0xa8);
+        other = *(char**)(self+0x394);
+        t = *(int*)(self+0x60);
+        lim = *(int*)(other+0x60) + 0x6e000;
+        if (t < lim) {
+            *(int*)(self+0x60) = lim;
+            *(int*)(self+0xa8) = 0;
+        }
+        other = *(char**)(self+0x394);
+        tbl = data_02082214;
+        c = *(s16*)(other+0x8e);
+        z = 0;
+        *(s16*)(self+0x8e) = c;
+        other = *(char**)(self+0x394);
+        other = other + 0x300;
+        c = *(s16*)(other+0xaa);
+        b = 0x800;
+        c = (s16)(c + 0x13000);
+        *(s16*)(self + 0x3aa) = c;
+        ang = *(u16*)(self + 0x3aa);
+        c = tbl[(ang>>4)*2];
+        *(int*)(self+0x378) = (int)(((s64)c * sp + b) >> 12);
+        *(int*)(self+0x37c) = z;
+        ang = *(u16*)(self + 0x3aa);
+        sn = tbl[(ang>>4)*2+1];
+        *(int*)(self+0x380) = (int)(((s64)sn * sp + b) >> 12);
+
+    }
+    func_ov096_02135948(self);
+    _ZN12CylinderClsn5ClearEv(self + 0x14c);
+    _ZN12CylinderClsn6UpdateEv(self + 0x14c);
+    return 1;
+}

--- a/src/func_ov096_02136fd4.c
+++ b/src/func_ov096_02136fd4.c
@@ -1,12 +1,9 @@
-// NONMATCHING: base materialization / addressing (div=9). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef struct Actor Actor;
 typedef int Fix12i;
 extern void func_ov096_02136e54(Actor* t, int x);
-extern Actor* _ZN5Actor13ClosestPlayerEv(void);
+extern Actor* _ZN5Actor13ClosestPlayerEv(Actor* self);
 extern Fix12i Vec3_HorzDist(const void* a, const void* b);
-
+#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
 void func_ov096_02136fd4(Actor* thiz)
 {
     char* c = (char*)thiz;
@@ -16,12 +13,12 @@ void func_ov096_02136fd4(Actor* thiz)
     return;
 rest:;
     {
-        int* q = (int*)(c + 0xec);
+        int* q = (int*)(int)M(c + 0xec);
         *q |= 1;
     }
     *(int*)(c + 0x33c) = 0;
     {
-        Actor* p = _ZN5Actor13ClosestPlayerEv();
+        Actor* p = _ZN5Actor13ClosestPlayerEv(thiz);
         if (p) {
             if (Vec3_HorzDist(c + 0x340, (char*)p + 0x5c) > 0x9c4000)
                 *(int*)(c + 0x35c) = 0;

--- a/src/func_ov096_02137088.c
+++ b/src/func_ov096_02137088.c
@@ -1,0 +1,102 @@
+//cpp
+extern "C" {
+struct Vector3 { int x, y, z; };
+extern short Vec3_HorzAngle(const void *a, const void *b);
+extern int Vec3_HorzDist(const void *a, const void *b);
+extern int Vec3_Dist(const void *a, const void *b);
+extern unsigned _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, const void *v, unsigned e);
+extern void *_ZN5Actor13ClosestPlayerEv(void *self);
+extern void _Z14ApproachLinearRsss(short *v, short target, short step);
+extern int func_ov002_020de328(void *p);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
+extern void func_020383fc(void *p);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *p);
+extern void *_ZNK12WithMeshClsn13GetWallResultEv(void *p);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *s, int *out);
+extern short _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+extern void func_ov096_02136e54(void *self, int n);
+extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, int x, int y, int z, const void *v, void *cb);
+void func_ov096_02137088(char *c);
+}
+#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+
+void func_ov096_02137088(char *c)
+{
+    struct Vector3 pos;
+    char *player;
+    void *p33c;
+    short ang;
+    unsigned short *p354 = (unsigned short *)(int)M(c + 0x354);
+    *p354 = (unsigned short)(*p354 + 1);
+
+    ang = Vec3_HorzAngle(c + 0x5c, c + 0x340);
+    *(short *)(c + 0x356) = ang;
+
+    *(unsigned *)(c + 0x36c) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+        *(unsigned *)(c + 0x36c), 3, 0x85, c + 0x74, 0);
+
+    *(int *)(c + 0x98) = 0x14000;
+
+    player = (char *)_ZN5Actor13ClosestPlayerEv(c);
+    if (player == 0)
+        goto null_player;
+
+    {
+        int *pp = (int *)(int)M(player + 0x5c);
+        pos.x = pp[0];
+        pos.y = pp[1];
+        pos.z = pp[2];
+    }
+
+    if (Vec3_HorzDist(c + 0x340, &pos) < *(int *)(c + 0x34c)
+        && *(unsigned char *)(c + 0x360) == 0
+        && *(unsigned short *)(c + 0x354) < 0x384) {
+        ang = Vec3_HorzAngle(c + 0x5c, &pos);
+        *(short *)(c + 0x358) = ang;
+        _Z14ApproachLinearRsss((short *)(c + 0x94), *(short *)(c + 0x358), 0x200);
+        p33c = *(void **)(c + 0x33c);
+        if (p33c != 0) {
+            if (func_ov002_020de328(p33c) != 0) {
+                unsigned char *pb = (unsigned char *)(int)M(c + 0x360);
+                *pb = (unsigned char)(*pb + 1);
+            }
+        }
+    } else {
+        _Z14ApproachLinearRsss((short *)(c + 0x94), *(short *)(c + 0x356), 0x200);
+        if (Vec3_HorzDist(c + 0x340, c + 0x5c) < 0xc8000)
+            *(int *)(c + 0x35c) = 2;
+    }
+    goto cont;
+
+null_player:
+    *(int *)(c + 0x35c) = 2;
+    return;
+
+cont:
+    if (Vec3_Dist(c + 0x5c, &pos) > 0xbb8000
+        || *(unsigned short *)(c + 0x354) >= 0x384) {
+        *(int *)(c + 0x35c) = 2;
+    }
+
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+    func_020383fc(c + 0x108);
+    if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x108) != 0) {
+        int n[3];
+        void *wr = _ZNK12WithMeshClsn13GetWallResultEv(c + 0x108);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char *)wr + 4, n);
+        *(short *)(c + 0x94) = _ZN4cstd5atan2E5Fix12IiES1_(n[0], n[2]);
+    }
+
+    func_ov096_02136e54(c, 0x1000);
+
+    {
+        int z = *(int *)(c + 0x64);
+        *(unsigned *)(c + 0x364) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned *)(c + 0x364), 0x11f,
+            *(int *)(c + 0x5c), *(int *)(c + 0x60), z, 0, 0);
+        z = *(int *)(c + 0x64);
+        *(unsigned *)(c + 0x368) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned *)(c + 0x368), 0x120,
+            *(int *)(c + 0x5c), *(int *)(c + 0x60), z, 0, 0);
+    }
+}

--- a/src/func_ov096_021372c0.c
+++ b/src/func_ov096_021372c0.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: base materialization / addressing (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern int _ZN5Actor13DistToCPlayerEv(void *self);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const void *v, unsigned int e);
@@ -9,6 +6,8 @@ extern void func_ov096_02136e54(void *self, int n);
 
 void func_ov096_021372c0(void *self);
 }
+
+#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
 
 void func_ov096_021372c0(void *self)
 {
@@ -27,11 +26,11 @@ void func_ov096_021372c0(void *self)
         *(int*)(c + 0x88) = 0;
         *(unsigned short*)(c + 0x352) = 0;
         if (_ZN5Actor13DistToCPlayerEv(c) < 0x5dc000) {
-            unsigned char *p = (unsigned char*)(c + 0x360);
+            unsigned char *p = (unsigned char*)(int)M(c + 0x360);
             *p = *p + 1;
         }
         *(unsigned short*)(c + 0x350) = 0;
-        *(int*)(c + 0xec) &= ~1;
+        *(int*)(int)M(c + 0xec) &= ~1;
         *(unsigned short*)(c + 0x354) = 0;
     } else {
         *(int*)(c + 0x36c) = _ZN5Sound8PlayLongEjjjRK7Vector3j(


### PR DESCRIPTION
## Summary

Byte-identical matches for **7** ov096 (Pokey) functions, verified with `tools/match.py --module ov096 --version 1.2/sp2p3`.

| Function | Address | Size | Lang | Notes |
|---|---|---|---|---|
| `func_ov096_02135948` | `0x2135948` | 1252 B | C++ | Collision reactions, Hurt, particles |
| `func_ov096_02136264` | `0x2136264` | 336 B | C | Attach-from-velocity Fix12 height |
| `func_ov096_02136434` | `0x2136434` | 256 B | C++ | Particle pair + JustHitGround |
| `func_ov096_02136754` | `0x2136754` | 336 B | C | Attached-head follow + sin/cos vel |
| `func_ov096_02136fd4` | `0x2136fd4` | 180 B | C | State wind-down; ClosestPlayer this-arg |
| `func_ov096_02137088` | `0x2137088` | 568 B | C++ | Chase/update, wall atan2, dual trails |
| `func_ov096_021372c0` | `0x21372c0` | 292 B | C++ | Idle/active; u64-mask bases |

**Compiler:** mwccarm 1.2/sp2p3  
**Flags (C):** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`  
**Flags (C++):** same with `-lang c++` (first line `//cpp`)

## Test plan

- [x] Each file verified with `tools/match.py --module ov096 --version 1.2/sp2p3` → MATCH
- [ ] CI `validate` green