### PR TITLE
readable: batch 03 - promote 185 files to readable form

### DIFF
--- a/src/_ZN11BobOmbBuddyD0Ev.c
+++ b/src/_ZN11BobOmbBuddyD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN11BobOmbBuddyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daRedBombhei_c */
 extern void *G0;
 int *_ZN11BobOmbBuddyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daRedBombhei_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x16c);
     _ZN9ModelAnimD1Ev((char *)t + 0x108);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/_ZN11CannonHatch13InitResourcesEv.cpp
+++ b/src/_ZN11CannonHatch13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11CannonHatch13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "CannonHatch.h"
 typedef short s16;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 extern struct SharedFilePtr data_ov002_0210e12c;
@@ -15,23 +18,23 @@ void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Blo
 int IsCannonOpenInCurLevel(void);
 }
 
-extern "C" int _ZN11CannonHatch13InitResourcesEv(unsigned char *self)
+int CannonHatch::InitResources()
 {
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e12c);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, -1);
-    _ZN8Platform21UpdateModelPosAndRotYEv(self);
-    _ZN8Platform19UpdateClsnPosAndRotEv(self);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((unsigned char *)this) + 0xd4, bmd, 1, -1);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((unsigned char *)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((unsigned char *)this));
     {
         struct KCL_File *kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov002_0210e124);
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-            self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x2ec), 0x199,
-            *(s16 *)(self + 0x8e), data_ov002_0210d7f4);
+            ((unsigned char *)this) + 0x124, kcl, *(struct Matrix4x3 *)((unsigned char *)&unk_2ec), 0x199,
+            unk_08e, data_ov002_0210d7f4);
     }
-    *(int *)(self + 0x320) = *(int *)(self + 0x5c);
-    *(int *)(self + 0x324) = *(int *)(self + 0x60);
-    *(int *)(self + 0x328) = *(int *)(self + 0x64);
+    unk_320 = mPosX;
+    unk_324 = mPosY;
+    unk_328 = mPosZ;
     if (IsCannonOpenInCurLevel() != 0) {
-        *(unsigned char *)(self + 0x32e) = 1;
+        unk_32e = 1;
     }
     return 1;
 }

--- a/src/_ZN11CannonHatch6RenderEv.cpp
+++ b/src/_ZN11CannonHatch6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11CannonHatch6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "CannonHatch.h"
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
 struct Sub {
@@ -9,12 +12,14 @@ struct Obj {
   char pad[0xd4];
   Sub sub;
 };
-extern "C" int _ZN11CannonHatch6RenderEv(Obj* c){
-  if (data_0209f2f8 == 6 && data_0209f220 == 1 && (*(int*)((char*)c + 8) & 0xff) == 1)
+
+int CannonHatch::Render()
+{
+  if (data_0209f2f8 == 6 && data_0209f220 == 1 && (*(int*)((char*)&mParam) & 0xff) == 1)
     return 1;
-  if (*(unsigned char*)((char*)c + 0x32e) != 0)
+  if (*(unsigned char*)((char*)&unk_32e) != 0)
     return 1;
-  Sub* b = &c->sub;
+  Sub* b = &((Obj*)this)->sub;
   b->m14(0);
   return 1;
 }

--- a/src/_ZN11CannonHatchD0Ev.c
+++ b/src/_ZN11CannonHatchD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11CannonHatchD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjCannonShutter_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN11CannonHatchD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjCannonShutter_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CannonHatchD1Ev.c
+++ b/src/_ZN11CannonHatchD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11CannonHatchD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjCannonShutter_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN11CannonHatchD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjCannonShutter_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CastleWater13InitResourcesEv.cpp
+++ b/src/_ZN11CastleWater13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11CastleWater13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "CastleWater.h"
 typedef short s16;
 struct SharedFilePtr { int x; }; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 extern "C" {
@@ -15,20 +18,21 @@ extern struct SharedFilePtr data_ov009_02113e88;
 extern struct CLPS_Block data_ov009_02112bf8;
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0;
+}
 
-int _ZN11CastleWater13InitResourcesEv(unsigned char *self)
+int CastleWater::InitResources()
 {
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov009_02113e90);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, -1);
-    _ZN8Platform21UpdateModelPosAndRotYEv(self);
-    _ZN8Platform19UpdateClsnPosAndRotEv(self);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((unsigned char *)this) + 0xd4, bmd, 1, -1);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((unsigned char *)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((unsigned char *)this));
     {
         struct KCL_File *kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov009_02113e88);
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-            self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x2ec), 0x1000,
-            *(s16 *)(self + 0x8e), data_ov009_02112bf8);
+            ((unsigned char *)this) + 0x124, kcl, *(struct Matrix4x3 *)((unsigned char *)&unk_2ec), 0x1000,
+            unk_08e, data_ov009_02112bf8);
     }
-    if ((*(int*)(self + 8) & 0xff) == 0xff) {
+    if ((unk_008 & 0xff) == 0xff) {
         int b = (int)(data_0209f2d8 == 1);
         if (b != 0) goto ret1;
         if ((*(int*)((char*)&data_0209caa0 + 8) & 0x80000) == 0) goto ret1;
@@ -40,5 +44,4 @@ int _ZN11CastleWater13InitResourcesEv(unsigned char *self)
     }
 ret1:
     return 1;
-}
 }

--- a/src/_ZN11CastleWater6RenderEv.cpp
+++ b/src/_ZN11CastleWater6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN11CastleWater6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "CastleWater.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN11CastleWater6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int CastleWater::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN11CastleWaterD0Ev.c
+++ b/src/_ZN11CastleWaterD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11CastleWaterD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN11CastleWaterD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjMc_Metalnet_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11CastleWaterD1Ev.c
+++ b/src/_ZN11CastleWaterD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11CastleWaterD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjMc_Metalnet_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN11CastleWaterD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjMc_Metalnet_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11ChiefChilly6RenderEv.cpp
+++ b/src/_ZN11ChiefChilly6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN11ChiefChilly6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ChiefChilly.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void M(void*); };
 struct Sub : Base { };
 struct C { char p1[0x30c]; Sub sub; };
-extern "C" int _ZN11ChiefChilly6RenderEv(C* c){
-  c->sub.M((char*)c+0x80);
+
+int ChiefChilly::Render()
+{
+  ((C*)this)->sub.M((char*)&mScaleX);
   return 1;
 }

--- a/src/_ZN11ChiefChillyD0Ev.c
+++ b/src/_ZN11ChiefChillyD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN11ChiefChillyD0Ev
+/* recovered: named members + shared header */
+#include "ChiefChilly.h"
 extern int func_0207328c(void* c, int a, int b, void* d);
 extern void* _ZTV11ChiefChilly[];
 extern void func_020072c0(void);
@@ -8,17 +11,16 @@ extern int _ZN25MovingCylinderClsnWithPosD1Ev(void* c);
 extern int func_ov002_020aed18(int* x);
 extern int data_020a0eac;
 extern int _ZN6Memory10DeallocateEPvP4Heap(void* p, void* h);
-int _ZN11ChiefChillyD0Ev(void* c)
-{
-    *(void**)c = _ZTV11ChiefChilly;
-    func_0207328c((char*)c+0x4d4, 2, 0xc, (void*)func_020072c0);
-    func_0207328c((char*)c+0x448, 8, 0xc, (void*)func_020072c0);
-    func_0207328c((char*)c+0x3e8, 8, 0xc, (void*)func_020072c0);
-    _ZN11ShadowModelD1Ev((char*)c+0x380);
-    _ZN14BlendModelAnimD1Ev((char*)c+0x30c);
-    _ZN12WithMeshClsnD1Ev((char*)c+0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x110);
-    func_ov002_020aed18((int*)c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, (void*)data_020a0eac);
-    return (int)c;
+int _ZN11ChiefChillyD0Ev(struct ChiefChilly *self) {
+    *(void**)((void*)self) = _ZTV11ChiefChilly;
+    func_0207328c((char*)((void*)self)+0x4d4, 2, 0xc, (void*)func_020072c0);
+    func_0207328c((char*)((void*)self)+0x448, 8, 0xc, (void*)func_020072c0);
+    func_0207328c((char*)((void*)self)+0x3e8, 8, 0xc, (void*)func_020072c0);
+    _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+    _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+    _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aed18((int*)((void*)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((void*)self), (void*)data_020a0eac);
+    return (int)((void*)self);
 }

--- a/src/_ZN11ChiefChillyD1Ev.c
+++ b/src/_ZN11ChiefChillyD1Ev.c
@@ -1,20 +1,24 @@
+// @symbol _ZN11ChiefChillyD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+/* recovered: named members + shared header */
+#include "ChiefChilly.h"
 extern int func_0207328c(void* p, int a, int b, void* d);
-extern void _ZN11ShadowModelD1Ev(void* p);
-extern void _ZN14BlendModelAnimD1Ev(void* p);
-extern void _ZN12WithMeshClsnD1Ev(void* p);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void* p);
 extern int func_ov002_020aed18(int* x);
 extern int func_020072c0;
 extern int _ZTV11ChiefChilly[];
-int _ZN11ChiefChillyD1Ev(int* c){
-  *(int**)c = _ZTV11ChiefChilly;
-  func_0207328c((char*)c+0x4d4, 2, 0xc, &func_020072c0);
-  func_0207328c((char*)c+0x448, 8, 0xc, &func_020072c0);
-  func_0207328c((char*)c+0x3e8, 8, 0xc, &func_020072c0);
-  _ZN11ShadowModelD1Ev((char*)c+0x380);
-  _ZN14BlendModelAnimD1Ev((char*)c+0x30c);
-  _ZN12WithMeshClsnD1Ev((char*)c+0x150);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x110);
-  func_ov002_020aed18(c);
-  return (int)c;
+int _ZN11ChiefChillyD1Ev(struct ChiefChilly *self) {
+  *(int**)((int*)self) = _ZTV11ChiefChilly;
+  func_0207328c((char*)((int*)self)+0x4d4, 2, 0xc, &func_020072c0);
+  func_0207328c((char*)((int*)self)+0x448, 8, 0xc, &func_020072c0);
+  func_0207328c((char*)((int*)self)+0x3e8, 8, 0xc, &func_020072c0);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  func_ov002_020aed18(((int*)self));
+  return (int)((int*)self);
 }

--- a/src/_ZN11CrazedCrate13InitResourcesEv.cpp
+++ b/src/_ZN11CrazedCrate13InitResourcesEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN11CrazedCrate13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CrazedCrate.h"
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
@@ -10,42 +14,41 @@ extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround* self);
 extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* self, const Vector3& v, void* actor);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
-extern "C" void func_ov080_0212513c(void* self);
 extern "C" void func_ov080_02124c3c(void* self);
 extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 
-extern void* data_ov080_02128468;
 
-extern "C" int _ZN11CrazedCrate13InitResourcesEv(char* self) {
+int CrazedCrate::InitResources()
+{
     RaycastGround rc;
     Vector3 pos;
     void* file = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov080_02128468);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, file, 1, 1);
-    _ZN11ShadowModel10InitCuboidEv(self + 0x124);
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self + 0x14c, self, 0x64000, 0x78000, 0x800004, 0x9010);
-    *(int*)(self + 0x9c) = -0x2000;
-    *(int*)(self + 0xa0) = -0x3c000;
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, file, 1, 1);
+    _ZN11ShadowModel10InitCuboidEv((char*)&mShadowModel);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x14c, ((char*)this), 0x64000, 0x78000, 0x800004, 0x9010);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
     {
         int p60;
-        pos.x = *(int*)(self + 0x5c);
-        p60 = *(int*)(self + 0x60);
+        pos.x = mPosX;
+        p60 = mPosY;
         pos.y = p60;
-        pos.z = *(int*)(self + 0x64);
+        pos.z = mPosZ;
         pos.y = p60 + 0xc8000;
     }
     _ZN13RaycastGroundC1Ev(&rc);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rc, pos, 0);
     if (_ZN13RaycastGround10DetectClsnEv(&rc))
-        *(int*)(self + 0x60) = rc.floor[(0x44 - 0x14) / 4];
+        mPosY = rc.floor[(0x44 - 0x14) / 4];
     else
-        *(int*)(self + 0x60) = pos.y;
-    *(int*)(self + 0x80) = 0x1000;
-    *(int*)(self + 0x84) = 0x1000;
-    *(int*)(self + 0x88) = 0x1000;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(self + 0x180, self, 0x32000, 0x32000, 0, 0);
-    *(int*)(self + 0x374) = 0;
-    func_ov080_0212513c(self);
-    func_ov080_02124c3c(self);
+        mPosY = pos.y;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x180, ((char*)this), 0x32000, 0x32000, 0, 0);
+    unk_374 = 0;
+    func_ov080_0212513c(((char*)this));
+    func_ov080_02124c3c(((char*)this));
     _ZN13RaycastGroundD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN11CrazedCrate6RenderEv.cpp
+++ b/src/_ZN11CrazedCrate6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11CrazedCrate6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "CrazedCrate.h"
 class Sub {
 public:
     virtual void F0();
@@ -9,12 +12,13 @@ public:
     virtual void F5(int n);
 };
 
-extern "C" int _ZN11CrazedCrate6RenderEv(char *c) {
-    int r1 = *(int*)(c + 0xb0);
+int CrazedCrate::Render()
+{
+    int r1 = unk_0b0;
     r1 = r1 & 0x40000;
     r1 = r1 ? 1 : 0;
     if (r1) return 1;
-    Sub *sub = (Sub*)(c + 0xd4);
+    Sub *sub = (Sub*)((char *)&mModel);
     sub->F5(0);
     return 1;
 }

--- a/src/_ZN11CrazedCrateD0Ev.c
+++ b/src/_ZN11CrazedCrateD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN11CrazedCrateD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daBttBk_c */
 extern void *G0;
 int *_ZN11CrazedCrateD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daBttBk_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x180);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x14c);
     _ZN11ShadowModelD1Ev((char *)t + 0x124);

--- a/src/_ZN11FallBlockWfD0Ev.c
+++ b/src/_ZN11FallBlockWfD0Ev.c
@@ -1,14 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN11FallBlockWfD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN11FallBlockWfD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN11FallBlockWfD1Ev.c
+++ b/src/_ZN11FallBlockWfD1Ev.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN11FallBlockWfD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN11FallBlockWfD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN11MirrorLuigi13InitResourcesEv.cpp
+++ b/src/_ZN11MirrorLuigi13InitResourcesEv.cpp
@@ -1,36 +1,27 @@
 //cpp
+// @symbol _ZN11MirrorLuigi13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MirrorLuigi.h"
 struct M48 { int w[12]; };
 
-extern "C" void *Model_LoadFile(void *fp);
-extern "C" void ModelBase_SetFile(void *self, void *bmd, int a, int b);
-extern "C" void func_02016acc(void *self, int v);
 extern "C" void func_02016b24(void *self, int v);
-extern "C" void TextureSequence_Prepare(void *bmd, void *btp);
-extern "C" void TextureSequence_SetFile(void *self, void *btp, int a, int fix, unsigned int b);
-extern "C" int ShadowModel_InitCylinder(void *self);
-extern "C" void *Animation_LoadFile(void *fp);
-extern "C" void ModelAnim_SetAnim(void *self, void *bca, int a, int fix, unsigned int b);
 extern "C" void Vec3_Asr(void *d, void *s, int sh);
 extern "C" void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationY(void *m, int angY);
-extern "C" void func_ov055_021112c4(void *c, void *p, int a2);
 
 extern void *data_ov002_0210ebb8;
 extern void *data_ov002_0210eb20;
 extern void *data_ov002_0210e8d0;
 extern void *data_ov002_0210ebd8;
-extern void *data_ov002_0210eaa0;
 extern int data_020a0e68;
 extern unsigned char data_0209f250;
 extern int data_0209f394[];
-extern void *data_ov055_02111b70;
-extern int data_ov055_02111a90;
-extern int data_ov055_02111b68;
-extern int data_ov055_02111b6c;
 
-extern "C" int _ZN11MirrorLuigi13InitResourcesEv(void *thiz)
+int MirrorLuigi::InitResources()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     int t[3];
 
     ModelBase_SetFile(c + 0xd4, Model_LoadFile(&data_ov002_0210ebb8), 1, -1);

--- a/src/_ZN11MirrorLuigi6RenderEv.cpp
+++ b/src/_ZN11MirrorLuigi6RenderEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN11MirrorLuigi6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MirrorLuigi.h"
 struct Mtx { int m[12]; };
 struct Sub {
     virtual void v0();
@@ -11,8 +16,6 @@ struct Sub {
 
 extern "C" {
 
-extern int data_ov055_02111b6c;
-extern int data_ov055_02111b64;
 extern unsigned char data_0209f250;
 extern char* data_0209f394[];
 extern char data_020a0e68;
@@ -25,7 +28,7 @@ void _ZN15TextureSequence6UpdateER15ModelComponents(void* ts, void* mc);
 
 }
 
-extern "C" int _ZN11MirrorLuigi6RenderEv(char* self)
+int MirrorLuigi::Render()
 {
     char* player;
     char* r8res;
@@ -41,31 +44,31 @@ extern "C" int _ZN11MirrorLuigi6RenderEv(char* self)
     player = data_0209f394[data_0209f250];
     r8res = func_ov002_020e496c(player);
 
-    q = (char*)(int)(((long long)(int)(self + 0xdc)) & 0xFFFFFFFFFFFFFFFFLL);
+    q = (char*)(int)(((long long)(int)((char*)&unk_0dc)));
     comp = *(char**)q;
     dst = *(Mtx**)(q + 0xc);
     src = *(Mtx**)(r8res + 0x14);
     for (i = 0; i < *(unsigned int*)(comp + 4); i++) {
-        *(Mtx*)(int)(((long long)(int)dst) & 0xFFFFFFFFFFFFFFFFLL) = *src;
+        *(Mtx*)(int)(((long long)(int)dst)) = *src;
         src++;
         dst++;
     }
 
-    p_f0 = self + 0xf0;
+    p_f0 = ((char*)this) + 0xf0;
     *(Mtx*)p_f0 = *(Mtx*)(r8res + 0x1c);
     *(int*)(p_f0 + 0x24) = -*(int*)(p_f0 + 0x24);
     func_0203c178(&data_020a0e68, -0x1000, 0x1000, 0x1000);
     MulMat3x3Mat3x3(p_f0, &data_020a0e68, p_f0);
-    *(Mtx*)(self + 0x154) = *(Mtx*)p_f0;
+    *(Mtx*)((char*)&unk_154) = *(Mtx*)p_f0;
 
     if (data_ov055_02111b64 & 0x20000) return 1;
 
-    _ZN5Model6RenderEPK7Vector3((void*)(self + 0xd4), 0);
-    *(Mtx*)(*(char**)(self + 0x14c)) = *(Mtx*)(*(char**)(self + 0xe8) + 0x2d0);
-    _ZN15TextureSequence6UpdateER15ModelComponents((void*)(self + 0x1b0), (void*)(self + 0xdc));
-    *(int*)(self + 0x1b8) = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
-    _ZN15TextureSequence6UpdateER15ModelComponents((void*)(self + 0x1c4), (void*)(self + 0x140));
-    *(int*)(self + 0x1cc) = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
-    ((Sub*)(self + 0x138))->m5(0);
+    _ZN5Model6RenderEPK7Vector3((void*)((char*)&mModelAnim), 0);
+    *(Mtx*)(*(char**)((char*)&unk_14c)) = *(Mtx*)(*(char**)((char*)&unk_0e8) + 0x2d0);
+    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1b0), (void*)((char*)&unk_0dc));
+    unk_1b8 = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
+    _ZN15TextureSequence6UpdateER15ModelComponents((void*)((char*)&unk_1c4), (void*)((char*)&unk_140));
+    unk_1cc = (int)(*(unsigned char*)(player + 0x6fb)) << 12;
+    ((Sub*)((char*)&mModel))->m5(0);
     return 1;
 }

--- a/src/_ZN11MirrorLuigi8BehaviorEv.cpp
+++ b/src/_ZN11MirrorLuigi8BehaviorEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+// @symbol _ZN11MirrorLuigi8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MirrorLuigi.h"
 extern "C" {
-extern int data_ov055_02111b68;
-extern int data_ov055_02111b6c;
-extern int data_ov055_02111b60;
-extern int data_ov055_02111a90;
-extern int data_ov055_02111b64;
 extern int data_0209caa0[];
 extern unsigned char data_0209f250;
 extern char *data_0209f394[];
@@ -22,7 +22,7 @@ struct Node {
     PMF fn;
 };
 
-extern "C" int _ZN11MirrorLuigi8BehaviorEv(char *c)
+int MirrorLuigi::Behavior()
 {
     int a, b;
     int f;
@@ -39,12 +39,12 @@ extern "C" int _ZN11MirrorLuigi8BehaviorEv(char *c)
         data_ov055_02111b64 = (data_ov055_02111b64 & ~0x20000) + (0x1ffff - data_ov055_02111b6c);
     }
     val = data_0209f394[data_0209f250];
-    node = *(Node **)(c + 0x1d8);
+    node = *(Node **)((char *)&unk_1d8);
     if (*(int *)&node->fn != 0)
-        (((C5 *)c)->*node->fn)(val);
-    Matrix4x3_FromTranslation(c + 0x1dc, *(int *)(c + 0x5c) >> 3, *(int *)(c + 0x60) >> 3, *(int *)(c + 0x64) >> 3);
+        (((C5 *)((char *)this))->*node->fn)(val);
+    Matrix4x3_FromTranslation(((char *)this) + 0x1dc, mPosX >> 3, mPosY >> 3, mPosZ >> 3);
     func_ov002_020e4374(val, &a, &b);
-    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0x188, c + 0x1dc, b, a, 0xf);
-    *(char **)(data_0209f318 + 0x114) = c;
+    _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(((char *)this), ((char *)this) + 0x188, ((char *)this) + 0x1dc, b, a, 0xf);
+    *(char **)(data_0209f318 + 0x114) = ((char *)this);
     return 1;
 }

--- a/src/_ZN11MirrorLuigiD0Ev.c
+++ b/src/_ZN11MirrorLuigiD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN11MirrorLuigiD0Ev
+/* recovered: named members + shared header */
+#include "MirrorLuigi.h"
 extern int _ZTV11MirrorLuigi[];
 extern int _ZN15TextureSequenceD1Ev(void*);
 extern int data_020a0eac[];
@@ -7,13 +10,13 @@ extern int _ZN5ModelD1Ev(void*);
 extern int _ZN9ModelAnimD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
-int _ZN11MirrorLuigiD0Ev(char* c){
-  *(int*)c=(int)_ZTV11MirrorLuigi;
-  func_0207328c(c+0x1b0,2,0x14,(void*)_ZN15TextureSequenceD1Ev);
-  _ZN11ShadowModelD1Ev(c+0x188);
-  _ZN5ModelD1Ev(c+0x138);
-  _ZN9ModelAnimD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c,(void*)data_020a0eac[0]);
-  return (int)c;
+int _ZN11MirrorLuigiD0Ev(struct MirrorLuigi *self) {
+  *(int*)((char*)self)=(int)_ZTV11MirrorLuigi;
+  func_0207328c(((char*)self)+0x1b0,2,0x14,(void*)_ZN15TextureSequenceD1Ev);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN5ActorD2Ev(((char*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self),(void*)data_020a0eac[0]);
+  return (int)((char*)self);
 }

--- a/src/_ZN11PyramidLift6RenderEv.cpp
+++ b/src/_ZN11PyramidLift6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11PyramidLift6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidLift.h"
 extern "C" {
 struct Mtx { int w[12]; };
 extern void Matrix4x3_FromTranslation(Mtx* m, int x, int y, int z);
@@ -15,20 +18,21 @@ struct Sub {
 
 struct Elem { int w[3]; };
 
-extern "C" int _ZN11PyramidLift6RenderEv(char* c){
+int PyramidLift::Render()
+{
     {
-        Sub* s = (Sub*)(c + 0xd4);
+        Sub* s = (Sub*)((char*)&mModel1);
         s->m(0);
     }
-    int i = *(unsigned char*)(c + 0x3f8);
+    int i = unk_3f8;
     if (i < 0xa) {
-        Elem* e = (Elem*)(c + i * 0xc);
+        Elem* e = (Elem*)(((char*)this) + i * 0xc);
         do {
-            Matrix4x3_FromTranslation((Mtx*)(c + 0x33c),
+            Matrix4x3_FromTranslation((Mtx*)((char*)&unk_33c),
                 e->w[(0x37c)/4] >> 3,
                 e->w[(0x380)/4] >> 3,
                 e->w[(0x384)/4] >> 3);
-            Sub* s2 = (Sub*)(c + 0x320);
+            Sub* s2 = (Sub*)((char*)&mModel2);
             s2->m(0);
             i++;
             e = (Elem*)((char*)e + 0xc);

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -1,79 +1,82 @@
 //cpp
+// @symbol _ZN11PyramidLift8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidLift.h"
 extern "C" {
 extern short data_02082214[];
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
+}
 
-int _ZN11PyramidLift8BehaviorEv(char* c)
+int PyramidLift::Behavior()
 {
-    switch (*(unsigned char*)(c + 0x3f6)) {
+    switch (mState) {
     case 0:
-        if (*(unsigned char*)(c + 0x3f7) != 0) {
-            *(unsigned char*)(c + 0x3f6) = 1;
-            *(short*)(c + 0x3f4) = 0;
+        if (unk_3f7 != 0) {
+            mState = 1;
+            mShakeTimer = 0;
         }
         break;
     case 1: {
-        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        unsigned short ang = mShakeTimer;
         int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
         int idx = t >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
-        *(int*)(c + 0x60) = *(int*)(c + 0x374) + d;
-        if (*(unsigned short*)(c + 0x3f4) == 8) {
-            *(unsigned char*)(c + 0x3f6) = 2;
-            *(int*)(c + 0xa8) = -0xa000;
+        mPosY = unk_374 + d;
+        if (mShakeTimer == 8) {
+            mState = 2;
+            unk_0a8 = -0xa000;
         }
         {
-            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
             *pa = *pa + 1;
         }
         break;
     }
     case 2: {
-        int v = *(int*)(c + 0x60);
-        int idx = *(unsigned char*)(c + 0x3f8);
-        int* p = (int*)(c + idx * 0xc + 0x380);
+        int v = mPosY;
+        int idx = unk_3f8;
+        int* p = (int*)(((char*)this) + idx * 0xc + 0x380);
         int lim = *p + 0x14000;
         if (v <= lim) {
-            unsigned char *pb = (unsigned char*)(((int)c + 0x3f8) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char *pb = (unsigned char*)(((int)((char*)this) + 0x3f8) & 0xFFFFFFFFFFFFFFFFLL);
             *pb = *pb + 1;
         }
         {
-            int *py = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
-            *py = *py + *(int*)(c + 0xa8);
+            int *py = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            *py = *py + unk_0a8;
         }
-        if (*(int*)(c + 0x60) < 0x80000) {
-            *(int*)(c + 0x60) = 0x80000;
-            *(unsigned char*)(c + 0x3f6) = 3;
-            *(short*)(c + 0x3f4) = 0;
+        if (mPosY < 0x80000) {
+            mPosY = 0x80000;
+            mState = 3;
+            mShakeTimer = 0;
         }
         break;
     }
     case 3: {
         int z = 0;
-        unsigned short ang = *(unsigned short*)(c + 0x3f4);
+        unsigned short ang = mShakeTimer;
         int t = (int)((unsigned short)((int)(ang << 0x1c) >> 0x10));
         int idx = t >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
-        *(int*)(c + 0x60) = d + 0x80000;
+        mPosY = d + 0x80000;
         {
-            unsigned short *pa = (unsigned short*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
-            if (*(unsigned short*)(c + 0x3f4) >= 8) {
-                *(int*)(c + 0xa8) = z;
-                *(int*)(c + 0x60) = 0x80000;
+            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            if (mShakeTimer >= 8) {
+                unk_0a8 = z;
+                mPosY = 0x80000;
             }
             *pa = *pa + 1;
         }
         break;
     }
     }
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
-    *(unsigned char*)(c + 0x3f7) = 0;
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+    unk_3f7 = 0;
     return 1;
-}
 }

--- a/src/_ZN11PyramidLiftD0Ev.c
+++ b/src/_ZN11PyramidLiftD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN11PyramidLiftD0Ev
+/* recovered: named members + shared header */
+#include "PyramidLift.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
@@ -7,14 +10,14 @@ extern int data_ov027_021139d4[];
 extern int func_020072c0[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN11PyramidLiftD0Ev(char *c) {
-    *(int**)(c) = data_ov027_021139d4;
-    func_0207328c(c+0x37c, 0xa, 0xc, func_020072c0);
-    _ZN5ModelD1Ev(c+0x320);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN11PyramidLiftD0Ev(struct PyramidLift *self) {
+    *(int**)(((char *)self)) = data_ov027_021139d4;
+    func_0207328c(((char *)self)+0x37c, 0xa, 0xc, func_020072c0);
+    _ZN5ModelD1Ev((char *)&self->mModel2);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel1);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN11PyramidLiftD1Ev.cpp
+++ b/src/_ZN11PyramidLiftD1Ev.cpp
@@ -1,20 +1,24 @@
 //cpp
+// @symbol _ZN11PyramidLiftD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "PyramidLift.h"
 extern "C" {
 extern void func_0207328c(void*,int,int,void*);
-extern void _ZN5ModelD1Ev(void*);
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN5ActorD2Ev(void*);
-extern int data_ov027_021139d4[];
 extern int func_020072c0();
 extern int _ZTV17ExclamationSwitch[];
-void* _ZN11PyramidLiftD1Ev(char* c){
-  *(int**)c = data_ov027_021139d4;
-  func_0207328c(c+0x37c, 0xa, 0xc, (void*)func_020072c0);
-  _ZN5ModelD1Ev(c+0x320);
-  *(int**)c = _ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN11PyramidLiftD1Ev(struct PyramidLift *self) {
+  *(int**)((char*)self) = data_ov027_021139d4;
+  func_0207328c(((char*)self)+0x37c, 0xa, 0xc, (void*)func_020072c0);
+  _ZN5ModelD1Ev((char*)&self->mModel2);
+  *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel1);
+  _ZN5ActorD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN11PyramidStep13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidStep13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11PyramidStep13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidStep.h"
 typedef short s16;
 struct SharedFilePtr { int x; }; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
@@ -14,39 +17,40 @@ void func_020393d4(int *p, int v);
 extern struct SharedFilePtr data_ov025_02113ab8;
 extern struct SharedFilePtr data_ov025_02113ab0;
 extern struct CLPS_Block data_ov025_02112ce8;
+}
 
-int _ZN11PyramidStep13InitResourcesEv(char *self){
+int PyramidStep::InitResources()
+{
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov025_02113ab8);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0x320, bmd, 1, -1);
-    func_ov025_02111e30(self);
-    func_ov025_02111dec(self);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x320, bmd, 1, -1);
+    func_ov025_02111e30(((char *)this));
+    func_ov025_02111dec(((char *)this));
     {
         struct KCL_File *kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov025_02113ab0);
         _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-            self + 0x124, kcl, *(struct Matrix4x3 *)(self + 0x374), 0x1000,
-            *(s16 *)(self + 0x8e), data_ov025_02112ce8);
+            ((char *)this) + 0x124, kcl, *(struct Matrix4x3 *)((char *)&unk_374), 0x1000,
+            unk_08e, data_ov025_02112ce8);
     }
-    func_020393d4((int *)(self + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    func_020393d4((int *)((char *)&mMovingMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     {
         int v = 0x5000;
-        int k = *(int*)(self + 8) & 3;
-        *(int*)(self + 0xa8) = -v;
-        *(unsigned char*)(self + 0x372) = 0;
-        *(s16*)(self + 0x370) = 0;
+        int k = unk_008 & 3;
+        unk_0a8 = -v;
+        unk_372 = 0;
+        unk_370 = 0;
         switch (k) {
         case 0:
             break;
         case 1:
-            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0xfa000;
-            *(unsigned short*)(((int)self + 0x370) & 0xFFFFFFFFFFFFFFFF) += 0x32;
+            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0xfa000;
+            *(unsigned short*)(((int)((char *)this) + 0x370) & 0xFFFFFFFFFFFFFFFF) += 0x32;
             break;
         case 2:
-            *(int*)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x1f4000;
-            *(unsigned char*)(self + 0x372) = 1;
-            *(int*)(self + 0xa8) = v;
+            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x1f4000;
+            unk_372 = 1;
+            unk_0a8 = v;
             break;
         }
     }
     return 1;
-}
 }

--- a/src/_ZN11PyramidStep6RenderEv.cpp
+++ b/src/_ZN11PyramidStep6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN11PyramidStep6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PyramidStep.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x320]; Base base; };
-extern "C" int _ZN11PyramidStep6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int PyramidStep::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN11PyramidStepD0Ev.c
+++ b/src/_ZN11PyramidStepD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11PyramidStepD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN11PyramidStepD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjDpBrock_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11PyramidStepD1Ev.c
+++ b/src/_ZN11PyramidStepD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN11PyramidStepD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjDpBrock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN11PyramidStepD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjDpBrock_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN11RaycastLine4Line3SetERK7Vector3S3_.c
+++ b/src/_ZN11RaycastLine4Line3SetERK7Vector3S3_.c
@@ -1,9 +1,12 @@
+// @symbol _ZN11RaycastLine4Line3SetERK7Vector3S3_
+/* recovered: named members + shared header */
+#include "RaycastLine__Line.h"
 struct V3 { int x, y, z; };
-void _ZN11RaycastLine4Line3SetERK7Vector3S3_(struct V3* o, const struct V3* a, const struct V3* b){
-  o->x = a->x;
-  o->y = a->y;
-  o->z = a->z;
-  *(int*)((char*)o+0xc) = b->x;
-  *(int*)((char*)o+0x10) = b->y;
-  *(int*)((char*)o+0x14) = b->z;
+void _ZN11RaycastLine4Line3SetERK7Vector3S3_(struct RaycastLine__Line *self, const struct V3* a, const struct V3* b) {
+  ((struct V3*)self)->x = a->x;
+  ((struct V3*)self)->y = a->y;
+  ((struct V3*)self)->z = a->z;
+  *(int*)((char*)&self->unk_00c) = b->x;
+  *(int*)((char*)&self->unk_010) = b->y;
+  *(int*)((char*)&self->unk_014) = b->z;
 }

--- a/src/_ZN11RaycastLineD1Ev.c
+++ b/src/_ZN11RaycastLineD1Ev.c
@@ -1,16 +1,14 @@
-extern void func_0203ac50(void *);
-extern void func_ov002_020feab8(void *);
-extern void func_020380ec(void *);
-extern void func_020354d0(void *);
-extern int VT0[];
-extern int VT1[];
-int *_ZN11RaycastLineD1Ev(int *t)
-{
-    t[0] = (int)VT0;
-    *(int *)((char *)t + 0x10) = (int)VT1;
-    func_0203ac50((char *)t + 0x64);
-    func_ov002_020feab8((char *)t + 0x38);
-    func_020380ec((char *)t + 0x10);
-    func_020354d0(t);
-    return t;
+// @symbol _ZN11RaycastLineD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "RaycastLine.h"
+int *_ZN11RaycastLineD1Ev(struct RaycastLine *self) {
+    ((int *)self)[0] = (int)VT0;
+    *(int *)((char *)&self->unk_010) = (int)VT1;
+    func_0203ac50((char *)&self->unk_064);
+    func_ov002_020feab8((char *)&self->unk_038);
+    func_020380ec((char *)&self->unk_010);
+    func_020354d0(((int *)self));
+    return ((int *)self);
 }

--- a/src/_ZN11RickshawBdwD0Ev.c
+++ b/src/_ZN11RickshawBdwD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN11RickshawBdwD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN11RickshawBdwD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN11RickshawBdwD1Ev.c
+++ b/src/_ZN11RickshawBdwD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN11RickshawBdwD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm1_Kuruma_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN11RickshawBdwD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjKm1_Kuruma_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN11RollingRock13InitResourcesEv.cpp
+++ b/src/_ZN11RollingRock13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11RollingRock13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "RollingRock.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -22,9 +25,9 @@ struct SharedFilePtr { void* file; void* bmd; };
 extern SharedFilePtr data_ov021_02114a50;
 extern short data_02082214[];
 
-extern "C" int _ZN11RollingRock13InitResourcesEv(void* self)
+int RollingRock::InitResources()
 {
-    u8* c = (u8*)self;
+    u8* c = (u8*)((void*)this);
     *(u8*)(c+0x3be) = (u8)(*(u32*)(c+8) & 0xf);
     *(u8*)(c+0x3c1) = 0xff;
     *(signed char*)(c+0x3c0) = -1;
@@ -38,7 +41,7 @@ extern "C" int _ZN11RollingRock13InitResourcesEv(void* self)
         if (_ZN11ShadowModel12InitCylinderEv((void*)(c+0x160)) == 0)
             return 0;
 
-        _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((void*)(c+0x1f8), self, 0x12c000, 0, 0, 0);
+        _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((void*)(c+0x1f8), ((void*)this), 0x12c000, 0, 0, 0);
         _ZN12WithMeshClsn13SetLimMovFlagEv((void*)(c+0x1f8));
         *(s32*)(c+0x3b8) = 0;
 
@@ -46,11 +49,11 @@ extern "C" int _ZN11RollingRock13InitResourcesEv(void* self)
             Vec3 pos;
             *(u8*)(c+0x3c1) = (u8)((*(u32*)(c+8) >> 8) & 0xf);
             pos.x = 0; pos.y = 0; pos.z = 0;
-            _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x1b8), self, &pos, 0x10e000, 0x226000, 0x200004, 0x3c0);
+            _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x1b8), ((void*)this), &pos, 0x10e000, 0x226000, 0x200004, 0x3c0);
         } else {
             Vec3 pos;
             pos.x = 0; pos.y = 0; pos.z = 0;
-            _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x1b8), self, &pos, 0xf3000, 0x226000, 0x200004, 0x3c0);
+            _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x1b8), ((void*)this), &pos, 0xf3000, 0x226000, 0x200004, 0x3c0);
 
             if (*(u8*)(c+0x3be) == 3) {
                 *(u8*)(c+0x3c1) = (u8)((*(u32*)(c+8) >> 8) & 0xf);
@@ -68,7 +71,7 @@ extern "C" int _ZN11RollingRock13InitResourcesEv(void* self)
     }
 
     if (*(u8*)(c+0x3be) != 1 && *(u8*)(c+0x3c1) != 0xff) {
-        *(u8*)(c+0x3c0) = _ZN5Actor9TrackStarEjj(self, *(u8*)(c+0x3c1), 2);
+        *(u8*)(c+0x3c0) = _ZN5Actor9TrackStarEjj(((void*)this), *(u8*)(c+0x3c1), 2);
     }
     *(s32*)(c+0x3c4) = 0;
     *(s32*)(c+0x10c) = 0;

--- a/src/_ZN11RollingRock6RenderEv.cpp
+++ b/src/_ZN11RollingRock6RenderEv.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN11RollingRock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RollingRock.h"
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
-extern "C" {
-int _ZN11RollingRock6RenderEv(char* c){
-  if(*(unsigned char*)(c+0x3be) >= 2)
-    ((Sub*)(c+0x110))->g5(0);
+
+int RollingRock::Render()
+{
+  if(mType >= 2)
+    ((Sub*)((char*)&mModel))->g5(0);
   return 1;
-}
 }

--- a/src/_ZN11RollingRockD0Ev.c
+++ b/src/_ZN11RollingRockD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN11RollingRockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daGrock_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN11RollingRockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daGrock_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1f8);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b8);
     _ZN11ShadowModelD1Ev((char *)t + 0x160);

--- a/src/_ZN11RollingRockD1Ev.c
+++ b/src/_ZN11RollingRockD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN11RollingRockD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV11RollingRock */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN11RollingRockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11RollingRock;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1f8);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b8);
     _ZN11ShadowModelD1Ev((char *)t + 0x160);

--- a/src/_ZN11ShadowModel10InitCuboidEv.cpp
+++ b/src/_ZN11ShadowModel10InitCuboidEv.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol _ZN11ShadowModel10InitCuboidEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShadowModel.h"
 extern "C" {
 int func_02016fd4(void* self, void* file, int a, int b);
-extern int data_020ad524;
 }
 
-extern "C" int _ZN11ShadowModel10InitCuboidEv(void* self)
+int ShadowModel::InitCuboid()
 {
-    return func_02016fd4(self, &data_020ad524, 1, -1);
+    return func_02016fd4(((void*)this), &data_020ad524, 1, -1);
 }

--- a/src/_ZN11ShadowModel12InitCylinderEv.cpp
+++ b/src/_ZN11ShadowModel12InitCylinderEv.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol _ZN11ShadowModel12InitCylinderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShadowModel.h"
 extern "C" {
 int func_02016fd4(void* self, void* file, int a, int b);
-extern int data_020ad560;
 }
 
-extern "C" int _ZN11ShadowModel12InitCylinderEv(void* self)
+int ShadowModel::InitCylinder()
 {
-    return func_02016fd4(self, &data_020ad560, 1, -1);
+    return func_02016fd4(((void*)this), &data_020ad560, 1, -1);
 }

--- a/src/_ZN11ShadowModel9DoSetFileEPcii.c
+++ b/src/_ZN11ShadowModel9DoSetFileEPcii.c
@@ -1,3 +1,6 @@
+// @symbol _ZN11ShadowModel9DoSetFileEPcii
+/* recovered: named members + shared header */
+#include "ShadowModel.h"
 struct ModelComponents {
     void *modelFile;
     void *materials;
@@ -12,23 +15,22 @@ struct ModelFile { char pad[0x24]; int materialCount; };
 extern struct ModelComponents *func_02016e70(void *file);
 extern void _ZN15ModelComponents21UpdateVertsUsingBonesEv(struct ModelComponents *data);
 
-int _ZN11ShadowModel9DoSetFileEPcii(char *self, void *file, int flag)
-{
-    *(struct ModelComponents **)(self + 8) = func_02016e70(file);
+int _ZN11ShadowModel9DoSetFileEPcii(struct ShadowModel *self, void *file, int flag) {
+    *(struct ModelComponents **)((char *)&self->unk_008) = func_02016e70(file);
 
-    if (*(struct ModelComponents **)(self + 8) == 0)
+    if (*(struct ModelComponents **)((char *)&self->unk_008) == 0)
         return 0;
 
-    _ZN15ModelComponents21UpdateVertsUsingBonesEv(*(struct ModelComponents **)(self + 8));
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv(*(struct ModelComponents **)((char *)&self->unk_008));
 
     if (flag != 0) {
-        struct ModelComponents *data = *(struct ModelComponents **)(self + 8);
+        struct ModelComponents *data = *(struct ModelComponents **)((char *)&self->unk_008);
         struct ModelFile *mf = (struct ModelFile *)data->modelFile;
         unsigned int n = mf->materialCount;
         struct Material *mat = (struct Material *)data->materials;
 
         for (unsigned int i = 0; i < n; i++) {
-            *(unsigned int *)(((long long)(int)&mat->flags) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+            *(unsigned int *)(((long long)(int)&mat->flags)) |= 0x8000;
             mat = (struct Material *)((char *)mat + 0x30);
         }
     }

--- a/src/_ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j.c
+++ b/src/_ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j.c
@@ -1,14 +1,17 @@
-extern unsigned char data_0209ceec[];
-extern void* data_0209cef4[];
-void _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j(void* c, int a1, int a2, int a3, int a4, unsigned char a5){
-  *(int*)((char*)c+0xc) = a1;
-  *(int*)((char*)c+0x10) = a2;
-  *(int*)((char*)c+0x14) = a3;
-  *(int*)((char*)c+0x18) = a4;
-  *(unsigned char*)((char*)c+0x1c) = a5;
+// @symbol _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ShadowModel.h"
+void _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j(struct ShadowModel *self, int a1, int a2, int a3, int a4, unsigned char a5) {
+  *(int*)((char*)&self->unk_00c) = a1;
+  *(int*)((char*)&self->unk_010) = a2;
+  *(int*)((char*)&self->unk_014) = a3;
+  *(int*)((char*)&self->unk_018) = a4;
+  *(unsigned char*)((char*)&self->unk_01c) = a5;
   if(data_0209ceec[0]) return;
-  *(void**)((char*)c+0x24) = *(void* volatile*)&data_0209cef4[0];
+  *(void**)((char*)&self->unk_024) = *(void* volatile*)&data_0209cef4[0];
   void* head = data_0209cef4[0];
-  if(head) *(void**)((char*)head+0x20) = c;
-  data_0209cef4[0] = c;
+  if(head) *(void**)((char*)head+0x20) = ((void*)self);
+  data_0209cef4[0] = ((void*)self);
 }

--- a/src/_ZN11SnowmanBody13InitResourcesEv.cpp
+++ b/src/_ZN11SnowmanBody13InitResourcesEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN11SnowmanBody13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanBody.h"
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
@@ -10,51 +14,50 @@ extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround* self);
 extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* self, const Vector3& v, void* actor);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
-extern "C" void func_ov072_0211fcb0(char* self, int a);
 extern "C" void func_ov072_0211f3e4(char* self);
 extern "C" void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 
 struct Block48 { int w[12]; };
 
-extern void* data_ov072_02122b20;
 extern Block48 data_02082128;
 
-extern "C" int _ZN11SnowmanBody13InitResourcesEv(char* self) {
+int SnowmanBody::InitResources()
+{
     RaycastGround rc;
     Vector3 pos;
     void* file = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov072_02122b20);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, file, 1, 1);
-    if (_ZN11ShadowModel12InitCylinderEv(self + 0x124) == 0)
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, file, 1, 1);
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
         return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self + 0x14c, self, 0x82000, 0x104000, 0x800004, 0);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(self + 0x180, self, 0x82000, 0x82000, 0, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x14c, ((char*)this), 0x82000, 0x104000, 0x800004, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x180, ((char*)this), 0x82000, 0x82000, 0, 0);
     {
         int p60;
-        pos.x = *(int*)(self + 0x5c);
-        p60 = *(int*)(self + 0x60);
+        pos.x = mPosX;
+        p60 = mPosY;
         pos.y = p60;
-        pos.z = *(int*)(self + 0x64);
+        pos.z = mPosZ;
         pos.y = p60 + 0x14000;
     }
     _ZN13RaycastGroundC1Ev(&rc);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rc, pos, 0);
     if (_ZN13RaycastGround10DetectClsnEv(&rc))
-        *(int*)(self + 0x60) = rc.floor[(0x44 - 0x14) / 4];
+        mPosY = rc.floor[(0x44 - 0x14) / 4];
     else
-        *(int*)(self + 0x60) = pos.y;
-    *(int*)(self + 0x33c) = *(int*)(self + 0x5c);
-    *(int*)(self + 0x340) = *(int*)(self + 0x60);
-    *(int*)(self + 0x344) = *(int*)(self + 0x64);
-    *(short*)(self + 0x348) = *(short*)(self + 0x8c);
-    *(short*)(self + 0x34a) = *(short*)(self + 0x8e);
-    *(short*)(self + 0x34c) = *(short*)(self + 0x90);
-    *(unsigned char*)(self + 0x3a4) = 0x5a;
-    func_ov072_0211fcb0(self, 0);
-    *(int*)(self + 0x390) = 0;
-    *(Block48*)(self + 0x350) = data_02082128;
-    func_ov072_0211f3e4(self);
-    _ZN7PathPtr6FromIDEj(self + 0x380, *(unsigned int*)(self + 8) & 0xff);
+        mPosY = pos.y;
+    unk_33c = mPosX;
+    unk_340 = mPosY;
+    unk_344 = mPosZ;
+    unk_348 = unk_08c;
+    unk_34a = unk_08e;
+    unk_34c = unk_090;
+    unk_3a4 = 0x5a;
+    func_ov072_0211fcb0(((char*)this), 0);
+    unk_390 = 0;
+    *(Block48*)((char*)&unk_350) = data_02082128;
+    func_ov072_0211f3e4(((char*)this));
+    _ZN7PathPtr6FromIDEj(((char*)this) + 0x380, mParam & 0xff);
     _ZN13RaycastGroundD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN11SnowmanBody6RenderEv.cpp
+++ b/src/_ZN11SnowmanBody6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN11SnowmanBody6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanBody.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void M(void*); };
 struct Sub : Base { };
 struct C { char p1[0xd4]; Sub sub; };
-extern "C" int _ZN11SnowmanBody6RenderEv(C* c){
-  c->sub.M((char*)c+0x80);
+
+int SnowmanBody::Render()
+{
+  ((C*)this)->sub.M((char*)&mScaleX);
   return 1;
 }

--- a/src/_ZN11SnowmanBody8BehaviorEv.cpp
+++ b/src/_ZN11SnowmanBody8BehaviorEv.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol _ZN11SnowmanBody8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanBody.h"
 struct CylinderClsn { void Clear(); void Update(); };
-extern "C" void func_ov072_0211fc3c(void *c);
 extern "C" void func_ov072_0211f3e4(void *c);
 
-extern "C" int _ZN11SnowmanBody8BehaviorEv(char *c)
+int SnowmanBody::Behavior()
 {
-    func_ov072_0211fc3c(c);
-    ((CylinderClsn*)(c + 0x14c))->Clear();
-    ((CylinderClsn*)(c + 0x14c))->Update();
-    func_ov072_0211f3e4(c);
+    func_ov072_0211fc3c(((char *)this));
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Clear();
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Update();
+    func_ov072_0211f3e4(((char *)this));
     return 1;
 }

--- a/src/_ZN11SnowmanBodyD0Ev.c
+++ b/src/_ZN11SnowmanBodyD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN11SnowmanBodyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBgSnmBdy_c */
 extern void *G0;
 int *_ZN11SnowmanBodyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBgSnmBdy_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x180);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x14c);
     _ZN11ShadowModelD1Ev((char *)t + 0x124);

--- a/src/_ZN11SnowmanHead13InitResourcesEv.cpp
+++ b/src/_ZN11SnowmanHead13InitResourcesEv.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol _ZN11SnowmanHead13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanHead.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
 
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *ref);
@@ -12,20 +16,18 @@ extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *t, 
 extern void _ZN13RaycastGroundC1Ev(void *t);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *t, const struct Vector3 *pos, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(void *t);
-extern void func_ov072_021205d4(void *c, int v);
 extern void func_ov072_0211ffd8(char *c);
 extern void _ZN13RaycastGroundD1Ev(void *t);
 
-extern void *data_ov072_02122bc4;
-extern void *data_ov072_02121ffc;
 }
 
-extern "C" int _ZN11SnowmanHead13InitResourcesEv(char *c) {
+int SnowmanHead::InitResources()
+{
     struct Vector3 pos;
     char ray[0x54];
     int i;
 
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4,
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4,
         _ZN5Model8LoadFileER13SharedFilePtr(&data_ov072_02122bc4), 1, -1);
 
     for (i = 0; i < 2; i++) {
@@ -35,25 +37,25 @@ extern "C" int _ZN11SnowmanHead13InitResourcesEv(char *c) {
             ((void **)&data_ov072_02122bc4)[1], ((void **)tex)[1]);
     }
 
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x138, c, 0x96000, 0x12c000, 0x800004, 0);
-    *(int *)(c + 0x80) = 0x1800;
-    *(int *)(c + 0x84) = 0x1800;
-    *(int *)(c + 0x88) = 0x1800;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x16c, c, 0x96000, 0x96000, 0, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x138, ((char *)this), 0x96000, 0x12c000, 0x800004, 0);
+    mScaleX = 0x1800;
+    mScaleY = 0x1800;
+    mScaleZ = 0x1800;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x16c, ((char *)this), 0x96000, 0x96000, 0, 0);
 
-    pos.x = *(int *)(c + 0x5c);
-    pos.y = *(int *)(c + 0x60);
-    pos.z = *(int *)(c + 0x64);
+    pos.x = mPosX;
+    pos.y = mPosY;
+    pos.z = mPosZ;
     pos.y += 0x14000;
     _ZN13RaycastGroundC1Ev(ray);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(ray, &pos, 0);
     if (_ZN13RaycastGround10DetectClsnEv(ray) != 0)
-        *(int *)(c + 0x60) = *(int *)(ray + 0x44);
+        mPosY = *(int *)(ray + 0x44);
     else
-        *(int *)(c + 0x60) = pos.y;
+        mPosY = pos.y;
 
-    func_ov072_021205d4(c, 0);
-    func_ov072_0211ffd8(c);
+    func_ov072_021205d4(((char *)this), 0);
+    func_ov072_0211ffd8(((char *)this));
     _ZN13RaycastGroundD1Ev(ray);
     return 1;
 }

--- a/src/_ZN11SnowmanHead6RenderEv.cpp
+++ b/src/_ZN11SnowmanHead6RenderEv.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol _ZN11SnowmanHead6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanHead.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN11SnowmanHead6RenderEv(char* c){
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x124, c+0xdc);
-  ((Sub*)(c+0xd4))->g5(c+0x80);
+
+int SnowmanHead::Render()
+{
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x124, ((char*)this)+0xdc);
+  ((Sub*)((char*)&mModel))->g5((char*)&mScaleX);
   return 1;
-}
 }

--- a/src/_ZN11SnowmanHead8BehaviorEv.cpp
+++ b/src/_ZN11SnowmanHead8BehaviorEv.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol _ZN11SnowmanHead8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanHead.h"
 struct CylinderClsn { void Clear(); void Update(); };
-extern "C" void func_ov072_02120560(void *c);
 extern "C" void func_ov072_0211ffd8(void *c);
 
-extern "C" int _ZN11SnowmanHead8BehaviorEv(char *c)
+int SnowmanHead::Behavior()
 {
-    func_ov072_02120560(c);
-    ((CylinderClsn*)(c + 0x138))->Clear();
-    ((CylinderClsn*)(c + 0x138))->Update();
-    func_ov072_0211ffd8(c);
+    func_ov072_02120560(((char *)this));
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Clear();
+    ((CylinderClsn*)((char *)&mMovingCylinderClsn))->Update();
+    func_ov072_0211ffd8(((char *)this));
     return 1;
 }

--- a/src/_ZN11SnowmanHeadD0Ev.c
+++ b/src/_ZN11SnowmanHeadD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN11SnowmanHeadD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBgSnmHed_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN11SnowmanHeadD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBgSnmHed_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x16c);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x138);
     _ZN15TextureSequenceD1Ev((char *)t + 0x124);

--- a/src/_ZN11VirtualDoorD0Ev.c
+++ b/src/_ZN11VirtualDoorD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN11VirtualDoorD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "VirtualDoor.h"
 int *_ZN11VirtualDoorD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN11WingFeather13InitResourcesEv.cpp
+++ b/src/_ZN11WingFeather13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN11WingFeather13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WingFeather.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct Actor;
@@ -7,7 +12,6 @@ extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
 extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, Actor *a, int b, int c, unsigned int d, unsigned int e);
-extern "C" void func_ov002_020b2c44(void *self);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, Actor *a, int b, int c, void *d, int e);
 
 extern SharedFilePtr data_ov002_0210da58;
@@ -16,31 +20,30 @@ extern unsigned char data_0209f2d8;
 struct Sub { char pad[0x7c]; short f7c; };
 extern char *data_0209f318;
 
-
-extern "C" int _ZN11WingFeather13InitResourcesEv(char *self)
+int WingFeather::InitResources()
 {
     BMD_File *bmd;
     int b;
 
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da58);
-    if (!_ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, 1))
+    if (!_ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, bmd, 1, 1))
         return 0;
-    if (!_ZN11ShadowModel12InitCylinderEv(self + 0x314))
+    if (!_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel))
         return 0;
 
-    *(int *)(self + 0x9c) = -0x199;
-    *(int *)(self + 0xa0) = -0x28000;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(self + 0x124, (Actor *)self, 0x6e000, 0x6e000, 0x100002, 0);
-    func_ov002_020b2c44(self);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(self + 0x158, (Actor *)self, 0x28000, 0xa000, 0, 0);
+    unk_09c = -0x199;
+    unk_0a0 = -0x28000;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x124, (Actor *)((char *)this), 0x6e000, 0x6e000, 0x100002, 0);
+    func_ov002_020b2c44(((char *)this));
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x158, (Actor *)((char *)this), 0x28000, 0xa000, 0, 0);
 
-    *(short *)(self + 0x8c) = 0x4000;
-    *(short *)(self + 0x90) = -0x4000;
+    unk_08c = 0x4000;
+    unk_090 = -0x4000;
     b = (data_0209f2d8 == 1);
     if (!b) {
-        *(short *)(self + 0x8e) = ((Sub *)(data_0209f318 + 0x100))->f7c + 0x4000;
+        unk_08e = ((Sub *)(data_0209f318 + 0x100))->f7c + 0x4000;
     }
-    *(unsigned char *)(self + 0x384) = 0xb4;
-    *(int *)(self + 0xa8) = 0x3000;
+    unk_384 = 0xb4;
+    unk_0a8 = 0x3000;
     return 1;
 }

--- a/src/_ZN11WingFeather6RenderEv.cpp
+++ b/src/_ZN11WingFeather6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11WingFeather6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "WingFeather.h"
 struct Sub {
     virtual ~Sub() {}
     virtual void a() {}
@@ -6,12 +9,14 @@ struct Sub {
     virtual void c() {}
     virtual int f4(int) = 0;
 };
-extern "C" int _ZN11WingFeather6RenderEv(void *obj) {
-    unsigned char b = *(unsigned char*)((char*)obj + 0x384);
+
+int WingFeather::Render()
+{
+    unsigned char b = *(unsigned char*)((char*)&unk_384);
     if (b < 0x2d) {
         if (b & 1) return 1;
     }
-    Sub *sub = (Sub*)((char*)obj + 0xd4);
+    Sub *sub = (Sub*)((char*)&mModel);
     sub->f4(0);
     return 1;
 }

--- a/src/_ZN11WingFeather8BehaviorEv.cpp
+++ b/src/_ZN11WingFeather8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN11WingFeather8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "WingFeather.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -31,73 +34,74 @@ extern void* data_0209f318;
 
 #pragma opt_common_subs off
 
-extern "C" int _ZN11WingFeather8BehaviorEv(char* self) {
+int WingFeather::Behavior()
+{
     {
         int b = (data_0209f2d8 == 1);
         if (!b) {
-            void* p = _ZN5Actor13ClosestPlayerEv(self);
+            void* p = _ZN5Actor13ClosestPlayerEv(((char*)this));
             if (*(int*)((char*)p + 8) != 0 || _ZN6Player15IsCollectingCapEv(p) != 0) {
-                _ZN5Actor13SmallPoofDustEv(self);
-                _ZN9ActorBase18MarkForDestructionEv(self);
+                _ZN5Actor13SmallPoofDustEv(((char*)this));
+                _ZN9ActorBase18MarkForDestructionEv(((char*)this));
                 return 1;
             }
         }
     }
 
-    *(u32*)(self + 0x380) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-        *(u32*)(self + 0x380), 0x4a, *(int*)(self + 0x5c), *(int*)(self + 0x60), *(int*)(self + 0x64), 0, 0);
+    unk_380 = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        unk_380, 0x4a, mPosX, mPosY, mPosZ, 0, 0);
 
-    _ZN5Actor9UpdatePosEP12CylinderClsn(self, 0);
-    func_020383fc(self + 0x158);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), 0);
+    func_020383fc((char*)&mWithMeshClsn);
 
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x158) != 0) {
-        _Z15ApproachLinear2Rsss((short*)(self + 0x37c), 0, 0x50);
-        _Z14ApproachLinearRiii((int*)(self + 0x98), 0, 0x555);
-        if (DecIfAbove0_Byte((u8*)(self + 0x384)) == 0) {
-            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, *(int*)(self + 0x5c), *(int*)(self + 0x60), *(int*)(self + 0x64));
-            _ZN9ActorBase18MarkForDestructionEv(self);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char*)&mWithMeshClsn) != 0) {
+        _Z15ApproachLinear2Rsss((short*)((char*)&unk_37c), 0, 0x50);
+        _Z14ApproachLinearRiii((int*)((char*)&unk_098), 0, 0x555);
+        if (DecIfAbove0_Byte((u8*)((char*)&unk_384)) == 0) {
+            _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, mPosX, mPosY, mPosZ);
+            _ZN9ActorBase18MarkForDestructionEv(((char*)this));
         }
     } else {
-        short* angp = (short*)((((s64)(self + 0x37c))) & 0xFFFFFFFFFFFFFFFFLL);
+        short* angp = (short*)((((s64)((char*)&unk_37c))));
         short old_ang = *angp;
         *angp = old_ang + 0x400;
-        u16 newv = *(u16*)((char*)(self + 0x300) + 0x7c);
+        u16 newv = *(u16*)((char*)((char*)&unk_300) + 0x7c);
         int idx = ((newv >> 4) << 1) + 1;
-        *(int*)(self + 0x98) = (int)(((s64)*(int*)(self + 0x378) * data_02082214[idx] + 0x800) >> 12);
+        unk_098 = (int)(((s64)unk_378 * data_02082214[idx] + 0x800) >> 12);
     }
 
-    _Z14ApproachLinearRiii((int*)(self + 0x378), 0x10000, 0x332);
+    _Z14ApproachLinearRiii((int*)((char*)&unk_378), 0x10000, 0x332);
 
     {
-        int idx2 = (*(u16*)(self + 0x37c) >> 4) << 1;
-        *(s16*)(self + 0x8c) = data_02082214[idx2] + 0x4000;
-        int idx3 = ((*(u16*)(self + 0x37c) >> 4) << 1) + 1;
-        *(s16*)(self + 0x90) = data_02082214[idx3] * 2 - 0x6000;
+        int idx2 = (unk_37c >> 4) << 1;
+        unk_08c = data_02082214[idx2] + 0x4000;
+        int idx3 = ((unk_37c >> 4) << 1) + 1;
+        unk_090 = data_02082214[idx3] * 2 - 0x6000;
     }
 
     {
         int b = (data_0209f2d8 == 1);
         if (!b) {
-            *(s16*)(self + 0x8e) = *(s16*)((char*)data_0209f318 + 0x17c) + 0x4000;
+            unk_08e = *(s16*)((char*)data_0209f318 + 0x17c) + 0x4000;
         }
     }
 
-    u32 id = *(u32*)(self + 0x148);
+    u32 id = unk_148;
     if (id != 0) {
         void* a = _ZN5Actor10FindWithIDEj(id);
         if (a != 0) {
             int eq = (*(u16*)((char*)a + 0xc) == 0xbf);
             if (eq) {
                 _ZN6Player16InitWingFeathersEb(a, 1);
-                _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, *(int*)(self + 0x5c), *(int*)(self + 0x60), *(int*)(self + 0x64));
-                _ZN9ActorBase18MarkForDestructionEv(self);
+                _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, mPosX, mPosY, mPosZ);
+                _ZN9ActorBase18MarkForDestructionEv(((char*)this));
                 return 1;
             }
         }
     }
 
-    _ZN12CylinderClsn5ClearEv(self + 0x124);
-    _ZN12CylinderClsn6UpdateEv(self + 0x124);
-    func_ov002_020b2c44(self);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
+    func_ov002_020b2c44(((char*)this));
     return 1;
 }

--- a/src/_ZN11WingFeatherD0Ev.c
+++ b/src/_ZN11WingFeatherD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN11WingFeatherD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daFeather_c */
 extern void *G0;
 int *_ZN11WingFeatherD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daFeather_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x314);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x158);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x124);

--- a/src/_ZN12CylinderClsn4InitE5Fix12IiES1_jj.cpp
+++ b/src/_ZN12CylinderClsn4InitE5Fix12IiES1_jj.cpp
@@ -1,7 +1,10 @@
 //cpp
