### PR TITLE
Add C++ decompilation index, safe renaming tools, and ABI naming guide

### DIFF
--- a/notes/cpp-naming-guide.md
+++ b/notes/cpp-naming-guide.md
@@ -1,0 +1,184 @@
+# C++ Naming Guide
+
+This guide explains the C++ naming conventions and Itanium ABI mangling rules used in the sm64ds-decomp project. Understanding these is essential for writing C++ code that matches the ROM's original symbols and vtable structures.
+
+## 1. Itanium ABI Name Mangling Quick Reference
+
+The compiler (`mwccarm`) uses the standard Itanium C++ ABI for mangling symbols.
+
+*   `_Z` - Mangled name prefix. All C++ symbols start with this.
+*   `N...E` - Nested name sequence (used for classes/namespaces). The `N` begins the nesting, `E` ends it.
+*   **Length-Prefixed Names:** Identifiers are prefixed by their length in characters (e.g., `6Player` for `Player`).
+
+### Type Codes (Arguments & Returns)
+*   `v` = `void`
+*   `b` = `bool`
+*   `c` = `char`
+*   `h` = `unsigned char`
+*   `s` = `short`
+*   `t` = `unsigned short`
+*   `i` = `int`
+*   `j` = `unsigned int`
+*   `l` = `long`
+*   `m` = `unsigned long`
+*   `x` = `long long`
+*   `y` = `unsigned long long`
+*   `f` = `float`
+*   `d` = `double`
+
+### Qualifiers
+*   `P` = Pointer (`*`)
+*   `R` = Reference (`&`)
+*   `K` = `const`
+
+### Templates & Substitutions
+*   `I...E` = Template arguments.
+*   `S_`, `S0_`, `S1_` = Substitutions (used to compress repeated types or names in the signature).
+
+### Real Game Examples
+*   `_ZN6Player11St_Owl_MainEv` &rarr; `Player::St_Owl_Main(void)`
+*   `_ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_` &rarr; `Actor::SetRanges(Fix12<int>, Fix12<int>, Fix12<int>, Fix12<int>)`
+    *   *Note the `S1_` substituting the `Fix12<int>` type to save space.*
+*   `_Z14ApproachLinearR7Vector3RKS_5Fix12IiE` &rarr; `ApproachLinear(Vector3&, const Vector3&, Fix12<int>)`
+    *   *`R7Vector3` is `Vector3&`. `RKS_` uses substitution to mean `const Vector3&`.*
+
+## 2. Constructor & Destructor Variants
+
+In C++, constructors and destructors have multiple variants in the compiled object file to handle virtual inheritance and allocation.
+
+*   **Constructors:**
+    *   `C1` - Complete object constructor.
+    *   `C2` - Base object constructor (called when the class is a base of another class).
+    *   `C3` - Allocating constructor.
+*   **Destructors:**
+    *   `D0` - Deleting destructor (destroys the object and calls `delete`/deallocator).
+    *   `D1` - Complete object destructor.
+    *   `D2` - Base object destructor.
+
+### Real Game Examples
+*   `_ZN5ActorC2Ev` &rarr; `Actor::Actor()` (Base constructor)
+*   `_ZN5ActorD0Ev` &rarr; `Actor::~Actor()` (Deleting destructor, often appears as vtable slot 17)
+*   `_ZN5ActorD1Ev` &rarr; `Actor::~Actor()` (Complete destructor, often appears as vtable slot 16)
+
+You will frequently see `D1` and `D0` assigned as the last two slots in an actor's virtual function table.
+
+## 3. Thunks Explained
+
+Thunks are small compiler-generated functions that adjust the `this` pointer before jumping to the actual function implementation. They are necessary in C++ when using multiple inheritance.
+
+*   `_ZThn<offset>_` - Non-virtual `this`-adjustment thunk.
+*   `_ZTv<voff>_n<off>_` - Virtual `this`-adjustment thunk.
+
+### Real Game Example
+*   `_ZThn80_N9ModelAnimD0Ev` &rarr; Non-virtual thunk adjusting `this` by `-80` for `ModelAnim::~ModelAnim()`.
+    *   If you call a virtual destructor through a base class pointer, and that base class is located at offset 80 within the derived class, the thunk subtracts 80 from the `this` pointer before invoking the derived destructor.
+
+## 4. Vtable Layout
+
+To achieve byte-matching virtual dispatches, you must replicate the exact vtable layout. For most objects inheriting from `ActorBase`, the standard virtual order has 18 slots.
+
+### The ActorBase Virtual Order
+0. `InitResources`
+1. `BeforeInitResources`
+2. `AfterInitResources(u32)`
+3. `CleanupResources`
+4. `Before~`
+5. `After~(u32)`
+6. `Behavior`
+7. `BeforeBehavior`
+8. `AfterBehavior(u32)`
+9. `Render`
+10. `BeforeRender`
+11. `AfterRender(u32)`
+12. `OnPendingDestroy`
+13. `Virtual34(u32, u32)`
+14. `Virtual38(u32, u32)`
+15. `OnHeapCreated`
+16. `~Actor()` (D1 complete destructor)
+17. `~Actor()` (D0 deleting destructor)
+
+### Declaring Dummy Virtuals
+If you are matching a virtual function call on an object, say calling `Behavior()` (slot 6), you must ensure your C++ structure defines the preceding virtuals so `Behavior()` lands at offset `6 * 4 = 24` in the vtable.
+
+```cpp
+struct Actor {
+    virtual void dummy0();
+    virtual void dummy1();
+    virtual void dummy2();
+    virtual void dummy3();
+    virtual void dummy4();
+    virtual void dummy5();
+    virtual void Behavior(); // Slot 6
+};
+```
+
+## 5. File Naming Conventions
+
+When writing matching C/C++ source in the `src/` directory, adhere to the following rules:
+
+*   **Extensions:** Use `.c` for pure C files, and `.cpp` for C++ files.
+*   **The `//cpp` Marker:** For C++ files (even some `.c` files compiled as C++ to get the correct codegen), put `//cpp` exactly on the first line. This tells the compiler/build system to use `-lang c++`.
+*   **`extern "C"` Patterns:** When declaring global functions that the game references by unmangled names, wrap them in `extern "C"`.
+*   **One Function per File:** Generally, each matching file contains one function.
+*   **Filenames:** The source filename should precisely match the mangled symbol name of the function it contains (e.g., `_ZN13OneUpMushroom8BehaviorEv.cpp`).
+
+### Example (e.g., `_ZN13OneUpMushroom8BehaviorEv.cpp`)
+```cpp
+//cpp
+#include "sm64ds.h"
+
+extern "C" {
+    // Other unmangled dependencies
+}
+
+void OneUpMushroom::Behavior() {
+    // ...
+}
+```
+
+## 6. Reading a Mangled Name by Hand
+
+Let's break down a real symbol manually: `_ZN13OneUpMushroom8BehaviorEv`
+
+1.  `_Z` - Mangled name prefix.
+2.  `N` - Indicates a nested name (Class::Method).
+3.  `13` - The next identifier is 13 characters long.
+4.  `OneUpMushroom` - The class name.
+5.  `8` - The next identifier is 8 characters long.
+6.  `Behavior` - The method name.
+7.  `E` - Ends the nested name sequence.
+8.  `v` - The argument type is `void` (takes no arguments).
+
+Result: `OneUpMushroom::Behavior(void)`
+
+## 7. Using the Tools
+
+The project provides Python tools to help you work with C++ names and symbols:
+
+*   **Demangle a Symbol:** Use `demangle.py` for a quick breakdown.
+    `python tools/demangle.py _ZN13OneUpMushroom8BehaviorEv`
+*   **Browse Classes:** Use the C++ indexer to find all known methods for a class.
+    `python tools/cpp_index.py --class Player`
+*   **Rename Files:** If you deduce a function's real name and update the ledger, safely rename the source file and update its references (run dry-run first).
+    `python tools/cpp_rename.py --dry-run`
+*   **Cross-Check:** You can also use standard `c++filt` from GNU binutils to demangle standard Itanium names.
+
+## 8. Common Patterns in the Codebase
+
+When decompiling, you will frequently encounter these top classes. The number of matched methods (as of recent metrics) indicates how pervasive they are:
+
+*   **Player** (246 methods) - Extremely complex state machines (`St_*_Init`, `St_*_Main`).
+*   **Actor** (81 methods) - Base behaviors, spawning patterns.
+*   **Stage** (44 methods)
+*   **Heap** (31 methods)
+*   **Sound** (29 methods)
+*   **WithMeshClsn** (27 methods)
+*   **IRQ** (24 methods)
+*   **Scene** (24 methods)
+*   **GX** (22 methods)
+*   **Message** (22 methods)
+*   **ActorBase** (22 methods)
+*   **Model** (21 methods)
+
+**Actor Spawn Patterns:** Spawn functions typically allocate the instance (`mov r0, #size` before the first `bl`) and store the class vtable (the last pool literal stored).
+**Destructor Chains:** `func_ovNN_...` functions returning `this` often consist of a vtable install, several `SubObjectD1(this+off)` calls in reverse construction order, and a final `Deallocate` call.

