### PR TITLE
Match 12 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_Z19LoadEntranceObjectsRN11LVL_Overlay11ObjSubTableEij.c
+++ b/src/_Z19LoadEntranceObjectsRN11LVL_Overlay11ObjSubTableEij.c
@@ -1,0 +1,108 @@
+enum Bool { false = 0, true = 1 };
+typedef int Fix12i;
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef int s32;
+typedef unsigned int u32;
+
+typedef struct { Fix12i x, y, z; } Vector3;
+typedef struct { s16 x, y, z; } Vector3_16;
+
+struct Entry {
+    u16 raw;        /* 0 */
+    s16 x;          /* 2 */
+    s16 y;          /* 4 */
+    s16 z;          /* 6 */
+    Vector3_16 rot; /* 8 */
+    u16 param;      /* 0xe */
+};
+
+struct ObjSubTable {
+    u8 pad0;
+    u8 count;
+    u8 pad2[2];
+    struct Entry* entries;
+};
+
+extern u8 data_0209f21c;
+extern u8 data_0209caa0[];
+extern u8 data_0209f2d8;
+extern u8 data_02092128[];
+extern u16 data_ov002_0210cbf4[];
+extern u8 data_0209fc5c[];
+extern void* data_0209f394[];
+extern u8 data_0209f250;
+extern void* data_0209f5c0;
+extern void* data_0209f318;
+extern signed char data_ov002_0210cb5c[];
+
+void func_0202b0e0(struct Entry* e, int count);
+void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 flags, const Vector3* pos, const Vector3_16* rot, s32 area, s32 death);
+void* _ZN12ActorDerived5SpawnEjP9ActorBaseii(u32 id, void* base, int a, int b);
+void StartEntranceFaderWipe(void);
+
+void _Z19LoadEntranceObjectsRN11LVL_Overlay11ObjSubTableEij(struct ObjSubTable* tbl, int p2, u32 p3)
+{
+    u32 sl;
+    struct Entry* e = tbl->entries;
+    func_0202b0e0(e, tbl->count);
+    e += p3;
+    sl = 0;
+
+    int entranceId = 0xf;
+    u8 i = 0;
+
+    while (i < data_0209f21c) {
+        {
+            Vector3 pos;
+            int vz = e->z << 12;
+            int vy = e->y << 12;
+            int vx = e->x << 12;
+            pos.x = vx;
+            pos.y = vy;
+            pos.z = vz;
+
+            u16 param = e->param;
+            sl = (param >> 7) & 0xf;
+
+            int f2 = data_0209caa0[0x41];
+            int f1 = data_02092128[i];
+            enum Bool cond = (enum Bool)(data_0209f2d8 == 1);
+            if (cond != false) {
+                f2 = 3;
+                f1 = 3;
+            }
+            u32 flags = f2 | (f1 << 3) | (i << 6) | (sl << 8);
+
+            void* a = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                data_ov002_0210cbf4[e->raw], flags, &pos, &e->rot,
+                (signed char)(param & 7), -1);
+
+            if (data_0209fc5c[i] == 0)
+                data_0209f394[i] = 0;
+            else
+                data_0209f394[i] = a;
+
+            if (i == data_0209f250)
+                entranceId = (e->param >> 3) & 0xf;
+
+            e++;
+            i++;
+        }
+    }
+
+    data_0209f318 = _ZN12ActorDerived5SpawnEjP9ActorBaseii(0x14c, data_0209f5c0, entranceId, 0);
+
+    int t = data_0209f2d8;
+    t = t == 2;
+    if (t != false)
+        return;
+
+    if (sl >= 0x13)
+        sl = 0;
+    if (data_ov002_0210cb5c[sl] < 0)
+        return;
+
+    StartEntranceFaderWipe();
+}

--- a/src/func_ov002_020cd71c.c
+++ b/src/func_ov002_020cd71c.c
@@ -1,0 +1,51 @@
+typedef short s16;
+
+extern int data_ov002_020ff1f0[];
+extern unsigned char data_020a0e40[];
+extern short data_0209f4a2[];
+extern void _Z15ApproachLinear2Rsss(short *v, short t, short s);
+
+void func_ov002_020cd71c(char *self)
+{
+    int ip = data_ov002_020ff1f0[*(int *)(self + 8)];
+    int a = (int)(((long long)ip * 0x320 + 0x800) >> 12);
+    int c = (int)((((long long)ip << 7) + 0x800) >> 12);
+    s16 step = (s16)((((long long)ip << 5) + 0x800) >> 12);
+    int b = (int)(((long long)ip * 0x240 + 0x800) >> 12);
+    int e = *(short *)((char *)data_0209f4a2 + data_020a0e40[0] * 0x18);
+    s16 target = (s16)(((long long)(-b) * e + 0x800) >> 12);
+
+    if (*(int *)(self + 0x640) == 0) {
+        step = (s16)((((long long)ip << 6) + 0x800) >> 12);
+        target = (s16)(((long long)(-a) * e + 0x800) >> 12);
+    }
+
+    if (target > 0) {
+        if (*(s16 *)(self + 0x69c) < 0) {
+            s16 *q = (s16 *)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFLL);
+            *q = *q + 0x40;
+            if (*(s16 *)(self + 0x69c) > c)
+                *(s16 *)(self + 0x69c) = c;
+        } else {
+            _Z15ApproachLinear2Rsss((short *)(self + 0x69c), target, step);
+        }
+    } else if (target < 0) {
+        if (*(s16 *)(self + 0x69c) > 0) {
+            s16 *q = (s16 *)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFLL);
+            *q = *q - 0x40;
+            if (*(s16 *)(self + 0x69c) < -c)
+                *(s16 *)(self + 0x69c) = -c;
+        } else {
+            _Z15ApproachLinear2Rsss((short *)(self + 0x69c), target, step);
+        }
+    } else {
+        _Z15ApproachLinear2Rsss((short *)(self + 0x69c), 0, 0x40);
+    }
+
+    {
+        s16 *q = (s16 *)(((int)self + 0x8e) & 0xFFFFFFFFFFFFFFFFLL);
+        *q = *q + *(s16 *)(self + 0x69c);
+    }
+    *(s16 *)(self + 0x90) = -(*(s16 *)(self + 0x69c) << 3);
+    *(s16 *)(self + 0x94) = *(s16 *)(self + 0x8e);
+}

--- a/src/func_ov002_020d9dcc.c
+++ b/src/func_ov002_020d9dcc.c
@@ -1,0 +1,75 @@
+typedef int s32;
+typedef short s16;
+typedef long long s64;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef signed char s8;
+
+extern int AngleDiff(int a, int b);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+
+extern u8 data_020a0e40;
+extern s16 data_0209f4a0[];
+extern int data_ov002_02110604[];
+
+int func_ov002_020d9dcc(char* c)
+{
+    char* p;
+
+    if (*(int*)(c + 8) != 2)
+        return 0;
+
+    p = *(char**)(c + 0x358);
+    if (p == 0 || (int)(((long long)(*(u16*)(p + 0xc) == 0xbf)) & 0xFFFFFFFFFFFFFFFFLL) == 0)
+        return 0;
+
+    if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) == 0 || *(u8*)(c + 0x6de) != 0) {
+        *(u16*)(c + 0x6a4) = 0;
+        return 0;
+    }
+
+    if (*(u16*)(c + 0x6a4) == 0) {
+        *(u16*)(c + 0x6a4) = 0x3c;
+        *(s16*)(c + 0x69c) = *(s16*)(c + 0x8e);
+        *(u8*)(c + 0x6e5) = 0;
+        return 0;
+    }
+
+    if (*(u8*)(c + 0x6e5) == 0) {
+        if (*(s16*)(c + 0x8e) < *(s16*)(c + 0x69c))
+            *(u8*)(c + 0x6e5) = 0xff;
+        else
+            *(u8*)(c + 0x6e5) = 1;
+    }
+
+    s16 diff = *(s16*)(c + 0x8e) - *(s16*)(c + 0x6d6);
+    if (*(s8*)(c + 0x6e5) >= 0) {
+        if (diff < 0) {
+            *(u16*)(c + 0x6a4) = 0;
+            return 0;
+        }
+        if (AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x69c)) >= 0x4000) {
+            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFF) += 0x4000;
+        }
+    } else {
+        if (diff > 0) {
+            *(u16*)(c + 0x6a4) = 0;
+            return 0;
+        }
+        if (AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x69c)) >= 0x4000) {
+            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) -= 1;
+            *(s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFF) -= 0x4000;
+        }
+    }
+
+    s8 v = *(s8*)(c + 0x6e5);
+    if (v < 0)
+        v = -v;
+    if (v < 5)
+        return 0;
+
+    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110604);
+    return 1;
+}

