### PR TITLE
readable: batch 05 - promote 180 files to readable form

### DIFF
--- a/src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN25RotatingUpDownPlatformUtm6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "RotatingUpDownPlatformUtm.h"
 struct Sub {
     virtual void m0();
     virtual void m1();
@@ -7,11 +10,11 @@ struct Sub {
     virtual void m4();
     virtual void doit(int);
 };
-extern "C" {
-int _ZN25RotatingUpDownPlatformUtm6RenderEv(char *c) {
-    if (*(unsigned char*)(c+0x3a0)) return 1;
-    if (*(int*)(c+8) == 0xffff) return 1;
-    ((struct Sub*)(c+0xd4))->doit(0);
+
+int RotatingUpDownPlatformUtm::Render()
+{
+    if (unk_3a0) return 1;
+    if (mSpawnParam == 0xffff) return 1;
+    ((struct Sub*)((char *)&mModel))->doit(0);
     return 1;
-}
 }

--- a/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
+++ b/src/_ZN25RotatingUpDownPlatformUtmD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN25RotatingUpDownPlatformUtmD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN25RotatingUpDownPlatformUtmD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV23daObjRotateUpdownLift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN25RotatingUpDownPlatformUtmD1Ev.c
+++ b/src/_ZN25RotatingUpDownPlatformUtmD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN25RotatingUpDownPlatformUtmD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV23daObjRotateUpdownLift_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN25RotatingUpDownPlatformUtmD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV23daObjRotateUpdownLift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
+++ b/src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp
@@ -1,21 +1,26 @@
 //cpp
+// @symbol _ZN25SlideDecorationSilverStar13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlideDecorationSilverStar.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void func_ov044_02111214(char*);
 extern int* data_ov031_02111424[];
-int _ZN25SlideDecorationSilverStar13InitResourcesEv(char *c){
-  unsigned short type = *(unsigned short*)(c+0xc);
-  switch(type){
-    case 0x12e: *(char*)(c+0x124)=0; break;
-    case 0x12f: *(char*)(c+0x124)=1; break;
-    case 0x130: *(char*)(c+0x124)=2; break;
-    case 0x131: *(char*)(c+0x124)=3; break;
-  }
-  unsigned char idx = *(unsigned char*)(c+0x124);
-  void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov031_02111424[idx]);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
-  func_ov044_02111214(c);
-  return 1;
 }
+
+int SlideDecorationSilverStar::InitResources()
+{
+  unsigned short type = unk_00c;
+  switch(type){
+    case 0x12e: mVariant=0; break;
+    case 0x12f: mVariant=1; break;
+    case 0x130: mVariant=2; break;
+    case 0x131: mVariant=3; break;
+  }
+  unsigned char idx = mVariant;
+  void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov031_02111424[idx]);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, f, 1, -1);
+  func_ov044_02111214(((char *)this));
+  return 1;
 }

--- a/src/_ZN25SlideDecorationSilverStar16CleanupResourcesEv.cpp
+++ b/src/_ZN25SlideDecorationSilverStar16CleanupResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN25SlideDecorationSilverStar16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlideDecorationSilverStar.h"
 class SharedFilePtr {
 public:
 void Release();
@@ -6,8 +9,9 @@ void Release();
 
 extern "C" int data_ov031_02111424[];
 
-extern "C" int _ZN25SlideDecorationSilverStar16CleanupResourcesEv(char *r0) {
-unsigned char r1 = *(unsigned char *)(r0 + 0x124);
+int SlideDecorationSilverStar::CleanupResources()
+{
+unsigned char r1 = mVariant;
 SharedFilePtr *ptr = (SharedFilePtr *)data_ov031_02111424[r1];
 ptr->Release();
 return 1;

--- a/src/_ZN25SlideDecorationSilverStar6RenderEv.cpp
+++ b/src/_ZN25SlideDecorationSilverStar6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN25SlideDecorationSilverStar6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SlideDecorationSilverStar.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN25SlideDecorationSilverStar6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int SlideDecorationSilverStar::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN25SlideDecorationSilverStarD0Ev.c
+++ b/src/_ZN25SlideDecorationSilverStarD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN25SlideDecorationSilverStarD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjHsBillboard_c */
 extern void *G0;
 int *_ZN25SlideDecorationSilverStarD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjHsBillboard_c;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FloatOnWaterPlatformWdwSquare.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct Model { int d; };
@@ -20,11 +25,10 @@ extern SharedFilePtr data_ov029_02114250;
 extern SharedFilePtr data_ov029_02114248;
 extern CLPS_Block data_ov029_0211302c;
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
-extern int func_ov029_021116e4;
 
-extern "C" int _ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv(char* thiz)
+int FloatOnWaterPlatformWdwSquare::InitResources()
 {
-    char* c = thiz;
+    char* c = ((char*)this);
     {
         BMD_File* bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114250);
         _ZN9ModelBase7SetFileEP8BMD_Fileii((ModelBase*)(c + 0xd4), bmd, 1, -1);

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN29FloatOnWaterPlatformWdwSquare6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FloatOnWaterPlatformWdwSquare.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN29FloatOnWaterPlatformWdwSquare6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int FloatOnWaterPlatformWdwSquare::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN29FloatOnWaterPlatformWdwSquareD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj02_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN29FloatOnWaterPlatformWdwSquareD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjWc_Obj02_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN29FloatOnWaterPlatformWdwSquareD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj02_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN29FloatOnWaterPlatformWdwSquareD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjWc_Obj02_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN32FloatOnWaterPlatformWdwRectangleD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN32FloatOnWaterPlatformWdwRectangleD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjWc_Obj07_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
+++ b/src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN32FloatOnWaterPlatformWdwRectangleD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj07_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN32FloatOnWaterPlatformWdwRectangleD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjWc_Obj07_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN3Amp13InitResourcesEv.cpp
+++ b/src/_ZN3Amp13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN3Amp13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Amp.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BTP_File;
@@ -30,13 +33,13 @@ extern char data_02082128;
 
 struct M48 { int w[12]; };
 
-extern "C" int _ZN3Amp13InitResourcesEv(char *c)
+int Amp::InitResources()
 {
     BMD_File *bmd;
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov070_021235fc);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, bmd, 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, bmd, 1, 1);
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov070_02123604);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x138, bmd, 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x138, bmd, 1, 1);
 
     int i;
     for (i = 0; i < 2; i++) {
@@ -50,24 +53,24 @@ extern "C" int _ZN3Amp13InitResourcesEv(char *c)
     bmd2 = *(BMD_File **)((char *)&data_ov070_02123604 + 4);
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*bmd2, data_ov070_021231f4);
 
-    if (!_ZN11ShadowModel12InitCylinderEv(c + 0x1b0))
+    if (!_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel))
         return 0;
 
-    if ((unsigned char)((*(unsigned int *)(c + 8) >> 1) & 1)) {
-        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_((Actor *)c, 0, 0x20d000, 0x1000000, 0xa28000);
+    if ((unsigned char)((unk_008 >> 1) & 1)) {
+        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_((Actor *)((char *)this), 0, 0x20d000, 0x1000000, 0xa28000);
     } else {
-        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_((Actor *)c, 0, 0x2c1000, 0x1000000, 0xa28000);
+        _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_((Actor *)((char *)this), 0, 0x2c1000, 0x1000000, 0xa28000);
     }
 
-    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c + 0x1d8, (Actor *)c, data_ov070_0212365c, 0x2d000, 0x50000, 0x200002, 0x8000);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x218, (Actor *)c, 0x2d000, 0x2d000, 0, 0);
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(((char *)this) + 0x1d8, (Actor *)((char *)this), data_ov070_0212365c, 0x2d000, 0x50000, 0x200002, 0x8000);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x218, (Actor *)((char *)this), 0x2d000, 0x2d000, 0, 0);
 
-    *(int *)(c + 0x9c) = 0;
-    *(int *)(c + 0xa0) = 0;
-    func_ov070_02120da8(c, 1);
+    unk_09c = 0;
+    unk_0a0 = 0;
+    func_ov070_02120da8(((char *)this), 1);
 
-    *(M48 *)(c + 0x3d4) = *(M48 *)&data_02082128;
+    *(M48 *)((char *)&unk_3d4) = *(M48 *)&data_02082128;
 
-    func_ov070_02120724(c);
+    func_ov070_02120724(((char *)this));
     return 1;
 }

--- a/src/_ZN3Amp6RenderEv.cpp
+++ b/src/_ZN3Amp6RenderEv.cpp
@@ -1,17 +1,22 @@
 //cpp
+// @symbol _ZN3Amp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Amp.h"
 struct Obj { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual int m5(int); };
 struct Obj2 { virtual void n0(); virtual void n1(); virtual void n2(); virtual void n3(); virtual void n4(); virtual int n5(void*); };
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void* a, void* b);
 extern int _ZN18TextureTransformer6UpdateER15ModelComponents(void* a, void* b);
-int _ZN3Amp6RenderEv(char* c){
-    ((Obj*)(c+0xd4))->m5(0);
-    int s = *(int*)(c+0x420);
+}
+
+int Amp::Render()
+{
+    ((Obj*)((char*)&mModelAnim))->m5(0);
+    int s = unk_420;
     if(s != 0 && s != 2){
-        _ZN15TextureSequence6UpdateER15ModelComponents(c+0x188, c+0x140);
-        _ZN18TextureTransformer6UpdateER15ModelComponents(c+0x19c, c+0x140);
-        ((Obj2*)(c+0x138))->n5(c+0x80);
+        _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x188, ((char*)this)+0x140);
+        _ZN18TextureTransformer6UpdateER15ModelComponents(((char*)this)+0x19c, ((char*)this)+0x140);
+        ((Obj2*)((char*)&mModel))->n5((char*)&unk_080);
     }
     return 1;
-}
 }

--- a/src/_ZN3Amp8BehaviorEv.cpp
+++ b/src/_ZN3Amp8BehaviorEv.cpp
@@ -1,21 +1,26 @@
 //cpp
+// @symbol _ZN3Amp8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Amp.h"
 extern "C" {
-extern void func_ov070_02120d34(void *c);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *self, void *v);
 extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void _ZN12CylinderClsn6UpdateEv(void *self);
 extern void func_ov070_02120724(void *c);
 extern int data_ov070_0212365c[];
-int _ZN3Amp8BehaviorEv(char *c)
+}
+
+int Amp::Behavior()
 {
     int *p;
-    func_ov070_02120d34(c);
-    p = (int *)(((int)c + 0x414) & 0xFFFFFFFFFFFFFFFF);
+    func_ov070_02120d34(((char *)this));
+    p = (int *)(((int)((char *)this) + 0x414) & 0xFFFFFFFFFFFFFFFF);
     *p += data_ov070_0212365c[1];
-    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1d8, c + 0x410);
-    _ZN12CylinderClsn5ClearEv(c + 0x1d8);
-    _ZN12CylinderClsn6UpdateEv(c + 0x1d8);
-    func_ov070_02120724(c);
+    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char *)this) + 0x1d8, ((char *)this) + 0x410);
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);
+    func_ov070_02120724(((char *)this));
     return 1;
-}
 }

--- a/src/_ZN3AmpD0Ev.c
+++ b/src/_ZN3AmpD0Ev.c
@@ -1,17 +1,20 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN3AmpD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daBrq_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18TextureTransformerD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN3AmpD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daBrq_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x218);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1d8);
     _ZN11ShadowModelD1Ev((char *)t + 0x1b0);

--- a/src/_ZN3Boo16CleanupResourcesEv.cpp
+++ b/src/_ZN3Boo16CleanupResourcesEv.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol _ZN3Boo16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Boo.h"
 struct Actor;
 extern "C" Actor *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern "C" void UnloadBlueCoinModel(void *o);
 struct SharedFilePtr;
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);
-extern "C" void UnloadKeyModels(int i);
 extern "C" void _ZN8CapEnemy14UnloadCapModelEv(void *self);
 
 extern SharedFilePtr data_ov063_0211edec;
@@ -30,43 +34,43 @@ struct O {
     unsigned char f5cf;       // +0x5cf
 };
 
-extern "C" int _ZN3Boo16CleanupResourcesEv(O *self)
+int Boo::CleanupResources()
 {
     int b;
     int *cnt;
 
-    if (self->f49c != 0) {
-        self->f48c = _ZN5Actor10FindWithIDEj(self->f49c);
-        if (self->f48c != 0)
-            _ZN9ActorBase18MarkForDestructionEv(self->f48c);
-        self->f48c = 0;
+    if (((O *)this)->f49c != 0) {
+        ((O *)this)->f48c = _ZN5Actor10FindWithIDEj(((O *)this)->f49c);
+        if (((O *)this)->f48c != 0)
+            _ZN9ActorBase18MarkForDestructionEv(((O *)this)->f48c);
+        ((O *)this)->f48c = 0;
     }
-    if (self->f494 != 0) {
-        self->f48c = _ZN5Actor10FindWithIDEj(self->f494);
-        if (self->f48c != 0) {
-            cnt = (int *)(((int)self->f48c + 0x5a0) & 0xFFFFFFFFFFFFFFFF);
+    if (((O *)this)->f494 != 0) {
+        ((O *)this)->f48c = _ZN5Actor10FindWithIDEj(((O *)this)->f494);
+        if (((O *)this)->f48c != 0) {
+            cnt = (int *)(((int)((O *)this)->f48c + 0x5a0) & 0xFFFFFFFFFFFFFFFF);
             (*cnt)++;
         }
-        self->f48c = 0;
+        ((O *)this)->f48c = 0;
     }
-    if (self->f4a0 == 0x122)
-        UnloadBlueCoinModel(self);
-    else if (self->f4a0 == 0xd4)
+    if (((O *)this)->f4a0 == 0x122)
+        UnloadBlueCoinModel(((O *)this));
+    else if (((O *)this)->f4a0 == 0xd4)
         _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edec);
 
-    b = (self->f0c == 0xd1);
+    b = (((O *)this)->f0c == 0xd1);
     if (b != 0) {
         _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edc4);
         _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211eddc);
     } else {
         _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edf4);
         _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211ede4);
-        if (self->f5cf == 0xf) {
+        if (((O *)this)->f5cf == 0xf) {
             UnloadKeyModels(3);
             _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edd4);
             _ZN13SharedFilePtr7ReleaseEv(&data_ov063_0211edcc);
         }
     }
-    _ZN8CapEnemy14UnloadCapModelEv(self);
+    _ZN8CapEnemy14UnloadCapModelEv(((O *)this));
     return 1;
 }

--- a/src/_ZN3Boo6RenderEv.cpp
+++ b/src/_ZN3Boo6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN3Boo6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Boo.h"
 struct Vector3;
 struct Model {
     virtual void f0(); virtual void f1(); virtual void f2();
@@ -11,42 +14,42 @@ extern "C" {
 void _ZN8CapEnemy14RenderCapModelEPK7Vector3(void *thiz, const void *v);
 void _ZN5Model12HideMaterialEii(void *thiz, int a, int b);
 void _ZN5Model6RenderEPK7Vector3(void *thiz, const void *v);
+}
 
-int _ZN3Boo6RenderEv(char *c)
+int Boo::Render()
 {
-    int b = (int)((*(int *)(c + 0xb0) & 0x40000) != 0);
+    int b = (int)((unk_0b0 & 0x40000) != 0);
     if (b != 0)
         return 1;
 
     {
-        Flags *f = (Flags *)(c + 0x5d4);
+        Flags *f = (Flags *)((char *)&unk_5d4);
         if (!f->b3)
             return 1;
         if (f->b1) {
-            ((Model *)(c + 0x3e4))->Render((const Vector3 *)(c + 0x510));
+            ((Model *)((char *)&mModel))->Render((const Vector3 *)((char *)&unk_510));
         }
-        _ZN8CapEnemy14RenderCapModelEPK7Vector3(c, 0);
+        _ZN8CapEnemy14RenderCapModelEPK7Vector3(((char *)this), 0);
     }
 
-    if (*(unsigned char *)(c + 0x5c8) < 8)
+    if (unk_5c8 < 8)
         return 1;
 
     {
-        unsigned char st = *(unsigned char *)(c + 0x5cf);
+        unsigned char st = unk_5cf;
         if (st >= 0xc && st != 0xf)
-            _ZN5Model12HideMaterialEii(c + 0x380, 0, 2);
+            _ZN5Model12HideMaterialEii(((char *)this) + 0x380, 0, 2);
     }
 
-    if (*(int *)(c + 0x10c) != 8 &&
-        (*(unsigned char *)(c + 0x5cc) == 3 ||
-         *(unsigned char *)(c + 0x5cc) == 3 ||
-         *(unsigned char *)(c + 0x5cc) == 3 ||
-         *(unsigned char *)(c + 0x5cc) == 3)) {
-        _ZN5Model6RenderEPK7Vector3(c + 0x380, c + 0x80);
+    if (unk_10c != 8 &&
+        (unk_5cc == 3 ||
+         unk_5cc == 3 ||
+         unk_5cc == 3 ||
+         unk_5cc == 3)) {
+        _ZN5Model6RenderEPK7Vector3(((char *)this) + 0x380, ((char *)this) + 0x80);
     } else {
-        ((Model *)(c + 0x380))->Render((const Vector3 *)(c + 0x80));
+        ((Model *)((char *)&mModelAnim))->Render((const Vector3 *)((char *)&unk_080));
     }
 
     return 1;
-}
 }

--- a/src/_ZN3BooD0Ev.c
+++ b/src/_ZN3BooD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN3BooD0Ev
+/* recovered: named members + shared header */
+#include "Boo.h"
 extern int _ZN11ShadowModelD1Ev();
 extern int _ZN5ModelD1Ev();
 extern int _ZN9ModelAnimD1Ev();
@@ -8,16 +11,15 @@ extern int _ZN6Memory10DeallocateEPvP4Heap();
 extern int _ZTV3Boo[];
 extern int *data_020a0eac;
 
-int *_ZN3BooD0Ev(int *t)
-{
-    *t = (int)_ZTV3Boo;
-    _ZN11ShadowModelD1Ev((char *)t + 0x45c);
-    _ZN11ShadowModelD1Ev((char *)t + 0x434);
-    _ZN5ModelD1Ev((char *)t + 0x3e4);
-    _ZN9ModelAnimD1Ev((char *)t + 0x380);
-    _ZN12WithMeshClsnD1Ev((char *)t + 0x1c4);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x184);
-    func_ov002_020aedbc(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
-    return t;
+int *_ZN3BooD0Ev(struct Boo *self) {
+    *((int *)self) = (int)_ZTV3Boo;
+    _ZN11ShadowModelD1Ev((char *)&self->mShadowModel2);
+    _ZN11ShadowModelD1Ev((char *)&self->mShadowModel1);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aedbc(((int *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((int *)self), data_020a0eac);
+    return ((int *)self);
 }

--- a/src/_ZN3BooD1Ev.c
+++ b/src/_ZN3BooD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN3BooD1Ev
+/* recovered: named members + shared header */
+#include "Boo.h"
 extern int _ZTV3Boo[];
 extern int _ZN11ShadowModelD1Ev(void*);
 extern int _ZN5ModelD1Ev(void*);
@@ -5,14 +8,14 @@ extern int _ZN9ModelAnimD1Ev(void*);
 extern int _ZN12WithMeshClsnD1Ev(void*);
 extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern int* func_ov002_020aedbc(int*);
-int _ZN3BooD1Ev(char* c){
-  *(int*)c=(int)_ZTV3Boo;
-  _ZN11ShadowModelD1Ev(c+0x45c);
-  _ZN11ShadowModelD1Ev(c+0x434);
-  _ZN5ModelD1Ev(c+0x3e4);
-  _ZN9ModelAnimD1Ev(c+0x380);
-  _ZN12WithMeshClsnD1Ev(c+0x1c4);
-  _ZN25MovingCylinderClsnWithPosD1Ev(c+0x184);
-  func_ov002_020aedbc((int*)c);
-  return (int)c;
+int _ZN3BooD1Ev(struct Boo *self) {
+  *(int*)((char*)self)=(int)_ZTV3Boo;
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel2);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel1);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  func_ov002_020aedbc((int*)((char*)self));
+  return (int)((char*)self);
 }

--- a/src/_ZN3Fog4InitEt5Fix12IiES1_.cpp
+++ b/src/_ZN3Fog4InitEt5Fix12IiES1_.cpp
@@ -1,20 +1,23 @@
 //cpp
-extern "C" void _ZN3Fog4InitEt5Fix12IiES1_(char* self, unsigned short color, int nearv, int farv) {
+// @symbol _ZN3Fog4InitEt5Fix12IiES1_
+/* recovered: named members + shared header */
+#include "Fog.h"
+extern "C" void _ZN3Fog4InitEt5Fix12IiES1_(struct Fog *self, unsigned short color, int nearv, int farv) {
     int dist;
     int step;
     int i;
     char* p;
 
-    *(unsigned char*)(self + 0x20) = 1;
+    self->unk_020 = 1;
     dist = 0x28000 - (nearv << 4);
-    *(unsigned short*)(self + 0x24) = color;
-    *(unsigned char*)(self + 0x21) = 6;
-    *(unsigned short*)(self + 0x22) = 0;
+    self->unk_024 = color;
+    self->unk_021 = 6;
+    self->unk_022 = 0;
     if (dist >= 0x80000)
         dist = 0x7ffff;
     step = (0x100000 - (farv << 4) - dist) >> 5;
     i = 0;
-    p = self;
+    p = ((char*)self);
     while (i < 0x20) {
         if (dist <= 0) {
             *p = 0;

--- a/src/_ZN3G2x13SetBlendAlphaEPVttttt.cpp
+++ b/src/_ZN3G2x13SetBlendAlphaEPVttttt.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN3G2x13SetBlendAlphaEPVttttt
+/* recovered: named members + shared header */
+#include "G2x.h"
 extern "C" void _ZN3G2x13SetBlendAlphaEPVttttt(
     volatile unsigned int *reg,
     unsigned short a, unsigned short b, unsigned short c,

--- a/src/_ZN3G2x18SetBlendBrightnessEPVtts.cpp
+++ b/src/_ZN3G2x18SetBlendBrightnessEPVtts.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN3G2x18SetBlendBrightnessEPVtts
+/* recovered: named members + shared header */
+#include "G2x.h"
 extern "C" void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short *p, unsigned short val, short amt);
 void _ZN3G2x18SetBlendBrightnessEPVtts(volatile unsigned short *p, unsigned short val, short amt)
 {

--- a/src/_ZN3HUD15RenderTimeTimerEv.cpp
+++ b/src/_ZN3HUD15RenderTimeTimerEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN3HUD15RenderTimeTimerEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Timer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HUD.h"
 // _ZN3HUD15RenderTimeTimerEv at 0x020fb96c (ov002)
 struct OamAttr;
 
@@ -13,12 +19,11 @@ extern struct OamAttr _ZN3OAM7MINUTESE;
 extern struct OamAttr data_ov002_0210c6c0;
 extern struct OamAttr* data_ov000_020aba70[];
 
-extern int GetOwnerLanguage(void);
-extern unsigned long long _ZN5Timer7GetTimeEv(void* thiz);
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int sub, struct OamAttr* attr, int x, int y, int a, int b, int sx, int sy, int c, int d);
 extern void _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(int sub, struct OamAttr* attr, int x, int y, int a, int b, void* m);
+}
 
-void _ZN3HUD15RenderTimeTimerEv(void* thisptr)
+void HUD::RenderTimeTimer()
 {
     unsigned long long t;
     unsigned long long min;
@@ -62,6 +67,4 @@ void _ZN3HUD15RenderTimeTimerEv(void* thisptr)
     _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, &data_ov002_0210c6c0, 0xdb, 0x1e, -1, 1, 0);
     _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[centi / 10], 0xe8, 0x16, -1, 1, 0);
     _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2(0, data_ov000_020aba70[centi % 10], 0xf0, 0x16, -1, 1, 0);
-}
-
 }

--- a/src/_ZN3HUD17RenderHealthMeterEv.cpp
+++ b/src/_ZN3HUD17RenderHealthMeterEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN3HUD17RenderHealthMeterEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HUD.h"
 // _ZN3HUD17RenderHealthMeterEv at 0x020fcfec
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 struct OamAttr;
@@ -12,43 +18,38 @@ extern unsigned char data_ov002_0211117c[];
 extern struct OamAttr* data_ov002_0210c254[];
 extern struct OamAttr* data_ov002_0210c278[];
 extern struct OamAttr* data_ov002_0210c230[];
-extern int data_ov002_0210c29c[];
 
 extern struct OamAttr data_ov002_0210d5d0;
 extern struct OamAttr data_ov002_0210d4f0;
 extern struct OamAttr data_ov002_0210c690;
 
-extern short data_ov002_0210c310[];
 
-extern int _ZN6Player16IsInsideOfCannonEv(void* thisptr);
-extern int GetOwnerLanguage(void);
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
     int a, struct OamAttr* attr, int x, int y, int e, int f, int g, int h, int i, int j);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
+}
 
-void _ZN3HUD17RenderHealthMeterEv(void* thisptr)
+void HUD::RenderHealthMeter()
 {
     if (_ZN6Player16IsInsideOfCannonEv(data_0209f394[data_0209f250[0]])) return;
 
     if (GetOwnerLanguage() == 5) {
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, data_ov002_0210c254[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, data_ov002_0210c254[data_ov002_0211117c[0]], 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, &data_ov002_0210d5d0, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, &data_ov002_0210d5d0, 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
     } else if (GetOwnerLanguage() == 4 || GetOwnerLanguage() == 2) {
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, data_ov002_0210c278[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, data_ov002_0210c278[data_ov002_0211117c[0]], 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, &data_ov002_0210d4f0, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, &data_ov002_0210d4f0, 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
     } else {
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, data_ov002_0210c230[data_ov002_0211117c[0]], 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, data_ov002_0210c230[data_ov002_0211117c[0]], 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
-            0, &data_ov002_0210c690, 0x80, *(short*)((char*)thisptr + 0x68), -1, 1, 0x1000, 0x1000, 0, -1);
+            0, &data_ov002_0210c690, 0x80, *(short*)((char*)&mHealthMeterY), -1, 1, 0x1000, 0x1000, 0, -1);
     }
 
     _ZN2GX11LoadOBJPlttEPKvjj(
         &data_ov002_0210c310[data_ov002_0210c29c[data_ov002_0211117c[0]]], 0x60, 0x20);
-}
-
 }

--- a/src/_ZN3HUD17UpdateHealthMeterEv.cpp
+++ b/src/_ZN3HUD17UpdateHealthMeterEv.cpp
@@ -1,61 +1,65 @@
 //cpp
+// @symbol _ZN3HUD17UpdateHealthMeterEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HUD.h"
 extern "C" {
 extern int _ZN5Event6GetBitEj(unsigned int bit);
 extern void func_02012790(int id);
 extern int _ZN6Player7IsInAirEv(void *p);
-extern void GiveLives(int n);
 
 extern unsigned char data_0209f250;
 extern unsigned char data_0209f2c4;
 extern unsigned char data_0209f20c;
 extern unsigned char data_0209f294;
-extern short data_02092144[];
 extern char *data_0209f394[];
 extern int data_0208ee44;
 extern unsigned char data_ov002_0211117c;
-extern unsigned char data_ov002_02111178;
+}
 
-void _ZN3HUD17UpdateHealthMeterEv(char *c) {
+void HUD::UpdateHealthMeter()
+{
     int chr = data_0209f250;
     char *player = data_0209f394[chr];
     unsigned int health = (data_02092144[chr] >> 8) & 0xff;
     if ((unsigned char)(data_0209f2c4 | data_0209f20c | data_0209f294) != 0)
         return;
-    if (*(unsigned short *)(c + 0x6a) != 0)
-        *(unsigned short *)((((int)c) + 0x6a) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
-    if (*(unsigned short *)(c + 0x6c) != 0)
-        *(unsigned short *)((((int)c) + 0x6c) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+    if (mHealthMeterHoldTimer != 0)
+        *(unsigned short *)((((int)((char *)this)) + 0x6a) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+    if (mHealthTickTimer != 0)
+        *(unsigned short *)((((int)((char *)this)) + 0x6c) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
     if (_ZN5Event6GetBitEj(0x1d)) {
-        unsigned char s = *(unsigned char *)(c + 0x73);
+        unsigned char s = mHealthMeterState;
         if (s != 0) {
             if (s < 5)
-                *(unsigned char *)(c + 0x73) = 5;
+                mHealthMeterState = 5;
         }
     }
-    switch (*(unsigned char *)(c + 0x73)) {
+    switch (mHealthMeterState) {
     case 0:
         if (*(unsigned char *)(player + 0x706) != 0) {
-            *(unsigned short *)(c + 0x68) = 0x39;
-            *(unsigned char *)(c + 0x73) = 1;
+            mHealthMeterY = 0x39;
+            mHealthMeterState = 1;
             return;
         }
         if (data_ov002_0211117c <= health)
             return;
-        *(unsigned short *)(c + 0x68) = 0x39;
+        mHealthMeterY = 0x39;
         data_ov002_0211117c = *(volatile unsigned char *)&data_ov002_0211117c - 1;
-        *(unsigned short *)(c + 0x6c) = 0x1e;
-        *(unsigned short *)(c + 0x6a) = 0x5a;
-        *(unsigned char *)(c + 0x73) = 1;
+        mHealthTickTimer = 0x1e;
+        mHealthMeterHoldTimer = 0x5a;
+        mHealthMeterState = 1;
         return;
     case 1:
-        if (*(unsigned short *)(c + 0x6a) == 0) {
-            if (*(short *)(c + 0x68) != 0x19) {
-                *(short *)((((int)c) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
-                if (*(short *)(c + 0x68) <= 0x19)
-                    *(short *)(c + 0x68) = 0x19;
+        if (mHealthMeterHoldTimer == 0) {
+            if (mHealthMeterY != 0x19) {
+                *(short *)((((int)((char *)this)) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
+                if (mHealthMeterY <= 0x19)
+                    mHealthMeterY = 0x19;
             }
         }
-        if (*(unsigned short *)(c + 0x6c) != 0)
+        if (mHealthTickTimer != 0)
             return;
         {
             unsigned char cur = data_ov002_0211117c;
@@ -63,7 +67,7 @@ void _ZN3HUD17UpdateHealthMeterEv(char *c) {
                 if ((int)(health - cur) > 1) {
                     data_ov002_0211117c = cur + 1;
                     func_02012790(0xd);
-                    *(unsigned short *)(c + 0x6c) = 0x10;
+                    mHealthTickTimer = 0x10;
                     return;
                 }
                 data_ov002_0211117c = health;
@@ -74,16 +78,16 @@ void _ZN3HUD17UpdateHealthMeterEv(char *c) {
                     return;
                 if (data_ov002_02111178 == 1) {
                     data_ov002_02111178 = 3;
-                    *(unsigned char *)(c + 0x73) = 2;
+                    mHealthMeterState = 2;
                 } else {
-                    *(unsigned short *)(c + 0x6a) = 0x3c;
-                    *(unsigned char *)(c + 0x73) = 4;
+                    mHealthMeterHoldTimer = 0x3c;
+                    mHealthMeterState = 4;
                 }
                 return;
             }
             if (cur > health) {
                 data_ov002_0211117c = cur - 1;
-                *(unsigned short *)(c + 0x6c) = 0x1e;
+                mHealthTickTimer = 0x1e;
                 return;
             }
             if (cur != 8)
@@ -94,45 +98,44 @@ void _ZN3HUD17UpdateHealthMeterEv(char *c) {
                 return;
             if (data_ov002_02111178 == 1) {
                 data_ov002_02111178 = 3;
-                *(unsigned char *)(c + 0x73) = 2;
+                mHealthMeterState = 2;
             } else {
-                *(unsigned short *)(c + 0x6a) = 0x3c;
-                *(unsigned char *)(c + 0x73) = 4;
+                mHealthMeterHoldTimer = 0x3c;
+                mHealthMeterState = 4;
             }
         }
         return;
     case 2:
         if (data_ov002_02111178 == 4) {
-            *(unsigned short *)(c + 0x6a) = 0x3c;
-            *(unsigned char *)(c + 0x73) = 3;
+            mHealthMeterHoldTimer = 0x3c;
+            mHealthMeterState = 3;
         }
         return;
     case 3:
-        if (*(unsigned short *)(c + 0x6a) != 0)
+        if (mHealthMeterHoldTimer != 0)
             return;
         GiveLives(-1);
         func_02012790(0x40);
         data_ov002_02111178 = 5;
-        *(unsigned short *)(c + 0x6a) = 0x3c;
-        *(unsigned char *)(c + 0x73) = 4;
+        mHealthMeterHoldTimer = 0x3c;
+        mHealthMeterState = 4;
         return;
     case 4:
     case 5:
-        if (*(unsigned short *)(c + 0x6a) != 0)
+        if (mHealthMeterHoldTimer != 0)
             return;
-        *(short *)((((int)c) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
-        if (*(short *)(c + 0x68) >= -0x18)
+        *(short *)((((int)((char *)this)) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
+        if (mHealthMeterY >= -0x18)
             return;
-        *(short *)(c + 0x68) = -0x18;
-        if (*(unsigned char *)(c + 0x73) == 4)
-            *(unsigned char *)(c + 0x73) = 0;
+        mHealthMeterY = -0x18;
+        if (mHealthMeterState == 4)
+            mHealthMeterState = 0;
         else
-            *(unsigned char *)(c + 0x73) = 6;
+            mHealthMeterState = 6;
         return;
     case 6:
         if (_ZN5Event6GetBitEj(0x1d) == 0)
-            *(unsigned char *)(c + 0x73) = 1;
+            mHealthMeterState = 1;
         return;
     }
-}
 }

--- a/src/_ZN3HUD6RenderEv.cpp
+++ b/src/_ZN3HUD6RenderEv.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN3HUD6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HUD.h"
 // _ZN3HUD6RenderEv at 0x020fd5e0
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 extern unsigned char data_0209f2d8;
-extern unsigned char data_0209fc9c;
 extern unsigned char data_0209f2c4;
 extern unsigned char data_0209f20c;
 extern unsigned char data_0209f294;
@@ -23,39 +27,41 @@ void _ZN3HUD17RenderSilverStarsEv(void *);
 void _ZN3HUD15RenderTimeTimerEv(void *);
 void _ZN5Stage20RenderBouncingArrowsEv(void);
 void _ZN3HUD15RenderLifeCountEv(void *);
+}
 
-int _ZN3HUD6RenderEv(void *self) {
+int HUD::Render()
+{
     int b = (data_0209f2d8 == 1);
     if (b) {
         if (data_0209fc9c != 0) goto end;
         if (((data_0209f2c4 | data_0209f20c | data_0209f294) & 0xff) == 0) {
-            _ZN3HUD13RenderVsTimerEv(self);
-            _ZN3HUD15RenderStarCountEv(self);
-            _ZN3HUD15RenderCoinCountEv(self);
-            _ZN3HUD19RenderCameraButtonsEv(self);
+            _ZN3HUD13RenderVsTimerEv(((void *)this));
+            _ZN3HUD15RenderStarCountEv(((void *)this));
+            _ZN3HUD15RenderCoinCountEv(((void *)this));
+            _ZN3HUD19RenderCameraButtonsEv(((void *)this));
         } else {
             if (data_0209f204 != 0) {
-                _ZN3HUD13RenderVsTimerEv(self);
+                _ZN3HUD13RenderVsTimerEv(((void *)this));
             }
         }
     } else {
         if ((data_0209caa0[2] & 0x80) == 0) goto end;
         unsigned char v = data_0209f20c;
         if (((data_0209f2c4 | v | data_0209f294) & 0xff) == 0) {
-            _ZN3HUD17RenderHealthMeterEv(self);
+            _ZN3HUD17RenderHealthMeterEv(((void *)this));
             if (_ZN5Event6GetBitEj(0x1d) == 0) {
-                _ZN3HUD15RenderCoinCountEv(self);
-                _ZN3HUD14RenderRedCoinsEv(self);
-                _ZN3HUD17RenderSilverStarsEv(self);
-                _ZN3HUD15RenderTimeTimerEv(self);
+                _ZN3HUD15RenderCoinCountEv(((void *)this));
+                _ZN3HUD14RenderRedCoinsEv(((void *)this));
+                _ZN3HUD17RenderSilverStarsEv(((void *)this));
+                _ZN3HUD15RenderTimeTimerEv(((void *)this));
             }
             if (data_0209f284 != 0) {
                 _ZN5Stage20RenderBouncingArrowsEv();
             }
         } else {
             if (v != 0) {
-                _ZN3HUD15RenderLifeCountEv(self);
-                _ZN3HUD15RenderStarCountEv(self);
+                _ZN3HUD15RenderLifeCountEv(((void *)this));
+                _ZN3HUD15RenderStarCountEv(((void *)this));
             }
         }
         unsigned char v2 = data_0209f20c;
@@ -63,11 +69,10 @@ int _ZN3HUD6RenderEv(void *self) {
             if (v2 == 0) goto end;
             if (data_0209f2d4 >= 3) goto end;
         }
-        _ZN3HUD15RenderStarCountEv(self);
-        _ZN3HUD19RenderCameraButtonsEv(self);
-        _ZN3HUD15RenderLifeCountEv(self);
+        _ZN3HUD15RenderStarCountEv(((void *)this));
+        _ZN3HUD19RenderCameraButtonsEv(((void *)this));
+        _ZN3HUD15RenderLifeCountEv(((void *)this));
     }
 end:
     return 1;
-}
 }

--- a/src/_ZN3HUDC1Ev.c
+++ b/src/_ZN3HUDC1Ev.c
@@ -1,14 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
+// @symbol _ZN3HUDC1Ev
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7dBase_c; VT1 = _ZTV8dMeter_c */
 extern void _ZN9ActorBaseC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN3HUDC1Ev(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(124);
     if (p) {
         _ZN9ActorBaseC1Ev(p);
-        p[0] = (int)VT0;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV7dBase_c;
+        p[0] = (int)_ZTV8dMeter_c;
     }
     return p;
 }

--- a/src/_ZN3HUDD0Ev.c
+++ b/src/_ZN3HUDD0Ev.c
@@ -1,12 +1,14 @@
+// @symbol _ZN3HUDD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8dMeter_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *_ZN3HUDD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8dMeter_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);
     return t;

--- a/src/_ZN3HUDD1Ev.c
+++ b/src/_ZN3HUDD1Ev.c
@@ -1,10 +1,13 @@
+// @symbol _ZN3HUDD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8dMeter_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN3HUDD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV8dMeter_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/_ZN3Key6RenderEv.cpp
+++ b/src/_ZN3Key6RenderEv.cpp
@@ -1,20 +1,23 @@
 //cpp
+// @symbol _ZN3Key6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Key.h"
 extern "C" {
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void*); };
 extern char data_ov089_021328b4[];
+}
 
-int _ZN3Key6RenderEv(char* c)
+int Key::Render()
 {
-  int b = (int)((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
+  int b = (int)((unk_0b0 & 0x40000) != 0);
   if (b) return 1;
-  if (*(int*)(c+0x448) != 0) {
-    ((Sub*)(c+0x114))->m(0);
+  if (unk_448 != 0) {
+    ((Sub*)((char*)&mModelAnim))->m(0);
   } else {
-    ((Sub*)(c+0x114))->m(c+0x80);
-    if (*(int*)((char*)data_ov089_021328b4 + (*(int*)(c+0x444) << 2)) != 0 && *(int*)(c+0x448) == 0) {
-      ((Sub*)(c+0x178))->m(0);
+    ((Sub*)((char*)&mModelAnim))->m((char*)&mScaleX);
+    if (*(int*)((char*)data_ov089_021328b4 + (mState << 2)) != 0 && unk_448 == 0) {
+      ((Sub*)((char*)&mModel))->m(0);
     }
   }
   return 1;
-}
 }

--- a/src/_ZN3Key8BehaviorEv.cpp
+++ b/src/_ZN3Key8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN3Key8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Key.h"
 typedef void (*VoidFn)();
 
 extern "C" {
@@ -11,7 +16,6 @@ extern void Vec3_LslInPlace(void* v, int sh);
 extern void AddVec3(void* d, void* a, void* b);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int x, int y, int z, const void* v, void* cb);
 extern void _ZN9Animation7AdvanceEv(void* a);
-extern void func_ov089_02131f54(void* c);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void* c, void* w);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
@@ -25,40 +29,40 @@ extern int data_ov089_02132b40[];
 extern int data_ov089_02132ca4[];
 }
 
-#define LAUNDER(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LAUNDER(p) ((long long)(int)(p))
 struct C { virtual void dummy(); };
 typedef void (C::*PMF)();
 struct PmfEntry { PMF pmf; };
 extern PmfEntry data_ov089_02132cec[];
 #define PMFTABLE data_ov089_02132cec
 
-extern "C" int _ZN3Key8BehaviorEv(char* c)
+int Key::Behavior()
 {
     int vec[3];
     int p7[3];
     int pe[3];
-    int v = *(int*)(c + 0x448);
+    int v = unk_448;
 
     if (v != 0) {
         if (v == 3) {
             {
-                char* o = *(char**)(c + 0x110);
+                char* o = *(char**)((char*)&unk_110);
                 if (o != 0) {
                     int* s = (int*)(int)LAUNDER(o + 0x5c);
-                    *(int*)(c + 0x5c) = s[0];
-                    *(int*)(c + 0x60) = s[1];
-                    *(int*)(c + 0x64) = s[2];
+                    mPosX = s[0];
+                    mPosY = s[1];
+                    mPosZ = s[2];
                     {
-                        char* o2 = *(char**)(c + 0x110);
+                        char* o2 = *(char**)((char*)&unk_110);
                         int ang = *(short*)(o2 + 0x8e);
-                        *(short*)(c + 0x8e) = ang;
+                        unk_08e = ang;
                     }
                 }
             }
-            if (_ZN9Animation8FinishedEv(c + 0x164) == 0) {
-                Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
-                Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c + 0x8e));
-                MulMat4x3Mat4x3(*(void**)(c + 0x128), &data_020a0e68, &data_020a0e68);
+            if (_ZN9Animation8FinishedEv((char*)&mAnimation) == 0) {
+                Matrix4x3_FromTranslation(&data_020a0e68, mPosX, mPosY, mPosZ);
+                Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, unk_08e);
+                MulMat4x3Mat4x3(*(void**)((char*)&unk_128), &data_020a0e68, &data_020a0e68);
                 {
                     char* m = &data_020a0e68;
                     int t0 = *(int*)(m + 0x24);
@@ -68,59 +72,59 @@ extern "C" int _ZN3Key8BehaviorEv(char* c)
                     vec[0] = t0;
                     vec[1] = t1;
                 }
-                SubVec3(vec, c + 0x5c, vec);
+                SubVec3(vec, ((char*)this) + 0x5c, vec);
                 Vec3_LslInPlace(vec, 3);
-                AddVec3(vec, c + 0x5c, vec);
-                vec[1] = *(int*)(*(char**)(c + 0x124) + 0xc) * 0x23 + vec[1];
+                AddVec3(vec, ((char*)this) + 0x5c, vec);
+                vec[1] = *(int*)(*(char**)((char*)&unk_124) + 0xc) * 0x23 + vec[1];
                 vec[1] = vec[1] - 0x48000;
-                *(void**)(c + 0x464) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(unsigned int*)(c + 0x464), 0x82, vec[0], vec[1], vec[2], 0, 0);
-                *(void**)(c + 0x468) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(unsigned int*)(c + 0x468), 0x83, vec[0], vec[1], vec[2], 0, 0);
+                *(void**)((char*)&unk_464) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unk_464, 0x82, vec[0], vec[1], vec[2], 0, 0);
+                *(void**)((char*)&unk_468) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unk_468, 0x83, vec[0], vec[1], vec[2], 0, 0);
             }
         }
 
-        _ZN9Animation7AdvanceEv(c + 0x164);
-        func_ov089_02131f54(c);
-        if (_ZN9Animation8FinishedEv(c + 0x164)) {
-            int b = (*(unsigned short*)(c + 0xc) == 0x11a);
+        _ZN9Animation7AdvanceEv((char*)&mAnimation);
+        func_ov089_02131f54(((char*)this));
+        if (_ZN9Animation8FinishedEv((char*)&mAnimation)) {
+            int b = (mActorID == 0x11a);
             if (b != 0) {
-                if (*(int*)(c + 0x174) != data_ov089_02132c40[1])
-                    _ZN9ActorBase18MarkForDestructionEv(c);
+                if (unk_174 != data_ov089_02132c40[1])
+                    _ZN9ActorBase18MarkForDestructionEv(((char*)this));
             }
         }
         return 1;
     }
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x260)) {
-        func_ov089_02131f54(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x220);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char*)this), ((char*)this) + 0x260)) {
+        func_ov089_02131f54(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
         return 1;
     }
-    *(int*)(c + 0xd0) = 0;
-    if (*(short*)(c + 0x440) > 0x400) {
-        short* q = (short*)(int)LAUNDER(c + 0x440);
+    mEatingPlayer = 0;
+    if (mSpinSpeed > 0x400) {
+        short* q = (short*)(int)LAUNDER((char*)&mSpinSpeed);
         *q = *q - 0x100;
-    } else if (*(short*)(c + 0x440) == 0) {
-        *(short*)(c + 0x440) = 0x400;
+    } else if (mSpinSpeed == 0) {
+        mSpinSpeed = 0x400;
     }
     {
-        short* ang = (short*)(int)LAUNDER(c + 0x8e);
-        *ang = *ang + *(short*)(c + 0x440);
+        short* ang = (short*)(int)LAUNDER((char*)&unk_08e);
+        *ang = *ang + mSpinSpeed;
     }
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-    (((C*)c)->*PMFTABLE[*(int*)(c + 0x444)].pmf)();
-    func_ov089_02131f54(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x220);
-    if (*(int*)(c + 0x444) == 7) {
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), 0);
+    (((C*)((char*)this))->*PMFTABLE[mState].pmf)();
+    func_ov089_02131f54(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+    if (mState == 7) {
         p7[0] = data_ov089_02132b40[0];
         p7[1] = data_ov089_02132b40[1];
         p7[2] = data_ov089_02132b40[2];
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x220, p7);
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0x220, p7);
     } else {
         pe[0] = data_ov089_02132ca4[0];
         pe[1] = data_ov089_02132ca4[1];
         pe[2] = data_ov089_02132ca4[2];
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x220, pe);
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0x220, pe);
     }
-    _ZN12CylinderClsn6UpdateEv(c + 0x220);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
     return 1;
 }

--- a/src/_ZN3KeyD0Ev.c
+++ b/src/_ZN3KeyD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN3KeyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daObjKey_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN3KeyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daObjKey_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x260);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x220);
     _ZN11ShadowModelD1Ev((char *)t + 0x1c8);

--- a/src/_ZN3KeyD1Ev.c
+++ b/src/_ZN3KeyD1Ev.c
@@ -1,13 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN3KeyD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV3Key */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN3KeyD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV3Key;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x260);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x220);
     _ZN11ShadowModelD1Ev((char *)t + 0x1c8);

--- a/src/_ZN3MrI6RenderEv.cpp
+++ b/src/_ZN3MrI6RenderEv.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol _ZN3MrI6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MrI.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN3MrI6RenderEv(char* c){
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x138, c+0xdc);
-  ((Sub*)(c+0xd4))->g5(c+0x80);
+
+int MrI::Render()
+{
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x138, ((char*)this)+0xdc);
+  ((Sub*)((char*)&mModelAnim))->g5((char*)&mScaleX);
   return 1;
-}
 }

--- a/src/_ZN3MrI8BehaviorEv.cpp
+++ b/src/_ZN3MrI8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN3MrI8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "MrI.h"
 extern "C" {
     void func_ov071_021215c0(void *c);
     void func_0200f760(void *c, void *p);
@@ -10,12 +13,13 @@ struct CylinderClsn {
     void Update();
 };
 
-extern "C" int _ZN3MrI8BehaviorEv(char *c) {
-    func_ov071_021215c0(c);
-    func_0200f760(c, c + 0x174);
-    *(short*)(c + 0x20c) = *(short*)(c + 0x8e);
-    ((CylinderClsn*)(c + 0x174))->Clear();
-    ((CylinderClsn*)(c + 0x174))->Update();
-    func_ov071_02120c90(c);
+int MrI::Behavior()
+{
+    func_ov071_021215c0(((char *)this));
+    func_0200f760(((char *)this), ((char *)this) + 0x174);
+    unk_20c = unk_08e;
+    ((CylinderClsn*)((char *)&mMovingCylinderClsnWithPos))->Clear();
+    ((CylinderClsn*)((char *)&mMovingCylinderClsnWithPos))->Update();
+    func_ov071_02120c90(((char *)this));
     return 1;
 }

--- a/src/_ZN3MrID0Ev.c
+++ b/src/_ZN3MrID0Ev.c
@@ -1,14 +1,17 @@
+// @symbol _ZN3MrID0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daEykn_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN3MrID0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daEykn_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x174);
     _ZN11ShadowModelD1Ev((char *)t + 0x14c);
     _ZN15TextureSequenceD1Ev((char *)t + 0x138);

--- a/src/_ZN3OAM11GetObjWidthEii.c
+++ b/src/_ZN3OAM11GetObjWidthEii.c
@@ -1,4 +1,8 @@
-extern unsigned char data_020755a0[];
+// @symbol _ZN3OAM11GetObjWidthEii
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "OAM.h"
 unsigned char _ZN3OAM11GetObjWidthEii(int a, int b){
   return *(unsigned char*)&((int*)((char*)data_020755a0 + b))[a];
 }

--- a/src/_ZN3OAM12GetObjHeightEii.c
+++ b/src/_ZN3OAM12GetObjHeightEii.c
@@ -1,4 +1,8 @@
-extern unsigned char data_020755ac[];
+// @symbol _ZN3OAM12GetObjHeightEii
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "OAM.h"
 unsigned char _ZN3OAM12GetObjHeightEii(int a, int b){
   return *(unsigned char*)&((int*)((char*)data_020755ac + b))[a];
 }

--- a/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
+++ b/src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c
@@ -1,3 +1,6 @@
+// @symbol _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2
+/* recovered: named members + shared header */
+#include "OAM.h"
 struct OamAttr { unsigned short a, b, c, param; };
 
 #pragma opt_strength_reduction off

--- a/src/_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c
+++ b/src/_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c
@@ -1,3 +1,9 @@
+// @symbol _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_OAM.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "OAM.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -12,15 +18,9 @@ typedef struct OamAttr {
 #define ATTR01(o) (*(u32 *)(o))
 typedef struct Matrix2x2 { s32 m00, m01, m10, m11; } Matrix2x2;
 
-extern int _ZN3OAM11GetObjWidthEii(int shape, int size);
-extern int _ZN3OAM12GetObjHeightEii(int shape, int size);
 extern int _ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2(OamAttr *attr, int *count, Matrix2x2 *mtx);
 
 extern u8 data_0209e660;
-extern int data_0209e664;
-extern int data_0209e668;
-extern int data_0209e66c;
-extern int data_0209e670;
 extern OamAttr data_0209e674[];
 extern OamAttr data_0209ea74[];
 

--- a/src/_ZN3OAM9RenderSubEP7OamAttrii.c
+++ b/src/_ZN3OAM9RenderSubEP7OamAttrii.c
@@ -1,3 +1,6 @@
+// @symbol _ZN3OAM9RenderSubEP7OamAttrii
+/* recovered: named members + shared header */
+#include "OAM.h"
 /* _ZN3OAM9RenderSubEP7OamAttrii at 0x0202194c, size=0x50
  * OAM::RenderSub(OamAttri* data, s32 x, s32 y) -
  * Calls OAM::Render(true, data, x, y, -1, -1, 0x1000, 0x1000, 0, -1).

--- a/src/_ZN3OAM9RenderSubEP7OamAttriiii.c
+++ b/src/_ZN3OAM9RenderSubEP7OamAttriiii.c
@@ -1,3 +1,6 @@
+// @symbol _ZN3OAM9RenderSubEP7OamAttriiii
+/* recovered: named members + shared header */
+#include "OAM.h"
 /* _ZN3OAM9RenderSubEP7OamAttriiii at 0x0202199c, size=0x54
  * OAM::RenderSub(OamAttri* data, s32 x, s32 y, s32 palette, s32 priority) -
  * Calls OAM::Render(true, data, x, y, palette, priority, 0x1000, 0x1000, 0, -1).

--- a/src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c
+++ b/src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c
@@ -1,18 +1,14 @@
+// @symbol _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "BgCh.h"
 /* _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b at 0x02039488
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
 extern int func_02037e78(int *p);
-extern int func_0203547c(unsigned char *p);
-extern int func_02037e20(int *p);
-extern int func_0203543c(unsigned char *p);
-extern int func_02037e2c(int *p);
-extern int func_0203545c(unsigned char *p);
-extern int func_02037e14(int *p);
 extern int func_02037e38(int *p);
-extern int func_02035408(unsigned char *p);
-extern int func_020353d4(unsigned char *p);
-extern int func_020354b0(unsigned char *p);
 
 int _ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b(void *p, int *clps, unsigned char *bg, int flag)
 {

--- a/src/_ZN4Bird13InitResourcesEv.cpp
+++ b/src/_ZN4Bird13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN4Bird13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Bird.h"
 extern "C" {
 struct SharedFilePtr; struct BMD_File; struct BCA_File;
 void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
@@ -6,29 +11,28 @@ void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 void* _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*, void*, int, int, unsigned int);
 void _ZN11ShadowModel12InitCylinderEv(void*);
-extern char data_ov009_02113c20[];
-extern char data_ov009_02113c28[];
+}
 
-int _ZN4Bird13InitResourcesEv(char* self){
+int Bird::InitResources()
+{
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov009_02113c20);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self+0xd4, m, 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, 1);
     void* a = _ZN9Animation8LoadFileER13SharedFilePtr(data_ov009_02113c28);
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self+0xd4, a, 0, 0x1000, 0);
-    _ZN11ShadowModel12InitCylinderEv(self+0x138);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this)+0xd4, a, 0, 0x1000, 0);
+    _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
     {
-        int *p60 = (int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p60 = (int *)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
         int y = *p60;
         int zero = 0;
         *p60 = y + 0xa000;
-        *(int*)(self+0x9c) = zero;
-        *(int*)(self+0xa0) = -0x32000;
-        *(unsigned char*)(self+0x180) = 1;
-        *(int*)(self+0x178) = *(int*)(self+0x4);
-        *(int*)(self+0x160) = *(int*)(self+0x5c);
-        *(int*)(self+0x164) = *(int*)(self+0x60);
-        *(int*)(self+0x168) = *(int*)(self+0x64);
-        *(int*)(self+0x17c) = zero;
+        unk_09c = zero;
+        unk_0a0 = -0x32000;
+        unk_180 = 1;
+        unk_178 = unk_004;
+        unk_160 = mPosX;
+        unk_164 = mPosY;
+        unk_168 = mPosZ;
+        unk_17c = zero;
     }
     return 1;
-}
 }

--- a/src/_ZN4Bird6RenderEv.cpp
+++ b/src/_ZN4Bird6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN4Bird6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bird.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN4Bird6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Bird::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN4Bird8BehaviorEv.cpp
+++ b/src/_ZN4Bird8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4Bird8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bird.h"
 extern "C" {
 extern void Vec3_Asr(void* dst, void* src, int n);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
@@ -10,10 +13,13 @@ struct PMF { int fn; int ptr; };
 struct Mtx { int w[12]; };
 extern struct PMF data_ov036_02113c48[];
 extern struct Mtx data_020a0e68;
-int _ZN4Bird8BehaviorEv(char* c){
-  int idx = *(int*)(c+0x17c);
+}
+
+int Bird::Behavior()
+{
+  int idx = unk_17c;
   struct PMF* m = &data_ov036_02113c48[idx];
-  char* obj = c + (m->ptr >> 1);
+  char* obj = ((char*)this) + (m->ptr >> 1);
   int p = m->ptr;
   void (*f)(void*);
   if(p & 1){
@@ -23,14 +29,13 @@ int _ZN4Bird8BehaviorEv(char* c){
   }
   f(obj);
   int tmp[3];
-  Vec3_Asr(tmp, c+0x5c, 3);
+  Vec3_Asr(tmp, ((char*)this)+0x5c, 3);
   Matrix4x3_FromTranslation(&data_020a0e68, tmp[0], tmp[1], tmp[2]);
-  *(short*)(c+0x8e) = *(short*)(c+0x94);
-  Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-  Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
-  *(struct Mtx*)(c+0xf0) = data_020a0e68;
-  _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x138, c+0xf0, 0x1e000, 0x7d0000, 0xf);
-  _ZN9Animation7AdvanceEv(c+0x124);
+  unk_08e = unk_094;
+  Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, unk_090);
+  Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, unk_08e);
+  *(struct Mtx*)((char*)&unk_0f0) = data_020a0e68;
+  _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(((char*)this), ((char*)this)+0x138, ((char*)this)+0xf0, 0x1e000, 0x7d0000, 0xf);
+  _ZN9Animation7AdvanceEv((char*)&mAnimation);
   return 1;
-}
 }

--- a/src/_ZN4BirdD0Ev.c
+++ b/src/_ZN4BirdD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4BirdD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daSBird_c */
 extern void *G0;
 int *_ZN4BirdD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daSBird_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x138);
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN4Clam13InitResourcesEv.cpp
+++ b/src/_ZN4Clam13InitResourcesEv.cpp
@@ -1,23 +1,27 @@
 //cpp
+// @symbol _ZN4Clam13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Clam.h"
 typedef int Fix12i;
 extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* mb, void* f, int a, int b);
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* ma, void* f, int b, Fix12i c, unsigned int d);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* mc, char* a, Fix12i r, Fix12i h, unsigned int f1, unsigned int f2);
-extern "C" void func_ov064_0211a9b4(char* t);
 extern int data_ov064_0211c9cc[];
 extern int data_ov064_0211c9bc[];
-extern int data_ov064_0211c9c4[];
 
-extern "C" int _ZN4Clam13InitResourcesEv(char* c){
+int Clam::InitResources()
+{
   _ZN9Animation8LoadFileER13SharedFilePtr(data_ov064_0211c9cc);
   _ZN9Animation8LoadFileER13SharedFilePtr(data_ov064_0211c9bc);
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov064_0211c9c4);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov064_0211c9bc[1], 0x40000000, 0x1000, 0);
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x138, c, 0x64000, 0x64000, 0x200004, 0);
-  func_ov064_0211a9b4(c);
-  *(unsigned char*)(c+0x16c) = 0;
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, -1);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this)+0xd4, (void*)data_ov064_0211c9bc[1], 0x40000000, 0x1000, 0);
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x138, ((char*)this), 0x64000, 0x64000, 0x200004, 0);
+  func_ov064_0211a9b4(((char*)this));
+  unk_16c = 0;
   return 1;
 }

--- a/src/_ZN4Clam6RenderEv.cpp
+++ b/src/_ZN4Clam6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN4Clam6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Clam.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN4Clam6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Clam::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN4ClamD0Ev.c
+++ b/src/_ZN4ClamD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4ClamD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daObjShell_c */
 extern void *G0;
 int *_ZN4ClamD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daObjShell_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x138);
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN4Coin6RenderEv.cpp
+++ b/src/_ZN4Coin6RenderEv.cpp
@@ -1,20 +1,25 @@
 //cpp
+// @symbol _ZN4Coin6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Coin.h"
 extern "C" int _ZN11CommonModel6RenderEPK7Vector3(void*, void*);
 struct Flags { unsigned char b0:1; };
-extern "C" int _ZN4Coin6RenderEv(char* c){
+
+int Coin::Render()
+{
   int f;
   int b;
-  if (!((struct Flags*)(c+0x3ae))->b0) return 1;
-  f = *(int*)(c+0xb0);
+  if (!((struct Flags*)((char*)&unk_3ae))->b0) return 1;
+  f = unk_0b0;
   b = (f & 0x40000) != 0;
   if (b) return 1;
   {
-    unsigned short x = *(unsigned short*)(c+0x3a8);
+    unsigned short x = unk_3a8;
     if (x < 0x2d && (x & 1)) return 1;
   }
   if (!(f & 0x10))
-    _ZN11CommonModel6RenderEPK7Vector3(c+0xd8, 0);
+    _ZN11CommonModel6RenderEPK7Vector3(((char*)this)+0xd8, 0);
   else
-    _ZN11CommonModel6RenderEPK7Vector3(c+0x114, 0);
+    _ZN11CommonModel6RenderEPK7Vector3(((char*)this)+0x114, 0);
   return 1;
 }

--- a/src/_ZN4Coin8BehaviorEv.cpp
+++ b/src/_ZN4Coin8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN4Coin8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Coin.h"
 /* _ZN4Coin8BehaviorEv @ 0x020b2324 (ov002, size 0x1e4)
  * Coin main behavior: pickup-flag sound, magnet flag, physics helpers,
  * state PMF-table dispatch, collision clear/update paths.
@@ -11,50 +16,45 @@ extern unsigned char data_0209f2d8;
 
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, char *pos);
-extern int func_ov002_020b10a0(char *c);
-extern int func_ov002_020b12ec(char *c);
-extern void func_ov002_020b14d8(char *c);
 extern void _ZN12CylinderClsn5ClearEv(char *c);
-extern void func_ov002_020b10e4(char *c);
-extern int func_ov002_020b19dc(char *c);
 extern int LenVec3(char *v);
 extern void _ZN12CylinderClsn6UpdateEv(char *c);
+}
 
-int _ZN4Coin8BehaviorEv(char *c)
+int Coin::Behavior()
 {
-    if ((unsigned int)(*(unsigned char *)(c + 0x3ae) << 0x1e) >> 0x1f) {
-        *(unsigned char *)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFF) &= ~2;
-        _ZN5Sound9PlayBank3EjRK7Vector3(0x30, c + 0x74);
+    if ((unsigned int)(unk_3ae << 0x1e) >> 0x1f) {
+        *(unsigned char *)(((int)((char *)this) + 0x3ae) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+        _ZN5Sound9PlayBank3EjRK7Vector3(0x30, ((char *)this) + 0x74);
     }
-    if ((int)(*(unsigned short *)(c + 0xc) == 0x122) != 0) {
-        if ((unsigned int)(*(unsigned char *)(c + 0x3ae) << 0x1f) >> 0x1f)
-            *(char *)(c + 0xcc) = -1;
+    if ((int)(mActorID == 0x122) != 0) {
+        if ((unsigned int)(unk_3ae << 0x1f) >> 0x1f)
+            mAreaId = -1;
     }
-    if (func_ov002_020b10a0(c) != 0) return 1;
-    *(short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0xc00;
-    if (func_ov002_020b12ec(c) != 0) {
-        func_ov002_020b14d8(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x178);
+    if (func_ov002_020b10a0(((char *)this)) != 0) return 1;
+    *(short *)(((int)((char *)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0xc00;
+    if (func_ov002_020b12ec(((char *)this)) != 0) {
+        func_ov002_020b14d8(((char *)this));
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
         return 1;
     }
-    func_ov002_020b10e4(c);
-    *(int *)(c + 0xd0) = 0;
-    if (func_ov002_020b19dc(c) != 0) return 1;
-    (((C *)c)->*data_ov002_0210dc70[*(int *)(c + 0x3a4)])();
-    if ((int)(data_0209f2d8 == 1) == 0 && (int)((*(int *)(c + 0xb0) & 8) != 0) != 0) {
-        _ZN12CylinderClsn5ClearEv(c + 0x178);
-        if (*(unsigned char *)(c + 0x3aa) == 0 && LenVec3(c + 0x74) < 0x64000) {
-            if (*(int *)(c + 0x3a0) != 1 || *(unsigned char *)(c + 0x3b0) == 0)
-                _ZN12CylinderClsn6UpdateEv(c + 0x178);
+    func_ov002_020b10e4(((char *)this));
+    mEatingPlayer = 0;
+    if (func_ov002_020b19dc(((char *)this)) != 0) return 1;
+    (((C *)((char *)this))->*data_ov002_0210dc70[mBehaviorType])();
+    if ((int)(data_0209f2d8 == 1) == 0 && (int)((unk_0b0 & 8) != 0) != 0) {
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
+        if (unk_3aa == 0 && LenVec3((char *)&unk_074) < 0x64000) {
+            if (mCoinType != 1 || unk_3b0 == 0)
+                _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
         }
     } else {
-        func_ov002_020b14d8(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x178);
-        if (*(unsigned char *)(c + 0x3aa) == 0) {
-            if (*(int *)(c + 0x3a0) != 1 || *(unsigned char *)(c + 0x3b0) == 0)
-                _ZN12CylinderClsn6UpdateEv(c + 0x178);
+        func_ov002_020b14d8(((char *)this));
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
+        if (unk_3aa == 0) {
+            if (mCoinType != 1 || unk_3b0 == 0)
+                _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
         }
     }
     return 1;
-}
 }

--- a/src/_ZN4CoinD0Ev.c
+++ b/src/_ZN4CoinD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN11CommonModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4CoinD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daCoin_c */
 extern void *G0;
 int *_ZN4CoinD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daCoin_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1ac);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x178);
     _ZN11ShadowModelD1Ev((char *)t + 0x150);

--- a/src/_ZN4Door13InitResourcesEv.cpp
+++ b/src/_ZN4Door13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4Door13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Door.h"
 struct SharedFilePtr;
 struct BMD_File;
 
@@ -11,9 +14,9 @@ extern unsigned char data_0209f250[];
 extern int data_0209f394[];
 extern int data_ov100_02148974[];
 