-extern "C" void _ZN12CylinderClsn4InitE5Fix12IiES1_jj(int* c,int a,int b,unsigned d,unsigned e){
-  c[1]=a;
-  c[2]=b;
-  *(int*)((char*)c+0x18)=d;
-  *(int*)((char*)c+0x1c)=e;
+// @symbol _ZN12CylinderClsn4InitE5Fix12IiES1_jj
+/* recovered: named members + shared header */
+#include "CylinderClsn.h"
+extern "C" void _ZN12CylinderClsn4InitE5Fix12IiES1_jj(struct CylinderClsn *self, int a, int b, unsigned d, unsigned e) {
+  ((int*)self)[1]=a;
+  ((int*)self)[2]=b;
+  *(int*)((char*)&self->unk_018)=d;
+  *(int*)((char*)&self->unk_01c)=e;
 }

--- a/src/_ZN12CylinderClsn6UpdateEv.cpp
+++ b/src/_ZN12CylinderClsn6UpdateEv.cpp
@@ -1,11 +1,17 @@
 //cpp
+// @symbol _ZN12CylinderClsn6UpdateEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CylinderClsn.h"
 extern "C" {
-extern void* data_0209cee8;
-void _ZN12CylinderClsn6UpdateEv(char* c){
-  if(*(int*)(c+0x18) & 1) return;
-  void* h = data_0209cee8;
-  *(void**)(c+0x2c) = h;
-  if(data_0209cee8) *(void**)((char*)data_0209cee8+0x28) = c;
-  data_0209cee8 = c;
 }
+
+void CylinderClsn::Update()
+{
+  if(unk_018 & 1) return;
+  void* h = data_0209cee8;
+  *(void**)((char*)&unk_02c) = h;
+  if(data_0209cee8) *(void**)((char*)data_0209cee8+0x28) = ((char*)this);
+  data_0209cee8 = ((char*)this);
 }

--- a/src/_ZN12CylinderClsnC2Ev.cpp
+++ b/src/_ZN12CylinderClsnC2Ev.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN12CylinderClsnC2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "CylinderClsn.h"
 extern "C" {
-extern int data_0208e6ec[];
-void _ZN12CylinderClsnC2Ev(void* c){
-  *(int*)((char*)c+0)=(int)data_0208e6ec;
-  *(int*)((char*)c+0x28)=0;
-  *(int*)((char*)c+0x2c)=0;
+void _ZN12CylinderClsnC2Ev(struct CylinderClsn *self) {
+  *(int*)((char*)&self->unk_000)=(int)data_0208e6ec;
+  *(int*)((char*)&self->unk_028)=0;
+  *(int*)((char*)&self->unk_02c)=0;
 }
 }

--- a/src/_ZN12CylinderClsnD1Ev.c
+++ b/src/_ZN12CylinderClsnD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN12CylinderClsnD1Ev
+/* recovered: named members + shared header */
+#include "CylinderClsn.h"
 /* CylinderClsn::~CylinderClsn() at 0x020150a8
  * Complete-object destructor (D1). Installs the CylinderClsn vtable, then runs
  * the base subobject destructor (func_02014fa4). Returns this.

--- a/src/_ZN12CylinderClsnD2Ev.c
+++ b/src/_ZN12CylinderClsnD2Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN12CylinderClsnD2Ev
+/* recovered: named members + shared header */
+#include "CylinderClsn.h"
 /* CylinderClsn::~CylinderClsn() at 0x02015058
  * Base-object destructor (D2). Installs the CylinderClsn vtable, then runs the
  * base subobject destructor (func_02014fa4). Returns this.

--- a/src/_ZN12EnemySpawnerD0Ev.c
+++ b/src/_ZN12EnemySpawnerD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN12EnemySpawnerD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "EnemySpawner.h"
 int *_ZN12EnemySpawnerD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN12FallBlockBbh16CleanupResourcesEv.cpp
+++ b/src/_ZN12FallBlockBbh16CleanupResourcesEv.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol _ZN12FallBlockBbh16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FallBlockBbh.h"
 // Cross-overlay tail-call veneer. #pragma long_calls forces mwccarm to emit the pooled
 // `ldr ip,[pc]; bx ip` indirect tail-call (a plain near `b` otherwise) that the ROM uses
 // to reach another overlay. Loads the data pointer into r1; this stays in r0.
 #pragma long_calls on
 extern "C" {
-extern int func_ov098_0213a2cc(void *thisp, void *data);
-extern char data_ov063_0211eb10[];
-
-int _ZN12FallBlockBbh16CleanupResourcesEv(void *thisp)
-{
-    return func_ov098_0213a2cc(thisp, data_ov063_0211eb10);
 }
+
+int FallBlockBbh::CleanupResources()
+{
+    return func_ov098_0213a2cc(((void *)this), data_ov063_0211eb10);
 }

--- a/src/_ZN12FallBlockBbhD0Ev.c
+++ b/src/_ZN12FallBlockBbhD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockBbhD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12FallBlockBbhD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjTh_Fall_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FallBlockBbhD1Ev.c
+++ b/src/_ZN12FallBlockBbhD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockBbhD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjTh_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockBbhD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjTh_Fall_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FallBlockBfsD0Ev.c
+++ b/src/_ZN12FallBlockBfsD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockBfsD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12FallBlockBfsD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FallBlockBfsD1Ev.c
+++ b/src/_ZN12FallBlockBfsD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockBfsD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm2_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockBfsD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV21daObjKm2_Fall_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FallBlockLll8BehaviorEv.cpp
+++ b/src/_ZN12FallBlockLll8BehaviorEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN12FallBlockLll8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "FallBlockLll.h"
 extern "C" {
 void func_020393a4(void* p, int v);
 unsigned char func_ov080_0212714c(void* a, void* b);
 extern int data_ov035_02112c98[];
-int _ZN12FallBlockLll8BehaviorEv(char* c){
-  func_020393a4(c+0x124, 0x500000);
-  return func_ov080_0212714c(c, data_ov035_02112c98) & 0xff;
 }
+
+int FallBlockLll::Behavior()
+{
+  func_020393a4(((char*)this)+0x124, 0x500000);
+  return func_ov080_0212714c(((char*)this), data_ov035_02112c98) & 0xff;
 }

--- a/src/_ZN12FallBlockLllD0Ev.c
+++ b/src/_ZN12FallBlockLllD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockLllD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFlMaruta_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12FallBlockLllD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFlMaruta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12FallBlockLllD1Ev.c
+++ b/src/_ZN12FallBlockLllD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12FallBlockLllD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFlMaruta_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FallBlockLllD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFlMaruta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12Flamethrower13InitResourcesEv.cpp
+++ b/src/_ZN12Flamethrower13InitResourcesEv.cpp
@@ -1,16 +1,18 @@
 //cpp
+// @symbol _ZN12Flamethrower13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Flamethrower.h"
 #pragma opt_strength_reduction off
 struct Vec3 { int x, y, z; };
-extern "C" void Matrix4x3_FromRotationXYZExt(void *m, int x, int y, int z);
 extern "C" void MulVec3Mat4x3(struct Vec3 *v, void *m, struct Vec3 *dst);
 extern "C" void Vec3_Add(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
 extern "C" void _ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj(void *self, struct Vec3 *pos, int fix, int t, unsigned int a, unsigned int b);
 
 extern signed char data_0209f2f8;
-extern int data_ov095_02136fb0[];
-extern short data_ov095_02136f80[];
 
-extern "C" int _ZN12Flamethrower13InitResourcesEv(char *sl)
+int Flamethrower::InitResources()
 {
     int count;
     int i;
@@ -27,14 +29,14 @@ extern "C" int _ZN12Flamethrower13InitResourcesEv(char *sl)
 
     count = 0xc;
     if (data_0209f2f8 == 0xc) count = 9;
-    Matrix4x3_FromRotationXYZExt(sl + 0x434, *(short *)(sl + 0x8c), *(short *)(sl + 0x8e), *(short *)(sl + 0x90));
+    Matrix4x3_FromRotationXYZExt(((char *)this) + 0x434, unk_08c, unk_08e, unk_090);
     zero = 0;
     flag = 0;
     i = 0;
     if (i < count) {
-        p6 = sl;
-        p5 = sl + 0x3a4;
-        p4 = sl + 0xd4;
+        p6 = ((char *)this);
+        p5 = ((char *)this) + 0x3a4;
+        p4 = ((char *)this) + 0xd4;
         do {
         im1 = i - 1;
         in.x = zero;
@@ -44,14 +46,14 @@ extern "C" int _ZN12Flamethrower13InitResourcesEv(char *sl)
         dst.y = zero;
         dst.z = zero;
         in.z = data_ov095_02136fb0[i];
-        MulVec3Mat4x3(&in, sl + 0x434, &dst);
+        MulVec3Mat4x3(&in, ((char *)this) + 0x434, &dst);
         if (im1 < 0) {
-            Vec3_Add(&sum, (struct Vec3 *)(sl + 0x5c), &dst);
+            Vec3_Add(&sum, (struct Vec3 *)((char *)&unk_05c), &dst);
             *(int *)(p6 + 0x3a4) = sum.x;
             *(int *)(p6 + 0x3a8) = sum.y;
             *(int *)(p6 + 0x3ac) = sum.z;
         } else {
-            Vec3_Add(&sum2, (struct Vec3 *)(sl + 0x3a4 + im1 * 0xc), &dst);
+            Vec3_Add(&sum2, (struct Vec3 *)(((char *)this) + 0x3a4 + im1 * 0xc), &dst);
             *(int *)(p6 + 0x3a4) = sum2.x;
             *(int *)(p6 + 0x3a8) = sum2.y;
             *(int *)(p6 + 0x3ac) = sum2.z;

--- a/src/_ZN12FlamethrowerD0Ev.cpp
+++ b/src/_ZN12FlamethrowerD0Ev.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol _ZN12FlamethrowerD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Flamethrower.h"
 extern "C" {
-extern int _ZTV12Flamethrower[];
 extern int func_020072c0[];
 extern int data_020a0eac[];
 extern int _ZN19CylinderClsnWithPosD1Ev[];

--- a/src/_ZN12FlamethrowerD1Ev.cpp
+++ b/src/_ZN12FlamethrowerD1Ev.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN12FlamethrowerD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Flamethrower.h"
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ActorD2Ev(void*);
-extern int _ZTV12Flamethrower[];
 extern int func_020072c0[];
 extern int _ZN19CylinderClsnWithPosD1Ev();
 int _ZN12FlamethrowerD1Ev(char* c){

--- a/src/_ZN12FortressWall6RenderEv.cpp
+++ b/src/_ZN12FortressWall6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN12FortressWall6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FortressWall.h"
 struct Base {
     virtual int vf0(int);
     virtual int vf1(int);
@@ -11,8 +14,10 @@ struct Obj {
     char pad[0xd4];
     Base sub;
 };
-extern "C" int _ZN12FortressWall6RenderEv(Obj *c) {
-    if (*(unsigned char*)((char*)c+0x321) != 0) return 1;
-    c->sub.vfunc(0);
+
+int FortressWall::Render()
+{
+    if (*(unsigned char*)((char*)&unk_321) != 0) return 1;
+    ((Obj *)this)->sub.vfunc(0);
     return 1;
 }

--- a/src/_ZN12FortressWallD0Ev.c
+++ b/src/_ZN12FortressWallD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN12FortressWallD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBk_Kabe_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12FortressWallD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjBk_Kabe_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12FortressWallD1Ev.c
+++ b/src/_ZN12FortressWallD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN12FortressWallD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBk_Kabe_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12FortressWallD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjBk_Kabe_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12HauntedChair6RenderEv.cpp
+++ b/src/_ZN12HauntedChair6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN12HauntedChair6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "HauntedChair.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN12HauntedChair6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int HauntedChair::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN12HauntedChairD0Ev.c
+++ b/src/_ZN12HauntedChairD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN12HauntedChairD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daChair_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN12HauntedChairD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daChair_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1bc);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x17c);
     _ZN11ShadowModelD1Ev((char *)t + 0x124);

--- a/src/_ZN12MansionSteps6RenderEv.cpp
+++ b/src/_ZN12MansionSteps6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN12MansionSteps6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MansionSteps.h"
 struct Base {
     virtual int vf0(int);
     virtual int vf1(int);
@@ -11,8 +14,10 @@ struct Obj {
     char pad[0xd4];
     Base sub;
 };
-extern "C" int _ZN12MansionSteps6RenderEv(Obj *c) {
-    if (*(unsigned char*)((char*)c+0x156) == 0) return 1;
-    c->sub.vfunc(0);
+
+int MansionSteps::Render()
+{
+    if (*(unsigned char*)((char*)&unk_156) == 0) return 1;
+    ((Obj *)this)->sub.vfunc(0);
     return 1;
 }

--- a/src/_ZN12MansionSteps8BehaviorEv.cpp
+++ b/src/_ZN12MansionSteps8BehaviorEv.cpp
@@ -1,26 +1,30 @@
 //cpp
+// @symbol _ZN12MansionSteps8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MansionSteps.h"
 extern "C" {
-extern void func_ov063_0211c684(char* c);
 extern int func_ov063_0211c6f8(char* c);
 }
 struct C;
 typedef void (C::*PMF)();
 extern PMF data_ov063_0211ef38[];
 
-extern "C" int _ZN12MansionSteps8BehaviorEv(char* c);
-extern "C" int _ZN12MansionSteps8BehaviorEv(char* c){
-  unsigned char before = *(unsigned char*)(c + 0x150);
-  int idx = *(int*)(c + 0x140);
-  C* obj = (C*)c;
+int MansionSteps::Behavior()
+{
+  unsigned char before = unk_150;
+  int idx = unk_140;
+  C* obj = (C*)((char*)this);
   (obj->*data_ov063_0211ef38[idx])();
-  unsigned short* ctr = (unsigned short*)(((int)c + 0x14c) & 0xFFFFFFFFFFFFFFFF);
+  unsigned short* ctr = (unsigned short*)(((int)((char*)this) + 0x14c) & 0xFFFFFFFFFFFFFFFF);
   *ctr = *ctr + 1;
-  if (before != *(unsigned char*)(c + 0x150)) {
-    unsigned short* base = (unsigned short*)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFF);
+  if (before != unk_150) {
+    unsigned short* base = (unsigned short*)(((int)((char*)this) + 0x100) & 0xFFFFFFFFFFFFFFFF);
     base[0x4c/2] = 0;
   }
-  func_ov063_0211c684(c);
-  func_ov063_0211c6f8(c);
-  *(int*)(c + 0x124) = 0;
+  func_ov063_0211c684(((char*)this));
+  func_ov063_0211c6f8(((char*)this));
+  unk_124 = 0;
   return 1;
 }

--- a/src/_ZN12MansionStepsD0Ev.c
+++ b/src/_ZN12MansionStepsD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN12MansionStepsD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daTrsTrap_c */
 extern void *G0;
 int *_ZN12MansionStepsD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daTrsTrap_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x15c);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,6 @@
+// @symbol _ZN12MeshCollider8LoadFileER13SharedFilePtr
+/* recovered: named members + shared header */
+#include "MeshCollider.h"
 typedef unsigned char u8;
 
 struct SharedFilePtr {

--- a/src/_ZN12MeshColliderD0Ev.c
+++ b/src/_ZN12MeshColliderD0Ev.c
@@ -1,10 +1,11 @@
-extern void func_02038224(void *);
-extern void func_02039658(void *);
-extern void _ZN6Memory16operator_delete2EPv(void *);
-extern int VT0[];
+// @symbol _ZN12MeshColliderD0Ev
+/* recovered: named members + shared header, globals resolved, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, globals resolved */
+/* resolved: VT0 = _ZTV12MeshCollider */
 int *_ZN12MeshColliderD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12MeshCollider;
     func_02038224((char *)t + 0x24);
     func_02039658(t);
     _ZN6Memory16operator_delete2EPv(t);

--- a/src/_ZN12MeshColliderD1Ev.c
+++ b/src/_ZN12MeshColliderD1Ev.c
@@ -1,9 +1,11 @@
-extern void func_02038224(void *);
-extern void func_02039658(void *);
-extern int VT0[];
+// @symbol _ZN12MeshColliderD1Ev
+/* recovered: named members + shared header, globals resolved, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, globals resolved */
+/* resolved: VT0 = _ZTV12MeshCollider */
 int *_ZN12MeshColliderD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12MeshCollider;
     func_02038224((char *)t + 0x24);
     func_02039658(t);
     return t;

--- a/src/_ZN12MetalNetLiftD0Ev.c
+++ b/src/_ZN12MetalNetLiftD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12MetalNetLiftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12MetalNetLiftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjFl_Gura_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12MetalNetLiftD1Ev.c
+++ b/src/_ZN12MetalNetLiftD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN12MetalNetLiftD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjFl_Gura_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12MetalNetLiftD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjFl_Gura_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
+++ b/src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN12PiranhaPlant16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "PiranhaPlant.h"
 extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
 extern int* data_ov084_021302f4;
 extern int data_ov002_0210da38;
-int _ZN12PiranhaPlant16CleanupResourcesEv(void* c){
+}
+
+int PiranhaPlant::CleanupResources()
+{
   int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
   for(i=0;i<6;i++){
     _ZN13SharedFilePtr7ReleaseEv((&data_ov084_021302f4)[i]);
   }
-  UnloadBlueCoinModel(c);
+  UnloadBlueCoinModel(((void*)this));
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   return 1;
-}
 }

--- a/src/_ZN12PiranhaPlant6RenderEv.cpp
+++ b/src/_ZN12PiranhaPlant6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN12PiranhaPlant6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PiranhaPlant.h"
 struct Obj {
     virtual void v0();
     virtual void v1();
@@ -10,12 +13,12 @@ struct Obj {
 struct G2 { int w[2]; };
 extern G2 data_ov084_02130df4;
 
-extern "C" int _ZN12PiranhaPlant6RenderEv(char* c)
+int PiranhaPlant::Render()
 {
-    if (*(int*)(c + 0x80) == 0)
+    if (mScaleX == 0)
         return 1;
-    ((Obj*)(c + 0x110))->m5(c + 0x80);
-    if (*(int*)(c + 0x170) == data_ov084_02130df4.w[1])
-        ((Obj*)(c + 0x174))->m5(c + 0x428);
+    ((Obj*)((char*)&mModelAnim))->m5((char*)&mScaleX);
+    if (unk_170 == data_ov084_02130df4.w[1])
+        ((Obj*)((char*)&mModel))->m5((char*)&unk_428);
     return 1;
 }

--- a/src/_ZN12PiranhaPlant8BehaviorEv.cpp
+++ b/src/_ZN12PiranhaPlant8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN12PiranhaPlant8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PiranhaPlant.h"
 struct Cls { virtual void dummy(); };
 typedef void (Cls::*PMF)();
 extern PMF data_ov084_02130e80[];
@@ -6,61 +11,59 @@ extern "C" {
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void*, void*, void*, unsigned int);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void*, void*);
 extern void _ZN9Animation7AdvanceEv(void*);
-extern void func_ov084_0212f204(void*);
-extern void func_ov084_0212ec60(void*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
 extern void _ZN12CylinderClsn6UpdateEv(void*);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void*, void*);
+}
 
-int _ZN12PiranhaPlant8BehaviorEv(char* c)
+int PiranhaPlant::Behavior()
 {
     int r;
     int old;
     int cur;
-    r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1c4, c + 0x110, 1);
+    r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(((char*)this), ((char*)this) + 0x1c4, ((char*)this) + 0x110, 1);
     if (r != 0) {
         if (r == 2) {
-            *(unsigned char*)(c + 0x108) = 0;
-            *(int*)(c + 0x458) = 7;
-            *(int*)(c + 0x80) = 0;
-            *(int*)(c + 0x84) = 0;
-            *(int*)(c + 0x88) = 0;
-            *(int*)(c + 0x5c) = *(int*)(c + 0x44c);
-            *(int*)(c + 0x60) = *(int*)(c + 0x450);
-            *(int*)(c + 0x64) = *(int*)(c + 0x454);
+            unk_108 = 0;
+            mState = 7;
+            mScaleX = 0;
+            mScaleY = 0;
+            mScaleZ = 0;
+            mPosX = unk_44c;
+            mPosY = unk_450;
+            mPosZ = unk_454;
         }
         return 1;
     }
-    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x380);
-    _ZN9Animation7AdvanceEv(c + 0x160);
-    func_ov084_0212f204(c);
-    old = *(int*)(c + 0x458);
-    (((Cls*)c)->*data_ov084_02130e80[old])();
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char*)this), ((char*)this) + 0x380);
+    _ZN9Animation7AdvanceEv((char*)&mAnimation);
+    func_ov084_0212f204(((char*)this));
+    old = mState;
+    (((Cls*)((char*)this))->*data_ov084_02130e80[old])();
     {
-        unsigned short* p100 = (unsigned short*)(((long long)(int)(c + 0x100)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short* p100 = (unsigned short*)(((long long)(int)((char*)&unk_100)));
         *p100 = (unsigned short)(*p100 + 1);
     }
-    cur = *(int*)(c + 0x458);
+    cur = mState;
     if (old != cur) {
         if (cur == 5) {
-            int* pb0 = (int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* pb0 = (int*)(((long long)(int)((char*)&unk_0b0)));
             *pb0 = *pb0 & ~0x10000000;
         }
-        *(unsigned short*)(c + 0x100) = 0;
-        *(int*)(c + 0x478) = 0;
+        unk_100 = 0;
+        unk_478 = 0;
     }
-    func_ov084_0212ec60(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x380);
-    _ZN12CylinderClsn5ClearEv(c + 0x3b4);
-    _ZN12CylinderClsn5ClearEv(c + 0x3e8);
-    if (*(unsigned char*)(c + 0x45c) != 0) {
-        _ZN12CylinderClsn6UpdateEv(c + 0x380);
-        _ZN12CylinderClsn6UpdateEv(c + 0x3b4);
-        if (*(int*)(c + 0x458) == 2) {
-            _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x3e8, c + 0x440);
-            _ZN12CylinderClsn6UpdateEv(c + 0x3e8);
+    func_ov084_0212ec60(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn1);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn2);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+    if (unk_45c != 0) {
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn1);
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn2);
+        if (mState == 2) {
+            _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0x3e8, ((char*)this) + 0x440);
+            _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
         }
     }
     return 1;
-}
 }

--- a/src/_ZN12PiranhaPlantD0Ev.c
+++ b/src/_ZN12PiranhaPlantD0Ev.c
@@ -1,15 +1,18 @@
+// @symbol _ZN12PiranhaPlantD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daPkn_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN12PiranhaPlantD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daPkn_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x3e8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x3b4);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x380);

--- a/src/_ZN12PiranhaPlantD1Ev.c
+++ b/src/_ZN12PiranhaPlantD1Ev.c
@@ -1,13 +1,17 @@
+// @symbol _ZN12PiranhaPlantD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12PiranhaPlant */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN12PiranhaPlantD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12PiranhaPlant;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x3e8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x3b4);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x380);

--- a/src/_ZN12SwitchPillar13InitResourcesEv.cpp
+++ b/src/_ZN12SwitchPillar13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN12SwitchPillar13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SwitchPillar.h"
 extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
@@ -9,26 +14,24 @@ int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
 int _ZN16MeshColliderBase6EnableEP5Actor(void*,void*);
-extern int data_ov012_021124d0[];
-extern int data_ov012_021124c8[];
-extern int data_ov012_02111c24[];
-extern int data_ov012_02111c90[];
 extern int data_0209caa0[];
-int _ZN12SwitchPillar13InitResourcesEv(char* c){
+}
+
+int SwitchPillar::InitResources()
+{
   _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124d0);
   _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov012_021124c8);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, data_ov012_021124d0[1], 1, 0x14);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, data_ov012_021124d0[1], 1, 0x14);
   _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(data_ov012_021124d0[1], data_ov012_02111c24);
-  _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c+0x320, data_ov012_02111c24, 0, 0x1000, 0);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, data_ov012_021124c8[1], c+0x2ec, 0x1000, *(short*)(c+0x8e), data_ov012_02111c90);
-  _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
-  int v = *(int*)(c+0x60) - 0x4b0000;
-  *(int*)(c+0x334) = v;
+  _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char*)this)+0x320, data_ov012_02111c24, 0, 0x1000, 0);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, data_ov012_021124c8[1], ((char*)this)+0x2ec, 0x1000, unk_08e, data_ov012_02111c90);
+  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  int v = mPosY - 0x4b0000;
+  mLoweredY = v;
   if(data_0209caa0[2] & 0x80000){
-    *(int*)(c+0x60) = *(int*)(c+0x334);
+    mPosY = mLoweredY;
   }
   return 1;
-}
 }

--- a/src/_ZN12SwitchPillar6RenderEv.cpp
+++ b/src/_ZN12SwitchPillar6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN12SwitchPillar6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SwitchPillar.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN12SwitchPillar6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int SwitchPillar::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN12SwitchPillarD0Ev.c
+++ b/src/_ZN12SwitchPillarD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN12SwitchPillarD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN12SwitchPillarD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjC0Water_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12SwitchPillarD1Ev.c
+++ b/src/_ZN12SwitchPillarD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN12SwitchPillarD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjC0Water_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN12SwitchPillarD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjC0Water_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN12WaterSuction13InitResourcesEv.cpp
+++ b/src/_ZN12WaterSuction13InitResourcesEv.cpp
@@ -1,17 +1,21 @@
 //cpp
+// @symbol _ZN12WaterSuction13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WaterSuction.h"
 extern "C" {
 struct V3 { int x, y, z; };
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* thiz, void* actor, V3* vec, int a, int b, unsigned int cc, unsigned int d);
-extern void func_ov026_021122d4(void* c, void* p);
 extern V3 data_ov026_02113f4c;
-extern int data_ov026_02113f58;
 }
 
-extern "C" int _ZN12WaterSuction13InitResourcesEv(char* c){
+int WaterSuction::InitResources()
+{
     V3 vec;
-    *(int*)(c + 0x314) = *(int*)(c + 8) & 0xff;
+    unk_314 = unk_008 & 0xff;
     vec = data_ov026_02113f4c;
-    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c + 0x110, c, &vec, 0x64000, 0xa4000, 0x800006, 0);
-    func_ov026_021122d4(c, &data_ov026_02113f58);
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(((char*)this) + 0x110, ((char*)this), &vec, 0x64000, 0xa4000, 0x800006, 0);
+    func_ov026_021122d4(((char*)this), &data_ov026_02113f58);
     return 1;
 }

--- a/src/_ZN12WaterSuction8BehaviorEv.cpp
+++ b/src/_ZN12WaterSuction8BehaviorEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN12WaterSuction8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WaterSuction.h"
 extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
-extern void func_ov026_02112324(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* a);
 extern void _ZN12CylinderClsn6UpdateEv(void* a);
 }
@@ -15,19 +19,20 @@ struct C {
     Obj* obj;
 };
 
-extern "C" int _ZN12WaterSuction8BehaviorEv(char* cc){
-    C* c = (C*)cc;
-    DecIfAbove0_Short((unsigned short*)(cc + 0x100));
+int WaterSuction::Behavior()
+{
+    C* c = (C*)((char*)this);
+    DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
     Obj* o = c->obj;
     if (*(int*)((char*)o + 8) != 0) {
         (c->*(o->pmf))();
     }
-    _ZN5Actor9UpdatePosEP12CylinderClsn(cc, cc + 0x110);
-    *(short*)(cc + 0x8c) = *(short*)(cc + 0x92);
-    *(short*)(cc + 0x8e) = *(short*)(cc + 0x94);
-    *(short*)(cc + 0x90) = *(short*)(cc + 0x96);
-    func_ov026_02112324(cc);
-    _ZN12CylinderClsn5ClearEv(cc + 0x110);
-    _ZN12CylinderClsn6UpdateEv(cc + 0x110);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this) + 0x110);
+    unk_08c = unk_092;
+    unk_08e = unk_094;
+    unk_090 = unk_096;
+    func_ov026_02112324(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
     return 1;
 }

--- a/src/_ZN12WaterSuctionD0Ev.c
+++ b/src/_ZN12WaterSuctionD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN12WaterSuctionD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daWater_Suikomi_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN12WaterSuctionD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17daWater_Suikomi_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN12WaterSuctionD1Ev.c
+++ b/src/_ZN12WaterSuctionD1Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN12WaterSuctionD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV12WaterSuction */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN12WaterSuctionD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12WaterSuction;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN12WithMeshClsn16UpdateContinuousEv.c
+++ b/src/_ZN12WithMeshClsn16UpdateContinuousEv.c
@@ -1,13 +1,18 @@
+// @symbol _ZN12WithMeshClsn16UpdateContinuousEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_SphereClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "WithMeshClsn.h"
 typedef unsigned char u8;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
-extern int func_020355a0(void* p);
-extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void* p);
 extern int func_02037938(void* p);
 extern void func_02038324(int a, int* b, int c, int d);
 extern void _ZN10ClsnResultC1Ev(ClsnResult* r);
@@ -15,24 +20,17 @@ extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, Vec
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);
 extern void _ZN11RaycastLine10GetClsnPosEv(Vec3* out, void* self);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vec3* out);
-extern int func_02039794(int x);
 extern void _ZNK10ClsnResult6CopyToERS_(void* self, ClsnResult* dst);
-extern void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(void* p);
 extern void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(void* self, Vec3* v, int rad, void* actor);
-extern int func_0203553c(void* p);
 extern void _ZN10SphereClsn14SetFloorResultERK10ClsnResult(void* self, ClsnResult* r);
 extern void _ZN10ClsnResultaSERKS_(void* self, ClsnResult* r);
-extern void func_020371b0(void* clsn, int justHit);
 extern void func_02037888(void* dst, ClsnResult* src);
-extern int _ZN10SphereClsn10DetectClsnEv(void* self);
-extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void* p);
 extern void func_020356d4(void* self);
 extern void _ZN10ClsnResultD1Ev(ClsnResult* r);
 
 #pragma opt_common_subs off
 
-void _ZN12WithMeshClsn16UpdateContinuousEv(char* c)
-{
+void _ZN12WithMeshClsn16UpdateContinuousEv(struct WithMeshClsn *self) {
     int floorFlag;
     int wallFlag;
     int height;
@@ -49,19 +47,19 @@ void _ZN12WithMeshClsn16UpdateContinuousEv(char* c)
     Vec3 sphere;
     char* a;
 
-    a = *(char**)(c + 0x14);
+    a = *(char**)((char*)&self->mActor);
     pos = (int*)(a + 0x5c);
     prev = (int*)(a + 0x68);
 
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c) && func_020355a0(c) && _ZNK12WithMeshClsn15ShouldUpdatePosEv(c))
-        func_02038324(func_02037938(c + 0x20), pos, *(int*)(c + 0x12c), *(int*)(c + 0x130));
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(((char*)self)) && func_020355a0(((char*)self)) && _ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self)))
+        func_02038324(func_02037938((char*)&self->mSphereClsn), pos, self->unk_12c, self->unk_130);
 
     floorFlag = 0;
     _ZN10ClsnResultC1Ev(&res0);
     wallFlag = 0;
     _ZN10ClsnResultC1Ev(&res1);
 
-    height = *(int*)(c + 0x1c);
+    height = self->unk_01c;
     {
         int tx = prev[0];
         int tz = prev[2];
@@ -78,12 +76,12 @@ void _ZN12WithMeshClsn16UpdateContinuousEv(char* c)
         lineEnd.y = ty;
         lineEnd.z = tz;
     }
-    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &lineStart, &lineEnd, *(void**)(c + 0x14));
-    if (_ZN11RaycastLine10DetectClsnEv(c + 0x134))
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(((char*)self) + 0x134, &lineStart, &lineEnd, *(void**)((char*)&self->mActor));
+    if (_ZN11RaycastLine10DetectClsnEv((char*)&self->mRaycastLine))
     {
         int r;
-        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, c + 0x134);
-        _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal);
+        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, ((char*)self) + 0x134);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3(((char*)self) + 0x148, &normal);
         newStart.x = clsnPos.x + (normal.x >> 2);
         newStart.y = (normal.y >> 2) + clsnPos.y;
         newStart.z = clsnPos.z + (normal.z >> 2);
@@ -93,71 +91,71 @@ void _ZN12WithMeshClsn16UpdateContinuousEv(char* c)
         r = func_02039794(normal.y);
         if (r == 1) {
             wallFlag = 1;
-            _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res1);
+            _ZNK10ClsnResult6CopyToERS_(((char*)self) + 0x144, &res1);
         } else if (r == 0) {
             floorFlag = 1;
-            _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res0);
+            _ZNK10ClsnResult6CopyToERS_(((char*)self) + 0x144, &res0);
         }
-        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &newStart, &newEnd, *(void**)(c + 0x14));
-        if (_ZN11RaycastLine10DetectClsnEv(c + 0x134)) {
-            _ZN11RaycastLine10GetClsnPosEv(&clsnPos2, c + 0x134);
-            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal2);
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(((char*)self) + 0x134, &newStart, &newEnd, *(void**)((char*)&self->mActor));
+        if (_ZN11RaycastLine10DetectClsnEv((char*)&self->mRaycastLine)) {
+            _ZN11RaycastLine10GetClsnPosEv(&clsnPos2, ((char*)self) + 0x134);
+            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(((char*)self) + 0x148, &normal2);
             if (func_02039794(normal2.y) == 0) {
                 floorFlag = 1;
-                _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res0);
+                _ZNK10ClsnResult6CopyToERS_(((char*)self) + 0x144, &res0);
             }
-            if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+            if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
                 pos[0] = clsnPos2.x - (normal2.x >> 2);
                 pos[1] = clsnPos2.y - (normal2.y >> 2) - (height >> 1);
                 pos[2] = clsnPos2.z - (normal2.z >> 2);
             }
