### PR TITLE
tools: emu-trace pipeline + actorcam (runtime tracing over the melonDS GDB stub)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ _glmwork/
 .agents/
 .codex/
 .cw2004work/
+
+# emu-trace runtime capture output (tools/trace) - regenerable, may contain ROM-derived memory dumps
+/traces/
+/behavior/

--- a/notes/emu-trace-build.md
+++ b/notes/emu-trace-build.md
@@ -1,0 +1,289 @@
+# Emu-trace build plan — engineering spec
+
+Companion to `notes/emu-trace-plan.md` (the *why/what*). This is the *how*:
+tech decisions, file layout, data schemas, and per-phase acceptance gates so
+each step is either provably working or provably dead before the next starts.
+
+Guiding rule from the strategy doc: **Phases 0–2 must stay at ~zero model
+credits** (local compute + Haiku-tier pennies). If any phase starts wanting
+fan-out tokens to make progress, stop and re-scope — the whole bet is that
+runtime facts are cheaper than token-brute-forcing structural guesses.
+
+---
+
+## 0. Fixed facts this build sits on (verified 2026-07-14)
+
+- ROM at repo root: `sm64.nds`.
+- `nearmiss/db.jsonl` (n=1014) records carry everything a breakpoint list needs:
+  `module` (`arm9` or `ovNNN`), `addr` (absolute hex string e.g. `"0x0211640c"`),
+  `name`, `size`, `target_hex` (full function bytes, little-endian hex),
+  `divergences`, `c_source`, `source`.
+- `addr` is the **absolute runtime address** — no overlay base math needed to set
+  a breakpoint. Overlay *residency/aliasing* is still the hazard (§4).
+- `config/arm9/config.yaml` maps `ovNNN` ⇄ overlay `id`. Load addresses aren't in
+  the snippet we need (addr is absolute), but overlay id is there if we later want
+  residency polling.
+- Existing loop we plug into: `crackloop.py prep|land`, `tools/sched_run.js`,
+  `tools/refine_run.js`. Annotations must land as a block those prompts can inject.
+
+---
+
+## 1. Tech-stack decision (make these before writing code)
+
+| Decision | Recommendation | Rationale / fallback |
+|---|---|---|
+| Emulator | **melonDS** (Qt frontend, GDB stub, `JIT_Enable=0`) | Accuracy for trace fidelity. DeSmuME `--arm9gdb=<port>` is the fallback and keeps Lua input-automation if savestate cycling gets painful. |
+| Stub transport | **Direct RSP over TCP socket** (our own tiny client) | No `gdb-multiarch` dependency (painful on Windows). RSP is a small protocol: `$<payload>#<cksum>`, ack `+`. Commands we need: `Z0`/`z0`, `g`, `p`, `m`, `c`, `?`, `D`. `pygdbmi`+gdb is the fallback if stub quirks fight us. |
+| Language | Python 3 (matches all existing `tools/*.py`) | Reuse `ledger.py`, `nearmiss_db.py`, config parsing. |
+| Phase-4 replay engine | **Unicorn (ARM)** running mwccarm-compiled draft | Deferred; only if spot-checks show drafts fail replay often enough to be worth a gate. |
+
+**melonDS config to set once** (document exact keys in `tools/trace/README.md`
+during Phase 0 — they vary slightly by version):
+`GdbEnabled=1`, `GdbPortARM9=3333`, `GdbPortARM7=3334`, `JIT_Enable=0`.
+JIT off is non-negotiable — the stub needs the interpreter core.
+
+---
+
+## 2. File layout (all new code under `tools/trace/`)
+
+```
+tools/trace/
+  README.md            # exact melonDS setup, register-packet layout, run recipes
+  rsp.py               # RSP socket client: connect, set/clear bp, read regs/mem, continue
+  gdb_harness.py       # Phase 0 spike: attach, bp at N matched funcs, dump on hit
+  bplist.py            # nearmiss/ledger -> breakpoint list (addr, canary bytes, module)
+  collect.py           # Phase 1: --wl worklist -> traces/<module>/<name>.jsonl
+  savestates/          # .mln library + coverage manifest (NOT committed if large)
+    manifest.json      # {slot, title, reaches:[modules/scenes], notes}
+  enrich.py            # Phase 2 deterministic passes (Q-format, struct histo, callgraph)
+  annotate.py          # Phase 2 model pass (Haiku/Sonnet-low) -> annotations.jsonl
+  replay.py            # Phase 4 (optional): Unicorn replay gate
+traces/                # OUTPUT, gitignored: raw + enriched trace data
+  <module>/<name>.jsonl
+  annotations.jsonl
+  coverage.jsonl       # per-func hit counts across savestates (dark-code ledger)
+```
+
+Keep `tools/trace/` self-contained; import `ledger`/`nearmiss_db` from `..`.
+
+---
+
+## 3. Data schemas (freeze these before Phase 1)
+
+### 3.1 Breakpoint list (`bplist.py` output, in-memory or `traces/bplist.json`)
+```jsonc
+{
+  "addr": 0x0211640c,          // int
+  "name": "func_ov063_0211640c",
+  "module": "ov063",
+  "size": 672,
+  "canary": "f0412de930d04de2" // first 8 bytes of target_hex, hex string
+}
+```
+Canary = `target_hex[:16]`. On every hit, read 8 bytes at `addr`; if they don't
+match `canary`, the resident overlay isn't ours — **discard the hit** (§4).
+
+### 3.2 Raw trace record (`traces/<module>/<name>.jsonl`, one line per hit)
+```jsonc
+{
+  "name": "func_ov063_0211640c",
+  "hit": 3,                    // Nth capture of this func
+  "canary_ok": true,
+  "regs": {                    // captured at ENTRY (bp on first insn)
+    "r0": 0x0210a3c4, "r1": 0x00001000, "r2": 3, "r3": 0,
+    "sp": 0x027e0f40, "lr": 0x02116210, "pc": 0x0211640c, "cpsr": 0x60000013
+  },
+  "stack": ["0x...", ...],     // first 8 words at sp
+  "args_deref": {              // for each of r0-r3 that looks like a pointer
+    "r0": { "addr": 0x0210a3c4, "bytes": "..128 bytes hex.." }
+  },
+  "caller": "func_ov063_02116210",  // symbol resolved from lr via ledger, or null
+  "overlay_set": ["ov063","ov000"], // best-effort; may be [] in Phase 1
+  "frame": 51234                    // frame counter if available, else null
+}
+```
+Pointer heuristic: value in `0x02000000–0x023fffff` (main RAM) or a known overlay
+range → deref 64–128 bytes. Cap deref count per hit to bound socket traffic.
+
+### 3.3 Return capture (optional, Phase 1.5)
+Entry bp gives args cheaply. Return values need a second bp at each `bx lr`/`pop
+{pc}` site (parse from `target_hex`), or a temporary bp on `lr` after first hit.
+**Defer** — args + input memory already constrain most structural misses. Add a
+`ret` object to the record only when the return value is the missing fact.
+
+### 3.4 Annotation block (`traces/annotations.jsonl`, Phase 2 output — the deliverable)
+```jsonc
+{
+  "name": "func_ov063_0211640c",
+  "module": "ov063",
+  "signature": "void f(Actor *self)",     // proposed
+  "arg_types": { "r0": "Actor* (this)" },
+  "field_types": [                          // struct-offset -> inferred type
+    { "off": 0x5c, "type": "Fix12 x", "evidence": "≡0 mod 4096, 3 hits" }
+  ],
+  "sem_name": "Actor_UpdateShadowMatrix",   // proposed real name (coordinate w/ Tango)
+  "behavior": "2-line summary from trace+asm",
+  "callers": ["func_ov063_02116210"],
+  "callees": ["Vec3_Asr","Matrix4x3_FromTranslation", ...],
+  "confidence": "high|med|low",
+  "evidence_hits": 3
+}
+```
+This is exactly the block Phase 3 injects into refine/fanout prompts, and the raw
+material for the labeling tier.
+
+---
+
+## 4. The three hazards, with concrete mitigations
+
+1. **Overlay residency / address aliasing.** A bp at `0x0211xxxx` is meaningless
+   when ov063 isn't loaded, and another overlay can map the same address.
+   - *Mitigation A (always):* canary check on every hit (§3.1). Cheap, catches
+     aliasing.
+   - *Mitigation B (Phase 1):* pick savestates where the target overlay is
+     resident (manifest `reaches`). Group the worklist by overlay so one run =
+     one overlay-consistent savestate.
+   - *Mitigation C (if needed):* melonDS sw breakpoints patch RAM; an overlay
+     reload overwrites the patch. Re-arm all bps on a timer or after detecting an
+     overlay swap. Only build this if Phase 1 shows lost breakpoints.
+
+2. **Throughput.** Each hit = `g` + several `m` round-trips on localhost. Kill
+   criterion (from strategy doc): <5 hits/sec with bps set → pivot to a small
+   melonDS fork with an in-process addr-set logger. Mitigate first by: capping
+   deref regions per hit, batching mem reads, and **never** bp-ing hot per-frame
+   funcs (we target the div≥26 tail, mostly not hot).
+
+3. **Savestate cycling / coverage.** melonDS has no Lua; DeSmuME does.
+   - Phase 0/1: **manual** savestate capture into `savestates/`, harness just
+     loads-and-collects. Good enough to prove value. Whatever the savestate
+     doesn't reach stays dark and gets logged in `coverage.jsonl` — never
+     silently missed.
+   - If coverage stalls, either (a) hand-record more savestates at the dark
+     scenes, or (b) switch that leg to DeSmuME + Lua input scripts.
+
+---
+
+## 5. Phase 0 spike — concrete checklist (½ day, zero tokens)
+
+Goal: prove attach + breakpoint + canary + register/mem dump end-to-end on
+**known-matched** functions (ground truth we can sanity-check against).
+
+1. `tools/trace/rsp.py`: TCP client. Methods: `connect(port)`, `send(pkt)` with
+   `$…#cksum` framing + `+`/`-` ack, `read_regs()`, `read_mem(addr,len)`,
+   `set_bp(addr)`, `clear_bp(addr)`, `cont()`, `wait_stop()`.
+2. `tools/trace/gdb_harness.py`: load ROM+savestate manually in melonDS, run
+   harness → attach, set bps at **2–3 matched funcs** whose overlay is resident,
+   continue, on stop dump regs+8 stack words + canary.
+3. Validate against ground truth:
+   - **Register-packet layout** — confirm the `g` packet byte-order maps to
+     r0…r15,cpsr as expected (classic stub gotcha; document the real layout in
+     README).
+   - **Canary** — printed 8 bytes == `target_hex[:16]` for the resident func;
+     force a miss (bp an address whose overlay is swapped out) and confirm the
+     canary rejects it.
+   - **pc == addr** on entry.
+4. **Throughput probe**: bp a moderately-frequent matched func, count hits/sec.
+
+**Acceptance gate:** canary works both directions, register layout documented,
+≥5 hits/sec. **Kill gate:** <5 hits/sec after mitigations → write the fork-logger
+spike ticket instead and stop here.
+
+---
+
+## 6. Phase 1 — collector (1–2 days, zero tokens)
+
+- `bplist.py`: read a worklist (names) → join nearmiss/ledger → bp list grouped
+  by module/overlay. Sort worklist so one run covers one overlay-consistent
+  savestate.
+- `collect.py --wl <worklist> [--hits N] [--savestate slot]`: arm ≤50–100 bps,
+  run, on each hit capture the §3.2 record (entry regs, stack, pointer derefs,
+  caller-from-lr via `ledger`), write `traces/<module>/<name>.jsonl`, bump
+  `coverage.jsonl`. Stop a func after N hits (default 3–5) to keep files small
+  and move the socket on.
+- First real target set: **top-100 div≥26 nearmisses** (the high-value tail).
+
+**Acceptance gate:** ≥60% of the top-100 produce ≥1 canary-clean hit from the
+savestate library; the rest logged as dark in `coverage.jsonl` (not silently
+dropped). If canary-clean hit-rate is low, the problem is coverage (more
+savestates) not the harness.
+
+---
+
+## 7. Phase 2 — enrichment (scripts first, then Haiku-tier)
+
+- `enrich.py` — **deterministic, zero model**:
+  - Q-format detector: arg/field values ≡ 0 mod 4096 and in plausible Fix12 range
+    → tag `Fix12`; flag 0x1000-scaled values near sin/cos table ranges.
+  - Struct-offset histogram: across hits, which offsets in a deref'd `this` are
+    read/written, and their value shape (ptr / small-int / Fix12 / angle s16).
+  - Callgraph edges: `lr`→caller and disasm-extracted `bl` targets → callee list.
+  - `this`-pointer / arg-count detection: is r0 always a stable pointer? do r1–r3
+    vary or stay 0 (unused)?
+- `annotate.py` — **cheap model pass** (Haiku or Sonnet-low, ~1–3K tok/func):
+  feed `{asm/target_hex, c_source draft, enrich.py facts}` → emit the §3.4
+  annotation. Batch through the same infra as the loop but at the cheap tier.
+- **Hand-eyeball 10 annotations** before trusting the batch (strategy step 3).
+
+**Acceptance gate:** on the 10 hand-checked, deterministic facts are correct
+(Q-format/field types match what we know) and ≥50% of proposed signatures are
+plausibly better than the current draft's guessed types.
+
+---
+
+## 8. Phase 3 — route into the loop + the A/B that decides everything
+
+The whole plan lives or dies on one measurement. Run it deliberately:
+
+- Pick **one overlay/band** with enough div≥26 nearmisses for two comparable
+  batches (≈10–15 funcs each), matched on divergence distribution.
+- **Batch A (control):** current `refine_run.js` / `--high-div` prompt, no
+  annotations.
+- **Batch B (treatment):** identical, with the §3.4 annotation block injected.
+- Metric: **tok/landed** (primary) and **match count** (secondary), vs the
+  measured 16–23K tok/landed `--high-div` baseline. Also log annotation
+  confidence per func so we can see if high-confidence annotations carry the lift.
+
+**Decision:** B beats A on tok/landed by a margin that covers Phase-2 cost →
+productionize (auto-enrich the refine tier). No lift → the labeling tier (§9) is
+still a permanent win; ship that and shelve the matching bet.
+
+## 9. Labeling tier (independent, cheapest, ship regardless of the A/B)
+
+Sweep already-**matched** `func_*` symbols that have traces → propose real names +
+doc comments from callgraph + arg semantics. This is pure repo-quality gain at
+Haiku-tier cost and doesn't depend on any match-rate lift.
+**Coordinate naming conventions with Tango before any mass rename** (see
+`notes/actor-naming.md`).
+
+## 10. Phase 4 — behavioral replay gate (optional, build only if justified)
+
+Trigger to build: Phase 1/3 spot-checks show drafts *frequently* fail a
+replay of `(entry args, input memory) → retval + memory writes`. If so:
+`replay.py` compiles the draft with mwccarm (or host cc), runs under Unicorn ARM
+with the captured input memory, diffs retval + written regions against the trace.
+A draft that fails replay is semantically wrong → reject **before** spending
+fan-out/refine tokens. Second oracle, all local compute.
+
+---
+
+## 11. Sequencing & effort
+
+| Step | Effort | Tokens | Gate to pass before next |
+|---|---|---|---|
+| Phase 0 spike | ½ day | 0 | canary both-ways + regs documented + ≥5 hits/s |
+| Phase 1 collector + savestates | 1–2 days | 0 | ≥60% of top-100 div≥26 get a clean hit |
+| Phase 2 enrich + annotate | 1 day | Haiku pennies | 10 hand-checked annotations hold up |
+| Phase 3 A/B | ½ day + 2 batches | refine tokens (measured) | B beats A on tok/landed, or pivot to §9 |
+| Phase 4 replay | 1–2 days | 0 | only if drafts fail replay often in spot checks |
+
+**Critical path is Phase 0** — everything downstream is dead if the stub
+throughput or register layout doesn't come together, and that's knowable in half
+a day. Do not build Phase 1 collector code before the Phase 0 gate passes.
+
+## 12. Open decisions for the user
+
+1. **Commit scope now:** just scaffold+run Phase 0 spike, or scaffold Phases 0–2
+   skeleton up front? (Recommend: Phase 0 only — cheap kill signal.)
+2. **melonDS vs DeSmuME primary** if you already have one installed/configured.
+3. **Savestate capture** — who records the library, and which scenes to
+   prioritize (title/file-select/castle/one-of-each-course/minigame/MP lobby).

