### PR TITLE
Match func_02030790 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02030790.c
+++ b/src/func_02030790.c
@@ -1,6 +1,3 @@
-// NONMATCHING: different op / idiom (div=15). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_0203da2c(int v);
 extern void func_02030500(void);
 extern void func_02019a58(void);
@@ -28,8 +25,7 @@ void func_02030790(void)
         func_02012790(0x123);
         _ZN5Sound22StopLoadedMusic_Layer1Ej(4);
         func_020132d8();
-        func_0201ffcc();
-        func_020199a4();
     }
-    return;
+    func_0201ffcc();
+    func_020199a4();
 }


### PR DESCRIPTION
Recovers the one function still stranded in #543.

That PR also added `func_0203bc7c.c`, which #544 landed independently with different source - leaving #543 permanently conflicted on an add/add, so its other function could never merge.

This is that function alone, unchanged from #543, with ruspecial retained as the commit author. NONMATCHING -> match upgrade, verified VERIFIED with 0 blind slots against the ROM.

Closing #543 as superseded.