### PR TITLE
readable: batch 04 - promote 184 files to readable form

### DIFF
--- a/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
+++ b/src/_ZN14KnockDownPlank13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN14KnockDownPlank13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "KnockDownPlank.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
@@ -8,34 +13,31 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,int,int,void*);
 extern void func_020393d4(int* p, int v);
 extern int func_01ffb0a4(void*);
-extern int func_01ffb07c(void*,void*);
-extern void func_020396d0(int* p, int v);
-extern void func_ov015_02111fb8(void* self, int idx);
 extern int data_ov015_02114534[];
-extern int data_ov034_02114538[];
-extern int data_ov015_0211453c[];
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
-int _ZN14KnockDownPlank13InitResourcesEv(char* c){
-  int b = (*(unsigned short*)((char*)c+0xc) == 0x35) ? 1 : 0;
-  if(b) *(int*)((char*)c+0x32c) = 1; else *(int*)((char*)c+0x32c) = 0;
-  int j0 = *(int*)((char*)c+0x32c) * 0xc;
+}
+
+int KnockDownPlank::InitResources()
+{
+  int b = (*(unsigned short*)((char*)&unk_00c) == 0x35) ? 1 : 0;
+  if(b) *(int*)((char*)&mVariant) = 1; else *(int*)((char*)&mVariant) = 0;
+  int j0 = *(int*)((char*)&mVariant) * 0xc;
   int m = _ZN5Model8LoadFileER13SharedFilePtr(*(void**)((char*)data_ov015_02114534 + j0));
-  _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)c+0xd4, m, 1, -1);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  int j = *(int*)((char*)c+0x32c) * 0xc;
+  _ZN9ModelBase7SetFileEP8BMD_Fileii((char*)((char*)this)+0xd4, m, 1, -1);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  int j = *(int*)((char*)&mVariant) * 0xc;
   int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(*(void**)((char*)data_ov034_02114538 + j));
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)c+0x124, k, (char*)c+0x2ec, 0x1000, *(short*)(c+0x8e), *(void**)((char*)data_ov015_0211453c + j));
-  func_020393d4((int*)((char*)c+0x124), (int)&_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block((char*)((char*)this)+0x124, k, (char*)((char*)this)+0x2ec, 0x1000, unk_08e, *(void**)((char*)data_ov015_0211453c + j));
+  func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
   int tmp[3];
   tmp[0] = 0x1000; tmp[1] = 0; tmp[2] = 0;
-  func_01ffb0a4((char*)c+0x124);
-  func_01ffb07c((char*)c+0x124, tmp);
-  func_020396d0((int*)((char*)c+0x124), 0xccd);
-  *(int*)((char*)c+0x320) = *(int*)((char*)c+0x5c);
-  *(int*)((char*)c+0x324) = *(int*)((char*)c+0x60);
-  *(int*)((char*)c+0x328) = *(int*)((char*)c+0x64);
-  func_ov015_02111fb8(c, 5);
+  func_01ffb0a4((char*)&mMeshCollider);
+  func_01ffb07c((char*)((char*)this)+0x124, tmp);
+  func_020396d0((int*)((char*)&mMeshCollider), 0xccd);
+  *(int*)((char*)&unk_320) = *(int*)((char*)&unk_05c);
+  *(int*)((char*)&unk_324) = *(int*)((char*)&unk_060);
+  *(int*)((char*)&unk_328) = *(int*)((char*)&unk_064);
+  func_ov015_02111fb8(((char*)this), 5);
   return 1;
-}
 }

--- a/src/_ZN14KnockDownPlank6RenderEv.cpp
+++ b/src/_ZN14KnockDownPlank6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN14KnockDownPlank6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "KnockDownPlank.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN14KnockDownPlank6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int KnockDownPlank::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN14KnockDownPlank8BehaviorEv.cpp
+++ b/src/_ZN14KnockDownPlank8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14KnockDownPlank8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "KnockDownPlank.h"
 struct C;
 typedef void (C::*PMF)();
 struct TabEnt { PMF pmf; };
@@ -12,11 +15,12 @@ struct C {
     char pad[0x330];
     int idx;
 };
-extern "C" int _ZN14KnockDownPlank8BehaviorEv(C *c)
+
+int KnockDownPlank::Behavior()
 {
-    (c->*(data_ov015_021149ec[c->idx].pmf))();
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    (((C *)this)->*(data_ov015_021149ec[((C *)this)->idx].pmf))();
+    _ZN8Platform21UpdateModelPosAndRotYEv(((C *)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((C *)this), 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(((C *)this));
     return 1;
 }

--- a/src/_ZN14KnockDownPlankD0Ev.c
+++ b/src/_ZN14KnockDownPlankD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14KnockDownPlankD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjBk_Dossunbar_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN14KnockDownPlankD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV19daObjBk_Dossunbar_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14KnockDownPlankD1Ev.c
+++ b/src/_ZN14KnockDownPlankD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14KnockDownPlankD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjBk_Dossunbar_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN14KnockDownPlankD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV19daObjBk_Dossunbar_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14MovingBarSmall6RenderEv.cpp
+++ b/src/_ZN14MovingBarSmall6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN14MovingBarSmall6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MovingBarSmall.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN14MovingBarSmall6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int MovingBarSmall::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN14MovingBarSmallD0Ev.c
+++ b/src/_ZN14MovingBarSmallD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14MovingBarSmallD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN14MovingBarSmallD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjBk_Lift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14MovingBarSmallD1Ev.c
+++ b/src/_ZN14MovingBarSmallD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14MovingBarSmallD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjBk_Lift_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN14MovingBarSmallD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjBk_Lift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14MrI_Projectile6RenderEv.cpp
+++ b/src/_ZN14MrI_Projectile6RenderEv.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol _ZN14MrI_Projectile6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MrI_Projectile.h"
 extern "C" {
 int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
     unsigned int a, unsigned int b, int c, int d, int e, const void* f);
 }
 
-extern "C" int _ZN14MrI_Projectile6RenderEv(char* c)
+int MrI_Projectile::Render()
 {
-    *(int*)(c + 0x328) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-        *(int*)(c + 0x328), 0x46, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64), 0);
-    *(int*)(c + 0x32c) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-        *(int*)(c + 0x32c), 0x47, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64), 0);
+    unk_328 = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+        unk_328, 0x46, mPosX, mPosY, mPosZ, 0);
+    unk_32c = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
+        unk_32c, 0x47, mPosX, mPosY, mPosZ, 0);
     return 1;
 }

--- a/src/_ZN14MrI_Projectile8BehaviorEv.cpp
+++ b/src/_ZN14MrI_Projectile8BehaviorEv.cpp
@@ -1,28 +1,29 @@
 //cpp
+// @symbol _ZN14MrI_Projectile8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MrI_Projectile.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
 
 extern "C" void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* self, const Vector3& v);
 extern "C" void Matrix4x3_FromRotationY(void* m, s16 ang);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationX(void* m, s16 ang);
 extern "C" void MulVec3Mat4x3(void* dst, void* m, void* src);
 extern "C" void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void* self, void* clsn);
-extern "C" void func_ov071_02121b50(void* self, void* clsn);
-extern "C" void func_ov071_02121ba4(void* c);
 extern "C" void func_ov071_02121c6c(void* c);
 extern "C" void _ZN12CylinderClsn5ClearEv(void* cl);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void* cl);
 extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
-extern "C" void func_ov071_02121b08(void* c);
 
 extern Vector3 data_ov071_021230b8;
 extern int data_020a0e68[];
 
-extern "C" int _ZN14MrI_Projectile8BehaviorEv(char* c)
+int MrI_Projectile::Behavior()
 {
     Vector3 v;
     Vector3 r;
-    int flags = *(int*)(c + 0xb0);
+    int flags = unk_0b0;
     int b1 = (int)((flags & 0x40000) != 0);
     int b2;
     if (b1 != 0)
@@ -30,24 +31,24 @@ extern "C" int _ZN14MrI_Projectile8BehaviorEv(char* c)
     b2 = (int)((flags & 0x20000) != 0);
     if (b2 == 0) {
         v = data_ov071_021230b8;
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0xfc, v);
-        r.z = *(int*)(c + 0x98);
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0xfc, v);
+        r.z = unk_098;
         r.x = 0;
         r.y = 0;
-        Matrix4x3_FromRotationY(data_020a0e68, *(s16*)(c + 0x94));
-        Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(s16*)(c + 0x92));
-        MulVec3Mat4x3(&r, data_020a0e68, c + 0xa4);
-        *(Vector3*)(c + 0xa4) = *(Vector3*)(c + 0xa4);
-        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, c + 0xfc);
-        func_ov071_02121b50(c, c + 0x13c);
-        func_ov071_02121ba4(c);
-        func_ov071_02121c6c(c);
-        _ZN12CylinderClsn5ClearEv(c + 0xfc);
-        _ZN12CylinderClsn6UpdateEv(c + 0xfc);
-        if (DecIfAbove0_Short((unsigned short*)(c + 0x330)) == 0)
-            func_ov071_02121b08(c);
+        Matrix4x3_FromRotationY(data_020a0e68, unk_094);
+        Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, unk_092);
+        MulVec3Mat4x3(&r, data_020a0e68, ((char*)this) + 0xa4);
+        *(Vector3*)((char*)&unk_0a4) = *(Vector3*)((char*)&unk_0a4);
+        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((char*)this), ((char*)this) + 0xfc);
+        func_ov071_02121b50(((char*)this), ((char*)this) + 0x13c);
+        func_ov071_02121ba4(((char*)this));
+        func_ov071_02121c6c(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
+        if (DecIfAbove0_Short((unsigned short*)((char*)&unk_330)) == 0)
+            func_ov071_02121b08(((char*)this));
     } else {
-        func_ov071_02121c6c(c);
+        func_ov071_02121c6c(((char*)this));
     }
     return 1;
 }

--- a/src/_ZN14MrI_ProjectileD0Ev.c
+++ b/src/_ZN14MrI_ProjectileD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN14MrI_ProjectileD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daEyBm_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN14MrI_ProjectileD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daEyBm_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x13c);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0xfc);
     _ZN11ShadowModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN14QuestionSwitch6RenderEv.cpp
+++ b/src/_ZN14QuestionSwitch6RenderEv.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol _ZN14QuestionSwitch6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "QuestionSwitch.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct D { char pad[0x6b4]; Base b; };
-extern "C" int _ZN14QuestionSwitch6RenderEv(D *d) {
-  d->b.m(0);
+
+int QuestionSwitch::Render()
+{
+  ((D *)this)->b.m(0);
   return 1;
 }

--- a/src/_ZN14QuestionSwitchD0Ev.c
+++ b/src/_ZN14QuestionSwitchD0Ev.c
@@ -1,21 +1,23 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int _ZTV14QuestionSwitch[];
+// @symbol _ZN14QuestionSwitchD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "QuestionSwitch.h"
 extern int _ZTV17ExclamationSwitch[];
 extern void *data_020a0eac;
-int *_ZN14QuestionSwitchD0Ev(int *t)
-{
-    t[0] = (int)_ZTV14QuestionSwitch;
-    _ZN9ModelAnimD1Ev((char *)t + 0x6b4);
-    _ZN18MovingMeshColliderD1Ev((char *)t + 0x4ec);
-    _ZN18MovingMeshColliderD1Ev((char *)t + 0x324);
-    t[0] = (int)_ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
-    _ZN5ModelD1Ev((char *)t + 0xd4);
-    _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
-    return t;
+int *_ZN14QuestionSwitchD0Ev(struct QuestionSwitch *self) {
+    ((int *)self)[0] = (int)_ZTV14QuestionSwitch;
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN18MovingMeshColliderD1Ev((char *)&self->unk_324);
+    ((int *)self)[0] = (int)_ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->unk_124);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((int *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((int *)self), data_020a0eac);
+    return ((int *)self);
 }

--- a/src/_ZN14QuestionSwitchD1Ev.cpp
+++ b/src/_ZN14QuestionSwitchD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14QuestionSwitchD1Ev
+/* recovered: named members + shared header */
+#include "QuestionSwitch.h"
 extern "C" {
 extern int _ZN9ModelAnimD1Ev(char*);
 extern int _ZN18MovingMeshColliderD1Ev(char*);
@@ -6,15 +9,15 @@ extern int _ZN5ModelD1Ev(char*);
 extern int _ZN5ActorD2Ev(char*);
 extern int _ZTV14QuestionSwitch[];
 extern int _ZTV17ExclamationSwitch[];
-char* _ZN14QuestionSwitchD1Ev(char* c){
-  *(int**)c = _ZTV14QuestionSwitch;
-  _ZN9ModelAnimD1Ev(c+0x6b4);
-  _ZN18MovingMeshColliderD1Ev(c+0x4ec);
-  _ZN18MovingMeshColliderD1Ev(c+0x324);
-  *(int**)c = _ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+char* _ZN14QuestionSwitchD1Ev(struct QuestionSwitch *self) {
+  *(int**)((char*)self) = _ZTV14QuestionSwitch;
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
+  _ZN18MovingMeshColliderD1Ev((char*)&self->unk_324);
+  *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN14SquarePathLift13InitResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14SquarePathLift13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SquarePathLift.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
@@ -11,17 +14,19 @@ extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 struct SFP { void* a; void* b; void* c; };
 extern struct SFP data_ov052_021125a0;
-int _ZN14SquarePathLift13InitResourcesEv(char* c){
-  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov052_021125a0.a);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  void* f2 = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov052_021125a0.b);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, f2, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov052_021125a0.c);
-  func_020393d4((int*)(c+0x124), &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  _ZN7PathPtr6FromIDEj(c+0x320, *(int*)(c+8)&0xff);
-  *(int*)(c+0x32c) = 1;
-  *(int*)(c+0x98) = 0xa000;
-  return 1;
 }
+
+int SquarePathLift::InitResources()
+{
+  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov052_021125a0.a);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, f, 1, -1);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  void* f2 = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov052_021125a0.b);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, f2, ((char*)this)+0x2ec, 0x199, unk_08e, data_ov052_021125a0.c);
+  func_020393d4((int*)((char*)&mMeshCollider), &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  _ZN7PathPtr6FromIDEj(((char*)this)+0x320, mParam&0xff);
+  mPathDir = 1;
+  mMoveSpeed = 0xa000;
+  return 1;
 }

--- a/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
+++ b/src/_ZN14SquarePathLift16CleanupResourcesEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN14SquarePathLift16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SquarePathLift.h"
 extern "C" {
 struct SFP{int x;};
 extern SFP data_ov052_021125a0[2];
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase7DisableEv(void*);
 void _ZN13SharedFilePtr7ReleaseEv(void*);
-int _ZN14SquarePathLift16CleanupResourcesEv(char* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+}
+
+int SquarePathLift::CleanupResources()
+{
+  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
+    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[0].x);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov052_021125a0[1].x);
   return 1;
-}
 }

