### PR TITLE
Match 7 functions via Opus->Fable escalation fan-out (batch 2)

### DIFF
--- a/src/InvMat4x3.c
+++ b/src/InvMat4x3.c
@@ -1,0 +1,64 @@
+typedef signed int s32;
+typedef signed long long s64;
+
+extern void _ZN4cstd16reciprocal_asyncE5Fix12IiE(int a);
+extern int _ZN4cstd11fdiv_resultEv(void);
+extern void Copy48Bytes(int *src, int *dst);
+
+int InvMat4x3(int *src, int *dst)
+{
+    s32 buf[12];
+    int *out;
+    int p, q, r;
+    int det;
+    int recip;
+
+    out = (src == dst) ? buf : dst;
+
+    p = (int)(((s64)src[4] * src[8] - (s64)src[5] * src[7] + 0x800) >> 12);
+    q = (int)(((s64)src[3] * src[8] - (s64)src[5] * src[6] + 0x800) >> 12);
+    r = (int)(((s64)src[3] * src[7] - (s64)src[4] * src[6] + 0x800) >> 12);
+
+    det = (int)(((s64)src[0] * p - (s64)src[1] * q + (s64)src[2] * r + 0x800) >> 12);
+    if (det == 0) {
+        return -1;
+    }
+
+    _ZN4cstd16reciprocal_asyncE5Fix12IiE(det);
+
+    {
+        int x1 = (int)(((s64)src[1] * src[8] - (s64)src[7] * src[2]) >> 12);
+        int x2 = (int)(((s64)src[1] * src[5] - (s64)src[4] * src[2]) >> 12);
+        int x3 = (int)(((s64)src[0] * src[8] - (s64)src[6] * src[2]) >> 12);
+        int x4 = (int)(((s64)src[0] * src[5] - (s64)src[3] * src[2]) >> 12);
+
+        recip = _ZN4cstd11fdiv_resultEv();
+
+        out[0] = (int)(((s64)recip * p) >> 12);
+        out[1] = -(int)(((s64)recip * x1) >> 12);
+        out[2] = (int)(((s64)recip * x2) >> 12);
+        out[3] = -(int)(((s64)recip * q) >> 12);
+        out[4] = (int)(((s64)recip * x3) >> 12);
+        out[5] = -(int)(((s64)recip * x4) >> 12);
+        out[6] = (int)(((s64)recip * r) >> 12);
+    }
+
+    {
+        int x5 = (int)(((s64)src[0] * src[7] - (s64)src[6] * src[1]) >> 12);
+        out[7] = -(int)(((s64)recip * x5) >> 12);
+    }
+    {
+        int x6 = (int)(((s64)src[0] * src[4] - (s64)src[3] * src[1]) >> 12);
+        out[8] = (int)(((s64)recip * x6) >> 12);
+    }
+
+    out[9]  = -(int)((((s64)out[0] * src[9]) + ((s64)out[3] * src[10]) + ((s64)out[6] * src[11])) >> 12);
+    out[10] = -(int)((((s64)out[1] * src[9]) + ((s64)out[4] * src[10]) + ((s64)out[7] * src[11])) >> 12);
+    out[11] = -(int)((((s64)out[2] * src[9]) + ((s64)out[5] * src[10]) + ((s64)out[8] * src[11])) >> 12);
+
+    if (out == buf) {
+        Copy48Bytes(buf, dst);
+    }
+
+    return 0;
+}

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -1,0 +1,157 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+
+extern "C" {
+extern int func_ov002_020d82f0(void* c);
+extern int _ZN6Player8HasNoCapEv(char* c);
+extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
+extern void func_ov002_020d91b8(char* self, int a);
+extern void func_ov002_020d5cec(char* c);
+extern s16 Vec3_HorzAngle(const void* v0, const void* v1);
+extern int AngleDiff(int a, int b);
+extern void func_02014fa4(char* c);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, int a, int b, int cc);
+extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
+extern int func_ov002_020d91e0(char* thiz, int damage, int doPre);
+
+extern u16 data_ov002_020ff128[];
+extern int data_ov002_02110094;
+extern int data_ov002_0211010c;
+extern int data_ov002_021100ac;
+}
+
+extern "C" int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char* c, void* a, u32 b, int dmg, u8 arg4, u8 arg5, u8 arg6)
+{
+    s16 ang;
+    void* p360;
+    int hasCap;
+
+    if (func_ov002_020d82f0(c) == 0) {
+        return 0;
+    }
+
+    if (arg5 != 0) {
+        if ((int)b < 2) {
+            b += 2;
+        }
+    }
+
+    hasCap = _ZN6Player8HasNoCapEv(c);
+    if (hasCap != 0) goto L88;
+    if (*(u8*)(c + 0x6d9) == *(int*)(c + 8)) goto L88;
+    if (*(u8*)(c + 0x6f9) != 0) goto L88;
+    if (b == 0) goto L88;
+
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x22, c + 0x74);
+    goto L9c;
+
+L88:
+    {
+        int t = 0;
+        if ((int)b > 1) t = 1;
+        func_ov002_020d91b8(c, t);
+    }
+
+L9c:
+    if (*(u8*)(c + 0x6f9) != 0) {
+        b = 0;
+    }
+    p360 = *(void**)(c + 0x360);
+    if (p360 != 0) {
+        int match = (*(u16*)((char*)p360 + 0xc) == 0xbf);
+        if (match) {
+            func_ov002_020d5cec((char*)p360);
+            *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+        }
+        *(u8*)(c + 0x714) = 0;
+        {
+            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p |= 0x80000;
+        }
+        {
+            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p &= ~0x40000;
+        }
+        {
+            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            *p &= ~0x20000;
+        }
+        *(void**)(c + 0x360) = 0;
+    }
+
+    *(u8*)(c + 0x6e3) = 0;
+
+    if (b != 0) {
+        int neq = 0;
+        if (*(u8*)(c + 0x6d9) != *(int*)(c + 8)) neq = 1;
+        if (neq) *(u8*)(c + 0x6e3) = 2;
+    }
+    if ((int)b > 1) {
+        *(u8*)(c + 0x6e3) = 2;
+    }
+    if (*(u8*)(c + 0x6de) != 0) {
+        *(u8*)(c + 0x6e3) = 4;
+    }
+
+    ang = Vec3_HorzAngle(c + 0x5c, a);
+    if (AngleDiff(*(s16*)(c + 0x8e), ang) > 0x4000) {
+        *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    }
+    *(s16*)(c + 0x94) = ang + 0x8000;
+    if (*(u8*)(c + 0x6e3) & 1) {
+        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+    } else {
+        *(s16*)(c + 0x8e) = ang;
+    }
+
+    if (arg4 == 1) {
+        u16 tv = data_ov002_020ff128[*(int*)(c + 8)];
+        dmg = (dmg * tv) / 100;
+    }
+    *(int*)(c + 0x98) = dmg;
+
+    if (arg5 != 0) {
+        u8 t = arg5 - 1;
+        *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+        *(u8*)(c + 0x6e5) = t;
+    }
+
+    func_02014fa4(c + 0x314);
+    *(int*)(c + 0x674) = b;
+
+    if (*(u8*)(c + 0x706) == 0) {
+        if (*(int*)(c + 0x674) != 0) {
+            if (arg6 != 0) {
+                volatile struct { int x, y, z; } v;
+                int y = *(int*)(c + 0x60);
+                int z = *(int*)(c + 0x64);
+                int x = *(int*)(c + 0x5c);
+                y = y + 0x50000;
+                v.x = x;
+                v.y = y;
+                v.z = z;
+                if (*(volatile int*)(c + 0x674) == 1) {
+                    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xcb, x, y, z);
+                    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xcc, v.x, v.y, v.z);
+                } else {
+                    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xc9, x, y, z);
+                    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xca, v.x, v.y, v.z);
+                }
+            }
+        }
+
+        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_02110094);
+        if (func_ov002_020d91e0(c, b << 8, 1) != 0) {
+            *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) &= 1;
+            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211010c);
+        }
+    } else {
+        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021100ac);
+        func_ov002_020d91e0(c, b << 8, 1);
+    }
+
+    return 1;
+}

--- a/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
+++ b/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
@@ -1,0 +1,125 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+extern "C" {
+    int func_0203da3c(void);
+    int func_0206045c(void);
+    int func_02057020(void);
+    void func_0205ff80(u16 a);
+    void func_0205ff70(u16 a);
+    void func_02057078(u16 lockID);
+    int func_02060484(int a, int b, int c, int d, int e, int f);
+}
+
+extern u8 data_020a4b40[8];
+
+extern "C" int _ZN8SaveData14SaveDataToCartEPcjj(char* data, u32 size, u32 fileID)
+{
+    int lockID;
+    u16 sum = 0;
+    int freeVal;
+    int retry;
+    int v14, v18, v10;
+    int hdrOff, dataOff;
+    int need;
+    int newBase;
+    int v20, v24, v1c;
+    int hdrOff2, dataOff2;
+    int retry2;
+
+    if (func_0203da3c() == 2)
+        return 1;
+
+    freeVal = (int)((u32)func_0206045c() >> 1);
+    need = (int)(fileID << 7);
+    if ((u32)freeVal <= (u32)need)
+        return 1;
+    if (size > (u32)(freeVal - need - 10))
+        return 1;
+
+    sum = 0;
+    {
+        int i = 0;
+        u16 acc = 0;
+        const u8* t = data_020a4b40;
+        do {
+            u8 c = *t;
+            i++;
+            acc = (u16)(acc + c);
+            t++;
+        } while (i < 8);
+        sum = acc;
+    }
+
+    {
+        u32 i;
+        for (i = 0; i < size; i++) {
+            sum = (u16)(((sum << 1) & 0xfffe) | ((sum >> 15) & 1));
+            sum = (u16)(sum ^ (((u8)data[i]) & 0xff));
+        }
+    }
+
+    lockID = func_02057020();
+    if (lockID == -3)
+        return 1;
+
+    func_0205ff80((u16)lockID);
+
+    retry = 0;
+    v14 = 0;
+    v18 = 0;
+    v10 = 0;
+    hdrOff = need + 2;
+    dataOff = need + 10;
+    goto body1;
+
+inc1:
+    retry++;
+    if (retry <= 0)
+        goto body1;
+    func_0205ff70((u16)lockID);
+    func_02057078((u16)lockID);
+    return 1;
+
+body1:
+    if (func_02060484(need, (int)&sum, 2, v10, v10, v10) != 1)
+        goto inc1;
+    if (func_02060484(hdrOff, (int)data_020a4b40, 8, v14, v14, v14) != 1)
+        goto inc1;
+    if (func_02060484(dataOff, (int)data, (int)size, v18, v18, v18) != 1)
+        goto inc1;
+
+    func_0205ff70((u16)lockID);
+    func_0205ff80((u16)lockID);
+
+    retry2 = 0;
+    newBase = freeVal + need;
+    v20 = 0;
+    v24 = 0;
+    v1c = 0;
+    hdrOff2 = newBase + 2;
+    dataOff2 = newBase + 10;
+    goto body2;
+
+inc2:
+    retry2++;
+    if (retry2 <= 0)
+        goto body2;
+    func_0205ff70((u16)lockID);
+    func_02057078((u16)lockID);
+    return 1;
+
+body2:
+    if (func_02060484(newBase, (int)&sum, 2, v1c, v1c, v1c) != 1)
+        goto inc2;
+    if (func_02060484(hdrOff2, (int)data_020a4b40, 8, v20, v20, v20) != 1)
+        goto inc2;
+    if (func_02060484(dataOff2, (int)data, (int)size, v24, v24, v24) != 1)
+        goto inc2;
+
+    func_0205ff70((u16)lockID);
+    func_02057078((u16)lockID);
+    return 0;
+}

