### PR TITLE
Match func_0204be40 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204be40.c
+++ b/src/func_0204be40.c
@@ -1,0 +1,145 @@
+typedef signed short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef long long s64;
+
+typedef struct { int x, y, z; } Vec3;
+
+typedef struct {
+    u32 start : 6;
+    u32 limit : 6;
+    u32 count : 6;
+    u32 : 14;
+} Cnt74;
+
+typedef struct {
+    char _pad[0x20];
+    s16 q20;
+    char _pad2[0x12];
+    u32 : 8;
+    u32 val : 16;
+    u32 fa : 2;
+    u32 fb : 2;
+    u32 : 4;
+} P0;
+
+typedef struct {
+    P0 *p0;
+    char _pad[0x10];
+    int *p14;
+} Adat;
+
+typedef struct {
+    char _pad[0x18];
+    Adat *p18;
+    char _pad2[0x74 - 0x1c];
+    Cnt74 cnt;
+} Ctx;
+
+typedef struct {
+    u16 lo : 5;
+    u16 hi : 5;
+    u16 : 6;
+} M40;
+
+typedef struct {
+    char _pad0[8];
+    int p8;
+    int pc;
+    int p10;
+    int p14;
+    int p18;
+    int p1c;
+    Vec3 v20;
+    char _pad2c[4];
+    int p30;
+    s16 p34;
+    u16 p36;
+    char _pad38[2];
+    u16 p3a;
+    char _pad3c[4];
+    M40 p40;
+} Node;
+
+typedef struct {
+    char _pad[0x30];
+    int p30;
+    Ctx *p34;
+    int *p38;
+} Self;
+
+extern void MulVec3Mat4x3(Vec3 *v, int *m, Vec3 *dst);
+extern void func_02055388(int *m);
+extern void func_0204c24c(u8 a, u8 b);
+extern s16 data_02082214[];
+
+#define FX(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+void func_0204be40(Self *self, Node *node)
+{
+    Ctx *c = self->p34;
+    s16 q = c->p18->p0->q20;
+    int scale = (node->p40.lo * (node->p40.hi + 1)) >> 5;
+    int *mtx = self->p38;
+    Vec3 trans;
+    int mat[12];
+    u32 f2;
+    u32 v;
+    int v2;
+    int v1w;
+
+    v = *(u32 *)((char *)c + 0x74) << 14;
+    f2 = v >> 26;
+    v = self->p30 | 0xc0;
+    v |= f2 << 24;
+    v |= scale << 16;
+    *(volatile u32 *)0x40004a4 = v;
+    *(volatile u32 *)0x40004a4;
+    {
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        qq->count++;
+        if (c->cnt.count > c->cnt.limit)
+            qq->count = c->cnt.start;
+    }
+
+    if (scale == 0)
+        return;
+
+    v1w = (int)(((s64)node->p30 * node->p34 + 0x800) >> 12);
+    trans.x = node->p14 + node->p8;
+    trans.y = node->p18 + node->pc;
+    trans.z = node->p1c + node->p10;
+    MulVec3Mat4x3(&trans, mtx, &trans);
+
+    {
+        int idx = node->p36 >> 4;
+        int sinv;
+        int cosv;
+
+        v2 = FX(v1w, q);
+        sinv = data_02082214[idx * 2 + 1];
+        cosv = data_02082214[idx * 2];
+
+        mat[0] = FX(sinv, v2);
+        mat[3] = FX(-cosv, v1w);
+        mat[1] = FX(cosv, v2);
+        mat[9] = trans.x;
+        mat[10] = trans.y;
+        mat[8] = 0x1000;
+        mat[11] = trans.z;
+        mat[6] = 0;
+        mat[4] = FX(sinv, v1w);
+        mat[7] = 0;
+        mat[2] = 0;
+        mat[5] = 0;
+        *(volatile u32 *)0x4000454 = 0;
+        func_02055388(mat);
+    }
+
+    *(volatile u32 *)0x4000480 = node->p3a;
+    {
+        P0 *p = self->p34->p18->p0;
+        func_0204c24c(p->fa, p->fb);
+    }
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 50 -> 0.

Lever:
MATCHED at div=0. Gates: t.div=0; match.py --trio -> 1.2/base, 1.2/sp2, 1.2/sp2p3 all MATCH; linkcheck -> verdict VERIFIED, blind 0. git status shows my only change is the new untracked src/func_0204be40.c (the `M src/func_02063e08.c` and `?? src/func_0204af3c.c` entries predate this session, per the session-start snapshot). Nothing to bank in nearmiss/db.jsonl since this landed as a full match, and no repo file other than my own src file was touched.

BASELINE DRIFT (process fix #3 confirmed again): prompt said stored draft div=56; it reproduced at 50 on the current tree. Reported start_div is the reproduced 50.

THE BIG LEVER - ADDRESS-NEIGHBOUR SIBLING TEMPLATE (50 -> 10 in ONE edit). This is a generalization of LEVER A (read before spelling), and it beat literal-pool decoding here. Before writing any C, I grepped src/ for the target's CALLEES (func_02055388, 0x04000454, MulVec3Mat4x3) and found src/func_0204b460.c and src/func_0204b81c.c - already-matched functions a few hundred bytes EARLIER in the same module. They are the same billboard/particle-render family and share the target's entire skeleton: identical typedef set (Cnt74 6:6:6 bitfield, P0 with s16 q20 at 0x20 and fa/f

Built with Claude Code
