### PR TITLE
docs(ov092): func_ov092_02131010 near-miss div=2 (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov092 func_ov092_02131010 (0x02131010, 0x1a0) | lunavyqo (AI-assisted) | 2026-07-12 | **near-miss div=2** — LandingDustAt mov r2,#1 vs str ip,[sp,#8] scheduler swap; API claim clm_eac7d2bda660; handoff in src header |
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |
 | ov029 8 funcs (0x02111254-0x02112354) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #221 open |
 | ov032: __sinit_ov032_02112c10 (0x02112c10), 02111254 (0x02111254), 02111620 (0x02111620), 02111830 (0x02111830), 02111e24 (0x02111e24) | lunavyqo | 2026-07-10 | done - verified byte-identical, PR #222 open |

--- a/src/func_ov092_02131010.cpp
+++ b/src/func_ov092_02131010.cpp
@@ -1,11 +1,15 @@
 //cpp
-// NONMATCHING: div 2/104 (was 63). Sole residual is one scheduler slot: the ROM
+// NONMATCHING: div=2 (2/104 words). Sole residual is one scheduler slot: the ROM
 // emits "sub r3; mov r2,#1; str ip,[sp,#8]" where every C spelling emits
 // "sub r3; str ip,[sp,#8]; mov r2,#1" (LandingDustAt's bool arg vs the volatile
-// tmp.z store, adjacent independent insns). Tried: named/inlined arg, y-reassign,
-// comma-arg hoist, b?z:z fake dep, bool proto, C++ copy-temp, cast-away volatile,
-// statement permutations, pragmas, and a 25-min PERM_RANDOMIZE-focused permuter
-// run (no improvement). Everything else byte-exact incl. frame 0x28 and coloring.
+// tmp.z store, adjacent independent insns).
+// Tried (still div=2): named/inlined bool, y-reassign/y-overwrite-as-bool, comma-arg
+// hoist, b?z:z / z+(b-b) / z|(b&0) fake deps, bool proto, C++ copy-temp / ctor,
+// cast-away volatile, partial-volatile fields, equal-arm ternary on dust/bool args
+// (6o), address-escape of b, #pragma opt_propagation off, statement/decl order
+// perms, 25-min+ permuter (score stuck at 60 = one reorder). Everything else
+// byte-exact incl. frame 0x28, pool (0x504, 0x5dc000), and coloring.
+// Compiler: mwccarm 1.2/sp2p3. Addr: 0x02131010 size 0x1a0 (ov092).
 struct Vector3 { int x, y, z; };
 typedef short s16;
 #define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)


### PR DESCRIPTION
## Summary

- Re-verified `func_ov092_02131010` (`ov092`, `0x02131010`, size `0x1a0`) under **mwccarm 1.2/sp2p3**.
- Best result remains **NONMATCHING div=2** (down from the original 63-div draft shape already improved on main).
- Sole residual is a one-slot scheduler reorder at the `LandingDustAt` arg setup:

  - ROM: `sub r3,r2,#0x78000; mov r2,#1; str ip,[sp,#8]`
  - Cand: `sub r3,r2,#0x78000; str ip,[sp,#8]; mov r2,#1`

- Everything else is byte-identical (frame `0x28`, pool `0x504` / `0x5dc000`, coloring, early exits, Earthquake/sound path).
- Expanded the `// NONMATCHING` header with additional levers tried this session (equal-arm ternary, partial volatile, y-as-bool reuse, address-escape, opt_propagation, permuter score stuck at 60).
- Claims API lock: `clm_eac7d2bda660` (handle `lunavyqo`); CLAIMS.md row added.

## Verify

```bash
python tools/match.py --c src/func_ov092_02131010.cpp --func func_ov092_02131010 \
  --addr 0x2131010 --size 0x1a0 --version 1.2/sp2p3 --module ov092
```

## Note

Not a full match. Opened as a refine-tier handoff for the remaining independent `mov`/`str` swap.

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build