### PR TITLE
Match func_020676e0 byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_020676e0.c
+++ b/src/func_020676e0.c
@@ -1,0 +1,76 @@
+extern void Crash(void);
+#define LD(x) (((int)(x)) & 0xFFFFFFFFFFFFFFFFLL)
+void func_020676e0(unsigned *self, unsigned *mode_p, unsigned *out, unsigned *cursor)
+{
+    unsigned mode = *mode_p;
+    unsigned *p;
+    unsigned addr, size, end;
+    unsigned bad, special;
+    unsigned *f;
+
+    if (mode == 0) goto case0;
+    if (mode == 1) goto case1;
+    if (mode == 2) goto case2;
+    return;
+
+case0:
+    p = (unsigned *)LD((int)self + 0x28);
+    addr = *p;
+    if (addr < 0x2000000u) goto crash0;
+    if (addr >= 0x22c0000u) goto crash0;
+    size = p[1];
+    if (addr + size > 0x22c0000u) goto crash0;
+    out[2] = size;
+    out[1] = *p;
+    f = (unsigned *)LD((int)out + 0xc);
+    out[0] = out[1];
+    *f = *f & ~1u;
+    return;
+crash0:
+    Crash();
+    return;
+
+case1:
+    p = (unsigned *)LD((int)self + 0x38);
+    addr = *p;
+    size = p[1];
+    bad = 0;
+    special = bad;
+    {
+        unsigned e = addr + size;
+        end = e;
+    }
+    if (addr < 0x2000000u) goto region2;
+    if (addr >= 0x23fe800u) goto region2;
+    if (end <= 0x2300000u) goto check_bad;
+    if (end >= 0x23fe800u) goto set_bad;
+    if (size <= 0x40000u) { special = 1; goto check_bad; }
+set_bad:
+    bad = 1;
+    goto check_bad;
+region2:
+    if (addr < 0x37f8000u) goto set_bad2;
+    if (addr >= 0x380f000u) goto set_bad2;
+    if (end <= 0x380f000u) { special = 1; goto check_bad; }
+    bad = 1;
+    goto check_bad;
+set_bad2:
+    bad = 1;
+check_bad:
+    if (bad == 1) Crash();
+    out[2] = p[1];
+    out[1] = p[0];
+    if (special == 0) out[0] = out[1];
+    else { out[0] = *cursor; *cursor = *cursor + out[2]; }
+    f = (unsigned *)LD((int)out + 0xc);
+    *f = (*f & ~1u) | 1u;
+    return;
+
+case2:
+    out[2] = 0x160;
+    out[1] = 0x027ffe00u;
+    out[0] = out[1];
+    f = (unsigned *)LD((int)out + 0xc);
+    *f = *f & ~1u;
+    return;
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 2 -> 0.

Lever:
NEW LEVER (switch-vs-goto-chain block formation): mwccarm forms a `switch` case body as a scheduling region that will not hoist a pc-relative pool load above a preceding store; the same statements under an `if (m == k) goto ck;` chain with the bodies laid out after the dispatch DO hoist it, and the dispatch bytes are identical (cmp/beq x3 then fallthrough epilogue, cases laid out after the default). Recipe: when a switch-case block's only divergence is a schedule perturbation or a coloring artifact of a construct you added to fix that perturbation, respell the switch as a goto chain before touching any allocator lever.

Method that got there: (1) reproduced stored div=2, classified both words as regperm on the SAME value (0x160 at r2 vs ROM r1) with all 452 other bytes exact; (2) instead of grinding the register, extracted case 2 into a standalone micro-function and disassembled it - it came out in the ROM's exact schedule AND (after mapping out:r0->r7) the ROM's exact register pattern with PLAIN stores and NO launder; (3) bisected micro -> full context: 1 param vs 4 params, no-branch vs if-guard, and finally switch vs if-guard, isolating `switch` as the sole perturbation; (4) conf

Built with Claude Code
