### PR TITLE
Convert 1398 functions to C++ class files and add C++ conversion guide

### DIFF
--- a/src/ActorDerived.cpp
+++ b/src/ActorDerived.cpp
@@ -1,0 +1,53 @@
+//cpp
+typedef unsigned int u32;
+
+struct Heap;
+struct Obj { void *vtable; };
+
+struct ActorBase {
+    void *vtable;
+    virtual void AfterInitResources(u32 result);
+    void MarkForDestruction();
+};
+
+struct ActorDerived : public ActorBase {
+    virtual void AfterInitResources(u32 result);
+};
+
+extern "C" {
+extern void *vtbl_ActorDerived[];
+extern void *_ZTV12ActorDerived[];
+void base_dtor_ActorDerived(void *);
+void _ZN9ActorBaseD2Ev(void *);
+void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, Heap *heap);
+extern Heap *_ZN6Memory11gameHeapPtrE;
+void func_02042ffc(void);
+void _ZN9ActorBase18AfterInitResourcesEj(void *, u32);
+
+struct Obj *_ZN12ActorDerivedD1Ev(struct Obj *thiz)
+{
+    thiz->vtable = (void *)vtbl_ActorDerived;
+    base_dtor_ActorDerived(thiz);
+    return thiz;
+}
+
+ActorDerived *_ZN12ActorDerivedD0Ev(ActorDerived *thiz)
+{
+    *(void ***)thiz = (void **)_ZTV12ActorDerived;
+    _ZN9ActorBaseD2Ev(thiz);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, _ZN6Memory11gameHeapPtrE);
+    return thiz;
+}
+
+void _ZN12ActorDerived5SpawnEjP9ActorBaseii(void) {
+    func_02042ffc();
+}
+}
+
+void ActorDerived::AfterInitResources(u32 result)
+{
+    if (result == 1) {
+        this->MarkForDestruction();
+    }
+    _ZN9ActorBase18AfterInitResourcesEj(this, result);
+}

--- a/src/_ZN10BowserTail13InitResourcesEv.cpp
+++ b/src/_ZN10BowserTail13InitResourcesEv.cpp
@@ -1,9 +1,16 @@
 //cpp
 extern "C" {
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *actor, int fix, int t, unsigned int e, unsigned int f);
-int _ZN10BowserTail13InitResourcesEv(char *c)
-{
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0x32000, 0x50000, 0x800000, 0x1000);
-    return 1;
 }
+
+struct BowserTail {
+    int InitResources();
+};
+
+int BowserTail::InitResources()
+{
+    char * c = (char *)this;
+_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0x32000, 0x50000, 0x800000, 0x1000);
+    return 1;
+
 }

--- a/src/_ZN10BrickBlock13InitResourcesEv.cpp
+++ b/src/_ZN10BrickBlock13InitResourcesEv.cpp
@@ -6,8 +6,16 @@ extern void LoadSilverStarAndNumber(void);
 extern int data_ov002_0210d9d8;
 extern int data_ov002_0210da30;
 extern int data_ov002_0210da18;
-int _ZN10BrickBlock13InitResourcesEv(char* c) {
-    *(signed char*)(c+0xd4) = *(int*)(c+8) & 0x7f;
+}
+
+struct BrickBlock {
+    int InitResources();
+};
+
+int BrickBlock::InitResources()
+{
+    char* c = (char*)this;
+*(signed char*)(c+0xd4) = *(int*)(c+8) & 0x7f;
     if (*(signed char*)(c+0xd4) == 0x7f) *(signed char*)(c+0xd4) = 0;
     switch (*(unsigned short*)(c+0xc)) {
     case 0x141:
@@ -29,5 +37,5 @@ int _ZN10BrickBlock13InitResourcesEv(char* c) {
         break;
     }
     return 1;
-}
+
 }

--- a/src/_ZN10ChainChomp8BehaviorEv.cpp
+++ b/src/_ZN10ChainChomp8BehaviorEv.cpp
@@ -15,9 +15,16 @@ void _ZN12CylinderClsn5ClearEv(void* self);
 char* _ZN5Actor13ClosestPlayerEv(char* self);
 void _ZN12CylinderClsn6UpdateEv(void* self);
 extern int data_ov014_02114700[];
+}
 
-int _ZN10ChainChomp8BehaviorEv(char* c){
-    *(unsigned char*)(c + 0x61c) = 0;
+struct ChainChomp {
+    int Behavior();
+};
+
+int ChainChomp::Behavior()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c + 0x61c) = 0;
     {
         int v = *(int*)(c + 0x5f0) + 0xc8000;
         if (*(int*)(c + 0x60) <= v) {
@@ -57,5 +64,5 @@ int _ZN10ChainChomp8BehaviorEv(char* c){
         _ZN12CylinderClsn6UpdateEv(c + 0x110);
     }
     return 1;
-}
+
 }

--- a/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
@@ -4,10 +4,18 @@ extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int* data_ov036_02113d78[];
-int _ZN10DonutBlock16CleanupResourcesEv(void* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124)) _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
+}
+
+struct DonutBlock {
+    int CleanupResources();
+};
+
+int DonutBlock::CleanupResources()
+{
+    void* c = (void*)this;
+if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124)) _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[0]);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[1]);
   return 1;
-}
+
 }

--- a/src/_ZN10FaderColor11AdvanceFadeEv.cpp
+++ b/src/_ZN10FaderColor11AdvanceFadeEv.cpp
@@ -1,12 +1,17 @@
 //cpp
 extern "C" {
-
 void _ZN5Fader13AdvanceInterpEv(void* thiz);
 void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short* p, unsigned short a, int b);
+}
 
-void _ZN10FaderColor11AdvanceFadeEv(char* thiz)
+struct FaderColor {
+    void AdvanceFade();
+};
+
+void FaderColor::AdvanceFade()
 {
-    int old = *(int*)(thiz + 4);
+    char* thiz = (char*)this;
+int old = *(int*)(thiz + 4);
     _ZN5Fader13AdvanceInterpEv(thiz);
     if (*(int*)(thiz + 4) == old) return;
     {
@@ -21,6 +26,5 @@ void _ZN10FaderColor11AdvanceFadeEv(char* thiz)
             *(unsigned short*)0x4001050 = 0;
         }
     }
-}
 
 }

--- a/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
+++ b/src/_ZN10KoopaShell16CleanupResourcesEv.cpp
@@ -2,9 +2,17 @@
 extern "C" {
 int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int data_ov102_0214d70c[];
-int _ZN10KoopaShell16CleanupResourcesEv(char* c){
-  unsigned char i=*(unsigned char*)(c+0x3c4);
+}
+
+struct KoopaShell {
+    int CleanupResources();
+};
+
+int KoopaShell::CleanupResources()
+{
+    char* c = (char*)this;
+unsigned char i=*(unsigned char*)(c+0x3c4);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov102_0214d70c[i]);
   return 1;
-}
+
 }

--- a/src/_ZN10PyramidTag13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTag13InitResourcesEv.cpp
@@ -3,11 +3,19 @@ extern "C" {
 int _ZN5Actor15FindWithActorIDEjPS_(unsigned int, void*);
 void _ZN9ActorBase18MarkForDestructionEv(void*);
 void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
-int _ZN10PyramidTag13InitResourcesEv(char* self){
-    int a = _ZN5Actor15FindWithActorIDEjPS_(0x55, 0);
+}
+
+struct PyramidTag {
+    int InitResources();
+};
+
+int PyramidTag::InitResources()
+{
+    char* self = (char*)this;
+int a = _ZN5Actor15FindWithActorIDEjPS_(0x55, 0);
     if(a == 0){ _ZN9ActorBase18MarkForDestructionEv(self); return 1; }
     *(int*)(self+0x108) = *(int*)(a+4);
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self+0xd4, self, 0x7d000, 0x28000, 2, 0x400000);
     return 1;
-}
+
 }

--- a/src/_ZN10PyramidTag8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTag8BehaviorEv.cpp
@@ -4,9 +4,16 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN12CylinderClsn5ClearEv(void* a);
 extern void _ZN12CylinderClsn6UpdateEv(void* a);
+}
 
-int _ZN10PyramidTag8BehaviorEv(char* c){
-  if(*(int*)(c+0xf8) != 0){
+struct PyramidTag {
+    int Behavior();
+};
+
+int PyramidTag::Behavior()
+{
+    char* c = (char*)this;
+if(*(int*)(c+0xf8) != 0){
     unsigned int id = *(unsigned int*)(c+0x108);
     if(id == 0){
       _ZN9ActorBase18MarkForDestructionEv(c);
@@ -23,5 +30,5 @@ int _ZN10PyramidTag8BehaviorEv(char* c){
   _ZN12CylinderClsn5ClearEv(c+0xd4);
   _ZN12CylinderClsn6UpdateEv(c+0xd4);
   return 1;
-}
+
 }

--- a/src/_ZN10PyramidTop13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTop13InitResourcesEv.cpp
@@ -13,10 +13,16 @@ extern int data_ov024_02113968[];
 extern int data_ov024_02113960[];
 extern int data_ov024_021129f0[];
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
-int _ZN10PyramidTop13InitResourcesEv(char* c)
+struct PyramidTop {
+    int InitResources();
+};
+
+int PyramidTop::InitResources()
 {
-    void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov024_02113968);
+    char* c = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov024_02113968);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x320, m, 1, -1);
     func_ov024_021114c4(c);
     func_ov024_02111480(c);
@@ -35,5 +41,5 @@ int _ZN10PyramidTop13InitResourcesEv(char* c)
     *(short*)(c + 0x3b4) = 0;
     _ZN5Event8ClearBitEj(0xe);
     return 1;
-}
+
 }

--- a/src/_ZN10Scuttlebug8BehaviorEv.cpp
+++ b/src/_ZN10Scuttlebug8BehaviorEv.cpp
@@ -7,8 +7,16 @@ extern int _ZNK12WithMeshClsn14GetResultFlag1Ev(void* self);
 extern int _ZNK12WithMeshClsn12TouchesWaterEv(void* self);
 extern void func_ov071_0211f498(char* c);
 extern void func_ov071_0211f524(char* c);
-int _ZN10Scuttlebug8BehaviorEv(char* c){
-  DecIfAbove0_Short(c+0x3a8);
+}
+
+struct Scuttlebug {
+    int Behavior();
+};
+
+int Scuttlebug::Behavior()
+{
+    char* c = (char*)this;
+DecIfAbove0_Short(c+0x3a8);
   func_ov071_02120278(c);
   _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c+0x160);
   if(_ZNK12WithMeshClsn14GetResultFlag1Ev(c+0x194) && _ZNK12WithMeshClsn12TouchesWaterEv(c+0x194)){
@@ -16,5 +24,5 @@ int _ZN10Scuttlebug8BehaviorEv(char* c){
   }
   func_ov071_0211f524(c);
   return 1;
-}
+
 }

--- a/src/_ZN10ShutterHmc8BehaviorEv.cpp
+++ b/src/_ZN10ShutterHmc8BehaviorEv.cpp
@@ -3,10 +3,18 @@ extern "C" {
 int func_ov002_020bac18(void);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-int _ZN10ShutterHmc8BehaviorEv(void* c){
-  int r = func_ov002_020bac18();
+}
+
+struct ShutterHmc {
+    int Behavior();
+};
+
+int ShutterHmc::Behavior()
+{
+    void* c = (void*)this;
+int r = func_ov002_020bac18();
   if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
   return r;
-}
+
 }

--- a/src/_ZN10SlidingIce13InitResourcesEv.cpp
+++ b/src/_ZN10SlidingIce13InitResourcesEv.cpp
@@ -12,8 +12,16 @@ extern int func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
 extern char data_ov027_02113108[];
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-int _ZN10SlidingIce13InitResourcesEv(char *c){
-  _ZN5Model8LoadFileER13SharedFilePtr(func_ov030_02113be8);
+}
+
+struct SlidingIce {
+    int InitResources();
+};
+
+int SlidingIce::InitResources()
+{
+    char * c = (char *)this;
+_ZN5Model8LoadFileER13SharedFilePtr(func_ov030_02113be8);
   _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov027_02113be0);
   int on = (*(unsigned short*)(c+0xc)==0x5d);
   if(on){
@@ -35,5 +43,5 @@ int _ZN10SlidingIce13InitResourcesEv(char *c){
     *(char*)(c+0x320) = 5;
   }
   return 1;
-}
+
 }

--- a/src/_ZN10StarMarker6RenderEv.cpp
+++ b/src/_ZN10StarMarker6RenderEv.cpp
@@ -1,6 +1,5 @@
 //cpp
 extern "C" {
-
 struct Sub {
     virtual void v0();
     virtual void v1();
@@ -9,14 +8,19 @@ struct Sub {
     virtual void v4();
     virtual void m(int);
 };
+}
 
-int _ZN10StarMarker6RenderEv(char *thiz)
+struct StarMarker {
+    int Render();
+};
+
+int StarMarker::Render()
 {
-    unsigned int b = *(unsigned char *)(thiz + 0x1db);
+    char * thiz = (char *)this;
+unsigned int b = *(unsigned char *)(thiz + 0x1db);
     if ((b << 30) >> 31) {
         ((Sub *)(thiz + 0x114))->m(0);
     }
     return 1;
-}
 
 }

--- a/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
+++ b/src/_ZN11ChiefChilly16CleanupResourcesEv.cpp
@@ -11,9 +11,15 @@ extern void* data_ov073_021232b0;
 extern void* data_ov073_021232b8;
 extern void* data_ov002_0210da30;
 extern void* data_ov073_02123298;
+}
 
-int _ZN11ChiefChilly16CleanupResourcesEv(void){
-  UnloadKeyModels(4);
+struct ChiefChilly {
+    int CleanupResources(void);
+};
+
+int ChiefChilly::CleanupResources(void)
+{
+UnloadKeyModels(4);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123280);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov073_021232a0);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123288);
@@ -24,5 +30,5 @@ int _ZN11ChiefChilly16CleanupResourcesEv(void){
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov073_02123298);
   return 1;
-}
+
 }

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -4,10 +4,16 @@ extern short data_02082214[];
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+}
 
-int _ZN11PyramidLift8BehaviorEv(char* c)
+struct PyramidLift {
+    int Behavior();
+};
+
+int PyramidLift::Behavior()
 {
-    switch (*(unsigned char*)(c + 0x3f6)) {
+    char* c = (char*)this;
+switch (*(unsigned char*)(c + 0x3f6)) {
     case 0:
         if (*(unsigned char*)(c + 0x3f7) != 0) {
             *(unsigned char*)(c + 0x3f6) = 1;
@@ -75,5 +81,5 @@ int _ZN11PyramidLift8BehaviorEv(char* c)
         _ZN8Platform19UpdateClsnPosAndRotEv(c);
     *(unsigned char*)(c + 0x3f7) = 0;
     return 1;
-}
+
 }

--- a/src/_ZN11ShadowModel8CleanAllEv.cpp
+++ b/src/_ZN11ShadowModel8CleanAllEv.cpp
@@ -2,8 +2,15 @@
 extern "C" {
 extern char* data_0209cef4;
 extern unsigned char data_0209ceec;
-void _ZN11ShadowModel8CleanAllEv(void){
-  if(data_0209cef4){
+}
+
+struct ShadowModel {
+    void CleanAll(void);
+};
+
+void ShadowModel::CleanAll(void)
+{
+if(data_0209cef4){
     do{
       char* n=data_0209cef4;
       char* nx=*(char**)(n+0x24);
@@ -13,5 +20,5 @@ void _ZN11ShadowModel8CleanAllEv(void){
     }while(data_0209cef4);
   }
   data_0209ceec=0;
-}
+
 }

--- a/src/_ZN11SnowmanHead6RenderEv.cpp
+++ b/src/_ZN11SnowmanHead6RenderEv.cpp
@@ -4,9 +4,17 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int _ZN11SnowmanHead6RenderEv(char* c){
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x124, c+0xdc);
+}
+
+struct SnowmanHead {
+    int Render();
+};
+
+int SnowmanHead::Render()
+{
+    char* c = (char*)this;
+_ZN15TextureSequence6UpdateER15ModelComponents(c+0x124, c+0xdc);
   ((Sub*)(c+0xd4))->g5(c+0x80);
   return 1;
-}
+
 }

--- a/src/_ZN11VirtualDoor13InitResourcesEv.cpp
+++ b/src/_ZN11VirtualDoor13InitResourcesEv.cpp
@@ -9,10 +9,16 @@ extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
 extern void InvMat4x3(void* out, void* in);
 
 #define M(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+}
 
-int _ZN11VirtualDoor13InitResourcesEv(char* c)
+struct VirtualDoor {
+    int InitResources();
+};
+
+int VirtualDoor::InitResources()
 {
-    if (data_0209f2f8 == 8 && data_0209f220 != 1) {
+    char* c = (char*)this;
+if (data_0209f2f8 == 8 && data_0209f220 != 1) {
         if (IsStarCollectedInLevel(8, 1) != 0) return 0;
     }
 
@@ -46,5 +52,5 @@ int _ZN11VirtualDoor13InitResourcesEv(char* c)
 
     *(int*)M(c + 0x60) += *(int*)(c + 0x84) >> 1;
     return 1;
-}
+
 }

--- a/src/_ZN12CylinderClsn6UpdateEv.cpp
+++ b/src/_ZN12CylinderClsn6UpdateEv.cpp
@@ -1,11 +1,19 @@
 //cpp
 extern "C" {
 extern void* data_0209cee8;
-void _ZN12CylinderClsn6UpdateEv(char* c){
-  if(*(int*)(c+0x18) & 1) return;
+}
+
+struct CylinderClsn {
+    void Update();
+};
+
+void CylinderClsn::Update()
+{
+    char* c = (char*)this;
+if(*(int*)(c+0x18) & 1) return;
   void* h = data_0209cee8;
   *(void**)(c+0x2c) = h;
   if(data_0209cee8) *(void**)((char*)data_0209cee8+0x28) = c;
   data_0209cee8 = c;
-}
+
 }

--- a/src/_ZN12EnemySpawner8BehaviorEv.cpp
+++ b/src/_ZN12EnemySpawner8BehaviorEv.cpp
@@ -4,13 +4,21 @@ extern int _ZN5Event6GetBitEj(unsigned int bit);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
   unsigned int id, unsigned int a2, void* pos, void* rot, int a5, int a6);
 extern void func_ov102_0214ad14(void* c);
-int _ZN12EnemySpawner8BehaviorEv(char* c){
-  if (_ZN5Event6GetBitEj(*(unsigned char*)(c+0xdc)) && *(int*)(c+0xd8) == 0) {
+}
+
+struct EnemySpawner {
+    int Behavior();
+};
+
+int EnemySpawner::Behavior()
+{
+    char* c = (char*)this;
+if (_ZN5Event6GetBitEj(*(unsigned char*)(c+0xdc)) && *(int*)(c+0xd8) == 0) {
     void* a = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
       *(unsigned short*)(c+0xd4), 4, c+0x5c, c+0x92, *(signed char*)(c+0xcc), -1);
     if (a != 0) func_ov102_0214ad14(a);
   }
   *(int*)(c+0xd8) = _ZN5Event6GetBitEj(*(unsigned char*)(c+0xdc));
   return 1;
-}
+
 }

--- a/src/_ZN12FallBlockLll8BehaviorEv.cpp
+++ b/src/_ZN12FallBlockLll8BehaviorEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 void func_020393a4(void* p, int v);
 unsigned char func_ov080_0212714c(void* a, void* b);
 extern int data_ov035_02112c98[];
-int _ZN12FallBlockLll8BehaviorEv(char* c){
-  func_020393a4(c+0x124, 0x500000);
-  return func_ov080_0212714c(c, data_ov035_02112c98) & 0xff;
 }
+
+struct FallBlockLll {
+    int Behavior();
+};
+
+int FallBlockLll::Behavior()
+{
+    char* c = (char*)this;
+func_020393a4(c+0x124, 0x500000);
+  return func_ov080_0212714c(c, data_ov035_02112c98) & 0xff;
+
 }

--- a/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
+++ b/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
@@ -5,8 +5,16 @@ extern void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern int* data_ov084_021302f4;
 extern int data_ov002_0210da38;
-int _ZN12PiranhaPlant16CleanupResourcesEv(void* c){
-  int i;
+}
+
+struct PiranhaPlant {
+    int CleanupResources();
+};
+
+int PiranhaPlant::CleanupResources()
+{
+    void* c = (void*)this;
+int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
   for(i=0;i<6;i++){
     _ZN13SharedFilePtr7ReleaseEv((&data_ov084_021302f4)[i]);
@@ -14,5 +22,5 @@ int _ZN12PiranhaPlant16CleanupResourcesEv(void* c){
   UnloadBlueCoinModel(c);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   return 1;
-}
+
 }

--- a/src/_ZN12SwitchPillar13InitResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar13InitResourcesEv.cpp
@@ -14,8 +14,16 @@ extern int data_ov012_021124c8[];
 extern int data_ov012_02111c24[];
 extern int data_ov012_02111c90[];
 extern int data_0209caa0[];
-int _ZN12SwitchPillar13InitResourcesEv(char* c){
-  _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124d0);
+}
+
+struct SwitchPillar {
+    int InitResources();
+};
+
+int SwitchPillar::InitResources()
+{
+    char* c = (char*)this;
+_ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124d0);
   _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov012_021124c8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, data_ov012_021124d0[1], 1, 0x14);
   _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(data_ov012_021124d0[1], data_ov012_02111c24);
@@ -30,5 +38,5 @@ int _ZN12SwitchPillar13InitResourcesEv(char* c){
     *(int*)(c+0x60) = *(int*)(c+0x334);
   }
   return 1;
-}
+
 }

--- a/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
@@ -1,6 +1,5 @@
 //cpp
 extern "C" {
-
 struct Vector3 { int x, y, z; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
@@ -14,10 +13,16 @@ extern int _ZN10SphereClsn10DetectClsnEv(void *self);
 extern void func_020371b0(void *clsn, int justHit);
 extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void *self);
 extern void func_020356d4(char *self);
+}
 
-void _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv(char *self)
+struct WithMeshClsn {
+    void UpdateDiscreteNoLava();
+};
+
+void WithMeshClsn::UpdateDiscreteNoLava()
 {
-    int onGround;
+    char * self = (char *)this;
+int onGround;
     int sy;
     struct Vector3 v;
     struct Vector3 *p6c;
@@ -61,5 +66,5 @@ void _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv(char *self)
     if (_ZNK12WithMeshClsn10IsOnGroundEv(self))
         return;
     func_020356d4(self);
-}
+
 }

--- a/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
+++ b/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
@@ -1,6 +1,5 @@
 //cpp
 extern "C" {
-
 struct Vector3 { int x, y, z; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
@@ -11,10 +10,16 @@ extern void func_020371b0(void *clsn, int justHit);
 extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void *self);
 extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void *self);
 extern void func_020356d4(char *self);
+}
 
-void _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev(char *self)
+struct WithMeshClsn {
+    void UpdateDiscreteNoLava_2();
+};
+
+void WithMeshClsn::UpdateDiscreteNoLava_2()
 {
-    int onGround;
+    char * self = (char *)this;
+int onGround;
     int sy;
     struct Vector3 v;
     struct Vector3 *p6c;
@@ -52,5 +57,5 @@ void _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev(char *self)
     if (_ZNK12WithMeshClsn10IsOnGroundEv(self))
         return;
     func_020356d4(self);
-}
+
 }

