### PR TITLE
func_02059d8c: reclassify as an asm primitive, per the #813 proof

### DIFF
--- a/src/func_02059d8c.c
+++ b/src/func_02059d8c.c
@@ -1,6 +1,11 @@
-// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
-// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
-// to a draft until someone reproduces the bytes from real C.
+// NONMATCHING (NOT-C-EXPRESSIBLE): byte-exact hand-written asm. Nintendo shipped this as an
+// assembly primitive, so there is no original C to recover and no match to chase. Counts as
+// done under the asm-primitive policy - see notes/asm-policy.md.
+// bhs reads the CARRY flag, which is a property of the value before the subtraction. C has
+// no expression over the post-subtraction result that denotes carry, and mwccarm fuses a
+// subtract with its following test only when the test is against zero (Z/N), so the HS
+// predicate is unreachable at the exact 12-byte shape. Established across 20 mwccarm builds
+// x 7 optimization levels x 8 pragmas - see notes/func_02059d8c-asm-origin.md.
 asm void func_02059d8c(void) {
 L0:
     subs r0, r0, #4;


### PR DESCRIPTION
Header-only change, no code. Still byte-exact under 1.2/sp2p3.

#813 proved this function has no C preimage: `bhs` reads the carry flag, which is a property of the value *before* the subtraction, and mwccarm fuses a subtract with its following test only when the test is against zero (Z/N). The HS predicate is therefore unreachable at the exact 12-byte shape, verified across 20 mwccarm builds x 7 optimization levels x 8 pragmas.

The proof landed, but `src/func_02059d8c.c` still carried the older wording:

> does NOT count as matched. Reverts to a draft until someone reproduces the bytes from real C.

So the function kept showing up as open work in every progress view even though it is settled. It now uses the same asm-primitive header the other established primitives use, and cites `notes/func_02059d8c-asm-origin.md`.

Found while reconciling the arm9 remaining count: 49 arm9 rows read `matched=false`, but 31 are policy-done primitives and 5 more are byte-exact asm hatches on matching walls. This was the one whose header disagreed with its own evidence.