### PR TITLE
Match 4 ov002 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020af4ec.cpp
+++ b/src/func_ov002_020af4ec.cpp
@@ -1,0 +1,68 @@
+//cpp
+struct Vec3 { int x, y, z; };
+struct RaycastGround { char buf[0x50]; };
+extern "C" {
+extern void Matrix4x3_FromRotationY(void* m, int angle);
+extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
+extern void _ZN13RaycastGroundC1Ev(struct RaycastGround* self);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround* self, const struct Vec3* v, void* actor);
+extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround* self);
+extern void _ZN13RaycastGroundD1Ev(struct RaycastGround* self);
+extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* shadow, void* mtx, int height, int rad, unsigned int x);
+void func_ov002_020af4ec(void* self);
+}
+
+void func_ov002_020af4ec(void* self)
+{
+    int rad;
+    char* c = (char*)self;
+    int height;
+    struct RaycastGround rg;
+    struct Vec3 v2;
+    struct Vec3 v1;
+
+    if ((unsigned)(*(int*)(c + 0x384) - 0xb) <= 1) {
+        Matrix4x3_FromRotationY(c + 0x31c, *(short*)(c + 0x8e));
+        *(int*)(c + 0x340) = *(int*)(c + 0x5c) >> 3;
+        *(int*)(c + 0x344) = *(int*)(c + 0x60) >> 3;
+        *(int*)(c + 0x348) = *(int*)(c + 0x64) >> 3;
+    } else {
+        Vec3_Asr(&v1, (struct Vec3*)(c + 0x5c), 3);
+        Matrix4x3_FromTranslation(c + 0x31c, v1.x, v1.y, v1.z);
+    }
+
+    if (*(unsigned char*)(c + 0x38e) == 0) return;
+
+    if ((unsigned)(*(int*)(c + 0x384) - 0xb) <= 1) {
+        height = 0x50000;
+        rad = 0x50000;
+    } else if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144)) {
+        int y = *(int*)(c + 0x60);
+        int z = *(int*)(c + 0x64);
+        int adjustedY;
+        int x = *(int*)(c + 0x5c);
+        adjustedY = y + 0x28000;
+        v2.x = x;
+        v2.y = adjustedY;
+        v2.z = z;
+        _ZN13RaycastGroundC1Ev(&rg);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &v2, 0);
+        rad = v2.y;
+        if (_ZN13RaycastGround10DetectClsnEv(&rg)) {
+            rad = *(int*)((char*)&rg + 0x44);
+        }
+        rad = *(int*)(c + 0x60) - rad;
+        if (rad <= 0x1000) rad = 0x1000;
+        height = (*(int*)(c + 0x114) - 0xa000) * 2 - (int)(((long long)rad * 0x180 + 0x800) >> 12);
+        if (height < 0xa000) height = 0xa000;
+        rad += 0x3c000;
+        _ZN13RaycastGroundD1Ev(&rg);
+    } else {
+        rad = 0x3c000;
+        height = (*(int*)(c + 0x114) - 0xa000) * 2;
+    }
+
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0x350, c + 0x31c, height, rad, 0xf);
+}

--- a/src/func_ov002_020c0fb4.c
+++ b/src/func_ov002_020c0fb4.c
@@ -1,0 +1,88 @@
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+extern int func_ov002_020c5d0c(char *c);
+extern int func_ov002_020dec70(char *c);
+extern int func_ov002_020bf40c(char *c);
+extern void _ZN5Timer10ResetTimerEv(unsigned char *self);
+extern void _ZN5Timer10StartTimerEv(unsigned char *self);
+extern void _ZN5Timer9StopTimerEv(unsigned char *self);
+extern unsigned long long _ZN5Timer7GetTimeEv(unsigned char *self);
+extern unsigned long long __aeabi_uldiv(unsigned long long a, unsigned long long b);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, const Vector3 *, const void *, int, int);
+extern int func_ov002_020d5338(char *c);
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(char *self);
+extern int func_ov002_020bfec0(char *self);
+extern int func_ov002_020c0d90(char *c, int y);
+extern int func_ov002_020d06c0(char *p);
+extern int func_ov002_020c0cbc(char *c);
+
+extern unsigned char data_ov002_02111184[];
+extern unsigned char data_0209d4c8[];
+extern signed char data_0209f2f8;
+
+int func_ov002_020c0fb4(char *c)
+{
+    int r;
+
+    switch (*(int *)(c + 0x664)) {
+    case 4:
+    case 5:
+        if ((r = func_ov002_020c5d0c(c)) != 0) return r;
+        break;
+    case 19:
+        if ((r = func_ov002_020dec70(c)) != 0) return r;
+        if ((r = func_ov002_020c5d0c(c)) != 0) return r;
+        break;
+    case 18:
+        if ((r = func_ov002_020bf40c(c)) != 0) return r;
+        break;
+    case 15:
+        if (data_ov002_02111184[0] != 0) break;
+        _ZN5Timer10ResetTimerEv(data_0209d4c8);
+        data_ov002_02111184[0] = 1;
+        _ZN5Timer10StartTimerEv(data_0209d4c8);
+        break;
+    case 16:
+        if (data_0209d4c8[8] == 0) break;
+        _ZN5Timer9StopTimerEv(data_0209d4c8);
+        {
+            unsigned long long t = _ZN5Timer7GetTimeEv(data_0209d4c8);
+            if (__aeabi_uldiv(t << 6, 0x1ff6210) > 0x14) break;
+        }
+        {
+            Vector3 pos;
+            int px, py, pz, sum;
+            py = *(int *)(c + 0x60);
+            pz = *(int *)(c + 0x64);
+            px = *(int *)(c + 0x5c);
+            sum = py + 0x82000;
+            pos.x = px;
+            pos.y = sum;
+            pos.z = pz;
+            _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, 0x42, &pos, 0, *(signed char *)(c + 0xcc), -1);
+        }
+        break;
+    }
+
+    if (data_0209f2f8 == 0x26) {
+        if (*(int *)(c + 0x60) < -0x3e8000) {
+            *(int *)(c + 0x60) = -0x3e8000;
+            if ((r = func_ov002_020d5338(c)) != 0) return r;
+        }
+    }
+
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380)) {
+        if (*(int *)(c + 0x668) == 1) {
+            int d = *(int *)(c + 0x60) - *(int *)(c + 0x648);
+            if (d < 0) d = -d;
+            if (d < 0x2000) {
+                if ((r = func_ov002_020d5338(c)) != 0) return r;
+            }
+        }
+        if ((r = func_ov002_020bfec0(c)) != 0) return r;
+    }
+
+    if ((r = func_ov002_020c0d90(c, *(int *)(c + 0x64c))) != 0) return r;
+    if ((r = func_ov002_020d06c0(c)) != 0) return r;
+    return func_ov002_020c0cbc(c);
+}

--- a/src/func_ov002_020c7350.cpp
+++ b/src/func_ov002_020c7350.cpp
@@ -1,0 +1,107 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef signed char s8;
+
+typedef struct { int x, y, z; } Vector3;
+typedef struct { short x, y, z; } Vector3_16;
+
+extern "C" {
+extern int _ZN6Player6IsAnimEj(void *self, unsigned int id);
+extern int _ZNK6Player14GetBodyModelIDEjb(void *self, unsigned int a, int b);
+extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);
+extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, Vector3 *v);
+extern int _ZN6Player12FinishedAnimEv(void *self);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int anim, int a, int b, unsigned int d);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, Vector3 *v, Vector3_16 *v2, int e, int f);
+extern void func_ov089_0213115c(void *actor, int i);
+
+extern u8 data_0209f20c;
+extern u8 data_0209f2d8;
+extern char data_0209caa0[];
+
+void func_ov002_020c7350(char *c)
+{
+    int id;
+    char *anim;
+
+    if (*(u8 *)(c + 0x6de) != 0)
+        return;
+
+    if (_ZN6Player6IsAnimEj(c, 0x10)) {
+        id = _ZNK6Player14GetBodyModelIDEjb(c, *(int *)(c + 8) & 0xff, 0);
+        anim = (char *)((int *)(c + 0xdc))[id] + 0x50;
+        if (_ZNK9Animation12WillHitFrameEi(anim, 0x52)) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x27, (Vector3 *)(c + 0x74));
+        }
+    }
+
+    if (_ZN6Player6IsAnimEj(c, 0x85)) {
+        id = _ZNK6Player14GetBodyModelIDEjb(c, *(int *)(c + 8) & 0xff, 0);
+        anim = (char *)((int *)(c + 0xdc))[id] + 0x50;
+        if (_ZNK9Animation12WillHitFrameEi(anim, 0x20)) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x35, (Vector3 *)(c + 0x74));
+        }
+    }
+
+    if (_ZN6Player6IsAnimEj(c, 0xa5)) {
+        id = _ZNK6Player14GetBodyModelIDEjb(c, *(int *)(c + 8) & 0xff, 0);
+        anim = (char *)((int *)(c + 0xdc))[id] + 0x50;
+        if (_ZNK9Animation12WillHitFrameEi(anim, 0x23)) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x37, (Vector3 *)(c + 0x74));
+        }
+    }
+
+    id = _ZNK6Player14GetBodyModelIDEjb(c, *(int *)(c + 8) & 0xff, 0);
+    anim = (char *)((int *)(c + 0xdc))[id] + 0x50;
+    if (_ZNK9Animation12WillHitFrameEi(anim, 0x8e)) {
+        if (_ZN6Player6IsAnimEj(c, 0xa5)) {
+            data_0209f20c = 1;
+        }
+    }
+
+    if (!_ZN6Player12FinishedAnimEv(c))
+        return;
+
+    {
+        u8 st = *(u8 *)(c + 0x6e3);
+        if (st == 0x10 || st == 0x12) {
+            void *actor;
+            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x94, 0x40000000, 0x1000, 0);
+            actor = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x11a, *(s8 *)(c + 0x719), (Vector3 *)(c + 0x5c), (Vector3_16 *)(c + 0x8c), *(s8 *)(c + 0xcc), -1);
+            if (*(int *)(c + 8) == 2) {
+                func_ov089_0213115c(actor, 4);
+            } else {
+                func_ov089_0213115c(actor, 1);
+            }
+            *(u8 *)(c + 0x6e5) = 6;
+            return;
+        }
+    }
+
+    if (_ZN6Player6IsAnimEj(c, 0x85)) {
+        data_0209f20c = 1;
+    }
+
+    {
+        u8 v = data_0209f2d8;
+        int isOne = (v == 1);
+        if (isOne != false)
+            goto setanim2;
+        if (!(*(int *)(data_0209caa0 + 8) & 0x80))
+            goto skip_setanim2;
+        {
+            int isTwo = (v == 2);
+            if (isTwo != false)
+                goto skip_setanim2;
+        }
+    setanim2:
+        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, 0, 0x1000, 0);
+    skip_setanim2:
+        ;
+    }
+
+    *(u8 *)(c + 0x6e5) = 2;
+}
+}

