### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/DMASyncFillTransfer.c
+++ b/src/DMASyncFillTransfer.c
@@ -1,0 +1,43 @@
+/* DMASyncFillTransfer at 0x0205a1b4
+ * Synchronous 32-bit DMA fill: waits for the DMA channel to be free, writes
+ * the fill value into the channel's DMA fill register (0x040000E0 + ch*4),
+ * then starts a source-fixed word DMA from that register (ctrl 0x85000000 =
+ * enable | 32-bit | src-fixed | immediate) and waits for completion.
+ *
+ * The identity `& 0xFFFFFFFFFFFFFFFF` on the fill-register address is the
+ * u64-laundering idiom (see notes/mwccarm-codegen.md, 6m): it routes the
+ * address through 64-bit arithmetic so mwccarm cannot fold it into the
+ * store's addressing mode, which makes the compiler materialize the address
+ * in fillReg's home register (r1, its call-arg slot) and lets the peephole
+ * fuse `add r1,r1,r0,lsl#2` + `str r2,[r1]` into the ROM's pre-indexed
+ * writeback `str r2,[r1,r0,lsl#2]!` (and, in turn, evacuates dst to ip at
+ * entry exactly like the ROM).
+ */
+
+typedef unsigned int u32;
+typedef volatile u32 vu32;
+
+extern void DMAStartTransferFB(u32 channel, void *src, void *dst, u32 cnt);
+
+void DMASyncFillTransfer(u32 channel, void *dst, u32 data, u32 size)
+{
+    vu32 *dmaCtrl;
+    vu32 *fillReg;
+    u32 *dmaBase;
+
+    if (size == 0)
+        return;
+
+    dmaBase = (u32 *)0x040000b0;
+    dmaCtrl = (vu32 *)dmaBase + (channel * 3 + 2);
+
+    while (*dmaCtrl & 0x80000000)
+        ;
+
+    fillReg = (vu32 *)(((u32)0x040000e0 + (channel << 2)) & 0xFFFFFFFFFFFFFFFF);
+    *fillReg = data;
+    DMAStartTransferFB(channel, (void *)fillReg, dst, (size >> 2) | 0x85000000);
+
+    while (*dmaCtrl & 0x80000000)
+        ;
+}

--- a/src/_ZNK9Animation12WillHitFrameEi.cpp
+++ b/src/_ZNK9Animation12WillHitFrameEi.cpp
@@ -1,0 +1,64 @@
+//cpp
+typedef int s32;
+typedef unsigned int u32;
+
+class Animation
+{
+public:
+    void* vtable;
+    u32 flagsAndCount; // bits 30-31: flags, bits 0-29: frame count (fx32)
+    s32 currFrame;     // fx32
+    s32 speed;         // fx32
+
+    bool WillHitFrame(int frame) const;
+};
+
+bool Animation::WillHitFrame(int frame) const
+{
+    s32 f = frame << 12;
+    s32 next = currFrame + speed;
+    s32 num = flagsAndCount & ~0xc0000000;
+
+    if ((flagsAndCount & 0xc0000000) == 0)
+    {
+        if (next < 0)
+        {
+            next = (next + num) % num;
+            if ((f >= 0 && f < currFrame) || (next <= f && f < num))
+                return true;
+        }
+        else if (next >= num)
+        {
+            next %= num;
+            if ((currFrame <= f && f < num) || f < next)
+                return true;
+        }
+        else if (currFrame <= next)
+        {
+            if (currFrame <= f && f < next)
+                return true;
+        }
+        else
+        {
+            if (next <= f && f < currFrame)
+                return true;
+        }
+    }
+    else
+    {
+        if (next < 0)
+            next = 0;
+        if (next >= num)
+            next = num - 1;
+
+        if (currFrame <= next)
+        {
+            if (f >= currFrame && f < next)
+                return true;
+        }
+        else if (f >= next && f < currFrame)
+            return true;
+    }
+
+    return false;
+}

--- a/src/func_02058568.c
+++ b/src/func_02058568.c
@@ -1,0 +1,35 @@
+// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
+// OS_InitContext-style SDK primitive: stores entry pc+4 and the two stack pointers
+// (sp_svc at +0x44, sp = sp_svc - 0x40 at +0x38), derives the initial CPSR from the
+// Thumb bit of the entry address (SYS mode 0x1f, +T bit -> 0x3f), and clears r0-r12
+// and lr in the context block. Same original hand-asm TU as ARMSaveContext (0x020585cc).
+// C reproductions floor at a 5-word register-coloring residual (t_pc4/t_sp40 webs color
+// r3/r1 under 1.2/sp2p3 for every source shape tried; ROM keeps both params in place).
+asm void func_02058568(void *ctx, unsigned int pc, unsigned int sp)
+{
+    add r1, r1, #4
+    str r1, [r0, #0x40]
+    str r2, [r0, #0x44]
+    sub r2, r2, #0x40
+    str r2, [r0, #0x38]
+    ands r1, r1, #1
+    movne r1, #0x3f
+    moveq r1, #0x1f
+    str r1, [r0, #0]
+    mov r1, #0
+    str r1, [r0, #0x4]
+    str r1, [r0, #0x8]
+    str r1, [r0, #0xc]
+    str r1, [r0, #0x10]
+    str r1, [r0, #0x14]
+    str r1, [r0, #0x18]
+    str r1, [r0, #0x1c]
+    str r1, [r0, #0x20]
+    str r1, [r0, #0x24]
+    str r1, [r0, #0x28]
+    str r1, [r0, #0x2c]
+    str r1, [r0, #0x30]
+    str r1, [r0, #0x34]
+    str r1, [r0, #0x3c]
+    bx lr
+}


### PR DESCRIPTION
Three matches, each verified locally with `tools/match.py --strict-relocs` against an EU retail dump:

| Function | Address | Size |
|---|---|---|
| `_ZNK9Animation12WillHitFrameEi` | 0x02015a98 | 0x134 |
| `DMASyncFillTransfer` | 0x0205a1b4 | 0x68 |
| `func_02058568` | 0x02058568 | 0x64 |

Notes:
- `DMASyncFillTransfer` uses the u64-laundering idiom from `notes/mwccarm-codegen.md` §6m to get the pre-indexed writeback store; its `bl` resolves to `DMAStartTransferFB` (ITCM).
- `func_02058568` is an OS_InitContext-style hand-asm SDK primitive (sibling of the already-banked `ARMSaveContext`, same original TU). ~200 C formulations floor at a 5-word register-coloring residual, so it is banked as a byte-faithful `asm` block per the asm-hatch policy in `notes/mwccarm-codegen.md` §8. If maintainers prefer to hold out for C here, happy to drop it from the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)