### PR TITLE
Match func_0204f364 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204f364.cpp
+++ b/src/func_0204f364.cpp
@@ -1,0 +1,32 @@
+//cpp
+struct HeapAllocator {
+    char pad[0x3d];
+    unsigned char field_3d;
+};
+
+struct NestedHeapIterator {
+    HeapAllocator *Next(HeapAllocator *);
+    void Remove(HeapAllocator *);
+};
+
+extern NestedHeapIterator data_020a4d54;
+extern NestedHeapIterator data_020a4d60;
+
+extern "C" void func_0204f3e0(HeapAllocator *);
+extern "C" void func_0204f400(HeapAllocator *);
+
+extern "C" HeapAllocator *func_0204f364(int arg)
+{
+    HeapAllocator *h = data_020a4d54.Next(0);
+    if (h == 0) {
+        h = data_020a4d60.Next(0);
+        int f = h->field_3d;
+        if (arg < f)
+            return 0;
+        func_0204f3e0(h);
+    }
+    data_020a4d54.Remove(h);
+    h->field_3d = (unsigned char)arg;
+    func_0204f400(h);
+    return h;
+}


### PR DESCRIPTION
Matches `func_0204f364` at `0x0204f364` (`0x7c` bytes).\n\nThe corrected helper prototype preserves the allocator pointer in `r0`, revealing the implicit argument handoff. Locally verified with strict relocation matching, `0/31` instruction mismatches, and `linkcheck: VERIFIED` with no blind relocations.