### PR TITLE
Match func_02009aa8 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02009aa8.c
+++ b/src/func_02009aa8.c
@@ -1,0 +1,109 @@
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned int u32;
+typedef int s32;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
+extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
+extern void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+extern int func_020091f8(void *a, void *b, int c, int d);
+extern unsigned int func_020093f4(void *p, int x);
+extern int func_02009138(int *thiz, int arg);
+extern void func_020089d8(void *p);
+
+extern s32 data_02086e90[3];
+extern unsigned char data_020a0e40[];
+extern short data_0209f4a2[];
+extern short data_0209f4a4[];
+
+int func_02009aa8(char *self)
+{
+    s32 tmp[3];
+    Vector3 delta;
+    Vector3 src;
+
+    src.x = data_02086e90[0];
+    src.y = data_02086e90[1];
+    src.z = data_02086e90[2];
+
+    Vec3_RotateYAndTranslate(tmp,
+        (int *)(*(char **)(self + 0x110) + 0x5c),
+        *(s16 *)(*(char **)(self + 0x110) + 0x8e),
+        (int *)&src);
+
+    if (*(u8 *)(self + 0x1a6) != 0) {
+        char *base;
+        int r;
+
+        Vec3_Sub(&delta,
+            (Vector3 *)(*(char **)(self + 0x110) + 0x5c),
+            (Vector3 *)(self + 0x98));
+        AddVec3((Vector3 *)(self + 0x80), &delta, (Vector3 *)(self + 0x80));
+        AddVec3((Vector3 *)(self + 0x8c), &delta, (Vector3 *)(self + 0x8c));
+
+        base = (char *)(((long long)(int)(*(char **)(self + 0x110) + 0x5c)) & ~0ULL);
+        *(s32 *)(self + 0x98) = *(s32 *)(base + 0);
+        *(s32 *)(self + 0x9c) = *(s32 *)(base + 4);
+        *(s32 *)(self + 0xa0) = *(s32 *)(base + 8);
+
+        r = func_020091f8(self, tmp, *(s16 *)(self + 0x186), 0);
+        if (r != 0) *(u8 *)(self + 0x1a6) = 0;
+
+        *(s32 *)(self + 0xa4) = 0;
+        *(s32 *)(self + 0xac) = 0;
+    } else {
+        s16 newAngle;
+        int idx;
+        s16 t1, t2;
+        s16 rem;
+        int diff2;
+        int clamped;
+        s16 v17e;
+
+        newAngle = *(s16 *)(*(char **)(self + 0x110) + 0x8e) + 0x8000;
+        *(s16 *)(((long long)(int)(self + 0x17c)) & ~0ULL) += newAngle - *(s16 *)(self + 0x186);
+        *(s16 *)(self + 0x186) = newAngle;
+
+        *(s32 *)(self + 0x80) = tmp[0];
+        *(s32 *)(self + 0x84) = tmp[1];
+        *(s32 *)(self + 0x88) = tmp[2];
+
+        idx = data_020a0e40[0] * 0x18;
+        t1 = *(s16 *)((char *)data_0209f4a2 + idx);
+        *(s16 *)(((long long)(int)(self + 0x17c)) & ~0ULL) -= (int)(((long long)t1 * 0x200 + 0x800) >> 12);
+
+        diff2 = (s16)(*(s16 *)(self + 0x17c) - newAngle);
+        if (diff2 < -0x2000) {
+            clamped = -0x2000;
+        } else {
+            if (diff2 > 0x2000) {
+                clamped = 0x2000;
+            } else {
+                clamped = diff2;
+            }
+        }
+        rem = diff2 - clamped;
+
+        *(s16 *)(((long long)(int)(*(char **)(self + 0x110) + 0x8e)) & ~0ULL) += rem;
+        *(s16 *)(((long long)(int)(self + 0x186)) & ~0ULL) += rem;
+
+        t2 = *(s16 *)((char *)data_0209f4a4 + idx);
+        *(s16 *)(((long long)(int)(self + 0x17e)) & ~0ULL) += (int)(((long long)t2 * 0x200 + 0x800) >> 12);
+
+        v17e = *(s16 *)(self + 0x17e);
+        if (v17e < -0x1c00) {
+            v17e = -0x1c00;
+        } else if (v17e > 0x1c00) {
+            v17e = 0x1c00;
+        }
+        *(s16 *)(self + 0x17e) = v17e;
+    }
+
+    func_02009138((int *)self, func_020093f4(self, 0x48000));
+    *(u32 *)(((long long)(int)(self + 0x154)) & ~0ULL) |= 0x80000;
+    func_020089d8(self);
+
+    return 1;
+}

