### PR TITLE
linkcheck: distinguish missing/wrong-length source from NO-REPRO

### DIFF
--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -22,8 +22,10 @@ Verdicts (per function):
   VERIFIED   every reloc resolved and the linked bytes equal the ROM
   WRONG      a resolved reloc links to bytes that differ from the ROM (false match)
   BLIND-n    n reloc slots could not be resolved; everything else verified
-  NO-REPRO   the committed source no longer reproduces the ROM bytes
-  NO-SYM     the function symbol was not found in the object
+  NO-REPRO   the committed source compiles to the right length but the bytes differ
+  NO-SRC     no src/<name>.c|.cpp on disk to try (e.g. wrong branch / not yet landed)
+  NO-BIN     the module binary for this address was not available
+  NO-SYM     the function symbol was not found, or compiled to the wrong length
 
 Usage:
   python tools/linkcheck.py                          # whole corpus
@@ -190,7 +192,11 @@ def linkcheck(name, addr, size, mod, name_index):
     import reverify_corpus as RV
     obj, sym, err = RA.winning_object(name, addr, size, mod)
     if obj is None:
-        return {"name": name, "module": mod, "addr": f"0x{addr:08x}", "verdict": "NO-REPRO",
+        # A missing or wrong-length source is NOT a false match; give it a verdict
+        # distinct from NO-REPRO so it does not read as "the source stopped matching".
+        verdict = {"no-source": "NO-SRC", "no-module-bin": "NO-BIN",
+                   "len-mismatch": "NO-SYM"}.get(err, "NO-REPRO")
+        return {"name": name, "module": mod, "addr": f"0x{addr:08x}", "verdict": verdict,
                 "reason": err, "diffs": [], "blind": 0}
     target = RV.rom_bytes(mod, addr, size)
     code, _ = M.extract_func(obj, sym)
@@ -286,7 +292,7 @@ def main():
         return "BLIND" if v.startswith("BLIND") else v
     cat = Counter(bucket(r["verdict"]) for r in results)
     print("\n=== link-based verification ===")
-    for k in ["VERIFIED", "BENIGN", "BLIND", "WRONG", "NO-REPRO", "NO-SYM"]:
+    for k in ["VERIFIED", "BENIGN", "BLIND", "WRONG", "NO-REPRO", "NO-SRC", "NO-BIN", "NO-SYM"]:
         if cat.get(k):
             print(f"  {k:10} {cat[k]}")
     wrong = [r for r in results if r["verdict"] == "WRONG"]

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -146,7 +146,13 @@ def winning_object(name, addr, size, mod):
     target = RV.rom_bytes(mod, addr, size)
     if target is None:
         return None, None, "no-module-bin"
+    # Distinguish the three ways this can fail so callers do not report a missing
+    # or wrong-length source as "no-repro" (which reads as a false-match red flag).
+    # saw_source: src_texts yielded at least one candidate to try.
+    # saw_len:    a candidate compiled to a function of the expected length.
+    saw_source = saw_len = False
     for src in RV.src_texts(name, addr):
+        saw_source = True
         attempts = ([(S.CPP_FLAGS, ".cpp")] if src.startswith("//cpp")
                     else [(M.DEFAULT_FLAGS, ".c"), (S.CPP_FLAGS, ".cpp")])
         for flags, suf in attempts:
@@ -169,12 +175,17 @@ def winning_object(name, addr, size, mod):
                         code, relocs = M.extract_func(obj, sym)
                         if code is None or len(code) != len(target):
                             continue
+                        saw_len = True
                         ok, _ = M.compare(target, code, relocs, verbose=False)
                         if ok:
                             return obj, sym, None
             finally:
                 pathlib.Path(tmp).unlink(missing_ok=True)
-    return None, None, "no-repro"
+    if not saw_source:
+        return None, None, "no-source"      # no src/<name>.c|.cpp on disk to try
+    if not saw_len:
+        return None, None, "len-mismatch"   # compiled, but never the target's length
+    return None, None, "no-repro"           # right length, but bytes never matched
 
 
 def classify(cand_name, cand_mod, cand_addr, cfg, sym_index):


### PR DESCRIPTION
## Problem

`reloc_audit.winning_object()` returned the single reason `"no-repro"` for three
distinct failures:

1. the committed source compiles to the right length but the bytes don't match (genuine non-reproduction),
2. **no `src/<name>.c|.cpp` exists on disk at all**, and
3. the source compiles but never to the target's length.

Cases 2 and 3 then surfaced through `linkcheck.py` as **`NO-REPRO`**, whose documented
meaning is "the committed source no longer reproduces the ROM bytes" — a false-match red
flag. In practice this fires whenever you link-check a function on a branch where its
source hasn't landed yet (or pass a wrong `--size`): the tool simply had nothing valid to
try, but the verdict reads as "this match broke." That cost real debugging time while the
PR-validation build box was offline and functions were being verified locally off PR
branches.

## Fix

`winning_object` now tracks whether any source was found (`saw_source`) and whether any
candidate reached the target length (`saw_len`), and returns distinct reasons:

| situation | reason | linkcheck verdict |
|---|---|---|
| no `src/<name>` file to try | `no-source` | **NO-SRC** |
| module binary unavailable | `no-module-bin` | **NO-BIN** |
| compiled, never the right length | `len-mismatch` | **NO-SYM** |
| right length, bytes differ | `no-repro` | **NO-REPRO** |

`linkcheck.py` maps the reasons to those verdicts, documents them in the header, and adds
them to the summary counter. **The `VERIFIED` path is unchanged** — this only refines the
`obj is None` failure reporting.

## Test

```
valid function          -> VERIFIED
absent source           -> NO-SRC     (was NO-REPRO)
present src, wrong size  -> NO-SYM     (was NO-REPRO)
```

Built with Claude Code