--- a/src/func_ov002_020d6368.c
+++ b/src/func_ov002_020d6368.c
@@ -1,0 +1,40 @@
+typedef long long s64;
+typedef struct { int x, y, z; } Vec3;
+struct Vector3_16 { short x, y, z; };
+
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, Vec3 *pos, void *rot, int e, int f);
+extern int func_ov002_020d6334(void *self, int val);
+extern short data_02082214[];
+
+#pragma opt_strength_reduction off
+void func_ov002_020d6368(char *self)
+{
+    volatile struct Vector3_16 rot;
+    Vec3 pos;
+    void *spawned;
+    int a;
+    int zero = 0;
+    short rotY;
+
+    pos.x = *(int *)(self + 0x5c);
+    pos.y = *(int *)(self + 0x60);
+    pos.z = *(int *)(self + 0x64);
+
+    a = *(volatile unsigned short *)(self + 0x8e) >> 4;
+    pos.x = pos.x - (int)(((s64)data_02082214[a * 2] * 0x14000 + 0x800) >> 12);
+
+    a = *(volatile unsigned short *)(self + 0x8e) >> 4;
+    *(volatile int *)&pos.y = pos.y - (int)(((s64)data_02082214[a * 2 + 1] * 0x14000 + 0x800) >> 12);
+
+    rotY = *(short *)(self + 0x8e);
+    rot.x = zero;
+    rot.z = zero;
+    rot.y = rotY;
+
+    spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+        9, *(unsigned char *)(self + 0x704) << 4,
+        &pos, (void *)&rot, *(signed char *)(self + 0xcc), -1);
+    *(char **)((char *)spawned + 0x38c) = self;
+    func_ov002_020d6334(self, (int)spawned);
+    *(unsigned char *)(self + 0x704) = zero;
+}


### PR DESCRIPTION
## Summary

- `func_ov002_020af4ec` @ `0x020af4ec` (`0x198` / 408 bytes): model/shadow placement with ground raycasting.
- `func_ov002_020c0fb4` @ `0x020c0fb4` (`0x280` / 640 bytes): state-driven behavior dispatch, timer handling, spawning, and collision transitions.
- `func_ov002_020c7350` @ `0x020c7350` (`0x2a0` / 672 bytes): player animation-frame voices, transition spawning, and next-animation control.
- `func_ov002_020d6368` @ `0x020d6368` (`0x10c` / 268 bytes): directional spawn positioning and rotation setup.

All four sources are byte-identical with the retail EU code under **mwccarm 1.2/sp2p3** (1,988 bytes total).

## Verification

- `tools/match.py --strict-relocs`: **MATCH** for all four functions
- `tools/linkcheck.py`: **VERIFIED**, `diffs=[]`, `blind=0` for all four functions
- Clean source-only branch based on `origin/main` `ec5566d8`
- `func_ov002_020c0fb4` explicitly uses configured `__aeabi_uldiv`; the otherwise byte-identical `_ll_udiv` spelling was rejected because linkcheck reported `blind=1`

Claims retained until merge verification: `clm_cb8b15e1587a`, `clm_af147b560624`, `clm_cedfe750e2b1`, `clm_fb85fcf4417c`.

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents