### PR TITLE
Match 4 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_0211134c.c
+++ b/src/func_ov006_0211134c.c
@@ -1,0 +1,107 @@
+#pragma opt_propagation off
+typedef unsigned char u8;
+
+typedef struct Obj {
+    char _0[4];
+    char *p;
+    int f8;
+    int fc;
+    int f10;
+    int f14;
+    char _18[8];
+    int f20;
+    int f24;
+    char _28[9];
+    u8  f31;
+    char _32[2];
+    int f34;
+    int f38;
+    int f3c;
+    int f40;
+    int f44;
+} Obj;
+
+extern u8 data_020a0e40;
+extern u8 data_020a0de8[];
+extern u8 data_020a0de9[];
+extern u8 data_020a0dea[];
+extern u8 data_020a0deb[];
+
+extern int func_020124c4(int, int, int, int);
+
+void func_ov006_0211134c(Obj *c)
+{
+    u8 lvl;
+    int de8v;
+    int flag;
+    int d;
+
+    c->f10 = c->f8;
+    c->f14 = c->fc;
+    if (*(u8 *)(c->p + 0x595d) != 0)
+        return;
+
+    de8v = data_020a0de8[data_020a0e40 * 4];
+    lvl = data_020a0e40;
+    flag = 0;
+    if (de8v != 0)
+        flag = data_020a0de9[lvl * 4] != 0;
+
+    if (flag != 0) {
+        c->f31 = 1;
+        c->f20 = 0;
+        c->f24 = 0;
+        c->f3c = data_020a0dea[data_020a0e40 * 4] << 12;
+        c->f34 = c->f3c;
+        c->f40 = data_020a0deb[data_020a0e40 * 4] << 12;
+        c->f38 = c->f40;
+        if (c->fc <= 0xa0000)
+            return;
+        {
+            int *pf38 = (int *)(((int)c + 0x38) & 0xFFFFFFFFFFFFFFFFLL);
+            *pf38 = *pf38 - (c->fc - 0xa0000);
+        }
+        return;
+    }
+
+    if (c->f31 == 1 && de8v != 0) {
+        c->f40 = data_020a0deb[lvl * 4] << 12;
+        d = c->f40 - c->f38;
+        if (d >= 0x38000)
+            c->f40 = c->f38 + 0x38000;
+        else if (c->f40 < c->f38)
+            c->f40 = c->f38;
+        c->fc = c->f40 - c->f38 + 0xa0000;
+        if (c->f14 == c->fc)
+            return;
+        c->f44 = func_020124c4(c->f44, 2, 0x16c, 0);
+        return;
+    }
+
+    {
+        int m;
+        if (de8v == 0 && data_020a0de9[lvl * 4] != 0)
+            m = 1;
+        else
+            m = 0;
+        if (m != 0) {
+            c->f31 = 0;
+            c->f20 = 0;
+            c->f24 = 0;
+            return;
+        }
+    }
+
+    {
+        int *pf24 = (int *)(((int)c + 0x24) & 0xFFFFFFFFFFFFFFFFLL);
+        *pf24 = *pf24 - (c->fc - 0xa0000) / 16;
+    }
+    {
+        int *pfc = (int *)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFFLL);
+        *pfc = *pfc + c->f24;
+    }
+    if (c->fc < 0xa0000) {
+        c->fc = 0xa0000;
+        c->f24 = 0;
+    }
+}