--- a/src/func_ov002_020c2b08.c
+++ b/src/func_ov002_020c2b08.c
@@ -1,0 +1,120 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
+extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
+extern int func_02037e78(int *p);
+extern int func_ov002_020bf30c(void *c, int a);
+extern void _ZN13RaycastGroundC1Ev(void *self);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void *pos, void *act);
+extern int _ZN13RaycastGround10DetectClsnEv(void *self);
+extern void _ZN13RaycastGroundD1Ev(void *self);
+extern int _ZN6Player7IsStateERNS_5StateE(void *thiz, void *st);
+
+extern char data_ov002_0211013c;
+
+void func_ov002_020c2b08(void *arg0)
+{
+    char *c = (char *)arg0;
+    char rg[0x54];
+    int v[3];
+
+    if (*(int *)(c + 8) != 1)
+        return;
+    if (*(u8 *)(c + 0x703) != 0)
+        return;
+
+    if (*(u8 *)(c + 0x6ea) == 0) {
+        int limit;
+
+        if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380))
+            return;
+        if (!func_02037e78((int *)((char *)_ZNK12WithMeshClsn14GetFloorResultEv(c + 0x380) + 4)))
+            return;
+
+        limit = func_ov002_020bf30c(c, 0x20000);
+        if (*(int *)(c + 0x98) >= limit)
+            *(u16 *)(c + 0x6ba) = 0x3c;
+        else
+            *(u16 *)(c + 0x6ba) = 0x1e;
+        *(u8 *)(c + 0x6ea) = 1;
+        return;
+    }
+
+    if (*(u16 *)(c + 0x6ba) != 0) {
+        if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380))
+            goto clear_timer;
+        if (!func_02037e78((int *)((char *)_ZNK12WithMeshClsn14GetFloorResultEv(c + 0x380) + 4)))
+            goto clear_timer;
+
+        *(u8 *)(c + 0x707) = 1;
+
+        if (*(u16 *)(c + 0x6ba) != 0) {
+            if (*(int *)(c + 0x98) >= 0x1000)
+                goto big_block;
+        }
+
+        *(u16 *)(c + 0x6ba) = 0;
+        *(int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x690);
+        if (*(int *)(c + 0x60) < *(int *)(c + 0x644))
+            *(int *)(c + 0x60) = *(int *)(c + 0x644);
+        return;
+
+    big_block:
+        {
+            int limit2 = func_ov002_020bf30c(c, 0x28000);
+
+            if (*(int *)(c + 0x98) < limit2) {
+                if (*(u16 *)(c + 0x6ba) >= 0x1e)
+                    *(u16 *)(c + 0x6ba) = 0x1e;
+            }
+
+            *(int *)(c + 0x55c) = 0;
+            {
+                int t = *(int *)(c + 0x55c);
+                *(int *)(c + 0x554) = t;
+                *(int *)(c + 0x558) = 0x1000;
+            }
+
+            {
+                int yy = *(int *)(c + 0x60);
+                int zz = *(int *)(c + 0x64);
+                int xx = *(int *)(c + 0x5c);
+                int yy2 = yy + 0x64000;
+                v[0] = xx;
+                v[1] = yy2;
+                v[2] = zz;
+            }
+
+            _ZN13RaycastGroundC1Ev(rg);
+            _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, v, c);
+
+            if (_ZN13RaycastGround10DetectClsnEv(rg) != 0) {
+                *(int *)(c + 0x644) = *(int *)(rg + 0x44);
+                if (*(int *)(c + 0x60) + *(int *)(c + 0x690) < *(int *)(rg + 0x44))
+                    *(u16 *)(c + 0x6ba) = 0;
+            }
+
+            _ZN13RaycastGroundD1Ev(rg);
+            return;
+        }
+
+    clear_timer:
+        *(u16 *)(c + 0x6ba) = 0;
+        return;
+    }
+
+    *(u8 *)(c + 0x6ec) = 0;
+    if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380))
+        return;
+    if (func_02037e78((int *)((char *)_ZNK12WithMeshClsn14GetFloorResultEv(c + 0x380) + 4)) != 0)
+        return;
+    if (*(u8 *)(c + 0x707) != 0)
+        return;
+
+    if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211013c)) {
+        *(u8 *)(c + 0x6ea) = 0;
+        *(u8 *)(c + 0x6ec) = 1;
+    }
+    return;
+}