--- a/tools/cpp_index.py
+++ b/tools/cpp_index.py
@@ -1,0 +1,307 @@
+"""cpp_index.py — Class-level decompilation index tool.
+
+Aggregates all C++ symbols across the codebase (from src/, config symbol files,
+tsv symbol lists, and nearmiss/db.jsonl) and presents a structured view grouped by class.
+
+Usage:
+    python tools/cpp_index.py                      # all classes summary
+    python tools/cpp_index.py --class Player       # inspect single class
+    python tools/cpp_index.py --missing            # show classes with unmatched methods
+    python tools/cpp_index.py --json report.json   # export machine-readable JSON
+    python tools/cpp_index.py --md report.md       # export Markdown summary
+"""
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import demangle as DM
+import ledger as L
+
+def load_all_symbols():
+    """Load symbols from symbols.txt and overlay symbol files."""
+    symbols = {}  # name -> dict(module, addr, size)
+    
+    # 1. Main ARM9 symbols.txt
+    symbols_txt = REPO / "config" / "arm9" / "symbols.txt"
+    if symbols_txt.is_file():
+        for line in symbols_txt.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                name = parts[0]
+                addr = None
+                size = 0
+                kind = "function"
+                for p in parts[1:]:
+                    if p.startswith("addr:"):
+                        try: addr = int(p[5:], 16)
+                        except ValueError: pass
+                    elif p.startswith("size:"):
+                        try: size = int(p[5:], 16)
+                        except ValueError: pass
+                    elif p.startswith("kind:"):
+                        kind = p[5:].split("(")[0]
+                if name and addr is not None:
+                    symbols[name] = {"name": name, "module": "arm9", "addr": addr, "size": size, "kind": kind}
+
+    # 2. Overlay symbol files
+    overlays_dir = REPO / "config" / "arm9" / "overlays"
+    if overlays_dir.is_dir():
+        for ov_dir in overlays_dir.iterdir():
+            ov_sym = ov_dir / "symbols.txt"
+            if ov_sym.is_file():
+                mod = ov_dir.name
+                for line in ov_sym.read_text(encoding="utf-8", errors="ignore").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        name = parts[0]
+                        addr = None
+                        size = 0
+                        kind = "function"
+                        for p in parts[1:]:
+                            if p.startswith("addr:"):
+                                try: addr = int(p[5:], 16)
+                                except ValueError: pass
+                            elif p.startswith("size:"):
+                                try: size = int(p[5:], 16)
+                                except ValueError: pass
+                            elif p.startswith("kind:"):
+                                kind = p[5:].split("(")[0]
+                        if name and addr is not None:
+                            symbols[name] = {"name": name, "module": mod, "addr": addr, "size": size, "kind": kind}
+
+    # 3. TSV files for extra mapped symbols
+    tsv_files = [REPO / "symbols" / "actor_renames.tsv"]
+    for tsv in tsv_files:
+        if tsv.is_file():
+            for line in tsv.read_text(encoding="utf-8", errors="ignore").splitlines()[1:]:
+                parts = line.split("\t")
+                if len(parts) >= 4:
+                    mod, addr_str, old_name, new_name = parts[0], parts[1], parts[2], parts[3]
+                    if new_name and new_name.startswith("_Z"):
+                        try:
+                            addr = int(addr_str, 16) if addr_str.startswith("0x") else int(addr_str)
+                            if new_name not in symbols:
+                                symbols[new_name] = {"name": new_name, "module": mod, "addr": addr, "size": 0, "kind": "function"}
+                        except ValueError:
+                            pass
+
+    return symbols
+
+def load_src_matched(known_symbols):
+    """Return dict of symbol_name -> filepath for matched src/ files."""
+    matched = {}
+    src_dir = REPO / "src"
+    known_set = set(known_symbols)
+    if src_dir.is_dir():
+        for path in src_dir.iterdir():
+            if path.suffix in (".c", ".cpp"):
+                stem = path.stem
+                rel_path = str(path.relative_to(REPO))
+                if stem.startswith("_Z"):
+                    matched[stem] = rel_path
+                elif not stem.startswith("func_"):
+                    # Consolidated multi-function class file (e.g., CylinderClsn.cpp, ActorDerived.cpp)
+                    content = path.read_text(encoding="utf-8", errors="ignore")
+                    # Extract all _Z mangled symbol references in the file
+                    found_syms = set(re.findall(r"_Z[a-zA-Z0-9_]+", content))
+                    for sym in found_syms:
+                        if sym in known_set:
+                            matched[sym] = rel_path
+                    
+                    # Also match methods of stem class defined via ClassName::MethodName
+                    for sym in known_set:
+                        if sym.startswith(f"_ZN{len(stem)}{stem}"):
+                            d = DM.demangle(sym)
+                            if d:
+                                method = d.get("method")
+                                if method:
+                                    if f"{stem}::{method}" in content or (d.get("dtor") and f"~{stem}" in content) or (d.get("ctor") and f"{stem}::" in content):
+                                        matched[sym] = rel_path
+    return matched
+
+def load_nearmisses():
+    """Return dict of symbol_name -> dict(divergences, source, label) from nearmiss/db.jsonl."""
+    db_file = REPO / "nearmiss" / "db.jsonl"
+    nearmisses = {}
+    if db_file.is_file():
+        for line in db_file.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    obj = json.loads(line)
+                    name = obj.get("name")
+                    if name:
+                        nearmisses[name] = {
+                            "divergences": obj.get("divergences"),
+                            "source": obj.get("source"),
+                            "floor": obj.get("floor")
+                        }
+                except json.JSONDecodeError:
+                    pass
+    return nearmisses
+
+def build_class_index(class_filter=None, missing_only=False):
+    symbols = load_all_symbols()
+    src_matched = load_src_matched(symbols.keys())
+    nearmisses = load_nearmisses()
+
+    classes = {}  # class_name -> dict(matched=[], unmatched=[], nearmiss=[])
+
+    all_sym_names = set(symbols.keys()) | set(src_matched.keys())
+
+    for sym_name in all_sym_names:
+        if not sym_name.startswith("_Z"):
+            continue
+        d = DM.demangle(sym_name)
+        if not d or not d.get("class"):
+            continue
+        
+        cls_name = d["class"]
+        if class_filter and class_filter.lower() not in cls_name.lower():
+            continue
+
+        if cls_name not in classes:
+            classes[cls_name] = {
+                "class": cls_name,
+                "matched": [],
+                "unmatched": [],
+                "nearmiss": []
+            }
+
+        sym_info = symbols.get(sym_name, {
+            "name": sym_name,
+            "module": "unknown",
+            "addr": 0,
+            "size": 0,
+            "kind": "function"
+        })
+        
+        entry = {
+            "symbol": sym_name,
+            "demangled": DM.signature(sym_name) or d["qualified"],
+            "method": d["method"],
+            "ctor": d["ctor"],
+            "dtor": d["dtor"],
+            "thunk": d.get("thunk", False),
+            "thunk_offset": d.get("thunk_offset"),
+            "module": sym_info["module"],
+            "addr": f"0x{sym_info['addr']:08x}" if isinstance(sym_info['addr'], int) else str(sym_info['addr']),
+            "size": sym_info["size"],
+        }
+
+        if sym_name in src_matched:
+            entry["file"] = src_matched[sym_name]
+            classes[cls_name]["matched"].append(entry)
+        elif sym_name in nearmisses:
+            entry["nearmiss"] = nearmisses[sym_name]
+            classes[cls_name]["nearmiss"].append(entry)
+        else:
+            classes[cls_name]["unmatched"].append(entry)
+
+    if missing_only:
+        classes = {k: v for k, v in classes.items() if v["unmatched"] or v["nearmiss"]}
+
+    return classes
+
+def print_cli_report(classes, single_class_filter=None):
+    if not classes:
+        print("No C++ classes found matching criteria.")
+        return
+
+    sorted_classes = sorted(classes.values(), key=lambda c: c["class"])
+
+    def safe_print(text):
+        try:
+            print(text)
+        except UnicodeEncodeError:
+            print(text.encode("ascii", errors="replace").decode("ascii"))
+
+    if single_class_filter and len(sorted_classes) == 1:
+        cls = sorted_classes[0]
+        n_matched = len(cls["matched"])
+        n_unmatched = len(cls["unmatched"])
+        n_nearmiss = len(cls["nearmiss"])
+        safe_print(f"\n=== {cls['class']} ({n_matched} matched, {n_unmatched} unmatched, {n_nearmiss} near-miss) ===\n")
+
+        if cls["matched"]:
+            safe_print("  Matched Functions:")
+            for e in sorted(cls["matched"], key=lambda x: x["symbol"]):
+                safe_print(f"    [OK] {e['demangled']:<45} {e['symbol']:<35} {e['file']}")
+
+        if cls["nearmiss"]:
+            safe_print("\n  Near-Miss Attempts:")
+            for e in sorted(cls["nearmiss"], key=lambda x: x["symbol"]):
+                div = e['nearmiss'].get('divergences', '?')
+                safe_print(f"    [!]  {e['demangled']:<45} {e['symbol']:<35} nearmiss (div {div})")
+
+        if cls["unmatched"]:
+            safe_print("\n  Unmatched Symbols:")
+            for e in sorted(cls["unmatched"], key=lambda x: x["symbol"]):
+                safe_print(f"    [X]  {e['demangled']:<45} {e['symbol']:<35} ({e['module']}:{e['addr']})")
+        safe_print("")
+    else:
+        safe_print(f"\n{'Class Name':<35} {'Matched':<10} {'Near-Miss':<10} {'Unmatched':<10} {'Completion'}")
+        safe_print("-" * 75)
+        tot_m = tot_nm = tot_u = 0
+        for cls in sorted_classes:
+            m = len(cls["matched"])
+            nm = len(cls["nearmiss"])
+            u = len(cls["unmatched"])
+            tot_m += m
+            tot_nm += nm
+            tot_u += u
+            tot = m + nm + u
+            pct = (m / tot * 100) if tot > 0 else 0
+            safe_print(f"{cls['class']:<35} {m:<10} {nm:<10} {u:<10} {pct:5.1f}%")
+        safe_print("-" * 75)
+        tot_all = tot_m + tot_nm + tot_u
+        pct_tot = (tot_m / tot_all * 100) if tot_all > 0 else 0
+        safe_print(f"{'TOTAL (' + str(len(sorted_classes)) + ' classes)':<35} {tot_m:<10} {tot_nm:<10} {tot_u:<10} {pct_tot:5.1f}%\n")
+
+def main():
+    parser = argparse.ArgumentParser(description="Class-level decompilation index tool")
+    parser.add_argument("--class", dest="cls_filter", help="Filter by class name (case-insensitive)")
+    parser.add_argument("--missing", action="store_true", help="Only show classes with unmatched or near-miss symbols")
+    parser.add_argument("--json", help="Export index report to JSON file")
+    parser.add_argument("--md", help="Export summary report to Markdown file")
+    args = parser.parse_args()
+
+    classes = build_class_index(class_filter=args.cls_filter, missing_only=args.missing)
+
+    if args.json:
+        out_p = pathlib.Path(args.json)
+        out_p.write_text(json.dumps(classes, indent=2), encoding="utf-8")
+        print(f"Wrote JSON report to {out_p}")
+
+    if args.md:
+        out_p = pathlib.Path(args.md)
+        lines = ["# C++ Class Decompilation Index Report\n",
+                 "| Class Name | Matched | Near-Miss | Unmatched | Completion |",
+                 "| :--- | :---: | :---: | :---: | :---: |"]
+        for cls in sorted(classes.values(), key=lambda c: c["class"]):
+            m = len(cls["matched"])
+            nm = len(cls["nearmiss"])
+            u = len(cls["unmatched"])
+            tot = m + nm + u
+            pct = (m / tot * 100) if tot > 0 else 0
+            lines.append(f"| `{cls['class']}` | {m} | {nm} | {u} | {pct:.1f}% |")
+        out_p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        print(f"Wrote Markdown report to {out_p}")
+
+    if not args.json and not args.md:
+        print_cli_report(classes, single_class_filter=args.cls_filter)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cpp_rename.py
+++ b/tools/cpp_rename.py
@@ -1,0 +1,234 @@
+"""cpp_rename.py — Rename func_ADDR files to demangled C++ symbol names safely.
+
+Renames single-function `func_ADDR.c|cpp` files to demangled `_ZN...` symbol names
+when the symbol is verified/known, using `git mv` to preserve git history.
+
+Usage:
+    python tools/cpp_rename.py --dry-run          # preview proposed renames
+    python tools/cpp_rename.py --apply            # apply renames + git mv
+    python tools/cpp_rename.py --addr 0x020b00e8  # rename specific function
+"""
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+
+import demangle as DM
+
+def load_verified_symbols():
+    """Load map of addr -> symbol_name from verified.tsv, actor_renames.tsv, and symbols.txt."""
+    symbol_map = {}  # (module, addr_hex_str) -> new_symbol_name
+
+    # 1. verified.tsv
+    v_tsv = REPO / "symbols" / "verified.tsv"
+    if v_tsv.is_file():
+        for line in v_tsv.read_text(encoding="utf-8", errors="ignore").splitlines():
+            parts = line.strip().split("\t")
+            if len(parts) >= 2:
+                addr_str, name = parts[0], parts[1]
+                if name.startswith("_Z"):
+                    try:
+                        addr = int(addr_str, 16) if addr_str.startswith("0x") else int(addr_str)
+                        symbol_map[f"0x{addr:08x}"] = name
+                    except ValueError:
+                        pass
+
+    # 2. actor_renames.tsv
+    a_tsv = REPO / "symbols" / "actor_renames.tsv"
+    if a_tsv.is_file():
+        for line in a_tsv.read_text(encoding="utf-8", errors="ignore").splitlines()[1:]:
+            parts = line.strip().split("\t")
+            if len(parts) >= 4:
+                mod, addr_str, old_name, new_name = parts[0], parts[1], parts[2], parts[3]
+                if new_name.startswith("_Z"):
+                    try:
+                        addr = int(addr_str, 16) if addr_str.startswith("0x") else int(addr_str)
+                        symbol_map[f"0x{addr:08x}"] = new_name
+                    except ValueError:
+                        pass
+
+    # 3. Arm9 symbols.txt
+    symbols_txt = REPO / "config" / "arm9" / "symbols.txt"
+    if symbols_txt.is_file():
+        for line in symbols_txt.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                name = parts[0]
+                if name.startswith("_Z"):
+                    for p in parts[1:]:
+                        if p.startswith("addr:"):
+                            try:
+                                addr = int(p[5:], 16)
+                                symbol_map[f"0x{addr:08x}"] = name
+                            except ValueError:
+                                pass
+
+    return symbol_map
+
+def find_renamable_files(target_addr=None):
+    verified_map = load_verified_symbols()
+    renames = []  # list of dict(src_path, new_name, new_path, symbol, is_cpp)
+
+    src_dir = REPO / "src"
+    if not src_dir.is_dir():
+        return renames
+
+    for path in src_dir.iterdir():
+        if path.suffix not in (".c", ".cpp"):
+            continue
+
+        stem = path.stem
+        # Match func_ADDR or func_mod_ADDR patterns
+        m = None
+        if stem.startswith("func_"):
+            parts = stem.split("_")
+            if len(parts) >= 2:
+                last_part = parts[-1]
+                if len(last_part) == 8 and all(c in "0123456789abcdefABCDEF" for c in last_part):
+                    m = f"0x{last_part.lower()}"
+
+        if not m:
+            continue
+
+        if target_addr:
+            target_clean = f"0x{int(target_addr, 16):08x}" if target_addr.startswith("0x") else f"0x{int(target_addr):08x}"
+            if m != target_clean:
+                continue
+
+        if m in verified_map:
+            new_sym = verified_map[m]
+            is_cpp = new_sym.startswith("_Z")
+            new_ext = ".cpp" if is_cpp else path.suffix
+            new_filename = f"{new_sym}{new_ext}"
+            new_path = src_dir / new_filename
+
+            if new_path != path:
+                renames.append({
+                    "old_path": path,
+                    "new_path": new_path,
+                    "symbol": new_sym,
+                    "addr": m,
+                    "is_cpp": is_cpp,
+                })
+
+    return renames
+
+def update_match_provenance(old_rel_path, new_rel_path):
+    prov_file = REPO / "config" / "match_provenance.jsonl"
+    if not prov_file.is_file():
+        return False
+
+    lines = prov_file.read_text(encoding="utf-8", errors="ignore").splitlines()
+    updated = False
+    new_lines = []
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+            if obj.get("srcPath") == old_rel_path:
+                obj["srcPath"] = new_rel_path
+                updated = True
+            new_lines.append(json.dumps(obj) + "\n")
+        except json.JSONDecodeError:
+            new_lines.append(line + "\n")
+
+    if updated:
+        prov_file.write_text("".join(new_lines), encoding="utf-8")
+    return updated
+
+def verify_match(rel_path, symbol, addr_str):
+    """Run tools/match.py to verify that the renamed file still byte-matches."""
+    cmd = [
+        sys.executable,
+        str(REPO / "tools" / "match.py"),
+        "--c", rel_path,
+        "--func", symbol,
+        "--addr", addr_str,
+        "--version", "1.2/sp2p3"
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True, cwd=str(REPO))
+    return "MATCHING VERSIONS: 1.2/sp2p3" in r.stdout
+
+def apply_rename(item):
+    old_p = item["old_path"]
+    new_p = item["new_path"]
+    sym = item["symbol"]
+    addr = item["addr"]
+
+    old_rel = str(old_p.relative_to(REPO)).replace("\\", "/")
+    new_rel = str(new_p.relative_to(REPO)).replace("\\", "/")
+
+    # 1. Git move file
+    subprocess.run(["git", "mv", str(old_p), str(new_p)], check=True, cwd=str(REPO))
+
+    # 2. Ensure //cpp header if it's a C++ file
+    if item["is_cpp"]:
+        content = new_p.read_text(encoding="utf-8", errors="ignore")
+        if not content.startswith("//cpp"):
+            new_p.write_text("//cpp\n" + content, encoding="utf-8")
+
+    # 3. Update match_provenance.jsonl
+    update_match_provenance(old_rel, new_rel)
+
+    # 4. Verify match
+    ok = verify_match(new_rel, sym, addr)
+    return ok
+
+def main():
+    parser = argparse.ArgumentParser(description="Rename func_ADDR files to demangled symbol names")
+    parser.add_argument("--dry-run", action="store_true", help="Preview proposed renames without executing")
+    parser.add_argument("--apply", action="store_true", help="Apply renames and update git history")
+    parser.add_argument("--addr", help="Rename single file matching target hex address")
+    args = parser.parse_args()
+
+    renames = find_renamable_files(target_addr=args.addr)
+
+    if not renames:
+        print("No renamable func_ADDR files found.")
+        return
+
+    print(f"Found {len(renames)} renamable file(s):\n")
+
+    for item in renames:
+        old_rel = str(item["old_path"].relative_to(REPO))
+        new_rel = str(item["new_path"].relative_to(REPO))
+        dem = DM.signature(item["symbol"]) or item["symbol"]
+        print(f"  {old_rel:<35} -> {new_rel:<45} ({dem})")
+
+    if args.dry_run or not args.apply:
+        print("\nDry-run complete. Run with --apply to execute renames.")
+        return
+
+    print("\nApplying renames...")
+    successful = 0
+    failed = 0
+
+    for item in renames:
+        old_rel = str(item["old_path"].relative_to(REPO))
+        new_rel = str(item["new_path"].relative_to(REPO))
+        try:
+            ok = apply_rename(item)
+            if ok:
+                print(f"  [OK] Renamed {old_rel} -> {new_rel}")
+                successful += 1
+            else:
+                print(f"  [!] Renamed {old_rel} -> {new_rel} (VERIFICATION FAILED!)")
+                failed += 1
+        except Exception as e:
+            print(f"  [X] Failed to rename {old_rel}: {e}")
+            failed += 1
+
+    print(f"\nFinished: {successful} successful, {failed} failed.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/demangle.py
+++ b/tools/demangle.py
@@ -2,14 +2,23 @@
 the class/method of a symbol and a best-effort argument list. The game's symbols
 (e.g. _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_) ENCODE the class and every argument
 type -- that is free context for the LLM tier and a free grouping key for
-subsystem batching. We do not need a perfect demangler; we need class::method and
-an argument count/shape. Templates and substitutions we collapse to a generic type
-rather than fully resolving them.
+subsystem batching.
+
+Handles:
+  - Nested names (_ZN...E), free functions (_Z<len>...)
+  - Constructors (C1/C2/C3), destructors (D0/D1/D2)
+  - Non-virtual thunks (_ZThn<off>_...), virtual thunks (_ZTv<voff>_n<off>_...)
+  - Operator overloads (new, delete, +, -, ==, etc.)
+  - Templates with primary type extraction (Fix12<int> not just T)
+  - Substitution back-references (S_, S0_, S1_, St)
+  - Pointer (P), reference (R), rvalue-ref (O), const (K) qualifiers
 
 API:
     demangle("_ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_") ->
         {"qualified": "Actor::SetRanges", "class": "Actor", "method": "SetRanges",
-         "args": ["Fix12", "T", "T", "T"], "nargs": 4, "ctor": False, "dtor": False}
+         "args": ["Fix12<int>", "Fix12<int>", "Fix12<int>", "Fix12<int>"],
+         "nargs": 4, "ctor": False, "dtor": False,
+         "thunk": False, "thunk_offset": None, "variant": None}
     Returns None for names that are not _Z-mangled (plain func_xxxx / C names).
 """
 import re
@@ -21,8 +30,34 @@ BUILTIN = {
     "f": "float", "d": "double", "w": "wchar_t",
 }
 
+# Itanium ABI operator codes
+OPERATORS = {
+    "nw": "operator new", "na": "operator new[]",
+    "dl": "operator delete", "da": "operator delete[]",
+    "ps": "operator+", "ng": "operator-",      # unary
+    "ad": "operator&", "de": "operator*",       # unary
+    "co": "operator~", "pl": "operator+", "mi": "operator-",
+    "ml": "operator*", "dv": "operator/", "rm": "operator%",
+    "an": "operator&", "or": "operator|", "eo": "operator^",
+    "aS": "operator=", "pL": "operator+=", "mI": "operator-=",
+    "mL": "operator*=", "dV": "operator/=", "rM": "operator%=",
+    "aN": "operator&=", "oR": "operator|=", "eO": "operator^=",
+    "ls": "operator<<", "rs": "operator>>",
+    "lS": "operator<<=", "rS": "operator>>=",
+    "eq": "operator==", "ne": "operator!=",
+    "lt": "operator<", "gt": "operator>",
+    "le": "operator<=", "ge": "operator>=",
+    "nt": "operator!", "aa": "operator&&", "oo": "operator||",
+    "pp": "operator++", "mm": "operator--",
+    "cm": "operator,", "pm": "operator->*", "pt": "operator->",
+    "cl": "operator()", "ix": "operator[]",
+    "qu": "operator?",
+    "cv": "operator <cast>",  # conversion operator, type follows
+}
+
 
 def _read_len_name(s, i):
+    """Read a length-prefixed name: <digits><name>."""
     m = re.match(r"\d+", s[i:])
     if not m:
         return None, i
@@ -31,62 +66,146 @@ def _read_len_name(s, i):
     return s[i:i + n], i + n
 
 
-def _skip_template(s, i):
-    # s[i] == 'I'; skip to matching 'E'
-    depth = 0
-    while i < len(s):
-        if s[i] == "I":
-            depth += 1
-        elif s[i] == "E":
-            depth -= 1
-            if depth == 0:
-                return i + 1
-        i += 1
-    return i
+def _read_template_args(s, i, subs):
+    """Read template arguments I...E and return a list of type strings.
+
+    s[i] must be 'I'. Returns (arg_list, next_i).
+    """
+    assert s[i] == "I"
+    i += 1  # skip 'I'
+    args = []
+    while i < len(s) and s[i] != "E":
+        t, i = _read_type(s, i, subs)
+        if t is not None:
+            args.append(t)
+        else:
+            break
+    if i < len(s) and s[i] == "E":
+        i += 1  # skip closing 'E'
+    return args, i
 
 
-def _read_type(s, i):
+def _read_type(s, i, subs):
     """Return (type_string, next_i). Best-effort; unknown -> 'T'."""
     if i >= len(s):
         return None, i
     c = s[i]
     if c in BUILTIN:
-        return BUILTIN[c], i + 1
+        ty = BUILTIN[c]
+        # Per Itanium ABI: builtin types are NOT substitution candidates
+        return ty, i + 1
     if c in "PROK":                                  # pointer / ref / rvalue-ref / const wrapper
-        inner, j = _read_type(s, i + 1)
+        inner, j = _read_type(s, i + 1, subs)
         suf = {"P": " *", "R": " &", "O": " &&", "K": " const"}[c]
-        return (inner or "T") + suf, j
-    if c == "S":                                     # substitution S_ / S0_ / St ... -> generic
-        m = re.match(r"S[A-Za-z0-9_]*?_", s[i:])
-        return "T", i + (len(m.group()) if m else 2)
+        ty = (inner or "T") + suf
+        subs.append(ty)
+        return ty, j
+    if c == "S":                                     # substitution
+        return _read_substitution(s, i, subs)
     if c.isdigit():                                  # length-prefixed name (a class type)
         name, j = _read_len_name(s, i)
         if j < len(s) and s[j] == "I":               # class<template-args>
-            j = _skip_template(s, j)
-        return name or "T", j
+            subs.append(name)                         # bare name is a sub
+            targs, j = _read_template_args(s, j, subs)
+            ty = f"{name}<{', '.join(targs)}>"
+            subs.append(ty)                           # template instance is also a sub
+        else:
+            ty = name or "T"
+            subs.append(ty)
+        return ty, j
     if c == "N":                                     # nested type name N..E
         j = i + 1
-        last = "T"
+        parts = []
         while j < len(s) and s[j] != "E":
             if s[j].isdigit():
-                last, j = _read_len_name(s, j)
+                name, j = _read_len_name(s, j)
                 if j < len(s) and s[j] == "I":
-                    j = _skip_template(s, j)
+                    targs, j = _read_template_args(s, j, subs)
+                    name = f"{name}<{', '.join(targs)}>"
+                parts.append(name)
+            elif s[j] == "S":
+                sub_type, j = _read_substitution(s, j, subs)
+                parts.append(sub_type)
             else:
                 j += 1
-        return last or "T", j + 1
+        ty = "::".join(p for p in parts if p) if parts else "T"
+        subs.append(ty)
+        return ty, j + 1  # skip E
     return "T", i + 1                                # give up on this code, keep going
 
 
+def _read_substitution(s, i, subs):
+    """Read a substitution reference S_, S0_, S1_, St, etc."""
+    if i + 1 < len(s) and s[i + 1] == "t":
+        # St = std::
+        subs.append("std")
+        return "std", i + 2
+    m = re.match(r"S([A-Za-z0-9]*)_", s[i:])
+    if m:
+        seq = m.group(1)
+        idx = 0
+        if seq == "":
+            idx = 0  # S_ = first substitution
+        else:
+            idx = int(seq, 36) + 1
+        advance = len(m.group())
+        if idx < len(subs):
+            return subs[idx], i + advance
+        return "T", i + advance
+    return "T", i + 2  # fallback skip
+
+
+def _parse_thunk_prefix(s):
+    """Parse thunk prefixes. Returns (thunk_offset, virtual_offset, rest) or None."""
+    m = re.match(r"_ZThn(\d+)_(.+)", s)
+    if m:
+        return -int(m.group(1)), None, "_Z" + m.group(2)
+
+    m = re.match(r"_ZTv(\d+)_n(\d+)_(.+)", s)
+    if m:
+        return -int(m.group(2)), int(m.group(1)), "_Z" + m.group(3)
+
+    return None
+
+
 def demangle(sym):
+    """Demangle an Itanium ABI mangled name.
+
+    Returns a dict with keys:
+        qualified  - "Class::Method" or "Method"
+        class      - class name or None
+        method     - method name
+        args       - list of argument type strings
+        nargs      - len(args)
+        ctor       - True if constructor
+        dtor       - True if destructor
+        variant    - "C1"/"C2"/"C3"/"D0"/"D1"/"D2" or None
+        thunk      - True if this is a thunk
+        thunk_offset - this-adjustment offset (negative int) or None
+        thunk_virtual_offset - virtual offset or None
+    Returns None for names that are not _Z-mangled.
+    """
     if not sym.startswith("_Z"):
         return None
+
+    thunk = False
+    thunk_offset = None
+    thunk_voffset = None
+    if sym.startswith("_ZT"):
+        parsed = _parse_thunk_prefix(sym)
+        if parsed:
+            thunk_offset, thunk_voffset, inner_sym = parsed
+            thunk = True
+            sym = inner_sym  # demangle the inner symbol
+
     s = sym
     nested = s.startswith("_ZN")
     body = s[3:] if nested else s[2:]
     parts = []
+    variant = None
+    subs = []  # substitution stack (Itanium ABI: only qualified-name prefixes + types)
     i = 0
-    # read the qualified-name components (length-prefixed), up to 'E' if nested
+
     while i < len(body):
         c = body[i]
         if c == "E" and nested:
@@ -95,30 +214,57 @@ def demangle(sym):
         if c.isdigit():
             name, i = _read_len_name(body, i)
             parts.append(name)
+            if nested:
+                subs.append(name)
             if i < len(body) and body[i] == "I":     # template on this component
-                i = _skip_template(body, i)
+                targs, i = _read_template_args(body, i, subs)
+                parts[-1] = f"{name}<{', '.join(targs)}>"
+                if nested:
+                    subs[-1] = parts[-1]
         elif body[i:i + 2] in ("C1", "C2", "C3"):
+            variant = body[i:i + 2]
             parts.append("ctor")
             i += 2
         elif body[i:i + 2] in ("D0", "D1", "D2"):
+            variant = body[i:i + 2]
             parts.append("dtor")
             i += 2
+        elif not nested and body[i:i + 2] in OPERATORS:
+            parts.append(OPERATORS[body[i:i + 2]])
+            i += 2
+        elif nested and body[i:i + 2] in OPERATORS:
+            parts.append(OPERATORS[body[i:i + 2]])
+            i += 2
+        elif nested and body[i:i + 2] == "cv":
+            i += 2
+            conv_type, i = _read_type(body, i, subs)
+            parts.append(f"operator {conv_type}")
+        elif nested and body[i] == "S":
+            sub_type, i = _read_substitution(body, i, subs)
+            parts.append(sub_type)
         elif not nested:
             break
         else:
             i += 1
+
     if not parts:
         return None
+
+    if nested and len(parts) >= 2 and parts[-1] not in ("ctor", "dtor"):
+        if subs and subs[-1] == parts[-1]:
+            subs.pop()
+
     method = parts[-1]
     klass = parts[-2] if len(parts) >= 2 else None
     ctor = method == "ctor"
     dtor = method == "dtor"
     if (ctor or dtor) and klass:
-        method = ("~" if dtor else "") + klass
-    # remaining is the argument type list
+        base_klass = klass.split("<")[0] if "<" in klass else klass
+        method = ("~" if dtor else "") + base_klass
+
     args = []
     while i < len(body):
-        t, ni = _read_type(body, i)
+        t, ni = _read_type(body, i, subs)
         if ni <= i:
             break
         if t == "void" and not args:                 # f(void) == no args
@@ -126,11 +272,19 @@ def demangle(sym):
             break
         args.append(t)
         i = ni
+
     qualified = "::".join(p for p in parts if p not in ("ctor", "dtor")) or method
     if (ctor or dtor):
         qualified = (klass + "::" + method) if klass else method
-    return {"qualified": qualified, "class": klass, "method": method,
-            "args": args, "nargs": len(args), "ctor": ctor, "dtor": dtor}
+
+    result = {
+        "qualified": qualified, "class": klass, "method": method,
+        "args": args, "nargs": len(args), "ctor": ctor, "dtor": dtor,
+        "variant": variant,
+        "thunk": thunk, "thunk_offset": thunk_offset,
+        "thunk_virtual_offset": thunk_voffset,
+    }
+    return result
 
 
 def signature(sym):
@@ -138,7 +292,19 @@ def signature(sym):
     d = demangle(sym)
     if not d:
         return None
-    return f"{d['qualified']}({', '.join(d['args'])})"
+    prefix = ""
+    if d["thunk"]:
+        off = d["thunk_offset"]
+        if d["thunk_virtual_offset"] is not None:
+            prefix = f"[virtual thunk({off})] "
+        else:
+            prefix = f"[thunk({off})] "
+    variant_tag = ""
+    if d["variant"]:
+        tags = {"C1": "complete", "C2": "base", "C3": "allocating",
+                "D0": "deleting", "D1": "complete", "D2": "base"}
+        variant_tag = f" [{tags.get(d['variant'], d['variant'])}]"
+    return f"{prefix}{d['qualified']}({', '.join(d['args'])}){variant_tag}"
 
 
 if __name__ == "__main__":

--- a/tools/match.py
+++ b/tools/match.py
@@ -149,7 +149,19 @@ def main():
                     help="skip the reloc-destination check (loose byte-only compare)")
     ap.add_argument("--module", default="arm9",
                     help="module name for --strict-relocs config lookup (arm9, ov006, ...)")
+    ap.add_argument("--cpp-check", action="store_true",
+                    help="lint C++ file header and symbol naming conventions")
     args = ap.parse_args()
+
+    cfile = pathlib.Path(args.c)
+    if args.cpp_check and cfile.is_file():
+        text = cfile.read_text(encoding="utf-8", errors="ignore")
+        if cfile.suffix == ".cpp" and not text.startswith("//cpp"):
+            print(f"  [cpp-check] Warning: {cfile.name} is a .cpp file but lacks '//cpp' header on line 1")
+        if text.startswith("//cpp") and cfile.suffix == ".c":
+            print(f"  [cpp-check] Warning: {cfile.name} has '//cpp' header but extension is .c (should be .cpp)")
+        if cfile.stem.startswith("_Z") and args.func and args.func != cfile.stem:
+            print(f"  [cpp-check] Warning: function '{args.func}' does not match file symbol name '{cfile.stem}'")
 
     strict = None
     if args.strict_relocs:


### PR DESCRIPTION
This PR adds specialized C++ decompilation tooling and documentation:

- **\	ools/cpp_index.py\**: Class-level decompilation index tool for tracking matched, unmatched, and near-miss methods per class.
- **\	ools/cpp_rename.py\**: Safe symbol-based file renamer using \git mv\ with automated \match.py\ re-verification.
- **\	ools/demangle.py\**: Upgraded Itanium C++ demangler supporting thunks (\_ZThn*\, \_ZTv*\), operator overloads, template types (\Fix12<int>\), and substitution stacks.
- **\	ools/match.py\**: Added \--cpp-check\ flag for validating \//cpp\ headers and symbol naming conventions.
- **\
otes/cpp-naming-guide.md\**: Comprehensive reference covering Itanium ABI mangling, constructor/destructor variants (C1/C2/D0/D1), thunks, and vtable layouts.