### PR TITLE
Match 11 ov062 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Koopa8BehaviorEv.c
+++ b/src/_ZN5Koopa8BehaviorEv.c
@@ -1,0 +1,136 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void *self, void *wm, void *ma, unsigned int j);
+extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *self, void *c);
+extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *self, void *c);
+extern int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(void *self, void *c);
+extern void _ZN5Actor8PoofDustEv(void *self);
+extern void func_ov062_021179e4(void *c);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
+extern void func_ov062_02117570(void *self);
+extern void func_ov062_02118334(char *c);
+extern void _ZN12CylinderClsn5ClearEv(void *c);
+extern void _ZN12CylinderClsn6UpdateEv(void *c);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *c);
+extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void *self, int d);
+extern void func_ov062_02118258(void *self, int a);
+extern void _ZN9Animation7AdvanceEv(void *a);
+extern void func_ov062_02117acc(char *c);
+extern void func_ov062_02117a3c(char *c);
+extern void func_ov062_02117c98(char *c);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
+extern int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, void *wm, int a, s16 b, int c, int d, int e);
+extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, void *wm, unsigned int j);
+extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(void *self, void *wm);
+
+int _ZN5Koopa8BehaviorEv(char *self)
+{
+    int state;
+    int kind;
+
+    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(
+            self, self + 0x144, self + 0x300, 3) != 0)
+        return 1;
+
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(self, self + 0x110);
+
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(self, self + 0x144) != 0) {
+        int *pb0 = (int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+        *pb0 = *pb0 & ~0x10000000;
+        if (_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(self, self + 0x110) != 0) {
+            _ZN5Actor8PoofDustEv(self);
+            func_ov062_021179e4(self);
+            _ZN5Actor24KillAndTrackInDeathTableEv(self);
+        }
+        if (*(u8 *)(self + 0x107) != 0)
+            func_ov062_02117570(self);
+        func_ov062_02118334(self);
+        _ZN12CylinderClsn5ClearEv(self + 0x110);
+        if (*(u8 *)(self + 0x107) != 0 && *(u16 *)(self + 0x104) == 0)
+            _ZN12CylinderClsn6UpdateEv(self + 0x110);
+        if (*(int *)(self + 0x390) == 1)
+            *(int *)(self + 0x38c) = 4;
+        else
+            *(int *)(self + 0x38c) = 1;
+        if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x144) != 0) {
+            *(int *)(self + 0x3a8) = *(int *)(self + 0x5c);
+            *(int *)(self + 0x3ac) = *(int *)(self + 0x60);
+            *(int *)(self + 0x3b0) = *(int *)(self + 0x64);
+        }
+        return 1;
+    }
+
+    if (*(int *)(self + 0x10c) == 0) {
+        if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(self, 0x5dc000) != 0)
+            return 1;
+
+        {
+            int *pb0 = (int *)(self + 0xb0);
+            if (*(u8 *)(self + 0x3ce) != 0)
+                *(u8 *)(((long long)(int)(self + 0x3ce)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            *pb0 = *pb0 | 0x10000000;
+        }
+        func_ov062_02118258(self, 0x3e8000);
+
+        if (*(int *)(self + 0x38c) != 0)
+            _ZN9Animation7AdvanceEv(self + 0x350);
+
+        kind = *(int *)(self + 0x390);
+        state = *(int *)(self + 0x38c);
+        switch (kind) {
+        case 0:
+        case 2:
+            func_ov062_02117acc(self);
+            break;
+        case 1:
+            func_ov062_02117a3c(self);
+            break;
+        }
+
+        {
+            int ang = *(s16 *)(self + 0x94);
+            *(s16 *)(self + 0x8e) = (s16)ang;
+            {
+                u16 *p100 = (u16 *)(((long long)(int)(self + 0x100)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p100 = (u16)(*p100 + 1);
+            }
+        }
+        if (state != *(int *)(self + 0x38c) || kind != *(int *)(self + 0x390)) {
+            *(u16 *)(self + 0x100) = 0;
+            *(u16 *)(self + 0x3c4) = 0;
+        }
+        func_ov062_02117c98(self);
+        _ZN5Actor9UpdatePosEP12CylinderClsn(self, self + 0x110);
+
+        if (*(int *)(self + 0x10c) == 0 && *(int *)(self + 0x38c) != 0) {
+            if (_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(
+                    self, self + 0x144, 0x32000, 0x3800, 0, 1, 0x32000) != 0) {
+                *(int *)(self + 0x5c) = *(int *)(self + 0x3a8);
+                *(int *)(self + 0x60) = *(int *)(self + 0x3ac);
+                *(int *)(self + 0x64) = *(int *)(self + 0x3b0);
+            } else {
+                *(int *)(self + 0x3a8) = *(int *)(self + 0x5c);
+                *(int *)(self + 0x3ac) = *(int *)(self + 0x60);
+                *(int *)(self + 0x3b0) = *(int *)(self + 0x64);
+            }
+        }
+
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(self, self + 0x144, 0);
+        func_ov062_02117570(self);
+        _ZN12CylinderClsn5ClearEv(self + 0x110);
+        if (*(int *)(self + 0x10c) == 0) {
+            if (*(u16 *)(self + 0x3ca) == 0) {
+                _ZN12CylinderClsn6UpdateEv(self + 0x110);
+            } else {
+                *(u16 *)(((long long)(int)(self + 0x3ca)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            }
+        }
+    } else {
+        _ZN5Enemy11UpdateDeathER12WithMeshClsn(self, self + 0x144);
+    }
+
+    func_ov062_02118334(self);
+    return 1;
+}

--- a/src/_ZN6Klepto13InitResourcesEv.c
+++ b/src/_ZN6Klepto13InitResourcesEv.c
@@ -1,0 +1,119 @@
+typedef int Fix12;
+typedef struct { int h; } SharedFilePtr;
+typedef struct { int x, y, z; } Vector3;
+
+extern void *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr *f);
+extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
+extern int _ZN11ShadowModel12InitCylinderEv(void *self);
+extern void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr *f);
+extern void _ZN7PathPtrC1Ev(void *self);
+extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, void *v, unsigned int idx);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *a, Fix12 r, Fix12 h, unsigned int d, unsigned int e);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *a, Fix12 b, Fix12 c, void *d, void *e);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *rot, int e, int f);
+extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
+extern int _ZN8SaveData16HasPlayerLostCapEv(void);
+extern void func_ov062_0211c658(void *c, void *p);
+extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+
+extern SharedFilePtr data_ov062_0211e0fc;
+extern SharedFilePtr data_ov062_0211e114;
+extern SharedFilePtr data_ov062_0211e10c;
+extern SharedFilePtr data_ov062_0211e104;
+extern SharedFilePtr data_ov002_0210da40;
+extern SharedFilePtr data_ov002_0210d9a0;
+extern SharedFilePtr data_ov002_0210d9c0;
+extern char data_ov062_0211e15c;
+extern char data_ov062_0211e17c;
+extern void *data_0209f394;
+
+int _ZN6Klepto13InitResourcesEv(char *o)
+{
+    void *bmd;
+    void *spawned;
+    void *pl;
+    char path1[8];
+    char path2[8];
+    unsigned char hat;
+    int area;
+    int param;
+    int zero;
+    
+
+    bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov062_0211e0fc);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(o + 0x334, bmd, 1, -1);
+    _ZN11ShadowModel12InitCylinderEv(o + 0x3a4);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov062_0211e114);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov062_0211e10c);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov062_0211e104);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da40);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9a0);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9c0);
+
+    *(int *)(o + 0x464) = *(unsigned int *)(o + 8) & 0xff;
+    *(int *)(o + 0x468) = (*(unsigned int *)(o + 8) >> 8) & 0xf;
+    *(int *)(o + 0x46c) = (*(unsigned int *)(o + 8) >> 0xc) & 0xf;
+    if (*(int *)(o + 0x464) < 0)
+        *(int *)(o + 0x464) = 0;
+    if (*(int *)(o + 0x468) == 0xff)
+        *(int *)(o + 0x468) = 0;
+    if (*(int *)(o + 0x468) == 2) {
+        *(unsigned char *)(o + 0x448) = 2;
+        *(int *)(o + 0x468) = 1;
+    }
+
+    _ZN7PathPtrC1Ev(path1);
+    _ZN7PathPtr6FromIDEj(path1, *(unsigned int *)(o + 0x464));
+    *(int *)(o + 0x470) = 4;
+    *(int *)(o + 0xa0) = -0x1e000;
+    *(int *)(o + 0x484) = *(int *)(o + 0x5c);
+    *(int *)(o + 0x488) = *(int *)(o + 0x60);
+    *(int *)(o + 0x48c) = *(int *)(o + 0x64);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(o + 0x110, o, 0x64000, 0xa0000, 0x200002, 0x3eff0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(o + 0x144, o, 0x3c000, 0xa0000, 0x200000, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(o + 0x178, o, 0x1e000, 0x1e000, 0, 0);
+
+    _ZN7PathPtrC1Ev(path2);
+    _ZN7PathPtr6FromIDEj(path2, *(unsigned int *)(o + 0x464));
+    _ZNK7PathPtr7GetNodeER7Vector3j(path2, o + 0x430, *(unsigned int *)(o + 0x474));
+    *(int *)(o + 0x390) = 0x1000;
+    *(int *)(o + 0x44c) = 0;
+
+    if (*(int *)(o + 0x468) == 1) {
+        if (*(unsigned char *)(o + 0x448) != 2) {
+            spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0xb2, *(int *)(o + 0x46c) | 0x50, o + 0x5c, 0, *(signed char *)(o + 0xcc), -1);
+        } else {
+            spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0xb3, 0x50, o + 0x5c, 0, *(signed char *)(o + 0xcc), -1);
+        }
+        if (spawned != 0) {
+            *(int *)(o + 0x44c) = *(int *)((char *)spawned + 4);
+            _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(spawned, 0x64000, 0x258000, 0x1f40000, 0x1f40000);
+        }
+        *(int *)(o + 0x5c) = *(int *)(o + 0x430);
+        *(int *)(o + 0x60) = *(int *)(o + 0x434);
+        *(int *)(o + 0x64) = *(int *)(o + 0x438);
+        func_ov062_0211c658(o, &data_ov062_0211e15c);
+    } else {
+        pl = data_0209f394;
+        if (pl != 0 && *(int *)((char *)pl + 8) != 3 && _ZN8SaveData16HasPlayerLostCapEv() != 0) {
+            {
+                unsigned int hat = *(unsigned char *)((char *)pl + 0x6d9);
+                int area = *(signed char *)(o + 0xcc);
+                unsigned int param = 0;
+                param = param | (hat << 8);
+                spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                    0x10d, param, o + 0x5c, 0, area, -1);
+            }
+            if (spawned != 0) {
+                _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(spawned, 0x64000, 0x258000, 0x1f40000, 0x1f40000);
+                *(int *)(o + 0x44c) = *(int *)((char *)spawned + 4);
+            }
+        }
+        *(short *)(o + 0x44a) = Vec3_HorzAngle((Vector3 *)(o + 0x5c), (Vector3 *)(o + 0x484));
+        func_ov062_0211c658(o, &data_ov062_0211e17c);
+    }
+    return 1;
+}

