### PR TITLE
Match func_ov002_020bf36c byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov002 func_ov002_020bf36c (0x020bf36c, size 0xa0) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #584 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov002_020bf36c.cpp
+++ b/src/func_ov002_020bf36c.cpp
@@ -1,32 +1,23 @@
 //cpp
-// NONMATCHING: register allocation (div=2). ldrb r2 vs ldrb r0 at +0x08/+0x10.
 typedef int Fix12i;
+extern "C" void func_ov002_020bfa74(void* self);
+extern "C" void func_ov002_020c0108(void* self, int x);
+extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
+extern "C" void func_ov002_020ce798(void* self);
 
-extern "C" void func_ov002_020bfa74(void);
-extern "C" void func_ov002_020c0108(void *self, int x);
-extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *c);
-extern "C" void func_ov002_020ce798(void *self);
-
-extern "C" void func_ov002_020bf36c(char *self, void *arg)
-{
-    unsigned char r2;
+extern "C" void func_ov002_020bf36c(char* self, void* arg){
     Fix12i saved;
-
-    r2 = *(unsigned char *)(self + 0x709);
-    if (r2 == 0) {
-        func_ov002_020bfa74();
-    }
-    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0 || *(unsigned char *)(self + 0x706) != 0) {
+    unsigned char f = *(unsigned char*)(self + 0x709);
+    if (f == 0)
+        func_ov002_020bfa74(self);
+    if ((*(unsigned char*)(self + 0x6e9) & 1) || *(unsigned char*)(self + 0x706))
         func_ov002_020c0108(self, 1);
-    }
-    if (*(int *)(self + 0x37c) != 0) {
+    if (*(int*)(self + 0x37c) != 0)
         return;
-    }
-    saved = *(Fix12i *)(self + 0x98);
-    if ((*(unsigned char *)(self + 0x6e9) & 1) != 0) {
-        *(Fix12i *)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i *)(self + 0x558) + 0x800) >> 12);
-    }
+    saved = *(Fix12i*)(self + 0x98);
+    if (*(unsigned char*)(self + 0x6e9) & 1)
+        *(Fix12i*)(self + 0x98) = (Fix12i)(((long long)saved * *(Fix12i*)(self + 0x558) + 0x800) >> 12);
     _ZN5Actor9UpdatePosEP12CylinderClsn(self, arg);
-    *(Fix12i *)(self + 0x98) = saved;
+    *(Fix12i*)(self + 0x98) = saved;
     func_ov002_020ce798(self);
 }


### PR DESCRIPTION
## Summary

- Byte-match `func_ov002_020bf36c` (ov002 @ `0x020bf36c`, size `0xa0`) under **mwccarm 1.2/sp2p3**.
- Replaces the prior `// NONMATCHING` div=2 draft in `src/`.
- Fix: `func_ov002_020bfa74` takes `self` (not void). Passing it keeps r0 live so the first `ldrb` colors into r2 like the ROM.

Verified locally:
```
python tools/match.py --c src/func_ov002_020bf36c.cpp --func func_ov002_020bf36c \
  --addr 0x20bf36c --size 0xa0 --version 1.2/sp2p3 --module ov002 --strict-relocs
# MATCHING VERSIONS: 1.2/sp2p3
```

## Test plan

- [x] Local `match.py` + strict-relocs green
- [ ] CI `validate` green