### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02071364.c
+++ b/src/func_02071364.c
@@ -1,0 +1,83 @@
+typedef struct Decimal {
+    unsigned char sign;
+    char unused;
+    short exp;
+    struct {
+        unsigned char length;
+        unsigned char text[32];
+        unsigned char unused;
+    } sig;
+} Decimal;
+
+extern void func_02071644(Decimal *result, int length);
+
+void func_02071364(Decimal *result, const Decimal *x, const Decimal *y)
+{
+    unsigned int accumulator = 0;
+    unsigned char mantissa[64];
+    int i = x->sig.length + y->sig.length - 1;
+    unsigned char *ip = mantissa + i + 1;
+    unsigned char *ep = ip;
+
+    result->sign = 0;
+
+    for (; i > 0; i--) {
+        int k = y->sig.length - 1;
+        int j = i - k - 1;
+        int l;
+        int t;
+        const unsigned char *jp;
+        const unsigned char *kp;
+
+        if (j < 0) {
+            j = 0;
+            k = i - 1;
+        }
+
+        jp = x->sig.text + j;
+        kp = y->sig.text + k;
+        l = k + 1;
+        t = x->sig.length - j;
+
+        if (l > t) {
+            l = t;
+        }
+
+        for (; l > 0; l--, jp++, kp--) {
+            accumulator += *jp * *kp;
+        }
+
+        *--ip = (unsigned char)(accumulator % 10);
+        accumulator /= 10;
+    }
+
+    result->exp = (short)(x->exp + y->exp);
+
+    if (accumulator) {
+        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)) &
+                                    0xffffffffffffffffLL);
+        *--ip = (unsigned char)accumulator;
+        *exp = *exp + 1;
+    }
+
+    for (i = 0; i < 32 && ip < ep; i++, ip++) {
+        result->sig.text[i] = *ip;
+    }
+    result->sig.length = (unsigned char)i;
+
+    if (ip < ep && *ip >= 5) {
+        if (*ip == 5) {
+            unsigned char *jp = ip + 1;
+            for (; jp < ep; jp++) {
+                if (*jp != 0) {
+                    goto round;
+                }
+            }
+            if ((ip[-1] & 1) == 0) {
+                return;
+            }
+        }
+    round:
+        func_02071644(result, result->sig.length);
+    }
+}

--- a/src/func_ov006_020eb3e4.c
+++ b/src/func_ov006_020eb3e4.c
@@ -1,0 +1,56 @@
+typedef struct P2 { int a, b; } P2;
+extern int data_ov006_0213ca44[];
+extern void _Z14ApproachLinearRiii(int *v, int target, int step);
+extern void _Z14ApproachLinearRsss(short *v, short target, short step);
+extern void func_0203d388(int *p, int angle);
+extern void func_0203d704(int *o, int *a, int *b);
+
+void func_ov006_020eb3e4(char *c)
+{
+    int va[2];
+    int vb[2];
+    short tgt;
+    short cnt;
+
+    _Z14ApproachLinearRiii((int *)(c + 0x48), 0, 0x200);
+    *(short *)(((int)c + 0x78) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    if (*(short *)(c + 0x78) == 0) {
+        int *p10 = (int *)(((int)c + 0x10) & 0xFFFFFFFFFFFFFFFF);
+        int *pd = (int *)(((int)data_ov006_0213ca44) & 0xFFFFFFFFFFFFFFFF);
+        if (p10[0] == pd[0] &&
+            (p10[1] == pd[1] || *(int *)(c + 0x10) == 0)) {
+            *(unsigned char *)(c + 0x94) = 1;
+            *(int *)(c + 0x48) = 0x3000;
+            *(unsigned char *)(c + 0x93) = 0;
+            *(unsigned char *)(c + 0x95) = 0;
+        } else {
+            *(unsigned char *)(c + 0x94) = 0;
+            *(unsigned char *)(c + 0x93) = 0;
+            *(int *)(c + 0x44) = 0xa00;
+            *(unsigned short *)(c + 0x86) = 0x600;
+            *(unsigned char *)(c + 0x95) = 2;
+            *(int *)(c + 0x68) = 0;
+            *(int *)(c + 0x6c) = 0x1ec;
+        }
+        *(P2 *)c = *(P2 *)(c + 0x10);
+        return;
+    }
+    {
+        int z = 0;
+        int n = 0x10000;
+        n = -n;
+        va[0] = z;
+        va[1] = n;
+    }
+    tgt = *(short *)(c + 0x76) - 0x1000;
+    _Z14ApproachLinearRsss((short *)(c + 0x7a), tgt, 0x400);
+    func_0203d388(va, *(short *)(c + 0x7a));
+    func_0203d704(vb, (int *)(c + 0x20), va);
+    *(int *)(c + 0x18) = vb[0];
+    *(int *)(c + 0x1c) = vb[1];
+    cnt = *(short *)(c + 0x78);
+    if ((cnt & 0x10) == 0 || cnt < 0x38)
+        *(unsigned char *)(c + 0x95) = 1;
+    else
+        *(unsigned char *)(c + 0x95) = 0;
+}


### PR DESCRIPTION
## Summary

- `func_02071364` @ `0x02071364` (`arm9`, size `0x1ac` / 428 bytes)
- `func_ov006_020eb3e4` @ `0x020eb3e4` (`ov006`, size `0x174` / 372 bytes)
- Both reproduce the retail EU bytes under `mwccarm 1.2/sp2p3` with `--strict-relocs`.
- Both pass `tools/linkcheck.py`: `VERIFIED`, `diffs: []`, `blind: 0`.

## Test plan

- `tools/match.py` strict oracle: MATCH for both files
- `tools/linkcheck.py`: VERIFIED with zero blind relocations for both files
- Upstream validate bot performs the linked validation

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents