### PR TITLE
Close the shared-header hole in the PR validation gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,29 @@ It recompiles each draft, keeps the closest, and records the divergence. The nea
 is now saved; do **not** also leave it in `src/`. A batch that is "12 matched + 3
 near-misses" is **12** `src/` files plus one DB ingest — never 15 `src/` files.
 
+## Shared headers (`include/`)
+
+`src/` files may `#include` from `include/` (`types.h`, `launder.h`, `Timer.hpp`, …) instead
+of re-declaring private typedefs. `include/` is always on the compiler search path — you do
+not pass a flag for it.
+
+**A header change is not a local change.** Editing a field width, a field order, or a typedef
+moves the codegen of every file that includes it, including files your diff never mentions.
+So:
+
+- Before pushing a header edit, list what it touches and verify all of it:
+  ```
+  python tools/affected_src.py include/types.h        # who consumes it
+  python tools/prepush_linkcheck.py --range origin/main..HEAD   # verifies consumers too
+  ```
+- `validate` expands changed headers to their consumers and compiles every one. A header PR
+  that breaks a consumer goes **red**, and a header edit touching more than ~200 sources is
+  refused for human review rather than auto-validated.
+- Adding a `#include` to a matched file means **deleting** the local typedefs it replaces —
+  C99 rejects a duplicate typedef, and C++ rejects a duplicate `struct` definition.
+- Don't add a type to a shared header speculatively. A name in `include/` is a claim that
+  every consumer agrees on it; a wrong shared type is far more expensive than a local one.
+
 ## Match logging (WHO / HOW / tries)
 
 | Extra | Store | Rule |

--- a/MERGE.md
+++ b/MERGE.md
@@ -27,6 +27,13 @@ function, follow this.
   `Stage::PS_Update`) **fails `validate` by design** — a non-matching file cannot byte-reproduce,
   and `main`'s current copy fails the same way. Review it and merge with an admin override
   (`gh pr merge <n> --admin --squash`). These are progress, not byte-matches.
+- **Header PRs** (anything touching `include/`) are byte-checked like match PRs, but on the
+  *consumers*: `validate` expands each changed header through the reverse include graph
+  (`tools/affected_src.py`) and compiles every source that includes it. Green means the header
+  edit is codegen-neutral for everything that uses it. Two verdicts to read carefully:
+  *"changed header(s) have no source consumer yet"* is a real pass (a header landing ahead of
+  its users); *"the validation clone has no tools/affected_src.py"* is a **build-box problem,
+  not a PR problem** — pull on the box and re-run, never override it.
 - **Near-miss DB / notes / tooling PRs** have no `src` match to byte-check; review for sanity
   and merge.
 - **Drafts:** never merge someone else's draft. That is the author saying "not ready."

--- a/tools/linkcheck.py
+++ b/tools/linkcheck.py
@@ -204,10 +204,18 @@ def link_function(code, addr, relocs):
     return bytes(buf), set(blind)
 
 
-def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=()):
-    """Verdict + detail for one banked match."""
+def linkcheck(name, addr, size, mod, name_index, candidate=None, include_dirs=(),
+              obj=None, sym=None):
+    """Verdict + detail for one banked match.
+
+    Normally compiles the source that defines `name` (reloc_audit.winning_object) and
+    checks the reproduced bytes. A caller that already holds the compiled object -- e.g.
+    pr_linkcheck checking a compiler-emitted passenger (a this-adjusting thunk or a weak
+    dtor/ctor copy) that has no source file of its own -- passes obj=<object bytes> and
+    sym=<symbol to extract> so the symbol is link-checked straight from that object."""
     import reverify_corpus as RV
-    obj, sym, err = RA.winning_object(name, addr, size, mod, candidate, include_dirs)
+    if obj is None:
+        obj, sym, err = RA.winning_object(name, addr, size, mod, candidate, include_dirs)
     if obj is None:
         # A missing or wrong-length source is NOT a false match; give it a verdict
         # distinct from NO-REPRO so it does not read as "the source stopped matching".

