### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020caf98.cpp
+++ b/src/func_ov002_020caf98.cpp
@@ -1,0 +1,83 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+struct Ret { int pad; int y; };
+
+struct Arg {
+    virtual void *m0();
+    virtual void *m1();
+    virtual struct Ret *m2();
+};
+
+struct Player {
+    struct State {};
+
+    int IsState(State &s);
+    int IsInAir();
+    int IsBeingShotOutOfCannon();
+    int ChangeState(State &s);
+};
+
+extern Player::State data_ov002_0211013c;
+extern Player::State data_ov002_021105bc;
+extern Player::State data_ov002_0211031c;
+extern Player::State data_ov002_021101b4;
+extern Player::State data_ov002_021106dc;
+
+extern "C" int func_ov002_020e0478(void *c);
+extern "C" int func_ov002_020e3078(struct Player *self, void *s);
+
+extern "C" int func_ov002_020caf98(Player *self, Arg *arg)
+{
+    char *p = (char *)self;
+    int b354, b358;
+
+    if (self->IsState(data_ov002_0211013c) == 0 &&
+        *(u16 *)(p + 0x6b6) == 0)
+    {
+        b354 = (*(int *)(p + 0x354) != 0);
+        if (b354 == 0 &&
+            *(int *)(p + 0x37c) == 0)
+        {
+            b358 = (*(int *)(p + 0x358) != 0);
+            if (b358 == 0 &&
+                *(u8 *)(p + 0x708) == 0 &&
+                *(u8 *)(p + 0x709) == 0 &&
+                *(u8 *)(p + 0x706) == 0 &&
+                *(u8 *)(p + 0x703) == 0)
+            {
+                goto cont;
+            }
+        }
+    }
+    return 0;
+
+cont:
+    if (self->IsInAir() != 0) goto state_check;
+    if (self->IsBeingShotOutOfCannon() != 0) goto state_check;
+    if (self->IsState(data_ov002_021105bc) != 0) goto state_check;
+    if (self->IsState(data_ov002_0211031c) != 0) goto state_check;
+
+    if (func_ov002_020e0478(self) == 0) goto ret0a;
+
+state_check:
+    if (self->IsState(data_ov002_021101b4) != 0) {
+        if (func_ov002_020e3078(self, &data_ov002_021106dc) != 0) return 0;
+    }
+
+    if (*(int *)((char *)arg + 0x18) & 0x400000) return 0;
+
+    {
+        Ret *r = arg->m2();
+        if (*(int *)(p + 0x60) - r->y < -0x64000)
+            *(int *)(p + 0x60) = r->y - 0x64000;
+    }
+
+    *(void **)(p + 0x37c) = arg;
+    self->ChangeState(data_ov002_021106dc);
+    return 1;
+
+ret0a:
+    return 0;
+}

--- a/src/func_ov060_02114d08.c
+++ b/src/func_ov060_02114d08.c
@@ -1,0 +1,54 @@
+typedef short s16;
+typedef unsigned short u16;
+
+extern int _ZN5Actor14GetSubtractionEss(void* actor, s16 a, s16 b);
+extern int _Z14ApproachLinearRsss(s16* dst, s16 target, int step);
+extern int func_ov060_02115744(void* c);
+extern int func_ov060_02115718(void* c);
+extern int func_ov060_021156ec(void* c);
+
+void func_ov060_02114d08(char* self)
+{
+    int r4;
+    int step;
+
+    r4 = _ZN5Actor14GetSubtractionEss(self, *(s16*)(self + 0x8e), *(s16*)(self + 0x406));
+
+    if (*(unsigned char*)(self + 0x414) == 1) {
+        step = 0x400;
+    } else {
+        int t = *(signed char*)(self + 0x41e);
+        if (t > 2) {
+            step = 0x400;
+        } else if (t == 2) {
+            step = 0x300;
+        } else {
+            step = 0x200;
+        }
+    }
+    _Z14ApproachLinearRsss((s16*)(self + 0x8e), *(s16*)(self + 0x406), step);
+
+    if (*(unsigned char*)(self + 0x423) == 0) {
+        *(short*)(self + 0x3fe) = 0;
+        if (func_ov060_02115744(self) == 0) return;
+        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        return;
+    }
+    if (*(unsigned char*)(self + 0x423) <= 2) {
+        if (func_ov060_02115718(self) == 0) return;
+        (*(u16*)(((int)self + 0x3fe) & 0xFFFFFFFFFFFFFFFFLL))++;
+        if (*(int*)(self + 0x418) & 0x20000) {
+            if (*(u16*)(self + 0x3fe) < 5) return;
+            *(int*)(((int)self + 0x418) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+            return;
+        }
+        if (r4 >= 0x2000) return;
+        *(int*)(self + 0x12c) = 0;
+        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        *(short*)(self + 0x3fe) = 0;
+        return;
+    }
+    if (func_ov060_021156ec(self) != 0) {
+        *(int*)(self + 0x40c) = 0;
+    }
+}


### PR DESCRIPTION
## Summary

- `func_ov060_02114d08` @ `0x02114d08` (`ov060`, size `0x194` / 404 bytes)
- `func_ov002_020caf98` @ `0x020caf98` (`ov002`, size `0x1c4` / 452 bytes)
- Both reproduce the retail EU bytes under `mwccarm 1.2/sp2p3` with `--strict-relocs`.
- Both pass `tools/linkcheck.py`: `VERIFIED`, `diffs: []`, `blind: 0`.
- The ov002 source uses the real nested `Player::State` ABI so all member relocations resolve.

## Test plan

- strict `tools/match.py`: MATCH for both files
- `tools/linkcheck.py`: VERIFIED with zero blind relocations for both files
- Upstream validate bot performs linked validation

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents