### PR TITLE
Match func_ov060_021184bc byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov060 func_ov060_021184bc (0x021184bc, size 0x88) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_c2edcc619489 kept active |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov060_021184bc.c
+++ b/src/func_ov060_021184bc.c
@@ -1,0 +1,30 @@
+extern void ClearSpikeBomb(int idx);
+extern char *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char *p);
+
+void func_ov060_021184bc(char *c)
+{
+    int i;
+    int j;
+    unsigned int id;
+    char *a;
+
+    ClearSpikeBomb(*(int *)(c + 0x1a8));
+    *(int *)(((int)c + 0x13c) & 0xFFFFFFFFFFFFFFFF) |= 1;
+    *(int *)(c + 0x170) = 3;
+    a = 0;
+    for (i = 0; i < 8; i++)
+        ((int *)(c + 0x188))[i] = 0;
+    j = 0;
+    id = 0x11c;
+    while (1) {
+        a = _ZN5Actor15FindWithActorIDEjPS_(id, a);
+        if (a == 0)
+            break;
+        if (a != c) {
+            ((int *)(c + 0x188))[j] = *(int *)(a + 4);
+            j++;
+            if (j == 8)
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Match `func_ov060_021184bc` (ov060 @ `0x021184bc`, size `0x88` / 136 bytes) byte-identical to EU retail.
- Compiler: **mwccarm 1.2/sp2p3** with `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.
- Local verify: `tools/match.py --c src/func_ov060_021184bc.c --func func_ov060_021184bc --addr 0x21184bc --size 0x88 --version 1.2/sp2p3 --module ov060 --strict-relocs` → **MATCH**.
- Claims API lock `clm_c2edcc619489` kept active (do not unclaim fully matched functions). CLAIMS.md row updated.

Behavior sketch: `ClearSpikeBomb` on `+0x1a8`, OR flag at `+0x13c`, set `+0x170 = 3`, zero eight slots at `+0x188`, then walk `Actor::FindWithActorID(0x11c, …)` collecting other actors’ unique IDs (up to 8).

## Test plan

- [x] `tools/match.py` strict-relocs MATCH on 1.2/sp2p3
- [x] CI `validate` green

Opened as draft
Model: Grok 4.5 (high)
Harness: Grok Build