### PR TITLE
Match 6 arm9 functions via refine cascade (Opus 4 + Fable 2)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -1309,6 +1309,55 @@ match at 1.2 and whether the divergent idiom appears ANYWHERE in the matched cor
 idiom is unique to that TU and a different mwccarm version reproduces it, stop -- it is a
 prebuilt object, and the div count is not a measure of how close you are.
 
+## 7a. The arm9 near-miss head: "register allocation" is a MISLABEL (2026-07-22, Opus->Fable cascade, 6 matches)
+
+The heuristic categorizer in `refine_wl.py` labelled ALL 14 arm9 near-miss drafts
+"register allocation" -- the category the router sends to the permuter and skips by
+default. That head had therefore NEVER been refined. It was wrong on 6 of 8: the
+residuals were structural, and 6 landed. **Run `refine_wl.py --include-all-cats` on a
+module whose head is uniformly one category** -- a uniform label is evidence of a
+categorizer failure, not of a real floor. (The same head is likely mislabelled in other
+modules; check before trusting the routing.)
+
+Levers that landed (all steer coloring/scheduling through SOURCE STRUCTURE, not pragmas):
+
+- **Reverse-order independent global stores** (`func_020338b0`, div 4->0). mwcc
+  re-reverses two adjacent independent stores to globals, so write the pair in the
+  REVERSE of the order you want emitted. Combined here with hoisting one store above an
+  `if` guard, which fixed an r1/r2-vs-r2/r3 scratch split.
+- **Block-scope the loop pointer, declare the counter last** (`func_0203128c`, div 6->0).
+  Scoping a pointer inside the if-body and declaring a distinct counter local AFTER it
+  flipped a pure r5/r6 swap. This is 6i applied to a loop induction pair.
+- **Stage a store-triple through a local struct temp, in emission order**
+  (`func_0200c394`, div 7->0). Three shifted s16->fx32 values assigned to `t.x/t.z/t.y`
+  in that order, then stored out, rotated the load/shift registers to r0/r3/r1/r2
+  exactly. A struct temp is a stronger ordering constraint than three scalars.
+- **Short-typed callee params hoist the narrowing** (`func_0205f77c`, div 8->0).
+  Declaring the callee with `unsigned short` params instead of keeping explicit u16
+  locals lets the compiler hoist the narrowing; explicit u16 temps rotated ALL
+  callee-saved coloring (a 720-permutation decl sweep bottomed at div 22). Cf. 6y.
+- **Arg pass-through keeps r0-r2 live to the `bl`** (`func_02068dc8`, div 4->0, Fable).
+  A callee declared `void`/no-args in the DB was really taking the caller's args:
+  passing `a,b,c` through costs zero instructions and holds r0-r2 live to the call,
+  rotating an early scratch temp onto r3. **This is the 6z `this`-liveness lever
+  generalized from C++ methods to plain args** -- suspect it whenever an early flag-load
+  temp lands one register too low.
+- **Drop an index temp for pure array subscripts** (`func_0203bc7c`, div 7->0, Fable).
+  After `#pragma opt_loop_invariants off` fixed the pooled base coloring, removing an
+  `ofs = i*2` temp in favour of `arr[i]` renumbered the vregs and slotted the induction
+  `add` into a load-use gap. An index temp is an extra vreg; subscripts are free.
+
+**Also confirmed here**: a low-div residual can be a COMPREHENSION bug. `func_0205f77c`'s
+last 3 divergences were not codegen at all -- the "discarded" tail IME read is the
+function's RETURN VALUE (`dummy = *IME; ... return dummy;`). Read the tail before
+declaring a floor.
+
+**Real floors from this batch** (both survived Opus 8 attempts AND Fable 8):
+`_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2` div 2 (coupled schedule+coalescing: the target
+needs the AND after the dependent `lsr` with dst on the pool-const register; any order
+that moves the AND later rotates t0 out of sl and blows div to 29-30) and `func_020729f4`
+div 3 (r0/r1 rotation on a loop-head tag byte, invariant under 12+ spellings).
+
 ---
 
 *Add to this file whenever you learn a new codegen rule. It is the project's accumulating

--- a/src/func_0200c394.c
+++ b/src/func_0200c394.c
@@ -1,0 +1,100 @@
+typedef struct { int x, y, z; } Vec3;
+
+extern signed char data_0209f2f8;
+extern int data_02087274, data_0208706c, data_0208715c, data_0208747c;
+extern int data_02087184, data_020871fc, data_02087224, data_0208733c, data_02087314;
+
+void Vec3_Sub(Vec3 *out, Vec3 *a, Vec3 *b);
+int LenVec3(Vec3 *v);
+int cstd_fdiv(int a, int b);
+void Vec3_MulScalarInPlace(Vec3 *v, int s);
+void Vec3_Add(Vec3 *out, Vec3 *a, Vec3 *b);
+void AddVec3(Vec3 *a, Vec3 *b, Vec3 *c);
+Vec3 *Vec3_AsrInPlace(Vec3 *v, int sh);
+
+int func_0200c394(void *self_, int a1, void *a2_, Vec3 *a3, void **a5, int *a6)
+{
+    char *self = (char *)self_;
+    unsigned char *a2 = (unsigned char *)a2_;
+    void *p = *(void **)(self + 0x13c);
+    Vec3 local, local2;
+    signed char g;
+    int flags = *(unsigned short *)((char *)p + 0x26);
+    int v;
+    short sz, sy, sx;
+
+    if ((flags & 0x20) == 0) {
+        v = *(int *)(self + 0x154) & 0x100;
+        if (v == 0) goto body;
+    }
+    return 0;
+body:
+    {
+            if (a1 == 7) {
+                void *o = *(void **)(self + 0x114);
+                if (o == 0) {
+                    if (a2 == 0) goto other;
+                    if (a2[0] != 3) goto other;
+                }
+                *a6 = 1;
+                o = *(void **)(self + 0x114);
+                if (o) {
+                    int qb = (int)o + 0x5c;
+                    *(int *)(self + 0x120) = *(int *)(qb & 0xFFFFFFFFFFFFFFFFLL);
+                    *(int *)(self + 0x124) = *(int *)(qb + 4);
+                    *(int *)(self + 0x128) = *(int *)(qb + 8);
+                } else {
+                    Vec3 t;
+                    sx = *(short *)(a2 + 2);
+                    sz = *(short *)(a2 + 6);
+                    sy = *(short *)(a2 + 4);
+                    t.x = sx << 12; t.z = sz << 12; t.y = sy << 12;
+                    *(int *)(self + 0x120) = t.x;
+                    *(int *)(self + 0x124) = t.y;
+                    *(int *)(self + 0x128) = t.z;
+                }
+                Vec3_Sub(&local, (Vec3 *)(self + 0x120), a3);
+                *(int *)(self + 0x12c) = LenVec3(&local) >> 1;
+                g = data_0209f2f8;
+                v = (g == 0x2d);
+                if (v) {
+                    if (*(int *)(self + 0x12c) < 0x100000) *(int *)(self + 0x12c) = 0x100000;
+                    else if (*(int *)(self + 0x12c) > 0x180000) *(int *)(self + 0x12c) = 0x180000;
+                } else {
+                    if (*(int *)(self + 0x12c) < 0x180000) *(int *)(self + 0x12c) = 0x180000;
+                }
+                if (*(int *)(self + 0x154) & 2) {
+                    *(int *)(self + 0x12c) = (int)(((long long)*(int *)(self + 0x12c) * 0x1800 + 0x800) >> 12);
+                }
+                if (g == 0x2f && *(int *)(self + 0x12c) > 0xc0000) {
+                    int s = cstd_fdiv(0xc0000, *(int *)(self + 0x12c) << 1);
+                    Vec3_MulScalarInPlace(&local, s);
+                    Vec3_Add(&local2, a3, &local);
+                    *(int *)(self + 0x120) = local2.x;
+                    *(int *)(self + 0x124) = local2.y;
+                    *(int *)(self + 0x128) = local2.z;
+                    *(int *)(self + 0x12c) = 0xc0000;
+                } else {
+                    AddVec3((Vec3 *)(self + 0x120), a3, (Vec3 *)(self + 0x120));
+                    Vec3_AsrInPlace((Vec3 *)(self + 0x120), 1);
+                }
+                *a5 = &data_02087274;
+                return v;
+            }
+
+        other:
+            if (flags & 4) {
+                return (p == &data_0208706c) ? 0 : 1;
+            }
+            if (p == &data_0208715c) {
+                if (v) { *a5 = &data_0208747c; }
+                else if (a1 == 8) { *a5 = &data_0208715c; }
+                else if (a1 == 6) { *a5 = &data_02087184; }
+                else if (a1 == 0xa) { *a5 = &data_020871fc; }
+                else if (a1 == 0xb) { *a5 = &data_02087224; }
+                else if (a1 == 9) { *a5 = &data_0208733c; }
+                else if (a1 == 2) { *a5 = &data_02087314; }
+            }
+            return 1;
+    }
+}

--- a/src/func_0203128c.c
+++ b/src/func_0203128c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: register allocation (div=6). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern unsigned char* data_0209fd0c;
 extern unsigned char NumStars(void);
 extern int func_020138dc(void);
