### PR TITLE
Match 10 functions via Opus->Fable escalation fan-out

### DIFF
--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -1,0 +1,152 @@
+//cpp
+typedef int s32;
+typedef short s16;
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef long long s64;
+typedef s32 Fix12;
+
+extern "C" {
+extern int func_02035638(u8* p);
+extern int func_0203564c(int p);
+extern int _ZNK10ClsnResult9GetClsnIDEv(void* c);
+extern void* _ZN5Actor10FindWithIDEj(u32 id);
+extern void func_ov002_020eeca8(void* c, int arg);
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* c);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
+extern int AngleDiff(int a, int b);
+extern void* _ZNK12WithMeshClsn13GetWallResultEv(void* c);
+extern int func_02037e58(u32* p);
+extern void func_ov002_020c1eb4(void* self, int dmg);
+extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
+extern void func_ov002_020cc660(char* self, int angle);
+extern void _Z14ApproachLinearRiii(int* a, int b, int c);
+extern int func_ov002_020c04e0(char* c);
+extern void func_ov002_020e25f0(char* c, int a);
+extern int func_ov002_020d674c(char* c);
+extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
+extern void func_ov002_020e28d4(char* c, int a, int b);
+extern int _ZN6Player12FinishedAnimEv(void* c);
+extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void func_ov002_020bedd4(char* c);
+
+extern u8 data_020a0e40;
+extern s16 data_0209f4a0[];
+extern u16 data_0209f49e[];
+extern u16 data_0209f49c[];
+extern int data_ov002_0211004c[];
+extern int data_ov002_021104e4[];
+}
+
+extern "C" int _ZN6Player13St_Shell_MainEv(char* c)
+{
+    int flag = 0;
+    void* res;
+
+    if (func_02035638((u8*)(c + 0x380))) {
+        flag = 1;
+        res = (void*)func_0203564c((int)(c + 0x380));
+        if (_ZNK10ClsnResult9GetClsnIDEv(res) != -1) {
+            void* a = _ZN5Actor10FindWithIDEj((u32)_ZNK10ClsnResult9GetClsnIDEv(res));
+            if (a) {
+                u16 type = *(u16*)((char*)a + 0xc);
+                if ((type == 0x14 ? flag : 0) || (type == 0x15 ? 1 : 0)) {
+                    func_ov002_020eeca8((void*)(c + 0x380), (int)c);
+                    flag = 0;
+                }
+            }
+        }
+    }
+
+    if (_ZNK12WithMeshClsn8IsOnWallEv((void*)(c + 0x380))) {
+        int ang = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x560), *(int*)(c + 0x568));
+        if (AngleDiff(ang, *(s16*)(c + 0x94)) > 0x6000) {
+            if (func_02037e58((u32*)((char*)_ZNK12WithMeshClsn13GetWallResultEv((void*)(c + 0x380)) + 4)) != 1) {
+                flag = 1;
+            }
+        }
+    }
+
+    if (flag) {
+        func_ov002_020c1eb4(c, (s16)(*(s16*)(c + 0x8e) + 0x8000));
+        return 1;
+    }
+
+    if (*(u8*)(c + 0x6e3) == 0) {
+        s16 target;
+        int accel;
+        if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
+            target = *(s16*)(c + 0x6d2);
+            accel = 0x40000;
+        } else {
+            target = *(s16*)(c + 0x8e);
+            accel = 0x18000;
+        }
+        s16 angleSave = *(s16*)(c + 0x94);
+        ApproachAngle((short*)(c + 0x94), target, 8, 0x800, 0x100);
+        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+        func_ov002_020cc660(c, angleSave);
+        {
+            int spd = *(int*)(c + 0x98);
+            int step = 0x1100;
+            if (spd > 0) step = 0x600;
+            _Z14ApproachLinearRiii((int*)(c + 0x98), accel, step);
+        }
+        func_ov002_020c04e0(c);
+        if (*(u8*)(c + 0x6de) != 0) {
+            (*(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            *(u8*)(c + 0x6de) = 1;
+            *(u8*)(c + 0x6df) = 0;
+        }
+        {
+            int off = data_020a0e40 * 0x18;
+            if (*(u16*)((char*)data_0209f49e + off) & 2) {
+                (*(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                *(int*)(c + 0xa8) = (*(int*)(c + 0x98) >> 2) + 0x2a000;
+                *(u8*)(c + 0x6de) = 1;
+                *(u8*)(c + 0x6df) = 0;
+                func_ov002_020e25f0(c, 0);
+                return 1;
+            } else if (*(u16*)((char*)data_0209f49c + off) & 0x400) {
+                if (func_ov002_020d674c(c)) {
+                    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211004c);
+                } else {
+                    *(u8*)(c + 0x6e3) = 0;
+                    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021104e4);
+                }
+                return 1;
+            }
+        }
+    } else {
+        if (*(u8*)(c + 0x6de) == 0) {
+            *(u8*)(c + 0x6e3) = 0;
+            *(s16*)(c + 0x766) = 0x1000;
+            *(s16*)(c + 0x760) = *(s16*)(c + 0x766);
+        } else {
+            *(s16*)(c + 0x766) = 0;
+            *(s16*)(c + 0x760) = *(s16*)(c + 0x766);
+            func_ov002_020e28d4(c, 0x1800, 0x800);
+            *(int*)(c + 0x9c) = -0x4000;
+            *(int*)(c + 0xa0) = -0x4b000;
+            if (*(int*)(c + 0xa8) >= 0) {
+                *(int*)(c + 0x9c) = -0x8000;
+                if (*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 2) {
+                    *(int*)(c + 0x9c) = -0x3400;
+                }
+            } else {
+                if ((*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 2) && *(u8*)(c + 0x6ff) != 0) {
+                    *(int*)(c + 0x9c) = -0x2000;
+                    *(int*)(c + 0xa0) = -0x25800;
+                }
+            }
+        }
+    }
+
+    if (_ZN6Player12FinishedAnimEv(c) && _ZN6Player6IsAnimEj(c, 0x35)) {
+        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x34, 0, 0x1000, 0);
+    }
+    func_ov002_020bedd4(c);
+    return 1;
+}

