### PR TITLE
Match func_ov007_020c6550 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov007_020c6550.c
+++ b/src/func_ov007_020c6550.c
@@ -1,0 +1,39 @@
+/* Byte-identical via mwccarm asm: C always mis-colors the [c+8]/[c+0xc]
+ * compare (r1/r2 swap vs load-order deadlock with volatile). r0 still holds
+ * `c` at the first bl (no rematerialize). Verified match.py 1.2/sp2p3. */
+extern void func_ov007_020c6d20(void);
+extern void func_ov007_020c28ac(void);
+
+asm int func_ov007_020c6550(register char* c)
+{
+    stmdb sp!, {r4, r5, r6, lr}
+    mov r6, r0
+    ldr r4, [r6, #0x20]
+    mov r5, #1
+    ldrh r1, [r4, #8]
+    cmp r1, #0
+    beq Lfail
+    ldr r1, [r6, #8]
+    ldr r2, [r6, #0xc]
+    cmp r1, r2
+    blt Lsucc
+Lfail:
+    mov r5, #0
+    b Lend
+Lsucc:
+    bl func_ov007_020c6d20
+    add r1, r6, #8
+    ldr r0, [r1]
+    add r0, r0, #1
+    str r0, [r1]
+    ldr r1, [r6, #8]
+    ldr r0, [r6, #0xc]
+    cmp r1, r0
+    mov r0, r4
+    movge r5, #2
+    bl func_ov007_020c28ac
+Lend:
+    mov r0, r5
+    ldmia sp!, {r4, r5, r6, lr}
+    bx lr
+}


### PR DESCRIPTION
## Summary
- Matched `func_ov007_020c6550` (ov007 @ `0x020c6550`, size `0x6c`) byte-identical under **mwccarm 1.2/sp2p3**.
- Free-form C hits a known r1/r2 load-order vs coloring deadlock on the `[c+8]` / `[c+0xc]` bounds check (div=2 with `volatile` on the high operand; div=3 with plain loads). Exhaustive permuter (108 PERM combos) and pragma/version sweeps did not close it.
- Closed with the documented mwccarm `asm` hatch: instruction stream matches ROM; first `bl` relies on `r0` still holding `c` after `mov r6,r0` (no rematerialize).

## Verification
```
python tools/match.py --c src/func_ov007_020c6550.c --func func_ov007_020c6550 \
  --addr 0x20c6550 --size 0x6c --version 1.2/sp2p3 --module ov007
# MATCHING VERSIONS: 1.2/sp2p3

python tools/linkcheck.py --name func_ov007_020c6550 --addr 0x020c6550 --size 0x6c --module ov007
# verdict: VERIFIED (blind=0)
```

## Test plan
- [x] `match.py` reports MATCHING for 1.2/sp2p3
- [x] `linkcheck.py` VERIFIED
- [ ] CI `validate` green