### PR TITLE
Track Codex exact-span matching claims and outcomes

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,10 +19,11 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | active — replacement easiest-free candidate; local byte-match + strict relocs |
 | ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
-| ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | done — 144-byte exact match, strict relocs + linkcheck VERIFIED; PR #371 |
 | ov074 _ZN8Goomboss16CleanupResourcesEv (0x02121abc, size 0xb4) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
-| ov060 func_ov060_021151d4 (0x021151d4, size 0x140) | Codex | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov060 func_ov060_021151d4 (0x021151d4, size 0x140) | Codex | 2026-07-16 | released — existing DB-best div=3 confirmed materialized-base floor; no tracked source change |
 | ov095: func_ov095_021357d8 (0x021357d8), func_ov095_021358cc (0x021358cc), func_ov095_02135cdc (0x02135cdc), UpDownLiftBbh::InitResources (0x021365d8), Flamethrower::Behavior (0x021368f0), Flamethrower::InitResources (0x02136d60) | lunavyqo | 2026-07-12 | done (partial) — 357d8 + UpDownLift InitResources MATCH (PR #305); 35cdc near-miss div≈40 in DB; 358cc/Flamethrower still open |
 | ov019 func_ov019_02111558 (0x02111558, size 0x1fc) | lunavyqo | 2026-07-12 | done - verified byte-identical, draft PR |
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
+| arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
+| ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | active — batch 9, free div=4 near-match refinement |
+| ov006 func_ov006_020c7734 (0x020c7734, size 0x12c) | Codex | 2026-07-16 | active — batch 9, free div=4 near-match refinement |
 | ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | released — DB-best div=6 confirmed three-register coloring floor; no tracked source change |
 | arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed hand-asm/context register floor; no tracked source change |
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,12 +19,12 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | active — free div=3 near-match refinement |
+| arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |
 | ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |
-| arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | active — free div=4 near-match refinement |
+| arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=4 confirmed r3/r0 register-coloring floor; no tracked source change |
 | arm9 func_02058df4 (0x02058df4, size 0xac) | Codex/Mendel | 2026-07-16 | active — free div=4 near-match refinement |
 | ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
-| ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
+| ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | done — exact 80 bytes with canonical relocation targets, linkcheck blind=0; PR #374 |
 | ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
 | ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | done — 80-byte exact match with verified relocation targets; PR #372 |
 | ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | released — DB-best div=3 confirmed register-allocation floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,10 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
-| arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
-| ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | active — batch 9, free div=4 near-match refinement |
-| ov075 func_ov075_0211a948 (0x0211a948, size 0xb8) | Codex | 2026-07-16 | active — batch 9 replacement, free div=5 refinement |
+| ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | done — exact 116 bytes, strict relocs + linkcheck VERIFIED; PR #376 |
+| arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed allocator floor; semantic correction documented, no tracked change |
+| ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | done — exact 228 bytes, strict relocs + linkcheck VERIFIED; PR #377 |
+| ov075 func_ov075_0211a948 (0x0211a948, size 0xb8) | Codex | 2026-07-16 | released — documented pure register-coloring floor (~150 prior variants); DB-best restored |
 | ov006 func_ov006_020c7734 (0x020c7734, size 0x12c) | Codex | 2026-07-16 | released — stale DB entry; existing src from PR #338 independently strict-matches and linkcheck VERIFIED |
 | ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | released — DB-best div=6 confirmed three-register coloring floor; no tracked source change |
 | arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed hand-asm/context register floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,9 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
+| ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
+| ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
 | ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | done — 80-byte exact match with verified relocation targets; PR #372 |
 | ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
 | ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | done — 144-byte exact match, strict relocs + linkcheck VERIFIED; PR #371 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | active — batch 10, free div=5 refinement |
+| ov002 func_ov002_020f5990 (0x020f5990, size 0xdc) | Codex/Lovelace | 2026-07-16 | active — batch 10, free div=5 refinement |
+| ov006 MgBounceAndPounce_Spawn (0x020eeafc, size 0xec) | Codex/Mendel | 2026-07-16 | active — batch 10, free div=5 refinement |
+| ov006 func_ov006_020c6088 (0x020c6088, size 0x100) | Codex | 2026-07-16 | active — batch 10, free div=5 refinement |
 | ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | done — exact 116 bytes, strict relocs + linkcheck VERIFIED; PR #376 |
 | arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed allocator floor; semantic correction documented, no tracked change |
 | ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | done — exact 228 bytes, strict relocs + linkcheck VERIFIED; PR #377 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -23,7 +23,8 @@ it is fair to take over: ping the claimant first.
 | arm9 func_02069918 (0x02069918, size 0x7c) | Codex/Lovelace | 2026-07-16 | released — required base-copy is optimized away; DB-best restored, no tracked change |
 | ov007 func_ov007_020b782c (0x020b782c, size 0xa4) | Codex/Lovelace | 2026-07-16 | active — batch 11 replacement, free div=8 refinement |
 | ov007 func_ov007_020c1448 (0x020c1448, size 0x70) | Codex/Mendel | 2026-07-16 | active — batch 11, free div=8 refinement |
-| ov006 func_ov006_0211b0ec (0x0211b0ec, size 0x90) | Codex | 2026-07-16 | active — batch 11, free div=8 refinement |
+| ov006 func_ov006_0211b0ec (0x0211b0ec, size 0x90) | Codex | 2026-07-16 | done — exact 144 bytes, strict relocs + linkcheck VERIFIED; PR #382 |
+| ov007 func_ov007_020c3598 (0x020c3598, size 0xf4) | Codex | 2026-07-16 | active — batch 11 replacement, free div=7 refinement |
 | arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | done — exact 188 bytes, strict relocs + linkcheck VERIFIED; PR #379 |
 | ov002 func_ov002_020f5990 (0x020f5990, size 0xdc) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed argument-register coloring floor; no tracked change |
 | ov006 MgBounceAndPounce_Spawn (0x020eeafc, size 0xec) | Codex/Mendel | 2026-07-16 | done — exact 236 bytes, strict relocs + linkcheck VERIFIED; PR #380 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -22,6 +22,7 @@ it is fair to take over: ping the claimant first.
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | active — free div=3 near-match refinement |
 | ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |
 | arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | active — free div=4 near-match refinement |
+| arm9 func_02058df4 (0x02058df4, size 0xac) | Codex/Mendel | 2026-07-16 | active — free div=4 near-match refinement |
 | ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
 | ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
 | ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | active — free div=5 near-match refinement |
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |
 | ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |
 | arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=4 confirmed r3/r0 register-coloring floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,12 +19,12 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | active — free div=6 near-match refinement |
-| arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | active — free div=5 near-match refinement |
+| ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | released — DB-best div=6 confirmed three-register coloring floor; no tracked source change |
+| arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed hand-asm/context register floor; no tracked source change |
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |
-| ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |
+| ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | released — DB-best raw div=3 confirmed literal-load scheduling floor; no tracked source change |
 | arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=4 confirmed r3/r0 register-coloring floor; no tracked source change |
-| arm9 func_02058df4 (0x02058df4, size 0xac) | Codex/Mendel | 2026-07-16 | active — free div=4 near-match refinement |
+| arm9 func_02058df4 (0x02058df4, size 0xac) | Codex/Mendel | 2026-07-16 | done — NitroSDK arena-high function exact 172 bytes, linkcheck blind=0; PR #375 |
 | ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
 | ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | done — exact 80 bytes with canonical relocation targets, linkcheck blind=0; PR #374 |
 | ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | active — free div=6 near-match refinement |
 | arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | active — free div=5 near-match refinement |
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |
 | ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,11 +19,14 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
+| arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | active — free div=3 near-match refinement |
+| ov006 func_ov006_0211dad0 (0x0211dad0, size 0xac) | Codex/Raman | 2026-07-16 | active — free div=2 near-match refinement |
+| arm9 func_02068dc8 (0x02068dc8, size 0x7c) | Codex/Lovelace | 2026-07-16 | active — free div=4 near-match refinement |
+| ov004 func_ov004_020ad878 (0x020ad878, size 0x40) | Codex/Lovelace | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
 | ov005 func_ov005_020bfefc (0x020bfefc, size 0x50) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
-| ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | active — easiest-free batch 8, exact byte + relocation verification |
+| ov007 func_ov007_020adb84 (0x020adb84, size 0x44) | Codex | 2026-07-16 | released — existing src independently confirmed exact + linkcheck VERIFIED; no change needed |
 | ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | done — 80-byte exact match with verified relocation targets; PR #372 |
-| ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | released — DB-best div=3 confirmed register-allocation floor; no tracked source change |
 | ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | done — 144-byte exact match, strict relocs + linkcheck VERIFIED; PR #371 |
 | ov074 _ZN8Goomboss16CleanupResourcesEv (0x02121abc, size 0xb4) | Codex/Mendel | 2026-07-16 | done — 180-byte exact match, strict relocs + linkcheck VERIFIED; PR #373 |
 | ov060 func_ov060_021151d4 (0x021151d4, size 0x140) | Codex | 2026-07-16 | released — existing DB-best div=3 confirmed materialized-base floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |
+| arm9 func_02069918 (0x02069918, size 0x7c) | Codex/Lovelace | 2026-07-16 | active — batch 11, free div=7 refinement |
+| ov007 func_ov007_020c1448 (0x020c1448, size 0x70) | Codex/Mendel | 2026-07-16 | active — batch 11, free div=8 refinement |
+| ov006 func_ov006_0211b0ec (0x0211b0ec, size 0x90) | Codex | 2026-07-16 | active — batch 11, free div=8 refinement |
 | arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | done — exact 188 bytes, strict relocs + linkcheck VERIFIED; PR #379 |
 | ov002 func_ov002_020f5990 (0x020f5990, size 0xdc) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed argument-register coloring floor; no tracked change |
 | ov006 MgBounceAndPounce_Spawn (0x020eeafc, size 0xec) | Codex/Mendel | 2026-07-16 | done — exact 236 bytes, strict relocs + linkcheck VERIFIED; PR #380 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,10 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | active — batch 10, free div=5 refinement |
-| ov002 func_ov002_020f5990 (0x020f5990, size 0xdc) | Codex/Lovelace | 2026-07-16 | active — batch 10, free div=5 refinement |
-| ov006 MgBounceAndPounce_Spawn (0x020eeafc, size 0xec) | Codex/Mendel | 2026-07-16 | active — batch 10, free div=5 refinement |
-| ov006 func_ov006_020c6088 (0x020c6088, size 0x100) | Codex | 2026-07-16 | active — batch 10, free div=5 refinement |
+| arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | done — exact 188 bytes, strict relocs + linkcheck VERIFIED; PR #379 |
+| ov002 func_ov002_020f5990 (0x020f5990, size 0xdc) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed argument-register coloring floor; no tracked change |
+| ov006 MgBounceAndPounce_Spawn (0x020eeafc, size 0xec) | Codex/Mendel | 2026-07-16 | done — exact 236 bytes, strict relocs + linkcheck VERIFIED; PR #380 |
+| ov006 func_ov006_020c6088 (0x020c6088, size 0x100) | Codex | 2026-07-16 | done — stale DB entry already byte-exact; canonical calls close BLIND-2; PR #378 |
 | ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | done — exact 116 bytes, strict relocs + linkcheck VERIFIED; PR #376 |
 | arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed allocator floor; semantic correction documented, no tracked change |
 | ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | done — exact 228 bytes, strict relocs + linkcheck VERIFIED; PR #377 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -20,7 +20,8 @@ it is fair to take over: ping the claimant first.
 | Range | Who | Claimed | Status |
 |---|---|---|---|
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |
-| arm9 func_02069918 (0x02069918, size 0x7c) | Codex/Lovelace | 2026-07-16 | active — batch 11, free div=7 refinement |
+| arm9 func_02069918 (0x02069918, size 0x7c) | Codex/Lovelace | 2026-07-16 | released — required base-copy is optimized away; DB-best restored, no tracked change |
+| ov007 func_ov007_020b782c (0x020b782c, size 0xa4) | Codex/Lovelace | 2026-07-16 | active — batch 11 replacement, free div=8 refinement |
 | ov007 func_ov007_020c1448 (0x020c1448, size 0x70) | Codex/Mendel | 2026-07-16 | active — batch 11, free div=8 refinement |
 | ov006 func_ov006_0211b0ec (0x0211b0ec, size 0x90) | Codex | 2026-07-16 | active — batch 11, free div=8 refinement |
 | arm9 func_020453c0 (0x020453c0, size 0xbc) | Codex/Raman | 2026-07-16 | done — exact 188 bytes, strict relocs + linkcheck VERIFIED; PR #379 |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -22,7 +22,8 @@ it is fair to take over: ping the claimant first.
 | ov006 func_ov006_020effb8 (0x020effb8, size 0x74) | Codex/Raman | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
 | arm9 func_0205d688 (0x0205d688, size 0x8c) | Codex/Lovelace | 2026-07-16 | active — batch 9, free div=5 near-match refinement |
 | ov006 func_ov006_020d1958 (0x020d1958, size 0xe4) | Codex/Mendel | 2026-07-16 | active — batch 9, free div=4 near-match refinement |
-| ov006 func_ov006_020c7734 (0x020c7734, size 0x12c) | Codex | 2026-07-16 | active — batch 9, free div=4 near-match refinement |
+| ov075 func_ov075_0211a948 (0x0211a948, size 0xb8) | Codex | 2026-07-16 | active — batch 9 replacement, free div=5 refinement |
+| ov006 func_ov006_020c7734 (0x020c7734, size 0x12c) | Codex | 2026-07-16 | released — stale DB entry; existing src from PR #338 independently strict-matches and linkcheck VERIFIED |
 | ov006 func_ov006_0211aed0 (0x0211aed0, size 0x90) | Codex | 2026-07-16 | released — DB-best div=6 confirmed three-register coloring floor; no tracked source change |
 | arm9 func_02058568 (0x02058568, size 0x64) | Codex/Lovelace | 2026-07-16 | released — DB-best div=5 confirmed hand-asm/context register floor; no tracked source change |
 | arm9 _ZN8CapEnemy11GetCapStateEv (0x02005fa0, size 0xb4) | Codex | 2026-07-16 | released — DB-best confirmed four-word scheduling floor; no tracked source change |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,10 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
-| ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | active — replacement easiest-free candidate; local byte-match + strict relocs |
+| ov003 func_ov003_020ad69c (0x020ad69c, size 0x50) | Codex | 2026-07-16 | done — 80-byte exact match with verified relocation targets; PR #372 |
 | ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
 | ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | done — 144-byte exact match, strict relocs + linkcheck VERIFIED; PR #371 |
-| ov074 _ZN8Goomboss16CleanupResourcesEv (0x02121abc, size 0xb4) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov074 _ZN8Goomboss16CleanupResourcesEv (0x02121abc, size 0xb4) | Codex/Mendel | 2026-07-16 | done — 180-byte exact match, strict relocs + linkcheck VERIFIED; PR #373 |
 | ov060 func_ov060_021151d4 (0x021151d4, size 0x140) | Codex | 2026-07-16 | released — existing DB-best div=3 confirmed materialized-base floor; no tracked source change |
 | ov095: func_ov095_021357d8 (0x021357d8), func_ov095_021358cc (0x021358cc), func_ov095_02135cdc (0x02135cdc), UpDownLiftBbh::InitResources (0x021365d8), Flamethrower::Behavior (0x021368f0), Flamethrower::InitResources (0x02136d60) | lunavyqo | 2026-07-12 | done (partial) — 357d8 + UpDownLift InitResources MATCH (PR #305); 35cdc near-miss div≈40 in DB; 358cc/Flamethrower still open |
 | ov019 func_ov019_02111558 (0x02111558, size 0x1fc) | lunavyqo | 2026-07-12 | done - verified byte-identical, draft PR |

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,10 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov007 func_ov007_020c6550 (0x020c6550, size 0x6c) | Codex/Raman | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov071 _ZN6Coffin8BehaviorEv (0x021224cc, size 0x90) | Codex/Lovelace | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov074 _ZN8Goomboss16CleanupResourcesEv (0x02121abc, size 0xb4) | Codex/Mendel | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
+| ov060 func_ov060_021151d4 (0x021151d4, size 0x140) | Codex | 2026-07-16 | active — easiest-free batch 7, byte-match + strict relocs/linkcheck |
 | ov095: func_ov095_021357d8 (0x021357d8), func_ov095_021358cc (0x021358cc), func_ov095_02135cdc (0x02135cdc), UpDownLiftBbh::InitResources (0x021365d8), Flamethrower::Behavior (0x021368f0), Flamethrower::InitResources (0x02136d60) | lunavyqo | 2026-07-12 | done (partial) — 357d8 + UpDownLift InitResources MATCH (PR #305); 35cdc near-miss div≈40 in DB; 358cc/Flamethrower still open |
 | ov019 func_ov019_02111558 (0x02111558, size 0x1fc) | lunavyqo | 2026-07-12 | done - verified byte-identical, draft PR |
 | _example: ov004 0x020b0000-0x020b8000_ | _handle_ | _2026-06-17_ | _example_ |


### PR DESCRIPTION
Publishes the exact-span coordination ledger used for the Codex matching waves.

- `CLAIMS.md` only; no source, tools, notes, or near-miss changes
- active rows identify current batch 11 work
- completed/released rows record PRs and confirmed compiler floors

This keeps concurrent agents from duplicating work while match implementations remain isolated in one-function PRs.