### PR TITLE
Match Model::DoSetFile byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Model9DoSetFileEPcii.cpp
+++ b/src/_ZN5Model9DoSetFileEPcii.cpp
@@ -1,21 +1,20 @@
 //cpp
-// NONMATCHING: register allocation (div=2). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void*);
 unsigned int func_02046564(void*);
 void* _ZN6Memory13operator_new2Ej(unsigned int);
-int func_020462d0(void*, void*);
+int func_020462d0(void*, void*, void*);
 int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void*);
 int func_02016b24(void*, int);
 int _ZN5Model12SetPolygonIDEi(void*, int);
 
 int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
+  void* buffer;
   _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
   *(void**)((char*)c+0x4c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
-  if (*(void**)((char*)c+0x4c) == 0) return 0;
-  func_020462d0((char*)c+8, file);
+  buffer = *(void**)((char*)c+0x4c);
+  if (buffer == 0) return 0;
+  func_020462d0((char*)c+8, file, buffer);
   _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
   if (a != 0) func_02016b24(c, 0x8000);
   if (b < 0) return 1;


### PR DESCRIPTION
Converts `_ZN5Model9DoSetFileEPcii` at `0x02016bf8` (`0xa0` bytes) from its old NONMATCHING form to a byte-identical match.\n\nThe previous source omitted `func_020462d0`’s third buffer argument. Restoring that handoff produces `0/40` instruction mismatches. Locally verified with strict relocations and `linkcheck: VERIFIED` with no blind relocations.