### PR TITLE
Match 1 function byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN8CapEnemy12Unk_02005d94Ev.c
+++ b/src/_ZN8CapEnemy12Unk_02005d94Ev.c
@@ -1,0 +1,18 @@
+extern unsigned char data_0209f2d8;
+extern int func_02005e28(void *c);
+
+void _ZN8CapEnemy12Unk_02005d94Ev(unsigned char *c)
+{
+    int b1;
+    int b2;
+    if (!(c[0x113] & 0x80)) return;
+    b1 = (*(unsigned int *)(c + 0xb0) & 8) ? 1 : 0;
+    if (b1 == 0) {
+        volatile unsigned char *q = &data_0209f2d8;
+        b2 = (q[0] == 1) ? 1 : 0;
+        if (b2 == 0) return;
+    }
+    *(unsigned char *)(((int)c + 0x113) & 0xFFFFFFFFFFFFFFFFULL) &= 7;
+    if (func_02005e28(c))
+        *(unsigned char *)(((int)(c + 0x113)) & 0xFFFFFFFFFFFFFFFFULL) |= 0x80;
+}


### PR DESCRIPTION
CapEnemy::Unk_02005d94() @ arm9 0x02005d94 (0x94). volatile-pointer load on data_0209f2d8 blocks mwccarm from folding the normalized boolean that gates the early return, reproducing the exact moveq/movne/cmp #0 sequence.


Claude-Session: https://claude.ai/code/session_012s73PvHtbyUHnjrZZxrgbG