### PR TITLE
Match 6 functions via Fable fan-out (0x400-0x800 low-sim logic)

### DIFF
--- a/src/_ZN12CylinderClsn7ProcessEv.cpp
+++ b/src/_ZN12CylinderClsn7ProcessEv.cpp
@@ -1,0 +1,207 @@
+//cpp
+typedef int Fix12i;
+typedef unsigned int u32;
+
+struct Vector3 { Fix12i x, y, z; };
+
+struct CylinderClsn
+{
+    virtual int v0();
+    virtual int v1();
+    virtual Vector3& GetPos();      // vt+0x08
+    virtual u32 GetOwnerID();       // vt+0x0C
+
+    Fix12i radius;       // 0x04
+    Fix12i height;       // 0x08
+    Vector3 pushback;    // 0x0C
+    u32 flags;           // 0x18
+    u32 vulnFlags;       // 0x1C
+    u32 hitFlags;        // 0x20
+    u32 otherOwner;      // 0x24
+    u32 unk28;           // 0x28
+    CylinderClsn* next;  // 0x2C
+
+    static void Process();
+};
+
+extern "C" {
+extern CylinderClsn* data_0209cee8;
+extern Fix12i Vec3_HorzLen(const Vector3* v);
+extern void func_02014f44(unsigned int id, CylinderClsn* clsn);
+}
+
+namespace cstd { int fdiv(int a, int b); }
+
+void CylinderClsn::Process()
+{
+    u32 owner0;
+    Fix12i vertDist;
+    Vector3* pos0;
+    CylinderClsn* other;
+    Fix12i dist;
+    Fix12i overlap;
+    u32 sharedFlags;
+    Fix12i minDist;
+    Vector3 diff;
+
+    if (data_0209cee8 == 0)
+        return;
+
+    minDist = 0x1000;
+
+    do
+    {
+        pos0 = &data_0209cee8->GetPos();
+        owner0 = data_0209cee8->GetOwnerID();
+
+        for (other = data_0209cee8->next; other != 0; other = other->next)
+        {
+            sharedFlags = (data_0209cee8->flags & other->vulnFlags) | (data_0209cee8->vulnFlags & other->flags);
+            if (sharedFlags == 0)
+                continue;
+            if (owner0 != 0 && owner0 == other->GetOwnerID())
+                continue;
+
+            Vector3& pos1 = other->GetPos();
+            diff.y = pos1.y - pos0->y;
+            if (diff.y < 0)
+                vertDist = other->height + diff.y;
+            else
+                vertDist = data_0209cee8->height - diff.y;
+            if (vertDist <= 0)
+                continue;
+
+            diff.x = pos1.x - pos0->x;
+            diff.z = pos1.z - pos0->z;
+            dist = Vec3_HorzLen(&diff);
+            if (dist == 0)
+            {
+                dist = minDist;
+                diff.x = dist;
+            }
+
+            overlap = data_0209cee8->radius + other->radius - dist;
+            if (overlap <= 0)
+                continue;
+
+            data_0209cee8->hitFlags = other->flags;
+            other->hitFlags = data_0209cee8->flags;
+            data_0209cee8->otherOwner = other->GetOwnerID();
+            other->otherOwner = data_0209cee8->GetOwnerID();
+
+            if (sharedFlags & 0x4000000)
+            {
+                u32* pf1 = (u32*)((unsigned long long)(unsigned int)((char*)other + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
+                u32* pf0 = (u32*)((unsigned long long)(unsigned int)((char*)data_0209cee8 + 0x20) & 0xFFFFFFFFFFFFFFFFULL);
+                *pf0 |= 0x8000000;
+                overlap -= 0x50000;
+                *pf1 |= 0x8000000;
+                if (overlap < 0)
+                    continue;
+            }
+
+            {
+                u32 f0 = data_0209cee8->flags;
+                if (f0 & 2)
+                    continue;
+                u32 f1 = other->flags;
+                if (f1 & 2)
+                    continue;
+
+                if (f0 & 4)
+                {
+                    if (f1 & 4)
+                    {
+                        if (diff.y < 0)
+                        {
+                            Fix12i h = vertDist >> 1;
+                            data_0209cee8->pushback.y = h;
+                            other->pushback.y = -h;
+                        }
+                        else
+                        {
+                            Fix12i h = vertDist >> 1;
+                            data_0209cee8->pushback.y = -h;
+                            other->pushback.y = h;
+                        }
+                        other->pushback.x = 0;
+                        other->pushback.z = 0;
+                    }
+                    else
+                    {
+                        if (diff.y < 0)
+                            other->pushback.y = -vertDist;
+                        else
+                            other->pushback.y = vertDist;
+                        if (data_0209cee8->flags & 8)
+                        {
+                            Fix12i r = data_0209cee8->radius;
+                            Fix12i t = overlap - (r - (((r << 1) + r) >> 3));
+                            if (t < 0)
+                                overlap = 0;
+                            else
+                                overlap = cstd::fdiv(t, dist);
+                            func_02014f44(data_0209cee8->otherOwner, data_0209cee8);
+                        }
+                        else
+                            overlap = cstd::fdiv(overlap, dist);
+                        other->pushback.x = (Fix12i)(((long long)diff.x * overlap + 0x800) >> 12);
+                        other->pushback.z = (Fix12i)(((long long)diff.z * overlap + 0x800) >> 12);
+                    }
+                    data_0209cee8->pushback.x = 0;
+                    data_0209cee8->pushback.z = 0;
+                }
+                else if (f1 & 4)
+                {
+                    if (diff.y < 0)
+                        data_0209cee8->pushback.y = vertDist;
+                    else
+                        data_0209cee8->pushback.y = -vertDist;
+                    if (other->flags & 8)
+                    {
+                        Fix12i r = data_0209cee8->radius;
+                        Fix12i t = overlap - (r - (((r << 1) + r) >> 3));
+                        if (t < 0)
+                            overlap = 0;
+                        else
+                            overlap = cstd::fdiv(t, dist);
+                        func_02014f44(other->otherOwner, other);
+                    }
+                    else
+                        overlap = cstd::fdiv(overlap, dist);
+                    data_0209cee8->pushback.x = -(Fix12i)(((long long)diff.x * overlap + 0x800) >> 12);
+                    data_0209cee8->pushback.z = -(Fix12i)(((long long)diff.z * overlap + 0x800) >> 12);
+                    other->pushback.x = 0;
+                    other->pushback.z = 0;
+                }
+                else if (!(f0 & 0x10000000) && !(f1 & 0x10000000))
+                {
+                    if (diff.y < 0)
+                    {
+                        Fix12i h = vertDist >> 1;
+                        data_0209cee8->pushback.y = h;
+                        other->pushback.y = -h;
+                    }
+                    else
+                    {
+                        Fix12i h = vertDist >> 1;
+                        data_0209cee8->pushback.y = -h;
+                        other->pushback.y = h;
+                    }
+                    Fix12i ratio = cstd::fdiv(overlap, dist) >> 1;
+                    data_0209cee8->pushback.x = -(Fix12i)(((long long)diff.x * ratio + 0x800) >> 12);
+                    data_0209cee8->pushback.z = -(Fix12i)(((long long)diff.z * ratio + 0x800) >> 12);
+                    other->pushback.x = (Fix12i)(((long long)diff.x * ratio + 0x800) >> 12);
+                    other->pushback.z = (Fix12i)(((long long)diff.z * ratio + 0x800) >> 12);
+                }
+            }
+        }
+
+        {
+            CylinderClsn* nxt = data_0209cee8->next;
+            data_0209cee8->unk28 = 0;
+            data_0209cee8->next = 0;
+            data_0209cee8 = nxt;
+        }
+    } while (data_0209cee8 != 0);
+}

--- a/src/func_02047218.c
+++ b/src/func_02047218.c
@@ -1,0 +1,48 @@
+typedef int fx32;
+typedef long long fx64;
+
+#define FX(a, b) ((fx32)(((fx64)(a) * (b) + 0x800) >> 12))
+#define PTR(base, off) ((fx32*)(int)(((long long)(int)((char*)(base) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_02047218(fx32 *m0, fx32 *m1, fx32 *dst, fx32 t)
+{
+    fx32 s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
+    fx32 *p;
+
+    s1  = FX(m0[1], t);
+    s2  = FX(m0[2], t);
+    s4  = FX(m0[4], t);
+    s5  = FX(m0[5], t);
+    s7  = FX(m0[7], t);
+    s8  = FX(m0[8], t);
+    s9  = FX(m0[9], t);
+    s10 = FX(m0[10], t);
+    s11 = FX(m0[11], t);
+    s3  = FX(m0[3], t);
+    s6  = FX(m0[6], t);
+    s0  = FX(m0[0], t);
+
+    dst[0] += FX(m1[0], s0) + (FX(m1[2], s6) + FX(m1[1], s3));
+    p = PTR(dst, 0xc);
+    *p += FX(m1[3], s0) + (FX(m1[5], s6) + FX(m1[4], s3));
+    p = PTR(dst, 0x18);
+    *p += FX(m1[6], s0) + (FX(m1[8], s6) + FX(m1[7], s3));
+    p = PTR(dst, 0x24);
+    *p += s9 + (FX(m1[9], s0) + (FX(m1[11], s6) + FX(m1[10], s3)));
+    p = PTR(dst, 0x4);
+    *p += FX(m1[0], s1) + (FX(m1[2], s7) + FX(m1[1], s4));
+    p = PTR(dst, 0x10);
+    *p += FX(m1[3], s1) + (FX(m1[5], s7) + FX(m1[4], s4));
+    p = PTR(dst, 0x1c);
+    *p += FX(m1[6], s1) + (FX(m1[8], s7) + FX(m1[7], s4));
+    p = PTR(dst, 0x28);
+    *p += s10 + (FX(m1[9], s1) + (FX(m1[11], s7) + FX(m1[10], s4)));
+    p = PTR(dst, 0x8);
+    *p += FX(m1[0], s2) + (FX(m1[2], s8) + FX(m1[1], s5));
+    p = PTR(dst, 0x14);
+    *p += FX(m1[3], s2) + (FX(m1[5], s8) + FX(m1[4], s5));
+    p = PTR(dst, 0x20);
+    *p += FX(m1[6], s2) + (FX(m1[8], s8) + FX(m1[7], s5));
+    p = PTR(dst, 0x2c);
+    *p += s11 + (FX(m1[9], s2) + (FX(m1[11], s8) + FX(m1[10], s5)));
+}

--- a/src/func_0204c584.c
+++ b/src/func_0204c584.c
@@ -1,0 +1,260 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef signed short s16;
+typedef unsigned int u32;
+typedef int s32;
+typedef long long s64;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+typedef struct Node { struct Node *next; struct Node *prev; } Node;
+typedef struct List { Node *head; int count; } List;
+
+typedef struct Def {
+    u32 mode : 4;      /* bits 0-3 */
+    u32 f4 : 2;        /* 4-5 */
+    u32 sel : 2;       /* 6-7 */
+    u32 f8 : 1;        /* 8 */
+    u32 texanim : 1;   /* 9 */
+    u32 f10 : 1;       /* 10 */
+    u32 colorrand : 1; /* 11 */
+    u32 sizerand : 1;  /* 12 */
+    u32 anglerand : 1; /* 13 */
+    u32 rest : 18;
+    int rate;          /* 0x4 */
+    u8 pad8[0xa];      /* 0x8 */
+    u16 tex;           /* 0x12 */
+    u8 pad14[0x10];    /* 0x14 */
+    s16 lo;            /* 0x24 */
+    s16 hi;            /* 0x26 */
+    u8 pad28[4];       /* 0x28 */
+    u8 b2c;            /* 0x2c */
+    u8 b2d;            /* 0x2d */
+    u8 b2e;            /* 0x2e */
+    u8 pad2f[4];       /* 0x2f */
+    u8 b33;            /* 0x33 */
+    u8 b34;            /* 0x34 */
+} Def;
+
+typedef struct TexAnim {
+    u16 a;             /* 0x0 */
+    u16 b;             /* 0x2 */
+    u8 pad[4];         /* 0x4 */
+    u16 flag : 1;      /* 0x8 bit 0 */
+    u16 frest : 15;
+} TexAnim;
+
+typedef struct Pal {
+    u8 colors[8];      /* 0x0 */
+    u32 cnt : 8;       /* 0x8 bits 0-7 */
+    u32 px : 8;        /* bits 8-15 */
+    u32 loop : 1;      /* bit 16 */
+    u32 prest : 15;
+} Pal;
+
+extern void func_0204cebc(void *c);
+extern Node *func_0204d958(List *list);
+extern void func_0204d9a0(List *list, Node *node);
+extern void func_0204da4c(Vector3 *out);
+extern void func_0204d9f0(Vector3 *out);
+extern void func_0204cd5c(int *out, int *in, int sel, s16 *m);
+extern void NormalizeVec3(Vector3 *src, Vector3 *dst);
+
+extern u32 data_020a4d30;
+extern s16 data_02082214[];
+
+static inline u32 RandVal(void)
+{
+    u32 s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+    data_020a4d30 = s;
+    return s;
+}
+
+static inline int RandScale(void)
+{
+    return (int)(((RandVal() >> 0x17) << 0xc) - 0x100000) >> 8;
+}
+
+static inline int FMul(int a, int b)
+{
+    return (int)(((s64)a * b + 0x800) >> 12);
+}
+
+void func_0204c584(u8 *self, List *list)
+{
+    int i;
+    int count;
+    int mag1;
+    int mag2;
+    int d10;
+    int d14;
+    int d18;
+    int d1c;
+    int d20;
+    int d24;
+    int d28;
+    u16 arr[3];
+    Vector3 vecB;
+    Vector3 vecC;
+    Vector3 vecE;
+    Vector3 nrm;
+    u8 *emitter;
+    Def *def;
+    u8 *p;
+    int acc;
+
+    emitter = *(u8 **)(self + 0x18);
+    def = *(Def **)emitter;
+    acc = def->rate + *(s16 *)(self + 0x3a);
+    *(s16 *)(self + 0x3a) = acc & 0xfff;
+    count = acc >> 0xc;
+    {
+        u32 t = def->mode;
+        if ((t == 2 || t == 3 || t == 5) && def->sel == 3)
+            func_0204cebc(self);
+    }
+    i = 0;
+    if (count <= 0)
+        return;
+    d10 = 0;
+    d18 = 0;
+    d14 = 0;
+    d1c = 0x1000;
+    d20 = i;
+    d24 = i;
+    d28 = i;
+    do {
+        p = (u8 *)func_0204d958(list);
+        if (p == 0)
+            return;
+        func_0204d9a0((List *)(self + 8), (Node *)p);
+        switch (def->mode) {
+        case 0:
+            *(int *)(p + 0x1c) = d14;
+            *(int *)(p + 0x18) = *(int *)(p + 0x1c);
+            *(int *)(p + 0x14) = *(int *)(p + 0x18);
+            break;
+        case 1:
+            func_0204da4c((Vector3 *)(p + 0x14));
+            *(int *)(p + 0x14) = (int)(((s64)*(int *)(p + 0x14) * *(int *)(self + 0x44) + 0x800) >> 12);
+            *(int *)(p + 0x18) = (int)(((s64)*(int *)(p + 0x18) * *(int *)(self + 0x44) + 0x800) >> 12);
+            *(int *)(p + 0x1c) = (int)(((s64)*(int *)(p + 0x1c) * *(int *)(self + 0x44) + 0x800) >> 12);
+            break;
+        case 2:
+            func_0204d9f0(&vecB);
+            vecB.x = (int)(((s64)vecB.x * *(int *)(self + 0x44) + 0x800) >> 12);
+            vecB.y = (int)(((s64)vecB.y * *(int *)(self + 0x44) + 0x800) >> 12);
+            func_0204cd5c((int *)(p + 0x14), (int *)&vecB, def->sel, (s16 *)self);
+            break;
+        case 3: {
+            int q = d10 / count;
+            int idx;
+            s16 c, sn;
+            d10 += 0x10000;
+            idx = (q >> 4) << 1;
+            c = data_02082214[idx];
+            sn = data_02082214[idx + 1];
+            vecC.x = FMul(c, *(int *)(self + 0x44));
+            vecC.y = FMul(sn, *(int *)(self + 0x44));
+            vecC.z = d18;
+            func_0204cd5c((int *)(p + 0x14), (int *)&vecC, def->sel, (s16 *)self);
+            break;
+        }
+        case 4:
+            func_0204da4c((Vector3 *)(p + 0x14));
+            *(int *)(p + 0x14) = FMul(FMul(*(int *)(p + 0x14), *(int *)(self + 0x44)), RandScale());
+            *(int *)(p + 0x18) = FMul(FMul(*(int *)(p + 0x18), *(int *)(self + 0x44)), RandScale());
+            *(int *)(p + 0x1c) = FMul(FMul(*(int *)(p + 0x1c), *(int *)(self + 0x44)), RandScale());
+            break;
+        case 5:
+            func_0204d9f0(&vecE);
+            vecE.x = FMul(FMul(vecE.x, *(int *)(self + 0x44)), RandScale());
+            vecE.y = FMul(FMul(vecE.y, *(int *)(self + 0x44)), RandScale());
+            func_0204cd5c((int *)(p + 0x14), (int *)&vecE, def->sel, (s16 *)self);
+            break;
+        }
+        {
+            u32 s;
+            int b;
+            s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            b = def->b2e;
+            mag1 = (*(int *)(self + 0x48) * ((b + 0xff) - ((b * (int)(s >> 0x18)) >> 7))) >> 8;
+            s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            b = def->b2e;
+            mag2 = (*(int *)(self + 0x4c) * ((b + 0xff) - ((b * (int)(s >> 0x18)) >> 7))) >> 8;
+        }
+        if (*(int *)(p + 0x14) == 0 && *(int *)(p + 0x18) == 0 && *(int *)(p + 0x1c) == 0)
+            func_0204da4c(&nrm);
+        else
+            NormalizeVec3((Vector3 *)(p + 0x14), &nrm);
+        *(int *)(p + 0x20) = (nrm.x * mag1 + *(s16 *)(self + 0x3c) * mag2) >> 0xc;
+        *(int *)(p + 0x24) = (nrm.y * mag1 + *(s16 *)(self + 0x3e) * mag2) >> 0xc;
+        *(int *)(p + 0x28) = (nrm.z * mag1 + *(s16 *)(self + 0x40) * mag2) >> 0xc;
+        *(Vector3 *)(p + 8) = *(Vector3 *)(self + 0x20);
+        {
+            u32 s;
+            int b;
+            s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            b = def->b2c;
+            *(int *)(p + 0x30) = (*(int *)(self + 0x50) * ((b + 0xff) - ((b * (int)(s >> 0x18)) >> 7))) >> 8;
+        }
+        *(u16 *)(p + 0x34) = (u16)d1c;
+        if (def->texanim && (*(TexAnim **)(emitter + 8))->flag) {
+            u32 s;
+            u8 *tex;
+            s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            tex = *(u8 **)(emitter + 8);
+            arr[0] = *(u16 *)tex;
+            arr[1] = def->tex;
+            arr[2] = *(u16 *)(tex + 2);
+            *(u16 *)(p + 0x3a) = arr[(s >> 0x14) % 3u];
+        } else {
+            *(u16 *)(p + 0x3a) = def->tex;
+        }
+        {
+            u16 *q = (u16 *)(((s64)(int)(p + 0x40)) & 0xFFFFFFFFFFFFFFFFLL);
+            *q = (u16)((*q & ~0x1f) | (*(u8 *)(self + 0x59) & 0x1f));
+            *q = (u16)((*q & ~0x3e0) | 0x3e0);
+        }
+        if (def->anglerand) {
+            u32 s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            *(u16 *)(p + 0x36) = (u16)s;
+        } else {
+            *(u16 *)(p + 0x36) = (u16)d20;
+        }
+        if (def->sizerand) {
+            *(u16 *)(p + 0x38) = (u16)((u32)((def->hi - def->lo) * (int)(RandVal() >> 0x14) + (def->lo << 0xc)) >> 0xc);
+        } else {
+            *(u16 *)(p + 0x38) = (u16)d24;
+        }
+        {
+            u32 s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+            data_020a4d30 = s;
+            *(u16 *)(p + 0x2c) = (u16)(((*(u16 *)(self + 0x54) * (0xff - ((def->b2d * (int)(s >> 0x18)) >> 8))) >> 8) + 1);
+        }
+        *(u16 *)(p + 0x2e) = (u16)d28;
+        {
+            u32 b11 = def->colorrand;
+            if (b11 != 0 && ((Pal *)*(u8 **)(emitter + 0x10))->loop) {
+                u32 s;
+                u8 *pal;
+                s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
+                data_020a4d30 = s;
+                pal = *(u8 **)(emitter + 0x10);
+                *(p + 0x42) = pal[(s >> 0x14) % pal[8]];
+            } else if (b11 != 0 && !((Pal *)*(u8 **)(emitter + 0x10))->loop) {
+                *(p + 0x42) = **(u8 **)(emitter + 0x10);
+            } else {
+                *(p + 0x42) = def->b33;
+            }
+        }
+        *(u16 *)(p + 0x3c) = (u16)(0xffff / (*(Def **)emitter)->b34);
+        *(u16 *)(p + 0x3e) = (u16)(0xffff / *(u16 *)(p + 0x2c));
+        i += 1;
+    } while (i < count);
+}

--- a/src/func_ov006_020d14c0.c
+++ b/src/func_ov006_020d14c0.c
@@ -1,0 +1,146 @@
+typedef unsigned char u8;
+
+typedef struct Ctx {
+    u8 pad_0000[0x46d8];
+    int unk46d8;
+    int unk46dc;
+    int unk46e0;
+    int unk46e4;
+    u8 pad_46e8[0x10];
+    int unk46f8;
+    int unk46fc;
+    u8 pad_4700[4];
+    u8 unk4704;
+    u8 unk4705;
+    u8 unk4706;
+    u8 unk4707;
+    u8 unk4708;
+    u8 unk4709;
+    u8 unk470a;
+    u8 pad_470b;
+    u8* unk470c;
+    u8* unk4710;
+} Ctx;
+
+extern void func_ov004_020ae3b4(Ctx* ctx, int y, int x, int arg3, int mode);
+
+void func_ov006_020d14c0(Ctx* ctx, int y, int x, int arg3)
+{
+    u8 f705;
+    u8 f707;
+    int x2;
+
+    if (ctx->unk4708 == 1) {
+        int py;
+        int pym;
+        int pyp;
+        if ((ctx->unk4710 + y * 0x158)[x + 0xc0] >= 3u) {
+            ctx->unk4709 = 1;
+        }
+        py = ctx->unk46f8;
+        if (y != py || x != ctx->unk46fc) {
+            pym = py - 1;
+            if (y == pym && x == ctx->unk46fc - 1) {
+                u8* b = ctx->unk4710;
+                if ((b + (y + 1) * 0x158)[x + 0xc0] >= 3u) {
+                    ctx->unk4709 = 1;
+                } else if ((b + y * 0x158)[x + 0xc1] >= 3u) {
+                    ctx->unk4709 = 1;
+                }
+            } else {
+                pyp = py + 1;
+                if (y == pyp && x == ctx->unk46fc - 1) {
+                    u8* b = ctx->unk4710;
+                    if ((b + (y - 1) * 0x158)[x + 0xc0] >= 3u) {
+                        ctx->unk4709 = 1;
+                    } else if ((b + y * 0x158)[x + 0xc1] >= 3u) {
+                        ctx->unk4709 = 1;
+                    }
+                } else if (y == pym && x == ctx->unk46fc + 1) {
+                    u8* b = ctx->unk4710;
+                    if ((b + (y + 1) * 0x158)[x + 0xc0] >= 3u) {
+                        ctx->unk4709 = 1;
+                    } else if ((b + y * 0x158)[x + 0xbf] >= 3u) {
+                        ctx->unk4709 = 1;
+                    }
+                } else if (y == pyp && x == ctx->unk46fc + 1) {
+                    u8* b = ctx->unk4710;
+                    if ((b + (y - 1) * 0x158)[x + 0xc0] >= 3u) {
+                        ctx->unk4709 = 1;
+                    } else if ((b + y * 0x158)[x + 0xbf] >= 3u) {
+                        ctx->unk4709 = 1;
+                    }
+                }
+            }
+        }
+        ctx->unk46f8 = y;
+        ctx->unk46fc = x;
+        return;
+    }
+
+    if (ctx->unk4706 == 1) {
+        func_ov004_020ae3b4(ctx, y, x, arg3, 4);
+        if (y < 0) return;
+        if (y >= 0x100) return;
+        if (x < -0xc0) return;
+        if (x >= 0x98) return;
+        (ctx->unk4710 + y * 0x158)[x + 0xc0] = ctx->unk470a;
+        return;
+    }
+
+    f705 = ctx->unk4705;
+    if (f705 == 1) {
+        func_ov004_020ae3b4(ctx, y, x, arg3, 2);
+        return;
+    }
+
+    f707 = ctx->unk4707;
+    x2 = x + 0xc0;
+    if (f707 != 0) {
+        func_ov004_020ae3b4(ctx, y, x, arg3, 4);
+        if (y >= 0 && y < 0x100 && x2 >= 0 && x2 < 0x158) {
+            (ctx->unk4710 + y * 0x158)[x2] = ctx->unk470a;
+        }
+    } else {
+        u8 b;
+        if (y < 0 || y >= 0x100 || x2 < 0 || x2 >= 0x158) {
+            func_ov004_020ae3b4(ctx, y, x, arg3, 4);
+            return;
+        }
+        if (y == 0x20 || y == 0x60 || y == 0xa0 || y == 0xe0) {
+            if (ctx->unk4704 == 0) {
+                ctx->unk4704 = 1;
+                ctx->unk46d8 = y;
+                ctx->unk46dc = x;
+                ctx->unk46e0 = y;
+                ctx->unk46e4 = x;
+                return;
+            }
+            if (f705 != 0) return;
+            if (y == ctx->unk46d8) {
+                ctx->unk46e4 = x;
+            } else {
+                ctx->unk4705 = 1;
+                ctx->unk46e0 = y;
+                ctx->unk46e4 = x;
+            }
+            return;
+        }
+        if (ctx->unk4704 == 0) {
+            func_ov004_020ae3b4(ctx, y, x, arg3, 2);
+            return;
+        }
+        b = (ctx->unk470c + y * 0x158)[x2];
+        if (b != 0 && ctx->unk470a != b) goto fail;
+        b = (ctx->unk4710 + y * 0x158)[x2];
+        if (b != 0 && ctx->unk470a != b) {
+        fail:
+            ctx->unk4704 = 0;
+            ctx->unk4705 = 1;
+            return;
+        }
+    }
+
+    func_ov004_020ae3b4(ctx, y, x, arg3, 2);
+    (ctx->unk470c + y * 0x158)[x2] = ctx->unk470a;
+}

--- a/src/func_ov006_0210ef48.c
+++ b/src/func_ov006_0210ef48.c
@@ -1,0 +1,196 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+typedef struct {
+    int f0;          /* 0x00 */
+    void* f4;        /* 0x04 */
+    int f8;          /* 0x08 */
+    int fc;          /* 0x0c */
+    u8 pad10[0x21];  /* 0x10 */
+    u8 cells[9];     /* 0x31 */
+    u8 pad3a[0x32];  /* 0x3a */
+    int lines[8];    /* 0x6c */
+    u8 marks[8];     /* 0x8c */
+    int f94;         /* 0x94 */
+    int f98;         /* 0x98 */
+} S;
+
+extern int data_ov006_02142c1c[];
+extern int data_ov006_0212edfc;
+
+extern int func_ov006_02115598(void* c, int* src, int v2, int v3, int v5);
+extern void func_ov006_02115060(void* p);
+extern void func_ov006_0210eca4(S* c, int i, int* p);
+extern void _ZN5Sound12PlayBank2_2DEj(u32 b);
+extern int func_ov006_02115040(void* base, int i);
+extern void func_ov006_02115024(void* p);
+extern void func_ov006_02114dfc(void* c);
+
+void func_ov006_0210ef48(void* arg, int i)
+{
+    int count;
+    int bingo;
+    int m;
+    int tmp;
+    int slot;
+    S* c;
+    int v;
+    int a[2];
+    int b[2];
+    int d[2];
+    int e[2];
+
+    c = (S*)arg;
+    slot = data_ov006_02142c1c[i];
+    if (c->cells[slot] == 1)
+        return;
+    c->cells[slot] = 1;
+    v = i * 0x18000 + 0x10000;
+    a[0] = v;
+    a[1] = 0x78000;
+    func_ov006_02115598(c->f4, a, 0x64, 0, 1);
+    func_ov006_02115060(c->f4);
+    b[0] = v;
+    b[1] = 0x78000;
+    func_ov006_0210eca4(c, i, b);
+    _ZN5Sound12PlayBank2_2DEj(0x173);
+    count = 0;
+    if (slot < 3) {
+        if (c->cells[slot + 3] == 1 && c->cells[slot + 6] == 1) {
+            c->lines[slot] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    } else if (slot < 6) {
+        if (c->cells[slot - 3] == 1 && c->cells[slot + 3] == 1) {
+            c->lines[slot - 3] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot - 3] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    } else {
+        if (c->cells[slot - 6] == 1 && c->cells[slot - 3] == 1) {
+            c->lines[slot - 6] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot - 6] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    }
+    i = slot % 3;
+    if (i == 0) {
+        if (c->cells[slot + 1] == 1 && c->cells[slot + 2] == 1) {
+            c->lines[slot / 3 + 3] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot / 3 + 3] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    } else if (i == 1) {
+        if (c->cells[slot - 1] == 1 && c->cells[slot + 1] == 1) {
+            c->lines[slot / 3 + 3] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot / 3 + 3] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    } else {
+        if (c->cells[slot - 2] == 1 && c->cells[slot - 1] == 1) {
+            c->lines[slot / 3 + 3] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[slot / 3 + 3] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+    }
+    switch (slot) {
+    case 0:
+        if (c->cells[4] == 1 && c->cells[8] == 1) {
+            c->lines[6] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[6] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    case 2:
+        if (c->cells[4] == 1 && c->cells[6] == 1) {
+            c->lines[7] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[7] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    case 4:
+        if (c->cells[0] == 1 && c->cells[8] == 1) {
+            c->lines[6] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[6] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        if (c->cells[2] == 1 && c->cells[6] == 1) {
+            c->lines[7] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[7] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    case 6:
+        if (c->cells[2] == 1 && c->cells[4] == 1) {
+            c->lines[7] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[7] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    case 8:
+        if (c->cells[0] == 1 && c->cells[4] == 1) {
+            c->lines[6] = 0x21d;
+            c->f94 = 0xb5;
+            c->marks[6] = 1;
+            count += 1;
+            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+        }
+        break;
+    }
+    bingo = 1;
+    {
+    int j;
+    for (j = 0; j < 9; j++) {
+        if (j == slot)
+            continue;
+        if (c->cells[j] == 0) {
+            bingo = 0;
+            break;
+        }
+    }
+    }
+    if (count <= 0)
+        return;
+    m = 0;
+    if (count > 0) {
+        tmp = data_ov006_0212edfc;
+        do {
+            d[0] = c->f8;
+            d[1] = c->fc;
+            func_ov006_02115598(c->f4, d, tmp, 0, 1);
+            func_ov006_02115040(c->f4, 1);
+            m++;
+        } while (m < count);
+    }
+    if (bingo != 1)
+        return;
+    e[0] = c->f8;
+    e[1] = c->fc;
+    func_ov006_02115598(c->f4, e, 0x2710, 0x3c, 1);
+    func_ov006_02115024(c->f4);
+    func_ov006_02114dfc(c->f4);
+    _ZN5Sound12PlayBank2_2DEj(0x174);
+}

--- a/src/func_ov006_02118488.c
+++ b/src/func_ov006_02118488.c
@@ -1,0 +1,197 @@
+#pragma opt_strength_reduction off
+typedef void (*VFunc)(void*);
+
+extern void func_ov006_02115480(char* c);
+extern void func_ov006_02115150(char* c);
+extern void func_ov006_02115a5c(char* c);
+extern int func_ov006_021156f8(char* c);
+extern int func_ov006_02111d74(char* c);
+extern void func_ov004_020ae20c(void);
+extern void func_ov004_020b0aa0(int a);
+extern int func_ov006_02111dcc(char* p, int val);
+extern void func_ov006_02111e48(char* o);
+extern void func_ov006_0211470c(int* a, char* b);
+extern void func_ov006_02115598(char* c, int* src, int v2, int v3, int v5);
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int s);
+extern void func_ov006_02114f98(char* self);
+extern void func_ov004_020b0a54(int a);
+extern unsigned int func_02012790(unsigned int a);
+extern void func_ov006_02114c04(char* c);
+
+extern unsigned char data_0209d454;
+extern unsigned char data_020a0e40;
+extern unsigned char data_020a0de8[];
+extern unsigned char data_020a0de9[];
+extern int func_020bc888;
+extern int func_020bc864;
+
+int func_ov006_02118488(void* arg)
+{
+    char* c = (char*)arg;
+    int vec[3];
+
+    if (*(unsigned char*)(c + 0xc4) == 0) {
+        c[0xc3] = 1;
+        c[0xc4] = 1;
+        *(short*)(c + 0xc0) = 0;
+    }
+
+    switch (*(int*)(c + 0x4660)) {
+    case 0:
+        {
+            char* o;
+            int i;
+
+            o = *(char**)(c + 0x4684);
+            (**(VFunc**)o)(o);
+
+            for (i = 0; i < *(int*)(c + 0x4668); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x4670); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x466c); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4720)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x4674); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4740)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x4678); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x474c)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x467c); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4764)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+            for (i = 0; i < *(int*)(c + 0x4680); i++) {
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4770)) & 0xFFFFFFFFFFFFFFFFLL);
+                (**(VFunc**)o)(o);
+            }
+
+            o = *(char**)(c + 0x4778);
+            if (o != 0) {
+                (**(VFunc**)o)(o);
+            }
+            o = *(char**)(c + 0x477c);
+            if (o != 0) {
+                (**(VFunc**)o)(o);
+            }
+            o = *(char**)(c + 0x4780);
+            if (o != 0) {
+                (**(VFunc**)o)(o);
+            }
+
+            func_ov006_02115480(c);
+            func_ov006_02115150(c);
+            func_ov006_02115a5c(c);
+
+            if (func_ov006_021156f8(c) != 0) {
+                if (*(int*)(c + 0x5954) >= 0x3c) {
+                    *(int*)(c + 0x4660) = 1;
+                } else {
+                    int* p = (int*)(((int)c + 0x5954) & 0xFFFFFFFFFFFFFFFF);
+                    (*p)++;
+                }
+            } else {
+                int cur;
+                int next;
+                *(int*)(c + 0x5954) = 0;
+                cur = *(int*)(c + 0x4664);
+                next = cur + 1;
+                if (next >= *(int*)(c + 0x4668)) {
+                    next = 0;
+                }
+                if (func_ov006_02111d74(((char**)(c + 0x4688))[cur]) != 0) {
+                    *(int*)(c + 0x4664) = next;
+                }
+            }
+
+            if (*(unsigned char*)(c + 0x595c) != 0) {
+                int t;
+                {
+                    int* p = (int*)(((int)c + 0x5958) & 0xFFFFFFFFFFFFFFFF);
+                    (*p)++;
+                }
+                if (*(int*)(c + 0x5958) == 0xb4) {
+                    func_ov004_020ae20c();
+                    func_ov004_020b0aa0(0x1d);
+                }
+                t = *(int*)(c + 0x5958);
+                if (t >= 0xb4 && t % 0x1e == 0) {
+                    int found = 0;
+                    for (i = 0; i < *(int*)(c + 0x4668); i++) {
+                        o = (i >= 13) ? 0 : ((char**)(c + 0x4688))[i];
+                        if (*(unsigned char*)(o + 0x30) != 0
+                            && func_ov006_02111dcc((i >= 13) ? 0 : ((char**)(c + 0x4688))[i], 1) != 0) {
+                            func_ov006_02111e48((i >= 13) ? 0 : ((char**)(c + 0x4688))[i]);
+                            func_ov006_0211470c(vec, (i >= 13) ? 0 : ((char**)(c + 0x4688))[i]);
+                            func_ov006_02115598(c, vec, 0x7d0, 0, 1);
+                            _ZN5Sound12PlayBank2_2DEj(0x175);
+                            func_ov006_02114f98(c);
+                            found = 1;
+                            break;
+                        }
+                    }
+                    if (found == 0) {
+                        *(int*)(c + 0x5958) = 0;
+                        *(unsigned char*)(c + 0x595c) = 0;
+                    }
+                }
+            }
+        }
+        break;
+    case 1:
+        func_ov006_02115480(c);
+        c[0xc3] = 0;
+        if (*(int*)(c + 0x5960) == 0) {
+            data_0209d454 |= 1;
+        }
+        if (*(int*)(c + 0x5998) > 0) {
+            int* p = (int*)(((int)c + 0x5998) & 0xFFFFFFFFFFFFFFFF);
+            *p -= 4;
+        } else {
+            int flag = 0;
+            *(int*)(c + 0x5998) = 0;
+            if (*(int*)(c + 0x5960) < 0x12c) {
+                int* p = (int*)(((int)c + 0x5960) & 0xFFFFFFFFFFFFFFFF);
+                (*p)++;
+            } else {
+                int idx = data_020a0e40;
+                if (data_020a0de8[idx * 4] != 0 && data_020a0de9[idx * 4] != 0) {
+                    flag = 1;
+                }
+                if (flag != 0) {
+                    if ((*(int*)(c + 8) & 0xff) == 0) {
+                        func_020bc888 = 0x80;
+                        func_020bc864 = -0x30;
+                    }
+                    func_ov004_020b0a54(0x10);
+                    *(int*)(c + 0x4660) = 2;
+                    func_02012790(0x62);
+                }
+            }
+        }
+        break;
+    case 2:
+        func_ov006_02115480(c);
+        break;
+    }
+
+    if (*(int*)(c + 0x4784) > 0) {
+        int* p = (int*)(((int)c + 0x4784) & 0xFFFFFFFFFFFFFFFF);
+        (*p)--;
+    }
+    if (*(int*)(c + 0x4788) > 0) {
+        int* p = (int*)(((int)c + 0x4788) & 0xFFFFFFFFFFFFFFFF);
+        (*p)--;
+    }
+
+    func_ov006_02114c04(c);
+    return 1;
+}


### PR DESCRIPTION
Salvaged from a background Fable-high fan-out over the 0x400-0x800 low-similarity logic band. The workflow's agents completed but the run lost its completion record across a session boundary; the 6 verified matches were recovered from the workflow journal and re-verified byte-exact via the link gate (`linkcheck.py`).

All 6 are `divergences: 0`, link-gate VERIFIED:

| function | module | levers |
|---|---|---|
| `_ZN12CylinderClsn7ProcessEv` | arm9 | u64-mask laundering on both hitFlags RMWs, `(r<<1)+r` for `r*3` |
| `func_02047218` | arm9 | 4x3 fx-matrix concat-accumulate, right-nested sums, u64-laundered row ptrs |
| `func_0204c584` | arm9 | 0x7d8 particle emitter, bitfield flag reads, decl-order spill control |
| `func_ov006_020d14c0` | ov006 | row-pointer grid grouping `(base+y*0x158)[x+col]` + py-1/py+1 CSE locals |
| `func_ov006_0210ef48` | ov006 | u64-laundered `(c+0x98)++` RMWs, count-first local coloring |
| `func_ov006_02118488` | ov006 | pooled-0x4688 reg-offset vtable dispatch, strength-reduction off |

🤖 Generated with [Claude Code](https://claude.com/claude-code)