### PR TITLE
Match 88 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/SetNumPlayers.c
+++ b/src/SetNumPlayers.c
@@ -1,0 +1,7 @@
+extern void func_020308d0(void);
+extern unsigned char data_0208a0e0;
+
+void SetNumPlayers(int n) {
+    data_0208a0e0 = n;
+    func_020308d0();
+}

--- a/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0202b060(void*, unsigned int);
+
+void _Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0202b060(tbl.entries, tbl.count);
+}
+}

--- a/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0203aca0(void*, unsigned int);
+
+void _Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0203aca0(tbl.entries, tbl.count);
+}
+}

--- a/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0202b0c4(void*, unsigned int);
+
+void _Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0202b0c4(tbl.entries, tbl.count);
+}
+}

--- a/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0202b044(void*, unsigned int);
+
+void _Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0202b044(tbl.entries, tbl.count);
+}
+}

--- a/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0202af80(void*, unsigned int);
+
+void _Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0202af80(tbl.entries, tbl.count);
+}
+}

--- a/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,0 +1,15 @@
+//cpp
+struct ObjSubTable {
+  unsigned char pad0;   // 0
+  unsigned char count;  // 1
+  unsigned char pad2[2];
+  void* entries;        // 4
+};
+
+extern "C" {
+extern void func_0202b090(void*, unsigned int);
+
+void _Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij(ObjSubTable& tbl, int p2, unsigned int p3) {
+    func_0202b090(tbl.entries, tbl.count);
+}
+}

--- a/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
+
+unsigned int _ZN13ExpandingHeap19VMaxAllocatableSizeEv(char* self) {
+    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
+}
+}

--- a/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
+
+unsigned int _ZN13ExpandingHeap22VMaxAllocationUnitSizeEv(char* self) {
+    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
+}
+}

--- a/src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp
+++ b/src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern void _ZN22ExpandingHeapAllocator10DeallocateEPv(void*, void*);
+
+void _ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j(void* p, void* alloc, unsigned int size) {
+    _ZN22ExpandingHeapAllocator10DeallocateEPv(alloc, p);
+}
+}

--- a/src/_ZN3G3X11SetFogTableEPv.cpp
+++ b/src/_ZN3G3X11SetFogTableEPv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern void Copy32Bytes(void*, void*);
+
+void _ZN3G3X11SetFogTableEPv(void* table) {
+    Copy32Bytes(table, (void*)0x4000360);
+}
+}

--- a/src/_ZN5Actor10EarthquakeERK7Vector35Fix12IiE.cpp
+++ b/src/_ZN5Actor10EarthquakeERK7Vector35Fix12IiE.cpp
@@ -1,0 +1,9 @@
+//cpp
+extern "C" {
+extern void func_0200d8c8(void*, int);
+extern void* data_0209f318;
+
+void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* v, int f) {
+    func_0200d8c8(data_0209f318, f);
+}
+}

--- a/src/_ZN5Sound12PlayBank2_2DEj.cpp
+++ b/src/_ZN5Sound12PlayBank2_2DEj.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN5Sound6Play2DEjj(unsigned int, unsigned int);
+
+unsigned int _ZN5Sound12PlayBank2_2DEj(unsigned int a) {
+    return _ZN5Sound6Play2DEjj(2, a);
+}
+}

--- a/src/_ZN5Sound12PlayBank3_2DEj.cpp
+++ b/src/_ZN5Sound12PlayBank3_2DEj.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN5Sound6Play2DEjj(unsigned int, unsigned int);
+
+unsigned int _ZN5Sound12PlayBank3_2DEj(unsigned int a) {
+    return _ZN5Sound6Play2DEjj(3, a);
+}
+}

--- a/src/_ZN5Sound22LoadAndSetMusic_Layer3Ej.cpp
+++ b/src/_ZN5Sound22LoadAndSetMusic_Layer3Ej.cpp
@@ -1,0 +1,17 @@
+//cpp
+extern "C" {
+extern void func_02011dcc(int player, unsigned int musicId);
+extern unsigned int data_0208e444;
+extern int data_0209b4a0[];
+}
+
+class Sound {
+public:
+    static void LoadAndSetMusic_Layer3(unsigned int musicId);
+};
+
+void Sound::LoadAndSetMusic_Layer3(unsigned int musicId)
+{
+    data_0208e444 = musicId;
+    func_02011dcc((int)data_0209b4a0, musicId);
+}

--- a/src/_ZN5Sound22StopLoadedMusic_Layer1Ej.cpp
+++ b/src/_ZN5Sound22StopLoadedMusic_Layer1Ej.cpp
@@ -1,0 +1,17 @@
+//cpp
+extern "C" {
+extern void func_0204fa2c(int player, unsigned int arg);
+extern unsigned int data_0209b4ac;
+extern int data_0209b4a0[];
+}
+
+class Sound {
+public:
+    static void StopLoadedMusic_Layer1(unsigned int arg);
+};
+
+void Sound::StopLoadedMusic_Layer1(unsigned int arg)
+{
+    data_0209b4ac = ~0u;
+    func_0204fa2c((int)data_0209b4a0, arg);
+}

--- a/src/_ZN6Memory8AllocateEj.cpp
+++ b/src/_ZN6Memory8AllocateEj.cpp
@@ -1,0 +1,14 @@
+//cpp
+typedef unsigned int u32;
+
+class Heap;
+
+namespace Memory
+{
+    void* Allocate(u32 size, int align, Heap* heap);
+
+    void* Allocate(u32 size)
+    {
+        return Allocate(size, 4, 0);
+    }
+}

--- a/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
+++ b/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
+
+unsigned int _ZN9SolidHeap11VMemoryLeftEv(char* self) {
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+}
+}

--- a/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
+++ b/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern void _ZN18SolidHeapAllocator5ResetEj(void*, unsigned int);
+
+void _ZN9SolidHeap14VDeallocateAllEv(char* self) {
+    _ZN18SolidHeapAllocator5ResetEj(*(void**)(self + 0x14), 3);
+}
+}

--- a/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
+
+unsigned int _ZN9SolidHeap19VMaxAllocatableSizeEv(char* self) {
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+}
+}

--- a/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,0 +1,8 @@
+//cpp
+extern "C" {
+extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
+
+unsigned int _ZN9SolidHeap22VMaxAllocationUnitSizeEv(char* self) {
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+}
+}

--- a/src/_ZThn80_N9AnimationD0Ev.cpp
+++ b/src/_ZThn80_N9AnimationD0Ev.cpp
@@ -1,0 +1,5 @@
+//cpp
+struct Base1 { int pad[19]; virtual ~Base1(); virtual void f1(); };
+struct Base2 { int b; virtual ~Base2(); virtual void g1(); };
+struct Animation : Base1, Base2 { virtual ~Animation(); };
+Animation::~Animation() {}

--- a/src/_ZThn80_N9AnimationD1Ev.cpp
+++ b/src/_ZThn80_N9AnimationD1Ev.cpp
@@ -1,0 +1,5 @@
+//cpp
+struct Base1 { int pad[19]; virtual ~Base1(); virtual void f1(); };
+struct Base2 { int b; virtual ~Base2(); virtual void g1(); };
+struct Animation : Base1, Base2 { virtual ~Animation(); };
+Animation::~Animation() {}

--- a/src/__sinit_02074da8.c
+++ b/src/__sinit_02074da8.c
@@ -1,0 +1,6 @@
+extern void func_02011a5c(void*);
+extern char data_0209b53c[];
+
+void __sinit_02074da8(void) {
+    func_02011a5c(data_0209b53c);
+}

--- a/src/func_02012310.c
+++ b/src/func_02012310.c
@@ -1,0 +1,5 @@
+extern void func_020124c4(int, int, int, int);
+
+void func_02012310(int a, int b, int c) {
+    func_020124c4(a, 2, b, c);
+}

--- a/src/func_0201277c.c
+++ b/src/func_0201277c.c
@@ -1,0 +1,5 @@
+extern unsigned int _ZN5Sound6Play2DEjj(unsigned int, unsigned int);
+
+unsigned int func_0201277c(unsigned int a) {
+    return _ZN5Sound6Play2DEjj(3, a);
+}

--- a/src/func_02012790.c
+++ b/src/func_02012790.c
@@ -1,0 +1,5 @@
+extern unsigned int _ZN5Sound6Play2DEjj(unsigned int, unsigned int);
+
+unsigned int func_02012790(unsigned int a) {
+    return _ZN5Sound6Play2DEjj(2, a);
+}

--- a/src/func_02012dbc.c
+++ b/src/func_02012dbc.c
@@ -1,0 +1,5 @@
+extern void func_0204f9c4(int, int);
+
+void func_02012dbc(int a) {
+    func_0204f9c4(0xe, a);
+}

--- a/src/func_02013524.c
+++ b/src/func_02013524.c
@@ -1,0 +1,10 @@
+extern void func_0204f8cc(int a, int b, int c);
+extern unsigned char data_0209b474;
+
+void func_02013524(int a, int b, int c)
+{
+    if (data_0209b474 != 0) {
+        c = b = 0;
+    }
+    func_0204f8cc(a, b, c);
+}

--- a/src/func_02013868.c
+++ b/src/func_02013868.c
@@ -1,0 +1,9 @@
+extern void func_0201361c(int idx);
+extern unsigned int data_0209caa0[];
+
+void func_02013868(int a, int b)
+{
+    int idx = (a << 2) | b;
+    data_0209caa0[3] |= 1 << idx;
+    func_0201361c(idx);
+}

--- a/src/func_02013e64.c
+++ b/src/func_02013e64.c
@@ -1,0 +1,7 @@
+extern void func_0205a588(void* dest, int value, int size);
+extern unsigned int data_0209caa0[];
+
+void func_02013e64(void)
+{
+    func_0205a588(data_0209caa0, 0, 0x32c);
+}

--- a/src/func_02019ebc.c
+++ b/src/func_02019ebc.c
@@ -1,0 +1,6 @@
+extern void func_02061128(void (*)(void));
+extern void func_02019f10(void);
+
+void func_02019ebc(void) {
+    func_02061128(func_02019f10);
+}

--- a/src/func_0201a4bc.c
+++ b/src/func_0201a4bc.c
@@ -1,0 +1,6 @@
+extern void func_020580f0(void*);
+extern char data_0209d500[];
+
+void func_0201a4bc(void) {
+    func_020580f0(data_0209d500);
+}

--- a/src/func_0201a4d0.c
+++ b/src/func_0201a4d0.c
@@ -1,0 +1,6 @@
+extern void func_020580f0(void*);
+extern char data_0209d4fc[];
+
+void func_0201a4d0(void) {
+    func_020580f0(data_0209d4fc);
+}

--- a/src/func_0202ae74.c
+++ b/src/func_0202ae74.c
@@ -1,0 +1,5 @@
+extern void StartFile(int, int);
+
+void func_0202ae74(void) {
+    StartFile(1, 0);
+}

--- a/src/func_02039e18.c
+++ b/src/func_02039e18.c
@@ -1,0 +1,5 @@
+extern void MulVec3Mat4x3(void*, void*, int);
+
+void func_02039e18(char* m, void* v, int c) {
+    MulVec3Mat4x3(v, m + 0x84, c);
+}

--- a/src/func_02039e30.c
+++ b/src/func_02039e30.c
@@ -1,0 +1,5 @@
+extern void MulVec3Mat4x3(void*, void*, int);
+
+void func_02039e30(char* m, void* v, int c) {
+    MulVec3Mat4x3(v, m + 0x134, c);
+}

--- a/src/func_02039e48.c
+++ b/src/func_02039e48.c
@@ -1,0 +1,5 @@
+extern void MulVec3Mat4x3(void*, void*, int);
+
+void func_02039e48(char* m, void* v, int c) {
+    MulVec3Mat4x3(v, m + 0x168, c);
+}

--- a/src/func_020423c8.c
+++ b/src/func_020423c8.c
@@ -1,0 +1,6 @@
+extern void func_02058048(void*);
+extern char data_020a15e4[];
+
+void func_020423c8(void) {
+    func_02058048(data_020a15e4);
+}

--- a/src/func_02042fe4.c
+++ b/src/func_02042fe4.c
@@ -1,0 +1,5 @@
+extern void func_02043098(int, int, int, int);
+
+void func_02042fe4(int a, int b, int c) {
+    func_02043098(a, 0, b, c);
+}

--- a/src/func_02053f30.c
+++ b/src/func_02053f30.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a609c;
+
+u16 func_02053f30(void) {
+    return func_0205402c(&data_020a609c);
+}

--- a/src/func_02053f44.c
+++ b/src/func_02053f44.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a609a;
+
+u16 func_02053f44(void) {
+    return func_0205402c(&data_020a609a);
+}

--- a/src/func_02053f58.c
+++ b/src/func_02053f58.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a6088;
+
+u16 func_02053f58(void) {
+    return func_0205402c(&data_020a6088);
+}

--- a/src/func_02053f6c.c
+++ b/src/func_02053f6c.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a608e;
+
+u16 func_02053f6c(void) {
+    return func_0205402c(&data_020a608e);
+}

--- a/src/func_02053f80.c
+++ b/src/func_02053f80.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a6094;
+
+u16 func_02053f80(void) {
+    return func_0205402c(&data_020a6094);
+}

--- a/src/func_02053f94.c
+++ b/src/func_02053f94.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a6092;
+
+u16 func_02053f94(void) {
+    return func_0205402c(&data_020a6092);
+}

--- a/src/func_02053fa8.c
+++ b/src/func_02053fa8.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a6090;
+
+u16 func_02053fa8(void) {
+    return func_0205402c(&data_020a6090);
+}

--- a/src/func_02054004.c
+++ b/src/func_02054004.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a608c;
+
+u16 func_02054004(void) {
+    return func_0205402c(&data_020a608c);
+}

--- a/src/func_02054018.c
+++ b/src/func_02054018.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_0205402c(u16*);
+extern u16 data_020a608a;
+
+u16 func_02054018(void) {
+    return func_0205402c(&data_020a608a);
+}

--- a/src/func_02054140.c
+++ b/src/func_02054140.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a609c;
+
+u16 func_02054140(void) {
+    return func_020541b8(&data_020a609c);
+}

--- a/src/func_02054154.c
+++ b/src/func_02054154.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a609a;
+
+u16 func_02054154(void) {
+    return func_020541b8(&data_020a609a);
+}

--- a/src/func_02054168.c
+++ b/src/func_02054168.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a6092;
+
+u16 func_02054168(void) {
+    return func_020541b8(&data_020a6092);
+}

--- a/src/func_0205417c.c
+++ b/src/func_0205417c.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a6090;
+
+u16 func_0205417c(void) {
+    return func_020541b8(&data_020a6090);
+}

--- a/src/func_02054190.c
+++ b/src/func_02054190.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a608c;
+
+u16 func_02054190(void) {
+    return func_020541b8(&data_020a608c);
+}

--- a/src/func_020541a4.c
+++ b/src/func_020541a4.c
@@ -1,0 +1,8 @@
+typedef unsigned short u16;
+
+extern u16 func_020541b8(u16*);
+extern u16 data_020a608a;
+
+u16 func_020541a4(void) {
+    return func_020541b8(&data_020a608a);
+}

--- a/src/func_0205ad3c.c
+++ b/src/func_0205ad3c.c
@@ -1,0 +1,5 @@
+extern void func_0205a924(int, int, int, int);
+
+void func_0205ad3c(int a, int b) {
+    func_0205a924(a, 6, b, 2);
+}

--- a/src/func_0205ad54.c
+++ b/src/func_0205ad54.c
@@ -1,0 +1,5 @@
+extern void func_0205a924(int, int, int, int);
+
+void func_0205ad54(int a, int b) {
+    func_0205a924(a, 0x1a, b, 2);
+}

