### PR TITLE
Match func_0204bbd8 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204bbd8.c
+++ b/src/func_0204bbd8.c
@@ -1,0 +1,143 @@
+typedef signed short s16;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef long long s64;
+
+typedef struct { int x, y, z; } Vec3;
+
+typedef struct {
+    u32 start : 6;
+    u32 limit : 6;
+    u32 count : 6;
+    u32 : 14;
+} Cnt74;
+
+typedef struct {
+    char _pad[0x20];
+    s16 q20;
+} P0;
+
+typedef struct {
+    char _pad[0x10];
+    u32 b0 : 2;
+    u32 b1 : 2;
+    u32 : 28;
+} Bdat;
+
+typedef struct {
+    P0 *p0;
+    char _pad[0x10];
+    Bdat *p14;
+} Adat;
+
+typedef struct {
+    char _pad[0x18];
+    Adat *p18;
+    char _pad2[0x74 - 0x1c];
+    Cnt74 cnt;
+} Ctx;
+
+typedef struct {
+    u16 lo : 5;
+    u16 hi : 5;
+    u16 : 6;
+} M40;
+
+typedef struct {
+    char _pad0[8];
+    int p8;
+    int pc;
+    int p10;
+    int p14;
+    int p18;
+    int p1c;
+    char _pad20[0x10];
+    int p30;
+    s16 p34;
+    u16 p36;
+    char _pad38[2];
+    u16 p3a;
+    char _pad3c[4];
+    M40 p40;
+} Node;
+
+typedef struct {
+    char _pad[0x30];
+    int p30;
+    Ctx *p34;
+    int *p38;
+} Self;
+
+extern void MulVec3Mat4x3(Vec3 *v, int *m, Vec3 *dst);
+extern void func_02055388(int *m);
+extern void func_0204c24c(u8 a, u8 b);
+extern s16 data_02082214[];
+
+#define FX(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
+
+void func_0204bbd8(Self *self, Node *node)
+{
+    Ctx *c = self->p34;
+    s16 q = c->p18->p0->q20;
+    int scale = (node->p40.lo * (node->p40.hi + 1)) >> 5;
+    int *mtx = self->p38;
+    Vec3 trans;
+    int mat[12];
+    u32 f2;
+    u32 v;
+    int v2;
+    int v1w;
+
+    v = *(u32 *)((char *)c + 0x74) << 14;
+    f2 = v >> 26;
+    v = self->p30 | 0xc0;
+    v |= f2 << 24;
+    v |= scale << 16;
+    *(volatile u32 *)0x40004a4 = v;
+    *(volatile u32 *)0x40004a4;
+    {
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        qq->count++;
+        if (c->cnt.count > c->cnt.limit)
+            qq->count = c->cnt.start;
+    }
+
+    if (scale == 0)
+        return;
+
+    v1w = (int)(((s64)node->p30 * node->p34 + 0x800) >> 12);
+    trans.x = node->p14 + node->p8;
+    trans.y = node->p18 + node->pc;
+    trans.z = node->p1c + node->p10;
+    MulVec3Mat4x3(&trans, mtx, &trans);
+
+    {
+        int idx = node->p36 >> 4;
+        int sinv;
+        int cosv;
+        v2 = FX(v1w, q);
+        sinv = data_02082214[idx * 2 + 1];
+        cosv = data_02082214[idx * 2];
+        mat[0] = FX(sinv, v2);
+        mat[3] = FX(-cosv, v1w);
+        mat[1] = FX(cosv, v2);
+        mat[9] = trans.x;
+        mat[10] = trans.y;
+        mat[8] = 0x1000;
+        mat[11] = trans.z;
+        mat[6] = 0;
+        mat[4] = FX(sinv, v1w);
+        mat[7] = 0;
+        mat[2] = 0;
+        mat[5] = 0;
+        *(volatile u32 *)0x4000454 = 0;
+        func_02055388(mat);
+    }
+
+    *(volatile u32 *)0x4000480 = node->p3a;
+    {
+        Bdat *b = self->p34->p18->p14;
+        func_0204c24c(b->b0, b->b1);
+    }
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 52 -> 0.

Lever:
LEVER THAT LANDED IT (two steps, both from reading matched neighbours, not from grinding):

1. SIBLING SCAFFOLD PORT (52 -> 41, entry block byte-exact in one edit). func_0204be40.c, matched earlier in this same run, is the same actor-render family: same Ctx/Cnt74 0x74 bitfield RMW with the u64-launder, same volatile 0x40004a4 assembly, same MulVec3Mat4x3 + func_02055388(mat) + 0x4000480 + func_0204c24c tail. Copying its whole scaffold verbatim (declarations at top, `v = *(u32*)((char*)c+0x74) << 14; f2 = v >> 26;` for the count extract, the laundered qq pointer) fixed the entire first half.

2. THE mat[] SOURCE STORE ORDER, COPIED LITERALLY FROM THE SIBLING (41 -> 0). Winning order is exactly func_0204be40.c's: mat[0], mat[3], mat[1], mat[9], mat[10], mat[8], mat[11], mat[6], mat[4], mat[7], mat[2], mat[5], with v2/sinv/cosv computed before the group. `s64 v1w` (as the siblings declare it) is NOT load-bearing here: int and s64+(int) casts both give div=0.

CORRECTION TO THE RUN'S LEVER 3(a) - THIS COST MOST OF THE SESSION. "Store order is source order for a local array feeding a call, so paste the ROM's store schedule in verbatim" is WRONG as stated, and following it pinned me at d

Built with Claude Code
