### PR TITLE
Match WithMeshClsn::UpdateContinuousNoLava (70.35%)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -871,6 +871,26 @@ u64-address laundering of RMW lvalues, `#pragma opt_strength_reduction off` for
 mla+spilled-base index math, `#pragma opt_common_subs off` to stop cross-EBB base+off
 CSE, and pointer-deref virtual calls to block devirtualization.)
 
+## 6q. Register-web priority follows VARIABLE IDENTITY, not declaration/definition order (2026-07-13, Fable 0x400-0x800)
+
+When two callee-saved locals (e.g. one in r8, one in `sb`/r9) sit in a swapped
+coloring that survives BOTH declaration-order AND definition-order permutation, the
+lever is neither: swap **which variable name holds which value**. The allocator's web
+priority is keyed on the variable's identity across its whole live range, so moving the
+*value* into the other-named local (rather than reordering decls/defs) is what rotates
+the two colors. Cracked the r8/sb residual on func_ov006_020d6e8c after decl- and
+def-order permutation both failed. Try this once the cheap ordering knobs (6k/6p) are
+exhausted on a two-callee-saved swap.
+
+## 6r. `#pragma opt_propagation off` keeps a 0/1 ternary selector as a stack scalar (2026-07-13, Fable 0x400-0x800)
+
+A `sel = cond ? 1 : 0` (or `? a : b`) selector that the ROM keeps stack-resident and
+reads back with predicated `ldrge`/`ldrlt` gets copy-propagated away by default (mwccarm
+folds the constant into the consumer). `#pragma opt_propagation off` leaves the selector
+as a plain scalar in the spill area so the predicated reload survives. Pair with a
+`u32`-cast on the following loads to block CSE **without** volatile's slot-reload penalty.
+Cracked a stranded 40-div near-miss on `_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh`.
+
 ## 8. The `asm`-block escape hatch (for hand-written-asm SDK primitives)
 
 Some functions -- especially arm9 NITRO-SDK primitives -- are HAND-WRITTEN ASSEMBLY that NO C

--- a/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
+++ b/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
@@ -1,0 +1,152 @@
+typedef unsigned char u8;
+
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+
+typedef struct Vec3 { int x, y, z; } Vec3;
+typedef struct ClsnResult { char pad[0x28]; } ClsnResult;
+
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void* p);
+extern void _ZN10ClsnResultC1Ev(ClsnResult* r);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, Vec3* a, Vec3* b, void* actor);
+extern int func_0203859c(void* self);
+extern void _ZN11RaycastLine10GetClsnPosEv(Vec3* out, void* self);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vec3* out);
+extern int func_02039794(int x);
+extern void _ZNK10ClsnResult6CopyToERS_(void* self, ClsnResult* dst);
+extern void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(void* p);
+extern void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(void* self, Vec3* v, int rad, void* actor);
+extern void _ZN10SphereClsn14SetFloorResultERK10ClsnResult(void* self, ClsnResult* r);
+extern void _ZN10ClsnResultaSERKS_(void* self, ClsnResult* r);
+extern void func_020371b0(void* clsn, int justHit);
+extern void func_02037888(void* dst, ClsnResult* src);
+extern int func_02038a38(void* self);
+extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void* p);
+extern void func_020356d4(void* self);
+extern void _ZN10ClsnResultD1Ev(ClsnResult* r);
+
+#pragma opt_common_subs off
+
+void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
+{
+    int floorFlag;
+    int wallFlag;
+    int height;
+    int onGround;
+    int* pos;
+    int* prev;
+    int handled;
+    ClsnResult res0;
+    ClsnResult res1;
+    Vec3 lineStart, lineEnd;
+    Vec3 clsnPos, normal;
+    Vec3 newStart, newEnd;
+    Vec3 clsnPos2, normal2;
+    Vec3 sphere;
+
+    {
+        char* a = *(char**)(c + 0x14);
+        pos = (int*)AT(a, 0x5c);
+        prev = (int*)AT(a, 0x68);
+    }
+
+    floorFlag = 0;
+    _ZN10ClsnResultC1Ev(&res0);
+    wallFlag = 0;
+    _ZN10ClsnResultC1Ev(&res1);
+
+    height = *(int*)(c + 0x1c);
+    {
+        int tx = prev[0];
+        int tz = prev[2];
+        int ty = prev[1] + height;
+        lineStart.x = tx;
+        lineStart.y = ty;
+        lineStart.z = tz;
+    }
+    {
+        int tx = pos[0];
+        int tz = pos[2];
+        int ty = pos[1] + height;
+        lineEnd.x = tx;
+        lineEnd.y = ty;
+        lineEnd.z = tz;
+    }
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &lineStart, &lineEnd, *(void**)(c + 0x14));
+    if (func_0203859c(c + 0x134))
+    {
+        int r;
+        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, c + 0x134);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal);
+        newStart.x = clsnPos.x + (normal.x >> 2);
+        newStart.y = (normal.y >> 2) + clsnPos.y;
+        newStart.z = clsnPos.z + (normal.z >> 2);
+        newEnd.x = newStart.x;
+        newEnd.y = newStart.y - height;
+        newEnd.z = newStart.z;
+        r = func_02039794(normal.y);
+        if (r == 1) {
+            wallFlag = 1;
+            _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res1);
+        }
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &newStart, &newEnd, *(void**)(c + 0x14));
+        if (func_0203859c(c + 0x134)) {
+            _ZN11RaycastLine10GetClsnPosEv(&clsnPos2, c + 0x134);
+            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal2);
+            if (func_02039794(normal2.y) == 0) {
+                floorFlag = 1;
+                _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res0);
+            }
+            if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+                pos[0] = clsnPos2.x - (normal2.x >> 2);
+                pos[1] = clsnPos2.y - (normal2.y >> 2) - (height >> 1);
+                pos[2] = clsnPos2.z - (normal2.z >> 2);
+            }
+        } else if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+            pos[0] = newStart.x;
+            pos[1] = newStart.y - height;
+            pos[2] = newStart.z;
+        }
+    }
+
+    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(c);
+    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(c);
+    handled = 0;
+    sphere.x = pos[0];
+    sphere.y = pos[1];
+    sphere.z = pos[2];
+    sphere.y += height;
+    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(c + 0x20, &sphere, *(int*)(c + 0x18), *(void**)(c + 0x14));
+    *(int*)(c + 0x128) = *(int*)(c + 0x1b8);
+    if (pos[1] - prev[1] > 0)
+        *(u8*)AT(c, 0x90) |= 0x20;
+    if (floorFlag != 0) {
+        *(u8*)AT(c, 0x90) |= 4;
+        _ZN10SphereClsn14SetFloorResultERK10ClsnResult(c + 0x20, &res0);
+        *(u8*)AT(c, 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(c + 0x30, &res0);
+        func_020371b0(c, onGround);
+        handled = 1;
+    }
+    if (wallFlag != 0) {
+        *(u8*)AT(c, 0x90) |= 8;
+        func_02037888(c + 0x20, &res1);
+        *(u8*)AT(c, 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(c + 0x30, &res1);
+    }
+    if (func_02038a38(c + 0x20)) {
+        prev = (int*)(c + 0x6c);
+        if ((*(u8*)(c + 0x90) & 4) && handled == 0)
+            func_020371b0(c, onGround);
+        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+            pos[0] += prev[0];
+            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(c))
+                *(int*)AT(pos, 4) += prev[1];
+            *(int*)AT(pos, 8) += prev[2];
+        }
+    }
+    if (onGround && _ZNK12WithMeshClsn10IsOnGroundEv(c) == 0)
+        func_020356d4(c);
+    _ZN10ClsnResultD1Ev(&res1);
+    _ZN10ClsnResultD1Ev(&res0);
+}

--- a/tools/fdiff.py
+++ b/tools/fdiff.py
@@ -11,13 +11,36 @@ Prints each word: offset | target insn | candidate insn | OK/MISMATCH/reloc, the
 a summary line "RESULT match=<bool> mismatches=<n>/<words>".
 """
 import argparse
+import difflib
 import pathlib
+import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import match as M
 import swarm as S
 import modules as MOD
+
+
+PCREL = re.compile(r"\[pc,\s*#-?(?:0x[0-9a-fA-F]+|[0-9]+)\]")
+STACK = re.compile(r"\[sp(?:,\s*#-?(?:0x[0-9a-fA-F]+|[0-9]+))?\]")
+REG = re.compile(r"\b(?:r(?:1[0-2]|[0-9])|fp|ip|sb|sl|lr)\b")
+
+
+def norm(ins):
+    if ins.mnemonic.startswith("b"):
+        return ins.mnemonic
+    return ins.mnemonic + " " + PCREL.sub("[pc]", S.squash(ins.op_str))
+
+
+def shape(ins):
+    if ins.mnemonic.startswith("b"):
+        return ins.mnemonic
+    operands = S.squash(ins.op_str)
+    operands = PCREL.sub("[pc]", operands)
+    operands = STACK.sub("[sp]", operands)
+    operands = REG.sub("r", operands)
+    return ins.mnemonic + " " + operands
 
 
 def target_from_args(a):
@@ -40,6 +63,24 @@ def main():
     ap.add_argument("--addr", type=lambda x: int(x, 0), default=None)
     ap.add_argument("--size", type=lambda x: int(x, 0), default=None)
     ap.add_argument("--quiet", action="store_true", help="summary line only")
+    ap.add_argument("--common-prefix", action="store_true",
+                    help="diff only the shared byte prefix when sizes differ")
+    ap.add_argument("--limit", type=lambda x: int(x, 0), default=None,
+                    help="limit the verbose comparison to this many bytes")
+    ap.add_argument("--align", action="store_true",
+                    help="show size-tolerant normalized instruction alignment")
+    ap.add_argument("--align-mnemonic", action="store_true",
+                    help="align only by mnemonic, ignoring operands")
+    ap.add_argument("--align-shape", action="store_true",
+                    help="align while ignoring register names and stack offsets")
+    ap.add_argument("--align-changes", type=int, default=40,
+                    help="maximum non-equal alignment ranges to print")
+    ap.add_argument("--find-candidate", default=None,
+                    help="print candidate instructions matching this regex")
+    ap.add_argument("--candidate-start", type=lambda x: int(x, 0), default=None,
+                    help="dump candidate disassembly starting at this byte offset")
+    ap.add_argument("--candidate-length", type=lambda x: int(x, 0), default=0x100,
+                    help="candidate disassembly byte count")
     ap.add_argument("--track", default=None,
                     help="checkpoint prefix: keep <prefix>.best.c at the lowest "
                          "mismatch count ever seen, so a near-miss is never lost")
@@ -60,7 +101,55 @@ def main():
     if code is None:
         print(f"RESULT match=False mismatches=no-symbol:{a.name}")
         return
-    ok, ndiff = M.compare(target, code, relocs, verbose=not a.quiet)
+    if a.find_candidate:
+        pattern = re.compile(a.find_candidate)
+        for index, ins in enumerate(S.md.disasm(code, 0)):
+            rendered = f"{ins.mnemonic} {ins.op_str}"
+            if pattern.search(rendered):
+                print(f"CAND {index:4} +0x{index * 4:04x}: {rendered}")
+    if a.candidate_start is not None:
+        begin = a.candidate_start
+        end = min(len(code), begin + a.candidate_length)
+        for ins in S.md.disasm(code[begin:end], begin):
+            print(f"CAND +0x{ins.address:04x}: {ins.mnemonic:<8} {ins.op_str}")
+    if a.align:
+        tins = list(S.md.disasm(target, 0))
+        cins = list(S.md.disasm(code, 0))
+        if a.align_mnemonic:
+            tnorm = [ins.mnemonic for ins in tins]
+            cnorm = [ins.mnemonic for ins in cins]
+        elif a.align_shape:
+            tnorm = [shape(ins) for ins in tins]
+            cnorm = [shape(ins) for ins in cins]
+        else:
+            tnorm = [norm(ins) for ins in tins]
+            cnorm = [norm(ins) for ins in cins]
+        sm = difflib.SequenceMatcher(a=tnorm, b=cnorm, autojunk=False)
+        counts = {"equal": 0, "replace": 0, "insert": 0, "delete": 0}
+        shown = 0
+        for tag, i1, i2, j1, j2 in sm.get_opcodes():
+            counts[tag] += max(i2 - i1, j2 - j1)
+            if tag == "equal" or shown >= a.align_changes:
+                continue
+            print(f"{tag.upper()} target[{i1}:{i2}] cand[{j1}:{j2}]")
+            for value in tnorm[i1:min(i2, i1 + 4)]:
+                print(f"  T {value}")
+            for value in cnorm[j1:min(j2, j1 + 4)]:
+                print(f"  C {value}")
+            shown += 1
+        print(f"ALIGN target={len(tnorm)} cand={len(cnorm)} "
+              f"ratio={sm.ratio():.4f} counts={counts}")
+    compare_target = target
+    compare_code = code
+    if a.common_prefix and len(target) != len(code):
+        common = min(len(target), len(code))
+        compare_target = target[:common]
+        compare_code = code[:common]
+    if a.limit is not None:
+        compare_target = compare_target[:a.limit]
+        compare_code = compare_code[:a.limit]
+    ok, ndiff = M.compare(compare_target, compare_code, relocs,
+                          verbose=not a.quiet)
     words = max(len(target), len(code)) // 4
     print(f"RESULT match={ok} mismatches={ndiff}/{words}")
 


### PR DESCRIPTION
## Summary
- Matches `WithMeshClsn::UpdateContinuousNoLava()` byte-perfect (arm9, 0x39c).
- Hand-drafted from the matched sibling `func_02036acc` (`UpdateContinuous`): identified the real semantic difference (the NoLava variant drops the `floorFlag` branch on the *first* raycast check, keeping it only on the refined second raycast) and swapped in the two NoLava-variant collision-detect callees (`func_0203859c`, `func_02038a38`).
- Landed at 92%+ match by hand; a single scoped Fable refine pass (27K tokens, 6 attempts) closed the remaining register-coloring/scheduling residual: `AT()` u64-mask laundering on the pos/prev derivation, `handled = 0` statement placement, and `lineEnd` temp declaration order.
- Progress: 70.3424% -> 70.3512% (8,012 -> 8,013 functions).

## Test plan
- [x] Independently re-verified via `bank_harvest` (oracle re-verify)
- [x] Link-gate VERIFIED via `tools/linkcheck.py` (reconstructed linked bytes match)
- [x] `crackloop.py land --refine` banked cleanly, claims released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186dXvXCxbeZjkpiTFJ9JNq