--- a/src/func_ov002_020f4710.c
+++ b/src/func_ov002_020f4710.c
@@ -1,0 +1,102 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+typedef unsigned int u32;
+
+extern short data_02082214[];
+extern int data_ov002_02100100[];
+extern int data_ov002_02100110[];
+extern int func_ov002_020f5a94(void *c);
+
+void func_ov002_020f4710(char *c, int i)
+{
+    int off = i * 0x4c;
+
+    if (*(u8*)(c + 0x48 + off) == 0) {
+        int idx;
+
+        idx = *(u16*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2 + 1];
+            int spd = *(s32*)(c + 0x10 + off);
+            *(s32*)(c + 0 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x80000;
+        }
+
+        idx = *(u16*)(c + 0x2e + off) >> 4;
+        {
+            short tv = data_02082214[idx * 2];
+            int spd = *(s32*)(c + 0x10 + off);
+            *(s32*)(c + 4 + off) = (int)(((long long)tv * spd + 0x800) >> 12) + 0x60000;
+        }
+
+        *(u16*)(c + 0x2e + off) -= *(u16*)(c + 0x42 + off);
+        *(s32*)(c + 0x24 + off) += *(u16*)(c + 0x42 + off);
+
+        if (*(u8*)(c + 0x48) != 0) {
+            *(u16*)(c + 0x42 + off) += 8;
+        } else if (*(u16*)(c + 0x42 + off) < 0x200) {
+            *(u16*)(c + 0x42 + off) += 6;
+            if (*(u16*)(c + 0x42 + off) > 0x200)
+                *(u16*)(c + 0x42 + off) = 0x200;
+        }
+
+        if ((u32)*(s32*)(c + 0x24 + off) < (u32)data_ov002_02100100[i])
+            return;
+        if (*(u8*)(c + 0x514) != 0)
+            return;
+
+        (*(u8*)(c + 0x48 + off))++;
+        *(u16*)(c + 0x36 + off) = 0;
+
+        if (i == 0 || i == 3) {
+            *(s32*)(c + 8 + off) = 0x2000;
+        } else {
+            *(s32*)(c + 8 + off) = -0x2000;
+        }
+
+        if (func_ov002_020f5a94(c) != 3)
+            return;
+        if (i != 2)
+            return;
+        if (*(u8*)(c + 0x514) == 0)
+            *(s32*)(c + 8 + off) = 0x2000;
+        return;
+    }
+
+    (*(u16*)(c + 0x36 + off))++;
+    *(s32*)(c + 0 + off) += *(s32*)(c + 8 + off);
+
+    if (func_ov002_020f5a94(c) == 3 && i == 2) {
+        *(s32*)(c + 8 + off) += 0x300;
+    } else if (i == 0 || i == 3) {
+        *(s32*)(c + 8 + off) += 0x300;
+    } else {
+        *(s32*)(c + 8 + off) -= 0x300;
+    }
+
+    if (*(u16*)(c + 0x36) < 0x60)
+        return;
+
+    {
+        int o2 = (int)((unsigned long long)i & 0xFFFFFFFFFFFFFFFFULL) * 0x4c;
+        (*(u8*)(c + 0x47 + o2))++;
+        *(u16*)(c + 0x3c + o2) = 0;
+        *(u8*)(c + 0x48 + off) = 0;
+        *(s32*)(c + 0x10 + o2) = 0x38000;
+        *(u16*)(c + 0x2e + o2) = 0x8000;
+        *(u16*)(c + 0x30 + o2) = (u16)(data_ov002_02100110[i] << 6);
+
+        if (func_ov002_020f5a94(c) == 3) {
+            if (i == 2)
+                *(u16*)(c + 0x30 + o2) = 0x40;
+        }
+    }
+
+    *(s32*)(c + 0 + off) = 0x110000;
+    *(s32*)(c + 4 + off) = 0;
+    *(u16*)(c + 0x42 + off) = 0x100;
+    *(s32*)(c + 8 + off) = 0x5800;
+    *(s32*)(c + 0x1c + off) = 0x80000;
+    *(s32*)(c + 0x20 + off) = 0x28000;
+}