--- a/src/func_ov062_02116010.c
+++ b/src/func_ov062_02116010.c
@@ -1,0 +1,68 @@
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef short s16;
+
+extern void *_ZN5Actor10FindWithIDEj(u32 id);
+extern void func_020ada40(void *c, void *v, void *a, int flag);
+extern void func_02012694(int a, void *p);
+extern int _ZN5Actor18HorzAngleToCPlayerEv(void *c);
+extern int AngleDiff(int a, int b);
+extern int _ZN6Player7TryGrabER5Actor(void *p, void *a);
+extern void func_ov062_02116cd8(void *c, void *p);
+extern int func_ov002_020db5f4(void *c, void *arg);
+extern int data_ov062_0211dea0[];
+extern int data_ov062_0211def0[];
+
+struct V3s { s16 x, y, z; };
+
+void func_ov062_02116010(char *c)
+{
+    u32 id;
+    void *a;
+    int b;
+    int angle;
+    struct V3s v;
+
+    id = *(u32 *)(c + 0x134);
+    if (id != 0 &&
+        (a = _ZN5Actor10FindWithIDEj(id)) != 0 &&
+        (*(int *)(c + 0x130) & 0x10) != 0) {
+        v.x = 0x1000;
+        v.y = 0;
+        v.z = 0;
+        func_020ada40(c, &v, a, 0);
+        func_02012694(0x125, c + 0x74);
+        return;
+    }
+
+    *(int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80;
+
+    id = *(u32 *)(c + 0x134);
+    if (id == 0)
+        return;
+    a = _ZN5Actor10FindWithIDEj(id);
+    if (a == 0)
+        return;
+    b = (int)(*(u16 *)((char *)a + 0xc) == 0xbf);
+    if (b == 0)
+        return;
+    angle = _ZN5Actor18HorzAngleToCPlayerEv(c);
+    angle = AngleDiff(angle, *(s16 *)(c + 0x8e));
+    if (angle > 0x2000) {
+        if ((*(int *)(c + 0x130) & 0x1000) == 0)
+            return;
+        *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFULL) |= 0x80;
+        if (_ZN6Player7TryGrabER5Actor(a, c) == 0)
+            return;
+        *(int *)(c + 0x3f8) = (int)a;
+        *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(int *)(c + 0x98) = 0;
+        func_ov062_02116cd8(c, data_ov062_0211dea0);
+        return;
+    }
+    if (func_ov002_020db5f4(a, c) == 0)
+        return;
+    *(int *)(c + 0x3f8) = (int)a;
+    *(int *)(c + 0x98) = 0;
+    func_ov062_02116cd8(c, data_ov062_0211def0);
+}

--- a/src/func_ov062_02118588.c
+++ b/src/func_ov062_02118588.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=43). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *a);
 extern void func_ov062_02118004(void *c, int a1);
@@ -13,53 +10,55 @@ void func_ov062_02118588(char *c)
 {
     void *found = 0;
     int match = 0;
-
-    if (*(int*)(c + 0x38c) == 2 && *(unsigned int*)(c + 0x134) != 0) {
-        found = _ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x134));
-        if (found != 0) {
-            if (*(unsigned short*)((char*)found + 0xc) == 0x11d)
-                match = 1;
+    if (*(int *)(c + 0x38c) == 2) {
+        if (*(unsigned int *)(c + 0x134) != 0) {
+            found = _ZN5Actor10FindWithIDEj(*(unsigned int *)(c + 0x134));
+            if (found != 0) {
+                int t = *(unsigned short *)((char *)found + 0xc);
+                t = (t == 0x11d);
+                if (t != 0)
+                    t = 1;
+                else
+                    t = match;
+                if (t != 0)
+                    match = 1;
+            }
         }
     }
-
-    if (match) {
-        int *hp = (int*)(c + 0x98);
-        *(int*)(c + 0x390) = 0;
-        *(int*)(c + 0x38c) = 4;
+    if (match != 0) {
+        int *hp = (int *)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(c + 0x390) = 0;
+        *(int *)(c + 0x38c) = 4;
         *hp = *hp / 2;
         _ZN9ActorBase18MarkForDestructionEv(found);
         return;
     }
-
-    if (*(int*)(c + 0x98) != 0) {
+    if (*(int *)(c + 0x98) != 0) {
         func_ov062_02118004(c, 0x800);
         return;
     }
 
     {
-        char *p = c + 0x300;
-        unsigned short *q = (unsigned short*)(c + 0x3c6);
-        if (*(unsigned short*)(p + 0xc6) != 0) {
-            (*q)--;
-            if (*(unsigned short*)(p + 0xc6) != 0)
+        if (*(unsigned short *)(c + 0x3c6) != 0) {
+            unsigned short *q = (unsigned short *)(((long long)(int)(c + 0x3c6)) & 0xFFFFFFFFFFFFFFFFLL);
+            char *p = c + 0x300;
+            *q = (unsigned short)(*q - 1);
+            if (*(unsigned short *)(p + 0xc6) != 0)
                 return;
             func_ov062_02117994(c, 8);
             return;
         }
     }
 
-    if (_ZNK9Animation12WillHitFrameEi(c + 0x350, 0x1e))
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x350, 0x1e) != 0)
         func_ov062_021175c0(c);
-
     if (_ZN9Animation8FinishedEv(c + 0x350) == 0)
         return;
-
-    if (*(int*)(c + 0x394) != 0) {
-        *(int*)(c + 0x38c) = 5;
+    if (*(int *)(c + 0x394) != 0) {
+        *(int *)(c + 0x38c) = 5;
         func_ov062_02117994(c, 0);
         return;
     }
-
-    *(int*)(c + 0x38c) = 1;
+    *(int *)(c + 0x38c) = 1;
     func_ov062_02117994(c, 3);
 }

--- a/src/func_ov062_02118a50.c
+++ b/src/func_ov062_02118a50.c
@@ -1,38 +1,42 @@
-// NONMATCHING: different op / idiom (div=18). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct S300 { char pad[0xc6]; unsigned short f; };
-extern int IsOnWall(void* thiz);
-extern void* GetWallResult(void* thiz);
-extern void CopyNormalTo(void* thiz, void* v);
-extern short ReflectAngle(void* thiz, int a, int b, short c);
-extern void func_ov062_02118004(void* c, int a1);
-extern void func_ov062_02117994(char* c, int idx);
-extern int WillHitFrame(void* thiz, int f);
-extern void func_ov062_021175c0(void* c);
-extern int Finished(void* thiz);
+typedef short s16;
+typedef unsigned short u16;
+struct Vector3 { int x, y, z; };
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *w);
+extern void *_ZNK12WithMeshClsn13GetWallResultEv(void *w);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *s, struct Vector3 *v);
+extern s16 _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *self, int a, int b, s16 ang);
+extern void func_ov062_02118004(void *c, int a1);
+extern void func_ov062_02117994(char *c, int idx);
+extern int _ZNK9Animation12WillHitFrameEi(void *anim, int f);
+extern void func_ov062_021175c0(void *c);
+extern int _ZN9Animation8FinishedEv(void *anim);
 
-void func_ov062_02118a50(char* c){
-  if (*(int*)(c+0x98) != 0) {
-    if (IsOnWall(c+0x144)) {
-      void* sr = GetWallResult(c+0x144);
-      CopyNormalTo((char*)sr+4, c+0xe0);
-      *(short*)(c+0x94) = ReflectAngle(c, *(int*)(c+0xe0), *(int*)(c+0xe8), *(short*)(c+0x94));
+void func_ov062_02118a50(char *c)
+{
+    if (*(int *)(c + 0x98) != 0) {
+        if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x144) != 0) {
+            void *sr = _ZNK12WithMeshClsn13GetWallResultEv(c + 0x144);
+            _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char *)sr + 4, (struct Vector3 *)(c + 0xe0));
+            *(s16 *)(c + 0x94) = _ZN5Actor12ReflectAngleE5Fix12IiES1_s(
+                c, *(int *)(c + 0xe0), *(int *)(c + 0xe8), *(s16 *)(c + 0x94));
+        }
+        func_ov062_02118004(c, 0x4cc);
+        return;
     }
-    func_ov062_02118004(c, 0x4cc);
-    return;
-  }
-  struct S300* o = (struct S300*)(c+0x300);
-  if (o->f != 0) {
-    unsigned short* t = (unsigned short*)(c+0x3c6); *t = *t - 1;
-    if (o->f != 0) return;
-    func_ov062_02117994(c, 8);
-    return;
-  }
-  if (WillHitFrame(c+0x350, 0x1e)) {
-    func_ov062_021175c0(c);
-  }
-  if (Finished(c+0x350) == 0) return;
-  *(int*)(c+0x38c) = 1;
-  func_ov062_02117994(c, 2);
+
+    {
+        if (*(u16 *)(c + 0x3c6) != 0) {
+            u16 *p = (u16 *)(((long long)(int)(c + 0x3c6)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p = (u16)(*p - 1);
+            if (*(u16 *)((c + 0x300) + 0xc6) != 0) return;
+            func_ov062_02117994(c, 8); return;
+        }
+    }
+
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x350, 0x1e) != 0)
+        func_ov062_021175c0(c);
+    if (_ZN9Animation8FinishedEv(c + 0x350) == 0)
+        return;
+    *(int *)(c + 0x38c) = 1;
+    func_ov062_02117994(c, 2);
 }

--- a/src/func_ov062_02119800.cpp
+++ b/src/func_ov062_02119800.cpp
@@ -1,0 +1,71 @@
+//cpp
+extern "C" void func_0201267c(unsigned int id, void *p);
+extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+extern short data_02082214[];
+
+extern "C" void func_ov062_02119800(char *c)
+{
+    volatile int stack[3];
+    char *self = c;
+    unsigned int kind = ((unsigned int)(*(int *)(self + 0x358) << 4)) >> 16;
+    short ang;
+    int x, y, z;
+
+    if (kind < 2)
+        goto check_hi;
+    if (kind <= 8)
+        goto body;
+check_hi:
+    if (kind < 0x13)
+        goto reset;
+    if (kind > 0x19)
+        goto reset;
+
+body:
+    if (*(unsigned char *)(self + 0x3b2) != 0)
+        return;
+    func_0201267c(0xe4, self + 0x74);
+    *(unsigned char *)(self + 0x3b2) = 1;
+
+    ang = *(short *)(self + 0x8e);
+    x = *(int *)(self + 0x5c);
+    /* Use kind right after x so cmp lands after both loads of ang and x */
+    stack[0] = (kind > 8) ? x : x;
+    y = *(int *)(self + 0x60);
+    ang = (short)(ang + 0x4000);
+    stack[1] = y;
+    z = *(int *)(self + 0x64);
+    stack[2] = z;
+    stack[1] = y + 0x1e000;
+
+    if (kind > 8)
+        goto add_path;
+
+    {
+        unsigned short u = (unsigned short)ang;
+        int n = (int)(u >> 4);
+        short cs = data_02082214[n * 2];
+        short sn = data_02082214[n * 2 + 1];
+        short k = 0x1e;
+        stack[0] = x - (int)(cs * k);
+        stack[2] = z - (int)(sn * k);
+    }
+    goto do_new;
+
+add_path:
+    {
+        unsigned short u = (unsigned short)ang;
+        int n = (int)(u >> 4);
+        short cs = data_02082214[n * 2];
+        short sn = data_02082214[n * 2 + 1];
+        short k = 0x1e;
+        stack[0] = (int)(cs * k) + x;
+        stack[2] = (int)(sn * k) + z;
+    }
+do_new:
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xf9, (int)stack[0], (int)stack[1], (int)stack[2]);
+    return;
+
+reset:
+    *(unsigned char *)(self + 0x3b2) = 0;
+}

