### PR TITLE
Skip tracked sources when generating matching worklists

### DIFF
--- a/tools/test_worklist.py
+++ b/tools/test_worklist.py
@@ -1,0 +1,50 @@
+import importlib
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+worklist = importlib.import_module("worklist")
+
+
+class TargetIsDoneTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_src = worklist.REPO_SRC
+        worklist.REPO_SRC = pathlib.Path(self.temp_dir.name)
+
+    def tearDown(self):
+        worklist.REPO_SRC = self.original_src
+        self.temp_dir.cleanup()
+
+    def test_ledger_entry_is_done(self):
+        done = {("arm9", 0x02001234)}
+        self.assertTrue(
+            worklist.target_is_done(done, "arm9", 0x02001234, "func_02001234")
+        )
+
+    def test_c_source_is_done_when_ledger_lags(self):
+        (worklist.REPO_SRC / "func_02001234.c").write_text(
+            "void func_02001234(void) {}\n", encoding="utf-8"
+        )
+        self.assertTrue(
+            worklist.target_is_done(set(), "arm9", 0x02001234, "func_02001234")
+        )
+
+    def test_cpp_source_is_done_when_ledger_lags(self):
+        (worklist.REPO_SRC / "func_02001234.cpp").write_text(
+            "//cpp\nvoid func_02001234() {}\n", encoding="utf-8"
+        )
+        self.assertTrue(
+            worklist.target_is_done(set(), "arm9", 0x02001234, "func_02001234")
+        )
+
+    def test_missing_source_and_ledger_entry_remains_available(self):
+        self.assertFalse(
+            worklist.target_is_done(set(), "arm9", 0x02001234, "func_02001234")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -69,6 +69,12 @@ def read_src_text(name):
     return None
 
 
+def target_is_done(done, label, addr, name):
+    """Treat the source tree as authoritative when the generated ledger lags."""
+    return ((label, addr) in done
+            or any((REPO_SRC / f"{name}.{ext}").exists() for ext in ("c", "cpp")))
+
+
 def callee_set(addr, ins, relocs, syms):
     """Frozenset of resolved bl/blx callee names for a function."""
     out = set()
@@ -204,7 +210,8 @@ def main():
                 continue
             label = "arm9" if mod["name"] == "main" else mod["name"]
             for name, addr, size in sweep.funcs(mod):
-                if (label, addr) in done or not (args.min <= size <= args.max):
+                if (target_is_done(done, label, addr, name)
+                        or not (args.min <= size <= args.max)):
                     continue
                 d = DM.demangle(name)
                 if d and d["class"]:
@@ -290,7 +297,8 @@ def main():
             label = "arm9" if mod["name"] == "main" else mod["name"]
             data = mod["bin"].read_bytes()
             for name, addr, size in sweep.funcs(mod):
-                if (label, addr) in done or not (args.min <= size <= args.max):
+                if (target_is_done(done, label, addr, name)
+                        or not (args.min <= size <= args.max)):
                     continue
                 cands.append((label, name, addr, size, mod, data))
         random.shuffle(cands)
@@ -322,9 +330,10 @@ def main():
             if args.addr is not None and addr != args.addr:
                 continue
             # An exact --addr means the caller wants THAT function - a hand-picked drive target -
-            # even if it's already matched or parked as nonmatching. Only apply the done-set
-            # exclusion in list/scheduling mode (no --addr), so batch generation still skips them.
-            if (args.addr is None and (label, addr) in done) or not (args.min <= size <= args.max):
+            # even if it's already matched or parked as nonmatching. Only apply the completed-
+            # target exclusion in list/scheduling mode, so batch generation still skips them.
+            if ((args.addr is None and target_is_done(done, label, addr, name))
+                    or not (args.min <= size <= args.max)):
                 continue
             tgt = data[addr - mod["base"]:addr - mod["base"] + size]
             rec = build_rec(label, name, addr, size, tgt, relocs)


### PR DESCRIPTION
## Summary

- Treat an existing `src/<symbol>.c` or `.cpp` file as authoritative completed work when generating worklists.
- Apply the guard consistently to class listing, random selection, and normal/spread scheduling.
- Preserve explicit `--addr` inspection for already matched or parked functions.
- Add focused unit coverage for ledger, C source, C++ source, and genuinely missing targets.

## Why

The generated ledger can briefly lag the tracked source tree. In that window, `worklist.py` emitted functions that already had verified source, which led agents to acquire unnecessary Claimsbot locks and independently rediscover existing matches.

## Verification

- `python -m unittest tools/test_worklist.py`: **4 tests passed**
- `python -m py_compile tools/worklist.py tools/test_worklist.py`
- Batch integration: 10 real source-missing targets emitted, zero tracked-source targets
- Explicit `--addr` integration: tracked `func_ov001_020ab3c4` remains inspectable

This PR contains tooling/tests only and is intentionally separate from source-match PR #427.

Model: OpenAI Codex Sol 5.6

Reasoning: high

Harness: Codex Desktop + native subagents
