### PR TITLE
Match 7 functions via Fable escalation (recovered orphans from #531/#532/#536)

### DIFF
--- a/src/func_0205e6e4.c
+++ b/src/func_0205e6e4.c
@@ -1,0 +1,43 @@
+#pragma opt_loop_invariants off
+typedef unsigned char u8;
+
+struct Obj {
+  char pad00[0x14];
+  int f14;       // 0x14
+  int f18;       // 0x18
+  int f1c;       // 0x1c
+  u8 buf[0x40];  // 0x20
+  int f60;       // 0x60
+  int f64;       // 0x64
+};
+
+extern void func_0205e3d4(struct Obj*);
+
+int func_0205e6e4(struct Obj* obj, u8* p, int count) {
+  if (count == 0) return 0;
+  if (obj == 0 || p == 0) return 1;
+  if (obj->f60 != 0) { obj->f64 = 3; return 3; }
+  if (obj->f64 != 0) return obj->f64;
+  goto test;
+
+body:
+  {
+    int i = obj->f1c;
+    *(int *)(((int)obj + 0x1c) & 0xFFFFFFFFFFFFFFFF) += 1;
+    obj->buf[i] = *p;
+  }
+  *(int *)(((int)obj + 0x14) & 0xFFFFFFFFFFFFFFFF) += 8;
+  if (obj->f14 == 0) {
+    *(int *)(((int)obj + 0x18) & 0xFFFFFFFFFFFFFFFF) += 1;
+    if (obj->f18 == 0) obj->f64 = 1;
+  }
+  if (obj->f1c == 0x40) func_0205e3d4(obj);
+  p++;
+
+test:
+  if (count-- == 0) goto ret0;
+  if (obj->f64 != 0) goto ret0;
+  goto body;
+ret0:
+  return 0;
+}

--- a/src/func_02060b64.c
+++ b/src/func_02060b64.c
@@ -1,0 +1,102 @@
+typedef unsigned int u32;
+
+struct G {
+    char pad[0x18];
+    u32 f18;
+    u32 f1c;
+    u32 f20;
+    u32 f24;
+};
+
+extern struct G data_020a8180;
+extern char func_01ff8000;
+extern void func_02060cac(void);
+extern void func_02060d1c(void);
+extern u32 _ZN4CP1518GetDTCMBaseAddressEv(void);
+extern int _ZN3IRQ7DisableEv(void);
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);
+extern void _ZN4CP1526InvalidateInstructionCacheEjj(u32 a, u32 b);
+extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 n, void (*h)(void));
+extern void _ZN3IRQ15ClearInterruptsEj(u32 n);
+extern void _ZN3IRQ10EnableIRQsEj(u32 n);
+extern void _ZN4CP1516DrainWriteBufferEv(void);
+extern void _ZN3IRQ7RestoreEj(int n);
+
+#pragma opt_propagation off
+int func_02060b64(int *self)
+{
+    int *p;
+    struct G *g;
+    u32 dtcm;
+    int r7;
+    int r6;
+    int r5;
+    u32 base;
+    int aligned;
+    u32 d;
+    u32 end;
+    int cond1;
+    int saved;
+
+    p = self;
+    g = &data_020a8180;
+    r7 = 0;
+    r6 = 0;
+    r5 = 0;
+    aligned = 0;
+
+    base = g->f1c;
+
+    if ((base & 3) == 0) {
+        if (g->f24 <= 3) aligned = 1;
+    }
+
+    if (aligned != 0) {
+        int bad;
+        int reject;
+        u32 e2;
+        dtcm = g->f20;
+        d = _ZN4CP1518GetDTCMBaseAddressEv();
+        e2 = base + dtcm;
+        bad = 1;
+        reject = 0;
+
+        if (e2 > (u32)&func_01ff8000) {
+            if (base < 0x2000000) reject = bad;
+        }
+
+        if (reject == 0) {
+            if (d >= e2) goto set0;
+            if (d + 0x4000 > base) goto tail;
+        set0:
+            bad = 0;
+        }
+    tail:
+
+        if (bad == 0) r5 = 1;
+    }
+
+    if (r5 != 0) {
+        if (((g->f18 | g->f20) & 0x1ff) == 0) r6 = 1;
+    }
+
+    if (r6 != 0) {
+        if (g->f20 != 0) r7 = 1;
+    }
+
+    p[1] = (*(int *)0x27ffe60 & ~0x7000000) | 0xa1000000;
+
+    if (r7 != 0) {
+        saved = _ZN3IRQ7DisableEv();
+        _ZN4CP1527FlushAndInvalidateDataCacheEjj(g->f1c, g->f20);
+        _ZN4CP1526InvalidateInstructionCacheEjj(g->f1c, g->f20);
+        _ZN3IRQ13SetIRQHandlerEjPFvvE(0x80000, func_02060cac);
+        _ZN3IRQ15ClearInterruptsEj(0x80000);
+        _ZN3IRQ10EnableIRQsEj(0x80000);
+        _ZN4CP1516DrainWriteBufferEv();
+        _ZN3IRQ7RestoreEj(saved);
+        func_02060d1c();
+    }
+
+    return r7;
+}

