### PR TITLE
Match 2 ov073 ChiefChilly functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,6 +20,7 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
+| ov073: 0211f2c0 (0x0211f2c0), 02120ed0 (0x02120ed0) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #260 open |
 | AI-assisted crack sweep: smallest untried funcs (~0x100 band), spread across modules (this batch mostly ov006/ov007) | beansntoast (AI-assisted) | 2026-06-29 | in progress |
 | ov002 __sinit_ov002_021019d0 (0x021019d0, size 0x5470) | Cursor/Grok | 2026-07-02 | done |
 | ov001 func_ov001_020ab550 (0x020ab550, size 0x60) | Cursor/Grok | 2026-07-02 | done |

--- a/src/func_ov073_0211f2c0.c
+++ b/src/func_ov073_0211f2c0.c
@@ -1,0 +1,110 @@
+struct Mtx43
+{
+  int m[12];
+};
+struct V3
+{
+  int x;
+  int y;
+  int z;
+};
+extern void func_0200d8c8(void *cam, void *v, int strength);
+extern void MulMat4x3Mat4x3(void *dst, void *a, void *b);
+extern void Vec3_Lsl(void *d, void *s, int sh);
+extern void _ZN5Actor17HugeLandingDustAtER7Vector3b(void *self, void *v, int b);
+extern void Matrix4x3_FromRotationY(void *m, short angle);
+extern void MulVec3Mat4x3(void *in, void *m, void *out);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void *data_0209f318;
+extern struct Mtx43 data_020a0e68;
+extern char data_ov073_02123360;
+extern char data_ov073_021233c0;
+extern char data_ov073_021233f0;
+void func_ov073_0211f2c0(char *c, int strength)
+{
+  struct V3 src;
+  volatile struct V3 pv;
+  struct V3 *new_var;
+  struct V3 in;
+  struct V3 res;
+  struct V3 out;
+  struct V3 dv;
+  int ty;
+  int tx;
+  int tz;
+  int x;
+  int y;
+  int z;
+  func_0200d8c8(data_0209f318, c + 0x5c, strength);
+  data_020a0e68 = *((struct Mtx43 *) (c + 0x328));
+  MulMat4x3Mat4x3(((char *) (*((void **) (c + 0x320)))) + ((*((int *) (c + 0x4bc))) * 0x30), &data_020a0e68, &data_020a0e68);
+  *((int *) ((((int) c) + 0x4bc) & 0xFFFFFFFFFFFFFFFF)) ^= 1;
+  ty = *((int *) (((char *) (&data_020a0e68)) + 0x28));
+  tx = *((int *) (((char *) (&data_020a0e68)) + 0x24));
+  src.y = ty;
+  tz = *((int *) (((char *) (&data_020a0e68)) + 0x2c));
+  src.z = tz;
+  src.x = tx;
+  Vec3_Lsl(&out, &src, 3);
+  x = out.x;
+  y = out.y;
+  z = out.z;
+  src.x = x;
+  src.y = y;
+  src.z = z;
+  if ((*((void **) (c + 0x37c))) == (&data_ov073_02123360))
+  {
+    dv.x = x;
+    dv.y = y;
+    dv.z = z;
+    _ZN5Actor17HugeLandingDustAtER7Vector3b(c, &dv, 1);
+    return;
+  }
+  pv.x = *((int *) (c + 0x5c));
+  pv.y = *((int *) (c + 0x60));
+  pv.z = *((int *) (c + 0x64));
+  {
+    unsigned char *b = (unsigned char *) c;
+    void *anim = *((void **) (b + 0x37c));
+    if (anim == (&data_ov073_021233c0))
+    {
+      goto do_mtx;
+    }
+    if (anim != (&data_ov073_021233f0))
+    {
+      goto spawn;
+    }
+  }
+  do_mtx:
+  in.z = 0;
+
+  in.z = -0xe6000;
+  in.x = 0;
+  in.y = 0;
+  res.x = 0;
+  res.y = 0;
+  res.z = 0;
+  new_var = &res;
+  Matrix4x3_FromRotationY(&data_020a0e68, *((short *) (c + 0x8e)));
+  MulVec3Mat4x3(&in, &data_020a0e68, &res);
+
+  {
+    int px = pv.x;
+    int rx = (*new_var).x;
+    px = px + rx;
+    rx = px;
+    int pz = pv.z;
+    int rz = res.z;
+    {
+      int t = pz + rz;
+      rz = t;
+    }
+    pv.x = rx;
+    pv.z = rz;
+  }
+
+  spawn:
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x88, pv.x, pv.y, pv.z);
+
+  _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x89, pv.x, pv.y, pv.z);
+}

--- a/src/func_ov073_02120ed0.c
+++ b/src/func_ov073_02120ed0.c
@@ -1,0 +1,143 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef short s16;
+
+enum { false, true };
+
+typedef struct { int x, y, z; } Vector3;
+
+extern void func_ov073_0212157c(void *c, void *p);
+extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void *self);
+extern int AngleDiff(int a, int b);
+extern void func_02012694(int a, void *p);
+extern void _Z14ApproachLinearRiii(int *p, int a, int b);
+extern int _ZN5Actor13DistToCPlayerEv(void *self);
+extern unsigned int RandomIntInternal(void *seed);
+extern void _Z14ApproachLinearRsss(s16 *p, s16 a, s16 b);
+extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int cc);
+extern void *_ZN5Actor13ClosestPlayerEv(void *self);
+extern int _ZN6Player12GetHurtStateEv(void *self);
+extern s16 Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *self, void *bca, int a, int b, int frame, u16 flags);
+extern int _ZNK9Animation12WillHitFrameEi(void *self, int f);
+extern void func_ov073_0211f2c0(void *c, int a);
+
+extern void *data_ov073_02123390;
+extern void *data_0209e650;
+extern int data_ov073_02123288[];
+
+int func_ov073_02120ed0(void *self)
+{
+    u8 *c = (u8 *)self;
+
+    if (c[0x4c9] == 1) {
+        func_ov073_0212157c(c, &data_ov073_02123390);
+        return 1;
+    }
+
+    switch (c[0x4c8]) {
+    case 0:
+        if (*(u16 *)(c + 0x100) == 0) {
+            *(s16 *)(c + 0x4c6) = _ZN5Actor18HorzAngleToCPlayerEv(c);
+            *(int *)(c + 0x4b4) = 0;
+            if (AngleDiff(*(s16 *)(c + 0x94), *(s16 *)(c + 0x4c6)) <= 0x2000) {
+                *(s16 *)(c + 0x100) = 0x1e;
+                break;
+            } else {
+                *(s16 *)(c + 0x100) = 0;
+                *(int *)(c + 0x4d0) = 0x1000;
+                (*(u8 *)(((int)c + 0x4c8) & 0xFFFFFFFFFFFFFFFF))++;
+                func_02012694(0x169, c + 0x74);
+                break;
+            }
+        } else {
+            _Z14ApproachLinearRiii((int *)(c + 0x98), 0x1e000, 0x3000);
+            if (*(int *)(c + 0x4b4) == 0) {
+                if (_ZN5Actor13DistToCPlayerEv(c) < 0x1f4000) {
+                    *(int *)(c + 0x4b4) = 1;
+                    if (((RandomIntInternal(&data_0209e650) >> 0x18) & 7) == 0) {
+                        c[0x4c8] = 3;
+                        *(int *)(c + 0x98) = 0;
+                        *(s16 *)(c + 0x100) = 0xf;
+                    }
+                }
+            }
+            _Z14ApproachLinearRsss((s16 *)(c + 0x94), *(s16 *)(c + 0x4c6), 0x1d0);
+            *(s16 *)(c + 0x8c) = *(s16 *)(c + 0x92);
+            *(s16 *)(c + 0x8e) = *(s16 *)(c + 0x94);
+            *(s16 *)(c + 0x90) = *(s16 *)(c + 0x96);
+            break;
+        }
+
+    case 3:
+        if (*(u16 *)(c + 0x100) == 0) {
+            *(int *)(c + 0x4d0) = 0x1000;
+            c[0x4c8] = 1;
+        }
+        break;
+
+    case 1:
+    case 2:
+    {
+        int d;
+        int i;
+        u8 *r5;
+        *(int *)(c + 0x4b4) = 0;
+        d = *(int *)(c + 0x98);
+        if (d < 0) d = -d;
+        if (d > 0xa) {
+            r5 = c;
+            i = 0;
+            do {
+                _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(
+                    *(int *)(r5 + 0x4d4), *(int *)(r5 + 0x4d8), *(int *)(r5 + 0x4dc));
+                i++;
+                r5 += 0xc;
+            } while (i < 2);
+        }
+        _Z14ApproachLinearRiii((int *)(c + 0x98), 0, *(int *)(c + 0x4d0));
+        if (c[0x4c8] == 1) {
+            *(s16 *)(c + 0x4c6) = _ZN5Actor18HorzAngleToCPlayerEv(c);
+            _Z14ApproachLinearRsss((s16 *)(c + 0x8e), *(s16 *)(c + 0x4c6), 0x500);
+        }
+        d = *(int *)(c + 0x98);
+        if (d < 0) d = -d;
+        if (d >= 0xa) break;
+        if (*(u16 *)(c + 0x100) != 0) break;
+        if (c[0x4c8] == 2) {
+            u8 *p = (u8 *)_ZN5Actor13ClosestPlayerEv(c);
+            if (p != 0) {
+                int t;
+                if (_ZN6Player12GetHurtStateEv(p) == 4) goto hz;
+                if (_ZN6Player12GetHurtStateEv(p) == 5) goto hz;
+                t = p[0x709] ? 1 : 0;
+                if (t == 1) {
+hz:
+                    *(s16 *)(c + 0x4c6) = Vec3_HorzAngle((Vector3 *)(c + 0x5c), (Vector3 *)(c + 0x3d8));
+                } else {
+                    *(s16 *)(c + 0x4c6) = _ZN5Actor18HorzAngleToCPlayerEv(c);
+                }
+            }
+        }
+        *(int *)(c + 0x98) = 0;
+        *(s16 *)(c + 0x94) = *(s16 *)(c + 0x8e);
+        *(s16 *)(c + 0x100) = 0x1e;
+        _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(
+            c + 0x30c, (void *)data_ov073_02123288[1], 4, 0, 0x1000, 0);
+        *(int *)(c + 0x368) = 0x2000;
+        *(int *)(c + 0x4b4) = 0;
+        c[0x4c8] = 0;
+        break;
+    }
+    }
+
+    if (c[0x4c8] == 0) {
+        if (_ZNK9Animation12WillHitFrameEi(c + 0x35c, 0) != 0 ||
+            _ZNK9Animation12WillHitFrameEi(c + 0x35c, 0xe) != 0) {
+            func_ov073_0211f2c0(c, 0x3e8000);
+            func_02012694(0x168, c + 0x74);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary
- `func_ov073_0211f2c0` @ `0x0211f2c0` size `0x1d4` — landing dust / particle helper
- `func_ov073_02120ed0` @ `0x02120ed0` size `0x35c` — approach/stomp state machine

Both verified byte-identical with mwccarm `1.2/sp2p3` via `tools/match.py`.

## Test plan
- [x] `match.py` MATCH for both functions
- [ ] CI `validate` green