### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN3HUD19RenderCameraButtonsEv.cpp
+++ b/src/_ZN3HUD19RenderCameraButtonsEv.cpp
@@ -1,0 +1,106 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct OamAttr;
+
+class OAM {
+public:
+    static OamAttr CAM_BUTTON_L;
+    static OamAttr CAM_BUTTON_L_PRESSED;
+    static OamAttr CAM_BUTTON_R;
+    static OamAttr CAM_BUTTON_R_PRESSED;
+    static OamAttr S_CAM_BUTTON_L;
+    static OamAttr S_CAM_BUTTON_L_PRESSED;
+    static OamAttr S_CAM_BUTTON_R;
+    static OamAttr S_CAM_BUTTON_R_PRESSED;
+    static OamAttr CAM_ZOOM_BUTTON;
+    static OamAttr CAM_ZOOM_BUTTON_PRESSED;
+    static OamAttr S_CAM_ZOOM_BUTTON;
+    static OamAttr S_CAM_ZOOM_BUTTON_PRESSED;
+    static void RenderSub(OamAttr *attr, int x, int y, int a, int b);
+};
+
+class HUD {
+public:
+    static void RenderCameraButtons();
+};
+
+typedef struct { u8 pad[0x18]; } Rec18;
+typedef struct { u8 pad[0x154]; u32 flags; } S154;
+
+extern "C" {
+extern u8 data_020a0e40;
+extern u8 data_ov002_02111180;
+extern S154 *data_0209f318;
+extern Rec18 data_0209f4ae[];
+extern int data_0208ee44;
+extern u32 data_0209b454;
+extern Rec18 data_0209f49c[];
+extern u8 data_0209d660;
+}
+
+void HUD::RenderCameraButtons()
+{
+    int idx = data_020a0e40;
+    u8 mode = *(u8 *)&data_0209f4ae[idx];
+    S154 *p = data_0209f318;
+    u8 t = data_ov002_02111180;
+
+    if (t != 0)
+        data_ov002_02111180 = t - data_0208ee44;
+
+    if (data_0209b454 & 0x40000000)
+        return;
+
+    if (p->flags & 0x1000) {
+        if (mode == 0) {
+            if (*(u16 *)&data_0209f49c[idx] & 0x200) {
+                OAM::RenderSub(&OAM::CAM_BUTTON_L_PRESSED, 0x19, 0xa5, -1, 1);
+                OAM::RenderSub(&OAM::CAM_BUTTON_L_PRESSED, 0xbf, 0xa5, -1, 1);
+            } else {
+                OAM::RenderSub(&OAM::CAM_BUTTON_L, 0x19, 0xa5, -1, 1);
+                OAM::RenderSub(&OAM::CAM_BUTTON_L, 0xbf, 0xa5, -1, 1);
+            }
+            if (*(u16 *)&data_0209f49c[data_020a0e40] & 0x100) {
+                OAM::RenderSub(&OAM::CAM_BUTTON_R_PRESSED, 0x41, 0xa5, -1, 1);
+                OAM::RenderSub(&OAM::CAM_BUTTON_R_PRESSED, 0xe7, 0xa5, -1, 1);
+            } else {
+                OAM::RenderSub(&OAM::CAM_BUTTON_R, 0x41, 0xa5, -1, 1);
+                OAM::RenderSub(&OAM::CAM_BUTTON_R, 0xe7, 0xa5, -1, 1);
+            }
+        } else if (mode == 2) {
+            if (*(u16 *)&data_0209f49c[idx] & 0x200) {
+                OAM::RenderSub(&OAM::S_CAM_BUTTON_L_PRESSED, 0xbf, 0xad, -1, 1);
+            } else {
+                OAM::RenderSub(&OAM::S_CAM_BUTTON_L, 0xbf, 0xad, -1, 1);
+            }
+            if (*(u16 *)&data_0209f49c[data_020a0e40] & 0x100) {
+                OAM::RenderSub(&OAM::S_CAM_BUTTON_R_PRESSED, 0xe7, 0xad, -1, 1);
+            } else {
+                OAM::RenderSub(&OAM::S_CAM_BUTTON_R, 0xe7, 0xad, -1, 1);
+            }
+        }
+    }
+
+    if (mode == 0)
+        return;
+    if (data_0209d660 != 0)
+        return;
+
+    int y = (mode == 1) ? 0xa5 : 0x85;
+    if (mode == 1) {
+        if (data_ov002_02111180 != 0) {
+            OAM::RenderSub(&OAM::CAM_ZOOM_BUTTON_PRESSED, 0xe7, y, -1, 1);
+            return;
+        }
+        OAM::RenderSub(&OAM::CAM_ZOOM_BUTTON, 0xe7, y, -1, 1);
+        return;
+    }
+    if (data_ov002_02111180 != 0) {
+        OAM::RenderSub(&OAM::S_CAM_ZOOM_BUTTON_PRESSED, 0xe7, y, -1, 1);
+        return;
+    }
+    OAM::RenderSub(&OAM::S_CAM_ZOOM_BUTTON, 0xe7, y, -1, 1);
+}