--- a/src/_ZN14SquarePathLift6RenderEv.cpp
+++ b/src/_ZN14SquarePathLift6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN14SquarePathLift6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SquarePathLift.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN14SquarePathLift6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int SquarePathLift::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN14SquarePathLiftD0Ev.c
+++ b/src/_ZN14SquarePathLiftD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14SquarePathLiftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN14SquarePathLiftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjEmmYuka_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14SquarePathLiftD1Ev.c
+++ b/src/_ZN14SquarePathLiftD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14SquarePathLiftD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjEmmYuka_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN14SquarePathLiftD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjEmmYuka_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14TtcMovingCubeA6RenderEv.cpp
+++ b/src/_ZN14TtcMovingCubeA6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN14TtcMovingCubeA6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TtcMovingCubeA.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN14TtcMovingCubeA6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int TtcMovingCubeA::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN14TtcMovingCubeAD0Ev.c
+++ b/src/_ZN14TtcMovingCubeAD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14TtcMovingCubeAD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN14TtcMovingCubeAD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha09_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14TtcMovingCubeAD1Ev.c
+++ b/src/_ZN14TtcMovingCubeAD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN14TtcMovingCubeAD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha09_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN14TtcMovingCubeAD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha09_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN14UnchainedChomp6RenderEv.cpp
+++ b/src/_ZN14UnchainedChomp6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14UnchainedChomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "UnchainedChomp.h"
 struct A;
 struct B {
     virtual void m0();
@@ -9,12 +12,13 @@ struct B {
     virtual void m5(A* arg);
 };
 
-extern "C" int _ZN14UnchainedChomp6RenderEv(char *c) {
-    B *b = (B*)(c+0x30c);
-    b->m5((A*)(c+0x80));
+int UnchainedChomp::Render()
+{
+    B *b = (B*)((char *)&mModelAnim);
+    b->m5((A*)((char *)&mScaleX));
     
     int j = 0;
-    char *p2 = c + 0x370;
+    char *p2 = ((char *)this) + 0x370;
     for (;;) {
         B *b2 = (B*)p2;
         b2->m5((A*)0);

--- a/src/_ZN14UnchainedChomp8BehaviorEv.cpp
+++ b/src/_ZN14UnchainedChomp8BehaviorEv.cpp
@@ -1,6 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+// @symbol _ZN14UnchainedChomp8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "UnchainedChomp.h"
 struct CylinderClsn;
 struct Actor;
 typedef void (Actor::*PMF)();
@@ -9,14 +12,11 @@ struct Holder { char pad[8]; PMF fn; };
 extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _Z14ApproachLinearRiii(int &x, int target, int step);
-extern void func_ov100_02143b68(char *c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(Actor *thiz, CylinderClsn *c);
-extern int func_ov100_02143370(char *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
 extern void func_02012694(int, void *);
 extern void _ZN5Actor15HugeLandingDustEb(Actor *thiz, bool b);
-extern int __aeabi_idiv(int a, int b);
 extern Actor *_ZN5Actor13ClosestPlayerEv(Actor *thiz);
 extern Actor *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const Vector3 &pos, const Vector3_16 *rot, int e, int f);
 extern void _ZN7PathPtrC1Ev(void *thiz);
@@ -32,9 +32,9 @@ extern unsigned char data_0209f2d8[];
 
 struct Actor { char pad[0x800]; };
 
-extern "C" int _ZN14UnchainedChomp8BehaviorEv(Actor *thiz)
+int UnchainedChomp::Behavior()
 {
-    char *c = (char *)thiz;
+    char *c = (char *)((Actor *)this);
     DecIfAbove0_Short((unsigned short *)(c + 0x6ca));
     DecIfAbove0_Short((unsigned short *)(c + 0x6a8));
     if (DecIfAbove0_Short((unsigned short *)(c + 0x6a6)) != 0) {
@@ -43,7 +43,7 @@ extern "C" int _ZN14UnchainedChomp8BehaviorEv(Actor *thiz)
         *(int *)(c + 0x84) = *(int *)(c + 0x88);
         func_ov100_02143b68(c);
         *(int *)(c + 0x98) = 0;
-        _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, (CylinderClsn *)(c + 0x110));
+        _ZN5Actor9UpdatePosEP12CylinderClsn(((Actor *)this), (CylinderClsn *)(c + 0x110));
         if (func_ov100_02143370(c) != 0) {
             *(int *)(c + 0xa0) = 0;
         }
@@ -57,26 +57,26 @@ extern "C" int _ZN14UnchainedChomp8BehaviorEv(Actor *thiz)
     {
         Holder *q = *(Holder **)(c + 0x668);
         if (q->fn != 0) {
-            (thiz->*(q->fn))();
+            (((Actor *)this)->*(q->fn))();
         }
     }
 
     *(int *)(c + 0x98) = 0x17000;
-    _ZN5Actor9UpdatePosEP12CylinderClsn(thiz, (CylinderClsn *)(c + 0x110));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((Actor *)this), (CylinderClsn *)(c + 0x110));
 
     if (func_ov100_02143370(c) != 0) {
         if (*(unsigned short *)(c + 0x6a8) == 0) {
             func_02012694(0x39, c + 0x74);
         }
         *(int *)(c + 0xa8) = 0x14000;
-        _ZN5Actor15HugeLandingDustEb(thiz, true);
+        _ZN5Actor15HugeLandingDustEb(((Actor *)this), true);
     }
 
     int flag = (data_0209f2d8[0] == 1);
     if (flag != 0 && *(unsigned short *)(c + 0x6ca) == 0) {
         int q16 = __aeabi_idiv(0x10000, *(int *)(c + 0x6b4));
         short spd = (short)q16;
-        Actor *pl = _ZN5Actor13ClosestPlayerEv(thiz);
+        Actor *pl = _ZN5Actor13ClosestPlayerEv(((Actor *)this));
         (void)pl;
 
         volatile Vector3 v;
@@ -131,7 +131,7 @@ extern "C" int _ZN14UnchainedChomp8BehaviorEv(Actor *thiz)
         func_ov100_02143b68(c);
         _ZN12CylinderClsn5ClearEv(c + 0x110);
 
-        Actor *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        Actor *p = _ZN5Actor13ClosestPlayerEv(((Actor *)this));
         if (p != 0 && *(unsigned char *)((char *)p + 0x6fb) == 0) {
             _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }

--- a/src/_ZN14UnchainedChompD0Ev.cpp
+++ b/src/_ZN14UnchainedChompD0Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14UnchainedChompD0Ev
+/* recovered: named members + shared header */
+#include "UnchainedChomp.h"
 extern "C" {
 int func_0207328c(void*, int, int, void*);
 int _ZN11ShadowModelD1Ev(void*);
@@ -12,19 +15,19 @@ extern void func_02011508();
 extern void func_020072c0();
 extern void _ZN5ModelD1Ev();
 extern int data_020a0eac[];
-void* _ZN14UnchainedChompD0Ev(char* c){
-  *(int**)c = _ZTV14UnchainedChomp;
-  func_0207328c(c+0x768, 6, 6, (void*)func_02011508);
-  func_0207328c(c+0x720, 6, 0xc, (void*)func_020072c0);
-  func_0207328c(c+0x6d8, 6, 0xc, (void*)func_020072c0);
-  _ZN11ShadowModelD1Ev(c+0x640);
-  func_0207328c(c+0x550, 6, 0x28, (void*)_ZN11ShadowModelD1Ev);
-  func_0207328c(c+0x370, 6, 0x50, (void*)_ZN5ModelD1Ev);
-  _ZN9ModelAnimD1Ev(c+0x30c);
-  _ZN12WithMeshClsnD1Ev(c+0x150);
-  _ZN25MovingCylinderClsnWithPosD1Ev(c+0x110);
-  func_ov002_020aed18(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, (void*)data_020a0eac[0]);
-  return c;
+void* _ZN14UnchainedChompD0Ev(struct UnchainedChomp *self) {
+  *(int**)((char*)self) = _ZTV14UnchainedChomp;
+  func_0207328c(((char*)self)+0x768, 6, 6, (void*)func_02011508);
+  func_0207328c(((char*)self)+0x720, 6, 0xc, (void*)func_020072c0);
+  func_0207328c(((char*)self)+0x6d8, 6, 0xc, (void*)func_020072c0);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  func_0207328c(((char*)self)+0x550, 6, 0x28, (void*)_ZN11ShadowModelD1Ev);
+  func_0207328c(((char*)self)+0x370, 6, 0x50, (void*)_ZN5ModelD1Ev);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  func_ov002_020aed18(((char*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self), (void*)data_020a0eac[0]);
+  return ((char*)self);
 }
 }

--- a/src/_ZN14UnchainedChompD1Ev.cpp
+++ b/src/_ZN14UnchainedChompD1Ev.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol _ZN14UnchainedChompD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+/* recovered: named members + shared header */
+#include "UnchainedChomp.h"
 extern "C" void func_0207328c(void* p, int n, int sz, void* dtor);
-extern "C" void _ZN11ShadowModelD1Ev(void*);
-extern "C" void _ZN9ModelAnimD1Ev(void*);
-extern "C" void _ZN12WithMeshClsnD1Ev(void*);
 extern "C" void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern "C" int func_ov002_020aed18(int* x);
-extern "C" void _ZN5ModelD1Ev(void*);
 
 extern int _ZTV14UnchainedChomp;
 extern "C" void func_02011508(void);

--- a/src/_ZN14UnknownVsEntry6RenderEv.cpp
+++ b/src/_ZN14UnknownVsEntry6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN14UnknownVsEntry6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "UnknownVsEntry.h"
 extern "C" {
 void _ZN11ShadowModel9RenderAllEv(void);
 void _ZN8Particle10SysTracker6UpdateEv(void* p);
@@ -16,23 +19,24 @@ struct Sub {
     virtual void m(int);
 };
 
-extern "C" int _ZN14UnknownVsEntry6RenderEv(char* c) {
-    Sub* s = (Sub*)(c + 0x86c);
+int UnknownVsEntry::Render()
+{
+    Sub* s = (Sub*)((char*)&mModel);
     s->m(0);
     _ZN11ShadowModel9RenderAllEv();
-    _ZN8Particle10SysTracker6UpdateEv(c + 0x50);
+    _ZN8Particle10SysTracker6UpdateEv((char*)&mParticle);
     int i = 0;
-    char* p = c + 0x920;
+    char* p = ((char*)this) + 0x920;
     do {
         func_ov075_02114be4(p);
         i++;
         p += 0x158;
     } while (i < 4);
-    if (*(unsigned char*)(c + 0xf40)) {
-        Sub* s2 = (Sub*)(c + 0x8bc);
+    if (unk_f40) {
+        Sub* s2 = (Sub*)((char*)&mModelAnim);
         s2->m(0);
     }
-    func_ov075_0211b3d8(c + 0xe80);
+    func_ov075_0211b3d8((char*)&unk_e80);
     _ZN8Particle9RenderAllEv();
     return 1;
 }

--- a/src/_ZN14UnknownVsEntryD0Ev.c
+++ b/src/_ZN14UnknownVsEntryD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN14UnknownVsEntryD0Ev
+/* recovered: named members + shared header */
+#include "UnknownVsEntry.h"
 extern int func_0207328c(void* p, int a, int b, void* d);
 extern void _ZN9ModelAnimD1Ev(void* p);
 extern void _ZN5ModelD1Ev(void* p);
@@ -8,14 +11,14 @@ extern int _ZTV14UnknownVsEntry[];
 extern int func_ov075_02113fdc;
 extern int data_0208e4b8[];
 extern int data_020a0eac[];
-int _ZN14UnknownVsEntryD0Ev(int* c){
-  *(int**)c = _ZTV14UnknownVsEntry;
-  func_0207328c((char*)c+0x920, 4, 0x158, &func_ov075_02113fdc);
-  _ZN9ModelAnimD1Ev((char*)c+0x8bc);
-  _ZN5ModelD1Ev((char*)c+0x86c);
-  _ZN8Particle10SysTrackerD1Ev((char*)c+0x50);
-  *(int**)c = data_0208e4b8;
-  _ZN9ActorBaseD2Ev(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac[0]);
-  return (int)c;
+int _ZN14UnknownVsEntryD0Ev(struct UnknownVsEntry *self) {
+  *(int**)((int*)self) = _ZTV14UnknownVsEntry;
+  func_0207328c((char*)((int*)self)+0x920, 4, 0x158, &func_ov075_02113fdc);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN8Particle10SysTrackerD1Ev((char*)&self->mParticle);
+  *(int**)((int*)self) = data_0208e4b8;
+  _ZN9ActorBaseD2Ev(((int*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((int*)self), data_020a0eac[0]);
+  return (int)((int*)self);
 }

--- a/src/_ZN14UnknownVsEntryD1Ev.cpp
+++ b/src/_ZN14UnknownVsEntryD1Ev.cpp
@@ -1,21 +1,25 @@
 //cpp
+// @symbol _ZN14UnknownVsEntryD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "UnknownVsEntry.h"
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN9ModelAnimD1Ev(void*);
-extern void _ZN5ModelD1Ev(void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void*);
 extern void _ZN9ActorBaseD2Ev(void*);
-extern int _ZTV14UnknownVsEntry[];
 extern int func_ov075_02113fdc[];
 extern int data_0208e4b8[];
-void* _ZN14UnknownVsEntryD1Ev(char* c){
-  *(int**)c = _ZTV14UnknownVsEntry;
-  func_0207328c(c+0x920, 4, 0x158, func_ov075_02113fdc);
-  _ZN9ModelAnimD1Ev(c+0x8bc);
-  _ZN5ModelD1Ev(c+0x86c);
-  _ZN8Particle10SysTrackerD1Ev(c+0x50);
-  *(int**)c = data_0208e4b8;
-  _ZN9ActorBaseD2Ev(c);
-  return c;
+void* _ZN14UnknownVsEntryD1Ev(struct UnknownVsEntry *self) {
+  *(int**)((char*)self) = _ZTV14UnknownVsEntry;
+  func_0207328c(((char*)self)+0x920, 4, 0x158, func_ov075_02113fdc);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN8Particle10SysTrackerD1Ev((char*)&self->mParticle);
+  *(int**)((char*)self) = data_0208e4b8;
+  _ZN9ActorBaseD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
+++ b/src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15BookShotSpawner16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "BookShotSpawner.h"
 class SharedFilePtr {
 public:
     void Release();
@@ -8,9 +11,10 @@ extern void UnloadBlueCoinModel(char *c);
 extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
 
-extern "C" int _ZN15BookShotSpawner16CleanupResourcesEv(char *c) {
+int BookShotSpawner::CleanupResources()
+{
     ((SharedFilePtr *)&data_ov020_02114aa0)->Release();
     ((SharedFilePtr *)&data_ov020_02114ab8)->Release();
-    UnloadBlueCoinModel(c);
+    UnloadBlueCoinModel(((char *)this));
     return 1;
 }

--- a/src/_ZN15BookShotSpawnerD0Ev.c
+++ b/src/_ZN15BookShotSpawnerD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN15BookShotSpawnerD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "BookShotSpawner.h"
 int *_ZN15BookShotSpawnerD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN15ChainChompFence6RenderEv.cpp
+++ b/src/_ZN15ChainChompFence6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15ChainChompFence6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ChainChompFence.h"
 struct Base {
     virtual int vf0(int);
     virtual int vf1(int);
@@ -11,8 +14,10 @@ struct Obj {
     char pad[0xd4];
     Base sub;
 };
-extern "C" int _ZN15ChainChompFence6RenderEv(Obj *c) {
-    if (*(unsigned char*)((char*)c+0x31e) != 0) return 1;
-    c->sub.vfunc(0);
+
+int ChainChompFence::Render()
+{
+    if (*(unsigned char*)((char*)&unk_31e) != 0) return 1;
+    ((Obj *)this)->sub.vfunc(0);
     return 1;
 }

--- a/src/_ZN15ChainChompFence8BehaviorEv.cpp
+++ b/src/_ZN15ChainChompFence8BehaviorEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN15ChainChompFence8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "ChainChompFence.h"
 extern "C" {
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
-int _ZN15ChainChompFence8BehaviorEv(void *c) {
-    if (*(unsigned char*)((char*)c+0x31e) != 0) return 1;
-    _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
-    return 1;
 }
+
+int ChainChompFence::Behavior()
+{
+    if (*(unsigned char*)((char*)&unk_31e) != 0) return 1;
+    _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((void *)this), 0, 0);
+    return 1;
 }

--- a/src/_ZN15ChainChompFenceD0Ev.c
+++ b/src/_ZN15ChainChompFenceD0Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15ChainChompFenceD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN15ChainChompFenceD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN15ChainChompFenceD1Ev.c
+++ b/src/_ZN15ChainChompFenceD1Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15ChainChompFenceD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN15ChainChompFenceD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN15FaderBrightness20IsBetweenStartAndEndEv.cpp
+++ b/src/_ZN15FaderBrightness20IsBetweenStartAndEndEv.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol _ZN15FaderBrightness20IsBetweenStartAndEndEv
+/* recovered: named members + shared header, real C++ method */
+#include "FaderBrightness.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual int a(); virtual int b(); };
-extern "C" int _ZN15FaderBrightness20IsBetweenStartAndEndEv(Base *c){
-  if(c->a()==0 && c->b()==0) return 1;
+
+int FaderBrightness::IsBetweenStartAndEnd()
+{
+  if(((Base *)this)->a()==0 && ((Base *)this)->b()==0) return 1;
   return 0;
 }

--- a/src/_ZN15FaderBrightnessD1Ev.c
+++ b/src/_ZN15FaderBrightnessD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN15FaderBrightnessD1Ev
+/* recovered: named members + shared header */
+#include "FaderBrightness.h"
 /* FaderBrightness::~FaderBrightness() at 0x02017814
  * Sets self->vtable to the FaderBrightness vtable, delegates to its base
  * (Fader) subobject destructor (func_02017838), and returns self

--- a/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN15FireSeaElevator13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FireSeaElevator.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -7,25 +12,22 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* act, int fix, int t, unsigned int a, unsigned int b);
-extern int data_ov045_021131b0[];
-extern int data_ov045_021131a8[];
-extern int data_ov045_02112510[];
+}
 
-int _ZN15FireSeaElevator13InitResourcesEv(char* c)
+int FireSeaElevator::InitResources()
 {
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_021131b0);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, -1);
-    if (*(int*)(c + 8) != 0xffff) {
-        int* p = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, -1);
+    if (unk_008 != 0xffff) {
+        int* p = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFF);
         *p -= 0x12c000;
     }
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov045_021131a8);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, mc, c + 0x2ec, 0x199, *(short*)(c + 0x8e), data_ov045_02112510);
+        ((char*)this) + 0x124, mc, ((char*)this) + 0x2ec, 0x199, unk_08e, data_ov045_02112510);
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(
-        c + 0x320, c, 0x35555, 0x258000, 0x280000c, 0);
+        ((char*)this) + 0x320, ((char*)this), 0x35555, 0x258000, 0x280000c, 0);
     return 1;
-}
 }

--- a/src/_ZN15FireSeaElevator6RenderEv.cpp
+++ b/src/_ZN15FireSeaElevator6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN15FireSeaElevator6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FireSeaElevator.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN15FireSeaElevator6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int FireSeaElevator::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN15FireSeaElevatorD0Ev.c
+++ b/src/_ZN15FireSeaElevatorD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15FireSeaElevatorD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN15FireSeaElevatorD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjKm2_Ami_Bou_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15FireSeaElevatorD1Ev.c
+++ b/src/_ZN15FireSeaElevatorD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15FireSeaElevatorD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjKm2_Ami_Bou_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN15FireSeaElevatorD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjKm2_Ami_Bou_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15IceSlideManagerD0Ev.c
+++ b/src/_ZN15IceSlideManagerD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN15IceSlideManagerD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "IceSlideManager.h"
 int *_ZN15IceSlideManagerD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN15InvisibleSecret13InitResourcesEv.cpp
+++ b/src/_ZN15InvisibleSecret13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15InvisibleSecret13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "InvisibleSecret.h"
 typedef int Fix12;
 
 struct SharedFilePtr { void* p; void* file; };
@@ -18,39 +21,39 @@ extern SharedFilePtr data_ov002_0210da28;
 extern SharedFilePtr data_ov002_0210d9e8;
 extern SharedFilePtr data_ov002_0210d9a8;
 
-extern "C" int _ZN15InvisibleSecret13InitResourcesEv(char* self)
+int InvisibleSecret::InitResources()
 {
-    if (*(int*)(self + 8) & 0x10) {
+    if (mParam & 0x10) {
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov002_0210da08);
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da28);
-        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, m, 1, 1) == 0)
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1) == 0)
             return 0;
         _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
             data_ov002_0210da28.file, data_ov002_0210da08.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
-            self + 0x124, data_ov002_0210da08.file, 0x40000000, 0, 0);
-        *(int*)(self + 0x12c) = (int)((((unsigned int)(*(int*)(self + 8) & 0xf) % 10) << 16) >> 4);
+            ((char*)this) + 0x124, data_ov002_0210da08.file, 0x40000000, 0, 0);
+        unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
     } else {
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov002_0210d9e8);
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a8);
-        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, m, 1, 1) == 0)
+        if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1) == 0)
             return 0;
         _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
             data_ov002_0210d9a8.file, data_ov002_0210d9e8.file);
         _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
-            self + 0x124, data_ov002_0210d9e8.file, 0x40000000, 0, 0);
-        *(int*)(self + 0x12c) = (int)((((unsigned int)(*(int*)(self + 8) & 0xf) % 10) << 16) >> 4);
+            ((char*)this) + 0x124, data_ov002_0210d9e8.file, 0x40000000, 0, 0);
+        unk_12c = (int)((((unsigned int)(mParam & 0xf) % 10) << 16) >> 4);
     }
 
-    *(unsigned char*)(self + 0x14e) = 0;
-    *(int*)(self + 0x13c) = *(int*)(self + 0x5c);
-    *(int*)(self + 0x140) = *(int*)(self + 0x60);
-    *(int*)(self + 0x144) = *(int*)(self + 0x64);
-    *(int*)(self + 0xa8) = 0x14000;
-    *(int*)(self + 0x9c) = -0x2000;
-    *(int*)(self + 0xa0) = -0x32000;
-    *(short*)(self + 0x100 + 0x4c) = 0;
-    *(int*)(self + 0x138) = 0;
-    *(int*)(self + 0x148) = 0;
+    unk_14e = 0;
+    unk_13c = mPosX;
+    mStartPosY = mPosY;
+    unk_144 = mPosZ;
+    mVertSpeed = 0x14000;
+    unk_09c = -0x2000;
+    unk_0a0 = -0x32000;
+    *(short*)(((char*)this) + 0x100 + 0x4c) = 0;
+    unk_138 = 0;
+    unk_148 = 0;
     return 1;
 }

--- a/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
+++ b/src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN15InvisibleSecret16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "InvisibleSecret.h"
 extern "C" {
 extern int data_ov002_0210da28[];
 extern int data_ov002_0210da08[];
 extern int data_ov002_0210d9a8[];
 extern int data_ov002_0210d9e8[];
 void _ZN13SharedFilePtr7ReleaseEv(void*);
-int _ZN15InvisibleSecret16CleanupResourcesEv(char* c){
-  if(*(int*)(c+8) & 0x10){
+}
+
+int InvisibleSecret::CleanupResources()
+{
+  if(mParam & 0x10){
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da28);
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da08);
   } else {
@@ -14,5 +20,4 @@ int _ZN15InvisibleSecret16CleanupResourcesEv(char* c){
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9e8);
   }
   return 1;
-}
 }

--- a/src/_ZN15InvisibleSecret6RenderEv.cpp
+++ b/src/_ZN15InvisibleSecret6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15InvisibleSecret6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "InvisibleSecret.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 
@@ -18,7 +21,7 @@ struct Obj {
     virtual void m(int a);
 };
 
-extern "C" int _ZN15InvisibleSecret6RenderEv(char* c)
+int InvisibleSecret::Render()
 {
     if (data_0209b454 & 0x4000000) {
         void* a = 0;
@@ -27,19 +30,19 @@ extern "C" int _ZN15InvisibleSecret6RenderEv(char* c)
             if ((a = _ZN5Actor15FindWithActorIDEjPS_(id, a)) == 0)
                 break;
             if (*(int*)((char*)a + 0x43c) == 6 && *(u16*)((char*)a + 0x496) == 0x64) {
-                _ZN9ActorBase18MarkForDestructionEv(c);
+                _ZN9ActorBase18MarkForDestructionEv(((char*)this));
                 return 1;
             }
         }
     }
 
-    if (*(u16*)(c + 0x14c) != 0) {
-        u16* p = (u16*)(int)(((long long)(int)(c + 0x14c)) & 0xFFFFFFFFFFFFFFFFLL);
+    if (unk_14c != 0) {
+        u16* p = (u16*)(int)(((long long)(int)((char*)&unk_14c)));
         *p = *p - 1;
         return 1;
     }
 
-    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x124, c + 0xdc);
-    ((Obj*)(c + 0xd4))->m(0);
+    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x124, ((char*)this) + 0xdc);
+    ((Obj*)((char*)&mModel))->m(0);
     return 1;
 }

--- a/src/_ZN15InvisibleSecretD0Ev.c
+++ b/src/_ZN15InvisibleSecretD0Ev.c
@@ -1,12 +1,15 @@
+// @symbol _ZN15InvisibleSecretD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjNumber_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN15InvisibleSecretD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daObjNumber_c;
     _ZN15TextureSequenceD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15MaterialChangerC1Ev.c
+++ b/src/_ZN15MaterialChangerC1Ev.c
@@ -1,6 +1,10 @@
-extern void _ZN9AnimationC2Ev(void* self);
+// @symbol _ZN15MaterialChangerC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MaterialChanger.h"
 
-extern unsigned int _ZTV15MaterialChanger[];
 
 typedef struct {
     unsigned int* vtable;

--- a/src/_ZN15MaterialChangerD1Ev.c
+++ b/src/_ZN15MaterialChangerD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN15MaterialChangerD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MaterialChanger.h"
 /* _ZN15MaterialChangerD1Ev at 0x0201582c
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
  * Call target: 0x02015cb4
  */
 struct Obj { void *vtable; };
-extern void *vtbl_MaterialChanger[];
 extern void base_dtor_MaterialChanger(struct Obj *thiz); /* 0x02015cb4 */
 struct Obj *_ZN15MaterialChangerD1Ev(struct Obj *thiz)
 {

--- a/src/_ZN15RollingIronBall6RenderEv.cpp
+++ b/src/_ZN15RollingIronBall6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15RollingIronBall6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RollingIronBall.h"
 struct EmbeddedClass {
   virtual void method(void* a);
   virtual void dummy1();
@@ -8,11 +11,12 @@ struct EmbeddedClass {
   virtual void virtualMethod(char* a);
 };
 
-extern "C" int _ZN15RollingIronBall6RenderEv(char* c){
-  unsigned char b = *(unsigned char*)(c+0x3d0);
+int RollingIronBall::Render()
+{
+  unsigned char b = unk_3d0;
   if(b){
-    EmbeddedClass* e = (EmbeddedClass*)(c+0x2cc);
-    e->virtualMethod(c+0x3ac);
+    EmbeddedClass* e = (EmbeddedClass*)((char*)&mModel);
+    e->virtualMethod((char*)&unk_3ac);
   }
   return 1;
 }

--- a/src/_ZN15RollingIronBallD0Ev.c
+++ b/src/_ZN15RollingIronBallD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN15RollingIronBallD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daIbl_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN15RollingIronBallD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daIbl_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x374);
     _ZN11ShadowModelD1Ev((char *)t + 0x31c);
     _ZN5ModelD1Ev((char *)t + 0x2cc);

--- a/src/_ZN15RollingIronBallD1Ev.c
+++ b/src/_ZN15RollingIronBallD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN15RollingIronBallD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV15RollingIronBall */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN15RollingIronBallD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15RollingIronBall;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x374);
     _ZN11ShadowModelD1Ev((char *)t + 0x31c);
     _ZN5ModelD1Ev((char *)t + 0x2cc);

--- a/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
+++ b/src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN15RotatingFirebar16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingFirebar.h"
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
 void _ZN13SharedFilePtr7ReleaseEv(void* self);
 extern int data_ov064_0211adbc[];
-int _ZN15RotatingFirebar16CleanupResourcesEv(char* c) {
-  if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+}
+
+int RotatingFirebar::CleanupResources()
+{
+  if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
+    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[0]);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov064_0211adbc[1]);
   return 1;
-}
 }

--- a/src/_ZN15RotatingFirebar6RenderEv.cpp
+++ b/src/_ZN15RotatingFirebar6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN15RotatingFirebar6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingFirebar.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN15RotatingFirebar6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int RotatingFirebar::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN15RotatingFirebarD0Ev.c
+++ b/src/_ZN15RotatingFirebarD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN15RotatingFirebarD0Ev
+/* recovered: named members + shared header */
+#include "RotatingFirebar.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
@@ -7,13 +10,13 @@ extern int _ZTV15RotatingFirebar[];
 extern int _ZN19CylinderClsnWithPosD1Ev[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN15RotatingFirebarD0Ev(char *c) {
-    *(int**)(c) = _ZTV15RotatingFirebar;
-    func_0207328c(c+0x360, 8, 0x3c, _ZN19CylinderClsnWithPosD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN15RotatingFirebarD0Ev(struct RotatingFirebar *self) {
+    *(int**)(((char *)self)) = _ZTV15RotatingFirebar;
+    func_0207328c(((char *)self)+0x360, 8, 0x3c, _ZN19CylinderClsnWithPosD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN15RotatingFirebarD1Ev.c
+++ b/src/_ZN15RotatingFirebarD1Ev.c
@@ -1,17 +1,20 @@
+// @symbol _ZN15RotatingFirebarD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "RotatingFirebar.h"
 extern void func_0207328c(void *arr, int a, int b, void *fn);
-extern void _ZN18MovingMeshColliderD1Ev(void *c);
-extern void _ZN5ModelD1Ev(void *c);
-extern void _ZN5ActorD2Ev(void *c);
-extern int _ZTV15RotatingFirebar[];
 extern void _ZN19CylinderClsnWithPosD1Ev(void *c);
 extern int _ZTV17ExclamationSwitch[];
-int _ZN15RotatingFirebarD1Ev(char *c)
-{
-    *(int**)c = (int*)_ZTV15RotatingFirebar;
-    func_0207328c(c + 0x360, 8, 0x3c, (void*)_ZN19CylinderClsnWithPosD1Ev);
-    *(int**)c = (int*)_ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c + 0x124);
-    _ZN5ModelD1Ev(c + 0xd4);
-    _ZN5ActorD2Ev(c);
-    return (int)c;
+int _ZN15RotatingFirebarD1Ev(struct RotatingFirebar *self) {
+    *(int**)((char *)self) = (int*)_ZTV15RotatingFirebar;
+    func_0207328c(((char *)self) + 0x360, 8, 0x3c, (void*)_ZN19CylinderClsnWithPosD1Ev);
+    *(int**)((char *)self) = (int*)_ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    return (int)((char *)self);
 }

--- a/src/_ZN15TextureSequence17UpdateFileOffsetsER8BTP_File.cpp
+++ b/src/_ZN15TextureSequence17UpdateFileOffsetsER8BTP_File.cpp
@@ -1,29 +1,32 @@
 //cpp
-extern "C" void _ZN15TextureSequence17UpdateFileOffsetsER8BTP_File(char *c){
+// @symbol _ZN15TextureSequence17UpdateFileOffsetsER8BTP_File
+/* recovered: named members + shared header */
+#include "TextureSequence.h"
+extern "C" void _ZN15TextureSequence17UpdateFileOffsetsER8BTP_File(struct TextureSequence *self) {
   int i = 0;
-  if (*(int*)(c+4)) *(int*)(c+4) += (int)c;
-  char *p = *(char**)(c+4);
-  while (i < (int)*(unsigned short*)(c+2)){
-    if (*(int*)(p+4)) *(int*)(p+4) += (int)c;
+  if (self->unk_004) self->unk_004 += (int)((char *)self);
+  char *p = *(char**)((char *)&self->unk_004);
+  while (i < (int)self->unk_002){
+    if (*(int*)(p+4)) *(int*)(p+4) += (int)((char *)self);
     i++;
     p += 8;
   }
-  if (*(int*)(c+0xc)) *(int*)(c+0xc) += (int)c;
-  char *q = *(char**)(c+0xc);
+  if (self->unk_00c) self->unk_00c += (int)((char *)self);
+  char *q = *(char**)((char *)&self->unk_00c);
   int j = 0;
-  while (j < (int)*(unsigned short*)(c+8)){
-    if (*(int*)(q+4)) *(int*)(q+4) += (int)c;
+  while (j < (int)*(unsigned short*)((char *)&self->unk_008)){
+    if (*(int*)(q+4)) *(int*)(q+4) += (int)((char *)self);
     j++;
     q += 8;
   }
-  if (*(int*)(c+0x10)) *(int*)(c+0x10) += (int)c;
-  if (*(int*)(c+0x14)) *(int*)(c+0x14) += (int)c;
-  if (*(int*)(c+0x18)) *(int*)(c+0x18) += (int)c;
-  if (*(int*)(c+0x20)) *(int*)(c+0x20) += (int)c;
-  char *r = *(char**)(c+0x20);
+  if (self->unk_010) self->unk_010 += (int)((char *)self);
+  if (self->unk_014) self->unk_014 += (int)((char *)self);
+  if (self->unk_018) self->unk_018 += (int)((char *)self);
+  if (self->unk_020) self->unk_020 += (int)((char *)self);
+  char *r = *(char**)((char *)&self->unk_020);
   int k = 0;
-  while (k < (int)*(unsigned short*)(c+0x1c)){
-    if (*(int*)(r+4)) *(int*)(r+4) += (int)c;
+  while (k < (int)self->unk_01c){
+    if (*(int*)(r+4)) *(int*)(r+4) += (int)((char *)self);
     k++;
     r += 0xc;
   }

--- a/src/_ZN15TextureSequence8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN15TextureSequence8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,6 @@
+// @symbol _ZN15TextureSequence8LoadFileER13SharedFilePtr
+/* recovered: named members + shared header */
+#include "TextureSequence.h"
 /* TextureSequence::LoadFile (static) at 0x020178e4
  * Loads a SharedFilePtr; if first reference and file is non-null, calls TextureSequence::UpdateFileOffsets.
  * Returns the BTP_File pointer.

--- a/src/_ZN15TextureSequenceD1Ev.c
+++ b/src/_ZN15TextureSequenceD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN15TextureSequenceD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "TextureSequence.h"
 /* _ZN15TextureSequenceD1Ev at 0x02015a2c
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
  * Call target: 0x02015cb4
  */
 struct Obj { void *vtable; };
-extern void *vtbl_TextureSequence[];
 extern void base_dtor_TextureSequence(struct Obj *thiz); /* 0x02015cb4 */
 struct Obj *_ZN15TextureSequenceD1Ev(struct Obj *thiz)
 {

--- a/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN15TtcRotatingCube13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "TtcRotatingCube.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -33,13 +38,9 @@ extern "C" {
 }
 
 extern void *data_ov065_0211cfd0[];
-extern void *data_ov065_0211c0a8[];
-extern s16 data_ov065_0211cfa8[];
 extern void *data_ov065_0211cfd4[];
-extern void *data_ov065_0211cfd8[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern u8 data_0209f2c0;
-extern u8 data_ov065_0211cfa4[];
 extern s32 data_020a0e68[];
 
 struct RaycastGround {
@@ -48,9 +49,9 @@ struct RaycastGround {
     char pad2[0xc];
 };
 
-extern "C" int _ZN15TtcRotatingCube13InitResourcesEv(void *self)
+int TtcRotatingCube::InitResources()
 {
-    u8 *c = (u8 *)self;
+    u8 *c = (u8 *)((void *)this);
     u16 id = *(u16 *)(c + 0xc);
 
     if (id != 0x6c) {
@@ -76,8 +77,8 @@ extern "C" int _ZN15TtcRotatingCube13InitResourcesEv(void *self)
 
     *(s16 *)(c + 0x300 + 0x78) = data_ov065_0211cfa8[*(u8 *)(c + 0x377)];
 
-    func_ov065_0211990c(self);
-    func_ov065_021198a0(self);
+    func_ov065_0211990c(((void *)this));
+    func_ov065_021198a0(((void *)this));
 
     idx = *(u8 *)(c + 0x377);
     if (idx == 0) {

--- a/src/_ZN15TtcRotatingCube6RenderEv.cpp
+++ b/src/_ZN15TtcRotatingCube6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN15TtcRotatingCube6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TtcRotatingCube.h"
 struct Base {
     virtual void method0();
     virtual void method1();
@@ -7,16 +10,17 @@ struct Base {
     virtual void method4();
     virtual void method5(int x);
 };
-extern "C" int _ZN15TtcRotatingCube6RenderEv(char *c)
+
+int TtcRotatingCube::Render()
 {
     int flags;
     int b;
-    flags = *(int*)(c + 0xb0);
+    flags = unk_0b0;
     b = flags & 8;
     b = (b != 0);
     if (!b) {
-        ((Base*)(c + 0xd4))->method5(0);
-        ((Base*)(c + 0x320))->method5(0);
+        ((Base*)((char *)&mModel1))->method5(0);
+        ((Base*)((char *)&mModel2))->method5(0);
     }
     return 1;
 }

--- a/src/_ZN15TtcRotatingCubeD0Ev.c
+++ b/src/_ZN15TtcRotatingCubeD0Ev.c
@@ -1,17 +1,19 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15TtcRotatingCubeD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN15TtcRotatingCubeD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV20daObjCtRotateBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x380);
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingCubeD1Ev.c
+++ b/src/_ZN15TtcRotatingCubeD1Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15TtcRotatingCubeD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjCtRotateBlock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN15TtcRotatingCubeD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV20daObjCtRotateBlock_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x380);
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingGear6RenderEv.cpp
+++ b/src/_ZN15TtcRotatingGear6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN15TtcRotatingGear6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TtcRotatingGear.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN15TtcRotatingGear6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int TtcRotatingGear::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
@@ -1,86 +1,91 @@
 //cpp
+// @symbol _ZN15TtcRotatingGear8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "TtcRotatingGear.h"
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef signed short s16;
 typedef unsigned char u8;
 
-extern "C" {
-void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
-int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
-void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
-u16 DecIfAbove0_Short(void *p);
-void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *cc);
-int RandomIntInternal(int *seed);
+extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
+extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
+extern u16 DecIfAbove0_Short(void *p);
+extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *cc);
+extern int RandomIntInternal(int *seed);
 
 extern u8 data_0209f2c0;
 extern int data_0209e650;
 extern u8 data_ov065_0211c0d4[];
 extern u8 data_ov065_0211c0d0[];
-}
-
-class TtcRotatingGear {
-public:
-    int Behavior();
-};
 
 int TtcRotatingGear::Behavior()
 {
-    char *c = (char *)this;
-
     if (data_0209f2c0 == 3) {
-        *(s32 *)(c + 0x60) = *(s32 *)(c + 0x324) + 0x14a000;
-        _ZN8Platform21UpdateModelPosAndRotYEv(c);
-        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) != 0)
-            _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        mPosY = unk_324 + 0x14a000;
+        _ZN8Platform21UpdateModelPosAndRotYEv(((char *)this));
+        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char *)this), 0, 0) != 0)
+            _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
         goto ret1;
     }
 
-    if (DecIfAbove0_Short(c + 0x32c) == 0) {
+    if (DecIfAbove0_Short((char *)&unk_32c) == 0) {
+
         s32 lower, upper, y, in;
-        _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-        lower = *(s32 *)(c + 0x324);
-        y = *(s32 *)(c + 0x60);
+        _ZN5Actor9UpdatePosEP12CylinderClsn(((char *)this), 0);
+        lower = unk_324;
+        y = mPosY;
         upper = lower + 0x14a000;
         if (y < lower)
-            goto setzero;
+            goto Lzero;
         if (y <= upper) {
             in = 1;
-            goto check;
+            goto Lchk;
         }
-setzero:
+Lzero:
         in = 0;
-check:
+Lchk:
         if (in != 0)
             goto tail;
         {
             s32 v = lower;
             if (y >= lower) {
-                s32 v2 = upper;
+                s32 t = upper;
                 if (y <= upper)
-                    v2 = y;
-                v = v2;
+                    t = y;
+                v = t;
             }
-            *(s32 *)(c + 0x60) = v;
+            mPosY = v;
         }
+
         {
-            u8 *tog = (u8 *)(((int)c + 0x32e) & 0xFFFFFFFFFFFFFFFFLL);
-            *tog ^= 1;
-            *(u16 *)(c + 0x32c) = *(u16 *)(&data_ov065_0211c0d4[data_0209f2c0 * 16] + *(u8 *)(c + 0x32e) * 8);
-            *(s32 *)(c + 0xa8) = *(s32 *)(&data_ov065_0211c0d0[data_0209f2c0 * 16] + *(u8 *)(c + 0x32e) * 8);
-            if (data_0209f2c0 != 2)
-                goto tail;
+            u8 *tog = (u8 *)(((int)((char *)this) + 0x32e) & 0xFFFFFFFFFFFFFFFF);
+            u8 tv = *tog;
+            *tog = tv ^ 1;
             {
-                u32 r = (u32)RandomIntInternal(&data_0209e650);
-                *(u16 *)(c + 0x32c) = (u16)((r % 6) * 0x14 + 0xa);
+                u8 *tbl_t = data_ov065_0211c0d4;
+                u8 *tbl_s = data_ov065_0211c0d0;
+                int idx = data_0209f2c0;
+                u8 t = mMoveDir;
+                unk_32c = *(u16 *)(&tbl_t[idx * 16] + t * 8);
+                t = mMoveDir;
+                unk_0a8 = *(s32 *)(&tbl_s[idx * 16] + t * 8);
+                if (data_0209f2c0 != 2)
+                    goto tail;
+                {
+                    u32 r = (u32)RandomIntInternal(&data_0209e650);
+                    unk_32c = (u16)((r % 6) * 0x14 + 0xa);
+                }
             }
         }
+
     }
 
 tail:
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) != 0)
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char *)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char *)this), 0, 0) != 0)
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
 ret1:
     return 1;
 }

--- a/src/_ZN15TtcRotatingGearD0Ev.c
+++ b/src/_ZN15TtcRotatingGearD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15TtcRotatingGearD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha08_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN15TtcRotatingGearD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCtMecha08_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN15TtcRotatingGearD1Ev.c
+++ b/src/_ZN15TtcRotatingGearD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN15TtcRotatingGearD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha08_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN15TtcRotatingGearD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCtMecha08_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
+++ b/src/_ZN16BowserShockwaves13InitResourcesEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN16BowserShockwaves13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_MaterialChanger.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserShockwaves.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -8,50 +14,43 @@ extern void func_02016b24(void* thiz, int a);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* a, void* b);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
-extern void _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(void* a, void* b);
-extern void _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* a, void* b);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 
-extern int data_ov060_0211b208[];
-extern int data_ov060_0211b1f8[];
-extern int data_ov060_0211b200[];
-extern int func_021115e4[];
-extern int func_021115f4[];
+}
 
-int _ZN16BowserShockwaves13InitResourcesEv(char* c)
+int BowserShockwaves::InitResources()
 {
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211b208), 1, 0x13);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x174, (void*)data_ov060_0211b208[1], 1, 0x13);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211b208), 1, 0x13);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x174, (void*)data_ov060_0211b208[1], 1, 0x13);
 
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov060_0211b1f8);
     _ZN15TextureSequence8LoadFileER13SharedFilePtr(&data_ov060_0211b200);
 
-    func_02016b24(c + 0xd4, 0x4000);
-    func_02016b24(c + 0x174, 0x4000);
+    func_02016b24(((char*)this) + 0xd4, 0x4000);
+    func_02016b24(((char*)this) + 0x174, 0x4000);
 
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x174, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0xd4, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0x174, (void*)data_ov060_0211b1f8[1], 0x40000000, 0x1000, 0);
 
     _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov060_0211b208[1], (void*)data_ov060_0211b200[1]);
     _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov060_0211b208[1], (void*)data_ov060_0211b200[1]);
 
-    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x138, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
-    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x1d8, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this) + 0x138, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
+    _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this) + 0x1d8, (void*)data_ov060_0211b200[1], 0x40000000, 0x1000, 0);
 
     _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File((void*)data_ov060_0211b208[1], func_021115e4);
     _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File((void*)data_ov060_0211b208[1], func_021115e4);
 
-    _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(c + 0x14c, func_021115e4, 0x40000000, 0x1000, 0);
-    _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(c + 0x1ec, func_021115e4, 0x40000000, 0x1000, 0);
+    _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(((char*)this) + 0x14c, func_021115e4, 0x40000000, 0x1000, 0);
+    _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj(((char*)this) + 0x1ec, func_021115e4, 0x40000000, 0x1000, 0);
 
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File((void*)data_ov060_0211b208[1], func_021115f4);
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File((void*)data_ov060_0211b208[1], func_021115f4);
 
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x160, func_021115f4, 0x40000000, 0x1000, 0);
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x200, func_021115f4, 0x40000000, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char*)this) + 0x160, func_021115f4, 0x40000000, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char*)this) + 0x200, func_021115f4, 0x40000000, 0x1000, 0);
 
