### PR TITLE
Bank Sonnet->Opus->Fable cascade near-misses, document register-coloring floors

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -610,6 +610,18 @@ Cracked `_ZN10SphereClsn10DetectClsnEv` (SphereClsn::DetectClsn, div 16 -> 0, Fa
 floor - the plain floor (register-coloring swap with NO virtual call feeding it) is
 still unreachable and should still be parked.
 
+**Confirmed NOT applicable (2026-07-11):** a symmetric `sb`/`sl` (dst-temp/src-temp)
+coloring swap in an inlined `ldm!/stm!` aggregate-copy loop with NO call in the loop
+body - mwccarm invariantly assigns dst-temp to `sb`, src-temp to `sl` regardless of
+decl order, block-scoped temps, array-subscript form, reference binding, or a
+fake-dependency ternary; applying the 6i call-result scoping trick here made it
+WORSE (div 8 -> 20). This is the genuine plain floor 6i itself warns about - do not
+retry 6i on a writeback-temp swap with no intervening call. (`func_ov055_02111358` /
+`_ZN11MirrorLuigi6RenderEv`, Opus reached div 13 -> 8 via decl reorder (i first, dst
+before src) fixing the OUTER counter/pointer coloring; Fable exhausted 8 attempts on
+the residual inner sb/sl swap with zero further movement - parked in nearmiss/db.jsonl
+at div 8.)
+
 ## 6j. Array-subscript indexing defeats a LICM index*scale hoist under EBB-local CSE (2026-07-10)
 
 Companion to 6e's `#pragma opt_common_subs off` master lever. Once the pragma flips CSE

--- a/tools/refine_run.js
+++ b/tools/refine_run.js
@@ -63,7 +63,7 @@ STRUCTURAL LEVERS (these fix what the permuter cannot; pick by what the diff sho
 - DUPLICATED early-exit epilogue (popeq/bxeq repeated instead of a beq to the shared tail): '#pragma optimize_for_size on' above the function
 - halfword/byte access at offset >= 0x100 in the target with a materialized base: that is ENCODING-forced - plain '*(short*)(p+0x100) = k' reproduces it; and a base passed as 'this'/call-arg materializes too (Sub *b = &c->sub; b->m(...))
 - stack slots optimized away: a volatile array keeps them live
-For the full catalogue read notes/pret-idioms.md and notes/mwccarm-codegen.md (sec 6e has the newest levers).
+For the full catalogue read notes/pret-idioms.md and notes/mwccarm-codegen.md - sec 2 is the register-coloring wall, 6e/6i/6j/6k/6l are the newest levers (6k: callee-saved locals color in REVERSE declaration order; 6j: array-subscript vs pointer-arithmetic indexing under EBB-local CSE; 6i: block-scoped temp around a call result flips loop coloring).
 
 MATERIALIZED BASE (add rX,base,#imm then [rX] where your C folds to [base,#imm]): the LEVER is the u64-mask laundering idiom - *(int *)(((int)base + 0xOFF) & 0xFFFFFFFFFFFFFFFF) - the identity AND blocks offset folding and forces the add. Verified on multiple previously-floor functions. Also check: halfword/byte at offset >= 0x100 materializes from a plain cast; a base the ROM passes to a call materializes via a pointer arg (Sub *b = &c->sub; b->m(...)). If the residual is pure two-word store-EMISSION order, stop and report your best.
 


### PR DESCRIPTION
## Summary
Ran a 3-model cascade (Sonnet -> Opus -> Fable) over 5 fresh functions in the 0x400-0x800 band plus a targeted retry on a prior near-miss. No new byte-matches, but real progress banked to the near-miss DB and two documentation/tooling fixes:

- `_ZN12WithMeshClsn16UpdateContinuousEv`: 63 -> 12 divergences (Opus)
- `func_ov006_020cfc74`: 81 -> 54 divergences (Opus then Fable)
- `func_ov002_020bfa74`: 217 -> 176 divergences (Fable) - **flags a possible compiler-VERSION mismatch**: the ROM call site's by-value-struct ABI matches mwccarm 2.0/sp1p5, not the 1.2/sp2p3 this repo builds against. Worth a maintainer look before writing this one off as a coloring floor.
- `func_ov055_02111358` (MirrorLuigi::Render): 13 -> 8 divergences (Opus); Fable then confirmed the residual `sb`/`sl` writeback-temp swap is a genuine floor, not reachable by the existing lever set.
- `_ZN6Player13St_Climb_MainEv`, `func_ov007_020caeac`: held at identical divergence counts across all 3 models - confirmed floors, not worth further fan-out spend.

`notes/mwccarm-codegen.md`: documents the confirmed-floor case (6i's block-scoped-temp lever does NOT apply to a call-free symmetric writeback-temp swap, to save future agents the attempt). `tools/refine_run.js`: fixes a stale "sec 6e has the newest levers" pointer to reference the current lever set (6e/6i/6j/6k/6l).

## Test plan
- [x] All 6 near-miss drafts independently re-verified against ROM bytes via `abverify.py` (divergence counts above are oracle-verified, not self-reported)
- [x] `nearmiss/db.jsonl` merge checked for conflicts against the latest `origin/main` snapshot (5 new rows, 1 update, 0 dropped)
- [x] No `src/` changes in this PR (no matches landed this batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsMWvq4X1BZH8cSW7oAp55