--- a/src/func_0200b798.c
+++ b/src/func_0200b798.c
@@ -1,0 +1,107 @@
+typedef long long s64;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+typedef struct RaycastGround { int _[0x15]; } RaycastGround;
+typedef struct Entry3 { int a, b, c; } Entry3;
+
+extern void _ZN13RaycastGroundC1Ev(RaycastGround *t);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround *t, const Vector3 *pos, void *actor);
+extern int _ZN13RaycastGround10DetectClsnEv(RaycastGround *t);
+extern void _ZN13RaycastGroundD1Ev(RaycastGround *t);
+extern int LenVec3(Vector3 *v);
+extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
+extern int _ZN4cstd4fdivEii(int a, int b);
+extern void Vec3_MulScalarInPlace(int *v, int s);
+extern void Vec3_Add(Vector3 *out, Vector3 *a, Vector3 *b);
+extern int func_020092c4(int self, Vector3 *out, Vector3 *target);
+extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
+
+extern Entry3 data_02086f58[];
+
+void func_0200b798(char *self, short *a1, int arg2)
+{
+    RaycastGround ray;
+    Vector3 pos;
+    Vector3 v1;
+    Vector3 v2;
+    Vector3 v3;
+    Vector3 v4;
+    int idx;
+    Entry3 *e;
+    int len;
+    int limit;
+    int scale;
+    int c;
+    int sum;
+
+    idx = *((unsigned char *)a1 + 1);
+    if (idx == 0xff) idx = 0;
+
+    e = &data_02086f58[idx];
+    {
+        int tz = a1[3] << 12;
+        int ty = a1[2] << 12;
+        int tx = a1[1] << 12;
+        pos.x = tx;
+        pos.y = ty;
+        pos.z = tz;
+    }
+
+    _ZN13RaycastGroundC1Ev(&ray);
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&ray, &pos, 0);
+    if (_ZN13RaycastGround10DetectClsnEv(&ray) != 0) {
+        pos.y -= ray._[0x11];
+    }
+
+    sum = arg2 + pos.y;
+    {
+        int sz = *(int *)(self + 0xa0);
+        int sx = *(int *)(self + 0x98);
+        int dz = sz - pos.z;
+        int dx = sx - pos.x;
+        int dy = sum - pos.y;
+        v1.x = dx;
+        v1.y = dy;
+        v1.z = dz;
+    }
+    c = e->c;
+    v2.y = sum;
+    v2.x = pos.x + (int)(((s64)v1.x * c + 0x800) >> 12);
+    v2.z = pos.z + (int)(((s64)v1.z * c + 0x800) >> 12);
+
+    len = LenVec3(&v1);
+    if (len < 0x220000) {
+        v2.y += 0x220000 - len;
+    }
+
+    Vec3_Sub(&v3, &v2, (Vector3 *)(self + 0x80));
+    v1.x = v3.x;
+    v1.y = v3.y;
+    v1.z = v3.z;
+    len = LenVec3(&v1);
+
+    limit = e->a;
+    if (*(int *)(self + 0x154) & 0xc00) limit = e->b;
+
+    if (len > limit) {
+        scale = _ZN4cstd4fdivEii(limit, len);
+        Vec3_MulScalarInPlace((int *)&v1, scale);
+        Vec3_Add(&v4, (Vector3 *)(self + 0x80), &v1);
+        v2.x = v4.x;
+        v2.y = v4.y;
+        v2.z = v4.z;
+    }
+
+    if (*(int *)(self + 0x154) & 4) {
+        *(int *)(self + 0x8c) = v2.x;
+        *(int *)(self + 0x90) = v2.y;
+        *(int *)(self + 0x94) = v2.z;
+    } else {
+        func_020092c4((int)self, (Vector3 *)(self + 0x8c), &v2);
+    }
+
+    *(short *)(self + 0x17c) =
+        Vec3_HorzAngle((Vector3 *)(self + 0x80), (Vector3 *)(self + 0x8c));
+
+    _ZN13RaycastGroundD1Ev(&ray);
+}

--- a/src/func_0203e20c.c
+++ b/src/func_0203e20c.c
@@ -1,0 +1,337 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef int s32;
+
+extern u8 data_020a0f04;
+extern u8 data_020a0f08;
+extern u8 data_020a0f0c;
+extern volatile u16 data_020a0f1c;
+extern u16 data_020a0f20;
+extern u16 data_020a0f28;
+extern void *data_020a0f3c;
+extern s32 data_020a0f40;
+extern s32 data_020a0f50;
+extern s32 data_020a0f6c;
+extern s32 data_020a0f70;
+extern s32 data_020a0f78;
+extern void *data_020a0f7c;
+extern u8 data_020a0f9d;
+extern u8 data_020a0fbe[24];
+extern u8 data_020a0fec[];
+extern u8 data_020a1040[];
+extern u8 data_020a1064[];
+extern u8 data_020a10fc[];
+extern u8 data_020a1112[];
+extern u8 data_020a1154[];
+extern u16 data_020a117c[4];
+extern u16 data_020a11a0[4];
+extern u16 data_020a11c4[4];
+extern s32 data_020a1680;
+extern u8 data_020a1780[];
+
+extern int func_02067194(void);
+extern void *_ZN6Memory8AllocateEji(unsigned int size, int align);
+extern void _ZN6Memory10DeallocateEPv(void *ptr);
+extern void func_0203f9d4(int a0, int a1);
+extern void func_0203e978(void);
+extern int func_02059640(void);
+extern void func_02068e4c(void *a, void *b, u16 c, u16 d, u16 e, int f);
+extern void func_02068dc8(int a, int b, int c);
+extern void func_020672a4(u32 val);
+extern void func_0203e9a8(u32 a0, int sel, int a2);
+extern int func_02068ae8(int param0);
+extern int func_02067e70(void *obj);
+extern int func_02067bfc(int a, void *b, int c);
+extern int func_02067928(void *a, void *b);
+extern void func_0205a588(void *dst, int val, unsigned int size);
+extern int func_02061c20(int *arg);
+extern void *func_020671b4(u16 idx);
+extern int func_02067250(u16 a);
+extern int func_0206703c(u16 arg0, int sel);
+extern void func_0205a61c(const void *src, void *dst, unsigned int size);
+extern int func_02067138(u16 idx);
+extern void func_02068a54(void);
+
+#define H(base, off) (*(u16 *)((char *)(base) + (off)))
+
+#pragma opt_dead_assignments off
+
+void func_0203e20c(void)
+{
+    if (data_020a0f40 != 0 && data_020a0f50 == 3) {
+        data_020a0f50 = 6;
+    }
+    if (data_020a0f50 > 3 && data_020a0f50 < 6 &&
+        (data_020a0f08 != (u8)(func_02067194() + 1) || (u32)func_02067194() < 1)) {
+        data_020a0f40 = 1;
+        data_020a0f50 = 6;
+        data_020a0f1c |= 4;
+    }
+
+    switch (data_020a0f50) {
+    case 0: {
+        void *ptr = _ZN6Memory8AllocateEji(0xB000, 0x20);
+        data_020a0f3c = ptr;
+        data_020a0f0c = 0;
+        func_0203f9d4((int)ptr, (int)func_0203e978);
+        data_020a0f50 += 1;
+        data_020a0f1c &= 0xFFFB;
+        break;
+    }
+
+    case 1:
+        if (data_020a0f0c != 0) {
+            data_020a0f50 += 1;
+        }
+        break;
+
+    case 2: {
+        void *p;
+        int size;
+        data_020a0f20 = (u16)func_02059640();
+        func_02068e4c(data_020a0f3c, data_020a10fc, H(data_020a1064, 6), H(data_020a1064, 8), data_020a0f20, 1);
+        func_02068dc8(0x1fe, 8, 3);
+        func_020672a4((u32)func_0203e9a8);
+        func_02068ae8(data_020a0f28);
+        size = func_02067e70(0);
+        p = _ZN6Memory8AllocateEji(size, 0x20);
+        data_020a0f7c = p;
+        if (func_02067bfc(0, p, size) != 0) {
+            func_02067928(data_020a0fec, data_020a0f7c);
+        }
+        data_020a0f70 = 0;
+        data_020a0f50 += 1;
+        break;
+    }
+
+    case 3: {
+        int cnt2;
+        int i2;
+        u8 *p9;
+        u8 *p11;
+        void *found;
+        u8 *pIdx;
+        u8 *base1112;
+        int idx;
+        int sel1;
+        int oneVal;
+
+        cnt2 = 1;
+        i2 = cnt2;
+        p9 = &data_020a0f9d;
+        p11 = data_020a1112;
+
+        data_020a0f1c |= 0x9000;
+        data_020a0f08 = cnt2;
+        do {
+            *p9 = 0;
+            func_0205a588(p11, 0, 0x16);
+            i2 += 1;
+            p9 += 1;
+            p11 += 0x16;
+        } while (i2 < 4);
+
+        func_02061c20(&data_020a1680);
+
+        pIdx = &data_020a0f9d;
+        base1112 = data_020a1112;
+        idx = 1;
+        sel1 = idx;
+        oneVal = idx;
+        do {
+            found = func_020671b4(idx);
+            if (found != 0 && ((H(data_020a1780, 0x7e) >> idx) & 1)) {
+                if (idx < 4) {
+                    if (func_02067250(idx) == 0xA) {
+                        func_0206703c(idx, sel1);
+                    } else if (func_02067250(idx) == 0xE) {
+                        cnt2 += 1;
+                    }
+                    *pIdx = oneVal;
+                    func_0205a61c(found, base1112, 0x16);
+                    data_020a0f08 += 1;
+                } else if (func_02067250(idx) == 0xA) {
+                    func_0206703c(idx, 0);
+                }
+            }
+            idx += 1;
+            pIdx += 1;
+            base1112 += 0x16;
+        } while (idx < 0x10);
+
+        if (data_020a0f70 != 0 && data_020a0f08 == cnt2) {
+            if ((u32)data_020a0f08 > 1U) {
+                u8 j;
+                u8 deadcnt;
+                int sel2;
+                deadcnt = 0;
+                j = 1;
+                sel2 = 2;
+                do {
+                    if (func_0206703c(j, sel2) == 1) {
+                        deadcnt = (u8)(deadcnt + 1);
+                    }
+                    j = (u8)(j + 1);
+                } while ((u32)j <= 0xF);
+            }
+            data_020a0f50 += 1;
+        }
+        break;
+    }
+
+    case 4: {
+        int ok = 1;
+        u8 *p = &data_020a0f9d;
+        int k = 1;
+        do {
+            if (*p != 0 && func_02067138(k) != 1) {
+                ok = 0;
+            }
+            k += 1;
+            p += 1;
+        } while (k < 4);
+        if (ok != 0) {
+            data_020a0f50 += 1;
+            data_020a0f6c = 0;
+            data_020a0f78 = 1;
+        }
+        break;
+    }
+
+    case 5:
+        if ((u32)data_020a0f08 > 1U) {
+            int result;
+            do {
+                u8 m;
+                u8 cnt;
+                cnt = 0;
+                m = 1;
+                do {
+                    if (func_0206703c(m, 3) == 1) {
+                        cnt = (u8)(cnt + 1);
+                    }
+                    m = (u8)(m + 1);
+                } while ((u32)m <= 0xF);
+                result = (cnt != 0) ? 1 : 0;
+            } while (result == 0);
+        }
+        data_020a0f50 += 1;
+        break;
+
+    case 6:
+        data_020a0f70 = 0;
+        data_020a0f1c &= 0x6FFF;
+        func_02068a54();
+        data_020a0f50 += 1;
+        break;
+
+    case 7:
+        if (data_020a0f70 != 0) {
+            data_020a0f50 += 1;
+        }
+        break;
+
+    default:
+        data_020a0f50 = 0;
+        data_020a0f04 = 0;
+        _ZN6Memory10DeallocateEPv(data_020a0f3c);
+        _ZN6Memory10DeallocateEPv(data_020a0f7c);
+        if (data_020a0f40 != 0) {
+            u8 *p9d = &data_020a0f9d;
+            u8 *p1112 = data_020a1112;
+            u8 *pbe = data_020a0fbe;
+            int sl;
+            data_020a0f40 = 0;
+            data_020a0f08 = 0;
+            sl = 1;
+            do {
+                *p9d = 0;
+                func_0205a588(p1112, 0, 0x16);
+                func_0205a588(pbe, 0, 6);
+                sl += 1;
+                p9d += 1;
+                p1112 += 0x16;
+                pbe += 6;
+            } while (sl < 4);
+        }
+        break;
+    }
+
+    {
+        u8 *p1040 = data_020a1040;
+        u8 *p1154 = data_020a1154;
+        int i;
+        int sh;
+        u16 t78, t7a, t54, t56, t30, t32, h4, h6, h8, ha;
+        data_020a0f1c &= 0xF0FF;
+        sh = (data_020a0f28 << 8) & 0xF00;
+        H(p1154, 0x78) = H(p1040, 0xc);
+        t78 = H(p1154, 0x78);
+        H(p1154, 0x7a) = H(p1040, 0xe);
+        t7a = H(p1154, 0x7a);
+        H(p1154, 0x54) = t78;
+        H(p1154, 0x56) = t7a;
+        t54 = H(p1154, 0x54);
+        t56 = H(p1154, 0x56);
+        H(p1154, 0x30) = t54;
+        H(p1154, 0x32) = t56;
+        t30 = H(p1154, 0x30);
+        t32 = H(p1154, 0x32);
+        H(p1154, 0xc) = t30;
+        data_020a0f1c |= sh;
+        H(p1154, 0xe) = t32;
+        h4 = H(p1040, 4);
+        h6 = H(p1040, 6);
+        h8 = H(p1040, 8);
+        ha = H(p1040, 0xa);
+        H(p1154, 0x70) = h4;
+        H(p1154, 0x72) = h6;
+        H(p1154, 0x74) = h8;
+        H(p1154, 0x76) = ha;
+
+        {
+            u16 *p11c4 = (u16 *)data_020a11c4;
+            H(p1154, 0x4c) = p11c4[0];
+            H(p1154, 0x4e) = p11c4[1];
+            H(p1154, 0x50) = p11c4[2];
+            H(p1154, 0x52) = p11c4[3];
+        }
+        {
+            u16 *p11a0 = (u16 *)data_020a11a0;
+            H(p1154, 0x28) = p11a0[0];
+            H(p1154, 0x2a) = p11a0[1];
+            H(p1154, 0x2c) = p11a0[2];
+            H(p1154, 0x2e) = p11a0[3];
+        }
+        {
+            u16 *p117c = (u16 *)data_020a117c;
+            H(p1154, 4) = p117c[0];
+            H(p1154, 6) = p117c[1];
+            H(p1154, 8) = p117c[2];
+            {
+                u16 last = p117c[3];
+                u16 h10 = H(p1040, 0x10);
+                H(p1154, 0x7c) = h10;
+                h10 = H(p1154, 0x7c);
+                H(p1154, 0xa) = last;
+                H(p1154, 0x58) = h10;
+                h10 = H(p1154, 0x58);
+                H(p1154, 0x34) = h10;
+                h10 = H(p1154, 0x34);
+                H(p1154, 0x10) = h10;
+            }
+        }
+
+        i = 0;
+        do {
+            p1154[0x7e] = p1040[0x12];
+            i += 1;
+            p1040 += 1;
+            p1154[0x5a] = p1154[0x7e];
+            p1154[0x36] = p1154[0x5a];
+            p1154[0x12] = p1154[0x36];
+            p1154 += 1;
+        } while (i < 0x11);
+    }
+}

