### PR TITLE
Match 6 ov077 Lakitu-related functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov077: 021241ac (0x021241ac), 021243c0 (0x021243c0), 021256b4 (0x021256b4), 02125bb4 (0x02125bb4), 02126300 (0x02126300), 0212679c (0x0212679c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #232 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov077_021241ac.c
+++ b/src/func_ov077_021241ac.c
@@ -1,0 +1,50 @@
+typedef long long s64;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+extern s16 data_02082214[];
+#define LA(p) ((int)(((s64)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+int func_ov077_021241ac(char *o)
+{
+
+    char *d0; int *a5c; int *a60; int *a64; int *src;
+    char *p400; int three; int k; s16 s; s16 cval; int v7000; int v1e;
+
+    *(int *)LA(o + 0xb0) &= ~0x80000;
+
+    d0 = *(char **)(o + 0xd0);
+    a5c = (int *)LA(o + 0x5c);
+    *(int *)(o + 0x98) = *(int *)(d0 + 0x98) + 0xa000;
+
+    d0 = *(char **)(o + 0xd0);
+    a60 = (int *)LA(o + 0x60);
+    a64 = (int *)LA(o + 0x64);
+    *(s16 *)(o + 0x94) = *(s16 *)(d0 + 0x8e);
+
+    d0 = *(char **)(o + 0xd0);
+
+    v7000 = 0x7000;
+    src = (int *)LA(d0 + 0x5c);
+    *(int *)(o + 0x5c) = src[0];
+    p400 = o + 0x400;
+    v1e = 0x1e;
+    *(int *)(o + 0x60) = src[1];
+    *(int *)(o + 0x64) = src[2];
+    three = 3;
+
+
+    k = ((int)*(u16 *)(o + 0x94)) >> 4;
+    s = data_02082214[k * 2];
+    *a5c = *a5c + (int)(((s64)s * 0x50000 + 0x800) >> 12);
+    *a60 = *a60 + 0x50000;
+    k = ((int)*(u16 *)(o + 0x94)) >> 4;
+    cval = data_02082214[k * 2 + 1];
+    *a64 = *a64 + (int)(((s64)cval * 0x50000 + 0x800) >> 12);
+
+    *(s16 *)(p400 + 0x1a) = (s16)v7000;
+    *(u8 *)(o + 0x41c) = (u8)v1e;
+    *(int *)(o + 0xd0) = 0;
+    *(int *)(o + 0x3f4) = three;
+    return 1;
+}

--- a/src/func_ov077_021243c0.c
+++ b/src/func_ov077_021243c0.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=10). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int Fix12i;
 struct V3 { Fix12i x, y, z; };
 extern "C" {
@@ -28,19 +25,20 @@ int func_ov077_021243c0(char* c){
     }
     if (_ZN9Animation8FinishedEv(c + 0x124)) {
         func_ov077_0212478c(c, 0);
-        func_ov077_0212390c(c);
-        func_ov077_02123814(c);
     }
+    func_ov077_0212390c(c);
+    func_ov077_02123814(c);
     _ZN9Animation7AdvanceEv(c + 0x124);
     _ZN9Animation7AdvanceEv(c + 0x1b0);
     func_ov077_02123a74(c);
     {
-        struct V3 v;
         int* d = data_ov077_02127b88;
         int off = *(int*)(c + 0x414);
-        v.x = d[0];
-        v.y = d[1] + off;
-        v.z = d[2];
+        int z = d[2];
+        int y = d[1] + off;
+        int x = d[0];
+        struct V3 v;
+        v.x = x; v.y = y; v.z = z;
         _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1c4, &v);
     }
     _ZN12CylinderClsn5ClearEv(c + 0x1c4);

--- a/src/func_ov077_021256b4.c
+++ b/src/func_ov077_021256b4.c
@@ -1,0 +1,74 @@
+typedef long long s64;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+struct Vector3 { int x, y, z; };
+extern s16 data_02082214[];
+extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *self);
+#define LA(p) ((int)(((s64)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+int func_ov077_021256b4(char *o)
+{
+    char *d0;
+    int *a5c;
+    int *a60;
+    int *a64;
+    int *src;
+    int k;
+    s16 s;
+    s16 cval;
+    s16 ang;
+    struct Vector3 v;
+    int one;
+    int y;
+    int z;
+    int x;
+
+    *(int *)LA(o + 0xb0) &= ~0x80000;
+    *(int *)(o + 0x98) = 0xa000;
+    *(int *)(o + 0xa8) = 0;
+
+    d0 = *(char **)(o + 0xd0);
+    a5c = (int *)LA(o + 0x5c);
+    ang = *(s16 *)(d0 + 0x8e);
+    *(s16 *)(o + 0x8c) = 0;
+    *(s16 *)(o + 0x8e) = ang;
+    *(s16 *)(o + 0x90) = 0;
+
+    *(s16 *)(o + 0x94) = *(s16 *)(o + 0x8e);
+    a60 = (int *)LA(o + 0x60);
+    a64 = (int *)LA(o + 0x64);
+
+    d0 = *(char **)(o + 0xd0);
+    src = (int *)LA(d0 + 0x5c);
+    one = 1;
+    *(int *)(o + 0x5c) = src[0];
+    *(int *)(o + 0x60) = src[1];
+    *(int *)(o + 0x64) = src[2];
+
+    k = ((int)*(u16 *)(o + 0x8e)) >> 4;
+    s = data_02082214[k * 2];
+    *a5c = *a5c + (int)(((s64)s * 0x3c000 + 0x800) >> 12);
+    *a60 = *a60 + 0x85000;
+    k = ((int)*(u16 *)(o + 0x8e)) >> 4;
+    cval = data_02082214[k * 2 + 1];
+    *a64 = *a64 + (int)(((s64)cval * 0x3c000 + 0x800) >> 12);
+
+    d0 = *(char **)(o + 0xd0);
+
+    {
+        int ty = *(int *)(d0 + 0x60);
+        int tz = *(int *)(d0 + 0x64);
+        int ty2 = ty + 0x50000;
+        int tx = *(int *)(d0 + 0x5c);
+        v.x = tx; v.y = ty2; v.z = tz;
+    }
+
+    _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(o, &v, (struct Vector3 *)(o + 0x5c), one);
+
+    *(int *)(o + 0xd0) = 0;
+    _ZN12WithMeshClsn13SetLimMovFlagEv(o + 0x1e4);
+
+    *(int *)(o + 0x3d8) = 4;
+    return 1;
+}

--- a/src/func_ov077_02125bb4.c
+++ b/src/func_ov077_02125bb4.c
@@ -1,0 +1,95 @@
+typedef int Fix12i;
+
+struct Vector3 {
+    int x, y, z;
+};
+
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *p);
+extern void func_ov077_021250a8(void *c);
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *p);
+extern void func_020383fc(void *p);
+extern int func_ov077_02124ce4(void *c);
+extern void func_02012694(int id, void *pos);
+extern void _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(Fix12i x, Fix12i y, Fix12i z);
+extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned int uniqueID, unsigned int effectID,
+    Fix12i x, Fix12i y, Fix12i z,
+    const void *dir, void *callback);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *p);
+extern void _ZN5Actor8PoofDustEv(void *c);
+extern void _ZN9ActorBase18MarkForDestructionEv(void *c);
+extern void _ZN12WithMeshClsn15ClearLimMovFlagEv(void *p);
+extern void func_ov077_02125e94(void *c, int a);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i x, Fix12i y, Fix12i z);
+extern void func_0201267c(int id, void *pos);
+extern void _ZN12CylinderClsn5ClearEv(void *p);
+extern void _ZN12CylinderClsn6UpdateEv(void *p);
+
+extern int data_0209f32c;
+
+int func_ov077_02125bb4(char *c)
+{
+    int r4;
+    int d;
+    int x, y, z;
+    struct Vector3 vec;
+
+    *(short *)(c + 0x8c) = *(short *)(c + 0x8c) + 0x4e20;
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x1b0);
+    func_ov077_021250a8(c);
+    _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x1e4);
+    func_020383fc(c + 0x1e4);
+
+    r4 = func_ov077_02124ce4(c);
+    if (r4) {
+        if (*(unsigned char *)(c + 0x3e4) == 0) {
+            func_02012694(0xe2, c + 0x74);
+            _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(
+                *(int *)(c + 0x5c), data_0209f32c, *(int *)(c + 0x64));
+            *(unsigned int *)(c + 0x3e0) =
+                _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                    *(unsigned int *)(c + 0x3e0), 0x109,
+                    *(int *)(c + 0x5c), data_0209f32c, *(int *)(c + 0x64),
+                    0, 0);
+        }
+        *(int *)(c + 0x9c) = -0x400;
+        *(int *)(c + 0xa0) = -0x5000;
+        *(int *)(c + 0x98) = 0x2000;
+    } else {
+        *(int *)(c + 0x9c) = -0x2000;
+        *(int *)(c + 0xa0) = -0x3c000;
+        *(int *)(c + 0x98) = 0x4000;
+    }
+    *(unsigned char *)(c + 0x3e4) = (unsigned char)r4;
+
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x1e4)) {
+        *(int *)(c + 0xa8) = (*(int *)(c + 0xa8) * -0x3c) / 100;
+        d = *(int *)(c + 0x3dc) ? *(int *)(c + 0x60) - *(int *)(c + 0x3dc) : 0;
+        if (d < -0xc8000) {
+            _ZN5Actor8PoofDustEv(c);
+            func_02012694(0x166, c + 0x74);
+            _ZN9ActorBase18MarkForDestructionEv(c);
+        } else if (*(int *)(c + 0xa8) < 0xa000) {
+            *(int *)(c + 0xa8) = 0;
+            *(short *)(c + 0x8c) = *(short *)(c + 0x92);
+            *(short *)(c + 0x8e) = *(short *)(c + 0x94);
+            *(short *)(c + 0x90) = *(short *)(c + 0x96);
+            _ZN12WithMeshClsn15ClearLimMovFlagEv(c + 0x1e4);
+            *(unsigned int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000000u;
+            func_ov077_02125e94(c, 1);
+        } else {
+            x = *(int *)(c + 0x5c);
+            y = *(int *)(c + 0x60) + 0x28000;
+            z = *(int *)(c + 0x64);
+            ((int *)&vec)[0] = x;
+            ((int *)&vec)[1] = y;
+            ((int *)&vec)[2] = z;
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb2, vec.x, vec.y, vec.z);
+            func_0201267c(0x109, c + 0x74);
+        }
+    }
+
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+    return 1;
+}

