### PR TITLE
Match 3 functions byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN5Actor17TrackInDeathTableEv.c
+++ b/src/_ZN5Actor17TrackInDeathTableEv.c
@@ -1,6 +1,6 @@
-extern void DeathTable_SetBit(int id);
+extern void DeathTable_SetBit(int);
 
-void _ZN5Actor17TrackInDeathTableEv(void *self)
+void _ZN5Actor17TrackInDeathTableEv(char *self)
 {
-    DeathTable_SetBit((short)((short *)self)[0xce >> 1]);
+    DeathTable_SetBit(*(short *)(self + 0xce));
 }

--- a/src/_ZN5Actor18GetBitInDeathTableEv.c
+++ b/src/_ZN5Actor18GetBitInDeathTableEv.c
@@ -1,6 +1,6 @@
-extern unsigned int DeathTable_GetBit(int id);
+extern int DeathTable_GetBit(int);
 
-unsigned int _ZN5Actor18GetBitInDeathTableEv(void *self)
+int _ZN5Actor18GetBitInDeathTableEv(char *self)
 {
-    return DeathTable_GetBit((short)((short *)self)[0xce >> 1]);
+    return DeathTable_GetBit(*(short *)(self + 0xce));
 }

--- a/src/_ZN5Actor19UntrackInDeathTableEv.c
+++ b/src/_ZN5Actor19UntrackInDeathTableEv.c
@@ -1,6 +1,6 @@
-extern void DeathTable_ClearBit(int id);
+extern void DeathTable_ClearBit(int);
 
-void _ZN5Actor19UntrackInDeathTableEv(void *self)
+void _ZN5Actor19UntrackInDeathTableEv(char *self)
 {
-    DeathTable_ClearBit((short)((short *)self)[0xce >> 1]);
+    DeathTable_ClearBit(*(short *)(self + 0xce));
 }


### PR DESCRIPTION
Matched three Actor death-table helpers byte-for-byte with mwccarm 1.2/sp2p3. Strict relocation/link checks pass for all three. This brings the cumulative matched total to five with the previously merged batch.