### PR TITLE
Match 10 functions via Opus refine + Fable escalation (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0202048c.cpp
+++ b/src/func_0202048c.cpp
@@ -1,0 +1,74 @@
+//cpp
+extern "C" {
+struct Matrix2x2;
+}
+typedef int Fix12i;
+
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int show, void* attr, int a, int b, int c, int d, Fix12i e, Fix12i f, int g, int h);
+extern "C" int _ZN3OAM9RenderSubEP7OamAttriiii(void* attr, int a, int b, int c, int d);
+extern "C" int _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int show, void* attr, int a, int b, int c, int d, Matrix2x2* m);
+
+extern short data_02082214[];
+
+extern "C" void func_0202048c(char* a0, int a1, int a2)
+{
+    if (*(unsigned char*)(a0 + 0x26) == 0) return;
+    if (*(void**)(a0 + 4) == 0) return;
+
+    int f08 = *(int*)(a0 + 8);
+    if (f08 == 0x1000 && *(int*)(a0 + 0xc) == 0x1000 && *(unsigned short*)(a0 + 0x20) == 0) {
+        int mode = *(int*)(a0 + 0x28);
+        if (mode == 2) {
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, *(void**)(a0 + 4), a1, a2 + 0xc0,
+                *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), 0x1000, 0x1000, 0, -1);
+            _ZN3OAM9RenderSubEP7OamAttriiii(*(void**)(a0 + 4), a1, a2,
+                *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23));
+            return;
+        }
+        if (mode == 1) {
+            _ZN3OAM9RenderSubEP7OamAttriiii(*(void**)(a0 + 4), a1, a2,
+                *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23));
+            return;
+        }
+        _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, *(void**)(a0 + 4), a1, a2,
+            *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), 0x1000, 0x1000, 0, -1);
+        return;
+    }
+
+    int idx = (*(unsigned short*)(a0 + 0x20)) >> 4;
+    int f0c = *(int*)(a0 + 0xc);
+    int i0 = idx * 2;
+    short tb = data_02082214[i0 + 1];
+    short ta = data_02082214[i0];
+
+    int m[4];
+    m[0] = (tb * f08 + 0x800) >> 12;
+    m[1] = (ta * f08 + 0x800) >> 12;
+    m[2] = -((ta * f0c + 0x800) >> 12);
+    m[3] = (tb * f0c + 0x800) >> 12;
+
+    if (*(int*)*(void**)(a0 + 4) & 0x10000000) {
+        m[0] = -m[0];
+        m[1] = -m[1];
+    }
+    if (*(int*)*(void**)(a0 + 4) & 0x20000000) {
+        m[2] = -m[2];
+        m[3] = -m[3];
+    }
+
+    int mode = *(int*)(a0 + 0x28);
+    if (mode == 2) {
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, *(void**)(a0 + 4), a1, a2 + 0xc0,
+            *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), (Matrix2x2*)m);
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, *(void**)(a0 + 4), a1, a2,
+            *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), (Matrix2x2*)m);
+        return;
+    }
+    if (mode == 1) {
+        _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(1, *(void**)(a0 + 4), a1, a2,
+            *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), (Matrix2x2*)m);
+        return;
+    }
+    _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, *(void**)(a0 + 4), a1, a2,
+        *(signed char*)(a0 + 0x22), *(signed char*)(a0 + 0x23), (Matrix2x2*)m);
+}

--- a/src/func_ov006_020de0e0.cpp
+++ b/src/func_ov006_020de0e0.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=22). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 extern "C" void func_ov004_020b0aa0(int arg);
 extern "C" void func_ov004_020ae20c(void);
@@ -12,20 +9,16 @@ extern unsigned char data_020a0de9[];
 
 extern "C" void func_ov006_020de0e0(char* self)
 {
-  if (*(int*)(self+0x51cc) == 0) return;
-  *(int*)(self+0x51cc) -= 1;
+  if (*(int*)(self+0x5000+0x1cc) == 0) return;
+  *(int*)(((int)self + 0x51cc) & 0xFFFFFFFFFFFFFFFF) -= 1;
   unsigned int idx = data_020a0e40[0];
   int flag = 0;
   if (data_020a0de8[idx*4] != 0) {
     if (data_020a0de9[idx*4] != 0) flag = 1;
   }
-  if (flag != 0) {
-    if (*(int*)(self+0x51cc) <= 0x80) {
-      *(int*)(self+0x51cc) = 0;
-      _ZN5Sound12PlayBank2_2DEj(0x62);
-    } else {
-      *(int*)(self+0x51cc) = 0x80;
-    }
+  if (flag != 0 && *(int*)(self+0x51cc) <= 0x80) {
+    *(int*)(self+0x51cc) = 0;
+    _ZN5Sound12PlayBank2_2DEj(0x62);
   } else {
     *(int*)(self+0x51cc) = 0x80;
   }

--- a/src/func_ov006_020e96f4.cpp
+++ b/src/func_ov006_020e96f4.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" void _ZN3G2x13SetBlendAlphaEPVttttt(
     volatile unsigned short *p, unsigned short a, unsigned short b,
     unsigned short c, int d);
@@ -9,10 +6,10 @@ extern "C" void func_ov006_020e9374(void *c);
 
 extern "C" void func_ov006_020e96f4(char *thiz)
 {
-    *(unsigned short*)(thiz + 0x554a) = *(unsigned short*)(thiz + 0x554a) + 1;
+    *(unsigned short*)(((int)thiz + 0x554a) & 0xFFFFFFFFFFFFFFFF) += 1;
     if (*(unsigned short*)(thiz + 0x554a) >= 4) {
         *(unsigned short*)(thiz + 0x554a) = 0;
-        *(unsigned char*)(thiz + 0x554e) = *(unsigned char*)(thiz + 0x554e) + 1;
+        *(unsigned char*)(((int)thiz + 0x554e) & 0xFFFFFFFFFFFFFFFF) += 1;
         _ZN3G2x13SetBlendAlphaEPVttttt(
             (volatile unsigned short*)0x4001050, 0, 4,
             *(unsigned char*)(thiz + 0x554e), 0x10 - *(unsigned char*)(thiz + 0x554e));

--- a/src/func_ov006_020ee5b8.c
+++ b/src/func_ov006_020ee5b8.c
@@ -1,15 +1,13 @@
-// NONMATCHING: push-set / frame (div=23). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 void func_ov004_020b0aa0(int arg);
 void func_ov006_020c7490(void);
 void func_ov006_020ee598(char* p);
 void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 void func_ov006_020c42bc(void);
 
+#pragma optimize_for_size on
 void func_ov006_020ee5b8(char* c){
     int v;
-    short* d = (short*)(c+0x5014);
+    short* d = (short*)(((unsigned long long)(c+0x5014)) & 0xFFFFFFFFFFFFFFFFull);
     char* base = c + 0x5000;
     *d = *d - 1;
     v = *(short*)(base + 0x14);
@@ -23,7 +21,7 @@ void func_ov006_020ee5b8(char* c){
         func_ov006_020c7490();
         func_ov006_020ee598(c);
     } else if (v == 0x77) {
-        func_ov004_020b0cac(0xd, 0x80, 0x60, 1, -1, 0xa);
-        func_ov006_020c42bc();
+        func_ov004_020b0cac(0xd, 0x80, 0x60, 1, -1, 0xd);
     }
+    func_ov006_020c42bc();
 }

--- a/src/func_ov006_02115150.c
+++ b/src/func_ov006_02115150.c
@@ -1,0 +1,32 @@
+extern int func_0203d614(const void* v);
+extern int func_0203d434(void* p);
+extern void func_0203d630(void* p, int m);
+
+#pragma opt_strength_reduction off
+void func_ov006_02115150(char* self)
+{
+    int i;
+    char* obj = self + 0x48d4;
+    for (i = 0; i < 0x10; i++) {
+        unsigned char* flag = (unsigned char*)(int)(((long long)(int)(self + i + 0x4804)) & 0xFFFFFFFFFFFFFFFFLL);
+        if (*flag != 0) {
+            *(int*)(((int)(self + i*8) + 0x4854) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(self + i*8 + 0x48d4);
+            *(int*)(((int)(self + i*8) + 0x4858) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(self + i*8 + 0x48d8);
+            {
+                int m = func_0203d614(obj) * 6 / 8;
+                if (func_0203d434(obj)) {
+                    func_0203d630(obj, m);
+                }
+            }
+            {
+                int* counter = (int*)(int)(((long long)(int)(self + i*4 + 0x4814)) & 0xFFFFFFFFFFFFFFFFLL);
+                *counter += 1;
+                if (*counter >= 0xf) {
+                    *flag = 0;
+                    *counter = 0;
+                }
+            }
+        }
+        obj += 8;
+    }
+}

--- a/src/func_ov006_0211fbf8.c
+++ b/src/func_ov006_0211fbf8.c
@@ -1,78 +1,83 @@
-// NONMATCHING: different op / idiom (div=27). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+
 extern void func_ov006_0211ddb8(char *p);
 extern void func_ov006_0211d7d8(char *p);
 extern void func_ov006_0211d688(char *p);
-
-void func_ov006_0211fbf8(char *p) {
-    char *q;
-    int v;
-    int i;
-    q = p;
-    v = 0;
-    i = 0;
-    do {
-        *(int*)(q + 0x4660) = v;
-        *(int*)(q + 0x4664) = v;
-        *(short*)(q + 0x466e) = v;
-        *(short*)(q + 0x4670) = v;
-        *(short*)(q + 0x4672) = v;
-        *(char*)(q + 0x4677) = v;
-        *(char*)(q + 0x4678) = v;
-        *(char*)(q + 0x4679) = v;
-        *(char*)(q + 0x467a) = v;
-        *(char*)(q + 0x467b) = v;
-        *(char*)(q + 0x467c) = v;
-        *(char*)(q + 0x467d) = v;
-        *(char*)(q + 0x467e) = v;
-        i++;
-        *(char*)(q + 0x4676) = v;
-        q += 0x24;
-    } while (i < 0x10);
-
-    q = p;
-    i = 0;
-    do {
-        *(int*)(q + 0x48a0) = i;
-        *(int*)(q + 0x48a4) = i;
-        *(char*)(q + 0x48a8) = i;
-        *(char*)(q + 0x48a9) = i;
-        v++;
-        *(char*)(q + 0x48aa) = i;
-        q += 0xc;
-    } while (v < 0x10);
-
-    v = 0;
-    do {
-        *(char*)(p + (v<<4) + 0x496d) = i;
-        v++;
-        *(char*)(p + ((v-1)<<4) + 0x496e) = i;
-    } while (v < 0x10);
-
-    *(int*)(p + 0x4bec) = i;
-    *(int*)(p + 0x4bf0) = i;
-    *(int*)(p + 0x4bf4) = i;
-    *(int*)(p + 0x4bf8) = i;
-    *(int*)(p + 0x4bfc) = i;
-    *(int*)(p + 0x4c00) = i;
-    *(short*)(p + 0x4c10) = i;
-    *(short*)(p + 0x4c0c) = i;
-    *(short*)(p + 0x4c0e) = i;
-    *(char*)(p + 0x4c1d) = i;
-    *(char*)(p + 0x4c1f) = i;
-    *(char*)(p + 0x4c20) = i;
-    *(short*)(p + 0x4c14) = i;
-    *(char*)(p + 0x4c1a) = i;
-    *(char*)(p + 0x4c1b) = i;
-    *(char*)(p + 0x4c1c) = i;
-    *(char*)(p + 0x4c21) = i;
-    func_ov006_0211ddb8(p);
-    func_ov006_0211d7d8(p);
-    *(short*)(p + 0x4c18) = i;
-    *(char*)(p + 0x4c24) = i;
-    func_ov006_0211d688(p);
-    *(int*)(p + 0x4c08) = i;
-    *(char*)(p + 0x4c26) = 0xff;
-    *(char*)(p + 0x4c27) = i;
+#pragma opt_strength_reduction off
+void func_ov006_0211fbf8(char *p)
+{
+  int v;
+  int i;
+  char *new_var;
+  char *q;
+  v = 0;
+  q = p;
+  i = 0;
+  do
+  {
+    *((int *) (q + 0x4660)) = v;
+    *((int *) (q + 0x4664)) = v;
+    *((short *) (q + 0x466e)) = v;
+    *((short *) (q + 0x4670)) = v;
+    *((short *) (q + 0x4672)) = v;
+    *((char *) (q + 0x4677)) = v;
+    *((char *) (q + 0x4678)) = v;
+    *((char *) (q + 0x4679)) = v;
+    new_var = q;
+    *((char *) (new_var + 0x467a)) = v;
+    *((char *) (q + 0x467b)) = v;
+    *((char *) (q + 0x467c)) = v;
+    *((char *) (q + 0x467d)) = v;
+    *((char *) (q + 0x467e)) = v;
+    i++;
+    *((char *) (q + 0x4676)) = v;
+    q += 0x24;
+  }
+  while (i < 0x10);
+  q = p;
+  v = 0;
+  i = 0;
+  do
+  {
+    *((int *) (q + 0x48a0)) = i;
+    *((int *) (q + 0x48a4)) = i;
+    *((char *) (q + 0x48a8)) = i;
+    *((char *) (q + 0x48a9)) = i;
+    v++;
+    *((char *) (q + 0x48aa)) = i;
+    q += 0xc;
+  }
+  while (v < 0x10);
+  v = 0;
+  do
+  {
+    *((char *) ((p + (v << 4)) + 0x496d)) = i;
+    *((char *) ((p + (v << 4)) + 0x496e)) = i;
+    v++;
+  }
+  while (v < 0x10);
+  *((int *) (p + 0x4bec)) = i;
+  *((int *) (p + 0x4bf0)) = i;
+  *((int *) (p + 0x4bf4)) = i;
+  *((int *) (p + 0x4bf8)) = i;
+  *((int *) (p + 0x4bfc)) = i;
+  *((int *) (p + 0x4c00)) = i;
+  *((short *) (p + 0x4c10)) = i;
+  *((short *) (p + 0x4c0c)) = i;
+  *((short *) (p + 0x4c0e)) = i;
+  *((char *) (p + 0x4c1d)) = i;
+  *((char *) (p + 0x4c1f)) = i;
+  *((char *) (p + 0x4c20)) = i;
+  *((short *) (p + 0x4c14)) = i;
+  *((char *) (p + 0x4c1a)) = i;
+  *((char *) (p + 0x4c1b)) = i;
+  *((char *) (p + 0x4c1c)) = i;
+  *((char *) (p + 0x4c21)) = i;
+  func_ov006_0211ddb8(p);
+  func_ov006_0211d7d8(p);
+  *((short *) (p + 0x4c18)) = i;
+  *((char *) (p + 0x4c24)) = i;
+  func_ov006_0211d688(p);
+  *((int *) (p + 0x4c08)) = i;
+  *((unsigned char *) (p + 0x4c26)) = 0xff;
+  *((char *) (p + 0x4c27)) = i;
 }


### PR DESCRIPTION
Finishes 10 structural near-miss drafts to byte-exact matches from a two-stage refine cascade. Every function is **linkcheck VERIFIED** — 0 byte diffs, 0 blind relocs.

### Opus refine fan-out (6 landed, 71K tok/landed)
| function | module | lever |
|---|---|---|
| `func_0202048c` | arm9 | `short`-typed `ta/tb` fixes the multiply grouping + `ta`/`i1` coloring |
| `func_ov006_020de0e0` | ov006 | merged else-blocks via `&&`; u64-launder `-=1` forces a separate 0x51cc pool materialization |
| `func_ov006_020ee5b8` | ov006 | hoist `func_ov006_020c42bc()` to a shared tail (`optimize_for_size` + u64-launder) |
| `func_ov006_020e96f4` | ov006 | u64-launder both increment RMWs → full-address pool-const |
| `func_ov006_0211fbf8` | ov006 | `opt_strength_reduction off` + `u8` cast; decomp-permuter closed the last 3-div coloring |
| `func_ov006_02115150` | ov006 | u64-launder RMW lvalues + `strength_reduction off` removes evicting induction vars |

### Fable escalation on Opus's floor-misses + a connection-retry (4 landed, 12K tok/landed)
| function | module | lever |
|---|---|---|
| `func_02072dac` | arm9 | (Opus agent died on connection error, retried) read-a+zero-check moved inside do/while; `&a/&b/&c` hoist as call-arg invariants |
| `func_ov002_020f30f8` | ov002 | hoist `arg1` to a temp before the call flips the r5/r4 base-CSE order (8→0) |
| `func_0205e6e4` | arm9 | u64-launder 3 in-loop RMWs + `opt_loop_invariants off` stops LICM hoisting the laundered bases |
| `func_ov002_020b8dd4` | ov002 | shared local `q` + int-typed null-check derefs defeat CSE so the check reg dies at `ldrh` |

**New lever:** `#pragma opt_loop_invariants off` is *not* inert on larger functions — it defeats LICM hoisting of a u64-laundered in-loop RMW base (the notes' prior small-function "inert" verdict does not generalize).

**Cross-model result:** all 3 residuals Opus mapped as compiler floors fell to a Fable pass from the *narrowed* drafts at 12K/landed. Relaying the residual, not re-grinding, is the whole game.

src-only; no ledger/DB files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)