### PR TITLE
CI: install pyelftools + capstone for the chaos-data refresh

### DIFF
--- a/.github/workflows/update-chaos-data.yml
+++ b/.github/workflows/update-chaos-data.yml
@@ -42,6 +42,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install tool dependencies
+        # tools/nearmiss_db.py imports match.py/swarm.py at module level, which need
+        # pyelftools + capstone; without them the dedupe step kills the whole run
+        # before the refresh commit (which is what keeps contributions.json moving).
+        run: pip install pyelftools capstone
       - name: Regenerate chaos-db.json + contributions.json
         run: python tools/chaos_db_ci.py --out _chaos_data/chaos-db.json --contrib-out contributions.json
       - name: Push if changed


### PR DESCRIPTION
update-chaos-data has failed on every push since 07-27: tools/nearmiss_db.py now imports match.py/swarm.py at module level (auto-merge change c95565c5), which need pyelftools + capstone, and the runner installs no pip packages. The run dies at the dedupe step before the refresh commit, so contributions.json (and everything downstream, including the match-coin milestone feed) froze at 2026-07-26 15:19.

One workflow step: pip install the two packages after setup-python. No tool changes.