### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov016: 02111284 (0x02111284), 021115c0 (0x021115c0), 02112fa8 (0x02112fa8) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #231 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov016_02111284.c
+++ b/src/func_ov016_02111284.c
@@ -1,0 +1,128 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+
+struct Vector3 { int x, y, z; };
+
+extern void Matrix4x3_FromRotationY(void* m, int angle);
+extern void MulVec3Mat4x3(void* in, void* m, void* out);
+extern void* _ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, struct Vector3* v, u32 a, int fix, u32 b, u32 d, u32 e);
+
+extern unsigned char data_0209f220;
+extern int data_ov016_02114dbc;
+extern int data_020a0e68[];
+
+#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_ov016_02111284(char* c)
+{
+    struct Vector3 va;
+    struct Vector3 vb;
+    struct Vector3 out;
+    struct Vector3 hv;
+    int r4;
+    int r6;
+    void* p;
+    int t;
+    u32 id;
+    int* ctr;
+    int idx;
+    char* base448;
+    char* base44c;
+    char* base450;
+    int i;
+    int* px;
+
+    *(volatile int*)&va.x = *(int*)(c + 0x5c);
+    *(volatile int*)&va.y = *(int*)(c + 0x60);
+    *(volatile int*)&va.z = *(int*)(c + 0x64);
+
+    vb.x = 0;
+    vb.y = 0;
+    vb.z = 0;
+    out.x = 0;
+    out.y = 0;
+    out.z = 0;
+
+    r4 = 0x52000;
+
+    if (data_0209f220 == 1 && *(int*)(c + 0x34c) != (int)&data_ov016_02114dbc) {
+        r6 = 0x128000;
+        r6 = -r6;
+        vb.y = r6;
+        vb.z = 0x7c000;
+        va.x = 0x15e0000;
+        va.y = 0xfee90000;
+        va.z = 0x65e000;
+        Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c + 0x8e));
+        MulVec3Mat4x3(&vb, data_020a0e68, &out);
+        va.x = va.x + out.x;
+        va.y = va.y + out.y;
+        va.z = va.z + out.z;
+        *(int*)(c + 0x184) = va.x;
+        {
+            int c1 = 0xc8000;
+            *(int*)(c + 0x188) = va.y;
+            int c2 = 0xf0000;
+            *(int*)(c + 0x18c) = va.z;
+            *(int*)(c + 0x154) = c1;
+            *(int*)(c + 0x158) = c2;
+        }
+    }
+
+    ctr = (int*)LA(c + 0x3fc);
+    *ctr = *ctr + 1;
+    if (*(int*)(c + 0x3fc) > 6)
+        *(int*)(c + 0x3fc) = 0;
+
+    idx = *(int*)(c + 0x3fc);
+    if (idx == 5)
+        r4 = 0xb8000;
+    vb.y = 0;
+    vb.x = 0;
+    vb.z = 0;
+    out.x = 0;
+    out.y = 0;
+    out.z = 0;
+    vb.y = -0x48000;
+    if (*(int*)(c + 0x3fc) == 5)
+        vb.z = 0x7c000;
+
+    Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c + 0x8e));
+    MulVec3Mat4x3(&vb, data_020a0e68, &out);
+
+    {
+      /* V4 structure but force *0xc via char index on int base */
+      int* p448 = (int*)(c + 0x448);
+      int* p44c = (int*)(c + 0x44c);
+      int* p450 = (int*)(c + 0x450);
+      int idx2 = *(int*)(c + 0x3fc);
+      ((int*)((char*)p448 + idx2 * 0xc))[0] = ((int*)((char*)p448 + idx2 * 0xc))[0] + out.x;
+      idx2 = *(int*)(c + 0x3fc);
+      ((int*)((char*)p44c + idx2 * 0xc))[0] = ((int*)((char*)p44c + idx2 * 0xc))[0] + out.y;
+      idx2 = *(int*)(c + 0x3fc);
+      ((int*)((char*)p450 + idx2 * 0xc))[0] = ((int*)((char*)p450 + idx2 * 0xc))[0] + out.z;
+      idx2 = *(int*)(c + 0x3fc);
+      px = (int*)((char*)p448 + idx2 * 0xc);
+      *(int*)(c + 0x144) = px[0];
+      *(int*)(c + 0x148) = px[1];
+      *(int*)(c + 0x14c) = px[2];
+    }
+
+    *(int*)(c + 0x114) = r4;
+    *(int*)(c + 0x118) = 0x70000;
+
+    id = *(u32*)(c + 0x134);
+    if (id == 0)
+        return;
+
+    p = _ZN5Actor10FindWithIDEj(id);
+    t = (int)(*(u16*)((char*)p + 0xc) == 0xbf);
+    if (t == 0)
+        return;
+
+    hv.x = *(int*)(c + 0x5c);
+    hv.y = *(int*)(c + 0x60);
+    hv.z = *(int*)(c + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(p, &hv, 3, 0xc000, 1, 0, 1);
+}