-extern "C" int _ZN4Door13InitResourcesEv(void *thiz)
+int Door::InitResources()
 {
-    unsigned char *c = (unsigned char *)thiz;
+    unsigned char *c = (unsigned char *)((void *)this);
     struct BMD_File *f;
 
     *(int *)(c + 8) = (unsigned)*(int *)(c + 8) >> 0x10;

--- a/src/_ZN4Door8BehaviorEv.cpp
+++ b/src/_ZN4Door8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4Door8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Door.h"
 struct Base {};
 typedef void (Base::*PMF)(int);
 struct CallbackNode {
@@ -6,11 +9,13 @@ struct CallbackNode {
     PMF callback;
 };
 extern int func_ov100_02145370(char *c);
-extern "C" int _ZN4Door8BehaviorEv(char *c) {
-    int res = func_ov100_02145370(c);
-    CallbackNode *node = *(CallbackNode**)((char*)c + 0x110);
+
+int Door::Behavior()
+{
+    int res = func_ov100_02145370(((char *)this));
+    CallbackNode *node = *(CallbackNode**)((char*)&unk_110);
     if (*(int*)&node->callback != 0) {
-        Base *base = (Base*)c;
+        Base *base = (Base*)((char *)this);
         (base->*(node->callback))(res);
     }
     return 1;

--- a/src/_ZN4DoorD0Ev.c
+++ b/src/_ZN4DoorD0Ev.c
@@ -1,11 +1,13 @@
-extern void _ZN11CommonModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4DoorD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daStarGate_c */
 extern void *G0;
 int *_ZN4DoorD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daStarGate_c;
     _ZN11CommonModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN4Fish6RenderEv.cpp
+++ b/src/_ZN4Fish6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4Fish6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Fish.h"
 struct Base {
     virtual void v0();
     virtual void v1();
@@ -7,9 +10,11 @@ struct Base {
     virtual void v4();
     virtual void m(int);
 };
-extern "C" int _ZN4Fish6RenderEv(char *c) {
-    if (*(unsigned char*)(c + 0x159) == 0) {
-        Base *b = (Base*)(c + 0xd4);
+
+int Fish::Render()
+{
+    if (unk_159 == 0) {
+        Base *b = (Base*)((char *)&mModelAnim);
         b->m(0);
     }
     return 1;

--- a/src/_ZN4Fish8BehaviorEv.cpp
+++ b/src/_ZN4Fish8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN4Fish8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Fish.h"
 struct C;
 typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
@@ -8,7 +13,6 @@ struct M48 { int w[12]; };
 extern "C" M48 data_020a0e68;
 
 extern "C" int* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern "C" int func_ov100_0214639c(int* p);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(C* c);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(C* c, int clsn);
 extern "C" void Vec3_Asr(Vec3* d, Vec3* s, int sh);
@@ -36,30 +40,30 @@ struct C {
     unsigned char flag; // 0x159
 };
 
-extern "C" int _ZN4Fish8BehaviorEv(C* c)
+int Fish::Behavior()
 {
     Vec3 v;
     int* r;
-    if (c->flag != 0) {
-        (c->*data_ov100_02148a1c[c->idx].pmf)();
+    if (((C*)this)->flag != 0) {
+        (((C*)this)->*data_ov100_02148a1c[((C*)this)->idx].pmf)();
     } else {
-        r = _ZN5Actor10FindWithIDEj(c->id);
+        r = _ZN5Actor10FindWithIDEj(((C*)this)->id);
         if (r == 0 || func_ov100_0214639c(r) != 0) {
-            _ZN9ActorBase18MarkForDestructionEv(c);
+            _ZN9ActorBase18MarkForDestructionEv(((C*)this));
         } else {
-            (c->*data_ov100_02148a1c[c->idx].pmf)();
-            _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+            (((C*)this)->*data_ov100_02148a1c[((C*)this)->idx].pmf)();
+            _ZN5Actor9UpdatePosEP12CylinderClsn(((C*)this), 0);
             {
-                int* cp = (int*)(((int)c + 0x150) & 0xFFFFFFFFFFFFFFFF);
+                int* cp = (int*)(((int)((C*)this) + 0x150) & 0xFFFFFFFFFFFFFFFF);
                 *cp = *cp + 1;
             }
         }
-        Vec3_Asr(&v, &c->pos, 3);
+        Vec3_Asr(&v, &((C*)this)->pos, 3);
         Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
-        c->f8e = c->f94;
-        Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, c->f8e);
-        c->mtx = data_020a0e68;
-        _ZN9Animation7AdvanceEv(&c->anim);
+        ((C*)this)->f8e = ((C*)this)->f94;
+        Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, ((C*)this)->f8e);
+        ((C*)this)->mtx = data_020a0e68;
+        _ZN9Animation7AdvanceEv(&((C*)this)->anim);
     }
     return 1;
 }

--- a/src/_ZN4FishD0Ev.c
+++ b/src/_ZN4FishD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4FishD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daFish_c */
 extern void *G0;
 int *_ZN4FishD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daFish_c;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN4Heap10DeallocateEPv.cpp
+++ b/src/_ZN4Heap10DeallocateEPv.cpp
@@ -1,3 +1,10 @@
 //cpp
+// @symbol _ZN4Heap10DeallocateEPv
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void m(void*); };
-extern "C" void _ZN4Heap10DeallocateEPv(Base *c, void *a){ c->m(a); }
+
+void Heap::Deallocate(void * a)
+{
+ ((Base *)this)->m(a);
+}

--- a/src/_ZN4Heap10ReallocateEPvj.cpp
+++ b/src/_ZN4Heap10ReallocateEPvj.cpp
@@ -1,3 +1,10 @@
 //cpp
+// @symbol _ZN4Heap10ReallocateEPvj
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void m(void*,unsigned int); };
-extern "C" void _ZN4Heap10ReallocateEPvj(Base *c, void *a, unsigned int b){ c->m(a,b); }
+
+void Heap::Reallocate(void * a, unsigned int b)
+{
+ ((Base *)this)->m(a,b);
+}

--- a/src/_ZN4Heap14CreateRootHeapEPvj.c
+++ b/src/_ZN4Heap14CreateRootHeapEPvj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap14CreateRootHeapEPvj
+/* recovered: named members + shared header */
+#include "Heap.h"
 typedef unsigned int u32;
 struct Heap;
 struct ExpandingHeapAllocator;

--- a/src/_ZN4Heap15CreateSolidHeapEjPS_i.c
+++ b/src/_ZN4Heap15CreateSolidHeapEjPS_i.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap15CreateSolidHeapEjPS_i
+/* recovered: named members + shared header */
+#include "Heap.h"
 typedef unsigned int u32;
 struct Heap;
 struct SolidHeapAllocator;

--- a/src/_ZN4Heap19CreateExpandingHeapEjPS_i.c
+++ b/src/_ZN4Heap19CreateExpandingHeapEjPS_i.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap19CreateExpandingHeapEjPS_i
+/* recovered: named members + shared header */
+#include "Heap.h"
 typedef unsigned int u32;
 struct Heap;
 struct ExpandingHeapAllocator;

--- a/src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp
@@ -1,3 +1,10 @@
 //cpp
+// @symbol _ZN4Heap21MaxAllocationUnitSizeEv
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual int m(); };
-extern "C" int _ZN4Heap21MaxAllocationUnitSizeEv(Base *c){ return c->m(); }
+
+int Heap::MaxAllocationUnitSize()
+{
+ return ((Base *)this)->m();
+}

--- a/src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c
+++ b/src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap23SetupSolidHeapAsDefaultEjPS_i
+/* recovered: named members + shared header */
+#include "Heap.h"
 // Heap::SetupSolidHeapAsDefault: creates a SolidHeap, saves default to tmp, sets new heap as default
 
 typedef void Heap;

--- a/src/_ZN4Heap24CreateSolidHeapAllocatorEPvjj.c
+++ b/src/_ZN4Heap24CreateSolidHeapAllocatorEPvjj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap24CreateSolidHeapAllocatorEPvjj
+/* recovered: named members + shared header */
+#include "Heap.h"
 // Heap::CreateSolidHeapAllocator(void* address, u32 size, u32 flags)
 // Address: 0x0204ebc4
 // Try: compute avail only in second condition to defer sub

--- a/src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
+++ b/src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4Heap28CreateExpandingHeapAllocatorEPvjj
+/* recovered: named members + shared header */
+#include "Heap.h"
 // Heap::CreateExpandingHeapAllocator(void* address, u32 size, u32 flags)
 // Address: 0x0204e3c0
 // Inline avail expression in || to defer sub r3,r1,r0 after bhi

--- a/src/_ZN4Heap6IntactEv.cpp
+++ b/src/_ZN4Heap6IntactEv.cpp
@@ -1,8 +1,14 @@
 //cpp
+// @symbol _ZN4Heap6IntactEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual bool m(); };
-extern "C" unsigned char data_020a0e98;
-extern "C" bool _ZN4Heap6IntactEv(Base *c){
-  bool r = c->m();
+
+bool Heap::Intact()
+{
+  bool r = ((Base *)this)->m();
   if (r) return r;
   if (!data_020a0e98) data_020a0e98 = 1;
   return r;

--- a/src/_ZN4Heap6RescueEv.cpp
+++ b/src/_ZN4Heap6RescueEv.cpp
@@ -1,3 +1,10 @@
 //cpp
+// @symbol _ZN4Heap6RescueEv
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual int m(); };
-extern "C" int _ZN4Heap6RescueEv(Base *c){ return c->m(); }
+
+int Heap::Rescue()
+{
+ return ((Base *)this)->m();
+}

--- a/src/_ZN4Heap6SizeofEPv.cpp
+++ b/src/_ZN4Heap6SizeofEPv.cpp
@@ -1,8 +1,14 @@
 //cpp
+// @symbol _ZN4Heap6SizeofEPv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual int m(void*); };
-extern "C" void Crash();
-extern "C" int _ZN4Heap6SizeofEPv(Base *c, void *a){
-  int r = c->m(a);
-  if (r == -1 && (*(int*)((char*)c+0x10) & 0x4000)) Crash();
+
+int Heap::Sizeof(void * a)
+{
+  int r = ((Base *)this)->m(a);
+  if (r == -1 && (*(int*)((char*)&unk_010) & 0x4000)) Crash();
   return r;
 }

--- a/src/_ZN4Heap7DestroyEv.cpp
+++ b/src/_ZN4Heap7DestroyEv.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol _ZN4Heap7DestroyEv
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void m(); };
 extern "C" void _ZN4Heap10DeallocateEPv(void*, void*);
-extern "C" void _ZN4Heap7DestroyEv(Base *c){
-  c->m();
-  *(int*)((char*)c+4)=0;
-  *(int*)((char*)c+8)=0;
-  void* p = *(void**)((char*)c+0xc);
+
+void Heap::Destroy()
+{
+  ((Base *)this)->m();
+  *(int*)((char*)&unk_004)=0;
+  *(int*)((char*)&unk_008)=0;
+  void* p = *(void**)((char*)&unk_00c);
   if (p==0) return;
-  _ZN4Heap10DeallocateEPv(p, c);
-  *(int*)((char*)c+0xc)=0;
+  _ZN4Heap10DeallocateEPv(p, ((Base *)this));
+  *(int*)((char*)&unk_00c)=0;
 }

--- a/src/_ZN4Heap8AllocateEji.cpp
+++ b/src/_ZN4Heap8AllocateEji.cpp
@@ -1,8 +1,14 @@
 //cpp
+// @symbol _ZN4Heap8AllocateEji
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual int m(unsigned int,int); };
-extern "C" void Crash();
-extern "C" int _ZN4Heap8AllocateEji(Base *c, unsigned int a, int b){
-  int r = c->m(a,b);
-  if (r == 0 && (*(int*)((char*)c+0x10) & 0x4000)) Crash();
+
+int Heap::Allocate(unsigned int a, int b)
+{
+  int r = ((Base *)this)->m(a,b);
+  if (r == 0 && (*(int*)((char*)&unk_010) & 0x4000)) Crash();
   return r;
 }

--- a/src/_ZN4Heap9SetNodeIDEj.cpp
+++ b/src/_ZN4Heap9SetNodeIDEj.cpp
@@ -1,8 +1,16 @@
 //cpp
+// @symbol _ZN4Heap9SetNodeIDEj
+/* recovered: named members + shared header, real C++ method */
+#include "Heap.h"
 struct Base {
     virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
     virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();
     virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11();
     virtual void v12(); virtual void v13(void*);
 };
-extern "C" void _ZN4Heap9SetNodeIDEj(Base *c, void *a) { c->v13(a); }
+
+void Heap::SetNodeID(unsigned int a_)
+{
+    void * a = (void *)a_;
+ ((Base *)this)->v13(a);
+}

--- a/src/_ZN4HeapC1EPvjP4Heap.c
+++ b/src/_ZN4HeapC1EPvjP4Heap.c
@@ -1,3 +1,8 @@
+// @symbol _ZN4HeapC1EPvjP4Heap
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Heap.h"
 typedef unsigned int u32;
 struct Heap;
 struct HeapS {
@@ -7,7 +12,6 @@ struct HeapS {
     struct Heap *parentHeap;
     u32 flags;
 };
-extern void *data_02099d90;
 void _ZN4HeapC1EPvjP4Heap(struct HeapS *heap, void *start, u32 size, struct Heap *root) {
   heap->vtable = &data_02099d90;
   heap->heapStart = start;

--- a/src/_ZN4HeapD1Ev.c
+++ b/src/_ZN4HeapD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4HeapD1Ev
+/* recovered: named members + shared header */
+#include "Heap.h"
 /* Heap::~Heap() at 0x0203ca44 -- complete object destructor (D1).
  * A trivial destructor whose only effect is to reset the object's vtable pointer
  * (at offset 0x00) back to Heap's own vtable. Returns void.

--- a/src/_ZN4HeapD2Ev.c
+++ b/src/_ZN4HeapD2Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN4HeapD2Ev
+/* recovered: named members + shared header */
+#include "Heap.h"
 /* Heap::~Heap() at 0x0203ca10 -- base object destructor (D2).
  * A trivial destructor whose only effect is to reset the object's vtable pointer
  * (at offset 0x00) back to Heap's own vtable before the base subobject is torn

--- a/src/_ZN4ToadD0Ev.c
+++ b/src/_ZN4ToadD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN4ToadD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daKinopio_c */
 extern void *G0;
 int *_ZN4ToadD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daKinopio_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x16c);
     _ZN9ModelAnimD1Ev((char *)t + 0x108);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/_ZN4Trap6RenderEv.cpp
+++ b/src/_ZN4Trap6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN4Trap6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Trap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN4Trap6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Trap::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN4Trap8BehaviorEv.cpp
+++ b/src/_ZN4Trap8BehaviorEv.cpp
@@ -1,26 +1,27 @@
 //cpp
+// @symbol _ZN4Trap8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Trap.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-typedef struct { s32 x, y, z; } Vector3;
-typedef struct { s32 m[12]; } Matrix4x3;
 
 extern "C" {
-extern int _ZN5Sound20PlaySmallSecretSoundEP5ActorPt(void* actor, u16* arg);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(const Vector3* v, const Matrix4x3* m, Vector3* res);
 extern void Vec3_Add(Vector3* out, const Vector3* a, const Vector3* b);
 extern int _ZN6Player12GetTalkStateEv(void* p);
 extern int _Z14ApproachLinearRsss(s16* val, s16 target, s16 step);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern void _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* p, void* base, u32 a, const Vector3* v, u32 b, u32 c);
 extern void _ZN7Message7EndTalkEv(void);
 extern void* _ZN5Actor10FindWithIDEj(u32 id);
 extern s16 Vec3_HorzAngle(const Vector3* v0, const Vector3* v1);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* p, void* base, int b);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
@@ -45,17 +46,17 @@ struct Obj {
     u16 arr_168[4];     /* 0x168 */
 };
 
-extern "C" int _ZN4Trap8BehaviorEv(Obj* thiz)
+int Trap::Behavior()
 {
     Vector3 vIn, vMid, vRes;
     Vector3 hv;
     Vector3 vIn2, vMid2, vRes2;
 
-    if (thiz->f164 != 0) {
+    if (((Obj*)this)->f164 != 0) {
         void* p;
-        if (!_ZN5Sound20PlaySmallSecretSoundEP5ActorPt(thiz, thiz->arr_168))
+        if (!_ZN5Sound20PlaySmallSecretSoundEP5ActorPt(((Obj*)this), ((Obj*)this)->arr_168))
             return 1;
-        p = (void*)thiz->f164;
+        p = (void*)((Obj*)this)->f164;
 
         vIn.x = -0x3b0000;
         vIn.y = 0x200000;
@@ -63,37 +64,37 @@ extern "C" int _ZN4Trap8BehaviorEv(Obj* thiz)
         vMid.x = 0;
         vMid.y = 0;
         vMid.z = 0;
-        Matrix4x3_FromRotationY(&data_020a0e68, thiz->angle_8e);
+        Matrix4x3_FromRotationY(&data_020a0e68, ((Obj*)this)->angle_8e);
         MulVec3Mat4x3(&vIn, &data_020a0e68, &vMid);
-        Vec3_Add(&vRes, &thiz->pos, &vMid);
+        Vec3_Add(&vRes, &((Obj*)this)->pos, &vMid);
 
         switch (_ZN6Player12GetTalkStateEv(p)) {
         case 0:
-            if (_Z14ApproachLinearRsss((s16*)((char*)p + 0x8e), thiz->angle_8e + 0x8000, 0x800)) {
+            if (_Z14ApproachLinearRsss((s16*)((char*)p + 0x8e), ((Obj*)this)->angle_8e + 0x8000, 0x800)) {
                 _ZN7Message11PrepareTalkEv();
-                _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(p, thiz, 0x192, &vRes, 0, 0);
+                _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(p, ((Obj*)this), 0x192, &vRes, 0, 0);
             }
             break;
         case 1:
             break;
         default:
             _ZN7Message7EndTalkEv();
-            thiz->f164 = 0;
+            ((Obj*)this)->f164 = 0;
             break;
         }
     } else {
-        if (thiz->f144 & 0x8000000) {
-            void* o = _ZN5Actor10FindWithIDEj(thiz->f148);
+        if (((Obj*)this)->f144 & 0x8000000) {
+            void* o = _ZN5Actor10FindWithIDEj(((Obj*)this)->f148);
             if (o) {
                 int b = (int)(*(u16*)((char*)o + 0xc) == 0xbf);
                 if (b) {
                     Vector3* op = (Vector3*)(((int)o + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
                     hv = *op;
-                    if (AngleDiff(Vec3_HorzAngle(&thiz->pos, &hv), thiz->angle_8e) < 0x4000) {
+                    if (AngleDiff(Vec3_HorzAngle(&((Obj*)this)->pos, &hv), ((Obj*)this)->angle_8e) < 0x4000) {
                         if (*(s32*)((char*)o + 0x664) == 0xd) {
-                            if (_ZN6Player9StartTalkER9ActorBaseb(o, thiz, 0)) {
-                                thiz->f164 = (s32)o;
-                                *(s16*)((char*)thiz + 0x168) = 0;
+                            if (_ZN6Player9StartTalkER9ActorBaseb(o, ((Obj*)this), 0)) {
+                                ((Obj*)this)->f164 = (s32)o;
+                                *(s16*)((char*)&unk_168) = 0;
                             }
                         }
                     }
@@ -108,14 +109,14 @@ extern "C" int _ZN4Trap8BehaviorEv(Obj* thiz)
     vMid2.x = 0;
     vMid2.y = 0;
     vMid2.z = 0;
-    Matrix4x3_FromRotationY(&data_020a0e68, thiz->angle_8e);
+    Matrix4x3_FromRotationY(&data_020a0e68, ((Obj*)this)->angle_8e);
     MulVec3Mat4x3(&vIn2, &data_020a0e68, &vMid2);
-    Vec3_Add(&vRes2, &thiz->pos, &vMid2);
-    thiz->vec_158.x = vRes2.x;
-    thiz->vec_158.y = vRes2.y;
-    thiz->vec_158.z = vRes2.z;
-    thiz->f128 = 0xf0000;
-    _ZN12CylinderClsn5ClearEv(&thiz->clsn_124);
-    _ZN12CylinderClsn6UpdateEv(&thiz->clsn_124);
+    Vec3_Add(&vRes2, &((Obj*)this)->pos, &vMid2);
+    ((Obj*)this)->vec_158.x = vRes2.x;
+    ((Obj*)this)->vec_158.y = vRes2.y;
+    ((Obj*)this)->vec_158.z = vRes2.z;
+    ((Obj*)this)->f128 = 0xf0000;
+    _ZN12CylinderClsn5ClearEv(&((Obj*)this)->clsn_124);
+    _ZN12CylinderClsn6UpdateEv(&((Obj*)this)->clsn_124);
     return 1;
 }

--- a/src/_ZN4TrapD0Ev.c
+++ b/src/_ZN4TrapD0Ev.c
@@ -1,12 +1,15 @@
+// @symbol _ZN4TrapD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjC1Hikari_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN4TrapD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjC1Hikari_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN4Tree16CleanupResourcesEv.cpp
+++ b/src/_ZN4Tree16CleanupResourcesEv.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN4Tree16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Tree.h"
 extern "C" {
 void _ZN19CylinderClsnWithPosD1Ev(void* c);
 void _ZN6Memory16operator_delete2EPv(void* p);
 }
 extern char* data_ov002_02110a48[];
-extern "C" int _ZN4Tree16CleanupResourcesEv(char* c){
-  char* r7 = c + 0xd4;
+
+int Tree::CleanupResources()
+{
+  char* r7 = ((char*)this) + 0xd4;
   char** r6 = data_ov002_02110a48;
   int i;
   for (i = 0; i < 5; i++){

--- a/src/_ZN4Tree6RenderEv.cpp
+++ b/src/_ZN4Tree6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4Tree6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Tree.h"
 extern "C" {
 struct Vec3 { int x, y, z; };
 extern int data_ov002_02110a48;
@@ -19,11 +22,11 @@ struct ModelBase {
     virtual void m(int arg);
 };
 
-extern "C" int _ZN4Tree6RenderEv(char *self)
+int Tree::Render()
 {
     char *base = (char *)data_0209f318;
     int *iter = &data_ov002_02110a48;
-    char *sl = self + 0xd4;
+    char *sl = ((char *)this) + 0xd4;
     int i = 0;
     int z5 = 0;
     int z4 = 0;

--- a/src/_ZN4TreeD0Ev.cpp
+++ b/src/_ZN4TreeD0Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4TreeD0Ev
+/* recovered: named members + shared header */
+#include "Tree.h"
 extern "C" {
 extern int _ZTV4Tree[];
 extern int data_020a0eac[];

--- a/src/_ZN4TreeD1Ev.cpp
+++ b/src/_ZN4TreeD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN4TreeD1Ev
+/* recovered: named members + shared header */
+#include "Tree.h"
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
 extern void _ZN5ActorD2Ev(void*);

--- a/src/_ZN5Actor10EarthquakeERK7Vector35Fix12IiE.cpp
+++ b/src/_ZN5Actor10EarthquakeERK7Vector35Fix12IiE.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Actor10EarthquakeERK7Vector35Fix12IiE
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 extern void func_0200d8c8(void*, int);
 extern void* data_0209f318;

--- a/src/_ZN5Actor10FindWithIDEj.cpp
+++ b/src/_ZN5Actor10FindWithIDEj.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Actor10FindWithIDEj
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 struct Actor;
 extern struct Actor* data_0209b468;

--- a/src/_ZN5Actor11OnAttacked1ERS_.c
+++ b/src/_ZN5Actor11OnAttacked1ERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor11OnAttacked1ERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnAttacked1(Actor&) at 0x02010144 -- vtable slot 21, combat hook.
  * Base Actor does nothing; leaf classes override to react to an attack.
  */

--- a/src/_ZN5Actor11OnAttacked2ERS_.c
+++ b/src/_ZN5Actor11OnAttacked2ERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor11OnAttacked2ERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnAttacked2(Actor&) at 0x02010140 -- vtable slot 22, combat hook.
  * Base Actor does nothing; leaf classes override to react to an attack.
  */

--- a/src/_ZN5Actor14GetSubtractionEss.cpp
+++ b/src/_ZN5Actor14GetSubtractionEss.cpp
@@ -1,9 +1,12 @@
 //cpp
-extern "C" {
-int _ZN5Actor14GetSubtractionEss(void*self,short a,short b){
+// @symbol _ZN5Actor14GetSubtractionEss
+#include "Actor.h"
+/* recovered: named members + shared header */
+
+int Actor::GetSubtraction(short a, short b)
+{
 int d=(short)(b-a);
 if(d==-0x8000) d=-0x7fff;
 if(d<0) d=(short)(-d);
 return d;
-}
 }

--- a/src/_ZN5Actor15FindWithActorIDEjPS_.c
+++ b/src/_ZN5Actor15FindWithActorIDEjPS_.c
@@ -1,5 +1,9 @@
+// @symbol _ZN5Actor15FindWithActorIDEjPS_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern int data_0209b468[];
-extern int *func_02043f4c(int *a, unsigned int j, int b);
 int _ZN5Actor15FindWithActorIDEjPS_(unsigned int j, int p) {
   int *r;
   if (p) r = func_02043f4c(data_0209b468, j, p+0x50);

--- a/src/_ZN5Actor15OnGroundPoundedERS_.c
+++ b/src/_ZN5Actor15OnGroundPoundedERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor15OnGroundPoundedERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnGroundPounded(Actor&) at 0x02010148 -- vtable slot 20, combat hook.
  * Base Actor does nothing; leaf classes override to react to a ground pound.
  */

--- a/src/_ZN5Actor19OnHitFromUnderneathERS_.c
+++ b/src/_ZN5Actor19OnHitFromUnderneathERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor19OnHitFromUnderneathERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnHitFromUnderneath(Actor&) at 0x0201012c -- vtable slot 27, combat hook.
  * Base Actor does nothing; leaf classes override to react when struck from below.
  */

--- a/src/_ZN5Actor24BumpedUnderneathByPlayerER6Player.cpp
+++ b/src/_ZN5Actor24BumpedUnderneathByPlayerER6Player.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol _ZN5Actor24BumpedUnderneathByPlayerER6Player
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
-int _ZN5Actor24BumpedUnderneathByPlayerER6Player(char*self,char*player){
+int _ZN5Actor24BumpedUnderneathByPlayerER6Player(struct Actor *self, char*player) {
 if(*(unsigned char*)(player+0x6de)!=0 && *(int*)(player+0xa8)>0
-   && *(int*)(player+0x60) < *(int*)(self+0x60))
+   && *(int*)(player+0x60) < self->mPosY)
   return 1;
 return 0;
 }

--- a/src/_ZN5Actor24OnHitByCannonBlastedCharERS_.c
+++ b/src/_ZN5Actor24OnHitByCannonBlastedCharERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor24OnHitByCannonBlastedCharERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnHitByCannonBlastedChar(Actor&) at 0x02010134 -- vtable slot 25, combat hook.
  * Base Actor does nothing; leaf classes override to react to a cannon-blasted character.
  */

--- a/src/_ZN5Actor4NextEPKS_.cpp
+++ b/src/_ZN5Actor4NextEPKS_.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol _ZN5Actor4NextEPKS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 struct Actor;
 extern struct Actor* data_0209b468;
-struct Actor* _ZN5Actor4NextEPKS_(struct Actor* c){
+struct Actor* _ZN5Actor4NextEPKS_(struct Actor *self) {
   struct Actor* p;
-  if(c) p = *(struct Actor**)((char*)c+0x54);
+  if(((struct Actor*)self)) p = *(struct Actor**)((char*)&self->unk_054);
   else  p = *(struct Actor**)&data_0209b468;
   if(p) return *(struct Actor**)((char*)p+8);
   return 0;

--- a/src/_ZN5Actor8OnKickedERS_.c
+++ b/src/_ZN5Actor8OnKickedERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor8OnKickedERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnKicked(Actor&) at 0x0201013c -- vtable slot 23, combat hook.
  * Base Actor does nothing; leaf classes override to react to being kicked.
  */

--- a/src/_ZN5Actor8OnPushedERS_.c
+++ b/src/_ZN5Actor8OnPushedERS_.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Actor8OnPushedERS_
+/* recovered: named members + shared header */
+#include "Actor.h"
 /* Actor::OnPushed(Actor&) at 0x02010138 -- vtable slot 24, combat hook.
  * Base Actor does nothing; leaf classes override to react to being pushed.
  */

--- a/src/_ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_.cpp
+++ b/src/_ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
-void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(char*self,int a,int b,int c,int d){
-*(int*)(self+0xb4)=a;
-*(int*)(self+0xb8)=b>>3;
-*(int*)(self+0xbc)=c>>3;
-*(int*)(self+0xc0)=d>>3;
+void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(struct Actor *self, int a, int b, int c, int d) {
+self->unk_0b4=a;
+self->unk_0b8=b>>3;
+self->unk_0bc=c>>3;
+self->unk_0c0=d>>3;
 }
 }

--- a/src/_ZN5ActorC1Ev.cpp
+++ b/src/_ZN5ActorC1Ev.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5ActorC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 void _ZN9ActorBaseC1Ev(void* self);
 void func_0203b244(void* l, void* n);
@@ -9,54 +14,53 @@ extern void* data_0208e3a4;
 extern void* data_0209b468;
 extern void* data_0209b460;
 extern void* data_0209b45c;
-extern signed char data_0209b44c;
 extern short data_0208e378;
 extern void* data_020a4bb8;
 extern unsigned char data_0209f2d8;
 
-extern "C" void* _ZN5ActorC1Ev(char* c) {
-  _ZN9ActorBaseC1Ev(c);
-  *(void**)c = &data_0208e4b8;
-  *(void**)c = &data_0208e3a4;
-  *(int*)(c+0x50) = 0;
-  *(int*)(c+0x54) = 0;
-  *(void**)(c+0x58) = c;
-  func_0203b244(&data_0209b468, c+0x50);
+extern "C" void* _ZN5ActorC1Ev(struct Actor *self) {
+  _ZN9ActorBaseC1Ev(((char*)self));
+  *(void**)((char*)self) = &data_0208e4b8;
+  *(void**)((char*)self) = &data_0208e3a4;
+  self->unk_050 = 0;
+  self->unk_054 = 0;
+  *(void**)((char*)&self->unk_058) = ((char*)self);
+  func_0203b244(&data_0209b468, ((char*)self)+0x50);
   {
     int* p = (int*)data_0209b460;
     if (p) {
-      *(int*)(c+0x5c) = p[0];
-      *(int*)(c+0x60) = p[1];
-      *(int*)(c+0x64) = p[2];
+      self->mPosX = p[0];
+      self->mPosY = p[1];
+      self->mPosZ = p[2];
     }
   }
   {
     short* q = (short*)data_0209b45c;
     if (q) {
-      *(short*)(c+0x8c) = q[0];
-      *(short*)(c+0x8e) = q[1];
-      *(short*)(c+0x90) = q[2];
+      self->unk_08c = q[0];
+      self->unk_08e = q[1];
+      self->unk_090 = q[2];
       q = (short*)data_0209b45c;
-      *(short*)(c+0x92) = q[0];
-      *(short*)(c+0x94) = q[1];
-      *(short*)(c+0x96) = q[2];
+      self->unk_092 = q[0];
+      self->unk_094 = q[1];
+      self->unk_096 = q[2];
     }
   }
-  *(signed char*)(c+0xcc) = data_0209b44c;
-  *(short*)(c+0xce) = data_0208e378;
+  self->mAreaId = data_0209b44c;
+  self->unk_0ce = data_0208e378;
   {
     void** base = *(void***)&data_020a4bb8;
-    int idx = *(unsigned short*)(c+0xc);
+    int idx = self->mActorID;
     char* s = (char*)base[idx];
-    *(int*)(c+0xb0) = *(int*)(s+8);
+    self->mFlags = *(int*)(s+8);
     {
       int b = (data_0209f2d8 == 2);
       int r3;
       int d = *(int*)(s+0x18);
       if (b) r3 = *(int*)(s+0x14) + 0x7d0000;
       else r3 = *(int*)(s+0x14);
-      _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, *(int*)(s+0xc), *(int*)(s+0x10), r3, d);
+      _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(((char*)self), *(int*)(s+0xc), *(int*)(s+0x10), r3, d);
     }
   }
-  return c;
+  return ((char*)self);
 }

--- a/src/_ZN5ActorC2Ev.cpp
+++ b/src/_ZN5ActorC2Ev.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5ActorC2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Actor.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef long long s64;
@@ -9,7 +14,6 @@ extern int data_0208e3a4;
 extern int data_0209b468;
 extern s16* data_0209b460;
 extern s16* data_0209b45c;
-extern signed char data_0209b44c;
 extern s16 data_0208e378;
 extern int* data_020a4bb8;
 extern unsigned char data_0209f2d8;
@@ -18,49 +22,48 @@ int func_0203b244(void* l, void* n);
 void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b, int c, int d);
 }
 
-extern "C" void* _ZN5ActorC2Ev(char* self)
-{
+extern "C" void* _ZN5ActorC2Ev(struct Actor *self) {
     int* entry;
     int b;
     int r3;
-    _ZN9ActorBaseC1Ev(self);
-    *(void**)self = &data_0208e4b8;
-    *(void**)self = &data_0208e3a4;
-    *(int*)(self + 0x50) = 0;
-    *(int*)(self + 0x54) = 0;
-    *(char**)(self + 0x58) = self;
-    func_0203b244((void*)&data_0209b468, self + 0x50);
+    _ZN9ActorBaseC1Ev(((char*)self));
+    *(void**)((char*)self) = &data_0208e4b8;
+    *(void**)((char*)self) = &data_0208e3a4;
+    self->unk_050 = 0;
+    self->unk_054 = 0;
+    *(char**)((char*)&self->unk_058) = ((char*)self);
+    func_0203b244((void*)&data_0209b468, ((char*)self) + 0x50);
     {
         s16* p = data_0209b460;
         if (p != 0) {
-            *(int*)(self + 0x5c) = ((int*)p)[0];
-            *(int*)(self + 0x60) = ((int*)p)[1];
-            *(int*)(self + 0x64) = ((int*)p)[2];
+            self->mPosX = ((int*)p)[0];
+            self->mPosY = ((int*)p)[1];
+            self->mPosZ = ((int*)p)[2];
         }
     }
     {
         s16* q = data_0209b45c;
         if (q != 0) {
-            *(s16*)(self + 0x8c) = q[0];
-            *(s16*)(self + 0x8e) = q[1];
-            *(s16*)(self + 0x90) = q[2];
+            self->unk_08c = q[0];
+            self->unk_08e = q[1];
+            self->unk_090 = q[2];
             {
                 s16* q2 = data_0209b45c;
-                *(s16*)(self + 0x92) = q2[0];
-                *(s16*)(self + 0x94) = q2[1];
-                *(s16*)(self + 0x96) = q2[2];
+                self->unk_092 = q2[0];
+                self->unk_094 = q2[1];
+                self->unk_096 = q2[2];
             }
         }
     }
-    *(signed char*)(self + 0xcc) = data_0209b44c;
-    *(s16*)(self + 0xce) = data_0208e378;
-    entry = (int*)(((int**)data_020a4bb8)[*(u16*)(self + 0xc)]);
-    *(int*)(self + 0xb0) = entry[2];
+    self->mAreaId = data_0209b44c;
+    self->unk_0ce = data_0208e378;
+    entry = (int*)(((int**)data_020a4bb8)[self->mActorID]);
+    self->mFlags = entry[2];
     b = (data_0209f2d8 == 2);
     if (b != 0)
         r3 = entry[5] + 0x7d0000;
     else
         r3 = entry[5];
-    _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(self, entry[3], entry[4], r3, entry[6]);
-    return self;
+    _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(((char*)self), entry[3], entry[4], r3, entry[6]);
+    return ((char*)self);
 }

--- a/src/_ZN5ActorD1Ev.cpp
+++ b/src/_ZN5ActorD1Ev.cpp
@@ -1,17 +1,20 @@
 //cpp
+// @symbol _ZN5ActorD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 extern int data_0208e3a4[];
 extern int data_0209b468[];
 extern int data_0208e4b8[];
-extern void func_0203b27c(int a, int c);
-extern void func_02044104(int a);
 extern void _ZN9ActorBaseD2Ev(int c);
-int _ZN5ActorD1Ev(int c) {
-  *(int*)c = (int)data_0208e3a4;
-  func_0203b27c((int)data_0209b468, c+0x50);
-  func_02044104(c+0x50);
-  *(int*)c = (int)data_0208e4b8;
-  _ZN9ActorBaseD2Ev(c);
-  return c;
+int _ZN5ActorD1Ev(struct Actor *self) {
+  *(int*)((int)self) = (int)data_0208e3a4;
+  func_0203b27c((int)data_0209b468, ((int)self)+0x50);
+  func_02044104((int)&self->unk_050);
+  *(int*)((int)self) = (int)data_0208e4b8;
+  _ZN9ActorBaseD2Ev(((int)self));
+  return ((int)self);
 }
 }

--- a/src/_ZN5ActorD2Ev.cpp
+++ b/src/_ZN5ActorD2Ev.cpp
@@ -1,17 +1,20 @@
 //cpp
+// @symbol _ZN5ActorD2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Actor.h"
 extern "C" {
 extern int data_0208e3a4[];
 extern int data_0209b468[];
 extern int data_0208e4b8[];
-extern void func_0203b27c(int a, int c);
-extern void func_02044104(int a);
 extern void _ZN9ActorBaseD2Ev(int c);
-int _ZN5ActorD2Ev(int c) {
-  *(int*)c = (int)data_0208e3a4;
-  func_0203b27c((int)data_0209b468, c+0x50);
-  func_02044104(c+0x50);
-  *(int*)c = (int)data_0208e4b8;
-  _ZN9ActorBaseD2Ev(c);
-  return c;
+int _ZN5ActorD2Ev(struct Actor *self) {
+  *(int*)((int)self) = (int)data_0208e3a4;
+  func_0203b27c((int)data_0209b468, ((int)self)+0x50);
+  func_02044104((int)&self->unk_050);
+  *(int*)((int)self) = (int)data_0208e4b8;
+  _ZN9ActorBaseD2Ev(((int)self));
+  return ((int)self);
 }
 }

--- a/src/_ZN5Bully16CleanupResourcesEv.cpp
+++ b/src/_ZN5Bully16CleanupResourcesEv.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol _ZN5Bully16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bully.h"
 extern "C" {
 int _ZN13SharedFilePtr7ReleaseEv(void *);
-int _ZN5Bully16CleanupResourcesEv(char *c) {
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+4));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+8));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0xc));
-    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)(c+0x330)+0x10));
-    return 1;
 }
+
+int Bully::CleanupResources()
+{
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0));
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+4));
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+8));
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0xc));
+    _ZN13SharedFilePtr7ReleaseEv(*(void**)(*(char**)((char *)&mFileTable)+0x10));
+    return 1;
 }

--- a/src/_ZN5Bully6RenderEv.cpp
+++ b/src/_ZN5Bully6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN5Bully6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bully.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x110]; Base base; };
-extern "C" int _ZN5Bully6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Bully::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN5BullyD0Ev.c
+++ b/src/_ZN5BullyD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN5BullyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *_ZN5BullyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daDonketu_c;
     t[0] = (int)VT1;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN5BullyD1Ev.c
+++ b/src/_ZN5BullyD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN5BullyD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN5BullyD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daDonketu_c;
     t[0] = (int)VT1;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN5Cloud13InitResourcesEv.cpp
+++ b/src/_ZN5Cloud13InitResourcesEv.cpp
@@ -1,13 +1,18 @@
 //cpp
-extern int data_ov039_021118e4[];
-extern int data_ov041_021118e0;
+// @symbol _ZN5Cloud13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Cloud.h"
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern "C" void func_ov044_02111214(char *t);
-extern "C" int _ZN5Cloud13InitResourcesEv(char *c){
+
+int Cloud::InitResources()
+{
   void *f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov039_021118e4);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, 2);
-  func_ov044_02111214(c);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, f, 1, 2);
+  func_ov044_02111214(((char *)this));
   data_ov041_021118e0++;
   return 1;
 }

--- a/src/_ZN5Cloud6RenderEv.cpp
+++ b/src/_ZN5Cloud6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN5Cloud6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Cloud.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN5Cloud6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Cloud::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN5Cloud8BehaviorEv.c
+++ b/src/_ZN5Cloud8BehaviorEv.c
@@ -1,6 +1,9 @@
+// @symbol _ZN5Cloud8BehaviorEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Cloud.h"
 extern int Vec3_Dist(void* a, void* b);
-extern void* FindWithActorID(unsigned int id, void* prev);
-extern int SetPolygonID(void* model, int id);
 
 #pragma opt_propagation off
 int _ZN5Cloud8BehaviorEv(char *c) {

--- a/src/_ZN5CloudD0Ev.c
+++ b/src/_ZN5CloudD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN5CloudD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daObjKumo_c */
 extern void *G0;
 int *_ZN5CloudD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daObjKumo_c;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN5Crate6RenderEv.cpp
+++ b/src/_ZN5Crate6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Crate6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Crate.h"
 struct Sub {
   virtual void v0();
   virtual void v1();
@@ -7,13 +10,15 @@ struct Sub {
   virtual void v4();
   virtual void m5(int);
 };
-extern "C" int _ZN5Crate6RenderEv(char* c){
-  if(*(int*)(c+0x560) == 6) return 1;
+
+int Crate::Render()
+{
+  if(unk_560 == 6) return 1;
   {
-    int b = (int)((*(int*)(c+0xb0) & 0x40000) != 0);
+    int b = (int)((unk_0b0 & 0x40000) != 0);
     if(b) return 1;
   }
-  Sub* o = (Sub*)(c+0xd4);
+  Sub* o = (Sub*)((char*)&mModel);
   o->m5(0);
   return 1;
 }

--- a/src/_ZN5CrateD0Ev.c
+++ b/src/_ZN5CrateD0Ev.c
@@ -1,25 +1,28 @@
+// @symbol _ZN5CrateD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Crate.h"
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
-extern void _ZN11ShadowModelD1Ev(void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN5ModelD1Ev(void*);
-extern void _ZN5ActorD2Ev(void*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern void* _ZTV5Crate;
 extern void* _ZTV17ExclamationSwitch;
 extern void* data_020a0eac[];
 
-void* _ZN5CrateD0Ev(char* c)
-{
-    *(void**)c = &_ZTV5Crate;
-    _ZN25MovingCylinderClsnWithPosD1Ev(c+0x5a4);
-    _ZN25MovingCylinderClsnWithPosD1Ev(c+0x564);
-    _ZN11ShadowModelD1Ev(c+0x508);
-    _ZN12WithMeshClsnD1Ev(c+0x320);
-    *(void**)c = &_ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac[0]);
-    return c;
+void* _ZN5CrateD0Ev(struct Crate *self) {
+    *(void**)((char*)self) = &_ZTV5Crate;
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos2);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
+    _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+    _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+    *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char*)&self->mModel);
+    _ZN5ActorD2Ev(((char*)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char*)self), data_020a0eac[0]);
+    return ((char*)self);
 }

--- a/src/_ZN5CrateD1Ev.cpp
+++ b/src/_ZN5CrateD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5CrateD1Ev
+/* recovered: named members + shared header */
+#include "Crate.h"
 extern "C" {
 void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 void _ZN11ShadowModelD1Ev(void*);
@@ -8,16 +11,16 @@ void _ZN5ModelD1Ev(void*);
 void _ZN5ActorD2Ev(void*);
 extern int _ZTV5Crate[];
 extern int _ZTV17ExclamationSwitch[];
-void* _ZN5CrateD1Ev(char* self){
-    *(int*)self = (int)_ZTV5Crate;
-    _ZN25MovingCylinderClsnWithPosD1Ev(self + 0x5a4);
-    _ZN25MovingCylinderClsnWithPosD1Ev(self + 0x564);
-    _ZN11ShadowModelD1Ev(self + 0x508);
-    _ZN12WithMeshClsnD1Ev(self + 0x320);
-    *(int*)self = (int)_ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(self + 0x124);
-    _ZN5ModelD1Ev(self + 0xd4);
-    _ZN5ActorD2Ev(self);
-    return self;
+void* _ZN5CrateD1Ev(struct Crate *self) {
+    *(int*)((char*)self) = (int)_ZTV5Crate;
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos2);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
+    _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+    _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+    *(int*)((char*)self) = (int)_ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+    _ZN5ModelD1Ev((char*)&self->mModel);
+    _ZN5ActorD2Ev(((char*)self));
+    return ((char*)self);
 }
 }

--- a/src/_ZN5Enemy12KillByAttackER5Actor.cpp
+++ b/src/_ZN5Enemy12KillByAttackER5Actor.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol _ZN5Enemy12KillByAttackER5Actor
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Enemy.h"
 typedef unsigned short u16;
-extern int func_ov004_020aea78(void *a, void *b, void *c, void *d);
 extern "C" void _ZN5Enemy12KillByAttackER5Actor(void *self, void *actor, void *c2, void *c3)
 {
     void *r8 = self;

--- a/src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp
+++ b/src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_ClsnResult.h"
+/* recovered: named members + shared header */
+#include "Enemy.h"
 extern "C" {
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 extern void _ZN11RaycastLineC1Ev(void* self);
@@ -8,42 +12,40 @@ extern void _ZN4BgCh19StartDetectingWaterEv(void* self);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);
 extern void _ZN10ClsnResultC1Ev(void* self);
 extern void _ZNK10ClsnResult6CopyToERS_(void* self, void* other);
-extern int _ZNK10ClsnResult9GetClsnIDEv(void* self);
 extern void _ZN10ClsnResultD1Ev(void* self);
 extern void _ZN11RaycastLineD1Ev(void* self);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, void* v);
 extern short data_02082214[];
 }
 
-extern "C" int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(
-    char* thiz, void* clsn, int fix2, short a3, unsigned char a4, unsigned char a5, int fix6) {
+extern "C" int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(struct Enemy *self, void* clsn, int fix2, short a3, unsigned char a4, unsigned char a5, int fix6) {
   Vector3 v1;
   Vector3 v2;
   char cr[0x28];
   Vector3 normal;
   char rl[0x7c];
-  thiz[0x106] = 0;
+  ((char*)self)[0x106] = 0;
   if (_ZNK12WithMeshClsn10IsOnGroundEv(clsn) != 0) {
     _ZN11RaycastLineC1Ev(rl);
-    v1.x = *(int*)(thiz + 0x5c);
-    v1.y = *(int*)(thiz + 0x60);
-    v1.z = *(int*)(thiz + 0x64);
+    v1.x = self->mPosX;
+    v1.y = self->mPosY;
+    v1.z = self->mPosZ;
     v1.y += fix6;
-    v2.x = *(int*)(thiz + 0x5c);
-    v2.y = *(int*)(thiz + 0x60);
-    v2.z = *(int*)(thiz + 0x64);
+    v2.x = self->mPosX;
+    v2.y = self->mPosY;
+    v2.z = self->mPosZ;
     v2.y -= fix2;
-    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, thiz);
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &v1, &v2, ((char*)self));
     if (a4 != 0)
       _ZN4BgCh19StartDetectingWaterEv(rl);
     if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
       if (*(int*)(rl + 0x60) - fix6 >= fix2)
-        thiz[0x106] = 1;
+        ((char*)self)[0x106] = 1;
       if (a5 == 0) {
         _ZN10ClsnResultC1Ev(cr);
         _ZNK10ClsnResult6CopyToERS_(rl + 0x10, cr);
         if (_ZNK10ClsnResult9GetClsnIDEv(cr) != -1) {
-          thiz[0x106] = 1;
+          ((char*)self)[0x106] = 1;
           _ZN10ClsnResultD1Ev(cr);
           _ZN11RaycastLineD1Ev(rl);
           return 1;
@@ -54,11 +56,11 @@ extern "C" int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(
       int idx = ((unsigned short)a3 >> 4) * 2;
       short s = data_02082214[idx + 1];
       if (normal.y < s)
-        thiz[0x106] = 2;
+        ((char*)self)[0x106] = 2;
     } else {
-      thiz[0x106] = 1;
+      ((char*)self)[0x106] = 1;
     }
     _ZN11RaycastLineD1Ev(rl);
   }
-  return *(unsigned char*)(thiz + 0x106) != 0;
+  return self->unk_106 != 0;
 }

--- a/src/_ZN5EnemyD0Ev.c
+++ b/src/_ZN5EnemyD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN5EnemyD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Enemy.h"
 int *_ZN5EnemyD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN5Fader13AdvanceInterpEv.cpp
+++ b/src/_ZN5Fader13AdvanceInterpEv.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol _ZN5Fader13AdvanceInterpEv
+/* recovered: named members + shared header, real C++ method */
+#include "Fader.h"
 extern "C" {
 void func_0203ae58(int* value, int target, int step);
 }
 
-extern "C" void _ZN5Fader13AdvanceInterpEv(char* self)
+void Fader::AdvanceInterp()
 {
-    int speed = *(int*)(self + 8);
+    int speed = unk_008;
     int target = speed >= 0 ? 0x1000 : 0;
     if (speed < 0)
         speed = -speed;
-    func_0203ae58((int*)(self + 4), target, speed);
+    func_0203ae58((int*)((char*)&unk_004), target, speed);
 }

--- a/src/_ZN5FaderD0Ev.c
+++ b/src/_ZN5FaderD0Ev.c
@@ -1,8 +1,12 @@
+// @symbol _ZN5FaderD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Fader.h"
 /* _ZN5FaderD0Ev at 0x02017848
  * Single-vtable destructor: write own vtable, call base/helper destructor (0x0203cbcc), return this.
  */
 struct Obj { void *vtable; };
-extern void *vtbl_Fader[];
 extern void base_dtor_Fader(struct Obj *thiz); /* 0x0203cbcc */
 struct Obj *_ZN5FaderD0Ev(struct Obj *thiz)
 {

--- a/src/_ZN5FaderD1Ev.c
+++ b/src/_ZN5FaderD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5FaderD1Ev
+/* recovered: named members + shared header */
+#include "Fader.h"
 /* Fader::~Fader() at 0x0201786c
  * Trivial destructor: restores the Fader vtable pointer into self->vtable
  * (slot 0x0) and returns. The currInterp/speed Fix12i members need no teardown.

--- a/src/_ZN5Koopa6RenderEv.cpp
+++ b/src/_ZN5Koopa6RenderEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Koopa6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Model.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Koopa.h"
 struct Mdl {
   virtual void v0();
   virtual void v1();
@@ -8,32 +13,32 @@ struct Mdl {
   virtual void slot5(void* p);
 };
 extern "C" {
-extern void _ZN5Model12ShowMaterialEii(void*, int, int);
-extern void _ZN5Model12HideMaterialEii(void*, int, int);
 struct V3 { int x, y, z; };
-int _ZN5Koopa6RenderEv(char* c){
-  volatile struct V3 saved;
-  int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
-  if (b) return 1;
-  if (*(int*)(c + 0x390) == 1) {
-    _ZN5Model12ShowMaterialEii(c + 0x300, 0, 1);
-    _ZN5Model12HideMaterialEii(c + 0x300, 0, 2);
-  } else {
-    _ZN5Model12HideMaterialEii(c + 0x300, 0, 1);
-    _ZN5Model12ShowMaterialEii(c + 0x300, 0, 2);
-  }
-  saved.x = *(int*)(c + 0x80);
-  saved.y = *(int*)(c + 0x84);
-  saved.z = *(int*)(c + 0x88);
-  if (*(int*)(c + 0x10c) == 1 && *(int*)(c + 0x390) == 2) {
-    *(int*)(c + 0x80) = (int)(((long long)*(volatile int*)(c + 0x80) * 0x800 + 0x800) >> 12);
-    *(int*)(c + 0x84) = (int)(((long long)*(volatile int*)(c + 0x84) * 0x800 + 0x800) >> 12);
-    *(int*)(c + 0x88) = (int)(((long long)*(volatile int*)(c + 0x88) * 0x800 + 0x800) >> 12);
-  }
-  ((struct Mdl*)(c + 0x300))->slot5(c + 0x80);
-  *(int*)(c + 0x80) = saved.x;
-  *(int*)(c + 0x84) = saved.y;
-  *(int*)(c + 0x88) = saved.z;
-  return 1;
 }
+
+int Koopa::Render()
+{
+  volatile struct V3 saved;
+  int b = (unk_0b0 & 0x40000) != 0;
+  if (b) return 1;
+  if (mKoopaVariant == 1) {
+    _ZN5Model12ShowMaterialEii(((char*)this) + 0x300, 0, 1);
+    _ZN5Model12HideMaterialEii(((char*)this) + 0x300, 0, 2);
+  } else {
+    _ZN5Model12HideMaterialEii(((char*)this) + 0x300, 0, 1);
+    _ZN5Model12ShowMaterialEii(((char*)this) + 0x300, 0, 2);
+  }
+  saved.x = mScaleX;
+  saved.y = mScaleY;
+  saved.z = mScaleZ;
+  if (unk_10c == 1 && mKoopaVariant == 2) {
+    mScaleX = (int)(((long long)*(volatile int*)((char*)&mScaleX) * 0x800 + 0x800) >> 12);
+    mScaleY = (int)(((long long)*(volatile int*)((char*)&mScaleY) * 0x800 + 0x800) >> 12);
+    mScaleZ = (int)(((long long)*(volatile int*)((char*)&mScaleZ) * 0x800 + 0x800) >> 12);
+  }
+  ((struct Mdl*)((char*)&mModelAnim))->slot5((char*)&mScaleX);
+  mScaleX = saved.x;
+  mScaleY = saved.y;
+  mScaleZ = saved.z;
+  return 1;
 }

--- a/src/_ZN5KoopaD0Ev.c
+++ b/src/_ZN5KoopaD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5KoopaD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daNknk_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN5KoopaD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daNknk_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN5KoopaD1Ev.c
+++ b/src/_ZN5KoopaD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5KoopaD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Koopa */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN5KoopaD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV5Koopa;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN5Model11UpdateVertsEv.cpp
+++ b/src/_ZN5Model11UpdateVertsEv.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN5Model11UpdateVertsEv
+/* recovered: named members + shared header, real C++ method */
+#include "Model.h"
 extern "C" {
 void _ZN15ModelComponents21UpdateVertsUsingBonesEv(char* p);
 }
 
-extern "C" void _ZN5Model11UpdateVertsEv(char* self)
+void Model::UpdateVerts()
 {
-    _ZN15ModelComponents21UpdateVertsUsingBonesEv(self + 8);
+    _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)&unk_008);
 }

--- a/src/_ZN5Model12SetPolygonIDEi.cpp
+++ b/src/_ZN5Model12SetPolygonIDEi.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN5Model12SetPolygonIDEi
+/* recovered: named members + shared header, real C++ method */
+#include "Model.h"
 extern "C" {
 void func_02046008(char* p, int id);
 }
 
-extern "C" void _ZN5Model12SetPolygonIDEi(char* self, int id)
+void Model::SetPolygonID(int id)
 {
-    func_02046008(self + 8, id);
+    func_02046008(((char*)this) + 8, id);
 }

--- a/src/_ZN5Model13GetVramOffsetEj.cpp
+++ b/src/_ZN5Model13GetVramOffsetEj.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol _ZN5Model13GetVramOffsetEj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Model.h"
 extern "C" {
-extern int data_020a4bdc;
 extern int data_020a4be0;
 extern int data_020a4be8;
 extern int data_020a4bc8;

--- a/src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp
+++ b/src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol _ZN5Model13LoadTexAndPalER8BMD_File
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Model.h"
 typedef unsigned int u32;
 
 extern "C" {
 
-extern u32 data_020a4bd8;
-extern u32 data_020a4bcc;
 
 void Crash();
 u32 _ZN5Model27LoadCompressedTextureToVramEPcjPc(char *src, u32 size, char *dst);
@@ -13,8 +16,7 @@ void _ZN2GX16BeginLoadTexPlttEv();
 void _ZN2GX11LoadTexPlttEPKvjj(const void *src, u32 addr, u32 size);
 void _ZN2GX14EndLoadTexPlttEv();
 
-void _ZN5Model13LoadTexAndPalER8BMD_File(char *f)
-{
+void _ZN5Model13LoadTexAndPalER8BMD_File(struct Model *self) {
     u32 i;
     u32 ret;
     u32 sz;
@@ -25,10 +27,10 @@ void _ZN5Model13LoadTexAndPalER8BMD_File(char *f)
     u32 off;
 
     i = 0;
-    if (i < *(u32 *)(f + 0x14)) {
+    if (i < self->unk_014) {
       off = i;
       do {
-        t = *(char **)(f + 0x18) + off;
+        t = *(char **)((char *)&self->unk_018) + off;
         sz = *(u32 *)(t + 8);
         if (((*(u32 *)(t + 0x10) >> 26) & 7) == 5) {
             ret = _ZN5Model27LoadCompressedTextureToVramEPcjPc(
@@ -39,16 +41,16 @@ void _ZN5Model13LoadTexAndPalER8BMD_File(char *f)
         *(u32 *)(t + 0x10) = (*(u32 *)(t + 0x10) & ~0xffff) | ((ret >> 3) & 0xffff);
         i++;
         off += 0x14;
-      } while (i < *(u32 *)(f + 0x14));
+      } while (i < self->unk_014);
     }
 
     _ZN2GX16BeginLoadTexPlttEv();
 
     j = 0;
-    if (j < *(u32 *)(f + 0x1c)) {
+    if (j < self->unk_01c) {
       poff = j;
       do {
-        p = *(char **)(f + 0x20) + poff;
+        p = *(char **)((char *)&self->unk_020) + poff;
         sz = *(u32 *)(p + 8);
         if (data_020a4bcc + sz > data_020a4bd8) Crash();
         if (sz <= 8) {
@@ -62,7 +64,7 @@ void _ZN5Model13LoadTexAndPalER8BMD_File(char *f)
         }
         j++;
         poff += 0x10;
-      } while (j < *(u32 *)(f + 0x1c));
+      } while (j < self->unk_01c);
     }
 
     _ZN2GX14EndLoadTexPlttEv();

--- a/src/_ZN5Model14SetPolygonModeEi.cpp
+++ b/src/_ZN5Model14SetPolygonModeEi.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN5Model14SetPolygonModeEi
+/* recovered: named members + shared header, real C++ method */
+#include "Model.h"
 extern "C" {
 void func_02046234(char* p, int mode);
 }
 
-extern "C" void _ZN5Model14SetPolygonModeEi(char* self, int mode)
+void Model::SetPolygonMode(int mode)
 {
-    func_02046234(self + 8, mode);
+    func_02046234(((char*)this) + 8, mode);
 }

--- a/src/_ZN5Model17LoadTextureToVramEPcj.c
+++ b/src/_ZN5Model17LoadTextureToVramEPcj.c
@@ -1,11 +1,12 @@
+// @symbol _ZN5Model17LoadTextureToVramEPcj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Model.h"
 typedef unsigned int u32;
 
-extern u32 _ZN5Model13GetVramOffsetEj(u32 size);
-extern void _ZN2GX12BeginLoadTexEv(void);
-extern void _ZN2GX7LoadTexEPKvjj(const void* texData, u32 vramOffset, u32 size);
-extern void _ZN2GX10EndLoadTexEv(void);
 
-extern u32 VRAM_Tex_Size;
 
 u32 _ZN5Model17LoadTextureToVramEPcj(char* texData, u32 size) {
     u32 vramOffset = _ZN5Model13GetVramOffsetEj(size);

--- a/src/_ZN5Model17UpdateFileOffsetsER8BMD_File.cpp
+++ b/src/_ZN5Model17UpdateFileOffsetsER8BMD_File.cpp
@@ -1,49 +1,52 @@
 //cpp
-extern "C" void _ZN5Model17UpdateFileOffsetsER8BMD_File(char *c) {
+// @symbol _ZN5Model17UpdateFileOffsetsER8BMD_File
+/* recovered: named members + shared header */
+#include "Model.h"
+extern "C" void _ZN5Model17UpdateFileOffsetsER8BMD_File(struct Model *self) {
   unsigned int i;
   int k;
-  if (*(int *)(c + 8)) *(int *)(c + 8) += (int)c;
-  for (i = 0; i < *(unsigned int *)(c + 4); i++) {
-    char *b = *(char **)(c + 8) + i * 0x40;
-    if (*(int *)(b + 4)) *(int *)(b + 4) += (int)c;
-    if (*(int *)(b + 0x34)) *(int *)(b + 0x34) += (int)c;
-    if (*(int *)(b + 0x38)) *(int *)(b + 0x38) += (int)c;
+  if (self->unk_008) self->unk_008 += (int)((char *)self);
+  for (i = 0; i < self->unk_004; i++) {
+    char *b = *(char **)((char *)&self->unk_008) + i * 0x40;
+    if (*(int *)(b + 4)) *(int *)(b + 4) += (int)((char *)self);
+    if (*(int *)(b + 0x34)) *(int *)(b + 0x34) += (int)((char *)self);
+    if (*(int *)(b + 0x38)) *(int *)(b + 0x38) += (int)((char *)self);
   }
-  if (*(int *)(c + 0x10)) *(int *)(c + 0x10) += (int)c;
-  for (i = 0; i < *(unsigned int *)(c + 0xc); i++) {
-    char *m = *(char **)(c + 0x10) + i * 8;
-    if (*(int *)(m + 4)) *(int *)(m + 4) += (int)c;
+  if (self->unk_010) self->unk_010 += (int)((char *)self);
+  for (i = 0; i < self->unk_00c; i++) {
+    char *m = *(char **)((char *)&self->unk_010) + i * 8;
+    if (*(int *)(m + 4)) *(int *)(m + 4) += (int)((char *)self);
     for (k = 0; k < *(int *)m; k++) {
       char *t = *(char **)(m + 4) + k * 0x10;
-      if (*(int *)(t + 4)) *(int *)(t + 4) += (int)c;
-      if (*(int *)(t + 0xc)) *(int *)(t + 0xc) += (int)c;
+      if (*(int *)(t + 4)) *(int *)(t + 4) += (int)((char *)self);
+      if (*(int *)(t + 0xc)) *(int *)(t + 0xc) += (int)((char *)self);
     }
   }
-  if (*(int *)(c + 0x18)) *(int *)(c + 0x18) += (int)c;
-  for (i = 0; i < *(unsigned int *)(c + 0x14); i++) {
-    char *e = *(char **)(c + 0x18) + i * 0x14;
-    if (*(int *)e) *(int *)e += (int)c;
-    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)c;
+  if (self->unk_018) self->unk_018 += (int)((char *)self);
+  for (i = 0; i < self->unk_014; i++) {
+    char *e = *(char **)((char *)&self->unk_018) + i * 0x14;
+    if (*(int *)e) *(int *)e += (int)((char *)self);
+    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)((char *)self);
   }
-  if (*(int *)(c + 0x20)) *(int *)(c + 0x20) += (int)c;
-  for (i = 0; i < *(unsigned int *)(c + 0x1c); i++) {
-    char *e = *(char **)(c + 0x20) + i * 0x10;
-    if (*(int *)e) *(int *)e += (int)c;
-    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)c;
+  if (self->unk_020) self->unk_020 += (int)((char *)self);
+  for (i = 0; i < self->unk_01c; i++) {
+    char *e = *(char **)((char *)&self->unk_020) + i * 0x10;
+    if (*(int *)e) *(int *)e += (int)((char *)self);
+    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)((char *)self);
   }
-  if (*(int *)(c + 0x28)) *(int *)(c + 0x28) += (int)c;
-  for (i = 0; i < *(unsigned int *)(c + 0x24); i++) {
-    char *e = *(char **)(c + 0x28) + i * 0x30;
-    if (*(int *)e) *(int *)e += (int)c;
+  if (self->unk_028) self->unk_028 += (int)((char *)self);
+  for (i = 0; i < self->unk_024; i++) {
+    char *e = *(char **)((char *)&self->unk_028) + i * 0x30;
+    if (*(int *)e) *(int *)e += (int)((char *)self);
   }
-  if (*(int *)(c + 0x2c)) *(int *)(c + 0x2c) += (int)c;
-  if (*(int *)(c + 0x30) == 0) return;
-  if (*(int *)(c + 0x34)) *(int *)(c + 0x34) += (int)c;
+  if (self->unk_02c) self->unk_02c += (int)((char *)self);
+  if (self->unk_030 == 0) return;
+  if (self->unk_034) self->unk_034 += (int)((char *)self);
   {
-    char *e = *(char **)(c + 0x34);
-    if (*(int *)e) *(int *)e += (int)c;
-    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)c;
-    if (*(int *)(e + 8)) *(int *)(e + 8) += (int)c;
-    if (*(int *)(e + 0xc)) *(int *)(e + 0xc) += (int)c;
+    char *e = *(char **)((char *)&self->unk_034);
+    if (*(int *)e) *(int *)e += (int)((char *)self);
+    if (*(int *)(e + 4)) *(int *)(e + 4) += (int)((char *)self);
+    if (*(int *)(e + 8)) *(int *)(e + 8) += (int)((char *)self);
+    if (*(int *)(e + 0xc)) *(int *)(e + 0xc) += (int)((char *)self);
   }
 }

--- a/src/_ZN5Model23AddToCommonModelDataArrER8BMD_File.c
+++ b/src/_ZN5Model23AddToCommonModelDataArrER8BMD_File.c
@@ -1,7 +1,10 @@
-extern int data_0209cef8[];
-extern int data_0209cefc[];
+// @symbol _ZN5Model23AddToCommonModelDataArrER8BMD_File
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Model.h"
 extern int data_0208e738[];
-extern int _ZN5Model13LoadTexAndPalER8BMD_File(void*);
 
 void* _ZN5Model23AddToCommonModelDataArrER8BMD_File(void* a){
   char* p = (char*)data_0209cefc;

--- a/src/_ZN5Model8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN5Model8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5Model8LoadFileER13SharedFilePtr
+/* recovered: named members + shared header */
+#include "Model.h"
 /* Model::LoadFile (static) at 0x02017a3c
  * Loads a SharedFilePtr; if it's the first reference and file is non-null,
  * calls UpdateFileOffsets, AddToCommonModelDataArr, and ReallocateModelFile.

--- a/src/_ZN5Model9DoSetFileEPcii.cpp
+++ b/src/_ZN5Model9DoSetFileEPcii.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Model9DoSetFileEPcii
+/* recovered: named members + shared header, real C++ method */
+#include "Model.h"
 extern "C" {
 int _ZN5Model23AddToCommonModelDataArrER8BMD_File(void*);
 unsigned int func_02046564(void*);
@@ -7,18 +10,21 @@ int func_020462d0(void*, void*, void*);
 int _ZN15ModelComponents21UpdateVertsUsingBonesEv(void*);
 int func_02016b24(void*, int);
 int _ZN5Model12SetPolygonIDEi(void*, int);
+}
 
-int _ZN5Model9DoSetFileEPcii(void* c, void* file, int a, int b){
+int Model::DoSetFile(char * file_, int a, int b)
+{
+    void* file = (void*)file_;
+
   void* buffer;
   _ZN5Model23AddToCommonModelDataArrER8BMD_File(file);
-  *(void**)((char*)c+0x4c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
-  buffer = *(void**)((char*)c+0x4c);
+  *(void**)((char*)&unk_04c) = _ZN6Memory13operator_new2Ej(func_02046564(file));
+  buffer = *(void**)((char*)&unk_04c);
   if (buffer == 0) return 0;
-  func_020462d0((char*)c+8, file, buffer);
-  _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)c+8);
-  if (a != 0) func_02016b24(c, 0x8000);
+  func_020462d0((char*)((void*)this)+8, file, buffer);
+  _ZN15ModelComponents21UpdateVertsUsingBonesEv((char*)&unk_008);
+  if (a != 0) func_02016b24(((void*)this), 0x8000);
   if (b < 0) return 1;
-  _ZN5Model12SetPolygonIDEi(c, b & 0xff);
+  _ZN5Model12SetPolygonIDEi(((void*)this), b & 0xff);
   return 1;
-}
 }

--- a/src/_ZN5Pokey13InitResourcesEv.cpp
+++ b/src/_ZN5Pokey13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Pokey13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Pokey.h"
 extern "C" {
 void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
@@ -18,65 +21,65 @@ struct Block48 { int w[12]; };
 struct Block3 { int w[3]; };
 extern Block48 data_02082128;
 
-extern "C" int _ZN5Pokey13InitResourcesEv(char* c)
+int Pokey::InitResources()
 {
     int t;
 
-    t = (*(unsigned short*)(c + 0xc) == 0xf0);
+    t = (mActorID == 0xf0);
     if (t != false) {
         void* m = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137b20);
-        _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, 1);
+        _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1);
         _ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137b28);
-        LoadBlueCoinModel(c);
-        *(unsigned char*)(c + 0x3a8) = 1;
+        LoadBlueCoinModel(((char*)this));
+        unk_3a8 = 1;
     } else {
-        t = (*(unsigned short*)(c + 0xc) == 0xf1);
+        t = (mActorID == 0xf1);
         if (t != false) {
             void* m = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137b28);
-            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, 1) == 0)
+            if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1) == 0)
                 return 0;
         }
     }
 
-    if (_ZN11ShadowModel12InitCylinderEv(c + 0x124) == 0)
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
         return 0;
 
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x14c, c, 0x3c000, 0x78000, 0x200004, 0x6eff0);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x180, c, 0x3c000, 0x3c000, 0, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x14c, ((char*)this), 0x3c000, 0x78000, 0x200004, 0x6eff0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x180, ((char*)this), 0x3c000, 0x3c000, 0, 0);
 
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x3c000;
-    *(int*)(c + 0x98) = 0x3000;
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
+    unk_098 = 0x3000;
 
-    t = (*(unsigned short*)(c + 0xc) == 0xf0);
+    t = (mActorID == 0xf0);
     if (t != false) {
-        *(int*)(c + 0x36c) = *(int*)(c + 0x5c);
-        *(int*)(c + 0x370) = *(int*)(c + 0x60);
-        *(int*)(c + 0x374) = *(int*)(c + 0x64);
-        *(int*)(c + 0x80) = 0x1000;
-        *(int*)(c + 0x84) = 0x1000;
-        *(int*)(c + 0x88) = 0x1000;
-        *(int*)(c + 0x390) = 0;
-        *(int*)(c + 0x394) = 0;
+        unk_36c = mPosX;
+        unk_370 = mPosY;
+        unk_374 = mPosZ;
+        mScaleX = 0x1000;
+        mScaleY = 0x1000;
+        mScaleZ = 0x1000;
+        unk_390 = 0;
+        unk_394 = 0;
     } else {
-        t = (*(unsigned short*)(c + 0xc) == 0xf1);
+        t = (mActorID == 0xf1);
         if (t != false) {
-            *(int*)(c + 0x80) = 0;
-            *(int*)(c + 0x84) = 0;
-            *(int*)(c + 0x88) = 0;
-            *(void**)(c + 0x390) = _ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 8));
-            *(int*)(c + 0x394) = 0;
+            mScaleX = 0;
+            mScaleY = 0;
+            mScaleZ = 0;
+            *(void**)((char*)&unk_390) = _ZN5Actor10FindWithIDEj(mParam);
+            unk_394 = 0;
             {
-                int* p = (int*)(((int)*(char**)(c + 0x390) + 0x36c) & 0xFFFFFFFFFFFFFFFF);
-                *(int*)(c + 0x36c) = p[0];
-                *(int*)(c + 0x370) = p[1];
-                *(int*)(c + 0x374) = p[2];
+                int* p = (int*)(((int)*(char**)((char*)&unk_390) + 0x36c) & 0xFFFFFFFFFFFFFFFF);
+                unk_36c = p[0];
+                unk_370 = p[1];
+                unk_374 = p[2];
             }
         }
     }
 
-    func_ov096_02136928(c, 1);
-    *(Block48*)(c + 0x33c) = data_02082128;
-    func_ov096_02135efc(c);
+    func_ov096_02136928(((char*)this), 1);
+    *(Block48*)((char*)&unk_33c) = data_02082128;
+    func_ov096_02135efc(((char*)this));
     return 1;
 }

--- a/src/_ZN5Pokey16CleanupResourcesEv.cpp
+++ b/src/_ZN5Pokey16CleanupResourcesEv.cpp
@@ -1,14 +1,20 @@
 //cpp
+// @symbol _ZN5Pokey16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Pokey.h"
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void *);
 extern int data_ov096_02137b20[];
 extern int data_ov096_02137b28[];
-int _ZN5Pokey16CleanupResourcesEv(char *c){
-  int id = *(unsigned short*)(c+0xc);
+}
+
+int Pokey::CleanupResources()
+{
+  int id = mActorID;
   int a = (id == 0xf0);
   if (a) {
-    UnloadBlueCoinModel(c);
+    UnloadBlueCoinModel(((char *)this));
     _ZN13SharedFilePtr7ReleaseEv(data_ov096_02137b20);
     _ZN13SharedFilePtr7ReleaseEv(data_ov096_02137b28);
   } else {
@@ -18,5 +24,4 @@ int _ZN5Pokey16CleanupResourcesEv(char *c){
     }
   }
   return 1;
-}
 }

--- a/src/_ZN5Pokey6RenderEv.cpp
+++ b/src/_ZN5Pokey6RenderEv.cpp
@@ -1,12 +1,16 @@
 //cpp
+// @symbol _ZN5Pokey6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Pokey.h"
 struct Arg;
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(Arg*); };
 struct Obj { char pad[0xb0]; unsigned int flags; char pad2[0xd4-0xb4]; Sub sub; };
-extern "C" int _ZN5Pokey6RenderEv(Obj *c)
+
+int Pokey::Render()
 {
-    unsigned int f = c->flags;
+    unsigned int f = ((Obj *)this)->flags;
     int b = ((f & 0x40000) != 0);
     if(b) return 1;
-    c->sub.m((Arg*)((char*)c+0x80));
+    ((Obj *)this)->sub.m((Arg*)((char*)&mScaleX));
     return 1;
 }

--- a/src/_ZN5PokeyD0Ev.c
+++ b/src/_ZN5PokeyD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN5PokeyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daSanbo_c */
 extern void *G0;
 int *_ZN5PokeyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daSanbo_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x180);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x14c);
     _ZN11ShadowModelD1Ev((char *)t + 0x124);

--- a/src/_ZN5Scene14StartSceneFadeEjjt.c
+++ b/src/_ZN5Scene14StartSceneFadeEjjt.c
@@ -1,7 +1,11 @@
+// @symbol _ZN5Scene14StartSceneFadeEjjt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Scene.h"
+/* recovered: named members + shared header */
+#include "Scene.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 
-extern int _ZN5Scene15SetSceneToSpawnEjj(u32 actorID, u32 param);
 
 struct FaderColor {
     int vtable_dummy; // 0x0

--- a/src/_ZN5Scene15SetSceneToSpawnEjj.c
+++ b/src/_ZN5Scene15SetSceneToSpawnEjj.c
@@ -1,5 +1,9 @@
+// @symbol _ZN5Scene15SetSceneToSpawnEjj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Scene.h"
 extern unsigned short data_02092664;
-extern unsigned int data_0209f5b8;
 int _ZN5Scene15SetSceneToSpawnEjj(unsigned int a, unsigned int b){
   if (a != data_02092664){
     data_02092664 = a;

--- a/src/_ZN5Shark13InitResourcesEv.cpp
+++ b/src/_ZN5Shark13InitResourcesEv.cpp
@@ -1,45 +1,47 @@
 //cpp
+// @symbol _ZN5Shark13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Shark.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* file, int a, int b);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN7PathPtrC1Ev(void* thiz);
 extern void _ZN7PathPtr6FromIDEj(void* thiz, unsigned int id);
-extern int _ZNK7PathPtr8NumNodesEv(void* thiz);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void* thiz, void* actor, void* pos, int f, int g, unsigned int h, unsigned int i);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* thiz, void* out, unsigned int j);
-extern void func_ov090_021338b4(void* c, void* p);
 
-extern char data_ov090_021345a4[];
 extern char data_ov090_021345ac[];
-extern char data_ov090_021345cc[];
 
 struct PathPtr { int a; int b; };
+}
 
-int _ZN5Shark13InitResourcesEv(char* c)
+int Shark::InitResources()
 {
     PathPtr p1;
     PathPtr p2;
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x30c,
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x30c,
         _ZN5Model8LoadFileER13SharedFilePtr(data_ov090_021345a4), 1, -1);
     _ZN9Animation8LoadFileER13SharedFilePtr(data_ov090_021345ac);
-    *(int*)(c + 0x388) = *(int*)(c + 8) & 0xff;
-    if (*(int*)(c + 0x388) < 0) *(int*)(c + 0x388) = 0;
+    mPathID = mParam & 0xff;
+    if (mPathID < 0) mPathID = 0;
     _ZN7PathPtrC1Ev(&p1);
-    _ZN7PathPtr6FromIDEj(&p1, *(int*)(c + 0x388));
-    *(int*)(c + 0x38c) = _ZNK7PathPtr8NumNodesEv(&p1);
-    *(int*)(c + 0xa0) = -0x3c000;
-    *(int*)(c + 0x374) = 0;
-    *(int*)(c + 0x378) = 0;
-    *(int*)(c + 0x37c) = 0;
+    _ZN7PathPtr6FromIDEj(&p1, mPathID);
+    unk_38c = _ZNK7PathPtr8NumNodesEv(&p1);
+    unk_0a0 = -0x3c000;
+    unk_374 = 0;
+    unk_378 = 0;
+    unk_37c = 0;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-        c + 0x110, c, c + 0x374, 0x42000, 0x6e000, 0x200004, 0);
+        ((char*)this) + 0x110, ((char*)this), ((char*)this) + 0x374, 0x42000, 0x6e000, 0x200004, 0);
     _ZN7PathPtrC1Ev(&p2);
-    _ZN7PathPtr6FromIDEj(&p2, *(int*)(c + 0x388));
-    *(int*)(c + 0x390) = 1;
-    _ZNK7PathPtr7GetNodeER7Vector3j(&p2, c + 0x5c, *(int*)(c + 0x390));
-    func_ov090_021338b4(c, data_ov090_021345cc);
+    _ZN7PathPtr6FromIDEj(&p2, mPathID);
+    mPathNodeIdx = 1;
+    _ZNK7PathPtr7GetNodeER7Vector3j(&p2, ((char*)this) + 0x5c, mPathNodeIdx);
+    func_ov090_021338b4(((char*)this), data_ov090_021345cc);
     return 1;
-}
 }

--- a/src/_ZN5Shark6RenderEv.cpp
+++ b/src/_ZN5Shark6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN5Shark6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Shark.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x30c]; Base base; };
-extern "C" int _ZN5Shark6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Shark::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN5SharkD0Ev.c
+++ b/src/_ZN5SharkD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN5SharkD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daShark_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN5SharkD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daShark_c;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN5SharkD1Ev.c
+++ b/src/_ZN5SharkD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN5SharkD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Shark */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN5SharkD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV5Shark;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN5Spiny13InitResourcesEv.cpp
+++ b/src/_ZN5Spiny13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Spiny13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BCA_File;
@@ -13,7 +18,6 @@ extern "C" int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, Actor *a, int b, int c, unsigned int d, unsigned int e);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, Actor *a, int b, int c, Vector3_16 *d, Vector3_16 *e);
 extern "C" int func_ov077_02125e94(void *c, int a, int b);
-extern "C" void func_ov077_02125304(char *c);
 
 extern SharedFilePtr data_ov077_02127b48;
 extern SharedFilePtr data_ov077_02127b38;
@@ -22,25 +26,25 @@ extern char data_02082128;
 
 struct M48 { int w[12]; };
 
-extern "C" int _ZN5Spiny13InitResourcesEv(char *c)
+int Spiny::InitResources()
 {
     BMD_File *bmd;
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b48);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, bmd, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0xd4, bmd, 1, -1);
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov077_02127b38);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x124, bmd, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x124, bmd, 1, -1);
     _ZN9Animation8LoadFileER13SharedFilePtr(data_ov077_02127c14);
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x124, *(BCA_File **)((char *)&data_ov077_02127c14 + 4), 0, 0x1000, 0);
-    if (!_ZN11ShadowModel12InitCylinderEv(c + 0x188))
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x124, *(BCA_File **)((char *)&data_ov077_02127c14 + 4), 0, 0x1000, 0);
+    if (!_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel))
         return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x1b0, (Actor *)c, 0x2d000, 0x3c000, 0x200000, 0x4a3d0);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1e4, (Actor *)c, 0x2d000, 0, (Vector3_16 *)(c + 0x92), (Vector3_16 *)(c + 0x8c));
-    *(int *)(c + 0x80) = 0x1000;
-    *(int *)(c + 0x84) = 0x1000;
-    *(int *)(c + 0x88) = 0x1000;
-    *(unsigned char *)(c + 0x3e9) = 0x2c;
-    func_ov077_02125e94(c, 0, 0x2c);
-    *(M48 *)(c + 0x3a0) = *(M48 *)&data_02082128;
-    func_ov077_02125304(c);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x1b0, (Actor *)((char *)this), 0x2d000, 0x3c000, 0x200000, 0x4a3d0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x1e4, (Actor *)((char *)this), 0x2d000, 0, (Vector3_16 *)((char *)&unk_092), (Vector3_16 *)((char *)&unk_08c));
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    unk_3e9 = 0x2c;
+    func_ov077_02125e94(((char *)this), 0, 0x2c);
+    *(M48 *)((char *)&unk_3a0) = *(M48 *)&data_02082128;
+    func_ov077_02125304(((char *)this));
     return 1;
 }

--- a/src/_ZN5Spiny6RenderEv.cpp
+++ b/src/_ZN5Spiny6RenderEv.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol _ZN5Spiny6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
 struct Obj {
   virtual void m0(); virtual void m1(); virtual void m2();
   virtual void m3(); virtual void m4(); virtual void doit(int);
 };
-extern "C" int _ZN5Spiny6RenderEv(char *c){
-  if((*(unsigned*)(c+0xb0) & 0x40000) ? 1 : 0) return 1;
-  int s=*(int*)(c+0x3d8);
-  if(s==0 || s==4) ((Obj*)(c+0xd4))->doit(0);
-  else ((Obj*)(c+0x124))->doit(0);
+
+int Spiny::Render()
+{
+  if((*(unsigned*)((char *)&unk_0b0) & 0x40000) ? 1 : 0) return 1;
+  int s=unk_3d8;
+  if(s==0 || s==4) ((Obj*)((char *)&mModel))->doit(0);
+  else ((Obj*)((char *)&mModelAnim))->doit(0);
   return 1;
 }

--- a/src/_ZN5Spiny8BehaviorEv.cpp
+++ b/src/_ZN5Spiny8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Spiny8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Spiny.h"
 extern "C" {
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
 int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void* c, int d);
@@ -12,30 +15,30 @@ void _ZN5Actor8PoofDustEv(void* c);
 void func_02012694(int a, void* p);
 
 extern signed char data_0209f2f8;
+}
 
-int _ZN5Spiny8BehaviorEv(char* c)
+int Spiny::Behavior()
 {
-    int s = *(int*)(c + 0x3d8);
-    if (s != 1 || _ZNK12WithMeshClsn10IsOnGroundEv(c + 0x1e4)) {
-        s = *(int*)(c + 0x3d8);
-        if (s != 4 && s != 5 && _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, 0x5dc000)) {
-            if (DecIfAbove0_Byte((unsigned char*)(c + 0x3e9)) == 0) {
-                _ZN9ActorBase18MarkForDestructionEv(c);
+    int s = unk_3d8;
+    if (s != 1 || _ZNK12WithMeshClsn10IsOnGroundEv((char*)&mWithMeshClsn)) {
+        s = unk_3d8;
+        if (s != 4 && s != 5 && _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(((char*)this), 0x5dc000)) {
+            if (DecIfAbove0_Byte((unsigned char*)((char*)&unk_3e9)) == 0) {
+                _ZN9ActorBase18MarkForDestructionEv(((char*)this));
                 return 1;
             }
             goto done;
         }
     }
-    func_ov077_02124c28(c);
-    func_ov077_02125e20(c);
-    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x1b0);
-    func_ov077_02125304(c);
-    if (data_0209f2f8 == 0x1c && *(int*)(c + 0x60) <= -0x1600000) {
-        _ZN5Actor8PoofDustEv(c);
-        func_02012694(0xc4, c + 0x74);
-        _ZN9ActorBase18MarkForDestructionEv(c);
+    func_ov077_02124c28(((char*)this));
+    func_ov077_02125e20(((char*)this));
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char*)this), ((char*)this) + 0x1b0);
+    func_ov077_02125304(((char*)this));
+    if (data_0209f2f8 == 0x1c && mPosY <= -0x1600000) {
+        _ZN5Actor8PoofDustEv(((char*)this));
+        func_02012694(0xc4, ((char*)this) + 0x74);
+        _ZN9ActorBase18MarkForDestructionEv(((char*)this));
     }
 done:
     return 1;
-}
 }

--- a/src/_ZN5SpinyD0Ev.c
+++ b/src/_ZN5SpinyD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN5SpinyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daTgz_c */
 extern void *G0;
 int *_ZN5SpinyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daTgz_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1e4);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x1b0);
     _ZN11ShadowModelD1Ev((char *)t + 0x188);

--- a/src/_ZN5Stage11RenderModelEv.cpp
+++ b/src/_ZN5Stage11RenderModelEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Stage11RenderModelEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Stage.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -40,15 +45,14 @@ struct ModelBase {
 };
 
 extern Info *data_0209f340;
-extern char data_020755d4;
 
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *transformer, ModelComponents &mc);
 
-extern "C" void _ZN5Stage11RenderModelEv(char *self)
+void Stage::RenderModel()
 {
-    ModelComponents *mc = (ModelComponents *)(((long long)(int)(self + 0x874)) & 0xFFFFFFFFFFFFFFFFLL);
+    ModelComponents *mc = (ModelComponents *)(((long long)(int)((char *)&unk_874)));
     Inner *inner = *(Inner **)((char *)mc->sub + 8);
-    Slot *slot = (Slot *)(self + 0x8bc);
+    Slot *slot = (Slot *)((char *)&unk_8bc);
     int i;
 
     for (i = 0; i < data_0209f340->count; i++) {
@@ -63,10 +67,10 @@ extern "C" void _ZN5Stage11RenderModelEv(char *self)
                 idx++;
                 u32 flagsTest = *(volatile u32 *)&comp->flags;
                 if ((flagsTest & 0x1f0000) == 0x1f0000) {
-                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)));
                     *p &= ~0x80000000;
                 } else {
-                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+                    u32 *p = (u32 *)(((long long)(int)((char *)comp + 0x24)));
                     *p |= 0x80000000;
                 }
             }
