### PR TITLE
Match func_02063e08 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02063e08.c
+++ b/src/func_02063e08.c
@@ -1,22 +1,23 @@
-// NONMATCHING: extra logic (you do more) (div=21). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
 int func_02065970(void);
 int func_02065bc0(void);
 int func_02065bd0(void);
-void func_02064eac(int p0, unsigned short mask, unsigned char e2, short a, int b, int c);
+int func_02064eac(int p0, unsigned short mask, unsigned char e2, short a, int b, int c);
 
 int func_02063e08(char* obj, int idx, int p2)
 {
-    unsigned char* e = (unsigned char*)(obj + 0x1d4 + idx * 0x68);
-    unsigned short mask = (unsigned short)(1 << idx);
-    int a, b, c;
-    if (e[0] != 2) return 0;
-    if (e[1] != 2) return 0;
-    a = func_02065970();
-    b = func_02065bc0();
-    c = func_02065bd0();
-    func_02064eac(p2, mask, e[2], (short)a, b, c);
-    e[0] = 1;
-    return 1;
+    unsigned char* e;
+    unsigned short mask;
+    int a, b, c, r;
+
+    r = 0;
+    e = (unsigned char*)(obj + 0x1d4 + idx * 0x68);
+    mask = (unsigned short)(1 << idx);
+    if (e[0] == 2 && e[1] == 2) {
+        a = func_02065970();
+        b = func_02065bc0();
+        c = func_02065bd0();
+        r = func_02064eac(p2, mask, e[2], (short)a, b, c);
+        e[0] = 1;
+    }
+    return r;
 }


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 5 -> 0.

Lever:
CRACKED div 5->0. All gates green: t.div=0/160, match.py --trio "1.2/sp2p3: MATCH" (also 1.2/base, 1.2/sp2), linkcheck verdict VERIFIED (blind 0, diffs []). Only src/func_02063e08.c touched (tracked NONMATCHING stub upgraded in place; src/func_0204af3c.c was already untracked in the tree, not mine).

THE LEVER (new rule, generalizable): RESULT-VARIABLE INITIALIZATION ORDER RE-RANKS OUTGOING-ARG EMISSION. Writing `r = 0;` as a STATEMENT BEFORE the `e` and `mask` computations - and keeping `e`/`mask` as plain assignments, NOT declaration initializers - flips the pre-schedule argument emission order from ascending (r0,r1,r2,r3) to descending (r3,r2,r1,r0), which is exactly what the ARM9 scheduler needs to emit the ROM's `str r6,[sp] / lsl r2,r7 / str r0,[sp,#4] / asr r3,r2 / ldrb r2,[r4,#2] / mov r1,r8 / mov r0,r5`. Moving `r = 0;` after the e/mask assignments (the stored draft's shape) is div=5; moving e/mask INTO their declarations as initializers is also div=5 even with `int r = 0;` first. Both the goto form and the natural `if (e[0]==2 && e[1]==2) {...}` block form match once the ordering is right; I shipped the natural one.

THE DIAGNOSTIC THAT FOUND IT (reusable tooling insight)

Built with Claude Code