--- a/src/func_ov016_021115c0.c
+++ b/src/func_ov016_021115c0.c
@@ -1,6 +1,3 @@
-// NONMATCHING: push-set / frame (div=32). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void _ZN7PathPtrC1Ev(void* self);
 extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, void* out, unsigned int idx);
@@ -20,6 +17,8 @@ extern char data_ov016_02114d7c;
 
 struct Vec3 { int x, y, z; };
 
+#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
 int func_ov016_021115c0(char* c)
 {
     char pp[8];
@@ -37,7 +36,7 @@ int func_ov016_021115c0(char* c)
     {
         int d = AngleDiff(ha, *(short*)(c + 0x94));
         int s = d + ((unsigned)d >> 31);
-        *(short*)(c + 0x426) = (short)(s >> 1);
+        *(short*)((char*)LA(c + 0x400) + 0x26) = (short)(s >> 1);
     }
     _Z14ApproachLinearRsss((short*)(c + 0x94), ha, 0x80);
 
@@ -52,16 +51,15 @@ int func_ov016_021115c0(char* c)
             return 1;
         }
         {
-            int* q = (int*)(c + 0x410);
+            int* q = (int*)LA(c + 0x410);
             *q = *q + 1;
         }
         if (*(int*)(c + 0x410) >= *(int*)(c + 0x40c))
             *(int*)(c + 0x410) = 0;
         func_02012694(0xfa, c + 0x74);
-        return 1;
+    } else {
+        Vec3_MulScalar(&scaled, &diff, _ZN4cstd4fdivEii(0xa000, len));
+        SubVec3(c + 0x5c, &scaled, c + 0x5c);
     }
-
-    Vec3_MulScalar(&scaled, &diff, _ZN4cstd4fdivEii(0xa000, len));
-    SubVec3(c + 0x5c, &scaled, c + 0x5c);
     return 1;
 }

--- a/src/func_ov016_02112fa8.c
+++ b/src/func_ov016_02112fa8.c
@@ -1,0 +1,7 @@
+extern int func_020b5e58(void *self, void *arg);
+extern char data_ov016_02114b8c;
+
+int func_ov016_02112fa8(void *self)
+{
+    return func_020b5e58(self, &data_ov016_02114b8c);
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for three ov016 (Unagi-adjacent) functions, verified with `tools/match.py` against the EU retail overlay (`mwccarm 1.2/sp2p3`).

| Function | Addr | Size | Notes |
|---|---|---|---|
| `func_ov016_02112fa8` | `0x02112fa8` | `0x14` | Tail-call trampoline to `func_020b5e58` |
| `func_ov016_021115c0` | `0x021115c0` | `0x158` | PathPtr follow / approach (replaces prior NONMATCHING) |
| `func_ov016_02111284` | `0x02111284` | `0x2b0` | Segment hurt volumes / counter |

### Verify

```
python tools/match.py --c src/func_ov016_02112fa8.c --func func_ov016_02112fa8 --addr 0x2112fa8 --size 0x14 --version 1.2/sp2p3 --module ov016
python tools/match.py --c src/func_ov016_021115c0.c --func func_ov016_021115c0 --addr 0x21115c0 --size 0x158 --version 1.2/sp2p3 --module ov016
python tools/match.py --c src/func_ov016_02111284.c --func func_ov016_02111284 --addr 0x2111284 --size 0x2b0 --version 1.2/sp2p3 --module ov016
```

## Test plan

- [ ] CI `validate` green on all three files