### PR TITLE
Match func_ov006_020effb8 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_020effb8.c
+++ b/src/func_ov006_020effb8.c
@@ -1,12 +1,9 @@
-// NONMATCHING: register allocation (div=5). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void func_ov006_020efdf0(char* c);
+extern void func_ov006_020efdf0(char* c, int idx);
 extern unsigned char data_0209d45c;
 
 void func_ov006_020effb8(char* c, int idx) {
     *(int*)(c + 0x47ec + idx * 0x14) += 0x2000;
-    func_ov006_020efdf0(c);
+    func_ov006_020efdf0(c, idx);
     if ((*(int*)(c + 0x47ec + idx * 0x14) >> 12) < 0xa0) return;
     *(unsigned char*)(c + 0x47f5 + idx * 0x14) += 1;
     data_0209d45c &= ~4;


### PR DESCRIPTION
Matches `func_ov006_020effb8` at `0x020effb8` (116 bytes). Restoring the helper's `idx` argument reproduces the original register allocation.

Verified locally:
- mwccarm 1.2/sp2p3 strict reloc match
- fdiff: 0/29 mismatches
- linkcheck: VERIFIED, blind=0