--- a/src/func_02044b30.c
+++ b/src/func_02044b30.c
@@ -1,0 +1,96 @@
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+extern s16 data_02082214[];
+extern u8 data_020a4bbc;
+extern u16 data_02099f94[8];
+extern s16 data_020a4bc0;
+extern s16 data_020a4bc4;
+extern void func_020553a4(int *m);
+void func_02044b30(char *obj, int idx)
+{
+  char *m = (*((char **) (obj + 4))) + (idx * 0x30);
+  int new_var;
+  int texParam;
+  *((int *) 0x40004a4) = *((int *) (m + 0x24));
+  *((int *) 0x40004c0) = *((int *) (m + 0x28));
+  *((int *) 0x40004c4) = *((int *) (m + 0x2c));
+  *((int *) 0x40004ac) = *((int *) (m + 0x20));
+  texParam = *((int *) (m + 0x1c));
+  *((int *) 0x40004a8) = texParam;
+  data_020a4bbc = (u8) (((u32) texParam) >> 0x1e);
+  switch (data_020a4bbc)
+  {
+    case 1:
+    {
+      int mtx[12];
+      int A;
+      int B;
+      int C;
+      int D;
+      u16 elemFieldE;
+      u16 elemFieldC;
+      char *elem;
+      int m0;
+      u16 rawAngle;
+      int angle;
+      int k;
+      s16 sinVal;
+      s16 cosVal;
+      int D0;
+      int D1;
+      *((int *) 0x4000440) = 3;
+      rawAngle = *((u16 *) (m + 0x10));
+      m0 = *((volatile int *) m);
+      elem = (*((char **) ((*((void **) obj)) + 0x18))) + (m0 * 0x14);
+      angle = ((u16) (rawAngle << 4)) >> 4;
+      k = angle << 1;
+      sinVal = data_02082214[k];
+      cosVal = data_02082214[k + 1];
+      C = (int) ((((long long) (*((int *) (m + 0x8)))) * sinVal) >> 12);
+      B = (int) ((((long long) (*((int *) (m + 0x8)))) * cosVal) >> 12);
+      A = (int) ((((long long) (*((int *) (m + 0xc)))) * sinVal) >> 12);
+      D = (int) ((((long long) (*((int *) (m + 0xc)))) * cosVal) >> 12);
+      elemFieldE = *((u16 *) (elem + 0xe));
+      elemFieldC = *((u16 *) (elem + 0xc));
+      D0 = (A * (-((int) elemFieldE))) / elemFieldC;
+      new_var = (C * elemFieldC) / elemFieldE;
+      mtx[0] = B;
+      mtx[1] = D0;
+      mtx[2] = 0;
+      D1 = new_var;
+      mtx[3] = D1;
+      mtx[4] = D;
+      mtx[5] = 0;
+      mtx[6] = 0;
+      mtx[7] = 0;
+      mtx[8] = 0;
+      mtx[9] = ((elemFieldC * ((*((int *) (m + 0x8))) - (C + B))) * 8) - (elemFieldC * ((int) ((((long long) (*((int *) (m + 0x8)))) * (*((int *) (m + 0x14)))) >> 8)));
+      mtx[10] = ((elemFieldE * (((A - D) - (*((int *) (m + 0xc)))) + 0x2000)) * 8) + (elemFieldE * ((int) ((((long long) (*((int *) (m + 0xc)))) * (*((int *) (m + 0x18)))) >> 8)));
+      mtx[11] = 0;
+      func_020553a4(mtx);
+    }
+      break;
+
+    case 2:
+    {
+      s16 buf[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+      int idx1;
+      int idx2;
+      s16 sa;
+      s16 sb_;
+      idx1 = (((u32) texParam) >> 0x17) & 7;
+      idx2 = (((u32) texParam) >> 0x14) & 7;
+      data_020a4bc0 = ((s16 *) buf)[idx2];
+      data_020a4bc4 = (s16) (-((s16 *) buf)[idx1]);
+      sa = (s16) ((*((int *) (m + 0x14))) >> 8);
+      sb_ = (s16) ((*((int *) (m + 0x18))) >> 8);
+      *((int *) 0x4000488) = ((u16) sa) | (((u16) sb_) << 16);
+    }
+      break;
+
+  }
+
+}

--- a/src/func_02061188.c
+++ b/src/func_02061188.c
@@ -1,0 +1,120 @@
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef void (*Handler)(void *msg);
+
+extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);
+extern void Crash(void);
+extern void MultiCopyHalf(const void *src, void *dst, u32 count);
+extern int func_02061674(void);
+extern void func_0206116c(void);
+
+extern u32 *data_020a89ac;
+
+typedef struct {
+    u16 w0;      /* 0x00 */
+    u16 w1;      /* 0x02 */
+    u16 w2;      /* 0x04 */
+    u16 w6;      /* 0x06 */
+    u32 d8;      /* 0x08 */
+    u32 dc;      /* 0x0c */
+    u16 w10;     /* 0x10 */
+    u16 w12;     /* 0x12 */
+    char _14[6]; /* 0x14 */
+    u16 w1a;     /* 0x1a */
+    u32 d1c;     /* 0x1c */
+} BufT;
+
+extern BufT data_020a89ec;
+extern char data_020a8a00;
+
+void func_02061188(int unused, u16 *msg, int flag)
+{
+    u16 op;
+
+    if (flag != 0)
+        return;
+
+    _ZN4CP1519InvalidateDataCacheEjj(data_020a89ac[4], 0x100);
+    _ZN4CP1519InvalidateDataCacheEjj(data_020a89ac[1], 0xa00);
+
+    op = msg[0];
+    if (op >= 0x25) {
+        if (op == 0x80) {
+            if (msg[1] == 0x13)
+                Crash();
+            if ((Handler)data_020a89ac[0x2a] != 0)
+                ((Handler)data_020a89ac[0x2a])(msg);
+        } else if (op == 0x82) {
+            if ((data_020a89ac + msg[3])[0x2b] != 0) {
+                *(u32 *)((char *)msg + 0x1c) = (data_020a89ac + msg[3])[0x3b];
+                _ZN4CP1519InvalidateDataCacheEjj(*(u32 *)(msg + 4),
+                    *(u16 *)((char *)data_020a89ac[1] + 0x46));
+                ((Handler)(data_020a89ac + msg[3])[0x2b])(msg);
+            }
+        } else if (op == 0x81) {
+            msg[0] = 0xf;
+            if (*(Handler *)((char *)msg + 0x14) != 0)
+                (*(Handler *)((char *)msg + 0x14))(msg);
+        }
+    } else {
+        if (op == 0xe) {
+            if ((u16)(msg[2] + 0xfff5) <= 1 && msg[1] == 0) {
+                _ZN4CP1519InvalidateDataCacheEjj(*(u32 *)(msg + 4),
+                    *(u16 *)((char *)data_020a89ac[1] + 0x46));
+            }
+        }
+
+        {
+            u16 t = msg[0];
+            if ((Handler)(data_020a89ac + t)[5] != 0)
+                ((Handler)(data_020a89ac + t)[5])(msg);
+        }
+
+        {
+            u16 op2 = msg[0];
+            if (op2 == 8 || op2 == 0xc) {
+                u16 objType;
+                u16 v5;
+                void *p;
+
+                if (op2 == 8) {
+                    p = &msg[5];
+                    objType = msg[4];
+                    v5 = msg[8];
+                } else if (op2 == 0xc) {
+                    objType = msg[4];
+                    v5 = msg[8];
+                    p = &msg[5];
+                }
+
+                if (objType == 7 || objType == 9) {
+                    u16 i;
+                    data_020a89ec.w0 = 0x82;
+                    data_020a89ec.w1 = 0;
+                    data_020a89ec.w2 = objType;
+                    data_020a89ec.d8 = 0;
+                    data_020a89ec.dc = 0;
+                    data_020a89ec.w10 = 0;
+                    data_020a89ec.w12 = v5;
+                    data_020a89ec.w1a = 0xffff;
+                    MultiCopyHalf(p, &data_020a8a00, 6);
+                    for (i = 0; i < 0x10; i++) {
+                        data_020a89ec.w6 = i;
+                        if ((data_020a89ac + i)[0x2b] != 0) {
+                            data_020a89ec.d1c = (data_020a89ac + i)[0x3b];
+                            ((Handler)(data_020a89ac + i)[0x2b])(&data_020a89ec);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (msg[0] == 2 && msg[1] == 0) {
+            func_02061674();
+            return;
+        }
+    }
+
+    _ZN4CP1519InvalidateDataCacheEjj(data_020a89ac[4], 0x100);
+    func_0206116c();
+}

--- a/src/func_02062df0.c
+++ b/src/func_02062df0.c
@@ -1,0 +1,134 @@
+#pragma opt_common_subs off
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern int func_02061548(void);
+extern int func_02061428(int count, ...);
+extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);
+extern int func_020623ec(int a0, int a1, int a2, int a3, u16 a4, u16 a5);
+extern void MultiCopyHalf(const void *src, void *dst, u32 count);
+extern void func_020627e8(void *self, int x);
+extern void func_02062990(void *self, u32 a, u32 b);
+extern void func_02062d10(void *self);
+
+#define H(o) (*(u16 *)(self + (o)))
+
+int func_02062df0(u8 *self, u8 *sb, u8 *r8)
+{
+    int slot;
+    u16 flag5;
+    u16 f86;
+    int did;
+    int fp;
+    int state;
+    int r;
+
+    slot = func_02061548();
+    r = func_02061428(2, 9, 0xa);
+    if (r != 0)
+        return r;
+
+    _ZN4CP1519InvalidateDataCacheEjj(*(u32 *)(slot + 4) + 0x10, 4);
+    if (*(u32 *)(*(u32 *)(slot + 4) + 0x10) == 0)
+        return 3;
+
+    if (self == 0)
+        return 6;
+    if (sb == 0)
+        return 6;
+    if (r8 == 0)
+        return 6;
+
+    _ZN4CP1519InvalidateDataCacheEjj(*(u32 *)(slot + 4) + 0x184, 2);
+    flag5 = *(u16 *)(*(u32 *)(slot + 4) + 0x184);
+    if (flag5 == 0) {
+        _ZN4CP1519InvalidateDataCacheEjj(*(u32 *)(slot + 4) + 0x86, 2);
+        f86 = *(u16 *)(*(u32 *)(slot + 4) + 0x86);
+    }
+
+    state = H(0x41c);
+    if (state == 3)
+        return 1;
+    if (state != 1 && state != 2)
+        return 3;
+
+    slot = 5;
+
+    if (flag5 == 0) {
+        did = 0;
+        fp = did;
+
+        if (state == 2) {
+            u16 n;
+            int cr;
+            H(0x41c) = 1;
+            n = (u16)((H(0x408) + 3) % 4);
+            cr = func_020623ec((int)func_02062d10, (int)(self + ((u32)n << 8)),
+                               H(0x414), (u16)(H(0x40e) & f86), H(0x416), 1);
+            if (cr == 7) {
+                *(u16 *)(self + ((u32)n << 1) + 0x400) = 0xffff;
+                H(0x40a) = (u16)((H(0x40a) + 1) % 4);
+            } else if (cr != 0 && cr != 2) {
+                H(0x41c) = 3;
+                return 1;
+            }
+        }
+
+        if (H(0x40c) != H(0x40a)) {
+            *(u16 *)(self + ((u32)H(0x40c) << 8)) |= 1;
+            MultiCopyHalf(self + ((u32)H(0x40c) << 8), r8, 0x100);
+            did = 1;
+            slot = 0;
+            H(0x41a) = *(u16 *)(self + ((u32)H(0x40c) << 1) + 0x400);
+            H(0x40c) = (u16)((H(0x40c) + 1) % 4);
+
+            if (H(0x418) == 0 && f86 != 0 && *(u16 *)(self + ((u32)H(0x408) << 8)) == 1)
+                fp = did;
+            else
+                fp = 0;
+        }
+
+        func_020627e8(self, 0);
+        if (did != 0) {
+            func_02062990(self, 0, (u32)sb);
+            if (H(0x418) == 0)
+                func_020627e8(self, fp);
+        }
+    } else {
+        int changed;
+
+        changed = 0;
+        if (state == 2) {
+            H(0x41c) = 1;
+            changed = 1;
+        } else {
+            if (H(0x40c) != H(0x408)) {
+                if ((*(u16 *)(self + ((u32)H(0x40c) << 8)) & 1) == 0) {
+                    *(u16 *)(self + ((u32)H(0x40c) << 8)) |= 1;
+                } else {
+                    MultiCopyHalf(self + ((u32)H(0x40c) << 8), r8, 0x100);
+                    changed = 1;
+                    slot = 0;
+                    H(0x41a) = *(u16 *)(self + ((u32)H(0x40c) << 1) + 0x400);
+                    H(0x40c) = (u16)((H(0x40c) + 1) % 4);
+                }
+            }
+        }
+
+        if (changed != 0) {
+            u8 *addr = self + ((u32)H(0x40a) << 8) + 0x20;
+            int cr;
+            MultiCopyHalf(sb, addr, H(0x410));
+            cr = func_020623ec((int)func_02062d10, (int)addr,
+                               H(0x410), H(0x40e), H(0x416), 1);
+            H(0x40a) = (u16)((H(0x40a) + 1) % 4);
+            if (cr != 2 && cr != 0) {
+                H(0x41c) = 3;
+                slot = 1;
+            }
+        }
+    }
+
+    return slot;
+}

--- a/src/func_ov002_020f40fc.c
+++ b/src/func_ov002_020f40fc.c
@@ -1,0 +1,85 @@
+extern short data_02082214[];
+extern int data_ov002_02100120[];
+extern int data_ov002_02100130[];
+extern int func_ov002_020f5a94(char *c);
+
+void func_ov002_020f40fc(char *c, int i)
+{
+    int off = i * 0x4c;
+
+    if (*(unsigned short*)(c + 0x3a + off) == 0) {
+        if (*(unsigned short*)(c + 0x32 + off) == 0) {
+            *(unsigned short*)(c + 0x3c + off) += 1;
+        }
+    }
+
+    if (*(unsigned char*)(c + 0x48 + off) == 0) {
+        int idx;
+        idx = *(unsigned short*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2 + 1];
+            int spd = *(int*)(c + 0x10 + off);
+            *(int*)(c + 0 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x80000;
+        }
+        idx = *(unsigned short*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2];
+            int spd = *(int*)(c + 0x10 + off);
+            *(int*)(c + 4 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x60000;
+        }
+
+        *(unsigned short*)(c + 0x2e + off) -= *(unsigned short*)(c + 0x42 + off);
+        *(int*)(c + 0x24 + off) += *(unsigned short*)(c + 0x42 + off);
+
+        if (*(unsigned char*)(c + 0x48) != 0) {
+            *(unsigned short*)(c + 0x42 + off) += 8;
+        } else {
+            if (*(unsigned short*)(c + 0x42 + off) < 0x200) {
+                *(unsigned short*)(c + 0x42 + off) += 6;
+                if (*(unsigned short*)(c + 0x42 + off) > 0x200)
+                    *(unsigned short*)(c + 0x42 + off) = 0x200;
+            }
+        }
+
+        if ((unsigned int)*(int*)(c + 0x24 + off) >= (unsigned int)data_ov002_02100120[i]
+            && *(unsigned char*)(c + 0x514) == 0) {
+            *(unsigned char*)(c + 0x48 + off) += 1;
+            *(unsigned short*)(c + 0x36 + off) = 0;
+            *(int*)(c + 8 + off) = 0x2000;
+        }
+
+        if (func_ov002_020f5a94(c) != 3)
+            return;
+        if ((unsigned int)*(int*)(c + 0x24 + off) < 0xc000)
+            return;
+        if (i != 2)
+            return;
+        if (*(unsigned char*)(c + 0x514) != 0)
+            return;
+        *(unsigned char*)(c + 0x48 + off) += 1;
+        *(unsigned short*)(c + 0x36 + off) = 0;
+        *(int*)(c + 8 + off) = 0x2000;
+        return;
+    }
+
+    *(unsigned short*)(c + 0x36 + off) += 1;
+    *(int*)(c + 0 + off) += *(int*)(c + 8 + off);
+    *(int*)(c + 8 + off) += 0x300;
+    if (*(unsigned short*)(c + 0x36) < 0x70)
+        return;
+    {
+        int off2 = (int)((long long)i & 0xffffffffffffffffLL) * 0x4c;
+        *(unsigned char*)(c + 0x47 + off2) += 1;
+        *(unsigned short*)(c + 0x3c + off2) = 0;
+        *(unsigned char*)(c + 0x48 + off) = 0;
+        *(int*)(c + 0x10 + off2) = 0x38000;
+        *(unsigned short*)(c + 0x2e + off2) = 0;
+        *(unsigned short*)(c + 0x30 + off2) = data_ov002_02100130[i] << 6;
+        *(int*)(c + 0 + off) = -0x10000;
+        *(int*)(c + 4 + off2) = 0;
+        *(unsigned short*)(c + 0x42 + off2) = 0x100;
+        *(int*)(c + 8 + off) = 0x5800;
+        *(int*)(c + 0x1c + off2) = 0x80000;
+        *(int*)(c + 0x20 + off2) = 0x28000;
+    }
+}

--- a/src/func_ov002_020f4d70.c
+++ b/src/func_ov002_020f4d70.c
@@ -1,0 +1,92 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+typedef unsigned int u32;
+typedef long long s64;
+
+extern short data_02082214[];
+extern int data_ov002_021000e0[];
+extern int data_ov002_021000f0[];
+extern int func_ov002_020f5a94(void *c);
+
+void func_ov002_020f4d70(char *c, int i)
+{
+    int off = i * 0x4c;
+
+    if (*(u16*)(c + 0x3a + off) == 0) {
+        if (*(u16*)(c + 0x32 + off) == 0)
+            (*(u16*)(c + 0x3c + off))++;
+    }
+
+    if (*(u8*)(c + 0x48 + off) == 0) {
+        int idx;
+
+        idx = *(unsigned short*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2 + 1];
+            int spd = *(int*)(c + 0x10 + off);
+            *(int*)(c + 0 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x80000;
+        }
+
+        idx = *(unsigned short*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2];
+            int spd = *(int*)(c + 0x10 + off);
+            *(int*)(c + 4 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x60000;
+        }
+
+        *(u16*)(c + 0x2e + off) += *(u16*)(c + 0x42 + off);
+        *(s32*)(c + 0x24 + off) += *(u16*)(c + 0x42 + off);
+
+        if (*(u8*)(c + 0x48) != 0) {
+            *(u16*)(c + 0x42 + off) += 8;
+        } else {
+            if (*(u16*)(c + 0x42 + off) < 0x200) {
+                *(u16*)(c + 0x42 + off) += 6;
+                if (*(u16*)(c + 0x42 + off) > 0x200)
+                    *(u16*)(c + 0x42 + off) = 0x200;
+            }
+        }
+
+        if ((u32)*(s32*)(c + 0x24 + off) < (u32)data_ov002_021000e0[i])
+            return;
+
+        if (*(u8*)(c + 0x514) != 0)
+            return;
+
+        (*(u8*)(c + 0x48 + off))++;
+        *(u16*)(c + 0x36 + off) = 0;
+        *(s32*)(c + 8 + off) = -0x2000;
+        return;
+    }
+
+    (*(u16*)(c + 0x36 + off))++;
+    *(s32*)(c + 0 + off) += *(s32*)(c + 8 + off);
+    *(s32*)(c + 8 + off) -= 0x300;
+
+    if (*(u16*)(c + 0x36) < 0x70)
+        return;
+
+    {
+        int o2 = (unsigned)i * 0x4c;
+        (*(u8*)(c + 0x47 + o2))++;
+        *(s32*)(c + 0x10 + o2) = 0x38000;
+        *(u16*)(c + 0x2e + o2) = 0x8000;
+        *(u8*)(c + 0x48 + off) = 0;
+        *(u16*)(c + 0x3c + o2) = 0;
+        *(u16*)(c + 0x30 + o2) = data_ov002_021000f0[i] << 6;
+
+        if (func_ov002_020f5a94(c) == 3) {
+            if (i == 2)
+                *(u16*)(c + 0x30 + o2) = 0x40;
+        }
+    }
+
+    *(s32*)(c + 0 + off) = 0x110000;
+    *(s32*)(c + 4 + off) = 0;
+    *(u16*)(c + 0x42 + off) = 0x100;
+    *(s32*)(c + 8 + off) = 0x5800;
+    *(s32*)(c + 0x1c + off) = 0x80000;
+    *(s32*)(c + 0x20 + off) = 0x28000;
+}

--- a/src/func_ov002_020f5328.c
+++ b/src/func_ov002_020f5328.c
@@ -1,0 +1,77 @@
+extern short data_02082214[];
+extern int data_ov002_02100150[];
+extern int data_ov002_02100160[];
+
+void func_ov002_020f5328(char *c, int i)
+{
+    int off = i * 0x4c;
+
+    if (*(unsigned char *)(c + 0x48 + off) == 0) {
+        int idx;
+        {
+            idx = *(unsigned short *)(c + 0x2e + off) >> 4;
+            short tv = data_02082214[idx * 2 + 1];
+            int spd = *(int *)(c + 0x10 + off);
+            *(int *)(c + 0x00 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x80000;
+        }
+        {
+            idx = *(unsigned short *)(c + 0x2e + off) >> 4;
+            short tv = data_02082214[idx * 2];
+            int spd = *(int *)(c + 0x10 + off);
+            *(int *)(c + 0x04 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x60000;
+        }
+
+        *(unsigned short *)(c + 0x2e + off) += *(unsigned short *)(c + 0x42 + off);
+        *(int *)(c + 0x24 + off) += *(unsigned short *)(c + 0x42 + off);
+
+        if (*(unsigned char *)(c + 0x48) != 0) {
+            *(unsigned short *)(c + 0x42 + off) += 8;
+        } else if (*(unsigned short *)(c + 0x42 + off) < 0x200) {
+            *(unsigned short *)(c + 0x42 + off) += 6;
+            if (*(unsigned short *)(c + 0x42 + off) > 0x200)
+                *(unsigned short *)(c + 0x42 + off) = 0x200;
+        }
+
+        if ((unsigned int)*(int *)(c + 0x24 + off) < (unsigned int)data_ov002_02100150[i])
+            return;
+        if (*(unsigned char *)(c + 0x514) != 0)
+            return;
+
+        *(unsigned char *)(c + 0x48 + off) += 1;
+        *(unsigned short *)(c + 0x36 + off) = 0;
+
+        if (i == 1 || i == 3) {
+            *(int *)(c + 0x08 + off) = 0x2000;
+        } else {
+            *(int *)(c + 0x08 + off) = -0x2000;
+        }
+        return;
+    }
+
+    *(unsigned short *)(c + 0x36 + off) += 1;
+    *(int *)(c + 0x00 + off) += *(int *)(c + 0x08 + off);
+    if (i == 1 || i == 3) {
+        *(int *)(c + 0x08 + off) += 0x300;
+    } else {
+        *(int *)(c + 0x08 + off) -= 0x300;
+    }
+
+    if (*(unsigned short *)(c + 0x36) < 0x60)
+        return;
+
+    {
+        int off2 = (int)((unsigned long long)i & 0xFFFFFFFFFFFFFFFFULL) * 0x4c;
+        *(unsigned char *)(c + 0x47 + off2) += 1;
+        *(unsigned short *)(c + 0x3c + off2) = 0;
+        *(unsigned char *)(c + 0x48 + off) = 0;
+        *(int *)(c + 0x10 + off2) = 0x38000;
+        *(unsigned short *)(c + 0x2e + off2) = 0;
+        *(unsigned short *)(c + 0x30 + off2) = (unsigned short)(data_ov002_02100160[i] << 6);
+        *(int *)(c + 0x00 + off) = -0x10000;
+        *(int *)(c + 0x04 + off2) = 0;
+        *(unsigned short *)(c + 0x42 + off2) = 0x100;
+        *(int *)(c + 0x08 + off) = 0x5800;
+        *(int *)(c + 0x1c + off2) = 0x80000;
+        *(int *)(c + 0x20 + off2) = 0x28000;
+    }
+}

--- a/src/func_ov006_020d9c5c.cpp
+++ b/src/func_ov006_020d9c5c.cpp
@@ -1,0 +1,122 @@
+//cpp
+extern "C" {
+    int _Z14ApproachLinearRiii(int* a, int b, int c);
+    int _Z15ApproachLinear2Rsss(short* a, short b, short c);
+    void _ZN5Sound12PlayBank2_2DEj(unsigned int n);
+    int func_ov006_020da8e4(void);
+    unsigned int func_02012790(unsigned int a);
+    extern int data_ov006_0214176c;
+    extern int data_ov006_02141768;
+    extern unsigned char data_020a0e40;
+    extern unsigned char data_020a0de8[];
+    extern unsigned char data_020a0de9[];
+    extern unsigned char data_020a0dea[][4];
+    extern unsigned char data_020a0deb[][4];
+}
+
+struct VObj { virtual int f0(); virtual int f1(); virtual int f2(); };
+
+extern "C" void func_ov006_020d9c5c(void* self)
+{
+    char* c = (char*)self;
+    int r5;
+
+    if (*(unsigned char*)(c + 0x2b) == 0)
+        return;
+
+    if (*(unsigned char*)(c + 0x2b) == 1) {
+        if (*(short*)(c + 0x28) != 0) {
+            _Z15ApproachLinear2Rsss((short*)(c + 0x28), 0, 1);
+            return;
+        }
+        r5 = _Z14ApproachLinearRiii((int*)(c + 8), *(int*)(c + 0x10), *(int*)(c + 0x18));
+        if (_Z14ApproachLinearRiii((int*)(c + 4), *(int*)(c + 0xc), *(int*)(c + 0x14)) != 0 && r5 != 0) {
+            _ZN5Sound12PlayBank2_2DEj(0x144);
+            *(unsigned char*)(c + 0x2b) = 2;
+            *(unsigned char*)(c + 0x2c) = 1;
+        }
+    }
+
+    if (*(unsigned char*)(c + 0x2c) != 0)
+        _Z14ApproachLinearRiii((int*)(c + 0x24), 0x4000, 0x200);
+    else
+        _Z14ApproachLinearRiii((int*)(c + 0x24), 0, 0x200);
+
+    {
+        int st = *(unsigned char*)(c + 0x2b);
+        if (st == 3) {
+            _Z14ApproachLinearRiii((int*)(c + 8), *(int*)(c + 0x10) - 0x10000, 0x2000);
+        } else if (st == 5) {
+            r5 = _Z14ApproachLinearRiii((int*)(c + 8), *(int*)(c + 0x10), *(int*)(c + 0x18));
+            if (_Z14ApproachLinearRiii((int*)(c + 4), *(int*)(c + 0xc), *(int*)(c + 0x14)) != 0 && r5 != 0) {
+                _ZN5Sound12PlayBank2_2DEj(0x144);
+                *(unsigned char*)(c + 0x2b) = 2;
+                *(unsigned char*)(c + 0x2c) = 1;
+            }
+        } else if (st == 2) {
+            _Z14ApproachLinearRiii((int*)(c + 8), *(int*)(c + 0x10), 0x4000);
+        } else if (st == 4 && *(int*)(c + 0x24) == 0) {
+            int result = ((VObj*)c)->f2();
+            if (_Z14ApproachLinearRiii((int*)(c + 8), result, 0x8000) != 0) {
+                *(int*)(c + 4) = 0x80000;
+                *(unsigned char*)(c + 0x2b) = 6;
+                *(unsigned char*)(c + 0x2a) = (unsigned char)func_ov006_020da8e4();
+            }
+        } else if (st == 7) {
+            if (_Z14ApproachLinearRiii((int*)(c + 4), *(int*)(c + 0x1c), 0x6000) != 0)
+                *(unsigned char*)(c + 0x2b) = 8;
+        } else if (st == 9) {
+            _Z14ApproachLinearRiii((int*)(c + 8), 0x80000, 0x6000);
+        } else if (st == 0xa) {
+            if (_Z15ApproachLinear2Rsss((short*)(c + 0x28), 0, 1) != 0)
+                _Z14ApproachLinearRiii((int*)(c + 4), *(int*)(c + 0x1c), *(int*)(c + 0x14));
+        }
+    }
+
+    if (data_ov006_0214176c != 0) {
+        if (*(unsigned char*)(c + 0x2b) == 3) {
+            *(unsigned char*)(c + 0x2b) = 4;
+            *(unsigned char*)(c + 0x2c) = 0;
+        }
+        return;
+    }
+    if (data_ov006_02141768 != 0)
+        return;
+
+    {
+        int idx = data_020a0e40;
+        unsigned char e8;
+        int flag = 0;
+        e8 = data_020a0de8[idx * 4];
+        if (e8 != 0 && data_020a0de9[idx * 4] != 0)
+            flag = 1;
+        if (flag == 0)
+            return;
+        {
+            unsigned char st = *(unsigned char*)(c + 0x2b);
+            if ((unsigned char)(st + 0xfe) > 1)
+                return;
+            if (*(int*)(c + 0x24) != 0x4000)
+                return;
+            {
+                int a = (int)data_020a0dea[idx][0] - (*(int*)(c + 4) >> 12);
+                int b = (int)data_020a0deb[idx][0] - (*(int*)(c + 8) >> 12);
+                if (a <= 7)
+                    return;
+                if (a >= 0x29)
+                    return;
+                if (b <= -1)
+                    return;
+                if (b >= 0x31)
+                    return;
+                if (st == 2) {
+                    func_02012790(0x14f);
+                    *(unsigned char*)(c + 0x2b) = 3;
+                } else {
+                    func_02012790(0x150);
+                    *(unsigned char*)(c + 0x2b) = 2;
+                }
+            }
+        }
+    }
+}

--- a/src/func_ov006_020eac38.c
+++ b/src/func_ov006_020eac38.c
@@ -1,0 +1,115 @@
+typedef struct { int x, y; } Vec2;
+
+extern short data_02082214[];
+extern int data_ov006_0213c958;
+extern void* data_ov006_02142018[];
+extern void* data_ov006_021375c0[];
+extern int data_ov006_0213c97c[];
+extern void* data_ov006_021375a0[];
+
+extern void func_0203d388(int* p, int angle);
+extern void func_0203d680(Vec2* out, const Vec2* in, int scale);
+extern int func_ov006_020ebb40(char* o, int i);
+extern int func_ov006_020ebc08(char* c, int n);
+extern int func_02053200(int x);
+extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(int b, void* attr, int x, int y, int a, int c, int f, int g);
+
+#pragma opt_strength_reduction off
+void func_ov006_020eac38(char* o)
+{
+    struct { int A, B, urot, va0x, res; } t;
+    Vec2 vb0;
+    struct { Vec2 vc0; } s3;
+    struct { Vec2 pos, va, vb, vc, vout; } s;
+    int px, py;
+    int a2i;
+    int i;
+    short rot, ang;
+
+    i = 0;
+    vb0.y = -0x18000;
+    s3.vc0.y = -0x14000;
+    t.A = 0;
+    t.B = 0;
+    vb0.x = 0x2000;
+    s3.vc0.x = 0;
+    t.va0x = 0;
+    for (; i < 5; i++) {
+        rot = ((short*)(o + 0x7a))[i];
+        s.pos.x = *(int*)(o + i*8 + 0x18);
+        s.pos.y = *(int*)(o + i*8 + 0x1c);
+        s.va.x = t.va0x;
+        s.va.y = 0x1000;
+        ang = (short)(*(short*)(o + 0x84) - t.A);
+        func_0203d388(&s.va.x, rot);
+
+        if (*(unsigned char*)(o + 0x94) == 0) {
+            if (i == 0) {
+                rot = (short)(rot + (data_02082214[((unsigned short)ang >> 4) * 2] >> 1));
+            } else {
+                int sinv = data_02082214[((unsigned short)ang >> 4) * 2];
+                rot = (short)(rot + (short)(((long long)sinv * (0x1800 - t.B) + 0x800) >> 12));
+            }
+        }
+
+        if (data_ov006_0213c958 >= 6) {
+            rot = (short)(rot & 0xfc00);
+        }
+        func_0203d680(&s.vout, &s.va, data_02082214[((unsigned short)(ang << 1) >> 4) * 2]);
+        s.pos.x += s.vout.x;
+        s.pos.y += s.vout.y;
+
+        t.res = func_ov006_020ebb40(o, i);
+        px = s.pos.y >> 12;
+        py = s.pos.x >> 12;
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(
+            1,
+            data_ov006_02142018[(a2i = func_ov006_020ebc08(o, i), (t.urot = (unsigned short)rot), a2i)],
+            py, px,
+            t.res, -1, 0x1000,
+            t.urot);
+
+        if (i == 0) {
+            if (*(unsigned char*)(o + 0x94) != 0 && *(int*)(o + 0x48) > 0) {
+                int fp2;
+                int scale;
+                fp2 = (0x3000 - *(int*)(o + 0x48)) >> 12;
+                s.vb.x = vb0.x;
+                s.vb.y = vb0.y;
+                func_0203d388(&s.vb.x, rot);
+                s.vb.x += s.pos.x;
+                s.vb.y += s.pos.y;
+                if (fp2 != 0)
+                    scale = 0x1000;
+                else
+                    scale = func_02053200((data_02082214[((unsigned short)ang >> 4) * 2] >> 2) + 0xc00);
+                _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(
+                    1, data_ov006_021375c0[fp2],
+                    s.vb.x >> 12, s.vb.y >> 12,
+                    -1, -1, scale, t.urot);
+            } else if (*(int*)o == data_ov006_0213c97c[0]) {
+                if ((*(int*)(o + 4) == data_ov006_0213c97c[1] || *(int*)o == 0) &&
+                    *(short*)(o + 0x90) > 0x1a && *(short*)(o + 0x90) < 0x30) {
+                    int idx = s3.vc0.x;
+                    s.vc.x = s3.vc0.x;
+                    s.vc.y = s3.vc0.y;
+                    if (*(short*)(o + 0x90) < 0x26) {
+                        int d = (0x30 - *(short*)(o + 0x90)) * 0x600;
+                        int vy;
+                        s.vc.y = (vy = *(volatile int*)((char*)&s - 4), (idx = 1) ? vy : vy) - d;
+                    }
+                    func_0203d388(&s.vc.x, rot);
+                    s.vc.x += s.pos.x;
+                    s.vc.y += s.pos.y;
+                    _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(
+                        1, data_ov006_021375a0[idx],
+                        s.vc.x >> 12, s.vc.y >> 12,
+                        -1, -1, 0x1000, (unsigned short)(short)(rot & 0xf800));
+                }
+            }
+        }
+
+        t.A += 0x1800;
+        t.B += 0x200;
+    }
+}

--- a/src/func_ov006_02103360.c
+++ b/src/func_ov006_02103360.c
@@ -1,0 +1,88 @@
+extern short data_02082214[];
+extern void func_ov006_02102718(char* c);
+extern void func_ov006_02102864(char* c);
+
+#pragma opt_common_subs off
+void func_ov006_02103360(char *c, int i)
+{
+    int idx;
+    int velX, velY;
+    int idx2;
+
+    idx2 = (*(unsigned short*)(c + i * 0x40 + 0x4600 + 0x94) >> 4) * 2;
+
+    if (data_02082214[idx2] <= 0) {
+        {
+            short tv = data_02082214[idx2 + 1];
+            int spd = *(int*)(c + i * 0x40 + 0x4000 + 0x680);
+            *(int*)(c + 0x4660 + i * 0x40) += (int)(((long long)tv * spd + 0x800) >> 12);
+        }
+
+        idx = *(unsigned short*)(c + i * 0x40 + 0x4600 + 0x94) >> 4;
+        {
+            short tv = data_02082214[idx * 2];
+            int spd = *(int*)(c + i * 0x40 + 0x4000 + 0x680);
+            *(int*)(c + 0x4664 + i * 0x40) += (int)(((long long)tv * spd + 0x800) >> 12);
+        }
+
+        *(int*)(c + 0x4684 + i * 0x40) += 0x10;
+
+        *(int*)(c + 0x4680 + i * 0x40) -= *(int*)(c + i * 0x40 + 0x4000 + 0x684);
+
+        if (*(int*)(c + i * 0x40 + 0x4000 + 0x684) >= 0x600) {
+            *(int*)(c + i * 0x40 + 0x4000 + 0x684) = 0x600;
+        }
+
+        if (*(int*)(c + i * 0x40 + 0x4000 + 0x680) < 0) {
+            *(unsigned char*)(c + i * 0x40 + 0x4000 + 0x699) = 3;
+            *(int*)(c + i * 0x40 + 0x4000 + 0x680) = 0;
+            *(int*)(c + i * 0x40 + 0x4000 + 0x684) = 0;
+            *(int*)(c + i * 0x40 + 0x4000 + 0x66c) = 0;
+            *(int*)(c + i * 0x40 + 0x4000 + 0x668) = 0;
+        }
+    } else {
+        *(int*)(c + 0x4660 + i * 0x40) += *(int*)(c + i * 0x40 + 0x4000 + 0x668);
+        *(int*)(c + 0x4664 + i * 0x40) += *(int*)(c + i * 0x40 + 0x4000 + 0x66c);
+        *(int*)(c + 0x4684 + i * 0x40) += 0x10;
+        *(int*)(c + 0x466c + i * 0x40) += *(int*)(c + i * 0x40 + 0x4000 + 0x684);
+
+        {
+            int v = *(int*)(c + i * 0x40 + 0x4000 + 0x668);
+            int nv;
+            if (v > 0) {
+                nv = v - 0x200;
+                if (nv <= 0) nv = 0;
+            } else if (v < 0) {
+                nv = v + 0x200;
+                if (nv >= 0) nv = 0;
+            } else {
+                *(unsigned char*)(c + i * 0x40 + 0x4000 + 0x699) = 3;
+                *(int*)(c + i * 0x40 + 0x4000 + 0x680) = 0;
+                *(int*)(c + i * 0x40 + 0x4000 + 0x684) = 0;
+                *(int*)(c + i * 0x40 + 0x4000 + 0x668) = 0;
+                return;
+            }
+            *(int*)(c + i * 0x40 + 0x4000 + 0x668) = nv;
+        }
+    }
+
+    {
+        int rawX = *(int*)(c + i * 0x40 + 0x4000 + 0x660);
+        int rawY = *(int*)(c + i * 0x40 + 0x4000 + 0x664);
+        velY = rawY >> 12;
+        *(unsigned short*)(c + 0x4690 + i * 0x40) += *(unsigned short*)(c + i * 0x40 + 0x4600 + 0x92);
+        velX = rawX >> 12;
+    }
+
+    if (velY <= -0x140 || velY >= 0xd0) {
+        *(unsigned char*)(c + i * 0x40 + 0x4000 + 0x699) = 6;
+    }
+    if (velX >= 0x140 || velX <= -0x40) {
+        *(unsigned char*)(c + i * 0x40 + 0x4000 + 0x699) = 6;
+    }
+
+    func_ov006_02102718(c);
+    if (*(unsigned char*)(c + 0x5676) != 0) {
+        func_ov006_02102864(c);
+    }
+}


### PR DESCRIPTION
## Summary
- Fanned out 12 locked, unmatched functions (4 each in ov002/ov006/arm9, sizes 0x288-0x3ec) to Opus agents; escalated every miss to a Fable agent seeded with the Opus draft and its divergence analysis.
- 10/12 reached a byte-exact match; the other 2 (`func_ov006_020ea914`, `func_0201b100`) improved substantially (124->81 and 129->21 words differing) but hit a confirmed register-allocation floor even after a decomp-permuter pass, so they're kept as near-miss seeds rather than included here.
- Every match was independently re-verified against the ROM via `tools/bank.py`'s own oracle (not just each agent's self-report) before being banked here.

## Functions matched
- `func_ov002_020f4d70` (ov002 0x020f4d70)
- `func_ov002_020f40fc` (ov002 0x020f40fc)
- `func_ov002_020f5328` (ov002 0x020f5328)
- `Player::St_Shell_Main` / `_ZN6Player13St_Shell_MainEv` (ov002 0x020cc27c)
- `func_ov006_02103360` (ov006 0x02103360)
- `func_ov006_020d9c5c` (ov006 0x020d9c5c)
- `func_ov006_020eac38` (ov006 0x020eac38)
- `func_02044b30` (arm9 0x02044b30)
- `func_02061188` (arm9 0x02061188)
- `func_02062df0` (arm9 0x02062df0)

Compiler: mwccarm 1.2/sp2p3.

## Test plan
- [x] Each function verified byte-identical against the retail ROM (relocation-aware compare) via `tools/bank.py --apply` (independent re-verify, not agent self-report)