--- a/src/func_02046e28.c
+++ b/src/func_02046e28.c
@@ -1,0 +1,82 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct MatAnimComp { u8 pad0; u8 which; u16 base; };
+struct MatAnimEntry { u16 matIdx; u8 pad2[6]; struct MatAnimComp comp[13]; };
+struct Material { u8 pad0[0x24]; u32 polyAttr; u32 diffAmb; u32 specEmi; };
+struct MatAnimData { u8 pad0[4]; u8 *values; u16 count; u8 pad_a[2]; struct MatAnimEntry *entries; };
+struct Model { u8 pad0[4]; struct Material *materials; };
+
+extern void Crash(void);
+
+#define LAUNDER(p) ((volatile u32 *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_02046e28(struct Model *model, struct MatAnimData *anim, short frame)
+{
+    u32 zero[1];
+    u16 sel[2];
+    int i;
+    struct MatAnimEntry *e;
+    int k;
+    struct Material *mat;
+    volatile u32 *pAttr;
+    volatile u32 *pDiffAmb;
+    volatile u32 *pSpecEmi;
+    u32 c;
+    u32 cb;
+    sel[0] = 0;
+    sel[1] = frame;
+
+    i = 0;
+    if (i < anim->count) {
+    k = 0;
+    zero[0] = 0;
+
+    do {
+        e = (struct MatAnimEntry *)((char *)anim->entries + k);
+        if (e->matIdx == 0xffff)
+            Crash();
+
+        mat = &model->materials[e->matIdx];
+        mat->diffAmb = 0x8000;
+        pDiffAmb = LAUNDER(&mat->diffAmb);
+
+        c = (u32)anim->values[e->comp[0].base + sel[e->comp[0].which]];
+        *pDiffAmb |= c;
+        c = (u32)anim->values[e->comp[1].base + sel[e->comp[1].which]];
+        *pDiffAmb |= c << 5;
+        c = (u32)anim->values[e->comp[2].base + sel[e->comp[2].which]];
+        *pDiffAmb |= c << 10;
+        c = (u32)anim->values[e->comp[3].base + sel[e->comp[3].which]];
+        *pDiffAmb |= c << 16;
+        c = (u32)anim->values[e->comp[4].base + sel[e->comp[4].which]];
+        *pDiffAmb |= c << 21;
+        c = (u32)anim->values[e->comp[5].base + sel[e->comp[5].which]];
+        *pDiffAmb |= c << 26;
+
+        mat->specEmi = zero[0];
+        pSpecEmi = LAUNDER(&mat->specEmi);
+        c = (u32)anim->values[e->comp[6].base + sel[e->comp[6].which]];
+        *pSpecEmi |= c;
+        c = (u32)anim->values[e->comp[7].base + sel[e->comp[7].which]];
+        *pSpecEmi |= c << 5;
+        c = (u32)anim->values[e->comp[8].base + sel[e->comp[8].which]];
+        *pSpecEmi |= c << 10;
+        c = (u32)anim->values[e->comp[9].base + sel[e->comp[9].which]];
+        *pSpecEmi |= c << 16;
+        c = (u32)anim->values[e->comp[10].base + sel[e->comp[10].which]];
+        *pSpecEmi |= c << 21;
+        cb = (u32)anim->values[e->comp[11].base + sel[e->comp[11].which]];
+        *pSpecEmi |= cb << 26;
+
+        pAttr = LAUNDER(&mat->polyAttr);
+        *pAttr &= 0xffe0ffffU;
+        c = (u32)anim->values[e->comp[12].base + sel[e->comp[12].which]];
+        *pAttr |= c << 16;
+
+        i++;
+        k += 0x3c;
+    } while (i < anim->count);
+    }
+}

