### PR TITLE
Match 6 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020af0c0.c
+++ b/src/func_ov002_020af0c0.c
@@ -1,0 +1,37 @@
+typedef struct Vector3 { int x, y, z; } Vector3;
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+extern short data_02082214[];
+#define SINE_TABLE data_02082214
+extern char* _ZN5Actor13ClosestPlayerEv(void*);
+extern int func_ov002_020d0d2c(void*);
+extern int Vec3_HorzLen(const Vector3*);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int, int);
+extern short Vec3_HorzAngle(const Vector3*, const Vector3*);
+extern void _Z14ApproachLinearRsss(short*, int, int);
+extern void func_ov002_020af3a8(void*);
+
+void func_ov002_020af0c0(char* c){
+    char* p = _ZN5Actor13ClosestPlayerEv(c);
+    if(p != 0){
+        Vector3 diff;
+        Vector3 ppos;
+        int* s = (int*)AT(p, 0x5c);
+        ppos.x = s[0];
+        ppos.y = s[1];
+        ppos.z = s[2];
+        diff.x = ppos.x - *(int*)(c+0x5c);
+        if(func_ov002_020d0d2c(p) != 0)
+            diff.y = ppos.y - *(int*)(c+0x60) - 0x50000;
+        else
+            diff.y = ppos.y - *(int*)(c+0x60) + 0x78000;
+        diff.z = ppos.z - *(int*)(c+0x64);
+        int len = Vec3_HorzLen(&diff);
+        int pitch = _ZN4cstd5atan2E5Fix12IiES1_(len, diff.y);
+        short yaw = Vec3_HorzAngle((Vector3*)(c+0x5c), &ppos);
+        _Z14ApproachLinearRsss((short*)(c+0x94), yaw, 0x1000);
+        _Z14ApproachLinearRsss((short*)(c+0x92), pitch, 0x1000);
+        *(int*)(c+0xa8) = (short)SINE_TABLE[(*(unsigned short*)(c+0x92) >> 4)*2+1] * (short)0x1e;
+        *(int*)(c+0x98) = (short)SINE_TABLE[(*(unsigned short*)(c+0x92) >> 4)*2] * (short)0x1e;
+    }
+    func_ov002_020af3a8(c);
+}

--- a/src/func_ov006_020fc9b0.c
+++ b/src/func_ov006_020fc9b0.c
@@ -1,0 +1,15 @@
+void func_ov006_020fc9b0(char *base, int i)
+{
+    int x, y, cnt;
+
+    if (*(unsigned char *)(base + 0x4000 + i * 0x38 + 0x68f) == 5) return;
+    x = *(int *)(base + 0x4000 + i * 0x38 + 0x660) >> 12;
+    y = *(int *)(base + 0x4000 + i * 0x38 + 0x664) >> 12;
+    cnt = 0;
+    if (y >= 0xd0) cnt++;
+    if (x >= 0x120 || x <= -0x20) cnt++;
+    if (cnt != 0) {
+        *(unsigned char *)(base + 0x4000 + i * 0x38 + 0x68c) = 0;
+        *(unsigned char *)(base + 0x4000 + i * 0x38 + 0x68d) = 0;
+    }
+}

--- a/src/func_ov006_02105c1c.c
+++ b/src/func_ov006_02105c1c.c
@@ -1,0 +1,13 @@
+void func_ov006_02105c1c(char *base)
+{
+    int i = 0;
+
+    if (*(int *)(base + 0x4cb8) <= 0) return;
+    do {
+        if (*(unsigned char *)(base + i + 0x4f1e) != *(unsigned char *)(base + i + 0x4f42)) {
+            *(unsigned char *)(base + i + 0x4efa) = 2;
+            *(unsigned short *)(base + (int)(((long long)i) & 0xFFFFFFFFFFFFFFFFLL) * 2 + 0x4e30) = 0;
+        }
+        i++;
+    } while (i < *(int *)(base + 0x4cb8));
+}

--- a/src/func_ov006_02119a18.c
+++ b/src/func_ov006_02119a18.c
@@ -1,0 +1,12 @@
+#define A(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+extern unsigned short data_ov006_0212ee38[];
+
+void func_ov006_02119a18(char *b)
+{
+    if (*(unsigned char *)(b + 0x5604) == 0) return;
+    if (*(unsigned char *)(b + 0x5606) >= 3) return;
+    *(unsigned short *)A(b + 0x5600) += 1;
+    if (*(unsigned short *)(b + 0x5600) < data_ov006_0212ee38[*(unsigned char *)(b + 0x5606)]) return;
+    *(unsigned short *)(b + 0x5600) = 0;
+    *(unsigned char *)A(b + 0x5606) += 1;
+}

--- a/src/func_ov006_0211e184.c
+++ b/src/func_ov006_0211e184.c
@@ -1,0 +1,25 @@
+#define LI(i) ((int)(((long long)(i)) & 0xFFFFFFFFFFFFFFFFLL) * 0x10)
+#define A(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_ov006_0211e184(char *base)
+{
+    int i;
+
+    for (i = 0; i < 0x10; i++) {
+        unsigned char *fp = (unsigned char *)A(base + LI(i) + 0x496d);
+        unsigned short *c16;
+        unsigned char *c8;
+        if (*fp == 0) continue;
+        c16 = (unsigned short *)A(base + LI(i) + 0x4968);
+        *c16 += 1;
+        if (*c16 < 4) continue;
+        *c16 = 0;
+        c8 = (unsigned char *)A(base + LI(i) + 0x496c);
+        *c8 += 1;
+        if (*c8 >= 5) {
+            *c8 = 0;
+            *(unsigned char *)(base + LI(i) + 0x496e) = 0;
+            *fp = 0;
+        }
+    }
+}

--- a/src/func_ov006_0211e4e0.c
+++ b/src/func_ov006_0211e4e0.c
@@ -1,0 +1,23 @@
+#define A(p) ((unsigned char *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_ov006_0211e4e0(char *base)
+{
+    int i;
+
+    for (i = 0; i < 0x10; i++) {
+        if (*(unsigned char *)(base + 0x48a9) != 0) {
+            if (*(unsigned char *)(base + 0x48a8) != 0) {
+                unsigned char *p = A(base + 0x48a8);
+                int v;
+                *p -= 1;
+                v = *(unsigned char *)(base + 0x48a8);
+                if (v < 0)
+                    *(unsigned char *)(base + 0x48a8) = 0;
+            } else {
+                *(unsigned char *)(base + 0x48a9) = 0;
+                *(unsigned char *)(base + 0x48aa) = 0;
+            }
+        }
+        base += 0xc;
+    }
+}


### PR DESCRIPTION
6 new byte-exact matches. Each compiles with mwccarm 1.2/sp2p3 and reproduces the ROM bytes (verified locally with `match`), and every relocation was audited to resolve to the config-recorded callee/global (`reloc_audit` CLEAN — no WRONG-DEST).

| function | module | size | shape |
|---|---|---|---|
| `func_ov002_020af0c0` | ov002 | 0x11c | player-tracking (atan2 / ApproachLinear / sine) |
| `func_ov006_020fc9b0` | ov006 | 0x6c | per-element range check |
| `func_ov006_02105c1c` | ov006 | 0x6c | predicated compare loop |
| `func_ov006_02119a18` | ov006 | 0x70 | counter-advance state fn (data-table reloc) |
| `func_ov006_0211e184` | ov006 | 0x9c | counter/threshold loop |
| `func_ov006_0211e4e0` | ov006 | 0x7c | walking-pointer decrement loop |

src-only, one function per file. `validate` is the gate.