### PR TITLE
Match func_ov006_020f1318 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020f1318 (0x020f1318, size 0xb4) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_472a457ac984 kept active |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov006_020f1318.c
+++ b/src/func_ov006_020f1318.c
@@ -1,23 +1,31 @@
-// NONMATCHING: base materialization / addressing (div=25). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_common_subs off
+#pragma opt_strength_reduction off
 void func_ov006_020f1318(char *c, int idx)
 {
-    unsigned short h = *(unsigned short*)(c + 0x506c + idx * 2);
-    char *m = c + idx * 2 + 0x5000;
+    char *base = c + 0x506c;
+    int twice = idx * 2;
+    unsigned short h = *(unsigned short *)(base + twice);
     unsigned char *q;
-    *(short*)(c + 0x506c + idx * 2) = h - 1;
-    if (*(short*)(m + 0x6c) < 0) *(short*)(m + 0x6c) = 0;
-    if ((((unsigned short)*(unsigned short*)(m + 0x6c) >> 2) & 1) == 0) {
-        char *p = c + 0x53dd;
-        p[idx] = 1;
-        q = (unsigned char*)(p + idx);
-    } else {
+
+    *(short *)(base + twice) = (short)(h - 1);
+
+    if (*(short *)(c + (idx << 1) + 0x5000 + 0x6c) < 0)
+        *(short *)(c + (idx << 1) + 0x5000 + 0x6c) = 0;
+
+    if ((((unsigned short)*(unsigned short *)(c + (idx << 1) + 0x5000 + 0x6c) >> 2) & 1) != 0) {
         char *p = c + 0x53dd;
         p[idx] = 0;
-        q = (unsigned char*)(p + idx);
+        q = (unsigned char *)(p + idx);
+        goto after_flag;
     }
-    if (*(unsigned short*)(m + 0x6c) != 0) return;
-    *(unsigned char*)(c + idx + 0x5000 + 0x1fd) = 0;
+    {
+        char *p = c + 0x53dd;
+        p[idx] = 1;
+        q = (unsigned char *)(p + idx);
+    }
+after_flag:
+    if (*(unsigned short *)(c + (idx << 1) + 0x5000 + 0x6c) != 0)
+        return;
+    *(unsigned char *)(c + idx + 0x5000 + 0x1fd) = 0;
     *q = 1;
 }


### PR DESCRIPTION
## Summary

- Match `func_ov006_020f1318` (ov006 @ `0x020f1318`, size `0xb4` / 180 bytes) byte-identical with mwccarm **1.2/sp2p3**.
- Replaces prior `// NONMATCHING` near-miss (div=25) with a verified match.
- CLAIMS.md: claimed and marked done (`clm_472a457ac984`).

### Verify

```
python tools/match.py --c src/func_ov006_020f1318.c --func func_ov006_020f1318 \
  --addr 0x20f1318 --size 0xb4 --version 1.2/sp2p3 --module ov006
```

Reports `MATCHING VERSIONS: 1.2/sp2p3`.

### Notes

Compiler flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Levers used: `#pragma opt_common_subs off` + `#pragma opt_strength_reduction off` for EBB rematerialization of the `c+(idx<<1)+0x5000` base; named `base`/`twice` declaration order for r4/lr coloring; inverted bit-test + `goto` for EQ-first conditional path.

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build