-        } else if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+        } else if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
             pos[0] = newStart.x;
             pos[1] = newStart.y - height;
             pos[2] = newStart.z;
         }
     }
 
-    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(c);
+    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char*)self));
     handled = 0;
-    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(c);
+    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char*)self));
     sphere.x = pos[0];
     sphere.y = pos[1];
     sphere.z = pos[2];
     sphere.y += height;
-    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(c + 0x20, &sphere, *(int*)(c + 0x18), *(void**)(c + 0x14));
-    if (func_0203553c(c) == 0)
-        *(u8*)AT(c, 0x90) |= 0x40;
-    *(int*)(c + 0x128) = *(int*)(c + 0x1b8);
+    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(((char*)self) + 0x20, &sphere, self->unk_018, *(void**)((char*)&self->mActor));
+    if (func_0203553c(((char*)self)) == 0)
+        *(u8*)AT(((char*)self), 0x90) |= 0x40;
+    self->unk_128 = self->unk_1b8;
     if (pos[1] - prev[1] > 0)
-        *(u8*)AT(c, 0x90) |= 0x20;
+        *(u8*)AT(((char*)self), 0x90) |= 0x20;
     if (floorFlag != 0) {
-        *(u8*)AT(c, 0x90) |= 4;
-        _ZN10SphereClsn14SetFloorResultERK10ClsnResult(c + 0x20, &res0);
-        *(u8*)AT(c, 0x90) |= 1;
-        _ZN10ClsnResultaSERKS_(c + 0x30, &res0);
-        func_020371b0(c, onGround);
+        *(u8*)AT(((char*)self), 0x90) |= 4;
+        _ZN10SphereClsn14SetFloorResultERK10ClsnResult(((char*)self) + 0x20, &res0);
+        *(u8*)AT(((char*)self), 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(((char*)self) + 0x30, &res0);
+        func_020371b0(((char*)self), onGround);
         handled = 1;
     }
     if (wallFlag != 0) {
-        *(u8*)AT(c, 0x90) |= 8;
-        func_02037888(c + 0x20, &res1);
-        *(u8*)AT(c, 0x90) |= 1;
-        _ZN10ClsnResultaSERKS_(c + 0x30, &res1);
+        *(u8*)AT(((char*)self), 0x90) |= 8;
+        func_02037888(((char*)self) + 0x20, &res1);
+        *(u8*)AT(((char*)self), 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(((char*)self) + 0x30, &res1);
     }
-    if (_ZN10SphereClsn10DetectClsnEv(c + 0x20)) {
-        prev = (int*)(c + 0x6c);
-        if ((*(u8*)(c + 0x90) & 4) && handled == 0)
-            func_020371b0(c, onGround);
-        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+    if (_ZN10SphereClsn10DetectClsnEv((char*)&self->mSphereClsn)) {
+        prev = (int*)((char*)&self->unk_06c);
+        if ((self->mClsnFlags & 4) && handled == 0)
+            func_020371b0(((char*)self), onGround);
+        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
             pos[0] += prev[0];
-            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(c))
+            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char*)self)))
                 *(int*)AT(pos, 4) += prev[1];
             *(int*)AT(pos, 8) += prev[2];
         }
     }
-    if (onGround && _ZNK12WithMeshClsn10IsOnGroundEv(c) == 0)
-        func_020356d4(c);
+    if (onGround && _ZNK12WithMeshClsn10IsOnGroundEv(((char*)self)) == 0)
+        func_020356d4(((char*)self));
     _ZN10ClsnResultD1Ev(&res1);
     _ZN10ClsnResultD1Ev(&res0);
 }

--- a/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
@@ -1,56 +1,57 @@
 //cpp
+// @symbol _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SphereClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WithMeshClsn.h"
 extern "C" {
 
-struct Vector3 { int x, y, z; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
-extern int func_020355a0(void *p);
-extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void *self);
 extern int func_02037938(int p);
 extern void func_02038324(void *arg, int b, int c, int d);
-extern void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(void *self);
 extern void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(void *self, struct Vector3 *v, int fix, void *actor);
-extern int _ZN10SphereClsn10DetectClsnEv(void *self);
-extern void func_020371b0(void *clsn, int justHit);
-extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void *self);
 extern void func_020356d4(char *self);
+}
 
-void _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv(char *self)
+void WithMeshClsn::UpdateDiscreteNoLava()
 {
     int onGround;
     int sy;
     struct Vector3 v;
     struct Vector3 *p6c;
-    char *obj = *(char **)(self + 0x14);
+    char *obj = *(char **)((char *)&mActor);
     struct Vector3 *src = (struct Vector3 *)(obj + 0x5c);
     struct Vector3 *p68 = (struct Vector3 *)(obj + 0x68);
 
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(self) && func_020355a0(self)
-        && _ZNK12WithMeshClsn15ShouldUpdatePosEv(self)) {
-        func_02038324((void *)func_02037938((int)(self + 0x20)), (int)src,
-                      *(int *)(self + 0x12c), *(int *)(self + 0x130));
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(((char *)this)) && func_020355a0(((char *)this))
+        && _ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
+        func_02038324((void *)func_02037938((int)((char *)&mSphereClsn)), (int)src,
+                      unk_12c, unk_130);
     }
-    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(self);
-    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(self);
+    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char *)this));
+    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char *)this));
     v.x = src->x;
     sy = src->y;
     v.y = sy;
     v.z = src->z;
-    v.y = sy + *(int *)(self + 0x1c);
-    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(self + 0x20, &v,
-        *(int *)(self + 0x18), *(void **)(self + 0x14));
-    *(int *)(self + 0x128) = *(int *)(self + 0x1b8);
+    v.y = sy + unk_01c;
+    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(((char *)this) + 0x20, &v,
+        unk_018, *(void **)((char *)&mActor));
+    unk_128 = unk_1b8;
     if (src->y - p68->y > 0) {
-        *(unsigned char *)(((long long)(int)(self + 0x90)) & 0xffffffffffffffffLL) |= 0x20;
+        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags)) & 0xffffffffffffffffLL) |= 0x20;
     }
-    if (_ZN10SphereClsn10DetectClsnEv(self + 0x20)) {
-        p6c = (struct Vector3 *)(self + 0x6c);
-        if (*(unsigned char *)(self + 0x90) & 4) {
-            func_020371b0(self, onGround);
+    if (_ZN10SphereClsn10DetectClsnEv((char *)&mSphereClsn)) {
+        p6c = (struct Vector3 *)((char *)&unk_06c);
+        if (mClsnFlags & 4) {
+            func_020371b0(((char *)this), onGround);
         }
-        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(self)) {
+        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
-            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(self)) {
+            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
                 *(int *)(((long long)(int)((char *)src + 4)) & 0xffffffffffffffffLL) += p6c->y;
             }
             *(int *)(((long long)(int)((char *)src + 8)) & 0xffffffffffffffffLL) += p6c->z;
@@ -58,8 +59,7 @@ void _ZN12WithMeshClsn20UpdateDiscreteNoLavaEv(char *self)
     }
     if (onGround == 0)
         return;
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(self))
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(((char *)this)))
         return;
-    func_020356d4(self);
-}
+    func_020356d4(((char *)this));
 }

--- a/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
+++ b/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
@@ -1,34 +1,32 @@
+// @symbol _ZN12WithMeshClsn22UpdateContinuousNoLavaEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "WithMeshClsn.h"
 typedef unsigned char u8;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
-extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void* p);
 extern void _ZN10ClsnResultC1Ev(ClsnResult* r);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, Vec3* a, Vec3* b, void* actor);
-extern int func_0203859c(void* self);
 extern void _ZN11RaycastLine10GetClsnPosEv(Vec3* out, void* self);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vec3* out);
-extern int func_02039794(int x);
 extern void _ZNK10ClsnResult6CopyToERS_(void* self, ClsnResult* dst);
-extern void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(void* p);
 extern void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(void* self, Vec3* v, int rad, void* actor);
 extern void _ZN10SphereClsn14SetFloorResultERK10ClsnResult(void* self, ClsnResult* r);
 extern void _ZN10ClsnResultaSERKS_(void* self, ClsnResult* r);
-extern void func_020371b0(void* clsn, int justHit);
 extern void func_02037888(void* dst, ClsnResult* src);
-extern int func_02038a38(void* self);
-extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void* p);
 extern void func_020356d4(void* self);
 extern void _ZN10ClsnResultD1Ev(ClsnResult* r);
 
 #pragma opt_common_subs off
 
-void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
-{
+void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(struct WithMeshClsn *self) {
     int floorFlag;
     int wallFlag;
     int height;
@@ -45,7 +43,7 @@ void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
     Vec3 sphere;
 
     {
-        char* a = *(char**)(c + 0x14);
+        char* a = *(char**)((char*)&self->mActor);
         pos = (int*)AT(a, 0x5c);
         prev = (int*)AT(a, 0x68);
     }
@@ -55,7 +53,7 @@ void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
     wallFlag = 0;
     _ZN10ClsnResultC1Ev(&res1);
 
-    height = *(int*)(c + 0x1c);
+    height = self->unk_01c;
     {
         int tx = prev[0];
         int tz = prev[2];
@@ -72,12 +70,12 @@ void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
         lineEnd.y = ty;
         lineEnd.z = tz;
     }
-    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &lineStart, &lineEnd, *(void**)(c + 0x14));
-    if (func_0203859c(c + 0x134))
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(((char*)self) + 0x134, &lineStart, &lineEnd, *(void**)((char*)&self->mActor));
+    if (func_0203859c((char*)&self->mRaycastLine))
     {
         int r;
-        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, c + 0x134);
-        _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal);
+        _ZN11RaycastLine10GetClsnPosEv(&clsnPos, ((char*)self) + 0x134);
+        _ZNK11SurfaceInfo12CopyNormalToER7Vector3(((char*)self) + 0x148, &normal);
         newStart.x = clsnPos.x + (normal.x >> 2);
         newStart.y = (normal.y >> 2) + clsnPos.y;
         newStart.z = clsnPos.z + (normal.z >> 2);
@@ -87,66 +85,66 @@ void _ZN12WithMeshClsn22UpdateContinuousNoLavaEv(char* c)
         r = func_02039794(normal.y);
         if (r == 1) {
             wallFlag = 1;
-            _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res1);
+            _ZNK10ClsnResult6CopyToERS_(((char*)self) + 0x144, &res1);
         }
-        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(c + 0x134, &newStart, &newEnd, *(void**)(c + 0x14));
-        if (func_0203859c(c + 0x134)) {
-            _ZN11RaycastLine10GetClsnPosEv(&clsnPos2, c + 0x134);
-            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(c + 0x148, &normal2);
+        _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(((char*)self) + 0x134, &newStart, &newEnd, *(void**)((char*)&self->mActor));
+        if (func_0203859c((char*)&self->mRaycastLine)) {
+            _ZN11RaycastLine10GetClsnPosEv(&clsnPos2, ((char*)self) + 0x134);
+            _ZNK11SurfaceInfo12CopyNormalToER7Vector3(((char*)self) + 0x148, &normal2);
             if (func_02039794(normal2.y) == 0) {
                 floorFlag = 1;
-                _ZNK10ClsnResult6CopyToERS_(c + 0x144, &res0);
+                _ZNK10ClsnResult6CopyToERS_(((char*)self) + 0x144, &res0);
             }
-            if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+            if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
                 pos[0] = clsnPos2.x - (normal2.x >> 2);
                 pos[1] = clsnPos2.y - (normal2.y >> 2) - (height >> 1);
                 pos[2] = clsnPos2.z - (normal2.z >> 2);
             }
-        } else if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+        } else if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
             pos[0] = newStart.x;
             pos[1] = newStart.y - height;
             pos[2] = newStart.z;
         }
     }
 
-    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(c);
-    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(c);
+    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char*)self));
+    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char*)self));
     handled = 0;
     sphere.x = pos[0];
     sphere.y = pos[1];
     sphere.z = pos[2];
     sphere.y += height;
-    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(c + 0x20, &sphere, *(int*)(c + 0x18), *(void**)(c + 0x14));
-    *(int*)(c + 0x128) = *(int*)(c + 0x1b8);
+    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(((char*)self) + 0x20, &sphere, self->unk_018, *(void**)((char*)&self->mActor));
+    self->unk_128 = self->unk_1b8;
     if (pos[1] - prev[1] > 0)
-        *(u8*)AT(c, 0x90) |= 0x20;
+        *(u8*)AT(((char*)self), 0x90) |= 0x20;
     if (floorFlag != 0) {
-        *(u8*)AT(c, 0x90) |= 4;
-        _ZN10SphereClsn14SetFloorResultERK10ClsnResult(c + 0x20, &res0);
-        *(u8*)AT(c, 0x90) |= 1;
-        _ZN10ClsnResultaSERKS_(c + 0x30, &res0);
-        func_020371b0(c, onGround);
+        *(u8*)AT(((char*)self), 0x90) |= 4;
+        _ZN10SphereClsn14SetFloorResultERK10ClsnResult(((char*)self) + 0x20, &res0);
+        *(u8*)AT(((char*)self), 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(((char*)self) + 0x30, &res0);
+        func_020371b0(((char*)self), onGround);
         handled = 1;
     }
     if (wallFlag != 0) {
-        *(u8*)AT(c, 0x90) |= 8;
-        func_02037888(c + 0x20, &res1);
-        *(u8*)AT(c, 0x90) |= 1;
-        _ZN10ClsnResultaSERKS_(c + 0x30, &res1);
+        *(u8*)AT(((char*)self), 0x90) |= 8;
+        func_02037888(((char*)self) + 0x20, &res1);
+        *(u8*)AT(((char*)self), 0x90) |= 1;
+        _ZN10ClsnResultaSERKS_(((char*)self) + 0x30, &res1);
     }
-    if (func_02038a38(c + 0x20)) {
-        prev = (int*)(c + 0x6c);
-        if ((*(u8*)(c + 0x90) & 4) && handled == 0)
-            func_020371b0(c, onGround);
-        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(c)) {
+    if (func_02038a38((char*)&self->mSphereClsn)) {
+        prev = (int*)((char*)&self->unk_06c);
+        if ((self->mClsnFlags & 4) && handled == 0)
+            func_020371b0(((char*)self), onGround);
+        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char*)self))) {
             pos[0] += prev[0];
-            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(c))
+            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char*)self)))
                 *(int*)AT(pos, 4) += prev[1];
             *(int*)AT(pos, 8) += prev[2];
         }
     }
-    if (onGround && _ZNK12WithMeshClsn10IsOnGroundEv(c) == 0)
-        func_020356d4(c);
+    if (onGround && _ZNK12WithMeshClsn10IsOnGroundEv(((char*)self)) == 0)
+        func_020356d4(((char*)self));
     _ZN10ClsnResultD1Ev(&res1);
     _ZN10ClsnResultD1Ev(&res0);
 }

--- a/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
+++ b/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
@@ -1,47 +1,48 @@
 //cpp
+// @symbol _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WithMeshClsn.h"
 extern "C" {
 
-struct Vector3 { int x, y, z; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
-extern void _ZN12WithMeshClsn19ClearAllGroundFlagsEv(void *self);
 extern void _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(void *self, struct Vector3 *v, int fix, void *actor);
-extern int func_02038a38(void *arg0);
-extern void func_020371b0(void *clsn, int justHit);
-extern int _ZNK12WithMeshClsn15ShouldUpdatePosEv(void *self);
-extern int _ZNK12WithMeshClsn16ShouldUpdatePosYEv(void *self);
 extern void func_020356d4(char *self);
+}
 
-void _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev(char *self)
+void WithMeshClsn::UpdateDiscreteNoLava_2()
 {
     int onGround;
     int sy;
     struct Vector3 v;
     struct Vector3 *p6c;
-    struct Vector3 *src = (struct Vector3 *)(*(char **)(self + 0x14) + 0x5c);
-    char *obj = *(char **)(self + 0x14);
+    struct Vector3 *src = (struct Vector3 *)(*(char **)((char *)&mActor) + 0x5c);
+    char *obj = *(char **)((char *)&mActor);
 
-    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(self);
-    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(self);
+    onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char *)this));
+    _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char *)this));
     v.x = *(int *)(((long long)(int)src) & 0xffffffffffffffffLL);
     sy = src->y;
     v.y = sy;
     v.z = src->z;
-    v.y = sy + *(int *)(self + 0x1c);
-    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(self + 0x20, &v,
-        *(int *)(self + 0x18), *(void **)(self + 0x14));
-    *(int *)(self + 0x128) = *(int *)(self + 0x1b8);
+    v.y = sy + unk_01c;
+    _ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor(((char *)this) + 0x20, &v,
+        unk_018, *(void **)((char *)&mActor));
+    unk_128 = unk_1b8;
     if (src->y - *(int *)(obj + 0x6c) > 0) {
-        *(unsigned char *)(((long long)(int)(self + 0x90)) & 0xffffffffffffffffLL) |= 0x20;
+        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags)) & 0xffffffffffffffffLL) |= 0x20;
     }
-    if (func_02038a38(self + 0x20)) {
-        p6c = (struct Vector3 *)(self + 0x6c);
-        if (*(unsigned char *)(self + 0x90) & 4) {
-            func_020371b0(self, onGround);
+    if (func_02038a38((char *)&mSphereClsn)) {
+        p6c = (struct Vector3 *)((char *)&unk_06c);
+        if (mClsnFlags & 4) {
+            func_020371b0(((char *)this), onGround);
         }
-        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(self)) {
+        if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
-            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(self)) {
+            if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
                 *(int *)(((long long)(int)((char *)src + 4)) & 0xffffffffffffffffLL) += p6c->y;
             }
             *(int *)(((long long)(int)((char *)src + 8)) & 0xffffffffffffffffLL) += p6c->z;
@@ -49,8 +50,7 @@ void _ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev(char *self)
     }
     if (onGround == 0)
         return;
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(self))
+    if (_ZNK12WithMeshClsn10IsOnGroundEv(((char *)this)))
         return;
-    func_020356d4(self);
-}
+    func_020356d4(((char *)this));
 }

