### PR TITLE
Match func_ov006_020de1d4 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov006 func_ov006_020de1d4 (0x020de1d4, size 0x98) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #586 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov006_020de1d4.c
+++ b/src/func_ov006_020de1d4.c
@@ -1,15 +1,13 @@
-// NONMATCHING: different op / idiom (div=16). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 extern char* func_020beb68;
 extern void func_ov006_020dc370(void*);
-void* func_ov006_020de1d4(char* c){
-  char* q = c + 0x5000;
-  int* p = (int*)(c + 0x51cc);
-  if (*(int*)(q + 0x1cc) != 0) {
+
+void func_ov006_020de1d4(char* c) {
+  if (*(int*)((c + 0x5000) + 0x1cc) != 0) {
+    int* p = (int*)(int)(((long long)(int)(c + 0x51cc)) & 0xFFFFFFFFFFFFFFFFLL);
     *p = *p - 1;
-    if (*(int*)(q + 0x1cc) < 0) *(int*)(q + 0x1cc) = 0;
-    return c;
+    if (*(int*)((c + 0x5000) + 0x1cc) < 0)
+      *(int*)((c + 0x5000) + 0x1cc) = 0;
+    return;
   }
   {
     char* o = func_020beb68;
@@ -17,9 +15,8 @@ void* func_ov006_020de1d4(char* c){
     if (v != 0) {
       *(unsigned char*)(c + 0x51de) = 0;
       func_ov006_020dc370(c);
-      *(int*)(c + 0x51cc) = 0xc0;
-      *(int*)(c + 0x51c8) = 5;
     }
   }
-  return c;
+  *(int*)(c + 0x51cc) = 0xc0;
+  *(int*)(c + 0x51c8) = 5;
 }


### PR DESCRIPTION
## Summary

- **func_ov006_020de1d4** (ov006 @ `0x020de1d4`, size `0x98`) — byte-identical match under mwccarm **1.2/sp2p3** with flags `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`.

Replaces the prior `// NONMATCHING` draft (div=16). Logic: if timer at `c+0x51cc` is non-zero, pool-materialized RMW decrement + signed clamp; else optional `func_ov006_020dc370` path, then always write timer=`0xc0` / state=`5`.

Verified locally:
```
python tools/match.py --c src/func_ov006_020de1d4.c --func func_ov006_020de1d4 \
  --addr 0x20de1d4 --size 0x98 --version 1.2/sp2p3 --module ov006 --strict-relocs
# MATCHING VERSIONS: 1.2/sp2p3
```

## Test plan

- [x] `tools/match.py` reports MATCH for 1.2/sp2p3
- [x] `--strict-relocs` clean
- [ ] CI `validate` green