### PR TITLE
Match 14 ov081 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov081 14 funcs (0x02123910-0x02127e1c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #240 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN10MrBlizzard8BehaviorEv.cpp
+++ b/src/_ZN10MrBlizzard8BehaviorEv.cpp
@@ -1,0 +1,106 @@
+//cpp
+struct C;
+typedef int (C::*PMF)();
+struct C { char pad[0x3f8]; PMF* pp; };
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern int _ZN8SaveData16HasPlayerLostCapEv(void);
+extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void* self, void* wm, void* anim, unsigned n);
+extern int _ZN5Enemy11UpdateDeathER12WithMeshClsn(void* self, void* wm);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned a, unsigned b, const Vector3* v, const void* p, int e, int f);
+extern void func_02012694(int a, void* p);
+extern void func_ov081_021254d8(void* self);
+extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b, int c, int d);
+extern void* _ZN5Actor13ClosestPlayerEv(void* self);
+extern unsigned short DecIfAbove0_Short(unsigned short* p);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cyl);
+extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* self, void* wm, unsigned n);
+extern void func_ov081_021243cc(void* self);
+extern void _ZN12CylinderClsn5ClearEv(void* self);
+extern void _ZN12CylinderClsn6UpdateEv(void* self);
+extern void _ZN9Animation7AdvanceEv(void* self);
+extern char data_ov081_02128e94;
+extern char data_ov081_02128e24;
+extern char data_ov081_02128e84;
+extern char data_ov081_02128e64;
+}
+
+extern "C" int _ZN10MrBlizzard8BehaviorEv(C* self)
+{
+    char* c = (char*)self;
+    void* r5;
+    char* p;
+    if (*(int*)(c + 0x41c) == 3) {
+        switch (*(unsigned char*)(c + 0x469)) {
+        case 0:
+            if (_ZN8SaveData16HasPlayerLostCapEv()) *(unsigned char*)(c + 0x469) = 1;
+            else *(unsigned char*)(c + 0x469) = 2;
+            break;
+        case 1:
+            if (!_ZN8SaveData16HasPlayerLostCapEv()) *(unsigned char*)(c + 0x469) = 2;
+            break;
+        case 2:
+            if (_ZN8SaveData16HasPlayerLostCapEv()) *(int*)(c + 0x41c) = 2;
+            break;
+        }
+        return 1;
+    }
+    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x150, c + 0x30c, 3)) return 1;
+    if (*(int*)(c + 0x10c) != 0) {
+        if (_ZN5Enemy11UpdateDeathER12WithMeshClsn(c, c + 0x150) && *(int*)(c + 0x41c) == 2) {
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xdf, 0x300, (Vector3*)(c + 0x44c), 0, *(signed char*)(c + 0xcc), -1);
+            *(int*)(c + 0x41c) = 0;
+        }
+        if (*(int*)(c + 0x10c) == 0 && *(unsigned char*)(c + 0x468) != 0) {
+            func_02012694(0x166, c + 0x74);
+            *(unsigned char*)(c + 0x468) = 0;
+        }
+        func_ov081_021254d8(c);
+        return 1;
+    }
+    if (*(int*)(c + 0x41c) == 2
+        && (char*)self->pp != &data_ov081_02128e94
+        && (char*)self->pp != &data_ov081_02128e24
+        && _ZN8SaveData16HasPlayerLostCapEv()
+        && *(int*)(c + 0x400) == 0) {
+
+        p = (char*)_ZN5Actor13ClosestPlayerEv(c);
+        if (p != 0) {
+            int param = 0xc;
+            param = param | (*(unsigned char*)(p + 0x6d9) << 8);
+            r5 = (void*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0x10d, param, (Vector3*)(c + 0x5c), 0, *(signed char*)(c + 0xcc), -1);
+            if (r5 != 0) {
+                _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(r5, 0x64000, 0xc8000, 0x1000000, 0x1000000);
+                *(int*)(c + 0x400) = *(int*)((char*)r5 + 4);
+            }
+        }
+
+    }
+    *(short*)(c + 0x8c) = *(short*)(c + 0x92);
+    *(short*)(c + 0x8e) = *(short*)(c + 0x94);
+    *(short*)(c + 0x90) = *(short*)(c + 0x96);
+    DecIfAbove0_Short((unsigned short*)(c + 0x100));
+    if (*(void**)((char*)self->pp + 8) != 0) {
+        PMF* p = self->pp + 1;
+        (self->**p)();
+    }
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
+    if (*(int*)(c + 0x41c) == 0)
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x150, 0);
+    func_ov081_021254d8(c);
+    if ((char*)self->pp != &data_ov081_02128e84
+        && (char*)self->pp != &data_ov081_02128e64
+        && (char*)self->pp != &data_ov081_02128e94
+        && (char*)self->pp != &data_ov081_02128e24)
+        func_ov081_021243cc(c);
+    _ZN12CylinderClsn5ClearEv(c + 0x110);
+    {
+        p = (char*)_ZN5Actor13ClosestPlayerEv(c);
+        if (p != 0 && *(unsigned char*)(p + 0x6fb) == 0)
+            _ZN12CylinderClsn6UpdateEv(c + 0x110);
+    }
+    *(int*)(c + 0x368) = 0x1000;
+    _ZN9Animation7AdvanceEv(c + 0x35c);
+    return 1;
+}

