### PR TITLE
Match 8 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020b979c.c
+++ b/src/func_ov002_020b979c.c
@@ -1,0 +1,73 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern void* _ZN5Actor10FindWithIDEj(u32 id);
+extern int _ZN6Player15IsCollectingCapEv(void* p);
+extern void _ZN6Player16InitWingFeathersEb(void* p, int b);
+extern void _ZN6Player16InitBalloonMarioEv(void* p);
+extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
+extern void _ZN6Player14InitMetalWarioEv(void* p);
+extern void _ZN6Player15InitVanishLuigiEv(void* p);
+extern void _ZN6Player13InitFireYoshiEv(void* p);
+
+void func_ov002_020b979c(char* self) {
+    char* other;
+    u32 id = *(u32*)(self + 0x1f0);
+    if (id == 0) return;
+
+    other = (char*)_ZN5Actor10FindWithIDEj(id);
+    if (other == 0) return;
+
+    {
+        int b = (int)(*(u16*)(other + 0xc) == 0xbf);
+        if (b == 0) return;
+    }
+
+    if (_ZN6Player15IsCollectingCapEv(other) != 0) return;
+
+    {
+        char* p = *(char**)(other + 0x358);
+        int t = (int)(p != 0);
+        if (t != 0) {
+            int b = (int)(*(u16*)(p + 0xc) == 0x10b);
+            if (b != 0) return;
+        }
+    }
+
+    {
+        u32 flags = *(u32*)(self + 0xb0);
+        int t = (int)((flags & 0x20000) != 0);
+        if (t != 0) {
+            *(u8*)(self + 0x3ca) = 0x64;
+            return;
+        }
+    }
+
+    switch (*(int*)(other + 8)) {
+    case 0:
+        if (*(int*)(self + 8) == 1) {
+            _ZN6Player16InitWingFeathersEb(other, 1);
+        } else {
+            _ZN6Player16InitBalloonMarioEv(other);
+        }
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    case 2:
+        _ZN6Player14InitMetalWarioEv(other);
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    case 1:
+        _ZN6Player15InitVanishLuigiEv(other);
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    case 3:
+        if (*(char**)(other + 0x360) != 0) {
+            char* p = *(char**)(other + 0x360);
+            if (*(u16*)(p + 0xc) == 0x10c) return;
+        }
+        _ZN6Player13InitFireYoshiEv(other);
+        _ZN9ActorBase18MarkForDestructionEv(self);
+        return;
+    }
+}

--- a/src/func_ov002_020ce5f8.c
+++ b/src/func_ov002_020ce5f8.c
@@ -1,0 +1,75 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+struct Vector3 { int x, y, z; };
+
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* st);
+extern int func_ov002_020ceb54(char* c);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, const struct Vector3* pos);
+extern void func_ov002_020ce8bc(void* c, int arg);
+extern void func_ov002_020ceb7c(void* c);
+extern u32 _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
+extern void MulVec3Mat4x3(void* v, void* m, void* dst);
+extern void* Vec3_LslInPlace(void* v, int sh);
+extern u32 func_020229f0(int x, int y, int z);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, const struct Vector3* pos);
+
+extern int data_0209f32c;
+extern char data_ov002_0211013c;
+
+int func_ov002_020ce5f8(char* c) {
+    int y, threshold;
+    struct Vector3 pos;
+
+    threshold = data_0209f32c - 0x50000;
+    y = *(int*)(c + 0x60);
+    if (y >= threshold) {
+        if ((*(u8*)(c + 0x6e9) & 1) == 0) {
+            if (*(int*)(c + 0xa8) >= 0) {
+                *(int*)(c + 0x60) = threshold;
+                *(int*)(c + 0xa8) = 0;
+            }
+        } else {
+            if (threshold < y - 0xa000) {
+                *(u8*)(c + 0x706) = 0;
+                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+                return 1;
+            }
+        }
+    }
+
+    if (func_ov002_020ceb54(c) == 0) {
+        if (*(u8*)(c + 0x70c) == 0) {
+            *(u8*)((((long long)(int)(c + 0x70c))) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            _ZN5Sound9PlayBank0EjRK7Vector3(0x17, (struct Vector3*)(c + 0x74));
+            *(int*)(c + 0x628) = 0;
+        }
+        func_ov002_020ce8bc(c, *(int*)(c + 0x640));
+    } else {
+        *(u8*)(c + 0x70c) = 0;
+    }
+    func_ov002_020ceb7c(c);
+
+    {
+        u32 idx = _ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0);
+        char* m1 = *(char**)(c + idx * 4 + 0xdc);
+        char* base;
+        u32 idx2;
+        char* m2;
+        base = *(char**)(m1 + 0x14) + 0x2d0;
+        idx2 = _ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0);
+        m2 = *(char**)(c + idx2 * 4 + 0xdc);
+        MulVec3Mat4x3(base + 0x24, m2 + 0x1c, &pos);
+    }
+    Vec3_LslInPlace(&pos, 3);
+
+    if (pos.y < data_0209f32c - 0x1e000) {
+        func_020229f0(pos.x, *(volatile int*)&pos.y, pos.z);
+        if (*(u16*)(c + 0x6a6) == 0) {
+            _ZN5Sound9PlayBank3EjRK7Vector3(0xb, (struct Vector3*)(c + 0x74));
+            *(u16*)(c + 0x6a6) = 0xa;
+        }
+    }
+    return 0;
+}

