### PR TITLE
Match Stage::LoadModel (0x0202b5ec) byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| arm9 Stage::LoadModel / _ZN5Stage9LoadModelEv (0x0202b5ec, size 0x90) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #579 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/_ZN5Stage9LoadModelEv.c
+++ b/src/_ZN5Stage9LoadModelEv.c
@@ -1,15 +1,12 @@
-// NONMATCHING: different op / idiom (div=13). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern char data_0209f340[];
 extern int data_0209f320;
 extern void _ZN5Model14LoadAndSetFileEtii(char* model, unsigned short id, int b, int c);
 void _ZN5Stage9LoadModelEv(char* self) {
     _ZN5Model14LoadAndSetFileEtii(self + 0x86c, *(unsigned short*)(*(char**)data_0209f340 + 8), 1, -1);
-    unsigned int i = 0;
     char* p = self + 0x874;
+    unsigned int count = *(unsigned int*)((*(char**)(((int)p) & 0xFFFFFFFFFFFFFFFFLL)) + 0x24);
     char* node = ((char**)p)[1];
-    unsigned int count = *(unsigned int*)(((char**)p)[0] + 0x24);
+    unsigned int i = 0;
     while (i < count) {
         unsigned int v = *(unsigned int*)(node + 0x24);
         i++;


### PR DESCRIPTION
## Summary

- Matched `_ZN5Stage9LoadModelEv` (`Stage::LoadModel`) at `0x0202b5ec` (size `0x90`) byte-identical under mwccarm **1.2/sp2p3**.
- Started from the near-miss draft (div=13); closed with u64-mask materialization of `self+0x874` and statement order that lands the ROM register coloring (`r2` list base, `r3` counter, `ip` node, `lr` count).
- Local verification:
  - `tools/match.py ... --version 1.2/sp2p3` → **MATCH**
  - `tools/linkcheck.py` → **VERIFIED** (blind=0)

## Test plan

- [x] `python tools/match.py --c src/_ZN5Stage9LoadModelEv.c --func _ZN5Stage9LoadModelEv --addr 0x202b5ec --size 0x90 --version 1.2/sp2p3`
- [x] `python tools/linkcheck.py --name _ZN5Stage9LoadModelEv --addr 0x202b5ec --size 0x90 --module arm9`
- [ ] CI `validate` green