### PR TITLE
readable: batch 02 - promote 189 spawn/actor files to readable form

### DIFF
--- a/src/RotatingPlatformRr_Spawn.c
+++ b/src/RotatingPlatformRr_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RotatingPlatformRr_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c */
 int *RotatingPlatformRr_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19daObjRc_Kaitendai_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RotatingPlatformWdw_Spawn.c
+++ b/src/RotatingPlatformWdw_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RotatingPlatformWdw_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c */
 int *RotatingPlatformWdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15daObjWc_Obj07_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RotatingPlatformWf_Spawn.c
+++ b/src/RotatingPlatformWf_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol RotatingPlatformWf_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c */
 int *RotatingPlatformWf_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjBk_Ukisima_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/RotatingUpDownPlatformUtm_Spawn.c
+++ b/src/RotatingUpDownPlatformUtm_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol RotatingUpDownPlatformUtm_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25RotatingUpDownPlatformUtm */
 int *RotatingUpDownPlatformUtm_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(936);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25RotatingUpDownPlatformUtm;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/RotatingUpDownPlatform_Spawn.c
+++ b/src/RotatingUpDownPlatform_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol RotatingUpDownPlatform_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25RotatingUpDownPlatformUtm */
 int *RotatingUpDownPlatform_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(936);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25RotatingUpDownPlatformUtm;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Scuttlebug_Spawn.c
+++ b/src/Scuttlebug_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Scuttlebug_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10Scuttlebug */
 int *Scuttlebug_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(940);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10Scuttlebug;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);

--- a/src/Seaweed_Spawn.c
+++ b/src/Seaweed_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol Seaweed_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjWakame_c */
 int *Seaweed_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(312);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13daObjWakame_c;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/SeesawBdw_Spawn.c
+++ b/src/SeesawBdw_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawBdw_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawBfs_Spawn.c
+++ b/src/SeesawBfs_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawBfs_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawBob_Spawn.c
+++ b/src/SeesawBob_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawBob_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawBob_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawBsPlank_Spawn.c
+++ b/src/SeesawBsPlank_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawBsPlank_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawBsPlank_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawBsZigZag_Spawn.c
+++ b/src/SeesawBsZigZag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawBsZigZag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawBsZigZag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawRr_Spawn.c
+++ b/src/SeesawRr_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawRr_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawRr_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/SeesawUtm_Spawn.c
+++ b/src/SeesawUtm_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SeesawUtm_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9SeesawBob */
 int *SeesawUtm_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(808);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV9SeesawBob; }
     return p;
 }

--- a/src/Shark_Spawn.c
+++ b/src/Shark_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol Shark_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Shark */
 int *Shark_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(928);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Shark;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/ShipDown_Spawn.c
+++ b/src/ShipDown_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ShipDown_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV6ShipUp */
 int *ShipDown_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV6ShipUp; }
     return p;
 }

--- a/src/ShipUp_Spawn.c
+++ b/src/ShipUp_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol ShipUp_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV6ShipUp */
 int *ShipUp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV6ShipUp; }
     return p;
 }

--- a/src/ShipWater_Spawn.c
+++ b/src/ShipWater_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol ShipWater_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9ShipWater */
 int *ShipWater_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(832);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9ShipWater;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/ShipWing_Spawn.c
+++ b/src/ShipWing_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern int VT0[];
+// @symbol ShipWing_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV18RotatingPlatformRr */
 int *ShipWing_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(284);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV18RotatingPlatformRr;
         _ZN11CommonModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/ShutterBob_Spawn.c
+++ b/src/ShutterBob_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol ShutterBob_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c */
 int *ShutterBob_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjBSwdoor_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/ShutterHmc_Spawn.c
+++ b/src/ShutterHmc_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol ShutterHmc_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCvShutter_c */
 int *ShutterHmc_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(804);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16daObjCvShutter_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/SignPost_Spawn.c
+++ b/src/SignPost_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol SignPost_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8SignPost */
 int *SignPost_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1444);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8SignPost;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x358);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x3c8);

--- a/src/SilverStarBlockTag_Spawn.c
+++ b/src/SilverStarBlockTag_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol SilverStarBlockTag_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10BrickBlock */
 int *SilverStarBlockTag_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(220);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV10BrickBlock; }
     return p;
 }

--- a/src/SilverStar_Spawn.c
+++ b/src/SilverStar_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol SilverStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9PowerStar */
 int *SilverStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1220);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9PowerStar;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN9ModelAnimC1Ev((char *)p + 0x30c);

--- a/src/SlideDecorationBlueSmiley_Spawn.c
+++ b/src/SlideDecorationBlueSmiley_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol SlideDecorationBlueSmiley_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25SlideDecorationSilverStar */
 int *SlideDecorationBlueSmiley_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25SlideDecorationSilverStar;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/SlideDecorationOrangeSmiley_Spawn.c
+++ b/src/SlideDecorationOrangeSmiley_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol SlideDecorationOrangeSmiley_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25SlideDecorationSilverStar */
 int *SlideDecorationOrangeSmiley_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25SlideDecorationSilverStar;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/SlideDecorationSilverStar_Spawn.c
+++ b/src/SlideDecorationSilverStar_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol SlideDecorationSilverStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25SlideDecorationSilverStar */
 int *SlideDecorationSilverStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25SlideDecorationSilverStar;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/SlideDecorationYellowStar_Spawn.c
+++ b/src/SlideDecorationYellowStar_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol SlideDecorationYellowStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV25SlideDecorationSilverStar */
 int *SlideDecorationYellowStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(296);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV25SlideDecorationSilverStar;
         _ZN5ModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/SlidingBox_Spawn.c
+++ b/src/SlidingBox_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol SlidingBox_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV23FloatOnWaterPlatformJrb */
 int *SlidingBox_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1272);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV23FloatOnWaterPlatformJrb;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x324);
     }
     return p;

--- a/src/SlidingIceSpawner_Spawn.c
+++ b/src/SlidingIceSpawner_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingIceSpawner_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10SlidingIce */
 int *SlidingIceSpawner_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV10SlidingIce; }
     return p;
 }

--- a/src/SlidingIce_Spawn.c
+++ b/src/SlidingIce_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingIce_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10SlidingIce */
 int *SlidingIce_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(812);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV10SlidingIce; }
     return p;
 }

--- a/src/SlidingPlatformBdw_Spawn.c
+++ b/src/SlidingPlatformBdw_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformBdw_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformBdw_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformBfsRectangle_Spawn.c
+++ b/src/SlidingPlatformBfsRectangle_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformBfsRectangle_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformBfsRectangle_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformBfsSquare_Spawn.c
+++ b/src/SlidingPlatformBfsSquare_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformBfsSquare_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformBfsSquare_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformBsLong_Spawn.c
+++ b/src/SlidingPlatformBsLong_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformBsLong_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformBsLong_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformBsWide_Spawn.c
+++ b/src/SlidingPlatformBsWide_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformBsWide_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformBsWide_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformRr_Spawn.c
+++ b/src/SlidingPlatformRr_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformRr_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformRr_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/SlidingPlatformWf_Spawn.c
+++ b/src/SlidingPlatformWf_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol SlidingPlatformWf_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV17SlidingPlatformWf */
 int *SlidingPlatformWf_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV17SlidingPlatformWf; }
     return p;
 }

--- a/src/Snowball_Spawn.c
+++ b/src/Snowball_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Snowball_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8Snowball */
 int *Snowball_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(908);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8Snowball;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/SnowmanBody_Spawn.c
+++ b/src/SnowmanBody_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
+// @symbol SnowmanBody_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11SnowmanBody */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *SnowmanBody_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(936);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11SnowmanBody;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x124);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x14c);

--- a/src/SnowmanHead_Spawn.c
+++ b/src/SnowmanHead_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol SnowmanHead_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_TextureSequence.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11SnowmanHead */
 int *SnowmanHead_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(824);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11SnowmanHead;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN15TextureSequenceC1Ev((char *)p + 0x124);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x138);

--- a/src/Snufit_Spawn.c
+++ b/src/Snufit_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Snufit_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Snufit */
 int *Snufit_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(996);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV6Snufit;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/SpikeBomb_Spawn.c
+++ b/src/SpikeBomb_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol SpikeBomb_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17BowserSkyPlatform */
 int *SpikeBomb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(432);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17BowserSkyPlatform;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x124);
     }

--- a/src/Spindrift_Spawn.c
+++ b/src/Spindrift_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Spindrift_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9Spindrift */
 int *Spindrift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(924);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9Spindrift;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN11ShadowModelC1Ev((char *)p + 0x174);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x19c);

--- a/src/SpinningPlatform_Spawn.c
+++ b/src/SpinningPlatform_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol SpinningPlatform_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17RotatingClockHand */
 int *SpinningPlatform_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(896);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17RotatingClockHand;
         _ZN11ShadowModelC1Ev((char *)p + 0x328);
     }
     return p;

--- a/src/Spiny_Spawn.c
+++ b/src/Spiny_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Spiny_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Spiny */
 int *Spiny_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1004);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Spiny;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN9ModelAnimC1Ev((char *)p + 0x124);
         _ZN11ShadowModelC1Ev((char *)p + 0x188);

--- a/src/SquareMetalNetLift_Spawn.c
+++ b/src/SquareMetalNetLift_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
+// @symbol SquareMetalNetLift_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV22RotatingUpDownPlatform */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *SquareMetalNetLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(856);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV22RotatingUpDownPlatform;
         _ZN7PathPtrC1Ev((char *)p + 0x344);
     }
     return p;

--- a/src/SquarePathLift_Spawn.c
+++ b/src/SquarePathLift_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
+// @symbol SquarePathLift_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14SquarePathLift */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *SquarePathLift_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14SquarePathLift;
         _ZN7PathPtrC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Squasher_Spawn.c
+++ b/src/Squasher_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Squasher_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT0 = _ZTV8Squasher */
 int *Squasher_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(892);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8Squasher;
         _ZN11ShadowModelC1Ev((char *)p + 0x324);
     }
     return p;

--- a/src/StarDoor_Spawn.c
+++ b/src/StarDoor_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN11CommonModelC1Ev(void *);
-extern int VT0[];
+// @symbol StarDoor_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Door */
 int *StarDoor_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(280);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Door;
         _ZN11CommonModelC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/StarMarker_Spawn.c
+++ b/src/StarMarker_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol StarMarker_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10StarMarker */
 int *StarMarker_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(476);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10StarMarker;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x114);
         _ZN11ShadowModelC1Ev((char *)p + 0x164);

--- a/src/StarSwitch_Spawn.c
+++ b/src/StarSwitch_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol StarSwitch_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV10StarSwitch */
 int *StarSwitch_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV10StarSwitch; }
     return p;
 }

--- a/src/StaticRock_Spawn.c
+++ b/src/StaticRock_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol StaticRock_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *StaticRock_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/SublevelToLevel.c
+++ b/src/SublevelToLevel.c
@@ -1,2 +1,6 @@
-extern signed char G[];
-int SublevelToLevel(int i) { return G[i]; }
+// @symbol SublevelToLevel
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: G = SUBLEVEL_LEVEL_TABLE */
+int SublevelToLevel(int i) { return SUBLEVEL_LEVEL_TABLE[i]; }

--- a/src/SwitchActivatedPlank_Spawn.c
+++ b/src/SwitchActivatedPlank_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol SwitchActivatedPlank_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV20SwitchActivatedPlank */
 int *SwitchActivatedPlank_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(936);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20SwitchActivatedPlank;
         _ZN5ModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Swoop_Spawn.c
+++ b/src/Swoop_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Swoop_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Swoop */
 int *Swoop_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1088);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV5Swoop;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/TTC_MovingBar_Spawn.c
+++ b/src/TTC_MovingBar_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TTC_MovingBar_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha05_c */
 int *TTC_MovingBar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(916);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16daObjCtMecha05_c;
         _ZN11ShadowModelC1Ev((char *)p + 0x33c);
     }
     return p;

--- a/src/TTC_MovingBeam_Spawn.c
+++ b/src/TTC_MovingBeam_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TTC_MovingBeam_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14TtcMovingCubeA */
 int *TTC_MovingBeam_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(908);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14TtcMovingCubeA;
         _ZN11ShadowModelC1Ev((char *)p + 0x334);
     }
     return p;

--- a/src/Thwomp_Spawn.c
+++ b/src/Thwomp_Spawn.c
@@ -1,15 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol Thwomp_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daDsn_c */
 int *Thwomp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(932);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7daDsn_c;
         _ZN15TextureSequenceC1Ev((char *)p + 0x324);
         _ZN11ShadowModelC1Ev((char *)p + 0x338);
         p[0] = (int)VT1;

--- a/src/TiltingPlatformBfs_Spawn.c
+++ b/src/TiltingPlatformBfs_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol TiltingPlatformBfs_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c */
 int *TiltingPlatformBfs_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(848);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15daObjKm2_Gura_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/TiltingPlatformLll_Spawn.c
+++ b/src/TiltingPlatformLll_Spawn.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol TiltingPlatformLll_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c */
 int *TiltingPlatformLll_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(848);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjFl_Gura_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/TinyWater_Spawn.c
+++ b/src/TinyWater_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol TinyWater_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT0 = _ZTV9TinyCover */
 int *TinyWater_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(832);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9TinyCover;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/Toad_Spawn.c
+++ b/src/Toad_Spawn.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol Toad_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV4Toad */
 int *Toad_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(528);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV4Toad;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
         _ZN9ModelAnimC1Ev((char *)p + 0x108);
         _ZN11ShadowModelC1Ev((char *)p + 0x16c);

--- a/src/Tornado_Spawn.c
+++ b/src/Tornado_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol Tornado_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7Tornado */
 int *Tornado_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(880);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV7Tornado;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x108);
         _ZN9ModelAnimC1Ev((char *)p + 0x2c4);

--- a/src/TowerStep_Spawn.c
+++ b/src/TowerStep_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TowerStep_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV14MovingBarSmall */
 int *TowerStep_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(916);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14MovingBarSmall;
         _ZN11ShadowModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/TrapDoor_Spawn.c
+++ b/src/TrapDoor_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol TrapDoor_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12MansionSteps */
 int *TrapDoor_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(852);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12MansionSteps;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingMeshColliderC1Ev((char *)p + 0x15c);
     }

--- a/src/Trap_Spawn.c
+++ b/src/Trap_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern int VT0[];
+// @symbol Trap_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjC1_Trap_c */
 int *Trap_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(944);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV14daObjC1_Trap_c;
         _ZN5ModelC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/TreasureChest_Spawn.c
+++ b/src/TreasureChest_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol TreasureChest_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13TreasureChest */
 int *TreasureChest_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(376);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13TreasureChest;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x138);
     }

--- a/src/TtcConveyorBeltLarge_Spawn.c
+++ b/src/TtcConveyorBeltLarge_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcConveyorBeltLarge_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV20TtcConveyorBeltLarge */
 int *TtcConveyorBeltLarge_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(928);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20TtcConveyorBeltLarge;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x334);
     }

--- a/src/TtcConveyorBeltSmall_Spawn.c
+++ b/src/TtcConveyorBeltSmall_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcConveyorBeltSmall_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV20TtcConveyorBeltLarge */
 int *TtcConveyorBeltSmall_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(928);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20TtcConveyorBeltLarge;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x334);
     }

--- a/src/TtcMovingCubeA_Spawn.c
+++ b/src/TtcMovingCubeA_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol TtcMovingCubeA_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV15TtcRotatingGear */
 int *TtcMovingCubeA_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV15TtcRotatingGear; }
     return p;
 }

--- a/src/TtcMovingCubeB_Spawn.c
+++ b/src/TtcMovingCubeB_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol TtcMovingCubeB_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV15TtcRotatingGear */
 int *TtcMovingCubeB_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV15TtcRotatingGear; }
     return p;
 }

--- a/src/TtcRotatingCube_Spawn.c
+++ b/src/TtcRotatingCube_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcRotatingCube_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15TtcRotatingCube */
 int *TtcRotatingCube_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(984);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15TtcRotatingCube;
         _ZN5ModelC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x380);
     }

--- a/src/TtcRotatingGear_Spawn.c
+++ b/src/TtcRotatingGear_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcRotatingGear_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13TTC_MovingBar */
 int *TtcRotatingGear_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(892);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13TTC_MovingBar;
         _ZN11ShadowModelC1Ev((char *)p + 0x324);
     }
     return p;

--- a/src/TtcRotatingPrism_Spawn.c
+++ b/src/TtcRotatingPrism_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcRotatingPrism_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15TtcRotatingCube */
 int *TtcRotatingPrism_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(984);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15TtcRotatingCube;
         _ZN5ModelC1Ev((char *)p + 0x320);
         _ZN11ShadowModelC1Ev((char *)p + 0x380);
     }

--- a/src/TtcRotatingTriangle_Spawn.c
+++ b/src/TtcRotatingTriangle_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol TtcRotatingTriangle_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13TTC_MovingBar */
 int *TtcRotatingTriangle_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(892);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13TTC_MovingBar;
         _ZN11ShadowModelC1Ev((char *)p + 0x324);
     }
     return p;

--- a/src/UkikiCage_Spawn.c
+++ b/src/UkikiCage_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol UkikiCage_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjHmBskt_c */
 int *UkikiCage_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1248);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13daObjHmBskt_c;
         _ZN12WithMeshClsnC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/UkikiStar_Spawn.c
+++ b/src/UkikiStar_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
+// @symbol UkikiStar_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13RollingLogTtm */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *UkikiStar_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(972);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13RollingLogTtm;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);

--- a/src/UkikiThief_Spawn.c
+++ b/src/UkikiThief_Spawn.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
+// @symbol UkikiThief_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13RollingLogTtm */
 extern void _ZN7PathPtrC1Ev(void *);
-extern int VT0[];
 int *UkikiThief_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(972);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13RollingLogTtm;
         _ZN9ModelAnimC1Ev((char *)p + 0xd4);
         _ZN11ShadowModelC1Ev((char *)p + 0x138);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x160);

--- a/src/UpDownLiftBbh_Spawn.c
+++ b/src/UpDownLiftBbh_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol UpDownLiftBbh_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13UpDownLiftBbh */
 int *UpDownLiftBbh_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13UpDownLiftBbh; }
     return p;
 }

--- a/src/UpDownLiftHmc_Spawn.c
+++ b/src/UpDownLiftHmc_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol UpDownLiftHmc_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13UpDownLiftBbh */
 int *UpDownLiftHmc_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13UpDownLiftBbh; }
     return p;
 }

--- a/src/UpDownLiftRr_Spawn.c
+++ b/src/UpDownLiftRr_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol UpDownLiftRr_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13UpDownLiftBbh */
 int *UpDownLiftRr_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(844);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13UpDownLiftBbh; }
     return p;
 }

--- a/src/VirtualDoor_Spawn.c
+++ b/src/VirtualDoor_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol VirtualDoor_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV9CameraTag */
 int *VirtualDoor_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(212);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV9CameraTag; }
     return p;
 }

--- a/src/VolcanoFire_Spawn.c
+++ b/src/VolcanoFire_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol VolcanoFire_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13RollingLogLll */
 int *VolcanoFire_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(284);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV13RollingLogLll;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/WDW_Water_Spawn.c
+++ b/src/WDW_Water_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol WDW_Water_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV19RotatingPlatformWdw */
 int *WDW_Water_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(840);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV19RotatingPlatformWdw;
         _ZN18TextureTransformerC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/WallSign_Spawn.c
+++ b/src/WallSign_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol WallSign_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8WallSign */
 int *WallSign_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(872);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8WallSign;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x320);
     }
     return p;

--- a/src/WarpPipe_Spawn.c
+++ b/src/WarpPipe_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol WarpPipe_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV13FortressTower */
 int *WarpPipe_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV13FortressTower; }
     return p;
 }

--- a/src/Warp_Spawn.c
+++ b/src/Warp_Spawn.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol Warp_Spawn
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daWarpkun_c */
 int *Warp_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(264);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11daWarpkun_c;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0xd4);
     }
     return p;

--- a/src/WaterBomb_Spawn.c
+++ b/src/WaterBomb_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol WaterBomb_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9WaterBomb */
 int *WaterBomb_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(972);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9WaterBomb;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN5ModelC1Ev((char *)p + 0x300);

--- a/src/WaterDiamond_Spawn.c
+++ b/src/WaterDiamond_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol WaterDiamond_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9ArrowLift */
 int *WaterDiamond_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(352);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9ArrowLift;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x124);
     }

--- a/src/WaterRing_Spawn.c
+++ b/src/WaterRing_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol WaterRing_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9WaterRing */
 int *WaterRing_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(912);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9WaterRing;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
         _ZN5ModelC1Ev((char *)p + 0x30c);

--- a/src/WaterSuction_Spawn.c
+++ b/src/WaterSuction_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol WaterSuction_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12WaterSuction */
 int *WaterSuction_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(792);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV12WaterSuction;
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x150);
     }

--- a/src/WaterfallMist_Spawn.c
+++ b/src/WaterfallMist_Spawn.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern int VT[];
+// @symbol WaterfallMist_Spawn
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV18PoppingLavaBubbles */
 int *WaterfallMist_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(220);
-    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN5ActorC2Ev(p); p[0] = (int)_ZTV18PoppingLavaBubbles; }
     return p;
 }

--- a/src/Whirlpool_Spawn.c
+++ b/src/Whirlpool_Spawn.c
@@ -1,14 +1,18 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN18TextureTransformerC1Ev(void *);
-extern int VT0[];
+// @symbol Whirlpool_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9Submarine */
 int *Whirlpool_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(444);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV9Submarine;
         _ZN9ModelAnimC1Ev((char *)p + 0x114);
         _ZN18TextureTransformerC1Ev((char *)p + 0x178);
     }

--- a/src/WingFeather_Spawn.c
+++ b/src/WingFeather_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol WingFeather_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11WingFeather */
 int *WingFeather_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(904);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11WingFeather;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x124);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x158);

--- a/src/YoshiEgg_Spawn.c
+++ b/src/YoshiEgg_Spawn.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol YoshiEgg_Spawn
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8YoshiEgg */
 int *YoshiEgg_Spawn(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1068);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8YoshiEgg;
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x110);
         _ZN12WithMeshClsnC1Ev((char *)p + 0x144);
         _ZN9ModelAnimC1Ev((char *)p + 0x300);

--- a/src/_ZN10BowserFire8BehaviorEv.cpp
+++ b/src/_ZN10BowserFire8BehaviorEv.cpp
@@ -1,32 +1,35 @@
 //cpp
+// @symbol _ZN10BowserFire8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserFire.h"
 struct Actor;
 typedef void (Actor::*PMF)();
 struct Entry { PMF pmf; };
 extern "C" Entry data_ov060_0211afb4[];
 extern "C" void func_02038420(void *p);
 extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void *c);
-extern "C" void func_ov060_02116740(char* c);
-extern "C" void func_ov060_02117624(char *c);
 struct CylinderClsn { void Clear(); void Update(); };
 
-extern "C" int _ZN10BowserFire8BehaviorEv(char *thiz)
+int BowserFire::Behavior()
 {
-    Actor *self = (Actor*)thiz;
-    *(int*)(((int)thiz + 0x370) & 0xFFFFFFFFFFFFFFFF) += 1;
-    (self->*data_ov060_0211afb4[*(int*)(thiz + 0x35c)].pmf)();
-    *(unsigned short*)(((int)thiz + 0x374) & 0xFFFFFFFFFFFFFFFF) += 1;
-    if (*(int*)(thiz + 0x9c) != 0) {
-        func_02038420(thiz + 0x110);
-        if (*(int*)(thiz + 0x35c) != 4) {
-            if (_ZNK12WithMeshClsn10IsOnGroundEv(thiz + 0x110) != 0) {
-                *(int*)(thiz + 0xa8) = 0;
-                *(int*)(thiz + 0x9c) = 0;
+    Actor *self = (Actor*)((char *)this);
+    *(int*)(((int)((char *)this) + 0x370) & 0xFFFFFFFFFFFFFFFF) += 1;
+    (self->*data_ov060_0211afb4[unk_35c].pmf)();
+    *(unsigned short*)(((int)((char *)this) + 0x374) & 0xFFFFFFFFFFFFFFFF) += 1;
+    if (unk_09c != 0) {
+        func_02038420((char *)&mWithMeshClsn);
+        if (unk_35c != 4) {
+            if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mWithMeshClsn) != 0) {
+                unk_0a8 = 0;
+                unk_09c = 0;
             }
         }
     }
-    func_ov060_02116740(thiz);
-    func_ov060_02117624(thiz);
-    ((CylinderClsn*)(thiz + 0x2d0))->Clear();
-    ((CylinderClsn*)(thiz + 0x2d0))->Update();
+    func_ov060_02116740(((char *)this));
+    func_ov060_02117624(((char *)this));
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Clear();
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Update();
     return 1;
 }

--- a/src/_ZN10BowserFireD0Ev.c
+++ b/src/_ZN10BowserFireD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10BowserFireD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daKpaFire_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10BowserFireD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daKpaFire_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x304);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x2d0);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN10BowserFireD1Ev.c
+++ b/src/_ZN10BowserFireD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10BowserFireD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10BowserFire */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10BowserFireD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10BowserFire;
     _ZN11ShadowModelD1Ev((char *)t + 0x304);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x2d0);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN10BowserTail13InitResourcesEv.cpp
+++ b/src/_ZN10BowserTail13InitResourcesEv.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN10BowserTail13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "BowserTail.h"
 extern "C" {
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *actor, int fix, int t, unsigned int e, unsigned int f);
-int _ZN10BowserTail13InitResourcesEv(char *c)
-{
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0x32000, 0x50000, 0x800000, 0x1000);
-    return 1;
 }
+
+int BowserTail::InitResources()
+{
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0xd4, ((char *)this), 0x32000, 0x50000, 0x800000, 0x1000);
+    return 1;
 }

--- a/src/_ZN10BowserTail8BehaviorEv.cpp
+++ b/src/_ZN10BowserTail8BehaviorEv.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol _ZN10BowserTail8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserTail.h"
 struct Actor { static Actor* FindWithID(unsigned int); };
-extern "C" void func_ov060_02115b84(void* c);
 extern short data_02082214[];
 
-extern "C" int _ZN10BowserTail8BehaviorEv(char* c)
+int BowserTail::Behavior()
 {
-    Actor* a = Actor::FindWithID(*(unsigned int*)(c + 0x108));
+    Actor* a = Actor::FindWithID(unk_108);
     if (!a) return 1;
 
     int ang = *(short*)((char*)a + 0x94);
@@ -16,10 +20,10 @@ extern "C" int _ZN10BowserTail8BehaviorEv(char* c)
     v[1] = ((int*)a)[1];
     v[2] = ((int*)a)[2];
     int j = 2 * (((unsigned short)(short)(ang + 0x8000)) >> 4);
-    *(int*)(c + 0x5c) = (short)data_02082214[j] * 0x8c + x;
-    *(int*)(c + 0x60) = v[1];
-    *(int*)(c + 0x64) = (short)data_02082214[j + 1] * 0x8c + v[2];
+    mPosX = (short)data_02082214[j] * 0x8c + x;
+    mPosY = v[1];
+    mPosZ = (short)data_02082214[j + 1] * 0x8c + v[2];
 
-    func_ov060_02115b84(c);
+    func_ov060_02115b84(((char*)this));
     return 1;
 }

--- a/src/_ZN10BowserTailD0Ev.c
+++ b/src/_ZN10BowserTailD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN10BowserTailD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daKpaTail_c */
 extern void *G0;
 int *_ZN10BowserTailD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daKpaTail_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN10BrickBlock8BehaviorEv.cpp
+++ b/src/_ZN10BrickBlock8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10BrickBlock8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "BrickBlock.h"
 struct C;
 typedef void (C::*PMF)();
 extern "C" PMF data_ov002_0210dd30[];
@@ -8,9 +11,11 @@ int Vec3_Dist(const void* a, const void* b);
 void _ZN9ActorBase18MarkForDestructionEv(void* c);
 }
 struct C { char pad[0x1000]; };
-extern "C" int _ZN10BrickBlock8BehaviorEv(char* c){
+
+int BrickBlock::Behavior()
+{
   char* o = 0;
-  if (*(unsigned char*)(c + 0xd8) != 0) goto d6;
+  if (unk_0d8 != 0) goto d6;
   o = (char*)_ZN5Actor4NextEPKS_(0);
   while (o){
     unsigned short t = *(unsigned short*)(o + 0xc);
@@ -23,22 +28,22 @@ extern "C" int _ZN10BrickBlock8BehaviorEv(char* c){
         if (!b) goto next;
       }
     }
-    if (Vec3_Dist(c + 0x5c, o + 0x5c) < 0x32000){
-      *(char**)(o + 0x328) = c;
-      *(unsigned char*)(c + 0xd8) = 1;
+    if (Vec3_Dist(((char*)this) + 0x5c, o + 0x5c) < 0x32000){
+      *(char**)(o + 0x328) = ((char*)this);
+      unk_0d8 = 1;
       return 1;
     }
   next:
     o = (char*)_ZN5Actor4NextEPKS_(o);
   }
   if (o) goto d6;
-  _ZN9ActorBase18MarkForDestructionEv(c);
+  _ZN9ActorBase18MarkForDestructionEv(((char*)this));
   return 1;
 d6:
-  if (*(unsigned char*)(c + 0xd6) != 0){
-    int idx = *(unsigned char*)(c + 0xd7);
-    (((C*)c)->*data_ov002_0210dd30[idx])();
-    _ZN9ActorBase18MarkForDestructionEv(c);
+  if (unk_0d6 != 0){
+    int idx = unk_0d7;
+    (((C*)((char*)this))->*data_ov002_0210dd30[idx])();
+    _ZN9ActorBase18MarkForDestructionEv(((char*)this));
   }
   return 1;
 }

--- a/src/_ZN10BrickBlockD0Ev.c
+++ b/src/_ZN10BrickBlockD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN10BrickBlockD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "BrickBlock.h"
 int *_ZN10BrickBlockD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN10BulletBill6RenderEv.cpp
+++ b/src/_ZN10BulletBill6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10BulletBill6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BulletBill.h"
 struct Foo {
     virtual void M0(int x);
     virtual void M1(int x);
@@ -13,8 +16,10 @@ struct Container {
     char pad2[0x4c];
     Foo obj2;
 };
-extern "C" int _ZN10BulletBill6RenderEv(Container *c) {
-    c->obj1.M5(0);
-    c->obj2.M5(0);
+
+int BulletBill::Render()
+{
+    ((Container *)this)->obj1.M5(0);
+    ((Container *)this)->obj2.M5(0);
     return 1;
 }

--- a/src/_ZN10BulletBillD0Ev.c
+++ b/src/_ZN10BulletBillD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10BulletBillD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daKlr_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10BulletBillD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daKlr_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3ac);
     _ZN5ModelD1Ev((char *)t + 0x35c);
     _ZN5ModelD1Ev((char *)t + 0x30c);

--- a/src/_ZN10BulletBillD1Ev.c
+++ b/src/_ZN10BulletBillD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10BulletBillD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10BulletBill */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10BulletBillD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10BulletBill;
     _ZN11ShadowModelD1Ev((char *)t + 0x3ac);
     _ZN5ModelD1Ev((char *)t + 0x35c);
     _ZN5ModelD1Ev((char *)t + 0x30c);

--- a/src/_ZN10ChainChomp13InitResourcesEv.cpp
+++ b/src/_ZN10ChainChomp13InitResourcesEv.cpp
@@ -1,21 +1,22 @@
 //cpp
+// @symbol _ZN10ChainChomp13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ChainChomp.h"
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmd, int a, int b);
 extern "C" void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN11ShadowModel12InitCylinderEv(void *self);
 extern "C" void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void *self, void *actor, void *pos, int fix, int t, unsigned int a, unsigned int b);
-extern "C" void func_ov014_02111ebc(void *c, int i);
 extern "C" void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *v16, int e, int f);
 
