### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/__sinit_ov002_02100c50.c
+++ b/src/__sinit_ov002_02100c50.c
@@ -1,29 +1,26 @@
-//cpp
-// NONMATCHING: register allocation (div=28). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" {
-struct P { int a, b; };
-extern P data_ov002_02108730;
-extern P data_ov002_02108770;
-extern P data_ov002_02108748;
-extern P data_ov002_02108760;
-extern P data_ov002_02108740;
-extern P data_ov002_02108758;
-extern P data_ov002_02108750;
-extern P data_ov002_02108768;
-extern P data_ov002_02108738;
-extern P data_ov002_0210dc70[9];
+typedef struct { int a, b; } Pair;
 
-void __sinit_ov002_02100c50(void){
-  data_ov002_0210dc70[0] = data_ov002_02108730;
-  data_ov002_0210dc70[1] = data_ov002_02108770;
-  data_ov002_0210dc70[2] = data_ov002_02108748;
-  data_ov002_0210dc70[3] = data_ov002_02108760;
-  data_ov002_0210dc70[4] = data_ov002_02108740;
-  data_ov002_0210dc70[5] = data_ov002_02108758;
-  data_ov002_0210dc70[6] = data_ov002_02108750;
-  data_ov002_0210dc70[7] = data_ov002_02108768;
-  data_ov002_0210dc70[8] = data_ov002_02108738;
-}
+extern Pair data_ov002_02108730;
+extern Pair data_ov002_02108770;
+extern Pair data_ov002_02108748;
+extern Pair data_ov002_02108760;
+extern Pair data_ov002_02108740;
+extern Pair data_ov002_02108758;
+extern Pair data_ov002_02108750;
+extern Pair data_ov002_02108768;
+extern Pair data_ov002_02108738;
+extern Pair data_ov002_0210dc70[];
+
+void __sinit_ov002_02100c50(void)
+{
+    Pair* dst = data_ov002_0210dc70;
+    dst[0] = data_ov002_02108730;
+    dst[1] = data_ov002_02108770;
+    dst[2] = data_ov002_02108748;
+    dst[3] = data_ov002_02108760;
+    dst[4] = data_ov002_02108740;
+    dst[5] = data_ov002_02108758;
+    dst[6] = data_ov002_02108750;
+    dst[7] = data_ov002_02108768;
+    dst[8] = data_ov002_02108738;
 }

--- a/src/func_ov002_020ec410.c
+++ b/src/func_ov002_020ec410.c
@@ -1,47 +1,40 @@
-// NONMATCHING: register allocation (div=20). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
+//cpp
+struct Actor {
+    static Actor* FindWithID(unsigned int id);
+};
+struct Player {
+    bool CanWarp();
+};
+struct CylinderClsn {
+    void Clear();
+    void Update();
+};
+extern "C" int IsPlayerWarping(int a0);
+extern "C" void WarpPlayer(int i, int val);
 
-struct Actor;
-extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
-extern u8 IsPlayerWarping(int a0);
-extern int _ZN6Player7CanWarpEv(void* p);
-extern void WarpPlayer(int i, int val);
-extern void _ZN12CylinderClsn5ClearEv(void* p);
-extern void _ZN12CylinderClsn6UpdateEv(void* p);
-
-int func_ov002_020ec410(char* c)
+extern "C" int func_ov002_020ec410(char* c)
 {
-    u32 id;
-    struct Actor* o;
-
-    id = *(u32*)(c + 0xf8);
+    unsigned int id = *(unsigned int*)(c + 0xf8);
     if (id != 0) {
-        do {
-            if (*(s16*)(c + 0x8e) != 0) break;
-            o = _ZN5Actor10FindWithIDEj(id);
-            if (o == 0) break;
-            {
-                int b = (int)(*(u16*)((char*)o + 0xc) == 0xbf);
-                if (b == 0) break;
+        if (*(short*)(c + 0x8e) == 0) {
+            Actor* a = Actor::FindWithID(id);
+            if (a != 0) {
+                int isPlayer = (*(unsigned short*)((char*)a + 0xc) == 0xbf) ? 1 : 0;
+                if (isPlayer != 0) {
+                    if (IsPlayerWarping(*(unsigned char*)((char*)a + 0x6d8)) != 0) {
+                        *(short*)(c + 0x8e) = 1;
+                    } else if (((Player*)a)->CanWarp()) {
+                        unsigned int param = (*(unsigned int*)(c + 8) >> 0xc) + 1;
+                        WarpPlayer(*(unsigned char*)((char*)a + 0x6d8), param & 0xff);
+                    }
+                }
             }
-            if (IsPlayerWarping(*(u8*)((char*)o + 0x6d8))) {
-                *(s16*)(c + 0x8e) = 1;
-                break;
-            }
-            if (_ZN6Player7CanWarpEv(o)) {
-                WarpPlayer(*(u8*)((char*)o + 0x6d8), ((*(u32*)(c + 8) >> 0xc) + 1) & 0xff);
-            }
-        } while (0);
+        }
     } else {
-        *(s16*)(c + 0x8e) = 0;
-        _ZN12CylinderClsn5ClearEv(c + 0xd4);
-        _ZN12CylinderClsn6UpdateEv(c + 0xd4);
+        *(short*)(c + 0x8e) = 0;
     }
+
+    ((CylinderClsn*)(c + 0xd4))->Clear();
+    ((CylinderClsn*)(c + 0xd4))->Update();
     return 1;
 }


### PR DESCRIPTION
Two ov002 functions upgraded from NONMATCHING to byte-exact matches.

- `func_ov002_020ec410` (0x020ec410, 0xb4)
- `__sinit_ov002_02100c50` (0x02100c50, 0xf4)

Both verified locally with `match --strict-relocs` at 1.2/sp2p3 - relocation-aware, so the callee/global links are checked (no WRONG-DEST). src-only.

