### PR TITLE
Match 4 ov073 ChiefChilly helpers byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov073: 0211f144 (0x0211f144), 0211f494 (0x0211f494), 0211fa74 (0x0211fa74), 0212128c (0x0212128c) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #256 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov073_0211f144.c
+++ b/src/func_ov073_0211f144.c
@@ -1,0 +1,37 @@
+typedef struct { int x, y, z; } Vector3;
+typedef int Fix12i;
+extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
+extern void Matrix4x3_FromRotationY(void* m, short ang);
+extern void MulVec3Mat4x3(const Vector3* in, void* m, Vector3* out);
+extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int, unsigned int, Fix12i, Fix12i, Fix12i, const void*, void*);
+extern void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
+extern int data_020a0e68[];
+void func_ov073_0211f144(char* c) {
+
+    Vector3 pos, in, out;
+    int y;
+    ((int*)&pos)[0] = *(int*)(c + 0x5c);
+    y = *(int*)(c + 0x60);
+    ((int*)&pos)[1] = y;
+    ((int*)&pos)[2] = *(int*)(c + 0x64);
+    ((int*)&pos)[1] = y + (int)(((long long)*(int*)(c + 0x80) * 0x1e000 + 0x800) >> 12);
+
+    Vec3_HorzAngle((Vector3*)(c + 0x5c), (Vector3*)(c + 0x3d8));
+    in.z = 0; in.z = 0xc8000; in.x = 0; in.y = 0;
+    out.x = 0; out.y = 0; out.z = 0;
+    Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c + 0x94));
+    MulVec3Mat4x3(&in, data_020a0e68, &out);
+    pos.x = pos.x + out.x;
+    pos.z = pos.z + out.z;
+    *(unsigned int*)(c + 0x4f8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(unsigned int*)(c + 0x4f8), 0x77, pos.x, pos.y, pos.z, 0, 0);
+    *(unsigned int*)(c + 0x4fc) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(unsigned int*)(c + 0x4fc), 0x78, pos.x, pos.y, pos.z, 0, 0);
+    if (*(unsigned int*)(c + 0x4f8) != 0) {
+        void* sys = _ZN8Particle6System12FromUniqueIDEj(*(unsigned int*)(c + 0x4f8));
+        if (sys != 0) *(int*)((char*)sys + 0x44) = *(int*)(c + 0x80) * 0x14;
+    }
+    if (*(unsigned int*)(c + 0x4fc) == 0) return;
+    {
+        void* sys = _ZN8Particle6System12FromUniqueIDEj(*(unsigned int*)(c + 0x4fc));
+        if (sys != 0) *(int*)((char*)sys + 0x44) = *(int*)(c + 0x80) * 0x14;
+    }
+}

--- a/src/func_ov073_0211f494.c
+++ b/src/func_ov073_0211f494.c
@@ -1,0 +1,52 @@
+
+typedef int Fix12;
+typedef struct { int x, y, z; } Vec3;
+extern void Vec3_Sub(Vec3 *out, Vec3 *a, Vec3 *b);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 y, Fix12 x);
+extern Fix12 Vec3_HorzLen(Vec3 *v);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12 x, Fix12 y, Fix12 z);
+extern short data_02082214[];
+void func_ov073_0211f494(char *a, char *b)
+{
+    Vec3 t, p, q, d;
+    int ay, ax, vx, tmp, cos_ax, sin_ax, cos_ay, sin_ay, rx, ry, rz;
+    int y0;
+    int *bp = (int *)(((int)b + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+
+    p.x = *(int *)(a + 0x5c);
+    y0 = *(int *)(a + 0x60);
+    p.y = y0;
+    {
+        Vec3 *pq = &q;
+        int zval = *(int *)(a + 0x64);
+        Vec3 *pp = &p;
+        pp->z = zval;
+        pq->x = bp[0];
+        pq->y = bp[1];
+        pq->z = bp[2];
+        {
+            int qy = pq->y + 0x46000;
+            int h = *(int *)(a + 0x118);
+            vx = *(int *)(a + 0x114);
+            pp->y = y0 + h;
+            pq->y = qy;
+            Vec3_Sub(&d, pq, pp);
+        }
+    }
+    t.x = d.x; t.y = d.y; t.z = d.z;
+    ay = _ZN4cstd5atan2E5Fix12IiES1_(t.x, t.z);
+    ax = _ZN4cstd5atan2E5Fix12IiES1_(t.y, Vec3_HorzLen(&t));
+    ax = (int)((unsigned short)ax >> 4);
+    ay = (int)((unsigned short)ay >> 4);
+    sin_ax = data_02082214[ax * 2 + 1];
+    cos_ax = data_02082214[ax * 2];
+    tmp = (int)(((long long)vx * sin_ax + 0x800) >> 12);
+    ry = (int)(((long long)vx * cos_ax + 0x800) >> 12);
+    cos_ay = data_02082214[ay * 2];
+    sin_ay = data_02082214[ay * 2 + 1];
+    rx = (int)(((long long)tmp * cos_ay + 0x800) >> 12);
+    rz = (int)(((long long)tmp * sin_ay + 0x800) >> 12);
+    p.x += rx; p.y += ry; p.z += rz;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x84, p.x, p.y, p.z);
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x85, p.x, p.y, p.z);
+}

--- a/src/func_ov073_0211fa74.c
+++ b/src/func_ov073_0211fa74.c
@@ -1,0 +1,69 @@
+struct Vector3 { int x, y, z; };
+struct Vector3_16 { short x, y, z; };
+extern void _ZN6Camera9SetFlag_3Ev(void* cam);
+extern void _Z14ApproachLinearRiii(int* p, int t, int s);
+extern void _ZN7Message7EndTalkEv(void);
+extern void _ZN5Sound22StopLoadedMusic_Layer3Ev(void);
+extern void func_02011cfc(void);
+extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);
+extern void func_0200fa8c(void* t, int a);
+extern short _ZN5Actor18HorzAngleToCPlayerEv(void* self);
+extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, void* pos, void* rot, int a, int b);
+extern void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* prev);
+extern void func_02012694(int a, void* p);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, void* pos);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
+extern void func_ov073_0211f144(void* c);
+extern void* data_0209f318;
+
+int func_ov073_0211fa74(char* c) {
+    void* cam;
+    void* spawned;
+    void* found;
+    volatile struct Vector3_16 rot;
+    struct Vector3 pos;
+    cam = data_0209f318;
+    _ZN6Camera9SetFlag_3Ev(cam);
+    _Z14ApproachLinearRiii((int*)(c + 0x80), 0, 0x80);
+    *(int*)(c + 0x88) = *(int*)(c + 0x80);
+    *(int*)(c + 0x84) = *(int*)(c + 0x88);
+    func_ov073_0211f144(c);
+    if (*(int*)(c + 0x80) >= 0x100) goto end;
+    pos.x = *(int*)(c + 0x3d8);
+    pos.y = *(int*)(c + 0x3dc);
+    pos.z = *(int*)(c + 0x3e0);
+    _ZN7Message7EndTalkEv();
+    _ZN5Sound22StopLoadedMusic_Layer3Ev();
+    func_02011cfc();
+    _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x7f, 0x15666);
+    pos.y = pos.y + 0x190000;
+    func_0200fa8c(c, 1);
+
+    {
+        unsigned short a = *(unsigned short*)(c + 0x8c);
+        unsigned short b = *(unsigned short*)(c + 0x8e);
+        rot.x = b ? a : a;
+        rot.y = b;
+        rot.z = *(unsigned short*)(c + 0x90);
+        rot.y = (unsigned short)_ZN5Actor18HorzAngleToCPlayerEv(c);
+    }
+
+    spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x11a, 4, &pos, 0, *(signed char*)(c + 0xcc), -1);
+    found = _ZN5Actor15FindWithActorIDEjPS_(0x13d, 0);
+    func_02012694(0xbb, c + 0x74);
+    if (found != 0) {
+        struct Vector3 fp;
+        int pv = (int)(((int)found + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        fp.x = *(int*)pv;
+        fp.y = *(int*)(pv + 4);
+        fp.z = *(int*)(pv + 8);
+        _ZN5Actor10PoofDustAtERK7Vector3(c, &fp);
+        _ZN9ActorBase18MarkForDestructionEv(found);
+    }
+    if (spawned != 0) {
+        *(int*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~8;
+        _ZN9ActorBase18MarkForDestructionEv(c);
+    }
+end:
+    return 1;
+}

--- a/src/func_ov073_0212128c.c
+++ b/src/func_ov073_0212128c.c
@@ -1,0 +1,47 @@
+struct Vector3 { int x, y, z; };
+
+extern void _ZN6Camera9SetFlag_3Ev(void* cam);
+extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, struct Vector3* v);
+extern void _ZN6Camera6SetPosERK7Vector3(void* cam, struct Vector3* v);
+extern int _ZN6Player12GetTalkStateEv(void* self);
+extern void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int a);
+extern void func_02011d08(void);
+extern int func_ov073_0212157c(void* c, void* p);
+
+extern void* data_0209f318;
+extern void* data_ov073_02123360;
+
+int func_ov073_0212128c(char* c)
+{
+    struct Vector3 la;
+    struct Vector3 ps;
+    void* cam;
+    void* player;
+
+    cam = data_0209f318;
+    player = *(void**)(c + 0x3e4);
+    _ZN6Camera9SetFlag_3Ev(cam);
+
+    la.x = *(int*)(c + 0x5c);
+    la.y = *(int*)(c + 0x60);
+    la.z = *(int*)(c + 0x64);
+    ps.x = *(int*)(c + 0x5c);
+    ps.y = *(int*)(c + 0x60);
+    ps.z = *(int*)(c + 0x64);
+    la.y = la.y + 0x70000;
+    la.z = la.z - 0x2a0000;
+    ps.x = ps.x - 0x300000;
+    ps.y = ps.y + 0x20000;
+    ps.z = ps.z + 0xffa34000;
+
+    _ZN6Camera9SetLookAtERK7Vector3(cam, &la);
+    _ZN6Camera6SetPosERK7Vector3(cam, &ps);
+
+    if (_ZN6Player12GetTalkStateEv(player) == -1) {
+        *(int*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~8;
+        _ZN5Sound22LoadAndSetMusic_Layer3Ej(0x2d);
+        func_02011d08();
+        func_ov073_0212157c(c, &data_ov073_02123360);
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for four related ov073 (ChiefChilly) helpers, verified with `tools/match.py` against the EU retail overlay using **mwccarm 1.2/sp2p3**.

| Function | Address | Size |
|---|---|---|
| `func_ov073_0211f144` | `0x211f144` | `0x17c` |
| `func_ov073_0211f494` | `0x211f494` | `0x188` |
| `func_ov073_0211fa74` | `0x211fa74` | `0x178` |
| `func_ov073_0212128c` | `0x212128c` | `0xec` |

Compiler flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

## Verify

```sh
python tools/match.py --c src/func_ov073_0211f144.c --func func_ov073_0211f144 --addr 0x211f144 --size 0x17c --version 1.2/sp2p3 --module ov073
python tools/match.py --c src/func_ov073_0211f494.c --func func_ov073_0211f494 --addr 0x211f494 --size 0x188 --version 1.2/sp2p3 --module ov073
python tools/match.py --c src/func_ov073_0211fa74.c --func func_ov073_0211fa74 --addr 0x211fa74 --size 0x178 --version 1.2/sp2p3 --module ov073
python tools/match.py --c src/func_ov073_0212128c.c --func func_ov073_0212128c --addr 0x212128c --size 0xec --version 1.2/sp2p3 --module ov073
```

## Notes

Four of the ten targets in this batch were already matched upstream (`func_ov073_0211f61c`, `func_ov073_021203ac`, `func_ov073_02120c7c`, `_ZN11ChiefChilly8BehaviorEv`). Work continues on `func_ov073_0211f2c0` and `func_ov073_02120ed0`.