--- a/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
-
-unsigned int _ZN13ExpandingHeap19VMaxAllocatableSizeEv(char* self) {
-    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
 }
+
+struct ExpandingHeap {
+    unsigned int VMaxAllocatableSize();
+};
+
+unsigned int ExpandingHeap::VMaxAllocatableSize()
+{
+    char* self = (char*)this;
+return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
+
 }

--- a/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
-
-unsigned int _ZN13ExpandingHeap22VMaxAllocationUnitSizeEv(char* self) {
-    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
 }
+
+struct ExpandingHeap {
+    unsigned int VMaxAllocationUnitSize();
+};
+
+unsigned int ExpandingHeap::VMaxAllocationUnitSize()
+{
+    char* self = (char*)this;
+return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
+
 }

--- a/src/_ZN13FortressTower8BehaviorEv.cpp
+++ b/src/_ZN13FortressTower8BehaviorEv.cpp
@@ -4,10 +4,16 @@ int _ZN16MeshColliderBase9IsEnabledEv(void* c);
 void _ZN16MeshColliderBase6EnableEP5Actor(void* c, void* a);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
 extern unsigned char data_0209f2d8[];
+}
 
-int _ZN13FortressTower8BehaviorEv(char* c)
+struct FortressTower {
+    int Behavior();
+};
+
+int FortressTower::Behavior()
 {
-    unsigned short id = *(unsigned short*)(c+0xc);
+    char* c = (char*)this;
+unsigned short id = *(unsigned short*)(c+0xc);
     int r1 = 0;
     switch (id) {
     case 0x31: r1 = 0x900000; break;
@@ -25,5 +31,5 @@ int _ZN13FortressTower8BehaviorEv(char* c)
         _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, r1, 0);
     }
     return 1;
-}
+
 }

--- a/src/_ZN13HeapAllocator7DestroyEv.cpp
+++ b/src/_ZN13HeapAllocator7DestroyEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-/* _ZN13HeapAllocator7DestroyEv @ 0x204e3b4 (arm9) -- tail-call veneer to _ZN13HeapAllocator6RemoveEv (0x204df38).
- * ldr ip, [pc]; bx ip; .word 0x204df38
- */
 extern "C" {
 extern void _ZN13HeapAllocator6RemoveEv(void);
-void _ZN13HeapAllocator7DestroyEv(void) {
-    _ZN13HeapAllocator6RemoveEv();
 }
+
+struct HeapAllocator {
+    void Destroy(void);
+};
+
+void HeapAllocator::Destroy(void)
+{
+_ZN13HeapAllocator6RemoveEv();
+
 }

--- a/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
+++ b/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
@@ -7,8 +7,16 @@ extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern void func_ov062_0211aac0(void* c);
 extern int data_ov062_0211e0a4[];
-int _ZN13KoopaTheQuick8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x38c);
+}
+
+struct KoopaTheQuick {
+    int Behavior();
+};
+
+int KoopaTheQuick::Behavior()
+{
+    char* c = (char*)this;
+int idx = *(int*)(c+0x38c);
   char* ent = (char*)&data_ov062_0211e0a4[idx*2];
   int adj = *(int*)(ent+4);
   char* self = c + (adj>>1);
@@ -24,5 +32,5 @@ int _ZN13KoopaTheQuick8BehaviorEv(char* c){
   _ZN12CylinderClsn6UpdateEv(c+0x110);
   func_ov062_0211aac0(c);
   return 1;
-}
+
 }

--- a/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
+++ b/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
@@ -5,8 +5,16 @@ int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*,void*,int,int,unsigned,unsigned);
 int _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*,void*,int,int,int,int);
 extern int data_ov080_021283c8[];
-int _ZN13MontyMoleRock13InitResourcesEv(char* c){
-  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov080_021283c8);
+}
+
+struct MontyMoleRock {
+    int InitResources();
+};
+
+int MontyMoleRock::InitResources()
+{
+    char* c = (char*)this;
+int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov080_021283c8);
   if(_ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x110, m, 1, -1) == 0) return 0;
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x160, c, 0x1e000, 0x1e000, 0x200004, 0);
   *(unsigned char*)(c+0x350) = *(int*)(c+8) & 1;
@@ -23,5 +31,5 @@ int _ZN13MontyMoleRock13InitResourcesEv(char* c){
     *(int*)(c+0x88) = 0x800;
   }
   return 1;
-}
+
 }

--- a/src/_ZN13PoleBillboard8BehaviorEv.cpp
+++ b/src/_ZN13PoleBillboard8BehaviorEv.cpp
@@ -9,10 +9,16 @@ extern void func_ov015_0211166c(char *t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern int func_ov015_021114f0(char *c);
+}
 
-int _ZN13PoleBillboard8BehaviorEv(char *c)
+struct PoleBillboard {
+    int Behavior();
+};
+
+int PoleBillboard::Behavior()
 {
-    switch (*(unsigned char *)(c + 0x397)) {
+    char * c = (char *)this;
+switch (*(unsigned char *)(c + 0x397)) {
     case 0:
         break;
     case 1: {
@@ -85,5 +91,5 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
         _ZN8Platform19UpdateClsnPosAndRotEv(c);
     func_ov015_021114f0(c);
     return 1;
-}
+
 }

--- a/src/_ZN13PrincessPeach8BehaviorEv.cpp
+++ b/src/_ZN13PrincessPeach8BehaviorEv.cpp
@@ -9,9 +9,16 @@ extern int func_ov085_02129fdc(void *c);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); };
 extern "C" {
-int _ZN13PrincessPeach8BehaviorEv(char *c)
+}
+
+struct PrincessPeach {
+    int Behavior();
+};
+
+int PrincessPeach::Behavior()
 {
-    func_ov085_0212a430(c);
+    char * c = (char *)this;
+func_ov085_0212a430(c);
     func_ov085_02129dbc(c);
     if (*(int*)(c + 0x354) != 1)
         _ZN9Animation7AdvanceEv(c + 0x124);
@@ -20,5 +27,5 @@ int _ZN13PrincessPeach8BehaviorEv(char *c)
     _ZN12CylinderClsn6UpdateEv(c + 0x160);
     func_ov085_02129fdc(c);
     return 1;
-}
+
 }

--- a/src/_ZN13RacingPenguin16CleanupResourcesEv.cpp
+++ b/src/_ZN13RacingPenguin16CleanupResourcesEv.cpp
@@ -6,11 +6,18 @@ void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern struct SharedFilePtr data_ov019_02113498;
 extern struct SharedFilePtr* _ZN9HugeCover6RenderEv[7];
 extern struct SharedFilePtr* data_ov019_0211277c[3];
-int _ZN13RacingPenguin16CleanupResourcesEv(void){
-  int i;
+}
+
+struct RacingPenguin {
+    int CleanupResources(void);
+};
+
+int RacingPenguin::CleanupResources(void)
+{
+int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov019_02113498);
   for(i=0;i<7;i++) _ZN13SharedFilePtr7ReleaseEv(_ZN9HugeCover6RenderEv[i]);
   for(i=0;i<3;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov019_0211277c[i]);
   return 1;
-}
+
 }

--- a/src/_ZN13RollingLogTtm6RenderEv.cpp
+++ b/src/_ZN13RollingLogTtm6RenderEv.cpp
@@ -1,10 +1,18 @@
 //cpp
 extern "C" {
 extern int _ZN5Model6RenderEPK7Vector3(void*, void*);
-int _ZN13RollingLogTtm6RenderEv(char* c){
-  int b = (*(int*)(c+0xb0) & 0x40000) != 0;
+}
+
+struct RollingLogTtm {
+    int Render();
+};
+
+int RollingLogTtm::Render()
+{
+    char* c = (char*)this;
+int b = (*(int*)(c+0xb0) & 0x40000) != 0;
   if(b) return 1;
   _ZN5Model6RenderEPK7Vector3(c+0xd4, 0);
   return 1;
-}
+
 }

--- a/src/_ZN13SnowmanBreath13InitResourcesEv.cpp
+++ b/src/_ZN13SnowmanBreath13InitResourcesEv.cpp
@@ -12,10 +12,16 @@ extern int data_ov002_0210d9c0[];
 extern int data_020a0e68[];
 
 typedef struct { int w[12]; } M48;
+}
 
-int _ZN13SnowmanBreath13InitResourcesEv(char* c)
+struct SnowmanBreath {
+    int InitResources();
+};
+
+int SnowmanBreath::InitResources()
 {
-    _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da40);
+    char* c = (char*)this;
+_ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da40);
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a0);
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9c0);
     *(int*)(c + 0x5c) = 0x3fa770;
@@ -29,5 +35,5 @@ int _ZN13SnowmanBreath13InitResourcesEv(char* c)
     InvMat4x3(data_020a0e68, data_020a0e68);
     *(M48*)(c + 0x1394) = *(M48*)data_020a0e68;
     return 1;
-}
+
 }

--- a/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
@@ -5,11 +5,19 @@ extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov095_02136f68[];
 extern void* data_ov095_02136f74[];
-int _ZN13UpDownLiftBbh16CleanupResourcesEv(void* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
+}
+
+struct UpDownLiftBbh {
+    int CleanupResources();
+};
+
+int UpDownLiftBbh::CleanupResources()
+{
+    void* c = (void*)this;
+if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
     _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f68[*(int*)((char*)c+0x328)]);
   _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f74[*(int*)((char*)c+0x328)]);
   return 1;
-}
+
 }

--- a/src/_ZN14ArrowSignRight8BehaviorEv.cpp
+++ b/src/_ZN14ArrowSignRight8BehaviorEv.cpp
@@ -5,10 +5,16 @@ void func_02039394(int* p, int v);
 void func_020393a4(int* p, int v);
 void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void* c, void* sm, void* mtx, int s, int x, int y, unsigned int j);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
+}
 
-int _ZN14ArrowSignRight8BehaviorEv(char* c)
+struct ArrowSignRight {
+    int Behavior();
+};
+
+int ArrowSignRight::Behavior()
 {
-    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(c, -0x2000, 0, 0, 0x96000))
+    char* c = (char*)this;
+if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(c, -0x2000, 0, 0, 0x96000))
         return 1;
     func_02039394((int*)(c+0x124), 0xc0000);
     func_020393a4((int*)(c+0x124), 0xe0000);
@@ -16,5 +22,5 @@ int _ZN14ArrowSignRight8BehaviorEv(char* c)
         c, (void*)(c+0x320), (void*)(c+0x348), 0x10e000, 0x64000, 0x46000, 0xf);
     _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x600000, 0);
     return 1;
-}
+
 }

--- a/src/_ZN14FlameChompFire6RenderEv.cpp
+++ b/src/_ZN14FlameChompFire6RenderEv.cpp
@@ -1,13 +1,21 @@
 //cpp
 extern "C" {
 extern int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, int c, int d, int e, void* f);
-int _ZN14FlameChompFire6RenderEv(char* c) {
-  int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
+}
+
+struct FlameChompFire {
+    int Render();
+};
+
+int FlameChompFire::Render()
+{
+    char* c = (char*)this;
+int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
   if (b) return 1;
   *(int*)(c + 0x324) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
       *(int*)(c + 0x324), 0x7f, *(int*)(c + 0x5c), *(int*)(c + 0x60) + 0x4b000, *(int*)(c + 0x64), 0);
   *(int*)(c + 0x328) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
       *(int*)(c + 0x328), 0x80, *(int*)(c + 0x5c), *(int*)(c + 0x60) + 0x4b000, *(int*)(c + 0x64), 0);
   return 1;
-}
+
 }

--- a/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
@@ -15,8 +15,16 @@ extern int data_ov015_02114534[];
 extern int data_ov034_02114538[];
 extern int data_ov015_0211453c[];
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
-int _ZN14KnockDownPlank13InitResourcesEv(char* c){
-  int b = (*(unsigned short*)((char*)c+0xc) == 0x35) ? 1 : 0;
+}
+
+struct KnockDownPlank {
+    int InitResources();
+};
+
+int KnockDownPlank::InitResources()
+{
+    char* c = (char*)this;
+int b = (*(unsigned short*)((char*)c+0xc) == 0x35) ? 1 : 0;
   if(b) *(int*)((char*)c+0x32c) = 1; else *(int*)((char*)c+0x32c) = 0;
   int j0 = *(int*)((char*)c+0x32c) * 0xc;
   int m = _ZN5Model8LoadFileER13SharedFilePtr(*(void**)((char*)data_ov015_02114534 + j0));
@@ -37,5 +45,5 @@ int _ZN14KnockDownPlank13InitResourcesEv(char* c){
   *(int*)((char*)c+0x328) = *(int*)((char*)c+0x64);
   func_ov015_02111fb8(c, 5);
   return 1;
-}
+
 }

--- a/src/_ZN14SquarePathLift13InitResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift13InitResourcesEv.cpp
@@ -11,8 +11,16 @@ extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 struct SFP { void* a; void* b; void* c; };
 extern struct SFP data_ov052_021125a0;
-int _ZN14SquarePathLift13InitResourcesEv(char* c){
-  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov052_021125a0.a);
+}
+
+struct SquarePathLift {
+    int InitResources();
+};
+
+int SquarePathLift::InitResources()
+{
+    char* c = (char*)this;
+void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov052_021125a0.a);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
@@ -23,5 +31,5 @@ int _ZN14SquarePathLift13InitResourcesEv(char* c){
   *(int*)(c+0x32c) = 1;
   *(int*)(c+0x98) = 0xa000;
   return 1;
-}
+
 }

--- a/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
@@ -5,11 +5,19 @@ extern SFP data_ov052_021125a0[2];
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase7DisableEv(void*);
 void _ZN13SharedFilePtr7ReleaseEv(void*);
-int _ZN14SquarePathLift16CleanupResourcesEv(char* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
+}
+
+struct SquarePathLift {
+    int CleanupResources();
+};
+
+int SquarePathLift::CleanupResources()
+{
+    char* c = (char*)this;
+if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[0].x);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[1].x);
   return 1;
-}
+
 }

--- a/src/_ZN15BookShotSpawner8BehaviorEv.cpp
+++ b/src/_ZN15BookShotSpawner8BehaviorEv.cpp
@@ -7,10 +7,16 @@ extern int Vec3_HorzDist(const Vector3 *a, const Vector3 *b);
 extern short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
 extern int _ZN5Actor14GetSubtractionEss(void *thiz, short a, short b);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const Vector3 *pos, const Vector3_16 *r, int e, int f);
+}
 
-int _ZN15BookShotSpawner8BehaviorEv(char *c)
+struct BookShotSpawner {
+    int Behavior();
+};
+
+int BookShotSpawner::Behavior()
 {
-    if (*(unsigned short *)(c + 0xd4) > 0x28) {
+    char * c = (char *)this;
+if (*(unsigned short *)(c + 0xd4) > 0x28) {
         char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
         if (p != 0) {
 
@@ -34,5 +40,5 @@ int _ZN15BookShotSpawner8BehaviorEv(char *c)
         *pt = *pt + 1;
     }
     return 1;
-}
+
 }

--- a/src/_ZN15ChainChompFence8BehaviorEv.cpp
+++ b/src/_ZN15ChainChompFence8BehaviorEv.cpp
@@ -1,9 +1,17 @@
 //cpp
 extern "C" {
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
-int _ZN15ChainChompFence8BehaviorEv(void *c) {
-    if (*(unsigned char*)((char*)c+0x31e) != 0) return 1;
+}
+
+struct ChainChompFence {
+    int Behavior();
+};
+
+int ChainChompFence::Behavior()
+{
+    void * c = (void *)this;
+if (*(unsigned char*)((char*)c+0x31e) != 0) return 1;
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
-}
+
 }

--- a/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
@@ -10,10 +10,16 @@ extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void*
 extern int data_ov045_021131b0[];
 extern int data_ov045_021131a8[];
 extern int data_ov045_02112510[];
+}
 
-int _ZN15FireSeaElevator13InitResourcesEv(char* c)
+struct FireSeaElevator {
+    int InitResources();
+};
+
+int FireSeaElevator::InitResources()
 {
-    void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_021131b0);
+    char* c = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_021131b0);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, -1);
     if (*(int*)(c + 8) != 0xffff) {
         int* p = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
@@ -27,5 +33,5 @@ int _ZN15FireSeaElevator13InitResourcesEv(char* c)
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(
         c + 0x320, c, 0x35555, 0x258000, 0x280000c, 0);
     return 1;
-}
+
 }

--- a/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
+++ b/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
@@ -5,8 +5,16 @@ extern int data_ov002_0210da08[];
 extern int data_ov002_0210d9a8[];
 extern int data_ov002_0210d9e8[];
 void _ZN13SharedFilePtr7ReleaseEv(void*);
-int _ZN15InvisibleSecret16CleanupResourcesEv(char* c){
-  if(*(int*)(c+8) & 0x10){
+}
+
+struct InvisibleSecret {
+    int CleanupResources();
+};
+
+int InvisibleSecret::CleanupResources()
+{
+    char* c = (char*)this;
+if(*(int*)(c+8) & 0x10){
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da28);
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da08);
   } else {
@@ -14,5 +22,5 @@ int _ZN15InvisibleSecret16CleanupResourcesEv(char* c){
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e8);
   }
   return 1;
-}
+
 }

--- a/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
@@ -4,11 +4,19 @@ int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
 void _ZN13SharedFilePtr7ReleaseEv(void* self);
 extern int data_ov064_0211adbc[];
-int _ZN15RotatingFirebar16CleanupResourcesEv(char* c) {
-  if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
+}
+
+struct RotatingFirebar {
+    int CleanupResources();
+};
+
+int RotatingFirebar::CleanupResources()
+{
+    char* c = (char*)this;
+if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[0]);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[1]);
   return 1;
-}
+
 }

--- a/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
+++ b/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
@@ -18,10 +18,16 @@ extern int data_ov060_0211b1f8[];
 extern int data_ov060_0211b200[];
 extern int func_021115e4[];
 extern int func_021115f4[];
+}
 
-int _ZN16BowserShockwaves13InitResourcesEv(char* c)
+struct BowserShockwaves {
+    int InitResources();
+};
+
+int BowserShockwaves::InitResources()
 {
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211b208), 1, 0x13);
+    char* c = (char*)this;
+_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211b208), 1, 0x13);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x174, (void*)data_ov060_0211b208[1], 1, 0x13);
 
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov060_0211b1f8);
@@ -53,5 +59,5 @@ int _ZN16BowserShockwaves13InitResourcesEv(char* c)
 
     *(short*)(c + 0x214) = 0;
     return 1;
-}
+
 }

--- a/src/_ZN16MeshColliderBase9IsEnabledEv.cpp
+++ b/src/_ZN16MeshColliderBase9IsEnabledEv.cpp
@@ -1,8 +1,13 @@
 //cpp
-extern "C" {
-int _ZN16MeshColliderBase9IsEnabledEv(unsigned char *c) {
-  unsigned char v = c[0x14];
+struct MeshColliderBase {
+    int IsEnabled();
+};
+
+int MeshColliderBase::IsEnabled()
+{
+    char * c = (char *)this;
+unsigned char v = c[0x14];
   if (v != 0x18) return 1;
   return 0;
-}
+
 }

--- a/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
@@ -7,8 +7,16 @@ extern char data_ov035_02112c78[];
 extern char data_ov056_02112c68[];
 extern char data_ov035_02112c70[];
 extern char data_ov035_02112c60[];
-int _ZN16RotatingCogSmall16CleanupResourcesEv(char *t){
-  if(*(int*)(t+0x32c)==0){
+}
+
+struct RotatingCogSmall {
+    int CleanupResources();
+};
+
+int RotatingCogSmall::CleanupResources()
+{
+    char * t = (char *)this;
+if(*(int*)(t+0x32c)==0){
     if(_ZN16MeshColliderBase9IsEnabledEv(t+0x124))
       _ZN16MeshColliderBase7DisableEv(t+0x124);
     _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c78);
@@ -21,5 +29,5 @@ int _ZN16RotatingCogSmall16CleanupResourcesEv(char *t){
       _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c60);
   }
   return 1;
-}
+
 }

--- a/src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp
+++ b/src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp
@@ -11,8 +11,16 @@ extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 struct SFP { void* a; void* b; void* c; };
 extern struct SFP data_ov056_02113314;
-int _ZN17BigMovingIceBlock13InitResourcesEv(char* c){
-  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov056_02113314.a);
+}
+
+struct BigMovingIceBlock {
+    int InitResources();
+};
+
+int BigMovingIceBlock::InitResources()
+{
+    char* c = (char*)this;
+void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov056_02113314.a);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
@@ -23,5 +31,5 @@ int _ZN17BigMovingIceBlock13InitResourcesEv(char* c){
   *(int*)(c+0x32c) = 1;
   *(int*)(c+0x98) = 0xa000;
   return 1;
-}
+
 }

--- a/src/_ZN17BowserSkyPlatform8BehaviorEv.cpp
+++ b/src/_ZN17BowserSkyPlatform8BehaviorEv.cpp
@@ -6,8 +6,16 @@ extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(voi
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern int data_ov060_0211b1d8[];
 struct V3 { int x,y,z; };
-int _ZN17BowserSkyPlatform8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x170);
+}
+
+struct BowserSkyPlatform {
+    int Behavior();
+};
+
+int BowserSkyPlatform::Behavior()
+{
+    char* c = (char*)this;
+int idx = *(int*)(c+0x170);
   char* ent = (char*)&data_ov060_0211b1d8[idx*2];
   int adj = *(int*)(ent+4);
   char* self = c + (adj>>1);
@@ -24,5 +32,5 @@ int _ZN17BowserSkyPlatform8BehaviorEv(char* c){
   _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c+0x124, &v);
   _ZN12CylinderClsn6UpdateEv(c+0x124);
   return 1;
-}
+
 }

--- a/src/_ZN17MgBounceAndPounce12BeforeRenderEv.cpp
+++ b/src/_ZN17MgBounceAndPounce12BeforeRenderEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-extern "C" {
-int _ZN17MgBounceAndPounce12BeforeRenderEv(){
-  extern int func_ov004_020b04f4();
+struct MgBounceAndPounce {
+    int BeforeRender();
+};
+
+int MgBounceAndPounce::BeforeRender()
+{
+extern int func_ov004_020b04f4();
   extern int _ZN8Particle9RenderAllEv();
   if(func_ov004_020b04f4()==0) return 0;
   _ZN8Particle9RenderAllEv();
   return 1;
-}
+
 }

--- a/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
+++ b/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
@@ -3,10 +3,18 @@ extern "C" {
 extern int func_ov004_020b0620(void*);
 extern unsigned int data_020a0db0;
 int _ZN8Particle10SysTracker6UpdateEv(void*);
-int _ZN17MgBounceAndPounce14BeforeBehaviorEv(void* c){
-  if(func_ov004_020b0620(c)==0) return 0;
+}
+
+struct MgBounceAndPounce {
+    int BeforeBehavior();
+};
+
+int MgBounceAndPounce::BeforeBehavior()
+{
+    void* c = (void*)this;
+if(func_ov004_020b0620(c)==0) return 0;
   if(data_020a0db0 & 1)
     _ZN8Particle10SysTracker6UpdateEv((char*)c+0x47e4);
   return 1;
-}
+
 }

--- a/src/_ZN18PoppingLavaBubbles8BehaviorEv.cpp
+++ b/src/_ZN18PoppingLavaBubbles8BehaviorEv.cpp
@@ -2,10 +2,18 @@
 extern "C" {
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned a, unsigned b, int x, int y, int z, const void* v, void* cb);
-int _ZN18PoppingLavaBubbles8BehaviorEv(char* c) {
-    *(void**)(c+0xd8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+}
+
+struct PoppingLavaBubbles {
+    int Behavior();
+};
+
+int PoppingLavaBubbles::Behavior()
+{
+    char* c = (char*)this;
+*(void**)(c+0xd8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(unsigned*)(c+0xd8), *(unsigned short*)(c+0xd4),
         *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64), 0, 0);
     return 1;
-}
+
 }

