### PR TITLE
Match 10 ov072 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov072 10 funcs (0x0211f1dc-0x021218dc) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #235 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov072_0211f1dc.cpp
+++ b/src/func_ov072_0211f1dc.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern int _ZNK7PathPtr7GetNodeER7Vector3j(void* self, void* v, unsigned int n);
 extern int Vec3_HorzDist(void* a, void* b);
@@ -10,13 +7,16 @@ extern int _Z11UpdateAngleRssis(short* a, short b, int c, short d);
 extern int _ZNK7PathPtr8NumNodesEv(void* self);
 int func_ov072_0211f1dc(char* c){
   int v[3];
+  int *idx;
+  int n;
   _ZNK7PathPtr7GetNodeER7Vector3j(c+0x380, v, *(int*)(c+0x388));
   int d = Vec3_HorzDist(c+0x5c, v);
   _Z11UpdateAngleRssis((short*)(c+0x8e), Vec3_HorzAngle(c+0x5c, v), 2, 0x600);
   *(short*)(c+0x94) = *(short*)(c+0x8e);
   if (d < *(int*)(c+0x398)) {
-    int n = _ZNK7PathPtr8NumNodesEv(c+0x380);
-    *(int*)(c+0x388) = *(int*)(c+0x388) + 1;
+    n = _ZNK7PathPtr8NumNodesEv(c+0x380);
+    idx = (int*)(((int)c + 0x388) & 0xFFFFFFFFFFFFFFFFLL);
+    *idx = *idx + 1;
     if (*(int*)(c+0x388) >= n - 1) return 1;
   }
   return 0;

--- a/src/func_ov072_0211f65c.cpp
+++ b/src/func_ov072_0211f65c.cpp
@@ -1,0 +1,70 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" {
+int Vec3_HorzDist(const void* a, const void* b);
+short Vec3_HorzAngle(const void* a, const void* b);
+int _Z11UpdateAngleRssis(short* a, short b, int c, short d);
+void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int c);
+unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const Vector3& v, unsigned int e);
+void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* a);
+void func_0201267c(int a, void* t);
+int _ZNK12WithMeshClsn13JustHitGroundEv(void* self);
+void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, const Vector3* v, int fix);
+void func_ov072_0211f158(void* c);
+void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
+void func_ov072_0211f330(void* c, void* p);
+void func_ov072_0211f280(void* c);
+extern Vector3 data_ov072_02122b58;
+}
+
+extern "C" int func_ov072_0211f65c(unsigned char* thiz)
+{
+    unsigned char* st;
+    switch (thiz[0x3a2]) {
+    case 0:
+        {
+            int d = Vec3_HorzDist(&data_ov072_02122b58, thiz + 0x5c);
+            _Z11UpdateAngleRssis((short*)(thiz + 0x8e), Vec3_HorzAngle(thiz + 0x5c, &data_ov072_02122b58), 2, 0x600);
+            *(short*)(thiz + 0x94) = *(short*)(thiz + 0x8e);
+            _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*(int*)(thiz + 0x5c), *(int*)(thiz + 0x60), *(int*)(thiz + 0x64));
+            *(unsigned int*)(thiz + 0x39c) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+                *(unsigned int*)(thiz + 0x39c), 3, 0x8a, *(const Vector3*)(thiz + 0x74), 0);
+            if (d < 0x17c000) {
+                void* a = _ZN5Actor15FindWithActorIDEjPS_(0x111, 0);
+                *(unsigned char*)((unsigned char*)a + 0x336) = 1;
+                func_0201267c(0x114, thiz + 0x74);
+                *(int*)(thiz + 0xa8) = 0x1d000;
+                *(int*)(thiz + 0x98) = 0xe000;
+                st = (unsigned char*)(((int)thiz + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+                *st = *st + 1;
+            }
+        }
+        break;
+    case 1:
+        if (_ZNK12WithMeshClsn13JustHitGroundEv(thiz + 0x180) != 0) {
+            Vector3 v;
+            v.x = *(int*)(thiz + 0x5c);
+            v.y = *(int*)(thiz + 0x60);
+            v.z = *(int*)(thiz + 0x64);
+            _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(thiz, &v, 0x5dc000);
+            *(int*)(thiz + 0x5c) = data_ov072_02122b58.x;
+            *(int*)(thiz + 0x60) = data_ov072_02122b58.y;
+            *(int*)(thiz + 0x64) = data_ov072_02122b58.z;
+            *(short*)(thiz + 0x8c) = 0;
+            *(short*)(thiz + 0x8e) = (short)-0x4000;
+            *(int*)(thiz + 0x98) = 0;
+            st = (unsigned char*)(((int)thiz + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+            *st = *st + 1;
+        }
+        break;
+    case 2:
+    default:
+        break;
+    }
+
+    func_ov072_0211f158(thiz);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, thiz + 0x14c);
+    func_ov072_0211f330(thiz, thiz + 0x180);
+    func_ov072_0211f280(thiz);
+    return 1;
+}

--- a/src/func_ov072_0211f81c.cpp
+++ b/src/func_ov072_0211f81c.cpp
@@ -1,0 +1,59 @@
+//cpp
+typedef int Fix12;
+struct Vector3 { int x, y, z; };
+extern "C" void _Z14ApproachLinearRiii(int* p, int a, int b);
+extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
+extern "C" void func_0203568c(int *p, int v);
+extern "C" void func_02035684(int *p, int v);
+extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
+extern "C" int func_ov072_0211f1dc(char* c);
+extern "C" int func_ov072_0211f0a4(char* c);
+extern "C" void func_ov072_0211fcb0(char* c, int i);
+extern "C" void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12 a, Fix12 b, Fix12 c);
+extern "C" int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, const struct Vector3* v, unsigned e);
+extern "C" void func_ov072_0211f158(char* c);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
+extern "C" void func_ov072_0211f330(char* c, void* mc);
+extern "C" void func_ov072_0211f280(char* c);
+extern "C" int Vec3_Dist(const void* a, const void* b);
+extern const struct Vector3 data_ov072_02122b40;
+
+extern "C" int func_ov072_0211f81c(char* c) {
+    int t;
+    int v;
+    _Z14ApproachLinearRiii((int*)(c+0x98), 0x28000, 0x400);
+    if (DecIfAbove0_Short((unsigned short*)(c+0x3a0)) == 0) {
+        t = *(int*)(c+0x80);
+        _Z14ApproachLinearRiii(&t, 0x1800, 0x11);
+        v = t;
+        *(int*)(c+0x80) = v;
+        *(int*)(c+0x84) = v;
+        *(int*)(c+0x88) = v;
+        /* reload t from stack for mul (matches ROM: str x3 then ldr for umull) */
+        *(int*)(c+0x398) = (int)(((long long)t * 0x82000 + 0x800) >> 12);
+        *(int*)(c+0x150) = *(int*)(c+0x398);
+        *(int*)(c+0x154) = *(int*)(c+0x398) << 1;
+        func_0203568c((int*)(c+0x180), *(int*)(c+0x398));
+        func_02035684((int*)(c+0x180), *(int*)(c+0x398));
+        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, *(int*)(c+0x398), *(int*)(c+0x398), 0x1000000, 0x1000000);
+    }
+    if (func_ov072_0211f1dc(c) != 0) {
+        if (*(unsigned char*)(c+0x3a3) != 0 && func_ov072_0211f0a4(c) != 0) {
+            func_ov072_0211fcb0(c, 3);
+        } else {
+            func_ov072_0211fcb0(c, 4);
+        }
+    }
+    _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
+    *(int*)(c+0x39c) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned*)(c+0x39c), 3, 0x8a, (const struct Vector3*)(c+0x74), 0);
+    func_ov072_0211f158(c);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x14c);
+    func_ov072_0211f330(c, c+0x180);
+    func_ov072_0211f280(c);
+    if (*(unsigned char*)(c+0x3a3) == 0) {
+        if (Vec3_Dist(&data_ov072_02122b40, *(char**)(c+0x390) + 0x5c) < 0x300000) {
+            *(unsigned char*)(c+0x3a3) = 1;
+        }
+    }
+    return 1;
+}

--- a/src/func_ov072_0211fa08.cpp
+++ b/src/func_ov072_0211fa08.cpp
@@ -1,14 +1,12 @@
 //cpp
-// NONMATCHING: push-set / frame (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(int, void*, int, void*, int, int);
 int _ZN6Player12GetTalkStateEv(void*);
 unsigned short DecIfAbove0_Short(unsigned short* p);
 int func_ov072_0211fcb0(void*, int);
-void func_ov072_0211fa08(char* c){
+int func_ov072_0211fa08(char* c){
   int v[3];
+  unsigned char *st;
   v[0] = *(int*)(c+0x5c);
   int y = *(int*)(c+0x60);
   v[1] = y;
@@ -17,11 +15,13 @@ void func_ov072_0211fa08(char* c){
   switch(*(unsigned char*)(c+0x3a2)){
   case 0:
     if(_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(int*)(c+0x390), c, 0xb0, v, 0, 0) == 0) break;
-    (*(unsigned char*)(c+0x3a2))++;
+    st = (unsigned char*)(((int)c + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+    *st = *st + 1;
     break;
   case 1:
     if(_ZN6Player12GetTalkStateEv((void*)*(int*)(c+0x390)) != -1) break;
-    (*(unsigned char*)(c+0x3a2))++;
+    st = (unsigned char*)(((int)c + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+    *st = *st + 1;
     break;
   case 2:
     if(DecIfAbove0_Short((unsigned short*)(c+0x3a0)) == 0){
@@ -29,5 +29,6 @@ void func_ov072_0211fa08(char* c){
     }
     break;
   }
+  return 1;
 }
 }

--- a/src/func_ov072_0211fb7c.c
+++ b/src/func_ov072_0211fb7c.c
@@ -1,11 +1,9 @@
-// NONMATCHING: base materialization / addressing (div=3). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 void func_0203568c(int *p, int v);
 void func_02035684(int *p, int v);
 void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *thiz, int a, int b, int c, int d);
 
 int func_ov072_0211fb7c(char *c) {
+    int *p;
     *(int*)(c + 0x9c) = 0;
     *(int*)(c + 0xa0) = 0;
     *(int*)(c + 0x80) = 0x800;
@@ -17,10 +15,8 @@ int func_ov072_0211fb7c(char *c) {
     func_0203568c((int*)(c + 0x180), *(int*)(c + 0x398));
     func_02035684((int*)(c + 0x180), *(int*)(c + 0x398));
     _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, *(int*)(c + 0x398), *(int*)(c + 0x398), 0x1000000, 0x1000000);
-    {
-        volatile int *p = (volatile int*)(c + 0xb0);
-        *p = *p | 1;
-    }
+    p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+    *p = *p | 1;
     *(int*)(c + 0x394) = 0;
     return 1;
 }

--- a/src/func_ov072_0212001c.c
+++ b/src/func_ov072_0212001c.c
@@ -1,0 +1,57 @@
+struct Vec3 { int x, y, z; };
+extern void *_ZN5Actor13ClosestPlayerEv(void *self);
+extern int Vec3_HorzDist(void *a, void *b);
+extern int _ZN6Player9StartTalkER9ActorBaseb(void *player, void *actor, int b);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *player, void *actor, unsigned msg, const void *pos, unsigned a, unsigned b);
+extern int _ZN6Player12GetTalkStateEv(void *player);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned id, unsigned param, const void *pos, const void *ang, int a, int b);
+extern void _ZN9Animation7AdvanceEv(void *anim);
+extern int _Z14ApproachLinearRsss(short *p, short to, short step);
+
+int func_ov072_0212001c(char *c)
+{
+    struct Vec3 v;
+    unsigned char *st;
+    unsigned int param;
+    v.x = *(int *)(c + 0x5c);
+    v.y = *(int *)(c + 0x60);
+    v.z = *(int *)(c + 0x64);
+    v.y = v.y + 0x1c2000;
+    switch (*(unsigned char *)(c + 0x334)) {
+    case 0:
+        *(void **)(c + 0x32c) = _ZN5Actor13ClosestPlayerEv(c);
+        if (Vec3_HorzDist(c + 0x5c, *(char **)(c + 0x32c) + 0x5c) < 0x118000) {
+            if (_ZN6Player9StartTalkER9ActorBaseb(*(void **)(c + 0x32c), c, 1)) {
+                st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+                *st = *st + 1;
+            }
+        }
+        break;
+    case 1:
+        if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void **)(c + 0x32c), c, 0xb1, &v, 0, 2)) {
+            st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            *st = *st + 1;
+        }
+        break;
+    case 2:
+        if (_ZN6Player12GetTalkStateEv(*(void **)(c + 0x32c)) == -1) {
+            param = *(int *)(c + 8) & 0xf;
+            param = param & 0xff;
+            param = param | 0x40;
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0xb2,
+                param,
+                c + 0x5c,
+                0,
+                *(signed char *)(c + 0xcc),
+                -1);
+            st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            *st = *st + 1;
+        }
+        break;
+    }
+    _ZN9Animation7AdvanceEv(c + 0x124);
+    _Z14ApproachLinearRsss((short *)(c + 0x8e), (short)-0x4000, 0x514);
+    *(int *)(c + 0x60) = (int)0xffc427c0;
+    return 1;
+}

--- a/src/func_ov072_021201d4.c
+++ b/src/func_ov072_021201d4.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=15). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int Fix12i;
 struct Vector3 { int x, y, z; };
 
@@ -15,6 +12,7 @@ extern void func_ov072_021205d4(void *self, int a);
 int func_ov072_021201d4(char *self)
 {
     struct Vector3 v;
+    unsigned char *st;
     switch (*(unsigned char *)(self + 0x334))
     {
     case 0:
@@ -29,7 +27,8 @@ int func_ov072_021201d4(char *self)
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x10f, *(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x110, *(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
             _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x15666, 0);
-            ++*(unsigned char *)(self + 0x334);
+            st = (unsigned char *)(((int)self + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            *st = *st + 1;
         }
         break;
     case 1:

--- a/src/func_ov072_02120358.c
+++ b/src/func_ov072_02120358.c
@@ -1,0 +1,33 @@
+struct Vec3 { int x, y, z; };
+extern short Vec3_HorzAngle(const void* a, const void* b);
+extern int _Z14ApproachLinearRsss(short* p, short to, short step);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const void* pos, unsigned int a, unsigned int b);
+extern int _ZN6Player12GetTalkStateEv(void* self);
+extern void func_ov072_021205d4(void* c, int a);
+
+int func_ov072_02120358(char* c)
+{
+    struct Vec3 v;
+    unsigned char *st;
+    switch (*(unsigned char*)(c + 0x334)) {
+    case 0:
+        if (_Z14ApproachLinearRsss((short*)(c + 0x8e),
+                Vec3_HorzAngle(c + 0x5c, *(char**)(c + 0x32c) + 0x5c), 0x514)) {
+            v.x = *(int*)(c + 0x5c);
+            v.y = *(int*)(c + 0x60);
+            v.z = *(int*)(c + 0x64);
+            v.y = v.y + 0xfa000;
+            if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void**)(c + 0x32c), c, 0xaf, &v, 0, 0)) {
+                st = (unsigned char*)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+                *st = *st + 1;
+            }
+        }
+        break;
+    case 1:
+        if (_ZN6Player12GetTalkStateEv(*(void**)(c + 0x32c)) == -1) {
+            func_ov072_021205d4(c, 0);
+        }
+        break;
+    }
+    return 1;
+}