--- a/tools/match.py
+++ b/tools/match.py
@@ -59,6 +59,13 @@ def compile_c(cfile: pathlib.Path, version: str, flags: str,
     if not exe.is_file():
         print(f"  ! no compiler at {version}")
         return None
+    # Cross-run the Windows compiler under an emulator when asked: the PR-validator
+    # sandbox runs this in a Linux container and sets MWCCARM_LAUNCHER=wine so the PE is
+    # invoked via Wine. Unset on native Windows -> the exe is run directly, so this is a
+    # no-op for every existing caller. (Wine was verified byte-transparent: the native and
+    # container corpus link-checks are identical.) This lives here so the build box can run
+    # stock repo tooling instead of a hand-patched fork of match.py.
+    launcher = os.environ.get("MWCCARM_LAUNCHER", "").split()
     with tempfile.TemporaryDirectory() as td:
         out_o = pathlib.Path(td) / "out.o"
         env = dict(os.environ, LM_LICENSE_FILE=str(LICENSE))
@@ -69,7 +76,7 @@ def compile_c(cfile: pathlib.Path, version: str, flags: str,
         canonical = INCLUDE.resolve()
         if canonical not in search:
             search.append(canonical)
-        cmd = [str(exe), *flags.split()]
+        cmd = [*launcher, str(exe), *flags.split()]
         for inc in search:
             cmd.extend(["-i", str(inc)])
         cmd.extend(["-c", str(cfile), "-o", str(out_o)])

--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -1,0 +1,314 @@
+"""PR-scoped link verification: resolve the symbols a PR's changed src files
+define, then run linkcheck's explicit (ledger-bypassing) mode on each.
+
+WHY THIS EXISTS
+---------------
+linkcheck.py's corpus and --name modes only inspect functions with a
+progress/matched.jsonl row, so compiler-emitted passengers with no ledger row --
+this-adjusting thunks (_ZThn..._) and the weak dtor/ctor copies emitted alongside
+a class definition -- are never checked. That gap let PR #86's
+_ZThn80_N9AnimationD1Ev pass local verify and fail review with WRONG-DEST (its
+tail branch relocated to Animation::~Animation when the ROM slot needs
+ModelAnim2::~ModelAnim2). This tool closes the gap by scope: it takes the exact
+files a PR touched, maps each filename to the symbol it defines (in this repo the
+src filename IS the mangled symbol), resolves that symbol's (addr, size, module)
+from the checked-in config/**/symbols.txt, and runs linkcheck on every slot.
+linkcheck's explicit --addr/--size/--module mode needs no ledger row and returns
+WRONG for a wrong-dest thunk (verified: is_benign forgives a branch diff only when
+the ROM's veneer/twin resolves to the exact address the source names).
+
+HEADER FAN-OUT
+--------------
+Since shared headers landed (#859, #860) a PR can change the codegen of a file it never
+names: edit a field width in `include/types.h` and every consumer's bytes move, while the
+diff lists only the header. Checking the literal diff would let that PR go green with
+matched functions broken behind it -- so a changed header is expanded through the reverse
+include graph (`affected_src.py`) and every consumer is checked too. Any caller that hands
+this tool a file list must therefore pass changed headers as well as changed sources.
+
+Usage:
+  python tools/pr_linkcheck.py                      # local branch vs origin/main
+  python tools/pr_linkcheck.py --base main          # vs a different base ref
+  python tools/pr_linkcheck.py --pr 86              # a GitHub PR (needs gh)
+  python tools/pr_linkcheck.py --files src/a.c src/b.cpp   # explicit file list
+  python tools/pr_linkcheck.py --files include/types.h     # expands to its consumers
+  python tools/pr_linkcheck.py --json out.json --fail       # CI mode
+"""
+import argparse
+import glob
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import affected_src as A  # noqa: E402
+import linkcheck as LC  # noqa: E402
+
+SRC_SUFFIXES = (".c", ".cpp")
+HDR_SUFFIXES = (".h", ".hpp")
+
+# name -> kind:function(...size=0xNN) ... addr:0xNNNN  (RE tolerant of extra attrs)
+_SYM_RE = re.compile(r"^(\S+)\s+kind:function\S*?size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
+
+
+def module_of(symbols_path: str) -> str:
+    """dsd config path -> the module string linkcheck/reverify expect."""
+    s = symbols_path.replace("\\", "/")
+    m = re.search(r"/overlays/(ov\d+)/", s)
+    if m:
+        return m.group(1)
+    if "/itcm/" in s:
+        return "itcm"
+    if "/dtcm/" in s:
+        return "dtcm"
+    return "arm9"  # config/arm9/symbols.txt == the main module (ledger calls it arm9)
+
+
+def build_symbol_index():
+    """symbol name -> [(addr, size, module), ...] from every checked-in symbols.txt.
+
+    Names are not unique: overlays reuse them and identical thunks repeat within a
+    module, so every slot is kept and checked."""
+    idx = {}
+    for sf in glob.glob(str(REPO / "config" / "**" / "symbols.txt"), recursive=True):
+        mod = module_of(sf)
+        for line in open(sf, encoding="utf-8"):
+            m = _SYM_RE.match(line.strip())
+            if m:
+                idx.setdefault(m.group(1), []).append(
+                    (int(m.group(3), 16), int(m.group(2), 16), mod))
+    return idx
+
+
+def changed_src_files(args):
+    """Every compiled file the PR/branch puts at risk.
+
+    That is its added/modified `src/*.c|*.cpp` PLUS every source that transitively
+    includes one of its added/modified `include/**/*.h|*.hpp` -- see HEADER FAN-OUT
+    above. A header with no consumer yet expands to nothing, which is correct: there
+    is no compiled artifact to check."""
+    if args.files:
+        paths = args.files
+    elif args.pr:
+        out = subprocess.run(
+            ["gh", "pr", "view", str(args.pr), "--json", "files",
+             "-q", ".files[].path"],
+            cwd=REPO, capture_output=True, text=True, check=True).stdout
+        paths = out.splitlines()
+    else:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", f"{args.base}...HEAD"],
+            cwd=REPO, capture_output=True, text=True, check=True).stdout
+        paths = out.splitlines()
+    keep, headers = [], []
+    for p in paths:
+        p = p.strip().replace("\\", "/")
+        if p.startswith("src/") and p.endswith(SRC_SUFFIXES):
+            keep.append(p)
+        elif p.startswith("include/") and p.endswith(HDR_SUFFIXES):
+            headers.append(p)
+    if not keep and not headers:
+        return []
+    expanded = A.affected_sources(keep + headers)
+    if headers:
+        extra = len(expanded) - len(set(keep) & set(expanded))
+        print(f"{len(headers)} changed header(s) fan out to {extra} additional "
+              f"source file(s); checking {len(expanded)} in total\n")
+    return expanded
+
+
+def _resolve(name, idx, ledger):
+    """(addr, size, module) slots for a symbol: the config symbol index first (a
+    superset of the ledger -- it carries thunks and weak dtor/ctor copies), then the
+    ledger for module disambiguation when a name is banked but absent from config."""
+    slots = idx.get(name)
+    if not slots and name in ledger:
+        e = ledger[name]
+        slots = [(e["addr"], e["size"], e["module"])]
+    return slots
+
+
+def check_file(path, idx, ledger):
+    """Link-check every symbol the file compiles to -- the named function AND its
+    compiler-emitted passengers (this-adjusting thunks, weak dtor/ctor copies, local
+    helpers) -- not just the filename stem, and not just ledger rows.
+
+    The file is compiled once; every emitted function symbol that resolves to a ROM
+    slot (via config/ledger) is checked against that slot. This is the class the
+    ledger-scoped checks miss -- e.g. PR #86's `_ZThn80_N9AnimationD1Ev` thunk, whose
+    tail branch relocated to the wrong dtor. Emitted symbols with no ROM slot (inline
+    or local emissions) are simply not ROM functions and are ignored."""
+    sym = pathlib.Path(path).stem
+    slots = _resolve(sym, idx, ledger)
+    if not slots:
+        return {"file": path, "symbol": sym, "results": [], "note": "unresolved"}
+
+    # Compile once (winning version/flags for the named symbol) so the named function
+    # and its passengers are read from the very same object the ROM was matched with.
+    import reloc_audit as RA
+    obj = wsym = None
+    for addr, size, mod in slots:
+        obj, wsym, _ = RA.winning_object(sym, addr, size, mod)
+        if obj is not None:
+            break
+
+    results = []
+    for addr, size, mod in slots:
+        r = LC.linkcheck(sym, addr, size, mod, _NAME_INDEX,
+                         obj=obj, sym=(wsym if obj is not None else None))
+        results.append({"sym": sym, "addr": f"0x{addr:08x}", "module": mod,
+                        "verdict": r["verdict"], "diffs": r.get("diffs", []),
+                        "passenger": False})
+
+    # Full-file: every OTHER function symbol this object emits that also owns a ROM
+    # slot. Checked straight out of the object (a thunk has no source file of its own).
+    if obj is not None:
+        import probe_versions as PV
+        try:
+            emitted = set(PV.funcs_in(obj).keys())
+        except Exception:
+            emitted = set()
+        for psym in sorted(emitted - {sym, wsym}):
+            pslots = _resolve(psym, idx, ledger)
+            if not pslots:
+                continue  # emitted symbol with no ROM slot -- normal, nothing to check
+            for addr, size, mod in pslots:
+                r = LC.linkcheck(psym, addr, size, mod, _NAME_INDEX, obj=obj, sym=psym)
+                results.append({"sym": psym, "addr": f"0x{addr:08x}", "module": mod,
+                                "verdict": r["verdict"], "diffs": r.get("diffs", []),
+                                "passenger": True})
+    return {"file": path, "symbol": sym, "results": results, "note": ""}
+
+
+def worst(results):
+    order = ["WRONG", "NO-REPRO", "NO-SYM", "BLIND", "BENIGN", "VERIFIED"]
+    verdicts = [x["verdict"].split("-")[0] if x["verdict"].startswith("BLIND")
+                else x["verdict"] for x in results]
+    for v in order:
+        if v in verdicts:
+            return v
+    return "NONE"
+
+
+_NAME_INDEX = None
+
+
+def main():
+    global _NAME_INDEX
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", default="origin/main", help="base ref for git diff")
+    ap.add_argument("--pr", type=int, default=None, help="GitHub PR number (uses gh)")
+    ap.add_argument("--files", nargs="*", help="explicit file list instead of a diff")
+    ap.add_argument("--json", default=None)
+    ap.add_argument("--md", default=None, help="write a markdown report (for PR comments)")
+    ap.add_argument("--fail", action="store_true",
+                    help="exit 1 if any file is WRONG-DEST or a non-reproducing near-miss")
+    args = ap.parse_args()
+
+    import reloc_audit as RA
+    _NAME_INDEX = RA.build_name_index()
+    idx = build_symbol_index()
+    ledger = {}
+    mp = REPO / "progress" / "matched.jsonl"
+    if mp.exists():
+        for l in mp.read_text().splitlines():
+            if l.strip():
+                e = json.loads(l)
+                a = e["addr"]
+                ledger[e["name"]] = {
+                    "addr": int(a, 16) if isinstance(a, str) else a,
+                    "size": e["size"], "module": e["module"]}
+
+    files = changed_src_files(args)
+    if not files:
+        print("nothing compiled to check: no changed src/*.c|*.cpp, and no changed "
+              "header with a source consumer")
+        return
+    print(f"link-checking {len(files)} changed src file(s) ...\n")
+
+    # A PR "passes" only when every changed file reproduces the ROM with correct
+    # relocation targets (VERIFIED/BENIGN, or BLIND where a slot is unverifiable).
+    # WRONG-DEST *and* a non-reproducing NO-REPRO near-miss are both failures — a
+    # near-miss is not a match and must not land.
+    FAIL = {"WRONG", "NO-REPRO"}
+    reports, bad = [], []
+    for path in files:
+        rep = check_file(path, idx, ledger)
+        reports.append(rep)
+        if rep["note"] == "unresolved":
+            rep["worst"] = "UNRESOLVED"
+            print(f"  ?      {path}  ({rep['symbol']}: not in config or ledger)")
+            continue
+        w = worst(rep["results"])
+        rep["worst"] = w
+        if w in FAIL:
+            bad.append((path, w))
+        mark = {"WRONG": "WRONG  ", "NO-REPRO": "NOREPRO", "BENIGN": "ok(ben)",
+                "VERIFIED": "ok     ", "BLIND": "ok(bln)"}.get(w, w)
+        npass = sum(1 for r in rep["results"] if r.get("passenger"))
+        extra = f", +{npass} passenger" if npass else ""
+        print(f"  {mark} {path}  ({len(rep['results'])} slot(s){extra})")
+        for r in rep["results"]:
+            if r["verdict"] == "WRONG":
+                for d in r["diffs"]:
+                    print(f"           {r['addr']} {r['module']}  {d.get('sym')} -> {d.get('target')}")
+
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(reports, indent=1))
+    if args.md:
+        pathlib.Path(args.md).write_text(render_md(reports, bad), encoding="utf-8")
+    if bad:
+        print("\nvalidation FAILED: " + "; ".join(f"{p} [{v}]" for p, v in bad))
+        if args.fail:
+            sys.exit(1)
+
+
+# Verdict -> a human label for the PR comment. VERIFIED/BENIGN/BLIND are passes;
+# NO-REPRO (near-miss) and WRONG-DEST are the two failures.
+_LABEL = {
+    "VERIFIED":   "✅ verified",
+    "BENIGN":     "✅ benign (equivalent veneer/twin)",
+    "BLIND":      "🔶 blind (a reloc slot could not be resolved)",
+    "NO-REPRO":   "❌ near-miss (does NOT reproduce the ROM)",
+    "WRONG":      "❌ wrong-dest (reloc links to the wrong symbol)",
+    "NO-SYM":     "🔶 no-sym",
+    "UNRESOLVED": "🔶 unresolved (symbol not in config/ledger)",
+}
+
+
+def render_md(reports, bad):
+    n = len(reports)
+    out = []
+    if bad:
+        kinds = ", ".join(sorted({v for _, v in bad}))
+        out.append(f"**{len(bad)} of {n} changed file(s) do not match the ROM** ({kinds}).")
+    else:
+        out.append(f"**All {n} changed file(s) compile to the ROM byte-for-byte with correct relocation targets.**")
+    out += ["", "| File | Symbol | Result | Slots checked |", "|---|---|---|---|"]
+    for rep in reports:
+        w = rep.get("worst", "?")
+        npass = sum(1 for r in rep["results"] if r.get("passenger"))
+        checked = f"{len(rep['results'])}" + (f" (+{npass} passenger)" if npass else "")
+        out.append(f"| `{rep['file']}` | `{rep['symbol']}` | {_LABEL.get(w, w)} | {checked} |")
+    # list the compiler-emitted passengers that were also verified (thunks / weak copies)
+    for rep in reports:
+        ps = sorted({r["sym"] for r in rep["results"] if r.get("passenger")})
+        if ps:
+            out += ["", f"- `{rep['file']}` also verified {len(ps)} emitted passenger(s): "
+                        + ", ".join(f"`{p}`" for p in ps)]
+    # spell out every wrong-dest reloc so a reviewer can see the exact bad link
+    for rep in reports:
+        for r in rep["results"]:
+            if r["verdict"] == "WRONG":
+                for d in r["diffs"]:
+                    out += ["", f"- `{rep['file']}` `{r.get('sym')}` @ `{r['addr']}` ({r['module']}): "
+                                f"wrong reloc `{d.get('sym')}` → `{d.get('target')}`"]
+    return "\n".join(out) + "\n"
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/prepush_linkcheck.py
+++ b/tools/prepush_linkcheck.py
@@ -61,7 +61,14 @@ def changed_src_files(rev_range):
     if out.returncode != 0:
         return []
     changed = [f.strip() for f in out.stdout.splitlines() if f.strip()]
-    return A.affected_sources(changed)
+    expanded = A.affected_sources(changed)
+    # Say so when headers pulled in files the diff never named. A silent expansion from 2
+    # files to 300 reads as a hung gate; a silent expansion to 0 reads as "checked, clean".
+    headers = [f for f in changed if f.endswith((".h", ".hpp"))]
+    if headers:
+        print(f"{len(headers)} changed header(s) fan out to {len(expanded)} source file(s) "
+              f"to verify", flush=True)
+    return expanded
 
 
 def is_draft(path):

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -162,7 +162,12 @@ def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
     candidate_path = pathlib.Path(candidate) if candidate is not None else None
     if candidate_path is not None:
         try:
-            sources = [(candidate_path.read_text(encoding="utf-8"), candidate_path)]
+            # errors="replace": the text is only used for the //cpp sniff -- mwccarm reads
+            # the file itself -- and a stray non-UTF-8 byte must not raise UnicodeDecodeError
+            # and take down a verdict. (Windows cp1252 round-trips have corrupted repo JSONL
+            # this way before; do not narrow this to a bare OSError catch.)
+            sources = [(candidate_path.read_text(encoding="utf-8", errors="replace"),
+                        candidate_path)]
         except OSError:
             sources = []
     else:


### PR DESCRIPTION
## The problem

Shared headers (#859, #860) mean a PR can change the codegen of files its diff never names.
The fan-out guard from #859 landed only in `tools/prepush_linkcheck.py` — a **local, optional**
pre-push tool — while the actual merge gate compiles the literal diff. A PR touching only
`include/` presents zero changed `src/` files and goes green.

Verified rather than assumed. Reordering `Timer`'s fields (size unchanged, so the `sizeof`
assert still passes) with **nothing in `src/` modified**:

```
$ python tools/pr_linkcheck.py --files include/Timer.hpp --fail
1 changed header(s) fan out to 4 additional source file(s); checking 4 in total
  NOREPRO src/_ZN5Timer10ResetTimerEv.cpp
  NOREPRO src/_ZN5Timer10StartTimerEv.cpp
  NOREPRO src/_ZN5Timer7GetTimeEv.cpp
  NOREPRO src/_ZN5Timer9StopTimerEv.cpp
validation FAILED  (exit 1)
```

Today that PR would be green.

## What changed

- **`tools/pr_linkcheck.py` (new)** — the validator's PR-scoped checker, vendored into the repo
  where it can be reviewed and tested instead of living only on the build box. It expands
  changed headers through the reverse include graph and checks every consumer. `run-worker.ps1`
  already prefers a repo copy over its bundled one, so this is how it was meant to work.
- **`tools/linkcheck.py`** — restore the `obj=`/`sym=` fast path `pr_linkcheck` needs to check
  compiler-emitted passengers (thunks, weak dtor copies) from an object it already holds.
  #859 replaced those params, which left the build box running a fork.
- **`tools/match.py`** — honor `MWCCARM_LAUNCHER` so the validator's Linux sandbox can run stock
  repo tooling under Wine. No-op when unset. Removes the last reason the box needs a
  hand-patched `match.py`.
- **`tools/prepush_linkcheck.py`** — report header fan-out. A silent 2 → 300 expansion reads as
  a hang; a silent expansion to 0 reads as "checked, clean".
- **`tools/reloc_audit.py`** — read candidate sources with `errors="replace"`. The text is only
  used for the `//cpp` sniff, and a stray non-UTF-8 byte shouldn't raise `UnicodeDecodeError`
  out of a verdict.
- **`AGENTS.md` / `MERGE.md`** — document `include/` at all. Neither file mentioned headers, so
  the rule that a header edit requires re-verifying consumers existed nowhere a contributor
  would look.

## Build-box side (not in this PR)

`scratch/sm64ds-validator/run-worker.ps1` needs the matching change: overlay the PR's
`include/` alongside its `src/`, expand via `tools/affected_src.py`, apply the `MaxFiles` cap to
the expanded set, and reset `include/` in cleanup. That change is written and parse-checked
locally but has to be deployed to the box by hand — it is not a repo file.

Until the box is updated it keeps validating PR sources against **its own** headers. Worth
knowing: that is why #859 and #860 passed — the box's `match.py` was hand-patched with
`-i include`, not bootstrapped from the PR.

## Validation

- `python -m unittest discover -s tools -p "test_*.py"` — 35 passed, 2 skipped
- `pr_linkcheck --files include/Timer.hpp` → 4 consumers, all `VERIFIED`
- same with reordered fields → 4× `NO-REPRO`, exit 1
- `pr_linkcheck --files src/func_ov002_020d869c.cpp` → `ok`
- `match.py` still matches `func_ov006_020fe750` on `1.2/sp2p3` with the launcher unset
- `prepush_linkcheck --range origin/main..HEAD` — no `src/` files in this push