--- a/src/func_0204d294.c
+++ b/src/func_0204d294.c
@@ -1,0 +1,113 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+/* Three-stop RGB555 colour ramp entry. */
+struct ColorRamp
+{
+    u16 startColor;
+    u16 endColor;
+    u8 stop1;
+    u8 stop2;
+    u8 stop3;
+    u8 pad7;
+    u16 flags;
+};
+
+struct EffectData
+{
+    u16 *palette;
+    int pad4;
+    struct ColorRamp *ramp;
+};
+
+struct Particle
+{
+    char pad0[0x3a];
+    u16 color;
+};
+
+void func_0204d294(struct Particle *ptcl, struct EffectData *data, int age)
+{
+    u16 *palette = data->palette;
+    struct ColorRamp *ramp = data->ramp;
+    u8 stop1 = ramp->stop1;
+    u8 stop2 = ramp->stop2;
+    u8 stop3 = ramp->stop3;
+
+    if (age < stop1)
+    {
+        ptcl->color = ramp->startColor;
+        return;
+    }
+    if (age < stop2)
+    {
+        u16 hiColor = *(u16 *)((char *)palette + 0x12);
+        u16 loColor = ramp->startColor;
+        u16 flags = ramp->flags;
+        int redHi = hiColor & 0x1f;
+        int redLo = loColor & 0x1f;
+        int greenHiRaw = hiColor >> 5;
+        int greenHi = greenHiRaw & 0x1f;
+        int greenLoRaw = loColor >> 5;
+        int greenLo = greenLoRaw & 0x1f;
+        int blueHiRaw = hiColor >> 10;
+        int blueHi = blueHiRaw & 0x1f;
+        int blueLoRaw = loColor >> 10;
+        int blueLo = blueLoRaw & 0x1f;
+        int lerp = (int)(((unsigned int)(flags << 29)) >> 31);
+        int num = age - stop1;
+        int denom = stop2 - stop1;
+        if (lerp == 0)
+            num = denom;
+        int blueDiff = blueHi - blueLo;
+        int blueMul = num * blueDiff;
+        int blueStep = blueMul / denom;
+        int redDiff = redHi - redLo;
+        int redMul = num * redDiff;
+        int redStep = redMul / denom;
+        int greenDiff = greenHi - greenLo;
+        int greenMul = num * greenDiff;
+        int greenStep = greenMul / denom;
+        int green = greenLo + greenStep;
+        int red = redLo + redStep;
+        int blue = blueLo + blueStep;
+        ptcl->color = (u16)(red | (green << 5) | (blue << 10));
+        return;
+    }
+    if (age < stop3)
+    {
+        u16 loColor = *(u16 *)((char *)palette + 0x12);
+        u16 hiColor = ramp->endColor;
+        u16 flags = ramp->flags;
+        int redLo = loColor & 0x1f;
+        int redHi = hiColor & 0x1f;
+        int greenLoRaw = loColor >> 5;
+        int greenLo = greenLoRaw & 0x1f;
+        int greenHiRaw = hiColor >> 5;
+        int greenHi = greenHiRaw & 0x1f;
+        int blueLoRaw = loColor >> 10;
+        int blueLo = blueLoRaw & 0x1f;
+        int blueHiRaw = hiColor >> 10;
+        int blueHi = blueHiRaw & 0x1f;
+        int lerp = (int)(((unsigned int)(flags << 29)) >> 31);
+        int num = age - stop2;
+        int denom = stop3 - stop2;
+        if (lerp == 0)
+            num = denom;
+        int blueDiff = blueHi - blueLo;
+        int blueMul = num * blueDiff;
+        int blueStep = blueMul / denom;
+        int redDiff = redHi - redLo;
+        int redMul = num * redDiff;
+        int redStep = redMul / denom;
+        int greenDiff = greenHi - greenLo;
+        int greenMul = num * greenDiff;
+        int greenStep = greenMul / denom;
+        int green = greenLo + greenStep;
+        int red = redLo + redStep;
+        int blue = blueLo + blueStep;
+        ptcl->color = (u16)(red | (green << 5) | (blue << 10));
+        return;
+    }
+    ptcl->color = ramp->endColor;
+}

--- a/src/func_020503a4.c
+++ b/src/func_020503a4.c
@@ -1,0 +1,122 @@
+typedef unsigned int u32;
+typedef long long s64;
+
+typedef struct G {
+    int f0, f4, f8, fc, f10, f14, f18, f1c, f20, f24, f28, f2c, f30, f34;
+    char f38[0x10];
+    int f48, f4c;
+} G;
+
+enum Fmt {
+    FMT_A = 0,
+    FMT_B = 1
+};
+
+extern G data_020a5634;
+extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(int a, int b);
+extern int func_0204f0d8(void);
+extern int func_0204f138(int a);
+extern int func_0204f194(int a);
+extern void func_0204f0b8(int a);
+extern void func_0204f11c(int a);
+extern int func_020500a4();
+extern void func_0205aa10(int a, int b, int c, int d, int e, u32 f, int g, int h, int i, int j);
+extern void func_0205ab6c(int a, int b, int c, u32 d, int e, int f, int g);
+extern void func_0205ab28(int a, int b, int c, int d, void *e);
+extern void func_0205a958(int a, int b, int c, int d);
+extern void func_0205ac28(int a, int b, int c, int d);
+extern void func_020524c4(void *a);
+extern void func_02052494(void *a, int b, int c);
+
+int func_020503a4(int a, int b, int c, int d, int p5, int p6, int p7, int p8,
+                  int p9, int p10, int p11, int p12, int p13, int p14, int p15)
+{
+    int mode = 0;
+    int align;
+    int total;
+    int blocks;
+    int q;
+    int fmt1;
+    int fmt2;
+    int m;
+    int dd;
+    int pp8;
+    int pp10;
+    u32 qlen;
+    int stereo;
+    int handle;
+    int chunk;
+    G *g;
+
+    dd = (int)(((s64)(int)d) & ~0ULL);
+    pp8 = (int)(((s64)(int)p8) & ~0ULL);
+    pp10 = (int)(((s64)(int)p10) & ~0ULL);
+
+    handle = -1;
+    g = &data_020a5634;
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(b, dd);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj(c, dd);
+    stereo = (p5 == 1) ? 1 : 0;
+    align = 0xffb0ff / p9;
+    if (p14 != 0) {
+        q = dd;
+        if (stereo == 0) q = dd >> 1;
+        align = (align + 0x10) & ~0x1f;
+        blocks = align >> 5;
+        q = q / p13;
+        total = blocks * q;
+        chunk = 0x20;
+        if (stereo == 0) chunk = chunk >> 1;
+        chunk = chunk * blocks;
+    }
+    {
+        fmt1 = (int)(stereo != 0 ? FMT_A : FMT_B);
+        fmt2 = (int)(stereo != 0 ? FMT_B : FMT_A);
+        if (a != 2) mode = 0xa;
+        if (p14 != 0) {
+            handle = func_0204f0d8();
+            if (handle < 0) return 0;
+        }
+        if (func_0204f138(3) == 0) {
+            if (handle >= 0) func_0204f0b8(handle);
+            return 0;
+        }
+        if (func_0204f194(0xa) == 0) {
+            if (handle >= 0) func_0204f0b8(handle);
+            func_0204f11c(3);
+            return 0;
+        }
+        qlen = (u32)dd >> 2;
+        func_0205aa10(1, fmt1, b, pp8 != 0 ? 1 : 2, 0, qlen, pp10, 0, align, p11);
+        func_0205ab6c(0, fmt2, b, qlen, pp8, p6, p7);
+        func_0205aa10(3, fmt1, c, pp8 != 0 ? 1 : 2, 0, qlen, pp10, 0, align, p12);
+        func_0205ab6c(1, fmt2, c, qlen, pp8, p6, p7);
+        if (handle >= 0) {
+            func_0205ab28(handle, total + chunk, total, (int)func_020500a4, g);
+        }
+        if (a == 1) {
+            func_0205a958(3, 3, 1, 1);
+        }
+        if (handle >= 0) m = 1 << handle; else m = 0;
+        func_0205ac28(mode, 3, m, 0);
+        g->f0 = 1;
+        g->f4 = a;
+        g->f1c = 0xa;
+        g->f20 = mode;
+        g->f24 = 3;
+        g->f28 = handle;
+        g->f8 = p5;
+        g->fc = b;
+        g->f10 = c;
+        g->f14 = dd;
+        g->f18 = 0;
+        g->f2c = p13;
+        g->f30 = p14;
+        g->f34 = p15;
+        g->f4c = pp10;
+        func_020524c4(g->f38);
+        func_02052494(g->f38, pp10 << 8, 1);
+        g->f48 = 0;
+        return 1;
+    }
+}

--- a/src/func_02058308.c
+++ b/src/func_02058308.c
@@ -1,0 +1,79 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef int s32;
+
+typedef struct {
+    char pad[0x14];
+    int slots[16];
+} Mgr;
+
+extern void func_00000000(void);
+extern void func_00000600(void);
+
+extern int data_020a6130;
+extern Mgr data_020a6134;
+extern char data_020a621c[];
+extern char data_020a613c[];
+extern void *data_020a612c;
+extern char data_023c0000;
+extern char data_020a6188[];
+extern void func_02057e34(void);
+extern char data_020a6378[];
+extern u32 func_02057e48(u32 newVal);
+extern void func_02058200(char *self, int a1, int a2, int end, int arg4, int arg5);
+
+void func_02058308(void)
+{
+    int i;
+    int ovr;
+    int base;
+    int end;
+
+    if (data_020a6130 != 0) {
+        return;
+    }
+    data_020a6130 = 1;
+
+    for (i = 0; i < 16; i++) {
+        data_020a6134.slots[i] = 0;
+    }
+
+    data_020a612c = data_020a613c;
+
+    *(int *)(data_020a621c + 0x70) = 0x10;
+    *(int *)(data_020a621c + 0x6c) = 0;
+    *(int *)(data_020a621c + 0x64) = 1;
+    *(int *)(data_020a621c + 0x68) = 0;
+    *(int *)(data_020a621c + 0x74) = 0;
+
+    *(char **)((char *)&data_020a6134 + 0x14) = data_020a621c;
+    *(char **)((char *)&data_020a6134 + 0xc) = data_020a621c;
+    *(char **)((char *)&data_020a6134 + 8) = data_020a621c;
+
+    ovr = (s32)func_00000000;
+    if (ovr == 0) {
+        base = 0x23c0020 - ovr;
+    } else {
+        base = (u32)&data_023c0000 + 0x3fc0 - (s32)func_00000600 - ovr;
+    }
+
+    end = (u32)&data_023c0000 + 0x3fc0 - (s32)func_00000600;
+
+    *(int *)(data_020a621c + 0x88) = end;
+    *(int *)(data_020a621c + 0x84) = base;
+    *(int *)(data_020a621c + 0x8c) = 0;
+    *(int *)(end - 4) = (int)0xfddb597d;
+    *(int *)(*(int *)(data_020a621c + 0x84)) = 0x7bf9dd5b;
+    *(u16 *)(data_020a621c + 0x90) = 0;
+    *(u16 *)((char *)&data_020a6134 + 2) = 0x10;
+    *(u16 *)((char *)&data_020a6134 + 0) = 0;
+    *(u16 *)((char *)&data_020a6134 + 4) = 0;
+    *(char **)0x027fffa0 = (char *)&data_020a6134;
+
+    func_02057e48(0);
+
+    func_02058200(data_020a6188, (int)&func_02057e34, 0, (int)data_020a6378, 0xc8, 0x1f);
+
+    *(int *)(data_020a6188 + 0x70) = 0x20;
+    *(int *)(data_020a6188 + 0x64) = 1;
+}

--- a/src/func_0205e3d4.c
+++ b/src/func_0205e3d4.c
@@ -1,0 +1,133 @@
+/* SHA-1 block transform (RFC 3174 SHA1ProcessMessageBlock), plus a
+   game-specific patch that temporarily zeroes two words of the message
+   block while data_020a80c4 is set.
+
+   Matching notes:
+   - RFC 3174 declaration order is load-bearing: K, t, temp, W, A..E.
+     `temp` lives at function scope, not inside the round loops, and the
+     circular shift is the inline macro (no named rotate local). Block-scoped
+     locals form their own late rank class and rotate the whole callee-saved
+     assignment; hoisting them to the top is what lands the ROM coloring.
+   - `save[2]` must NOT be volatile. Volatile stores are high-priority for the
+     list scheduler and sink to the block front, which hoists the shared
+     `mov r0, #0` above the two save loads.
+   - The round-1 K read goes through a volatile pointer. Register pressure in
+     the round-1 body is what keeps K[0] un-hoisted in the ROM; rounds 2..4
+     hoist their K into the preheader on their own.
+   - The Intermediate_Hash[1..4] updates use the u64 identity launder so each
+     one materializes its own base register (`add r3, ip, #4` etc.) instead of
+     folding into `[ip, #4]`. */
+
+typedef struct
+{
+    unsigned int w[4];
+} T4;
+
+typedef struct
+{
+    unsigned int Intermediate_Hash[5]; /* 0x00 */
+    unsigned int Length_Low;           /* 0x14 */
+    unsigned int Length_High;          /* 0x18 */
+    unsigned int Message_Block_Index;  /* 0x1c */
+    unsigned char Message_Block[64];   /* 0x20 */
+} SHA1Context;
+
+extern int data_020a80c4;
+extern unsigned int data_0209a054[4];
+
+#define SHA1CircularShift(bits, word) (((word) << (bits)) | ((word) >> (32 - (bits))))
+
+void func_0205e3d4(void *ctx)
+{
+    SHA1Context *context = (SHA1Context *)ctx;
+    unsigned int K[4];
+    int t;
+    unsigned int temp;
+    unsigned int W[80];
+    unsigned int A, B, C, D, E;
+    unsigned int save[2];
+    unsigned char *blk;
+
+    *(T4 *)K = *(T4 *)data_0209a054;
+    blk = context->Message_Block;
+    if (data_020a80c4 != 0)
+    {
+        save[0] = *(unsigned int *)(blk + 0x18);
+        save[1] = *(unsigned int *)(blk + 0x38);
+        *(unsigned int *)(blk + 0x18) = 0;
+        *(unsigned int *)(blk + 0x38) = 0;
+    }
+
+    for (t = 0; t < 16; t++)
+    {
+        W[t] = (unsigned int)context->Message_Block[t * 4] << 24;
+        W[t] |= (unsigned int)context->Message_Block[t * 4 + 1] << 16;
+        W[t] |= (unsigned int)context->Message_Block[t * 4 + 2] << 8;
+        W[t] |= (unsigned int)context->Message_Block[t * 4 + 3];
+    }
+
+    for (t = 16; t < 80; t++)
+    {
+        W[t] = SHA1CircularShift(1, W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16]);
+    }
+
+    A = context->Intermediate_Hash[0];
+    B = context->Intermediate_Hash[1];
+    C = context->Intermediate_Hash[2];
+    D = context->Intermediate_Hash[3];
+    E = context->Intermediate_Hash[4];
+
+    for (t = 0; t < 20; t++)
+    {
+        temp = SHA1CircularShift(5, A) + ((B & C) | ((~B) & D)) + E + W[t] +
+               ((volatile unsigned int *)K)[0];
+        E = D;
+        D = C;
+        C = SHA1CircularShift(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 20; t < 40; t++)
+    {
+        temp = SHA1CircularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[1];
+        E = D;
+        D = C;
+        C = SHA1CircularShift(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 40; t < 60; t++)
+    {
+        temp = SHA1CircularShift(5, A) + ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
+        E = D;
+        D = C;
+        C = SHA1CircularShift(30, B);
+        B = A;
+        A = temp;
+    }
+
+    for (t = 60; t < 80; t++)
+    {
+        temp = SHA1CircularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[3];
+        E = D;
+        D = C;
+        C = SHA1CircularShift(30, B);
+        B = A;
+        A = temp;
+    }
+
+    context->Intermediate_Hash[0] += A;
+    *(unsigned int *)(((int)&context->Intermediate_Hash[1]) & ~0ULL) += B;
+    *(unsigned int *)(((int)&context->Intermediate_Hash[2]) & ~0ULL) += C;
+    *(unsigned int *)(((int)&context->Intermediate_Hash[3]) & ~0ULL) += D;
+    *(unsigned int *)(((int)&context->Intermediate_Hash[4]) & ~0ULL) += E;
+    context->Message_Block_Index = 0;
+
+    if (data_020a80c4 != 0)
+    {
+        *(unsigned int *)(blk + 0x18) = save[0];
+        *(unsigned int *)(blk + 0x38) = save[1];
+    }
+}

--- a/src/func_020676e0.c
+++ b/src/func_020676e0.c
@@ -1,0 +1,76 @@
+extern void Crash(void);
+#define LD(x) (((int)(x)) & 0xFFFFFFFFFFFFFFFFLL)
+void func_020676e0(unsigned *self, unsigned *mode_p, unsigned *out, unsigned *cursor)
+{
+    unsigned mode = *mode_p;
+    unsigned *p;
+    unsigned addr, size, end;
+    unsigned bad, special;
+    unsigned *f;
+
+    if (mode == 0) goto case0;
+    if (mode == 1) goto case1;
+    if (mode == 2) goto case2;
+    return;
+
+case0:
+    p = (unsigned *)LD((int)self + 0x28);
+    addr = *p;
+    if (addr < 0x2000000u) goto crash0;
+    if (addr >= 0x22c0000u) goto crash0;
+    size = p[1];
+    if (addr + size > 0x22c0000u) goto crash0;
+    out[2] = size;
+    out[1] = *p;
+    f = (unsigned *)LD((int)out + 0xc);
+    out[0] = out[1];
+    *f = *f & ~1u;
+    return;
+crash0:
+    Crash();
+    return;
+
+case1:
+    p = (unsigned *)LD((int)self + 0x38);
+    addr = *p;
+    size = p[1];
+    bad = 0;
+    special = bad;
+    {
+        unsigned e = addr + size;
+        end = e;
+    }
+    if (addr < 0x2000000u) goto region2;
+    if (addr >= 0x23fe800u) goto region2;
+    if (end <= 0x2300000u) goto check_bad;
+    if (end >= 0x23fe800u) goto set_bad;
+    if (size <= 0x40000u) { special = 1; goto check_bad; }
+set_bad:
+    bad = 1;
+    goto check_bad;
+region2:
+    if (addr < 0x37f8000u) goto set_bad2;
+    if (addr >= 0x380f000u) goto set_bad2;
+    if (end <= 0x380f000u) { special = 1; goto check_bad; }
+    bad = 1;
+    goto check_bad;
+set_bad2:
+    bad = 1;
+check_bad:
+    if (bad == 1) Crash();
+    out[2] = p[1];
+    out[1] = p[0];
+    if (special == 0) out[0] = out[1];
+    else { out[0] = *cursor; *cursor = *cursor + out[2]; }
+    f = (unsigned *)LD((int)out + 0xc);
+    *f = (*f & ~1u) | 1u;
+    return;
+
+case2:
+    out[2] = 0x160;
+    out[1] = 0x027ffe00u;
+    out[0] = out[1];
+    f = (unsigned *)LD((int)out + 0xc);
+    *f = *f & ~1u;
+    return;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 999 -> 0.

Lever:
Stored draft did NOT reproduce at div=86 on this tree: it compiled to 608 bytes vs target 648 (div 999). Rebuilt from ROM reading instead of resuming the draft. ~15 compiles total, one 3-bit sweep.

WHAT THE ROM SAID (every crack came from the disasm + literal pool, zero grinding):

1. LITERAL POOL FIRST. The pool at +0x270 held 0x02086e90, 0x020a0e40, 0x0209f4a2, 0x00000186, 0x0209f4a4, 0x0000017e. Two of the six words are plain OFFSETS (0x186, 0x17e), not addresses. That is the tell for the whole function: ldrsh/strh carry only an 8-bit offset, so any halfword access past +0xff must materialize a base, and mwccarm has exactly two shapes for it. Reading which shape appears at which site reconstructs the source spelling directly.

2. NEW RULE - THE TWO HALFWORD-BASE SHAPES AND WHAT PICKS THEM (generalizes 6aa item 5).
   - split base: `add rX, r4, #0x100` + `[rX, #0x86]` -> a plain read or a plain store of `*(s16*)(self + 0x186)`. mwccarm chops the offset at the largest encodable chunk leaving <=255, and CSEs that base BASIC-BLOCK-LOCALLY. Proof in this ROM: it recomputes `add r0, r4, #0x100` twice around the clamp's blt (0x2009cac and 0x2009cd0) - the address CSE does not cross a

Built with Claude Code
