### PR TITLE
Match 2 ov071 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov071: 0211f8d0 (0x0211f8d0), 0212070c (0x0212070c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #238 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov071_0211f8d0.cpp
+++ b/src/func_ov071_0211f8d0.cpp
@@ -1,0 +1,87 @@
+//cpp
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void* self, Vector3* a, Vector3* out, int doStore);
+void _ZN12WithMeshClsn13SetLimMovFlagEv(void* self);
+}
+
+extern s16 data_02082214[];
+
+extern "C" int func_ov071_0211f8d0(char* self)
+{
+    Vector3* pos;
+    Vector3 v;
+    int zero;
+    char* parent;
+    int *pb0;
+    int *py;
+    int *pz;
+    int s0, s1;
+    u16 hang;
+    int saved_x;
+    int mul;
+    int rnd;
+    int one;
+    Vector3* srcv;
+    int adj;
+    int y, z, x, y2;
+
+    zero = 0;
+    pb0 = (int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    *pb0 = (*pb0) & 0xfff7fffe;
+
+    parent = *(char **)(self + 0xd0);
+    pos = (Vector3 *)(((int)self + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    mul = 0x5a000;
+    *(int *)(self + 0x98) = *(int *)(parent + 0x98) + 0x7000;
+    *(int *)(self + 0xa8) = zero;
+
+    parent = *(char **)(self + 0xd0);
+    rnd = 0x800;
+    *(s16 *)(self + 0x8e) = *(s16 *)(parent + 0x8e);
+    py = (int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF);
+    pz = (int *)(((int)self + 0x64) & 0xFFFFFFFFFFFFFFFF);
+    *(s16 *)(self + 0x94) = *(s16 *)(self + 0x8e);
+
+    parent = *(char **)(self + 0xd0);
+    one = 1;
+    srcv = (Vector3 *)(((int)parent + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    *(int *)(self + 0x5c) = srcv->x;
+    *(int *)(self + 0x60) = srcv->y;
+    *(int *)(self + 0x64) = srcv->z;
+
+    saved_x = pos->x;
+    hang = *(u16 *)(self + 0x8e);
+    s0 = data_02082214[(hang >> 4) * 2];
+    adj = (int)(((s64)s0 * mul + rnd) >> 12);
+    pos->x = saved_x + adj;
+
+    *py = *py + 0x50000;
+
+    hang = *(u16 *)(self + 0x8e);
+    s1 = data_02082214[(hang >> 4) * 2 + 1];
+    adj = (int)(((s64)s1 * mul + rnd) >> 12);
+    *pz = *pz + adj;
+
+    parent = *(char **)(self + 0xd0);
+    y = *(int *)(parent + 0x60);
+    z = *(int *)(parent + 0x64);
+    y2 = y + 0x50000;
+    x = *(int *)(parent + 0x5c);
+    v.x = x;
+    v.y = y2;
+    v.z = z;
+
+    _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(self, &v, pos, one);
+
+    *(int *)(self + 0xd0) = zero;
+    _ZN12WithMeshClsn13SetLimMovFlagEv(self + 0x194);
+
+    *(int *)(self + 0x39c) = 7;
+    return 1;
+}

--- a/src/func_ov071_0212070c.c
+++ b/src/func_ov071_0212070c.c
@@ -1,0 +1,56 @@
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+
+int func_ov071_0212070c(char* c)
+{
+    int delta;
+    int eq;
+    int hi;
+    int *p;
+    int v;
+    short *b200;
+
+    b200 = (short *)(c + 0x200);
+    delta = (short)(*(short *)(c + 0x8e) - b200[6]);
+    eq = (int)(*(unsigned short *)(c + 0xc) == 0x107);
+    if (eq != 0)
+        hi = 0x190;
+    else
+        hi = 0x320;
+
+    if (delta > hi) {
+        v = *(int *)(c + 0x1f4);
+        if (v >= 0) {
+            p = (int *)(((int)c + 0x1f4) & 0xFFFFFFFFFFFFFFFF);
+            *p = *p + delta;
+            *(unsigned char *)(c + 0x216) = 0x2e;
+        } else {
+            if (*(unsigned char *)(c + 0x216) == 0)
+                *(int *)(c + 0x1f4) = 0;
+            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+        }
+    } else if (delta < -hi) {
+        v = *(int *)(c + 0x1f4);
+        /* fallthrough ADD when v <= 0 (target: bgt to Dec) */
+        if (v <= 0) {
+            p = (int *)(((int)c + 0x1f4) & 0xFFFFFFFFFFFFFFFF);
+            *p = *p + delta;
+            *(unsigned char *)(c + 0x216) = 0x2e;
+        } else {
+            if (*(unsigned char *)(c + 0x216) == 0)
+                *(int *)(c + 0x1f4) = 0;
+            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+        }
+    } else {
+        if (*(unsigned char *)(c + 0x216) == 0)
+            *(int *)(c + 0x1f4) = 0;
+        DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+    }
+
+    v = *(int *)(c + 0x1f4);
+    if (v > 0x17fff || v < -0x17fff) {
+        *(int *)(c + 0x1f4) = 0;
+        *(unsigned char *)(c + 0x216) = 0x2e;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
Byte-identical matches for two ov071 functions (mwccarm 1.2/sp2p3):

| Function | Address | Size |
|---|---|---|
| `func_ov071_0212070c` | `0x0212070c` | `0x154` |
| `func_ov071_0211f8d0` | `0x0211f8d0` | `0x184` |

Verified locally with `tools/match.py` against overlay_0071 (`--version 1.2/sp2p3`).

## Notes
- `func_ov071_0212070c`: angle-delta / f1f4 clamp helper; u64-mask laundering for RMW at `0x1f4`, bool materialization for actor-ID threshold.
- `func_ov071_0211f8d0`: launch-from-parent setup with sin/cos Fix12 offset and raycast; `//cpp`, u64-mask for flags base, early py/pz materialization.

## Test plan
- [x] `match.py` reports MATCH for both under 1.2/sp2p3
- [ ] CI `validate` green