### PR TITLE
Match 3 actor behavior functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN15TtcRotatingCube8BehaviorEv.c
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.c
@@ -1,0 +1,57 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern u16 DecIfAbove0_Short(u16 *p);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void *v);
+extern int _Z14ApproachLinearRsss(s16 *val, int target, int step);
+extern int RandomIntInternal(int *seed);
+extern void func_ov065_0211990c(char *c);
+extern void func_ov065_02119794(char *c);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
+extern void func_ov065_021198a0(char *self);
+
+extern u8 data_0209f2c0;
+extern u8 data_ov065_0211cfa4[];
+extern int data_0209e650;
+extern s16 data_ov065_0211cfa8[];
+
+int _ZN15TtcRotatingCube8BehaviorEv(char *self) {
+    if (data_0209f2c0 != 3) {
+        switch (*(u8 *)(self + 0x376)) {
+        case 0:
+            if (DecIfAbove0_Short((u16 *)(self + 0x374)) != 0)
+                break;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x5b, self + 0x74);
+            (*(u8 *)(((int)self + 0x376) & 0xFFFFFFFFFFFFFFFF))++;
+            *(int *)(self + 0xa8) = -0x5000;
+            break;
+        case 1:
+            *(int *)(((int)self + 0xa8) & 0xFFFFFFFFFFFFFFFF) += 0x800;
+            *(int *)(((int)self + 0x370) & 0xFFFFFFFFFFFFFFFF) += *(int *)(self + 0xa8);
+            if (*(int *)(self + 0x370) < 0)
+                break;
+            *(int *)(self + 0x370) = 0;
+            *(s16 *)(self + 0x374) = 6;
+            (*(u8 *)(((int)self + 0x376) & 0xFFFFFFFFFFFFFFFF))++;
+            break;
+        case 2:
+            if (DecIfAbove0_Short((u16 *)(self + 0x374)) != 0)
+                break;
+            if (_Z14ApproachLinearRsss((s16 *)(self + 0x90), *(s16 *)(self + 0x378), 0x4b0) == 0)
+                break;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x40, self + 0x74);
+            *(u8 *)(self + 0x376) = 0;
+            *(s16 *)(self + 0x374) = data_ov065_0211cfa4[data_0209f2c0];
+            if (data_0209f2c0 == 2)
+                *(s16 *)(self + 0x374) = (unsigned int)RandomIntInternal(&data_0209e650) % 7 * 0x14 + 5;
+            *(s16 *)(((int)self + 0x378) & 0xFFFFFFFFFFFFFFFF) += data_ov065_0211cfa8[*(u8 *)(self + 0x377)];
+            break;
+        }
+    }
+    func_ov065_0211990c(self);
+    func_ov065_02119794(self);
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(self, 0, 0))
+        func_ov065_021198a0(self);
+    return 1;
+}

--- a/src/func_ov002_020b10e4.c
+++ b/src/func_ov002_020b10e4.c
@@ -1,0 +1,91 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef int Fix12i;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+typedef struct Actor Actor;
+
+struct BF3ae {
+    u8 b0 : 1;
+    u8 : 4;
+    u8 sel : 3;
+};
+
+extern signed char data_0209f2f8;
+
+extern Actor* _ZN5Actor4NextEPKS_(const Actor* prev);
+extern Fix12i Vec3_HorzDist(const Vector3* a, const Vector3* b);
+extern void _ZN11RaycastLineC1Ev(void* self);
+extern void _ZN11RaycastLineD1Ev(void* self);
+extern void _ZN10ClsnResultC1Ev(void* self);
+extern void _ZN10ClsnResultD1Ev(void* self);
+extern int _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, const Vector3* a, const Vector3* b, Actor* obj);
+extern int _ZN11RaycastLine10DetectClsnEv(void* self);
+extern void _ZNK10ClsnResult6CopyToERS_(const void* self, void* dst);
+extern u32 _ZNK10ClsnResult9GetClsnIDEv(const void* self);
+extern Actor* _ZN5Actor10FindWithIDEj(u32 id);
+extern void _ZN11RaycastLine10GetClsnPosEv(Vector3* res, void* self);
+
+void func_ov002_020b10e4(char* c)
+{
+    int b;
+    Actor* a;
+
+    b = (int)((*(int*)(c + 0xb0) & 8) != 0);
+    if (b) return;
+
+    if (((struct BF3ae*)(c + 0x3ae))->sel != 7) return;
+
+    if (data_0209f2f8 == 0x1c || data_0209f2f8 == 0x27) {
+        a = _ZN5Actor4NextEPKS_(0);
+        if (a) {
+            do {
+                char* ac = (char*)a;
+                u16 type = *(u16*)(ac + 0xc);
+                if (type == 0x7e || type == 0x81 || type == 0x9c) {
+                    int dy = *(int*)(c + 0x60) - *(int*)(ac + 0x60);
+                    int radius = *(int*)(ac + 0xb8);
+                    int dist = Vec3_HorzDist((Vector3*)(c + 0x5c), (Vector3*)(ac + 0x5c));
+                    if (dist < (radius << 3) && dy <= 0x1f4000 && dy >= 0) {
+                        *(int*)(c + 0x398) = *(int*)(ac + 0x60) + 0x32000;
+                        ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 1;
+                        return;
+                    }
+                }
+                a = _ZN5Actor4NextEPKS_(a);
+            } while (a);
+        }
+    }
+
+    {
+        char rl[0x78];
+        char cr[0x28];
+        Vector3 va, vb;
+        _ZN11RaycastLineC1Ev(rl);
+        _ZN10ClsnResultC1Ev(cr);
+        vb.x = *(int*)(c + 0x5c);
+        vb.y = *(int*)(c + 0x60);
+        vb.z = *(int*)(c + 0x64);
+        va.x = vb.x;
+        va.y = vb.y;
+        va.z = vb.z;
+        va.y += 0x14000;
+        vb.y -= 0x1f4000;
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &va, &vb, (Actor*)c);
+        if (_ZN11RaycastLine10DetectClsnEv(rl)) {
+            _ZNK10ClsnResult6CopyToERS_(rl + 0x10, cr);
+            if (_ZNK10ClsnResult9GetClsnIDEv(cr) != (u32)-1 &&
+                _ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(cr)) != 0) {
+                ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 0;
+            } else {
+                Vector3 pos;
+                _ZN11RaycastLine10GetClsnPosEv(&pos, rl);
+                *(int*)(c + 0x398) = pos.y;
+                ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 1;
+            }
+        }
+        _ZN10ClsnResultD1Ev(cr);
+        _ZN11RaycastLineD1Ev(rl);
+    }
+}

