### PR TITLE
Match 14 ov084 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
+++ b/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
@@ -1,13 +1,10 @@
 //cpp
-// NONMATCHING: different op / idiom (div=9). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vector3 { int x, y, z; };
 extern "C" void func_ov084_0212c9a8(void *c);
 extern "C" void *_ZN5Actor13ClosestPlayerEv(void *thiz);
 extern "C" int Vec3_HorzDist(const Vector3* a, const Vector3* b);
 extern "C" short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
-extern "C" void _Z14ApproachLinearRsss(short &r, short b, short c);
+extern "C" int _Z14ApproachLinearRsss(short *r, short b, short c);
 extern "C" void _ZN9Animation7AdvanceEv(void *a);
 extern "C" void func_02012694(int a0, void *a1);
 extern "C" void func_ov084_0212ce50(void *c);
@@ -21,20 +18,17 @@ extern "C" int _ZN11BobOmbBuddy8BehaviorEv(char *thiz)
     func_ov084_0212c9a8(thiz);
     p = (char*)_ZN5Actor13ClosestPlayerEv(thiz);
     if (p != 0) {
-        Vector3 *pv = (Vector3*)(p + 0x5c);
-        v.x = pv->x;
-        v.y = pv->y;
-        v.z = pv->z;
+        Vector3 *ps = (Vector3 *)(((unsigned long long)(unsigned)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFULL);
+        v = *ps;
         if (Vec3_HorzDist((Vector3*)(thiz + 0x5c), &v) < 0x12c000) {
             short ang = Vec3_HorzAngle((Vector3*)(thiz + 0x5c), &v);
-            _Z14ApproachLinearRsss(*(short*)(thiz + 0x8e), ang, 0x100);
+            _Z14ApproachLinearRsss((short*)(thiz + 0x8e), ang, 0x100);
         }
     }
     _ZN9Animation7AdvanceEv(thiz + 0x158);
-    if ((unsigned short)(*(int*)(thiz + 0x160) >> 12) == 0) {
+    if ((unsigned short)(*(int*)(thiz + 0x160) >> 12) == 0)
         func_02012694(0xd7, thiz + 0x74);
-        func_ov084_0212ce50(thiz);
-    }
+    func_ov084_0212ce50(thiz);
     _ZN12CylinderClsn5ClearEv(thiz + 0xd4);
     _ZN12CylinderClsn6UpdateEv(thiz + 0xd4);
     return 1;

--- a/src/_ZN12PiranhaPlant13InitResourcesEv.cpp
+++ b/src/_ZN12PiranhaPlant13InitResourcesEv.cpp
@@ -1,0 +1,76 @@
+//cpp
+typedef int Fix12;
+typedef short s16;
+struct Vector3 { int x, y, z; };
+struct SharedFilePtr { int id; void* file; };
+extern "C" {
+void* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* f);
+void LoadBlueCoinModel(void* c);
+int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
+void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, const Vector3* v, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12 b, Fix12 cc, void* d, void* e);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, Fix12 b, unsigned int cc);
+extern SharedFilePtr* data_ov084_021302f4[];
+extern SharedFilePtr data_ov084_02130dfc;
+extern SharedFilePtr data_ov002_0210da38;
+extern SharedFilePtr data_ov084_02130df4;
+extern s16 data_02082214[];
+}
+extern "C" int _ZN12PiranhaPlant13InitResourcesEv(char* c)
+{
+    int i;
+    Vector3 v;
+    for (i = 0; i < 6; i++)
+        _ZN9Animation8LoadFileER13SharedFilePtr(data_ov084_021302f4[i]);
+    LoadBlueCoinModel(c);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov084_02130dfc);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da38);
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x110, data_ov084_02130dfc.file, 1, -1) == 0)
+        return 0;
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x174, data_ov002_0210da38.file, 1, -1) == 0)
+        return 0;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x380, c, 0x32000, 0x64000, 0x200004, 0x423e0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x3b4, c, 0x82000, 0x64000, 2, 0x423e0);
+    v.x = 0; v.y = 0; v.z = 0;
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c + 0x3e8, c, &v, 0x46000, 0x64000, 0x200002, 0);
+    *(int*)(c + 0x80) = 0x1000;
+    *(int*)(c + 0x84) = 0x1000;
+    *(int*)(c + 0x88) = 0x1000;
+    *(int*)(c + 0x458) = 0;
+    *(short*)(c + 0x468) = *(short*)(c + 0x94);
+    *(int*)(c + 0x464) = 0x7fffffff;
+    *(int*)(c + 0x460) = 0;
+    *(unsigned char*)(c + 0x45c) = 0;
+    *(unsigned char*)(c + 0x45d) = 1;
+    *(short*)(c + 0x100) = 0;
+    *(unsigned char*)(c + 0x108) = 3;
+    *(int*)(c + 0x46c) = 0;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1c4, c, 0x64000, 0x64000, 0, 0);
+    *(int*)(c + 0x440) = *(int*)(c + 0x5c);
+    *(int*)(c + 0x444) = *(int*)(c + 0x60);
+    *(int*)(c + 0x448) = *(int*)(c + 0x64);
+    {
+        s16 *tbl = data_02082214;
+        Vector3* home = (Vector3*)(((int)c + 0x440) & 0xFFFFFFFFFFFFFFFFLL);
+        *(Vector3*)(c + 0x44c) = *home;
+        unsigned short angh = *(unsigned short*)(c + 0x8e);
+        int ang = angh >> 4;
+        int y0 = *(int*)(c + 0x60);
+        int z0 = *(int*)(c + 0x64);
+        int cosv = tbl[(ang << 1) + 1];
+        int sinv = tbl[ang << 1];
+        int z = cosv * 0xe0 + z0;
+        int y = y0 + 0x37800;
+        int x = sinv * 0xe0 + *(int*)(c + 0x5c);
+        *(int*)(c + 0x434) = x;
+        *(int*)(c + 0x438) = y;
+        *(int*)(c + 0x43c) = z;
+    }
+    *(int*)(c + 0x474) = 0;
+    *(int*)(c + 0x470) = *(int*)(c + 0x474);
+    *(int*)(c + 0x478) = 0;
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, data_ov084_02130df4.file, 0, 0x1000, 0);
+    return 1;
+}

--- a/src/_ZN12PiranhaPlant8BehaviorEv.cpp
+++ b/src/_ZN12PiranhaPlant8BehaviorEv.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=44). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Cls { virtual void dummy(); };
 typedef void (Cls::*PMF)();
 extern PMF data_ov084_02130e80[];
@@ -14,51 +11,56 @@ extern void func_ov084_0212ec60(void*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
 extern void _ZN12CylinderClsn6UpdateEv(void*);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void*, void*);
-int _ZN12PiranhaPlant8BehaviorEv(char* c){
-  int r;
-  int old;
-  r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1c4, c + 0x110, 1);
-  if (r != 0) {
-    if (r == 2) {
-      *(unsigned char*)(c + 0x108) = 0;
-      *(int*)(c + 0x458) = 7;
-      *(int*)(c + 0x80) = 0;
-      *(int*)(c + 0x84) = 0;
-      *(int*)(c + 0x88) = 0;
-      *(int*)(c + 0x5c) = *(int*)(c + 0x44c);
-      *(int*)(c + 0x60) = *(int*)(c + 0x450);
-      *(int*)(c + 0x64) = *(int*)(c + 0x454);
+
+int _ZN12PiranhaPlant8BehaviorEv(char* c)
+{
+    int r;
+    int old;
+    int cur;
+    r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1c4, c + 0x110, 1);
+    if (r != 0) {
+        if (r == 2) {
+            *(unsigned char*)(c + 0x108) = 0;
+            *(int*)(c + 0x458) = 7;
+            *(int*)(c + 0x80) = 0;
+            *(int*)(c + 0x84) = 0;
+            *(int*)(c + 0x88) = 0;
+            *(int*)(c + 0x5c) = *(int*)(c + 0x44c);
+            *(int*)(c + 0x60) = *(int*)(c + 0x450);
+            *(int*)(c + 0x64) = *(int*)(c + 0x454);
+        }
+        return 1;
     }
-    return 1;
-  }
-  {
     _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x380);
     _ZN9Animation7AdvanceEv(c + 0x160);
     func_ov084_0212f204(c);
     old = *(int*)(c + 0x458);
     (((Cls*)c)->*data_ov084_02130e80[old])();
-    *(unsigned short*)(c + 0x100) = *(unsigned short*)(c + 0x100) + 1;
-    if (old != *(int*)(c + 0x458)) {
-      if (*(int*)(c + 0x458) == 5) {
-        int* pb0 = (int*)(c + 0xb0);
-        *pb0 = *pb0 & ~0x10000000;
-      }
-      *(unsigned short*)(c + 0x100) = 0;
-      *(int*)(c + 0x478) = 0;
+    {
+        unsigned short* p100 = (unsigned short*)(((long long)(int)(c + 0x100)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p100 = (unsigned short)(*p100 + 1);
+    }
+    cur = *(int*)(c + 0x458);
+    if (old != cur) {
+        if (cur == 5) {
+            int* pb0 = (int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            *pb0 = *pb0 & ~0x10000000;
+        }
+        *(unsigned short*)(c + 0x100) = 0;
+        *(int*)(c + 0x478) = 0;
     }
     func_ov084_0212ec60(c);
     _ZN12CylinderClsn5ClearEv(c + 0x380);
     _ZN12CylinderClsn5ClearEv(c + 0x3b4);
     _ZN12CylinderClsn5ClearEv(c + 0x3e8);
     if (*(unsigned char*)(c + 0x45c) != 0) {
-      _ZN12CylinderClsn6UpdateEv(c + 0x380);
-      _ZN12CylinderClsn6UpdateEv(c + 0x3b4);
-      if (*(int*)(c + 0x458) == 2) {
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x3e8, c + 0x440);
-      }
-      _ZN12CylinderClsn6UpdateEv(c + 0x3e8);
+        _ZN12CylinderClsn6UpdateEv(c + 0x380);
+        _ZN12CylinderClsn6UpdateEv(c + 0x3b4);
+        if (*(int*)(c + 0x458) == 2) {
+            _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x3e8, c + 0x440);
+            _ZN12CylinderClsn6UpdateEv(c + 0x3e8);
+        }
     }
-  }
-  return 1;
+    return 1;
 }
 }

--- a/src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp
@@ -1,0 +1,98 @@
+//cpp
+typedef int Fix12;
+struct Vector3 { int x, y, z; };
+struct SharedFilePtr { int id; void *file; };
+
+extern "C" {
+void *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr *f);
+void *_ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr *f);
+int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
+void LoadBlueCoinModel(void *c);
+void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *f, int a, Fix12 b, unsigned int cc);
+void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *a, Vector3 *v, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+int _ZN5Actor18GetBitInDeathTableEv(void *self);
+
+extern SharedFilePtr data_ov084_02130dfc;
+extern SharedFilePtr *data_ov084_021302f4[];
+extern SharedFilePtr data_ov002_0210da38;
+extern SharedFilePtr data_ov084_02130df4;
+}
+
+extern "C" int _ZN19FirePiranhaPlantBig13InitResourcesEv(char *c)
+{
+    int i;
+    Vector3 v;
+    int id;
+    int cond;
+
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(
+        c + 0x110,
+        _ZN5Model8LoadFileER13SharedFilePtr(&data_ov084_02130dfc),
+        1, -1);
+
+    for (i = 0; i < 6; i++)
+        _ZN9Animation8LoadFileER13SharedFilePtr(data_ov084_021302f4[i]);
+
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da38);
+    LoadBlueCoinModel(c);
+
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
+        c + 0x110, data_ov084_02130df4.file, 0x40000000, 0x1000, 0);
+
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(
+        c + 0x174, c, 0, 0, 0x200001, 0x66fe0);
+
+    v.x = 0;
+    v.y = 0;
+    v.z = 0;
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
+        c + 0x1a8, c, &v, 0x4b000, 0x64000, 0x200002, 0x66fe0);
+
+    *(int *)(c + 0x204) = 0;
+    *(int *)(c + 0x1e8) = 0;
+    *(int *)(c + 0x1ec) = 0;
+    *(int *)(c + 0x1f0) = 0;
+    *(int *)(c + 0x1f4) = 0;
+    *(unsigned char *)(c + 0x21a) = 0;
+    *(unsigned char *)(c + 0x21b) = 0;
+    *(unsigned char *)(c + 0x21c) = 0;
+    *(unsigned char *)(c + 0x21d) = 0;
+    *(unsigned char *)(c + 0x21e) = 1;
+    *(int *)(c + 0x228) = 0;
+    *(int *)(c + 0x224) = *(int *)(c + 0x228);
+
+    id = *(unsigned short *)(c + 0xc);
+    cond = (id == 0xfc);
+    if (cond != 0) {
+        *(int *)(c + 0x208) = 0x3c;
+        *(int *)(c + 0x20c) = 0xaa;
+        *(int *)(c + 0x210) = 0x800;
+        *(int *)(c + 0x214) = 0x52;
+        *(int *)(c + 0x1ec) = 1;
+        *(int *)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFF) |= 0x8000;
+    } else {
+        cond = (id == 0xfd);
+        if (cond != 0) {
+            *(int *)(c + 0x208) = 0x28;
+            *(int *)(c + 0x20c) = 0xaa;
+            *(int *)(c + 0x210) = 0x1000;
+            *(int *)(c + 0x214) = 0xa4;
+            *(int *)(c + 0x1ec) = 1;
+        } else {
+            *(int *)(c + 0x208) = 0x28;
+            *(int *)(c + 0x20c) = 0x96;
+            *(int *)(c + 0x210) = 0x2000;
+            *(int *)(c + 0x214) = 0x147;
+            *(int *)(c + 0x1ac) = 0x64000;
+            *(int *)(c + 0x1b0) = 0x64000;
+            if (_ZN5Actor18GetBitInDeathTableEv(c) != 0)
+                *(unsigned char *)(c + 0x220) = 0;
+            else
+                *(unsigned char *)(c + 0x220) = 1;
+        }
+    }
+
+    *(unsigned char *)(c + 0x21f) = (unsigned char)(*(int *)(c + 8) & 0xf);
+    return 1;
+}

--- a/src/_ZN6Goomba16CleanupResourcesEv.c
+++ b/src/_ZN6Goomba16CleanupResourcesEv.c
@@ -1,7 +1,4 @@
-// NONMATCHING: different op / idiom (div=15). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void UnloadBlueCoinModel(void);
+extern void UnloadBlueCoinModel(void* p);
 extern void _ZN13SharedFilePtr7ReleaseEv(void* p);
 extern void UnloadSilverStarAndNumber(void);
 extern void _ZN8CapEnemy14UnloadCapModelEv(char* c);
@@ -10,25 +7,23 @@ extern char data_ov084_02130cf8[];
 extern void* data_ov084_02130278[];
 
 int _ZN6Goomba16CleanupResourcesEv(char* c) {
-  if (*(int*)(c+0x460) == 2) {
-    UnloadBlueCoinModel();
-    _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130cf8);
-  }
-  {
-    int i = 0;
-    do {
-      _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130278[i]);
-      i = i + 1;
-    } while (i < 7);
-  }
-  if ((unsigned char)(*(unsigned char*)(c+0x464) + 0xff) <= 1) {
+  int i;
+  if (*(int*)(c + 0x460) == 2)
+    UnloadBlueCoinModel(c);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130cf8);
+  for (i = 0; i < 7; ++i)
+    _ZN13SharedFilePtr7ReleaseEv(data_ov084_02130278[i]);
+  if ((unsigned char)(*(unsigned char*)(c + 0x464) + 0xff) <= 1)
     UnloadSilverStarAndNumber();
-    _ZN8CapEnemy14UnloadCapModelEv(c);
-  }
-  if (*(int*)(c+0x460) == 3 && *(int*)(c+0x43c) != 0) {
-    char* a = _ZN5Actor10FindWithIDEj(*(unsigned int*)(c+0x43c));
-    if (a != 0) {
-      (*(unsigned char*)(a+0x602))--;
+  _ZN8CapEnemy14UnloadCapModelEv(c);
+  if (*(int*)(c + 0x460) == 3) {
+    unsigned int id = *(unsigned int*)(c + 0x43c);
+    if (id != 0) {
+      char* a = _ZN5Actor10FindWithIDEj(id);
+      if (a != 0) {
+        unsigned char *p = (unsigned char*)(((int)a + 0x602) & 0xFFFFFFFFFFFFFFFFLL);
+        *p = *p - 1;
+      }
     }
   }
   return 1;

--- a/src/func_ov084_0212b344.cpp
+++ b/src/func_ov084_0212b344.cpp
@@ -1,0 +1,80 @@
+//cpp
+extern "C" {
+void _ZN8CapEnemy15RespawnIfHasCapEv(char *self);
+int _ZN6Player15IsCollectingCapEv(char *p);
+void _ZN5Actor15GivePlayerCoinsER6Playerhj(char *self, char *p, unsigned char a, unsigned int b);
+void func_ov084_021296cc(char *self);
+void _ZN5Actor11UntrackStarERa(char *self, signed char *p);
+char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const void *pos, const void *rot, int e, int f);
+void _ZN6Player20RegisterEggCoinCountEjbb(char *p, unsigned int a, int b, int c);
+void func_ov084_02129498(char *self);
+}
+
+extern unsigned char data_0209f208;
+extern unsigned char *data_0209f344;
+
+struct Obj {
+    virtual int f00();
+    virtual int f01();
+    virtual int f02();
+    virtual int f03();
+    virtual int f04();
+    virtual int f05();
+    virtual int f06();
+    virtual int f07();
+    virtual int f08();
+    virtual int f09();
+    virtual int f10();
+    virtual int f11();
+    virtual int f12();
+    virtual int f13();
+    virtual int f14();
+    virtual int f15();
+    virtual int f16();
+    virtual int f17();
+    virtual int GetState();
+};
+
+extern "C" void func_ov084_0212b344(char *self, char *player)
+{
+    Obj *o = (Obj *)self;
+    int b5, b4;
+
+    if ((*(unsigned char *)(self + 0x113) & 0xf) < 6 || *(unsigned char *)(self + 0x464) == 2) {
+        *(int *)(self + 0x5c) = *(int *)(self + 0x41c);
+        *(int *)(self + 0x60) = *(int *)(self + 0x420);
+        *(int *)(self + 0x64) = *(int *)(self + 0x424);
+        _ZN8CapEnemy15RespawnIfHasCapEv(self);
+    }
+
+    if (o->GetState() == 6) {
+        if (_ZN6Player15IsCollectingCapEv(player)) {
+            if (*(unsigned char *)(self + 0x108) == 1)
+                _ZN5Actor15GivePlayerCoinsER6Playerhj(self, player, 1, 0);
+            func_ov084_021296cc(self);
+        } else {
+            b5 = 0;
+            b4 = b5;
+            if (*(unsigned char *)(self + 0x108) == 1)
+                b5 = 1;
+            if (*(unsigned char *)(self + 0x464) == 1) {
+                _ZN5Actor11UntrackStarERa(self, (signed char *)(self + 0x465));
+                b4 = 1;
+                _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb4, 0x50, self + 0x41c, 0, *(signed char *)(self + 0xcc), -1);
+                *(int *)(self + 8) = *(int *)(self + 8) & 0xff0f;
+            } else if (*(unsigned char *)(self + 0x464) == 2) {
+                if (*(unsigned char *)(self + 0x466) == data_0209f344[data_0209f208]) {
+                    _ZN5Actor11UntrackStarERa(self, (signed char *)(self + 0x465));
+                    *(unsigned char *)(self + 0x464) = 3;
+                    b4 = 1;
+                }
+            }
+            _ZN6Player20RegisterEggCoinCountEjbb(player, b5, b4, 0);
+        }
+    } else if (o->GetState() == 4) {
+        if (*(unsigned char *)(self + 0x108) == 1)
+            _ZN5Actor15GivePlayerCoinsER6Playerhj(self, player, 1, 0);
+    }
+
+    func_ov084_02129498(self);
+}

--- a/src/func_ov084_0212c508.cpp
+++ b/src/func_ov084_0212c508.cpp
@@ -1,0 +1,154 @@
+//cpp
+typedef short s16;
+typedef unsigned short u16;
+typedef signed char s8;
+typedef unsigned char u8;
+struct Vector3 { int x, y, z; };
+extern "C" s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
+extern "C" int func_ov084_0212cac0(char *c);
+extern "C" int IsCannonOpenInCurLevel(void);
+extern "C" void func_ov084_0212c960(char *c, int i);
+extern "C" int _ZN6Player12GetTalkStateEv(char *c);
+extern "C" int _Z14ApproachLinearRsss(s16 *a, s16 b, s16 c);
+extern "C" int func_ov084_0212caa8(char *c);
+extern "C" s8 NumRedCoins(void);
+extern "C" void func_ov084_0212c9f0(char *c, int arg1, unsigned int arg2);
+extern "C" int ObjectMessageIDToActualMessageID(int id);
+extern "C" int func_ov084_0212ca60(char *c);
+extern "C" void func_02012790(int a);
+extern int data_0209caa0[];
+extern u8 data_0209f288;
+extern s8 data_0209f2f8;
+extern u8 data_0209d660;
+extern u8 data_0209d6bc;
+extern u16 data_0209d6d4;
+extern u8 data_0209f284;
+
+extern "C" void func_ov084_0212c508(char *self)
+{
+    char *r5 = *(char **)(self + 0x194);
+    int r4 = 0;
+    int t = *(int *)(self + 8);
+    s16 r7;
+    struct Vector3 pv;
+    int r1;
+    u16 r4b;
+    if (t != 0xffff)
+        r4 = (u16)t;
+    {
+        int *p = (int *)(unsigned)((unsigned long long)(unsigned)(r5 + 0x5c));
+        int a = p[0];
+        pv.x = a;
+        int b = p[1];
+        pv.y = b;
+        int c = p[2];
+        pv.z = c;
+    }
+    r7 = Vec3_HorzAngle((struct Vector3 *)(self + 0x5c), &pv);
+
+    if (func_ov084_0212cac0(self) != 0) {
+        if (IsCannonOpenInCurLevel() == 0) {
+            func_ov084_0212c960(self, 2);
+            return;
+        }
+    }
+
+    switch (_ZN6Player12GetTalkStateEv(r5)) {
+    case 0:
+        if (_Z14ApproachLinearRsss((s16 *)(self + 0x8e), r7, 0x800) != 0) {
+            if (func_ov084_0212caa8(self) != 0) {
+                if ((data_0209caa0[2] & 0x8000) == 0) {
+                    data_0209caa0[2] |= 0x8000;
+                    r1 = 0x15b;
+                } else if (NumRedCoins() <= 3) {
+                    r1 = 0x15c;
+                } else if (NumRedCoins() <= 6) {
+                    r1 = 0x15d;
+                } else if (NumRedCoins() == 7) {
+                    r1 = 0x15e;
+                } else {
+                    r1 = 0x15f;
+                }
+                func_ov084_0212c9f0(self, r1, 0);
+                data_0209f288 = 1;
+            } else if (func_ov084_0212cac0(self) != 0 && IsCannonOpenInCurLevel() != 0) {
+                if (*(u8 *)(self + 0x1ea) == 0) {
+                    if (data_0209f2f8 == 6)
+                        r1 = 0x8f;
+                    else
+                        r1 = 0x14a;
+                } else {
+                    if (data_0209f2f8 == 6)
+                        r1 = 0x90;
+                    else
+                        r1 = 0x14b;
+                }
+                *(u8 *)(self + 0x1ea) = 1;
+                func_ov084_0212c9f0(self, r1, 0);
+            } else {
+                r1 = ObjectMessageIDToActualMessageID((int)(s16)r4);
+                r1 = r1 + *(int *)(r5 + 8);
+                func_ov084_0212c9f0(self, (u16)r1, 0);
+            }
+        }
+        break;
+    case 1:
+        break;
+    default:
+        func_ov084_0212c960(self, 0);
+        break;
+    }
+
+    if (data_0209d660 == 0)
+        return;
+
+    if (data_0209d6bc == 9) {
+        if (func_ov084_0212caa8(self) != 0)
+            data_0209f288 = 0;
+    }
+
+    {
+        u8 d6bc = data_0209d6bc;
+        if (*(u16 *)(self + 0x1ec) != d6bc) {
+            if (d6bc == 3)
+                goto do_inc;
+            if (d6bc != 9)
+                goto skip_inc;
+        do_inc:
+            {
+                u8 *p = (u8 *)(((long long)(int)(self + 0x1eb)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p = (u8)(*p + 1);
+            }
+        skip_inc:
+            ;
+        }
+    }
+
+    r4b = data_0209d6d4;
+    if (r4b == 0x15c || r4b == 0x15e || func_ov084_0212ca60(self) != 0) {
+        if (*(u8 *)(self + 0x1eb) == 0)
+            data_0209f284 = 1;
+        else
+            data_0209f284 = 0;
+    }
+
+    if (r4b == 0x15b || r4b == 0x15d) {
+        if (*(u8 *)(self + 0x1eb) == 1)
+            data_0209f284 = 1;
+        else
+            data_0209f284 = 0;
+    }
+
+    if (r4b == 0x8a) {
+        if (*(u8 *)(self + 0x1eb) == 1)
+            data_0209f284 = 1;
+        if (data_0209d6bc == 9)
+            data_0209f284 = 0;
+    }
+
+    if (*(u8 *)(self + 0x1ee) != data_0209f284 && data_0209f284 != 0)
+        func_02012790(0x24);
+
+    *(u8 *)(self + 0x1ee) = data_0209f284;
+    *(u16 *)(self + 0x1ec) = data_0209d6bc;
+}

--- a/src/func_ov084_0212cae0.c
+++ b/src/func_ov084_0212cae0.c
@@ -1,12 +1,7 @@
-// NONMATCHING: different op / idiom (div=39). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 struct Mtx43 { int m[12]; };
-
 extern char *data_0209f318;
 extern struct Mtx43 data_020a0e68;
-
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void MulVec3Mat4x3(struct Vec3 *v, struct Mtx43 *m, struct Vec3 *out);
@@ -17,84 +12,60 @@ extern void _ZN6Camera6SetPosERK7Vector3(void *cam, struct Vec3 *v);
 
 int func_ov084_0212cae0(char *self)
 {
+    int ok2, ok1;
     char *cam;
     char *actor;
-    struct Vec3 vF;
-    struct Vec3 vG;
-    struct Vec3 vA;
-    struct Vec3 vB;
-    struct Vec3 vC;
-    struct Vec3 vD;
-    struct Vec3 vE;
-    int ok1;
-    int ok2;
-
+    struct Vec3 vF, vG, vA, vB, vC, vD, vE;
+    unsigned id = *(unsigned int *)(self + 0x198);
     cam = data_0209f318;
-    if (*(unsigned int *)(self + 0x198) != 0)
-    {
-        actor = _ZN5Actor10FindWithIDEj(*(unsigned int *)(self + 0x198));
-        if (actor != 0)
-            goto body;
+    if (id != 0) {
+        actor = _ZN5Actor10FindWithIDEj(id);
+        if (actor != 0) goto body;
     }
     goto end;
-
 body:
     ok1 = 0;
-    vA.x = ok1;
-    vA.y = 0x80000;
-    vA.z = -0xa000;
-    vB.x = ok1;
-    vB.y = 0x200000;
-    vB.z = 0xc8000;
-    vC.x = ok1;
-    vC.y = ok1;
-    vC.z = ok1;
-
+    vA.x = ok1; vA.y = 0x80000; vA.z = -0xa000;
+    vB.x = ok1; vB.y = 0x200000; vB.z = 0xc8000;
+    vC.x = ok1; vC.y = ok1; vC.z = ok1;
     Matrix4x3_FromRotationY(&data_020a0e68, *(short *)(actor + 0x8e));
     MulVec3Mat4x3(&vA, &data_020a0e68, &vC);
     Vec3_Add(&vD, (struct Vec3 *)(actor + 0x5c), &vC);
-    vC.x = ok1;
-    vA.x = vD.x;
-    vC.y = ok1;
-    vA.y = vD.y;
-    vC.z = ok1;
-    vA.z = vD.z;
-
+    {
+        int dx = vD.x; int dy = vD.y; int z = ok1;
+        *(volatile int *)&vC.x = z; *(volatile int *)&vA.x = dx;
+        *(volatile int *)&vC.y = z; *(volatile int *)&vA.y = dy;
+        int dz = *(volatile int *)&vD.z;
+        *(volatile int *)&vC.z = z; *(volatile int *)&vA.z = dz;
+    }
     MulVec3Mat4x3(&vB, &data_020a0e68, &vC);
     Vec3_Add(&vE, (struct Vec3 *)(actor + 0x5c), &vC);
-    vB.y = vE.y;
-    vB.x = vE.x;
-    vB.z = vE.z;
-
     {
-        struct Vec3 *pF = (struct Vec3 *)(cam + 0x80);
-        vF.x = pF->x;
+        int ey = vE.y; int ex = vE.x;
+        vB.y = ey;
+        int ez = vE.z;
+        vB.x = ez ? ex : ex;
+        vB.z = ez;
+    }
+    {
+        int *pF = (int *)(unsigned)((unsigned long long)(unsigned)(cam + 0x80));
+        vF.x = pF[0];
         {
-            struct Vec3 *pG = (struct Vec3 *)(cam + 0x8c);
-            vF.y = pF->y;
-            vF.z = pF->z;
-            vG.x = pG->x;
-            vG.y = pG->y;
-            vG.z = pG->z;
+            int *pG = (int *)(unsigned)((unsigned long long)(unsigned)(cam + 0x8c));
+            vF.y = pF[1]; vF.z = pF[2];
+            vG.x = pG[0]; vG.y = pG[1]; vG.z = pG[2];
         }
     }
-
     ok1 = func_ov084_0212cda0((int)self, &vF, &vA);
     ok2 = func_ov084_0212cda0((int)self, &vG, &vB);
-
-    if ((*(short *)(self + 0x8c) & 0xff) == 2)
-    {
-        ok1 = 1;
-        ok2 = 1;
+    if ((*(short *)(self + 0x8c) & 0xff) == 2) {
+        ok1 = 1; ok2 = 1;
         _ZN6Camera9SetLookAtERK7Vector3(cam, &vA);
         _ZN6Camera6SetPosERK7Vector3(cam, &vB);
-    }
-    else
-    {
+    } else {
         _ZN6Camera9SetLookAtERK7Vector3(cam, &vF);
         _ZN6Camera6SetPosERK7Vector3(cam, &vG);
     }
-
 end:
     return (ok1 != 0 && ok2 != 0) ? 1 : 0;
 }

--- a/src/func_ov084_0212d42c.c
+++ b/src/func_ov084_0212d42c.c
@@ -1,0 +1,63 @@
+typedef unsigned int u32;
+typedef int Fix12i;
+typedef short s16;
+
+extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    u32 slot, u32 unk, Fix12i x, Fix12i y, Fix12i z, void *rot, void *callback);
+
+extern int data_ov084_02130e24[];
+extern s16 data_02082214[];
+extern int data_ov084_0213029c[];
+extern int data_ov084_021302c4[];
+
+void func_ov084_0212d42c(char *self)
+{
+    int space[3];
+    int idx, fac, spd, s, m, x, y, z, zero, bias;
+    long long prod;
+    volatile int *ytbl;
+    volatile int *xtbl;
+    s16 *st;
+
+    if (*(int *)(self + 0x170) != data_ov084_02130e24[1])
+        return;
+    idx = (int)((unsigned)(*(int *)(self + 0x168) << 4) >> 16);
+    if (idx >= 0xa)
+        return;
+
+    x = *(int *)(self + 0x5c);
+    st = data_02082214;
+    *(volatile int *)&space[0] = x;
+    y = *(int *)(self + 0x60);
+    xtbl = data_ov084_0213029c;
+    *(volatile int *)&space[1] = y;
+    z = *(int *)(self + 0x64);
+    bias = 0x800;
+    *(volatile int *)&space[2] = z;
+
+    {
+        unsigned short ang = *(unsigned short *)(self + 0x8e);
+        fac = xtbl[idx];
+        spd = *(int *)(self + 0x204);
+        s = st[(ang >> 4) << 1];
+        ytbl = data_ov084_021302c4;
+        zero = 0;
+        m = fac * s;
+        prod = (long long)m * spd + bias;
+        x = x + (int)(prod >> 12);
+        *(volatile int *)&space[0] = x;
+    }
+    {
+        unsigned short ang = *(unsigned short *)(self + 0x8e);
+        s = st[((ang >> 4) << 1) + 1];
+        spd = *(int *)(self + 0x204);
+        m = fac * s;
+        prod = (long long)m * spd + bias;
+        z = z + (int)(prod >> 12);
+        *(volatile int *)&space[2] = z;
+    }
+    y = y + *(int *)(self + 0x204) * ytbl[idx];
+    *(volatile int *)&space[1] = y;
+    *(u32 *)(self + 0x224) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        *(u32 *)(self + 0x224), 0xfb, space[0], space[1], z, (void *)zero, (void *)zero);
+}

--- a/src/func_ov084_0212d86c.c
+++ b/src/func_ov084_0212d86c.c
@@ -1,0 +1,144 @@
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern void func_02012694(u32 id, void *pos);
+extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void *pos);
+extern void _ZN5Enemy9SpawnCoinEv(char *self);
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(char *self);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thiz, void *anim, int a, int fix, u32 flags);
+extern char *_ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN6Player16IncMegaKillCountEv(void *p);
+extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(char *self, void *clsn, char *player);
+extern void _ZN6Player6BounceE5Fix12IiE(char *p, int fix);
+extern int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char *self, const void *pos, u32 a, int fix, u32 b, u32 c, u32 d);
+
+extern int data_ov084_02130e24[];
+
+void func_ov084_0212d86c(char *r5)
+{
+    char *r4;
+    int t;
+    int flags;
+    int pos1[3];
+    int pos2[3];
+    u32 id;
+
+    id = *(u32 *)(r5 + 0x198);
+    if (id == 0)
+        goto second;
+
+    flags = *(int *)(r5 + 0x194) & 0x66ff0;
+    if (flags != 0) {
+        t = (int)(*(u16 *)(r5 + 0xc) == 0xfb);
+        if (t != 0)
+            func_02012694(0x1e, r5 + 0x74);
+        else
+            _ZN5Sound9PlayBank0EjRK7Vector3(0xa, r5 + 0x74);
+    activate_path:
+        t = (int)(*(u16 *)(r5 + 0xc) == 0xfc);
+        if (t != 0) {
+            *(u8 *)(r5 + 0x108) = 1;
+            _ZN5Enemy9SpawnCoinEv(r5);
+            _ZN5Actor24KillAndTrackInDeathTableEv(r5);
+            _ZN5Sound9PlayBank0EjRK7Vector3(0xa, r5 + 0x74);
+        } else {
+            *(int *)(r5 + 0x1ec) = 1;
+            *(u8 *)(r5 + 0x21d) = 0xa;
+            *(u16 *)(r5 + 0x218) = 0x1f40;
+            {
+                u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
+                u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+                *p18c |= 1u;
+                *pb0 &= ~0x10000000u;
+            }
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(r5 + 0x110, (void *)data_ov084_02130e24[1], 0x40000000, 0x1000, 0);
+            *(u8 *)(r5 + 0x21e) = 0;
+            *(int *)(r5 + 0x224) = 0;
+        }
+        if ((*(int *)(r5 + 0x194) & 0x10) == 0)
+            goto second;
+        _ZN5Sound9PlayBank0EjRK7Vector3(0xa, r5 + 0x74);
+        r4 = _ZN5Actor10FindWithIDEj(*(u32 *)(r5 + 0x198));
+        if (r4 == 0)
+            goto second;
+        _ZN6Player16IncMegaKillCountEv(r4);
+        func_02012694(0x1d, r5 + 0x74);
+        goto second;
+    }
+
+    r4 = _ZN5Actor10FindWithIDEj(id);
+    if (r4 == 0)
+        goto second;
+    t = (int)(*(u16 *)(r4 + 0xc) == 0xbf);
+    if (t == 0)
+        goto second;
+    if (*(u8 *)(r4 + 0x6f9) != 0) {
+        _ZN5Sound9PlayBank0EjRK7Vector3(0xa, r5 + 0x74);
+        goto activate_path;
+    }
+    t = (int)(*(u16 *)(r5 + 0xc) == 0xfc);
+    if (t != 0) {
+        if (_ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(r5, r5 + 0x174, r4) != 0) {
+            _ZN5Sound9PlayBank0EjRK7Vector3(0xb6, r5 + 0x74);
+            _ZN6Player6BounceE5Fix12IiE(r4, 0x28000);
+            goto activate_path;
+        }
+    }
+    if (*(u8 *)(r4 + 0x6fb) != 0)
+        goto second;
+    t = (int)(*(u16 *)(r5 + 0xc) == 0xfb);
+    if (t != 0)
+        goto second;
+    pos1[0] = *(int *)(r5 + 0x5c);
+    pos1[1] = *(int *)(r5 + 0x60);
+    pos1[2] = *(int *)(r5 + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r4, pos1, 2, 0xc000, 1, 0, 1);
+
+second:
+    id = *(u32 *)(r5 + 0x1cc);
+    if (id == 0)
+        return;
+    r4 = _ZN5Actor10FindWithIDEj(id);
+    if (r4 == 0)
+        return;
+    t = (int)(*(u16 *)(r4 + 0xc) == 0xbf);
+    if (t == 0)
+        return;
+
+    flags = *(int *)(r5 + 0x1c8) & 0x66ff0;
+    if (flags != 0) {
+        if ((flags & 0x10) != 0) {
+            _ZN6Player16IncMegaKillCountEv(r4);
+            func_02012694(0x1d, r5 + 0x74);
+        } else {
+            t = (int)(*(u16 *)(r5 + 0xc) == 0xfb);
+            if (t != 0)
+                func_02012694(0x1e, r5 + 0x74);
+            else
+                _ZN5Sound9PlayBank0EjRK7Vector3(0xa, r5 + 0x74);
+        }
+        *(int *)(r5 + 0x1ec) = 1;
+        *(u8 *)(r5 + 0x21d) = 0xa;
+        *(u16 *)(r5 + 0x218) = 0x1f40;
+        {
+            u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
+            u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p18c |= 1u;
+            *pb0 &= ~0x10000000u;
+        }
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(r5 + 0x110, (void *)data_ov084_02130e24[1], 0x40000000, 0x1000, 0);
+        *(u8 *)(r5 + 0x21e) = 0;
+        *(int *)(r5 + 0x224) = 0;
+        return;
+    }
+
+    if (*(u8 *)(r4 + 0x6f9) != 0)
+        return;
+    if (*(u8 *)(r4 + 0x6fb) != 0)
+        return;
+    pos2[0] = *(int *)(r5 + 0x5c);
+    pos2[1] = *(int *)(r5 + 0x60);
+    pos2[2] = *(int *)(r5 + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r4, pos2, 2, 0xc000, 1, 0, 1);
+}

