### PR TITLE
Match 4 arm9 functions via refine cascade (Opus 3 + Fable 1)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -1358,6 +1358,61 @@ needs the AND after the dependent `lsr` with dst on the pool-const register; any
 that moves the AND later rotates t0 out of sl and blows div to 29-30) and `func_020729f4`
 div 3 (r0/r1 rotation on a loop-head tag byte, invariant under 12+ spellings).
 
+## 7b. Second arm9 head cascade (2026-07-22, 4 matches) + an amendment to 6t/6u
+
+Follow-on to 7a, on the arm9 drafts carrying *structural* categories (predicate vs branch,
+missing logic, constant/value). Opus 4/12, Fable 4/9 on the misses.
+
+**AMENDMENT to sec 6t/6u**: the claim that an `asm` block "cannot spell `ldm{cond}` /
+`bx{cond}`" is **WRONG**. mwccarm assembles `ldmeqia sp!, {lr}` (the explicit `ia` suffix is
+what it wants) and `bxeq lr` directly. It also accepts `DCD 0x<word>` for hand-encoded
+instructions where `dc.l` / `dc.w` / `opword` / `.long` all fail to compile -- useful to know
+for the leaf-library asm files. The *C-side* predication floor in 6u is real and was
+re-confirmed twice: plain C predicates the middle guard into `movne` (div 6) and no source
+form reaches the ROM's conditional-return pair. **This does not make asm the answer for game
+logic** -- `func_02068398` matches byte-exact as a whole-function `asm` block and was
+deliberately NOT banked; it stays a near-miss. Whole-function asm for game logic is an asm
+transcription, not a decompilation.
+
+Levers that landed:
+
+- **Fake-dependency store reordering** (`Particle::CheckLavaCallback::SpawnParticles`, div 2->0).
+  To make a Vector3 field be *computed* first but *stored* second, hoist it into a temp and
+  reference the temp in a degenerate ternary on the other store:
+  `vy = <y expr>; v.x = vy ? sx<<3 : sx<<3;`. Generalizes 6y's fake-dependency trick to
+  store-emission order.
+- **Mixed temp/RMW interleave beats both pure families** (`Camera::Render`, div 4->0, Fable).
+  On a 6-element `(x+4)>>3` writeback, *def order* pins register/slot assignment while
+  *store-statement order* pins emission. Pure-temp and pure-RMW forms both floor (an
+  exhaustive 720-permutation sweep bottomed at div 4); temps for a SUBSET (0,1,2,4) with
+  def order (2,1,0,5,4,3) let the stores run ascending while holding the coloring. When a
+  store block resists, mix the two idioms rather than permuting within one.
+- **Volatile must cover BOTH sides of a str/ldr pair** (`func_0206dac4`, Fable). Volatile on
+  the counter global alone was ignored by the scheduler for the non-volatile array load;
+  volatile on the counter *and* the fn-ptr array, plus a temp index
+  (`i = cnt-1; cnt = i; arr[i]();`), pinned str-before-ldr. Extends the 6-family volatile
+  lever: the scheduler only serializes a pair when both ends are volatile.
+  (NOTE: this function was matched concurrently upstream in #542 and was not banked here.)
+- **Read the callee's real width and arity** (`func_02059c18`, div 6->0). The callee returned
+  a full `long long` (the `sbc` subtracts BOTH words) and took a third arg the ROM never
+  materializes -- `mov r2,#0` is absent because r2 already held a CSE'd zero from an earlier
+  `*(vu16*)0x4000106 = 0` store, which is exactly what kept r2 live and pushed another load
+  onto ip. A "missing" argument set-up instruction is evidence of a live CSE'd constant, not
+  of a missing argument.
+- **Control flow again, not codegen** (`OAM::Reset`, div 4->0). The if-arm's branch skipped
+  past two `MultiCopy32Bytes` calls AND a zero-store pair, so five statements belonged inside
+  the `else`; only two shared stores are the tail. This also explained an apparently
+  "duplicated" `mov r2,#0` (separate basic blocks). **Third such case in two batches** -- when
+  a residual includes a duplicated constant materialization, suspect basic-block structure
+  before reaching for a coloring lever.
+
+**Gate catch worth remembering**: `func_0205fb58` reached div 0 by merging a "phantom" symbol
+(`data_020a813c`) into one struct array at `data_020a8138` so mwcc folds the +4 field offset
+into a pool literal. The wildcarded byte oracle accepts it; the link gate rejected it
+(`WRONG-DEST reloc: data_020a8138 != config 0x020a813c`). If a merge like this is genuinely
+right, it is a CONFIG symbol-merge change, not a source spelling -- see the dsd symbol-split
+note in the session log.
+
 ---
 
 *Add to this file whenever you learn a new codegen rule. It is the project's accumulating

--- a/src/_ZN3OAM5ResetEv.cpp
+++ b/src/_ZN3OAM5ResetEv.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=13). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -18,10 +15,10 @@ extern OAMEntry data_0209e674[];
 extern int data_0209e67c[];
 extern int data_0209e694[];
 extern int data_0209ea74[];
-extern int data_0209e670;
-extern int data_0209e66c;
-extern int data_0209e664;
-extern int data_0209e668;
+extern volatile int data_0209e670;
+extern volatile int data_0209e66c;
+extern volatile int data_0209e664;
+extern volatile int data_0209e668;
 
 namespace OAM {
 void Reset() {
@@ -35,10 +32,12 @@ void Reset() {
         data_0209e674[0].a = 0xc0;
         data_0209e674[0].b = 0;
         MultiCopy_Int((int*)data_0209e674, data_0209e67c, 0x18);
+        MultiCopy32Bytes((int*)data_0209e674, data_0209e694, 0x3e0);
+        MultiCopy32Bytes((int*)data_0209e674, data_0209ea74, 0x400);
+        data_0209e670 = 0;
+        data_0209e66c = 0;
     }
-    MultiCopy32Bytes((int*)data_0209e674, data_0209e694, 0x3e0);
-    MultiCopy32Bytes((int*)data_0209e674, data_0209ea74, 0x400);
-    data_0209e670 = data_0209e66c = 0;
-    data_0209e664 = data_0209e668 = 0;
+    data_0209e664 = 0;
+    data_0209e668 = 0;
 }
 }

--- a/src/_ZN6Camera6RenderEv.cpp
+++ b/src/_ZN6Camera6RenderEv.cpp
@@ -1,0 +1,175 @@
+//cpp
+
+typedef short s16;
+typedef unsigned short u16;
+typedef unsigned char u8;
+typedef int s32;
+typedef unsigned int u32;
+typedef signed char s8;
+
+struct Vector3 { int x, y, z; };
+struct Matrix4x3 { int m[12]; };
+
+extern "C" {
+    s32 Vec3_Dist(const Vector3 *a, const Vector3 *b);
+    s32 Vec3_HorzDist(const Vector3 *a, const Vector3 *b);
+    void func_0200af20(void *self, s32 *a, s32 *b, s16 *c);
+    void func_0200d954(void *self, s16 arg);
+    void Matrix4x3_FromRotationZ(void *m, int angle);
+    void MulMat4x3Mat4x3(void *dst, void *a, void *b);
+
+    extern s32 data_0209fc48;
+    extern u8 data_0208738c;
+    extern void *data_ov002_0210c3b0;
+    extern void *data_ov002_0210c3e0[2];
+    extern u8 data_0209f20c;
+    extern u8 data_0209f294;
+    extern u8 data_0209f2c4;
+    extern s8 data_0209f2f8;
+    extern s32 data_0209ee90[];
+    extern s16 data_02082214[];
+    extern void *data_02086efc;
+    extern void *data_02086f08;
+    extern Matrix4x3 data_020a0e68;
+}
+
+struct OamAttr;
+
+struct OAM {
+    static void Render(bool, OamAttr *, int, int, int, int, int, int, int, int);
+};
+struct G2x {
+    static void SetBlendAlpha(volatile unsigned short *, u16, u16, u16, u16);
+};
+struct G3i {
+    static void PerspectiveW_(int, int, int, int, int, int, bool, Matrix4x3 *);
+    static void LookAt_(const Vector3 *, const Vector3 *, const Vector3 *, bool, Matrix4x3 *);
+};
+
+struct View {
+    int render();
+    int Render();
+};
+struct Camera : View {
+    int Render();
+};
+
+int Camera::Render()
+{
+    Camera *self = this;
+    s32 sp[6];
+    s16 sp18;
+    s16 var_r4;
+
+    sp[0] = *(s32 *)((char *)self + 0x80);
+    sp[1] = *(s32 *)((char *)self + 0x84);
+    sp[2] = *(s32 *)((char *)self + 0x88);
+    sp[3] = *(s32 *)((char *)self + 0x8c);
+    sp[4] = *(s32 *)((char *)self + 0x90);
+    sp[5] = *(s32 *)((char *)self + 0x94);
+    sp18 = *(s16 *)((char *)self + 0x17a);
+    var_r4 = *(s16 *)((char *)self + 0x178);
+
+    if (Vec3_Dist((Vector3 *)&sp[0], (Vector3 *)((char *)self + 0xc8)) < 0x1000 &&
+        Vec3_Dist((Vector3 *)&sp[3], (Vector3 *)((char *)self + 0xd4)) < 0x1000) {
+        sp[0] = *(s32 *)((char *)self + 0xc8);
+        sp[1] = *(s32 *)((char *)self + 0xcc);
+        sp[2] = *(s32 *)((char *)self + 0xd0);
+        sp[3] = *(s32 *)((char *)self + 0xd4);
+        sp[4] = *(s32 *)((char *)self + 0xd8);
+        sp[5] = *(s32 *)((char *)self + 0xdc);
+    }
+
+    if (!(data_0209fc48 != 0 ? 1 : 0)) {
+        s32 f = *(s32 *)((char *)self + 0x154);
+        if (!(f & 8)) {
+            if (*(u8 **)((char *)self + 0x13c) == &data_0208738c) {
+                OAM::Render(0, (OamAttr *)&data_ov002_0210c3b0, 0x80, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                G2x::SetBlendAlpha((volatile unsigned short *)0x04000050, 0x10, 0x2f, 0xc, 6);
+            } else {
+                if (f & 0x20) {
+                    OAM::Render(0, (OamAttr *)data_ov002_0210c3e0[0], 0x14, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                }
+                if (*(s32 *)((char *)self + 0x154) & 0x40) {
+                    OAM::Render(0, (OamAttr *)data_ov002_0210c3e0[1], 0xec, 0x60, -1, -1, 0x1000, 0x1000, 0, -1);
+                }
+            }
+            s32 t = *(s32 *)((char *)self + 0x168);
+            if (t != 0x1000) {
+                s32 d = 0xaaa - sp18;
+                sp18 = (s16)(sp18 + (s16)(((long long)d * t + 0x800) >> 12));
+            }
+            if (data_0209f20c == 0 && data_0209f294 == 0 &&
+                (u8)(data_0209f294 | (data_0209f2c4 | data_0209f20c)) != 0) {
+                func_0200af20(self, &sp[0], &sp[3], &sp18);
+            }
+        }
+    }
+
+    sp[1] += *(s32 *)((char *)self + 0x134);
+    sp[4] += *(s32 *)((char *)self + 0x134);
+
+    s16 tr3 = *(s16 *)((char *)self + 0x18c);
+    if (tr3 != 0) {
+        s16 c = data_02082214[((s32)*(u16 *)((char *)self + 0x18a) >> 4) * 2];
+        var_r4 = (s16)(var_r4 + (s16)(((long long)tr3 * c + 0x800) >> 12));
+    }
+
+    s16 tr0 = *(s16 *)((char *)self + 0x18e);
+    if (tr0 != 0) {
+        s16 c = data_02082214[((s32)*(u16 *)((char *)self + 0x192) >> 4) * 2 + 1];
+        s32 m = (int)(((long long)c * 0x360 + 0x800) >> 12);
+        sp18 = (s16)(sp18 + ((tr0 * m) << 4 >> 16));
+    }
+
+    func_0200d954(self, sp18);
+
+    *(volatile s32 *)0x04000580 =
+        *(u8 *)((char *)self + 0x10c) |
+        (*(u8 *)((char *)self + 0x10d) << 8) |
+        (*(u8 *)((char *)self + 0x10e) << 16) |
+        (*(u8 *)((char *)self + 0x10f) << 24);
+
+    s32 var_r6;
+    if (data_0209f2f8 == 0x28) {
+        var_r6 = 0x10;
+    } else {
+        var_r6 = data_0209ee90[0x44 / 4];
+    }
+
+    s32 idx = ((s32)(u16)sp18 >> 4) * 2;
+    G3i::PerspectiveW_(
+        data_02082214[idx],
+        data_02082214[idx + 1],
+        *(s32 *)((char *)self + 0xf8),
+        *(s32 *)((char *)self + 0xfc),
+        *(s32 *)((char *)self + 0x100),
+        var_r6, 1, (Matrix4x3 *)0);
+
+    {
+        s32 s2 = (s32)(sp[2] + 4) >> 3;
+        s32 s1 = (s32)(sp[1] + 4) >> 3;
+        s32 s0 = (s32)(sp[0] + 4) >> 3;
+        sp[0] = s0;
+        sp[1] = s1;
+        sp[2] = s2;
+        sp[5] = (s32)(sp[5] + 4) >> 3;
+        s32 s4 = (s32)(sp[4] + 4) >> 3;
+        sp[3] = (s32)(sp[3] + 4) >> 3;
+        sp[4] = s4;
+    }
+
+    void *lookdir = &data_02086efc;
+    if (Vec3_HorzDist((Vector3 *)&sp[0], (Vector3 *)&sp[3]) == 0) {
+        lookdir = &data_02086f08;
+    }
+    G3i::LookAt_((Vector3 *)&sp[3], (Vector3 *)lookdir, (Vector3 *)&sp[0], 1, (Matrix4x3 *)((char *)self + 0x50));
+
+    if (var_r4 != 0) {
+        Matrix4x3_FromRotationZ(&data_020a0e68, var_r4);
+        MulMat4x3Mat4x3((Matrix4x3 *)((char *)self + 0x50), &data_020a0e68, (Matrix4x3 *)((char *)self + 0x50));
+    }
+
+    View::Render();
+    return 1;
+}

--- a/src/_ZN8Particle17CheckLavaCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle17CheckLavaCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -1,12 +1,10 @@
 //cpp
-// NONMATCHING: different op / idiom (div=18). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct Vector3 { int x, y, z; Vector3(int a,int b,int c):x(a),y(b),z(c){} Vector3(){} };
+struct Vector3 { int x, y, z; };
 struct Actor;
 
 struct RaycastGround {
-    char pad[0x50];
+    char pad0[0x14];
+    unsigned int sub[(0x50 - 0x14) / 4];
     RaycastGround();
     ~RaycastGround();
     void SetObjAndPos(const Vector3 &pos, Actor *obj);
@@ -40,22 +38,25 @@ void CheckLavaCallback::SpawnParticles(System &sys)
 {
     SimpleCallback::SpawnParticles(sys);
 
-    Node *n = *(Node **)((char *)&sys + 8);
-    while (n != 0) {
+    for (Node *n = *(Node **)((char *)&sys + 8); n != 0; n = n->next) {
         int sx = n->f14 + n->f8;
         int sy = n->f18 + n->fc;
         int sz = n->f1c + n->f10;
         RaycastGround rg;
-        Vector3 v(sx << 3, (sy << 3) + 0x12c000, sz << 3);
+        int vy = (sy << 3) + 0x12c000;
+        Vector3 v;
+        v.x = vy ? sx << 3 : sx << 3;
+        v.y = vy;
+        v.z = sz << 3;
         rg.SetObjAndPos(v, 0);
-        if (rg.DetectClsn() != 0) {
-            if (func_02037e38((unsigned int *)((char *)&rg + 0x14)) != 1) {
-                n->f2e = n->f2c;
-            } else {
-                n->f18 = (*(int *)((char *)&rg + 0x44) + 0x7000 >> 3) - n->fc;
-            }
+        if (rg.DetectClsn() == 0)
+            goto Lac;
+        if (func_02037e38(rg.sub) != 1) {
+        Lac:
+            n->f2e = n->f2c;
+        } else {
+            n->f18 = ((int)rg.sub[12] + 0x7000 >> 3) - n->fc;
         }
-        n = n->next;
     }
 }
 }

--- a/src/func_02059c18.c
+++ b/src/func_02059c18.c
@@ -1,11 +1,7 @@
-// NONMATCHING: register allocation (div=6). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-
 typedef unsigned short u16;
 typedef unsigned int u32;
 extern long long func_02059650(void *obj);
-extern void func_02056e4c(int a, void *fn);
+extern void func_02056e4c(u32 idx, u32 handler, u32 arg);
 extern void func_02059824(void);
 extern void _ZN3IRQ10EnableIRQsEj(unsigned int mask);
 typedef struct Obj
@@ -16,12 +12,12 @@ typedef struct Obj
 void func_02059c18(Obj *obj)
 {
   long long v;
-  int sub;
+  long long sub;
   u16 timer;
   sub = func_02059650(obj);
   *((volatile u16 *) 0x4000106) = 0;
   v = obj->t - sub;
-  func_02056e4c(1, (void *) func_02059824);
+  func_02056e4c(1, (u32) func_02059824, 0);
   if (v < 0)
   {
     timer = 0xfffe;


### PR DESCRIPTION
Second pass over the arm9 near-miss head — this time the drafts carrying *structural* categories (`predicate vs branch`, `missing logic`, `constant / value`) rather than the `register allocation` mislabel that #544 covered.

### Opus stage (3 banked)

| function | div | fix |
|---|---|---|
| `Particle::CheckLavaCallback::SpawnParticles` | 2 → 0 | Vector3 store-emission order — fake-dependency lever hoists y into a temp so it is *computed* first but *stored* second |
| `OAM::Reset` | 4 → 0 | **control-flow fix, not codegen**: the if-arm's branch skipped past both `MultiCopy32Bytes` calls and a zero-store pair, so five statements belong inside the `else` (which also explains the apparently duplicated `mov r2,#0` — separate basic blocks) |
| `func_02059c18` | 6 → 0 | the callee returns a full `long long` (the `sbc` subtracts both words) and takes a third arg; the ROM omits `mov r2,#0` because r2 already holds a CSE'd zero from an earlier volatile store |

### Fable escalation on Opus's misses (1 banked)

| function | div | fix |
|---|---|---|
| `Camera::Render` | 4 → 0 | mixed temp/RMW interleave in the 6-element `(x+4)>>3` writeback: *def order* pins slot assignment, *store-statement order* pins emission. Pure-temp and pure-RMW families both floor at div 4 — an exhaustive 720-permutation sweep confirmed it |

### Verification

Link-gated: **3 VERIFIED**, `Camera::Render` **BLIND-4** with zero diffs (the blind slots are cross-module `data_ov002_*` references, unresolvable from arm9 by design).

### Deliberately not banked

- **`func_02068398`** matches byte-exact only as a whole-function `asm` block, which is an asm transcription rather than a decompilation — it stays a near-miss. It did establish that mwccarm assembles `ldmeqia sp!, {lr}` and `bxeq lr` (and accepts `DCD` for hand-encoded words), which **amends the 6t/6u note** claiming asm can't spell those. The C-side predication floor is real and was re-confirmed twice.
- **`func_0205fb58`** reached div 0 by merging a phantom symbol into one struct array so mwcc folds the +4 offset into a pool literal. The wildcarded byte oracle accepts it; the link gate correctly rejected it as `WRONG-DEST reloc: data_020a8138 != config 0x020a813c`. A real fix would be a config symbol merge, not a source spelling.
- **`func_0206dac4`** was matched concurrently upstream in #542 (during this batch, despite the claim lock), so it is dropped here rather than conflicting.

Levers written up in `notes/mwccarm-codegen.md` section 7b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzF9T9FdeAbwq1GBg55oVB
