### PR TITLE
Match 3 ov070 FlyGuy-related functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov070: _ZN6FlyGuy8BehaviorEv (0x02120210), 0211f368 (0x0211f368), 0212156c (0x0212156c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #233 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN6FlyGuy8BehaviorEv.cpp
+++ b/src/_ZN6FlyGuy8BehaviorEv.cpp
@@ -1,0 +1,95 @@
+//cpp
+struct WithMeshClsn;
+struct Enemy;
+typedef void (Enemy::*PMF)();
+struct Holder { char pad[8]; PMF fn; };
+
+extern "C" {
+extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
+extern void _ZN12CylinderClsn5ClearEv(void *thiz);
+extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
+extern void func_ov070_02120070(char *c);
+extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(Enemy *thiz, WithMeshClsn *wm);
+extern unsigned short DecIfAbove0_Short(unsigned short *p);
+extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(Enemy *thiz, void *clsn);
+extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *wm, unsigned int j);
+extern void func_ov070_0211f100(char *c);
+extern char *_ZN5Actor13ClosestPlayerEv(Enemy *thiz);
+extern void _ZN9Animation7AdvanceEv(void *thiz);
+
+extern char data_ov070_021235cc[];
+extern char data_ov070_021235bc[];
+}
+
+struct Enemy { char pad[0x800]; };
+
+extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
+{
+    char *c = (char *)thiz;
+
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+        _ZN12CylinderClsn5ClearEv(c + 0x110);
+        if (*(unsigned char *)(c + 0x107) != 0) {
+            if (*(unsigned short *)(c + 0x104) == 0) {
+                _ZN12CylinderClsn6UpdateEv(c + 0x110);
+            }
+        }
+        func_ov070_02120070(c);
+        return 1;
+    }
+
+    if (*(int *)(c + 0x10c) != 0) {
+        _ZN5Enemy11UpdateDeathER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144));
+        func_ov070_02120070(c);
+        return 1;
+    }
+
+    if (*(char **)(c + 0x3bc) != data_ov070_021235cc) {
+        DecIfAbove0_Short((unsigned short *)(c + 0x100));
+    }
+    DecIfAbove0_Short((unsigned short *)(c + 0x3cc));
+
+    {
+        Holder *q = *(Holder **)(c + 0x3bc);
+        if (q->fn != 0) {
+            (thiz->*(q->fn))();
+        }
+    }
+
+    {
+        int v = *(int *)(c + 0xa8) + *(int *)(c + 0x9c);
+        int hi = *(int *)(c + 0xa0);
+        if (v >= hi) {
+            hi = v;
+        }
+        int tmp = *(int *)(c + 0xac);
+        *(int *)(c + 0xa8) = hi;
+        *(int *)(c + 0xac) = tmp;
+    }
+
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(thiz, (void *)(c + 0x110));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+
+    if (*(char **)(c + 0x3bc) != data_ov070_021235bc) {
+        *(short *)(c + 0x8e) = *(short *)(c + 0x94);
+        *(short *)(c + 0x90) = *(short *)(c + 0x96);
+    }
+
+    func_ov070_02120070(c);
+
+    if (*(char **)(c + 0x3bc) != data_ov070_021235bc) {
+        func_ov070_0211f100(c);
+    }
+
+    _ZN12CylinderClsn5ClearEv(c + 0x110);
+    {
+        char *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
+            _ZN12CylinderClsn6UpdateEv(c + 0x110);
+        }
+    }
+
+    *(int *)(c + 0x35c) = 0x1000;
+    _ZN9Animation7AdvanceEv(c + 0x350);
+    return 1;
+}

