### PR TITLE
Match func_02046e28 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02046e28.c
+++ b/src/func_02046e28.c
@@ -1,0 +1,82 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+
+struct MatAnimComp { u8 pad0; u8 which; u16 base; };
+struct MatAnimEntry { u16 matIdx; u8 pad2[6]; struct MatAnimComp comp[13]; };
+struct Material { u8 pad0[0x24]; u32 polyAttr; u32 diffAmb; u32 specEmi; };
+struct MatAnimData { u8 pad0[4]; u8 *values; u16 count; u8 pad_a[2]; struct MatAnimEntry *entries; };
+struct Model { u8 pad0[4]; struct Material *materials; };
+
+extern void Crash(void);
+
+#define LAUNDER(p) ((volatile u32 *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+void func_02046e28(struct Model *model, struct MatAnimData *anim, short frame)
+{
+    u32 zero[1];
+    u16 sel[2];
+    int i;
+    struct MatAnimEntry *e;
+    int k;
+    struct Material *mat;
+    volatile u32 *pAttr;
+    volatile u32 *pDiffAmb;
+    volatile u32 *pSpecEmi;
+    u32 c;
+    u32 cb;
+    sel[0] = 0;
+    sel[1] = frame;
+
+    i = 0;
+    if (i < anim->count) {
+    k = 0;
+    zero[0] = 0;
+
+    do {
+        e = (struct MatAnimEntry *)((char *)anim->entries + k);
+        if (e->matIdx == 0xffff)
+            Crash();
+
+        mat = &model->materials[e->matIdx];
+        mat->diffAmb = 0x8000;
+        pDiffAmb = LAUNDER(&mat->diffAmb);
+
+        c = (u32)anim->values[e->comp[0].base + sel[e->comp[0].which]];
+        *pDiffAmb |= c;
+        c = (u32)anim->values[e->comp[1].base + sel[e->comp[1].which]];
+        *pDiffAmb |= c << 5;
+        c = (u32)anim->values[e->comp[2].base + sel[e->comp[2].which]];
+        *pDiffAmb |= c << 10;
+        c = (u32)anim->values[e->comp[3].base + sel[e->comp[3].which]];
+        *pDiffAmb |= c << 16;
+        c = (u32)anim->values[e->comp[4].base + sel[e->comp[4].which]];
+        *pDiffAmb |= c << 21;
+        c = (u32)anim->values[e->comp[5].base + sel[e->comp[5].which]];
+        *pDiffAmb |= c << 26;
+
+        mat->specEmi = zero[0];
+        pSpecEmi = LAUNDER(&mat->specEmi);
+        c = (u32)anim->values[e->comp[6].base + sel[e->comp[6].which]];
+        *pSpecEmi |= c;
+        c = (u32)anim->values[e->comp[7].base + sel[e->comp[7].which]];
+        *pSpecEmi |= c << 5;
+        c = (u32)anim->values[e->comp[8].base + sel[e->comp[8].which]];
+        *pSpecEmi |= c << 10;
+        c = (u32)anim->values[e->comp[9].base + sel[e->comp[9].which]];
+        *pSpecEmi |= c << 16;
+        c = (u32)anim->values[e->comp[10].base + sel[e->comp[10].which]];
+        *pSpecEmi |= c << 21;
+        cb = (u32)anim->values[e->comp[11].base + sel[e->comp[11].which]];
+        *pSpecEmi |= cb << 26;
+
+        pAttr = LAUNDER(&mat->polyAttr);
+        *pAttr &= 0xffe0ffffU;
+        c = (u32)anim->values[e->comp[12].base + sel[e->comp[12].which]];
+        *pAttr |= c << 16;
+
+        i++;
+        k += 0x3c;
+    } while (i < anim->count);
+    }
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 101 -> 0.

Lever:
ANATOMY (read from ROM first, per the group-2 rule). NDS material-animation applier. `mov r0,#0x30` + `mla` => 0x30-byte Material; `bic r0,r0,#0x1f0000` at +0x24 => POLYGON_ATTR alpha (bits 16-20); seed 0x8000 at +0x28 => DIFF_AMB "set vertex colour" bit; the 6 shifts 0/5/10/16/21/26 in each of +0x28/+0x2c are two RGB555 halves => diffuse+ambient and specular+emission. 13 five-bit components total. `sel[2] = {0, frame}` at [sp+8] is a static-vs-animated frame selector indexed by comp.which. Only xref is a LOAD at 0x020157a8 (function-pointer table); the useful sibling is the ALREADY-MATCHED func_02046bbc (src/func_02046bbc.c), which supplied the entry/`id==0xffff`->Crash()/`base + id*0x30` scaffold and the u64-launder idiom verbatim. The draft's schedule was already correct at div 101 - every divergence but two was regperm, so this was a pure coloring problem from word one.

LEVER 1 - WHOLE-EXPRESSION u64 LAUNDER IS THE ONLY UN-FOLDER, AND ALL 64-BIT VARIANTS ARE ONE IR. The ROM materialises three separate base registers (`add r0,mat,#0x28` / `add r3,mat,#0x2c` / `add r2,mat,#0x24`) and derefs them at offset 0. Swept 6 pointer spellings x 12 launder macros (72 compiles): EVERY 32-b

Built with Claude Code