--- a/src/func_ov002_020e28d4.c
+++ b/src/func_ov002_020e28d4.c
@@ -1,0 +1,73 @@
+typedef int s32;
+typedef short s16;
+typedef long long s64;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef s32 Fix12;
+
+extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
+extern int AngleDiff(int a, int b);
+extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);
+extern void _Z14ApproachLinearRiii(int* a, int b, int c);
+extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
+extern int func_ov002_020bf30c(void* c, int a);
+extern int func_ov002_020bf224(void* c, int a, int b);
+
+extern u8 data_020a0e40;
+extern s16 data_0209f4a0[];
+extern s16 data_02082214[];
+extern int data_ov002_0211055c[];
+
+void func_ov002_020e28d4(char* c, int a, int b)
+{
+    int r4;
+
+    if (*(int*)(c + 8) == 1)
+        a <<= 1;
+
+    if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
+        if (*(u8*)(c + 0x6e9) & 2) {
+            int t = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x560), *(int*)(c + 0x568));
+            if (AngleDiff((s16)(t + 0x8000), *(s16*)(c + 0x94)) < 0x2000) {
+                if (*(int*)(c + 0x98) >= 0x3000)
+                    *(int*)(c + 0x98) = 0x3000;
+            }
+        }
+        if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211055c)) {
+            r4 = func_ov002_020bf30c(c, 0x3c000);
+            s16 e = AngleDiff(*(s16*)(c + 0x6d2), *(s16*)(c + 0x8e));
+            e = e + 0x4000;
+            s16 tv = data_02082214[((u16)e >> 4) * 2];
+            r4 = (int)(((s64)r4 * tv + 0x800) >> 12);
+            if (r4 < 0)
+                r4 = -r4;
+            if (r4 < 0xa000)
+                r4 = 0xa000;
+        } else {
+            r4 = func_ov002_020bf224(c, func_ov002_020bf30c(c, 0x21000), func_ov002_020bf30c(c, 0xa000));
+        }
+
+        s16 r7 = *(s16*)(c + 0x6d2);
+        if (*(int*)(c + 0x98) != 0) {
+            if (AngleDiff(*(s16*)(c + 0x94), r7) > 0x6000) {
+                r7 = r7 + 0x8000;
+                r4 = -r4;
+            }
+            ApproachAngle((s16*)(c + 0x94), r7, 0x10, 0x100, 0);
+        } else {
+            *(s16*)(c + 0x94) = r7;
+        }
+    } else {
+        r4 = 0;
+        a = b;
+    }
+
+    _Z14ApproachLinearRiii((int*)(c + 0x98), r4, a);
+
+    if (AngleDiff(*(s16*)(c + 0x94), *(s16*)(c + 0x8e)) < 0x4000)
+        return;
+
+    if (*(int*)(c + 0x98) >= 0x10000)
+        *(int*)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x2000;
+}

--- a/src/func_ov006_020c47d4.c
+++ b/src/func_ov006_020c47d4.c
@@ -1,0 +1,96 @@
+typedef int Fix12;
+typedef struct Vec3 { Fix12 x, y, z; } Vec3;
+
+typedef struct Obj Obj;
+typedef struct ObjVt {
+    Vec3 *(*f0)(Obj *);
+    Vec3 *(*f1)(Obj *);
+    int   (*f2)(Obj *);
+} ObjVt;
+struct Obj {
+    ObjVt *vt;      /* 0x0 */
+    Vec3 vec;       /* 0x4 */
+    short flag;     /* 0x10 */
+};
+
+typedef struct Self {
+    char _pad0[0x9c];
+    Vec3 pos;       /* 0x9c */
+    Vec3 vel;       /* 0xa8 */
+    char _padb4[0xd8 - 0xb4];
+    int speed;      /* 0xd8 */
+} Self;
+
+extern Obj *data_ov006_021403f4[3];
+extern void Vec3_Sub(Vec3 *out, Vec3 *a, Vec3 *b);
+extern void Vec3_Add(Vec3 *out, Vec3 *a, Vec3 *b);
+extern Fix12 DotVec3(const Vec3 *a, const Vec3 *b);
+extern int LenVec3(Vec3 *v);
+extern int NormalizeVec3IfNonZero(Vec3 *v);
+extern void func_ov006_020c4f68(Self *self);
+
+void func_ov006_020c47d4(Self *self)
+{
+    int i;
+    int thresh = (int)(((long long)self->speed * 0x12000 + 0x800) >> 12);
+
+    for (i = 0; i < 3; i++) {
+        Vec3 disp, rel, up, sum;
+        Vec3 *p, *q;
+        Obj *o;
+
+        if (data_ov006_021403f4[i]->vt->f2(data_ov006_021403f4[i]) == 0)
+            continue;
+
+        p = data_ov006_021403f4[i]->vt->f0(data_ov006_021403f4[i]);
+        Vec3_Sub(&disp, p, &self->pos);
+
+        disp.y -= thresh >> 1;
+        if (disp.y < 0) {
+            if (disp.y > -0x18000)
+                disp.y = 0;
+            else
+                disp.y += 0x18000;
+        } else {
+            if (disp.x > 0x2000)
+                disp.x -= 0x2000;
+            else if (disp.x < -0x2000)
+                disp.x += 0x2000;
+            else
+                disp.x = 0;
+        }
+
+        q = data_ov006_021403f4[i]->vt->f1(data_ov006_021403f4[i]);
+        Vec3_Sub(&rel, q, &self->vel);
+        Vec3_Add(&sum, &disp, &rel);
+
+        if (LenVec3(&sum) > thresh)
+            continue;
+
+        if (NormalizeVec3IfNonZero(&disp) == 0) {
+            data_ov006_021403f4[i]->flag = 1;
+            o = data_ov006_021403f4[i];
+            o->vec.x = self->pos.x;
+            o->vec.y = self->pos.y;
+            o->vec.z = self->pos.z;
+            func_ov006_020c4f68(self);
+        }
+
+        up.x = 0;
+        up.y = 0x1000;
+        up.z = 0;
+        if (DotVec3(&up, &disp) <= 0)
+            continue;
+
+        if (rel.y >= 0)
+            continue;
+
+        data_ov006_021403f4[i]->flag = 1;
+        o = data_ov006_021403f4[i];
+        o->vec.x = self->pos.x;
+        o->vec.y = self->pos.y;
+        o->vec.z = self->pos.z;
+        func_ov006_020c4f68(self);
+        return;
+    }
+}

--- a/src/func_ov006_020c49d8.c
+++ b/src/func_ov006_020c49d8.c
@@ -1,0 +1,77 @@
+typedef struct { int x, y, z; } Vec3;
+typedef int (**VT)(void*);
+
+struct Self {
+    char pad0[0x9c];
+    Vec3 pos;                /* 0x9c */
+    Vec3 vel;                /* 0xa8 */
+    char padb4[0xd8 - 0xb4];
+    int d8;                  /* 0xd8 */
+};
+
+extern void Vec3_Sub(Vec3* out, Vec3* a, Vec3* b);
+extern void Vec3_Add(Vec3* out, Vec3* a, Vec3* b);
+extern int LenVec3(Vec3* v);
+extern int DotVec3(Vec3* a, Vec3* b);
+extern int NormalizeVec3IfNonZero(Vec3* v);
+extern void func_ov006_020c4f68(struct Self* self);
+extern char* data_ov006_021403f4[];
+
+#define O  (data_ov006_021403f4[i])
+#define OM (((char* volatile*)data_ov006_021403f4)[i])
+
+void func_ov006_020c49d8(struct Self* self)
+{
+    int i;
+    int lim = (int)(((long long)self->d8 * 0x12000 + 0x800) >> 12);
+    int half = lim >> 1;
+
+    for (i = 0; i < 3; i++) {
+        Vec3 a;
+        Vec3 b;
+        Vec3 d;
+        Vec3 c;
+
+        if ((*(VT*)O)[2](O) == 0) continue;
+
+        Vec3_Sub(&a, (Vec3*)(*(VT*)O)[0](O), &self->pos);
+        a.y -= half;
+        if (a.y < 0) {
+            if (a.y > -0x18000) a.y = 0;
+            else a.y += 0x18000;
+        } else {
+            if (a.x > 0x2000) a.x -= 0x2000;
+            else if (a.x < -0x2000) a.x += 0x2000;
+            else a.x = 0;
+        }
+
+        Vec3_Sub(&b, (Vec3*)(*(VT*)O)[1](O), &self->vel);
+        Vec3_Add(&c, &a, &b);
+        if (LenVec3(&c) > lim) continue;
+
+        if (NormalizeVec3IfNonZero(&a) == 0) {
+            *(short*)(OM + 0x10) = 1;
+            *(int*)(O + 4) = self->pos.x;
+            *(int*)(O + 8) = self->pos.y;
+            *(int*)(O + 0xc) = self->pos.z;
+            func_ov006_020c4f68(self);
+        }
+
+        d.x = 0;
+        d.y = 0x1000;
+        d.z = 0;
+        if (DotVec3(&d, &a) > 0) {
+            *(short*)(OM + 0x10) = 1;
+            *(int*)(O + 4) = self->pos.x;
+            *(int*)(O + 8) = self->pos.y;
+            *(int*)(O + 0xc) = self->pos.z;
+            func_ov006_020c4f68(self);
+            return;
+        } else {
+            *(short*)(OM + 0x10) = 2;
+            *(int*)(O + 4) = self->pos.x;
+            *(int*)(O + 8) = self->pos.y;
+            *(int*)(O + 0xc) = self->pos.z;
+        }
+    }
+}

