### PR TITLE
Contributor color: ruspecial

### DIFF
--- a/contributor-colors.json
+++ b/contributor-colors.json
@@ -1,3 +1,4 @@
 {
-  "tangosdev": "#f787d9"
+  "tangosdev": "#f787d9",
+  "ruspecial": "#000000"
 }


### PR DESCRIPTION
Sets ruspecial's contributor color to `#000000` in `contributor-colors.json`. One key only; opened from tangOS Console.