@@ -20,7 +17,7 @@ void func_0203128c(void){
   int i;
   int q;
   int cnt;
-  unsigned char* pp;
+  int n2;
   g = data_0209fd0c;
   mode = (unsigned short)(g[4] | (g[3]<<8));
   switch(mode){
@@ -48,14 +45,14 @@ void func_0203128c(void){
     break;
   case 1:
     func_02031028(-1);
-    num = 0;
+    n2 = 0;
     if((int)data_0209fca0[0] > 0){
-      pp = data_02092818;
+      unsigned char* pp = data_02092818;
       do {
         func_02031b84(*pp);
-        num++;
+        n2++;
         pp++;
-      } while(num < (int)data_0209fca0[0]);
+      } while(n2 < (int)data_0209fca0[0]);
     }
     break;
   }

--- a/src/func_020338b0.cpp
+++ b/src/func_020338b0.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=19). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern "C" {
 extern short data_0209fce8;
 extern unsigned char data_0209fc9c;
@@ -19,26 +16,31 @@ void func_020338b0(int a, int b, short c, int d) {
     int p, s;
     volatile int li0, li1;
     volatile unsigned short ls0, ls1;
+    int zero = 0;
     data_0209fce8 = c;
-    data_0209fc9c = 0;
+    data_0209fc9c = zero;
     func_02034504();
-    data_0209fc78 = 0;
-    if (d >= 0) data_0209fc84 = d;
     data_0209fc94 = 1;
-    if (data_0209fce8 == 0x13) {
-        li0 = 0;
+    data_0209fc78 = zero;
+    if (d >= 0) data_0209fc84 = d;
+    switch (data_0209fce8) {
+    case 0x13:
+    case 0x15:
         p = _ZN3G2S13GetBG0CharPtrEv() + 0x4000;
+        li0 = 0;
         MultiStore_Int(li0, p, 0x3000);
         s = _ZN3G2S12GetBG0ScrPtrEv();
         ls0 = 0x37f;
         MultiStore16(ls0, s, 0x800);
-    } else if (data_0209fce8 == 0x15) {
-        li1 = 0;
+        break;
+    default:
         p = _ZN3G2S13GetBG0CharPtrEv() + 0x4000;
+        li1 = 0;
         MultiStore_Int(li1, p, 0x2000);
         s = _ZN3G2S12GetBG0ScrPtrEv();
         ls1 = 0x2ff;
         MultiStore16(ls1, s, 0x800);
+        break;
     }
     func_02033e50(a, b);
 }

--- a/src/func_0203bc7c.c
+++ b/src/func_0203bc7c.c
@@ -1,0 +1,43 @@
+#pragma opt_strength_reduction off
+#pragma opt_loop_invariants off
+
+typedef unsigned short u16;
+
+typedef struct InputPair
+{
+    u16 cur;
+    u16 pressed;
+} InputPair;
+
+extern unsigned char data_020a0e44;
+extern u16 data_020a0e48[4];
+extern u16 data_020a0e50[4];
+extern InputPair data_020a0e58[4];
+
+extern u16 func_0203dae4(int idx);
+
+void func_0203bc7c(void)
+{
+    InputPair *p = data_020a0e58;
+    int i;
+    data_020a0e44 = 0;
+    for (i = 0; i < 4; i++)
+    {
+        u16 keys = func_0203dae4(i);
+        u16 old;
+        int changed;
+        if ((keys & 0x30) == 0x30)
+            keys &= ~0x30;
+        if ((keys & 0xc0) == 0xc0)
+            keys &= ~0xc0;
+        if (keys == 0x30c)
+            data_020a0e44 = 1;
+        old = data_020a0e50[i];
+        changed = keys ^ old;
+        p->pressed = keys & changed;
+        data_020a0e48[i] = old & changed;
+        data_020a0e50[i] = keys;
+        p->cur = keys;
+        p++;
+    }
+}

--- a/src/func_0205f77c.cpp
+++ b/src/func_0205f77c.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: register allocation (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 struct IRQ {
     static unsigned int Disable();
     static unsigned int DisableIRQs(unsigned int);
@@ -10,18 +7,20 @@ struct IRQ {
 };
 struct CP15 { static void WaitForInterrupt(); };
 extern "C" void func_02059d8c(int x);
-extern "C" int func_0205fc44(int a, int b);
+extern "C" int func_0205fc44(unsigned short a, unsigned short b);
 extern "C" int func_0205f68c(int mode, int arg1, int arg2, int arg3);
 extern "C" int func_0205f958(void);
 extern "C" int func_0206a4a0(void);
 
 extern "C" int func_0205f77c(int mode, int arg1, int arg2)
 {
-    unsigned int saved_ime, saved_irq;
-    unsigned short old;
-    int flag = 0;
+    unsigned int saved_ime;
+    unsigned int saved_irq;
+    unsigned int flag = 0;
+    unsigned short old_ime;
+    unsigned short dummy;
 
-    old = *(volatile unsigned short *)0x4000208;
+    old_ime = *(volatile unsigned short *)0x4000208;
     *(volatile unsigned short *)0x4000208 = 0;
     saved_ime = IRQ::Disable();
     saved_irq = IRQ::DisableIRQs(0x3fffff);
@@ -36,9 +35,7 @@ extern "C" int func_0205f77c(int mode, int arg1, int arg2)
     if (mode & 0x10) {
         if (func_0206a4a0() == 0) mode &= ~0x10;
     }
-    arg1 = (unsigned short)(arg1 | arg2);
-    mode = (unsigned short)mode;
-    while (func_0205fc44(mode, arg1) != 0)
+    while (func_0205fc44(mode, arg1 | arg2) != 0)
         ;
 
     CP15::WaitForInterrupt();
@@ -53,8 +50,10 @@ extern "C" int func_0205f77c(int mode, int arg1, int arg2)
     IRQ::SetIRQs(saved_irq);
     IRQ::Restore(saved_ime);
 
-    *(volatile unsigned short *)0x4000208;
-    *(volatile unsigned short *)0x4000208 = old;
-    if (flag == 0) return 0;
-    return func_0205f958();
+    dummy = *(volatile unsigned short *)0x4000208;
+    *(volatile unsigned short *)0x4000208 = old_ime;
+    if (flag != 0) {
+        return func_0205f958();
+    }
+    return dummy;
 }

--- a/src/func_02068dc8.c
+++ b/src/func_02068dc8.c
@@ -1,0 +1,17 @@
+typedef unsigned short u16;
+typedef unsigned char u8;
+
+extern char* data_020a9db4;
+extern int func_02068e44(int, int, int);
+
+int func_02068dc8(int a, int b, int c)
+{
+    if (*(u8*)(data_020a9db4 + 0x1000 + 0x411))
+        return 0;
+    if (func_02068e44(a, b, c) == 0)
+        return 0;
+    *(u16*)(data_020a9db4 + 0x1300 + 0xe) = c;
+    *(u16*)(data_020a9db4 + 0x1400) = a;
+    *(u16*)(data_020a9db4 + 0x1400 + 2) = b;
+    return 1;
+}


### PR DESCRIPTION
Six arm9 near-misses converted to byte-exact matches, all from the committed near-miss DB.

### Why these were still sitting there

The arm9 near-miss head (div 4-8) had **never been refined**: every arm9 draft is categorized `"register allocation"`, the category `refine_wl.py` routes to the permuter and skips by default. That label was wrong on 6 of 8 — the residuals were structural. Worth noting for future batches: a *uniform* category label across a module's head is evidence the heuristic categorizer failed, not that the head is floor. `refine_wl.py --include-all-cats` surfaces them.

### Opus stage (4/8, ~38K tok/landed)

| function | div | lever |
|---|---|---|
| `func_020338b0` | 4 → 0 | write the independent global-store pair in **reverse** source order; mwcc re-reverses them |
| `func_0203128c` | 6 → 0 | block-scope the loop pointer, declare the counter local last (r5/r6 flip) |
| `func_0200c394` | 7 → 0 | stage the three shifted values through a local `Vec3` temp in x/z/y order |
| `func_0205f77c` | 8 → 0 | callee declared with `unsigned short` params so narrowing is hoisted; the "discarded" tail IME read is actually the **return value** |

### Fable escalation on Opus's floor-declared misses (2/4)

| function | div | lever |
|---|---|---|
| `func_02068dc8` | 4 → 0 | pass `a,b,c` through to the callee so r0-r2 stay live to the `bl`, rotating the flag temp to r3 |
| `func_0203bc7c` | 7 → 0 | hoist the `0x30c` check above the old-load, drop the `i*2` temp for pure array subscripts |

### Verification

Link-gated: **5 VERIFIED**, `func_0200c394` **BLIND-1** (one unresolvable reloc slot, zero diffs).

`func_020338b0` and `func_0205f77c` were committed NONMATCHING drafts (`.c`) and become matching sources (`.cpp`); `func_0203128c`'s draft is updated in place.

The 2 remaining misses stay parked as genuine coloring floors — `OAM::Render` (div 2, coupled schedule+coalescing) and `func_020729f4` (div 3, r0/r1 rotation on a loop-head tag byte) — each unmoved by 8 Opus plus 8 Fable attempts.

Levers written up in `notes/mwccarm-codegen.md` section 7a, including the `this`-liveness lever generalized from C++ methods to plain args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzF9T9FdeAbwq1GBg55oVB
