### PR TITLE
Match func_0205fb58 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| arm9 func_0205fb58 (0x0205fb58, size 0x78) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #580 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_0205fb58.c
+++ b/src/func_0205fb58.c
@@ -1,0 +1,25 @@
+typedef unsigned short u16;
+
+extern int func_0205ff20(int a, int b, int c, int d);
+extern void func_0205f8b0(int param);
+
+struct D020a8114 { int w0; int w1; int w2; };
+extern struct D020a8114 data_020a8114;
+
+/* 8-byte slots: halfword at +0, word at +4. data_020a813c is the +4 label. */
+struct Slot { u16 h; u16 pad; int w; };
+extern struct Slot data_020a8138[];
+
+int func_0205fb58(int a, int b, int c, int d)
+{
+    int z;
+    if (!func_0205ff20(a, b, c, d))
+        return 1;
+    z = 0;
+    data_020a8138[a].h = (u16)z;
+    data_020a8114.w1 = c;
+    data_020a8114.w2 = d;
+    data_020a8138[a].w = b;
+    func_0205f8b0((a & 0xff) | 0x3006500);
+    return z;
+}


### PR DESCRIPTION
## Summary

- Match **func_0205fb58** (arm9 @ `0x0205fb58`, size `0x78`) byte-identical under mwccarm **1.2/sp2p3**.
- Near-miss was div=6 (pool-load interleaving). Fixed by modeling the 8-byte BSS slot as `struct Slot { u16 h; u16 pad; int w }` at `data_020a8138`, so the word store is `data_020a8138[a].w` (reloc `data_020a8138+4` == `data_020a813c`).
- Local verify: `match.py` MATCH; `linkcheck.py` VERIFIED (relocated bytes).

## Test plan

- [x] `python tools/match.py --c src/func_0205fb58.c --func func_0205fb58 --addr 0x205fb58 --size 0x78 --version 1.2/sp2p3`
- [x] `python tools/linkcheck.py --name func_0205fb58 --addr 0x0205fb58 --size 0x78 --module arm9` → VERIFIED
- [ ] CI `validate` green