### PR TITLE
test: PR-validator smoke test (comment-only change)

### DIFF
--- a/src/ARMMathLoadState.c
+++ b/src/ARMMathLoadState.c
@@ -1,3 +1,4 @@
+// PR-validator smoke test: comment-only change; compiled bytes are unchanged.
 typedef unsigned long long u64;
 typedef unsigned short u16;
 


### PR DESCRIPTION
End-to-end smoke test of the PR link-validation pipeline (relay -> self-hosted worker).

Adds a single comment to `src/ARMMathLoadState.c`, which already matches the ROM byte-for-byte. Because the change is comment-only, the compiled bytes are identical, so this should validate as **PASS**.

Safe to close/merge either way — it exists only to confirm the validator worker is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)