--- a/src/func_ov084_0212ddbc.c
+++ b/src/func_ov084_0212ddbc.c
@@ -1,0 +1,99 @@
+typedef int s32;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef signed short s16;
+typedef long long s64;
+
+struct Vec3 { int x, y, z; };
+
+extern int _Z14ApproachLinearRiii(s32 *p, int a, int b);
+extern int _ZN9Animation8FinishedEv(void *a);
+extern void func_0201267c(int a, void *p);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *o, void *f, int a, int fx, int j);
+extern void *_ZN5Actor13ClosestPlayerEv(void *c);
+extern s16 Vec3_HorzAngle(const void *v0, const void *v1);
+extern int _Z14ApproachLinearRsss(s16 *p, short a, short b);
+extern int _ZNK9Animation12WillHitFrameEi(void *o, int f);
+extern void _ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(
+    void *self, const void *pos, const void *v16, int a, int b, u32 g);
+
+extern void *data_ov084_02130e1c[];
+extern s16 data_02082214[];
+
+void func_ov084_0212ddbc(char *c)
+{
+    struct Vec3 pos;
+    s16 ang;
+    int b;
+    int speed;
+    int idx;
+    int dx;
+    int dz;
+    int y;
+    int tmp;
+    void *player;
+
+    if (_Z14ApproachLinearRiii((s32 *)(c + 0x204), *(s32 *)(c + 0x210), *(s32 *)(c + 0x214)) == 0)
+        goto cold;
+
+    if (_ZN9Animation8FinishedEv(c + 0x160) != 0) {
+        b = (int)(*(u16 *)(c + 0xc) == 0xfc);
+        if (b != 0)
+            func_0201267c(0xe3, c + 0x74);
+        else
+            func_0201267c(0x120, c + 0x74);
+        *(s32 *)(c + 0x1ec) = 1;
+        _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, data_ov084_02130e1c[1], 0, 0x1000, 0);
+    } else {
+        if (*(u16 *)(c + 0x100) < 0x3a) {
+            ang = *(s16 *)(c + 0x8e);
+            player = _ZN5Actor13ClosestPlayerEv(c);
+            if (player != 0)
+                ang = Vec3_HorzAngle(c + 0x5c, (char *)player + 0x5c);
+            _Z14ApproachLinearRsss((s16 *)(c + 0x8e), ang, 0x400);
+        }
+    }
+
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x160, 0x3a) == 0)
+        return;
+
+    b = (int)(*(u16 *)(c + 0xc) == 0xfc);
+    if (b != 0)
+        func_0201267c(0x105, c + 0x74);
+    else
+        func_0201267c(0x122, c + 0x74);
+
+    pos.x = *(s32 *)(c + 0x5c);
+    y = *(s32 *)(c + 0x60);
+    pos.y = y;
+    pos.z = *(s32 *)(c + 0x64);
+    speed = *(s32 *)(c + 0x210);
+    idx = *(u16 *)(c + 0x8e) >> 4;
+    tmp = speed * 0x3c;
+    dx = (s32)(((s64)tmp * data_02082214[idx * 2] + 0x800) >> 12);
+    pos.x = pos.x + dx;
+
+    idx = *(u16 *)(c + 0x8e) >> 4;
+    speed = *(s32 *)(c + 0x210);
+    tmp = speed * 0x3c;
+    dz = (s32)(((s64)tmp * data_02082214[idx * 2 + 1] + 0x800) >> 12);
+    pos.z = pos.z + dz;
+
+    speed = *(s32 *)(c + 0x210);
+    pos.y = y + speed * 0x5a;
+    *(s16 *)(c + 0x8c) = 0x1000;
+
+    _ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j(
+        c, &pos, c + 0x8c, 0x1e000, 0xa000, 3);
+    return;
+
+cold:
+    if (*(s32 *)(c + 0x204) <= (*(s32 *)(c + 0x210) >> 1))
+        return;
+    {
+        u32 *p18c = (u32 *)(((long long)(int)(c + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32 *pb0 = (u32 *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p18c &= ~1u;
+        *pb0 |= 0x10000000u;
+    }
+}

--- a/src/func_ov084_0212f33c.c
+++ b/src/func_ov084_0212f33c.c
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=7). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct Vec3 { int x, y, z; };
 extern "C" {
 extern void func_02012694(unsigned int a, void *b);
@@ -37,15 +34,13 @@ void func_ov084_0212f33c(void *self)
     } else {
         r4 = 0;
         if (*(unsigned char*)(c + 0x108) != 0) {
-            int vy = *(int*)(c + 0x60) + 0x78000;
-            int vz = *(int*)(c + 0x64);
-            v.x = *(int*)(c + 0x5c);
-            v.y = vy;
-            v.z = vz;
+            int y = *(int*)(c + 0x60);
+            int z = *(int*)(c + 0x64);
+            v = (struct Vec3){*(int*)(c + 0x5c), y + 0x78000, z};
             _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
                 0x122, r4, &v, (void*)r4, *(signed char*)(c + 0xcc), -1);
+            *(unsigned char*)(c + 0x108) = r4;
         }
-        *(unsigned char*)(c + 0x108) = r4;
         *(int*)(c + 0x458) = 7;
     }
     *(int*)(c + 0x80) = r4;

--- a/src/func_ov084_0212f460.c
+++ b/src/func_ov084_0212f460.c
@@ -1,0 +1,56 @@
+//cpp
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef short s16;
+
+extern "C" {
+extern void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned, unsigned, unsigned, int, int);
+extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+    u32, u32, int, int, int, const void *, void *);
+extern int _ZN9Animation8FinishedEv(void *);
+extern s16 data_02082214[];
+extern int data_ov084_0213030c[];
+extern int data_ov084_02130334[];
+void func_ov084_0212f460(void *self);
+}
+
+void func_ov084_0212f460(void *self)
+{
+    char *c = (char *)self;
+    int space[3];
+    int zero;
+
+    _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x36, 0x7f, 0, 0xcb33, 0);
+    zero = 0;
+    *(unsigned char *)(c + 0x45c) = zero;
+    if (*(u16 *)(c + 0x100) < 0xa) {
+        u16 *fp = (u16 *)(c + 0x100);
+        int x = *(int *)(c + 0x5c);
+        s16 *sintbl = data_02082214;
+        *(volatile int *)&space[0] = x;
+        int y = *(int *)(c + 0x60);
+        int *xtbl = data_ov084_0213030c;
+        *(volatile int *)&space[1] = y;
+        int z = *(int *)(c + 0x64);
+        int *ytbl = data_ov084_02130334;
+        *(volatile int *)&space[2] = z;
+
+        x = xtbl[*fp] * sintbl[(*(u16 *)(c + 0x8e) >> 4) * 2] + x;
+        *(volatile int *)&space[0] = x;
+        z = xtbl[*fp] * sintbl[(*(u16 *)(c + 0x8e) >> 4) * 2 + 1] + z;
+        *(volatile int *)&space[2] = z;
+        y = y + (ytbl[*fp] << 12);
+        *(volatile int *)&space[1] = y;
+
+        u32 slot = *(u32 *)(c + 0x470);
+        int px = space[0];
+        int py = space[1];
+        *(void **)(c + 0x470) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+            slot, 0xfb, px, py, z, 0, 0);
+    }
+    if (_ZN9Animation8FinishedEv(c + 0x160) == 0)
+        return;
+    *(int *)(c + 0x458) = 6;
+    *(int *)(c + 0x474) = 0;
+    *(void **)(c + 0x470) = *(void **)(c + 0x474);
+}