--- a/src/func_ov077_02126300.c
+++ b/src/func_ov077_02126300.c
@@ -1,0 +1,117 @@
+typedef struct Vector3 {
+    int x, y, z;
+} Vector3;
+
+typedef struct RaycastLine {
+    char pad[0x78];
+} RaycastLine;
+
+extern signed char data_0209f2f8;
+extern char data_020a0e68[];
+
+extern void _ZN11RaycastLineC1Ev(void *self);
+extern void _ZN11RaycastLineD1Ev(void *self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(
+    void *self, Vector3 *a, Vector3 *b, void *actor);
+extern int _ZN11RaycastLine10DetectClsnEv(void *self);
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, int angle);
+extern void MulVec3Mat4x3(void *in, void *m, void *out);
+
+int func_ov077_02126300(char *c)
+{
+    RaycastLine ray1;
+    RaycastLine ray2;
+    Vector3 start;
+    Vector3 end;
+    Vector3 dir;
+    Vector3 out;
+    int y;
+
+    if (data_0209f2f8 == 0x2a) {
+        _ZN11RaycastLineC1Ev(&ray1);
+        _ZN11RaycastLineC1Ev(&ray2);
+
+        start.x = 0;
+        start.y = 0;
+        start.z = 0;
+        end.x = 0;
+        end.y = 0;
+        end.z = 0;
+        dir.x = 0;
+        dir.y = 0;
+        dir.z = 0;
+        out.x = 0;
+        out.y = 0;
+        out.z = 0;
+
+        start.x = *(int *)(c + 0x5c);
+        y = *(int *)(c + 0x60);
+        start.y = y;
+        start.z = *(int *)(c + 0x64);
+        start.y = y + 0x28000;
+        dir.z = 0xc8000;
+        Matrix4x3_FromRotationY(data_020a0e68, *(short *)(c + 0x8e));
+        MulVec3Mat4x3(&dir, data_020a0e68, &out);
+        {
+            int sx = start.x;
+            int ox = out.x;
+            int sy = start.y;
+            int sz = start.z;
+            int oy;
+            int oz;
+            end.x = sx;
+            end.x = sx + ox;
+            oy = out.y;
+            oz = out.z;
+            end.y = sy;
+            end.y = sy + oy;
+            end.z = sz;
+            end.z = sz + oz;
+        }
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(&ray1, &start, &end, c);
+
+        start.x = *(int *)(c + 0x5c);
+        y = *(int *)(c + 0x60);
+        start.y = y;
+        start.z = *(int *)(c + 0x64);
+        start.y = y + 0x28000;
+        dir.x = 0;
+        dir.y = 0;
+        dir.z = 0x2c000;
+        Matrix4x3_FromRotationY(data_020a0e68, *(short *)(c + 0x8e));
+        Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, 0x3000);
+        MulVec3Mat4x3(&dir, data_020a0e68, &out);
+        {
+            int sx = start.x;
+            int ox = out.x;
+            int sy = start.y;
+            int sz = start.z;
+            int oy;
+            int oz;
+            end.x = sx;
+            end.x = sx + ox;
+            oy = out.y;
+            oz = out.z;
+            end.y = sy;
+            end.y = sy + oy;
+            end.z = sz;
+            end.z = sz + oz;
+        }
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(&ray2, &start, &end, c);
+
+        if (_ZN11RaycastLine10DetectClsnEv(&ray1) != 0 ||
+            _ZN11RaycastLine10DetectClsnEv(&ray2) == 0) {
+            *(int *)(c + 0x5c) = *(int *)(c + 0x410);
+            *(int *)(c + 0x60) = *(int *)(c + 0x414);
+            *(int *)(c + 0x64) = *(int *)(c + 0x418);
+            *(int *)(c + 0x98) = 0;
+            _ZN11RaycastLineD1Ev(&ray2);
+            _ZN11RaycastLineD1Ev(&ray1);
+            return 1;
+        }
+        _ZN11RaycastLineD1Ev(&ray2);
+        _ZN11RaycastLineD1Ev(&ray1);
+    }
+    return 0;
+}

