### PR TITLE
Match 7 arm9 functions via refine cascade (Opus 6 + Fable 1)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -1413,6 +1413,52 @@ into a pool literal. The wildcarded byte oracle accepts it; the link gate reject
 right, it is a CONFIG symbol-merge change, not a source spelling -- see the dsd symbol-split
 note in the session log.
 
+## 7c. Third arm9 head cascade (2026-07-22, 7 matches) -- the head's deep tail still pays
+
+Opus 6/11 at 40.5K tok/landed on a div 2-17 pool (BETTER than the div 2-6 pools of 7a/7b),
+then Fable 1/5 at 231K on the misses. Read that pair carefully: **on this backlog, draft
+divergence count did NOT predict winnability** -- div 10/11 drafts landed while div 2-5 ones
+floored. What predicted it was whether the residual was structural. The Fable escalation, which
+paid 2/4 and 4/9 on shallower pools, dropped to 1/5 here; escalation is worth one pass, not two.
+
+New levers:
+
+- **Spill slots are grouped by TYPE, not declaration order** (`func_020319fc`, div 5->0).
+  A stack-slot ordering residual was fixed by declaring a local `int` instead of `unsigned int`
+  -- signed/unsigned was pinning the slot grouping. Try the type before permuting decl order.
+- **DELETE a named local and let EBB-local CSE rediscover it** (`func_02046bbc`, div 10->0).
+  A named `struct Node0 *node = ctx->node;` forced scratch r0 coloring; using inline
+  `ctx->node->m18` / `ctx->node->m28` at both uses let CSE make the temp, which colors to
+  callee-saved r7 like the ROM. The inverse of the usual "add a temp" instinct: **a named local
+  and a CSE temp get different coloring priority**.
+- **Mixed named/inline spelling of the SAME invariant reorders the preheader hoist batch**
+  (`func_0206071c`, div 11->0, Fable). mwcc emits loop-invariant ADDRESS adds before CONSTANT
+  movs; naming the invariant at only ONE of its three uses (inline at the other two) flipped
+  the group order to the ROM's constants-first. Pairs with `opt_loop_invariants off`.
+- **`opt_loop_invariants off` fixes preheader EMISSION ORDER, not just hoisting**
+  (`func_02060f60`, div 2->0) -- it stopped LICM lifting a laundered base above the constant movs.
+- **`volatile` on a ring-buffer array pins an indexed store ahead of a wrap-check**
+  (`func_0205b070`, div 11->0), after fixing tail store order with inline RMW instead of
+  hoisted temps.
+- **A backward `bne` with imm=-4 is a spin-wait loop, not an `if`** (`func_0205583c`, div 11->0).
+  The draft had modelled a GXSTAT busy-wait as an `if`; the back-edge block boundary is what
+  re-materializes a `mov #0` the draft appeared to be "missing". **FOURTH control-flow-not-codegen
+  case in three batches** -- the recurring tell is a missing or duplicated constant
+  materialization. Check the branch offsets before believing a coloring diagnosis.
+
+**Confirmed floors** (survived Opus AND Fable, both exhaustive): `Stage::LoadFog` (r5/r8 swap,
+the CSE'd zero web colors last under every lever), `func_020341a8` (r1/r2 swap rooted in one
+in-place-vs-fresh allocator choice), `GX::LoadTex` (r4/r5 web-identity swap; 9 disjoint probes
+compiled BITWISE IDENTICAL -- a 6y-class allocator-priority floor).
+
+**`func_02072fcc` is a ONE-INSTRUCTION miss and the best hand-fix candidate in the backlog**:
+mwcc PRE-hoists a loop-invariant `b+1` whose only use is on a cold retry path into the
+preheader (`add r1,r1,#1` + in-loop `mov r3,r1`) where the ROM recomputes `add r3,r1,#1`
+in-loop. All 17 "divergences" are that one insn plus the +4 branch-offset ripple. Both models
+exhausted the pragma space (opt_loop_invariants / common_subs / propagation / lifetimes /
+strength_reduction / dead_assignments, optimization_level 2/3, optimize_for_size), u64
+laundering, `&b[1]`, temps, goto/nested loop forms. Do not spend more model time on it.
+
 ---
 
 *Add to this file whenever you learn a new codegen rule. It is the project's accumulating

--- a/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp
@@ -1,0 +1,76 @@
+//cpp
+extern "C" {
+
+struct Target { int start; int end; };
+
+extern void _ZN10MemoryNode6TargetC1EP10MemoryNode(struct Target* thiz, void* node);
+extern void* _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(void* c, void* node);
+extern void* _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(struct Target* t, unsigned short tt);
+extern void* _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(void* c, void* node, void* link);
+extern void MultiStore_Int(int val, int* dst, int len);
+
+void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(void* c, void* node, void* target, unsigned int size, unsigned short z)
+{
+    struct Target t0;
+    struct Target t1;
+    struct Target t2;
+    void* link;
+    int header;
+    _ZN10MemoryNode6TargetC1EP10MemoryNode(&t0, node);
+
+    int oldLimit = t0.end;
+    header = (int)target - 0x10;
+    int backStart = (int)size + (int)target;
+    t0.end = header;
+    t1.end = oldLimit;
+    t1.start = backStart;
+
+    link = _ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_(c, node);
+
+    unsigned int frontGap = t0.end - t0.start;
+    if (frontGap < 0x10) {
+        t0.end = t0.start;
+    } else {
+        void* newFront = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t0, 0x4652);
+        link = _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(c, newFront, link);
+    }
+
+    unsigned int backGap = t1.end - t1.start;
+    if (backGap < 0x10) {
+        t1.start = t1.end;
+    } else {
+        void* newBack = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t1, 0x4652);
+        link = _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(c, newBack, link);
+    }
+
+    int flagsWord = *(int*)((char*)c - 4);
+    int* dst = (int*)t0.end;
+    int len = t1.start - t0.end;
+    if (((unsigned short)(flagsWord & 0xff)) & 1) {
+        volatile int zero = 0;
+        MultiStore_Int(zero, dst, len);
+    }
+
+    t2.start = header;
+    t2.end = t1.start;
+    void* allocNode = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t2, 0x5544);
+
+    unsigned short* flagsPtr = (unsigned short*)((long long)(int)((char*)allocNode + 2) & 0xFFFFFFFFFFFFFFFFLL);
+    void* usedList = (char*)c + 8;
+    *flagsPtr &= ~0x8000;
+    *flagsPtr |= (z & 1) << 15;
+    int t0e = t0.end;
+    *flagsPtr &= ~0x7f00;
+    *flagsPtr |= (((unsigned short)((int)allocNode - t0e)) & 0x7f) << 8;
+    unsigned int cRaw = *(unsigned short*)((char*)c + 0x10);
+    unsigned int cValue = cRaw & 0xff;
+    *flagsPtr &= ~0xff;
+    *flagsPtr |= cValue;
+
+    void* usedTail = (void*)(*(int*)((char*)c + 0xc));
+    _ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_(usedList, allocNode, usedTail);
+
+    return target;
+}
+
+}

--- a/src/func_020319fc.c
+++ b/src/func_020319fc.c
@@ -1,0 +1,54 @@
+extern unsigned char data_0209fc94;
+extern unsigned char data_0209fcb0;
+extern unsigned char data_0209fc78;
+extern unsigned char data_0209fc7c;
+extern unsigned char data_0209fcd8;
+extern unsigned int data_0209fd5c[];
+extern unsigned char data_0209fd20[];
+extern unsigned int data_0209287c[];
+extern unsigned int data_0209283c[];
+extern char *_ZN3G2S13GetBG0CharPtrEv(void);
+extern char *func_02054d88(void);
+
+void func_020319fc(int n)
+{
+    unsigned int *dst;
+    int i;
+    unsigned int col;
+    int j;
+    int col0;
+    int skip;
+    int count;
+    int blk;
+    int wordIdx;
+    unsigned char rem;
+
+    if (data_0209fc94 != 0)
+        dst = (unsigned int *)(_ZN3G2S13GetBG0CharPtrEv() + (((data_0209fcb0 * data_0209fc78 << 1) + 0x200) << 5));
+    else
+        dst = (unsigned int *)(func_02054d88() + (((data_0209fcb0 * data_0209fc78 << 1) + 0x200) << 5));
+
+    skip = (n - 1) << 5;
+    col0 = data_0209fc7c;
+    count = data_0209fcd8;
+    col = col0;
+
+    for (i = 0; i < 0x10; i++) {
+        for (j = 0; j < count; j++) {
+            blk = col >> 3;
+            wordIdx = blk << 3;
+            rem = col & 7;
+            dst[wordIdx] = (data_0209287c[rem] & data_0209fd5c[i + j * 0x10]) | dst[wordIdx];
+            if (rem != 0)
+                *(unsigned int *)((char *)&dst[wordIdx] + 0x20) =
+                    *(unsigned int *)((char *)data_0209283c + (rem << 2)) &
+                    *(unsigned int *)((char *)data_0209fd5c + ((i + j * 0x10) << 2));
+            col = (col + data_0209fd20[j]) & 0xff;
+        }
+        dst++;
+        if (i == 7)
+            dst = (unsigned int *)((char *)dst + skip);
+        col = col0;
+    }
+    data_0209fcb0++;
+}

--- a/src/func_02046bbc.c
+++ b/src/func_02046bbc.c
@@ -1,0 +1,108 @@
+typedef unsigned short u16;
+struct Entry
+{
+  u16 id;
+  u16 pad2;
+  u16 pad4;
+  u16 pad6;
+  u16 count8;
+  u16 offA;
+};
+struct Node0
+{
+  char pad0[0x18];
+  char *m18;
+  char *pad1c;
+  char *m20;
+  char *pad24;
+  char *m28;
+};
+struct Ctx
+{
+  struct Node0 *node;
+  char *base;
+};
+struct Desc
+{
+  u16 field0;
+  u16 pad2;
+  u16 *field4;
+  u16 field8;
+  u16 padA;
+  u16 *fieldC;
+  u16 *field10;
+  u16 *field14;
+  u16 *field18;
+  u16 count;
+  u16 pad1e;
+  struct Entry *entries;
+};
+extern void Crash(void);
+void func_02046bbc(struct Ctx *ctx, struct Desc *desc, unsigned int sb)
+{
+  int i;
+  if (sb >= desc->field0)
+  {
+    Crash();
+  }
+  for (i = 0; i < desc->count; i++)
+  {
+    int j;
+    u16 *p;
+    struct Entry *e;
+    char *dst;
+    int k;
+    int v0;
+    u16 idx0;
+    char *item;
+    int flags;
+    e = &desc->entries[i];
+    if (e->id == 0xffff)
+    {
+      Crash();
+    }
+    dst = ctx->base + (e->id * 0x30);
+    j = e->count8 - 1;
+    p = ((&desc->field10[e->offA]) + e->count8) - 1;
+    for (;;)
+    {
+      if ((*p) <= sb)
+      {
+        break;
+      }
+      p--;
+      j--;
+      if (j < 0)
+      {
+        Crash();
+      }
+    }
+
+    k = j + e->offA;
+    idx0 = desc->field14[k];
+    v0 = idx0;
+    idx0 = *((u16 *) (((char *) desc->field4) + (v0 * 8)));
+    item = ctx->node->m18 + (idx0 * 0x14);
+    *((int *) (dst + 0x1c)) = *((int *) ((((char *) ctx->node->m28) + (e->id * 0x30)) + 0x20));
+    *((int *) (((unsigned int) (dst + 0x1c)) & 0xFFFFFFFFFFFFFFFFULL)) |= *((int *) (item + 0x10));
+    flags = ((*((unsigned int *) (item + 0x10))) >> 26) & 7;
+    if (desc->field8 != 0)
+    {
+      u16 t = desc->field18[k];
+      int c = *((u16 *) (((char *) desc->fieldC) + (t * 8)));
+      if (c != (-1))
+      {
+        char *a = ctx->node->m20 + (c * 0x10);
+        if (flags == 2)
+        {
+          *((int *) (dst + 0x20)) = (*((unsigned int *) (a + 0xc))) >> 3;
+        }
+        else
+        {
+          *((int *) (dst + 0x20)) = (*((unsigned int *) (a + 0xc))) >> 4;
+        }
+      }
+    }
+  }
+
+}

--- a/src/func_0205583c.c
+++ b/src/func_0205583c.c
@@ -1,6 +1,3 @@
-// NONMATCHING: extra logic (you do more) (div=11). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern void func_02055780(void);
 extern void func_020556d0(void);
 extern void func_020554bc(void);
@@ -9,18 +6,18 @@ void func_0205583c(void)
 {
     func_02055780();
     *(volatile unsigned int *)0x4000504 = 0;
-    if (!(*(volatile unsigned int *)0x4000600 & 0x8000000)) {
-        *(volatile unsigned short *)0x4000060 = 0;
-        *(volatile unsigned int *)0x4000600 = 0;
-        *(volatile unsigned int *)0x4000010 = 0;
-        *(volatile unsigned short *)0x4000060 |= 0x2000;
-        *(volatile unsigned short *)0x4000060 |= 0x1000;
-        *(volatile unsigned short *)0x4000060 &= 0xcffd;
-        *(volatile unsigned short *)0x4000060 = (*(volatile unsigned short *)0x4000060 & ~0x3000) | 0x10;
-        *(volatile unsigned short *)0x4000060 &= 0xcffb;
-        *(volatile unsigned int *)0x4000600 |= 0x8000;
-        *(volatile unsigned int *)0x4000600 = (*(volatile unsigned int *)0x4000600 & ~0xc0000000) | 0x80000000;
-    }
+    while (*(volatile unsigned int *)0x4000600 & 0x8000000)
+        ;
+    *(volatile unsigned short *)0x4000060 = 0;
+    *(volatile unsigned int *)0x4000600 = 0;
+    *(volatile unsigned int *)0x4000010 = 0;
+    *(volatile unsigned short *)0x4000060 |= 0x2000;
+    *(volatile unsigned short *)0x4000060 |= 0x1000;
+    *(volatile unsigned short *)0x4000060 &= ~0x3002;
+    *(volatile unsigned short *)0x4000060 = (*(volatile unsigned short *)0x4000060 & ~0x3000) | 0x10;
+    *(volatile unsigned short *)0x4000060 &= 0xcffb;
+    *(volatile unsigned int *)0x4000600 |= 0x8000;
+    *(volatile unsigned int *)0x4000600 = (*(volatile unsigned int *)0x4000600 & ~0xc0000000) | 0x80000000;
     func_020556d0();
     *(volatile unsigned int *)0x4000350 = 0;
     *(volatile unsigned short *)0x4000354 = 0x7fff;

--- a/src/func_0205b070.c
+++ b/src/func_0205b070.c
@@ -1,11 +1,8 @@
-// NONMATCHING: different op / idiom (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern int data_020a648c;
+extern volatile int data_020a648c;
+extern volatile int data_020a649c;
 extern int data_020a64a0;
 extern int data_020a6760;
-extern int data_020a649c;
-extern int data_020a64a8[];
+extern volatile int data_020a64a8[];
 extern int data_020a64a4;
 extern int data_020a6490;
 
@@ -28,13 +25,16 @@ int func_0205b070(int x)
         while (IPCSend(7, data_020a648c, 0) < 0)
             ;
     }
-    data_020a64a8[data_020a649c] = data_020a648c;
-    data_020a649c++;
-    if (data_020a649c > 8) data_020a649c = 0;
+    int temp = data_020a648c;
+    int idx = data_020a649c;
+    data_020a64a8[idx] = temp;
+    idx++;
+    data_020a649c = idx;
+    if (idx > 8) data_020a649c = 0;
 
-    data_020a64a4++;
     data_020a648c = 0;
     data_020a6490 = 0;