--- a/src/func_ov062_0211a740.cpp
+++ b/src/func_ov062_0211a740.cpp
@@ -1,0 +1,93 @@
+//cpp
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef signed char s8;
+struct Vector3 { int x, y, z; };
+extern "C" {
+int _Z14ApproachLinearRsss(s16* v, s16 target, s16 step);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* file, int i, int fix, unsigned int a);
+void func_0201267c(int a, void* p);
+void func_02012790(int a);
+int _ZN6Player12GetTalkStateEv(void* self);
+int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const Vector3* v, unsigned int a, unsigned int b);
+int _ZN6Player18HasFinishedTalkingEv(void* self);
+void _ZN5Timer10ResetTimerEv(void* self);
+}
+extern int data_ov062_0211e03c[];
+extern int data_ov062_0211e034[];
+extern s8 data_0209f2f8;
+extern u8 data_0209d684;
+extern char data_0209d4c8[];
+extern "C" void func_ov062_0211a740(char* c)
+{
+    switch (*(u8*)(c + 0x390)) {
+    case 0:
+        if (_Z14ApproachLinearRsss((s16*)(c + 0x94), *(s16*)(c + 0x3a8), 0x800) != 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x300), (void*)data_ov062_0211e03c[1], 0, 0x1000, 0);
+            *(u8*)((((long long)(int)(c + 0x390)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+            func_0201267c(0xec, c + 0x74);
+            if (*(int*)(*(int*)(c + 0x398) + 8) == 0) {
+                func_02012790(0xa);
+                *(u8*)(c + 0x3b6) = 1;
+            }
+        }
+        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+        return;
+    case 1:
+        if (_ZN6Player12GetTalkStateEv(*(void**)(c + 0x398)) != 0)
+            return;
+        {
+            unsigned int msg;
+            Vector3 v;
+            if (*(u8*)(c + 0x3b6) == 0) {
+                msg = 0x9e;
+            } else if (data_0209f2f8 == 0x18) {
+                msg = 0xc4;
+            } else {
+                msg = 0x91;
+            }
+
+            {
+                int z = *(int*)(c + 0x64);
+                int y = *(int*)(c + 0x60) + 0xc8000;
+                int x = *(int*)(c + 0x5c);
+                v.x = x;
+                v.y = y;
+                v.z = z;
+            }
+            if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void**)(c + 0x398), c, msg, &v, 1, 0) != 0)
+                *(u8*)((((long long)(int)(c + 0x390)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+        }
+        return;
+    case 2:
+        if (_ZN6Player12GetTalkStateEv(*(void**)(c + 0x398)) != 2)
+            return;
+        if (*(u8*)(c + 0x3b6) != 0) {
+            if (data_0209d684 == 1) {
+                *(int*)(c + 0x38c) = 2;
+                *(u16*)(c + 0x100) = 0x32;
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x300), (void*)data_ov062_0211e034[1], 0, 0x1000, 0);
+                *(u16*)(c + 0x3aa) = 0;
+                *(u8*)(c + 0x3b6) = 0;
+            } else if (data_0209d684 == 2) {
+                *(int*)(c + 0x38c) = 0;
+                *(u16*)(c + 0x100) = 0x3c;
+                _ZN6Player18HasFinishedTalkingEv(*(void**)(c + 0x398));
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x300), (void*)data_ov062_0211e034[1], 0, 0x1000, 0);
+                *(u8*)(c + 0x3b6) = 0;
+            }
+        } else {
+            *(int*)(c + 0x38c) = 0;
+            *(u16*)(c + 0x100) = 0x3c;
+            _ZN6Player18HasFinishedTalkingEv(*(void**)(c + 0x398));
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x300), (void*)data_ov062_0211e034[1], 0, 0x1000, 0);
+        }
+        *(u8*)(c + 0x390) = 0;
+        *(int*)(c + 0x98) = 0;
+        _ZN5Timer10ResetTimerEv(data_0209d4c8);
+        return;
+    default:
+        return;
+    }
+}

--- a/src/func_ov062_0211a9c4.c
+++ b/src/func_ov062_0211a9c4.c
@@ -1,31 +1,54 @@
-// NONMATCHING: register allocation (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct Vec3 { int x, y, z; };
-extern void* ClosestPlayer(void);
-extern int Vec3_Dist(struct Vec3* a, struct Vec3* b);
-extern int StartTalk(void* thiz, void* ref, int b);
-extern void* FindWithActorID(unsigned id, void* p);
-extern short Vec3_HorzAngle(struct Vec3* a, struct Vec3* b);
+struct Vec3
+{
+    int x;
+    int y;
+    int z;
+};
 
