### PR TITLE
Match 15 ov080 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -111,4 +111,4 @@ it is fair to take over: ping the claimant first.
 | ov016 Unagi batch: func_ov016_021119ec, _ZN5Unagi8BehaviorEv, _ZN5Unagi13InitResourcesEv (0x021119ec-0x02112e1c) | lunavyqo (Grok) | 2026-07-13 | **done** — 3 matched byte-identical; near-misses func_ov016_02111c40 (div=54) + func_ov016_02112b50 (div=10) banked in nearmiss/db.jsonl |
 | ov066: func_ov066_02118e04 (0x02118e04, 0x218) + _ZN6Eyerok8BehaviorEv (0x02119838, 0x4b0) | lunavyqo (Grok) | 2026-07-15 | **done** — both verified byte-identical |
 | ov034 Wiggler batch: func_ov034_021113d4/115cc/11e68/120ac/12688/12874 (0x021113d4-0x0211323c) | lunavyqo (Grok) | 2026-07-15 | **done** — 6 matched byte-identical; _ZN7Wiggler8BehaviorEv near-miss (div=277, size 0x6e0) banked in nearmiss/db.jsonl |
-| ov080 batch16: 02123a34,23c24,24360,24acc,24c3c,24edc,25630,256f8,25940,25af0,25de0,25fd0,261f4,2677c,26ca0,2714c | lunavyqo (Grok) | 2026-07-15 | **active** — matching 16-func batch |
+| ov080 batch16: 15/16 MATCH (261f4 div=5 4a8 regperm wall, same as 25460) | lunavyqo (Grok) | 2026-07-15 | **active** — 15 matched PR draft; 261f4 near-miss banked |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -111,3 +111,4 @@ it is fair to take over: ping the claimant first.
 | ov016 Unagi batch: func_ov016_021119ec, _ZN5Unagi8BehaviorEv, _ZN5Unagi13InitResourcesEv (0x021119ec-0x02112e1c) | lunavyqo (Grok) | 2026-07-13 | **done** — 3 matched byte-identical; near-misses func_ov016_02111c40 (div=54) + func_ov016_02112b50 (div=10) banked in nearmiss/db.jsonl |
 | ov066: func_ov066_02118e04 (0x02118e04, 0x218) + _ZN6Eyerok8BehaviorEv (0x02119838, 0x4b0) | lunavyqo (Grok) | 2026-07-15 | **done** — both verified byte-identical |
 | ov034 Wiggler batch: func_ov034_021113d4/115cc/11e68/120ac/12688/12874 (0x021113d4-0x0211323c) | lunavyqo (Grok) | 2026-07-15 | **done** — 6 matched byte-identical; _ZN7Wiggler8BehaviorEv near-miss (div=277, size 0x6e0) banked in nearmiss/db.jsonl |
+| ov080 batch16: 02123a34,23c24,24360,24acc,24c3c,24edc,25630,256f8,25940,25af0,25de0,25fd0,261f4,2677c,26ca0,2714c | lunavyqo (Grok) | 2026-07-15 | **active** — matching 16-func batch |

--- a/src/func_ov080_02123a34.cpp
+++ b/src/func_ov080_02123a34.cpp
@@ -1,0 +1,80 @@
+//cpp
+struct V16 { short x, y, z; };
+struct V3 { int x, y, z; };
+extern "C" {
+extern void _ZN9Animation7AdvanceEv(void*);
+extern int _ZNK9Animation12WillHitFrameEi(void*, int);
+extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, V3*, V16*, int, int);
+extern int _ZN5Actor13DistToCPlayerEv(void*);
+extern void func_0201267c(unsigned int, void*);
+extern int _ZN9Animation8FinishedEv(void*);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
+extern short data_02082214[];
+extern void* data_ov080_021283e8[];
+extern void* data_ov080_021283d0[];
+}
+
+extern "C" void func_ov080_02123a34(char* c)
+{
+    _ZN9Animation7AdvanceEv(c + 0x124);
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x124, 0xa)) {
+        V16 v16;
+        V3 pos;
+        unsigned short ax, ay;
+        void* a;
+        int d;
+        short s;
+        int idx;
+        int px, py, pz;
+        V16* pAng = &v16;
+
+        ax = *(unsigned short*)(c + 0x8c);
+        ay = *(unsigned short*)(c + 0x8e);
+        *(volatile short*)&v16.y = (short)ay;
+        *(volatile short*)&v16.x = (short)ax;
+        {
+            unsigned short z = *(unsigned short*)(c + 0x90);
+            pAng->z = z;
+            short yv = (short)v16.y;
+            px = *(int*)(c + 0x5c);
+            pos.x = px;
+            yv = (short)(yv + 0x400);
+            py = *(int*)(c + 0x60);
+            pos.y = py;
+            pz = *(int*)(c + 0x64);
+            pAng->y = yv;
+            pos.z = pz;
+            pos.y = py + 0xa000;
+        }
+
+        idx = (unsigned short)(short)(*(short*)(c + 0x8e) - 0x4000) >> 4;
+        s = data_02082214[idx << 1];
+        pos.x = s * (short)0x50 + px;
+
+        idx = (unsigned short)(short)(*(short*)(c + 0x8e) - 0x4000) >> 4;
+        s = data_02082214[(idx << 1) + 1];
+        pos.z = s * (short)0x50 + pz;
+
+        a = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+            py ? 0x137u : 0x137u, 0, &pos, pAng, *(signed char*)(c + 0xcc), -1);
+        d = _ZN5Actor13DistToCPlayerEv(c);
+        if (d >= 0x258000)
+            d = 0x258000;
+        *(int*)((char*)a + 0x98) = 0x1e000;
+        *(int*)((char*)a + 0xa4) = 0;
+        *(int*)((char*)a + 0xa8) = (d << 2) / 100 + 0x4000;
+        *(int*)((char*)a + 0xac) = 0;
+        func_0201267c(0xd2, c + 0x74);
+    }
+
+    if (_ZN9Animation8FinishedEv(c + 0x124) == 0)
+        return;
+
+    if (_ZN5Actor13DistToCPlayerEv(c) < 0x3e8000) {
+        *(int*)(c + 0x17c) = 5;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov080_021283e8[1], 0x40000000, 0x1000, 0);
+    } else {
+        *(int*)(c + 0x17c) = 4;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov080_021283d0[1], 0x40000000, 0x1000, 0);
+    }
+}

--- a/src/func_ov080_02123c24.c
+++ b/src/func_ov080_02123c24.c
@@ -1,6 +1,3 @@
-// NONMATCHING: push-set / frame (div=78). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void _ZN9Animation7AdvanceEv(void *anim);
 extern int _ZN9Animation8FinishedEv(void *anim);
 extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
@@ -24,18 +21,20 @@ extern struct G data_ov080_021283e8;
 
 void func_ov080_02123c24(char *c)
 {
-    int raw;
     int amt;
-    unsigned short state;
+    unsigned int state;
+    int raw;
 
     _ZN9Animation7AdvanceEv(c + 0x124);
     raw = *(int *)(c + 0x12c);
     amt = 0;
-    state = (unsigned short)(raw >> 12);
+    state = ((unsigned int)raw << 4) >> 16;
 
     if (state == 6) {
-        *(unsigned int *)(c + 0x150) &= ~1;
-        *(unsigned int *)(c + 0xb0) |= 0x10000000;
+        int *p150 = (int *)(((int)c + 0x150) & 0xFFFFFFFFFFFFFFFF);
+        int *pb0 = (int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+        *p150 = *p150 & ~1;
+        *pb0 = *pb0 | 0x10000000;
     }
 
     if (state >= 6) {
@@ -52,14 +51,14 @@ void func_ov080_02123c24(char *c)
 
     *(int *)(c + 0x140) = amt;
 
-    if (!_ZN9Animation8FinishedEv(c + 0x124))
+    if (_ZN9Animation8FinishedEv(c + 0x124) == 0)
         return;
 
     *(unsigned int *)(c + 0x188) = 0;
 
     if (*(unsigned char *)(c + 0x180) == 2) {
         unsigned int rv = (unsigned int)RandomIntInternal(data_0209e650) >> 8;
-        unsigned char rem = (unsigned char)(rv % 3);
+        unsigned int rem = (rv % 3) & 0xff;
         if (rem == 0) {
             *(int *)(c + 0x17c) = 3;
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov080_021283e0.w[1], 0x40000000, 0x1000, 0);
@@ -76,8 +75,8 @@ void func_ov080_02123c24(char *c)
     }
 
     {
-        void *player = _ZN5Actor13ClosestPlayerEv(c);
-        if (!player) {
+        char *player = (char *)_ZN5Actor13ClosestPlayerEv(c);
+        if (player == 0) {
             *(int *)(c + 0x17c) = 3;
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov080_021283e0.w[1], 0x40000000, 0x1000, 0);
             return;
@@ -85,19 +84,19 @@ void func_ov080_02123c24(char *c)
         {
             struct Vector3 pos;
             short horz;
-            short diff;
-            int *pb = (int *)((char *)player + 0x5c);
+            int diff;
+            int *pb = (int *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFF);
             pos.x = pb[0];
             pos.y = pb[1];
             pos.z = pb[2];
             horz = Vec3_HorzAngle((struct Vector3 *)(c + 0x5c), &pos);
             diff = (short)AngleDiff(*(short *)(c + 0x8e), horz);
-            if (diff >= 0x4000) {
-                *(int *)(c + 0x17c) = 4;
-                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov080_021283d0.w[1], 0x40000000, 0x1000, 0);
-            } else {
+            if (diff < 0x4000) {
                 *(int *)(c + 0x17c) = 3;
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov080_021283e0.w[1], 0x40000000, 0x1000, 0);
+            } else {
+                *(int *)(c + 0x17c) = 4;
+                _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void *)data_ov080_021283d0.w[1], 0x40000000, 0x1000, 0);
             }
         }
     }

--- a/src/func_ov080_02124360.c
+++ b/src/func_ov080_02124360.c
@@ -1,0 +1,25 @@
+extern int RandomIntInternal(int *seed);
+extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
+extern int data_0209e650;
+
+void *func_ov080_02124360(char *c)
+{
+    unsigned char n = *(unsigned char *)(c + 0x180);
+    void *obj;
+    if (n == 0)
+        return (void *)(unsigned int)n;
+    *(unsigned char *)(c + 0x181) = 0;
+    for (;;) {
+        unsigned int r = ((unsigned int)RandomIntInternal(&data_0209e650)) >> 8;
+        unsigned int cnt = *(unsigned char *)(c + 0x183);
+        unsigned int idx = r % cnt;
+        unsigned int id = *(unsigned int *)(c + 0x16c + (idx * 4));
+        obj = _ZN5Actor10FindWithIDEj(id);
+        if (obj == 0)
+            continue;
+        if (*(unsigned char *)((char *)obj + 0x181) != 0)
+            continue;
+        *(unsigned char *)((char *)obj + 0x181) = 1;
+        return obj;
+    }
+}

--- a/src/func_ov080_02124acc.cpp
+++ b/src/func_ov080_02124acc.cpp
@@ -1,72 +1,47 @@
 //cpp
-// NONMATCHING: missing logic (ROM does more) (div=47). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct Vector3 { int x, y, z; };
-
-extern "C" void* func_02010304(void* a, void* b);
-extern "C" void func_ov080_0212513c(void* c, int n);
-
-struct Actor {
-    static Actor* FindWithID(u32 id);
-    void PoofDustAt(const Vector3&);
-    void SpawnCoins(const Vector3&, u32, int, short);
-};
-struct Player { static void IncMegaKillCount(); };
-namespace Particle { struct System { static void* NewSimple(u32, int, int, int); }; }
-struct Sound { static void PlayBank3(u32, const Vector3&); };
-struct ActorBase { void MarkForDestruction(); };
-
-extern "C" void func_ov080_02124acc(char* c)
+extern "C" {
+void* func_02010304(void* a, void* b);
+void func_ov080_0212513c(void* c, int n);
+void* _ZN5Actor10FindWithIDEj(unsigned int id);
+void _ZN6Player16IncMegaKillCountEv(void* p);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void* self, const Vector3& v, unsigned int n, int vel, short unk);
+void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+void _ZN9ActorBase18MarkForDestructionEv(void* self);
+}
+extern "C" void func_ov080_02124acc(char* c);
+void func_ov080_02124acc(char* c)
 {
-    if (*(int*)(c + 0x170) == 0)
-        return;
-
+    if (*(int*)(c + 0x170) == 0) return;
     void* p = func_02010304(c, c + 0x14c);
-    if (p != 0) {
-        *(void**)(c + 0x374) = p;
-        func_ov080_0212513c(c, 1);
-        return;
-    }
-
-    Actor* a = Actor::FindWithID(*(u32*)(c + 0x170));
-    if (a == 0)
-        return;
-
-    int b1 = (int)(*(u16*)((char*)a + 0xc) == 0xbf);
-    if (b1 == 0)
-        return;
-
-    int b2 = (int)((*(u32*)(c + 0xb0) & 0x20000) != 0);
-    if (b2) {
-        func_ov080_0212513c(c, 2);
-        return;
-    }
-    if ((*(u32*)(c + 0x16c) & 0x10) == 0)
-        return;
-
-    Player::IncMegaKillCount();
-
-    Vector3 v;
-    v.x = *(int*)(c + 0x5c);
-    v.y = *(int*)(c + 0x60) + 0x32000;
-    v.z = *(int*)(c + 0x64);
-    Particle::System::NewSimple(6, v.x, v.y, v.z);
-
-    Vector3 v2 = v;
-    ((Actor*)c)->PoofDustAt(v2);
-
-    Vector3 v3;
+    if (p != 0) { *(void**)(c + 0x374) = p; func_ov080_0212513c(c, 1); return; }
+    void* a = _ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x170));
+    if (a == 0) return;
+    int b1 = (int)(*(unsigned short*)((char*)a + 0xc) == 0xbf);
+    if (b1 == 0) return;
+    int b2 = (int)((*(unsigned int*)(c + 0xb0) & 0x20000) != 0);
+    if (b2) { func_ov080_0212513c(c, 2); return; }
+    if ((*(unsigned int*)(c + 0x16c) & 0x10) == 0) return;
+    _ZN6Player16IncMegaKillCountEv(a);
+    Vector3 v; Vector3 v2; Vector3 v3;
+    int y0 = *(int*)(c + 0x60);
+    int z = *(int*)(c + 0x64);
+    int x = *(int*)(c + 0x5c);
+    int y = y0 + 0x32000;
+    v.x = x; v.y = y; v.z = z;
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(6, v.x, v.y, v.z);
+    ((int*)&v2)[0] = ((int*)&v)[0];
+    ((int*)&v2)[1] = ((int*)&v)[1];
+    ((int*)&v2)[2] = ((int*)&v)[2];
+    _ZN5Actor10PoofDustAtERK7Vector3(c, v2);
+    int t = *(int*)(c + 0x60) + 0x64000;
     v3.x = v.x;
-    v.y = *(int*)(c + 0x60) + 0x64000;
-    v3.y = v.y;
+    v.y = t;
+    v3.y = t;
     v3.z = v.z;
-    ((Actor*)c)->SpawnCoins(v3, 5, 0xf000, 0);
-
-    Sound::PlayBank3(0x41, *(Vector3*)(c + 0x74));
-
-    ((ActorBase*)c)->MarkForDestruction();
+    _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, v3, 5, 0xf000, 0);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(c + 0x74));
+    _ZN9ActorBase18MarkForDestructionEv(c);
 }

--- a/src/func_ov080_02124c3c.cpp
+++ b/src/func_ov080_02124c3c.cpp
@@ -1,0 +1,75 @@
+//cpp
+typedef short s16;
+typedef long long s64;
+struct Vector3 { int x, y, z; };
+struct Mtx43 { int a[12]; };
+extern "C" {
+void Matrix4x3_ApplyInPlaceToTranslation(Mtx43* m, int x, int y, int z);
+void Vec3_LslInPlace(Vector3* v, int sh);
+void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
+void Matrix4x3_FromRotationY(void* m, int angle);
+void _ZN13RaycastGroundC1Ev(void* self);
+void _ZN13RaycastGroundD1Ev(void* self);
+void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* self, const Vector3* pos, void* actor);
+int _ZN13RaycastGround10DetectClsnEv(void* self);
+void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
+    void* self, void* sm, void* mtx, int r, int t5, int t6, unsigned int u);
+}
+extern Mtx43 data_020a0e68;
+extern s16 data_02082214[];
+extern "C" void func_ov080_02124c3c(char* c);
+void func_ov080_02124c3c(char* c)
+{
+    Vector3 t;
+    Vector3 pos;
+    char rg[0x54];
+    int flags = *(int*)(c + 0xb0);
+    int gb = (flags & 0x40000) != 0;
+    if (gb != false) return;
+    void* p = *(void**)(c + 0x374);
+    if (p != 0) {
+        int gb2 = (flags & 0x4000) != 0;
+        if (gb2 != false) {
+            if (*(int*)((char*)p + 0xc8) != 0) {
+
+                int tx = 0xc000, ty = 0x2000, tz = 0;
+                ((int*)&t)[0] = tx; ((int*)&t)[1] = ty; ((int*)&t)[2] = tz;
+                p = *(void**)(c + 0x374);
+                data_020a0e68 = *(Mtx43*)(*(void**)((char*)p + 0xc8));
+                Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, ((int*)&t)[0], ((int*)&t)[1], ((int*)&t)[2]);
+
+                *(int*)(c + 0x5c) = data_020a0e68.a[9];
+                *(int*)(c + 0x60) = data_020a0e68.a[10];
+                *(int*)(c + 0x64) = data_020a0e68.a[11];
+                Vec3_LslInPlace((Vector3*)(c + 0x5c), 3);
+            }
+        }
+    }
+    Matrix4x3_FromRotationXYZExt(c + 0xf0, *(s16*)(c + 0x8c), *(s16*)(c + 0x8e), *(s16*)(c + 0x90));
+    *(int*)(c + 0x114) = *(int*)(c + 0x5c) >> 3;
+    *(int*)(c + 0x118) = *(int*)(c + 0x60) >> 3;
+    *(int*)(c + 0x11c) = *(int*)(c + 0x64) >> 3;
+    pos.x = *(int*)(c + 0x5c);
+    pos.y = *(int*)(c + 0x60);
+    pos.z = *(int*)(c + 0x64);
+    pos.y = pos.y + 0x14000;
+    _ZN13RaycastGroundC1Ev(rg);
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, &pos, 0);
+    int h = pos.y;
+    if (_ZN13RaycastGround10DetectClsnEv(rg)) {
+        h = *(int*)(rg + 0x44);
+    }
+    Matrix4x3_FromRotationY(c + 0x33c, *(s16*)(c + 0x8e));
+    *(int*)(c + 0x360) = *(int*)(c + 0x5c) >> 3;
+    *(int*)(c + 0x364) = h >> 3;
+    *(int*)(c + 0x368) = *(int*)(c + 0x64) >> 3;
+    {
+        s16 a = *(s16*)(c + 0x8c);
+        int sv = data_02082214[((unsigned short)(short)(a << 1) >> 4) * 2];
+        if (sv < 0) sv = -sv;
+        int result = (int)(((s64)sv * 0x28000 + 0x800) >> 12);
+        _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
+            c, c + 0x124, c + 0x33c, 0x96000, 0x32000, result + 0x96000, 0xf);
+    }
+    _ZN13RaycastGroundD1Ev(rg);
+}

--- a/src/func_ov080_02124edc.cpp
+++ b/src/func_ov080_02124edc.cpp
@@ -1,0 +1,62 @@
+//cpp
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
+void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
+void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void* self, const Vector3& v, unsigned n, int f, short s);
+void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
+void _ZN9ActorBase18MarkForDestructionEv(void* self);
+void _ZN12CylinderClsn5ClearEv(void* self);
+}
+
+extern "C" int func_ov080_02124edc(char* c);
+int func_ov080_02124edc(char* c)
+{
+    *(short*)(c + 0x8c) = *(short*)(*(char**)(c + 0x374) + 0x8c);
+    *(short*)(c + 0x8e) = *(short*)(*(char**)(c + 0x374) + 0x8e);
+    *(short*)(c + 0x92) = *(short*)(c + 0x8c);
+    *(short*)(c + 0x94) = *(short*)(c + 0x8e);
+    {
+        int f = *(int*)(c + 0xb0);
+        int a = (int)((f & 0x100) != 0);
+        if (a != 0) {
+            int b = (int)((f & 0x2000) != 0);
+            if (b == 0) goto clear;
+        }
+        {
+            Vector3 vec;
+            Vector3 vec2;
+            int x = *(int*)(c + 0x5c);
+            int z = *(int*)(c + 0x64);
+            int y = *(int*)(c + 0x60) + 0xb4000;
+            vec.x = x;
+            vec.y = y;
+            vec.z = z;
+            ((int*)&vec2)[0] = ((int*)&vec)[0];
+            ((int*)&vec2)[1] = ((int*)&vec)[1];
+            ((int*)&vec2)[2] = ((int*)&vec)[2];
+            _ZN5Actor10PoofDustAtERK7Vector3(c, vec2);
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(6, vec.x, vec.y, vec.z);
+
+            {
+                int ybase = *(int*)(c + 0x60);
+                int xx = vec.x;
+                int y2 = ybase + 0x64000;
+                int zz = vec.z;
+                Vector3 v3;
+                v3.x = xx;
+                v3.z = zz;
+                vec.y = y2;
+                v3.y = y2;
+                _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(c, v3, 5, 0xf000, 0);
+            }
+
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x41, *(Vector3*)(c + 0x74));
+            _ZN9ActorBase18MarkForDestructionEv(c);
+        }
+    }
+clear:
+    _ZN12CylinderClsn5ClearEv(c + 0x14c);
+    return 1;
+}

--- a/src/func_ov080_02125630.cpp
+++ b/src/func_ov080_02125630.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=30). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct SharedFilePtr { int w[2]; };
 extern "C" void *func_0201787c(SharedFilePtr *sfp);
 extern "C" int func_02045ad8(void *p);
@@ -11,24 +8,29 @@ extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);
 extern unsigned char data_ov080_0212869c[];
 extern unsigned char data_ov080_02128688[];
 extern SharedFilePtr *data_ov080_0212775c[];