--- a/src/_ZN8IceBlock8BehaviorEv.cpp
+++ b/src/_ZN8IceBlock8BehaviorEv.cpp
@@ -1,0 +1,92 @@
+//cpp
+struct Vector3 { int x, y, z; };
+
+struct VObj {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual void v29(); virtual void v30();
+    virtual void OnHit(); /* slot 31 = 0x7c */
+};
+
+extern "C" {
+extern void _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern unsigned char DecIfAbove0_Byte(unsigned char* p);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
+extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned int a, unsigned int b, int x, int y, int z, void* v, void* cb);
+extern void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
+extern void func_02012694(int a, void* p);
+extern void func_ov081_02127be0(void* c);
+extern void _ZN12CylinderClsn5ClearEv(void* p);
+extern void _ZN12CylinderClsn6UpdateEv(void* p);
+}
+
+extern "C" int _ZN8IceBlock8BehaviorEv(char* c)
+{
+    Vector3 v;
+    int yo;
+    void* s;
+    char* p;
+    unsigned int id;
+
+    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
+
+    if (*(unsigned char*)(c + 0x354) != 0) {
+        *(int*)(c + 0x358) = _ZN4cstd4fdivEii(*(unsigned char*)(c + 0x354) << 12, 0x1e000);
+
+        if (DecIfAbove0_Byte((unsigned char*)(c + 0x354)) == 0) {
+            p = *(char**)(c + 0x364);
+            if (p != 0) {
+                if (*(unsigned short*)(p + 0xc) == 0xb2)
+                    *(unsigned char*)(p + 0x49f) = 0;
+            }
+            _ZN9ActorBase18MarkForDestructionEv(c);
+        } else {
+            ((int*)&v)[0] = *(int*)(c + 0x5c);
+            ((int*)&v)[1] = *(int*)(c + 0x60);
+            ((int*)&v)[2] = *(int*)(c + 0x64);
+            yo = (int)(((long long)*(int*)(c + 0x358) * 0x96000 + 0x800) >> 12);
+            ((int*)&v)[1] = v.y + yo;
+
+            *(unsigned int*)(c + 0x35c) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                *(unsigned int*)(c + 0x35c), 0x77, v.x, v.y, v.z, 0, 0);
+            *(unsigned int*)(c + 0x360) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                *(unsigned int*)(c + 0x360), 0x78, v.x, v.y, v.z, 0, 0);
+
+            id = *(unsigned int*)(c + 0x35c);
+            if (id != 0) {
+                s = _ZN8Particle6System12FromUniqueIDEj(id);
+                if (s != 0)
+                    *(int*)((char*)s + 0x44) = *(int*)(c + 0x358) * 0xf;
+            }
+            id = *(unsigned int*)(c + 0x360);
+            if (id != 0) {
+                s = _ZN8Particle6System12FromUniqueIDEj(id);
+                if (s != 0)
+                    *(int*)((char*)s + 0x44) = *(int*)(c + 0x358) * 0xf;
+            }
+        }
+        return 1;
+    }
+
+    if (*(int*)(c + 0x344) != 0) {
+        if ((*(int*)(c + 0x340) & 0x40000) != 0) {
+            *(unsigned char*)(c + 0x354) = 0x1e;
+            func_02012694(0x7a, c + 0x74);
+            func_ov081_02127be0(c);
+        }
+        if ((*(int*)(c + 0x340) & 0x4000) != 0) {
+            ((VObj*)c)->OnHit();
+        }
+    }
+
+    _ZN12CylinderClsn5ClearEv(c + 0x320);
+    _ZN12CylinderClsn6UpdateEv(c + 0x320);
+    return 1;
+}

--- a/src/func_ov081_02123910.cpp
+++ b/src/func_ov081_02123910.cpp
@@ -1,0 +1,109 @@
+//cpp
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+
+struct VObj {
+    virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
+    virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();
+    virtual void v08(); virtual void v09(); virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
+    virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19();
+    virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23();
+    virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
+    virtual void v28(); virtual int m29(); /* slot 0x74 = index 29 */
+};
+
+extern "C" {
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern void _ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player(void* self, Vector3_16* v, void* player, int unused);
+extern void func_ov081_021237ec(void* c);
+extern int _ZN6Player9IsOnShellEv(void* p);
+extern int func_ov002_020e10a8(void* p);
+extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(void* self, void* cyl, void* player);
+extern void _ZN6Player10SpinBounceE5Fix12IiE(void* p, int f);
+extern short Vec3_HorzAngle(void* a, void* b);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, void* v, unsigned n, int f, unsigned a, unsigned b, unsigned c);
+}
+
+extern "C" void func_ov081_02123910(char* c)
+{
+    void* other;
+    unsigned int id;
+    int flags;
+    int isPlayer;
+    Vector3_16 kv;
+    Vector3 pos;
+
+    id = *(unsigned int*)(c + 0x1c0);
+    if (id == 0)
+        return;
+    other = _ZN5Actor10FindWithIDEj(id);
+    if (other == 0)
+        return;
+
+    flags = *(int*)(c + 0x1bc);
+    if ((flags & 0x10) != 0) {
+        int tmp;
+        kv.x = (short)-0x2000;
+        kv.y = 0;
+        kv.z = 0;
+        tmp = ((VObj*)c)->m29();
+        _ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player(c, &kv, other, tmp);
+        return;
+    }
+
+    if ((flags & 0x26000) != 0) {
+        func_ov081_021237ec(c);
+        return;
+    }
+
+    isPlayer = (int)(*(unsigned short*)((char*)other + 0xc) == 0xbf);
+    if (isPlayer == 0)
+        return;
+
+    if (*(unsigned char*)((char*)other + 0x6f9) == 0) {
+        if (_ZN6Player9IsOnShellEv(other) == 0) {
+            flags = *(int*)(c + 0x1bc);
+            if ((flags & 0x40000) == 0)
+                goto cont;
+        }
+    }
+    func_ov081_021237ec(c);
+    return;
+
+cont:
+    if ((flags & 0x26fe0) != 0) {
+        if (func_ov002_020e10a8(other) == 0) {
+            func_ov081_021237ec(c);
+            return;
+        }
+    }
+
+    if (_ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(c, c + 0x19c, other) != 0) {
+        _ZN6Player10SpinBounceE5Fix12IiE(other, 0x28000);
+        func_ov081_021237ec(c);
+        return;
+    }
+
+    if (*(unsigned char*)((char*)other + 0x6fb) != 0)
+        return;
+    if ((*(int*)(c + 0x1bc) & 0x400000) == 0)
+        return;
+
+    {
+        unsigned char one = 1;
+        int a;
+        short* p;
+        *(unsigned char*)(c + 0x39a) = one;
+        a = 0xa000;
+        p = (short*)(c + 0x100);
+        *p = 0;
+        *(int*)(c + 0x98) = -a;
+    }
+    *(short*)(c + 0x94) = Vec3_HorzAngle(c + 0x5c, (char*)other + 0x5c);
+
+    pos.x = *(int*)(c + 0x5c);
+    pos.y = *(int*)(c + 0x60);
+    pos.z = *(int*)(c + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(other, &pos, 2, 0xc000, 1, 0, 1);
+}

--- a/src/func_ov081_0212423c.c
+++ b/src/func_ov081_0212423c.c
@@ -1,0 +1,84 @@
+typedef short s16;
+
+struct Vector3 { int x, y, z; };
+
+extern s16 data_ov081_021289a4;
+extern s16 data_ov081_021289a6;
+extern s16 data_ov081_021289a8;
+extern char data_ov081_02128e94;
+
+extern char* _ZN5Actor22ClosestNonVanishPlayerEv(char* self);
+extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
+extern void ApproachAngle(s16* p, int target, int a, int b, int c);
+extern int AngleDiff(int a, int b);
+extern void func_ov081_02125488(char* self, char* p);
+
+void func_ov081_0212423c(char* self, int idx)
+{
+    char* player;
+    struct Vector3 v;
+    int ang;
+    int off;
+    s16* p8;
+    s16* p6;
+    s16* p4;
+    s16* p414;
+    int lim;
+
+    player = _ZN5Actor22ClosestNonVanishPlayerEv(self);
+    if (player == 0)
+        return;
+
+    {
+        int* pp = (int*)(((int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int py = pp[1];
+        int pz = pp[2];
+        v.x = pp[0];
+        v.y = py;
+        v.z = pz;
+    }
+    ang = Vec3_HorzAngle((struct Vector3*)(self + 0x5c), &v);
+
+    off = idx * 6;
+    p8 = (s16*)((char*)&data_ov081_021289a8 + off);
+    p6 = (s16*)((char*)&data_ov081_021289a6 + off);
+    p4 = (s16*)((char*)&data_ov081_021289a4 + off);
+
+    ApproachAngle((s16*)(self + 0x94), ang, *p4, *p6, *p8);
+
+    if (idx != 1) {
+        *(s16*)(self + 0x414) = 0;
+        *(int*)(self + 0x410) = 0;
+        goto second;
+    }
+
+    if (AngleDiff(ang, *(s16*)(self + 0x8e)) > 0x200) {
+        p414 = (s16*)(((int)self + 0x414) & 0xFFFFFFFFFFFFFFFFLL);
+        lim = -0x2000;
+        *p414 = *p414 - 0x100;
+        if (*(s16*)(self + 0x400 + 0x14) >= lim)
+            goto second;
+        *(s16*)(self + 0x400 + 0x14) = (s16)lim;
+    } else {
+        goto full_tail;
+    }
+
+    {
+        int* p410 = (int*)(((int)self + 0x410) & 0xFFFFFFFFFFFFFFFFLL);
+        *p410 = *p410 + 1;
+    }
+    if (*(int*)(self + 0x410) > 0x28) {
+        *(int*)(self + 0x408) = *(s16*)(self + 0x8e) - ang;
+        func_ov081_02125488(self, &data_ov081_02128e94);
+        return;
+    }
+    goto second;
+
+full_tail:
+    *(int*)(self + 0x410) = 0;
+    ApproachAngle((s16*)(((int)self + 0x414) & 0xFFFFFFFFFFFFFFFFLL), 0, 1, 0x500, 0x500);
+
+second:
+    ApproachAngle((s16*)(self + 0x8c), *(s16*)(self + 0x414), *p4, *p6, *p8);
+    *(s16*)(self + 0x8e) = *(s16*)(self + 0x94);
+}

--- a/src/func_ov081_02124894.c
+++ b/src/func_ov081_02124894.c
@@ -1,11 +1,6 @@
-// NONMATCHING: base materialization / addressing (div=33). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
-typedef unsigned short u16;
 typedef short s16;
 typedef int Fix12i;
-
 typedef struct { int x, y, z; } Vector3;
 
 extern int ApproachAngle(s16* angle, int target, int a, int b, int max);
@@ -16,19 +11,25 @@ extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* c);
 int func_ov081_02124894(char* c)
 {
     Vector3 v;
-    if (*(int*)(c + 0x408) <= 0)
-        *(s16*)(c + 0x414) = *(s16*)(c + 0x414) + 0x200;
+    /* Source written as (>0 ? sub : add) so mwccarm inversion emits the
+       ROM's le/add arm first, then the unconditional sub arm. */
+    if (*(int*)(c + 0x408) > 0)
+        *(s16*)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF) =
+            *(s16*)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF) - 0x200;
     else
-        *(s16*)(c + 0x414) = *(s16*)(c + 0x414) - 0x200;
-
-    *(s16*)(c + 0x94) = *(s16*)(c + 0x94) + *(s16*)(c + 0x414);
-    ApproachAngle((s16*)(c + 0x8c), -0x2800, 1, 0x500, 0x500);
+        *(s16*)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF) =
+            *(s16*)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF) + 0x200;
 
     {
-        int* p = (int*)(c + 0x410);
-        *p += 1;
+        s16 *ang = (s16*)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF);
+        *ang = *ang + *(s16*)((c + 0x400) + 0x14);
     }
