### PR TITLE
Match func_02009aa8 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02009aa8.c
+++ b/src/func_02009aa8.c
@@ -1,0 +1,109 @@
+typedef unsigned char u8;
+typedef short s16;
+typedef unsigned int u32;
+typedef int s32;
+
+typedef struct Vector3 { int x, y, z; } Vector3;
+
+extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
+extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
+extern void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+extern int func_020091f8(void *a, void *b, int c, int d);
+extern unsigned int func_020093f4(void *p, int x);
+extern int func_02009138(int *thiz, int arg);
+extern void func_020089d8(void *p);
+
+extern s32 data_02086e90[3];
+extern unsigned char data_020a0e40[];
+extern short data_0209f4a2[];
+extern short data_0209f4a4[];
+
+int func_02009aa8(char *self)
+{
+    s32 tmp[3];
+    Vector3 delta;
+    Vector3 src;
+
+    src.x = data_02086e90[0];
+    src.y = data_02086e90[1];
+    src.z = data_02086e90[2];
+
+    Vec3_RotateYAndTranslate(tmp,
+        (int *)(*(char **)(self + 0x110) + 0x5c),
+        *(s16 *)(*(char **)(self + 0x110) + 0x8e),
+        (int *)&src);
+
+    if (*(u8 *)(self + 0x1a6) != 0) {
+        char *base;
+        int r;
+
+        Vec3_Sub(&delta,
+            (Vector3 *)(*(char **)(self + 0x110) + 0x5c),
+            (Vector3 *)(self + 0x98));
+        AddVec3((Vector3 *)(self + 0x80), &delta, (Vector3 *)(self + 0x80));
+        AddVec3((Vector3 *)(self + 0x8c), &delta, (Vector3 *)(self + 0x8c));
+
+        base = (char *)(((long long)(int)(*(char **)(self + 0x110) + 0x5c)) & ~0ULL);
+        *(s32 *)(self + 0x98) = *(s32 *)(base + 0);
+        *(s32 *)(self + 0x9c) = *(s32 *)(base + 4);
+        *(s32 *)(self + 0xa0) = *(s32 *)(base + 8);
+
+        r = func_020091f8(self, tmp, *(s16 *)(self + 0x186), 0);
+        if (r != 0) *(u8 *)(self + 0x1a6) = 0;
+
+        *(s32 *)(self + 0xa4) = 0;
+        *(s32 *)(self + 0xac) = 0;
+    } else {
+        s16 newAngle;
+        int idx;
+        s16 t1, t2;
+        s16 rem;
+        int diff2;
+        int clamped;
+        s16 v17e;
+
+        newAngle = *(s16 *)(*(char **)(self + 0x110) + 0x8e) + 0x8000;
+        *(s16 *)(((long long)(int)(self + 0x17c)) & ~0ULL) += newAngle - *(s16 *)(self + 0x186);
+        *(s16 *)(self + 0x186) = newAngle;
+
+        *(s32 *)(self + 0x80) = tmp[0];
+        *(s32 *)(self + 0x84) = tmp[1];
+        *(s32 *)(self + 0x88) = tmp[2];
+
+        idx = data_020a0e40[0] * 0x18;
+        t1 = *(s16 *)((char *)data_0209f4a2 + idx);
+        *(s16 *)(((long long)(int)(self + 0x17c)) & ~0ULL) -= (int)(((long long)t1 * 0x200 + 0x800) >> 12);
+
+        diff2 = (s16)(*(s16 *)(self + 0x17c) - newAngle);
+        if (diff2 < -0x2000) {
+            clamped = -0x2000;
+        } else {
+            if (diff2 > 0x2000) {
+                clamped = 0x2000;
+            } else {
+                clamped = diff2;
+            }
+        }
+        rem = diff2 - clamped;
+
+        *(s16 *)(((long long)(int)(*(char **)(self + 0x110) + 0x8e)) & ~0ULL) += rem;
+        *(s16 *)(((long long)(int)(self + 0x186)) & ~0ULL) += rem;
+
+        t2 = *(s16 *)((char *)data_0209f4a4 + idx);
+        *(s16 *)(((long long)(int)(self + 0x17e)) & ~0ULL) += (int)(((long long)t2 * 0x200 + 0x800) >> 12);
+
+        v17e = *(s16 *)(self + 0x17e);
+        if (v17e < -0x1c00) {
+            v17e = -0x1c00;
+        } else if (v17e > 0x1c00) {
+            v17e = 0x1c00;
+        }
+        *(s16 *)(self + 0x17e) = v17e;
+    }
+
+    func_02009138((int *)self, func_020093f4(self, 0x48000));
+    *(u32 *)(((long long)(int)(self + 0x154)) & ~0ULL) |= 0x80000;
+    func_020089d8(self);
+
+    return 1;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 999 -> 0.

Lever:
Stored draft did NOT reproduce at div=86 on this tree: it compiled to 608 bytes vs target 648 (div 999). Rebuilt from ROM reading instead of resuming the draft. ~15 compiles total, one 3-bit sweep.

WHAT THE ROM SAID (every crack came from the disasm + literal pool, zero grinding):

1. LITERAL POOL FIRST. The pool at +0x270 held 0x02086e90, 0x020a0e40, 0x0209f4a2, 0x00000186, 0x0209f4a4, 0x0000017e. Two of the six words are plain OFFSETS (0x186, 0x17e), not addresses. That is the tell for the whole function: ldrsh/strh carry only an 8-bit offset, so any halfword access past +0xff must materialize a base, and mwccarm has exactly two shapes for it. Reading which shape appears at which site reconstructs the source spelling directly.

2. NEW RULE - THE TWO HALFWORD-BASE SHAPES AND WHAT PICKS THEM (generalizes 6aa item 5).
   - split base: `add rX, r4, #0x100` + `[rX, #0x86]` -> a plain read or a plain store of `*(s16*)(self + 0x186)`. mwccarm chops the offset at the largest encodable chunk leaving <=255, and CSEs that base BASIC-BLOCK-LOCALLY. Proof in this ROM: it recomputes `add r0, r4, #0x100` twice around the clamp's blt (0x2009cac and 0x2009cd0) - the address CSE does not cross a

Built with Claude Code
