### PR TITLE
Match func_02071364 (arm9, 0x1ac bytes)

### DIFF
--- a/src/func_02071364.c
+++ b/src/func_02071364.c
@@ -54,10 +54,8 @@ void func_02071364(Decimal *result, const Decimal *x, const Decimal *y)
     result->exp = (short)(x->exp + y->exp);
 
     if (accumulator) {
-        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)) &
-                                    0xffffffffffffffffLL);
         *--ip = (unsigned char)accumulator;
-        *exp = *exp + 1;
+        *(short *)((int)((char *)result + 2) & 0xFFFFFFFFFFFFFFFF) += 1;
     }
 
     for (i = 0; i < 32 && ip < ep; i++, ip++) {


### PR DESCRIPTION
## Summary

Byte-match **func_02071364** in arm9 (0x1ac / 428 bytes) at mwccarm 1.2/sp2p3.

## What changed

Fixed a single register-allocation divergence at +0xe0 (target uses `addne`, generated code used unconditional `add`).

**Root cause:** The intermediate pointer variable
```c
short *exp = (short *)(int)(((long long)(int)((char *)result + 2)) & 0xffffffffffffffffLL);
```
caused the compiler to materialize the address unconditionally before the conditional block.

**Fix:** Removed the intermediate variable and used a direct cast with lvalue materialization inside the if-block:
```c
*(short *)((int)((char *)result + 2) & 0xFFFFFFFFFFFFFFFF) += 1;
```
This forces the compiler to compute the exp address only when the condition is true, matching the target's conditional execution pattern.

## Verification

- `tools/match.py` reports **MATCHING VERSIONS: 1.2/sp2p3** with zero divergences
- Only `src/` file touched; no generated files or tooling modified

Generated with Qwen Code