### PR TITLE
Match 6 ov066 Eyerok helper functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov066: 0211603c (0x0211603c), 02116390 (0x02116390), 02116db0 (0x02116db0), 021171b0 (0x021171b0), 02118188 (0x02118188), 0211a2e4 (0x0211a2e4) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #243 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov066_0211603c.c
+++ b/src/func_ov066_0211603c.c
@@ -1,0 +1,111 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef signed char s8;
+
+enum Bool { FALSE, TRUE };
+
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern int _ZN5Actor18HorzAngleToCPlayerEv(void *self);
+extern int AngleDiff(int a, int b);
+extern void _ZN6Player16IncMegaKillCountEv(void *p);
+extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *m, void *f, int a, int b, int fix, u16 t);
+extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *m, void *f, int a, int fix, unsigned int j);
+extern void func_02012694(int a, void *p);
+extern void func_ov066_02119454(void *c, void *p);
+
+extern void *data_ov066_0211ae5c[];
+extern void *data_ov066_0211ae3c[];
+extern void *data_ov066_0211ae84[];
+extern void *data_ov066_0211aebc[];
+extern u8 data_ov066_0211ae08;
+extern u8 data_ov066_0211abe0;
+extern int data_ov066_0211abe4;
+extern int data_ov066_0211b07c;
+
+int func_ov066_0211603c(char *self)
+{
+    char *actor;
+    int flags;
+    int hit;
+    unsigned int id;
+    u16 type;
+    enum Bool is_player;
+
+    id = *(unsigned int *)(self + 0x344);
+    if (id == 0)
+        goto fail;
+
+    actor = (char *)_ZN5Actor10FindWithIDEj(id);
+    if (actor == 0)
+        return 0;
+
+    if (AngleDiff(*(s16 *)(self + 0x8e), _ZN5Actor18HorzAngleToCPlayerEv(self)) >= 0x4000)
+        return 0;
+
+    type = *(u16 *)(actor + 0xc);
+    hit = 0;
+    flags = *(int *)(self + 0x340);
+    is_player = (enum Bool)(type == 0xbf);
+    if (is_player == FALSE)
+        goto other;
+
+    if (*(u8 *)(actor + 0x6f9) == 1) {
+        (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+        hit = 1;
+    }
+    if (flags & 0x10) {
+        (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+        if (*(s8 *)(self + 0x4d8) <= 0)
+            _ZN6Player16IncMegaKillCountEv(actor);
+        hit = 1;
+    }
+
+other:
+    if (hit == 0) {
+        if (flags & 0x427e0) {
+            if (flags & 0x40) {
+                if (*(int *)(actor + 8) == 2)
+                    (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+            }
+            if (flags & 0x40000)
+                *(s16 *)(self + 0x4d4) = 1;
+            (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+            hit = 1;
+        }
+    }
+
+    if (hit == 0)
+        goto fail;
+
+    if (*(s8 *)(self + 0x4d8) > 0) {
+        if (*(int *)(self + 0x49c) == 2) {
+            _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(
+                self + 0x360, data_ov066_0211ae5c[1], 4, 0x40000000, 0x1000, 0);
+            _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
+                self + 0x448, data_ov066_0211ae3c[1], 0x40000000, 0x1000, 0);
+        } else {
+            _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(
+                self + 0x360, data_ov066_0211ae84[1], 4, 0x40000000, 0x1000, 0);
+            _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
+                self + 0x448, data_ov066_0211aebc[1], 0x40000000, 0x1000, 0);
+        }
+        func_02012694(0x141, self + 0x74);
+        return 1;
+    }
+
+    {
+        u8 x = data_ov066_0211ae08;
+        u8 y = data_ov066_0211abe0;
+        int side = *(int *)(self + 0x49c);
+        data_ov066_0211abe0 = (u8)(y ^ side);
+        data_ov066_0211ae08 = (u8)(x + 1);
+        data_ov066_0211abe4 = -3;
+    }
+    func_02012694(0x142, self + 0x74);
+    func_ov066_02119454(self, &data_ov066_0211b07c);
+    return 2;
+
+fail:
+    return 0;
+}

--- a/src/func_ov066_02116390.c
+++ b/src/func_ov066_02116390.c
@@ -1,13 +1,10 @@
-// NONMATCHING: different op / idiom (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
-extern int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*, int, int, int, unsigned);
+extern int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*, void*, int, int, unsigned);
 extern int RandomIntInternal(int* seed);
