### PR TITLE
tools: stop schedulers offering settled asm primitives

### DIFF
--- a/tools/cluster_targets.py
+++ b/tools/cluster_targets.py
@@ -105,9 +105,9 @@ def main():
             continue
         # A committed src/ file is the portable is-it-matched signal (matched.jsonl is
         # gitignored). A "// NONMATCHING" draft is NOT matched and stays a valid target,
-        # same rule coddog uses.
+        # but one settled under the asm-primitive policy is done and must not be offered.
         src = WL.read_src_text(name)
-        if src is not None and "// NONMATCHING" not in src[:200]:
+        if src is not None and ("// NONMATCHING" not in src[:200] or WL.is_policy_done(src)):
             continue
         code = a9[ad - BASE: ad - BASE + sz]
         cs = callees(code, ad, sz)

--- a/tools/coddog.py
+++ b/tools/coddog.py
@@ -100,6 +100,11 @@ def build_corpus():
             if src is not None and not hatch:
                 rec["src"] = src
                 matched.append(rec)
+            elif hatch and WL.is_policy_done(src):
+                # Settled under the asm-primitive policy: assembly WAS the original source,
+                # so there is no C to recover. Belongs in NEITHER pool - not a target, and
+                # not a sibling example either, since the body is asm rather than real C.
+                continue
             elif (label, addr) not in parked and not S.is_thunk(list(S.md.disasm(tgt, 0))):
                 # A hatch is never a valid SIBLING, but it is still a legitimate TARGET: most
                 # hatches are just old drafts, not proven walls (only a handful carry a floor

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -81,6 +81,35 @@ def read_src_text(name):
     return texts[0] if texts else None
 
 
+# A committed `// NONMATCHING` file means one of two very different things, and both
+# header families open with "hand-written asm", so the banner alone cannot separate them:
+#
+#   SETTLED  "// NONMATCHING (ASM-PRIMITIVE): ... no match to chase. Counts as done
+#             under the asm-primitive policy"      -> assembly WAS the original source.
+#   OWES C   "// NONMATCHING: hand-written asm ... does NOT count as matched. Reverts to
+#             a draft until someone reproduces the bytes from real C"  -> still open work.
+#
+# Only the second is a legitimate target. Schedulers that tested for the banner alone
+# treated both as open drafts and kept handing out settled assembly: #822 was a whole
+# agent run that re-emitted an asm block already committed under the other extension.
+_SETTLED_TAGS = ("NONMATCHING (ASM-PRIMITIVE)", "NONMATCHING (NOT-C-EXPRESSIBLE)")
+_SETTLED_PHRASES = ("counts as done", "no match to chase", "nothing here to match")
+_OWES_C = "does not count as matched"
+
+
+def is_policy_done(src):
+    """True when a committed NONMATCHING file is SETTLED under notes/asm-policy.md
+    rather than an open draft. Never offer these as targets; they are also not valid
+    sibling examples, since the body is assembly rather than recovered C."""
+    if not src:
+        return False
+    head = src[:600]
+    low = head.lower()
+    if _OWES_C in low:                      # explicitly still owes a C decompilation
+        return False
+    return any(t in head for t in _SETTLED_TAGS) or any(p in low for p in _SETTLED_PHRASES)
+
+
 def target_is_done(done, label, addr, name):
     """Treat the source tree as authoritative when the generated ledger lags."""
     return ((label, addr) in done


### PR DESCRIPTION
Tools only, no `src/` change. Follow-up to #820, and the direct cause of #822.

## Why #822 happened

A committed `// NONMATCHING` file means one of two very different things, and **both header families open with "hand-written asm"**, so testing for the banner cannot separate them:

| | header | meaning |
|---|---|---|
| **SETTLED** | `// NONMATCHING (ASM-PRIMITIVE): ... no match to chase. Counts as done under the asm-primitive policy` | assembly WAS the original source |
| **OWES C** | `// NONMATCHING: hand-written asm ... does NOT count as matched. Reverts to a draft until someone reproduces the bytes from real C` | still open work |

Only the second is a target. Every scheduler tested the banner alone, so settled assembly stayed in the pool. #822 is what that costs: an agent was handed `func_02058568`, which is already committed as an asm primitive, and spent a full run re-emitting the same asm block under a second extension.

chaos-db has the same blind spot from the other direction — it reports `matched=false` for these — which is what made arm9 read as **49 remaining when the real figure was 13**.

## The fix

`worklist.py` gains `is_policy_done()`. It keys on the parenthetical tag plus the "counts as done" phrasing, and explicitly returns `False` when the header says "does NOT count as matched", so the two families cannot be confused.

`coddog` drops settled entries from **both** pools — not a target, and not a sibling example either, since the body is assembly rather than recovered C. `cluster_targets` applies the same rule.

## Effect

| class | count | schedulable? |
|---|---|---|
| settled asm primitives | 32 | **no longer** |
| asm hatches that owe C | 10 | yes |
| plain NONMATCHING drafts | 59 | yes |

coddog's arm9 unmatched pool goes **186 -> 160**.

## Verification

Tested against all three header families, with the park filter bypassed to isolate this change:

- settled (`func_02058568`, `func_0206a928`, `func_02057014`, `func_020729e8`, `func_02059d8c`) — all absent
- owes-C (`func_0206470c`, `func_02068398`, `func_02071644`, `func_020610fc`) — all still present
- plain draft (`func_02038824`) — still present

`test_worklist.py` 4/4, plus end-to-end smoke tests of coddog, cluster_targets and worklist.