--- a/src/func_ov006_020f6c90.c
+++ b/src/func_ov006_020f6c90.c
@@ -1,0 +1,98 @@
+typedef unsigned char u8;
+typedef unsigned int u32;
+
+extern int RandomIntInternal(int *seed);
+extern void func_ov006_020f6f88(char *obj);
+extern int data_0209d4b8;
+
+void func_ov006_020f6c90(char *c)
+{
+    for (int i = 0; i < 11; i++)
+        *(u8 *)(c + i + 0x53f2) = 0;
+    for (int i = 0; i < 8; i++)
+        *(u8 *)(c + i + 0x53fd) = 0xff;
+
+    u8 flag = *(u8 *)(c + 0x540a);
+    if (flag == 0) {
+        int i = 0;
+        char *p = c;
+        for (; i < 16; i++, p += 0x18) {
+            u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 8 >> 15);
+            u8 *entry;
+        check0:
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            if (*entry < 2) {
+                *(u8 *)(p + 0x51b8) = idx;
+                (*entry)++;
+            } else {
+                idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 8 >> 15);
+                goto check0;
+            }
+        }
+        int j = 0;
+        char *q = c;
+        for (; j < 16; j++, q += 0x18) {
+            *(int *)(q + 0x51a8) = 0x80000;
+            *(int *)(q + 0x51ac) = -0x80000;
+            *(int *)(q + 0x51b0) = 0x8000;
+            *(u8 *)(q + 0x51ba) = 1;
+            *(u8 *)(q + 0x51bc) = 0;
+        }
+        func_ov006_020f6f88(c);
+        return;
+    } else if (flag == 1) {
+        int i = 0;
+        char *p = c;
+        for (; i < 18; i++, p += 0x18) {
+            u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15);
+            u8 *entry;
+        check1:
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            if (*entry < 2) {
+                *(u8 *)(p + 0x51b8) = idx;
+                (*entry)++;
+            } else {
+                idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15);
+                goto check1;
+            }
+        }
+        int j = 0;
+        char *q = c;
+        for (; j < 18; j++, q += 0x18) {
+            *(int *)(q + 0x51a8) = 0x80000;
+            *(int *)(q + 0x51ac) = -0x80000;
+            *(int *)(q + 0x51b0) = 0x8000;
+            *(u8 *)(q + 0x51ba) = 1;
+            *(u8 *)(q + 0x51bc) = 0;
+        }
+        func_ov006_020f6f88(c);
+        return;
+    } else {
+        int i = 0;
+        char *p = c;
+        for (; i < 20; i++, p += 0x18) {
+            u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 10 >> 15);
+            u8 *entry;
+        check2:
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            if (*entry < 2) {
+                *(u8 *)(p + 0x51b8) = idx;
+                (*entry)++;
+            } else {
+                idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 10 >> 15);
+                goto check2;
+            }
+        }
+        int j = 0;
+        char *q = c;
+        for (; j < 20; j++, q += 0x18) {
+            *(int *)(q + 0x51a8) = 0x80000;
+            *(int *)(q + 0x51ac) = -0x80000;
+            *(int *)(q + 0x51b0) = 0x8000;
+            *(u8 *)(q + 0x51ba) = 1;
+            *(u8 *)(q + 0x51bc) = 0;
+        }
+        func_ov006_020f6f88(c);
+        return;
+    }
+}

