### PR TITLE
Contributor color: tangosdev

### DIFF
--- a/contributor-colors.json
+++ b/contributor-colors.json
@@ -1,3 +1,4 @@
 {
-  "tangosdev": "#ff8a8a"
+  "tangosdev": "#ff8a8a",
+  "ruspecial": "#000000"
 }

--- a/contributor-colors.json
+++ b/contributor-colors.json
@@ -1,3 +1,3 @@
 {
-  "tangosdev": "#f787d9"
+  "tangosdev": "#ff8a8a"
 }


### PR DESCRIPTION
Sets tangosdev's contributor color to `#ff8a8a` in `contributor-colors.json`. One key only; opened from tangOS Console.