### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_020e8f14.c
+++ b/src/func_ov006_020e8f14.c
@@ -1,0 +1,110 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+typedef long long s64;
+
+extern int RandomIntInternal(int *seed);
+extern s16 data_02082214[];
+extern int data_0209d4b8;
+extern void func_ov006_020e7d7c(char *c);
+
+void func_ov006_020e8f14(char *self, int i)
+{
+    int n;
+    u16 timer;
+    s16 tv1;
+    s16 tv2;
+    int speed2;
+    int speed1;
+    int angle1;
+    char *angleBase;
+    char *speedBase;
+
+    n = i * 0x18;
+    timer = *(u16 *) (self + 0x5214 + n);
+    if (timer != 0)
+    {
+        *(u16 *) (self + 0x5214 + n) = timer - 1;
+        if ((*(s16 *) (self + 0x5214 + n)) <= 0)
+        {
+            *(u16 *) (self + 0x5214 + n) = 0;
+        }
+        return;
+    }
+
+    speedBase = self + 0x5210;
+    angleBase = self + 0x5216;
+    speed1 = *(int *) (speedBase + n);
+    angle1 = *(u16 *) (angleBase + n);
+    angle1 >>= 4;
+    tv1 = data_02082214[(angle1 << 1) + 1];
+    *(int *) (self + 0x5208 + n) = (*(int *) (self + 0x5208 + n)) + ((int) ((((s64) tv1) * speed1 + 0x800) >> 0xc));
+
+    tv2 = data_02082214[(*(u16 *) (angleBase + n) >> 4) << 1];
+    speed2 = *(int *) (speedBase + n);
+    *(int *) (self + 0x520c + n) = (*(int *) (self + 0x520c + n)) + ((int) ((((s64) tv2) * speed2 + 0x800) >> 0xc));
+    *(int *) (speedBase + n) = (*(int *) (speedBase + n)) + 0x300;
+
+    {
+        int dx = 0x80 - ((*(int *) (self + 0x5208 + n)) >> 0xc);
+        int dz = 0x30 - ((*(int *) (self + 0x520c + n)) >> 0xc);
+        if (dx < -6)
+            return;
+        if (dx > 6)
+            return;
+        if (dz < -6)
+            return;
+        if (dz > 6)
+            return;
+    }
+
+    *(int *) (self + 0x5208 + n) = 0x80000;
+    *(int *) (self + 0x520c + n) = 0x30000;
+    *(u8 *) (self + 0x5218 + n) = 0;
+
+    if (*(u8 *) (self + 0x5552) == 0)
+    {
+        if ((*(u8 *) (self + 0x5551)) == (*(u8 *) (self + 0x521b + n)))
+        {
+            *(u8 *) (self + 0x5550) = 1;
+        }
+        else
+        {
+            int rnd = RandomIntInternal(&data_0209d4b8);
+            u32 temp = ((u32) rnd >> 16) & 0x7fff;
+            if (((temp << 1) >> 0xf) == 0)
+            {
+                *(u8 *) (self + 0x5550) = 0;
+            }
+            else
+            {
+                *(u8 *) (self + 0x5551) = *(u8 *) (self + 0x521b + n);
+                *(u16 *) (self + 0x51f0) = *(u8 *) (self + 0x521b + n);
+                *(u8 *) (self + 0x5550) = 1;
+            }
+        }
+    }
+    else
+    {
+        if ((*(u8 *) (self + 0x5551)) == (*(u8 *) (self + 0x521b + n)))
+        {
+            *(u8 *) (self + 0x5550) = 1;
+        }
+        else
+        {
+            *(u8 *) (self + 0x5550) = 0;
+        }
+    }
+
+    *(int *) (self + 0x553c) = 2;
+    *(int *) (self + 0x5540) = 0;
+    *(u16 *) (self + 0x5548) = 0x90;
+    if (*(u8 *) (self + 0x5550) == 0)
+    {
+        u16 *p548 = (u16 *) ((long long) (int) (self + 0x5548) & 0xFFFFFFFFFFFFFFFFLL);
+        *p548 = *p548 + 0x40;
+    }
+
+    func_ov006_020e7d7c(self + 0x4fd8);
+}