-extern char data_ov014_02114968;
-extern char data_ov014_02114978;
 extern char data_ov014_02114980;
 extern char data_ov014_02114970;
-extern int data_ov014_02114700[];
 
-extern "C" int _ZN10ChainChomp13InitResourcesEv(void *thiz)
+int ChainChomp::InitResources()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     void *f;
         int i;
     unsigned char *p;
@@ -89,11 +90,11 @@ extern "C" int _ZN10ChainChomp13InitResourcesEv(void *thiz)
     *(unsigned char *)((unsigned char *)spawned + 0x320) = (unsigned char)one;
     *(int *)(c + 0x60c) = 0;
 
-    px = (int *)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    px = (int *)(((long long)(int)(c + 0x5c)));
     *px = *px + 0xc8000;
-    py = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    py = (int *)(((long long)(int)(c + 0x60)));
     *py = *py + 0xc8000;
-    pz = (int *)(((long long)(int)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    pz = (int *)(((long long)(int)(c + 0x64)));
     *pz = *pz + 0xc8000;
 
     *(int *)(c + 0x5f8) = 0x50000;

--- a/src/_ZN10ChainChomp6RenderEv.cpp
+++ b/src/_ZN10ChainChomp6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10ChainChomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ChainChomp.h"
 struct A;
 struct B {
     virtual void m0();
@@ -9,12 +12,13 @@ struct B {
     virtual void m5(A* arg);
 };
 
-extern "C" int _ZN10ChainChomp6RenderEv(char *c) {
-    B *b = (B*)(c+0x150);
-    b->m5((A*)(c+0x80));
+int ChainChomp::Render()
+{
+    B *b = (B*)((char *)&mModelAnim);
+    b->m5((A*)((char *)&mScaleX));
     
     int j = 0;
-    char *p2 = c + 0x1dc;
+    char *p2 = ((char *)this) + 0x1dc;
     for (;;) {
         B *b2 = (B*)p2;
         b2->m5((A*)0);

--- a/src/_ZN10ChainChomp8BehaviorEv.cpp
+++ b/src/_ZN10ChainChomp8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN10ChainChomp8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ChainChomp.h"
 extern "C" {
 int func_ov014_02111fb8(char* c);
 char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int a, void* b);
@@ -14,48 +19,48 @@ void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* self
 void _ZN12CylinderClsn5ClearEv(void* self);
 char* _ZN5Actor13ClosestPlayerEv(char* self);
 void _ZN12CylinderClsn6UpdateEv(void* self);
-extern int data_ov014_02114700[];
+}
 
-int _ZN10ChainChomp8BehaviorEv(char* c){
-    *(unsigned char*)(c + 0x61c) = 0;
+int ChainChomp::Behavior()
+{
+    unk_61c = 0;
     {
-        int v = *(int*)(c + 0x5f0) + 0xc8000;
-        if (*(int*)(c + 0x60) <= v) {
-            *(int*)(c + 0x60) = v;
-            if (*(unsigned char*)(c + 0x61d) == 0) {
-                func_ov014_02111fb8(c);
+        int v = unk_5f0 + 0xc8000;
+        if (mPosY <= v) {
+            mPosY = v;
+            if (unk_61d == 0) {
+                func_ov014_02111fb8(((char*)this));
             }
-            *(unsigned char*)(c + 0x61c) = 1;
+            unk_61c = 1;
         }
     }
-    *(unsigned char*)(c + 0x61d) = *(unsigned char*)(c + 0x61c);
-    if (*(int*)(c + 0x60c) == 0) {
+    unk_61d = unk_61c;
+    if (unk_60c == 0) {
         char* r = _ZN5Actor15FindWithActorIDEjPS_(0x29, 0);
-        *(int*)(c + 0x60c) = *(int*)(r + 4);
+        unk_60c = *(int*)(r + 4);
     }
-    func_ov014_02111f08(c);
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
-    func_ov014_02112114(c);
-    if (*(unsigned char*)(c + 0x605) == 0) {
-        func_ov014_02111fe0(c);
+    func_ov014_02111f08(((char*)this));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this) + 0x110);
+    func_ov014_02112114(((char*)this));
+    if (unk_605 == 0) {
+        func_ov014_02111fe0(((char*)this));
     }
-    func_ov014_0211250c(c);
-    if (*(unsigned char*)(c + 0x605) == 0) {
-        func_ov014_0211236c(c);
-        func_ov014_021122dc(c);
+    func_ov014_0211250c(((char*)this));
+    if (unk_605 == 0) {
+        func_ov014_0211236c(((char*)this));
+        func_ov014_021122dc(((char*)this));
     }
-    func_ov014_02112788(c);
+    func_ov014_02112788(((char*)this));
     {
         int v[3];
         v[0] = data_ov014_02114700[0];
         v[1] = data_ov014_02114700[1];
         v[2] = data_ov014_02114700[2];
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x110, v);
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0x110, v);
     }
-    _ZN12CylinderClsn5ClearEv(c + 0x110);
-    if (*(unsigned char*)(_ZN5Actor13ClosestPlayerEv(c) + 0x6fb) == 0) {
-        _ZN12CylinderClsn6UpdateEv(c + 0x110);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+    if (*(unsigned char*)(_ZN5Actor13ClosestPlayerEv(((char*)this)) + 0x6fb) == 0) {
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
     }
     return 1;
-}
 }

--- a/src/_ZN10ChainChompD0Ev.cpp
+++ b/src/_ZN10ChainChompD0Ev.cpp
@@ -1,27 +1,31 @@
 //cpp
+// @symbol _ZN10ChainChompD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ChainChomp.h"
 extern "C" {
 extern int func_0207328c(void *p, int a, int b, void *fn);
-extern void _ZN11ShadowModelD1Ev(void *p);
-extern void _ZN9ModelAnimD1Ev(void *p);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *p);
 extern int func_ov002_020aed18(int *x);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *p, void *heap);
-extern void _ZN5ModelD1Ev(void *p);
 extern int data_ov034_021147ec[];
 extern int func_020072c0(void);
 extern int data_020a0eac;
 
-void *_ZN10ChainChompD0Ev(char *self) {
-    *(int**)self = data_ov034_021147ec;
-    func_0207328c(self + 0x578, 7, 0xc, (void*)func_020072c0);
-    func_0207328c(self + 0x524, 7, 0xc, (void*)func_020072c0);
-    func_0207328c(self + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);
-    func_0207328c(self + 0x1dc, 7, 0x50, (void*)_ZN5ModelD1Ev);
-    _ZN11ShadowModelD1Ev(self + 0x1b4);
-    _ZN9ModelAnimD1Ev(self + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev(self + 0x110);
-    func_ov002_020aed18((int*)self);
-    _ZN6Memory10DeallocateEPvP4Heap(self, *(void**)&data_020a0eac);
-    return self;
+void *_ZN10ChainChompD0Ev(struct ChainChomp *self) {
+    *(int**)((char *)self) = data_ov034_021147ec;
+    func_0207328c(((char *)self) + 0x578, 7, 0xc, (void*)func_020072c0);
+    func_0207328c(((char *)self) + 0x524, 7, 0xc, (void*)func_020072c0);
+    func_0207328c(((char *)self) + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);
+    func_0207328c(((char *)self) + 0x1dc, 7, 0x50, (void*)_ZN5ModelD1Ev);
+    _ZN11ShadowModelD1Ev((char *)&self->mShadowModel);
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aed18((int*)((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), *(void**)&data_020a0eac);
+    return ((char *)self);
 }
 }

--- a/src/_ZN10ChainChompD1Ev.c
+++ b/src/_ZN10ChainChompD1Ev.c
@@ -1,21 +1,25 @@
+// @symbol _ZN10ChainChompD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+/* recovered: named members + shared header */
+#include "ChainChomp.h"
 extern int func_0207328c(void *arr, int n, int sz, void *dtor);
 extern void func_020072c0(void);
-extern void _ZN11ShadowModelD1Ev(void *p);
-extern void _ZN5ModelD1Ev(void *p);
-extern void _ZN9ModelAnimD1Ev(void *p);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *p);
 extern int func_ov002_020aed18(int *x);
 extern void *data_ov034_021147ec[];
 
-void *_ZN10ChainChompD1Ev(char *c) {
-    *(void**)c = data_ov034_021147ec;
-    func_0207328c(c + 0x578, 7, 0xc, (void*)func_020072c0);
-    func_0207328c(c + 0x524, 7, 0xc, (void*)func_020072c0);
-    func_0207328c(c + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);
-    func_0207328c(c + 0x1dc, 7, 0x50, (void*)_ZN5ModelD1Ev);
-    _ZN11ShadowModelD1Ev(c + 0x1b4);
-    _ZN9ModelAnimD1Ev(c + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev(c + 0x110);
-    func_ov002_020aed18((int*)c);
-    return c;
+void *_ZN10ChainChompD1Ev(struct ChainChomp *self) {
+    *(void**)((char *)self) = data_ov034_021147ec;
+    func_0207328c(((char *)self) + 0x578, 7, 0xc, (void*)func_020072c0);
+    func_0207328c(((char *)self) + 0x524, 7, 0xc, (void*)func_020072c0);
+    func_0207328c(((char *)self) + 0x40c, 7, 0x28, (void*)_ZN11ShadowModelD1Ev);
+    func_0207328c(((char *)self) + 0x1dc, 7, 0x50, (void*)_ZN5ModelD1Ev);
+    _ZN11ShadowModelD1Ev((char *)&self->mShadowModel);
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aed18((int*)((char *)self));
+    return ((char *)self);
 }

--- a/src/_ZN10CheepCheep13InitResourcesEv.cpp
+++ b/src/_ZN10CheepCheep13InitResourcesEv.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN10CheepCheep13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CheepCheep.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BCA_File;
 struct Actor;
-struct Vector3 { int x, y, z; };
 struct Vector3_16;
 
 extern struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
@@ -21,31 +25,31 @@ extern struct SharedFilePtr data_ov090_02134564;
 struct AnimFilePtr { int a; struct BCA_File *file; };
 extern struct AnimFilePtr data_ov090_0213455c;
 extern struct Vector3 data_ov090_021342d8;
-extern int data_ov090_02134594;
 
-extern "C" int _ZN10CheepCheep13InitResourcesEv(char *self) {
+int CheepCheep::InitResources()
+{
     struct BMD_File *bmd;
     struct Vector3 v;
 
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov090_02134564);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii((void *)(self + 0x30c), bmd, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii((void *)((char *)&mModelAnim), bmd, 1, -1);
 
     _ZN9Animation8LoadFileER13SharedFilePtr(*(struct SharedFilePtr *)&data_ov090_0213455c);
 
     v = data_ov090_021342d8;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-        (void *)(self + 0x110), (struct Actor *)self, v, 0x32000, 0x3c000, 0x200004, 0x8000);
+        (void *)((char *)&mMovingCylinderClsnWithPos), (struct Actor *)((char *)this), v, 0x32000, 0x3c000, 0x200004, 0x8000);
 
-    *(int *)(self + 0x374) = *(int *)(self + 0x5c);
-    *(int *)(self + 0x378) = *(int *)(self + 0x60);
-    *(int *)(self + 0x37c) = *(int *)(self + 0x64);
-    *(short *)(self + 0x8e) = *(short *)(self + 0x94);
+    unk_374 = mPosX;
+    unk_378 = mPosY;
+    unk_37c = mPosZ;
+    unk_08e = unk_094;
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
-        (void *)(self + 0x150), (struct Actor *)self, 0x1e000, 0x1e000, 0, 0);
+        (void *)((char *)&mWithMeshClsn), (struct Actor *)((char *)this), 0x1e000, 0x1e000, 0, 0);
 
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
-        (void *)(self + 0x30c), data_ov090_0213455c.file, 0, 0x1000, 0);
+        (void *)((char *)&mModelAnim), data_ov090_0213455c.file, 0, 0x1000, 0);
 
-    func_ov090_021332e8(self, &data_ov090_02134594);
+    func_ov090_021332e8(((char *)this), &data_ov090_02134594);
     return 1;
 }

--- a/src/_ZN10CheepCheep6RenderEv.cpp
+++ b/src/_ZN10CheepCheep6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10CheepCheep6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "CheepCheep.h"
 struct Obj {
     virtual void m0();
     virtual void m1();
@@ -7,10 +10,12 @@ struct Obj {
     virtual void m4();
     virtual void Target(int);
 };
-extern "C" int _ZN10CheepCheep6RenderEv(char *c) {
-    int b = ((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
+
+int CheepCheep::Render()
+{
+    int b = ((unk_0b0 & 0x40000) != 0);
     if (b) return 1;
-    Obj *o = (Obj*)(c+0x30c);
+    Obj *o = (Obj*)((char *)&mModelAnim);
     o->Target(0);
     return 1;
 }

--- a/src/_ZN10CheepCheep8BehaviorEv.cpp
+++ b/src/_ZN10CheepCheep8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN10CheepCheep8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CheepCheep.h"
 struct WithMeshClsn;
 struct CylinderClsn;
 struct Enemy;
@@ -10,20 +15,18 @@ typedef unsigned int u32;
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
-extern void func_ov090_02133338(char *c);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(Enemy *thiz, void *clsn);
 extern void _ZN9Animation7AdvanceEv(void *thiz);
-extern void func_ov090_021330c8(char *thiz);
 extern char *_ZN5Actor13ClosestPlayerEv(Enemy *thiz);
 }
 
 struct Enemy { char pad[0x800]; };
 
-extern "C" int _ZN10CheepCheep8BehaviorEv(Enemy *thiz)
+int CheepCheep::Behavior()
 {
-    char *c = (char *)thiz;
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x150)) != 0) {
+    char *c = (char *)((Enemy *)this);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x150)) != 0) {
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         if (*(unsigned char *)(c + 0x107) != 0) {
             if (*(unsigned short *)(c + 0x104) == 0) {
@@ -35,10 +38,10 @@ extern "C" int _ZN10CheepCheep8BehaviorEv(Enemy *thiz)
     }
 
     DecIfAbove0_Short((unsigned short *)(c + 0x100));
-    _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, (void *)(c + 0x110));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((Enemy *)this), (void *)(c + 0x110));
     {
         Holder *q = *(Holder **)(c + 0x370);
-        if (q->fn != 0) (thiz->*(q->fn))();
+        if (q->fn != 0) (((Enemy *)this)->*(q->fn))();
     }
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     *(int *)(c + 0x368) = 0x1000;
@@ -47,7 +50,7 @@ extern "C" int _ZN10CheepCheep8BehaviorEv(Enemy *thiz)
     func_ov090_021330c8(c);
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {
-        char *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        char *p = _ZN5Actor13ClosestPlayerEv(((Enemy *)this));
         if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
             _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }

--- a/src/_ZN10CheepCheepD0Ev.c
+++ b/src/_ZN10CheepCheepD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10CheepCheepD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daPukupuku_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10CheepCheepD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daPukupuku_c;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN10CheepCheepD1Ev.c
+++ b/src/_ZN10CheepCheepD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10CheepCheepD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10CheepCheep */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10CheepCheepD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10CheepCheep;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN10ClsnResultC1Ev.c
+++ b/src/_ZN10ClsnResultC1Ev.c
@@ -1,10 +1,11 @@
-extern void func_02037f18(void *);
-extern void func_020380c0(void *);
-extern int VT0[];
-int *_ZN10ClsnResultC1Ev(int *t)
-{
-    func_02037f18((char *)t + 0x4);
-    t[0] = (int)VT0;
-    func_020380c0(t);
-    return t;
+// @symbol _ZN10ClsnResultC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ClsnResult.h"
+int *_ZN10ClsnResultC1Ev(struct ClsnResult *self) {
+    func_02037f18((char *)&self->unk_004);
+    ((int *)self)[0] = (int)VT0;
+    func_020380c0(((int *)self));
+    return ((int *)self);
 }

--- a/src/_ZN10ClsnResultD1Ev.c
+++ b/src/_ZN10ClsnResultD1Ev.c
@@ -1,8 +1,10 @@
-extern void func_02037ee4(void *);
-extern int VT0[];
-int *_ZN10ClsnResultD1Ev(int *t)
-{
-    t[0] = (int)VT0;
-    func_02037ee4((char *)t + 0x4);
-    return t;
+// @symbol _ZN10ClsnResultD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ClsnResult.h"
+int *_ZN10ClsnResultD1Ev(struct ClsnResult *self) {
+    ((int *)self)[0] = (int)VT0;
+    func_02037ee4((char *)&self->unk_004);
+    return ((int *)self);
 }

--- a/src/_ZN10ClsnResultaSERKS_.cpp
+++ b/src/_ZN10ClsnResultaSERKS_.cpp
@@ -1,14 +1,16 @@
 //cpp
-extern "C" char *_ZN10ClsnResultaSERKS_(char *thiz, const char *o)
-{
-    *(long long *)(thiz + 4) = *(const long long *)(o + 4);
-    *(int *)(thiz + 0xc) = *(const int *)(o + 0xc);
-    *(int *)(thiz + 0x10) = *(const int *)(o + 0x10);
-    *(int *)(thiz + 0x14) = *(const int *)(o + 0x14);
-    *(unsigned short *)(thiz + 0x18) = *(const unsigned short *)(o + 0x18);
-    *(unsigned short *)(thiz + 0x1a) = *(const unsigned short *)(o + 0x1a);
-    *(int *)(thiz + 0x1c) = *(const int *)(o + 0x1c);
-    *(int *)(thiz + 0x20) = *(const int *)(o + 0x20);
-    *(int *)(thiz + 0x24) = *(const int *)(o + 0x24);
-    return thiz;
+// @symbol _ZN10ClsnResultaSERKS_
+/* recovered: named members + shared header */
+#include "ClsnResult.h"
+extern "C" char *_ZN10ClsnResultaSERKS_(struct ClsnResult *self, const char *o) {
+    self->unk_004 = *(const long long *)(o + 4);
+    self->unk_00c = *(const int *)(o + 0xc);
+    self->unk_010 = *(const int *)(o + 0x10);
+    self->unk_014 = *(const int *)(o + 0x14);
+    self->unk_018 = *(const unsigned short *)(o + 0x18);
+    self->unk_01a = *(const unsigned short *)(o + 0x1a);
+    self->unk_01c = *(const int *)(o + 0x1c);
+    self->unk_020 = *(const int *)(o + 0x20);
+    self->unk_024 = *(const int *)(o + 0x24);
+    return ((char *)self);
 }

--- a/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN10DonutBlock16CleanupResourcesEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN10DonutBlock16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "DonutBlock.h"
 extern "C" {
 extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int* data_ov036_02113d78[];
-int _ZN10DonutBlock16CleanupResourcesEv(void* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124)) _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
+}
+
+int DonutBlock::CleanupResources()
+{
+  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[0]);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113d78[1]);
   return 1;
-}
 }

--- a/src/_ZN10DonutBlock6RenderEv.cpp
+++ b/src/_ZN10DonutBlock6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN10DonutBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "DonutBlock.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN10DonutBlock6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int DonutBlock::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN10DonutBlock8BehaviorEv.cpp
+++ b/src/_ZN10DonutBlock8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10DonutBlock8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "DonutBlock.h"
 typedef int Fix12;
 struct MeshColliderBase { bool IsEnabled(); void Disable(); };
 struct Platform {
@@ -7,18 +10,18 @@ struct Platform {
     void UpdateClsnPosAndRot();
 };
 
-extern "C" int _ZN10DonutBlock8BehaviorEv(char *c)
+int DonutBlock::Behavior()
 {
-    short *s = (short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
-    short *t = (short *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF);
+    short *s = (short *)(((int)((char *)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+    short *t = (short *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFF);
     *s = (short)(*s + t[0x1e / 2]);
-    int b = (int)((*(int *)(c + 0xb0) & 8) != 0);
+    int b = (int)((unk_0b0 & 8) != 0);
     if (b != 0) {
-        if (((MeshColliderBase *)(c + 0x124))->IsEnabled())
-            ((MeshColliderBase *)(c + 0x124))->Disable();
+        if (((MeshColliderBase *)((char *)&mMeshCollider))->IsEnabled())
+            ((MeshColliderBase *)((char *)&mMeshCollider))->Disable();
         return 1;
     }
-    Platform *p = (Platform *)c;
+    Platform *p = (Platform *)((char *)this);
     p->UpdateModelPosAndRotY();
     if (p->IsClsnInRange(0, 0))
         p->UpdateClsnPosAndRot();

--- a/src/_ZN10DonutBlockD0Ev.c
+++ b/src/_ZN10DonutBlockD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10DonutBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjRc_Guruguru_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10DonutBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjRc_Guruguru_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10DonutBlockD1Ev.c
+++ b/src/_ZN10DonutBlockD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10DonutBlockD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjRc_Guruguru_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10DonutBlockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjRc_Guruguru_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10FaderColor11AdvanceFadeEv.cpp
+++ b/src/_ZN10FaderColor11AdvanceFadeEv.cpp
@@ -1,18 +1,22 @@
 //cpp
+// @symbol _ZN10FaderColor11AdvanceFadeEv
+/* recovered: named members + shared header, real C++ method */
+#include "FaderColor.h"
 extern "C" {
 
 void _ZN5Fader13AdvanceInterpEv(void* thiz);
 void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short* p, unsigned short a, int b);
+}
 
-void _ZN10FaderColor11AdvanceFadeEv(char* thiz)
+void FaderColor::AdvanceFade()
 {
-    int old = *(int*)(thiz + 4);
-    _ZN5Fader13AdvanceInterpEv(thiz);
-    if (*(int*)(thiz + 4) == old) return;
+    int old = unk_004;
+    _ZN5Fader13AdvanceInterpEv(((char*)this));
+    if (unk_004 == old) return;
     {
-        unsigned short color = *(unsigned short*)(thiz + 0xc);
+        unsigned short color = unk_00c;
         int m = color ? 0x10 : -0x10;
-        int r = (*(int*)(thiz + 4) * m) >> 12;
+        int r = (unk_004 * m) >> 12;
         if (r != 0) {
             _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4000050, 0x3f, r);
             _ZN3G2x18SetBlendBrightnessEPVtts((volatile unsigned short*)0x4001050, 0x3f, r);
@@ -21,6 +25,4 @@ void _ZN10FaderColor11AdvanceFadeEv(char* thiz)
             *(unsigned short*)0x4001050 = 0;
         }
     }
-}
-
 }

--- a/src/_ZN10FaderColorD1Ev.c
+++ b/src/_ZN10FaderColorD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN10FaderColorD1Ev
+/* recovered: named members + shared header */
+#include "FaderColor.h"
 /* FaderColor::~FaderColor() at 0x020175c4
  * Sets self->vtable to the FaderColor vtable, delegates to the base-subobject
  * destructor (func_020177c4, shared with Color::~Color), and returns self

--- a/src/_ZN10FlameChomp6RenderEv.cpp
+++ b/src/_ZN10FlameChomp6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN10FlameChomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChomp.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void M(void*); };
 struct Sub : Base { };
 struct C { char p1[0xd4]; Sub sub; };
-extern "C" int _ZN10FlameChomp6RenderEv(C* c){
-  c->sub.M((char*)c+0x80);
+
+int FlameChomp::Render()
+{
+  ((C*)this)->sub.M((char*)&mScaleX);
   return 1;
 }

--- a/src/_ZN10FlameChompD0Ev.c
+++ b/src/_ZN10FlameChompD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10FlameChompD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daKrpa_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10FlameChompD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daKrpa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1a0);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x160);
     _ZN11ShadowModelD1Ev((char *)t + 0x138);

--- a/src/_ZN10HootTheOwl6RenderEv.cpp
+++ b/src/_ZN10HootTheOwl6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10HootTheOwl6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "HootTheOwl.h"
 extern "C" {
 extern char data_ov094_02136b40[];
 }
@@ -10,8 +13,10 @@ struct O {
   virtual void m4();
   virtual void m5(int);
 };
-extern "C" int _ZN10HootTheOwl6RenderEv(char *t){
-  if(*(void**)(t+0x3c8) == (void*)data_ov094_02136b40) return 1;
-  ((O*)(t+0x30c))->m5(0);
+
+int HootTheOwl::Render()
+{
+  if(*(void**)((char *)&mCurrentState) == (void*)data_ov094_02136b40) return 1;
+  ((O*)((char *)&mModelAnim))->m5(0);
   return 1;
 }

--- a/src/_ZN10HootTheOwl8BehaviorEv.cpp
+++ b/src/_ZN10HootTheOwl8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN10HootTheOwl8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HootTheOwl.h"
 struct C3;
 typedef void (C3::*Fn)();
 struct Obj { char pad[8]; Fn fn; };
@@ -6,70 +11,64 @@ extern "C" {
 extern void DecIfAbove0_Short(void*);
 extern void _ZN9Animation7AdvanceEv(void*);
 extern void func_02012694(int, void*);
-extern void func_ov094_021362e0(void*);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void*, void*, unsigned int);
-extern void func_ov094_021361d8(void*);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void*, void*);
-extern int func_ov096_021357a4(void*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
 extern void _ZN12CylinderClsn6UpdateEv(void*);
 
 extern char data_ov094_02136b40[];
-extern char data_ov094_02136b50[];
 extern char data_ov094_02136b60[];
-extern char data_ov094_02136b30[];
-extern char data_ov094_02136b70[];
 }
 
-extern "C" int _ZN10HootTheOwl8BehaviorEv(char *c)
+int HootTheOwl::Behavior()
 {
-    DecIfAbove0_Short(c+0x100);
+    DecIfAbove0_Short((char *)&unk_100);
     {
-        Obj *o = *(Obj**)(c+0x3c8);
+        Obj *o = *(Obj**)((char *)&mCurrentState);
         if (*(int*)((char*)o+8) != 0) {
-            (((C3*)c)->*(o->fn))();
+            (((C3*)((char *)this))->*(o->fn))();
         }
     }
-    if (*(char**)(c+0x3c8) == data_ov094_02136b40) return 1;
-    *(int*)(c+0x368) = *(int*)(c+0x3f0);
-    _ZN9Animation7AdvanceEv(c+0x35c);
+    if (*(char**)((char *)&mCurrentState) == data_ov094_02136b40) return 1;
+    unk_368 = unk_3f0;
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
     {
-        char *m = *(char**)(c+0x3c8);
+        char *m = *(char**)((char *)&mCurrentState);
         if ((m == data_ov094_02136b50 || m == data_ov094_02136b60 ||
              m == data_ov094_02136b30) &&
-            (unsigned short)(*(int*)(c+0x364) >> 0xc) == 0) {
-            func_02012694(0x139, c+0x74);
+            (unsigned short)(unk_364 >> 0xc) == 0) {
+            func_02012694(0x139, ((char *)this)+0x74);
         }
     }
-    if (*(char**)(c+0x3c8) == data_ov094_02136b70) {
-        if (*(char**)(c+0x3c8) == data_ov094_02136b70) {
-            func_ov094_021362e0(c);
-            *(short*)(c+0x8c) = *(short*)(c+0x92);
-            *(short*)(c+0x8e) = *(short*)(c+0x94);
-            *(short*)(c+0x90) = *(short*)(c+0x96);
-            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c+0x150, 0);
+    if (*(char**)((char *)&mCurrentState) == data_ov094_02136b70) {
+        if (*(char**)((char *)&mCurrentState) == data_ov094_02136b70) {
+            func_ov094_021362e0(((char *)this));
+            unk_08c = unk_092;
+            unk_08e = unk_094;
+            unk_090 = unk_096;
+            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char *)this), ((char *)this)+0x150, 0);
         } else {
-            func_ov094_021361d8(c);
+            func_ov094_021361d8(((char *)this));
         }
         return 1;
     }
     {
-        int s = *(int*)(c+0xa8) + *(int*)(c+0x9c);
-        int m2 = *(int*)(c+0xa0);
-        int ac = *(int*)(c+0xac);
+        int s = unk_0a8 + unk_09c;
+        int m2 = unk_0a0;
+        int ac = unk_0ac;
         if (s >= m2) m2 = s;
-        *(int*)(c+0xa8) = m2;
-        *(int*)(c+0xac) = ac;
+        unk_0a8 = m2;
+        unk_0ac = ac;
     }
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, c+0x110);
-    *(short*)(c+0x8c) = *(short*)(c+0x92);
-    *(short*)(c+0x8e) = *(short*)(c+0x94);
-    *(short*)(c+0x90) = *(short*)(c+0x96);
-    func_ov094_021361d8(c);
-    if (*(char**)(c+0x3c8) == data_ov094_02136b60 && *(unsigned char*)(c+0x3d4) == 2) {
-        func_ov096_021357a4(c);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((char *)this), ((char *)this)+0x110);
+    unk_08c = unk_092;
+    unk_08e = unk_094;
+    unk_090 = unk_096;
+    func_ov094_021361d8(((char *)this));
+    if (*(char**)((char *)&mCurrentState) == data_ov094_02136b60 && unk_3d4 == 2) {
+        func_ov096_021357a4(((char *)this));
     }
-    _ZN12CylinderClsn5ClearEv(c+0x110);
-    _ZN12CylinderClsn6UpdateEv(c+0x110);
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);
     return 1;
 }

--- a/src/_ZN10HootTheOwlD0Ev.c
+++ b/src/_ZN10HootTheOwlD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10HootTheOwlD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daOwl_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10HootTheOwlD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daOwl_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZN10HootTheOwlD1Ev.c
+++ b/src/_ZN10HootTheOwlD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10HootTheOwlD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10HootTheOwl */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10HootTheOwlD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10HootTheOwl;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZN10KingBobOmb8BehaviorEv.cpp
+++ b/src/_ZN10KingBobOmb8BehaviorEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN10KingBobOmb8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "KingBobOmb.h"
 struct C; typedef int (C::*PMF)();
 struct C { char pad[0x420]; PMF *pp; };
 
-struct Vector3 { int x, y, z; };
 
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); };
 struct Derived { char pad[0x2cc]; Base base; };
@@ -10,8 +14,6 @@ struct Derived { char pad[0x2cc]; Base base; };
 extern "C" {
 extern int _ZN5Actor13DistToCPlayerEv(void *self);
 extern void _ZN14BlendModelAnim7AdvanceEv(void *self);
-extern void func_ov078_02125de0(char *c);
-extern int func_ov078_02125c98(void *c);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern unsigned char DecIfAbove0_Byte(unsigned char *p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
@@ -26,23 +28,21 @@ extern void _ZN12CylinderClsn6UpdateEv(void *self);
 
 extern void *data_0209f318;
 extern char data_ov078_0212707c[];
-extern char data_ov078_021270bc[];
 extern char data_ov078_0212703c[];
 extern char data_ov078_021270fc[];
-extern Vector3 data_ov078_02126e00;
 }
 
-extern "C" int _ZN10KingBobOmb8BehaviorEv(C *c)
+int KingBobOmb::Behavior()
 {
-    char *self = (char *)c;
+    char *self = (char *)((C *)this);
 
-    if (_ZN5Actor13DistToCPlayerEv(c) < 0x1770000) {
-        *(C **)((char *)data_0209f318 + 0x114) = c;
+    if (_ZN5Actor13DistToCPlayerEv(((C *)this)) < 0x1770000) {
+        *(C **)((char *)data_0209f318 + 0x114) = ((C *)this);
     }
 
-    if (*(void **)((char *)c->pp + 8) != 0) {
-        PMF *p = c->pp + 1;
-        (c->**p)();
+    if (*(void **)((char *)((C *)this)->pp + 8) != 0) {
+        PMF *p = ((C *)this)->pp + 1;
+        (((C *)this)->**p)();
     }
 
     {
@@ -52,7 +52,7 @@ extern "C" int _ZN10KingBobOmb8BehaviorEv(C *c)
     }
     _ZN14BlendModelAnim7AdvanceEv(self + 0x2cc);
 
-    if ((char *)c->pp == data_ov078_0212707c) {
+    if ((char *)((C *)this)->pp == data_ov078_0212707c) {
         void *r1 = *(void **)(self + 0x494);
         int b;
         if (r1 != 0) {
@@ -71,17 +71,17 @@ extern "C" int _ZN10KingBobOmb8BehaviorEv(C *c)
     DecIfAbove0_Byte((unsigned char *)(self + 0x505));
     DecIfAbove0_Byte((unsigned char *)(self + 0x504));
 
-    if ((char *)c->pp != data_ov078_021270bc) {
+    if ((char *)((C *)this)->pp != data_ov078_021270bc) {
         _ZN5Actor9UpdatePosEP12CylinderClsn(self, self + 0x33c);
     } else {
         _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(self, self + 0x33c);
     }
 
-    if ((char *)c->pp != data_ov078_021270bc || *(unsigned char *)(self + 0x499) == 1) {
+    if ((char *)((C *)this)->pp != data_ov078_021270bc || *(unsigned char *)(self + 0x499) == 1) {
         _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(self, self + 0x110, 0);
     }
 
-    if ((char *)c->pp == data_ov078_0212703c || (char *)c->pp == data_ov078_021270fc) {
+    if ((char *)((C *)this)->pp == data_ov078_0212703c || (char *)((C *)this)->pp == data_ov078_021270fc) {
         if (_ZNK12WithMeshClsn8IsOnWallEv(self + 0x110) != 0
             || _ZNK12WithMeshClsn10IsOnGroundEv(self + 0x110) == 0
             || (*(int *)(self + 0x4d8) - 0x28000) > *(int *)(self + 0x60)) {

--- a/src/_ZN10KingBobOmbD0Ev.c
+++ b/src/_ZN10KingBobOmbD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN11CommonModelD1Ev(void *);
+// @symbol _ZN10KingBobOmbD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBombking_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN14BlendModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10KingBobOmbD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBombking_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3f8);
     _ZN11CommonModelD1Ev((char *)t + 0x3bc);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x37c);

--- a/src/_ZN10KingBobOmbD1Ev.c
+++ b/src/_ZN10KingBobOmbD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN11CommonModelD1Ev(void *);
+// @symbol _ZN10KingBobOmbD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10KingBobOmb */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN14BlendModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10KingBobOmbD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10KingBobOmb;
     _ZN11ShadowModelD1Ev((char *)t + 0x3f8);
     _ZN11CommonModelD1Ev((char *)t + 0x3bc);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x37c);

--- a/src/_ZN10KoopaShellD0Ev.c
+++ b/src/_ZN10KoopaShellD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10KoopaShellD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daShl_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10KoopaShellD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daShl_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x378);
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);

--- a/src/_ZN10KoopaShellD1Ev.c
+++ b/src/_ZN10KoopaShellD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10KoopaShellD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10KoopaShell */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10KoopaShellD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10KoopaShell;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x378);
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);

--- a/src/_ZN10LavaBubble8BehaviorEv.cpp
+++ b/src/_ZN10LavaBubble8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10LavaBubble8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "LavaBubble.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef int Fix12;
@@ -19,15 +22,15 @@ void _ZN12CylinderClsn5ClearEv(CylinderClsn* self);
 void _ZN12CylinderClsn6UpdateEv(CylinderClsn* self);
 }
 
-extern "C" int _ZN10LavaBubble8BehaviorEv(char* c)
+int LavaBubble::Behavior()
 {
-    int flags = *(int*)(c + 0xb0);
+    int flags = unk_0b0;
     int b20 = (flags & 0x20000) != 0;
 
     if (b20) {
-        M* m = *(M**)(c + 0x300);
+        M* m = *(M**)((char*)&unk_300);
         if (m->pmf != 0)
-            (((Klass*)c)->*(m->pmf))();
+            (((Klass*)((char*)this))->*(m->pmf))();
         return 1;
     }
 
@@ -37,18 +40,18 @@ extern "C" int _ZN10LavaBubble8BehaviorEv(char* c)
             return 1;
     }
 
-    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, 0x5dc000)) {
-        if (*(u8*)(c + 0x310) != 0)
-            _ZN9ActorBase18MarkForDestructionEv(c);
+    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(((char*)this), 0x5dc000)) {
+        if (unk_310 != 0)
+            _ZN9ActorBase18MarkForDestructionEv(((char*)this));
         return 1;
     }
 
-    DecIfAbove0_Short((unsigned short*)(c + 0x100));
+    DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
 
     {
-        unsigned int id = *(unsigned int*)(c + 0x134);
+        unsigned int id = unk_134;
         if (id != 0) {
-            if ((*(int*)(c + 0x130) & 0x8000) == 0) {
+            if ((unk_130 & 0x8000) == 0) {
                 char* a = (char*)_ZN5Actor10FindWithIDEj(id);
                 if (a != 0) {
                     int hit = (*(u16*)(a + 0xc) == 0xbf);
@@ -56,23 +59,23 @@ extern "C" int _ZN10LavaBubble8BehaviorEv(char* c)
                         _ZN6Player4BurnEv(a);
                 }
             } else {
-                *(int*)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+                *(int*)(((long long)(int)((char*)&unk_128))) |= 1;
             }
         }
     }
 
     {
-        M* m = *(M**)(c + 0x300);
+        M* m = *(M**)((char*)&unk_300);
         if (m->pmf != 0)
-            (((Klass*)c)->*(m->pmf))();
+            (((Klass*)((char*)this))->*(m->pmf))();
     }
 
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, (CylinderClsn*)(c + 0x110));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), (CylinderClsn*)((char*)&mMovingCylinderClsn));
 
-    if (*(int*)(c + 0x9c) != 0)
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (WithMeshClsn*)(c + 0x144), 0);
+    if (unk_09c != 0)
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char*)this), (WithMeshClsn*)((char*)&mWithMeshClsn), 0);
 