--- a/src/func_ov006_021231ac.c
+++ b/src/func_ov006_021231ac.c
@@ -1,0 +1,68 @@
+typedef unsigned short u16;
+
+extern void func_0203cd80(int* m, short angle);
+extern void func_ov006_02120c08(void);
+extern void func_ov006_020eef58(void);
+extern int GetOwnerLanguage(void);
+extern int func_ov004_020ad674(void);
+extern void func_ov004_020afcf8(void* a0, void* a1, int a2, void* a3);
+extern void func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
+extern void func_ov004_020b1a5c(int a0, int a1);
+extern void func_ov006_020caadc(void);
+extern void func_ov006_020d09e0(void);
+extern void func_ov006_020ced84(void);
+extern void func_ov006_02122a4c(void);
+
+extern int data_ov006_0213b0f0;
+extern int data_ov006_02134ecc;
+extern int* data_ov006_0213fc48[];
+extern int data_ov006_02140830;
+
+int func_ov006_021231ac(char* self)
+{
+    int m[3];
+    int count;
+    int a1v;
+    int i;
+
+    m[0] = 0;
+    m[1] = 0;
+    m[2] = 0xfffff008;
+    func_0203cd80(m, -0x4000);
+
+    *(volatile int*)0x40004c8 =
+        (((short)m[0] >> 3) & 0x3ff) |
+        ((((short)m[1] >> 3) & 0x3ff) << 10) |
+        ((((short)m[2] >> 3) & 0x3ff) << 20);
+    *(volatile int*)0x40004cc = 0x7fff;
+    *(volatile int*)0x40004cc = 0x40007fff;
+
+    func_ov006_02120c08();
+    func_ov006_020eef58();
+
+    if (*(u16*)(self + 0x4664) == 1) {
+        count = data_ov006_0213b0f0;
+        a1v = 0x6e;
+        if (GetOwnerLanguage() == 5 || GetOwnerLanguage() == 4)
+            a1v -= 4;
+        for (i = 0; i < 3; i++) {
+            if (i >= count) {
+                int idx = func_ov004_020ad674();
+                func_ov004_020afcf8((void*)data_ov006_0213fc48[idx][1], (void*)a1v, 0xc, (void*)0);
+            } else {
+                func_ov004_020afa20(data_ov006_02134ecc, a1v, 0xc, -1, -1);
+            }
+            a1v += 0x12;
+        }
+    }
+
+    func_ov004_020b1a5c(data_ov006_02140830, 6);
+
+    if (*(short*)(self + 0x7ba8) == 0) {
+        func_ov006_020caadc();
+        func_ov006_020d09e0();
+        func_ov006_020ced84();
+    }
+    func_ov006_02122a4c();
+    return 1;
+}

