### PR TITLE
readable: batch 01 - promote 190 spawn/actor files to readable form

### DIFF
--- a/src/AmbientSoundEffects_Spawn.c
+++ b/src/AmbientSoundEffects_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol AmbientSoundEffects_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV14EnemySwitchTag */
 int *AmbientSoundEffects_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(216);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV14EnemySwitchTag; }
     return p;
 }

--- a/src/Amp_Spawn.c
+++ b/src/Amp_Spawn.c
@@ -1,19 +1,23 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Amp_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3Amp */
 int *Amp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1076);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV3Amp;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x138);
         _ZN15TextureSequenceC1Ev((char *)p + 0x188);

--- a/src/ArmedRotatingPlatform_Spawn.c
+++ b/src/ArmedRotatingPlatform_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ArmedRotatingPlatform_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10DonutBlock */
 int *ArmedRotatingPlatform_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV10DonutBlock; }
     return p;
 }

--- a/src/ArrowLift_Spawn.c
+++ b/src/ArrowLift_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ArrowLift_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV29FloatOnWaterPlatformWdwSquare */
 int *ArrowLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV29FloatOnWaterPlatformWdwSquare; }
     return p;
 }

--- a/src/ArrowPathLift_Spawn.c
+++ b/src/ArrowPathLift_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
+// @symbol ArrowPathLift_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV22RotatingUpDownPlatform */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *ArrowPathLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(856);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV22RotatingUpDownPlatform;
         _ZN7PathPtrC1Ev((char *)p + 0x344);
     }
     return p;

--- a/src/ArrowSignLeft_Spawn.c
+++ b/src/ArrowSignLeft_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol ArrowSignLeft_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14ArrowSignRight */
 int *ArrowSignLeft_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(896);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14ArrowSignRight;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/ArrowSignRight_Spawn.c
+++ b/src/ArrowSignRight_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol ArrowSignRight_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14ArrowSignRight */
 int *ArrowSignRight_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(896);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14ArrowSignRight;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/BabyPenguin_Spawn.c
+++ b/src/BabyPenguin_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol BabyPenguin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11BabyPenguin */
 int *BabyPenguin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(880);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11BabyPenguin;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);

--- a/src/BasementWater_Spawn.c
+++ b/src/BasementWater_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol BasementWater_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12SwitchPillar */
 int *BasementWater_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(832);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12SwitchPillar;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/BigBooIcon_Spawn.c
+++ b/src/BigBooIcon_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol BigBooIcon_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10BigBooIcon */
 int *BigBooIcon_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(216);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV10BigBooIcon; }
     return p;
 }

--- a/src/BigBrickBlock_Spawn.c
+++ b/src/BigBrickBlock_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol BigBrickBlock_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13BigBrickBlock */
 int *BigBrickBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13BigBrickBlock; }
     return p;
 }

--- a/src/BigBully_Spawn.c
+++ b/src/BigBully_Spawn.c
@@ -1,17 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol BigBully_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12daBDonketu_c */
 int *BigBully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1024);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12daBDonketu_c;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/BigMovingIceBlock_Spawn.c
+++ b/src/BigMovingIceBlock_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
+// @symbol BigMovingIceBlock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17BigMovingIceBlock */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *BigMovingIceBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17BigMovingIceBlock;
         _ZN7PathPtrC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/BigMrI_Spawn.c
+++ b/src/BigMrI_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol BigMrI_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3MrI */
 int *BigMrI_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(536);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV3MrI;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x14c);

--- a/src/Bird_Spawn.c
+++ b/src/Bird_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Bird_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Bird */
 int *Bird_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(388);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Bird;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
     }

--- a/src/BlackBrickBlock_Spawn.c
+++ b/src/BlackBrickBlock_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol BlackBrickBlock_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13BigBrickBlock */
 int *BlackBrickBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13BigBrickBlock; }
     return p;
 }

--- a/src/BlueCoin_Spawn.c
+++ b/src/BlueCoin_Spawn.c
@@ -1,16 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol BlueCoin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Coin */
 int *BlueCoin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(948);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Coin;
         _ZN11CommonModelC1Ev((char *)p + 0xd8);
         _ZN11CommonModelC1Ev((char *)p + 0x114);
         _ZN11ShadowModelC1Ev((char *)p + 0x150);

--- a/src/BlueFlame_Spawn.c
+++ b/src/BlueFlame_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol BlueFlame_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9BlueFlame */
 int *BlueFlame_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(280);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9BlueFlame;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xe4);
     }
     return p;

--- a/src/BobOmbBuddy_Spawn.c
+++ b/src/BobOmbBuddy_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol BobOmbBuddy_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11BobOmbBuddy */
 int *BobOmbBuddy_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(496);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11BobOmbBuddy;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
         _ZN9ModelAnimC1Ev((char *)p + 0x108);
         _ZN11ShadowModelC1Ev((char *)p + 0x16c);

--- a/src/BobOmb_Spawn.c
+++ b/src/BobOmb_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol BobOmb_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6BobOmb */
 int *BobOmb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1024);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6BobOmb;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/BooCage_Spawn.c
+++ b/src/BooCage_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol BooCage_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7BooCage */
 int *BooCage_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(896);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7BooCage;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/BookShotSpawner_Spawn.c
+++ b/src/BookShotSpawner_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol BookShotSpawner_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV15BookShotSpawner */
 int *BookShotSpawner_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(216);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV15BookShotSpawner; }
     return p;
 }

--- a/src/BookShot_Spawn.c
+++ b/src/BookShot_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol BookShot_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8BookShot */
 int *BookShot_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1108);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8BookShot;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN5ModelC1Ev((char *)p + 0x174);
         _ZN11ShadowModelC1Ev((char *)p + 0x1c4);

--- a/src/Bookend_Spawn.c
+++ b/src/Bookend_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Bookend_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8BookShot */
 int *Bookend_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1108);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8BookShot;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN5ModelC1Ev((char *)p + 0x174);
         _ZN11ShadowModelC1Ev((char *)p + 0x1c4);

--- a/src/Bookshelf_Spawn.c
+++ b/src/Bookshelf_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol Bookshelf_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12MansionSteps */
 int *Bookshelf_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12MansionSteps;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingMeshColliderC1Ev((char *)p + 0x15c);
     }

--- a/src/BowserFireSeaArena_Spawn.c
+++ b/src/BowserFireSeaArena_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol BowserFireSeaArena_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV18BowserFireSeaArena */
 int *BowserFireSeaArena_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1392);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV18BowserFireSeaArena;
         _ZN5ModelC1Ev((char *)p + 0x324);
         _ZN18MovingMeshColliderC1Ev((char *)p + 0x374);
     }

--- a/src/BowserFire_Spawn.c
+++ b/src/BowserFire_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol BowserFire_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10BowserFire */
 int *BowserFire_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(908);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10BowserFire;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x2d0);
         _ZN11ShadowModelC1Ev((char *)p + 0x304);

--- a/src/BowserPuzzlePiece_Spawn.c
+++ b/src/BowserPuzzlePiece_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol BowserPuzzlePiece_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV19BowserPuzzleManager */
 int *BowserPuzzlePiece_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(828);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV19BowserPuzzleManager; }
     return p;
 }

--- a/src/BowserShockwaves_Spawn.c
+++ b/src/BowserShockwaves_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN15MaterialChangerC1Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol BowserShockwaves_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MaterialChanger.h"
+#include "decl_ModelAnim.h"
+#include "decl_TextureSequence.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV16BowserShockwaves */
 int *BowserShockwaves_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(536);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16BowserShockwaves;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN15MaterialChangerC1Ev((char *)p + 0x14c);

--- a/src/BowserTail_Spawn.c
+++ b/src/BowserTail_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol BowserTail_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10BowserTail */
 int *BowserTail_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(280);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10BowserTail;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/Bowser_Spawn.c
+++ b/src/Bowser_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol Bowser_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Bowser */
 int *Bowser_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1108);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Bowser;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x14c);

--- a/src/BrickBlockSwitchActivated_Spawn.c
+++ b/src/BrickBlockSwitchActivated_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol BrickBlockSwitchActivated_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13BigBrickBlock */
 int *BrickBlockSwitchActivated_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13BigBrickBlock; }
     return p;
 }

--- a/src/BrickBlock_Spawn.c
+++ b/src/BrickBlock_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol BrickBlock_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13BigBrickBlock */
 int *BrickBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13BigBrickBlock; }
     return p;
 }

--- a/src/Bubble_Spawn.c
+++ b/src/Bubble_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Bubble_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12daObjAbuku_c */
 int *Bubble_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(276);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12daObjAbuku_c;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/BulletBill_Spawn.c
+++ b/src/BulletBill_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol BulletBill_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10BulletBill */
 int *BulletBill_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(992);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10BulletBill;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN5ModelC1Ev((char *)p + 0x30c);

--- a/src/Bullet_Spawn.c
+++ b/src/Bullet_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol Bullet_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Bullet */
 int *Bullet_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(860);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Bullet;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/Bully_Spawn.c
+++ b/src/Bully_Spawn.c
@@ -1,17 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol Bully_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daDonketu_c */
 int *Bully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1024);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11daDonketu_c;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/Butterfly_Spawn.c
+++ b/src/Butterfly_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol Butterfly_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9Butterfly */
 int *Butterfly_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1012);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9Butterfly;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x188);

--- a/src/CameraTag_Spawn.c
+++ b/src/CameraTag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol CameraTag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13InvisiblePole */
 int *CameraTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(212);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV13InvisiblePole; }
     return p;
 }

--- a/src/CannonHatch_Spawn.c
+++ b/src/CannonHatch_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol CannonHatch_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV11CannonHatch */
 int *CannonHatch_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV11CannonHatch; }
     return p;
 }

--- a/src/Cannon_Spawn.c
+++ b/src/Cannon_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Cannon_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Cannon */
 int *Cannon_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(408);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Cannon;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x124);
     }

--- a/src/CapBlockLuigi_Spawn.c
+++ b/src/CapBlockLuigi_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol CapBlockLuigi_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *CapBlockLuigi_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/CapBlockMario_Spawn.c
+++ b/src/CapBlockMario_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol CapBlockMario_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *CapBlockMario_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/CapBlockWario_Spawn.c
+++ b/src/CapBlockWario_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol CapBlockWario_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *CapBlockWario_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/Cap_Spawn.c
+++ b/src/Cap_Spawn.c
@@ -1,17 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void func_ov001_020ab3c4(void *);
-extern int VT0[];
+// @symbol Cap_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13WaterfallMist */
 int *Cap_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1040);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13WaterfallMist;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/CastleWater_Spawn.c
+++ b/src/CastleWater_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol CastleWater_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjMcWater_c */
 int *CastleWater_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(824);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjMcWater_c;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/CccArena_Spawn.c
+++ b/src/CccArena_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol CccArena_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV8CccArena */
 int *CccArena_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(828);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV8CccArena; }
     return p;
 }

--- a/src/CccBigIce_Spawn.c
+++ b/src/CccBigIce_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol CccBigIce_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV8CccArena */
 int *CccBigIce_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(828);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV8CccArena; }
     return p;
 }

--- a/src/CccSmallIce_Spawn.c
+++ b/src/CccSmallIce_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol CccSmallIce_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV8CccArena */
 int *CccSmallIce_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(828);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV8CccArena; }
     return p;
 }

