### PR TITLE
Match func_02032f9c byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_02032f9c.c
+++ b/src/func_02032f9c.c
@@ -1,0 +1,109 @@
+typedef unsigned char u8;
+typedef unsigned short u16;
+
+typedef struct {
+    int m0;
+    short m4;
+    u8 m6;
+    u8 m7;
+} StarEntry;
+
+extern short data_0209fce8;
+extern u8 data_0209fc9c;
+extern StarEntry *data_0209fd08;
+extern int data_0209fd14;
+extern int *data_0209fcf8;
+extern u8 data_0209fc94;
+extern u8 data_0209fc78;
+extern StarEntry *data_0209fd00;
+extern int data_0209fd0c;
+extern u8 data_0209fc84;
+extern u8 data_0209fc88;
+extern u8 data_0209fc7c;
+extern u8 data_0209fc90;
+extern u8 data_0209fcd8;
+extern u8 data_0209fccc;
+extern u8 data_0209fcd4;
+extern u8 data_0209fcdc;
+
+void func_02034504(void);
+int func_02054d88(void);
+void MultiStore_Int(int a, int b, int n);
+int func_02054fb0(void);
+void MultiStore16(int a, int b, int n);
+void func_02031cd4(void *arg);
+void func_02031e00(void);
+void func_020319fc(u8 a);
+
+void func_02032f9c(int a)
+{
+    volatile int li;
+    volatile unsigned short ls;
+    int idx;
+    int p, s;
+    int v;
+    int i;
+    u16 *q;
+    int v2;
+    int w, n;
+    u8 c;
+    u8 old94;
+
+    data_0209fce8 = 0x20;
+    data_0209fc9c = 0;
+    func_02034504();
+
+    idx = data_0209fce8;
+    v = data_0209fd14;
+    data_0209fc94 = 1;
+    data_0209fc78 = 0;
+    data_0209fd00 = (StarEntry *)((char *)data_0209fd08 + idx * 8);
+    data_0209fd0c = v + 0x28 + data_0209fcf8[1] + *(int *)((char *)data_0209fd08 + idx * 8);
+
+    p = func_02054d88() + 0x4000;
+    li = 0;
+    MultiStore_Int(li, p, 0x2000);
+
+    s = func_02054fb0();
+    ls = 0x2ff;
+    MultiStore16(ls, s, 0x800);
+
+    if (a < 0) {
+        return;
+    }
+
+    data_0209fc84 = (u8)a;
+    func_02031cd4(0);
+
+    w = 0x100 - data_0209fc88;
+    data_0209fc7c = (u8)((w >> 1) & 7);
+    q = (u16 *)(func_02054fb0() + 0x40) + (u16)(w / 8 >> 1);
+    c = data_0209fc7c;
+    n = (data_0209fc88 + c + 7) >> 3;
+    i = 0;
+    if (n > 0) {
+        v2 = n + 0x200;
+        do {
+            q[i] = (u16)(i + 0x200);
+            (q + i)[0x20] = (u16)v2;
+            v2++;
+            i++;
+        } while (i < n);
+    }
+
+    data_0209fc90 = 1;
+    data_0209fcd4 = 4;
+    data_0209fccc = c;
+    data_0209fcd8 = 0;
+    data_0209fc88 = 0;
+    old94 = data_0209fc94;
+    data_0209fc94 = 0;
+    func_02031e00();
+
+    data_0209fc88 = data_0209fc88 + data_0209fc7c;
+    func_020319fc((u8)((data_0209fc88 + 7) >> 3));
+
+    data_0209fc94 = old94;
+    data_0209fcd4 = 0;
+    data_0209fcdc = (u8)(((data_0209fc88 + 7) >> 3) << 1);
+}


### PR DESCRIPTION
Byte-identical at mwccarm 1.2/sp2p3 (trio MATCH), linkcheck VERIFIED, blind 0. Divergence 10 -> 0.

Lever:
MATCHED, div 10 -> 0, in two edits. Gates: t.div=0/608; match.py --trio = MATCH on 1.2/base, 1.2/sp2, 1.2/sp2p3; linkcheck verdict VERIFIED, diffs [], blind 0. Written to src/func_02032f9c.c (untracked, not committed).

LEVER 1 (killed 6 of 10 words - the entire recorded "floor"): halfword-INDEX vs byte-OFFSET spelling of the scratch-buffer address. Draft: `q = (u16 *)(func_02054fb0() + 0x40 + ((((unsigned int)(w / 8 << 15)) >> 16) << 1));`. Fix: `q = (u16 *)(func_02054fb0() + 0x40) + (u16)(w / 8 >> 1);`. Byte-identical output for the whole expression, but the two forms build different webs: the byte-offset fold makes the `<<15/>>16` truncation temp a callee-saved-class web that claims r4, which forces `w` off r4's slot onto... no, onto r4 itself, with the pool pointer demoted to r2. The index form emits the truncation into scratch r2 (ROM +0x110/+0x124) and gives the `&data_0209fc7c` pool pointer and the `ret+0x40` base the r4 slot (ROM +0x114/+0x120/+0x138), which is what pushes `w` to r5 (ROM +0x00ec/+0x00f0/+0x0100/+0x0108). This is the 6ab "equal-bytes shift-extract respell reranks webs" family, generalized: `(u16)(x >> 1)` and `((u32)(x << 15)) >> 16` compile to the same lsl#

Built with Claude Code
