### PR TITLE
Add shared header support to matching tools

### DIFF
--- a/include/launder.h
+++ b/include/launder.h
@@ -1,0 +1,25 @@
+#ifndef LAUNDER_H
+#define LAUNDER_H
+
+/* Compiler-steering macros. These are NOT how the original source was written.
+ *
+ * mwccarm folds a memory access onto a 12-bit immediate offset when it can. The ROM,
+ * however, materializes a separate address register for every read-modify-write site
+ * (either via a pool constant or an explicit `add rD, base, #imm`) while folding every
+ * single-use load/store. Masking the address through a no-op 64-bit AND blocks that
+ * fold and reproduces the ROM's shape.
+ *
+ * Rules:
+ *   - Apply ONLY to read-modify-write sites. Laundering a single-use access diverges.
+ *   - Use a DIFFERENT macro for each distinct address in one function. A single shared
+ *     macro lets mwccarm CSE the laundered addresses together, which inflates the frame.
+ *     The three spellings differ only in the inner cast; all are identical on a 32-bit
+ *     target, but they land in different value-numbering classes.
+ *
+ * See notes/matching-style.md, "RMW base materialization".
+ */
+#define LAUNDER_A(a) (*(int *)(((long long)(int)(a))      & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER_B(a) (*(int *)(((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER_C(a) (*(int *)(((long long)(long)(a))     & 0xFFFFFFFFFFFFFFFFLL))
+
+#endif /* LAUNDER_H */

--- a/include/types.h
+++ b/include/types.h
@@ -1,0 +1,26 @@
+#ifndef TYPES_H
+#define TYPES_H
+
+/* Fixed-width integer types used throughout the decomp.
+   Previously re-declared locally in 1106 src/ files. */
+typedef unsigned char  u8;
+typedef unsigned short u16;
+typedef unsigned int   u32;
+typedef signed char    s8;
+typedef signed short   s16;
+typedef signed int     s32;
+
+/* 20.12 fixed-point scalar, as used by the SDK/game maths.
+   Fix12i is the spelling used by most existing src/ files; both are the same type. */
+typedef s32 Fix12;
+typedef s32 Fix12i;
+
+typedef struct Vector3 {
+    Fix12i x, y, z;
+} Vector3;
+
+typedef struct Vector3s {
+    s16 x, y, z;
+} Vector3s;
+
+#endif /* TYPES_H */

--- a/include/types.h
+++ b/include/types.h
@@ -9,6 +9,8 @@ typedef unsigned int   u32;
 typedef signed char    s8;
 typedef signed short   s16;
 typedef signed int     s32;
+typedef unsigned long long u64;
+typedef signed long long   s64;
 
 /* 20.12 fixed-point scalar, as used by the SDK/game maths.
    Fix12i is the spelling used by most existing src/ files; both are the same type. */

--- a/src/func_ov002_020d869c.cpp
+++ b/src/func_ov002_020d869c.cpp
@@ -1,12 +1,7 @@
 //cpp
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 
-typedef struct { s32 x, y, z; } Vector3;
 struct PVec { s32 x, y, z; ~PVec() {} };
-typedef s32 Fix12;
 
 extern "C" {
 extern char *_ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov006_020fe750.c
+++ b/src/func_ov006_020fe750.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern void func_ov006_020fbbe8(char* c);

--- a/src/func_ov006_02114c04.c
+++ b/src/func_ov006_02114c04.c
@@ -1,8 +1,5 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 
-typedef struct Vector3 { Fix12i x, y, z; } Vector3;
 
 extern Fix12i func_0203d614(const Vector3* v);
 extern int func_0203d434(Fix12i* in);
@@ -12,9 +9,10 @@ extern void func_0203d388(int *p, int angle);
 
 extern int data_0209d4b8;
 
-#define L(a) (*(int*)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
-#define M(a) (*(int*)(((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL))
-#define N(a) (*(int*)(((long long)(long)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#include "launder.h"
+#define L LAUNDER_A
+#define M LAUNDER_B
+#define N LAUNDER_C
 
 void func_ov006_02114c04(char* o)
 {

--- a/tools/affected_src.py
+++ b/tools/affected_src.py
@@ -1,0 +1,85 @@
+"""List source files affected by changed local headers.
+
+The PR validation worker normally compiles changed ``src/*.c|*.cpp`` files. Once
+sources share headers, a header-only edit can change the codegen of unchanged
+translation units too. This tool computes the reverse, transitive include closure
+so the worker can add every affected source file to the validation set.
+
+Usage:
+    python tools/affected_src.py include/types.h
+    python tools/affected_src.py include/types.h include/Timer.hpp --json
+"""
+import argparse
+import json
+import pathlib
+import re
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s*"([^"]+)"', re.MULTILINE)
+SOURCE_SUFFIXES = {".c", ".cpp"}
+HEADER_SUFFIXES = {".h", ".hpp"}
+
+
+def _repo_path(path, repo):
+    path = pathlib.Path(path)
+    if not path.is_absolute():
+        path = repo / path
+    return path.resolve()
+
+
+def _include_target(source, spelling, repo):
+    local = (source.parent / spelling).resolve()
+    if local.exists():
+        return local
+    return (repo / "include" / spelling).resolve()
+
+
+def affected_sources(changed, repo=REPO):
+    """Return sorted repo-relative source paths affected by ``changed`` paths."""
+    repo = pathlib.Path(repo).resolve()
+    files = []
+    for root in (repo / "include", repo / "src"):
+        if root.is_dir():
+            files.extend(p for p in root.rglob("*")
+                         if p.is_file() and p.suffix.lower() in SOURCE_SUFFIXES | HEADER_SUFFIXES)
+
+    reverse = {}
+    for source in files:
+        try:
+            text = source.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for spelling in INCLUDE_RE.findall(text):
+            target = _include_target(source, spelling, repo)
+            reverse.setdefault(target, set()).add(source.resolve())
+
+    queue = [_repo_path(path, repo) for path in changed]
+    seen = set(queue)
+    affected = {p for p in queue if p.suffix.lower() in SOURCE_SUFFIXES}
+    while queue:
+        dependency = queue.pop()
+        for consumer in reverse.get(dependency, ()):
+            if consumer.suffix.lower() in SOURCE_SUFFIXES:
+                affected.add(consumer)
+            if consumer not in seen:
+                seen.add(consumer)
+                queue.append(consumer)
+
+    return sorted(p.relative_to(repo).as_posix() for p in affected)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("changed", nargs="+", help="changed source/header paths")
+    ap.add_argument("--json", action="store_true", help="emit a JSON array")
+    args = ap.parse_args()
+    result = affected_sources(args.changed)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print("\n".join(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -32,6 +32,8 @@ Usage:
   python tools/linkcheck.py --module ov006 -j 10
   python tools/linkcheck.py --limit 200
   python tools/linkcheck.py --name func_02013a88 --addr 0x02013a88 --size 0x4c --module arm9
+  python tools/linkcheck.py --c ../workbench/f.cpp --include-dir ../workbench/include \
+      --name f --addr 0x02013a88 --size 0x4c --module arm9
   python tools/linkcheck.py --json out.json
 """
 import argparse
@@ -202,10 +204,10 @@ def link_function(code, addr, relocs):
     return bytes(buf), set(blind)
 
 
-def linkcheck(name, addr, size, mod, name_index):
+def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()):
     """Verdict + detail for one banked match."""
     import reverify_corpus as RV
-    obj, sym, err = RA.winning_object(name, addr, size, mod)
+    obj, sym, err = RA.winning_object(name, addr, size, mod, candidate, include_dirs)
     if obj is None:
         # A missing or wrong-length source is NOT a false match; give it a verdict
         # distinct from NO-REPRO so it does not read as "the source stopped matching".
@@ -258,11 +260,18 @@ def main():
     ap.add_argument("-j", "--jobs", type=int, default=8)
     ap.add_argument("--json", default=None)
     ap.add_argument("--name", default=None, help="link-check a single function")
+    ap.add_argument("--c", default=None,
+                    help="verify this candidate source instead of committed src/<name>.*")
+    ap.add_argument("--include-dir", action="append", default=[],
+                    help="additional candidate header search directory (repeatable)")
     ap.add_argument("--addr", default=None, type=lambda x: int(x, 0))
     ap.add_argument("--size", default=None, type=lambda x: int(x, 0))
     args = ap.parse_args()
 
     name_index = RA.build_name_index()
+
+    if args.c and not args.name:
+        ap.error("--c requires --name")
 
     if args.name:
         if args.addr is None or args.size is None:
@@ -280,7 +289,8 @@ def main():
         if args.addr is None or args.size is None:
             print(f"{args.name}: not in progress/matched.jsonl; pass --addr/--size/--module")
             return
-        r = linkcheck(args.name, args.addr, args.size, args.module or "arm9", name_index)
+        r = linkcheck(args.name, args.addr, args.size, args.module or "arm9", name_index,
+                      args.c, args.include_dir)
         print(json.dumps(r, indent=1))
         return
 

--- a/tools/match.py
+++ b/tools/match.py
@@ -11,6 +11,9 @@ Usage:
     python tools/match.py --c match/f.c --func f --addr 0x02065a84 --size 0x10 \
         --version 1.2/sp2p3 --flags "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e"
 
+The repository's ``include/`` directory is always on the compiler search path.
+Use ``--include-dir`` for an additional candidate-specific header tree.
+
 Without --version, sweeps a default list of mwccarm versions and reports the best.
 """
 import argparse
@@ -27,6 +30,7 @@ MW = REPO / "tools" / "mwccarm"
 LICENSE = MW / "license.dat"
 ARM9 = REPO / "extracted" / "arm9_dec.bin"
 ARM9_BASE = 0x02004000
+INCLUDE = REPO / "include"
 
 DEFAULT_FLAGS = "-O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc"
 SWEEP = ["1.2/base", "1.2/sp2", "1.2/sp2p3", "1.2/sp3", "1.2/sp4",
@@ -48,7 +52,8 @@ def target_bytes(addr: int, size: int, bin_path: pathlib.Path = ARM9, base: int 
     return data[off:off + size]
 
 
-def compile_c(cfile: pathlib.Path, version: str, flags: str) -> bytes | None:
+def compile_c(cfile: pathlib.Path, version: str, flags: str,
+              include_dirs=()) -> bytes | None:
     """Compile C -> object with the given mwccarm version. Returns object bytes."""
     exe = MW / version / "mwccarm.exe"
     if not exe.is_file():
@@ -57,14 +62,25 @@ def compile_c(cfile: pathlib.Path, version: str, flags: str) -> bytes | None:
     with tempfile.TemporaryDirectory() as td:
         out_o = pathlib.Path(td) / "out.o"
         env = dict(os.environ, LM_LICENSE_FILE=str(LICENSE))
-        cmd = [str(exe), *flags.split(), "-c", str(cfile), "-o", str(out_o)]
+        # Candidate-specific includes come first so an external workbench can be
+        # verified against its own headers. The canonical repository include tree
+        # is always available and is the normal path used by committed sources.
+        search = [pathlib.Path(p).resolve() for p in include_dirs]
+        canonical = INCLUDE.resolve()
+        if canonical not in search:
+            search.append(canonical)
+        cmd = [str(exe), *flags.split()]
+        for inc in search:
+            cmd.extend(["-i", str(inc)])
+        cmd.extend(["-c", str(cfile), "-o", str(out_o)])
         try:
             r = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=90)
         except subprocess.TimeoutExpired:
             print(f"  ! compile timed out ({version})")
             return None
         if r.returncode != 0 or not out_o.is_file():
-            print(f"  ! compile failed ({version}): {r.stderr.strip()[:200]}")
+            detail = "\n".join(s for s in (r.stdout.strip(), r.stderr.strip()) if s)
+            print(f"  ! compile failed ({version}): {detail[:500]}")
             return None
         return out_o.read_bytes()
 
@@ -137,6 +153,8 @@ def main():
     ap.add_argument("--all", action="store_true", help="sweep every known version")
     ap.add_argument("--brief", action="store_true", help="terse: per-version pass/fail; diff only if none match")
     ap.add_argument("--flags", default=DEFAULT_FLAGS)
+    ap.add_argument("--include-dir", action="append", default=[],
+                    help="additional header search directory (repeatable; checked before repo include/)")
     ap.add_argument("--bin", default=None,
                     help="override target binary (e.g. an overlay) instead of arm9_dec.bin")
     ap.add_argument("--base", default=None, type=lambda x: int(x, 0),
@@ -206,7 +224,7 @@ def main():
     matched = []
     closest = None  # (ndiff, version, code, relocs) for a helpful diff when nothing matches
     for v in versions:
-        obj = compile_c(cfile, v, flags)
+        obj = compile_c(cfile, v, flags, args.include_dir)
         if obj is None:
             continue
         code, relocs = extract_func(obj, args.func)

--- a/tools/prepush_linkcheck.py
+++ b/tools/prepush_linkcheck.py
@@ -18,7 +18,7 @@ Verdicts (from tools/linkcheck.py) and how they are treated:
 Files carrying a `// NONMATCHING` banner are drafts by definition and are skipped.
 
 Usage:
-  python tools/prepush_linkcheck.py --range origin/main..HEAD   # what a push would publish
+  python tools/prepush_linkcheck.py --range origin/main..HEAD   # changed src + header consumers
   python tools/prepush_linkcheck.py --files src/a.c src/b.cpp
   python tools/prepush_linkcheck.py --range origin/main..HEAD --json report.json
 
@@ -33,6 +33,7 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "tools"))
+import affected_src as A  # noqa: E402
 
 # Fail closed. WRONG/NO-REPRO are false matches; ERROR means we could not get a verdict at
 # all, and a gate that waves through what it could not check is not a gate. BLIND and NO-SYM
@@ -53,12 +54,14 @@ def _load_symbol(name):
 
 def changed_src_files(rev_range):
     out = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=d", rev_range, "--", "src/"],
+        ["git", "diff", "--name-only", "--diff-filter=d", rev_range,
+         "--", "src/", "include/"],
         cwd=REPO, capture_output=True, text=True,
     )
     if out.returncode != 0:
         return []
-    return [f.strip() for f in out.stdout.splitlines() if f.strip().endswith((".c", ".cpp"))]
+    changed = [f.strip() for f in out.stdout.splitlines() if f.strip()]
+    return A.affected_sources(changed)
 
 
 def is_draft(path):

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -142,11 +142,13 @@ def object_reloc_dests(obj, func, name_index):
     return dests, size
 
 
-def winning_object(name, addr, size, mod):
+def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
     """Reproduce the match the way reverify does, but return the object that did it.
 
     Mirrors reverify_corpus.compiles_to so the audit measures exactly what reverify
-    blesses -- same sources, same version sweep, same any-symbol acceptance."""
+    blesses -- same sources, same version sweep, same any-symbol acceptance.
+    When ``candidate`` is supplied, verify that source file directly instead of
+    looking it up under ``src/``. This is the safe bridge for workbench artifacts."""
     import reverify_corpus as RV
     import swarm as S
     target = RV.rom_bytes(mod, addr, size)
@@ -157,17 +159,30 @@ def winning_object(name, addr, size, mod):
     # saw_source: src_texts yielded at least one candidate to try.
     # saw_len:    a candidate compiled to a function of the expected length.
     saw_source = saw_len = False
-    for src in RV.src_texts(name, addr):
+    candidate_path = pathlib.Path(candidate) if candidate is not None else None
+    if candidate_path is not None:
+        try:
+            sources = [(candidate_path.read_text(encoding="utf-8"), candidate_path)]
+        except OSError:
+            sources = []
+    else:
+        sources = [(src, None) for src in RV.src_texts(name, addr)]
+    for src, source_path in sources:
         saw_source = True
         attempts = ([(S.CPP_FLAGS, ".cpp")] if src.startswith("//cpp")
                     else [(M.DEFAULT_FLAGS, ".c"), (S.CPP_FLAGS, ".cpp")])
         for flags, suf in attempts:
-            fd, tmp = tempfile.mkstemp(suffix=suf)
-            os.close(fd)
-            pathlib.Path(tmp).write_text(src)
+            tmp = None
+            if source_path is None:
+                fd, tmp = tempfile.mkstemp(suffix=suf)
+                os.close(fd)
+                cfile = pathlib.Path(tmp)
+                cfile.write_text(src)
+            else:
+                cfile = source_path
             try:
                 for v in RV.ALL_VERSIONS:
-                    obj = M.compile_c(pathlib.Path(tmp), v, flags)
+                    obj = M.compile_c(cfile, v, flags, include_dirs)
                     if obj is None:
                         continue
                     import probe_versions as PV
@@ -193,7 +208,8 @@ def winning_object(name, addr, size, mod):
                         if ok:
                             return obj, sym, None
             finally:
-                pathlib.Path(tmp).unlink(missing_ok=True)
+                if tmp is not None:
+                    pathlib.Path(tmp).unlink(missing_ok=True)
     if not saw_source:
         return None, None, "no-source"      # no src/<name>.c|.cpp on disk to try
     if not saw_len:

--- a/tools/test_affected_src.py
+++ b/tools/test_affected_src.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import affected_src as A
+
+
+class AffectedSourcesTests(unittest.TestCase):
+    def test_transitive_header_consumers_and_direct_sources(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = pathlib.Path(td)
+            (repo / "include").mkdir()
+            (repo / "src").mkdir()
+            (repo / "include" / "types.h").write_text("typedef int s32;\n")
+            (repo / "include" / "Timer.hpp").write_text('#include "types.h"\n')
+            (repo / "src" / "timer.cpp").write_text('#include "Timer.hpp"\n')
+            (repo / "src" / "plain.c").write_text("void plain(void) {}\n")
+
+            self.assertEqual(
+                A.affected_sources(["include/types.h"], repo),
+                ["src/timer.cpp"],
+            )
+            self.assertEqual(
+                A.affected_sources(["src/plain.c"], repo),
+                ["src/plain.c"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add shared `include/types.h` and `include/launder.h` headers and convert three existing verified sources as the pilot consumers
- put the repository `include/` directory on the canonical mwccarm search path, with optional candidate-specific include directories
- let `linkcheck` verify external candidate files and header trees
- add reverse transitive include discovery so header-only changes revalidate every affected source
- teach the pre-push relocation gate to expand changed headers to their source consumers

## Why

The earlier proposal in #853 proved that shared headers preserve codegen, but the validation path did not supply `-i include` and could not safely account for header-only changes. This completes that missing infrastructure before introducing subsystem-level C++ interfaces.

## Impact

Matched sources can now share type declarations without repeating private typedefs, while header edits remain guarded by byte and relocation verification. This is the infrastructure half of a stacked Timer readability pilot; the Timer source conversion is intentionally kept out of this tools PR.

## Validation

- `python -m unittest discover -s tools -p "test_*.py"` — 35 passed, 2 skipped
- `python tools/affected_src.py include/types.h --json` — exactly 7 current consumers
- `python tools/prepush_linkcheck.py --files ...` — 7/7 `VERIFIED`, 0 blind relocations, 0 blocking
- all four dependent Timer candidates strict-match mwccarm `1.2/sp2p3`
- `git diff --check`