--- a/src/func_ov004_020b39a4.c
+++ b/src/func_ov004_020b39a4.c
@@ -1,0 +1,81 @@
+typedef short s16;
+typedef int s32;
+typedef unsigned int u32;
+
+extern void func_020731dc(int a, int b, void **node);
+extern void func_0203d704(int* o, int* a, int* b);
+extern void func_0203d388(int *p, int angle);
+extern int RandomIntInternal(int* seed);
+extern void func_ov004_020adfc4(int c, short a1, int* a2, int* r3, int* sp0);
+extern void func_0203d47c(void);
+
+struct Pair { int a, b; };
+extern struct Pair data_ov004_020bc17c;
+extern struct Pair data_ov004_020bc1ec;
+extern int data_ov004_020bf3ec;
+extern int data_ov004_020bf3f4[2];
+extern void* data_ov004_020bf410[3];
+extern int data_0209e650;
+
+void func_ov004_020b39a4(char* c) {
+    int i;
+    int angle;
+    int boxA[2], boxB[2], boxC[2];
+    int posA[2];
+    int outA[2], outB[2];
+    int flags;
+
+    int shifted;
+
+    *(int*)(c + 0x24) = 0;
+    angle = *(short*)(c + 0x2c);
+    angle = angle + 1;
+    shifted = angle << 14;
+    *(int*)(c + 0x28) = shifted;
+
+    *(struct Pair*)(c + 0)   = data_ov004_020bc17c;
+    *(struct Pair*)(c + 8)   = data_ov004_020bc1ec;
+
+    boxA[0] = 0; boxA[1] = -0x2000;
+    boxB[0] = 0; boxB[1] = -0x1800;
+    boxC[0] = 0; boxC[1] = -0x4000;
+
+    flags = data_ov004_020bf3ec;
+
+    {
+        int y12 = *(short*)(c + 0x12);
+        int y10 = *(short*)(c + 0x10);
+        int sY12, sY10;
+        flags = flags & 1;
+        sY12 = y12 << 12;
+        sY10 = y10 << 12;
+        posA[0] = sY10;
+        posA[1] = sY12;
+    }
+
+    if (flags == 0) {
+        data_ov004_020bf3f4[0] = 0;
+        data_ov004_020bf3f4[1] = 0xc0;
+        func_020731dc((int)data_ov004_020bf3f4, (int)func_0203d47c, data_ov004_020bf410);
+        data_ov004_020bf3ec = data_ov004_020bf3ec | 1;
+    }
+
+    for (i = 0; i < 0x20; i++) {
+        int r;
+        int ang;
+        s16 spawnAngle;
+
+        func_0203d704(outA, posA, boxC);
+        func_0203d388(boxA, 0x800);
+        func_0203d388(boxC, 0x800);
+        func_0203d704(outB, boxB, boxA);
+
+        r = RandomIntInternal(&data_0209e650);
+        r &= 0x7fffffff;
+        ang = (int)((u32)r >> 0x13) * 0x3c >> 0xc;
+        ang = ang + 0x5a;
+        spawnAngle = (s16)ang;
+
+        func_ov004_020adfc4(0, spawnAngle, outA, outB, data_ov004_020bf3f4);
+    }
+}