-    _ZN12CylinderClsn5ClearEv((CylinderClsn*)(c + 0x110));
-    _ZN12CylinderClsn6UpdateEv((CylinderClsn*)(c + 0x110));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn*)((char*)&mMovingCylinderClsn));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn*)((char*)&mMovingCylinderClsn));
     return 1;
 }

--- a/src/_ZN10LavaBubbleD0Ev.c
+++ b/src/_ZN10LavaBubbleD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN10LavaBubbleD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daBbl_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10LavaBubbleD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daBbl_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN10LavaBubbleD1Ev.c
+++ b/src/_ZN10LavaBubbleD1Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN10LavaBubbleD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10LavaBubble */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10LavaBubbleD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10LavaBubble;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN10ModelAnim24CopyERKS_Pcj.c
+++ b/src/_ZN10ModelAnim24CopyERKS_Pcj.c
@@ -1,18 +1,21 @@
+// @symbol _ZN10ModelAnim24CopyERKS_Pcj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_ModelAnim.h"
+/* recovered: named members + shared header */
+#include "ModelAnim2.h"
 /* _ZN10ModelAnim24CopyERKS_Pcj at 0x02016254
  * ModelAnim2::Copy(const ModelAnim2& src, char* newFile, u32 newUnk64):
  *   copy ModelAnim base (r0=this, r1=src, r2=newFile passed through),
  *   then copy the otherAnim Animation subobject at +0x68 from src's +0x50,
  *   then set unk64 at +0x64 from newUnk64 (if nonzero) or from src->unk64.
  */