--- a/src/_ZN6Player17St_NoControl_MainEv.cpp
+++ b/src/_ZN6Player17St_NoControl_MainEv.cpp
@@ -1,0 +1,153 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef short s16;
+typedef int s32;
+
+extern "C" {
+extern int func_0200ee68(void);
+extern short GetAngleToCamera(int i);
+extern void func_ov002_020c965c(char* c);
+extern int func_ov002_020c94a4(char* c);
+extern void func_ov002_020c92fc(char* c);
+extern void func_ov002_020c9288(char* c);
+extern void func_ov002_020c924c(char* c);
+extern int func_ov002_020c91bc(char* c);
+extern void func_ov002_020c9718(char* c);
+extern int func_ov002_020c9128(char* c);
+extern void func_ov002_020c8cb0(char* c);
+extern void func_ov002_020c904c(char* c);
+extern void func_ov002_020c8f80(char* c);
+extern void func_ov002_020c8f0c(char* c);
+extern void func_ov002_020c8b54(char* c);
+extern void func_ov002_020c8a4c(char* c);
+extern void func_ov002_020c897c(char* c);
+extern void func_ov002_020c8d14(char* c);
+extern void func_ov002_020c8b78(char* c);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, unsigned int id, int flags, int speed, unsigned int extra);
+extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, unsigned int a, int b);
+extern int _ZNK9Animation12WillHitFrameEi(void* thiz, int f);
+extern int _ZN6Player12FinishedAnimEv(void* thiz);
+extern void func_ov002_020c8714(char* c);
+extern int func_ov002_020c8540(char* c);
+extern int func_ov002_020c84b0(char* c);
+extern void func_ov002_020bedd4(char* c);
+
+extern int data_ov002_0211013c[];
+}
+
+extern "C" int _ZN6Player17St_NoControl_MainEv(char* self)
+{
+    u8 mode = *(u8*)(self + 0x70a);
+    if (mode == 0 || mode == 1 || (mode == 0x11 && *(u8*)(self + 0x6e3) != 0x18)) {
+        if (func_0200ee68() == 0) {
+            *(s16*)(self + 0x8e) = GetAngleToCamera(*(u8*)(self + 0x6d8));
+            *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
+        }
+    }
+
+    switch (*(u8*)(self + 0x6e3)) {
+    case 0:
+        func_ov002_020c965c(self);
+        break;
+    case 1:
+        if (func_ov002_020c94a4(self) != 0)
+            return 1;
+        break;
+    case 2:
+    case 9:
+        func_ov002_020c92fc(self);
+        break;
+    case 10:
+        func_ov002_020c9288(self);
+        break;
+    case 20:
+        func_ov002_020c924c(self);
+        return 1;
+    case 21:
+        if (func_ov002_020c91bc(self) != 0)
+            return 1;
+        break;
+    case 3:
+    case 6:
+        if (*(u16*)(self + 0x6a6) == 0)
+            *(int*)(self + 0x98) = 0;
+        if (*(u8*)(self + 0x70a) == 6 && *(u8*)(self + 0x706) != 0) {
+            *(int*)(self + 0x9c) = 0;
+            *(int*)(self + 0xa8) = 0;
+        } else {
+            func_ov002_020c9718(self);
+        }
+        if (*(u8*)(self + 0x70a) == 0 || *(u8*)(self + 0x70a) == 3)
+            return 1;
+        break;
+    case 4:
+    case 5:
+        if (func_ov002_020c9128(self) != 0)
+            return 1;
+        break;
+    case 7:
+    case 8:
+        func_ov002_020c8cb0(self);
+        break;
+    case 11:
+        func_ov002_020c904c(self);
+        break;
+    case 12:
+        func_ov002_020c8f80(self);
+        break;
+    case 13:
+        func_ov002_020c8f0c(self);
+        break;
+    case 14:
+        func_ov002_020c8b54(self);
+        break;
+    case 15:
+        func_ov002_020c8a4c(self);
+        break;
+    case 16:
+        func_ov002_020c897c(self);
+        break;
+    case 17:
+        func_ov002_020c8d14(self);
+        break;
+    case 18:
+        func_ov002_020c8b78(self);
+        break;
+    case 19:
+        if (*(u8*)(self + 0x70b) == 0)
+            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211013c);
+        break;
+    case 22:
+        if (*(u8*)(self + 0x6de) == 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x98, 0x40000000, 0x1000, 0);
+            *(u8*)(self + 0x6e3) = 0x17;
+        }
+        break;
+    case 23: {
+        int id = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self + 8) & 0xff, 0);
+        char* anim = (char*)((int*)(self + 0xdc))[id] + 0x50;
+        if (_ZNK9Animation12WillHitFrameEi(anim, 0x1c))
+            *(u8*)(self + 0x71a) = 0;
+        if (_ZN6Player12FinishedAnimEv(self))
+            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211013c);
+        break;
+    }
+    case 24:
+        func_ov002_020c8714(self);
+        break;
+    case 25:
+        if (func_ov002_020c8540(self) != 0)
+            return 1;
+        break;
+    case 26:
+        if (func_ov002_020c84b0(self) != 0)
+            return 1;
+        break;
+    }
+
+    func_ov002_020bedd4(self);
+    return 1;
+}

