### PR TITLE
Match func_ov006_02100f7c byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/src/func_ov006_02100f7c.c
+++ b/src/func_ov006_02100f7c.c
@@ -1,34 +1,26 @@
-// NONMATCHING: different op / idiom (div=32). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-typedef unsigned short u16;
-typedef unsigned char u8;
+#pragma opt_common_subs off
 
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 
 void func_ov006_02100f7c(char *c, int i)
 {
-    int off = i * 0x40;
-    int A, B;
-
-    *(int *)(c + 0x5264 + off) = *(int *)(c + 0x5264 + off) + *(int *)(c + 0x526c + off);
-    A = *(int *)(c + 0x5264 + off);
-    B = *(int *)(c + 0x526c + off);
-    if (B <= 0x4000)
-        *(int *)(c + 0x526c + off) = *(int *)(c + 0x526c + off) + 0x200;
-    if ((A >> 0xc) < 0xa0)
+    int d;
+    *(int *)(c + 0x5264 + (i << 6)) += *(int *)(c + 0x5000 + (i << 6) + 0x26c);
+    d = *(int *)(c + 0x5000 + (i << 6) + 0x264) >> 12;
+    if (*(int *)(c + 0x5000 + (i << 6) + 0x26c) <= 0x4000)
+        *(int *)(c + 0x526c + (i << 6)) += 0x200;
+    if (d < 0xa0)
         return;
-
-    *(int *)(c + 0x5264 + off) = 0xa0000;
-    *(u8 *)(c + 0x5296 + off) = 0xa;
-    *(int *)(c + 0x526c + off) = 0;
-    *(u16 *)(c + 0x5292 + off) = 0x40;
-    if ((((unsigned int)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) << 1 >> 0xf) {
-        *(int *)(c + 0x5268 + off) = 0x1000;
-        *(u8 *)(c + 0x529a + off) = 0;
+    *(int *)(c + 0x5000 + (i << 6) + 0x264) = 0xa0000;
+    *(unsigned char *)(c + 0x5000 + (i << 6) + 0x296) = 0xa;
+    *(int *)(c + 0x5000 + (i << 6) + 0x26c) = 0;
+    *(unsigned short *)(c + 0x5200 + (i << 6) + 0x92) = 0x40;
+    if ((((((unsigned int)RandomIntInternal(&data_0209d4b8)) >> 16) & 0x7fff) << 1) >> 15) {
+        *(int *)(c + 0x5000 + (i << 6) + 0x268) = 0x1000;
+        *(unsigned char *)(c + 0x5000 + (i << 6) + 0x29a) = 0;
     } else {
-        *(int *)(c + 0x5268 + off) = -0x1000;
-        *(u8 *)(c + 0x529a + off) = 1;
+        *(int *)(c + 0x5000 + (i << 6) + 0x268) = -0x1000;
+        *(unsigned char *)(c + 0x5000 + (i << 6) + 0x29a) = 1;
     }
 }


### PR DESCRIPTION
Matches func_ov006_02100f7c (ov006, 0x02100f7c, size 0x10c) byte-for-byte at mwccarm 1.2/sp2p3, verified with the oracle.

Upgrades the prior // NONMATCHING draft (div=32) to a real match. The lever was splitting the base offset as 0x5000 + (i << 6) + field and using #pragma opt_common_subs off so the compiler reproduces the ROM's reloads of the 0x26c field. src-only.