### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov007_020c92d0.c
+++ b/src/func_ov007_020c92d0.c
@@ -1,0 +1,25 @@
+void func_ov007_020c92d0(char *state)
+{
+    short pending = *(short *)(state + 2);
+
+    if (pending != -1) {
+        short current = *(short *)state;
+
+        if (pending != current) {
+            *(short *)(state + 8) = current;
+            *(short *)state = *(short *)(state + 2);
+        }
+        *(short *)(state + 2) = -1;
+    }
+
+    if (*(short *)state != *(short *)(state + 8)) {
+        *(int *)(state + 12) = 0;
+        *(short *)(state + 10) = *(short *)(state + 8);
+        *(int *)(state + 4) = 0;
+    } else if ((unsigned int)*(int *)(state + 12) < 0xffffffffU) {
+        int *counter = (int *)(((long long)((int)state + 12)) & 0xffffffffffffffffLL);
+        ++*counter;
+    }
+
+    *(short *)(state + 8) = *(short *)state;
+}

--- a/src/func_ov095_021358cc.c
+++ b/src/func_ov095_021358cc.c
@@ -1,0 +1,20 @@
+#pragma opt_common_subs off
+int func_ov095_021358cc(int a, short* pos, short* vel, int target, short thresh, int accel, short mult)
+{
+    short old = pos[0];
+    pos[0] = old + vel[0];
+    short now = pos[0];
+    if (now == target
+        || ((now - target) * (old - target) < 0
+            && vel[0] > -thresh && vel[0] < thresh)) {
+        pos[0] = target;
+        vel[0] = 0;
+        return 1;
+    }
+    if (now >= target)
+        accel = (short)-accel;
+    if ((short)vel[0] * (short)accel < 0)
+        accel = (short)accel * (short)mult;
+    vel[0] = vel[0] + accel;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- `func_ov007_020c92d0` @ `0x020c92d0` (ov007, size `0x7c`): updates a small state/history structure. The documented u64 address-laundering idiom preserves the retail counter-pointer materialization.
- `func_ov095_021358cc` @ `0x021358cc` (ov095, size `0xb0`): advances a signed-short position/velocity toward a target. `#pragma opt_common_subs off` reproduces the retail register coloring.

Both files are byte-identical with the retail EU ROM under **mwccarm 1.2/sp2p3**.

## Verification

- strict oracle: `MATCHING VERSIONS: 1.2/sp2p3` for both files
- linkcheck: `VERIFIED`, `diffs: []`, `blind: 0` for both files
- PR contains only the two new `src/` files

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents