### PR TITLE
WIP: Match func_ov002_020d869c byte-identical

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -19,6 +19,7 @@ it is fair to take over: ping the claimant first.
 
 | Range | Who | Claimed | Status |
 |---|---|---|---|
+| ov002 func_ov002_020d869c (0x020d869c, size 0x19c) | Putxo (Codex) | 2026-07-29 | **active** — matching released div=11 near-miss; exact claim span 0x020d869c-0x020d8838 |
 | overlay batch 2026-07-27: ov075 func_ov075_0211a948; ov006 func_ov006_020c8c78 / 020e26f8 / 020e5a0c / 020ebc7c / 020eb9dc / 020dd334 / 020dbe9c; ov007 func_ov007_020c3fe4 / 020b8d48; ov002 func_ov002_020cfaf0; ov004 func_ov004_020b38ac | andrewboudreau (Claude) | 2026-07-27 | **done** — 10 matched byte-identical (mwccarm 1.2/sp2p3): ov002 020cfaf0, ov004 020b38ac, ov006 020c8c78/020dd334/020e26f8/020e5a0c/020eb9dc/020ebc7c, ov007 020b8d48/020c3fe4 (Fable uninit-decl split); 2 wall-marked near-misses banked: ov075 0211a948 (div 5, two-attractor rank-pin), ov006 020dbe9c (div 21, 6ab rank-pin) |
 | arm9 Opus batch (15 funcs) | Tango (Opus groups of 5) | 2026-07-26 | **released** — 9 matched byte-identical + verified (levers: notes 6ac); func_02063e08 improved 20->5 (banked); func_0202ffec + OAM Render Fix12IiEi overload floor-marked with evidence; still open, fair game: func_0206cf98 (div 6), func_0206de14 (div 16), func_02048234 (div 34) |
 | ov063 func_ov063_02119960 (0x02119960, size 0xcc) | lunavyqo (Grok) | 2026-07-26 | **done** — verified byte-identical + linkcheck VERIFIED (mwccarm 1.2/sp2p3); unnest 19b1c always + u64-launder 0x5d4 + mask-left 0xfff&(ri>>16); from near-miss div=20→6→0; API clm_c1af27048edb kept |


### PR DESCRIPTION
Claims `func_ov002_020d869c` while upgrading the released div=11 near-miss to an exact byte-identical match.

- Module/span: `ov002:0x020d869c-0x020d8838` (`0x19c` bytes)
- Coordination API checked free before starting.
- Live claim key is not configured, so the claim is recorded in `CLAIMS.md` and this draft PR.

Draft while matching and link validation are in progress.