### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.c
+++ b/src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.c
@@ -1,14 +1,17 @@
-// NONMATCHING: register allocation (div=11). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
 struct HeapAllocator;
 extern void _ZN18NestedHeapIterator4InitEP13HeapAllocator(char* it, char* a);
 void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(char* it, char* a) {
     if (*(char**)it == 0) { _ZN18NestedHeapIterator4InitEP13HeapAllocator(it, a); return; }
-    unsigned short* cnt = (unsigned short*)(it + 8);
-    *(int*)(a + *(unsigned short*)(it + 0xa)) = 0;
-    *(int*)(a + *(unsigned short*)(it + 0xa) + 4) = *(int*)it;
+    {
+        int* pa = (int*)(a + *(unsigned short*)(it + 0xa));
+        pa[0] = 0;
+        pa[1] = *(int*)it;
+    }
     *(int*)(*(char**)it + *(unsigned short*)(it + 0xa)) = (int)a;
     *(char**)it = a;
-    *cnt = *cnt + 1;
+    {
+        unsigned short* cnt = (unsigned short*)AT(it, 8);
+        *cnt = *cnt + 1;
+    }
 }

--- a/src/_ZN5StageC1Ev.c
+++ b/src/_ZN5StageC1Ev.c
@@ -1,6 +1,4 @@
-// NONMATCHING: base materialization / addressing (div=12). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
 extern int _ZN9ActorBasenwEj(unsigned int);
 extern int _ZN9ActorBaseC1Ev(void *);
 extern int _ZN8Particle10SysTrackerC1Ev(void *);
@@ -14,12 +12,11 @@ void *_ZN5StageC1Ev(void)
 {
     char *p = (char*)_ZN9ActorBasenwEj(0x9c8);
     if (p) {
-        unsigned char *flag = (unsigned char*)(p+0x13);
         _ZN9ActorBaseC1Ev(p);
         *(int*)(p) = (int)data_0208e4b8;
         *(int*)(p) = (int)_ZTV5Stage;
-        *flag |= 1;
-        *flag |= 4;
+        *(unsigned char*)AT(p, 0x13) |= 1;
+        *(unsigned char*)AT(p, 0x13) |= 4;
         *(int*)(p) = (int)data_020921c0;
         _ZN8Particle10SysTrackerC1Ev(p+0x50);
         _ZN5ModelC1Ev(p+0x86c);

--- a/src/func_ov006_020f95f0.c
+++ b/src/func_ov006_020f95f0.c
@@ -1,6 +1,4 @@
-// NONMATCHING: different op / idiom (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_propagation off
 extern int data_ov006_0213d700;
 extern short data_ov006_0213d6f8;
 extern short data_ov006_0214255c;
@@ -8,13 +6,15 @@ extern int data_ov006_02142570;
 extern int data_ov006_02142574;
 
 int func_ov006_020f95f0(void) {
-    int a = (short)(data_ov006_0213d700 << 4);
+    int a = (data_ov006_0213d700 << 4) >> 16;
+    int r = 0;
     int b = data_ov006_0213d6f8;
     if (b > 0x14) b = 0x14;
-    if (a != b) return 0;
-    if (data_ov006_0214255c != 0) return 0;
+    if (a != b) return r;
+    if (data_ov006_0214255c != 0) return r;
     if (data_ov006_02142570 != 0) {
-        if (data_ov006_02142574 != 0) return 0;
+        if (data_ov006_02142574 != 0) return r;
     }
-    return 1;
+    r = 1;
+    return r;
 }


### PR DESCRIPTION
Three functions matched byte-identical at mwccarm 1.2/sp2p3, verified with the tangos oracle (`match` → MATCH on all three).

- `_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator` (arm9, 0x0204de0c, size 0x68)
- `_ZN5StageC1Ev` (arm9, 0x0202e088, size 0x90)
- `func_ov006_020f95f0` (ov006, 0x020f95f0, size 0x78)

src-only; one matched function per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)