### PR TITLE
Fix two functions that call the wrong symbol

### DIFF
--- a/src/_ZN14BlendModelAnimD0Ev.c
+++ b/src/_ZN14BlendModelAnimD0Ev.c
@@ -4,7 +4,7 @@
  * at +0x50 and an owned pointer at +0x6c.
  *   [this+0]    = _ZTV14BlendModelAnim                  (0x0208e94c)
  *   [this+0x50] = VTable_Animation_BlendModelAnimThunk  (0x0208e970)
- *   if (this->unk6c) operator delete(this->unk6c)  (bl 0x0203cbc0 -> _ZdlPv)
+ *   if (this->unk6c) operator delete(this->unk6c)  (bl 0x0203cbc0 -> func_0203cbc0)
  *   bl 0x0201689c = ModelAnim::~ModelAnim(this)    (D2/base)
  *   bl 0x0203cbcc = Memory::operator_delete2(this)
  *   return this;
@@ -21,7 +21,7 @@ struct BlendModelAnim {
 extern void *_ZTV14BlendModelAnim[];
 extern void *VTable_Animation_BlendModelAnimThunk[];
 
-extern void _ZdlPv(void *ptr);                          /* 0x0203cbc0 */
+extern void func_0203cbc0(void *ptr);                   /* 0x0203cbc0 */
 extern void *_ZN9ModelAnimD2Ev(struct BlendModelAnim *self); /* 0x0201689c */
 extern void _ZN6Memory16operator_delete2EPv(void *p);   /* 0x0203cbcc */
 
@@ -30,7 +30,7 @@ struct BlendModelAnim *_ZN14BlendModelAnimD0Ev(struct BlendModelAnim *self)
     self->vtable = (void **)_ZTV14BlendModelAnim;
     self->animVtable = (void **)VTable_Animation_BlendModelAnimThunk;
     if (self->unk6c)
-        _ZdlPv(self->unk6c);
+        func_0203cbc0(self->unk6c);
     _ZN9ModelAnimD2Ev(self);
     _ZN6Memory16operator_delete2EPv(self);
     return self;

--- a/src/_ZN9SolidHeap8VDestroyEv.c
+++ b/src/_ZN9SolidHeap8VDestroyEv.c
@@ -6,7 +6,7 @@ typedef unsigned int u32;
 
 struct HeapAllocator;
 
-extern void _ZN13HeapAllocator7DestroyEv(struct HeapAllocator* self);
+extern void func_0204ebb8(struct HeapAllocator* self);
 
 struct Heap {
     void* vtable;       // 0x00
@@ -22,6 +22,6 @@ struct ExpandingHeap {
 };
 
 void _ZN9SolidHeap8VDestroyEv(struct ExpandingHeap* self) {
-    _ZN13HeapAllocator7DestroyEv(self->allocator);
+    func_0204ebb8(self->allocator);
     self->allocator = 0;
 }


### PR DESCRIPTION
Both of these compile and read correctly but reference a function the ROM does not call, so their relocations do not match and neither is a true match today.

| file | calls | which is at | ROM relocation points to |
|---|---|---|---|
| `src/_ZN9SolidHeap8VDestroyEv.c` | `_ZN13HeapAllocator7DestroyEv` | `0x0204e3b4` | `0x0204ebb8` (`func_0204ebb8`), at `+0x00c` |
| `src/_ZN14BlendModelAnimD0Ev.c` | `_ZdlPv` | `0x0203cbf0` | `0x0203cbc0` (`func_0203cbc0`), at `+0x024` |

The second is the clearer slip: the file's own comment already reads
`bl 0x0203cbc0 -> _ZdlPv`. The address was right and the name attached to it
was not — `_ZdlPv` lives 0x30 bytes further on.

## Scope

One symbol per file, 5 lines total. Struct layouts, comments, naming and
structure are otherwise untouched — the analysis in both files is correct and
only the callee identity was wrong.

## Verification

With these changes both functions compile under mwccarm 1.2/sp2p3 with the
project's flags to instructions byte-identical to the ROM, and every relocation
destination resolves to the address the ROM's relocation table names.

Checked with an oracle that masks linker-written bits per relocation kind and
requires **zero** unverified destinations, so a symbol that merely fails to
resolve does not pass. Both files fail that check on `main` today
(`relocation_symbol_differs`) and pass with this change.

## How it was found

While evaluating a fine-tuned decompiler against a held-out set. The model
produced byte-matching C for both functions, which surfaced the discrepancy
against the committed sources. **The change here is the minimal correction to
the existing human source, not the model's output** — the generated versions
were byte-exact but less readable (raw offsets instead of the documented struct
layouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qRCTtb8tWJbt8g1X9RWz4