### PR TITLE
Match func_ov006_020d09e0 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_020d09e0.c
+++ b/src/func_ov006_020d09e0.c
@@ -1,7 +1,4 @@
-// NONMATCHING: register allocation (div=18). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-struct V3 { int x, y, z; };
+struct V3 { int z, y, x; };
 extern void func_020553a4(void* p);
 extern void func_0203cd80(struct V3* out, int a, int b);
 extern void func_ov006_020cf2fc(char* p);
@@ -11,14 +8,17 @@ void func_ov006_020d09e0(void) {
     struct V3 s;
     *(volatile int*)0x4000440 = 2;
     func_020553a4(data_0209b3ec);
-    s.x = 0;
+    s.z = 0;
     s.y = 0;
-    s.z = 0xfffff008;
+    s.x = 0xfffff008;
     func_0203cd80(&s, -0x2000, 0xfffff008);
-    *(volatile int*)0x40004c8 = (0x3ff & ((s.x << 16) >> 19)) | ((0x3ff & ((s.y << 16) >> 19)) << 10) | ((0x3ff & ((s.z << 16) >> 19)) << 20) | 0x40000000;
+    *(volatile int*)0x40004c8 = (((short)s.z >> 3) & 0x3ff)
+        | ((((short)s.y >> 3) & 0x3ff) << 10)
+        | ((((short)s.x >> 3) & 0x3ff) << 20)
+        | 0x40000000;
     *(volatile int*)0x40004cc = 0x40007fff;
-    char* p = data_ov006_02140990;
     int i;
+    char* p = data_ov006_02140990;
     for (i = 0; i < 4; i++) {
         if (*(unsigned char*)(p + 0x328) != 0) {
             func_ov006_020cf2fc(p);


### PR DESCRIPTION
## Summary

- **Function:** `func_ov006_020d09e0` @ `ov006:0x020d09e0` (size `0xe0` / 224 bytes)
- **Compiler:** mwccarm **1.2/sp2p3** (`-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`)
- Replaces the previous `// NONMATCHING` (div=18) draft in `src/` with a byte-identical match.
- Started from the DB near-miss tip (div=11, `<<16>>19` pack form). Match came from switching the light-color pack to the matched-sibling idiom `((short)v >> 3) & 0x3ff`, which still emits `lsl #16` / `asr #19` but with the ROM’s `r1`/`r0`/`ip` coloring.

## Verification

```
python tools/match.py --c src/func_ov006_020d09e0.c --func func_ov006_020d09e0 \
  --addr 0x20d09e0 --size 0xe0 --version 1.2/sp2p3 --module ov006 --strict-relocs
# MATCHING VERSIONS: 1.2/sp2p3

python tools/linkcheck.py --module ov006 --name func_ov006_020d09e0 \
  --addr 0x020d09e0 --size 0xe0
# verdict: VERIFIED, blind: 0
```

## Author / provenance

- **author:** lunavyqo
- **matchProvenance:** `kind=ai model=grok-4.5 reasoning=high harness=grok-build`