### PR TITLE
Match func_ov020_02113148 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov020_02113148.c
+++ b/src/func_ov020_02113148.c
@@ -1,36 +1,20 @@
-// NONMATCHING: register allocation (f in r0 not ip; dual ldrsh / smulbb operand coloring) (div=22)
-int func_ov020_02113148(int a, short *b, short *c, int d, short e, int f, short g)
+#pragma opt_common_subs off
+int func_ov020_02113148(int a, short* pos, short* vel, int target, short thresh, int accel, short mult)
 {
-    int ip;
-    short lr, r0, r5;
-    ip = f;
-    lr = b[0];
-    r0 = c[0];
-    b[0] = (short)(lr + r0);
-    r5 = b[0];
-    if (r5 != d) {
-        if ((r5 - d) * (lr - d) >= 0)
-            goto cont;
-        {
-            short lim = e;
-            short vel = c[0];
-            if (vel <= -lim || vel >= lim)
-                goto cont;
-        }
+    short old = pos[0];
+    pos[0] = old + vel[0];
+    short now = pos[0];
+    if (now == target
+        || ((now - target) * (old - target) < 0
+            && vel[0] > -thresh && vel[0] < thresh)) {
+        pos[0] = target;
+        vel[0] = 0;
+        return 1;
     }
-    b[0] = (short)d;
-    c[0] = 0;
-    return 1;
-cont:
-    if (r5 >= d)
-        ip = (short)(-ip);
-    {
-        short s0 = c[0];
-        short s1 = c[0];
-        int v = (int)s0 * (int)(short)ip;
-        if (v < 0)
-            ip = (short)ip * (short)g;
-        c[0] = (short)(s1 + ip);
-    }
+    if (now >= target)
+        accel = (short)-accel;
+    if ((short)vel[0] * (short)accel < 0)
+        accel = (short)accel * (short)mult;
+    vel[0] = vel[0] + accel;
     return 0;
 }


### PR DESCRIPTION
## Summary
- upgrades the committed `func_ov020_02113148` NONMATCHING hatch to byte-identical C
- uses the relocation-compatible structural sibling shape discovered by the family-first clone pass
- preserves readable position/velocity names while reproducing the retail register allocation

## Verification
- `tools/match.py --c src/func_ov020_02113148.c --func func_ov020_02113148 --addr 0x02113148 --size 0xb0 --version 1.2/sp2p3 --module ov020 --strict-relocs` -> MATCH
- `tools/linkcheck.py --name func_ov020_02113148 --addr 0x02113148 --size 0xb0 --module ov020` -> VERIFIED, diffs=[], blind=0

Model: OpenAI Codex Sol 5.6
Reasoning: high
Harness: Codex Desktop native agent + qemu-i386/wibo compiler backend