--- a/src/func_ov006_020df3bc.c
+++ b/src/func_ov006_020df3bc.c
@@ -1,0 +1,60 @@
+extern unsigned char data_020a0e40[];
+extern unsigned char data_020a0de8[];
+extern unsigned char data_020a0de9[];
+extern unsigned char data_020a0deb[];
+extern unsigned char data_020a0dea[];
+
+extern void func_ov006_020def80(char* c, int i);
+extern void func_ov004_020b0aa0(int arg);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int id);
+
+#pragma opt_common_subs off
+#pragma opt_strength_reduction off
+void func_ov006_020df3bc(char* c)
+{
+    int flag = 0;
+    unsigned int idx = data_020a0e40[0];
+    int j;
+    unsigned char thA;
+    unsigned char thB;
+
+    if (data_020a0de8[idx * 4] != 0 && data_020a0de9[idx * 4] != 0) flag = 1;
+    if (flag == 0) return;
+
+    {
+        unsigned char* thP = &data_020a0de8[idx * 4];
+        thA = thP[2];
+        thB = thP[3];
+    }
+
+    for (j = 0; j < 3; j++) {
+        int dx = thA - (*(int*)(c + j * 8 + 0x5000 + 0x3e8) >> 12);
+        int dy = thB - (*(int*)(c + j * 8 + 0x5000 + 0x3ec) >> 12);
+        if (dx > 0x10 || dx < -0x28 || dy > 0x18 || dy < -0x20) continue;
+
+        *(unsigned char*)(c + j + 0x5000 + 0x465) = 1;
+        func_ov006_020def80(c, j);
+
+        if (*(unsigned char*)(c + 0x5000 + 0x468) == *(unsigned char*)(c + j + 0x5000 + 0x462)) {
+            *(unsigned char*)(c + 0x5000 + 0x469) = 1;
+            *(int*)(c + j * 4 + 0x5000 + 0x434) = 6;
+        } else {
+            *(unsigned char*)(c + 0x5000 + 0x469) = 0;
+        }
+
+        *(int*)(c + 0x5000 + 0x418) = 5;
+        *(int*)(c + 0x5000 + 0x41c) = 0x3c;
+        func_ov004_020b0aa0(0x1d);
+
+        {
+            unsigned int idx2 = data_020a0e40[0];
+            unsigned char a1 = *(volatile unsigned char*)&data_020a0deb[idx2 * 4];
+            unsigned char a2 = *(volatile unsigned char*)&data_020a0dea[idx2 * 4];
+            *(int*)(c + 0x5000 + 0xdc) = 1;
+            *(int*)(c + 0x5000 + 0xd4) = a2;
+            *(int*)(c + 0x5000 + 0xd8) = a1;
+        }
+        _ZN5Sound12PlayBank2_2DEj(0x1cd);
+        return;
+    }
+}

--- a/src/func_ov006_020e6354.cpp
+++ b/src/func_ov006_020e6354.cpp
@@ -1,0 +1,52 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+struct C;
+typedef void (C::*PMF0)();
+typedef void (C::*PMF1)(int);
+
+extern "C" {
+extern PMF0 data_ov006_02141978[];
+extern PMF1 data_ov006_021419d8[];
+}
+
+extern "C" void func_ov006_020e6354(char* c)
+{
+    if (*(u16*)(c + 0x55b6) != 0) {
+        u16* q = (u16*)((long long)(int)(c + 0x55b6) & 0xFFFFFFFFFFFFFFFFLL);
+        *q = *q - 1;
+        return;
+    }
+    if (*(u8*)(c + 0xc4) == 0) {
+        *(u8*)(c + 0xc3) = 1;
+        *(u8*)(c + 0xc4) = 1;
+        *(u16*)(c + 0xc0) = 0;
+    }
+    if (*(u8*)(c + 0x55bd) != 0) {
+        u8* q = (u8*)((long long)(int)(c + 0x55bd) & 0xFFFFFFFFFFFFFFFFLL);
+        *q = *q - 1;
+    }
+    (((C*)c)->*data_ov006_02141978[*(u8*)(c + 0x55b8)])();
+
+    {
+        int count = 0;
+        int i = 0;
+        char* p = c;
+        for (; i < 0xb; i++, p += 0x30) {
+            if (*(u8*)(p + 0x4689) != 0) {
+                *(int*)(p + 0x466c) = *(int*)(p + 0x4660);
+                *(int*)(p + 0x4670) = *(int*)(p + 0x4664);
+                if (*(u16*)(p + 0x4680) != 0) {
+                    u16* q = (u16*)((long long)(int)(p + 0x4680) & 0xFFFFFFFFFFFFFFFFLL);
+                    *q = *q - 1;
+                }
+                (((C*)c)->*data_ov006_021419d8[*(u8*)(p + 0x4688)])(i);
+                if (*(u8*)(p + 0x4688) != 2) count++;
+            }
+        }
+        if (count != 0) return;
+    }
+    *(int*)(c + 0x5580) = 2;
+    *(u16*)(c + 0x55b6) = 0x40;
+}