-extern "C" unsigned char *func_ov080_02125630(int i)
+extern "C" unsigned char *func_ov080_02125630(void *unused, int i)
 {
     int off = 0x18 * i;
     unsigned char *e = &data_ov080_02128688[off];
     unsigned char *fl = &data_ov080_0212869c[off];
     if (data_ov080_0212869c[off] == 0) {
+        char *a;
+        char *b;
+        char *c;
         SharedFilePtr *sfp = data_ov080_0212775c[i];
         char *o = (char *)func_0201787c(sfp);
-        char *a = *(char **)(o + 0x18);
-        char *b = *(char **)(o + 0x28);
-        char *c = *(char **)(o + 0x20);
+        a = *(char **)(o + 0x18);
+        b = *(char **)(o + 0x28);
+        c = *(char **)(o + 0x20);
+        int sz;
         *(int *)(e + 0) = _ZN5Model27LoadCompressedTextureToVramEPcjPc(
             *(char **)(a + 4), *(unsigned int *)(a + 8),
             *(char **)(a + 4) + *(unsigned int *)(a + 8));
-        if (*(int *)(c + 8) <= 8)
+        sz = *(int *)(c + 8);
+        if (sz <= 8)
             *(int *)(e + 4) = func_02045ad8(*(void **)(c + 4));
         else
-            *(int *)(e + 4) = func_02045a50(*(const void **)(c + 4), *(unsigned int *)(c + 8));
+            *(int *)(e + 4) = (int)func_02045a50(*(const void **)(c + 4), (unsigned int)sz);
         *(int *)(e + 8) = *(int *)(b + 0x28);
         *(int *)(e + 0xc) = *(int *)(b + 0x2c);
         *(int *)(e + 0x10) = *(int *)(a + 0x10);

--- a/src/func_ov080_021256f8.c
+++ b/src/func_ov080_021256f8.c
@@ -1,0 +1,98 @@
+typedef unsigned int u32;
+typedef unsigned char u8;
+
+typedef struct { int x, y, z; } Vec3;
+typedef struct { int m[12]; } Mtx;
+
+extern char *_ZN5Actor13ClosestPlayerEv(char *self);
+extern void Vec3_Asr(Vec3 *d, Vec3 *s, int sh);
+extern void MulVec3Mat4x3(const Vec3 *v, void *m, Vec3 *out);
+extern void func_ov080_02125de0(char *c, int a, int b, int d);
+extern void func_02012694(u32 id, void *pos);
+extern Mtx data_020a0e68;
+
+void func_ov080_021256f8(char *r4)
+{
+    Vec3 a;
+    Vec3 b;
+    Vec3 ob;
+    Vec3 oa;
+    char *r5;
+    int za;
+    int zb;
+    int x, y;
+    int lim;
+    u32 raw;
+    u8 nib;
+
+    r5 = _ZN5Actor13ClosestPlayerEv(r4);
+    if (r5 == 0)
+        return;
+
+    Vec3_Asr(&a, (Vec3 *)(r5 + 0x68), 3);
+    Vec3_Asr(&b, (Vec3 *)(r5 + 0x5c), 3);
+    data_020a0e68 = *(Mtx *)(r4 + 0x104);
+    MulVec3Mat4x3(&a, &data_020a0e68, &oa);
+    MulVec3Mat4x3(&b, &data_020a0e68, &ob);
+
+    za = oa.z;
+    if (za <= 0)
+        goto L9c;
+    zb = ob.z;
+    if (zb <= 0)
+        goto Lb0;
+L9c:
+    if (za >= 0)
+        goto neg;
+    zb = ob.z;
+    if (zb < 0)
+        goto neg;
+Lb0:
+    x = ob.x << 3;
+    y = ob.y << 3;
+    ob.x = x;
+    ob.y = y;
+    if (x < 0)
+        return;
+    raw = *(u32 *)(r4 + 8);
+    nib = raw & 0xf;
+    lim = (nib + 1) * 0x64000;
+    if (x > lim)
+        return;
+    if (y < 0)
+        return;
+    nib = (raw >> 4) & 0xf;
+    lim = (nib + 1) * 0x64000;
+    if (y > lim)
+        return;
+    func_ov080_02125de0(r4, x, y, 1);
+    return;
+
+neg:
+    if (za <= 0xa000)
+        return;
+    zb = ob.z;
+    if (zb > 0xa000)
+        return;
+    if (*(unsigned short *)(r4 + 0x1b6) != 0)
+        return;
+    x = ob.x << 3;
+    y = ob.y << 3;
+    ob.x = x;
+    ob.y = y;
+    if (x < -0x46000)
+        return;
+    raw = *(u32 *)(r4 + 8);
+    nib = raw & 0xf;
+    lim = (nib + 1) * 0x64000 + 0x46000;
+    if (x > lim)
+        return;
+    if (y < -0xc8000)
+        return;
+    nib = (raw >> 4) & 0xf;
+    lim = (nib + 1) * 0x64000 + 0xc8000;
+    if (y > lim)
+        return;
+    func_ov080_02125de0(r4, x, y, 0);
+    func_02012694(0x7b, r4 + 0x74);
+}

--- a/src/func_ov080_02125940.c
+++ b/src/func_ov080_02125940.c
@@ -1,0 +1,51 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern void SubVec3(Vec3* a, Vec3* b, Vec3* out);
+extern void CrossVec3(Vec3* a, Vec3* b, Vec3* out);
+extern void NormalizeVec3(Vec3* a, Vec3* out);
+
+void func_ov080_02125940(char* self)
+{
+    Vec3 ej;
+    Vec3 ei;
+    Vec3 n;
+    char* p;
+    int i;
+    int j;
+    int mask = 0x3ff;
+
+    p = *(char**)(self + 0x1a0);
+
+    for (i = 0; i < *(unsigned char*)(self + 0x1bb); i++) {
+        for (j = 0; j < *(unsigned char*)(self + 0x1ba); j++) {
+            int *q;
+            int z = 0;
+            q = (int*)&ej; q[0] = z; q[1] = z; q[2] = z;
+            q = (int*)&ei; q[0] = z; q[1] = z; q[2] = z;
+            q = (int*)&n;  q[0] = z; q[1] = z; q[2] = z;
+
+            if (j == 0)
+                SubVec3((Vec3*)p, (Vec3*)(p + 0x18), &ej);
+            else if (j == *(unsigned char*)(self + 0x1ba) - 1)
+                SubVec3((Vec3*)(p - 0x18), (Vec3*)p, &ej);
+            else
+                SubVec3((Vec3*)(p - 0x18), (Vec3*)(p + 0x18), &ej);
+
+            if (i == 0)
+                SubVec3((Vec3*)p, (Vec3*)(p + *(unsigned char*)(self + 0x1bb) * 0x18), &ei);
+            else if (i == *(unsigned char*)(self + 0x1bb) - 1)
+                SubVec3((Vec3*)(p - *(unsigned char*)(self + 0x1bb) * 0x18), (Vec3*)p, &ei);
+            else
+                SubVec3((Vec3*)(p - *(unsigned char*)(self + 0x1bb) * 0x18),
+                        (Vec3*)(p + *(unsigned char*)(self + 0x1bb) * 0x18), &ei);
+
+            CrossVec3(&ej, &ei, &n);
+            n.z >>= 1;
+            NormalizeVec3(&n, &n);
+            *(int*)(p + 0x10) = (n.x >> 3 & mask)
+                | ((n.y >> 3 & mask) << 10)
+                | ((n.z >> 3 & mask) << 20);
+            p += 0x18;
+        }
+    }
+}

--- a/src/func_ov080_02125af0.c
+++ b/src/func_ov080_02125af0.c
@@ -1,42 +1,32 @@
-// NONMATCHING: register allocation (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+/* walk entry pointer: p starts at base, p += 1 each (struct size 0x18) */
+typedef struct { int a,b,c,pad,e,pad2; } Ent;
 void func_ov080_02125af0(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
     int i;
-    int idx;
-    int cnt = *(u16 *)((c + 0x100) + 0xb8);
-
+    int cnt = *(unsigned short *)((c + 0x100) + 0xb8);
     i = 0;
     if (cnt <= 0) return;
-
-    idx = i;
     do {
-        char *base = (char *)*(int **)(c + 0x1a0);
-        int v = *(int *)(base + idx);
+        Ent *e = *(Ent **)(c + 0x1a0) + i;
+        int v = e->a;
         if (v != 0) {
-            u32 t = *(u32 *)(c + 8);
-            int a = ((u8)(t & 0xf) + 1) * 0x64000;
+            unsigned int t = *(unsigned int *)(c + 8);
+            int a = ((unsigned char)(t & 0xf) + 1) * 0x64000;
             if (v != a) {
-                int v2 = *(int *)(base + idx + 4);
+                int v2 = e->b;
                 if (v2 != 0) {
-                    int b = ((u8)((t >> 4) & 0xf) + 1) * 0x64000;
+                    int b = ((unsigned char)((t >> 4) & 0xf) + 1) * 0x64000;
                     if (v2 != b) goto next;
                 }
             }
         }
-        *(int *)(base + idx + 8) = 0;
+        e->c = 0;
         {
-            char *base2 = (char *)*(int **)(c + 0x1a0);
-            *(int *)(base2 + idx + 0x10) = 0x1ff00000;
+            Ent *e2 = *(Ent **)(c + 0x1a0) + i;
+            e2->e = 0x1ff00000;
         }
     next:
         i++;
-        idx += 0x18;
-    } while (i < *(u16 *)((c + 0x100) + 0xb8));
+    } while (i < *(unsigned short *)((c + 0x100) + 0xb8));
 }

--- a/src/func_ov080_02125de0.c
+++ b/src/func_ov080_02125de0.c
@@ -1,0 +1,36 @@
+typedef unsigned int u32;
+extern void func_ov080_02125d64(char* c);
+extern char data_ov080_021277a8[];
+
+void func_ov080_02125de0(char* c, int a1, int a2, int a3)
+{
+    u32 m8;
+    int r0;
+    unsigned char f;
+    *(int*)(c + 0x134) = a1;
+    *(int*)(c + 0x138) = a2;
+    *(int*)(c + 0x13c) = 0;
+    func_ov080_02125d64(c);
+    m8 = *(u32*)(c + 8);
+    r0 = 0;
+    if ((unsigned char)((m8 >> 0xd) & 3) == 1) {
+        f = (unsigned char)((m8 >> 8) & 0x1f);
+        if (f == 4)
+            r0 = 0xc;
+        else if (f == 7)
+            r0 = 0xd;
+    } else {
+        switch ((unsigned char)(m8 & 0xf) + 1) {
+        case 3: r0 = 0; break;
+        case 4: r0 = 1; break;
+        case 5: r0 = 2; break;
+        case 6: r0 = 3; break;
+        case 7: r0 = 4; break;
+        case 16: r0 = 5; break;
+        }
+        if (a3 != 0)
+            r0 += 6;
+    }
+    *(char**)(c + 0x1ac) = data_ov080_021277a8 + r0 * 0x14;
+    *(unsigned short*)(c + 0x1b6) = *(int*)(*(char**)(c + 0x1ac) + 0x10);
+}

--- a/src/func_ov080_02125fd0.c
+++ b/src/func_ov080_02125fd0.c
@@ -1,6 +1,4 @@
-// NONMATCHING: different op / idiom (div=41). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+/* use unsigned loads / different shift form (>>8) cast s16 */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef short s16;
@@ -14,7 +12,7 @@ void func_ov080_02125fd0(char* self)
 {
     int tmp[13];
     int i;
-    char* p;
+    int* p;
 
     *(int*)0x4000444 = 0;
     MulMat4x3Mat4x3((void*)(self + 0xd4), &data_0209b3ec, tmp);
@@ -30,15 +28,22 @@ void func_ov080_02125fd0(char* self)
     *(int*)0x4000500 = 1;
 
     i = 0;
-    p = self + 0x140;
+    p = (int*)(self + 0x140);
     do {
-        *(int*)0x4000488 = *(int*)(p + 0x14);
-        *(int*)0x4000484 = *(int*)(p + 0x10);
-        *(int*)0x400048c = (u16)(s16)((*(int*)(p + 0) << 8) >> 0x10)
-                         | (s16)((*(int*)(p + 4) << 8) >> 0x10) << 0x10;
-        *(int*)0x400048c = (u16)(s16)((*(int*)(p + 8) << 8) >> 0x10);
+        int v0, v1, v2;
+        s16 s0, s1, s2;
+        *(int*)0x4000488 = p[5];
+        *(int*)0x4000484 = p[4];
+        v0 = p[0];
+        v1 = p[1];
+        v2 = p[2];
+        s0 = (s16)(v0 >> 8);
+        s1 = (s16)(v1 >> 8);
+        s2 = (s16)(v2 >> 8);
+        *(int*)0x400048c = (u16)s0 | ((u16)s1 << 16);
+        *(int*)0x400048c = (u16)s2;
         i++;
-        p += 0x18;
+        p += 6;
     } while (i < 4);
 
     *(int*)0x4000504 = 0;

--- a/src/func_ov080_0212677c.c
+++ b/src/func_ov080_0212677c.c
@@ -1,0 +1,84 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned char u8;
+
+extern void func_ov080_02125fd0(char *c);
+extern void MulMat4x3Mat4x3(const void *a, const void *b, void *out);
+extern void func_020553a4(void *m);
+extern void func_ov080_02125460(char *c);
+extern int data_0209b3ec;
+
+void func_ov080_0212677c(char *self)
+{
+    int tmp[12];
+    int i, j, n;
+    int z = 0;
+
+    if (*(u16 *)((self + 0x100) + 0xb6) == 0) {
+        func_ov080_02125fd0(self);
+        return;
+    }
+
+    *(int *)0x4000444 = z;
+    MulMat4x3Mat4x3((void *)(self + 0xd4), &data_0209b3ec, tmp);
+    *(int *)0x4000440 = 2;
+    func_020553a4(tmp);
+    *(int *)0x4000440 = 1;
+    func_020553a4(tmp);
+
+    *(int *)0x40004c8 = 0xe0000000;
+    *(int *)0x40004cc = 0xc0007fff;
+    func_ov080_02125460(self);
+
+    *(int *)0x400046c = 0x20000;
+    *(int *)0x400046c = 0x20000;
+    *(int *)0x400046c = 0x20000;
+
+    n = (int)*(u8 *)(self + 0x1ba);
+    i = z; /* mov before sub: use z then sub n */
+    n = n - 1;
+    if (n > 0) {
+        do {
+            *(int *)0x4000500 = 2;
+            j = z;
+            if ((int)*(u8 *)(self + 0x1bb) > 0) {
+                do {
+                    char *base = *(char **)(self + 0x1a0);
+                    int cols = (int)*(u8 *)(self + 0x1bb);
+                    char *v1 = base + (i + j * cols) * 0x18;
+                    char *v2 = base + ((i + 1) + j * cols) * 0x18;
+                    int v0, v1y, v2z;
+                    s16 s0, s1, s2;
+
+                    *(int *)0x4000488 = *(int *)(v1 + 0x14);
+                    *(int *)0x4000484 = *(int *)(v1 + 0x10);
+                    v0 = *(int *)(v1 + 0);
+                    v1y = *(int *)(v1 + 4);
+                    v2z = *(int *)(v1 + 8);
+                    s0 = (s16)(v0 >> 8);
+                    s1 = (s16)(v1y >> 8);
+                    s2 = (s16)(v2z >> 8);
+                    *(int *)0x400048c = (u16)s0 | ((u16)s1 << 16);
+                    *(int *)0x400048c = (u16)s2;
+
+                    *(int *)0x4000488 = *(int *)(v2 + 0x14);
+                    *(int *)0x4000484 = *(int *)(v2 + 0x10);
+                    v0 = *(int *)(v2 + 0);
+                    v1y = *(int *)(v2 + 4);
+                    v2z = *(int *)(v2 + 8);
+                    s0 = (s16)(v0 >> 8);
+                    s1 = (s16)(v1y >> 8);
+                    s2 = (s16)(v2z >> 8);
+                    *(int *)0x400048c = (u16)s0 | ((u16)s1 << 16);
+                    *(int *)0x400048c = (u16)s2;
+
+                    j++;
+                } while (j < (int)*(u8 *)(self + 0x1bb));
+            }
+            *(int *)0x4000504 = z;
+            i++;
+        } while (i < (int)*(u8 *)(self + 0x1ba) - 1);
+    }
+    *(int *)0x4000448 = 1;
+}

--- a/src/func_ov080_02126ca0.cpp
+++ b/src/func_ov080_02126ca0.cpp
@@ -1,0 +1,121 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+struct C;
+typedef void (C::*PMF)();
+struct Disp {
+    PMF pmf;
+    int pad[4];
+};
+
+extern "C" void* _ZN6Memory13operator_new2Ej(unsigned int n);
+extern "C" int func_ov080_02125630(void* c, int a);
+extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b, int c, int d);
+extern "C" void func_ov080_0212555c(void* c);
+
+extern u8 data_ov080_02127714[];
+extern void* data_ov080_02127834;
+extern Disp data_ov080_02128628[];
+extern int data_0209caa0[];
+
+extern "C" int func_ov080_02126ca0(char* c)
+{
+    unsigned int m = (unsigned char)((*(unsigned int*)(c + 8) >> 0xd) & 3);
+
+    if (m >= 2) {
+        *(u8*)(c + 0x1bb) = 2;
+        *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+        *(u16*)(c + 0x1b8) = (u16)(*(u8*)(c + 0x1ba) * *(u8*)(c + 0x1bb));
+    } else {
+        unsigned int idx = (unsigned char)(*(unsigned int*)(c + 8) & 0xf) + 1;
+        switch (idx) {
+        case 0:
+        case 1:
+        case 2:
+            break;
+        case 3:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[0];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 4:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[1];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 5:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[2];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 6:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[3];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 7:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[4];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 8:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[5];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        case 9:
+        case 10:
+        case 11:
+        case 12:
+        case 13:
+        case 14:
+        case 15:
+            break;
+        case 16:
+            *(u8*)(c + 0x1bb) = data_ov080_02127714[6];
+            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            break;
+        }
+        *(u16*)(c + 0x1b8) = (u16)(*(u8*)(c + 0x1ba) * *(u8*)(c + 0x1bb));
+    }
+
+    *(void**)(c + 0x1a0) = _ZN6Memory13operator_new2Ej((unsigned)(*(u16*)(c + 0x1b8)) * 0x18u);
+    *(int*)(c + 0x1a8) = func_ov080_02125630(c, (int)((unsigned char)((*(unsigned int*)(c + 8) >> 8) & 0x1f)));
+    *(void**)(c + 0x1ac) = &data_ov080_02127834;
+    {
+        unsigned int mi = (unsigned char)((*(unsigned int*)(c + 8) >> 0xd) & 3);
+        *(Disp**)(c + 0x1a4) = &data_ov080_02128628[mi];
+    }
+    {
+        Disp* d = *(Disp**)(c + 0x1a4);
+        C* o = (C*)c;
+        (o->*(d->pmf))();
+    }
+
+    {
+        unsigned int f = *(unsigned int*)(c + 8);
+        int lo = (int)((unsigned char)(f & 0xf) + 1);
+        int hi = (int)((unsigned char)((f >> 4) & 0xf) + 1);
+        int a = lo * 0x64000;
+        int b = hi * 0x64000;
+        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, b / 2, (a / 2) + 0xc8000, 0x1964000, 0x1964000);
+    }
+    {
+        unsigned int f = *(unsigned int*)(c + 8);
+        if ((unsigned char)((f >> 8) & 0x1f) == 4) {
+            if ((unsigned char)((f >> 0xd) & 3) == 1) {
+                int* pb0 = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+                *pb0 = *pb0 & ~3;
+            }
+        }
+    }
+    {
+        unsigned int f = *(unsigned int*)(c + 8);
+        if ((unsigned char)((f >> 8) & 0x1f) == 7) {
+            if ((unsigned char)((f >> 0xd) & 3) == 1) {
+                *(int*)(c + 0x1b0) = *(int*)(c + 0x5c);
+                if (data_0209caa0[2] & 0x40000) {
+                    int* p = (int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                    *p = *p + 0x802000;
+                }
+            }
+        }
+    }
+    func_ov080_0212555c(c);
+    return 1;
+}

--- a/src/func_ov080_0212714c.c
+++ b/src/func_ov080_0212714c.c
@@ -1,0 +1,138 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void *self, s16 a, s16 b, s16 c, int d);
+extern int DecIfAbove0_Byte(u8 *p);
+extern int Vec3_Dist(void *a, void *b);
+extern short Vec3_HorzAngle(void *a, void *b);
+extern int AngleDiff(int a, int b);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *a, void *b);
+extern void Vec3_Sub(void *out, void *a, void *b);
+extern int LenVec3(void *v);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void *);
+extern u16 DecIfAbove0_Short(u16 *p);
+extern void func_ov080_02127094(char *t);
+extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *, int, int);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, int, int);
+
+int func_ov080_0212714c(char *c, int *p2)
+{
+    int tmp[3];
+    int len;
+    int ang;
+    s16 v;
+    int horz;
+
+    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(c, (s16)-0x1500, 0, 0, 0) != 0)
+        return 1;
+    if ((int)((*(int *)(c + 0xb0) & 8) != 0) != 0)
+        return 1;
+
+    if (*(u8 *)(c + 0x342) == 0) {
+        if (DecIfAbove0_Byte((u8 *)((int)c + 0x33e))) {
+            if (*(s16 *)((c + 0x300) + 0x3c) > 0) {
+                s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p = (s16)(*p - 0x10);
+            } else {
+                s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p = (s16)(*p + 0x10);
+            }
+            v = *(s16 *)((c + 0x300) + 0x3c);
+            if (v <= 0x10 && v >= (s16)-0x10)
+                *(s16 *)((c + 0x300) + 0x3c) = 0;
+        } else {
+            v = *(s16 *)((c + 0x300) + 0x3c);
+            if (v != 0x100) {
+                if (v > 0x100) {
+                    s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *p = (s16)(*p - 0x10);
+                } else {
+                    s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *p = (s16)(*p + 0x10);
+                }
+                v = *(s16 *)((c + 0x300) + 0x3c);
+                if (v < 0x110 && v > 0xf0)
+                    *(s16 *)((c + 0x300) + 0x3c) = 0x100;
+            }
+        }
+        if (Vec3_Dist(c + 0x5c, c + 0x320) < 0x2000)
+            *(s16 *)((c + 0x300) + 0x3c) = 0;
+    } else {
+        horz = Vec3_HorzAngle(c + 0x5c, c + 0x32c);
+        AngleDiff(horz, *(s16 *)(c + 0x8e));
+        ang = AngleDiff(horz, *(s16 *)(c + 0x8e));
+        if (ang > 0x4000) {
+            s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p = (s16)(*p - 0x10);
+        } else {
+            s16 *p = (s16 *)(int)(((long long)(int)(c + 0x33c)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p = (s16)(*p + 0x10);
+        }
+        v = *(s16 *)((c + 0x300) + 0x3c);
+        {
+            int lim = 0x200;
+            int nlim = -lim;
+            if (v < nlim)
+                v = (s16)nlim;
+            else if (v > lim)
+                v = (s16)lim;
+        }
+        *(s16 *)((c + 0x300) + 0x3c) = v;
+    }
+
+    {
+        int d = *(s16 *)((c + 0x300) + 0x3c);
+        int t = d + ((unsigned)(d >> 5) >> 26);
+        *(int *)(c + 0x98) = (t >> 6) << 12;
+    }
+    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+    Vec3_Sub(tmp, c + 0x5c, c + 0x320);
+    len = LenVec3(tmp);
+    ang = Vec3_HorzAngle(c + 0x5c, c + 0x320);
+    ang = AngleDiff(ang, *(s16 *)(c + 0x8e));
+    if (ang >= 0x7f00)
+        ang = 0x8000;
+    if (ang <= 0x100)
+        ang = 0;
+    if (len > *p2) {
+        *(int *)(c + 0x5c) = *(int *)(c + 0x68);
+        *(int *)(c + 0x60) = *(int *)(c + 0x6c);
+        *(int *)(c + 0x64) = *(int *)(c + 0x70);
+    }
+    if (ang == *(int *)(c + 0x338) || ang == 0x8000) {
+        *(int *)(c + 0x5c) = *(int *)(c + 0x68);
+        *(int *)(c + 0x60) = *(int *)(c + 0x6c);
+        *(int *)(c + 0x64) = *(int *)(c + 0x70);
+        *(u8 *)(c + 0x33e) = 0xa;
+    }
+    {
+        s16 *px = (s16 *)(int)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+        *px = (s16)(*px + *(s16 *)((c + 0x300) + 0x3c));
+    }
+    {
+        int mask = 0x1fff;
+        if ((*(s16 *)(c + 0x8c) & mask) < 0x210 && *(s16 *)((c + 0x300) + 0x3c) != 0) {
+            if (*(u16 *)((c + 0x300) + 0x40) == 0) {
+                _ZN5Sound9PlayBank3EjRK7Vector3(0x25, c + 0x74);
+                *(u16 *)((c + 0x300) + 0x40) = 0xe;
+            }
+        } else {
+            DecIfAbove0_Short((u16 *)(c + 0x340));
+        }
+    }
+    func_ov080_02127094(c);
+    {
+        int is66 = (int)(*(u16 *)(c + 0xc) == 0x66);
+        if (is66 != 0) {
+            if (_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0) != 0)
+                _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        } else {
+            if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) != 0)
+                _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        }
+    }
+    *(u8 *)(c + 0x342) = 0;
+    return 1;
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for 15 ov080 functions (mwccarm **1.2/sp2p3**, flags: `-O4,p -enum int -lang c99` / `//cpp` where needed, `-char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).

| Function | Addr | Size |
|---|---|---|
| `func_ov080_02123a34` | `0x02123a34` | `0x1f0` |
| `func_ov080_02123c24` | `0x02123c24` | `0x2a8` |
| `func_ov080_02124360` | `0x02124360` | `0x78` |
| `func_ov080_02124acc` | `0x02124acc` | `0x170` |
| `func_ov080_02124c3c` | `0x02124c3c` | `0x224` |
| `func_ov080_02124edc` | `0x02124edc` | `0x110` |
| `func_ov080_02125630` | `0x02125630` | `0xc8` |
| `func_ov080_021256f8` | `0x021256f8` | `0x248` |
| `func_ov080_02125940` | `0x02125940` | `0x1b0` |
| `func_ov080_02125af0` | `0x02125af0` | `0xc0` |
| `func_ov080_02125de0` | `0x02125de0` | `0x120` |
| `func_ov080_02125fd0` | `0x02125fd0` | `0x150` |
| `func_ov080_0212677c` | `0x0212677c` | `0x23c` |
| `func_ov080_02126ca0` | `0x02126ca0` | `0x2ec` |
| `func_ov080_0212714c` | `0x0212714c` | `0x360` |

Verified locally with `tools/match.py --module ov080 --version 1.2/sp2p3`.

### Not in this PR

- **`func_ov080_021261f4`** (`0x021261f4`, `0x2f8`): near-miss **div=5** — pure 4a8 TEXIMAGE_PARAM first-combine regperm (`ldr r2,[r2]` vs `ldr r3,[r2]`). Same wall as existing NONMATCHING `func_ov080_02125460`. Draft banked in scratch; not promoted to `src/`.

## Test plan

- [ ] CI `validate` green on all listed files
- [ ] linkcheck clean if applicable

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build