### PR TITLE
Match func_ov006_020e61c4 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020e61c4 (0x020e61c4, size 0xc8) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #583 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov006_020e61c4.c
+++ b/src/func_ov006_020e61c4.c
@@ -1,20 +1,16 @@
-// NONMATCHING: different op / idiom (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 int func_ov004_020adbe0(void);
 void func_ov004_020b0a54(void* c);
-
 void func_ov006_020e61c4(char *thiz)
 {
     int i;
     char *p;
-    unsigned short *q = (unsigned short*)(thiz + 0x5500);
-    if (q[0x5b] != 0) {
-        --*(volatile unsigned short*)(thiz + 0x55b6);
-        if (((short*)q)[0x5b] <= 0)
-            ((short*)q)[0x5b] = 0;
+    if (*(unsigned short*)(thiz + 0x55B6) != 0) {
+        --*(volatile unsigned short*)(((int)thiz + 0x55B6) & 0xFFFFFFFFFFFFFFFF);
+        if (*(short*)(thiz + 0x55B6) <= 0)
+            *(short*)(thiz + 0x55B6) = 0;
         return;
     }
+
     if (func_ov004_020adbe0() != 0) {
         *(unsigned char*)((thiz + 0x5000) + 0x5bc) = 0;
         *(int*)((thiz + 0x5000) + 0x580) = 4;


### PR DESCRIPTION
## Summary
- Byte-identical match of `func_ov006_020e61c4` (ov006, `0x020e61c4`, size `0xc8`) under **mwccarm 1.2/sp2p3**.
- Replaces the previous `// NONMATCHING` draft in `src/` (div=14) with a verified match.

## Key matching lever
Early-path counter RMW at `thiz+0x55b6` needs the ROM's literal-pool load + `add r2,r4,r0` form. Achieved by:
1. Not naming a persistent `q = thiz+0x5500` base (inline `*(unsigned short*)(thiz+0x55B6)` loads color into `r1` as `add r1,r4,#0x5500` + `ldrh [r1,#0xb6]`).
2. u64-mask laundering the RMW address: `--*(volatile unsigned short*)(((int)thiz + 0x55B6) & 0xFFFFFFFFFFFFFFFF)`.

## Verify
```
python tools/match.py --c src/func_ov006_020e61c4.c --func func_ov006_020e61c4 \
  --addr 0x20e61c4 --size 0xc8 --version 1.2/sp2p3 --module ov006 --strict-relocs
# → MATCHING VERSIONS: 1.2/sp2p3
```

## Test plan
- [x] Local `match.py` with `--module ov006 --strict-relocs` reports MATCH
- [ ] CI `validate` green on this file