### PR TITLE
Match func_020469e8 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_020469e8.c
+++ b/src/func_020469e8.c
@@ -1,68 +1,62 @@
-typedef unsigned short u16;
-
-struct Entry {
-    u16 id;     /* +0x00 */
-    u16 p2;
-    u16 p4;
-    u16 p6;
-    u16 flag1;  /* +0x08 */
-    u16 idx1;   /* +0x0a */
-    u16 flag2;  /* +0x0c */
-    u16 idx2;   /* +0x0e */
-    u16 flag3;  /* +0x10 */
-    u16 idx3;   /* +0x12 */
-    u16 flag4;  /* +0x14 */
-    u16 idx4;   /* +0x16 */
-    u16 flag5;  /* +0x18 */
-    u16 idx5;   /* +0x1a */
-};
-
-struct Desc {
-    int f0;             /* +0x00 */
-    int *tableA;        /* +0x04 */
-    u16 *tableB;        /* +0x08 */
-    int *tableC;        /* +0x0c */
-    u16 count;          /* +0x10 */
-    u16 p12;
-    struct Entry *entries; /* +0x14 */
-};
-
-struct Ctx {
-    int f0;
-    char *base;         /* +0x04 */
-};
-
-struct Dst {
-    char pad[8];
-    int f8;    /* +0x08 */
-    int fc;    /* +0x0c */
-    u16 f10;   /* +0x10 */
-    u16 p12;
-    int f14;   /* +0x14 */
-    int f18;   /* +0x18 */
-    char pad2[0x30 - 0x1c];
-};
-
 extern void Crash(void);
-extern void func_02045e44(struct Ctx *self, unsigned int value, int index);
+extern void func_02045e44(void* self, unsigned int value, int index);
 
-void func_020469e8(struct Ctx *ctx, struct Desc *desc, int sb) {
-    int i;
-    for (i = 0; i < desc->count; i++) {
-        struct Entry *e = &desc->entries[i];
-        struct Dst *dst;
-        if (e->id == 0xffff) Crash();
-        dst = (struct Dst *)(ctx->base + e->id * 0x30);
-        func_02045e44(ctx, 1, e->id);
-        if (e->flag1 == 1) dst->f8 = desc->tableA[e->idx1];
-        else dst->f8 = desc->tableA[e->idx1 + sb];
-        if (e->flag2 == 1) dst->fc = desc->tableA[e->idx2];
-        else dst->fc = desc->tableA[e->idx2 + sb];
-        if (e->flag3 == 1) dst->f10 = desc->tableB[e->idx3];
-        else dst->f10 = desc->tableB[e->idx3 + sb];
-        if (e->flag4 == 1) dst->f14 = desc->tableC[e->idx4];
-        else dst->f14 = desc->tableC[e->idx4 + sb];
-        if (e->flag5 == 1) dst->f18 = desc->tableC[e->idx5];
-        else dst->f18 = desc->tableC[e->idx5 + sb];
+void func_020469e8(void* arg0, char* sl, int sb)
+{
+    int j;
+
+    for (j = 0; j < *(unsigned short*)(sl + 0x10); j++) {
+        char* src = *(char**)(sl + 0x14) + j * 0x1c;
+        unsigned short srcIdx;
+        char* dst;
+        int* dstBase;
+
+        srcIdx = *(unsigned short*)src;
+        if (srcIdx == 0xffff) Crash();
+
+        dstBase = *(int**)((char*)arg0 + 4);
+        srcIdx = *(unsigned short*)src;
+        dst = (char*)dstBase + srcIdx * 0x30;
+        func_02045e44(arg0, 1, srcIdx);
+
+        if (*(unsigned short*)(src + 8) == 1) {
+            unsigned short idx = *(unsigned short*)(src + 0xa);
+            *(int*)(dst + 8) = *(int*)(*(int**)(sl + 4) + idx);
+        } else {
+            unsigned short idx = *(unsigned short*)(src + 0xa);
+            *(int*)(dst + 8) = *(int*)(*(int**)(sl + 4) + (idx + sb));
+        }
+
+        if (*(unsigned short*)(src + 0xc) == 1) {
+            unsigned short idx = *(unsigned short*)(src + 0xe);
+            *(int*)(dst + 0xc) = *(int*)(*(int**)(sl + 4) + idx);
+        } else {
+            unsigned short idx = *(unsigned short*)(src + 0xe);
+            *(int*)(dst + 0xc) = *(int*)(*(int**)(sl + 4) + (idx + sb));
+        }
+
+        if (*(unsigned short*)(src + 0x10) == 1) {
+            unsigned short idx = *(unsigned short*)(src + 0x12);
+            *(unsigned short*)(dst + 0x10) = *(unsigned short*)(*(unsigned short**)(sl + 8) + idx);
+        } else {
+            unsigned short idx = *(unsigned short*)(src + 0x12);
+            *(unsigned short*)(dst + 0x10) = *(unsigned short*)(*(unsigned short**)(sl + 8) + (idx + sb));
+        }
+
+        if (*(unsigned short*)(src + 0x14) == 1) {
+            unsigned short idx = *(unsigned short*)(src + 0x16);
+            *(int*)(dst + 0x14) = *(int*)(*(int**)(sl + 0xc) + idx);
+        } else {
+            unsigned short idx = *(unsigned short*)(src + 0x16);
+            *(int*)(dst + 0x14) = *(int*)(*(int**)(sl + 0xc) + (idx + sb));
+        }
+
+        if (*(unsigned short*)(src + 0x18) == 1) {
+            unsigned short idx = *(unsigned short*)(src + 0x1a);
+            *(int*)(dst + 0x18) = *(int*)(*(int**)(sl + 0xc) + idx);
+        } else {
+            unsigned short idx = *(unsigned short*)(src + 0x1a);
+            *(int*)(dst + 0x18) = *(int*)(*(int**)(sl + 0xc) + (idx + sb));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `func_020469e8` now matches byte-identical to the ROM under mwccarm 1.2/sp2p3.

## Context
This was part of a 15-function match session on `tangos/work`; 14 of the 15 had already landed on `main` via other merges (identical content confirmed by blob hash), so this PR carries just the one remaining function.

## Test plan
- [x] Verified byte-identical match locally during the matching session