### PR TITLE
Match functions via Opus refine + Fable escalation (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020ec80c.c
+++ b/src/func_ov002_020ec80c.c
@@ -1,40 +1,37 @@
-// NONMATCHING: different op / idiom (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern int RandomIntInternal(int* seed);
-extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* v, void* w, int e, int f);
-extern int data_0209e650;
-
-void func_ov002_020ec80c(char* a, void* b, int count, int sl, short arg5)
-{
-    unsigned int r;
-    int zero;
-    char* n;
-    int rv;
-    int prev;
-    int i;
-    int v98;
-    prev = 0xff;
-    if (count > 1) {
-        if (sl < 0x4000) sl = 0x4000;
-    }
-    i = 0;
-    if (count <= 0) return;
-    zero = i;
-    do {
-        n = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x122, 2, b, 0, *(signed char*)(a + 0xcc), -1);
-        if (n != 0) {
-            do {
-                rv = (int)(((unsigned int)RandomIntInternal(&data_0209e650) >> 16) << 27) >> 16;
-            } while (rv == prev);
-            r = (unsigned int)RandomIntInternal(&data_0209e650) >> 16;
-            *(short*)(n + 0x92) = zero;
-            v98 = sl * ((r % 50) + 100) / 100;
-            prev = rv;
-            *(short*)(n + 0x94) = arg5 + rv;
-            *(short*)(n + 0x96) = zero;
-            *(int*)(n + 0x98) = v98;
+    extern int RandomIntInternal(int* seed);
+    extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* v, void* w, int e, int f);
+    extern int data_0209e650;
+    
+    void func_ov002_020ec80c(char* a, void* b, int count, int sl, short arg5)
+    {
+        unsigned int r;
+        int zero;
+        char* n;
+        int rv;
+        int prev;
+        int i;
+        prev = 0xff;
+        if (count > 1) {
+            if (sl < 0x4000) sl = 0x4000;
         }
-        i++;
-    } while (i < count);
-}
+        i = 0;
+        if (count <= 0) return;
+        zero = i;
+        do {
+            n = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x122, 2, b, 0, *(signed char*)(a + 0xcc), -1);
+            if (n != 0) {
+                do {
+                    rv = (int)(((unsigned int)RandomIntInternal(&data_0209e650) >> 16) << 27) >> 16;
+                } while (rv == prev);
+                r = (unsigned int)RandomIntInternal(&data_0209e650);
+                r = r >> 16;
+                *(short*)(n + 0x92) = zero;
+                sl = sl * ((r % 50) + 100) / 100;
+                prev = rv;
+                *(short*)(n + 0x94) = arg5 + rv;
+                *(short*)(n + 0x96) = zero;
+                *(int*)(n + 0x98) = sl;
+            }
+            i++;
+        } while (i < count);
+    }

--- a/src/func_ov002_020edb3c.cpp
+++ b/src/func_ov002_020edb3c.cpp
@@ -1,0 +1,67 @@
+//cpp
+extern "C" {
+extern int func_ov002_020ec654(unsigned char *p);
+extern void func_ov002_020edca4(char *self);
+extern void *_ZN5Actor4NextEPKS_(const void *prev);
+extern int Vec3_Dist(const void *a, const void *b);
+
+struct VObj { virtual int s0(); virtual int s1(); virtual int s2(); virtual int s3(); virtual int s4(); virtual int s5(); virtual int s6(); virtual int s7(); virtual int s8(); virtual int s9(); virtual int s10(); virtual int s11(); virtual int s12(); virtual int s13(); virtual int s14(); virtual int s15(); virtual int s16(); virtual int s17(); virtual int s18(); virtual int s19(); virtual int s20(); };
+#pragma opt_strength_reduction off
+int func_ov002_020edb3c(char *self, int a1, int best)
+{
+    char *found;
+    char *actor;
+    int matched;
+    int b;
+    struct P { int a, b, c, d; };
+    volatile struct P _p;
+    struct P *_q = (struct P *)&_p;
+
+    if (*(unsigned char *)(self + 0x41c) >= 5) {
+        if (func_ov002_020ec654((unsigned char *)self) == 0) {
+            func_ov002_020edca4(self);
+        }
+        return 0;
+    }
+
+    found = 0;
+    actor = (char *)_ZN5Actor4NextEPKS_(0);
+    if (actor == 0) goto end;
+
+loop:
+    if (actor == self) goto next;
+    if (actor == *(char **)(self + 0x38c)) goto next;
+    b = (*(int *)(actor + 0xb0) & 0x10000000) != 0;
+    if (!b) goto next;
+    b = (*(int *)(actor + 0xb0) & 8) != 0;
+    if (b) goto next;
+    matched = 0;
+    for (int i = 0; i < 5; i++) {
+        int bv = *(int *)(self + (i << 2) + 0x3fc);
+        if (bv == *(int *)(actor + 4)) matched = 1;
+    }
+    if (matched != 0) goto next;
+    if (func_ov002_020ec654((unsigned char *)self) != 0) {
+        if (((VObj *)actor)->s20() == 0) goto next;
+    }
+    {
+        int d = Vec3_Dist(self + 0x5c, actor + 0x5c);
+        if (d < best) {
+            best = d;
+            found = actor;
+        }
+    }
+next:
+    actor = (char *)_ZN5Actor4NextEPKS_(actor);
+    if (actor != 0) goto loop;
+
+end:
+    if (found != 0) {
+        int idx = *(unsigned char *)(self + 0x41c);
+        *(int *)(self + (idx << 2) + 0x3fc) = *(int *)(found + 4);
+        *(int *)(self + 0x410) = *(int *)(found + 4);
+        *(unsigned char *)(((long long)(int)(self + 0x41c)) & 0xffffffffffffffffLL) += 1;
+    }
+    return (int)found;
+}
+}

--- a/src/func_ov006_020dc5c4.c
+++ b/src/func_ov006_020dc5c4.c
@@ -1,20 +1,14 @@
-// NONMATCHING: different op / idiom (div=30). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned short u16;
 typedef unsigned char u8;
-
 extern void func_ov006_020dc26c(char *c);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 extern u16 data_ov006_0212e33c[];
 extern u8 data_ov006_0212e310[];
-
 void func_ov006_020dc5c4(char *c, int i)
 {
     int off = i * 0x14;
     u16 *counter = (u16 *)(c + 0x519e + off);
     u8  *st = (u8 *)(c + 0x51a4 + off);
-
     *counter = (u16)(*counter + 1);
     if (*counter < data_ov006_0212e33c[*st])
         return;
@@ -24,16 +18,16 @@ void func_ov006_020dc5c4(char *c, int i)
         func_ov006_020dc26c(c);
         _ZN5Sound12PlayBank2_2DEj(0xf0);
     }
-    if (*st < 4) {
+    if (*st >= 4) {
+        *(u16 *)(c + 0x519c + off) = 0xb4;
+        *(u8 *)(c + 0x51a1 + off) = 2;
+        {
+            int *p = (int *)(((int)c + 0x51c8) & 0xFFFFFFFFFFFFFFFF);
+            *st = 0;
+            *counter = 0;
+            *p = *p + 1;
+        }
+    } else {
         *(u8 *)(c + 0x51a3 + off) = data_ov006_0212e310[*st];
-        return;
-    }
-    *(u16 *)(c + 0x519c + off) = 0xb4;
-    *(u8 *)(c + 0x51a1 + off) = 2;
-    {
-        int *p = (int *)(c + 0x51c8);
-        *st = 0;
-        *counter = 0;
-        *p = *p + 1;
     }
 }

--- a/src/func_ov006_020f6538.c
+++ b/src/func_ov006_020f6538.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov004_020b67f8(void);
 extern void func_ov004_020b0a54(int);
 extern void func_ov004_020adb1c(int self);
@@ -22,7 +19,8 @@ void func_ov006_020f6538(char *c)
     if (*(unsigned short *)(c + 0x53e4) == 0)
         goto zero;
 
-    *(unsigned short *)(c + 0x53e4) = *(unsigned short *)(c + 0x53e4) - 1;
+    *(unsigned short *)(((int)c + 0x53e4) & 0xffffffffffffffffLL) =
+        *(unsigned short *)(((int)c + 0x53e4) & 0xffffffffffffffffLL) - 1;
     if (*(short *)(c + 0x53e4) > 0)
         return;
 
@@ -35,7 +33,7 @@ void func_ov006_020f6538(char *c)
         p = func_020beb68;
         if (p != 0) {
             if (p->b4 < 0x270f)
-                p->b4++;
+                *(int *)(((int)p + 0xb4) & 0xffffffffffffffffLL) += 1;
             if (p->b4 > p->b8)
                 p->b8 = p->b4;
         }
@@ -48,7 +46,7 @@ void func_ov006_020f6538(char *c)
     p = func_020beb68;
     if (p != 0) {
         if (p->b4 > 0)
-            p->b4--;
+            *(int *)(((int)p + 0xb4) & 0xffffffffffffffffLL) -= 1;
     }
     func_ov006_020c0d68(c + 0x4f38);
     return;

--- a/src/func_ov006_020fb4e0.c
+++ b/src/func_ov006_020fb4e0.c
@@ -1,42 +1,37 @@
-// NONMATCHING: different op / idiom (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
-extern int RandomIntInternal(int* seed);
-extern int data_0209d4b8;
+    extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
+    extern int RandomIntInternal(int* seed);
+    extern int data_0209d4b8;
 
-struct E { char pad[0x1c]; };
+    struct E { char pad[0x1c]; };
 
-void func_ov006_020fb4e0(char* c, int idx)
-{
-    int off;
-    short* p;
-    unsigned int v;
-    off = idx * 0x1c;
-    p = (short*)((char*)&((struct E*)(c + 0x5bc4))[idx]);
-    if (*(unsigned short*)p != 0) {
-        *p = *(unsigned short*)p - 1;
-        if (*p < 0) *p = 0;
-        return;
+    #pragma opt_common_subs off
+    void func_ov006_020fb4e0(char* c, int idx)
+    {
+        int off;
+        short* p;
+        unsigned int v;
+        off = idx * 0x1c;
+        p = (short*)((char*)&((struct E*)(c + 0x5bc4))[idx]);
+        if (*(unsigned short*)p != 0) {
+            *p = *(unsigned short*)p - 1;
+            if (*p < 0) *p = 0;
+            return;
+        }
+        _ZN5Sound12PlayBank2_2DEj(0x188);
+        *(char*)(c + off + 0x5000 + 0xbc8) = 1;
+        v = (((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) << 1;
+        v = v >> 0xf;
+        *(char*)(c + off + 0x5000 + 0xbc9) = v;
+        if (v != 0) {
+            *(char*)(c + off + 0x5000 + 0xbc7) = 1;
+            *(int*)(c + off + 0x5000 + 0xbb0) = -0x10000;
+            *(int*)(c + off + 0x5000 + 0xbb8) = 0x400;
+        } else {
+            *(char*)(c + off + 0x5000 + 0xbc7) = 1;
+            *(int*)(c + off + 0x5000 + 0xbb0) = 0x110000;
+            *(int*)(c + off + 0x5000 + 0xbb8) = -0x400;
+        }
+        *(int*)(c + off + 0x5000 + 0xbb4) = -0xf8000;
+        *(char*)(c + off + 0x5000 + 0xbca) = ((((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 3 >> 0xf) + 2;
+        *(int*)(c + off + 0x5000 + 0xbbc) = 0x2000;
     }
-    _ZN5Sound12PlayBank2_2DEj(0x188);
-    *(char*)(c + off + 0x5000 + 0xbc8) = 1;
-    v = (((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) << 1;
-    v = v >> 0xf;
-    *(char*)(c + off + 0x5000 + 0xbc9) = v;
-    if (v != 0) {
-        *(char*)(c + off + 0x5000 + 0xbc7) = 1;
-        *(int*)(c + off + 0x5000 + 0xbb0) = -0x10000;
-        *(int*)(c + off + 0x5000 + 0xbb8) = 0x400;
-    } else {
-        *(char*)(c + off + 0x5000 + 0xbc7) = 1;
-        *(int*)(c + off + 0x5000 + 0xbb0) = 0x110000;
-        *(int*)(c + off + 0x5000 + 0xbb8) = -0x400;
-    }
-    *(int*)(c + off + 0x5000 + 0xbb4) = -0xf8000;
-    v = ((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff;
-    v = (v * 3) >> 0xf;
-    v = v + 2;
-    *(char*)(c + off + 0x5000 + 0xbca) = v;
-    *(int*)(c + off + 0x5000 + 0xbbc) = 0x2000;
-}

--- a/src/func_ov006_02104ecc.cpp
+++ b/src/func_ov006_02104ecc.cpp
@@ -1,19 +1,17 @@
 //cpp
-// NONMATCHING: different op / idiom (div=31). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" void func_ov004_020b0aa0(int arg);
 extern "C" void func_ov006_02106048(char* c);
 extern "C" void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 
 extern "C" void func_ov006_02104ecc(char* c)
 {
-    int* a = (int*)(c + 0x4660);
-    int* b = (int*)(c + 0x4668);
-    *a += *b;
+    int* a = (int*)(((int)c + 0x4660) & 0xFFFFFFFFFFFFFFFF);
+    *a += *(int*)(c + 0x4668);
+    int* b = (int*)(((int)c + 0x4668) & 0xFFFFFFFFFFFFFFFF);
     *b -= 0x400;
     if ((*(int*)(c + 0x4660) >> 12) > -0x40) return;
-    *(int*)(c + 0x4cac) += 1;
+    int* e = (int*)(((int)c + 0x4cac) & 0xFFFFFFFFFFFFFFFF);
+    (*e)++;
     *(unsigned char*)(c + 0x4675) = 4;
     *(int*)(c + 0x4660) = 0x10000;
     *(int*)(c + 0x4664) = 0x24000;


### PR DESCRIPTION
Refine cascade over the near-miss DB (div≤40 structural tier). All functions linkcheck VERIFIED (0 diffs, 0 blind).

### Opus refine (6 landed, 83K tok/landed)
| function | module | lever |
|---|---|---|
| `func_ov002_020ec80c` | ov002 | in-place `sl` accumulate reuses the param reg; split shift reassignment blocks copy-prop |
| `func_ov006_020fb4e0` | ov006 | `opt_common_subs off` stops cross-call CSE of `c+off`; collapse 2nd RandomInt keeps `v` in r0 past the mul |
| `func_ov006_020f6538` | ov006 | u64-mask launder all three RMWs (timer + `b4++`/`--`) forces full-address materialization |
| `func_ov006_020dc5c4` | ov006 | if/else big-THEN small-ELSE if-converts to a predicated `lo` block; 0x51c8 u64-launder base |
| `func_ov006_02104ecc` | ov006 | u64-launder a/b/e pointers → pool materialization; dropping the base var frees a callee-saved reg + slot |
| `func_ov002_020edb3c` | ov002 | volatile escaped-address struct forces the dead 0x10 frame; real C++ virtual dispatch homes `this` in r0 |

_(Fable escalation on the close misses — incl. a div-1 near-match — is in flight; this PR will be updated.)_

src-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)