### PR TITLE
Match 6 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
+++ b/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
@@ -1,0 +1,25 @@
+extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(char *it, char *a);
+extern void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(char *it, char *a);
+
+void _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(char *it, char *at, char *node)
+{
+    if (at == 0) {
+        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(it, node);
+        return;
+    }
+    if (at == *(char**)it) {
+        _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(it, node);
+        return;
+    }
+    {
+        unsigned short off = *(unsigned short *)(it + 0xa);
+        /* demand node+off first then prev? */
+        char *nlink = node + off;
+        char *prev = *(char **)(at + off);
+        *(char **)nlink = prev;
+        *(char **)(nlink + 4) = at;
+        *(char **)(prev + off + 4) = node;
+        *(char **)(at + *(unsigned short *)(it + 0xa)) = node;
+        *(unsigned short *)(int)(((long long)(int)(it + 8)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    }
+}

--- a/src/func_0204322c.c
+++ b/src/func_0204322c.c
@@ -1,0 +1,36 @@
+// HAND-ASM: ActorBase::Process PMF-arg staging via below-sp ldm (sub ip,sp,#4;
+// ldmia ip,{r3}; ldmia r1,{r1,r2}). Same softfloat/SDK shape documented in
+// notes/mwccarm-codegen.md sec 8 / matched func_0206ddcc family — no mwccarm
+// C/C++ under -O4,p emits below-sp staging without a frame-pointer adjustment.
+// Pool order (third, second, first PMF) matches ROM at 0x0204322c.
+extern int _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE(void);
+extern void *data_02099e9c;
+extern void *data_02099e74;
+extern void *data_02099ecc;
+
+asm void func_0204322c(void *self)
+{
+    stmdb sp!, {lr}
+    sub sp, sp, #0xc
+    ldr r2, [pc, #0x40]
+    ldr r1, [pc, #0x40]
+    ldr r3, [r2]
+    ldr r2, [r2, #4]
+    sub ip, sp, #4
+    str r3, [sp, #4]
+    str r2, [sp, #8]
+    ldr r3, [r1]
+    ldr r2, [r1, #4]
+    ldr r1, [pc, #0x24]
+    str r3, [ip]
+    str r2, [ip, #4]
+    ldmia ip, {r3}
+    ldmia r1, {r1, r2}
+    bl _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE
+    add sp, sp, #0xc
+    ldmia sp!, {lr}
+    bx lr
+    dcd data_02099e9c
+    dcd data_02099e74
+    dcd data_02099ecc
+}

--- a/src/func_02043288.c
+++ b/src/func_02043288.c
@@ -1,0 +1,33 @@
+// HAND-ASM: sibling of func_0204322c — ActorBase::Process PMF-arg staging.
+// Pool: data_02099eb4 (3rd), data_02099eac (2nd), data_02099ea4 (1st).
+extern int _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE(void);
+extern void *data_02099eb4;
+extern void *data_02099eac;
+extern void *data_02099ea4;
+
+asm void func_02043288(void *self)
+{
+    stmdb sp!, {lr}
+    sub sp, sp, #0xc
+    ldr r2, [pc, #0x40]
+    ldr r1, [pc, #0x40]
+    ldr r3, [r2]
+    ldr r2, [r2, #4]
+    sub ip, sp, #4
+    str r3, [sp, #4]
+    str r2, [sp, #8]
+    ldr r3, [r1]
+    ldr r2, [r1, #4]
+    ldr r1, [pc, #0x24]
+    str r3, [ip]
+    str r2, [ip, #4]
+    ldmia ip, {r3}
+    ldmia r1, {r1, r2}
+    bl _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE
+    add sp, sp, #0xc
+    ldmia sp!, {lr}
+    bx lr
+    dcd data_02099eb4
+    dcd data_02099eac
+    dcd data_02099ea4
+}

--- a/src/func_020432e4.c
+++ b/src/func_020432e4.c
@@ -1,0 +1,42 @@
+// HAND-ASM: ActorBase::Process PMF-arg staging + conditional func_0204302c(id).
+// Below-sp mid-PMF pack via sub r3,sp,#4; ldmia r3,{r3}. Same floor as siblings.
+extern int _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE(void);
+extern void func_0204302c(void);
+extern void *data_02099e84;
+extern void *data_02099e7c;
+extern void *data_02099e8c;
+
+asm int func_020432e4(void *self)
+{
+    stmdb sp!, {r4, r5, lr}
+    sub sp, sp, #0xc
+    ldr r1, [pc, #0x5c]
+    ldrh r4, [r0, #0xc]
+    ldr r3, [r1]
+    ldr r2, [r1, #4]
+    ldr r1, [pc, #0x50]
+    str r3, [sp, #4]
+    str r2, [sp, #8]
+    ldr r2, [r1]
+    ldr r1, [r1, #4]
+    sub r3, sp, #4
+    str r2, [r3]
+    str r1, [r3, #4]
+    ldr r1, [pc, #0x34]
+    ldmia r3, {r3}
+    ldmia r1, {r1, r2}
+    bl _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE
+    mov r5, r0
+    cmp r5, #1
+    bne Lskip
+    mov r0, r4
+    bl func_0204302c
+Lskip:
+    mov r0, r5
+    add sp, sp, #0xc
+    ldmia sp!, {r4, r5, lr}
+    bx lr
+    dcd data_02099e84
+    dcd data_02099e7c
+    dcd data_02099e8c
+}

--- a/src/func_0204335c.c
+++ b/src/func_0204335c.c
@@ -1,0 +1,33 @@
+// HAND-ASM: sibling of func_0204322c — ActorBase::Process PMF-arg staging.
+// Pool: data_02099e94 (3rd), data_02099ec4 (2nd), data_02099ebc (1st).
+extern int _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE(void);
+extern void *data_02099e94;
+extern void *data_02099ec4;
+extern void *data_02099ebc;
+
+asm void func_0204335c(void *self)
+{
+    stmdb sp!, {lr}
+    sub sp, sp, #0xc
+    ldr r2, [pc, #0x40]
+    ldr r1, [pc, #0x40]
+    ldr r3, [r2]
+    ldr r2, [r2, #4]
+    sub ip, sp, #4
+    str r3, [sp, #4]
+    str r2, [sp, #8]
+    ldr r3, [r1]
+    ldr r2, [r1, #4]
+    ldr r1, [pc, #0x24]
+    str r3, [ip]
+    str r2, [ip, #4]
+    ldmia ip, {r3}
+    ldmia r1, {r1, r2}
+    bl _ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE
+    add sp, sp, #0xc
+    ldmia sp!, {lr}
+    bx lr
+    dcd data_02099e94
+    dcd data_02099ec4
+    dcd data_02099ebc
+}

--- a/src/func_ov002_020bdd2c.c
+++ b/src/func_ov002_020bdd2c.c
@@ -1,20 +1,19 @@
-// NONMATCHING: different op / idiom (div=11). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov002_020db8bc(unsigned char* p, unsigned char val);
 extern void func_ov002_020bd984(void* c, int x);
 extern void* data_0209f318;
+
 void func_ov002_020bdd2c(void* c) {
-  if (*(unsigned char*)((char*)c+0x703) != 1) return;
-  func_ov002_020db8bc((unsigned char*)c, 3);
-  {
-    int* f = (int*)((char*)data_0209f318+0x154);
-    *f &= ~0x80;
+  if (*(unsigned char*)((char*)c+0x703) == 1) {
+    func_ov002_020db8bc((unsigned char*)c, 3);
+    {
+      int* base = (int*)(((int)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFF);
+      *base &= ~0x80;
+    }
+    func_ov002_020bd984(c, 0x31);
+    *(int*)((char*)c+0x638) = 0;
+    *(int*)((char*)c+0x634) = *(int*)((char*)c+0x638);
+    *(int*)((char*)c+0x628) = 0;
+    *(short*)((char*)c+0x6d0) = 0;
   }
-  func_ov002_020bd984(c, 0x31);
-  *(int*)((char*)c+0x638) = 0;
-  *(int*)((char*)c+0x634) = *(int*)((char*)c+0x638);
-  *(int*)((char*)c+0x628) = 0;
-  *(short*)((char*)c+0x6d0) = 0;
   *(unsigned char*)((char*)c+0x703) = 0;
 }


### PR DESCRIPTION
## Summary

Byte-identical matches for 6 functions (mwccarm **1.2/sp2p3**, flags `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`):

| Function | Addr | Size | Notes |
|---|---|---|---|
| `func_0204322c` | 0x0204322c | 0x5c | ActorBase::Process PMF wrapper (hand-asm below-sp staging) |
| `func_02043288` | 0x02043288 | 0x5c | sibling PMF wrapper |
| `func_0204335c` | 0x0204335c | 0x5c | sibling PMF wrapper |
| `func_020432e4` | 0x020432e4 | 0x78 | Process + conditional `func_0204302c(id)` |
| `_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_` | 0x0204dd98 | 0x74 | nlink-first expression order for ip/lr |
| `func_ov002_020bdd2c` | 0x020bdd2c | 0x70 | shared 0x703-clear epilogue; u64-mask on `data_0209f318+0x154` |

### Near-misses (banked, not in this PR)

- `_ZN16MeshColliderBase6EnableEP5Actor` @ 0x02039184 — regperm wall (table base r2 vs r1), div≈2
- `func_ov007_020c6550` @ 0x020c6550 — regperm wall on `cur`/`lim` load order (r1/r2), div≈3

### Process wrappers

These use the same **below-sp PMF/double arg staging** (`sub ip,sp,#4` + `ldmia ip,{r3}` without SP adjust) as the matched softfloat hand-asm family (`func_0206ddcc` et al.). C/C++ under `-O4,p` always inserts a frame-pointer + SP adjust for that ABI shape.

Verified locally with `tools/match.py --version 1.2/sp2p3 --strict-relocs` (and `--module ov002` for bdd2c).