### PR TITLE
Match func_ov006_020f4a40 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020f4a40 (0x020f4a40, size 0x94) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #576 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov006_020f4a40.c
+++ b/src/func_ov006_020f4a40.c
@@ -1,23 +1,32 @@
-// NONMATCHING: register allocation (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 void* func_ov006_020f4a40(char* c){
   int cnt = 0;
-  int i;
+  int i = 0;
   char* p = c;
-  for (i = 0; i < 0xc; i++) {
-    char* b = p + 0x5000;
-    if (*(unsigned char*)(b + 0x1bb) != 0) {
-      if (*(unsigned char*)(b + 0x1bc) != 1) cnt++;
+  for (; i < 0xc; ) {
+    if (*(unsigned char*)(p + 0x51bb) != 0) {
+      if (*(unsigned char*)(p + 0x51bc) != 1) {
+        cnt++;
+        break;
+      }
     }
+    i++;
     p += 0x18;
   }
   if (cnt != 0) return c;
   p = c;
-  for (i = 0; i < 0xc; i++) {
-    *(unsigned char*)(p + 0x51bc) = 2;
-    p += 0x18;
+  i = 0;
+  {
+    unsigned char v = 2;
+    for (; i < 0xc; ) {
+      *(unsigned char*)(p + 0x51bc) = v;
+      i++;
+      p += 0x18;
+    }
   }
-  *(int*)(c + 0x5318) = 0;
-  *(int*)(c + 0x5314) = 2;
+  {
+    char* base = c + 0x5000;
+    *(int*)(base + 0x318) = 0;
+    *(int*)(base + 0x314) = 2;
+    return base;
+  }
 }


### PR DESCRIPTION
## Summary

- Byte-identical match for `func_ov006_020f4a40` (ov006, `0x020f4a40`, size `0x94`)
- Replaces the previous `// NONMATCHING` draft in `src/`
- Compiler: **mwccarm 1.2/sp2p3** with standard flags (`-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`)

Verified locally:

```
python tools/match.py --c src/func_ov006_020f4a40.c --func func_ov006_020f4a40 --addr 0x20f4a40 --size 0x94 --version 1.2/sp2p3 --module ov006
# MATCHING VERSIONS: 1.2/sp2p3
```

Key shape notes for the match:
- First loop breaks on the first slot where `p[0x51bb] != 0` and `p[0x51bc] != 1` (counts via `cnt++` then exit)
- On success path: set all 12 slots' `p[0x51bc] = 2`, then write status fields at `c+0x5318` / `c+0x5314` and return `c+0x5000`

## Test plan

- [x] `tools/match.py` reports MATCH for 1.2/sp2p3
- [ ] CI `validate` green on this file