### PR TITLE
Match 3 functions via Fable escalation (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020b6494.c
+++ b/src/func_ov002_020b6494.c
@@ -1,6 +1,3 @@
-// NONMATCHING: missing logic (ROM does more) (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -16,10 +13,12 @@ int func_ov002_020b6494(char* c){
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
   }
-  *(u16*)(c+0x328) += 0x100;
+  *(u16*)(((int)c + 0x328) & 0xFFFFFFFFFFFFFFFF) += 0x100;
   {
-    s16 a = data_02082214[((u16)*(s16*)(c+0x328) >> 4) * 2];
-    *(int*)(c+0x60) = *(int*)(c+0x60) - (int)((((s64)*(int*)(c+0x324) * a) + 0x800) >> 0xc);
+    u16 h = (u16)(((s64)*(s16*)(c+0x328)) & 0xFFFFFFFFFFFFFFFF);
+    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
+      *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)
+      - (int)((((s64)*(int*)(c+0x324) * data_02082214[(h >> 4) * 2]) + 0x800) >> 0xc);
   }
   {
     int d = *(int*)(c+0x60) - *(int*)(c+0x320);

--- a/src/func_ov004_020b4360.c
+++ b/src/func_ov004_020b4360.c
@@ -1,0 +1,76 @@
+typedef short s16;
+typedef unsigned short u16;
+typedef long long s64;
+
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern int func_02053200(int x);
+struct M { int _00, _01, _10, _11; };
+struct B { unsigned int pad : 16; unsigned int f : 9; unsigned int hi : 7; };
+extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, struct M* a5);
+
+#pragma opt_propagation off
+void func_ov004_020b4360(char* self) {
+    u16 flag;
+    int val = *(int*)(self + 0x24);
+    if (val == 0) return;
+    {
+        char* el = self + 0x34;
+        if (val < 0x1e000) {
+            int d;
+            int scale;
+            if (val < 0x14000) {
+                int t;
+                d = (int)(((s64)val * 0x100 + 0x800) >> 12);
+                t = _ZN4cstd4fdivEii(d, 0x1400);
+                scale = (int)(((s64)t * 0x1400 + 0x800) >> 12);
+            } else {
+                int a = (int)(((s64)(val - 0x14000) * 0x66 + 0x800) >> 12);
+                int b = 0x1400 - a;
+                int t = _ZN4cstd4fdivEii(b - 0x1000, 0x400);
+                scale = (0x1000 - t) + (int)(((s64)t * 0x1400 + 0x800) >> 12);
+                d = b;
+            }
+            d = func_02053200(d);
+            {
+                struct M m = {0};
+                m._00 = d;
+                m._11 = d;
+                scale = 0x1000 - scale;
+                do {
+                    s16 f = (s16)((((unsigned int)(*(int*)el << 7)) >> 23) & 0xFFFFFFFFFFFFFFFFull);
+                    int off;
+                    if (f > 0x100) f -= 0x200;
+                    off = f * scale;
+                    func_ov004_020b1c68(el,
+                                        *(s16*)(self + 0x10) - ((off << 4) >> 16),
+                                        *(s16*)(self + 0x12), *(int*)(self + 0x1c),
+                                        *(int*)(self + 0x18), &m);
+                    flag = *(u16*)(el + 6);
+                    el += 8;
+                } while (flag != 0xffff);
+            }
+        } else {
+            int idx = (val - 0x1e000) >> 2;
+            int i = 0x1000;
+            do {
+                int diff = idx - i;
+                int r = 0x1000;
+                if (diff < 0) diff = -diff;
+                if (diff < 0x1000) {
+                    r += (int)(((s64)(0x1000 - diff) * 0x400 + 0x800) >> 12);
+                }
+                r = func_02053200(r);
+                {
+                    struct M m2 = {0};
+                    m2._00 = r;
+                    m2._11 = r;
+                    func_ov004_020b1c68(el, *(s16*)(self + 0x10), *(s16*)(self + 0x12),
+                                        *(int*)(self + 0x1c), *(int*)(self + 0x18), &m2);
+                }
+                i += 0x1000;
+                flag = *(u16*)(el + 6);
+                el += 8;
+            } while (flag != 0xffff);
+        }
+    }
+}

--- a/src/func_ov007_020b2614.c
+++ b/src/func_ov007_020b2614.c
@@ -1,6 +1,3 @@
-// NONMATCHING: missing logic (ROM does more) (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef struct G {
     char pad[0xf4];
     char* p_f4;
@@ -25,9 +22,9 @@ void func_ov007_020b2614(int self, int b, int c) {
         func_ov007_020bc3dc((char*)data_ov007_0210342c->p_f4, self, b, c);
         *(int*)((char*)data_ov007_0210342c->p_f4 + 0x94) = 1;
         *(int*)((char*)data_ov007_0210342c->p_f4 + 0x98) = 1;
-        func_ov007_020bc2e4(data_ov007_0210342c->p_f4, self, b);
-        func_ov007_020bc32c(data_ov007_0210342c->p_f4, self, b);
     }
+    func_ov007_020bc2e4(data_ov007_0210342c->p_f4, self, b);
+    func_ov007_020bc32c(data_ov007_0210342c->p_f4, self, b);
     if (self == 0) {
         func_ov007_020be980(data_ov007_0210342c->p_100, 0, b);
         func_ov007_020be980(data_ov007_0210342c->p_104, 0, b);


### PR DESCRIPTION
Three residuals from the div≤40 Opus refine batch (whose 6 Opus matches merged as #534), cracked by Fable escalation from the narrowed drafts. All **linkcheck VERIFIED** (0 diffs, 0 blind).

| function | module | lever |
|---|---|---|
| `func_ov007_020b2614` | ov007 | **control-flow correctness fix** (not a codegen lever): the ROM's branch lands *on* the `020bc2e4` call, so both if/else paths run the `2e4`/`32c` calls — the draft wrongly nested them in the else-arm; the join also forces the per-basic-block pool rematerialization |
| `func_ov004_020b4360` | ov004 | u64-launder the 9-bit extract keeps `s16` `lsl`/`asr`; `opt_propagation off` → predicated `lslgt`/`asrgt`; assigning `d` before the `fdiv` call flips the s64 hi/lo temp swap |
| `func_ov002_020b6494` | ov002 | value-launder `((s64)load & ~0)` forces `ldrsh`+`lsl`/`lsr` where every cast/volatile form folded to `ldrh` |

src-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)