### PR TITLE
Match func_ov090_02130f94 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -622,6 +622,22 @@ before src) fixing the OUTER counter/pointer coloring; Fable exhausted 8 attempt
 the residual inner sb/sl swap with zero further movement - parked in nearmiss/db.jsonl
 at div 8.)
 
+**Follow-up (2026-07-11, func_ov090_02130f94 MATCHED, div 48 -> 0):** the only other
+ROM instance of the `mov sl,rSRC / mov lr,rDST / ldm sl!/stm sb!` writeback-temp shape
+needed NO copy-temp intervention at all - a plain `global = *src;` aggregate assign
+colored sb/sl/lr correctly on the first try. The real walls were elsewhere, and the fix
+generalizes: when the target loop has BOTH a surviving multiplicative induction counter
+(`add r4,r4,#3` feeding an mla) AND a scaled access that is NOT reduced (`add
+r0,r7,r6,lsl #2` recomputed on both sides of a call instead of a `+=4` induction var +
+cross-call CSE), turn BOTH `#pragma opt_strength_reduction off` and `#pragma
+opt_common_subs off` on and hand-write the surviving counter as an explicit variable
+(`idx = 6; ... idx += 3;` in the loop) so it outlives the pragma. Either pragma alone
+made it worse (53/14 div); together with the explicit counter: div 6. The last 6 words
+were the 3-word `v = r;` struct copy: struct assign emits ldm/stm (wrong), int temps
+extend live ranges and reorder the loads (wrong); plain per-field `v.x = r.x; v.y =
+r.y; v.z = r.z;` under `opt_common_subs off` emits the batched 3-load/3-store shape
+byte-exact, including reusing the r.z load (r3) for a later stack arg.
+
 ## 6j. Array-subscript indexing defeats a LICM index*scale hoist under EBB-local CSE (2026-07-10)
 
 Companion to 6e's `#pragma opt_common_subs off` master lever. Once the pragma flips CSE

--- a/src/func_ov090_02130f94.c
+++ b/src/func_ov090_02130f94.c
@@ -1,0 +1,51 @@
+#pragma opt_strength_reduction off
+#pragma opt_common_subs off
+struct Mtx { int w[12]; };
+struct Vector3 { int x, y, z; };
+extern void MulMat4x3Mat4x3(struct Mtx* out, struct Mtx* a, struct Mtx* b);
+extern void Vec3_Lsl(struct Vector3* out, const struct Vector3* in, int n);
+extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    unsigned int a0, unsigned int a1, int a2, int a3, int a4, int a5, int a6);
+extern struct Mtx data_020a0e68;
+
+void func_ov090_02130f94(char* c_)
+{
+    int zero;
+    int sh;
+    char* c;
+    int i;
+    struct Mtx* src;
+    int idx;
+    int b;
+    unsigned int id;
+
+    c = c_;
+    b = (int)((*(int*)(c + 0xb0) & 8) != 0);
+    if (b != 0) return;
+
+    src = (struct Mtx*)(c + 0x328);
+    i = 0;
+    idx = 6;
+    zero = 0;
+    sh = 3;
+    id = 0xea;
+    for (; i < 4; ++i) {
+        struct Vector3 v;
+        struct Vector3 r;
+
+        data_020a0e68 = *src;
+        MulMat4x3Mat4x3((struct Mtx*)*(void**)(c + 0x320) + idx, &data_020a0e68, &data_020a0e68);
+        v.x = *(int*)((char*)&data_020a0e68 + 0x24);
+        v.y = *(int*)((char*)&data_020a0e68 + 0x28);
+        v.z = *(int*)((char*)&data_020a0e68 + 0x2c);
+        Vec3_Lsl(&r, &v, sh);
+        v.x = r.x;
+        v.y = r.y;
+        v.z = r.z;
+        v.y = *(int*)(c + 0x3ac);
+        *(unsigned int*)(c + i * 4 + 0x380) =
+            _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                *(unsigned int*)(c + i * 4 + 0x380), id, v.x, v.y, r.z, zero, zero);
+        idx += 3;
+    }
+}


### PR DESCRIPTION
Cracks the div-48 parked near-miss func_ov090_02130f94 (ov090, 0x02130f94, 288 bytes, particle spawner loop) to a full byte match. Pops the near-miss row and records the lever in notes/mwccarm-codegen.md.

Verified locally: abverify MATCH, linkcheck VERIFIED (0 diffs, 0 blind).

Built with Claude Code