### PR TITLE
Match EnemySwitchTag::Behavior byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov002 EnemySwitchTag::Behavior / _ZN14EnemySwitchTag8BehaviorEv (0x020f19fc, size 0xc8) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #585 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.c
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.c
@@ -1,31 +1,32 @@
-// NONMATCHING: different op / idiom (div=20). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef unsigned int u32;
-typedef unsigned char u8;
 
-extern int _ZNK6Camera12IsUnderwaterEv(void);
-extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, void* v, u32 e);
+extern int _ZNK6Camera12IsUnderwaterEv(void *self);
+extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, void *v, u32 e);
 extern int data_ov002_02110aec;
 extern int data_0209b4ac;
-extern int data_0209f318;
+extern void *data_0209f318;
 extern int data_ov002_0210b498[];
 
-int _ZN14EnemySwitchTag8BehaviorEv(char* c)
+int _ZN14EnemySwitchTag8BehaviorEv(char *c)
 {
-    if (data_ov002_02110aec != 0) return 1;
+    u32 param;
+    int a;
+    void *cam;
 
-    if (*(u32*)(c + 8) >= 1 && *(u32*)(c + 8) <= 4) {
-        int a = data_0209b4ac;
-        data_0209f318;
-        if (a != 0x32 && a != 0x33 && a != 0x34) {
-            if (_ZNK6Camera12IsUnderwaterEv()) return 1;
-        } else {
+    if (data_ov002_02110aec != 0)
+        return 1;
+
+    param = *(u32 *)(c + 8);
+    if (param >= 1 && param <= 4) {
+        cam = data_0209f318;
+        a = data_0209b4ac;
+        if (a == 0x32 || a == 0x33 || a == 0x34 ||
+            _ZNK6Camera12IsUnderwaterEv(cam))
             return 1;
-        }
     }
 
-    *(u32*)(c + 0xd4) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
-        *(u32*)(c + 0xd4), 3, data_ov002_0210b498[*(u32*)(c + 8)], c + 0x74, 0);
+    *(u32 *)(c + 0xd4) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+        *(u32 *)(c + 0xd4), 3, (u32)data_ov002_0210b498[*(u32 *)(c + 8)],
+        c + 0x74, 0);
     return 1;
 }


### PR DESCRIPTION
## Summary

- Match `_ZN14EnemySwitchTag8BehaviorEv` (`EnemySwitchTag::Behavior`) at `0x020f19fc` size `0xc8` (ov002) byte-identical with mwccarm **1.2/sp2p3**.
- Replaces the prior `// NONMATCHING` (div=20) draft.
- Local verification: `match.py` → MATCH; `linkcheck.py` → **VERIFIED**.

### Notes
- `data_0209f318` is the Camera pointer passed as `this` to `Camera::IsUnderwater()`.
- Statement order of the two global loads (`cam` then level id) is required for register coloring.

## Test plan
- [x] `python tools/match.py --c src/_ZN14EnemySwitchTag8BehaviorEv.c --func _ZN14EnemySwitchTag8BehaviorEv --addr 0x20f19fc --size 0xc8 --version 1.2/sp2p3 --module ov002`
- [x] `python tools/linkcheck.py --name _ZN14EnemySwitchTag8BehaviorEv --addr 0x20f19fc --size 0xc8 --module ov002` → VERIFIED
- [ ] CI `validate` green