--- a/notes/emu-trace-plan.md
+++ b/notes/emu-trace-plan.md
@@ -1,0 +1,98 @@
+# Emulator-assisted matching & labeling plan (melonDS/DeSmuME runtime traces)
+
+## Premise check — what runtime data can and cannot buy
+
+The target asm is already perfect ground truth, so runtime data adds **nothing**
+to codegen-floor misses (register coloring, scheduling, value-numbering CSE).
+Per nearmiss/db.jsonl (2026-07-14, n=1014):
+
+| divergences | count | nature | emulator value |
+|---|---|---|---|
+| 1–3   | 30  | pure codegen floor | none |
+| 4–10  | 101 | mostly floor | ~none |
+| 11–25 | 219 | mixed structural | moderate |
+| 26–100| 492 | structurally wrong draft | **high** |
+| >100  | 172 | draft is a guess | **high** |
+
+**65% of the miss tail (664 funcs, plus every unmatched func with sim<0.35 and
+no draft) fails because the C *shape* is wrong** — unknown arg types, struct
+layouts, Fix12/Q-format confusion, virtual-dispatch targets, misread control
+flow. Runtime observation constrains all of those. That's the target. Secondary
+payoff: naming/labeling matched-but-`func_*` code from real call graphs and
+argument values — pure documentation win at ~zero token cost.
+
+## Tooling
+
+- **melonDS** (recommended): GDB stub in settings (JIT must be off; ARM9/ARM7 on
+  separate ports). Best accuracy. Script via `gdb-multiarch` batch mode or
+  pygdbmi — no emulator fork needed.
+- **DeSmuME** fallback: `--arm9gdb=<port>` straight from the CLI; also has Lua
+  scripting for input automation / savestate cycling.
+- We already have per-function `addr`, `module`, `size`, `target_hex` in the
+  ledger + nearmiss DB → breakpoint lists are free.
+- **Overlay gotcha**: overlay funcs (ov0xx) only exist while their overlay is
+  resident, and another overlay can map the same address. Gate every breakpoint
+  hit with a canary: read 4–8 bytes at `addr`, compare against `target_hex`
+  prefix; discard mismatched hits.
+- **Coverage gotcha**: a function only traces if gameplay reaches it. Maintain a
+  savestate library (title, file select, castle, one course of each type,
+  minigames, multiplayer lobby) and a per-func hit-count ledger so we know
+  what's still dark.
+
+## Pipeline
+
+### Phase 0 — spike (half a day, zero tokens)
+Boot ROM in melonDS with GDB stub, attach, break at 2–3 *matched* functions,
+confirm ledger addresses line up and the canary check works. Deliverable:
+`tools/trace/gdb_harness.py` (connect, set/clear bps, dump regs+mem on hit).
+Kill criterion: if stub throughput is unusable (<~5 hits/sec with bps set),
+pivot to a small melonDS fork with an in-process addr-set call logger.
+
+### Phase 1 — trace collector (1–2 days, zero tokens)
+`tools/trace/collect.py --wl <worklist>`: for each target func capture N hits:
+- entry: r0–r3, first ~8 stack words, lr (caller identity), cpsr
+- pointer-looking args (2000000–23fffff / overlay ranges): deref 64–128 bytes
+- return: r0/r1, plus re-read of arg-pointed memory to see what was written
+- context: overlay set, frame counter
+Emit `traces/<module>/<name>.jsonl`. Batch ~50–100 bps per run, cycle
+savestates, record hit coverage.
+
+### Phase 2 — cheap enrichment (scripts + Haiku-tier only)
+Deterministic passes first: Q-format detection (values ≡ 0 mod 4096 → Fix12;
+0x1000-scaled sin/cos tables), struct-offset histogram from deref'd memory,
+caller→callee edges, arg-count/`this`-pointer detection. Then a *cheap* model
+pass (Haiku/Sonnet-low, ~1–3K tok/func) turns trace+asm into a structured
+annotation: proposed signature, arg/field types, semantic name, 2-line behavior
+summary. Store as `nearmiss` DB annotations / `traces/annotations.jsonl`.
+
+### Phase 3 — route into the existing loop
+- **Refine tier**: inject the annotation block into refine_run.js prompts for
+  div≥26 targets. Measure tok/landed vs the 16–23K --high-div baseline; the bet
+  is fewer wasted structural guesses, not better permutation.
+- **Fan-out tier**: same block in sched_run.js prompts for sim<0.35 large-logic
+  bands where even Fable floors today.
+- **Labeling tier** (independent, cheapest): sweep already-matched `func_*`
+  symbols, propose real names + doc comments from call graph + arg semantics.
+  Coordinate naming conventions with Tango before mass-renaming.
+
+### Phase 4 (optional, biggest cost-saver) — behavioral diff gate
+Replay captured (args, input memory) against our *draft* C compiled for the
+host (or ARM via mwccarm + Unicorn), compare retval + memory writes to the
+trace. A draft that fails replay is semantically wrong — reject it **before**
+spending fan-out/refine tokens permuting it. This turns "compile+diff asm" from
+the only oracle into the *second* oracle, and it's all local compute.
+
+## Economics
+- Phases 0–2 are essentially free (local compute + Haiku-tier pennies) vs the
+  measured 16–23K tok/landed refine floor and 85–140K+ tok/landed fan-outs.
+- Success metric: tok/landed on div≥26 refine batches with annotations vs
+  without; and count of sim<0.35 funcs promoted to viable drafts.
+- Even if match-rate lift is modest, Phase 3 labeling output is a permanent
+  repo-quality gain that no other pipeline provides.
+
+## Order of work
+1. Phase 0 spike (melonDS + GDB stub + canary check)
+2. Phase 1 collector + savestate library, trace top-100 div≥26 nearmisses
+3. Phase 2 deterministic enrichment; eyeball 10 annotations by hand
+4. Phase 3 A/B: one annotated vs one unannotated refine batch, compare tok/landed
+5. Decide on Phase 4 based on how often drafts fail replay in spot checks

--- a/tools/trace/README.md
+++ b/tools/trace/README.md
@@ -1,0 +1,136 @@
+# tools/trace — emu-trace pipeline
+
+Runtime-trace tooling for the emulator-assisted matching/labeling plan.
+Strategy: `notes/emu-trace-plan.md`. Build spec: `notes/emu-trace-build.md`.
+
+Status: **Phase 0 spike** (attach + breakpoint + canary + register/mem dump).
+
+## Files
+- `rsp.py` — minimal GDB Remote Serial Protocol client over a TCP socket (no
+  gdb dependency). Set/clear breakpoints, read registers/memory, continue.
+- `symindex.py` — addr→symbol index from `config/**/symbols.txt` + `nearmiss/db.jsonl`,
+  used to resolve a captured `lr` to a caller name.
+- `gdb_harness.py` — the Phase-0 spike runner. Breaks at always-resident arm9
+  functions and validates the pipeline against ground truth.
+
+## Prerequisites: melonDS GDB stub
+
+1. Install melonDS (Qt frontend — the GDB stub lives there).
+2. Emu settings → enable the GDB stub. In `melonDS.ini` the keys are roughly:
+   ```
+   GdbEnabled=1
+   GdbPortARM9=3333
+   GdbPortARM7=3334
+   JIT_Enable=0          ; REQUIRED — the stub needs the interpreter core
+   ```
+   (Exact key names vary by melonDS version — confirm in the UI. The two that
+   matter: stub ON, JIT OFF.)
+3. Load `sm64.nds` and **load a savestate / let the game run past boot** so the
+   CPU is actually executing game code (otherwise the arm9 targets never fire).
+   melonDS suspends the CPU while a GDB client is attached, then resumes on
+   `continue` — that's expected.
+
+DeSmuME fallback: launch with `--arm9gdb=3333`; everything below is identical.
+
+## Run the spike
+
+```
+# default: 6 small always-resident arm9 funcs, 20s window
+python tools/trace/gdb_harness.py --duration 20
+
+# pick your own targets (must exist in nearmiss/db.jsonl)
+python tools/trace/gdb_harness.py --names func_02043288,DMASyncFillTransfer
+
+# write every hit record to JSONL for inspection
+python tools/trace/gdb_harness.py --duration 30 --out traces/spike.jsonl
+
+# canary-rejection test: bp an address whose overlay is swapped out (or any
+# address you expect NOT to hold the named func) and confirm canary_ok=false
+python tools/trace/gdb_harness.py --negative 0x0211640c
+```
+
+## What to look for (Phase-0 acceptance gates)
+
+The run prints a summary. Report these back:
+
+1. **Register layout** — the startup line `register packet: N words; pc=... cpsr=...`.
+   - `pc` on a breakpoint hit MUST equal the target function's address.
+   - Confirm `cpsr` has a sane mode (low byte one of 10/11/12/13/1f) and note
+     `cpsr_src` (`word16` = core layout, `last` = legacy-FPA layout). **Write the
+     confirmed layout here** once known — it's the classic stub gotcha.
+2. **Canary** — `canary clean` count > 0 on resident targets; the `--negative`
+   test should log a rejected/unexpected hit (canary_ok=false). Both directions
+   must work.
+3. **Throughput** — `total hits (X/s)`. **Gate: ≥ 5 hits/s.** Below that after
+   capping derefs, the pivot (per the build plan) is a small melonDS fork with
+   an in-process addr-set logger instead of stop-the-world breakpoints.
+
+## Confirmed facts (Phase 0 spike, 2026-07-14, melonDS 1.1 windows-x86_64)
+
+**Register packet layout** (from `src/debug/GdbArch.h`, validated live): 39 words.
+Indices 0–12 = r0–r12, 13 = sp, 14 = lr, 15 = pc, 16 = cpsr, then banked/spsr
+regs. `rsp.py` reads word13/14/15/16 — correct. cpsr src = `word16`.
+
+**Throughput: ~1,500 breakpoint hits/sec** with 206 breakpoints armed on the
+title/intro scene (14,998 hits in 10s, all canary-clean). The <5/s kill
+criterion is not remotely a concern — stop-the-world breakpoints are plenty fast.
+
+**melonDS 1.1 GDB-stub quirks (these shaped rsp.py — do not regress them):**
+1. **Config is per-instance.** Enabling `[Gdb] Enabled=true` alone does NOTHING;
+   you must set `[Instance0.Gdb] Enabled=true`. JIT is `[JIT] Enable=false`.
+   Config lives in `melonDS.toml` next to the exe.
+2. **Mandatory handshake:** on accept the stub blocks in `WaitAckBlocking`
+   expecting the CLIENT to send a `+` byte first, then it replies `+`. Without
+   that leading `+` it closes the connection on the first packet. `rsp.py`
+   `connect()` sends it.
+3. **Single session.** The stub services ONE client. You MUST send `D` (detach)
+   before disconnecting, or it keeps holding the dead ConnFd and the next
+   connection's packets go unanswered (times out). It rebuilds its listen
+   socket on each disconnect, so a fresh `connect()` can be briefly refused —
+   `rsp.py` retries.
+4. **Never send a `0x03` break.** Halting a running target (or breaking while
+   stopped) resets/wedges the Windows stub. Not needed anyway: set breakpoints
+   while the target runs, and each bp HIT stops it on its own. Teardown = `D`.
+5. **A SIGKILL'd client wedges the stub** (dead ConnFd, single session). If runs
+   start timing out, restart melonDS. Restarting between trace sessions is
+   expected anyway (to cycle savestates).
+
+**Working model (what the collector should do):** launch melonDS with ROM +
+savestate → open ONE persistent RSP connection → set all breakpoints while
+running → continue → loop {wait_for_stop → read regs/mem → continue} → `D` +
+close → kill melonDS. One connection per trace session, detach cleanly.
+
+Launch recipe used:
+`Start-Process melonDS.exe -ArgumentList '<rom>'` with the pre-written
+`melonDS.toml`; stub binds ~6–8s after boot.
+
+## actorcam: live actor-list heartbeat (`actors.py`)
+
+Human-friendly runtime naming tool: while YOU play in melonDS, it walks the
+game's global Actor list every snapshot and prints what is alive - actor ID
+joined to the community `ActorList.h` name, vtable, uniqueID, param, world
+position - and diffs snapshots so "what spawned/despawned when X happened" is
+one keypress. Snapshots append to `traces/actors/session_*.jsonl` with your
+event labels for later vtable->name joining.
+
+Setup (once): `melonDS.toml` needs `[Gdb] Enabled=true`, `[Gdb.ARM9]
+Port=3333 BreakOnStartup=true`, `[JIT] Enable=false`; clone
+`reference/DynamicAllocationDecomp` for actor-ID names.
+
+Use:
+```
+1. start melonDS with sm64.nds        (game waits, halted, for the client)
+2. python tools/trace/actors.py       (attaches, releases the boot, prompts)
+3. play; press Enter to snapshot, or type "star exploded" + Enter to tag one
+```
+
+melonDS 1.1 stub facts this tool obeys (learned the hard way):
+- one client per emulator launch; if attach probes time out -> restart melonDS
+- memory reads work fine while the game RUNS; `?` only answers when halted
+- with BreakOnStartup the game powers on halted; the tool auto-continues
+- every reply must be ACKed - only talk to the stub through `rsp.py`
+
+Addresses are EU (this repo's ROM): actor list head `0x0209b468` (node
+embedded at actor+0x50), `LOADED_LEVEL_OVL_ID 0x02092130`; layouts credited to
+SplattyDS/DynamicAllocationDecomp (see CREDITS.md), vtable slot semantics
+validated in `tools/actor_names.py`.

--- a/tools/trace/actors.py
+++ b/tools/trace/actors.py
@@ -1,0 +1,264 @@
+"""actorcam: live actor-list heartbeat over the melonDS/DeSmuME GDB stub.
+
+Walks the game's behavior processing list in emulator RAM and prints every live
+actor: address, actor ID (joined against the community ActorList.h enum), class
+vtable, its Behavior/destructor symbols from our config, and world position.
+Snapshots diff against the previous one, so "what just spawned/despawned when
+the star blew up" is a single keypress. Every snapshot is appended to a JSONL
+session log under traces/actors/ for later joining/naming work.
+
+Runtime layout (EU ROM, from reference/DynamicAllocationDecomp symbols.x +
+include/Actor/ActorBase.h, credit CREDITS.md; vtable slot semantics validated
+in tools/actor_names.py against byte-matched code, list layout corroborated by
+matched src/_ZN5ActorC2Ev.cpp / _ZN5Actor4NextEPKS_):
+
+  FIRST_ACTOR_LIST_NODE @ 0x0209b468 -> Actor::ListNode*  (global Actor list)
+  Actor::ListNode (embedded at actor+0x50): +0 prev, +4 next, +8 actor(==this)
+  ActorBase: +0 vtable, +4 u32 uniqueID, +8 u32 param1, +0xc u16 actorID,
+             +0xe u8 aliveState (1=alive 2=dead)
+  Actor:     +0x5c Vector3 pos (fix12), +0xb0 u32 flags
+  vtable:    slot 6 = Behavior, slots 16/17 = D1/D0 destructors
+  LOADED_LEVEL_OVL_ID @ 0x02092130
+
+melonDS stub ground rules (hard-learned):
+  - melonDS.toml needs [Gdb] Enabled=true, [Gdb.ARM9] Port/BreakOnStartup=true,
+    [JIT] Enable=false. With BreakOnStartup the game waits for us at power-on;
+    we auto-continue on attach.
+  - EVERY stub reply must be ACKed ('+') or the stub wedges forever (rsp.py
+    does this; never talk to the socket by hand).
+  - Memory reads work fine WHILE THE GAME RUNS - never send 0x03 interrupts.
+
+Usage (start melonDS with the GDB stub on first, then):
+  python tools/trace/actors.py             # interactive: Enter=snapshot,
+                                           #   any text = snapshot tagged with
+                                           #   that label, q = quit
+  python tools/trace/actors.py --once      # one snapshot and exit
+  python tools/trace/actors.py --watch 2   # snapshot every 2 seconds
+  python tools/trace/actors.py --port 3333 --host 127.0.0.1
+
+The emulator keeps running between snapshots; each snapshot halts the core for
+a few milliseconds of reads and resumes it.
+"""
+import argparse
+import json
+import pathlib
+import re
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from rsp import RspClient, RspError
+import symindex
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+FIRST_ACTOR_LIST_NODE = 0x0209B468
+LOADED_LEVEL_OVL_ID = 0x02092130
+NODE_PREV, NODE_NEXT, NODE_ACTOR = 0x0, 0x4, 0x8
+ACTOR_VTABLE, ACTOR_UID, ACTOR_PARAM1, ACTOR_ID, ACTOR_ALIVE = 0x0, 0x4, 0x8, 0xC, 0xE
+ACTOR_POS = 0x5C
+VT_SLOT_BEHAVIOR = 6
+VT_SLOTS_READ = 18          # covers Behavior + both destructors
+RAM_LO, RAM_HI = 0x02000000, 0x02400000
+MAX_NODES = 1024
+
+ACTORLIST_H = REPO / "reference" / "DynamicAllocationDecomp" / "include" / "List" / "ActorList.h"
+
+
+def load_actor_names():
+    """{actor_id: EnumName} from the community headers; empty dict if absent."""
+    names = {}
+    if ACTORLIST_H.is_file():
+        for m in re.finditer(r"^\s*(\w+?)_ACTOR_ID\s*=\s*(\d+),",
+                             ACTORLIST_H.read_text(encoding="utf-8"), re.M):
+            names[int(m.group(2))] = m.group(1)
+    return names
+
+
+def u32(b, off):
+    return int.from_bytes(b[off:off + 4], "little")
+
+
+def u16(b, off):
+    return int.from_bytes(b[off:off + 2], "little")
+
+
+def s32(v):
+    return v - 0x100000000 if v & 0x80000000 else v
+
+
+def in_ram(p):
+    return RAM_LO <= p < RAM_HI
+
+
+class VtableCache:
+    """vtable addr -> {'behavior': name|None, 'dtor': name|None}; reads each
+    unique vtable once per session."""
+
+    def __init__(self, cli, syms):
+        self.cli = cli
+        self.syms = syms
+        self.cache = {}
+
+    def info(self, vt):
+        if vt in self.cache:
+            return self.cache[vt]
+        out = {"behavior": None, "behavior_addr": None, "dtor": None}
+        try:
+            raw = self.cli.read_mem(vt, VT_SLOTS_READ * 4)
+            beh = u32(raw, VT_SLOT_BEHAVIOR * 4)
+            d1 = u32(raw, 16 * 4)
+            if in_ram(beh):
+                out["behavior_addr"] = beh
+                out["behavior"] = self.syms.resolve(beh)
+            if in_ram(d1):
+                out["dtor"] = self.syms.resolve(d1)
+        except RspError:
+            pass
+        self.cache[vt] = out
+        return out
+
+
+def walk_actors(cli, vtcache):
+    """Walk the global Actor list and return actor dicts.
+
+    Reads happen WHILE THE TARGET RUNS (verified stable on melonDS 1.1); a
+    snapshot is very slightly racy against a mid-frame list mutation, and the
+    in_ram()/cycle guards turn that into a truncated snapshot, not a crash."""
+    head = u32(cli.read_mem(FIRST_ACTOR_LIST_NODE, 4), 0)
+    actors, seen, node = [], set(), head
+    while in_ram(node) and node not in seen and len(seen) < MAX_NODES:
+        seen.add(node)
+        nb = cli.read_mem(node, 0xC)
+        aptr = u32(nb, NODE_ACTOR)
+        if in_ram(aptr):
+            ab = cli.read_mem(aptr, 0x10)
+            pos = None
+            try:
+                pb = cli.read_mem(aptr + ACTOR_POS, 12)
+                pos = [round(s32(u32(pb, i)) / 4096.0, 1) for i in (0, 4, 8)]
+            except RspError:
+                pass
+            vt = u32(ab, ACTOR_VTABLE)
+            actors.append({
+                "addr": aptr,
+                "vtable": vt,
+                "uid": u32(ab, ACTOR_UID),
+                "param1": u32(ab, ACTOR_PARAM1),
+                "id": u16(ab, ACTOR_ID),
+                "alive": ab[ACTOR_ALIVE],
+                "pos": pos,
+                **vtcache.info(vt),
+            })
+        node = u32(nb, NODE_NEXT)
+    return actors
+
+
+def fmt_row(a, names):
+    name = names.get(a["id"], "?")
+    beh = a["behavior"] or (f"0x{a['behavior_addr']:08x}" if a["behavior_addr"] else "-")
+    pos = "({:>8} {:>8} {:>8})".format(*a["pos"]) if a["pos"] else "-"
+    dead = "" if a.get("alive", 1) == 1 else " DEAD"
+    return (f"  {a['addr']:08x}  id={a['id']:<4} {name:<28} uid={a['uid']:<6} "
+            f"vt={a['vtable']:08x}  {pos}  beh={beh}{dead}")
+
+
+def print_snapshot(actors, prev, names, mark=None, level_ovl=None):
+    tag = f"  [{mark}]" if mark else ""
+    lvl = f"  level_ovl={level_ovl}" if level_ovl is not None else ""
+    print(f"\n=== {time.strftime('%H:%M:%S')}  {len(actors)} live actors{lvl}{tag}")
+    for a in actors:
+        print(fmt_row(a, names))
+    if prev is not None:
+        prev_uids = {a["uid"]: a for a in prev}
+        cur_uids = {a["uid"]: a for a in actors}
+        spawned = [a for u, a in cur_uids.items() if u not in prev_uids]
+        gone = [a for u, a in prev_uids.items() if u not in cur_uids]
+        for a in spawned:
+            print("  ++ SPAWNED  " + fmt_row(a, names).strip())
+        for a in gone:
+            print("  -- GONE     " + fmt_row(a, names).strip())
+        if not spawned and not gone:
+            print("  (no spawn/despawn since last snapshot)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="live actor-list heartbeat (melonDS/DeSmuME GDB stub)")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=3333)
+    ap.add_argument("--once", action="store_true", help="one snapshot, then exit")
+    ap.add_argument("--watch", type=float, metavar="SEC", help="snapshot every SEC seconds")
+    args = ap.parse_args()
+
+    names = load_actor_names()
+    if not names:
+        print("[warn] reference/DynamicAllocationDecomp missing - actor IDs will be numeric only")
+    syms = symindex.get()
+
+    outdir = REPO / "traces" / "actors"
+    outdir.mkdir(parents=True, exist_ok=True)
+    log = outdir / time.strftime("session_%Y%m%d_%H%M%S.jsonl")
+
+    print(f"[*] connecting to {args.host}:{args.port} (start melonDS + ROM first) ...")
+    cli = RspClient(args.host, args.port)
+    cli.connect()
+    # Probe the stub with a harmless read. The melonDS 1.1 stub serves exactly
+    # ONE client per emulator launch: if a previous client (even a crashed one)
+    # already attached, the socket still accepts but nothing answers.
+    try:
+        cli.read_mem(FIRST_ACTOR_LIST_NODE, 4)
+    except (RspError, OSError, TimeoutError):
+        print("[!] stub connected but not answering. The melonDS GDB stub only\n"
+              "    serves one client per emulator launch - close and restart\n"
+              "    melonDS, then run this again (it releases the halted boot).",
+              file=sys.stderr)
+        cli.close()
+        return
+    # With BreakOnStartup=true the game powers on halted, waiting for us.
+    # `c` is harmless if it is already running.
+    cli.cont()
+    print("[*] attached; game running.")
+    print(f"[*] logging to {log.relative_to(REPO)}")
+    vtcache = VtableCache(cli, syms)
+
+    def snapshot(prev, mark=None):
+        level_ovl = None
+        try:
+            level_ovl = u32(cli.read_mem(LOADED_LEVEL_OVL_ID, 4), 0)
+        except RspError:
+            pass
+        actors = walk_actors(cli, vtcache)
+        print_snapshot(actors, prev, names, mark, level_ovl)
+        with open(log, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"t": time.time(), "mark": mark,
+                                "level_ovl": level_ovl, "actors": actors}) + "\n")
+        return actors
+
+    prev = None
+    try:
+        if args.once:
+            snapshot(prev)
+        elif args.watch:
+            while True:
+                prev = snapshot(prev)
+                time.sleep(args.watch)
+        else:
+            print("[*] Enter = snapshot | type a label (e.g. 'star exploded') = tagged snapshot | q = quit")
+            while True:
+                try:
+                    line = input("actorcam> ").strip()
+                except EOFError:
+                    break
+                if line.lower() in ("q", "quit", "exit"):
+                    break
+                prev = snapshot(prev, mark=line or None)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cli.detach()
+        cli.close()
+        print("[*] detached; emulator resumed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/trace/actors.py
+++ b/tools/trace/actors.py
@@ -100,6 +100,19 @@ class VtableCache:
         self.syms = syms
         self.cache = {}
 
+    def _resolve(self, addr):
+        """Overlay-aliasing-aware resolve. ~100 level/actor overlays share the
+        same VA range, so a bare range hit can name a function from an overlay
+        that is not even loaded. Return the unique name when only one symbol
+        range contains addr; otherwise join all candidates with '|' and a '?'
+        so the ambiguity is visible instead of silently wrong."""
+        hits = sorted({name for lo, hi, name in self.syms.ranges if lo <= addr < hi})
+        if not hits:
+            return None
+        if len(hits) == 1:
+            return hits[0]
+        return "?" + "|".join(hits[:4]) + ("|..." if len(hits) > 4 else "")
+
     def info(self, vt):
         if vt in self.cache:
             return self.cache[vt]
@@ -110,9 +123,9 @@ class VtableCache:
             d1 = u32(raw, 16 * 4)
             if in_ram(beh):
                 out["behavior_addr"] = beh
-                out["behavior"] = self.syms.resolve(beh)
+                out["behavior"] = self._resolve(beh)
             if in_ram(d1):
-                out["dtor"] = self.syms.resolve(d1)
+                out["dtor"] = self._resolve(d1)
         except RspError:
             pass
         self.cache[vt] = out

--- a/tools/trace/annotate.py
+++ b/tools/trace/annotate.py
@@ -1,0 +1,225 @@
+"""Phase-2 batch annotation pass.
+
+For each function that has a runtime trace, run the deterministic enrichment
+(enrich.py) and a CHEAP model call to turn {draft C, trace facts} into a
+structured annotation (corrected signature, arg types, semantic name, behavior,
+draft errors, confidence). Results are appended to traces/annotations.jsonl and
+are what Phase 3 injects into refine/fanout prompts.
+
+Model access mirrors tools/glm_refine.py: the Anthropic Messages dialect over
+the env-configured endpoint, so it plugs into the same setup the refine loop
+uses. Defaults to a cheap tier.
+
+  GLM_BASE_URL   (default https://api.z.ai/api/anthropic; set to
+                  https://api.anthropic.com for real Claude)
+  GLM_API_KEY    (or first line of ~/.glm_key)
+  ANNOTATE_MODEL (default: GLM_MODEL, else claude-haiku-4-5-20251001)
+
+Usage:
+  python tools/trace/annotate.py --all-traced            # every func with a trace
+  python tools/trace/annotate.py --wl funcs.txt
+  python tools/trace/annotate.py --all-traced --dry-run  # build prompts, no model
+  python tools/trace/annotate.py --emit-prompts out/     # write prompts for a
+                                                         # Workflow fan-out (keyless)
+"""
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import enrich as enrich_mod  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TRACES = REPO / "traces"
+ANNOTATIONS = TRACES / "annotations.jsonl"
+
+BASE_URL = os.environ.get("GLM_BASE_URL", "https://api.z.ai/api/anthropic")
+API_KEY = os.environ.get("GLM_API_KEY", "")
+MODEL = os.environ.get("ANNOTATE_MODEL", os.environ.get("GLM_MODEL", "claude-haiku-4-5-20251001"))
+if not API_KEY:
+    _kf = pathlib.Path.home() / ".glm_key"
+    if _kf.is_file():
+        API_KEY = _kf.read_text(encoding="utf-8").strip().splitlines()[0].strip()
+
+PROMPT_HEAD = """You are annotating a decompiled Nintendo DS (ARM9) function to help a decomp \
+matching effort. Below is the current decomp DRAFT plus RUNTIME TRACE FACTS captured from a real \
+emulator (per-arg value profiles at entry, pointer-deref memory, callers, callees). Use the trace \
+to propose a BETTER-INFORMED annotation than the draft: which of r0-r3 are actually live args (the \
+draft may have the arity wrong), each arg's type (pointer vs small int vs hardware I/O register -- \
+NDS I/O is 0x04000000+, the 0x040004xx range is the GX geometry/command engine), Fix12 fixed-point \
+(values that are multiples of 4096), and what pointer args point to.
+
+Output ONLY this block, terse and concrete, no preamble:
+
+SIGNATURE: <corrected C prototype>
+ARGS:
+  r0: <type> -- <role>
+  r1: <type> -- <role>
+  r2: <type> -- <role>
+  r3: <type> -- <role>
+SEMANTIC_NAME: <best guess at a real function name>
+BEHAVIOR: <2 sentences>
+DRAFT_ERRORS: <what the trace shows the draft got wrong>
+CONFIDENCE: <high|medium|low> -- <one clause why>
+
+--- TRACE FACTS + DRAFT ---
+"""
+
+
+def build_prompt(facts):
+    L = [f"FUNCTION: {facts['name']} (module {facts['module']}, addr {facts['addr']}, "
+         f"size {facts['size']}, divergences {facts['divergences']}, {facts['n_hits']} hits)", ""]
+    L.append("RUNTIME ARG PROFILES (r0-r3 at entry across hits):")
+    for k, v in facts["arg_profiles"].items():
+        tags = [t for t in ("stable", "all_zero", "ram_ptr", "io_reg", "fix12_whole") if v[t]]
+        L.append(f"  {k}: tags={tags or ['(varies)']} distinct={v['distinct']}")
+    L.append("")
+    for a in ("r0", "r1", "r2", "r3"):
+        if facts["arg_derefs"].get(a):
+            L.append(f"*{a} memory words: {facts['arg_derefs'][a]}")
+    L.append("")
+    L.append(f"CALLERS (runtime): {facts['callers']}")
+    L.append(f"CALLEES (disasm): {[c['name'] or c['addr'] for c in facts['callees']] or 'leaf'}")
+    L.append("")
+    L.append("CURRENT DECOMP DRAFT (structurally imperfect):")
+    L.append(facts["draft_c_source"])
+    return PROMPT_HEAD + "\n".join(L)
+
+
+_FIELD = re.compile(r"^(SIGNATURE|SEMANTIC_NAME|BEHAVIOR|DRAFT_ERRORS|CONFIDENCE):\s*(.*)$")
+
+
+def parse_annotation(text):
+    """Parse the fixed block into fields; keep the raw too."""
+    out = {"signature": None, "args": {}, "semantic_name": None, "behavior": None,
+           "draft_errors": None, "confidence": None, "raw": text.strip()}
+    in_args = False
+    for line in text.splitlines():
+        m = _FIELD.match(line.strip())
+        if m:
+            in_args = False
+            key = m.group(1).lower()
+            out[{"signature": "signature", "semantic_name": "semantic_name",
+                 "behavior": "behavior", "draft_errors": "draft_errors",
+                 "confidence": "confidence"}[key]] = m.group(2).strip()
+            continue
+        if line.strip() == "ARGS:":
+            in_args = True
+            continue
+        if in_args:
+            am = re.match(r"\s*(r[0-3]):\s*(.*)", line)
+            if am:
+                out["args"][am.group(1)] = am.group(2).strip()
+    return out
+
+
+def call_model(prompt, max_tokens=1024, timeout=120):
+    import requests
+    if not API_KEY:
+        raise RuntimeError("no API key (GLM_API_KEY / ~/.glm_key). Use --dry-run or "
+                           "--emit-prompts and drive a Workflow fan-out instead.")
+    url = BASE_URL.rstrip("/") + "/v1/messages"
+    headers = {"x-api-key": API_KEY, "anthropic-version": "2023-06-01",
+               "content-type": "application/json"}
+    body = {"model": MODEL, "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}]}
+    r = requests.post(url, headers=headers, json=body, timeout=timeout)
+    r.raise_for_status()
+    data = r.json()
+    return "".join(b.get("text", "") for b in data.get("content", []))
+
+
+def traced_funcs():
+    """Every func name that has a traces/<module>/<name>.jsonl file."""
+    out = []
+    if not TRACES.is_dir():
+        return out
+    for p in TRACES.glob("*/*.jsonl"):
+        if p.name != "coverage.jsonl":
+            out.append(p.stem)
+    return sorted(set(out))
+
+
+def already_done():
+    done = set()
+    if ANNOTATIONS.is_file():
+        for line in ANNOTATIONS.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                try:
+                    done.add(json.loads(line)["name"])
+                except (json.JSONDecodeError, KeyError):
+                    pass
+    return done
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--all-traced", action="store_true", help="annotate every traced func")
+    ap.add_argument("--wl", default=None, help="worklist of names to annotate")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--dry-run", action="store_true", help="build prompts, no model call")
+    ap.add_argument("--emit-prompts", default=None,
+                    help="write per-func prompt .txt files to this dir (for Workflow fan-out)")
+    ap.add_argument("--force", action="store_true", help="re-annotate already-done funcs")
+    args = ap.parse_args()
+
+    if args.wl:
+        names = [n.strip() for n in pathlib.Path(args.wl).read_text().split()
+                 if n.strip() and not n.startswith("#")]
+    elif args.all_traced:
+        names = traced_funcs()
+    else:
+        print("specify --all-traced or --wl", file=sys.stderr)
+        return 2
+
+    if not args.force:
+        done = already_done()
+        names = [n for n in names if n not in done]
+    if args.limit:
+        names = names[:args.limit]
+    print(f"[*] {len(names)} func(s) to annotate; model={MODEL}", file=sys.stderr)
+
+    emit_dir = pathlib.Path(args.emit_prompts) if args.emit_prompts else None
+    if emit_dir:
+        emit_dir.mkdir(parents=True, exist_ok=True)
+
+    ANNOTATIONS.parent.mkdir(parents=True, exist_ok=True)
+    n_ok = 0
+    for name in names:
+        try:
+            facts = enrich_mod.enrich(name)
+        except SystemExit as e:
+            print(f"  ! {name}: {e}", file=sys.stderr)
+            continue
+        prompt = build_prompt(facts)
+        if emit_dir:
+            (emit_dir / f"{name}.txt").write_text(prompt, encoding="utf-8")
+            n_ok += 1
+            continue
+        if args.dry_run:
+            print(f"\n===== {name} ({len(prompt)} chars) =====\n{prompt[:600]} ...")
+            n_ok += 1
+            continue
+        try:
+            resp = call_model(prompt)
+        except Exception as e:
+            print(f"  ! {name}: model call failed: {e}", file=sys.stderr)
+            continue
+        ann = parse_annotation(resp)
+        ann.update({"name": name, "module": facts["module"], "addr": facts["addr"],
+                    "divergences": facts["divergences"], "model": MODEL})
+        with open(ANNOTATIONS, "a", encoding="utf-8") as f:
+            f.write(json.dumps(ann) + "\n")
+        n_ok += 1
+        print(f"  ok {name}: {ann['semantic_name']} [{ann['confidence']}]", file=sys.stderr)
+
+    where = emit_dir if emit_dir else ("(dry-run)" if args.dry_run else ANNOTATIONS)
+    print(f"[=] {n_ok}/{len(names)} done -> {where}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace/behavior.py
+++ b/tools/trace/behavior.py
@@ -1,0 +1,176 @@
+"""Behavioral snapshot capture -- record per-call (inputs -> outputs) test cases
+for a function from a running melonDS, to be diffed across ROM builds (retail vs
+your recompiled C) as an equivalence oracle. See behavior_diff.py for the compare.
+
+Why capture instead of live-diff two runs: runtime state (RNG, frame counters,
+heap addresses) drifts between runs, so you cannot diff live execution. Instead
+we record, per call: the INPUTS (r0-r3, sp, and the memory each pointer arg
+points to) at entry, and the OUTPUTS (r0/r1 and the SAME memory regions re-read)
+at return. Two builds are equivalent iff, for identical inputs, they produce
+identical outputs (esp. memory writes -- the return value can be dead for a void
+function).
+
+Exit is caught with the lr-return trick: at entry we read lr (the return
+address), set a one-shot breakpoint there, and continue; the function's own
+internal returns all converge on lr. Recursion is detected and that case skipped
+(v1 limitation).
+
+For a real retail-vs-recompiled comparison, capture BOTH builds from the SAME
+savestate (identical starting state) so the two runs call functions with matching
+inputs -- fresh-boot timing makes cross-run input overlap unreliable for
+continuously-animating code. melonDS's stub is single-session and fragile under
+heavy breakpoint churn, so capture a few functions per session and restart
+melonDS between sessions (cases are flushed per-function as they complete).
+
+Usage (melonDS running with a ROM/savestate loaded, stub on 3333):
+  python tools/trace/behavior.py --names NormalizeVec3,MulMat4x3Mat4x3 \
+      --cases 20 --out behavior/retail
+"""
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from rsp import RspClient, RspError  # noqa: E402
+import bplist  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MAIN_RAM = (0x02000000, 0x02400000)
+
+
+def looks_like_ptr(v):
+    return MAIN_RAM[0] <= v < MAIN_RAM[1]
+
+
+def _ptr_args(regs):
+    """Which of r0-r3 look like RAM pointers -> {reg: addr}."""
+    return {f"r{i}": regs[f"r{i}"] for i in range(4) if looks_like_ptr(regs[f"r{i}"])}
+
+
+def _read_regions(cli, ptrs, window):
+    out = {}
+    for reg, addr in ptrs.items():
+        try:
+            out[reg] = {"addr": addr, "hex": cli.read_mem(addr, window).hex()}
+        except RspError:
+            pass
+    return out
+
+
+def capture_one(cli, tgt, n_cases, window, per_case_timeout=4.0):
+    """Capture up to n_cases (inputs->outputs) for one function.
+
+    Assumes ONLY tgt's entry breakpoint is currently armed. Uses a temporary
+    lr breakpoint per call to catch the return.
+    """
+    entry = tgt["addr"]
+    canary = tgt["canary"]
+    cases = []
+    skipped_recursive = 0
+    while len(cases) < n_cases:
+        # --- wait for an entry hit (canary-clean) ---
+        try:
+            cli.wait_for_stop()
+        except (RspError, OSError):
+            break  # no more hits within the socket timeout
+        regs = cli.read_registers()
+        if regs["pc"] != entry:
+            cli.cont()
+            continue
+        try:
+            if cli.read_mem(entry, 8).hex() != canary:
+                cli.cont()  # aliased overlay
+                continue
+        except RspError:
+            cli.cont()
+            continue
+
+        in_ptrs = _ptr_args(regs)
+        case = {
+            "in": {k: regs[k] for k in ("r0", "r1", "r2", "r3", "sp")},
+            "in_mem": _read_regions(cli, in_ptrs, window),
+            "lr": regs["lr"],
+        }
+        lr = regs["lr"]
+        cli.set_breakpoint(lr)
+        # --- run to return ---
+        deadline = time.time() + per_case_timeout
+        got = False
+        recursed = False
+        while time.time() < deadline:
+            cli.cont()
+            try:
+                cli.wait_for_stop()
+            except (RspError, OSError):
+                break
+            r = cli.read_registers()
+            if r["pc"] == lr:
+                case["out"] = {"r0": r["r0"], "r1": r["r1"]}
+                case["out_mem"] = _read_regions(cli, in_ptrs, window)
+                got = True
+                break
+            if r["pc"] == entry:
+                recursed = True  # re-entered before returning: v1 can't pair this
+                break
+            # some other breakpoint (shouldn't happen: only entry+lr armed)
+        cli.clear_breakpoint(lr)
+        if got:
+            cases.append(case)
+        elif recursed:
+            skipped_recursive += 1
+            if skipped_recursive > n_cases:
+                break
+        cli.cont()
+    return cases, skipped_recursive
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=3333)
+    ap.add_argument("--names", required=True, help="comma-separated function names")
+    ap.add_argument("--cases", type=int, default=20, help="target cases per func")
+    ap.add_argument("--window", type=int, default=64, help="bytes of pointer memory to snapshot")
+    ap.add_argument("--out", required=True, help="output dir (e.g. behavior/retail)")
+    args = ap.parse_args()
+
+    targets, missing = bplist.from_names(args.names.split(","))
+    if missing:
+        print(f"  ! not in nearmiss DB: {missing}", file=sys.stderr)
+    if not targets:
+        return 2
+    outdir = pathlib.Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[*] connecting to {args.host}:{args.port} ...")
+    try:
+        cli = RspClient(args.host, args.port).connect()
+    except OSError as e:
+        print(f"[!] no GDB stub: {e} (melonDS running, stub on, ROM loaded?)", file=sys.stderr)
+        return 3
+    try:
+        cli.read_registers()  # sanity
+        cli.cont()  # kickoff: resume the target so breakpoints start firing
+        for tgt in targets:
+            # one function at a time: only its entry bp armed, so the lr-return
+            # trick is unambiguous.
+            cli.set_breakpoint(tgt["addr"])
+            print(f"[*] {tgt['name']}: capturing up to {args.cases} cases ...", flush=True)
+            cases, rec = capture_one(cli, tgt, args.cases, args.window)
+            cli.clear_breakpoint(tgt["addr"])
+            path = outdir / f"{tgt['name']}.jsonl"
+            with open(path, "w", encoding="utf-8") as f:
+                for c in cases:
+                    f.write(json.dumps(c) + "\n")
+            note = f" ({rec} recursive skipped)" if rec else ""
+            print(f"    {len(cases)} cases -> {path}{note}")
+    finally:
+        cli.detach()
+        cli.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace/behavior_diff.py
+++ b/tools/trace/behavior_diff.py
@@ -1,0 +1,135 @@
+"""Behavioral equivalence oracle: diff two sets of captured (inputs->outputs)
+cases (behavior.py output) for the same function across two ROM builds -- e.g.
+retail vs your recompiled C.
+
+Method: index each side's cases by an INPUT signature (r0-r3 + the bytes of every
+pointer-arg memory region at entry). For every input present in BOTH builds,
+compare the OUTPUTS:
+  - memory writes: the delta (in_mem -> out_mem) for each pointer region. This is
+    the robust, codegen-independent behavioral signal.
+  - return value r0/r1: reported, but flagged "weak" -- r0 is dead for void funcs,
+    so an r0-only difference is not conclusive.
+
+Verdict per function:
+  EQUIVALENT   -- every shared input produced identical memory writes
+  DIVERGENT    -- some shared input produced different memory writes (a real bug)
+  INCONCLUSIVE -- no shared inputs (drive matching scenes / capture more cases)
+
+Usage:
+  python tools/trace/behavior_diff.py behavior/retail behavior/recompiled
+  python tools/trace/behavior_diff.py behavior/retail behavior/retail2 --name NormalizeVec3
+"""
+import argparse
+import json
+import pathlib
+import sys
+
+
+def load(path, name):
+    p = pathlib.Path(path) / f"{name}.jsonl"
+    if not p.is_file():
+        return []
+    return [json.loads(l) for l in p.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def input_sig(case):
+    r = case["in"]
+    parts = [f"{r['r0']:08x}{r['r1']:08x}{r['r2']:08x}{r['r3']:08x}"]
+    for reg in ("r0", "r1", "r2", "r3"):
+        m = case.get("in_mem", {}).get(reg)
+        if m:
+            parts.append(f"{reg}:{m['hex']}")
+    return "|".join(parts)
+
+
+def mem_writes(case):
+    """{reg: (before_hex, after_hex)} for pointer regions that CHANGED between
+    entry and return -- i.e. what the function wrote through its args."""
+    out = {}
+    inm = case.get("in_mem", {})
+    outm = case.get("out_mem", {})
+    for reg in ("r0", "r1", "r2", "r3"):
+        b = inm.get(reg, {}).get("hex")
+        a = outm.get(reg, {}).get("hex")
+        if b is not None and a is not None and b != a:
+            out[reg] = (b, a)
+    return out
+
+
+def diff_one(name, a_cases, b_cases):
+    a_by = {}
+    for c in a_cases:
+        a_by.setdefault(input_sig(c), c)
+    shared = 0
+    mem_divergent = []
+    ret_divergent = []
+    for c in b_cases:
+        sig = input_sig(c)
+        if sig not in a_by:
+            continue
+        shared += 1
+        ca = a_by[sig]
+        wa, wb = mem_writes(ca), mem_writes(c)
+        if wa != wb:
+            mem_divergent.append((sig, wa, wb))
+        elif ca.get("out", {}).get("r0") != c.get("out", {}).get("r0") or \
+                ca.get("out", {}).get("r1") != c.get("out", {}).get("r1"):
+            ret_divergent.append((sig, ca.get("out"), c.get("out")))
+    if shared == 0:
+        verdict = "INCONCLUSIVE"
+    elif mem_divergent:
+        verdict = "DIVERGENT"
+    else:
+        verdict = "EQUIVALENT"
+    return {
+        "name": name, "verdict": verdict, "shared_inputs": shared,
+        "a_cases": len(a_cases), "b_cases": len(b_cases),
+        "mem_divergent": mem_divergent, "ret_divergent": ret_divergent,
+    }
+
+
+def func_names(a_dir, b_dir):
+    names = set()
+    for d in (pathlib.Path(a_dir), pathlib.Path(b_dir)):
+        if d.is_dir():
+            names.update(p.stem for p in d.glob("*.jsonl"))
+    return sorted(names)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dir_a", help="baseline captures (e.g. behavior/retail)")
+    ap.add_argument("dir_b", help="candidate captures (e.g. behavior/recompiled)")
+    ap.add_argument("--name", default=None, help="only this function")
+    ap.add_argument("--verbose", action="store_true", help="show diverging bytes")
+    args = ap.parse_args()
+
+    names = [args.name] if args.name else func_names(args.dir_a, args.dir_b)
+    if not names:
+        print("no captures found", file=sys.stderr)
+        return 2
+
+    tally = {"EQUIVALENT": 0, "DIVERGENT": 0, "INCONCLUSIVE": 0}
+    for name in names:
+        r = diff_one(name, load(args.dir_a, name), load(args.dir_b, name))
+        tally[r["verdict"]] += 1
+        mark = {"EQUIVALENT": "OK ", "DIVERGENT": "XX ", "INCONCLUSIVE": "-- "}[r["verdict"]]
+        print(f"{mark}{name:40} {r['verdict']:12} "
+              f"shared={r['shared_inputs']:3} (a={r['a_cases']} b={r['b_cases']})")
+        if r["mem_divergent"]:
+            print(f"      {len(r['mem_divergent'])} input(s) produced different MEMORY WRITES:")
+            for sig, wa, wb in r["mem_divergent"][:5]:
+                for reg in sorted(set(wa) | set(wb)):
+                    print(f"        {reg}: baseline {wa.get(reg,('-','-'))[1][:32]}"
+                          f" != candidate {wb.get(reg,('-','-'))[1][:32]}"
+                          if args.verbose else f"        {reg}: write differs")
+        elif r["ret_divergent"] and args.verbose:
+            print(f"      note: {len(r['ret_divergent'])} r0/r1 differ but memory matches "
+                  f"(weak signal -- likely dead retval on a void fn)")
+    print(f"\n[=] {tally['EQUIVALENT']} equivalent, {tally['DIVERGENT']} DIVERGENT, "
+          f"{tally['INCONCLUSIVE']} inconclusive")
+    return 1 if tally["DIVERGENT"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace/bplist.py
+++ b/tools/trace/bplist.py
@@ -1,0 +1,95 @@
+"""Turn a worklist (or a nearmiss filter) into a breakpoint-target list.
+
+A target dict is:
+    {"name", "addr" (int), "module", "size", "canary" (16 hex chars)}
+
+The canary is target_hex[:16] -- the first 8 bytes of the function. On a bp hit
+we read 8 bytes at addr and compare; a mismatch means a DIFFERENT overlay is
+mapped there (address aliasing) and the hit is discarded. melonDS keeps
+breakpoints as a checked PC-list (not a RAM patch), so bps survive overlay
+reloads -- residency only affects whether the code runs, i.e. coverage.
+"""
+import json
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+DB = REPO / "nearmiss" / "db.jsonl"
+
+
+def _iter_db():
+    for line in DB.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def _target(r):
+    return {
+        "name": r["name"],
+        "addr": int(str(r["addr"]), 16),
+        "module": r.get("module", "arm9"),
+        "size": r.get("size"),
+        "canary": r["target_hex"][:16].lower(),
+    }
+
+
+def from_names(names):
+    """Targets for an explicit list of function names (skips unknowns)."""
+    want = {n.strip() for n in names if n.strip()}
+    by_name = {r["name"]: r for r in _iter_db()}
+    out, missing = [], []
+    for n in want:
+        if n in by_name:
+            out.append(_target(by_name[n]))
+        else:
+            missing.append(n)
+    return out, missing
+
+
+def from_worklist(path):
+    """Read names from a worklist file: one per line, or a JSON list, or a
+    JSONL of records with a 'name' field. '#' comments and blanks ignored."""
+    text = pathlib.Path(path).read_text(encoding="utf-8", errors="replace").strip()
+    names = []
+    if text.startswith("["):
+        for item in json.loads(text):
+            names.append(item if isinstance(item, str) else item.get("name"))
+    else:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("{"):
+                try:
+                    names.append(json.loads(line).get("name"))
+                    continue
+                except json.JSONDecodeError:
+                    pass
+            names.append(line.split()[0])
+    return from_names([n for n in names if n])
+
+
+def from_nearmiss(min_div=None, module=None, limit=None):
+    """Targets straight from the nearmiss DB, filtered."""
+    out = []
+    for r in _iter_db():
+        if min_div is not None and r.get("divergences", 0) < min_div:
+            continue
+        if module is not None and r.get("module", "arm9") != module:
+            continue
+        out.append(_target(r))
+    # densest-first so a fixed run captures the highest-divergence funcs earliest
+    out.sort(key=lambda t: -(t["size"] or 0))
+    if limit:
+        out = out[:limit]
+    return out
+
+
+def group_by_module(targets):
+    g = {}
+    for t in targets:
+        g.setdefault(t["module"], []).append(t)
+    return g

--- a/tools/trace/collect.py
+++ b/tools/trace/collect.py
@@ -1,0 +1,207 @@
+"""Phase-1 trace collector.
+
+Attaches to a running melonDS GDB stub (see tools/trace/README.md for the
+setup + the stub's quirks), arms breakpoints for a worklist of functions, and
+captures N canary-clean hits per function -- entry regs, stack, pointer derefs,
+and the resolved caller. Once a function reaches its hit cap its breakpoint is
+removed (z0) so rarer functions in the tail still get airtime.
+
+Output:
+  traces/<module>/<name>.jsonl   one line per captured hit
+  traces/coverage.jsonl          per-func {hits, alias_rejects, dark} ledger
+
+Coverage depends on gameplay REACHING each function while its overlay is
+resident -- drive the emulator (or load savestates) to cover different scenes.
+Whatever isn't reached is recorded as dark, never silently dropped.
+
+Usage (melonDS running with a ROM/savestate loaded, stub on 3333):
+  python tools/trace/collect.py --wl worklist.txt --hits 5
+  python tools/trace/collect.py --nearmiss-div 26 --module ov006 --hits 5
+  python tools/trace/collect.py --nearmiss-div 26 --module arm9 --duration 60
+"""
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from rsp import RspClient, RspError  # noqa: E402
+import bplist  # noqa: E402
+import symindex  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+TRACES = REPO / "traces"
+MAIN_RAM = (0x02000000, 0x02400000)
+
+
+def looks_like_ptr(v):
+    return MAIN_RAM[0] <= v < MAIN_RAM[1]
+
+
+def capture(cli, tgt, syms, deref_len=96, frame=None):
+    """Build one hit record from the halted target (pc == tgt['addr'])."""
+    regs = cli.read_registers()
+    stack = []
+    try:
+        stack = _words(cli.read_mem(regs["sp"], 32))
+    except RspError:
+        pass
+    derefs = {}
+    for i in range(4):
+        v = regs[f"r{i}"]
+        if looks_like_ptr(v):
+            try:
+                derefs[f"r{i}"] = cli.read_mem(v, deref_len).hex()
+            except RspError:
+                pass
+    return {
+        "name": tgt["name"],
+        "module": tgt["module"],
+        "regs": {k: regs[k] for k in ("r0", "r1", "r2", "r3", "sp", "lr", "pc", "cpsr")},
+        "caller": syms.resolve(regs["lr"]),
+        "stack": stack,
+        "derefs": derefs,
+        "frame": frame,
+    }
+
+
+def _words(b):
+    return [int.from_bytes(b[i:i + 4], "little") for i in range(0, len(b) - 3, 4)]
+
+
+def load_targets(args):
+    if args.wl:
+        targets, missing = bplist.from_worklist(args.wl)
+        if missing:
+            print(f"  ! {len(missing)} worklist names not in nearmiss DB "
+                  f"(e.g. {missing[:3]})", file=sys.stderr)
+        return targets
+    if args.nearmiss_div is not None or args.module:
+        return bplist.from_nearmiss(min_div=args.nearmiss_div, module=args.module,
+                                    limit=args.limit)
+    print("specify --wl, or --nearmiss-div / --module", file=sys.stderr)
+    return []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=3333)
+    ap.add_argument("--wl", default=None, help="worklist file of function names")
+    ap.add_argument("--nearmiss-div", type=int, default=None,
+                    help="target nearmiss funcs with divergences >= this")
+    ap.add_argument("--module", default=None, help="restrict to a module (arm9/ovNNN)")
+    ap.add_argument("--limit", type=int, default=None, help="cap number of targets")
+    ap.add_argument("--hits", type=int, default=5, help="hits to capture per func")
+    ap.add_argument("--duration", type=float, default=120.0, help="max seconds")
+    ap.add_argument("--idle", type=float, default=20.0,
+                    help="stop after this many seconds with no NEW func captured")
+    ap.add_argument("--out", default=str(TRACES), help="output dir (default traces/)")
+    args = ap.parse_args()
+
+    targets = load_targets(args)
+    if not targets:
+        return 2
+    by_addr = {t["addr"]: t for t in targets}
+    syms = symindex.get()
+    outdir = pathlib.Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    hits = {t["name"]: 0 for t in targets}
+    alias = {t["name"]: 0 for t in targets}
+    fps = {}  # name -> open file handle (lazy)
+
+    def fp_for(t):
+        if t["name"] not in fps:
+            d = outdir / t["module"]
+            d.mkdir(parents=True, exist_ok=True)
+            fps[t["name"]] = open(d / f"{t['name']}.jsonl", "a", encoding="utf-8")
+        return fps[t["name"]]
+
+    print(f"[*] {len(targets)} targets across "
+          f"{len(bplist.group_by_module(targets))} module(s); "
+          f"hit-cap={args.hits}")
+    print(f"[*] connecting to {args.host}:{args.port} ...")
+    try:
+        cli = RspClient(args.host, args.port).connect()
+    except OSError as e:
+        print(f"[!] no GDB stub on {args.host}:{args.port}: {e}\n"
+              f"    Is melonDS running (stub on, JIT off, ROM/savestate loaded)?",
+              file=sys.stderr)
+        return 3
+
+    remaining = len(targets)
+    captured_total = 0
+    try:
+        r0 = cli.read_registers()
+        print(f"[*] attached (running); pc={r0['pc']:#010x}. arming {len(targets)} bps ...")
+        armed = sum(1 for t in targets if cli.set_breakpoint(t["addr"]))
+        print(f"[*] armed {armed}/{len(targets)}; collecting "
+              f"(<= {args.duration:.0f}s, idle-stop {args.idle:.0f}s) ...")
+        cli.cont()
+
+        t_start = time.time()
+        t_last_new = t_start
+        while remaining > 0 and time.time() - t_start < args.duration:
+            if time.time() - t_last_new > args.idle:
+                print(f"[*] idle {args.idle:.0f}s with nothing new -> stopping")
+                break
+            try:
+                cli.wait_for_stop()
+            except (RspError, OSError):
+                continue  # socket read timeout between hits; keep polling
+            regs = cli.read_registers()
+            pc = regs["pc"]
+            tgt = by_addr.get(pc)
+            if tgt is None:
+                cli.cont()
+                continue
+            # canary-gate against overlay aliasing
+            seen = ""
+            try:
+                seen = cli.read_mem(pc, 8).hex()
+            except RspError:
+                pass
+            if seen != tgt["canary"]:
+                alias[tgt["name"]] += 1
+                cli.cont()
+                continue
+            if hits[tgt["name"]] < args.hits:
+                rec = capture(cli, tgt, syms)
+                fp_for(tgt).write(json.dumps(rec) + "\n")
+                hits[tgt["name"]] += 1
+                captured_total += 1
+                if hits[tgt["name"]] == 1:
+                    t_last_new = time.time()
+                if hits[tgt["name"]] >= args.hits:
+                    cli.clear_breakpoint(tgt["addr"])  # tail-friendly: free the slot
+                    remaining -= 1
+            cli.cont()
+
+        elapsed = time.time() - t_start
+        print(f"\n[=] elapsed {elapsed:.1f}s; captured {captured_total} hits; "
+              f"{len([n for n,c in hits.items() if c>0])}/{len(targets)} funcs reached")
+    finally:
+        for f in fps.values():
+            f.close()
+        cli.detach()
+        cli.close()
+
+    # coverage ledger (append-friendly: one snapshot line per run per func)
+    cov = outdir / "coverage.jsonl"
+    with open(cov, "a", encoding="utf-8") as c:
+        for t in targets:
+            c.write(json.dumps({
+                "name": t["name"], "module": t["module"],
+                "hits": hits[t["name"]], "alias_rejects": alias[t["name"]],
+                "dark": hits[t["name"]] == 0,
+            }) + "\n")
+    reached = len([n for n, c in hits.items() if c > 0])
+    print(f"[=] coverage: {reached}/{len(targets)} reached "
+          f"({100*reached/len(targets):.0f}%); dark logged to {cov}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace/enrich.py
+++ b/tools/trace/enrich.py
@@ -1,0 +1,116 @@
+"""Deterministic (zero-model) enrichment of a function's trace + nearmiss record.
+
+Produces the structured facts that a cheap model pass then turns into a human
+annotation (proposed signature / types / name / behavior). Everything here is
+computed, not guessed:
+  - per-arg profile (r0-r3): stable pointer? varies? zero? RAM ptr? I/O register?
+    Fix12-looking? distinct observed values
+  - callers seen at runtime (from lr resolution)
+  - callees (BL targets disassembled from target_hex, resolved to symbols)
+  - deref'd memory for pointer args, shown as word grids (reveals struct layout)
+"""
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import symindex  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+RAM = (0x02000000, 0x02400000)
+IO = (0x04000000, 0x05000000)
+
+
+def _db_record(name):
+    for line in (REPO / "nearmiss" / "db.jsonl").read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        if r["name"] == name:
+            return r
+    return None
+
+
+def _callees(target_hex, base):
+    """Disassemble ARM BL (0xEB......) sites from the function bytes."""
+    b = bytes.fromhex(target_hex)
+    syms = symindex.get()
+    out = []
+    for off in range(0, len(b) - 3, 4):
+        word = int.from_bytes(b[off:off + 4], "little")
+        if (word >> 24) == 0xEB:  # unconditional BL
+            imm = word & 0xFFFFFF
+            if imm & 0x800000:
+                imm -= 0x1000000
+            tgt = (base + off + 8 + (imm << 2)) & 0xFFFFFFFF
+            out.append((tgt, syms.resolve(tgt)))
+    # de-dup, keep order
+    seen, uniq = set(), []
+    for t, n in out:
+        if t not in seen:
+            seen.add(t)
+            uniq.append({"addr": f"{t:#010x}", "name": n})
+    return uniq
+
+
+def _classify(vals):
+    nz = [v for v in vals]
+    prof = {"distinct": sorted(set(f"{v:#010x}" for v in vals))[:6]}
+    prof["stable"] = len(set(vals)) == 1
+    prof["all_zero"] = all(v == 0 for v in vals)
+    prof["ram_ptr"] = all(RAM[0] <= v < RAM[1] for v in vals) and not prof["all_zero"]
+    prof["io_reg"] = all(IO[0] <= v < IO[1] for v in vals) and not prof["all_zero"]
+    nzvals = [v for v in nz if v]
+    prof["fix12_whole"] = bool(nzvals) and all(v % 4096 == 0 for v in nzvals)
+    return prof
+
+
+def _words(hexstr):
+    b = bytes.fromhex(hexstr)
+    return [int.from_bytes(b[i:i + 4], "little") for i in range(0, len(b) - 3, 4)]
+
+
+def enrich(name, traces_dir=None):
+    traces_dir = pathlib.Path(traces_dir or (REPO / "traces"))
+    rec = _db_record(name)
+    if rec is None:
+        raise SystemExit(f"{name} not in nearmiss DB")
+    module = rec.get("module", "arm9")
+    tfile = traces_dir / module / f"{name}.jsonl"
+    hits = [json.loads(l) for l in tfile.read_text(encoding="utf-8").splitlines() if l.strip()]
+    if not hits:
+        raise SystemExit(f"no trace hits for {name}")
+
+    args = {}
+    for i in range(4):
+        vals = [h["regs"][f"r{i}"] for h in hits]
+        args[f"r{i}"] = _classify(vals)
+
+    # deref word-grids for pointer args (first hit that has each deref)
+    derefs = {}
+    for i in range(4):
+        for h in hits:
+            d = h.get("derefs", {}).get(f"r{i}")
+            if d:
+                derefs[f"r{i}"] = [f"{w:#010x}" for w in _words(d)][:16]
+                break
+
+    callers = sorted({h["caller"] for h in hits if h.get("caller")})
+    base = int(str(rec["addr"]), 16)
+    return {
+        "name": name,
+        "module": module,
+        "addr": rec["addr"],
+        "size": rec["size"],
+        "divergences": rec["divergences"],
+        "n_hits": len(hits),
+        "arg_profiles": args,
+        "arg_derefs": derefs,
+        "callers": callers,
+        "callees": _callees(rec["target_hex"], base),
+        "draft_c_source": rec["c_source"],
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(enrich(sys.argv[1]), indent=2))

--- a/tools/trace/gdb_harness.py
+++ b/tools/trace/gdb_harness.py
@@ -1,0 +1,262 @@
+"""Phase-0 spike: attach to a melonDS/DeSmuME GDB stub, break at known-address
+functions, and prove attach + breakpoint + canary + register/memory dump work
+end-to-end. See notes/emu-trace-build.md section 5.
+
+This is a SPIKE, not the collector. It targets always-resident arm9 functions
+(ground truth: we know their address and their first bytes from the nearmiss DB)
+so the overlay-residency variable is removed. Its job is to answer:
+  1. Does the register-packet layout parse to r0..r15 (+cpsr) correctly?
+  2. Does the canary (first 8 bytes == target_hex[:16]) hold for a resident
+     func, and reject a bogus one?
+  3. What is the breakpoint-hit throughput (hits/sec)?  Gate: >= 5 hits/sec.
+
+Usage (melonDS running with GdbEnabled=1, GdbPortARM9=3333, JIT_Enable=0, a
+savestate loaded so the game is actually executing):
+
+  python tools/trace/gdb_harness.py --duration 20
+  python tools/trace/gdb_harness.py --names func_02043288,func_02058568
+  python tools/trace/gdb_harness.py --negative 0x02043288   # canary-reject test
+"""
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from rsp import RspClient, RspError  # noqa: E402
+import symindex  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MAIN_RAM = (0x02000000, 0x02400000)
+
+# Default ground-truth targets: small always-resident arm9 funcs from nearmiss DB.
+DEFAULT_NAMES = [
+    "func_02043288", "func_0204335c", "func_0204322c",
+    "func_02058568", "DMASyncFillTransfer", "func_0206e3dc",
+]
+
+
+def load_targets(names):
+    """Join requested names against the nearmiss DB for addr + canary bytes."""
+    db = REPO / "nearmiss" / "db.jsonl"
+    by_name = {}
+    for line in db.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        by_name[r["name"]] = r
+    targets = []
+    for n in names:
+        r = by_name.get(n)
+        if not r:
+            print(f"  ! {n}: not in nearmiss DB, skipping", file=sys.stderr)
+            continue
+        targets.append({
+            "name": n,
+            "addr": int(str(r["addr"]), 16),
+            "size": r.get("size"),
+            "module": r.get("module", "arm9"),
+            "canary": r["target_hex"][:16].lower(),
+        })
+    return targets
+
+
+def load_all_arm9():
+    """Every arm9 (always-resident) nearmiss func -- maximizes hit coverage."""
+    db = REPO / "nearmiss" / "db.jsonl"
+    out = []
+    for line in db.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if r.get("module", "arm9") != "arm9":
+            continue
+        out.append({
+            "name": r["name"],
+            "addr": int(str(r["addr"]), 16),
+            "size": r.get("size"),
+            "module": "arm9",
+            "canary": r["target_hex"][:16].lower(),
+        })
+    return out
+
+
+def looks_like_ptr(v):
+    return MAIN_RAM[0] <= v < MAIN_RAM[1]
+
+
+def dump_hit(cli, tgt, syms, deref_len=64):
+    regs = cli.read_registers()
+    # canary: read first 8 bytes at the function address
+    raw = cli.read_mem(tgt["addr"], 8)
+    canary_seen = raw.hex()
+    canary_ok = canary_seen == tgt["canary"]
+    stack = []
+    try:
+        sp = regs["sp"]
+        stack = [w for w in _words(cli.read_mem(sp, 32))]
+    except RspError:
+        pass
+    derefs = {}
+    for i in range(4):
+        v = regs[f"r{i}"]
+        if looks_like_ptr(v):
+            try:
+                derefs[f"r{i}"] = cli.read_mem(v, deref_len).hex()
+            except RspError:
+                pass
+    return {
+        "name": tgt["name"],
+        "canary_ok": canary_ok,
+        "canary_seen": canary_seen,
+        "pc": regs["pc"],
+        "regs": {k: regs[k] for k in ("r0", "r1", "r2", "r3", "sp", "lr", "pc")},
+        "cpsr": regs["cpsr"],
+        "cpsr_src": regs["cpsr_src"],
+        "reg_words": len(regs["words"]),
+        "caller": syms.resolve(regs["lr"]),
+        "stack": stack,
+        "derefs": derefs,
+    }
+
+
+def _words(b):
+    return [int.from_bytes(b[i:i + 4], "little") for i in range(0, len(b) - 3, 4)]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=3333)
+    ap.add_argument("--names", default=None, help="comma-separated func names")
+    ap.add_argument("--arm9-all", action="store_true",
+                    help="target every arm9 nearmiss func (good for throughput/coverage)")
+    ap.add_argument("--duration", type=float, default=20.0, help="seconds to run")
+    ap.add_argument("--negative", default=None,
+                    help="addr (hex) to bp with a deliberately wrong canary test")
+    ap.add_argument("--out", default=None, help="write hit records as JSONL here")
+    args = ap.parse_args()
+
+    if args.names:
+        targets = load_targets(args.names.split(","))
+    elif args.arm9_all:
+        targets = load_all_arm9()
+        print(f"[*] loaded all {len(targets)} arm9 nearmiss funcs as targets")
+    else:
+        targets = load_targets(DEFAULT_NAMES)
+    if not targets:
+        print("no valid targets", file=sys.stderr)
+        return 2
+    by_addr = {t["addr"]: t for t in targets}
+    syms = symindex.get()
+
+    print(f"[*] connecting to {args.host}:{args.port} ...")
+    try:
+        cli = RspClient(args.host, args.port).connect()
+    except OSError as e:
+        print(f"[!] could not connect to a GDB stub on {args.host}:{args.port}: {e}\n"
+              f"    Is melonDS running with the stub enabled (GdbEnabled=1, "
+              f"GdbPortARM9={args.port}, JIT_Enable=0) and a ROM/savestate loaded?",
+              file=sys.stderr)
+        return 3
+    try:
+        # The melonDS target is RUNNING when we attach and its stub is
+        # single-session. We do NOT halt it (sending 0x03 resets the melonDS
+        # Windows stub) -- breakpoints are set while running, and each bp HIT
+        # stops the target on its own. Read regs once (while running) just to
+        # report the detected register-packet layout.
+        r0 = cli.read_registers()
+        print(f"[*] attached (running). register packet: {len(r0['words'])} words; "
+              f"pc={r0['pc']:#010x} cpsr={r0['cpsr']:#010x} (src={r0['cpsr_src']})")
+
+        armed = 0
+        for t in targets:
+            if cli.set_breakpoint(t["addr"]):
+                armed += 1
+            else:
+                print(f"  ! failed to arm bp at {t['name']} {t['addr']:#010x}",
+                      file=sys.stderr)
+        if args.negative:
+            neg = int(args.negative, 16)
+            cli.set_breakpoint(neg)
+            print(f"[*] negative-canary bp armed at {neg:#010x}")
+        print(f"[*] armed {armed}/{len(targets)} breakpoints; running "
+              f"{args.duration:.0f}s ...")
+
+        out_fp = open(args.out, "w", encoding="utf-8") if args.out else None
+        hits = 0
+        clean = 0
+        rejected = 0
+        per_func = {}
+        t_start = time.time()
+        cli.cont()
+        while time.time() - t_start < args.duration:
+            try:
+                stop = cli.wait_for_stop()
+            except (RspError, OSError) as e:
+                print(f"[!] stop wait ended: {e}", file=sys.stderr)
+                break
+            regs = cli.read_registers()
+            pc = regs["pc"]
+            tgt = by_addr.get(pc)
+            hits += 1
+            if tgt is None:
+                # could be the negative bp or an unexpected stop
+                rec = {"name": "?", "pc": pc, "canary_ok": False, "unexpected": True}
+            else:
+                rec = dump_hit(cli, tgt, syms)
+                per_func[tgt["name"]] = per_func.get(tgt["name"], 0) + 1
+                if rec["canary_ok"]:
+                    clean += 1
+                else:
+                    rejected += 1
+            if out_fp:
+                out_fp.write(json.dumps(rec) + "\n")
+            if hits <= 12:
+                _print_rec(rec)
+            cli.cont()
+
+        elapsed = time.time() - t_start
+        if out_fp:
+            out_fp.close()
+
+        print("\n" + "=" * 60)
+        print(f"[=] elapsed:        {elapsed:.1f}s")
+        print(f"[=] total hits:     {hits}  ({hits / elapsed:.1f}/s)")
+        print(f"[=] canary clean:   {clean}")
+        print(f"[=] canary rejected:{rejected}")
+        print(f"[=] per-func hits:  {per_func}")
+        print("[=] GATE throughput >=5/s:  "
+              + ("PASS" if hits / elapsed >= 5 else "FAIL (see pivot in build plan)"))
+        print("[=] GATE canary:            "
+              + ("PASS (had clean hits)" if clean else "no clean hits -- check savestate/targets"))
+    finally:
+        # Clean teardown: `D` (detach) makes the stub drop its breakpoints and
+        # resume. No 0x03 break (that resets the melonDS Windows stub). Errors
+        # here are harmless -- we're exiting, and melonDS is restarted between
+        # trace sessions anyway (to cycle savestates).
+        cli.detach()
+        cli.close()
+    return 0
+
+
+def _print_rec(rec):
+    if rec.get("unexpected"):
+        print(f"  hit @ {rec['pc']:#010x}  <unexpected / negative bp>")
+        return
+    reg = rec["regs"]
+    mark = "OK " if rec["canary_ok"] else "XX "
+    caller = rec.get("caller") or "?"
+    print(f"  {mark}{rec['name']:<28} r0={reg['r0']:#010x} r1={reg['r1']:#010x} "
+          f"lr={reg['lr']:#010x}<-{caller} derefs={list(rec.get('derefs', {}))}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/trace/inject.py
+++ b/tools/trace/inject.py
@@ -1,0 +1,69 @@
+"""Phase-3 annotation injection.
+
+Formats a function's Phase-2 annotation (from traces/annotations.jsonl) into a
+compact block suitable for PREPENDING to a refine (glm_refine.py / refine_run.js)
+or fan-out (sched_run.js) prompt. Additive and opt-in: the loop tooling stays
+untouched; an A/B harness calls block_for(name) and prepends the result (empty
+string when there is no annotation, so the control arm is a no-op).
+
+The block deliberately leads with runtime-observed FACTS and frames them as
+hints, not ground truth -- the asm remains the oracle.
+"""
+import json
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+ANNOTATIONS = REPO / "traces" / "annotations.jsonl"
+
+
+def load_annotations(path=None):
+    path = pathlib.Path(path) if path else ANNOTATIONS
+    out = {}
+    if path.is_file():
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                try:
+                    r = json.loads(line)
+                    out[r["name"]] = r
+                except (json.JSONDecodeError, KeyError):
+                    pass
+    return out
+
+
+def block_for(name, annotations=None):
+    """Return the injection block for `name`, or '' if no annotation exists."""
+    anns = annotations if annotations is not None else load_annotations()
+    a = anns.get(name)
+    if not a:
+        return ""
+    lines = [
+        "=== RUNTIME TRACE HINTS (observed in a real emulator; the retail asm is",
+        "still the oracle -- use these to fix the C SHAPE, esp. arg arity/types) ===",
+    ]
+    if a.get("signature"):
+        lines.append(f"Observed signature: {a['signature']}")
+    if a.get("args"):
+        lines.append("Arg roles (r0-r3 at entry):")
+        for reg, desc in a["args"].items():
+            lines.append(f"  {reg}: {desc}")
+    if a.get("semantic_name"):
+        lines.append(f"Likely purpose: {a['semantic_name']}")
+    if a.get("behavior"):
+        lines.append(f"Behavior: {a['behavior']}")
+    if a.get("draft_errors"):
+        lines.append(f"Trace vs current draft: {a['draft_errors']}")
+    if a.get("confidence"):
+        lines.append(f"Confidence: {a['confidence']}")
+    lines.append("=== END TRACE HINTS ===\n")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    import sys
+    anns = load_annotations()
+    if len(sys.argv) > 1:
+        print(block_for(sys.argv[1], anns) or f"(no annotation for {sys.argv[1]})")
+    else:
+        print(f"{len(anns)} annotation(s) available:")
+        for n, a in anns.items():
+            print(f"  {n}: {a.get('semantic_name')} [{(a.get('confidence') or '').split(' -- ')[0]}]")

--- a/tools/trace/rsp.py
+++ b/tools/trace/rsp.py
@@ -1,0 +1,231 @@
+"""Minimal GDB Remote Serial Protocol (RSP) client over a TCP socket.
+
+No gdb / gdb-multiarch dependency -- we speak RSP directly to the melonDS (or
+DeSmuME) GDB stub. This is the Phase-0 transport for the emu-trace pipeline
+(see notes/emu-trace-build.md).
+
+Only the handful of packets the tracer needs are implemented:
+  ?           stop reason / are-we-halted
+  <0x03>      interrupt (halt a running target)
+  g           read all registers
+  m addr,len  read memory
+  Z0/z0       set/clear software breakpoint
+  c           continue
+  D           detach
+
+Register-layout note: the first 16 words of the `g` reply are always r0..r15
+in every ARM GDB layout (core, legacy-FPA, ...). sp=r13, lr=r14, pc=r15 are
+therefore reliable regardless of stub quirks. CPSR position DOES vary between
+stubs -- read_registers() detects it heuristically and reports what it found;
+that ambiguity is exactly what the Phase-0 spike exists to pin down.
+"""
+import socket
+import time
+
+
+class RspError(Exception):
+    pass
+
+
+class RspClient:
+    def __init__(self, host="127.0.0.1", port=3333, timeout=10.0):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sock = None
+        self._buf = b""
+
+    # ------------------------------------------------------------------ conn
+    def connect(self, retries=20, retry_delay=0.25):
+        # melonDS rebuilds its listen socket on each client disconnect, leaving a
+        # brief window where connect() is refused. Retry across it.
+        last = None
+        for _ in range(retries):
+            try:
+                self.sock = socket.create_connection((self.host, self.port), self.timeout)
+                break
+            except ConnectionRefusedError as e:
+                last = e
+                time.sleep(retry_delay)
+        else:
+            raise last
+        self.sock.settimeout(self.timeout)
+        # melonDS handshake: on accept the stub calls WaitAckBlocking expecting
+        # the CLIENT to send '+' first (within ~1s), then it SendAck's '+' back.
+        # Without this leading '+' it closes the connection on the first packet.
+        self.sock.sendall(b"+")
+        # swallow its single handshake '+' byte (best-effort; _read_reply also
+        # skips stray acks, so a miss here is harmless).
+        old = self.sock.gettimeout()
+        self.sock.settimeout(1.0)
+        try:
+            self._read_byte()
+        except (socket.timeout, OSError):
+            pass
+        finally:
+            self.sock.settimeout(old)
+        return self
+
+    def close(self):
+        if self.sock:
+            try:
+                self.sock.close()
+            finally:
+                self.sock = None
+
+    def __enter__(self):
+        return self.connect()
+
+    def __exit__(self, *exc):
+        self.close()
+
+    # -------------------------------------------------------------- framing
+    @staticmethod
+    def _checksum(data: bytes) -> int:
+        return sum(data) & 0xFF
+
+    def _read_byte(self) -> bytes:
+        if not self._buf:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise RspError("connection closed by stub")
+            self._buf = chunk
+        b, self._buf = self._buf[:1], self._buf[1:]
+        return b
+
+    def send_packet(self, payload: str, expect_reply=True, retries=3) -> str:
+        """Send `$payload#cc`, consume the +/- ack, optionally return the reply."""
+        data = payload.encode("ascii")
+        pkt = b"$" + data + b"#" + f"{self._checksum(data):02x}".encode("ascii")
+        for _ in range(retries):
+            self.sock.sendall(pkt)
+            ack = self._read_byte()
+            if ack == b"+":
+                break
+            if ack == b"-":
+                continue  # stub asked for retransmit
+            # some stubs skip the ack; treat the byte as start of the reply
+            self._buf = ack + self._buf
+            break
+        else:
+            raise RspError("stub kept NAKing packet: %r" % payload)
+        if not expect_reply:
+            return ""
+        return self._read_reply()
+
+    def _read_reply(self) -> str:
+        # skip stray acks, then read $...#cc, verify checksum, ACK it.
+        while True:
+            b = self._read_byte()
+            if b == b"$":
+                break
+            # '+'/'-' or notification bytes: ignore
+        body = b""
+        while True:
+            b = self._read_byte()
+            if b == b"#":
+                break
+            body += b
+        cs = self._read_byte() + self._read_byte()
+        got = int(cs, 16)
+        if got != self._checksum(body):
+            self.sock.sendall(b"-")
+            raise RspError("bad checksum in reply %r" % body)
+        self.sock.sendall(b"+")
+        return body.decode("ascii", "replace")
+
+    def interrupt(self):
+        """Send a raw Ctrl-C (0x03) to halt a running target."""
+        self.sock.sendall(b"\x03")
+
+    def drain(self, timeout=0.5):
+        """Best-effort read of one pending reply (e.g. the stop packet an
+        interrupt produces). Returns the packet, or None if nothing arrived.
+        Used to keep the interrupt->command handshake from desyncing."""
+        old = self.sock.gettimeout()
+        self.sock.settimeout(timeout)
+        try:
+            return self._read_reply()
+        except (socket.timeout, OSError):
+            return None
+        finally:
+            self.sock.settimeout(old)
+
+    def halt_and_sync(self):
+        """Halt a running target and swallow the resulting stop packet so the
+        socket is left clean for subsequent commands."""
+        self.interrupt()
+        return self.drain(timeout=1.0)
+
+    # -------------------------------------------------------------- commands
+    def stop_reason(self) -> str:
+        return self.send_packet("?")
+
+    def cont(self, expect_reply=False) -> str:
+        # `c` does not reply until the target next stops; callers that want the
+        # stop packet should use wait_for_stop() instead.
+        return self.send_packet("c", expect_reply=expect_reply)
+
+    def wait_for_stop(self) -> str:
+        """Block until the target reports a stop (S/T packet) and return it."""
+        return self._read_reply()
+
+    def set_breakpoint(self, addr: int, kind=4) -> bool:
+        r = self.send_packet(f"Z0,{addr:x},{kind}")
+        return r == "OK"
+
+    def clear_breakpoint(self, addr: int, kind=4) -> bool:
+        r = self.send_packet(f"z0,{addr:x},{kind}")
+        return r == "OK"
+
+    def read_mem(self, addr: int, length: int) -> bytes:
+        r = self.send_packet(f"m{addr:x},{length:x}")
+        if r.startswith("E"):
+            raise RspError(f"m{addr:x},{length:x} -> {r}")
+        return bytes.fromhex(r)
+
+    def read_registers(self) -> dict:
+        """Return {'raw', 'words', 'r0'..'r15', 'sp','lr','pc', 'cpsr', 'cpsr_src'}.
+
+        First 16 words are r0..r15 in every layout. CPSR is located heuristically:
+        a valid CPSR has a legal mode field in bits[4:0]. We test the two common
+        positions (word[16] for core layout, word[-1] for legacy-FPA) and report
+        which one looked valid.
+        """
+        raw = self.send_packet("g")
+        if raw.startswith("E") or len(raw) < 16 * 8:
+            raise RspError(f"g -> {raw!r}")
+        words = [
+            int.from_bytes(bytes.fromhex(raw[i:i + 8]), "little")
+            for i in range(0, len(raw) - len(raw) % 8, 8)
+        ]
+        out = {"raw": raw, "words": words}
+        for i in range(16):
+            out[f"r{i}"] = words[i]
+        out["sp"], out["lr"], out["pc"] = words[13], words[14], words[15]
+        out["cpsr"], out["cpsr_src"] = self._pick_cpsr(words)
+        return out
+
+    @staticmethod
+    def _pick_cpsr(words):
+        valid_modes = {0x10, 0x11, 0x12, 0x13, 0x16, 0x17, 0x1B, 0x1F}
+        candidates = []
+        if len(words) >= 17:
+            candidates.append(("word16", words[16]))
+        if len(words) >= 18:
+            candidates.append(("last", words[-1]))
+        for src, val in candidates:
+            if (val & 0x1F) in valid_modes:
+                return val, src
+        return (candidates[0][1] if candidates else None,
+                candidates[0][0] if candidates else "none")
+
+    def detach(self):
+        # `D` tells the stub to remove its breakpoints and resume the target,
+        # releasing the single session so the next client can attach. Never
+        # precede this with a 0x03 break -- on the melonDS Windows stub that
+        # resets the connection.
+        try:
+            self.send_packet("D")
+        except (RspError, OSError):
+            pass

--- a/tools/trace/symindex.py
+++ b/tools/trace/symindex.py
@@ -1,0 +1,72 @@
+"""addr -> symbol-name index, built from config symbols + the nearmiss DB.
+
+Used to resolve a captured `lr` back to a caller name. Best-effort: returns the
+name of the function whose [addr, addr+size) range contains the query, else None.
+"""
+import json
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+_SYM_RE = re.compile(r"^(\S+)\s+kind:function\([^)]*size=(0x[0-9a-fA-F]+)\)\s+addr:(0x[0-9a-fA-F]+)")
+
+
+def _iter_symbol_files():
+    yield REPO / "config" / "arm9" / "symbols.txt"
+    ovdir = REPO / "config" / "arm9" / "overlays"
+    if ovdir.is_dir():
+        for p in sorted(ovdir.glob("ov*/symbols.txt")):
+            yield p
+
+
+class SymIndex:
+    def __init__(self):
+        # list of (start, end, name), kept sorted for bisect-free small scans
+        self.ranges = []
+        self._load()
+
+    def _add(self, addr, size, name):
+        if addr is None:
+            return
+        self.ranges.append((addr, addr + (size or 4), name))
+
+    def _load(self):
+        for sf in _iter_symbol_files():
+            if not sf.is_file():
+                continue
+            for line in sf.read_text(encoding="utf-8", errors="replace").splitlines():
+                m = _SYM_RE.match(line.strip())
+                if m:
+                    self._add(int(m.group(3), 16), int(m.group(2), 16), m.group(1))
+        db = REPO / "nearmiss" / "db.jsonl"
+        if db.is_file():
+            for line in db.read_text(encoding="utf-8", errors="replace").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                self._add(int(str(r["addr"]), 16), r.get("size"), r["name"])
+        self.ranges.sort()
+
+    def resolve(self, addr):
+        if addr is None:
+            return None
+        # ARM lr carries return address; the call site is lr-4 (or -2 thumb).
+        for probe in (addr, addr - 4, addr - 2):
+            for start, end, name in self.ranges:
+                if start <= probe < end:
+                    return name
+        return None
+
+
+_INSTANCE = None
+
+
+def get():
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = SymIndex()
+    return _INSTANCE


### PR DESCRIPTION
Tools-only PR (no src/ changes). Adds `tools/trace/`:

- **rsp.py** — dependency-free GDB Remote Serial Protocol client over TCP (no gdb/gdb-multiarch install needed)
- **actors.py (actorcam)** — live actor-list heartbeat: walks the game's global Actor list in emulator RAM while you play, prints actor ID (joined to the community ActorList.h enum), uniqueID, position, and vtable→symbol resolution, with spawn/despawn diffing and JSONL session logs for naming evidence. First run already identified `func_ov003_020af8a0` as the 1-Up Mushroom Behavior and `func_ov007_020b6d40` as the waterfall-mist init.
- Phase 0–3 trace pipeline (gdb_harness, bplist, collect, enrich, annotate, inject) + behavioral-equivalence oracle (behavior.py / behavior_diff.py)
- notes/emu-trace-plan.md + notes/emu-trace-build.md (strategy + build spec), tools/trace/README.md (melonDS setup + hard-learned stub rules)

Cleanliness: rebuilt from the old emu-trace branch WITHOUT its scratch artifacts; no ROM-derived data, no binaries — capture output dirs (/traces/, /behavior/) are gitignored. Actor struct layouts credited to SplattyDS/DynamicAllocationDecomp per CREDITS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8GUYDE9faHH6L1hohzt2Q