--- a/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
@@ -5,13 +5,21 @@ void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern void *data_ov085_021302f4[];
 extern int data_ov002_0210da38;
-int _ZN19FirePiranhaPlantBig16CleanupResourcesEv(void *c) {
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
+}
+
+struct FirePiranhaPlantBig {
+    int CleanupResources();
+};
+
+int FirePiranhaPlantBig::CleanupResources()
+{
+    void * c = (void *)this;
+_ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
   for (int i = 0; i < 6; i++) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov085_021302f4[i]);
   }
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   UnloadBlueCoinModel(c);
   return 1;
-}
+
 }

--- a/src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp
@@ -1,13 +1,21 @@
 //cpp
 extern "C" {
 struct EHA;
-unsigned int _ZN22ExpandingHeapAllocator10MemoryLeftEv(EHA* thiz) {
-  void* n = *(void**)((char*)thiz + 0x24);
+}
+
+struct ExpandingHeapAllocator {
+    unsigned int MemoryLeft();
+};
+
+unsigned int ExpandingHeapAllocator::MemoryLeft()
+{
+    EHA* thiz = (EHA*)this;
+void* n = *(void**)((char*)thiz + 0x24);
   unsigned int total = 0;
   while (n) {
     total += *(unsigned int*)((char*)n + 4);
     n = *(void**)((char*)n + 0xc);
   }
   return total;
-}
+
 }

--- a/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp
@@ -1,6 +1,5 @@
 //cpp
 extern "C" {
-
 struct MemoryNode {
   unsigned short tag;
   unsigned short flags;
@@ -17,9 +16,16 @@ struct NodeList {
 };
 
 void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(NodeList* c, MemoryNode* node, void* target, unsigned int size, unsigned int z);
+}
 
-void* _ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void* thiz, unsigned int size, unsigned int align) {
-  NodeList* c = (NodeList*)((char*)thiz + 0x24);
+struct ExpandingHeapAllocator {
+    void* AllocateForwards(unsigned int size, unsigned int align);
+};
+
+void* ExpandingHeapAllocator::AllocateForwards(unsigned int size, unsigned int align)
+{
+    void* thiz = (void*)this;
+NodeList* c = (NodeList*)((char*)thiz + 0x24);
   unsigned short flag = c->flag;
   int firstFit = ((unsigned short)(flag & 1) == 0);
   MemoryNode* best = 0;
@@ -45,5 +51,5 @@ void* _ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void* thiz, unsigned int 
   }
   if (best == 0) return 0;
   return _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(c, best, bestTarget, size, 0);
-}
+
 }

--- a/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp
@@ -1,6 +1,5 @@
 //cpp
 extern "C" {
-
 struct MemoryNode {
   unsigned short tag;
   unsigned short flags;
@@ -17,9 +16,16 @@ struct NodeList {
 };
 
 void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(NodeList* c, MemoryNode* node, void* target, unsigned int size, unsigned int z);
+}
 
-void* _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void* thiz, unsigned int size, unsigned int align) {
-  NodeList* c = (NodeList*)((char*)thiz + 0x24);
+struct ExpandingHeapAllocator {
+    void* AllocateBackwards(unsigned int size, unsigned int align);
+};
+
+void* ExpandingHeapAllocator::AllocateBackwards(unsigned int size, unsigned int align)
+{
+    void* thiz = (void*)this;
+NodeList* c = (NodeList*)((char*)thiz + 0x24);
   unsigned short flag = c->flag;
   int firstFit = ((unsigned short)(flag & 1) == 0);
   MemoryNode* best = 0;
@@ -45,5 +51,5 @@ void* _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void* thiz, unsigned int
   }
   if (best == 0) return 0;
   return _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(c, best, bestTarget, size, 1);
-}
+
 }

--- a/src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp
+++ b/src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 int _ZN4cstd3absEi(int);
 struct EHA;
-int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(EHA* thiz, int arg) {
-  int align = _ZN4cstd3absEi(arg);
+}
+
+struct ExpandingHeapAllocator {
+    int MaxAllocatableSize(int arg);
+};
+
+int ExpandingHeapAllocator::MaxAllocatableSize(int arg)
+{
+    EHA* thiz = (EHA*)this;
+int align = _ZN4cstd3absEi(arg);
   unsigned int bestSize = 0;
   unsigned int bestOffset = -1;
   char* n = *(char**)((char*)thiz + 0x24);
@@ -22,5 +30,5 @@ int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(EHA* thiz, int arg) {
     n = *(char**)(n + 0xc);
   }
   return bestSize;
-}
+
 }

--- a/src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp
@@ -2,10 +2,18 @@
 extern "C" {
 struct Inner { char pad[0x10]; unsigned short id; };
 struct EHA { char pad[0x24]; struct Inner inner; };
-int _ZN22ExpandingHeapAllocator9SetNodeIDEj(struct EHA* thiz, unsigned int id) {
-  struct Inner* p = &thiz->inner;
+}
+
+struct ExpandingHeapAllocator {
+    int SetNodeID(unsigned int id);
+};
+
+int ExpandingHeapAllocator::SetNodeID(unsigned int id)
+{
+    EHA* thiz = (EHA*)this;
+struct Inner* p = &thiz->inner;
   unsigned short old = p->id;
   p->id = (unsigned short)id;
   return old;
-}
+
 }

--- a/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
@@ -4,10 +4,18 @@ extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern void* data_ov091_021344fc[];
 extern void* data_ov091_021344f4[];
-int _ZN22RotatingUpDownPlatform16CleanupResourcesEv(char* c){
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344fc[*(unsigned char*)(c+0x352)]);
+}
+
+struct RotatingUpDownPlatform {
+    int CleanupResources();
+};
+
+int RotatingUpDownPlatform::CleanupResources()
+{
+    char* c = (char*)this;
+_ZN13SharedFilePtr7ReleaseEv(data_ov091_021344fc[*(unsigned char*)(c+0x352)]);
   _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344f4[*(unsigned char*)(c+0x352)]);
   _ZN16MeshColliderBase7DisableEv(c+0x124);
   return 1;
-}
+
 }

--- a/src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp
@@ -12,10 +12,16 @@ extern int data_ov016_02114e74[];
 extern int data_ov016_02114e6c[];
 extern int data_ov016_02113bac[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
-int _ZN23FloatOnWaterPlatformJrb13InitResourcesEv(char* c)
+struct FloatOnWaterPlatformJrb {
+    int InitResources();
+};
+
+int FloatOnWaterPlatformJrb::InitResources()
 {
-    void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov016_02114e74);
+    char* c = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov016_02114e74);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, -1);
     func_ov016_021130a4(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
@@ -30,5 +36,5 @@ int _ZN23FloatOnWaterPlatformJrb13InitResourcesEv(char* c)
     *(unsigned char*)(c + 0x4f4) = 0;
     *(int*)(c + 0x4f0) = 0;
     return 1;
-}
+
 }

--- a/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
+++ b/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
@@ -4,8 +4,16 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void func_ov044_02111214(char*);
 extern int* data_ov031_02111424[];
-int _ZN25SlideDecorationSilverStar13InitResourcesEv(char *c){
-  unsigned short type = *(unsigned short*)(c+0xc);
+}
+
+struct SlideDecorationSilverStar {
+    int InitResources();
+};
+
+int SlideDecorationSilverStar::InitResources()
+{
+    char * c = (char *)this;
+unsigned short type = *(unsigned short*)(c+0xc);
   switch(type){
     case 0x12e: *(char*)(c+0x124)=0; break;
     case 0x12f: *(char*)(c+0x124)=1; break;
@@ -17,5 +25,5 @@ int _ZN25SlideDecorationSilverStar13InitResourcesEv(char *c){
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   func_ov044_02111214(c);
   return 1;
-}
+
 }

--- a/src/_ZN3Amp8BehaviorEv.cpp
+++ b/src/_ZN3Amp8BehaviorEv.cpp
@@ -6,9 +6,16 @@ extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void _ZN12CylinderClsn6UpdateEv(void *self);
 extern void func_ov070_02120724(void *c);
 extern int data_ov070_0212365c[];
-int _ZN3Amp8BehaviorEv(char *c)
+}
+
+struct Amp {
+    int Behavior();
+};
+
+int Amp::Behavior()
 {
-    int *p;
+    char * c = (char *)this;
+int *p;
     func_ov070_02120d34(c);
     p = (int *)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF);
     *p += data_ov070_0212365c[1];
@@ -17,5 +24,5 @@ int _ZN3Amp8BehaviorEv(char *c)
     _ZN12CylinderClsn6UpdateEv(c + 0x1d8);
     func_ov070_02120724(c);
     return 1;
-}
+
 }

--- a/src/_ZN3HUD17RenderSilverStarsEv.cpp
+++ b/src/_ZN3HUD17RenderSilverStarsEv.cpp
@@ -4,8 +4,15 @@ extern unsigned char data_0209f250[];
 extern signed char data_0209f310[];
 extern int data_ov001_020abac8[];
 int _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int, void *, int, int, int, int, void *);
-void _ZN3HUD17RenderSilverStarsEv(void) {
-    int sl = 0;
+}
+
+struct HUD {
+    void RenderSilverStars(void);
+};
+
+void HUD::RenderSilverStars(void)
+{
+int sl = 0;
     unsigned short n = (unsigned short)(short)data_0209f310[data_0209f250[0]];
     int sb;
     if (sl < n) {
@@ -16,5 +23,5 @@ void _ZN3HUD17RenderSilverStarsEv(void) {
             sb += 0x11;
         } while (sl < n);
     }
-}
+
 }

--- a/src/_ZN3HUD17UpdateHealthMeterEv.cpp
+++ b/src/_ZN3HUD17UpdateHealthMeterEv.cpp
@@ -14,9 +14,16 @@ extern char *data_0209f394[];
 extern int data_0208ee44;
 extern unsigned char data_ov002_0211117c;
 extern unsigned char data_ov002_02111178;
+}
 
-void _ZN3HUD17UpdateHealthMeterEv(char *c) {
-    int chr = data_0209f250;
+struct HUD {
+    void UpdateHealthMeter();
+};
+
+void HUD::UpdateHealthMeter()
+{
+    char * c = (char *)this;
+int chr = data_0209f250;
     char *player = data_0209f394[chr];
     unsigned int health = (data_02092144[chr] >> 8) & 0xff;
     if ((unsigned char)(data_0209f2c4 | data_0209f20c | data_0209f294) != 0)
@@ -134,5 +141,5 @@ void _ZN3HUD17UpdateHealthMeterEv(char *c) {
             *(unsigned char *)(c + 0x73) = 1;
         return;
     }
-}
+
 }

--- a/src/_ZN3HUD6RenderEv.cpp
+++ b/src/_ZN3HUD6RenderEv.cpp
@@ -1,6 +1,4 @@
 //cpp
-// _ZN3HUD6RenderEv at 0x020fd5e0
-// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 extern unsigned char data_0209f2d8;
 extern unsigned char data_0209fc9c;
@@ -23,9 +21,16 @@ void _ZN3HUD17RenderSilverStarsEv(void *);
 void _ZN3HUD15RenderTimeTimerEv(void *);
 void _ZN5Stage20RenderBouncingArrowsEv(void);
 void _ZN3HUD15RenderLifeCountEv(void *);
+}
 
-int _ZN3HUD6RenderEv(void *self) {
-    int b = (data_0209f2d8 == 1);
+struct HUD {
+    int Render();
+};
+
+int HUD::Render()
+{
+    void * self = (void *)this;
+int b = (data_0209f2d8 == 1);
     if (b) {
         if (data_0209fc9c != 0) goto end;
         if (((data_0209f2c4 | data_0209f20c | data_0209f294) & 0xff) == 0) {
@@ -69,5 +74,5 @@ int _ZN3HUD6RenderEv(void *self) {
     }
 end:
     return 1;
-}
+
 }

--- a/src/_ZN3Key6RenderEv.cpp
+++ b/src/_ZN3Key6RenderEv.cpp
@@ -2,10 +2,16 @@
 extern "C" {
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void*); };
 extern char data_ov089_021328b4[];
+}
 
-int _ZN3Key6RenderEv(char* c)
+struct Key {
+    int Render();
+};
+
+int Key::Render()
 {
-  int b = (int)((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
+    char* c = (char*)this;
+int b = (int)((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
   if (b) return 1;
   if (*(int*)(c+0x448) != 0) {
     ((Sub*)(c+0x114))->m(0);
@@ -16,5 +22,5 @@ int _ZN3Key6RenderEv(char* c)
     }
   }
   return 1;
-}
+
 }

--- a/src/_ZN3MrI16CleanupResourcesEv.cpp
+++ b/src/_ZN3MrI16CleanupResourcesEv.cpp
@@ -6,8 +6,15 @@ extern int data_ov002_0210da38;
 extern int data_ov071_02123050;
 extern int* data_ov071_021226a4;
 extern void* data_ov071_021226a0;
-int _ZN3MrI16CleanupResourcesEv(void){
-  int i;
+}
+
+struct MrI {
+    int CleanupResources(void);
+};
+
+int MrI::CleanupResources(void)
+{
+int i;
   UnloadBlueCoinModel();
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov071_02123050);
@@ -16,5 +23,5 @@ int _ZN3MrI16CleanupResourcesEv(void){
   }
   _ZN13SharedFilePtr7ReleaseEv(data_ov071_021226a0);
   return 1;
-}
+
 }

--- a/src/_ZN3MrI6RenderEv.cpp
+++ b/src/_ZN3MrI6RenderEv.cpp
@@ -4,9 +4,17 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int _ZN3MrI6RenderEv(char* c){
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x138, c+0xdc);
+}
+
+struct MrI {
+    int Render();
+};
+
+int MrI::Render()
+{
+    char* c = (char*)this;
+_ZN15TextureSequence6UpdateER15ModelComponents(c+0x138, c+0xdc);
   ((Sub*)(c+0xd4))->g5(c+0x80);
   return 1;
-}
+
 }

--- a/src/_ZN4Bird13InitResourcesEv.cpp
+++ b/src/_ZN4Bird13InitResourcesEv.cpp
@@ -8,9 +8,16 @@ void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigne
 void _ZN11ShadowModel12InitCylinderEv(void*);
 extern char data_ov009_02113c20[];
 extern char data_ov009_02113c28[];
+}
 
-int _ZN4Bird13InitResourcesEv(char* self){
-    void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov009_02113c20);
+struct Bird {
+    int InitResources();
+};
+
+int Bird::InitResources()
+{
+    char* self = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov009_02113c20);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(self+0xd4, m, 1, 1);
     void* a = _ZN9Animation8LoadFileER13SharedFilePtr(data_ov009_02113c28);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self+0xd4, a, 0, 0x1000, 0);
@@ -30,5 +37,5 @@ int _ZN4Bird13InitResourcesEv(char* self){
         *(int*)(self+0x17c) = zero;
     }
     return 1;
-}
+
 }

--- a/src/_ZN4Bird8BehaviorEv.cpp
+++ b/src/_ZN4Bird8BehaviorEv.cpp
@@ -10,8 +10,16 @@ struct PMF { int fn; int ptr; };
 struct Mtx { int w[12]; };
 extern struct PMF data_ov036_02113c48[];
 extern struct Mtx data_020a0e68;
-int _ZN4Bird8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x17c);
+}
+
+struct Bird {
+    int Behavior();
+};
+
+int Bird::Behavior()
+{
+    char* c = (char*)this;
+int idx = *(int*)(c+0x17c);
   struct PMF* m = &data_ov036_02113c48[idx];
   char* obj = c + (m->ptr >> 1);
   int p = m->ptr;
@@ -32,5 +40,5 @@ int _ZN4Bird8BehaviorEv(char* c){
   _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x138, c+0xf0, 0x1e000, 0x7d0000, 0xf);
   _ZN9Animation7AdvanceEv(c+0x124);
   return 1;
-}
+
 }

--- a/src/_ZN4Heap8_DestroyEv.cpp
+++ b/src/_ZN4Heap8_DestroyEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-/* _ZN4Heap8_DestroyEv @ 0x203c74c (arm9) -- tail-call veneer to _ZN4Heap7DestroyEv (0x203c758).
- * ldr ip, [pc]; bx ip; .word 0x203c758
- */
 extern "C" {
 extern void _ZN4Heap7DestroyEv(void);
-void _ZN4Heap8_DestroyEv(void) {
-    _ZN4Heap7DestroyEv();
 }
+
+struct Heap {
+    void _Destroy(void);
+};
+
+void Heap::_Destroy(void)
+{
+_ZN4Heap7DestroyEv();
+
 }

--- a/src/_ZN4Tree8BehaviorEv.cpp
+++ b/src/_ZN4Tree8BehaviorEv.cpp
@@ -3,8 +3,15 @@ extern "C" {
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12CylinderClsn6UpdateEv(void*);
 extern char* data_ov002_02110a48[5];
-int _ZN4Tree8BehaviorEv(void){
-  char** pp = data_ov002_02110a48;
+}
+
+struct Tree {
+    int Behavior(void);
+};
+
+int Tree::Behavior(void)
+{
+char** pp = data_ov002_02110a48;
   int i;
   for(i=0;i<5;i++){
     char* p = *pp;
@@ -16,5 +23,5 @@ int _ZN4Tree8BehaviorEv(void){
     pp++;
   }
   return 1;
-}
+
 }

--- a/src/_ZN5Actor14GetSubtractionEss.cpp
+++ b/src/_ZN5Actor14GetSubtractionEss.cpp
@@ -1,9 +1,14 @@
 //cpp
-extern "C" {
-int _ZN5Actor14GetSubtractionEss(void*self,short a,short b){
+struct Actor {
+    int GetSubtraction(short a, short b);
+};
+
+int Actor::GetSubtraction(short a, short b)
+{
+    void* self = (void*)this;
 int d=(short)(b-a);
 if(d==-0x8000) d=-0x7fff;
 if(d<0) d=(short)(-d);
 return d;
-}
+
 }

--- a/src/_ZN5Bully16CleanupResourcesEv.cpp
+++ b/src/_ZN5Bully16CleanupResourcesEv.cpp
@@ -1,12 +1,20 @@
 //cpp
 extern "C" {
 int _ZN13SharedFilePtr7ReleaseEv(void *);
-int _ZN5Bully16CleanupResourcesEv(char *c) {
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0));
+}
+
+struct Bully {
+    int CleanupResources();
+};
+
+int Bully::CleanupResources()
+{
+    char * c = (char *)this;
+_ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0));
     _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+4));
     _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+8));
     _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0xc));
     _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0x10));
     return 1;
-}
+
 }

--- a/src/_ZN5Pokey16CleanupResourcesEv.cpp
+++ b/src/_ZN5Pokey16CleanupResourcesEv.cpp
@@ -4,8 +4,16 @@ void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void *);
 extern int data_ov096_02137b20[];
 extern int data_ov096_02137b28[];
-int _ZN5Pokey16CleanupResourcesEv(char *c){
-  int id = *(unsigned short*)(c+0xc);
+}
+
+struct Pokey {
+    int CleanupResources();
+};
+
+int Pokey::CleanupResources()
+{
+    char * c = (char *)this;
+int id = *(unsigned short*)(c+0xc);
   int a = (id == 0xf0);
   if (a) {
     UnloadBlueCoinModel(c);
@@ -18,5 +26,5 @@ int _ZN5Pokey16CleanupResourcesEv(char *c){
     }
   }
   return 1;
-}
+
 }

--- a/src/_ZN5Shark13InitResourcesEv.cpp
+++ b/src/_ZN5Shark13InitResourcesEv.cpp
@@ -16,10 +16,16 @@ extern char data_ov090_021345ac[];
 extern char data_ov090_021345cc[];
 
 struct PathPtr { int a; int b; };
+}
 
-int _ZN5Shark13InitResourcesEv(char* c)
+struct Shark {
+    int InitResources();
+};
+
+int Shark::InitResources()
 {
-    PathPtr p1;
+    char* c = (char*)this;
+PathPtr p1;
     PathPtr p2;
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x30c,
         _ZN5Model8LoadFileER13SharedFilePtr(data_ov090_021345a4), 1, -1);
@@ -41,5 +47,5 @@ int _ZN5Shark13InitResourcesEv(char* c)
     _ZNK7PathPtr7GetNodeER7Vector3j(&p2, c + 0x5c, *(int*)(c + 0x390));
     func_ov090_021338b4(c, data_ov090_021345cc);
     return 1;
-}
+
 }

--- a/src/_ZN5Spiny8BehaviorEv.cpp
+++ b/src/_ZN5Spiny8BehaviorEv.cpp
@@ -12,10 +12,16 @@ void _ZN5Actor8PoofDustEv(void* c);
 void func_02012694(int a, void* p);
 
 extern signed char data_0209f2f8;
+}
 
-int _ZN5Spiny8BehaviorEv(char* c)
+struct Spiny {
+    int Behavior();
+};
+
+int Spiny::Behavior()
 {
-    int s = *(int*)(c + 0x3d8);
+    char* c = (char*)this;
+int s = *(int*)(c + 0x3d8);
     if (s != 1 || _ZNK12WithMeshClsn10IsOnGroundEv(c + 0x1e4)) {
         s = *(int*)(c + 0x3d8);
         if (s != 4 && s != 5 && _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, 0x5dc000)) {
@@ -37,5 +43,5 @@ int _ZN5Spiny8BehaviorEv(char* c)
     }
 done:
     return 1;
-}
+
 }

--- a/src/_ZN5Stage19BeforeInitResourcesEv.cpp
+++ b/src/_ZN5Stage19BeforeInitResourcesEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-/* _ZN5Stage19BeforeInitResourcesEv @ 0x202ddc8 (arm9) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
- * ldr ip, [pc]; bx ip; .word 0x202e66c
- */
 extern "C" {
 extern void _ZN5Scene19ResetFadersAndSoundEv(void);
-void _ZN5Stage19BeforeInitResourcesEv(void) {
-    _ZN5Scene19ResetFadersAndSoundEv();
 }
+
+struct Stage {
+    void BeforeInitResources(void);
+};
+
+void Stage::BeforeInitResources(void)
+{
+_ZN5Scene19ResetFadersAndSoundEv();
+
 }

--- a/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
+++ b/src/_ZN5Stage20RenderBouncingArrowsEv.cpp
@@ -1,6 +1,4 @@
 //cpp
-// _ZN5Stage20RenderBouncingArrowsEv at 0x02023be0
-// Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
 extern "C" {
 extern int data_0208ee44;
 extern int data_020a0db0;
@@ -10,9 +8,15 @@ extern unsigned char data_0209f2d8;
 extern unsigned char data_0209f248;
 extern void func_020abd88(void);
 int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, void*, int, int, int, int, int, int, int, int);
+}
 