--- a/src/func_ov002_020b8dd4.c
+++ b/src/func_ov002_020b8dd4.c
@@ -1,0 +1,92 @@
+typedef short s16;
+typedef struct { int m[12]; } Matrix4x3;
+typedef struct { int x, y, z; } Vector3;
+
+extern Matrix4x3 data_020a0e68;
+
+extern int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void *c, s16 a, s16 b, s16 d, int fix);
+extern void Matrix4x3_FromRotationY(Matrix4x3 *m, int angle);
+extern void MulVec3Mat4x3(Vector3 *v, Matrix4x3 *m, Vector3 *dst);
+extern void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+extern void _ZN13RaycastGroundC1Ev(char *thiz);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(char *thiz, Vector3 *v, void *actor);
+extern int _ZN13RaycastGround10DetectClsnEv(char *thiz);
+extern void _ZN13RaycastGroundD1Ev(char *thiz);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *thiz, void *clsn);
+extern void func_020383fc(void *p);
+extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *thiz);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *thiz);
+extern void func_020393a4(int *p, int v);
+extern void func_02039394(int *p, int v);
+extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *thiz, int a, int b);
+extern int Vec3_Dist(Vector3 *a, Vector3 *b);
+extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, Vector3 *pos, unsigned int e);
+extern int Vec3_HorzDist(Vector3 *a, Vector3 *b);
+extern void func_ov002_020f0438(void *thiz);
+
+int func_ov002_020b8dd4(char *c)
+{
+    Vector3 v;
+    Vector3 dst;
+    volatile Vector3 pos;
+    char ray[0x50];
+    char *q;
+
+    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(c, 0x1800, 0, 0, 0x96000) != 0) {
+        return 1;
+    }
+
+    if (*(int *)(c + 0x98) != 0) {
+        v.x = 0;
+        dst.x = 0;
+        dst.y = 0;
+        dst.z = 0;
+        v.y = 0x96000;
+        v.z = 0x96000;
+        Matrix4x3_FromRotationY(&data_020a0e68, *(s16 *)(c + 0x94));
+        MulVec3Mat4x3(&v, &data_020a0e68, &dst);
+        AddVec3(&dst, (Vector3 *)(c + 0x5c), &dst);
+        _ZN13RaycastGroundC1Ev(ray);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(ray, &dst, 0);
+        if (_ZN13RaycastGround10DetectClsnEv(ray) != 0) {
+            if (*(int *)(c + 0x4e8) != *(int *)(ray + 0x44)) {
+                *(int *)(c + 0x98) = 0;
+            }
+        } else {
+            *(int *)(c + 0x98) = 0;
+        }
+        _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+        func_020383fc(c + 0x320);
+        _ZN8Platform21UpdateModelPosAndRotYEv(c);
+        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        _ZN13RaycastGroundD1Ev(ray);
+    }
+
+    func_020393a4((int *)(c + 0x124), 0x12c000);
+    func_02039394((int *)(c + 0x124), 0x96000);
+    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x3e8000, 0x96000);
+
+    if (*(int *)(c + 0x98) != 0 && Vec3_Dist((Vector3 *)(c + 0x5c), (Vector3 *)(c + 0x68)) != 0) {
+        *(unsigned int *)(c + 0x4ec) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int *)(c + 0x4ec), 3, 0x97, (Vector3 *)(c + 0x74), 0);
+    }
+
+    if (Vec3_HorzDist((Vector3 *)(c + 0x4dc), (Vector3 *)(c + 0x5c)) >= 0x12c000) {
+        if (*(int *)(c + 0x4f0) != 0) {
+            if (*(unsigned short *)(*(int *)(c + 0x4f0) + 0xc) == 0x149) {
+                pos.x = *(int *)(c + 0x4dc);
+                pos.y = *(int *)(c + 0x4e0);
+                pos.z = *(int *)(c + 0x4e4);
+                pos.y = *(int *)(c + 0x4e0) + 0x96000;
+                q = *(char **)(c + 0x4f0);
+                *(int *)(q + 0x5c) = *(int *)(c + 0x4dc);
+                *(int *)(q + 0x60) = pos.y;
+                *(int *)(q + 0x64) = pos.z;
+                func_ov002_020f0438(*(void **)(c + 0x4f0));
+            }
+            *(void **)(c + 0x4f0) = 0;
+        }
+    }
+
+    *(int *)(c + 0x98) = 0;
+    return 1;
+}

--- a/src/func_ov002_020cc05c.c
+++ b/src/func_ov002_020cc05c.c
@@ -1,0 +1,31 @@
+typedef unsigned char u8;
+typedef short s16;
+typedef long long s64;
+extern u8 data_020a0e40;
+extern s16 data_0209f4a2[];
+void func_ov002_020cc05c(char *self)
+{
+    int idx = data_020a0e40 * 0x18;
+    s16 curval = *(s16*)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFull);
+    *(s16*)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFull) = curval + (s16)(int)(((s64)*(s16*)((char*)data_0209f4a2 + idx) * 0x80 + 0x800) >> 12);
+    {
+        s16 tv2 = *(s16*)((char*)data_0209f4a2 + idx);
+    {
+        s16 av = tv2;
+        if (av < 0) av = (s16)(-av);
+        {
+            int mag32 = (int)(((s64)av * 0x480 + 0x800) >> 12);
+            s16 mag = (s16)mag32;
+            s16 nmag = (s16)(-mag);
+            s16 cur2 = *(s16*)(self + 0x600 + 0x9c);
+            s16 result;
+            if (cur2 < nmag) result = nmag;
+            else {
+                if (cur2 <= mag) mag = cur2;
+                result = mag;
+            }
+            *(s16*)(self + 0x600 + 0x9c) = result;
+        }
+    }
+}
+}

--- a/src/func_ov002_020f30f8.c
+++ b/src/func_ov002_020f30f8.c
@@ -1,0 +1,48 @@
+extern void func_ov002_020f2f18(char *c, int a, int b);
+extern void SetSubBg1Offset(int a, int b);
+extern void SetSubBg2Offset(int a, int b);
+
+void func_ov002_020f30f8(char *o, int i)
+{
+    int idx = i * 0x30;
+    unsigned short t;
+    int oldA, oldB;
+    int cc, dd, ee, ff;
+
+    t = *(unsigned short *)(o + 0x158 + idx);
+    if (t != 0) {
+        *(unsigned short *)(o + 0x158 + idx) = t - 1;
+        return;
+    }
+
+    *(int *)(o + 0x140 + idx) -= *(int *)(o + 0x150 + idx);
+    *(int *)(o + 0x144 + idx) -= *(int *)(o + 0x154 + idx);
+    *(int *)(o + 0x148 + idx) += *(int *)(o + 0x150 + idx);
+    *(int *)(o + 0x14c + idx) += *(int *)(o + 0x154 + idx);
+
+    oldA = *(int *)(o + 0x130 + idx);
+    oldB = *(int *)(o + 0x134 + idx);
+    *(int *)(o + 0x130 + idx) = oldA + *(int *)(o + 0x150 + idx);
+    *(int *)(o + 0x134 + idx) += *(int *)(o + 0x154 + idx);
+
+    if (*(int *)(o + 0x130 + idx) >= 0) *(int *)(o + 0x130 + idx) = 0;
+    if (*(int *)(o + 0x134 + idx) >= 0) *(int *)(o + 0x134 + idx) = 0;
+    if (*(int *)(o + 0x140 + idx) < 0) *(int *)(o + 0x140 + idx) = 0;
+    if (*(int *)(o + 0x144 + idx) < 0) *(int *)(o + 0x144 + idx) = 0;
+    if (*(int *)(o + 0x148 + idx) >= 0xff000) *(int *)(o + 0x148 + idx) = 0xff000;
+    if (*(int *)(o + 0x14c + idx) >= 0xc0000) *(int *)(o + 0x14c + idx) = 0xc0000;
+    if (*(int *)(o + 0x130 + idx) > 0) *(int *)(o + 0x130 + idx) = 0;
+    if (*(int *)(o + 0x134 + idx) > 0) *(int *)(o + 0x134 + idx) = 0;
+
+    cc = *(int *)(o + 0x130 + idx) - oldA;
+    func_ov002_020f2f18(o, cc, *(int *)(o + 0x134 + idx) - oldB);
+
+    ee = *(int *)(o + 0x148 + idx) >> 12;
+    ff = *(int *)(o + 0x14c + idx) >> 12;
+    cc = *(int *)(o + 0x140 + idx) >> 12;
+    dd = *(int *)(o + 0x144 + idx) >> 12;
+    *(unsigned short *)0x4001042 = ((cc << 8) & 0xff00) | (ee & 0xff);
+    *(unsigned short *)0x4001046 = ((dd << 8) & 0xff00) | (ff & 0xff);
+    SetSubBg1Offset(*(int *)(o + 0x130 + idx) >> 12, *(int *)(o + 0x134 + idx) >> 12);
+    SetSubBg2Offset(*(int *)(o + 0x130 + idx) >> 12, *(int *)(o + 0x134 + idx) >> 12);
+}

--- a/src/func_ov006_020ed8a4.c
+++ b/src/func_ov006_020ed8a4.c
@@ -1,0 +1,64 @@
+typedef int s32;
+typedef short s16;
+typedef unsigned char u8;
+
+typedef struct { int a, b; } Pair;
+
+extern int func_ov006_020ebe6c(void);
+extern int RandomIntInternal(int *seed);
+extern void func_ov006_020ebd7c(int count);
+extern void func_ov006_020ecdb8(char *self, int arg1, int arg2);
+extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
+
+extern s16 data_ov006_0212e80c[];
+extern volatile int data_ov006_0212e820[];
+extern volatile s16 data_ov006_02141fd8;
+extern int data_ov006_0213c958;
+extern int data_0209e650;
+extern Pair data_ov006_0213c964;
+
+void func_ov006_020ed8a4(char *r4) {
+    if (*(s32 *)(r4 + 0xbc) < 0xa) {
+        int bc = *(s32 *)(r4 + 0xbc);
+        data_ov006_02141fd8 = data_ov006_0212e80c[bc];
+        data_ov006_0213c958 = data_ov006_0212e820[bc];
+    } else {
+        int ret = func_ov006_020ebe6c();
+        data_ov006_02141fd8 = ret;
+        if (ret == 3) {
+            data_ov006_0213c958 = 0xf;
+        } else {
+            unsigned int rnd = RandomIntInternal(&data_0209e650) & 0x7fffffff;
+            data_ov006_0213c958 = ((int)(rnd >> 19) * 3 >> 12) + 3;
+        }
+    }
+
+    if (*(unsigned int *)(r4 + 0xbc) < 0xa)
+        func_ov006_020ebd7c(2);
+    else
+        func_ov006_020ebd7c(3);
+
+    {
+        int i = 0;
+        if (data_ov006_0213c958 > 0) {
+            char *p = (char *)(r4 + 0x4678);
+            do {
+                func_ov006_020ecdb8(p, i, *(s32 *)(r4 + 0xbc));
+                i++;
+                p += 0x98;
+            } while (i < data_ov006_0213c958);
+        }
+    }
+
+    {
+        unsigned int rnd = RandomIntInternal(&data_0209e650) & 0x7fffffff;
+        int k = (int)(rnd >> 19) * data_ov006_0213c958 >> 12;
+        *(char **)(r4 + 0x4f60) = (char *)(r4 + 0x4678) + k * 0x98;
+        *(s32 *)(*(char **)(r4 + 0x4f60) + 0x70) = 0;
+        *(s32 *)(r4 + 0x4668) = 0x3c;
+        func_ov004_020b0cac(0xd, 0x80, 0x50, 1, -1, 0xd);
+        *(s32 *)(r4 + 0x4674) = 0x3c;
+        *(u8 *)(r4 + 0x4f64) = 0;
+        *(Pair *)(r4 + 0x4660) = data_ov006_0213c964;
+    }
+}

--- a/src/func_ov006_02124088.c
+++ b/src/func_ov006_02124088.c
@@ -1,0 +1,65 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+
+extern void func_ov006_020d0ac0(void);
+extern int func_02054d88(void);
+extern void MultiStore16(u16 val, char *dst, int nbytes);
+extern void func_ov006_020d0b78(void);
+extern void func_02012718(void *a, int b);
+extern void func_ov006_02124040(char *c);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern int RandomIntInternal(int *seed);
+extern int func_020126e8(int a);
+extern int func_02012468(int a, int b, int c, int d, int e, int f, int g, int h);
+extern int func_ov004_020ae5c4(void *a, int b, int c, int d, int e, int f, int g);
+
+extern s16 data_ov006_0212e058;
+extern s16 data_ov006_0212e050;
+extern s16 data_ov006_0212e048;
+extern int data_0209e650;
+
+void func_ov006_02124088(char *c)
+{
+    int counter;
+
+    func_ov006_020d0ac0();
+    *(int *)(((long long)(int)(c + 0x7b84)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    counter = *(int *)(c + 0x7b84);
+
+    if (counter == 0) {
+        if (*(u8 *)(c + 0xc4) == 0) {
+            *(u8 *)(c + 0xc3) = 1;
+            *(u8 *)(c + 0xc4) = 1;
+            *(s16 *)(c + 0xc0) = 0;
+        }
+
+        {
+            int dst = func_02054d88();
+            volatile u16 tmp = 0;
+            MultiStore16(tmp, (char *)dst, 0x6000);
+        }
+
+        func_ov006_020d0b78();
+        func_02012718((void *)0x1af, 0x8000);
+        func_ov006_02124040(c);
+        return;
+    }
+
+    {
+        int t = _ZN4cstd4fdivEii(counter << 12, 0x5a000);
+        volatile s16 old9c = *(s16 *)(c + 0x7b9c);
+        volatile s16 old9e = *(s16 *)(c + 0x7b9e);
+        int mixRaw = data_ov006_0212e050 * t + data_ov006_0212e058 * (0x1000 - t);
+        *(s16 *)(c + 0x7b9c) = (s16)(mixRaw >> 12);
+        *(s16 *)(c + 0x7b9e) = data_ov006_0212e048;
+
+        *(s16 *)(((long long)(int)(c + 0x7b9e)) & 0xFFFFFFFFFFFFFFFFLL) +=
+            ((((int)((unsigned int)(RandomIntInternal(&data_0209e650) & ~0x80000000) >> 19) - 0x800) << 2) >> 12);
+
+        func_ov004_020ae5c4(c, old9c, old9e, *(s16 *)(c + 0x7b9c), *(s16 *)(c + 0x7b9e), 2, 0xc);
+
+        *(int *)(c + 0x7b8c) = func_02012468(*(int *)(c + 0x7b8c), 2, 0x1b0, 2, 0,
+                                              func_020126e8(mixRaw), 0, 0);
+    }
+}


### PR DESCRIPTION
**Recovery PR.** These 7 verified Fable matches were silently orphaned: the fast auto-merges on #531/#532/#536 fired *between* each batch's Opus-commit push and its Fable-commit push, so the second (Fable) commit landed on an already-merged branch and never reached main — even though each PR body listed them. All 7 are still unmatched on main; re-verified **linkcheck VERIFIED against current main** (0 diffs, 0 blind).

| function | module | lever |
|---|---|---|
| `func_ov002_020f30f8` | ov002 | hoist arg1 before the call flips the r5/r4 CSE order |
| `func_0205e6e4` | arm9 | u64-launder 3 in-loop RMWs + `opt_loop_invariants off` |
| `func_ov002_020b8dd4` | ov002 | shared local `q` + int-typed null-check derefs defeat CSE |
| `func_02060b64` | arm9 | `bad=1` before `reject=0` + `opt_propagation off` |
| `func_ov006_02124088` | ov006 | volatile captures before the lerp rotate the free list |
| `func_ov006_020ed8a4` | ov006 | dual-`volatile` pins load/store to source order |
| `func_ov002_020cc05c` | ov002 | u64-launder inline twice; CSE gives pooled 0x69c |

Single commit (the two-commit split is what orphaned them). src-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)