-void func_ov062_0211a9c4(char* c){
-  unsigned short cnt = *(unsigned short*)(c+0x100);
-  if (cnt) { *(unsigned short*)(c+0x100) = cnt-1; return; }
-  *(void**)(c+0x398) = ClosestPlayer();
-  void* p = *(void**)(c+0x398);
-  if (p == 0) return;
-  struct Vec3* sp = (struct Vec3*)((char*)p + 0x5c);
-  struct Vec3 v;
-  v.x = sp->x;
-  v.y = sp->y;
-  v.z = sp->z;
-  if (Vec3_Dist((struct Vec3*)(c+0x5c), &v) >= 0xc8000) return;
-  if (StartTalk(*(void**)(c+0x398), c, 1) == 0) return;
-  char* a = (char*)FindWithActorID(0xcd, 0);
-  if (a == 0) return;
-  *(int*)(c+0x394) = *(int*)(a+4);
-  *(unsigned char*)(a+0x16e) = 0;
-  *(int*)(c+0x38c) = 1;
-  *(short*)(c+0x3a8) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), &v);
-  *(unsigned char*)(c+0x390) = 0;
+extern void *_ZN5Actor13ClosestPlayerEv(void *self);
+extern int Vec3_Dist(struct Vec3 *a, struct Vec3 *b);
+extern int StartTalk(void *thiz, void *ref, int b);
+extern void *FindWithActorID(unsigned id, void *p);
+extern short Vec3_HorzAngle(struct Vec3 *a, struct Vec3 *b);
+
+void func_ov062_0211a9c4(char *c)
+{
+    unsigned short val;
+    struct Vec3 v;
+    char *a;
+    struct Vec3 *sp;
+
+    val = *(unsigned short *)(c + 0x100);
+    if (val != 0) {
+        *(unsigned short *)(c + 0x100) = val - 1;
+        return;
+    }
+
+    *(void **)(c + 0x398) = _ZN5Actor13ClosestPlayerEv(c);
+    if (*(void **)(c + 0x398) == 0)
+        return;
+
+    sp = (struct Vec3 *)(((int)*(void **)(c + 0x398) + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+    v.x = sp->x;
+    v.y = sp->y;
+    v.z = sp->z;
+
+    if (Vec3_Dist((struct Vec3 *)(c + 0x5c), &v) >= 0xc8000)
+        return;
+
+    if (StartTalk(*(void **)(c + 0x398), c, 1) == 0)
+        return;
+
+    a = (char *)FindWithActorID(0xcd, 0);
+    if (a == 0)
+        return;
+
+    *(int *)(c + 0x394) = *(int *)(a + 4);
+    *(unsigned char *)(a + 0x16e) = 0;
+    *(int *)(c + 0x38c) = 1;
+    {
+        char *base = c + 0x300;
+        *(short *)(base + 0xa8) = Vec3_HorzAngle((struct Vec3 *)(c + 0x5c), &v);
+    }
+    *(unsigned char *)(c + 0x390) = 0;
 }

--- a/src/func_ov062_0211b3ac.cpp
+++ b/src/func_ov062_0211b3ac.cpp
@@ -1,0 +1,66 @@
+//cpp
+typedef unsigned int u32;
+struct Vector3 { int x, y, z; };
+struct PathPtr { int a, b; };
+extern "C" void* _ZN5Actor13ClosestPlayerEv(void* self);
+extern "C" void _ZN7PathPtrC1Ev(PathPtr* self);
+extern "C" void _ZN7PathPtr6FromIDEj(PathPtr* self, u32 id);
+extern "C" void _ZNK7PathPtr7GetNodeER7Vector3j(PathPtr* self, Vector3* v, u32 i);
+extern "C" int Vec3_HorzDist(const Vector3* a, const Vector3* b);
+extern signed char data_0209f2f8;
+extern "C" int func_ov062_0211b3ac(char* sl)
+{
+    char* player;
+    PathPtr path;
+    Vector3 node;
+    Vector3 best;
+    Vector3 ppos;
+    int i;
+    int bestIdx;
+    int bestDist;
+
+    {
+        int *ctr = (int *)(((long long)(int)(sl + 0x460)) & 0xFFFFFFFFFFFFFFFFLL);
+        *ctr = *ctr + 1;
+        *ctr = *ctr & 7;
+    }
+    if (*(int *)(sl + 0x460) != 0)
+        return 0;
+
+    player = (char*)_ZN5Actor13ClosestPlayerEv(sl);
+    _ZN7PathPtrC1Ev(&path);
+    _ZN7PathPtr6FromIDEj(&path, *(u32*)(sl + 0x464));
+
+    bestIdx = 0;
+    node.x = bestIdx; node.y = bestIdx; node.z = bestIdx;
+    best.x = bestIdx; best.y = bestIdx; best.z = bestIdx;
+
+    if (player != 0) {
+        int *pp = (int *)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        ppos.x = *pp;
+        i = bestIdx;
+        ppos.y = pp[1];
+        bestDist = 0x10000000;
+        ppos.z = pp[2];
+        while (i < 4) {
+            _ZNK7PathPtr7GetNodeER7Vector3j(&path, &node, (u32)i);
+            if (bestDist > Vec3_HorzDist(&node, &ppos)) {
+                bestIdx = i;
+                bestDist = Vec3_HorzDist(&node, &ppos);
+                best = node;
+            }
+            i = i + 1;
+        }
+    }
+
+    if (Vec3_HorzDist(&best, (Vector3*)(sl + 0x430)) == 0)
+        return 0;
+
+    if (data_0209f2f8 == 0x10) {
+        *(unsigned char*)(sl + 0x446) = 0;
+        if (*(int*)(sl + 0x474) == (bestIdx ^ 2))
+            *(unsigned char*)(sl + 0x446) = 1;
+    }
+    *(int*)(sl + 0x474) = bestIdx;
+    return 1;
+}

--- a/src/func_ov062_0211b51c.c
+++ b/src/func_ov062_0211b51c.c
@@ -1,0 +1,121 @@
+typedef struct { int x, y, z; } Vector3;
+typedef unsigned short u16;
+typedef unsigned char u8;
+enum Bool { FALSE, TRUE };
+
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern int func_ov062_0211c658(void *c, void *p);
+extern int _ZN5Actor24BumpedUnderneathByPlayerER6Player(void *c, void *pl);
+extern int _ZN6Player9IsOnShellEv(void *pl);
+extern int _ZN6Player15IsCollectingCapEv(void *pl);
+extern void _ZN6Player18SetNewHatCharacterEjjb(void *pl, unsigned int a, unsigned int b, int c);
+extern int _ZN8SaveData16HasPlayerLostCapEv(void);
+extern void _ZN8SaveData13PlayerLoseCapEv(void);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *rot, int e, int f);
+extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *a, int b, int c, int d, int e);
+extern int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *pl, Vector3 *v, unsigned int a, int b, unsigned int c, unsigned int d, unsigned int e);
+extern char data_ov062_0211e14c[];
+extern char data_ov062_0211e17c[];
+extern char data_ov062_0211e18c[];
+
+int func_ov062_0211b51c(char *c)
+{
+    void *pl;
+    void *sp;
+    Vector3 pos;
+    unsigned int flag;
+    int fl;
+    int id;
+    enum Bool isPlayer;
+    void *state;
+    int r;
+    u8 hc;
+    u8 st;
+    int newchar;
+    int zero;
+
+    id = *(int *)(c + 0x134);
+    if (id != 0) {
+        pl = _ZN5Actor10FindWithIDEj((unsigned int)id);
+        if (pl == 0)
+            return (int)pl;
+        fl = *(int *)(c + 0x130);
+        if ((fl & 0x4000) != 0)
+            return func_ov062_0211c658(c, data_ov062_0211e14c);
+        if ((fl & 0x27f0) != 0)
+            return func_ov062_0211c658(c, data_ov062_0211e14c);
+        isPlayer = (enum Bool)(*(u16 *)((char *)pl + 0xc) == 0xbf);
+        if (isPlayer) {
+            if (_ZN5Actor24BumpedUnderneathByPlayerER6Player(c, pl) == 1 ||
+                *(u8 *)((char *)pl + 0x6f9) == 1 ||
+                _ZN6Player9IsOnShellEv(pl) == 1)
+                return func_ov062_0211c658(c, data_ov062_0211e14c);
+        }
+    }
+
+    id = *(int *)(c + 0x168);
+    if (id == 0)
+        return id;
+    pl = _ZN5Actor10FindWithIDEj((unsigned int)id);
+    if (pl == 0)
+        return (int)pl;
+    isPlayer = (enum Bool)(*(u16 *)((char *)pl + 0xc) == 0xbf);
+    if (!isPlayer)
+        return (int)isPlayer;
+    state = data_ov062_0211e18c;
+    if (*(void **)(c + 0x42c) != state)
+        return (int)state;
+    r = _ZN6Player15IsCollectingCapEv(pl);
+    if (r != 0)
+        return r;
+    r = *(int *)(c + 0x44c);
+    if (r != 0)
+        return r;
+
+    st = *(u8 *)(c + 0x448);
+    hc = *(u8 *)((char *)pl + 0x6d9);
+    if (st != 2 &&
+        *(u8 *)((char *)pl + 0x6ff) == 0 &&
+        *(u8 *)((char *)pl + 0x6fd) == 0 &&
+        *(u8 *)((char *)pl + 0x6fb) == 0 &&
+        *(u8 *)((char *)pl + 0x6f9) == 0 &&
+        *(int *)((char *)pl + 8) != 3) {
+        newchar = *(int *)((char *)pl + 8);
+        if (hc != newchar) {
+            _ZN6Player18SetNewHatCharacterEjjb(pl, hc, 0, 0);
+        } else {
+            r = _ZN8SaveData16HasPlayerLostCapEv();
+            if (r != 0)
+                return r;
+            _ZN8SaveData13PlayerLoseCapEv();
+        }
+        {
+            int area = *(signed char *)(c + 0xcc);
+            unsigned int ch = *(unsigned int *)((char *)pl + 8);
+            unsigned int param = 0;
+            param = param | (ch << 8);
+            sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                0x10d, param, c + 0x5c, 0, area, -1);
+        }
+        if (sp != 0) {
+            _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(
+                sp, 0x64000, 0x258000, 0x1f40000, 0x1f40000);
+            *(int *)(c + 0x44c) = *(int *)((char *)sp + 4);
+            func_ov062_0211c658(c, data_ov062_0211e17c);
+        }
+    }
+
+    *(u8 *)(c + 0x447) = 1;
+    flag = 0;
+    if (*(u8 *)(c + 0x448) == 2 || *(int *)((char *)pl + 8) == 3)
+        flag = 1;
+
+    pos.x = *(int *)(c + 0x5c);
+    pos.y = *(int *)(c + 0x60);
+    pos.z = *(int *)(c + 0x64);
+    r = _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(pl, &pos, flag, 0xc000, 1, 0, 1);
+    if (r == 0)
+        return r;
+    *(u16 *)(c + 0x444) = 0x1e;
+    return func_ov062_0211c658(c, data_ov062_0211e17c);
+}

