### PR TITLE
Match 7 functions via Opus refine + Fable escalation (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Stage11RenderModelEv.cpp
+++ b/src/_ZN5Stage11RenderModelEv.cpp
@@ -1,0 +1,90 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct Info {
+    char pad[0x14];
+    u8 count;
+};
+
+struct Inner {
+    char pad[0x30];
+    u16 count;
+    u8 *ids;
+};
+
+struct Component {
+    char pad[0x24];
+    u32 flags;
+};
+
+struct ModelComponents {
+    void *sub;               // offset 0x0 -> *(sub+8) is Inner*
+    Component *components;   // offset 0x4
+};
+
+struct Slot {
+    void *transformer;       // 0x0
+    u8 flag;                  // 0x4
+    char pad[7];
+};
+
+struct ModelBase {
+    virtual void vf0();
+    virtual void vf1();
+    virtual void vf2();
+    virtual void vf3();
+    virtual void vf4();
+    virtual void Render(void *ctx);
+};
+
+extern Info *data_0209f340;
+extern char data_020755d4;
+
+extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *transformer, ModelComponents &mc);
+
+extern "C" void _ZN5Stage11RenderModelEv(char *self)
+{
+    ModelComponents *mc = (ModelComponents *)(((long long)(int)(self + 0x874)) & 0xFFFFFFFFFFFFFFFFLL);
+    Inner *inner = *(Inner **)((char *)mc->sub + 8);
+    Slot *slot = (Slot *)(self + 0x8bc);
+    int i;
+
+    for (i = 0; i < data_0209f340->count; i++) {
+        u8 flag = slot->flag;
+        u8 *idx = inner->ids;
+
+        if (flag != 0) {
+            u16 j;
+            for (j = 0; j < inner->count; j++) {
+                u8 id = *idx;
+                Component *comp = (Component *)((char *)mc->components + id * 0x30);
+                idx++;
+                u32 flagsTest = *(volatile u32 *)&comp->flags;
+                if ((flagsTest & 0x1f0000) == 0x1f0000) {
+                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *p &= ~0x80000000;
+                } else {
+                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *p |= 0x80000000;
+                }
+            }
+            if (slot->transformer != 0)
+                _ZN18TextureTransformer6UpdateER15ModelComponents(slot->transformer, *mc);
+        } else {
+            u16 j;
+            for (j = 0; j < inner->count; j++) {
+                u8 id = *idx;
+                Component *comp = (Component *)((char *)mc->components + id * 0x30);
+                *(u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80000000;
+                idx++;
+            }
+        }
+
+        slot = (Slot *)((char *)slot + 0xc);
+        inner = (Inner *)((char *)inner + 0x40);
+    }
+
+    ((ModelBase *)(self + 0x86c))->Render(&data_020755d4);
+}

--- a/src/func_ov002_020ea100.cpp
+++ b/src/func_ov002_020ea100.cpp
@@ -1,0 +1,121 @@
+//cpp
+extern "C" {
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+extern int func_ov002_020e73ac(char *arg);
+extern int _ZN6Player12Unk_020c9e5cEh(void *thisPtr, int state);
+extern void func_ov002_020e6fbc(char *c, int arg);
+extern void func_ov002_020e9464(char *p);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, int bcaFile, int fixA, int fixB, unsigned int arg4);
+extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int fixA);
+extern int func_ov002_020ca0f4(void *player);
+extern void GiveVsStars(int idx, int delta);
+extern void func_ov002_020e9448(unsigned char *p);
+
+extern char data_ov002_02110924[];
+extern char data_ov002_02110944[];
+extern unsigned char data_0209f2d8;
+extern signed char data_0209f310[];
+
+struct VObj {
+    virtual void unk0();
+};
+
+#pragma opt_common_subs off
+void func_ov002_020ea100(char *c)
+{
+    char *common;
+    int state;
+
+    common = *(char **)(c + 0x438);
+    state = func_ov002_020e73ac(c);
+
+    if (_ZN6Player12Unk_020c9e5cEh(common, state)) {
+        if (state == 1 || state == 2) {
+            func_ov002_020e6fbc(c, 0x14);
+            *(u8 *)(c + 0x49c) = 1;
+        } else if (state != 3) {
+            func_ov002_020e6fbc(c, 0);
+            *(u8 *)(c + 0x49c) = 2;
+        }
+
+        int *posY = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+
+        *(int *)(c + 0x440) = 6;
+        *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+        *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(u16 *)(c + 0x490) = 0;
+
+        {
+            int *src = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *cache = (int *)(((long long)(int)(c + 0x454)) & 0xFFFFFFFFFFFFFFFFLL);
+            *(int *)(c + 0x454) = src[0];
+            *(int *)(c + 0x458) = src[1];
+            *(int *)(c + 0x45c) = src[2];
+            *(int *)(c + 0x5c) = cache[0];
+            *(int *)(c + 0x60) = cache[1];
+            *(int *)(c + 0x64) = cache[2];
+            *posY += 0x1e000;
+        }
+
+        *(short *)(c + 0x94) = *(short *)(*(int *)(c + 0x438) + 0x8e);
+        *(u16 *)(c + 0x8c) = 0;
+
+        if (*(u8 *)(common + 0x703) != 0) {
+            *(int *)(c + 0x80) = 0x3000;
+            *(int *)(c + 0x84) = 0x3000;
+            *(int *)(c + 0x88) = 0x3000;
+        } else {
+            *(int *)(c + 0x80) = 0x1000;
+            *(int *)(c + 0x84) = 0x1000;
+            *(int *)(c + 0x88) = 0x1000;
+        }
+
+        func_ov002_020e9464(c);
+
+        if (*(u8 *)(common + 0x706) != 0) {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x30c, *(int *)(data_ov002_02110924 + 4), 0x40000000, 0x1000, 0);
+        } else {
+            _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x30c, *(int *)(data_ov002_02110944 + 4), 0x40000000, 0x1000, 0);
+        }
+
+        {
+            struct VObj *vobj = (struct VObj *)(c + 0x3d4);
+            { u16 *_p = (u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL); *_p = (*_p & ~1) | 1; }
+            vobj->unk0();
+        }
+
+        if (*(int *)(c + 0x43c) == 9) {
+            _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0, 0x7f000);
+        }
+    } else {
+        if (func_ov002_020ca0f4(common) != 0) {
+            int *posY2 = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *s = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            *(int *)(c + 0x5c) = s[0];
+            *(int *)(c + 0x60) = s[1];
+            *(int *)(c + 0x64) = s[2];
+            *posY2 += 0xc8000;
+        } else {
+            int ok = (data_0209f2d8 == 1);
+            if (ok) {
+                unsigned char idx = *(u8 *)(common + 0x6d8);
+                if (data_0209f310[idx] != 0) {
+                    GiveVsStars(idx, -1);
+                }
+            }
+            *(int *)(c + 0x440) = 8;
+            *(int *)(c + 0xa8) = 0x20000;
+            *(int *)(c + 0x98) = 0xc000;
+            func_ov002_020e9448((unsigned char *)c);
+            *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        }
+    }
+
+    *(int *)(c + 0x4b8) = 0;
+    *(int *)(c + 0x4b4) = *(int *)(c + 0x4b8);
+}
+
+}