--- a/src/func_ov072_021217ac.cpp
+++ b/src/func_ov072_021217ac.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=8). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vector3 { int x, y, z; };
 class Actor;
 extern "C" int func_ov072_02121d50(Actor *a);
@@ -12,30 +9,34 @@ extern void _ZN12CylinderClsn5ClearEv(void *clsn);
 extern "C" int func_ov072_021217ac(Actor *thiz)
 {
     char *c = (char *)thiz;
-    char *p = *(char **)(c + 0x360);
-    short h = *(short *)(p + 0x8e);
+    short h = *(short *)(*(char **)(c + 0x360) + 0x8e);
     *(short *)(c + 0x8e) = h;
     *(short *)(c + 0x94) = *(short *)(c + 0x8e);
     int flags = *(int *)(c + 0xb0);
     int b1 = (int)((flags & 0x100) != 0);
-    int skip = 0;
     if (b1 != 0) {
         int b2 = (int)((flags & 0x2000) != 0);
-        if (b2 == 0) skip = 1;
+        if (b2 == 0) goto after_ray;
     }
-    if (!skip) {
+    {
         char *q = *(char **)(c + 0x360);
+        Vector3 v;
         int y = *(int *)(q + 0x60);
         int z = *(int *)(q + 0x64);
+        /* demand x first into a live, then y+ so first-demanded gets higher reg (ip) */
         int x = *(int *)(q + 0x5c);
-        Vector3 v;
+        int y2 = y + 0x32000;
         v.x = x;
-        v.y = y + 0x32000;
+        v.y = y2;
         v.z = z;
         _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(thiz, v, *(Vector3 *)(c + 0x5c), true);
-        *(int *)(c + 0x360) = 0;
+        {
+            int z0 = 0;
+            *(int *)(c + 0x360) = z0;
+            func_ov072_02121d50(thiz);
+        }
     }
-    func_ov072_02121d50(thiz);
+after_ray:
     _ZN9Animation7AdvanceEv(c + 0x124);
     _ZN12CylinderClsn5ClearEv(c + 0x160);
     if (*(int *)(c + 8) == 0) {

--- a/src/func_ov072_021218dc.cpp
+++ b/src/func_ov072_021218dc.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: missing logic (ROM does more) (div=37). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int Fix12i;
 extern "C" int _ZN9Animation8FinishedEv(void* a);
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* ma, void* f, int b, Fix12i c, unsigned int d);
@@ -24,15 +21,16 @@ extern "C" int func_ov072_021218dc(char* self){
     if(_ZN9Animation8FinishedEv(self+0x124)){
       _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self+0xd4, data_ov072_02122cac[1], 0, 0x1000, 0);
       *(int*)(self+0x130)=0x1000;
-      pb=(unsigned char*)(self+0x36e); (*pb)++;
+      pb=(unsigned char*)(((int)self+0x36e) & 0xFFFFFFFFFFFFFFFFLL); (*pb)++;
     }
     break;
   case 1:
-    pi=(int*)(self+0x98); *pi -= 0x3000;
+    pi=(int*)(((int)self+0x98) & 0xFFFFFFFFFFFFFFFFLL);
+    *pi = *pi - 0x3000;
     if(*(int*)(self+0x98) < 0){
       _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self+0xd4, data_ov072_02122ca4[1], 0x40000000, 0x1000, 0);
       *(int*)(self+0x98)=0;
-      pb=(unsigned char*)(self+0x36e); (*pb)++;
+      pb=(unsigned char*)(((int)self+0x36e) & 0xFFFFFFFFFFFFFFFFLL); (*pb)++;
     }
     break;
   case 2:


### PR DESCRIPTION
## Summary

Byte-matched **10** ov072 functions against EU retail (ASMP) using **mwccarm 1.2/sp2p3** with the standard flags:

`-O4,p -enum int -lang c99` / `//cpp` C++ path `-char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

| Function | Address | Size |
|---|---|---|
| `func_ov072_0211fb7c` | `0x211fb7c` | `0xc0` |
| `func_ov072_0211f1dc` | `0x211f1dc` | `0xa4` |
| `func_ov072_0211fa08` | `0x211fa08` | `0xe8` |
| `func_ov072_0211f65c` | `0x211f65c` | `0x1a8` |
| `func_ov072_0211f81c` | `0x211f81c` | `0x1a8` |
| `func_ov072_0212001c` | `0x212001c` | `0x164` |
| `func_ov072_021201d4` | `0x21201d4` | `0x134` |
| `func_ov072_02120358` | `0x2120358` | `0xd8` |
| `func_ov072_021217ac` | `0x21217ac` | `0xe4` |
| `func_ov072_021218dc` | `0x21218dc` | `0x14c` |

Each file was verified locally with `tools/match.py --version 1.2/sp2p3 --module ov072` reporting `MATCHING VERSIONS: 1.2/sp2p3`.

### Matching notes

- **u64-mask laundering** (`((int)base + off) & 0xFFFFFFFFFFFFFFFFLL`) for materialized byte-increment and flag RMW bases
- **store-then-reload** of a stack `ApproachLinear` local before the Fix12 scale multiply (`f81c`)
- **statement demand order** for DetectRaycast vector temps (`217ac` ip/lr coloring)
- Correct nesting: raycast + clear + `func_ov072_02121d50` share one branch (`217ac`)

### Not in this PR

Two remaining claimed targets are still near-misses (left for refine):
- `__sinit_ov072_02122414` @ `0x2122414` — S12 tail regalloc (div=12)
- `func_ov072_02121368` @ `0x2121368` — sin/cos offset draft incomplete

## Test plan

- [x] Local `tools/match.py` MATCH for each of the 10 files (1.2/sp2p3, `--module ov072`)
- [ ] CI `validate` green on this PR