### PR TITLE
linkcheck: resolve mwccarm long-long division helpers

### DIFF
--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -88,6 +88,10 @@ _RUNTIME_ALIASES = {
     "_u32_div":   "__aeabi_uidiv",
     "_s32_div_f": "__aeabi_idiv",
     "_s32_div":   "__aeabi_idiv",
+    # long-long family: mwccarm lowers u64 `/` and `%` the same way (seen on
+    # func_02059a60, campaign 2026-07-18); ITCM records them as __aeabi_ul*.
+    "_ll_udiv":   "__aeabi_uldiv",
+    "_ll_umod":   "__aeabi_ulmod",
 }
 
 


### PR DESCRIPTION
Extends the reloc_audit runtime-alias table with _ll_udiv -> __aeabi_uldiv and _ll_umod -> __aeabi_ulmod (ITCM 0x01ffa9dc/0x01ffa9e8). Same class as the u32/s32 aliases from PR #210. Found via func_02059a60 in the arm9 campaign reading BLIND-1 on a byte-correct u64 division.

Built with Claude Code