### PR TITLE
Match func_ov002_020f5990 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov002_020f5990.cpp
+++ b/src/func_ov002_020f5990.cpp
@@ -1,7 +1,4 @@
 //cpp
-// NONMATCHING: different op / idiom (div=31). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 typedef int s32;
 typedef short s16;
 typedef unsigned char u8;
@@ -27,22 +24,22 @@ struct Sub {
 };
 
 extern "C" void func_ov002_020f5990(char* c);
+
 void func_ov002_020f5990(char* c)
 {
-    C* self = (C*)c;
-    Sub* s = (Sub*)c;
     int i;
+    Sub* s = (Sub*)c;
     {
-        int* cnt = (int*)(c + 0x1f8);
+        int* cnt = (int*)(((int)c + 0x1f8) & 0xFFFFFFFFFFFFFFFF);
         *cnt = *cnt + 1;
         *cnt = *cnt & 3;
     }
     for (i = 0; i < 4; i++, s = (Sub*)((char*)s + 0x4c)) {
         if (s->f44 == 0) continue;
-        (self->*data_ov002_02110e7c[s->f46])(i);
+        (((C*)c)->*data_ov002_02110e7c[s->f46])(i);
         func_ov002_020f39ec(c, i);
         if (s->f49 == 0) continue;
         if (i != *(int*)(c + 0x1f8)) continue;
-        func_ov002_020f2790(c, (s->f0 << 4) >> 0x10, (s->f4 << 4) >> 0x10, s->f28, s->f2c);
+        func_ov002_020f2790(c, (s16)(s->f0 >> 12), (s16)(s->f4 >> 12), s->f28, s->f2c);
     }
 }


### PR DESCRIPTION
## Summary
- Match `func_ov002_020f5990` (ov002 @ `0x020f5990`, size `0xdc` / 220 bytes) byte-identical under mwccarm **1.2/sp2p3**.
- Replaces the previous `// NONMATCHING` `src/func_ov002_020f5990.c` with matching C++ (`//cpp`).
- Cracked the stored div=5 near-miss (arg-register coloring floor): use `(s16)(s->f0 >> 12)` / `(s16)(s->f4 >> 12)` instead of `(f << 4) >> 0x10` so mwccarm emits the ROM’s `ldr r1/r2; lsl; asr` schedule without `ip`.

## Verify
```
python tools/match.py --c src/func_ov002_020f5990.cpp --func func_ov002_020f5990 \
  --addr 0x20f5990 --size 0xdc --version 1.2/sp2p3 --module ov002 --strict-relocs
# → MATCHING VERSIONS: 1.2/sp2p3

python tools/linkcheck.py --module ov002 --name func_ov002_020f5990 \
  --addr 0x020f5990 --size 0xdc
# → VERIFIED, blind=0
```

Author credit: lunavyqo