### PR TITLE
Verify func_ov005_020bfefc relocation targets (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov005_020bfefc.c
+++ b/src/func_ov005_020bfefc.c
@@ -1,15 +1,16 @@
-extern void _ZN9ActorBaseD1Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
-extern void *G0;
+extern void _ZN9ActorBaseD1Ev(void *self);
+extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, void *heap);
+extern int data_ov005_020c2490[];
+extern int _ZTV5Stage[];
+extern int data_0208e4b8[];
+extern void *data_020a0eac;
+
 int *func_ov005_020bfefc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)data_ov005_020c2490;
+    t[0] = (int)_ZTV5Stage;
+    t[0] = (int)data_0208e4b8;
     _ZN9ActorBaseD1Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }


### PR DESCRIPTION
Replaces the generic relocation placeholders in `func_ov005_020bfefc` with the verified ov005 vtable chain and game-heap symbols while preserving the exact 80 ROM bytes.

Verified locally:
- mwccarm 1.2/sp2p3 strict reloc match
- fdiff: 0/20 mismatches
- linkcheck: VERIFIED, blind=0