### PR TITLE
Match func_02058308 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02058308.c
+++ b/src/func_02058308.c
@@ -1,0 +1,79 @@
+typedef unsigned int u32;
+typedef unsigned short u16;
+typedef int s32;
+
+typedef struct {
+    char pad[0x14];
+    int slots[16];
+} Mgr;
+
+extern void func_00000000(void);
+extern void func_00000600(void);
+
+extern int data_020a6130;
+extern Mgr data_020a6134;
+extern char data_020a621c[];
+extern char data_020a613c[];
+extern void *data_020a612c;
+extern char data_023c0000;
+extern char data_020a6188[];
+extern void func_02057e34(void);
+extern char data_020a6378[];
+extern u32 func_02057e48(u32 newVal);
+extern void func_02058200(char *self, int a1, int a2, int end, int arg4, int arg5);
+
+void func_02058308(void)
+{
+    int i;
+    int ovr;
+    int base;
+    int end;
+
+    if (data_020a6130 != 0) {
+        return;
+    }
+    data_020a6130 = 1;
+
+    for (i = 0; i < 16; i++) {
+        data_020a6134.slots[i] = 0;
+    }
+
+    data_020a612c = data_020a613c;
+
+    *(int *)(data_020a621c + 0x70) = 0x10;
+    *(int *)(data_020a621c + 0x6c) = 0;
+    *(int *)(data_020a621c + 0x64) = 1;
+    *(int *)(data_020a621c + 0x68) = 0;
+    *(int *)(data_020a621c + 0x74) = 0;
+
+    *(char **)((char *)&data_020a6134 + 0x14) = data_020a621c;
+    *(char **)((char *)&data_020a6134 + 0xc) = data_020a621c;
+    *(char **)((char *)&data_020a6134 + 8) = data_020a621c;
+
+    ovr = (s32)func_00000000;
+    if (ovr == 0) {
+        base = 0x23c0020 - ovr;
+    } else {
+        base = (u32)&data_023c0000 + 0x3fc0 - (s32)func_00000600 - ovr;
+    }
+
+    end = (u32)&data_023c0000 + 0x3fc0 - (s32)func_00000600;
+
+    *(int *)(data_020a621c + 0x88) = end;
+    *(int *)(data_020a621c + 0x84) = base;
+    *(int *)(data_020a621c + 0x8c) = 0;
+    *(int *)(end - 4) = (int)0xfddb597d;
+    *(int *)(*(int *)(data_020a621c + 0x84)) = 0x7bf9dd5b;
+    *(u16 *)(data_020a621c + 0x90) = 0;
+    *(u16 *)((char *)&data_020a6134 + 2) = 0x10;
+    *(u16 *)((char *)&data_020a6134 + 0) = 0;
+    *(u16 *)((char *)&data_020a6134 + 4) = 0;
+    *(char **)0x027fffa0 = (char *)&data_020a6134;
+
+    func_02057e48(0);
+
+    func_02058200(data_020a6188, (int)&func_02057e34, 0, (int)data_020a6378, 0xc8, 0x1f);
+
+    *(int *)(data_020a6188 + 0x70) = 0x20;
+    *(int *)(data_020a6188 + 0x64) = 1;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 999 -> 0.

Lever:
MATCHED in 3 structural steps, ~10 compiles total, zero pragmas, zero grinding. Every step came from reading the ROM literal pool, not from spelling variants.

START STATE CORRECTION: the stored draft reproduces at div=999 (size 348 vs 384), NOT the 75 recorded in nearmiss/db.jsonl - that DB number is stale for this entry. 36 bytes short = 9 missing instructions, so this was a SHAPE problem, not a coloring problem, and the entire regperm lever family handed down from group 2 was inapplicable. Classify by size drift first.

STEP 1 - THE POOL READ IDENTIFIED TWO ABSOLUTE SYMBOLS (+6 instructions, the decisive move). The ROM emits `ldrne r1,=0x023c0000 / addne r1,r1,#0x3fc0 / subne r0,r1,r0` with 0x600 sitting in a POOL WORD, even though #0x600 is a perfectly encodable ARM immediate (6 ror 24) and 0x3fc0-0x600 would fold to the encodable #0x39c0. A small constant the compiler refuses to encode, and a constant sum it refuses to fold, means SYMBOL not number. config/arm9/relocs.txt has no reloc at either pool slot (0x02058458 = 0x00000000, 0x0205846c = 0x00000600), i.e. both are absolute-valued symbols dsd never classified. The sibling hunt confirmed it: `grep -rn 023c0000 src/` hits sr

Built with Claude Code
