### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp
+++ b/src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp
@@ -1,0 +1,64 @@
+//cpp
+struct Vector3 { int x, y, z; };
+extern "C" {
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
+extern void _ZN4BgCh19StartDetectingWaterEv(void* self);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern void _ZN10ClsnResultC1Ev(void* self);
+extern void _ZNK10ClsnResult6CopyToERS_(void* self, void* other);
+extern int _ZNK10ClsnResult9GetClsnIDEv(void* self);
+extern void _ZN10ClsnResultD1Ev(void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, void* v);
+extern short data_02082214[];
+}
+
+extern "C" int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(
+    char* thiz, void* clsn, int fix2, short a3, unsigned char a4, unsigned char a5, int fix6) {
+  Vector3 v1;
+  Vector3 v2;
+  char cr[0x28];
+  Vector3 normal;
+  char rl[0x7c];
+  thiz[0x106] = 0;
+  if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn) != 0) {
+    _ZN11RaycastLineC1Ev(rl);
+    v1.x = *(int*)(thiz + 0x5c);
+    v1.y = *(int*)(thiz + 0x60);
+    v1.z = *(int*)(thiz + 0x64);
+    v1.y += fix6;
+    v2.x = *(int*)(thiz + 0x5c);
+    v2.y = *(int*)(thiz + 0x60);
+    v2.z = *(int*)(thiz + 0x64);
+    v2.y -= fix2;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, thiz);
+    if (a4 != 0)
+      _ZN4BgCh19StartDetectingWaterEv(rl);
+    if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
+      if (*(int*)(rl + 0x60) - fix6 >= fix2)
+        thiz[0x106] = 1;
+      if (a5 == 0) {
+        _ZN10ClsnResultC1Ev(cr);
+        _ZNK10ClsnResult6CopyToERS_(rl + 0x10, cr);
+        if (_ZNK10ClsnResult9GetClsnIDEv(cr) != -1) {
+          thiz[0x106] = 1;
+          _ZN10ClsnResultD1Ev(cr);
+          _ZN11RaycastLineD1Ev(rl);
+          return 1;
+        }
+        _ZN10ClsnResultD1Ev(cr);
+      }
+      _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rl + 0x14, &normal);
+      int idx = ((unsigned short)a3 >> 4) * 2;
+      short s = data_02082214[idx + 1];
+      if (normal.y < s)
+        thiz[0x106] = 2;
+    } else {
+      thiz[0x106] = 1;
+    }
+    _ZN11RaycastLineD1Ev(rl);
+  }
+  return *(unsigned char*)(thiz + 0x106) != 0;
+}

--- a/src/func_ov070_0211fd98.c
+++ b/src/func_ov070_0211fd98.c
@@ -1,0 +1,73 @@
+typedef int Fix12;
+typedef short s16;
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+extern int Vec3_Dist(void *a, void *b);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void *p);
+extern short Vec3_HorzAngle(void *a, void *b);
+extern void ApproachAngle(s16 *dst, s16 target, int a, int b, int c);
+extern short Vec3_VertAngle(void *a, void *b);
+extern void _Z14ApproachLinearRsss(void *dst, short a, short b);
+extern void Matrix4x3_FromRotationY(void *m, int angle);
+extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
+extern void MulVec3Mat4x3(void *in, void *m, void *out);
+extern void _Z14ApproachLinearRiii(void *dst, int a, int b);
+extern int func_ov070_02120020(void *c, void *p);
+extern void *_ZN5Actor22ClosestNonVanishPlayerEv(void *c);
+
+extern char data_020a0e68[];
+extern char data_ov070_0212359c[];
+extern char data_ov070_021235ac[];
+
+int func_ov070_0211fd98(char *c)
+{
+    int in[3];
+    int out[3];
+    Vector3 t;
+    void *p;
+
+    in[0] = 0; in[1] = 0; in[2] = 0;
+    out[0] = 0; out[1] = 0; out[2] = 0;
+
+    if (Vec3_Dist(c + 0x5c, c + 0x3c0) > 0x1f4000 ||
+        _ZNK12WithMeshClsn8IsOnWallEv(c + 0x144)) {
+        *(s16 *)(c + 0x300 + 0xe6) = Vec3_HorzAngle(c + 0x5c, c + 0x3c0);
+        if (*(unsigned short *)(c + 0x100) < 0x14)
+            *(unsigned short *)(c + 0x100) = 0x14;
+    }
+    ApproachAngle((s16 *)(c + 0x94), *(s16 *)(c + 0x300 + 0xe6), 0xa, 0x200, 0x100);
+
+    _Z14ApproachLinearRsss(c + 0x92, Vec3_VertAngle(c + 0x5c, c + 0x3c0), 0x100);
+
+    ApproachAngle((s16 *)(c + 0x96),
+                  (*(s16 *)(c + 0x94) - *(s16 *)(c + 0x300 + 0xe6)) / 2,
+                  0xa, 0x100, 0x50);
+
+    in[2] = 0xa000;
+    Matrix4x3_FromRotationY(data_020a0e68, *(s16 *)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(s16 *)(c + 0x92));
+    MulVec3Mat4x3(in, data_020a0e68, out);
+
+    _Z14ApproachLinearRiii(c + 0xa4, out[0], 0x1000);
+    _Z14ApproachLinearRiii(c + 0xa8, out[1], 0x800);
+    _Z14ApproachLinearRiii(c + 0xac, out[2], 0x1000);
+
+    if (*(unsigned short *)(c + 0x100) == 0) {
+        func_ov070_02120020(c, data_ov070_0212359c);
+        return 1;
+    }
+    if (*(unsigned short *)(c + 0x300 + 0xcc) != 0)
+        return 1;
+    if (Vec3_Dist(c + 0x5c, c + 0x3c0) < 0x5dc000) {
+        p = _ZN5Actor22ClosestNonVanishPlayerEv(c);
+        if (p) {
+            int *pos = (int *)(((int)p + 0x5c) & 0xffffffffffffffffLL);
+            t.x = pos[0];
+            t.y = pos[1];
+            t.z = pos[2];
+            if (Vec3_Dist(c + 0x5c, &t) < 0x3e8000)
+                func_ov070_02120020(c, data_ov070_021235ac);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
## Summary

- `_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_` @ `0x020ae2b8` (ov002, `0x19c` / 412 bytes)
  - Reconstructs grounded enemy cliff detection, raycast handling, surface-normal checks, and the collision-result early return.
- `func_ov070_0211fd98` @ `0x0211fd98` (ov070, `0x210` / 528 bytes)
  - Reconstructs target-facing angle updates, movement-vector rotation, approach speeds, and close-player behavior selection.

Both sources are byte-identical with the retail EU code under **mwccarm 1.2/sp2p3**.

## Verification

- `tools/match.py --strict-relocs`: **MATCH** for both functions
- `tools/linkcheck.py`: **VERIFIED**, `diffs=[]`, `blind=0` for both functions
- Clean source-only branch based on `origin/main` `ec5566d8`

Claims retained until merge verification: `clm_ee31be647544`, `clm_c39192c96fc0`.

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents