### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_0211bf44.c
+++ b/src/func_ov006_0211bf44.c
@@ -1,0 +1,66 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern u8 data_020a0e40[];
+extern u8 data_020a0de8[];
+extern u8 data_020a0de9[];
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+
+extern void _ZN5Sound12PlayBank2_2DEj(unsigned int soundId);
+
+void func_ov006_0211bf44(char* base, int slot)
+{
+    u8 player;
+    int offset;
+    int active;
+    char* entry;
+    int dx;
+    int dy;
+
+    if (*(int*)(base + 0x5608) != 1) {
+        return;
+    }
+    if (*(u8*)(base + 0x5624) >= 2) {
+        return;
+    }
+
+    player = data_020a0e40[0];
+    offset = player * 4;
+    active = 0;
+    if (data_020a0de8[offset] != 0) {
+        if (data_020a0de9[offset] != 0) {
+            active = 1;
+        }
+    }
+    if (active == 0) {
+        return;
+    }
+
+    entry = base + slot * 0x14;
+    entry += 0x5000;
+    dx = data_020a0dea[player * 4] - (*(int*)(entry + 0xe8) >> 12);
+    dy = data_020a0deb[player * 4] - (*(int*)(entry + 0xec) >> 12);
+
+    if (dx > 0x18) {
+        return;
+    }
+    if (dx < -0x18) {
+        return;
+    }
+    if (dy > 0x18) {
+        return;
+    }
+    if (dy < -0x18) {
+        return;
+    }
+
+    *(u8*)(entry + 0xf4) = 1;
+    *(u16*)(entry + 0xf0) = 0;
+    *(u8*)(entry + 0xf7) = 0;
+    {
+        u8* counter = (u8*)(int)(((long long)(int)(base + 0x5624)) & 0xFFFFFFFFFFFFFFFFLL);
+        *counter = *counter + 1;
+    }
+    _ZN5Sound12PlayBank2_2DEj(0x201);
+}

--- a/src/func_ov102_0214baa0.c
+++ b/src/func_ov102_0214baa0.c
@@ -1,0 +1,62 @@
+typedef unsigned char u8;
+typedef short s16;
+
+extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
+extern void _ZN12CylinderClsn5ClearEv(void *self);
+extern void func_0203568c(int *value, int target);
+extern void func_02035684(int *value, int target);
+
+#define LAUNDER_PTR(ptr) \
+    ((int *)(int)(((long long)(int)(ptr)) & 0xffffffffffffffffLL))
+#define LAUNDER_32(base, offset) \
+    ((int *)(int)(((long long)((int)(base) + (offset))) & 0xffffffffffffffffLL))
+
+void func_ov102_0214baa0(char *self)
+{
+    u8 variant;
+
+    *LAUNDER_32(self, 0xb0) &= ~0x10000000;
+    variant = *(u8 *)(self + 0x3f5);
+    if (!(variant < 2 || variant == 5)) {
+        _ZN5Actor24KillAndTrackInDeathTableEv(self);
+        return;
+    }
+
+    *(int *)(self + 0x3dc) = 5;
+    *(int *)(self + 0x98) = 0;
+    _ZN12CylinderClsn5ClearEv(self + 0x110);
+
+    *LAUNDER_PTR(self + 0xb0) &= 0xfff1fffe;
+    *(int *)(self + 0x5c) = *(int *)(self + 0x3c4);
+    *(int *)(self + 0x60) = *(int *)(self + 0x3c8);
+    *(int *)(self + 0x64) = *(int *)(self + 0x3cc);
+    *(u8 *)(self + 0x3f3) = 0;
+    *(int *)(self + 0x38c) = 0;
+    *(int *)(self + 0x390) = 0;
+    *(s16 *)(self + 0x3ea) = 0;
+    *(int *)(self + 0x80) = 0x1000;
+    *(int *)(self + 0x84) = 0x1000;
+    *(int *)(self + 0x88) = 0x1000;
+    *(s16 *)(self + 0x8c) = 0;
+    *(s16 *)(self + 0x8e) = 0;
+    *(s16 *)(self + 0x90) = 0;
+    *(s16 *)(self + 0x92) = 0;
+    *(s16 *)(self + 0x94) = 0;
+    *(s16 *)(self + 0x96) = 0;
+
+    {
+        s16 angle = *(s16 *)(self + 0x3f0);
+        *(s16 *)(self + 0x8e) = angle;
+        s16 copy = *(s16 *)(self + 0x8e);
+        *(s16 *)(self + 0x94) = copy;
+    }
+
+    *LAUNDER_PTR(self + 0x128) &= ~0x4002;
+    *LAUNDER_PTR(self + 0x128) |= 4;
+    *(int *)(self + 0x114) = 0x3c000;
+    *(int *)(self + 0x118) = 0x50000;
+
+    func_0203568c((int *)(self + 0x144), 0x32000);
+    func_02035684((int *)(self + 0x144), 0x32000);
+    *(int *)(self + 8) = 0;
+}


### PR DESCRIPTION
## Summary

- `func_ov006_0211bf44` @ `0x0211bf44` (`ov006`, size `0x13c` / 316 bytes)
  - Handles a slot-machine minigame slot entering the active hit area, resets its slot state, increments the active counter, and plays sound `0x201`.
- `func_ov102_0214baa0` @ `0x0214baa0` (`ov102`, size `0x138` / 312 bytes)
  - Resets an actor into state 5, clears collision and movement state, restores its saved position and orientation, and removes unsupported variants.
- Both are byte-identical with the retail EU ROM under **mwccarm 1.2/sp2p3**.
- Source-only batch; no tooling or notes changes.

Claims: `clm_0e949c10cda8`, `clm_c9d08ea6be93` (kept active until the merged sources are verified on `origin/main`).

## Test plan

- `tools/match.py --strict-relocs` reports `MATCH` for both functions.
- `tools/linkcheck.py` reports `VERIFIED`, `diffs=[]`, `blind=0` for both functions.
- `git diff --check` is clean.

Model: OpenAI Codex Sol 5.6  
Reasoning: high  
Harness: Codex Desktop + native subagents
