### PR TITLE
chore: gitignore per-session scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,16 @@ tools/claims_key.txt
 tools/claims_handle.txt
 /scratchpad/
 
+# per-session runtime scratch (terminal logs, temp files, local MCP setup)
+/temp/
+/terminals/
+/mcps/
+
 # coddog fan-out scratch (agents write candidates here)
 _abwork/
+
+# glm fan-out scratch (agents write candidates here)
+_glmwork/
 
 # AI-session draft area (Cursor/Grok and friends): unverified candidates live
 # here, never in src/ - src/ is oracle-verified matches only


### PR DESCRIPTION
Ignore per-session runtime scratch that was untracked-but-not-ignored:

- `_glmwork/` (glm fan-out candidates, mirrors the existing `_abwork/` rule)
- `/temp/`, `/terminals/`, `/mcps/` (temp files, terminal logs, local MCP setup)

Keeps `git status` clean and prevents an accidental `git add .` from committing them.

Built with Claude Code