--- a/src/_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_.c
+++ b/src/_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_.c
@@ -1,9 +1,12 @@
-void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* c, int a1, int a2, int a3, int sp0, int sp1){
-  *(int*)((char*)c+0x14)=a1;
-  *(int*)((char*)c+0x18)=a2;
-  *(int*)((char*)c+0x1c)=a3;
-  *(int*)((char*)c+0x10)=0;
-  *(int*)((char*)c+0x12c)=sp0;
-  *(int*)((char*)c+0x130)=sp1;
-  *(int*)((char*)c+0x1b8)=0x1000;
+// @symbol _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_
+/* recovered: named members + shared header */
+#include "WithMeshClsn.h"
+void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(struct WithMeshClsn *self, int a1, int a2, int a3, int sp0, int sp1) {
+  *(int*)((char*)&self->mActor)=a1;
+  *(int*)((char*)&self->unk_018)=a2;
+  *(int*)((char*)&self->unk_01c)=a3;
+  *(int*)((char*)&self->mFlags)=0;
+  *(int*)((char*)&self->unk_12c)=sp0;
+  *(int*)((char*)&self->unk_130)=sp1;
+  *(int*)((char*)&self->unk_1b8)=0x1000;
 }

--- a/src/_ZN12WithMeshClsnC1Ev.c
+++ b/src/_ZN12WithMeshClsnC1Ev.c
@@ -1,12 +1,15 @@
+// @symbol _ZN12WithMeshClsnC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_SphereClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "WithMeshClsn.h"
 extern void func_02035514(void *);
-extern void _ZN10SphereClsnC1Ev(void *);
 extern void _ZN11RaycastLineC1Ev(void *);
-extern int VT0[];
-int *_ZN12WithMeshClsnC1Ev(int *t)
-{
-    func_02035514(t);
-    t[0] = (int)VT0;
-    _ZN10SphereClsnC1Ev((char *)t + 0x20);
-    _ZN11RaycastLineC1Ev((char *)t + 0x134);
-    return t;
+int *_ZN12WithMeshClsnC1Ev(struct WithMeshClsn *self) {
+    func_02035514(((int *)self));
+    ((int *)self)[0] = (int)VT0;
+    _ZN10SphereClsnC1Ev((char *)&self->mSphereClsn);
+    _ZN11RaycastLineC1Ev((char *)&self->mRaycastLine);
+    return ((int *)self);
 }

--- a/src/_ZN12WorkElevator6RenderEv.cpp
+++ b/src/_ZN12WorkElevator6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN12WorkElevator6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "WorkElevator.h"
 struct Obj {
     virtual void m0();
     virtual void m1();
@@ -7,14 +10,16 @@ struct Obj {
     virtual void m4();
     virtual void Target(int);
 };
-extern "C" int _ZN12WorkElevator6RenderEv(char *c) {
-    unsigned short v = *(unsigned short*)(c+0xc00+0x74);
+
+int WorkElevator::Render()
+{
+    unsigned short v = *(unsigned short*)(((char *)this)+0xc00+0x74);
     if (v < 0x2d && (v & 1)) return 1;
-    Obj *o = (Obj*)(c+0xd4);
+    Obj *o = (Obj*)((char *)&mModel);
     o->Target(0);
     int arg = 0;
     int i = 0;
-    char *p = c+0x320;
+    char *p = ((char *)this)+0x320;
     do {
         Obj *o2 = (Obj*)p;
         o2->Target(arg);

--- a/src/_ZN12WorkElevatorD0Ev.c
+++ b/src/_ZN12WorkElevatorD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN12WorkElevatorD0Ev
+/* recovered: named members + shared header */
+#include "WorkElevator.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ModelD1Ev(void *p);
@@ -6,14 +9,14 @@ extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int func_ov075_0211478c[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN12WorkElevatorD0Ev(char *c) {
-    *(int**)(c) = func_ov075_0211478c;
-    func_0207328c(c+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
-    func_0207328c(c+0x320, 4, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN12WorkElevatorD0Ev(struct WorkElevator *self) {
+    *(int**)(((char *)self)) = func_ov075_0211478c;
+    func_0207328c(((char *)self)+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(((char *)self)+0x320, 4, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN12WorkElevatorD1Ev.cpp
+++ b/src/_ZN12WorkElevatorD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN12WorkElevatorD1Ev
+/* recovered: named members + shared header */
+#include "WorkElevator.h"
 extern "C" {
 extern void* func_ov075_0211478c;
 extern void* _ZTV17ExclamationSwitch;
@@ -6,14 +9,14 @@ void func_0207328c(void*, int, int, void(*)(void*));
 void _ZN18MovingMeshColliderD1Ev(void*);
 void _ZN5ModelD1Ev(void*);
 void _ZN5ActorD2Ev(void*);
-void* _ZN12WorkElevatorD1Ev(char* self){
-    *(void**)self = &func_ov075_0211478c;
-    func_0207328c(self+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
-    func_0207328c(self+0x320, 4, 0x50, _ZN5ModelD1Ev);
-    *(void**)self = &_ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(self+0x124);
-    _ZN5ModelD1Ev(self+0xd4);
-    _ZN5ActorD2Ev(self);
-    return self;
+void* _ZN12WorkElevatorD1Ev(struct WorkElevator *self) {
+    *(void**)((char*)self) = &func_ov075_0211478c;
+    func_0207328c(((char*)self)+0x520, 4, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(((char*)self)+0x320, 4, 0x50, _ZN5ModelD1Ev);
+    *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char*)&self->mModel);
+    _ZN5ActorD2Ev(((char*)self));
+    return ((char*)self);
 }
 }

--- a/src/_ZN13BigBrickBlock6RenderEv.cpp
+++ b/src/_ZN13BigBrickBlock6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13BigBrickBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BigBrickBlock.h"
 extern "C" int _ZN5Event6GetBitEj(unsigned int bit);
 
 struct V3 { int x, y, z; };
@@ -13,13 +16,14 @@ struct Sub {
   virtual void m(V3* p);
 };
 
-extern "C" int _ZN13BigBrickBlock6RenderEv(char* c){
-  int b = (*(unsigned short*)(c+0xc) == 0x13);
+int BigBrickBlock::Render()
+{
+  int b = (mActorId == 0x13);
   if (b != 0) {
-    if (!(_ZN5Event6GetBitEj(*(unsigned char*)(c+0x320)) != 0 && *(unsigned char*)(c+0x31e) == 0)) {
+    if (!(_ZN5Event6GetBitEj(mEventID) != 0 && unk_31e == 0)) {
       return 1;
     } else {
-      char* o = *(char**)(c+0x324);
+      char* o = *(char**)((char*)&mSwitch);
       if (o != 0) {
         unsigned short d = (unsigned short)(*(unsigned short*)(o+0x33a) - *(unsigned short*)(o+0x338));
         if (d < 0x2d) {
@@ -28,12 +32,12 @@ extern "C" int _ZN13BigBrickBlock6RenderEv(char* c){
       }
     }
   }
-  int b2 = (*(unsigned short*)(c+0xc) == 0x10);
+  int b2 = (mActorId == 0x10);
   if (b2 != 0) {
     V3 v = data_ov002_021089e0;
-    ((Sub*)(c+0xd4))->m(&v);
+    ((Sub*)((char*)&mModel))->m(&v);
   } else {
-    ((Sub*)(c+0xd4))->m(0);
+    ((Sub*)((char*)&mModel))->m(0);
   }
   return 1;
 }

--- a/src/_ZN13BigBrickBlock8BehaviorEv.cpp
+++ b/src/_ZN13BigBrickBlock8BehaviorEv.cpp
@@ -1,54 +1,57 @@
 //cpp
+// @symbol _ZN13BigBrickBlock8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BigBrickBlock.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 
 extern "C" int _ZN5Event6GetBitEj(unsigned int a);
 extern "C" void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *after);
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *p);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void *p);
 extern "C" void func_020393a4(int *p, int v);
 extern "C" void func_02039394(int *p, int v);
 extern "C" void _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int _ZN13BigBrickBlock8BehaviorEv(char *c)
+int BigBrickBlock::Behavior()
 {
-    int is13 = (int)(*(u16 *)(c + 0xc) == 0x13);
+    int is13 = (int)(mActorId == 0x13);
     if (is13 != 0) {
-        if (*(u8 *)(c + 0x31f) != _ZN5Event6GetBitEj(*(u8 *)(c + 0x320)))
-            *(u8 *)(c + 0x31e) = 0;
+        if (unk_31f != _ZN5Event6GetBitEj(mEventID))
+            unk_31e = 0;
 
-        if (*(void **)(c + 0x324) == 0) {
+        if (*(void **)((char *)&mSwitch) == 0) {
             unsigned int id = 0xb;
             char *p;
             do {
-                *(void **)(c + 0x324) = _ZN5Actor15FindWithActorIDEjPS_(id, *(void **)(c + 0x324));
-                p = *(char **)(c + 0x324);
-            } while (p == 0 || *(u8 *)(c + 0x320) != *(u8 *)(p + 0x34e));
+                *(void **)((char *)&mSwitch) = _ZN5Actor15FindWithActorIDEjPS_(id, *(void **)((char *)&mSwitch));
+                p = *(char **)((char *)&mSwitch);
+            } while (p == 0 || mEventID != *(u8 *)(p + 0x34e));
         }
 
-        if (_ZN5Event6GetBitEj(*(u8 *)(c + 0x320)) == 0 || *(u8 *)(c + 0x31e) != 0) {
-            if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124) != 0)
-                _ZN16MeshColliderBase7DisableEv(c + 0x124);
+        if (_ZN5Event6GetBitEj(mEventID) == 0 || unk_31e != 0) {
+            if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider) != 0)
+                _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
         } else {
-            func_020393a4((int *)(c + 0x124), 0x15e000);
-            func_02039394((int *)(c + 0x124), 0x64000);
-            _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x150000, 0);
+            func_020393a4((int *)((char *)&mMeshCollider), 0x15e000);
+            func_02039394((int *)((char *)&mMeshCollider), 0x64000);
+            _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char *)this), 0x150000, 0);
         }
 
-        *(u8 *)(c + 0x31f) = _ZN5Event6GetBitEj(*(u8 *)(c + 0x320));
+        unk_31f = _ZN5Event6GetBitEj(mEventID);
     } else {
         int v1 = 0x15e000;
         int v5 = 0x64000;
         int t;
-        if ((t = (int)(*(u16 *)(c + 0xc) == 0x10)) != 0 ||
-            (t = (int)(*(u16 *)(c + 0xc) == 0x11)) != 0 ||
-            (t = (int)(*(u16 *)(c + 0xc) == 0x2e)) != 0) {
+        if ((t = (int)(mActorId == 0x10)) != 0 ||
+            (t = (int)(mActorId == 0x11)) != 0 ||
+            (t = (int)(mActorId == 0x2e)) != 0) {
             v1 = 0x1c2000;
             v5 = 0x96000;
         }
-        func_020393a4((int *)(c + 0x124), v1);
-        func_02039394((int *)(c + 0x124), v5);
-        _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x600000, 0);
+        func_020393a4((int *)((char *)&mMeshCollider), v1);
+        func_02039394((int *)((char *)&mMeshCollider), v5);
+        _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char *)this), 0x600000, 0);
     }
     return 1;
 }

--- a/src/_ZN13BigBrickBlockD0Ev.c
+++ b/src/_ZN13BigBrickBlockD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13BigBrickBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjBlockL_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13BigBrickBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjBlockL_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13BigBrickBlockD1Ev.c
+++ b/src/_ZN13BigBrickBlockD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13BigBrickBlockD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjBlockL_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13BigBrickBlockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjBlockL_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN13ExpandingHeap19VMaxAllocatableSizeEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_ExpandingHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ExpandingHeap.h"
 extern "C" {
-extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
-
-unsigned int _ZN13ExpandingHeap19VMaxAllocatableSizeEv(char* self) {
-    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
 }
+
+unsigned int ExpandingHeap::VMaxAllocatableSize()
+{
+    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)((char*)&unk_014), 4);
 }

--- a/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN13ExpandingHeap22VMaxAllocationUnitSizeEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_ExpandingHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ExpandingHeap.h"
 extern "C" {
-extern unsigned int _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(void*, int);
-
-unsigned int _ZN13ExpandingHeap22VMaxAllocationUnitSizeEv(char* self) {
-    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)(self + 0x14), 4);
 }
+
+unsigned int ExpandingHeap::VMaxAllocationUnitSize()
+{
+    return _ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi(*(void**)((char*)&unk_014), 4);
 }

--- a/src/_ZN13FortressTower13InitResourcesEv.cpp
+++ b/src/_ZN13FortressTower13InitResourcesEv.cpp
@@ -1,27 +1,25 @@
 //cpp
+// @symbol _ZN13FortressTower13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FortressTower.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
 struct Matrix4x3;
 struct CLPS_Block;
 
-extern "C" void *Model_LoadFile(void *fp);
-extern "C" void ModelBase_SetFile(void *self, void *bmd, int a, int b);
-extern "C" void Platform_UpdateModelPosAndRotY(void *self);
-extern "C" void Platform_UpdateClsnPosAndRot(void *self);
-extern "C" void *MeshCollider_LoadFile(void *fp);
-extern "C" void MovingMeshCollider_SetFile(void *self, void *kcl, void *mtx, int fix, short s, void *clps);
 extern "C" int IsStarCollectedInCurLevel(int a);
 
 extern void *data_ov102_0214e188[];
 extern void *data_ov102_0214e18c[];
-extern void *data_ov102_0214e190[];
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
 
-extern "C" int _ZN13FortressTower13InitResourcesEv(void *thiz)
+int FortressTower::InitResources()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     unsigned short id = *(unsigned short *)(c + 0xc);
     unsigned char idx;
 

--- a/src/_ZN13FortressTower6RenderEv.cpp
+++ b/src/_ZN13FortressTower6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN13FortressTower6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FortressTower.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13FortressTower6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int FortressTower::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN13FortressTower8BehaviorEv.cpp
+++ b/src/_ZN13FortressTower8BehaviorEv.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol _ZN13FortressTower8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "FortressTower.h"
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void* c);
 void _ZN16MeshColliderBase6EnableEP5Actor(void* c, void* a);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
 extern unsigned char data_0209f2d8[];
+}
 
-int _ZN13FortressTower8BehaviorEv(char* c)
+int FortressTower::Behavior()
 {
-    unsigned short id = *(unsigned short*)(c+0xc);
+    unsigned short id = unk_00c;
     int r1 = 0;
     switch (id) {
     case 0x31: r1 = 0x900000; break;
@@ -19,11 +23,10 @@ int _ZN13FortressTower8BehaviorEv(char* c)
     }
     int on = (data_0209f2d8[0] == 1);
     if (on) {
-        if (!_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
-            _ZN16MeshColliderBase6EnableEP5Actor((char*)c+0x124, c);
+        if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider))
+            _ZN16MeshColliderBase6EnableEP5Actor((char*)((char*)this)+0x124, ((char*)this));
     } else {
-        _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, r1, 0);
+        _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char*)this), r1, 0);
     }
     return 1;
-}
 }

--- a/src/_ZN13FortressTowerD0Ev.c
+++ b/src/_ZN13FortressTowerD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13FortressTowerD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjSimpleBg_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13FortressTowerD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjSimpleBg_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13FortressTowerD1Ev.c
+++ b/src/_ZN13FortressTowerD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13FortressTowerD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjSimpleBg_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13FortressTowerD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjSimpleBg_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -1,33 +1,36 @@
 //cpp
+// @symbol _ZN13HeapAllocatorC1EjPvPvj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_NestedHeapIterator.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "HeapAllocator.h"
 extern "C" {
 
 typedef unsigned int u32;
 
-extern void _ZN18NestedHeapIteratorC1Ej(void* self, u32 off);
 extern void* _ZN18NestedHeapIterator10FindNestedEPv(void* ptr);
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void* iter, void* node);
 
-extern int _ZN6Memory25isRootHeapIterInitializedE;
-extern char _ZN6Memory16rootHeapIteratorE;
 
-void _ZN13HeapAllocatorC1EjPvPvj(char* self, u32 magic, void* a, void* b, unsigned short size) {
-    *(u32*)self = magic;
-    *(void**)(self + 0x18) = a;
-    *(void**)(self + 0x1c) = b;
-    *(u32*)(self + 0x20) = 0;
+void _ZN13HeapAllocatorC1EjPvPvj(struct HeapAllocator *self, u32 magic, void* a, void* b, unsigned short size) {
+    *(u32*)((char*)self) = magic;
+    *(void**)((char*)&self->unk_018) = a;
+    *(void**)((char*)&self->unk_01c) = b;
+    self->unk_020 = 0;
     {
-        u32* p = (u32*)(((long long)(int)(self + 0x20)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32* p = (u32*)(((long long)(int)((char*)&self->unk_020)));
         *p &= ~0xffu;
         *p |= (size & 0xffu);
     }
-    _ZN18NestedHeapIteratorC1Ej(self + 0xc, 4);
+    _ZN18NestedHeapIteratorC1Ej(((char*)self) + 0xc, 4);
     if (_ZN6Memory25isRootHeapIterInitializedE == 0) {
         _ZN18NestedHeapIteratorC1Ej(&_ZN6Memory16rootHeapIteratorE, 4);
         _ZN6Memory25isRootHeapIterInitializedE = 1;
     }
     {
-        void* it = _ZN18NestedHeapIterator10FindNestedEPv(self);
-        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(it, self);
+        void* it = _ZN18NestedHeapIterator10FindNestedEPv(((char*)self));
+        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(it, ((char*)self));
     }
 }
 

--- a/src/_ZN13KoopaTheQuick6RenderEv.cpp
+++ b/src/_ZN13KoopaTheQuick6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13KoopaTheQuick6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "KoopaTheQuick.h"
 struct Model {
   virtual void v0();
   virtual void v1();
@@ -8,11 +11,11 @@ struct Model {
   virtual void v5(void* p);
   void HideMaterial(int a, int b);
 };
-extern "C" {
-int _ZN13KoopaTheQuick6RenderEv(char* c){
-  Model* m = (Model*)(c+0x300);
+
+int KoopaTheQuick::Render()
+{
+  Model* m = (Model*)((char*)&mModelAnim);
   m->HideMaterial(0, 1);
-  ((Model*)(c+0x300))->v5(c+0x80);
+  ((Model*)((char*)&mModelAnim))->v5((char*)&mScaleX);
   return 1;
-}
 }

--- a/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
+++ b/src/_ZN13KoopaTheQuick8BehaviorEv.cpp
@@ -1,28 +1,33 @@
 //cpp
+// @symbol _ZN13KoopaTheQuick8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "KoopaTheQuick.h"
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* a, void* b);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* a, void* b, unsigned int j);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
-extern void func_ov062_0211aac0(void* c);
-extern int data_ov062_0211e0a4[];
-int _ZN13KoopaTheQuick8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x38c);
+}
+
+int KoopaTheQuick::Behavior()
+{
+  int idx = unk_38c;
   char* ent = (char*)&data_ov062_0211e0a4[idx*2];
   int adj = *(int*)(ent+4);
-  char* self = c + (adj>>1);
+  char* self = ((char*)this) + (adj>>1);
   void* fn;
   if(adj&1){ void* vt=*(void**)self; fn=*(void**)((char*)vt + *(int*)ent); }
   else fn=*(void**)ent;
   ((void(*)(char*))fn)(self);
-  _ZN9Animation7AdvanceEv(c+0x350);
-  *(short*)(c+0x8e) = *(short*)(c+0x94);
-  _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x110);
-  _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c+0x144, 0);
-  _ZN12CylinderClsn5ClearEv(c+0x110);
-  _ZN12CylinderClsn6UpdateEv(c+0x110);
-  func_ov062_0211aac0(c);
+  _ZN9Animation7AdvanceEv((char*)&unk_350);
+  unk_08e = unk_094;
+  _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this)+0x110);
+  _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char*)this), ((char*)this)+0x144, 0);
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
+  func_ov062_0211aac0(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN13KoopaTheQuickD0Ev.c
+++ b/src/_ZN13KoopaTheQuickD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13KoopaTheQuickD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daRNk_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN13KoopaTheQuickD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daRNk_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN13KoopaTheQuickD1Ev.c
+++ b/src/_ZN13KoopaTheQuickD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13KoopaTheQuickD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13KoopaTheQuick */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN13KoopaTheQuickD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13KoopaTheQuick;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
+++ b/src/_ZN13MontyMoleRock13InitResourcesEv.cpp
@@ -1,27 +1,32 @@
 //cpp
+// @symbol _ZN13MontyMoleRock13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "MontyMoleRock.h"
 extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*,void*,int,int,unsigned,unsigned);
 int _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*,void*,int,int,int,int);
 extern int data_ov080_021283c8[];
-int _ZN13MontyMoleRock13InitResourcesEv(char* c){
+}
+
+int MontyMoleRock::InitResources()
+{
   int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov080_021283c8);
-  if(_ZN9ModelBase7SetFileEP8BMD_Fileii(c+0x110, m, 1, -1) == 0) return 0;
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x160, c, 0x1e000, 0x1e000, 0x200004, 0);
-  *(unsigned char*)(c+0x350) = *(int*)(c+8) & 1;
-  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x194, c, 0x1e000, 0x1e000, 0, 0);
-  *(int*)(c+0x9c) = -0x2000;
-  *(int*)(c+0xa0) = -0x3c000;
-  if(*(unsigned char*)(c+0x350) == 0){
-    *(int*)(c+0x80) = 0x1000;
-    *(int*)(c+0x84) = 0x1000;
-    *(int*)(c+0x88) = 0x1000;
+  if(_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0x110, m, 1, -1) == 0) return 0;
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x160, ((char*)this), 0x1e000, 0x1e000, 0x200004, 0);
+  unk_350 = unk_008 & 1;
+  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this)+0x194, ((char*)this), 0x1e000, 0x1e000, 0, 0);
+  unk_09c = -0x2000;
+  unk_0a0 = -0x3c000;
+  if(unk_350 == 0){
+    unk_080 = 0x1000;
+    unk_084 = 0x1000;
+    unk_088 = 0x1000;
   } else {
-    *(int*)(c+0x80) = 0x800;
-    *(int*)(c+0x84) = 0x800;
-    *(int*)(c+0x88) = 0x800;
+    unk_080 = 0x800;
+    unk_084 = 0x800;
+    unk_088 = 0x800;
   }
   return 1;
-}
 }

--- a/src/_ZN13MontyMoleRock6RenderEv.cpp
+++ b/src/_ZN13MontyMoleRock6RenderEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN13MontyMoleRock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MontyMoleRock.h"
 extern "C" {
 struct Base{ virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void*); };
-int _ZN13MontyMoleRock6RenderEv(char*o){
-  Base*b=(Base*)(o+0x110);
-  b->m(o+0x80);
-  return 1;
 }
+
+int MontyMoleRock::Render()
+{
+  Base*b=(Base*)((char*)&mModel);
+  b->m((char*)&unk_080);
+  return 1;
 }

--- a/src/_ZN13MontyMoleRock8BehaviorEv.cpp
+++ b/src/_ZN13MontyMoleRock8BehaviorEv.cpp
@@ -1,22 +1,17 @@
 //cpp
-extern "C" void Actor_MakeVanishLuigiWork(void *self, void *clsn);
-extern "C" void *Actor_FindWithID(unsigned int id);
-extern "C" void Player_Hurt(void *self, void *pos, unsigned int a, int fix, unsigned int b, unsigned int cc, unsigned int d);
-extern "C" int WithMeshClsn_IsOnGround(void *self);
+// @symbol _ZN13MontyMoleRock8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MontyMoleRock.h"
 extern "C" void *Actor_Spawn(unsigned int a, unsigned int b, void *pos, void *v16, int e, int f);
 extern "C" int RandomIntInternal(int *seed);
-extern "C" void ActorBase_MarkForDestruction(void *self);
-extern "C" void Actor_UpdatePos(void *self, void *clsn);
-extern "C" void Enemy_UpdateWMClsn(void *self, void *w, unsigned int j);
-extern "C" void func_ov080_02124418(void *t);
-extern "C" void CylinderClsn_Clear(void *self);
-extern "C" void CylinderClsn_Update(void *self);
 
 extern int data_0209e650;
 
-extern "C" int _ZN13MontyMoleRock8BehaviorEv(void *thiz)
+int MontyMoleRock::Behavior()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     unsigned char *o;
 
     Actor_MakeVanishLuigiWork(c, c + 0x160);

--- a/src/_ZN13MontyMoleRockD0Ev.c
+++ b/src/_ZN13MontyMoleRockD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN13MontyMoleRockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daChoro_Rock_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN13MontyMoleRockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daChoro_Rock_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN5ModelD1Ev((char *)t + 0x110);

--- a/src/_ZN13MontyMoleRockD1Ev.c
+++ b/src/_ZN13MontyMoleRockD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN13MontyMoleRockD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13MontyMoleRock */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN13MontyMoleRockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13MontyMoleRock;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN5ModelD1Ev((char *)t + 0x110);

--- a/src/_ZN13OneUpMushroom13InitResourcesEv.cpp
+++ b/src/_ZN13OneUpMushroom13InitResourcesEv.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol _ZN13OneUpMushroom13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpMushroom.h"
 typedef int Fix12;
 typedef struct { int w[2]; } SharedFilePtr;
-typedef struct { short x, y, z; } Vector3_16;
 typedef struct BMD_File BMD_File;
 typedef struct Actor Actor;
 
@@ -10,8 +15,6 @@ struct ModelCache { int pad0; BMD_File* file; };
 extern ModelCache data_ov002_0210d9b8;
 extern SharedFilePtr data_ov002_0210d9d8;
 extern SharedFilePtr data_ov002_0210da30;
-extern unsigned char data_ov002_020ff040[];
-extern unsigned char data_ov002_020ff050[];
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
 
@@ -20,81 +23,80 @@ extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, BMD_File* f, int a
 extern "C" int _ZN11ShadowModel12InitCylinderEv(void* self);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, Actor* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, Actor* a, Fix12 r, Fix12 h, Vector3_16* p, Fix12 q);
-extern "C" void _ZN12WithMeshClsn13SetLimMovFlagEv(void* self);
 extern "C" int IsStarCollectedInCurLevel(int a);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* self);
 
-extern "C" int _ZN13OneUpMushroom13InitResourcesEv(char* c)
+int OneUpMushroom::InitResources()
 {
     BMD_File* f;
     int isKind0, isKind115;
 
-    *(int*)(c + 0x384) = *(int*)(c + 8) & 0xf;
+    mMushroomType = mParam & 0xf;
 
-    isKind0 = (*(unsigned short*)(c + 0xc) == 0x114);
+    isKind0 = (mActorID == 0x114);
     if (isKind0) {
-        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
-            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
+        if ((unsigned int)(mMushroomType - 0xb) <= 1) {
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
                 return 0;
         } else {
             f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9d8);
-            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, f, 1, 1) == 0)
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x300, f, 1, 1) == 0)
                 return 0;
         }
     } else {
-        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
-            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
+        if ((unsigned int)(mMushroomType - 0xb) <= 1) {
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x300, data_ov002_0210d9b8.file, 1, 1) == 0)
                 return 0;
         } else {
             f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da30);
-            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, f, 1, 1) == 0)
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x300, f, 1, 1) == 0)
                 return 0;
         }
     }
 
-    if (_ZN11ShadowModel12InitCylinderEv(c + 0x350) == 0)
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
         return 0;
 
-    if (*(int*)(c + 0x384) == 6 || *(int*)(c + 0x384) == 8 || (unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
-        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x64000, 0x40000, 0x100002, 0);
-        if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
-            *(int*)((long long)(c + 0x12c) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+    if (mMushroomType == 6 || mMushroomType == 8 || (unsigned int)(mMushroomType - 0xb) <= 1) {
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x110, (Actor*)((char*)this), 0x64000, 0x40000, 0x100002, 0);
+        if ((unsigned int)(mMushroomType - 0xb) <= 1) {
+            *(int*)((long long)((char*)&unk_12c)) |= 0x8000;
         }
     } else {
-        isKind115 = (*(unsigned short*)(c + 0xc) == 0x115);
+        isKind115 = (mActorID == 0x115);
         if (isKind115) {
-            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x41000, 0x41000, 0x100002, 0);
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x110, (Actor*)((char*)this), 0x41000, 0x41000, 0x100002, 0);
         } else {
-            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, (Actor*)c, 0x32000, 0x32000, 0x100002, 0);
+            _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x110, (Actor*)((char*)this), 0x32000, 0x32000, 0x100002, 0);
         }
     }
 
-    *(int*)(c + 0x388) = 0;
-    if (data_ov002_020ff040[*(int*)(c + 0x384)] == 0) {
-        *(int*)((long long)(c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    unk_388 = 0;
+    if (data_ov002_020ff040[mMushroomType] == 0) {
+        *(int*)((long long)((char*)&unk_128)) |= 1;
     }
-    if (data_ov002_020ff050[*(int*)(c + 0x384)] == 0) {
-        *(int*)((long long)(c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    if (data_ov002_020ff050[mMushroomType] == 0) {
+        *(int*)((long long)((char*)&unk_0b0)) &= ~1;
     }
-    if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1) {
-        *(unsigned char*)(c + 0x38e) = 1;
+    if ((unsigned int)(mMushroomType - 0xb) <= 1) {
+        unk_38e = 1;
     } else {
-        *(unsigned char*)(c + 0x38e) = 0;
+        unk_38e = 0;
     }
-    *(unsigned char*)(c + 0x38f) = 1;
-    *(int*)(c + 0x390) = ((unsigned int)*(int*)(c + 8) >> 4) & 0xf;
-    *(int*)(c + 0x378) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x37c) = *(int*)(c + 0x60);
-    *(int*)(c + 0x380) = *(int*)(c + 0x64);
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x32000;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x144, (Actor*)c, 0x32000, 0x32000, 0, 0);
-    _ZN12WithMeshClsn13SetLimMovFlagEv(c + 0x144);
-    *(int*)(c + 0x394) = 0;
+    unk_38f = 1;
+    unk_390 = ((unsigned int)mParam >> 4) & 0xf;
+    unk_378 = mPosX;
+    unk_37c = mPosY;
+    unk_380 = mPosZ;
+    unk_09c = -0x2000;
+    unk_0a0 = -0x32000;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x144, (Actor*)((char*)this), 0x32000, 0x32000, 0, 0);
+    _ZN12WithMeshClsn13SetLimMovFlagEv((char*)&mWithMeshClsn);
+    unk_394 = 0;
 
-    if (data_0209f2f8 == 7 && *(int*)(c + 0x60) == 0xdac000 && *(int*)(c + 0x64) == 0
+    if (data_0209f2f8 == 7 && mPosY == 0xdac000 && mPosZ == 0
         && (data_0209f220 == 1 || IsStarCollectedInCurLevel(1) == 0)) {
-        _ZN9ActorBase18MarkForDestructionEv(c);
+        _ZN9ActorBase18MarkForDestructionEv(((char*)this));
         return 0;
     }
 

--- a/src/_ZN13OneUpMushroom16CleanupResourcesEv.cpp
+++ b/src/_ZN13OneUpMushroom16CleanupResourcesEv.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN13OneUpMushroom16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpMushroom.h"
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void* fp);
 void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 }
 extern void* data_ov002_0210d9d8;
 extern void* data_ov002_0210da30;
-extern "C" int _ZN13OneUpMushroom16CleanupResourcesEv(char* c){
-  int s = *(int*)(c + 0x384);
+
+int OneUpMushroom::CleanupResources()
+{
+  int s = mMushroomType;
   if (s != 0xb && s != 0xc){
-    int b = (*(unsigned short*)(c + 0xc) == 0x114);
+    int b = (mActorID == 0x114);
     if (b != 0) _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9d8);
     else _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
   }
-  if ((unsigned int)(*(int*)(c + 0x384) - 0xb) <= 1)
-    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, *(int*)(c + 0x5c), *(int*)(c + 0x60) + 0x28000, *(int*)(c + 0x64));
+  if ((unsigned int)(mMushroomType - 0xb) <= 1)
+    _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd2, mPosX, mPosY + 0x28000, mPosZ);
   return 1;
 }

