### PR TITLE
Match func_ov006_0211b0ec byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_0211b0ec.c
+++ b/src/func_ov006_0211b0ec.c
@@ -1,19 +1,20 @@
-// NONMATCHING: register allocation (div=19). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int data_ov006_0212eef4[];
 extern int data_ov006_0212eee8[];
-void func_ov006_0211b0ec(char *c, int i){
+
+void func_ov006_0211b0ec(char *c, int i)
+{
     int o = i * 0x24;
     char *bIdx = c + 0x51d2;
     char *bVal = c + 0x51b0;
-    char *b50 = c + o + 0x5000;
+    char *b50 = (c + o) + 0x5000;
     unsigned char idx;
-    *(unsigned char*)(b50 + 0x1cd) = 1;
-    idx = *(unsigned char*)(bIdx + o);
-    *(int*)(bVal + o) = *(int*)(bVal + o) + data_ov006_0212eef4[idx];
-    *(int*)(b50 + 0x1bc) = -0x2000;
-    *(int*)(b50 + 0x1b8) = data_ov006_0212eee8[*(unsigned char*)(bIdx + o)];
-    *(short*)(c + o + 0x51c8) = 0;
-    *(unsigned char*)(b50 + 0x1d1) = 1;
+    *((unsigned char *)(((c + (o & 0xFFFFFFFFFFFFFFFFu)) + 0x5000) + 0x1cd)) = 1;
+    idx = *((unsigned char *)(bIdx + o));
+    *((int *)(bVal + o)) =
+        (*((int *)(bVal + o))) + data_ov006_0212eef4[idx];
+    *((int *)(((c + o) + 0x5000) + 0x1bc)) = -0x2000;
+    *((int *)(b50 + 0x1b8)) =
+        data_ov006_0212eee8[*((unsigned char *)(bIdx + o))];
+    *((short *)((c + o) + 0x51c8)) = 0;
+    *((unsigned char *)(((c + o) + 0x5000) + 0x1d1)) = 1;
 }


### PR DESCRIPTION
Matches `func_ov006_0211b0ec` at `0x0211b0ec` (144 bytes) by applying the verified address-shaping idiom from exact sibling functions.

Verified locally:
- mwccarm 1.2/sp2p3 strict reloc match
- fdiff: 0/36 mismatches
- linkcheck: VERIFIED, blind=0