-    *(short*)(c + 0x214) = 0;
+    unk_214 = 0;
     return 1;
-}
 }

--- a/src/_ZN16BowserShockwaves8BehaviorEv.cpp
+++ b/src/_ZN16BowserShockwaves8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN16BowserShockwaves8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserShockwaves.h"
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern "C" int Vec3_HorzDist(const void* a, const void* b);
 extern "C" void _ZN6Player5ShockEj(void* p, unsigned int x);
@@ -6,20 +11,20 @@ extern "C" void _ZN9Animation7AdvanceEv(void* a);
 extern "C" void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern "C" int _ZN9Animation8FinishedEv(void* a);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* a);
-extern int data_ov060_0211ab20[];
 
-extern "C" int _ZN16BowserShockwaves8BehaviorEv(char* self){
+int BowserShockwaves::Behavior()
+{
   char* pl;
   unsigned int n;
   int d;
   int s;
   int m0, m1, m2, m3;
-  ((*(unsigned short *)(((int)self + 0x214) & 0xFFFFFFFFFFFFFFFF)))++;
-  pl = (char*)_ZN5Actor13ClosestPlayerEv(self);
-  n = *(unsigned short*)(self+0x200+0x14);
+  ((*(unsigned short *)(((int)((char*)this) + 0x214) & 0xFFFFFFFFFFFFFFFF)))++;
+  pl = (char*)_ZN5Actor13ClosestPlayerEv(((char*)this));
+  n = *(unsigned short*)(((char*)this)+0x200+0x14);
   s = n * 0x22;
   if(pl != 0 && n < 0x46 && *(unsigned char*)(pl+0x6de) == 0){
-    d = Vec3_HorzDist(self+0x5c, pl+0x5c);
+    d = Vec3_HorzDist(((char*)this)+0x5c, pl+0x5c);
     m0 = s*data_ov060_0211ab20[0];
     m1 = s*data_ov060_0211ab20[1];
     m2 = s*data_ov060_0211ab20[2];
@@ -28,18 +33,18 @@ extern "C" int _ZN16BowserShockwaves8BehaviorEv(char* self){
       _ZN6Player5ShockEj(pl, 1);
     }
   }
-  _ZN9Animation7AdvanceEv(self+0x138);
-  _ZN9Animation7AdvanceEv(self+0x1d8);
-  _ZN9Animation7AdvanceEv(self+0x14c);
-  _ZN9Animation7AdvanceEv(self+0x1ec);
-  _ZN9Animation7AdvanceEv(self+0x160);
-  _ZN9Animation7AdvanceEv(self+0x200);
-  _ZN9Animation7AdvanceEv(self+0x124);
-  _ZN9Animation7AdvanceEv(self+0x1c4);
-  Matrix4x3_FromTranslation(self+0xf0, *(int*)(self+0x5c)>>3, *(int*)(self+0x60)>>3, *(int*)(self+0x64)>>3);
-  Matrix4x3_FromTranslation(self+0x190, *(int*)(self+0x5c)>>3, *(int*)(self+0x60)>>3, *(int*)(self+0x64)>>3);
-  if(_ZN9Animation8FinishedEv(self+0x124)){
-    _ZN9ActorBase18MarkForDestructionEv(self);
+  _ZN9Animation7AdvanceEv((char*)&mTextureSequence1);
+  _ZN9Animation7AdvanceEv((char*)&mTextureSequence2);
+  _ZN9Animation7AdvanceEv((char*)&mMaterialChanger1);
+  _ZN9Animation7AdvanceEv((char*)&mMaterialChanger2);
+  _ZN9Animation7AdvanceEv((char*)&mTextureTransformer1);
+  _ZN9Animation7AdvanceEv((char*)&mTextureTransformer2);
+  _ZN9Animation7AdvanceEv((char*)&mAnimation1);
+  _ZN9Animation7AdvanceEv((char*)&mAnimation2);
+  Matrix4x3_FromTranslation(((char*)this)+0xf0, mPosX>>3, mPosY>>3, mPosZ>>3);
+  Matrix4x3_FromTranslation(((char*)this)+0x190, mPosX>>3, mPosY>>3, mPosZ>>3);
+  if(_ZN9Animation8FinishedEv((char*)&mAnimation1)){
+    _ZN9ActorBase18MarkForDestructionEv(((char*)this));
   }
   return 1;
 }

--- a/src/_ZN16BowserShockwavesD0Ev.c
+++ b/src/_ZN16BowserShockwavesD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
+// @symbol _ZN16BowserShockwavesD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daFRing_c */
 extern void _ZN15MaterialChangerD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN16BowserShockwavesD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daFRing_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x200);
     _ZN15MaterialChangerD1Ev((char *)t + 0x1ec);
     _ZN15TextureSequenceD1Ev((char *)t + 0x1d8);

--- a/src/_ZN16BowserShockwavesD1Ev.c
+++ b/src/_ZN16BowserShockwavesD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
+// @symbol _ZN16BowserShockwavesD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV16BowserShockwaves */
 extern void _ZN15MaterialChangerD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
 int *_ZN16BowserShockwavesD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16BowserShockwaves;
     _ZN18TextureTransformerD1Ev((char *)t + 0x200);
     _ZN15MaterialChangerD1Ev((char *)t + 0x1ec);
     _ZN15TextureSequenceD1Ev((char *)t + 0x1d8);

--- a/src/_ZN16FloatingFloorBfsD0Ev.c
+++ b/src/_ZN16FloatingFloorBfsD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN16FloatingFloorBfsD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN16FloatingFloorBfsD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjKm2_Gura_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN16FloatingFloorBfsD1Ev.c
+++ b/src/_ZN16FloatingFloorBfsD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN16FloatingFloorBfsD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjKm2_Gura_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN16FloatingFloorBfsD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjKm2_Gura_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp
@@ -1,25 +1,29 @@
 //cpp
+// @symbol _ZN16RotatingCogSmall16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingCogSmall.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern char data_ov035_02112c78[];
-extern char data_ov056_02112c68[];
 extern char data_ov035_02112c70[];
 extern char data_ov035_02112c60[];
-int _ZN16RotatingCogSmall16CleanupResourcesEv(char *t){
-  if(*(int*)(t+0x32c)==0){
-    if(_ZN16MeshColliderBase9IsEnabledEv(t+0x124))
-      _ZN16MeshColliderBase7DisableEv(t+0x124);
+}
+
+int RotatingCogSmall::CleanupResources()
+{
+  if(mRotationState==0){
+    if(_ZN16MeshColliderBase9IsEnabledEv((char *)&mMovingMeshCollider))
+      _ZN16MeshColliderBase7DisableEv((char *)&mMovingMeshCollider);
     _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c78);
     _ZN13SharedFilePtr7ReleaseEv(data_ov056_02112c68);
   } else {
-    int on = (*(unsigned short*)(t+0xc)==0x79);
+    int on = (unk_00c==0x79);
     if(on)
       _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c70);
     else
       _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112c60);
   }
   return 1;
