### PR TITLE
permuter+worklist: unlock C-bodied C++ near-misses & fix NONMATCHING-shadow ghosts

### DIFF
--- a/tools/permuter/import_func.py
+++ b/tools/permuter/import_func.py
@@ -47,14 +47,46 @@ CFLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gc
 
 
 def cpp_to_c(src):
-    """Strip a `//cpp` + single `extern "C" { ... }` wrapper to plain C so the C-only
-    permuter parser (pycparser) can mutate it. The mangled names are valid C identifiers.
-    Returns None when the source is real C++ (member fns / virtuals / multiple wrappers)
-    that doesn't fit the simple pattern."""
+    """Strip a `//cpp` draft down to plain C so the C-only permuter parser (pycparser)
+    can mutate it: drop the `//cpp` marker, unwrap every `extern "C" { ... }` linkage
+    block (keeping its inner content), remove single-declaration `extern "C"` forms, and
+    auto-typedef bare struct tags (C++ accepts `Name x;`, C needs `struct Name` or a
+    typedef). The mangled names are valid C identifiers.
+
+    Returns None only when `src` is not a `//cpp` draft. Over-broad stripping is SAFE:
+    permutable_base() keeps the C form only when it compiles byte-IDENTICALLY to the C++
+    original, so a draft that still contains real C++ after stripping (member-fn defs
+    `T Class::method(...)`, references, templates, virtuals) either fails to compile as C
+    or byte-mismatches, and is rejected -- never a wrong seed. Widening this from the old
+    single-wrapper regex unlocked the large class of drafts that are plain C wrapped in
+    `extern "C"` purely for name mangling / linkage."""
     if not src.startswith("//cpp"):
         return None
-    m = re.match(r'//cpp\s*\n\s*extern\s*"C"\s*\{(.*)\}\s*$', src, re.DOTALL)
-    return (m.group(1).strip() + "\n") if m else None
+    s = re.sub(r'^//cpp[^\n]*\n', '', src, count=1)
+    # Unwrap braced `extern "C" { ... }` blocks (possibly several, with content between),
+    # brace-matching each so nested braces in the body are handled.
+    out, i = [], 0
+    while i < len(s):
+        m = re.compile(r'extern\s*"C"\s*\{').match(s, i)
+        if not m:
+            out.append(s[i]); i += 1; continue
+        depth, j = 1, m.end()
+        while j < len(s) and depth:
+            depth += {"{": 1, "}": -1}.get(s[j], 0)
+            j += 1
+        if depth == 0:
+            out.append(s[m.end():j - 1]); i = j    # keep inner, drop the wrapper braces
+        else:
+            out.append(s[i]); i += 1               # unbalanced: leave verbatim
+    s = "".join(out)
+    # Single-declaration `extern "C" int foo();` -> drop just the linkage specifier.
+    s = re.sub(r'extern\s*"C"\s+(?=[A-Za-z_])', '', s)
+    # Auto-typedef bare struct tags so C accepts `Name x;`.
+    seen, pre = set(), []
+    for tag in re.findall(r'\bstruct\s+([A-Za-z_]\w*)\s*\{', s):
+        if tag not in seen:
+            seen.add(tag); pre.append(f"typedef struct {tag} {tag};")
+    return ("\n".join(pre) + "\n" + s) if pre else s
 
 
 def permutable_base(src, name):

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -62,11 +62,22 @@ def mnem_key(ins):
 
 
 def read_src_text(name):
+    # A function can end up with BOTH src/<name>.c and src/<name>.cpp -- typically a
+    # stale `// NONMATCHING` near-miss draft left behind when the real match later landed
+    # under the other extension. Returning the first-found (old behaviour: .c before .cpp)
+    # lets a stale NONMATCHING draft SHADOW a landed match, so every caller that checks
+    # "is this matched?" sees the banner and wrongly treats the function as unmatched --
+    # resurrecting it as a fan-out/permuter target and a near-miss-DB ghost. Prefer a real
+    # match over a NONMATCHING draft when both exist.
+    texts = []
     for ext in ("c", "cpp"):
         p = REPO_SRC / f"{name}.{ext}"
         if p.exists():
-            return p.read_text(encoding="utf-8")
-    return None
+            texts.append(p.read_text(encoding="utf-8"))
+    for t in texts:
+        if "// NONMATCHING" not in t[:200]:
+            return t
+    return texts[0] if texts else None
 
 
 def target_is_done(done, label, addr, name):


### PR DESCRIPTION
Two related tooling fixes that unblock the free (no-LLM) permuter vein on C++ near-misses and stop already-matched functions being resurrected as work. Tooling only — no data/src changes.

## 1. Widen the `//cpp`→C converter (`import_func.py`)

decomp-permuter's front-end is **pycparser (C-only)**, so a `//cpp` near-miss must be converted to plain C before it can be permuted. The old `cpp_to_c` matched only a single `//cpp` + one whole-file `extern "C" { ... }` wrapper, rejecting the large class of drafts that are plain C wrapped in `extern "C"` purely for name mangling/linkage but carry typedefs/structs/pragmas outside the wrapper, or use several wrappers (`Syntax error in base.c`).

Generalize it: drop the `//cpp` marker, brace-match and unwrap **every** `extern "C" { ... }` block, strip single-declaration `extern "C"` forms, and auto-typedef bare struct tags. **Safe by construction** — `permutable_base()` keeps the converted C only when it compiles byte-identically to the C++ original, so real C++ that survives stripping fails to compile as C or byte-mismatches and falls back to the untouched source. Never a wrong seed.

Measured: gate-passing permutable arm9 `//cpp` seeds go from ~4 to 13. A sweep over the newly-unlocked seeds is where the shadow bug below surfaced.

## 2. Prefer a real match over a NONMATCHING draft (`worklist.py`)

`read_src_text` returned the first of `src/<name>.{c,cpp}` that existed (`.c` first). When a stale `// NONMATCHING` near-miss draft is left behind under one extension after the real match landed under the other, that draft **shadows** the match — every "is this matched?" check (coddog unmatched-detection, nearmiss ingest, `prune-matched`) sees the banner and treats the function as unmatched, resurrecting it as a fan-out/permuter target and a near-miss-DB ghost.

This is exactly how the permuter wasted a slot re-deriving a match for the already-matched `_ZN7Message11DisplayTextEt`. There are **13 such shadow pairs** in `src/` (10 arm9 confirmed matched via `.cpp`).

Fix: prefer the non-NONMATCHING source when both exist. With it, `prune-matched` drops the shadow ghosts (**21** in the current DB) and coddog stops resurfacing them — **no committed src files need deleting, and the DB self-heals on the next prune.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYJVcsozzWpmgqx3j1WjA