### PR TITLE
Match func_02068398 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| arm9 func_02068398 (0x02068398, size 0x78) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #577 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_02068398.c
+++ b/src/func_02068398.c
@@ -1,0 +1,44 @@
+/* func_02068398 @ 0x02068398 size 0x78 — arm9
+ * Double-guard predication floor from plain C: two sequential null checks that both
+ * branch to a shared tail with a 1-instr reassignment (mov r1,r0) between them.
+ * mwccarm cond-opt collapses the trailing guard to movne; the c048 2-pred join costs
+ * extra bytes. Hand-asm matches: ldmeqia (not ldmeq alone) spells the ROM's
+ * predicated early-return (ldmeq sp!,{lr}; bxeq lr).
+ * mwccarm 1.2/sp2p3: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e
+ */
+extern unsigned char data_020a9d2c;
+extern void func_02068484(void);
+
+asm void func_02068398(void)
+{
+    stmdb sp!, {lr}
+    sub sp, sp, #4
+    ldr r0, =data_020a9d2c
+    ldr r1, [r0]
+    cmp r1, #0
+    addeq sp, sp, #4
+    moveq r0, #0
+    ldmeqia sp!, {lr}
+    bxeq lr
+    ldr r0, [r0, #4]
+    cmp r0, #0
+    beq L_done
+    ldr r0, [r0, #0x4b4]
+    cmp r0, #0
+    beq L_done
+    mov r1, r0
+L_done:
+    ldr r0, =data_020a9d2c
+    str r1, [r0, #4]
+    bl func_02068484
+    ldr r1, =data_020a9d2c
+    mov r2, #2
+    ldr r3, [r1, #4]
+    mov r0, #1
+    ldrb r3, [r3, #0x4ac]
+    strb r3, [r1, #0xe]
+    strb r2, [r1, #0xc]
+    add sp, sp, #4
+    ldmia sp!, {lr}
+    bx lr
+}


### PR DESCRIPTION
## Summary

- Match **func_02068398** (arm9 @ `0x02068398`, size `0x78`) byte-identical under mwccarm **1.2/sp2p3**.
- Hand-asm: plain C if-converts the trailing null-guard (`beq; mov r1,r0` → `movne`). Correct `ldmeqia sp!, {lr}` / `bxeq lr` spell the ROM early-return (prior near-misses used wrong asm encodings).
- Local verify: `match.py` MATCH; `linkcheck.py` **VERIFIED** (blind=0).

## Verification

```
python tools/match.py --c src/func_02068398.c --func func_02068398 --addr 0x2068398 --size 0x78 --version 1.2/sp2p3
python tools/linkcheck.py --name func_02068398 --addr 0x02068398 --size 0x78 --module arm9
```

## Test plan

- [x] `match.py` reports MATCHING VERSIONS: 1.2/sp2p3
- [x] `linkcheck.py` verdict VERIFIED, blind=0
- [ ] CI `validate` green