--- a/src/CgStairs_Spawn.c
+++ b/src/CgStairs_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol CgStairs_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *CgStairs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/ChainChompFence_Spawn.c
+++ b/src/ChainChompFence_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ChainChompFence_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV15ChainChompFence */
 int *ChainChompFence_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV15ChainChompFence; }
     return p;
 }

--- a/src/CheepCheep_Spawn.c
+++ b/src/CheepCheep_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol CheepCheep_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10CheepCheep */
 int *CheepCheep_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(904);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10CheepCheep;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/ChillBully_Spawn.c
+++ b/src/ChillBully_Spawn.c
@@ -1,17 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol ChillBully_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12daIDonketu_c */
 int *ChillBully_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1020);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12daIDonketu_c;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x33c);

--- a/src/Chuckya_Spawn.c
+++ b/src/Chuckya_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Chuckya_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7Chuckya */
 int *Chuckya_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1080);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7Chuckya;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/Clam_Spawn.c
+++ b/src/Clam_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Clam_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Clam */
 int *Clam_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(372);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Clam;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x138);
     }

--- a/src/ClockPaintingHandLong_Spawn.c
+++ b/src/ClockPaintingHandLong_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol ClockPaintingHandLong_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV22ClockPaintingHandShort */
 int *ClockPaintingHandLong_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV22ClockPaintingHandShort;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/ClockPaintingHandShort_Spawn.c
+++ b/src/ClockPaintingHandShort_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol ClockPaintingHandShort_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV22ClockPaintingHandShort */
 int *ClockPaintingHandShort_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV22ClockPaintingHandShort;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/ClockPaintingPendulum_Spawn.c
+++ b/src/ClockPaintingPendulum_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol ClockPaintingPendulum_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjClockHuriko_c */
 int *ClockPaintingPendulum_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV18daObjClockHuriko_c;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/Cloud_Spawn.c
+++ b/src/Cloud_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol Cloud_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Cloud */
 int *Cloud_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(292);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Cloud;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/Coffin_Spawn.c
+++ b/src/Coffin_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol Coffin_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV6Coffin */
 int *Coffin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV6Coffin; }
     return p;
 }

--- a/src/Coin_Spawn.c
+++ b/src/Coin_Spawn.c
@@ -1,16 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Coin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Coin */
 int *Coin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(948);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Coin;
         _ZN11CommonModelC1Ev((char *)p + 0xd8);
         _ZN11CommonModelC1Ev((char *)p + 0x114);
         _ZN11ShadowModelC1Ev((char *)p + 0x150);

--- a/src/CrazedCrate_Spawn.c
+++ b/src/CrazedCrate_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol CrazedCrate_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11CrazedCrate */
 int *CrazedCrate_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(888);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11CrazedCrate;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x124);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x14c);

--- a/src/CutsceneObject_Spawn.c
+++ b/src/CutsceneObject_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol CutsceneObject_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV8MugenBgm */
 int *CutsceneObject_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(260);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV8MugenBgm; }
     return p;
 }

--- a/src/DockPole_Spawn.c
+++ b/src/DockPole_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol DockPole_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV11CastleWater */
 int *DockPole_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV11CastleWater; }
     return p;
 }

--- a/src/DonutBlock_Spawn.c
+++ b/src/DonutBlock_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol DonutBlock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8ShipWing */
 int *DonutBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1260);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8ShipWing;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Door_Spawn.c
+++ b/src/Door_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol Door_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV8daDoor_c */
 int *Door_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(328);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8daDoor_c;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/DorrieCap_Spawn.c
+++ b/src/DorrieCap_Spawn.c
@@ -1,15 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void func_ov001_020ab3c4(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol DorrieCap_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9DorrieCap */
 int *DorrieCap_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(388);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9DorrieCap;
         func_ov001_020ab3c4((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0xf0);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x140);

--- a/src/EnemySpawner_Spawn.c
+++ b/src/EnemySpawner_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol EnemySpawner_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV12EnemySpawner */
 int *EnemySpawner_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(224);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV12EnemySpawner; }
     return p;
 }

--- a/src/EnemySwitchTag_Spawn.c
+++ b/src/EnemySwitchTag_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol EnemySwitchTag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14BlueCoinSwitch */
 int *EnemySwitchTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(272);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14BlueCoinSwitch;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/ExclamationBlockVs_Spawn.c
+++ b/src/ExclamationBlockVs_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol ExclamationBlockVs_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *ExclamationBlockVs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/ExclamationBlock_Spawn.c
+++ b/src/ExclamationBlock_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol ExclamationBlock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *ExclamationBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/ExclamationSwitch_Spawn.c
+++ b/src/ExclamationSwitch_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ExclamationSwitch_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10StarSwitch */
 int *ExclamationSwitch_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV10StarSwitch; }
     return p;
 }

--- a/src/Exit_Spawn.c
+++ b/src/Exit_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol Exit_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV11VirtualDoor */
 int *Exit_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(260);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV11VirtualDoor; }
     return p;
 }

--- a/src/ExtendingPlatform_Spawn.c
+++ b/src/ExtendingPlatform_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN21ExtendingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol ExtendingPlatform_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ExtendingMeshCollider.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8PoleLift */
 int *ExtendingPlatform_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8PoleLift;
         _ZN5ModelC1Ev((char *)p + 0xd8);
         _ZN21ExtendingMeshColliderC1Ev((char *)p + 0x158);
     }

--- a/src/FallBlockBbh_Spawn.c
+++ b/src/FallBlockBbh_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FallBlockBbh_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c */
 int *FallBlockBbh_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20daObjTh_Fall_Block_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FallBlockBfs_Spawn.c
