### PR TITLE
Match func_02071364 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02071364.c
+++ b/src/func_02071364.c
@@ -1,83 +1,94 @@
-typedef struct Decimal {
-    unsigned char sign;
-    char unused;
-    short exp;
-    struct {
-        unsigned char length;
-        unsigned char text[32];
-        unsigned char unused;
-    } sig;
-} Decimal;
+struct S {
+    unsigned char b0;
+    unsigned char pad1;
+    short s2;
+    unsigned char b4;
+    unsigned char data[1];
+};
 
-extern void func_02071644(Decimal *result, int length);
+extern void func_02071644(struct S *out, int len);
 
-void func_02071364(Decimal *result, const Decimal *x, const Decimal *y)
+void func_02071364(struct S *out, struct S *a, struct S *b)
 {
-    unsigned int accumulator = 0;
-    unsigned char mantissa[64];
-    int i = x->sig.length + y->sig.length - 1;
-    unsigned char *ip = mantissa + i + 1;
-    unsigned char *ep = ip;
+    unsigned char buf[68];
+    unsigned int carry;
+    int sb;
+    unsigned char *p;
+    unsigned char *end;
+    int i;
 
-    result->sign = 0;
+    carry = 0;
+    sb = a->b4 + b->b4 - 1;
+    p = buf + sb + 1;
+    end = p;
+    out->b0 = 0;
+    if (sb > 0) {
+        do {
+            int count;
+            unsigned char *pa;
+            unsigned char *pb;
+            int startA;
+            int startB;
+            int rem;
 
-    for (; i > 0; i--) {
-        int k = y->sig.length - 1;
-        int j = i - k - 1;
-        int l;
-        int t;
-        const unsigned char *jp;
-        const unsigned char *kp;
-
-        if (j < 0) {
-            j = 0;
-            k = i - 1;
-        }
-
-        jp = x->sig.text + j;
-        kp = y->sig.text + k;
-        l = k + 1;
-        t = x->sig.length - j;
-
-        if (l > t) {
-            l = t;
-        }
-
-        for (; l > 0; l--, jp++, kp--) {
-            accumulator += *jp * *kp;
-        }
-
-        *--ip = (unsigned char)(accumulator % 10);
-        accumulator /= 10;
-    }
-
-    result->exp = (short)(x->exp + y->exp);
-
-    if (accumulator) {
-        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)) &
-                                    0xffffffffffffffffLL);
-        *--ip = (unsigned char)accumulator;
-        *exp = *exp + 1;
-    }
-
-    for (i = 0; i < 32 && ip < ep; i++, ip++) {
-        result->sig.text[i] = *ip;
-    }
-    result->sig.length = (unsigned char)i;
-
-    if (ip < ep && *ip >= 5) {
-        if (*ip == 5) {
-            unsigned char *jp = ip + 1;
-            for (; jp < ep; jp++) {
-                if (*jp != 0) {
-                    goto round;
-                }
+            startB = b->b4 - 1;
+            startA = sb - startB - 1;
+            if (startA < 0) {
+                startA = 0;
+                startB = sb - 1;
             }
-            if ((ip[-1] & 1) == 0) {
-                return;
+            pa = &a->data[startA];
+            rem = a->b4 - startA;
+            pb = &b->data[startB];
+            count = startB + 1;
+            if (count > rem) count = rem;
+            while (count > 0) {
+                carry += (*pa) * (*pb);
+                count--;
+                pa++;
+                pb--;
+            }
+            *--p = (unsigned char)(carry % 10);
+            carry = carry / 10;
+            sb--;
+        } while (sb > 0);
+    }
+
+    {
+        out->s2 = a->s2 + b->s2;
+        if (carry != 0) {
+            /* Launder so ep materializes as addne r2,r0,#2 (not folded [r0,#2]). */
+            short *ep = (short *)((long long)(int)((char *)out + 2) & 0xFFFFFFFFFFFFFFFFLL);
+            *--p = (unsigned char)carry;
+            *ep = (short)(*ep + 1);
+        }
+    }
+
+    i = 0;
+    while (i < 0x20 && p < end) {
+        unsigned char v = *p;
+        out->data[i] = v;
+        i++;
+        p++;
+    }
+    out->b4 = (unsigned char)i;
+    if (p >= end) return;
+
+    {
+        unsigned char d;
+        d = *p;
+        if (d < 5) return;
+        if (d != 5) goto docall;
+        {
+            unsigned char *q;
+            q = p + 1;
+            while (q < end) {
+                if (*q != 0) goto docall;
+                q++;
             }
         }
-    round:
-        func_02071644(result, result->sig.length);
+        if ((*(p - 1) & 1) == 0) return;
     }
+docall:
+    func_02071644(out, out->b4);
 }


### PR DESCRIPTION
## Summary
- Byte-match `func_02071364` @ `0x02071364` size `0x1ac` (arm9) with mwccarm 1.2/sp2p3.
- Decimal big-int multiply helper (near-miss tip was div=1).
- Final lever: store `out->s2 = a->s2 + b->s2` unconditionally first; under `if (carry)` materialize `&out->s2` via u64-mask launder so the ROM’s `addne r2,r0,#2` / `ldrshne` / `strhne` through r2 is reproduced (plain `&out->s2` folded to `[r0,#2]` and dropped the predicated add).

## Test plan
- [x] `.venv/bin/python tools/match.py --c src/func_02071364.c --func func_02071364 --addr 0x02071364 --size 0x1ac --version 1.2/sp2p3` → MATCH
- [ ] CI `validate` green