### PR TITLE
Match func_0204d294 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_0204d294.c
+++ b/src/func_0204d294.c
@@ -1,0 +1,113 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+/* Three-stop RGB555 colour ramp entry. */
+struct ColorRamp
+{
+    u16 startColor;
+    u16 endColor;
+    u8 stop1;
+    u8 stop2;
+    u8 stop3;
+    u8 pad7;
+    u16 flags;
+};
+
+struct EffectData
+{
+    u16 *palette;
+    int pad4;
+    struct ColorRamp *ramp;
+};
+
+struct Particle
+{
+    char pad0[0x3a];
+    u16 color;
+};
+
+void func_0204d294(struct Particle *ptcl, struct EffectData *data, int age)
+{
+    u16 *palette = data->palette;
+    struct ColorRamp *ramp = data->ramp;
+    u8 stop1 = ramp->stop1;
+    u8 stop2 = ramp->stop2;
+    u8 stop3 = ramp->stop3;
+
+    if (age < stop1)
+    {
+        ptcl->color = ramp->startColor;
+        return;
+    }
+    if (age < stop2)
+    {
+        u16 hiColor = *(u16 *)((char *)palette + 0x12);
+        u16 loColor = ramp->startColor;
+        u16 flags = ramp->flags;
+        int redHi = hiColor & 0x1f;
+        int redLo = loColor & 0x1f;
+        int greenHiRaw = hiColor >> 5;
+        int greenHi = greenHiRaw & 0x1f;
+        int greenLoRaw = loColor >> 5;
+        int greenLo = greenLoRaw & 0x1f;
+        int blueHiRaw = hiColor >> 10;
+        int blueHi = blueHiRaw & 0x1f;
+        int blueLoRaw = loColor >> 10;
+        int blueLo = blueLoRaw & 0x1f;
+        int lerp = (int)(((unsigned int)(flags << 29)) >> 31);
+        int num = age - stop1;
+        int denom = stop2 - stop1;
+        if (lerp == 0)
+            num = denom;
+        int blueDiff = blueHi - blueLo;
+        int blueMul = num * blueDiff;
+        int blueStep = blueMul / denom;
+        int redDiff = redHi - redLo;
+        int redMul = num * redDiff;
+        int redStep = redMul / denom;
+        int greenDiff = greenHi - greenLo;
+        int greenMul = num * greenDiff;
+        int greenStep = greenMul / denom;
+        int green = greenLo + greenStep;
+        int red = redLo + redStep;
+        int blue = blueLo + blueStep;
+        ptcl->color = (u16)(red | (green << 5) | (blue << 10));
+        return;
+    }
+    if (age < stop3)
+    {
+        u16 loColor = *(u16 *)((char *)palette + 0x12);
+        u16 hiColor = ramp->endColor;
+        u16 flags = ramp->flags;
+        int redLo = loColor & 0x1f;
+        int redHi = hiColor & 0x1f;
+        int greenLoRaw = loColor >> 5;
+        int greenLo = greenLoRaw & 0x1f;
+        int greenHiRaw = hiColor >> 5;
+        int greenHi = greenHiRaw & 0x1f;
+        int blueLoRaw = loColor >> 10;
+        int blueLo = blueLoRaw & 0x1f;
+        int blueHiRaw = hiColor >> 10;
+        int blueHi = blueHiRaw & 0x1f;
+        int lerp = (int)(((unsigned int)(flags << 29)) >> 31);
+        int num = age - stop2;
+        int denom = stop3 - stop2;
+        if (lerp == 0)
+            num = denom;
+        int blueDiff = blueHi - blueLo;
+        int blueMul = num * blueDiff;
+        int blueStep = blueMul / denom;
+        int redDiff = redHi - redLo;
+        int redMul = num * redDiff;
+        int redStep = redMul / denom;
+        int greenDiff = greenHi - greenLo;
+        int greenMul = num * greenDiff;
+        int greenStep = greenMul / denom;
+        int green = greenLo + greenStep;
+        int red = redLo + redStep;
+        int blue = blueLo + blueStep;
+        ptcl->color = (u16)(red | (green << 5) | (blue << 10));
+        return;
+    }
+    ptcl->color = ramp->endColor;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 63 -> 0.

Lever:
ANATOMY (from the ROM, before any spelling): a 3-stop RGB555 colour ramp. Entry loads ramp=data[2], stop1/stop2/stop3 (u8 at +4/+5/+6) and palette=data[0]; the first `if` is IF-CONVERTED (ldrhlt/addlt/strhlt/poplt/bxlt). Each of the two interpolating bodies extracts r/g/b from two RGB555 words (one from palette+0x12, one from the ramp), does `lsl ip,flags,#29` + `lsrs r0,ip,#31` + `moveq num,denom` for the lerp-enable bit, then THREE divide calls in order blue, red, green (blue's result spilled to [sp] / [sp,#4] because it must survive two calls), and recombines red | green<<5 | blue<<10.

Stored draft div 70 reproduced as 63 (size already exact 428, identical instruction multiset -> pure schedule+coloring permutation). Four ordering levers, each measured:

1. SPLIT-THEN-MASK BLOCKS LOSE TO PER-COMPONENT EXTRACTION (63 -> 46). The draft grouped all four `x >> N` raws together, then all four `& 0x1f` masks. That gives the list scheduler enough slack to reorder by critical-path height: it hoisted BOTH `asr #0xa` (the blue chain feeding the first division) to the top, so the ROM's `asr #5, asr #0xa, asr #5, asr #0xa` word-grouped order was unreachable. Writing each component as an adj

Built with Claude Code