--- a/src/func_ov065_0211a1c8.c
+++ b/src/func_ov065_0211a1c8.c
@@ -1,0 +1,65 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern u16 DecIfAbove0_Short(u16* p);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
+extern int RandomIntInternal(int* seed);
+extern int func_ov065_0211a114(char* c);
+extern void func_ov065_02119fe8(char* self);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
+
+extern u8 data_0209f2c0;
+extern int data_0209e650;
+
+#define I16(off) (*(short*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
+
+int func_ov065_0211a1c8(char* c)
+{
+    if (data_0209f2c0 != 3) {
+        if (*(unsigned short*)(c + 0x300 + 0x26) != 0) {
+            if (DecIfAbove0_Short((u16*)(c + 0x326)) == 0) {
+                _ZN5Sound9PlayBank3EjRK7Vector3(0x38, c + 0x74);
+            }
+        }
+        if (DecIfAbove0_Short((u16*)(c + 0x328)) == 0) {
+            {
+                short vx = *(short*)(c + 0x300 + 0x1e);
+                short vy = *(short*)(c + 0x300 + 0x22);
+                short* accelP = (short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFFLL);
+                if (vy * vx > 0) {
+                    vx = -vx;
+                    *(short*)(c + 0x300 + 0x1e) = vx;
+                }
+                {
+                    short spd = *(short*)(c + 0x300 + 0x20);
+                    short pos = *(short*)(c + 0x300 + 0x1e);
+                    short accel = *accelP;
+                    *accelP = (short)(spd * pos + accel);
+                }
+            }
+            if (data_0209f2c0 == 2 && *(short*)(c + 0x300 + 0x24) == 0) {
+                int r0 = RandomIntInternal(&data_0209e650);
+                if ((unsigned)r0 % 3 != 0)
+                    *(short*)(c + 0x300 + 0x20) = 0xd;
+                else
+                    *(short*)(c + 0x300 + 0x20) = 0x2a;
+                if ((r0 & 1) == 0) {
+                    *(short*)(c + 0x300 + 0x28) = (short)((unsigned)r0 >> 0x1b) + 3;
+                }
+            }
+            if (*(short*)(c + 0x300 + 0x24) == 0) {
+                *(short*)(c + 0x300 + 0x26) = *(unsigned short*)(c + 0x300 + 0x28) + 0xf;
+            }
+            I16(0x322) = I16(0x322) + *(short*)(c + 0x300 + 0x24);
+        }
+        *(short*)(c + 0x90) = *(short*)(c + 0x300 + 0x22);
+    }
+
+    func_ov065_0211a114(c);
+    func_ov065_02119fe8(c);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0x300000, -0x200000) != 0)
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    return 1;
+}