-    if (*(int*)(c + 0x410) <= 0x28) return 1;
+    ApproachAngle((s16*)(c + 0x8c), -0x2800, 1, 0x500, 0x500);
+    {
+        int *p = (int*)(((int)c + 0x410) & 0xFFFFFFFFFFFFFFFF);
+        *p = *p + 1;
+    }
+    if (*(int*)(c + 0x410) <= 0x28) goto done;
     if (*(u8*)(c + 0x469) == 0) {
         v.x = *(int*)(c + 0x5c);
         v.y = *(int*)(c + 0x60);
@@ -37,5 +38,6 @@ int func_ov081_02124894(char* c)
     }
     func_ov081_02124134(c);
     _ZN5Actor24KillAndTrackInDeathTableEv(c);
+done:
     return 1;
 }

--- a/src/func_ov081_021249f4.c
+++ b/src/func_ov081_021249f4.c
@@ -1,0 +1,44 @@
+extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned a, unsigned b, int c, int d, int e, const void *f, void *g);
+extern int ApproachAngle(short *angle, int target, int a, int b, int max);
+extern void func_ov081_02125488(void *c, void *p);
+extern char data_ov081_02128e84[];
+
+struct Vec3 { int x, y, z; };
+
+int func_ov081_021249f4(char *c)
+{
+    struct Vec3 pos;
+    void *cb;
+    int t;
+
+    pos.x = *(int *)(c + 0x44c);
+    pos.y = *(int *)(c + 0x450);
+    pos.z = *(int *)(c + 0x454);
+    cb = 0;
+    *(unsigned *)(c + 0x460) =
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned *)(c + 0x460), 0x11d, pos.x, pos.y, pos.z, 0, cb ? &pos : 0);
+    pos.y = pos.y + 0x1e000;
+    *(unsigned *)(c + 0x464) =
+        _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            *(unsigned *)(c + 0x464), 0x11e, pos.x, pos.y, pos.z, 0, cb ? &pos : 0);
+
+    if (*(int *)(c + 0x450) > *(int *)(c + 0x60)) {
+        char *b = c + 0x400;
+        ApproachAngle((short *)(c + 0x8c), *(short *)(b + 0x14), 1, 0x1000, 0x1000);
+    }
+    t = *(int *)(c + 0x450) - 0x118000;
+    if (t > *(int *)(c + 0x60)) {
+        *(int *)(c + 0x60) = t;
+        *(int *)(c + 0xa8) = 0;
+        *(int *)(c + 0x9c) = 0;
+        func_ov081_02125488(c, data_ov081_02128e84);
+    }
+    {
+        short *ang = (short *)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL);
+        *ang = (short)(*ang + 0x2000);
+        *(short *)(c + 0x8e) = *(short *)(c + 0x94);
+    }
+    return 1;
+}

--- a/src/func_ov081_02124b08.c
+++ b/src/func_ov081_02124b08.c
@@ -1,28 +1,33 @@
-//cpp
-// NONMATCHING: different op / idiom (div=11). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef int Fix12;
-struct BCA_File;
-struct Actor { static Actor *FindWithID(unsigned int id); };
-struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
+struct S2 { void *w[2]; };
+extern struct S2 data_ov081_02128da8;
 
-extern void *data_ov081_02128da8[];
-
-extern "C" int func_ov081_02124b08(char *c)
+int func_ov081_02124b08(char *c)
 {
     unsigned int id = *(unsigned int *)(c + 0x3fc);
     if (id != 0) {
-        char *a = (char *)Actor::FindWithID(id);
+        char *a = (char *)_ZN5Actor10FindWithIDEj(id);
         if (a != 0) {
-            *(int *)(a + 0x9c) = -0x2000;
-            *(int *)(a + 0xa0) = -0x28000;
+            int n = 0x2000;
+            *(int *)(a + 0x9c) = -n;
+            n = 0x28000;
+            *(int *)(a + 0xa0) = -n;
             *(int *)(c + 0x3fc) = 0;
-            *(int *)(c + 0xa8) = 0xa000;
-            *(int *)(c + 0x9c) = -0x4000;
-            *(short *)(c + 0x414) = 0;
-            ((ModelAnim *)(c + 0x30c))->SetAnim((BCA_File *)data_ov081_02128da8[1], 0, 0x1000, 0);
         }
+    }
+    {
+        int z = 0;
+        int n;
+        *(int *)(c + 0xa8) = 0xa000;
+        n = 0x4000;
+        *(int *)(c + 0x9c) = -n;
+        {
+            char *base = c + 0x400;
+            *(short *)(base + 0x14) = z;
+        }
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
+            c + 0x30c, data_ov081_02128da8.w[1], 0, 0x1000, z);
     }
     return 1;
 }

--- a/src/func_ov081_02124f7c.c
+++ b/src/func_ov081_02124f7c.c
@@ -1,26 +1,31 @@
-//cpp
-// NONMATCHING: extra logic (you do more) (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" void func_02012694(int a0, void *a1);
-extern "C" void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-    unsigned int a, unsigned int b, int c, int d, int e, const void *f, void *g);
+extern void func_02012694(int a0, void *a1);
+extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned a, unsigned b, int c, int d, int e, const void *f, void *g);
 
-extern "C" int func_ov081_02124f7c(char *thiz)
+struct Vec3 { int x, y, z; };
+
+int func_ov081_02124f7c(char *thiz)
 {
-    volatile int c, d, e;
-    *(int*)(thiz + 0xa8) = 0x3c000;
-    *(int*)(thiz + 0x9c) = -0x4000;
+    int n;
+    struct Vec3 pos;
+    void *cb;
+
+    *(int *)(thiz + 0xa8) = 0x3c000;
+    n = 0x4000;
+    *(int *)(thiz + 0x9c) = -n;
     func_02012694(0xdc, thiz + 0x74);
-    c = *(int*)(thiz + 0x44c);
-    d = *(int*)(thiz + 0x450);
-    e = *(int*)(thiz + 0x454);
-    *(void**)(thiz + 0x460) =
+    pos.x = *(int *)(thiz + 0x44c);
+    pos.y = *(int *)(thiz + 0x450);
+    pos.z = *(int *)(thiz + 0x454);
+    cb = 0;
+    *(unsigned *)(thiz + 0x460) =
         _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-            *(unsigned int*)(thiz + 0x460), 0x11a, c, d, e, 0, 0);
-    d = d + 0x1e000;
-    *(void**)(thiz + 0x464) =
+            *(unsigned *)(thiz + 0x460), 0x11a, pos.x, pos.y, pos.z, 0,
+            cb ? &pos : 0);
+    pos.y = pos.y + 0x1e000;
+    *(unsigned *)(thiz + 0x464) =
         _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-            *(unsigned int*)(thiz + 0x464), 0x11b, c, d, e, 0, 0);
+            *(unsigned *)(thiz + 0x464), 0x11b, pos.x, pos.y, pos.z, 0,
+            cb ? &pos : 0);
     return 1;
 }

--- a/src/func_ov081_02125208.c
+++ b/src/func_ov081_02125208.c
@@ -1,6 +1,3 @@
-// NONMATCHING: constant / value (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 struct PathPtr { int a, b; };
 
@@ -20,6 +17,9 @@ extern char data_ov081_02128e74[];
 int func_ov081_02125208(char *c) {
     struct PathPtr p;
     struct Vec3 node;
+    int st;
+    int z;
+    int n;
 
     if (*(unsigned short*)(c + 0x100) != 0) {
         goto exit;
@@ -27,7 +27,8 @@ int func_ov081_02125208(char *c) {
 
     if (*(int*)(c + 0x408) == 1) {
         *(int*)(c + 0xa8) = 0x14000;
-        *(int*)(c + 0x9c) = -0x4000;
+        n = 0x4000;
+        *(int*)(c + 0x9c) = -n;
         *(int*)(c + 0x408) = 2;
         func_02012694(0xdd, c + 0x74);
     }
@@ -45,10 +46,11 @@ int func_ov081_02125208(char *c) {
         goto exit;
     }
 
-    if (*(int*)(c + 0x408) == 0) {
+    st = *(int*)(c + 0x408);
+    if (st == 0) {
         goto label_118;
     }
-    if (*(int*)(c + 0x408) != 1) {
+    if (st != 1) {
         goto label_ec;
     }
 
@@ -56,7 +58,7 @@ int func_ov081_02125208(char *c) {
 
 label_ec:
     {
-        int *pState = (int*)(c + 0x408);
+        int *pState = (int*)(((int)c + 0x408) & 0xFFFFFFFFFFFFFFFF);
         *pState = *pState + 1;
         if (*(int*)(c + 0x408) < 0xb) {
             return 1;
@@ -64,13 +66,12 @@ label_ec:
     }
 
 label_118:
-    {
-        unsigned int zero = 0;
-        *(int*)(c + 0x408) = zero;
-        *(int*)(c + 0xa8) = 0x3a000;
-        *(int*)(c + 0x9c) = -0x4000;
-        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x30c, *(void**)(data_ov081_02128d88 + 4), 0x40000000, 0x1000, zero);
-    }
+    z = 0;
+    n = 0x4000;
+    *(int*)(c + 0x408) = z;
+    *(int*)(c + 0xa8) = 0x3a000;
+    *(int*)(c + 0x9c) = -n;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x30c, *(void**)(data_ov081_02128d88 + 4), 0x40000000, 0x1000, z);
     func_02012694(0xdd, c + 0x74);
     func_ov081_02125488(c, data_ov081_02128e74);
 

--- a/src/func_ov081_0212538c.c
+++ b/src/func_ov081_0212538c.c
@@ -1,37 +1,40 @@
-// NONMATCHING: different op / idiom (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 struct PathPtr { int a, b; };
-extern void PathPtr_ctor(struct PathPtr* p);
-extern void PathPtr_FromID(struct PathPtr* p, unsigned id);
-extern void PathPtr_GetNode(struct PathPtr* p, struct Vec3* out, unsigned i);
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern int LenVec3(struct Vec3* v);
-extern void SetAnim(void* thiz, void* f, int a, int frame, unsigned g);
-extern void* data_ov081_02128d98[];
 
-int func_ov081_0212538c(char* c){
-  struct PathPtr pp;
-  PathPtr_ctor(&pp);
-  PathPtr_FromID(&pp, *(unsigned*)(c+0x418));
-  struct Vec3 node;
-  PathPtr_GetNode(&pp, &node, *(unsigned*)(c+0x424));
-  node.y = *(int*)(c+0x60);
-  struct Vec3 diff;
-  Vec3_Sub(&diff, (struct Vec3*)(c+0x5c), &node);
-  int len = LenVec3(&diff);
-  *(int*)(c+0x458) = 0xa000;
-  *(int*)(c+0x408) = 0;
-  if (len == 0 || len <= *(int*)(c+0x458)) {
-    *(int*)(c+0x5c) = node.x;
-    *(int*)(c+0x60) = node.y;
-    *(int*)(c+0x64) = node.z;
-    (*(int*)(c+0x424))++;
-    if (*(int*)(c+0x424) >= *(int*)(c+0x420)) *(int*)(c+0x424) = 0;
-    *(int*)(c+0x408) = 1;
-  }
-  *(short*)(c+0x100) = 0xa;
-  SetAnim(c+0x30c, data_ov081_02128d98[1], 0, 0x1000, 0);
-  return 1;
+extern void _ZN7PathPtrC1Ev(struct PathPtr *self);
+extern void _ZN7PathPtr6FromIDEj(struct PathPtr *self, unsigned int id);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vec3 *v, unsigned int i);
+extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
+extern int LenVec3(struct Vec3 *v);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
+extern void *data_ov081_02128d98[];
+
+int func_ov081_0212538c(char *c)
+{
+    struct PathPtr pp;
+    struct Vec3 node;
+    struct Vec3 diff;
+    int len;
+
+    _ZN7PathPtrC1Ev(&pp);
+    _ZN7PathPtr6FromIDEj(&pp, *(unsigned int *)(c + 0x418));
+    _ZNK7PathPtr7GetNodeER7Vector3j(&pp, &node, *(unsigned int *)(c + 0x424));
+    node.y = *(int *)(c + 0x60);
+    Vec3_Sub(&diff, (struct Vec3 *)(c + 0x5c), &node);
+    len = LenVec3(&diff);
+    *(int *)(c + 0x458) = 0xa000;
+    *(int *)(c + 0x408) = 0;
+    if (len == 0 || len <= *(int *)(c + 0x458)) {
+        *(int *)(c + 0x5c) = node.x;
+        *(int *)(c + 0x60) = node.y;
+        *(int *)(c + 0x64) = node.z;
+        (*(int *)(((long long)(int)(c + 0x424)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        if (*(int *)(c + 0x424) >= *(int *)(c + 0x420))
+            *(int *)(c + 0x424) = 0;
+        *(int *)(c + 0x408) = 1;
+    }
+    *(short *)(c + 0x100) = 0xa;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
+        c + 0x30c, data_ov081_02128d98[1], 0, 0x1000, 0);
+    return 1;
 }

--- a/src/func_ov081_02126d64.c
+++ b/src/func_ov081_02126d64.c
@@ -1,37 +1,34 @@
-//cpp
-// NONMATCHING: different op / idiom (div=5). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct CylinderClsn { void Clear(); void Update(); };
-struct WithMeshClsn {
-    bool JustHitGround() const;
-    bool IsOnGround() const;
-    void ClearLimMovFlag();
-};
-struct Actor { void UpdatePos(CylinderClsn* c); };
+/* Pure C version — angle reset only on IsOnGround path (not JustHitGround). */
+extern void func_02038414(void *p);
+extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *w);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *w);
+extern void _ZN12WithMeshClsn15ClearLimMovFlagEv(void *w);
+extern void func_ov081_021265c8(void *c);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *a, void *clsn);
+extern void func_ov081_02126758(void *c);
+extern void _ZN12CylinderClsn5ClearEv(void *cl);
+extern void _ZN12CylinderClsn6UpdateEv(void *cl);
 
-extern "C" void func_02038414(void* p);
-extern "C" void func_ov081_021265c8(void* c);
-extern "C" void func_ov081_02126758(void* c);
-
-extern "C" bool func_ov081_02126d64(Actor* self) {
-    char* s = (char*)self;
+int func_ov081_02126d64(char *s)
+{
     func_02038414(s + 0x1e4);
-    *(short*)(s + 0x8c) += 0x1000;
-    if (((WithMeshClsn*)(s + 0x1e4))->JustHitGround()) {
-        *(int*)(s + 0xa8) = *(int*)(s + 0xa8) * -0x3c / 100;
-    } else if (((WithMeshClsn*)(s + 0x1e4))->IsOnGround()) {
-        *(int*)(s + 0xa8) = 0;
-        ((WithMeshClsn*)(s + 0x1e4))->ClearLimMovFlag();
+    *(short *)(s + 0x8c) += 0x1000;
+    if (_ZNK12WithMeshClsn13JustHitGroundEv(s + 0x1e4) != 0) {
+        *(int *)(s + 0xa8) = *(int *)(s + 0xa8) * -0x3c / 100;
+    } else if (_ZNK12WithMeshClsn10IsOnGroundEv(s + 0x1e4) != 0) {
+        *(int *)(s + 0xa8) = 0;
+        _ZN12WithMeshClsn15ClearLimMovFlagEv(s + 0x1e4);
+        {
+            short v94 = *(short *)(s + 0x94);
+            *(short *)(s + 0x8c) = 0;
+            *(short *)(s + 0x8e) = v94;
+            *(short *)(s + 0x90) = 0;
+            func_ov081_021265c8(s);
+        }
     }
-    short v94 = *(short*)(s + 0x94);
-    *(short*)(s + 0x8c) = 0;
-    *(short*)(s + 0x8e) = v94;
-    *(short*)(s + 0x90) = 0;
-    func_ov081_021265c8(self);
-    ((Actor*)self)->UpdatePos((CylinderClsn*)(s + 0x1b0));
-    func_ov081_02126758(self);
-    ((CylinderClsn*)(s + 0x1b0))->Clear();
-    ((CylinderClsn*)(s + 0x1b0))->Update();
-    return true;
+    _ZN5Actor9UpdatePosEP12CylinderClsn(s, s + 0x1b0);
+    func_ov081_02126758(s);
+    _ZN12CylinderClsn5ClearEv(s + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(s + 0x1b0);
+    return 1;
 }

--- a/src/func_ov081_02126e28.c
+++ b/src/func_ov081_02126e28.c
@@ -1,0 +1,56 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+typedef struct { int x, y, z; } Vector3;
+extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void* self, Vector3* a, Vector3* b, int cc);
+extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void* self);
+extern s16 data_02082214[];
+
+int func_ov081_02126e28(char* c) {
+  int* pf; Vector3 v; char* player; char* src; int zero; s16 ang; int idx; s16 s;
+
+  pf = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+  *pf = *pf & ~0x80000;
+  zero = 0;
+  player = *(char**)(c + 0xd0);
+  *(int*)(c + 0x98) = *(int*)(player + 0x98) + 0x7000;
+  *(int*)(c + 0xa8) = zero;
+  player = *(char**)(c + 0xd0);
+  ang = *(s16*)(player + 0x8e);
+  *(s16*)(c + 0x8e) = ang;
+  *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+
+  player = *(char**)(c + 0xd0);
+  src = (char*)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+  *(int*)(c + 0x5c) = *(int*)src;
+  *(int*)(c + 0x60) = *(int*)(src+4);
+  *(int*)(c + 0x64) = *(int*)(src+8);
+
+  idx = (*(u16*)(c + 0x8e) >> 4);
+  s = *(s16*)((char*)data_02082214 + (idx << 2));
+  *(int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL) =
+    *(int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL)
+    + (int)(((s64)s * 0x50000 + 0x800) >> 12);
+  *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) =
+    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) + 0x50000;
+  idx = (*(u16*)(c + 0x8e) >> 4);
+  s = *(s16*)((char*)data_02082214 + ((idx * 2 + 1) << 1));
+  *(int*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL) =
+    *(int*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL)
+    + (int)(((s64)s * 0x50000 + 0x800) >> 12);
+
+  player = *(char**)(c + 0xd0);
+  {
+    int y = *(int*)(player + 0x60);
+    int z = *(int*)(player + 0x64);
+    int y2 = y + 0x14000;
+    int x = *(int*)(player + 0x5c);
+    ((int*)&v)[0]=x; ((int*)&v)[1]=y2; ((int*)&v)[2]=z;
+  }
+
+  _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(c, &v, (Vector3*)(c + 0x5c), 1);
+  *(int*)(c + 0xd0) = zero;
+  _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x1e4);
+  *(int*)(c + 0x3e0) = 7;
+  return 1;
+}

--- a/src/func_ov081_02127188.c
+++ b/src/func_ov081_02127188.c
@@ -1,20 +1,18 @@
-// NONMATCHING: base materialization / addressing (div=9). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void _ZN9Animation7AdvanceEv(void *);
 extern int _ZN9Animation8FinishedEv(void *);
 extern int func_ov081_0212777c(void *, int);
 extern int func_ov081_02126758(void *);
 extern void _ZN12CylinderClsn5ClearEv(void *);
 extern void _ZN12CylinderClsn6UpdateEv(void *);
+
 int func_ov081_02127188(char *c) {
     _ZN9Animation7AdvanceEv(c + 0x124);
     if (_ZN9Animation8FinishedEv(c + 0x124)) {
-        *(int*)(c + 0xb0) |= 1;
-        func_ov081_0212777c(c, *(int*)(c + 0x3e4));
-        func_ov081_02126758(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x1b0);
-        _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+        *(unsigned int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        func_ov081_0212777c(c, *(int *)(c + 0x3e4));
     }
+    func_ov081_02126758(c);
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
     return 1;
 }

--- a/src/func_ov081_02127558.c
+++ b/src/func_ov081_02127558.c
@@ -1,0 +1,54 @@
+typedef unsigned char u8;
+typedef short s16;
+
+extern int _Z15ApproachLinear2Riii(int* p, int a, int b);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int a, int b, unsigned int c, unsigned int d);
+extern int _ZN5Actor13DistToCPlayerEv(void* thiz);
+extern void func_0201267c(int a, void* p);
+extern void func_ov081_0212777c(void* c, int n);
+extern void func_ov081_02126758(void* c);
+extern void _ZN12CylinderClsn5ClearEv(void* thiz);
+extern void _ZN12CylinderClsn6UpdateEv(void* thiz);
+
+int func_ov081_02127558(char* c)
+{
+    u8* pstate;
+    int* pflg;
+    int off;
+    char* base;
+
+    switch (*(u8*)(c + 0x3f1)) {
+    case 0:
+        if (_Z15ApproachLinear2Riii((int*)(c + 0x3f0), 1, 2) != 0) {
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x1b0, c, 0x4b000, 0x73000, 0x200000, 0);
+            pflg = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+            *pflg = *pflg & ~0x10000000;
+            pstate = (u8*)(((int)c + 0x3f1) & 0xFFFFFFFFFFFFFFFFLL);
+            *pstate = *pstate + 1;
+        }
+        break;
+    case 1:
+        if (_ZN5Actor13DistToCPlayerEv(c) < 0x1f4000) {
+            pflg = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+            *pflg = *pflg | 0x10000000;
+            func_0201267c(0x76, c + 0x74);
+            pstate = (u8*)(((int)c + 0x3f1) & 0xFFFFFFFFFFFFFFFFLL);
+            *pstate = *pstate + 1;
+        }
+        break;
+    case 2:
+        if (_Z15ApproachLinear2Riii((int*)(c + 0x3f0), 0x1f, 2) != 0) {
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x1b0, c, 0x4b000, 0x73000, 0x200000, 0x6eff0);
+            func_ov081_0212777c(c, 3);
+        }
+        break;
+    }
+
+    off = 0x300;
+    base = c + off;
+    *(s16*)(base + 0xec) += 0xc00;
+    func_ov081_02126758(c);
+    _ZN12CylinderClsn5ClearEv(c + 0x1b0);
+    _ZN12CylinderClsn6UpdateEv(c + 0x1b0);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for 14 ov081 functions against EU retail (mwccarm **1.2/sp2p3**).

| Function | Addr | Size |
|---|---|---|
| `IceBlock::Behavior` | `0x2127e1c` | `0x1d4` |
| `MrBlizzard::Behavior` | `0x212588c` | `0x314` |
| `func_ov081_02123910` | `0x2123910` | `0x210` |
| `func_ov081_0212423c` | `0x212423c` | `0x190` |
| `func_ov081_02124894` | `0x2124894` | `0xf8` |
| `func_ov081_021249f4` | `0x21249f4` | `0x114` |
| `func_ov081_02124b08` | `0x2124b08` | `0x90` |
| `func_ov081_02124f7c` | `0x2124f7c` | `0xbc` |
| `func_ov081_02125208` | `0x2125208` | `0x184` |
| `func_ov081_0212538c` | `0x212538c` | `0xfc` |
| `func_ov081_02126d64` | `0x2126d64` | `0xc4` |
| `func_ov081_02126e28` | `0x2126e28` | `0x17c` |
| `func_ov081_02127188` | `0x2127188` | `0x60` |
| `func_ov081_02127558` | `0x2127558` | `0x158` |

Verified locally with:

```
.venv/bin/python tools/match.py --c src/<file> --func <name> --addr <addr> --size <size> --version 1.2/sp2p3 --module ov081
```

(C++ sources via `//cpp` + fdiff / CPP_FLAGS.)

## Test plan

- [ ] CI `validate` green for all 14 files
- [ ] No WRONG-DEST reloc failures