### PR TITLE
tools: include 2004/b56 in match.py --all sweeps

### DIFF
--- a/tools/match.py
+++ b/tools/match.py
@@ -30,7 +30,11 @@ ARM9_BASE = 0x02004000
 
 DEFAULT_FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
 SWEEP = ["1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
-         "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3"]
+         "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3",
+         # The recovered 2004 build 0056 (see #776 / notes 6ai): a handful of ROM
+         # functions only reproduce under it, so a floor certified without it is
+         # incomplete. Last so the trio still wins ties.
+         "2004/b56"]
 # The CodeWarrior 1.2 trio that survived version-pinning.
 PINNED = ["1.2/base", "1.2/sp2", "1.2/sp2p3"]
 # Proven (45 probe constructs + 60 ROM functions) byte-identical across the trio,

--- a/tools/match.py
+++ b/tools/match.py
@@ -31,9 +31,7 @@ ARM9_BASE = 0x02004000
 DEFAULT_FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
 SWEEP = ["1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
          "2.0/base", "2.0/sp1", "2.0/sp1p2", "2.0/sp2", "2.0/sp2p2", "2.0/sp2p3",
-         # The recovered 2004 build 0056 (see #776 / notes 6ai): a handful of ROM
-         # functions only reproduce under it, so a floor certified without it is
-         # incomplete. Last so the trio still wins ties.
+         # The recovered 2004 build 0056 (see #776 / notes 6ai):
          "2004/b56"]
 # The CodeWarrior 1.2 trio that survived version-pinning.
 PINNED = ["1.2/base", "1.2/sp2", "1.2/sp2p3"]


### PR DESCRIPTION
Follow-up to #776, which taught `reverify_corpus.py` to reach the recovered 2004 build 0056 — but `tools/match.py` (the oracle agents use while matching) still stopped at 2.0, so `--all` silently skipped b56.

Why it matters: floors certified via `--all` without b56 are incomplete. The 2026-07-28 re-attempt on `_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii` found exactly this gap — its 2026-07-26 floor certification never ran b56 (it happens to give the identical residual there, but that was luck, not coverage).

b56 is appended last so the pinned 1.2 trio still wins ties. `--trio` and the canonical single-compile default are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTYgAg4fLSk5YiKy7imswZ