-extern void _ZN9ModelAnim4CopyERKS_Pc(void *thiz, const void *src, void *newFile);
-extern void _ZN9Animation4CopyERKS_(void *thiz, const void *src);
 
-void _ZN10ModelAnim24CopyERKS_Pcj(void *thiz, const void *src, void *newFile, unsigned int newUnk64)
-{
-    _ZN9ModelAnim4CopyERKS_Pc(thiz, src, newFile);
-    _ZN9Animation4CopyERKS_((char *)thiz + 0x68, (const char *)src + 0x50);
+void _ZN10ModelAnim24CopyERKS_Pcj(struct ModelAnim2 *self, const void *src, void *newFile, unsigned int newUnk64) {
+    _ZN9ModelAnim4CopyERKS_Pc(((void *)self), src, newFile);
+    _ZN9Animation4CopyERKS_((char *)((void *)self) + 0x68, (const char *)src + 0x50);
     if (newUnk64)
-        *(unsigned int *)((char *)thiz + 0x64) = newUnk64;
+        *(unsigned int *)((char *)&self->unk_064) = newUnk64;
     else
-        *(unsigned int *)((char *)thiz + 0x64) = *(const unsigned int *)((const char *)src + 0x64);
+        *(unsigned int *)((char *)&self->unk_064) = *(const unsigned int *)((const char *)src + 0x64);
 }

--- a/src/_ZN10MrBlizzard8BehaviorEv.cpp
+++ b/src/_ZN10MrBlizzard8BehaviorEv.cpp
@@ -1,33 +1,34 @@
 //cpp
+// @symbol _ZN10MrBlizzard8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SaveData.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MrBlizzard.h"
 struct C;
 typedef int (C::*PMF)();
 struct C { char pad[0x3f8]; PMF* pp; };
-struct Vector3 { int x, y, z; };
 extern "C" {
-extern int _ZN8SaveData16HasPlayerLostCapEv(void);
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void* self, void* wm, void* anim, unsigned n);
 extern int _ZN5Enemy11UpdateDeathER12WithMeshClsn(void* self, void* wm);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned a, unsigned b, const Vector3* v, const void* p, int e, int f);
 extern void func_02012694(int a, void* p);
-extern void func_ov081_021254d8(void* self);
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b, int c, int d);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cyl);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* self, void* wm, unsigned n);
-extern void func_ov081_021243cc(void* self);
 extern void _ZN12CylinderClsn5ClearEv(void* self);
 extern void _ZN12CylinderClsn6UpdateEv(void* self);
 extern void _ZN9Animation7AdvanceEv(void* self);
-extern char data_ov081_02128e94;
 extern char data_ov081_02128e24;
 extern char data_ov081_02128e84;
 extern char data_ov081_02128e64;
 }
 
-extern "C" int _ZN10MrBlizzard8BehaviorEv(C* self)
+int MrBlizzard::Behavior()
 {
-    char* c = (char*)self;
+    char* c = (char*)((C*)this);
     void* r5;
     char* p;
     if (*(int*)(c + 0x41c) == 3) {
@@ -59,8 +60,8 @@ extern "C" int _ZN10MrBlizzard8BehaviorEv(C* self)
         return 1;
     }
     if (*(int*)(c + 0x41c) == 2
-        && (char*)self->pp != &data_ov081_02128e94
-        && (char*)self->pp != &data_ov081_02128e24
+        && (char*)((C*)this)->pp != &data_ov081_02128e94
+        && (char*)((C*)this)->pp != &data_ov081_02128e24
         && _ZN8SaveData16HasPlayerLostCapEv()
         && *(int*)(c + 0x400) == 0) {
 
@@ -81,18 +82,18 @@ extern "C" int _ZN10MrBlizzard8BehaviorEv(C* self)
     *(short*)(c + 0x8e) = *(short*)(c + 0x94);
     *(short*)(c + 0x90) = *(short*)(c + 0x96);
     DecIfAbove0_Short((unsigned short*)(c + 0x100));
-    if (*(void**)((char*)self->pp + 8) != 0) {
-        PMF* p = self->pp + 1;
-        (self->**p)();
+    if (*(void**)((char*)((C*)this)->pp + 8) != 0) {
+        PMF* p = ((C*)this)->pp + 1;
+        (((C*)this)->**p)();
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
     if (*(int*)(c + 0x41c) == 0)
         _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x150, 0);
     func_ov081_021254d8(c);
-    if ((char*)self->pp != &data_ov081_02128e84
-        && (char*)self->pp != &data_ov081_02128e64
-        && (char*)self->pp != &data_ov081_02128e94
-        && (char*)self->pp != &data_ov081_02128e24)
+    if ((char*)((C*)this)->pp != &data_ov081_02128e84
+        && (char*)((C*)this)->pp != &data_ov081_02128e64
+        && (char*)((C*)this)->pp != &data_ov081_02128e94
+        && (char*)((C*)this)->pp != &data_ov081_02128e24)
         func_ov081_021243cc(c);
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {

--- a/src/_ZN10MrBlizzardD0Ev.c
+++ b/src/_ZN10MrBlizzardD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10MrBlizzardD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daSnowman_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10MrBlizzardD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daSnowman_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZN10MrBlizzardD1Ev.c
+++ b/src/_ZN10MrBlizzardD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN10MrBlizzardD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV10MrBlizzard */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN10MrBlizzardD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10MrBlizzard;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZN10PyramidTag13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTag13InitResourcesEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN10PyramidTag13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidTag.h"
 extern "C" {
 int _ZN5Actor15FindWithActorIDEjPS_(unsigned int, void*);
 void _ZN9ActorBase18MarkForDestructionEv(void*);
 void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
-int _ZN10PyramidTag13InitResourcesEv(char* self){
-    int a = _ZN5Actor15FindWithActorIDEjPS_(0x55, 0);
-    if(a == 0){ _ZN9ActorBase18MarkForDestructionEv(self); return 1; }
-    *(int*)(self+0x108) = *(int*)(a+4);
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self+0xd4, self, 0x7d000, 0x28000, 2, 0x400000);
-    return 1;
 }
+
+int PyramidTag::InitResources()
+{
+    int a = _ZN5Actor15FindWithActorIDEjPS_(0x55, 0);
+    if(a == 0){ _ZN9ActorBase18MarkForDestructionEv(((char*)this)); return 1; }
+    unk_108 = *(int*)(a+4);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0xd4, ((char*)this), 0x7d000, 0x28000, 2, 0x400000);
+    return 1;
 }

--- a/src/_ZN10PyramidTag8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTag8BehaviorEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN10PyramidTag8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidTag.h"
 extern "C" {
 extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN12CylinderClsn5ClearEv(void* a);
 extern void _ZN12CylinderClsn6UpdateEv(void* a);
+}
 
-int _ZN10PyramidTag8BehaviorEv(char* c){
-  if(*(int*)(c+0xf8) != 0){
-    unsigned int id = *(unsigned int*)(c+0x108);
+int PyramidTag::Behavior()
+{
+  if(unk_0f8 != 0){
+    unsigned int id = unk_108;
     if(id == 0){
-      _ZN9ActorBase18MarkForDestructionEv(c);
+      _ZN9ActorBase18MarkForDestructionEv(((char*)this));
       return 1;
     }
     char* a = _ZN5Actor10FindWithIDEj(id);
@@ -17,11 +22,10 @@ int _ZN10PyramidTag8BehaviorEv(char* c){
       unsigned char* p = (unsigned char*)(((int)a + 0x3b6) & 0xFFFFFFFFFFFFFFFF);
       *p += 1;
     }
-    _ZN9ActorBase18MarkForDestructionEv(c);
+    _ZN9ActorBase18MarkForDestructionEv(((char*)this));
     return 1;
   }
-  _ZN12CylinderClsn5ClearEv(c+0xd4);
-  _ZN12CylinderClsn6UpdateEv(c+0xd4);
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
   return 1;
-}
 }

--- a/src/_ZN10PyramidTagD0Ev.c
+++ b/src/_ZN10PyramidTagD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN10PyramidTagD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjDlPyramidDummy_c */
 extern void *G0;
 int *_ZN10PyramidTagD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV21daObjDlPyramidDummy_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN10PyramidTop13InitResourcesEv.cpp
+++ b/src/_ZN10PyramidTop13InitResourcesEv.cpp
@@ -1,39 +1,39 @@
 //cpp
+// @symbol _ZN10PyramidTop13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidTop.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
-extern void func_ov024_021114c4(char* t);
-extern void func_ov024_02111480(char* c);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void* thiz, void* act);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
-extern int data_ov024_02113968[];
-extern int data_ov024_02113960[];
-extern int data_ov024_021129f0[];
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
-int _ZN10PyramidTop13InitResourcesEv(char* c)
+int PyramidTop::InitResources()
 {
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov024_02113968);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x320, m, 1, -1);
-    func_ov024_021114c4(c);
-    func_ov024_02111480(c);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x320, m, 1, -1);
+    func_ov024_021114c4(((char*)this));
+    func_ov024_02111480(((char*)this));
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov024_02113960);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, mc, c + 0x370, 0x199, *(short*)(c + 0x8e), data_ov024_021129f0);
-    func_020393d4(c + 0x124, (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
-    *(int*)(c + 0x3a0) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x3a4) = *(int*)(c + 0x60);
-    *(int*)(c + 0x3a8) = *(int*)(c + 0x64);
-    *(short*)(c + 0x3b0) = 0;
-    *(unsigned char*)(c + 0x3b6) = 0;
-    *(unsigned char*)(c + 0x3b7) = 0;
-    *(int*)(c + 0x3ac) = 0;
-    *(short*)(c + 0x3b4) = 0;
+        ((char*)this) + 0x124, mc, ((char*)this) + 0x370, 0x199, unk_08e, data_ov024_021129f0);
+    func_020393d4(((char*)this) + 0x124, (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this) + 0x124, ((char*)this));
+    unk_3a0 = mPosX;
+    unk_3a4 = mPosY;
+    unk_3a8 = mPosZ;
+    unk_3b0 = 0;
+    unk_3b6 = 0;
+    unk_3b7 = 0;
+    unk_3ac = 0;
+    unk_3b4 = 0;
     _ZN5Event8ClearBitEj(0xe);
     return 1;
