### PR TITLE
NONMATCHING: func_ov078_021240a0 near-miss (div=7) for refine

### DIFF
--- a/src/func_ov078_021240a0.c
+++ b/src/func_ov078_021240a0.c
@@ -1,6 +1,6 @@
-// NONMATCHING: different op / idiom (div=104). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+// NONMATCHING: regperm on random-angle clamp (div=7). Logic+shape otherwise
+// byte-identical at mwccarm 1.2/sp2p3. Remaining: r0/r1 swap for lim vs
+// shifted random (lsl/mov #0x4000/asr/rsb block at +0x1f0).
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
 extern void func_ov078_02125c24(char* c, int a);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(char* c);
@@ -28,67 +28,85 @@ struct V3 { int x, y, z; };
 int func_ov078_021240a0(char* c)
 {
     struct V3 v;
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x110)) {
+    short msg;
+
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x110) != 0) {
         if (*(int*)(c + 0x500) <= 0) {
             if (*(int*)(c + 0x98) != 0) {
                 *(int*)(c + 0x98) = 0;
                 func_ov078_02125c24(c, 0x7d0000);
             }
-            if ((*(unsigned short*)(*(int*)(c + 0x430) + 0x6ce) & 0x800) != 0)
+            if ((unsigned short)(*(unsigned short*)(*(int*)(c + 0x430) + 0x6ce) & 0x800) != 0)
                 return 1;
-            _ZN5Actor18HorzAngleToCPlayerEv(c);
+
             ApproachAngle((short*)(c + 0x94), _ZN5Actor18HorzAngleToCPlayerEv(c), 5, 0x1000, 0x200);
             *(short*)(c + 0x8e) = *(short*)(c + 0x94);
             if (AngleDiff(_ZN5Actor18HorzAngleToCPlayerEv(c), *(short*)(c + 0x8e)) < 0x1000) {
                 char* pl = (char*)(long)*(int*)(c + 0x430);
-                if (_ZN6Player9StartTalkER9ActorBaseb(pl, c, 1)) {
-                    int msg;
+                if (_ZN6Player9StartTalkER9ActorBaseb(pl, c, 1) != 0) {
+                    msg = 0;
                     if (data_0209f220 == 1) {
-                        msg = (short)(*(int*)(pl + 8) + 0x9a);
+                        msg += (short)(*(int*)(pl + 8) + 0x9a);
                     } else {
                         msg = 0x95;
                     }
                     _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x14, 0x15666);
-                    if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(pl, c, msg, c + 0x5c, 0, 0)) {
+                    if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(pl, c, (int)msg, c + 0x5c, 0, 0) != 0) {
                         func_02012694(0x12a, c + 0x74);
                         func_ov078_02125c48(c, &data_ov078_0212705c);
                     }
                 }
             }
-        } else {
-            if (*(unsigned char*)(c + 0x499) == 0) {
-                func_02012694(0x128, c + 0x74);
-                func_ov078_02125c24(c, 0x7d0000);
-                _ZN5Actor15HugeLandingDustEb(c, 1);
-                *(unsigned char*)(c + 0x499) = 1;
-            }
-            if (*(unsigned short*)(c + 0x100) == 0) {
-                *(int*)(c + 0x49c) = 0;
-                func_ov078_02125c48(c, &data_ov078_0212702c);
-                return 1;
-            }
-            if (Vec3_Dist(c + 0x4d4, c + 0x5c) < 0x258000) {
-                int r = RandomIntInternal(&data_0209e650);
-                int d = ((r >> 8) & 0xf) << 0x1c >> 0x10;
-                if (d < -0x4000) d = -0x4000;
-                else if (d > 0x4000) d = 0x4000;
-                *(short*)(c + 0x4fa) = *(short*)(c + 0x4fa) + d;
-            } else {
-                *(short*)(c + 0x4fa) = Vec3_HorzAngle(c + 0x5c, c + 0x4d4);
-            }
-            *(unsigned char*)(c + 0x499) = 0;
-            *(int*)(c + 0xa8) = 0x1e000;
-            *(int*)(c + 0x98) = 0xa000;
+            return 1;
         }
+
+        if (*(unsigned char*)(c + 0x499) == 0) {
+            func_02012694(0x128, c + 0x74);
+            func_ov078_02125c24(c, 0x7d0000);
+            _ZN5Actor15HugeLandingDustEb(c, 1);
+            *(unsigned char*)(c + 0x499) = 1;
+        }
+        if (*(unsigned short*)(c + 0x100) == 0) {
+            *(int*)(c + 0x49c) = 0;
+            func_ov078_02125c48(c, &data_ov078_0212702c);
+            return 1;
+        }
+        if (Vec3_Dist(c + 0x4d4, c + 0x5c) < 0x258000) {
+            int r = RandomIntInternal(&data_0209e650);
+            int lim;
+            int d;
+            int nlim;
+            r = ((unsigned)r >> 8) & 0xf;
+            r <<= 0x1c;
+            lim = 0x4000;
+            d = r >> 0x10;
+            nlim = -lim;
+            if (d < nlim)
+                d = nlim;
+            else if (d > lim)
+                d = lim;
+            {
+                short* p = (short*)((unsigned long long)((int)c + 0x4fa) & 0xFFFFFFFFFFFFFFFFULL);
+                *p = (short)(*p + d);
+            }
+        } else {
+            *(short*)(c + 0x4fa) = Vec3_HorzAngle(c + 0x5c, c + 0x4d4);
+        }
+        *(unsigned char*)(c + 0x499) = 0;
+        *(int*)(c + 0xa8) = 0x1e000;
+        *(int*)(c + 0x98) = 0xa000;
     } else {
-        if (*(int*)(c + 0xa8) < 0 && *(int*)(c + 0x360) != 0) {
-            char* a = (char*)_ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x360));
-            if (a != 0) {
-                int b = (*(unsigned short*)(a + 0xc) == 0xbf);
-                if (b != 0) {
-                    v = *(struct V3*)(a + 0x5c);
-                    if (*(int*)(c + 0x60) > v.y)
-                        _ZN6Player12Unk_020c6a10Ej(a, 1);
+        if (*(int*)(c + 0xa8) < 0) {
+            unsigned int id = *(unsigned int*)(c + 0x360);
+            if (id != 0) {
+                char* a = (char*)_ZN5Actor10FindWithIDEj(id);
+                if (a != 0) {
+                    int b = (int)(*(unsigned short*)(a + 0xc) == 0xbf);
+                    if (b != 0) {
+                        v = *(struct V3*)(a + 0x5c);
+                        if (*(int*)(c + 0x60) > v.y)
+                            _ZN6Player12Unk_020c6a10Ej(a, 1);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Near-miss draft for `func_ov078_021240a0` @ `0x21240a0` (size `0x320`, ov078).

- **div: 104 → 7** (size now exact)
- Remaining wall: regperm on random-angle clamp (`+0x1f0`–`+0x210`) — ROM keeps shifted random in `r0` and `0x4000` in `r1`; candidate swaps them
- Logic and rest of shape byte-identical (reloc wildcards)

## Verify
```
python tools/match.py --c src/func_ov078_021240a0.c --func func_ov078_021240a0 --addr 0x21240a0 --size 0x320 --version 1.2/sp2p3 --module ov078
```

Compiler: **mwccarm 1.2/sp2p3**. Highest-yield input for the refine/permuter tier.