--- a/src/func_ov006_020d7f5c.c
+++ b/src/func_ov006_020d7f5c.c
@@ -1,0 +1,71 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+void func_ov006_020d6b88(char *this, int idx);
+void func_ov006_020d6c90(char *this, int idx);
+void func_ov006_020d6e8c(char *this, int idx);
+void func_02012718(void *a, int b);
+int func_020126e8(int a);
+int func_02012468(int a, int b, int c, int d, int e, int f, int g, short h);
+
+extern u8 data_020a0e40;
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+
+#define B ((char *)this + idx * 0x40 + 0x4000)
+
+#pragma opt_common_subs off
+
+void func_ov006_020d7f5c(char *this, int idx)
+{
+    if (*(u8 *)(this + 0x62f6) == 0xff) {
+        *(u8 *)(B + 0x697) = 1;
+        *(u16 *)((char *)this + 0x4692 + idx * 0x40) += 0x40;
+        func_ov006_020d6b88(this, idx);
+        func_ov006_020d6c90(this, idx);
+    } else {
+        int old_x = *(int *)(B + 0x660);
+        int old_y = *(int *)(B + 0x664);
+        int cx, cy;
+        u8 was;
+        int t = data_020a0e40;
+
+        *(int *)(B + 0x660) = (data_020a0dea[t << 2] << 12) - *(int *)(B + 0x668);
+        *(int *)(B + 0x664) = (data_020a0deb[t << 2] << 12) - *(int *)(B + 0x66c);
+        cx = old_x >> 12;
+        cy = old_y >> 12;
+
+        func_ov006_020d6e8c(this, idx);
+
+        {
+            int t2 = data_020a0e40;
+            *(int *)(B + 0x660) = (data_020a0dea[t2 << 2] << 12) - *(int *)(B + 0x668);
+            *(int *)(B + 0x664) = (data_020a0deb[t2 << 2] << 12) - *(int *)(B + 0x66c);
+        }
+
+        was = *(u8 *)(B + 0x69e);
+        if (*(u8 *)(B + 0x696) != 0) {
+            if (cx > 0xc0 && cy > 0x40 && cy < 0x80) {
+                *(u8 *)(B + 0x69e) = 1;
+            } else {
+                *(u8 *)(B + 0x69e) = 0;
+            }
+        } else {
+            if (cx < 0x40 && cy > 0x40 && cy < 0x80) {
+                *(u8 *)(B + 0x69e) = 1;
+            } else {
+                *(u8 *)(B + 0x69e) = 0;
+            }
+        }
+
+        if (was == 0 && *(u8 *)(B + 0x69e) != 0) {
+            func_02012718((void *)0x1e4, *(int *)(B + 0x660));
+        }
+
+        *(int *)(B + 0x688) = func_02012468(*(int *)(B + 0x688), 2, 0x1e5, 4, 0, 0,
+                                            func_020126e8(*(int *)(B + 0x660)), 0);
+        *(int *)(B + 0x67c) = *(int *)(B + 0x660);
+        *(int *)(B + 0x680) = *(int *)(B + 0x664);
+    }
+}

--- a/src/func_ov006_020da5e8.c
+++ b/src/func_ov006_020da5e8.c
@@ -1,0 +1,48 @@
+int func_ov006_020da5e8(char *a, char *b);
+int func_ov006_020da5e8(char *a, char *b) {
+    short arr1[6];
+    short arr2[6];
+    short *p1 = (short *)(((int)arr1) & 0xFFFFFFFFFFFFFFFF);
+    short *p2 = (short *)(((int)arr2) & 0xFFFFFFFFFFFFFFFF);
+    int max1, sec1;
+    short max1i, sec1i;
+    int max2, sec2;
+    short max2i, sec2i;
+    int i;
+    short tmp;
+
+    p1[0] = 0; p1[1] = 0; p1[2] = 0; p1[3] = 0; p1[4] = 0; p1[5] = 0;
+    p2[0] = 0; p2[1] = 0; p2[2] = 0; p2[3] = 0; p2[4] = 0; p2[5] = 0;
+
+    max1 = 0; max1i = 6; sec1 = 0; sec1i = 6;
+    max2 = 0; sec2 = 0; max2i = 6; sec2i = 6;
+
+    for (i = 0; i < 5; i++) {
+        arr1[*(unsigned char *)(a + 0x2a)]++;
+        a += 0x30;
+        arr2[*(unsigned char *)(b + 0x2a)]++;
+        b += 0x30;
+    }
+
+    for (i = 0; i < 6; i++) {
+        if (max1 <= arr1[i]) { sec1 = max1; sec1i = max1i; max1 = arr1[i]; max1i = i; }
+        else if (sec1 <= arr1[i]) { sec1 = arr1[i]; sec1i = i; }
+        if (max2 <= arr2[i]) { sec2 = max2; sec2i = max2i; max2 = arr2[i]; max2i = i; }
+        else if (sec2 <= arr2[i]) { sec2 = arr2[i]; sec2i = i; }
+    }
+
+    if (max1 == sec1 && max1i < sec1i) { tmp = max1i; max1i = sec1i; sec1i = tmp; }
+    if (max2 == sec2 && max2i < sec2i) { tmp = max2i; max2i = sec2i; sec2i = tmp; }
+
+    if (max1 > max2) return 1;
+    if (max1 < max2) return -1;
+    if (sec1 > sec2) return 1;
+    if (sec1 < sec2) return -1;
+    if (max1 == 1 && max2 == 1) return 0;
+    if (max1i > max2i) return 1;
+    if (max1i < max2i) return -1;
+    if (sec1 == 1 && sec2 == 1) return 0;
+    if (sec1i > sec2i) return 1;
+    if (sec1i < sec2i) return -1;
+    return 0;
+}

--- a/src/func_ov006_020dbf7c.c
+++ b/src/func_ov006_020dbf7c.c
@@ -1,0 +1,71 @@
+extern int RandomIntInternal(int *seed);
+extern void func_02012718(void *a, int b);
+extern int data_0209d4b8;
+extern int data_ov006_0212e370[];
+extern int data_ov006_0212e388[];
+extern int data_ov006_0212e344[];
+
+typedef struct {
+    int field_00;
+    int field_04;
+    int field_08;
+    int field_0c;
+    unsigned short field_10;
+    unsigned short field_12;
+    unsigned char field_14;
+    unsigned char field_15;
+    unsigned char field_16;
+    unsigned char field_17;
+    unsigned char field_18;
+    unsigned char field_19;
+    unsigned char field_1a;
+    unsigned char field_1b;
+} Sub;
+
+struct Obj {
+    unsigned char pad[0x51a8];
+    Sub arr[1];
+};
+
+void func_ov006_020dbf7c(struct Obj *sb, int i)
+{
+    int v;
+    int k;
+
+    sb->arr[i].field_00 += sb->arr[i].field_08;
+    sb->arr[i].field_04 += sb->arr[i].field_0c;
+    sb->arr[i].field_0c += 0x400;
+    if (sb->arr[i].field_08 > 0) {
+        sb->arr[i].field_10 += 0x400;
+    } else {
+        sb->arr[i].field_10 -= 0x400;
+    }
+
+    v = sb->arr[i].field_04 >> 12;
+    k = sb->arr[i].field_19;
+
+    if (k >= 6) {
+        if (v >= 0xd0) {
+            sb->arr[i].field_15 = 0;
+            sb->arr[i].field_14 = 0;
+        }
+        return;
+    }
+
+    if (sb->arr[i].field_18 != 0) {
+        unsigned int r;
+        if (v < (data_ov006_0212e370[k] - data_ov006_0212e388[k])) {
+            return;
+        }
+        r = (unsigned int)RandomIntInternal(&data_0209d4b8);
+        sb->arr[i].field_08 = data_ov006_0212e344[((r >> 16 & 0x7fff) << 1) >> 15];
+        sb->arr[i].field_0c = -0x3000;
+        sb->arr[i].field_18--;
+        func_02012718((void *)0xef, sb->arr[i].field_00);
+        if (sb->arr[i].field_18 == 0) {
+            sb->arr[i].field_19++;
+        }
+    } else {
+        sb->arr[i].field_18 = 1;
+    }
+}

--- a/src/func_ov006_020ecba4.c
+++ b/src/func_ov006_020ecba4.c
@@ -1,0 +1,91 @@
+typedef short s16;
+typedef long long s64;
+
+typedef struct { int x, y; } V2;
+
+struct C {
+    V2 v0;              /* 0x00 */
+    V2 v8;              /* 0x08 */
+    char pad10[8];      /* 0x10 */
+    V2 v18[5];          /* 0x18 */
+    int w40;            /* 0x40 */
+    int w44;            /* 0x44 */
+    int w48;            /* 0x48 */
+    int w4c[5];         /* 0x4c */
+    char pad60[0x16];   /* 0x60 */
+    s16 s76;            /* 0x76 */
+    char pad78[2];      /* 0x78 */
+    s16 s7a[5];         /* 0x7a */
+    char pad84[2];      /* 0x84 */
+    s16 s86;            /* 0x86 */
+    char pad88[0xc];    /* 0x88 */
+    unsigned char b94;  /* 0x94 */
+    unsigned char b95;  /* 0x95 */
+};
+
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern int data_ov006_0213c958;
+extern V2 data_ov006_0213c9dc;
+extern void func_0203d388(V2* p, int angle);
+extern void func_0203d704(V2* o, V2* a, V2* b);
+extern void func_ov006_020ec2bc(struct C* c);
+
+void func_ov006_020ecba4(struct C* c, int param)
+{
+    V2 vec0;
+    V2 vec1;
+    V2 vec3;
+    V2 vec2;
+    V2 vec4;
+    int m, r1, r2, k, i, j;
+
+    c->b94 = 1;
+    c->w48 = 0x3000;
+    c->b95 = 0;
+    c->s86 = 0x200;
+    c->w40 = 0;
+    c->w44 = 0;
+
+    m = data_ov006_0213c958 - 1;
+    r1 = _ZN4cstd4fdivEii(param << 12, m << 12);
+    r2 = _ZN4cstd4fdivEii((m - param) << 12, m << 12);
+    k = (m - 2) * 8;
+
+    vec0.y = 0;
+    vec0.y = (int)(((s64)((0x40 - k) << 12) * r1 + 0x800) >> 12)
+           + (int)(((s64)((k + 0x98) << 12) * r2 + 0x800) >> 12);
+    vec0.x = 0;
+    if (param & 1)
+        vec0.x = 0xa8000;
+    else
+        vec0.x = 0x38000;
+
+    c->s76 = -0x8000;
+    c->v18[0].x = *(int*)&vec0;
+    c->v18[0].y = *((int*)&vec0 + 1);
+    c->s7a[0] = c->s76 - 0x2000;
+
+    for (i = 1; i < 5; i++) {
+        j = i - 1;
+        vec1.x = 0;
+        vec1.y = (i * 2 + 0x10) << 12;
+        func_0203d388(&vec1, (s16)(c->s7a[j] + 0x2000));
+        c->s7a[i] = c->s7a[j] + 0x2000;
+        func_0203d704(&vec2, &c->v18[j], &vec1);
+        c->v18[i].x = vec2.x;
+        c->v18[i].y = vec2.y;
+    }
+
+    func_ov006_020ec2bc(c);
+
+    vec3.x = 0;
+    vec3.y = -0x10000;
+    c->s7a[0] = c->s76 - 0x2000;
+    func_0203d388(&vec3, c->s7a[0]);
+    func_0203d704(&vec4, &c->v18[1], &vec3);
+    c->v18[0].x = vec4.x;
+    c->v18[0].y = vec4.y;
+
+    c->v0 = data_ov006_0213c9dc;
+    c->v8 = c->v0;
+}