-}
 }

--- a/src/_ZN10PyramidTop6RenderEv.cpp
+++ b/src/_ZN10PyramidTop6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN10PyramidTop6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidTop.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x320]; Base base; };
-extern "C" int _ZN10PyramidTop6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int PyramidTop::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN10PyramidTopD0Ev.c
+++ b/src/_ZN10PyramidTopD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10PyramidTopD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10PyramidTopD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjDlPyramid_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10PyramidTopD1Ev.c
+++ b/src/_ZN10PyramidTopD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10PyramidTopD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjDlPyramid_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10PyramidTopD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjDlPyramid_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10RickshawBsD0Ev.c
+++ b/src/_ZN10RickshawBsD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10RickshawBsD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10RickshawBsD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10RickshawBsD1Ev.c
+++ b/src/_ZN10RickshawBsD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10RickshawBsD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10RickshawBsD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10Scuttlebug13InitResourcesEv.cpp
+++ b/src/_ZN10Scuttlebug13InitResourcesEv.cpp
@@ -1,28 +1,30 @@
 //cpp
+// @symbol _ZN10Scuttlebug13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Scuttlebug.h"
 struct BMD_File; struct BCA_File; struct Actor; struct Vector3_16;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
-extern "C" void AnimLoadFile(void *fp);
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor *a, int b, int c, unsigned int d, unsigned int e); };
 struct WithMeshClsn { void Init(Actor *a, int b, int c, void *d, int e); void StartDetectingWater(); };
-extern "C" char data_ov071_02122f80;
 extern "C" char data_ov071_02122f88;
 struct Blob48 { int w[12]; };
 extern "C" Blob48 data_02082128;
 extern "C" void func_ov071_021202ec(Actor *self, int type);
 extern "C" int func_ov071_0211f524(char *c);
 
-extern "C" int _ZN10Scuttlebug13InitResourcesEv(Actor *self)
+int Scuttlebug::InitResources()
 {
-    char *s = (char*)self;
+    char *s = (char*)((Actor *)this);
     void *mf = ModelLoadFile(&data_ov071_02122f80);
     ((ModelBase*)(s + 0xd4))->SetFile((BMD_File*)mf, 1, -1);
     AnimLoadFile(&data_ov071_02122f88);
     if (((ShadowModel*)(s + 0x138))->InitCylinder() == 0)
         return 0;
-    ((MovingCylinderClsn*)(s + 0x160))->Init(self, 0x46000, 0x64000, 0x200000, 0x6eff0);
-    ((WithMeshClsn*)(s + 0x194))->Init(self, 0x50000, 0x50000, 0, 0);
+    ((MovingCylinderClsn*)(s + 0x160))->Init(((Actor *)this), 0x46000, 0x64000, 0x200000, 0x6eff0);
+    ((WithMeshClsn*)(s + 0x194))->Init(((Actor *)this), 0x50000, 0x50000, 0, 0);
     ((WithMeshClsn*)(s + 0x194))->StartDetectingWater();
     *(int*)(s + 0x384) = *(int*)(s + 0x5c);
     *(int*)(s + 0x388) = *(int*)(s + 0x60);
@@ -32,9 +34,9 @@ extern "C" int _ZN10Scuttlebug13InitResourcesEv(Actor *self)
     *(int*)(s + 0x394) = *(int*)(s + 0x60);
     *(int*)(s + 0x398) = *(int*)(s + 0x64);
     if (*(int*)(s + 8) != 0)
-        func_ov071_021202ec(self, 0);
+        func_ov071_021202ec(((Actor *)this), 0);
     else
-        func_ov071_021202ec(self, 2);
+        func_ov071_021202ec(((Actor *)this), 2);
     *(char*)(s + 0x3aa) = 3;
     *(int*)(s + 0x9c) = -0x2000;
     *(int*)(s + 0xa0) = -0x3c000;

--- a/src/_ZN10Scuttlebug6RenderEv.cpp
+++ b/src/_ZN10Scuttlebug6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10Scuttlebug6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Scuttlebug.h"
 struct Sub {
     virtual int method0();
     virtual int method1();
@@ -15,14 +18,16 @@ struct Obj {
     char pad3[0x2c3];
     int state39c;
 };
-extern "C" int _ZN10Scuttlebug6RenderEv(Obj *c) {
-    int flag = (c->flags & 0x40000) ? 1 : 0;
+
+int Scuttlebug::Render()
+{
+    int flag = (((Obj *)this)->flags & 0x40000) ? 1 : 0;
     if (flag) goto ret;
-    if (!c->state39c) goto ret;
+    if (!((Obj *)this)->state39c) goto ret;
     goto call;
 ret:
     return 1;
 call:
-    c->sub.method5(0);
+    ((Obj *)this)->sub.method5(0);
     return 1;
 }

--- a/src/_ZN10Scuttlebug8BehaviorEv.cpp
+++ b/src/_ZN10Scuttlebug8BehaviorEv.cpp
@@ -1,20 +1,25 @@
 //cpp
+// @symbol _ZN10Scuttlebug8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Scuttlebug.h"
 extern "C" {
 extern void DecIfAbove0_Short(void* p);
-extern void func_ov071_02120278(char* c);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(char* self, void* clsn);
 extern int _ZNK12WithMeshClsn14GetResultFlag1Ev(void* self);
 extern int _ZNK12WithMeshClsn12TouchesWaterEv(void* self);
-extern void func_ov071_0211f498(char* c);
 extern void func_ov071_0211f524(char* c);
-int _ZN10Scuttlebug8BehaviorEv(char* c){
-  DecIfAbove0_Short(c+0x3a8);
-  func_ov071_02120278(c);
-  _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c+0x160);
-  if(_ZNK12WithMeshClsn14GetResultFlag1Ev(c+0x194) && _ZNK12WithMeshClsn12TouchesWaterEv(c+0x194)){
-    func_ov071_0211f498(c);
-  }
-  func_ov071_0211f524(c);
-  return 1;
 }
+
+int Scuttlebug::Behavior()
+{
+  DecIfAbove0_Short((char*)&unk_3a8);
+  func_ov071_02120278(((char*)this));
+  _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char*)this), ((char*)this)+0x160);
+  if(_ZNK12WithMeshClsn14GetResultFlag1Ev((char*)&mWithMeshClsn) && _ZNK12WithMeshClsn12TouchesWaterEv((char*)&mWithMeshClsn)){
+    func_ov071_0211f498(((char*)this));
+  }
+  func_ov071_0211f524(((char*)this));
+  return 1;
 }

--- a/src/_ZN10ScuttlebugD0Ev.c
+++ b/src/_ZN10ScuttlebugD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN10ScuttlebugD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daSpd_c */
 extern void *G0;
 int *_ZN10ScuttlebugD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daSpd_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN11ShadowModelD1Ev((char *)t + 0x138);

--- a/src/_ZN10ShutterBob13InitResourcesEv.cpp
+++ b/src/_ZN10ShutterBob13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10ShutterBob13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "ShutterBob.h"
 class Actor {};
 class MeshColliderBase {
 public:
@@ -8,8 +11,9 @@ public:
 extern int func_ov002_020bad10(void *c, void **f);
 extern int data_ov014_021145c4;
 
-extern "C" int _ZN10ShutterBob13InitResourcesEv(char *c) {
-    int r4 = func_ov002_020bad10(c, (void **)&data_ov014_021145c4);
-    ((MeshColliderBase *)(c + 0x124))->Enable((Actor *)c);
+int ShutterBob::InitResources()
+{
+    int r4 = func_ov002_020bad10(((char *)this), (void **)&data_ov014_021145c4);
+    ((MeshColliderBase *)((char *)&mMovingMeshCollider))->Enable((Actor *)((char *)this));
     return r4;
 }

--- a/src/_ZN10ShutterBob16CleanupResourcesEv.cpp
+++ b/src/_ZN10ShutterBob16CleanupResourcesEv.cpp
@@ -1,14 +1,18 @@
 //cpp
+// @symbol _ZN10ShutterBob16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShutterBob.h"
 // Cross-overlay tail-call veneer. #pragma long_calls forces mwccarm to emit the pooled
 // `ldr ip,[pc]; bx ip` indirect tail-call (a plain near `b` otherwise) that the ROM uses
 // to reach another overlay. Loads the data pointer into r1; this stays in r0.
 #pragma long_calls on
 extern "C" {
-extern int func_ov002_020baba8(void *thisp, void *data);
 extern char data_ov014_021145c4[];
-
-int _ZN10ShutterBob16CleanupResourcesEv(void *thisp)
-{
-    return func_ov002_020baba8(thisp, data_ov014_021145c4);
 }
+
+int ShutterBob::CleanupResources()
+{
+    return func_ov002_020baba8(((void *)this), data_ov014_021145c4);
 }

--- a/src/_ZN10ShutterBob8BehaviorEv.cpp
+++ b/src/_ZN10ShutterBob8BehaviorEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN10ShutterBob8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShutterBob.h"
 class Platform {
 public:
 void UpdateClsnPosAndRot();
 };
 
-extern "C" int func_ov002_020bac18();
 
-extern "C" int _ZN10ShutterBob8BehaviorEv(Platform *r5) {
+int ShutterBob::Behavior()
+{
 int r4 = func_ov002_020bac18();
-r5->UpdateClsnPosAndRot();
+((Platform *)this)->UpdateClsnPosAndRot();
 return r4;
 }

--- a/src/_ZN10ShutterBobD0Ev.c
+++ b/src/_ZN10ShutterBobD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10ShutterBobD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10ShutterBobD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjBSwdoor_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterBobD1Ev.c
+++ b/src/_ZN10ShutterBobD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10ShutterBobD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBSwdoor_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10ShutterBobD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjBSwdoor_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterHmc8BehaviorEv.cpp
+++ b/src/_ZN10ShutterHmc8BehaviorEv.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol _ZN10ShutterHmc8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "ShutterHmc.h"
 extern "C" {
 int func_ov002_020bac18(void);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-int _ZN10ShutterHmc8BehaviorEv(void* c){
-  int r = func_ov002_020bac18();
-  if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  return r;
 }
+
+int ShutterHmc::Behavior()
+{
+  int r = func_ov002_020bac18();
+  if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((void*)this), 0, 0))
+    _ZN8Platform19UpdateClsnPosAndRotEv(((void*)this));
+  return r;
 }

--- a/src/_ZN10ShutterHmcD0Ev.c
+++ b/src/_ZN10ShutterHmcD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10ShutterHmcD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10ShutterHmcD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCvShutter_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10ShutterHmcD1Ev.c
+++ b/src/_ZN10ShutterHmcD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN10ShutterHmcD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCvShutter_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10ShutterHmcD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCvShutter_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
+++ b/src/_ZN10SlidingIce16CleanupResourcesEv.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN10SlidingIce16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlidingIce.h"
 extern "C" void _ZN16MeshColliderBase7DisableEv(char*);
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern char func_ov030_02113be8[];
 extern char data_ov027_02113be0[];
-extern "C" int _ZN10SlidingIce16CleanupResourcesEv(char *c){
-  unsigned char ok = (*(unsigned short*)(c+0xc)==0x5d);
-  if(ok){ _ZN16MeshColliderBase7DisableEv(c+0x124); }
+
+int SlidingIce::CleanupResources()
+{
+  unsigned char ok = (mActorID==0x5d);
+  if(ok){ _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider); }
   _ZN13SharedFilePtr7ReleaseEv(func_ov030_02113be8);
   _ZN13SharedFilePtr7ReleaseEv(data_ov027_02113be0);
   return 1;

--- a/src/_ZN10SlidingIce6RenderEv.cpp
+++ b/src/_ZN10SlidingIce6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10SlidingIce6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlidingIce.h"
 struct VObj {
   virtual void f0();
   virtual void f1();
@@ -10,13 +13,15 @@ struct VObj {
 extern "C" {
 void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-int _ZN10SlidingIce6RenderEv(char* c){
-  int x = *(unsigned short*)(c+0xc)==0x5d;
+}
+
+int SlidingIce::Render()
+{
+  int x = mActorID==0x5d;
   if(x){
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
-    ((VObj*)(c+0xd4))->m5(0);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+    ((VObj*)((char*)&mModel))->m5(0);
   }
   return 1;
-}
 }

--- a/src/_ZN10SlidingIce8BehaviorEv.cpp
+++ b/src/_ZN10SlidingIce8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10SlidingIce8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlidingIce.h"
 struct V3 { int x,y,z; };
 struct V316 { short x,y,z; };
 extern "C" {
@@ -9,35 +12,37 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void*);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int, unsigned int, unsigned int, void*, unsigned int);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, void*, void*, int, int);
-int _ZN10SlidingIce8BehaviorEv(char *c){
-  int isType = (*(unsigned short*)(c+0xc) == 0x5d);
+}
+
+int SlidingIce::Behavior()
+{
+  int isType = (mActorID == 0x5d);
   if(isType){
-    if(DecIfAbove0_Short(c+0x31e) == 0){
-      _Z14ApproachLinearRiii((int*)(c+0x98), 0, 0x3000);
-      if(_Z14ApproachLinearRiii((int*)(c+0x60), *(int*)(c+0x324), 0xa000) != 0){
-        _ZN9ActorBase18MarkForDestructionEv(c);
+    if(DecIfAbove0_Short((char *)&unk_31e) == 0){
+      _Z14ApproachLinearRiii((int*)((char *)&unk_098), 0, 0x3000);
+      if(_Z14ApproachLinearRiii((int*)((char *)&mPosY), unk_324, 0xa000) != 0){
+        _ZN9ActorBase18MarkForDestructionEv(((char *)this));
       }
     }
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-    *(int*)(c+0x328) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int*)(c+0x328), 3, 0x98, c+0x74, 0);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char *)this), 0);
+    unk_328 = _ZN5Sound8PlayLongEjjjRK7Vector3j(unk_328, 3, 0x98, ((char *)this)+0x74, 0);
   } else {
-    if(DecIfAbove0_Short(c+0x31e) == 0){
+    if(DecIfAbove0_Short((char *)&unk_31e) == 0){
       V3 pos;
-      pos.x = *(int*)(c+0x5c);
-      pos.y = *(int*)(c+0x60);
-      pos.z = *(int*)(c+0x64);
+      pos.x = mPosX;
+      pos.y = mPosY;
+      pos.z = mPosZ;
       int spawnType = 1;
-      if(DecIfAbove0_Byte(c+0x320) == 0){
-        *(char*)(c+0x320) = 5;
+      if(DecIfAbove0_Byte((char *)&unk_320) == 0){
+        unk_320 = 5;
         spawnType = 2;
       } else {
         pos.y -= 0x50000;
       }
-      unsigned char cnt = *(unsigned char*)(c+0x320);
-      *(short*)(c+0x31e) = (cnt + 1) * 0x14;
-      _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x5d, spawnType, &pos, c+0x8c, *(signed char*)(c+0xcc), -1);
+      unsigned char cnt = unk_320;
+      unk_31e = (cnt + 1) * 0x14;
+      _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x5d, spawnType, &pos, ((char *)this)+0x8c, mAreaId, -1);
     }
   }
   return 1;
-}
 }

