### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov089: 02130fb4 (0x02130fb4), 02131df4 (0x02131df4) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #251 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov089_02130fb4.c
+++ b/src/func_ov089_02130fb4.c
@@ -1,0 +1,36 @@
+extern unsigned int _ZN4cstd4sqrtEy(unsigned long long v);
+typedef struct { int x, y, z; } Vec3;
+extern int Vec3_HorzDist(const Vec3* a, const Vec3* b);
+extern short Vec3_HorzAngle(const Vec3* a, const Vec3* b);
+
+void func_ov089_02130fb4(char* c, int* p, int n) {
+    int dy = p[1] - *(int*)(c + 0x60);
+    if (dy < 0)
+        dy = -dy;
+    {
+        int s0 = (int)_ZN4cstd4sqrtEy((unsigned long long)(long long)n);
+        int s1 = (int)_ZN4cstd4sqrtEy((unsigned long long)(long long)(n + dy));
+        int s2 = (int)_ZN4cstd4sqrtEy((unsigned long long)(long long)n);
+        dy = (s0 * 0x1e) / (s1 + s2); /* reuse dy as r7 */
+    }
+    {
+        int left = -(n << 1);
+        int den = dy * dy;
+        n = 0x1e - dy; /* reuse n as inv (target overwrites r4) */
+        *(int*)(c + 0x9c) = left / den;
+    }
+    if (p[1] >= *(int*)(c + 0x60)) {
+        int v = *(int*)(c + 0x9c);
+        if (v < 0)
+            v = -v;
+        *(int*)(c + 0xa8) = n * v;
+    } else {
+        int v = *(int*)(c + 0x9c);
+        if (v < 0)
+            v = -v;
+        *(int*)(c + 0xa8) = (dy + 1) * v;
+    }
+    *(int*)(c + 0xa0) = -0x32000;
+    *(int*)(c + 0x98) = Vec3_HorzDist((const Vec3*)(c + 0x5c), (const Vec3*)p) / 30;
+    *(short*)(c + 0x94) = Vec3_HorzAngle((const Vec3*)(c + 0x5c), (const Vec3*)p);
+}

--- a/src/func_ov089_02131df4.c
+++ b/src/func_ov089_02131df4.c
@@ -1,6 +1,3 @@
-// NONMATCHING: base materialization / addressing (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int _ZN6Player17SetNoControlStateEhih(void* p, unsigned char a, int b, unsigned char d);
 extern void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int a);
 extern void func_ov089_0213115c(char* c, int i);
@@ -27,12 +24,20 @@ void func_ov089_02131df4(char* c, char* player)
     func_ov089_0213115c(c, 3);
     *(char**)(c + 0x110) = player;
     {
-        int* s = (int*)(*(char**)(c + 0x110) + 0x5c);
-        *(int*)(c + 0x5c) = s[0];
+        char* pl = *(char**)(c + 0x110);
+        /* force separate base materialization like ROM: r2=c+0xb0, r3=pl+0x5c */
+        int* fl = (int*)(unsigned)((unsigned long long)(unsigned)(c + 0xb0));
+        int* s = (int*)(unsigned)((unsigned long long)(unsigned)(pl + 0x5c));
+        int t0 = s[0];
+        int ev = 0x1d;
+        *(int*)(c + 0x5c) = t0;
         *(int*)(c + 0x60) = s[1];
         *(int*)(c + 0x64) = s[2];
+        {
+            int ang = *(short*)(*(char**)(c + 0x110) + 0x8e);
+            *(short*)(c + 0x8e) = ang;
+        }
+        *fl &= ~0x40000;
+        _ZN5Event6SetBitEj(ev);
     }
-    *(short*)(c + 0x8e) = *(short*)(*(char**)(c + 0x110) + 0x8e);
-    *(int*)(c + 0xb0) &= ~0x40000;
-    _ZN5Event6SetBitEj(0x1d);
 }


### PR DESCRIPTION
## Summary

Byte-identical matches (mwccarm **1.2/sp2p3**, standard C flags) for two ov089 Key helpers:

| Function | Addr | Size | Notes |
|---|---|---|---|
| `func_ov089_02130fb4` | `0x02130fb4` | `0x118` | Trajectory / arc setup (`cstd::sqrt`, `Vec3_HorzDist/Angle`). Register coloring via **reusing** `dy` as the ratio and `n` as `0x1e - ratio`. |
| `func_ov089_02131df4` | `0x02131df4` | `0x110` | Key collect → player handoff. **u64-mask laundering** forces `add r2,c,#0xb0` / `add r3,player,#0x5c` materialization. |

Verified locally:

```
python tools/match.py --c src/func_ov089_02130fb4.c --func func_ov089_02130fb4 --addr 0x2130fb4 --size 0x118 --version 1.2/sp2p3 --module ov089
python tools/match.py --c src/func_ov089_02131df4.c --func func_ov089_02131df4 --addr 0x2131df4 --size 0x110 --version 1.2/sp2p3 --module ov089
```

Both report `MATCHING VERSIONS: 1.2/sp2p3`.

## Near-misses still in progress (not in this PR)

| Function | Status |
|---|---|
| `func_ov089_02131b18` | div≈7 (case1 tail r0/r1/r2 regperm after schedule fix) |
| `func_ov089_021311c0` | large state machine, size gap |
| `func_ov089_0213162c` | large state machine, size gap |
| `_ZN3Key8BehaviorEv` | near-miss / compile residual |

Claims held for those ranges; matched functions left claimed per instructions.

## Test plan

- [x] Local `match.py` for both functions
- [ ] CI `validate` green