--- a/src/func_ov062_0211ba84.c
+++ b/src/func_ov062_0211ba84.c
@@ -1,0 +1,73 @@
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef short s16;
+typedef struct { int x, y, z; } Vector3;
+extern char *_ZN5Actor13ClosestPlayerEv(char *self);
+extern int func_ov062_0211c658(char *c, void *p);
+extern s16 Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
+extern s16 Vec3_VertAngle(const Vector3 *v0, const Vector3 *v1);
+extern void _Z14ApproachLinearRsss(s16 *cur, s16 tgt, s16 step);
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, s16 angX);
+extern void MulVec3Mat4x3(const Vector3 *v, void *m, Vector3 *out);
+extern void func_ov062_0211b51c(char *c);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(char *self);
+extern void *data_ov062_0211e17c;
+extern signed char data_0209f2f8;
+extern int data_020a0e68[];
+
+int func_ov062_0211ba84(char *c)
+{
+    Vector3 v;
+    Vector3 t;
+    Vector3 hv;
+    Vector3 vv;
+    s16 r4;
+    char *ip;
+    int tx, ty, tz;
+
+    r4 = 0;
+    v.x = 0;
+    v.y = 0;
+    v.z = 0;
+    ip = _ZN5Actor13ClosestPlayerEv(c);
+    if (ip != 0) {
+        if (*(u8 *)(ip + 0x6fb) == 1) {
+            *(s16 *)(c + 0x444) = 0x1e;
+            func_ov062_0211c658(c, &data_ov062_0211e17c);
+            return 1;
+        }
+
+        t = *(Vector3 *)(ip + 0x5c);
+        tx = t.x;
+        {
+            int y = *(int *)(ip + 0x644);
+            t.y = y;
+            t.y = y + 0x28000;
+        }
+        tz = t.z;
+        ty = t.y;
+        hv.x = tx; hv.y = ty; hv.z = tz;
+        *(s16 *)(c + 0x44a) = Vec3_HorzAngle((Vector3 *)(c + 0x5c), &hv);
+        vv.x = tx; vv.y = ty; vv.z = tz;
+        r4 = Vec3_VertAngle((Vector3 *)(c + 0x5c), &vv);
+
+    }
+    if (data_0209f2f8 == 0x10) {
+        _Z14ApproachLinearRsss((s16 *)(c + 0x94), *(s16 *)(c + 0x44a), (s16)*(int *)(c + 0x43c));
+        _Z14ApproachLinearRsss((s16 *)(c + 0x92), r4, (s16)*(int *)(c + 0x43c));
+    } else {
+        _Z14ApproachLinearRsss((s16 *)(c + 0x94), *(s16 *)(c + 0x44a), (s16)(*(int *)(c + 0x43c) + 0x500));
+        _Z14ApproachLinearRsss((s16 *)(c + 0x92), r4, (s16)(*(int *)(c + 0x43c) + 0x500));
+    }
+    v.z = 0x1e000;
+    Matrix4x3_FromRotationY(data_020a0e68, *(s16 *)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(s16 *)(c + 0x8c));
+    MulVec3Mat4x3(&v, data_020a0e68, (Vector3 *)(c + 0xa4));
+    func_ov062_0211b51c(c);
+    if (*(u16 *)(c + 0x100) == 0 || _ZNK12WithMeshClsn8IsOnWallEv(c + 0x178) != 0) {
+        *(s16 *)(c + 0x444) = 0x1e;
+        func_ov062_0211c658(c, &data_ov062_0211e17c);
+    }
+    return 1;
+}