--- a/src/_ZN10SlidingIceD0Ev.c
+++ b/src/_ZN10SlidingIceD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10SlidingIceD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjSlIceBlock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10SlidingIceD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjSlIceBlock_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10SlidingIceD1Ev.c
+++ b/src/_ZN10SlidingIceD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10SlidingIceD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjSlIceBlock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10SlidingIceD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjSlIceBlock_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor.c
+++ b/src/_ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor.c
@@ -1,10 +1,13 @@
-extern void func_0203abd4(int* a, int* b, int c);
+// @symbol _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SphereClsn.h"
 extern void func_020353b0(void* c, void* p);
-extern void func_02037b5c(void* c);
 
-void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(char* c, int* vec, int fix, void* actor){
-    func_0203abd4((int*)(c + 0x38), vec, fix);
-    func_020353b0(c, actor);
-    func_02037b5c(c);
-    *(int*)(c + 0x108) = 0x1000;
+void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(struct SphereClsn *self, int* vec, int fix, void* actor) {
+    func_0203abd4((int*)((char*)&self->unk_038), vec, fix);
+    func_020353b0(((char*)self), actor);
+    func_02037b5c(((char*)self));
+    self->unk_108 = 0x1000;
 }

--- a/src/_ZN10SphereClsnC1Ev.c
+++ b/src/_ZN10SphereClsnC1Ev.c
@@ -1,23 +1,23 @@
+// @symbol _ZN10SphereClsnC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SphereClsn.h"
 extern void func_02035514(char *c);
 extern int *func_0203819c(int *t);
-extern void func_0203ac70(int *p);
 extern void _ZN10ClsnResultC1Ev(void *p);
 
-extern int data_02099338;
-extern int data_02099348;
-extern int data_02099358;
 
-void *_ZN10SphereClsnC1Ev(char *this)
-{
-    func_02035514(this);
-    func_0203819c((int *)(this + 0x10));
-    func_0203ac70((int *)(this + 0x38));
-    *(int **)this = &data_02099338;
-    *(int **)(this + 0x10) = &data_02099348;
-    *(int **)(this + 0x38) = &data_02099358;
-    _ZN10ClsnResultC1Ev(this + 0x74);
-    _ZN10ClsnResultC1Ev(this + 0x9c);
-    _ZN10ClsnResultC1Ev(this + 0xc4);
-    *(int *)(this + 0xec) = 0;
-    return this;
+void *_ZN10SphereClsnC1Ev(struct SphereClsn *self) {
+    func_02035514(((char *)self));
+    func_0203819c((int *)((char *)&self->unk_010));
+    func_0203ac70((int *)((char *)&self->unk_038));
+    *(int **)((char *)self) = &data_02099338;
+    *(int **)((char *)&self->unk_010) = &data_02099348;
+    *(int **)((char *)&self->unk_038) = &data_02099358;
+    _ZN10ClsnResultC1Ev((char *)&self->mClsnResult1);
+    _ZN10ClsnResultC1Ev((char *)&self->mClsnResult2);
+    _ZN10ClsnResultC1Ev((char *)&self->mClsnResult3);
+    self->unk_0ec = 0;
+    return ((char *)self);
 }

--- a/src/_ZN10SphereClsnD1Ev.c
+++ b/src/_ZN10SphereClsnD1Ev.c
@@ -1,20 +1,18 @@
+// @symbol _ZN10SphereClsnD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SphereClsn.h"
 extern void _ZN10ClsnResultD1Ev(void *);
-extern void func_0203ac1c(void *);
-extern void func_020380ec(void *);
-extern void func_020354d0(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
-int *_ZN10SphereClsnD1Ev(int *t)
-{
-    t[0] = (int)VT0;
-    *(int *)((char *)t + 0x10) = (int)VT1;
-    *(int *)((char *)t + 0x38) = (int)VT2;
-    _ZN10ClsnResultD1Ev((char *)t + 0xc4);
-    _ZN10ClsnResultD1Ev((char *)t + 0x9c);
-    _ZN10ClsnResultD1Ev((char *)t + 0x74);
-    func_0203ac1c((char *)t + 0x38);
-    func_020380ec((char *)t + 0x10);
-    func_020354d0(t);
-    return t;
+int *_ZN10SphereClsnD1Ev(struct SphereClsn *self) {
+    ((int *)self)[0] = (int)VT0;
+    *(int *)((char *)&self->unk_010) = (int)VT1;
+    *(int *)((char *)&self->unk_038) = (int)VT2;
+    _ZN10ClsnResultD1Ev((char *)&self->mClsnResult3);
+    _ZN10ClsnResultD1Ev((char *)&self->mClsnResult2);
+    _ZN10ClsnResultD1Ev((char *)&self->mClsnResult1);
+    func_0203ac1c((char *)&self->unk_038);
+    func_020380ec((char *)&self->unk_010);
+    func_020354d0(((int *)self));
+    return ((int *)self);
 }

--- a/src/_ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv.cpp
+++ b/src/_ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv.cpp
@@ -1,23 +1,28 @@
 //cpp
+// @symbol _ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv
+/* recovered: named members + shared header, real C++ method */
+#include "StarMarker.h"
 struct Vec3 { int x, y, z; };
 extern "C" signed char NumRedCoins(void);
 extern "C" void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vec3* pos, void* rot, int a, int b);
 extern "C" void _ZN9PowerStar13AddStarMarkerEv(void* p);
-extern "C" void _ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv(char* c){
+
+void StarMarker::SpawnRedCoinStarIfNecessary()
+{
   struct Vec3 v;
   char* star;
   int y;
-  if(((unsigned int)*(unsigned char*)(c+0x1db) << 29) >> 31) return;
+  if(((unsigned int)mFlags << 29) >> 31) return;
   if(NumRedCoins() != 8) return;
-  v.x = *(int*)(c+0x5c);
-  y = *(int*)(c+0x60);
+  v.x = mPosX;
+  y = mPosY;
   v.y = y;
-  v.z = *(int*)(c+0x64);
+  v.z = mPosZ;
   v.y = y + 0x78000;
-  star = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, *(unsigned char*)(c+0x1d9), &v, 0, *(signed char*)(c+0xcc), -1);
+  star = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, mStarID, &v, 0, mAreaId, -1);
   if(star == 0) return;
   _ZN9PowerStar13AddStarMarkerEv(star);
   *(unsigned short*)(((int)star + 0x4a2) & 0xFFFFFFFFFFFFFFFF) |= 0x1000;
-  *(int*)(star+0x434) = *(int*)(c+4);
-  *(unsigned char*)(((int)c + 0x1db) & 0xFFFFFFFFFFFFFFFF) |= 4;
+  *(int*)(star+0x434) = unk_004;
+  *(unsigned char*)(((int)((char*)this) + 0x1db) & 0xFFFFFFFFFFFFFFFF) |= 4;
 }

--- a/src/_ZN10StarMarker6RenderEv.cpp
+++ b/src/_ZN10StarMarker6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10StarMarker6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "StarMarker.h"
 extern "C" {
 
 struct Sub {
@@ -9,14 +12,13 @@ struct Sub {
     virtual void v4();
     virtual void m(int);
 };
-
-int _ZN10StarMarker6RenderEv(char *thiz)
-{
-    unsigned int b = *(unsigned char *)(thiz + 0x1db);
-    if ((b << 30) >> 31) {
-        ((Sub *)(thiz + 0x114))->m(0);
-    }
-    return 1;
 }
 
+int StarMarker::Render()
+{
+    unsigned int b = mFlags;
+    if ((b << 30) >> 31) {
+        ((Sub *)((char *)&mModel))->m(0);
+    }
+    return 1;
 }

--- a/src/_ZN10StarMarker8BehaviorEv.cpp
+++ b/src/_ZN10StarMarker8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN10StarMarker8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "StarMarker.h"
 typedef struct Mtx { int m[12]; } Mtx;
 extern "C" {
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
@@ -6,80 +11,80 @@ extern void Matrix4x3_FromRotationY(void *m, int ang);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *sm, void *mtx, int rad, int h, unsigned int g);
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov002_020e7d84(void *c);
 extern void _ZN12CylinderClsn5ClearEv(void *p);
 extern void _ZN12CylinderClsn6UpdateEv(void *p);
 
 extern unsigned char data_0209f208;
 extern unsigned char *data_0209f344;
 extern Mtx data_02082128;
+}
 
-int _ZN10StarMarker8BehaviorEv(char *c) {
-    if ((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1c) >> 0x1f) {
-        if (*(unsigned char *)(c + 0x1d9) == data_0209f344[data_0209f208]) {
-            *(unsigned short *)(c + 0x1d4) = 0;
-            if (((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1f) >> 0x1f) == 0) {
-                *(unsigned char *)((((int)c) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
-                *(int *)((((int)c) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+int StarMarker::Behavior()
+{
+    if ((unsigned int)(mFlags << 0x1c) >> 0x1f) {
+        if (mStarID == data_0209f344[data_0209f208]) {
+            mAppearTimer = 0;
+            if (((unsigned int)(mFlags << 0x1f) >> 0x1f) == 0) {
+                *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+                *(int *)((((int)((char *)this)) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
             }
         } else {
-            *(unsigned short *)(c + 0x1d4) = 0x2a;
+            mAppearTimer = 0x2a;
         }
-        *(unsigned char *)((((int)c) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+        *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
     }
-    if (*(unsigned char *)(c + 0x1d8) != 0) {
-        if (*(unsigned short *)(c + 0x1d4) != 0) {
-            if (((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1e) >> 0x1f) == 0) {
-                if (*(unsigned char *)(c + 0x1d9) == data_0209f344[data_0209f208]) {
-                    *(unsigned short *)((((int)c) + 0x1d4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
-                    if (*(unsigned short *)(c + 0x1d4) == 0) {
-                        if (((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1f) >> 0x1f) == 0) {
-                            *(unsigned char *)((((int)c) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
-                            *(int *)((((int)c) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    if (mState != 0) {
+        if (mAppearTimer != 0) {
+            if (((unsigned int)(mFlags << 0x1e) >> 0x1f) == 0) {
+                if (mStarID == data_0209f344[data_0209f208]) {
+                    *(unsigned short *)((((int)((char *)this)) + 0x1d4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                    if (mAppearTimer == 0) {
+                        if (((unsigned int)(mFlags << 0x1f) >> 0x1f) == 0) {
+                            *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+                            *(int *)((((int)((char *)this)) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
                         }
                     }
                 }
             }
         }
-        Matrix4x3_FromTranslation(c + 0x130, *(int *)(c + 0x5c) >> 3, *(int *)(c + 0x60) >> 3,
-                                  *(int *)(c + 0x64) >> 3);
+        Matrix4x3_FromTranslation(((char *)this) + 0x130, mPosX >> 3, mPosY >> 3,
+                                  mPosZ >> 3);
     } else {
-        *(short *)((((int)c) + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += 0x400;
-        Matrix4x3_FromRotationY(c + 0x130, *(short *)(c + 0x8e));
-        *(int *)(c + 0x154) = *(int *)(c + 0x5c) >> 3;
-        *(int *)(c + 0x158) = *(int *)(c + 0x60) >> 3;
-        *(int *)(c + 0x15c) = *(int *)(c + 0x64) >> 3;
+        *(short *)((((int)((char *)this)) + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += 0x400;
+        Matrix4x3_FromRotationY(((char *)this) + 0x130, unk_08e);
+        unk_154 = mPosX >> 3;
+        unk_158 = mPosY >> 3;
+        unk_15c = mPosZ >> 3;
     }
-    if ((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1e) >> 0x1f) {
-        *(Mtx *)(c + 0x18c) = data_02082128;
-        *(int *)(c + 0x1b0) = *(int *)(c + 0x5c) >> 3;
-        *(int *)(c + 0x1b4) = *(int *)(c + 0x60) >> 3;
-        *(int *)(c + 0x1b8) = *(int *)(c + 0x64) >> 3;
+    if ((unsigned int)(mFlags << 0x1e) >> 0x1f) {
+        *(Mtx *)((char *)&unk_18c) = data_02082128;
+        unk_1b0 = mPosX >> 3;
+        unk_1b4 = mPosY >> 3;
+        unk_1b8 = mPosZ >> 3;
         {
-            int d = *(int *)(c + 0x60) - *(int *)(c + 0x1c8);
+            int d = mPosY - unk_1c8;
             int rad = 0xa0000;
-            if (*(unsigned char *)(c + 0x1d8) != 0)
+            if (mState != 0)
                 rad = 0xc8000;
             _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
-                c, c + 0x164, c + 0x18c, rad, d + 0x28000, 0xf);
+                ((char *)this), ((char *)this) + 0x164, ((char *)this) + 0x18c, rad, d + 0x28000, 0xf);
         }
     }
-    if (*(unsigned char *)(c + 0x1d8) != 0) {
-        if ((unsigned int)(*(unsigned char *)(c + 0x1db) << 0x1e) >> 0x1f) {
-            if (*(unsigned char *)(c + 0x1d8) != 2 && *(int *)(c + 0xf8) != 0) {
-                char *a = _ZN5Actor10FindWithIDEj(*(int *)(c + 0xf8));
+    if (mState != 0) {
+        if ((unsigned int)(mFlags << 0x1e) >> 0x1f) {
+            if (mState != 2 && unk_0f8 != 0) {
+                char *a = _ZN5Actor10FindWithIDEj(unk_0f8);
                 if (a != 0) {
-                    if ((*(int *)(c + 0xf4) & 0x408000) != 0) {
-                        *(int *)(c + 0x1d0) = (int)a;
-                        func_ov002_020e7d84(c);
+                    if ((unk_0f4 & 0x408000) != 0) {
+                        unk_1d0 = (int)a;
+                        func_ov002_020e7d84(((char *)this));
                         return 1;
                     }
                 }
             }
-            _ZN12CylinderClsn5ClearEv(c + 0xd4);
-            _ZN12CylinderClsn6UpdateEv(c + 0xd4);
+            _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
+            _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);
         }
     }
     return 1;
-}
 }

--- a/src/_ZN10StarMarkerD0Ev.c
+++ b/src/_ZN10StarMarkerD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN10StarMarkerD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daStarBase_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN10StarMarkerD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daStarBase_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0xd4);

--- a/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
+++ b/src/_ZN10StarSwitch16CleanupResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN10StarSwitch16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "StarSwitch.h"
 // _ZN10StarSwitch16CleanupResourcesEv at 0x020ba568
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
@@ -12,14 +15,15 @@ extern char data_ov002_021098e8;
 extern char data_ov002_021098ec;
 extern char data_ov002_0211092c;
 
-extern "C" int _ZN10StarSwitch16CleanupResourcesEv(char* c) {
+int StarSwitch::CleanupResources()
+{
     int t;
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) {
+        _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
     }
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098e8 + *(unsigned char*)(c + 0x34c) * 0xc));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098ec + *(unsigned char*)(c + 0x34c) * 0xc));
-    t = *(unsigned short*)(c + 0xc) == 0xc;
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098e8 + unk_34c * 0xc));
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(&data_ov002_021098ec + unk_34c * 0xc));
+    t = mActorID == 0xc;
     if (t != false) {
         UnloadSilverStarAndNumber();
         _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0211092c);

--- a/src/_ZN10StarSwitch6RenderEv.cpp
+++ b/src/_ZN10StarSwitch6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN10StarSwitch6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "StarSwitch.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void M(void*); };
 struct Sub : Base { };
 struct C { char p1[0xd4]; Sub sub; };
-extern "C" int _ZN10StarSwitch6RenderEv(C* c){
-  c->sub.M((char*)c+0x320);
+
+int StarSwitch::Render()
+{
+  ((C*)this)->sub.M((char*)&unk_320);
   return 1;
 }

--- a/src/_ZN10StarSwitchD0Ev.c
+++ b/src/_ZN10StarSwitchD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10StarSwitchD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjSwitch_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN10StarSwitchD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjSwitch_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN10StarSwitchD1Ev.c
+++ b/src/_ZN10StarSwitchD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN10StarSwitchD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjSwitch_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN10StarSwitchD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjSwitch_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11BabyPenguin13InitResourcesEv.cpp
+++ b/src/_ZN11BabyPenguin13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN11BabyPenguin13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BabyPenguin.h"
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *file, int a, int b);
 extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -6,32 +11,29 @@ extern "C" int _ZN11ShadowModel12InitCylinderEv(void *thiz);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int r, int h, unsigned int a, unsigned int b);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, int r, int h, void *v, int b);
 extern "C" void func_ov072_02121d50(void *c);
-extern "C" void func_ov072_021210c4(void *c);
-extern "C" char data_ov072_02122cb4;
-extern "C" int data_ov072_02122004[];
 
-extern "C" int _ZN11BabyPenguin13InitResourcesEv(char *c)
+int BabyPenguin::InitResources()
 {
     void *f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov072_02122cb4);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, f, 1, -1);
     int i;
     for (i = 0; i < 5; i++) {
         _ZN9Animation8LoadFileER13SharedFilePtr((void *)data_ov072_02122004[i]);
     }
-    if (_ZN11ShadowModel12InitCylinderEv(c + 0x138) == 0) return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x160, c, 0x28000, 0x50000, 0x800004, 0x9000);
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x3c000;
-    *(int*)(c + 0x350) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x354) = *(int*)(c + 0x60);
-    *(int*)(c + 0x358) = *(int*)(c + 0x64);
-    *(int*)(c + 0x80) = 0x400;
-    *(int*)(c + 0x84) = 0x400;
-    *(int*)(c + 0x88) = 0x400;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x194, c, 0x32000, 0x32000, 0, 0);
-    *(int*)(c + 0xd0) = 0;
-    *(int*)(c + 0x360) = 0;
-    func_ov072_02121d50(c);
-    func_ov072_021210c4(c);
+    if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) return 0;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x160, ((char *)this), 0x28000, 0x50000, 0x800004, 0x9000);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
+    unk_350 = mPosX;
+    unk_354 = mPosY;
+    unk_358 = mPosZ;
+    mScaleX = 0x400;
+    mScaleY = 0x400;
+    mScaleZ = 0x400;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x194, ((char *)this), 0x32000, 0x32000, 0, 0);
+    mEatingPlayer = 0;
+    unk_360 = 0;
+    func_ov072_02121d50(((char *)this));
+    func_ov072_021210c4(((char *)this));
     return 1;
 }

--- a/src/_ZN11BabyPenguin6RenderEv.cpp
+++ b/src/_ZN11BabyPenguin6RenderEv.cpp
@@ -1,12 +1,16 @@
 //cpp
+// @symbol _ZN11BabyPenguin6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BabyPenguin.h"
 struct Arg;
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(Arg*); };
 struct Obj { char pad[0xb0]; unsigned int flags; char pad2[0xd4-0xb4]; Sub sub; };
-extern "C" int _ZN11BabyPenguin6RenderEv(Obj *c)
+
+int BabyPenguin::Render()
 {
-    unsigned int f = c->flags;
+    unsigned int f = ((Obj *)this)->flags;
     int b = ((f & 0x40000) != 0);
     if(b) return 1;
-    c->sub.m((Arg*)((char*)c+0x80));
+    ((Obj *)this)->sub.m((Arg*)((char*)&mScaleX));
     return 1;
 }

--- a/src/_ZN11BabyPenguin8BehaviorEv.cpp
+++ b/src/_ZN11BabyPenguin8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11BabyPenguin8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "BabyPenguin.h"
 extern "C" {
 int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void* self, int d);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
@@ -8,16 +11,16 @@ void func_ov072_02121cdc(void* c);
 void func_ov072_021210c4(void* c);
 }
 
-extern "C" int _ZN11BabyPenguin8BehaviorEv(char* c)
+int BabyPenguin::Behavior()
 {
-    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, 0x7d0000) && _ZNK12WithMeshClsn10IsOnGroundEv(c + 0x194)) {
-        func_ov072_02120d04(c);
+    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(((char*)this), 0x7d0000) && _ZNK12WithMeshClsn10IsOnGroundEv((char*)&mWithMeshClsn)) {
+        func_ov072_02120d04(((char*)this));
     } else {
-        if (*(int*)(c + 0x364) == 0)
-            *(void**)(c + 0x364) = _ZN5Actor15FindWithActorIDEjPS_(0x101, 0);
-        *(short*)(c + 0x36c) = 0x384;
-        func_ov072_02121cdc(c);
-        func_ov072_021210c4(c);
+        if (unk_364 == 0)
+            *(void**)((char*)&unk_364) = _ZN5Actor15FindWithActorIDEjPS_(0x101, 0);
+        unk_36c = 0x384;
+        func_ov072_02121cdc(((char*)this));
+        func_ov072_021210c4(((char*)this));
     }
     return 1;
 }

--- a/src/_ZN11BabyPenguinD0Ev.c
+++ b/src/_ZN11BabyPenguinD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN11BabyPenguinD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daPgBby_c */
 extern void *G0;
 int *_ZN11BabyPenguinD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daPgBby_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN11ShadowModelD1Ev((char *)t + 0x138);

--- a/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
+++ b/src/_ZN11BobOmbBuddy13InitResourcesEv.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol _ZN11BobOmbBuddy13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SaveData.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BobOmbBuddy.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" {
@@ -15,34 +20,30 @@ extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* se
 extern int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
 extern int func_ov084_0212ca60(void* p);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
-extern int _ZN8SaveData16HasPlayerLostCapEv(void);
-extern int func_ov084_0212cac0(char* c);
-extern int SublevelToLevel(int i);
 extern int IsStarCollected(int r0, int r1);
 extern void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 
-extern void* data_ov084_02130da4;
-extern void* data_ov084_02130d9c;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
 }
 
-extern "C" int _ZN11BobOmbBuddy13InitResourcesEv(char* self) {
+int BobOmbBuddy::InitResources()
+{
     RaycastGround rc;
     Vector3 pos;
 
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0x108,
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x108,
         _ZN5Model8LoadFileER13SharedFilePtr(&data_ov084_02130da4), 1, -1);
-    _ZN11ShadowModel12InitCylinderEv(self + 0x16c);
+    _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov084_02130d9c);
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self + 0xd4, self, 0x8c000, 0x8c000, 0x4200004, 0);
-    func_ov084_0212c960(self, 0);
-    *(int*)(self + 0x198) = 0;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0xd4, ((char*)this), 0x8c000, 0x8c000, 0x4200004, 0);
+    func_ov084_0212c960(((char*)this), 0);
+    unk_198 = 0;
 
     {
-        int z = *(int*)(self + 0x64);
-        int y = *(int*)(self + 0x60) + 0x64000;
-        pos.x = *(int*)(self + 0x5c);
+        int z = mPosZ;
+        int y = mPosY + 0x64000;
+        pos.x = mPosX;
         pos.y = y;
         pos.z = z;
     }
@@ -50,24 +51,24 @@ extern "C" int _ZN11BobOmbBuddy13InitResourcesEv(char* self) {
     _ZN13RaycastGroundC1Ev(&rc);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rc, pos, 0);
     if (_ZN13RaycastGround10DetectClsnEv(&rc) != 0)
-        *(int*)(self + 0x60) = rc.floor[(0x44 - 0x14) / 4];
+        mPosY = rc.floor[(0x44 - 0x14) / 4];
 
-    if (func_ov084_0212ca60(self) != 0) {
-        void* player = _ZN5Actor13ClosestPlayerEv(self);
+    if (func_ov084_0212ca60(((char*)this)) != 0) {
+        void* player = _ZN5Actor13ClosestPlayerEv(((char*)this));
         unsigned char state = *(unsigned char*)((char*)player + 0x6d9);
 
         if (state != 0) goto state_check1;
-        if (*(int*)(self + 8) == 0xb26)
+        if (mParam == 0xb26)
             goto state_return0;
 
     state_check1:
         if (state != 1) goto state_check2;
-        if (*(int*)(self + 8) == 0xb27)
+        if (mParam == 0xb27)
             goto state_return0;
 
     state_check2:
         if (state != 2) goto state_lostcap;
-        if (*(int*)(self + 8) == 0xb28)
+        if (mParam == 0xb28)
             goto state_return0;
 
     state_lostcap:
@@ -80,7 +81,7 @@ extern "C" int _ZN11BobOmbBuddy13InitResourcesEv(char* self) {
     }
 
 after_lostcap:
-    if (func_ov084_0212cac0(self) == 0)
+    if (func_ov084_0212cac0(((char*)this)) == 0)
         goto return1;
     if (data_0209f2f8 != 8)
         goto return1;

--- a/src/_ZN11BobOmbBuddy6RenderEv.cpp
+++ b/src/_ZN11BobOmbBuddy6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN11BobOmbBuddy6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BobOmbBuddy.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x108]; Base base; };
-extern "C" int _ZN11BobOmbBuddy6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int BobOmbBuddy::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
+++ b/src/_ZN11BobOmbBuddy8BehaviorEv.cpp
@@ -1,35 +1,37 @@
 //cpp
-struct Vector3 { int x, y, z; };
-extern "C" void func_ov084_0212c9a8(void *c);
+// @symbol _ZN11BobOmbBuddy8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BobOmbBuddy.h"
 extern "C" void *_ZN5Actor13ClosestPlayerEv(void *thiz);
 extern "C" int Vec3_HorzDist(const Vector3* a, const Vector3* b);
 extern "C" short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
 extern "C" int _Z14ApproachLinearRsss(short *r, short b, short c);
 extern "C" void _ZN9Animation7AdvanceEv(void *a);
 extern "C" void func_02012694(int a0, void *a1);
-extern "C" void func_ov084_0212ce50(void *c);
 extern "C" void _ZN12CylinderClsn5ClearEv(void *c);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void *c);
 
-extern "C" int _ZN11BobOmbBuddy8BehaviorEv(char *thiz)
+int BobOmbBuddy::Behavior()
 {
     Vector3 v;
     char *p;
-    func_ov084_0212c9a8(thiz);
-    p = (char*)_ZN5Actor13ClosestPlayerEv(thiz);
+    func_ov084_0212c9a8(((char *)this));
+    p = (char*)_ZN5Actor13ClosestPlayerEv(((char *)this));
     if (p != 0) {
         Vector3 *ps = (Vector3 *)(((unsigned long long)(unsigned)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFULL);
         v = *ps;
-        if (Vec3_HorzDist((Vector3*)(thiz + 0x5c), &v) < 0x12c000) {
-            short ang = Vec3_HorzAngle((Vector3*)(thiz + 0x5c), &v);
-            _Z14ApproachLinearRsss((short*)(thiz + 0x8e), ang, 0x100);
+        if (Vec3_HorzDist((Vector3*)((char *)&mPosX), &v) < 0x12c000) {
+            short ang = Vec3_HorzAngle((Vector3*)((char *)&mPosX), &v);
+            _Z14ApproachLinearRsss((short*)((char *)&unk_08e), ang, 0x100);
         }
     }
-    _ZN9Animation7AdvanceEv(thiz + 0x158);
-    if ((unsigned short)(*(int*)(thiz + 0x160) >> 12) == 0)
-        func_02012694(0xd7, thiz + 0x74);
-    func_ov084_0212ce50(thiz);
-    _ZN12CylinderClsn5ClearEv(thiz + 0xd4);
-    _ZN12CylinderClsn6UpdateEv(thiz + 0xd4);
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    if ((unsigned short)(unk_160 >> 12) == 0)
+        func_02012694(0xd7, ((char *)this) + 0x74);
+    func_ov084_0212ce50(((char *)this));
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
     return 1;
 }


### PR DESCRIPTION
Batch 02 of the readable-tree migration. Promotes 189 already-matched spawn/actor files to their readable form (shared `decl_*.h`/class headers, resolved vtable symbols, named members). Same bytes, same ROM. Stacked on the shared-header layer (#866) and batch 01 (#867), both merged; this batch is src-only, no header churn.

Local link-verification (tools/prepush_linkcheck.py, mwccarm 1.2/sp2p3): 123 VERIFIED, 66 BLIND, 0 WRONG/NO-REPRO. One file (_ZN10BulletBill8BehaviorEv) was dropped: main already carries a matching readable version of it and the folded form no longer reproduces against current main.

BLIND = instruction bytes verified, 1-2 reloc slots reference an RTTI-recovered symbol not yet in config (separate naming follow-up), not a wrong match.

Built with Claude Code.