+++ b/src/FallBlockBfs_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FallBlockBfs_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c */
 int *FallBlockBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FallBlockLll_Spawn.c
+++ b/src/FallBlockLll_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FallBlockLll_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjFl_Fall_Block_c */
 int *FallBlockLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20daObjFl_Fall_Block_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FirePiranhaPlantBig_Spawn.c
+++ b/src/FirePiranhaPlantBig_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol FirePiranhaPlantBig_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV19FirePiranhaPlantBig */
 int *FirePiranhaPlantBig_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(556);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19FirePiranhaPlantBig;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x174);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1a8);

--- a/src/FirePiranhaPlantSmall_Spawn.c
+++ b/src/FirePiranhaPlantSmall_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol FirePiranhaPlantSmall_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV19FirePiranhaPlantBig */
 int *FirePiranhaPlantSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(556);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19FirePiranhaPlantBig;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x174);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1a8);

--- a/src/FirePiranhaPlant_Spawn.c
+++ b/src/FirePiranhaPlant_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol FirePiranhaPlant_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV19FirePiranhaPlantBig */
 int *FirePiranhaPlant_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(556);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19FirePiranhaPlantBig;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x174);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1a8);

--- a/src/Fireball_Spawn.c
+++ b/src/Fireball_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Fireball_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8Fireball */
 int *Fireball_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(888);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8Fireball;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN11ShadowModelC1Ev((char *)p + 0x300);

--- a/src/Flag_Spawn.c
+++ b/src/Flag_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol Flag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8DockPole */
 int *Flag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(312);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8DockPole;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/FlameChompFire_Spawn.c
+++ b/src/FlameChompFire_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol FlameChompFire_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14FlameChompFire */
 int *FlameChompFire_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14FlameChompFire;
         _ZN11ShadowModelC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xfc);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x130);

--- a/src/FlameChomp_Spawn.c
+++ b/src/FlameChomp_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol FlameChomp_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10FlameChomp */
 int *FlameChomp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10FlameChomp;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x160);

--- a/src/FloatOnLavaPlatform_Spawn.c
+++ b/src/FloatOnLavaPlatform_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol FloatOnLavaPlatform_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV19RotatingPlatformLll */
 int *FloatOnLavaPlatform_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV19RotatingPlatformLll; }
     return p;
 }

--- a/src/FloatOnWaterPlatformJrb_Spawn.c
+++ b/src/FloatOnWaterPlatformJrb_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatOnWaterPlatformJrb_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjKi_Ita_c */
 int *FloatOnWaterPlatformJrb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13daObjKi_Ita_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwRectangle_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatOnWaterPlatformWdwRectangle_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWcObj06_c */
 int *FloatOnWaterPlatformWdwRectangle_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjWcObj06_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FloatOnWaterPlatformWdwSquare_Spawn.c
+++ b/src/FloatOnWaterPlatformWdwSquare_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatOnWaterPlatformWdwSquare_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWcObj01_c */
 int *FloatOnWaterPlatformWdwSquare_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjWcObj01_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FloatingFloorBfs_Spawn.c
+++ b/src/FloatingFloorBfs_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatingFloorBfs_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c */
 int *FloatingFloorBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19daObjKm2_Ukishima_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FloatingFloorLllBig_Spawn.c
+++ b/src/FloatingFloorLllBig_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatingFloorLllBig_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
 int *FloatingFloorLllBig_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FloatingFloorLllSmall_Spawn.c
+++ b/src/FloatingFloorLllSmall_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol FloatingFloorLllSmall_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c */
 int *FloatingFloorLllSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/FlyGuy_Spawn.c
+++ b/src/FlyGuy_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol FlyGuy_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6FlyGuy */
 int *FlyGuy_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1000);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6FlyGuy;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/FortressTowerWall_Spawn.c
+++ b/src/FortressTowerWall_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol FortressTowerWall_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13BigBrickBlock */
 int *FortressTowerWall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13BigBrickBlock; }
     return p;
 }

--- a/src/FortressTower_Spawn.c
+++ b/src/FortressTower_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol FortressTower_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *FortressTower_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/FortressWallBreakable_Spawn.c
+++ b/src/FortressWallBreakable_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol FortressWallBreakable_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV12FortressWall */
 int *FortressWallBreakable_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV12FortressWall; }
     return p;
 }

--- a/src/FortressWall_Spawn.c
+++ b/src/FortressWall_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol FortressWall_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV12FortressWall */
 int *FortressWall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV12FortressWall; }
     return p;
 }

--- a/src/Fwoosh_Spawn.c
+++ b/src/Fwoosh_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol Fwoosh_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Stump */
 int *Fwoosh_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(888);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Stump;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/GoombaLarge_Spawn.c
+++ b/src/GoombaLarge_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8CapEnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN15MaterialChangerC1Ev(void *);
-extern int VT0[];
+// @symbol GoombaLarge_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_CapEnemy.h"
+#include "decl_MaterialChanger.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Goomba */
 int *GoombaLarge_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1144);
     if (p) {
         _ZN8CapEnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Goomba;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x180);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x1b4);
         _ZN9ModelAnimC1Ev((char *)p + 0x370);

--- a/src/GoombaSmall_Spawn.c
+++ b/src/GoombaSmall_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8CapEnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN15MaterialChangerC1Ev(void *);
-extern int VT0[];
+// @symbol GoombaSmall_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_CapEnemy.h"
+#include "decl_MaterialChanger.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Goomba */
 int *GoombaSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1144);
     if (p) {
         _ZN8CapEnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Goomba;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x180);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x1b4);
         _ZN9ModelAnimC1Ev((char *)p + 0x370);