--- a/src/func_ov077_0212679c.c
+++ b/src/func_ov077_0212679c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=4). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 
 extern int Vec3_Dist(void *a, void *b);
@@ -37,8 +34,9 @@ int func_ov077_0212679c(char *c)
     }
 
     p = (char *)_ZN5Actor13ClosestPlayerEv(c);
-    pp = (struct Vec3 *)(p + 0x5c);
     if (p != 0) {
+        /* u64 launder forces base materialization after the null cmp */
+        pp = (struct Vec3 *)(void *)(unsigned long long)(unsigned long)(p + 0x5c);
         pv.x = pp->x;
         pv.y = pp->y;
         pv.z = pp->z;
@@ -56,11 +54,8 @@ int func_ov077_0212679c(char *c)
         *(int *)(c + 0x39c) = __aeabi_idiv(0x1000, 5 - spd / 20);
     }
 
-    if (dist <= 0x5dc000 && *(unsigned short *)(c + 0x100) != 0) {
-        if (func_ov077_02126300(c) != 0) {
-            func_ov077_02126d5c(c, data_ov077_02127cf8);
-        }
-    }
+    if (dist > 0x5dc000 || *(unsigned short *)(c + 0x100) == 0 || func_ov077_02126300(c) != 0)
+        func_ov077_02126d5c(c, data_ov077_02127cf8);
 
     return 1;
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for six ov077 (Lakitu) functions against the EU retail ROM, compiled with **mwccarm 1.2/sp2p3**.

| Function | Address | Size |
|---|---|---|
| `func_ov077_021241ac` | `0x021241ac` | `0x144` |
| `func_ov077_021243c0` | `0x021243c0` | `0x114` (`//cpp`) |
| `func_ov077_021256b4` | `0x021256b4` | `0x17c` |
| `func_ov077_02125bb4` | `0x02125bb4` | `0x220` |
| `func_ov077_02126300` | `0x02126300` | `0x228` |
| `func_ov077_0212679c` | `0x0212679c` | `0x194` |

**Flags (C):** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`  
**Flags (C++ for `//cpp`):** same with `-lang c++`

Each file was verified locally with `tools/match.py` reporting `MATCHING VERSIONS: 1.2/sp2p3`.

### Not in this PR

`_ZN6Lakitu13InitResourcesEv` (@ `0x02124908`) improved from div=10 → **div=6** but remains a pure register-coloring residual (`r1` vs `r3` for the zero temp after `WithMeshClsn_Init`). Best draft kept in scratch for the refine/permuter tier — not promoted as a false match.

## Test plan

- [x] Local `match.py` byte-identical for all six
- [ ] CI `validate` green on each `src/` file