### PR TITLE
Match OAM::LoadAffineParams byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
+++ b/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
@@ -1,0 +1,34 @@
+struct OamAttr { unsigned short a, b, c, param; };
+
+#pragma opt_strength_reduction off
+#pragma opt_common_subs off
+int _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2(struct OamAttr *oam, int *count, int *m)
+{
+    unsigned int k0 = (unsigned short)((unsigned int)m[0] >> 4);
+    unsigned int k1 = (unsigned short)((unsigned int)m[1] >> 4);
+    unsigned int k2 = (unsigned short)((unsigned int)m[2] >> 4);
+    unsigned int k3 = (unsigned short)((unsigned int)m[3] >> 4);
+    int n = *count;
+    int i;
+
+    for (i = 0; i < n; i += 4) {
+        struct OamAttr *e = &oam[i];
+        if (k0 == e[0].param && k1 == e[1].param &&
+            k2 == e[2].param && k3 == e[3].param)
+            return i >> 2;
+    }
+    if (n >= 0x80)
+        return -1;
+    {
+        struct OamAttr *e = &oam[n];
+        e[0].param = m[0] >> 4;
+        e[1].param = m[1] >> 4;
+        e[2].param = m[2] >> 4;
+        e[3].param = m[3] >> 4;
+    }
+    {
+        int t = *count;
+        *count = t + 4;
+        return t >> 2;
+    }
+}


### PR DESCRIPTION
## Match

- **Function:** `_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2` (`OAM::LoadAffineParams`)
- **Module/addr/size:** arm9 `0x02020884` / `0xe8` (232 bytes)
- **Compiler:** mwccarm **1.2/sp2p3**
- **Flags:** `-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`
- **Verify:** `tools/match.py` reports **MATCH** (strict-relocs)

## Notes

Near-miss draft (div=61) refined with `#pragma opt_strength_reduction off` + `#pragma opt_common_subs off`, then the shift-form coloring lever:

```c
(unsigned short)((unsigned int)m[i] >> 4)
```

which emits the ROM’s in-place `lsl #12` / `lsr #16` prologue coloring (r4/ip/r5/r6).

Author: lunavyqo