--- a/src/func_ov007_020c8498.c
+++ b/src/func_ov007_020c8498.c
@@ -1,0 +1,92 @@
+typedef unsigned int u32;
+
+extern void func_ov007_020c86c4(void* p);
+extern void func_ov007_020c897c(void* p);
+extern void func_ov007_020c8970(void* p);
+extern void func_ov007_020c8688(void* p, int a);
+extern void func_ov007_020c86a8(void* p, int a);
+extern void func_ov007_020c8c88(void* p, int a);
+extern void func_ov007_020c8bc8(void* p, int a);
+extern void func_ov007_020c8b34(void* p, int a);
+
+typedef void (*VFN)(void);
+
+void func_ov007_020c8498(char* r5)
+{
+    int r4 = 0;
+    VFN r6;
+
+    if(*(int*)(r5 + 0x20) == 1){
+        func_ov007_020c86c4(r5);
+    }else if(*(int*)(r5 + 0x20) == 2){
+        func_ov007_020c897c(r5);
+    }
+
+    if(*(int*)(r5 + 8) == 0) return;
+
+    if(*(int*)(r5 + 8) == 1){
+        int* v14 = (int*)((((long long)(int)(r5 + 0x14)) & 0xFFFFFFFFFFFFFFFFLL));
+        *v14 += *(int*)(r5 + 0x18);
+        if(*(int*)(r5 + 0x14) > 0x1000){
+            *(int*)(r5 + 0x14) = 0x1000;
+            switch(*(int*)(r5 + 0xc)){
+            case 0:
+                func_ov007_020c8970(r5);
+                break;
+            case 1:
+                *(int*)(r5 + 8) = 3;
+                break;
+            case 2:
+                if(*(int*)(r5 + 0x1c) == 1) func_ov007_020c8688(r5, *(int*)(r5 + 4));
+                else func_ov007_020c86a8(r5, *(int*)(r5 + 4));
+                break;
+            case 3:
+                if(*(int*)(r5 + 0x1c) == 1) func_ov007_020c86a8(r5, *(int*)(r5 + 4));
+                else func_ov007_020c8688(r5, *(int*)(r5 + 4));
+                break;
+            }
+
+            r6 = *(VFN*)(r5 + 0x24);
+            if(r6 != 0){
+                r6();
+            }
+            if(r6 != *(VFN*)(r5 + 0x24)) goto next;
+            if((u32)*(int*)(r5 + 0xc) <= 1) *(int*)(r5 + 0x24) = 0;
+        }
+    }
+
+next:
+    if(*(int*)(r5 + 8) == 0) return;
+
+    switch(*(int*)(r5 + 0x10)){
+    case 0:
+        r4 = *(int*)(r5 + 0x14);
+        break;
+    case 1:
+        r4 = *(int*)(r5 + 0x14) << 1;
+        if(r4 > 0x1000) r4 = -(r4 - 0x2000);
+        break;
+    case 2:
+        r4 = (int)(((long long)*(int*)(r5 + 0x14) * *(int*)(r5 + 0x14)) >> 12);
+        break;
+    case 3:
+        break;
+    }
+
+    if(*(int*)(r5 + 0x1c) == 1) r4 = 0x1000 - r4;
+
+    switch(*(int*)(r5)){
+    case 1:
+        func_ov007_020c8c88(r5, r4);
+        break;
+    case 2:
+    case 3:
+        func_ov007_020c8bc8(r5, r4);
+        break;
+    case 4:
+        func_ov007_020c8b34(r5, r4);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/func_ov100_02146e70.c
+++ b/src/func_ov100_02146e70.c
@@ -1,0 +1,43 @@
+enum { false, true };
+
+extern void Matrix4x3_FromRotationY(void *m, short ang);
+extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void *self, void *sm, void *mtx, int a, int b, int d, unsigned int e);
+extern short data_02082214[];
+extern signed char data_0209f2f8;
+extern unsigned char data_0209f2d8;
+
+void func_ov100_02146e70(char *c) {
+    int r6;
+    int r5;
+    int belse;
+    int idx;
+    int s0;
+    int s1;
+    int t;
+
+    if (data_0209f2f8 == 13) return;
+    if (*(int*)(c+0x4ac) > *(int*)(c+0x60)) return;
+
+    belse = (*(int*)(c+0x60) - *(int*)(c+0x4ac)) + 0x64000;
+
+    idx = *(unsigned short*)(c+0x8c) >> 4;
+    s0 = data_02082214[idx << 1];
+    r5 = (int)(((long long)s0 * 0x17c000 + 0x800) >> 12);
+    if (r5 < 0) r5 = -r5;
+    s1 = data_02082214[(idx << 1) + 1];
+    r6 = (int)(((long long)s1 * 0x17c000 + 0x800) >> 12);
+    if (r6 < 0) r6 = -r6;
+
+    Matrix4x3_FromRotationY(c+0x478, *(short*)(c+0x8e));
+    *(int*)(c+0x49c) = *(int*)(c+0x5c) >> 3;
+    *(int*)(c+0x4a0) = (*(int*)(c+0x60) - r5) >> 3;
+    *(int*)(c+0x4a4) = *(int*)(c+0x64) >> 3;
+
+    t = data_0209f2d8;
+    t = t == 1;
+    if (t != false) {
+        _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(c, c+0x450, c+0x478, 0x118000, 0x7d0000, r6, 0xf);
+    } else {
+        _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(c, c+0x450, c+0x478, 0x118000, belse, r6, 0xf);
+    }
+}


### PR DESCRIPTION
## Summary

- `func_ov007_020c8498` @ `0x020c8498` (ov007, `0x1f0` / 496 bytes): advances easing state, runs completion callbacks, and dispatches transform updates.
- `func_ov006_0211134c` @ `0x0211134c` (ov006, `0x214` / 532 bytes): updates level-dependent state, interpolation limits, and interface motion values.
- `func_ov006_021231ac` @ `0x021231ac` (ov006, `0x194` / 404 bytes): configures packed vector/graphics state, initializes interface resources, lays out language-dependent entries, and runs subsystem setup.
- `func_ov100_02146e70` @ `0x02146e70` (ov100, `0x19c` / 412 bytes): computes fixed-point shadow offsets/scales and updates the actor shadow matrix.

All four sources are byte-identical with the retail EU code under **mwccarm 1.2/sp2p3** (1,844 bytes total).

## Verification

- `tools/match.py --strict-relocs`: **MATCH** for all four functions
- `tools/linkcheck.py`: **VERIFIED**, `diffs=[]`, `blind=0` for all four functions
- Clean source-only branch based on `origin/main` `ec5566d8`

Claims retained until merge verification: `clm_65b8d96fd316`, `clm_bcfc44e25a5b`, `clm_06ab51d4688c`, `clm_9db4c22ec7ef`.

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents