### PR TITLE
Match 2 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/__sinit_ov002_02107f88.c
+++ b/src/__sinit_ov002_02107f88.c
@@ -1,17 +1,13 @@
-//cpp
-// NONMATCHING: register allocation (div=29). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct S2 { int a, b; };
-extern "C" {
-extern struct S2 data_ov002_0210c040;
-extern struct S2 data_ov002_0210c010;
-extern struct S2 data_ov002_0210c020;
-extern struct S2 data_ov002_0210c038;
-extern struct S2 data_ov002_0210c030;
-extern struct S2 data_ov002_0210c018;
-extern struct S2 data_ov002_0210c028;
-extern struct S2 data_ov002_0211110c[7];
+struct P2 { int a, b; };
+extern struct P2 data_ov002_0210c040;
+extern struct P2 data_ov002_0210c010;
+extern struct P2 data_ov002_0210c020;
+extern struct P2 data_ov002_0210c038;
+extern struct P2 data_ov002_0210c030;
+extern struct P2 data_ov002_0210c018;
+extern struct P2 data_ov002_0210c028;
+extern struct P2 data_ov002_0211110c[];
+
 void __sinit_ov002_02107f88(void) {
     data_ov002_0211110c[0] = data_ov002_0210c040;
     data_ov002_0211110c[1] = data_ov002_0210c010;
@@ -20,5 +16,4 @@ void __sinit_ov002_02107f88(void) {
     data_ov002_0211110c[4] = data_ov002_0210c030;
     data_ov002_0211110c[5] = data_ov002_0210c018;
     data_ov002_0211110c[6] = data_ov002_0210c028;
-}
 }

--- a/src/func_ov006_020f670c.c
+++ b/src/func_ov006_020f670c.c
@@ -1,23 +1,32 @@
-// NONMATCHING: register allocation (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 void* func_ov006_020f670c(char* c){
   int cnt = 0;
-  int i;
+  int i = 0;
   char* p = c;
-  for (i = 0; i < 0x14; i++) {
-    char* b = p + 0x5000;
-    if (*(unsigned char*)(b + 0x1bb) != 0) {
-      if (*(unsigned char*)(b + 0x1bc) != 1) cnt++;
+  for (; i < 0x14; ) {
+    if (*(unsigned char*)(p + 0x51bb) != 0) {
+      if (*(unsigned char*)(p + 0x51bc) != 1) {
+        cnt++;
+        break;
+      }
     }
+    i++;
     p += 0x18;
   }
   if (cnt != 0) return c;
   p = c;
-  for (i = 0; i < 0x14; i++) {
-    *(unsigned char*)(p + 0x51bc) = 2;
-    p += 0x18;
+  i = 0;
+  {
+    unsigned char v = 2;
+    for (; i < 0x14; ) {
+      *(unsigned char*)(p + 0x51bc) = v;
+      i++;
+      p += 0x18;
+    }
   }
-  *(int*)(c + 0x53d8) = 0;
-  *(int*)(c + 0x53d4) = 2;
+  {
+    char* base = c + 0x5000;
+    *(int*)(base + 0x3d8) = 0;
+    *(int*)(base + 0x3d4) = 2;
+    return base;
+  }
 }


### PR DESCRIPTION
Replace two `NONMATCHING` drafts with exact mwccarm C implementations:

- `__sinit_ov002_02107f88` (ov002, `0x02107f88`, `0xc4`)
- `func_ov006_020f670c` (ov006, `0x020f670c`, `0x94`)

Validation:
- `python tools/match.py --c src/__sinit_ov002_02107f88.c --func __sinit_ov002_02107f88 --addr 0x02107f88 --size 0xc4 --version 1.2/sp2p3 --bin extracted/overlays/overlay_0002.bin --base 0x020ad660 --module ov002 --strict-relocs --brief`
- `python tools/match.py --c src/func_ov006_020f670c.c --func func_ov006_020f670c --addr 0x020f670c --size 0x94 --version 1.2/sp2p3 --bin extracted/overlays/overlay_0006.bin --base 0x020bfec0 --module ov006 --strict-relocs --brief`
- `python tools/linkcheck.py --name __sinit_ov002_02107f88 --addr 0x02107f88 --size 0xc4 --module ov002`
- `python tools/linkcheck.py --name func_ov006_020f670c --addr 0x020f670c --size 0x94 --module ov006`

Both matches pass; linkcheck reports `VERIFIED` with `blind: 0` for each.
