### PR TITLE
Match GX::LoadTex byte-identical (mwccarm 1.2/sp2p3)

### DIFF
--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -2462,3 +2462,18 @@ void func_02071644(void *obj, int len) {   /* decimal digit-string increment w/ 
 `bx lr` is byte 0x50-0x53.) Rule: when a tiny symbol is a bare epilogue, a lone `bx lr`, or
 a catch-island shape (starts mid-frame, uses fp/r4-r7 it never set), check whether the
 PREVIOUS symbol's compiled form simply extends over it before believing any floor label.
+
+## 6an. Signedness is a coloring lever separable from condition codes (2026-07-30, GX::LoadTex)
+
+GX::LoadTex sat at div=16 as a pure r4/r5 web-identity swap (`base`->r4/`top`->r5 vs the
+ROM's r5/r4) with both locals typed `unsigned int`. Retyping BOTH as plain `int` flips the
+allocator's rank assignment and lands the ROM's coloring (16->7). Signed vs unsigned is a
+RANK input like the local's width (6al): int and unsigned int locals do not rank equally.
+
+The catch and the second half of the lever: the retype drags the COMPARISONS signed
+(`lt/ge` where the ROM has `lo/hs`, 7 residual divs). Do NOT fix that with `(int)` casts
+on the operands - fix it by leaving the comparisons in mixed signed/unsigned form so C's
+usual arithmetic conversions promote them back to unsigned (`int top` vs `unsigned offset`
+compares unsigned, emitting lo/hs) while the LOCALS keep their signed rank. Coloring reads
+the declared type; the condition code reads the promoted comparison type. The two are
+independently steerable (7->0, byte-identical, 1.2/sp2p3).

--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -2477,3 +2477,10 @@ usual arithmetic conversions promote them back to unsigned (`int top` vs `unsign
 compares unsigned, emitting lo/hs) while the LOCALS keep their signed rank. Coloring reads
 the declared type; the condition code reads the promoted comparison type. The two are
 independently steerable (7->0, byte-identical, 1.2/sp2p3).
+
+Scope check (same night): a mechanical signedness sweep (singles, pairs, all-flip; 581
+compiles) across the seven other stuck arm9 residues (0202ffec, CapEnemy::GetCapState,
+Stage::InitResources, 0204a730, 020412f0, Stage::PS_UpdateOkAndBackButtons, 02038824)
+moved NOTHING. The lever fires when the residue is a two-local callee-saved web-identity
+swap; it does not perturb scheduling knots or wider coloring webs. Sweep script pattern:
+flip (unsigned int|int|u32|s32) decls in the bank draft, abverify each.

--- a/notes/mwccarm-codegen.md
+++ b/notes/mwccarm-codegen.md
@@ -2484,3 +2484,28 @@ Stage::InitResources, 0204a730, 020412f0, Stage::PS_UpdateOkAndBackButtons, 0203
 moved NOTHING. The lever fires when the residue is a two-local callee-saved web-identity
 swap; it does not perturb scheduling knots or wider coloring webs. Sweep script pattern:
 flip (unsigned int|int|u32|s32) decls in the bank draft, abverify each.
+
+## 6ao. Flag-across-call rematerialization, and the for(;;) dead epilogue (2026-07-30, func_02072168)
+
+Two finds from the deep pass on the WM bytecode dispatcher (both currently OPEN, no
+counter-lever known):
+
+1. **mwccarm refuses to hold a cheap flag live across calls.** The ROM computes
+`and rX, op, #mask` into a callee-saved register BEFORE two `bl`s and does a bare
+`cmp rX, #0` after. Every mwccarm spelling instead REMATERIALIZES (`ands r1, op, #mask`)
+at the use site - the inverse of the usual too-much-CSE problem. Inert or worse:
+`volatile int` (stack spill, wrong shape), `unsigned char` (spurious narrowing AND),
+`(op & mask) != 0` bool cast (much worse), statement reordering,
+`#pragma opt_common_subs off` (regressed), `#pragma opt_propagation off` (regressed).
+The heuristic looks like remat-if-cheaper-than-spill with no source knob found yet. It
+recurs in ~10 of the dispatcher's 20 cases and dominates its div=195. Any future crack
+of this pattern unlocks func_02072168 nearly whole.
+
+2. **`for(;;)` containing a predicated early `return` emits a dead unreachable trailing
+epilogue** (20-byte minimal repro). `while(1)` and goto-loop forms behave identically;
+`#pragma optimize_for_size on` converts the predicated return to a branch-to-shared-tail
+(reachable, but not the ROM's predicated shape). If a target ROM function has NO dead
+epilogue but ours does, the ROM's early-exit idiom differs from a plain in-loop return -
+treat the dead-epilogue delta as a diagnostic fingerprint, not noise. (Related: 6al's
+trailing-bx-lr note - mwccarm appends one after a for(;;) whose exits are all early
+returns; that one the ROM DOES keep.)

--- a/src/_ZN2GX7LoadTexEPKvjj.cpp
+++ b/src/_ZN2GX7LoadTexEPKvjj.cpp
@@ -1,8 +1,11 @@
 //cpp
-// NONMATCHING: register allocation (div=41). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
-extern "C" void DMASyncWordTransfer(unsigned char channel, unsigned int src, unsigned int dest, unsigned int len);
+/* _ZN2GX7LoadTexEPKvjj (GX::LoadTex) @ 0x02056a50 (arm9, size 0x14c)   [mwccarm 1.2/sp2p3]
+ * VRAM texture upload with banked destination: below-top goes to the base window,
+ * above-top to the secondary bank, straddling splits into two DMA (or CPU copy)
+ * halves. Lever that matched: base/top typed as plain int (r4/r5 web identity),
+ * comparisons left to natural unsigned promotion for lo/hs condition codes.
+ */
+extern "C" void DMASyncWordTransfer(unsigned int channel, void const *src, void *dest, unsigned int len);
 extern "C" void func_02059fd0(int ch, int src, int dst, unsigned int size, void (*cb)(int), int cbarg);
 extern "C" void MultiCopy_Int(int *src, int *dst, int len);
 
@@ -14,33 +17,33 @@ extern int data_02099fd0;
 namespace GX {
 void LoadTex(void const *src, unsigned int offset, unsigned int size) {
     unsigned int dst;
-    unsigned int base = data_020a60bc;
+    int base = data_020a60bc;
     if (base == 0) {
         dst = data_020a60ac + offset;
     } else {
-        unsigned int top = data_020a60c0;
+        int top = data_020a60c0;
         if (offset + size < top) {
             dst = data_020a60ac + offset;
         } else if (offset >= top) {
             dst = base + offset - top;
         } else {
-            int len = top - offset;
+            top -= offset;
             unsigned int d0 = data_020a60ac + offset;
             int ch = data_02099fd0;
             if (ch != -1) {
-                DMASyncWordTransfer(ch, (unsigned int)src, d0, len);
-                func_02059fd0(data_02099fd0, (int)((char*)src + len), base, size - len, 0, 0);
+                DMASyncWordTransfer(ch, src, (void*)d0, top);
+                func_02059fd0(data_02099fd0, (int)((char*)src + top), base, size - top, 0, 0);
                 return;
             }
-            MultiCopy_Int((int*)src, (int*)d0, len);
-            MultiCopy_Int((int*)((char*)src + len), (int*)base, size - len);
+            MultiCopy_Int((int*)src, (int*)d0, top);
+            MultiCopy_Int((int*)((char*)src + top), (int*)base, size - top);
             return;
         }
     }
-    if (data_02099fd0 == -1) {
-        MultiCopy_Int((int*)src, (int*)dst, size);
+    if (data_02099fd0 != -1) {
+        func_02059fd0(data_02099fd0, (int)src, dst, size, 0, 0);
         return;
     }
-    func_02059fd0(data_02099fd0, (int)src, dst, size, 0, 0);
+    MultiCopy_Int((int*)src, (int*)dst, size);
 }
 }


### PR DESCRIPTION
Upgrades src/_ZN2GX7LoadTexEPKvjj.cpp from NONMATCHING (regalloc, div=41) to a byte-identical match at 1.2/sp2p3. Verified twice locally: abverify MATCH against the banked target bytes, and linkcheck VERIFIED (0 diffs, 0 blind spots) at 0x02056a50.

Lever writeup added as notes section 6an: local signedness is an allocator rank input separable from comparison condition codes.

Built with Claude Code