### PR TITLE
Match 6 ov030 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov030: _ZN9UkikiCage13InitResourcesEv (0x02111638), _ZN9UkikiCage16CleanupResourcesEv (0x02111610), _ZN9UkikiCage8BehaviorEv (0x02111624), 02111b20 (0x02111b20), 02112da0 (0x02112da0), 02113094 (0x02113094) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #237 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN9UkikiCage13InitResourcesEv.c
+++ b/src/_ZN9UkikiCage13InitResourcesEv.c
@@ -1,0 +1,11 @@
+// Long-branch veneer: load absolute target into ip and data arg into r1, then bx ip.
+extern void func_ov080_021274ac(void);
+extern void *data_ov030_02115a04;
+asm void _ZN9UkikiCage13InitResourcesEv(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_ov080_021274ac
+    dcd data_ov030_02115a04
+}

--- a/src/_ZN9UkikiCage16CleanupResourcesEv.c
+++ b/src/_ZN9UkikiCage16CleanupResourcesEv.c
@@ -1,0 +1,11 @@
+// Long-branch veneer: load absolute target into ip and data arg into r1, then bx ip.
+extern void func_ov080_021270dc(void);
+extern void *data_ov030_02115a04;
+asm void _ZN9UkikiCage16CleanupResourcesEv(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_ov080_021270dc
+    dcd data_ov030_02115a04
+}

