### PR TITLE
tools: sigaudit.py — find near-miss drafts with wrong function signatures

### DIFF
--- a/tools/sigaudit.py
+++ b/tools/sigaudit.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Audit near-miss drafts for wrong function signatures, using matched src/ as ground truth.
+
+A wrong arity costs argument-setup instructions, so it shows up as a small size mismatch or a
+couple of divergent words -- and it is invisible to codegen-shape debugging, because the C looks
+fine. It has buried at least three otherwise-correct drafts in this repo, so it is worth checking
+BEFORE grinding shape.
+
+Two independent checks, both pure static analysis (no compiles):
+
+  A. The draft's OWN parameter count vs how already-matched code CALLS it.
+  B. The draft's `extern` callee prototypes vs those callees' REAL definitions in matched src/.
+
+Ground truth is only ever taken from files that byte-reproduce the ROM: files containing
+`// NONMATCHING` are skipped, since their codegen (and often their signatures) are not authoritative.
+
+Usage:
+    python tools/sigaudit.py                      # audit every draft in nearmiss/db.jsonl
+    python tools/sigaudit.py --name func_ov007_020c6550
+    python tools/sigaudit.py --json out.json
+
+Caveats worth knowing before you trust a hit:
+  * `f()` in C means UNSPECIFIED parameters, not zero. Those are skipped, not flagged.
+  * Check A treats the majority arg-count across call sites as truth; a function called through a
+    mixture of prototypes can produce a false hit. Always eyeball the reported call sites.
+  * A caller's translation unit can legitimately pass MORE arguments than the callee's definition
+    uses -- a cross-TU prototype mismatch baked into the original build. Observed on
+    func_ov006_020ec84c: the ROM does `mov r0,r6; mov r1,r5; bl ...` while that callee's matched
+    definition takes one parameter, so the draft's 2-arg call was already correct. That is history,
+    not a bug, and it is NOT statically detectable from src/ alone -- only the disassembly at the
+    call site settles it. Expect roughly half of check-B hits to be this or a veneer.
+  * Nothing here is auto-fixable. Correcting an arity means deciding WHAT to pass, which has to come
+    from the disassembly at the call site. Read the ROM, do not guess.
+"""
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import sys
+
+CALL_RE = re.compile(r'\b(func_(?:ov\d+_)?[0-9a-f]{8})\s*\(')
+TYPE_KEYWORDS = ('char', 'int', 'void', 'unsigned', 'signed', 'short', 'long', 'struct',
+                 'float', 'const', 'u8', 'u16', 'u32', 's8', 's16', 's32', 'bool')
+
+
+def strip_comments(s):
+    s = re.sub(r'/\*.*?\*/', '', s, flags=re.S)
+    return re.sub(r'//[^\n]*', '', s)
+
+
+def split_args(s):
+    """Split a parenthesised argument list on top-level commas."""
+    out, depth, cur = [], 0, ''
+    for ch in s:
+        if ch in '([{':
+            depth += 1
+        elif ch in ')]}':
+            depth -= 1
+        if ch == ',' and depth == 0:
+            out.append(cur.strip())
+            cur = ''
+        else:
+            cur += ch
+    if cur.strip():
+        out.append(cur.strip())
+    return out
+
+
+def paren_span(text, i):
+    """text[i] must be '('. Returns (inner_text, index_after_close)."""
+    depth = 0
+    for j in range(i, len(text)):
+        if text[j] == '(':
+            depth += 1
+        elif text[j] == ')':
+            depth -= 1
+            if depth == 0:
+                return text[i + 1:j], j + 1
+    return None, None
+
+
+def nargs(inner):
+    args = split_args(inner)
+    if not args or (len(args) == 1 and args[0].replace(' ', '') == 'void'):
+        return 0
+    return len(args)
+
+
+def _already_matched(repo, name):
+    """True only if src/<name> exists AND byte-reproduces (i.e. is not a NONMATCHING hatch)."""
+    for ext in ('.c', '.cpp'):
+        path = os.path.join(repo, 'src', name + ext)
+        if not os.path.exists(path):
+            continue
+        try:
+            head = open(path, encoding='utf-8', errors='ignore').read(400)
+        except OSError:
+            return False
+        return 'NONMATCHING' not in head
+    return False
+
+
+def matched_sources(repo):
+    """Yield (stem, text) for every src/ file that byte-reproduces the ROM."""
+    for path in sorted(glob.glob(os.path.join(repo, 'src', '*.c')) +
+                       glob.glob(os.path.join(repo, 'src', '*.cpp'))):
+        try:
+            text = open(path, encoding='utf-8', errors='ignore').read()
+        except OSError:
+            continue
+        if 'NONMATCHING' in text[:400]:
+            continue                      # not authoritative -- does not reproduce the ROM
+        yield os.path.basename(path).rsplit('.', 1)[0], strip_comments(text)
+
+
+def build_indexes(repo):
+    """definitions: name -> param count (from the DEFINITION), calls: name -> Counter(argcount)."""
+    definitions, calls = {}, collections.defaultdict(collections.Counter)
+    for stem, text in matched_sources(repo):
+        for m in re.finditer(r'\b(%s)\s*\(' % re.escape(stem), text):
+            inner, after = paren_span(text, m.end() - 1)
+            if inner is None or '{' not in text[after:after + 3]:
+                continue                  # a prototype, not the definition
+            definitions[stem] = nargs(inner)
+            break
+        for m in CALL_RE.finditer(text):
+            name = m.group(1)
+            if name == stem:
+                continue                  # skip the file's own definition/prototype
+            inner, after = paren_span(text, m.end() - 1)
+            if inner is None:
+                continue
+            if any(k in inner for k in TYPE_KEYWORDS):
+                continue                  # looks like a prototype, not a call
+            calls[name][nargs(inner)] += 1
+    return definitions, calls
+
+
+def audit(repo, only=None):
+    definitions, calls = build_indexes(repo)
+    db = os.path.join(repo, 'nearmiss', 'db.jsonl')
+    own_bad, callee_bad = [], []
+    with open(db, 'rb') as fh:
+        raw = fh.read()
+    for line in raw.split(b'\n'):
+        if not line.strip():
+            continue
+        d = json.loads(line.decode('utf-8', 'replace'))
+        name, src = d.get('name') or '', d.get('c_source')
+        if not src or (only and name != only):
+            continue
+        # Skip drafts whose function is already a REAL match -- auditing those re-solves solved work.
+        # Crucially, a `// NONMATCHING` hatch in src/ does NOT count as solved: the function is still
+        # shipped as hand-written asm, and its banked C draft is exactly what is needed to retire the
+        # hatch. Two hatches (func_ov007_020c6550, func_ov006_020cb72c) were retired from such drafts
+        # on 2026-07-30, and a naive "exists in src/" filter would have hidden both. As of that date
+        # 61 of the 62 drafts with a src/ file are hatches; only 1 is genuinely stale.
+        if _already_matched(repo, name):
+            continue
+        text = strip_comments(src)
+
+        # --- A: the draft's own arity vs how matched code calls it ---
+        for m in re.finditer(r'\b%s\s*\(' % re.escape(name), text):
+            inner, after = paren_span(text, m.end() - 1)
+            if inner is None or '{' not in text[after:after + 3]:
+                continue
+            observed = calls.get(name)
+            if observed:
+                majority = max(observed.items(), key=lambda kv: kv[1])[0]
+                if majority != nargs(inner):
+                    own_bad.append(dict(name=name, draft=nargs(inner), callers=majority,
+                                        sites=dict(observed),
+                                        divergences=d.get('divergences')))
+            break
+
+        # --- B: the draft's extern callee prototypes vs the real definitions ---
+        for m in re.finditer(r'\bextern\b[^;{]*?\b(func_(?:ov\d+_)?[0-9a-f]{8})\s*\(', text):
+            callee = m.group(1)
+            inner, after = paren_span(text, m.end() - 1)
+            if inner is None or callee not in definitions:
+                continue
+            if inner.strip() == '':
+                continue                  # f() is UNSPECIFIED args in C, not zero -- not a bug
+            if nargs(inner) == definitions[callee]:
+                continue
+            # A definition alone is NOT trustworthy ground truth. Tail-call veneers and thunks are
+            # defined `(void)` because the body never names the argument, while the real calling
+            # convention still passes it -- e.g. func_020383fc is defined `void func_020383fc(void)`
+            # but is a veneer to a C++ method and every matched caller passes `this` in r0. Only
+            # flag when the definition AND the matched call sites agree with each other and both
+            # disagree with the draft.
+            observed = calls.get(callee)
+            if observed:
+                majority = max(observed.items(), key=lambda kv: kv[1])[0]
+                if majority != definitions[callee]:
+                    continue              # definition and call sites disagree -> untrustworthy
+                if majority == nargs(inner):
+                    continue              # draft agrees with real usage
+            callee_bad.append(dict(name=name, callee=callee, draft=nargs(inner),
+                                   real=definitions[callee],
+                                   call_sites=dict(observed) if observed else None,
+                                   divergences=d.get('divergences')))
+    return own_bad, callee_bad, len(definitions)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--repo', default='.', help='decomp root (default: cwd)')
+    ap.add_argument('--name', help='audit a single near-miss by symbol name')
+    ap.add_argument('--json', help='write full findings to this path')
+    args = ap.parse_args()
+
+    own_bad, callee_bad, ndefs = audit(args.repo, args.name)
+
+    def key(rec):
+        dv = rec.get('divergences')
+        return dv if isinstance(dv, int) else 10 ** 6
+
+    print('indexed %d matched definitions\n' % ndefs)
+    print('=== A: draft arity disagrees with matched call sites (%d) ===' % len(own_bad))
+    for r in sorted(own_bad, key=key):
+        print('  %-44s div=%-6s draft=%s callers=%s  sites=%s'
+              % (r['name'], r['divergences'], r['draft'], r['callers'], r['sites']))
+    print('\n=== B: extern callee prototype disagrees with real definition (%d) ===' % len(callee_bad))
+    for r in sorted(callee_bad, key=key):
+        print('  %-44s div=%-6s %s: draft=%s real=%s'
+              % (r['name'], r['divergences'], r['callee'], r['draft'], r['real']))
+
+    if args.json:
+        with open(args.json, 'w', encoding='utf-8') as fh:
+            json.dump({'own_arity': own_bad, 'callee_prototypes': callee_bad}, fh, indent=1)
+        print('\nwrote %s' % args.json)
+    return 1 if (own_bad or callee_bad) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Tools-only, one new file. No `src/`, no notes, no CI changes.

## Why

A wrong arity costs argument-setup instructions, so it surfaces as a **small size mismatch or a
couple of divergent words** — and it is invisible to codegen-shape debugging, because the C itself
looks correct. It has now buried **four** otherwise-correct drafts in this repo, including one whose
key insight was written off entirely over an unrelated callee-arity error.

Checking costs nothing: pure static analysis against matched `src/`, no compiles.

## What it does

- **Check A** — the draft's own parameter count vs how already-matched code *calls* it.
- **Check B** — the draft's `extern` callee prototypes vs those callees' *real* definitions.

Ground truth is only ever taken from files that byte-reproduce the ROM; `// NONMATCHING` files are
skipped, since their signatures are not authoritative.

```
python tools/sigaudit.py                        # audit every draft in nearmiss/db.jsonl
python tools/sigaudit.py --name func_ov007_020c6550
python tools/sigaudit.py --json findings.json
```

## Three false-positive classes are handled — each found the hard way

1. **`f()` means UNSPECIFIED parameters in C, not zero.** Skipped, not flagged. An earlier version
   flagged every such prototype.
2. **Prototypes masquerading as call sites.** Argument text containing type keywords is treated as a
   declaration and excluded from the call-site tally.
3. **Tail-call veneers and thunks are defined `(void)` while the real convention still passes
   arguments.** `func_020383fc` is defined `void func_020383fc(void)` but is a veneer to a C++
   method, and every matched caller correctly passes `this` in r0. An agent caught this by reading
   the disassembly after my audit sent it chasing a bug that did not exist. Check B now requires the
   definition **and** the matched call sites to agree with each other before flagging — that alone
   removed **13 of 31** raw hits.

## Current findings

**6** in check A, **18** in check B. Two of the original hits are already resolved:
`func_ov007_020bc02c` (#838) and `func_ov007_020c6550` (#839) — the latter replacing a hand-written
**asm hatch** with real C, since the missing argument was the wall its own comment documented.

## Deliberately not auto-fixing

Correcting an arity means deciding *what to pass*, which has to be read out of the disassembly at the
call site — on `func_ov007_020c6550` the second argument turned out to be `*(int*)(c+8)`, recoverable
only from what sits in r1 before the `bl`. An automated rewrite would guess, producing drafts that
look fixed but are not. The tool reports; a human or agent reads the ROM.
