### PR TITLE
Match 5 functions via Fable fan-out (0x400-0x800 low-sim logic)

### DIFF
--- a/src/_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh.c
+++ b/src/_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh.c
@@ -1,0 +1,95 @@
+typedef unsigned char u8;
+typedef int s32;
+typedef long long s64;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+typedef struct Clipper {
+    void* vtable;       /* 0x00 */
+    Vector3 planes[4];  /* 0x04 */
+    int unk34[7];       /* 0x34 */
+    int minZ;           /* 0x50 */
+    int maxZ;           /* 0x54 */
+} Clipper;
+
+#pragma opt_propagation off
+int _ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh(Clipper* thiz, Vector3* v, int clip, u8* hint)
+{
+    if (hint != 0)
+    {
+        unsigned int first;
+        s64 y;
+        s64 x;
+        s64 z;
+        s64 c;
+        int negZ;
+        int one;
+        int zero;
+        s64 dot;
+        int outside;
+        unsigned int i;
+        int ok;
+        s64 d;
+
+        negZ = -v->z;
+        if (negZ < thiz->minZ - clip) goto fail1;
+        if (negZ > thiz->maxZ + clip) goto fail1;
+
+        first = *hint & 3;
+        x = v->x;
+        c = clip;
+        dot = ((s64)v->x * thiz->planes[first].x + (s64)v->y * thiz->planes[first].y + (s64)v->z * thiz->planes[first].z + 0x800) >> 12;
+        outside = 0;
+        if (c < dot) outside = 1;
+        if (outside == 0)
+        {
+            i = (first + 1) & 3;
+            y = (s32)*(unsigned int*)&v->y;
+            z = (s32)*(unsigned int*)&v->z;
+            zero = 0;
+            one = 1;
+            do {
+                d = (z * thiz->planes[i].z + (x * thiz->planes[i].x + y * thiz->planes[i].y) + 0x800) >> 12;
+                ok = d <= c ? one : zero;
+                if (ok == 0) goto failstore;
+                i = (i + 1) & 3;
+            } while (i != first);
+            return negZ;
+        failstore:
+            *hint = (u8)i;
+        }
+    fail1:
+        return 0x7FFFFFFF;
+    }
+    else
+    {
+        int negZ;
+
+        negZ = -v->z;
+        if (negZ < thiz->minZ - clip) goto fail2;
+        if (negZ > thiz->maxZ + clip) goto fail2;
+
+        if ((s32)(((s64)v->z * thiz->planes[0].z + 0x800) >> 12)
+            + ((s32)(((s64)v->x * thiz->planes[0].x + 0x800) >> 12)
+             + (s32)(((s64)v->y * thiz->planes[0].y + 0x800) >> 12)) > clip)
+            goto fail2;
+
+        {
+            s64 x = v->x, y = v->y, z = v->z;
+            if ((s32)((z * thiz->planes[1].z + 0x800) >> 12)
+                + ((s32)((x * thiz->planes[1].x + 0x800) >> 12)
+                 + (s32)((y * thiz->planes[1].y + 0x800) >> 12)) > clip)
+                goto fail2;
+            if ((s32)((z * thiz->planes[2].z + 0x800) >> 12)
+                + ((s32)((x * thiz->planes[2].x + 0x800) >> 12)
+                 + (s32)((y * thiz->planes[2].y + 0x800) >> 12)) > clip)
+                goto fail2;
+            if ((s32)((z * thiz->planes[3].z + 0x800) >> 12)
+                + ((s32)((x * thiz->planes[3].x + 0x800) >> 12)
+                 + (s32)((y * thiz->planes[3].y + 0x800) >> 12)) <= clip)
+                return negZ;
+        }
+    fail2:
+        return 0x7FFFFFFF;
+    }
+}

--- a/src/func_0206fd6c.c
+++ b/src/func_0206fd6c.c
@@ -1,0 +1,257 @@
+/* func_0206fd6c @ 0x0206fd6c (arm9, size 0x5dc)
+ * MSL printf helper parse_format: parses a %-conversion specification
+ * (flags, field width, precision, length modifier, conversion char)
+ * into a print_format struct. Returns pointer past the specifier.
+ */
+typedef struct {
+    unsigned char justification_options;
+    unsigned char sign_options;
+    unsigned char precision_specified;
+    unsigned char alternate_form;
+    unsigned char argument_options;
+    unsigned char conversion_char;
+    char fill_char;
+    char pad7;
+    int field_width;
+    int precision;
+} print_format;
+
+enum { only_minus = 0, sign_always = 1, space_holder = 2 };
+enum { left_justification = 0, right_justification = 1, zero_fill = 2 };
+enum {
+    normal_argument = 0,
+    char_argument,
+    short_argument,
+    long_argument,
+    intmax_argument,
+    size_t_argument,
+    ptrdiff_argument,
+    long_long_argument,
+    long_double_argument,
+    wchar_argument
+};
+
+extern unsigned short data_02086a58[];
+
+#define isdigit_(c) ((c) < 0 || (c) >= 0x80 ? 0 : data_02086a58[c] & 8)
+
+unsigned char *func_0206fd6c(unsigned char *format_string, char **arg, print_format *format)
+{
+    print_format f;
+    unsigned char *s = format_string;
+    int c;
+    int flag_found;
+
+    f.justification_options = right_justification;
+    f.sign_options          = only_minus;
+    f.precision_specified   = 0;
+    f.alternate_form        = 0;
+    f.argument_options      = normal_argument;
+    f.field_width           = 0;
+    f.precision             = 0;
+
+    s = (unsigned char *)(((long long)(int)(format_string + 1)) & 0xFFFFFFFFFFFFFFFFLL);
+    if ((c = *s) == '%') {
+        f.conversion_char = (unsigned char)c;
+        *format = f;
+        return s + 1;
+    }
+
+    do {
+        flag_found = 1;
+
+        switch (c) {
+        case '-':
+            f.justification_options = left_justification;
+            break;
+        case '+':
+            f.sign_options = sign_always;
+            break;
+        case ' ':
+            if (f.sign_options != sign_always)
+                f.sign_options = space_holder;
+            break;
+        case '#':
+            f.alternate_form = 1;
+            break;
+        case '0':
+            if (f.justification_options != left_justification)
+                f.justification_options = zero_fill;
+            break;
+        default:
+            flag_found = 0;
+            break;
+        }
+
+    } while (flag_found && (c = *++s, 1));
+
+    if (c == '*') {
+        *arg += 4;
+        if ((f.field_width = *(int *)(*arg - 4)) < 0) {
+            f.justification_options = left_justification;
+            f.field_width = -f.field_width;
+        }
+        c = *++s;
+    } else {
+        while (isdigit_(c)) {
+            f.field_width = (f.field_width * 10) + (c - '0');
+            c = *++s;
+        }
+    }
+
+    if (f.field_width > 509) {
+        f.conversion_char = 0xFF;
+        *format = f;
+        return s + 1;
+    }
+
+    if (c == '.') {
+        f.precision_specified = 1;
+
+        c = *++s;
+
+        if (c == '*') {
+            *arg += 4;
+            if ((f.precision = *(int *)(*arg - 4)) < 0)
+                f.precision_specified = 0;
+            c = *++s;
+        } else {
+            while (isdigit_(c)) {
+                f.precision = (f.precision * 10) + (c - '0');
+                c = *++s;
+            }
+        }
+    }
+
+    flag_found = 1;
+
+    switch (c) {
+    case 'h':
+        f.argument_options = short_argument;
+        if (*(s + 1) == 'h') {
+            f.argument_options = char_argument;
+            c = *++s;
+        }
+        break;
+    case 'l':
+        f.argument_options = long_argument;
+        if (*(s + 1) == 'l') {
+            f.argument_options = long_long_argument;
+            c = *++s;
+        }
+        break;
+    case 'L':
+        f.argument_options = long_double_argument;
+        break;
+    case 'j':
+        f.argument_options = intmax_argument;
+        break;
+    case 'z':
+        f.argument_options = size_t_argument;
+        break;
+    case 't':
+        f.argument_options = ptrdiff_argument;
+        break;
+    default:
+        flag_found = 0;
+        break;
+    }
+
+    if (flag_found)
+        c = *++s;
+
+    f.conversion_char = (unsigned char)c;
+
+    switch (c) {
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X':
+        if (f.argument_options == long_double_argument) {
+            f.conversion_char = 0xFF;
+            break;
+        }
+        if (!f.precision_specified)
+            f.precision = 1;
+        else if (f.justification_options == zero_fill)
+            f.justification_options = right_justification;
+        break;
+
+    case 'f':
+    case 'F':
+        if (f.argument_options == short_argument ||
+            (unsigned char)(f.argument_options + 0xFC) <=
+                (unsigned char)(long_long_argument - intmax_argument)) {
+            f.conversion_char = 0xFF;
+            break;
+        }
+        if (!f.precision_specified)
+            f.precision = 6;
+        break;
+
+    case 'a':
+    case 'A':
+        if (!f.precision_specified)
+            f.precision = 13;
+        if (f.argument_options == short_argument ||
+            f.argument_options == intmax_argument ||
+            f.argument_options == size_t_argument ||
+            f.argument_options == ptrdiff_argument ||
+            f.argument_options == long_long_argument ||
+            f.argument_options == char_argument)
+            f.conversion_char = 0xFF;
+        break;
+
+    case 'g':
+    case 'G':
+        if (f.precision == 0)
+            f.precision = 1;
+    case 'e':
+    case 'E':
+        if (f.argument_options == short_argument ||
+            f.argument_options == intmax_argument ||
+            f.argument_options == size_t_argument ||
+            f.argument_options == ptrdiff_argument ||
+            f.argument_options == long_long_argument ||
+            f.argument_options == char_argument)
+            f.conversion_char = 0xFF;
+        else if (!f.precision_specified)
+            f.precision = 6;
+        break;
+
+    case 'p':
+        f.conversion_char = 'x';
+        f.alternate_form = 1;
+        f.argument_options = long_argument;
+        f.precision = 8;
+        break;
+
+    case 'c':
+        if (f.argument_options == long_argument)
+            f.argument_options = wchar_argument;
+        else if (f.precision_specified || f.argument_options != normal_argument)
+            f.conversion_char = 0xFF;
+        break;
+
+    case 's':
+        if (f.argument_options == long_argument)
+            f.argument_options = wchar_argument;
+        else if (f.argument_options != normal_argument)
+            f.conversion_char = 0xFF;
+        break;
+
+    case 'n':
+        if (f.argument_options == long_double_argument)
+            f.conversion_char = 0xFF;
+        break;
+
+    default:
+        f.conversion_char = 0xFF;
+        break;
+    }
+
+    *format = f;
+    return s + 1;
+}

--- a/src/func_ov006_020d6e8c.c
+++ b/src/func_ov006_020d6e8c.c
@@ -1,0 +1,161 @@
+typedef signed short s16;
+typedef unsigned short u16;
+typedef long long s64;
+typedef unsigned long long u64;
+
+extern s16 data_02082214[];
+
+extern s64 _ZN4cstd4sqrtEy(u64 x);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
+
+#pragma opt_common_subs off
+void func_ov006_020d6e8c(char* self, int idx)
+{
+    int x, y, py, dx, dy1, ang, i2, a, dy2, sy, px;
+
+    x = *(int*)(self + (idx << 6) + 0x4660) >> 12;
+    y = *(int*)(self + (idx << 6) + 0x4664) >> 12;
+
+    if (x + 12 > 0x100) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4660) = 0xF4000;
+    } else if (x - 12 < 0) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4660) = 0xC000;
+    }
+
+    if (y + 12 > 0xB8) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4664) = 0xAC000;
+    } else if (y - 12 < 0) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4664) = 0xC000;
+    }
+
+    px = *(int*)(self + (idx << 6) + 0x4660) >> 12;
+    py = *(int*)(self + (idx << 6) + 0x4664) >> 12;
+
+    if (px + 12 > 0xC0 && py + 12 > 0x40 && py - 12 < 0x80) {
+        dx = px - 0xC0;
+        dy1 = py - 0x40;
+        dy2 = 0x80 - py;
+        if (px <= 0xC0 && py >= 0x40 && py <= 0x80) {
+            *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+            *(int*)(self + (idx << 6) + 0x4660) = 0xB4000;
+        } else if (px > 0xC0 && py < 0x40) {
+            *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+            *(int*)(self + (idx << 6) + 0x4664) = 0x34000;
+        } else if (px > 0xC0 && py > 0x80) {
+            *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+            *(int*)(self + (idx << 6) + 0x4664) = 0x8C000;
+        } else if (px > 0xC0 && py > 0x40 && py < 0x80) {
+            if (dy1 < dy2) {
+                if (dx < dy1) {
+                    *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+                    *(int*)(self + (idx << 6) + 0x4660) = 0xB4000;
+                } else {
+                    *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+                    *(int*)(self + (idx << 6) + 0x4664) = 0x34000;
+                }
+            } else {
+                if (dx < dy2) {
+                    *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+                    *(int*)(self + (idx << 6) + 0x4660) = 0xB4000;
+                } else {
+                    *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+                    *(int*)(self + (idx << 6) + 0x4664) = 0x8C000;
+                }
+            }
+        } else {
+            if (py >= 0x60) {
+                sy = 0xC0 - px;
+            } else {
+                dy2 = 0x40 - py;
+                sy = 0xC0 - px;
+            }
+            _ZN4cstd4sqrtEy((s64)(sy * sy + dy2 * dy2));
+            ang = (u16)_ZN4cstd5atan2E5Fix12IiES1_(dy2, sy);
+            i2 = (ang >> 4) * 2;
+            *(int*)(self + (idx << 6) + 0x4660) =
+                (0xC0 - (int)(((s64)data_02082214[i2 + 1] * 0xF + 0x800) >> 12)) << 12;
+            if (py >= 0x60) {
+                *(int*)(self + (idx << 6) + 0x4664) =
+                    (0x80 - (int)(((s64)data_02082214[i2] * 0xF + 0x800) >> 12)) << 12;
+            } else {
+                *(int*)(self + (idx << 6) + 0x4664) =
+                    (0x40 - (int)(((s64)data_02082214[i2] * 0xF + 0x800) >> 12)) << 12;
+            }
+            a = *(u16*)(self + (idx << 6) + 0x468c);
+            if (data_02082214[(a >> 4) * 2 + 1] > 0) {
+                *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - a;
+            } else {
+                *(u16*)(self + (idx << 6) + 0x468c) = 0 - a;
+            }
+        }
+    }
+
+    if (px - 12 >= 0x40) return;
+    if (py + 12 <= 0x40) return;
+    if (py - 12 >= 0x80) return;
+
+    dy2 = 0x40 - px;
+    dy1 = py - 0x40;
+    sy = 0x80 - py;
+    if (px >= 0x40 && py >= 0x40 && py <= 0x80) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4660) = 0x4C000;
+        return;
+    }
+    if (px < 0x40 && py < 0x40) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4664) = 0x34000;
+        return;
+    }
+    if (px < 0x40 && py > 0x80) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4664) = 0x8C000;
+        return;
+    }
+    if (px < 0x40 && py > 0x40 && py < 0x80) {
+        if (dy1 < sy) {
+            if (dy2 < dy1) {
+                *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+                *(int*)(self + (idx << 6) + 0x4660) = 0x4C000;
+                return;
+            }
+            *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+            *(int*)(self + (idx << 6) + 0x4664) = 0x34000;
+            return;
+        }
+        if (dy2 < sy) {
+            *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - *(u16*)(self + (idx << 6) + 0x468c);
+            *(int*)(self + (idx << 6) + 0x4660) = 0x4C000;
+            return;
+        }
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - *(u16*)(self + (idx << 6) + 0x468c);
+        *(int*)(self + (idx << 6) + 0x4664) = 0x8C000;
+        return;
+    }
+
+    if (py < 0x60) {
+        sy = 0x40 - py;
+    }
+    _ZN4cstd4sqrtEy((s64)(dy2 * dy2 + sy * sy));
+    ang = (u16)_ZN4cstd5atan2E5Fix12IiES1_(sy, dy2);
+    i2 = (ang >> 4) * 2;
+    *(int*)(self + (idx << 6) + 0x4660) =
+        (0x40 - (int)(((s64)data_02082214[i2 + 1] * 0xF + 0x800) >> 12)) << 12;
+    if (py >= 0x60) {
+        *(int*)(self + (idx << 6) + 0x4664) =
+            (0x80 - (int)(((s64)data_02082214[i2] * 0xF + 0x800) >> 12)) << 12;
+    } else {
+        *(int*)(self + (idx << 6) + 0x4664) =
+            (0x40 - (int)(((s64)data_02082214[i2] * 0xF + 0x800) >> 12)) << 12;
+    }
+    a = *(u16*)(self + (idx << 6) + 0x468c);
+    if (data_02082214[(a >> 4) * 2 + 1] < 0) {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0x8000 - a;
+    } else {
+        *(u16*)(self + (idx << 6) + 0x468c) = 0 - a;
+    }
+}

