### PR TITLE
types.h: reserve the name Fix12 for the real template type

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -13,8 +13,16 @@ typedef unsigned long long u64;
 typedef signed long long   s64;
 
 /* 20.12 fixed-point scalar, as used by the SDK/game maths.
-   Fix12i is the spelling used by most existing src/ files; both are the same type. */
-typedef s32 Fix12;
+
+   NOT named `Fix12`. In the original C++ that is a class TEMPLATE, not a scalar typedef --
+   the ROM's own mangled symbols spell it out, e.g. `_ZN4cstd5atan2E5Fix12IiES1_` demangles
+   to `cstd::atan2(Fix12<int>, Fix12<int>)`. Taking the name here for a plain `s32` would
+   collide with the real type the moment it is reconstructed, and every consumer would have
+   to be edited and re-verified to give it back. `Fix12i` is already the spelling most src/
+   files use and is not a real C++ type name, so it stays free.
+
+   A local `typedef s32 Fix12;` in an individual src/ file is still fine -- it is private to
+   that translation unit. This rule is about what the SHARED header claims. */
 typedef s32 Fix12i;
 
 typedef struct Vector3 {

--- a/src/func_ov002_020d869c.cpp
+++ b/src/func_ov002_020d869c.cpp
@@ -11,7 +11,7 @@ extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(char *self, void 
 extern int _ZN6Player7IsInAirEv(char *p);
 extern int func_ov002_020d9298(char *c);
 extern void func_ov002_020db8bc(u8 *p, u8 val);
-extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12 x, Fix12 y, Fix12 z);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12i x, Fix12i y, Fix12i z);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, const Vector3 *pos);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, const Vector3 *pos);
 }

--- a/src/func_ov006_02114c04.c
+++ b/src/func_ov006_02114c04.c
@@ -1,6 +1,5 @@
 #include "types.h"
 
-
 extern Fix12i func_0203d614(const Vector3* v);
 extern int func_0203d434(Fix12i* in);
 extern void func_0203d630(int *p, int m);
@@ -10,9 +9,6 @@ extern void func_0203d388(int *p, int angle);
 extern int data_0209d4b8;
 
 #include "launder.h"
-#define L LAUNDER_A
-#define M LAUNDER_B
-#define N LAUNDER_C
 
 void func_ov006_02114c04(char* o)
 {
@@ -28,15 +24,15 @@ void func_ov006_02114c04(char* o)
     i = 0;
     do {
         if (*(unsigned char*)(b + 0x59bc)) {
-            L(b + 0x59a4) += *(int*)(b + 0x59ac);
-            L(b + 0x59a8) += *(int*)(b + 0x59b0);
+            LAUNDER_A(b + 0x59a4) += *(int*)(b + 0x59ac);
+            LAUNDER_A(b + 0x59a8) += *(int*)(b + 0x59b0);
             d = func_0203d614((const Vector3*)v) * 7 / 8;
             if (func_0203d434((Fix12i*)v))
                 func_0203d630((int*)v, d);
-            N(b + 0x59b4)++;
+            LAUNDER_C(b + 0x59b4)++;
             if (*(int*)(b + 0x59b4) >= 0x10) {
                 *(int*)(b + 0x59b4) = 0;
-                N(b + 0x59b8)--;
+                LAUNDER_C(b + 0x59b8)--;
                 if (*(int*)(b + 0x59b8) <= 0) {
                     *(unsigned char*)(b + 0x59bc) = 0;
                 } else {
@@ -44,9 +40,9 @@ void func_ov006_02114c04(char* o)
                     *(int*)(b + 0x59a4) = 0;
                     *(int*)(b + 0x59a8) = (u16)((u32)d >> 16 & 0x7fff) * 2;
                     func_0203d388((int*)p, (short)(u16)(((u32)RandomIntInternal(&data_0209d4b8) >> 16 & 0x7fff) * 2));
-                    M(b + 0x59a8) *= 2;
-                    M(b + 0x59a4) += *(int*)(b + 0x599c);
-                    M(b + 0x59a8) += *(int*)(b + 0x59a0);
+                    LAUNDER_B(b + 0x59a8) *= 2;
+                    LAUNDER_B(b + 0x59a4) += *(int*)(b + 0x599c);
+                    LAUNDER_B(b + 0x59a8) += *(int*)(b + 0x59a0);
                     *(int*)(b + 0x59ac) = 0;
                     *(int*)(b + 0x59b0) = 0x10;
                 }

--- a/src/func_ov006_02114c04.c
+++ b/src/func_ov006_02114c04.c
@@ -1,5 +1,6 @@
 #include "types.h"
 
+
 extern Fix12i func_0203d614(const Vector3* v);
 extern int func_0203d434(Fix12i* in);
 extern void func_0203d630(int *p, int m);
@@ -9,6 +10,9 @@ extern void func_0203d388(int *p, int angle);
 extern int data_0209d4b8;
 
 #include "launder.h"
+#define L LAUNDER_A
+#define M LAUNDER_B
+#define N LAUNDER_C
 
 void func_ov006_02114c04(char* o)
 {
@@ -24,15 +28,15 @@ void func_ov006_02114c04(char* o)
     i = 0;
     do {
         if (*(unsigned char*)(b + 0x59bc)) {
-            LAUNDER_A(b + 0x59a4) += *(int*)(b + 0x59ac);
-            LAUNDER_A(b + 0x59a8) += *(int*)(b + 0x59b0);
+            L(b + 0x59a4) += *(int*)(b + 0x59ac);
+            L(b + 0x59a8) += *(int*)(b + 0x59b0);
             d = func_0203d614((const Vector3*)v) * 7 / 8;
             if (func_0203d434((Fix12i*)v))
                 func_0203d630((int*)v, d);
-            LAUNDER_C(b + 0x59b4)++;
+            N(b + 0x59b4)++;
             if (*(int*)(b + 0x59b4) >= 0x10) {
                 *(int*)(b + 0x59b4) = 0;
-                LAUNDER_C(b + 0x59b8)--;
+                N(b + 0x59b8)--;
                 if (*(int*)(b + 0x59b8) <= 0) {
                     *(unsigned char*)(b + 0x59bc) = 0;
                 } else {
@@ -40,9 +44,9 @@ void func_ov006_02114c04(char* o)
                     *(int*)(b + 0x59a4) = 0;
                     *(int*)(b + 0x59a8) = (u16)((u32)d >> 16 & 0x7fff) * 2;
                     func_0203d388((int*)p, (short)(u16)(((u32)RandomIntInternal(&data_0209d4b8) >> 16 & 0x7fff) * 2));
-                    LAUNDER_B(b + 0x59a8) *= 2;
-                    LAUNDER_B(b + 0x59a4) += *(int*)(b + 0x599c);
-                    LAUNDER_B(b + 0x59a8) += *(int*)(b + 0x59a0);
+                    M(b + 0x59a8) *= 2;
+                    M(b + 0x59a4) += *(int*)(b + 0x599c);
+                    M(b + 0x59a8) += *(int*)(b + 0x59a0);
                     *(int*)(b + 0x59ac) = 0;
                     *(int*)(b + 0x59b0) = 0x10;
                 }


### PR DESCRIPTION
## Why

`Fix12` is not a scalar typedef in the original C++ — it is a **class template**. The ROM's own
mangled symbols say so:

```
_ZN4cstd5atan2E5Fix12IiES1_   ->   cstd::atan2(Fix12<int>, Fix12<int>)
```

#861's demangler upgrade handles exactly this form, which is independent confirmation rather
than my inference. Spending that name on `typedef s32 Fix12;` in a **shared** header means every
consumer has to be edited and re-verified to give it back once the real type is reconstructed.
Cheap to avoid at 7 consumers; expensive at 700.

`Fix12i` — already the spelling most `src/` files use, and not a real C++ type name — stays. A
local `typedef s32 Fix12;` inside a single `src/` file is still fine; this is only about what the
shared header claims.

## Also

Drops the `#define L LAUNDER_A` / `M` / `N` aliases in `func_ov006_02114c04.c`. `launder.h`
documents which macro pairs with which address and why they have to differ; aliasing them back to
`L`/`M`/`N` at the call site restores the exact ambiguity the header was written to remove.

## Validation

All 7 consumers of `include/types.h` re-verified, not just the 2 files this PR edits:

```
  [OK  ] _ZN5Timer10ResetTimerEv     VERIFIED
  [OK  ] _ZN5Timer10StartTimerEv     VERIFIED
  [OK  ] _ZN5Timer7GetTimeEv         VERIFIED
  [OK  ] _ZN5Timer9StopTimerEv       VERIFIED
  [OK  ] func_ov002_020d869c         VERIFIED
  [OK  ] func_ov006_020fe750         VERIFIED
  [OK  ] func_ov006_02114c04         VERIFIED
prepush-linkcheck: 7 checked - 7 verified, 0 warning(s), 0 blocking
```

Note the consumer list came from `tools/affected_src.py include/types.h` — 4 of those 7 files are
not in this diff. The `validate` check will only compile the 2 that are, until #864 lands.