### PR TITLE
Match 3 ov005 menu helpers byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov005: 020c0140 (0x020c0140), 020c0878 (0x020c0878), 020c14a0 (0x020c14a0) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #236 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov005_020c0140.c
+++ b/src/func_ov005_020c0140.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern int* data_0209f5bc[];
 extern unsigned char data_0209b304[];
@@ -17,8 +14,7 @@ void func_ov005_020c0140(char* c) {
     if (*(int*)(c + 0x98) > 0) return;
     if (data_0209b304[0] == 0) {
         if (*(int*)(c + 0x50) >= 0) {
-            int* p = (int*)(c + 0x50);
-            *p -= 8;
+            *(int*)(((int)c + 0x50) & 0xFFFFFFFFFFFFFFFFULL) -= 8;
             if (*(int*)(c + 0x50) <= 0) {
                 *(int*)(c + 0x50) = 0;
                 *(unsigned char*)(c + 0x54) = 0;
@@ -26,8 +22,7 @@ void func_ov005_020c0140(char* c) {
         }
     } else {
         if (*(int*)(c + 0x50) <= 0xb0) {
-            int* p = (int*)(c + 0x50);
-            *p += 8;
+            *(int*)(((int)c + 0x50) & 0xFFFFFFFFFFFFFFFFULL) += 8;
             if (*(int*)(c + 0x50) >= 0xb0) {
                 *(int*)(c + 0x50) = 0xb0;
                 *(unsigned char*)(c + 0x54) = 0;

--- a/src/func_ov005_020c0878.c
+++ b/src/func_ov005_020c0878.c
@@ -1,0 +1,104 @@
+//cpp
+extern "C" {
+extern void* data_0209f5bc;
+extern int data_0208a170;
+extern unsigned char data_020a0e40;
+extern unsigned char data_020a0de8[];
+extern unsigned char data_020a0de9[];
+extern int data_ov005_020c2250[];
+void func_ov005_020c16e4(void* sl);
+void func_02012790(int idx);
+
+void func_ov005_020c0878(char* sl)
+{
+    void* g = data_0209f5bc;
+    int (**vt)(void*) = *(int(***)(void*))g;
+    if (vt[5](g) == 0)
+        return;
+    if (*(unsigned char*)(sl + 0xac) != 0)
+        return;
+    if (*(unsigned char*)(sl + 0x54) == 1)
+        return;
+    if (*(int*)(sl + 0x90) > 0)
+        return;
+    if (*(int*)(sl + 0x94) > 0)
+        return;
+    if (*(int*)(sl + 0x98) > 0)
+        return;
+
+    if (*(int*)(sl + 0xa0) > 0) {
+        int* pa0 = (int*)(((int)sl + 0xa0) & 0xFFFFFFFFFFFFFFFFULL);
+        *pa0 = *pa0 - 1;
+        if (*(int*)(sl + 0xa0) == 0) {
+            int f58 = *(int*)(sl + 0x58);
+            if (f58 != data_0208a170) {
+                data_0208a170 = f58;
+                func_ov005_020c16e4(sl);
+                *(int*)(sl + 0xa0) = 0x1e;
+            }
+        }
+    }
+
+    {
+        int flag = 0;
+        unsigned char idx = data_020a0e40;
+        unsigned char v = data_020a0de8[idx * 4];
+        if (v != 0) {
+            if (data_020a0de9[idx * 4] != 0)
+                flag = 1;
+        }
+        if (flag != 0 || (*(int*)(sl + 0xa0) <= 0 && v != 0)) {
+            int i = 0;
+            int lo = 2;
+            int hi = 0x2e;
+            int z = 0;
+            int t = 0x1e;
+            do {
+                int e = data_ov005_020c2250[i];
+                if (data_0208a170 != e) {
+                    unsigned char ix = data_020a0e40;
+                    unsigned char* p = data_020a0de8 + (ix * 4);
+                    if (p[2] <= 0x30 && p[3] >= lo && p[3] <= hi) {
+                        data_0208a170 = e;
+                        *(int*)(sl + 0x58) = e;
+                        func_02012790(z);
+                        func_ov005_020c16e4(sl);
+                        *(int*)(sl + 0xa0) = t;
+                    }
+                }
+                i++;
+                lo += 0x30;
+                hi += 0x30;
+            } while (i < 4);
+            return;
+        }
+
+        if (*(int*)(sl + 0xa0) <= 0)
+            return;
+        if (v == 0)
+            return;
+        {
+            int i = 0;
+            int lo = 2;
+            int hi = 0x2e;
+            int z = 0;
+            int t = 0x1e;
+            do {
+                int e = data_ov005_020c2250[i];
+                if (*(int*)(sl + 0x58) != e) {
+                    unsigned char ix = data_020a0e40;
+                    unsigned char* p = data_020a0de8 + (ix * 4);
+                    if (p[2] <= 0x30 && p[3] >= lo && p[3] <= hi) {
+                        *(int*)(sl + 0x58) = e;
+                        func_02012790(z);
+                        *(int*)(sl + 0xa0) = t;
+                    }
+                }
+                i++;
+                lo += 0x30;
+                hi += 0x30;
+            } while (i < 4);
+        }
+    }
+}
+}

--- a/src/func_ov005_020c14a0.c
+++ b/src/func_ov005_020c14a0.c
@@ -1,6 +1,4 @@
-// NONMATCHING: push-set / frame (div=45). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 extern int func_02012790(int);
 extern int func_ov005_020bff4c(char* c);
 extern int RandomIntInternal(int* seed);
@@ -21,7 +19,7 @@ extern int data_0209e650;
 extern unsigned char data_0209b304;
 
 int func_ov005_020c14a0(char* c) {
-    if ((data_020a0e5a[(&data_020a0e40)[0]<<1] & 0xfff) != 0) {
+    if ((data_020a0e5a[data_020a0e40 << 1] & 0xfff) != 0) {
         func_02012790(0xe);
     }
     if (data_0209b300 == 1) {
@@ -32,40 +30,36 @@ int func_ov005_020c14a0(char* c) {
     RandomIntInternal(&data_0209e650);
 
     if (*(int*)(c+0x90) > 0) {
-        int* p = (int*)(c+0x90);
-        *p = *p - 1;
+        *(int*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
         if (*(int*)(c+0x90) == 0) {
             data_0209b304 = 0;
             *(unsigned char*)(c+0x54) = 1;
         }
     } else if (*(int*)(c+0x94) > 0) {
-        int* p = (int*)(c+0x94);
-        *p = *p - 1;
+        *(int*)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
         if (*(int*)(c+0x94) == 0) {
             data_0209b304 = 1;
             *(unsigned char*)(c+0x54) = 1;
         }
     } else if (*(int*)(c+0x98) > 1) {
-        int* p = (int*)(c+0x98);
-        *p = *p - 1;
+        *(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
         if (*(int*)(c+0x98) == 1) {
             _ZN5Scene20SetAndStopColorFaderEv();
             ExitMinigameMenu();
             _ZN5Sound22StopLoadedMusic_Layer1Ej(0x1e);
             *(unsigned char*)(c+0xac) = 1;
+            return 1;
         }
     } else {
-        int* p8c = (int*)(c+0x8c);
-        int* p9c = (int*)(c+0x9c);
-        *p8c = *p8c + 1;
+        *(int*)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFFULL) += 1;
         if (*(int*)(c+0x8c) >= 0x40) *(int*)(c+0x8c) = 0;
-        *p9c = *p9c + 1;
+        *(int*)(((int)c + 0x9c) & 0xFFFFFFFFFFFFFFFFULL) += 1;
         if (*(int*)(c+0x9c) >= 0x40) *(int*)(c+0x9c) = 0;
-        func_ov005_020c0878(c);
-        func_ov005_020c06cc(c);
-        func_ov005_020c0378(c);
-        func_ov005_020c0250(c);
-        func_ov005_020c0140(c);
     }
+    func_ov005_020c0878(c);
+    func_ov005_020c06cc(c);
+    func_ov005_020c0378(c);
+    func_ov005_020c0250(c);
+    func_ov005_020c0140(c);
     return 1;
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for three related ov005 minigame/menu helpers (mwccarm **1.2/sp2p3**):

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov005_020c0140` | `0x20c0140` | `0x110` | Upgrades prior NONMATCHING; u64-mask launder for `add`+RMW on `this+0x50` |
| `func_ov005_020c14a0` | `0x20c14a0` | `0x1b4` | Upgrades prior NONMATCHING; countdown paths fall into shared call chain |
| `func_ov005_020c0878` | `0x20c0878` | `0x288` | New; dual selection loops with do-while induction |

## Verify

```sh
python tools/match.py --c src/func_ov005_020c0140.c --func func_ov005_020c0140 --addr 0x20c0140 --size 0x110 --version 1.2/sp2p3 --module ov005 --flags "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
python tools/match.py --c src/func_ov005_020c14a0.c --func func_ov005_020c14a0 --addr 0x20c14a0 --size 0x1b4 --version 1.2/sp2p3 --module ov005
python tools/match.py --c src/func_ov005_020c0878.c --func func_ov005_020c0878 --addr 0x20c0878 --size 0x288 --version 1.2/sp2p3 --module ov005 --flags "-O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
```

All three report `MATCHING VERSIONS: 1.2/sp2p3`.

## Still in progress (claimed, not in this PR)

- `func_ov005_020c0b04` (size-exact near-miss, ~32 schedule/reg diffs)
- `func_ov005_020c0378`, `func_ov005_020c1130`, `func_ov005_020c16e4`