### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN9ActorBase9Virtual34Ejj.cpp
+++ b/src/_ZN9ActorBase9Virtual34Ejj.cpp
@@ -1,0 +1,132 @@
+//cpp
+typedef unsigned int u32;
+
+struct Heap;
+struct ActorBase;
+
+extern "C" {
+    Heap* _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i(u32 size, Heap* heap, int flag);
+    void* _ZN6Memory8AllocateEjiP4Heap(u32 size, int align, Heap* heap);
+    void  _ZN4Heap20RestoreFromTemporaryEv(void);
+    void  _ZN4Heap8_DestroyEv(Heap* h);
+    u32   _ZN4Heap21MaxAllocationUnitSizeEv(Heap* h);
+    void  _ZN4Heap11ResizeToFitEv(Heap* h);
+    void  _ZN9ActorBase18MarkForDestructionEv(ActorBase* self);
+}
+
+struct ActorBase {
+    virtual void v0();  virtual void v1();  virtual void v2();  virtual void v3();
+    virtual void v4();  virtual void v5();  virtual void v6();  virtual void v7();
+    virtual void v8();  virtual void v9();  virtual void v10(); virtual void v11();
+    virtual void v12(); virtual void v13(); virtual void v14();
+    virtual int  v15();
+
+    int Virtual34(u32 a, u32 b);
+};
+
+int ActorBase::Virtual34(u32 a, u32 b)
+{
+    Heap* h = 0;
+    u32 avail;
+
+    if (*(Heap**)((char*)this + 0x4c) != 0)
+        return 1;
+
+    if (a != 0) {
+        h = _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i(a, (Heap*)b, 0x20);
+        if (h != 0) {
+            u32 flagA = (*(u32*)((char*)h + 4)) & 0x10;
+            if (flagA != 0)
+                _ZN6Memory8AllocateEjiP4Heap(0x10, 4, 0);
+            int res = this->v15();
+            u32 okA;
+            if (flagA != 0) {
+                okA = (u32)res;
+            } else {
+                void* allocRes = _ZN6Memory8AllocateEjiP4Heap(0x10, 4, 0);
+                okA = (allocRes != 0) ? (u32)res : 0;
+            }
+            _ZN4Heap20RestoreFromTemporaryEv();
+            if (okA == 0) {
+                _ZN4Heap8_DestroyEv(h);
+                h = 0;
+            } else {
+                u32 topA = *(u32*)((char*)h + 8);
+                avail = topA - _ZN4Heap21MaxAllocationUnitSizeEv(h);
+                avail = (avail + 0x1f) & ~0x1f;
+                if (a == avail) {
+                    _ZN4Heap11ResizeToFitEv(h);
+                    *(Heap**)((char*)this + 0x4c) = h;
+                    return 1;
+                }
+            }
+        }
+    }
+
+    if (h == 0) {
+        h = _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i((u32)-1, (Heap*)b, 0x20);
+        u32 flagB = (*(u32*)((char*)h + 4)) & 0x10;
+        if (flagB != 0)
+            _ZN6Memory8AllocateEjiP4Heap(0x10, 4, 0);
+        a = (u32)this->v15();
+        if (flagB == 0) {
+            void* allocRes2 = _ZN6Memory8AllocateEjiP4Heap(0x10, 4, 0);
+            if (allocRes2 == 0)
+                a = 0;
+        }
+        _ZN4Heap20RestoreFromTemporaryEv();
+        if (a == 0) {
+            _ZN4Heap8_DestroyEv(h);
+            _ZN9ActorBase18MarkForDestructionEv(this);
+            return 0;
+        }
+        u32 topB = *(u32*)((char*)h + 8);
+        avail = topB - _ZN4Heap21MaxAllocationUnitSizeEv(h);
+        avail = (avail + 0x1f) & ~0x1f;
+    }
+
+    if (h == 0)
+        goto fail;
+
+    {
+        u32 topH = *(u32*)((char*)h + 8);
+        Heap* h2 = 0;
+        u32 availInH = topH - _ZN4Heap21MaxAllocationUnitSizeEv(h);
+        u32 needed = ((availInH + 0xf) & ~0xf) + 0x30;
+        if (needed < _ZN4Heap21MaxAllocationUnitSizeEv((Heap*)b)) {
+            h2 = _ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i(avail, (Heap*)b, 0x20);
+        }
+        if (h2 != 0) {
+            if ((u32)h2 < (u32)h) {
+                _ZN4Heap8_DestroyEv(h);
+                h = 0;
+                int res3 = this->v15();
+                u32 okC = (u32)res3;
+                _ZN4Heap20RestoreFromTemporaryEv();
+                if (okC == 0) {
+                    _ZN4Heap8_DestroyEv(h2);
+                    h2 = h;
+                }
+            } else {
+                _ZN4Heap20RestoreFromTemporaryEv();
+                _ZN4Heap8_DestroyEv(h2);
+                h2 = 0;
+            }
+        }
+        if (h2 != 0) {
+            _ZN4Heap11ResizeToFitEv(h2);
+            *(Heap**)((char*)this + 0x4c) = h2;
+            return 1;
+        }
+    }
+
+    if (h != 0) {
+        _ZN4Heap11ResizeToFitEv(h);
+        *(Heap**)((char*)this + 0x4c) = h;
+        return 1;
+    }
+
+fail:
+    _ZN9ActorBase18MarkForDestructionEv(this);
+    return 0;
+}

--- a/src/func_ov006_0210ff1c.c
+++ b/src/func_ov006_0210ff1c.c
@@ -1,0 +1,53 @@
+
+struct S_0210ff1c
+{
+  char _0[8];
+  int f8;
+  int fc;
+  char _10[0x34 - 0x10];
+  struct 
+  {
+    int a;
+    int b;
+  } arr[3];
+};
+extern void *data_ov006_021379dc;
+extern void *data_ov006_021379e8;
+extern void *data_ov006_02137a00;
+extern void *data_ov006_021379f4;
+extern void func_ov004_020afdd0(void *, int, int, int, int);
+inline int inline_fn(int arg0, int arg1)
+{
+  return arg0 + arg1;
+}
+
+void func_ov006_0210ff1c(void *self)
+{
+  struct S_0210ff1c *s = self;
+  int i;
+  int x;
+  int xo;
+  for (i = 0, x = 0; i < 3; i++, x += 0x18)
+  {
+    if (1)
+    {
+    }
+    func_ov004_020afdd0(data_ov006_021379dc, inline_fn(s->f8 >> 12, x - 0x18), s->fc >> 12, -1, 2);
+  }
+
+  i = 0;
+  x = 0;
+second_loop:
+  {
+    xo = (x - 0x18) & 0xFFFFFFFFFFFFFFFF;
+    func_ov004_020afdd0(data_ov006_021379e8, inline_fn(inline_fn(s->f8 >> 12, s->arr[i].a >> 12), xo), inline_fn(s->fc >> 12, s->arr[i].b >> 12), -1, 3);
+    func_ov004_020afdd0(data_ov006_02137a00, inline_fn(inline_fn(s->f8 >> 12, s->arr[i].a >> 12), xo), inline_fn(s->fc >> 12, s->arr[i].b >> 12) - 0x10, -1, 3);
+    func_ov004_020afdd0(data_ov006_021379f4, inline_fn(inline_fn(s->f8 >> 12, s->arr[i].a >> 12), xo), inline_fn(s->fc >> 12, s->arr[i].b >> 12) - 0x20, -1, 3);
+    func_ov004_020afdd0(data_ov006_021379e8, inline_fn(inline_fn(s->f8 >> 12, s->arr[i].a >> 12), xo), inline_fn(s->fc >> 12, s->arr[i].b >> 12) - 0x30, -1, 3);
+    x += 0x18;
+    i++;
+    if (i < 3)
+      goto second_loop;
+  }
+
+}

--- a/src/func_ov007_020c81a0.c
+++ b/src/func_ov007_020c81a0.c
@@ -1,0 +1,35 @@
+typedef short s16;
+typedef long long s64;
+
+struct T {
+    int* f0;
+    int f4;
+    int f8;
+    char pad_c[4];
+    int f10;
+    int f14;
+    char pad_18[4];
+    s16 f1c;
+    char pad_1e[2];
+    int f20;
+};
+
+void func_ov007_020c81a0(struct T* o, int factor, int shift)
+{
+    if (!(o->f20 & 1)) {
+        if (o->f1c == 0x1000) {
+            *(int *)((int)&o->f4 & 0xFFFFFFFFFFFFFFFF) += (o->f10 - (int)(((s64)factor * o->f4 + 0x800) >> 0xc)) >> shift;
+            *(int *)((int)&o->f8 & 0xFFFFFFFFFFFFFFFF) += (o->f14 - (int)(((s64)factor * o->f8 + 0x800) >> 0xc)) >> shift;
+        } else {
+            *(int *)((int)&o->f10 & 0xFFFFFFFFFFFFFFFF) -= (int)(((s64)factor * o->f4 + 0x800) >> 0xc);
+            *(int *)((int)&o->f14 & 0xFFFFFFFFFFFFFFFF) -= (int)(((s64)factor * o->f8 + 0x800) >> 0xc);
+            *(int *)((int)&o->f4 & 0xFFFFFFFFFFFFFFFF) += (int)(((s64)o->f10 * (o->f1c >> shift) + 0x800) >> 0xc);
+            *(int *)((int)&o->f8 & 0xFFFFFFFFFFFFFFFF) += (int)(((s64)o->f14 * (o->f1c >> shift) + 0x800) >> 0xc);
+        }
+        o->f0[0] += o->f4 >> shift;
+        *(int *)((int)&o->f0[1] & 0xFFFFFFFFFFFFFFFF) += o->f8 >> shift;
+    }
+
+    o->f14 = 0;
+    o->f10 = o->f14;
+}


### PR DESCRIPTION
## Summary

- `_ZN9ActorBase9Virtual34Ejj` @ `0x0204357c` (`arm9`, size `0x294` / 660 bytes)
- `func_ov006_0210ff1c` @ `0x0210ff1c` (`ov006`, size `0x18c` / 396 bytes)
- `func_ov007_020c81a0` @ `0x020c81a0` (`ov007`, size `0x17c` / 380 bytes)
- All three reproduce the retail EU bytes under `mwccarm 1.2/sp2p3` with `--strict-relocs`.
- All three pass `tools/linkcheck.py`: `VERIFIED`, `diffs: []`, `blind: 0`.

## Test plan

- strict `tools/match.py`: MATCH for all three files
- `tools/linkcheck.py`: VERIFIED with zero blind relocations for all three files
- Upstream validate bot performs linked validation

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents