### PR TITLE
Verify func_ov013_021111a0 relocation target (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov013_021111a0.c
+++ b/src/func_ov013_021111a0.c
@@ -1,9 +1,9 @@
 extern void _ZN5ModelD1Ev(void *);
 extern void _ZN5ActorD1Ev(void *);
-extern int VT0[];
+extern int data_ov013_02112128[];
 int *func_ov013_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_ov013_02112128;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD1Ev(t);
     return t;


### PR DESCRIPTION
## Summary

- `func_ov013_021111a0` @ `0x021111a0` (ov013, size `0x30`)
- replaces the generic `VT0` alias with concrete target `data_ov013_02112128`
- preserves byte-identical code while making the vtable/data relocation provable

## Verification

- strict oracle: `MATCHING VERSIONS: 1.2/sp2p3`
- linkcheck: `VERIFIED`, `diffs: []`, `blind: 0`
- PR contains only the single `src/` relocation correction

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents