### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_020f1cb4.c
+++ b/src/func_ov006_020f1cb4.c
@@ -1,35 +1,29 @@
-// NONMATCHING: register allocation (div=9). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef short s16;
-typedef unsigned short u16;
 typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
 typedef long long s64;
 
-extern void func_ov006_020f1dbc(void);
 extern int data_ov006_0212e8c8[];
 extern s16 data_02082214[];
 
-void func_ov006_020f1cb4(char *r0, int r1)
-{
-    u8 *flag = (u8*)(r0 + 0x5275 + r1);
-    int idx, k, t, mat;
-    if (*flag == 0) {
-        *(u16*)(r0 + r1 * 2 + 0x4f7c) = 0x6000;
-        *flag = *flag + 1;
+void func_ov006_020f1dbc(char* c, int i);
+
+void func_ov006_020f1cb4(char* c, int i) {
+    u8* counter = (u8*)(c + 0x5275);
+    if (counter[i] == 0) {
+        *(u16*)(c + i * 2 + 0x4f7c) = 0x6000;
+        counter[i]++;
         return;
     }
-    idx = *(u16*)(r0 + r1 * 2 + 0x4f7c) >> 4;
-    k = *(u8*)(r0 + 0x5365 + r1);
-    t = data_02082214[idx * 2 + 1];
-    mat = data_ov006_0212e8c8[k];
-    *(int*)(r0 + 0x47f8 + r1 * 4) = *(int*)(r0 + 0x47f8 + r1 * 4)
-        + (int)(((s64)t * mat + 0x800) >> 12);
-    idx = *(u16*)(r0 + r1 * 2 + 0x4f7c) >> 4;
-    k = *(u8*)(r0 + 0x5365 + r1);
-    t = data_02082214[idx * 2];
-    mat = data_ov006_0212e8c8[k];
-    *(int*)(r0 + 0x49d8 + r1 * 4) = *(int*)(r0 + 0x49d8 + r1 * 4)
-        + (int)(((s64)t * mat + 0x800) >> 12);
-    func_ov006_020f1dbc();
+    {
+        u8* spd = (u8*)(c + 0x5365);
+        int* xs = (int*)(c + 0x47f8);
+        int a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
+        xs[i] = xs[i] + (int)(((s64)data_02082214[a * 2 + 1] * data_ov006_0212e8c8[spd[i]] + 0x800) >> 12);
+        int* ys = (int*)(c + 0x49d8);
+        a = (int)*(u16*)(c + i * 2 + 0x4f7c) >> 4;
+        ys[i] = ys[i] + (int)(((s64)data_02082214[a * 2] * data_ov006_0212e8c8[spd[i]] + 0x800) >> 12);
+    }
+    func_ov006_020f1dbc(c, i);
 }

--- a/src/func_ov006_020f6488.c
+++ b/src/func_ov006_020f6488.c
@@ -1,32 +1,21 @@
-// NONMATCHING: register allocation (div=15). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern int func_ov004_020b56c8(int);
+extern void func_ov004_020b56c8(char* p);
 extern short data_ov004_020bf9e4;
 
-struct S5300 {
-    char pad[0xe2];
-    unsigned short timer;   /* 0xe2 */
-    char pad2[0xea - 0xe4];
-    unsigned short fea;     /* 0xea */
-};
-
-void func_ov006_020f6488(char *c)
-{
-    struct S5300 *s = (struct S5300 *)(c + 0x5300);
-    unsigned short *t;
-    if (s->timer != 0) {
-        t = (unsigned short *)(c + 0x53e2);
-        t[0] = t[0] - 1;
-        if (s->timer != 0)
+void func_ov006_020f6488(char *c) {
+    if (*((unsigned short *)(c + 0x5300 + 0xE2)) != 0) {
+        unsigned short *ptr = (unsigned short *)((((int)c) + 0x53E2) & 0xFFFFFFFFFFFFFFFFULL);
+        *ptr = *ptr - 1;
+        if (*((unsigned short *)(c + 0x5300 + 0xE2)) != 0) {
             return;
-        if (*(unsigned char *)(c + 0x5405) < s->fea)
+        }
+        if (*((unsigned char *)(c + 0x5000 + 0x405)) < *((unsigned short *)(c + 0x5300 + 0xEA))) {
             return;
-        func_ov004_020b56c8((5 - *(unsigned char *)(c + 0x5408)) * 5);
+        }
+        func_ov004_020b56c8((char *)(5 * (5 - *((unsigned char *)(c + 0x5000 + 0x408)))));
         return;
     }
     if (data_ov004_020bf9e4 == 1) {
-        s->timer = 0;
-        *(int *)(c + 0x53d8) = 2;
+        *((unsigned short *)(c + 0x5300 + 0xE2)) = 0;
+        *((int *)(c + 0x5000 + 0x3D8)) = 2;
     }
 }


### PR DESCRIPTION
Two ov006 register-allocation near-misses, cracked via the permuter and verified byte-identical (mwccarm 1.2/sp2p3):

- `func_ov006_020f1cb4` (size 0x108)
- `func_ov006_020f6488` (size 0xb0)

Both were `// NONMATCHING` on main. src-only; `validate` confirms the relocations.

Built with Claude Code