--- a/src/func_ov002_020f335c.c
+++ b/src/func_ov002_020f335c.c
@@ -1,22 +1,18 @@
-// NONMATCHING: missing logic (ROM does more) (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_common_subs off
 void func_ov002_020f335c(char *o, int i) {
     int idx = i * 0x30;
     int *fld = (int *)(o + 0x144 + idx);
-    int v;
-    int a, b, c;
-    *fld += 0x1800;
-    v = *fld;
-    if (v < 0x66000) goto noclamp;
-    *fld = 0x66000;
-noclamp:
-    *(unsigned char *)(o + idx + 0x15c) = 0;
-    *(unsigned char *)(o + idx + 0x15e) = 0;
-    a = *(int *)(o + idx + 0x140) >> 0xc;
-    v = *fld >> 0xc;
-    b = *(int *)(o + idx + 0x148) >> 0xc;
-    c = *(int *)(o + idx + 0x14c) >> 0xc;
-    *(volatile unsigned short *)0x4001042 = (unsigned short)(((a << 8) & 0xff00) | (v & 0xff));
-    *(volatile unsigned short *)0x4001046 = (unsigned short)(((b << 8) & 0xff00) | (c & 0xff));
+    *fld = *fld + 0x1800;
+    if (*fld >= 0x66000) {
+        *fld = 0x66000;
+        *(unsigned char *)(o + idx + 0x15c) = 0;
+        *(unsigned char *)(o + idx + 0x15e) = 0;
+    }
+    char *b = o + idx;
+    int f140 = *(int *)(b + 0x140) >> 0xc;
+    int f148 = *(int *)(b + 0x148) >> 0xc;
+    int f14c = *(int *)(b + 0x14c) >> 0xc;
+    int fv   = *fld >> 0xc;
+    *(volatile unsigned short *)0x4001042 = (unsigned short)(((f140 << 8) & 0xff00) | (f148 & 0xff));
+    *(volatile unsigned short *)0x4001046 = (unsigned short)(((fv   << 8) & 0xff00) | (f14c & 0xff));
 }

--- a/src/func_ov002_020f340c.c
+++ b/src/func_ov002_020f340c.c
@@ -1,22 +1,18 @@
-// NONMATCHING: missing logic (ROM does more) (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_common_subs off
 void func_ov002_020f340c(char *o, int i) {
     int idx = i * 0x30;
     int *fld = (int *)(o + 0x144 + idx);
-    int v;
-    int a, b, c;
-    *fld += 0x1800;
-    v = *fld;
-    if (v < 0x66000) goto noclamp;
-    *fld = 0x66000;
-noclamp:
-    *(unsigned char *)(o + idx + 0x15c) = 0;
-    *(unsigned char *)(o + idx + 0x15e) = 0;
-    a = *(int *)(o + idx + 0x140) >> 0xc;
-    v = *fld >> 0xc;
-    b = *(int *)(o + idx + 0x148) >> 0xc;
-    c = *(int *)(o + idx + 0x14c) >> 0xc;
-    *(volatile unsigned short *)0x4001042 = (unsigned short)(((a << 8) & 0xff00) | (v & 0xff));
-    *(volatile unsigned short *)0x4001046 = (unsigned short)(((b << 8) & 0xff00) | (c & 0xff));
+    *fld = *fld + 0x1800;
+    if (*fld >= 0x66000) {
+        *fld = 0x66000;
+        *(unsigned char *)(o + idx + 0x15c) = 0;
+        *(unsigned char *)(o + idx + 0x15e) = 0;
+    }
+    char *b = o + idx;
+    int f140 = *(int *)(b + 0x140) >> 0xc;
+    int f148 = *(int *)(b + 0x148) >> 0xc;
+    int f14c = *(int *)(b + 0x14c) >> 0xc;
+    int fv   = *fld >> 0xc;
+    *(volatile unsigned short *)0x4001042 = (unsigned short)(((f140 << 8) & 0xff00) | (f148 & 0xff));
+    *(volatile unsigned short *)0x4001046 = (unsigned short)(((fv   << 8) & 0xff00) | (f14c & 0xff));
 }

--- a/src/func_ov063_02116bf4.c
+++ b/src/func_ov063_02116bf4.c
@@ -1,39 +1,48 @@
-// NONMATCHING: different op / idiom (div=44). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void func_ov063_02119c18(void* c, unsigned int id);
-extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
-
-void func_ov063_02116bf4(char* c)
-{
-    *(unsigned short*)(c + 0x5d4) &= ~8;
-    *(int*)(c + 0x19c) |= 1;
-    func_ov063_02119c18(c, 0x9f);
-
-    switch (*(unsigned char*)(c + 0x5cc)) {
-    case 0:
-        if (*(int*)(c + 0x580) >= 0x3e8000)
+    extern void func_ov063_02119c18(void* c, unsigned int id);
+    extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
+    
+    void func_ov063_02116bf4(char* c)
+    {
+        unsigned short *ip = (unsigned short *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *r3 = (int *)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char st;
+    
+        *ip = (unsigned short)(*ip & ~8);
+        *r3 = *r3 | 1;
+        func_ov063_02119c18(c, 0x9f);
+    
+        st = *(unsigned char*)(c + 0x5cc);
+        switch (st) {
+        case 0:
+            if (*(int*)(c + 0x580) >= 0x3e8000)
+                return;
+            if (*(int*)(c + 0x5a0) < 5) {
+                unsigned char cb = *(unsigned char*)(c + 0x5cb);
+                if (cb != 5 && (int)cb - *(int*)(c + 0x5a0) < 2) {
+                    char* p = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
+                        0xd1, 0xfff1, c + 0x5c, c + 0x92, *(signed char*)(c + 0x5d0), -1);
+                    if (p != 0) {
+                        *(int*)(p + 0x494) = *(int*)(c + 4);
+                        *(int*)(p + 0x498) = *(int*)(c + 0x498);
+                    }
+                    {
+                        unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cb)) & 0xFFFFFFFFFFFFFFFFLL);
+                        *q = *q + 1;
+                    }
+                }
+                {
+                    unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cc)) & 0xFFFFFFFFFFFFFFFFLL);
+                    *q = *q + 1;
+                }
+            }
+            if (*(int*)(c + 0x5a0) >= 5)
+                *(unsigned char*)(c + 0x5cc) = 2;
             break;
-        if (*(int*)(c + 0x5a0) >= 5) {
-            if ((unsigned short)*(unsigned short*)(c + 0x100) > 0x3c)
+        case 1:
+            if (*(unsigned short*)(c + 0x100) > 0x3c)
                 *(unsigned char*)(c + 0x5cc) = 0;
             break;
+        case 2:
+            break;
         }
-        if (*(unsigned char*)(c + 0x5cb) != 5
-            && *(unsigned char*)(c + 0x5cb) - *(int*)(c + 0x5a0) < 2) {
-            char* p = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-                0xd1, 0xfff1, c + 0x5c, c + 0x92, *(signed char*)(c + 0x5d0), -1);
-            if (p) {
-                *(int*)(p + 0x494) = *(int*)(c + 4);
-                *(int*)(p + 0x498) = *(int*)(c + 0x498);
-            }
-        }
-        (*(unsigned char*)(c + 0x5cb))++;
-        (*(unsigned char*)(c + 0x5cc))++;
-        if (*(int*)(c + 0x5a0) >= 5)
-            *(unsigned char*)(c + 0x5cc) = 2;
-        break;
-    case 1:
-        break;
     }
-}


### PR DESCRIPTION
Finishes 7 structural near-miss drafts to byte-exact matches from a two-stage refine cascade over the near-miss DB. Every function is **linkcheck VERIFIED** — 0 byte diffs, 0 blind relocs — not just match.py MATCH (which wildcards reloc slots).

### Opus refine fan-out (5 landed, 75K tok/landed)
| function | module | lever |
|---|---|---|
| `_ZN5Stage11RenderModelEv` | arm9 | u64-launder on `&mc` + else-branch RMW lvalue → pre-index writeback `ldr [r0,#0x24]!` |
| `func_ov002_020ea100` | ov002 | u64-mask launder + `opt_common_subs off` re-materialize the 0x4a2 halfword-RMW base |
| `func_ov002_020f335c` | ov002 | `strb=0` into the `>=` if-body forces the real `blt`; fv-last decl + `char*` base settles coloring |
| `func_ov002_020f340c` | ov002 | clone-derived structural sibling of `func_ov002_020f335c` |
| `func_ov063_02116bf4` | ov063 | `if/else` chain → `switch(st)` matching the ROM's up-front case dispatch |

### Fable escalation on Opus's floor-mapped misses (2 landed)
| function | module | lever |
|---|---|---|
| `_ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3` | arm9 | `m=modules;m+=idx` (mla coalescing) + volatile pair-selector flips the r0/r1 swap |
| `_ZN5Actor11UpdateCarryER6PlayerRK7Vector3` | arm9 | 12-byte struct copy emits the exact `ldr/ldr/str/ldr/str/str` word1-first rotate |

**Cross-model lesson:** a register-coloring residual one model maps as a compiler floor can fall to another model's different register rotation — relaying the *narrowed* draft (not a scratch re-grind) is what closed both Fable matches.

3 residuals remain genuine floors (pure coloring / s64-shift lowering / call-arg emission order) and stay parked as near-misses. src-only; no ledger/DB files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)