-extern int data_ov066_0211ae2c[];
-extern int data_ov066_0211ae9c[];
-extern int data_ov066_0211ae3c[];
-extern int data_ov066_0211aebc[];
+extern void *data_ov066_0211ae2c[];
+extern void *data_ov066_0211ae9c[];
+extern void *data_ov066_0211ae3c[];
+extern void *data_ov066_0211aebc[];
 extern int data_0209e650;
 
 void func_ov066_02116390(void* thiz)
@@ -28,6 +25,6 @@ void func_ov066_02116390(void* thiz)
         else
             _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x448, data_ov066_0211aebc[1], 0x40000000, 0x1000, 0);
         *(unsigned short*)(c + 0x66c) = 8;
-        *(unsigned char*)(((int)c + 0x66e) & 0xFFFFFFFFFFFFFFFF) ^= 1;
     }
+    *(unsigned char*)(((int)c + 0x66e) & 0xFFFFFFFFFFFFFFFF) ^= 1;
 }

--- a/src/func_ov066_02116db0.c
+++ b/src/func_ov066_02116db0.c
@@ -1,0 +1,152 @@
+typedef struct Vec3 { int x, y, z; } Vec3;
+typedef short s16;
+
+extern void * _ZN5Actor13ClosestPlayerEv(void *thiz);
+extern void func_02012694(int a, void *p);
+extern void func_ov066_021166c8(void *thiz);
+extern s16 Vec3_HorzAngle(const void *a, const void *b);
+extern void Matrix4x3_FromRotationY(void *m, s16 ang);
+extern void MulVec3Mat4x3(void *a, void *m, void *b);
+extern int ApproachAngle(s16 *angle, int target, int a, int b, int max);
+extern int func_ov066_0211603c(void *c);
+extern int Vec3_ApproachHorz(void *out, void *a, int maxStep);
+extern int func_ov066_02116b78(void *c);
+extern int Vec3_HorzDist(const void *a, const void *b);
+extern void func_ov066_021165cc(void *c);
+extern void func_ov066_021164ec(void *c);
+extern int _ZN9Animation8FinishedEv(void *thiz);
+extern void func_ov066_021162e8(void *c);
+extern int _ZN16MeshColliderBase9IsEnabledEv(void *thiz);
+extern void _ZN16MeshColliderBase7DisableEv(void *thiz);
+extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *thiz, void *f, void *m, int fx, int s, void *clps);
+extern void func_020393d4(void *p, void *v);
+extern void func_020393c4(void *p, void *v);
+extern void func_020398fc(void *p);
+extern void _ZN16MeshColliderBase6EnableEP5Actor(void *thiz, void *a);
+extern void func_ov066_02119454(void *c, void *p);
+
+extern int data_020a0e68[];
+extern unsigned char data_ov066_0211ae08;
+extern unsigned char data_ov066_0211ae04;
+extern char data_ov066_0211ae14[];
+extern char data_ov066_0211aeac[];
+extern char data_ov066_0211b06c;
+extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+extern int func_02112c08;
+extern int func_02112d48;
+extern int func_ov066_0211a35c;
+
+int func_ov066_02116db0(void *thiz)
+{
+    char *c = (char *)thiz;
+    Vec3 in, out;
+    s16 ang;
+    int r;
+
+    switch (*(int *)(c + 0x4a0)) {
+    case 0:
+        func_ov066_021166c8(c);
+        *(int *)(c + 0x4a0) = 1;
+        break;
+
+    case 1:
+        if (*(int *)(c + 0x498) == 0) {
+            char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
+            if (p != 0) {
+                Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                *(int *)(c + 0x4bc) = pp->x;
+                *(int *)(c + 0x4c0) = pp->y;
+                *(int *)(c + 0x4c4) = pp->z;
+
+                in.x = 0;
+                in.y = 0;
+                in.z = 0;
+                out.x = 0;
+                out.y = 0;
+                out.z = 0;
+                in.z = 0x3e8000;
+
+                ang = Vec3_HorzAngle(c + 0x5c, c + 0x4bc);
+                Matrix4x3_FromRotationY(data_020a0e68, ang);
+                MulVec3Mat4x3(&in, data_020a0e68, &out);
+
+                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) += out.x;
+                *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) += out.z;
+            }
+
+            if ((unsigned short)(*(int *)(c + 0x3b8) >> 0xc) == 0)
+                func_02012694(0x140, c + 0x74);
+
+            if ((unsigned short)(*(int *)(c + 0x3b8) >> 0xc) == 0) {
+                func_ov066_021164ec(c);
+                func_02012694(0x144, c + 0x74);
+            }
+
+            ang = Vec3_HorzAngle(c + 0x5c, c + 0x4bc);
+            ApproachAngle((s16 *)(c + 0x8e), ang, 2, 0x400, 0x200);
+        }
+
+        if (*(int *)(c + 0x498) == 1) {
+            r = func_ov066_0211603c(c);
+            if (r != 0) {
+                if (r == 1)
+                    *(int *)(c + 0x4a0) = 2;
+                break;
+            }
+            Vec3_ApproachHorz(c + 0x5c, c + 0x4bc, 0x37000);
+            if (func_ov066_02116b78(c) == 1 || Vec3_HorzDist(c + 0x5c, c + 0x4bc) <= 0x37000) {
+                func_ov066_021165cc(c);
+                *(int *)(c + 0x4a0) = 3;
+            }
+        }
+        break;
+
+    /* case 3 body before case 2 to match ROM placement */
+    case 3:
+        if (_ZN9Animation8FinishedEv(c + 0x3b0) != 0) {
+            if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x674) != 0)
+                _ZN16MeshColliderBase7DisableEv(c + 0x674);
+            if (*(int *)(c + 0x49c) == 1)
+                _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+                    c + 0x674, *(void **)(data_ov066_0211ae14 + 4), c + 0x83c, 0x199,
+                    *(s16 *)(c + 0x8e), &func_02112c08);
+            else
+                _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+                    c + 0x674, *(void **)(data_ov066_0211aeac + 4), c + 0x83c, 0x199,
+                    *(s16 *)(c + 0x8e), &func_02112d48);
+            func_020393d4(c + 0x674, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+            func_020393c4(c + 0x674, &func_ov066_0211a35c);
+            func_020398fc(c + 0x674);
+            _ZN16MeshColliderBase6EnableEP5Actor(c + 0x674, c);
+            *(int *)(c + 0x4a0) = 4;
+        }
+        break;
+
+    case 2:
+        if (_ZN9Animation8FinishedEv(c + 0x3b0) != 0) {
+            func_ov066_021165cc(c);
+            *(int *)(c + 0x4a0) = 3;
+        }
+        break;
+
+    case 4:
+        func_ov066_021162e8(c);
+        ApproachAngle((s16 *)(c + 0x8e), 0, 2, 0x400, 0x200);
+        Vec3_ApproachHorz(c + 0x5c, c + 0x4a4, 0x37000);
+        if (Vec3_HorzDist(c + 0x5c, c + 0x4a4) <= 0x37000) {
+            *(int *)(c + 0x5c) = *(int *)(c + 0x4a4);
+            *(int *)(c + 0x60) = *(int *)(c + 0x4a8);
+            *(int *)(c + 0x64) = *(int *)(c + 0x4ac);
+            data_ov066_0211ae08 = 2;
+            *(s16 *)(c + 0x8e) = 0;
+            *(int *)(c + 0x4a0) = 5;
+        }
+        break;
+
+    case 5:
+        if (data_ov066_0211ae04 != 9)
+            func_ov066_02119454(c, &data_ov066_0211b06c);
+        break;
+    }
+    return 1;
+}