--- a/src/func_0205c410.c
+++ b/src/func_0205c410.c
@@ -1,0 +1,9 @@
+void func_0205c410(char* c)
+{
+    char* obj = *(char**)(c + 0x8);
+    unsigned inc = *(unsigned*)(c + 0x34);
+    unsigned b = *(unsigned*)(c + 0x28);
+    unsigned a = *(unsigned*)(c + 0x2c);
+    *(unsigned*)(((long long)(int)(c + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+    (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x40))(obj, a, b, inc);
+}

--- a/src/func_0205c448.c
+++ b/src/func_0205c448.c
@@ -1,0 +1,9 @@
+void func_0205c448(char* c)
+{
+    char* obj = *(char**)(c + 0x8);
+    unsigned inc = *(unsigned*)(c + 0x34);
+    unsigned b = *(unsigned*)(c + 0x28);
+    unsigned a = *(unsigned*)(c + 0x2c);
+    *(unsigned*)(((long long)(int)(c + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+    (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x3c))(obj, a, b, inc);
+}

--- a/src/func_020600e0.c
+++ b/src/func_020600e0.c
@@ -1,0 +1,25 @@
+unsigned int _ZN3IRQ7DisableEv(void);
+void _ZN3IRQ7RestoreEj(unsigned int);
+void Crash(void);
+void func_0205807c(void* p);
+typedef struct { int* f0; char pad4[4]; int f8; int fc; int f10; int f14; } G;
+extern G data_020a8180;
+void func_020600e0(int a0, int a1)
+{
+    G* g = &data_020a8180;
+    int gi = (int)&data_020a8180;
+    unsigned int s = _ZN3IRQ7DisableEv();
+    if (g->f8 != a0 || g->fc == 0) {
+        Crash();
+    } else {
+        if (g->f14 != a1) Crash();
+        { int* pc = (int*)((gi + 0xc) & 0xFFFFFFFFFFFFFFFF); *pc = *pc - 1; }
+        if (g->fc == 0) {
+            g->f8 = -3;
+            g->f14 = 0;
+            func_0205807c(&g->f10);
+        }
+    }
+    *g->f0 = 0;
+    _ZN3IRQ7RestoreEj(s);
+}

--- a/src/func_ov002_020b56c4.c
+++ b/src/func_ov002_020b56c4.c
@@ -1,0 +1,5 @@
+extern void func_ov002_020b567c(void*, void*);
+
+void func_ov002_020b56c4(void* a, void* b, void* c) {
+    func_ov002_020b567c(b, c);
+}

--- a/src/func_ov002_020b5fc4.c
+++ b/src/func_ov002_020b5fc4.c
@@ -1,0 +1,5 @@
+extern void func_ov002_020b5f9c(void*, void*);
+
+void func_ov002_020b5fc4(void* a, void* b, void* c) {
+    func_ov002_020b5f9c(b, c);
+}

--- a/src/func_ov002_020b6374.c
+++ b/src/func_ov002_020b6374.c
@@ -1,0 +1,5 @@
+extern void func_ov002_020b62cc(void*, void*);
+
+void func_ov002_020b6374(void* a, void* b, void* c) {
+    func_ov002_020b62cc(b, c);
+}

--- a/src/func_ov002_020baa98.c
+++ b/src/func_ov002_020baa98.c
@@ -1,0 +1,5 @@
+extern void func_ov002_020baa2c(void*, void*);
+
+void func_ov002_020baa98(void* a, void* b, void* c) {
+    func_ov002_020baa2c(b, c);
+}

--- a/src/func_ov002_020bec84.c
+++ b/src/func_ov002_020bec84.c
@@ -1,0 +1,6 @@
+extern int _ZN6Player6IsAnimEj(void*, unsigned int);
+extern unsigned int data_ov002_020ff220[];
+
+int func_ov002_020bec84(void* p, unsigned int i) {
+    return _ZN6Player6IsAnimEj(p, data_ov002_020ff220[i]);
+}

--- a/src/func_ov002_020c3dbc.c
+++ b/src/func_ov002_020c3dbc.c
@@ -1,0 +1,6 @@
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
+extern char data_ov002_0211058c[];
+
+void func_ov002_020c3dbc(void* player) {
+    _ZN6Player11ChangeStateERNS_5StateE(player, data_ov002_0211058c);
+}

--- a/src/func_ov002_020c3e8c.c
+++ b/src/func_ov002_020c3e8c.c
@@ -1,0 +1,6 @@
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
+extern char data_ov002_0211013c[];
+
+void func_ov002_020c3e8c(void* player) {
+    _ZN6Player11ChangeStateERNS_5StateE(player, data_ov002_0211013c);
+}

--- a/src/func_ov002_020c3f18.c
+++ b/src/func_ov002_020c3f18.c
@@ -1,0 +1,6 @@
+extern void func_ov002_020d2e74(void*);
+
+void func_ov002_020c3f18(char* p) {
+    p[0x6e6] = 1;
+    func_ov002_020d2e74(p);
+}

--- a/src/func_ov002_020c3f2c.c
+++ b/src/func_ov002_020c3f2c.c
@@ -1,0 +1,6 @@
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
+extern char data_ov002_02110544[];
+
+void func_ov002_020c3f2c(void* player) {
+    _ZN6Player11ChangeStateERNS_5StateE(player, data_ov002_02110544);
+}

--- a/src/func_ov002_020ca0f4.c
+++ b/src/func_ov002_020ca0f4.c
@@ -1,0 +1,6 @@
+extern int _ZN6Player7IsStateERNS_5StateE(void*, void*);
+extern char data_ov002_0211022c[];
+
+int func_ov002_020ca0f4(void* player) {
+    return _ZN6Player7IsStateERNS_5StateE(player, data_ov002_0211022c);
+}

--- a/src/func_ov002_020cf700.c
+++ b/src/func_ov002_020cf700.c
@@ -1,0 +1,6 @@
+extern int _ZN6Player7IsStateERNS_5StateE(void*, void*);
+extern char data_ov002_0211001c[];
+
+int func_ov002_020cf700(void* player) {
+    return _ZN6Player7IsStateERNS_5StateE(player, data_ov002_0211001c);
+}

--- a/src/func_ov002_020d718c.c
+++ b/src/func_ov002_020d718c.c
@@ -1,0 +1,6 @@
+extern void func_ov002_020d71a0(void*);
+
+void func_ov002_020d718c(char* p) {
+    *(int*)(p + 0x360) = 0;
+    func_ov002_020d71a0(p);
+}

--- a/src/func_ov002_020dd8f4.c
+++ b/src/func_ov002_020dd8f4.c
@@ -1,0 +1,6 @@
+extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
+extern char data_ov002_021101b4[];
+
+void func_ov002_020dd8f4(void* player) {
+    _ZN6Player11ChangeStateERNS_5StateE(player, data_ov002_021101b4);
+}

--- a/src/func_ov002_020de328.c
+++ b/src/func_ov002_020de328.c
@@ -1,0 +1,6 @@
+extern int _ZN6Player7IsStateERNS_5StateE(void*, void*);
+extern char data_ov002_021102bc[];
+
+int func_ov002_020de328(void* player) {
+    return _ZN6Player7IsStateERNS_5StateE(player, data_ov002_021102bc);
+}

--- a/src/func_ov002_020e6b3c.c
+++ b/src/func_ov002_020e6b3c.c
@@ -1,0 +1,20 @@
+struct A {
+    char pad[0x24];
+    unsigned int count;
+};
+
+struct B {
+    char pad[0x1c];
+    unsigned int idx;
+    char pad2[0x10];
+};
+
+void func_ov002_020e6b3c(char *o) {
+    void **p = (void **)(((long long)(int)(o + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    struct A *a = (struct A *)p[0];
+    unsigned int n = a->count;
+    struct B *b = (struct B *)p[1];
+    unsigned int i;
+    for (i = 0; i < n; i++, b++)
+        b->idx = 0;
+}

--- a/src/func_ov002_020f15b8.c
+++ b/src/func_ov002_020f15b8.c
@@ -1,0 +1,5 @@
+extern void func_ov002_020f1578(void*, void*);
+
+void func_ov002_020f15b8(void* a, void* b, void* c) {
+    func_ov002_020f1578(b, c);
+}

--- a/src/func_ov004_020b4214.c
+++ b/src/func_ov004_020b4214.c
@@ -1,0 +1,5 @@
+extern void _Z14ApproachLinearRiii(int*, int, int);
+
+void func_ov004_020b4214(char* p) {
+    _Z14ApproachLinearRiii((int*)(p + 0x24), *(int*)(p + 0x28), 0x1000);
+}

--- a/src/func_ov004_020b4a28.c
+++ b/src/func_ov004_020b4a28.c
@@ -1,0 +1,5 @@
+extern void _Z15ApproachLinear2Rsss(short*, short, short);
+
+void func_ov004_020b4a28(char* p) {
+    _Z15ApproachLinear2Rsss((short*)(p + 0x12), *(short*)(p + 0x16), 4);
+}

--- a/src/func_ov004_020b4a4c.c
+++ b/src/func_ov004_020b4a4c.c
@@ -1,0 +1,5 @@
+extern void _Z15ApproachLinear2Rsss(short*, short, short);
+
+void func_ov004_020b4a4c(char* p) {
+    _Z15ApproachLinear2Rsss((short*)(p + 0x12), *(short*)(p + 0x16), 4);
+}

--- a/src/func_ov006_020dfed4.c
+++ b/src/func_ov006_020dfed4.c
@@ -1,0 +1,5 @@
+extern void func_ov006_020c2594(void*);
+
+void func_ov006_020dfed4(char* p) {
+    func_ov006_020c2594(p + 0x4f38);
+}

--- a/src/func_ov006_020f523c.c
+++ b/src/func_ov006_020f523c.c
@@ -1,0 +1,5 @@
+extern int func_ov004_020b63a0(int);
+
+int func_ov006_020f523c(char* p) {
+    return func_ov004_020b63a0(*(unsigned char*)(p + 0x533b));
+}

--- a/src/func_ov006_020f730c.c
+++ b/src/func_ov006_020f730c.c
@@ -1,0 +1,5 @@
+extern int func_ov004_020b63a0(int);
+
+int func_ov006_020f730c(char* p) {
+    return func_ov004_020b63a0(*(unsigned char*)(p + 0x5409));
+}

--- a/src/func_ov006_02111e7c.c
+++ b/src/func_ov006_02111e7c.c
@@ -1,0 +1,6 @@
+extern void func_ov006_02111e48(void*);
+
+void func_ov006_02111e7c(char* p) {
+    p[0x121] = 1;
+    func_ov006_02111e48(p);
+}

--- a/src/func_ov006_021146f4.c
+++ b/src/func_ov006_021146f4.c
@@ -1,0 +1,5 @@
+extern void func_0203d6d0(void*, void*, void*);
+
+void func_ov006_021146f4(void* a, char* b) {
+    func_0203d6d0(a, b + 8, b + 0x10);
+}

--- a/src/func_ov060_021183f4.c
+++ b/src/func_ov060_021183f4.c
@@ -1,0 +1,5 @@
+extern void func_ov060_021183cc(void*, void*);
+
+void func_ov060_021183f4(void* a, void* b, void* c) {
+    func_ov060_021183cc(b, c);
+}

--- a/src/func_ov063_0211d28c.c
+++ b/src/func_ov063_0211d28c.c
@@ -1,0 +1,5 @@
+extern void func_ov063_0211d270(void*, void*);
+
+void func_ov063_0211d28c(void* a, void* b, void* c) {
+    func_ov063_0211d270(b, c);
+}

--- a/src/func_ov064_02118cd4.c
+++ b/src/func_ov064_02118cd4.c
@@ -1,0 +1,5 @@
+extern void func_ov064_02118e24(void*, int, int, int);
+
+void func_ov064_02118cd4(void* a) {
+    func_ov064_02118e24(a, 0, 0x78000, 4);
+}

--- a/src/func_ov064_02118d08.c
+++ b/src/func_ov064_02118d08.c
@@ -1,0 +1,5 @@
+extern void func_ov064_02118e24(void*, int, int, int);
+
+void func_ov064_02118d08(void* a) {
+    func_ov064_02118e24(a, 0x78000, 0, 4);
+}


### PR DESCRIPTION
88 functions, byte-verified locally with `tools/match.py` (relocation-aware compare vs ROM at mwccarm 1.2/sp2p3) against current `main` headers — all 88 reproduce. src-only, one coherent batch.

Backlog of matches accumulated over the day that never got PR'd; sorted from a larger working-tree pile (near-misses routed to the DB separately).