### PR TITLE
tools: let the version sweep reach the recovered 2004 build 0056

### DIFF
--- a/tools/reverify_corpus.py
+++ b/tools/reverify_corpus.py
@@ -26,7 +26,15 @@ import swarm as S
 SRC = REPO / "src"
 AUTO = REPO / "match" / "auto"
 ALL_VERSIONS = ["1.2/sp2p3", "1.2/base", "1.2/sp2", "1.2/sp3", "1.2/sp4",
-                "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
+                "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3",
+                # Last on purpose. The sweep returns the FIRST version that reproduces,
+                # so 1.2/sp2p3 stays authoritative and nothing that passes today changes
+                # verdict. b56 is only reached for the pre-2005 codegen no later build can
+                # emit: the materialized member RMW and the PTMF wrapper frames (notes
+                # 6ai). It is not a strict superset of 1.2 -- func_ov004_020adc1c matches
+                # under sp2p3 and not under b56 -- which is exactly why it goes last
+                # rather than replacing anything.
+                "2004/b56"]
 
 _modcache = {}        # module name -> dict
 _bincache = {}        # module name -> full bytes


### PR DESCRIPTION
Unblocks #770, #771 and #773.

The PR validator reproduces each changed file by sweeping `ALL_VERSIONS` and taking the
first version that matches. A file only the 2004 compiler can emit therefore comes back
NO-REPRO no matter how correct it is. Two are already in open PRs:

| file | 1.2/base | 1.2/sp2 | 1.2/sp2p3 | 2004/b56 |
|---|---|---|---|---|
| `src/func_ov006_020f0bf0.c` | differs | differs | differs | **MATCH** |
| `src/func_ov002_020dec70.c` | differs | differs | differs | **MATCH** |

`2004/b56` goes **last**. The sweep short-circuits on the first hit, so `1.2/sp2p3`
stays authoritative and nothing that passes today can change verdict. b56 is reached
only for the pre-2005 codegen no later build emits.

Deliberately an addition rather than a replacement: b56 is not a superset of 1.2.
`func_ov004_020adc1c` reproduces under sp2p3 and not under b56, so ordering matters and
swapping the pin would regress about 1% of the corpus.

The compiler binary is not committed. `tools/mwccarm` stays gitignored and the build box
obtains it with `tools/recover_cw2004.py`, which is already installed and verified there.