-}
 }

--- a/src/_ZN16RotatingCogSmall6RenderEv.cpp
+++ b/src/_ZN16RotatingCogSmall6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN16RotatingCogSmall6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingCogSmall.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN16RotatingCogSmall6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int RotatingCogSmall::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN16RotatingCogSmall8BehaviorEv.cpp
+++ b/src/_ZN16RotatingCogSmall8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN16RotatingCogSmall8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingCogSmall.h"
 extern "C" {
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void*, int, int);
@@ -12,39 +15,39 @@ extern short data_ov035_02111ef0[];
 extern int data_0209e650[];
 }
 
-extern "C" int _ZN16RotatingCogSmall8BehaviorEv(char* c)
+int RotatingCogSmall::Behavior()
 {
     if (data_0209f2c0[0] == 3) {
-        _ZN8Platform21UpdateModelPosAndRotYEv(c);
-        if (*(int*)(c + 0x32c) == 0 && _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-            _ZN8Platform19UpdateClsnPosAndRotEv(c);
+        _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+        if (mRotationState == 0 && _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0))
+            _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
         return 1;
     }
 
-    if (_Z14ApproachLinearRsss((short*)(c + 0x8e), *(short*)(c + 0x322), 0xc8) != 0 &&
-        DecIfAbove0_Short((unsigned short*)(c + 0x31e)) == 0) {
-        short* p = (short*)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF);
-        *p = *p + *(short*)(c + 0x324);
+    if (_Z14ApproachLinearRsss((short*)((char*)&unk_08e), unk_322, 0xc8) != 0 &&
+        DecIfAbove0_Short((unsigned short*)((char*)&unk_31e)) == 0) {
+        short* p = (short*)(((int)((char*)this) + 0x322) & 0xFFFFFFFFFFFFFFFF);
+        *p = *p + unk_324;
         unsigned char k = data_0209f2c0[0];
-        *(short*)(c + 0x31e) = data_ov035_02111ef4[*(int*)(c + 0x32c)][k];
+        unk_31e = data_ov035_02111ef4[mRotationState][k];
         if (k == 2) {
             int rnd = RandomIntInternal(data_0209e650);
-            if (DecIfAbove0_Short((unsigned short*)(c + 0x320)) == 0) {
+            if (DecIfAbove0_Short((unsigned short*)((char*)&unk_320)) == 0) {
                 if ((unsigned int)rnd % 3 != 0) {
                     int r2 = (rnd & 3) * 0x3c;
-                    *(short*)(c + 0x324) = data_ov035_02111ef0[*(int*)(c + 0x32c)];
-                    *(short*)(c + 0x320) = r2 + 0x5a;
+                    unk_324 = data_ov035_02111ef0[mRotationState];
+                    unk_320 = r2 + 0x5a;
                 } else {
-                    *(short*)(c + 0x324) = -data_ov035_02111ef0[*(int*)(c + 0x32c)];
-                    *(short*)(c + 0x320) = ((unsigned int)rnd % 3 + 1) * 0x1e;
+                    unk_324 = -data_ov035_02111ef0[mRotationState];
+                    unk_320 = ((unsigned int)rnd % 3 + 1) * 0x1e;
                 }
             }
-            *(short*)(c + 0x31e) = (unsigned int)rnd % 3 * 0x14 + 0xa;
+            unk_31e = (unsigned int)rnd % 3 * 0x14 + 0xa;
         }
     }
 
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    if (*(int*)(c + 0x32c) == 0 && _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    if (mRotationState == 0 && _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0))
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     return 1;
 }

--- a/src/_ZN16RotatingCogSmallD0Ev.c
+++ b/src/_ZN16RotatingCogSmallD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN16RotatingCogSmallD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha10_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN16RotatingCogSmallD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCtMecha10_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN16RotatingCogSmallD1Ev.c
+++ b/src/_ZN16RotatingCogSmallD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN16RotatingCogSmallD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha10_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN16RotatingCogSmallD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjCtMecha10_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp
+++ b/src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN17BigMovingIceBlock13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "BigMovingIceBlock.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
@@ -11,17 +14,19 @@ extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 struct SFP { void* a; void* b; void* c; };
 extern struct SFP data_ov056_02113314;
-int _ZN17BigMovingIceBlock13InitResourcesEv(char* c){
-  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov056_02113314.a);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  void* f2 = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov056_02113314.b);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, f2, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov056_02113314.c);
-  func_020393d4((int*)(c+0x124), &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  _ZN7PathPtr6FromIDEj(c+0x320, *(int*)(c+8)&0xff);
-  *(int*)(c+0x32c) = 1;
-  *(int*)(c+0x98) = 0xa000;
-  return 1;
 }
+
+int BigMovingIceBlock::InitResources()
+{
+  void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov056_02113314.a);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, f, 1, -1);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  void* f2 = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov056_02113314.b);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, f2, ((char*)this)+0x2ec, 0x199, unk_08e, data_ov056_02113314.c);
+  func_020393d4((int*)((char*)&mMeshCollider), &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  _ZN7PathPtr6FromIDEj(((char*)this)+0x320, mParam&0xff);
+  mPathDir = 1;
+  mHorzSpeed = 0xa000;
+  return 1;
 }

--- a/src/_ZN17BigMovingIceBlock6RenderEv.cpp
+++ b/src/_ZN17BigMovingIceBlock6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN17BigMovingIceBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BigMovingIceBlock.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN17BigMovingIceBlock6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int BigMovingIceBlock::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN17BigMovingIceBlockD0Ev.c
+++ b/src/_ZN17BigMovingIceBlockD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17BigMovingIceBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN17BigMovingIceBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjEwmIceBlock_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17BigMovingIceBlockD1Ev.c
+++ b/src/_ZN17BigMovingIceBlockD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17BigMovingIceBlockD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjEwmIceBlock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN17BigMovingIceBlockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjEwmIceBlock_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp
@@ -1,31 +1,33 @@
 //cpp
+// @symbol _ZN17BowserPuzzlePiece13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserPuzzlePiece.h"
 typedef int Fix12i;
 struct SharedFilePtr;
 struct Actor;
 struct PMF;
 namespace Model { void LoadFile(SharedFilePtr& f); }
-extern "C" int SublevelToLevel(int i);
 extern "C" int IsStarCollected(int r0, int r1);
 struct MovingCylinderClsn { void Init(Actor* a, Fix12i b, int c, unsigned int d, unsigned int e); };
-extern "C" void func_ov064_0211982c(void *c, void *p);
 
 extern SharedFilePtr data_ov002_0210da10;
 extern SharedFilePtr data_ov002_0210d9a8;
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f220;
-extern int data_ov064_0211c934;
 
-extern "C" int _ZN17BowserPuzzlePiece13InitResourcesEv(char* c)
+int BowserPuzzlePiece::InitResources()
 {
     Model::LoadFile(data_ov002_0210da10);
     Model::LoadFile(data_ov002_0210d9a8);
-    *(int*)(c + 0x314) = (*(unsigned int*)(c + 8) >> 0xc) & 0xf;
-    *(int*)(c + 0x318) = *(unsigned int*)(c + 8) & 1;
-    if ((*(unsigned int*)(c + 8) & 0xf) > 1) *(int*)(c + 0x318) = 0;
+    unk_314 = (unk_008 >> 0xc) & 0xf;
+    unk_318 = unk_008 & 1;
+    if ((unk_008 & 0xf) > 1) unk_318 = 0;
     if (data_0209f2f8 == 8 && (data_0209f220 == 1 || IsStarCollected(SublevelToLevel(8), 1) == 0)) {
         return 0;
     }
-    ((MovingCylinderClsn*)(c + 0x110))->Init((Actor*)c, 0xc8000, 0x190000, 0x800004, 0);
-    func_ov064_0211982c(c, &data_ov064_0211c934);
+    ((MovingCylinderClsn*)((char*)&mMovingCylinderClsn))->Init((Actor*)((char*)this), 0xc8000, 0x190000, 0x800004, 0);
+    func_ov064_0211982c(((char*)this), &data_ov064_0211c934);
     return 1;
 }

--- a/src/_ZN17BowserPuzzlePiece8BehaviorEv.cpp
+++ b/src/_ZN17BowserPuzzlePiece8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN17BowserPuzzlePiece8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "BowserPuzzlePiece.h"
 extern "C" {
 unsigned short DecIfAbove0_Short(unsigned short* p);
 void func_ov064_0211987c(void* c);
@@ -10,14 +13,16 @@ struct C {
   char pad[0x300];
   Obj* obj;
 };
-extern "C" int _ZN17BowserPuzzlePiece8BehaviorEv(C* c){
-  DecIfAbove0_Short((unsigned short*)((char*)c+0x100));
-  if(c->obj->pmf){
-    (c->*(c->obj->pmf))();
+
+int BowserPuzzlePiece::Behavior()
+{
+  DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
+  if(((C*)this)->obj->pmf){
+    (((C*)this)->*(((C*)this)->obj->pmf))();
   }
-  *(short*)((char*)c+0x8c) = *(short*)((char*)c+0x92);
-  *(short*)((char*)c+0x8e) = *(short*)((char*)c+0x94);
-  *(short*)((char*)c+0x90) = *(short*)((char*)c+0x96);
-  func_ov064_0211987c(c);
+  *(short*)((char*)&unk_08c) = *(short*)((char*)&unk_092);
+  *(short*)((char*)&unk_08e) = *(short*)((char*)&unk_094);
+  *(short*)((char*)&unk_090) = *(short*)((char*)&unk_096);
+  func_ov064_0211987c(((C*)this));
   return 1;
 }

--- a/src/_ZN17BowserPuzzlePieceD0Ev.c
+++ b/src/_ZN17BowserPuzzlePieceD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN17BowserPuzzlePieceD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daWater_Hakidasi_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN17BowserPuzzlePieceD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daWater_Hakidasi_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN17BowserPuzzlePieceD1Ev.c
+++ b/src/_ZN17BowserPuzzlePieceD1Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN17BowserPuzzlePieceD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17BowserPuzzlePiece */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN17BowserPuzzlePieceD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17BowserPuzzlePiece;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp
+++ b/src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN17BowserSkyPlatform13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserSkyPlatform.h"
 
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
@@ -8,11 +12,9 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void *thiz, void *actor, const Vector3 &v, int radius, int height, unsigned a, unsigned b);
 extern short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
 extern int Vec3_HorzLen(const Vector3 *v);
-extern int AddSpikeBomb(void *p);
-extern void *data_ov060_0211b1c4;
 }
 
-extern "C" int _ZN17BowserSkyPlatform13InitResourcesEv(char *c)
+int BowserSkyPlatform::InitResources()
 {
     Vector3 v;
     Vector3 z;
@@ -21,34 +23,34 @@ extern "C" int _ZN17BowserSkyPlatform13InitResourcesEv(char *c)
     int t;
 
     file = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov060_0211b1c4);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, file, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, file, 1, -1);
     v.x = 0;
     v.y = -0x96000;
     v.z = 0;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-        c + 0x124, c, v, 0x96000, 0x12c000, 0x204004, 0);
-    *(int *)(c + 0x80) = 0x1000;
-    *(int *)(c + 0x84) = 0x1000;
-    *(int *)(c + 0x88) = 0x1000;
-    *(unsigned char *)(c + 0x1ae) = 0xff;
+        ((char *)this) + 0x124, ((char *)this), v, 0x96000, 0x12c000, 0x204004, 0);
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    unk_1ae = 0xff;
     z.x = 0;
     z.y = 0;
     z.z = 0;
-    Vec3_HorzAngle(&z, (const Vector3 *)(c + 0x5c));
-    p178 = (int *)(((long long)(int)(c + 0x178)) & 0xFFFFFFFFFFFFFFFFLL);
-    *(int *)(c + 0x184) = 0x2ee000;
-    t = *(int *)(c + 0x5c);
-    /* materialize r0 = c+0x5c between load and store */
+    Vec3_HorzAngle(&z, (const Vector3 *)((char *)&mPosX));
+    p178 = (int *)(((long long)(int)((char *)&unk_178)));
+    unk_184 = 0x2ee000;
+    t = mPosX;
+    /* materialize r0 = ((char *)this)+0x5c between load and store */
     {
-        Vector3 *pos = (Vector3 *)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        Vector3 *pos = (Vector3 *)(((long long)(int)((char *)&mPosX)));
         (void)pos;
     }
-    *(int *)(c + 0x174) = t;
-    *(int *)(c + 0x178) = *(int *)(c + 0x60);
-    *(int *)(c + 0x17c) = *(int *)(c + 0x64);
-    *p178 = *p178 + (*(int *)(c + 0x184) >> 3);
-    *(int *)(c + 0x180) = Vec3_HorzLen((const Vector3 *)(c + 0x5c));
-    *(int *)(c + 0x170) = 0;
-    *(int *)(c + 0x1a8) = AddSpikeBomb(c);
+    unk_174 = t;
+    unk_178 = mPosY;
+    unk_17c = mPosZ;
+    *p178 = *p178 + (unk_184 >> 3);
+    unk_180 = Vec3_HorzLen((const Vector3 *)((char *)&mPosX));
+    unk_170 = 0;
+    unk_1a8 = AddSpikeBomb(((char *)this));
     return 1;
 }

--- a/src/_ZN17BowserSkyPlatform6RenderEv.cpp
+++ b/src/_ZN17BowserSkyPlatform6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN17BowserSkyPlatform6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BowserSkyPlatform.h"
 struct Sub {
     virtual void v0();
     virtual void v1();
@@ -7,9 +10,11 @@ struct Sub {
     virtual void v4();
     virtual void m(int);
 };
-extern "C" int _ZN17BowserSkyPlatform6RenderEv(unsigned char* c) {
-    if (*(int*)(c + 0x170) != 0) return 1;
-    if (*(unsigned char*)(c + 0x1ae) < 8) return 1;
-    ((Sub*)(c + 0xd4))->m(0);
+
+int BowserSkyPlatform::Render()
+{
+    if (unk_170 != 0) return 1;
+    if (unk_1ae < 8) return 1;
+    ((Sub*)((unsigned char*)&mModel))->m(0);
     return 1;
 }

--- a/src/_ZN17BowserSkyPlatform8BehaviorEv.cpp
+++ b/src/_ZN17BowserSkyPlatform8BehaviorEv.cpp
@@ -1,28 +1,33 @@
 //cpp
+// @symbol _ZN17BowserSkyPlatform8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserSkyPlatform.h"
 extern "C" {
-extern void func_ov060_02118690(char* c);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* p, void* v);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
-extern int data_ov060_0211b1d8[];
 struct V3 { int x,y,z; };
-int _ZN17BowserSkyPlatform8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x170);
+}
+
+int BowserSkyPlatform::Behavior()
+{
+  int idx = unk_170;
   char* ent = (char*)&data_ov060_0211b1d8[idx*2];
   int adj = *(int*)(ent+4);
-  char* self = c + (adj>>1);
+  char* self = ((char*)this) + (adj>>1);
   void* fn;
   if(adj&1){ void* vt=*(void**)self; fn=*(void**)((char*)vt + *(int*)ent); }
   else fn=*(void**)ent;
   ((void(*)(char*))fn)(self);
-  func_ov060_02118690(c);
-  _ZN12CylinderClsn5ClearEv(c+0x124);
+  func_ov060_02118690(((char*)this));
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
   struct V3 v;
   v.x = 0;
   v.y = -0x96000;
   v.z = 0;
-  _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c+0x124, &v);
-  _ZN12CylinderClsn6UpdateEv(c+0x124);
+  _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this)+0x124, &v);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
   return 1;
-}
 }