--- a/src/func_ov084_0212f6d8.c
+++ b/src/func_ov084_0212f6d8.c
@@ -1,0 +1,147 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+
+struct Vector3 { int x, y, z; };
+
+extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);
+extern void func_0201267c(unsigned int a, void *p);
+extern void _Z14ApproachLinearRsss(s16 *val, s16 target, s16 step);
+extern int _ZN9Animation8FinishedEv(void *anim);
+extern void *_ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN6Player16IncMegaKillCountEv(void *player);
+extern void func_02012694(unsigned int a, void *p);
+extern void func_ov084_0212ebb4(void *c);
+extern int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *player, const void *pos, u32 a, int fix, u32 b, u32 c, u32 d);
+
+void func_ov084_0212f6d8(char *c)
+{
+    void *actor;
+    u16 type;
+    int isPlayer;
+    int isNine;
+    u32 flags;
+    struct Vector3 pos1;
+    struct Vector3 pos2;
+
+    *(u8 *)(c + 0x45c) = 1;
+
+    if (_ZNK9Animation12WillHitFrameEi(c + 0x160, 0x10)
+        || _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x20)
+        || _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x34)
+        || _ZNK9Animation12WillHitFrameEi(c + 0x160, 0x4b)) {
+        func_0201267c(0xc0, c + 0x74);
+    }
+
+    _Z14ApproachLinearRsss((s16 *)(c + 0x94), *(s16 *)(c + 0x468), 0x800);
+    *(s16 *)(c + 0x8e) = *(s16 *)(c + 0x94);
+
+    if (_ZN9Animation8FinishedEv(c + 0x160) != 0) {
+        int thr;
+        if (*(int *)(c + 0x46c) != 0)
+            thr = 0x12c000;
+        else
+            thr = 0x190000;
+        thr = thr + 0x64000;
+        if (*(int *)(c + 0x464) > thr)
+            *(int *)(c + 0x458) = 4;
+        else
+            *(int *)(c + 0x168) = 0;
+    }
+
+    /* cylinder 0 (id @ +0x3a4, flags @ +0x3a0) */
+    if (*(u32 *)(c + 0x3a4) != 0) {
+        actor = _ZN5Actor10FindWithIDEj(*(u32 *)(c + 0x3a4));
+        if (actor != 0) {
+            type = *(u16 *)((char *)actor + 0xc);
+            isPlayer = (int)(type == 0xbf);
+            if (isPlayer != 0) {
+                flags = *(u32 *)(c + 0x3a0);
+                if (flags & 0x10) {
+                    _ZN6Player16IncMegaKillCountEv(actor);
+                    func_02012694(0x1d, c + 0x74);
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+                if (*(u8 *)((char *)actor + 0x6f9) != 0) {
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+                if (*(u8 *)((char *)actor + 0x6fb) == 0) {
+                    pos1.x = *(int *)(c + 0x5c);
+                    pos1.y = *(int *)(c + 0x60);
+                    pos1.z = *(int *)(c + 0x64);
+                    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(actor, &pos1, 3, 0xc000, 1, 0, 1);
+                    return;
+                }
+                if ((flags & 0x40000) == 0)
+                    return;
+                func_ov084_0212ebb4(c);
+                return;
+            }
+            if ((*(u32 *)(c + 0x3a0) & 0x2000) != 0) {
+                isNine = (int)(type == 9);
+                if (isNine != 0) {
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+            }
+        }
+    }
+
+    /* cylinder 1 (id @ +0x3d8, flags @ +0x3d4; mega bit read from +0x3a0 per ROM) */
+    if (*(u32 *)(c + 0x3d8) != 0) {
+        actor = _ZN5Actor10FindWithIDEj(*(u32 *)(c + 0x3d8));
+        if (actor != 0) {
+            type = *(u16 *)((char *)actor + 0xc);
+            isPlayer = (int)(type == 0xbf);
+            if (isPlayer != 0) {
+                if ((*(u32 *)(c + 0x3a0) & 0x10) != 0) {
+                    _ZN6Player16IncMegaKillCountEv(actor);
+                    func_02012694(0x1d, c + 0x74);
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+                if (*(u8 *)((char *)actor + 0x6f9) != 0) {
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+                if ((*(u32 *)(c + 0x3d4) & 0x40000) == 0)
+                    return;
+                func_ov084_0212ebb4(c);
+                return;
+            }
+            if ((*(u32 *)(c + 0x3d4) & 0x2000) != 0) {
+                isNine = (int)(type == 9);
+                if (isNine != 0) {
+                    func_ov084_0212ebb4(c);
+                    return;
+                }
+            }
+        }
+    }
+
+    /* cylinder 2 (id @ +0x40c, flags @ +0x408) — player only */
+    if (*(u32 *)(c + 0x40c) == 0)
+        return;
+    actor = _ZN5Actor10FindWithIDEj(*(u32 *)(c + 0x40c));
+    if (actor == 0)
+        return;
+    type = *(u16 *)((char *)actor + 0xc);
+    isPlayer = (int)(type == 0xbf);
+    if (isPlayer == 0)
+        return;
+    if ((*(u32 *)(c + 0x408) & 0x10) != 0) {
+        _ZN6Player16IncMegaKillCountEv(actor);
+        func_02012694(0x1d, c + 0x74);
+        func_ov084_0212ebb4(c);
+        return;
+    }
+    if (*(u8 *)((char *)actor + 0x6f9) != 0)
+        return;
+    pos2.x = *(int *)(c + 0x5c);
+    pos2.y = *(int *)(c + 0x60);
+    pos2.z = *(int *)(c + 0x64);
+    _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(actor, &pos2, 3, 0xc000, 1, 0, 1);
+}


### PR DESCRIPTION
## Summary

Byte-identical matches for 14 functions in **ov084** (mwccarm **1.2/sp2p3**, flags `-O4,p -enum int -lang c99|-lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).

| Function | Addr | Size |
|---|---|---|
| `_ZN12PiranhaPlant13InitResourcesEv` | 0x0212feb4 | 0x25c |
| `_ZN12PiranhaPlant8BehaviorEv` | 0x0212fd4c | 0x168 |
| `func_ov084_0212f6d8` | 0x0212f6d8 | 0x3a4 |
| `func_ov084_0212f460` | 0x0212f460 | 0x128 |
| `func_ov084_0212f33c` | 0x0212f33c | 0x124 |
| `_ZN19FirePiranhaPlantBig13InitResourcesEv` | 0x0212e774 | 0x224 |
| `func_ov084_0212ddbc` | 0x0212ddbc | 0x254 |
| `func_ov084_0212d86c` | 0x0212d86c | 0x3c4 |
| `func_ov084_0212d42c` | 0x0212d42c | 0x134 |
| `_ZN11BobOmbBuddy8BehaviorEv` | 0x0212cf6c | 0xbc |
| `func_ov084_0212cae0` | 0x0212cae0 | 0x1d4 |
| `func_ov084_0212c508` | 0x0212c508 | 0x394 |
| `_ZN6Goomba16CleanupResourcesEv` | 0x0212b510 | 0xa8 |
| `func_ov084_0212b344` | 0x0212b344 | 0x1cc |

Verified locally with `tools/fdiff.py` / `tools/match.py` (`--module ov084`, version 1.2/sp2p3).

### Batch note (not in this PR)

Two related targets remain near-miss after real effort (size-matched, schedule/regperm walls); held for refine rather than landing NONMATCHING into `src/`:

- `func_ov084_0212ec60` @ 0x0212ec60 size 0x2a0 (div≈80)
- `func_ov084_0212d564` @ 0x0212d564 size 0x308 (div≈52)

Claims API key returned 401 (expired); locked via CLAIMS.md only.

## Test plan

- [ ] CI `validate` green on all 14 files
- [ ] Confirm no WRONG-DEST on relocated calls/globals

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build