--- a/src/_ZN13OneUpMushroom6RenderEv.cpp
+++ b/src/_ZN13OneUpMushroom6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13OneUpMushroom6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpMushroom.h"
 struct Obj {
     virtual void m0();
     virtual void m1();
@@ -8,22 +11,18 @@ struct Obj {
     virtual void func5(int x);
 };
 
-extern "C" {
-
-unsigned int _ZN13OneUpMushroom6RenderEv(char *self)
+unsigned int OneUpMushroom::Render()
 {
-    if (*(unsigned char *)(self + 0x38e) == 0 || *(unsigned char *)(self + 0x38f) == 0)
+    if (unk_38e == 0 || unk_38f == 0)
         return 1;
     {
-        int b = (*(unsigned int *)(self + 0xb0) & 0x40000) ? 1 : 0;
+        int b = (unk_0b0 & 0x40000) ? 1 : 0;
         if (b)
             return 1;
     }
     {
-        Obj *o = (Obj *)(self + 0x300);
+        Obj *o = (Obj *)((char *)&mModel);
         o->func5(0);
     }
     return 1;
-}
-
 }

--- a/src/_ZN13OneUpMushroom8BehaviorEv.cpp
+++ b/src/_ZN13OneUpMushroom8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN13OneUpMushroom8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpMushroom.h"
 struct C;
 typedef void (C::*PMF)();
 struct C {
@@ -6,32 +11,33 @@ struct C {
 };
 extern "C" {
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(char* c, char* clsn);
-extern void func_ov002_020af4ec(char* c);
 extern void _ZN12CylinderClsn5ClearEv(char* c);
 extern void _ZN12CylinderClsn6UpdateEv(char* c);
 extern PMF data_ov002_0210dc00[];
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
-int _ZN13OneUpMushroom8BehaviorEv(char* c){
-  if(_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c+0x144) != 0){
-    func_ov002_020af4ec(c);
-    _ZN12CylinderClsn5ClearEv(c+0x110);
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
+}
+
+int OneUpMushroom::Behavior()
+{
+  if(_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char*)this), ((char*)this)+0x144) != 0){
+    func_ov002_020af4ec(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
     return 1;
   }
-  *(int*)(c+0xd0) = 0;
+  mEatingPlayer = 0;
   {
-    int old = *(int*)(c+0x388);
-    C* self = (C*)c;
-    (self->*data_ov002_0210dc00[*(int*)(c+0x384)])();
-    ++*(unsigned short*)AT(c, 0x100);
-    ++*(unsigned short*)AT(c, 0x38c);
-    if(old != *(int*)(c+0x388)){
-      *(unsigned short*)AT(c, 0x100) = 0;
-      *(unsigned short*)(c+0x300+0x8c) = 0;
+    int old = unk_388;
+    C* self = (C*)((char*)this);
+    (self->*data_ov002_0210dc00[mMushroomType])();
+    ++*(unsigned short*)AT(((char*)this), 0x100);
+    ++*(unsigned short*)AT(((char*)this), 0x38c);
+    if(old != unk_388){
+      *(unsigned short*)AT(((char*)this), 0x100) = 0;
+      *(unsigned short*)(((char*)this)+0x300+0x8c) = 0;
     }
   }
-  _ZN12CylinderClsn5ClearEv(c+0x110);
-  _ZN12CylinderClsn6UpdateEv(c+0x110);
-  func_ov002_020af4ec(c);
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
+  func_ov002_020af4ec(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN13OneUpMushroomD0Ev.c
+++ b/src/_ZN13OneUpMushroomD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13OneUpMushroomD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7da1up_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN13OneUpMushroomD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7da1up_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN13OneUpMushroomD1Ev.c
+++ b/src/_ZN13OneUpMushroomD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13OneUpMushroomD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13OneUpMushroom */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN13OneUpMushroomD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13OneUpMushroom;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN13PeachPainting6RenderEv.cpp
+++ b/src/_ZN13PeachPainting6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13PeachPainting6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PeachPainting.h"
 struct Base {
     virtual int vf0(int);
     virtual int vf1(int);
@@ -11,8 +14,10 @@ struct Obj {
     char pad[0xd4];
     Base sub;
 };
-extern "C" int _ZN13PeachPainting6RenderEv(Obj *c) {
-    if (*(unsigned char*)((char*)c+0x124) == 0) return 1;
-    c->sub.vfunc(0);
+
+int PeachPainting::Render()
+{
+    if (*(unsigned char*)((char*)&mOpacity) == 0) return 1;
+    ((Obj *)this)->sub.vfunc(0);
     return 1;
 }

--- a/src/_ZN13PeachPainting8BehaviorEv.cpp
+++ b/src/_ZN13PeachPainting8BehaviorEv.cpp
@@ -1,20 +1,23 @@
 //cpp
+// @symbol _ZN13PeachPainting8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "PeachPainting.h"
 struct Actor { int DistToCPlayer(); };
 namespace cstd { int fdiv(int a, int b); }
 struct ModelBase { void ApplyOpacity(unsigned int o, int x); };
 
-extern "C" int _ZN13PeachPainting8BehaviorEv(char *c)
+int PeachPainting::Behavior()
 {
-    int d = ((Actor *)c)->DistToCPlayer();
+    int d = ((Actor *)((char *)this))->DistToCPlayer();
     if (d >= 0xe10000) {
-        *(unsigned char *)(c + 0x124) = 0xff;
+        mOpacity = 0xff;
     } else if (d <= 0xbf4000) {
-        *(unsigned char *)(c + 0x124) = 0;
+        mOpacity = 0;
     } else {
         int q = cstd::fdiv(d - 0xbf4000, 0x21c000);
         int o = (int)(((long long)q * 0xff + 0x800) >> 12);
-        *(unsigned char *)(c + 0x124) = (unsigned char)(o >> 3);
+        mOpacity = (unsigned char)(o >> 3);
     }
-    ((ModelBase *)(c + 0xd4))->ApplyOpacity(*(unsigned char *)(c + 0x124), 1);
+    ((ModelBase *)((char *)&mModel))->ApplyOpacity(mOpacity, 1);
     return 1;
 }

--- a/src/_ZN13PeachPaintingD0Ev.c
+++ b/src/_ZN13PeachPaintingD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN13PeachPaintingD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjC1Peach_c */
 extern void *G0;
 int *_ZN13PeachPaintingD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjC1Peach_c;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN13PoleBillboard6RenderEv.cpp
+++ b/src/_ZN13PoleBillboard6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN13PoleBillboard6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PoleBillboard.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13PoleBillboard6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int PoleBillboard::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN13PoleBillboardD0Ev.c
+++ b/src/_ZN13PoleBillboardD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13PoleBillboardD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13PoleBillboardD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17daObjBk_Botaosi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13PoleBillboardD1Ev.c
+++ b/src/_ZN13PoleBillboardD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13PoleBillboardD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Botaosi_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13PoleBillboardD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17daObjBk_Botaosi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13PrincessPeach13InitResourcesEv.cpp
+++ b/src/_ZN13PrincessPeach13InitResourcesEv.cpp
@@ -1,27 +1,27 @@
 //cpp
+// @symbol _ZN13PrincessPeach13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PrincessPeach.h"
 struct BMD_File; struct Actor; struct Vector3_16;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
-extern "C" void AnimLoadFile(void *fp);
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor *a, int b, int c, unsigned int d, unsigned int e); };
 struct WithMeshClsn { void Init(Actor *a, int b, int c, void *d, int e); };
-extern "C" int data_ov085_0212f280[];
-extern "C" char data_ov085_021304f4;
-extern "C" void func_ov085_0212a4a4(char *c, int x);
 extern "C" void func_ov085_02129fdc(char *c);
 
-extern "C" int _ZN13PrincessPeach13InitResourcesEv(Actor *self)
+int PrincessPeach::InitResources()
 {
-    char *s = (char*)self;
+    char *s = (char*)((Actor *)this);
     void *f = ModelLoadFile(&data_ov085_021304f4);
     ((ModelBase*)(s + 0xd4))->SetFile((BMD_File*)f, 1, -1);
     for (int i = 0; i < 7; i++)
         AnimLoadFile((void*)data_ov085_0212f280[i]);
     if (((ShadowModel*)(s + 0x138))->InitCylinder() == 0)
         return 0;
-    ((MovingCylinderClsn*)(s + 0x160))->Init(self, 0x90000, 0xc0000, 0x4800004, 0);
-    ((WithMeshClsn*)(s + 0x194))->Init(self, 0x40000, 0x40000, 0, 0);
+    ((MovingCylinderClsn*)(s + 0x160))->Init(((Actor *)this), 0x90000, 0xc0000, 0x4800004, 0);
+    ((WithMeshClsn*)(s + 0x194))->Init(((Actor *)this), 0x40000, 0x40000, 0, 0);
     *(int*)(s + 0x9c) = -0x2000;
     *(int*)(s + 0xa0) = -0x3c000;
     *(int*)(s + 0x80) = 0x1000;

--- a/src/_ZN13PrincessPeach8BehaviorEv.cpp
+++ b/src/_ZN13PrincessPeach8BehaviorEv.cpp
@@ -1,24 +1,26 @@
 //cpp
+// @symbol _ZN13PrincessPeach8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PrincessPeach.h"
 extern "C" {
-extern int func_ov085_0212a430(void *c);
-extern int func_ov085_02129dbc(void *c);
 extern void _ZN9Animation7AdvanceEv(void *a);
 extern void _ZN12CylinderClsn5ClearEv(void *);
 extern void _ZN12CylinderClsn6UpdateEv(void *);
 extern int func_ov085_02129fdc(void *c);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); };
-extern "C" {
-int _ZN13PrincessPeach8BehaviorEv(char *c)
+
+int PrincessPeach::Behavior()
 {
-    func_ov085_0212a430(c);
-    func_ov085_02129dbc(c);
-    if (*(int*)(c + 0x354) != 1)
-        _ZN9Animation7AdvanceEv(c + 0x124);
-    ((Sub*)(c + 0xd4))->g3();
-    _ZN12CylinderClsn5ClearEv(c + 0x160);
-    _ZN12CylinderClsn6UpdateEv(c + 0x160);
-    func_ov085_02129fdc(c);
+    func_ov085_0212a430(((char *)this));
+    func_ov085_02129dbc(((char *)this));
+    if (unk_354 != 1)
+        _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    ((Sub*)((char *)&mModelAnim))->g3();
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
+    func_ov085_02129fdc(((char *)this));
     return 1;
-}
 }

--- a/src/_ZN13PrincessPeachD0Ev.c
+++ b/src/_ZN13PrincessPeachD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN13PrincessPeachD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daPeach_c */
 extern void *G0;
 int *_ZN13PrincessPeachD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daPeach_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN11ShadowModelD1Ev((char *)t + 0x138);

--- a/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
+++ b/src/_ZN13QuestionBlock16CleanupResourcesEv.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol _ZN13QuestionBlock16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "QuestionBlock.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *p);
-extern void _ZN16MeshColliderBase7DisableEv(void *p);
 extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void _ZN5Actor11UntrackStarERa(void *self, void *p);
 }
@@ -15,34 +18,29 @@ extern char data_ov002_0210d9e0[];
 extern char data_ov002_0210da40[];
 extern char data_ov002_0210d9a0[];
 extern char data_ov002_0210d9c0[];
-extern char data_ov102_0214e7e8[];
-extern char data_ov102_0214e808[];
 extern char data_ov102_0214e7f8[];
-extern char data_ov102_0214e800[];
 extern char data_ov102_0214e7f0[];
-extern char data_ov102_0214e7d8[];
-extern char data_ov102_0214e7e0[];
 extern char data_ov102_0214e7d0[];
 
-extern "C" int _ZN13QuestionBlock16CleanupResourcesEv(char *c)
+int QuestionBlock::CleanupResources()
 {
     int b, b2, b3;
-    if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124))
-        _ZN16MeshColliderBase7DisableEv(c + 0x124);
+    if (_ZN16MeshColliderBase9IsEnabledEv((char *)&mMeshCollider))
+        _ZN16MeshColliderBase7DisableEv((char *)&mMeshCollider);
 
-    b = (int)(*(unsigned short *)(c + 0xc) == 0x16);
+    b = (int)(mActorId == 0x16);
     if (b)
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da58);
 
-    b2 = (int)(*(unsigned short *)(c + 0xc) == 0x14);
+    b2 = (int)(mActorId == 0x14);
     if (b2)
         goto dosw;
-    b3 = (int)(*(unsigned short *)(c + 0xc) == 0x15);
+    b3 = (int)(mActorId == 0x15);
     if (b3) {
     dosw:
-        switch (*(unsigned char *)(c + 0x3f3)) {
+        switch (unk_3f3) {
         case 1:
-            _ZN5Actor11UntrackStarERa(c, c + 0x3f0);
+            _ZN5Actor11UntrackStarERa(((char *)this), ((char *)this) + 0x3f0);
             break;
         case 3:
             _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da18);
@@ -70,7 +68,7 @@ extern "C" int _ZN13QuestionBlock16CleanupResourcesEv(char *c)
         }
     }
 
-    switch (*(unsigned short *)(c + 0xc) - 0x14) {
+    switch (mActorId - 0x14) {
     case 0:
         _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e7e8);
         _ZN13SharedFilePtr7ReleaseEv(data_ov102_0214e808);

--- a/src/_ZN13QuestionBlock6RenderEv.cpp
+++ b/src/_ZN13QuestionBlock6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13QuestionBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "QuestionBlock.h"
 extern "C" { extern int data_0209caa0; }
 
 struct Sub {
@@ -11,20 +14,22 @@ struct Sub {
 };
 
 #pragma optimize_for_size on
-extern "C" int _ZN13QuestionBlock6RenderEv(char* c) {
-    if (*(int*)(c + 0x3e8) == 2)
+
+int QuestionBlock::Render()
+{
+    if (unk_3e8 == 2)
         goto done;
     if ((*(int*)((char*)&data_0209caa0 + 4) & 0x80000000) == 0) {
-        int b = (*(unsigned short*)(c + 0xc) == 0x14);
+        int b = (mActorId == 0x14);
         if (b != 0) {
-            Sub* s = (Sub*)(c + 0x320);
+            Sub* s = (Sub*)((char*)&mModelAnim);
             s->m(0);
             goto done;
         }
     }
     {
-        Sub* s2 = (Sub*)(c + 0xd4);
-        s2->m((int)(c + 0x80));
+        Sub* s2 = (Sub*)((char*)&mModel);
+        s2->m((int)((char*)&mScaleX));
     }
 done:
     return 1;

--- a/src/_ZN13QuestionBlockD0Ev.c
+++ b/src/_ZN13QuestionBlockD0Ev.c
@@ -1,18 +1,20 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13QuestionBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13QuestionBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjHatenaBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13QuestionBlockD1Ev.c
+++ b/src/_ZN13QuestionBlockD1Ev.c
@@ -1,16 +1,19 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13QuestionBlockD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjHatenaBlock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13QuestionBlockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjHatenaBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13RacingPenguin13InitResourcesEv.cpp
+++ b/src/_ZN13RacingPenguin13InitResourcesEv.cpp
@@ -1,28 +1,16 @@
 //cpp
-extern "C" void *Model_LoadFile(void *fp);
-extern "C" void ModelBase_SetFile(void *self, void *bmd, int a, int b);
-extern "C" void *Animation_LoadFile(void *fp);
-extern "C" void *TextureSequence_LoadFile(void *fp);
-extern "C" void TextureSequence_Prepare(void *bmd, void *btp);
-extern "C" int ShadowModel_InitCylinder(void *self);
+// @symbol _ZN13RacingPenguin13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RacingPenguin.h"
 extern "C" unsigned char NumStars(void);
-extern "C" void MovingCylinderClsn_Init(void *self, void *actor, int fix, int t, unsigned int a, unsigned int b);
-extern "C" void WithMeshClsn_Init(void *self, void *actor, int fix, int t, void *v16, int u);
 extern "C" void Actor_SetRanges(void *self, int a, int b, int cc, int d);
-extern "C" unsigned char Actor_TrackStar(void *self, unsigned int a, unsigned int b);
-extern "C" void PathPtr_FromID(void *self, unsigned int id);
-extern "C" void PathPtr_GetNode(void *self, void *v, unsigned int j);
-extern "C" void func_ov019_021114ec(void *c);
-extern "C" void func_ov019_021122dc(void *c, int i);
-extern "C" void func_ov019_021113b0(void *c);
 
-extern void *data_ov019_02113498;
-extern void *data_ov019_02112788[];
-extern void *data_ov019_0211277c[];
 
-extern "C" int _ZN13RacingPenguin13InitResourcesEv(void *thiz)
+int RacingPenguin::InitResources()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     int i;
 
     ModelBase_SetFile(c + 0xd4, Model_LoadFile(&data_ov019_02113498), 1, 1);

--- a/src/_ZN13RacingPenguin6RenderEv.cpp
+++ b/src/_ZN13RacingPenguin6RenderEv.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol _ZN13RacingPenguin6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RacingPenguin.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void *); };
 
 extern "C" void _ZN15TextureSequence6UpdateER15ModelComponents(void *, void *);
 
-extern "C" int _ZN13RacingPenguin6RenderEv(char *c) {
-    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x138, c + 0xdc);
-    Sub *s = (Sub *)(c + 0xd4);
-    s->m(c + 0x80);
+int RacingPenguin::Render()
+{
+    _ZN15TextureSequence6UpdateER15ModelComponents(((char *)this) + 0x138, ((char *)this) + 0xdc);
+    Sub *s = (Sub *)((char *)&mModelAnim);
+    s->m((char *)&unk_080);
     return 1;
 }

--- a/src/_ZN13RacingPenguinD0Ev.c
+++ b/src/_ZN13RacingPenguinD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN13RacingPenguinD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daPgRcer_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN13RacingPenguinD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daPgRcer_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1a8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x174);
     _ZN11ShadowModelD1Ev((char *)t + 0x14c);

--- a/src/_ZN13RaycastGroundC1Ev.c
+++ b/src/_ZN13RaycastGroundC1Ev.c
@@ -1,13 +1,16 @@
+// @symbol _ZN13RaycastGroundC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "RaycastGround.h"
 extern void func_02035514(void* c);
 extern int* func_0203819c(void* t);
-extern unsigned int data_02099264[];
-extern unsigned int data_02099274[];
 
-void* _ZN13RaycastGroundC1Ev(char* c){
-    func_02035514(c);
-    func_0203819c(c + 0x10);
-    *(unsigned int**)c = data_02099264;
-    *(unsigned int**)(c + 0x10) = data_02099274;
-    *(int*)(c + 0x4c) = 0x1f4000;
-    return c;
+void* _ZN13RaycastGroundC1Ev(struct RaycastGround *self) {
+    func_02035514(((char*)self));
+    func_0203819c((char*)&self->unk_010);
+    *(unsigned int**)((char*)self) = data_02099264;
+    *(unsigned int**)((char*)&self->unk_010) = data_02099274;
+    self->unk_04c = 0x1f4000;
+    return ((char*)self);
 }

--- a/src/_ZN13RaycastGroundD1Ev.c
+++ b/src/_ZN13RaycastGroundD1Ev.c
@@ -1,12 +1,12 @@
-extern void func_020380ec(void *);
-extern void func_020354d0(void *);
-extern int VT0[];
-extern int VT1[];
-int *_ZN13RaycastGroundD1Ev(int *t)
-{
-    t[0] = (int)VT0;
-    *(int *)((char *)t + 0x10) = (int)VT1;
-    func_020380ec((char *)t + 0x10);
-    func_020354d0(t);
-    return t;
+// @symbol _ZN13RaycastGroundD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "RaycastGround.h"
+int *_ZN13RaycastGroundD1Ev(struct RaycastGround *self) {
+    ((int *)self)[0] = (int)VT0;
+    *(int *)((char *)&self->unk_010) = (int)VT1;
+    func_020380ec((char *)&self->unk_010);
+    func_020354d0(((int *)self));
+    return ((int *)self);
 }

--- a/src/_ZN13RollingLogLll13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogLll13InitResourcesEv.cpp
@@ -1,16 +1,19 @@
 //cpp
+// @symbol _ZN13RollingLogLll13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RollingLogLll.h"
 struct Actor;
 struct MovingCylinderClsn {
     void Init(Actor *a, int b, int c, unsigned int d, unsigned int e);
 };
-extern "C" void func_ov022_02112790(void *c, void *p);
-extern "C" char data_ov022_02114690;
 
-extern "C" int _ZN13RollingLogLll13InitResourcesEv(Actor *a)
+int RollingLogLll::InitResources()
 {
-    char *c = (char*)a;
+    char *c = (char*)((Actor *)this);
     *(int*)(c + 0xa0) = -0xc8000;
-    ((MovingCylinderClsn*)(c + 0xd4))->Init(a, 0x1e000, 0x1e000, 0x200002, 0);
-    func_ov022_02112790((void*)a, (void*)&data_ov022_02114690);
+    ((MovingCylinderClsn*)(c + 0xd4))->Init(((Actor *)this), 0x1e000, 0x1e000, 0x200002, 0);
+    func_ov022_02112790((void*)((Actor *)this), (void*)&data_ov022_02114690);
     return 1;
 }

--- a/src/_ZN13RollingLogLll8BehaviorEv.cpp
+++ b/src/_ZN13RollingLogLll8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13RollingLogLll8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "RollingLogLll.h"
 typedef int Fix12i;
 struct Vector3_16f;
 struct CylinderClsn;
@@ -14,9 +17,9 @@ extern "C" void _ZN12CylinderClsn6UpdateEv(void* c);
 extern "C" unsigned int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
     unsigned int a, unsigned int b, Fix12i c, Fix12i d, Fix12i e, const Vector3_16f* f);
 
-extern "C" int _ZN13RollingLogLll8BehaviorEv(char* thiz)
+int RollingLogLll::Behavior()
 {
-    char* c = thiz;
+    char* c = ((char*)this);
     C* o = (C*)c;
     DecIfAbove0_Short((unsigned short*)(c + 0x110));
     {

--- a/src/_ZN13RollingLogLllD0Ev.c
+++ b/src/_ZN13RollingLogLllD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN13RollingLogLllD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV21daObj_volcanoCannon_c */
 extern void *G0;
 int *_ZN13RollingLogLllD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV21daObj_volcanoCannon_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN13RollingLogTtm6RenderEv.cpp
+++ b/src/_ZN13RollingLogTtm6RenderEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN13RollingLogTtm6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RollingLogTtm.h"
 extern "C" {
 extern int _ZN5Model6RenderEPK7Vector3(void*, void*);
-int _ZN13RollingLogTtm6RenderEv(char* c){
-  int b = (*(int*)(c+0xb0) & 0x40000) != 0;
-  if(b) return 1;
-  _ZN5Model6RenderEPK7Vector3(c+0xd4, 0);
-  return 1;
 }
+
+int RollingLogTtm::Render()
+{
+  int b = (unk_0b0 & 0x40000) != 0;
+  if(b) return 1;
+  _ZN5Model6RenderEPK7Vector3(((char*)this)+0xd4, 0);
+  return 1;
 }

--- a/src/_ZN13RollingLogTtm8BehaviorEv.cpp
+++ b/src/_ZN13RollingLogTtm8BehaviorEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN13RollingLogTtm8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SaveData.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RollingLogTtm.h"
 struct Vector3;
 struct Vector3_16;
 struct Actor;
@@ -6,11 +12,9 @@ struct Actor;
 extern "C" {
 typedef unsigned int u32;
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(Actor *thiz, int d);
-extern int _ZN8SaveData16HasPlayerLostCapEv(void);
 extern Actor *_ZN5Actor13ClosestPlayerEv(Actor *thiz);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const Vector3 *c, const Vector3_16 *d, int e, int f);
 extern void func_ov030_021141a8(Actor *c);
-extern void func_ov030_02111734(char *c);
 extern void func_ov030_02114134(Actor *c);
 extern void func_ov030_02112094(Actor *c);
 }
@@ -24,14 +28,14 @@ struct VObj {
     virtual void v3();
 };
 
-extern "C" int _ZN13RollingLogTtm8BehaviorEv(Actor *thiz)
+int RollingLogTtm::Behavior()
 {
-    char *c = (char *)thiz;
-    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(thiz, 0x5dc000) != 0 &&
+    char *c = (char *)((Actor *)this);
+    if (_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(((Actor *)this), 0x5dc000) != 0 &&
         *(int *)(c + 0x3b4) != 8) {
         int b = (*(unsigned short *)(c + 0xc) == 0x10b);
         if (b != 0 && *(unsigned char *)(c + 0x3c8) == 0 && _ZN8SaveData16HasPlayerLostCapEv() != 0) {
-            Actor *pl = _ZN5Actor13ClosestPlayerEv(thiz);
+            Actor *pl = _ZN5Actor13ClosestPlayerEv(((Actor *)this));
             unsigned cp = *(unsigned *)((char *)pl + 8);
             if (cp < 3) {
                 void *spawned;
@@ -45,14 +49,14 @@ extern "C" int _ZN13RollingLogTtm8BehaviorEv(Actor *thiz)
                     -1);
                 *(int *)(c + 0x3ac) = *(int *)((char *)spawned + 4);
                 *(unsigned char *)(c + 0x3c8) = 1;
-                func_ov030_021141a8(thiz);
+                func_ov030_021141a8(((Actor *)this));
             }
         }
         func_ov030_02111734(c);
     } else {
-        func_ov030_02114134(thiz);
+        func_ov030_02114134(((Actor *)this));
         ((VObj *)(c + 0xd4))->v3();
-        func_ov030_02112094(thiz);
+        func_ov030_02112094(((Actor *)this));
     }
     return 1;
 }

--- a/src/_ZN13RollingLogTtmD0Ev.c
+++ b/src/_ZN13RollingLogTtmD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN13RollingLogTtmD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daMky_c */
 extern void *G0;
 int *_ZN13RollingLogTtmD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daMky_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x194);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x160);
     _ZN11ShadowModelD1Ev((char *)t + 0x138);

--- a/src/_ZN13SnowmanBreath13InitResourcesEv.cpp
+++ b/src/_ZN13SnowmanBreath13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13SnowmanBreath13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SnowmanBreath.h"
 extern "C" {
 struct Vec3 { int x, y, z; };
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
@@ -12,22 +15,22 @@ extern int data_ov002_0210d9c0[];
 extern int data_020a0e68[];
 
 typedef struct { int w[12]; } M48;
+}
 
-int _ZN13SnowmanBreath13InitResourcesEv(char* c)
+int SnowmanBreath::InitResources()
 {
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da40);
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a0);
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9c0);
-    *(int*)(c + 0x5c) = 0x3fa770;
-    *(int*)(c + 0x60) = 0xcb2000;
-    *(int*)(c + 0x64) = 0x46988e;
-    *(short*)(c + 0x8e) = 0x5d30;
+    mPosX = 0x3fa770;
+    mPosY = 0xcb2000;
+    mPosZ = 0x46988e;
+    unk_08e = 0x5d30;
     Vec3 v;
