### PR TITLE
Match func_ov090_021327e4 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov090_021327e4.cpp
+++ b/src/func_ov090_021327e4.cpp
@@ -66,12 +66,15 @@ extern "C" int func_ov090_021327e4(char* c)
         *(int*)((((long long)(int)(c + 0x400)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
         if (*(int*)(c + 0x400) >= 0x14)
             *(int*)(c + 0x400) = 0;
-        /* Equal arms preserve the target mwccarm load and compare order. */
-        if (((int*)(c + 0x3ac))[*(int*)(c + 0x400)] !=
-            (*(int*)(c + 0x378)
-                ? (*(int**)(c + 0x3a8))[1]
-                : (*(int**)(c + 0x3a8))[1]))
-            goto Lreset;
+        {
+            int r0 = *(int*)(c + 0x400);
+            int r1 = (int)*(int**)(c + 0x3a8);
+            r0 = (int)(c + (r0 << 2));
+            r1 = *(int*)(r1 + 4);
+            r0 = *(int*)(r0 + 0x3ac);
+            if (r0 != r1)
+                goto Lreset;
+        }
         *(int*)((((long long)(int)(c + 0x378)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
         func_02012790(0x25);
         num2 = *(Vector3*)((((long long)(int)((char*)*(void**)(c + 0x3a8) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));


### PR DESCRIPTION
## Summary
- Byte-match `func_ov090_021327e4` @ `0x021327e4` size `0x274` (ov090) with mwccarm 1.2/sp2p3.
- Near-miss tip was div=1: only `cmp r1,r0` vs ROM `cmp r0,r1` on the slot-check path.
- Fix: replay the ROM load chain with temps that land in the same registers (`r0`/`r1` reuse for idx → base → slot, object → other), then `if (r0 != r1) goto Lreset`.

## Test plan
- [x] `.venv/bin/python tools/match.py --c src/func_ov090_021327e4.cpp --func func_ov090_021327e4 --addr 0x021327e4 --size 0x274 --module ov090 --version 1.2/sp2p3` → MATCH
- [ ] CI `validate` green