### PR TITLE
Match func_ov007_020aec00 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov007 func_ov007_020aec00 (0x020aec00, size 0x94) | lunavyqo (Grok) | 2026-07-22 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); PR #587 |
 | main (arm9): 7 funcs — 02048234, 02048720, 020490b0, 020494cc, 0204bbd8, 0204be40, 0204c304 (also locked via claims api) | ai-tdd-labs (claude-fable) | 2026-07-16 | released (api locks freed; no matches landed) |
 | ov004: func_ov004_020af2f8 (0x020af2f8, size 0x2e8) | lunavyqo (Grok) | 2026-07-16 | **done** — verified byte-identical (mwccarm 1.2/sp2p3); claim clm_a25f174bbe49 kept active |
 | ov006 func_ov006_020fc8c0 (0x020fc8c0, size 0xf0) | Codex/Raman | 2026-07-16 | active — batch 11, free div=6 refinement |

--- a/src/func_ov007_020aec00.c
+++ b/src/func_ov007_020aec00.c
@@ -1,0 +1,44 @@
+extern int *data_ov007_0210342c;
+void func_ov007_020aec00(void)
+{
+  int *p28;
+  int zero;
+  int neg1;
+  int i;
+  int sum;
+  int k;
+  int *g;
+  int off;
+  unsigned char *arr;
+  unsigned char *e;
+  unsigned char *row;
+  i = 0;
+  g = data_ov007_0210342c;
+  off = i;
+  p28 = (int *) g[10];
+  zero = i;
+  neg1 = -1;
+  for (; i < 3; i++)
+  {
+    arr = (unsigned char *) (*p28);
+    sum = zero;
+    row = arr + i;
+    if (row[0xb] != 0)
+    {
+      k = zero;
+      e = arr + off;
+      while (k < 15)
+      {
+        sum += e[0x11];
+        sum += e[0x6b];
+        e++;
+        k++;
+      }
+      sum += row[0x98];
+    }
+    else
+      sum = neg1;
+    ((short *) (((char *) p28) + 4))[i] = (short) sum;
+    off += 15;
+  }
+}


### PR DESCRIPTION
## Summary

- Match `func_ov007_020aec00` (ov007, `0x020aec00`, size `0x94`) byte-identical under mwccarm **1.2/sp2p3** with the standard flags (`-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`).
- Started from the banked near-miss (div=7, pure regperm: `off`/`p28` swapped between r0 and r3). Declaring `int *p28` before `int off` forces the allocator to color `p28→r3` and `off→r0`, matching the ROM setup sequence.

## Verification

```
python tools/match.py --c src/func_ov007_020aec00.c --func func_ov007_020aec00 --addr 0x20aec00 --size 0x94 --version 1.2/sp2p3 --module ov007
# MATCHING VERSIONS: 1.2/sp2p3
```

## Contents

- `src/func_ov007_020aec00.c` only