### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204b244.c
+++ b/src/func_0204b244.c
@@ -1,0 +1,135 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned char u8;
+typedef long long s64;
+
+typedef struct {
+    u32 start : 6;
+    u32 limit : 6;
+    u32 count : 6;
+    u32 : 14;
+} Cnt74;
+
+/* G: first word packs axis (bits 17-18) and flag (bit 19); scale at +0x20; fa/fb at +0x34 */
+typedef struct {
+    u32 : 17;
+    u32 axis : 2;
+    u32 flag : 1;
+    u32 : 12;
+    char _pad4[0x20 - 4];
+    s16 scale;
+    char _pad22[0x34 - 0x22];
+    u32 : 24;
+    u32 fa : 2;
+    u32 fb : 2;
+    u32 : 4;
+} G;
+
+typedef struct {
+    G *p0;
+} Adat;
+
+typedef struct {
+    char _pad0[0x18];
+    Adat *p18;
+    char _pad1c[0x74 - 0x1c];
+    Cnt74 cnt;
+} Ctx;
+
+typedef struct {
+    u16 lo : 5;
+    u16 hi : 5;
+    u16 : 6;
+} M40;
+
+typedef struct {
+    char _pad0[8];
+    int p8;
+    int pc;
+    int p10;
+    int p14;
+    int p18;
+    int p1c;
+    char _pad20[0x30 - 0x20];
+    int p30;
+    s16 p34;
+    u16 p36;
+    char _pad38[2];
+    u16 p3a;
+    char _pad3c[4];
+    M40 p40;
+} Node;
+
+typedef struct {
+    char _pad0[0x30];
+    int p30;
+    Ctx *p34;
+    void *p38;
+} Self;
+
+extern s16 data_02082214[];
+extern void (*data_02099fbc[])(int, int, void *);
+extern void (*data_02099fb4[])(u8, u8);
+
+extern void func_020527e8(int *m, int sx, int sy, int sz);
+extern void MulMat4x3Mat4x3(void *a, void *b, void *out);
+extern void func_020553a4(void *m);
+extern void func_02055388(void *m);
+
+void func_0204b244(Self *self, Node *node)
+{
+    Ctx *c = self->p34;
+    int scale = (node->p40.lo * (node->p40.hi + 1)) >> 5;
+    int out[12];
+    int rot[12];
+    int scl[12];
+    u32 f2;
+    u32 v;
+
+    v = *(u32 *)((char *)c + 0x74) << 14;
+    f2 = v >> 26;
+    v = self->p30 | 0xc0;
+    v |= f2 << 24;
+    v |= scale << 16;
+    *(volatile u32 *)0x40004a4 = v;
+    *(volatile u32 *)0x40004a4;
+    {
+        Cnt74 *q = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        q->count++;
+        if (c->cnt.count > c->cnt.limit)
+            q->count = c->cnt.start;
+    }
+
+    if (scale == 0)
+        return;
+
+    {
+        G *g = self->p34->p18->p0;
+        int idx = node->p36 >> 4;
+        data_02099fbc[g->axis](data_02082214[idx * 2], data_02082214[idx * 2 + 1], rot);
+    }
+
+    {
+        G *g = self->p34->p18->p0;
+        int v1 = (int)(((long long)node->p30 * node->p34 + 0x800) >> 12);
+        int v2 = (int)(((long long)v1 * g->scale + 0x800) >> 12);
+        func_020527e8(scl, v2, v1, v1);
+    }
+
+    /* ROM: r0=scl@0x60, r1=rot@0x30, r2=out@0 */
+    MulMat4x3Mat4x3(scl, rot, out);
+
+    out[9] = node->p14 + node->p8;
+    out[10] = node->p18 + node->pc;
+    out[11] = node->p1c + node->p10;
+
+    func_020553a4(self->p38);
+    func_02055388(out);
+
+    *(volatile u32 *)0x4000480 = node->p3a;
+    {
+        G *g = self->p34->p18->p0;
+        data_02099fb4[g->flag]((u8)g->fa, (u8)g->fb);
+    }
+}

--- a/src/func_0204b81c.c
+++ b/src/func_0204b81c.c
@@ -1,0 +1,176 @@
+typedef signed short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef long long s64;
+
+typedef struct { int x, y, z; } Vec3;
+
+typedef struct {
+    u32 start : 6;
+    u32 limit : 6;
+    u32 count : 6;
+    u32 : 14;
+} Cnt74;
+
+typedef struct {
+    char _pad[0x10];
+    u32 tx : 2;
+    u32 ty : 2;
+    u32 : 28;
+} Bdat;
+
+typedef struct {
+    char _pad[0x20];
+    s16 q20;
+    char _pad2[0x12];
+    u32 : 8;
+    u32 val : 16;
+    u32 fa : 2;
+    u32 fb : 2;
+    u32 : 4;
+} P0;
+
+typedef struct {
+    P0 *p0;
+    char _pad[0x10];
+    Bdat *p14;
+} Adat;
+
+typedef struct {
+    char _pad[0x18];
+    Adat *p18;
+    char _pad2[0x74 - 0x1c];
+    Cnt74 cnt;
+} Ctx;
+
+typedef struct {
+    u16 lo : 5;
+    u16 hi : 5;
+    u16 : 6;
+} M40;
+
+typedef struct {
+    char _pad0[8];
+    int p8;
+    int pc;
+    int p10;
+    int p14;
+    int p18;
+    int p1c;
+    Vec3 v20;
+    char _pad2c[4];
+    int p30;
+    s16 p34;
+    u16 p36;
+    char _pad38[2];
+    u16 p3a;
+    char _pad3c[4];
+    M40 p40;
+} Node;
+
+typedef struct {
+    char _pad[0x30];
+    int p30;
+    Ctx *p34;
+    int *p38;
+} Self;
+
+extern void CrossVec3(Vec3 *a, Vec3 *b, Vec3 *out);
+extern void NormalizeVec3(Vec3 *a, Vec3 *b);
+extern void Copy36Bytes(int *src, int *dst);
+extern void MulVec3Mat3x3(int *in, int *m, int *out);
+extern void MulVec3Mat4x3(Vec3 *v, int *m, Vec3 *dst);
+extern void func_02055388(int *m);
+extern void func_0204c24c(u8 a, u8 b);
+
+#define FX(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+void func_0204b81c(Self *self, Node *node)
+{
+    Ctx *c = self->p34;
+    s16 q = c->p18->p0->q20;
+    int scale = (node->p40.lo * (node->p40.hi + 1)) >> 5;
+    int *mtx = self->p38;
+    Vec3 nv;
+    Vec3 trans;
+    Vec3 cr;
+    Vec3 col;
+    int tmp[9];
+    int mat[12];
+    u32 f2;
+    u32 v;
+    int v2;
+    s64 v1w;
+
+    v = *(u32 *)((char *)c + 0x74) << 14;
+    f2 = v >> 26;
+    v = self->p30 | 0xc0;
+    v |= f2 << 24;
+    v |= scale << 16;
+    *(volatile u32 *)0x40004a4 = v;
+    *(volatile u32 *)0x40004a4;
+    {
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        qq->count++;
+        if (c->cnt.count > c->cnt.limit)
+            qq->count = c->cnt.start;
+    }
+
+    if (scale == 0)
+        return;
+
+    v1w = (int)(((s64)node->p30 * node->p34 + 0x800) >> 12);
+    trans.x = node->p14 + node->p8;
+    trans.y = node->p18 + node->pc;
+    trans.z = node->p1c + node->p10;
+    v2 = FX((int)v1w, q);
+    cr = node->v20;
+    col.x = mtx[2];
+    col.y = mtx[5];
+    col.z = mtx[8];
+    CrossVec3(&cr, &col, &cr);
+
+    if (cr.x == 0 && cr.y == 0 && cr.z == 0)
+        return;
+
+    NormalizeVec3(&cr, &cr);
+    Copy36Bytes(mtx, tmp);
+    MulVec3Mat3x3((int *)&cr, tmp, (int *)&cr);
+    MulVec3Mat4x3(&trans, mtx, &trans);
+    nv = node->v20;
+    NormalizeVec3(&nv, &nv);
+
+    {
+        int d = FX(nv.x, -mtx[2]) + FX(nv.y, -mtx[5]) + FX(nv.z, -mtx[8]);
+        int w;
+        int s;
+        int t;
+        if (d < 0)
+            d = -d;
+        w = 0x1000 - d;
+        s = FX(w, (int)self->p34->p18->p0->val);
+        t = (int)((v1w * (s + 0x1000) + 0x800) >> 12);
+
+        mat[0] = FX(cr.x, v2);
+        mat[8] = 0x1000;
+        mat[9] = trans.x;
+        mat[10] = trans.y;
+        mat[11] = trans.z;
+        mat[3] = FX(-cr.y, t);
+        mat[1] = FX(cr.y, v2);
+        mat[6] = 0;
+        mat[4] = FX(cr.x, t);
+        mat[7] = 0;
+        mat[2] = 0;
+        mat[5] = 0;
+        *(volatile u32 *)0x4000454 = 0;
+        func_02055388(mat);
+    }
+
+    *(volatile u32 *)0x4000480 = node->p3a;
+    {
+        P0 *p = self->p34->p18->p0;
+        func_0204c24c(p->fa, p->fb);
+    }
+}

--- a/src/func_ov005_020c1130.c
+++ b/src/func_ov005_020c1130.c
@@ -1,4 +1,3 @@
-// NONMATCHING: entry-load/00b4 setup; switch schedule; type5 close (div=92)
 typedef unsigned char u8;
 typedef unsigned int u32;
 
@@ -23,14 +22,14 @@ typedef struct Entry {
 
 extern Pair data_ov005_020c2280[];
 extern Entry data_ov005_020c24d8[];
-extern void* data_ov005_020c2f4c[];
+extern void *data_ov005_020c2f4c[];
 
-extern int func_ov005_020c00b4(void* self, int n);
-extern int func_ov005_020bfff4(void* self, int n, int c);
-extern void func_ov005_020c1030(void* self, int x, int y, int val);
-extern int _ZN3OAM9RenderSubEP7OamAttriiii(void* oam, int x, int y, int a, int b);
+extern int func_ov005_020c00b4(void *self, int n);
+extern int func_ov005_020bfff4(void *self, int n, int c);
+extern void func_ov005_020c1030(void *self, int x, int y, int val);
+extern int _ZN3OAM9RenderSubEP7OamAttriiii(void *oam, int x, int y, int a, int b);
 
-void func_ov005_020c1130(char* sl)
+void func_ov005_020c1130(char *sl)
 {
     int end;
     int i;
@@ -38,7 +37,6 @@ void func_ov005_020c1130(char* sl)
     int zero;
     int neg1;
     int type;
-    int idx;
     int x, y;
     int val;
     unsigned int u;
@@ -46,7 +44,7 @@ void func_ov005_020c1130(char* sl)
     unsigned int rem;
     unsigned int pct;
 
-    if (*(u8*)(sl + 0x54) == 1)
+    if (*(u8 *)(sl + 0x54) == 1)
         return;
 
     if (data_0209b304 == 1) {
@@ -63,9 +61,8 @@ void func_ov005_020c1130(char* sl)
     neg1 = -1;
     r8 = i * 4;
     do {
-        idx = data_0208a170 + r8;
-        if (func_ov005_020c00b4(sl, idx) != 0) {
-            type = data_ov005_020c24d8[idx].unk8;
+        if (func_ov005_020c00b4(sl, data_0208a170 + r8) != 0) {
+            type = data_ov005_020c24d8[data_0208a170 + r8].unk8;
             if (type != 0) {
                 if (type == 1) {
                     y = data_ov005_020c2280[i].y;
@@ -86,14 +83,14 @@ void func_ov005_020c1130(char* sl)
                     val = func_ov005_020bfff4(sl, data_0208a170 + r8, zero);
                     func_ov005_020c1030(sl, x - 4, y, val);
                 } else if (type == 3) {
-                    val = func_ov005_020bfff4(sl, idx, zero);
+                    val = func_ov005_020bfff4(sl, data_0208a170 + r8, zero);
                     x = data_ov005_020c2280[i].x;
                     y = data_ov005_020c2280[i].y;
                     func_ov005_020c1030(sl, x - 0x14, y, val);
                 } else if (type == 5) {
                     y = data_ov005_020c2280[i].y;
                     x = data_ov005_020c2280[i].x;
-                    val = func_ov005_020bfff4(sl, idx, zero);
+                    val = func_ov005_020bfff4(sl, data_0208a170 + r8, zero);
                     u = (unsigned int)val;
                     major = u / 60u;
                     func_ov005_020c1030(sl, x - 0x10, y, (int)major);
@@ -102,7 +99,6 @@ void func_ov005_020c1130(char* sl)
                     val = func_ov005_020bfff4(sl, data_0208a170 + r8, zero);
                     u = (unsigned int)val;
                     rem = u % 60u;
-                    /* rem/6 == (rem*100/60)/10 — ROM uses rem*100 then magic /600 */
                     pct = rem * 100u;
                     func_ov005_020c1030(sl, x + 8, y, (int)(pct / 600u));
 
@@ -114,7 +110,7 @@ void func_ov005_020c1130(char* sl)
                 }
             }
         }
+        r8 += 4;
         i += 1;
-        r8 = i * 4;
     } while (i <= end);
 }


### PR DESCRIPTION
## Summary

Three byte-identical matches under mwccarm `1.2/sp2p3`:

| File | Addr | Size | Module |
|------|------|------|--------|
| `src/func_0204b244.c` | `0x0204b244` | `0x21c` | arm9 (new) |
| `src/func_0204b81c.c` | `0x0204b81c` | `0x3bc` | arm9 (new) |
| `src/func_ov005_020c1130.c` | `0x020c1130` | `0x370` | ov005 (replaces NONMATCHING) |

Local verify (all `MATCHING VERSIONS: 1.2/sp2p3`):

```
tools/match.py --c src/func_0204b244.c --func func_0204b244 --addr 0x0204b244 --size 0x21c --version 1.2/sp2p3
tools/match.py --c src/func_0204b81c.c --func func_0204b81c --addr 0x0204b81c --size 0x3bc --version 1.2/sp2p3
tools/match.py --c src/func_ov005_020c1130.c --func func_ov005_020c1130 --module ov005 --addr 0x020c1130 --size 0x370 --version 1.2/sp2p3
```

`src/` only — no near-misses, no tools/notes.

## Test plan

- [x] Local `match.py` MATCH on all three
- [ ] CI `validate` green