### PR TITLE
tools: stop the worklist builders handing out floor-marked functions

### DIFF
--- a/tools/cluster_targets.py
+++ b/tools/cluster_targets.py
@@ -17,8 +17,12 @@ import argparse
 import json
 import pathlib
 import re
+import sys
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
+import ledger as L
+import worklist as WL
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 ARM9 = REPO / "extracted" / "arm9_dec.bin"
@@ -42,15 +46,13 @@ def load_named():
 
 
 def load_matched():
-    done = set()
-    if MATCHED.is_file():
-        for l in MATCHED.read_text(errors="ignore").splitlines():
-            l = l.strip()
-            if l:
-                try:
-                    done.add(int(json.loads(l)["addr"], 0))
-                except Exception:
-                    pass
+    """arm9 addresses this tool must not hand to an agent.
+
+    matched.jsonl alone is not enough: it is gitignored, so on a fresh clone this
+    filtered nothing and the tool offered functions that were already matched, plus any
+    carrying a verified floor mark. schedule_skip_set() supplies matched + locally parked
+    + committed floors; a committed src/ file is the portable is-it-done signal on top."""
+    done = {addr for mod, addr in L.schedule_skip_set() if mod == "arm9"}
     # Also skip known-hard functions that repeatedly fail (one hex addr per line).
     skip = REPO / "progress" / "skip.txt"
     if skip.is_file():
@@ -100,6 +102,12 @@ def main():
         if mode != "arm" or not (args.min <= sz <= args.max):
             continue
         if not (args.lo <= ad < args.hi) or not (BASE <= ad < limit) or ad in done:
+            continue
+        # A committed src/ file is the portable is-it-matched signal (matched.jsonl is
+        # gitignored). A "// NONMATCHING" draft is NOT matched and stays a valid target,
+        # same rule coddog uses.
+        src = WL.read_src_text(name)
+        if src is not None and "// NONMATCHING" not in src[:200]:
             continue
         code = a9[ad - BASE: ad - BASE + sz]
         cs = callees(code, ad, sz)

--- a/tools/coddog.py
+++ b/tools/coddog.py
@@ -60,12 +60,14 @@ def load_parked(refine_max_div=REFINE_MAX_DIV):
     out was claimed by NEITHER tier and became unschedulable. Keep the two pools
     complementary - if the refiner won't have it, it stays a fresh target here.
     nearmiss/db.jsonl is committed (shared); nonmatching.jsonl is local - both used if present."""
-    parked = L.nonmatching_set()
+    # Locally parked + verified floors come from the shared helper, so this scheduler and
+    # the ones that go through ledger cannot drift apart. The refinable-deferral below is
+    # coddog's own routing policy, not a "never work this" statement, so it stays here.
+    parked = L.parked_set()
     for r in L.read_records(REPO / "nearmiss" / "db.jsonl"):
         try:
             div = r.get("divergences")
-            refinable = isinstance(div, int) and 0 < div <= refine_max_div
-            if r.get("floor") or refinable:
+            if isinstance(div, int) and 0 < div <= refine_max_div:
                 parked.add(L.key_of(r))
         except Exception:
             pass

--- a/tools/harvest_wl.py
+++ b/tools/harvest_wl.py
@@ -19,6 +19,7 @@ import argparse, json, subprocess, sys, pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
 import swarm as S
+import ledger as L
 md = Cs(CS_ARCH_ARM, CS_MODE_ARM)
 REPO = pathlib.Path(__file__).resolve().parent.parent
 
@@ -77,24 +78,22 @@ def main():
 
     # exclude functions already parked NONMATCHING and the floor skip-list (confirmed
     # floor/regperm that agents keep re-hitting but can't match from C -- don't re-attempt).
+    # Keys go through L.key_of, which normalizes module and address. These files disagree
+    # on the addr type -- nonmatching.jsonl carries ints, nearmiss/db.jsonl mostly hex
+    # strings -- so a raw (module, addr) tuple silently failed to match across them and let
+    # excluded functions back into the pool.
     parked = set()
     for fn in ("nonmatching.jsonl", "floor_skip.jsonl"):
         p = REPO / "progress" / fn
         if p.exists():
-            for l in p.read_text().splitlines():
-                if l.strip():
-                    r = json.loads(l)
-                    parked.add((r["module"], r["addr"]))
+            for r in L.read_records(p):
+                parked.add(L.key_of(r))
     # also exclude functions already in the near-miss DB: they were attempted and their best
     # compiling attempt is stored (nearmiss/db.jsonl); re-fanning them out wastes tokens. Finish
     # those through the permuter / by hand from the DB, not by re-harvesting.
-    nmdb = REPO / "nearmiss" / "db.jsonl"
-    if nmdb.exists():
-        for l in nmdb.read_text(encoding="utf-8").splitlines():
-            if l.strip():
-                r = json.loads(l)
-                parked.add((r["module"], r["addr"]))
-    rows = [r for r in rows if (r["module"], r["addr"]) not in parked]
+    for r in L.read_records(REPO / "nearmiss" / "db.jsonl"):
+        parked.add(L.key_of(r))
+    rows = [r for r in rows if L.key_of(r) not in parked]
 
     sz = lambda r: int(r["size"], 16) if isinstance(r["size"], str) else r["size"]
     floor = [r for r in rows if is_floor(r["target_hex"])]

--- a/tools/ledger.py
+++ b/tools/ledger.py
@@ -32,6 +32,7 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
 MATCHED = REPO / "progress" / "matched.jsonl"
 NONMATCHING = REPO / "progress" / "nonmatching.jsonl"
+NEARMISS = REPO / "nearmiss" / "db.jsonl"
 LOCKDIR = REPO / "progress" / ".lock"
 
 
@@ -96,9 +97,42 @@ def nonmatching_set():
     return _key_set(NONMATCHING)
 
 
+def floor_set():
+    """Canonical keys of every near-miss carrying a verified `floor` mark.
+
+    nonmatching.jsonl is gitignored, so a scheduler that parks only on THAT filters
+    nothing on a fresh clone. nearmiss/db.jsonl is committed, which makes it the only
+    portable record of "this one is a verified wall, do not schedule it". Reading it
+    here means every scheduler gets the same answer instead of each re-deriving one:
+    coddog and refine_wl already consulted the DB, while worklist.py and harvest_wl.py
+    did not, so an agent that built a worklist directly was still offered floors."""
+    out = set()
+    for rec in read_records(NEARMISS):
+        try:
+            if rec.get("floor"):
+                out.add(key_of(rec))
+        except Exception:
+            pass                        # a malformed DB row must not break scheduling
+    return out
+
+
+def parked_set():
+    """Everything no scheduler should offer as a target: locally parked + verified floors."""
+    return nonmatching_set() | floor_set()
+
+
 def load_done():
     """matched + parked: the do-not-select / do-not-re-bank set."""
     return matched_set() | nonmatching_set()
+
+
+def schedule_skip_set():
+    """Keys an LLM-spending scheduler must not hand out: matched, locally parked, or a
+    verified floor. Deliberately NOT load_done(): the free local sweeps (clone,
+    paramclone, sweep, swarm) cost no tokens, and floor marks have been wrong often
+    enough that excluding them from a zero-cost pass is a pure loss. Use this only where
+    a target turns into model spend."""
+    return matched_set() | parked_set()
 
 
 # ---------------------------------------------------------------------- lock

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -211,7 +211,10 @@ def main():
         args.max = 0x40000 if args.random else 0x200
 
     matched = L.matched_set()            # example pool: byte-exact matches only
-    done = L.load_done()                 # matched + parked: skipped as targets
+    # matched + locally parked + verified floors. NOT load_done(): that reads only the
+    # gitignored nonmatching.jsonl, so on a fresh clone this handed floor-marked
+    # functions straight to an agent that built its worklist here instead of via coddog.
+    done = L.schedule_skip_set()
     gsyms = R.load_all_syms()
     kb = KB.build_kb()
     ex_mnem, ex_callee = (build_example_index(matched, gsyms, args.max)


### PR DESCRIPTION
Tools only, no `src/` change.

## The bypass

The park set was defined three different ways from three different inputs, so which functions a scheduler refused to offer depended on which scheduler you used:

| tool | reads | portable? |
|---|---|---|
| `coddog.py`, `refine_wl.py` | `nearmiss/db.jsonl` floor marks | yes (committed) |
| `worklist.py` (via `ledger.load_done`) | `progress/nonmatching.jsonl` only | **no (gitignored)** |
| `harvest_wl.py` | `nonmatching.jsonl` + `floor_skip.jsonl` | **no (gitignored)** |

On a fresh clone `nonmatching.jsonl` does not exist, so the bottom two filtered **nothing**. Go around the Console's coddog path, build a worklist directly, and the floor marks simply stop applying.

Measured on a clean tree: `load_done()` returns **0** keys there while `schedule_skip_set()` returns **11**. Before this change, `worklist.py` would hand all 11 floor-marked functions straight to an agent.

## The fix

`ledger.py` gains `floor_set()`, `parked_set()` and `schedule_skip_set()`. `worklist.py` uses the last one. `coddog.py` takes its base from `parked_set()` so the floor logic lives in one place, keeping its own refinable-deferral, which is routing policy rather than a do-not-work mark.

**`load_done()` keeps its exact previous meaning, deliberately.** It gates `append_nonmatching` and the *free* local sweeps (`clone`, `paramclone`, `sweep`, `swarm`). Those cost no tokens, and floor marks have been wrong twice today (#816's RMW correction, and my own frame-size claim in #817/#819), so excluding floors from a zero-cost pass would be a pure loss. Only tools where a target becomes model spend use the new set.

## Second bug found on the way

`harvest_wl.py` built its keys as raw `(module, addr)` tuples while reading files that disagree on the type — `nonmatching.jsonl` carries ints, `nearmiss/db.jsonl` mostly hex strings — so its exclusions silently failed to match across sources. It now goes through `ledger.key_of`. Same normalization bug as #812; worth knowing this class recurs wherever a raw tuple is used as a cross-file key.

It was also missing an `import ledger` entirely, which an import check could not catch because importing a module does not run `main()`. Only a smoke test surfaced it.

## Verification

- `test_worklist.py`: 4/4 pass
- `coddog.py`, `worklist.py`, `harvest_wl.py` all smoke-tested end to end
- all four floor-marked arm9 functions now excluded from scheduling while remaining bankable

## Caveat worth raising separately

While tracing this I found the reason the arm9 residue never moves: of the 7 remaining unmatched arm9 functions, **6 were unschedulable** — 5 parked as "refinable" (div <= 20, deferred to the refine tier) and 1 on a floor mark. Those five have sat at div 2-12 long enough that clearly nothing picked them up. The two pools are meant to be complementary and there is a gap between them. Not fixed here; it needs a decision about which tier actually owns a stalled refinable draft.