### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii.cpp
+++ b/src/_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii.cpp
@@ -1,0 +1,28 @@
+//cpp
+typedef unsigned short u16;
+typedef short s16;
+
+struct Matrix2x2 { int m[4]; };
+
+extern "C" {
+
+void _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(volatile u16 *p, Matrix2x2 *m, int a, int b, int c, int d)
+{
+    u16 pa = (u16)(s16)(m->m[0] >> 4);
+    u16 pb = (u16)(s16)(m->m[1] >> 4);
+    *(volatile unsigned int *)p = pa | (pb << 16);
+
+    u16 pc = (u16)(s16)(m->m[2] >> 4);
+    u16 pd = (u16)(s16)(m->m[3] >> 4);
+    *(volatile unsigned int *)(p + 2) = pc | (pd << 16);
+
+    int dx = c - a;
+    int dy = d - b;
+    int x = m->m[0] * dx + m->m[1] * dy + (a << 12);
+    int y = m->m[2] * dx + m->m[3] * dy + (b << 12);
+
+    *(volatile int *)(p + 4) = x >> 4;
+    *(volatile int *)(p + 6) = y >> 4;
+}
+
+}

--- a/src/func_0204f364.c
+++ b/src/func_0204f364.c
@@ -1,0 +1,25 @@
+typedef unsigned char u8;
+
+extern char data_020a4d54[];
+extern char data_020a4d60[];
+
+char* _ZN18NestedHeapIterator4NextEP13HeapAllocator(char* self, char* a);
+void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(char* self, char* node);
+void func_0204f3e0(unsigned char* c);
+void func_0204f400(char* self);
+
+char* func_0204f364(int key)
+{
+    char* node = _ZN18NestedHeapIterator4NextEP13HeapAllocator(data_020a4d54, 0);
+    if (node == 0) {
+        node = _ZN18NestedHeapIterator4NextEP13HeapAllocator(data_020a4d60, 0);
+        if (key < *(u8*)(node + 0x3d)) {
+            return 0;
+        }
+        func_0204f3e0((unsigned char*)node);
+    }
+    _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(data_020a4d54, node);
+    *(u8*)(node + 0x3d) = key;
+    func_0204f400(node);
+    return node;
+}

--- a/src/func_ov002_020f2bf4.c
+++ b/src/func_ov002_020f2bf4.c
@@ -1,0 +1,31 @@
+extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *p, unsigned short a, unsigned short b, int c, unsigned short d);
+extern unsigned char data_0209d454;
+extern void func_0201ef50(unsigned char v);
+
+#pragma opt_common_subs off
+
+void func_ov002_020f2bf4(char *c, int idx)
+{
+    unsigned char cnt;
+
+    *(unsigned short *)(c + 0x1c4 + idx * 8) += 1;
+    *(unsigned short *)(c + 0x1c6 + idx * 8) += 1;
+
+    if (*(unsigned short *)(c + idx * 8 + 0x100 + 0xc6) >= 2) {
+        *(unsigned short *)(c + idx * 8 + 0x100 + 0xc6) = 0;
+        *(unsigned char *)(c + 0x1ca + idx * 8) += 1;
+        cnt = *(unsigned char *)(c + idx * 8 + 0x1ca);
+        _ZN3G2x13SetBlendAlphaEPVttttt((volatile void *)0x4001050, 1, 0x36, 0x10 - cnt, cnt);
+    }
+
+    if (*(unsigned short *)(c + idx * 8 + 0x100 + 0xc4) < 30) {
+        return;
+    }
+    *(unsigned short *)(c + idx * 8 + 0x100 + 0xc4) = 0;
+    *(unsigned char *)(c + 0x1c9 + idx * 8) += 1;
+    *(unsigned char *)(c + 0x1cb + idx * 8) += 1;
+    *(unsigned char *)(c + idx * 8 + 0x1ca) = 0;
+    *(unsigned short *)(c + idx * 8 + 0x100 + 0xc6) = 0;
+    data_0209d454 &= ~1;
+    func_0201ef50(*(unsigned char *)(c + idx * 8 + 0x1cb));
+}


### PR DESCRIPTION
3 functions from a 36-candidate easy/spread fan-out batch (run 2, mostly arm9 + ov002/ov006), each verified byte-identical on all three versions (1.2/base, sp2, sp2p3) and linkcheck VERIFIED (0 blind relocs):

- func_ov002_020f2bf4
- func_0204f364
- _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii

src-only, no bundled tools/CI. The 33 remaining candidates hit documented register-coloring/scheduling/materialization walls (drafts in scratchpad, not committed) — several were within 1-2 instructions of matching.