### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov021: _ZN10ShutterHmc13InitResourcesEv (0x02112ec0), _ZN10ShutterHmc16CleanupResourcesEv (0x02112e68) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #241 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN10ShutterHmc13InitResourcesEv.c
+++ b/src/_ZN10ShutterHmc13InitResourcesEv.c
@@ -1,0 +1,6 @@
+extern int func_ov002_020bad10(void *self, void *data);
+extern int data_ov021_021148d0[];
+int _ZN10ShutterHmc13InitResourcesEv(void *self)
+{
+    return func_ov002_020bad10(self, data_ov021_021148d0);
+}

--- a/src/_ZN10ShutterHmc16CleanupResourcesEv.c
+++ b/src/_ZN10ShutterHmc16CleanupResourcesEv.c
@@ -1,0 +1,6 @@
+extern int func_ov002_020baba8(void *self, void *data);
+extern int data_ov021_021148d0[];
+int _ZN10ShutterHmc16CleanupResourcesEv(void *self)
+{
+    return func_ov002_020baba8(self, data_ov021_021148d0);
+}


### PR DESCRIPTION
## Summary
- `_ZN10ShutterHmc13InitResourcesEv` @ `0x02112ec0` size `0x14` (ov021)
- `_ZN10ShutterHmc16CleanupResourcesEv` @ `0x02112e68` size `0x14` (ov021)

Both are tail-call trampolines:
- Init → `func_ov002_020bad10(self, data_ov021_021148d0)`
- Cleanup → `func_ov002_020baba8(self, data_ov021_021148d0)`

## Compiler
mwccarm **1.2/sp2p3** with flags:
`-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Verify
```
python tools/match.py --c src/_ZN10ShutterHmc13InitResourcesEv.c --func _ZN10ShutterHmc13InitResourcesEv --addr 0x2112ec0 --size 0x14 --version 1.2/sp2p3 --bin extracted/overlays/overlay_0021.bin --base 0x021111a0 --module ov021
python tools/match.py --c src/_ZN10ShutterHmc16CleanupResourcesEv.c --func _ZN10ShutterHmc16CleanupResourcesEv --addr 0x2112e68 --size 0x14 --version 1.2/sp2p3 --bin extracted/overlays/overlay_0021.bin --base 0x021111a0 --module ov021
```
Both report `MATCHING VERSIONS: 1.2/sp2p3`.