--- a/src/func_ov070_0211f368.cpp
+++ b/src/func_ov070_0211f368.cpp
@@ -1,0 +1,31 @@
+//cpp
+typedef int Fix12i;
+struct Vector3 { int x, y, z; };
+extern "C" unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f, void* g);
+extern "C" unsigned _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f);
+extern "C" void ApproachAngle(short* v, int a, int b, int c, int d);
+extern "C" void _Z14ApproachLinearRsss(short* v, int a, int b);
+extern "C" int func_ov070_0211f0a4(void* c);
+
+extern "C" int func_ov070_0211f368(char* c)
+{
+    if (*(int*)(c + 0x3d8) != 0) {
+        Vector3 v;
+        int x, y, z;
+        x = *(int*)(c + 0x5c);
+        z = *(int*)(c + 0x64);
+        y = *(int*)(c + 0x60) + 0x50000;
+        ((int*)&v)[0] = x;
+        ((int*)&v)[1] = y;
+        ((int*)&v)[2] = z;
+        *(unsigned*)(c + 0x3d0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned*)(c + 0x3d0), 0x13a, v.x, v.y, v.z, 0, 0);
+        *(unsigned*)(c + 0x3d4) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+            *(unsigned*)(c + 0x3d4), 0x13b, v.x, v.y, v.z, 0);
+    }
+    ApproachAngle((short*)(c + 0x8c), -0x4000, 0xa, 0x200, 0x100);
+    _Z14ApproachLinearRsss((short*)(c + 0x8c), -0x4000, 0x200);
+    if (*(unsigned short*)(c + 0x100) == 0)
+        func_ov070_0211f0a4(c);
+    return 1;
+}

--- a/src/func_ov070_0212156c.c
+++ b/src/func_ov070_0212156c.c
@@ -1,0 +1,45 @@
+struct V3 { int x, y, z; };
+extern short data_02082214[];
+void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct V3 *pos, void *v16, int d, int e);
+void func_0201267c(int a, void *p);
+void func_ov070_02121880(void *c, int i);
+void _ZN9Animation7AdvanceEv(void *thiz);
+int func_ov070_02121a64(void *p);
+void func_ov070_02121298(char *c);
+void func_ov070_021211c4(char *c);
+void _ZN12CylinderClsn5ClearEv(void *thiz);
+void _ZN12CylinderClsn6UpdateEv(void *thiz);
+
+int func_ov070_0212156c(char *c){
+  if(*(int*)(c+0x398) == 0x1e){
+    struct V3 pos;
+    int idx = (int)*(unsigned short*)(c+0x8e) >> 4;
+    int s = data_02082214[idx*2+1];
+    int cn = data_02082214[idx*2];
+    int offZ = (int)(((long long)s * 0x50000 + 0x800) >> 12);
+    int offX = (int)(((long long)cn * 0x50000 + 0x800) >> 12);
+    int x = *(int*)(c+0x5c) + offX;
+    int z = *(int*)(c+0x64) + offZ;
+    int y = *(int*)(c+0x60) - 0x29000;
+    ((int*)&pos)[0] = x;
+    ((int*)&pos)[2] = z;
+    ((int*)&pos)[1] = y;
+    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x10f, 0, &pos, c+0x8c, *(signed char*)(c+0xcc), -1);
+    func_0201267c(0x105, c+0x74);
+  }
+  if(*(int*)(c+0x398) == *(int*)(c+0x394)){
+    func_ov070_02121880(c, 0);
+  }
+  _ZN9Animation7AdvanceEv(c+0x124);
+  {
+    int r = func_ov070_02121a64(c+0x38c);
+    *(int*)(c+0x80) = r;
+    *(int*)(c+0x84) = r;
+    *(int*)(c+0x88) = r;
+  }
+  func_ov070_02121298(c);
+  func_ov070_021211c4(c);
+  _ZN12CylinderClsn5ClearEv(c+0x160);
+  _ZN12CylinderClsn6UpdateEv(c+0x160);
+  return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for three ov070 FlyGuy-related functions:

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov070_0211f368` | `0x211f368` | 0xe8 | Particle System::New + ApproachAngle |
| `func_ov070_0212156c` | `0x212156c` | 0x14c | Sin-table offset Actor::Spawn |
| `FlyGuy::Behavior` | `0x2120210` | 0x1a4 | Main enemy behavior dispatcher |

## Compiler

- **mwccarm** `1.2/sp2p3`
- Flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Verification

Each file was verified locally with:

```
python tools/match.py --c <file> --func <name> --addr <addr> --size <size> --version 1.2/sp2p3 --module ov070
```

All three report `MATCHING VERSIONS: 1.2/sp2p3`.

## Matching notes

- **0211f368**: Crate-style `((int*)&v)[i]` materialization for stack Vector3 before Particle::System::New.
- **0212156c**: Plain `data_02082214[]` index + Fix12 mul + Crate-style store order x/z/y for the spawn position.
- **FlyGuy::Behavior**: Same shape as Snufit::Behavior (Yoshi-eat / death / PMF state / WMClsn); angle-copy gated on `data_ov070_021235bc`.