-void _ZN5Stage20RenderBouncingArrowsEv(void) {
-    int r4;
+struct Stage {
+    void RenderBouncingArrows(void);
+};
+
+void Stage::RenderBouncingArrows(void)
+{
+int r4;
     unsigned char A;
     if (data_0208ee44 == 1) {
         r4 = (data_020a0db0 & 0x10) ? 0xae : 0xb0;
@@ -38,5 +42,5 @@ draw2:
     _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xc, r4, -1, -1, 0x1000, 0x1000, 0, -1);
     _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, (void*)func_020abd88, 0xf4, r4, -1, -1, 0x1000, 0x1000, 0, -1);
     return;
-}
+
 }

--- a/src/_ZN5Stage7VE_InitEv.cpp
+++ b/src/_ZN5Stage7VE_InitEv.cpp
@@ -15,10 +15,15 @@ extern void SetBg2Offset(int a, int b);
 extern void SetSubBg0Offset(int a, int b);
 extern void SetSubBg1Offset(int a, int b);
 extern void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short *p, int val, short amt);
+}
 
-void _ZN5Stage7VE_InitEv(void)
+struct Stage {
+    void VE_Init(void);
+};
+
+void Stage::VE_Init(void)
 {
-    unsigned int a;
+unsigned int a;
     unsigned int b;
 
     a = data_0209d45c[0] ^ 0x10;
@@ -42,5 +47,5 @@ void _ZN5Stage7VE_InitEv(void)
     data_0209f290[0] = 0;
     _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short *)0x4000050, a | 0x20, -7);
     _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short *)0x4001050, b | 0x20, -7);
-}
+
 }

--- a/src/_ZN5Stage9LoadModelEv.cpp
+++ b/src/_ZN5Stage9LoadModelEv.cpp
@@ -3,10 +3,16 @@ extern "C" {
 extern char data_0209f340[];
 extern int data_0209f320;
 void _ZN5Model14LoadAndSetFileEtii(char* model, unsigned short id, int b, int c);
-void _ZN5Stage9LoadModelEv(char* self);
 }
-void _ZN5Stage9LoadModelEv(char* self) {
-    _ZN5Model14LoadAndSetFileEtii(self + 0x86c, *(unsigned short*)(*(char**)data_0209f340 + 8), 1, -1);
+
+struct Stage {
+    void LoadModel();
+};
+
+void Stage::LoadModel()
+{
+    char* self = (char*)this;
+_ZN5Model14LoadAndSetFileEtii(self + 0x86c, *(unsigned short*)(*(char**)data_0209f340 + 8), 1, -1);
     char* list;
     unsigned int count;
     char* node;
@@ -27,4 +33,5 @@ void _ZN5Stage9LoadModelEv(char* self) {
         node += 0x30;
     }
     data_0209f320 = (int)p;
+
 }

--- a/src/_ZN5Stump6RenderEv.cpp
+++ b/src/_ZN5Stump6RenderEv.cpp
@@ -1,12 +1,19 @@
 //cpp
 extern "C" {
 struct V { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual int m5(int); };
-int _ZN5Stump6RenderEv(char *c)
+}
+
+struct Stump {
+    int Render();
+};
+
+int Stump::Render()
 {
-    if (*(int*)(c+0x374) == 1) return 1;
+    char * c = (char *)this;
+if (*(int*)(c+0x374) == 1) return 1;
     int b = (*(int*)(c+0xb0) & 0x40000) != 0;
     if (b) return 1;
     ((V*)(c+0x300))->m5(0);
     return 1;
-}
+
 }

--- a/src/_ZN5Whomp6RenderEv.cpp
+++ b/src/_ZN5Whomp6RenderEv.cpp
@@ -4,11 +4,19 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
 extern "C" {
-int _ZN5Whomp6RenderEv(char* c){
-  if(*(unsigned char*)(c+0x404)==0) return 1;
+}
+
+struct Whomp {
+    int Render();
+};
+
+int Whomp::Render()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x404)==0) return 1;
   if(*(unsigned char*)(c+0x414)!=0)
     _ZN15TextureSequence6UpdateER15ModelComponents(c+0x330, c+0x2d4);
   ((Sub*)(c+0x2cc))->g5(0);
   return 1;
-}
+
 }

--- a/src/_ZN6Camera14GoBehindPlayerEj.cpp
+++ b/src/_ZN6Camera14GoBehindPlayerEj.cpp
@@ -8,10 +8,16 @@ extern int data_0209b0e8;
 extern void func_0200cb58(void *obj, int index);
 extern void func_0200c66c(void *self, void *base, int *a, int *b, int *c);
 extern void _ZN6Camera11ChangeStateEPNS_5StateE(void *self, void *st);
+}
 
-void _ZN6Camera14GoBehindPlayerEj(int self, unsigned int j)
+struct Camera {
+    void GoBehindPlayer(unsigned int j);
+};
+
+void Camera::GoBehindPlayer(unsigned int j)
 {
-    int slot4, slot8, slotc;
+    int self = (int)this;
+int slot4, slot8, slotc;
 
     if (j != data_0209f250)
         return;
@@ -31,5 +37,5 @@ void _ZN6Camera14GoBehindPlayerEj(int self, unsigned int j)
     if (slot4 == (int)&data_0208742c)
         return;
     _ZN6Camera11ChangeStateEPNS_5StateE((void *)self, &data_0209b0e8);
-}
+
 }

--- a/src/_ZN6Lakitu8BehaviorEv.cpp
+++ b/src/_ZN6Lakitu8BehaviorEv.cpp
@@ -3,11 +3,19 @@ extern "C" {
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void*, int);
 extern int func_ov077_02124718(void*);
 extern int func_ov077_02123d40(void*);
-int _ZN6Lakitu8BehaviorEv(char *c){
-  int v = *(int*)(c+8);
+}
+
+struct Lakitu {
+    int Behavior();
+};
+
+int Lakitu::Behavior()
+{
+    char * c = (char *)this;
+int v = *(int*)(c+8);
   if(_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, v ? 0x1068000 : 0x7d0000)) return 1;
   func_ov077_02124718(c);
   func_ov077_02123d40(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player11St_Fly_InitEv.cpp
+++ b/src/_ZN6Player11St_Fly_InitEv.cpp
@@ -4,8 +4,16 @@ extern int data_0209f318[];
 extern void func_ov002_020dab14(char*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern void func_0200d6f0(void*,unsigned char);
-int _ZN6Player11St_Fly_InitEv(char* c){
-  *(short*)(c+0x69e)=0;
+}
+
+struct Player {
+    int St_Fly_Init();
+};
+
+int Player::St_Fly_Init()
+{
+    char* c = (char*)this;
+*(short*)(c+0x69e)=0;
   *(short*)(c+0x69c)=0;
   *(short*)(c+0x92)=0;
   *(short*)(c+0x96)=0;
@@ -21,5 +29,5 @@ int _ZN6Player11St_Fly_InitEv(char* c){
   }
   func_0200d6f0((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
   return 1;
-}
+
 }

--- a/src/_ZN6Player11St_Owl_InitEv.cpp
+++ b/src/_ZN6Player11St_Owl_InitEv.cpp
@@ -4,8 +4,16 @@ extern int data_0209f318[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern void func_0200d6b4(void*,unsigned char);
 extern void func_ov002_020bd928(char*,unsigned int);
-int _ZN6Player11St_Owl_InitEv(char* c){
-  *(int*)(c+0xa0)=-0x4b000;
+}
+
+struct Player {
+    int St_Owl_Init();
+};
+
+int Player::St_Owl_Init()
+{
+    char* c = (char*)this;
+*(int*)(c+0xa0)=-0x4b000;
   *(int*)(c+0x9c)=0;
   *(unsigned char*)(c+0x6e3)=0;
   *(int*)(c+0x98)=0;
@@ -13,5 +21,5 @@ int _ZN6Player11St_Owl_InitEv(char* c){
   func_0200d6b4((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
   func_ov002_020bd928(c,0x2f);
   return 1;
-}
+
 }

--- a/src/_ZN6Player11St_Owl_MainEv.cpp
+++ b/src/_ZN6Player11St_Owl_MainEv.cpp
@@ -19,10 +19,16 @@ extern int data_ov002_021101b4[];
 extern short data_02082214[];
 extern char* data_0209f318;
 extern unsigned char data_0209d660;
+}
 
-int _ZN6Player11St_Owl_MainEv(char* c)
+struct Player {
+    int St_Owl_Main();
+};
+
+int Player::St_Owl_Main()
 {
-    unsigned char st;
+    char* c = (char*)this;
+unsigned char st;
 
     *(int*)(c+0x684) = *(int*)(c+0x60);
     st = *(unsigned char*)(c+0x6e3);
@@ -114,5 +120,5 @@ int _ZN6Player11St_Owl_MainEv(char* c)
     *(short*)(c+0x94) = *(short*)(c+0x8e);
     func_ov002_020bedd4(c);
     return 1;
-}
+
 }

--- a/src/_ZN6Player12GetHurtStateEv.cpp
+++ b/src/_ZN6Player12GetHurtStateEv.cpp
@@ -2,9 +2,17 @@
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* st);
 extern int data_ov002_02110094[];
-int _ZN6Player12GetHurtStateEv(char* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110094))
+}
+
+struct Player {
+    int GetHurtState();
+};
+
+int Player::GetHurtState()
+{
+    char* c = (char*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110094))
     return *(unsigned char*)(c+0x6e3) & 7;
   return -1;
-}
+
 }

--- a/src/_ZN6Player12GetTalkStateEv.cpp
+++ b/src/_ZN6Player12GetTalkStateEv.cpp
@@ -3,12 +3,20 @@ extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player12GetTalkStateEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c)) return -1;
+}
+
+struct Player {
+    int GetTalkState();
+};
+
+int Player::GetTalkState()
+{
+    char* c = (char*)this;
+if(!_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c)) return -1;
   unsigned char v=*(unsigned char*)(c+0x6e3);
   if(v==0) return 0;
   if(v==3) return 2;
   if(v==5||v==7) return 3;
   return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Bonk_InitEv.cpp
+++ b/src/_ZN6Player12St_Bonk_InitEv.cpp
@@ -1,12 +1,20 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player12St_Bonk_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x13,0x40000000,0x1000,0);
+}
+
+struct Player {
+    int St_Bonk_Init();
+};
+
+int Player::St_Bonk_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c,0x13,0x40000000,0x1000,0);
   *(short*)(c+0x6a4)=0x10;
   *(int*)(c+0x98)=0x40;
   *(int*)(c+0xa8)=0xa000;
   *(char*)(c+0x6e5)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Jump_MainEv.cpp
+++ b/src/_ZN6Player12St_Jump_MainEv.cpp
@@ -19,9 +19,16 @@ extern u8 data_020a0e40;
 extern u8 data_0209f4ab[];
 extern u16 data_0209f49e[];
 extern int data_ov002_0211073c[];
+}
 
-int _ZN6Player12St_Jump_MainEv(void* c) {
-  func_ov002_020eeca8((char*)c + 0x380, c);
+struct Player {
+    int St_Jump_Main();
+};
+
+int Player::St_Jump_Main()
+{
+    void* c = (void*)this;
+func_ov002_020eeca8((char*)c + 0x380, c);
   func_ov002_020e28d4(c, 0xd00, 0x800);
 
   if (*(u8*)((char*)c + 0x6de) == 0) {
@@ -80,5 +87,5 @@ int _ZN6Player12St_Jump_MainEv(void* c) {
 
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Null_InitEv.cpp
+++ b/src/_ZN6Player12St_Null_InitEv.cpp
@@ -5,8 +5,15 @@ extern char* data_ov006_02140554;
 void func_ov006_020c8f20(void*);
 void func_ov006_020ce46c(void*,int);
 void func_ov006_020c8a64(void);
-void _ZN6Player12St_Null_InitEv(void){
-  int i=0;
+}
+
+struct Player {
+    void St_Null_Init(void);
+};
+
+void Player::St_Null_Init(void)
+{
+int i=0;
   if(data_ov006_021405bc>0){
     int off=0;
     do{
@@ -17,5 +24,5 @@ void _ZN6Player12St_Null_InitEv(void){
     }while(i<data_ov006_021405bc);
   }
   func_ov006_020c8a64();
-}
+
 }

--- a/src/_ZN6Player12St_Spin_InitEv.cpp
+++ b/src/_ZN6Player12St_Spin_InitEv.cpp
@@ -6,8 +6,16 @@ extern int* data_0209f318;
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, Fix12i d, unsigned int e);
 extern void func_ov002_020e25f0(void* c, int i);
 extern void func_0200d678(Camera* thiz, unsigned char pid);
-int _ZN6Player12St_Spin_InitEv(char* c){
-  *(unsigned char*)(c+0x71b) = 0;
+}
+
+struct Player {
+    int St_Spin_Init();
+};
+
+int Player::St_Spin_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x71b) = 0;
   *(unsigned char*)(c+0x712) = 1;
   *(unsigned char*)(c+0x70d) = 0;
   *(unsigned char*)(c+0x6e1) = 0;
@@ -26,5 +34,5 @@ int _ZN6Player12St_Spin_InitEv(char* c){
   unsigned char pid = *(unsigned char*)(c+0x6d8);
   func_0200d678((Camera*)*cam_ptr_ptr, pid);
   return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Swim_InitEv.cpp
+++ b/src/_ZN6Player12St_Swim_InitEv.cpp
@@ -5,8 +5,16 @@ extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned,unsigned,void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void func_0200d768(void*,unsigned char);
 extern int data_0209f318[];
-int _ZN6Player12St_Swim_InitEv(char* c){
-  func_ov002_020dab14(c);
+}
+
+struct Player {
+    int St_Swim_Init();
+};
+
+int Player::St_Swim_Init()
+{
+    char* c = (char*)this;
+func_ov002_020dab14(c);
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x2e,c+0x74);
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0xa7,0x40000000,0x1000,0);
   *(char*)(c+0x6e3)=0;
@@ -22,5 +30,5 @@ int _ZN6Player12St_Swim_InitEv(char* c){
   *(char*)(c+0x70c)=0;
   *(short*)(c+0x6a8)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Swim_MainEv.cpp
+++ b/src/_ZN6Player12St_Swim_MainEv.cpp
@@ -45,10 +45,16 @@ extern unsigned char data_020a0e40;
 extern unsigned short data_0209f49c;
 extern unsigned short data_0209f49e;
 extern char data_0209ee90[];
+}
 
-int _ZN6Player12St_Swim_MainEv(char* c)
+struct Player {
+    int St_Swim_Main();
+};
+
+int Player::St_Swim_Main()
 {
-    int t4;
+    char* c = (char*)this;
+int t4;
     volatile int pos[3];
     int* fr;
     int ang;
@@ -290,5 +296,5 @@ int _ZN6Player12St_Swim_MainEv(char* c)
     if (func_ov002_020ce5f8(c) != 0) return 1;
     func_ov002_020bedd4(c);
     return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Wait_InitEv.cpp
+++ b/src/_ZN6Player12St_Wait_InitEv.cpp
@@ -5,10 +5,16 @@ extern int _ZN6Player9GetHealthEv(void* c);
 
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0[];
+}
 
-int _ZN6Player12St_Wait_InitEv(char* c)
+struct Player {
+    int St_Wait_Init();
+};
+
+int Player::St_Wait_Init()
 {
-    unsigned char f2d8;
+    char* c = (char*)this;
+unsigned char f2d8;
     int b0;
 
     *(unsigned char*)(c + 0x6e6) = 0;
@@ -55,5 +61,5 @@ L13c:
     }
     *(unsigned short*)(c + 0x6a4) = 0x384;
     return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Wait_MainEv.cpp
+++ b/src/_ZN6Player12St_Wait_MainEv.cpp
@@ -30,10 +30,16 @@ extern int data_0209caa0[];
 extern unsigned char data_0209f49e[];
 extern int data_ov002_0211019c[];
 extern int data_ov002_0211013c[];
+}
 
-int _ZN6Player12St_Wait_MainEv(char* c)
+struct Player {
+    int St_Wait_Main();
+};
+
+int Player::St_Wait_Main()
 {
-    if ((unsigned short)(*(unsigned short*)(c+0x6ce) & 1)) {
+    char* c = (char*)this;
+if ((unsigned short)(*(unsigned short*)(c+0x6ce) & 1)) {
         func_ov002_020c0364(c, 3);
         return 1;
     }
@@ -299,5 +305,5 @@ int _ZN6Player12St_Wait_MainEv(char* c)
 
     func_ov002_020bedd4(c);
     return 1;
-}
+
 }

--- a/src/_ZN6Player12St_Walk_InitEv.cpp
+++ b/src/_ZN6Player12St_Walk_InitEv.cpp
@@ -21,10 +21,16 @@ extern int data_ov002_0211010c[];
 extern int data_ov002_02110154[];
 extern int data_ov002_0210e160[];
 extern int data_ov002_020ff1b0[4];
+}
 
-int _ZN6Player12St_Walk_InitEv(char *c)
+struct Player {
+    int St_Walk_Init();
+};
+
+int Player::St_Walk_Init()
 {
-    if (_ZN6Player9GetHealthEv(c) == 0) {
+    char * c = (char *)this;
+if (_ZN6Player9GetHealthEv(c) == 0) {
         *(unsigned char *)(c + 0x6e3) = 1;
         _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211010c);
         return 1;
@@ -102,5 +108,5 @@ merge:
         _ZN6Player17SetNoControlStateEhih(c, 0xd, -1, 0);
     }
     return 1;
-}
+
 }

--- a/src/_ZN6Player12Unk_020c4f40Et.cpp
+++ b/src/_ZN6Player12Unk_020c4f40Et.cpp
@@ -3,12 +3,20 @@ extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player12Unk_020c4f40Et(char* c, unsigned short x){
-  if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
+}
+
+struct Player {
+    int Unk_020c4f40(unsigned short x);
+};
+
+int Player::Unk_020c4f40(unsigned short x)
+{
+    char* c = (char*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
     *(unsigned short*)(c+0x6a6)=x;
     *(unsigned char*)(c+0x6e3)=5;
     return 1;
   }
   return 0;
-}
+
 }

--- a/src/_ZN6Player13St_Crawl_InitEv.cpp
+++ b/src/_ZN6Player13St_Crawl_InitEv.cpp
@@ -1,9 +1,17 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player13St_Crawl_InitEv(char* c){
-  *(char*)(c+0x6e3)=3;
+}
+
+struct Player {
+    int St_Crawl_Init();
+};
+
+int Player::St_Crawl_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x6e3)=3;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x64,0x40000000,0x1000,0);
   return 1;
-}
+
 }

--- a/src/_ZN6Player13St_Shell_InitEv.cpp
+++ b/src/_ZN6Player13St_Shell_InitEv.cpp
@@ -3,11 +3,19 @@ extern "C" {
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov002_020bd928(void*,int);
-int _ZN6Player13St_Shell_InitEv(char* c){
-  func_ov002_020dab14(c);
+}
+
+struct Player {
+    int St_Shell_Init();
+};
+
+int Player::St_Shell_Init()
+{
+    char* c = (char*)this;
+func_ov002_020dab14(c);
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x35,0x40000000,0x1000,0);
   *(char*)(c+0x6e3)=0;
   func_ov002_020bd928(c,0x33);
   return 1;
-}
+
 }

--- a/src/_ZN6Player13St_Throw_InitEv.cpp
+++ b/src/_ZN6Player13St_Throw_InitEv.cpp
@@ -1,12 +1,18 @@
 //cpp
-// _ZN6Player13St_Throw_InitEv at 0x020dafd4
-// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 struct Vector3{int x,y,z;};
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned a, unsigned b, const Vector3& v);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
-int _ZN6Player13St_Throw_InitEv(char* c){
-  int* p = *(int**)(c+0x358);
+}
+
+struct Player {
+    int St_Throw_Init();
+};
+
+int Player::St_Throw_Init()
+{
+    char* c = (char*)this;
+int* p = *(int**)(c+0x358);
   int b = (*(int*)((char*)p+0xb0) & 0x200) ? 1 : 0;
   if(!b){
     unsigned short a = *(unsigned short*)((char*)p+0xc);
@@ -25,5 +31,5 @@ voice:
     _ZN6Player7SetAnimEji5Fix12IiEj(c,0x8a,0x40000000,0x1000,0);
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player13St_Throw_MainEv.cpp
+++ b/src/_ZN6Player13St_Throw_MainEv.cpp
@@ -1,6 +1,4 @@
 //cpp
-// _ZN6Player13St_Throw_MainEv at 0x020dae6c
-// Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 extern int _Z14ApproachLinearRiii(int&, int, int);
 extern int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned, int);
@@ -12,9 +10,16 @@ extern int _ZN6Player12FinishedAnimEv(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern void func_ov002_020bedd4(void*);
 extern int data_ov002_0211013c[];
+}
 
-int _ZN6Player13St_Throw_MainEv(char* c){
-  if(*(unsigned char*)(c+0x6de)==0){
+struct Player {
+    int St_Throw_Main();
+};
+
+int Player::St_Throw_Main()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6de)==0){
     _Z14ApproachLinearRiii(*(int*)(c+0x98), 0, 0x1000);
   }
   if(*(char**)(c+0x358)){
@@ -51,5 +56,5 @@ int _ZN6Player13St_Throw_MainEv(char* c){
     _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player13TryTalkToDoorEh.cpp
+++ b/src/_ZN6Player13TryTalkToDoorEh.cpp
@@ -5,8 +5,16 @@ extern int _ZN6Player17SetNoControlStateEhih(void*,unsigned char,int,unsigned ch
 extern int data_ov002_0211013c[];
 extern int _ZN6Player7ST_WAITE[];
 extern int data_ov002_0211043c[];
-int _ZN6Player13TryTalkToDoorEh(void* c, unsigned char a){
-  if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
+}
+
+struct Player {
+    int TryTalkToDoor(unsigned char a);
+};
+
+int Player::TryTalkToDoor(unsigned char a)
+{
+    void* c = (void*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
      || _ZN6Player7IsStateERNS_5StateE(c,_ZN6Player7ST_WAITE)
      || _ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211043c)){
     *(unsigned char*)((char*)c+0x70c)=a;
@@ -14,5 +22,5 @@ int _ZN6Player13TryTalkToDoorEh(void* c, unsigned char a){
     return 1;
   }
   return 0;
-}
+
 }

--- a/src/_ZN6Player14IsFrontSlidingEv.cpp
+++ b/src/_ZN6Player14IsFrontSlidingEv.cpp
@@ -1,7 +1,15 @@
 //cpp
 extern "C" {
 int _ZN6Player6IsAnimEj(void*, unsigned int);
-int _ZN6Player14IsFrontSlidingEv(void* c){
-  return _ZN6Player6IsAnimEj(c, 0x43) || _ZN6Player6IsAnimEj(c, 0x40);
 }
+
+struct Player {
+    int IsFrontSliding();
+};
+
+int Player::IsFrontSliding()
+{
+    void* c = (void*)this;
+return _ZN6Player6IsAnimEj(c, 0x43) || _ZN6Player6IsAnimEj(c, 0x40);
+
 }

--- a/src/_ZN6Player14St_Cannon_InitEv.cpp
+++ b/src/_ZN6Player14St_Cannon_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern int func_ov002_020c9e40(void*);
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_Cannon_InitEv(char* c){
-  func_ov002_020c9e40(c);
+}
+
+struct Player {
+    int St_Cannon_Init();
+};
+
+int Player::St_Cannon_Init()
+{
+    char* c = (char*)this;
+func_ov002_020c9e40(c);
   *(unsigned char*)(c+0x706)=0;
   *(unsigned char*)(c+0x712)=1;
   *(unsigned char*)(c+0x70d)=0;
@@ -19,5 +27,5 @@ int _ZN6Player14St_Cannon_InitEv(char* c){
   *(unsigned char*)(c+0x6e5)=0;
   *(unsigned char*)(c+0x6f6)=1;
   return 1;
-}
+
 }

--- a/src/_ZN6Player14St_Crouch_InitEv.cpp
+++ b/src/_ZN6Player14St_Crouch_InitEv.cpp
@@ -1,13 +1,20 @@
 //cpp
-struct Vector3 { int x,y,z; };
 extern "C" {
 extern unsigned char data_020a0e40;
 extern unsigned char data_0209f49c[];
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
 extern int func_ov002_020d1204(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_Crouch_InitEv(char* c){
-  if(*(unsigned char*)(c+0x6ed)){
+}
+
+struct Player {
+    int St_Crouch_Init();
+};
+
+int Player::St_Crouch_Init()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6ed)){
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x2e,(struct Vector3*)(c+0x74));
   }
   *(short*)(c+0x6a4)=0x1e;
@@ -21,5 +28,5 @@ int _ZN6Player14St_Crouch_InitEv(char* c){
     _ZN6Player7SetAnimEji5Fix12IiEj(c,0x2c,0,0x1000,0);
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player14St_OnWall_InitEv.cpp
+++ b/src/_ZN6Player14St_OnWall_InitEv.cpp
@@ -2,13 +2,21 @@
 extern "C" {
 extern int data_ov002_020ff164[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_OnWall_InitEv(char* c){
-  int r3=0x1000;
+}
+
+struct Player {
+    int St_OnWall_Init();
+};
+
+int Player::St_OnWall_Init()
+{
+    char* c = (char*)this;
+int r3=0x1000;
   if(*(int*)(c+8)==2){
     if(*(unsigned char*)(c+0x6e3)==2) r3=0x2000;
   }
   _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff164[*(unsigned char*)(c+0x6e3)], 0, r3, 0);
   *(int*)(c+0x98)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player14St_Owl_CleanupEv.cpp
+++ b/src/_ZN6Player14St_Owl_CleanupEv.cpp
@@ -1,9 +1,17 @@
 //cpp
 extern "C" {
 extern int func_ov002_020bd8c0(void*,int);
-int _ZN6Player14St_Owl_CleanupEv(char* c){
-  func_ov002_020bd8c0(c,0x2f);
+}
+
+struct Player {
+    int St_Owl_Cleanup();
+};
+
+int Player::St_Owl_Cleanup()
+{
+    char* c = (char*)this;
+func_ov002_020bd8c0(c,0x2f);
   *(int*)(c+0x358)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player14St_Thrown_InitEv.cpp
+++ b/src/_ZN6Player14St_Thrown_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 struct Vector3{int x,y,z;};
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned a, unsigned b, const Vector3& v);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
-int _ZN6Player14St_Thrown_InitEv(char* c){
-  int b = (*(int*)(c+0xb0) & 0x400) ? 1 : 0;
+}
+
+struct Player {
+    int St_Thrown_Init();
+};
+
+int Player::St_Thrown_Init()
+{
+    char* c = (char*)this;
+int b = (*(int*)(c+0xb0) & 0x400) ? 1 : 0;
   if(b)
     *(short*)(c+0x6a4)=4;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x1d, *(Vector3*)(c+0x74));
@@ -14,5 +22,5 @@ int _ZN6Player14St_Thrown_InitEv(char* c){
   *(short*)(c+0x8e)=*(short*)(c+0x94);
   *(unsigned char*)(c+0x70c)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player15IsEnteringLevelEv.cpp
+++ b/src/_ZN6Player15IsEnteringLevelEv.cpp
@@ -1,10 +1,18 @@
 //cpp
 extern "C" {
 extern int _ZN6Player20IsStateEnteringLevelEv(char*c);
-int _ZN6Player15IsEnteringLevelEv(char*c){
-  if(_ZN6Player20IsStateEnteringLevelEv(c)==0) return 0;
+}
+
+struct Player {
+    int IsEnteringLevel();
+};
+
+int Player::IsEnteringLevel()
+{
+    char* c = (char*)this;
+if(_ZN6Player20IsStateEnteringLevelEv(c)==0) return 0;
   unsigned char s=*(unsigned char*)(c+0x6e3);
   if(s==8||s==9||s==0x10) return 1;
   return 0;
-}
+
 }

--- a/src/_ZN6Player15St_Balloon_InitEv.cpp
+++ b/src/_ZN6Player15St_Balloon_InitEv.cpp
@@ -5,8 +5,16 @@ extern int data_0209f318[];
 extern void func_0200d63c(void*,unsigned char);
 extern int data_ov002_0210e750[];
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,void*,int,int,unsigned int);
-int _ZN6Player15St_Balloon_InitEv(char* c){
-  func_ov002_020dab14(c);
+}
+
+struct Player {
+    int St_Balloon_Init();
+};
+
+int Player::St_Balloon_Init()
+{
+    char* c = (char*)this;
+func_ov002_020dab14(c);
   *(unsigned char*)(c+0x712)=1;
   *(unsigned char*)(c+0x70d)=0;
   if(*(int*)(c+0xa8) >= 0x10000) *(int*)(c+0xa8)=0x10000;
@@ -20,5 +28,5 @@ int _ZN6Player15St_Balloon_InitEv(char* c){
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c+0xf0), (void*)data_ov002_0210e750[1], 0x40000000, 0x1000, 0);
   *(int*)(c+0x148)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player15St_DeadHit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadHit_InitEv.cpp
@@ -5,8 +5,16 @@ extern int data_ov002_0210a424[];
 extern char* data_0209f318;
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void func_0200d89c(char*p);
-int _ZN6Player15St_DeadHit_InitEv(char*c){
-  func_ov002_020c9e40(c);
+}
+
+struct Player {
+    int St_DeadHit_Init();
+};
+
+int Player::St_DeadHit_Init()
+{
+    char* c = (char*)this;
+func_ov002_020c9e40(c);
   *(unsigned char*)(c+0x713)=0;
   int idx=*(unsigned char*)(c+0x6e3)&1;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,data_ov002_0210a424[idx],0x40000000,0x1000,0);
@@ -14,5 +22,5 @@ int _ZN6Player15St_DeadHit_InitEv(char*c){
   *(unsigned char*)(c+0x6e5)=0;
   func_0200d89c(data_0209f318);
   return 1;
-}
+
 }

--- a/src/_ZN6Player15St_DeadPit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_InitEv.cpp
@@ -13,10 +13,16 @@ void HitDeathPlane(int arg);
 void FUN_020299f4(void);
 void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int a, int b, int f, unsigned int g);
 void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, char* v);
+}
 
-int _ZN6Player15St_DeadPit_InitEv(char* c)
+struct Player {
+    int St_DeadPit_Init();
+};
+
+int Player::St_DeadPit_Init()
 {
-    func_ov002_020dab14(c);
+    char* c = (char*)this;
+func_ov002_020dab14(c);
     if (*(char**)(c + 0x360) != 0) {
         int b = (*(u16*)(*(char**)(c + 0x360) + 0xc) == 0xbf);
         if (b) {
@@ -102,5 +108,5 @@ int _ZN6Player15St_DeadPit_InitEv(char* c)
         }
     }
     return 1;
-}
+
 }

--- a/src/_ZN6Player15St_Grabbed_InitEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern void func_ov002_020da9d4(void* c);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
-int _ZN6Player15St_Grabbed_InitEv(char* c){
-  func_ov002_020da9d4(c);
+}
+
+struct Player {
+    int St_Grabbed_Init();
+};
+
+int Player::St_Grabbed_Init()
+{
+    char* c = (char*)this;
+func_ov002_020da9d4(c);
   *(int*)(int)(((unsigned long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
   *(unsigned char*)(c+0x713) = 0;
   *(unsigned char*)(c+0x716) = 1;
@@ -13,5 +21,5 @@ int _ZN6Player15St_Grabbed_InitEv(char* c){
   *(unsigned char*)(c+0x717) = 1;
   *(unsigned char*)(c+0x6e3) = 0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player15St_Swallow_InitEv.cpp
+++ b/src/_ZN6Player15St_Swallow_InitEv.cpp
@@ -4,8 +4,16 @@ struct State; extern State data_ov002_02110034;
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,State*);
 extern int func_ov002_020c9e40(void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player15St_Swallow_InitEv(char* c){
-  if(*(void**)(c+0x360)){
+}
+
+struct Player {
+    int St_Swallow_Init();
+};
+
+int Player::St_Swallow_Init()
+{
+    char* c = (char*)this;
+if(*(void**)(c+0x360)){
     void* o=*(void**)(c+0x360);
     int(*f)(void*)=*(int(**)(void*))(*(char**)o+0x48);
     if(f(o)==4){
@@ -19,5 +27,5 @@ int _ZN6Player15St_Swallow_InitEv(char* c){
   }
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x70,0x40000000,0x1000,0);
   return 1;
-}
+
 }

--- a/src/_ZN6Player15St_Swallow_MainEv.cpp
+++ b/src/_ZN6Player15St_Swallow_MainEv.cpp
@@ -14,10 +14,16 @@ extern void func_ov002_020bedd4(char* c);
 extern int data_0209ee90[];
 extern int data_ov002_0211067c;
 extern int data_ov002_0211013c;
+}
 
-int _ZN6Player15St_Swallow_MainEv(char* c)
+struct Player {
+    int St_Swallow_Main();
+};
+
+int Player::St_Swallow_Main()
 {
-    void* p360;
+    char* c = (char*)this;
+void* p360;
 
     if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c + 8) & 0xff, 0) << 2) + 0xdc)) + 0x50, 3)) {
         func_ov002_020d71a0(c);
@@ -73,5 +79,5 @@ L65ec:
     }
     func_ov002_020bedd4(c);
     return 1;
-}
+
 }

--- a/src/_ZN6Player15St_Swim_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Swim_CleanupEv.cpp
@@ -1,11 +1,19 @@
 //cpp
 extern "C" {
 extern int func_ov002_020bd8c0(void*,int);
-int _ZN6Player15St_Swim_CleanupEv(char* c){
-  if(*(unsigned char*)(c+0x6f7)!=0){
+}
+
+struct Player {
+    int St_Swim_Cleanup();
+};
+
+int Player::St_Swim_Cleanup()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6f7)!=0){
     *(char*)(c+0x6f7)=0;
     func_ov002_020bd8c0(c,0x33);
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player15St_Wait_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Wait_CleanupEv.cpp
@@ -3,10 +3,16 @@ extern "C" {
 extern unsigned char data_0209f2d8;
 extern void* data_0209f318;
 extern int data_0209caa0[];
+}
 
-int _ZN6Player15St_Wait_CleanupEv(char* c)
+struct Player {
+    int St_Wait_Cleanup();
+};
+
+int Player::St_Wait_Cleanup()
 {
-    void* r4 = data_0209f318;
+    char* c = (char*)this;
+void* r4 = data_0209f318;
     (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
     *(unsigned char*)(c+0x721) = 0;
     do {
@@ -23,5 +29,5 @@ int _ZN6Player15St_Wait_CleanupEv(char* c)
         }
     } while (0);
     return 1;
-}
+
 }

--- a/src/_ZN6Player16IsInsideOfCannonEv.cpp
+++ b/src/_ZN6Player16IsInsideOfCannonEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 struct State;
 extern State data_ov002_021102d4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player16IsInsideOfCannonEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
-  return *(unsigned char*)(c+0x6e3)!=2 ? 1 : 0;
 }
+
+struct Player {
+    int IsInsideOfCannon();
+};
+
+int Player::IsInsideOfCannon()
+{
+    char* c = (char*)this;
+if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
+  return *(unsigned char*)(c+0x6e3)!=2 ? 1 : 0;
+
 }

--- a/src/_ZN6Player16St_BurnFire_InitEv.cpp
+++ b/src/_ZN6Player16St_BurnFire_InitEv.cpp
@@ -1,10 +1,17 @@
 //cpp
-struct Vector3 { int x,y,z; };
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player16St_BurnFire_InitEv(char* c){
-  *(char*)(c+0x708)=1;
+}
+
+struct Player {
+    int St_BurnFire_Init();
+};
+
+int Player::St_BurnFire_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x708)=1;
   *(char*)(c+0x6de)=1;
   *(char*)(c+0x6df)=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x16,0,0x1000,0);
@@ -19,5 +26,5 @@ int _ZN6Player16St_BurnFire_InitEv(char* c){
   *(char*)(c+0x6e5)=0;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x23,(struct Vector3*)(c+0x74));
   return 1;
-}
+
 }

--- a/src/_ZN6Player16St_BurnLava_InitEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_InitEv.cpp
@@ -1,13 +1,20 @@
 //cpp
-struct Vector3 { int x,y,z; };
 extern "C" {
 extern int data_ov002_021100f4[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov006_020e3078(void*,int*);
 extern int func_ov002_020d91e0(void*,int,int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player16St_BurnLava_InitEv(char* c){
-  *(char*)(c+0x712)=1;
+}
+
+struct Player {
+    int St_BurnLava_Init();
+};
+
+int Player::St_BurnLava_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x712)=1;
   *(char*)(c+0x6e1)=0;
   *(char*)(c+0x6de)=1;
   *(char*)(c+0x6df)=0;
@@ -23,5 +30,5 @@ int _ZN6Player16St_BurnLava_InitEv(char* c){
   func_ov002_020d91e0(c,0x300,1);
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x23,(struct Vector3*)(c+0x74));
   return 1;
-}
+
 }

--- a/src/_ZN6Player16St_LongJump_MainEv.cpp
+++ b/src/_ZN6Player16St_LongJump_MainEv.cpp
@@ -4,12 +4,20 @@ extern int func_ov002_020e28d4(void*,int,int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int func_ov002_020bedd4(void*);
 extern int data_ov002_02110424[];
-int _ZN6Player16St_LongJump_MainEv(char* c){
-  func_ov002_020e28d4(c,0x1800,0x800);
+}
+
+struct Player {
+    int St_LongJump_Main();
+};
+
+int Player::St_LongJump_Main()
+{
+    char* c = (char*)this;
+func_ov002_020e28d4(c,0x1800,0x800);
   if(*(unsigned char*)(c+0x6de)==0){
     _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_02110424);
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player16St_Shell_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Shell_CleanupEv.cpp
@@ -1,8 +1,16 @@
 //cpp
 extern "C" {
 extern void func_ov002_020bd8c0(char* c, unsigned int r1);
-int _ZN6Player16St_Shell_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x354);
+}
+
+struct Player {
+    int St_Shell_Cleanup();
+};
+
+int Player::St_Shell_Cleanup()
+{
+    char* c = (char*)this;
+char* p = *(char**)(c + 0x354);
   if (p != 0) {
     *(int*)(p + 0x3c0) = 0;
     *(int*)(c + 0x354) = 0;
@@ -12,5 +20,5 @@ int _ZN6Player16St_Shell_CleanupEv(char* c){
     func_ov002_020bd8c0(c, 0x33);
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player16St_Teleport_InitEv.cpp
+++ b/src/_ZN6Player16St_Teleport_InitEv.cpp
@@ -3,13 +3,21 @@ extern "C" {
 extern void func_ov002_020c9e40(char*c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
-int _ZN6Player16St_Teleport_InitEv(char*c){
-  func_ov002_020c9e40(c);
+}
+
+struct Player {
+    int St_Teleport_Init();
+};
+
+int Player::St_Teleport_Init()
+{
+    char* c = (char*)this;
+func_ov002_020c9e40(c);
   *(unsigned char*)(c+0x6e5)=0;
   *(unsigned char*)(c+0x6e3)=0;
   *(int*)(c+0x98)=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
   _ZN5Sound9PlayBank0EjRK7Vector3(0x19,(char*)c+0x74);
   return 1;
-}
+
 }

--- a/src/_ZN6Player16St_WallJump_MainEv.cpp
+++ b/src/_ZN6Player16St_WallJump_MainEv.cpp
@@ -12,9 +12,16 @@ extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
 extern char data_ov002_0211052c[];
 extern int data_ov002_0211073c[];
+}
 
-int _ZN6Player16St_WallJump_MainEv(void* c) {
-  func_ov002_020eeca8((char*)c+0x380, c);
+struct Player {
+    int St_WallJump_Main();
+};
+
+int Player::St_WallJump_Main()
+{
+    void* c = (void*)this;
+func_ov002_020eeca8((char*)c+0x380, c);
   func_ov002_020e28d4(c, 0x1800, 0x800);
   if (*(unsigned char*)((char*)c+0x6de) == 0) {
     _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110424);
@@ -41,5 +48,5 @@ int _ZN6Player16St_WallJump_MainEv(void* c) {
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player16TryTalkToKeyDoorEv.cpp
+++ b/src/_ZN6Player16TryTalkToKeyDoorEv.cpp
@@ -5,13 +5,21 @@ extern int _ZN6Player17SetNoControlStateEhih(void*,unsigned char,int,unsigned ch
 extern int data_ov002_0211013c[];
 extern int _ZN6Player7ST_WAITE[];
 extern int data_ov002_0211043c[];
-int _ZN6Player16TryTalkToKeyDoorEv(void* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
+}
+
+struct Player {
+    int TryTalkToKeyDoor();
+};
+
+int Player::TryTalkToKeyDoor()
+{
+    void* c = (void*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
      || _ZN6Player7IsStateERNS_5StateE(c,_ZN6Player7ST_WAITE)
      || _ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211043c)){
     _ZN6Player17SetNoControlStateEhih(c,0xb,-1,0);
     return 1;
   }
   return 0;
-}
+
 }

--- a/src/_ZN6Player17LostGrabbedObjectEv.cpp
+++ b/src/_ZN6Player17LostGrabbedObjectEv.cpp
@@ -1,7 +1,15 @@
 //cpp
 extern "C" {
 int _ZN6Player6IsAnimEj(void*, unsigned int);
-int _ZN6Player17LostGrabbedObjectEv(void* c){
-  return _ZN6Player6IsAnimEj(c, 0x18) || _ZN6Player6IsAnimEj(c, 0x8b);
 }
+
+struct Player {
+    int LostGrabbedObject();
+};
+
+int Player::LostGrabbedObject()
+{
+    void* c = (void*)this;
+return _ZN6Player6IsAnimEj(c, 0x18) || _ZN6Player6IsAnimEj(c, 0x8b);
+
 }

--- a/src/_ZN6Player17St_ButtSlide_InitEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_InitEv.cpp
@@ -1,11 +1,18 @@
 //cpp
-struct Camera;
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
 extern void func_0200d544(struct Camera* thiz, unsigned char playerID);
-int _ZN6Player17St_ButtSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x41, 0x40000000, 0x1000, 0);
+}
+
+struct Player {
+    int St_ButtSlide_Init();
+};
+
+int Player::St_ButtSlide_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c, 0x41, 0x40000000, 0x1000, 0);
   *(char*)(c+0x6e3)=0;
   if(*(unsigned char*)(c+0x70e)){
     func_0200d544(data_0209f318, *(unsigned char*)(c+0x6d8));
@@ -15,5 +22,5 @@ int _ZN6Player17St_ButtSlide_InitEv(char* c){
   *(short*)(c+0x600+0xa6)=6;
   *(char*)(c+0x6e4)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_EndingFly_MainEv.cpp
+++ b/src/_ZN6Player17St_EndingFly_MainEv.cpp
@@ -2,7 +2,15 @@
 extern "C" {
 typedef void (*FP)(void*);
 extern FP data_ov007_02103254;
-void _ZN6Player17St_EndingFly_MainEv(void* self){
-  data_ov007_02103254(self);
 }
+
+struct Player {
+    void St_EndingFly_Main();
+};
+
+void Player::St_EndingFly_Main()
+{
+    void* self = (void*)this;
+data_ov007_02103254(self);
+
 }

--- a/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
@@ -1,13 +1,20 @@
 //cpp
-struct Vector3 { int x,y,z; };
 extern "C" {
 extern int data_ov002_020ff254[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player17St_HoldHeavy_InitEv(char* c){
-  *(char*)(c+0x6e5)=0;
+}
+
+struct Player {
+    int St_HoldHeavy_Init();
+};
+
+int Player::St_HoldHeavy_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x6e5)=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff254[*(unsigned char*)(c+0x6e5)], 0x40000000, 0x1000, 0);
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x12, (struct Vector3*)(c+0x74));
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_HurtWater_InitEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_InitEv.cpp
@@ -6,8 +6,16 @@ extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void func_ov002_020d93ac(void*);
 extern void func_ov002_020d94cc(void*);
 extern void func_0200d89c(char* p);
-int _ZN6Player17St_HurtWater_InitEv(char* c){
-  unsigned a=data_ov002_02109fe4[*(unsigned char*)(c+0x6e3)&1];
+}
+
+struct Player {
+    int St_HurtWater_Init();
+};
+
+int Player::St_HurtWater_Init()
+{
+    char* c = (char*)this;
+unsigned a=data_ov002_02109fe4[*(unsigned char*)(c+0x6e3)&1];
   _ZN6Player7SetAnimEji5Fix12IiEj(c,a,0x40000000,0x1000,0);
   *(char*)(c+0x6e5)=0;
   *(char*)(c+0x70c)=0;
@@ -24,5 +32,5 @@ int _ZN6Player17St_HurtWater_InitEv(char* c){
   }
   func_0200d89c(*(char**)data_0209f318);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_HurtWater_MainEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_MainEv.cpp
@@ -12,8 +12,16 @@ extern int func_ov002_020bedd4(void*);
 extern int data_ov002_0211067c[];
 extern int data_ov002_021106ac[];
 extern int data_0209f32c[];
-int _ZN6Player17St_HurtWater_MainEv(char* c){
-  if(func_ov002_020cec2c(c)) return 1;
+}
+
+struct Player {
+    int St_HurtWater_Main();
+};
+
+int Player::St_HurtWater_Main()
+{
+    char* c = (char*)this;
+if(func_ov002_020cec2c(c)) return 1;
   _Z14ApproachLinearRiii((int*)(c+0x98),0,0x800);
   int t=func_ov002_020ceaf4(c);
   _Z14ApproachLinearRiii((int*)(c+0xa8),t,0x800);
@@ -45,5 +53,5 @@ int _ZN6Player17St_HurtWater_MainEv(char* c){
   func_ov002_020ceb7c(c);
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player17St_LedgeGrab_InitEv(char* c){
-  if(*(unsigned char*)(c+0x6e3)){
+}
+
+struct Player {
+    int St_LedgeGrab_Init();
+};
+
+int Player::St_LedgeGrab_Init()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6e3)){
     _ZN6Player7SetAnimEji5Fix12IiEj(c,0x20,0x40000000,0x1000,0);
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x1a,(void*)(c+0x74));
   } else {
@@ -11,5 +19,5 @@ int _ZN6Player17St_LedgeGrab_InitEv(char* c){
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x17,(void*)(c+0x74));
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
@@ -8,8 +8,16 @@ extern int _ZNK9Animation12WillHitFrameEi(void*,int);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
 extern int func_ov002_020bedd4(void*);
 extern int data_ov002_0211013c[];
-int _ZN6Player17St_LedgeGrab_MainEv(char* c){
-  if(_ZN6Player12FinishedAnimEv(c))
+}
+
+struct Player {
+    int St_LedgeGrab_Main();
+};
+
+int Player::St_LedgeGrab_Main()
+{
+    char* c = (char*)this;
+if(_ZN6Player12FinishedAnimEv(c))
     _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
   if(_ZN6Player6IsAnimEj(c,0x20)){
     int id=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
@@ -19,5 +27,5 @@ int _ZN6Player17St_LedgeGrab_MainEv(char* c){
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_NoControl_InitEv.cpp
+++ b/src/_ZN6Player17St_NoControl_InitEv.cpp
@@ -4,8 +4,16 @@ extern int func_ov002_020c9e40(void* c);
 extern int func_ov002_020dab14(void* c);
 struct PMF { int adj; int ptr; };
 extern struct PMF data_ov002_02110884[];
-int _ZN6Player17St_NoControl_InitEv(char* c){
-  *(unsigned char*)(c+0x6f6)=1;
+}
+
+struct Player {
+    int St_NoControl_Init();
+};
+
+int Player::St_NoControl_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x6f6)=1;
   *(unsigned char*)(c+0x6e6)=0;
   func_ov002_020c9e40(c);
   func_ov002_020dab14(c);
@@ -25,5 +33,5 @@ int _ZN6Player17St_NoControl_InitEv(char* c){
   }
   f(obj);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_PunchKick_InitEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_InitEv.cpp
@@ -4,8 +4,16 @@ extern int _ZN6Player15IsCollectingCapEv(void*);
 extern int func_ov002_020dc020(void*);
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12CylinderClsn6UpdateEv(void*);
-int _ZN6Player17St_PunchKick_InitEv(void* c){
-  *(int*)((char*)c+0x684)=*(int*)((char*)c+0x60);
+}
+
+struct Player {
+    int St_PunchKick_Init();
+};
+
+int Player::St_PunchKick_Init()
+{
+    void* c = (void*)this;
+*(int*)((char*)c+0x684)=*(int*)((char*)c+0x60);
   *(char*)((char*)c+0x726)=0;
   *(short*)((char*)c+0x6a4)=2;
   *(char*)((char*)c+0x6e6)=0;
@@ -18,5 +26,5 @@ int _ZN6Player17St_PunchKick_InitEv(void* c){
     _ZN12CylinderClsn5ClearEv((char*)c+0x314);
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_SlopeJump_InitEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_InitEv.cpp
@@ -4,8 +4,16 @@ extern int func_ov002_020e2b6c(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov002_020e2ad0(void*);
 extern int func_ov002_020e25f0(void*,int);
-int _ZN6Player17St_SlopeJump_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=0;
+}
+
+struct Player {
+    int St_SlopeJump_Init();
+};
+
+int Player::St_SlopeJump_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x71b)=0;
   if(func_ov002_020e2b6c(c)) return 1;
   *(unsigned char*)(c+0x712)=1;
   *(unsigned char*)(c+0x70d)=0;
@@ -20,5 +28,5 @@ int _ZN6Player17St_SlopeJump_InitEv(char* c){
   }
   func_ov002_020e25f0(c,0);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_SlopeJump_MainEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_MainEv.cpp
@@ -8,8 +8,16 @@ extern char data_ov002_02110034[];
 extern char data_ov002_021105bc[];
 extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
-int _ZN6Player17St_SlopeJump_MainEv(char* c){
-  _Z14ApproachLinearRiii((int*)(c+0x98),0,0x800);
+}
+
+struct Player {
+    int St_SlopeJump_Main();
+};
+
+int Player::St_SlopeJump_Main()
+{
+    char* c = (char*)this;
+_Z14ApproachLinearRiii((int*)(c+0x98),0,0x800);
   if(*(unsigned char*)(c+0x6de)==0){
     _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
   }
@@ -25,5 +33,5 @@ int _ZN6Player17St_SlopeJump_MainEv(char* c){
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_SweepKick_InitEv.cpp
+++ b/src/_ZN6Player17St_SweepKick_InitEv.cpp
@@ -1,13 +1,20 @@
 //cpp
-struct Vector3 { int x,y,z; };
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player17St_SweepKick_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x68, 0x40000000, 0x1000, 0);
+}
+
+struct Player {
+    int St_SweepKick_Init();
+};
+
+int Player::St_SweepKick_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c, 0x68, 0x40000000, 0x1000, 0);
   *(int*)(c+0x98)=0;
   *(char*)(c+0x726)=0;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0xa, (struct Vector3*)(c+0x74));
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_SweepKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SweepKick_MainEv.cpp
@@ -8,8 +8,16 @@ extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
 extern int data_ov002_0211019c[];
 extern int data_ov002_021104e4[];
-int _ZN6Player17St_SweepKick_MainEv(void* c){
-  if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 2)
+}
+
+struct Player {
+    int St_SweepKick_Main();
+};
+
+int Player::St_SweepKick_Main()
+{
+    void* c = (void*)this;
+if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 2)
     _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211019c);
   func_ov002_020d8a50(c,3);
   if(_ZN6Player12FinishedAnimEv(c)){
@@ -18,5 +26,5 @@ int _ZN6Player17St_SweepKick_MainEv(void* c){
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_WallSlide_InitEv.cpp
+++ b/src/_ZN6Player17St_WallSlide_InitEv.cpp
@@ -1,11 +1,19 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player17St_WallSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x29,0x40000000,0x1000,0);
+}
+
+struct Player {
+    int St_WallSlide_Init();
+};
+
+int Player::St_WallSlide_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c,0x29,0x40000000,0x1000,0);
   *(int*)(c+0x98)=0;
   if(*(int*)(c+0xa8) >= 0) *(int*)(c+0xa8)=0;
   *(short*)(c+0x6a4)=7;
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_WaterJump_InitEv.cpp
+++ b/src/_ZN6Player17St_WaterJump_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int func_ov002_020e25f0(void*,int);
-int _ZN6Player17St_WaterJump_InitEv(char* c){
-  *(char*)(c+0x71b)=0;
+}
+
+struct Player {
+    int St_WaterJump_Init();
+};
+
+int Player::St_WaterJump_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x71b)=0;
   *(char*)(c+0x712)=1;
   *(char*)(c+0x70d)=0;
   *(char*)(c+0x6e1)=0;
@@ -16,5 +24,5 @@ int _ZN6Player17St_WaterJump_InitEv(char* c){
   _ZN5Sound9PlayBank0EjRK7Vector3(0x18,(char*)c+0x74);
   func_ov002_020e25f0(c,0);
   return 1;
-}
+
 }

--- a/src/_ZN6Player17St_WindCarry_InitEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_InitEv.cpp
@@ -4,13 +4,21 @@ extern int func_ov002_020da9d4(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int data_0209f318[];
 extern void func_0200d63c(void*,unsigned char);
-int _ZN6Player17St_WindCarry_InitEv(char* c){
-  func_ov002_020da9d4(c);
+}
+
+struct Player {
+    int St_WindCarry_Init();
+};
+
+int Player::St_WindCarry_Init()
+{
+    char* c = (char*)this;
+func_ov002_020da9d4(c);
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x4a,0x40000000,0x1000,0);
   *(int*)(c+0xa8)=0;
   *(unsigned char*)(c+0x6de)=1;
   *(unsigned char*)(c+0x6df)=0;
   func_0200d63c((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
   return 1;
-}
+
 }

--- a/src/_ZN6Player18HasFinishedTalkingEv.cpp
+++ b/src/_ZN6Player18HasFinishedTalkingEv.cpp
@@ -3,11 +3,19 @@ extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player18HasFinishedTalkingEv(char* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
+}
+
+struct Player {
+    int HasFinishedTalking();
+};
+
+int Player::HasFinishedTalking()
+{
+    char* c = (char*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
     *(unsigned char*)(c+0x6e3)=4;
     return 1;
   }
   return 0;
-}
+
 }

--- a/src/_ZN6Player18St_CameraZoom_InitEv.cpp
+++ b/src/_ZN6Player18St_CameraZoom_InitEv.cpp
@@ -1,13 +1,20 @@
 //cpp
-struct Camera;
 extern "C" {
 extern int func_0200d064(struct Camera* thiz, int playerID);
 extern void func_0200d7e0(struct Camera* thiz, int playerID);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
 extern unsigned char data_0209f28c;
-int _ZN6Player18St_CameraZoom_InitEv(void* c){
-  *(int*)((char*)c+0x98)=0;
+}
+
+struct Player {
+    int St_CameraZoom_Init();
+};
+
+int Player::St_CameraZoom_Init()
+{
+    void* c = (void*)this;
+*(int*)((char*)c+0x98)=0;
   *(int*)((char*)c+0xa8)=0;
   struct Camera* cam = data_0209f318;
   int pid = *(unsigned char*)((char*)c+0x6d8);
@@ -16,5 +23,5 @@ int _ZN6Player18St_CameraZoom_InitEv(void* c){
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
   data_0209f28c=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player18St_DizzyStars_InitEv.cpp
+++ b/src/_ZN6Player18St_DizzyStars_InitEv.cpp
@@ -1,9 +1,13 @@
 //cpp
-extern "C" {
-int _ZN6Player18St_DizzyStars_InitEv(char *c)
+struct Player {
+    int St_DizzyStars_Init();
+};
+
+int Player::St_DizzyStars_Init()
 {
-    *(short *)(c + 0x6a4) = 0x12c;
+    char * c = (char *)this;
+*(short *)(c + 0x6a4) = 0x12c;
     *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
     return 1;
-}
+
 }

--- a/src/_ZN6Player18St_DizzyStars_MainEv.cpp
+++ b/src/_ZN6Player18St_DizzyStars_MainEv.cpp
@@ -3,10 +3,18 @@ extern "C" {
 extern int func_ov002_020d98b4(void*);
 extern int data_ov002_0211013c[];
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-int _ZN6Player18St_DizzyStars_MainEv(char* c){
-  func_ov002_020d98b4(c);
+}
+
+struct Player {
+    int St_DizzyStars_Main();
+};
+
+int Player::St_DizzyStars_Main()
+{
+    char* c = (char*)this;
+func_ov002_020d98b4(c);
   if(*(short*)(c+0x6a4) > 0) return 1;
   _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player18St_TurnAround_InitEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_InitEv.cpp
@@ -1,9 +1,17 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player18St_TurnAround_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x46,0x40000000,0x1000,0);
+}
+
+struct Player {
+    int St_TurnAround_Init();
+};
+
+int Player::St_TurnAround_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c,0x46,0x40000000,0x1000,0);
   *(char*)(c+0x6e3)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -1,13 +1,17 @@
 //cpp
-/* _ZN6Player19St_CrazedCrate_InitEv at 0x020e0fac (ov002), size 0x74
- * Matched byte-for-byte with mwccarm 1.2/sp2p3.
- * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
- */
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
 extern void func_ov002_020e0f38(void* c, unsigned char a);
-int _ZN6Player19St_CrazedCrate_InitEv(char* c){
-  *(unsigned char*)(c+0x71b) = 0;
+}
+
+struct Player {
+    int St_CrazedCrate_Init();
+};
+
+int Player::St_CrazedCrate_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x71b) = 0;
   *(unsigned char*)(c+0x712) = 1;
   *(unsigned char*)(c+0x70d) = 0;
   *(unsigned char*)(c+0x6e1) = 0;
@@ -18,5 +22,5 @@ int _ZN6Player19St_CrazedCrate_InitEv(char* c){
   *(unsigned short*)(c+0x94) = *(short*)(c+0x8e);
   *(int*)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
   return 1;
-}
+
 }

--- a/src/_ZN6Player19St_Electrocute_InitEv.cpp
+++ b/src/_ZN6Player19St_Electrocute_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern int func_ov002_020da9d4(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player19St_Electrocute_InitEv(void* c){
-  func_ov002_020da9d4(c);
+}
+
+struct Player {
+    int St_Electrocute_Init();
+};
+
+int Player::St_Electrocute_Init()
+{
+    void* c = (void*)this;
+func_ov002_020da9d4(c);
   *(char*)((char*)c+0x708)=1;
   *(short*)((char*)c+0x6a4)=0x1e;
   *(short*)((char*)c+0x6a0)=0x1e;
@@ -14,5 +22,5 @@ int _ZN6Player19St_Electrocute_InitEv(void* c){
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x11,0,0x1000,0);
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)((char*)c+0x6d9),7,(char*)c+0x74);
   return 1;
-}
+
 }

--- a/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
+++ b/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
@@ -1,9 +1,16 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
+}
 
-int _ZN6Player19St_SwingPlayer_InitEv(char* c){
-  *(int*)(c+0x98) = 0;
+struct Player {
+    int St_SwingPlayer_Init();
+};
+
+int Player::St_SwingPlayer_Init()
+{
+    char* c = (char*)this;
+*(int*)(c+0x98) = 0;
   _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x6c, 0x40000000, 0x1000, 0);
   *(unsigned char*)(c+0x6e3) = 0;
   *(short*)(c+0x69c) = *(short*)(c+0x8e) - *(short*)(c+0x6d6);
@@ -13,5 +20,5 @@ int _ZN6Player19St_SwingPlayer_InitEv(char* c){
       *(int*)(((long long)(int)((char*)obj+0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800;
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
+++ b/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
@@ -5,8 +5,16 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 extern int data_0209f318[];
 extern void func_0200d6b4(void*,unsigned char);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player19St_TornadoSpin_InitEv(char* c){
-  func_ov002_020dab14(c);
+}
+
+struct Player {
+    int St_TornadoSpin_Init();
+};
+
+int Player::St_TornadoSpin_Init()
+{
+    char* c = (char*)this;
+func_ov002_020dab14(c);
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x5f,0,0x1000,0);
   *(int*)(c+0xa8)=0;
   *(int*)(c+0x9c)=0;
@@ -16,5 +24,5 @@ int _ZN6Player19St_TornadoSpin_InitEv(char* c){
   *(int*)(c+0x688)=*(int*)(c+0x60) - *(int*)(*(int*)(c+0x364)+0x60);
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x26,(void*)(c+0x74));
   return 1;
-}
+
 }

--- a/src/_ZN6Player20IsStateEnteringLevelEv.cpp
+++ b/src/_ZN6Player20IsStateEnteringLevelEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern int data_ov002_021104b4[];
 extern int data_ov002_0211025c[];
 extern int _ZN6Player7IsStateERNS_5StateE(char*c, void*s);
-int _ZN6Player20IsStateEnteringLevelEv(char*c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021104b4)) return 1;
-  return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211025c);
 }
+
+struct Player {
+    int IsStateEnteringLevel();
+};
+
+int Player::IsStateEnteringLevel()
+{
+    char* c = (char*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021104b4)) return 1;
+  return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211025c);
+
 }

--- a/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
+++ b/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
@@ -1,13 +1,15 @@
 //cpp
+struct Player {
+    void RegisterEggCoinCount(unsigned int count, bool b2, bool b3);
+};
 
-extern "C" {
-
-void _ZN6Player20RegisterEggCoinCountEjbb(char* self, unsigned int count, bool b2, bool b3) {
-	*(unsigned char *)(self + 0x704) = (count & 0xf) << 2;
+void Player::RegisterEggCoinCount(unsigned int count, bool b2, bool b3)
+{
+    char* self = (char*)this;
+*(unsigned char *)(self + 0x704) = (count & 0xf) << 2;
 	if (b3)
 		*(unsigned char *)(((long long)(int)(self + 0x704)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
 	if (b2)
 		*(unsigned char *)(((long long)(int)(self + 0x704)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
-}
 
 }

--- a/src/_ZN6Player20St_CeilingGrate_InitEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_InitEv.cpp
@@ -2,11 +2,19 @@
 extern "C" {
 extern void func_ov002_020cf384(char* p);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player20St_CeilingGrate_InitEv(char* c){
-  func_ov002_020cf384(c);
+}
+
+struct Player {
+    int St_CeilingGrate_Init();
+};
+
+int Player::St_CeilingGrate_Init()
+{
+    char* c = (char*)this;
+func_ov002_020cf384(c);
   *(char*)(c+0x6e3)=0;
   *(char*)(c+0x6e5)=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x5b,0x40000000,0x1000,0);
   return 1;
-}
+
 }

--- a/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
+++ b/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
@@ -1,10 +1,15 @@
 //cpp
-extern "C" {
-int _ZN6Player20St_HoldLight_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x358);
+struct Player {
+    int St_HoldLight_Cleanup();
+};
+
+int Player::St_HoldLight_Cleanup()
+{
+    char* c = (char*)this;
+char* p = *(char**)(c + 0x358);
   if (p) {
     *(unsigned int*)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
   }
   return 1;
-}
+
 }

--- a/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
@@ -1,10 +1,16 @@
 //cpp
 extern "C" {
 extern void func_ov002_020bdb50(char *c, int arg);
+}
 
-int _ZN6Player20St_InYoshiMouth_InitEv(char *c)
+struct Player {
+    int St_InYoshiMouth_Init();
+};
+
+int Player::St_InYoshiMouth_Init()
 {
-    unsigned int r3;
+    char * c = (char *)this;
+unsigned int r3;
     char *slot;
     unsigned int r1;
 
@@ -18,5 +24,5 @@ int _ZN6Player20St_InYoshiMouth_InitEv(char *c)
     *(unsigned int *)slot = r1;
     *(unsigned char *)(c + 0x713) = (unsigned char)r3;
     return 1;
-}
+
 }

--- a/src/_ZN6Player20St_NoControl_CleanupEv.cpp
+++ b/src/_ZN6Player20St_NoControl_CleanupEv.cpp
@@ -1,13 +1,21 @@
 //cpp
 extern "C" {
 extern int EndKuppaScript(void);
-int _ZN6Player20St_NoControl_CleanupEv(char*c){
-  int v=0x1000;
+}
+
+struct Player {
+    int St_NoControl_Cleanup();
+};
+
+int Player::St_NoControl_Cleanup()
+{
+    char* c = (char*)this;
+int v=0x1000;
   if(*(unsigned char*)(c+0x703)) v=0x3000;
   *(int*)(c+0x80)=v;
   *(int*)(c+0x84)=v;
   *(int*)(c+0x88)=v;
   if(*(unsigned char*)(c+0x70a)==0x11) EndKuppaScript();
   return 1;
-}
+
 }

--- a/src/_ZN6Player20St_StomachSlide_InitEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_InitEv.cpp
@@ -1,11 +1,18 @@
 //cpp
-struct Camera;
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
 extern void func_0200d544(struct Camera* thiz, unsigned char playerID);
-int _ZN6Player20St_StomachSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x40, 0x40000000, 0x1000, 0);
+}
+
+struct Player {
+    int St_StomachSlide_Init();
+};
+
+int Player::St_StomachSlide_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c, 0x40, 0x40000000, 0x1000, 0);
   *(char*)(c+0x6e3)=0;
   if(*(unsigned char*)(c+0x70e)){
     func_0200d544(data_0209f318, *(unsigned char*)(c+0x6d8));
@@ -16,5 +23,5 @@ int _ZN6Player20St_StomachSlide_InitEv(char* c){
   *(char*)(c+0x70c)=*(unsigned char*)(c+0x70e);
   *(char*)(c+0x6e4)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_HeadstandJump_InitEv.cpp
+++ b/src/_ZN6Player21St_HeadstandJump_InitEv.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player21St_HeadstandJump_InitEv(char* c){
-  *(char*)(c+0x71b)=0;
+}
+
+struct Player {
+    int St_HeadstandJump_Init();
+};
+
+int Player::St_HeadstandJump_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x71b)=0;
   *(char*)(c+0x712)=1;
   *(char*)(c+0x70d)=0;
   *(char*)(c+0x6e1)=0;
@@ -14,5 +22,5 @@ int _ZN6Player21St_HeadstandJump_InitEv(char* c){
   *(int*)(c+0x98)=0x18000;
   _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0xc,(char*)c+0x74);
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_JumpQuicksand_InitEv.cpp
+++ b/src/_ZN6Player21St_JumpQuicksand_InitEv.cpp
@@ -1,13 +1,21 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_JumpQuicksand_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=1;
+}
+
+struct Player {
+    int St_JumpQuicksand_Init();
+};
+
+int Player::St_JumpQuicksand_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x71b)=1;
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0x53,0x40000000,0x1000,0);
   *(unsigned char*)(c+0x6e5)=0;
   *(int*)(c+0xa8)=0;
   *(unsigned char*)(c+0x6de)=1;
   *(unsigned char*)(c+0x6df)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
+++ b/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
@@ -1,8 +1,16 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_SmallLaunchUp_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=0;
+}
+
+struct Player {
+    int St_SmallLaunchUp_Init();
+};
+
+int Player::St_SmallLaunchUp_Init()
+{
+    char* c = (char*)this;
+*(unsigned char*)(c+0x71b)=0;
   *(unsigned char*)(c+0x712)=1;
   *(unsigned char*)(c+0x70d)=0;
   *(unsigned char*)(c+0x6e1)=0;
@@ -15,5 +23,5 @@ int _ZN6Player21St_SmallLaunchUp_InitEv(char* c){
   *(short*)(c+0x8e)=*(short*)(c+0x94);
   *(short*)(c+0x90)=*(short*)(c+0x96);
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_SmallLaunchUp_MainEv.cpp
+++ b/src/_ZN6Player21St_SmallLaunchUp_MainEv.cpp
@@ -4,11 +4,19 @@ struct State;
 extern State data_ov002_02110424;
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,State*);
 extern void func_ov002_020bedd4(void*);
-int _ZN6Player21St_SmallLaunchUp_MainEv(char* c){
-  if(*(unsigned char*)(c+0x6de)==0){
+}
+
+struct Player {
+    int St_SmallLaunchUp_Main();
+};
+
+int Player::St_SmallLaunchUp_Main()
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6de)==0){
     _ZN6Player11ChangeStateERNS_5StateE(c,&data_ov002_02110424);
   }
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_StuckInGround_InitEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_InitEv.cpp
@@ -6,8 +6,16 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int func_ov002_020c5444(void*);
 extern int data_ov002_0210a560[];
-int _ZN6Player21St_StuckInGround_InitEv(void* c){
-  func_ov002_020c9e40(c);
+}
+
+struct Player {
+    int St_StuckInGround_Init();
+};
+
+int Player::St_StuckInGround_Init()
+{
+    void* c = (void*)this;
+func_ov002_020c9e40(c);
   func_ov002_020dab14(c);
   unsigned char idx = *(unsigned char*)((char*)c+0x6e3);
   _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a560[idx], 0x40000000, 0x1000, 0);
@@ -17,5 +25,5 @@ int _ZN6Player21St_StuckInGround_InitEv(void* c){
   *(int*)((char*)c+0x98)=0;
   *(unsigned char*)((char*)c+0x6e5)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_WaitQuicksand_InitEv.cpp
+++ b/src/_ZN6Player21St_WaitQuicksand_InitEv.cpp
@@ -1,9 +1,17 @@
 //cpp
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_WaitQuicksand_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
+}
+
+struct Player {
+    int St_WaitQuicksand_Init();
+};
+
+int Player::St_WaitQuicksand_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
   *(char*)(c+0x6e5)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
@@ -6,8 +6,16 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 extern int func_ov007_020c5dec(void*,int);
 extern int func_ov002_020d22ec(void*,int);
 extern int func_ov002_020bedd4(void*);
-int _ZN6Player21St_WaitQuicksand_MainEv(char* c){
-  int v=*(int*)(c+0x68c);
+}
+
+struct Player {
+    int St_WaitQuicksand_Main();
+};
+
+int Player::St_WaitQuicksand_Main()
+{
+    char* c = (char*)this;
+int v=*(int*)(c+0x68c);
   if(v<0x1e000){
     _ZN6Player11ChangeStateERNS_5StateE(c,&_ZN6Player7ST_WAITE);
     return 1;
@@ -21,5 +29,5 @@ int _ZN6Player21St_WaitQuicksand_MainEv(char* c){
   func_ov002_020d22ec(c,0);
   func_ov002_020bedd4(c);
   return 1;
-}
+
 }

--- a/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
+++ b/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
@@ -3,10 +3,16 @@ extern "C" {
 extern void func_ov002_020d718c(char*);
 extern void func_ov002_020d6790(char*);
 extern void func_ov002_020d71a0(char*);
+}
 
-int _ZN6Player21St_YoshiPower_CleanupEv(char* c)
+struct Player {
+    int St_YoshiPower_Cleanup();
+};
+
+int Player::St_YoshiPower_Cleanup()
 {
-    char* r2 = *(char**)(c+0x360);
+    char* c = (char*)this;
+char* r2 = *(char**)(c+0x360);
     if (r2 != 0) {
         int t = (int)((*(int*)(r2+0xb0) & 0x20000) != 0);
         if (t != 0) {
@@ -32,5 +38,5 @@ int _ZN6Player21St_YoshiPower_CleanupEv(char* c)
     }
 end:
     return 1;
-}
+
 }

--- a/src/_ZN6Player22IsBeingShotOutOfCannonEv.cpp
+++ b/src/_ZN6Player22IsBeingShotOutOfCannonEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 struct State;
 extern State data_ov002_021102d4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player22IsBeingShotOutOfCannonEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
-  return *(unsigned char*)(c+0x6e3)==2 ? 1 : 0;
 }
+
+struct Player {
+    int IsBeingShotOutOfCannon();
+};
+
+int Player::IsBeingShotOutOfCannon()
+{
+    char* c = (char*)this;
+if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
+  return *(unsigned char*)(c+0x6e3)==2 ? 1 : 0;
+
 }

--- a/src/_ZN6Player22St_GrabBowserTail_InitEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_InitEv.cpp
@@ -3,13 +3,21 @@ extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void func_0200d10c(void* cam, unsigned char id);
 extern int* data_0209f318;
-int _ZN6Player22St_GrabBowserTail_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x81,0x40000000,0x1000,0);
+}
+
+struct Player {
+    int St_GrabBowserTail_Init();
+};
+
+int Player::St_GrabBowserTail_Init()
+{
+    char* c = (char*)this;
+_ZN6Player7SetAnimEji5Fix12IiEj(c,0x81,0x40000000,0x1000,0);
   *(unsigned char*)(c+0x6e3)=0;
   *(short*)(c+0x69c)=0;
   *(unsigned char*)(c+0x6e5)=0;
   *(unsigned char*)(c+0x70c)=0;
   func_0200d10c((void*)data_0209f318, *(unsigned char*)(c+0x6d8));
   return 1;
-}
+
 }

--- a/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
+++ b/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
@@ -1,11 +1,16 @@
 //cpp
-extern "C" {
-int _ZN6Player22St_SwingPlayer_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x358);
+struct Player {
+    int St_SwingPlayer_Cleanup();
+};
+
+int Player::St_SwingPlayer_Cleanup()
+{
+    char* c = (char*)this;
+char* p = *(char**)(c + 0x358);
   if (p) {
     *(unsigned int*)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800;
   }
   *(short*)(c + 0x94) = *(short*)(c + 0x8e);
   return 1;
-}
+
 }

--- a/src/_ZN6Player23St_MetalWaterWater_InitEv.cpp
+++ b/src/_ZN6Player23St_MetalWaterWater_InitEv.cpp
@@ -3,8 +3,16 @@ extern "C" {
 extern void func_ov002_020bf2d8(void*,int);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
-int _ZN6Player23St_MetalWaterWater_InitEv(char* c){
-  *(char*)(c+0x712)=1;
+}
+
+struct Player {
+    int St_MetalWaterWater_Init();
+};
+
+int Player::St_MetalWaterWater_Init()
+{
+    char* c = (char*)this;
+*(char*)(c+0x712)=1;
   *(char*)(c+0x706)=1;
   *(char*)(c+0x6de)=1;
   *(char*)(c+0x6df)=0;
@@ -17,5 +25,5 @@ int _ZN6Player23St_MetalWaterWater_InitEv(char* c){
   _ZN5Sound9PlayBank0EjRK7Vector3(0xa8,c+0x74);
   *(char*)(c+0x6e5)=0;
   return 1;
-}
+
 }

--- a/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
@@ -1,8 +1,16 @@
 //cpp
 extern "C" {
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned, unsigned, void*);
-int _ZN6Player24St_MetalWaterGround_InitEv(char* c) {
-    int* p = *(int**)(c+0x358);
+}
+
+struct Player {
+    int St_MetalWaterGround_Init();
+};
+
+int Player::St_MetalWaterGround_Init()
+{
+    char* c = (char*)this;
+int* p = *(int**)(c+0x358);
     int b0 = (p != 0);
     if (b0) {
         int h = *(unsigned short*)((char*)p+0xc);
@@ -22,5 +30,5 @@ tail:
     if (*(int*)(c+0x98) >= 0x14000) *(int*)(c+0x98) = 0x14000;
     *(unsigned char*)(c+0x706) = 1;
     return 1;
-}
+
 }

--- a/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
@@ -21,10 +21,16 @@ extern short data_0209f4a0;
 extern int data_ov002_0211013c[];
 extern int data_ov002_021106c4[];
 extern int data_ov002_0211067c[];
+}
 
-int _ZN6Player24St_MetalWaterGround_MainEv(char* c)
+struct Player {
+    int St_MetalWaterGround_Main();
+};
+
+int Player::St_MetalWaterGround_Main()
 {
-    if(func_ov002_020cec2c(c)) return 1;
+    char* c = (char*)this;
+if(func_ov002_020cec2c(c)) return 1;
     int u703 = *(unsigned char*)(c+0x703);
     if((int)(data_0209f32c - 0x50000) < (int)(*(int*)(c+0x60) - 0xa000)){
         *(unsigned char*)(c+0x706) = 0;
@@ -86,6 +92,5 @@ int _ZN6Player24St_MetalWaterGround_MainEv(char* c)
     }
     func_ov002_020bedd4(c);
     return 1;
-}
 
 }

--- a/src/_ZN6Player4BurnEv.cpp
+++ b/src/_ZN6Player4BurnEv.cpp
@@ -3,10 +3,18 @@ extern "C" {
 extern int func_ov002_020d82f0(void*);
 extern int data_ov002_021100dc[];
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-int _ZN6Player4BurnEv(char* c){
-  if(func_ov002_020d82f0(c)==0) return 0;
+}
+
+struct Player {
+    int Burn();
+};
+
+int Player::Burn()
+{
+    char* c = (char*)this;
+if(func_ov002_020d82f0(c)==0) return 0;
   if(*(unsigned char*)(c+0x6f9) || *(unsigned char*)(c+0x706)) return 0;
   _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_021100dc);
   return 1;
-}
+
 }

--- a/src/_ZN6Player5ShockEj.cpp
+++ b/src/_ZN6Player5ShockEj.cpp
@@ -5,8 +5,16 @@ extern State data_ov002_021100c4;
 extern int func_ov002_020d82f0(void* c);
 extern int func_ov002_020d91e0(void* c, int a, int b, int d);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, State* st);
-int _ZN6Player5ShockEj(char* c, unsigned int j){
-  if (func_ov002_020d82f0(c) == 0) return 0;
+}
+
+struct Player {
+    int Shock(unsigned int j);
+};
+
+int Player::Shock(unsigned int j)
+{
+    char* c = (char*)this;
+if (func_ov002_020d82f0(c) == 0) return 0;
   if (*(unsigned char*)(c+0x6f9)) j = 0;
   *(unsigned char*)(c+0x6e5) = 0;
   if (func_ov002_020d91e0(c, j<<8, 1, 0)) *(unsigned char*)(c+0x6e5) = 1;
@@ -16,5 +24,5 @@ int _ZN6Player5ShockEj(char* c, unsigned int j){
   }
   _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021100c4);
   return 1;
-}
+
 }

--- a/src/_ZN6Player7CanWarpEv.cpp
+++ b/src/_ZN6Player7CanWarpEv.cpp
@@ -4,8 +4,16 @@ struct State;
 extern State _ZN6Player7ST_WAITE;
 extern State data_ov002_021102a4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player7CanWarpEv(void* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, &_ZN6Player7ST_WAITE) || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102a4)) return 1;
-  return 0;
 }
+
+struct Player {
+    int CanWarp();
+};
+
+int Player::CanWarp()
+{
+    void* c = (void*)this;
+if(_ZN6Player7IsStateERNS_5StateE(c, &_ZN6Player7ST_WAITE) || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102a4)) return 1;
+  return 0;
+
 }

--- a/src/_ZN6Player8BlowAwayEs.cpp
+++ b/src/_ZN6Player8BlowAwayEs.cpp
@@ -2,11 +2,19 @@
 extern "C" {
 extern int data_ov002_0211037c[];
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-void _ZN6Player8BlowAwayEs(char* c, short v){
-  if(*(unsigned char*)(c+0x6f9)) return;
+}
+
+struct Player {
+    void BlowAway(short v);
+};
+
+void Player::BlowAway(short v)
+{
+    char* c = (char*)this;
+if(*(unsigned char*)(c+0x6f9)) return;
   if(*(unsigned char*)(c+0x6fd)) return;
   *(short*)(c+0x94)=v;
   *(short*)(c+0x8e)=(short)(v+0x8000);
   _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211037c);
-}
+
 }

--- a/src/_ZN6Player8CanPauseEv.cpp
+++ b/src/_ZN6Player8CanPauseEv.cpp
@@ -4,8 +4,16 @@ struct State;
 extern State data_ov002_0211067c;
 extern State data_ov002_021106ac;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player8CanPauseEv(void* c){
-  if(*(unsigned char*)((char*)c+0x706)){
+}
+
+struct Player {
+    int CanPause();
+};
+
+int Player::CanPause()
+{
+    void* c = (void*)this;
+if(*(unsigned char*)((char*)c+0x706)){
     if(_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211067c)) goto ret1a;
     if(_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021106ac)) goto ret1a;
     goto ret0;
@@ -18,5 +26,5 @@ ret1a:
   return 1;
 ret0:
   return 0;
-}
+
 }

--- a/src/_ZN6Player8HasNoCapEv.cpp
+++ b/src/_ZN6Player8HasNoCapEv.cpp
@@ -5,8 +5,16 @@ extern unsigned char data_0209f2d8;
 extern int data_ov002_0211058c;
 int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 int _ZN8SaveData16HasPlayerLostCapEv(void);
-int _ZN6Player8HasNoCapEv(char* c){
-    if(data_0209f2f8 == 0x1f) return 0;
+}
+
+struct Player {
+    int HasNoCap();
+};
+
+int Player::HasNoCap()
+{
+    char* c = (char*)this;
+if(data_0209f2f8 == 0x1f) return 0;
     int r = (data_0209f2d8 == 2);
     if(!r){
         if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211058c)){
@@ -19,5 +27,5 @@ int _ZN6Player8HasNoCapEv(char* c){
     if(*(int*)(c+8) == 3) return 0;
     r = *(unsigned char*)(c+0x71a) != 0;
     return r;
-}
+
 }

--- a/src/_ZN6Player8IsDivingEv.cpp
+++ b/src/_ZN6Player8IsDivingEv.cpp
@@ -2,7 +2,15 @@
 extern "C" {
 extern int data_ov002_021105bc[];
 int _ZN6Player7IsStateERNS_5StateE(void*, void*);
-int _ZN6Player8IsDivingEv(void* c){
-  return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105bc) != 0;
 }
+
+struct Player {
+    int IsDiving();
+};
+
+int Player::IsDiving()
+{
+    void* c = (void*)this;
+return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105bc) != 0;
+
 }

--- a/src/_ZN6ShipUp16CleanupResourcesEv.cpp
+++ b/src/_ZN6ShipUp16CleanupResourcesEv.cpp
@@ -5,11 +5,19 @@ extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov016_021136e4[];
 extern void* data_ov016_021136dc[];
-int _ZN6ShipUp16CleanupResourcesEv(char* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
+}
+
+struct ShipUp {
+    int CleanupResources();
+};
+
+int ShipUp::CleanupResources()
+{
+    char* c = (char*)this;
+if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136e4[*(unsigned char*)(c+0x31e)]);
   _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136dc[*(unsigned char*)(c+0x31e)]);
   return 1;
-}
+
 }

--- a/src/_ZN6Thwomp6RenderEv.cpp
+++ b/src/_ZN6Thwomp6RenderEv.cpp
@@ -4,11 +4,19 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
 extern "C" {
-int _ZN6Thwomp6RenderEv(char* c){
-  int check = *(int*)(*(int*)(c+0x320)+0xc);
+}
+
+struct Thwomp {
+    int Render();
+};
+
+int Thwomp::Render()
+{
+    char* c = (char*)this;
+int check = *(int*)(*(int*)(c+0x320)+0xc);
   if (check != 0)
     _ZN15TextureSequence6UpdateER15ModelComponents(c+0x324, c+0xdc);
   ((Sub*)(c+0xd4))->g5(0);
   return 1;
-}
+
 }

--- a/src/_ZN6Thwomp8BehaviorEv.cpp
+++ b/src/_ZN6Thwomp8BehaviorEv.cpp
@@ -12,10 +12,16 @@ int _ZN9Animation8FinishedEv(void *self);
 void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
+}
 
-int _ZN6Thwomp8BehaviorEv(char *c)
+struct Thwomp {
+    int Behavior();
+};
+
+int Thwomp::Behavior()
 {
-    if (*(int *)(c + 0x398) < 2) {
+    char * c = (char *)this;
+if (*(int *)(c + 0x398) < 2) {
         if (*(unsigned char *)(c + 0x3a2) != 0)
             *(int *)(c + 0x398) = 2;
     }
@@ -91,5 +97,5 @@ int _ZN6Thwomp8BehaviorEv(char *c)
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
 done:
     return 1;
-}
+
 }

--- a/src/_ZN6ToxBox16CleanupResourcesEv.cpp
+++ b/src/_ZN6ToxBox16CleanupResourcesEv.cpp
@@ -5,11 +5,19 @@ int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov092_02132540[];
 extern int data_ov092_02132548[];
-int _ZN6ToxBox16CleanupResourcesEv(char* c){
-  _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132540);
+}
+
+struct ToxBox {
+    int CleanupResources();
+};
+
+int ToxBox::CleanupResources()
+{
+    char* c = (char*)this;
+_ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132540);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132548);
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase7DisableEv(c+0x124);
   return 1;
-}
+
 }

--- a/src/_ZN7HeaveHo13InitResourcesEv.cpp
+++ b/src/_ZN7HeaveHo13InitResourcesEv.cpp
@@ -14,8 +14,16 @@ extern char data_ov077_02127c90;
 extern char data_ov077_02127c98;
 extern struct V3 data_ov077_02127a5c;
 extern char data_ov077_02127ce8;
-int _ZN7HeaveHo13InitResourcesEv(char* c){
-  struct V3 v;
+}
+
+struct HeaveHo {
+    int InitResources();
+};
+
+int HeaveHo::InitResources()
+{
+    char* c = (char*)this;
+struct V3 v;
   void* f;
   f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov077_02127c88);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x340, f, 1, -1);
@@ -41,5 +49,5 @@ int _ZN7HeaveHo13InitResourcesEv(char* c){
   *(int*)(c + 0x418) = *(int*)(c + 0x64);
   func_ov077_02126d5c(c, &data_ov077_02127ce8);
   return 1;
-}
+
 }

--- a/src/_ZN7Seaweed13InitResourcesEv.cpp
+++ b/src/_ZN7Seaweed13InitResourcesEv.cpp
@@ -10,12 +10,20 @@ extern BCA_File* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr& f);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* m, BCA_File* f, int a, Fix12i b, unsigned int c);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* m, void* a, Fix12i r, Fix12i h, unsigned int f1, unsigned int f2);
 extern void func_ov002_020bc664(void* t);
-int _ZN7Seaweed13InitResourcesEv(char* c){
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e104), 1, -1);
+}
+
+struct Seaweed {
+    int InitResources();
+};
+
+int Seaweed::InitResources()
+{
+    char* c = (char*)this;
+_ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e104), 1, -1);
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_0210e0fc), 0, 0x1000, 0);
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x138, c, 0x3c000, 0x78000, 0x100002, 0x8000);
   *(int*)(c+0x16c) = 0x1000;
   func_ov002_020bc664(c);
   return 1;
-}
+
 }

--- a/src/_ZN7SkiLift13InitResourcesEv.cpp
+++ b/src/_ZN7SkiLift13InitResourcesEv.cpp
@@ -17,8 +17,16 @@ extern void _ZN13RaycastGroundD1Ev(void *self);
 extern int data_ov036_02113c00[];
 extern int data_ov018_02112c0c[];
 extern int data_ov056_02112c04[];
-int _ZN7SkiLift13InitResourcesEv(char *c) {
-    void *m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_02113c00);
+}
+
+struct SkiLift {
+    int InitResources();
+};
+
+int SkiLift::InitResources()
+{
+    char * c = (char *)this;
+void *m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_02113c00);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, 1);
     for (int i = 0; i < 2; i++)
         _ZN9Animation8LoadFileER13SharedFilePtr((void*)data_ov018_02112c0c[i]);
@@ -55,5 +63,5 @@ int _ZN7SkiLift13InitResourcesEv(char *c) {
     func_ov018_02111d28(c, 0);
     _ZN13RaycastGroundD1Ev(rg);
     return 1;
-}
+
 }

--- a/src/_ZN7SkiLift16CleanupResourcesEv.cpp
+++ b/src/_ZN7SkiLift16CleanupResourcesEv.cpp
@@ -6,11 +6,18 @@ void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern struct SharedFilePtr data_ov036_02113c00;
 extern struct SharedFilePtr* data_ov018_02112c0c[2];
 extern struct SharedFilePtr* data_ov056_02112c04[2];
-int _ZN7SkiLift16CleanupResourcesEv(void){
-  int i;
+}
+
+struct SkiLift {
+    int CleanupResources(void);
+};
+
+int SkiLift::CleanupResources(void)
+{
+int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov036_02113c00);
   for(i=0;i<2;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov018_02112c0c[i]);
   for(i=0;i<2;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov056_02112c04[i]);
   return 1;
-}
+
 }

--- a/src/_ZN7Tornado13InitResourcesEv.cpp
+++ b/src/_ZN7Tornado13InitResourcesEv.cpp
@@ -12,10 +12,16 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thi
 extern int data_ov096_02137ba8[];
 extern int data_ov096_02137bb0[];
 extern int func_02112968[];
+}
 
-int _ZN7Tornado13InitResourcesEv(char* c)
+struct Tornado {
+    int InitResources();
+};
+
+int Tornado::InitResources()
 {
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x2c4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137ba8), 1, 0x15);
+    char* c = (char*)this;
+_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x2c4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137ba8), 1, 0x15);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov096_02137bb0);
     func_02016aac(c + 0x2c4, 0x16, 1);
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x2c4, (void*)data_ov096_02137bb0[1], 0, 0x1000, 0);
@@ -42,5 +48,5 @@ int _ZN7Tornado13InitResourcesEv(char* c)
     *(int*)(c + 0x364) = 0;
     *(int*)(c + 0x368) = 0;
     return 1;
-}
+
 }

--- a/src/_ZN7Wiggler6RenderEv.cpp
+++ b/src/_ZN7Wiggler6RenderEv.cpp
@@ -4,8 +4,16 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int _ZN7Wiggler6RenderEv(char* c){
-  int i = 0;
+}
+
+struct Wiggler {
+    int Render();
+};
+
+int Wiggler::Render()
+{
+    char* c = (char*)this;
+int i = 0;
   char* p6 = c+0x110;
   char* p5 = c+0x368;
   char* p4 = c+0x408;
@@ -17,5 +25,5 @@ int _ZN7Wiggler6RenderEv(char* c){
     p4 += 0xc;
   }
   return 1;
-}
+
 }

--- a/src/_ZN8BigBully13InitResourcesEv.cpp
+++ b/src/_ZN8BigBully13InitResourcesEv.cpp
@@ -20,10 +20,16 @@ extern void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 extern Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 actorID, u32 param1, const Vector3* pos, const Vector3_16* rot, s8 areaID, s16 deathTableID);
 extern int data_ov064_0211b93c;
 extern s16 data_02082214[];
+}
 
-int _ZN8BigBully13InitResourcesEv(char* c)
+struct BigBully {
+    int InitResources();
+};
+
+int BigBully::InitResources()
 {
-    int saved;
+    char* c = (char*)this;
+int saved;
 
     *(void**)(c + 0x330) = &data_ov064_0211b93c;
     saved = func_ov064_02116ec0(c);
@@ -83,5 +89,5 @@ int _ZN8BigBully13InitResourcesEv(char* c)
     *(u8*)(c + 0x3fe) = 0xff;
 done:
     return saved;
-}
+
 }

--- a/src/_ZN8BookShot16CleanupResourcesEv.cpp
+++ b/src/_ZN8BookShot16CleanupResourcesEv.cpp
@@ -6,12 +6,20 @@ extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
 extern int data_ov020_02114aa8;
 extern int data_ov020_02114ab0;
-int _ZN8BookShot16CleanupResourcesEv(void *c){
-  _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa0);
+}
+
+struct BookShot {
+    int CleanupResources();
+};
+
+int BookShot::CleanupResources()
+{
+    void * c = (void *)this;
+_ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa0);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab8);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa8);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab0);
   UnloadBlueCoinModel(c);
   return 1;
-}
+
 }

--- a/src/_ZN8BookShot8BehaviorEv.cpp
+++ b/src/_ZN8BookShot8BehaviorEv.cpp
@@ -9,10 +9,16 @@ extern void func_ov020_0211174c(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* thiz);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* thiz, const Vector3& v);
 extern void _ZN12CylinderClsn6UpdateEv(void* thiz);
+}
 
-int _ZN8BookShot8BehaviorEv(char* c)
+struct BookShot {
+    int Behavior();
+};
+
+int BookShot::Behavior()
 {
-    func_0200f760(c, c + 0x21c);
+    char* c = (char*)this;
+func_0200f760(c, c + 0x21c);
     if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x25c) != 0) {
         if (*(unsigned char*)(c + 0x107) != 0 && *(unsigned short*)(c + 0x104) == 5) {
             *(int*)(c + 0x428) = *(int*)(c + 0x424);
@@ -37,5 +43,5 @@ int _ZN8BookShot8BehaviorEv(char* c)
     _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x21c, *(Vector3*)(c + 0x438));
     _ZN12CylinderClsn6UpdateEv(c + 0x21c);
     return 1;
-}
+
 }

--- a/src/_ZN8CccArena8BehaviorEv.cpp
+++ b/src/_ZN8CccArena8BehaviorEv.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 extern void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
-int _ZN8CccArena8BehaviorEv(char* c){
-  void* o = *(void**)(c+0x320);
+}
+
+struct CccArena {
+    int Behavior();
+};
+
+int CccArena::Behavior()
+{
+    char* c = (char*)this;
+void* o = *(void**)(c+0x320);
   if(*(int*)((char*)o+8)){
     char* base = (char*)o+8;
     int adj = *(int*)(base+4);
@@ -19,5 +27,5 @@ int _ZN8CccArena8BehaviorEv(char* c){
   *(int*)(c+0x11c) = *(int*)(c+0x64) >> 3;
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   return 1;
-}
+
 }

--- a/src/_ZN8DockPole8BehaviorEv.cpp
+++ b/src/_ZN8DockPole8BehaviorEv.cpp
@@ -2,12 +2,20 @@
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void* c);
 extern void Matrix4x3_FromRotationY(void* m, short angle);
-int _ZN8DockPole8BehaviorEv(char* c){
-  _ZN9Animation7AdvanceEv(c+0x124);
+}
+
+struct DockPole {
+    int Behavior();
+};
+
+int DockPole::Behavior()
+{
+    char* c = (char*)this;
+_ZN9Animation7AdvanceEv(c+0x124);
   Matrix4x3_FromRotationY(c+0xf0, *(short*)(c+0x8e));
   *(int*)(c+0x114)=*(int*)(c+0x5c)>>3;
   *(int*)(c+0x118)=*(int*)(c+0x60)>>3;
   *(int*)(c+0x11c)=*(int*)(c+0x64)>>3;
   return 1;
-}
+
 }

--- a/src/_ZN8Goomboss16CleanupResourcesEv.cpp
+++ b/src/_ZN8Goomboss16CleanupResourcesEv.cpp
@@ -9,10 +9,16 @@ extern void* data_ov074_0212292c[];
 extern char data_ov074_02123000;
 extern void* data_ov074_02122948[];
 extern char data_ov074_02123040;
+}
 
-int _ZN8Goomboss16CleanupResourcesEv(int* c)
+struct Goomboss {
+    int CleanupResources();
+};
+
+int Goomboss::CleanupResources()
 {
-    int i;
+    int* c = (int*)this;
+int i;
     int v = c[2];
     if (v == 0x1111) {
         return func_ov074_0212229c(c);
@@ -27,5 +33,5 @@ int _ZN8Goomboss16CleanupResourcesEv(int* c)
         _ZN13SharedFilePtr7ReleaseEv(data_ov074_02122948[i]);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov074_02123040);
     return 1;
-}
+
 }

--- a/src/_ZN8IceSheet8BehaviorEv.cpp
+++ b/src/_ZN8IceSheet8BehaviorEv.cpp
@@ -2,9 +2,17 @@
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
-int _ZN8IceSheet8BehaviorEv(char* c){
-  if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
+}
+
+struct IceSheet {
+    int Behavior();
+};
+
+int IceSheet::Behavior()
+{
+    char* c = (char*)this;
+if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
     _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
   return 1;
-}
+
 }

--- a/src/_ZN8PathLift9AfterClsnEv.cpp
+++ b/src/_ZN8PathLift9AfterClsnEv.cpp
@@ -4,8 +4,16 @@ int func_ov002_020efedc(void *c);
 int DecIfAbove0_Byte(void *p);
 void func_02012694(int a, void *p);
 void func_ov002_020efa54(void *c, int a);
-void _ZN8PathLift9AfterClsnEv(char *c) {
-    if (func_ov002_020efedc(c) != 0 &&
+}
+
+struct PathLift {
+    void AfterClsn();
+};
+
+void PathLift::AfterClsn()
+{
+    char * c = (char *)this;
+if (func_ov002_020efedc(c) != 0 &&
         *(int*)(c + 0x44c) == 0 &&
         DecIfAbove0_Byte(c + 0x42b) == 0) {
         int b = *(unsigned short *)(c + 0xc) == 0x1f;
@@ -15,5 +23,5 @@ void _ZN8PathLift9AfterClsnEv(char *c) {
         func_ov002_020efa54(c, 1);
     }
     *(unsigned char *)(c + 0x42a) = 1;
-}
+
 }

--- a/src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp
+++ b/src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp
@@ -4,12 +4,20 @@ struct M4 { int w[12]; };
 struct MMC { char p[0x124]; };
 struct Obj { char p[0x2ec]; M4 m; };
 int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
-void _ZN8Platform19UpdateClsnPosAndRotEv(char* self){
-    Obj* o = (Obj*)self;
+}
+
+struct Platform {
+    void UpdateClsnPosAndRot();
+};
+
+void Platform::UpdateClsnPosAndRot()
+{
+    char* self = (char*)this;
+Obj* o = (Obj*)self;
     o->m = *(M4*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60);
     *(int*)(self+0x318) = *(int*)(self+0x64);
     _ZN18MovingMeshCollider9TransformERK9Matrix4x3s((MMC*)(self+0x124), o->m, *(short*)(self+0x8e));
-}
+
 }

--- a/src/_ZN8PoleLift8BehaviorEv.cpp
+++ b/src/_ZN8PoleLift8BehaviorEv.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 extern int func_0203aad0(void*);
 extern int _ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE(void*,int);
-int _ZN8PoleLift8BehaviorEv(char* c){
-  int v=func_0203aad0(c+0x158);
+}
+
+struct PoleLift {
+    int Behavior();
+};
+
+int PoleLift::Behavior()
+{
+    char* c = (char*)this;
+int v=func_0203aad0(c+0x158);
   if(*(unsigned char*)(c+0xd4)){
     _ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE(c+0x158, v+8);
     if(func_0203aad0(c+0x158)>0x1000) *(char*)(c+0xd4)=0;
@@ -12,5 +20,5 @@ int _ZN8PoleLift8BehaviorEv(char* c){
     if(func_0203aad0(c+0x158)<0x800) *(char*)(c+0xd4)=1;
   }
   return 1;
-}
+
 }

--- a/src/_ZN8SaveData16CanPlayerHaveCapEv.cpp
+++ b/src/_ZN8SaveData16CanPlayerHaveCapEv.cpp
@@ -2,11 +2,18 @@
 extern "C" {
 extern unsigned char data_0209caa0[];
 extern unsigned char data_0209f2d8[];
-int _ZN8SaveData16CanPlayerHaveCapEv(void){
-  if (data_0209caa0[0x41] != 3) {
+}
+
+struct SaveData {
+    int CanPlayerHaveCap(void);
+};
+
+int SaveData::CanPlayerHaveCap(void)
+{
+if (data_0209caa0[0x41] != 3) {
     int b = (int)(data_0209f2d8[0] == 1);
     if (b == 0) return 1;
   }
   return 0;
-}
+
 }

--- a/src/_ZN8SaveData22NumGlowingRabbitsFoundEv.cpp
+++ b/src/_ZN8SaveData22NumGlowingRabbitsFoundEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned char data_0209caa0[];
-int _ZN8SaveData22NumGlowingRabbitsFoundEv(void){
-  int count = 0;
+}
+
+struct SaveData {
+    int NumGlowingRabbitsFound(void);
+};
+
+int SaveData::NumGlowingRabbitsFound(void)
+{
+int count = 0;
   int f = *(int*)(data_0209caa0+8);
   unsigned int mask = 0x100000;
   int i = 0;
@@ -12,5 +19,5 @@ int _ZN8SaveData22NumGlowingRabbitsFoundEv(void){
     mask <<= 1;
   } while(i < 8);
   return count;
-}
+
 }

--- a/src/_ZN8ShipWing13InitResourcesEv.cpp
+++ b/src/_ZN8ShipWing13InitResourcesEv.cpp
@@ -14,8 +14,16 @@ extern int data_ov036_02114084[];
 extern int data_ov036_02112b48[];
 extern void _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern void func_ov036_02111cc4();
-int _ZN8ShipWing13InitResourcesEv(char* c){
-  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_0211408c);
+}
+
+struct ShipWing {
+    int InitResources();
+};
+
+int ShipWing::InitResources()
+{
+    char* c = (char*)this;
+int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_0211408c);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
@@ -30,5 +38,5 @@ int _ZN8ShipWing13InitResourcesEv(char* c){
   *(int*)(c+0x4e0) = *(int*)(c+0x60);
   *(int*)(c+0x4e4) = *(int*)(c+0x64);
   return 1;
-}
+
 }

--- a/src/_ZN8Squasher13InitResourcesEv.cpp
+++ b/src/_ZN8Squasher13InitResourcesEv.cpp
@@ -14,9 +14,16 @@ extern void* data_ov023_02112088;
 extern void* _ZN32FloatOnWaterPlatformWdwRectangleD1Ev;
 extern void* data_ov064_0211ba4c;
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
-int _ZN8Squasher13InitResourcesEv(char* c) {
-  int bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov023_02112088);
+struct Squasher {
+    int InitResources();
+};
+
+int Squasher::InitResources()
+{
+    char* c = (char*)this;
+int bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov023_02112088);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, bmd, 1, -1);
   _ZN11ShadowModel10InitCuboidEv(c+0x324);
   func_ov026_02111308(c);
@@ -29,5 +36,5 @@ int _ZN8Squasher13InitResourcesEv(char* c) {
   *(short*)(c+0x320) = 0;
   *(char*)(c+0x322) = 0;
   return 1;
-}
+
 }

--- a/src/_ZN8YoshiEgg8BehaviorEv.cpp
+++ b/src/_ZN8YoshiEgg8BehaviorEv.cpp
@@ -11,10 +11,16 @@ extern void _ZN9ModelBase12ApplyOpacityEj(void *self, unsigned int op, int z);
 extern void func_ov002_020ed998(void *c);
 extern void func_ov002_020ed7f8(void *c);
 extern void func_ov002_020edca4(void *c);
+}
 
-int _ZN8YoshiEgg8BehaviorEv(char *self)
+struct YoshiEgg {
+    int Behavior();
+};
+
+int YoshiEgg::Behavior()
 {
-    Vec3 vin;
+    char * self = (char *)this;
+Vec3 vin;
     Vec3 vmid;
     Vec3 vout;
     func_ov002_020ed684(self);
@@ -54,5 +60,5 @@ int _ZN8YoshiEgg8BehaviorEv(char *self)
         func_ov002_020edca4(self);
     }
     return 1;
-}
+
 }

--- a/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
+++ b/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
@@ -2,12 +2,20 @@
 extern "C" {
 extern int data_020a4b88[]; extern int data_02099f24[]; extern int data_020a4b78[]; extern int data_020a4b98[];
 extern void func_0203b27c(void*, void*); extern void func_0204405c(void*, void*);
-void _ZN9ActorBase18AfterInitResourcesEj(char* c, unsigned int a){
-  if(a!=2) return;
+}
+
+struct ActorBase {
+    void AfterInitResources(unsigned int a);
+};
+
+void ActorBase::AfterInitResources(unsigned int a)
+{
+    char* c = (char*)this;
+if(a!=2) return;
   func_0203b27c(data_020a4b88, c+0x28);
   volatile int* p=data_02099f24; bool b=(p[0]==3); if(b){ *(bool*)(c+0x10)=true; return; }
   func_0204405c(data_020a4b78, c+0x28);
   func_0204405c(data_020a4b98, c+0x38);
   *(bool*)(c+0xe)=true;
-}
+
 }

--- a/src/_ZN9Animation8FinishedEv.cpp
+++ b/src/_ZN9Animation8FinishedEv.cpp
@@ -1,8 +1,13 @@
 //cpp
-extern "C" {
-int _ZN9Animation8FinishedEv(void* c){
-  unsigned int f=*(unsigned int*)((char*)c+4);
+struct Animation {
+    int Finished();
+};
+
+int Animation::Finished()
+{
+    void* c = (void*)this;
+unsigned int f=*(unsigned int*)((char*)c+4);
   int cur=*(int*)((char*)c+8);
   return cur>=(int)((f&0x3fffffff)-1);
-}
+
 }

--- a/src/_ZN9Animation8SetFlagsEi.cpp
+++ b/src/_ZN9Animation8SetFlagsEi.cpp
@@ -1,6 +1,11 @@
 //cpp
-extern "C" {
-void _ZN9Animation8SetFlagsEi(void* c,int flags){
-  *(unsigned int*)((char*)c+4)=(*(unsigned int*)((char*)c+4)&0x3fffffff)|flags;
-}
+struct Animation {
+    void SetFlags(int flags);
+};
+
+void Animation::SetFlags(int flags)
+{
+    void* c = (void*)this;
+*(unsigned int*)((char*)c+4)=(*(unsigned int*)((char*)c+4)&0x3fffffff)|flags;
+
 }

--- a/src/_ZN9ArrowLift13InitResourcesEv.cpp
+++ b/src/_ZN9ArrowLift13InitResourcesEv.cpp
@@ -4,8 +4,16 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* bmd, int a, int b);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, int fix, int t, unsigned int u, unsigned int v);
 extern int data_ov029_02114270[];
-int _ZN9ArrowLift13InitResourcesEv(char* c){
-  void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
+}
+
+struct ArrowLift {
+    int InitResources();
+};
+
+int ArrowLift::InitResources()
+{
+    char* c = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x124, c, 0x32000, 0x64000, 0x800002, 0);
   *(int*)(c+0x158) = 0;
@@ -13,5 +21,5 @@ int _ZN9ArrowLift13InitResourcesEv(char* c){
   *(char*)(c+0x15d) = 0;
   *(short*)(c+0x8e) = 0;
   return 1;
-}
+
 }

--- a/src/_ZN9LakituBro6RenderEv.cpp
+++ b/src/_ZN9LakituBro6RenderEv.cpp
@@ -4,10 +4,18 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int _ZN9LakituBro6RenderEv(char* c){
-  if (*(unsigned char*)(c+0x2dc) == 1) return 1;
+}
+
+struct LakituBro {
+    int Render();
+};
+
+int LakituBro::Render()
+{
+    char* c = (char*)this;
+if (*(unsigned char*)(c+0x2dc) == 1) return 1;
   _ZN15TextureSequence6UpdateER15ModelComponents(c+0x1d8, c+0x118);
   ((Sub*)(c+0x110))->g5(0);
   return 1;
-}
+
 }

--- a/src/_ZN9OneUpLogo13InitResourcesEv.cpp
+++ b/src/_ZN9OneUpLogo13InitResourcesEv.cpp
@@ -8,9 +8,16 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, int c, unsigned int n);
+}
 
-int _ZN9OneUpLogo13InitResourcesEv(char* self){
-  unsigned short n;
+struct OneUpLogo {
+    int InitResources();
+};
+
+int OneUpLogo::InitResources()
+{
+    char* self = (char*)this;
+unsigned short n;
   {
     unsigned int v = *(unsigned int*)(self+8);
     n = (unsigned short)(v > 8 ? 7 : (v - 1));
@@ -31,5 +38,5 @@ int _ZN9OneUpLogo13InitResourcesEv(char* self){
   *(int*)(self+0x138) = 0;
   *(int*)(self+0x148) = 0;
   return 1;
-}
+
 }

--- a/src/_ZN9RabbitKey8BehaviorEv.cpp
+++ b/src/_ZN9RabbitKey8BehaviorEv.cpp
@@ -2,8 +2,16 @@
 extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void* a, void* b);
-int _ZN9RabbitKey8BehaviorEv(char* c){
-  DecIfAbove0_Short((unsigned short*)(c+0x100));
+}
+
+struct RabbitKey {
+    int Behavior();
+};
+
+int RabbitKey::Behavior()
+{
+    char* c = (char*)this;
+DecIfAbove0_Short((unsigned short*)(c+0x100));
   void* o = *(void**)(c+0x188);
   if(*(int*)((char*)o+8)){
     char* base = (char*)o+8;
@@ -22,5 +30,5 @@ int _ZN9RabbitKey8BehaviorEv(char* c){
   *(int*)(c+0xac) = t;
   _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, 0);
   return 1;
-}
+
 }

--- a/src/_ZN9SeesawBob8BehaviorEv.cpp
+++ b/src/_ZN9SeesawBob8BehaviorEv.cpp
@@ -1,6 +1,4 @@
 //cpp
-typedef short s16;
-struct V3 { int x, y, z; };
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
@@ -9,9 +7,16 @@ void func_ov095_021358cc(void* c, void* a, void* b, int d, int e, int f, int g);
 void func_ov095_0213597c(char *t);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
+}
 
-int _ZN9SeesawBob8BehaviorEv(char* c){
-    int b = (int)((*(int*)(c + 0xb0) & 8) != 0);
+struct SeesawBob {
+    int Behavior();
+};
+
+int SeesawBob::Behavior()
+{
+    char* c = (char*)this;
+int b = (int)((*(int*)(c + 0xb0) & 8) != 0);
     if (b != 0) {
         if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
             _ZN16MeshColliderBase7DisableEv(c + 0x124);
@@ -37,5 +42,5 @@ int _ZN9SeesawBob8BehaviorEv(char* c){
     }
     *(unsigned char*)(c + 0x326) = 0;
     return 1;
-}
+
 }

--- a/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
+++ b/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap11VMemoryLeftEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+struct SolidHeap {
+    unsigned int VMemoryLeft();
+};
+
+unsigned int SolidHeap::VMemoryLeft()
+{
+    char* self = (char*)this;
+return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+
 }

--- a/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
+++ b/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern void _ZN18SolidHeapAllocator5ResetEj(void*, unsigned int);
-
-void _ZN9SolidHeap14VDeallocateAllEv(char* self) {
-    _ZN18SolidHeapAllocator5ResetEj(*(void**)(self + 0x14), 3);
 }
+
+struct SolidHeap {
+    void VDeallocateAll();
+};
+
+void SolidHeap::VDeallocateAll()
+{
+    char* self = (char*)this;
+_ZN18SolidHeapAllocator5ResetEj(*(void**)(self + 0x14), 3);
+
 }

--- a/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap19VMaxAllocatableSizeEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+struct SolidHeap {
+    unsigned int VMaxAllocatableSize();
+};
+
+unsigned int SolidHeap::VMaxAllocatableSize()
+{
+    char* self = (char*)this;
+return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+
 }

--- a/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,8 +1,15 @@
 //cpp
 extern "C" {
 extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap22VMaxAllocationUnitSizeEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+struct SolidHeap {
+    unsigned int VMaxAllocationUnitSize();
+};
+
+unsigned int SolidHeap::VMaxAllocationUnitSize()
+{
+    char* self = (char*)this;
+return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
+
 }

--- a/src/_ZN9Spindrift8BehaviorEv.cpp
+++ b/src/_ZN9Spindrift8BehaviorEv.cpp
@@ -19,10 +19,16 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *, void *);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *, void *, unsigned);
 extern int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *, void *, int, short, int, int, int);
 /* sig: (this, WithMeshClsn&, Fix12, short, bool, bool, Fix12) */
+}
 
-int _ZN9Spindrift8BehaviorEv(char *c)
+struct Spindrift {
+    int Behavior();
+};
+
+int Spindrift::Behavior()
 {
-    int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1d0, c + 0x110, 3);
+    char * c = (char *)this;
+int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1d0, c + 0x110, 3);
     if (r != 0) {
         if (r == 2)
             func_ov081_021237ec(c);
@@ -86,5 +92,5 @@ int _ZN9Spindrift8BehaviorEv(char *c)
     _ZN12CylinderClsn5ClearEv(c + 0x19c);
     _ZN12CylinderClsn6UpdateEv(c + 0x19c);
     return 1;
-}
+
 }

--- a/src/_ZN9TinyCover13InitResourcesEv.cpp
+++ b/src/_ZN9TinyCover13InitResourcesEv.cpp
@@ -14,10 +14,16 @@ extern int data_ov033_021124f0[];
 extern int data_ov033_02111bc8[];
 extern int data_ov033_021124e8[];
 extern int data_ov033_02111c1c[];
+}
 
-int _ZN9TinyCover13InitResourcesEv(char* c)
+struct TinyCover {
+    int InitResources();
+};
+
+int TinyCover::InitResources()
 {
-    void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov033_021124f0);
+    char* c = (char*)this;
+void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov033_021124f0);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, 0x14);
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*(void**)((char*)data_ov033_021124f0 + 4), data_ov033_02111bc8);
     _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x320, data_ov033_02111bc8, 0, 0x1000, 0);
@@ -29,5 +35,5 @@ int _ZN9TinyCover13InitResourcesEv(char* c)
     _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
     *(int*)(c + 0x334) = *(int*)(c + 0x60) - 0x3c000;
     return _ZN5Event6GetBitEj(0xe) == 0;
-}
+
 }

--- a/src/_ZN9TowerStep13InitResourcesEv.cpp
+++ b/src/_ZN9TowerStep13InitResourcesEv.cpp
@@ -11,8 +11,16 @@ extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vect
 extern void* data_ov015_02114a8c;
 extern void* data_ov015_02114a84;
 extern void* data_ov015_02113654;
-int _ZN9TowerStep13InitResourcesEv(char* c) {
-  void* f;
+}
+
+struct TowerStep {
+    int InitResources();
+};
+
+int TowerStep::InitResources()
+{
+    char* c = (char*)this;
+void* f;
   f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov015_02114a8c);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
@@ -23,5 +31,5 @@ int _ZN9TowerStep13InitResourcesEv(char* c) {
   func_020393d4((int*)(c + 0x124), (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
   *(unsigned char*)(c + 0x31e) = 0x3c;
   return 1;
-}
+
 }

--- a/src/_ZN9WaterBomb16CleanupResourcesEv.cpp
+++ b/src/_ZN9WaterBomb16CleanupResourcesEv.cpp
@@ -4,14 +4,21 @@ struct SharedFilePtr { unsigned short fileID; unsigned char numRefs; char* fileP
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr* self);
 extern struct SharedFilePtr data_ov002_0210da38;
 extern struct SharedFilePtr data_ov098_0213c91c;
+}
 
-int _ZN9WaterBomb16CleanupResourcesEv(char* c){
-  if (*(int*)(c+0x3c8) == 2) {
+struct WaterBomb {
+    int CleanupResources();
+};
+
+int WaterBomb::CleanupResources()
+{
+    char* c = (char*)this;
+if (*(int*)(c+0x3c8) == 2) {
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   } else {
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov098_0213c91c);
   }
   return 1;
-}
+
 }

--- a/src/_ZN9WaterBomb8BehaviorEv.cpp
+++ b/src/_ZN9WaterBomb8BehaviorEv.cpp
@@ -11,9 +11,16 @@ extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern int data_ov098_0213c930[];
+}
 
-int _ZN9WaterBomb8BehaviorEv(char* c) {
-    if (func_ov098_0213b6e0(c)) {
+struct WaterBomb {
+    int Behavior();
+};
+
+int WaterBomb::Behavior()
+{
+    char* c = (char*)this;
+if (func_ov098_0213b6e0(c)) {
         func_ov098_0213b584(c);
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         return 1;
@@ -50,5 +57,5 @@ int _ZN9WaterBomb8BehaviorEv(char* c) {
         DecIfAbove0_Short((unsigned short*)(c + 0x100));
     }
     return 1;
-}
+
 }


### PR DESCRIPTION
This PR converts 1,398 mangled C++ functions in \src/\ from \.c\ files to \.cpp\ files with \//cpp\ headers and refactors functions into native C++ class member methods (\Class::Method\) and virtual destructors.

### Highlights:
- **1,398 C++ mangled functions** (_Z...) converted to \.cpp\ files in \src/\.
- **Verified 100% byte-matched** via \	ools/match.py\ (\mwccarm 1.2/sp2p3\).
- **Added \
otes/cpp-class-conversion.md\** detailing native C++ class method standards and updated \AGENTS.md\ for future agents.