### PR TITLE
Match 2 functions byte-identical (mwccarm 2004/b56)

### DIFF
--- a/src/func_ov002_020dec70.c
+++ b/src/func_ov002_020dec70.c
@@ -1,0 +1,46 @@
+//cpp
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+
+struct Vector3_16f { s16 x, y, z; };
+struct Vector3 { int x, y, z; };
+
+extern "C" {
+void func_ov002_020bf800(char *c, Vector3_16f v);
+u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, Vector3 *v, u32 d);
+int _ZN6Player7IsStateERNS_5StateE(char *c, void *st);
+int func_ov002_020e0478(void *c);
+void _ZN6Player11ChangeStateERNS_5StateE(char *c, void *st);
+}
+extern char data_ov002_02110274;
+extern char data_ov002_021102d4;
+extern char data_ov002_02110244;
+
+extern "C" int func_ov002_020dec70(char *c)
+{
+    int t = *(int *)(c + 0x60) + 0x514000;
+    if (t < (int)0xfdecc000) return 0;
+    {
+        Vector3_16f v;
+        v.z = 0;
+        v.y = 0x1000;
+        v.x = v.z;
+        func_ov002_020bf800(c, v);
+    }
+    *(u32 *)(c + 0x624) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(u32 *)(c + 0x624), 3, 0x90, (Vector3 *)(c + 0x74), 0);
+    if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110274)
+        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)
+        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110244)
+        || *(u8 *)(c + 0x6f9)
+        || *(u8 *)(c + 0x703)
+        || *(u8 *)(c + 0x709)
+        || *(u8 *)(c + 0x6de) == 0) return 0;
+    if (func_ov002_020e0478(c) != 0 || *(u8 *)(c + 0x6fd) != 0) {
+        if (t < 0x898000) *(int *)(c + 0x60) += 0x8000;
+        return 0;
+    }
+    _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_02110274);
+    return 1;
+}

--- a/src/func_ov006_020f0bf0.c
+++ b/src/func_ov006_020f0bf0.c
@@ -1,0 +1,48 @@
+extern unsigned char data_0209d460;
+extern int data_ov006_0212e850[];
+
+void func_ov006_020f0bf0(char* c, int i) {
+    unsigned short t;
+    int x;
+    int v;
+
+    t = *(unsigned short*)(c + 0x47b0 + i * 0x18);
+    if (t != 0) {
+        *(short*)(c + 0x47b0 + i * 0x18) = t - 1;
+        if (*(short*)(c + 0x47b0 + i * 0x18) < 0)
+            *(short*)(c + 0x47b0 + i * 0x18) = 0;
+        return;
+    }
+
+    x = *(unsigned short*)0x400004a;
+    x &= ~0x3f00;
+    x |= 0x1800;
+    x &= ~0x2000;
+    x |= 0x2000;
+    *(unsigned short*)0x400004a = x;
+    x = (*(unsigned short*)0x400004a & ~0x3f) | 0x14;
+    *(unsigned short*)0x400004a = x;
+    *(volatile int*)0x4000000 = (*(volatile int*)0x4000000 & ~0xe000) | 0x8000;
+    data_0209d460 = 4;
+
+    *(int*)(c + 0x47a0 + i * 0x18) = data_ov006_0212e850[i] << 12;
+    *(int*)(c + 0x47a4 + i * 0x18) = 0x60000;
+    *(char*)(c + 0x47b5 + i * 0x18) = 1;
+    *(char*)(c + 0x47b6 + i * 0x18) = 1;
+    if (i != 0)
+        *(int*)(c + 0x47a8 + i * 0x18) = -0x8000;
+    else
+        *(int*)(c + 0x47a8 + i * 0x18) = 0x8000;
+
+    v = *(int*)(c + 0xbc);
+    while (v >= 5)
+        v -= 5;
+    if (v != 0) {
+        *(char*)(c + 0x47b6 + i * 0x18) = 2;
+        if (i != 0)
+            *(int*)(c + 0x47a8 + i * 0x18) = -0x7000;
+        else
+            *(int*)(c + 0x47a8 + i * 0x18) = 0x7000;
+    }
+    *(int*)(c + 0x47ac + i * 0x18) = 0;
+}


### PR DESCRIPTION
Recovers two verified matches that were dropped rather than landed.

Both were in the 2026-07-27 overlay stack. `match/2026-07-27b` was later force-pushed
without them, so #770 merged as 31 functions under 1.2/sp2p3 and these two were left
behind on the downstream branches. Neither is on main.

| function | module | size | reproduces under |
|---|---|---|---|
| `func_ov006_020f0bf0` | ov006 | 0x168 | **2004/b56** only |
| `func_ov002_020dec70` | ov002 | 0x180 | **2004/b56** only |

1.2/base, 1.2/sp2 and 1.2/sp2p3 all differ on each. These are the first two matches in
the tree that need the recovered 2004 compiler, and the validator can check them now
that #776 put `2004/b56` at the end of the version sweep.

Ledger rows (`config/match_attempts.jsonl`, `config/match_provenance.jsonl`) are not
included here since their originals went with the force-push; worth a follow-up if the
bookkeeping matters.