### PR TITLE
PROPOSAL (draft, do not merge): shared headers pilot — requires `-i include` on the build box

### DIFF
--- a/include/launder.h
+++ b/include/launder.h
@@ -1,0 +1,25 @@
+#ifndef LAUNDER_H
+#define LAUNDER_H
+
+/* Compiler-steering macros. These are NOT how the original source was written.
+ *
+ * mwccarm folds a memory access onto a 12-bit immediate offset when it can. The ROM,
+ * however, materializes a separate address register for every read-modify-write site
+ * (either via a pool constant or an explicit `add rD, base, #imm`) while folding every
+ * single-use load/store. Masking the address through a no-op 64-bit AND blocks that
+ * fold and reproduces the ROM's shape.
+ *
+ * Rules:
+ *   - Apply ONLY to read-modify-write sites. Laundering a single-use access diverges.
+ *   - Use a DIFFERENT macro for each distinct address in one function. A single shared
+ *     macro lets mwccarm CSE the laundered addresses together, which inflates the frame.
+ *     The three spellings differ only in the inner cast; all are identical on a 32-bit
+ *     target, but they land in different value-numbering classes.
+ *
+ * See notes/matching-style.md, "RMW base materialization".
+ */
+#define LAUNDER_A(a) (*(int *)(((long long)(int)(a))      & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER_B(a) (*(int *)(((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER_C(a) (*(int *)(((long long)(long)(a))     & 0xFFFFFFFFFFFFFFFFLL))
+
+#endif /* LAUNDER_H */

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,26 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+/* Fixed-width integer types used throughout the decomp.
+   Previously re-declared locally in 1106 src/ files. */
+typedef unsigned char  u8;
+typedef unsigned short u16;
+typedef unsigned int   u32;
+typedef signed char    s8;
+typedef signed short   s16;
+typedef signed int     s32;
+
+/* 20.12 fixed-point scalar, as used by the SDK/game maths.
+   Fix12i is the spelling used by most existing src/ files; both are the same type. */
+typedef s32 Fix12;
+typedef s32 Fix12i;
+
+typedef struct Vector3 {
+    Fix12i x, y, z;
+} Vector3;
+
+typedef struct Vector3s {
+    s16 x, y, z;
+} Vector3s;
+
+#endif /* TYPES_H */

--- a/src/func_ov002_020d869c.cpp
+++ b/src/func_ov002_020d869c.cpp
@@ -1,12 +1,7 @@
 //cpp
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 
-typedef struct { s32 x, y, z; } Vector3;
 struct PVec { s32 x, y, z; ~PVec() {} };
-typedef s32 Fix12;
 
 extern "C" {
 extern char *_ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov006_020fe750.c
+++ b/src/func_ov006_020fe750.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern void func_ov006_020fbbe8(char* c);

--- a/src/func_ov006_02114c04.c
+++ b/src/func_ov006_02114c04.c
@@ -1,8 +1,5 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 
-typedef struct Vector3 { Fix12i x, y, z; } Vector3;
 
 extern Fix12i func_0203d614(const Vector3* v);
 extern int func_0203d434(Fix12i* in);
@@ -12,9 +9,10 @@ extern void func_0203d388(int *p, int angle);
 
 extern int data_0209d4b8;
 
-#define L(a) (*(int*)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
-#define M(a) (*(int*)(((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL))
-#define N(a) (*(int*)(((long long)(long)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#include "launder.h"
+#define L LAUNDER_A
+#define M LAUNDER_B
+#define N LAUNDER_C
 
 void func_ov006_02114c04(char* o)
 {


### PR DESCRIPTION
**Draft / proposal. `validate` will be RED on this branch and that is expected** — please do not merge
before the build-box change below is agreed. Opening it as evidence for a decision, not as work to land.

## The ask (one line)

Add **`-i include`** to the compiler flags on the private validate box. That is the entire dependency.

Note the spelling: mwccarm wants `-i include` (lowercase). Plain `-I include` fails; `-I` needs the
`+` form. I lost a compile to this before finding it in `mwccarm --help`.

## Why

`src/` has **no headers at all**. Today:

| | count |
|---|---|
| files re-declaring `typedef unsigned short u16` | 1,106 |
| files defining their own private `Vector3` | 96 |
| files carrying copies of the same no-op mask macros | 1,652 |
| files addressing structures as raw `(c + 0xNNN)` casts | 2,615 (23%) |

The last row is the substance of recent outside criticism that the code doesn't read like human
source, and it follows from the first three: with no shared types, raw offsets are the path of least
resistance. You cannot write `player->velocity.y` if there is nowhere to define `Player`.

## What this pilot does — and does not — do

It changes **no codegen**. It only proves the mechanism works:

- **`include/types.h`** — `u8`…`s32`, `Fix12` (plus the `Fix12i` spelling most files already use),
  `Vector3`, `Vector3s`.
- **`include/launder.h`** — the compiler-steering mask macros, with the rules written down: RMW sites
  only, and a *distinct* macro per address within one function or mwccarm CSEs them together and
  inflates the frame. Documented explicitly as **not** how the original was written.
- Three `src/` files converted as proof, one of them C++.

## Verification

| check | result |
|---|---|
| 3 converted files, `2004/b56` **and** `1.2/sp2p3`, with `-i include` | byte-identical |
| an **unconverted** file with the same flags | unaffected |
| a converted file **without** the flag | compile failure |

That last row is the point: it is what makes this a build change rather than a cleanup PR, and why
merging it early would break CI.

## One finding worth keeping

Converting a `.cpp` also requires deleting its local anonymous `typedef struct { s32 x, y, z; } Vector3;`
and `typedef s32 Fix12;`. C tolerates the duplicate typedef; **C++ rejects the redefinition.** So a
bulk conversion cannot be a single regex across both languages.

## If accepted, the next step is the real one

Types are the point; this is only the plumbing. The follow-up is to recover **one actual struct** — the
ov006 actor is the natural first, since matched functions already pin the entity array at `+0x4660`
(stride `0x40`), a counter at `+0x5670` and a flag byte at `+0x4c21` — convert a handful of files to
named fields, re-verify each, and then gate new files on using a named type rather than a bare cast.

Without that gate the style regresses, which is why I'd rather agree the direction than land cleanup.
