### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov007_020bffb8.c
+++ b/src/func_ov007_020bffb8.c
@@ -1,0 +1,50 @@
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+
+extern s16 data_02082214[];
+
+void func_ov007_020bffb8(char *c)
+{
+    s32 *out = (s32 *)(((int)c + 8) & 0xFFFFFFFFFFFFFFFF);
+    s32 *base = (s32 *)(((int)c + 0x14) & 0xFFFFFFFFFFFFFFFF);
+    s32 angleA = *(u16 *)(c + 0x30);
+    s32 angleB = *(u16 *)(c + 0x32);
+    s32 indexA;
+    s32 indexB;
+    s32 trigAPlus;
+
+    angleA >>= 4;
+    angleB >>= 4;
+    indexA = angleA << 1;
+    indexB = angleB << 1;
+    trigAPlus = data_02082214[indexA + 1];
+
+    {
+        s32 initialX = (trigAPlus * *(s32 *)(c + 0x2c)) >> 12;
+        s32 trigB = data_02082214[indexB];
+        s32 storedX;
+        s32 product;
+
+        out[0] = initialX;
+        storedX = out[0];
+        product = storedX * trigB;
+        out[0] = base[0] + (product >> 12);
+    }
+    {
+        s32 trigA = data_02082214[indexA];
+        s32 product = trigA * *(s32 *)(c + 0x2c);
+        out[1] = base[1] + (product >> 12);
+    }
+    {
+        s32 initialZ = (trigAPlus * *(s32 *)(c + 0x2c)) >> 12;
+        s32 trigB = data_02082214[indexB + 1];
+        s32 storedZ;
+        s32 product;
+
+        out[2] = initialZ;
+        storedZ = out[2];
+        product = storedZ * trigB;
+        out[2] = base[2] + (product >> 12);
+    }
+}

--- a/src/func_ov063_02118914.c
+++ b/src/func_ov063_02118914.c
@@ -1,0 +1,34 @@
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned short u16;
+typedef int s32;
+typedef unsigned int u32;
+
+void func_ov063_02118914(char *c)
+{
+    int zero = 0;
+    u8 copied;
+    s32 scale;
+
+    *(u8 *)(c + 0x5cc) = 7;
+    *(u8 *)(c + 0x5c8) = zero;
+    copied = *(u8 *)(c + 0x5c8);
+    *(u8 *)(c + 0x5c9) = copied;
+    *(s32 *)(c + 0x584) = 0x1000;
+    *(u8 *)(c + 0x5ca) = 3;
+
+    scale = *(s32 *)(c + 0x584);
+    *(s32 *)(c + 0x80) = scale;
+    *(s32 *)(c + 0x84) = scale;
+    *(s32 *)(c + 0x88) = scale;
+    *(s32 *)(c + 0x188) = *(s32 *)(c + 0x590) * *(s32 *)(c + 0x584);
+    *(s32 *)(c + 0x18c) = *(s32 *)(c + 0x594) * *(s32 *)(c + 0x584);
+    *(u16 *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+    *(u32 *)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    *(u16 *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+    *(s32 *)(c + 0x5c) = -*(s32 *)(c + 0x51c);
+    *(s16 *)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0x8000;
+    *(s16 *)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL) += 0x8000;
+    *(u8 *)(c + 0x5ce) = zero;
+    *(u32 *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+}


### PR DESCRIPTION
## Summary

- `func_ov063_02118914` @ `0x02118914` (ov063, `0xe0` / 224 bytes)
- `func_ov007_020bffb8` @ `0x020bffb8` (ov007, `0xc0` / 192 bytes)
- Total recovered: 416 bytes

Both functions are byte-identical with the retail EU ROM under **mwccarm 1.2/sp2p3**.

## Local verification

- `tools/match.py --strict-relocs`: **MATCH** for both functions
- `tools/linkcheck.py`: **VERIFIED**, `diffs=[]`, `blind=0` for both functions
- Source SHA-256:
  - `func_ov063_02118914.c`: `77c76df8af0ce76f9b33592908c04c42b9ae355e94d034304c0d5d2decd03e71`
  - `func_ov007_020bffb8.c`: `71311de43dd798c96224aabb03bb489ad7df1f7a47548f8e89777b5129c3e27d`

`func_ov063_02118914` initializes actor state, scale, flags and orientation fields. `func_ov007_020bffb8` computes fixed-point trigonometric position outputs.

Claims remain active until merge and upstream source verification.

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents