### PR TITLE
Tag the arm9 files that need no match, so the atlas can paint them apart

### DIFF
--- a/src/func_0200497c.c
+++ b/src/func_0200497c.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
 // Segment/autoload initializer: reads a {dest, end, source} table from a pooled base,
 // block-copies words then bzeroes ranges, and chains to the next init routine by falling

--- a/src/func_02052514.c
+++ b/src/func_02052514.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive: block copy,
 // CP15, IRQ/CPSR, svc, matrix/math, context-switch). No C to decompile to. Per asm policy.
 asm void func_02052514(void *dst, void *src) {

--- a/src/func_0205256c.c
+++ b/src/func_0205256c.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_020527e8.c
+++ b/src/func_020527e8.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_02052800.c
+++ b/src/func_02052800.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_02052820.c
+++ b/src/func_02052820.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_0205283c.c
+++ b/src/func_0205283c.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_02052ec8.c
+++ b/src/func_02052ec8.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_020553c0.c
+++ b/src/func_020553c0.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
 // Bulk hardware-FIFO/command-port write: pushes 4 zeroed registers via 32 identical
 // no-writeback stmia to the fixed address in r0 (a FIFO port, not memory). No C compiler

--- a/src/func_02057014.c
+++ b/src/func_02057014.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. Veneer that tail-calls
 // func_02057178 through r1 (compiled C always uses ip for tail-call veneers,
 // so this register choice marks hand-written assembly).

--- a/src/func_02057020.c
+++ b/src/func_02057020.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
 asm int func_02057020(void) {
     ldr r3, =0x027fffb0

--- a/src/func_02057078.c
+++ b/src/func_02057078.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
 // NitroSDK OS_ReleaseLockID sibling of func_02057020 (OS_GetLockID) - SDK ships these as asm functions.
 asm void func_02057078(int lockID) {

--- a/src/func_02058568.c
+++ b/src/func_02058568.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
 // OS_InitContext-style SDK primitive: stores entry pc+4 and the two stack pointers
 // (sp_svc at +0x44, sp = sp_svc - 0x40 at +0x38), derives the initial CPSR from the

--- a/src/func_02059468.c
+++ b/src/func_02059468.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_02059824.c
+++ b/src/func_02059824.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_02059d98.c
+++ b/src/func_02059d98.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive: block copy,
 // CP15, IRQ/CPSR, svc, matrix/math, context-switch). No C to decompile to. Per asm policy.
 asm void func_02059d98(void *p, unsigned int n) {

--- a/src/func_0205a588.c
+++ b/src/func_0205a588.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
 // SDK byte-fill (memset): aligns to halfword then word with read-modify-write at the
 // unaligned head/tail (ldrh; and #0xff00; orr; strh to preserve the adjacent byte),

--- a/src/func_0205a61c.c
+++ b/src/func_0205a61c.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
 // SDK unaligned block copy - the memcpy twin of func_0205a588's byte-fill (they sit
 // adjacent in the ROM). Aligns dst to a halfword with an edge-preserving read-modify-write

--- a/src/func_0206a928.c
+++ b/src/func_0206a928.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL debug printf / format
 // core (same family as pret MSL_Common_printf). Soft-double helpers of this
 // cluster matched as C; this 0x1360 DFA stays asm — stack-home wall under C.

--- a/src/func_0206e330.c
+++ b/src/func_0206e330.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only runtime primitive).
 // SDK byte-fill (memset): replicates the fill byte across a word and runs an alignment
 // ladder (strb head to word-align, str-writeback word loop, strb tail). The hand-tuned

--- a/src/func_02071790.c
+++ b/src/func_02071790.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. This function was assembly
 // in the original (SDK/runtime primitive: block copy, matrix/math, CP15, context
 // switch, etc.), so there is no C to decompile it to -- the asm block is the

--- a/src/func_020717c0.c
+++ b/src/func_020717c0.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
 extern void func_02071be8(void);
 

--- a/src/func_020729e8.c
+++ b/src/func_020729e8.c
@@ -1,4 +1,4 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (NOT-C-EXPRESSIBLE): byte-exact hand-written asm. A bare epilogue / mid-frame
+// exit stub the symbol table split out, not a real function - no standalone C construct
+// produces it. Nothing here to match - see notes/arm9-endgame.md.
 asm void func_020729e8(void) { add sp, sp, #0xac; ldmia sp!, {r4, r5, r6, r7, r8, r9, r10, r11, lr}; bx lr }

--- a/src/func_0207328c.c
+++ b/src/func_0207328c.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL C++ runtime array
 // destroy helper (dtor applied to elements in reverse) with an exception-frame
 // (fp anchor + sp spill at [fp,#0x14]) that no C under our flags reproduces;

--- a/src/func_020732e8.c
+++ b/src/func_020732e8.c
@@ -1,8 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive: block copy,
-// CP15, IRQ/CPSR, svc, matrix/math, context-switch). No C to decompile to. Per asm policy.
+// NONMATCHING (NOT-C-EXPRESSIBLE): byte-exact hand-written asm. A bare epilogue / mid-frame
+// exit stub the symbol table split out, not a real function - no standalone C construct
+// produces it. Nothing here to match - see notes/arm9-endgame.md.
 void func_020731fc(void);
 void func_02071ba0(void);
 

--- a/src/func_02073300.c
+++ b/src/func_02073300.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL C++ runtime array
 // destroy helper (reverse dtor loop, 0x30-byte exception frame with sp spill
 // at [fp,#0x14]); its out-of-line landing pad is the already-matched

--- a/src/func_0207335c.c
+++ b/src/func_0207335c.c
@@ -1,7 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive). Per asm policy.
+// NONMATCHING (NOT-C-EXPRESSIBLE): byte-exact hand-written asm. A bare epilogue / mid-frame
+// exit stub the symbol table split out, not a real function - no standalone C construct
+// produces it. Nothing here to match - see notes/arm9-endgame.md.
 extern void func_020731fc(void);
 extern void func_02071ba0(void);
 extern void func_020717c0(void);

--- a/src/func_020733a8.c
+++ b/src/func_020733a8.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL C++ runtime array
 // construction (ctor applied forward across n elements) with an exception
 // frame (fp anchor + sp spill at [fp,#0x14]) and a landing pad that calls the

--- a/src/func_02073470.c
+++ b/src/func_02073470.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL C++ runtime array
 // construct-with-cleanup: allocates count*size+cookie, writes the array cookie,
 // constructs each element via an indirect ctor, with an exception landing pad at

--- a/src/func_02073534.c
+++ b/src/func_02073534.c
@@ -1,6 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (ASM-PRIMITIVE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/arm9-endgame.md.
 // HAND-ASM PRIMITIVE: byte-faithful asm-block match. MSL C++ runtime partial
 // array destroy (dtor applied downward from 'current' back to 'base') with an
 // exception frame (fp anchor + sp spill at [fp,#0x14]) that no C under our

--- a/src/func_02073584.c
+++ b/src/func_02073584.c
@@ -1,8 +1,6 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
-// HAND-ASM PRIMITIVE: byte-faithful asm-block match (assembly-only primitive: block copy,
-// CP15, IRQ/CPSR, svc, matrix/math, context-switch). No C to decompile to. Per asm policy.
+// NONMATCHING (NOT-C-EXPRESSIBLE): byte-exact hand-written asm. A bare epilogue / mid-frame
+// exit stub the symbol table split out, not a real function - no standalone C construct
+// produces it. Nothing here to match - see notes/arm9-endgame.md.
 void func_020731fc(void);
 void func_02071ba0(void);
 

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -34,6 +34,32 @@ FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
 LOGIN_RE = re.compile(r"^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$")
 
+# A NONMATCHING file that reproduces the ROM and has no match left to chase - the banner
+# tags which kind. These are NOT pending work, so the viewers paint them apart from real
+# near-miss drafts instead of lumping everything unmatched together.
+NOMATCH_RE = re.compile(r"NONMATCHING \((ASM-PRIMITIVE|NOT-C-EXPRESSIBLE)\)")
+NOMATCH_REASONS = {
+    "ASM-PRIMITIVE": (
+        "asm-primitive",
+        "Nintendo shipped this as an assembly primitive. There is no original C to "
+        "recover, so writing C for it would invent a source that never existed.",
+    ),
+    "NOT-C-EXPRESSIBLE": (
+        "not-c-expressible",
+        "A bare epilogue or mid-frame exit stub the symbol table split out, not a real "
+        "function. No standalone C construct produces it.",
+    ),
+}
+
+
+def no_match_needed(head: str) -> dict[str, str] | None:
+    """Bucket + hover explanation for a file that needs no match, else None."""
+    m = NOMATCH_RE.search(head)
+    if not m:
+        return None
+    bucket, reason = NOMATCH_REASONS[m.group(1)]
+    return {"bucket": bucket, "reason": reason}
+
 
 def module_label(sym_path: pathlib.Path) -> str | None:
     """config/arm9/symbols.txt -> arm9; config/arm9/overlays/ovNNN -> ovNNN.
@@ -281,13 +307,16 @@ def main():
                 if f.is_file():
                     src_path = f"src/{name}.{ext}"
                     break
-            matched = bool(src_path) and "NONMATCHING" not in (
-                (SRC / src_path.split("/", 1)[1]).read_text(errors="ignore")[:200] if src_path else "")
+            head = (SRC / src_path.split("/", 1)[1]).read_text(errors="ignore")[:200] if src_path else ""
+            matched = bool(src_path) and "NONMATCHING" not in head
             total_b += size
             rec = {"id": f"{label}:0x{addr:08x}", "module": label, "name": name,
                    "addr": addr, "size": size, "matched": matched}
             if src_path:
                 rec["srcPath"] = src_path
+                nomatch = no_match_needed(head)
+                if nomatch:
+                    rec["noMatch"] = nomatch
                 if matched:
                     # Priority: manual override > whoever FINISHED the match (turned the
                     # NONMATCHING draft byte-identical) > whoever first added the file.


### PR DESCRIPTION
Machine-readable half of #787. That PR is prose; this makes the same call something the viewers can render.

The 31 arm9 files triaged as "leave alone" already reproduce the ROM and carry no work, but they shared the blanket banner with real near-miss drafts:

> does NOT count as matched. Reverts to a draft until someone reproduces the bytes from real C.

So every atlas painted them the same amber as a genuine near-miss, and the set read as pending work. The banner now names the bucket:

| banner | files | bucket |
|---|---|---|
| `NONMATCHING (ASM-PRIMITIVE)` | 27 | Nintendo shipped these as assembly |
| `NONMATCHING (NOT-C-EXPRESSIBLE)` | 4 | bare epilogue + mid-frame exit stubs |

`NONMATCHING` stays the first token, so `chaos_db_ci.py`'s matched rule is untouched: **11,021 of 11,348 before and after**. The tag also lands inside the first 200 characters the rule already reads, so the backend's DraftTracker picks up the bucket on blob reads it was doing anyway.

### The marker count was off by three

#787 says bucket A is 27, but 30 files carried `HAND-ASM PRIMITIVE`. The extra three are `func_020732e8`, `func_02073584` and `func_0207335c` — they are bucket B exit stubs, not primitives. They start mid-frame using `fp` without ever establishing it, which is exactly the thing #787 describes bucket B as. `func_020729e8` carried no marker at all. Retagged all four; that reconciles 30 to 27 + 4.

### Generator

`chaos_db_ci.py` emits the bucket plus a plain-English reason as `noMatch` on the function record. That is what the viewers hover, so the explanation lives next to the code it describes rather than being duplicated in three front-ends.

Consumers: tangosdev/tangos-backend#23 (serves it live), tangosdev/tangOS#9 (renders it).