### PR TITLE
glm_refine: show a near-miss's starting divergence in the result header

### DIFF
--- a/tools/glm_refine.py
+++ b/tools/glm_refine.py
@@ -207,6 +207,7 @@ def verify(name, wl):
 
 def crack_one(name, wl, attempts, row):
     t_in = t_out = 0
+    orig_div = None  # stored draft's divergence before refining; None if verify never ran
     att_log = []  # per-attempt lines, printed by the caller BELOW the result header
     try:
         ctx = run_tool(["tools/abrow.py", "--name", name, "--wl", wl])
@@ -214,10 +215,11 @@ def crack_one(name, wl, attempts, row):
         _WORKDIR.mkdir(exist_ok=True, parents=True)
         (_WORKDIR / f"{name}.src").write_text(draft, encoding="utf-8", newline="\n")
         best_div, vout = verify(name, wl)
+        orig_div = best_div  # the "from": stored draft's divergence before any refine attempt
         best_src = draft
         if best_div == 0:
             return {"name": name, "matched": True, "c_source": draft, "attempts": 0,
-                    "divergences": 0, "note": "stored draft already matches",
+                    "divergences": 0, "orig_div": orig_div, "note": "stored draft already matches",
                     "log": att_log}, 0, 0
 
         messages = [{"role": "user", "content":
@@ -259,7 +261,7 @@ def crack_one(name, wl, attempts, row):
                 stale += 1
             if div == 0:
                 return {"name": name, "matched": True, "c_source": src, "attempts": att,
-                        "divergences": 0, "note": note or "matched",
+                        "divergences": 0, "orig_div": orig_div, "note": note or "matched",
                         "log": att_log}, t_in, t_out
             if floor or stale >= 2:
                 break
@@ -269,11 +271,11 @@ def crack_one(name, wl, attempts, row):
                              f"Best so far is {best_div}. Try a different lever."})
         (_WORKDIR / f"{name}.src").write_text(best_src, encoding="utf-8", newline="\n")
         return {"name": name, "matched": False, "c_source": best_src,
-                "attempts": attempts, "divergences": best_div,
+                "attempts": attempts, "divergences": best_div, "orig_div": orig_div,
                 "note": note or "no improvement", "log": att_log}, t_in, t_out
     except Exception as e:  # one function failing must not sink the batch
         return {"name": name, "matched": False, "c_source": row.get("draft") or "",
-                "attempts": 0, "divergences": 999,
+                "attempts": 0, "divergences": 999, "orig_div": orig_div,
                 "note": f"driver error: {e}"[:300], "log": att_log}, t_in, t_out
 
 
@@ -375,6 +377,11 @@ def main():
                     # function's attempts indented below, so each function reads as one
                     # tidy unit and a new header means the previous one finished.
                     status = 'MATCH' if res['matched'] else 'div=' + str(res['divergences'])
+                    # Show the stored draft's starting divergence so a near-miss improvement (or
+                    # lack of one) is legible at a glance: "div=6 (from: 40)" vs "div=6 (from: 6)".
+                    orig = res.get('orig_div')
+                    if isinstance(orig, int) and orig > 0:
+                        status += f" (from: {orig})"
                     lines = [f"({len(results)}/{len(rows)}) {res['name']}: {status}"]
                     lines += [f"    {ln}" for ln in res.get('log', [])]
                     log("\n".join(lines))


### PR DESCRIPTION
## What

The refine driver's result-first header (`(4/13) func_02018c00: div=6`) printed only the **final** divergence, so the live viewer couldn't tell whether a near-miss actually improved. This appends the stored draft's starting div:

- `div=6 (from: 40)` - improved
- `div=6 (from: 6)` - no improvement (now legible)
- `MATCH (from: 40)` - cracked a near-miss outright

## How

Captures `orig_div` from the pre-attempt verify in `crack_one` and appends `(from: X)` when it's a real positive div. Hidden for an already-matching draft (`from: 0`) or a driver error (verify never ran).

Tools-only, no `src/` change. The console just streams this stdout to the viewer and parses the leading `MATCH`/`div=N` with a regex that's unaffected by the suffix, so no console change or release is involved.

Built with Claude Code