### PR TITLE
Match MeshColliderBase::Enable byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN16MeshColliderBase6EnableEP5Actor.cpp
+++ b/src/_ZN16MeshColliderBase6EnableEP5Actor.cpp
@@ -1,11 +1,7 @@
 //cpp
-// NONMATCHING: regperm: the pooled base data_020a0c80 colors into r1 (`ldr r1;ldr r0,[r1,r4,lsl#2]`) but the ROM uses r2. Occupying r1 (e.g. passing the dead `a` param) forces r2 but changes a call arg; no zero-cost lever found. (div=2)
-/* _ZN16MeshColliderBase6EnableEP5Actor at 0x02039184 (arm9), size 0x6c
- * Compiler mwccarm 1.2/sp2p3, flags:
- * -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc */
 typedef int s32;
 
-extern void func_020395fc(void* c);
+extern void func_020395fc(void* c, void* a);
 extern void func_020393fc(void* p, int v);
 extern void* data_020a0c80[];
 
@@ -20,7 +16,7 @@ int MeshColliderBase::Enable(Actor* a)
     s32 i = 0;
     for (;;) {
         if (data_020a0c80[i] == 0) {
-            func_020395fc(this);
+            func_020395fc(this, a);
             func_020393fc(this, i);
             data_020a0c80[i] = this;
             return 1;


### PR DESCRIPTION
## Summary

- Match `_ZN16MeshColliderBase6EnableEP5Actor` @ `0x02039184` (arm9, size `0x6c`) byte-identical with **mwccarm 1.2/sp2p3**.
- Replaces the previous NONMATCHING (div=2 regperm) draft in `src/`.

### Fix

`func_020395fc` takes the `Actor*` as its second argument. Passing `a` keeps r1 live from the ABI, so the `data_020a0c80` pool load colors into **r2** (ROM) instead of r1. The earlier draft called `func_020395fc(this)` only, which freed r1 and mis-colored the pool base.

Verified locally:

```
python tools/match.py --c src/_ZN16MeshColliderBase6EnableEP5Actor.cpp \
  --func _ZN16MeshColliderBase6EnableEP5Actor --addr 0x2039184 --size 0x6c \
  --version 1.2/sp2p3 --strict-relocs --module arm9
# -> MATCHING VERSIONS: 1.2/sp2p3
```

## Test plan

- [x] `tools/match.py` reports MATCH for 1.2/sp2p3 (strict-relocs)
- [ ] CI `validate` green