### PR DESCRIPTION
Partial ov062 batch: **11** functions verified byte-identical with `mwccarm 1.2/sp2p3` (`-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).

### Matched
| Symbol | Addr | Size |
|---|---|---|
| `func_ov062_02116010` | `0x02116010` | `0x198` |
| `func_ov062_02118588` | `0x02118588` | `0x190` |
| `func_ov062_02118a50` | `0x02118a50` | `0xfc` |
| `_ZN5Koopa8BehaviorEv` | `0x021190ec` | `0x334` |
| `func_ov062_02119800` | `0x02119800` | `0x154` |
| `func_ov062_0211a740` | `0x0211a740` | `0x284` |
| `func_ov062_0211a9c4` | `0x0211a9c4` | `0xfc` |
| `func_ov062_0211b3ac` | `0x0211b3ac` | `0x170` |
| `func_ov062_0211b51c` | `0x0211b51c` | `0x2e4` |
| `func_ov062_0211ba84` | `0x0211ba84` | `0x1d0` |
| `_ZN6Klepto13InitResourcesEv` | `0x0211cb4c` | `0x32c` |

Replaces three prior NONMATCHING drafts on main (`02118588`, `02118a50`, `0211a9c4`) with matching C.

### Not in this PR (still near-miss)
- `func_ov062_02119af0` (div=5 sub emission order)
- `func_ov062_02116a08` (div=4 prologue schedule wall)
- `func_ov062_02117724` (div≈16 table/mul schedule)
- `func_ov062_02117c98` (size short)
- `func_ov062_0211bd10` (size short)

Local check: each file `tools/match.py --module ov062 --version 1.2/sp2p3` → `MATCHING VERSIONS: 1.2/sp2p3`.

model: Grok 4.5
harness: Grok Build