### PR TITLE
Match 7 ov091 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov091: _ZN22RotatingUpDownPlatform13InitResourcesEv (0x0213220c), _ZN25RotatingUpDownPlatformUtm13InitResourcesEv (0x021318f0), 02131db8 (0x02131db8), 02132f04 (0x02132f04), 021334b8 (0x021334b8), 02133c6c (0x02133c6c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #252 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,7 +20,6 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
-| ov091: _ZN22RotatingUpDownPlatform13InitResourcesEv (0x0213220c), _ZN25RotatingUpDownPlatformUtm13InitResourcesEv (0x021318f0), 02131db8 (0x02131db8), 02132f04 (0x02132f04), 021334b8 (0x021334b8), 02133c6c (0x02133c6c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #252 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.c
+++ b/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.c
@@ -1,6 +1,3 @@
-// NONMATCHING: base materialization / addressing (div=7). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
@@ -11,7 +8,7 @@ extern void func_020393c4(void* p, void* v);
 extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern int _ZNK7PathPtr8NumNodesEv(void* self);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, void* out, unsigned int idx);
-extern int Vec3_Equal(void* a, void* b);
+extern int Vec3_equal(void* a, void* b);
 
 extern int data_ov091_021344fc[];
 extern int data_ov091_021344f4[];
@@ -48,10 +45,10 @@ int _ZN22RotatingUpDownPlatform13InitResourcesEv(char* c)
     *(int*)(c + 0x334) = *(int*)(c + 0x64);
     _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x344, c + 0x338, *(unsigned*)(c + 0x328));
 
-    if (Vec3_Equal(c + 0x338, c + 0x32c)) {
-        int* p = (int*)(c + 0x328);
+    if (Vec3_equal(c + 0x338, c + 0x32c)) {
+        int* p = (int*)(((int)c + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
         *p = *p + 1;
-        _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x344, c + 0x338, *p);
+        _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x344, c + 0x338, *(unsigned*)(c + 0x328));
     }
 
     *(short*)(c + 0x350) = *(short*)(c + 0x8e);

--- a/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.c
+++ b/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.c
@@ -1,6 +1,3 @@
-// NONMATCHING: missing logic (ROM does more) (div=49). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 enum Bool { FALSE, TRUE };
 
 typedef struct { int x, y, z; } Vector3;
@@ -46,7 +43,8 @@ int _ZN25RotatingUpDownPlatformUtm13InitResourcesEv(char *c)
     void *kcl;
 
     if (*(unsigned int*)(c + 8) == 0xffff) {
-        *(int*)(c + 0xb0) &= ~2;
+        int *p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+        *p = *p & ~2;
         _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, 0, 0x1000, 0, 0);
         return 1;
     }
@@ -70,18 +68,24 @@ int _ZN25RotatingUpDownPlatformUtm13InitResourcesEv(char *c)
     c[0x394] = (unsigned char)(*(unsigned int*)(c + 8) & 0xf);
 
     if ((unsigned char)c[0x394] == 2) {
-        idx395 = (unsigned char)c[0x395];
-        Vec3_Add(&v, (Vector3*)(c + 0x388), (Vector3*)((char*)data_ov091_02134cdc + idx395 * 0x78));
-        idx395 = (unsigned char)c[0x395];
-        v.y += *(int*)((char*)data_ov091_02134d1c + idx395 * 0x78);
+        char *tbl = data_ov091_02134cdc;
+        int s = 0x78;
+        int i = (unsigned char)c[0x395];
+        Vec3_Add(&v, (Vector3*)(c + 0x388), (Vector3*)(tbl + i * s));
+        i = (unsigned char)c[0x395];
+        v.y += *(int*)(data_ov091_02134d1c + i * s);
         _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x1d, 0xffff, &v, 0, *(signed char*)(c + 0xcc), -1);
     }
 
     Matrix4x3_FromRotationY(&data_020a0e68, *(short*)(c + 0x8e));
 
-    idx395 = (unsigned char)c[0x395];
-    idx394 = (unsigned char)c[0x394];
-    MulVec3Mat4x3((Vector3*)((char*)data_ov091_02134cdc + idx395 * 0x78 + idx394 * 0xc), &data_020a0e68, &rotated);
+    {
+        char *tbl = data_ov091_02134cdc;
+        int s = 0x78;
+        int i = (unsigned char)c[0x395];
+        idx394 = (unsigned char)c[0x394];
+        MulVec3Mat4x3((Vector3*)(tbl + i * s + idx394 * 0xc), &data_020a0e68, &rotated);
+    }
 
     Vec3_Add(&v2, (Vector3*)(c + 0x388), &rotated);
 

