### PR TITLE
Match func_0204af3c byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204af3c.c
+++ b/src/func_0204af3c.c
@@ -1,0 +1,72 @@
+#pragma opt_propagation off
+
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef int s32;
+typedef s32 fx32;
+
+#define reg_G3_TEXIMAGE_PARAM (*(volatile u32 *)0x040004a8)
+#define reg_G3_TEXPLTT_BASE   (*(volatile u32 *)0x040004ac)
+#define reg_G3_MTX_MODE       (*(volatile u32 *)0x04000440)
+#define reg_G3_IDENTITY       (*(volatile u32 *)0x04000454)
+#define reg_G3_SCALE          (*(volatile u32 *)0x0400046c)
+
+static inline void G3_MtxMode(int mode)
+{
+    reg_G3_MTX_MODE = (u32)mode;
+}
+
+static inline void G3_Identity(void)
+{
+    reg_G3_IDENTITY = 0;
+}
+
+static inline void G3_Scale(fx32 x, fx32 y, fx32 z)
+{
+    reg_G3_SCALE = (u32)x;
+    reg_G3_SCALE = (u32)y;
+    reg_G3_SCALE = (u32)z;
+}
+
+static inline void G3_TexPlttBase(u32 addr, u32 texFmt)
+{
+    reg_G3_TEXPLTT_BASE = (u32)(addr >> (4 - (texFmt == 2)));
+}
+
+static inline void G3_TexImageParam(u32 addr, u32 texFmt, u32 texGen, u32 sizeS, u32 sizeT,
+                                    u32 repeat, u32 flip, u32 pltt0)
+{
+    reg_G3_TEXIMAGE_PARAM = (u32)((addr >> 3) | (texFmt << 26) | (texGen << 30)
+        | (sizeS << 20) | (sizeT << 23) | (repeat << 16) | (flip << 18) | (pltt0 << 29));
+}
+
+struct TexParam
+{
+    u32 fmt : 4;
+    u32 sizeS : 4;
+    u32 sizeT : 4;
+    u32 repeat : 2;
+    u32 flip : 2;
+    u32 color0 : 1;
+};
+
+struct Tex
+{
+    int f0;
+    u32 texAddr;
+    u32 pltAddr;
+    struct TexParam param;
+    u16 width;
+    u16 height;
+};
+
+void func_0204af3c(struct Tex *self)
+{
+    struct TexParam p = self->param;
+    G3_TexImageParam(self->texAddr, p.fmt, 1, p.sizeS, p.sizeT, p.repeat, p.flip, p.color0);
+    G3_TexPlttBase(self->pltAddr, p.fmt);
+    G3_MtxMode(3);
+    G3_Identity();
+    G3_Scale(self->width << 12, self->height << 12, 0);
+    G3_MtxMode(1);
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 24 -> 0.

Lever:
MATCHED. Gates: t.div=0; match.py 1.2/base+sp2+sp2p3 MATCH; linkcheck VERIFIED (blind 0). No prior file existed; nothing else in the repo touched.

ROM READING FIRST (the whole crack came from it, zero grinding):
1. Literal pool decode identified the function outright. Pool = 0x040004a8, 0x040004ac, 0x04000440, 0x04000454, 0x0400046c = NitroSDK G3 immediate-mode registers TEXIMAGE_PARAM / TEXPLTT_BASE / MTX_MODE / IDENTITY / SCALE. So the body is G3_TexImageParam + G3_TexPlttBase + G3_MtxMode(GX_MTXMODE_TEXTURE) + G3_Identity + G3_Scale(w<<12, h<<12, 0) + G3_MtxMode(1).
2. lsl/lsr PAIRS off one word (lsl#0x1c/lsr#0x1c, lsl#0x18/lsr#0x1c, lsl#0x14/lsr#0x1c, lsl#0x12/lsr#0x1e, lsl#0x10/lsr#0x1e, lsl#0xf/lsr#0x1f) are mwccarm's bitfield-extract signature, LSB-first: decoding lsl S / lsr R as bits [j+R-S] gives fields at 0-3, 4-7, 8-11, 12-13, 14-15, 16 -> struct TexParam { u32 fmt:4; sizeS:4; sizeT:4; repeat:2; flip:2; color0:1; }. The draft's hand-rolled shift soup was the same IR and could never move.
3. `sub sp,#4` + `str r7,[sp]` with NO reload = a local struct COPY of the bitfield word (`struct TexParam p = self->param;`), not a volatile crutch.
4. `moveq r1,#1 / movne r1,#0 / rs

Built with Claude Code