--- a/src/func_ov066_021171b0.c
+++ b/src/func_ov066_021171b0.c
@@ -1,135 +1,143 @@
-// NONMATCHING: different op / idiom (div=99). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern char* _ZN5Actor13ClosestPlayerEv(void);
-extern void func_02012694(int a, char* b);
-extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(char* out, char* tgt, int step);
-extern int Vec3_Dist(char* a, char* b);
-extern void func_ov066_02116ac4(char* c, int v);
-extern int Vec3_ApproachHorz(char* out, char* a, int step);
-extern int Vec3_HorzDist(char* a, char* b);
-extern void func_ov066_02119454(char* c, void* p);
+/* candidate for func_ov066_021171b0 */
+typedef struct Vec3 { int x, y, z; } Vec3;
+
+extern void *_ZN5Actor13ClosestPlayerEv(void *thiz);
+extern void func_02012694(int a, void *b);
+extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(void *out, void *tgt, int step);
+extern int Vec3_Dist(void *a, void *b);
+extern void func_ov066_02116ac4(void *c, int v);
+extern int Vec3_ApproachHorz(void *out, void *a, int step);
+extern int Vec3_HorzDist(void *a, void *b);
+extern void func_ov066_02119454(void *c, void *p);
 extern unsigned char data_ov066_0211ae0c;
 extern unsigned char data_ov066_0211ae00;
 extern unsigned char data_ov066_0211ae08;
 extern unsigned char data_ov066_0211ae04;
