### PR TITLE
Match func_ov006_0211f554 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_0211f554.c
+++ b/src/func_ov006_0211f554.c
@@ -1,18 +1,28 @@
-// NONMATCHING: different op / idiom (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov006_0211f454(char *c, int i);
 extern void func_ov006_0211f34c(char *c, int i);
 extern short data_02082214[];
 
 void func_ov006_0211f554(char *c, int i)
 {
-    char *e = c + i * 0x24;
+    int off;
+    char *e;
     int v;
+    unsigned short h;
+    int t;
+
+    off = i;
+    off *= 0x24;
+    e = c;
+    e += off;
     *(unsigned short *)(e + 0x466e) = 0;
     func_ov006_0211f454(c, i);
     func_ov006_0211f34c(c, i);
-    v = data_02082214[(*(unsigned short *)(e + 0x466c) >> 4) * 2 + 1];
+    e = c;
+    e += off;
+    h = *(unsigned short *)(e + 0x466c);
+    t = (int)(h >> 4);
+    t = t * 2 + 1;
+    v = data_02082214[t];
     if (v >= 0)
         *(unsigned char *)(e + 0x467e) = 1;
     else


### PR DESCRIPTION
## Summary

- Matched `func_ov006_0211f554` (ov006, `0x0211f554`, size `0x80`) byte-identical with mwccarm `1.2/sp2p3`.
- Replaces the previous `// NONMATCHING` draft in `src/`.

## Matching lever

Split the non-power-of-2 stride so mwccarm emits `mul` then `add` (not `mla`):

```c
off = i;
off *= 0x24;
e = c;
e += off;
```

Also recompute `e` after the two calls, and expand the table index for the predicated `strb` arms. Calls take `(c, i)` (not `(e, i)`).

## Verification

```
.venv/bin/python tools/match.py --c src/func_ov006_0211f554.c \
  --func func_ov006_0211f554 --addr 0x211f554 --size 0x80 \
  --version 1.2/sp2p3 --module ov006
# MATCHING VERSIONS: 1.2/sp2p3
```