### PR TITLE
Replace the expired Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Discord Server][discord-badge]][discord]
 
-[discord]: https://discord.gg/JXckvdARc
+[discord]: https://discord.gg/YpReERF4e3
 [discord-badge]: https://img.shields.io/discord/1520811338568569112?color=7289DA&logo=discord&logoColor=ffffff
 
 A from-scratch decompilation (decomp) of **Super Mario 64 DS** into matching C.

--- a/tangos.json
+++ b/tangos.json
@@ -9,7 +9,7 @@
     "platform": "nds",
     "compiler": "mwccarm 1.2/sp2p3. Flags (C): -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc",
     "cppNote": "If a name starts with _Z (C++ mangled), write C++ with the FIRST LINE exactly //cpp",
-    "discord": "https://discord.gg/JXckvdARc",
+    "discord": "https://discord.gg/YpReERF4e3",
     "setup": "clone {github} and follow CONTRIBUTING.md (python deps + mwccarm from the DS-decomp Discord + tools/unpack.py on YOUR OWN cartridge dump).",
     "verifyCommand": "python tools/match.py --c yourfile.c --func {name} --addr 0x{addrHex} --size 0x{sizeHex} --version 1.2/sp2p3",
     "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via CLAIMS.md.",

--- a/tools/chaosviewer.config.json
+++ b/tools/chaosviewer.config.json
@@ -10,7 +10,7 @@
   "verifyCommand": "python tools/match.py --c yourfile.c --func {name} --addr 0x{addrHex} --size 0x{sizeHex} --version 1.2/sp2p3",
   "readFirst": "notes/mwccarm-codegen.md (esp. sec 6e-6g levers: u64-mask laundering for materialized bases, declaration/statement order for register coloring, //cpp dummy-vtable dispatch, struct-copy interleave) and notes/pret-idioms.md. Coordinate via CLAIMS.md.",
   "rules": "only your own legally dumped ROM; never commit the ROM, its assets, or extracted binaries - the one deliberate exception is the annotated disassembly TEXT of still-unmatched functions, published in the coordination data (chaos-data branch) so contributors can work, the same practice as decomp repos committing .s files; import struct/field knowledge (see CREDITS.md) but write all C from scratch.",
-  "discord": "https://discord.gg/JXckvdARc",
+  "discord": "https://discord.gg/YpReERF4e3",
   "claimsApi": "https://tangos.dev/api/claims",
   "claimsAuthUrl": "https://tangos.dev/auth/github/start",
   "nearMissNote": "If a function will not fully match after real effort, do not discard your best attempt - it is still valuable. Open a PR anyway with your closest compiling draft as src/<name>.c, headed by one line: // NONMATCHING: <what still differs> (div=N, from the verify output). Near-miss drafts are the highest-yield input to this project's refine tier - most matches now start from someone's stored near-miss, and a close draft is usually finished within a day.",


### PR DESCRIPTION
The Discord badge at the top of the README links to `discord.gg/JXckvdARc`, which the Discord API reports as:

```
Invite is expired  (code 50270)
```

So anyone trying to join the project chat from the repo lands on a dead page. The same dead code was also in `tangos.json` and `tools/chaosviewer.config.json`.

Replaced with a permanent invite to **the same server** — guild `1520811338568569112`, "Tango's Decomp Jamboree", which is the guild the badge already references, so the member-count badge and the link now agree. Verified through the Discord API: valid, no expiry.

The other invite in the README, `discord.com/invite/gwN6M3HQrA`, is the separate **DS Decompilation** server used for fetching mwccarm. Still live, left alone.

Found while adding a chat section to the new tangOS-decomps org profile — I checked the invite before linking it rather than copying it across, which is how the expiry surfaced.