-extern void* data_ov066_0211b06c;
+extern char data_ov066_0211b06c;
 
-int func_ov066_021171b0(char* c)
+int func_ov066_021171b0(void *thiz)
 {
-    switch (*(int*)(c + 0x4a0)) {
+    char *c = (char *)thiz;
+
+    switch (*(int *)(c + 0x4a0)) {
     case 0: {
-        int* q;
-        int* sp;
-        char* p = _ZN5Actor13ClosestPlayerEv();
-        if (p == 0) goto end;
-        sp = (int*)(p + 0x5c);
-        *(int*)(c + 0x4bc) = sp[0];
-        *(int*)(c + 0x4c0) = sp[1];
-        *(int*)(c + 0x4c4) = sp[2];
-        q = (int*)(c + 0x4c4);
-        *q -= 0xc8000;
-        if (*(int*)(c + 0x4c4) < (int)0xff3ae000) {
-            *(int*)(c + 0x4c4) = (int)0xff3ae000;
-        } else if (*(int*)(c + 0x4c4) > (int)0xff8c6000) {
-            *(int*)(c + 0x4c4) = (int)0xff8c6000;
+        char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
+        if (p == 0)
+            break;
+        {
+            Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+            *(int *)(c + 0x4bc) = pp->x;
+            *(int *)(c + 0x4c0) = pp->y;
+            *(int *)(c + 0x4c4) = pp->z;
+        }
+        *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) -= 0xc8000;
+        if (*(int *)(c + 0x4c4) < (int)0xff3ae000) {
+            *(int *)(c + 0x4c4) = (int)0xff3ae000;
+        } else if (*(int *)(c + 0x4c4) > (int)0xff8c6000) {
+            *(int *)(c + 0x4c4) = (int)0xff8c6000;
         }
         if (data_ov066_0211ae0c == 1) {
-            int* r;
-            *(short*)(c + 0x94) = -0x4000;
-            *(int*)(c + 0x4bc) = 0x334000;
-            if (*(int*)(c + 0x49c) == 1) {
-                r = (int*)(c + 0x4bc);
-                *r -= 0xf2000;
+            *(short *)(c + 0x94) = -0x4000;
+            *(int *)(c + 0x4bc) = 0x334000;
+            if (*(int *)(c + 0x49c) == 1) {
+                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0xf2000;
             }
         } else {
-            int* r;
-            *(short*)(c + 0x94) = 0x4000;
-            *(int*)(c + 0x4bc) = (int)0xffe8e000;
-            if (*(int*)(c + 0x49c) == 1) {
-                r = (int*)(c + 0x4bc);
-                *r -= 0xf2000;
+            *(short *)(c + 0x94) = 0x4000;
+            *(int *)(c + 0x4bc) = (int)0xffe8e000;
+            if (*(int *)(c + 0x49c) == 1) {
+                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0xf2000;
             }
         }
         func_02012694(0x144, c + 0x74);
-        *(int*)(c + 0x4c0) = *(int*)(c + 0x4a8) + 0x1c2000;
-        *(int*)(c + 0x4a0) = 1;
-        goto end;
+        *(int *)(c + 0x4c0) = *(int *)(c + 0x4a8) + 0x1c2000;
+        *(int *)(c + 0x4a0) = 1;
+        break;
     }
     case 1:
         _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(c + 0x5c, c + 0x4bc, 0x28000);
-        if (Vec3_Dist(c + 0x5c, c + 0x4bc) > 0x28000) goto end;
-        *(int*)(c + 0x5c) = *(int*)(c + 0x4bc);
-        *(int*)(c + 0x60) = *(int*)(c + 0x4c0);
-        *(int*)(c + 0x64) = *(int*)(c + 0x4c4);
-        data_ov066_0211ae00 |= *(int*)(c + 0x49c);
-        if (data_ov066_0211ae00 != 3) goto end;
-        *(short*)(c + 0x4d0) = 0xa;
+        if (Vec3_Dist(c + 0x5c, c + 0x4bc) > 0x28000)
+            break;
+        *(int *)(c + 0x5c) = *(int *)(c + 0x4bc);
+        *(int *)(c + 0x60) = *(int *)(c + 0x4c0);
+        *(int *)(c + 0x64) = *(int *)(c + 0x4c4);
+        data_ov066_0211ae00 |= *(int *)(c + 0x49c);
+        if (data_ov066_0211ae00 != 3)
+            break;
+        *(unsigned short *)(c + 0x4d0) = 0xa;
         if (data_ov066_0211ae0c == 1) {
-            if (*(int*)(c + 0x49c) == 2) *(short*)(c + 0x4d0) = 0x12;
+            if (*(int *)(c + 0x49c) == 2)
+                *(unsigned short *)(c + 0x4d0) = 0x12;
         } else {
-            if (*(int*)(c + 0x49c) == 1) *(short*)(c + 0x4d0) = 0x12;
+            if (*(int *)(c + 0x49c) == 1)
+                *(unsigned short *)(c + 0x4d0) = 0x12;
         }
-        *(int*)(c + 0x4c0) = *(int*)(c + 0x4a8) + 0x1a000;
-        *(int*)(c + 0x4a0) = 2;
-        goto end;
+        *(int *)(c + 0x4c0) = *(int *)(c + 0x4a8) + 0x1a000;
+        *(int *)(c + 0x4a0) = 2;
+        break;
     case 2:
-        if (*(unsigned short*)(c + 0x4d0) != 0) goto end;
+        if (*(unsigned short *)(c + 0x4d0) != 0)
+            break;
         _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(c + 0x5c, c + 0x4bc, 0x32000);
-        if (Vec3_Dist(c + 0x5c, c + 0x4bc) > 0x32000) goto end;
-        *(int*)(c + 0x5c) = *(int*)(c + 0x4bc);
-        *(int*)(c + 0x60) = *(int*)(c + 0x4c0);
-        *(int*)(c + 0x64) = *(int*)(c + 0x4c4);
+        if (Vec3_Dist(c + 0x5c, c + 0x4bc) > 0x32000)
+            break;
+        *(int *)(c + 0x5c) = *(int *)(c + 0x4bc);
+        *(int *)(c + 0x60) = *(int *)(c + 0x4c0);
+        *(int *)(c + 0x64) = *(int *)(c + 0x4c4);
         func_ov066_02116ac4(c, 0x7d0000);
-        *(short*)(c + 0x4d0) = 0xf;
-        *(int*)(c + 0x4a0) = 3;
-        goto end;
+        *(unsigned short *)(c + 0x4d0) = 0xf;
+        *(int *)(c + 0x4a0) = 3;
+        break;
     case 3: {
-        unsigned short st = *(unsigned short*)(c + 0x4d0);
-        if (st == 0) {
-            *(int*)(c + 0xa8) = 0x7c000;
-            *(int*)(c + 0x9c) = -0x14000;
-            *(int*)(c + 0x98) = 0x1e000;
-            *(int*)(c + 0xb0) = 0x2000000;
-            goto end;
+        unsigned short st = *(unsigned short *)(c + 0x4d0);
+        if (st != 0) {
+            if (st != 1)
+                break;
+            *(int *)(c + 0xa8) = 0x7c000;
+            *(int *)(c + 0x9c) = -0x14000;
+            *(int *)(c + 0x98) = 0x1e000;
+            *(int *)(c + 0xb0) = 0x2000000;
+            break;
         }
-        if (st != 1) goto end;
-        if (*(int*)(c + 0x9c) == 0) goto end;
-        if (*(int*)(c + 0x4a8) < *(int*)(c + 0x60)) goto end;
-        *(int*)(c + 0x60) = *(int*)(c + 0x4a8);
-        *(int*)(c + 0xa8) = 0;
-        *(int*)(c + 0x9c) = 0;
-        *(int*)(c + 0x98) = 0;
+        if (*(int *)(c + 0x9c) == 0)
+            break;
+        if (*(int *)(c + 0x4a8) < *(int *)(c + 0x60))
+            break;
+        *(int *)(c + 0x60) = *(int *)(c + 0x4a8);
+        *(int *)(c + 0xa8) = 0;
+        *(int *)(c + 0x9c) = 0;
+        *(int *)(c + 0x98) = 0;
         func_ov066_02116ac4(c, 0x7d0000);
-        *(short*)(c + 0x4d0) = 0xf;
-        *(int*)(c + 0x494) += 1;
-        if (*(int*)(c + 0x494) < 3) {
-            *(int*)(c + 0x4a0) = 3;
-        } else {
-            *(int*)(c + 0x4a0) = 4;
-        }
-        goto end;
+        *(unsigned short *)(c + 0x4d0) = 0xf;
+        *(int *)(((int)c + 0x494) & 0xFFFFFFFFFFFFFFFF) += 1;
+        if (*(int *)(c + 0x494) < 3)
+            *(int *)(c + 0x4a0) = 3;
+        else
+            *(int *)(c + 0x4a0) = 4;
+        break;
     }
     case 4:
-        if (*(unsigned short*)(c + 0x4d0) == 1) {
-            data_ov066_0211ae00 ^= *(int*)(c + 0x49c);
+        if (*(unsigned short *)(c + 0x4d0) == 1) {
+            data_ov066_0211ae00 ^= *(int *)(c + 0x49c);
         }
-        if (data_ov066_0211ae00 != 0) goto end;
+        if (data_ov066_0211ae00 != 0)
+            break;
         Vec3_ApproachHorz(c + 0x5c, c + 0x4a4, 0x28000);
-        if (Vec3_HorzDist(c + 0x5c, c + 0x4a4) > 0x28000) goto end;
+        if (Vec3_HorzDist(c + 0x5c, c + 0x4a4) > 0x28000)
+            break;
         data_ov066_0211ae0c = 0;
-        *(int*)(c + 0x5c) = *(int*)(c + 0x4a4);
-        *(int*)(c + 0x60) = *(int*)(c + 0x4a8);
-        *(int*)(c + 0x64) = *(int*)(c + 0x4ac);
+        *(int *)(c + 0x5c) = *(int *)(c + 0x4a4);
+        *(int *)(c + 0x60) = *(int *)(c + 0x4a8);
+        *(int *)(c + 0x64) = *(int *)(c + 0x4ac);
         data_ov066_0211ae08 += 1;
-        *(int*)(c + 0x4a0) = 5;
-        goto end;
+        *(int *)(c + 0x4a0) = 5;
+        break;
     case 5:
-        if (data_ov066_0211ae04 == 8) goto end;
-        *(int*)(c + 0xb0) = 0;
+        if (data_ov066_0211ae04 == 8)
+            break;
+        *(int *)(c + 0xb0) = 0;
         func_ov066_02119454(c, &data_ov066_0211b06c);
-        goto end;
+        break;
     }
-end:
     return 1;
 }

--- a/src/func_ov066_02118188.c
+++ b/src/func_ov066_02118188.c
@@ -1,44 +1,40 @@
-//cpp
-// NONMATCHING: different op / idiom (div=81). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" void func_ov066_021166c8(void *thiz);
-extern "C" void func_ov066_02116ac4(void *thiz, int a1);
-extern "C" void func_ov066_021165cc(void *thiz);
-extern "C" void func_02012694(int size, void *p);
-extern "C" void func_ov066_021164ec(void *thiz);
-extern "C" int func_ov066_02116390(void *thiz);
-extern "C" int func_ov066_0211603c(void *thiz);
-extern "C" int _ZN9Animation8FinishedEv(void *self);
-extern "C" void func_ov066_021162e8(void *thiz);
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *self);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void *self);
-extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
+/* candidate for func_ov066_02118188 */
+extern void func_ov066_021166c8(void *thiz);
+extern void func_ov066_02116ac4(void *thiz, int a1);
+extern void func_ov066_021165cc(void *thiz);
+extern void func_02012694(int size, void *p);
+extern void func_ov066_021164ec(void *thiz);
+extern int func_ov066_02116390(void *thiz);
+extern int func_ov066_0211603c(void *thiz);
+extern int _ZN9Animation8FinishedEv(void *self);
+extern void func_ov066_021162e8(void *thiz);
+extern int _ZN16MeshColliderBase9IsEnabledEv(void *self);
+extern void _ZN16MeshColliderBase7DisableEv(void *self);
+extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void *self, void *kcl, void *mtx, int fix, short s, void *clps);
-extern "C" void func_020393d4(void *p, void *v);
-extern "C" void func_020393c4(void *p, void *v);
-extern "C" void func_020398fc(void *p);
-extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void *self, void *actor);
-extern "C" int func_ov066_02119454(void *c, void *pmf);
+extern void func_020393d4(void *p, void *v);
+extern void func_020393c4(void *p, void *v);
+extern void func_020398fc(void *p);
+extern void _ZN16MeshColliderBase6EnableEP5Actor(void *self, void *actor);
+extern int func_ov066_02119454(void *c, void *pmf);
 
 extern unsigned char data_ov066_0211ae0c;
 extern unsigned char data_ov066_0211ae08;
 extern unsigned char data_ov066_0211abe0;
-extern void **data_ov066_0211ae14;
-extern void **data_ov066_0211aeac;
+extern char data_ov066_0211ae14[];
+extern char data_ov066_0211aeac[];
 extern unsigned char data_ov066_0211ae04;
-extern void *data_ov066_0211b06c;
-extern void func_02112c08();
-extern void func_02112d48();
-extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
-extern void func_ov066_0211a35c();
+extern char data_ov066_0211b06c;
+extern int func_02112c08;
+extern int func_02112d48;
+extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
+extern int func_ov066_0211a35c;
 
-extern "C" int func_ov066_02118188(void *thiz)
+int func_ov066_02118188(void *thiz)
 {
-    unsigned char *c = (unsigned char *)thiz;
-    int state = *(int *)(c + 0x4a0);
+    char *c = (char *)thiz;
 
-    switch (state) {
+    switch (*(int *)(c + 0x4a0)) {
     case 0:
         if (*(unsigned short *)(c + 0x4d0) != 0)
             break;
@@ -69,16 +65,17 @@ extern "C" int func_ov066_02118188(void *thiz)
         break;
 
     case 2:
-        if (*(int *)(c + 0x498) == 1 && data_ov066_0211ae08 != 0) {
-            if (*(int *)(c + 0x494) > 0x14) {
-                *(int *)(c + 0x494) = 0;
-                func_ov066_021165cc(c);
-                *(int *)(c + 0x4a0) = 4;
-                break;
+        if (*(int *)(c + 0x498) == 1) {
+            if (data_ov066_0211ae08 != 0) {
+                if (*(int *)(c + 0x494) > 0x14) {
+                    *(int *)(c + 0x494) = 0;
+                    func_ov066_021165cc(c);
+                    *(int *)(c + 0x4a0) = 4;
+                    break;
+                }
+                *(int *)(((int)c + 0x494) & 0xFFFFFFFFFFFFFFFF) += 1;
             }
         }
-
-        *(int *)(c + 0x494) = *(int *)(c + 0x494) + 1;
 
         if ((unsigned short)(*(int *)(c + 0x3b8) >> 0xc) == 0) {
             func_02012694(0x140, c + 0x74);
@@ -116,16 +113,16 @@ extern "C" int func_ov066_02118188(void *thiz)
 
         if (*(int *)(c + 0x49c) == 1) {
             _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-                c + 0x674, ((void **)&data_ov066_0211ae14)[1], c + 0x83c, 0x199,
-                *(short *)(c + 0x8e), (void *)func_02112c08);
+                c + 0x674, *(void **)(data_ov066_0211ae14 + 4), c + 0x83c, 0x199,
+                *(short *)(c + 0x8e), &func_02112c08);
         } else {
             _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-                c + 0x674, ((void **)&data_ov066_0211aeac)[1], c + 0x83c, 0x199,
-                *(short *)(c + 0x8e), (void *)func_02112d48);
+                c + 0x674, *(void **)(data_ov066_0211aeac + 4), c + 0x83c, 0x199,
+                *(short *)(c + 0x8e), &func_02112d48);
         }
 
-        func_020393d4(c + 0x674, (void *)_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-        func_020393c4(c + 0x674, (void *)func_ov066_0211a35c);
+        func_020393d4(c + 0x674, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+        func_020393c4(c + 0x674, &func_ov066_0211a35c);
         func_020398fc(c + 0x674);
         _ZN16MeshColliderBase6EnableEP5Actor(c + 0x674, c);
 

--- a/src/func_ov066_0211a2e4.c
+++ b/src/func_ov066_0211a2e4.c
@@ -1,16 +1,15 @@
-// NONMATCHING: register allocation (div=8). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void* _ZN5Actor13ClosestPlayerEv(void);
+extern void* _ZN5Actor13ClosestPlayerEv(void* c);
 extern unsigned char data_ov066_0211ae04;
 extern unsigned char data_ov066_0211ae08;
 
-void func_ov066_0211a2e4(int a, int b)
+void func_ov066_0211a2e4(void* a, int b)
 {
+    volatile int dummy[3];
+    (void)dummy;
     void* p;
     if (data_ov066_0211ae04 != 1) return;
     if (b == 0) return;
-    p = _ZN5Actor13ClosestPlayerEv();
+    p = _ZN5Actor13ClosestPlayerEv(a);
     if (p == 0) return;
     if (*(int*)((char*)p + 0x64) < (int)0xff387000) {
         data_ov066_0211ae08++;


### PR DESCRIPTION
## Summary

Byte-identical matches for six ov066 (Eyerok) helpers, verified with `tools/match.py` against the EU retail overlay using **mwccarm 1.2/sp2p3**.

| Function | Address | Size |
|---|---|---|
| `func_ov066_0211a2e4` | `0x211a2e4` | `0x78` |
| `func_ov066_02116390` | `0x2116390` | `0x15c` |
| `func_ov066_0211603c` | `0x211603c` | `0x2ac` |
| `func_ov066_02118188` | `0x2118188` | `0x338` |
| `func_ov066_021171b0` | `0x21171b0` | `0x40c` |
| `func_ov066_02116db0` | `0x2116db0` | `0x3e0` |

Replaces prior NONMATCHING drafts where present (including renaming `func_ov066_02118188.cpp` → `.c`).

### Matching notes (high level)

- **0211a2e4:** pass `this` into `ClosestPlayer`; `volatile int dummy[3]` for `sub sp,#0xc`
- **02116390:** xor of texture flip flag runs on *both* timer paths (not only the else)
- **0211603c:** `enum Bool` for actor-type test; shared fail epilogue; success path before death
- **02118188 / 021171b0 / 02116db0:** state machines with u64-mask launders for materialized bases

### Compiler

```
mwccarm 1.2/sp2p3
-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
```

### Near-misses (not in this PR)

Still open in the same claim range (refine later):

- `func_ov066_02118e04` @ `0x2118e04` — div≈20 (abe4 dual-store / `ip` schedule)
- `_ZN6Eyerok8BehaviorEv` @ `0x2119838` — regperm / frame (self in `r4` vs `sl`+`fp`)

## Test plan

- [x] Local `tools/match.py --version 1.2/sp2p3 --module ov066` reports MATCH for all six
- [ ] CI `validate` green on this PR