--- a/src/func_ov006_0211944c.c
+++ b/src/func_ov006_0211944c.c
@@ -1,0 +1,171 @@
+#pragma opt_strength_reduction off
+extern int data_ov006_0213ec98[];
+extern int data_ov006_0213ed10[];
+extern int data_ov006_0213ed88[];
+extern int data_ov006_0213ed4c[];
+extern int data_ov006_0213ecfc[];
+extern int data_ov006_0213ece8[];
+extern int data_ov006_0213ecac[];
+extern int data_ov006_0213ed9c[];
+extern int data_ov006_0213ed38[];
+extern int data_ov006_0213ed74[];
+extern int data_ov006_0213ed60[];
+extern int data_ov006_0213ed24[];
+
+extern void _ZN6Memory16operator_delete2EPv(void *p);
+extern void func_0207328c(void *p, int a, int b, void *cb);
+extern void func_0203d47c(void);
+extern void func_ov004_020b0840(char *c, int arg);
+
+void func_ov006_0211944c(char *c, int mode)
+{
+    if (mode != 2)
+        return;
+
+    for (int i = 0; i < 0xd; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ec98;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x668) = 0;
+
+    for (int i = 0; i < 0x19; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ed88;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x670) = 0;
+
+    for (int i = 0; i < 8; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ed4c;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x66c) = 0;
+
+    {
+        int *p = *(int **)(c + 0x4000 + 0x684);
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ecfc;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *(int *)(c + 0x4000 + 0x684) = 0;
+        }
+    }
+
+    for (int i = 0; i < 3; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ece8;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+
+    for (int i = 0; i < 6; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ecac;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x678) = 0;
+
+    for (int i = 0; i < 3; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ed9c;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x67c) = 0;
+
+    for (int i = 0; i < 2; i++) {
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = *slot;
+        if (p != 0) {
+            if (p != 0) {
+                *(int volatile *)p = (int)data_ov006_0213ed38;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *slot = 0;
+        }
+    }
+    *(int *)(c + 0x4000 + 0x680) = 0;
+
+    {
+        int *p = *(int **)(c + 0x4000 + 0x778);
+        if (p != 0) {
+            if (p != 0) {
+                *p = (int)data_ov006_0213ed74;
+                func_0207328c((char *)p + 0x4c, 3, 8, func_0203d47c);
+                func_0207328c((char *)p + 0x34, 3, 8, func_0203d47c);
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *(int **)(c + 0x4000 + 0x778) = 0;
+        }
+    }
+    {
+        int *p = *(int **)(c + 0x4000 + 0x77c);
+        if (p != 0) {
+            if (p != 0) {
+                *p = (int)data_ov006_0213ed60;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *(int **)(c + 0x4000 + 0x77c) = 0;
+        }
+    }
+    {
+        int *p = *(int **)(c + 0x4000 + 0x780);
+        if (p != 0) {
+            if (p != 0) {
+                *p = (int)data_ov006_0213ed24;
+                *(int volatile *)p = (int)data_ov006_0213ed10;
+                _ZN6Memory16operator_delete2EPv(p);
+            }
+            *(int **)(c + 0x4000 + 0x780) = 0;
+        }
+    }
+
+    func_ov004_020b0840(c, mode);
+}


### PR DESCRIPTION
## Summary
- Second 15-function batch through the Opus-first / Fable-escalation pipeline (same flow as #470): 7/15 reached byte-exact matches.
- Matched: `func_ov002_020f4710`, `func_ov002_020c2b08`, `func_ov006_0211944c`, `InvMat4x3`, `_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj`, `_ZN8SaveData14SaveDataToCartEPcjj`, `func_ov006_020f6c90`.
- 8 near-misses banked as compiling seeds in `nearmiss.jsonl` for permuter/hand-fix follow-up (best divergences ranged 3-239 words after Fable escalation); one of those (`func_0206f46c`) hit a documented mwccarm 1.2-vs-2.0 struct-by-value calling-convention wall, not a source-level lever gap, so it wasn't re-escalated.
- Several new codegen levers surfaced this batch (goto-layout to defeat loop-peeling, duplicated-retry-block via else+backward-goto, decl-order→callee-saved-register generalization) — worth folding into `notes/mwccarm-codegen.md`.

## Test plan
- [x] Every matched function independently re-verified via `tools/bank.py`'s own oracle (`abverify`/`match.py` compile+compare) before banking, not just agent self-report.
- [x] `git status` clean staging — only the 7 new `src/` files added, no unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANArKoZswQm7iP2DG7bzKA