### PR TITLE
Match func_0206de14 byte-identical (mwccarm 2004/b56)

### DIFF
--- a/src/func_0206de14.c
+++ b/src/func_0206de14.c
@@ -1,0 +1,63 @@
+/* Dispatches to one of five handlers selected by bits 26-30 of flags, then
+ * forwards its own arguments unchanged.
+ *
+ * The two 8-byte struct parameters are load-bearing, not cosmetic. p2 straddles
+ * the r3/stack boundary, so the forwarded call has to stage it contiguously
+ * across that edge: the ROM writes the pair to [sp-4] and [sp], then reads the
+ * register half back with `ldm r2, {r3}`. Modelling the arguments as five ints
+ * read through &a0 produces plain per-slot loads instead and is 12 bytes short.
+ *
+ * Needs mwccarm 2004/b56. Every 1.2 and 2.0 build brackets that below-sp staging
+ * with `mov sp, r2` / `add sp, r2, #4` and takes a frame pointer to do it, which
+ * is the same pre-2005 codegen difference recorded in notes/mwccarm-codegen.md
+ * 6ai for the ActorBase::Process wrappers.
+ */
+typedef struct { int x, y; } Pair;
+
+extern int func_02073238(void);
+extern int func_01ffb008(int a, int b);
+extern void func_0207037c(int idx);
+
+typedef void (*DispatchFn)(int a0, Pair p1, Pair p2, unsigned int flags);
+
+void func_0206de14(int a0, Pair p1, Pair p2, unsigned int flags)
+{
+  DispatchFn fn = (DispatchFn) func_02073238();
+  if ((flags & 0xc00000) == 0)
+  {
+    flags |= func_01ffb008(0, 0) & 0xc00000;
+  }
+  switch (flags & 0x7c000000)
+  {
+    case 0x40000000:
+      fn = *((DispatchFn *) (((char *) fn) + 0x14));
+      break;
+
+    case 0x04000000:
+      fn = *((DispatchFn *) (((char *) fn) + 4));
+      break;
+
+    case 0x10000000:
+      fn = *((DispatchFn *) (((char *) fn) + 0xc));
+      break;
+
+    case 0x20000000:
+      fn = *((DispatchFn *) (((char *) fn) + 0x10));
+      break;
+
+    case 0x08000000:
+      fn = *((DispatchFn *) (((char *) fn) + 8));
+      break;
+
+    default:
+      fn = 0;
+      break;
+
+  }
+
+  if (fn == 0)
+  {
+    func_0207037c(2);
+  }
+  fn(a0, p1, p2, flags);
+}


### PR DESCRIPTION
arm9 `0x0206de14`, 0x100 bytes. `linkcheck` VERIFIED, zero blind slots. Gate reports `MATCHING VERSIONS: 2004/b56`.

The stored near-miss draft was not stale, it was the wrong shape. It modelled the function as five ints forwarded through `&a0`, which compiles 12 bytes short of the ROM. The tail gives the real signature away:

```
str r6, [sp, #4]        ldr r1, [sp, #0x24]     ldr r0, [sp, #0x28]
sub r2, sp, #4          str r1, [r2]            str r0, [r2, #4]
add r1, sp, #0x1c       ldm r2, {r3}            mov r0, r4
ldm r1, {r1, r2}        blx r5
```

`ldm r1, {r1, r2}` loads a pair into r1/r2, and the `sub r2, sp, #4` / str / str / `ldm r2, {r3}` sequence stages a second pair across the r3-to-stack boundary. Those are struct-by-value argument copies, so the function takes two 8-byte structs:

```c
void func_0206de14(int a0, Pair p1, Pair p2, unsigned int flags)
```

With that signature the whole tail reproduces in order. Under 1.2/sp2p3 the result is 264 against 256, and the entire excess is the frame pointer plus `mov sp, r2` / `add sp, r2, #4` that every 1.2 and 2.0 build wraps around the below-sp staging. Build 0056 emits it directly, which is the same pre-2005 difference notes 6ai records for the ActorBase::Process wrappers.

### Two corrections to notes/arm9-endgame.md

Left for a follow-up so this PR stays one file:

- **"2004/b56 is 0/22 here, so that sweep should not be repeated"** was measured against this wrong-shape draft, so it never tested the real one. At least one of the 22 does fall to b56.
- **"a permuter pass agreed"** on the floored group: re-running the permuter on `func_020316d8` with a proper budget moved it from 28 to 25 divergences. The recorded pass was budget-limited, not conclusive.

### CI

`validate` will stay red until the build box installs 2004/b56 (`tools/recover_cw2004.py`), same as #783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hw3nmhEaQ9vEfnixivVX1y