--- a/src/func_02070ec0.c
+++ b/src/func_02070ec0.c
@@ -1,0 +1,71 @@
+typedef struct Big {
+    short v[19];
+} Big;
+
+extern unsigned char data_0209a628[];
+extern unsigned char data_0209a658[];
+extern unsigned char data_0209a680[];
+extern unsigned char data_0209a698[];
+extern unsigned char data_0209a6a8[];
+extern unsigned char data_0209a6b0[];
+extern unsigned char data_0209a6b8[];
+extern unsigned char data_0209a6c0[];
+extern unsigned char data_0209a6c8[];
+extern unsigned char data_0209a6cc[];
+extern unsigned char data_0209a6d0[];
+extern unsigned char data_0209a6d4[];
+extern unsigned char data_0209a6d8[];
+extern unsigned char data_0209a6dc[];
+extern unsigned char data_0209a6e0[];
+extern unsigned char data_0209a6e4[];
+extern unsigned char data_0209a6e8[];
+extern unsigned char data_0209a6ec[];
+extern unsigned char data_0209a6f0[];
+extern unsigned char data_0209a6f4[];
+extern unsigned char data_0209a6f8[];
+
+void func_020712a0(Big *out, unsigned char *str, short val);
+void func_02071364(Big *dst, Big *a, Big *b);
+void func_02070ec0(Big *out, int n);
+
+void func_02070ec0(Big *out, int n)
+{
+    Big half;
+    Big copy;
+
+    switch (n) {
+    case -64: func_020712a0(out, data_0209a628, -20); return;
+    case -53: func_020712a0(out, data_0209a658, -16); return;
+    case -32: func_020712a0(out, data_0209a680, -10); return;
+    case -16: func_020712a0(out, data_0209a698, -5); return;
+    case -8:  func_020712a0(out, data_0209a6a8, -3); return;
+    case -7:  func_020712a0(out, data_0209a6b0, -3); return;
+    case -6:  func_020712a0(out, data_0209a6b8, -2); return;
+    case -5:  func_020712a0(out, data_0209a6c0, -2); return;
+    case -4:  func_020712a0(out, data_0209a6c8, -2); return;
+    case -3:  func_020712a0(out, data_0209a6cc, -1); return;
+    case -2:  func_020712a0(out, data_0209a6d0, -1); return;
+    case -1:  func_020712a0(out, data_0209a6d4, -1); return;
+    case 0:   func_020712a0(out, data_0209a6d8, 0); return;
+    case 1:   func_020712a0(out, data_0209a6dc, 0); return;
+    case 2:   func_020712a0(out, data_0209a6e0, 0); return;
+    case 3:   func_020712a0(out, data_0209a6e4, 0); return;
+    case 4:   func_020712a0(out, data_0209a6e8, 1); return;
+    case 5:   func_020712a0(out, data_0209a6ec, 1); return;
+    case 6:   func_020712a0(out, data_0209a6f0, 1); return;
+    case 7:   func_020712a0(out, data_0209a6f4, 2); return;
+    case 8:   func_020712a0(out, data_0209a6f8, 2); return;
+    default:
+        func_02070ec0(&half, (int)(n + ((n & 0x80000000u) >> 31)) >> 1);
+        func_02071364(out, &half, &half);
+        if (n & 1) {
+            copy = *out;
+            if (n > 0)
+                func_020712a0(&half, data_0209a6dc, 0);
+            else
+                func_020712a0(&half, data_0209a6d4, -1);
+            func_02071364(out, &copy, &half);
+        }
+        return;
+    }
+}


### PR DESCRIPTION
3 functions, each linkcheck VERIFIED (0 blind relocs) and byte-identical on 1.2 base/sp2/sp2p3:

- `_ZN6Player17St_NoControl_MainEv` (Player::St_NoControl_Main, ov002, 0x344)
- `_ZN3HUD19RenderCameraButtonsEv` (HUD::RenderCameraButtons, ov002, 0x378)
- `func_02070ec0` (arm9, 0x3e0)

src-only, no bundled tools/CI. These are the genuinely-new matched functions extracted from #356 (which was conflicting and mixed in tooling, CI, and already-merged duplicates).

Built with Claude Code