### PR TITLE
feat: declare matchConventions for tangOS (near-miss, no attempt tree yet)

### DIFF
--- a/notes/match-conventions-tangos.md
+++ b/notes/match-conventions-tangos.md
@@ -1,0 +1,19 @@
+# Match conventions (tangOS / Chaos Viewer)
+
+SM64DS keeps the **matching spine**: `src/` = matches only, near-miss tips in
+`nearmiss/db.jsonl`.
+
+`tangos.json` declares `project.matchConventions` so **tangOS Console**
+(builds with match-convention support, e.g. lunavyqo/tangOS until upstream) can:
+
+- Treat near-miss tips as tool-based (not paste) via `nearMissDb`
+- Prefill default AI provenance slugs
+- Keep **`attemptTree: false`** — full try-diary logging is optional and not
+  required for SM64DS
+
+To adopt EP-style attempt trees later (every try in `config/match_attempts.jsonl`),
+see:
+
+https://github.com/lunavyqo/electroplankton-decomp/blob/main/notes/adopting-match-conventions.md
+
+Do **not** put non-matching C in `src/`.

--- a/tangos.json
+++ b/tangos.json
@@ -16,6 +16,16 @@
     "submitting": "Before opening a PR read AGENTS.md in the repo root. Every file you add to src/ MUST byte-reproduce the ROM (pass the `validate` CI check) - green is the ONLY merge gate. NEVER commit a non-reproducing file to src/: a near-miss/WRONG-DEST file is a false match someone has to rip back out. Close-but-not-matching drafts go to nearmiss/db.jsonl via tools/nearmiss_db.py, NOT src/. One matched function per src/<symbol>.c|.cpp (first line //cpp for C++). Claim your span in CLAIMS.md first. PR title: 'Match N functions byte-identical (mwccarm 1.2/sp2p3)', src-only, no bundled tools/CI. How PRs are reviewed + merged: MERGE.md.",
     "rules": "only your own legally dumped ROM; never commit the ROM, its assets, or extracted binaries - the one deliberate exception is the annotated disassembly TEXT of still-unmatched functions, published in the coordination data (chaos-data branch) so contributors can work, the same practice as decomp repos committing .s files; import struct/field knowledge (see CREDITS.md) but write all C from scratch.",
     "nearMissNote": "If a function will not fully match after real effort, do not discard your best attempt - it is still valuable. Store the closest compiling draft as a near-miss (highest-yield input to the refine tier); most matches now start from someone's stored near-miss.",
+    "matchConventions": {
+      "attemptTree": false,
+      "nearMissDb": "nearmiss/db.jsonl",
+      "ghidraDrafts": false,
+      "defaultProvenance": {
+        "model": "grok-4.5",
+        "reasoning": "high",
+        "harness": "grok-build"
+      }
+    },
     "knownWalls": "PROVEN unreachable from source (see notes/matching-style.md 'Known walls') - not an excuse to give up, but if your near-miss has collapsed to EXACTLY one of these, verify it, tell the user it's a known wall, and move on/hand to the permuter instead of grinding. (1) FIRST-ACCESS-FOLD: a single read-modify-write through base+offset (x->flag |= BIT) is 'add rN,base,#off; ldr [rN]; op; str [rN]' in the ROM but folds to 'ldr [base,#off]' from ALL C/C++ (array-index/pointer/(int)-cast/volatile/C++ inheritance, -O1..-O4, any version, permuter) - the whole tiny-arm9 flag-setter cluster (WithMeshClsn/BgCh setters, func_020353e0..func_02035784). If your ONLY divergence is that 1-instr materialization, it's the wall. (2) PURE SCHEDULING: same instructions reordered (load/store batching, cond-move polarity), same size, no statement/operand order changes it - the permuter can't flip it either."
   },
   "runtime": {


### PR DESCRIPTION
## Summary
Gives Tango / Console a clear SM64DS hook for the match-conventions system without changing the matching spine.

- `tangos.json` → `project.matchConventions`:
  - **`attemptTree: false`** (SM64DS stays nearmiss-tip only for now)
  - **`nearMissDb`**: `nearmiss/db.jsonl`
  - **`ghidraDrafts: false`**
  - default provenance slugs for agents
- Short note: `notes/match-conventions-tangos.md`
- Full staged adoption (optional try-diary later): [EP adopting guide](https://github.com/lunavyqo/electroplankton-decomp/blob/main/notes/adopting-match-conventions.md)

Requires a tangOS build that understands `matchConventions` (e.g. [lunavyqo/tangOS](https://github.com/lunavyqo/tangOS) until upstream).

## Test plan
- [ ] Open SM64DS in that Console — near-miss path recognized
- [ ] No attempt-tree logging forced
- [ ] validate / match path unchanged