@@ -77,7 +81,7 @@ extern "C" void _ZN5Stage11RenderModelEv(char *self)
             for (j = 0; j < inner->count; j++) {
                 u8 id = *idx;
                 Component *comp = (Component *)((char *)mc->components + id * 0x30);
-                *(u32 *)(((long long)(int)((char *)comp + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80000000;
+                *(u32 *)(((long long)(int)((char *)comp + 0x24))) |= 0x80000000;
                 idx++;
             }
         }
@@ -86,5 +90,5 @@ extern "C" void _ZN5Stage11RenderModelEv(char *self)
         inner = (Inner *)((char *)inner + 0x40);
     }
 
-    ((ModelBase *)(self + 0x86c))->Render(&data_020755d4);
+    ((ModelBase *)((char *)&unk_86c))->Render(&data_020755d4);
 }

--- a/src/_ZN5Stage14GraphCallback2EP12SceneRelated.c
+++ b/src/_ZN5Stage14GraphCallback2EP12SceneRelated.c
@@ -1,3 +1,8 @@
+// @symbol _ZN5Stage14GraphCallback2EP12SceneRelated
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Stage.h"
 // Stage::GraphCallback2 - sets BG3 affine transform from SceneRelated
 typedef int s32;
 typedef unsigned short u16;
@@ -21,16 +26,15 @@ struct SceneRelated {
     struct Matrix2x2* mat;
 };
 
-extern vu16 reg_G2S_DB_BG3PA;
 extern void _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(vu16* reg, struct Matrix2x2* mat, s32 a, s32 b, s32 c, s32 d);
 
-s32 _ZN5Stage14GraphCallback2EP12SceneRelated(struct SceneRelated* arg) {
+s32 _ZN5Stage14GraphCallback2EP12SceneRelated(struct Stage *self) {
     _ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii(
         &reg_G2S_DB_BG3PA,
-        (struct Matrix2x2*)((unsigned char*)arg + 4),
-        arg->unk14,
-        arg->unk18,
-        arg->unk1c,
-        arg->unk20);
+        (struct Matrix2x2*)((unsigned char*)&self->unk_004),
+        ((struct SceneRelated*)self)->unk14,
+        ((struct SceneRelated*)self)->unk18,
+        ((struct SceneRelated*)self)->unk1c,
+        ((struct SceneRelated*)self)->unk20);
     return 1;
 }

--- a/src/_ZN5Stage16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stage16CleanupResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Stage16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Stage.h"
 /* _ZN5Stage16CleanupResourcesEv @ 0x0202c9a8 (arm9, size 0x264)
  * Releases the level file handles, tears down fader/mesh-collider/message
  * state and unloads the level overlays/archive. Returns 1.
@@ -48,8 +51,9 @@ static inline void DestroyVirt(void **o)
     if (o)
         ((void (*)(void *))((void **)o[0])[1])((void *)o);
 }
+}
 
-int _ZN5Stage16CleanupResourcesEv(char *thiz)
+int Stage::CleanupResources()
 {
     u32 i;
 
@@ -65,13 +69,13 @@ int _ZN5Stage16CleanupResourcesEv(char *thiz)
     data_0209d4a8 = 0;
 
     {
-        void **o = *(void ***)(thiz + 0x9bc);
+        void **o = *(void ***)((char *)&unk_9bc);
         if (o)
             DestroyVirt(o);
     }
 
     {
-        char *e = thiz + 0x8bc;
+        char *e = ((char *)this) + 0x8bc;
         int j;
         for (j = 0; j < *(u8 *)(data_0209f340 + 0x14); j++, e += 0xc) {
             void **o = *(void ***)e;
@@ -95,9 +99,9 @@ int _ZN5Stage16CleanupResourcesEv(char *thiz)
     func_02073244(data_0209f324, 0x60, 8, _ZN9FaderWipeD1Ev);
     data_0209f324 = 0;
     CleanCommonModelDataArr();
-    _ZN16MeshColliderBase7DisableEv(thiz + 0x91c);
+    _ZN16MeshColliderBase7DisableEv((char *)&unk_91c);
     _ZN5Stage18ResetMeshCollidersEv();
-    func_01ffb0c8(thiz + 0x91c);
+    func_01ffb0c8((char *)&unk_91c);
     Deallocate();
     _Z19UnloadLevelOverlaysi(data_0209f2f8);
     if (data_0209f2f8 == 1)
@@ -128,5 +132,4 @@ int _ZN5Stage16CleanupResourcesEv(char *thiz)
         }
     }
     return 1;
-}
 }

--- a/src/_ZN5Stage17PS_UpdateSaveMenuEb.c
+++ b/src/_ZN5Stage17PS_UpdateSaveMenuEb.c
@@ -1,8 +1,10 @@
+// @symbol _ZN5Stage17PS_UpdateSaveMenuEb
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Stage.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
-extern u16 data_020755c8[];
-extern u8 data_0209f2e0;
-extern u8 data_0209f244;
 extern u16 *_ZN3G2S12GetBG1ScrPtrEv(void);
 
 void _ZN5Stage17PS_UpdateSaveMenuEb(int b)

--- a/src/_ZN5Stage17UpdateMenuButtonsEb.c
+++ b/src/_ZN5Stage17UpdateMenuButtonsEb.c
@@ -1,12 +1,12 @@
+// @symbol _ZN5Stage17UpdateMenuButtonsEb
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Stage.h"
 
     typedef unsigned char u8;
     typedef unsigned short u16;
-    extern u8 data_0209f2b4;
-    extern u16 data_0209f360[];
-    extern u8 data_0209f2e0;
-    extern u8 data_0209f244;
     extern u8 data_0209f2c4;
-    extern u8 data_0209f248;
     extern unsigned short *_ZN3G2S12GetBG1ScrPtrEv(void);
     void _ZN5Stage17UpdateMenuButtonsEb(int b)
     {

--- a/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
+++ b/src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Stage.h"
 struct KCL_File;
 struct CLPS_Block;
 struct MeshCollider;
@@ -23,24 +28,18 @@ struct LVL_Overlay_s {
 
 extern "C" {
 
-extern short data_ov002_0211118c;
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0[];
 extern struct ActorBase* data_0209f5c0;
 
-extern void func_0203accc(int v);
-extern void func_0203aca0(int a, int b);
 extern struct KCL_File* LoadFile(int handle);
 extern void _ZN12MeshCollider17UpdateFileOffsetsER8KCL_File(struct KCL_File* f);
 extern void _ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block(struct MeshCollider* thiz, struct KCL_File* f, struct CLPS_Block* clps);
 extern int _ZNK12MeshCollider16GetOctreeOriginYEv(struct MeshCollider* thiz);
 extern int _ZNK12MeshCollider13GetUnkOctreeYEv(struct MeshCollider* thiz);
-extern void func_0202a850(int a, int b);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(struct MeshCollider* thiz, struct Actor* a);
 extern void _Z11LoadObjectsRN11LVL_Overlay8ObjTableEij(struct ObjTable* t, int i, unsigned int p);
-extern int ContinueKuppaScriptIfNecessary(void);
 extern void _ZN12ActorDerived5SpawnEjP9ActorBaseii(unsigned int id, struct ActorBase* parent, int a, int b);
-extern void StartIntroCutscene(void);
 
 void _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider(struct LVL_Overlay_s* ovl, unsigned int p, struct MeshCollider* mc)
 {

--- a/src/_ZN5Stage22RenderModelTransparentEv.cpp
+++ b/src/_ZN5Stage22RenderModelTransparentEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Stage22RenderModelTransparentEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Stage.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -13,14 +18,13 @@ struct VBase {
 
 extern "C" {
 extern char *data_0209f340;
-extern char data_020755d4;
 }
 
-extern "C" void _ZN5Stage22RenderModelTransparentEv(char *c)
+void Stage::RenderModelTransparent()
 {
-    char *p = (char *)(((int)c + 0x874) & 0xFFFFFFFFFFFFFFFF);
+    char *p = (char *)(((int)((char *)this) + 0x874) & 0xFFFFFFFFFFFFFFFF);
     char *arr = *(char **)(*(char **)p + 8);
-    char *q = c + 0x8bc;
+    char *q = ((char *)this) + 0x8bc;
     int i;
     for (i = 0; i < *(u8 *)(data_0209f340 + 0x14); i++, q += 0xc, arr += 0x40) {
         if (*(u8 *)(q + 4) != 0) {
@@ -36,5 +40,5 @@ extern "C" void _ZN5Stage22RenderModelTransparentEv(char *c)
             }
         }
     }
-    ((VBase *)(c + 0x86c))->m5(&data_020755d4);
+    ((VBase *)((char *)&unk_86c))->m5(&data_020755d4);
 }

--- a/src/_ZN5Stage9RenderFogEv.cpp
+++ b/src/_ZN5Stage9RenderFogEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Stage9RenderFogEv
+/* recovered: named members + shared header, real C++ method */
+#include "Stage.h"
 extern "C" {
 extern signed char data_0209f2f8;
 extern int data_0209f318[];
@@ -7,8 +10,10 @@ int _ZNK6Camera12IsUnderwaterEv(void *self);
 void _ZN3G3X6SetFogEbiii(int b, int a1, int a2, int a3);
 void _ZN3G3X11SetFogTableEPv(void *p);
 }
-extern "C" void _ZN5Stage9RenderFogEv(void *thiz){
-  char *c=(char*)thiz;
+
+void Stage::RenderFog()
+{
+  char *c=(char*)((void *)this);
   char *r4=0;
   if(data_0209f2f8==5) r4=(char*)func_ov002_020f1c20();
   if(r4==0){

--- a/src/_ZN5Stump6RenderEv.cpp
+++ b/src/_ZN5Stump6RenderEv.cpp
@@ -1,12 +1,16 @@
 //cpp
+// @symbol _ZN5Stump6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Stump.h"
 extern "C" {
 struct V { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual int m5(int); };
-int _ZN5Stump6RenderEv(char *c)
-{
-    if (*(int*)(c+0x374) == 1) return 1;
-    int b = (*(int*)(c+0xb0) & 0x40000) != 0;
-    if (b) return 1;
-    ((V*)(c+0x300))->m5(0);
-    return 1;
 }
+
+int Stump::Render()
+{
+    if (mVariant == 1) return 1;
+    int b = (unk_0b0 & 0x40000) != 0;
+    if (b) return 1;
+    ((V*)((char *)&mModelAnim))->m5(0);
+    return 1;
 }

--- a/src/_ZN5Stump8BehaviorEv.cpp
+++ b/src/_ZN5Stump8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN5Stump8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Stump.h"
 struct WithMeshClsn;
 struct CylinderClsn;
 struct Enemy;
@@ -9,20 +14,18 @@ extern "C" {
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
-extern void func_ov091_02134094(char *c);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(Enemy *thiz, void *clsn);
-extern void func_ov091_021339fc(char *thiz);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *wm, unsigned int j);
 extern void _ZN9Animation7AdvanceEv(void *thiz);
 }
 
 struct Enemy { char pad[0x800]; };
 
-extern "C" int _ZN5Stump8BehaviorEv(Enemy *thiz)
+int Stump::Behavior()
 {
-    char *c = (char *)thiz;
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+    char *c = (char *)((Enemy *)this);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144)) != 0) {
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         if (*(unsigned char *)(c + 0x107) != 0) {
             if (*(unsigned short *)(c + 0x104) == 0) {
@@ -36,7 +39,7 @@ extern "C" int _ZN5Stump8BehaviorEv(Enemy *thiz)
     DecIfAbove0_Short((unsigned short *)(c + 0x100));
     {
         Holder *q = *(Holder **)(c + 0x364);
-        if (q->fn != 0) (thiz->*(q->fn))();
+        if (q->fn != 0) (((Enemy *)this)->*(q->fn))();
     }
     *(short *)(c + 0x8c) = *(short *)(c + 0x92);
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
@@ -50,13 +53,13 @@ extern "C" int _ZN5Stump8BehaviorEv(Enemy *thiz)
         *(int *)(c + 0xa8) = hi;
         *(int *)(c + 0xac) = tmp;
     }
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(thiz, (void *)(c + 0x110));
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((Enemy *)this), (void *)(c + 0x110));
     func_ov091_021339fc(c);
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     _ZN12CylinderClsn6UpdateEv(c + 0x110);
 
     if (*(int *)(c + 0x374) == 1) {
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
         return 1;
     }
 

--- a/src/_ZN5StumpD0Ev.c
+++ b/src/_ZN5StumpD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5StumpD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daHyuhyu_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN5StumpD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daHyuhyu_c;
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN5StumpD1Ev.c
+++ b/src/_ZN5StumpD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5StumpD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Stump */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN5StumpD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV5Stump;
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN5Swoop6RenderEv.cpp
+++ b/src/_ZN5Swoop6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Swoop6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Swoop.h"
 struct Base {
     virtual void v0();
     virtual void v1();
@@ -8,16 +11,15 @@ struct Base {
     virtual void m(int a);
 };
 
-extern "C" int _ZN5Swoop6RenderEv(char *c);
-extern "C" int _ZN5Swoop6RenderEv(char *c)
+int Swoop::Render()
 {
-    int flag = (*(int *)(c + 0xb0) & 0x40000) != 0;
+    int flag = (unk_0b0 & 0x40000) != 0;
     if (flag != 0) return 1;
-    if (*(unsigned char *)(c + 0x43c) == 1) {
-        Base *b = (Base *)(c + 0x300);
+    if (unk_43c == 1) {
+        Base *b = (Base *)((char *)&mModelAnim1);
         b->m(0);
     } else {
-        Base *b = (Base *)(c + 0x364);
+        Base *b = (Base *)((char *)&mModelAnim2);
         b->m(0);
     }
     return 1;

--- a/src/_ZN5Swoop8BehaviorEv.cpp
+++ b/src/_ZN5Swoop8BehaviorEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN5Swoop8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Swoop.h"
 struct WithMeshClsn;
 struct ModelAnim;
 struct Enemy;
@@ -9,28 +15,24 @@ extern "C" {
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
-extern void func_ov065_02117994(char *c);
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(Enemy *thiz, WithMeshClsn *wm, ModelAnim *ma, unsigned int j);
 extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(Enemy *thiz, WithMeshClsn *wm);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
-extern int _ZNK9Animation12WillHitFrameEi(void *thiz, int frame);
 extern void func_02012694(int, void *);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(Enemy *thiz, void *clsn);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *wm, unsigned int j);
-extern void func_ov065_0211704c(char *c);
 extern char *_ZN5Actor13ClosestPlayerEv(Enemy *thiz);
 extern void _ZN9Animation7AdvanceEv(void *thiz);
 
-extern char data_ov065_0211d6e0[];
 extern char data_ov065_0211d6f0[];
 }
 
 struct Enemy { char pad[0x800]; };
 
-extern "C" int _ZN5Swoop8BehaviorEv(Enemy *thiz)
+int Swoop::Behavior()
 {
-    char *c = (char *)thiz;
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+    char *c = (char *)((Enemy *)this);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144)) != 0) {
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         if (*(unsigned char *)(c + 0x107) != 0) {
             if (*(unsigned short *)(c + 0x104) == 0) {
@@ -40,18 +42,18 @@ extern "C" int _ZN5Swoop8BehaviorEv(Enemy *thiz)
         func_ov065_02117994(c);
         return 1;
     }
-    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(thiz, (WithMeshClsn *)(c + 0x144), (ModelAnim *)(c + 0x300), 3) != 0) {
+    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), (ModelAnim *)(c + 0x300), 3) != 0) {
         return 1;
     }
     if (*(int *)(c + 0x10c) != 0) {
-        _ZN5Enemy11UpdateDeathER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144));
+        _ZN5Enemy11UpdateDeathER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144));
         func_ov065_02117994(c);
         return 1;
     }
     DecIfAbove0_Short((unsigned short *)(c + 0x100));
     {
         Holder *q = *(Holder **)(c + 0x420);
-        if (q->fn != 0) (thiz->*(q->fn))();
+        if (q->fn != 0) (((Enemy *)this)->*(q->fn))();
     }
     {
         char *m = *(char **)(c + 0x420);
@@ -72,8 +74,8 @@ extern "C" int _ZN5Swoop8BehaviorEv(Enemy *thiz)
         *(int *)(c + 0xa8) = hi;
         *(int *)(c + 0xac) = tmp;
     }
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(thiz, (void *)(c + 0x110));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((Enemy *)this), (void *)(c + 0x110));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
     *(short *)(c + 0x8c) = *(short *)(c + 0x92);
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     *(short *)(c + 0x90) = *(short *)(c + 0x96);
@@ -83,7 +85,7 @@ extern "C" int _ZN5Swoop8BehaviorEv(Enemy *thiz)
     }
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {
-        char *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        char *p = _ZN5Actor13ClosestPlayerEv(((Enemy *)this));
         if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
             _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }

--- a/src/_ZN5SwoopD0Ev.c
+++ b/src/_ZN5SwoopD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5SwoopD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBasabasa_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN5SwoopD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBasabasa_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3c8);
     _ZN9ModelAnimD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN5SwoopD1Ev.c
+++ b/src/_ZN5SwoopD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN5SwoopD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV5Swoop */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN5SwoopD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV5Swoop;
     _ZN11ShadowModelD1Ev((char *)t + 0x3c8);
     _ZN9ModelAnimD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN5Timer10ResetTimerEv.cpp
+++ b/src/_ZN5Timer10ResetTimerEv.cpp
@@ -1,8 +1,12 @@
 //cpp
-#include "Timer.hpp"
+// @symbol _ZN5Timer10ResetTimerEv
+/* recovered: named members + shared header, real C++ method */
+#include "Timer.h"
+
 
 void Timer::ResetTimer()
 {
     mIsRunning = 0;
-    mTimeBase = 0;
+    unk_000 = 0;
+    unk_004 = 0;
 }

--- a/src/_ZN5Timer10StartTimerEv.cpp
+++ b/src/_ZN5Timer10StartTimerEv.cpp
@@ -1,10 +1,13 @@
 //cpp
-#include "Timer.hpp"
-
-extern "C" s64 func_02059650();
+// @symbol _ZN5Timer10StartTimerEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Timer.h"
+typedef long long s64;
 
 void Timer::StartTimer()
 {
-    mIsRunning = 1;
-    mTimeBase = func_02059650() - mTimeBase;
+  mIsRunning = 1;
+  *(s64*)((char *)this) = func_02059650() - *(s64*)((char *)this);
 }

--- a/src/_ZN5Timer7GetTimeEv.cpp
+++ b/src/_ZN5Timer7GetTimeEv.cpp
@@ -1,11 +1,14 @@
 //cpp
-#include "Timer.hpp"
-
-extern "C" s64 func_02059650();
+// @symbol _ZN5Timer7GetTimeEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Timer.h"
+typedef long long s64;
 
 s64 Timer::GetTime()
 {
-    if (!mIsRunning)
-        return mTimeBase;
-    return func_02059650() - mTimeBase;
+  if (mIsRunning == 0)
+    return *(s64*)((char *)this);
+  return func_02059650() - *(s64*)((char *)this);
 }

--- a/src/_ZN5Timer9StopTimerEv.cpp
+++ b/src/_ZN5Timer9StopTimerEv.cpp
@@ -1,12 +1,15 @@
 //cpp
-#include "Timer.hpp"
-
-extern "C" s64 func_02059650();
+// @symbol _ZN5Timer9StopTimerEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Timer.h"
+typedef long long s64;
 
 void Timer::StopTimer()
 {
-    if (!mIsRunning)
-        return;
-    mIsRunning = 0;
-    mTimeBase = func_02059650() - mTimeBase;
+  if (mIsRunning == 0)
+    return;
+  mIsRunning = 0;
+  *(s64*)((char *)this) = func_02059650() - *(s64*)((char *)this);
 }

--- a/src/_ZN5Unagi13InitResourcesEv.cpp
+++ b/src/_ZN5Unagi13InitResourcesEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN5Unagi13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Unagi.h"
 struct V3 { int x, y, z; };
 struct PathPtr { char b[8]; };
 
@@ -8,9 +14,7 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* m, void* f, int a, int b);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN7PathPtrC1Ev(void* p);
 extern void _ZN7PathPtr6FromIDEj(void* p, unsigned int id);
-extern int _ZNK7PathPtr8NumNodesEv(void* p);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, char* actor, struct V3* pos, int r3, int sp0, int sp4, int sp8);
-extern int SublevelToLevel(int i);
 extern int IsStarCollected(int a, int b);
 extern void func_ov016_02111bf0(char* c, void* p);
 extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, char* pos, void* d, int sp0, int sp4);
@@ -18,17 +22,12 @@ extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(char* a, int r1, int r2, int 
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* p, char* out, unsigned int n);
 extern short Vec3_HorzAngle(char* a, char* b);
 
-extern char data_ov016_02114d38[];
-extern char data_ov016_02114d20[];
-extern char data_ov016_02114d30[];
-extern char data_ov016_02114d28[];
 extern struct V3 data_ov016_02114d4c;
-extern void* data_ov016_02114d8c;
 extern void* data_ov016_02114dbc;
 extern unsigned char data_0209f220;
 }
 
-extern "C" int _ZN5Unagi13InitResourcesEv(char* c)
+int Unagi::InitResources()
 {
     PathPtr path1;
     PathPtr path2;
@@ -42,39 +41,39 @@ extern "C" int _ZN5Unagi13InitResourcesEv(char* c)
     char* spawned;
 
     f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov016_02114d38);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x350, f, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x350, f, 1, -1);
     _ZN9Animation8LoadFileER13SharedFilePtr(data_ov016_02114d20);
     _ZN9Animation8LoadFileER13SharedFilePtr(data_ov016_02114d30);
     _ZN9Animation8LoadFileER13SharedFilePtr(data_ov016_02114d28);
 
-    *(int*)(c + 0x404) = *(int*)(c + 8) & 0xff;
-    *(int*)(c + 0x408) = (*(unsigned int*)(c + 8) >> 8) & 0xf;
-    *(unsigned char*)(c + 0x414) = (*(unsigned int*)(c + 8) >> 0xc) & 0xf;
-    if (*(int*)(c + 0x408) == 0xff)
-        *(int*)(c + 0x408) = 0;
-    if (*(int*)(c + 0x404) < 0)
-        *(int*)(c + 0x404) = 0;
+    mPathID = mParam & 0xff;
+    mVariant = (mParam >> 8) & 0xf;
+    unk_414 = (mParam >> 0xc) & 0xf;
+    if (mVariant == 0xff)
+        mVariant = 0;
+    if (mPathID < 0)
+        mPathID = 0;
 
     _ZN7PathPtrC1Ev(&path1);
-    _ZN7PathPtr6FromIDEj(&path1, *(int*)(c + 0x404));
-    *(int*)(c + 0x40c) = _ZNK7PathPtr8NumNodesEv(&path1);
+    _ZN7PathPtr6FromIDEj(&path1, mPathID);
+    unk_40c = _ZNK7PathPtr8NumNodesEv(&path1);
 
-    *(int*)(c + 0x3f0) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x3f4) = *(int*)(c + 0x60);
-    *(int*)(c + 0x3f8) = *(int*)(c + 0x64);
-    *(int*)(c + 0xa0) = -0x1e000;
+    unk_3f0 = mPosX;
+    unk_3f4 = mPosY;
+    unk_3f8 = mPosZ;
+    unk_0a0 = -0x1e000;
     v1 = data_ov016_02114d4c;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-        c + 0x110, c, &v1, 0x32000, 0x50000, 0x200004, 0);
+        ((char*)this) + 0x110, ((char*)this), &v1, 0x32000, 0x50000, 0x200004, 0);
     v2 = data_ov016_02114d4c;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
-        c + 0x150, c, &v2, 0x32000, 0x50000, 0x200000, 0);
+        ((char*)this) + 0x150, ((char*)this), &v2, 0x32000, 0x50000, 0x200000, 0);
 
     _ZN7PathPtrC1Ev(&path2);
-    _ZN7PathPtr6FromIDEj(&path2, *(int*)(c + 0x404));
-    *(int*)(c + 0x410) = 1;
-    *(int*)(c + 0x49c) = 0;
-    *(int*)(c + 0x3ac) = 0x1000;
+    _ZN7PathPtr6FromIDEj(&path2, mPathID);
+    unk_410 = 1;
+    mStarUniqueID = 0;
+    unk_3ac = 0x1000;
 
     if (data_0209f220 == 1)
         goto check_param2;
@@ -82,15 +81,15 @@ extern "C" int _ZN5Unagi13InitResourcesEv(char* c)
         goto stage2_path;
 
 check_param2:
-    if (*(int*)(c + 0x408) != 2)
+    if (mVariant != 2)
         goto ret0_a;
     /* u64-mask forces add r2,r4,#0x3f4 materialization (ROM shape) */
-    *(int*)(((int)c + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80000;
-    *(int*)(c + 0x410) = 8;
-    if (*(int*)(c + 0x410) >= *(int*)(c + 0x40c))
-        *(int*)(c + 0x410) = 4;
-    *(int*)(c + 0x60) = *(int*)(c + 0x3f4);
-    func_ov016_02111bf0(c, &data_ov016_02114d8c);
+    *(int*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80000;
+    unk_410 = 8;
+    if (unk_410 >= unk_40c)
+        unk_410 = 4;
+    mPosY = unk_3f4;
+    func_ov016_02111bf0(((char*)this), &data_ov016_02114d8c);
     goto tail;
 ret0_a:
     return 0;
@@ -102,48 +101,48 @@ stage2_path:
         goto check_param0;
 
 check_param1:
-    if (*(int*)(c + 0x408) != 1)
+    if (mVariant != 1)
         goto ret0_b;
     spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        0xb2, *(unsigned char*)(c + 0x414) | 0x50, c + 0x5c, 0,
-        *(signed char*)(c + 0xcc), -1);
+        0xb2, unk_414 | 0x50, ((char*)this) + 0x5c, 0,
+        mAreaId, -1);
     if (spawned != 0) {
-        *(int*)(c + 0x49c) = *(int*)(spawned + 4);
+        mStarUniqueID = *(int*)(spawned + 4);
         *(int*)(spawned + 0xb0) = 0;
         _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(spawned, 0, 0x3e8000, 0x1f40000, 0x1f40000);
     }
-    func_ov016_02111bf0(c, &data_ov016_02114d8c);
+    func_ov016_02111bf0(((char*)this), &data_ov016_02114d8c);
     goto tail;
 ret0_b:
     return 0;
 
 check_param0:
-    if (*(int*)(c + 0x408) != 0)
+    if (mVariant != 0)
         goto ret0_c;
     _ZN7PathPtrC1Ev(&path3);
-    _ZN7PathPtr6FromIDEj(&path3, *(int*)(c + 0x404));
-    _ZNK7PathPtr7GetNodeER7Vector3j(&path3, c + 0x5c, 0);
-    _ZNK7PathPtr7GetNodeER7Vector3j(&path3, c + 0x5c, 1);
-    *(short*)(c + 0x94) = Vec3_HorzAngle(c + 0x5c, (char*)&node);
-    *(short*)(c + 0x8e) = *(short*)(c + 0x94);
-    func_ov016_02111bf0(c, &data_ov016_02114dbc);
+    _ZN7PathPtr6FromIDEj(&path3, mPathID);
+    _ZNK7PathPtr7GetNodeER7Vector3j(&path3, ((char*)this) + 0x5c, 0);
+    _ZNK7PathPtr7GetNodeER7Vector3j(&path3, ((char*)this) + 0x5c, 1);
+    unk_094 = Vec3_HorzAngle(((char*)this) + 0x5c, (char*)&node);
+    unk_08e = unk_094;
+    func_ov016_02111bf0(((char*)this), &data_ov016_02114dbc);
     goto tail;
 ret0_c:
     return 0;
 
 tail:
-    r3 = c;
+    r3 = ((char*)this);
     for (i = 0; i < 7; i++) {
         /* array index form -> add r0,r4,ip,lsl#1 (not strength-reduced i*2) */
-        ((short*)(c + 0x418))[i] = 0;
-        ((short*)(c + 0x426))[0] = 0;
-        *(int*)(r3 + 0x448) = *(int*)(c + 0x5c);
-        *(int*)(r3 + 0x44c) = *(int*)(c + 0x60);
-        *(int*)(r3 + 0x450) = *(int*)(c + 0x64);
+        ((short*)((char*)&unk_418))[i] = 0;
+        ((short*)((char*)&unk_426))[0] = 0;
+        *(int*)(r3 + 0x448) = mPosX;
+        *(int*)(r3 + 0x44c) = mPosY;
+        *(int*)(r3 + 0x450) = mPosZ;
         r3 += 0xc;
     }
-    *(short*)(c + 0x428) = *(short*)(c + 0x8c);
-    *(short*)(c + 0x42a) = *(short*)(c + 0x8e);
-    *(short*)(c + 0x42c) = *(short*)(c + 0x90);
+    unk_428 = unk_08c;
+    unk_42a = unk_08e;
+    unk_42c = unk_090;
     return 1;
 }

--- a/src/_ZN5Unagi6RenderEv.c
+++ b/src/_ZN5Unagi6RenderEv.c
@@ -1,24 +1,28 @@
+// @symbol _ZN5Unagi6RenderEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Unagi.h"
 extern int func_020167a4(char* p);
-extern int func_0204531c(char* p, int a);
 extern int _ZN5Model6RenderEPK7Vector3(char* p, void* v);
 struct DE { int w0, w1, w2; };
 extern struct DE data_ov016_02114908[];
 #pragma opt_strength_reduction off
-int _ZN5Unagi6RenderEv(char* c) {
+int _ZN5Unagi6RenderEv(struct Unagi *self) {
     int i;
     struct DE* dp;
     char* base;
-    func_020167a4(c+0x350);
-    base = (char*)(*(int*)(c+0x360) + 0x34);
+    func_020167a4((char*)&self->mBlendModelAnim);
+    base = (char*)(self->unk_360 + 0x34);
     dp = data_ov016_02114908;
     for (i = 1; i < 7; i++) {
-        short mv = ((short*)(c + 0x400 + 0x18))[i];
+        short mv = ((short*)(((char*)self) + 0x400 + 0x18))[i];
         unsigned short* curr = (unsigned short*)(((int)base + 0x1e) & 0xFFFFFFFFFFFFFFFF);
         *curr = *curr + (unsigned short)(short)(mv * dp->w2);
         dp++;
         base += 0x34;
     }
-    func_0204531c(c+0x358, *(int*)(c+0x3b4));
-    _ZN5Model6RenderEPK7Vector3(c+0x350, 0);
+    func_0204531c(((char*)self)+0x358, self->unk_3b4);
+    _ZN5Model6RenderEPK7Vector3(((char*)self)+0x350, 0);
     return 1;
 }

--- a/src/_ZN5Unagi8BehaviorEv.cpp
+++ b/src/_ZN5Unagi8BehaviorEv.cpp
@@ -1,21 +1,22 @@
 //cpp
+// @symbol _ZN5Unagi8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Unagi.h"
 typedef short s16;
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
 
 struct C;
 typedef void (C::*PMF)();
 
 extern "C" u16 DecIfAbove0_Short(u16* p);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
-extern "C" int func_ov016_02111c40(void* self);
 extern "C" void* _ZN5Actor10FindWithIDEj(unsigned id);
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern "C" int Vec3_Dist(const void* a, const void* b);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* self);
 extern "C" void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned a, unsigned b, const Vector3& pos, const Vector3_16* rot, int e, int f);
-extern "C" void func_ov016_02111284(void* self);
 extern "C" void _ZN12CylinderClsn5ClearEv(void* self);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void* self);
 extern "C" void _ZN14BlendModelAnim7AdvanceEv(void* self);
@@ -25,74 +26,75 @@ struct Disp { int unused[2]; PMF pmf; };
 extern "C" unsigned char data_0209f220;
 extern void* data_ov016_02114dbc;
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
 
-extern "C" int _ZN5Unagi8BehaviorEv(char* c) {
+int Unagi::Behavior()
+{
     void* found;
     unsigned id;
 
-    DecIfAbove0_Short((u16*)(c + 0x100));
+    DecIfAbove0_Short((u16*)((char*)&unk_100));
     {
-        Disp* d = *(Disp**)(c + 0x34c);
+        Disp* d = *(Disp**)((char*)&unk_34c);
         if (d->pmf) {
-            (((C*)c)->*(d->pmf))();
+            (((C*)((char*)this))->*(d->pmf))();
         }
     }
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
-    *(s16*)(c + 0x8c) = *(s16*)(c + 0x92);
-    *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-    *(s16*)(c + 0x90) = *(s16*)(c + 0x96);
-    func_ov016_02111c40(c);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this) + 0x110);
+    unk_08c = unk_092;
+    unk_08e = unk_094;
+    unk_090 = unk_096;
+    func_ov016_02111c40(((char*)this));
 
-    id = *(unsigned*)(c + 0x49c);
+    id = *(unsigned*)((char*)&mStarUniqueID);
     if (id != 0) {
         found = _ZN5Actor10FindWithIDEj(id);
         if (found == 0)
             goto clear_id;
-        if (*(int*)(c + 0x408) == 1) {
-            void* cp = _ZN5Actor13ClosestPlayerEv(c);
+        if (mVariant == 1) {
+            void* cp = _ZN5Actor13ClosestPlayerEv(((char*)this));
             if (cp != 0) {
                 int off43c = 0x43c;
-                if (Vec3_Dist(c + off43c, (char*)cp + 0x5c) < 0xfa000) {
+                if (Vec3_Dist(((char*)this) + off43c, (char*)cp + 0x5c) < 0xfa000) {
                     _ZN9ActorBase18MarkForDestructionEv(found);
                     {
-                        int param = *(signed char*)(c + 0xcc);
+                        int param = mAreaId;
                         int m1 = -1;
                         int off = 0x43c;
                         _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-                            0xb2, *(unsigned char*)(c + 0x414) | 0x40,
-                            *(Vector3*)(c + off), (Vector3_16*)0,
+                            0xb2, unk_414 | 0x40,
+                            *(Vector3*)(((char*)this) + off), (Vector3_16*)0,
                             param, m1);
                     }
-                    *(int*)(c + 0x49c) = 0;
+                    mStarUniqueID = 0;
                     goto after_first;
                 }
             }
         }
         goto after_first;
     clear_id:
-        *(int*)(c + 0x49c) = 0;
+        mStarUniqueID = 0;
     after_first:
-        if (*(int*)(c + 0x49c) != 0) {
+        if (mStarUniqueID != 0) {
 
-        int x = *(int*)(c + 0x43c);
+        int x = unk_43c;
         int off = 0x416;
         *(int*)((char*)found + 0x5c) = x;
-        short* r = (short*)LA(c + off);
-        *(int*)((char*)found + 0x60) = *(int*)(c + 0x440);
-        *(int*)((char*)found + 0x64) = *(int*)(c + 0x444);
+        short* r = (short*)LA(((char*)this) + off);
+        *(int*)((char*)found + 0x60) = unk_440;
+        *(int*)((char*)found + 0x64) = unk_444;
         *r += 0x1000;
 
         }
     }
 
-    func_ov016_02111284(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x110);
-    _ZN12CylinderClsn6UpdateEv(c + 0x110);
-    if (data_0209f220 == 1 && *(void**)(c + 0x34c) != &data_ov016_02114dbc) {
-        _ZN12CylinderClsn5ClearEv(c + 0x150);
-        _ZN12CylinderClsn6UpdateEv(c + 0x150);
+    func_ov016_02111284(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos1);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos1);
+    if (data_0209f220 == 1 && *(void**)((char*)&unk_34c) != &data_ov016_02114dbc) {
+        _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos2);
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos2);
     }
-    _ZN14BlendModelAnim7AdvanceEv(c + 0x350);
+    _ZN14BlendModelAnim7AdvanceEv((char*)&mBlendModelAnim);
     return 1;
 }

--- a/src/_ZN5UnagiD0Ev.cpp
+++ b/src/_ZN5UnagiD0Ev.cpp
@@ -1,23 +1,26 @@
 //cpp
+// @symbol _ZN5UnagiD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Unagi.h"
 extern "C" {
 extern int func_0207328c(void*,int,int,void*);
-extern void _ZN14BlendModelAnimD1Ev(void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern int func_ov002_020aed18(int*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
-extern int _ZTV5Unagi[];
 extern void func_020072c0(void);
 extern void* data_020a0eac[];
-void* _ZN5UnagiD0Ev(char* c){
-  *(int**)c = _ZTV5Unagi;
-  func_0207328c(c+0x448, 7, 0xc, (void*)func_020072c0);
-  _ZN14BlendModelAnimD1Ev(c+0x350);
-  _ZN12WithMeshClsnD1Ev(c+0x190);
-  _ZN25MovingCylinderClsnWithPosD1Ev(c+0x150);
-  _ZN25MovingCylinderClsnWithPosD1Ev(c+0x110);
-  func_ov002_020aed18((int*)c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac[0]);
-  return c;
+void* _ZN5UnagiD0Ev(struct Unagi *self) {
+  *(int**)((char*)self) = _ZTV5Unagi;
+  func_0207328c(((char*)self)+0x448, 7, 0xc, (void*)func_020072c0);
+  _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos2);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
+  func_ov002_020aed18((int*)((char*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self), data_020a0eac[0]);
+  return ((char*)self);
 }
 }

--- a/src/_ZN5UnagiD1Ev.c
+++ b/src/_ZN5UnagiD1Ev.c
@@ -1,18 +1,22 @@
+// @symbol _ZN5UnagiD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Unagi.h"
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN14BlendModelAnimD1Ev(void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern int func_ov002_020aed18(int*);
-extern int _ZTV5Unagi[];
 extern void func_020072c0(void);
 
-int _ZN5UnagiD1Ev(void* c) {
-    *(void**)c = _ZTV5Unagi;
-    func_0207328c((char*)c + 0x448, 7, 0xc, (void*)func_020072c0);
-    _ZN14BlendModelAnimD1Ev((char*)c + 0x350);
-    _ZN12WithMeshClsnD1Ev((char*)c + 0x190);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char*)c + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char*)c + 0x110);
-    func_ov002_020aed18((int*)c);
-    return (int)c;
+int _ZN5UnagiD1Ev(struct Unagi *self) {
+    *(void**)((void*)self) = _ZTV5Unagi;
+    func_0207328c((char*)((void*)self) + 0x448, 7, 0xc, (void*)func_020072c0);
+    _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+    _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos2);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos1);
+    func_ov002_020aed18((int*)((void*)self));
+    return (int)((void*)self);
 }

--- a/src/_ZN5Whomp6RenderEv.cpp
+++ b/src/_ZN5Whomp6RenderEv.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol _ZN5Whomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Whomp.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
-extern "C" {
-int _ZN5Whomp6RenderEv(char* c){
-  if(*(unsigned char*)(c+0x404)==0) return 1;
-  if(*(unsigned char*)(c+0x414)!=0)
-    _ZN15TextureSequence6UpdateER15ModelComponents(c+0x330, c+0x2d4);
-  ((Sub*)(c+0x2cc))->g5(0);
+
+int Whomp::Render()
+{
+  if(unk_404==0) return 1;
+  if(mIsKing!=0)
+    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x330, ((char*)this)+0x2d4);
+  ((Sub*)((char*)&mModelAnim))->g5(0);
   return 1;
-}
 }

--- a/src/_ZN5Whomp8BehaviorEv.cpp
+++ b/src/_ZN5Whomp8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN5Whomp8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Whomp.h"
 struct Actor; typedef int (Actor::*PMF)();
 struct WithMeshClsn;
 struct CylinderClsn;
@@ -18,21 +21,21 @@ void func_ov079_02124008(Actor* self);
 extern int data_0209f318;
 extern PMF data_ov079_02128280[];
 
-extern "C" int _ZN5Whomp8BehaviorEv(Actor* self)
+int Whomp::Behavior()
 {
-    char* c = (char*)self;
+    char* c = (char*)((Actor*)this);
 
     if (*(unsigned char*)(c + 0x414) != 0 && *(int*)(c + 0x3b0) != 9) {
-        if (_ZN5Actor13DistToCPlayerEv(self) < 0x1770000) {
-            *(int*)(*(int*)&data_0209f318 + 0x114) = (int)self;
+        if (_ZN5Actor13DistToCPlayerEv(((Actor*)this)) < 0x1770000) {
+            *(int*)(*(int*)&data_0209f318 + 0x114) = (int)((Actor*)this);
         }
     }
 
-    func_ov079_02123f34(self);
-    _ZN5Actor9UpdatePosEP12CylinderClsn(self, 0);
+    func_ov079_02123f34(((Actor*)this));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((Actor*)this), 0);
 
     if (*(int*)(c + 0x98) != 0) {
-        if (_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(self, (WithMeshClsn*)(c + 0x110), 0x3c000, (short)0x2888, 0, 0, (void*)0x32000)) {
+        if (_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(((Actor*)this), (WithMeshClsn*)(c + 0x110), 0x3c000, (short)0x2888, 0, 0, (void*)0x32000)) {
             *(int*)(c + 0x5c) = *(int*)(c + 0x3d4);
             *(int*)(c + 0x60) = *(int*)(c + 0x3d8);
             *(int*)(c + 0x64) = *(int*)(c + 0x3dc);
@@ -47,12 +50,12 @@ extern "C" int _ZN5Whomp8BehaviorEv(Actor* self)
         *(int*)(c + 0x3dc) = *(int*)(c + 0x64);
     }
 
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(self, (WithMeshClsn*)(c + 0x110), 0);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Actor*)this), (WithMeshClsn*)(c + 0x110), 0);
 
     {
         int idx = *(int*)(c + 0x3b0);
         PMF* pmf = &data_ov079_02128280[idx];
-        (self->**pmf)();
+        (((Actor*)this)->**pmf)();
 
         {
             unsigned short* ctr = (unsigned short*)(c + 0x100);
@@ -64,10 +67,10 @@ extern "C" int _ZN5Whomp8BehaviorEv(Actor* self)
         }
     }
 
-    func_ov079_02124188(self);
+    func_ov079_02124188(((Actor*)this));
 
-    if (func_ov079_021243e0((char*)self, 0) == 0 || func_ov079_02123a8c(self) != 0) {
-        func_ov079_02124008(self);
+    if (func_ov079_021243e0((char*)((Actor*)this), 0) == 0 || func_ov079_02123a8c(((Actor*)this)) != 0) {
+        func_ov079_02124008(((Actor*)this));
     }
 
     *(unsigned char*)(c + 0x403) = 0;

--- a/src/_ZN5WhompD0Ev.c
+++ b/src/_ZN5WhompD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN5WhompD0Ev
+/* recovered: named members + shared header */
+#include "Whomp.h"
 extern int _ZN18MovingMeshColliderD1Ev(void*);
 extern int _ZN11ShadowModelD1Ev(void*);
 extern int _ZN15TextureSequenceD1Ev(void*);
@@ -7,14 +10,14 @@ extern int func_ov002_020aed18(void*);
 extern int _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
 extern int _ZTV5Whomp[];
 extern void* data_020a0eac;
-int _ZN5WhompD0Ev(char *c){
-    *(int*)c=(int)_ZTV5Whomp;
-    _ZN18MovingMeshColliderD1Ev(c+0x418);
-    _ZN11ShadowModelD1Ev(c+0x344);
-    _ZN15TextureSequenceD1Ev(c+0x330);
-    _ZN9ModelAnimD1Ev(c+0x2cc);
-    _ZN12WithMeshClsnD1Ev(c+0x110);
-    func_ov002_020aed18(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN5WhompD0Ev(struct Whomp *self) {
+    *(int*)((char *)self)=(int)_ZTV5Whomp;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN11ShadowModelD1Ev((char *)&self->mShadowModel);
+    _ZN15TextureSequenceD1Ev((char *)&self->mTextureSequence);
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+    func_ov002_020aed18(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN5WhompD1Ev.c
+++ b/src/_ZN5WhompD1Ev.c
@@ -1,17 +1,21 @@
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN11ShadowModelD1Ev(void*);
+// @symbol _ZN5WhompD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Whomp.h"
 extern void _ZN15TextureSequenceD1Ev(void*);
-extern void _ZN9ModelAnimD1Ev(void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
 extern int func_ov002_020aed18(int* x);
-extern int _ZTV5Whomp[];
-void* _ZN5WhompD1Ev(char* r4) {
-  *(int*)r4 = (int)_ZTV5Whomp;
-  _ZN18MovingMeshColliderD1Ev(r4 + 0x418);
-  _ZN11ShadowModelD1Ev(r4 + 0x344);
-  _ZN15TextureSequenceD1Ev(r4 + 0x330);
-  _ZN9ModelAnimD1Ev(r4 + 0x2cc);
-  _ZN12WithMeshClsnD1Ev(r4 + 0x110);
-  func_ov002_020aed18((int*)r4);
-  return r4;
+void* _ZN5WhompD1Ev(struct Whomp *self) {
+  *(int*)((char*)self) = (int)_ZTV5Whomp;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMovingMeshCollider);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  _ZN15TextureSequenceD1Ev((char*)&self->mTextureSequence);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  func_ov002_020aed18((int*)((char*)self));
+  return ((char*)self);
 }

--- a/src/_ZN6BobOmb13InitResourcesEv.cpp
+++ b/src/_ZN6BobOmb13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6BobOmb13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "BobOmb.h"
 typedef int Fix12;
 struct BMD_File;
 struct SharedFilePtr { int h; };
@@ -68,51 +71,51 @@ struct Obj {
     unsigned char f3f2, f3f3, f3f4, f3f5, f3f6;  /* 3f2..3f6 */
 };
 
-extern "C" int _ZN6BobOmb13InitResourcesEv(Obj* o)
+int BobOmb::InitResources()
 {
     BMD_File* bmd;
 
     Animation::LoadFile(data_ov102_0214e9c0);
     Animation::LoadFile(data_ov102_0214e9c8);
     bmd = Model::LoadFile(data_ov002_0210d9e0);
-    if (((ModelBase*)&o->f300)->SetFile(bmd, 1, -1) == 0)
+    if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, -1) == 0)
         return 0;
-    if (((ShadowModel*)&o->f364)->InitCylinder() == 0)
+    if (((ShadowModel*)&((Obj*)this)->f364)->InitCylinder() == 0)
         return 0;
 
-    o->f3f5 = (unsigned char)(o->f8 & 7);
-    o->f3ec = 0x2000;
-    func_ov102_0214c0b8(o);
-    ((MovingCylinderClsn*)&o->f110)->Init((Actor*)o, 0x3c000, 0x50000, 0x200004, 0xa6d380);
-    o->fa0 = -0x37000;
+    ((Obj*)this)->f3f5 = (unsigned char)(((Obj*)this)->f8 & 7);
+    ((Obj*)this)->f3ec = 0x2000;
+    func_ov102_0214c0b8(((Obj*)this));
+    ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x3c000, 0x50000, 0x200004, 0xa6d380);
+    ((Obj*)this)->fa0 = -0x37000;
 
-    if (o->f3f5 == 2) {
-        *(unsigned int*)(((int)o + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
-        *(unsigned int*)(((int)o + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1u;
-        o->f108 = 0;
-    } else if (o->f3f5 == 4) {
-        o->f108 = 0;
+    if (((Obj*)this)->f3f5 == 2) {
+        *(unsigned int*)(((int)((Obj*)this) + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
+        *(unsigned int*)(((int)((Obj*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1u;
+        ((Obj*)this)->f108 = 0;
+    } else if (((Obj*)this)->f3f5 == 4) {
+        ((Obj*)this)->f108 = 0;
     } else {
-        o->f108 = 1;
+        ((Obj*)this)->f108 = 1;
     }
 
-    o->f3c4 = o->f5c;
-    o->f3c8 = o->f60;
-    o->f3cc = o->f64;
-    o->f394 = data_02082128;
-    o->f3e8 = 0;
-    o->f3ea = 0;
-    o->f80 = 0x1000;
-    o->f84 = 0x1000;
-    o->f88 = 0x1000;
-    o->f390 = 0;
-    o->f3f2 = 0;
-    ((WithMeshClsn*)&o->f144)->Init((Actor*)o, 0x32000, 0x32000, 0, 0);
-    ((WithMeshClsn*)&o->f144)->StartDetectingWater();
-    o->f3f3 = 1;
-    o->fc8 = 0;
-    o->f3e0 = 2;
-    o->f3f6 = 0;
-    o->f3f0 = o->f8e;
+    ((Obj*)this)->f3c4 = ((Obj*)this)->f5c;
+    ((Obj*)this)->f3c8 = ((Obj*)this)->f60;
+    ((Obj*)this)->f3cc = ((Obj*)this)->f64;
+    ((Obj*)this)->f394 = data_02082128;
+    ((Obj*)this)->f3e8 = 0;
+    ((Obj*)this)->f3ea = 0;
+    ((Obj*)this)->f80 = 0x1000;
+    ((Obj*)this)->f84 = 0x1000;
+    ((Obj*)this)->f88 = 0x1000;
+    ((Obj*)this)->f390 = 0;
+    ((Obj*)this)->f3f2 = 0;
+    ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
+    ((WithMeshClsn*)&((Obj*)this)->f144)->StartDetectingWater();
+    ((Obj*)this)->f3f3 = 1;
+    ((Obj*)this)->fc8 = 0;
+    ((Obj*)this)->f3e0 = 2;
+    ((Obj*)this)->f3f6 = 0;
+    ((Obj*)this)->f3f0 = ((Obj*)this)->f8e;
     return 1;
 }

--- a/src/_ZN6BobOmb6RenderEv.cpp
+++ b/src/_ZN6BobOmb6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6BobOmb6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BobOmb.h"
 struct VBase {
     virtual void method0() = 0;
     virtual void method1() = 0;
@@ -7,14 +10,16 @@ struct VBase {
     virtual void method4() = 0;
     virtual void method5(char *arg);
 };
-extern "C" int _ZN6BobOmb6RenderEv(char *c) {
+
+int BobOmb::Render()
+{
     int result = 1;
-    if (*(unsigned char*)(c + 0x3f3) != 0) {
-        int flags = *(int*)(c + 0xb0);
+    if (unk_3f3 != 0) {
+        int flags = unk_0b0;
         int b = (flags & 0x40000) != 0;
         if (!b) {
-            VBase *obj = (VBase*)(c + 0x300);
-            obj->method5(c + 0x80);
+            VBase *obj = (VBase*)((char *)&mModelAnim);
+            obj->method5((char *)&unk_080);
         }
     }
     return result;


### PR DESCRIPTION
Batch 05 of the readable-tree migration. Promotes 180 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (tools/prepush_linkcheck.py, mwccarm 1.2/sp2p3): 109 VERIFIED, 71 BLIND, 0 WRONG/NO-REPRO. 10 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