--- a/src/func_ov006_020df5b8.c
+++ b/src/func_ov006_020df5b8.c
@@ -1,0 +1,180 @@
+#pragma opt_common_subs off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef signed char s8;
+typedef short s16;
+typedef unsigned int u32;
+
+extern int func_02012468(int a, int b, int c, int d, int e, int f, int g, short h);
+extern void func_ov006_020deaf0(char* p, int key, int a, int b);
+extern int RandomIntInternal(int* seed);
+extern int func_ov006_020deb48(char *c, int a, int b, int d, signed char e);
+
+extern short data_02082214[];
+extern int data_0209e650;
+extern signed char data_ov006_0213c084[];
+extern signed char data_ov006_0213c085[];
+
+void func_ov006_020df5b8(char *c)
+{
+    int ox, oy;
+
+    {
+        int v = *(s16*)(c + 0x545e);
+        int amp;
+        if (v < 0) v = -v;
+        amp = (v * 0x1f4) / 0x1000;
+        if (amp >= 0x1f4) amp = 0x1f4;
+        *(int*)(c + 0x5458) = func_02012468(*(int*)(c + 0x5458), 2, 0x1cb, 2, 0, amp, 0, 0);
+    }
+
+    *(u16*)(((long long)(int)(c + 0x545c)) & 0xFFFFFFFFFFFFFFFFLL) += *(s16*)(c + 0x545e);
+
+    {
+        s16 vv = *(s16*)(c + 0x545e);
+        if ((vv >= 0 && *(u16*)(c + 0x545c) >= 0x8000u) ||
+            (vv < 0 && *(u16*)(c + 0x545c) <= 0x8000u)) {
+            *(u16*)(c + 0x545c) = 0x8000;
+        }
+    }
+
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+        int sv = data_02082214[(*(u16*)(c + 0x545c) >> 4) * 2 + 1];
+        ox = *(int*)(c + slot * 8 + 0x53e8);
+        oy = *(int*)(c + slot * 8 + 0x53ec);
+        *(int*)(c + slot * 8 + 0x53e8) = *(int*)(c + 0x5400)
+            - (int)(((long long)sv * *(int*)(c + 0x5408) + 0x800) >> 12);
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+        *(int*)(c + slot * 8 + 0x53ec) = *(int*)(c + 0x5404)
+            - (int)((data_02082214[(*(u16*)(c + 0x545c) >> 4) * 2] * 0x14000LL + 0x800) >> 12);
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+        *(int*)(c + slot * 4 + 0x540c) = ((*(int*)(c + slot * 8 + 0x53ec) - *(int*)(c + 0x5404)) >> 7) + 0x1000;
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+        func_ov006_020deaf0(c + 0x50e8, (u8)(s8)slot,
+            *(int*)(c + slot * 8 + 0x53e8) - ox,
+            *(int*)(c + slot * 8 + 0x53ec) - oy);
+    }
+
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+        int sv = data_02082214[(*(u16*)(c + 0x545c) >> 4) * 2 + 1];
+        ox = *(int*)(c + slot * 8 + 0x53e8);
+        oy = *(int*)(c + slot * 8 + 0x53ec);
+        *(int*)(c + slot * 8 + 0x53e8) = *(int*)(c + 0x5400)
+            + (int)(((long long)sv * *(int*)(c + 0x5408) + 0x800) >> 12);
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+        *(int*)(c + slot * 8 + 0x53ec) = *(int*)(c + 0x5404)
+            + (int)((data_02082214[(*(u16*)(c + 0x545c) >> 4) * 2] * 0x14000LL + 0x800) >> 12);
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+        *(int*)(c + slot * 4 + 0x540c) = ((*(int*)(c + slot * 8 + 0x53ec) - *(int*)(c + 0x5404)) >> 7) + 0x1000;
+    }
+    {
+        int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+        func_ov006_020deaf0(c + 0x50e8, (u8)(s8)slot,
+            *(int*)(c + slot * 8 + 0x53e8) - ox,
+            *(int*)(c + slot * 8 + 0x53ec) - oy);
+    }
+
+    {
+        u16 uu = *(u16*)(c + 0x545c);
+        if (uu == 0x8000) {
+            int tb = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+            int ta = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+            *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420) = tb;
+            *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420) = ta;
+            *(u8*)(((long long)(int)(c + 0x5460)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            if (*(u8*)(c + 0x5460) == 0) {
+                *(int*)(c + 0x541c) = 0x1e;
+                *(int*)(c + 0x5418) = 3;
+            } else {
+                u32 r = RandomIntInternal(&data_0209e650);
+                *(int*)(c + 0x541c) = (r >> 8) % 0x18 + 1;
+                *(int*)(c + 0x5418) = 1;
+            }
+        } else if (*(u8*)(c + 0x546a) != 0) {
+            s16 vv = *(s16*)(c + 0x545e);
+            if ((vv >= 0 && uu >= 0x5555u) || (vv < 0 && uu <= 0xaaabu)) {
+                *(s16*)(c + 0x545e) = -vv;
+                *(u16*)(c + 0x545c) += 0x8000;
+                {
+                    int tb = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+                    int ta = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+                    *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420) = tb;
+                    *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420) = ta;
+                }
+                *(u8*)(c + 0x546a) = 0;
+            }
+        }
+    }
+
+    if (*(u8*)(c + 0x546b) != 0) {
+        int cnt = *(int*)(c + 0x541c);
+        if ((cnt & 3) == 0) {
+            int i;
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+                i = (cnt >> 2) & 7;
+                func_ov006_020deb48(c + 0x50e8, 2,
+                    *(int*)(c + slot * 8 + 0x53e8) + (data_ov006_0213c084[i * 2] << 12),
+                    *(int*)(c + slot * 8 + 0x53ec) + (data_ov006_0213c085[i * 2] << 12),
+                    slot);
+            }
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+                func_ov006_020deb48(c + 0x50e8, 2,
+                    *(int*)(c + slot * 8 + 0x53e8) + (data_ov006_0213c084[i * 2] << 12),
+                    *(int*)(c + slot * 8 + 0x53ec) + (data_ov006_0213c085[i * 2] << 12),
+                    slot);
+            }
+        }
+    } else {
+        int cnt = *(int*)(c + 0x541c);
+        if (cnt & 1) {
+            int i;
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+                i = (cnt >> 1) & 7;
+                func_ov006_020deb48(c + 0x50e8, 1,
+                    *(int*)(c + slot * 8 + 0x53e8) + (data_ov006_0213c084[i * 2] << 12),
+                    *(int*)(c + slot * 8 + 0x53ec) + (data_ov006_0213c085[i * 2] << 12),
+                    slot);
+            }
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+                func_ov006_020deb48(c + 0x50e8, 1,
+                    *(int*)(c + slot * 8 + 0x53e8) + (data_ov006_0213c084[i * 2] << 12),
+                    *(int*)(c + slot * 8 + 0x53ec) + (data_ov006_0213c085[i * 2] << 12),
+                    slot);
+            }
+        }
+        if ((*(int*)(c + 0x541c) & 3) == 0) {
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
+                func_ov006_020deb48(c + 0x50e8, 0,
+                    *(int*)(c + slot * 8 + 0x53e8) - 0xe000,
+                    *(int*)(c + slot * 8 + 0x53ec) + 0x1c000,
+                    slot);
+            }
+            {
+                int slot = *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420);
+                func_ov006_020deb48(c + 0x50e8, 0,
+                    *(int*)(c + slot * 8 + 0x53e8) - 0xe000,
+                    *(int*)(c + slot * 8 + 0x53ec) + 0x1c000,
+                    slot);
+            }
+        }
+    }
+
+    *(int*)(((long long)(int)(c + 0x541c)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+}

--- a/src/func_ov006_02108650.c
+++ b/src/func_ov006_02108650.c
@@ -1,0 +1,96 @@
+extern int data_ov006_0212ed4c[];
+extern int data_ov006_0212ed68[];
+
+int func_ov006_02108650(int x, int y)
+{
+    int r = 0x25;
+
+    if (x > data_ov006_0212ed4c[0] && x <= data_ov006_0212ed4c[1]) {
+        if (y > 0x10 && y <= 0x60) {
+            r = 0x23;
+        } else if (y > 0x60 && y <= 0xb0) {
+            r = 0x24;
+        }
+    } else if (x > data_ov006_0212ed4c[1] && x <= data_ov006_0212ed4c[2]) {
+        if (y > data_ov006_0212ed68[0] && y <= data_ov006_0212ed68[1]) {
+            r = 0;
+        } else if (y > data_ov006_0212ed68[1] && y <= data_ov006_0212ed68[2]) {
+            r = 0x14;
+        } else if (y > data_ov006_0212ed68[2] && y <= data_ov006_0212ed68[3]) {
+            r = 3;
+        } else if (y > data_ov006_0212ed68[3] && y <= data_ov006_0212ed68[4]) {
+            r = 0x17;
+        } else if (y > data_ov006_0212ed68[4] && y <= data_ov006_0212ed68[5]) {
+            r = 6;
+        } else if (y > data_ov006_0212ed68[5] && y <= data_ov006_0212ed68[6]) {
+            r = 0x1a;
+        } else if (y > data_ov006_0212ed68[6] && y <= data_ov006_0212ed68[7]) {
+            r = 9;
+        }
+    } else if (x > data_ov006_0212ed4c[2] && x <= data_ov006_0212ed4c[3]) {
+        if (y > data_ov006_0212ed68[0] && y <= data_ov006_0212ed68[1]) {
+            r = 0xc;
+        } else if (y > data_ov006_0212ed68[1] && y <= data_ov006_0212ed68[2]) {
+            r = 0x1d;
+        } else if (y > data_ov006_0212ed68[2] && y <= data_ov006_0212ed68[3]) {
+            r = 0xe;
+        } else if (y > data_ov006_0212ed68[3] && y <= data_ov006_0212ed68[4]) {
+            r = 0x1f;
+        } else if (y > data_ov006_0212ed68[4] && y <= data_ov006_0212ed68[5]) {
+            r = 0x10;
+        } else if (y > data_ov006_0212ed68[5] && y <= data_ov006_0212ed68[6]) {
+            r = 0x21;
+        } else if (y > data_ov006_0212ed68[6] && y <= data_ov006_0212ed68[7]) {
+            r = 0x12;
+        }
+    } else if (x > data_ov006_0212ed4c[3] && x <= data_ov006_0212ed4c[4]) {
+        if (y > data_ov006_0212ed68[0] && y <= data_ov006_0212ed68[1]) {
+            r = 1;
+        } else if (y > data_ov006_0212ed68[1] && y <= data_ov006_0212ed68[2]) {
+            r = 0x15;
+        } else if (y > data_ov006_0212ed68[2] && y <= data_ov006_0212ed68[3]) {
+            r = 4;
+        } else if (y > data_ov006_0212ed68[3] && y <= data_ov006_0212ed68[4]) {
+            r = 0x18;
+        } else if (y > data_ov006_0212ed68[4] && y <= data_ov006_0212ed68[5]) {
+            r = 7;
+        } else if (y > data_ov006_0212ed68[5] && y <= data_ov006_0212ed68[6]) {
+            r = 0x1b;
+        } else if (y > data_ov006_0212ed68[6] && y <= data_ov006_0212ed68[7]) {
+            r = 0xa;
+        }
+    } else if (x > data_ov006_0212ed4c[4] && x <= data_ov006_0212ed4c[5]) {
+        if (y > data_ov006_0212ed68[0] && y <= data_ov006_0212ed68[1]) {
+            r = 0xd;
+        } else if (y > data_ov006_0212ed68[1] && y <= data_ov006_0212ed68[2]) {
+            r = 0x1e;
+        } else if (y > data_ov006_0212ed68[2] && y <= data_ov006_0212ed68[3]) {
+            r = 0xf;
+        } else if (y > data_ov006_0212ed68[3] && y <= data_ov006_0212ed68[4]) {
+            r = 0x20;
+        } else if (y > data_ov006_0212ed68[4] && y <= data_ov006_0212ed68[5]) {
+            r = 0x11;
+        } else if (y > data_ov006_0212ed68[5] && y <= data_ov006_0212ed68[6]) {
+            r = 0x22;
+        } else if (y > data_ov006_0212ed68[6] && y <= data_ov006_0212ed68[7]) {
+            r = 0x13;
+        }
+    } else if (x > data_ov006_0212ed4c[5] && x <= data_ov006_0212ed4c[6]) {
+        if (y > data_ov006_0212ed68[0] && y <= data_ov006_0212ed68[1]) {
+            r = 2;
+        } else if (y > data_ov006_0212ed68[1] && y <= data_ov006_0212ed68[2]) {
+            r = 0x16;
+        } else if (y > data_ov006_0212ed68[2] && y <= data_ov006_0212ed68[3]) {
+            r = 5;
+        } else if (y > data_ov006_0212ed68[3] && y <= data_ov006_0212ed68[4]) {
+            r = 0x19;
+        } else if (y > data_ov006_0212ed68[4] && y <= data_ov006_0212ed68[5]) {
+            r = 8;
+        } else if (y > data_ov006_0212ed68[5] && y <= data_ov006_0212ed68[6]) {
+            r = 0x1c;
+        } else if (y > data_ov006_0212ed68[6] && y <= data_ov006_0212ed68[7]) {
+            r = 0xb;
+        }
+    }
+    return r;
+}


### PR DESCRIPTION
Second half of the 0x400-0x800 Fable-high fan-out (the first 6 merged as #328). All 5 are `divergences: 0`, link-gate VERIFIED.

| function | module | levers |
|---|---|---|
| `func_ov006_020df5b8` | ov006 | `opt_common_subs off`, `0x14000LL` 64-bit mul, u64-mask RMW laundering |
| `_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh` | arm9 | `opt_propagation off` keeps stack ternary selectors as scalars |
| `func_ov006_020d6e8c` | ov006 | `opt_common_subs off`, int-return atan2, variable-identity web priority |
| `func_ov006_02108650` | ov006 | 2D range-classifier else-if grid over two extern int tables |
| `func_0206fd6c` | arm9 | MSL `parse_format` (printf.c); fused loop tail, u64-mask laundering |

🤖 Generated with [Claude Code](https://claude.com/claude-code)