-    Vec3_Asr(&v, c + 0x5c, 3);
+    Vec3_Asr(&v, ((char*)this) + 0x5c, 3);
     Matrix4x3_FromTranslation(data_020a0e68, v.x, v.y, v.z);
-    Matrix4x3_ApplyInPlaceToRotationY(data_020a0e68, *(short*)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationY(data_020a0e68, unk_08e);
     InvMat4x3(data_020a0e68, data_020a0e68);
-    *(M48*)(c + 0x1394) = *(M48*)data_020a0e68;
+    *(M48*)((char*)&unk_1394) = *(M48*)data_020a0e68;
     return 1;
-}
 }

--- a/src/_ZN13SnowmanBreathD0Ev.cpp
+++ b/src/_ZN13SnowmanBreathD0Ev.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol _ZN13SnowmanBreathD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SnowmanBreath.h"
 extern "C" {
-extern int RotatingPlatformRr_SpawnInfo[];
-extern int data_ov056_02112158[];
 extern int data_020a0eac[];
 void func_0207328c(void*, int, int, void*);
 void _ZN5ActorD2Ev(void*);

--- a/src/_ZN13SnowmanBreathD1Ev.cpp
+++ b/src/_ZN13SnowmanBreathD1Ev.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN13SnowmanBreathD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SnowmanBreath.h"
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ActorD2Ev(void*);
-extern int RotatingPlatformRr_SpawnInfo[];
-extern int data_ov056_02112158[];
 int _ZN13SnowmanBreathD1Ev(char* c){
   *(int**)c = RotatingPlatformRr_SpawnInfo;
   func_0207328c(c+0xd4, 0x32, 0x60, data_ov056_02112158);

--- a/src/_ZN13TTC_MovingBar6RenderEv.cpp
+++ b/src/_ZN13TTC_MovingBar6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN13TTC_MovingBar6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TTC_MovingBar.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13TTC_MovingBar6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int TTC_MovingBar::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN13TTC_MovingBarD0Ev.c
+++ b/src/_ZN13TTC_MovingBarD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13TTC_MovingBarD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13TTC_MovingBarD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjCtKaitendai_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13TTC_MovingBarD1Ev.c
+++ b/src/_ZN13TTC_MovingBarD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13TTC_MovingBarD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjCtKaitendai_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13TTC_MovingBarD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjCtKaitendai_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13TreasureChest13InitResourcesEv.cpp
+++ b/src/_ZN13TreasureChest13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13TreasureChest13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "TreasureChest.h"
 struct SharedFilePtr { int x; };
 struct BMD_File;
 struct BCA_File;
@@ -17,19 +20,20 @@ extern SharedFilePtr data_ov002_0210da38;
 extern SharedFilePtr data_ov064_0211c96c;
 extern SharedFilePtr data_ov064_0211c964;
 
-extern "C" int _ZN13TreasureChest13InitResourcesEv(char* c) {
+int TreasureChest::InitResources()
+{
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a8);
     _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da38);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4,
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4,
         _ZN5Model8LoadFileER13SharedFilePtr(data_ov064_0211c96c), 1, -1);
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4,
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0xd4,
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov064_0211c964), 0x40000000, 0x1000, 0);
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x138, (Actor*)c, 0x96000, 0x96000, 0x200004, 0);
-    func_ov064_0211a284(c);
-    *(unsigned char*)(c + 0x172) = *(int*)(c + 8);
-    *(unsigned char*)(c + 0x174) = (unsigned int)*(int*)(c + 8) >> 8;
-    if (*(unsigned char*)(c + 0x174) != 0xff) {
-        *(unsigned char*)(c + 0x175) = _ZN5Actor9TrackStarEjj(c, *(unsigned char*)(c + 0x174), 2);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x138, (Actor*)((char*)this), 0x96000, 0x96000, 0x200004, 0);
+    func_ov064_0211a284(((char*)this));
+    unk_172 = unk_008;
+    unk_174 = (unsigned int)unk_008 >> 8;
+    if (unk_174 != 0xff) {
+        unk_175 = _ZN5Actor9TrackStarEjj(((char*)this), unk_174, 2);
     }
     return 1;
 }

--- a/src/_ZN13TreasureChest6RenderEv.cpp
+++ b/src/_ZN13TreasureChest6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN13TreasureChest6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TreasureChest.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13TreasureChest6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int TreasureChest::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN13TreasureChestD0Ev.c
+++ b/src/_ZN13TreasureChestD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN13TreasureChestD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daObjTbox_c */
 extern void *G0;
 int *_ZN13TreasureChestD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daObjTbox_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x138);
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN13UpDownLiftBbh16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "UpDownLiftBbh.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov095_02136f68[];
 extern void* data_ov095_02136f74[];
-int _ZN13UpDownLiftBbh16CleanupResourcesEv(void* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
-    _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f68[*(int*)((char*)c+0x328)]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f74[*(int*)((char*)c+0x328)]);
-  return 1;
 }
+
+int UpDownLiftBbh::CleanupResources()
+{
+  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
+    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f68[*(int*)((char*)&mVariant)]);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov095_02136f74[*(int*)((char*)&mVariant)]);
+  return 1;
 }

--- a/src/_ZN13UpDownLiftBbh6RenderEv.cpp
+++ b/src/_ZN13UpDownLiftBbh6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN13UpDownLiftBbh6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "UpDownLiftBbh.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN13UpDownLiftBbh6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int UpDownLiftBbh::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
+++ b/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13UpDownLiftBbh8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "UpDownLiftBbh.h"
 struct Plat;
 typedef void (Plat::*PMF)();
 extern "C" PMF data_ov095_02137910[];
@@ -12,30 +15,30 @@ extern "C" int _ZN6Player7IsInAirEv(void* c);
 typedef unsigned char u8;
 typedef unsigned short u16;
 
-extern "C" int _ZN13UpDownLiftBbh8BehaviorEv(char* c)
+int UpDownLiftBbh::Behavior()
 {
     int old;
-    *(void**)(c + 0x324) = _ZN5Actor13ClosestPlayerEv(c);
-    old = *(int*)(c + 0x32c);
-    (((Plat*)c)->*data_ov095_02137910[old])();
-    *(u16*)(((int)c + 0x344) & 0xFFFFFFFFFFFFFFFF) += 1;
-    if (old != *(int*)(c + 0x32c)) *(u16*)((c + 0x300) + 0x44) = 0;
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) != 0)
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
-    if (*(int*)(c + 0x32c) == 0 || (unsigned)(*(int*)(c + 0x32c) - 3) <= 1) {
-        void* pl = *(void**)(c + 0x320);
+    *(void**)((char*)&unk_324) = _ZN5Actor13ClosestPlayerEv(((char*)this));
+    old = mState;
+    (((Plat*)((char*)this))->*data_ov095_02137910[old])();
+    *(u16*)(((int)((char*)this) + 0x344) & 0xFFFFFFFFFFFFFFFF) += 1;
+    if (old != mState) *(u16*)(((char*)&unk_300) + 0x44) = 0;
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0) != 0)
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+    if (mState == 0 || (unsigned)(mState - 3) <= 1) {
+        void* pl = *(void**)((char*)&unk_320);
         if (pl != 0) {
             if (_ZN6Player7IsInAirEv(pl) == 0) {
-                if (*(u8*)(c + 0x348) == 0) {
-                    *(int*)(c + 0x320) = 0;
-                    *(u8*)(c + 0x347) = 1;
+                if (unk_348 == 0) {
+                    unk_320 = 0;
+                    unk_347 = 1;
                 }
             }
         }
     }
-    *(u8*)(c + 0x348) = 0;
-    if (*(void**)(c + 0x324) != 0)
-        *(int*)(c + 0x330) = *(int*)(*(char**)(c + 0x324) + 0x60);
+    unk_348 = 0;
+    if (*(void**)((char*)&unk_324) != 0)
+        unk_330 = *(int*)(*(char**)((char*)&unk_324) + 0x60);
     return 1;
 }

--- a/src/_ZN13UpDownLiftBbhD0Ev.c
+++ b/src/_ZN13UpDownLiftBbhD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13UpDownLiftBbhD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daUdlift_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN13UpDownLiftBbhD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10daUdlift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13UpDownLiftBbhD1Ev.c
+++ b/src/_ZN13UpDownLiftBbhD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN13UpDownLiftBbhD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daUdlift_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN13UpDownLiftBbhD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10daUdlift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN13WaterfallMist16CleanupResourcesEv.cpp
+++ b/src/_ZN13WaterfallMist16CleanupResourcesEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN13WaterfallMist16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WaterfallMist.h"
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void* fp);
 }
-extern void* data_ov002_020ff0ac[];
 extern void* data_ov002_0210de50;
 extern void* data_ov002_0210de60;
 extern void* data_ov002_0210de48;
@@ -16,11 +20,13 @@ extern void* data_ov002_0210de58;
 extern void* data_ov002_0210de18;
 extern void* data_ov002_0210de30;
 extern void* data_ov002_0210de38;
-extern "C" int _ZN13WaterfallMist16CleanupResourcesEv(char* c){
-  int i = *(int*)(c + 0x3f4);
+
+int WaterfallMist::CleanupResources()
+{
+  int i = mModelIndex;
   if (i >= 3) return 1;
   _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff0ac[i]);
-  switch (*(int*)(c + 0x3f0)) {
+  switch (mType) {
   case 0xf:
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de50);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210de60);

--- a/src/_ZN13WaterfallMist6RenderEv.cpp
+++ b/src/_ZN13WaterfallMist6RenderEv.cpp
@@ -1,22 +1,25 @@
 //cpp
+// @symbol _ZN13WaterfallMist6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "WaterfallMist.h"
 // _ZN13WaterfallMist6RenderEv at 0x020b83c4
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" int _ZN5Model6RenderEPK7Vector3(void *, const void *);
 extern "C" int data_ov002_0210df54;
 
-extern "C" int _ZN13WaterfallMist6RenderEv(char *self)
+int WaterfallMist::Render()
 {
-    int b = (*(int *)(self + 0xb0) & 0x40000) ? 1 : 0;
+    int b = (unk_0b0 & 0x40000) ? 1 : 0;
     if (b) return 1;
-    if (*(unsigned char *)(self + 0x3ff) == 1 || *(int *)(self + 0x80) < 0x100) return 1;
+    if (unk_3ff == 1 || mScaleX < 0x100) return 1;
 
-    int t = *(int *)(self + 0x3f0);
+    int t = mType;
     if (t == 4 || t == 17 || t == 5 || t == 18 || t == 16 || t == 11 || (unsigned)(t - 6) <= 3) {
-        if (!(*(int *)(self + 0x3ec) & 1) || *(int *)(self + 0x3bc) == (int)&data_ov002_0210df54) {
-            _ZN5Model6RenderEPK7Vector3(self + 0x300, self + 0x80);
+        if (!(unk_3ec & 1) || unk_3bc == (int)&data_ov002_0210df54) {
+            _ZN5Model6RenderEPK7Vector3(((char *)this) + 0x300, ((char *)this) + 0x80);
         }
     } else {
-        _ZN5Model6RenderEPK7Vector3(self + 0x300, self + 0x80);
+        _ZN5Model6RenderEPK7Vector3(((char *)this) + 0x300, ((char *)this) + 0x80);
     }
     return 1;
 }

--- a/src/_ZN13WaterfallMist8BehaviorEv.cpp
+++ b/src/_ZN13WaterfallMist8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN13WaterfallMist8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "WaterfallMist.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 
@@ -33,9 +36,9 @@ extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
 }
 
-extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
+int WaterfallMist::Behavior()
 {
-    char *c = (char *)thiz;
+    char *c = (char *)((Enemy *)this);
 
     if (*(u8 *)(c + 0x400) != 0xff) {
         if (((Flags3eb *)(c + 0x3eb))->f1 == 0) {
@@ -48,7 +51,7 @@ extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
             *(int *)(c + 0x40c) = 0x2000;
             *(u8 *)(c + 0x402) = 1;
             *(int *)(c + 0xa8) = 0xf000;
-            _ZN5Actor13SmallPoofDustEv(thiz);
+            _ZN5Actor13SmallPoofDustEv(((Enemy *)this));
         }
     }
 
@@ -61,8 +64,8 @@ extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
         _Z14ApproachLinearRiii((int *)(c + 0x80), *(int *)(c + 0x40c), 0x400);
         *(int *)(c + 0x88) = *(int *)(c + 0x80);
         *(int *)(c + 0x84) = *(int *)(c + 0x88);
-        _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, c + 0x110);
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+        _ZN5Actor9UpdatePosEP12CylinderClsn(((Enemy *)this), c + 0x110);
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
         if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x144) != 0) {
             if (*(int *)(c + 0x80) == 0x1000) {
                 *(u8 *)(c + 0x402) = 0;
@@ -73,7 +76,7 @@ extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
     {
         Holder *q = *(Holder **)(c + 0x3bc);
         if (q->fn != 0) {
-            (thiz->*(q->fn))();
+            (((Enemy *)this)->*(q->fn))();
         }
     }
 
@@ -85,7 +88,7 @@ extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
         ((VObj *)(c + 0x300))->v03();
     }
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144)) != 0) {
         return 1;
     }
 
@@ -93,8 +96,8 @@ extern "C" int _ZN13WaterfallMist8BehaviorEv(Enemy *thiz)
         int v = *(int *)(c + 0x3f0);
         if (v != 4 && v != 0x11 && v != 6 && v != 8 && v != 0xc && v != 0xa
             && v != 0x13 && v != 0xf && v != 0x14 && v != 0x15 && v != 0x16 && v != 0xd) {
-            _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, c + 0x110);
-            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+            _ZN5Actor9UpdatePosEP12CylinderClsn(((Enemy *)this), c + 0x110);
+            _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
         }
     }
 

--- a/src/_ZN13WaterfallMistD0Ev.c
+++ b/src/_ZN13WaterfallMistD0Ev.c
@@ -1,15 +1,17 @@
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13WaterfallMistD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjMarioCap_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN13WaterfallMistD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjMarioCap_c;
     func_ov001_020ab3a0((char *)t + 0x3d0);
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN13WaterfallMistD1Ev.c
+++ b/src/_ZN13WaterfallMistD1Ev.c
@@ -1,13 +1,16 @@
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN13WaterfallMistD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV13WaterfallMist */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN13WaterfallMistD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13WaterfallMist;
     func_ov001_020ab3a0((char *)t + 0x3d0);
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN14ArrowSignRight6RenderEv.cpp
+++ b/src/_ZN14ArrowSignRight6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN14ArrowSignRight6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ArrowSignRight.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN14ArrowSignRight6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int ArrowSignRight::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN14ArrowSignRight8BehaviorEv.cpp
+++ b/src/_ZN14ArrowSignRight8BehaviorEv.cpp
@@ -1,20 +1,23 @@
 //cpp
+// @symbol _ZN14ArrowSignRight8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "ArrowSignRight.h"
 extern "C" {
 int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void* c, short a, short b, short d, int e);
 void func_02039394(int* p, int v);
 void func_020393a4(int* p, int v);
 void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void* c, void* sm, void* mtx, int s, int x, int y, unsigned int j);
 int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* c, int a, int b);
-
-int _ZN14ArrowSignRight8BehaviorEv(char* c)
-{
-    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(c, -0x2000, 0, 0, 0x96000))
-        return 1;
-    func_02039394((int*)(c+0x124), 0xc0000);
-    func_020393a4((int*)(c+0x124), 0xe0000);
-    _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
-        c, (void*)(c+0x320), (void*)(c+0x348), 0x10e000, 0x64000, 0x46000, 0xf);
-    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x600000, 0);
-    return 1;
 }
+
+int ArrowSignRight::Behavior()
+{
+    if (_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(((char*)this), -0x2000, 0, 0, 0x96000))
+        return 1;
+    func_02039394((int*)((char*)&mMeshCollider), 0xc0000);
+    func_020393a4((int*)((char*)&mMeshCollider), 0xe0000);
+    _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
+        ((char*)this), (void*)((char*)&mShadowModel), (void*)((char*)&unk_348), 0x10e000, 0x64000, 0x46000, 0xf);
+    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char*)this), 0x600000, 0);
+    return 1;
 }

--- a/src/_ZN14ArrowSignRightD0Ev.c
+++ b/src/_ZN14ArrowSignRightD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14ArrowSignRightD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN14ArrowSignRightD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjYajirusi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14ArrowSignRightD1Ev.c
+++ b/src/_ZN14ArrowSignRightD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14ArrowSignRightD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjYajirusi_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN14ArrowSignRightD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjYajirusi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14BlueCoinSwitchD0Ev.c
+++ b/src/_ZN14BlueCoinSwitchD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN14BlueCoinSwitchD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daESwitch_c */
 extern void *G0;
 int *_ZN14BlueCoinSwitchD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daESwitch_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN14EnemySwitchTagD0Ev.c
+++ b/src/_ZN14EnemySwitchTagD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN14EnemySwitchTagD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "EnemySwitchTag.h"
 int *_ZN14EnemySwitchTagD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN14FlameChompFire13InitResourcesEv.cpp
+++ b/src/_ZN14FlameChompFire13InitResourcesEv.cpp
@@ -1,25 +1,29 @@
 //cpp
+// @symbol _ZN14FlameChompFire13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChompFire.h"
 struct M48 { int w[12]; };
 extern "C" {
 extern int _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int fix12, int t, unsigned int a, unsigned int b);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, int fix12, int t, void* vec, int last);
-extern void func_ov070_02122044(void* c, int a);
 extern int data_02082128[];
-
-int _ZN14FlameChompFire13InitResourcesEv(char* c)
-{
-    if (_ZN11ShadowModel12InitCylinderEv(c + 0xd4) == 0)
-        return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xfc, c, 0x37000, 0x78000, 0x200002, 0x8000);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x130, c, 0x32000, 0x32000, 0, 0);
-    *(int*)(c + 0x9c) = -0x400;
-    *(int*)(c + 0xa0) = -0x5000;
-    *(int*)(c + 0x80) = 0x1000;
-    *(int*)(c + 0x84) = 0x1000;
-    *(int*)(c + 0x88) = 0x1000;
-    func_ov070_02122044(c, 0);
-    *(struct M48*)(c + 0x2ec) = *(struct M48*)data_02082128;
-    return 1;
 }
+
+int FlameChompFire::InitResources()
+{
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
+        return 0;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0xfc, ((char*)this), 0x37000, 0x78000, 0x200002, 0x8000);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x130, ((char*)this), 0x32000, 0x32000, 0, 0);
+    unk_09c = -0x400;
+    unk_0a0 = -0x5000;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    func_ov070_02122044(((char*)this), 0);
+    *(struct M48*)((char*)&unk_2ec) = *(struct M48*)data_02082128;
+    return 1;
 }

--- a/src/_ZN14FlameChompFire6RenderEv.cpp
+++ b/src/_ZN14FlameChompFire6RenderEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN14FlameChompFire6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlameChompFire.h"
 extern "C" {
 extern int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, int c, int d, int e, void* f);
-int _ZN14FlameChompFire6RenderEv(char* c) {
-  int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
-  if (b) return 1;
-  *(int*)(c + 0x324) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-      *(int*)(c + 0x324), 0x7f, *(int*)(c + 0x5c), *(int*)(c + 0x60) + 0x4b000, *(int*)(c + 0x64), 0);
-  *(int*)(c + 0x328) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-      *(int*)(c + 0x328), 0x80, *(int*)(c + 0x5c), *(int*)(c + 0x60) + 0x4b000, *(int*)(c + 0x64), 0);
-  return 1;
 }
+
+int FlameChompFire::Render()
+{
+  int b = (unk_0b0 & 0x40000) != 0;
+  if (b) return 1;
+  unk_324 = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+      unk_324, 0x7f, mPosX, mPosY + 0x4b000, mPosZ, 0);
+  unk_328 = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+      unk_328, 0x80, mPosX, mPosY + 0x4b000, mPosZ, 0);
+  return 1;
 }

--- a/src/_ZN14FlameChompFireD0Ev.c
+++ b/src/_ZN14FlameChompFireD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN14FlameChompFireD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daKpFr_c */
 extern void *G0;
 int *_ZN14FlameChompFireD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daKpFr_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x130);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xfc);
     _ZN11ShadowModelD1Ev((char *)t + 0xd4);


### PR DESCRIPTION
Batch 03 of the readable-tree migration. Promotes 185 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (tools/prepush_linkcheck.py, mwccarm 1.2/sp2p3): 78 VERIFIED, 107 BLIND, 0 WRONG/NO-REPRO. 5 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