--- a/src/func_ov006_021020c4.c
+++ b/src/func_ov006_021020c4.c
@@ -1,0 +1,69 @@
+#pragma opt_common_subs off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern void func_ov006_02101e88(char* p, int i);
+extern int* data_ov006_0213db6c[];
+
+void func_ov006_021020c4(char* p, int i)
+{
+    int limit;
+
+    *(int*)(p + 0x5264 + (i << 6)) += *(int*)(p + 0x5000 + (i << 6) + 0x26c);
+    limit = data_ov006_0213db6c[*(int*)(p + 0x5668)][i];
+
+    if ((*(int*)(p + 0x5000 + (i << 6) + 0x264) >> 12) >= limit) {
+        *(int*)(p + 0x5000 + (i << 6) + 0x264) = limit << 12;
+        *(int*)(p + 0x5000 + (i << 6) + 0x26c) = 0;
+
+        if (i & 2) {
+            if (*(int*)(p + 0x5000 + (i << 6) + 0x268) > 0)
+                *(int*)(p + 0x5000 + (i << 6) + 0x268) = 0xc80;
+            else
+                *(int*)(p + 0x5000 + (i << 6) + 0x268) = -0xc80;
+        }
+
+        if (*(int*)(p + 0x5668) == 1) {
+            *(u8*)(p + 0x5000 + (i << 6) + 0x296) = 4;
+            if (*(int*)(p + 0x5000 + (i << 6) + 0x268) > 0)
+                *(u16*)(p + 0x5000 + (i << 6) + 0x290) = 0x8000;
+            else
+                *(u16*)(p + 0x5000 + (i << 6) + 0x290) = 0;
+        }
+
+        if (*(int*)(p + 0x5668) == 3) {
+            *(u8*)(p + 0x5000 + (i << 6) + 0x296) = 3;
+            *(int*)(p + 0x5000 + (i << 6) + 0x268) = 0;
+            if (*(u8*)(p + 0x5000 + (i << 6) + 0x298) != 0) {
+                *(int*)(p + 0x5000 + (i << 6) + 0x26c) = 0xc00;
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 0;
+            } else {
+                *(int*)(p + 0x5000 + (i << 6) + 0x26c) = -0xc00;
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 2;
+            }
+            return;
+        }
+
+        if (*(int*)(p + 0x5668) == 4) {
+            *(u8*)(p + 0x5000 + (i << 6) + 0x296) = 5;
+            if (i == 0)
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 0;
+            else
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 1;
+        }
+
+        if (*(int*)(p + 0x5668) == 5) {
+            *(u8*)(p + 0x5000 + (i << 6) + 0x296) = 6;
+            if (*(u8*)(p + 0x5000 + (i << 6) + 0x298) != 0)
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 0;
+            else
+                *(u8*)(p + 0x5000 + (i << 6) + 0x29b) = 1;
+            return;
+        }
+    } else {
+        *(int*)(p + 0x526c + (i << 6)) -= 0x20;
+    }
+
+    func_ov006_02101e88(p, i);
+}

--- a/src/func_ov006_0211d368.c
+++ b/src/func_ov006_0211d368.c
@@ -1,0 +1,50 @@
+extern unsigned short data_ov006_0212efc8[];
+extern unsigned char data_ov006_0212efc4[];
+extern unsigned char data_0209d45c;
+extern int data_0209d4b8;
+extern void SetBg3Offset(int a, int b);
+extern int RandomIntInternal(int *seed);
+
+void func_ov006_0211d368(char *obj, int i)
+{
+    unsigned char state = *(unsigned char *)(obj + 0x4be3 + i * 0x1c);
+    if ((unsigned char)(state - 8) < 2)
+    {
+        (*(unsigned short *)(obj + 0x4bdc + i * 0x1c))++;
+        if (*(unsigned short *)(obj + 0x4bdc + i * 0x1c) >= data_ov006_0212efc8[(unsigned char)(state - 8)])
+        {
+            *(unsigned short *)(obj + 0x4bdc + i * 0x1c) = 0;
+            (*(unsigned char *)(obj + 0x4be3 + i * 0x1c))++;
+        }
+    }
+    if (*(unsigned short *)(obj + 0x4bde + i * 0x1c) != 0)
+    {
+        (*(unsigned short *)(obj + 0x4bde + i * 0x1c))--;
+        return;
+    }
+    data_0209d45c &= ~4;
+    SetBg3Offset(0, 0x100);
+    {
+    int rnd = RandomIntInternal(&data_0209d4b8);
+    *(unsigned char *)(obj + 0x4be1 + i * 0x1c) =
+        data_ov006_0212efc4[((unsigned int)(((unsigned int)rnd >> 16) & 0x7fff) * 2) >> 15];
+    }
+    *(unsigned short *)(obj + 0x4bdc + i * 0x1c) = 0;
+    *(unsigned char *)(obj + 0x4be3 + i * 0x1c) = 0;
+    if (*(unsigned char *)(obj + 0x4be1 + i * 0x1c) == 2)
+    {
+        *(unsigned char *)(obj + 0x4be4 + i * 0x1c) = 0;
+        *(int *)(obj + 0x4bd4 + i * 0x1c) = -0x4800;
+        *(int *)(obj + 0x4bcc + i * 0x1c) = 0x180000;
+    }
+    else
+    {
+        *(unsigned char *)(obj + 0x4be4 + i * 0x1c) = 1;
+        *(int *)(obj + 0x4bd4 + i * 0x1c) = 0x4800;
+        *(int *)(obj + 0x4bcc + i * 0x1c) = -0x80000;
+    }
+    if (*(unsigned char *)(obj + 0x4be5 + i * 0x1c) != 0)
+    {
+        *(unsigned char *)(obj + 0x4be1 + i * 0x1c) = 5;
+    }
+}


### PR DESCRIPTION
12 fresh ov002/ov006 functions decompiled and verified byte-exact with mwccarm 1.2/sp2p3 (relocations checked locally via `match.py --strict-relocs`). src-only. The `validate` CI table is the review.