### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_021009b8.c
+++ b/src/func_ov006_021009b8.c
@@ -1,0 +1,39 @@
+#pragma opt_common_subs off
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int data_ov006_0212ec80[];
+
+void func_ov006_021009b8(char *p, int i)
+{
+    int v;
+    u8 state;
+
+    if (*(u16 *)(p + 0x5200 + (i << 6) + 0x92) != 0) {
+        (*(u16 *)(p + 0x5292 + (i << 6)))--;
+        if (*(short *)(p + 0x5200 + (i << 6) + 0x92) > 0)
+            return;
+        *(int *)(p + 0x5000 + (i << 6) + 0x26c) = 0;
+        *(int *)(p + 0x5000 + (i << 6) + 0x268) = data_ov006_0212ec80[i];
+        *(u8 *)(p + 0x5000 + (i << 6) + 0x298) = i;
+        return;
+    }
+
+    *(int *)(p + 0x5260 + (i << 6)) += *(int *)(p + 0x5000 + (i << 6) + 0x268);
+    *(int *)(p + 0x5264 + (i << 6)) += *(int *)(p + 0x5000 + (i << 6) + 0x26c);
+    *(int *)(p + 0x526c + (i << 6)) -= 0x20;
+    state = *(u8 *)(p + 0x5000 + (i << 6) + 0x298);
+    if (state == 0) {
+        if (*(int *)(p + 0x5000 + (i << 6) + 0x268) <= 0xc00)
+            *(int *)(p + 0x5268 + (i << 6)) += 0x80;
+    } else if (state == 1) {
+        if (*(int *)(p + 0x5000 + (i << 6) + 0x268) >= -0xc00)
+            *(int *)(p + 0x5268 + (i << 6)) -= 0x80;
+    }
+
+    v = *(int *)(p + 0x5000 + (i << 6) + 0x264) >> 12;
+    if (v <= -0x120) {
+        *(u8 *)(p + 0x5000 + (i << 6) + 0x294) = 0;
+        *(u8 *)(p + 0x5000 + (i << 6) + 0x295) = 0;
+    }
+}

--- a/src/func_ov006_0210935c.c
+++ b/src/func_ov006_0210935c.c
@@ -1,0 +1,79 @@
+extern struct P { int x, y; } data_ov006_02142ab4[];
+extern struct P data_ov006_02142ab8[];
+void func_ov006_02109530(int *out, int *a, int scale);
+
+#define LNDR(e) ((int)(((long long)(e)) & 0xFFFFFFFFFFFFFFFFLL))
+
+struct S {
+    char pad[0x18];
+    int f18;
+    int f1c;
+    char pad2[0x2c - 0x20];
+    short f2c;
+};
+
+void func_ov006_0210935c(struct S *self, int idx)
+{
+    int buf[7];
+    int f18 = self->f18;
+    int a, b, lr, t, hi;
+    buf[0] = f18;
+    buf[1] = self->f1c;
+    if ((unsigned short)(short)(idx - 0x23) <= 1) {
+        a = data_ov006_02142ab4[idx].x;
+        b = data_ov006_02142ab8[idx].x;
+        buf[2] = a;
+        buf[3] = b;
+        lr = a + 0x8000;
+        hi = a + 0x18000;
+        if (f18 >= lr) {
+            if (f18 <= hi)
+                hi = f18;
+            lr = hi;
+        }
+        b = buf[3];
+        t = buf[1];
+        {
+            int lo = b - 0x20000;
+            buf[0] = lr;
+            lr = lo;
+            hi = b + 0x20000;
+            if (t >= lo) {
+                if (t <= hi)
+                    hi = t;
+                lr = hi;
+            }
+        }
+        buf[1] = lr;
+        func_ov006_02109530((int *)self, buf, 0x100);
+        return;
+    }
+    {
+        int early = (self->f2c <= 0xb) ? 1 : 0;
+        if (LNDR(early) == 0)
+            return;
+    }
+    a = data_ov006_02142ab4[idx].x;
+    b = data_ov006_02142ab8[idx].x;
+    buf[4] = a;
+    buf[5] = b;
+    lr = a - 0x10000;
+    hi = a + 0x10000;
+    if (buf[0] >= lr) {
+        if (buf[0] <= hi)
+            hi = buf[0];
+        lr = hi;
+    }
+    b = buf[5];
+    t = buf[1];
+    buf[0] = lr;
+    lr = b - 0xc000;
+    hi = b + 0xc000;
+    if (t >= lr) {
+        if (t <= hi)
+            hi = t;
+        lr = hi;
+    }
+    buf[1] = lr;
+    func_ov006_02109530((int *)self, buf, 0x100);
+}

--- a/src/func_ov006_021228bc.cpp
+++ b/src/func_ov006_021228bc.cpp
@@ -1,0 +1,59 @@
+//cpp
+extern "C" {
+struct Tbl { int a, b, c; };
+extern int data_0209e650[];
+extern struct Tbl data_ov006_0213fbf8;
+extern unsigned short data_ov006_0212f144[];
+extern int RandomIntInternal(int* seed);
+extern void func_020169f4(char* self, int kind);
+extern void func_02016a14(char* self, int arg);
+extern void func_02016a04(char* self, int arg);
+
+void func_ov006_021228bc(char* r0, int r1) {
+    char* r5 = r0;
+    int r4 = r1;
+    struct Tbl t = data_ov006_0213fbf8;
+    unsigned int rnd = ((unsigned int)RandomIntInternal(data_0209e650) & 0x7fffffff) >> 0x13;
+    int idx;
+    if ((int)rnd < t.a) {
+        idx = 0;
+    } else if ((int)rnd < t.b) {
+        idx = 1;
+    } else if ((int)rnd < t.c) {
+        idx = 2;
+    } else {
+        idx = 3;
+    }
+    func_020169f4(r5, data_ov006_0212f144[idx]);
+    int r1_4 = r4 * 0xA00;
+    *(short*)(r5 + 0x76) = 0xF0;
+    if (r1_4 > 0x4000) {
+        r1_4 = 0x4000;
+    }
+    int r0_5 = r1_4 + 0x4000;
+    *(int*)(r5 + 0x50) = r0_5;
+    *(int*)(r5 + 0x54) = r0_5;
+    *(int*)(r5 + 0x58) = r0_5;
+    *(int*)(r5 + 0x5c) = 0x60000;
+    *(int*)(r5 + 0x60) = 0x100000;
+    *(int*)(r5 + 0x64) = 0x18000;
+    int r1_9 = -0x1C00;
+    *(int*)(r5 + 0x68) = r1_9;
+    *(int*)(r5 + 0x6c) = r1_9;
+    *(int*)(r5 + 0x70) = 0;
+    unsigned int rnd2 = (unsigned int)RandomIntInternal(data_0209e650);
+    int* p1 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x5c)) & 0xffffffffffffffffULL);
+    int v1 = *p1 + ((((rnd2 & 0x7fffffff) >> 0x13) - 0x800) * 0x40);
+    *p1 = v1;
+    int rnd3 = RandomIntInternal(data_0209e650);
+    int* p2 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x68)) & 0xffffffffffffffffULL);
+    int adj3 = (int)(((unsigned int)rnd3 & 0x7fffffff) >> 0x13);
+    *p2 -= adj3 >> 1;
+    int rnd4 = RandomIntInternal(data_0209e650);
+    int* p3 = (int*)(((unsigned long long)(unsigned int)(r5 + 0x6c)) & 0xffffffffffffffffULL);
+    int adj4 = (int)(((unsigned int)rnd4 & 0x7fffffff) >> 0x13);
+    *p3 -= adj4 >> 1;
+    func_02016a14(r5, 0);
+    func_02016a04(r5, 0);
+}
+}


### PR DESCRIPTION
## Summary

- `func_ov006_021009b8` @ `0x021009b8`, size `0x150` / 336 bytes
- `func_ov006_0210935c` @ `0x0210935c`, size `0x150` / 336 bytes
- `func_ov006_021228bc` @ `0x021228bc`, size `0x160` / 352 bytes
- Total: 1,024 bytes of ov006 source

Each file independently reports strict oracle `MATCH` under mwccarm `1.2/sp2p3` and linkcheck `VERIFIED` with `diffs=[]`, `blind=0`. The three Claimsbot locks remain active through merge and direct verification on `origin/main`.

## Test plan

- `tools/match.py --strict-relocs` reports `MATCH` for all three files
- `tools/linkcheck.py` reports `VERIFIED`, `diffs=[]`, `blind=0` for all three files
- Remote `validate` should confirm linked retail bytes

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop + native subagents