### PR TITLE
Match func_ov060_021134ac byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov060 func_ov060_021134ac (0x021134ac, size 0xb8) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #574 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov060_021134ac.c
+++ b/src/func_ov060_021134ac.c
@@ -1,6 +1,3 @@
-// NONMATCHING: base materialization / addressing (div=17). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_ov060_02115a84(void* c, void* p);
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(void* clsn);
 extern void func_ov060_02111cc0(void* c, int a, int b);
@@ -20,14 +17,18 @@ void func_ov060_021134ac(void* thiz)
             func_ov060_02111cc0(c, 5, 0x40000000);
         }
         {
-            int* p = (int*)(c + 0x98);
+            int* p = (int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF);
             *p = *p >> 1;
         }
     }
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x14c) &&
-        !_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x14c)) {
-        *(int*)(c + 0x98) = 0;
-        (*(unsigned char*)(c + 0x423))++;
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x14c)) {
+        if (!_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x14c)) {
+            *(int*)(c + 0x98) = 0;
+            {
+                unsigned char* p = (unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+                *p = *p + 1;
+            }
+        }
     }
     func_ov060_02112350(c);
 }


### PR DESCRIPTION
## Summary

- **func_ov060_021134ac** (ov060 @ `0x021134ac`, size `0xb8`) — verified byte-identical with mwccarm **1.2/sp2p3**.
- Replaces the prior `// NONMATCHING` (div=17) draft in `src/`.
- Levers: u64-mask laundering for `c+0x98` asr RMW and `c+0x423` increment; nested `if`s for real branch control flow (not predicated form).

## Verification

```
python tools/match.py --c src/func_ov060_021134ac.c --func func_ov060_021134ac \
  --addr 0x21134ac --size 0xb8 --version 1.2/sp2p3 --module ov060
# MATCHING VERSIONS: 1.2/sp2p3

python tools/linkcheck.py --module ov060 --name func_ov060_021134ac \
  --addr 0x21134ac --size 0xb8
# verdict: VERIFIED
```

Compiler flags: `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`

Claim: `clm_4d8b66e2ea3c` (kept active per matched-function policy).

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build