--- a/src/func_ov079_02124ed4.c
+++ b/src/func_ov079_02124ed4.c
@@ -1,0 +1,58 @@
+extern void _ZN9Animation7AdvanceEv(void* a);
+extern void func_02012694(int a, void* p);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* m, void* f, int a, int b, unsigned int e);
+extern void* data_ov079_021281b0[];
+
+void func_ov079_02124ed4(char* c)
+{
+    _ZN9Animation7AdvanceEv(c + 0x31c);
+    *(unsigned char*)(c + 0x405) = 0;
+    if (*(unsigned char*)(c + 0x40c) == 0) {
+        if (*(unsigned char*)(c + 0x402) != 0) {
+            *(unsigned char*)(c + 0x402) = 0;
+            {
+                unsigned char* p401 = (unsigned char*)(((int)c + 0x401) & 0xFFFFFFFFFFFFFFFF);
+                *p401 = *p401 - 1;
+            }
+            func_02012694(0x134, c + 0x74);
+            {
+                int* p = (int*)(((int)*(int*)(c + 0x3ac) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(3, p[0], p[1], p[2]);
+            }
+            if (*(unsigned char*)(c + 0x401) == 0) {
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x2cc, data_ov079_021281b0[1], 0x40000000, 0x1000, 0);
+                *(int*)(c + 0x3b0) = 8;
+            } else {
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x2cc, data_ov079_021281b0[1], 0x40000000, 0x1000, 0);
+                *(int*)(c + 0x3ac) = 0;
+                _ZN9Animation7AdvanceEv(c + 0x330);
+                {
+                    unsigned char* p40c = (unsigned char*)(((int)c + 0x40c) & 0xFFFFFFFFFFFFFFFF);
+                    *p40c = *p40c + 1;
+                }
+            }
+        }
+        *(unsigned short*)(c + 0x300 + 0xfc) = 0;
+        return;
+    } else {
+        unsigned short v;
+        {
+            unsigned short* p3fc = (unsigned short*)(((int)c + 0x3fc) & 0xFFFFFFFFFFFFFFFF);
+            *p3fc = *p3fc + 1;
+        }
+        v = *(unsigned short*)(c + 0x300 + 0xfc);
+        if (v <= 10) {
+            if ((int)v % 2) {
+                int* p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+                *p60 = *p60 + 0x10000;
+            } else {
+                int* p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+                *p60 = *p60 - 0x10000;
+            }
+            return;
+        }
+        *(unsigned char*)(c + 0x40c) = 10;
+        *(unsigned short*)(c + 0x300 + 0xfc) = 0;
+    }
+}

--- a/src/func_ov084_0212dc30.c
+++ b/src/func_ov084_0212dc30.c
@@ -1,0 +1,61 @@
+struct Vector3 { int x, y, z; };
+
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+
+extern int _Z14ApproachLinearRiii(int *cur, int target, int step);
+extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);
+extern void func_0201267c(unsigned int id, const struct Vector3 *v);
+extern void *_ZN5Actor13ClosestPlayerEv(void *self);
+extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
+extern int _Z14ApproachLinearRsss(short *cur, short target, short step);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int a, const struct Vector3 *pos, const void *rot, int e, int f);
+extern void func_ov084_0212ec04(char *c, int arg);
+extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
+
+void func_ov084_0212dc30(char *c)
+{
+    void *player;
+    struct Vector3 v;
+    short angle;
+    void *spawned;
+    int *p;
+
+    if (_Z14ApproachLinearRiii((int*)(c + 0x204), *(int*)(c + 0x210), *(int*)(c + 0x214)) == 0) {
+        goto tail;
+    }
+
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x160, 0x10) ||
+        _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x20) ||
+        _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x34) ||
+        _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x4b)) {
+        func_0201267c(0xc0, (struct Vector3*)(c + 0x74));
+    }
+
+    angle = *(short*)(c + 0x8e);
+    player = _ZN5Actor13ClosestPlayerEv(c);
+    p = (int*)AT(player, 0x5c);
+    v.x = p[0];
+    v.y = p[1];
+    v.z = p[2];
+    if (player != 0) {
+        angle = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &v);
+    }
+    _Z14ApproachLinearRsss((short*)(c + 0x8e), angle, 0x400);
+
+    if (*(unsigned char*)(c + 0x21e) == 1) {
+        spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xfa, 0, (struct Vector3*)(c + 0x5c), (void*)(c + 0x8c), *(signed char*)(c + 0xcc), -1);
+        if (spawned == 0) return;
+
+        *(unsigned char*)(c + 0x21e) = 2;
+        func_ov084_0212ec04((char*)spawned, (short)((unsigned int)(*(int*)(c + 0x168) << 4) >> 16));
+        *(int*)AT(c, 0x18c) |= 1;
+        *(int*)AT(c, 0x1c0) |= 1;
+        return;
+    }
+
+    _ZN9ActorBase18MarkForDestructionEv(c);
+    return;
+
+tail:
+    *(int*)AT(c, 0x18c) |= 1;
+}


### PR DESCRIPTION
8 functions matched **byte-identical** to mwccarm 1.2/sp2p3, one matched function per file.

These are the remaining verified matches from sessions 4-5 whose branches were reset by a concurrent automation (the other 27 already landed in main). Each was verified with `match.py --trio` + `linkcheck` earlier this run; the ROM bytes are immutable so the matches still hold. Built directly onto latest main via git plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)