### PR TITLE
Match MgBounceAndPounce_Spawn byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/MgBounceAndPounce_Spawn.cpp
+++ b/src/MgBounceAndPounce_Spawn.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=34). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern void *_ZN9ActorBasenwEj(unsigned int sz);
 extern int func_ov004_020b2adc(void *p);
@@ -25,14 +22,22 @@ extern "C" void *MgBounceAndPounce_Spawn(void)
         *(int *)p = (int)_ZTV17MgBounceAndPounce;
         *(short *)(p + 0x4664) = 0;
         it = p + 0x466c;
-        do {
-            it += 0xbc;
-        } while (it != p + 0x47e4);
+        {
+            char *end = p;
+            end += 0x47e4;
+            do {
+                it += 0xbc;
+            } while (it != end);
+        }
         _ZN8Particle10SysTrackerC1Ev(p + 0x47e4);
         *(int *)p = (int)data_ov006_0213cbe4;
         _ZN5ModelC1Ev(p + 0x501c);
-        func_020733a8(p + 0x506c, 3, 0xb8, (void *)func_ov006_020c8a04, (void *)func_ov006_020c893c);
-        func_020733a8(p + 0x5294, 6, 0xf0, (void *)func_ov006_020c6f70, (void *)_ZN6Player18St_LevelEnter_MainEv);
+        func_020733a8(p + 0x506c, 3, 0xb8,
+                      (void *)func_ov006_020c8a04,
+                      (void *)func_ov006_020c893c);
+        func_020733a8(p + 0x5294, 6, 0xf0,
+                      (void *)func_ov006_020c6f70,
+                      (void *)_ZN6Player18St_LevelEnter_MainEv);
     }
     return p;
 }


### PR DESCRIPTION
Matches `MgBounceAndPounce_Spawn` at `0x020eeafc` (236 bytes). Two-step loop-end construction reproduces the original literal-load schedule.

Verified locally:
- mwccarm 1.2/sp2p3 strict reloc match
- fdiff: 0/59 mismatches
- linkcheck: VERIFIED, blind=0