--- a/src/_ZN9UkikiCage8BehaviorEv.c
+++ b/src/_ZN9UkikiCage8BehaviorEv.c
@@ -1,0 +1,11 @@
+// Long-branch veneer: load absolute target into ip and data arg into r1, then bx ip.
+extern void func_ov080_0212714c(void);
+extern void *data_ov030_021159f4;
+asm void _ZN9UkikiCage8BehaviorEv(void)
+{
+    ldr ip, [pc, #4]
+    ldr r1, [pc, #4]
+    bx ip
+    dcd func_ov080_0212714c
+    dcd data_ov030_021159f4
+}

--- a/src/func_ov030_02111b20.c
+++ b/src/func_ov030_02111b20.c
@@ -1,6 +1,3 @@
-// NONMATCHING: register allocation (div=20). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef short s16;
 struct Vector3 { int x, y, z; };
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, struct Vector3* v, unsigned int i);
@@ -12,13 +9,19 @@ extern int _ZNK7PathPtr8NumNodesEv(void* self);
 int func_ov030_02111b20(char* c) {
   struct Vector3 v;
   int d;
+  s16 ang;
+  int *p;
+  int n;
   _ZNK7PathPtr7GetNodeER7Vector3j(c+0x398, &v, *(unsigned int*)(c+0x3a0));
   d = Vec3_HorzDist((struct Vector3*)(c+0x5c), &v);
-  _Z11UpdateAngleRssis((short*)(c+0x8e), Vec3_HorzAngle((struct Vector3*)(c+0x5c), &v), 2, 0x400);
+  ang = Vec3_HorzAngle((struct Vector3*)(c+0x5c), &v);
+  _Z11UpdateAngleRssis((short*)(c+0x8e), ang, 2, 0x400);
   *(s16*)(c+0x94) = *(s16*)(c+0x8e);
   if (d < *(int*)(c+0x98)) {
-    int n = _ZNK7PathPtr8NumNodesEv(c+0x398) - 1;
-    *(int*)(c+0x3a0) = *(int*)(c+0x3a0) + 1;
+    n = _ZNK7PathPtr8NumNodesEv(c+0x398);
+    p = (int*)((long long)(int)(c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+    n = n - 1;
+    *p = *p + 1;
     if (*(int*)(c+0x3a0) >= n) return 1;
   }
   return 0;

--- a/src/func_ov030_02112da0.c
+++ b/src/func_ov030_02112da0.c
@@ -1,0 +1,91 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern void func_ov030_021141a8(void *a, int m);
+extern int Vec3_Dist(void *a, void *b);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *a, void *self, unsigned int, void *, unsigned int, unsigned int);
+extern void func_0201267c(int, void *);
+extern int _ZN6Player12GetTalkStateEv(void *p);
+extern void _ZN6Player9DropActorEv(void *p);
+extern u8 DecIfAbove0_Byte(u8 *p);
+extern u8 data_0209d684;
+
+int func_ov030_02112da0(char *a) {
+    int b = (int)((*(u32 *)(a + 0xb0) & 0x40000) != 0);
+    if (b != 0) {
+        int p = (int)((long long)(int)(*(char **)(a + 0x3a8) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(a + 0x5c) = *(int *)p;
+        *(int *)(a + 0x60) = *(int *)(p + 4);
+        *(int *)(a + 0x64) = *(int *)(p + 8);
+    }
+
+    {
+        u32 flags = *(u32 *)(a + 0xb0);
+        b = (int)((flags & 0x80000) != 0);
+        if (b != 0) {
+            *(int *)(a + 0x3b8) = 1;
+            func_ov030_021141a8(a, 7);
+            return 1;
+        }
+
+        switch (*(u8 *)(a + 0x3c7)) {
+        case 0: {
+            int b2 = (int)((flags & 0x40000) != 0);
+            if (b2 != 0) {
+                char *s = *(char **)(a + 0x3a8);
+                int off = 0x3c7;
+                int *p = (int *)((long long)(int)(s + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                int x = *p;
+                u8 *st = (u8 *)(((int)a + off) & 0xFFFFFFFFFFFFFFFFLL);
+                *(int *)(a + 0x5c) = x;
+                *(int *)(a + 0x60) = p[1];
+                *(int *)(a + 0x64) = p[2];
+                (*st)++;
+            } else {
+                int b3 = (int)((flags & 0x20000) != 0);
+                if (b3 != 0) break;
+                if (b2 != 0) break;
+                *(int *)(a + 0xd0) = 0;
+                func_ov030_021141a8(a, *(int *)(a + 0x3b8));
+            }
+            break;
+        }
+        case 1:
+            if (Vec3_Dist(a + 0x380, a + 0x5c) < 0x514000 &&
+                *(int *)(a + 0x60) > *(int *)(a + 0x384) - 0x12c000) {
+                if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(char **)(a + 0x3a8), a, 0xc1, 0, 0, 0) != 0) {
+                    func_0201267c(0xd1, a + 0x74);
+                    (*(u8 *)(((int)a + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+                }
+            }
+            {
+                char *s = *(char **)(a + 0x3a8);
+                u8 val = 0x3c;
+                int *p = (int *)((long long)(int)(s + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                *(int *)(a + 0x5c) = *p;
+                *(int *)(a + 0x60) = p[1];
+                *(int *)(a + 0x64) = p[2];
+                *(u8 *)(a + 0x3c6) = val;
+            }
+            break;
+        case 2:
+            if (_ZN6Player12GetTalkStateEv(*(char **)(a + 0x3a8)) == -1) {
+                u8 g = data_0209d684;
+                if (g == 1) {
+                    _ZN6Player9DropActorEv(*(char **)(a + 0x3a8));
+                    *(int *)(a + 0x3b8) = 8;
+                    func_ov030_021141a8(a, 7);
+                } else if (g == 2) {
+                    (*(u8 *)(((int)a + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+                }
+            }
+            break;
+        case 3:
+            if (DecIfAbove0_Byte((u8 *)(((int)a + 0x3c6) & 0xFFFFFFFFFFFFFFFFLL)) == 0) {
+                *(u8 *)(a + 0x3c7) = 1;
+            }
+            break;
+        }
+    }
+    return 1;
+}

--- a/src/func_ov030_02113094.c
+++ b/src/func_ov030_02113094.c
@@ -1,0 +1,91 @@
+typedef signed char s8;
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Actor;
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { s16 x, y, z; };
+
+extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
+extern void func_ov030_021141a8(char* self, int a);
+extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(char* p, char* self, u32 msg, const struct Vector3* pos, u32 a, u32 b);
+extern void func_0201267c(u32 id, char* p);
+extern int _ZN6Player12GetTalkStateEv(char* p);
+extern void _ZN6Player9DropActorEv(char* p);
+extern struct Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 param, const struct Vector3* pos, const struct Vector3_16* rot, int a, int b);
+extern void _ZN9ActorBase18MarkForDestructionEv(char* self);
+
+int func_ov030_02113094(char* self)
+{
+    {
+        int b = (int)((*(u32*)(self + 0xb0) & 0x40000) != 0);
+        if (b != 0) {
+            int p = (int)((((int)*(char**)(self + 0x3a8)) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            *(int*)(self + 0x5c) = *(int*)p;
+            *(int*)(self + 0x60) = *(int*)(p + 4);
+            *(int*)(self + 0x64) = *(int*)(p + 8);
+        }
+    }
+
+    switch (*(u8*)(self + 0x3c7)) {
+    case 0: {
+        int b2 = (int)((*(u32*)(self + 0xb0) & 0x40000) != 0);
+        if (b2 != 0) {
+            if (*(u8*)(self + 0x3c8) != 0) {
+                struct Actor* a = _ZN5Actor10FindWithIDEj(*(u32*)(self + 0x3ac));
+                *(char**)((char*)a + 0xd0) = *(char**)(self + 0x3a8);
+                *(u32*)(((int)a + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40000;
+            }
+            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+        } else {
+            int b3 = (int)((*(u32*)(self + 0xb0) & 0x20000) != 0);
+            if (b3 != 0) break;
+            if (b2 != 0) break;
+            *(int*)(self + 0xd0) = 0;
+            func_ov030_021141a8(self, *(int*)(self + 0x3b8));
+        }
+        break;
+    }
+    case 1: {
+        int msg = (*(u8*)(self + 0x3c8) != 0) ? 0xc2 : 0xc3;
+        if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(char**)(self + 0x3a8), self, (s16)msg, 0, 0, 0) != 0) {
+            func_0201267c(0xd1, self + 0x74);
+            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        {
+            int b4 = (int)((*(u32*)(self + 0xb0) & 0x80000) != 0);
+            if (b4 != 0) {
+                func_ov030_021141a8(self, 7);
+            }
+        }
+        break;
+    }
+    case 2:
+        if (_ZN6Player12GetTalkStateEv(*(char**)(self + 0x3a8)) == -1) {
+            _ZN6Player9DropActorEv(*(char**)(self + 0x3a8));
+            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    case 3: {
+        int b5 = (int)((*(u32*)(self + 0xb0) & 0x80000) != 0);
+        if (b5 != 0) {
+            if (*(u8*)(self + 0x3c8) != 0) {
+                _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x10d, (*(u32*)(self + 0x3b0) << 8) | 5, (struct Vector3*)(*(char**)(self + 0x3a8) + 0x5c), 0, *(s8*)(self + 0xcc), -1);
+                _ZN9ActorBase18MarkForDestructionEv((char*)_ZN5Actor10FindWithIDEj(*(u32*)(self + 0x3ac)));
+                {
+                    u32 z = 0;
+                    *(u32*)(self + 0x3ac) = z;
+                    *(u8*)(self + 0x3c8) = (u8)z;
+                    *(int*)(self + 0x3b8) = 0xa;
+                }
+            }
+            func_ov030_021141a8(self, 7);
+        }
+        break;
+    }
+    }
+
+    return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for six ov030 functions (mwccarm **1.2/sp2p3**, flags `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).

| Function | Addr | Size | Notes |
|---|---|---|---|
| `_ZN9UkikiCage16CleanupResourcesEv` | 0x02111610 | 0x14 | long-branch veneer → `func_ov080_021270dc` |
| `_ZN9UkikiCage8BehaviorEv` | 0x02111624 | 0x14 | long-branch veneer → `func_ov080_0212714c` |
| `_ZN9UkikiCage13InitResourcesEv` | 0x02111638 | 0x14 | long-branch veneer → `func_ov080_021274ac` |
| `func_ov030_02111b20` | 0x02111b20 | 0xa4 | path follow; `ll` u64-mask on node index ptr |
| `func_ov030_02112da0` | 0x02112da0 | 0x258 | talk/state machine |
| `func_ov030_02113094` | 0x02113094 | 0x240 | cap-related state machine |

Verified locally with:
```
python tools/match.py --c src/<file> --func <name> --addr <addr> --size <size> --version 1.2/sp2p3 --module ov030
```
all report `MATCHING VERSIONS: 1.2/sp2p3`.

## Remaining from this batch (not in this PR)

Still open after real effort (near-misses / hard targets): `func_ov030_02112578` (div≈3 pool-load reg order), `func_ov030_02112400`, `func_ov030_02113324`, `func_ov030_02112c14`, `func_ov030_021136b0`. Claims held; not released for the matched set.

## Test plan

- [x] Local `tools/match.py` MATCH on each of the six files
- [ ] CI `validate` green on the six `src/` additions