### PR TITLE
Match func_ov006_02115a5c byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_02115a5c.c
+++ b/src/func_ov006_02115a5c.c
@@ -1,0 +1,18 @@
+#pragma opt_strength_reduction off
+#pragma opt_common_subs off
+
+extern void func_ov006_02115830(char *p, int i, int j, int a, int b);
+
+void func_ov006_02115a5c(char *p)
+{
+    int n = *(int *)(p + 0x4668);
+    int i, j;
+    for (i = 0; i < n; i++) {
+        for (j = 0; j < n; j++) {
+            int a = (i >= 13) ? 0 : *(int *)(int)(((long long)(int)(p + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+            int b = (j >= 13) ? 0 : *(int *)(p + j * 4 + 0x4688);
+            func_ov006_02115830(p, i, j, a, b);
+            n = *(int *)(p + 0x4668);
+        }
+    }
+}


### PR DESCRIPTION
Matches `func_ov006_02115a5c` (overlay ov006, `0x02115a5c`, size `0xb0`) byte-identical under mwccarm 1.2/sp2p3.

**Verification**
- `match` oracle: `MATCH` at 1.2/sp2p3; `fdiff` 0/44 instructions diverging.
- Relocations checked against `config/arm9/overlays/ov006/relocs.txt` ground truth (a byte-match alone does not prove this — match/fdiff wildcard relocated words, so a call to the wrong symbol with the right shape still matches locally and then fails CI as WRONG-DEST). The function's span contains exactly one reloc, `0x02115adc -> 0x02115830`, which resolves to `func_ov006_02115830` — the single extern the source names. The `0x4688` pool word is a plain constant carrying no reloc in the ROM, consistent with the source. Exact correspondence.

**Notes on the match**
`#pragma opt_strength_reduction off` + `#pragma opt_common_subs off`; an explicit reload of the named count after the call reproduces mwcc's entry-throwaway-base + LICM'd-reload-base split; a u64-mask launder on the i-indexed ternary load produces the pooled-0x4688 `[r7]` form; flipping both ternaries to `(x >= 13) ? 0 : load` fixed the movge/ldrlt emission order.

Contents: `src/` addition only, one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GM8EtS8Vwp3RHs9wfpPbNJ