### PR TITLE
Match 8 functions via Opus refine + Fable escalation (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_020ebd7c.c
+++ b/src/func_ov006_020ebd7c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: extra logic (you do more) (div=26). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
 extern int data_ov006_0213c958;
@@ -13,14 +10,17 @@ void func_ov006_020ebd7c(int count)
     int i, j;
     data_ov006_02141fd4 = (short)(RandomIntInternal(&data_0209e650) & 0xf);
     data_ov006_02141fd0 = (short)count;
-    if (count <= 0)
-        return;
     for (i = 0; i < count; i++) {
-        data_ov006_02141fdc[i] = (unsigned short)((int)((data_ov006_0213c958 * (int)((unsigned int)(RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13))) >> 0xc);
-        for (j = 0; j < i; j++) {
+        int r = RandomIntInternal(&data_0209e650);
+        data_ov006_02141fdc[i] = (unsigned short)((int)((int)((unsigned int)(r & 0x7fffffff) >> 0x13) * data_ov006_0213c958) >> 0xc);
+        j = 0;
+        while (j < i) {
             if (data_ov006_02141fdc[j] == data_ov006_02141fdc[i]) {
-                data_ov006_02141fdc[i] = (unsigned short)((int)((data_ov006_0213c958 * (int)((unsigned int)(RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13))) >> 0xc);
+                r = RandomIntInternal(&data_0209e650);
+                data_ov006_02141fdc[i] = (unsigned short)((int)((int)((unsigned int)(r & 0x7fffffff) >> 0x13) * data_ov006_0213c958) >> 0xc);
                 j = 0;
+            } else {
+                j++;
             }
         }
     }

--- a/src/func_ov006_02104920.c
+++ b/src/func_ov006_02104920.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=28). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void SetSubBg0Offset(int a, int b);
 extern void func_02012790(int a);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int a);
@@ -10,16 +7,17 @@ extern int data_ov006_0212ed00[];
 void func_ov006_02104920(char *c, int idx)
 {
     int n = idx * 0xc;
+    char *base = c + 0x4690;
     int cnt;
-    *(unsigned short *)(c + 0x4690 + n) = *(unsigned short *)(c + 0x4690 + n) + 1;
-    cnt = *(unsigned short *)(c + 0x4690 + n);
+    *(unsigned short *)(base + n) = *(unsigned short *)(base + n) + 1;
+    cnt = *(unsigned short *)(base + n);
     if ((unsigned int)cnt >= 0x20) {
-        *(unsigned short *)(c + 0x4690 + n) = 0;
+        *(unsigned short *)(base + n) = 0;
         *(unsigned char *)(c + n + 0x4000 + 0x693) = 0;
         SetSubBg0Offset(0, 0);
         data_0209d454 &= ~1;
         func_02012790(0x12f);
-        *(unsigned char *)(c + 0x4fe2) -= 1;
+        *(unsigned char *)(((int)c + 0x4fe2) & 0xffffffffffffffff) -= 1;
         return;
     }
     *(int *)(c + 0x468c + n) = data_ov006_0212ed00[cnt >> 3];


### PR DESCRIPTION
Refine cascade over the near-miss DB (div≤40 structural tier). All 8 functions **linkcheck VERIFIED** (0 diffs, 0 blind).

### Opus refine (2 landed)
| function | module | lever |
|---|---|---|
| `func_ov006_020ebd7c` | ov006 | dropped `count<=0` guard (single predicated exit); `while(j<i)` dup-regen inner loop; named RNG temp flips the mul-block coloring |
| `func_ov006_02104920` | ov006 | explicit `char *base=c+0x4690` keeps `n` in r2; u64-mask launder forces the materialized 0x4fe2 base |

### Fable escalation on Opus's floor-misses (6 landed, 46K tok/landed)
| function | module | lever |
|---|---|---|
| `func_02060b64` | arm9 | `bad=1` before `reject=0` (mirrors `mov r3,#1`/`mov r1,#0`) + `opt_propagation off` stops jump-threading to `blo` |
| `func_ov075_021190a4` | ov075 | `char*` param stops the scheduler hoisting the laundered `add` into the `ldr`/`cmp` load-use slot |
| `func_ov006_02124088` | ov006 | volatile stack captures before the lerp rotate the free list so `mul` dest coalesces with the dying operand |
| `func_ov006_020ed8a4` | ov006 | volatile on two globals pins load/store to source order, moving `bc` from callee-saved r5 to scratch r3 |
| `func_0205e280` | arm9 | split the 0x80 postincrement into `old=count`; laundered RMW; `buf[old]=0x80` forces the fresh materialized r3 |
| `func_ov063_0211aa34` | ov063 | inverted arm2 inner condition defeats if-conversion, keeping the ROM's `strble`+`ble` partial form |

**Cross-model pattern holds:** the div≤40 band is floor-dense for Opus (2/12), but Fable cracked 6 of its 8 floor-misses from the *narrowed* drafts. src-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)