### PR TITLE
Match 4 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/Skeeter_Spawn.c
+++ b/src/Skeeter_Spawn.c
@@ -3,13 +3,13 @@ extern void _ZN5EnemyC2Ev(void *);
 extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
 extern void _ZN12WithMeshClsnC1Ev(void *);
 extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+extern int _ZTV7Skeeter[];
 int *Skeeter_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7Skeeter;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/_ZN8MantaRay16CleanupResourcesEv.c
+++ b/src/_ZN8MantaRay16CleanupResourcesEv.c
@@ -1,13 +1,13 @@
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
-extern int G0[];
-extern int G1[];
-extern int G2[];
-extern int G3[];
+extern char data_ov090_02134524[];
+extern char data_ov002_0210da10[];
+extern char data_ov002_0210d9a8[];
+extern char data_ov090_0213452c[];
 int _ZN8MantaRay16CleanupResourcesEv(void)
 {
-    _ZN13SharedFilePtr7ReleaseEv(G0);
-    _ZN13SharedFilePtr7ReleaseEv(G1);
-    _ZN13SharedFilePtr7ReleaseEv(G2);
-    _ZN13SharedFilePtr7ReleaseEv(G3);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov090_02134524);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da10);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a8);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov090_0213452c);
     return 1;
 }

--- a/src/_ZN8MantaRayD0Ev.c
+++ b/src/_ZN8MantaRayD0Ev.c
@@ -3,15 +3,15 @@ extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern void *G0;
+extern int _ZTV8MantaRay[];
+extern void *data_020a0eac;
 int *_ZN8MantaRayD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8MantaRay;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
+    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
     return t;
 }

--- a/src/_ZN8MantaRayD1Ev.c
+++ b/src/_ZN8MantaRayD1Ev.c
@@ -2,10 +2,10 @@ extern void _ZN9ModelAnimD1Ev(void *);
 extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
+extern int _ZTV8MantaRay[];
 int *_ZN8MantaRayD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8MantaRay;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);


### PR DESCRIPTION
Resolves the concrete relocation targets for four existing byte-identical ov090 functions inside the claimed Skeeter/MantaRay range:

- `Skeeter_Spawn` — 0x02132654, size 0x48: `_ZTV7Skeeter`
- `_ZN8MantaRayD1Ev` — 0x0213269c, size 0x40: `_ZTV8MantaRay`
- `_ZN8MantaRayD0Ev` — 0x021326dc, size 0x54: `_ZTV8MantaRay`, `data_020a0eac`
- `_ZN8MantaRay16CleanupResourcesEv` — 0x02132c1c, size 0x48: four concrete SharedFilePtr targets

Verification for every function:
- strict oracle: `MATCHING VERSIONS: 1.2/sp2p3`
- linkcheck: `VERIFIED`, `diffs: []`, `blind: 0`

The one-instruction near-miss at `func_ov090_021327e4` is intentionally not included. This PR contains only `src/` changes.

Model: Codex SOL 5.6 (high)
Harness: Codex CLI (ChatGPT app)

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents