### PR TITLE
Match func_ov006_02101088 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_02101088 (0x02101088, size 0xc0) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #582 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov006_02101088.c
+++ b/src/func_ov006_02101088.c
@@ -1,0 +1,18 @@
+
+#pragma opt_common_subs off
+void func_ov006_02101088(char *p, int i)
+{
+    int d;
+    *(int *)(p + 0x5264 + (i << 6)) += *(int *)(p + 0x5000 + (i << 6) + 0x26c);
+    d = (*(int *)(p + 0x5000 + (i << 6) + 0x264) - *(int *)(p + 0x5000 + (i << 6) + 0x280)) >> 12;
+    if (d >= 0x40) {
+        if (*(int *)(p + 0x5000 + (i << 6) + 0x26c) >= 0x1000)
+            *(int *)(p + 0x526c + (i << 6)) -= 0x100;
+    } else if (*(int *)(p + 0x5000 + (i << 6) + 0x26c) <= 0x4000) {
+        *(int *)(p + 0x526c + (i << 6)) += 0x200;
+    }
+    if (d < 0x60) return;
+    *(unsigned short *)(p + 0x5200 + (i << 6) + 0x92) = 0x10;
+    *(int *)(p + 0x5000 + (i << 6) + 0x26c) = 0;
+    *(unsigned char *)(p + 0x5000 + (i << 6) + 0x296) = 0xb;
+}


### PR DESCRIPTION
## Summary

- Byte-identical match of `func_ov006_02101088` (ov006 @ `0x02101088`, size `0xc0` / 192 bytes).
- Compiler: **mwccarm 1.2/sp2p3** with `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.
- Verified locally: `tools/match.py --c src/func_ov006_02101088.c --func func_ov006_02101088 --addr 0x2101088 --size 0xc0 --version 1.2/sp2p3 --module ov006` → **MATCH**.
- Leaf function (no calls); only pool constants `0x5264` / `0x526c`. Shape uses `#pragma opt_common_subs off` + inline indexed accesses (sibling pattern to other ov006 slot updaters).

## Test plan

- [x] `tools/match.py` reports MATCH for 1.2/sp2p3
- [ ] CI `validate` green