--- a/src/_ZN17BowserSkyPlatformD0Ev.c
+++ b/src/_ZN17BowserSkyPlatformD0Ev.c
@@ -1,12 +1,15 @@
+// @symbol _ZN17BowserSkyPlatformD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daKirai_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN17BowserSkyPlatformD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daKirai_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
+++ b/src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN17MgBounceAndPounce14BeforeBehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MgBounceAndPounce.h"
 extern "C" {
-extern int func_ov004_020b0620(void*);
 extern unsigned int data_020a0db0;
 int _ZN8Particle10SysTracker6UpdateEv(void*);
-int _ZN17MgBounceAndPounce14BeforeBehaviorEv(void* c){
-  if(func_ov004_020b0620(c)==0) return 0;
-  if(data_020a0db0 & 1)
-    _ZN8Particle10SysTracker6UpdateEv((char*)c+0x47e4);
-  return 1;
 }
+
+int MgBounceAndPounce::BeforeBehavior()
+{
+  if(func_ov004_020b0620(((void*)this))==0) return 0;
+  if(data_020a0db0 & 1)
+    _ZN8Particle10SysTracker6UpdateEv((char*)&unk_47e4);
+  return 1;
 }

--- a/src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp
+++ b/src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN17MgBounceAndPounce18AfterInitResourcesEj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MgBounceAndPounce.h"
 extern "C" {
-extern int func_ov004_020b08f0(void*);
 int _ZN8Particle10SysTracker10InitialiseEv(void*);
-int _ZN17MgBounceAndPounce18AfterInitResourcesEj(void* c){
-  func_ov004_020b08f0(c);
-  return _ZN8Particle10SysTracker10InitialiseEv((char*)c+0x47e4);
+int _ZN17MgBounceAndPounce18AfterInitResourcesEj(struct MgBounceAndPounce *self) {
+  func_ov004_020b08f0(((void*)self));
+  return _ZN8Particle10SysTracker10InitialiseEv((char*)&self->unk_47e4);
 }
 }

--- a/src/_ZN17MgBounceAndPounceD0Ev.cpp
+++ b/src/_ZN17MgBounceAndPounceD0Ev.cpp
@@ -1,15 +1,18 @@
 //cpp
+// @symbol _ZN17MgBounceAndPounceD0Ev
+/* recovered: named members + shared header */
+#include "MgBounceAndPounce.h"
 extern "C" {
 extern int _ZN8Particle10SysTrackerD1Ev(void*);
 extern int func_ov004_020b29c0(void*);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
 extern int _ZTV17MgBounceAndPounce[];
 extern void* data_020a0eac[];
-int _ZN17MgBounceAndPounceD0Ev(char* c){
-  *(int*)c=(int)_ZTV17MgBounceAndPounce;
-  _ZN8Particle10SysTrackerD1Ev(c+0x47e4);
-  func_ov004_020b29c0(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c,data_020a0eac[0]);
-  return (int)c;
+int _ZN17MgBounceAndPounceD0Ev(struct MgBounceAndPounce *self) {
+  *(int*)((char*)self)=(int)_ZTV17MgBounceAndPounce;
+  _ZN8Particle10SysTrackerD1Ev((char*)&self->unk_47e4);
+  func_ov004_020b29c0(((char*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self),data_020a0eac[0]);
+  return (int)((char*)self);
 }
 }

--- a/src/_ZN17MgBounceAndPounceD1Ev.cpp
+++ b/src/_ZN17MgBounceAndPounceD1Ev.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol _ZN17MgBounceAndPounceD1Ev
+/* recovered: named members + shared header */
+#include "MgBounceAndPounce.h"
 extern "C" {
 extern int _ZN8Particle10SysTrackerD1Ev(void*);
 extern int func_ov004_020b29c0(void*);
 extern int _ZTV17MgBounceAndPounce[];
-int _ZN17MgBounceAndPounceD1Ev(char* c){
-  *(int*)c=(int)_ZTV17MgBounceAndPounce;
-  _ZN8Particle10SysTrackerD1Ev(c+0x47e4);
-  func_ov004_020b29c0(c);
-  return (int)c;
+int _ZN17MgBounceAndPounceD1Ev(struct MgBounceAndPounce *self) {
+  *(int*)((char*)self)=(int)_ZTV17MgBounceAndPounce;
+  _ZN8Particle10SysTrackerD1Ev((char*)&self->unk_47e4);
+  func_ov004_020b29c0(((char*)self));
+  return (int)((char*)self);
 }
 }

--- a/src/_ZN17RotatingClockHand13InitResourcesEv.cpp
+++ b/src/_ZN17RotatingClockHand13InitResourcesEv.cpp
@@ -1,17 +1,18 @@
 //cpp
+// @symbol _ZN17RotatingClockHand13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingClockHand.h"
 struct BMD_File; struct KCL_File; struct Actor; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
 struct ShadowModel { void InitCuboid(); };
-extern "C" void func_ov035_021118a8(char *t);
 struct Platform { void UpdateClsnPosAndRot(); };
-extern "C" void *MeshColliderLoadFile(void *fp);
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, int fix, short sh, CLPS_Block &b);
 };
 extern "C" void func_020393d4(void *p, void *v);
-extern "C" void func_020396c0(void *p, int v);
 struct RaycastGround {
     int pad[0x11];
     int result;       // offset 0x44
@@ -21,34 +22,31 @@ struct RaycastGround {
     int DetectClsn();
     ~RaycastGround();
 };
-extern "C" char data_ov035_02112cb0;
-extern "C" char data_ov035_02112cb8;
 extern "C" CLPS_Block data_ov035_02112238;
-extern "C" void UpdatePosWithTransformSym();
 
 struct V3 { int x, y, z; };
 
-extern "C" int _ZN17RotatingClockHand13InitResourcesEv(char *self)
+int RotatingClockHand::InitResources()
 {
     void *mf = ModelLoadFile(&data_ov035_02112cb0);
-    ((ModelBase*)(self + 0xd4))->SetFile((BMD_File*)mf, 1, -1);
-    ((ShadowModel*)(self + 0x328))->InitCuboid();
-    func_ov035_021118a8(self);
-    ((Platform*)self)->UpdateClsnPosAndRot();
+    ((ModelBase*)((char *)&mModel))->SetFile((BMD_File*)mf, 1, -1);
+    ((ShadowModel*)((char *)&mShadowModel))->InitCuboid();
+    func_ov035_021118a8(((char *)this));
+    ((Platform*)((char *)this))->UpdateClsnPosAndRot();
     void *kf = MeshColliderLoadFile(&data_ov035_02112cb8);
-    ((MovingMeshCollider*)(self + 0x124))->SetFile((KCL_File*)kf,
-        *(Matrix4x3*)(self + 0x2ec), 0x1000, *(short*)(self + 0x8e), data_ov035_02112238);
-    func_020393d4(self + 0x124, (void*)&UpdatePosWithTransformSym);
-    func_020396c0(self + 0x124, 0);
+    ((MovingMeshCollider*)((char *)&mMeshCollider))->SetFile((KCL_File*)kf,
+        *(Matrix4x3*)((char *)&unk_2ec), 0x1000, unk_08e, data_ov035_02112238);
+    func_020393d4(((char *)this) + 0x124, (void*)&UpdatePosWithTransformSym);
+    func_020396c0(((char *)this) + 0x124, 0);
     V3 v;
-    v.x = *(int*)(self + 0x5c);
-    v.y = *(int*)(self + 0x60);
-    v.z = *(int*)(self + 0x64);
+    v.x = mPosX;
+    v.y = mPosY;
+    v.z = mPosZ;
     v.y = v.y - 0xa000;
     RaycastGround rg;
     rg.SetObjAndPos(*(Vector3*)&v, (Actor*)0);
-    *(int*)(self + 0x324) = v.y;
+    unk_324 = v.y;
     if (rg.DetectClsn() != 0)
-        *(int*)(self + 0x324) = rg.result;
+        unk_324 = rg.result;
     return 1;
 }

--- a/src/_ZN17RotatingClockHand6RenderEv.cpp
+++ b/src/_ZN17RotatingClockHand6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN17RotatingClockHand6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingClockHand.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN17RotatingClockHand6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int RotatingClockHand::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN17RotatingClockHandD0Ev.c
+++ b/src/_ZN17RotatingClockHandD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17RotatingClockHandD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN17RotatingClockHandD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha11_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x328);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17RotatingClockHandD1Ev.c
+++ b/src/_ZN17RotatingClockHandD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17RotatingClockHandD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha11_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN17RotatingClockHandD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha11_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x328);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
+++ b/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN17SlidingPlatformWf13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlidingPlatformWf.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -23,9 +26,9 @@ extern u16 data_ov091_02134514[];
 extern u16 data_ov091_02134504[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int _ZN17SlidingPlatformWf13InitResourcesEv(void* self)
+int SlidingPlatformWf::InitResources()
 {
-    u8* c = (u8*)self;
+    u8* c = (u8*)((void*)this);
     u16 t = *(u16*)(c+0xc);
     switch (t) {
         case 0x37: *(u8*)(c+0x322) = 6; break;
@@ -51,8 +54,8 @@ extern "C" int _ZN17SlidingPlatformWf13InitResourcesEv(void* self)
     *(s32*)(c+0x324) = *(s32*)(c+0x5c);
     *(s32*)(c+0x328) = *(s32*)(c+0x60);
     *(s32*)(c+0x32c) = *(s32*)(c+0x64);
-    _ZN8Platform21UpdateModelPosAndRotYEv(self);
-    _ZN8Platform19UpdateClsnPosAndRotEv(self);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((void*)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((void*)this));
 
     if (*(u8*)(c+0x322) == 6) {
         int oi = *(u8*)(c+0x322) * 0xc;

--- a/src/_ZN17SlidingPlatformWf6RenderEv.cpp
+++ b/src/_ZN17SlidingPlatformWf6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN17SlidingPlatformWf6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlidingPlatformWf.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN17SlidingPlatformWf6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int SlidingPlatformWf::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN17SlidingPlatformWfD0Ev.c
+++ b/src/_ZN17SlidingPlatformWfD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17SlidingPlatformWfD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjSimpleLift_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN17SlidingPlatformWfD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjSimpleLift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN17SlidingPlatformWfD1Ev.c
+++ b/src/_ZN17SlidingPlatformWfD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN17SlidingPlatformWfD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjSimpleLift_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN17SlidingPlatformWfD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjSimpleLift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18BowserFireSeaArena6RenderEv.cpp
+++ b/src/_ZN18BowserFireSeaArena6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN18BowserFireSeaArena6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BowserFireSeaArena.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x324]; Base base; };
-extern "C" int _ZN18BowserFireSeaArena6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int BowserFireSeaArena::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN18BowserFireSeaArenaD0Ev.c
+++ b/src/_ZN18BowserFireSeaArenaD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN18BowserFireSeaArenaD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN18BowserFireSeaArenaD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daKpa2Bg_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x374);
     _ZN5ModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18BowserFireSeaArenaD1Ev.c
+++ b/src/_ZN18BowserFireSeaArenaD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN18BowserFireSeaArenaD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daKpa2Bg_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN18BowserFireSeaArenaD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daKpa2Bg_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x374);
     _ZN5ModelD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.cpp
+++ b/src/_ZN18MovingCylinderClsn10GetOwnerIDEv.cpp
@@ -1,6 +1,11 @@
 //cpp
-extern "C" int _ZN18MovingCylinderClsn10GetOwnerIDEv(char *p)
+// @symbol _ZN18MovingCylinderClsn10GetOwnerIDEv
+/* recovered: named members + shared header, real C++ method */
+#include "MovingCylinderClsn.h"
+
+
+int MovingCylinderClsn::GetOwnerID()
 {
-    char *q = *(char **)(p + 0x30);
+    char *q = *(char **)((char *)&unk_030);
     return *(int *)(q + 4);
 }

--- a/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
+++ b/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
@@ -1,18 +1,15 @@
+// @symbol _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_CylinderClsn.h"
+/* recovered: named members + shared header */
+#include "MovingCylinderClsn.h"
 typedef int Fix12i;
 typedef unsigned int u32;
 
 struct Actor { void* vtable; };
 
-extern void _ZN12CylinderClsn4InitE5Fix12IiES1_jj(void* self, Fix12i radius, Fix12i height, u32 flags, u32 vulnFlags);
 
-void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(
-    void* self,
-    struct Actor* actor,
-    Fix12i radius,
-    Fix12i height,
-    u32 flags,
-    u32 vulnFlags)
-{
-    *((struct Actor**)((char*)self + 0x30)) = actor;
-    _ZN12CylinderClsn4InitE5Fix12IiES1_jj(self, radius, height, flags, vulnFlags);
+void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(struct MovingCylinderClsn *self, struct Actor* actor, Fix12i radius, Fix12i height, u32 flags, u32 vulnFlags) {
+    *((struct Actor**)((char*)&self->unk_030)) = actor;
+    _ZN12CylinderClsn4InitE5Fix12IiES1_jj(((void*)self), radius, height, flags, vulnFlags);
 }

--- a/src/_ZN18MovingCylinderClsn6GetPosEv.cpp
+++ b/src/_ZN18MovingCylinderClsn6GetPosEv.cpp
@@ -1,6 +1,11 @@
 //cpp
-extern "C" void *_ZN18MovingCylinderClsn6GetPosEv(char *p)
+// @symbol _ZN18MovingCylinderClsn6GetPosEv
+/* recovered: named members + shared header, real C++ method */
+#include "MovingCylinderClsn.h"
+
+
+void * MovingCylinderClsn::GetPos()
 {
-    char *q = *(char **)(p + 0x30);
+    char *q = *(char **)((char *)&unk_030);
     return q + 0x5c;
 }

--- a/src/_ZN18MovingCylinderClsnD1Ev.c
+++ b/src/_ZN18MovingCylinderClsnD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN18MovingCylinderClsnD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MovingCylinderClsn.h"
 /* _ZN18MovingCylinderClsnD1Ev at 0x020149a4
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void *vtbl_MovingCylinderClsn[];
 extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD1Ev(struct Obj *thiz)
 {

--- a/src/_ZN18MovingCylinderClsnD2Ev.c
+++ b/src/_ZN18MovingCylinderClsnD2Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN18MovingCylinderClsnD2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MovingCylinderClsn.h"
 /* _ZN18MovingCylinderClsnD2Ev at 0x02014954
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void *vtbl_MovingCylinderClsn[];
 extern void base_dtor_MovingCylinderClsn(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN18MovingCylinderClsnD2Ev(struct Obj *thiz)
 {

--- a/src/_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c
+++ b/src/_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c
@@ -1,14 +1,13 @@
+// @symbol _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MovingMeshCollider.h"
 
 struct KCL_File;
 struct CLPS_Block;
-typedef struct 
-{
-  int m[12];
-} Matrix4x3;
 extern void _ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block(void *thiz, void *f, void *b);
-extern void func_02039624(char *o);
 extern void InvMat4x3(void *dst, void *src);
-extern int func_02053200(int x);
 extern void Matrix4x3_ApplyInPlaceToScale(void *m, int x, int y, int z);
 extern void func_02039e18(void *thiz, int *vec, void *p);
 extern Matrix4x3 data_020a0e68;

--- a/src/_ZN18MovingMeshColliderC1Ev.c
+++ b/src/_ZN18MovingMeshColliderC1Ev.c
@@ -1,9 +1,13 @@
+// @symbol _ZN18MovingMeshColliderC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MovingMeshCollider.h"
 /* _ZN18MovingMeshColliderC1Ev at 0x02014878
  * MovingMeshCollider C1 (complete object) constructor:
  *   call base CylinderClsn::CylinderClsn() (C2), then set own vtable.
  */
 struct Obj { void *vtable; };
-extern void *_ZTV18MovingMeshCollider[];
 extern void func_020398c8(struct Obj *thiz); /* 0x020150cc */
 
 struct Obj *_ZN18MovingMeshColliderC1Ev(struct Obj *thiz)

--- a/src/_ZN18MovingMeshColliderD1Ev.c
+++ b/src/_ZN18MovingMeshColliderD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18MovingMeshColliderD1Ev
+/* recovered: named members + shared header */
+#include "MovingMeshCollider.h"
 /* MovingMeshCollider::~MovingMeshCollider() at 0x0203a470
  * Complete-object destructor. Installs the MovingMeshCollider vtable, then runs
  * the base subobject destructor (func_020397fc). Returns this.

--- a/src/_ZN18NestedHeapIterator4NextEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator4NextEP13HeapAllocator.cpp
@@ -1,8 +1,15 @@
 //cpp
-extern "C" {
-int _ZN18NestedHeapIterator4NextEP13HeapAllocator(char* c, char* h) {
-  if (h == 0) return *(int*)c;
-  unsigned short off = *(unsigned short*)(c+0xa);
+// @symbol _ZN18NestedHeapIterator4NextEP13HeapAllocator
+/* recovered: named members + shared header, real C++ method */
+#include "NestedHeapIterator.h"
+struct HeapAllocator;
+
+
+int NestedHeapIterator::Next(HeapAllocator * h_)
+{
+    char* h = (char*)h_;
+
+  if (h == 0) return *(int*)((char*)this);
+  unsigned short off = mLinkOffset;
   return *(int*)(h+off+4);
-}
 }

--- a/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
+++ b/src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c
@@ -1,25 +1,28 @@
+// @symbol _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_NestedHeapIterator.h"
+/* recovered: named members + shared header */
+#include "NestedHeapIterator.h"
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(char *it, char *a);
-extern void _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(char *it, char *a);
 
-void _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(char *it, char *at, char *node)
-{
+void _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(struct NestedHeapIterator *self, char *at, char *node) {
     if (at == 0) {
-        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(it, node);
+        _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(((char *)self), node);
         return;
     }
-    if (at == *(char**)it) {
-        _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(it, node);
+    if (at == *(char**)((char *)self)) {
+        _ZN18NestedHeapIterator8AddFirstEP13HeapAllocator(((char *)self), node);
         return;
     }
     {
-        unsigned short off = *(unsigned short *)(it + 0xa);
+        unsigned short off = self->mLinkOffset;
         /* demand node+off first then prev? */
         char *nlink = node + off;
         char *prev = *(char **)(at + off);
         *(char **)nlink = prev;
         *(char **)(nlink + 4) = at;
         *(char **)(prev + off + 4) = node;
-        *(char **)(at + *(unsigned short *)(it + 0xa)) = node;
-        *(unsigned short *)(int)(((long long)(int)(it + 8)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(char **)(at + self->mLinkOffset) = node;
+        *(unsigned short *)(int)(((long long)(int)((char *)&self->unk_008))) += 1;
     }
 }

--- a/src/_ZN18NestedHeapIterator8PreviousEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator8PreviousEP13HeapAllocator.cpp
@@ -1,8 +1,15 @@
 //cpp
-extern "C" {
-int _ZN18NestedHeapIterator8PreviousEP13HeapAllocator(char* c, char* h) {
-  if (h == 0) return *(int*)(c+4);
-  unsigned short off = *(unsigned short*)(c+0xa);
+// @symbol _ZN18NestedHeapIterator8PreviousEP13HeapAllocator
+/* recovered: named members + shared header, real C++ method */
+#include "NestedHeapIterator.h"
+struct HeapAllocator;
+
+
+int NestedHeapIterator::Previous(HeapAllocator * h_)
+{
+    char* h = (char*)h_;
+
+  if (h == 0) return mLast;
+  unsigned short off = mLinkOffset;
   return *(int*)(h+off);
-}
 }

--- a/src/_ZN18NestedHeapIteratorC1Ej.c
+++ b/src/_ZN18NestedHeapIteratorC1Ej.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18NestedHeapIteratorC1Ej
+/* recovered: named members + shared header */
+#include "NestedHeapIterator.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 

--- a/src/_ZN18PoppingLavaBubblesD0Ev.c
+++ b/src/_ZN18PoppingLavaBubblesD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN18PoppingLavaBubblesD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "PoppingLavaBubbles.h"
 int *_ZN18PoppingLavaBubblesD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN18RickshawPlatformBsD0Ev.c
+++ b/src/_ZN18RickshawPlatformBsD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18RickshawPlatformBsD0Ev
+/* recovered: named members + shared header */
+#include "RickshawPlatformBs.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ModelD1Ev(void *p);
@@ -7,15 +10,15 @@ extern int _ZTV18RickshawPlatformBs[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN18RickshawPlatformBsD0Ev(char *c){
-    *(int**)(c) = _ZTV18RickshawPlatformBs;
-    *(int**)(c) = data_ov002_02108d94;
-    func_0207328c(c+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
-    func_0207328c(c+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN18RickshawPlatformBsD0Ev(struct RickshawPlatformBs *self) {
+    *(int**)(((char *)self)) = _ZTV18RickshawPlatformBs;
+    *(int**)(((char *)self)) = data_ov002_02108d94;
+    func_0207328c(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN18RickshawPlatformBsD1Ev.c
+++ b/src/_ZN18RickshawPlatformBsD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18RickshawPlatformBsD1Ev
+/* recovered: named members + shared header */
+#include "RickshawPlatformBs.h"
 extern int _ZTV18RickshawPlatformBs[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
@@ -5,14 +8,14 @@ extern int func_0207328c(void*,int,int,void*);
 extern int _ZN18MovingMeshColliderD1Ev(void*);
 extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
-int _ZN18RickshawPlatformBsD1Ev(char* c){
-  *(int*)c=(int)_ZTV18RickshawPlatformBs;
-  *(int*)c=(int)data_ov002_02108d94;
-  func_0207328c(c+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
-  func_0207328c(c+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int*)c=(int)_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return (int)c;
+int _ZN18RickshawPlatformBsD1Ev(struct RickshawPlatformBs *self) {
+  *(int*)((char*)self)=(int)_ZTV18RickshawPlatformBs;
+  *(int*)((char*)self)=(int)data_ov002_02108d94;
+  func_0207328c(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
+  func_0207328c(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
+  *(int*)((char*)self)=(int)_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  return (int)((char*)self);
 }

--- a/src/_ZN18RotatingPlatformRrD0Ev.c
+++ b/src/_ZN18RotatingPlatformRrD0Ev.c
@@ -1,11 +1,13 @@
-extern void _ZN11CommonModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN18RotatingPlatformRrD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjRc_Hane_c */
 extern void *G0;
 int *_ZN18RotatingPlatformRrD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjRc_Hane_c;
     _ZN11CommonModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN18SolidHeapAllocator16AllocateForwardsEPvjj.c
+++ b/src/_ZN18SolidHeapAllocator16AllocateForwardsEPvjj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18SolidHeapAllocator16AllocateForwardsEPvjj
+/* recovered: named members + shared header */
+#include "SolidHeapAllocator.h"
 typedef unsigned int u32;
 typedef signed int s32;
 typedef unsigned short u16;

--- a/src/_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj.c
+++ b/src/_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN18SolidHeapAllocator17AllocateBackwardsEPvjj
+/* recovered: named members + shared header */
+#include "SolidHeapAllocator.h"
 typedef unsigned int u32;
 typedef signed int s32;
 typedef unsigned short u16;

--- a/src/_ZN18SolidHeapAllocatorC1EPvj.c
+++ b/src/_ZN18SolidHeapAllocatorC1EPvj.c
@@ -1,18 +1,21 @@
+// @symbol _ZN18SolidHeapAllocatorC1EPvj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_HeapAllocator.h"
+/* recovered: named members + shared header */
+#include "SolidHeapAllocator.h"
 typedef unsigned int u32;
 
 struct FreeList { void* begin; void* end; int flags; };
 
-extern void _ZN13HeapAllocatorC1EjPvPvj(void* self, u32 magic, void* a, void* b, u32 size);
 
-void* _ZN18SolidHeapAllocatorC1EPvj(void* c, void* ptr, u32 size)
-{
+void* _ZN18SolidHeapAllocatorC1EPvj(struct SolidHeapAllocator *self, void* ptr, u32 size) {
     struct FreeList *fl;
 
-    fl = (struct FreeList *)((char *)c + 0x24);
-    _ZN13HeapAllocatorC1EjPvPvj(c, 0x46524d48, (char *)fl + 0xc, ptr, size);
-    *(void **)(((long long)(int)fl) & 0xFFFFFFFFFFFFFFFFLL) =
-        *(void **)((char *)c + 0x18);
-    fl->end = *(void **)((char *)c + 0x1c);
+    fl = (struct FreeList *)((char *)&self->mFreeRegion);
+    _ZN13HeapAllocatorC1EjPvPvj(((void*)self), 0x46524d48, (char *)fl + 0xc, ptr, size);
+    *(void **)(((long long)(int)fl)) =
+        *(void **)((char *)&self->unk_018);
+    fl->end = *(void **)((char *)&self->mEnd);
     fl->flags = 0;
-    return c;
+    return ((void*)self);
 }

--- a/src/_ZN18TextureTransformerC1Ev.c
+++ b/src/_ZN18TextureTransformerC1Ev.c
@@ -1,6 +1,10 @@
-extern void _ZN9AnimationC2Ev(void* self);
+// @symbol _ZN18TextureTransformerC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "TextureTransformer.h"
 
-extern unsigned int _ZTV18TextureTransformer[];
 
 typedef struct {
     unsigned int* vtable;

--- a/src/_ZN18TextureTransformerD1Ev.c
+++ b/src/_ZN18TextureTransformerD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN18TextureTransformerD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "TextureTransformer.h"
 /* _ZN18TextureTransformerD1Ev at 0x0201592c
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
  * Call target: 0x02015cb4
  */
 struct Obj { void *vtable; };
-extern void *vtbl_TextureTransformer[];
 extern void base_dtor_TextureTransformer(struct Obj *thiz); /* 0x02015cb4 */
 struct Obj *_ZN18TextureTransformerD1Ev(struct Obj *thiz)
 {

--- a/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
+++ b/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN19AmbientSoundEffects8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "AmbientSoundEffects.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -18,12 +23,10 @@ int _ZN5Sound7PlaySubEjjj5Fix12IiEb(u32 a, u32 b, u32 c, int d, int e);
 extern u8 data_0209f250;
 extern char* data_0209f394[];
 extern int data_020a0ebc[];
-extern int data_0208e434;
 extern u8 data_0209caa0[];
 extern char* data_0209f318;
-extern void* data_ov002_02110af8;
 
-extern "C" int _ZN19AmbientSoundEffects8BehaviorEv(char* self)
+int AmbientSoundEffects::Behavior()
 {
     int vol;
     int flag;
@@ -32,10 +35,10 @@ extern "C" int _ZN19AmbientSoundEffects8BehaviorEv(char* self)
     int diff[3];
     int rotated[3];
 
-    Vec3_Sub(diff, (int*)(data_0209f394[data_0209f250] + 0x5c), (int*)(self + 0x5c));
-    Vec3_RotateYAndTranslate(rotated, data_020a0ebc, *(s16*)(self + 0x8e), diff);
+    Vec3_Sub(diff, (int*)(data_0209f394[data_0209f250] + 0x5c), (int*)((char*)&unk_05c));
+    Vec3_RotateYAndTranslate(rotated, data_020a0ebc, mAngleY, diff);
 
-    if (*(int*)(self + 8) == 1) {
+    if (mParam == 1) {
         int z = rotated[2];
         int x = rotated[0];
         int az = (z < 0) ? -z : z;
@@ -63,7 +66,7 @@ extern "C" int _ZN19AmbientSoundEffects8BehaviorEv(char* self)
                 int d;
                 vol = 0;
                 flag = 0x7f;
-                d = AngleDiff(*(s16*)(self + 0x8e), *(s16*)(data_0209f318 + 0x17c)) - 0x2000;
+                d = AngleDiff(mAngleY, *(s16*)(data_0209f318 + 0x17c)) - 0x2000;
                 if (d < 0)
                     d = 0;
                 else if (d > 0x4000)
@@ -81,15 +84,15 @@ extern "C" int _ZN19AmbientSoundEffects8BehaviorEv(char* self)
             _ZN3Fog4InitEt5Fix12IiES1_(fog, 0, (u16)depth, color);
     }
 
-    if (*(int*)(self + 0x98) == 0) {
+    if (unk_098 == 0) {
         if (func_ov100_02144f84() == 0)
             return 1;
-        *(int*)(self + 0x98) = 1;
+        unk_098 = 1;
     }
 
     if (_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x2e, vol, flag, 0x1451, 0) != 0) {
         if (flag == 0)
-            *(int*)(self + 0x98) = 0;
+            unk_098 = 0;
     }
     return 1;
 }

--- a/src/_ZN19AmbientSoundEffectsD0Ev.c
+++ b/src/_ZN19AmbientSoundEffectsD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN19AmbientSoundEffectsD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "AmbientSoundEffects.h"
 int *_ZN19AmbientSoundEffectsD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN19BowserPuzzleManager13InitResourcesEv.cpp
+++ b/src/_ZN19BowserPuzzleManager13InitResourcesEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN19BowserPuzzleManager13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BowserPuzzleManager.h"
 struct SharedFilePtr { int x; };
 struct BMD_File;
 struct KCL_File;
-struct Matrix4x3 { int m[12]; };
 struct CLPS_Block { int x; };
 extern "C" {
 BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
@@ -16,26 +20,25 @@ void func_020393c4(int* p, int v);
 extern SharedFilePtr* data_ov064_0211adc8[];
 extern SharedFilePtr data_ov064_0211c800;
 extern CLPS_Block data_ov064_0211baac;
-extern void func_ov064_021192bc();
-extern int data_ov064_0211c198[];
 
-extern "C" void _ZN19BowserPuzzleManager13InitResourcesEv(char* c) {
-    *(unsigned char*)(c + 0x337) = *(int*)(c + 8) & 0xf;
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4,
-        _ZN5Model8LoadFileER13SharedFilePtr(*data_ov064_0211adc8[*(unsigned char*)(c + 0x337)]), 1, -1);
-    func_ov064_02119010(c);
-    func_ov064_02118fa4(c);
+void BowserPuzzleManager::InitResources()
+{
+    unk_337 = unk_008 & 0xf;
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4,
+        _ZN5Model8LoadFileER13SharedFilePtr(*data_ov064_0211adc8[unk_337]), 1, -1);
+    func_ov064_02119010(((char*)this));
+    func_ov064_02118fa4(((char*)this));
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124,
+        ((char*)this) + 0x124,
         _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov064_0211c800),
-        *(const Matrix4x3*)(c + 0x2ec), 0x1000, *(short*)(c + 0x8e), data_ov064_0211baac);
-    func_020393c4((int*)(c + 0x124), (int)&func_ov064_021192bc);
-    *(int*)(c + 0x324) = data_ov064_0211c198[*(unsigned char*)(c + 0x337)];
-    *(unsigned char*)(c + 0x328) = 0;
-    *(int*)(c + 0x32c) = 0;
-    *(short*)(c + 0x334) = 0;
-    *(unsigned char*)(c + 0x338) = 0;
-    *(unsigned char*)(c + 0x339) = 1;
-    *(unsigned char*)(c + 0x336) = 0;
-    *(unsigned char*)(c + 0x33a) = 1;
+        *(const Matrix4x3*)((char*)&unk_2ec), 0x1000, unk_08e, data_ov064_0211baac);
+    func_020393c4((int*)((char*)&mMovingMeshCollider), (int)&func_ov064_021192bc);
+    unk_324 = data_ov064_0211c198[unk_337];
+    unk_328 = 0;
+    unk_32c = 0;
+    unk_334 = 0;
+    unk_338 = 0;
+    unk_339 = 1;
+    unk_336 = 0;
+    unk_33a = 1;
 }

--- a/src/_ZN19BowserPuzzleManager6RenderEv.cpp
+++ b/src/_ZN19BowserPuzzleManager6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN19BowserPuzzleManager6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BowserPuzzleManager.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN19BowserPuzzleManager6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int BowserPuzzleManager::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN19BowserPuzzleManagerD0Ev.c
+++ b/src/_ZN19BowserPuzzleManagerD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19BowserPuzzleManagerD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_Puzzle_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN19BowserPuzzleManagerD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjFl_Puzzle_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19BowserPuzzleManagerD1Ev.c
+++ b/src/_ZN19BowserPuzzleManagerD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19BowserPuzzleManagerD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_Puzzle_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN19BowserPuzzleManagerD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjFl_Puzzle_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19CylinderClsnWithPosC1Ev.c
+++ b/src/_ZN19CylinderClsnWithPosC1Ev.c
@@ -1,9 +1,13 @@
+// @symbol _ZN19CylinderClsnWithPosC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "CylinderClsnWithPos.h"
 /* _ZN19CylinderClsnWithPosC1Ev at 0x02014878
  * CylinderClsnWithPos C1 (complete object) constructor:
  *   call base CylinderClsn::CylinderClsn() (C2), then set own vtable.
  */
 struct Obj { void *vtable; };
-extern void *_ZTV19CylinderClsnWithPos[];
 extern void _ZN12CylinderClsnC2Ev(struct Obj *thiz); /* 0x020150cc */
 
 struct Obj *_ZN19CylinderClsnWithPosC1Ev(struct Obj *thiz)

--- a/src/_ZN19CylinderClsnWithPosD1Ev.c
+++ b/src/_ZN19CylinderClsnWithPosD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN19CylinderClsnWithPosD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "CylinderClsnWithPos.h"
 /* _ZN19CylinderClsnWithPosD1Ev at 0x02014854
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void *vtbl_CylinderClsnWithPos[];
 extern void base_dtor_CylinderClsnWithPos(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN19CylinderClsnWithPosD1Ev(struct Obj *thiz)
 {

--- a/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp
@@ -1,17 +1,23 @@
 //cpp
+// @symbol _ZN19FirePiranhaPlantBig16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FirePiranhaPlantBig.h"
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void*);
 void UnloadBlueCoinModel(void*);
 extern int data_ov084_02130dfc;
-extern void *data_ov085_021302f4[];
 extern int data_ov002_0210da38;
-int _ZN19FirePiranhaPlantBig16CleanupResourcesEv(void *c) {
+}
+
+int FirePiranhaPlantBig::CleanupResources()
+{
   _ZN13SharedFilePtr7ReleaseEv(&data_ov084_02130dfc);
   for (int i = 0; i < 6; i++) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov085_021302f4[i]);
   }
   _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
-  UnloadBlueCoinModel(c);
+  UnloadBlueCoinModel(((void *)this));
   return 1;
-}
 }

--- a/src/_ZN19FirePiranhaPlantBig6RenderEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN19FirePiranhaPlantBig6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FirePiranhaPlantBig.h"
 struct V3 { int x, y, z; };
 struct Obj {
     virtual void v0();
@@ -9,18 +12,18 @@ struct Obj {
     virtual void m5(V3* p);
 };
 
-extern "C" int _ZN19FirePiranhaPlantBig6RenderEv(char* c)
+int FirePiranhaPlantBig::Render()
 {
-    int v = *(int*)(c + 0x204);
+    int v = mScale;
     int b;
-    if (v == 0 || (b = (*(int*)(c + 0xb0) & 0x40000) != 0, b != 0)) {
+    if (v == 0 || (b = (unk_0b0 & 0x40000) != 0, b != 0)) {
         return 1;
     }
     V3 s;
     s.x = v;
     s.y = v;
     s.z = v;
-    Obj* o = (Obj*)(c + 0x110);
+    Obj* o = (Obj*)((char*)&mModelAnim);
     o->m5(&s);
     return 1;
 }

--- a/src/_ZN19FirePiranhaPlantBig8BehaviorEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig8BehaviorEv.cpp
@@ -1,63 +1,62 @@
 //cpp
+// @symbol _ZN19FirePiranhaPlantBig8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FirePiranhaPlantBig.h"
 extern "C" {
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(char *thiz, char *clsn);
-extern int func_ov084_0212d564(char *);
 extern void _ZN9Animation7AdvanceEv(char *thiz);
-extern int func_ov084_0212e4e0(char *);
-extern int func_ov084_0212e010(char *);
-extern int func_ov084_0212ddbc(char *);
-extern int func_ov084_0212dc30(char *);
-extern int func_ov084_0212d86c(char *);
 extern void _ZN12CylinderClsn5ClearEv(char *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(char *thiz);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char *thiz, char *v);
 }
 
-extern "C" int _ZN19FirePiranhaPlantBig8BehaviorEv(char *c)
+int FirePiranhaPlantBig::Behavior()
 {
-    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x174);
-    int b = (*(int *)(c + 0xb0) & 0x60000) != 0;
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char *)this), ((char *)this) + 0x174);
+    int b = (unk_0b0 & 0x60000) != 0;
     if (b != 0) {
-        func_ov084_0212d564(c);
+        func_ov084_0212d564(((char *)this));
         return 1;
     }
-    _ZN9Animation7AdvanceEv(c + 0x160);
-    int s = *(int *)(c + 0x1ec);
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    int s = mState;
     switch (s) {
     case 0:
-        func_ov084_0212e4e0(c);
+        func_ov084_0212e4e0(((char *)this));
         break;
     case 1:
-        func_ov084_0212e010(c);
+        func_ov084_0212e010(((char *)this));
         break;
     case 2:
-        func_ov084_0212ddbc(c);
+        func_ov084_0212ddbc(((char *)this));
         break;
     case 3:
-        func_ov084_0212dc30(c);
+        func_ov084_0212dc30(((char *)this));
         break;
     case 4:
         break;
     }
     {
-        char * p = c + 0x100;
+        char * p = ((char *)this) + 0x100;
         *(unsigned short *)p = *(unsigned short *)p + 1;
-        if (s != *(int *)(c + 0x1ec))
+        if (s != mState)
             *(unsigned short *)p = 0;
     }
-    func_ov084_0212d86c(c);
-    func_ov084_0212d564(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x174);
-    *(int *)(c + 0x178) = *(int *)(c + 0x204) * *(int *)(c + 0x208);
-    *(int *)(c + 0x17c) = *(int *)(c + 0x204) * *(int *)(c + 0x20c);
-    _ZN12CylinderClsn6UpdateEv(c + 0x174);
-    _ZN12CylinderClsn5ClearEv(c + 0x1a8);
-    int b2 = *(unsigned short *)(c + 0xc) == 0xfc;
+    func_ov084_0212d86c(((char *)this));
+    func_ov084_0212d564(((char *)this));
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
+    unk_178 = mScale * unk_208;
+    unk_17c = mScale * unk_20c;
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
+    int b2 = unk_00c == 0xfc;
     if (b2 == 0
-        && (unsigned int)(*(int *)(c + 0x1ec) - 2) <= 1
-        && *(int *)(c + 0x204) == *(int *)(c + 0x210)) {
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1a8, c + 0x1f8);
-        _ZN12CylinderClsn6UpdateEv(c + 0x1a8);
+        && (unsigned int)(mState - 2) <= 1
+        && mScale == unk_210) {
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char *)this) + 0x1a8, ((char *)this) + 0x1f8);
+        _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);
     }
     return 1;
 }

--- a/src/_ZN19FirePiranhaPlantBigD0Ev.c
+++ b/src/_ZN19FirePiranhaPlantBigD0Ev.c
@@ -1,13 +1,16 @@
+// @symbol _ZN19FirePiranhaPlantBigD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daFPkn_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN19FirePiranhaPlantBigD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daFPkn_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1a8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x174);
     _ZN9ModelAnimD1Ev((char *)t + 0x110);

--- a/src/_ZN19FirePiranhaPlantBigD1Ev.c
+++ b/src/_ZN19FirePiranhaPlantBigD1Ev.c
@@ -1,11 +1,15 @@
+// @symbol _ZN19FirePiranhaPlantBigD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV19FirePiranhaPlantBig */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN19FirePiranhaPlantBigD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV19FirePiranhaPlantBig;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1a8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x174);
     _ZN9ModelAnimD1Ev((char *)t + 0x110);

--- a/src/_ZN19FloatingFloorLllBig6RenderEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN19FloatingFloorLllBig6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FloatingFloorLllBig.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN19FloatingFloorLllBig6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int FloatingFloorLllBig::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN19FloatingFloorLllBigD0Ev.c
+++ b/src/_ZN19FloatingFloorLllBigD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19FloatingFloorLllBigD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFl_UkiKi_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN19FloatingFloorLllBigD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFl_UkiKi_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19FloatingFloorLllBigD1Ev.c
+++ b/src/_ZN19FloatingFloorLllBigD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19FloatingFloorLllBigD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFl_UkiKi_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN19FloatingFloorLllBigD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFl_UkiKi_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19OrangeBallBillboard6RenderEv.cpp
+++ b/src/_ZN19OrangeBallBillboard6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN19OrangeBallBillboard6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "OrangeBallBillboard.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN19OrangeBallBillboard6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int OrangeBallBillboard::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN19OrangeBallBillboardD0Ev.c
+++ b/src/_ZN19OrangeBallBillboardD0Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN19OrangeBallBillboardD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "OrangeBallBillboard.h"
 extern void *G0;
-int *_ZN19OrangeBallBillboardD0Ev(int *t)
-{
-    t[0] = (int)VT0;
-    _ZN5ModelD1Ev((char *)t + 0xd4);
-    _ZN5ActorD2Ev(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, G0);
-    return t;
+int *_ZN19OrangeBallBillboardD0Ev(struct OrangeBallBillboard *self) {
+    ((int *)self)[0] = (int)VT0;
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((int *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((int *)self), G0);
+    return ((int *)self);
 }

--- a/src/_ZN19RickshawPlatformBdwD0Ev.c
+++ b/src/_ZN19RickshawPlatformBdwD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN19RickshawPlatformBdwD0Ev
+/* recovered: named members + shared header */
+#include "RickshawPlatformBdw.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ModelD1Ev(void *p);
@@ -7,15 +10,15 @@ extern int _ZTV19RickshawPlatformBdw[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN19RickshawPlatformBdwD0Ev(char *c){
-    *(int**)(c) = _ZTV19RickshawPlatformBdw;
-    *(int**)(c) = data_ov002_02108d94;
-    func_0207328c(c+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
-    func_0207328c(c+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN19RickshawPlatformBdwD0Ev(struct RickshawPlatformBdw *self) {
+    *(int**)(((char *)self)) = _ZTV19RickshawPlatformBdw;
+    *(int**)(((char *)self)) = data_ov002_02108d94;
+    func_0207328c(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN19RickshawPlatformBdwD1Ev.cpp
+++ b/src/_ZN19RickshawPlatformBdwD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN19RickshawPlatformBdwD1Ev
+/* recovered: named members + shared header */
+#include "RickshawPlatformBdw.h"
 extern "C" {
 extern int func_0207328c(void*,int,int,void*);
 extern int _ZN18MovingMeshColliderD1Ev(void*);
@@ -7,15 +10,15 @@ extern int _ZN5ActorD2Ev(void*);
 extern int _ZTV19RickshawPlatformBdw[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
-void* _ZN19RickshawPlatformBdwD1Ev(char* c){
-  *(int**)c=_ZTV19RickshawPlatformBdw;
-  *(int**)c=data_ov002_02108d94;
-  func_0207328c(c+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
-  func_0207328c(c+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)c=_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN19RickshawPlatformBdwD1Ev(struct RickshawPlatformBdw *self) {
+  *(int**)((char*)self)=_ZTV19RickshawPlatformBdw;
+  *(int**)((char*)self)=data_ov002_02108d94;
+  func_0207328c(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
+  func_0207328c(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
+  *(int**)((char*)self)=_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN19RotatingPlatformLll6RenderEv.cpp
+++ b/src/_ZN19RotatingPlatformLll6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN19RotatingPlatformLll6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingPlatformLll.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN19RotatingPlatformLll6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int RotatingPlatformLll::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN19RotatingPlatformLllD0Ev.c
+++ b/src/_ZN19RotatingPlatformLllD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19RotatingPlatformLllD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFl_Block_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN19RotatingPlatformLllD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFl_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformLllD1Ev.c
+++ b/src/_ZN19RotatingPlatformLllD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19RotatingPlatformLllD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjFl_Block_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN19RotatingPlatformLllD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjFl_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformWdw6RenderEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN19RotatingPlatformWdw6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingPlatformWdw.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN19RotatingPlatformWdw6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int RotatingPlatformWdw::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN19RotatingPlatformWdwD0Ev.c
+++ b/src/_ZN19RotatingPlatformWdwD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19RotatingPlatformWdwD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN19RotatingPlatformWdwD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjWc_Mizu_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN19RotatingPlatformWdwD1Ev.c
+++ b/src/_ZN19RotatingPlatformWdwD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN19RotatingPlatformWdwD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWc_Mizu_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN19RotatingPlatformWdwD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjWc_Mizu_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN20SwitchActivatedPlank13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SwitchActivatedPlank.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct Model { int d; };
@@ -8,8 +13,6 @@ struct MovingMeshCollider { int d; };
 
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);
-extern "C" void func_ov029_02112710(char* t);
-extern "C" void func_ov029_021126dc(char* c);
 extern "C" KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     MovingMeshCollider*, KCL_File*, const Matrix4x3&, Fix12i, short, CLPS_Block&);
@@ -20,9 +23,9 @@ extern SharedFilePtr data_ov029_02114324;
 extern CLPS_Block data_ov029_0211304c;
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 
-extern "C" int _ZN20SwitchActivatedPlank13InitResourcesEv(char* thiz)
+int SwitchActivatedPlank::InitResources()
 {
-    char* c = thiz;
+    char* c = ((char*)this);
     BMD_File* bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_0211432c);
     _ZN9ModelBase7SetFileEP8BMD_Fileii((ModelBase*)(c + 0x320), bmd, 1, -1);
     func_ov029_02112710(c);

--- a/src/_ZN20SwitchActivatedPlank6RenderEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank6RenderEv.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol _ZN20SwitchActivatedPlank6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SwitchActivatedPlank.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(int); };
-extern "C" {
-int _ZN20SwitchActivatedPlank6RenderEv(char *c){
-  if (*(unsigned char*)(c+0x3a3) != 0) {
-    Sub *s = (Sub*)(c+0x320);
+
+int SwitchActivatedPlank::Render()
+{
+  if (unk_3a3 != 0) {
+    Sub *s = (Sub*)((char *)&mModel2);
     s->v5(0);
   }
   return 1;
-}
 }

--- a/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN20SwitchActivatedPlank8BehaviorEv
+/* recovered: named members + shared header */
+#include "SwitchActivatedPlank.h"
 extern "C" {
 void func_020393a4(void* p, int v);
 int _ZN5Event6GetBitEj(unsigned int);
@@ -9,36 +12,36 @@ int _ZN16MeshColliderBase7DisableEv(void*);
 
 #pragma optimize_for_size on
 
-int _ZN20SwitchActivatedPlank8BehaviorEv(char* c){
-    func_020393a4(c+0x124, 0x100000);
+int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
+    func_020393a4(((char*)self)+0x124, 0x100000);
 
-    switch(*(unsigned char*)(c+0x3a2)){
+    switch(self->unk_3a2){
     case 0:
-        if(_ZN5Event6GetBitEj(*(unsigned char*)(c+0x3a4)) == 0) break;
+        if(_ZN5Event6GetBitEj(self->unk_3a4) == 0) break;
 
         {
-            unsigned char* st_ptr = (unsigned char*)(((int)c + 0x3a2) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char* st_ptr = (unsigned char*)(((int)((char*)self) + 0x3a2) & 0xFFFFFFFFFFFFFFFF);
             *st_ptr = *st_ptr + 1;
         }
 
-        *(short*)(c + 0x300 + 0xa0) = 0;
-        *(unsigned char*)(c+0x3a3) = 1;
+        *(short*)(((char*)self) + 0x300 + 0xa0) = 0;
+        self->unk_3a3 = 1;
 
-        _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
-        func_ov029_021126dc(c);
-        _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(c+0x124, c+0x370, *(short*)(c+0x8e));
+        _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
+        func_ov029_021126dc(((char*)self));
+        _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(((char*)self)+0x124, ((char*)self)+0x370, self->unk_08e);
         break;
 
     case 1: {
-        unsigned short* p = (unsigned short*)(c + 0x3a0);
-        if (*(unsigned short*)(c + 0x300 + 0xa0) > 0x168) {
-            *(unsigned char*)(c + 0x3a3) = *(unsigned short*)(c + 0x300 + 0xa0) & 1;
+        unsigned short* p = (unsigned short*)((char*)&self->unk_3a0);
+        if (*(unsigned short*)(((char*)self) + 0x300 + 0xa0) > 0x168) {
+            self->unk_3a3 = *(unsigned short*)(((char*)self) + 0x300 + 0xa0) & 1;
         }
         *p = *p + 1;
-        if (_ZN5Event6GetBitEj(*(unsigned char*)(c+0x3a4)) != 0) break;
-        _ZN16MeshColliderBase7DisableEv(c+0x124);
-        *(unsigned char*)(c+0x3a2) = 0;
-        *(unsigned char*)(c+0x3a3) = 0;
+        if (_ZN5Event6GetBitEj(self->unk_3a4) != 0) break;
+        _ZN16MeshColliderBase7DisableEv((char*)&self->mMovingMeshCollider);
+        self->unk_3a2 = 0;
+        self->unk_3a3 = 0;
         break;
     }
     }

--- a/src/_ZN20SwitchActivatedPlankD0Ev.c
+++ b/src/_ZN20SwitchActivatedPlankD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN20SwitchActivatedPlankD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN20SwitchActivatedPlankD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjWc_Obj04_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20SwitchActivatedPlankD1Ev.c
+++ b/src/_ZN20SwitchActivatedPlankD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN20SwitchActivatedPlankD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj04_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN20SwitchActivatedPlankD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjWc_Obj04_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN20TtcConveyorBeltLarge13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "TtcConveyorBeltLarge.h"
 struct BMD_File;
 struct BTA_File;
 struct KCL_File;
@@ -56,7 +61,6 @@ struct Entry3 {
     void *c;
 };
 
-extern "C" char data_ov065_0211d16c[8];
 extern "C" Entry3 data_ov065_0211d194[];
 extern "C" Entry3 data_ov065_0211d198[];
 extern "C" Entry3 data_ov065_0211d19c[];
@@ -70,7 +74,7 @@ struct V3 {
     int z;
 };
 
-extern "C" int _ZN20TtcConveyorBeltLarge13InitResourcesEv(char *self)
+int TtcConveyorBeltLarge::InitResources()
 {
     void *locbuf[2];
     V3 v;
@@ -81,67 +85,67 @@ extern "C" int _ZN20TtcConveyorBeltLarge13InitResourcesEv(char *self)
     locbuf[0] = *(void **)&data_ov065_0211d16c[0];
     locbuf[1] = *(void **)&data_ov065_0211d16c[4];
 
-    if (*(unsigned short *)(self + 0xc) != 0x6f) {
-        if (*(unsigned short *)(self + 0xc) == 0x70)
-            *(unsigned char *)(self + 0x39e) = 1;
+    if (mActorID != 0x6f) {
+        if (mActorID == 0x70)
+            mVariant = 1;
     } else {
-        *(unsigned char *)(self + 0x39e) = 0;
+        mVariant = 0;
     }
 
-    e = *(unsigned char *)(self + 0x39e);
+    e = mVariant;
     mf = _ZN5Model8LoadFileER13SharedFilePtr(
         data_ov065_0211d194[e].a);
-    ((ModelBase *)(self + 0xd4))->SetFile(
+    ((ModelBase *)((char *)&mModel))->SetFile(
         (BMD_File *)mf, 1, -1);
 
-    ((ShadowModel *)(self + 0x334))->InitCuboid();
+    ((ShadowModel *)((char *)&mShadowModel))->InitCuboid();
 
-    e = *(unsigned char *)(self + 0x39e);
+    e = mVariant;
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(
         *(BMD_File *)*(void **)((char *)data_ov065_0211d194[e].a + 4),
         *(BTA_File *)locbuf[e]);
 
-    ((TextureTransformer *)(self + 0x320))->SetFile(
-        *(BTA_File *)locbuf[*(unsigned char *)(self + 0x39e)],
+    ((TextureTransformer *)((char *)&mTextureTransformer))->SetFile(
+        *(BTA_File *)locbuf[mVariant],
         0, 0x1000, 0);
 
-    ((Platform *)self)->UpdateModelPosAndRotY();
-    ((Platform *)self)->UpdateClsnPosAndRot();
+    ((Platform *)((char *)this))->UpdateModelPosAndRotY();
+    ((Platform *)((char *)this))->UpdateClsnPosAndRot();
 
-    e = *(unsigned char *)(self + 0x39e);
+    e = mVariant;
     kf = _ZN12MeshCollider8LoadFileER13SharedFilePtr(
         data_ov065_0211d198[e].a);
-    ((MovingMeshCollider *)(self + 0x124))->SetFile(
+    ((MovingMeshCollider *)((char *)&mMeshCollider))->SetFile(
         (KCL_File *)kf,
-        *(Matrix4x3 *)(self + 0x2ec),
+        *(Matrix4x3 *)((char *)&unk_2ec),
         0x199,
-        *(short *)(self + 0x8e),
+        unk_08e,
         *(CLPS_Block *)data_ov065_0211d19c[e].a);
 
     func_020393c4(
-        self + 0x124,
+        ((char *)this) + 0x124,
         (void *)&func_ov065_0211aacc);
 
-    *(void **)(self + 0x390) =
+    *(void **)((char *)&mTargetBeltSpeed) =
         data_ov065_0211c0b8[data_0209f2c0];
-    *(void **)(self + 0x38c) =
-        *(void **)(self + 0x390);
-    *(void **)(self + 0x32c) =
-        *(void **)(self + 0x38c);
+    *(void **)((char *)&mBeltSpeed) =
+        *(void **)((char *)&mTargetBeltSpeed);
+    *(void **)((char *)&unk_32c) =
+        *(void **)((char *)&mBeltSpeed);
 
-    v.x = *(int *)(self + 0x5c);
-    v.y = *(int *)(self + 0x60);
-    v.z = *(int *)(self + 0x64);
+    v.x = mPosX;
+    v.y = mPosY;
+    v.z = mPosZ;
     v.y = v.y - 0xa000;
 
     {
         RaycastGround rg;
 
         rg.SetObjAndPos(*(Vector3 *)&v, (Actor *)0);
-        *(int *)(self + 0x394) = v.y;
+        unk_394 = v.y;
 
         if (rg.DetectClsn() != 0)
-            *(int *)(self + 0x394) = rg.result;
+            unk_394 = rg.result;
     }
 
     return 1;

--- a/src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN20TtcConveyorBeltLarge6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TtcConveyorBeltLarge.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN20TtcConveyorBeltLarge6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int TtcConveyorBeltLarge::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN20TtcConveyorBeltLargeD0Ev.c
+++ b/src/_ZN20TtcConveyorBeltLargeD0Ev.c
@@ -1,18 +1,20 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN20TtcConveyorBeltLargeD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN20TtcConveyorBeltLargeD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha04_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN20TtcConveyorBeltLargeD1Ev.c
+++ b/src/_ZN20TtcConveyorBeltLargeD1Ev.c
@@ -1,16 +1,19 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN20TtcConveyorBeltLargeD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha04_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN20TtcConveyorBeltLargeD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha04_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x334);
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN21ArmedRotatingPlatformD0Ev.c
+++ b/src/_ZN21ArmedRotatingPlatformD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN21ArmedRotatingPlatformD0Ev
+/* recovered: named members + shared header */
+#include "ArmedRotatingPlatform.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ModelD1Ev(void *p);
@@ -7,15 +10,15 @@ extern int _ZTV21ArmedRotatingPlatform[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN21ArmedRotatingPlatformD0Ev(char *c){
-    *(int**)(c) = _ZTV21ArmedRotatingPlatform;
-    *(int**)(c) = data_ov002_02108d94;
-    func_0207328c(c+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
-    func_0207328c(c+0x320, 5, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN21ArmedRotatingPlatformD0Ev(struct ArmedRotatingPlatform *self) {
+    *(int**)(((char *)self)) = _ZTV21ArmedRotatingPlatform;
+    *(int**)(((char *)self)) = data_ov002_02108d94;
+    func_0207328c(((char *)self)+0x4b0, 5, 0x1c8, _ZN18MovingMeshColliderD1Ev);
+    func_0207328c(((char *)self)+0x320, 5, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN21ArmedRotatingPlatformD1Ev.cpp
+++ b/src/_ZN21ArmedRotatingPlatformD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN21ArmedRotatingPlatformD1Ev
+/* recovered: named members + shared header */
+#include "ArmedRotatingPlatform.h"
 extern "C" {
 extern int func_0207328c(void*,int,int,void*);
 extern int _ZN18MovingMeshColliderD1Ev(void*);
@@ -7,15 +10,15 @@ extern int _ZN5ActorD2Ev(void*);
 extern int _ZTV21ArmedRotatingPlatform[];
 extern int data_ov002_02108d94[];
 extern int _ZTV17ExclamationSwitch[];
-void* _ZN21ArmedRotatingPlatformD1Ev(char* c){
-  *(int**)c=_ZTV21ArmedRotatingPlatform;
-  *(int**)c=data_ov002_02108d94;
-  func_0207328c(c+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
-  func_0207328c(c+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
-  *(int**)c=_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN21ArmedRotatingPlatformD1Ev(struct ArmedRotatingPlatform *self) {
+  *(int**)((char*)self)=_ZTV21ArmedRotatingPlatform;
+  *(int**)((char*)self)=data_ov002_02108d94;
+  func_0207328c(((char*)self)+0x4b0,5,0x1c8,(void*)_ZN18MovingMeshColliderD1Ev);
+  func_0207328c(((char*)self)+0x320,5,0x50,(void*)_ZN5ModelD1Ev);
+  *(int**)((char*)self)=_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c
+++ b/src/_ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c
@@ -1,11 +1,13 @@
+// @symbol _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block
+/* recovered: named members + shared header */
+#include "ExtendingMeshCollider.h"
 struct Matrix4x3;
 struct KCL_File;
 struct CLPS_Block;
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
     void* thiz, struct KCL_File* f, const struct Matrix4x3* m, int fix, short s, struct CLPS_Block* b);
-void _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-    void* thiz, struct KCL_File* f, const struct Matrix4x3* m, int fix, short s, struct CLPS_Block* b) {
-    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(thiz, f, m, fix, s, b);
-    *(int*)((char*)thiz + 0x1c8) = 0x1000;
-    *(int*)((char*)thiz + 0x1cc) = 0x1000;
+void _ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(struct ExtendingMeshCollider *self, struct KCL_File* f, const struct Matrix4x3* m, int fix, short s, struct CLPS_Block* b) {
+    _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((void*)self), f, m, fix, s, b);
+    *(int*)((char*)&self->unk_1c8) = 0x1000;
+    *(int*)((char*)&self->unk_1cc) = 0x1000;
 }

--- a/src/_ZN21ExtendingMeshColliderC1Ev.c
+++ b/src/_ZN21ExtendingMeshColliderC1Ev.c
@@ -1,9 +1,13 @@
+// @symbol _ZN21ExtendingMeshColliderC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ExtendingMeshCollider.h"
 /* _ZN21ExtendingMeshColliderC1Ev at 0x02014878
  * ExtendingMeshCollider C1 (complete object) constructor:
  *   call base CylinderClsn::CylinderClsn() (C2), then set own vtable.
  */
 struct Obj { void *vtable; };
-extern void *_ZTV21ExtendingMeshCollider[];
 extern void func_0203a4b8(struct Obj *thiz); /* 0x020150cc */
 
 struct Obj *_ZN21ExtendingMeshColliderC1Ev(struct Obj *thiz)

--- a/src/_ZN21ExtendingMeshColliderD1Ev.c
+++ b/src/_ZN21ExtendingMeshColliderD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN21ExtendingMeshColliderD1Ev
+/* recovered: named members + shared header */
+#include "ExtendingMeshCollider.h"
 /* ExtendingMeshCollider::~ExtendingMeshCollider() at 0x0203ab68
  * Complete-object destructor. Installs the ExtendingMeshCollider vtable, then
  * runs the base subobject destructor (func_0203a420). Returns this.

--- a/src/_ZN21FloatingFloorLllSmallD0Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN21FloatingFloorLllSmallD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN21FloatingFloorLllSmallD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN21FloatingFloorLllSmallD1Ev.c
+++ b/src/_ZN21FloatingFloorLllSmallD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN21FloatingFloorLllSmallD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Ukiyuka_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN21FloatingFloorLllSmallD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjFl_Ukiyuka_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp
+++ b/src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN21MegaMushroomCreateTag8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MegaMushroomCreateTag.h"
 typedef int Fix12i;
 
 extern "C" Fix12i Vec3_Dist(const Vector3 *a, const Vector3 *b);
@@ -31,45 +35,43 @@ struct Actor : ActorBase {
     static Actor *FindWithActorID(unsigned int id, Actor *after);
 };
 
-extern void func_ov002_020b4714(void *self);
-extern void func_ov002_020b47ec(void *self);
 
-extern "C" int _ZN21MegaMushroomCreateTag8BehaviorEv(Actor *self)
+int MegaMushroomCreateTag::Behavior()
 {
     Actor *o;
-    int isTarget = (int)(self->actorID == 0x140);
+    int isTarget = (int)(((Actor *)this)->actorID == 0x140);
     if (isTarget) {
-        if (!self->b10b) {
+        if (!((Actor *)this)->b10b) {
             o = Actor::FindWithActorID(0x1b, 0);
             while (o) {
-                if (Vec3_Dist(&self->pos, &o->pos) < 0x96000) {
-                    self->b108 = 1;
-                    o->p32c = self;
-                    self->b10b = 1;
+                if (Vec3_Dist(&((Actor *)this)->pos, &o->pos) < 0x96000) {
+                    ((Actor *)this)->b108 = 1;
+                    o->p32c = ((Actor *)this);
+                    ((Actor *)this)->b10b = 1;
                     return 1;
                 }
                 o = Actor::FindWithActorID(0x1b, o);
             }
-            self->b10b = 1;
+            ((Actor *)this)->b10b = 1;
         }
     }
-    if (!self->b10a) {
+    if (!((Actor *)this)->b10a) {
         o = Actor::FindWithActorID(0x13f, 0);
         while (o) {
-            if (self->b109 == o->b109) self->b10a = 1;
+            if (((Actor *)this)->b109 == o->b109) ((Actor *)this)->b10a = 1;
             o = Actor::FindWithActorID(0x13f, o);
         }
-        if (!self->b10a) self->MarkForDestruction();
+        if (!((Actor *)this)->b10a) ((Actor *)this)->MarkForDestruction();
     }
-    isTarget = (int)(self->actorID == 0x140);
+    isTarget = (int)(((Actor *)this)->actorID == 0x140);
     if (isTarget) {
-        if (self->b108 == 1) {
-            if (self->b10c) func_ov002_020b4714(self);
+        if (((Actor *)this)->b108 == 1) {
+            if (((Actor *)this)->b10c) func_ov002_020b4714(((Actor *)this));
         } else {
-            func_ov002_020b47ec(self);
+            func_ov002_020b47ec(((Actor *)this));
         }
     }
-    self->clsn.Clear();
-    self->clsn.Update();
+    ((Actor *)this)->clsn.Clear();
+    ((Actor *)this)->clsn.Update();
     return 1;
 }

--- a/src/_ZN21MegaMushroomCreateTagD0Ev.c
+++ b/src/_ZN21MegaMushroomCreateTagD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN21MegaMushroomCreateTagD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjKinokoTag_c */
 extern void *G0;
 int *_ZN21MegaMushroomCreateTagD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjKinokoTag_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN22ClockPaintingHandShort16CleanupResourcesEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort16CleanupResourcesEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN22ClockPaintingHandShort16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ClockPaintingHandShort.h"
 class SharedFilePtr {
 public:
 void Release();
 };
 
-extern "C" int data_ov013_021116b0[];
 
-extern "C" int _ZN22ClockPaintingHandShort16CleanupResourcesEv(char *r0) {
-unsigned char r1 = *(unsigned char *)(r0 + 0x124);
+int ClockPaintingHandShort::CleanupResources()
+{
+unsigned char r1 = mHandIndex;
 SharedFilePtr *ptr = (SharedFilePtr *)data_ov013_021116b0[r1];
 ptr->Release();
 return 1;

--- a/src/_ZN22ClockPaintingHandShort6RenderEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN22ClockPaintingHandShort6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ClockPaintingHandShort.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN22ClockPaintingHandShort6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int ClockPaintingHandShort::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN22ClockPaintingHandShortD0Ev.c
+++ b/src/_ZN22ClockPaintingHandShortD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN22ClockPaintingHandShortD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daObjClock_c */
 extern void *G0;
 int *_ZN22ClockPaintingHandShortD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daObjClock_c;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c
+++ b/src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c
@@ -1,3 +1,6 @@
+// @symbol _ZN22ExpandingHeapAllocator14SizeofInternalEPv
+/* recovered: named members + shared header */
+#include "ExpandingHeapAllocator.h"
 /* ExpandingHeapAllocator::SizeofInternal(void* userPtr) at 0x0204e084
  * Returns the allocated size of a block given a user pointer. The block's
  * MemoryNode header sits immediately before the user data; its `size` field (see

--- a/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
+++ b/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
@@ -1,3 +1,8 @@
+// @symbol _ZN22ExpandingHeapAllocatorC1EPvj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_HeapAllocator.h"
+/* recovered: named members + shared header */
+#include "ExpandingHeapAllocator.h"
 // ExpandingHeapAllocator constructor: runs the HeapAllocator base ctor with
 // magic 'HPXE', zeroes the two u16 counters at +0x34/+0x36, clears bit 0 of
 // the +0x36 flags, creates the initial free node ('FR') spanning the heap
@@ -12,23 +17,22 @@ typedef struct {
 
 typedef struct MemoryNode MemoryNode;
 
-extern void _ZN13HeapAllocatorC1EjPvPvj(void *this, u32 magic, void *a, void *b, u32 size);
 extern MemoryNode *_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(Target *t, u16 v);
 
-void *_ZN22ExpandingHeapAllocatorC1EPvj(char *this, void *start, u32 size) {
-    char *inner = this + 0x24;
+void *_ZN22ExpandingHeapAllocatorC1EPvj(struct ExpandingHeapAllocator *self, void *start, u32 size) {
+    char *inner = ((char *)self) + 0x24;
     Target t;
     MemoryNode *node;
-    _ZN13HeapAllocatorC1EjPvPvj(this, 0x45585048, inner + 0x14, start, size);
+    _ZN13HeapAllocatorC1EjPvPvj(((char *)self), 0x45585048, inner + 0x14, start, size);
     *(u16 *)(inner + 0x10) = 0;
     *(u16 *)(inner + 0x12) = 0;
-    (*(u16 *)((long long)(int)(inner + 0x12) & 0xFFFFFFFFFFFFFFFFLL)) &= ~1;
-    t.start = *(void **)(this + 0x18);
-    t.end = *(void **)(this + 0x1c);
+    (*(u16 *)((long long)(int)(inner + 0x12))) &= ~1;
+    t.start = *(void **)((char *)&self->unk_018);
+    t.end = *(void **)((char *)&self->unk_01c);
     node = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t, 0x4652);
-    *(MemoryNode **)((long long)(int)inner & 0xFFFFFFFFFFFFFFFFLL) = node;
+    *(MemoryNode **)((long long)(int)inner) = node;
     *(MemoryNode **)(inner + 4) = node;
     *(u32 *)(inner + 8) = 0;
     *(u32 *)(inner + 0xc) = 0;
-    return this;
+    return ((char *)self);
 }

--- a/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN22RotatingUpDownPlatform16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingUpDownPlatform.h"
 extern "C" {
 extern int _ZN13SharedFilePtr7ReleaseEv(void*);
 extern int _ZN16MeshColliderBase7DisableEv(void*);
 extern void* data_ov091_021344fc[];
 extern void* data_ov091_021344f4[];
-int _ZN22RotatingUpDownPlatform16CleanupResourcesEv(char* c){
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344fc[*(unsigned char*)(c+0x352)]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344f4[*(unsigned char*)(c+0x352)]);
-  _ZN16MeshColliderBase7DisableEv(c+0x124);
-  return 1;
 }
+
+int RotatingUpDownPlatform::CleanupResources()
+{
+  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344fc[mVariant]);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov091_021344f4[mVariant]);
+  _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  return 1;
 }

--- a/src/_ZN22RotatingUpDownPlatform6RenderEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN22RotatingUpDownPlatform6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingUpDownPlatform.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN22RotatingUpDownPlatform6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int RotatingUpDownPlatform::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN22RotatingUpDownPlatform8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingUpDownPlatform.h"
 typedef void (*PMFholder);
 struct Platform {
     void UpdateModelPosAndRotY();
@@ -7,18 +12,16 @@ struct Platform {
 };
 struct PmfEntry;
 extern "C" void func_020393d4(void *p, void *v);
-extern "C" void ApproachLinearI(int *dst, int target, int rate);
-extern "C" void UpdatePosWithVelocitySym();
 
 typedef void (Platform::*PMF)();
 struct PmfRow { PMF pmf; };
 extern "C" PmfRow data_ov091_021354e0[];
 
-extern "C" int _ZN22RotatingUpDownPlatform8BehaviorEv(Platform *self)
+int RotatingUpDownPlatform::Behavior()
 {
-    char *s = (char*)self;
+    char *s = (char*)((Platform *)this);
     int old = *(int*)(s + 0x320);
-    (self->*data_ov091_021354e0[old].pmf)();
+    (((Platform *)this)->*data_ov091_021354e0[old].pmf)();
     *(unsigned short*)(((int)s + 0x354) & 0xFFFFFFFFFFFFFFFF) += 1;
     if (old != *(int*)(s + 0x320)) {
         *(short*)(s + 0x354) = 0;
@@ -33,9 +36,9 @@ extern "C" int _ZN22RotatingUpDownPlatform8BehaviorEv(Platform *self)
         *(int*)(((int)s + 0x60) & 0xFFFFFFFFFFFFFFFF) -= *(int*)(s + 0x34c);
         *(int*)(s + 0x60) = saved;
     }
-    self->UpdateModelPosAndRotY();
-    if (self->IsClsnInRange(0, 0) != 0)
-        self->UpdateClsnPosAndRot();
+    ((Platform *)this)->UpdateModelPosAndRotY();
+    if (((Platform *)this)->IsClsnInRange(0, 0) != 0)
+        ((Platform *)this)->UpdateClsnPosAndRot();
     *(unsigned char*)(s + 0x356) = 0;
     return 1;
 }

--- a/src/_ZN22RotatingUpDownPlatformD0Ev.c
+++ b/src/_ZN22RotatingUpDownPlatformD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN22RotatingUpDownPlatformD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN22RotatingUpDownPlatformD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daLinelift2_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN22RotatingUpDownPlatformD1Ev.c
+++ b/src/_ZN22RotatingUpDownPlatformD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN22RotatingUpDownPlatformD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daLinelift2_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN22RotatingUpDownPlatformD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daLinelift2_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp
@@ -1,34 +1,35 @@
 //cpp
+// @symbol _ZN23FloatOnWaterPlatformJrb13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FloatOnWaterPlatformJrb.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
-extern void func_ov016_021130a4(char* t);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* thiz);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* act, int fix, int t, void* vr, int t2);
-extern int data_ov016_02114e74[];
-extern int data_ov016_02114e6c[];
-extern int data_ov016_02113bac[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
+}
 
-int _ZN23FloatOnWaterPlatformJrb13InitResourcesEv(char* c)
+int FloatOnWaterPlatformJrb::InitResources()
 {
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov016_02114e74);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, -1);
-    func_ov016_021130a4(c);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, -1);
+    func_ov016_021130a4(((char*)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov016_02114e6c);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, mc, c + 0x2ec, 0x199, *(short*)(c + 0x8e), data_ov016_02113bac);
-    func_020393d4(c + 0x124, (void*)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x324, c, 0x14000, 0x14000, 0, 0);
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x14000;
-    *(int*)(c + 0x320) = 0;
-    *(unsigned char*)(c + 0x4f4) = 0;
-    *(int*)(c + 0x4f0) = 0;
+        ((char*)this) + 0x124, mc, ((char*)this) + 0x2ec, 0x199, unk_08e, data_ov016_02113bac);
+    func_020393d4(((char*)this) + 0x124, (void*)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x324, ((char*)this), 0x14000, 0x14000, 0, 0);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x14000;
+    unk_320 = 0;
+    unk_4f4 = 0;
+    unk_4f0 = 0;
     return 1;
-}
 }

--- a/src/_ZN23FloatOnWaterPlatformJrb6RenderEv.cpp
+++ b/src/_ZN23FloatOnWaterPlatformJrb6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN23FloatOnWaterPlatformJrb6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FloatOnWaterPlatformJrb.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN23FloatOnWaterPlatformJrb6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int FloatOnWaterPlatformJrb::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
+++ b/src/_ZN23FloatOnWaterPlatformJrbD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN23FloatOnWaterPlatformJrbD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN23FloatOnWaterPlatformJrbD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daSlide_Box_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN23FloatOnWaterPlatformJrbD1Ev.c
+++ b/src/_ZN23FloatOnWaterPlatformJrbD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN23FloatOnWaterPlatformJrbD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daSlide_Box_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN23FloatOnWaterPlatformJrbD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daSlide_Box_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x324);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
+++ b/src/_ZN25MovingCylinderClsnWithPosD1Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN25MovingCylinderClsnWithPosD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MovingCylinderClsnWithPos.h"
 /* _ZN25MovingCylinderClsnWithPosD1Ev at 0x02014a60
  * Single-vtable D1/D2 destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call immediate-base destructor, return this.
  * Base dtor call target: 0x02014954
  */
 struct Obj { void *vtable; };
-extern void *vtbl_MovingCylinderClsnWithPos[];
 extern void base_dtor_MovingCylinderClsnWithPos(struct Obj *thiz); /* 0x02014954 */
 struct Obj *_ZN25MovingCylinderClsnWithPosD1Ev(struct Obj *thiz)
 {


### PR DESCRIPTION
Batch 04 of the readable-tree migration. Promotes 184 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (tools/prepush_linkcheck.py, mwccarm 1.2/sp2p3): 91 VERIFIED, 93 BLIND, 0 WRONG/NO-REPRO. 6 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
