### PR TITLE
Match func_ov071_02120200 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov071 func_ov071_02120200 (0x02120200, size 0x78) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #578 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov071_02120200.c
+++ b/src/func_ov071_02120200.c
@@ -1,24 +1,23 @@
-// NONMATCHING: different op / idiom (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 
 int func_ov071_02120200(char* c)
 {
-    short* sub = (short*)(c + 0x300);
-    {
-        int* p = (int*)(c + 0xb0);
-        *p = *p & ~0x10000001;
-    }
+    int* p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+    int z;
+    short ang;
+
+    *p = *p & ~0x10000001;
     *(int*)(c + 0x5c) = *(int*)(c + 0x384);
+    z = 0;
     *(int*)(c + 0x60) = *(int*)(c + 0x388);
     *(int*)(c + 0x64) = *(int*)(c + 0x38c);
-    *(short*)(c + 0x94) = sub[0x53];      /* [0x3a6] */
-    *(short*)(c + 0x8c) = 0;
-    *(short*)(c + 0x8e) = sub[0x53];
-    *(short*)(c + 0x90) = 0;
-    *(int*)(c + 0x98) = 0;
-    sub[0x54] = 0x1e;                      /* [0x3a8] */
+    *(short*)(c + 0x94) = *(short*)(c + 0x3a6);
+    ang = *(short*)(c + 0x3a6);
+    *(short*)(c + 0x8c) = z;
+    *(short*)(c + 0x8e) = ang;
+    *(short*)(c + 0x90) = z;
+    *(int*)(c + 0x98) = z;
+    *(short*)(c + 0x3a8) = 0x1e;
     _ZN12CylinderClsn5ClearEv(c + 0x160);
     *(int*)(c + 0x39c) = 0;
     return 1;


### PR DESCRIPTION
## Summary

- Byte-identical match of `func_ov071_02120200` (ov071 @ `0x02120200`, size `0x78` / 120 bytes)
- Replaces the prior NONMATCHING draft (div=16)
- Compiler: **mwccarm 1.2/sp2p3** with flags `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`
- Strict reloc verified: `CylinderClsn::Clear` at `+0x160` → `0x02015024` (arm9)

## Match notes

- u64-mask launder forces materialized `add r2,r4,#0xb0` for the flag BIC at `actor+0xb0`
- No named long-lived `short* sub`; halfword accesses use `c+0x3a6`/`c+0x3a8` so the `+0x300` base colors as `r1`
- Mid-block `z = 0` + named `ang` reload orders the double `ldrsh` and keeps zero in `r3` / angles in `ip`

## Test plan

- [x] `python tools/match.py --c src/func_ov071_02120200.c --func func_ov071_02120200 --addr 0x2120200 --size 0x78 --version 1.2/sp2p3 --module ov071` → **MATCHING VERSIONS: 1.2/sp2p3**
- [x] Strict reloc destination OK (Clear → 0x02015024)
- [ ] CI `validate` green