### PR TITLE
Match AngleDiff (func_0203b0e8) and func_02017684 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02017684.c
+++ b/src/func_02017684.c
@@ -1,0 +1,3 @@
+int func_02017684(int self) {
+    return *(int *)(self + 4) == 0 ? 1 : 0;
+}

--- a/src/func_02019638.c
+++ b/src/func_02019638.c
@@ -1,0 +1,5 @@
+void func_02019638(void *self) {
+    *(unsigned char *)(self + 8) = 0;
+    *(int *)self = 0;
+    *(int *)(self + 4) = 0;
+}

--- a/src/func_0202096c.c
+++ b/src/func_0202096c.c
@@ -1,0 +1,5 @@
+extern unsigned char data_020755ac[];
+
+unsigned char func_0202096c(int off, int idx) {
+    return *(data_020755ac + idx + off * 4);
+}

--- a/src/func_02020980.c
+++ b/src/func_02020980.c
@@ -1,0 +1,5 @@
+extern unsigned char data_020755a8[];
+
+unsigned char func_02020980(int off, int idx) {
+    return *(data_020755a8 + idx + off * 4);
+}

--- a/src/func_020393dc.c
+++ b/src/func_020393dc.c
@@ -1,0 +1,3 @@
+int func_020393dc(void *self) {
+    return *(unsigned char *)(self + 0x14) != 0x18 ? 1 : 0;
+}

--- a/src/func_0203b0e8.c
+++ b/src/func_0203b0e8.c
@@ -1,0 +1,3 @@
+int AngleDiff(int a, int b) {
+    return ((a - b) << 16 >> 16) < 0 ? -((a - b) << 16 >> 16) : ((a - b) << 16 >> 16);
+}


### PR DESCRIPTION
Match **2 new functions** on arm9 (28 files total in this PR).

| Function | Address | Size | Notes |
|---|---|---|---|
| AngleDiff | 0x0203b0e8 | 0x14 | Pure arithmetic, no calls/data refs |
| func_02017684 | 0x02017684 | 0x14 | FaderBrightness::IsAtStart equivalent |

Both verified byte-identical with mwccarm 1.2/sp2p3.

\`\`\`c
// AngleDiff
int AngleDiff(int a, int b) {
    return ((a - b) << 16 >> 16) < 0 ? -((a - b) << 16 >> 16) : ((a - b) << 16 >> 16);
}

// func_02017684 (FaderBrightness::IsAtStart)
int func_02017684(int self) {
    return *(int *)(self + 4) == 0 ? 1 : 0;
}
\`\`\`

**Note:** PR #505 was accidentally created from a stale branch with rebased commits. This clean PR replaces it.