### PR TITLE
Point claims coordination at tangos.dev

### DIFF
--- a/tangos.json
+++ b/tangos.json
@@ -62,7 +62,7 @@
         "note": "Local Nemotron-3 via LM Studio (OpenAI-compatible server on localhost:1234, model 'nemo'). The server ignores the value, so any placeholder like 'lm-studio' works - storing it just switches the Nemotron box on and makes it console-drivable. Start LM Studio (Start-Nemotron.ps1) before driving."
       },
       "CLAIMS_API_KEY": {
-        "note": "Write key for the belongto.us claims board, so your locks post under your handle. Optional - read-only works without it."
+        "note": "Write key for the tangos.dev claims board, so your locks post under your handle. Optional - read-only works without it."
       }
     }
   },
@@ -81,7 +81,7 @@
     "generate": "{python} tools/chaos_db_ci.py --out {out}",
     "dbPath": "chaos-db.json",
     "committedDbUrl": "https://raw.githubusercontent.com/tangosdev/sm64ds-decomp/chaos-data/chaos-db.json",
-    "claimsApi": "https://belongto.us/api/claims"
+    "claimsApi": "https://tangos.dev/api/claims"
   },
   "categories": [
     {

--- a/tools/chaosviewer.config.json
+++ b/tools/chaosviewer.config.json
@@ -11,8 +11,8 @@
   "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via CLAIMS.md.",
   "rules": "only your own legally dumped ROM; never commit the ROM, its assets, or extracted binaries - the one deliberate exception is the annotated disassembly TEXT of still-unmatched functions, published in the coordination data (chaos-data branch) so contributors can work, the same practice as decomp repos committing .s files; import struct/field knowledge (see CREDITS.md) but write all C from scratch.",
   "discord": "https://discord.gg/JXckvdARc",
-  "claimsApi": "https://belongto.us/api/claims",
-  "claimsAuthUrl": "https://belongto.us/auth/github/start",
+  "claimsApi": "https://tangos.dev/api/claims",
+  "claimsAuthUrl": "https://tangos.dev/auth/github/start",
   "nearMissNote": "If a function will not fully match after real effort, do not discard your best attempt - it is still valuable. Open a PR anyway with your closest compiling draft as src/<name>.c, headed by one line: // NONMATCHING: <what still differs> (div=N, from the verify output). Near-miss drafts are the highest-yield input to this project's refine tier - most matches now start from someone's stored near-miss, and a close draft is usually finished within a day.",
   "dataUrl": "https://raw.githubusercontent.com/tangosdev/sm64ds-decomp/chaos-data/chaos-db.json"
 }

--- a/tools/claims.py
+++ b/tools/claims.py
@@ -1,4 +1,4 @@
-"""Coordinate decomp work via the belongto.us claims lock service so multiple bots
+"""Coordinate decomp work via the tangos.dev claims lock service so multiple bots
 do not grind the same address ranges. Programmatic sibling of CLAIMS.md.
 
 Lock flow: try-lock a (module, start, end) span -> renew while working -> release when
@@ -27,7 +27,7 @@ import sys
 import urllib.request
 import urllib.parse
 
-BASE = "https://belongto.us"
+BASE = "https://tangos.dev"
 
 
 def _load_local(env, fname):

--- a/tools/glm_refine.py
+++ b/tools/glm_refine.py
@@ -444,7 +444,7 @@ def main():
     claims = None
     if not args.no_claims:
         sys.path.insert(0, str(REPO / "tools"))
-        import claims  # belongto.us lock service; per-chunk try-lock/release
+        import claims  # tangos.dev lock service; per-chunk try-lock/release
 
     def addr_int(r):
         a = r["addr"]


### PR DESCRIPTION
## What

Flips every tracked config source that feeds decomp claim coordination from `belongto.us` to `tangos.dev` (the canonical host).

| File | Change |
|---|---|
| `tools/chaosviewer.config.json` | `claimsApi` + `claimsAuthUrl` — this is what `chaos_db_ci.py` bakes into `chaos-db.json` |
| `tangos.json` | `data.claimsApi` + the `CLAIMS_API_KEY` note text |
| `tools/claims.py` | `BASE` — the lock client agents actually run |
| `tools/glm_refine.py` | stale comment |

## Why

`tangos.dev` serves `/api/claims` and `/auth/github/start`. Agents that followed the old config locked ranges on `belongto.us`, where nobody coordinating via tangos.dev could see them — two boards, split coordination.

## Not live until a regen

Agents read the config baked into the **`chaos-data` branch's** `chaos-db.json`. This flips the *source* only; it takes effect once `chaos_db_ci.py` re-runs and republishes `chaos-db.json`. Force a regen rather than waiting on the cron.

The historical `CLAIMS.md` coordination log still references belongto.us — left as a record, not a live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXLjabk7oY5z5LmgTEtC7y