--- a/src/Goomba_Spawn.c
+++ b/src/Goomba_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8CapEnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN15MaterialChangerC1Ev(void *);
-extern int VT0[];
+// @symbol Goomba_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_CapEnemy.h"
+#include "decl_MaterialChanger.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Goomba */
 int *Goomba_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1144);
     if (p) {
         _ZN8CapEnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Goomba;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x180);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x1b4);
         _ZN9ModelAnimC1Ev((char *)p + 0x370);

--- a/src/GreenShellBlockTag_Spawn.c
+++ b/src/GreenShellBlockTag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol GreenShellBlockTag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10BrickBlock */
 int *GreenShellBlockTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(220);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV10BrickBlock; }
     return p;
 }

--- a/src/Grindel_Spawn.c
+++ b/src/Grindel_Spawn.c
@@ -1,15 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol Grindel_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daDkk_c */
 int *Grindel_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(928);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7daDkk_c;
         _ZN15TextureSequenceC1Ev((char *)p + 0x324);
         _ZN11ShadowModelC1Ev((char *)p + 0x338);
         p[0] = (int)VT1;

--- a/src/HauntedChair_Spawn.c
+++ b/src/HauntedChair_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol HauntedChair_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12HauntedChair */
 int *HauntedChair_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(936);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12HauntedChair;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x124);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x17c);

--- a/src/HealingHeart_Spawn.c
+++ b/src/HealingHeart_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol HealingHeart_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7Seaweed */
 int *HealingHeart_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(372);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7Seaweed;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x138);
     }

--- a/src/HeaveHo_Spawn.c
+++ b/src/HeaveHo_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol HeaveHo_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7HeaveHo */
 int *HeaveHo_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1068);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7HeaveHo;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x144);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x184);

--- a/src/HootTheOwl_Spawn.c
+++ b/src/HootTheOwl_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol HootTheOwl_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10HootTheOwl */
 int *HootTheOwl_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10HootTheOwl;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/HugeWater_Spawn.c
+++ b/src/HugeWater_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol HugeWater_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9HugeCover */
 int *HugeWater_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(820);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9HugeCover;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/IceBlock_Spawn.c
+++ b/src/IceBlock_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol IceBlock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8IceBlock */
 int *IceBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(872);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8IceBlock;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/IceSheet_Spawn.c
+++ b/src/IceSheet_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol IceSheet_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV8IceSheet */
 int *IceSheet_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV8IceSheet; }
     return p;
 }

--- a/src/IceSlideManager_Spawn.c
+++ b/src/IceSlideManager_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol IceSlideManager_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV15IceSlideManager */
 int *IceSlideManager_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(216);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV15IceSlideManager; }
     return p;
 }

--- a/src/InvisiblePole_Spawn.c
+++ b/src/InvisiblePole_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol InvisiblePole_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daBar_c */
 int *InvisiblePole_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(264);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7daBar_c;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/InvisibleSecret_Spawn.c
+++ b/src/InvisibleSecret_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol InvisibleSecret_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV9daSCoin_c */
 int *InvisibleSecret_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(276);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9daSCoin_c;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/JetStream_Spawn.c
+++ b/src/JetStream_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol JetStream_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17BowserPuzzlePiece */
 int *JetStream_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(888);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17BowserPuzzlePiece;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
     }

--- a/src/Key_Spawn.c
+++ b/src/Key_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Key_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3Key */
 int *Key_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1136);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV3Key;
         _ZN9ModelAnimC1Ev((char *)p + 0x114);
         _ZN5ModelC1Ev((char *)p + 0x178);
         _ZN11ShadowModelC1Ev((char *)p + 0x1c8);

--- a/src/KingBobOmb_Spawn.c
+++ b/src/KingBobOmb_Spawn.c
@@ -1,17 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN14BlendModelAnimC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol KingBobOmb_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_BlendModelAnim.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10KingBobOmb */
 int *KingBobOmb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1292);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10KingBobOmb;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x110);
         _ZN14BlendModelAnimC1Ev((char *)p + 0x2cc);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x33c);

--- a/src/Klepto_Spawn.c
+++ b/src/Klepto_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN14BlendModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Klepto_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_BlendModelAnim.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Klepto */
 int *Klepto_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1168);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Klepto;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x144);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x178);

--- a/src/KnockDownPlank_Spawn.c
+++ b/src/KnockDownPlank_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol KnockDownPlank_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13PoleBillboard */
 int *KnockDownPlank_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(924);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13PoleBillboard;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/KoopaFlag_Spawn.c
+++ b/src/KoopaFlag_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol KoopaFlag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9KoopaFlag */
 int *KoopaFlag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(372);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9KoopaFlag;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
         _ZN9ModelAnimC1Ev((char *)p + 0x108);
     }

--- a/src/KoopaShell_Spawn.c
+++ b/src/KoopaShell_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol KoopaShell_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10KoopaShell */
 int *KoopaShell_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(992);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10KoopaShell;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/KoopaSmall_Spawn.c
+++ b/src/KoopaSmall_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol KoopaSmall_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Koopa */
 int *KoopaSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(976);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Koopa;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/KoopaTheQuick_Spawn.c
+++ b/src/KoopaTheQuick_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
+// @symbol KoopaTheQuick_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13KoopaTheQuick */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *KoopaTheQuick_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(992);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13KoopaTheQuick;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/Koopa_Spawn.c
+++ b/src/Koopa_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Koopa_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Koopa */
 int *Koopa_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(976);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Koopa;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/LakituBro_Spawn.c
+++ b/src/LakituBro_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol LakituBro_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9LakituBro */
 int *LakituBro_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(744);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9LakituBro;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN9ModelAnimC1Ev((char *)p + 0x174);
         _ZN15TextureSequenceC1Ev((char *)p + 0x1d8);

--- a/src/Lakitu_Spawn.c
+++ b/src/Lakitu_Spawn.c
@@ -1,18 +1,22 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Lakitu_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Lakitu */
 int *Lakitu_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1056);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Lakitu;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x188);

--- a/src/LastStar_Spawn.c
+++ b/src/LastStar_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol LastStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3Key */
 int *LastStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1136);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV3Key;
         _ZN9ModelAnimC1Ev((char *)p + 0x114);
         _ZN5ModelC1Ev((char *)p + 0x178);
         _ZN11ShadowModelC1Ev((char *)p + 0x1c8);

--- a/src/LavaBubble_Spawn.c
+++ b/src/LavaBubble_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol LavaBubble_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10LavaBubble */
 int *LavaBubble_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(796);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10LavaBubble;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
     }

--- a/src/LavaPlank_Spawn.c
+++ b/src/LavaPlank_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol LavaPlank_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV19FloatingFloorLllBig */
 int *LavaPlank_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV19FloatingFloorLllBig; }
     return p;
 }

--- a/src/LightBeam_Spawn.c
+++ b/src/LightBeam_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol LightBeam_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Trap */
 int *LightBeam_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(364);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Trap;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x124);
     }

--- a/src/MansionSteps_Spawn.c
+++ b/src/MansionSteps_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol MansionSteps_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12MansionSteps */
 int *MansionSteps_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12MansionSteps;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingMeshColliderC1Ev((char *)p + 0x15c);
     }

--- a/src/MantaRay_Spawn.c
+++ b/src/MantaRay_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol MantaRay_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8MantaRay */
 int *MantaRay_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1028);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8MantaRay;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/MegaMushroomBlockTag_Spawn.c
+++ b/src/MegaMushroomBlockTag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol MegaMushroomBlockTag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10BrickBlock */
 int *MegaMushroomBlockTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(220);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV10BrickBlock; }
     return p;
 }

--- a/src/MegaMushroomCreateTag_Spawn.c
+++ b/src/MegaMushroomCreateTag_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MegaMushroomCreateTag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV21MegaMushroomCreateTag */
 int *MegaMushroomCreateTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(272);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV21MegaMushroomCreateTag;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/MegaMushroomTag_Spawn.c
+++ b/src/MegaMushroomTag_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MegaMushroomTag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV21MegaMushroomCreateTag */
 int *MegaMushroomTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(272);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV21MegaMushroomCreateTag;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/MegaMushroom_Spawn.c
+++ b/src/MegaMushroom_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol MegaMushroom_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13OneUpMushroom */
 int *MegaMushroom_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(920);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13OneUpMushroom;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/MerryGoRound_Spawn.c
+++ b/src/MerryGoRound_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol MerryGoRound_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12MansionSteps */
 int *MerryGoRound_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12MansionSteps;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingMeshColliderC1Ev((char *)p + 0x15c);
     }

--- a/src/MetalNetLift_Spawn.c
+++ b/src/MetalNetLift_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
+// @symbol MetalNetLift_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Amilift_c */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *MetalNetLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(872);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjFl_Amilift_c;
         _ZN7PathPtrC1Ev((char *)p + 0x360);
     }
     return p;

--- a/src/MgBobOmbSquad_Spawn.c
+++ b/src/MgBobOmbSquad_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgBobOmbSquad_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15dScMgPachinko_c */
 int *MgBobOmbSquad_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(23608);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15dScMgPachinko_c;
     }
     return p;
 }

--- a/src/MgHideAndBooSeek_Spawn.c
+++ b/src/MgHideAndBooSeek_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgHideAndBooSeek_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13dScMgTeresa_c */
 int *MgHideAndBooSeek_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(19496);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13dScMgTeresa_c;
     }
     return p;
 }

--- a/src/MgLakituLaunch_Spawn.c
+++ b/src/MgLakituLaunch_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgLakituLaunch_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16dScMgPachinko2_c */
 int *MgLakituLaunch_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(22140);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16dScMgPachinko2_c;
     }
     return p;
 }

--- a/src/MgPuzzlePanelPuzzlePanic_Spawn.c
+++ b/src/MgPuzzlePanelPuzzlePanic_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgPuzzlePanelPuzzlePanic_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12dScMgPanel_c */
 int *MgPuzzlePanelPuzzlePanic_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(20460);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12dScMgPanel_c;
     }
     return p;
 }

--- a/src/MgShuffleShell_Spawn.c
+++ b/src/MgShuffleShell_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgShuffleShell_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14dScMgCurling_c */
 int *MgShuffleShell_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(20204);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14dScMgCurling_c;
     }
     return p;
 }

--- a/src/MgWanted_Spawn.c
+++ b/src/MgWanted_Spawn.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol MgWanted_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12dScMgLuigi_c */
 int *MgWanted_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(21596);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12dScMgLuigi_c;
     }
     return p;
 }

--- a/src/Moneybag_Spawn.c
+++ b/src/Moneybag_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Moneybag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8Moneybag */
 int *Moneybag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1012);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8Moneybag;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x188);

--- a/src/MontyMoleRock_Spawn.c
+++ b/src/MontyMoleRock_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MontyMoleRock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13MontyMoleRock */
 int *MontyMoleRock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13MontyMoleRock;
         _ZN5ModelC1Ev((char *)p + 0x110);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x194);

--- a/src/MontyMole_Spawn.c
+++ b/src/MontyMole_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MontyMole_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9MontyMole */
 int *MontyMole_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(396);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9MontyMole;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x138);
     }

--- a/src/MotherPenguin_Spawn.c
+++ b/src/MotherPenguin_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MotherPenguin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7SkiLift */
 int *MotherPenguin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(908);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7SkiLift;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x14c);

--- a/src/MovingBarBig_Spawn.c
+++ b/src/MovingBarBig_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol MovingBarBig_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV14KnockDownPlank */
 int *MovingBarBig_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(824);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV14KnockDownPlank; }
     return p;
 }

--- a/src/MovingBarSmall_Spawn.c
+++ b/src/MovingBarSmall_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol MovingBarSmall_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV14KnockDownPlank */
 int *MovingBarSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(824);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV14KnockDownPlank; }
     return p;
 }

--- a/src/MrBlizzard_Spawn.c
+++ b/src/MrBlizzard_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol MrBlizzard_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10MrBlizzard */
 int *MrBlizzard_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1132);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10MrBlizzard;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/MrI_Projectile_Spawn.c
+++ b/src/MrI_Projectile_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol MrI_Projectile_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14MrI_Projectile */
 int *MrI_Projectile_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(820);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14MrI_Projectile;
         _ZN11ShadowModelC1Ev((char *)p + 0xd4);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0xfc);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x13c);

--- a/src/MrI_Spawn.c
+++ b/src/MrI_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol MrI_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3MrI */
 int *MrI_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(536);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV3MrI;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x14c);

--- a/src/MugenBgm_Spawn.c
+++ b/src/MugenBgm_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol MugenBgm_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV19AmbientSoundEffects */
 int *MugenBgm_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(212);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV19AmbientSoundEffects; }
     return p;
 }

--- a/src/Number_Spawn.c
+++ b/src/Number_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern int VT0[];
+// @symbol Number_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15InvisibleSecret */
 int *Number_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(336);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15InvisibleSecret;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x124);
     }

--- a/src/OneUpLogo_Spawn.c
+++ b/src/OneUpLogo_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern int VT0[];
+// @symbol OneUpLogo_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9OneUpLogo */
 int *OneUpLogo_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(336);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9OneUpLogo;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x124);
     }

--- a/src/OneUpMushroomBlockTag_Spawn.c
+++ b/src/OneUpMushroomBlockTag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol OneUpMushroomBlockTag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10BrickBlock */
 int *OneUpMushroomBlockTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(220);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV10BrickBlock; }
     return p;
 }

--- a/src/OneUpMushroom_Spawn.c
+++ b/src/OneUpMushroom_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol OneUpMushroom_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13OneUpMushroom */
 int *OneUpMushroom_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(920);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13OneUpMushroom;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/OrangeBallBillboard_Spawn.c
+++ b/src/OrangeBallBillboard_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol OrangeBallBillboard_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT0 = _ZTV19OrangeBallBillboard */
 int *OrangeBallBillboard_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(292);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19OrangeBallBillboard;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/PeachPainting_Spawn.c
+++ b/src/PeachPainting_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol PeachPainting_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13PeachPainting */
 int *PeachPainting_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13PeachPainting;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/PiranhaPlant_Spawn.c
+++ b/src/PiranhaPlant_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol PiranhaPlant_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12PiranhaPlant */
 int *PiranhaPlant_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1148);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12PiranhaPlant;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN5ModelC1Ev((char *)p + 0x174);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x1c4);

--- a/src/PokeySegment_Spawn.c
+++ b/src/PokeySegment_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PokeySegment_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Pokey */
 int *PokeySegment_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Pokey;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x124);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x14c);

--- a/src/Pokey_Spawn.c
+++ b/src/Pokey_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Pokey_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Pokey */
 int *Pokey_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Pokey;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x124);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x14c);

--- a/src/PoleBillboard_Spawn.c
+++ b/src/PoleBillboard_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol PoleBillboard_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjBkBillboard_c */
 int *PoleBillboard_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(292);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV18daObjBkBillboard_c;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/PoleLift_Spawn.c
+++ b/src/PoleLift_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PoleLift_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15FireSeaElevator */
 int *PoleLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(856);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15FireSeaElevator;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/PowerFlower_Spawn.c
+++ b/src/PowerFlower_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PowerFlower_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9PushBlock */
 int *PowerFlower_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(972);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9PushBlock;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x124);
         _ZN11ShadowModelC1Ev((char *)p + 0x174);

--- a/src/PowerStar_Spawn.c
+++ b/src/PowerStar_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol PowerStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9PowerStar */
 int *PowerStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1220);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9PowerStar;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/PrincessPeach_Spawn.c
+++ b/src/PrincessPeach_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PrincessPeach_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13PrincessPeach */
 int *PrincessPeach_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(876);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13PrincessPeach;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);

--- a/src/PushBlock_Spawn.c
+++ b/src/PushBlock_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PushBlock_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjPushblock_c */
 int *PushBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1268);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16daObjPushblock_c;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/PyramidStep_Spawn.c
+++ b/src/PyramidStep_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol PyramidStep_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11PyramidStep */
 int *PyramidStep_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(932);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11PyramidStep;
         _ZN5ModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/PyramidTag_Spawn.c
+++ b/src/PyramidTag_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol PyramidTag_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10PyramidTag */
 int *PyramidTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(268);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10PyramidTag;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/PyramidTop_Spawn.c
+++ b/src/PyramidTop_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol PyramidTop_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10PyramidTop */
 int *PyramidTop_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(952);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10PyramidTop;
         _ZN5ModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/QuestionBlock_Spawn.c
+++ b/src/QuestionBlock_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol QuestionBlock_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13QuestionBlock */
 int *QuestionBlock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1016);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13QuestionBlock;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x384);
     }

--- a/src/RabbitKey_Spawn.c
+++ b/src/RabbitKey_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol RabbitKey_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9RabbitKey */
 int *RabbitKey_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(416);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9RabbitKey;
         _ZN5ModelC1Ev((char *)p + 0x110);
         _ZN11ShadowModelC1Ev((char *)p + 0x160);
     }

--- a/src/Rabbit_Spawn.c
+++ b/src/Rabbit_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Rabbit_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Rabbit */
 int *Rabbit_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1140);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Rabbit;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/RacingPenguin_Spawn.c
+++ b/src/RacingPenguin_Spawn.c
@@ -1,18 +1,22 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
+// @symbol RacingPenguin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13RacingPenguin */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *RacingPenguin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(920);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13RacingPenguin;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x138);
         _ZN11ShadowModelC1Ev((char *)p + 0x14c);

--- a/src/RedCoin_Spawn.c
+++ b/src/RedCoin_Spawn.c
@@ -1,16 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol RedCoin_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Coin */
 int *RedCoin_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(948);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Coin;
         _ZN11CommonModelC1Ev((char *)p + 0xd8);
         _ZN11CommonModelC1Ev((char *)p + 0x114);
         _ZN11ShadowModelC1Ev((char *)p + 0x150);

--- a/src/RedFlame_Spawn.c
+++ b/src/RedFlame_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol RedFlame_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9BlueFlame */
 int *RedFlame_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(280);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9BlueFlame;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xe4);
     }
     return p;

--- a/src/RickshawBdw_Spawn.c
+++ b/src/RickshawBdw_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RickshawBdw_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c */
 int *RickshawBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RickshawBs_Spawn.c
+++ b/src/RickshawBs_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RickshawBs_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c */
 int *RickshawBs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RickshawPlatformBdw_Spawn.c
+++ b/src/RickshawPlatformBdw_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RickshawPlatformBdw_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c */
 int *RickshawPlatformBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjKm1_Kuruma_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RickshawPlatformBs_Spawn.c
+++ b/src/RickshawPlatformBs_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RickshawPlatformBs_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c */
 int *RickshawPlatformBs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjKm3_Kuruma_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RockTriangle_Spawn.c
+++ b/src/RockTriangle_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol RockTriangle_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *RockTriangle_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/RollingIronBall_Spawn.c
+++ b/src/RollingIronBall_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
+// @symbol RollingIronBall_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15RollingIronBall */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *RollingIronBall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1020);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15RollingIronBall;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x110);
         _ZN5ModelC1Ev((char *)p + 0x2cc);
         _ZN11ShadowModelC1Ev((char *)p + 0x31c);

--- a/src/RollingLogLll_Spawn.c
+++ b/src/RollingLogLll_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RollingLogLll_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFlMaruta_c */
 int *RollingLogLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(836);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15daObjFlMaruta_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RollingLogTtm_Spawn.c
+++ b/src/RollingLogTtm_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RollingLogTtm_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjHmMaruta_c */
 int *RollingLogTtm_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(836);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15daObjHmMaruta_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RollingRock_Spawn.c
+++ b/src/RollingRock_Spawn.c
@@ -1,16 +1,19 @@
+// @symbol RollingRock_Spawn
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11RollingRock */
 extern void *_ZN9ActorBasenwEj(unsigned);
 extern void _ZN5EnemyC2Ev(void *);
 extern void _ZN5ModelC1Ev(void *);
 extern void _ZN11ShadowModelC1Ev(void *);
 extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
 extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+extern int _ZTV11RollingRock[];
 int *RollingRock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(968);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11RollingRock;
         _ZN5ModelC1Ev((char *)p + 0x110);
         _ZN11ShadowModelC1Ev((char *)p + 0x160);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x1b8);

--- a/src/RopeBarrier_Spawn.c
+++ b/src/RopeBarrier_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol RopeBarrier_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *RopeBarrier_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/RotatingBridge_Spawn.c
+++ b/src/RotatingBridge_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol RotatingBridge_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9TowerStep */
 int *RotatingBridge_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9TowerStep; }
     return p;
 }

--- a/src/RotatingClockHand_Spawn.c
+++ b/src/RotatingClockHand_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol RotatingClockHand_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV16RotatingCogSmall */
 int *RotatingClockHand_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV16RotatingCogSmall; }
     return p;
 }

--- a/src/RotatingCogSmall_Spawn.c
+++ b/src/RotatingCogSmall_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol RotatingCogSmall_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV16RotatingCogSmall */
 int *RotatingCogSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV16RotatingCogSmall; }
     return p;
 }

--- a/src/RotatingPlatformLll_Spawn.c
+++ b/src/RotatingPlatformLll_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RotatingPlatformLll_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c */
 int *RotatingPlatformLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16daObjFl_Koma_D_c;
         p[0] = (int)VT1;
     }
     return p;


### PR DESCRIPTION
First batch of the readable-tree migration. Promotes 190 already-matched spawn/actor files to their readable form: inline extern walls replaced with shared `#include "decl_*.h"` headers, and `VT0`-style vtable placeholders resolved to real symbols. Same bytes, same ROM.

Stacked on the shared-header PR (that one must merge first; these files include the headers it adds). This batch changes `src/` only, no `include/` churn.

## Verification

Every file link-verified against the ROM on the build box (`tools/prepush_linkcheck.py`): compiled with mwccarm 1.2/sp2p3 and its relocated bytes compared to the cartridge.

- VERIFIED: 155
- BLIND (bytes verified, 1-2 reloc slots reference an RTTI-recovered symbol not yet in config): 35
- WRONG / NO-REPRO: 0

The BLIND slots are not wrong matches. They point at real recovered class-vtable names (for example `_ZTV12daBDonketu_c`, the internal Nintendo name behind BigBully) that main's `symbols.txt` does not carry yet. The instruction bytes reproduce exactly; only the reloc-target name is unresolved. Naming those symbols is a separate follow-up.

Kept under the validation file cap deliberately. The remaining ~2,600 clean-overwrite files follow in further batches of this size.

Built with Claude Code.