--- a/src/_ZN6Thwomp8BehaviorEv.cpp
+++ b/src/_ZN6Thwomp8BehaviorEv.cpp
@@ -1,0 +1,95 @@
+//cpp
+extern "C" {
+void func_ov091_02133020(char *c);
+void func_ov091_02132ff4(char *c);
+void func_ov091_02132f04(char *c);
+void func_ov091_02132e98(char *c);
+void func_ov091_02132e64(char *c);
+void func_ov091_02133098(char *c);
+int func_ov091_02132dc0(char *c);
+int _ZN9Animation7AdvanceEv(void *self);
+int _ZN9Animation8FinishedEv(void *self);
+void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
+void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
+int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
+
+int _ZN6Thwomp8BehaviorEv(char *c)
+{
+    if (*(int *)(c + 0x398) < 2) {
+        if (*(unsigned char *)(c + 0x3a2) != 0)
+            *(int *)(c + 0x398) = 2;
+    }
+    switch (*(int *)(c + 0x398)) {
+    case 0: {
+        unsigned short cnt = (unsigned short)(*(int *)(c + 0x32c) >> 12);
+        if (cnt != 0) {
+            *(int *)(c + 0x32c) = (int)((((unsigned)cnt - 1) << 16) >> 4);
+            cnt = (unsigned short)(*(int *)(c + 0x32c) >> 12);
+            if (cnt == 0) {
+                char *p = c + 0x300;
+                *(unsigned short *)(p + 0xa0) = 0xa;
+            }
+        } else {
+            char *p = (char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+            int t = *(unsigned short *)(p + 0xa0);
+            if (t != 0) {
+                unsigned short *q = (unsigned short *)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                *q = *q - 1;
+            } else {
+                func_ov091_02133020(c);
+            }
+        }
+        break;
+    }
+    case 1:
+        func_ov091_02132ff4(c);
+        break;
+    case 2:
+        if (*(unsigned char *)(c + 0x3a2) != 0) {
+            *(int *)(c + 0x32c) = 0;
+            func_ov091_02132f04(c);
+        } else {
+            _ZN9Animation7AdvanceEv(c + 0x324);
+            if (_ZN9Animation8FinishedEv(c + 0x324) != 0) {
+                char *p = (char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                int t = *(unsigned short *)(p + 0xa0);
+                if (t != 0) {
+                    unsigned short *q = (unsigned short *)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                    *q = *q - 1;
+                } else {
+                    func_ov091_02132f04(c);
+                }
+            } else {
+                char *p = c + 0x300;
+                *(unsigned short *)(p + 0xa0) = 5;
+            }
+        }
+        break;
+    case 3:
+        func_ov091_02132e98(c);
+        if (*(int *)(c + 0x398) == 4) {
+            if (*(unsigned char *)(c + 0x3a2) != 0) {
+                *(unsigned char *)(c + 0x39e) = 0x5a;
+                *(unsigned char *)(c + 0x3a2) = 0;
+            }
+        }
+        break;
+    case 4:
+        if (*(unsigned char *)(c + 0x3a2) != 0) {
+            *(unsigned char *)(c + 0x3a2) = 0;
+            *(unsigned char *)(c + 0x39e) = 0x5a;
+        }
+        func_ov091_02132e64(c);
+        break;
+    }
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    func_ov091_02133098(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) == 0) {
+        if (func_ov091_02132dc0(c) == 0)
+            goto done;
+    }
+    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+done:
+    return 1;
+}
+}

--- a/src/func_ov091_02131db8.c
+++ b/src/func_ov091_02131db8.c
@@ -1,12 +1,11 @@
-// NONMATCHING: base materialization / addressing (div=8). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef struct { int x, y, z; } Vec3;
 extern void AddVec3(Vec3* out, const Vec3* a, const Vec3* b);
 extern int Vec3_Dist(const Vec3* a, const Vec3* b);
 extern int _ZNK7PathPtr7GetNodeER7Vector3j(void* p, Vec3* v, unsigned int i);
 extern void func_ov091_02131cb0(void* c, const Vec3* v0, const Vec3* v1);
 extern void func_02010da4(void* c);
+
+#define LAUNDER_P(base, off) ((int *)((unsigned long long)((int)(base) + (off)) & 0xFFFFFFFFFFFFFFFFULL))
 
 int func_ov091_02131db8(char* c) {
     int r4;
@@ -20,17 +19,17 @@ int func_ov091_02131db8(char* c) {
         *(int*)(c+0x60) = *(int*)(c+0x330);
         *(int*)(c+0x64) = *(int*)(c+0x334);
         if (*(int*)(c+0x320) == 1) {
-            int* p328 = (int*)(c+0x328);
-            *p328 = *p328 + 1;
-            if (*p328 >= *(int*)(c+0x324)) {
-                *p328 = *(int*)(c+0x324) - 2;
+            int *p = LAUNDER_P(c, 0x328);
+            *p = *p + 1;
+            if (*(int*)(c+0x328) >= *(int*)(c+0x324)) {
+                *(int*)(c+0x328) = *(int*)(c+0x324) - 2;
                 r4 = -1;
             }
         } else {
-            int* p328 = (int*)(c+0x328);
-            *p328 = *p328 - 1;
-            if (*p328 < 0) {
-                *p328 = r4;
+            int *p = LAUNDER_P(c, 0x328);
+            *p = *p - 1;
+            if (*(int*)(c+0x328) < 0) {
+                *(int*)(c+0x328) = r4;
                 r4 = -1;
             }
         }

--- a/src/func_ov091_02132f04.c
+++ b/src/func_ov091_02132f04.c
@@ -1,40 +1,40 @@
 //cpp
-// NONMATCHING: base materialization / addressing (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 struct V3 { int x, y, z; };
 int _ZN5Actor15HugeLandingDustEb(void*, int);
-int _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(int, struct V3);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 int _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void*, struct V3*, int);
 int func_0201267c(int, void*);
 void func_ov091_02132f04(char* c){
-  int* pa8 = (int*)(c+0xa8);
-  int* p60 = (int*)(c+0x60);
-  *pa8 = *pa8 - 0x4000;
-  *p60 = *p60 + *(int*)(c+0xa8);
+  int *pa8 = (int*)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFFLL);
+  int a = *pa8;
+  int *p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+  a = a - 0x4000;
+  *pa8 = a;
+  a = *p60 + *(int*)(c+0xa8);
+  *p60 = a;
   if(*(int*)(c+0x60) > *(int*)(c+0x394)) return;
   *(int*)(c+0x60) = *(int*)(c+0x394);
-  *(int*)(c+0xa8) = 0;
+  int zero = 0;
+  *(int*)(c+0xa8) = zero;
   *(int*)(c+0x398) = 3;
   *(unsigned char*)(c+0x39e) = 0xa;
-  int flag = 0;
-  if(*(unsigned short*)(c+0xc) == 0xa1) flag = 1;
-  if(flag != 0){
+  if(*(unsigned short*)(c+0xc) == 0xa1) zero = 1;
+
+  struct { struct V3 part; struct V3 quake; } sp;
+  if(zero != 0){
     _ZN5Actor15HugeLandingDustEb(c, 1);
   } else {
-    struct V3 v;
-    v.x = *(int*)(c+0x5c);
-    v.y = *(int*)(c+0x60);
-    v.z = *(int*)(c+0x64);
-    v.y = *(int*)(c+0x60) + 0x3c000;
-    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x2e, v);
+    sp.part.x = *(int*)(c+0x5c);
+    sp.part.y = *(int*)(c+0x60);
+    sp.part.z = *(int*)(c+0x64);
+    sp.part.y = sp.part.y + 0x3c000;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x2e, sp.part.x, sp.part.y, sp.part.z);
   }
-  struct V3 w;
-  w.x = *(int*)(c+0x5c);
-  w.y = *(int*)(c+0x60);
-  w.z = *(int*)(c+0x64);
-  _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, &w, 0x7d0000);
+  sp.quake.x = *(int*)(c+0x5c);
+  sp.quake.y = *(int*)(c+0x60);
+  sp.quake.z = *(int*)(c+0x64);
+  _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, &sp.quake, 0x7d0000);
   func_0201267c(0xc7, c+0x74);
 }
 }

--- a/src/func_ov091_021334b8.cpp
+++ b/src/func_ov091_021334b8.cpp
@@ -1,0 +1,50 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
+extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
+extern "C" int _ZN5Actor18GetBitInDeathTableEv(void *c);
+extern "C" void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void *c, Vector3 const &v, unsigned int n, int f, short s);
+extern "C" void _ZN5Actor17TrackInDeathTableEv(void *c);
+extern "C" void func_ov091_02133498(char *c);
+
+extern "C" void func_ov091_021334b8(char *c, int flag)
+{
+    if (flag != 0) {
+        unsigned char n = *(unsigned char *)(c + 0x31e);
+        int *p = (int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int m = n * 0x3c;
+        int y = *p;
+        *p = y - (m << 12);
+        *(unsigned char *)(c + 0x31e) = 0;
+    } else {
+        int *p = (int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int y = *p;
+        *p = y - 0x3c000;
+        int off = 0x31e;
+        unsigned char *q = (unsigned char *)(((int)c + off) & 0xFFFFFFFFFFFFFFFFLL);
+        *q = *q - 1;
+    }
+    *(unsigned char *)(c + 0x31f) = 0xf;
+    _ZN8Platform21UpdateModelPosAndRotYEv(c);
+    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    if (*(unsigned char *)(c + 0x31e) != 0) return;
+
+    struct {
+        int vx, vy, vz;
+        int v2x, v2y, v2z;
+    } st;
+    st.vx = *(int *)(c + 0x5c);
+    st.vy = *(int *)(c + 0x60);
+    st.vz = *(int *)(c + 0x64);
+    st.vy = st.vy + 0x17c000;
+    if (*(unsigned char *)(c + 0x320) == 0) {
+        if (_ZN5Actor18GetBitInDeathTableEv(c) == 0) {
+            st.v2x = st.vx;
+            st.v2y = st.vy;
+            st.v2z = st.vz;
+            _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, *(struct Vector3 *)&st.v2x, 5, 0x5000, 0);
+        }
+    }
+    _ZN5Actor17TrackInDeathTableEv(c);
+    func_ov091_02133498(c);
+}

--- a/src/func_ov091_02133c6c.c
+++ b/src/func_ov091_02133c6c.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int s32;
 typedef struct { s32 x, y, z; } Vector3;
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
@@ -14,18 +11,22 @@ extern int data_020a0e68[];
 
 extern "C" int func_ov091_02133c6c(char* c){
   Vector3 v;
-  v.z = 0x1e000;
-  short* a = (short*)(c+0x92);
+  short* a;
   v.x = 0;
   v.y = 0;
-  *a = *a - 0x80;
+  v.z = 0x1e000;
+  a = (short*)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFFLL);
+  *a = (short)(*a - 0x80);
   Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c+0x94));
   Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(short*)(c+0x92));
   MulVec3Mat4x3(&v, data_020a0e68, (Vector3*)(c+0xa4));
-  if (*(unsigned short*)(c+0x100) != 0
-      && _ZNK12WithMeshClsn10IsOnGroundEv(c+0x144) == 0
-      && _ZNK12WithMeshClsn8IsOnWallEv(c+0x144) == 0
-      && (*(int*)(c+0xb0) & 8))
-    _ZN9ActorBase18MarkForDestructionEv(c);
+  {
+    unsigned short *hp = (unsigned short*)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFLL);
+    if (*hp == 0
+        || _ZNK12WithMeshClsn10IsOnGroundEv(c+0x144) != 0
+        || _ZNK12WithMeshClsn8IsOnWallEv(c+0x144) != 0
+        || (*(int*)(c+0xb0) & 8))
+      _ZN9ActorBase18MarkForDestructionEv(c);
+  }
   return 1;
 }


### PR DESCRIPTION
## Summary
Byte-identical matches for **7** ov091 functions against the EU retail ROM (mwccarm 1.2/sp2p3).

| Function | Addr | Size | Notes |
|---|---|---|---|
| `func_ov091_02131db8` | 0x02131db8 | 0x138 | u64-mask launder for path-index RMW |
| `func_ov091_02133c6c` | 0x02133c6c | 0xb0 | destroy when timer==0 OR ground/wall OR flags&8 |
| `_ZN22RotatingUpDownPlatform13InitResourcesEv` | 0x0213220c | 0x154 | launder on node index |
| `func_ov091_02132f04` | 0x02132f04 | 0xf0 | landing dust / earthquake |
| `func_ov091_021334b8` | 0x021334b8 | 0x11c | //cpp dual frame |
| `_ZN25RotatingUpDownPlatformUtm13InitResourcesEv` | 0x021318f0 | 0x2b4 | mla decl order tbl/s/i |
| `_ZN6Thwomp8BehaviorEv` | 0x02132ab0 | 0x1d4 | dual-base launder timer; predicated subne/strhne; flag reuse via `*q=*q-1; if(*q)` |

Still grinding the remaining 3 of the original batch of 10:
- `func_ov091_02133098` (13-div: Fix12 lsr/adc schedule + b8 interleave)
- `func_ov091_02131160` (38-div: early `add lr,sp,#0x18` + reg coloring)
- `func_ov091_02133d30` (regalloc; permuter ~1.5k)

Verified locally with `tools/match.py --version 1.2/sp2p3 --module ov091` and `tools/fdiff.py`.

## Test plan
- [ ] CI `validate` green on all seven files