### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02069918.c
+++ b/src/func_02069918.c
@@ -1,0 +1,17 @@
+typedef unsigned short u16;
+
+extern char *data_020a9db4;
+
+#define DISPATCH(a, b) \
+    (*(void (**)(int, void *))(data_020a9db4 + 0x1000 + 0xe1c))((a), (b))
+
+void func_02069918(char *arg0)
+{
+    u16 v;
+    if (*(u16 *)(arg0 + 2) != 0) return;
+    v = *(u16 *)(arg0 + 4);
+    if (v == 7) return;
+    if (v == 9) return;
+    if (v != 0x15) return;
+    DISPATCH(9, arg0);
+}

--- a/src/nds_printt.c
+++ b/src/nds_printt.c
@@ -1,0 +1,39 @@
+extern int _ZN4cstd6strlenEPKc(const char *s);
+extern void func_020147bc(unsigned short *p, int c);
+
+#pragma opt_common_subs off
+
+void nds_printt(unsigned short *dest, char *str, int value)
+{
+    int len = _ZN4cstd6strlenEPKc(str);
+    char c;
+    unsigned short *p = dest + len;
+    while (value != 0 && len != 0) {
+        int out;
+        len--;
+        c = str[len];
+        p--;
+        if (c >= 0x30 && c <= 0x39) {
+            out = value % (c - 0x2f);
+            value = value / (c - 0x2f);
+            out += 0x30;
+        } else if (c >= 0x61 && c <= 0x7a) {
+            out = c;
+        } else if (c >= 0x41 && c <= 0x5a) {
+            out = c;
+        } else {
+            out = (int)(((long long)(int)c) & 0xFFFFFFFFFFFFFFFFLL);
+        }
+        func_020147bc(p, (char)out);
+    }
+    if (len == 0) return;
+    {
+        unsigned short *q = dest + len;
+        int space = 0x20;
+        do {
+            q--;
+            len--;
+            func_020147bc(q, space);
+        } while (len != 0);
+    }
+}


### PR DESCRIPTION
Two arm9 functions matched byte-identical under mwccarm 1.2/sp2p3.

| function | addr | size | fdiff |
|---|---|---|---|
| `nds_printt` | 0x02014620 | 0xec | 0/59 |
| `func_02069918` | 0x02069918 | 0x7c | 0/31 |

**`nds_printt`** — sibling of the already-matched `nds_printf` in the same TU.
**`func_02069918`** — sound-event filter; dispatches through a function pointer, same idiom as the matched sibling `func_02069994`.

**Verification.** Both report `MATCH` from the `match` oracle at 1.2/sp2p3. Since `match`/`fdiff` wildcard relocated words, relocations were additionally checked against `config/arm9/relocs.txt` ground truth — every reloc in each function's span resolves to the named symbol:

- `nds_printt` -> `_ZN4cstd6strlenEPKc` @ 0x02070788; `func_020147bc` @ 0x020147bc (x2); `__aeabi_idiv` @ 0x01ffabe4 (x2, compiler-implicit from `%` and `/`, correctly named in no source line).
- `func_02069918` -> `data_020a9db4` (bss). The indirect `blx` carries no reloc, as in the ROM.

Exact correspondence in both, so no WRONG-DEST exposure.

Contents: `src/` additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM8EtS8Vwp3RHs9wfpPbNJ