### PR TITLE
readable: batch 06 - promote 181 files to readable form

### DIFF
--- a/src/_ZN6BobOmbD0Ev.c
+++ b/src/_ZN6BobOmbD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6BobOmbD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daBmb_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6BobOmbD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daBmb_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6BobOmbD1Ev.c
+++ b/src/_ZN6BobOmbD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6BobOmbD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6BobOmb */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6BobOmbD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6BobOmb;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6Bowser6RenderEv.cpp
+++ b/src/_ZN6Bowser6RenderEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN6Bowser6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bowser.h"
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void*); };
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void* a);
 extern void _ZN15TextureSequence6UpdateER15ModelComponents(void* a, void* b);
-int _ZN6Bowser6RenderEv(char* c){
-  if(*(unsigned char*)(c+0x41c) < 8) return 1;
-  _ZN9Animation7AdvanceEv(c+0x138);
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x138, c+0xdc);
-  ((Obj*)(c+0xd4))->m(c+0x80);
-  return 1;
 }
+
+int Bowser::Render()
+{
+  if(unk_41c < 8) return 1;
+  _ZN9Animation7AdvanceEv((char*)&mTextureSequence);
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x138, ((char*)this)+0xdc);
+  ((Obj*)((char*)&mModelAnim))->m((char*)&mScaleX);
+  return 1;
 }

--- a/src/_ZN6Bowser8BehaviorEv.cpp
+++ b/src/_ZN6Bowser8BehaviorEv.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN6Bowser8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Bowser.h"
 typedef int Fix12;
 typedef short s16;
 typedef unsigned char u8;
 
-struct Vector3 { int x, y, z; };
 
 struct Actor {
     Actor* ClosestPlayer();
@@ -24,40 +28,38 @@ extern "C" {
 extern int RandomIntInternal(int* seed);
 extern s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern Fix12 Vec3_HorzDist(const Vector3* a, const Vector3* b);
-extern void func_ov060_02112434(void* t);
-extern void func_ov060_02111a28(void* t);
-extern void func_ov060_0211577c(void* t);
 extern int data_0209e650;
 extern char* data_0209f318;
 }
 
-extern "C" int _ZN6Bowser8BehaviorEv(char* self) {
+int Bowser::Behavior()
+{
     RandomIntInternal(&data_0209e650);
-    *(int*)(self + 0x3a0) = (int)((Actor*)self)->ClosestPlayer();
-    if (*(Actor**)(self + 0x3a0) != 0) {
-        *(s16*)(self + 0x406) = Vec3_HorzAngle((Vector3*)(self + 0x5c), (Vector3*)((char*)*(Actor**)(self + 0x3a0) + 0x5c));
-        *(int*)(self + 0x3ec) = Vec3_HorzDist((Vector3*)(self + 0x5c), (Vector3*)((char*)*(Actor**)(self + 0x3a0) + 0x5c));
+    mTargetPlayer = (int)((Actor*)((char*)this))->ClosestPlayer();
+    if (*(Actor**)((char*)&mTargetPlayer) != 0) {
+        unk_406 = Vec3_HorzAngle((Vector3*)((char*)&mPosX), (Vector3*)((char*)*(Actor**)((char*)&mTargetPlayer) + 0x5c));
+        unk_3ec = Vec3_HorzDist((Vector3*)((char*)&mPosX), (Vector3*)((char*)*(Actor**)((char*)&mTargetPlayer) + 0x5c));
     } else {
-        *(s16*)(self + 0x406) = *(s16*)(self + 0x8e);
-        *(int*)(self + 0x3ec) = ~0x80000000;
+        unk_406 = unk_08e;
+        unk_3ec = ~0x80000000;
     }
-    func_ov060_02112434(self);
-    func_ov060_02111a28(self);
-    *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
-    *(int*)(self + 0x130) = *(int*)(self + 0x3f8);
-    ((Animation*)(self + 0x124))->Advance();
-    func_ov060_0211577c(self);
-    *(char**)(data_0209f318 + 0x114) = self;
-    ((CylinderClsn*)(self + 0x360))->Clear();
+    func_ov060_02112434(((char*)this));
+    func_ov060_02111a28(((char*)this));
+    unk_094 = unk_08e;
+    unk_130 = unk_3f8;
+    ((Animation*)((char*)&mAnimation))->Advance();
+    func_ov060_0211577c(((char*)this));
+    *(char**)(data_0209f318 + 0x114) = ((char*)this);
+    ((CylinderClsn*)((char*)&mMovingCylinderClsnWithPos))->Clear();
     Vector3 v;
     v.z = 0x50000;
     v.x = 0;
     v.y = 0;
-    ((MovingCylinderClsnWithPos*)(self + 0x360))->SetPosRelativeToActor(v);
-    ((CylinderClsn*)(self + 0x360))->Update();
-    if (*(u8*)(self + 0x42b) != 0) {
+    ((MovingCylinderClsnWithPos*)((char*)&mMovingCylinderClsnWithPos))->SetPosRelativeToActor(v);
+    ((CylinderClsn*)((char*)&mMovingCylinderClsnWithPos))->Update();
+    if (unk_42b != 0) {
         Actor* f = Actor::FindWithActorID(0x10d, 0);
-        if (f == 0) *(u8*)(self + 0x42b) = 0;
+        if (f == 0) unk_42b = 0;
     }
     return 1;
 }

--- a/src/_ZN6BowserD0Ev.c
+++ b/src/_ZN6BowserD0Ev.c
@@ -1,15 +1,18 @@
+// @symbol _ZN6BowserD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daKpa_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6BowserD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daKpa_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x360);
     _ZN11ShadowModelD1Ev((char *)t + 0x308);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x14c);

--- a/src/_ZN6Bullet6RenderEv.cpp
+++ b/src/_ZN6Bullet6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Bullet6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Bullet.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x300]; Base base; };
-extern "C" int _ZN6Bullet6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Bullet::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6Bullet8BehaviorEv.cpp
+++ b/src/_ZN6Bullet8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Bullet8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Bullet.h"
 extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
 
 struct CylinderClsn { int dummy; };
@@ -19,7 +24,6 @@ struct Holder {
     PMF pmf;   // function-pointer word at offset 8
 };
 
-extern "C" void func_ov002_020fed7c(char* c);
 
 struct CC {
     void Clear();
@@ -31,27 +35,28 @@ extern "C" void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Actor* a, WithMeshClsn*
 extern "C" void _ZN12CylinderClsn5ClearEv(void* c);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void* c);
 
-extern "C" int _ZN6Bullet8BehaviorEv(Actor* a) {
-    DecIfAbove0_Short((unsigned short*)((char*)a + 0x100));
-    Holder* h = a->h;
+int Bullet::Behavior()
+{
+    DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
+    Holder* h = ((Actor*)this)->h;
     if (h->pmf != 0) {
-        (a->*(h->pmf))();
+        (((Actor*)this)->*(h->pmf))();
     }
     {
-        int spd = *(int*)((char*)a + 0xa8);
-        int pos = *(int*)((char*)a + 0x9c);
-        int lim = *(int*)((char*)a + 0xa0);
-        int ac = *(int*)((char*)a + 0xac);
+        int spd = *(int*)((char*)&unk_0a8);
+        int pos = *(int*)((char*)&unk_09c);
+        int lim = *(int*)((char*)&unk_0a0);
+        int ac = *(int*)((char*)&unk_0ac);
         int np = spd + pos;
         if (np >= lim) lim = np;
-        *(int*)((char*)a + 0xa8) = lim;
-        *(int*)((char*)a + 0xac) = ac;
-        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(a, (CylinderClsn*)((char*)a + 0x110));
+        *(int*)((char*)&unk_0a8) = lim;
+        *(int*)((char*)&unk_0ac) = ac;
+        _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((Actor*)this), (CylinderClsn*)((char*)&mMovingCylinderClsn));
     }
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(a, (WithMeshClsn*)((char*)a + 0x144), 0);
-    *(short*)((char*)a + 0x8e) = *(short*)((char*)a + 0x94);
-    func_ov002_020fed7c((char*)a);
-    _ZN12CylinderClsn5ClearEv((char*)a + 0x110);
-    _ZN12CylinderClsn6UpdateEv((char*)a + 0x110);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Actor*)this), (WithMeshClsn*)((char*)&mWithMeshClsn), 0);
+    *(short*)((char*)&unk_08e) = *(short*)((char*)&unk_094);
+    func_ov002_020fed7c((char*)((Actor*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
     return 1;
 }

--- a/src/_ZN6BulletD0Ev.c
+++ b/src/_ZN6BulletD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6BulletD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV24daPropeller_Heyho_Fire_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6BulletD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV24daPropeller_Heyho_Fire_c;
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN6BulletD1Ev.c
+++ b/src/_ZN6BulletD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6BulletD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Bullet */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6BulletD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6Bullet;
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN6Camera11ChangeStateEPNS_5StateE.cpp
+++ b/src/_ZN6Camera11ChangeStateEPNS_5StateE.cpp
@@ -1,19 +1,20 @@
 //cpp
-extern int data_0209b0c8;
-extern void FUN_02029a68(void);
-extern void func_020089f8(void *camera);
-extern int func_0200cae4(void *camera);
+// @symbol _ZN6Camera11ChangeStateEPNS_5StateE
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Camera.h"
 
-extern "C" int _ZN6Camera11ChangeStateEPNS_5StateE(void *camera, void *state) {
-    if ((*(unsigned int *)((unsigned char *)camera + 0x154) & 0x10) != 0)
+extern "C" int _ZN6Camera11ChangeStateEPNS_5StateE(struct Camera *self, void *state) {
+    if ((*(unsigned int *)((unsigned char *)&self->unk_154) & 0x10) != 0)
         return 0;
-    if (state != *(void **)((unsigned char *)camera + 0x138)) {
-        if (*(void **)((unsigned char *)camera + 0x138) == (void *)&data_0209b0c8) {
+    if (state != *(void **)((unsigned char *)&self->unk_138)) {
+        if (*(void **)((unsigned char *)&self->unk_138) == (void *)&data_0209b0c8) {
             FUN_02029a68();
-            func_020089f8(camera);
+            func_020089f8(((void *)self));
         }
-        *(void **)((unsigned char *)camera + 0x138) = state;
-        *(unsigned char *)((unsigned char *)camera + 0x1a6) = 0;
+        *(void **)((unsigned char *)&self->unk_138) = state;
+        *(unsigned char *)((unsigned char *)&self->unk_1a6) = 0;
     }
-    return func_0200cae4(camera);
+    return func_0200cae4(((void *)self));
 }

--- a/src/_ZN6Camera14GoBehindPlayerEj.cpp
+++ b/src/_ZN6Camera14GoBehindPlayerEj.cpp
@@ -1,15 +1,16 @@
 //cpp
+// @symbol _ZN6Camera14GoBehindPlayerEj
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Camera.h"
 extern "C" {
 extern unsigned char data_0209f250;
 extern signed char data_02092110;
-extern int data_020873dc;
-extern int data_0208742c;
-extern int data_0209b0e8;
-extern void func_0200cb58(void *obj, int index);
-extern void func_0200c66c(void *self, void *base, int *a, int *b, int *c);
 extern void _ZN6Camera11ChangeStateEPNS_5StateE(void *self, void *st);
+}
 
-void _ZN6Camera14GoBehindPlayerEj(int self, unsigned int j)
+void Camera::GoBehindPlayer(unsigned int j)
 {
     int slot4, slot8, slotc;
 
@@ -19,17 +20,16 @@ void _ZN6Camera14GoBehindPlayerEj(int self, unsigned int j)
         return;
 
     /* different launder spellings to defeat CSE across the call */
-    *(unsigned int *)((self + 0x154) & 0xFFFFFFFFFFFFFFFF) &= 0xfffffaf7u;
-    func_0200cb58((void *)self, 0xa);
-    *(unsigned int *)(((long long)(int)(self + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) |= 4u;
+    *(unsigned int *)(((int)&unk_154) & 0xFFFFFFFFFFFFFFFF) &= 0xfffffaf7u;
+    func_0200cb58((void *)((int)this), 0xa);
+    *(unsigned int *)(((long long)(int)((int)&unk_154)) & 0xFFFFFFFFFFFFFFFFLL) |= 4u;
 
-    slot4 = *(int *)(self + 0x13c);
+    slot4 = unk_13c;
     slotc = 0;
-    func_0200c66c((void *)self, (void *)(*(int *)(self + 0x110) + 0x5c), &slot8, &slot4, &slotc);
+    func_0200c66c((void *)((int)this), (void *)(unk_110 + 0x5c), &slot8, &slot4, &slotc);
     if (slot4 == (int)&data_020873dc)
         return;
     if (slot4 == (int)&data_0208742c)
         return;
-    _ZN6Camera11ChangeStateEPNS_5StateE((void *)self, &data_0209b0e8);
-}
+    _ZN6Camera11ChangeStateEPNS_5StateE((void *)((int)this), &data_0209b0e8);
 }

--- a/src/_ZN6Camera25SaveCameraStateBeforeTalkEv.cpp
+++ b/src/_ZN6Camera25SaveCameraStateBeforeTalkEv.cpp
@@ -1,11 +1,17 @@
 //cpp
-extern "C" void _ZN6Camera25SaveCameraStateBeforeTalkEv(void *obj) {
-    if (*(unsigned int *)((char *)obj + 0x154) & 0x4000U) return;
-    *(unsigned int *)((char *)obj + 0xb0) = *(unsigned int *)((char *)obj + 0x80);
-    *(unsigned int *)((char *)obj + 0xb4) = *(unsigned int *)((char *)obj + 0x84);
-    *(unsigned int *)((char *)obj + 0xb8) = *(unsigned int *)((char *)obj + 0x88);
-    *(unsigned int *)((char *)obj + 0xbc) = *(unsigned int *)((char *)obj + 0x8c);
-    *(unsigned int *)((char *)obj + 0xc0) = *(unsigned int *)((char *)obj + 0x90);
-    *(unsigned int *)((char *)obj + 0xc4) = *(unsigned int *)((char *)obj + 0x94);
-    *(unsigned int *)((int *)(((int)obj + 0x154) & 0xFFFFFFFFFFFFFFFF)) |= 0x4000U;
+// @symbol _ZN6Camera25SaveCameraStateBeforeTalkEv
+/* recovered: named members + shared header, real C++ method */
+#include "Camera.h"
+
+
+void Camera::SaveCameraStateBeforeTalk()
+{
+    if (*(unsigned int *)((char *)&unk_154) & 0x4000U) return;
+    *(unsigned int *)((char *)&unk_0b0) = *(unsigned int *)((char *)&unk_080);
+    *(unsigned int *)((char *)&unk_0b4) = *(unsigned int *)((char *)&unk_084);
+    *(unsigned int *)((char *)&unk_0b8) = *(unsigned int *)((char *)&unk_088);
+    *(unsigned int *)((char *)&unk_0bc) = *(unsigned int *)((char *)&unk_08c);
+    *(unsigned int *)((char *)&unk_0c0) = *(unsigned int *)((char *)&unk_090);
+    *(unsigned int *)((char *)&unk_0c4) = *(unsigned int *)((char *)&unk_094);
+    *(unsigned int *)((int *)(((int)((void *)this) + 0x154) & 0xFFFFFFFFFFFFFFFF)) |= 0x4000U;
 }

--- a/src/_ZN6Camera8BehaviorEv.cpp
+++ b/src/_ZN6Camera8BehaviorEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Camera8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Camera.h"
+#include "decl_Particle.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Camera.h"
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
@@ -13,22 +20,13 @@ extern "C" {
 extern int _ZN6Camera11ChangeStateEPNS_5StateE(void *thiz, void *state);
 extern short Vec3_HorzAngle(const void *v0, const void *v1);
 extern short Vec3_VertAngle(const void *v1, const void *v0);
-extern void func_020089f8(void *camera);
-extern void Math_Function_0203b0fc(int *p, int target, int scale, int max);
-extern int func_0200ca50(void *self);
 extern void _Z14ApproachLinearRiii(int &dst, int target, int step);
 extern int _Z15ApproachLinear2Rsss(short &dst, short target, short step);
 extern void MulVec3Mat4x3(void *dst, void *src, void *out);
 extern int *Vec3_LslInPlace(int *v, int sh);
-extern int _ZNK6Camera12IsUnderwaterEv(void *self);
-extern u32 _ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj(
-    u32 uid, u32 eid, Fix12i x, Fix12i y, Fix12i z, const void *dir, u8 numNow);
-extern void func_0203dafc(int v);
 }
 
-extern u32 data_0208733c;
 extern s32 data_0209fc48;
-extern char data_0209b008;
 extern u8 data_0209f2c4;
 extern u8 data_0209f20c;
 extern u8 data_0209f294;
@@ -36,12 +34,11 @@ extern s32 data_0209b454;
 extern s8 data_0209f2f8;
 extern s32 data_0209f32c;
 extern s16 data_02082214[];
-extern char CAM_SPACE_CAM_POS_ASR_3;
 extern char data_0209b41c;
 
-extern "C" int _ZN6Camera8BehaviorEv(void *arg0)
+int Camera::Behavior()
 {
-    char *c = (char *)arg0;
+    char *c = (char *)((void *)this);
     s32 spVec[3];
     s32 temp_r1;
     s32 r5;

--- a/src/_ZN6CameraC1Ev.c
+++ b/src/_ZN6CameraC1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN6CameraC1Ev
+/* recovered: named members + shared header */
+#include "Camera.h"
 typedef unsigned int u32;
 typedef int s32;
 

--- a/src/_ZN6Cannon13InitResourcesEv.cpp
+++ b/src/_ZN6Cannon13InitResourcesEv.cpp
@@ -1,22 +1,25 @@
 //cpp
+// @symbol _ZN6Cannon13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Cannon.h"
 typedef unsigned char u8;
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *file, int a, int b);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int r, int h, unsigned int a, unsigned int b);
-extern "C" void func_ov098_0213b15c(void *c);
-extern "C" char data_ov098_0213c8e8;
 extern "C" char data_ov098_0213c91c;
 extern "C" char data_ov002_0210da38;
 
-extern "C" int _ZN6Cannon13InitResourcesEv(void *self)
+int Cannon::InitResources()
 {
-    char *c = (char*)self;
+    char *c = (char*)((void *)this);
     void *f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov098_0213c8e8);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
     *(int*)(c + 0x194) = *(int*)(*(int*)(c + 0xe4) + 0x58);
     *(u8*)(c + 0x184) = *(int*)(c + 8) & 3;
     *(int*)(c + 0x174) = 0;
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x50000;
+    *(int*)(((long long)(int)(c + 0x60))) -= 0x50000;
     *(int*)(c + 0x15c) = *(int*)(c + 0x5c);
     *(int*)(c + 0x160) = *(int*)(c + 0x60);
     *(int*)(c + 0x164) = *(int*)(c + 0x64);
@@ -28,15 +31,15 @@ extern "C" int _ZN6Cannon13InitResourcesEv(void *self)
         *(short*)(c + 0x178) = 0x2000;
         *(short*)(c + 0x17a) = *(short*)(c + 0x8e);
         *(int*)(c + 0x180) = 0;
-        func_ov098_0213b15c(self);
-        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, self, 0xa0000, 0x12c000, 0x800004, 0);
+        func_ov098_0213b15c(((void *)this));
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, ((void *)this), 0xa0000, 0x12c000, 0x800004, 0);
     } else {
-        *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x190000;
+        *(int*)(((long long)(int)(c + 0x60))) -= 0x190000;
         *(short*)(c + 0x17a) = *(short*)(c + 0x90);
         *(short*)(c + 0x178) = 0x2000;
         *(int*)(c + 0x180) = 2;
-        *(int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
-        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, self, 0x50000, 0x12c000, 0x800004, 0);
+        *(int*)(((long long)(int)(c + 0xb0))) &= ~1;
+        _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x124, ((void *)this), 0x50000, 0x12c000, 0x800004, 0);
     }
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov098_0213c91c);
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da38);

--- a/src/_ZN6Cannon6RenderEv.cpp
+++ b/src/_ZN6Cannon6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Cannon6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Cannon.h"
 struct Sub {
   virtual void v0();
   virtual void v1();
@@ -7,13 +10,15 @@ struct Sub {
   virtual void v4();
   virtual void m5(int);
 };
-extern "C" int _ZN6Cannon6RenderEv(char* c){
-  if(*(int*)(c+0x180) == 3){
-    if(*(unsigned char*)(c+0x185) >= 3) return 1;
+
+int Cannon::Render()
+{
+  if(unk_180 == 3){
+    if(unk_185 >= 3) return 1;
   }
-  Sub* o = (Sub*)(c+0xd4);
+  Sub* o = (Sub*)((char*)&mModel);
   o->m3();
-  Sub* o2 = (Sub*)(c+0xd4);
+  Sub* o2 = (Sub*)((char*)&mModel);
   o2->m5(0);
   return 1;
 }

--- a/src/_ZN6Cannon8BehaviorEv.cpp
+++ b/src/_ZN6Cannon8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Cannon8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Cannon.h"
 extern "C" {
 int func_ov098_0213a984(void* c);
 void _ZN12CylinderClsn5ClearEv(void* self);
@@ -16,13 +19,13 @@ struct C {
     unsigned char flag; // 0x184
 };
 
-extern "C" int _ZN6Cannon8BehaviorEv(C* c)
+int Cannon::Behavior()
 {
-    if (c->flag != 1) {
-        (c->*data_ov098_0213c8fc[c->idx].pmf)();
+    if (((C*)this)->flag != 1) {
+        (((C*)this)->*data_ov098_0213c8fc[((C*)this)->idx].pmf)();
     }
-    func_ov098_0213a984(c);
-    _ZN12CylinderClsn5ClearEv((char*)c + 0x124);
-    _ZN12CylinderClsn6UpdateEv((char*)c + 0x124);
+    func_ov098_0213a984(((C*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
     return 1;
 }

--- a/src/_ZN6CannonD0Ev.c
+++ b/src/_ZN6CannonD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN6CannonD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daCnn_c */
 extern void *G0;
 int *_ZN6CannonD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daCnn_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6Coffin13InitResourcesEv.cpp
+++ b/src/_ZN6Coffin13InitResourcesEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN6Coffin13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Coffin.h"
 typedef int Fix12;
 typedef short s16;
 
-struct Vector3 { int x, y, z; };
 struct Matrix4x3;
 struct SharedFilePtr;
 struct BMD_File;
@@ -35,7 +39,6 @@ extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(const Vector3* v, const void* m, Vector3* res);
 extern void Vec3_Add(Vector3* out, Vector3* a, Vector3* b);
-extern void func_ov071_02122080(char* t);
 extern void func_020393d4(int* p, int v);
 
 extern SharedFilePtr data_ov071_021230d0;
@@ -46,10 +49,11 @@ extern CLPS_Block data_ov063_0211ebd8;
 
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 
-extern "C" int _ZN6Coffin13InitResourcesEv(char* self) {
-    ((ModelBase*)(self + 0xd4))->SetFile(Model::LoadFile(data_ov071_021230d0), 1, -1);
-    *(int*)(self + 0x9c) = -0x2000;
-    *(int*)(self + 0xa0) = -0x3c000;
+int Coffin::InitResources()
+{
+    ((ModelBase*)((char*)&mModel))->SetFile(Model::LoadFile(data_ov071_021230d0), 1, -1);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
     Vector3 in;
     Vector3 out;
     in.x = 0;
@@ -58,18 +62,18 @@ extern "C" int _ZN6Coffin13InitResourcesEv(char* self) {
     out.x = 0;
     out.y = 0;
     out.z = 0;
-    Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(self + 0x8e));
+    Matrix4x3_FromRotationY(&data_020a0e68, unk_08e);
     MulVec3Mat4x3(&in, &data_020a0e68, &out);
     Vector3 res;
-    Vec3_Add(&res, (Vector3*)(self + 0x5c), &out);
-    *(int*)(self + 0x5c) = res.x;
-    *(int*)(self + 0x60) = res.y;
-    *(int*)(self + 0x64) = res.z;
-    func_ov071_02122080(self);
-    ((Platform*)self)->UpdateClsnPosAndRot();
-    ((MovingMeshCollider*)(self + 0x124))->SetFile(
+    Vec3_Add(&res, (Vector3*)((char*)&mPosX), &out);
+    mPosX = res.x;
+    mPosY = res.y;
+    mPosZ = res.z;
+    func_ov071_02122080(((char*)this));
+    ((Platform*)((char*)this))->UpdateClsnPosAndRot();
+    ((MovingMeshCollider*)((char*)&mMeshCollider))->SetFile(
         MeshCollider::LoadFile(data_ov071_021230d8),
-        *(Matrix4x3*)(self + 0x2ec), 0x199, *(s16*)(self + 0x8e), data_ov063_0211ebd8);
-    func_020393d4((int*)(self + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+        *(Matrix4x3*)((char*)&unk_2ec), 0x199, unk_08e, data_ov063_0211ebd8);
+    func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/_ZN6Coffin6RenderEv.cpp
+++ b/src/_ZN6Coffin6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Coffin6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Coffin.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN6Coffin6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Coffin::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6Coffin8BehaviorEv.cpp
+++ b/src/_ZN6Coffin8BehaviorEv.cpp
@@ -1,32 +1,35 @@
 //cpp
+// @symbol _ZN6Coffin8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Coffin.h"
 extern "C" {
-extern void func_ov071_02122080(char *t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char *self);
-extern void func_ov071_02122414(char *c);
 }
 
-extern "C" int _ZN6Coffin8BehaviorEv(char *self)
+int Coffin::Behavior()
 {
     char *stateField;
 
-    if ((*(int *)(stateField = self + 8) & 0xff) == 1) {
-        func_ov071_02122080(self);
-        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(self, 0, 0)) {
-            _ZN8Platform19UpdateClsnPosAndRotEv(self);
+    if ((*(int *)(stateField = ((char *)this) + 8) & 0xff) == 1) {
+        func_ov071_02122080(((char *)this));
+        if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char *)this), 0, 0)) {
+            _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
         }
         return 1;
     }
 
     {
         unsigned short *timer =
-            (unsigned short *)(((int)self + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
+            (unsigned short *)(((int)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
         *timer = *timer + 1;
     }
-    func_ov071_02122414(self);
-    func_ov071_02122080(self);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(self, 0, 0)) {
-        _ZN8Platform19UpdateClsnPosAndRotEv(self);
+    func_ov071_02122414(((char *)this));
+    func_ov071_02122080(((char *)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char *)this), 0, 0)) {
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
     }
     return 1;
 }

--- a/src/_ZN6CoffinD0Ev.c
+++ b/src/_ZN6CoffinD0Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN6CoffinD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN6CoffinD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN6CoffinD1Ev.c
+++ b/src/_ZN6CoffinD1Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN6CoffinD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN6CoffinD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN6Dorrie6RenderEv.cpp
+++ b/src/_ZN6Dorrie6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Dorrie6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Dorrie.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xec]; Base base; };
-extern "C" int _ZN6Dorrie6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Dorrie::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6DorrieD0Ev.cpp
+++ b/src/_ZN6DorrieD0Ev.cpp
@@ -1,25 +1,28 @@
 //cpp
+// @symbol _ZN6DorrieD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Dorrie.h"
 extern "C" {
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
 extern int func_0207328c(void *, int, int, void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
 extern void func_ov065_021180b8();
 extern void *_ZTV6Dorrie[];
 extern void *data_020a0eac;
-void *_ZN6DorrieD0Ev(char *c);
-void *_ZN6DorrieD0Ev(char *c) {
-    *(void ***)c = _ZTV6Dorrie;
-    _ZN25MovingCylinderClsnWithPosD1Ev(c + 0x1140);
-    _ZN18MovingCylinderClsnD1Ev(c + 0x110c);
-    _ZN12WithMeshClsnD1Ev(c + 0xf50);
-    func_0207328c(c + 0x150, 7, 0x200, (void*)&func_ov065_021180b8);
-    _ZN9ModelAnimD1Ev(c + 0xec);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, *(void **)&data_020a0eac);
-    return c;
+void *_ZN6DorrieD0Ev(struct Dorrie *self) {
+    *(void ***)((char *)self) = _ZTV6Dorrie;
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->unk_1140);
+    _ZN18MovingCylinderClsnD1Ev((char *)&self->unk_110c);
+    _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+    func_0207328c(((char *)self) + 0x150, 7, 0x200, (void*)&func_ov065_021180b8);
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), *(void **)&data_020a0eac);
+    return ((char *)self);
 }
 }

--- a/src/_ZN6DorrieD1Ev.cpp
+++ b/src/_ZN6DorrieD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6DorrieD1Ev
+/* recovered: named members + shared header */
+#include "Dorrie.h"
 extern "C" {
 extern void *_ZTV6Dorrie;
 extern void func_ov065_021180b8(void);

--- a/src/_ZN6Eyerok6RenderEv.cpp
+++ b/src/_ZN6Eyerok6RenderEv.cpp
@@ -1,19 +1,23 @@
 //cpp
+// @symbol _ZN6Eyerok6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Eyerok.h"
 extern "C" {
 extern void _ZN15TextureSequence6UpdateER15ModelComponents(void* thiz, void* mc);
 extern unsigned char data_ov066_0211ae04;
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" int _ZN6Eyerok6RenderEv(char* c);
-extern "C" int _ZN6Eyerok6RenderEv(char* c){
-  if (*(int*)(c + 0x49c) == 0) {
+
+int Eyerok::Render()
+{
+  if (unk_49c == 0) {
     if (data_ov066_0211ae04 == 1) {
-      ((Sub*)(c + 0x3d0))->g5(0);
+      ((Sub*)((char*)&mModel2))->g5(0);
     }
     return 1;
   }
   if (data_ov066_0211ae04 == 1) return 1;
-  _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x448, c + 0x368);
-  ((Sub*)(c + 0x360))->g5(0);
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x448, ((char*)this) + 0x368);
+  ((Sub*)((char*)&mBlendModelAnim))->g5(0);
   return 1;
 }

--- a/src/_ZN6EyerokD0Ev.c
+++ b/src/_ZN6EyerokD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN6EyerokD0Ev
+/* recovered: named members + shared header */
+#include "Eyerok.h"
 extern void _ZN18MovingMeshColliderD1Ev(void*);
 extern void* func_0207328c(void*, int, int, void*);
 extern void _ZN15TextureSequenceD1Ev(void*);
@@ -11,19 +14,19 @@ extern int _ZTV6Eyerok[];
 extern int func_020072c0[];
 extern int _ZTV17ExclamationSwitch[];
 extern void* data_020a0eac;
-void* _ZN6EyerokD0Ev(char* c) {
-    *(int**)c = _ZTV6Eyerok;
-    _ZN18MovingMeshColliderD1Ev(c+0x674);
-    func_0207328c(c+0x4dc, 0x14, 0xc, func_020072c0);
-    _ZN15TextureSequenceD1Ev(c+0x448);
-    _ZN11ShadowModelD1Ev(c+0x420);
-    _ZN5ModelD1Ev(c+0x3d0);
-    _ZN14BlendModelAnimD1Ev(c+0x360);
-    _ZN25MovingCylinderClsnWithPosD1Ev(c+0x320);
-    *(int**)c = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return c;
+void* _ZN6EyerokD0Ev(struct Eyerok *self) {
+    *(int**)((char*)self) = _ZTV6Eyerok;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->unk_674);
+    func_0207328c(((char*)self)+0x4dc, 0x14, 0xc, func_020072c0);
+    _ZN15TextureSequenceD1Ev((char*)&self->mTextureSequence);
+    _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+    _ZN5ModelD1Ev((char*)&self->mModel2);
+    _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+    *(int**)((char*)self) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
+    _ZN5ModelD1Ev((char*)&self->mModel1);
+    _ZN5ActorD2Ev(((char*)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char*)self), data_020a0eac);
+    return ((char*)self);
 }

--- a/src/_ZN6EyerokD1Ev.c
+++ b/src/_ZN6EyerokD1Ev.c
@@ -1,26 +1,30 @@
-extern void _ZN18MovingMeshColliderD1Ev(void* p);
+// @symbol _ZN6EyerokD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_BlendModelAnim.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Eyerok.h"
 extern void _ZN15TextureSequenceD1Ev(void* p);
-extern void _ZN11ShadowModelD1Ev(void* p);
-extern void _ZN5ModelD1Ev(void* p);
-extern void _ZN14BlendModelAnimD1Ev(void* p);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void* p);
-extern void _ZN5ActorD2Ev(void* p);
 extern int func_0207328c(void* p, int a, int b, void* fn);
-extern int _ZTV6Eyerok[];
 extern int _ZTV17ExclamationSwitch[];
 extern int func_020072c0[];
-void* _ZN6EyerokD1Ev(char* c) {
-    *(void**)c = _ZTV6Eyerok;
-    _ZN18MovingMeshColliderD1Ev(c+0x674);
-    func_0207328c(c+0x4dc, 0x14, 0xc, func_020072c0);
-    _ZN15TextureSequenceD1Ev(c+0x448);
-    _ZN11ShadowModelD1Ev(c+0x420);
-    _ZN5ModelD1Ev(c+0x3d0);
-    _ZN14BlendModelAnimD1Ev(c+0x360);
-    _ZN25MovingCylinderClsnWithPosD1Ev(c+0x320);
-    *(void**)c = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    return c;
+void* _ZN6EyerokD1Ev(struct Eyerok *self) {
+    *(void**)((char*)self) = _ZTV6Eyerok;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->unk_674);
+    func_0207328c(((char*)self)+0x4dc, 0x14, 0xc, func_020072c0);
+    _ZN15TextureSequenceD1Ev((char*)&self->mTextureSequence);
+    _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+    _ZN5ModelD1Ev((char*)&self->mModel2);
+    _ZN14BlendModelAnimD1Ev((char*)&self->mBlendModelAnim);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+    *(void**)((char*)self) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char*)&self->unk_124);
+    _ZN5ModelD1Ev((char*)&self->mModel1);
+    _ZN5ActorD2Ev(((char*)self));
+    return ((char*)self);
 }

--- a/src/_ZN6FlyGuy6RenderEv.cpp
+++ b/src/_ZN6FlyGuy6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6FlyGuy6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "FlyGuy.h"
 struct Obj {
     virtual void m0();
     virtual void m1();
@@ -7,10 +10,12 @@ struct Obj {
     virtual void m4();
     virtual void Target(int);
 };
-extern "C" int _ZN6FlyGuy6RenderEv(char *c) {
-    int b = ((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
+
+int FlyGuy::Render()
+{
+    int b = ((unk_0b0 & 0x40000) != 0);
     if (b) return 1;
-    Obj *o = (Obj*)(c+0x300);
+    Obj *o = (Obj*)((char *)&mModelAnim);
     o->Target(0);
     return 1;
 }

--- a/src/_ZN6FlyGuy8BehaviorEv.cpp
+++ b/src/_ZN6FlyGuy8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6FlyGuy8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "FlyGuy.h"
 struct WithMeshClsn;
 struct Enemy;
 typedef void (Enemy::*PMF)();
@@ -8,26 +13,22 @@ extern "C" {
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
-extern void func_ov070_02120070(char *c);
 extern void _ZN5Enemy11UpdateDeathER12WithMeshClsn(Enemy *thiz, WithMeshClsn *wm);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(Enemy *thiz, void *clsn);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *wm, unsigned int j);
-extern void func_ov070_0211f100(char *c);
 extern char *_ZN5Actor13ClosestPlayerEv(Enemy *thiz);
 extern void _ZN9Animation7AdvanceEv(void *thiz);
 
-extern char data_ov070_021235cc[];
-extern char data_ov070_021235bc[];
 }
 
 struct Enemy { char pad[0x800]; };
 
-extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
+int FlyGuy::Behavior()
 {
-    char *c = (char *)thiz;
+    char *c = (char *)((Enemy *)this);
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144)) != 0) {
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         if (*(unsigned char *)(c + 0x107) != 0) {
             if (*(unsigned short *)(c + 0x104) == 0) {
@@ -39,7 +40,7 @@ extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
     }
 
     if (*(int *)(c + 0x10c) != 0) {
-        _ZN5Enemy11UpdateDeathER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144));
+        _ZN5Enemy11UpdateDeathER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144));
         func_ov070_02120070(c);
         return 1;
     }
@@ -52,7 +53,7 @@ extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
     {
         Holder *q = *(Holder **)(c + 0x3bc);
         if (q->fn != 0) {
-            (thiz->*(q->fn))();
+            (((Enemy *)this)->*(q->fn))();
         }
     }
 
@@ -67,8 +68,8 @@ extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
         *(int *)(c + 0xac) = tmp;
     }
 
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(thiz, (void *)(c + 0x110));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((Enemy *)this), (void *)(c + 0x110));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
 
     if (*(char **)(c + 0x3bc) != data_ov070_021235bc) {
         *(short *)(c + 0x8e) = *(short *)(c + 0x94);
@@ -83,7 +84,7 @@ extern "C" int _ZN6FlyGuy8BehaviorEv(Enemy *thiz)
 
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {
-        char *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        char *p = _ZN5Actor13ClosestPlayerEv(((Enemy *)this));
         if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
             _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }

--- a/src/_ZN6FlyGuyD0Ev.c
+++ b/src/_ZN6FlyGuyD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6FlyGuyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV19daPropeller_Heyho_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6FlyGuyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV19daPropeller_Heyho_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6FlyGuyD1Ev.c
+++ b/src/_ZN6FlyGuyD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6FlyGuyD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6FlyGuy */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6FlyGuyD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6FlyGuy;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6Goomba6RenderEv.cpp
+++ b/src/_ZN6Goomba6RenderEv.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol _ZN6Goomba6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_CapEnemy.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Goomba.h"
 #pragma opt_common_subs off
-struct Vector3 { int x, y, z; };
 
 struct Sub {
     virtual void m0();
@@ -12,38 +17,36 @@ struct Sub {
 };
 
 extern "C" {
-extern int data_ov084_02130258[];
 extern void _ZN15MaterialChanger6UpdateER15ModelComponents(char* self, void* model);
-extern void _ZN8CapEnemy14RenderCapModelEPK7Vector3(char* c, const Vector3* v);
 }
 
-extern "C" int _ZN6Goomba6RenderEv(char* c)
+int Goomba::Render()
 {
     int locked;
     volatile Vector3 backup;
 
-    locked = (*(unsigned int*)(c + 0xb0) & 0x40000) != 0;
-    if (locked || *(unsigned char*)(c + 0x111) != 0) return 1;
+    locked = (unk_0b0 & 0x40000) != 0;
+    if (locked || unk_111 != 0) return 1;
 
-    backup.x = *(int*)(c + 0x80);
-    backup.y = *(int*)(c + 0x84);
-    backup.z = *(int*)(c + 0x88);
+    backup.x = mScaleX;
+    backup.y = mScaleY;
+    backup.z = mScaleZ;
 
-    if (*(int*)(c + 0x10c) == 1) {
-        *(int*)(c + 0x80) = (int)(((long long)*(int*)(c + 0x80) * data_ov084_02130258[*(int*)(c + 0x460)] + 0x800) >> 12);
-        *(int*)(c + 0x84) = (int)(((long long)*(int*)(c + 0x84) * data_ov084_02130258[*(int*)(c + 0x460)] + 0x800) >> 12);
-        *(int*)(c + 0x88) = (int)(((long long)*(int*)(c + 0x88) * data_ov084_02130258[*(int*)(c + 0x460)] + 0x800) >> 12);
+    if (mDeathType == 1) {
+        mScaleX = (int)(((long long)mScaleX * data_ov084_02130258[mGoombaType] + 0x800) >> 12);
+        mScaleY = (int)(((long long)mScaleY * data_ov084_02130258[mGoombaType] + 0x800) >> 12);
+        mScaleZ = (int)(((long long)mScaleZ * data_ov084_02130258[mGoombaType] + 0x800) >> 12);
     }
 
     {
-        Sub* b = (Sub*)(c + 0x370);
-        b->m5((Vector3*)(c + 0x80));
+        Sub* b = (Sub*)((char*)&mModelAnim);
+        b->m5((Vector3*)((char*)&mScaleX));
     }
 
-    *(int*)(c + 0x80) = backup.x;
-    *(int*)(c + 0x84) = backup.y;
-    *(int*)(c + 0x88) = backup.z;
-    _ZN15MaterialChanger6UpdateER15ModelComponents(c + 0x3fc, c + 0x378);
-    _ZN8CapEnemy14RenderCapModelEPK7Vector3(c, 0);
+    mScaleX = backup.x;
+    mScaleY = backup.y;
+    mScaleZ = backup.z;
+    _ZN15MaterialChanger6UpdateER15ModelComponents(((char*)this) + 0x3fc, ((char*)this) + 0x378);
+    _ZN8CapEnemy14RenderCapModelEPK7Vector3(((char*)this), 0);
     return 1;
 }

--- a/src/_ZN6GoombaD0Ev.c
+++ b/src/_ZN6GoombaD0Ev.c
@@ -1,15 +1,18 @@
+// @symbol _ZN6GoombaD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daKrb_c */
 extern void _ZN15MaterialChangerD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
 extern void func_ov002_020aedbc(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6GoombaD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daKrb_c;
     _ZN15MaterialChangerD1Ev((char *)t + 0x3fc);
     _ZN11ShadowModelD1Ev((char *)t + 0x3d4);
     _ZN9ModelAnimD1Ev((char *)t + 0x370);

--- a/src/_ZN6GoombaD1Ev.c
+++ b/src/_ZN6GoombaD1Ev.c
@@ -1,13 +1,17 @@
+// @symbol _ZN6GoombaD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Goomba */
 extern void _ZN15MaterialChangerD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
 extern void func_ov002_020aedbc(void *);
-extern int VT0[];
 int *_ZN6GoombaD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6Goomba;
     _ZN15MaterialChangerD1Ev((char *)t + 0x3fc);
     _ZN11ShadowModelD1Ev((char *)t + 0x3d4);
     _ZN9ModelAnimD1Ev((char *)t + 0x370);

--- a/src/_ZN6Klepto6RenderEv.cpp
+++ b/src/_ZN6Klepto6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Klepto6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Klepto.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x334]; Base base; };
-extern "C" int _ZN6Klepto6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Klepto::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6Klepto8BehaviorEv.cpp
+++ b/src/_ZN6Klepto8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Klepto8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Klepto.h"
 struct Klass; typedef void (Klass::*PMF)();
 struct M { char pad[8]; PMF pmf; };
 struct CylinderClsn;
@@ -17,86 +22,85 @@ void func_ov062_0211b51c(void *self);
 void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
 void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
 extern char data_ov062_0211e17c[];
-extern char data_ov062_0211e14c[];
 }
 
-extern "C" int _ZN6Klepto8BehaviorEv(char *c)
+int Klepto::Behavior()
 {
     M *m;
     int b;
 
-    DecIfAbove0_Short((unsigned short *)(c + 0x100));
-    DecIfAbove0_Short((unsigned short *)(c + 0x444));
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_100));
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_444));
 
-    m = *(M **)(c + 0x42c);
+    m = *(M **)((char *)&unk_42c);
     if (m->pmf != 0)
-        (((Klass *)c)->*(m->pmf))();
+        (((Klass *)((char *)this))->*(m->pmf))();
 
     {
-        int accum = *(int *)(c + 0xa8);
-        int a0 = *(int *)(c + 0x9c);
-        int lim = *(int *)(c + 0xa0);
+        int accum = unk_0a8;
+        int a0 = unk_09c;
+        int lim = unk_0a0;
         int sum = accum + a0;
         if (sum >= lim)
             lim = sum;
-        int t = *(int *)(c + 0xac);
-        *(int *)(c + 0xa8) = lim;
-        *(int *)(c + 0xac) = t;
+        int t = unk_0ac;
+        unk_0a8 = lim;
+        unk_0ac = t;
     }
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, (CylinderClsn *)(c + 0x110));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (WithMeshClsn *)(c + 0x178), 0);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((char *)this), (CylinderClsn *)((char *)&mMovingCylinderClsn1));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 0);
 
-    *(short *)(c + 0x8c) = *(short *)(c + 0x92);
-    *(short *)(c + 0x8e) = *(short *)(c + 0x94);
-    *(short *)(c + 0x90) = *(short *)(c + 0x96);
-    func_ov062_0211c6a8(c);
+    unk_08c = unk_092;
+    unk_08e = unk_094;
+    unk_090 = unk_096;
+    func_ov062_0211c6a8(((char *)this));
 
-    unsigned int actorId = *(unsigned int *)(c + 0x44c);
+    unsigned int actorId = mHeldActorID;
     if (actorId != 0) {
         void *p = _ZN5Actor10FindWithIDEj(actorId);
         if (p != 0) {
-            if (*(int *)(c + 0x468) == 1) {
-                *(int *)((char *)p + 0x5c) = *(int *)(c + 0x450);
-                *(int *)((char *)p + 0x60) = *(int *)(c + 0x454);
-                *(int *)((char *)p + 0x64) = *(int *)(c + 0x458);
+            if (mCarriedItem == 1) {
+                *(int *)((char *)p + 0x5c) = unk_450;
+                *(int *)((char *)p + 0x60) = unk_454;
+                *(int *)((char *)p + 0x64) = unk_458;
                 goto skip_destroy;
             } else if (*(unsigned char *)((char *)p + 0x403) == 0) {
-                *(int *)((char *)p + 0x5c) = *(int *)(c + 0x450);
-                *(int *)((char *)p + 0x60) = *(int *)(c + 0x454);
-                *(int *)((char *)p + 0x64) = *(int *)(c + 0x458);
+                *(int *)((char *)p + 0x5c) = unk_450;
+                *(int *)((char *)p + 0x60) = unk_454;
+                *(int *)((char *)p + 0x64) = unk_458;
                 goto skip_destroy;
             } else {
-                *(int *)(c + 0x44c) = 0;
+                mHeldActorID = 0;
                 func_02012790(0xa, 0);
-                *(unsigned short *)(c + 0x400 + 0x44) = 0x1e;
-                func_ov062_0211c658(c, (PMF *)data_ov062_0211e17c);
+                *(unsigned short *)(((char *)this) + 0x400 + 0x44) = 0x1e;
+                func_ov062_0211c658(((char *)this), (PMF *)data_ov062_0211e17c);
                 goto skip_destroy;
             }
         } else {
-            *(int *)(c + 0x44c) = 0;
+            mHeldActorID = 0;
             func_02012790(0xa, 0);
-            *(unsigned short *)(c + 0x400 + 0x44) = 0x1e;
-            func_ov062_0211c658(c, (PMF *)data_ov062_0211e17c);
+            *(unsigned short *)(((char *)this) + 0x400 + 0x44) = 0x1e;
+            func_ov062_0211c658(((char *)this), (PMF *)data_ov062_0211e17c);
             goto skip_destroy;
         }
     }
 
-    if (*(int *)(c + 0x468) == 1 && *(unsigned char *)(c + 0x448) != 2) {
-        b = (*(int *)(c + 0xb0) & 8) != 0;
+    if (mCarriedItem == 1 && unk_448 != 2) {
+        b = (unk_0b0 & 8) != 0;
         if (b != 0) {
-            _ZN9ActorBase18MarkForDestructionEv(c);
+            _ZN9ActorBase18MarkForDestructionEv(((char *)this));
         }
     }
 skip_destroy:
-    _ZN14BlendModelAnim7AdvanceEv((void *)(c + 0x334));
-    if (*(void **)(c + 0x42c) != (void *)data_ov062_0211e14c) {
-        func_ov062_0211b51c(c);
+    _ZN14BlendModelAnim7AdvanceEv((void *)((char *)&mBlendModelAnim));
+    if (*(void **)((char *)&unk_42c) != (void *)data_ov062_0211e14c) {
+        func_ov062_0211b51c(((char *)this));
     }
 
-    _ZN12CylinderClsn5ClearEv((CylinderClsn *)(c + 0x110));
-    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(c + 0x110));
-    _ZN12CylinderClsn5ClearEv((CylinderClsn *)(c + 0x144));
-    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(c + 0x144));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsn1));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsn1));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsn2));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsn2));
 
     return 1;
 }

--- a/src/_ZN6KleptoD0Ev.c
+++ b/src/_ZN6KleptoD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN14BlendModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6KleptoD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daJango_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6KleptoD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daJango_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3a4);
     _ZN14BlendModelAnimD1Ev((char *)t + 0x334);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x178);

--- a/src/_ZN6KleptoD1Ev.c
+++ b/src/_ZN6KleptoD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN14BlendModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6KleptoD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_BlendModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Klepto */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6KleptoD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6Klepto;
     _ZN11ShadowModelD1Ev((char *)t + 0x3a4);
     _ZN14BlendModelAnimD1Ev((char *)t + 0x334);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x178);

--- a/src/_ZN6Lakitu6RenderEv.cpp
+++ b/src/_ZN6Lakitu6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Lakitu6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Lakitu.h"
 struct ModelComponents;
 struct TextureSequence { void Update(ModelComponents &m); };
 struct VObj {
@@ -10,17 +13,17 @@ struct VObj {
     virtual void m(int x);
 };
 
-extern "C" int _ZN6Lakitu6RenderEv(char *c)
+int Lakitu::Render()
 {
-    int b = (int)((*(int *)(c + 0xb0) & 0x40000) != 0);
+    int b = (int)((unk_0b0 & 0x40000) != 0);
     if (b != 0)
         return 1;
-    ((TextureSequence *)(c + 0x1b0))->Update(*(ModelComponents *)(c + 0xdc));
-    ((VObj *)(c + 0xd4))->m(0);
-    if (*(int *)(c + 0x3f4) == 1) {
-        unsigned int v = ((unsigned int)(*(int *)(c + 0x12c) << 4)) >> 0x10;
+    ((TextureSequence *)((char *)&mTextureSequence))->Update(*(ModelComponents *)((char *)&unk_0dc));
+    ((VObj *)((char *)&mModelAnim))->m(0);
+    if (unk_3f4 == 1) {
+        unsigned int v = ((unsigned int)(unk_12c << 4)) >> 0x10;
         if (v >= 0x19 && v <= 0x3a)
-            ((VObj *)(c + 0x138))->m(0);
+            ((VObj *)((char *)&mModel))->m(0);
     }
     return 1;
 }

--- a/src/_ZN6Lakitu8BehaviorEv.cpp
+++ b/src/_ZN6Lakitu8BehaviorEv.cpp
@@ -1,13 +1,19 @@
 //cpp
+// @symbol _ZN6Lakitu8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Lakitu.h"
 extern "C" {
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void*, int);
-extern int func_ov077_02124718(void*);
 extern int func_ov077_02123d40(void*);
-int _ZN6Lakitu8BehaviorEv(char *c){
-  int v = *(int*)(c+8);
-  if(_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, v ? 0x1068000 : 0x7d0000)) return 1;
-  func_ov077_02124718(c);
-  func_ov077_02123d40(c);
-  return 1;
 }
+
+int Lakitu::Behavior()
+{
+  int v = mParam;
+  if(_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(((char *)this), v ? 0x1068000 : 0x7d0000)) return 1;
+  func_ov077_02124718(((char *)this));
+  func_ov077_02123d40(((char *)this));
+  return 1;
 }

--- a/src/_ZN6LakituD0Ev.c
+++ b/src/_ZN6LakituD0Ev.c
@@ -1,16 +1,19 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN6LakituD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daJgm_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6LakituD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daJgm_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x204);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1c4);
     _ZN15TextureSequenceD1Ev((char *)t + 0x1b0);

--- a/src/_ZN6Player10SpinBounceE5Fix12IiE.cpp
+++ b/src/_ZN6Player10SpinBounceE5Fix12IiE.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player10SpinBounceE5Fix12IiE
+/* recovered: named members + shared header */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void*,void*);
 extern int _ZN6Player9GetHealthEv(void*);
@@ -7,13 +10,13 @@ extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int data_ov002_021105a4[];
 extern int data_ov002_02110454[];
-void _ZN6Player10SpinBounceE5Fix12IiE(char* c, int f){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105a4)) return;
-  if(_ZN6Player9GetHealthEv(c)==0) return;
-  *(int*)(c+0xa8) = f;
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x28,(char*)c+0x74);
-  _ZN5Sound9PlayBank0EjRK7Vector3(0xb6,(char*)c+0x74);
-  *(char*)(c+0x6e6)=1;
-  _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110454);
+void _ZN6Player10SpinBounceE5Fix12IiE(struct Player *self, int f) {
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)self), data_ov002_021105a4)) return;
+  if(_ZN6Player9GetHealthEv(((char*)self))==0) return;
+  self->mVertSpeed = f;
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(self->mCharacter,0x28,(char*)((char*)self)+0x74);
+  _ZN5Sound9PlayBank0EjRK7Vector3(0xb6,(char*)((char*)self)+0x74);
+  self->unk_6e6=1;
+  _ZN6Player11ChangeStateERNS_5StateE(((char*)self), data_ov002_02110454);
 }
 }

--- a/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
+++ b/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player11ChangeStateERNS_5StateE
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Player.h"
 struct C3;
 typedef int (C3::*PMF)();
 
@@ -11,7 +16,6 @@ struct State {
 extern "C" {
 extern void func_ov002_020d4540(char *p);
 extern void func_ov002_020c9e18(char *c);
-extern void func_ov002_020e6780(char *p);
 extern void func_0200d81c(void *thiz, int playerID);
 
 extern void *data_0209f318;
@@ -22,24 +26,23 @@ extern State data_ov002_021106ac;
 extern State data_ov002_02110364;
 }
 
-extern "C" int _ZN6Player11ChangeStateERNS_5StateE(char *c, State *newState)
-{
-    *(State**)(c+0x378) = newState;
+extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *newState) {
+    *(State**)((char *)&self->unk_378) = newState;
 
     {
         State *cur;
         int ok;
-        cur = *(State**)(c+0x370);
+        cur = *(State**)((char *)&self->unk_370);
         if (cur == 0) { ok = 1; goto check_ok; }
         if (*(int*)((char*)cur+0x10) == 0) { ok = 1; goto check_ok; }
-        ok = (((C3*)c)->*(cur->onExit))();
+        ok = (((C3*)((char *)self))->*(cur->onExit))();
     check_ok:
         if (!ok) return 0;
     }
 
-    if (*(State**)(c+0x370) == &data_ov002_0211022c
-        && (unsigned short)(*(unsigned short*)(c+0x6ce) & 0x400) == 0
-        && *(unsigned char*)(c+0x709) != 0
+    if (*(State**)((char *)&self->unk_370) == &data_ov002_0211022c
+        && (unsigned short)(self->mStateFlags & 0x400) == 0
+        && self->mIsNoControl != 0
         && newState != &data_ov002_0211013c
         && newState != &data_ov002_0211067c
         && newState != &data_ov002_021106ac
@@ -49,67 +52,67 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(char *c, State *newState)
     }
 
     {
-        int b = (*(int*)(c+0x358) != 0);
+        int b = (self->mHeldObj != 0);
         if (b) {
         if (newState == &data_ov002_0211013c) {
-            *(unsigned char*)(c+0x6e3) = 1;
+            self->mStateStep = 1;
             newState = &data_ov002_02110364;
         }
         }
     }
 
-    *(int*)(c+0x620) = 0;
-    *(int*)(c+0x630) = 0;
-    *(int*)(c+0x62c) = *(int*)(c+0x630);
-    *(int*)(c+0x628) = *(int*)(c+0x62c);
+    self->mLoopingSoundHandle = 0;
+    self->unk_630 = 0;
+    self->mParticle2 = self->unk_630;
+    self->unk_628 = self->mParticle2;
 
-    *(State**)(c+0x374) = *(State**)(c+0x370);
-    *(State**)(c+0x370) = newState;
+    *(State**)((char *)&self->unk_374) = *(State**)((char *)&self->unk_370);
+    *(State**)((char *)&self->unk_370) = newState;
 
-    *(unsigned char*)(c+0x717) = 0;
-    *(unsigned char*)(c+0x713) = 1;
-    *(unsigned char*)(c+0x716) = 0;
+    self->unk_717 = 0;
+    self->mIsBodyClsnEnabled = 1;
+    self->unk_716 = 0;
 
-    *(int*)(c+0x694) = 0;
-    *(int*)(c+0x690) = *(int*)(c+0x694);
+    self->unk_694 = 0;
+    self->unk_690 = self->unk_694;
 
-    *(unsigned char*)(c+0x712) = 0;
-    *(int*)(c+0x654) = 0;
+    self->mIsInAirState = 0;
+    self->unk_654 = 0;
 
-    *(short*)(c+0x90) = 0;
-    *(short*)(c+0x8c) = *(short*)(c+0x90);
+    self->mAngZ = 0;
+    self->mAngX = self->mAngZ;
 
-    *(unsigned char*)(c+0x6f6) = 0;
-    *(unsigned char*)(c+0x6ec) = 0;
-    *(unsigned char*)(c+0x726) = 0;
+    self->mIsControlDisabled = 0;
+    self->unk_6ec = 0;
+    self->unk_726 = 0;
 
-    *(unsigned short*)(((long long)(int)(c+0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x200;
+    *(unsigned short*)(((long long)(int)((char *)&self->mStateFlags))) &= ~0x200;
 
     {
         int v1 = 0x4000;
         int v2 = 0x4b000;
         v1 = -v1;
         v2 = -v2;
-        *(int*)(c+0x9c) = v1;
-        *(int*)(c+0xa0) = v2;
+        self->mVertAccel = v1;
+        self->mTerminalVelocity = v2;
     }
 
-    *(short*)(c+0x6a4) = 0;
+    self->mStateTimer = 0;
 
-    func_ov002_020d4540(c);
+    func_ov002_020d4540(((char *)self));
 
-    *(unsigned char*)(c+0x708) = 0;
-    func_ov002_020c9e18(c);
+    self->mIsTakingDamage = 0;
+    func_ov002_020c9e18(((char *)self));
 
-    func_ov002_020e6780(c);
+    func_ov002_020e6780(((char *)self));
 
     if (data_0209f318 != 0) {
-        func_0200d81c(data_0209f318, *(unsigned char*)(c+0x6d8));
+        func_0200d81c(data_0209f318, self->mPlayerNo);
     }
 
     {
-        State *s = *(State**)(c+0x370);
+        State *s = *(State**)((char *)&self->unk_370);
         if (*(int*)s == 0) return 1;
-        return (((C3*)c)->*(s->onEnter))();
+        return (((C3*)((char *)self))->*(s->onEnter))();
     }
 }

--- a/src/_ZN6Player11St_Fly_InitEv.cpp
+++ b/src/_ZN6Player11St_Fly_InitEv.cpp
@@ -1,25 +1,30 @@
 //cpp
+// @symbol _ZN6Player11St_Fly_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int data_0209f318[];
 extern void func_ov002_020dab14(char*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern void func_0200d6f0(void*,unsigned char);
-int _ZN6Player11St_Fly_InitEv(char* c){
-  *(short*)(c+0x69e)=0;
-  *(short*)(c+0x69c)=0;
-  *(short*)(c+0x92)=0;
-  *(short*)(c+0x96)=0;
-  *(short*)(c+0x94)=*(short*)(c+0x8e);
-  func_ov002_020dab14(c);
-  if(*(unsigned char*)(c+0x6e3)==0){
-    *(int*)(c+0xa8)=0x5d000;
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x4a,0x40000000,0x1000,0);
-    *(int*)(c+0xa0)=-0x4000;
-  } else {
-    *(int*)(c+0x9c)=0;
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x49,0,0x1000,0);
-  }
-  func_0200d6f0((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
-  return 1;
 }
+
+int Player::St_Fly_Init()
+{
+  unk_69e=0;
+  mAngleYSpeed=0;
+  unk_092=0;
+  unk_096=0;
+  mTargetAngleY=mAngleY;
+  func_ov002_020dab14(((char*)this));
+  if(mStateStep==0){
+    mVertSpeed=0x5d000;
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x4a,0x40000000,0x1000,0);
+    mTerminalVelocity=-0x4000;
+  } else {
+    mVertAccel=0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x49,0,0x1000,0);
+  }
+  func_0200d6f0((void*)data_0209f318[0], mPlayerNo);
+  return 1;
 }

--- a/src/_ZN6Player11St_Owl_InitEv.cpp
+++ b/src/_ZN6Player11St_Owl_InitEv.cpp
@@ -1,17 +1,23 @@
 //cpp
+// @symbol _ZN6Player11St_Owl_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int data_0209f318[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-extern void func_0200d6b4(void*,unsigned char);
 extern void func_ov002_020bd928(char*,unsigned int);
-int _ZN6Player11St_Owl_InitEv(char* c){
-  *(int*)(c+0xa0)=-0x4b000;
-  *(int*)(c+0x9c)=0;
-  *(unsigned char*)(c+0x6e3)=0;
-  *(int*)(c+0x98)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x5b,0x40000000,0x1000,0);
-  func_0200d6b4((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
-  func_ov002_020bd928(c,0x2f);
-  return 1;
 }
+
+int Player::St_Owl_Init()
+{
+  mTerminalVelocity=-0x4b000;
+  mVertAccel=0;
+  mStateStep=0;
+  mHorzSpeed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x5b,0x40000000,0x1000,0);
+  func_0200d6b4((void*)data_0209f318[0], mPlayerNo);
+  func_ov002_020bd928(((char*)this),0x2f);
+  return 1;
 }

--- a/src/_ZN6Player11St_Owl_MainEv.cpp
+++ b/src/_ZN6Player11St_Owl_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player11St_Owl_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
 extern void _Z14ApproachLinearRiii(int* p, int value, int speed);
@@ -6,7 +11,6 @@ extern int ApproachAngle(short* cur, short target, int divisor, int band, int ma
 extern void func_0201f32c(int a);
 extern void func_0200d3f8(void* thiz, unsigned char playerID, void* ptr);
 extern void func_ov002_020c9e40(char* c);
-extern void func_0200d6b4(void* thiz, unsigned char playerID);
 extern void func_ov002_020c9e18(char* c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int d, unsigned int e);
@@ -19,45 +23,46 @@ extern int data_ov002_021101b4[];
 extern short data_02082214[];
 extern char* data_0209f318;
 extern unsigned char data_0209d660;
+}
 
-int _ZN6Player11St_Owl_MainEv(char* c)
+int Player::St_Owl_Main()
 {
     unsigned char st;
 
-    *(int*)(c+0x684) = *(int*)(c+0x60);
-    st = *(unsigned char*)(c+0x6e3);
+    mPeakY = mPosY;
+    st = mStateStep;
     if (st != 2 && st != 3) {
-        if (*(int*)(c+0x358) == 0 ||
+        if (mHeldObj == 0 ||
             (*(unsigned short*)(data_0209f49c + data_020a0e40*0x18) & 2) == 0 ||
-            (*(unsigned char*)(c+0x6e9) & 2)) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            (mClsnFlags & 2)) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
             return 1;
         }
     }
 
     switch (st) {
     case 0:
-        if (*(int*)(c+0x688) <= *(int*)(c+0x60)) {
-            (*(unsigned char*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
-            *(int*)(c+0x9c) = -0x2c00;
+        if (mAttachOffsetY <= mPosY) {
+            (*(unsigned char*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+            mVertAccel = -0x2c00;
         }
-        if (*(unsigned char*)(c+0x6de) != 0) {
-            if (*(int*)(c+0xa8) < 0) {
-                _Z14ApproachLinearRiii((int*)(c+0xa8), 0x3c000, 0x8000);
+        if (mIsAirborne != 0) {
+            if (mVertSpeed < 0) {
+                _Z14ApproachLinearRiii((int*)((char*)&mVertSpeed), 0x3c000, 0x8000);
             } else {
-                _Z14ApproachLinearRiii((int*)(c+0xa8), 0x3c000, 0x2000);
+                _Z14ApproachLinearRiii((int*)((char*)&mVertSpeed), 0x3c000, 0x2000);
             }
         } else {
-            *(int*)(c+0xa8) = 0x8000;
-            *(unsigned char*)(c+0x6de) = 1;
-            *(unsigned char*)(c+0x6df) = 0;
+            mVertSpeed = 0x8000;
+            mIsAirborne = 1;
+            mLandSoundPlayed = 0;
         }
-        ApproachAngle((short*)(c+0x8e), *(short*)(c+0x69c), 0x10, 0x100, 0);
+        ApproachAngle((short*)((char*)&mAngleY), mAngleYSpeed, 0x10, 0x100, 0);
         break;
 
     case 1:
     case 4: {
-        int x = *(int*)(c+0x358);
+        int x = mHeldObj;
         short ang;
         int i;
         short mag = 10;
@@ -66,23 +71,23 @@ int _ZN6Player11St_Owl_MainEv(char* c)
         x += 0xb;
         ang = x * 0xccc;
         i = (unsigned short)ang >> 4;
-        *(int*)(c+0xa8) = data_02082214[i*2+1] * mag;
-        *(int*)(c+0x98) = 0x14000;
+        mVertSpeed = data_02082214[i*2+1] * mag;
+        mHorzSpeed = 0x14000;
         if (*(short*)(data_0209f4a0 + data_020a0e40*0x18) != 0) {
-            ApproachAngle((short*)(c+0x8e), *(short*)(c+0x6d2), 0x20, 0x100, 0);
+            ApproachAngle((short*)((char*)&mAngleY), mDesiredAngleY, 0x20, 0x100, 0);
         }
-        if (*(unsigned char*)(c+0x6e3) == 1) {
-            if (*(int*)(c+0x688) - 0xed8000 > *(int*)(c+0x60)) {
-                *(unsigned char*)(c+0x724) = 1;
+        if (mStateStep == 1) {
+            if (mAttachOffsetY - 0xed8000 > mPosY) {
+                unk_724 = 1;
                 func_0201f32c(0xa3);
-                func_0200d3f8(data_0209f318, *(unsigned char*)(c+0x6d8), 0);
-                *(int*)(c+0x9c) = 0;
-                func_ov002_020c9e40(c);
-                *(unsigned char*)(c+0x6e3) = 2;
+                func_0200d3f8(data_0209f318, mPlayerNo, 0);
+                mVertAccel = 0;
+                func_ov002_020c9e40(((char*)this));
+                mStateStep = 2;
             }
         } else {
-            if (*(unsigned short*)(c+0x6a4) == 0) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            if (mStateTimer == 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
                 return 1;
             }
         }
@@ -90,29 +95,28 @@ int _ZN6Player11St_Owl_MainEv(char* c)
     }
 
     case 2:
-        *(int*)(c+0x98) = 0;
-        *(int*)(c+0xa8) = *(int*)(c+0x98);
+        mHorzSpeed = 0;
+        mVertSpeed = mHorzSpeed;
         if (data_0209d660 == 0) {
-            *(unsigned char*)(c+0x6e3) = 3;
-            func_0200d6b4(data_0209f318, *(unsigned char*)(c+0x6d8));
+            mStateStep = 3;
+            func_0200d6b4(data_0209f318, mPlayerNo);
         }
         break;
 
     case 3:
         if ((*(int*)(data_0209f318 + 0x154) & 0x8000) == 0) {
-            *(unsigned char*)(c+0x6e3) = 4;
-            *(unsigned short*)(c+0x6a4) = 0x3c;
-            func_ov002_020c9e18(c);
-            *(unsigned char*)(c+0x724) = 0;
+            mStateStep = 4;
+            mStateTimer = 0x3c;
+            func_ov002_020c9e18(((char*)this));
+            unk_724 = 0;
         }
         break;
     }
 
-    if (_ZN6Player12FinishedAnimEv(c)) {
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x58, 0, 0x1000, 0);
+    if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x58, 0, 0x1000, 0);
     }
-    *(short*)(c+0x94) = *(short*)(c+0x8e);
-    func_ov002_020bedd4(c);
+    mTargetAngleY = mAngleY;
+    func_ov002_020bedd4(((char*)this));
     return 1;
-}
 }

--- a/src/_ZN6Player12FinishedAnimEv.cpp
+++ b/src/_ZN6Player12FinishedAnimEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN6Player12FinishedAnimEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" unsigned int _ZNK6Player14GetBodyModelIDEjb(char*,unsigned int,char);
 extern "C" int _ZN9Animation8FinishedEv(char*);
-extern "C" int _ZN6Player12FinishedAnimEv(char* c){
-  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c+8)&0xff, 0);
-  char* m = *(char**)(c + id*4 + 0xdc);
+
+int Player::FinishedAnim()
+{
+  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam&0xff, 0);
+  char* m = *(char**)(((char*)this) + id*4 + 0xdc);
   return _ZN9Animation8FinishedEv(m+0x50) != 0;
 }

--- a/src/_ZN6Player12GetHurtStateEv.cpp
+++ b/src/_ZN6Player12GetHurtStateEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN6Player12GetHurtStateEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* st);
 extern int data_ov002_02110094[];
-int _ZN6Player12GetHurtStateEv(char* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110094))
-    return *(unsigned char*)(c+0x6e3) & 7;
-  return -1;
 }
+
+int Player::GetHurtState()
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_02110094))
+    return mStateStep & 7;
+  return -1;
 }

--- a/src/_ZN6Player12GetTalkStateEv.cpp
+++ b/src/_ZN6Player12GetTalkStateEv.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN6Player12GetTalkStateEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player12GetTalkStateEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c)) return -1;
-  unsigned char v=*(unsigned char*)(c+0x6e3);
+}
+
+int Player::GetTalkState()
+{
+  if(!_ZN6Player7IsStateERNS_5StateE(((char*)this),&data_ov002_0211046c)) return -1;
+  unsigned char v=mStateStep;
   if(v==0) return 0;
   if(v==3) return 2;
   if(v==5||v==7) return 3;
   return 1;
-}
 }

--- a/src/_ZN6Player12St_Bonk_InitEv.cpp
+++ b/src/_ZN6Player12St_Bonk_InitEv.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol _ZN6Player12St_Bonk_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player12St_Bonk_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x13,0x40000000,0x1000,0);
-  *(short*)(c+0x6a4)=0x10;
-  *(int*)(c+0x98)=0x40;
-  *(int*)(c+0xa8)=0xa000;
-  *(char*)(c+0x6e5)=0;
-  return 1;
 }
+
+int Player::St_Bonk_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x13,0x40000000,0x1000,0);
+  mStateTimer=0x10;
+  mHorzSpeed=0x40;
+  mVertSpeed=0xa000;
+  mStateWork=0;
+  return 1;
 }

--- a/src/_ZN6Player12St_Bonk_MainEv.cpp
+++ b/src/_ZN6Player12St_Bonk_MainEv.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol _ZN6Player12St_Bonk_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-struct Vector3 { int x, y, z; };
 struct Camera;
 
 extern "C" {
@@ -13,7 +17,6 @@ extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020bedd4(void* c);
@@ -23,70 +26,70 @@ extern struct Camera* data_0209f318;
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player12St_Bonk_MainEv(char* c)
+int Player::St_Bonk_Main()
 {
     int rate;
 
-    if (*(u16*)(c + 0x6a4) != 0) {
-        *(int*)(c + 0x98) = 0x40000;
-        *(int*)(c + 0xa8) = 0x8000;
+    if (mStateTimer != 0) {
+        mHorzSpeed = 0x40000;
+        mVertSpeed = 0x8000;
         goto ret1;
     }
 
     rate = 0x1000;
-    if (*(u8*)(c + 0x6de) == 0) {
-        int v = *(int*)(c + 0x640);
+    if (mIsAirborne == 0) {
+        int v = mPrevVertSpeed;
         if (v < 0) {
-            *(int*)(c + 0xa8) = (-v) / 3;
-            if (*(int*)(c + 0xa8) <= 0x1000) {
-                *(int*)(c + 0xa8) = 0;
+            mVertSpeed = (-v) / 3;
+            if (mVertSpeed <= 0x1000) {
+                mVertSpeed = 0;
             }
         }
 
-        if (*(u8*)(c + 0x70c) == 0) {
-            _ZN5Sound9PlayBank0EjRK7Vector3(*(u32*)(c + 0x66c) + 0x50, c + 0x74);
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x11, c + 0x74);
-            *(u8*)(c + 0x70c) = 1;
+        if (mStateArg == 0) {
+            _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType + 0x50, ((char*)this) + 0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x11, ((char*)this) + 0x74);
+            mStateArg = 1;
         }
 
-        if (*(int*)(c + 0x684) - *(int*)(c + 0x60) > 0xbb8000) {
-            func_0200d8c8(data_0209f318, (struct Vector3*)(c + 0x5c), 0x7d0000);
+        if (mPeakY - mPosY > 0xbb8000) {
+            func_0200d8c8(data_0209f318, (struct Vector3*)((char*)&mPosX), 0x7d0000);
         }
 
         rate = 0x1800;
     }
 
-    _Z14ApproachLinearRiii((int*)(c + 0x98), 0, rate);
+    _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), 0, rate);
 
-    if (*(int*)(c + 0x98) != 0) {
+    if (mHorzSpeed != 0) {
         goto willhit;
     }
-    if (*(u8*)(c + 0x6de) == 0) {
+    if (mIsAirborne == 0) {
         goto finishedanim;
     }
 willhit:
     {
-        u32 arg = (u8)*(int*)(c + 8);
-        int modelIdx = _ZNK6Player14GetBodyModelIDEjb(c, arg, 0);
-        char* anim = *(char**)(c + modelIdx * 4 + 0xdc) + 0x50;
+        u32 arg = (u8)mParam;
+        int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
+        char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
         if (_ZNK9Animation12WillHitFrameEi(anim, 0x2e) != 0) {
-            *(u8*)(c + 0x6e5) = 1;
+            mStateWork = 1;
         }
     }
     goto tail;
 finishedanim:
-    *(u8*)(c + 0x6e5) = 0;
-    if (_ZN6Player12FinishedAnimEv(c) != 0) {
-        *(s16*)(c + 0x94) = *(s16*)(c + 0x94) + 0x8000;
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    mStateWork = 0;
+    if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+        mTargetAngleY = mTargetAngleY + 0x8000;
+        mAngleY = mTargetAngleY;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
 tail:
-    if (*(u8*)(c + 0x6e5) == 0) {
-        func_ov002_020bedd4(c);
+    if (mStateWork == 0) {
+        func_ov002_020bedd4(((char*)this));
     }
-    *(int*)(c + 0x640) = *(int*)(c + 0xa8);
+    mPrevVertSpeed = mVertSpeed;
 ret1:
     return 1;
 }

--- a/src/_ZN6Player12St_Dive_InitEv.cpp
+++ b/src/_ZN6Player12St_Dive_InitEv.cpp
@@ -1,21 +1,24 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN6Player12St_Dive_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, const Vector3&);
 extern "C" int RandomIntInternal(int* seed);
 extern "C" void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, const Vector3&);
 extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
 extern int data_ov002_0210e160;
-extern int data_ov002_020ff100[];
 
-extern "C" int _ZN6Player12St_Dive_InitEv(void* thisptr)
+int Player::St_Dive_Init()
 {
-    unsigned char* p = (unsigned char*)thisptr;
+    unsigned char* p = (unsigned char*)((void*)this);
     _ZN5Sound9PlayBank0EjRK7Vector3(0x11, *(Vector3*)(p + 0x74));
     unsigned int r = (unsigned int)RandomIntInternal(&data_ov002_0210e160);
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(p[0x6d9], data_ov002_020ff100[(r >> 4) & 1], *(Vector3*)(p + 0x74));
-    _ZN6Player7SetAnimEji5Fix12IiEj(thisptr, 0x40, 0x40000000, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x40, 0x40000000, 0x1000, 0);
     *(unsigned char*)(p + 0x6e3) = 0;
-    int* yv = (int*)(((long long)(int)(p + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* yv = (int*)(((long long)(int)(p + 0x98)));
     *(int*)(p + 0xa8) = 0x1e000;
     yv[0] += 0xf000;
     if (*(int*)(p + 0x98) > 0x28000) *(int*)(p + 0x98) = 0x28000;

--- a/src/_ZN6Player12St_Jump_MainEv.cpp
+++ b/src/_ZN6Player12St_Jump_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player12St_Jump_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 typedef int s32;
 typedef short s16;
@@ -9,27 +14,26 @@ typedef unsigned char u8;
 extern int func_ov002_020eeca8(void*, void*);
 extern int func_ov002_020e28d4(void*, int, int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
-extern int func_ov002_020e2664(void*);
 extern u32 _ZNK6Player14GetBodyModelIDEjb(void*, u32, int);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32, void*);
 extern int func_ov002_020bedd4(void*);
 
 extern char data_ov002_02110424[];
 extern u8 data_020a0e40;
-extern u8 data_0209f4ab[];
 extern u16 data_0209f49e[];
-extern int data_ov002_0211073c[];
+}
 
-int _ZN6Player12St_Jump_MainEv(void* c) {
-  func_ov002_020eeca8((char*)c + 0x380, c);
-  func_ov002_020e28d4(c, 0xd00, 0x800);
+int Player::St_Jump_Main()
+{
+  func_ov002_020eeca8((char*)((void*)this) + 0x380, ((void*)this));
+  func_ov002_020e28d4(((void*)this), 0xd00, 0x800);
 
-  if (*(u8*)((char*)c + 0x6de) == 0) {
-    if (*(u16*)((char*)c + 0x6a4) != 0) {
-      u16* q = (u16*)(((long long)(int)((char*)c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL);
+  if (*(u8*)((char*)&mIsAirborne) == 0) {
+    if (*(u16*)((char*)&mStateTimer) != 0) {
+      u16* q = (u16*)(((long long)(int)((char*)&mStateFlags)));
       *q |= 0x100;
     }
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110424);
+    _ZN6Player11ChangeStateERNS_5StateE(((void*)this), data_ov002_02110424);
   } else {
     {
       int off = data_020a0e40 * 0x18;
@@ -38,36 +42,36 @@ int _ZN6Player12St_Jump_MainEv(void* c) {
         *p = 5;
       }
       if (*(u16*)((char*)data_0209f49e + off) & 2) {
-        *(u16*)((char*)c + 0x6a4) = 5;
+        *(u16*)((char*)&mStateTimer) = 5;
       }
     }
 
-    if (func_ov002_020e2664(c)) return 1;
+    if (func_ov002_020e2664(((void*)this))) return 1;
 
-    if (*(u8*)((char*)c + 0x6e1) == 2) {
-      *(s32*)((char*)c + 0x9c) = -0x4000;
-      *(s32*)((char*)c + 0xa0) = -0x4b000;
-      if (*(s32*)((char*)c + 0xa8) >= 0) {
-        *(s32*)((char*)c + 0x9c) = -0x3400;
+    if (*(u8*)((char*)&mJumpComboStage) == 2) {
+      *(s32*)((char*)&mVertAccel) = -0x4000;
+      *(s32*)((char*)&mTerminalVelocity) = -0x4b000;
+      if (*(s32*)((char*)&mVertSpeed) >= 0) {
+        *(s32*)((char*)&mVertAccel) = -0x3400;
       }
 
       {
-        u32 id = _ZNK6Player14GetBodyModelIDEjb(c, *(u32*)((char*)c + 8) & 0xff, 0);
-        void* anim = *(void**)((char*)c + (id << 2) + 0xdc);
-        u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50)) & 0xFFFFFFFFFFFFFFFFLL) + 8);
+        u32 id = _ZNK6Player14GetBodyModelIDEjb(((void*)this), *(u32*)((char*)&mParam) & 0xff, 0);
+        void* anim = *(void**)((char*)((void*)this) + (id << 2) + 0xdc);
+        u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
         u16 t = (u16)(w >> 12);
         if (t == 4 || t == 0x18 || t == 0x2c) {
-          _ZN5Sound9PlayBank0EjRK7Vector3(0xf, (char*)c + 0x74);
+          _ZN5Sound9PlayBank0EjRK7Vector3(0xf, (char*)((void*)this) + 0x74);
         }
       }
     } else {
-      int idx = *(int*)((char*)c + 8);
-      if (*(u8*)((char*)c + 0x703) != 0) {
+      int idx = *(int*)((char*)&mParam);
+      if (*(u8*)((char*)&mIsMega) != 0) {
         idx = 0;
       }
       int* row = &data_ov002_0211073c[idx * 2];
       int v = row[1];
-      void* p2 = (char*)c + (v >> 1);
+      void* p2 = (char*)((void*)this) + (v >> 1);
       int (*f)(void*);
       if (v & 1) {
         f = *(int (**)(void*))((char*)(*(int**)p2) + row[0]);
@@ -78,7 +82,6 @@ int _ZN6Player12St_Jump_MainEv(void* c) {
     }
   }
 
-  func_ov002_020bedd4(c);
+  func_ov002_020bedd4(((void*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player12St_Land_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -10,18 +15,14 @@ extern "C" {
 extern int func_ov002_020c0434(void* c);
 extern void func_ov002_020c0364(void* c, u32 arg);
 extern void func_ov002_020c06fc(void* c, u32 arg);
-extern void func_ov002_020e04a4(void* c);
 extern int func_ov002_020e3078(void* c, void* s);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
-extern int func_ov002_020d5c6c(void* c);
-extern int func_ov002_020dde74(void* c);
 extern int func_ov002_020bf30c(void* c, int a);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020bedd4(void* c);
 
@@ -29,97 +30,95 @@ extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
 extern u16 data_0209f49c[];
 extern s16 data_0209f4a0[];
-extern int data_ov002_0211055c[];
-extern int data_ov002_0211019c[];
 extern int data_ov002_0211052c[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player12St_Land_MainEv(char* c)
+int Player::St_Land_Main()
 {
-    if (func_ov002_020c0434(c)) {
-        func_ov002_020c0364(c, 3);
-        func_ov002_020c06fc(c, 0x4000);
+    if (func_ov002_020c0434(((char*)this))) {
+        func_ov002_020c0364(((char*)this), 3);
+        func_ov002_020c06fc(((char*)this), 0x4000);
         return 1;
     }
 
-    func_ov002_020e04a4(c);
-    u16 temp_r3 = *(u16*)(c + 0x6ce);
+    func_ov002_020e04a4(((char*)this));
+    u16 temp_r3 = mStateFlags;
 
     if ((u16)(temp_r3 & 0x40) == 0) {
         if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2)
             || (u16)(temp_r3 & 0x100) != 0) {
-            *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
-            if (func_ov002_020e3078(c, data_ov002_0211055c) != 0
+            *(u16*)(((long long)(int)((char*)&mStateFlags))) &= ~0x100;
+            if (func_ov002_020e3078(((char*)this), data_ov002_0211055c) != 0
                 && (*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 0x400)
-                && *(int*)(c + 0x98) >= 0) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211055c);
+                && mHorzSpeed >= 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211055c);
                 return 1;
             }
-            if (_ZN6Player6IsAnimEj(c, 0x4e) != 0) {
-                *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+            if (_ZN6Player6IsAnimEj(((char*)this), 0x4e) != 0) {
+                mAngleY = mTargetAngleY;
             }
-            int v = (*(int*)(c + 0x358) != 0);
+            int v = (mHeldObj != 0);
             if (v != 0) {
-                *(s16*)(c + 0x6a8) = 0;
+                mJumpComboTimer = 0;
             }
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211019c);
             return 1;
         }
-        if (func_ov002_020d5c6c(c) != 0) {
+        if (func_ov002_020d5c6c(((char*)this)) != 0) {
             return 1;
         }
         if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 1) {
-            return func_ov002_020dde74(c);
+            return func_ov002_020dde74(((char*)this));
         }
     } else {
-        *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
+        *(u16*)(((long long)(int)((char*)&mStateFlags))) &= ~0x100;
     }
 
-    _Z14ApproachLinearRiii((int*)(c + 0x98),
-        func_ov002_020bf224(c, func_ov002_020bf30c(c, 0x20000), 0),
+    _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed),
+        func_ov002_020bf224(((char*)this), func_ov002_020bf30c(((char*)this), 0x20000), 0),
         0x4000);
 
-    if (func_ov002_020e3078(c, data_ov002_0211052c) != 0) {
-        *(int*)(c + 0x98) = 0;
+    if (func_ov002_020e3078(((char*)this), data_ov002_0211052c) != 0) {
+        mHorzSpeed = 0;
     }
 
-    if (*(u16*)(c + 0x6a4) != 0) {
+    if (mStateTimer != 0) {
         goto tail;
     }
 
     if ((*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0)
-        || (_ZN6Player12FinishedAnimEv(c) != 0)) {
-        if (_ZN6Player6IsAnimEj(c, 0x1b) != 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2e, 0x40000000, 0x1000, 0);
+        || (_ZN6Player12FinishedAnimEv(((char*)this)) != 0)) {
+        if (_ZN6Player6IsAnimEj(((char*)this), 0x1b) != 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x2e, 0x40000000, 0x1000, 0);
             goto tail;
         }
-        if (_ZN6Player6IsAnimEj(c, 0x4e) != 0) {
-            *(s16*)(c + 0x8e) = (s16)(*(s16*)(c + 0x8e) + 0x8000);
+        if (_ZN6Player6IsAnimEj(((char*)this), 0x4e) != 0) {
+            mAngleY = (s16)(mAngleY + 0x8000);
         }
         if ((*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0)
-            && AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x94)) >= 0x4000) {
-            if (AngleDiff(*(s16*)(c + 0x6d2), *(s16*)(c + 0x8e)) >= 0x4000) {
-                *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+            && AngleDiff(mAngleY, mTargetAngleY) >= 0x4000) {
+            if (AngleDiff(mDesiredAngleY, mAngleY) >= 0x4000) {
+                mAngleY = mTargetAngleY;
             } else {
-                *(int*)(c + 0x98) = 0 - *(int*)(c + 0x98);
+                mHorzSpeed = 0 - mHorzSpeed;
             }
         }
-        *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
-        if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211013c) != 0
-            && *(u8*)(c + 0x6e3) != 0
-            && *(int*)(c + 0x98) >= func_ov002_020bf30c(c, 0x1c000)) {
-            *(s16*)(c + 0x760) = 0x4000;
+        mTargetAngleY = mAngleY;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
+        if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211013c) != 0
+            && mStateStep != 0
+            && mHorzSpeed >= func_ov002_020bf30c(((char*)this), 0x1c000)) {
+            unk_760 = 0x4000;
         }
         return 1;
     }
 
-    if (func_ov002_020e3078(c, data_ov002_0211019c) == 0) {
-        *(int*)(c + 0x98) = 0;
+    if (func_ov002_020e3078(((char*)this), data_ov002_0211019c) == 0) {
+        mHorzSpeed = 0;
     }
 
 tail:
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player12St_Spin_InitEv.cpp
+++ b/src/_ZN6Player12St_Spin_InitEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player12St_Spin_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 typedef int Fix12i;
 struct Camera;
@@ -6,25 +9,27 @@ extern int* data_0209f318;
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, Fix12i d, unsigned int e);
 extern void func_ov002_020e25f0(void* c, int i);
 extern void func_0200d678(Camera* thiz, unsigned char pid);
-int _ZN6Player12St_Spin_InitEv(char* c){
-  *(unsigned char*)(c+0x71b) = 0;
-  *(unsigned char*)(c+0x712) = 1;
-  *(unsigned char*)(c+0x70d) = 0;
-  *(unsigned char*)(c+0x6e1) = 0;
-  *(unsigned char*)(c+0x6de) = 1;
-  *(unsigned char*)(c+0x6df) = 0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x5f, 0, 0x1000, 0);
-  *(int*)(c+0xa0) = -0x10000;
-  if (*(unsigned char*)(c+0x6e6)) {
-    *(int*)(c+0xa8) = 0x50000;
-    func_ov002_020e25f0(c, 2);
+}
+
+int Player::St_Spin_Init()
+{
+  mJumpedFromQuicksand = 0;
+  mIsInAirState = 1;
+  mIsFallScreaming = 0;
+  mJumpComboStage = 0;
+  mIsAirborne = 1;
+  mLandSoundPlayed = 0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x5f, 0, 0x1000, 0);
+  mTerminalVelocity = -0x10000;
+  if (unk_6e6) {
+    mVertSpeed = 0x50000;
+    func_ov002_020e25f0(((char*)this), 2);
   }
-  int* p = (int*)(((int)c + 0x2ec) & 0xFFFFFFFFFFFFFFFFull);
+  int* p = (int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFull);
   int old = *p;
   int** cam_ptr_ptr = &data_0209f318;
   *p = old | 0x20;
-  unsigned char pid = *(unsigned char*)(c+0x6d8);
+  unsigned char pid = mPlayerNo;
   func_0200d678((Camera*)*cam_ptr_ptr, pid);
   return 1;
-}
 }

--- a/src/_ZN6Player12St_Swim_InitEv.cpp
+++ b/src/_ZN6Player12St_Swim_InitEv.cpp
@@ -1,26 +1,32 @@
 //cpp
+// @symbol _ZN6Player12St_Swim_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020dab14(void*);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned,unsigned,void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
-extern void func_0200d768(void*,unsigned char);
 extern int data_0209f318[];
-int _ZN6Player12St_Swim_InitEv(char* c){
-  func_ov002_020dab14(c);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x2e,c+0x74);
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0xa7,0x40000000,0x1000,0);
-  *(char*)(c+0x6e3)=0;
-  *(int*)(c+0x9c)=0;
-  *(int*)(c+0xa0)=-0xc000;
-  *(char*)(c+0x706)=1;
-  func_0200d768(*(void**)data_0209f318,*(unsigned char*)(c+0x6d8));
-  *(int*)(c+0x640)=*(int*)(c+0xa8);
-  *(int*)(c+0x98)=0;
-  *(int*)(c+0xa8)=0;
-  *(short*)(c+0x69c)=0;
-  *(char*)(c+0x6e5)=0;
-  *(char*)(c+0x70c)=0;
-  *(short*)(c+0x6a8)=0;
-  return 1;
 }
+
+int Player::St_Swim_Init()
+{
+  func_ov002_020dab14(((char*)this));
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x2e,((char*)this)+0x74);
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0xa7,0x40000000,0x1000,0);
+  mStateStep=0;
+  mVertAccel=0;
+  mTerminalVelocity=-0xc000;
+  mIsUnderwater=1;
+  func_0200d768(*(void**)data_0209f318,mPlayerNo);
+  mPrevVertSpeed=mVertSpeed;
+  mHorzSpeed=0;
+  mVertSpeed=0;
+  mAngleYSpeed=0;
+  mStateWork=0;
+  mStateArg=0;
+  mJumpComboTimer=0;
+  return 1;
 }

--- a/src/_ZN6Player12St_Talk_MainEv.cpp
+++ b/src/_ZN6Player12St_Talk_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player12St_Talk_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -7,13 +12,9 @@ typedef int s32;
 
 extern "C" {
 extern int _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, int t);
-extern int func_ov002_020c47f4(char* c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
-extern void func_0201fc88(s16 a);
 extern void func_0201f32c(s16 a);
 extern void func_0200d3f8(void* cam, u8 playerID, void* ptr);
-extern void func_0200d7a4(void* cam, u8 playerID);
-extern int func_ov100_02144fcc(void);
 extern int _Z15ApproachLinear2Rsss(s16* v, s16 target, s16 step);
 extern void func_0200d81c(void* cam, u8 playerID);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
@@ -27,45 +28,45 @@ extern int data_ov002_02110514[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player12St_Talk_MainEv(char* self)
+int Player::St_Talk_Main()
 {
-    if (*(u8*)(self + 0x722) != 0) {
+    if (unk_722 != 0) {
         if (_ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x7f, 0x7222) != 0)
-            *(u8*)(self + 0x722) = 0;
+            unk_722 = 0;
     }
 
-    if (*(u8*)(self + 0x70a) == 0) {
-        char* p = *(char**)(self + 0x368);
+    if (mNoCtrlKind == 0) {
+        char* p = *(char**)((char*)&mTalkActor);
         if (p != 0)
             *(u32*)(((int)p + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x800000;
-        *(u32*)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x800000;
+        *(u32*)(((int)((char*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x800000;
         data_0209b454 |= 0x800000;
-        *(u8*)(self + 0x70a) = 1;
+        mNoCtrlKind = 1;
     }
 
-    switch (*(u8*)(self + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        if (*(u8*)(self + 0x6e5) != 0)
-            func_ov002_020c47f4(self);
+        if (mStateWork != 0)
+            func_ov002_020c47f4(((char*)this));
         break;
     case 1:
-        if (!_ZN6Player6IsAnimEj(self, 0x64)) {
-            if (!func_ov002_020c47f4(self))
+        if (!_ZN6Player6IsAnimEj(((char*)this), 0x64)) {
+            if (!func_ov002_020c47f4(((char*)this)))
                 break;
         }
-        *(u8*)(self + 0x6e3) = 2;
-        if (*(u8*)(self + 0x6e5) == 0)
-            func_0201fc88(*(int*)(self + 0x688));
+        mStateStep = 2;
+        if (mStateWork == 0)
+            func_0201fc88(mAttachOffsetY);
         else
-            func_0201f32c(*(int*)(self + 0x688));
+            func_0201f32c(mAttachOffsetY);
         {
             char* cam = data_0209f318;
-            switch ((*(u8*)(self + 0x70c) >> 2) & 3) {
+            switch ((mStateArg >> 2) & 3) {
             case 0:
-                func_0200d3f8(cam, *(u8*)(self + 0x6d8), self + 0x744);
+                func_0200d3f8(cam, mPlayerNo, ((char*)this) + 0x744);
                 break;
             case 1:
-                func_0200d7a4(cam, *(u8*)(self + 0x6d8));
+                func_0200d7a4(cam, mPlayerNo);
                 break;
             }
         }
@@ -73,55 +74,55 @@ extern "C" int _ZN6Player12St_Talk_MainEv(char* self)
     case 2:
         if (data_0209d660 != 0)
             break;
-        switch (*(u8*)(self + 0x70c) & 3) {
+        switch (mStateArg & 3) {
         case 0:
-            *(u8*)(self + 0x6e3) = 4;
+            mStateStep = 4;
             break;
         case 1:
-            *(u8*)(self + 0x6e3) = 3;
+            mStateStep = 3;
             break;
         case 2:
-            *(u8*)(self + 0x6e3) = 8;
+            mStateStep = 8;
             break;
         }
         break;
     case 8:
         if (func_ov100_02144fcc() != 0)
-            *(u8*)(self + 0x6e3) = 4;
+            mStateStep = 4;
         break;
     case 4:
     case 5:
-        if (_Z15ApproachLinear2Rsss((s16*)(self + 0x762), 0, 0x200) != 0) {
-            if (*(u8*)(self + 0x6e3) != 5)
-                *(u8*)(self + 0x6e3) = 6;
+        if (_Z15ApproachLinear2Rsss((s16*)((char*)&unk_762), 0, 0x200) != 0) {
+            if (mStateStep != 5)
+                mStateStep = 6;
             else
-                *(u8*)(self + 0x6e3) = 7;
-            *(u8*)(self + 0x6e5) = 0;
-            *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
+                mStateStep = 7;
+            mStateWork = 0;
+            mTargetAngleY = mAngleY;
             char* cam = data_0209f318;
-            func_0200d81c(cam, *(u8*)(self + 0x6d8));
+            func_0200d81c(cam, mPlayerNo);
             *(u32*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~8;
-            *(u8*)(self + 0x742) = 4;
+            unk_742 = 4;
         }
         break;
     case 7:
-        if (*(u16*)(self + 0x6a6) != 0)
+        if (mStateWaitTimer != 0)
             break;
     case 6:
         if ((*(u32*)(data_0209f318 + 0x154) & 0x8000) != 0)
             break;
-        if (*(u8*)(self + 0x70b) != 0) {
-            *(u8*)(self + 0x70a) = 0x13;
-            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211022c);
-            *(u8*)(self + 0x6e3) = 0x13;
-        } else if (_ZN6Player6IsAnimEj(self, 0x64)) {
-            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_02110514);
+        if (mIsOpeningBigDoor != 0) {
+            mNoCtrlKind = 0x13;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211022c);
+            mStateStep = 0x13;
+        } else if (_ZN6Player6IsAnimEj(((char*)this), 0x64)) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110514);
         } else {
-            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         break;
     }
 
-    func_ov002_020bedd4(self);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player12St_Wait_InitEv.cpp
+++ b/src/_ZN6Player12St_Wait_InitEv.cpp
@@ -1,17 +1,21 @@
 //cpp
+// @symbol _ZN6Player12St_Wait_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int d, unsigned int e);
 extern int _ZN6Player9GetHealthEv(void* c);
 
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0[];
+}
 
-int _ZN6Player12St_Wait_InitEv(char* c)
+int Player::St_Wait_Init()
 {
     unsigned char f2d8;
     int b0;
 
-    *(unsigned char*)(c + 0x6e6) = 0;
+    unk_6e6 = 0;
     f2d8 = data_0209f2d8;
     b0 = (f2d8 == 1);
     if (b0 != 0) goto L80;
@@ -21,39 +25,38 @@ int _ZN6Player12St_Wait_InitEv(char* c)
         if (b1 == 0) goto L80;
     }
 L50:
-    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xb3, 0, 0x1000, 0);
-    *(unsigned char*)(c + 0x6e3) = 0;
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xb3, 0, 0x1000, 0);
+    mStateStep = 0;
     return 1;
 
 L80:
-    if (*(unsigned char*)(c + 0x703) == 0) goto Ld8;
+    if (mIsMega == 0) goto Ld8;
     if (b0 != 0) goto Lbc;
     if (data_0209caa0[2] & 0x80) goto Lbc;
-    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xa0, 0, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xa0, 0, 0x1000, 0);
 Lbc:
-    *(unsigned short*)(c + 0x6a4) = 0x384;
+    mStateTimer = 0x384;
     return 1;
 
 Ld8:
-    if (*(int*)(c + 0x650) == 0x80000000) goto L13c;
-    if (*(int*)(c + 0x60) >= *(int*)(c + 0x650) - 0x64000) goto L13c;
-    if (*(unsigned char*)(c + 0x6f9) != 0) goto L13c;
-    if (*(unsigned char*)(c + 0x6fb) != 0) goto L13c;
-    *(unsigned char*)(c + 0x6e3) = 0xa;
-    _ZN6Player7SetAnimEji5Fix12IiEj(c, 5, 0, 0x1000, 0);
+    if (unk_650 == 0x80000000) goto L13c;
+    if (mPosY >= unk_650 - 0x64000) goto L13c;
+    if (mIsMetal != 0) goto L13c;
+    if (unk_6fb != 0) goto L13c;
+    mStateStep = 0xa;
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 5, 0, 0x1000, 0);
     return 1;
 
 L13c:
-    *(unsigned char*)(c + 0x6e3) = 0;
-    if (*(int*)(c + 0x68c) > 0x32000) {
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x7d, 0, 0x1000, 0);
-    } else if (_ZN6Player9GetHealthEv(c) <= 2) {
-        *(unsigned char*)(c + 0x6e3) = 7;
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xe, 0x40000000, 0x1000, 0);
+    mStateStep = 0;
+    if (mSinkDepth > 0x32000) {
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x7d, 0, 0x1000, 0);
+    } else if (_ZN6Player9GetHealthEv(((char*)this)) <= 2) {
+        mStateStep = 7;
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xe, 0x40000000, 0x1000, 0);
     } else {
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, 0, 0x1000, 0);
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x47, 0, 0x1000, 0);
     }
-    *(unsigned short*)(c + 0x6a4) = 0x384;
+    mStateTimer = 0x384;
     return 1;
-}
 }

--- a/src/_ZN6Player12St_Wait_MainEv.cpp
+++ b/src/_ZN6Player12St_Wait_MainEv.cpp
@@ -1,25 +1,23 @@
 //cpp
+// @symbol _ZN6Player12St_Wait_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020c0364(char* c, unsigned int arg);
 extern int func_ov002_020c5244(void);
-extern int func_ov002_020c6adc(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, unsigned int a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
-extern void func_ov002_020bcdf0(void* c);
-extern int func_ov002_020d2fdc(void* c);
 extern int func_ov002_020d22ec(char* c, int arg);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int d, unsigned int e);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int a, void* v);
-extern int func_ov002_020d2da0(void* c);
 extern void func_ov002_020cabe0(void* c);
-extern void func_ov002_020d2f24(void* c);
-extern void func_ov002_020d2e74(void* c);
 extern void func_ov002_020bedd4(void* c);
 
-extern int data_ov002_0211049c[];
 extern void* data_0209f318;
 extern unsigned char data_020a0e40;
 extern unsigned char data_0209f49c[];
@@ -28,28 +26,28 @@ extern unsigned char data_0209f4ae[];
 extern unsigned char data_0209f2d8;
 extern int data_0209caa0[];
 extern unsigned char data_0209f49e[];
-extern int data_ov002_0211019c[];
 extern int data_ov002_0211013c[];
+}
 
-int _ZN6Player12St_Wait_MainEv(char* c)
+int Player::St_Wait_Main()
 {
-    if ((unsigned short)(*(unsigned short*)(c+0x6ce) & 1)) {
-        func_ov002_020c0364(c, 3);
+    if ((unsigned short)(mStateFlags & 1)) {
+        func_ov002_020c0364(((char*)this), 3);
         return 1;
     }
     if (func_ov002_020c5244()) {
         return 1;
     }
-    if (func_ov002_020c6adc(c)) {
+    if (func_ov002_020c6adc(((char*)this))) {
         return 1;
     }
-    if (*(int*)(c+0x68c) >= 0x1e000) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211049c);
+    if (mSinkDepth >= 0x1e000) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211049c);
         return 1;
     }
 
     {
-    unsigned char st = *(unsigned char*)(c+0x6e3);
+    unsigned char st = mStateStep;
     void* r4 = data_0209f318;
     switch (st) {
     default:
@@ -57,8 +55,8 @@ int _ZN6Player12St_Wait_MainEv(char* c)
 
     case 8: {
         if (!(*(unsigned short*)(data_0209f49c+data_020a0e40*0x18) & 0x800) &&
-            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0)) {
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2c, c+0x74);
+            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0)) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2c, ((char*)this)+0x74);
         }
     }
     case 0: {
@@ -71,11 +69,11 @@ int _ZN6Player12St_Wait_MainEv(char* c)
                 goto blk0_35;
             }
             blk0_34:
-            func_ov002_020bcdf0(c);
+            func_ov002_020bcdf0(((char*)this));
             goto blk0_36;
         }
         blk0_35:
-        if (func_ov002_020d2fdc(c) == 0) {
+        if (func_ov002_020d2fdc(((char*)this)) == 0) {
             blk0_36:
             {
                 int idx0 = data_020a0e40 * 0x18;
@@ -83,13 +81,13 @@ int _ZN6Player12St_Wait_MainEv(char* c)
                 if (lvl0 != 0) {
                     int thr0 = (*(unsigned char*)(data_0209f4ae+idx0)!=2) ? 0x471 : 0x555;
                     if (lvl0 < thr0) {
-                        *(short*)(c+0x94) = *(short*)(c+0x6d2);
-                        *(short*)(c+0x8e) = *(short*)(c+0x94);
+                        mTargetAngleY = mDesiredAngleY;
+                        mAngleY = mTargetAngleY;
                     }
                 }
                 {
                     int thr0b = (*(unsigned char*)(data_0209f4ae+idx0)!=2) ? 0x471 : 0x555;
-                    func_ov002_020d22ec(c, thr0b);
+                    func_ov002_020d22ec(((char*)this), thr0b);
                 }
             }
         }
@@ -97,10 +95,10 @@ int _ZN6Player12St_Wait_MainEv(char* c)
     }
 
     case 10: {
-        if (*(unsigned char*)(c+0x6f9)!=0 || *(unsigned char*)(c+0x6fb)!=0) {
-            *(unsigned char*)(c+0x6e3) = 0;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, 0, 0x1000, 0);
-            *(unsigned short*)(c+0x6a4) = 0x384;
+        if (mIsMetal!=0 || unk_6fb!=0) {
+            mStateStep = 0;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x47, 0, 0x1000, 0);
+            mStateTimer = 0x384;
         }
         {
             int idx10 = data_020a0e40 * 0x18;
@@ -108,85 +106,85 @@ int _ZN6Player12St_Wait_MainEv(char* c)
             if (lvl10 != 0) {
                 int thr10 = (*(unsigned char*)(data_0209f4ae+idx10)!=2) ? 0x471 : 0x555;
                 if (lvl10 < thr10) {
-                    *(short*)(c+0x94) = *(short*)(c+0x6d2);
-                    *(short*)(c+0x8e) = *(short*)(c+0x94);
+                    mTargetAngleY = mDesiredAngleY;
+                    mAngleY = mTargetAngleY;
                 }
             }
             {
                 int thr10b = (*(unsigned char*)(data_0209f4ae+idx10)!=2) ? 0x471 : 0x555;
-                func_ov002_020d22ec(c, thr10b);
+                func_ov002_020d22ec(((char*)this), thr10b);
             }
         }
         break;
     }
 
     case 1: {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xc, 0, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 2;
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xc, 0, 0x1000, 0);
+            mStateStep = 2;
         }
         {
-        unsigned int x1 = *(unsigned int*)(c+8);
+        unsigned int x1 = mParam;
         switch (x1) {
         default:
             break;
         case 0: {
-            int idA = _ZNK6Player14GetBodyModelIDEjb(c, x1&0xff, 0);
-            void* animA = *(void**)(c+(idA<<2)+0xdc);
+            int idA = _ZNK6Player14GetBodyModelIDEjb(((char*)this), x1&0xff, 0);
+            void* animA = *(void**)(((char*)this)+(idA<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animA+0x50, 0x5a)) {
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2d, c+0x74);
-            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0x3a)
-                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0x44)) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(4, c+0x74);
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2d, ((char*)this)+0x74);
+            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x3a)
+                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x44)) {
+                _ZN5Sound9PlayBank0EjRK7Vector3(4, ((char*)this)+0x74);
             }
             break;
         }
         case 1: {
-            int idD = _ZNK6Player14GetBodyModelIDEjb(c, x1&0xff, 0);
-            void* animD = *(void**)(c+(idD<<2)+0xdc);
+            int idD = _ZNK6Player14GetBodyModelIDEjb(((char*)this), x1&0xff, 0);
+            void* animD = *(void**)(((char*)this)+(idD<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animD+0x50, 0x6e)) {
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2d, c+0x74);
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2d, ((char*)this)+0x74);
             } else {
-                int idE = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8)&0xff, 0);
-                void* animE = *(void**)(c+(idE<<2)+0xdc);
+                int idE = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam&0xff, 0);
+                void* animE = *(void**)(((char*)this)+(idE<<2)+0xdc);
                 if (_ZNK9Animation12WillHitFrameEi((char*)animE+0x50, 0x32)) {
-                    _ZN5Sound9PlayBank0EjRK7Vector3(0xb1, c+0x74);
+                    _ZN5Sound9PlayBank0EjRK7Vector3(0xb1, ((char*)this)+0x74);
                 }
             }
             break;
         }
         case 2: {
-            int idF = _ZNK6Player14GetBodyModelIDEjb(c, x1&0xff, 0);
-            void* animF = *(void**)(c+(idF<<2)+0xdc);
+            int idF = _ZNK6Player14GetBodyModelIDEjb(((char*)this), x1&0xff, 0);
+            void* animF = *(void**)(((char*)this)+(idF<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animF+0x50, 0x20)) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(2, c+0x74);
-            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0x47)
-                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0x60)) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(3, c+0x74);
+                _ZN5Sound9PlayBank0EjRK7Vector3(2, ((char*)this)+0x74);
+            } else if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x47)
+                    || _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0x60)) {
+                _ZN5Sound9PlayBank0EjRK7Vector3(3, ((char*)this)+0x74);
             }
             break;
         }
         case 3: {
-            int idI = _ZNK6Player14GetBodyModelIDEjb(c, x1&0xff, 0);
-            void* animI = *(void**)(c+(idI<<2)+0xdc);
+            int idI = _ZNK6Player14GetBodyModelIDEjb(((char*)this), x1&0xff, 0);
+            void* animI = *(void**)(((char*)this)+(idI<<2)+0xdc);
             if (_ZNK9Animation12WillHitFrameEi((char*)animI+0x50, 0xad)) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(0x50, c+0x74);
+                _ZN5Sound9PlayBank0EjRK7Vector3(0x50, ((char*)this)+0x74);
             }
             break;
         }
         }
         }
-        if (func_ov002_020d22ec(c, 0)) {
+        if (func_ov002_020d22ec(((char*)this), 0)) {
             (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2e, c+0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
         }
         break;
     }
 
     case 2: {
-        if (*(unsigned char*)(c+0x723)==0 &&
-            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 1)) {
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2a, c+0x74);
+        if (unk_723==0 &&
+            _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 1)) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2a, ((char*)this)+0x74);
         }
         {
             unsigned char f2d8_2 = data_0209f2d8;
@@ -197,57 +195,57 @@ int _ZN6Player12St_Wait_MainEv(char* c)
                 if (b2b != false) break;
             }
         }
-        if (*(unsigned short*)(c+0x6a4) == 0) {
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2e, c+0x74);
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xa, 0x40000000, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 3;
-            *(unsigned char*)(c+0x721) = 1;
+        if (mStateTimer == 0) {
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xa, 0x40000000, 0x1000, 0);
+            mStateStep = 3;
+            mSleepStage = 1;
         }
         if (*(unsigned short*)(data_0209f49e+data_020a0e40*0x18) & 2) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211019c);
             (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2e, c+0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
             return 1;
         }
-        if (func_ov002_020d2da0(c)==1 || (unsigned short)(*(unsigned short*)(c+0x6ce)&4)!=0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xb, 0x40000000, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 9;
+        if (func_ov002_020d2da0(((char*)this))==1 || (unsigned short)(mStateFlags&4)!=0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xb, 0x40000000, 0x1000, 0);
+            mStateStep = 9;
         }
         break;
     }
 
     case 3: {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 9, 0, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 4;
-            *(int*)(c+0x56c) = 0;
-            *(int*)(c+0x570) = 0;
-            *(int*)(c+0x574) = 0;
-            *(unsigned char*)(c+0x721) = 2;
-            *(unsigned char*)(c+0x70c) = 1;
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 9, 0, 0x1000, 0);
+            mStateStep = 4;
+            unk_56c = 0;
+            unk_570 = 0;
+            unk_574 = 0;
+            mSleepStage = 2;
+            mStateArg = 1;
         }
-        if ((unsigned short)(*(unsigned short*)(c+0x6ce)&4) != 0) {
-            func_ov002_020cabe0(c);
+        if ((unsigned short)(mStateFlags&4) != 0) {
+            func_ov002_020cabe0(((char*)this));
             return 1;
         }
         break;
     }
 
     case 5: {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(unsigned char*)(c+0x6e3) = 6;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x96, 0, 0x1000, 0);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mStateStep = 6;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x96, 0, 0x1000, 0);
         }
-        func_ov002_020d22ec(c, 0);
+        func_ov002_020d22ec(((char*)this), 0);
         break;
     }
 
     case 4: {
-        if (*(unsigned char*)(c+0x6e6) == 0) {
-            func_ov002_020d2f24(c);
-            if (*(unsigned char*)(c+0x723)==0 &&
-                _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c+(_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0)<<2)+0xdc))+0x50, 0xd)) {
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2b, c+0x74);
+        if (unk_6e6 == 0) {
+            func_ov002_020d2f24(((char*)this));
+            if (unk_723==0 &&
+                _ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this)+(_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0)<<2)+0xdc))+0x50, 0xd)) {
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2b, ((char*)this)+0x74);
             }
         }
         {
@@ -258,46 +256,45 @@ int _ZN6Player12St_Wait_MainEv(char* c)
                 int b4b = (f2d8_4 == 2);
                 if (b4b != false) break;
             }
-            if (func_ov002_020d2da0(c)==1 || *(int*)(c+0x56c) >= 0x3000 || *(unsigned char*)(c+0x707)!=0 ||
-                (unsigned short)(*(unsigned short*)(c+0x6ce)&4)) {
-                func_ov002_020d2e74(c);
-                *(unsigned char*)(c+0x721) = 0;
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 8, 0x40000000, 0x1000, 0);
-                *(unsigned char*)(c+0x6e3) = 9;
+            if (func_ov002_020d2da0(((char*)this))==1 || unk_56c >= 0x3000 || mIsInShallowWater!=0 ||
+                (unsigned short)(mStateFlags&4)) {
+                func_ov002_020d2e74(((char*)this));
+                mSleepStage = 0;
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 8, 0x40000000, 0x1000, 0);
+                mStateStep = 9;
             }
         }
         break;
     }
 
     case 6: {
-        if (func_ov002_020d2da0(c) == 1) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x97, 0x40000000, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 9;
+        if (func_ov002_020d2da0(((char*)this)) == 1) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x97, 0x40000000, 0x1000, 0);
+            mStateStep = 9;
         }
         break;
     }
 
     case 7: {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xf, 0, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 8;
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xf, 0, 0x1000, 0);
+            mStateStep = 8;
         }
-        if ((unsigned short)(*(unsigned short*)(c+0x6ce)&0x800) == 0) {
-            func_ov002_020d22ec(c, 0);
+        if ((unsigned short)(mStateFlags&0x800) == 0) {
+            func_ov002_020d22ec(((char*)this), 0);
         }
         break;
     }
 
     case 9: {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         break;
     }
     }
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
-}
 }

--- a/src/_ZN6Player12St_Walk_InitEv.cpp
+++ b/src/_ZN6Player12St_Walk_InitEv.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol _ZN6Player12St_Walk_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player9GetHealthEv(void *c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *c, void *state);
 extern int func_ov002_020bf30c(void *c, int a);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, unsigned int a, int b, int f, unsigned int d);
-extern void func_ov002_020d4748(void *c);
 extern void func_ov002_020d4540(void *p);
 extern void func_ov002_020caf68(void *self);
 extern int func_ov002_020e3078(void *self, void *s);
@@ -20,21 +24,21 @@ extern unsigned char data_0209f4ac;
 extern int data_ov002_0211010c[];
 extern int data_ov002_02110154[];
 extern int data_ov002_0210e160[];
-extern int data_ov002_020ff1b0[4];
+}
 
-int _ZN6Player12St_Walk_InitEv(char *c)
+int Player::St_Walk_Init()
 {
-    if (_ZN6Player9GetHealthEv(c) == 0) {
-        *(unsigned char *)(c + 0x6e3) = 1;
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211010c);
+    if (_ZN6Player9GetHealthEv(((char *)this)) == 0) {
+        mStateStep = 1;
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), data_ov002_0211010c);
         return 1;
     }
 
-    if (*(int *)(c + 0x98) > func_ov002_020bf30c(c, 0x28000)) {
-        *(int *)(c + 0x98) = func_ov002_020bf30c(c, 0x28000);
+    if (mHorzSpeed > func_ov002_020bf30c(((char *)this), 0x28000)) {
+        mHorzSpeed = func_ov002_020bf30c(((char *)this), 0x28000);
     }
-    if (*(int *)(c + 0x98) < -0xe000) {
-        *(int *)(c + 0x98) = -0xe000;
+    if (mHorzSpeed < -0xe000) {
+        mHorzSpeed = -0xe000;
     }
 
     if (*(short *)((char *)&data_0209f4a0 + data_020a0e40 * 0x18) == 0) {
@@ -45,62 +49,61 @@ int _ZN6Player12St_Walk_InitEv(char *c)
         cond = (byte1 == 2);
         if (cond) goto merge;
 do_anim:
-        if (*(unsigned char *)(c + 0x703) != 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xa0, 0, 0x1000, 0);
+        if (mIsMega != 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0xa0, 0, 0x1000, 0);
         } else {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, 0, 0x1000, 0);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0x47, 0, 0x1000, 0);
         }
     } else {
-        func_ov002_020d4748(c);
+        func_ov002_020d4748(((char *)this));
     }
 merge:
-    *(short *)(c + 0x6a4) = 0;
+    mStateTimer = 0;
     if (*(unsigned char *)((char *)&data_0209f4ac + data_020a0e40 * 0x18) == 0) {
-        if (*(int *)(c + 0x98) == 0) {
-            *(short *)(c + 0x6a4) = 0x3c;
+        if (mHorzSpeed == 0) {
+            mStateTimer = 0x3c;
         }
     }
 
-    *(int *)(c + 0x684) = *(int *)(c + 0x60);
-    *(unsigned char *)(c + 0x6e5) = 0;
-    *(unsigned char *)(c + 0x70c) = 0;
-    if (*(int *)(c + 0x98) > func_ov002_020bf30c(c, 0x24000)) {
-        *(unsigned char *)(c + 0x70c) = 1;
+    mPeakY = mPosY;
+    mStateWork = 0;
+    mStateArg = 0;
+    if (mHorzSpeed > func_ov002_020bf30c(((char *)this), 0x24000)) {
+        mStateArg = 1;
     }
-    *(unsigned short *)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
-    *(unsigned char *)(c + 0x706) = 0;
-    func_ov002_020d4540(c);
+    *(unsigned short *)(((long long)(int)((char *)&mStateFlags))) &= ~0x100;
+    mIsUnderwater = 0;
+    func_ov002_020d4540(((char *)this));
 
-    func_ov002_020caf68(c);
+    func_ov002_020caf68(((char *)this));
 
-    *(int *)(c + 0x354) = 0;
-    *(int *)(c + 0x358) = 0;
-    *(int *)(c + 0x35c) = 0;
-    *(unsigned char *)(c + 0x6e3) = 0;
-    *(int *)(c + 0xd0) = 0;
-    if (func_ov002_020e3078(c, data_ov002_02110154) != 0) {
-        *(short *)(c + 0x6b8) = 0x10;
+    mRidingShell = 0;
+    mHeldObj = 0;
+    unk_35c = 0;
+    mStateStep = 0;
+    mEatingPlayer = 0;
+    if (func_ov002_020e3078(((char *)this), data_ov002_02110154) != 0) {
+        unk_6b8 = 0x10;
         if (*(short *)((char *)&data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            *(short *)(c + 0x94) = *(short *)(c + 0x6d2);
-            *(short *)(c + 0x8e) = *(short *)(c + 0x94);
+            mTargetAngleY = mDesiredAngleY;
+            mAngleY = mTargetAngleY;
         }
-        if (*(unsigned char *)(c + 0x6ed) != 0) {
+        if (unk_6ed != 0) {
             unsigned int rnd = (unsigned int)RandomIntInternal(data_ov002_0210e160);
             int idx = (rnd >> 6) & 3;
             int voiceId = data_ov002_020ff1b0[idx];
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char *)(c + 0x6d9), voiceId, c + 0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, voiceId, ((char *)this) + 0x74);
         }
     }
 
-    if (*(int *)(c + 8) == 1) {
-        if (*(unsigned char *)(c + 0x707) == 0) {
-            *(unsigned char *)(c + 0x6ec) = 1;
+    if (mParam == 1) {
+        if (mIsInShallowWater == 0) {
+            unk_6ec = 1;
         }
     }
 
-    if (*(unsigned char *)(c + 0x703) != 0 && *(int *)(c + 0x80) != 0x3000) {
-        _ZN6Player17SetNoControlStateEhih(c, 0xd, -1, 0);
+    if (mIsMega != 0 && mScaleX != 0x3000) {
+        _ZN6Player17SetNoControlStateEhih(((char *)this), 0xd, -1, 0);
     }
     return 1;
-}
 }

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player12St_Walk_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -10,9 +16,6 @@ extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int func_ov002_020c5244(void);
 extern int func_ov002_020d36d8(void* c, int a);
-extern void func_ov002_020d45c0(void* c);
-extern int func_ov002_020d3b9c(void* c);
-extern void func_ov002_020d413c(void* c, short arg);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, short a5);
@@ -21,8 +24,6 @@ extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u
 extern void func_ov002_020d4540(void* c);
 extern void func_ov002_020cabe0(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZN9Animation8GetFlagsEv(void* anim);
-extern void func_ov002_020d4748(void* c);
 extern void func_ov002_020bedd4(void* c);
 
 extern u8 data_020a0e40;
@@ -31,90 +32,90 @@ extern s16 data_0209f4a0[];
 extern int data_ov002_02110154[];
 }
 
-extern "C" int _ZN6Player12St_Walk_MainEv(char* c)
+int Player::St_Walk_Main()
 {
-    if ((u16)(*(u16*)(c + 0x6ce) & 0x800)) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+    if ((u16)(mStateFlags & 0x800)) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110154);
         return 1;
     }
     if (func_ov002_020c5244()) return 1;
-    if (func_ov002_020d36d8(c, 0)) return 1;
+    if (func_ov002_020d36d8(((char*)this), 0)) return 1;
 
-    func_ov002_020d45c0(c);
-    short r5 = *(short*)(c + 0x94);
-    if (func_ov002_020d3b9c(c)) return 1;
+    func_ov002_020d45c0(((char*)this));
+    short r5 = mTargetAngleY;
+    if (func_ov002_020d3b9c(((char*)this))) return 1;
 
-    func_ov002_020d413c(c, r5);
+    func_ov002_020d413c(((char*)this), r5);
 
-    if (*(int*)(c + 0x98) == 0) {
-        *(short*)(c + 0x8e) = *(short*)(c + 0x94);
+    if (mHorzSpeed == 0) {
+        mAngleY = mTargetAngleY;
     } else {
-        ApproachAngle((short*)(c + 0x8e), *(short*)(c + 0x94), 4, 0x2000, 0x800);
+        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 4, 0x2000, 0x800);
     }
 
-    if (*(u8*)(c + 0x6e0) != 0) {
-        if (!_ZN6Player6IsAnimEj(c, 0x37)) {
-            int result = func_0201226c(*(int*)(c + 0x620), 0, *(int*)(c + 0x66c) + 0xe2, (int)(c + 0x74), *(int*)(c + 0x98), 0);
-            *(int*)(c + 0x620) = result;
+    if (unk_6e0 != 0) {
+        if (!_ZN6Player6IsAnimEj(((char*)this), 0x37)) {
+            int result = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePos), mHorzSpeed, 0);
+            mLoopingSoundHandle = result;
         }
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            if (_ZN6Player6IsAnimEj(c, 0x36)) {
-                if (*(int*)(c + 0x98) == 0) {
-                    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x37, 0x40000000, 0x1000, 0);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            if (_ZN6Player6IsAnimEj(((char*)this), 0x36)) {
+                if (mHorzSpeed == 0) {
+                    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x37, 0x40000000, 0x1000, 0);
                 }
             } else {
-                if (_ZN6Player6IsAnimEj(c, 0x37)) {
-                    func_ov002_020d4540(c);
+                if (_ZN6Player6IsAnimEj(((char*)this), 0x37)) {
+                    func_ov002_020d4540(((char*)this));
                 }
             }
         }
         goto end;
     }
 
-    if (*(int*)(c + 0x98) != 0) goto label_29c;
+    if (mHorzSpeed != 0) goto label_29c;
 
     {
         u8 idx = data_020a0e40;
         int off = idx * 0x18;
         u8 b = data_0209f4ae[off];
         int thresh = (b != 2) ? 0x471 : 0x555;
-        u8 v710 = *(u8*)(c + 0x710);
+        u8 v710 = unk_710;
         int rhs = thresh - (v710 << 7);
         short lhs = *(s16*)((char*)data_0209f4a0 + off);
         if (lhs < rhs) goto label_1f0;
-        if ((u16)(*(u16*)(c + 0x6ce) & 0xc) == 0) goto label_29c;
+        if ((u16)(mStateFlags & 0xc) == 0) goto label_29c;
     }
 
 label_1f0:
-    if (*(u8*)(c + 0x703) != 0) {
-        if (_ZN6Player12FinishedAnimEv(c) && _ZN6Player6IsAnimEj(c, 0x9d)) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
-            *(u8*)(c + 0x6e5) = 1;
-            func_ov002_020cabe0(c);
+    if (mIsMega != 0) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) && _ZN6Player6IsAnimEj(((char*)this), 0x9d)) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110154);
+            mStateWork = 1;
+            func_ov002_020cabe0(((char*)this));
         }
         goto end;
     }
 
-    if (_ZN6Player12FinishedAnimEv(c)) goto label_27c;
+    if (_ZN6Player12FinishedAnimEv(((char*)this))) goto label_27c;
 
     {
-        u32 arg = (u8)*(int*)(c + 8);
-        int modelIdx = _ZNK6Player14GetBodyModelIDEjb(c, arg, 0);
-        char* anim = *(char**)(c + modelIdx * 4 + 0xdc) + 0x50;
+        u32 arg = (u8)mParam;
+        int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
+        char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
         if (_ZN9Animation8GetFlagsEv(anim)) goto end;
     }
 
 label_27c:
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
-    *(u8*)(c + 0x6e5) = 1;
-    func_ov002_020cabe0(c);
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110154);
+    mStateWork = 1;
+    func_ov002_020cabe0(((char*)this));
     goto end;
 
 label_29c:
-    func_ov002_020d4748(c);
-    *(u8*)(c + 0x6e5) = 1;
+    func_ov002_020d4748(((char*)this));
+    mStateWork = 1;
 
 end:
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player12Unk_020c4f40Et.cpp
+++ b/src/_ZN6Player12Unk_020c4f40Et.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN6Player12Unk_020c4f40Et
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player12Unk_020c4f40Et(char* c, unsigned short x){
-  if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
-    *(unsigned short*)(c+0x6a6)=x;
-    *(unsigned char*)(c+0x6e3)=5;
+}
+
+int Player::Unk_020c4f40(unsigned short x)
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)this),&data_ov002_0211046c) && mStateStep==3){
+    mStateWaitTimer=x;
+    mStateStep=5;
     return 1;
   }
   return 0;
-}
 }

--- a/src/_ZN6Player12Unk_020ca488Ev.cpp
+++ b/src/_ZN6Player12Unk_020ca488Ev.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player12Unk_020ca488Ev
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 /* _ZN6Player12Unk_020ca488Ev @ 0x20ca488 (ov002) -- tail-call veneer to _ZN6Player12Unk_020c9e5cEh (0x20c9e5c) with r1=11.
  */
 extern "C" {
 extern void _ZN6Player12Unk_020c9e5cEh(void*, int);
-void _ZN6Player12Unk_020ca488Ev(void* a) {
-    _ZN6Player12Unk_020c9e5cEh(a, 11);
 }
+
+void Player::Unk_020ca488()
+{
+    _ZN6Player12Unk_020c9e5cEh(((void*)this), 11);
 }

--- a/src/_ZN6Player13InitFireYoshiEv.cpp
+++ b/src/_ZN6Player13InitFireYoshiEv.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol _ZN6Player13InitFireYoshiEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned short u16;
 
 extern "C" void _ZN6Player11ChangeStateERNS_5StateE(char *c, void *st);
 extern int data_ov002_0211004c;
 
-extern "C" void _ZN6Player13InitFireYoshiEv(char *c)
+void Player::InitFireYoshi()
 {
-    u16 *p = (u16 *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL);
+    u16 *p = (u16 *)(((int)((char *)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL);
     *p |= 0x1000;
-    if (*(int *)(c + 0x360) == 0)
+    if (mObjInMouth == 0)
         return;
-    _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211004c);
+    _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211004c);
 }

--- a/src/_ZN6Player13St_Crawl_InitEv.cpp
+++ b/src/_ZN6Player13St_Crawl_InitEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player13St_Crawl_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player13St_Crawl_InitEv(char* c){
-  *(char*)(c+0x6e3)=3;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x64,0x40000000,0x1000,0);
-  return 1;
 }
+
+int Player::St_Crawl_Init()
+{
+  mStateStep=3;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x64,0x40000000,0x1000,0);
+  return 1;
 }

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player13St_Crawl_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -9,9 +15,7 @@ typedef s32 Fix12;
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern int func_ov002_020d1164(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* thiz, int f);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern int func_ov002_020d36d8(void* c, int arg);
 extern int func_ov002_020bf30c(void* c, int a);
@@ -28,58 +32,58 @@ extern u16 data_0209f49c[];
 extern int data_ov002_021104e4;
 }
 
-extern "C" int _ZN6Player13St_Crawl_MainEv(char* c)
+int Player::St_Crawl_Main()
 {
     int a = 0;
     int b = 0;
 
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 3:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(u8*)(c + 0x6e3) = 4;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x63, 0, 0x1000, 0);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mStateStep = 4;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x63, 0, 0x1000, 0);
         }
         break;
     case 4: {
         u8 idx = data_020a0e40;
         int off = idx * 0x18;
         s16 val1 = *(s16*)((char*)data_0209f4a0 + off);
-        if (val1 >= 0x200 && ((*(u16*)((char*)data_0209f49c + off) & 0x400) != 0 || func_ov002_020d1164(c) != 0)) {
-            int id = _ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c + 8) & 0xff, 0);
-            char* anim = (char*)((int*)(c + 0xdc))[id] + 0x50;
+        if (val1 >= 0x200 && ((*(u16*)((char*)data_0209f49c + off) & 0x400) != 0 || func_ov002_020d1164(((char*)this)) != 0)) {
+            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            char* anim = (char*)((int*)((char*)&mBodyModels))[id] + 0x50;
             if (_ZNK9Animation12WillHitFrameEi(anim, 0xe) ||
-                _ZNK9Animation12WillHitFrameEi((char*)((int*)(c + 0xdc))[_ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c + 8) & 0xff, 0)] + 0x50, 0x1c)) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(*(u32*)(c + 0x66c) + 0xc0, c + 0x74);
+                _ZNK9Animation12WillHitFrameEi((char*)((int*)((char*)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0)] + 0x50, 0x1c)) {
+                _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType + 0xc0, ((char*)this) + 0x74);
             }
-            int shifted = *(int*)(c + 0x98) >> 2;
-            int id3 = _ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c + 8) & 0xff, 0);
-            char* anim3 = (char*)(((long long)(int)((char*)((int*)(c + 0xdc))[id3] + 0x50)) & 0xffffffffffffffffLL);
+            int shifted = mHorzSpeed >> 2;
+            int id3 = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            char* anim3 = (char*)(((long long)(int)((char*)((int*)((char*)&mBodyModels))[id3] + 0x50)) & 0xffffffffffffffffLL);
             *(int*)(anim3 + 0xc) = shifted;
-            if (func_ov002_020d36d8(c, 1))
+            if (func_ov002_020d36d8(((char*)this), 1))
                 return 1;
-            int r4v = func_ov002_020bf30c(c, 0x8000);
-            int r2v = func_ov002_020bf30c(c, 0x1000);
-            a = func_ov002_020bf224(c, r4v, r2v);
+            int r4v = func_ov002_020bf30c(((char*)this), 0x8000);
+            int r2v = func_ov002_020bf30c(((char*)this), 0x1000);
+            a = func_ov002_020bf224(((char*)this), r4v, r2v);
             b = 0x1000;
-            ApproachAngle((s16*)(c + 0x94), *(s16*)(c + 0x6d2), 0x10, 0x2000, 0x100);
-            *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-            func_ov002_020c18b0(c, 0);
+            ApproachAngle((s16*)((char*)&mTargetAngleY), mDesiredAngleY, 0x10, 0x2000, 0x100);
+            mAngleY = mTargetAngleY;
+            func_ov002_020c18b0(((char*)this), 0);
         } else {
-            *(int*)(c + 0x98) = 0;
-            *(u8*)(c + 0x6e3) = 5;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x62, 0x40000000, 0x1000, 0);
+            mHorzSpeed = 0;
+            mStateStep = 5;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x62, 0x40000000, 0x1000, 0);
         }
         break;
     }
     case 5:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021104e4);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mStateStep = 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_021104e4);
         }
         break;
     }
 
-    func_ov002_020d4d88(c, a, b);
-    func_ov002_020bedd4(c);
+    func_ov002_020d4d88(((char*)this), a, b);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player13St_Shell_InitEv.cpp
+++ b/src/_ZN6Player13St_Shell_InitEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN6Player13St_Shell_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov002_020bd928(void*,int);
-int _ZN6Player13St_Shell_InitEv(char* c){
-  func_ov002_020dab14(c);
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x35,0x40000000,0x1000,0);
-  *(char*)(c+0x6e3)=0;
-  func_ov002_020bd928(c,0x33);
-  return 1;
 }
+
+int Player::St_Shell_Init()
+{
+  func_ov002_020dab14(((char*)this));
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x35,0x40000000,0x1000,0);
+  mStateStep=0;
+  func_ov002_020bd928(((char*)this),0x33);
+  return 1;
 }

--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6Player13St_Shell_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_ClsnResult.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -8,23 +15,14 @@ typedef long long s64;
 typedef s32 Fix12;
 
 extern "C" {
-extern int func_02035638(u8* p);
-extern int func_0203564c(int p);
-extern int _ZNK10ClsnResult9GetClsnIDEv(void* c);
 extern void* _ZN5Actor10FindWithIDEj(u32 id);
 extern void func_ov002_020eeca8(void* c, int arg);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void* c);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
-extern int AngleDiff(int a, int b);
-extern void* _ZNK12WithMeshClsn13GetWallResultEv(void* c);
 extern int func_02037e58(u32* p);
-extern void func_ov002_020c1eb4(void* self, int dmg);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
-extern void func_ov002_020cc660(char* self, int angle);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
-extern int func_ov002_020c04e0(char* c);
 extern void func_ov002_020e25f0(char* c, int a);
-extern int func_ov002_020d674c(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020e28d4(char* c, int a, int b);
 extern int _ZN6Player12FinishedAnimEv(void* c);
@@ -40,113 +38,113 @@ extern int data_ov002_0211004c[];
 extern int data_ov002_021104e4[];
 }
 
-extern "C" int _ZN6Player13St_Shell_MainEv(char* c)
+int Player::St_Shell_Main()
 {
     int flag = 0;
     void* res;
 
-    if (func_02035638((u8*)(c + 0x380))) {
+    if (func_02035638((u8*)((char*)&mMeshClsn))) {
         flag = 1;
-        res = (void*)func_0203564c((int)(c + 0x380));
+        res = (void*)func_0203564c((int)((char*)&mMeshClsn));
         if (_ZNK10ClsnResult9GetClsnIDEv(res) != -1) {
             void* a = _ZN5Actor10FindWithIDEj((u32)_ZNK10ClsnResult9GetClsnIDEv(res));
             if (a) {
                 u16 type = *(u16*)((char*)a + 0xc);
                 if ((type == 0x14 ? flag : 0) || (type == 0x15 ? 1 : 0)) {
-                    func_ov002_020eeca8((void*)(c + 0x380), (int)c);
+                    func_ov002_020eeca8((void*)((char*)&mMeshClsn), (int)((char*)this));
                     flag = 0;
                 }
             }
         }
     }
 
-    if (_ZNK12WithMeshClsn8IsOnWallEv((void*)(c + 0x380))) {
-        int ang = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x560), *(int*)(c + 0x568));
-        if (AngleDiff(ang, *(s16*)(c + 0x94)) > 0x6000) {
-            if (func_02037e58((u32*)((char*)_ZNK12WithMeshClsn13GetWallResultEv((void*)(c + 0x380)) + 4)) != 1) {
+    if (_ZNK12WithMeshClsn8IsOnWallEv((void*)((char*)&mMeshClsn))) {
+        int ang = _ZN4cstd5atan2E5Fix12IiES1_(unk_560, unk_568);
+        if (AngleDiff(ang, mTargetAngleY) > 0x6000) {
+            if (func_02037e58((u32*)((char*)_ZNK12WithMeshClsn13GetWallResultEv((void*)((char*)&mMeshClsn)) + 4)) != 1) {
                 flag = 1;
             }
         }
     }
 
     if (flag) {
-        func_ov002_020c1eb4(c, (s16)(*(s16*)(c + 0x8e) + 0x8000));
+        func_ov002_020c1eb4(((char*)this), (s16)(mAngleY + 0x8000));
         return 1;
     }
 
-    if (*(u8*)(c + 0x6e3) == 0) {
+    if (mStateStep == 0) {
         s16 target;
         int accel;
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            target = *(s16*)(c + 0x6d2);
+            target = mDesiredAngleY;
             accel = 0x40000;
         } else {
-            target = *(s16*)(c + 0x8e);
+            target = mAngleY;
             accel = 0x18000;
         }
-        s16 angleSave = *(s16*)(c + 0x94);
-        ApproachAngle((short*)(c + 0x94), target, 8, 0x800, 0x100);
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-        func_ov002_020cc660(c, angleSave);
+        s16 angleSave = mTargetAngleY;
+        ApproachAngle((short*)((char*)&mTargetAngleY), target, 8, 0x800, 0x100);
+        mAngleY = mTargetAngleY;
+        func_ov002_020cc660(((char*)this), angleSave);
         {
-            int spd = *(int*)(c + 0x98);
+            int spd = mHorzSpeed;
             int step = 0x1100;
             if (spd > 0) step = 0x600;
-            _Z14ApproachLinearRiii((int*)(c + 0x98), accel, step);
+            _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), accel, step);
         }
-        func_ov002_020c04e0(c);
-        if (*(u8*)(c + 0x6de) != 0) {
-            (*(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
-            *(u8*)(c + 0x6de) = 1;
-            *(u8*)(c + 0x6df) = 0;
+        func_ov002_020c04e0(((char*)this));
+        if (mIsAirborne != 0) {
+            (*(u8*)(((long long)(int)((char*)&mStateStep))))++;
+            mIsAirborne = 1;
+            mLandSoundPlayed = 0;
         }
         {
             int off = data_020a0e40 * 0x18;
             if (*(u16*)((char*)data_0209f49e + off) & 2) {
-                (*(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
-                *(int*)(c + 0xa8) = (*(int*)(c + 0x98) >> 2) + 0x2a000;
-                *(u8*)(c + 0x6de) = 1;
-                *(u8*)(c + 0x6df) = 0;
-                func_ov002_020e25f0(c, 0);
+                (*(u8*)(((long long)(int)((char*)&mStateStep))))++;
+                mVertSpeed = (mHorzSpeed >> 2) + 0x2a000;
+                mIsAirborne = 1;
+                mLandSoundPlayed = 0;
+                func_ov002_020e25f0(((char*)this), 0);
                 return 1;
             } else if (*(u16*)((char*)data_0209f49c + off) & 0x400) {
-                if (func_ov002_020d674c(c)) {
-                    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211004c);
+                if (func_ov002_020d674c(((char*)this))) {
+                    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211004c);
                 } else {
-                    *(u8*)(c + 0x6e3) = 0;
-                    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021104e4);
+                    mStateStep = 0;
+                    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021104e4);
                 }
                 return 1;
             }
         }
     } else {
-        if (*(u8*)(c + 0x6de) == 0) {
-            *(u8*)(c + 0x6e3) = 0;
-            *(s16*)(c + 0x766) = 0x1000;
-            *(s16*)(c + 0x760) = *(s16*)(c + 0x766);
+        if (mIsAirborne == 0) {
+            mStateStep = 0;
+            unk_766 = 0x1000;
+            unk_760 = unk_766;
         } else {
-            *(s16*)(c + 0x766) = 0;
-            *(s16*)(c + 0x760) = *(s16*)(c + 0x766);
-            func_ov002_020e28d4(c, 0x1800, 0x800);
-            *(int*)(c + 0x9c) = -0x4000;
-            *(int*)(c + 0xa0) = -0x4b000;
-            if (*(int*)(c + 0xa8) >= 0) {
-                *(int*)(c + 0x9c) = -0x8000;
+            unk_766 = 0;
+            unk_760 = unk_766;
+            func_ov002_020e28d4(((char*)this), 0x1800, 0x800);
+            mVertAccel = -0x4000;
+            mTerminalVelocity = -0x4b000;
+            if (mVertSpeed >= 0) {
+                mVertAccel = -0x8000;
                 if (*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 2) {
-                    *(int*)(c + 0x9c) = -0x3400;
+                    mVertAccel = -0x3400;
                 }
             } else {
-                if ((*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 2) && *(u8*)(c + 0x6ff) != 0) {
-                    *(int*)(c + 0x9c) = -0x2000;
-                    *(int*)(c + 0xa0) = -0x25800;
+                if ((*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 2) && mHasWings != 0) {
+                    mVertAccel = -0x2000;
+                    mTerminalVelocity = -0x25800;
                 }
             }
         }
     }
 
-    if (_ZN6Player12FinishedAnimEv(c) && _ZN6Player6IsAnimEj(c, 0x35)) {
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x34, 0, 0x1000, 0);
+    if (_ZN6Player12FinishedAnimEv(((char*)this)) && _ZN6Player6IsAnimEj(((char*)this), 0x35)) {
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x34, 0, 0x1000, 0);
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player13St_Throw_MainEv.cpp
+++ b/src/_ZN6Player13St_Throw_MainEv.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol _ZN6Player13St_Throw_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // _ZN6Player13St_Throw_MainEv at 0x020dae6c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
 extern int _Z14ApproachLinearRiii(int&, int, int);
 extern int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned, int);
-extern int _ZNK9Animation12WillHitFrameEi(void*, int);
 extern int func_ov002_020c19d0(void*, int, int);
 extern void func_ov002_020daa74(void*);
 extern void func_ov002_020da9d4(void*);
@@ -12,19 +16,21 @@ extern int _ZN6Player12FinishedAnimEv(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern void func_ov002_020bedd4(void*);
 extern int data_ov002_0211013c[];
+}
 
-int _ZN6Player13St_Throw_MainEv(char* c){
-  if(*(unsigned char*)(c+0x6de)==0){
-    _Z14ApproachLinearRiii(*(int*)(c+0x98), 0, 0x1000);
+int Player::St_Throw_Main()
+{
+  if(mIsAirborne==0){
+    _Z14ApproachLinearRiii(mHorzSpeed, 0, 0x1000);
   }
-  if(*(char**)(c+0x358)){
+  if(*(char**)((char*)&mHeldObj)){
     int r4 = 5;
-    int id=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
-    void* anim=*(void**)(c+(id<<2)+0xdc);
+    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    void* anim=*(void**)(((char*)this)+(id<<2)+0xdc);
     if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0)){
-      if(func_ov002_020c19d0(c,0x40,0x32)) r4=0;
+      if(func_ov002_020c19d0(((char*)this),0x40,0x32)) r4=0;
     }
-    char* q=*(char**)(c+0x358);
+    char* q=*(char**)((char*)&mHeldObj);
     unsigned short a=*(unsigned short*)(q+0xc);
     int t1=(a==0xbd);
     if(!t1){
@@ -39,17 +45,16 @@ int _ZN6Player13St_Throw_MainEv(char* c){
       if(b) r4=0xd;
     }
   Ld0:
-    int id2=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
-    void* anim2=*(void**)(c+(id2<<2)+0xdc);
+    int id2=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    void* anim2=*(void**)(((char*)this)+(id2<<2)+0xdc);
     if(_ZNK9Animation12WillHitFrameEi((char*)anim2+0x50,r4)){
-      int b2=(*(int*)(*(char**)(c+0x358)+0xb0)&0x200)?1:0;
-      if(b2==0) func_ov002_020daa74(c);
-      else func_ov002_020da9d4(c);
+      int b2=(*(int*)(*(char**)((char*)&mHeldObj)+0xb0)&0x200)?1:0;
+      if(b2==0) func_ov002_020daa74(((char*)this));
+      else func_ov002_020da9d4(((char*)this));
     }
   }
-  if(_ZN6Player12FinishedAnimEv(c))
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
-  func_ov002_020bedd4(c);
+  if(_ZN6Player12FinishedAnimEv(((char*)this)))
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211013c);
+  func_ov002_020bedd4(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player13TryTalkToDoorEh.cpp
+++ b/src/_ZN6Player13TryTalkToDoorEh.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN6Player13TryTalkToDoorEh
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void*,void*);
 extern int _ZN6Player17SetNoControlStateEhih(void*,unsigned char,int,unsigned char);
 extern int data_ov002_0211013c[];
 extern int _ZN6Player7ST_WAITE[];
 extern int data_ov002_0211043c[];
-int _ZN6Player13TryTalkToDoorEh(void* c, unsigned char a){
-  if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
-     || _ZN6Player7IsStateERNS_5StateE(c,_ZN6Player7ST_WAITE)
-     || _ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211043c)){
-    *(unsigned char*)((char*)c+0x70c)=a;
-    _ZN6Player17SetNoControlStateEhih(c,0xe,-1,0);
+}
+
+int Player::TryTalkToDoor(unsigned char a)
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((void*)this),data_ov002_0211013c)
+     || _ZN6Player7IsStateERNS_5StateE(((void*)this),_ZN6Player7ST_WAITE)
+     || _ZN6Player7IsStateERNS_5StateE(((void*)this),data_ov002_0211043c)){
+    *(unsigned char*)((char*)&mStateArg)=a;
+    _ZN6Player17SetNoControlStateEhih(((void*)this),0xe,-1,0);
     return 1;
   }
   return 0;
-}
 }

--- a/src/_ZN6Player14EnterWhirlpoolEv.cpp
+++ b/src/_ZN6Player14EnterWhirlpoolEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player14EnterWhirlpoolEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 /* _ZN6Player14EnterWhirlpoolEv @ 0x20c5cc8 (ov002) -- tail-call veneer to func_ov002_020c5dec (0x20c5dec) with r1=9.
  */
 extern "C" {
 extern void func_ov002_020c5dec(void*, int);
-void _ZN6Player14EnterWhirlpoolEv(void* a) {
-    func_ov002_020c5dec(a, 9);
 }
+
+void Player::EnterWhirlpool()
+{
+    func_ov002_020c5dec(((void*)this), 9);
 }

--- a/src/_ZN6Player14InitMetalWarioEv.cpp
+++ b/src/_ZN6Player14InitMetalWarioEv.cpp
@@ -1,46 +1,50 @@
 //cpp
+// @symbol _ZN6Player14InitMetalWarioEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_ModelAnim2.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned int u32;
 typedef unsigned char u8;
 typedef unsigned short u16;
 
 extern "C" void func_ov002_020bda48(char *self);
-extern "C" int func_ov002_020bea7c(char *self);
-extern "C" void _ZN6Player18TurnOffToonShadingEj(char *self, u32 a);
 extern "C" u32 _ZNK6Player14GetBodyModelIDEjb(char *self, u32 a, bool b);
-extern "C" void _ZN10ModelAnim24CopyERKS_Pcj(void *self, void *src, char *p, u32 n);
 extern "C" void func_ov002_020bd9ec(char *self, u32 a);
 extern "C" void func_ov002_020c43c4(char *self, u32 a);
 
 extern char *data_ov002_020ff480[];
 
-extern "C" void _ZN6Player14InitMetalWarioEv(char *self)
+void Player::InitMetalWario()
 {
     u32 v;
     u32 id;
 
-    func_ov002_020bda48(self);
-    if (func_ov002_020bea7c(self) != 0) {
-        u32 b = *(u8 *)(self + 0x6dd);
+    func_ov002_020bda48(((char *)this));
+    if (func_ov002_020bea7c(((char *)this)) != 0) {
+        u32 b = mHatCharacter;
         if (b != 2)
             return;
-        _ZN6Player18TurnOffToonShadingEj(self, b);
-        _ZN6Player18TurnOffToonShadingEj(self, *(u8 *)(self + 0x6dc));
-        *(u16 *)(self + 0x73c) = 0;
-        *(u32 *)(self + 8) = *(u8 *)(self + 0x6dd);
-        *(u8 *)(self + 0x71a) = 0;
+        _ZN6Player18TurnOffToonShadingEj(((char *)this), b);
+        _ZN6Player18TurnOffToonShadingEj(((char *)this), unk_6dc);
+        unk_73c = 0;
+        mParam = mHatCharacter;
+        unk_71a = 0;
     }
 
-    *(u8 *)(self + 0x6f9) = 1;
+    mIsMetal = 1;
 
-    v = *(u32 *)(self + 8);
-    id = _ZNK6Player14GetBodyModelIDEjb(self, v & 0xff, 0);
+    v = mParam;
+    id = _ZNK6Player14GetBodyModelIDEjb(((char *)this), v & 0xff, 0);
     _ZN10ModelAnim24CopyERKS_Pcj(
-        *(void **)(self + id * 4 + 0xdc),
-        *(void **)(self + v * 4 + 0xdc),
-        *(char **)((char *)data_ov002_020ff480[*(u32 *)(self + 0x63c) + v] + 4),
+        *(void **)(((char *)this) + id * 4 + 0xdc),
+        *(void **)(((char *)this) + v * 4 + 0xdc),
+        *(char **)((char *)data_ov002_020ff480[mCharFileBase + v] + 4),
         0);
 
-    *(u16 *)(self + 0x6ae) = 0x258;
-    func_ov002_020bd9ec(self, 0x34);
-    func_ov002_020c43c4(self, 4);
+    unk_6ae = 0x258;
+    func_ov002_020bd9ec(((char *)this), 0x34);
+    func_ov002_020c43c4(((char *)this), 4);
 }

--- a/src/_ZN6Player14IsFrontSlidingEv.cpp
+++ b/src/_ZN6Player14IsFrontSlidingEv.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol _ZN6Player14IsFrontSlidingEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 int _ZN6Player6IsAnimEj(void*, unsigned int);
-int _ZN6Player14IsFrontSlidingEv(void* c){
-  return _ZN6Player6IsAnimEj(c, 0x43) || _ZN6Player6IsAnimEj(c, 0x40);
 }
+
+int Player::IsFrontSliding()
+{
+  return _ZN6Player6IsAnimEj(((void*)this), 0x43) || _ZN6Player6IsAnimEj(((void*)this), 0x40);
 }

--- a/src/_ZN6Player14St_Cannon_InitEv.cpp
+++ b/src/_ZN6Player14St_Cannon_InitEv.cpp
@@ -1,23 +1,28 @@
 //cpp
+// @symbol _ZN6Player14St_Cannon_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020c9e40(void*);
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_Cannon_InitEv(char* c){
-  func_ov002_020c9e40(c);
-  *(unsigned char*)(c+0x706)=0;
-  *(unsigned char*)(c+0x712)=1;
-  *(unsigned char*)(c+0x70d)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  func_ov002_020dab14(c);
-  *(unsigned char*)(c+0x6e3)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x73,0,0x1000,0);
-  *(int*)(c+0x9c)=-0x1200;
-  *(unsigned char*)(c+0x6f5)=0;
-  *(unsigned char*)(c+0x713)=0;
-  *(unsigned char*)(c+0x6e5)=0;
-  *(unsigned char*)(c+0x6f6)=1;
-  return 1;
 }
+
+int Player::St_Cannon_Init()
+{
+  func_ov002_020c9e40(((char*)this));
+  mIsUnderwater=0;
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  func_ov002_020dab14(((char*)this));
+  mStateStep=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x73,0,0x1000,0);
+  mVertAccel=-0x1200;
+  mOpacity=0;
+  mIsBodyClsnEnabled=0;
+  mStateWork=0;
+  mIsControlDisabled=1;
+  return 1;
 }

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player14St_Cannon_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -13,7 +18,6 @@ extern void func_02012694(u32 id, void* v);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void func_ov002_020c9e18(void* c);
-extern void func_ov002_020c1eb4(void* self, int dmg);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int cc);
@@ -29,9 +33,9 @@ extern int data_ov002_0211031c[];
 extern int data_ov002_02110214[];
 }
 
-extern "C" int _ZN6Player14St_Cannon_MainEv(char* c)
+int Player::St_Cannon_Main()
 {
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
         break;
     case 1: {
@@ -39,62 +43,62 @@ extern "C" int _ZN6Player14St_Cannon_MainEv(char* c)
             break;
 
         char* p = data_0209f318;
-        *(s16*)(c + 0x94) = GetAngleToCamera(*(u8*)(c + 0x6d8)) + 0x8000;
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+        mTargetAngleY = GetAngleToCamera(mPlayerNo) + 0x8000;
+        mAngleY = mTargetAngleY;
 
         int ang = *(u16*)(p + 0x17e);
         int j = ang >> 4;
-        *(int*)(c + 0x98) = (int)(((long long)data_02082214[j * 2 + 1] * 0x64000 + 0x800) >> 12);
-        *(int*)(c + 0xa8) = (int)(((long long)data_02082214[j * 2] * 0x64000 + 0x800) >> 12);
-        *(s16*)(c + 0x8c) = 0;
-        *(u8*)(c + 0x6e3) = 2;
-        *(u8*)(c + 0x6f5) = 0x1f;
-        *(u8*)(c + 0x713) = 1;
-        *(int*)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
-        func_0200d6f0(p, *(u8*)(c + 0x6d8));
-        func_02012694(0x14f, c + 0x74);
-        _ZN5Sound9PlayBank0EjRK7Vector3(0xb9, c + 0x74);
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0xc, c + 0x74);
-        func_ov002_020c9e18(c);
-        *(u8*)(c + 0x6f6) = 0;
+        mHorzSpeed = (int)(((long long)data_02082214[j * 2 + 1] * 0x64000 + 0x800) >> 12);
+        mVertSpeed = (int)(((long long)data_02082214[j * 2] * 0x64000 + 0x800) >> 12);
+        mAngX = 0;
+        mStateStep = 2;
+        mOpacity = 0x1f;
+        mIsBodyClsnEnabled = 1;
+        *(int*)(((long long)(int)((char*)&mBodyClsnFlags))) |= 0x20;
+        func_0200d6f0(p, mPlayerNo);
+        func_02012694(0x14f, ((char*)this) + 0x74);
+        _ZN5Sound9PlayBank0EjRK7Vector3(0xb9, ((char*)this) + 0x74);
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xc, ((char*)this) + 0x74);
+        func_ov002_020c9e18(((char*)this));
+        mIsControlDisabled = 0;
         break;
     }
     case 2:
-        if ((*(u8*)(c + 0x6e9) & 6) != 0) {
-            func_ov002_020c1eb4(c, (short)(*(s16*)(c + 0x8e) + 0x8000));
+        if ((mClsnFlags & 6) != 0) {
+            func_ov002_020c1eb4(((char*)this), (short)(mAngleY + 0x8000));
             return 1;
         }
-        if (*(u8*)(c + 0x6de) == 0) {
-            if (*(u8*)(c + 0x6e5) != 0) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211031c);
+        if (mIsAirborne == 0) {
+            if (mStateWork != 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211031c);
                 return 1;
             }
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211031c);
-            *(u8*)(c + 0x6de) = 1;
-            *(u8*)(c + 0x6df) = 0;
-            *(int*)(c + 0xa8) = 0xa000;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211031c);
+            mIsAirborne = 1;
+            mLandSoundPlayed = 0;
+            mVertSpeed = 0xa000;
             return 1;
         }
-        if (*(u8*)(c + 0x6ff) != 0 && *(int*)(c + 0xa8) < 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x72, 0x40000000, 0x1000, 0);
-            *(u8*)(c + 0x6e3) = 3;
+        if (mHasWings != 0 && mVertSpeed < 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x72, 0x40000000, 0x1000, 0);
+            mStateStep = 3;
             return 1;
         }
-        *(int*)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80;
-        if (*(int*)(c + 0x98) < 0xa000)
-            *(int*)(c + 0x98) = 0xa000;
-        if (*(int*)(c + 0xa8) >= 0)
-            _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*(int*)(c + 0x5c), *(int*)(c + 0x60), *(int*)(c + 0x64));
-        if (*(u8*)(c + 0x6e5) == 0)
-            *(s16*)(c + 0x8c) = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x98) >> 8, *(int*)(c + 0xa8) >> 8) - 0x4000;
-        func_ov002_020bedd4(c);
+        *(int*)(((long long)(int)((char*)&mHorzSpeed))) -= 0x80;
+        if (mHorzSpeed < 0xa000)
+            mHorzSpeed = 0xa000;
+        if (mVertSpeed >= 0)
+            _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(mPosX, mPosY, mPosZ);
+        if (mStateWork == 0)
+            mAngX = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed >> 8, mVertSpeed >> 8) - 0x4000;
+        func_ov002_020bedd4(((char*)this));
         // fall through
     case 3:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110214);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mStateStep = 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110214);
         }
-        func_ov002_020bedd4(c);
+        func_ov002_020bedd4(((char*)this));
         break;
     }
     return 1;

--- a/src/_ZN6Player14St_Crouch_InitEv.cpp
+++ b/src/_ZN6Player14St_Crouch_InitEv.cpp
@@ -1,25 +1,30 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN6Player14St_Crouch_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern unsigned char data_020a0e40;
 extern unsigned char data_0209f49c[];
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-extern int func_ov002_020d1204(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_Crouch_InitEv(char* c){
-  if(*(unsigned char*)(c+0x6ed)){
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x2e,(struct Vector3*)(c+0x74));
+}
+
+int Player::St_Crouch_Init()
+{
+  if(unk_6ed){
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x2e,(struct Vector3*)((char*)&mCamSpacePos));
   }
-  *(short*)(c+0x6a4)=0x1e;
+  mStateTimer=0x1e;
   if(*(unsigned short*)(data_0209f49c + data_020a0e40*0x18) & 2){
-    if(func_ov002_020d1204(c)) return 1;
+    if(func_ov002_020d1204(((char*)this))) return 1;
   }
-  if(*(unsigned char*)(c+0x6e3)==0){
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x2d,0x40000000,0x1000,0);
-    *(short*)(c+0x94)=*(short*)(c+0x8e);
-  } else if(*(unsigned char*)(c+0x6e3)==1){
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x2c,0,0x1000,0);
+  if(mStateStep==0){
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x2d,0x40000000,0x1000,0);
+    mTargetAngleY=mAngleY;
+  } else if(mStateStep==1){
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x2c,0,0x1000,0);
   }
   return 1;
-}
 }

--- a/src/_ZN6Player14St_Crouch_MainEv.cpp
+++ b/src/_ZN6Player14St_Crouch_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player14St_Crouch_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -12,9 +17,6 @@ extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern int func_ov002_020d12b0(void* c);
-extern int func_ov002_020d1204(void* c);
-extern int func_ov002_020d1164(void* c);
 extern void func_ov002_020c06fc(void* c, u32 a);
 extern int func_ov002_020dd2f4(void* c);
 extern void func_ov002_020c0364(void* c, u32 a);
@@ -28,67 +30,67 @@ extern int data_ov002_02110514[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player14St_Crouch_MainEv(char* c)
+int Player::St_Crouch_Main()
 {
-    func_ov002_020bf90c(c);
+    func_ov002_020bf90c(((char*)this));
 
-    if (*(u8*)(c + 0x6de) != 0) {
-        int d = *(int*)(c + 0x60) - *(int*)(c + 0x644);
+    if (mIsAirborne != 0) {
+        int d = mPosY - mGroundY;
         if (d >= 0x32000) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
             return 1;
         }
     }
 
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        if (_ZN6Player6IsAnimEj(c, 0x2d) && _ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2c, 0, 0x1000, 0);
-            *(u8*)(c + 0x6e3) = 1;
+        if (_ZN6Player6IsAnimEj(((char*)this), 0x2d) && _ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x2c, 0, 0x1000, 0);
+            mStateStep = 1;
         }
-        if (func_ov002_020d12b0(c))
+        if (func_ov002_020d12b0(((char*)this)))
             return 1;
-        func_ov002_020d1204(c);
+        func_ov002_020d1204(((char*)this));
         break;
     case 1:
         if ((*(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18) & 0x400) != 0
-            || *(int*)(c + 0x98) != 0
-            || func_ov002_020d1164(c) != 0) {
-            if (*(int*)(c + 0x98) != 0) {
-                func_ov002_020c06fc(c, 0x4000);
-                func_ov002_020dd2f4(c);
+            || mHorzSpeed != 0
+            || func_ov002_020d1164(((char*)this)) != 0) {
+            if (mHorzSpeed != 0) {
+                func_ov002_020c06fc(((char*)this), 0x4000);
+                func_ov002_020dd2f4(((char*)this));
             } else {
-                if (*(u8*)(c + 0x703) == 0) {
+                if (mIsMega == 0) {
                     if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) >= 0x200) {
-                        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110514);
+                        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110514);
                         return 1;
                     }
                 }
             }
-            u16 bit = *(u16*)(c + 0x6ce) & 1;
+            u16 bit = mStateFlags & 1;
             if (bit != 0) {
-                func_ov002_020c0364(c, 1);
+                func_ov002_020c0364(((char*)this), 1);
                 return 1;
             }
         } else {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x2e, 0x40000000, 0x1000, 0);
-            *(u8*)(c + 0x6e3) = 2;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x2e, 0x40000000, 0x1000, 0);
+            mStateStep = 2;
         }
-        if (func_ov002_020d12b0(c))
+        if (func_ov002_020d12b0(((char*)this)))
             return 1;
-        if (func_ov002_020d1204(c) != 0)
+        if (func_ov002_020d1204(((char*)this)) != 0)
             return 1;
         break;
     case 2:
-        if (_ZN6Player6IsAnimEj(c, 0x2e) && _ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
-            *(u16*)(c + 0x6b0) = 0xa;
+        if (_ZN6Player6IsAnimEj(((char*)this), 0x2e) && _ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
+            unk_6b0 = 0xa;
         } else {
-            func_ov002_020d1204(c);
+            func_ov002_020d1204(((char*)this));
         }
         break;
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player14St_OnWall_InitEv.cpp
+++ b/src/_ZN6Player14St_OnWall_InitEv.cpp
@@ -1,14 +1,20 @@
 //cpp
+// @symbol _ZN6Player14St_OnWall_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int data_ov002_020ff164[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player14St_OnWall_InitEv(char* c){
-  int r3=0x1000;
-  if(*(int*)(c+8)==2){
-    if(*(unsigned char*)(c+0x6e3)==2) r3=0x2000;
-  }
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff164[*(unsigned char*)(c+0x6e3)], 0, r3, 0);
-  *(int*)(c+0x98)=0;
-  return 1;
 }
+
+int Player::St_OnWall_Init()
+{
+  int r3=0x1000;
+  if(mParam==2){
+    if(mStateStep==2) r3=0x2000;
+  }
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff164[mStateStep], 0, r3, 0);
+  mHorzSpeed=0;
+  return 1;
 }

--- a/src/_ZN6Player14St_OnWall_MainEv.cpp
+++ b/src/_ZN6Player14St_OnWall_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player14St_OnWall_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef long long s64;
@@ -14,11 +20,8 @@ extern int func_ov002_020c5244();
 extern int func_ov002_020d36d8(char* c, int a);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
-extern int AngleDiff(int a, int b);
-extern void _ZN6Player14St_OnWall_InitEv(char* c);
 extern void _Z14ApproachLinearRsss(s16* v, s16 t, s16 s);
 extern int func_ov002_020bf224(char* c, int a, int b);
-extern void func_ov002_020eee3c(char* a, char* b);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern int func_ov002_020d4d88(char* c, int a, int b);
 extern void func_ov002_020bedd4(char* c);
@@ -28,84 +31,84 @@ extern s16 data_0209f4a0[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player14St_OnWall_MainEv(char* c)
+int Player::St_OnWall_Main()
 {
-    u16 f = *(u16*)(c + 0x6ce);
+    u16 f = mStateFlags;
     u16 b0 = f & 1;
     if (b0 != 0) {
-        func_ov002_020c0364(c, 3);
+        func_ov002_020c0364(((char*)this), 3);
         return 1;
     }
     u16 b1 = f & 4;
     if (b1 != 0) {
-        func_ov002_020cabe0(c);
+        func_ov002_020cabe0(((char*)this));
         return 1;
     }
     if (func_ov002_020c5244() != 0)
         return 1;
-    if (func_ov002_020d36d8(c, 0) != 0) {
-        *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+    if (func_ov002_020d36d8(((char*)this), 0) != 0) {
+        mTargetAngleY = mAngleY;
         return 1;
     }
-    if ((*(u8*)(c + 0x6e9) & 2) == 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    if ((mClsnFlags & 2) == 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
-    if (*(u8*)(c + 0x6e3) == 2) {
+    if (mStateStep == 2) {
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) == 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
             return 1;
         }
-        int a = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x560), *(int*)(c + 0x568)) + 0x8000;
-        int d = AngleDiff((s16)a, *(s16*)(c + 0x6d2));
+        int a = _ZN4cstd5atan2E5Fix12IiES1_(unk_560, unk_568) + 0x8000;
+        int d = AngleDiff((s16)a, mDesiredAngleY);
         if (d >= 0x4000) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
             return 1;
         }
         if (d >= 0x1555) {
-            *(u8*)(c + 0x6e3) = 0;
-            if ((s16)a == (s16)(*(s16*)(c + 0x6d2) + d))
-                *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player14St_OnWall_InitEv(c);
+            mStateStep = 0;
+            if ((s16)a == (s16)(mDesiredAngleY + d))
+                mStateStep = 1;
+            _ZN6Player14St_OnWall_InitEv(((char*)this));
             return 1;
         }
-        _Z14ApproachLinearRsss((s16*)(c + 0x8e), (s16)a, 0x800);
-        *(s16*)(c + 0x94) = a;
-        *(int*)(c + 0x98) = func_ov002_020bf224(c, 0xa000, 0x2000);
-        func_ov002_020eee3c(c + 0x380, c);
+        _Z14ApproachLinearRsss((s16*)((char*)&mAngleY), (s16)a, 0x800);
+        mTargetAngleY = a;
+        mHorzSpeed = func_ov002_020bf224(((char*)this), 0xa000, 0x2000);
+        func_ov002_020eee3c(((char*)this) + 0x380, ((char*)this));
     } else {
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            int ang = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x560), *(int*)(c + 0x568));
-            int d = AngleDiff((s16)(ang + 0x8000), *(s16*)(c + 0x6d2));
+            int ang = _ZN4cstd5atan2E5Fix12IiES1_(unk_560, unk_568);
+            int d = AngleDiff((s16)(ang + 0x8000), mDesiredAngleY);
             if (d >= 0x4000) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
                 return 1;
             }
             if (d < 0x1555) {
-                *(u8*)(c + 0x6e3) = 2;
-                _ZN6Player14St_OnWall_InitEv(c);
+                mStateStep = 2;
+                _ZN6Player14St_OnWall_InitEv(((char*)this));
                 return 1;
             }
             int a2 = ang + 0x8000;
-            _Z14ApproachLinearRsss((s16*)(c + 0x8e), (s16)a2, 0x800);
+            _Z14ApproachLinearRsss((s16*)((char*)&mAngleY), (s16)a2, 0x800);
             u32 anim;
-            if ((s16)a2 == (s16)(*(s16*)(c + 0x6d2) + d)) {
-                *(s16*)(c + 0x94) = ang + 0x4000;
+            if ((s16)a2 == (s16)(mDesiredAngleY + d)) {
+                mTargetAngleY = ang + 0x4000;
                 anim = 0x5d;
             } else {
-                *(s16*)(c + 0x94) = ang - 0x4000;
+                mTargetAngleY = ang - 0x4000;
                 anim = 0x5c;
             }
-            Fix12 spd = (Fix12)(((s64)*(int*)(c + 0x98) * 0x600 + 0x800) >> 12);
+            Fix12 spd = (Fix12)(((s64)mHorzSpeed * 0x600 + 0x800) >> 12);
             if (spd < 0x400)
                 spd = 0x400;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, anim, 0, spd, 0);
-            func_ov002_020d4d88(c, func_ov002_020bf224(c, 0x6000, 0x1000), 0x1000);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), anim, 0, spd, 0);
+            func_ov002_020d4d88(((char*)this), func_ov002_020bf224(((char*)this), 0x6000, 0x1000), 0x1000);
         } else {
-            *(int*)(c + 0x98) = 0;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x5e, 0, 0x1000, 0);
+            mHorzSpeed = 0;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x5e, 0, 0x1000, 0);
         }
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player14St_Owl_CleanupEv.cpp
+++ b/src/_ZN6Player14St_Owl_CleanupEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player14St_Owl_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020bd8c0(void*,int);
-int _ZN6Player14St_Owl_CleanupEv(char* c){
-  func_ov002_020bd8c0(c,0x2f);
-  *(int*)(c+0x358)=0;
-  return 1;
 }
+
+int Player::St_Owl_Cleanup()
+{
+  func_ov002_020bd8c0(((char*)this),0x2f);
+  mHeldObj=0;
+  return 1;
 }

--- a/src/_ZN6Player14St_Squish_MainEv.cpp
+++ b/src/_ZN6Player14St_Squish_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player14St_Squish_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned short u16;
@@ -9,40 +14,37 @@ extern char data_ov002_0211013c;
 extern char data_ov002_021101b4;
 
 extern "C" {
-extern int func_ov002_020c6908(char *c);
-extern int func_ov002_020c647c(char *c, int a);
 extern int func_ov002_020d91e0(char *c, int a, int b);
 extern void func_ov002_020db8bc(char *c, int a);
-extern int func_ov002_020c6538(char *c);
-extern void KillPlayer(void);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, char *v);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char *c, char *s);
 extern int _ZN6Player9GetHealthEv(char *c);
+}
 
-int _ZN6Player14St_Squish_MainEv(char *c)
+int Player::St_Squish_Main()
 {
-    switch (*(u8 *)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        if (func_ov002_020c6908(c) != 0)
+        if (func_ov002_020c6908(((char *)this)) != 0)
             return 1;
         {
-            int r = func_ov002_020c647c(c, *(int *)(c + 0x688));
+            int r = func_ov002_020c647c(((char *)this), mAttachOffsetY);
             if (r >= 0) {
-                *(int *)(c + 0x84) = (r << 12) / 160;
+                mScaleY = (r << 12) / 160;
                 if (r >= 0x20)
                     break;
-                if (*(u8 *)(c + 0x6e6) != 2)
+                if (unk_6e6 != 2)
                     break;
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 7, c + 0x74);
-                *(int *)(c + 0x84) = 0x100;
-                *(u8 *)(c + 0x6e3) = 2;
-                *(u8 *)(c + 0x70c) = 1;
-                if (*(u8 *)(c + 0x6f9) == 0) {
-                    if (func_ov002_020d91e0(c, 0x300, 1) != 0)
-                        *(u8 *)(c + 0x70c) = 2;
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 7, ((char *)this) + 0x74);
+                mScaleY = 0x100;
+                mStateStep = 2;
+                mStateArg = 1;
+                if (mIsMetal == 0) {
+                    if (func_ov002_020d91e0(((char *)this), 0x300, 1) != 0)
+                        mStateArg = 2;
                 }
                 {
-                    char *a = *(char **)(c + 0x364);
+                    char *a = *(char **)((char *)&mAttachedActor);
                     if (a != 0) {
                         u16 id = *(u16 *)(a + 0xc);
                         int b1 = (id == 0xa4);
@@ -52,61 +54,60 @@ int _ZN6Player14St_Squish_MainEv(char *c)
                     }
                 }
             } else {
-                *(u16 *)(c + 0x6a4) = 0xa;
-                (*(u8 *)(int)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                mStateTimer = 0xa;
+                (*(u8 *)(int)(((long long)(int)((char *)&mStateStep))))++;
             }
         }
         break;
     case 1:
-        if (*(u16 *)(c + 0x6a4) != 0) {
-            (*(int *)(int)(((long long)(int)(c + 0x84)) & 0xFFFFFFFFFFFFFFFFLL)) += 0x100;
-            if (*(int *)(c + 0x84) > 0x1000)
-                *(int *)(c + 0x84) = 0x1000;
+        if (mStateTimer != 0) {
+            (*(int *)(int)(((long long)(int)((char *)&mScaleY)))) += 0x100;
+            if (mScaleY > 0x1000)
+                mScaleY = 0x1000;
         } else {
-            *(int *)(c + 0x84) = 0x1000;
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+            mScaleY = 0x1000;
+            _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
         }
         break;
     case 2:
-        if (func_ov002_020c6908(c) != 0)
+        if (func_ov002_020c6908(((char *)this)) != 0)
             return 1;
-        if (func_ov002_020c647c(c, *(int *)(c + 0x688)) < 0) {
-            if (*(u8 *)(c + 0x70c) == 1) {
-                func_ov002_020db8bc(c, 1);
-                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+        if (func_ov002_020c647c(((char *)this), mAttachOffsetY) < 0) {
+            if (mStateArg == 1) {
+                func_ov002_020db8bc(((char *)this), 1);
+                _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
             } else {
-                (*(u8 *)(int)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
-                *(u8 *)(c + 0x70c) = 0;
+                (*(u8 *)(int)(((long long)(int)((char *)&mStateStep))))++;
+                mStateArg = 0;
             }
         }
         break;
     case 3:
-        if (*(u8 *)(c + 0x6e5) == 2 && func_ov002_020c6538(c) == 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021101b4);
+        if (mStateWork == 2 && func_ov002_020c6538(((char *)this)) == 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_021101b4);
             return 1;
         }
-        if (*(u8 *)(c + 0x70c) != 0)
+        if (mStateArg != 0)
             break;
-        if (_ZN6Player9GetHealthEv(c) != 0) {
-            func_ov002_020db8bc(c, 1);
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+        if (_ZN6Player9GetHealthEv(((char *)this)) != 0) {
+            func_ov002_020db8bc(((char *)this), 1);
+            _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
         }
         if (data_ov002_0211117c != 0)
             break;
         KillPlayer();
-        (*(u8 *)(int)(((long long)(int)(c + 0x70c)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8 *)(int)(((long long)(int)((char *)&mStateArg))))++;
         break;
     case 4:
-        if (*(u16 *)(c + 0x6a4) != 0)
+        if (mStateTimer != 0)
             break;
-        if (*(u8 *)(c + 0x70c) != 1) {
-            *(u8 *)(c + 0x6e3) = 3;
+        if (mStateArg != 1) {
+            mStateStep = 3;
             break;
         }
-        func_ov002_020db8bc(c, 1);
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+        func_ov002_020db8bc(((char *)this), 1);
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
         break;
     }
     return 1;
-}
 }

--- a/src/_ZN6Player14St_Thrown_MainEv.cpp
+++ b/src/_ZN6Player14St_Thrown_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player14St_Thrown_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -6,13 +11,11 @@ typedef unsigned short u16;
 typedef unsigned char u8;
 typedef s32 Fix12;
 
-struct Vector3 { int x, y, z; };
 
 extern "C" {
 extern void func_ov002_020bf90c(char* c);
 extern void func_ov002_020c06fc(char* c, u32 mask);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, const Vector3& v);
-extern int func_ov002_020e2c84(char* c);
 extern void func_ov002_020bf9d4(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
@@ -26,69 +29,69 @@ extern int data_ov002_0211010c[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player14St_Thrown_MainEv(char* c)
+int Player::St_Thrown_Main()
 {
-    if (*(u16*)(c + 0x6a4) == 1) {
-        *(int*)(((int)c + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) |= 0x2000;
+    if (mStateTimer == 1) {
+        *(int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) |= 0x2000;
     }
-    func_ov002_020bf90c(c);
+    func_ov002_020bf90c(((char*)this));
 
-    u8 state = *(u8*)(c + 0x6e3);
+    u8 state = mStateStep;
     switch (state) {
     case 0:
-        if (*(u8*)(c + 0x6de) == 0) {
-            *(s16*)(c + 0x8c) = 0;
-            *(int*)(((int)c + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) &= ~0x2000;
-            func_ov002_020c06fc(c, 0x8000);
-            if (*(u8*)(c + 0x70c) == 0) {
-                *(u8*)(c + 0x70c) = 1;
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 6, *(Vector3*)(c + 0x74));
+        if (mIsAirborne == 0) {
+            mAngX = 0;
+            *(int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) &= ~0x2000;
+            func_ov002_020c06fc(((char*)this), 0x8000);
+            if (mStateArg == 0) {
+                mStateArg = 1;
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, *(Vector3*)((char*)&mCamSpacePos));
             }
-            int r5 = func_ov002_020e2c84(c);
-            if (r5 != 2 && *(u8*)(c + 0x707) == 0) {
-                func_ov002_020bf9d4(c);
+            int r5 = func_ov002_020e2c84(((char*)this));
+            if (r5 != 2 && mIsInShallowWater == 0) {
+                func_ov002_020bf9d4(((char*)this));
             }
             if (r5 != 0) {
                 return 1;
             }
-            if (*(int*)(c + 0x558) == 0x1000) {
-                if (*(int*)(c + 0x98) == 0) {
-                    *(u8*)(c + 0x6e3) = 1;
+            if (unk_558 == 0x1000) {
+                if (mHorzSpeed == 0) {
+                    mStateStep = 1;
                     goto L1f8;
                 }
             } else {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211031c);
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211031c);
                 return 1;
             }
         }
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-        *(int*)(c + 0x98) = (int)(((long long)*(int*)(c + 0x98) * 0xfae + 0x800) >> 12);
-        if (*(u8*)(c + 0x6de) != 0) {
-            int a = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x98), *(int*)(c + 0xa8));
+        mAngleY = mTargetAngleY;
+        mHorzSpeed = (int)(((long long)mHorzSpeed * 0xfae + 0x800) >> 12);
+        if (mIsAirborne != 0) {
+            int a = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed, mVertSpeed);
             s16 b = a - 0x4000;
             if (b > 0x3000) b = 0x3000;
-            *(s16*)(c + 0x8c) = b;
+            mAngX = b;
         } else {
-            _Z15ApproachLinear2Rsss((s16*)(c + 0x8c), 0, 0x400);
+            _Z15ApproachLinear2Rsss((s16*)((char*)&mAngX), 0, 0x400);
         }
         break;
     case 1:
-        if (_ZN6Player9GetHealthEv(c) == 0) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211010c);
+        if (_ZN6Player9GetHealthEv(((char*)this)) == 0) {
+            mStateStep = 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211010c);
             return 1;
         }
-        if (_ZN6Player12FinishedAnimEv(c) != 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
-            *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
+            mTargetAngleY = mAngleY;
         }
-        func_ov002_020bedd4(c);
+        func_ov002_020bedd4(((char*)this));
         break;
     }
 
 L1f8:
-    if (*(u8*)(c + 0x6de) == 0) {
-        func_ov002_020e2c84(c);
+    if (mIsAirborne == 0) {
+        func_ov002_020e2c84(((char*)this));
     }
     return 1;
 }

--- a/src/_ZN6Player15IsCollectingCapEv.cpp
+++ b/src/_ZN6Player15IsCollectingCapEv.cpp
@@ -1,6 +1,12 @@
 //cpp
-extern "C" int _ZN6Player15IsCollectingCapEv(char* c){
-  unsigned short v = *(unsigned short*)(c+0x73c);
+// @symbol _ZN6Player15IsCollectingCapEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
+
+
+int Player::IsCollectingCap()
+{
+  unsigned short v = unk_73c;
   if(v!=0 && (v&7)<5) return 1;
   return 0;
 }

--- a/src/_ZN6Player15IsEnteringLevelEv.cpp
+++ b/src/_ZN6Player15IsEnteringLevelEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN6Player15IsEnteringLevelEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player20IsStateEnteringLevelEv(char*c);
-int _ZN6Player15IsEnteringLevelEv(char*c){
-  if(_ZN6Player20IsStateEnteringLevelEv(c)==0) return 0;
-  unsigned char s=*(unsigned char*)(c+0x6e3);
+}
+
+int Player::IsEnteringLevel()
+{
+  if(_ZN6Player20IsStateEnteringLevelEv(((char*)this))==0) return 0;
+  unsigned char s=mStateStep;
   if(s==8||s==9||s==0x10) return 1;
   return 0;
-}
 }

--- a/src/_ZN6Player15St_Balloon_InitEv.cpp
+++ b/src/_ZN6Player15St_Balloon_InitEv.cpp
@@ -1,24 +1,30 @@
 //cpp
+// @symbol _ZN6Player15St_Balloon_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020dab14(void*);
 extern int data_0209f318[];
-extern void func_0200d63c(void*,unsigned char);
 extern int data_ov002_0210e750[];
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,void*,int,int,unsigned int);
-int _ZN6Player15St_Balloon_InitEv(char* c){
-  func_ov002_020dab14(c);
-  *(unsigned char*)(c+0x712)=1;
-  *(unsigned char*)(c+0x70d)=0;
-  if(*(int*)(c+0xa8) >= 0x10000) *(int*)(c+0xa8)=0x10000;
-  if(*(int*)(c+0xa8) <= -0x10000) *(int*)(c+0xa8)=-0x10000;
-  *(int*)(c+0x98)=0;
-  *(int*)(c+0x690)=0x64000;
-  func_0200d63c((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
-  *(short*)(c+0x69c)=0x100;
-  *(short*)(c+0x69e)=0x100;
-  *(int*)(c+0x640)=*(int*)(c+0xa8);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c+0xf0), (void*)data_ov002_0210e750[1], 0x40000000, 0x1000, 0);
-  *(int*)(c+0x148)=0;
-  return 1;
 }
+
+int Player::St_Balloon_Init()
+{
+  func_ov002_020dab14(((char*)this));
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  if(mVertSpeed >= 0x10000) mVertSpeed=0x10000;
+  if(mVertSpeed <= -0x10000) mVertSpeed=-0x10000;
+  mHorzSpeed=0;
+  unk_690=0x64000;
+  func_0200d63c((void*)data_0209f318[0], mPlayerNo);
+  mAngleYSpeed=0x100;
+  unk_69e=0x100;
+  mPrevVertSpeed=mVertSpeed;
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)((char*)&mModelAnim3), (void*)data_ov002_0210e750[1], 0x40000000, 0x1000, 0);
+  unk_148=0;
+  return 1;
 }

--- a/src/_ZN6Player15St_DeadHit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadHit_InitEv.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN6Player15St_DeadHit_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020c9e40(char*c);
-extern int data_ov002_0210a424[];
 extern char* data_0209f318;
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
-extern void func_0200d89c(char*p);
-int _ZN6Player15St_DeadHit_InitEv(char*c){
-  func_ov002_020c9e40(c);
-  *(unsigned char*)(c+0x713)=0;
-  int idx=*(unsigned char*)(c+0x6e3)&1;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,data_ov002_0210a424[idx],0x40000000,0x1000,0);
-  *(unsigned char*)(c+0x70c)=0;
-  *(unsigned char*)(c+0x6e5)=0;
+}
+
+int Player::St_DeadHit_Init()
+{
+  func_ov002_020c9e40(((char*)this));
+  mIsBodyClsnEnabled=0;
+  int idx=mStateStep&1;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),data_ov002_0210a424[idx],0x40000000,0x1000,0);
+  mStateArg=0;
+  mStateWork=0;
   func_0200d89c(data_0209f318);
   return 1;
-}
 }

--- a/src/_ZN6Player15St_DeadHit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadHit_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player15St_DeadHit_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -11,65 +17,61 @@ extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void *v);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void *v);
 extern void _Z14ApproachLinearRiii(int *v, int a, int b);
 extern u32 _ZNK6Player14GetBodyModelIDEjb(char *c, u32 a, bool b);
-extern int _ZNK9Animation12WillHitFrameEi(void *anim, int f);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char *c, u32 a, int b, int d, u32 e);
 extern int _ZN6Player12FinishedAnimEv(char *c);
-extern void KillPlayer(void);
 extern void func_ov002_020bedd4(char *c);
 
-extern u8 data_ov002_02109db8[];
-extern u32 data_ov002_0210a07c[];
 extern u8 data_ov002_0211117c;
 }
 
-extern "C" int _ZN6Player15St_DeadHit_MainEv(char *c)
+int Player::St_DeadHit_Main()
 {
     u32 t;
 
-    if (*(u8 *)(c + 0x6de) == 0) {
-        if (*(u8 *)(c + 0x70c) == 0) {
-            if (*(s32 *)(c + 0x640) < 0) {
-                *(s32 *)(c + 0xa8) = -*(s32 *)(c + 0x640) / 3;
-                if (*(s32 *)(c + 0xa8) <= 0x1000)
-                    *(s32 *)(c + 0xa8) = 0;
+    if (mIsAirborne == 0) {
+        if (mStateArg == 0) {
+            if (mPrevVertSpeed < 0) {
+                mVertSpeed = -mPrevVertSpeed / 3;
+                if (mVertSpeed <= 0x1000)
+                    mVertSpeed = 0;
             }
-            t = *(u8 *)(c + 0x6e3) & 0xf0;
+            t = mStateStep & 0xf0;
             if (t == 0 || t == 0x10)
-                func_ov002_020d94cc(c);
-            _ZN5Sound9PlayBank0EjRK7Vector3(*(u32 *)(c + 0x66c) + 0x50, c + 0x74);
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x11, c + 0x74);
-            *(u8 *)(c + 0x70c) = 1;
+                func_ov002_020d94cc(((char *)this));
+            _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType + 0x50, ((char *)this) + 0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x11, ((char *)this) + 0x74);
+            mStateArg = 1;
         }
-        _Z14ApproachLinearRiii((int *)(c + 0x98), 0, 0x1800);
+        _Z14ApproachLinearRiii((int *)((char *)&mHorzSpeed), 0, 0x1800);
     }
 
-    switch (*(u8 *)(c + 0x6e5)) {
+    switch (mStateWork) {
     case 0:
         if (_ZNK9Animation12WillHitFrameEi(
-                (void *)(((s32 *)(c + 0xdc))[_ZNK6Player14GetBodyModelIDEjb(c, *(s32 *)(c + 8) & 0xff, 0)] + 0x50),
-                data_ov002_02109db8[*(u8 *)(c + 0x6e3) & 1]) != 0)
-            *(u8 *)(c + 0x6e5) = 1;
+                (void *)(((s32 *)((char *)&mBodyModels))[_ZNK6Player14GetBodyModelIDEjb(((char *)this), mParam & 0xff, 0)] + 0x50),
+                data_ov002_02109db8[mStateStep & 1]) != 0)
+            mStateWork = 1;
         break;
     case 1:
-        if (*(u8 *)(c + 0x6de) != 0) break;
-        if (*(u8 *)(c + 0x70c) == 0) break;
-        if (*(s32 *)(c + 0x98) != 0) break;
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a07c[*(u8 *)(c + 0x6e3) & 1], 0x40000000, 0x1000, 0);
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0xb, c + 0x74);
-        *(u8 *)(c + 0x6e5) = 2;
+        if (mIsAirborne != 0) break;
+        if (mStateArg == 0) break;
+        if (mHorzSpeed != 0) break;
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), data_ov002_0210a07c[mStateStep & 1], 0x40000000, 0x1000, 0);
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xb, ((char *)this) + 0x74);
+        mStateWork = 2;
         break;
     case 2:
-        if (_ZN6Player12FinishedAnimEv(c) != 0) {
+        if (_ZN6Player12FinishedAnimEv(((char *)this)) != 0) {
             if (data_ov002_0211117c == 0) {
                 KillPlayer();
-                *(u8 *)(c + 0x6e5) = 3;
+                mStateWork = 3;
             }
         }
         break;
     }
 
-    if (*(u8 *)(c + 0x6e5) != 1)
-        func_ov002_020bedd4(c);
-    *(s32 *)(c + 0x640) = *(s32 *)(c + 0xa8);
+    if (mStateWork != 1)
+        func_ov002_020bedd4(((char *)this));
+    mPrevVertSpeed = mVertSpeed;
     return 1;
 }

--- a/src/_ZN6Player15St_DeadPit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_InitEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player15St_DeadPit_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -13,94 +16,94 @@ void HitDeathPlane(int arg);
 void FUN_020299f4(void);
 void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, unsigned int a, int b, int f, unsigned int g);
 void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, char* v);
+}
 
-int _ZN6Player15St_DeadPit_InitEv(char* c)
+int Player::St_DeadPit_Init()
 {
-    func_ov002_020dab14(c);
-    if (*(char**)(c + 0x360) != 0) {
-        int b = (*(u16*)(*(char**)(c + 0x360) + 0xc) == 0xbf);
+    func_ov002_020dab14(((char*)this));
+    if (*(char**)((char*)&mObjInMouth) != 0) {
+        int b = (*(u16*)(*(char**)((char*)&mObjInMouth) + 0xc) == 0xbf);
         if (b) {
-            func_ov002_020d5cec(*(char**)(c + 0x360));
-            *(u16*)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF) &= ~2;
-            *(int*)(*(char**)(c + 0x360) + 0xd0) = 0;
+            func_ov002_020d5cec(*(char**)((char*)&mObjInMouth));
+            *(u16*)(((int)((char*)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+            *(int*)(*(char**)((char*)&mObjInMouth) + 0xd0) = 0;
         }
-        *(u8*)(c + 0x714) = 0;
-        *(int*)(((int)*(char**)(c + 0x360) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x80000;
-        *(int*)(((int)*(char**)(c + 0x360) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x40000;
-        *(int*)(((int)*(char**)(c + 0x360) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x20000;
-        *(char**)(c + 0x360) = 0;
+        mUseAltBodyModel = 0;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x80000;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x40000;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x20000;
+        *(char**)((char*)&mObjInMouth) = 0;
     }
-    func_ov002_020c9e40(c);
+    func_ov002_020c9e40(((char*)this));
     {
         int t = 0;
-        *(u8*)(c + 0x713) = t;
-        *(u8*)(c + 0x6e5) = t;
-        switch (*(u8*)(c + 0x6e3)) {
+        mIsBodyClsnEnabled = t;
+        mStateWork = t;
+        switch (mStateStep) {
         case 0:
             break;
         case 1:
             if (data_0209f2d8 == 1) t = 1;
             if (t == 0) {
                 int a = 2;
-                if (*(int*)(c + 0x664) == 5) a = 0;
+                if (unk_664 == 5) a = 0;
                 HitDeathPlane(a);
             } else {
-                if (*(u8*)(c + 0x6d8) == data_0209f250) FUN_020299f4();
-                *(u16*)(c + 0x6a6) = 0x1e;
+                if (mPlayerNo == data_0209f250) FUN_020299f4();
+                mStateWaitTimer = 0x1e;
             }
-            *(u8*)(c + 0x716) = 1;
+            unk_716 = 1;
             break;
         case 2:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 7, 0x40000000, 0x1000, t);
-            *(int*)(c + 0xa8) = 0xa000;
-            *(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 1;
-            *(u8*)(c + 0x6de) = 1;
-            *(u8*)(c + 0x6df) = 0;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0xb, c + 0x74);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 7, 0x40000000, 0x1000, t);
+            mVertSpeed = 0xa000;
+            *(int*)(((int)((char*)this) + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 1;
+            mIsAirborne = 1;
+            mLandSoundPlayed = 0;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xb, ((char*)this) + 0x74);
             break;
         case 3:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x82, 0x40000000, 0x1000, t);
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x98) = 0;
-            *(u8*)(c + 0x70c) = 0;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x82, 0x40000000, 0x1000, t);
+            mVertSpeed = 0;
+            mHorzSpeed = 0;
+            mStateArg = 0;
             break;
         case 4:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 2, 0x40000000, 0x1000, t);
-            *(u16*)(c + 0x6a4) = 0x64;
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x98) = 0;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0xb, c + 0x74);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 2, 0x40000000, 0x1000, t);
+            mStateTimer = 0x64;
+            mVertSpeed = 0;
+            mHorzSpeed = 0;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xb, ((char*)this) + 0x74);
             break;
         case 5:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 6, 0x40000000, 0x1000, t);
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x98) = 0;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0xb, c + 0x74);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 6, 0x40000000, 0x1000, t);
+            mVertSpeed = 0;
+            mHorzSpeed = 0;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xb, ((char*)this) + 0x74);
             break;
         case 6:
-            *(u16*)(c + 0x6a4) = 0x3c;
-            *(int*)(c + 0xa8) = t;
-            *(int*)(c + 0x98) = t;
-            *(int*)(c + 0x9c) = t;
+            mStateTimer = 0x3c;
+            mVertSpeed = t;
+            mHorzSpeed = t;
+            mVertAccel = t;
             break;
         case 7:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x84, 0x40000000, 0x1000, t);
-            *(int*)(c + 0x9c) = 0;
-            *(int*)(c + 0xa0) = -0x1800;
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x98) = 0;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x34, c + 0x74);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x84, 0x40000000, 0x1000, t);
+            mVertAccel = 0;
+            mTerminalVelocity = -0x1800;
+            mVertSpeed = 0;
+            mHorzSpeed = 0;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x34, ((char*)this) + 0x74);
             break;
         case 8:
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x83, 0x40000000, 0x1000, t);
-            *(int*)(c + 0x9c) = 0;
-            *(int*)(c + 0xa0) = -0x1800;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x83, 0x40000000, 0x1000, t);
+            mVertAccel = 0;
+            mTerminalVelocity = -0x1800;
             break;
         case 9:
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x36, c + 0x74);
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x36, ((char*)this) + 0x74);
             break;
         }
     }
     return 1;
-}
 }

--- a/src/_ZN6Player15St_DeadPit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player15St_DeadPit_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -8,8 +13,6 @@ typedef short s16;
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern void KillPlayer(void);
-extern void func_ov002_020c0108(void* c, int a);
 extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, int* pos, u32 d);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, int* pos);
 extern void Vec3_RotateYAndTranslate(int* out, int* in, s16 angle, int* src);
@@ -20,16 +23,16 @@ extern u8 data_0209f2d8;
 extern int data_ov002_021104fc[];
 }
 
-extern "C" int _ZN6Player15St_DeadPit_MainEv(char* self)
+int Player::St_DeadPit_Main()
 {
-    switch (*(u8*)(self + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
         break;
     case 1: {
         int b = (data_0209f2d8 == 1);
         if (b) {
-            if (*(u16*)(self + 0x6a6) == 0) {
-                _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_021104fc);
+            if (mStateWaitTimer == 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021104fc);
                 return 1;
             }
         }
@@ -37,33 +40,33 @@ extern "C" int _ZN6Player15St_DeadPit_MainEv(char* self)
     }
     case 2:
     case 5:
-        if (*(u8*)(self + 0x6de) == 0) {
-            *(u32*)(self + 0x98) = 0;
-            *(u32*)(self + 0xa8) = 0;
+        if (mIsAirborne == 0) {
+            mHorzSpeed = 0;
+            mVertSpeed = 0;
         }
-        if (*(u8*)(self + 0x6e5) == 0) {
-            if (_ZN6Player12FinishedAnimEv(self) != 0) {
-                *(u8*)(self + 0x6e5) = 1;
+        if (mStateWork == 0) {
+            if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+                mStateWork = 1;
                 KillPlayer();
             }
         }
         break;
     case 3: {
-        func_ov002_020c0108(self, 0);
-        u32 snd = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(u32*)(self + 0x620), 0, 0x10a, (int*)(self + 0x74), 0);
-        int* p = (int*)(((long long)(int)(self + 0x68c)) & 0xFFFFFFFFFFFFFFFFLL);
-        *(u32*)(self + 0x620) = snd;
+        func_ov002_020c0108(((char*)this), 0);
+        u32 snd = _ZN5Sound8PlayLongEjjjRK7Vector3j(mLoopingSoundHandle, 0, 0x10a, (int*)((char*)&mCamSpacePos), 0);
+        int* p = (int*)(((long long)(int)((char*)&mSinkDepth)));
+        mLoopingSoundHandle = snd;
         *p += 0x5000;
-        if (*(u8*)(self + 0x6e5) == 0) {
-            if (*(s32*)(self + 0x68c) >= 0xb4000) {
-                *(u8*)(self + 0x6e5) = 1;
+        if (mStateWork == 0) {
+            if (mSinkDepth >= 0xb4000) {
+                mStateWork = 1;
                 KillPlayer();
             } else {
                 *p += 0x2000;
-                if (*(u8*)(self + 0x70c) == 0) {
-                    if (*(s32*)(self + 0x68c) >= 0x64) {
-                        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(self + 0x6d9), 0x25, (int*)(self + 0x74));
-                        *(u8*)(self + 0x70c) = 1;
+                if (mStateArg == 0) {
+                    if (mSinkDepth >= 0x64) {
+                        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x25, (int*)((char*)&mCamSpacePos));
+                        mStateArg = 1;
                     }
                 }
             }
@@ -75,28 +78,28 @@ extern "C" int _ZN6Player15St_DeadPit_MainEv(char* self)
         src[0] = 0;
         src[1] = -0x1e000;
         src[2] = 0x64000;
-        int* q = *(int**)(self + 0x364);
+        int* q = *(int**)((char*)&mAttachedActor);
         s16 angle = *(s16*)((char*)q + 0x8e);
-        Vec3_RotateYAndTranslate((int*)(self + 0x5c), (int*)((char*)q + 0x5c), angle, src);
-        if (*(u16*)(self + 0x6a4) < 30) {
-            *(u8*)(self + 0x6f5) = 0;
+        Vec3_RotateYAndTranslate((int*)((char*)&mPosX), (int*)((char*)q + 0x5c), angle, src);
+        if (mStateTimer < 30) {
+            mOpacity = 0;
         }
     }
     /* fallthrough */
     case 4:
-        if (*(u16*)(self + 0x6a4) == 1) {
+        if (mStateTimer == 1) {
             KillPlayer();
-            *(u8*)(self + 0x6f5) = 0;
+            mOpacity = 0;
         }
         break;
     case 7:
     case 8:
-        func_ov002_020c9718((u8*)self);
-        if (*(u8*)(self + 0x6e5) == 0) {
-            if (_ZN6Player12FinishedAnimEv(self) != 0) {
-                *(u8*)(self + 0x6e5) = 1;
+        func_ov002_020c9718((u8*)((char*)this));
+        if (mStateWork == 0) {
+            if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+                mStateWork = 1;
                 KillPlayer();
-                *(u8*)(self + 0x706) = 1;
+                mIsUnderwater = 1;
             }
         }
         break;
@@ -104,6 +107,6 @@ extern "C" int _ZN6Player15St_DeadPit_MainEv(char* self)
         break;
     }
 
-    func_ov002_020bedd4(self);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player15St_Grabbed_InitEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_InitEv.cpp
@@ -1,17 +1,22 @@
 //cpp
+// @symbol _ZN6Player15St_Grabbed_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020da9d4(void* c);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
-int _ZN6Player15St_Grabbed_InitEv(char* c){
-  func_ov002_020da9d4(c);
-  *(int*)(int)(((unsigned long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
-  *(unsigned char*)(c+0x713) = 0;
-  *(unsigned char*)(c+0x716) = 1;
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 6, (void*)(c+0x74));
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x71, 0, 0x1000, 0);
-  *(unsigned char*)(c+0x717) = 1;
-  *(unsigned char*)(c+0x6e3) = 0;
-  return 1;
 }
+
+int Player::St_Grabbed_Init()
+{
+  func_ov002_020da9d4(((char*)this));
+  *(int*)(int)(((unsigned long long)(int)((char*)&mBodyClsnFlags)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
+  mIsBodyClsnEnabled = 0;
+  unk_716 = 1;
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, (void*)((char*)&mCamSpacePos));
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x71, 0, 0x1000, 0);
+  unk_717 = 1;
+  mStateStep = 0;
+  return 1;
 }

--- a/src/_ZN6Player15St_Grabbed_MainEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_MainEv.cpp
@@ -1,15 +1,18 @@
 //cpp
+// @symbol _ZN6Player15St_Grabbed_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 
-extern "C" int func_ov002_020beb38(char* c);
-extern "C" void func_ov002_020db54c(char* self, int a, int b, int c);
 extern "C" void func_ov002_020bedd4(char* self);
 extern "C" void _ZN6Player9DropActorEv(char* a);
 extern "C" unsigned int _ZNK6Player14GetBodyModelIDEjb(char* self, unsigned int a, int b);
 
-extern "C" int _ZN6Player15St_Grabbed_MainEv(char* self)
+int Player::St_Grabbed_Main()
 {
     char* grab;
     u8* p;
@@ -18,38 +21,38 @@ extern "C" int _ZN6Player15St_Grabbed_MainEv(char* self)
     volatile int* pRate;
     char* model;
 
-    *(int*)(self + 0x684) = *(int*)(self + 0x60);
-    grab = *(char**)(self + 0x35c);
+    mPeakY = mPosY;
+    grab = *(char**)((char*)&unk_35c);
     if (grab != 0) {
         int isBob = (*(u16*)(grab + 0xc) == 0xbf);
         if (isBob != 0) {
-            ret = func_ov002_020beb38(self);
+            ret = func_ov002_020beb38(((char*)this));
             if (ret != 0) {
-                p = (u8*)(int)(((long long)(int)(self + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+                p = (u8*)(int)(((long long)(int)((char*)&mStateStep)));
                 *p = (u8)(*p + ret);
-                *(u16*)(self + 0x6a4) = 6;
-                if ((s16)(*(u8*)(self + 0x6e3) - ret) < 0) {
-                    _ZN6Player9DropActorEv(*(char**)(self + 0x35c));
-                    func_ov002_020db54c(self, 0x10000, 0x10000, *(s16*)(self + 0x8e));
+                mStateTimer = 6;
+                if ((s16)(mStateStep - ret) < 0) {
+                    _ZN6Player9DropActorEv(*(char**)((char*)&unk_35c));
+                    func_ov002_020db54c(((char*)this), 0x10000, 0x10000, mAngleY);
                     return 1;
                 }
             }
         }
     }
 
-    if (*(u16*)(self + 0x6a4) != 0) {
-        id = _ZNK6Player14GetBodyModelIDEjb(self, *(unsigned int*)(self + 8) & 0xff, 0);
-        model = *(char**)(self + (id << 2) + 0xdc);
+    if (mStateTimer != 0) {
+        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        model = *(char**)(((char*)this) + (id << 2) + 0xdc);
         pRate = (int*)(model + 0x50);
         pRate = (int*)((char*)pRate + 0xc);
         *pRate = 0x4000;
     } else {
-        id = _ZNK6Player14GetBodyModelIDEjb(self, *(unsigned int*)(self + 8) & 0xff, 0);
-        model = *(char**)(self + (id << 2) + 0xdc);
+        id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        model = *(char**)(((char*)this) + (id << 2) + 0xdc);
         pRate = (int*)(model + 0x50);
         pRate = (int*)((char*)pRate + 0xc);
         *pRate = 0x1000;
     }
-    func_ov002_020bedd4(self);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player15St_Hurt_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Hurt_CleanupEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player15St_Hurt_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // Player::St_Hurt_Cleanup - clear flag bit 0x80 in the u32 at this+0xb0, return 1.
 // The u64-mask launder forces the base to materialize (add r2,this,#0xb0) so the
 // load/store reuse it, matching the ROM instead of folding the offset into ldr/str.
-extern "C" {
-int _ZN6Player15St_Hurt_CleanupEv(char *c)
+
+int Player::St_Hurt_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80;
+    *(unsigned int *)(((long long)(int)((char *)&unk_0b0))) &= ~0x80;
     return 1;
-}
 }

--- a/src/_ZN6Player15St_Respawn_MainEv.cpp
+++ b/src/_ZN6Player15St_Respawn_MainEv.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol _ZN6Player15St_Respawn_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern "C" {
-extern void FUN_02029980(void);
-extern void FUN_02029934(void);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 a, int b, int f, u32 g);
 extern int _ZN6Player12FinishedAnimEv(void *c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void *c, void *s);
@@ -14,44 +17,44 @@ extern u8 data_0209f250;
 extern int data_ov002_02110154[];
 }
 
-extern "C" int _ZN6Player15St_Respawn_MainEv(char *c)
+int Player::St_Respawn_Main()
 {
-    switch (*(u8 *)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0: {
-        u16 t = *(u16 *)(c + 0x6a4);
+        u16 t = mStateTimer;
         if (t != 0) {
             if (t == 1) {
-                *(int *)(c + 0x9c) = -0x4000;
-                if (*(u8 *)(c + 0x6d8) == data_0209f250) {
+                mVertAccel = -0x4000;
+                if (mPlayerNo == data_0209f250) {
                     FUN_02029980();
-                    *(u16 *)(c + 0x6a6) = 0x26;
+                    mStateWaitTimer = 0x26;
                 }
             }
         } else {
-            if (*(u8 *)(c + 0x6de) == 0) {
+            if (mIsAirborne == 0) {
                 u32 zero = 0;
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x55, 0x40000000, 0x1000, zero);
-                *(u8 *)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0x55, 0x40000000, 0x1000, zero);
+                *(u8 *)(((int)((char *)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
             }
         }
         break;
     }
     case 1:
-        if (_ZN6Player12FinishedAnimEv(c) != 0) {
+        if (_ZN6Player12FinishedAnimEv(((char *)this)) != 0) {
             int z = 0;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, z, 0x1000, z);
-            *(u8 *)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0x47, z, 0x1000, z);
+            *(u8 *)(((int)((char *)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
         }
         break;
     case 2:
-        if (*(u16 *)(c + 0x6a6) == 0) {
-            if (*(u8 *)(c + 0x6d8) == data_0209f250) {
+        if (mStateWaitTimer == 0) {
+            if (mPlayerNo == data_0209f250) {
                 FUN_02029934();
             }
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+            _ZN6Player11ChangeStateERNS_5StateE(((char *)this), data_ov002_02110154);
         }
         break;
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char *)this));
     return 1;
 }

--- a/src/_ZN6Player15St_Spin_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Spin_CleanupEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player15St_Spin_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // Player::St_Spin_Cleanup - clear flag bit 0x20 in the u32 at this+0x2ec, return 1.
 // The u64-mask launder forces the base to materialize (add r2,this,#0x2ec) so the
 // load/store reuse it, matching the ROM instead of folding the offset into ldr/str.
-extern "C" {
-int _ZN6Player15St_Spin_CleanupEv(char *c)
+
+int Player::St_Spin_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
     return 1;
-}
 }

--- a/src/_ZN6Player15St_Swallow_InitEv.cpp
+++ b/src/_ZN6Player15St_Swallow_InitEv.cpp
@@ -1,23 +1,28 @@
 //cpp
+// @symbol _ZN6Player15St_Swallow_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State; extern State data_ov002_02110034;
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,State*);
 extern int func_ov002_020c9e40(void*);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player15St_Swallow_InitEv(char* c){
-  if(*(void**)(c+0x360)){
-    void* o=*(void**)(c+0x360);
+}
+
+int Player::St_Swallow_Init()
+{
+  if(*(void**)((char*)&mObjInMouth)){
+    void* o=*(void**)((char*)&mObjInMouth);
     int(*f)(void*)=*(int(**)(void*))(*(char**)o+0x48);
     if(f(o)==4){
-      func_ov002_020c9e40(c);
+      func_ov002_020c9e40(((char*)this));
     }
-    int eq = *(unsigned short*)(*(char**)(c+0x360)+0xc)==0xbf;
+    int eq = *(unsigned short*)(*(char**)((char*)&mObjInMouth)+0xc)==0xbf;
     if(eq!=0){
-      _ZN6Player11ChangeStateERNS_5StateE(c,&data_ov002_02110034);
+      _ZN6Player11ChangeStateERNS_5StateE(((char*)this),&data_ov002_02110034);
       return 1;
     }
   }
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x70,0x40000000,0x1000,0);
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x70,0x40000000,0x1000,0);
   return 1;
-}
 }

--- a/src/_ZN6Player15St_Swallow_MainEv.cpp
+++ b/src/_ZN6Player15St_Swallow_MainEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player15St_Swallow_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern unsigned int _ZNK6Player14GetBodyModelIDEjb(void* c, unsigned int a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
-extern void func_ov002_020d71a0(char* c);
-extern int func_ov002_020d5ab4(void* p);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, void* v);
-extern void func_ov002_020d6368(char* c);
 extern int func_ov002_020ceaf4(char* c);
 extern int _ZN6Player12FinishedAnimEv(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
@@ -14,64 +16,64 @@ extern void func_ov002_020bedd4(char* c);
 extern int data_0209ee90[];
 extern int data_ov002_0211067c;
 extern int data_ov002_0211013c;
+}
 
-int _ZN6Player15St_Swallow_MainEv(char* c)
+int Player::St_Swallow_Main()
 {
     void* p360;
 
-    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c + 8) & 0xff, 0) << 2) + 0xdc)) + 0x50, 3)) {
-        func_ov002_020d71a0(c);
+    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc)) + 0x50, 3)) {
+        func_ov002_020d71a0(((char*)this));
         goto L65ec;
     }
-    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c + 8) & 0xff, 0) << 2) + 0xdc)) + 0x50, 7) == 0) {
+    if (_ZNK9Animation12WillHitFrameEi((char*)(*(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc)) + 0x50, 7) == 0) {
         goto L65ec;
     }
 
-    p360 = *(void**)(c + 0x360);
+    p360 = *(void**)((char*)&mObjInMouth);
     if (p360 == 0) goto L65e4;
     {
         int b = (*(unsigned short*)((char*)p360 + 0xc) == 0xbf);
         if (b == 0) goto L653c;
     }
-    *(short*)((char*)p360 + 0x8c) = *(short*)(c + 0x8c);
-    *(short*)((char*)p360 + 0x8e) = *(short*)(c + 0x8e);
-    *(short*)((char*)p360 + 0x90) = *(short*)(c + 0x90);
-    func_ov002_020d5ab4(*(void**)(c + 0x360));
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, c + 0x74);
+    *(short*)((char*)p360 + 0x8c) = mAngX;
+    *(short*)((char*)p360 + 0x8e) = mAngleY;
+    *(short*)((char*)p360 + 0x90) = mAngZ;
+    func_ov002_020d5ab4(*(void**)((char*)&mObjInMouth));
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, ((char*)this) + 0x74);
     goto L65e4;
 
 L653c:
-    (*(void (**)(void*, char*))(*(char**)p360 + 0x4c))(p360, c);
+    (*(void (**)(void*, char*))(*(char**)p360 + 0x4c))(p360, ((char*)this));
     {
-        void* q = *(void**)(c + 0x360);
+        void* q = *(void**)((char*)&mObjInMouth);
         if ((*(int (**)(void*))(*(char**)q + 0x48))(q) == 1) goto L65e4;
     }
-    if ((unsigned short)(*(unsigned short*)(c + 0x6ce) & 0x1000)) goto L65e4;
+    if ((unsigned short)(mStateFlags & 0x1000)) goto L65e4;
     {
         unsigned char flag = 0;
-        int b_c2 = (*(unsigned short*)((char*)*(void**)(c + 0x360) + 0xc) == 0xc2);
+        int b_c2 = (*(unsigned short*)((char*)*(void**)((char*)&mObjInMouth) + 0xc) == 0xc2);
         if (b_c2 || *(int*)((char*)data_0209ee90 + 0x238) != 0) {
             flag |= 1;
         }
-        *(unsigned char*)(((long long)(int)(c + 0x704)) & 0xFFFFFFFFFFFFFFFFLL) |= (flag + 1);
+        *(unsigned char*)(((long long)(int)((char*)&mEggParams))) |= (flag + 1);
     }
-    func_ov002_020d6368(c);
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, c + 0x74);
+    func_ov002_020d6368(((char*)this));
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, ((char*)this) + 0x74);
 
 L65e4:
-    *(void**)(c + 0x360) = 0;
+    *(void**)((char*)&mObjInMouth) = 0;
 L65ec:
-    if (*(unsigned char*)(c + 0x706) != 0) {
-        *(int*)(((long long)(int)(c + 0xa8)) & 0xFFFFFFFFFFFFFFFFLL) += func_ov002_020ceaf4(c);
+    if (mIsUnderwater != 0) {
+        *(int*)(((long long)(int)((char*)&mVertSpeed))) += func_ov002_020ceaf4(((char*)this));
     }
-    if (_ZN6Player12FinishedAnimEv(c)) {
-        if (*(unsigned char*)(c + 0x706) != 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211067c);
+    if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+        if (mIsUnderwater != 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_0211067c);
         } else {
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_0211013c);
         }
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
-}
 }

--- a/src/_ZN6Player15St_Swim_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Swim_CleanupEv.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN6Player15St_Swim_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020bd8c0(void*,int);
-int _ZN6Player15St_Swim_CleanupEv(char* c){
-  if(*(unsigned char*)(c+0x6f7)!=0){
-    *(char*)(c+0x6f7)=0;
-    func_ov002_020bd8c0(c,0x33);
+}
+
+int Player::St_Swim_Cleanup()
+{
+  if(unk_6f7!=0){
+    unk_6f7=0;
+    func_ov002_020bd8c0(((char*)this),0x33);
   }
   return 1;
-}
 }

--- a/src/_ZN6Player15St_Wait_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Wait_CleanupEv.cpp
@@ -1,14 +1,18 @@
 //cpp
+// @symbol _ZN6Player15St_Wait_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern unsigned char data_0209f2d8;
 extern void* data_0209f318;
 extern int data_0209caa0[];
+}
 
-int _ZN6Player15St_Wait_CleanupEv(char* c)
+int Player::St_Wait_Cleanup()
 {
     void* r4 = data_0209f318;
     (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
-    *(unsigned char*)(c+0x721) = 0;
+    mSleepStage = 0;
     do {
         unsigned char v = data_0209f2d8;
         int b0 = (v == 1);
@@ -17,11 +21,10 @@ int _ZN6Player15St_Wait_CleanupEv(char* c)
                 int b1 = (v == 2);
                 if (b1 == 0) break;
             }
-            if (*(unsigned char*)(c+0x727) == 0xf) *(unsigned char*)(c+0x743) = 0;
-            *(unsigned char*)(c+0x727) = 0;
-            *(unsigned char*)(c+0x728) = 0;
+            if (unk_727 == 0xf) unk_743 = 0;
+            unk_727 = 0;
+            unk_728 = 0;
         }
     } while (0);
     return 1;
-}
 }

--- a/src/_ZN6Player16CleanupResourcesEv.cpp
+++ b/src/_ZN6Player16CleanupResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef signed char s8;
@@ -29,170 +34,82 @@ extern char data_ov002_0210d9a8[];
 extern char data_ov002_0210d9c0[];
 extern char data_ov002_0210da38[];
 extern char data_ov002_0210da40[];
-extern char data_ov002_0210e1c8[];
-extern char data_ov002_0210e1d0[];
-extern char data_ov002_0210e1e0[];
-extern char data_ov002_0210e1e8[];
-extern char data_ov002_0210e230[];
-extern char data_ov002_0210e250[];
-extern char data_ov002_0210e270[];
-extern char data_ov002_0210e288[];
-extern char data_ov002_0210e2f0[];
-extern char data_ov002_0210e3b0[];
-extern char data_ov002_0210e3c8[];
 extern char data_ov002_0210e3d8[];
-extern char data_ov002_0210e3e0[];
-extern char data_ov002_0210e3e8[];
-extern char data_ov002_0210e400[];
-extern char data_ov002_0210e408[];
-extern char data_ov002_0210e430[];
-extern char data_ov002_0210e438[];
-extern char data_ov002_0210e450[];
-extern char data_ov002_0210e458[];
-extern char data_ov002_0210e460[];
-extern char data_ov002_0210e478[];
-extern char data_ov002_0210e4b8[];
-extern char data_ov002_0210e4c0[];
-extern char data_ov002_0210e4d0[];
-extern char data_ov002_0210e4e8[];
-extern char data_ov002_0210e4f0[];
-extern char data_ov002_0210e500[];
-extern char data_ov002_0210e538[];
-extern char data_ov002_0210e540[];
-extern char data_ov002_0210e588[];
-extern char data_ov002_0210e600[];
-extern char data_ov002_0210e620[];
-extern char data_ov002_0210e640[];
-extern char data_ov002_0210e660[];
-extern char data_ov002_0210e670[];
-extern char data_ov002_0210e680[];
-extern char data_ov002_0210e690[];
-extern char data_ov002_0210e6a0[];
-extern char data_ov002_0210e6b8[];
-extern char data_ov002_0210e6c0[];
-extern char data_ov002_0210e6e0[];
-extern char data_ov002_0210e6f8[];
-extern char data_ov002_0210e708[];
-extern char data_ov002_0210e728[];
-extern char data_ov002_0210e738[];
 extern char data_ov002_0210e750[];
-extern char data_ov002_0210e758[];
-extern char data_ov002_0210e770[];
-extern char data_ov002_0210e780[];
-extern char data_ov002_0210e788[];
-extern char data_ov002_0210e790[];
-extern char data_ov002_0210e798[];
-extern char data_ov002_0210e7a8[];
-extern char data_ov002_0210e7b0[];
-extern char data_ov002_0210e7e8[];
-extern char data_ov002_0210e7f0[];
-extern char data_ov002_0210e800[];
-extern char data_ov002_0210e818[];
-extern char data_ov002_0210e898[];
 extern char data_ov002_0210e8d0[];
-extern char data_ov002_0210e8e8[];
-extern char data_ov002_0210e910[];
-extern char data_ov002_0210e958[];
-extern char data_ov002_0210e9d0[];
-extern char data_ov002_0210e9e8[];
-extern char data_ov002_0210ea10[];
-extern char data_ov002_0210ea30[];
-extern char data_ov002_0210ea70[];
-extern char data_ov002_0210ea88[];
-extern char data_ov002_0210eac8[];
-extern char data_ov002_0210eaf0[];
-extern char data_ov002_0210eb00[];
-extern char data_ov002_0210eb10[];
 extern char data_ov002_0210eb20[];
-extern char data_ov002_0210eb38[];
-extern char data_ov002_0210eb58[];
-extern char data_ov002_0210eb70[];
-extern char data_ov002_0210eb88[];
-extern char data_ov002_0210eb90[];
-extern char data_ov002_0210eb98[];
-extern char data_ov002_0210eba8[];
 extern char data_ov002_0210ebb8[];
-extern char data_ov002_0210ebc8[];
 extern char data_ov002_0210ebd8[];
-extern char data_ov002_0210ec00[];
-extern char data_ov002_0210ec10[];
-extern char data_ov002_0210ec38[];
-extern char data_ov002_0210ec40[];
-extern char data_ov002_0210ec50[];
-extern char data_ov002_0210ec60[];
-extern char data_ov002_0210ec98[];
-extern char data_ov002_0210eca8[];
-extern char data_ov002_0210ecb8[];
 extern char data_ov002_02110aa4[];
 }
 
-extern "C" int _ZN6Player16CleanupResourcesEv(char *c)
+int Player::CleanupResources()
 {
     int i;
     u32 b;
 
-    func_ov002_020bdd2c(c);
-    func_ov002_020bdef0(c);
-    func_ov002_020bdd9c(c);
-    func_ov002_020e032c(c);
+    func_ov002_020bdd2c(((char *)this));
+    func_ov002_020bdef0(((char *)this));
+    func_ov002_020bdd9c(((char *)this));
+    func_ov002_020e032c(((char *)this));
     for (i = 0; i < 4; i++) {
         int j;
-        VB *p = *(VB **)(c + i * 4 + 0xdc);
+        VB *p = *(VB **)(((char *)this) + i * 4 + 0xdc);
         if (p != 0) {
             if (p != 0)
                 p->v1();
         }
-        p = *(VB **)(c + i * 4 + 0x154);
+        p = *(VB **)(((char *)this) + i * 4 + 0x154);
         if (p != 0) {
             if (p != 0)
                 p->v1();
         }
         j = i + 4;
-        p = *(VB **)(c + j * 4 + 0x154);
+        p = *(VB **)(((char *)this) + j * 4 + 0x154);
         if (p != 0) {
             if (p != 0)
                 p->v1();
         }
         {
-            int q = *(int *)(c + i * 4 + 0x27c);
+            int q = *(int *)(((char *)this) + i * 4 + 0x27c);
             if (q != 0)
                 func_0203cbc0(q);
-            q = *(int *)(c + i * 4 + 0x28c);
+            q = *(int *)(((char *)this) + i * 4 + 0x28c);
             if (q != 0)
                 func_0203cbc0(q);
-            q = *(int *)(c + j * 4 + 0x28c);
+            q = *(int *)(((char *)this) + j * 4 + 0x28c);
             if (q != 0)
                 func_0203cbc0(q);
         }
     }
     {
-        VB *p = *(VB **)(c + 0xec);
+        VB *p = *(VB **)((char *)&unk_0ec);
         if (p != 0) {
             if (p != 0)
                 p->v1();
         }
-        p = *(VB **)(c + 0x1d8);
+        p = *(VB **)((char *)&unk_1d8);
         if (p != 0) {
             if (p != 0)
                 p->v1();
         }
     }
     {
-        int q = *(int *)(c + 0x578);
+        int q = unk_578;
         if (q != 0)
             func_02073244(q, 0xc, 8, func_020072c0);
-        q = *(int *)(c + 0x57c);
+        q = unk_57c;
         if (q != 0)
             func_0203cbc0(q);
-        q = *(int *)(c + 0x588);
+        q = mHeldObjQueue;
         if (q != 0)
             func_0203cbc0(q);
     }
-    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[*(int *)(c + 0x63c) + (*(int *)(c + 8) & 3)]);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + (mParam & 3)]);
     b = data_0209f2d8;
     b = b == 1;
     if (b != false_)
-        func_ov002_020bebd4(c);
+        func_ov002_020bebd4(((char *)this));
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec50);
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ebb8);
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec60);
@@ -291,20 +208,20 @@ extern "C" int _ZN6Player16CleanupResourcesEv(char *c)
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210ec00);
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e728);
     }
-    if (*(u8 *)(c + 0x718) & 1)
+    if (mLoadedResourceFlags & 1)
         UnloadSilverStarAndNumber();
-    if (*(u8 *)(c + 0x718) & 2)
+    if (mLoadedResourceFlags & 2)
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210da40);
-    if (*(u8 *)(c + 0x718) & 4)
+    if (mLoadedResourceFlags & 4)
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9a0);
-    if (*(u8 *)(c + 0x718) & 8)
+    if (mLoadedResourceFlags & 8)
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210d9c0);
-    if (*(u8 *)(c + 0x718) & 0x10)
-        UnloadKeyModels(*(s8 *)(c + 0x719));
+    if (mLoadedResourceFlags & 0x10)
+        UnloadKeyModels(unk_719);
     b = data_0209f2d8;
     b = b == 1;
     if (b == false_) {
-        if (*(u8 *)(c + 0x718) & 0x20) {
+        if (mLoadedResourceFlags & 0x20) {
             _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e6f8);
             _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7b0);
             _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e780);
@@ -312,11 +229,11 @@ extern "C" int _ZN6Player16CleanupResourcesEv(char *c)
     } else {
         _ZN13SharedFilePtr7ReleaseEv(data_ov002_0210e7b0);
     }
-    if (*(u8 *)(c + 0x718) & 0x40) {
-        u32 idx = *(u8 *)(c + 0x6dd);
-        if (idx == (u32)*(int *)(c + 8))
-            idx = *(u8 *)(c + 0x6dc);
-        _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[*(int *)(c + 0x63c) + idx]);
+    if (mLoadedResourceFlags & 0x40) {
+        u32 idx = mHatCharacter;
+        if (idx == (u32)mParam)
+            idx = unk_6dc;
+        _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[mCharFileBase + idx]);
     }
     return 1;
 }

--- a/src/_ZN6Player16IncMegaKillCountEv.cpp
+++ b/src/_ZN6Player16IncMegaKillCountEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-
+// @symbol _ZN6Player16IncMegaKillCountEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 struct Vec3
 {
   int x;
@@ -7,10 +11,9 @@ struct Vec3
   int z;
 };
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void *v);
-extern void GiveLives(int delta);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vec3 *pos, void *rot, int a, int b);
-extern void func_ov002_020f0e54(char *a, char *b);
-extern "C" void _ZN6Player16IncMegaKillCountEv(char *c)
+
+void Player::IncMegaKillCount()
 {
   struct Vec3 v;
   char *new_var2;
@@ -19,27 +22,27 @@ extern "C" void _ZN6Player16IncMegaKillCountEv(char *c)
   char *st;
   int y;
   char *new_var;
-  if ((*((unsigned char *) (c + 0x703))) == 0)
+  if ((*((unsigned char *) ((char *)&mIsMega))) == 0)
   {
     return;
   }
-  ++(*((unsigned short *) (((int) (c + 0x6d0)) & 0xFFFFFFFFFFFFFFFFLL)));
+  ++(*((unsigned short *) (((int) ((char *)&unk_6d0)) & 0xFFFFFFFFFFFFFFFFLL)));
   new_var3 = -1;
-  st = c;
+  st = ((char *)this);
   st = st + 0x600;
   if ((*((unsigned short *) (st + 0xd0))) >= 8)
   {
     *((unsigned short *) (st + 0xd0)) = 8;
-    _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, c + 0x74);
+    _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, ((char *)this) + 0x74);
     GiveLives(1);
   }
-  v.x = *((int *) (c + 0x5c));
-  y = *((int *) (c + 0x60));
+  v.x = *((int *) ((char *)&mPosX));
+  y = *((int *) ((char *)&mPosY));
   v.y = y;
-  new_var = c;
+  new_var = ((char *)this);
   v.z = *((int *) (new_var + 0x64));
   v.y = y + 0x190000;
-  new_var2 = (char *) _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x14b, *((unsigned short *) ((c + 0x600) + 0xd0)), &v, 0, *((signed char *) (c + 0xcc)), new_var3);
+  new_var2 = (char *) _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x14b, *((unsigned short *) (((char *)&unk_600) + 0xd0)), &v, 0, *((signed char *) ((char *)&mAreaId)), new_var3);
   a = new_var2;
   if (a == 0)
   {

--- a/src/_ZN6Player16InitWingFeathersEb.cpp
+++ b/src/_ZN6Player16InitWingFeathersEb.cpp
@@ -1,23 +1,31 @@
 //cpp
+// @symbol _ZN6Player16InitWingFeathersEb
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern void func_ov002_020bdd2c(void* c);
 extern void func_ov002_020bd9ec(void* c, unsigned r1);
 extern void func_ov002_020c43c4(void* c, int r1);
 extern unsigned char data_0209f2d8[];
-void _ZN6Player16InitWingFeathersEb(char* c, int b) {
+}
+
+void Player::InitWingFeathers(bool b_)
+{
+    int b = (int)b_;
+
     int t0 = (data_0209f2d8[0] == 1);
     if (!t0) {
-        if (*(int*)(c+8) != 0) return;
+        if (mParam != 0) return;
     }
-    func_ov002_020bdd2c(c);
-    *(unsigned char*)(c+0x6ff) = 1;
-    *(short*)(c+0x600+0xae) = 0x708;
+    func_ov002_020bdd2c(((char*)this));
+    mHasWings = 1;
+    *(short*)(((char*)this)+0x600+0xae) = 0x708;
     {
         int t1 = (data_0209f2d8[0] == 1);
-        if (!t1) func_ov002_020bd9ec(c, 0x33);
-        else func_ov002_020bd9ec(c, 0x4e);
+        if (!t1) func_ov002_020bd9ec(((char*)this), 0x33);
+        else func_ov002_020bd9ec(((char*)this), 0x4e);
     }
     if (b == 0) return;
-    func_ov002_020c43c4(c, 1);
-}
+    func_ov002_020c43c4(((char*)this), 1);
 }

--- a/src/_ZN6Player16IsInsideOfCannonEv.cpp
+++ b/src/_ZN6Player16IsInsideOfCannonEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN6Player16IsInsideOfCannonEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_021102d4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player16IsInsideOfCannonEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
-  return *(unsigned char*)(c+0x6e3)!=2 ? 1 : 0;
 }
+
+int Player::IsInsideOfCannon()
+{
+  if(!_ZN6Player7IsStateERNS_5StateE(((char*)this), &data_ov002_021102d4)) return 0;
+  return mStateStep!=2 ? 1 : 0;
 }

--- a/src/_ZN6Player16SetRealCharacterEj.cpp
+++ b/src/_ZN6Player16SetRealCharacterEj.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player16SetRealCharacterEj
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_ModelAnim2.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned int u32;
 typedef unsigned char u8;
 
@@ -7,42 +13,41 @@ struct SharedFilePtr;
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);
 extern "C" void _ZN6Player18SetNewHatCharacterEjjb(void *self, u32 a, u32 b, bool c);
 extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr &f);
-extern "C" void func_ov002_020e6330(void *self);
 extern "C" void _ZN6Player4HealEi(void *self, int hp);
 extern "C" u32 _ZNK6Player14GetBodyModelIDEjb(void *self, u32 a, bool b);
-extern "C" void _ZN10ModelAnim24CopyERKS_Pcj(void *self, void *src, char *p, u32 n);
-extern "C" void _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(void *self, u32 a, int b, int c, unsigned short d);
 
 extern SharedFilePtr *data_ov002_020ff480[];
 extern u8 data_02092128[];
 extern u8 data_0209caa0[];
 
-extern "C" void _ZN6Player16SetRealCharacterEj(char *self, u32 chr)
+void Player::SetRealCharacter(unsigned int chr_)
 {
-    u32 cur = *(u32 *)(self + 8);
-    u32 base = *(u32 *)(self + 0x63c);
+    u32 chr = (u32)chr_;
+
+    u32 cur = mParam;
+    u32 base = mCharFileBase;
     u32 m1, m2;
 
     _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[base + (cur & 3)]);
-    _ZN6Player18SetNewHatCharacterEjjb(self, chr, 0, 1);
-    *(u32 *)(self + 8) = chr;
-    *(u8 *)(self + 0x6d9) = (u8)chr;
-    data_02092128[*(u8 *)(self + 0x6d8)] = (u8)*(u32 *)(self + 8);
-    data_0209caa0[0x41] = (u8)*(u32 *)(self + 8);
-    _ZN9Animation8LoadFileER13SharedFilePtr(*data_ov002_020ff480[*(u32 *)(self + 0x63c) + (*(u32 *)(self + 8) & 3)]);
-    func_ov002_020e6330(self);
-    _ZN6Player4HealEi(self, 0x880);
-    *(unsigned short *)(self + 0x73c) = 0;
+    _ZN6Player18SetNewHatCharacterEjjb(((char *)this), chr, 0, 1);
+    mParam = chr;
+    mCharacter = (u8)chr;
+    data_02092128[mPlayerNo] = (u8)mParam;
+    data_0209caa0[0x41] = (u8)mParam;
+    _ZN9Animation8LoadFileER13SharedFilePtr(*data_ov002_020ff480[mCharFileBase + (mParam & 3)]);
+    func_ov002_020e6330(((char *)this));
+    _ZN6Player4HealEi(((char *)this), 0x880);
+    unk_73c = 0;
 
-    m1 = _ZNK6Player14GetBodyModelIDEjb(self, chr, 0);
-    m2 = _ZNK6Player14GetBodyModelIDEjb(self, *(u32 *)(self + 8) & 0xff, 0);
+    m1 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), chr, 0);
+    m2 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), mParam & 0xff, 0);
     _ZN10ModelAnim24CopyERKS_Pcj(
-        *(void **)(self + m1 * 4 + 0xdc),
-        *(void **)(self + m2 * 4 + 0xdc),
-        *(char **)((char *)data_ov002_020ff480[*(u32 *)(self + 0x63c) + chr] + 4),
+        *(void **)(((char *)this) + m1 * 4 + 0xdc),
+        *(void **)(((char *)this) + m2 * 4 + 0xdc),
+        *(char **)((char *)data_ov002_020ff480[mCharFileBase + chr] + 4),
         0);
-    m1 = _ZNK6Player14GetBodyModelIDEjb(self, chr, 0);
+    m1 = _ZNK6Player14GetBodyModelIDEjb(((char *)this), chr, 0);
     _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(
-        *(void **)(self + m1 * 4 + 0xdc),
+        *(void **)(((char *)this) + m1 * 4 + 0xdc),
         *(int *)((char *)data_ov002_020ff480[chr + 0xc4] + 4), 0, 0x1000, 0);
 }

--- a/src/_ZN6Player16St_BurnLava_InitEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_InitEv.cpp
@@ -1,27 +1,31 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN6Player16St_BurnLava_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int data_ov002_021100f4[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-extern int func_ov006_020e3078(void*,int*);
 extern int func_ov002_020d91e0(void*,int,int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player16St_BurnLava_InitEv(char* c){
-  *(char*)(c+0x712)=1;
-  *(char*)(c+0x6e1)=0;
-  *(char*)(c+0x6de)=1;
-  *(char*)(c+0x6df)=0;
-  *(char*)(c+0x708)=1;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x16,0,0x1000,0);
-  *(int*)(c+0x98)=0;
-  *(int*)(c+0xa8)=0x64000;
-  *(char*)(c+0x6e5)=0;
-  *(char*)(c+0x6e3)=0;
-  if(func_ov006_020e3078(c,data_ov002_021100f4)==0){
-    *(char*)(c+0x70c)=0;
-  }
-  func_ov002_020d91e0(c,0x300,1);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x23,(struct Vector3*)(c+0x74));
-  return 1;
 }
+
+int Player::St_BurnLava_Init()
+{
+  mIsInAirState=1;
+  mJumpComboStage=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  mIsTakingDamage=1;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x16,0,0x1000,0);
+  mHorzSpeed=0;
+  mVertSpeed=0x64000;
+  mStateWork=0;
+  mStateStep=0;
+  if(func_ov006_020e3078(((char*)this),data_ov002_021100f4)==0){
+    mStateArg=0;
+  }
+  func_ov002_020d91e0(((char*)this),0x300,1);
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x23,(struct Vector3*)((char*)&mCamSpacePos));
+  return 1;
 }

--- a/src/_ZN6Player16St_DebugFly_MainEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player16St_DebugFly_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned int u32;
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -14,32 +17,32 @@ extern char data_0209f49c[];
 extern char data_020a0e5a[];
 extern int data_ov002_0211013c;
 
-extern "C" int _ZN6Player16St_DebugFly_MainEv(char *self)
+int Player::St_DebugFly_Main()
 {
     u32 idx;
     u16 flags;
 
-    *(int *)(self + 0x98) = 0;
-    *(int *)(self + 0xa8) = 0;
-    *(u8 *)(self + 0x6e9) = 0;
+    mHorzSpeed = 0;
+    mVertSpeed = 0;
+    mClsnFlags = 0;
 
     if (*(s16 *)(data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-        *(u16 *)(self + 0x94) = *(s16 *)(self + 0x6d2);
-        *(int *)(self + 0x98) = func_ov002_020bf224((int)self, 0x50000, 0);
+        mTargetAngleY = mDesiredAngleY;
+        mHorzSpeed = func_ov002_020bf224((int)((char *)this), 0x50000, 0);
     }
 
     idx = data_020a0e40;
     flags = *(u16 *)(data_0209f49c + idx * 0x18);
     if (flags & 2) {
-        *(int *)(((long long)(int)(self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x28000;
+        *(int *)(((long long)(int)((char *)&mPosY))) += 0x28000;
     } else if (flags & 1) {
-        *(int *)(((long long)(int)(self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x28000;
+        *(int *)(((long long)(int)((char *)&mPosY))) -= 0x28000;
     }
 
     if (*(u16 *)(data_020a0e5a + idx * 4) & 0x400) {
-        _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_0211013c);
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0211013c);
     }
 
-    func_ov002_020bedd4(self);
+    func_ov002_020bedd4(((char *)this));
     return 1;
 }

--- a/src/_ZN6Player16St_LongJump_MainEv.cpp
+++ b/src/_ZN6Player16St_LongJump_MainEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN6Player16St_LongJump_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020e28d4(void*,int,int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int func_ov002_020bedd4(void*);
 extern int data_ov002_02110424[];
-int _ZN6Player16St_LongJump_MainEv(char* c){
-  func_ov002_020e28d4(c,0x1800,0x800);
-  if(*(unsigned char*)(c+0x6de)==0){
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_02110424);
-  }
-  func_ov002_020bedd4(c);
-  return 1;
 }
+
+int Player::St_LongJump_Main()
+{
+  func_ov002_020e28d4(((char*)this),0x1800,0x800);
+  if(mIsAirborne==0){
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_02110424);
+  }
+  func_ov002_020bedd4(((char*)this));
+  return 1;
 }

--- a/src/_ZN6Player16St_Shell_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Shell_CleanupEv.cpp
@@ -1,16 +1,21 @@
 //cpp
+// @symbol _ZN6Player16St_Shell_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020bd8c0(char* c, unsigned int r1);
-int _ZN6Player16St_Shell_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x354);
+}
+
+int Player::St_Shell_Cleanup()
+{
+  char* p = *(char**)((char*)&mRidingShell);
   if (p != 0) {
     *(int*)(p + 0x3c0) = 0;
-    *(int*)(c + 0x354) = 0;
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += 0x46000;
-    *(unsigned char*)(c + 0x6de) = 1;
-    *(unsigned char*)(c + 0x6df) = 0;
-    func_ov002_020bd8c0(c, 0x33);
+    mRidingShell = 0;
+    *(int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += 0x46000;
+    mIsAirborne = 1;
+    mLandSoundPlayed = 0;
+    func_ov002_020bd8c0(((char*)this), 0x33);
   }
   return 1;
-}
 }

--- a/src/_ZN6Player16St_SideFlip_MainEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player16St_SideFlip_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -11,85 +16,81 @@ extern void func_ov002_020eeca8(void* a, void* b);
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020e28d4(void* c, u32 a, u32 b);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern int func_ov002_020e2664(void* c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern void func_ov002_020bedd4(void* c);
 
-extern int data_ov002_02110694[];
 extern int data_ov002_02110424[];
-extern int data_ov002_021101fc[];
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
 extern int data_ov002_0211052c[];
 extern u16 data_0209f49c[];
-extern int data_ov002_021101e4[];
 extern int data_ov002_02110454[];
 }
 
-extern "C" int _ZN6Player16St_SideFlip_MainEv(char* c)
+int Player::St_SideFlip_Main()
 {
-    func_ov002_020eeca8(c + 0x380, c);
+    func_ov002_020eeca8(((char*)this) + 0x380, ((char*)this));
 
-    if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110694)) {
-        if (*(int*)(c + 0xa8) < 0) {
-            *(int*)(c + 0x98) = 0x12000;
+    if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_02110694)) {
+        if (mVertSpeed < 0) {
+            mHorzSpeed = 0x12000;
         }
-        func_ov002_020e28d4(c, 0, 0x800);
+        func_ov002_020e28d4(((char*)this), 0, 0x800);
     } else {
-        func_ov002_020e28d4(c, 0x1800, 0x800);
+        func_ov002_020e28d4(((char*)this), 0x1800, 0x800);
     }
 
-    if (*(u8*)(c + 0x6de) == 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110424);
+    if (mIsAirborne == 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110424);
     } else {
-        if (!_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021101fc)) {
+        if (!_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021101fc)) {
             u16 r0v = *(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18);
             if (r0v & 0x400) {
-                if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211052c)) {
-                    *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+                if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211052c)) {
+                    mTargetAngleY = mAngleY;
                 }
             }
-            if (func_ov002_020e2664(c)) {
+            if (func_ov002_020e2664(((char*)this))) {
                 return 1;
             }
         } else {
-            if (_ZN6Player12FinishedAnimEv(c)) {
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x54, 0x40000000, 0x1000, 0);
+            if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x54, 0x40000000, 0x1000, 0);
             }
         }
 
-        *(int*)(c + 0x9c) = -0x4000;
+        mVertAccel = -0x4000;
 
-        if (*(int*)(c + 0xa8) >= 0) {
+        if (mVertSpeed >= 0) {
             u16 r1v = *(u16*)((char*)data_0209f49c + data_020a0e40 * 0x18);
             if ((r1v & 2) != 0
-                || _ZN6Player7IsStateERNS_5StateE(c, data_ov002_021101e4)
-                || _ZN6Player7IsStateERNS_5StateE(c, data_ov002_021101fc)
-                || _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211052c)) {
-                *(int*)(c + 0x9c) = -0x3400;
+                || _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021101e4)
+                || _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021101fc)
+                || _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211052c)) {
+                mVertAccel = -0x3400;
             }
         } else {
-            if (*(int*)(c + 8) == 1
-                && _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211052c)) {
-                *(u8*)(c + 0x6e6) = 0;
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110454);
+            if (mParam == 1
+                && _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211052c)) {
+                unk_6e6 = 0;
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110454);
                 return 1;
             }
         }
 
-        if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021101e4)) {
-            int id = _ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0);
-            void* anim = *(void**)(c + (id << 2) + 0xdc);
-            u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50)) & 0xFFFFFFFFFFFFFFFFLL) + 8);
+        if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021101e4)) {
+            int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+            void* anim = *(void**)(((char*)this) + (id << 2) + 0xdc);
+            u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
             if ((u16)(w >> 12) == 0x10) {
-                _ZN5Sound9PlayBank0EjRK7Vector3(0xf, c + 0x74);
+                _ZN5Sound9PlayBank0EjRK7Vector3(0xf, ((char*)this) + 0x74);
             }
         }
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player16St_Teleport_InitEv.cpp
+++ b/src/_ZN6Player16St_Teleport_InitEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN6Player16St_Teleport_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020c9e40(char*c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
-int _ZN6Player16St_Teleport_InitEv(char*c){
-  func_ov002_020c9e40(c);
-  *(unsigned char*)(c+0x6e5)=0;
-  *(unsigned char*)(c+0x6e3)=0;
-  *(int*)(c+0x98)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
-  _ZN5Sound9PlayBank0EjRK7Vector3(0x19,(char*)c+0x74);
-  return 1;
 }
+
+int Player::St_Teleport_Init()
+{
+  func_ov002_020c9e40(((char*)this));
+  mStateWork=0;
+  mStateStep=0;
+  mHorzSpeed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x47,0,0x1000,0);
+  _ZN5Sound9PlayBank0EjRK7Vector3(0x19,(char*)((char*)this)+0x74);
+  return 1;
 }

--- a/src/_ZN6Player16St_Teleport_MainEv.cpp
+++ b/src/_ZN6Player16St_Teleport_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player16St_Teleport_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -6,15 +11,12 @@ typedef unsigned short u16;
 typedef unsigned char u8;
 
 typedef struct Obj { s16 x, y, z; u16 param; } Obj;
-typedef struct Vector3 { int x, y, z; } Vector3;
 
 extern "C" {
 extern Obj* GetTeleportDestObj(int i);
 extern void func_02035860(char* o, void* src);
-extern void func_0200d1e4(char* self);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, char* v);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, char* v);
-extern void func_02020388(int handle);
 extern void _ZN13RaycastGroundC1Ev(char* rc);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(char* rc, Vector3* v, char* actor);
 extern int _ZN13RaycastGround10DetectClsnEv(char* rc);
@@ -31,78 +33,78 @@ extern int data_ov002_0211067c[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player16St_Teleport_MainEv(char* c)
+int Player::St_Teleport_Main()
 {
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        if (*(u8*)(c + 0x6f5) > 1) {
-            (*(u8*)(((int)c + 0x6f5) & 0xFFFFFFFFFFFFFFFF))--;
+        if (mOpacity > 1) {
+            (*(u8*)(((int)((char*)this) + 0x6f5) & 0xFFFFFFFFFFFFFFFF))--;
             break;
         }
-        (*(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
-        if (*(u8*)(c + 0x6e5) >= 0x10) {
-            Obj* obj = GetTeleportDestObj((u8)(*(u8*)(c + 0x6e8) - 1));
+        (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
+        if (mStateWork >= 0x10) {
+            Obj* obj = GetTeleportDestObj((u8)(unk_6e8 - 1));
             int tx = obj->x << 12;
             int tz = obj->z << 12;
             int ty = obj->y << 12;
-            *(int*)(c + 0x5c) = tx;
-            *(int*)(c + 0x60) = ty;
-            *(int*)(c + 0x64) = tz;
-            *(u8*)(c + 0xcc) = obj->param & 0xf;
-            *(s16*)(c + 0x8e) = ((obj->param >> 4) & 0xf) << 12;
-            *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-            *(int*)(c + 0x644) = 0x80000000;
-            *(int*)(c + 0x64c) = 0x80000000;
-            func_02035860(c + 0x380, c + 0x5c);
-            *(u8*)(c + 0x6f5) = 0;
+            mPosX = tx;
+            mPosY = ty;
+            mPosZ = tz;
+            mAreaId = obj->param & 0xf;
+            mAngleY = ((obj->param >> 4) & 0xf) << 12;
+            mTargetAngleY = mAngleY;
+            mGroundY = 0x80000000;
+            unk_64c = 0x80000000;
+            func_02035860(((char*)this) + 0x380, ((char*)this) + 0x5c);
+            mOpacity = 0;
             func_0200d1e4(data_0209f318);
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x19, c + 0x74);
-            _ZN5Sound9PlayBank0EjRK7Vector3(0x19, c + 0x74);
-            *(u8*)(c + 0x6e3) = 1;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x19, ((char*)this) + 0x74);
+            _ZN5Sound9PlayBank0EjRK7Vector3(0x19, ((char*)this) + 0x74);
+            mStateStep = 1;
         }
         break;
     case 1:
-        if (*(u8*)(c + 0x6e5) != 0) {
-            if (*(u8*)(c + 0x6e5) >= 0x10) {
-                if (data_0209f32c > *(int*)(c + 0x60) + 0x64000)
-                    *(u8*)(c + 0x706) = 1;
+        if (mStateWork != 0) {
+            if (mStateWork >= 0x10) {
+                if (data_0209f32c > mPosY + 0x64000)
+                    mIsUnderwater = 1;
             }
-            (*(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))--;
             break;
         }
-        (*(u8*)(((int)c + 0x6f5) & 0xFFFFFFFFFFFFFFFF))++;
-        func_02020388(*(u8*)(c + 0x6d8));
-        if (*(u8*)(c + 0x6f5) >= 0x1f) {
+        (*(u8*)(((int)((char*)this) + 0x6f5) & 0xFFFFFFFFFFFFFFFF))++;
+        func_02020388(mPlayerNo);
+        if (mOpacity >= 0x1f) {
             int hit = 0;
-            *(u8*)(c + 0x6f5) = 0x1f;
-            if (data_0209f32c >= *(int*)(c + 0x60) + 0x64000) {
+            mOpacity = 0x1f;
+            if (data_0209f32c >= mPosY + 0x64000) {
                 Vector3 v;
                 char rc[0x50];
                 _ZN13RaycastGroundC1Ev(rc);
                 {
-                    int vz = *(int*)(c + 0x64);
+                    int vz = mPosZ;
                     int vy = data_0209f32c + 0x64000;
-                    int vx = *(int*)(c + 0x5c);
+                    int vx = mPosX;
                     v.x = vx;
                     v.y = vy;
                     v.z = vz;
                 }
-                _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rc, &v, c);
+                _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rc, &v, ((char*)this));
                 if (_ZN13RaycastGround10DetectClsnEv(rc))
                     hit = 1;
                 _ZN13RaycastGroundD1Ev(rc);
             }
             if (hit)
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211067c);
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211067c);
             else
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
             data_0209f284 = 1;
-            *(u16*)(c + 0x6c8) = 0x3c;
+            unk_6c8 = 0x3c;
             func_02012790(0x24);
         }
         break;
     }
-    _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4000050, 0x3f, *(u8*)(c + 0x6e5));
-    func_ov002_020bedd4(c);
+    _ZN3G2x18SetBlendBrightnessEPVtts((volatile u16*)0x4000050, 0x3f, mStateWork);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player16St_WallJump_MainEv.cpp
+++ b/src/_ZN6Player16St_WallJump_MainEv.cpp
@@ -1,35 +1,40 @@
 //cpp
+// @symbol _ZN6Player16St_WallJump_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 typedef int Fix12i;
 extern int func_ov002_020eeca8(void*, void*);
 extern int func_ov002_020e28d4(void*, int, int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*, void*);
 extern int _ZN6Player7IsStateERNS_5StateE(void*, void*);
-extern int func_ov002_020e2664(void*);
 extern int func_ov002_020bedd4(void*);
 extern char data_ov002_02110424[];
 extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
 extern char data_ov002_0211052c[];
-extern int data_ov002_0211073c[];
+}
 
-int _ZN6Player16St_WallJump_MainEv(void* c) {
-  func_ov002_020eeca8((char*)c+0x380, c);
-  func_ov002_020e28d4(c, 0x1800, 0x800);
-  if (*(unsigned char*)((char*)c+0x6de) == 0) {
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110424);
+int Player::St_WallJump_Main()
+{
+  func_ov002_020eeca8((char*)((void*)this)+0x380, ((void*)this));
+  func_ov002_020e28d4(((void*)this), 0x1800, 0x800);
+  if (*(unsigned char*)((char*)&mIsAirborne) == 0) {
+    _ZN6Player11ChangeStateERNS_5StateE(((void*)this), data_ov002_02110424);
   } else {
     if (*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 0x400) {
-      if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211052c)) {
-        *(short*)((char*)c+0x94) = *(short*)((char*)c+0x8e);
+      if (_ZN6Player7IsStateERNS_5StateE(((void*)this), data_ov002_0211052c)) {
+        *(short*)((char*)&mTargetAngleY) = *(short*)((char*)&mAngleY);
       }
     }
-    if (func_ov002_020e2664(c)) return 1;
+    if (func_ov002_020e2664(((void*)this))) return 1;
     {
-      int idx = *(int*)((char*)c+8);
+      int idx = *(int*)((char*)&mParam);
       int* row = &data_ov002_0211073c[idx*2];
       int v = row[1];
-      void* p = (char*)c + (v>>1);
+      void* p = (char*)((void*)this) + (v>>1);
       int (*f)(void*);
       if (v & 1) {
         f = *(int(**)(void*))((char*)(*(int**)p) + row[0]);
@@ -39,7 +44,6 @@ int _ZN6Player16St_WallJump_MainEv(void* c) {
       f(p);
     }
   }
-  func_ov002_020bedd4(c);
+  func_ov002_020bedd4(((void*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player16TryTalkToKeyDoorEv.cpp
+++ b/src/_ZN6Player16TryTalkToKeyDoorEv.cpp
@@ -1,17 +1,22 @@
 //cpp
+// @symbol _ZN6Player16TryTalkToKeyDoorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void*,void*);
 extern int _ZN6Player17SetNoControlStateEhih(void*,unsigned char,int,unsigned char);
 extern int data_ov002_0211013c[];
 extern int _ZN6Player7ST_WAITE[];
 extern int data_ov002_0211043c[];
-int _ZN6Player16TryTalkToKeyDoorEv(void* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211013c)
-     || _ZN6Player7IsStateERNS_5StateE(c,_ZN6Player7ST_WAITE)
-     || _ZN6Player7IsStateERNS_5StateE(c,data_ov002_0211043c)){
-    _ZN6Player17SetNoControlStateEhih(c,0xb,-1,0);
+}
+
+int Player::TryTalkToKeyDoor()
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((void*)this),data_ov002_0211013c)
+     || _ZN6Player7IsStateERNS_5StateE(((void*)this),_ZN6Player7ST_WAITE)
+     || _ZN6Player7IsStateERNS_5StateE(((void*)this),data_ov002_0211043c)){
+    _ZN6Player17SetNoControlStateEhih(((void*)this),0xb,-1,0);
     return 1;
   }
   return 0;
-}
 }

--- a/src/_ZN6Player17LostGrabbedObjectEv.cpp
+++ b/src/_ZN6Player17LostGrabbedObjectEv.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol _ZN6Player17LostGrabbedObjectEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 int _ZN6Player6IsAnimEj(void*, unsigned int);
-int _ZN6Player17LostGrabbedObjectEv(void* c){
-  return _ZN6Player6IsAnimEj(c, 0x18) || _ZN6Player6IsAnimEj(c, 0x8b);
 }
+
+int Player::LostGrabbedObject()
+{
+  return _ZN6Player6IsAnimEj(((void*)this), 0x18) || _ZN6Player6IsAnimEj(((void*)this), 0x8b);
 }

--- a/src/_ZN6Player17St_ButtSlide_InitEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_InitEv.cpp
@@ -1,19 +1,24 @@
 //cpp
+// @symbol _ZN6Player17St_ButtSlide_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 struct Camera;
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
 extern void func_0200d544(struct Camera* thiz, unsigned char playerID);
-int _ZN6Player17St_ButtSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x41, 0x40000000, 0x1000, 0);
-  *(char*)(c+0x6e3)=0;
-  if(*(unsigned char*)(c+0x70e)){
-    func_0200d544(data_0209f318, *(unsigned char*)(c+0x6d8));
-  }
-  *(char*)(c+0x6e6)=0;
-  *(char*)(c+0x70c)=*(unsigned char*)(c+0x70e);
-  *(short*)(c+0x600+0xa6)=6;
-  *(char*)(c+0x6e4)=0;
-  return 1;
 }
+
+int Player::St_ButtSlide_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x41, 0x40000000, 0x1000, 0);
+  mStateStep=0;
+  if(mSlideType){
+    func_0200d544(data_0209f318, mPlayerNo);
+  }
+  unk_6e6=0;
+  mStateArg=mSlideType;
+  *(short*)(((char*)this)+0x600+0xa6)=6;
+  mIsSlidingOnGround=0;
+  return 1;
 }

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player17St_ButtSlide_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -15,7 +20,6 @@ extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* s);
 extern int func_0201226c(int a0, int a1, int a2, char* a3, int a4, int a5);
 extern void func_ov002_020e25f0(char* c, int a);
 extern void func_ov002_020c18b0(char* c, int a);
-extern void func_ov002_020dcafc(char* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, char* v);
 extern void func_ov002_020dc560(char* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12 b, u32 d);
@@ -24,99 +28,98 @@ extern void func_ov002_020bedd4(char* c);
 
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
-extern int data_ov002_0211019c[];
 extern int data_ov002_021101b4[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player17St_ButtSlide_MainEv(char* c)
+int Player::St_ButtSlide_Main()
 {
-    switch (*(u8*)(c + 0x6e6)) {
+    switch (unk_6e6) {
     case 0:
-        func_ov002_020bf90c(c);
-        if (*(u8*)(c + 0x6de) == 0) {
-            *(u8*)(c + 0x6e4) = 1;
-            func_ov002_020c06fc(c, 0x4000);
-            func_ov002_020dd2f4(c);
+        func_ov002_020bf90c(((char*)this));
+        if (mIsAirborne == 0) {
+            mIsSlidingOnGround = 1;
+            func_ov002_020c06fc(((char*)this), 0x4000);
+            func_ov002_020dd2f4(((char*)this));
         }
-        if (*(int*)(c + 0x98) == 0) {
-            if (*(u8*)(c + 0x70e) == 0) {
-                *(u8*)(c + 0x6e6) = 2;
-                *(u8*)(c + 0x6e5) = 0;
+        if (mHorzSpeed == 0) {
+            if (mSlideType == 0) {
+                unk_6e6 = 2;
+                mStateWork = 0;
                 break;
             }
-            (*(u8*)(((int)c + 0x6e7) & 0xFFFFFFFFFFFFFFFF))++;
-            if (*(u8*)(c + 0x6e7) >= 0x1e) {
-                *(u8*)(c + 0x6e6) = 2;
-                *(u8*)(c + 0x6e5) = 0;
+            (*(u8*)(((int)((char*)this) + 0x6e7) & 0xFFFFFFFFFFFFFFFF))++;
+            if (mSlideStoppedTimer >= 0x1e) {
+                unk_6e6 = 2;
+                mStateWork = 0;
                 break;
             }
         } else {
-            *(u8*)(c + 0x6e7) = 0;
+            mSlideStoppedTimer = 0;
         }
-        if (func_ov002_020c0688(c) != 0) {
+        if (func_ov002_020c0688(((char*)this)) != 0) {
             if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) != 0
-                && *(u16*)(c + 0x6a6) == 0) {
-                *(u8*)(c + 0x6e1) = 0;
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+                && mStateWaitTimer == 0) {
+                mJumpComboStage = 0;
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211019c);
                 return 1;
             }
-            *(int*)(c + 0x620) = func_0201226c(*(int*)(c + 0x620), 0, *(int*)(c + 0x66c) + 0xe2, c + 0x74, *(int*)(c + 0x98), 0);
+            mLoopingSoundHandle = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, ((char*)this) + 0x74, mHorzSpeed, 0);
         } else {
-            *(u8*)(c + 0x6e3) = 0;
-            *(u8*)(c + 0x6e6) = 1;
-            *(u8*)(c + 0x6e5) = 0;
-            if ((*(u8*)(c + 0x70c) | *(u8*)(c + 0x70e)) != 0)
-                *(int*)(c + 0xa8) = 0x15000;
-            func_ov002_020e25f0(c, 0);
-            *(u8*)(c + 0x6de) = 1;
-            *(u8*)(c + 0x6df) = 0;
+            mStateStep = 0;
+            unk_6e6 = 1;
+            mStateWork = 0;
+            if ((mStateArg | mSlideType) != 0)
+                mVertSpeed = 0x15000;
+            func_ov002_020e25f0(((char*)this), 0);
+            mIsAirborne = 1;
+            mLandSoundPlayed = 0;
             break;
         }
-        func_ov002_020c18b0(c, 0);
-        func_ov002_020dcafc(c);
+        func_ov002_020c18b0(((char*)this), 0);
+        func_ov002_020dcafc(((char*)this));
         break;
     case 1:
-        *(s16*)(c + 0x90) = 0;
-        *(s16*)(c + 0x8c) = *(s16*)(c + 0x90);
-        if (*(u8*)(c + 0x6de) == 0) {
-            if (*(u8*)(c + 0x6df) == 0) {
-                *(u8*)(c + 0x6df) = 1;
-                _ZN5Sound9PlayBank0EjRK7Vector3(*(int*)(c + 0x66c) + 0x50, c + 0x74);
+        mAngZ = 0;
+        mAngX = mAngZ;
+        if (mIsAirborne == 0) {
+            if (mLandSoundPlayed == 0) {
+                mLandSoundPlayed = 1;
+                _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType + 0x50, ((char*)this) + 0x74);
             }
-            if (*(u8*)(c + 0x6e5) == 0 && *(int*)(c + 0x558) >= 0xfc1) {
-                *(int*)(c + 0xa8) = -*(int*)(c + 0x640) / 2;
-                (*(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
+            if (mStateWork == 0 && unk_558 >= 0xfc1) {
+                mVertSpeed = -mPrevVertSpeed / 2;
+                (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
             } else {
-                *(u8*)(c + 0x6e6) = 0;
-                *(int*)(c + 0xa8) = 0;
+                unk_6e6 = 0;
+                mVertSpeed = 0;
                 break;
             }
         } else {
-            func_ov002_020dc560(c);
+            func_ov002_020dc560(((char*)this));
         }
-        (*(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
-        if (*(u8*)(c + 0x6e3) > 0x1e
-            && *(int*)(c + 0x60) - *(int*)(c + 0x644) > 0x1f4000) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+        (*(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+        if (mStateStep > 0x1e
+            && mPosY - mGroundY > 0x1f4000) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
             return 1;
         }
         break;
     case 2:
-        *(s16*)(c + 0x90) = 0;
-        *(s16*)(c + 0x8c) = *(s16*)(c + 0x90);
-        if (*(u8*)(c + 0x6e5) == 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x42, 0x40000000, 0x1000, 0);
-            *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-            *(u8*)(c + 0x6e5) = 1;
-        } else if (_ZN6Player12FinishedAnimEv(c) != 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        mAngZ = 0;
+        mAngX = mAngZ;
+        if (mStateWork == 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x42, 0x40000000, 0x1000, 0);
+            mTargetAngleY = mAngleY;
+            mStateWork = 1;
+        } else if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         break;
     }
 
-    *(int*)(c + 0x640) = *(int*)(c + 0xa8);
-    func_ov002_020bedd4(c);
-    *(u8*)(c + 0x70c) = *(u8*)(c + 0x70e);
+    mPrevVertSpeed = mVertSpeed;
+    func_ov002_020bedd4(((char*)this));
+    mStateArg = mSlideType;
     return 1;
 }

--- a/src/_ZN6Player17St_Cannon_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Cannon_CleanupEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player17St_Cannon_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // Player::St_Cannon_Cleanup - clear flag bit 0x20 in the u32 at this+0x2ec, return 1.
 // The u64-mask launder forces the base to materialize (add r2,this,#0x2ec) so the
 // load/store reuse it, matching the ROM instead of folding the offset into ldr/str.
-extern "C" {
-int _ZN6Player17St_Cannon_CleanupEv(char *c)
+
+int Player::St_Cannon_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
     return 1;
-}
 }

--- a/src/_ZN6Player17St_EndingFly_MainEv.cpp
+++ b/src/_ZN6Player17St_EndingFly_MainEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN6Player17St_EndingFly_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 typedef void (*FP)(void*);
 extern FP data_ov007_02103254;
-void _ZN6Player17St_EndingFly_MainEv(void* self){
-  data_ov007_02103254(self);
 }
+
+void Player::St_EndingFly_Main()
+{
+  data_ov007_02103254(((void*)this));
 }

--- a/src/_ZN6Player17St_Headstand_MainEv.cpp
+++ b/src/_ZN6Player17St_Headstand_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player17St_Headstand_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -14,32 +19,28 @@ struct Obj {
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void* c, unsigned int a, int b, int d, unsigned int e);
-extern void func_ov002_020cc05c(void* c, unsigned short v);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* state);
 extern void func_ov002_020bedd4(void* c);
 
 extern u8 data_020a0e40;
-extern s16 data_0209f4a4[];
 extern u16 data_0209f49c[];
 extern u16 data_0209f49e[];
-extern int data_ov002_02110724[];
-extern int data_ov002_021106dc[];
 }
 
-extern "C" int _ZN6Player17St_Headstand_MainEv(char* c)
+int Player::St_Headstand_Main()
 {
-    Obj* obj = *(Obj**)(c+0x37c);
+    Obj* obj = *(Obj**)((char*)&unk_37c);
     Obj* r = obj->v2();
-    *(int*)(c+0x5c) = *(int*)r;
-    *(int*)(c+0x64) = *(int*)((char*)r+8);
-    *(int*)(c+0x60) = *(int*)((char*)r+4) + *(int*)((char*)(*(Obj**)(c+0x37c))+8);
+    mPosX = *(int*)r;
+    mPosZ = *(int*)((char*)r+8);
+    mPosY = *(int*)((char*)r+4) + *(int*)((char*)(*(Obj**)((char*)&unk_37c))+8);
 
-    u8 st = *(u8*)(c+0x6e3);
+    u8 st = mStateStep;
     switch (st) {
     case 2:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x1d, 0, 0x1000, 0);
-            *(u8*)(c+0x6e3) = 3;
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x1d, 0, 0x1000, 0);
+            mStateStep = 3;
         }
         break;
     case 3: {
@@ -47,28 +48,28 @@ extern "C" int _ZN6Player17St_Headstand_MainEv(char* c)
         s16 val = *(s16*)((char*)data_0209f4a4 + idx);
         u16 mag = *(u16*)((char*)data_0209f49c + idx);
         if (val > 0x200) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x1f, 0x40000000, 0x1000, 0);
-            *(u8*)(c+0x6e3) = 4;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x1f, 0x40000000, 0x1000, 0);
+            mStateStep = 4;
         }
-        func_ov002_020cc05c(c, mag);
+        func_ov002_020cc05c(((char*)this), mag);
         {
-            s16* p = (s16*)((((long long)(int)(c+0x8e)) & 0xFFFFFFFFFFFFFFFFLL));
-            *p = *p + *(s16*)(c+0x69c);
+            s16* p = (s16*)((((long long)(int)((char*)&mAngleY))));
+            *p = *p + mAngleYSpeed;
         }
         if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) {
-            *(s16*)(c+0x94) = *(s16*)(c+0x8e);
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110724);
+            mTargetAngleY = mAngleY;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110724);
             return 1;
         }
         break;
     }
     case 4:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021106dc);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021106dc);
         }
         break;
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
@@ -1,13 +1,18 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN6Player17St_HoldHeavy_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int data_ov002_020ff254[];
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,struct Vector3*);
-int _ZN6Player17St_HoldHeavy_InitEv(char* c){
-  *(char*)(c+0x6e5)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff254[*(unsigned char*)(c+0x6e5)], 0x40000000, 0x1000, 0);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x12, (struct Vector3*)(c+0x74));
-  return 1;
 }
+
+int Player::St_HoldHeavy_Init()
+{
+  mStateWork=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff254[mStateWork], 0x40000000, 0x1000, 0);
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x12, (struct Vector3*)((char*)&mCamSpacePos));
+  return 1;
 }

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player17St_HoldHeavy_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -12,56 +18,51 @@ extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern void func_ov002_020da9d4(void* c);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void func_ov002_020d4d88(void* c, int a, int b);
-extern int _ZN9Animation8GetFlagsEv(void* anim);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern void func_ov002_020d1f78(void* c, u32 a);
 extern void func_ov002_020bedd4(void* c);
 
 extern int data_ov002_0211013c[];
-extern int data_ov002_020ff254[];
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
 extern int data_ov002_021105d4[];
 extern int data_ov002_021101b4[];
 extern s16 data_0209f4a0[];
-extern int data_ov002_020ff1d0[];
 extern u8 data_0209f4ac[];
 extern u16 data_0209f49c[];
 }
 
-extern "C" int _ZN6Player17St_HoldHeavy_MainEv(char* c)
+int Player::St_HoldHeavy_Main()
 {
     int var_r1 = 0;
 
-    if (*(int*)(c + 0x358) == 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    if (mHeldObj == 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
 
-    if (*(u8*)(c + 0x6e3) == 0) {
-        u32 anim = data_ov002_020ff254[*(u8*)(c + 0x6e5)];
-        if (_ZN6Player6IsAnimEj(c, anim)) {
-            if (_ZN6Player12FinishedAnimEv(c)) {
-                *(u8*)(c + 0x6e3) = 1;
+    if (mStateStep == 0) {
+        u32 anim = data_ov002_020ff254[mStateWork];
+        if (_ZN6Player6IsAnimEj(((char*)this), anim)) {
+            if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+                mStateStep = 1;
             } else {
-                u32 arg = (u8)*(int*)(c + 8);
-                int modelIdx = _ZNK6Player14GetBodyModelIDEjb(c, arg, 0);
-                char* animPtr = *(char**)(c + modelIdx * 4 + 0xdc) + 0x50;
+                u32 arg = (u8)mParam;
+                int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
+                char* animPtr = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
                 if (_ZNK9Animation12WillHitFrameEi(animPtr, 6)) {
-                    int* heavy = *(int**)(c + 0x358);
+                    int* heavy = *(int**)((char*)&mHeldObj);
                     if (heavy != 0) {
-                        *(int*)(((long long)(int)((char*)heavy + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
+                        *(int*)(((long long)(int)((char*)heavy + 0xb0))) |= 0x4000;
                     }
                 }
             }
         }
-        _Z14ApproachLinearRiii((int*)(c + 0x98), 0, 0x1000);
+        _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), 0, 0x1000);
         goto end;
     }
 
@@ -69,22 +70,22 @@ extern "C" int _ZN6Player17St_HoldHeavy_MainEv(char* c)
         int off = data_020a0e40 * 0x18;
         u16 flags = *(u16*)((char*)data_0209f49e + off);
         if (flags & 1) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021105d4);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021105d4);
             return 1;
         }
 
-        if (*(u8*)(c + 0x6de) != 0) {
-            func_ov002_020da9d4(c);
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
-            *(u16*)(c + 0x6b4) = 0xa;
+        if (mIsAirborne != 0) {
+            func_ov002_020da9d4(((char*)this));
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
+            unk_6b4 = 0xa;
             return 1;
         }
 
         {
             s16 t = *(s16*)((char*)data_0209f4a0 + off);
             if (t != 0) {
-                ApproachAngle((short*)(c + 0x94), *(s16*)(c + 0x6d2), 8, 0x1000, 0x400);
-                var_r1 = data_ov002_020ff1d0[*(int*)(c + 8)];
+                ApproachAngle((short*)((char*)&mTargetAngleY), mDesiredAngleY, 8, 0x1000, 0x400);
+                var_r1 = data_ov002_020ff1d0[mParam];
             }
         }
     }
@@ -96,30 +97,30 @@ extern "C" int _ZN6Player17St_HoldHeavy_MainEv(char* c)
                 var_r1 >>= 1;
             }
         } else {
-            var_r1 = func_ov002_020bf224(c, var_r1, 0);
+            var_r1 = func_ov002_020bf224(((char*)this), var_r1, 0);
         }
-        func_ov002_020d4d88(c, var_r1, 0x1000);
+        func_ov002_020d4d88(((char*)this), var_r1, 0x1000);
     }
 
-    if (*(int*)(c + 0x98) == 0) {
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-    } else if (*(int*)(c + 8) == 1) {
-        ApproachAngle((short*)(c + 0x8e), *(s16*)(c + 0x94), 0x10, 0x1000, 0x100);
+    if (mHorzSpeed == 0) {
+        mAngleY = mTargetAngleY;
+    } else if (mParam == 1) {
+        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 0x10, 0x1000, 0x100);
     } else {
-        ApproachAngle((short*)(c + 0x8e), *(s16*)(c + 0x94), 8, 0x2000, 0x400);
+        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x400);
     }
 
-    if (*(int*)(c + 0x98) == 0) {
-        if (_ZN6Player12FinishedAnimEv(c) ||
+    if (mHorzSpeed == 0) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) ||
             !_ZN9Animation8GetFlagsEv(
-                *(char**)(c + _ZNK6Player14GetBodyModelIDEjb(c, (u8)*(int*)(c + 8), 0) * 4 + 0xdc) + 0x50)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff254[*(u8*)(c + 0x6e5) + 2], 0, 0x1000, 0);
+                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4 + 0xdc) + 0x50)) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff254[mStateWork + 2], 0, 0x1000, 0);
         }
     } else {
-        func_ov002_020d1f78(c, data_ov002_020ff254[*(u8*)(c + 0x6e5) + 4]);
+        func_ov002_020d1f78(((char*)this), data_ov002_020ff254[mStateWork + 4]);
     }
 
 end:
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player17St_HoldLight_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -16,59 +22,53 @@ extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int func_ov002_020e0ccc(void* c, short* st);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern int func_ov002_020c5244(void* c);
 extern int func_ov002_020dab14(void* c);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void func_ov002_020d4d88(void* c, int a, int b);
-extern int func_ov002_020d9dcc(void* c);
-extern int _ZN9Animation8GetFlagsEv(void* anim);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern void func_ov002_020d1f78(void* c, u32 a);
 extern void func_ov002_020bedd4(void* c);
 
 extern u8 data_020a0e40;
 extern s16 data_0209f4a0[];
-extern int data_ov002_020ff1c0[];
 extern u8 data_0209f4ac[];
 extern u16 data_0209f49c[];
 extern u16 data_0209f49e[];
 extern int data_ov002_0211013c[];
 extern int data_ov002_021105d4[];
-extern int data_ov002_0211019c[];
 extern int data_ov002_021101b4[];
 }
 
-extern "C" int _ZN6Player17St_HoldLight_MainEv(char* c)
+int Player::St_HoldLight_Main()
 {
-    if (*(int*)(c + 0x358) == 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    if (mHeldObj == 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
-    if (func_ov002_020c0434(c)) {
-        func_ov002_020c0364(c, 3);
+    if (func_ov002_020c0434(((char*)this))) {
+        func_ov002_020c0364(((char*)this), 3);
         return 1;
     }
 
-    if (*(u8*)(c + 0x6e3) == 0) {
-        _Z14ApproachLinearRiii((int*)(c + 0x98), 0, 0x800);
-        if (_ZN6Player6IsAnimEj(c, 0x2f) || _ZN6Player6IsAnimEj(c, 0x86)) {
-            if (_ZN6Player12FinishedAnimEv(c)) {
-                if (func_ov002_020e0ccc(c, *(short**)(c + 0x358))) {
+    if (mStateStep == 0) {
+        _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), 0, 0x800);
+        if (_ZN6Player6IsAnimEj(((char*)this), 0x2f) || _ZN6Player6IsAnimEj(((char*)this), 0x86)) {
+            if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+                if (func_ov002_020e0ccc(((char*)this), *(short**)((char*)&mHeldObj))) {
                     return 1;
                 }
-                *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-                *(int*)(c + 0x98) = 0;
-                *(u8*)(c + 0x6e3) = 1;
+                mTargetAngleY = mAngleY;
+                mHorzSpeed = 0;
+                mStateStep = 1;
             } else {
-                u32 arg = (u8)*(int*)(c + 8);
-                int modelIdx = _ZNK6Player14GetBodyModelIDEjb(c, arg, 0);
-                char* anim = *(char**)(c + modelIdx * 4 + 0xdc) + 0x50;
+                u32 arg = (u8)mParam;
+                int modelIdx = _ZNK6Player14GetBodyModelIDEjb(((char*)this), arg, 0);
+                char* anim = *(char**)(((char*)this) + modelIdx * 4 + 0xdc) + 0x50;
                 if (_ZNK9Animation12WillHitFrameEi(anim, 6)) {
-                    int* light = *(int**)(c + 0x358);
+                    int* light = *(int**)((char*)&mHeldObj);
                     if (light != 0) {
-                        int* p = (int*)(((long long)(int)((char*)light + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+                        int* p = (int*)(((long long)(int)((char*)light + 0xb0)));
                         *p |= 0x4000;
                     }
                 }
@@ -77,25 +77,25 @@ extern "C" int _ZN6Player17St_HoldLight_MainEv(char* c)
         goto end;
     }
 
-    if (func_ov002_020c5244(c)) {
+    if (func_ov002_020c5244(((char*)this))) {
         return 1;
     }
 
-    if (*(int*)(c + 0x68c) > 0x19000) {
-        func_ov002_020dab14(c);
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    if (mSinkDepth > 0x19000) {
+        func_ov002_020dab14(((char*)this));
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
 
     int var_r4 = 0;
     if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-        s16 t = *(s16*)(c + 0x6d2);
-        if (*(u8*)(c + 0x70c) != 0) {
-            *(s16*)(c + 0x94) = t;
-            *(u8*)(c + 0x70c) = 0;
+        s16 t = mDesiredAngleY;
+        if (mStateArg != 0) {
+            mTargetAngleY = t;
+            mStateArg = 0;
         }
-        ApproachAngle((short*)(c + 0x94), t, 4, 0x2000, 0x800);
-        var_r4 = data_ov002_020ff1c0[*(int*)(c + 8)];
+        ApproachAngle((short*)((char*)&mTargetAngleY), t, 4, 0x2000, 0x800);
+        var_r4 = data_ov002_020ff1c0[mParam];
     }
 
     if (*((u8*)data_0209f4ac + data_020a0e40 * 0x18) == 0) {
@@ -103,57 +103,57 @@ extern "C" int _ZN6Player17St_HoldLight_MainEv(char* c)
             var_r4 = (s32)(((s64)var_r4 * 0xa00 + 0x800) >> 0xc);
         }
     } else {
-        var_r4 = func_ov002_020bf224(c, var_r4, 0);
+        var_r4 = func_ov002_020bf224(((char*)this), var_r4, 0);
     }
 
-    *(u8*)(c + 0x70c) = 0;
-    if (*(int*)(c + 0x98) == 0) {
-        *(u8*)(c + 0x70c) = 1;
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+    mStateArg = 0;
+    if (mHorzSpeed == 0) {
+        mStateArg = 1;
+        mAngleY = mTargetAngleY;
     } else {
-        ApproachAngle((short*)(c + 0x8e), *(s16*)(c + 0x94), 8, 0x2000, 0x800);
+        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x800);
     }
 
-    func_ov002_020d4d88(c, var_r4, 0x1000);
+    func_ov002_020d4d88(((char*)this), var_r4, 0x1000);
 
     {
         u16 flags = *(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18);
         if (flags & 1) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021105d4);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021105d4);
             return 1;
         }
         if (flags & 2) {
-            *(s16*)(c + 0x6a8) = 0;
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+            mJumpComboTimer = 0;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211019c);
             return 1;
         }
         if (flags & 0x400) {
-            if (func_ov002_020dab14(c)) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+            if (func_ov002_020dab14(((char*)this))) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
             }
             return 1;
         }
     }
 
-    if (*(u8*)(c + 0x6de) != 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+    if (mIsAirborne != 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
         return 1;
     }
-    if (func_ov002_020d9dcc(c)) {
+    if (func_ov002_020d9dcc(((char*)this))) {
         return 1;
     }
 
-    if (*(int*)(c + 0x98) == 0) {
-        if (_ZN6Player12FinishedAnimEv(c) ||
+    if (mHorzSpeed == 0) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) ||
             !_ZN9Animation8GetFlagsEv(
-                *(char**)(c + _ZNK6Player14GetBodyModelIDEjb(c, (u8)*(int*)(c + 8), 0) * 4 + 0xdc) + 0x50)) {
-            int* light = *(int**)(c + 0x358);
+                *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4 + 0xdc) + 0x50)) {
+            int* light = *(int**)((char*)&mHeldObj);
             u32 animId = 0x33;
             if (light != 0) {
                 int b = (*(int*)((char*)light + 0xb0) & 0x8000) != 0;
                 if (b) {
                     animId = 0x87;
-                    if (*(int*)(c + 8) == 2) {
+                    if (mParam == 2) {
                         int b2 = (*(u16*)((char*)light + 0xc) == 0xce);
                         if (b2) {
                             animId = 0x33;
@@ -161,13 +161,13 @@ extern "C" int _ZN6Player17St_HoldLight_MainEv(char* c)
                     }
                 }
             }
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, animId, 0, 0x1000, 0);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), animId, 0, 0x1000, 0);
         }
     } else {
-        func_ov002_020d1f78(c, 0x48);
+        func_ov002_020d1f78(((char*)this), 0x48);
     }
 
 end:
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_HurtWater_InitEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_InitEv.cpp
@@ -1,28 +1,33 @@
 //cpp
+// @symbol _ZN6Player17St_HurtWater_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int data_ov002_02109fe4[];
 extern int data_0209f318[];
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void func_ov002_020d93ac(void*);
 extern void func_ov002_020d94cc(void*);
-extern void func_0200d89c(char* p);
-int _ZN6Player17St_HurtWater_InitEv(char* c){
-  unsigned a=data_ov002_02109fe4[*(unsigned char*)(c+0x6e3)&1];
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,a,0x40000000,0x1000,0);
-  *(char*)(c+0x6e5)=0;
-  *(char*)(c+0x70c)=0;
-  *(int*)(c+0x9c)=0;
-  *(int*)(c+0xa0)=-0xc000;
-  *(int*)(c+0xa8)=0x10000;
-  *(char*)(c+0x708)=1;
-  if(*(int*)(c+0x674)){
-    int b=*(unsigned char*)(c+0x6e3)&0xf0;
+}
+
+int Player::St_HurtWater_Init()
+{
+  unsigned a=data_ov002_02109fe4[mStateStep&1];
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),a,0x40000000,0x1000,0);
+  mStateWork=0;
+  mStateArg=0;
+  mVertAccel=0;
+  mTerminalVelocity=-0xc000;
+  mVertSpeed=0x10000;
+  mIsTakingDamage=1;
+  if(mHurtDamage){
+    int b=mStateStep&0xf0;
     if(b==0 || b==0x10){
-      func_ov002_020d93ac(c);
-      func_ov002_020d94cc(c);
+      func_ov002_020d93ac(((char*)this));
+      func_ov002_020d94cc(((char*)this));
     }
   }
   func_0200d89c(*(char**)data_0209f318);
   return 1;
-}
 }

--- a/src/_ZN6Player17St_HurtWater_MainEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player17St_HurtWater_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020cec2c(void*);
 extern void _Z14ApproachLinearRiii(int*,int,int);
@@ -12,38 +15,40 @@ extern int func_ov002_020bedd4(void*);
 extern int data_ov002_0211067c[];
 extern int data_ov002_021106ac[];
 extern int data_0209f32c[];
-int _ZN6Player17St_HurtWater_MainEv(char* c){
-  if(func_ov002_020cec2c(c)) return 1;
-  _Z14ApproachLinearRiii((int*)(c+0x98),0,0x800);
-  int t=func_ov002_020ceaf4(c);
-  _Z14ApproachLinearRiii((int*)(c+0xa8),t,0x800);
-  if(_ZN6Player12FinishedAnimEv(c)){
-    if((*(unsigned char*)(c+0x6e3)&1)==0){
-      *(short*)(c+0x94)=*(short*)(c+0x94)+0x8000;
-      *(short*)(c+0x8e)=*(short*)(c+0x94);
+}
+
+int Player::St_HurtWater_Main()
+{
+  if(func_ov002_020cec2c(((char*)this))) return 1;
+  _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed),0,0x800);
+  int t=func_ov002_020ceaf4(((char*)this));
+  _Z14ApproachLinearRiii((int*)((char*)&mVertSpeed),t,0x800);
+  if(_ZN6Player12FinishedAnimEv(((char*)this))){
+    if((mStateStep&1)==0){
+      mTargetAngleY=mTargetAngleY+0x8000;
+      mAngleY=mTargetAngleY;
     }
-    if(_ZN6Player9GetHealthEv(c)){
-      if(*(unsigned char*)(c+0x6f9)==0)
-        _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211067c);
+    if(_ZN6Player9GetHealthEv(((char*)this))){
+      if(mIsMetal==0)
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211067c);
       else
-        _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_021106ac);
-      *(char*)(c+0x708)=0;
-      if(*(int*)(c+0x674))
-        *(short*)(c+0x6a0)=0x24;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_021106ac);
+      mIsTakingDamage=0;
+      if(mHurtDamage)
+        mInvincibleTimer=0x24;
     }else{
-      func_ov007_020c5dec(c,8);
+      func_ov007_020c5dec(((char*)this),8);
       return 1;
     }
   }
   int lim=*(int*)data_0209f32c-0x50000;
-  if(*(int*)(c+0x60)>=lim && (*(unsigned char*)(c+0x6e9)&1)==0){
-    if(*(int*)(c+0xa8)>=0){
-      *(int*)(c+0x60)=lim;
-      *(int*)(c+0xa8)=0;
+  if(mPosY>=lim && (mClsnFlags&1)==0){
+    if(mVertSpeed>=0){
+      mPosY=lim;
+      mVertSpeed=0;
     }
   }
-  func_ov002_020ceb7c(c);
-  func_ov002_020bedd4(c);
+  func_ov002_020ceb7c(((char*)this));
+  func_ov002_020bedd4(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN6Player17St_LedgeGrab_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player17St_LedgeGrab_InitEv(char* c){
-  if(*(unsigned char*)(c+0x6e3)){
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x20,0x40000000,0x1000,0);
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x1a,(void*)(c+0x74));
+}
+
+int Player::St_LedgeGrab_Init()
+{
+  if(mStateStep){
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x20,0x40000000,0x1000,0);
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x1a,(void*)((char*)&mCamSpacePos));
   } else {
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x23,0x40000000,0x1000,0);
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x17,(void*)(c+0x74));
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x23,0x40000000,0x1000,0);
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x17,(void*)((char*)&mCamSpacePos));
   }
   return 1;
-}
 }

--- a/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_MainEv.cpp
@@ -1,23 +1,29 @@
 //cpp
+// @symbol _ZN6Player17St_LedgeGrab_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int _ZN6Player6IsAnimEj(void*,unsigned);
 extern int _ZNK6Player14GetBodyModelIDEjb(void*,unsigned,int);
-extern int _ZNK9Animation12WillHitFrameEi(void*,int);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
 extern int func_ov002_020bedd4(void*);
 extern int data_ov002_0211013c[];
-int _ZN6Player17St_LedgeGrab_MainEv(char* c){
-  if(_ZN6Player12FinishedAnimEv(c))
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
-  if(_ZN6Player6IsAnimEj(c,0x20)){
-    int id=_ZNK6Player14GetBodyModelIDEjb(c,*(unsigned int*)(c+8)&0xff,0);
-    void* anim=*(void**)(c+(id<<2)+0xdc);
-    if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0x1e))
-      _ZN5Sound9PlayBank0EjRK7Vector3(*(int*)(c+0x66c)+0x40,c+0x74);
-  }
-  func_ov002_020bedd4(c);
-  return 1;
 }
+
+int Player::St_LedgeGrab_Main()
+{
+  if(_ZN6Player12FinishedAnimEv(((char*)this)))
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211013c);
+  if(_ZN6Player6IsAnimEj(((char*)this),0x20)){
+    int id=_ZNK6Player14GetBodyModelIDEjb(((char*)this),mParam&0xff,0);
+    void* anim=*(void**)(((char*)this)+(id<<2)+0xdc);
+    if(_ZNK9Animation12WillHitFrameEi((char*)anim+0x50,0x1e))
+      _ZN5Sound9PlayBank0EjRK7Vector3(mGroundSoundType+0x40,((char*)this)+0x74);
+  }
+  func_ov002_020bedd4(((char*)this));
+  return 1;
 }

--- a/src/_ZN6Player17St_LedgeHang_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player17St_LedgeHang_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -7,76 +12,70 @@ typedef unsigned char u8;
 typedef s32 Fix12;
 
 extern "C" {
-extern void func_ov002_020d0948(void* c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
-extern int func_ov002_020cfaf0(void* c);
-extern int func_ov002_020cfea4(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern int func_ov002_020cfbdc(void* c);
-extern int AngleDiff(int a, int b);
 extern void func_ov002_020bedd4(void* c);
 
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
 extern s16 data_0209f4a0[];
-extern int data_ov002_02110004[];
 }
 
-extern "C" int _ZN6Player17St_LedgeHang_MainEv(char* c)
+int Player::St_LedgeHang_Main()
 {
-    int v = *(int*)(c + 0x644);
+    int v = mGroundY;
     if (v != (int)0x80000000) {
-        int d = v - *(int*)(c + 0x60);
+        int d = v - mPosY;
         if (d < 0) d = -d;
         if (d < 0x28000) {
-            *(int*)(c + 0x60) = v;
-            *(u8*)(c + 0x6de) = 0;
-            if (*(int*)(c + 0x558) < 0xddb) {
-                func_ov002_020d0948(c);
+            mPosY = v;
+            mIsAirborne = 0;
+            if (unk_558 < 0xddb) {
+                func_ov002_020d0948(((char*)this));
                 return 1;
             }
         }
     }
 
-    if (*(u8*)(c + 0x6de) != 0) {
-        func_ov002_020d0948(c);
+    if (mIsAirborne != 0) {
+        func_ov002_020d0948(((char*)this));
         return 1;
     }
 
-    if (*(u8*)(c + 0x6e3) == 0) {
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x21, 0, 0x1000, 0);
-            *(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
-                *(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
+    if (mStateStep == 0) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x21, 0, 0x1000, 0);
+            *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
+                *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
         }
     } else {
-        if ((!func_ov002_020cfaf0(c)
+        if ((!func_ov002_020cfaf0(((char*)this))
              && (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2))
-            || func_ov002_020cfea4(c)) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110004);
+            || func_ov002_020cfea4(((char*)this))) {
+            mStateStep = 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110004);
         } else {
-            if (func_ov002_020cfbdc(c))
+            if (func_ov002_020cfbdc(((char*)this)))
                 return 1;
             if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 0x400) {
-                func_ov002_020d0948(c);
+                func_ov002_020d0948(((char*)this));
                 return 1;
             }
             {
-                if (*(u16*)(c + 0x6a4) == 0
+                if (mStateTimer == 0
                     && *(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-                    if (AngleDiff(*(s16*)(c + 0x6d2), *(s16*)(c + 0x8e)) >= 0x4000) {
-                        func_ov002_020d0948(c);
-                    } else if (!func_ov002_020cfaf0(c)) {
-                        *(u8*)(c + 0x6e3) = 0;
-                        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110004);
+                    if (AngleDiff(mDesiredAngleY, mAngleY) >= 0x4000) {
+                        func_ov002_020d0948(((char*)this));
+                    } else if (!func_ov002_020cfaf0(((char*)this))) {
+                        mStateStep = 0;
+                        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110004);
                     }
                 }
             }
         }
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_NoControl_InitEv.cpp
+++ b/src/_ZN6Player17St_NoControl_InitEv.cpp
@@ -1,21 +1,27 @@
 //cpp
+// @symbol _ZN6Player17St_NoControl_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020c9e40(void* c);
 extern int func_ov002_020dab14(void* c);
 struct PMF { int adj; int ptr; };
 extern struct PMF data_ov002_02110884[];
-int _ZN6Player17St_NoControl_InitEv(char* c){
-  *(unsigned char*)(c+0x6f6)=1;
-  *(unsigned char*)(c+0x6e6)=0;
-  func_ov002_020c9e40(c);
-  func_ov002_020dab14(c);
-  *(int*)(c+0x354)=0;
-  *(int*)(c+0x358)=0;
-  *(int*)(c+0x35c)=0;
-  *(unsigned char*)(c+0x70b)=0;
-  unsigned idx = *(unsigned char*)(c+0x70a);
+}
+
+int Player::St_NoControl_Init()
+{
+  mIsControlDisabled=1;
+  unk_6e6=0;
+  func_ov002_020c9e40(((char*)this));
+  func_ov002_020dab14(((char*)this));
+  mRidingShell=0;
+  mHeldObj=0;
+  unk_35c=0;
+  mIsOpeningBigDoor=0;
+  unsigned idx = mNoCtrlKind;
   struct PMF* m=&data_ov002_02110884[idx];
-  char* obj=c + (m->ptr >> 1);
+  char* obj=((char*)this) + (m->ptr >> 1);
   int fn=m->ptr;
   void (*f)(void*);
   if(fn & 1){
@@ -25,5 +31,4 @@ int _ZN6Player17St_NoControl_InitEv(char* c){
   }
   f(obj);
   return 1;
-}
 }

--- a/src/_ZN6Player17St_NoControl_MainEv.cpp
+++ b/src/_ZN6Player17St_NoControl_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player17St_NoControl_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -6,148 +12,128 @@ typedef short s16;
 typedef int s32;
 
 extern "C" {
-extern int func_0200ee68(void);
 extern short GetAngleToCamera(int i);
-extern void func_ov002_020c965c(char* c);
-extern int func_ov002_020c94a4(char* c);
-extern void func_ov002_020c92fc(char* c);
-extern void func_ov002_020c9288(char* c);
-extern void func_ov002_020c924c(char* c);
-extern int func_ov002_020c91bc(char* c);
 extern void func_ov002_020c9718(char* c);
-extern int func_ov002_020c9128(char* c);
-extern void func_ov002_020c8cb0(char* c);
-extern void func_ov002_020c904c(char* c);
-extern void func_ov002_020c8f80(char* c);
-extern void func_ov002_020c8f0c(char* c);
-extern void func_ov002_020c8b54(char* c);
 extern void func_ov002_020c8a4c(char* c);
-extern void func_ov002_020c897c(char* c);
-extern void func_ov002_020c8d14(char* c);
-extern void func_ov002_020c8b78(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, unsigned int id, int flags, int speed, unsigned int extra);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, unsigned int a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* thiz, int f);
 extern int _ZN6Player12FinishedAnimEv(void* thiz);
-extern void func_ov002_020c8714(char* c);
-extern int func_ov002_020c8540(char* c);
-extern int func_ov002_020c84b0(char* c);
 extern void func_ov002_020bedd4(char* c);
 
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player17St_NoControl_MainEv(char* self)
+int Player::St_NoControl_Main()
 {
-    u8 mode = *(u8*)(self + 0x70a);
-    if (mode == 0 || mode == 1 || (mode == 0x11 && *(u8*)(self + 0x6e3) != 0x18)) {
+    u8 mode = mNoCtrlKind;
+    if (mode == 0 || mode == 1 || (mode == 0x11 && mStateStep != 0x18)) {
         if (func_0200ee68() == 0) {
-            *(s16*)(self + 0x8e) = GetAngleToCamera(*(u8*)(self + 0x6d8));
-            *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
+            mAngleY = GetAngleToCamera(mPlayerNo);
+            mTargetAngleY = mAngleY;
         }
     }
 
-    switch (*(u8*)(self + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        func_ov002_020c965c(self);
+        func_ov002_020c965c(((char*)this));
         break;
     case 1:
-        if (func_ov002_020c94a4(self) != 0)
+        if (func_ov002_020c94a4(((char*)this)) != 0)
             return 1;
         break;
     case 2:
     case 9:
-        func_ov002_020c92fc(self);
+        func_ov002_020c92fc(((char*)this));
         break;
     case 10:
-        func_ov002_020c9288(self);
+        func_ov002_020c9288(((char*)this));
         break;
     case 20:
-        func_ov002_020c924c(self);
+        func_ov002_020c924c(((char*)this));
         return 1;
     case 21:
-        if (func_ov002_020c91bc(self) != 0)
+        if (func_ov002_020c91bc(((char*)this)) != 0)
             return 1;
         break;
     case 3:
     case 6:
-        if (*(u16*)(self + 0x6a6) == 0)
-            *(int*)(self + 0x98) = 0;
-        if (*(u8*)(self + 0x70a) == 6 && *(u8*)(self + 0x706) != 0) {
-            *(int*)(self + 0x9c) = 0;
-            *(int*)(self + 0xa8) = 0;
+        if (mStateWaitTimer == 0)
+            mHorzSpeed = 0;
+        if (mNoCtrlKind == 6 && mIsUnderwater != 0) {
+            mVertAccel = 0;
+            mVertSpeed = 0;
         } else {
-            func_ov002_020c9718(self);
+            func_ov002_020c9718(((char*)this));
         }
-        if (*(u8*)(self + 0x70a) == 0 || *(u8*)(self + 0x70a) == 3)
+        if (mNoCtrlKind == 0 || mNoCtrlKind == 3)
             return 1;
         break;
     case 4:
     case 5:
-        if (func_ov002_020c9128(self) != 0)
+        if (func_ov002_020c9128(((char*)this)) != 0)
             return 1;
         break;
     case 7:
     case 8:
-        func_ov002_020c8cb0(self);
+        func_ov002_020c8cb0(((char*)this));
         break;
     case 11:
-        func_ov002_020c904c(self);
+        func_ov002_020c904c(((char*)this));
         break;
     case 12:
-        func_ov002_020c8f80(self);
+        func_ov002_020c8f80(((char*)this));
         break;
     case 13:
-        func_ov002_020c8f0c(self);
+        func_ov002_020c8f0c(((char*)this));
         break;
     case 14:
-        func_ov002_020c8b54(self);
+        func_ov002_020c8b54(((char*)this));
         break;
     case 15:
-        func_ov002_020c8a4c(self);
+        func_ov002_020c8a4c(((char*)this));
         break;
     case 16:
-        func_ov002_020c897c(self);
+        func_ov002_020c897c(((char*)this));
         break;
     case 17:
-        func_ov002_020c8d14(self);
+        func_ov002_020c8d14(((char*)this));
         break;
     case 18:
-        func_ov002_020c8b78(self);
+        func_ov002_020c8b78(((char*)this));
         break;
     case 19:
-        if (*(u8*)(self + 0x70b) == 0)
-            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211013c);
+        if (mIsOpeningBigDoor == 0)
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         break;
     case 22:
-        if (*(u8*)(self + 0x6de) == 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x98, 0x40000000, 0x1000, 0);
-            *(u8*)(self + 0x6e3) = 0x17;
+        if (mIsAirborne == 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x98, 0x40000000, 0x1000, 0);
+            mStateStep = 0x17;
         }
         break;
     case 23: {
-        int id = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self + 8) & 0xff, 0);
-        char* anim = (char*)((int*)(self + 0xdc))[id] + 0x50;
+        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        char* anim = (char*)((int*)((char*)&mBodyModels))[id] + 0x50;
         if (_ZNK9Animation12WillHitFrameEi(anim, 0x1c))
-            *(u8*)(self + 0x71a) = 0;
-        if (_ZN6Player12FinishedAnimEv(self))
-            _ZN6Player11ChangeStateERNS_5StateE(self, data_ov002_0211013c);
+            unk_71a = 0;
+        if (_ZN6Player12FinishedAnimEv(((char*)this)))
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         break;
     }
     case 24:
-        func_ov002_020c8714(self);
+        func_ov002_020c8714(((char*)this));
         break;
     case 25:
-        if (func_ov002_020c8540(self) != 0)
+        if (func_ov002_020c8540(((char*)this)) != 0)
             return 1;
         break;
     case 26:
-        if (func_ov002_020c84b0(self) != 0)
+        if (func_ov002_020c84b0(((char*)this)) != 0)
             return 1;
         break;
     }
 
-    func_ov002_020bedd4(self);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_PunchKick_InitEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_InitEv.cpp
@@ -1,22 +1,28 @@
 //cpp
+// @symbol _ZN6Player17St_PunchKick_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void*);
-extern int func_ov002_020dc020(void*);
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12CylinderClsn6UpdateEv(void*);
-int _ZN6Player17St_PunchKick_InitEv(void* c){
-  *(int*)((char*)c+0x684)=*(int*)((char*)c+0x60);
-  *(char*)((char*)c+0x726)=0;
-  *(short*)((char*)c+0x6a4)=2;
-  *(char*)((char*)c+0x6e6)=0;
-  if(*(unsigned char*)((char*)c+0x6e2)==2 || _ZN6Player15IsCollectingCapEv(c)) return 1;
-  if(*(unsigned char*)((char*)c+0x703)==0){
-    func_ov002_020dc020(c);
-    _ZN12CylinderClsn5ClearEv((char*)c+0x314);
-    _ZN12CylinderClsn6UpdateEv((char*)c+0x314);
+}
+
+int Player::St_PunchKick_Init()
+{
+  *(int*)((char*)&mPeakY)=*(int*)((char*)&mPosY);
+  *(char*)((char*)&unk_726)=0;
+  *(short*)((char*)&mStateTimer)=2;
+  *(char*)((char*)&unk_6e6)=0;
+  if(*(unsigned char*)((char*)&mPunchKickStep)==2 || _ZN6Player15IsCollectingCapEv(((void*)this))) return 1;
+  if(*(unsigned char*)((char*)&mIsMega)==0){
+    func_ov002_020dc020(((void*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mAttackClsn);
   } else {
-    _ZN12CylinderClsn5ClearEv((char*)c+0x314);
+    _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
   }
   return 1;
-}
 }

--- a/src/_ZN6Player17St_PunchKick_MainEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player17St_PunchKick_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -7,10 +13,7 @@ typedef unsigned char u8;
 typedef s32 Fix12;
 
 extern "C" {
-extern void func_ov002_020dd5ec(void* c);
-extern void _ZN6Player17St_PunchKick_InitEv(void* c);
 extern void func_ov002_020d8a50(void* c, u32 a);
-extern int func_ov002_020e2c84(char* self);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern void func_ov002_020c2f64(void* c);
 extern int func_ov002_020c0434(char* c);
@@ -27,77 +30,77 @@ extern s16 data_0209f4a0[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player17St_PunchKick_MainEv(char* c)
+int Player::St_PunchKick_Main()
 {
-    u16 st = *(u16*)(c + 0x6a4);
+    u16 st = mStateTimer;
 
     if (st != 0) {
         if (st == 1) {
-            func_ov002_020dd5ec(c);
+            func_ov002_020dd5ec(((char*)this));
         }
     } else {
-        if (*(u16*)(c + 0x6aa) == 0) {
+        if (unk_6aa == 0) {
             u8 idx = data_020a0e40;
             u16 flags = *(u16*)((char*)data_0209f49e + idx * 0x18);
-            if ((flags & 1) != 0 && *(u8*)(c + 0x6e2) < 2) {
-                u8* p = (u8*)(((long long)(int)(c + 0x6e2)) & 0xFFFFFFFFFFFFFFFFLL);
+            if ((flags & 1) != 0 && mPunchKickStep < 2) {
+                u8* p = (u8*)(((long long)(int)((char*)&mPunchKickStep)));
                 (*p)++;
-                _ZN6Player17St_PunchKick_InitEv(c);
+                _ZN6Player17St_PunchKick_InitEv(((char*)this));
                 return 1;
             }
         }
 
-        func_ov002_020d8a50(c, *(u8*)(c + 0x6e2));
+        func_ov002_020d8a50(((char*)this), mPunchKickStep);
 
-        if (*(u8*)(c + 0x6de) != 0)
+        if (mIsAirborne != 0)
             goto end;
 
-        if (*(u8*)(c + 0x6e2) == 2 && *(u8*)(c + 0x6e6) == 0) {
-            *(u8*)(c + 0x6e6) = 1;
-            if (func_ov002_020e2c84(c) != 0)
+        if (mPunchKickStep == 2 && unk_6e6 == 0) {
+            unk_6e6 = 1;
+            if (func_ov002_020e2c84(((char*)this)) != 0)
                 return 1;
         }
 
-        _Z14ApproachLinearRiii((int*)(c + 0x98), 0, 0x800);
-        func_ov002_020c2f64(c);
+        _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), 0, 0x800);
+        func_ov002_020c2f64(((char*)this));
 
-        if (func_ov002_020c0434(c) != 0) {
-            func_ov002_020c0364(c, 3);
+        if (func_ov002_020c0434(((char*)this)) != 0) {
+            func_ov002_020c0364(((char*)this), 3);
             return 1;
         }
 
-        if (_ZN6Player12FinishedAnimEv(c) || *(u8*)(c + 0x6e2) == 2) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
-            *(u16*)(c + 0x6aa) = 0x10;
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) || mPunchKickStep == 2) {
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
+            unk_6aa = 0x10;
 
-            if (*(u8*)(c + 0x6e2) != 2)
-                *(int*)(c + 0x98) = 0;
+            if (mPunchKickStep != 2)
+                mHorzSpeed = 0;
 
-            if (*(s16*)(c + 0x94) != *(s16*)(c + 0x8e)) {
-                *(int*)(c + 0x98) = 0;
-                *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+            if (mTargetAngleY != mAngleY) {
+                mHorzSpeed = 0;
+                mTargetAngleY = mAngleY;
             }
 
             {
                 u8 idx2 = data_020a0e40;
                 s16 val = *(s16*)((char*)data_0209f4a0 + idx2 * 0x18);
-                if (val == 0 && *(u8*)(c + 0x6e2) == 2) {
-                    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x52, 0x40000000, 0x1000, 0);
-                    *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-                    *(int*)(c + 0x98) = 0;
+                if (val == 0 && mPunchKickStep == 2) {
+                    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x52, 0x40000000, 0x1000, 0);
+                    mTargetAngleY = mAngleY;
+                    mHorzSpeed = 0;
                 }
             }
 
-            if (*(u8*)(c + 0x6e2) != 2)
+            if (mPunchKickStep != 2)
                 goto end;
-            if (*(u8*)(c + 0x707) != 0)
+            if (mIsInShallowWater != 0)
                 goto end;
 
-            func_ov002_020bf9d4(c);
+            func_ov002_020bf9d4(((char*)this));
         }
     }
 
 end:
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player17St_SlideKick_InitEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_InitEv.cpp
@@ -1,19 +1,22 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN6Player17St_SlideKick_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, const Vector3&);
 extern "C" int RandomIntInternal(int* seed);
 extern "C" void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, const Vector3&);
 extern "C" void _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
 extern int data_ov002_0210e160;
-extern int data_ov002_020ff130[];
 
-extern "C" int _ZN6Player17St_SlideKick_InitEv(void* thisptr)
+int Player::St_SlideKick_Init()
 {
-    unsigned char* p = (unsigned char*)thisptr;
+    unsigned char* p = (unsigned char*)((void*)this);
     _ZN5Sound9PlayBank0EjRK7Vector3(0x11, *(Vector3*)(p + 0x74));
     unsigned int r = (unsigned int)RandomIntInternal(&data_ov002_0210e160);
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(p[0x6d9], data_ov002_020ff130[(r >> 4) & 1], *(Vector3*)(p + 0x74));
-    _ZN6Player7SetAnimEji5Fix12IiEj(thisptr, 0x67, 0x40000000, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x67, 0x40000000, 0x1000, 0);
     int* yv = (int*)(((int)p + 0x98) & 0xFFFFFFFFFFFFFFFF);
     *(int*)(p + 0xa8) = 0x14000;
     yv[0] += 0xf000;

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player17St_SlideKick_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -16,7 +21,6 @@ extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int func_ov002_020c0688(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern void func_ov002_020dbaec(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
 extern void func_ov002_020bedd4(void* c);
@@ -24,49 +28,48 @@ extern void func_ov002_020bedd4(void* c);
 extern int data_ov002_021104e4[];
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
-extern int data_ov002_021101fc[];
 extern int data_ov002_021101b4[];
 }
 
-extern "C" int _ZN6Player17St_SlideKick_MainEv(char* c)
+int Player::St_SlideKick_Main()
 {
-    func_ov002_020bf90c(c);
-    if (*(u8*)(c + 0x6de) == 0) {
-        *(u8*)(c + 0x6e4) = 1;
-        func_ov002_020c06fc(c, 0x4000);
-        func_ov002_020dd2f4(c);
+    func_ov002_020bf90c(((char*)this));
+    if (mIsAirborne == 0) {
+        mIsSlidingOnGround = 1;
+        func_ov002_020c06fc(((char*)this), 0x4000);
+        func_ov002_020dd2f4(((char*)this));
     }
 
-    if (*(int*)(c + 0x98) != 0)
+    if (mHorzSpeed != 0)
         goto La8;
 
-    if (_ZN6Player12FinishedAnimEv(c) == 0)
+    if (_ZN6Player12FinishedAnimEv(((char*)this)) == 0)
         goto L1d8;
 
-    if (_ZN6Player6IsAnimEj(c, 0x67) == 0)
+    if (_ZN6Player6IsAnimEj(((char*)this), 0x67) == 0)
         goto L88;
 
-    _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x66, 0x40000000, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x66, 0x40000000, 0x1000, 0);
     goto L1d8;
 
 L88:
-    *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
-    *(u8*)(c + 0x6e3) = 1;
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021104e4);
+    mTargetAngleY = mAngleY;
+    mStateStep = 1;
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021104e4);
     goto L1d8;
 
 La8:
-    if (func_ov002_020c0688(c) == 0)
+    if (func_ov002_020c0688(((char*)this)) == 0)
         goto L14c;
 
-    if (*(u8*)(c + 0x6e5) == 0) {
-        if (*(int*)(c + 0x640) < 0) {
-            u16 bit = *(u16*)(c + 0x600 + 0xce) & 1;
+    if (mStateWork == 0) {
+        if (mPrevVertSpeed < 0) {
+            u16 bit = *(u16*)(((char*)this) + 0x600 + 0xce) & 1;
             if (bit == 0) {
-                int t = -*(int*)(c + 0x640);
+                int t = -mPrevVertSpeed;
                 if (t > 0x14000) t = 0x14000;
-                *(int*)(c + 0xa8) = t;
-                *(u8*)(c + 0x6e5) = 1;
+                mVertSpeed = t;
+                mStateWork = 1;
             }
         }
     }
@@ -74,37 +77,37 @@ La8:
     {
         u16 r1 = *(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18);
         if ((r1 & 1) || (r1 & 2)) {
-            if (*(u8*)(c + 0x70e) == 0) {
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101fc);
+            if (mSlideType == 0) {
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101fc);
             }
         }
     }
-    *(u8*)(c + 0x6e3) = 0;
+    mStateStep = 0;
     goto L18c;
 
 L14c:
-    *(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
-        *(u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
-    if (*(u8*)(c + 0x6e3) <= 0x1e)
+    *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
+        *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
+    if (mStateStep <= 0x1e)
         goto L18c;
-    if (*(int*)(c + 0x60) - *(int*)(c + 0x644) <= 0x64000)
+    if (mPosY - mGroundY <= 0x64000)
         goto L18c;
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
 
 L18c:
     {
-        int id = _ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0);
-        void* anim = *(void**)(c + (id << 2) + 0xdc);
+        int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
+        void* anim = *(void**)(((char*)this) + (id << 2) + 0xdc);
         u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50)) & 0xFFFFFFFFFFFFFFFFLL) + 8);
         if ((u16)(w >> 12) < 4)
             goto L1d8;
-        func_ov002_020dbaec(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x314);
-        _ZN12CylinderClsn6UpdateEv(c + 0x314);
+        func_ov002_020dbaec(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
+        _ZN12CylinderClsn6UpdateEv((char*)&mAttackClsn);
     }
 
 L1d8:
-    func_ov002_020bedd4(c);
-    *(int*)(c + 0x640) = *(int*)(c + 0xa8);
+    func_ov002_020bedd4(((char*)this));
+    mPrevVertSpeed = mVertSpeed;
     return 1;
 }

--- a/src/_ZN6Player17St_SlopeJump_InitEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_InitEv.cpp
@@ -1,24 +1,29 @@
 //cpp
+// @symbol _ZN6Player17St_SlopeJump_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020e2b6c(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int func_ov002_020e2ad0(void*);
 extern int func_ov002_020e25f0(void*,int);
-int _ZN6Player17St_SlopeJump_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=0;
-  if(func_ov002_020e2b6c(c)) return 1;
-  *(unsigned char*)(c+0x712)=1;
-  *(unsigned char*)(c+0x70d)=0;
-  *(unsigned char*)(c+0x6e1)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x53,0x40000000,0x1000,0);
-  *(int*)(c+0xa8)=0x2a000;
-  func_ov002_020e2ad0(c);
-  if(*(int*)(c+0x98)>0){
-    *(int*)(c+0x98)=(int)(((long long)*(int*)(c+0x98)*0xc00+0x800)>>12);
-  }
-  func_ov002_020e25f0(c,0);
-  return 1;
 }
+
+int Player::St_SlopeJump_Init()
+{
+  mJumpedFromQuicksand=0;
+  if(func_ov002_020e2b6c(((char*)this))) return 1;
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  mJumpComboStage=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x53,0x40000000,0x1000,0);
+  mVertSpeed=0x2a000;
+  func_ov002_020e2ad0(((char*)this));
+  if(mHorzSpeed>0){
+    mHorzSpeed=(int)(((long long)mHorzSpeed*0xc00+0x800)>>12);
+  }
+  func_ov002_020e25f0(((char*)this),0);
+  return 1;
 }

--- a/src/_ZN6Player17St_SlopeJump_MainEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player17St_SlopeJump_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void _Z14ApproachLinearRiii(int*,int,int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
@@ -8,22 +11,24 @@ extern char data_ov002_02110034[];
 extern char data_ov002_021105bc[];
 extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
-int _ZN6Player17St_SlopeJump_MainEv(char* c){
-  _Z14ApproachLinearRiii((int*)(c+0x98),0,0x800);
-  if(*(unsigned char*)(c+0x6de)==0){
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211013c);
+}
+
+int Player::St_SlopeJump_Main()
+{
+  _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed),0,0x800);
+  if(mIsAirborne==0){
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211013c);
   }
   if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 1){
-    *(short*)(c+0x94)=*(short*)(c+0x8e);
-    if(*(unsigned char*)(c+0x703)==0){
-      if(*(int*)(c+8)==3){
-        _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_02110034);
+    mTargetAngleY=mAngleY;
+    if(mIsMega==0){
+      if(mParam==3){
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_02110034);
       }else{
-        _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_021105bc);
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_021105bc);
       }
     }
   }
-  func_ov002_020bedd4(c);
+  func_ov002_020bedd4(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player17St_SweepKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SweepKick_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player17St_SweepKick_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int func_ov002_020d8a50(void*,int);
@@ -6,17 +11,18 @@ extern int _ZN6Player12FinishedAnimEv(void*);
 extern int func_ov002_020bedd4(void*);
 extern unsigned char data_020a0e40[];
 extern unsigned short data_0209f49e[];
-extern int data_ov002_0211019c[];
 extern int data_ov002_021104e4[];
-int _ZN6Player17St_SweepKick_MainEv(void* c){
-  if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 2)
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211019c);
-  func_ov002_020d8a50(c,3);
-  if(_ZN6Player12FinishedAnimEv(c)){
-    *(char*)((char*)c+0x6e3)=1;
-    _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_021104e4);
-  }
-  func_ov002_020bedd4(c);
-  return 1;
 }
+
+int Player::St_SweepKick_Main()
+{
+  if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 2)
+    _ZN6Player11ChangeStateERNS_5StateE(((void*)this),data_ov002_0211019c);
+  func_ov002_020d8a50(((void*)this),3);
+  if(_ZN6Player12FinishedAnimEv(((void*)this))){
+    *(char*)((char*)&mStateStep)=1;
+    _ZN6Player11ChangeStateERNS_5StateE(((void*)this),data_ov002_021104e4);
+  }
+  func_ov002_020bedd4(((void*)this));
+  return 1;
 }

--- a/src/_ZN6Player17St_Thrown_CleanupEv.cpp
+++ b/src/_ZN6Player17St_Thrown_CleanupEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player17St_Thrown_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // Player::St_Thrown_Cleanup - clear flag bit 0x2000 in the u32 at this+0x2ec, return 1.
 // The u64-mask launder forces the base to materialize (add r2,this,#0x2ec) so the
 // load/store reuse it, matching the ROM instead of folding the offset into ldr/str.
-extern "C" {
-int _ZN6Player17St_Thrown_CleanupEv(char *c)
+
+int Player::St_Thrown_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x2000;
+    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x2000;
     return 1;
-}
 }

--- a/src/_ZN6Player17St_WallSlide_InitEv.cpp
+++ b/src/_ZN6Player17St_WallSlide_InitEv.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN6Player17St_WallSlide_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player17St_WallSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x29,0x40000000,0x1000,0);
-  *(int*)(c+0x98)=0;
-  if(*(int*)(c+0xa8) >= 0) *(int*)(c+0xa8)=0;
-  *(short*)(c+0x6a4)=7;
-  return 1;
 }
+
+int Player::St_WallSlide_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x29,0x40000000,0x1000,0);
+  mHorzSpeed=0;
+  if(mVertSpeed >= 0) mVertSpeed=0;
+  mStateTimer=7;
+  return 1;
 }

--- a/src/_ZN6Player17St_WaterJump_InitEv.cpp
+++ b/src/_ZN6Player17St_WaterJump_InitEv.cpp
@@ -1,20 +1,25 @@
 //cpp
+// @symbol _ZN6Player17St_WaterJump_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int func_ov002_020e25f0(void*,int);
-int _ZN6Player17St_WaterJump_InitEv(char* c){
-  *(char*)(c+0x71b)=0;
-  *(char*)(c+0x712)=1;
-  *(char*)(c+0x70d)=0;
-  *(char*)(c+0x6e1)=0;
-  *(char*)(c+0x6de)=1;
-  *(char*)(c+0x6df)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x53,0x40000000,0x1000,0);
-  *(int*)(c+0xa8)=0x2a000;
-  *(int*)(c+0x98)=0x12000;
-  _ZN5Sound9PlayBank0EjRK7Vector3(0x18,(char*)c+0x74);
-  func_ov002_020e25f0(c,0);
-  return 1;
 }
+
+int Player::St_WaterJump_Init()
+{
+  mJumpedFromQuicksand=0;
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  mJumpComboStage=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x53,0x40000000,0x1000,0);
+  mVertSpeed=0x2a000;
+  mHorzSpeed=0x12000;
+  _ZN5Sound9PlayBank0EjRK7Vector3(0x18,(char*)((char*)this)+0x74);
+  func_ov002_020e25f0(((char*)this),0);
+  return 1;
 }

--- a/src/_ZN6Player17St_WindCarry_InitEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_InitEv.cpp
@@ -1,16 +1,22 @@
 //cpp
+// @symbol _ZN6Player17St_WindCarry_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020da9d4(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int data_0209f318[];
-extern void func_0200d63c(void*,unsigned char);
-int _ZN6Player17St_WindCarry_InitEv(char* c){
-  func_ov002_020da9d4(c);
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x4a,0x40000000,0x1000,0);
-  *(int*)(c+0xa8)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  func_0200d63c((void*)data_0209f318[0], *(unsigned char*)(c+0x6d8));
-  return 1;
 }
+
+int Player::St_WindCarry_Init()
+{
+  func_ov002_020da9d4(((char*)this));
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x4a,0x40000000,0x1000,0);
+  mVertSpeed=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  func_0200d63c((void*)data_0209f318[0], mPlayerNo);
+  return 1;
 }

--- a/src/_ZN6Player18HasFinishedTalkingEv.cpp
+++ b/src/_ZN6Player18HasFinishedTalkingEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN6Player18HasFinishedTalkingEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_0211046c;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player18HasFinishedTalkingEv(char* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c,&data_ov002_0211046c) && *(unsigned char*)(c+0x6e3)==3){
-    *(unsigned char*)(c+0x6e3)=4;
+}
+
+int Player::HasFinishedTalking()
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)this),&data_ov002_0211046c) && mStateStep==3){
+    mStateStep=4;
     return 1;
   }
   return 0;
-}
 }

--- a/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
+++ b/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player18SetNewHatCharacterEjjb
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 struct State;
 extern State data_ov002_02110604;
 extern State data_ov002_0211013c;
@@ -12,30 +15,30 @@ void func_ov002_020da95c(char* c);
 void _ZN6Player11ChangeStateERNS_5StateE(char* c, State& s);
 void func_02012790(int n);
 void func_ov002_020e6350(char* c);
+}
 
-void _ZN6Player18SetNewHatCharacterEjjb(char* c, unsigned int p1, unsigned int p2, bool p3)
+void Player::SetNewHatCharacter(unsigned int p1, unsigned int p2, bool p3)
 {
-  unsigned int old = *(unsigned int*)(c + 8);
+  unsigned int old = mParam;
   if (p1 == old) return;
-  *(unsigned char*)(c + 0x6dc) = (unsigned char)old;
-  *(unsigned char*)(c + 0x6dd) = (unsigned char)p1;
-  *(unsigned short*)((char*)(((int)c + 0x700) & 0xFFFFFFFFFFFFFFFF) + 0x3c) = 1;
-  if (p1 != *(unsigned char*)(c + 0x6d9)) {
-    *(unsigned short*)((char*)(((int)c + 0x73c) & 0xFFFFFFFFFFFFFFFF)) |= 0x8000;
+  unk_6dc = (unsigned char)old;
+  mHatCharacter = (unsigned char)p1;
+  *(unsigned short*)((char*)(((int)((char*)this) + 0x700) & 0xFFFFFFFFFFFFFFFF) + 0x3c) = 1;
+  if (p1 != mCharacter) {
+    *(unsigned short*)((char*)(((int)((char*)this) + 0x73c) & 0xFFFFFFFFFFFFFFFF)) |= 0x8000;
   }
-  func_ov002_020bdb50(c, p2);
-  func_ov002_020bda48(c);
-  if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110604)) {
-    func_ov002_020d9c70(c);
-    func_ov002_020da95c(c);
-    _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+  func_ov002_020bdb50(((char*)this), p2);
+  func_ov002_020bda48(((char*)this));
+  if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_02110604)) {
+    func_ov002_020d9c70(((char*)this));
+    func_ov002_020da95c(((char*)this));
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
   }
   if (p3 == 0) {
-    if (p1 != *(unsigned char*)(c + 0x6d9)) func_02012790(0xb);
+    if (p1 != mCharacter) func_02012790(0xb);
     else func_02012790(0xc);
   }
-  *(unsigned int*)(c + 8) = *(unsigned char*)(c + 0x6dd);
-  func_ov002_020e6350(c);
-  *(unsigned int*)(c + 8) = *(unsigned char*)(c + 0x6dc);
-}
+  mParam = mHatCharacter;
+  func_ov002_020e6350(((char*)this));
+  mParam = unk_6dc;
 }

--- a/src/_ZN6Player18St_CameraZoom_InitEv.cpp
+++ b/src/_ZN6Player18St_CameraZoom_InitEv.cpp
@@ -1,20 +1,26 @@
 //cpp
+// @symbol _ZN6Player18St_CameraZoom_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 struct Camera;
 extern "C" {
 extern int func_0200d064(struct Camera* thiz, int playerID);
 extern void func_0200d7e0(struct Camera* thiz, int playerID);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
-extern unsigned char data_0209f28c;
-int _ZN6Player18St_CameraZoom_InitEv(void* c){
-  *(int*)((char*)c+0x98)=0;
-  *(int*)((char*)c+0xa8)=0;
+}
+
+int Player::St_CameraZoom_Init()
+{
+  *(int*)((char*)&mHorzSpeed)=0;
+  *(int*)((char*)&mVertSpeed)=0;
   struct Camera* cam = data_0209f318;
-  int pid = *(unsigned char*)((char*)c+0x6d8);
+  int pid = *(unsigned char*)((char*)&mPlayerNo);
   func_0200d064(cam, pid);
-  func_0200d7e0(cam, *(unsigned char*)((char*)c+0x6d8));
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
+  func_0200d7e0(cam, *(unsigned char*)((char*)&mPlayerNo));
+  _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this),0x47,0,0x1000,0);
   data_0209f28c=0;
   return 1;
-}
 }

--- a/src/_ZN6Player18St_DizzyStars_InitEv.cpp
+++ b/src/_ZN6Player18St_DizzyStars_InitEv.cpp
@@ -1,9 +1,12 @@
 //cpp
-extern "C" {
-int _ZN6Player18St_DizzyStars_InitEv(char *c)
+// @symbol _ZN6Player18St_DizzyStars_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
+
+
+int Player::St_DizzyStars_Init()
 {
-    *(short *)(c + 0x6a4) = 0x12c;
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
+    mStateTimer = 0x12c;
+    *(int *)(((int)((char *)this) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
     return 1;
-}
 }

--- a/src/_ZN6Player18St_LevelEnter_InitEv.cpp
+++ b/src/_ZN6Player18St_LevelEnter_InitEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player18St_LevelEnter_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef signed short s16;
@@ -6,7 +11,6 @@ typedef unsigned int u32;
 typedef int s32;
 typedef long long s64;
 
-struct Vector3 { int x, y, z; };
 
 typedef struct RaycastGround {
     char pre[0x10];
@@ -30,129 +34,128 @@ void _ZN6Player16InitWingFeathersEb(void* self, int b);
 void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 }
 
-extern u32 data_ov002_0210a7e8[];
 extern u8 data_0209f2d8;
 extern s16 data_02082214[];
 extern signed char data_0209f2f8;
 extern u8 data_0209f264;
 extern u8 data_0209f2fc;
 
-extern "C" int _ZN6Player18St_LevelEnter_InitEv(char* self)
+int Player::St_LevelEnter_Init()
 {
     RaycastGround rg;
 
-    u32 anim = data_ov002_0210a7e8[*(u8*)(self + 0x6e3)];
+    u32 anim = data_ov002_0210a7e8[mStateStep];
     if (_ZN8SaveData16HasPlayerLostCapEv() != 0) {
         if (anim == 0x85) anim = 0xa5;
     }
-    _ZN6Player7SetAnimEji5Fix12IiEj(self, anim, 0, 0x1000, 0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), anim, 0, 0x1000, 0);
 
-    u8 st = *(u8*)(self + 0x6e3);
+    u8 st = mStateStep;
     if (st != 3 && st != 0xa && st != 0) {
         _ZN9Animation8SetFlagsEi(
-            *(char**)((self + (_ZNK6Player14GetBodyModelIDEjb(self, (u8)*(int*)(self + 8), 0) * 4)) + 0xdc) + 0x50,
+            *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4)) + 0xdc) + 0x50,
             0x40000000);
-        if (*(u8*)(self + 0x6e3) == 2) {
-            char* p = *(char**)((self + (_ZNK6Player14GetBodyModelIDEjb(self, (u8)*(int*)(self + 8), 0) * 4)) + 0xdc) + 0x50;
+        if (mStateStep == 2) {
+            char* p = *(char**)((((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), (u8)mParam, 0) * 4)) + 0xdc) + 0x50;
             *(int*)(p + 8) = 0x14000;
         }
     }
 
-    *(signed char*)(self + 0x719) = -1;
-    func_ov002_020c9e40(self);
-    *(u8*)(self + 0x6e1) = 0;
-    *(int*)(self + 0x98) = 0;
-    *(u8*)(self + 0x70c) = 0;
-    *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
-    *(u8*)(self + 0x6e5) = 0;
+    unk_719 = -1;
+    func_ov002_020c9e40(((char*)this));
+    mJumpComboStage = 0;
+    mHorzSpeed = 0;
+    mStateArg = 0;
+    mTargetAngleY = mAngleY;
+    mStateWork = 0;
     _ZN13RaycastGroundC1Ev(&rg);
 
-    switch (*(u8*)(self + 0x6e3)) {
+    switch (mStateStep) {
     case 0: {
         Vector3 pos;
         int hit;
-        int y = *(int*)(self + 0x60);
-        int z = *(int*)(self + 0x64);
-        int x = *(int*)(self + 0x5c);
+        int y = mPosY;
+        int z = mPosZ;
+        int x = mPosX;
         int w = y + 0xc8000;
         pos.x = x;
         pos.y = w;
         pos.z = z;
-        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &pos, self);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &pos, ((char*)this));
         hit = 0x80000000;
         if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0) hit = rg.clsnY;
-        *(int*)(self + 0x60) = hit;
-        *(u8*)(self + 0x6e5) = 2;
+        mPosY = hit;
+        mStateWork = 2;
         {
             int b = (data_0209f2d8 == 2);
-            if (b == 0) *(s16*)(self + 0x6a6) = 0x1e;
-            else *(s16*)(self + 0x6a6) = 0;
+            if (b == 0) mStateWaitTimer = 0x1e;
+            else mStateWaitTimer = 0;
         }
         break;
     }
     case 1:
-        *(int*)(self + 0x9c) = 0;
-        *(u8*)(self + 0x6e5) = 4;
-        *(u8*)(self + 0x706) = 1;
+        mVertAccel = 0;
+        mStateWork = 4;
+        mIsUnderwater = 1;
         break;
     case 5:
     case 15:
-        *(u8*)(self + 0x70c) = 1;
+        mStateArg = 1;
         break;
     case 11:
     case 12: {
         s32 idx;
         s16 cosv, sinv;
-        if (func_ov002_020c7cbc(self) != 0) *(u8*)(self + 0x6e3) = 0x12;
-        *(int*)(((long long)(int)(self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x64000;
-        idx = ((s32)(u16)(s16)(*(s16*)(self + 0x8e) + 0x8000) >> 4) * 2;
+        if (func_ov002_020c7cbc(((char*)this)) != 0) mStateStep = 0x12;
+        *(int*)(((long long)(int)((char*)&mPosY))) += 0x64000;
+        idx = ((s32)(u16)(s16)(mAngleY + 0x8000) >> 4) * 2;
         cosv = data_02082214[idx];
         sinv = data_02082214[idx + 1];
-        *(int*)(((long long)(int)(self + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL) += (int)(((s64)0xa0000 * cosv + 0x800) >> 12);
-        *(int*)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL) += (int)(((s64)0xa0000 * sinv + 0x800) >> 12);
-        *(s16*)(self + 0x6a4) = 0x20;
-        *(u8*)(self + 0x70c) = 1;
-        *(int*)(self + 0x9c) = 0;
-        *(u8*)(self + 0x6e5) = 5;
+        *(int*)(((long long)(int)((char*)&mPosX))) += (int)(((s64)0xa0000 * cosv + 0x800) >> 12);
+        *(int*)(((long long)(int)((char*)&mPosZ))) += (int)(((s64)0xa0000 * sinv + 0x800) >> 12);
+        mStateTimer = 0x20;
+        mStateArg = 1;
+        mVertAccel = 0;
+        mStateWork = 5;
         break;
     }
     case 8:
     case 9:
-        if (func_ov002_020c7cbc(self) != 0) *(u8*)(self + 0x6e3) = 0x10;
-        *(s16*)(self + 0x6a4) = 2;
-        *(u8*)(self + 0x70c) = 1;
-        *(int*)(self + 0x9c) = 0;
-        *(u8*)(self + 0x6e5) = 5;
+        if (func_ov002_020c7cbc(((char*)this)) != 0) mStateStep = 0x10;
+        mStateTimer = 2;
+        mStateArg = 1;
+        mVertAccel = 0;
+        mStateWork = 5;
         break;
     case 13:
     case 17: {
-        u8 st2 = *(u8*)(self + 0x6e3);
-        if (st2 == 0x11) *(s16*)(self + 0x6a4) = 2;
-        else *(s16*)(self + 0x6a4) = 0x20;
-        *(u8*)(self + 0x70c) = 1;
-        *(int*)(self + 0x9c) = 0;
-        *(u8*)(self + 0x6e5) = 5;
+        u8 st2 = mStateStep;
+        if (st2 == 0x11) mStateTimer = 2;
+        else mStateTimer = 0x20;
+        mStateArg = 1;
+        mVertAccel = 0;
+        mStateWork = 5;
         if (data_0209f2f8 == 0x18) func_02012790(0x16);
         else if (data_0209f2f8 == 0x19) func_02012790(0x17);
         break;
     }
     case 2:
-        if (*(int*)(self + 8) != 0) {
-            *(u8*)(self + 0x6e3) = 0xa;
-            _ZN6Player7SetAnimEji5Fix12IiEj(self, data_ov002_0210a7e8[*(u8*)(self + 0x6e3)], 0, 0x1000, 0);
+        if (mParam != 0) {
+            mStateStep = 0xa;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a7e8[mStateStep], 0, 0x1000, 0);
         } else {
-            _ZN6Player16InitWingFeathersEb(self, 0);
-            *(u8*)(self + 0x6e5) = 3;
-            *(int*)(self + 0xa8) = 0;
-            *(int*)(self + 0x9c) = 0;
+            _ZN6Player16InitWingFeathersEb(((char*)this), 0);
+            mStateWork = 3;
+            mVertSpeed = 0;
+            mVertAccel = 0;
         }
         break;
     default:
         break;
     }
 
-    *(u8*)(self + 0x6de) = 1;
-    *(u8*)(self + 0x6df) = 0;
+    mIsAirborne = 1;
+    mLandSoundPlayed = 0;
     {
         u8 c2 = data_0209f264;
         if (data_0209f2f8 == 2) {

--- a/src/_ZN6Player18St_TurnAround_InitEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_InitEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player18St_TurnAround_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player18St_TurnAround_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x46,0x40000000,0x1000,0);
-  *(char*)(c+0x6e3)=0;
-  return 1;
 }
+
+int Player::St_TurnAround_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x46,0x40000000,0x1000,0);
+  mStateStep=0;
+  return 1;
 }

--- a/src/_ZN6Player18St_TurnAround_MainEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player18St_TurnAround_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -8,15 +13,12 @@ typedef s32 Fix12;
 
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern int func_ov002_020bf56c(void* c, int b);
 extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);
 extern Fix12 func_ov002_020bf30c(void* c, Fix12 a);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void func_ov002_020d3498(void* c);
-extern void func_ov002_020bf88c(void* c);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, s16 a5);
 extern void func_ov002_020bedd4(void* c);
 
@@ -24,11 +26,10 @@ extern u16 data_0209f49e[];
 extern u8 data_020a0e40;
 extern s16 data_0209f4a0[];
 extern int data_ov002_021101b4[];
-extern int data_ov002_021101e4[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player18St_TurnAround_MainEv(char* c)
+int Player::St_TurnAround_Main()
 {
     int r5v;
     s16 angle;
@@ -36,37 +37,37 @@ extern "C" int _ZN6Player18St_TurnAround_MainEv(char* c)
     int raw;
     int tmp;
 
-    raw = *(s16*)(c + 0x6d2);
+    raw = mDesiredAngleY;
     if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
         angle = (s16)(raw + 0x8000);
-        sel = (*(int*)(c + 0x98) < 0) ? 0x1800 : 0x8000;
-        r5v = func_ov002_020bf56c(c, sel);
-        ApproachAngle((s16*)(c + 0x94), angle, 0x10, 0x1000, 0x200);
-        tmp = func_ov002_020bf30c(c, 0x28000);
-        _Z14ApproachLinearRiii((int*)(c + 0x98), -tmp, r5v);
+        sel = (mHorzSpeed < 0) ? 0x1800 : 0x8000;
+        r5v = func_ov002_020bf56c(((char*)this), sel);
+        ApproachAngle((s16*)((char*)&mTargetAngleY), angle, 0x10, 0x1000, 0x200);
+        tmp = func_ov002_020bf30c(((char*)this), 0x28000);
+        _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), -tmp, r5v);
     } else {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
 
-    ApproachAngle((s16*)(c + 0x8e), *(s16*)(c + 0x94), 8, 0x2000, 0x800);
+    ApproachAngle((s16*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x800);
 
     if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) != 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101e4);
-    } else if (*(u8*)(c + 0x6de) != 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
-    } else if (*(int*)(c + 0x98) <= 0x12000) {
-        if (!_ZN6Player6IsAnimEj(c, 0x45))
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x45, 0x40000000, 0x1000, 0);
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            func_ov002_020d3498(c);
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101e4);
+    } else if (mIsAirborne != 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
+    } else if (mHorzSpeed <= 0x12000) {
+        if (!_ZN6Player6IsAnimEj(((char*)this), 0x45))
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x45, 0x40000000, 0x1000, 0);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            func_ov002_020d3498(((char*)this));
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
     } else {
-        func_ov002_020bf88c(c);
-        *(int*)(c + 0x620) = func_0201226c(*(int*)(c + 0x620), 0, *(int*)(c + 0x66c) + 0xe2, (int)(c + 0x74), *(int*)(c + 0x98), 0);
+        func_ov002_020bf88c(((char*)this));
+        mLoopingSoundHandle = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePos), mHorzSpeed, 0);
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player18St_YoshiPower_InitEv.cpp
+++ b/src/_ZN6Player18St_YoshiPower_InitEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player18St_YoshiPower_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 /* Player::St_YoshiPower_Init at 0x020d7ed0 (ov002), size 0x200
  * Matched byte-for-byte with mwccarm 1.2/sp2p3
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
@@ -6,60 +11,58 @@
 extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char*, unsigned int, int, int, unsigned int);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int, unsigned int, void*);
-extern void func_ov002_020d71a0(char*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
-extern void func_ov002_020d708c(char*);
 extern void func_ov002_020ed63c(void*, int);
+}
 
-int _ZN6Player18St_YoshiPower_InitEv(char* c)
+int Player::St_YoshiPower_Init()
 {
-    *(unsigned short*)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
-    *(unsigned char*)(c+0x6ee) = 0;
-    *(unsigned char*)(c+0x704) = 0;
-    if (*(unsigned short*)(c+0x6be) != 0) {
-        *(unsigned char*)(c+0x6f4) = 2;
+    *(unsigned short*)(((int)((char*)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+    unk_6ee = 0;
+    mEggParams = 0;
+    if (unk_6be != 0) {
+        unk_6f4 = 2;
     }
-    if (*(int*)(c+0x98) >= 0x1c000) {
-        *(int*)(c+0x98) = 0x1c000;
+    if (mHorzSpeed >= 0x1c000) {
+        mHorzSpeed = 0x1c000;
     }
-    if (**(int**)(c+0x588) == 0) {
-        if (*(unsigned char*)(c+0x6f4) != 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x6d, 0x40000000, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 5;
-            *(unsigned short*)(c+0x6a4) = 0x1e;
-            *(unsigned char*)(((int)c + 0x6f4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x101, c+0x74);
-        } else if (*(void**)(c+0x360) == 0) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x6c, 0x40000000, 0x1000, 0);
-            if (*(unsigned char*)(c+0x714) != 0) {
-                func_ov002_020d71a0(c);
+    if (**(int**)((char*)&mHeldObjQueue) == 0) {
+        if (unk_6f4 != 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6d, 0x40000000, 0x1000, 0);
+            mStateStep = 5;
+            mStateTimer = 0x1e;
+            *(unsigned char*)(((int)((char*)this) + 0x6f4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x101, ((char*)this)+0x74);
+        } else if (*(void**)((char*)&mObjInMouth) == 0) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6c, 0x40000000, 0x1000, 0);
+            if (mUseAltBodyModel != 0) {
+                func_ov002_020d71a0(((char*)this));
             }
-            *(unsigned char*)(c+0x6e3) = 0;
-            *(unsigned char*)(c+0x70c) = 0;
-            _ZN12CylinderClsn5ClearEv(c+0x314);
-            func_ov002_020d708c(c);
-            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0xfc, c+0x74);
+            mStateStep = 0;
+            mStateArg = 0;
+            _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
+            func_ov002_020d708c(((char*)this));
+            _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0xfc, ((char*)this)+0x74);
         } else {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x6d, 0x40000000, 0x1000, 0);
-            *(unsigned char*)(c+0x6e3) = 4;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6d, 0x40000000, 0x1000, 0);
+            mStateStep = 4;
         }
     } else {
         int i;
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x30, 0x40000000, 0x1000, 0);
-        *(unsigned char*)(c+0x6e3) = 6;
-        *(void**)(c+0x358) = **(void***)(c+0x588);
-        *(int*)(((int)*(void**)(c+0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
-        func_ov002_020ed63c(*(void**)(c+0x358), 1);
-        (*(int**)(c+0x588))[0] = 0;
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x30, 0x40000000, 0x1000, 0);
+        mStateStep = 6;
+        *(void**)((char*)&mHeldObj) = **(void***)((char*)&mHeldObjQueue);
+        *(int*)(((int)*(void**)((char*)&mHeldObj) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+        func_ov002_020ed63c(*(void**)((char*)&mHeldObj), 1);
+        (*(int**)((char*)&mHeldObjQueue))[0] = 0;
         for (i = 1; i < 5; i++) {
-            int* p = *(int**)(c+0x588);
+            int* p = *(int**)((char*)&mHeldObjQueue);
             int v = p[i];
             if (v != 0) {
                 (p + i)[-1] = v;
-                (*(int**)(c+0x588))[i] = 0;
+                (*(int**)((char*)&mHeldObjQueue))[i] = 0;
             }
         }
     }
     return 1;
-}
 }

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -1,22 +1,28 @@
 //cpp
+// @symbol _ZN6Player19St_CrazedCrate_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 /* _ZN6Player19St_CrazedCrate_InitEv at 0x020e0fac (ov002), size 0x74
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
-extern void func_ov002_020e0f38(void* c, unsigned char a);
-int _ZN6Player19St_CrazedCrate_InitEv(char* c){
-  *(unsigned char*)(c+0x71b) = 0;
-  *(unsigned char*)(c+0x712) = 1;
-  *(unsigned char*)(c+0x70d) = 0;
-  *(unsigned char*)(c+0x6e1) = 0;
-  *(unsigned char*)(c+0x6de) = 1;
-  *(unsigned char*)(c+0x6df) = 0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x43, 0x40000000, 0x1000, 0);
-  func_ov002_020e0f38(c, *(unsigned char*)(c+0x6e1));
-  *(unsigned short*)(c+0x94) = *(short*)(c+0x8e);
-  *(int*)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
-  return 1;
 }
+
+int Player::St_CrazedCrate_Init()
+{
+  mJumpedFromQuicksand = 0;
+  mIsInAirState = 1;
+  mIsFallScreaming = 0;
+  mJumpComboStage = 0;
+  mIsAirborne = 1;
+  mLandSoundPlayed = 0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
+  func_ov002_020e0f38(((char*)this), mJumpComboStage);
+  mTargetAngleY = mAngleY;
+  *(int*)(((long long)(int)((char*)&mBodyClsnFlags))) |= 0x20;
+  return 1;
 }

--- a/src/_ZN6Player19St_Electrocute_InitEv.cpp
+++ b/src/_ZN6Player19St_Electrocute_InitEv.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN6Player19St_Electrocute_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020da9d4(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player19St_Electrocute_InitEv(void* c){
-  func_ov002_020da9d4(c);
-  *(char*)((char*)c+0x708)=1;
-  *(short*)((char*)c+0x6a4)=0x1e;
-  *(short*)((char*)c+0x6a0)=0x1e;
-  *(int*)((char*)c+0x98)=0;
-  *(int*)((char*)c+0xa8)=0;
-  *(int*)((char*)c+0x9c)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x11,0,0x1000,0);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)((char*)c+0x6d9),7,(char*)c+0x74);
-  return 1;
 }
+
+int Player::St_Electrocute_Init()
+{
+  func_ov002_020da9d4(((void*)this));
+  *(char*)((char*)&mIsTakingDamage)=1;
+  *(short*)((char*)&mStateTimer)=0x1e;
+  *(short*)((char*)&mInvincibleTimer)=0x1e;
+  *(int*)((char*)&mHorzSpeed)=0;
+  *(int*)((char*)&mVertSpeed)=0;
+  *(int*)((char*)&mVertAccel)=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this),0x11,0,0x1000,0);
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)((char*)&mCharacter),7,(char*)((void*)this)+0x74);
+  return 1;
 }

--- a/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
+++ b/src/_ZN6Player19St_SwingPlayer_InitEv.cpp
@@ -1,17 +1,21 @@
 //cpp
+// @symbol _ZN6Player19St_SwingPlayer_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, int, unsigned int);
+}
 
-int _ZN6Player19St_SwingPlayer_InitEv(char* c){
-  *(int*)(c+0x98) = 0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x6c, 0x40000000, 0x1000, 0);
-  *(unsigned char*)(c+0x6e3) = 0;
-  *(short*)(c+0x69c) = *(short*)(c+0x8e) - *(short*)(c+0x6d6);
+int Player::St_SwingPlayer_Init()
+{
+  mHorzSpeed = 0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6c, 0x40000000, 0x1000, 0);
+  mStateStep = 0;
+  mAngleYSpeed = mAngleY - unk_6d6;
   {
-    void* obj = *(void**)(c+0x358);
+    void* obj = *(void**)((char*)&mHeldObj);
     if (obj != 0)
-      *(int*)(((long long)(int)((char*)obj+0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800;
+      *(int*)(((long long)(int)((char*)obj+0xb0))) |= 0x800;
   }
   return 1;
-}
 }

--- a/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
+++ b/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
@@ -1,20 +1,26 @@
 //cpp
+// @symbol _ZN6Player19St_TornadoSpin_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int data_0209f318[];
-extern void func_0200d6b4(void*,unsigned char);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player19St_TornadoSpin_InitEv(char* c){
-  func_ov002_020dab14(c);
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x5f,0,0x1000,0);
-  *(int*)(c+0xa8)=0;
-  *(int*)(c+0x9c)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  func_0200d6b4(*(void**)data_0209f318, *(unsigned char*)(c+0x6d8));
-  *(int*)(c+0x688)=*(int*)(c+0x60) - *(int*)(*(int*)(c+0x364)+0x60);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x26,(void*)(c+0x74));
-  return 1;
 }
+
+int Player::St_TornadoSpin_Init()
+{
+  func_ov002_020dab14(((char*)this));
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x5f,0,0x1000,0);
+  mVertSpeed=0;
+  mVertAccel=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  func_0200d6b4(*(void**)data_0209f318, mPlayerNo);
+  mAttachOffsetY=mPosY - *(int*)(mAttachedActor+0x60);
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x26,(void*)((char*)&mCamSpacePos));
+  return 1;
 }

--- a/src/_ZN6Player20IsStateEnteringLevelEv.cpp
+++ b/src/_ZN6Player20IsStateEnteringLevelEv.cpp
@@ -1,10 +1,16 @@
 //cpp
+// @symbol _ZN6Player20IsStateEnteringLevelEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int data_ov002_021104b4[];
-extern int data_ov002_0211025c[];
 extern int _ZN6Player7IsStateERNS_5StateE(char*c, void*s);
-int _ZN6Player20IsStateEnteringLevelEv(char*c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021104b4)) return 1;
-  return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211025c);
 }
+
+int Player::IsStateEnteringLevel()
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021104b4)) return 1;
+  return _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211025c);
 }

--- a/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
+++ b/src/_ZN6Player20RegisterEggCoinCountEjbb.cpp
@@ -1,13 +1,14 @@
 //cpp
+// @symbol _ZN6Player20RegisterEggCoinCountEjbb
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 
-extern "C" {
 
-void _ZN6Player20RegisterEggCoinCountEjbb(char* self, unsigned int count, bool b2, bool b3) {
-	*(unsigned char *)(self + 0x704) = (count & 0xf) << 2;
+void Player::RegisterEggCoinCount(unsigned int count, bool b2, bool b3)
+{
+	mEggParams = (count & 0xf) << 2;
 	if (b3)
-		*(unsigned char *)(((long long)(int)(self + 0x704)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+		*(unsigned char *)(((long long)(int)((char*)&mEggParams))) |= 0x40;
 	if (b2)
-		*(unsigned char *)(((long long)(int)(self + 0x704)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
-}
-
+		*(unsigned char *)(((long long)(int)((char*)&mEggParams))) |= 0x80;
 }

--- a/src/_ZN6Player20St_CeilingGrate_InitEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_InitEv.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN6Player20St_CeilingGrate_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern void func_ov002_020cf384(char* p);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player20St_CeilingGrate_InitEv(char* c){
-  func_ov002_020cf384(c);
-  *(char*)(c+0x6e3)=0;
-  *(char*)(c+0x6e5)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x5b,0x40000000,0x1000,0);
-  return 1;
 }
+
+int Player::St_CeilingGrate_Init()
+{
+  func_ov002_020cf384(((char*)this));
+  mStateStep=0;
+  mStateWork=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x5b,0x40000000,0x1000,0);
+  return 1;
 }

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -1,18 +1,19 @@
 //cpp
+// @symbol _ZN6Player20St_CeilingGrate_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 
 extern "C" {
-extern int func_ov002_020cf20c(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
-extern int func_ov002_020d674c(char* c);
-extern void func_ov002_020cf384(char* c);
 extern int _ZN6Player12FinishedAnimEv(char* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, int b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(char* c, u32 a, int b);
-extern void func_ov002_020cf2f8(char* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void* v);
 extern void func_ov002_020bedd4(char* c);
 
@@ -20,37 +21,35 @@ extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
 extern u16 data_0209f49e[];
 extern s16 data_0209f4a0[];
-extern u8 data_0209f4ab[];
 extern int data_ov002_0211013c;
 extern int data_ov002_0211004c;
 extern int data_ov002_021105a4;
-extern u32 data_ov002_0210a60c[];
 }
 
-extern "C" int _ZN6Player20St_CeilingGrate_MainEv(char* c)
+int Player::St_CeilingGrate_Main()
 {
     int r4;
     int spd;
 
-    r4 = func_ov002_020cf20c(c);
+    r4 = func_ov002_020cf20c(((char*)this));
     if (r4 == 0x80000000) {
-        *(int*)(c + 0x5c) = *(int*)(c + 0x548);
-        *(int*)(c + 0x60) = *(int*)(c + 0x54c);
-        *(int*)(c + 0x64) = *(int*)(c + 0x550);
-        r4 = *(int*)(c + 0x60) + 0x90000;
+        mPosX = unk_548;
+        mPosY = unk_54c;
+        mPosZ = unk_550;
+        r4 = mPosY + 0x90000;
     }
 
     {
         int idx = data_020a0e40 * 0x18;
         if ((*(u16*)((char*)data_0209f49c + idx) & 2) == 0) {
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_0211013c);
             return 1;
         }
         if (*(u16*)((char*)data_0209f49e + idx) & 0x400) {
-            if (func_ov002_020d674c(c) != 0)
-                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211004c);
+            if (func_ov002_020d674c(((char*)this)) != 0)
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_0211004c);
             else
-                _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021105a4);
+                _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_021105a4);
             return 1;
         }
         {
@@ -60,52 +59,52 @@ extern "C" int _ZN6Player20St_CeilingGrate_MainEv(char* c)
         }
     }
 
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        func_ov002_020cf384(c);
-        if (_ZN6Player12FinishedAnimEv(c) != 0) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[*(u8*)(c + 0x6e5) & 1], 0, 0x1000, 0);
+        func_ov002_020cf384(((char*)this));
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+            mStateStep = 1;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[mStateWork & 1], 0, 0x1000, 0);
         }
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
             if ((u32)(*(int*)(anim + 8) << 4) >> 0x10 < 0x21)
                 break;
         }
     case 1:
-        func_ov002_020cf384(c);
+        func_ov002_020cf384(((char*)this));
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
-            *(u8*)(c + 0x6e3) = 2;
-            spd = *(int*)(c + 0x98) >> 3;
+            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+            mStateStep = 2;
+            spd = mHorzSpeed >> 3;
             if (spd < 0x800)
                 spd = 0x800;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[(*(u8*)(c + 0x6e5) & 1) + 2], 0x40000000, spd, 0);
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[(mStateWork & 1) + 2], 0x40000000, spd, 0);
         }
         break;
     case 2:
-        func_ov002_020cf2f8(c);
-        spd = *(int*)(c + 0x98) >> 3;
+        func_ov002_020cf2f8(((char*)this));
+        spd = mHorzSpeed >> 3;
         if (spd < 0x800)
             spd = 0x800;
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
             *(int*)(anim + 0xc) = spd;
         }
-        if (_ZN6Player12FinishedAnimEv(c) != 0) {
-            _ZN5Sound9PlayBank0EjRK7Vector3(0xb2, c + 0x74);
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
+            _ZN5Sound9PlayBank0EjRK7Vector3(0xb2, ((char*)this) + 0x74);
             if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-                *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[(*(u8*)(c + 0x6e5) & 1) + 2], 0x40000000, 0x1000, 0);
+                *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[(mStateWork & 1) + 2], 0x40000000, 0x1000, 0);
             } else {
-                *(u8*)(c + 0x6e3) = 1;
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a60c[*(u8*)(c + 0x6e5) & 1], 0, 0x1000, 0);
+                mStateStep = 1;
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[mStateWork & 1], 0, 0x1000, 0);
             }
         }
         break;
     }
 
-    *(int*)(c + 0x60) = r4 - 0x90000;
-    func_ov002_020bedd4(c);
+    mPosY = r4 - 0x90000;
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
+++ b/src/_ZN6Player20St_HoldLight_CleanupEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-extern "C" {
-int _ZN6Player20St_HoldLight_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x358);
+// @symbol _ZN6Player20St_HoldLight_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
+
+
+int Player::St_HoldLight_Cleanup()
+{
+  char* p = *(char**)((char*)&mHeldObj);
   if (p) {
-    *(unsigned int*)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
+    *(unsigned int*)(((long long)(int)(p + 0xb0))) |= 0x4000;
   }
   return 1;
-}
 }

--- a/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_InitEv.cpp
@@ -1,22 +1,26 @@
 //cpp
+// @symbol _ZN6Player20St_InYoshiMouth_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern void func_ov002_020bdb50(char *c, int arg);
+}
 
-int _ZN6Player20St_InYoshiMouth_InitEv(char *c)
+int Player::St_InYoshiMouth_Init()
 {
     unsigned int r3;
     char *slot;
     unsigned int r1;
 
-    func_ov002_020bdb50(c, 0);
+    func_ov002_020bdb50(((char *)this), 0);
     r3 = 0;
-    *(unsigned char *)(c + 0x6e5) = (unsigned char)r3;
-    *(unsigned char *)(c + 0x6e6) = (unsigned char)r3;
-    slot = (char *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL);
+    mStateWork = (unsigned char)r3;
+    unk_6e6 = (unsigned char)r3;
+    slot = (char *)(((long long)(int)((char *)&mBodyClsnFlags)));
     r1 = *(unsigned int *)slot;
     r1 |= 2u;
     *(unsigned int *)slot = r1;
-    *(unsigned char *)(c + 0x713) = (unsigned char)r3;
+    mIsBodyClsnEnabled = (unsigned char)r3;
     return 1;
-}
 }

--- a/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
@@ -1,55 +1,56 @@
 //cpp
+// @symbol _ZN6Player20St_InYoshiMouth_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-typedef struct Vector3 { int x, y, z; } Vector3;
 
 extern "C" {
 extern int func_ov002_020d5cec(char *c);
-extern int func_ov002_020beb38(char *c);
 extern void Vec3_RotateYAndTranslate(Vector3 *res, Vector3 *trans, short angY, Vector3 *add);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char *c, void *s);
 extern int _ZN6Player12FinishedAnimEv(char *c);
 extern void func_ov002_020bedd4(char *c);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *thiz, void *v, u32 a, int b, u32 cc, u32 d, u32 e);
 
-extern int data_ov002_0211019c[];
 extern int data_ov002_02110094[];
-extern int data_ov002_0211007c[];
 }
 
-extern "C" int _ZN6Player20St_InYoshiMouth_MainEv(char *c)
+int Player::St_InYoshiMouth_Main()
 {
-    switch (*(u8 *)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
         break;
     case 1:
         {
-            char *r4 = *(char **)(c + 0xd0);
+            char *r4 = *(char **)((char *)&mEatingPlayer);
             u32 t;
             int d;
-            if (r4 != 0 && *(char **)(r4 + 0x360) != c) {
-                if (func_ov002_020d5cec(c))
+            if (r4 != 0 && *(char **)(r4 + 0x360) != ((char *)this)) {
+                if (func_ov002_020d5cec(((char *)this)))
                     return 1;
             }
             {
                 int *p = (int *)(int)(((long long)(int)(r4 + 0x5c)) & 0xffffffffffffffffLL);
-                *(int *)(c + 0x5c) = p[0];
-                *(int *)(c + 0x60) = p[1];
-                *(int *)(c + 0x64) = p[2];
+                mPosX = p[0];
+                mPosY = p[1];
+                mPosZ = p[2];
             }
-            d = func_ov002_020beb38(c);
+            d = func_ov002_020beb38(((char *)this));
             t = *(u16 *)(r4 + 0x6c6);
             if (*(u8 *)(r4 + 0x709) == 0 && *(u8 *)(r4 + 0x708) == 0) {
                 t = (u16)(t - d);
-                *(u8 *)(((long long)(int)(c + 0x6e6)) & 0xffffffffffffffffLL) += d;
+                *(u8 *)(((long long)(int)((char *)&unk_6e6)) & 0xffffffffffffffffLL) += d;
                 if ((s16)t < 0)
                     t = 0;
             }
-            if (t <= 1 && *(u8 *)(c + 0x6e6) >= 0x1e) {
+            if (t <= 1 && unk_6e6 >= 0x1e) {
                 Vector3 res;
                 Vector3 addv;
                 Vector3 hv;
@@ -61,36 +62,36 @@ extern "C" int _ZN6Player20St_InYoshiMouth_MainEv(char *c)
                 hv.y = res.y;
                 hv.z = res.z;
                 _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(r4, &hv, 1, 0, 0, (*(int *)(r4 + 8) + 1) & 0xff, 1);
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
+                _ZN6Player11ChangeStateERNS_5StateE(((char *)this), data_ov002_0211019c);
                 *(int *)(r4 + 0x360) = 0;
-                *(int *)(c + 0xd0) = 0;
+                mEatingPlayer = 0;
                 return 1;
             }
             *(u16 *)(r4 + 0x6c6) = (s16)t;
             break;
         }
     case 2:
-        if (*(u16 *)(c + 0x6a4) == 0)
-            *(int *)(((long long)(int)(c + 0x2ec)) & 0xffffffffffffffffLL) |= 0x2000;
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(u8 *)(c + 0x6e3) = 3;
-            *(int *)(c + 0x674) = 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110094);
+        if (mStateTimer == 0)
+            *(int *)(((long long)(int)((char *)&mBodyClsnFlags)) & 0xffffffffffffffffLL) |= 0x2000;
+        if (_ZN6Player12FinishedAnimEv(((char *)this))) {
+            mStateStep = 3;
+            mHurtDamage = 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char *)this), data_ov002_02110094);
         }
         break;
     case 3:
         {
-            int d = func_ov002_020beb38(c);
-            *(u16 *)(((long long)(int)(c + 0x6a4)) & 0xffffffffffffffffLL) -= (d << 2);
-            *(u8 *)(c + 0x6e5) = d;
-            if ((s16)*(u16 *)(c + 0x6a4) <= 0) {
-                *(u16 *)(c + 0x6a4) = 0;
-                *(u8 *)(c + 0x6f5) = 0x1f;
-                _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211007c);
+            int d = func_ov002_020beb38(((char *)this));
+            *(u16 *)(((long long)(int)((char *)&mStateTimer)) & 0xffffffffffffffffLL) -= (d << 2);
+            mStateWork = d;
+            if ((s16)mStateTimer <= 0) {
+                mStateTimer = 0;
+                mOpacity = 0x1f;
+                _ZN6Player11ChangeStateERNS_5StateE(((char *)this), data_ov002_0211007c);
             }
         }
         break;
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char *)this));
     return 1;
 }

--- a/src/_ZN6Player20St_NoControl_CleanupEv.cpp
+++ b/src/_ZN6Player20St_NoControl_CleanupEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN6Player20St_NoControl_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int EndKuppaScript(void);
-int _ZN6Player20St_NoControl_CleanupEv(char*c){
-  int v=0x1000;
-  if(*(unsigned char*)(c+0x703)) v=0x3000;
-  *(int*)(c+0x80)=v;
-  *(int*)(c+0x84)=v;
-  *(int*)(c+0x88)=v;
-  if(*(unsigned char*)(c+0x70a)==0x11) EndKuppaScript();
-  return 1;
 }
+
+int Player::St_NoControl_Cleanup()
+{
+  int v=0x1000;
+  if(mIsMega) v=0x3000;
+  mScaleX=v;
+  mScaleY=v;
+  mScaleZ=v;
+  if(mNoCtrlKind==0x11) EndKuppaScript();
+  return 1;
 }

--- a/src/_ZN6Player20St_StomachSlide_InitEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_InitEv.cpp
@@ -1,20 +1,25 @@
 //cpp
+// @symbol _ZN6Player20St_StomachSlide_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 struct Camera;
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern struct Camera* data_0209f318;
 extern void func_0200d544(struct Camera* thiz, unsigned char playerID);
-int _ZN6Player20St_StomachSlide_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x40, 0x40000000, 0x1000, 0);
-  *(char*)(c+0x6e3)=0;
-  if(*(unsigned char*)(c+0x70e)){
-    func_0200d544(data_0209f318, *(unsigned char*)(c+0x6d8));
-  }
-  *(char*)(c+0x6e5)=0;
-  *(char*)(c+0x6e6)=0;
-  *(char*)(c+0x6e7)=0;
-  *(char*)(c+0x70c)=*(unsigned char*)(c+0x70e);
-  *(char*)(c+0x6e4)=0;
-  return 1;
 }
+
+int Player::St_StomachSlide_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x40, 0x40000000, 0x1000, 0);
+  mStateStep=0;
+  if(mSlideType){
+    func_0200d544(data_0209f318, mPlayerNo);
+  }
+  mStateWork=0;
+  unk_6e6=0;
+  mSlideStoppedTimer=0;
+  mStateArg=mSlideType;
+  mIsSlidingOnGround=0;
+  return 1;
 }

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player20St_StomachSlide_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -20,7 +25,6 @@ extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern void func_ov002_020c18b0(void* c, u32 a);
 extern void func_ov002_020e25f0(void* c, int a);
-extern void func_ov002_020dba0c(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
 extern void func_ov002_020dc560(void* c);
@@ -33,163 +37,162 @@ extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
 extern u8 data_0209ee90;
 extern int data_ov002_021105bc[];
-extern int data_ov002_021101fc[];
 extern int data_ov002_0211031c[];
 extern int data_ov002_0211013c[];
 extern int data_ov002_021101b4[];
 }
 
-extern "C" int _ZN6Player20St_StomachSlide_MainEv(char* c)
+int Player::St_StomachSlide_Main()
 {
-    void* light0 = *(void**)(c + 0x358);
+    void* light0 = *(void**)((char*)&mHeldObj);
     if (light0 != 0) {
-        int* p = (int*)(((long long)(int)((char*)light0 + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p = (int*)(((long long)(int)((char*)light0 + 0xb0)));
         *p |= 0x4000;
     }
 
-    switch (*(u8*)(c + 0x6e6)) {
+    switch (unk_6e6) {
     case 0:
-        func_ov002_020bf90c(c);
-        if (*(u8*)(c + 0x6de) == 0) {
-            *(u8*)(c + 0x6e4) = 1;
-            if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105bc)) {
-                if (*(int*)(c + 0x358) != 0) {
-                    *(int*)(c + 0x98) = 0;
+        func_ov002_020bf90c(((char*)this));
+        if (mIsAirborne == 0) {
+            mIsSlidingOnGround = 1;
+            if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021105bc)) {
+                if (mHeldObj != 0) {
+                    mHorzSpeed = 0;
                     goto case0_e0;
                 }
             }
             {
                 u32 arg = 0x4000;
-                if (*(u8*)(c + 0x70e) == 0) arg = 0x8000;
-                func_ov002_020c06fc(c, arg);
+                if (mSlideType == 0) arg = 0x8000;
+                func_ov002_020c06fc(((char*)this), arg);
             }
-            func_ov002_020dd2f4(c);
-            if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105bc) &&
-                (u16)(*(u16*)(c + 0x6ce) & 1)) {
-                func_ov002_020c0364(c, 2);
+            func_ov002_020dd2f4(((char*)this));
+            if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_021105bc) &&
+                (u16)(mStateFlags & 1)) {
+                func_ov002_020c0364(((char*)this), 2);
             }
         }
     case0_e0:
-        if (*(int*)(c + 0x98) == 0) {
-            if (*(u8*)(c + 0x70e) == 0) {
-                *(u8*)(c + 0x6e3) = 0;
-                *(u8*)(c + 0x6e6) = 2;
+        if (mHorzSpeed == 0) {
+            if (mSlideType == 0) {
+                mStateStep = 0;
+                unk_6e6 = 2;
                 goto end;
             }
             {
-                u8* p = (u8*)(((long long)(int)(c + 0x6e7)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((long long)(int)((char*)&mSlideStoppedTimer)));
                 *p = (u8)(*p + 1);
             }
-            if (*(u8*)(c + 0x6e7) >= 0x1e) {
-                *(u8*)(c + 0x6e3) = 0;
-                *(u8*)(c + 0x6e6) = 2;
+            if (mSlideStoppedTimer >= 0x1e) {
+                mStateStep = 0;
+                unk_6e6 = 2;
                 goto end;
             }
         } else {
-            *(u8*)(c + 0x6e7) = 0;
+            mSlideStoppedTimer = 0;
         }
 
-        if (func_ov002_020c0688(c)) {
-            if (func_ov002_020e2ea0(c)) {
+        if (func_ov002_020c0688(((char*)this))) {
+            if (func_ov002_020e2ea0(((char*)this))) {
                 return 1;
             }
-            if (_ZN6Player6IsAnimEj(c, 0x40) && _ZN6Player12FinishedAnimEv(c)) {
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x43, 0x40000000, 0x1000, 0);
+            if (_ZN6Player6IsAnimEj(((char*)this), 0x40) && _ZN6Player12FinishedAnimEv(((char*)this))) {
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
             }
             {
                 u16 flags = *(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18);
                 if ((flags & 1) || (flags & 2)) {
-                    if (!(u16)(*(u16*)(c + 0x6ce) & 1)) {
-                        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101fc);
+                    if (!(u16)(mStateFlags & 1)) {
+                        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101fc);
                     }
                 }
             }
-            func_ov002_020c18b0(c, 0);
+            func_ov002_020c18b0(((char*)this), 0);
         } else {
-            if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211031c)) {
-                *(u8*)(c + 0x6e6) = 1;
-                *(u8*)(c + 0x6e3) = 0;
+            if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211031c)) {
+                unk_6e6 = 1;
+                mStateStep = 0;
                 if (*(int*)((char*)&data_0209ee90 + 0x244) != 0) {
-                    if ((*(u8*)(c + 0x70c) | *(u8*)(c + 0x70e)) != 0) {
-                        *(int*)(c + 0xa8) = 0x15000;
+                    if ((mStateArg | mSlideType) != 0) {
+                        mVertSpeed = 0x15000;
                     }
                 }
-                func_ov002_020e25f0(c, 0);
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x54, 0x40000000, 0x1000, 0);
+                func_ov002_020e25f0(((char*)this), 0);
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x54, 0x40000000, 0x1000, 0);
             }
         }
-        func_ov002_020dba0c(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x314);
-        _ZN12CylinderClsn6UpdateEv(c + 0x314);
+        func_ov002_020dba0c(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
+        _ZN12CylinderClsn6UpdateEv((char*)&mAttackClsn);
         goto end;
 
     case 1:
-        func_ov002_020dba0c(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x314);
-        _ZN12CylinderClsn6UpdateEv(c + 0x314);
-        if (*(u8*)(c + 0x6de) == 0) {
-            *(u8*)(c + 0x6e6) = 0;
-            *(int*)(c + 0xa8) = 0;
-            *(u8*)(c + 0x6e3) = 0;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x43, 0x40000000, 0x1000, 0);
+        func_ov002_020dba0c(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mAttackClsn);
+        _ZN12CylinderClsn6UpdateEv((char*)&mAttackClsn);
+        if (mIsAirborne == 0) {
+            unk_6e6 = 0;
+            mVertSpeed = 0;
+            mStateStep = 0;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
             goto end;
         }
-        func_ov002_020dc560(c);
+        func_ov002_020dc560(((char*)this));
         {
-            u8* p = (u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8* p = (u8*)(((long long)(int)((char*)&mStateStep)));
             *p = (u8)(*p + 1);
         }
-        if (*(u8*)(c + 0x6e3) <= 0x1e) goto end;
-        if (*(int*)(c + 0x60) - *(int*)(c + 0x644) <= 0x1f4000) goto end;
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021101b4);
+        if (mStateStep <= 0x1e) goto end;
+        if (mPosY - mGroundY <= 0x1f4000) goto end;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);
         return 1;
 
     case 2:
-        *(s16*)(c + 0x90) = 0;
-        *(s16*)(c + 0x8c) = *(s16*)(c + 0x90);
-        if (*(u8*)(c + 0x6e3) == 0) {
-            void* light = *(void**)(c + 0x358);
+        mAngZ = 0;
+        mAngX = mAngZ;
+        if (mStateStep == 0) {
+            void* light = *(void**)((char*)&mHeldObj);
             int haveLight = (light != 0);
             if (haveLight) {
                 u32 animId = 0x18;
                 int b1 = (*(int*)((char*)light + 0xb0) & 0x8000) != 0;
                 if (b1) {
                     animId = 0x8b;
-                    if (*(int*)(c + 8) == 2) {
+                    if (mParam == 2) {
                         int b2 = (*(u16*)((char*)light + 0xc) == 0xce);
                         if (b2) {
                             animId = 0x18;
                         }
                     }
                 }
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, animId, 0x40000000, 0x1000, 0);
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), animId, 0x40000000, 0x1000, 0);
             } else {
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x3e, 0x40000000, 0x1000, 0);
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x3e, 0x40000000, 0x1000, 0);
             }
-            *(s16*)(c + 0x94) = *(s16*)(c + 0x8e);
+            mTargetAngleY = mAngleY;
             {
-                u8* p = (u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((long long)(int)((char*)&mStateStep)));
                 *p = (u8)(*p + 1);
             }
             goto end;
         }
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            if (func_ov002_020e0ccc(c, *(short**)(c + 0x358))) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            if (func_ov002_020e0ccc(((char*)this), *(short**)((char*)&mHeldObj))) {
                 return 1;
             }
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         goto end;
     }
 
 end:
-    if (*(u8*)(c + 0x6de) != 0) {
-        s16 v = _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0x98) >> 8, *(int*)(c + 0xa8) >> 8) - 0x4000;
+    if (mIsAirborne != 0) {
+        s16 v = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed >> 8, mVertSpeed >> 8) - 0x4000;
         if (v < 0) v = 0;
         if (v >= 0x2aaa) v = 0x2aaa;
-        _Z15ApproachLinear2Rsss((short*)(c + 0x8c), v, 0x200);
+        _Z15ApproachLinear2Rsss((short*)((char*)&mAngX), v, 0x200);
     }
-    func_ov002_020bedd4(c);
-    *(u8*)(c + 0x70c) = *(u8*)(c + 0x70e);
+    func_ov002_020bedd4(((char*)this));
+    mStateArg = mSlideType;
     return 1;
 }

--- a/src/_ZN6Player21St_HeadstandJump_InitEv.cpp
+++ b/src/_ZN6Player21St_HeadstandJump_InitEv.cpp
@@ -1,18 +1,23 @@
 //cpp
+// @symbol _ZN6Player21St_HeadstandJump_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
-int _ZN6Player21St_HeadstandJump_InitEv(char* c){
-  *(char*)(c+0x71b)=0;
-  *(char*)(c+0x712)=1;
-  *(char*)(c+0x70d)=0;
-  *(char*)(c+0x6e1)=0;
-  *(char*)(c+0x6de)=1;
-  *(char*)(c+0x6df)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x1c,0x40000000,0x1000,0);
-  *(int*)(c+0xa8)=0x3e000;
-  *(int*)(c+0x98)=0x18000;
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0xc,(char*)c+0x74);
-  return 1;
 }
+
+int Player::St_HeadstandJump_Init()
+{
+  mJumpedFromQuicksand=0;
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  mJumpComboStage=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x1c,0x40000000,0x1000,0);
+  mVertSpeed=0x3e000;
+  mHorzSpeed=0x18000;
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0xc,(char*)((char*)this)+0x74);
+  return 1;
 }

--- a/src/_ZN6Player21St_JumpQuicksand_InitEv.cpp
+++ b/src/_ZN6Player21St_JumpQuicksand_InitEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN6Player21St_JumpQuicksand_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_JumpQuicksand_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=1;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x53,0x40000000,0x1000,0);
-  *(unsigned char*)(c+0x6e5)=0;
-  *(int*)(c+0xa8)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  return 1;
 }
+
+int Player::St_JumpQuicksand_Init()
+{
+  mJumpedFromQuicksand=1;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x53,0x40000000,0x1000,0);
+  mStateWork=0;
+  mVertSpeed=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  return 1;
 }

--- a/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player21St_JumpQuicksand_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -8,20 +11,20 @@ extern char data_ov002_02110424;
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(char *, char *);
 extern void func_ov002_020bedd4(char *);
-
-int _ZN6Player21St_JumpQuicksand_MainEv(char *c)
-{
-    u8 t = *(u8 *)(c + 0x6e5);
-    (*(u8 *)(int)(((long long)(int)(c + 0x6e5)) & 0xFFFFFFFFFFFFFFFFLL))++;
-    if (t < 6) {
-        (*(int *)(int)(((long long)(int)(c + 0x68c)) & 0xFFFFFFFFFFFFFFFFLL)) -=
-            (int)((((7 - *(u8 *)(c + 0x6e5)) << 12) * 0xcccLL + 0x800) >> 12);
-        if (*(int *)(c + 0x68c) < 0x1000)
-            *(int *)(c + 0x68c) = 0x1100;
-    } else {
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_02110424);
-    }
-    func_ov002_020bedd4(c);
-    return 1;
 }
+
+int Player::St_JumpQuicksand_Main()
+{
+    u8 t = mStateWork;
+    (*(u8 *)(int)(((long long)(int)((char *)&mStateWork))))++;
+    if (t < 6) {
+        (*(int *)(int)(((long long)(int)((char *)&mSinkDepth)))) -=
+            (int)((((7 - mStateWork) << 12) * 0xcccLL + 0x800) >> 12);
+        if (mSinkDepth < 0x1000)
+            mSinkDepth = 0x1100;
+    } else {
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_02110424);
+    }
+    func_ov002_020bedd4(((char *)this));
+    return 1;
 }

--- a/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
+++ b/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
@@ -1,19 +1,24 @@
 //cpp
+// @symbol _ZN6Player21St_SmallLaunchUp_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_SmallLaunchUp_InitEv(char* c){
-  *(unsigned char*)(c+0x71b)=0;
-  *(unsigned char*)(c+0x712)=1;
-  *(unsigned char*)(c+0x70d)=0;
-  *(unsigned char*)(c+0x6e1)=0;
-  *(unsigned char*)(c+0x6de)=1;
-  *(unsigned char*)(c+0x6df)=0;
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x56,0,0x1000,0);
-  *(int*)(c+0xa8)=0x2a000;
-  *(int*)(c+0x98)=0;
-  *(short*)(c+0x8c)=*(short*)(c+0x92);
-  *(short*)(c+0x8e)=*(short*)(c+0x94);
-  *(short*)(c+0x90)=*(short*)(c+0x96);
-  return 1;
 }
+
+int Player::St_SmallLaunchUp_Init()
+{
+  mJumpedFromQuicksand=0;
+  mIsInAirState=1;
+  mIsFallScreaming=0;
+  mJumpComboStage=0;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x56,0,0x1000,0);
+  mVertSpeed=0x2a000;
+  mHorzSpeed=0;
+  mAngX=unk_092;
+  mAngleY=mTargetAngleY;
+  mAngZ=unk_096;
+  return 1;
 }

--- a/src/_ZN6Player21St_SmallLaunchUp_MainEv.cpp
+++ b/src/_ZN6Player21St_SmallLaunchUp_MainEv.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN6Player21St_SmallLaunchUp_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_02110424;
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,State*);
 extern void func_ov002_020bedd4(void*);
-int _ZN6Player21St_SmallLaunchUp_MainEv(char* c){
-  if(*(unsigned char*)(c+0x6de)==0){
-    _ZN6Player11ChangeStateERNS_5StateE(c,&data_ov002_02110424);
-  }
-  func_ov002_020bedd4(c);
-  return 1;
 }
+
+int Player::St_SmallLaunchUp_Main()
+{
+  if(mIsAirborne==0){
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),&data_ov002_02110424);
+  }
+  func_ov002_020bedd4(((char*)this));
+  return 1;
 }

--- a/src/_ZN6Player21St_StuckInGround_InitEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_InitEv.cpp
@@ -1,21 +1,27 @@
 //cpp
+// @symbol _ZN6Player21St_StuckInGround_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020c9e40(void*);
 extern int func_ov002_020dab14(void*);
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int func_ov002_020c5444(void*);
-extern int data_ov002_0210a560[];
-int _ZN6Player21St_StuckInGround_InitEv(void* c){
-  func_ov002_020c9e40(c);
-  func_ov002_020dab14(c);
-  unsigned char idx = *(unsigned char*)((char*)c+0x6e3);
-  _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a560[idx], 0x40000000, 0x1000, 0);
-  _ZN5Sound9PlayBank0EjRK7Vector3(*(int*)((char*)c+0x66c)+0x80, (char*)c+0x74);
-  func_ov002_020c5444(c);
-  *(int*)((char*)c+0xa8)=0;
-  *(int*)((char*)c+0x98)=0;
-  *(unsigned char*)((char*)c+0x6e5)=0;
-  return 1;
 }
+
+int Player::St_StuckInGround_Init()
+{
+  func_ov002_020c9e40(((void*)this));
+  func_ov002_020dab14(((void*)this));
+  unsigned char idx = *(unsigned char*)((char*)&mStateStep);
+  _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), data_ov002_0210a560[idx], 0x40000000, 0x1000, 0);
+  _ZN5Sound9PlayBank0EjRK7Vector3(*(int*)((char*)&mGroundSoundType)+0x80, (char*)((void*)this)+0x74);
+  func_ov002_020c5444(((void*)this));
+  *(int*)((char*)&mVertSpeed)=0;
+  *(int*)((char*)&mHorzSpeed)=0;
+  *(unsigned char*)((char*)&mStateWork)=0;
+  return 1;
 }

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol _ZN6Player21St_StuckInGround_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -10,55 +16,51 @@ extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* a, int f);
 extern void func_ov002_020c5444(char* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void* v);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020bedd4(char* c);
 
-extern u32 data_ov002_0210a578[];
-extern u32 data_ov002_0210a584[];
 extern u8 data_020a0e40;
 extern u16 data_0209f49e[];
-extern u8 data_ov002_020ff0ec[];
 extern int data_ov002_0211013c[];
 }
 
-extern "C" int _ZN6Player21St_StuckInGround_MainEv(char* c)
+int Player::St_StuckInGround_Main()
 {
-    switch (*(u8*)(c + 0x6e5)) {
+    switch (mStateWork) {
     case 0:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a578[*(u8*)(c + 0x6e3)], 0x40000000, 0x1000, 0);
-            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
-                *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a578[mStateStep], 0x40000000, 0x1000, 0);
+            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
+                *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
             return 1;
         }
         break;
     case 1:
-        if (_ZN6Player12FinishedAnimEv(c) == 0) {
+        if (_ZN6Player12FinishedAnimEv(((char*)this)) == 0) {
             if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) == 0)
                 break;
         }
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_0210a584[*(u8*)(c + 0x6e3)], 0x40000000, 0x1000, 0);
-        *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
-            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a584[mStateStep], 0x40000000, 0x1000, 0);
+        *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
+            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
         break;
     case 2:
         {
-            void* anim = *(void**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u32*)(c + 8) & 0xff, 0) << 2) + 0xdc);
-            if (_ZNK9Animation12WillHitFrameEi((char*)anim + 0x50, data_ov002_020ff0ec[*(u8*)(c + 0x6e3)])) {
-                func_ov002_020c5444(c);
-                _ZN5Sound9PlayBank0EjRK7Vector3(0xb4, c + 0x74);
+            void* anim = *(void**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc);
+            if (_ZNK9Animation12WillHitFrameEi((char*)anim + 0x50, data_ov002_020ff0ec[mStateStep])) {
+                func_ov002_020c5444(((char*)this));
+                _ZN5Sound9PlayBank0EjRK7Vector3(0xb4, ((char*)this) + 0x74);
             }
         }
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mAngleY = mTargetAngleY;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         break;
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player21St_WaitQuicksand_InitEv.cpp
+++ b/src/_ZN6Player21St_WaitQuicksand_InitEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN6Player21St_WaitQuicksand_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
-int _ZN6Player21St_WaitQuicksand_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x47,0,0x1000,0);
-  *(char*)(c+0x6e5)=0;
-  return 1;
 }
+
+int Player::St_WaitQuicksand_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x47,0,0x1000,0);
+  mStateWork=0;
+  return 1;
 }

--- a/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_WaitQuicksand_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player21St_WaitQuicksand_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7ST_WAITE;
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
@@ -6,20 +9,22 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 extern int func_ov007_020c5dec(void*,int);
 extern int func_ov002_020d22ec(void*,int);
 extern int func_ov002_020bedd4(void*);
-int _ZN6Player21St_WaitQuicksand_MainEv(char* c){
-  int v=*(int*)(c+0x68c);
+}
+
+int Player::St_WaitQuicksand_Main()
+{
+  int v=mSinkDepth;
   if(v<0x1e000){
-    _ZN6Player11ChangeStateERNS_5StateE(c,&_ZN6Player7ST_WAITE);
+    _ZN6Player11ChangeStateERNS_5StateE(((char*)this),&_ZN6Player7ST_WAITE);
     return 1;
   }
   if(v>=0x46000){
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x82,0,0x1000,0);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x82,0,0x1000,0);
   }
-  if(*(int*)(c+0x68c)>=0xb4000){
-    if(func_ov007_020c5dec(c,3)) return 1;
+  if(mSinkDepth>=0xb4000){
+    if(func_ov007_020c5dec(((char*)this),3)) return 1;
   }
-  func_ov002_020d22ec(c,0);
-  func_ov002_020bedd4(c);
+  func_ov002_020d22ec(((char*)this),0);
+  func_ov002_020bedd4(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
+++ b/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
@@ -1,36 +1,40 @@
 //cpp
+// @symbol _ZN6Player21St_YoshiPower_CleanupEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020d718c(char*);
 extern void func_ov002_020d6790(char*);
-extern void func_ov002_020d71a0(char*);
+}
 
-int _ZN6Player21St_YoshiPower_CleanupEv(char* c)
+int Player::St_YoshiPower_Cleanup()
 {
-    char* r2 = *(char**)(c+0x360);
+    char* r2 = *(char**)((char*)&mObjInMouth);
     if (r2 != 0) {
         int t = (int)((*(int*)(r2+0xb0) & 0x20000) != 0);
         if (t != 0) {
             *(int*)(((int)r2 + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000;
-            func_ov002_020d718c(c);
+            func_ov002_020d718c(((char*)this));
             return 1;
         }
         *(int*)(((int)r2 + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
     }
-    if (*(unsigned char*)(c+0x714) == 0) {
-        char* q = *(char**)(c+0x360);
+    if (mUseAltBodyModel == 0) {
+        char* q = *(char**)((char*)&mObjInMouth);
         if (q != 0) {
             int eq = (int)(*(unsigned short*)(q+0xc) == 0xbf);
             if (eq == 0) {
-                func_ov002_020d6790(c);
+                func_ov002_020d6790(((char*)this));
                 goto end;
             }
         }
-        func_ov002_020d718c(c);
+        func_ov002_020d718c(((char*)this));
     } else {
-        if (*(char**)(c+0x360) == 0 && *(unsigned char*)(c+0x6f4) == 0)
-            func_ov002_020d71a0(c);
+        if (*(char**)((char*)&mObjInMouth) == 0 && unk_6f4 == 0)
+            func_ov002_020d71a0(((char*)this));
     }
 end:
     return 1;
-}
 }

--- a/src/_ZN6Player22IsBeingShotOutOfCannonEv.cpp
+++ b/src/_ZN6Player22IsBeingShotOutOfCannonEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN6Player22IsBeingShotOutOfCannonEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_021102d4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player22IsBeingShotOutOfCannonEv(char* c){
-  if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102d4)) return 0;
-  return *(unsigned char*)(c+0x6e3)==2 ? 1 : 0;
 }
+
+int Player::IsBeingShotOutOfCannon()
+{
+  if(!_ZN6Player7IsStateERNS_5StateE(((char*)this), &data_ov002_021102d4)) return 0;
+  return mStateStep==2 ? 1 : 0;
 }

--- a/src/_ZN6Player22St_GrabBowserTail_InitEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_InitEv.cpp
@@ -1,15 +1,21 @@
 //cpp
+// @symbol _ZN6Player22St_GrabBowserTail_InitEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
-extern void func_0200d10c(void* cam, unsigned char id);
 extern int* data_0209f318;
-int _ZN6Player22St_GrabBowserTail_InitEv(char* c){
-  _ZN6Player7SetAnimEji5Fix12IiEj(c,0x81,0x40000000,0x1000,0);
-  *(unsigned char*)(c+0x6e3)=0;
-  *(short*)(c+0x69c)=0;
-  *(unsigned char*)(c+0x6e5)=0;
-  *(unsigned char*)(c+0x70c)=0;
-  func_0200d10c((void*)data_0209f318, *(unsigned char*)(c+0x6d8));
-  return 1;
 }
+
+int Player::St_GrabBowserTail_Init()
+{
+  _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x81,0x40000000,0x1000,0);
+  mStateStep=0;
+  mAngleYSpeed=0;
+  mStateWork=0;
+  mStateArg=0;
+  func_0200d10c((void*)data_0209f318, mPlayerNo);
+  return 1;
 }

--- a/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player22St_GrabBowserTail_MainEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
@@ -23,83 +26,83 @@ extern char data_0209ee90[];
 extern int data_ov002_02110154[];
 }
 
-extern "C" int _ZN6Player22St_GrabBowserTail_MainEv(char* c)
+int Player::St_GrabBowserTail_Main()
 {
-    switch (*(u8*)(c + 0x6e3)) {
+    switch (mStateStep) {
     case 0:
-        if (_ZN6Player12FinishedAnimEv(c)) {
-            *(u8*)(c + 0x6e3) = 1;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x80, 0, 0x1000, 0);
+        if (_ZN6Player12FinishedAnimEv(((char*)this))) {
+            mStateStep = 1;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x80, 0, 0x1000, 0);
         }
         break;
     case 1:
         if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 1) != 0) {
-            s16 x = *(s16*)(c + 0x69c);
+            s16 x = mAngleYSpeed;
             if (x < 0) x = -x;
             if (x > 0xe00)
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x32, c + 0x74);
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x32, ((char*)this) + 0x74);
             else
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x33, c + 0x74);
-            *(u8*)(c + 0x6e3) = 2;
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x7f, 0x40000000, 0x1000, 0);
-            func_ov002_020daa74(c);
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x33, ((char*)this) + 0x74);
+            mStateStep = 2;
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x7f, 0x40000000, 0x1000, 0);
+            func_ov002_020daa74(((char*)this));
             return 1;
         }
         if (*(int*)(data_0209ee90 + 0x24c) != 0)
-            *(u8*)(c + 0x6e5) = 0;
+            mStateWork = 0;
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) == 0) {
-            u8 v = *(u8*)(c + 0x6e5);
-            (*(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL))++;
+            u8 v = mStateWork;
+            (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL))++;
             if (v > 0x78) {
-                *(u8*)(c + 0x6e3) = 2;
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x7f, 0x40000000, 0x1000, 0);
-                func_ov002_020daa74(c);
+                mStateStep = 2;
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x7f, 0x40000000, 0x1000, 0);
+                func_ov002_020daa74(((char*)this));
                 return 1;
             }
         } else {
-            *(u8*)(c + 0x6e5) = 0;
+            mStateWork = 0;
         }
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) > 0x200) {
-            if (*(u8*)(c + 0x70c) == 0) {
-                *(u8*)(c + 0x70c) = 1;
-                *(s16*)(c + 0x6d4) = *(s16*)(c + 0x6d2);
+            if (mStateArg == 0) {
+                mStateArg = 1;
+                unk_6d4 = mDesiredAngleY;
             } else {
-                s16 xv = *(s16*)(c + 0x69c);
+                s16 xv = mAngleYSpeed;
                 if (xv < 0) xv = -xv;
                 s32 r3;
                 if (xv < 0x800)
-                    r3 = ((*(s16*)(c + 0x6d2) - *(s16*)(c + 0x6d4)) << 10) >> 16;
+                    r3 = ((mDesiredAngleY - unk_6d4) << 10) >> 16;
                 else
-                    r3 = ((*(s16*)(c + 0x6d2) - *(s16*)(c + 0x6d4)) << 9) >> 16;
+                    r3 = ((mDesiredAngleY - unk_6d4) << 9) >> 16;
                 if (r3 < -0x80) r3 = -0x80;
                 if (r3 > 0x80) r3 = 0x80;
-                *(s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFFLL) += r3;
-                if (*(s16*)(c + 0x69c) > 0x1000) *(s16*)(c + 0x69c) = 0x1000;
-                if (*(s16*)(c + 0x69c) < -0x1000) *(s16*)(c + 0x69c) = -0x1000;
+                *(s16*)(((int)((char*)this) + 0x69c) & 0xFFFFFFFFFFFFFFFFLL) += r3;
+                if (mAngleYSpeed > 0x1000) mAngleYSpeed = 0x1000;
+                if (mAngleYSpeed < -0x1000) mAngleYSpeed = -0x1000;
             }
         } else {
-            *(u8*)(c + 0x70c) = 0;
-            _Z15ApproachLinear2Rsss((s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFFLL), 0, 0x40);
+            mStateArg = 0;
+            _Z15ApproachLinear2Rsss((s16*)(((int)((char*)this) + 0x69c) & 0xFFFFFFFFFFFFFFFFLL), 0, 0x40);
         }
         {
-            s16 before = *(s16*)(c + 0x8e);
-            *(s16*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += *(s16*)(c + 0x69c);
-            if ((*(s16*)(c + 0x69c) <= -0x100 && before < *(s16*)(c + 0x8e)) ||
-                (*(s16*)(c + 0x69c) >= 0x100 && before > *(s16*)(c + 0x8e)))
-                func_02012694(0xb4, c + 0x74);
-            s16 sp = *(s16*)(c + 0x69c);
+            s16 before = mAngleY;
+            *(s16*)(((int)((char*)this) + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += mAngleYSpeed;
+            if ((mAngleYSpeed <= -0x100 && before < mAngleY) ||
+                (mAngleYSpeed >= 0x100 && before > mAngleY))
+                func_02012694(0xb4, ((char*)this) + 0x74);
+            s16 sp = mAngleYSpeed;
             if (sp >= 0)
-                *(s16*)(c + 0x8c) = -sp;
+                mAngX = -sp;
             else
-                *(s16*)(c + 0x8c) = sp;
+                mAngX = sp;
         }
         break;
     case 2:
-        if (_ZN6Player12FinishedAnimEv(c))
-            _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_02110154);
+        if (_ZN6Player12FinishedAnimEv(((char*)this)))
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110154);
         break;
     }
 
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
+++ b/src/_ZN6Player22St_GroundPound_CleanupEv.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol _ZN6Player22St_GroundPound_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 // Player::St_GroundPound_Cleanup - clear flag bit 0x20 in the u32 at this+0x2ec, return 1.
 // The u64-mask launder forces the base to materialize (add r2,this,#0x2ec) so the
 // load/store reuse it, matching the ROM instead of folding the offset into ldr/str.
-extern "C" {
-int _ZN6Player22St_GroundPound_CleanupEv(char *c)
+
+int Player::St_GroundPound_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+    *(unsigned int *)(((long long)(int)((char *)&mBodyClsnFlags))) &= ~0x20;
     return 1;
-}
 }

--- a/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
+++ b/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
@@ -1,11 +1,15 @@
 //cpp
-extern "C" {
-int _ZN6Player22St_SwingPlayer_CleanupEv(char* c){
-  char* p = *(char**)(c + 0x358);
+// @symbol _ZN6Player22St_SwingPlayer_CleanupEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
+
+
+int Player::St_SwingPlayer_Cleanup()
+{
+  char* p = *(char**)((char*)&mHeldObj);
   if (p) {
-    *(unsigned int*)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800;
+    *(unsigned int*)(((long long)(int)(p + 0xb0))) &= ~0x800;
   }
-  *(short*)(c + 0x94) = *(short*)(c + 0x8e);
+  mTargetAngleY = mAngleY;
   return 1;
-}
 }

--- a/src/_ZN6Player23St_MetalWaterWater_InitEv.cpp
+++ b/src/_ZN6Player23St_MetalWaterWater_InitEv.cpp
@@ -1,21 +1,26 @@
 //cpp
+// @symbol _ZN6Player23St_MetalWaterWater_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void func_ov002_020bf2d8(void*,int);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned,int,int,unsigned);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned,void*);
-int _ZN6Player23St_MetalWaterWater_InitEv(char* c){
-  *(char*)(c+0x712)=1;
-  *(char*)(c+0x706)=1;
-  *(char*)(c+0x6de)=1;
-  *(char*)(c+0x6df)=0;
-  if(*(unsigned char*)(c+0x6e3)==0){
-    func_ov002_020bf2d8(c,0x20000);
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x53,0x40000000,0x1000,0);
-  }else{
-    _ZN6Player7SetAnimEji5Fix12IiEj(c,0x54,0x40000000,0x1000,0);
-  }
-  _ZN5Sound9PlayBank0EjRK7Vector3(0xa8,c+0x74);
-  *(char*)(c+0x6e5)=0;
-  return 1;
 }
+
+int Player::St_MetalWaterWater_Init()
+{
+  mIsInAirState=1;
+  mIsUnderwater=1;
+  mIsAirborne=1;
+  mLandSoundPlayed=0;
+  if(mStateStep==0){
+    func_ov002_020bf2d8(((char*)this),0x20000);
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x53,0x40000000,0x1000,0);
+  }else{
+    _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x54,0x40000000,0x1000,0);
+  }
+  _ZN5Sound9PlayBank0EjRK7Vector3(0xa8,((char*)this)+0x74);
+  mStateWork=0;
+  return 1;
 }

--- a/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_InitEv.cpp
@@ -1,8 +1,14 @@
 //cpp
+// @symbol _ZN6Player24St_MetalWaterGround_InitEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned, unsigned, void*);
-int _ZN6Player24St_MetalWaterGround_InitEv(char* c) {
-    int* p = *(int**)(c+0x358);
+}
+
+int Player::St_MetalWaterGround_Init()
+{
+    int* p = *(int**)((char*)&mHeldObj);
     int b0 = (p != 0);
     if (b0) {
         int h = *(unsigned short*)((char*)p+0xc);
@@ -11,16 +17,15 @@ int _ZN6Player24St_MetalWaterGround_InitEv(char* c) {
             int b2 = (h == 0x10b);
             if (!b2) goto tail;
         }
-        *(int*)(int)(((long long)(int)((char*)p+0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x4000;
-        *(int*)(int)(((long long)(int)((char*)*(int**)(c+0x358)+0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
-        *(int**)(c+0x358) = 0;
+        *(int*)(int)(((long long)(int)((char*)p+0xb0))) &= ~0x4000;
+        *(int*)(int)(((long long)(int)((char*)*(int**)((char*)&mHeldObj)+0xb0))) &= ~0x100;
+        *(int**)((char*)&mHeldObj) = 0;
     }
 tail:
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9), 0x2e, c+0x74);
-    *(int*)(c+0x9c) = -0x1800;
-    *(int*)(c+0xa0) = -0x14000;
-    if (*(int*)(c+0x98) >= 0x14000) *(int*)(c+0x98) = 0x14000;
-    *(unsigned char*)(c+0x706) = 1;
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
+    mVertAccel = -0x1800;
+    mTerminalVelocity = -0x14000;
+    if (mHorzSpeed >= 0x14000) mHorzSpeed = 0x14000;
+    mIsUnderwater = 1;
     return 1;
-}
 }

--- a/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
@@ -1,17 +1,20 @@
 //cpp
+// @symbol _ZN6Player24St_MetalWaterGround_MainEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int func_ov002_020cec2c(void*);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-extern void func_ov002_020cd190(void*);
 extern void ApproachAngle(void*,short,int,int,int);
 extern int func_ov002_020bf224(void*,int,int);
 extern void _Z14ApproachLinearRiii(int*,int,int);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned int);
 extern int _ZN6Player6IsAnimEj(void*,unsigned int);
 extern int _ZN6Player12FinishedAnimEv(void*);
-extern void func_ov002_020bf5e0(void*);
 extern int _ZNK6Player14GetBodyModelIDEjb(void*,unsigned int,int);
-extern int _ZNK9Animation12WillHitFrameEi(void*,int);
 extern void func_0201251c(int,int,void*,int);
 extern void func_ov002_020bedd4(void*);
 extern int data_0209f32c;
@@ -19,73 +22,71 @@ extern unsigned char data_0209f49e;
 extern unsigned char data_020a0e40;
 extern short data_0209f4a0;
 extern int data_ov002_0211013c[];
-extern int data_ov002_021106c4[];
 extern int data_ov002_0211067c[];
+}
 
-int _ZN6Player24St_MetalWaterGround_MainEv(char* c)
+int Player::St_MetalWaterGround_Main()
 {
-    if(func_ov002_020cec2c(c)) return 1;
-    int u703 = *(unsigned char*)(c+0x703);
-    if((int)(data_0209f32c - 0x50000) < (int)(*(int*)(c+0x60) - 0xa000)){
-        *(unsigned char*)(c+0x706) = 0;
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211013c);
+    if(func_ov002_020cec2c(((char*)this))) return 1;
+    int u703 = mIsMega;
+    if((int)(data_0209f32c - 0x50000) < (int)(mPosY - 0xa000)){
+        mIsUnderwater = 0;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }
     if(*(unsigned short*)((char*)&data_0209f49e + data_020a0e40 * 0x18) & 2){
-        *(unsigned char*)(c+0x6e3) = 0;
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021106c4);
+        mStateStep = 0;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021106c4);
         return 1;
     }
-    if(*(unsigned char*)(c+0x6de) != 0 && (*(int*)(c+0x60) - *(int*)(c+0x644)) >= 0x32000){
-        *(unsigned char*)(c+0x6e3) = 1;
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021106c4);
+    if(mIsAirborne != 0 && (mPosY - mGroundY) >= 0x32000){
+        mStateStep = 1;
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021106c4);
         return 1;
     }
-    if(*(unsigned char*)(c+0x6f9) == 0 && u703 == 0){
-        _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211067c);
+    if(mIsMetal == 0 && u703 == 0){
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211067c);
         return 1;
     }
-    func_ov002_020cd190(c);
+    func_ov002_020cd190(((char*)this));
     int approach = 0;
     if(*(short*)((char*)&data_0209f4a0 + data_020a0e40 * 0x18) != 0){
-        ApproachAngle((short*)(c+0x94), *(short*)(c+0x6d2), 8, 0x1000, 0x80);
-        approach = func_ov002_020bf224(c, 0x14000, 0x1000);
+        ApproachAngle((short*)((char*)&mTargetAngleY), mDesiredAngleY, 8, 0x1000, 0x80);
+        approach = func_ov002_020bf224(((char*)this), 0x14000, 0x1000);
     }
-    _Z14ApproachLinearRiii((int*)(c+0x98), approach, 0x1000);
-    *(short*)(c+0x8e) = *(short*)(c+0x94);
-    if(*(unsigned char*)(c+0x703) != 0){
-        if(*(int*)(c+0x98) == 0){
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xa0, 0, 0x1000, 0);
-        }else if(_ZN6Player6IsAnimEj(c, 0xa0) != 0){
-            _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9f, 0x40000000, 0x1000, 0);
-        }else if(_ZN6Player6IsAnimEj(c, 0x9f) != 0){
-            if(_ZN6Player12FinishedAnimEv(c) != 0){
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9e, 0, *(short*)((char*)&data_0209f4a0 + data_020a0e40 * 0x18) * 2, 0);
+    _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), approach, 0x1000);
+    mAngleY = mTargetAngleY;
+    if(mIsMega != 0){
+        if(mHorzSpeed == 0){
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xa0, 0, 0x1000, 0);
+        }else if(_ZN6Player6IsAnimEj(((char*)this), 0xa0) != 0){
+            _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x9f, 0x40000000, 0x1000, 0);
+        }else if(_ZN6Player6IsAnimEj(((char*)this), 0x9f) != 0){
+            if(_ZN6Player12FinishedAnimEv(((char*)this)) != 0){
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x9e, 0, *(short*)((char*)&data_0209f4a0 + data_020a0e40 * 0x18) * 2, 0);
             }
-        }else if(_ZN6Player6IsAnimEj(c, 0x9f) == 0){
+        }else if(_ZN6Player6IsAnimEj(((char*)this), 0x9f) == 0){
             int v = *(short*)((char*)&data_0209f4a0 + data_020a0e40 * 0x18);
             if(v != 0){
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9e, 0, v * 2, 0);
-                func_ov002_020bf5e0(c);
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x9e, 0, v * 2, 0);
+                func_ov002_020bf5e0(((char*)this));
             }else{
-                _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9d, 0x40000000, 0x1000, 0);
+                _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x9d, 0x40000000, 0x1000, 0);
             }
         }
-    }else if(*(int*)(c+0x98) == 0){
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x47, 0, 0x1000, 0);
+    }else if(mHorzSpeed == 0){
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x47, 0, 0x1000, 0);
     }else{
-        _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x48, 0, 0x1000, 0);
-        int r5 = (int)((((long long)*(int*)(c+0x98) << 9) + 0x800) >> 12);
+        _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x48, 0, 0x1000, 0);
+        int r5 = (int)((((long long)mHorzSpeed << 9) + 0x800) >> 12);
         if(r5 < 0x400) r5 = 0x400;
-        char* anim = *(char**)(c + _ZNK6Player14GetBodyModelIDEjb(c, (unsigned char)*(int*)(c+8), 0) * 4 + 0xdc) + 0x50;
+        char* anim = *(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50;
         *(int*)(anim + 0xc) = r5;
-        if(_ZNK9Animation12WillHitFrameEi((void*)(*(char**)(c + _ZNK6Player14GetBodyModelIDEjb(c, (unsigned char)*(int*)(c+8), 0) * 4 + 0xdc) + 0x50), 4) != 0
-           || _ZNK9Animation12WillHitFrameEi((void*)(*(char**)(c + _ZNK6Player14GetBodyModelIDEjb(c, (unsigned char)*(int*)(c+8), 0) * 4 + 0xdc) + 0x50), 0x13) != 0){
-            func_0201251c(0, 0xaa, (void*)(c+0x74), *(int*)(c+0x98));
+        if(_ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 4) != 0
+           || _ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 0x13) != 0){
+            func_0201251c(0, 0xaa, (void*)((char*)&mCamSpacePos), mHorzSpeed);
         }
     }
-    func_ov002_020bedd4(c);
+    func_ov002_020bedd4(((char*)this));
     return 1;
-}
-
 }


### PR DESCRIPTION
Batch 06 of the readable-tree migration. Promotes 181 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (tools/prepush_linkcheck.py, mwccarm 1.2/sp2p3): 96 VERIFIED, 85 BLIND, 0 WRONG/NO-REPRO. 9 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