-    data_020a64a0++;
+    data_020a64a0 = data_020a64a0 + 1;
+    data_020a64a4 = data_020a64a4 + 1;
     return 1;
 }

--- a/src/func_0206071c.c
+++ b/src/func_0206071c.c
@@ -1,6 +1,4 @@
-// NONMATCHING: register allocation (div=26). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+#pragma opt_loop_invariants off
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int a, unsigned int b);
 extern int func_02060f60(void *thiz, int a, int b);
 extern void func_0205a61c(void *a, int b, unsigned int c);
@@ -8,23 +6,26 @@ extern void func_0206081c(void *thiz);
 
 void func_0206071c(char *thiz)
 {
-    int *p20 = (int *)(thiz + 0x20);
-    int *p1c = (int *)(thiz + 0x1c);
-    int *p18 = (int *)(thiz + 0x18);
-    char *e0 = thiz + 0xe0;
-    int local = 1;
-    do {
-        unsigned int n = *(unsigned int *)(thiz + 0x20);
-        if (n > 0x100) n = 0x100;
-        _ZN4CP1519InvalidateDataCacheEjj((unsigned int)e0, 0x100);
-        *(int *)(*(int *)thiz + 0xc) = *(int *)(thiz + 0x18);
-        *(char **)(*(int *)thiz + 0x10) = e0;
-        *(unsigned int *)(*(int *)thiz + 0x14) = n;
-        if (func_02060f60(thiz, 6, local) == 0) break;
-        func_0205a61c(e0, *(int *)(thiz + 0x1c), n);
-        *p18 = *p18 + n;
-        *p1c = *p1c + n;
-        *p20 = *p20 - n;
-    } while (*(int *)(thiz + 0x20) != 0);
-    func_0206081c(thiz);
+  unsigned int n;
+  char *e0;
+
+  e0 = thiz + 0xe0;
+
+  do
+  {
+    n = *((unsigned int *)(thiz + 0x20));
+    if (n > 0x100) n = 0x100;
+    _ZN4CP1519InvalidateDataCacheEjj((unsigned int)(thiz + 0xe0), 0x100);
+    *((int *)((*((int *)thiz)) + 0xc)) = *((int *)(thiz + 0x18));
+    *((char **)((*((int *)thiz)) + 0x10)) = thiz + 0xe0;
+    *((unsigned int *)((*((int *)thiz)) + 0x14)) = n;
+    if (func_02060f60(thiz, 6, 1) == 0) break;
+    func_0205a61c(e0, *((int *)(thiz + 0x1c)), n);
+    *((int *)(((int)thiz + 0x18) & 0xFFFFFFFFFFFFFFFFull)) += n;
+    *((int *)(((int)thiz + 0x1c) & 0xFFFFFFFFFFFFFFFFull)) += n;
+    *((int *)(((int)thiz + 0x20) & 0xFFFFFFFFFFFFFFFFull)) -= n;
+  }
+  while (*((int *)(thiz + 0x20)) != 0);
+
+  func_0206081c(thiz);
 }

--- a/src/func_02060f60.cpp
+++ b/src/func_02060f60.cpp
@@ -1,0 +1,71 @@
+//cpp
+extern "C" int func_0205ba3c(int bit, int word);
+extern "C" void func_02059d8c(int x);
+extern "C" int IPCSend(unsigned int a, unsigned int c, unsigned int b);
+
+typedef unsigned short u16;
+extern "C" void func_020580f0(u16 *x);
+
+namespace CP15 {
+    void FlushAndInvalidateDataCache(unsigned int a, unsigned int b);
+    void DrainWriteBuffer();
+}
+namespace IRQ {
+    unsigned int Disable();
+    void Restore(unsigned int x);
+}
+
+struct T {
+    int *f0;
+    int f4;
+    char pad[0x2c];
+    int f34;
+};
+
+#pragma opt_loop_invariants off
+extern "C" int func_02060f60(T *thiz, int v, int count) {
+    unsigned int saved;
+    int r;
+
+    if (!(*(volatile int *)&thiz->f34 & 2)) {
+        int *p = (int *)(((int)thiz + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+        *p |= 2;
+        if (func_0205ba3c(0xb, 1) == 0) {
+            do {
+                func_02059d8c(0x64);
+            } while (func_0205ba3c(0xb, 1) == 0);
+        }
+        func_02060f60(thiz, 0, 1);
+    }
+
+    CP15::FlushAndInvalidateDataCache((unsigned int)thiz->f0, 0x20);
+    CP15::DrainWriteBuffer();
+
+    do {
+        thiz->f4 = v;
+        *(int *)(((int)thiz + 0x34) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+
+        while (IPCSend(0xb, v, 1) < 0) {
+        }
+
+        if (v == 0) {
+            int *q = thiz->f0;
+            while (IPCSend(0xb, (unsigned int)q, 1) < 0) {
+            }
+        }
+
+        saved = IRQ::Disable();
+        while (thiz->f34 & 0x20) {
+            func_020580f0((u16 *)0);
+        }
+        IRQ::Restore(saved);
+
+        r = *thiz->f0;
+        if (r != 4) {
+            break;
+        }
+        count--;
+    } while (count > 0);
+
+    return r == 0;
+}


### PR DESCRIPTION
Third pass over the arm9 near-miss head, taking essentially the whole remaining pool (div 2–17 — the shallow head is drained).

### Opus (6/11, ~40K tok/landed)

| function | div | fix |
|---|---|---|
| `func_02060f60` | 2 → 0 | `opt_loop_invariants off` stopped LICM hoisting a laundered base above the preheader's constant movs — an emission-**order** fix, not a hoist fix |
| `func_020319fc` | 5 → 0 | **spill slots are grouped by TYPE**: declaring `col0` signed instead of unsigned pinned the stack-slot order; decl order was never the lever |
| `ExpandingHeapAllocator::AllocateNode` | 9 → 0 | declare the 5th stack param `unsigned short` rather than punning `*(u16*)&z` (the pun cost a callee-saved reg), then split a halfword read into raw load + mask |
| `func_02046bbc` | 10 → 0 | **delete** the named local and let EBB-local CSE rediscover it — a named local forced scratch r0; the CSE temp colors callee-saved r7 as in the ROM |
| `func_0205583c` | 11 → 0 | the draft's `if` was really a **spin-wait `while`** (the `bne` encodes imm=-4, a GXSTAT busy-wait); the back-edge block boundary re-materializes the `mov #0` the draft appeared to be missing |
| `func_0205b070` | 11 → 0 | tail store order via inline RMW, then `volatile` on the ring-buffer array pinned the indexed store ahead of the wrap-check |

### Fable escalation (1/5)

| function | div | fix |
|---|---|---|
| `func_0206071c` | 11 → 0 | mixed named/inline spelling of the *same* loop invariant (named at one use, inline at the other two) rotated the preheader hoist batch to the ROM's constants-before-address-adds order |

### Verification

All 7 link-gated **VERIFIED**, zero diffs.

### Notes on the pool

Draft divergence **did not predict winnability** here — div 10/11 drafts landed while div 2–5 ones floored. What predicted it was whether the residual was structural.

Confirmed floors, exhausted by both models: `Stage::LoadFog` (r5/r8 swap, the CSE'd zero web colors last under every lever), `func_020341a8` (r1/r2 swap rooted in one in-place-vs-fresh allocator choice), `GX::LoadTex` (r4/r5 web-identity swap — 9 disjoint probes compiled *bitwise identical*).

`func_02072fcc` is a **one-instruction** miss: mwcc PRE-hoists a loop-invariant `b+1` whose only use is on a cold retry path, where the ROM recomputes it in-loop. All 17 "divergences" are that one insn plus branch-offset ripple. Both models exhausted the pragma space — it's the best hand-fix candidate in the backlog, not a model-time candidate.

Levers written up in `notes/mwccarm-codegen.md` section 7c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzF9T9FdeAbwq1GBg55oVB
