### PR TITLE
Match func_02048234 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02048234.c
+++ b/src/func_02048234.c
@@ -1,0 +1,34 @@
+typedef long long s64;
+typedef signed short s16;
+
+extern s16 data_02082214[];
+
+void func_02048234(int *out, int sa, int sb, int sc, unsigned short ax, unsigned short ay, unsigned short az, int tx, int ty, int tz) {
+    s16 *t = data_02082214;
+    int ia = ax >> 4;
+    int ib = ay >> 4;
+    int ic = az >> 4;
+    int a0 = t[ia * 2];
+    int a1 = t[ia * 2 + 1];
+    int b0 = t[ib * 2];
+    int b1 = t[ib * 2 + 1];
+    int c0 = t[ic * 2];
+    int c1 = t[ic * 2 + 1];
+    int p00 = (int)(((s64)a0 * c0) >> 12);
+    int p11 = (int)(((s64)a1 * c1) >> 12);
+    int p01 = (int)(((s64)a0 * c1) >> 12);
+    int p10 = (int)(((s64)a1 * c0) >> 12);
+
+    out[0] = (int)(((s64)sa * (((s64)b1 * c1) >> 12)) >> 12);
+    out[1] = (int)(((s64)sa * (((s64)b1 * c0) >> 12)) >> 12);
+    out[2] = (int)(((s64)(-b0) * sa) >> 12);
+    out[3] = (int)(((s64)sb * ((int)(((s64)b0 * p01 + 0x800) >> 12) - p10) + 0x800) >> 12);
+    out[4] = (int)(((s64)sb * (p11 + (int)(((s64)b0 * p00 + 0x800) >> 12)) + 0x800) >> 12);
+    out[5] = (int)(((s64)sb * (((s64)b1 * a0) >> 12)) >> 12);
+    out[6] = (int)(((s64)sc * (p00 + (int)(((s64)b0 * p11 + 0x800) >> 12)) + 0x800) >> 12);
+    out[7] = (int)(((s64)sc * ((int)(((s64)b0 * p10 + 0x800) >> 12) - p01) + 0x800) >> 12);
+    out[8] = (int)(((s64)sc * (((s64)b1 * a1) >> 12)) >> 12);
+    out[9] = tx;
+    out[10] = ty;
+    out[11] = tz;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 34 -> 0.

Lever:
CRACKED 34 -> 0. All three gates pass: wallcrack div=0; match.py --trio reports MATCH on 1.2/base, 1.2/sp2 AND 1.2/sp2p3; linkcheck verdict VERIFIED, diffs=[], blind=0. Written to src/func_02048234.c (new file, no other repo file touched, nothing committed).

THE WINNING LEVER (new, and the most generalizable finding of this run): FIND THE ALREADY-MATCHED SIBLING VIA THE CALLER CROSS-REFERENCE, AND TRANSCRIBE ITS IDIOM. Do this BEFORE any coloring or scheduling work on a function that has callers in config/arm9/relocs.txt.

Route in, exactly reproducible:
1. grep config/arm9/relocs.txt for "to:<addr>" -> two callers at 0x02044fe0 and 0x02045110.
2. Map caller addresses to enclosing functions via config/arm9/symbols.txt (kind:function(arm,size=...) ranges) -> func_02044f74 and func_02045074.
3. BOTH were already matched in src/. src/func_02045074.c has a two-branch if: one arm calls func_02048234, the OTHER arm calls func_02045178 with the same out-pointer and the same 3 angles + 3 translations, just no scale args. That is the same routine minus scaling, and src/func_02045178.c was already matched.
4. Transcribe src/func_02045178.c's structure verbatim, re-adding the three scale mul

Built with Claude Code