--- a/src/func_ov007_020c8de0.c
+++ b/src/func_ov007_020c8de0.c
@@ -1,0 +1,95 @@
+typedef short s16;
+typedef long long s64;
+
+struct Vec3
+{
+  int x;
+  int y;
+  int z;
+};
+
+extern void func_ov007_020c90c0(void *self);
+extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+extern int LenVec3(struct Vec3 *v);
+extern void NormalizeVec3(struct Vec3 *a, struct Vec3 *b);
+extern void func_02053320(int s, int *a, int *b, int *out);
+
+struct T
+{
+  int state;
+  int sub;
+  char pad_8[4];
+  s16 f_c;
+  char pad_e[2];
+  int *f10;
+  int f14;
+  int f18;
+  int f1c;
+  int f20;
+  int f24;
+  int f28;
+};
+
+int func_ov007_020c8de0(struct T *o)
+{
+  struct Vec3 tmp;
+  if (o->state == 2)
+  {
+    o->state = 3;
+  }
+  if (o->state != 1)
+  {
+    goto done;
+  }
+  switch (o->sub)
+  {
+    case 0:
+    {
+      int t0 = o->f_c;
+      int a0 = o->f20;
+      int b0 = o->f14;
+      o->f10[0] = (t0 >= 0x1000) ? (a0) : ((t0 <= 0) ? (b0) : (((((s64) (0x1000 - t0)) * b0) + (((s64) t0) * o->f20)) >> 0xc));
+    }
+    {
+      int t1 = o->f_c;
+      int a1 = o->f24;
+      int b1 = o->f18;
+      o->f10[1] = (t1 >= 0x1000) ? (a1) : ((t1 <= 0) ? (b1) : (((((s64) (0x1000 - t1)) * b1) + (((s64) t1) * o->f24)) >> 0xc));
+    }
+    {
+      int t2 = o->f_c;
+      int a2 = o->f28;
+      int b2 = o->f1c;
+      o->f10[2] = (t2 >= 0x1000) ? (a2) : ((t2 <= 0) ? (b2) : (((((s64) (0x1000 - t2)) * b2) + (((s64) t2) * o->f28)) >> 0xc));
+    }
+    func_ov007_020c90c0(o);
+    break;
+
+    case 1:
+    {
+      int *dst = o->f10;
+      int r5 = *((int *) (((char *) o) + 8));
+      int ok;
+      SubVec3((struct Vec3 *) (&o->f20), (struct Vec3 *) dst, &tmp);
+      if (LenVec3(&tmp) <= r5)
+      {
+        *((struct Vec3 *) dst) = *((struct Vec3 *) (&o->f20));
+        ok = 1;
+      }
+      else
+      {
+        NormalizeVec3(&tmp, &tmp);
+        func_02053320(r5, (int *) (&tmp), dst, dst);
+        ok = 0;
+      }
+      if (ok)
+      {
+        o->state = 2;
+      }
+      break;
+    }
+  }
+
+done:
+  return (o->state == 3) ? (1) : (0);
+}


### PR DESCRIPTION
## Summary

- `func_ov002_020b10e4` @ `0x020b10e4` (ov002, `0x208` / 520 bytes): scans nearby actors and raycasts downward to update actor-ground state.
- `func_ov007_020c8de0` @ `0x020c8de0` (ov007, `0x178` / 376 bytes): interpolates vector state, normalizes/moves toward targets, and reports completion.
- `_ZN15TtcRotatingCube8BehaviorEv` @ `0x02119a50` (ov065, `0x1e8` / 488 bytes): runs the rotating-cube state machine and shared collision/update tail.

All three sources are byte-identical with the retail EU code under **mwccarm 1.2/sp2p3** (1,384 bytes total).

## Verification

- `tools/match.py --strict-relocs`: **MATCH** for all three functions
- `tools/linkcheck.py`: **VERIFIED**, `diffs=[]`, `blind=0` for all three functions
- Clean source-only branch based on `origin/main` `ec5566d8`

Claims retained until merge verification: `clm_18299c04715b`, `clm_c41061e03605`, `clm_8bcd5a170a6f`.

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents