### PR TITLE
VERIFY: 4 stranded near-miss drafts (do not merge — CI verdict probe)

### DIFF
--- a/src/func_ov004_020b38ac.c
+++ b/src/func_ov004_020b38ac.c
@@ -1,0 +1,55 @@
+typedef long long s64;
+typedef unsigned short u16;
+extern int func_02053200(int x);
+extern void func_ov004_020b1c68(void *a0, int a1, int a2, int a3, int a4, int a5);
+
+void func_ov004_020b38ac(char *sl)
+{
+    int s[4];
+    char *sb;
+    int base;
+    int step;
+    int w0;
+    int *sp8;
+    int zero;
+    u16 lim;
+
+    {
+        int tmp = *(int *)(sl + 0x24);
+        sb = sl + 0x34;
+        base = tmp >> 2;
+    }
+    step = 0x1000;
+    w0 = step;
+    sp8 = s;
+    zero = 0;
+    lim = 0xffff;
+    do {
+        int d = base - step;
+        int weight = w0;
+        int w;
+        if (d < 0)
+            d = -d;
+        if (d < 0x1000) {
+            s64 t = (s64)(0x1000 - d) << 10;
+            t = t + 0x800;
+            weight = weight + (int)(t >> 12);
+        }
+        w = func_02053200(weight);
+        sp8[0] = zero;
+        sp8[1] = zero;
+        sp8[2] = zero;
+        sp8[3] = zero;
+        s[0] = w;
+        s[3] = w;
+        func_ov004_020b1c68(sb, *(short *)(sl + 0x10), *(short *)(sl + 0x12),
+                            *(int *)(sl + 0x1c), *(int *)(sl + 0x18), (int)sp8);
+        {
+            u16 field = *(u16 *)(sb + 6);
+            step += 0x1000;
+            sb += 8;
+            if (field == lim)
+                break;
+        }
+    } while (1);
+}

--- a/src/func_ov063_02119074.c
+++ b/src/func_ov063_02119074.c
@@ -1,0 +1,81 @@
+typedef short s16;
+typedef unsigned short u16;
+struct Vector3 { int x, y, z; };
+
+extern void func_ov063_02116bf0(char *c);
+extern void func_ov063_02119c18(void *c, unsigned int id);
+extern int func_ov063_0211ad00(char *c);
+extern void _ZN5Model12SetPolygonIDEi(void *self, int id);
+extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int fix, int loop);
+extern char *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *p);
+extern s16 Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
+extern void func_ov063_02116244(char *c);
+extern void func_ov063_0211adfc(char *p);
+
+extern int data_ov063_0211e1d0[];
+extern int data_0209b490;
+
+void func_ov063_02119074(char *self)
+{
+    unsigned char s = *(unsigned char *)(self + 0x5cf);
+
+    if (s == 0xc || s == 0xf) {
+        func_ov063_02116bf0(self);
+        *(int *)(self + 0x180) = 0xa;
+    }
+    if (*(unsigned char *)(self + 0x5cf) == 0xd)
+        func_ov063_02119c18(self, 0x9f);
+
+    *(int *)(self + 0x490) = 0;
+    *(unsigned char *)(self + 0x5c8) = 0x28;
+
+    if (func_ov063_0211ad00(self) != 0 && *(int *)(self + 0x180) >= 5) {
+        u16 *ip = (u16 *)(((long long)(int)(self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+        int scale;
+        *ip |= 8;
+        *(unsigned char *)(self + 0x5ca) = 3;
+        scale = data_ov063_0211e1d0[*(unsigned char *)(self + 0x5cf) - 0xc];
+        *(int *)(self + 0x584) = scale;
+        *(int *)(self + 0x80) = scale;
+        *(int *)(self + 0x84) = scale;
+        *(int *)(self + 0x88) = scale;
+        _ZN5Model12SetPolygonIDEi(self + 0x380, 0x16);
+
+        if (*(unsigned char *)(self + 0x5cf) == 0xd) {
+            *(int *)(self + 0x57c) = data_0209b490;
+            if ((((unsigned)*(u16 *)(self + 0x5d4) << 0x16) >> 0x1f) == 0) {
+                _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x6b000, 1);
+                *(u16 *)(self + 0x5c6) = 1;
+                {
+                    u16 *h = (u16 *)(((long long)(int)(self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *h |= 0x200;
+                }
+            }
+            *(int *)(self + 0x98) = 0x800;
+            *(unsigned char *)(self + 0x5cc) = 5;
+            {
+                char *r = _ZN5Actor15FindWithActorIDEjPS_(0x9f, 0);
+                if (r != 0)
+                    *(s16 *)(self + 0x94) = Vec3_HorzAngle((struct Vector3 *)(self + 0x5c), (struct Vector3 *)(r + 0x5c));
+            }
+        } else {
+            if (*(unsigned char *)(self + 0x5cf) == 0xe)
+                func_ov063_02116244(self);
+            *(unsigned char *)(self + 0x5cc) = 1;
+        }
+
+        *(unsigned char *)(self + 0x5c9) = 0xff;
+        *(int *)(self + 0x188) = *(int *)(self + 0x590) * *(int *)(self + 0x584);
+        *(int *)(self + 0x18c) = *(int *)(self + 0x594) * *(int *)(self + 0x584);
+        {
+            int *p = (int *)(self + 0x19c);
+            *p &= ~1;
+        }
+    } else {
+        u16 *h = (u16 *)(((long long)(int)(self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(self + 0x19c);
+        *h &= ~8;
+        *p |= 1;
+        func_ov063_0211adfc(self);
+    }
+}

--- a/src/func_ov063_0211a3d0.cpp
+++ b/src/func_ov063_0211a3d0.cpp
@@ -1,0 +1,73 @@
+//cpp
+struct Vec3 { int x, y, z; };
+extern "C" {
+extern int _ZNK12WithMeshClsn8IsOnWallEv(void* self);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vec3& v);
+extern void _ZN5Actor8PoofDustEv(void* self);
+extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
+extern void func_ov063_02116244(char* c);
+}
+
+extern "C" int func_ov063_0211a3d0(char* c)
+{
+    if (*(unsigned short*)(c + 0x100) == 0) {
+        *(int*)(c + 0x98) = 0x28000;
+        *(short*)(c + 0x94) = *(short*)(*(char**)(c + 0x484) + 0x8e);
+        *(int*)(c + 0x5a0) = 1;
+        {
+            unsigned short* f = (unsigned short*)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+            *f &= ~4;
+        }
+    } else {
+        if (*(unsigned short*)(c + 0x100) == 5)
+            *(unsigned char*)(c + 0x5c9) = 8;
+        if (*(unsigned short*)(c + 0x100) > 0x1e || _ZNK12WithMeshClsn8IsOnWallEv(c + 0x1c4) != 0) {
+            if (*(unsigned char*)(c + 0x5cf) == 0xf) {
+                int x = *(int*)(c + 0x5c);
+                volatile int s[3];
+                int y;
+                Vec3 v;
+                s[0] = x;
+                s[1] = *(int*)(c + 0x60);
+                s[2] = *(int*)(c + 0x64);
+                y = s[1];
+                if (((unsigned)(*(unsigned short*)(c + 0x5d4) << 23)) >> 31)
+                    s[0] = (int)(x * 0xFFFFFFFFu);
+                v.x = s[0];
+                v.y = y;
+                v.z = s[2];
+                _ZN5Actor10PoofDustAtERK7Vector3(c, v);
+            } else {
+                _ZN5Actor8PoofDustEv(c);
+            }
+            *(int*)(c + 0x5a0) = 2;
+            if (*(unsigned char*)(c + 0x5cf) != 0) {
+                unsigned int id = *(unsigned int*)(c + 0x490);
+                if (id != 0) {
+                    *(void**)(c + 0x48c) = _ZN5Actor10FindWithIDEj(id);
+                    {
+                        char* a = *(char**)(c + 0x48c);
+                        if (a != 0) {
+                            if (*(unsigned char*)(c + 0x5cf) != 2) {
+                                int* p = (int*)(((long long)(int)(a + 0x180)) & 0xFFFFFFFFFFFFFFFFLL);
+                                *p = *p + 1;
+                            }
+                            func_ov063_02116244(*(char**)(c + 0x48c));
+                        }
+                    }
+                    *(void**)(c + 0x48c) = 0;
+                }
+            }
+            return 1;
+        }
+    }
+
+    *(int*)(c + 0xa8) = 0x5000;
+    {
+        short* a = (short*)(((long long)(int)(c + 0x90)) & 0xFFFFFFFFFFFFFFFFLL);
+        short* b = (short*)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+        *a = *a + 0x800;
+        *b = *b + 0x800;
+    }
+    return 0;
+}

--- a/src/func_ov075_0211867c.c
+++ b/src/func_ov075_0211867c.c
@@ -1,0 +1,118 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int func_0203da9c(void);
+extern u8 func_02020168(void);
+extern void func_02020304(void);
+extern void func_020200e0(void);
+extern void func_ov075_0211a148(char* c, void* a, int b);
+extern void func_02012790(int a);
+extern int func_0203d9b4(void);
+extern void func_02020334(void);
+extern int func_ov075_02116d40(void* c);
+extern void func_02020124(void);
+extern void func_02020768(void* p);
+
+extern char data_ov075_0211d810[];
+extern u8 data_0209fc5c[];
+extern u16 data_020a0e58[];
+extern u8 data_020a0de8[];
+extern int data_0208ee44;
+extern u8 data_0209b2f0[];
+
+void func_ov075_0211867c(void* self)
+{
+    char* c = (char*)self;
+    int id = func_0203da9c();
+
+    if (func_02020168() != 0) {
+        func_02020304();
+        func_020200e0();
+        func_ov075_0211a148(c, data_ov075_0211d810, 5);
+        func_02012790(0x124);
+    } else {
+        if (func_0203d9b4() != 0) {
+            if (*(int*)(c + 0x274) == 0) {
+                int r3 = 0;
+                int i = 0;
+                u8* g = data_0209fc5c;
+                for (; i < 4; i++, g++) {
+                    if (*g != 0) {
+                        u16* hw = (u16*)((char*)data_020a0e58 + (i << 2));
+                        int bits = hw[1] & 0xc;
+                        r3 |= bits;
+                        if (data_020a0de8[i << 2] != 0) {
+                            int b = 0;
+                            if (data_020a0de8[(i << 2) + 1] != 0)
+                                b = 1;
+                            r3 |= b;
+                        } else {
+                            r3 |= 0;
+                        }
+                    }
+                }
+                {
+                    int *q = (int*)(c + 0x264);
+                    *q = *q - data_0208ee44;
+                }
+                {
+                    int t = *(int*)(c + 0x264);
+                    if (t <= 0)
+                        goto do_stop;
+                    if (t >= 0x21c)
+                        goto after_timer;
+                    if (r3 == 0)
+                        goto after_timer;
+                do_stop:
+                    func_02020334();
+                    *(int*)(c + 0x274) = 1;
+                }
+            } else {
+                if (func_ov075_02116d40(c) != 0)
+                    func_02020124();
+            }
+        } else {
+            if (*(int*)(c + 0x274) == 0) {
+                {
+                    int *q = (int*)(c + 0x264);
+                    *q = *q - data_0208ee44;
+                }
+                if (*(int*)(c + 0x264) < 0x1e0) {
+                    func_02020334();
+                    *(int*)(c + 0x274) = 1;
+                }
+            }
+        }
+    after_timer:
+        {
+            int r = func_0203da9c();
+            u16 v = *(u16*)((char*)data_020a0e58 + (r << 2));
+            if ((v & ~0xc) != 0)
+                func_02012790(0xe);
+        }
+    }
+
+    func_02020768(c + 0x1b4);
+    func_02020768(c + 0x1e0);
+    func_02020768(c + 0x20c);
+    {
+        u8 *bp = data_0209b2f0 + id;
+        if (*bp == 0)
+            func_02020768(c + 0x238);
+    }
+
+    if (*(u8*)(c + 0x1d9) != 0)
+        return;
+    if (*(u8*)(c + 0x205) != 0)
+        return;
+
+    *(u8*)(c + 0x1da) = 0;
+    *(u8*)(c + 0x205) = 1;
+    *(u8*)(c + 0x206) = 1;
+    if (*(u8*)(data_0209b2f0 + id) == 0) {
+        *(u8*)(c + 0x231) = 1;
+        *(u8*)(c + 0x232) = 1;
+        *(u8*)(c + 0x25d) = 1;
+        *(u8*)(c + 0x25e) = 1;
+    }
+}


### PR DESCRIPTION
Probe only. Four uncommitted near-miss drafts salvaged from an overnight session's working tree, already banked in nearmiss/db.jsonl. Opening to get CI's authoritative per-file verdict (local match.py is stale on this box). Expect validate to FAIL overall; reading the per-file table to confirm each is a near-miss (no action) or catch any that is secretly a real match (salvage it). Will close after reading.