--- a/src/func_ov084_021294d0.cpp
+++ b/src/func_ov084_021294d0.cpp
@@ -1,0 +1,82 @@
+//cpp
+extern "C" {
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
+extern char* _ZNK12WithMeshClsn14GetFloorResultEv(void*);
+extern int func_02037e78(int* p);
+extern void func_ov084_021296cc(void*);
+extern void _ZN5Enemy9SpawnCoinEv(void*);
+extern void func_ov084_02129498(void*);
+extern void _ZN8CapEnemy10ReleaseCapERK7Vector3(void*, void*);
+extern void _ZN8CapEnemy15RespawnIfHasCapEv(void*);
+extern int func_02037e38(unsigned int* p);
+extern int func_02037e84(int* p);
+extern void _ZN10ClsnResultD1Ev(void*);
+extern int data_02099368[];
+}
+
+struct V3 { int x, y, z; };
+
+extern "C" void func_ov084_021294d0(char* c)
+{
+    char obj[0x28];
+    if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x1b4))
+        return;
+
+    char* fr = _ZNK12WithMeshClsn14GetFloorResultEv(c + 0x1b4);
+    if (func_02037e78((int*)(fr + 4))) {
+        func_ov084_021296cc(c);
+        _ZN5Enemy9SpawnCoinEv(c);
+        func_ov084_02129498(c);
+        V3 v;
+        v.x = 0; v.y = 0x6c000; v.z = 0;
+        _ZN8CapEnemy10ReleaseCapERK7Vector3(c, &v);
+        *(int*)(c + 0x5c) = *(int*)(c + 0x41c);
+        *(int*)(c + 0x60) = *(int*)(c + 0x420);
+        *(int*)(c + 0x64) = *(int*)(c + 0x424);
+        _ZN8CapEnemy15RespawnIfHasCapEv(c);
+        return;
+    }
+
+    char* fr2 = _ZNK12WithMeshClsn14GetFloorResultEv(c + 0x1b4);
+    int r5;
+    {
+    char* d = obj + 4;
+    int a = *(int*)(fr2 + 4);
+    int b = *(int*)(fr2 + 8);
+    *(int*)(d) = b ? a : a;
+    *(int*)(d + 4) = b;
+    *(int*)(d + 8) = *(int*)(fr2 + 0xc);
+    *(int*)(d + 0xc) = *(int*)(fr2 + 0x10);
+    *(int*)(d + 0x10) = *(int*)(fr2 + 0x14);
+    *(int*)(obj) = (int)data_02099368;
+    *(unsigned short*)(obj + 0x18) = *(unsigned short*)(fr2 + 0x18);
+    *(unsigned short*)(obj + 0x1a) = *(unsigned short*)(fr2 + 0x1a);
+    *(int*)(obj + 0x1c) = *(int*)(fr2 + 0x1c);
+    *(int*)(obj + 0x20) = *(int*)(fr2 + 0x20);
+    *(int*)(obj + 0x24) = *(int*)(fr2 + 0x24);
+    r5 = func_02037e38((unsigned int*)d);
+    }
+    if (func_02037e84((int*)(obj + 4)) == 8) {
+        if (r5 == 6 || r5 == 7 || r5 == 8 || r5 == 9)
+            goto action;
+    }
+    if (r5 == 0x13 || r5 == 1)
+        goto action;
+    if ((unsigned)(r5 - 4) > 1)
+        goto dtor;
+action:
+    _ZN5Enemy9SpawnCoinEv(c);
+    func_ov084_02129498(c);
+    if ((*(unsigned char*)(c + 0x113) & 0xf) < 6 ||
+        *(unsigned char*)(c + 0x464) == 2) {
+        *(int*)(c + 0x5c) = *(int*)(c + 0x41c);
+        *(int*)(c + 0x60) = *(int*)(c + 0x420);
+        *(int*)(c + 0x64) = *(int*)(c + 0x424);
+        V3 v2;
+        v2.x = 0; v2.y = 0x6c000; v2.z = 0;
+        _ZN8CapEnemy10ReleaseCapERK7Vector3(c, &v2);
+        _ZN8CapEnemy15RespawnIfHasCapEv(c);
+    }
+dtor:
+    _ZN10ClsnResultD1Ev(obj);
+}


### PR DESCRIPTION
## Summary

- func_ov006_020e8f14 at 0x020e8f14 (ov006), size 0x28c / 652 bytes
- func_ov084_021294d0 at 0x021294d0 (ov084), size 0x1e0 / 480 bytes
- Both compile byte-identically with the retail EU ROM under mwccarm 1.2/sp2p3
- Each source passed strict relocation matching and linked-target verification

## Test plan

- tools/match.py --strict-relocs reports MATCH for both functions
- tools/linkcheck.py reports VERIFIED, diffs=[], blind=0 for both functions
- PR contains only the two src additions

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents