### PR TITLE
Match 2 ov034 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov034: 02112020 (0x02112020), 02112484 (0x02112484) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #253 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov034_02112020.c
+++ b/src/func_ov034_02112020.c
@@ -1,35 +1,21 @@
-// NONMATCHING: missing logic (ROM does more) (div=3). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_strength_reduction off
 
-extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int a, int b, unsigned int u);
-struct G
-{
-  int *p[2];
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *anim, void *file, int a, int b, unsigned int u);
+
+struct Ent {
+    int pad;
+    void *f;
 };
-extern struct G data_ov034_02113888;
-struct E
-{
-  int w[16];
-};
+extern struct Ent *data_ov034_02113888[];
+
 void func_ov034_02112020(char *c)
 {
-  struct E *new_var2;
-  int i;
-  struct E *arr = (struct E *) c;
-  char *new_var3;
-  char *new_var;
-  if (1)
-  {
-  }
-  new_var3 = ((char *) (new_var2 = &arr[i])) + 0x490;
-  for (i = 0; i < 5; i++)
-  {
-    *((int *) new_var3) &= ~4;
-  }
-
-  *((unsigned char *) (c + 0x8da)) = 0;
-  new_var = c + 0x110;
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(new_var, (void *) data_ov034_02113888.p[0][1], 0x40000000, 0x1000, 0);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x174, (void *) data_ov034_02113888.p[1][1], 0x40000000, 0x1000, 0);
+    int i;
+    for (i = 0; i < 5; i++) {
+        int *p = (int *)(void *)(unsigned long long)(unsigned)(c + (i << 6) + 0x490);
+        *p &= ~4;
+    }
+    *(unsigned char *)(c + 0x8da) = 0;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, data_ov034_02113888[0]->f, 0x40000000, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x174, data_ov034_02113888[1]->f, 0x40000000, 0x1000, 0);
 }

--- a/src/func_ov034_02112484.c
+++ b/src/func_ov034_02112484.c
@@ -1,12 +1,8 @@
 //cpp
-// NONMATCHING: different op / idiom (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_strength_reduction off
 extern int data_ov034_02114488;
 extern char data_020a0e68[];
-
 struct Vec3 { int x, y, z; };
-
 extern "C" int _ZN5Actor18HorzAngleToCPlayerEv(void *self);
 extern "C" void Matrix4x3_FromRotationY(void *m, int angle);
 extern "C" void MulVec3Mat4x3(struct Vec3 *in, void *m, struct Vec3 *out);
@@ -15,38 +11,52 @@ extern "C" void Vec3_Add(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
 extern "C" void func_ov034_02112484(char *sl)
 {
     int sb;
+    char *r8;
+    char *r7;
+    int zero;
     struct Vec3 in;
     struct Vec3 out;
     struct Vec3 sum;
-    char *r8 = sl;
-    char *r7 = sl;
-    *(int *)(sl + 0x8c8) = 0;
+
+    sb = 0;
+    *(int *)(sl + 0x8c8) = sb;
     *(int *)(sl + 0x98) = data_ov034_02114488;
-    for (sb = 0; sb < 5; sb++) {
+    r8 = sl;
+    r7 = sl;
+    zero = sb;
+    for (; sb < 5; sb++, r8 += 0xc, r7 += 6) {
         if (sb == 0) {
             *(int *)(r8 + 0x3cc) = *(int *)(sl + 0x5c);
             *(int *)(r8 + 0x3d0) = *(int *)(sl + 0x60);
             *(int *)(r8 + 0x3d4) = *(int *)(sl + 0x64);
-            *(short *)(r7 + 0x400 + 0x46) = (short)_ZN5Actor18HorzAngleToCPlayerEv(sl);
-            *(short *)(sl + 0x94) = *(short *)(r7 + 0x400 + 0x46);
+            {
+                short ang = (short)_ZN5Actor18HorzAngleToCPlayerEv(sl);
+                *(short *)(r7 + 0x446) = ang;
+                *(short *)(sl + 0x94) = *(short *)(r7 + 0x446);
+            }
         } else {
-            int r6 = sb - 1;
-            in.x = 0;
-            in.y = 0;
-            in.z = -*(int *)(sl + sb * 4 + 0x464);
-            out.x = 0;
-            out.y = 0;
-            out.z = 0;
-            Matrix4x3_FromRotationY(data_020a0e68, (short)(*(short *)(sl + 0x400 + 0x46) + 0x200));
+            int r6;
+            int zval;
+            char *angbase;
+            zval = -*(int *)(sl + (sb << 2) + 0x464);
+            angbase = sl + 0x400;
+            in.x = zero;
+            in.y = zero;
+            out.x = zero;
+            out.y = zero;
+            out.z = zero;
+            in.z = zval;
+            {
+                short ang = *(short *)(angbase + 0x46);
+                Matrix4x3_FromRotationY(data_020a0e68, (short)(ang + 0x200));
+            }
             MulVec3Mat4x3(&in, data_020a0e68, &out);
+            r6 = sb - 1;
             Vec3_Add(&sum, (struct Vec3 *)(sl + 0x3cc + r6 * 0xc), &out);
             *(int *)(r8 + 0x3cc) = sum.x;
             *(int *)(r8 + 0x3d0) = sum.y;
             *(int *)(r8 + 0x3d4) = sum.z;
-            *(short *)(r7 + 0x400 + 0x46) =
-                *(short *)(sl + r6 * 6 + 0x400 + 0x46);
+            *(short *)(r7 + 0x446) = *(short *)(sl + r6 * 6 + 0x446);
         }
-        r8 += 0xc;
-        r7 += 6;
     }
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for two ov034 (Wiggler-related) helpers, compiled with **mwccarm 1.2/sp2p3** and flags `-O4,p -enum int -lang c99/-lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.

| Function | Address | Size | Notes |
|---|---|---|---|
| `func_ov034_02112020` | `0x02112020` | `0x8c` | C; `#pragma opt_strength_reduction off` + u64 cast launder for `add base,idx,lsl#6` + separate `add #0x490` address materialization |
| `func_ov034_02112484` | `0x02112484` | `0x134` | C++ (`//cpp`); strength_reduction off; else-branch field store order for stack Vec3 setup |

Local verification:
```
python tools/match.py --c src/func_ov034_02112020.c --func func_ov034_02112020 --addr 0x2112020 --size 0x8c --version 1.2/sp2p3 --module ov034
python tools/fdiff.py --c src/func_ov034_02112484.c --name func_ov034_02112484 --module ov034 --addr 0x2112484 --size 0x134
```
Both report MATCH / mismatches=0.

## Test plan

- [x] Local `match.py` / `fdiff.py` byte-identical for both
- [ ] CI `validate` green