### PR TITLE
readable: batch 07 - promote 183 files to readable form

### DIFF
--- a/src/_ZN6Player4BurnEv.cpp
+++ b/src/_ZN6Player4BurnEv.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN6Player4BurnEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int func_ov002_020d82f0(void*);
 extern int data_ov002_021100dc[];
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-int _ZN6Player4BurnEv(char* c){
-  if(func_ov002_020d82f0(c)==0) return 0;
-  if(*(unsigned char*)(c+0x6f9) || *(unsigned char*)(c+0x706)) return 0;
-  _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_021100dc);
-  return 1;
 }
+
+int Player::Burn()
+{
+  if(func_ov002_020d82f0(((char*)this))==0) return 0;
+  if(mIsMetal || mIsUnderwater) return 0;
+  _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_021100dc);
+  return 1;
 }

--- a/src/_ZN6Player4HealEi.cpp
+++ b/src/_ZN6Player4HealEi.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN6Player4HealEi
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" int _ZN6Player7IsStateERNS_5StateE(char*, void*);
 extern int data_ov002_0211010c[];
 extern int data_ov002_02110124[];
-extern "C" int GiveHealth(int,int);
-extern "C" int _ZN6Player4HealEi(char* c, int amt){
-  int r = _ZN6Player7IsStateERNS_5StateE(c, data_ov002_0211010c);
+
+int Player::Heal(int amt)
+{
+  int r = _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211010c);
   if(r) return r;
-  r = _ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110124);
+  r = _ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_02110124);
   if(r) return r;
-  return GiveHealth(*(unsigned char*)(c+0x6d8), amt);
+  return GiveHealth(mPlayerNo, amt);
 }

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -1,35 +1,33 @@
 //cpp
+// @symbol _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 
 extern "C" {
-extern int func_ov002_020d82f0(void* c);
 extern int _ZN6Player8HasNoCapEv(char* c);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
-extern void func_ov002_020d91b8(char* self, int a);
 extern void func_ov002_020d5cec(char* c);
 extern s16 Vec3_HorzAngle(const void* v0, const void* v1);
-extern int AngleDiff(int a, int b);
-extern void func_02014fa4(char* c);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, int a, int b, int cc);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
 extern int func_ov002_020d91e0(char* thiz, int damage, int doPre);
 
-extern u16 data_ov002_020ff128[];
 extern int data_ov002_02110094;
 extern int data_ov002_0211010c;
-extern int data_ov002_021100ac;
 }
 
-extern "C" int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char* c, void* a, u32 b, int dmg, u8 arg4, u8 arg5, u8 arg6)
-{
+extern "C" int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Player *self, void* a, u32 b, int dmg, u8 arg4, u8 arg5, u8 arg6) {
     s16 ang;
     void* p360;
     int hasCap;
 
-    if (func_ov002_020d82f0(c) == 0) {
+    if (func_ov002_020d82f0(((char*)self)) == 0) {
         return 0;
     }
 
@@ -39,101 +37,101 @@ extern "C" int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char* c, void* a, u32 b, 
         }
     }
 
-    hasCap = _ZN6Player8HasNoCapEv(c);
+    hasCap = _ZN6Player8HasNoCapEv(((char*)self));
     if (hasCap != 0) goto L88;
-    if (*(u8*)(c + 0x6d9) == *(int*)(c + 8)) goto L88;
-    if (*(u8*)(c + 0x6f9) != 0) goto L88;
+    if (self->mCharacter == self->mParam) goto L88;
+    if (self->mIsMetal != 0) goto L88;
     if (b == 0) goto L88;
 
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8*)(c + 0x6d9), 0x22, c + 0x74);
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(self->mCharacter, 0x22, ((char*)self) + 0x74);
     goto L9c;
 
 L88:
     {
         int t = 0;
         if ((int)b > 1) t = 1;
-        func_ov002_020d91b8(c, t);
+        func_ov002_020d91b8(((char*)self), t);
     }
 
 L9c:
-    if (*(u8*)(c + 0x6f9) != 0) {
+    if (self->mIsMetal != 0) {
         b = 0;
     }
-    p360 = *(void**)(c + 0x360);
+    p360 = *(void**)((char*)&self->mObjInMouth);
     if (p360 != 0) {
         int match = (*(u16*)((char*)p360 + 0xc) == 0xbf);
         if (match) {
             func_ov002_020d5cec((char*)p360);
-            *(u16*)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+            *(u16*)(((long long)(int)((char*)&self->mStateFlags))) &= ~2;
         }
-        *(u8*)(c + 0x714) = 0;
+        self->mUseAltBodyModel = 0;
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
             *p |= 0x80000;
         }
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
             *p &= ~0x40000;
         }
         {
-            int* p = (int*)(((long long)(int)((char*)*(void**)(c + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((long long)(int)((char*)*(void**)((char*)&self->mObjInMouth) + 0xb0)));
             *p &= ~0x20000;
         }
-        *(void**)(c + 0x360) = 0;
+        *(void**)((char*)&self->mObjInMouth) = 0;
     }
 
-    *(u8*)(c + 0x6e3) = 0;
+    self->mStateStep = 0;
 
     if (b != 0) {
         int neq = 0;
-        if (*(u8*)(c + 0x6d9) != *(int*)(c + 8)) neq = 1;
-        if (neq) *(u8*)(c + 0x6e3) = 2;
+        if (self->mCharacter != self->mParam) neq = 1;
+        if (neq) self->mStateStep = 2;
     }
     if ((int)b > 1) {
-        *(u8*)(c + 0x6e3) = 2;
+        self->mStateStep = 2;
     }
-    if (*(u8*)(c + 0x6de) != 0) {
-        *(u8*)(c + 0x6e3) = 4;
+    if (self->mIsAirborne != 0) {
+        self->mStateStep = 4;
     }
 
-    ang = Vec3_HorzAngle(c + 0x5c, a);
-    if (AngleDiff(*(s16*)(c + 0x8e), ang) > 0x4000) {
-        *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    ang = Vec3_HorzAngle(((char*)self) + 0x5c, a);
+    if (AngleDiff(self->mAngleY, ang) > 0x4000) {
+        *(u8*)(((long long)(int)((char*)&self->mStateStep))) += 1;
     }
-    *(s16*)(c + 0x94) = ang + 0x8000;
-    if (*(u8*)(c + 0x6e3) & 1) {
-        *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
+    self->mTargetAngleY = ang + 0x8000;
+    if (self->mStateStep & 1) {
+        self->mAngleY = self->mTargetAngleY;
     } else {
-        *(s16*)(c + 0x8e) = ang;
+        self->mAngleY = ang;
     }
 
     if (arg4 == 1) {
-        u16 tv = data_ov002_020ff128[*(int*)(c + 8)];
+        u16 tv = data_ov002_020ff128[self->mParam];
         dmg = (dmg * tv) / 100;
     }
-    *(int*)(c + 0x98) = dmg;
+    self->mHorzSpeed = dmg;
 
     if (arg5 != 0) {
         u8 t = arg5 - 1;
-        *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
-        *(u8*)(c + 0x6e5) = t;
+        *(u8*)(((long long)(int)((char*)&self->mStateStep))) |= 0x10;
+        self->mStateWork = t;
     }
 
-    func_02014fa4(c + 0x314);
-    *(int*)(c + 0x674) = b;
+    func_02014fa4((char*)&self->mAttackClsn);
+    self->mHurtDamage = b;
 
-    if (*(u8*)(c + 0x706) == 0) {
-        if (*(int*)(c + 0x674) != 0) {
+    if (self->mIsUnderwater == 0) {
+        if (self->mHurtDamage != 0) {
             if (arg6 != 0) {
                 volatile struct { int x, y, z; } v;
-                int y = *(int*)(c + 0x60);
-                int z = *(int*)(c + 0x64);
-                int x = *(int*)(c + 0x5c);
+                int y = self->mPosY;
+                int z = self->mPosZ;
+                int x = self->mPosX;
                 y = y + 0x50000;
                 v.x = x;
                 v.y = y;
                 v.z = z;
-                if (*(volatile int*)(c + 0x674) == 1) {
+                if (*(volatile int*)((char*)&self->mHurtDamage) == 1) {
                     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xcb, x, y, z);
                     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xcc, v.x, v.y, v.z);
                 } else {
@@ -143,14 +141,14 @@ L9c:
             }
         }
 
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_02110094);
-        if (func_ov002_020d91e0(c, b << 8, 1) != 0) {
-            *(u8*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL) &= 1;
-            _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0211010c);
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)self), &data_ov002_02110094);
+        if (func_ov002_020d91e0(((char*)self), b << 8, 1) != 0) {
+            *(u8*)(((long long)(int)((char*)&self->mStateStep))) &= 1;
+            _ZN6Player11ChangeStateERNS_5StateE(((char*)self), &data_ov002_0211010c);
         }
     } else {
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021100ac);
-        func_ov002_020d91e0(c, b << 8, 1);
+        _ZN6Player11ChangeStateERNS_5StateE(((char*)self), &data_ov002_021100ac);
+        func_ov002_020d91e0(((char*)self), b << 8, 1);
     }
 
     return 1;

--- a/src/_ZN6Player5ShockEj.cpp
+++ b/src/_ZN6Player5ShockEj.cpp
@@ -1,20 +1,26 @@
 //cpp
+// @symbol _ZN6Player5ShockEj
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_021100c4;
-extern int func_ov002_020d82f0(void* c);
 extern int func_ov002_020d91e0(void* c, int a, int b, int d);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, State* st);
-int _ZN6Player5ShockEj(char* c, unsigned int j){
-  if (func_ov002_020d82f0(c) == 0) return 0;
-  if (*(unsigned char*)(c+0x6f9)) j = 0;
-  *(unsigned char*)(c+0x6e5) = 0;
-  if (func_ov002_020d91e0(c, j<<8, 1, 0)) *(unsigned char*)(c+0x6e5) = 1;
-  if (*(unsigned char*)(c+0x706)) {
-    unsigned char* p = (unsigned char*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF);
+}
+
+int Player::Shock(unsigned int j)
+{
+  if (func_ov002_020d82f0(((char*)this)) == 0) return 0;
+  if (mIsMetal) j = 0;
+  mStateWork = 0;
+  if (func_ov002_020d91e0(((char*)this), j<<8, 1, 0)) mStateWork = 1;
+  if (mIsUnderwater) {
+    unsigned char* p = (unsigned char*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF);
     *p |= 2;
   }
-  _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021100c4);
+  _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_021100c4);
   return 1;
-}
 }

--- a/src/_ZN6Player6BounceE5Fix12IiE.cpp
+++ b/src/_ZN6Player6BounceE5Fix12IiE.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player6BounceE5Fix12IiE
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Player.h"
 extern "C" {
 extern int _ZN6Player7IsStateERNS_5StateE(void*,void*);
 extern int _ZN6Player9GetHealthEv(void*);
@@ -6,13 +11,12 @@ extern int _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
 extern int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int,unsigned int,void*);
 extern int _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int,void*);
 extern int data_ov002_021105a4[];
-extern int data_ov002_0211019c[];
-void _ZN6Player6BounceE5Fix12IiE(char* c, int f){
-  if(_ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105a4)) return;
-  if(_ZN6Player9GetHealthEv(c)==0) return;
-  _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_0211019c);
-  *(int*)(c+0xa8) = f;
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(c+0x6d9),0x14,(char*)c+0x74);
-  _ZN5Sound9PlayBank0EjRK7Vector3(0xb6,(char*)c+0x74);
+void _ZN6Player6BounceE5Fix12IiE(struct Player *self, int f) {
+  if(_ZN6Player7IsStateERNS_5StateE(((char*)self), data_ov002_021105a4)) return;
+  if(_ZN6Player9GetHealthEv(((char*)self))==0) return;
+  _ZN6Player11ChangeStateERNS_5StateE(((char*)self), data_ov002_0211019c);
+  self->mVertSpeed = f;
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(self->mCharacter,0x14,(char*)((char*)self)+0x74);
+  _ZN5Sound9PlayBank0EjRK7Vector3(0xb6,(char*)((char*)self)+0x74);
 }
 }

--- a/src/_ZN6Player6IsAnimEj.cpp
+++ b/src/_ZN6Player6IsAnimEj.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN6Player6IsAnimEj
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" unsigned int _ZNK6Player14GetBodyModelIDEjb(char*,unsigned int,char);
 extern int data_ov002_020ff480[];
-extern "C" int _ZN6Player6IsAnimEj(char* c, unsigned int a){
-  int ip = *(int*)(c+8);
+
+int Player::IsAnim(unsigned int a)
+{
+  int ip = mParam;
   int* p = (int*)data_ov002_020ff480[ip + a*4];
   int v = p[1];
-  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(c, ip&0xff, 0);
-  int* m = *(int**)(c + id*4 + 0xdc);
+  unsigned int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), ip&0xff, 0);
+  int* m = *(int**)(((char*)this) + id*4 + 0xdc);
   int r=(m[24]==v); return r?1:0;
 }

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -15,7 +20,7 @@ struct VObj {
 
 typedef struct M34 { int m[12]; } M34;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 #pragma opt_common_subs off
 
@@ -27,119 +32,116 @@ extern int func_ov002_020becf4(char* self, u32 a, int b);
 extern void _ZN9ModelBase12ApplyOpacityEj(void* self, u32 a, int b);
 extern void _ZN5Model6RenderEPK7Vector3(void* self, void* pos);
 extern void _ZN15TextureSequence6UpdateER15ModelComponents(void* self, void* mc);
-extern void func_ov002_020e3e00(void* mdl, void* pos, u32 a);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void* m, int ang);
 extern void MulMat4x3Mat4x3(void* a, void* b, void* c);
-extern int func_ov002_020bea7c(char* self);
 extern int func_ov002_020d225c(char* self);
 extern u8 data_0209f2d8;
 extern u8 data_0209fc5c[];
 extern int data_ov002_021100c4;
 extern int data_020a0e68;
+}
 
-int _ZN6Player6RenderEv(char* c)
+int Player::Render()
 {
     int t = (data_0209f2d8 == 1);
     if (t != false) {
-        if (data_0209fc5c[*(u8*)(c + 0x6d8)] == 0)
+        if (data_0209fc5c[mPlayerNo] == 0)
             return 1;
     }
-    if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021100c4)) {
-        if (*(u16*)(c + 0x6a0) & 2)
+    if (_ZN6Player7IsStateERNS_5StateE(((char*)this), &data_ov002_021100c4)) {
+        if (mInvincibleTimer & 2)
             return 1;
     } else {
-        if (*(u16*)(c + 0x6a0) & 1)
+        if (mInvincibleTimer & 1)
             return 1;
     }
-    if (*(u8*)(c + 0x6f5) == 0)
+    if (mOpacity == 0)
         return 1;
-    if (!(*(int*)(c + 0xb0) & 0x10)) {
+    if (!(unk_0b0 & 0x10)) {
         char* bodyMdl;
         int i;
-        bodyMdl = *(char**)(c + 0xdc + _ZNK6Player14GetBodyModelIDEjb(c, *(u8*)(c + 0x6db), 1) * 4);
-        if (*(u8*)(c + 0x6fd) == 0) {
-            _ZN9ModelBase12ApplyOpacityEj(bodyMdl, *(u8*)(c + 0x6f5), 0);
+        bodyMdl = *(char**)(((char*)this) + 0xdc + _ZNK6Player14GetBodyModelIDEjb(((char*)this), unk_6db, 1) * 4);
+        if (mIsBalloon == 0) {
+            _ZN9ModelBase12ApplyOpacityEj(bodyMdl, mOpacity, 0);
             {
                 int t2 = (data_0209f2d8 == 1);
                 if (t2 != false) {
-                    if (*(int*)(c + 8) == 3) {
+                    if (mParam == 3) {
                         int* p = (int*)AT(bodyMdl, 8);
                         char* hdr = (char*)p[0];
                         char* rec = (char*)p[1];
                         u32 i2;
                         for (i2 = 0; i2 < *(u32*)(hdr + 0x24); i2++) {
-                            *(int*)(rec + 0x20) = *(int*)(c + 0x61c);
+                            *(int*)(rec + 0x20) = unk_61c;
                             rec += 0x30;
                         }
                     }
                 }
             }
-            _ZN5Model6RenderEPK7Vector3(bodyMdl, c + 0x80);
-            if (*(int*)(c + 8) == 1) {
-                _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x254, *(char**)(c + 0xe0) + 8);
-                *(int*)(c + 0x25c) = *(u8*)(c + 0x6fc) << 12;
+            _ZN5Model6RenderEPK7Vector3(bodyMdl, ((char*)this) + 0x80);
+            if (mParam == 1) {
+                _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x254, *(char**)((char*)&unk_0e0) + 8);
+                unk_25c = unk_6fc << 12;
             }
-            func_ov002_020e3e00(bodyMdl, c + 0x80, *(u8*)(c + 0x6f5));
-            if (*(u8*)(c + 0x700) != 0) {
-                _ZN9ModelBase12ApplyOpacityEj(c + 0x174, *(u8*)(c + 0x6f5), 0);
-                if (*(u8*)(c + 0x6db) == 3) {
+            func_ov002_020e3e00(bodyMdl, ((char*)this) + 0x80, mOpacity);
+            if (unk_700 != 0) {
+                _ZN9ModelBase12ApplyOpacityEj(((char*)this) + 0x174, mOpacity, 0);
+                if (unk_6db == 3) {
                     Matrix4x3_FromTranslation(&data_020a0e68, -0x1b33, -0x666, 0);
                     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, 0x4000);
                     MulMat4x3Mat4x3(&data_020a0e68, *(char**)(bodyMdl + 0x14) + 0x180, &data_020a0e68);
-                    ((VObj*)(c + 0x174))->m18(&data_020a0e68, c + 0x80);
+                    ((VObj*)((char*)&mModelAnim4))->m18(&data_020a0e68, ((char*)this) + 0x80);
                 } else {
-                    ((VObj*)(c + 0x174))->m18(*(char**)(bodyMdl + 0x14) + 0x2d0, c + 0x80);
+                    ((VObj*)((char*)&mModelAnim4))->m18(*(char**)(bodyMdl + 0x14) + 0x2d0, ((char*)this) + 0x80);
                 }
             }
         } else {
-            _ZN9ModelBase12ApplyOpacityEj(c + 0xf0, *(u8*)(c + 0x6f5), 0);
-            ((VObj*)(c + 0xf0))->m14(c + 0x80);
+            _ZN9ModelBase12ApplyOpacityEj(((char*)this) + 0xf0, mOpacity, 0);
+            ((VObj*)((char*)&mModelAnim3))->m14((char*)&mScaleX);
         }
-        i = func_ov002_020becf4(c, *(u8*)(c + 0x6db), 1);
+        i = func_ov002_020becf4(((char*)this), unk_6db, 1);
         {
-            char* mdl4 = *(char**)(c + 0x154 + i * 4);
+            char* mdl4 = *(char**)(((char*)this) + 0x154 + i * 4);
             if (mdl4 != 0 && i != 9 && i != 8) {
-                _ZN9ModelBase12ApplyOpacityEj(mdl4, *(u8*)(c + 0x6f5), 0);
+                _ZN9ModelBase12ApplyOpacityEj(mdl4, mOpacity, 0);
                 {
                     int t3 = (data_0209f2d8 == 1);
                     if (t3 != false) {
-                        if (*(int*)(c + 8) == 3) {
-                            int* p = (int*)AT(*(char**)(c + 0x154 + i * 4), 8);
+                        if (mParam == 3) {
+                            int* p = (int*)AT(*(char**)(((char*)this) + 0x154 + i * 4), 8);
                             char* hdr = (char*)p[0];
                             char* rec = (char*)p[1];
                             u32 i2;
                             for (i2 = 0; i2 < *(u32*)(hdr + 0x24); i2++) {
-                                *(int*)(rec + 0x20) = *(int*)(c + 0x61c);
+                                *(int*)(rec + 0x20) = unk_61c;
                                 rec += 0x30;
                             }
                         }
                     }
                 }
                 if (i == 3) {
-                    _ZN5Model6RenderEPK7Vector3(*(char**)(c + 0x154 + i * 4), c + 0x80);
+                    _ZN5Model6RenderEPK7Vector3(*(char**)(((char*)this) + 0x154 + i * 4), ((char*)this) + 0x80);
                 } else {
-                    char* m = *(char**)(c + 0x154 + i * 4);
+                    char* m = *(char**)(((char*)this) + 0x154 + i * 4);
                     char* dst = *(char**)(m + 0x14);
                     char* src = *(char**)(bodyMdl + 0x14) + 0x2d0;
                     *(M34*)dst = *(M34*)src;
-                    ((VObj*)*(char**)(c + 0x154 + i * 4))->m14(c + 0x80);
+                    ((VObj*)*(char**)(((char*)this) + 0x154 + i * 4))->m14((char*)&mScaleX);
                 }
-                if (*(int*)(c + 8) == 1) {
-                    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x268, *(char**)(c + 0x158) + 8);
-                    *(int*)(c + 0x270) = *(u8*)(c + 0x6fc) << 12;
+                if (mParam == 1) {
+                    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x268, *(char**)((char*)&unk_158) + 8);
+                    unk_270 = unk_6fc << 12;
                 }
-                if (func_ov002_020bea7c(c) == 0) {
-                    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x1dc + *(u8*)(c + 0x6db) * 0x14, *(char**)(c + 0x154 + i * 4) + 8);
+                if (func_ov002_020bea7c(((char*)this)) == 0) {
+                    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x1dc + unk_6db * 0x14, *(char**)(((char*)this) + 0x154 + i * 4) + 8);
                 }
-                func_ov002_020e3e00(*(char**)(c + 0x154 + i * 4), c + 0x80, *(u8*)(c + 0x6f5));
-                if (func_ov002_020d225c(c)) {
-                    ((VObj*)*(char**)(c + 0x1d8))->m14(c + 0x56c);
+                func_ov002_020e3e00(*(char**)(((char*)this) + 0x154 + i * 4), ((char*)this) + 0x80, mOpacity);
+                if (func_ov002_020d225c(((char*)this))) {
+                    ((VObj*)*(char**)((char*)&unk_1d8))->m14((char*)&unk_56c);
                 }
             }
         }
     }
     return 1;
-}
-
 }

--- a/src/_ZN6Player6ST_OWLE.c
+++ b/src/_ZN6Player6ST_OWLE.c
@@ -1,9 +1,13 @@
+// @symbol _ZN6Player6ST_OWLE
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Player.h"
 struct S { int a, b; };
 
-extern long long func_0203d5bc(int *p);
 extern int func_ov006_02114590(void *a0, struct S *p, struct S *q0, struct S *q1, struct S *q2);
 
-int _ZN6Player6ST_OWLE(char *self, struct S *v) {
+int _ZN6Player6ST_OWLE(struct Player *self, struct S *v) {
     struct S d;
     struct S p, t1, t2, t3;
     struct S p2, t4, t5, t6;
@@ -12,59 +16,59 @@ int _ZN6Player6ST_OWLE(char *self, struct S *v) {
     int yv, xv;
     int yv2, xv2;
 
-    if (*(unsigned char *)(self + 0x30) == 0)
+    if (self->unk_030 == 0)
         return 0;
     t = v->a;
     d.a = t;
     d.b = v->b;
-    d.a -= *(int *)(self + 0x8);
-    d.b -= *(int *)(self + 0xc);
-    if (*(int *)(self + 0x38) <= 0) {
-        t = *(int *)(self + 0xc);
+    d.a -= self->mParam;
+    d.b -= self->unk_00c;
+    if (self->mModelAnim1 <= 0) {
+        t = self->unk_00c;
         if (v->b >= t) {
             if (func_0203d5bc(&d.a) >= 0x190000)
                 return 0;
             return func_0203d5bc(&d.a) >= 0xc4000;
         }
-        if (v->a >= *(int *)(self + 0x8) - 0x14000 && v->a < *(int *)(self + 0x8) + 0x14000 &&
+        if (v->a >= self->mParam - 0x14000 && v->a < self->mParam + 0x14000 &&
             v->b >= t - 0xc000) {
-            if (v->a >= *(int *)(self + 0x8) - 0x14000 && v->a < *(int *)(self + 0x8) - 0xa000) {
+            if (v->a >= self->mParam - 0x14000 && v->a < self->mParam - 0xa000) {
                 p.a = v->a;
                 p.b = v->b;
-                yv = *(int *)(self + 0xc) - 0xc000;
-                xv = *(int *)(self + 0x8) - 0x14000;
+                yv = self->unk_00c - 0xc000;
+                xv = self->mParam - 0x14000;
                 t1.a = xv;
                 t1.b = yv;
-                yv = *(int *)(self + 0xc) - 0xc000;
-                xv = *(int *)(self + 0x8) - 0xa000;
+                yv = self->unk_00c - 0xc000;
+                xv = self->mParam - 0xa000;
                 t2.a = xv;
                 t2.b = yv;
-                yv = *(int *)(self + 0xc) - 0x1000;
-                xv = *(int *)(self + 0x8) - 0xa000;
+                yv = self->unk_00c - 0x1000;
+                xv = self->mParam - 0xa000;
                 t3.a = xv;
                 t3.b = yv;
-                r = func_ov006_02114590(self, &p, &t1, &t2, &t3);
+                r = func_ov006_02114590(((char *)self), &p, &t1, &t2, &t3);
                 if (r == 0) goto in1;
                 return 0;
             in1:
                 return 1;
             }
-            if (v->a >= *(int *)(self + 0x8) + 0xa000 && v->a < *(int *)(self + 0x8) + 0x16000) {
+            if (v->a >= self->mParam + 0xa000 && v->a < self->mParam + 0x16000) {
                 p2.a = v->a;
                 p2.b = v->b;
-                yv2 = *(int *)(self + 0xc) - 0xc000;
-                xv2 = *(int *)(self + 0x8) + 0x14000;
+                yv2 = self->unk_00c - 0xc000;
+                xv2 = self->mParam + 0x14000;
                 t4.a = xv2;
                 t4.b = yv2;
-                yv2 = *(int *)(self + 0xc) - 0xc000;
-                xv2 = *(int *)(self + 0x8) + 0xa000;
+                yv2 = self->unk_00c - 0xc000;
+                xv2 = self->mParam + 0xa000;
                 t5.a = xv2;
                 t5.b = yv2;
-                yv2 = *(int *)(self + 0xc) - 0x1000;
-                xv2 = *(int *)(self + 0x8) + 0xa000;
+                yv2 = self->unk_00c - 0x1000;
+                xv2 = self->mParam + 0xa000;
                 t6.a = xv2;
                 t6.b = yv2;
-                r = func_ov006_02114590(self, &p2, &t4, &t5, &t6);
+                r = func_ov006_02114590(((char *)self), &p2, &t4, &t5, &t6);
                 if (r == 0) goto in2;
                 return 0;
             in2:

--- a/src/_ZN6Player7CanWarpEv.cpp
+++ b/src/_ZN6Player7CanWarpEv.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol _ZN6Player7CanWarpEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State _ZN6Player7ST_WAITE;
 extern State data_ov002_021102a4;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player7CanWarpEv(void* c){
-  if(_ZN6Player7IsStateERNS_5StateE(c, &_ZN6Player7ST_WAITE) || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021102a4)) return 1;
-  return 0;
 }
+
+int Player::CanWarp()
+{
+  if(_ZN6Player7IsStateERNS_5StateE(((void*)this), &_ZN6Player7ST_WAITE) || _ZN6Player7IsStateERNS_5StateE(((void*)this), &data_ov002_021102a4)) return 1;
+  return 0;
 }

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Player8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef signed char s8;
 typedef short s16;
 typedef int s32;
@@ -7,7 +12,6 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vector3 { s32 x, y, z; };
 struct C3;
 typedef int (C3::*PMF)();
 struct State {
@@ -20,7 +24,7 @@ struct G_ee90 {
     s32 flag26c;
 };
 
-#define LAU(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LAU(p) ((long long)(int)(p))
 
 extern "C" {
 extern u16 DecIfAbove0_Short(u16 *p);
@@ -34,30 +38,14 @@ extern int _ZN6Player7IsStateERNS_5StateE(void *self, State *s);
 extern void _ZN9Animation7AdvanceEv(void *self);
 extern void func_02035684(void *p, s32 v);
 extern void func_0203568c(void *p, s32 v);
-extern void func_ov002_020bdd2c(void *self);
-extern void func_ov002_020bdd9c(void *self);
-extern void func_ov002_020bdef0(void *self);
-extern void func_ov002_020bf13c(void *self);
-extern void func_ov002_020bf36c(void *self, void *cyl);
-extern void func_ov002_020c2db8(void *self);
-extern void func_ov002_020c2e78(void *self);
-extern int func_ov002_020c4188(void *self);
-extern void func_ov002_020ca940(void *self);
 extern void func_ov002_020ce8bc(void *self, s32 arg);
 extern void func_ov002_020d6790(void *self);
 extern void func_ov002_020d80d0(void *self);
-extern void func_ov002_020d8158(void *self);
-extern void func_ov002_020d869c(void *self);
-extern void func_ov002_020db704(void *self);
-extern void func_ov002_020e032c(void *self);
-extern void func_ov002_020e4bb8(void *self);
 
 extern u8 data_0209f250;
-extern u8 data_0209f254;
 extern s8 data_0209f284;
 extern u8 data_0209f2d8;
 extern s8 data_0209f2f8;
-extern s16 data_0209f4a6;
 extern s32 data_0209fc48;
 extern u8 data_0209fc5c[];
 extern s32 data_0209fc68;
@@ -79,7 +67,7 @@ extern State data_ov002_02110634;
 extern State data_ov002_021106f4;
 }
 
-extern "C" int _ZN6Player8BehaviorEv(char *c)
+int Player::Behavior()
 {
     s32 r0;
     s32 scale;
@@ -94,38 +82,38 @@ extern "C" int _ZN6Player8BehaviorEv(char *c)
         r0 = 1;
     else
         r0 = 0;
-    if (r0 != 0 && data_0209fc5c[*(u8 *)(c + 0x6d8)] == 0)
+    if (r0 != 0 && data_0209fc5c[mPlayerNo] == 0)
         return 1;
 
     scale = 0x1000;
     r2 = scale;
-    if (*(u8 *)(c + 0x703) != 0) {
+    if (mIsMega != 0) {
         scale = 0x3000;
         r2 = 0x4200;
-    } else if (*(u8 *)(c + 0x6fd) != 0) {
+    } else if (mIsBalloon != 0) {
         scale = 0x1400;
         r2 = 0x2000;
     }
     temp = (s32)(((s64)r2 * 0x32000 + 0x800) >> 12);
-    func_0203568c(c + 0x380, temp);
-    func_02035684(c + 0x380, temp);
-    *(s32 *)(c + 0x2d8) = scale * 0x28;
+    func_0203568c(((char *)this) + 0x380, temp);
+    func_02035684(((char *)this) + 0x380, temp);
+    unk_2d8 = scale * 0x28;
     mul = 0x96;
-    if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021104e4)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110514)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110334)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211031c)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021105bc)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211061c)
-        || _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110634)) {
+    if (_ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_021104e4)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110514)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110334)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_0211031c)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_021105bc)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_0211061c)
+        || _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110634)) {
         mul = 0x5a;
     }
-    *(s32 *)(c + 0x2dc) = mul * scale;
+    unk_2dc = mul * scale;
 
-    if (*(u8 *)(c + 0x703) != 0)
-        *(u32 *)LAU(c + 0x2ec) |= 0x10;
+    if (mIsMega != 0)
+        *(u32 *)LAU((char *)&mBodyClsnFlags) |= 0x10;
     else
-        *(u32 *)LAU(c + 0x2ec) &= ~0x10;
+        *(u32 *)LAU((char *)&mBodyClsnFlags) &= ~0x10;
 
     if (data_0209fc68 == 0) {
         if (data_0209fc48 != 0)
@@ -137,118 +125,118 @@ extern "C" int _ZN6Player8BehaviorEv(char *c)
             goto after_player_slot;
         }
     }
-    data_020a0e40 = *(u8 *)(c + 0x6d8);
+    data_020a0e40 = mPlayerNo;
 after_player_slot:
 
-    if (func_ov002_020c4188(c) != 0)
+    if (func_ov002_020c4188(((char *)this)) != 0)
         return 1;
 
-    DecIfAbove0_Short((u16 *)(c + 0x6a4));
-    DecIfAbove0_Short((u16 *)(c + 0x6a6));
-    DecIfAbove0_Short((u16 *)(c + 0x6a0));
-    DecIfAbove0_Short((u16 *)(c + 0x6a8));
-    DecIfAbove0_Short((u16 *)(c + 0x6aa));
-    DecIfAbove0_Short((u16 *)(c + 0x6ac));
-    DecIfAbove0_Short((u16 *)(c + 0x6b0));
-    DecIfAbove0_Short((u16 *)(c + 0x6b2));
-    DecIfAbove0_Short((u16 *)(c + 0x6b4));
-    DecIfAbove0_Short((u16 *)(c + 0x6b6));
-    DecIfAbove0_Short((u16 *)(c + 0x6b8));
-    DecIfAbove0_Short((u16 *)(c + 0x6ba));
-    DecIfAbove0_Short((u16 *)(c + 0x6bc));
-    DecIfAbove0_Short((u16 *)(c + 0x6c4));
-    DecIfAbove0_Short((u16 *)(c + 0x6c8));
+    DecIfAbove0_Short((u16 *)((char *)&mStateTimer));
+    DecIfAbove0_Short((u16 *)((char *)&mStateWaitTimer));
+    DecIfAbove0_Short((u16 *)((char *)&mInvincibleTimer));
+    DecIfAbove0_Short((u16 *)((char *)&mJumpComboTimer));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6aa));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6ac));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6b0));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6b2));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6b4));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6b6));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6b8));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6ba));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6bc));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6c4));
+    DecIfAbove0_Short((u16 *)((char *)&unk_6c8));
 
-    if (*(u16 *)(c + 0x6c8) == 1)
+    if (unk_6c8 == 1)
         data_0209f284 = 0;
 
-    if (*(u8 *)(c + 0x6f6) == 0) {
-        DecIfAbove0_Short((u16 *)(c + 0x6c0));
-        if (DecIfAbove0_Short((u16 *)(c + 0x6be)) == 0)
-            func_ov002_020d80d0(c);
-        if (DecIfAbove0_Short((u16 *)(c + 0x6ae)) == 0) {
-            func_ov002_020e032c(c);
-            func_ov002_020bdef0(c);
-            func_ov002_020bdd9c(c);
+    if (mIsControlDisabled == 0) {
+        DecIfAbove0_Short((u16 *)((char *)&unk_6c0));
+        if (DecIfAbove0_Short((u16 *)((char *)&unk_6be)) == 0)
+            func_ov002_020d80d0(((char *)this));
+        if (DecIfAbove0_Short((u16 *)((char *)&unk_6ae)) == 0) {
+            func_ov002_020e032c(((char *)this));
+            func_ov002_020bdef0(((char *)this));
+            func_ov002_020bdd9c(((char *)this));
         }
-        if (DecIfAbove0_Short((u16 *)(c + 0x6c2)) == 0)
-            func_ov002_020bdd2c(c);
+        if (DecIfAbove0_Short((u16 *)((char *)&unk_6c2)) == 0)
+            func_ov002_020bdd2c(((char *)this));
 
-        if (*(u16 *)(c + 0x6a2) != *(s8 *)(c + 0xcc)) {
-            *(u16 *)(c + 0x6a2) = *(s8 *)(c + 0xcc);
-            *(u16 *)(c + 0x6c6) = 0;
+        if (unk_6a2 != mAreaId) {
+            unk_6a2 = mAreaId;
+            unk_6c6 = 0;
         }
-        if (DecIfAbove0_Short((u16 *)(c + 0x6c6)) == 0 && *(s32 *)(c + 0x360) != 0)
-            func_ov002_020d6790(c);
+        if (DecIfAbove0_Short((u16 *)((char *)&unk_6c6)) == 0 && mObjInMouth != 0)
+            func_ov002_020d6790(((char *)this));
     }
 
     {
-        s16 ang = *(s16 *)(c + 0x6d2);
+        s16 ang = mDesiredAngleY;
         s32 stride = 0x18;
-        *(s16 *)(c + 0x6d4) = ang;
-        *(s16 *)(c + 0x6d2) = *(s16 *)((char *)&data_0209f4a6 + data_020a0e40 * stride);
+        unk_6d4 = ang;
+        mDesiredAngleY = *(s16 *)((char *)&data_0209f4a6 + data_020a0e40 * stride);
         if (data_0209fc68 == 0) {
             s16 add = GetAngleToCamera(0);
-            s16 *p = (s16 *)LAU(c + 0x6d2);
+            s16 *p = (s16 *)LAU((char *)&mDesiredAngleY);
             *p = (s16)(*p + add);
         } else {
-            s16 add = GetAngleToCamera(*(u8 *)(c + 0x6d8));
-            s16 *p = (s16 *)LAU(c + 0x6d2);
+            s16 add = GetAngleToCamera(mPlayerNo);
+            s16 *p = (s16 *)LAU((char *)&mDesiredAngleY);
             *p = (s16)(*p + add);
         }
     }
 
-    func_ov002_020c2e78(c);
-    func_ov002_020ca940(c);
-    func_ov002_020d8158(c);
+    func_ov002_020c2e78(((char *)this));
+    func_ov002_020ca940(((char *)this));
+    func_ov002_020d8158(((char *)this));
 
     {
-        State *st = *(State **)(c + 0x370);
+        State *st = *(State **)((char *)&unk_370);
         if (*(void **)&st->main != 0)
-            (((C3 *)c)->*(st->main))();
+            (((C3 *)((char *)this))->*(st->main))();
     }
 
-    if ((u16)(*(u16 *)(c + 0x6ce) & 0x80) != 0) {
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021104fc);
-        *(u16 *)LAU(c + 0x6ce) &= ~0x80;
+    if ((u16)(mStateFlags & 0x80) != 0) {
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_021104fc);
+        *(u16 *)LAU((char *)&mStateFlags) &= ~0x80;
     }
 
-    if (*(u8 *)(c + 0x709) != 0)
+    if (mIsNoControl != 0)
         fallFlag = 1;
     else
         fallFlag = 0;
     if (data_0209f2f8 == 0x1f
-        && _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021104b4) != 0)
+        && _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_021104b4) != 0)
         fallFlag = 0;
 
-    if (*(u8 *)(c + 0x6de) == 0 || fallFlag != 0 || *(s32 *)(c + 0x684) < *(s32 *)(c + 0x60))
-        *(s32 *)(c + 0x684) = *(s32 *)(c + 0x60);
+    if (mIsAirborne == 0 || fallFlag != 0 || mPeakY < mPosY)
+        mPeakY = mPosY;
 
-    if (*(u8 *)(c + 0x6de) == 0 && *(u8 *)(c + 0x70d) != 0) {
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x2e, (const Vector3 *)(c + 0x74));
-        *(u8 *)(c + 0x70d) = 0;
+    if (mIsAirborne == 0 && mIsFallScreaming != 0) {
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, (const Vector3 *)((char *)&mCamSpacePos));
+        mIsFallScreaming = 0;
     }
-    if (*(u8 *)(c + 0x6de) != 0 && *(u8 *)(c + 0x70d) == 0
-        && _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110454) == 0
-        && (*(s32 *)(c + 0x684) - *(s32 *)(c + 0x60)) > 0x47e000) {
-        *(u8 *)(c + 0x70d) = 1;
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(u8 *)(c + 0x6d9), 0x1d, (const Vector3 *)(c + 0x74));
+    if (mIsAirborne != 0 && mIsFallScreaming == 0
+        && _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110454) == 0
+        && (mPeakY - mPosY) > 0x47e000) {
+        mIsFallScreaming = 1;
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x1d, (const Vector3 *)((char *)&mCamSpacePos));
     }
 
-    if (*(u8 *)(c + 0x707) != 0 && *(u8 *)(c + 0x706) == 0 && *(u8 *)(c + 0x6de) == 0)
-        func_ov002_020ce8bc(c, *(s32 *)(c + 0x98));
+    if (mIsInShallowWater != 0 && mIsUnderwater == 0 && mIsAirborne == 0)
+        func_ov002_020ce8bc(((char *)this), mHorzSpeed);
 
-    *(s16 *)(c + 0x6d6) = *(s16 *)(c + 0x8e);
-    *(u16 *)LAU(c + 0x6ce) &= ~0x440;
+    unk_6d6 = mAngleY;
+    *(u16 *)LAU((char *)&mStateFlags) &= ~0x440;
 
-    if (*(u8 *)(c + 0x6ff) != 0)
-        _ZN9Animation7AdvanceEv(c + 0x1c4);
+    if (mHasWings != 0)
+        _ZN9Animation7AdvanceEv((char *)&mAnimation2);
 
-    *(s32 *)(c + 0x548) = *(s32 *)(c + 0x5c);
-    *(s32 *)(c + 0x54c) = *(s32 *)(c + 0x60);
-    *(s32 *)(c + 0x550) = *(s32 *)(c + 0x64);
-    func_ov002_020bf36c(c, c + 0x2d4);
-    func_ov002_020bf13c(c);
+    unk_548 = mPosX;
+    unk_54c = mPosY;
+    unk_550 = mPosZ;
+    func_ov002_020bf36c(((char *)this), ((char *)this) + 0x2d4);
+    func_ov002_020bf13c(((char *)this));
 
     {
         s32 *p = (s32 *)LAU((int)&v0);
@@ -258,15 +246,15 @@ after_player_slot:
         {
             State *st = &data_ov002_0210ffec;
             p[2] = z;
-            if (_ZN6Player7IsStateERNS_5StateE(c, st) != 0) {
-                if (*(u8 *)(c + 0x703) != 0) {
+            if (_ZN6Player7IsStateERNS_5StateE(((char *)this), st) != 0) {
+                if (mIsMega != 0) {
                     s32 t = 0x12c000;
                     v0.y = -t;
                 } else {
                     s32 t = 0x64000;
                     v0.y = -t;
                 }
-            } else if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021106f4) != 0) {
+            } else if (_ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_021106f4) != 0) {
                 v0.y = 0x64000;
             }
         }
@@ -274,48 +262,48 @@ after_player_slot:
     v1.x = v0.x;
     v1.y = v0.y;
     v1.z = v0.z;
-    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x2d4, &v1);
-    func_ov002_020c2db8(c);
+    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char *)this) + 0x2d4, &v1);
+    func_ov002_020c2db8(((char *)this));
 
-    if (*(u8 *)(c + 0x707) != 0)
-        *(s32 *)(c + 0x66c) = 3;
+    if (mIsInShallowWater != 0)
+        mGroundSoundType = 3;
 
     if (data_0209ee90.flag26c != 0) {
         data_0209ee90.flag26c = 0;
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021101b4);
-        *(u8 *)(c + 0x6e3) = 0;
-        _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_0210ffec);
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_021101b4);
+        mStateStep = 0;
+        _ZN6Player11ChangeStateERNS_5StateE(((char *)this), &data_ov002_0210ffec);
     }
 
-    func_ov002_020db704(c);
-    func_ov002_020d869c(c);
+    func_ov002_020db704(((char *)this));
+    func_ov002_020d869c(((char *)this));
 
     {
-        u16 t = *(u16 *)(c + 0x6a0);
+        u16 t = mInvincibleTimer;
         if (t != 0) {
             if (t == 1)
-                *(u32 *)LAU(c + 0x2f0) |= 0x10000000;
+                *(u32 *)LAU((char *)&unk_2f0) |= 0x10000000;
             else
-                *(u32 *)LAU(c + 0x2f0) &= ~0x10000000;
+                *(u32 *)LAU((char *)&unk_2f0) &= ~0x10000000;
         }
     }
 
-    _ZN12CylinderClsn5ClearEv(c + 0x2d4);
-    if (*(u8 *)(c + 0x713) != 0)
-        _ZN12CylinderClsn6UpdateEv(c + 0x2d4);
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);
+    if (mIsBodyClsnEnabled != 0)
+        _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsnWithPos);
 
     if (data_0209fc68 == 0)
         data_020a0e40 = 0;
     else
         data_020a0e40 = data_0209f250;
 
-    func_ov002_020e4bb8(c);
+    func_ov002_020e4bb8(((char *)this));
 
     {
-        s32 r2 = *(s32 *)(c + 0x654);
+        s32 r2 = unk_654;
         if (r2 != 0) {
-            u8 ch = *(u8 *)(c + 0x714);
-            char *t4 = (char *)(*(int *)(*(int *)(c + ((ch << 2) + 3) * 4 + 0x154) + 0x14) + 0x90);
+            u8 ch = mUseAltBodyModel;
+            char *t4 = (char *)(*(int *)(*(int *)(((char *)this) + ((ch << 2) + 3) * 4 + 0x154) + 0x14) + 0x90);
             if (r2 < 0)
                 r2 = -r2;
             *(s32 *)(t4 + 0x2c) = r2 >> 3;
@@ -323,8 +311,8 @@ after_player_slot:
     }
 
     data_0209f254 = 0;
-    if (*(s32 *)(c + 8) == 3) {
-        void *p = *(void **)(*(void **)(c + 0x588));
+    if (mParam == 3) {
+        void *p = *(void **)(*(void **)((char *)&mHeldObjQueue));
         if (p != 0)
             data_0209f254 = *(u8 *)((char *)p + 0x428);
     }

--- a/src/_ZN6Player8BlowAwayEs.cpp
+++ b/src/_ZN6Player8BlowAwayEs.cpp
@@ -1,12 +1,18 @@
 //cpp
+// @symbol _ZN6Player8BlowAwayEs
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
-extern int data_ov002_0211037c[];
 extern void _ZN6Player11ChangeStateERNS_5StateE(void*,void*);
-void _ZN6Player8BlowAwayEs(char* c, short v){
-  if(*(unsigned char*)(c+0x6f9)) return;
-  if(*(unsigned char*)(c+0x6fd)) return;
-  *(short*)(c+0x94)=v;
-  *(short*)(c+0x8e)=(short)(v+0x8000);
-  _ZN6Player11ChangeStateERNS_5StateE(c,data_ov002_0211037c);
 }
+
+void Player::BlowAway(short v)
+{
+  if(mIsMetal) return;
+  if(mIsBalloon) return;
+  mTargetAngleY=v;
+  mAngleY=(short)(v+0x8000);
+  _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211037c);
 }

--- a/src/_ZN6Player8CanPauseEv.cpp
+++ b/src/_ZN6Player8CanPauseEv.cpp
@@ -1,22 +1,27 @@
 //cpp
+// @symbol _ZN6Player8CanPauseEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 struct State;
 extern State data_ov002_0211067c;
 extern State data_ov002_021106ac;
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, State* st);
-int _ZN6Player8CanPauseEv(void* c){
-  if(*(unsigned char*)((char*)c+0x706)){
-    if(_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211067c)) goto ret1a;
-    if(_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021106ac)) goto ret1a;
+}
+
+int Player::CanPause()
+{
+  if(*(unsigned char*)((char*)&mIsUnderwater)){
+    if(_ZN6Player7IsStateERNS_5StateE(((void*)this), &data_ov002_0211067c)) goto ret1a;
+    if(_ZN6Player7IsStateERNS_5StateE(((void*)this), &data_ov002_021106ac)) goto ret1a;
     goto ret0;
 ret1a:
     return 1;
   }
-  if(*(unsigned char*)((char*)c+0x6de)) goto ret0;
-  if(*(unsigned char*)((char*)c+0x708)) goto ret0;
-  if(*(unsigned char*)((char*)c+0x709)) goto ret0;
+  if(*(unsigned char*)((char*)&mIsAirborne)) goto ret0;
+  if(*(unsigned char*)((char*)&mIsTakingDamage)) goto ret0;
+  if(*(unsigned char*)((char*)&mIsNoControl)) goto ret0;
   return 1;
 ret0:
   return 0;
-}
 }

--- a/src/_ZN6Player8HasNoCapEv.cpp
+++ b/src/_ZN6Player8HasNoCapEv.cpp
@@ -1,23 +1,29 @@
 //cpp
+// @symbol _ZN6Player8HasNoCapEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f2d8;
-extern int data_ov002_0211058c;
 int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 int _ZN8SaveData16HasPlayerLostCapEv(void);
-int _ZN6Player8HasNoCapEv(char* c){
+}
+
+int Player::HasNoCap()
+{
     if(data_0209f2f8 == 0x1f) return 0;
     int r = (data_0209f2d8 == 2);
     if(!r){
-        if(!_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_0211058c)){
+        if(!_ZN6Player7IsStateERNS_5StateE(((char*)this), &data_ov002_0211058c)){
             r = (data_0209f2d8 == 1);
             if(!r){
                 if(_ZN8SaveData16HasPlayerLostCapEv()) return 1;
             }
         }
     }
-    if(*(int*)(c+8) == 3) return 0;
-    r = *(unsigned char*)(c+0x71a) != 0;
+    if(mParam == 3) return 0;
+    r = unk_71a != 0;
     return r;
-}
 }

--- a/src/_ZN6Player8IsDivingEv.cpp
+++ b/src/_ZN6Player8IsDivingEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN6Player8IsDivingEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 extern "C" {
 extern int data_ov002_021105bc[];
 int _ZN6Player7IsStateERNS_5StateE(void*, void*);
-int _ZN6Player8IsDivingEv(void* c){
-  return _ZN6Player7IsStateERNS_5StateE(c, data_ov002_021105bc) != 0;
 }
+
+int Player::IsDiving()
+{
+  return _ZN6Player7IsStateERNS_5StateE(((void*)this), data_ov002_021105bc) != 0;
 }

--- a/src/_ZN6Player9DropActorEv.cpp
+++ b/src/_ZN6Player9DropActorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Player9DropActorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
 typedef unsigned int u32;
 typedef unsigned long long u64;
 struct State;
@@ -12,8 +15,9 @@ extern State data_ov002_0211013c;
 extern State data_ov002_021105d4;
 extern State data_ov002_02110034;
 
-extern "C" int _ZN6Player9DropActorEv(char* thiz){
-    u32* s = *(u32**)(thiz + 0x358);
+int Player::DropActor()
+{
+    u32* s = *(u32**)((char*)&mHeldObj);
     int present = (s != 0);
     if (present) {
         int held = ((s[0x2c] & 0x200) != 0);
@@ -21,45 +25,45 @@ extern "C" int _ZN6Player9DropActorEv(char* thiz){
             u32* s_ptr1 = (u32*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *s_ptr1 &= ~0x4000u;
 
-            u32* s_ptr2 = *(u32**)(thiz + 0x358);
+            u32* s_ptr2 = *(u32**)((char*)&mHeldObj);
             u32* field_ptr2 = (u32*)(((int)s_ptr2 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *field_ptr2 &= ~0x100u;
 
-            u32* s_ptr3 = *(u32**)(thiz + 0x358);
+            u32* s_ptr3 = *(u32**)((char*)&mHeldObj);
             u32* field_ptr3 = (u32*)(((int)s_ptr3 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *field_ptr3 &= ~0x400u;
 
-            u32* s_ptr4 = *(u32**)(thiz + 0x358);
+            u32* s_ptr4 = *(u32**)((char*)&mHeldObj);
             u32* field_ptr4 = (u32*)(((int)s_ptr4 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *field_ptr4 &= ~0x2000u;
 
-            u32* s_ptr5 = *(u32**)(thiz + 0x358);
+            u32* s_ptr5 = *(u32**)((char*)&mHeldObj);
             u32* field_ptr5 = (u32*)(((int)s_ptr5 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *field_ptr5 &= ~0x800u;
 
-            u32* s_ptr6 = *(u32**)(thiz + 0x358);
+            u32* s_ptr6 = *(u32**)((char*)&mHeldObj);
             u32* field_ptr6 = (u32*)(((int)s_ptr6 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
             *field_ptr6 &= ~0x1000u;
 
-            *(u32**)(thiz + 0x358) = 0;
+            *(u32**)((char*)&mHeldObj) = 0;
 
-            if (_ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110364) ||
-                _ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110394) ||
-                _ZN6Player7IsStateERNS_5StateE((Player*)thiz, &data_ov002_02110604))
+            if (_ZN6Player7IsStateERNS_5StateE((Player*)((char*)this), &data_ov002_02110364) ||
+                _ZN6Player7IsStateERNS_5StateE((Player*)((char*)this), &data_ov002_02110394) ||
+                _ZN6Player7IsStateERNS_5StateE((Player*)((char*)this), &data_ov002_02110604))
             {
-                _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_0211013c);
+                _ZN6Player11ChangeStateERNS_5StateE((Player*)((char*)this), &data_ov002_0211013c);
             }
         } else {
-            _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_021105d4);
+            _ZN6Player11ChangeStateERNS_5StateE((Player*)((char*)this), &data_ov002_021105d4);
         }
         return 1;
     }
     {
-        int b = (*(int*)(thiz + 0x360) != 0);
+        int b = (mObjInMouth != 0);
         if (!b) {
             return 0;
         }
-        _ZN6Player11ChangeStateERNS_5StateE((Player*)thiz, &data_ov002_02110034);
+        _ZN6Player11ChangeStateERNS_5StateE((Player*)((char*)this), &data_ov002_02110034);
         return 1;
     }
 }

--- a/src/_ZN6Player9GetHealthEv.cpp
+++ b/src/_ZN6Player9GetHealthEv.cpp
@@ -1,6 +1,12 @@
 //cpp
-extern short data_02092144[];
-extern "C" int _ZN6Player9GetHealthEv(char* c){
-  unsigned char i = *(unsigned char*)(c+0x6d8);
+// @symbol _ZN6Player9GetHealthEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Player.h"
+
+int Player::GetHealth()
+{
+  unsigned char i = mPlayerNo;
   return (signed char)(data_02092144[i] >> 8);
 }

--- a/src/_ZN6PlayerC1Ev.cpp
+++ b/src/_ZN6PlayerC1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6PlayerC1Ev
+/* recovered: named members + shared header */
+#include "Player.h"
 extern "C" {
 extern int data_ov002_0210a83c[];
 void _ZN5ActorC2Ev(void*);

--- a/src/_ZN6PlayerD0Ev.cpp
+++ b/src/_ZN6PlayerD0Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6PlayerD0Ev
+/* recovered: named members + shared header */
+#include "Player.h"
 extern "C" {
 extern int _ZN12WithMeshClsnD1Ev(void*);
 extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
@@ -11,19 +14,19 @@ extern void _ZN15TextureSequenceD1Ev(void);
 extern void _ZN15MaterialChangerD1Ev(void);
 extern void* data_ov002_0210a83c[];
 extern void* data_020a0eac;
-void* _ZN6PlayerD0Ev(void* c) {
-  *(void***)c = data_ov002_0210a83c;
-  _ZN12WithMeshClsnD1Ev((char*)c+0x380);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x314);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x2d4);
-  _ZN11ShadowModelD1Ev((char*)c+0x2ac);
-  func_0207328c((char*)c+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  func_0207328c((char*)c+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
-  func_0207328c((char*)c+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  _ZN9ModelAnimD1Ev((char*)c+0x174);
-  _ZN9ModelAnimD1Ev((char*)c+0xf0);
-  _ZN5ActorD2Ev(c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, *(void**)&data_020a0eac);
-  return c;
+void* _ZN6PlayerD0Ev(struct Player *self) {
+  *(void***)((void*)self) = data_ov002_0210a83c;
+  _ZN12WithMeshClsnD1Ev((char*)&self->mMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mAttackClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  func_0207328c((char*)((void*)self)+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  func_0207328c((char*)((void*)self)+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
+  func_0207328c((char*)((void*)self)+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim4);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim3);
+  _ZN5ActorD2Ev(((void*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((void*)self), *(void**)&data_020a0eac);
+  return ((void*)self);
 }
 }

--- a/src/_ZN6PlayerD2Ev.cpp
+++ b/src/_ZN6PlayerD2Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6PlayerD2Ev
+/* recovered: named members + shared header */
+#include "Player.h"
 extern "C" {
 extern int _ZN12WithMeshClsnD1Ev(void*);
 extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
@@ -9,18 +12,18 @@ extern int _ZN5ActorD2Ev(void*);
 extern void _ZN15TextureSequenceD1Ev(void);
 extern void _ZN15MaterialChangerD1Ev(void);
 extern void* data_ov002_0210a83c[];
-void* _ZN6PlayerD2Ev(void* c) {
-  *(void***)c = data_ov002_0210a83c;
-  _ZN12WithMeshClsnD1Ev((char*)c+0x380);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x314);
-  _ZN25MovingCylinderClsnWithPosD1Ev((char*)c+0x2d4);
-  _ZN11ShadowModelD1Ev((char*)c+0x2ac);
-  func_0207328c((char*)c+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  func_0207328c((char*)c+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
-  func_0207328c((char*)c+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  _ZN9ModelAnimD1Ev((char*)c+0x174);
-  _ZN9ModelAnimD1Ev((char*)c+0xf0);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN6PlayerD2Ev(struct Player *self) {
+  *(void***)((void*)self) = data_ov002_0210a83c;
+  _ZN12WithMeshClsnD1Ev((char*)&self->mMeshClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mAttackClsn);
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel);
+  func_0207328c((char*)((void*)self)+0x254, 2, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  func_0207328c((char*)((void*)self)+0x22c, 2, 0x14, (void*)_ZN15MaterialChangerD1Ev);
+  func_0207328c((char*)((void*)self)+0x1dc, 4, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim4);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim3);
+  _ZN5ActorD2Ev(((void*)self));
+  return ((void*)self);
 }
 }

--- a/src/_ZN6Rabbit6RenderEv.cpp
+++ b/src/_ZN6Rabbit6RenderEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN6Rabbit6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Rabbit.h"
 extern "C" {
 extern signed char data_0209f2f8;
 extern signed char data_02092120;
-extern void func_ov085_0212c150(void* self);
 }
 
 struct VObj {
@@ -14,33 +18,33 @@ struct VObj {
     virtual void m14(void* arg);
 };
 
-extern "C" int _ZN6Rabbit6RenderEv(char* c)
+int Rabbit::Render()
 {
-    if (*(unsigned char*)(c + 0x428) == 1) return 1;
+    if (unk_428 == 1) return 1;
 
     {
-        int b = (*(int*)(c + 0xb0) & 0x40000) != 0;
+        int b = (unk_0b0 & 0x40000) != 0;
         if (b) return 1;
     }
 
-    *(int*)(c + 0x80) = 0x1500;
-    *(int*)(c + 0x88) = *(int*)(c + 0x80);
-    *(int*)(c + 0x84) = *(int*)(c + 0x88);
+    mScale = 0x1500;
+    unk_088 = mScale;
+    unk_084 = unk_088;
 
     {
-        int** base = (int**)(((long long)(int)(c + 0x308)) & 0xFFFFFFFFFFFFFFFFLL);
+        int** base = (int**)(((long long)(int)((char*)&unk_308)));
         int* r3 = base[0];
         char* r1 = (char*)base[1];
         for (unsigned int i = 0; i < *(unsigned int*)((char*)r3 + 0x24); i++) {
-            *(int*)(r1 + 0x20) = *(int*)(c + 0x468);
+            *(int*)(r1 + 0x20) = unk_468;
             r1 += 0x30;
         }
     }
 
     if (data_0209f2f8 == 5 && data_02092120 == 3) {
-        func_ov085_0212c150(c);
+        func_ov085_0212c150(((char*)this));
     }
 
-    ((VObj*)(c + 0x300))->m14(c + 0x80);
+    ((VObj*)((char*)&mModelAnim))->m14((char*)&mScale);
     return 1;
 }

--- a/src/_ZN6RabbitD0Ev.c
+++ b/src/_ZN6RabbitD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6RabbitD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daMip_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6RabbitD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daMip_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3c0);
     _ZN11ShadowModelD1Ev((char *)t + 0x368);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN6RabbitD1Ev.c
+++ b/src/_ZN6RabbitD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6RabbitD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Rabbit */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6RabbitD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6Rabbit;
     _ZN11ShadowModelD1Ev((char *)t + 0x3c0);
     _ZN11ShadowModelD1Ev((char *)t + 0x368);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);

--- a/src/_ZN6ShipUp16CleanupResourcesEv.cpp
+++ b/src/_ZN6ShipUp16CleanupResourcesEv.cpp
@@ -1,15 +1,18 @@
 //cpp
+// @symbol _ZN6ShipUp16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShipUp.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
-extern void* data_ov016_021136e4[];
-extern void* data_ov016_021136dc[];
-int _ZN6ShipUp16CleanupResourcesEv(char* c){
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136e4[*(unsigned char*)(c+0x31e)]);
-  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136dc[*(unsigned char*)(c+0x31e)]);
-  return 1;
 }
+
+int ShipUp::CleanupResources()
+{
+  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
+    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136e4[mModelIndex]);
+  _ZN13SharedFilePtr7ReleaseEv(data_ov016_021136dc[mModelIndex]);
+  return 1;
 }

--- a/src/_ZN6ShipUp6RenderEv.cpp
+++ b/src/_ZN6ShipUp6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6ShipUp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ShipUp.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN6ShipUp6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int ShipUp::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6ShipUpD0Ev.c
+++ b/src/_ZN6ShipUpD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN6ShipUpD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjKi_Fune_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN6ShipUpD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjKi_Fune_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6ShipUpD1Ev.c
+++ b/src/_ZN6ShipUpD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN6ShipUpD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjKi_Fune_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN6ShipUpD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjKi_Fune_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN6Snufit6RenderEv.cpp
+++ b/src/_ZN6Snufit6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Snufit6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Snufit.h"
 struct Obj {
     virtual void m0();
     virtual void m1();
@@ -7,10 +10,12 @@ struct Obj {
     virtual void m4();
     virtual void Target(int);
 };
-extern "C" int _ZN6Snufit6RenderEv(char *c) {
-    int b = ((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
+
+int Snufit::Render()
+{
+    int b = ((unk_0b0 & 0x40000) != 0);
     if (b) return 1;
-    Obj *o = (Obj*)(c+0x300);
+    Obj *o = (Obj*)((char *)&mModelAnim);
     o->Target(0);
     return 1;
 }

--- a/src/_ZN6Snufit8BehaviorEv.cpp
+++ b/src/_ZN6Snufit8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN6Snufit8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Snufit.h"
 struct WithMeshClsn;
 struct ModelAnim;
 struct Enemy;
@@ -9,7 +14,6 @@ extern "C" {
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);
-extern void func_ov065_0211696c(char *c);
 extern int func_ov065_0211691c(void *c, void *p);
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(Enemy *thiz, WithMeshClsn *wm, ModelAnim *ma, unsigned int j);
 extern int ApproachAngle(short *target, short from, short start, short speed, short max);
@@ -18,13 +22,10 @@ extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _Z14ApproachLinearRiii(int *x, int target, int step);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(Enemy *thiz, void *clsn);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *wm, unsigned int j);
-extern void func_ov065_02115ff0(char *c);
 extern char *_ZN5Actor13ClosestPlayerEv(Enemy *thiz);
 extern void _ZN9Animation7AdvanceEv(void *thiz);
 
 extern short data_02082214[];
-extern char data_ov065_0211d650[];
-extern char data_ov065_0211d660[];
 extern int data_ov065_0211d670[];
 }
 
@@ -35,10 +36,10 @@ struct ActorOv065 {
     int ang;
 };
 
-extern "C" int _ZN6Snufit8BehaviorEv(Enemy *thiz)
+int Snufit::Behavior()
 {
-    char *c = (char *)thiz;
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144)) != 0) {
+    char *c = (char *)((Enemy *)this);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144)) != 0) {
         _ZN12CylinderClsn5ClearEv(c + 0x110);
         if (*(unsigned char *)(c + 0x107) != 0) {
             if (*(unsigned short *)(c + 0x104) == 0) {
@@ -52,12 +53,12 @@ extern "C" int _ZN6Snufit8BehaviorEv(Enemy *thiz)
         func_ov065_0211691c(c, data_ov065_0211d670);
         return 1;
     }
-    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(thiz, (WithMeshClsn *)(c + 0x144), (ModelAnim *)(c + 0x300), 3) != 0) {
+    if (_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), (ModelAnim *)(c + 0x300), 3) != 0) {
         return 1;
     }
     if (*(int *)(c + 0x10c) != 0) {
         ApproachAngle((short *)(c + 0x8c), -0x4000, 0xa, 0x200, 0x100);
-        _ZN5Enemy11UpdateDeathER12WithMeshClsn(thiz, (WithMeshClsn *)(c + 0x144));
+        _ZN5Enemy11UpdateDeathER12WithMeshClsn(((Enemy *)this), (WithMeshClsn *)(c + 0x144));
         func_ov065_0211696c(c);
         return 1;
     }
@@ -65,7 +66,7 @@ extern "C" int _ZN6Snufit8BehaviorEv(Enemy *thiz)
     {
         Holder *q = *(Holder **)(c + 0x3bc);
         if (q->fn != 0) {
-            (thiz->*(q->fn))();
+            (((Enemy *)this)->*(q->fn))();
         }
     }
     {
@@ -92,8 +93,8 @@ extern "C" int _ZN6Snufit8BehaviorEv(Enemy *thiz)
         result = (int)(((long long)tbl * 0x46000 + 0x800) >> 12);
         _Z14ApproachLinearRiii((int *)(void *)(c + 0x60), *(int *)(c + 0x3d0) + (result + 0xb4000), 0x3000);
     }
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(thiz, (void *)(c + 0x110));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(thiz, (WithMeshClsn *)(c + 0x144), 0);
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((Enemy *)this), (void *)(c + 0x110));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((Enemy *)this), (WithMeshClsn *)(c + 0x144), 0);
     func_ov065_0211696c(c);
     if (*(char **)(c + 0x3bc) != data_ov065_0211d660) {
         *(short *)(c + 0x8c) = *(short *)(c + 0x92);
@@ -103,7 +104,7 @@ extern "C" int _ZN6Snufit8BehaviorEv(Enemy *thiz)
     }
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {
-        char *p = _ZN5Actor13ClosestPlayerEv(thiz);
+        char *p = _ZN5Actor13ClosestPlayerEv(((Enemy *)this));
         if (p != 0 && *(unsigned char *)(p + 0x6fb) == 0) {
             _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }

--- a/src/_ZN6SnufitD0Ev.c
+++ b/src/_ZN6SnufitD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6SnufitD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daYurei_Mucho_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN6SnufitD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daYurei_Mucho_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6SnufitD1Ev.c
+++ b/src/_ZN6SnufitD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN6SnufitD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV6Snufit */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN6SnufitD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV6Snufit;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN6Thwomp6RenderEv.cpp
+++ b/src/_ZN6Thwomp6RenderEv.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol _ZN6Thwomp6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Thwomp.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
-extern "C" {
-int _ZN6Thwomp6RenderEv(char* c){
-  int check = *(int*)(*(int*)(c+0x320)+0xc);
+
+int Thwomp::Render()
+{
+  int check = *(int*)(mFileTable+0xc);
   if (check != 0)
-    _ZN15TextureSequence6UpdateER15ModelComponents(c+0x324, c+0xdc);
-  ((Sub*)(c+0xd4))->g5(0);
+    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x324, ((char*)this)+0xdc);
+  ((Sub*)((char*)&mModel))->g5(0);
   return 1;
-}
 }

--- a/src/_ZN6Thwomp8BehaviorEv.cpp
+++ b/src/_ZN6Thwomp8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6Thwomp8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "Thwomp.h"
 extern "C" {
 void func_ov091_02133020(char *c);
 void func_ov091_02132ff4(char *c);
@@ -12,84 +15,84 @@ int _ZN9Animation8FinishedEv(void *self);
 void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
+}
 
-int _ZN6Thwomp8BehaviorEv(char *c)
+int Thwomp::Behavior()
 {
-    if (*(int *)(c + 0x398) < 2) {
-        if (*(unsigned char *)(c + 0x3a2) != 0)
-            *(int *)(c + 0x398) = 2;
+    if (mState < 2) {
+        if (mTriggered != 0)
+            mState = 2;
     }
-    switch (*(int *)(c + 0x398)) {
+    switch (mState) {
     case 0: {
-        unsigned short cnt = (unsigned short)(*(int *)(c + 0x32c) >> 12);
+        unsigned short cnt = (unsigned short)(unk_32c >> 12);
         if (cnt != 0) {
-            *(int *)(c + 0x32c) = (int)((((unsigned)cnt - 1) << 16) >> 4);
-            cnt = (unsigned short)(*(int *)(c + 0x32c) >> 12);
+            unk_32c = (int)((((unsigned)cnt - 1) << 16) >> 4);
+            cnt = (unsigned short)(unk_32c >> 12);
             if (cnt == 0) {
-                char *p = c + 0x300;
+                char *p = ((char *)this) + 0x300;
                 *(unsigned short *)(p + 0xa0) = 0xa;
             }
         } else {
-            char *p = (char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+            char *p = (char *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
             int t = *(unsigned short *)(p + 0xa0);
             if (t != 0) {
-                unsigned short *q = (unsigned short *)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
                 *q = *q - 1;
             } else {
-                func_ov091_02133020(c);
+                func_ov091_02133020(((char *)this));
             }
         }
         break;
     }
     case 1:
-        func_ov091_02132ff4(c);
+        func_ov091_02132ff4(((char *)this));
         break;
     case 2:
-        if (*(unsigned char *)(c + 0x3a2) != 0) {
-            *(int *)(c + 0x32c) = 0;
-            func_ov091_02132f04(c);
+        if (mTriggered != 0) {
+            unk_32c = 0;
+            func_ov091_02132f04(((char *)this));
         } else {
-            _ZN9Animation7AdvanceEv(c + 0x324);
-            if (_ZN9Animation8FinishedEv(c + 0x324) != 0) {
-                char *p = (char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+            _ZN9Animation7AdvanceEv((char *)&mTextureSequence);
+            if (_ZN9Animation8FinishedEv((char *)&mTextureSequence) != 0) {
+                char *p = (char *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
                 int t = *(unsigned short *)(p + 0xa0);
                 if (t != 0) {
-                    unsigned short *q = (unsigned short *)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                    unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
                     *q = *q - 1;
                 } else {
-                    func_ov091_02132f04(c);
+                    func_ov091_02132f04(((char *)this));
                 }
             } else {
-                char *p = c + 0x300;
+                char *p = ((char *)this) + 0x300;
                 *(unsigned short *)(p + 0xa0) = 5;
             }
         }
         break;
     case 3:
-        func_ov091_02132e98(c);
-        if (*(int *)(c + 0x398) == 4) {
-            if (*(unsigned char *)(c + 0x3a2) != 0) {
-                *(unsigned char *)(c + 0x39e) = 0x5a;
-                *(unsigned char *)(c + 0x3a2) = 0;
+        func_ov091_02132e98(((char *)this));
+        if (mState == 4) {
+            if (mTriggered != 0) {
+                unk_39e = 0x5a;
+                mTriggered = 0;
             }
         }
         break;
     case 4:
-        if (*(unsigned char *)(c + 0x3a2) != 0) {
-            *(unsigned char *)(c + 0x3a2) = 0;
-            *(unsigned char *)(c + 0x39e) = 0x5a;
+        if (mTriggered != 0) {
+            mTriggered = 0;
+            unk_39e = 0x5a;
         }
-        func_ov091_02132e64(c);
+        func_ov091_02132e64(((char *)this));
         break;
     }
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    func_ov091_02133098(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0) == 0) {
-        if (func_ov091_02132dc0(c) == 0)
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char *)this));
+    func_ov091_02133098(((char *)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char *)this), 0, 0) == 0) {
+        if (func_ov091_02132dc0(((char *)this)) == 0)
             goto done;
     }
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));
 done:
     return 1;
-}
 }

--- a/src/_ZN6ThwompD0Ev.c
+++ b/src/_ZN6ThwompD0Ev.c
@@ -1,17 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN6ThwompD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 extern void *G0;
 int *_ZN6ThwompD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV7daDsn_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)VT2;

--- a/src/_ZN6ThwompD1Ev.c
+++ b/src/_ZN6ThwompD1Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN6ThwompD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daDsn_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *_ZN6ThwompD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV7daDsn_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)VT2;

--- a/src/_ZN6ToxBox16CleanupResourcesEv.cpp
+++ b/src/_ZN6ToxBox16CleanupResourcesEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN6ToxBox16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "ToxBox.h"
 extern "C" {
 int _ZN13SharedFilePtr7ReleaseEv(void*);
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov092_02132540[];
 extern int data_ov092_02132548[];
-int _ZN6ToxBox16CleanupResourcesEv(char* c){
+}
+
+int ToxBox::CleanupResources()
+{
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132540);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov092_02132548);
-  if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase7DisableEv(c+0x124);
+  if(_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider))
+    _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
   return 1;
-}
 }

--- a/src/_ZN6ToxBox6RenderEv.cpp
+++ b/src/_ZN6ToxBox6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN6ToxBox6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ToxBox.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN6ToxBox6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int ToxBox::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN6ToxBoxD0Ev.cpp
+++ b/src/_ZN6ToxBoxD0Ev.cpp
@@ -1,23 +1,27 @@
 //cpp
+// @symbol _ZN6ToxBoxD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ToxBox.h"
 extern "C" {
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN5ModelD1Ev(void*);
-extern void _ZN5ActorD2Ev(void*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
 extern int _ZTV6ToxBox[];
 extern int _ZTV17ExclamationSwitch[];
 extern void* data_020a0eac;
-void* _ZN6ToxBoxD0Ev(char* self){
-  *(int**)(self)=_ZTV6ToxBox;
-  _ZN25MovingCylinderClsnWithPosD1Ev(self+0x4e8);
-  _ZN12WithMeshClsnD1Ev(self+0x324);
-  *(int**)(self)=_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(self+0x124);
-  _ZN5ModelD1Ev(self+0xd4);
-  _ZN5ActorD2Ev(self);
-  _ZN6Memory10DeallocateEPvP4Heap(self, data_020a0eac);
-  return self;
+void* _ZN6ToxBoxD0Ev(struct ToxBox *self) {
+  *(int**)(((char*)self))=_ZTV6ToxBox;
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  *(int**)(((char*)self))=_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char*)self), data_020a0eac);
+  return ((char*)self);
 }
 }

--- a/src/_ZN6ToxBoxD1Ev.cpp
+++ b/src/_ZN6ToxBoxD1Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN6ToxBoxD1Ev
+/* recovered: named members + shared header */
+#include "ToxBox.h"
 extern "C" {
 extern int _ZN25MovingCylinderClsnWithPosD1Ev(void*);
 extern int _ZN12WithMeshClsnD1Ev(void*);
@@ -7,14 +10,14 @@ extern int _ZN5ModelD1Ev(void*);
 extern int _ZN5ActorD2Ev(void*);
 extern void* _ZTV6ToxBox;
 extern void* _ZTV17ExclamationSwitch;
-void* _ZN6ToxBoxD1Ev(char* c){
-  *(void**)c = &_ZTV6ToxBox;
-  _ZN25MovingCylinderClsnWithPosD1Ev(c+0x4e8);
-  _ZN12WithMeshClsnD1Ev(c+0x324);
-  *(void**)c = &_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev(c+0x124);
-  _ZN5ModelD1Ev(c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN6ToxBoxD1Ev(struct ToxBox *self) {
+  *(void**)((char*)self) = &_ZTV6ToxBox;
+  _ZN25MovingCylinderClsnWithPosD1Ev((char*)&self->mMovingCylinderClsnWithPos);
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  *(void**)((char*)self) = &_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((char*)self));
+  return ((char*)self);
 }
 }

--- a/src/_ZN7BooCage6RenderEv.cpp
+++ b/src/_ZN7BooCage6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN7BooCage6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BooCage.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x300]; Base base; };
-extern "C" int _ZN7BooCage6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int BooCage::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN7BooCageD0Ev.c
+++ b/src/_ZN7BooCageD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN7BooCageD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daTBasket_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN7BooCageD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daTBasket_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN7BooCageD1Ev.c
+++ b/src/_ZN7BooCageD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN7BooCageD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7BooCage */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN7BooCageD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7BooCage;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN7ChuckyaD0Ev.c
+++ b/src/_ZN7ChuckyaD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN7ChuckyaD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daHolhei_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN7ChuckyaD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daHolhei_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x368);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN7ChuckyaD1Ev.c
+++ b/src/_ZN7ChuckyaD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN7ChuckyaD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7Chuckya */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN7ChuckyaD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7Chuckya;
     _ZN11ShadowModelD1Ev((char *)t + 0x368);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN7Clipper13Func_020156DCEv.cpp
+++ b/src/_ZN7Clipper13Func_020156DCEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Clipper13Func_020156DCEv
+/* recovered: named members + shared header */
+#include "Clipper.h"
 typedef int Fix12i;
 typedef unsigned int u32;
 typedef unsigned short u16;
@@ -7,12 +10,12 @@ extern "C" {
 
 void _ZN7Clipper13Func_0201559CEv(void* self);
 
-void _ZN7Clipper13Func_020156DCEv(char* self, u32 a, u16 b, Fix12i c, Fix12i d) {
-    *(u32*)(self + 0x4c) = a;
-    *(u16*)(self + 0x58) = b;
-    *(Fix12i*)(self + 0x50) = c;
-    *(Fix12i*)(self + 0x54) = d;
-    _ZN7Clipper13Func_0201559CEv(self);
+void _ZN7Clipper13Func_020156DCEv(struct Clipper *self, u32 a, u16 b, Fix12i c, Fix12i d) {
+    self->unk_04c = a;
+    self->unk_058 = b;
+    *(Fix12i*)((char*)&self->unk_050) = c;
+    *(Fix12i*)((char*)&self->unk_054) = d;
+    _ZN7Clipper13Func_0201559CEv(((char*)self));
 }
 
 }

--- a/src/_ZN7ClipperD0Ev.c
+++ b/src/_ZN7ClipperD0Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN7ClipperD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Clipper.h"
 /* _ZN7ClipperD0Ev at 0x020156fc
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
  * Call target: 0x0203cbcc
  */
 struct Obj { void *vtable; };
-extern void *vtbl_Clipper[];
 extern void base_dtor_Clipper(struct Obj *thiz); /* 0x0203cbcc */
 struct Obj *_ZN7ClipperD0Ev(struct Obj *thiz)
 {

--- a/src/_ZN7ClipperD1Ev.c
+++ b/src/_ZN7ClipperD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN7ClipperD1Ev
+/* recovered: named members + shared header */
+#include "Clipper.h"
 /* Clipper::~Clipper() at 0x02015720
  * Trivial destructor: stores the Clipper vtable pointer into self->vtable
  * (slot 0x0) and returns. No members need teardown.

--- a/src/_ZN7HeaveHo13InitResourcesEv.cpp
+++ b/src/_ZN7HeaveHo13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7HeaveHo13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -8,38 +13,35 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*, void*, int, int, void*, int);
 extern void func_ov077_02126d5c(void*, void*);
 struct V3 { int x, y, z; };
-extern char data_ov077_02127c88;
-extern char data_ov077_02127ca0;
-extern char data_ov077_02127c90;
-extern char data_ov077_02127c98;
 extern struct V3 data_ov077_02127a5c;
-extern char data_ov077_02127ce8;
-int _ZN7HeaveHo13InitResourcesEv(char* c){
+}
+
+int HeaveHo::InitResources()
+{
   struct V3 v;
   void* f;
   f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov077_02127c88);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x340, f, 1, -1);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x340, f, 1, -1);
   _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127ca0);
   _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127c90);
   _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov077_02127c98);
-  *(int*)(c + 0x9c) = -0x1000;
-  *(int*)(c + 0xa0) = -0x1e000;
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, c, 0x52000, 0x52000, 0x800004, 0);
+  unk_09c = -0x1000;
+  unk_0a0 = -0x1e000;
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x110, ((char*)this), 0x52000, 0x52000, 0x800004, 0);
   v.x = data_ov077_02127a5c.x;
   v.y = data_ov077_02127a5c.y;
   v.z = data_ov077_02127a5c.z;
-  _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c + 0x144, c, &v, 0x54000, 0x32000, 0x200004, 0);
-  *(short*)(c + 0x8e) = *(short*)(c + 0x94);
-  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x184, c, 0x64000, 0x64000, 0, 0);
-  *(int*)(c + 0x400) = 0;
-  *(int*)(c + 0x404) = *(int*)(c + 0x5c);
-  *(int*)(c + 0x408) = *(int*)(c + 0x60);
-  *(int*)(c + 0x40c) = *(int*)(c + 0x64);
-  *(int*)(c + 0x39c) = 0x1000;
-  *(int*)(c + 0x410) = *(int*)(c + 0x5c);
-  *(int*)(c + 0x414) = *(int*)(c + 0x60);
-  *(int*)(c + 0x418) = *(int*)(c + 0x64);
-  func_ov077_02126d5c(c, &data_ov077_02127ce8);
+  _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(((char*)this) + 0x144, ((char*)this), &v, 0x54000, 0x32000, 0x200004, 0);
+  unk_08e = unk_094;
+  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x184, ((char*)this), 0x64000, 0x64000, 0, 0);
+  unk_400 = 0;
+  unk_404 = mPosX;
+  unk_408 = mPosY;
+  unk_40c = mPosZ;
+  unk_39c = 0x1000;
+  unk_410 = mPosX;
+  unk_414 = mPosY;
+  unk_418 = mPosZ;
+  func_ov077_02126d5c(((char*)this), &data_ov077_02127ce8);
   return 1;
-}
 }

--- a/src/_ZN7HeaveHo6RenderEv.cpp
+++ b/src/_ZN7HeaveHo6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7HeaveHo6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
 extern int data_0209f32c;
 
 struct Cls {
@@ -10,9 +13,10 @@ struct Cls {
     virtual void method5(int);  /* at vtable offset 0x14 */
 };
 
-extern "C" int _ZN7HeaveHo6RenderEv(char* c) {
-    if (*(int*)(c+0x60) < data_0209f32c) return 1;
-    Cls *obj = (Cls*)(c + 0x340);
+int HeaveHo::Render()
+{
+    if (mPosY < data_0209f32c) return 1;
+    Cls *obj = (Cls*)((char*)&mModelAnim);
     obj->method5(0);
     return 1;
 }

--- a/src/_ZN7HeaveHo8BehaviorEv.cpp
+++ b/src/_ZN7HeaveHo8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7HeaveHo8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "HeaveHo.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef int Fix12;
@@ -6,7 +11,6 @@ struct Klass; typedef void (Klass::*PMF)();
 struct M { char pad[8]; PMF pmf; };
 struct CylinderClsn;
 struct WithMeshClsn;
-struct Vector3 { int x, y, z; };
 extern "C" {
 unsigned short DecIfAbove0_Short(unsigned short *p);
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, CylinderClsn *cc);
@@ -22,66 +26,65 @@ void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
 void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
 void _ZN9Animation7AdvanceEv(void *self);
 extern int data_0209f32c;
-extern char data_ov077_02127cd8[];
 }
 
-extern "C" int _ZN7HeaveHo8BehaviorEv(char *c)
+int HeaveHo::Behavior()
 {
     int b;
     Vector3 v;
     int r5;
     M *m;
 
-    if (*(int *)(c + 0x60) < data_0209f32c) {
-        *(int *)(c + 0x5c) = *(int *)(c + 0x404);
-        *(int *)(c + 0x60) = *(int *)(c + 0x408);
-        *(int *)(c + 0x64) = *(int *)(c + 0x40c);
+    if (mPosY < data_0209f32c) {
+        mPosX = unk_404;
+        mPosY = unk_408;
+        mPosZ = unk_40c;
         return 1;
     }
 
-    DecIfAbove0_Short((unsigned short *)(c + 0x100));
-    DecIfAbove0_Short((unsigned short *)(c + 0x426));
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_100));
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_426));
 
-    m = *(M **)(c + 0x3fc);
+    m = *(M **)((char *)&unk_3fc);
     if (m->pmf != 0)
-        (((Klass *)c)->*(m->pmf))();
+        (((Klass *)((char *)this))->*(m->pmf))();
 
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, (CylinderClsn *)(c + 0x144));
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char *)this), (CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
 
     r5 = 0;
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x184)) {
-        void *fr = _ZNK12WithMeshClsn14GetFloorResultEv(c + 0x184);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mWithMeshClsn)) {
+        void *fr = _ZNK12WithMeshClsn14GetFloorResultEv((char *)&mWithMeshClsn);
         _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char *)fr + 4, &v);
-        r5 = func_02010844(c, &v, *(s16 *)(c + 0x8e));
+        r5 = func_02010844(((char *)this), &v, unk_08e);
     }
 
-    b = _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(c, (WithMeshClsn *)(c + 0x184), 0x3c000, (s16)0x2888, 0, 1, (void *)0x32000);
+    b = _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 0x3c000, (s16)0x2888, 0, 1, (void *)0x32000);
     if (b == 0) {
         if (r5 < 0)
             r5 = (s16)-r5;
         if (r5 <= 0x100)
             goto writeback;
     }
-    *(int *)(c + 0x5c) = *(int *)(c + 0x410);
-    *(int *)(c + 0x60) = *(int *)(c + 0x414);
-    *(int *)(c + 0x64) = *(int *)(c + 0x418);
+    mPosX = unk_410;
+    mPosY = unk_414;
+    mPosZ = unk_418;
 writeback:
-    *(int *)(c + 0x410) = *(int *)(c + 0x5c);
-    *(int *)(c + 0x414) = *(int *)(c + 0x60);
-    *(int *)(c + 0x418) = *(int *)(c + 0x64);
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (WithMeshClsn *)(c + 0x184), 2);
+    unk_410 = mPosX;
+    unk_414 = mPosY;
+    unk_418 = mPosZ;
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 2);
 
-    *(s16 *)(c + 0x8e) = *(s16 *)(c + 0x94);
-    func_ov077_02126dac(c);
+    unk_08e = unk_094;
+    func_ov077_02126dac(((char *)this));
 
-    if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x184) && *(void **)(c + 0x3fc) != (void *)data_ov077_02127cd8) {
-        func_ov077_02126528(c);
+    if (_ZNK12WithMeshClsn10IsOnGroundEv((char *)&mWithMeshClsn) && *(void **)((char *)&unk_3fc) != (void *)data_ov077_02127cd8) {
+        func_ov077_02126528(((char *)this));
     }
-    _ZN12CylinderClsn5ClearEv((CylinderClsn *)(c + 0x110));
-    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(c + 0x110));
-    _ZN12CylinderClsn5ClearEv((CylinderClsn *)(c + 0x144));
-    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(c + 0x144));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
+    _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsnWithPos));
 
-    _ZN9Animation7AdvanceEv(c + 0x390);
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
     return 1;
 }

--- a/src/_ZN7HeaveHoD0Ev.c
+++ b/src/_ZN7HeaveHoD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN7HeaveHoD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daPopoi_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN7HeaveHoD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daPopoi_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3a4);
     _ZN9ModelAnimD1Ev((char *)t + 0x340);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x184);

--- a/src/_ZN7HeaveHoD1Ev.c
+++ b/src/_ZN7HeaveHoD1Ev.c
@@ -1,13 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN7HeaveHoD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7HeaveHo */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN7HeaveHoD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7HeaveHo;
     _ZN11ShadowModelD1Ev((char *)t + 0x3a4);
     _ZN9ModelAnimD1Ev((char *)t + 0x340);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x184);

--- a/src/_ZN7Message11DisplayTextEt.cpp
+++ b/src/_ZN7Message11DisplayTextEt.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Message11DisplayTextEt
+/* recovered: named members + shared header */
+#include "Message.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 

--- a/src/_ZN7Message13DisplaySavingEt.cpp
+++ b/src/_ZN7Message13DisplaySavingEt.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Message13DisplaySavingEt
+/* recovered: named members + shared header */
+#include "Message.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef signed short s16;

--- a/src/_ZN7Message16DisplayPauseTextEth.cpp
+++ b/src/_ZN7Message16DisplayPauseTextEth.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7Message16DisplayPauseTextEth
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern short data_0209d6d4;
 extern unsigned char data_0209d6a8;
@@ -8,7 +13,6 @@ extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_0201d6a0(int a, int b);
 
 void _ZN7Message16DisplayPauseTextEth(unsigned short n, unsigned char b) {
     volatile int li;

--- a/src/_ZN7Message17DisplayVsExitTextEt.cpp
+++ b/src/_ZN7Message17DisplayVsExitTextEt.cpp
@@ -1,16 +1,15 @@
 //cpp
+// @symbol _ZN7Message17DisplayVsExitTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern unsigned short data_0209fce8;
-extern unsigned char data_0209fc9c;
-extern unsigned char data_0209fc94;
-extern unsigned char data_0209fc78;
-extern unsigned char data_0209fcdc;
-extern int func_02034504();
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_020341a8(int a, int b);
 
 void _ZN7Message17DisplayVsExitTextEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message18DisplayPauseTextVSEt.cpp
+++ b/src/_ZN7Message18DisplayPauseTextVSEt.cpp
@@ -1,14 +1,15 @@
 //cpp
+// @symbol _ZN7Message18DisplayPauseTextVSEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern short data_0209fce8;
-extern unsigned char data_0209fc78;
-extern unsigned char data_0209fc94;
-extern int func_02034504();
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_020341a8(int a, int b);
 
 void _ZN7Message18DisplayPauseTextVSEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message19DisplayDontSaveTextEt.cpp
+++ b/src/_ZN7Message19DisplayDontSaveTextEt.cpp
@@ -1,16 +1,18 @@
 //cpp
+// @symbol _ZN7Message19DisplayDontSaveTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern short data_0209d6d4;
 extern unsigned char data_0209d660;
 extern unsigned char data_0209d668;
 extern unsigned char data_0209d6a8;
-extern int func_0201eaac();
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_0201d418(int a, int b);
-extern void func_0201d6a0(int a, int b);
 
 void _ZN7Message19DisplayDontSaveTextEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message19DisplaySaveMenuTextEt.c
+++ b/src/_ZN7Message19DisplaySaveMenuTextEt.c
@@ -1,9 +1,12 @@
+// @symbol _ZN7Message19DisplaySaveMenuTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern unsigned short data_0209d6d4;
 extern unsigned char data_0209d660;
 extern unsigned char data_0209d6a8;
 extern unsigned char data_0209d668;
-extern int func_0201eaac();
-extern int func_0201e220(int);
 
 void _ZN7Message19DisplaySaveMenuTextEt(unsigned short n) {
     data_0209d6d4 = n;

--- a/src/_ZN7Message21DisplayLevelClearTextEta.c
+++ b/src/_ZN7Message21DisplayLevelClearTextEta.c
@@ -1,7 +1,11 @@
+// @symbol _ZN7Message21DisplayLevelClearTextEta
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern unsigned short data_0209d6d4;
 extern unsigned char data_0209d668;
 extern int func_0201d850(signed char a);
-extern int func_0201e220(int);
 
 void _ZN7Message21DisplayLevelClearTextEta(unsigned short a, signed char b)
 {

--- a/src/_ZN7Message21DisplaySaveStatusTextEt.cpp
+++ b/src/_ZN7Message21DisplaySaveStatusTextEt.cpp
@@ -1,16 +1,18 @@
 //cpp
+// @symbol _ZN7Message21DisplaySaveStatusTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern unsigned short data_0209d6d4;
 extern unsigned char data_0209d660;
 extern unsigned char data_0209d668;
 extern unsigned char data_0209d6a8;
-extern unsigned char data_0209d674;
-extern int func_0201eaac();
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_0201d418(int a, int b);
 
 void _ZN7Message21DisplaySaveStatusTextEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message22DisplayOptionsMenuTextEt.cpp
+++ b/src/_ZN7Message22DisplayOptionsMenuTextEt.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7Message22DisplayOptionsMenuTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern short data_0209d6d4;
 extern unsigned char data_0209d6c0;
@@ -7,9 +12,6 @@ extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern int func_0201cfb8(unsigned short n);
-extern void func_0201d418(int a, int b);
-extern void func_0201d6a0(int a, int b);
 
 void _ZN7Message22DisplayOptionsMenuTextEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message25DisplayControllerModeTextEt.cpp
+++ b/src/_ZN7Message25DisplayControllerModeTextEt.cpp
@@ -1,17 +1,18 @@
 //cpp
+// @symbol _ZN7Message25DisplayControllerModeTextEt
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Message.h"
 extern "C" {
 extern short data_0209d6d4;
 extern unsigned char data_0209d660;
 extern unsigned char data_0209d668;
 extern unsigned char data_0209d6a8;
-extern unsigned char data_0209d674;
-extern int func_0201eaac();
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);
 extern void MultiStore16(int a, int b, int n);
-extern void func_0201d418(int a, int b);
-extern void func_0201d6a0(int a, int b);
 
 void _ZN7Message25DisplayControllerModeTextEt(unsigned short n) {
     volatile int li;

--- a/src/_ZN7Message28DisplayStarNameForStarSelectEj.cpp
+++ b/src/_ZN7Message28DisplayStarNameForStarSelectEj.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Message28DisplayStarNameForStarSelectEj
+/* recovered: named members + shared header */
+#include "Message.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 

--- a/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
+++ b/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Message30DisplayCourseNameForStarSelectEj
+/* recovered: named members + shared header, named members + shared header */
+#include "Message.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -33,8 +36,7 @@ void func_0201b7cc(void);
 void func_0201b388(int a);
 }
 
-extern "C" void _ZN7Message30DisplayCourseNameForStarSelectEj(unsigned int courseID)
-{
+extern "C" void _ZN7Message30DisplayCourseNameForStarSelectEj(struct Message *self) {
     volatile unsigned short ls;
     volatile int li1;
     volatile int li2;
@@ -44,7 +46,7 @@ extern "C" void _ZN7Message30DisplayCourseNameForStarSelectEj(unsigned int cours
     int div;
     int div2;
 
-    data_0209d6d4 = (short)(courseID + 0x196);
+    data_0209d6d4 = (short)((unsigned int)&self->unk_196);
     data_0209d660 = 0;
     func_0201eaac();
 

--- a/src/_ZN7Message7DisplayEj.cpp
+++ b/src/_ZN7Message7DisplayEj.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Message7DisplayEj
+/* recovered: named members + shared header, real C++ method */
+#include "Message.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -19,7 +22,7 @@ int _ZN3G2S12GetBG0ScrPtrEv(void);
 void func_0201d6a0(int a, int b);
 }
 
-extern "C" void _ZN7Message7DisplayEj(void* self, unsigned int msg)
+void Message::Display(unsigned int msg)
 {
     volatile int li;
     volatile unsigned short ls;
@@ -34,7 +37,7 @@ extern "C" void _ZN7Message7DisplayEj(void* self, unsigned int msg)
     s = func_02054fb0();
     ls = 0x2ff;
     MultiStore16(ls, s, 0x800);
-    _ZN7Message11DisplayTextEt(self);
+    _ZN7Message11DisplayTextEt(((void*)this));
     data_0209d6d4 = 0x276;
     data_0209d6c4 = 0;
     data_0209d668 = 1;

--- a/src/_ZN7Minimap13InitResourcesEv.cpp
+++ b/src/_ZN7Minimap13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Minimap13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Minimap.h"
 #pragma opt_strength_reduction off
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -37,7 +40,7 @@ extern s32 data_0209caa0[];
 extern s32 data_0209fc48;
 extern u8 data_ov002_02111150;
 
-extern "C" int _ZN7Minimap13InitResourcesEv(char *c)
+int Minimap::InitResources()
 {
     u16 *p;
     s32 i;
@@ -93,39 +96,39 @@ extern "C" int _ZN7Minimap13InitResourcesEv(char *c)
             || SublevelToLevel(data_0209f2f8) == -1)
         {
             *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x4010));
-            *(s32*)(c + 0x1d8) = 0x100;
-            *(s32*)(c + 0x1dc) = 0x80;
+            unk_1d8 = 0x100;
+            unk_1dc = 0x80;
 
             if (SublevelToLevel(data_0209f2f8) == 4) {
-                *(s32*)(c + 0x1e0) = 0x258000;
-                *(s32*)(c + 0x1e4) = 0;
-                *(s32*)(c + 0x1e8) = 0x64000;
+                unk_1e0 = 0x258000;
+                unk_1e4 = 0;
+                unk_1e8 = 0x64000;
             } else if (SublevelToLevel(data_0209f2f8) == 0x1d && data_0209f2f8 != 1 && data_0209f2f8 != 0x33 && data_0209f2f8 != 3) {
-                *(s32*)(c + 0x1e0) = -0x2bc000;
-                *(s32*)(c + 0x1e4) = 0;
-                *(s32*)(c + 0x1e8) = -0x2bc000;
+                unk_1e0 = -0x2bc000;
+                unk_1e4 = 0;
+                unk_1e8 = -0x2bc000;
             } else {
                 SublevelToLevel(data_0209f2f8);
-                *(s32*)(c + 0x1e0) = 0;
-                *(s32*)(c + 0x1e4) = 0;
-                *(s32*)(c + 0x1e8) = 0;
+                unk_1e0 = 0;
+                unk_1e4 = 0;
+                unk_1e8 = 0;
             }
-            *(u8*)(c + 0x251) = 1;
+            unk_251 = 1;
         } else {
             *(volatile u16*)0x400100e = (u16)(((0x1f - data_ov002_02111148) << 8) | ((*(volatile u16*)0x400100e & 0x43) | 0x10));
-            *(s32*)(c + 0x1d8) = 0x80;
-            *(s32*)(c + 0x1dc) = 0x40;
-            *(s32*)(c + 0x1e0) = 0;
-            *(s32*)(c + 0x1e4) = 0;
-            *(s32*)(c + 0x1e8) = 0;
-            *(u8*)(c + 0x251) = 2;
+            unk_1d8 = 0x80;
+            unk_1dc = 0x40;
+            unk_1e0 = 0;
+            unk_1e4 = 0;
+            unk_1e8 = 0;
+            unk_251 = 2;
         }
         data_0209d454 |= 8;
     } else {
         data_0209d454 &= ~8;
     }
 
-    *(s32*)(c + 0x214) = GetMinimapScale(data_ov002_02111148);
+    unk_214 = GetMinimapScale(data_ov002_02111148);
 
     {
         int b1 = (data_0209f2d8 == 0);
@@ -133,36 +136,36 @@ extern "C" int _ZN7Minimap13InitResourcesEv(char *c)
             if (!(data_0209caa0[2] & 0x80)) {
                 int b3 = (data_0209fc48 != 0);
                 if (!b3) {
-                    *(s32*)(c + 0x218) = (*(s32*)(c + 0x214)) << 1;
-                    *(u16*)(c + 0x21c) = 0;
-                    *(u8*)(c + 0x255) = 1;
+                    unk_218 = (unk_214) << 1;
+                    unk_21c = 0;
+                    unk_255 = 1;
                     goto unk218_done;
                 }
             }
         }
-        *(s32*)(c + 0x218) = *(s32*)(c + 0x214);
-        *(u8*)(c + 0x255) = 0;
+        unk_218 = unk_214;
+        unk_255 = 0;
     unk218_done:;
     }
 
     data_ov002_02111150 = 0;
-    *(s32*)(c + 0x50) = 0x1000;
-    *(s32*)(c + 0x54) = 0;
-    *(s32*)(c + 0x58) = 0;
-    *(s32*)(c + 0x5c) = 0x1000;
-    *(s32*)(c + 0x200) = 0x1000;
-    *(s32*)(c + 0x204) = 0;
-    *(s32*)(c + 0x208) = 0;
-    *(s32*)(c + 0x20c) = 0x1000;
-    *(s32*)(c + 0x1ec) = 0;
-    *(s32*)(c + 0x210) = 0x1000;
-    *(s32*)(c + 0x90) = 0;
-    *(s32*)(c + 0x94) = 0;
-    *(s32*)(c + 0x98) = 0;
-    *(s32*)(c + 0x9c) = 0;
+    unk_050 = 0x1000;
+    unk_054 = 0;
+    unk_058 = 0;
+    mPosX = 0x1000;
+    unk_200 = 0x1000;
+    unk_204 = 0;
+    unk_208 = 0;
+    unk_20c = 0x1000;
+    unk_1ec = 0;
+    unk_210 = 0x1000;
+    unk_090 = 0;
+    unk_094 = 0;
+    unk_098 = 0;
+    unk_09c = 0;
 
-    *(s32*)(c + 0x1d4) = func_0202a958();
-    *(s32*)(c + 0x1d4) = ((*(s32*)(c + 0x1d8)) << 12) / (*(s32*)(c + 0x1d4)) / 10;
+    unk_1d4 = func_0202a958();
+    unk_1d4 = ((unk_1d8) << 12) / (unk_1d4) / 10;
 
     return 1;
 }

--- a/src/_ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_.cpp
+++ b/src/_ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_
+/* recovered: named members + shared header */
+#include "Minimap.h"
 struct Vec3 { int x, y, z; };
 extern "C" {
 void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);

--- a/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
+++ b/src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp
@@ -1,12 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Minimap.h"
 
 extern "C" {
-extern int SublevelToLevel(int i);
 extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern signed char data_0209f2f8;
-extern signed char data_ov002_02111148;
 
 void _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(struct Vector3* v)
 {

--- a/src/_ZN7MinimapC1Ev.c
+++ b/src/_ZN7MinimapC1Ev.c
@@ -1,14 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
+// @symbol _ZN7MinimapC1Ev
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7dBase_c; VT1 = _ZTV6dMap_c */
 extern void _ZN9ActorBaseC1Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN7MinimapC1Ev(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(600);
     if (p) {
         _ZN9ActorBaseC1Ev(p);
-        p[0] = (int)VT0;
-        p[0] = (int)VT1;
+        p[0] = (int)_ZTV7dBase_c;
+        p[0] = (int)_ZTV6dMap_c;
     }
     return p;
 }

--- a/src/_ZN7MinimapD0Ev.c
+++ b/src/_ZN7MinimapD0Ev.c
@@ -1,12 +1,14 @@
+// @symbol _ZN7MinimapD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV6dMap_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *_ZN7MinimapD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV6dMap_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);
     return t;

--- a/src/_ZN7MinimapD1Ev.c
+++ b/src/_ZN7MinimapD1Ev.c
@@ -1,10 +1,13 @@
+// @symbol _ZN7MinimapD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV6dMap_c; VT1 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN7MinimapD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV6dMap_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/_ZN7PathPtrC1Ev.c
+++ b/src/_ZN7PathPtrC1Ev.c
@@ -1,5 +1,7 @@
-void _ZN7PathPtrC1Ev(char *p)
-{
-    *(int *)(p + 0x0) = 0;
-    *(int *)(p + 0x4) = 0;
+// @symbol _ZN7PathPtrC1Ev
+/* recovered: named members + shared header */
+#include "PathPtr.h"
+void _ZN7PathPtrC1Ev(struct PathPtr *self) {
+    self->unk_000 = 0;
+    self->unk_004 = 0;
 }

--- a/src/_ZN7Seaweed13InitResourcesEv.cpp
+++ b/src/_ZN7Seaweed13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7Seaweed13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Seaweed.h"
 extern "C" {
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct BCA_File;
@@ -9,13 +14,14 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* m, BMD_File* f, int a, int 
 extern BCA_File* _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr& f);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* m, BCA_File* f, int a, Fix12i b, unsigned int c);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* m, void* a, Fix12i r, Fix12i h, unsigned int f1, unsigned int f2);
-extern void func_ov002_020bc664(void* t);
-int _ZN7Seaweed13InitResourcesEv(char* c){
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e104), 1, -1);
-  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_0210e0fc), 0, 0x1000, 0);
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x138, c, 0x3c000, 0x78000, 0x100002, 0x8000);
-  *(int*)(c+0x16c) = 0x1000;
-  func_ov002_020bc664(c);
-  return 1;
 }
+
+int Seaweed::InitResources()
+{
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e104), 1, -1);
+  _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this)+0xd4, _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_0210e0fc), 0, 0x1000, 0);
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x138, ((char*)this), 0x3c000, 0x78000, 0x100002, 0x8000);
+  unk_16c = 0x1000;
+  func_ov002_020bc664(((char*)this));
+  return 1;
 }

--- a/src/_ZN7Seaweed6RenderEv.cpp
+++ b/src/_ZN7Seaweed6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN7Seaweed6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Seaweed.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN7Seaweed6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Seaweed::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN7SeaweedD0Ev.c
+++ b/src/_ZN7SeaweedD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN7SeaweedD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daObjHeart_c */
 extern void *G0;
 int *_ZN7SeaweedD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daObjHeart_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x138);
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN7Skeeter6RenderEv.cpp
+++ b/src/_ZN7Skeeter6RenderEv.cpp
@@ -1,12 +1,16 @@
 //cpp
+// @symbol _ZN7Skeeter6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Skeeter.h"
 struct Arg;
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(Arg*); };
 struct Obj { char pad[0xb0]; unsigned int flags; char pad2[0x30c-0xb4]; Sub sub; };
-extern "C" int _ZN7Skeeter6RenderEv(Obj *c)
+
+int Skeeter::Render()
 {
-    unsigned int f = c->flags;
+    unsigned int f = ((Obj *)this)->flags;
     int b = ((f & 0x40000) != 0);
     if(b) return 1;
-    c->sub.m((Arg*)((char*)c+0x80));
+    ((Obj *)this)->sub.m((Arg*)((char*)&mScaleX));
     return 1;
 }

--- a/src/_ZN7SkeeterD0Ev.c
+++ b/src/_ZN7SkeeterD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN7SkeeterD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daMenbo_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN7SkeeterD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daMenbo_c;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN7SkeeterD1Ev.c
+++ b/src/_ZN7SkeeterD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN7SkeeterD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV7Skeeter */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN7SkeeterD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7Skeeter;
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);

--- a/src/_ZN7SkiLift13InitResourcesEv.cpp
+++ b/src/_ZN7SkiLift13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN7SkiLift13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SkiLift.h"
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *f, int a, int b);
@@ -7,19 +12,18 @@ extern void *_ZN15TextureSequence8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern int _ZN11ShadowModel12InitCylinderEv(void *self);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *self, void *act, int a, int b, unsigned int c2, unsigned int d);
-extern int *func_ov022_021123d0(int *t, int r1);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *self, void *act, int a, int b, void *c2, void *d);
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void *pos, void *act);
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void func_ov018_02111d28(char *c, int r1);
 extern void _ZN13RaycastGroundD1Ev(void *self);
-extern int data_ov036_02113c00[];
-extern int data_ov018_02112c0c[];
-extern int data_ov056_02112c04[];
-int _ZN7SkiLift13InitResourcesEv(char *c) {
+}
+
+int SkiLift::InitResources()
+{
     void *m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_02113c00);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, 1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this)+0xd4, m, 1, 1);
     for (int i = 0; i < 2; i++)
         _ZN9Animation8LoadFileER13SharedFilePtr((void*)data_ov018_02112c0c[i]);
     for (int i = 0; i < 2; i++) {
@@ -27,33 +31,32 @@ int _ZN7SkiLift13InitResourcesEv(char *c) {
         _ZN15TextureSequence8LoadFileER13SharedFilePtr(t);
         _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov036_02113c00[1], (void*)((int*)t)[1]);
     }
-    if (_ZN11ShadowModel12InitCylinderEv(c+0x14c) == 0) return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x174, c, 0x104000, 0x12c000, 0x4800004, 0x900000);
-    func_ov022_021123d0((int*)c, 0);
-    *(int*)(c+0x9c) = -0x2000;
-    *(int*)(c+0xa0) = -0x3c000;
-    *(int*)(c+0x80) = 0x1000;
-    *(int*)(c+0x84) = 0x1000;
-    *(int*)(c+0x88) = 0x1000;
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x1a8, c, 0x32000, 0x32000, 0, 0);
+    if (_ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel) == 0) return 0;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this)+0x174, ((char *)this), 0x104000, 0x12c000, 0x4800004, 0x900000);
+    func_ov022_021123d0((int*)((char *)this), 0);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this)+0x1a8, ((char *)this), 0x32000, 0x32000, 0, 0);
     char rg[0x54];
     int v[3];
-    v[0] = *(int*)(c+0x5c);
-    v[1] = *(int*)(c+0x60);
-    v[2] = *(int*)(c+0x64);
+    v[0] = mPosX;
+    v[1] = mPosY;
+    v[2] = mPosZ;
     v[1] += 0x14000;
     _ZN13RaycastGroundC1Ev(rg);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, v, 0);
     if (_ZN13RaycastGround10DetectClsnEv(rg))
-        *(int*)(c+0x60) = *(int*)(rg+0x44);
+        mPosY = *(int*)(rg+0x44);
     else
-        *(int*)(c+0x60) = v[1];
-    *(int*)(c+0x364) = *(int*)(c+0x5c);
-    *(int*)(c+0x368) = *(int*)(c+0x60);
-    *(int*)(c+0x36c) = *(int*)(c+0x64);
-    *(int*)(c+0x374) = 0;
-    func_ov018_02111d28(c, 0);
+        mPosY = v[1];
+    unk_364 = mPosX;
+    unk_368 = mPosY;
+    unk_36c = mPosZ;
+    unk_374 = 0;
+    func_ov018_02111d28(((char *)this), 0);
     _ZN13RaycastGroundD1Ev(rg);
     return 1;
-}
 }

--- a/src/_ZN7SkiLift8BehaviorEv.cpp
+++ b/src/_ZN7SkiLift8BehaviorEv.cpp
@@ -1,19 +1,25 @@
 //cpp
+// @symbol _ZN7SkiLift8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_RacingPenguin.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SkiLift.h"
 extern "C" {
-extern void _ZN13RacingPenguin16OnPendingDestroyEv(void);
 extern void _ZN9Animation7AdvanceEv(void*);
 extern void _ZN12CylinderClsn5ClearEv(void*);
 extern void _ZN12CylinderClsn6UpdateEv(void*);
 extern int func_ov018_02111d28(void*);
 }
 struct Sub { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); };
-extern "C" int _ZN7SkiLift8BehaviorEv(char* c){
+
+int SkiLift::Behavior()
+{
   _ZN13RacingPenguin16OnPendingDestroyEv();
-  _ZN9Animation7AdvanceEv(c+0x124);
-  _ZN9Animation7AdvanceEv(c+0x138);
-  _ZN12CylinderClsn5ClearEv(c+0x174);
-  _ZN12CylinderClsn6UpdateEv(c+0x174);
-  ((Sub*)(c+0xd4))->m3();
-  func_ov018_02111d28(c);
+  _ZN9Animation7AdvanceEv((char*)&mAnimation);
+  _ZN9Animation7AdvanceEv((char*)&mTextureSequence);
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
+  ((Sub*)((char*)&mModelAnim))->m3();
+  func_ov018_02111d28(((char*)this));
   return 1;
 }

--- a/src/_ZN7SkiLiftD0Ev.c
+++ b/src/_ZN7SkiLiftD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN7SkiLiftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daPgMthr_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN7SkiLiftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daPgMthr_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1a8);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x174);
     _ZN11ShadowModelD1Ev((char *)t + 0x14c);

--- a/src/_ZN7Tornado13InitResourcesEv.cpp
+++ b/src/_ZN7Tornado13InitResourcesEv.cpp
@@ -1,46 +1,47 @@
 //cpp
+// @symbol _ZN7Tornado13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Tornado.h"
 extern "C" {
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
-extern void func_02016aac(void* thiz, int a, int b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void* a, void* b);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void* thiz, void* f, int a, int fix, unsigned int u);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int a, int b, unsigned int c, unsigned int d);
 extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* thiz, void* actor, int a, int b, void* v, int e);
-extern int data_ov096_02137ba8[];
-extern int data_ov096_02137bb0[];
-extern int func_02112968[];
-
-int _ZN7Tornado13InitResourcesEv(char* c)
-{
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x2c4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137ba8), 1, 0x15);
-    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov096_02137bb0);
-    func_02016aac(c + 0x2c4, 0x16, 1);
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x2c4, (void*)data_ov096_02137bb0[1], 0, 0x1000, 0);
-    _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File((void*)data_ov096_02137ba8[1], func_02112968);
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x328, func_02112968, 0, 0x1000, 0);
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0, 0, 0x200002, 0);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x108, c, 0x50000, 0x50000, 0, 0);
-
-    *(int*)(c + 0x340) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x344) = *(int*)(c + 0x60);
-    *(int*)(c + 0x348) = *(int*)(c + 0x64);
-    *(short*)(c + 0x35a) = 0;
-    *(int*)(c + 0x35c) = 0;
-    *(unsigned char*)(c + 0x360) = 0;
-    *(int*)(c + 0x9c) = -0x1000;
-    *(int*)(c + 0xa0) = -0x1e000;
-    {
-        unsigned int t = *(int*)(c + 8) & 0xff;
-        if (t == 0xff)
-            *(int*)(c + 0x34c) = 0x5dc000;
-        else
-            *(int*)(c + 0x34c) = t * 0x64000;
-    }
-    *(int*)(c + 0x364) = 0;
-    *(int*)(c + 0x368) = 0;
-    return 1;
 }
+
+int Tornado::InitResources()
+{
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x2c4, (void*)_ZN5Model8LoadFileER13SharedFilePtr(&data_ov096_02137ba8), 1, 0x15);
+    _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov096_02137bb0);
+    func_02016aac(((char*)this) + 0x2c4, 0x16, 1);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this) + 0x2c4, (void*)data_ov096_02137bb0[1], 0, 0x1000, 0);
+    _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File((void*)data_ov096_02137ba8[1], func_02112968);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char*)this) + 0x328, func_02112968, 0, 0x1000, 0);
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0xd4, ((char*)this), 0, 0, 0x200002, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x108, ((char*)this), 0x50000, 0x50000, 0, 0);
+
+    unk_340 = mPosX;
+    unk_344 = mPosY;
+    unk_348 = mPosZ;
+    unk_35a = 0;
+    unk_35c = 0;
+    unk_360 = 0;
+    unk_09c = -0x1000;
+    unk_0a0 = -0x1e000;
+    {
+        unsigned int t = mParam & 0xff;
+        if (t == 0xff)
+            unk_34c = 0x5dc000;
+        else
+            unk_34c = t * 0x64000;
+    }
+    unk_364 = 0;
+    unk_368 = 0;
+    return 1;
 }

--- a/src/_ZN7Tornado8BehaviorEv.cpp
+++ b/src/_ZN7Tornado8BehaviorEv.cpp
@@ -1,48 +1,49 @@
 //cpp
-extern "C" void func_ov096_021372c0(void);
-extern "C" void func_ov096_02137088(void);
-extern "C" void func_ov096_02136fd4(void);
+// @symbol _ZN7Tornado8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Tornado.h"
 extern "C" void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void *_ZN5Actor18ClosestWithActorIDEj(void *actor, unsigned int id);
 extern "C" int Vec3_Dist(void *a, void *b);
-extern "C" int func_ov002_020de33c(char *c, int a);
 extern "C" void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void *thiz);
 extern "C" void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern "C" void _ZN9Animation7AdvanceEv(void *thiz);
 
-extern "C" int _ZN7Tornado8BehaviorEv(char *c)
+int Tornado::Behavior()
 {
-    int s = *(int*)(c + 0x35c);
+    int s = unk_35c;
     switch (s) {
     case 0: func_ov096_021372c0(); break;
     case 1: func_ov096_02137088(); break;
     case 2: func_ov096_02136fd4(); break;
     }
     {
-        unsigned short *p = (unsigned short*)(((int)c + 0x350) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *p = (unsigned short*)(((int)((char *)this) + 0x350) & 0xFFFFFFFFFFFFFFFF);
         *p = *p + 1;
     }
-    if (s != *(int*)(c + 0x35c)) {
-        *(unsigned short*)(c + 0x350) = 0;
-        *(unsigned char*)(c + 0x360) = 0;
+    if (s != unk_35c) {
+        unk_350 = 0;
+        unk_360 = 0;
     }
-    unsigned int id = *(unsigned int*)(c + 0xf8);
-    if (id != 0 && (*(int*)(c + 0xf4) & 0x400000) != 0) {
+    unsigned int id = unk_0f8;
+    if (id != 0 && (unk_0f4 & 0x400000) != 0) {
         void *o = _ZN5Actor10FindWithIDEj(id);
         if (o != 0) {
-            void *closest = _ZN5Actor18ClosestWithActorIDEj(c, 0x135);
+            void *closest = _ZN5Actor18ClosestWithActorIDEj(((char *)this), 0x135);
             if (closest == 0 || Vec3_Dist((char*)o + 0x5c, (char*)closest + 0x5c) > 0x118000) {
-                if (func_ov002_020de33c((char*)o, (int)c) != 0) {
-                    *(void**)(c + 0x33c) = o;
+                if (func_ov002_020de33c((char*)o, (int)((char *)this)) != 0) {
+                    *(void**)((char *)&unk_33c) = o;
                 }
             }
         }
     }
-    _ZN12CylinderClsn5ClearEv(c + 0xd4);
-    _ZN12CylinderClsn6UpdateEv(c + 0xd4);
-    Matrix4x3_FromTranslation(c + 0x2e0, *(int*)(c + 0x5c) >> 3, *(int*)(c + 0x60) >> 3, *(int*)(c + 0x64) >> 3);
-    _ZN9Animation7AdvanceEv(c + 0x314);
-    _ZN9Animation7AdvanceEv(c + 0x328);
+    _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char *)&mMovingCylinderClsn);
+    Matrix4x3_FromTranslation(((char *)this) + 0x2e0, mPosX >> 3, mPosY >> 3, mPosZ >> 3);
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    _ZN9Animation7AdvanceEv((char *)&mTextureTransformer);
     return 1;
 }

--- a/src/_ZN7TornadoD0Ev.c
+++ b/src/_ZN7TornadoD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN7TornadoD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daTor_c */
 extern void *G0;
 int *_ZN7TornadoD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daTor_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x328);
     _ZN9ModelAnimD1Ev((char *)t + 0x2c4);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x108);

--- a/src/_ZN7Wiggler6RenderEv.cpp
+++ b/src/_ZN7Wiggler6RenderEv.cpp
@@ -1,14 +1,18 @@
 //cpp
+// @symbol _ZN7Wiggler6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Wiggler.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN7Wiggler6RenderEv(char* c){
+
+int Wiggler::Render()
+{
   int i = 0;
-  char* p6 = c+0x110;
-  char* p5 = c+0x368;
-  char* p4 = c+0x408;
+  char* p6 = ((char*)this)+0x110;
+  char* p5 = ((char*)this)+0x368;
+  char* p4 = ((char*)this)+0x408;
   for(;i<5;i++){
     _ZN15TextureSequence6UpdateER15ModelComponents(p5, p6+8);
     ((Sub*)p6)->g5(p4);
@@ -17,5 +21,4 @@ int _ZN7Wiggler6RenderEv(char* c){
     p4 += 0xc;
   }
   return 1;
-}
 }

--- a/src/_ZN7WigglerD0Ev.c
+++ b/src/_ZN7WigglerD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN7WigglerD0Ev
+/* recovered: named members + shared header */
+#include "Wiggler.h"
 extern void _ZN12WithMeshClsnD1Ev(void *);
 extern void func_0207328c(void *p, int count, int size, void *dtor);
 extern int func_ov002_020aed18(int *x);
@@ -10,18 +13,18 @@ extern void _ZN15TextureSequenceD1Ev(void);
 extern void _ZN15MaterialChangerD1Ev(void);
 extern void _ZN9ModelAnimD1Ev(void);
 extern void *data_020a0eac;
-int _ZN7WigglerD0Ev(char *c){
-  *(void**)c = _ZTV7Wiggler;
-  _ZN12WithMeshClsnD1Ev(c+0x708);
-  func_0207328c(c+0x5b8, 5, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
-  func_0207328c(c+0x478, 5, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
-  func_0207328c(c+0x444, 5, 6, (void*)func_02011508);
-  func_0207328c(c+0x408, 5, 0xc, (void*)func_020072c0);
-  func_0207328c(c+0x3cc, 5, 0xc, (void*)func_020072c0);
-  func_0207328c(c+0x368, 5, 0x14, (void*)_ZN15TextureSequenceD1Ev);
-  func_0207328c(c+0x304, 5, 0x14, (void*)_ZN15MaterialChangerD1Ev);
-  func_0207328c(c+0x110, 5, 0x64, (void*)_ZN9ModelAnimD1Ev);
-  func_ov002_020aed18((int*)c);
-  _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-  return (int)c;
+int _ZN7WigglerD0Ev(struct Wiggler *self) {
+  *(void**)((char *)self) = _ZTV7Wiggler;
+  _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+  func_0207328c(((char *)self)+0x5b8, 5, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
+  func_0207328c(((char *)self)+0x478, 5, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
+  func_0207328c(((char *)self)+0x444, 5, 6, (void*)func_02011508);
+  func_0207328c(((char *)self)+0x408, 5, 0xc, (void*)func_020072c0);
+  func_0207328c(((char *)self)+0x3cc, 5, 0xc, (void*)func_020072c0);
+  func_0207328c(((char *)self)+0x368, 5, 0x14, (void*)_ZN15TextureSequenceD1Ev);
+  func_0207328c(((char *)self)+0x304, 5, 0x14, (void*)_ZN15MaterialChangerD1Ev);
+  func_0207328c(((char *)self)+0x110, 5, 0x64, (void*)_ZN9ModelAnimD1Ev);
+  func_ov002_020aed18((int*)((char *)self));
+  _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+  return (int)((char *)self);
 }

--- a/src/_ZN7WigglerD1Ev.c
+++ b/src/_ZN7WigglerD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN7WigglerD1Ev
+/* recovered: named members + shared header */
+#include "Wiggler.h"
 extern int _ZN12WithMeshClsnD1Ev(void *p);
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int func_ov002_020aed18(void *p);
@@ -8,17 +11,17 @@ extern int _ZN15TextureSequenceD1Ev(void *p);
 extern int _ZN15MaterialChangerD1Ev(void *p);
 extern int _ZN9ModelAnimD1Ev(void *p);
 extern int _ZTV7Wiggler[];
-int _ZN7WigglerD1Ev(char *c){
-  *(int**)(c) = _ZTV7Wiggler;
-  _ZN12WithMeshClsnD1Ev(c+0x708);
-  func_0207328c(c+0x5b8, 5, 0x40, _ZN25MovingCylinderClsnWithPosD1Ev);
-  func_0207328c(c+0x478, 5, 0x40, _ZN25MovingCylinderClsnWithPosD1Ev);
-  func_0207328c(c+0x444, 5, 6, func_02011508);
-  func_0207328c(c+0x408, 5, 0xc, func_020072c0);
-  func_0207328c(c+0x3cc, 5, 0xc, func_020072c0);
-  func_0207328c(c+0x368, 5, 0x14, _ZN15TextureSequenceD1Ev);
-  func_0207328c(c+0x304, 5, 0x14, _ZN15MaterialChangerD1Ev);
-  func_0207328c(c+0x110, 5, 0x64, _ZN9ModelAnimD1Ev);
-  func_ov002_020aed18(c);
-  return (int)c;
+int _ZN7WigglerD1Ev(struct Wiggler *self) {
+  *(int**)(((char *)self)) = _ZTV7Wiggler;
+  _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+  func_0207328c(((char *)self)+0x5b8, 5, 0x40, _ZN25MovingCylinderClsnWithPosD1Ev);
+  func_0207328c(((char *)self)+0x478, 5, 0x40, _ZN25MovingCylinderClsnWithPosD1Ev);
+  func_0207328c(((char *)self)+0x444, 5, 6, func_02011508);
+  func_0207328c(((char *)self)+0x408, 5, 0xc, func_020072c0);
+  func_0207328c(((char *)self)+0x3cc, 5, 0xc, func_020072c0);
+  func_0207328c(((char *)self)+0x368, 5, 0x14, _ZN15TextureSequenceD1Ev);
+  func_0207328c(((char *)self)+0x304, 5, 0x14, _ZN15MaterialChangerD1Ev);
+  func_0207328c(((char *)self)+0x110, 5, 0x64, _ZN9ModelAnimD1Ev);
+  func_ov002_020aed18(((char *)self));
+  return (int)((char *)self);
 }

--- a/src/_ZN8BigBully13InitResourcesEv.cpp
+++ b/src/_ZN8BigBully13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8BigBully13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BigBully.h"
 extern "C" {
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -6,8 +11,6 @@ typedef signed char s8;
 typedef short s16;
 typedef unsigned int u32;
 
-typedef struct { int x, y, z; } Vector3;
-typedef struct { short x, y, z; } Vector3_16;
 typedef struct Actor Actor;
 struct RaycastGround { char buf[0x50]; };
 
@@ -18,38 +21,38 @@ extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* se
 extern int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
 extern void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 extern Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 actorID, u32 param1, const Vector3* pos, const Vector3_16* rot, s8 areaID, s16 deathTableID);
-extern int data_ov064_0211b93c;
 extern s16 data_02082214[];
+}
 
-int _ZN8BigBully13InitResourcesEv(char* c)
+int BigBully::InitResources()
 {
     int saved;
 
-    *(void**)(c + 0x330) = &data_ov064_0211b93c;
-    saved = func_ov064_02116ec0(c);
-    *(u8*)(c + 0x3fc) = *(int*)(c + 8) & 0xf;
-    *(u8*)(c + 0x3fd) = (u8)_ZN5Actor9TrackStarEjj((Actor*)c, *(u8*)(c + 0x3fc), 2);
-    *(short*)(c + 0x3fa) = 0;
+    *(void**)((char*)&unk_330) = &data_ov064_0211b93c;
+    saved = func_ov064_02116ec0(((char*)this));
+    unk_3fc = mParam & 0xf;
+    unk_3fd = (u8)_ZN5Actor9TrackStarEjj((Actor*)((char*)this), unk_3fc, 2);
+    mSecretSoundCounter = 0;
 
-    if ((*(int*)(c + 8) & 0xff00) == 0x100) {
+    if ((mParam & 0xff00) == 0x100) {
         RaycastGround rg;
         Vector3 pos;
         Vector3 v;
         int i;
         int ang;
 
-        *(u8*)(c + 0x3fe) = 0;
+        unk_3fe = 0;
         _ZN13RaycastGroundC1Ev(&rg);
 
         {
-            int tz = *(int*)(c + 0x64);
-            int ty = *(int*)(c + 0x60) + 0x32000;
-            int tx = *(int*)(c + 0x5c);
+            int tz = mPosZ;
+            int ty = mPosY + 0x32000;
+            int tx = mPosX;
             v.x = tx;
             v.y = ty;
             v.z = tz;
         }
-        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &v, (Actor*)c);
+        _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rg, &v, (Actor*)((char*)this));
 
         if (_ZN13RaycastGround10DetectClsnEv(&rg) != 0) {
             pos.y = *(int*)(rg.buf + 0x44);
@@ -61,12 +64,12 @@ int _ZN8BigBully13InitResourcesEv(char* c)
             int idx = (u16)(s16)ang >> 4;
             Actor* spawned;
 
-            pos.x = *(int*)(c + 0x5c) + data_02082214[idx * 2] * 500 - 0x64000;
-            pos.z = *(int*)(c + 0x64) - data_02082214[idx * 2 + 1] * 500;
+            pos.x = mPosX + data_02082214[idx * 2] * 500 - 0x64000;
+            pos.z = mPosZ - data_02082214[idx * 2 + 1] * 500;
 
-            spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xd7, -1, &pos, (Vector3_16*)0, *(s8*)(c + 0xcc), -1);
+            spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xd7, -1, &pos, (Vector3_16*)0, mAreaId, -1);
             if (spawned != 0) {
-                *(int*)((char*)spawned + 0x3fc) = *(int*)(c + 4);
+                *(int*)((char*)spawned + 0x3fc) = unk_004;
             } else {
                 _ZN13RaycastGroundD1Ev(&rg);
                 return 0;
@@ -80,8 +83,7 @@ int _ZN8BigBully13InitResourcesEv(char* c)
         goto done;
     }
 
-    *(u8*)(c + 0x3fe) = 0xff;
+    unk_3fe = 0xff;
 done:
     return saved;
-}
 }

--- a/src/_ZN8BigBully6RenderEv.cpp
+++ b/src/_ZN8BigBully6RenderEv.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol _ZN8BigBully6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "BigBully.h"
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(int); };
-extern "C" {
-int _ZN8BigBully6RenderEv(char* c){
-  if(*(unsigned char*)(c+0x3fe) >= 3)
-    ((Sub*)(c+0x110))->g5(0);
+
+int BigBully::Render()
+{
+  if(unk_3fe >= 3)
+    ((Sub*)((char*)&mModelAnim))->g5(0);
   return 1;
-}
 }

--- a/src/_ZN8BigBullyD0Ev.c
+++ b/src/_ZN8BigBullyD0Ev.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN8BigBullyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *_ZN8BigBullyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBDonketu_c;
     t[0] = (int)VT1;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN8BigBullyD1Ev.c
+++ b/src/_ZN8BigBullyD1Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN8BigBullyD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daBDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN8BigBullyD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daBDonketu_c;
     t[0] = (int)VT1;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/_ZN8BookShot16CleanupResourcesEv.cpp
+++ b/src/_ZN8BookShot16CleanupResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN8BookShot16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "BookShot.h"
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void *);
 void UnloadBlueCoinModel(void *);
@@ -6,12 +9,14 @@ extern int data_ov020_02114aa0;
 extern int data_ov020_02114ab8;
 extern int data_ov020_02114aa8;
 extern int data_ov020_02114ab0;
-int _ZN8BookShot16CleanupResourcesEv(void *c){
+}
+
+int BookShot::CleanupResources()
+{
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa0);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab8);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114aa8);
   _ZN13SharedFilePtr7ReleaseEv(&data_ov020_02114ab0);
-  UnloadBlueCoinModel(c);
+  UnloadBlueCoinModel(((void *)this));
   return 1;
-}
 }

--- a/src/_ZN8BookShot8BehaviorEv.cpp
+++ b/src/_ZN8BookShot8BehaviorEv.cpp
@@ -1,41 +1,42 @@
 //cpp
+// @symbol _ZN8BookShot8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "BookShot.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
 extern void func_0200f760(void* a, void* b);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void* thiz, void* w);
-extern void func_ov020_0211216c(void* c);
-extern void func_ov020_02112080(void* c);
-extern void func_ov020_0211174c(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* thiz);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* thiz, const Vector3& v);
 extern void _ZN12CylinderClsn6UpdateEv(void* thiz);
+}
 
-int _ZN8BookShot8BehaviorEv(char* c)
+int BookShot::Behavior()
 {
-    func_0200f760(c, c + 0x21c);
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x25c) != 0) {
-        if (*(unsigned char*)(c + 0x107) != 0 && *(unsigned short*)(c + 0x104) == 5) {
-            *(int*)(c + 0x428) = *(int*)(c + 0x424);
-            *(int*)(c + 0x424) = 5;
-            *(unsigned char*)(c + 0x107) = 0;
-            *(int*)(c + 0xa8) = 0;
-            *(int*)(c + 0x98) = 0x8000;
+    func_0200f760(((char*)this), ((char*)this) + 0x21c);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char*)this), ((char*)this) + 0x25c) != 0) {
+        if (unk_107 != 0 && unk_104 == 5) {
+            unk_428 = mState;
+            mState = 5;
+            unk_107 = 0;
+            unk_0a8 = 0;
+            unk_098 = 0x8000;
         }
-        func_ov020_0211216c(c);
+        func_ov020_0211216c(((char*)this));
         return 1;
     }
-    switch (*(int*)(c + 0x420)) {
+    switch (unk_420) {
     case 0:
-        func_ov020_02112080(c);
+        func_ov020_02112080(((char*)this));
         break;
     case 1:
-        func_ov020_0211174c(c);
+        func_ov020_0211174c(((char*)this));
         break;
     }
-    func_ov020_0211216c(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x21c);
-    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x21c, *(Vector3*)(c + 0x438));
-    _ZN12CylinderClsn6UpdateEv(c + 0x21c);
+    func_ov020_0211216c(((char*)this));
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+    _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char*)this) + 0x21c, *(Vector3*)((char*)&unk_438));
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
     return 1;
-}
 }

--- a/src/_ZN8BookShotD0Ev.c
+++ b/src/_ZN8BookShotD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN8BookShotD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daBook_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN8BookShotD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daBook_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x25c);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x21c);
     _ZN11ShadowModelD1Ev((char *)t + 0x1c4);

--- a/src/_ZN8BookShotD1Ev.c
+++ b/src/_ZN8BookShotD1Ev.c
@@ -1,13 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN8BookShotD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8BookShot */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN8BookShotD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8BookShot;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x25c);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x21c);
     _ZN11ShadowModelD1Ev((char *)t + 0x1c4);

--- a/src/_ZN8CapEnemy14RenderCapModelEPK7Vector3.cpp
+++ b/src/_ZN8CapEnemy14RenderCapModelEPK7Vector3.cpp
@@ -1,14 +1,18 @@
 //cpp
+// @symbol _ZN8CapEnemy14RenderCapModelEPK7Vector3
+/* recovered: named members + shared header, real C++ method */
+#include "CapEnemy.h"
+struct Vector3;
 struct Vector3;
 struct CapModel {
   virtual void f0(); virtual void f1(); virtual void f2();
   virtual void f3(); virtual void f4();
   virtual void render(const Vector3*);
 };
-extern "C" {
-void _ZN8CapEnemy14RenderCapModelEPK7Vector3(char* c, const Vector3* v){
-  if((unsigned char)c[0x113] >= 6) return;
-  CapModel* o=(CapModel*)(c+0x114);
+
+void CapEnemy::RenderCapModel(const Vector3 * v)
+{
+  if((unsigned char)((char*)this)[0x113] >= 6) return;
+  CapModel* o=(CapModel*)((char*)&mModel);
   o->render(v);
-}
 }

--- a/src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp
+++ b/src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp
@@ -1,24 +1,27 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+// @symbol _ZN8CapEnemy15RespawnIfHasCapEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CapEnemy.h"
 struct Actor;
 
 extern "C" {
-extern void func_02005ed8(unsigned char *t);
 extern struct Actor *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
     unsigned int a1, unsigned int a2, const struct Vector3 *a3,
     const struct Vector3_16 *a4, int a5, int a6);
+}
 
-struct Actor *_ZN8CapEnemy15RespawnIfHasCapEv(unsigned char *c)
+struct Actor * CapEnemy::RespawnIfHasCap()
 {
     struct Actor *r;
-    func_02005ed8(c);
-    if ((c[0x113] & 0xf) >= 6) return 0;
+    func_02005ed8(((unsigned char *)this));
+    if ((((unsigned char *)this)[0x113] & 0xf) >= 6) return 0;
     r = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        *(unsigned short *)(c + 0xc), *(unsigned int *)(c + 8),
-        (const struct Vector3 *)(c + 0x5c),
-        (const struct Vector3_16 *)(c + 0x8c),
-        *(signed char *)(c + 0xcc), -1);
+        mActorID, mParam,
+        (const struct Vector3 *)((unsigned char *)&unk_05c),
+        (const struct Vector3_16 *)((unsigned char *)&unk_08c),
+        mAreaId, -1);
     if (!r) return r;
     *(unsigned char *)((char *)r + 0x111) = 1;
     *(int *)((char *)r + 0xf4) = *(int *)((char *)r + 0xb0);
@@ -29,5 +32,4 @@ struct Actor *_ZN8CapEnemy15RespawnIfHasCapEv(unsigned char *c)
         *p &= ~0x10000000;
     }
     return r;
-}
 }

--- a/src/_ZN8CapEnemyD0Ev.c
+++ b/src/_ZN8CapEnemyD0Ev.c
@@ -1,12 +1,14 @@
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN8CapEnemyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11dCapEnemy_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN8CapEnemyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11dCapEnemy_c;
     func_ov001_020ab3a0((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/_ZN8CccArena6RenderEv.cpp
+++ b/src/_ZN8CccArena6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8CccArena6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "CccArena.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8CccArena6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int CccArena::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8CccArena8BehaviorEv.cpp
+++ b/src/_ZN8CccArena8BehaviorEv.cpp
@@ -1,23 +1,29 @@
 //cpp
+// @symbol _ZN8CccArena8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "CccArena.h"
 extern "C" {
-extern void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
-int _ZN8CccArena8BehaviorEv(char* c){
-  void* o = *(void**)(c+0x320);
+}
+
+int CccArena::Behavior()
+{
+  void* o = *(void**)((char*)&unk_320);
   if(*(int*)((char*)o+8)){
     char* base = (char*)o+8;
     int adj = *(int*)(base+4);
-    char* self = c + (adj>>1);
+    char* self = ((char*)this) + (adj>>1);
     void* fn;
     if(adj&1){ void* vt=*(void**)self; fn=*(void**)((char*)vt + *(int*)base); }
     else fn=*(void**)base;
     ((void(*)(char*))fn)(self);
   }
-  Matrix4x3_FromRotationXYZExt(c+0xf0, *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-  *(int*)(c+0x114) = *(int*)(c+0x5c) >> 3;
-  *(int*)(c+0x118) = *(int*)(c+0x60) >> 3;
-  *(int*)(c+0x11c) = *(int*)(c+0x64) >> 3;
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
+  Matrix4x3_FromRotationXYZExt(((char*)this)+0xf0, unk_08c, unk_08e, unk_090);
+  unk_114 = mPosX >> 3;
+  unk_118 = mPosY >> 3;
+  unk_11c = mPosZ >> 3;
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   return 1;
-}
 }

--- a/src/_ZN8CccArenaD0Ev.c
+++ b/src/_ZN8CccArenaD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8CccArenaD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjEwbIce_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8CccArenaD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjEwbIce_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8CccArenaD1Ev.c
+++ b/src/_ZN8CccArenaD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8CccArenaD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjEwbIce_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN8CccArenaD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjEwbIce_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8DockPole6RenderEv.cpp
+++ b/src/_ZN8DockPole6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8DockPole6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "DockPole.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8DockPole6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int DockPole::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8DockPole8BehaviorEv.cpp
+++ b/src/_ZN8DockPole8BehaviorEv.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN8DockPole8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "DockPole.h"
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void* c);
 extern void Matrix4x3_FromRotationY(void* m, short angle);
-int _ZN8DockPole8BehaviorEv(char* c){
-  _ZN9Animation7AdvanceEv(c+0x124);
-  Matrix4x3_FromRotationY(c+0xf0, *(short*)(c+0x8e));
-  *(int*)(c+0x114)=*(int*)(c+0x5c)>>3;
-  *(int*)(c+0x118)=*(int*)(c+0x60)>>3;
-  *(int*)(c+0x11c)=*(int*)(c+0x64)>>3;
-  return 1;
 }
+
+int DockPole::Behavior()
+{
+  _ZN9Animation7AdvanceEv((char*)&mAnimation);
+  Matrix4x3_FromRotationY(((char*)this)+0xf0, unk_08e);
+  unk_114=mPosX>>3;
+  unk_118=mPosY>>3;
+  unk_11c=mPosZ>>3;
+  return 1;
 }

--- a/src/_ZN8DockPoleD0Ev.c
+++ b/src/_ZN8DockPoleD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN8DockPoleD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10daMcFlag_c */
 extern void *G0;
 int *_ZN8DockPoleD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daMcFlag_c;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN8FireballD0Ev.c
+++ b/src/_ZN8FireballD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8FireballD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daFPknBall_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN8FireballD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daFPknBall_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN8FireballD1Ev.c
+++ b/src/_ZN8FireballD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8FireballD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8Fireball */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN8FireballD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8Fireball;
     _ZN11ShadowModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x110);

--- a/src/_ZN8Goomboss16CleanupResourcesEv.cpp
+++ b/src/_ZN8Goomboss16CleanupResourcesEv.cpp
@@ -1,21 +1,25 @@
 //cpp
+// @symbol _ZN8Goomboss16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Goomboss.h"
 extern "C" {
 int func_ov074_0212229c(int* c);
 void _ZN13SharedFilePtr7ReleaseEv(void* thiz);
 void UnloadKeyModels(int i);
 extern char data_ov002_0210da30;
 extern char data_ov084_02130cf8;
-extern void* data_ov074_0212292c[];
 extern char data_ov074_02123000;
-extern void* data_ov074_02122948[];
 extern char data_ov074_02123040;
+}
 
-int _ZN8Goomboss16CleanupResourcesEv(int* c)
+int Goomboss::CleanupResources()
 {
     int i;
-    int v = c[2];
+    int v = ((int*)this)[2];
     if (v == 0x1111) {
-        return func_ov074_0212229c(c);
+        return func_ov074_0212229c(((int*)this));
     }
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da30);
     UnloadKeyModels(2);
@@ -27,5 +31,4 @@ int _ZN8Goomboss16CleanupResourcesEv(int* c)
         _ZN13SharedFilePtr7ReleaseEv(data_ov074_02122948[i]);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov074_02123040);
     return 1;
-}
 }

--- a/src/_ZN8Goomboss6RenderEv.cpp
+++ b/src/_ZN8Goomboss6RenderEv.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol _ZN8Goomboss6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Goomboss.h"
 extern "C" {
-extern int func_ov074_021222e0(void* c);
 extern void _ZN15TextureSequence6UpdateER15ModelComponents(void* a, void* b);
 extern void _ZN15MaterialChanger6UpdateER15ModelComponents(void* a, void* b);
 extern void _ZN18TextureTransformer6UpdateER15ModelComponents(void* a, void* b);
@@ -9,13 +13,15 @@ struct Sub {
   virtual void v0(); virtual void v1(); virtual void v2();
   virtual void v3(); virtual void v4(); virtual void m(void*);
 };
-extern "C" int _ZN8Goomboss6RenderEv(char* c){
-  if(*(int*)(c+8)==0x1111) return func_ov074_021222e0(c);
-  if(*(unsigned char*)(c+0x60a)==0) return 1;
-  Sub* s = (Sub*)(c+0x210);
-  s->m(c+0x80);
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x3e4, c+0x218);
-  _ZN15MaterialChanger6UpdateER15ModelComponents(c+0x3d0, c+0x218);
-  _ZN18TextureTransformer6UpdateER15ModelComponents(c+0x3f8, c+0x218);
+
+int Goomboss::Render()
+{
+  if(mParam==0x1111) return func_ov074_021222e0(((char*)this));
+  if(unk_60a==0) return 1;
+  Sub* s = (Sub*)((char*)&mModelAnim);
+  s->m((char*)&mScaleX);
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x3e4, ((char*)this)+0x218);
+  _ZN15MaterialChanger6UpdateER15ModelComponents(((char*)this)+0x3d0, ((char*)this)+0x218);
+  _ZN18TextureTransformer6UpdateER15ModelComponents(((char*)this)+0x3f8, ((char*)this)+0x218);
   return 1;
 }

--- a/src/_ZN8GoombossD0Ev.c
+++ b/src/_ZN8GoombossD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8GoombossD0Ev
+/* recovered: named members + shared header */
+#include "Goomboss.h"
 extern int func_0207328c(void* c, int a, int b, void* d);
 extern void* _ZTV8Goomboss[];
 extern void func_020072c0(void);
@@ -11,18 +14,17 @@ extern int _ZN9ModelAnimD1Ev(void* c);
 extern int func_ov002_020aed18(int* x);
 extern int data_020a0eac;
 extern int _ZN6Memory10DeallocateEPvP4Heap(void* p, void* h);
-int _ZN8GoombossD0Ev(void* c)
-{
-    *(void**)c = _ZTV8Goomboss;
-    _ZN12WithMeshClsnD1Ev((char*)c+0x40c);
-    _ZN18TextureTransformerD1Ev((char*)c+0x3f8);
-    _ZN15TextureSequenceD1Ev((char*)c+0x3e4);
-    _ZN15MaterialChangerD1Ev((char*)c+0x3d0);
-    func_0207328c((char*)c+0x3ac, 3, 0xc, (void*)func_020072c0);
-    func_0207328c((char*)c+0x274, 3, 0x28, (void*)_ZN11ShadowModelD1Ev);
-    _ZN9ModelAnimD1Ev((char*)c+0x210);
-    func_0207328c((char*)c+0x110, 4, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
-    func_ov002_020aed18((int*)c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, (void*)data_020a0eac);
-    return (int)c;
+int _ZN8GoombossD0Ev(struct Goomboss *self) {
+    *(void**)((void*)self) = _ZTV8Goomboss;
+    _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+    _ZN18TextureTransformerD1Ev((char*)&self->mTextureTransformer);
+    _ZN15TextureSequenceD1Ev((char*)&self->mTextureSequence);
+    _ZN15MaterialChangerD1Ev((char*)&self->mMaterialChanger);
+    func_0207328c((char*)((void*)self)+0x3ac, 3, 0xc, (void*)func_020072c0);
+    func_0207328c((char*)((void*)self)+0x274, 3, 0x28, (void*)_ZN11ShadowModelD1Ev);
+    _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+    func_0207328c((char*)((void*)self)+0x110, 4, 0x40, (void*)_ZN25MovingCylinderClsnWithPosD1Ev);
+    func_ov002_020aed18((int*)((void*)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((void*)self), (void*)data_020a0eac);
+    return (int)((void*)self);
 }

--- a/src/_ZN8GoombossD1Ev.c
+++ b/src/_ZN8GoombossD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8GoombossD1Ev
+/* recovered: named members + shared header */
+#include "Goomboss.h"
 extern int func_0207328c(void* p, int a, int b, void* d);
 extern void _ZN12WithMeshClsnD1Ev(void* p);
 extern void _ZN18TextureTransformerD1Ev(void* p);
@@ -9,16 +12,16 @@ extern int func_020072c0;
 extern int _ZN11ShadowModelD1Ev;
 extern int _ZN25MovingCylinderClsnWithPosD1Ev;
 extern int _ZTV8Goomboss[];
-int _ZN8GoombossD1Ev(int* c){
-  *(int**)c = _ZTV8Goomboss;
-  _ZN12WithMeshClsnD1Ev((char*)c+0x40c);
-  _ZN18TextureTransformerD1Ev((char*)c+0x3f8);
-  _ZN15TextureSequenceD1Ev((char*)c+0x3e4);
-  _ZN15MaterialChangerD1Ev((char*)c+0x3d0);
-  func_0207328c((char*)c+0x3ac, 3, 0xc, &func_020072c0);
-  func_0207328c((char*)c+0x274, 3, 0x28, &_ZN11ShadowModelD1Ev);
-  _ZN9ModelAnimD1Ev((char*)c+0x210);
-  func_0207328c((char*)c+0x110, 4, 0x40, &_ZN25MovingCylinderClsnWithPosD1Ev);
-  func_ov002_020aed18(c);
-  return (int)c;
+int _ZN8GoombossD1Ev(struct Goomboss *self) {
+  *(int**)((int*)self) = _ZTV8Goomboss;
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  _ZN18TextureTransformerD1Ev((char*)&self->mTextureTransformer);
+  _ZN15TextureSequenceD1Ev((char*)&self->mTextureSequence);
+  _ZN15MaterialChangerD1Ev((char*)&self->mMaterialChanger);
+  func_0207328c((char*)((int*)self)+0x3ac, 3, 0xc, &func_020072c0);
+  func_0207328c((char*)((int*)self)+0x274, 3, 0x28, &_ZN11ShadowModelD1Ev);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  func_0207328c((char*)((int*)self)+0x110, 4, 0x40, &_ZN25MovingCylinderClsnWithPosD1Ev);
+  func_ov002_020aed18(((int*)self));
+  return (int)((int*)self);
 }

--- a/src/_ZN8IceBlock13InitResourcesEv.cpp
+++ b/src/_ZN8IceBlock13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8IceBlock13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "IceBlock.h"
 typedef int Fix12i;
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* mb, void* f, int a, int b);
@@ -7,18 +12,16 @@ extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(char* c);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 extern "C" void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* sfp);
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(char* mmc, void* kcl, char* mtx, Fix12i s, short sh, void* clps);
-extern int data_ov081_02128fd8[];
-extern int data_ov081_02128fd0[];
-extern int data_ov002_0210d8d4[];
 
-extern "C" int _ZN8IceBlock13InitResourcesEv(char* c){
+int IceBlock::InitResources()
+{
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov081_02128fd8);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, 0x17);
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x320, c, 0xc8000, 0x12c000, 0x800002, 0x44000);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, 0x17);
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x320, ((char*)this), 0xc8000, 0x12c000, 0x800002, 0x44000);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   void* k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov081_02128fd0);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x1000, *(short*)(c+0x8e), data_ov002_0210d8d4);
-  *(int*)(c+0x358) = 0x1000;
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, k, ((char*)this)+0x2ec, 0x1000, unk_08e, data_ov002_0210d8d4);
+  mScale = 0x1000;
   return 1;
 }

--- a/src/_ZN8IceBlock6RenderEv.cpp
+++ b/src/_ZN8IceBlock6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN8IceBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "IceBlock.h"
 class Sub {
 public:
     virtual void F0();
@@ -9,12 +12,13 @@ public:
     virtual void F5(int* v);
 };
 
-extern "C" int _ZN8IceBlock6RenderEv(char *c) {
+int IceBlock::Render()
+{
     int v[3];
-    v[0] = *(int*)(c + 0x358);
-    v[1] = *(int*)(c + 0x358);
-    v[2] = *(int*)(c + 0x358);
-    Sub *sub = (Sub*)(c + 0xd4);
+    v[0] = mScale;
+    v[1] = mScale;
+    v[2] = mScale;
+    Sub *sub = (Sub*)((char *)&mModel);
     sub->F5(v);
     return 1;
 }

--- a/src/_ZN8IceBlock8BehaviorEv.cpp
+++ b/src/_ZN8IceBlock8BehaviorEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN8IceBlock8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "IceBlock.h"
 
 struct VObj {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -22,12 +26,11 @@ extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_
     unsigned int a, unsigned int b, int x, int y, int z, void* v, void* cb);
 extern void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
 extern void func_02012694(int a, void* p);
-extern void func_ov081_02127be0(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 }
 
-extern "C" int _ZN8IceBlock8BehaviorEv(char* c)
+int IceBlock::Behavior()
 {
     Vector3 v;
     int yo;
@@ -35,58 +38,58 @@ extern "C" int _ZN8IceBlock8BehaviorEv(char* c)
     char* p;
     unsigned int id;
 
-    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
+    _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char*)this), 0, 0);
 
-    if (*(unsigned char*)(c + 0x354) != 0) {
-        *(int*)(c + 0x358) = _ZN4cstd4fdivEii(*(unsigned char*)(c + 0x354) << 12, 0x1e000);
+    if (unk_354 != 0) {
+        mScale = _ZN4cstd4fdivEii(unk_354 << 12, 0x1e000);
 
-        if (DecIfAbove0_Byte((unsigned char*)(c + 0x354)) == 0) {
-            p = *(char**)(c + 0x364);
+        if (DecIfAbove0_Byte((unsigned char*)((char*)&unk_354)) == 0) {
+            p = *(char**)((char*)&unk_364);
             if (p != 0) {
                 if (*(unsigned short*)(p + 0xc) == 0xb2)
                     *(unsigned char*)(p + 0x49f) = 0;
             }
-            _ZN9ActorBase18MarkForDestructionEv(c);
+            _ZN9ActorBase18MarkForDestructionEv(((char*)this));
         } else {
-            ((int*)&v)[0] = *(int*)(c + 0x5c);
-            ((int*)&v)[1] = *(int*)(c + 0x60);
-            ((int*)&v)[2] = *(int*)(c + 0x64);
-            yo = (int)(((long long)*(int*)(c + 0x358) * 0x96000 + 0x800) >> 12);
+            ((int*)&v)[0] = mPosX;
+            ((int*)&v)[1] = mPosY;
+            ((int*)&v)[2] = mPosZ;
+            yo = (int)(((long long)mScale * 0x96000 + 0x800) >> 12);
             ((int*)&v)[1] = v.y + yo;
 
-            *(unsigned int*)(c + 0x35c) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-                *(unsigned int*)(c + 0x35c), 0x77, v.x, v.y, v.z, 0, 0);
-            *(unsigned int*)(c + 0x360) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-                *(unsigned int*)(c + 0x360), 0x78, v.x, v.y, v.z, 0, 0);
+            unk_35c = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                unk_35c, 0x77, v.x, v.y, v.z, 0, 0);
+            unk_360 = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+                unk_360, 0x78, v.x, v.y, v.z, 0, 0);
 
-            id = *(unsigned int*)(c + 0x35c);
+            id = unk_35c;
             if (id != 0) {
                 s = _ZN8Particle6System12FromUniqueIDEj(id);
                 if (s != 0)
-                    *(int*)((char*)s + 0x44) = *(int*)(c + 0x358) * 0xf;
+                    *(int*)((char*)s + 0x44) = mScale * 0xf;
             }
-            id = *(unsigned int*)(c + 0x360);
+            id = unk_360;
             if (id != 0) {
                 s = _ZN8Particle6System12FromUniqueIDEj(id);
                 if (s != 0)
-                    *(int*)((char*)s + 0x44) = *(int*)(c + 0x358) * 0xf;
+                    *(int*)((char*)s + 0x44) = mScale * 0xf;
             }
         }
         return 1;
     }
 
-    if (*(int*)(c + 0x344) != 0) {
-        if ((*(int*)(c + 0x340) & 0x40000) != 0) {
-            *(unsigned char*)(c + 0x354) = 0x1e;
-            func_02012694(0x7a, c + 0x74);
-            func_ov081_02127be0(c);
+    if (unk_344 != 0) {
+        if ((unk_340 & 0x40000) != 0) {
+            unk_354 = 0x1e;
+            func_02012694(0x7a, ((char*)this) + 0x74);
+            func_ov081_02127be0(((char*)this));
         }
-        if ((*(int*)(c + 0x340) & 0x4000) != 0) {
-            ((VObj*)c)->OnHit();
+        if ((unk_340 & 0x4000) != 0) {
+            ((VObj*)((char*)this))->OnHit();
         }
     }
 
-    _ZN12CylinderClsn5ClearEv(c + 0x320);
-    _ZN12CylinderClsn6UpdateEv(c + 0x320);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
     return 1;
 }

--- a/src/_ZN8IceBlockD0Ev.c
+++ b/src/_ZN8IceBlockD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8IceBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8IceBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjIceBlock_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceBlockD1Ev.c
+++ b/src/_ZN8IceBlockD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8IceBlockD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjIceBlock_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN8IceBlockD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjIceBlock_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceSheet6RenderEv.cpp
+++ b/src/_ZN8IceSheet6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8IceSheet6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "IceSheet.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8IceSheet6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int IceSheet::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8IceSheet8BehaviorEv.cpp
+++ b/src/_ZN8IceSheet8BehaviorEv.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol _ZN8IceSheet8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "IceSheet.h"
 extern "C" {
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
-int _ZN8IceSheet8BehaviorEv(char* c){
-  if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
-  return 1;
 }
+
+int IceSheet::Behavior()
+{
+  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&mMovingMeshCollider))
+    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  return 1;
 }

--- a/src/_ZN8IceSheetD0Ev.c
+++ b/src/_ZN8IceSheetD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8IceSheetD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjIceBoard_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8IceSheetD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjIceBoard_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8IceSheetD1Ev.c
+++ b/src/_ZN8IceSheetD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8IceSheetD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjIceBoard_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN8IceSheetD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjIceBoard_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8MadPiano6RenderEv.cpp
+++ b/src/_ZN8MadPiano6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8MadPiano6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MadPiano.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x320]; Base base; };
-extern "C" int _ZN8MadPiano6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int MadPiano::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8MadPiano8BehaviorEv.cpp
+++ b/src/_ZN8MadPiano8BehaviorEv.cpp
@@ -1,13 +1,14 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN8MadPiano8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "MadPiano.h"
 struct CylinderClsn;
-extern "C" int func_ov063_0211ddf4(void* c);
 extern "C" int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern "C" void func_020383fc(void* p);
 extern "C" void func_0203568c(void* p, int v);
 extern "C" void func_02035684(void* p, int v);
-extern "C" void func_ov063_0211d88c(char* t);
-extern "C" void func_ov063_0211d828(char* self);
 extern "C" void func_ov063_0211d5f4(void* self);
 
 struct Actor {
@@ -22,30 +23,30 @@ struct Platform {
   int IsClsnInRange(int, int);
 };
 
-extern "C" int _ZN8MadPiano8BehaviorEv(char* self)
+int MadPiano::Behavior()
 {
-  func_ov063_0211ddf4(self);
-  ((struct Actor*)self)->UpdatePos(0);
-  if (Vec3_HorzDist((struct Vector3*)(self+0x6d4), (struct Vector3*)(self+0x5c)) > 0x180000) {
-    *(int*)(self+0x5c) = *(int*)(self+0x68);
-    *(int*)(self+0x60) = *(int*)(self+0x6c);
-    *(int*)(self+0x64) = *(int*)(self+0x70);
+  func_ov063_0211ddf4(((char*)this));
+  ((struct Actor*)((char*)this))->UpdatePos(0);
+  if (Vec3_HorzDist((struct Vector3*)((char*)&unk_6d4), (struct Vector3*)((char*)&mPosX)) > 0x180000) {
+    mPosX = unk_068;
+    mPosY = unk_06c;
+    mPosZ = unk_070;
   }
   {
-    int r1 = *(int*)(self+0x6cc);
-    if (*(int*)(self+0x60) <= r1) *(int*)(self+0x60) = r1;
+    int r1 = unk_6cc;
+    if (mPosY <= r1) mPosY = r1;
   }
-  func_020383fc(self+0x50c);
-  func_0203568c(self+0x50c, 0x159000);
-  func_02035684(self+0x50c, 0x159000);
-  if (*(unsigned char*)((char*)((struct Actor*)self)->ClosestPlayer()+0x6fb) != 0) {
-    if (((struct MeshColliderBase*)(self+0x124))->IsEnabled() != 0)
-      ((struct MeshColliderBase*)(self+0x124))->Disable();
+  func_020383fc((char*)&mWithMeshClsn);
+  func_0203568c(((char*)this)+0x50c, 0x159000);
+  func_02035684(((char*)this)+0x50c, 0x159000);
+  if (*(unsigned char*)((char*)((struct Actor*)((char*)this))->ClosestPlayer()+0x6fb) != 0) {
+    if (((struct MeshColliderBase*)((char*)&mMeshCollider))->IsEnabled() != 0)
+      ((struct MeshColliderBase*)((char*)&mMeshCollider))->Disable();
   } else {
-    ((struct Platform*)self)->IsClsnInRange(0x1f4000, 0);
+    ((struct Platform*)((char*)this))->IsClsnInRange(0x1f4000, 0);
   }
-  func_ov063_0211d88c(self);
-  func_ov063_0211d828(self);
-  func_ov063_0211d5f4(self);
+  func_ov063_0211d88c(((char*)this));
+  func_ov063_0211d828(((char*)this));
+  func_ov063_0211d5f4(((char*)this));
   return 1;
 }

--- a/src/_ZN8MadPianoD0Ev.cpp
+++ b/src/_ZN8MadPianoD0Ev.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN8MadPianoD0Ev
+/* recovered: named members + shared header */
+#include "MadPiano.h"
 struct Heap;
 
 extern "C" void _ZN12WithMeshClsnD1Ev(void *thiz);

--- a/src/_ZN8MadPianoD1Ev.c
+++ b/src/_ZN8MadPianoD1Ev.c
@@ -1,24 +1,28 @@
+// @symbol _ZN8MadPianoD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+/* recovered: named members + shared header */
+#include "MadPiano.h"
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN12WithMeshClsnD1Ev(void*);
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void*);
-extern void _ZN11ShadowModelD1Ev(void*);
-extern void _ZN9ModelAnimD1Ev(void*);
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN5ModelD1Ev(void*);
-extern void _ZN5ActorD2Ev(void*);
 extern void* _ZTV8MadPiano;
 extern void* _ZTV17ExclamationSwitch;
-void* _ZN8MadPianoD1Ev(void* c) {
-  *(void**)c = &_ZTV8MadPiano;
-  _ZN12WithMeshClsnD1Ev((char*)c+0x50c);
-  func_0207328c((char*)c+0x48c, 2, 0x40, &_ZN25MovingCylinderClsnWithPosD1Ev);
-  _ZN11ShadowModelD1Ev((char*)c+0x3d4);
-  _ZN11ShadowModelD1Ev((char*)c+0x3ac);
-  _ZN11ShadowModelD1Ev((char*)c+0x384);
-  _ZN9ModelAnimD1Ev((char*)c+0x320);
-  *(void**)c = &_ZTV17ExclamationSwitch;
-  _ZN18MovingMeshColliderD1Ev((char*)c+0x124);
-  _ZN5ModelD1Ev((char*)c+0xd4);
-  _ZN5ActorD2Ev(c);
-  return c;
+void* _ZN8MadPianoD1Ev(struct MadPiano *self) {
+  *(void**)((void*)self) = &_ZTV8MadPiano;
+  _ZN12WithMeshClsnD1Ev((char*)&self->mWithMeshClsn);
+  func_0207328c((char*)((void*)self)+0x48c, 2, 0x40, &_ZN25MovingCylinderClsnWithPosD1Ev);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel3);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel2);
+  _ZN11ShadowModelD1Ev((char*)&self->mShadowModel1);
+  _ZN9ModelAnimD1Ev((char*)&self->mModelAnim);
+  *(void**)((void*)self) = &_ZTV17ExclamationSwitch;
+  _ZN18MovingMeshColliderD1Ev((char*)&self->mMeshCollider);
+  _ZN5ModelD1Ev((char*)&self->mModel);
+  _ZN5ActorD2Ev(((void*)self));
+  return ((void*)self);
 }

--- a/src/_ZN8MantaRay6RenderEv.cpp
+++ b/src/_ZN8MantaRay6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8MantaRay6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MantaRay.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x30c]; Base base; };
-extern "C" int _ZN8MantaRay6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int MantaRay::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8MantaRayD0Ev.c
+++ b/src/_ZN8MantaRayD0Ev.c
@@ -1,17 +1,19 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN8MantaRayD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MantaRay.h"
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int _ZTV8MantaRay[];
 extern void *data_020a0eac;
-int *_ZN8MantaRayD0Ev(int *t)
-{
-    t[0] = (int)_ZTV8MantaRay;
-    _ZN9ModelAnimD1Ev((char *)t + 0x30c);
-    _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);
-    func_ov002_020aed18(t);
-    _ZN6Memory10DeallocateEPvP4Heap(t, data_020a0eac);
-    return t;
+int *_ZN8MantaRayD0Ev(struct MantaRay *self) {
+    ((int *)self)[0] = (int)_ZTV8MantaRay;
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aed18(((int *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((int *)self), data_020a0eac);
+    return ((int *)self);
 }

--- a/src/_ZN8MantaRayD1Ev.c
+++ b/src/_ZN8MantaRayD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN8MantaRayD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MantaRay.h"
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int _ZTV8MantaRay[];
-int *_ZN8MantaRayD1Ev(int *t)
-{
-    t[0] = (int)_ZTV8MantaRay;
-    _ZN9ModelAnimD1Ev((char *)t + 0x30c);
-    _ZN12WithMeshClsnD1Ev((char *)t + 0x150);
-    _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x110);
-    func_ov002_020aed18(t);
-    return t;
+int *_ZN8MantaRayD1Ev(struct MantaRay *self) {
+    ((int *)self)[0] = (int)_ZTV8MantaRay;
+    _ZN9ModelAnimD1Ev((char *)&self->mModelAnim);
+    _ZN12WithMeshClsnD1Ev((char *)&self->mWithMeshClsn);
+    _ZN25MovingCylinderClsnWithPosD1Ev((char *)&self->mMovingCylinderClsnWithPos);
+    func_ov002_020aed18(((int *)self));
+    return ((int *)self);
 }

--- a/src/_ZN8Moneybag13InitResourcesEv.cpp
+++ b/src/_ZN8Moneybag13InitResourcesEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol _ZN8Moneybag13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Moneybag.h"
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
@@ -9,60 +13,57 @@ extern "C" int _ZN11ShadowModel12InitCylinderEv(void* self);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, int a, int b, unsigned int c, unsigned int d);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* actor, int a, int b, void* v, int c);
 extern "C" void _ZN12WithMeshClsn19StartDetectingWaterEv(void* self);
-extern "C" void func_ov081_0212777c(void* self, int a);
 extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround* self);
 extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* self, const Vector3& v, void* actor);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
-extern "C" void func_ov081_02126a20(char* self);
 extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround* self);
 
 struct Block48 { int w[12]; };
 
-extern void* data_ov081_02128ed4;
 extern int data_ov002_0210d9b8[];
-extern void* data_ov081_021280d8[4];
 extern Block48 data_02082128;
 
-extern "C" int _ZN8Moneybag13InitResourcesEv(char* c) {
+int Moneybag::InitResources()
+{
     RaycastGround rc;
     Vector3 pos;
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov081_02128ed4);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, 1);
-    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x138, (void*)data_ov002_0210d9b8[1], 1, 1) == 0)
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 1);
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x138, (void*)data_ov002_0210d9b8[1], 1, 1) == 0)
         return 0;
     for (int i = 0; i < 4; i++)
         _ZN9Animation8LoadFileER13SharedFilePtr(data_ov081_021280d8[i]);
-    if (_ZN11ShadowModel12InitCylinderEv(c + 0x188) == 0)
+    if (_ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel) == 0)
         return 0;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x1b0, c, 0x4b000, 0x73000, 0x200000, 0x6eff0);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x1e4, c, 0x4b000, 0x4b000, 0, 0);
-    _ZN12WithMeshClsn19StartDetectingWaterEv(c + 0x1e4);
-    func_ov081_0212777c(c, 0);
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x3c000;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this) + 0x1b0, ((char*)this), 0x4b000, 0x73000, 0x200000, 0x6eff0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this) + 0x1e4, ((char*)this), 0x4b000, 0x4b000, 0, 0);
+    _ZN12WithMeshClsn19StartDetectingWaterEv((char*)&mWithMeshClsn);
+    func_ov081_0212777c(((char*)this), 0);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
     {
         int p60;
-        pos.x = *(int*)(c + 0x5c);
-        p60 = *(int*)(c + 0x60);
+        pos.x = mPosX;
+        p60 = mPosY;
         pos.y = p60;
-        pos.z = *(int*)(c + 0x64);
+        pos.z = mPosZ;
         pos.y = p60 + 0x14000;
     }
     _ZN13RaycastGroundC1Ev(&rc);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rc, pos, 0);
     if (_ZN13RaycastGround10DetectClsnEv(&rc))
-        *(int*)(c + 0x60) = rc.floor[(0x44 - 0x14) / 4];
+        mPosY = rc.floor[(0x44 - 0x14) / 4];
     else
-        *(int*)(c + 0x60) = pos.y;
-    *(int*)(c + 0x80) = 0x1000;
-    *(int*)(c + 0x84) = 0x1000;
-    *(int*)(c + 0x88) = 0x1000;
-    *(int*)(c + 0x3d0) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x3d4) = *(int*)(c + 0x60);
-    *(int*)(c + 0x3d8) = *(int*)(c + 0x64);
-    *(unsigned char*)(c + 0x3f0) = 1;
-    *(Block48*)(c + 0x3a0) = data_02082128;
-    func_ov081_02126a20(c);
+        mPosY = pos.y;
+    mScaleX = 0x1000;
+    mScaleY = 0x1000;
+    mScaleZ = 0x1000;
+    unk_3d0 = mPosX;
+    unk_3d4 = mPosY;
+    unk_3d8 = mPosZ;
+    unk_3f0 = 1;
+    *(Block48*)((char*)&unk_3a0) = data_02082128;
+    func_ov081_02126a20(((char*)this));
     _ZN13RaycastGroundD1Ev(&rc);
     return 1;
 }

--- a/src/_ZN8Moneybag6RenderEv.cpp
+++ b/src/_ZN8Moneybag6RenderEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN8Moneybag6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Moneybag.h"
 struct Sub { virtual int v0(); virtual int v1(); virtual int v2(); virtual int v3(); virtual int v4(); virtual int m(void*); };
-extern "C" int _ZN8Moneybag6RenderEv(char* c){
-  bool b = *(int*)(c+0xb0) & 0x40000;
+
+int Moneybag::Render()
+{
+  bool b = unk_0b0 & 0x40000;
   if(b != 0) return 1;
-  if(*(unsigned char*)(c+0x3f0) > 1){ ((Sub*)(c+0xd4))->m(0); }
-  if(*(unsigned char*)(c+0x3f0) <= 0x1f){ ((Sub*)(c+0x138))->m(0); }
+  if(unk_3f0 > 1){ ((Sub*)((char*)&mModelAnim))->m(0); }
+  if(unk_3f0 <= 0x1f){ ((Sub*)((char*)&mModel))->m(0); }
   return 1;
 }

--- a/src/_ZN8MoneybagD0Ev.c
+++ b/src/_ZN8MoneybagD0Ev.c
@@ -1,15 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN8MoneybagD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daGmch_c */
 extern void *G0;
 int *_ZN8MoneybagD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daGmch_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1e4);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x1b0);
     _ZN11ShadowModelD1Ev((char *)t + 0x188);

--- a/src/_ZN8MugenBgm16CleanupResourcesEv.cpp
+++ b/src/_ZN8MugenBgm16CleanupResourcesEv.cpp
@@ -1,16 +1,21 @@
 //cpp
+// @symbol _ZN8MugenBgm16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "MugenBgm.h"
 extern "C" {
 int func_ov002_020f63a0(void* thiz);
 int func_ov002_020f23d0(void* c);
 }
 struct Obj { virtual void v00(); virtual void m04(); };
-extern "C" int _ZN8MugenBgm16CleanupResourcesEv(char* c){
-  int r1 = *(int*)(c + 8);
-  if (r1 == 0x2e) return func_ov002_020f63a0(c);
-  if (r1 == 0x2f) return func_ov002_020f23d0(c);
-  Obj* a = *(Obj**)(c + 0xdc);
+
+int MugenBgm::CleanupResources()
+{
+  int r1 = unk_008;
+  if (r1 == 0x2e) return func_ov002_020f63a0(((char*)this));
+  if (r1 == 0x2f) return func_ov002_020f23d0(((char*)this));
+  Obj* a = *(Obj**)((char*)&mModel);
   if (a) if (a) a->m04();
-  Obj* b = *(Obj**)(c + 0xe0);
+  Obj* b = *(Obj**)((char*)&unk_0e0);
   if (b) if (b) b->m04();
   return 1;
 }

--- a/src/_ZN8MugenBgmD0Ev.c
+++ b/src/_ZN8MugenBgmD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN8MugenBgmD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "MugenBgm.h"
 int *_ZN8MugenBgmD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
+++ b/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
@@ -1,42 +1,26 @@
 //cpp
+// @symbol _ZN8Particle10SysTracker10InitialiseEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Heap.h"
+#include "decl_Particle.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__SysTracker.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern "C" void* _ZN6Memory13operator_new2Ej(unsigned int sz);
-extern "C" int func_02045d10(void);
-extern "C" int func_02045cf0(void);
-extern "C" int func_02045ce0(void);
-extern "C" char* func_0204a4c8(char* (*alloc)(int), int a, int b, int c, unsigned short arg5);
-extern "C" char* func_02023178(int sz);
-extern "C" int func_0206e28c(const u8* a, const u8* b, u32 n);
-extern "C" void* _ZN6Memory8AllocateEj(unsigned int sz);
 extern "C" void DecompressLZ16(const void* src, void* dst);
-extern "C" void _ZN4CP1514FlushDataCacheEjj(unsigned int addr, unsigned int size);
-extern "C" void func_0204a17c(void* a, void* b);
-extern "C" int func_0204a0dc(void* thiz, u32 (*cb)(const void*, u32));
-extern "C" int func_0204a028(void* thiz, unsigned int (*cb)(unsigned int, unsigned int));
-extern "C" u32 _ZN4Heap7_SizeofEPv(void* heap, void* p);
-extern "C" void _ZN4Heap10ReallocateEPvj(void* heap, void* p, unsigned int sz);
 
-extern "C" u32 _ZN8Particle7Texture12AllocTexVramEjb(const void*, u32);
-extern "C" unsigned int _ZN8Particle7Texture12AllocPalVramEjb(unsigned int, unsigned int);
 
 extern signed char data_0209f2f8;
-extern void* data_0209ee80;
-extern void* data_0209ee78;
-extern void* data_0209ee7c;
-extern int data_0209ee88;
 extern int data_0209ee84;
 extern int data_0209ee8c;
-extern char data_02075f14[];
-extern unsigned char data_0208f668[];
 extern void* data_020a0ea0;
 
 #define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
 
-extern "C" void _ZN8Particle10SysTracker10InitialiseEv(char* self)
-{
+extern "C" void _ZN8Particle10SysTracker10InitialiseEv(struct Particle__SysTracker *self) {
     signed char v = data_0209f2f8;
     unsigned int allocSize = 0x8c00;
     int countA = 0x28;
@@ -60,28 +44,28 @@ extern "C" void _ZN8Particle10SysTracker10InitialiseEv(char* self)
     data_0209ee84 = func_02045cf0();
     data_0209ee8c = func_02045ce0();
 
-    *(char**)(self + 4) = func_0204a4c8(func_02023178, countA, countB, 0x1a, 0x3e);
-    *(int*)(*(char**)(self + 4) + 0x30) = 0x8000;
+    *(char**)((char*)&self->unk_004) = func_0204a4c8(func_02023178, countA, countB, 0x1a, 0x3e);
+    *(int*)(*(char**)((char*)&self->unk_004) + 0x30) = 0x8000;
 
     if (func_0206e28c((u8*)data_02075f14, data_0208f668, 4) != 0) {
-        *(char**)self = data_02075f14;
+        *(char**)((char*)self) = data_02075f14;
     } else {
         char* hdr = (char*)(int)M(data_02075f14);
         unsigned int size = (unsigned int)M(*(unsigned int*)(hdr + 4) >> 8);
         void* dst = _ZN6Memory8AllocateEj(size);
         DecompressLZ16(hdr + 4, dst);
         _ZN4CP1514FlushDataCacheEjj((unsigned int)dst, size);
-        *(void**)self = dst;
+        *(void**)((char*)self) = dst;
     }
 
-    func_0204a17c(*(char**)(self + 4), *(char**)self);
-    func_0204a0dc(*(void**)(self + 4), _ZN8Particle7Texture12AllocTexVramEjb);
-    func_0204a028(*(void**)(self + 4), _ZN8Particle7Texture12AllocPalVramEjb);
+    func_0204a17c(*(char**)((char*)&self->unk_004), *(char**)((char*)self));
+    func_0204a0dc(*(void**)((char*)&self->unk_004), _ZN8Particle7Texture12AllocTexVramEjb);
+    func_0204a028(*(void**)((char*)&self->unk_004), _ZN8Particle7Texture12AllocPalVramEjb);
 
-    if (*(char**)self != data_02075f14) {
+    if (*(char**)((char*)self) != data_02075f14) {
         void* heap = (void*)(int)M(data_020a0ea0);
-        unsigned int oldSize = (unsigned int)M(*(unsigned int*)(*(char**)self + 0x18));
-        _ZN4Heap7_SizeofEPv(heap, *(void**)self);
-        _ZN4Heap10ReallocateEPvj(heap, *(void**)self, oldSize);
+        unsigned int oldSize = (unsigned int)M(*(unsigned int*)(*(char**)((char*)self) + 0x18));
+        _ZN4Heap7_SizeofEPv(heap, *(void**)((char*)self));
+        _ZN4Heap10ReallocateEPvj(heap, *(void**)((char*)self), oldSize);
     }
 }

--- a/src/_ZN8Particle10SysTracker6UpdateEv.c
+++ b/src/_ZN8Particle10SysTracker6UpdateEv.c
@@ -1,6 +1,9 @@
-extern int func_02021bec(void* p);
-extern int func_02049f58(void* p);
-void _ZN8Particle10SysTracker6UpdateEv(void* c) {
-    func_02021bec((char*)c + 8);
-    func_02049f58(*(void**)((char*)c + 4));
+// @symbol _ZN8Particle10SysTracker6UpdateEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__SysTracker.h"
+void _ZN8Particle10SysTracker6UpdateEv(struct Particle__SysTracker *self) {
+    func_02021bec((char*)&self->unk_008);
+    func_02049f58(*(void**)((char*)&self->unk_004));
 }

--- a/src/_ZN8Particle10SysTrackerC1Ev.c
+++ b/src/_ZN8Particle10SysTrackerC1Ev.c
@@ -1,67 +1,60 @@
-extern void func_02021c90(char *c);
-extern void _ZN8Particle14SimpleCallbackC2Ev(char *c);
-extern void func_020226a4(char *p);
-extern void func_020225fc(char *thiz);
+// @symbol _ZN8Particle10SysTrackerC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Particle.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle.h"
 
-extern char data_0208f3e4[];
-extern char data_0208f3a4[];
-extern char data_0208f444[];
 extern char data_0208f3b4[];
-extern char data_0208f3f4[];
-extern char data_0208f424[];
-extern char data_0208f454[];
-extern char data_0208f404[];
-extern char data_0208f434[];
-extern char data_0208f464[];
 extern void *data_0209ee74;
 
-void *_ZN8Particle10SysTrackerC1Ev(char *self) {
-    func_02021c90(self + 8);
-    _ZN8Particle14SimpleCallbackC2Ev(self + 0x754);
-    _ZN8Particle14SimpleCallbackC2Ev(self + 0x760);
-    func_020226a4(self + 0x76c);
-    *(void **)(self + 0x76c) = data_0208f3e4;
-    func_020226a4(self + 0x778);
-    *(void **)(self + 0x778) = data_0208f3e4;
-    func_020226a4(self + 0x784);
-    *(void **)(self + 0x784) = data_0208f3a4;
-    func_020226a4(self + 0x790);
-    *(void **)(self + 0x790) = data_0208f444;
-    _ZN8Particle14SimpleCallbackC2Ev(self + 0x79c);
-    _ZN8Particle14SimpleCallbackC2Ev(self + 0x7a8);
-    func_020225fc(self + 0x7b4);
-    func_020225fc(self + 0x7c4);
-    func_020225fc(self + 0x7d4);
-    func_020225fc(self + 0x7e4);
-    *(volatile void **)(self + 0x7f0) = data_0208f3b4;
-    *(volatile void **)(self + 0x7f0) = data_0208f3f4;
-    *(volatile void **)(self + 0x7f4) = data_0208f3b4;
-    *(volatile void **)(self + 0x7f4) = data_0208f424;
-    *(volatile void **)(self + 0x7f8) = data_0208f3b4;
-    *(volatile void **)(self + 0x7f8) = data_0208f454;
-    *(int *)(self + 0x7fc) = 0x3000;
-    *(volatile void **)(self + 0x800) = data_0208f3b4;
-    *(volatile void **)(self + 0x800) = data_0208f454;
-    *(int *)(self + 0x804) = 0x3000;
-    func_020226a4(self + 0x808);
-    *(void **)(self + 0x808) = data_0208f404;
-    *(volatile void **)(self + 0x810) = data_0208f3b4;
-    *(volatile void **)(self + 0x810) = data_0208f434;
-    *(unsigned char *)(self + 0x814) = 1;
-    *(volatile void **)(self + 0x818) = data_0208f3b4;
-    *(volatile void **)(self + 0x818) = data_0208f464;
-    data_0209ee74 = self;
-    *(int *)(self + 4) = 0;
-    *(int *)(self + 0x750) = 0;
-    *(int *)(self + 0x75c) = 0;
-    *(int *)(self + 0x768) = 0;
-    *(int *)(self + 0x774) = 0;
-    *(int *)(self + 0x780) = 0;
-    *(int *)(self + 0x78c) = 0;
-    *(int *)(self + 0x798) = 0;
-    *(int *)(self + 0x7a4) = 0;
-    *(int *)(self + 0x7b0) = 0;
-    *(int *)(self + 0x7c0) = 0;
-    *(int *)(self + 0x804) = 0x4b000;
-    return self;
+void *_ZN8Particle10SysTrackerC1Ev(struct Particle *self) {
+    func_02021c90((char *)&self->unk_008);
+    _ZN8Particle14SimpleCallbackC2Ev((char *)&self->mParticle1);
+    _ZN8Particle14SimpleCallbackC2Ev((char *)&self->mParticle2);
+    func_020226a4((char *)&self->unk_76c);
+    *(void **)((char *)&self->unk_76c) = data_0208f3e4;
+    func_020226a4((char *)&self->unk_778);
+    *(void **)((char *)&self->unk_778) = data_0208f3e4;
+    func_020226a4((char *)&self->unk_784);
+    *(void **)((char *)&self->unk_784) = data_0208f3a4;
+    func_020226a4((char *)&self->unk_790);
+    *(void **)((char *)&self->unk_790) = data_0208f444;
+    _ZN8Particle14SimpleCallbackC2Ev((char *)&self->mParticle3);
+    _ZN8Particle14SimpleCallbackC2Ev((char *)&self->mParticle4);
+    func_020225fc((char *)&self->unk_7b4);
+    func_020225fc((char *)&self->unk_7c4);
+    func_020225fc((char *)&self->unk_7d4);
+    func_020225fc((char *)&self->unk_7e4);
+    *(volatile void **)((char *)&self->unk_7f0) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_7f0) = data_0208f3f4;
+    *(volatile void **)((char *)&self->unk_7f4) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_7f4) = data_0208f424;
+    *(volatile void **)((char *)&self->unk_7f8) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_7f8) = data_0208f454;
+    self->unk_7fc = 0x3000;
+    *(volatile void **)((char *)&self->unk_800) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_800) = data_0208f454;
+    self->unk_804 = 0x3000;
+    func_020226a4((char *)&self->unk_808);
+    *(void **)((char *)&self->unk_808) = data_0208f404;
+    *(volatile void **)((char *)&self->unk_810) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_810) = data_0208f434;
+    self->unk_814 = 1;
+    *(volatile void **)((char *)&self->unk_818) = data_0208f3b4;
+    *(volatile void **)((char *)&self->unk_818) = data_0208f464;
+    data_0209ee74 = ((char *)self);
+    self->unk_004 = 0;
+    self->unk_750 = 0;
+    self->unk_75c = 0;
+    self->unk_768 = 0;
+    self->unk_774 = 0;
+    self->unk_780 = 0;
+    self->unk_78c = 0;
+    self->unk_798 = 0;
+    self->unk_7a4 = 0;
+    self->unk_7b0 = 0;
+    self->unk_7c0 = 0;
+    self->unk_804 = 0x4b000;
+    return ((char *)self);
 }

--- a/src/_ZN8Particle10SysTrackerD1Ev.cpp
+++ b/src/_ZN8Particle10SysTrackerD1Ev.cpp
@@ -1,21 +1,21 @@
 //cpp
-extern "C" void func_02021b98(void *base);
+// @symbol _ZN8Particle10SysTrackerD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle.h"
 extern "C" void func_0203cbc0(void *p);
-extern "C" void _ZN6Memory10DeallocateEPv(void *p);
-extern void *data_0209ee80;
-extern char data_02075f14[];
 extern void *data_0209ee74;
 
-extern "C" void *_ZN8Particle10SysTrackerD1Ev(char *thiz)
-{
+extern "C" void *_ZN8Particle10SysTrackerD1Ev(struct Particle *self) {
     if (data_0209ee80 != 0) {
-        func_02021b98(thiz + 8);
+        func_02021b98((char *)&self->unk_008);
         func_0203cbc0(data_0209ee80);
         data_0209ee80 = 0;
     }
-    if (*(void **)thiz != (void *)data_02075f14) {
-        _ZN6Memory10DeallocateEPv(*(void **)thiz);
+    if (*(void **)((char *)self) != (void *)data_02075f14) {
+        _ZN6Memory10DeallocateEPv(*(void **)((char *)self));
     }
     data_0209ee74 = 0;
-    return thiz;
+    return ((char *)self);
 }

--- a/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol _ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3
+/* recovered: named members + shared header */
+#include "Particle__Acceleration.h"
 extern "C" {
-void _ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3(char* ed, char* p, int* vec){
-  vec[0] += (int)*(short*)(ed+0);
-  *(int*)(((long long)(int)(vec+1)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+2);
-  *(int*)(((long long)(int)(vec+2)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+4);
+void _ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Acceleration *self, char* p, int* vec) {
+  vec[0] += (int)self->unk_000;
+  *(int*)(((long long)(int)(vec+1))) += (int)self->unk_002;
+  *(int*)(((long long)(int)(vec+2))) += (int)self->unk_004;
 }
 }

--- a/src/_ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol _ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3
+/* recovered: named members + shared header */
+#include "Particle__RadiusConverge.h"
 extern "C" {
-void _ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3(char* ed, char* p, int* vec){
-  *(int*)(((long long)(int)(p+0x14)) & 0xFFFFFFFFFFFFFFFFLL) += (int)((((long long)*(short*)(ed+0xc) * (*(int*)(ed+0) - *(int*)(p+0x14))) + 0x800) >> 12);
-  *(int*)(((long long)(int)(p+0x18)) & 0xFFFFFFFFFFFFFFFFLL) += (int)((((long long)*(short*)(ed+0xc) * (*(int*)(ed+4) - *(int*)(p+0x18))) + 0x800) >> 12);
-  *(int*)(((long long)(int)(p+0x1c)) & 0xFFFFFFFFFFFFFFFFLL) += (int)((((long long)*(short*)(ed+0xc) * (*(int*)(ed+8) - *(int*)(p+0x1c))) + 0x800) >> 12);
+void _ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__RadiusConverge *self, char* p, int* vec) {
+  *(int*)(((long long)(int)(p+0x14))) += (int)((((long long)self->unk_00c * (self->unk_000 - *(int*)(p+0x14))) + 0x800) >> 12);
+  *(int*)(((long long)(int)(p+0x18))) += (int)((((long long)self->unk_00c * (self->unk_004 - *(int*)(p+0x18))) + 0x800) >> 12);
+  *(int*)(((long long)(int)(p+0x1c))) += (int)((((long long)self->unk_00c * (self->unk_008 - *(int*)(p+0x1c))) + 0x800) >> 12);
 }
 }

--- a/src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.cpp
@@ -1,6 +1,8 @@
 //cpp
-extern "C" int _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb(char *self, char *sys)
-{
-    *(short *)(self + 4) = *(short *)(sys + 0x3a);
+// @symbol _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb
+/* recovered: named members + shared header */
+#include "Particle__SimpleCallback.h"
+extern "C" int _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb(struct Particle__SimpleCallback *self, char *sys) {
+    self->unk_004 = *(short *)(sys + 0x3a);
     return 1;
 }

--- a/src/_ZN8Particle14SimpleCallbackC2Ev.cpp
+++ b/src/_ZN8Particle14SimpleCallbackC2Ev.cpp
@@ -1,10 +1,12 @@
 //cpp
+// @symbol _ZN8Particle14SimpleCallbackC2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle.h"
 extern void *data_0208f3b4;
-extern void *data_0208f3c4;
-extern "C" void _ZN8Particle14SimpleCallbackC2Ev(char *p);
-extern "C" void _ZN8Particle14SimpleCallbackC2Ev(char *p)
-{
-    *(void **)p = &data_0208f3b4;
-    *(void **)p = &data_0208f3c4;
-    *(short *)(p + 4) = 0;
+extern "C" void _ZN8Particle14SimpleCallbackC2Ev(struct Particle *self) {
+    *(void **)((char *)self) = &data_0208f3b4;
+    *(void **)((char *)self) = &data_0208f3c4;
+    *(short *)((char *)&self->unk_004) = 0;
 }

--- a/src/_ZN8Particle19SetSelfDestructFlagEj.c
+++ b/src/_ZN8Particle19SetSelfDestructFlagEj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8Particle19SetSelfDestructFlagEj
+/* recovered: named members + shared header */
+#include "Particle.h"
 typedef unsigned int u32;
 extern char* data_0209ee74;
 void _ZN8Particle19SetSelfDestructFlagEj(u32 idx)

--- a/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
+++ b/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
@@ -1,8 +1,12 @@
+// @symbol _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle.h"
 typedef signed int s32;
 typedef unsigned int u32;
 typedef s32 Fix12i;
 
-extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,

--- a/src/_ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE.c
+++ b/src/_ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE
+/* recovered: named members + shared header */
+#include "Particle__EndingStarGlitterCallback.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef int s32;
@@ -28,18 +31,17 @@ struct StarGlitterSystem {
 
 extern void _ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE(void* cb, struct StarGlitterSystem* sys);
 
-void _ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE(void* cb, struct StarGlitterSystem* sys)
-{
+void _ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE(struct Particle__EndingStarGlitterCallback *self, struct StarGlitterSystem* sys) {
     void** p;
     u32 ip;
     s16 val;
 
     p  = (void**)sys->ptr18;
-    ip = *(u32*)((char*)cb + 0x308);
+    ip = *(u32*)((char*)&self->unk_308);
     ((u32*)*p)[1] = ip;
 
-    val = *(s16*)((char*)cb + 0x30c);
+    val = *(s16*)((char*)&self->unk_30c);
     sys->unk48 = val;
 
-    _ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE(cb, sys);
+    _ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE(((void*)self), sys);
 }

--- a/src/_ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb.c
@@ -1,13 +1,16 @@
+// @symbol _ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__EndingStarGlitterCallback.h"
 typedef signed int s32;
 typedef unsigned int u32;
 typedef int Bool;
 
 /* forward declarations */
-extern void func_02022260(void);
 
 extern int _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb(void* cb, void* sys, Bool active);
 
-extern void func_0204dab4(void* sys, void* buf, u32 count, u32 mask, void* fnptr);
 
 int _ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb(void* cb, void* sys, Bool active)
 {

--- a/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,28 +1,31 @@
 //cpp
+// @symbol _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__Jitter.h"
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
-extern "C" u32 data_020a4d30;
-extern "C" void _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3(char* e, char* p, int* v)
-{
+extern "C" void _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Jitter *self, char* p, int* v) {
     u32 s;
     int r;
     int amp;
-    if ((int)*(u16*)(p + 0x2e) % (int)*(u16*)(e + 6) != 0)
+    if ((int)*(u16*)(p + 0x2e) % (int)self->unk_006 != 0)
         return;
     s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
     data_020a4d30 = s;
-    amp = *(s16*)(e + 0);
+    amp = self->unk_000;
     r = s >> 23;
     v[0] += (amp * r - (amp << 8)) >> 8;
     s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
     data_020a4d30 = s;
-    amp = *(s16*)(e + 2);
+    amp = self->unk_002;
     r = s >> 23;
-    *(int*)(((long long)(int)(v + 1)) & 0xFFFFFFFFFFFFFFFFLL) += (amp * r - (amp << 8)) >> 8;
+    *(int*)(((long long)(int)(v + 1))) += (amp * r - (amp << 8)) >> 8;
     s = data_020a4d30 * 0x5eedf715u + 0x1b0cb173u;
     data_020a4d30 = s;
-    amp = *(s16*)(e + 4);
+    amp = self->unk_004;
     r = s >> 23;
-    *(int*)(((long long)(int)(v + 2)) & 0xFFFFFFFFFFFFFFFFLL) += (amp * r - (amp << 8)) >> 8;
+    *(int*)(((long long)(int)(v + 2))) += (amp * r - (amp << 8)) >> 8;
 }

--- a/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
+++ b/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
@@ -1,30 +1,32 @@
+// @symbol _ZN8Particle7Manager9AddSystemEiR7Vector3
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__Manager.h"
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
-extern void* func_0204d958(void* p);
-extern void func_0204ae2c(void* o, void* p18, void* src3);
-extern void func_0204d9a0(void* a, void* b);
 
-int _ZN8Particle7Manager9AddSystemEiR7Vector3(char* self, int idx, void* v) {
+int _ZN8Particle7Manager9AddSystemEiR7Vector3(struct Particle__Manager *self, int idx, void* v) {
     int r4;
     char* sys;
     u32* p;
     u32 lo;
     r4 = 0;
-    if (*(int*)(self + 0xc) != 0) {
-        sys = (char*)func_0204d958(self + 0xc);
+    if (self->unk_00c != 0) {
+        sys = (char*)func_0204d958((char*)&self->unk_00c);
         r4 = (int)sys;
-        func_0204ae2c(sys, *(char**)(self + 0x1c) + idx * 0x20, v);
+        func_0204ae2c(sys, *(char**)((char*)&self->unk_01c) + idx * 0x20, v);
         p = (u32*)AT(sys, 0x74);
-        *p = (*p & ~0x3fu) | (*(u16*)(self + 0x2c) & 0x3f);
-        *p = (*p & ~0xfc0u) | ((*(u16*)(self + 0x2e) & 0x3f) << 6);
-        lo = (u32)(((long long)(int)(*(u32*)(sys + 0x74) << 26)) & 0xFFFFFFFFFFFFFFFFLL);
+        *p = (*p & ~0x3fu) | (self->unk_02c & 0x3f);
+        *p = (*p & ~0xfc0u) | ((self->unk_02e & 0x3f) << 6);
+        lo = (u32)(((long long)(int)(*(u32*)(sys + 0x74) << 26)));
         lo = lo >> 26;
-        *p = (*p & ~0x3f000u) | (((u32)(((long long)(int)lo) & 0xFFFFFFFFFFFFFFFFLL) & 0x3f) << 12);
+        *p = (*p & ~0x3f000u) | (((u32)(((long long)(int)lo)) & 0x3f) << 12);
         *p = *p & 0x3ffff;
-        func_0204d9a0(self + 4, sys);
+        func_0204d9a0(((char*)self) + 4, sys);
         if ((***(u32***)(sys + 0x18) << 17) >> 31) r4 = 0;
     }
     return r4;

--- a/src/_ZN8Particle7Texture12AllocPalVramEjb.c
+++ b/src/_ZN8Particle7Texture12AllocPalVramEjb.c
@@ -1,14 +1,17 @@
+// @symbol _ZN8Particle7Texture12AllocPalVramEjb
+/* recovered: named members + shared header */
+#include "Particle__Texture.h"
 extern unsigned int data_0209ee84;
 extern unsigned int data_0209ee8c;
 
-unsigned int _ZN8Particle7Texture12AllocPalVramEjb(unsigned int size, int b){
+unsigned int _ZN8Particle7Texture12AllocPalVramEjb(struct Particle__Texture *self, int b) {
   if (b) {
-    unsigned int a = (size + 7) & ~7;
+    unsigned int a = ((unsigned int)&self->unk_007) & ~7;
     unsigned int old = data_0209ee84;
     data_0209ee84 = old + a;
     return old;
   } else {
-    unsigned int a = (size + 0xf) & ~0xf;
+    unsigned int a = ((unsigned int)&self->unk_00f) & ~0xf;
     unsigned int v = data_0209ee8c - a;
     data_0209ee8c = v;
     return v;

--- a/src/_ZN8Particle7Texture12AllocTexVramEjb.c
+++ b/src/_ZN8Particle7Texture12AllocTexVramEjb.c
@@ -1,8 +1,12 @@
+// @symbol _ZN8Particle7Texture12AllocTexVramEjb
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Particle__Texture.h"
 typedef unsigned int u32;
 
-extern u32 _ZN5Model13GetVramOffsetEj(u32 size);
 
-extern u32 unk_0209ee88;
 
 u32 _ZN8Particle7Texture12AllocTexVramEjb(u32 size, int isTexel4x4) {
     if (isTexel4x4) {

--- a/src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol _ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3
+/* recovered: named members + shared header */
+#include "Particle__Converge.h"
 extern "C" {
-void _ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3(char* ed, char* p, int* vec){
-  vec[0] += (int)*(short*)(ed+0xc) * ((*(int*)(ed+0) - *(int*)(p+0x14)) - *(int*)(p+0x20)) >> 12;
-  *(int*)(((long long)(int)(vec+1)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+0xc) * ((*(int*)(ed+4) - *(int*)(p+0x18)) - *(int*)(p+0x24)) >> 12;
-  *(int*)(((long long)(int)(vec+2)) & 0xFFFFFFFFFFFFFFFFLL) += (int)*(short*)(ed+0xc) * ((*(int*)(ed+8) - *(int*)(p+0x1c)) - *(int*)(p+0x28)) >> 12;
+void _ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Converge *self, char* p, int* vec) {
+  vec[0] += (int)self->unk_00c * ((self->unk_000 - *(int*)(p+0x14)) - *(int*)(p+0x20)) >> 12;
+  *(int*)(((long long)(int)(vec+1))) += (int)self->unk_00c * ((self->unk_004 - *(int*)(p+0x18)) - *(int*)(p+0x24)) >> 12;
+  *(int*)(((long long)(int)(vec+2))) += (int)self->unk_00c * ((self->unk_008 - *(int*)(p+0x1c)) - *(int*)(p+0x28)) >> 12;
 }
 }

--- a/src/_ZN8PathLift9AfterClsnEv.cpp
+++ b/src/_ZN8PathLift9AfterClsnEv.cpp
@@ -1,19 +1,24 @@
 //cpp
+// @symbol _ZN8PathLift9AfterClsnEv
+/* recovered: named members + shared header, real C++ method */
+#include "PathLift.h"
 extern "C" {
 int func_ov002_020efedc(void *c);
 int DecIfAbove0_Byte(void *p);
 void func_02012694(int a, void *p);
 void func_ov002_020efa54(void *c, int a);
-void _ZN8PathLift9AfterClsnEv(char *c) {
-    if (func_ov002_020efedc(c) != 0 &&
-        *(int*)(c + 0x44c) == 0 &&
-        DecIfAbove0_Byte(c + 0x42b) == 0) {
-        int b = *(unsigned short *)(c + 0xc) == 0x1f;
-        if (b) {
-            func_02012694(0x6f, c + 0x74);
-        }
-        func_ov002_020efa54(c, 1);
-    }
-    *(unsigned char *)(c + 0x42a) = 1;
 }
+
+void PathLift::AfterClsn()
+{
+    if (func_ov002_020efedc(((char *)this)) != 0 &&
+        unk_44c == 0 &&
+        DecIfAbove0_Byte((char *)&unk_42b) == 0) {
+        int b = unk_00c == 0x1f;
+        if (b) {
+            func_02012694(0x6f, ((char *)this) + 0x74);
+        }
+        func_ov002_020efa54(((char *)this), 1);
+    }
+    unk_42a = 1;
 }

--- a/src/_ZN8PathLiftD0Ev.c
+++ b/src/_ZN8PathLiftD0Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8PathLiftD0Ev
+/* recovered: named members + shared header */
+#include "PathLift.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
@@ -6,13 +9,13 @@ extern int _ZN6Memory10DeallocateEPvP4Heap(void *p, void *h);
 extern int data_ov002_0210af70[];
 extern int _ZTV17ExclamationSwitch[];
 extern int *data_020a0eac;
-int _ZN8PathLiftD0Ev(char *c) {
-    *(int**)(c) = data_ov002_0210af70;
-    func_0207328c(c+0x320, 3, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    _ZN6Memory10DeallocateEPvP4Heap(c, data_020a0eac);
-    return (int)c;
+int _ZN8PathLiftD0Ev(struct PathLift *self) {
+    *(int**)(((char *)self)) = data_ov002_0210af70;
+    func_0207328c(((char *)self)+0x320, 3, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    _ZN6Memory10DeallocateEPvP4Heap(((char *)self), data_020a0eac);
+    return (int)((char *)self);
 }

--- a/src/_ZN8PathLiftD2Ev.c
+++ b/src/_ZN8PathLiftD2Ev.c
@@ -1,15 +1,18 @@
+// @symbol _ZN8PathLiftD2Ev
+/* recovered: named members + shared header */
+#include "PathLift.h"
 extern int func_0207328c(void *p, int a, int b, void *f);
 extern int _ZN5ModelD1Ev(void *p);
 extern int _ZN18MovingMeshColliderD1Ev(void *p);
 extern int _ZN5ActorD2Ev(void *p);
 extern int data_ov002_0210af70[];
 extern int _ZTV17ExclamationSwitch[];
-int _ZN8PathLiftD2Ev(char *c) {
-    *(int**)(c) = data_ov002_0210af70;
-    func_0207328c(c+0x320, 3, 0x50, _ZN5ModelD1Ev);
-    *(int**)(c) = _ZTV17ExclamationSwitch;
-    _ZN18MovingMeshColliderD1Ev(c+0x124);
-    _ZN5ModelD1Ev(c+0xd4);
-    _ZN5ActorD2Ev(c);
-    return (int)c;
+int _ZN8PathLiftD2Ev(struct PathLift *self) {
+    *(int**)(((char *)self)) = data_ov002_0210af70;
+    func_0207328c(((char *)self)+0x320, 3, 0x50, _ZN5ModelD1Ev);
+    *(int**)(((char *)self)) = _ZTV17ExclamationSwitch;
+    _ZN18MovingMeshColliderD1Ev((char *)&self->mMovingMeshCollider);
+    _ZN5ModelD1Ev((char *)&self->mModel);
+    _ZN5ActorD2Ev(((char *)self));
+    return (int)((char *)self);
 }

--- a/src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp
+++ b/src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp
@@ -1,28 +1,30 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN8Platform13IsClsnInRangeE5Fix12IiES1_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Platform.h"
 extern "C" {
 extern void* _ZN5Actor13ClosestPlayerEv(void*);
 extern int Vec3_Dist(void*, void*);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
-int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, int a, int b){
+int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(struct Platform *self, int a, int b) {
   struct Vector3 v;
-  v.x = *(int*)(c+0x5c);
-  v.y = *(int*)(c+0x60);
-  v.z = *(int*)(c+0x64);
-  if (a == 0) a = *(int*)(c+0xb8) << 3;
-  if (b == 0) v.y = v.y + *(int*)(c+0xb4);
+  v.x = self->mPosX;
+  v.y = self->mPosY;
+  v.z = self->mPosZ;
+  if (a == 0) a = self->unk_0b8 << 3;
+  if (b == 0) v.y = v.y + self->unk_0b4;
   else v.y = v.y + b;
-  void* p = _ZN5Actor13ClosestPlayerEv(c);
+  void* p = _ZN5Actor13ClosestPlayerEv(((char*)self));
   int d = Vec3_Dist(&v, (char*)p+0x5c);
   if (d > a) {
-    if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-      _ZN16MeshColliderBase7DisableEv(c+0x124);
+    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
     return 0;
   }
-  if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
+  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+    _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
   return 1;
 }
 }

--- a/src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp
+++ b/src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN8Platform19UpdateClsnPosAndRotEv
+/* recovered: named members + shared header, real C++ method */
+#include "Platform.h"
 extern "C" {
 struct M4 { int w[12]; };
 struct MMC { char p[0x124]; };
 struct Obj { char p[0x2ec]; M4 m; };
 int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
-void _ZN8Platform19UpdateClsnPosAndRotEv(char* self){
-    Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
-    *(int*)(self+0x310) = *(int*)(self+0x5c);
-    *(int*)(self+0x314) = *(int*)(self+0x60);
-    *(int*)(self+0x318) = *(int*)(self+0x64);
-    _ZN18MovingMeshCollider9TransformERK9Matrix4x3s((MMC*)(self+0x124), o->m, *(short*)(self+0x8e));
 }
+
+void Platform::UpdateClsnPosAndRot()
+{
+    Obj* o = (Obj*)((char*)this);
+    o->m = *(M4*)((char*)&unk_0f0);
+    unk_310 = mPosX;
+    unk_314 = mPosY;
+    unk_318 = mPosZ;
+    _ZN18MovingMeshCollider9TransformERK9Matrix4x3s((MMC*)((char*)&mMeshCollider), o->m, unk_08e);
 }

--- a/src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp
+++ b/src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp
@@ -1,39 +1,41 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Platform.h"
 extern "C" {
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern void* _ZN5Actor13ClosestPlayerEv(void*);
 extern int Vec3_Dist(void*, void*);
-int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(char* c, int a, int b){
-  int on = (*(int*)(c+0xb0) & 8) != 0;
+int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(struct Platform *self, int a, int b) {
+  int on = (self->unk_0b0 & 8) != 0;
   if (on) {
-    if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-      _ZN16MeshColliderBase7DisableEv(c+0x124);
+    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
     return 0;
   }
   if (a == 0) {
-    if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-      _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
+    if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+      _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
     goto done;
   }
   {
   struct Vector3 v;
-  v.x = *(int*)(c+0x5c);
-  v.y = *(int*)(c+0x60);
-  v.z = *(int*)(c+0x64);
-  if (b == 0) v.y = v.y + *(int*)(c+0xb4);
+  v.x = self->mPosX;
+  v.y = self->mPosY;
+  v.z = self->mPosZ;
+  if (b == 0) v.y = v.y + self->unk_0b4;
   else v.y = v.y + b;
-  void* p = _ZN5Actor13ClosestPlayerEv(c);
+  void* p = _ZN5Actor13ClosestPlayerEv(((char*)self));
   int d = Vec3_Dist(&v, (char*)p+0x5c);
   if (d > a) {
-    if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-      _ZN16MeshColliderBase7DisableEv(c+0x124);
+    if (_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+      _ZN16MeshColliderBase7DisableEv((char*)&self->mMeshCollider);
     return 0;
   }
-  if (!_ZN16MeshColliderBase9IsEnabledEv(c+0x124))
-    _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
+  if (!_ZN16MeshColliderBase9IsEnabledEv((char*)&self->mMeshCollider))
+    _ZN16MeshColliderBase6EnableEP5Actor(((char*)self)+0x124, ((char*)self));
   }
 done:
   return 1;

--- a/src/_ZN8PlatformC2Ev.c
+++ b/src/_ZN8PlatformC2Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN18MovingMeshColliderC1Ev(void *);
-extern int VT0[];
+// @symbol _ZN8PlatformC2Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17ExclamationSwitch */
+extern int _ZTV17ExclamationSwitch[];
 int *_ZN8PlatformC2Ev(int *t)
 {
     _ZN5ActorC2Ev(t);
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17ExclamationSwitch;
     _ZN5ModelC1Ev((char *)t + 0xd4);
     _ZN18MovingMeshColliderC1Ev((char *)t + 0x124);
     return t;

--- a/src/_ZN8PlatformD0Ev.c
+++ b/src/_ZN8PlatformD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN8PlatformD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8PlatformD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8PlatformD2Ev.c
+++ b/src/_ZN8PlatformD2Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol _ZN8PlatformD2Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV17ExclamationSwitch */
+extern int _ZTV17ExclamationSwitch[];
 int *_ZN8PlatformD2Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17ExclamationSwitch;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8PoleLift6RenderEv.cpp
+++ b/src/_ZN8PoleLift6RenderEv.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol _ZN8PoleLift6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PoleLift.h"
 struct Args { int a, b, c; };
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(Args*); };
 struct Derived { char pad[0xd8]; Base base; };
 extern "C" {
 extern int func_0203aad0(int *p);
-int _ZN8PoleLift6RenderEv(Derived *d) {
+}
+
+int PoleLift::Render()
+{
   Args s;
   s.a = 0x1000;
-  s.b = func_0203aad0((int*)((char*)d+0x158));
+  s.b = func_0203aad0((int*)((char*)&mCollider));
   s.c = 0x1000;
-  Base *b = &d->base; b->m(&s);
+  Base *b = &((Derived *)this)->base; b->m(&s);
   return 1;
-}
 }

--- a/src/_ZN8PoleLiftD0Ev.c
+++ b/src/_ZN8PoleLiftD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN21ExtendingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN8PoleLiftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ExtendingMeshCollider.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm2_Nobiru_c */
 extern void *G0;
 int *_ZN8PoleLiftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17daObjKm2_Nobiru_c;
     _ZN21ExtendingMeshColliderD1Ev((char *)t + 0x158);
     _ZN5ModelD1Ev((char *)t + 0xd8);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN8SaveData12ReadFileDataEjP12FileSaveData
+/* recovered: named members + shared header */
+#include "SaveData.h"
 typedef unsigned int u32;
 typedef int s32;
 
@@ -22,7 +25,7 @@ extern "C" int _ZN8SaveData12ReadFileDataEjP12FileSaveData(u32 fileID, struct Fi
         return 0;
     }
     {
-        int* p = (int*)(((long long)(int)(r5 + 0xc)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p = (int*)(((long long)(int)(r5 + 0xc)));
         *p = *p & *(int*)((char*)&data_0209caa0 + 0x48);
     }
     return 1;

--- a/src/_ZN8SaveData13GetCoinRecordEj.c
+++ b/src/_ZN8SaveData13GetCoinRecordEj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8SaveData13GetCoinRecordEj
+/* recovered: named members + shared header */
+#include "SaveData.h"
 /* SaveData::GetCoinRecord(u32 courseID) at 0x0201366c
  * Static method (no `this`); returns the saved coin count for a main level.
  * Reads SAVE_DATA.coinRecords[courseID] -- a u8 array. See Save.h:

--- a/src/_ZN8SaveData13SaveMinigamesEP16MinigameSaveData.c
+++ b/src/_ZN8SaveData13SaveMinigamesEP16MinigameSaveData.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8SaveData13SaveMinigamesEP16MinigameSaveData
+/* recovered: named members + shared header */
+#include "SaveData.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;

--- a/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
+++ b/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8SaveData14SaveDataToCartEPcjj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SaveData.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -13,7 +18,6 @@ extern "C" {
     int func_02060484(int a, int b, int c, int d, int e, int f);
 }
 
-extern u8 data_020a4b40[8];
 
 extern "C" int _ZN8SaveData14SaveDataToCartEPcjj(char* data, u32 size, u32 fileID)
 {

--- a/src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c
+++ b/src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c
@@ -1,3 +1,8 @@
+// @symbol _ZN8SaveData16ReadMinigameDataEP16MinigameSaveData
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_SaveData.h"
+/* recovered: named members + shared header */
+#include "SaveData.h"
 /* _ZN8SaveData16ReadMinigameDataEP16MinigameSaveData at 0x02013c0c
  * Reads minigame save data from cart. Returns 1 on success, 0 on failure/no data.
  */
@@ -8,7 +13,6 @@ typedef signed int s32;
 
 struct MinigameSaveData { char data[0x2e4]; };
 
-extern s32 _ZN8SaveData16ReadDataFromCartEPcjj(char* data, u32 size, u32 fileID);
 extern void _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData(struct MinigameSaveData* data);
 
 int _ZN8SaveData16ReadMinigameDataEP16MinigameSaveData(struct MinigameSaveData* dest)

--- a/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
+++ b/src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp
@@ -1,11 +1,20 @@
 //cpp
+// @symbol _ZN8SaveData16SetDefaultValuesEP12FileSaveData
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SaveData.h"
+struct FileSaveData;
 extern "C" {
-extern void* func_0205a588(void*, int, int);
-void _ZN8SaveData16SetDefaultValuesEP12FileSaveData(void* self, void* fsd){
-  func_0205a588(self, 0, 0x44);
-  *(int*)self = 0x30303038;
-  *(unsigned char*)((char*)self + 0x41) = 3;
-  *(int*)(((long long)(int)((char*)self + 8)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
-  *(unsigned char*)((char*)self + 0x42) = 0;
 }
+
+void SaveData::SetDefaultValues(FileSaveData * fsd_)
+{
+    void* fsd = (void*)fsd_;
+
+  func_0205a588(((void*)this), 0, 0x44);
+  *(int*)((void*)this) = 0x30303038;
+  *(unsigned char*)((char*)&unk_041) = 3;
+  *(int*)(((long long)(int)((char*)&unk_008))) |= 8;
+  *(unsigned char*)((char*)&unk_042) = 0;
 }

--- a/src/_ZN8SaveData17SetCharacterIntroEi.c
+++ b/src/_ZN8SaveData17SetCharacterIntroEi.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8SaveData17SetCharacterIntroEi
+/* recovered: named members + shared header */
+#include "SaveData.h"
 /* SaveData::SetCharacterIntro(s32 character) at 0x02013910
  * Static method (no `this`); marks an intro/flag bit as seen.
  * Sets bit `character` in the u32 SAVE_DATA.flags2 (the FileSaveData word at

--- a/src/_ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData.cpp
+++ b/src/_ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData.cpp
@@ -1,8 +1,17 @@
 //cpp
+// @symbol _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SaveData.h"
+struct MinigameSaveData;
 extern "C" {
-extern void* func_0205a588(void*, int, int);
-void _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData(void* self, void* mg){
-  func_0205a588(self, 0, 0x2e4);
-  *(int*)self = 0x30303035;
 }
+
+void SaveData::SetDefaultValuesMg(MinigameSaveData * mg_)
+{
+    void* mg = (void*)mg_;
+
+  func_0205a588(((void*)this), 0, 0x2e4);
+  *(int*)((void*)this) = 0x30303035;
 }

--- a/src/_ZN8SaveData19IsCharacterUnlockedEj.c
+++ b/src/_ZN8SaveData19IsCharacterUnlockedEj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8SaveData19IsCharacterUnlockedEj
+/* recovered: named members + shared header */
+#include "SaveData.h"
 /* SaveData::IsCharacterUnlocked(u32 character) at 0x0201392c
  * Static method (no `this`); returns nonzero if the character's bit is set.
  * Tests bit `character` in the u32 SAVE_DATA.flags2 (the FileSaveData word at

--- a/src/_ZN8SaveData21SetCoinRecordIfHigherEah.c
+++ b/src/_ZN8SaveData21SetCoinRecordIfHigherEah.c
@@ -1,4 +1,8 @@
-extern unsigned char data_0209cad2[];
+// @symbol _ZN8SaveData21SetCoinRecordIfHigherEah
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "SaveData.h"
 void _ZN8SaveData21SetCoinRecordIfHigherEah(int a, unsigned char b){
   if (b > data_0209cad2[a])
     data_0209cad2[a] = b;

--- a/src/_ZN8SaveData26CountStarsCollectedInLevelEj.c
+++ b/src/_ZN8SaveData26CountStarsCollectedInLevelEj.c
@@ -1,3 +1,6 @@
+// @symbol _ZN8SaveData26CountStarsCollectedInLevelEj
+/* recovered: named members + shared header */
+#include "SaveData.h"
 /* _ZN8SaveData26CountStarsCollectedInLevelEj at 0x02013768
  * Counts how many stars have been collected in a given course (0-7 stars).
  */

--- a/src/_ZN8ShipWing13InitResourcesEv.cpp
+++ b/src/_ZN8ShipWing13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8ShipWing13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ShipWing.h"
 extern "C" {
 int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
@@ -9,26 +14,24 @@ int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Bloc
 void func_020393d4(void* p, void* v);
 void func_020393c4(void* p, void* v);
 int _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void*,void*,int,int,int,int);
-extern int data_ov036_0211408c[];
-extern int data_ov036_02114084[];
-extern int data_ov036_02112b48[];
 extern void _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
-extern void func_ov036_02111cc4();
-int _ZN8ShipWing13InitResourcesEv(char* c){
-  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_0211408c);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov036_02114084);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x1000, *(short*)(c+0x8e), data_ov036_02112b48);
-  func_020393d4(c+0x124, (void*)_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  func_020393c4(c+0x124, (void*)func_ov036_02111cc4);
-  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c+0x320, c, 0x32000, 0x64000, 0, 0);
-  *(int*)(c+0xa0) = -0x1e000;
-  *(int*)(c+0x9c) = ~0x198;
-  *(int*)(c+0x4dc) = *(int*)(c+0x5c);
-  *(int*)(c+0x4e0) = *(int*)(c+0x60);
-  *(int*)(c+0x4e4) = *(int*)(c+0x64);
-  return 1;
 }
+
+int ShipWing::InitResources()
+{
+  int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov036_0211408c);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, -1);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov036_02114084);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, k, ((char*)this)+0x2ec, 0x1000, unk_08e, data_ov036_02112b48);
+  func_020393d4(((char*)this)+0x124, (void*)_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  func_020393c4(((char*)this)+0x124, (void*)func_ov036_02111cc4);
+  _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char*)this)+0x320, ((char*)this), 0x32000, 0x64000, 0, 0);
+  unk_0a0 = -0x1e000;
+  unk_09c = ~0x198;
+  unk_4dc = mPosX;
+  unk_4e0 = mPosY;
+  unk_4e4 = mPosZ;
+  return 1;
 }

--- a/src/_ZN8ShipWing6RenderEv.cpp
+++ b/src/_ZN8ShipWing6RenderEv.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol _ZN8ShipWing6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ShipWing.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8ShipWing6RenderEv(Derived *d) {
-  if(*(unsigned char*)((char*)d+0x4ea)!=2){
-    Base *b = &d->base; b->m(0);
+
+int ShipWing::Render()
+{
+  if(*(unsigned char*)((char*)&mState)!=2){
+    Base *b = &((Derived *)this)->base; b->m(0);
   }
   return 1;
 }

--- a/src/_ZN8ShipWingD0Ev.c
+++ b/src/_ZN8ShipWingD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8ShipWingD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8ShipWingD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjRc_Tikuwa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8ShipWingD1Ev.c
+++ b/src/_ZN8ShipWingD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8ShipWingD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjRc_Tikuwa_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN8ShipWingD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjRc_Tikuwa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SignPost13InitResourcesEv.cpp
+++ b/src/_ZN8SignPost13InitResourcesEv.cpp
@@ -1,12 +1,14 @@
 //cpp
+// @symbol _ZN8SignPost13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SignPost.h"
 struct BMD_File; struct KCL_File; struct Actor; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr; struct Vector3_16;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
 struct ShadowModel { void InitCuboid(); };
 struct Platform { void UpdateModelPosAndRotY(); void UpdateClsnPosAndRot(); };
-extern "C" void func_ov002_020baf80(char *t);
-extern "C" void *MeshColliderLoadFile(void *fp);
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, int fix, short sh, CLPS_Block &b);
 };
@@ -26,50 +28,48 @@ struct RaycastGround {
     int DetectClsn();
     ~RaycastGround();
 };
-extern "C" char data_ov002_0210e064;
-extern "C" char data_ov002_0210e05c;
 extern "C" CLPS_Block data_ov002_0210d714;
 
 struct V3 { int x, y, z; };
 
-extern "C" int _ZN8SignPost13InitResourcesEv(char *self)
+int SignPost::InitResources()
 {
     void *mf = ModelLoadFile(&data_ov002_0210e064);
-    ((ModelBase*)(self + 0xd4))->SetFile((BMD_File*)mf, 1, -1);
-    ((ShadowModel*)(self + 0x358))->InitCuboid();
+    ((ModelBase*)((char *)&mModel))->SetFile((BMD_File*)mf, 1, -1);
+    ((ShadowModel*)((char *)&mShadowModel))->InitCuboid();
 
-    int py = *(int*)(self + 0x60);
-    int pz = *(int*)(self + 0x64);
-    int px = *(int*)(self + 0x5c);
+    int py = mPosY;
+    int pz = mPosZ;
+    int px = mPosX;
     int py2 = py + 0x64000;
     V3 v = { px, py2, pz };
     RaycastGround rg;
     rg.SetObjAndPos(*(Vector3*)&v, (Actor*)0);
     if (rg.DetectClsn() != 0)
-        *(int*)(self + 0x60) = rg.result;
+        mPosY = rg.result;
 
-    ((Platform*)self)->UpdateModelPosAndRotY();
-    ((Platform*)self)->UpdateClsnPosAndRot();
-    func_ov002_020baf80(self);
+    ((Platform*)((char *)this))->UpdateModelPosAndRotY();
+    ((Platform*)((char *)this))->UpdateClsnPosAndRot();
+    func_ov002_020baf80(((char *)this));
 
     void *kf = MeshColliderLoadFile(&data_ov002_0210e05c);
-    ((MovingMeshCollider*)(self + 0x124))->SetFile((KCL_File*)kf,
-        *(Matrix4x3*)(self + 0x2ec), 0x199, *(short*)(self + 0x8e), data_ov002_0210d714);
+    ((MovingMeshCollider*)((char *)&mMeshCollider))->SetFile((KCL_File*)kf,
+        *(Matrix4x3*)((char *)&unk_2ec), 0x199, unk_08e, data_ov002_0210d714);
 
-    ((MovingCylinderClsn*)(self + 0x320))->Init((Actor*)self, 0x64000, 0x64000, 0x4800002, 0x41000);
+    ((MovingCylinderClsn*)((char *)&mMovingCylinderClsn))->Init((Actor*)((char *)this), 0x64000, 0x64000, 0x4800002, 0x41000);
 
-    *(char*)(self + 0x58e) = 2;
-    *(int*)(self + 0x3b0) = *(int*)(self + 0x5c);
-    *(int*)(self + 0x3b4) = *(int*)(self + 0x60);
-    *(int*)(self + 0x3b8) = *(int*)(self + 0x64);
-    *(short*)(self + 0x3bc) = *(short*)(self + 0x8c);
-    *(short*)(self + 0x3be) = *(short*)(self + 0x8e);
-    *(short*)(self + 0x3c0) = *(short*)(self + 0x90);
-    *(int*)(self + 0x9c) = -0x2000;
-    *(int*)(self + 0xa0) = -0x3c000;
+    unk_58e = 2;
+    unk_3b0 = mPosX;
+    unk_3b4 = mPosY;
+    unk_3b8 = mPosZ;
+    unk_3bc = unk_08c;
+    unk_3be = unk_08e;
+    unk_3c0 = unk_090;
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
 
-    ((WithMeshClsn*)(self + 0x3c8))->Init((Actor*)self, 0x28000, 0x28000, (Vector3_16*)0, 0);
-    ((WithMeshClsn*)(self + 0x3c8))->StartDetectingWater();
+    ((WithMeshClsn*)((char *)&mWithMeshClsn))->Init((Actor*)((char *)this), 0x28000, 0x28000, (Vector3_16*)0, 0);
+    ((WithMeshClsn*)((char *)&mWithMeshClsn))->StartDetectingWater();
 
     return 1;
 }

--- a/src/_ZN8SignPost6RenderEv.cpp
+++ b/src/_ZN8SignPost6RenderEv.cpp
@@ -1,21 +1,27 @@
 //cpp
+// @symbol _ZN8SignPost6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SignPost.h"
 extern "C" {
-extern int func_ov002_020bb060(void* c);
 }
 struct Sub041 {
   virtual void v0(); virtual void v1(); virtual void v2();
   virtual void v3(); virtual void v4(); virtual void v5(int);
 };
-extern "C" int _ZN8SignPost6RenderEv(char* c){
-  if (*(unsigned char*)(c+0x590) != 0) return 1;
-  void* r = *(void**)(c+0x59c);
+
+int SignPost::Render()
+{
+  if (unk_590 != 0) return 1;
+  void* r = *(void**)((char*)&unk_59c);
   if (r != 0) {
-    int b = (*(int*)(c+0xb0) & 0x4000) != 0;
+    int b = (unk_0b0 & 0x4000) != 0;
     if (b && *(int*)((char*)r+0xc8) != 0) {
-      func_ov002_020bb060(c);
+      func_ov002_020bb060(((char*)this));
     }
   }
-  Sub041* s = (Sub041*)(c+0xd4);
+  Sub041* s = (Sub041*)((char*)&mModel);
   s->v5(0);
   return 1;
 }

--- a/src/_ZN8SignPostD0Ev.c
+++ b/src/_ZN8SignPostD0Ev.c
@@ -1,20 +1,22 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8SignPostD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8SignPostD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjTatefuda_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x3c8);
     _ZN11ShadowModelD1Ev((char *)t + 0x358);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8SignPostD1Ev.c
+++ b/src/_ZN8SignPostD1Ev.c
@@ -1,18 +1,21 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8SignPostD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjTatefuda_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN8SignPostD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjTatefuda_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x3c8);
     _ZN11ShadowModelD1Ev((char *)t + 0x358);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8Snowball13InitResourcesEv.cpp
+++ b/src/_ZN8Snowball13InitResourcesEv.cpp
@@ -1,31 +1,34 @@
 //cpp
+// @symbol _ZN8Snowball13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Snowball.h"
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *file, int a, int b);
 extern "C" int _ZN11ShadowModel12InitCylinderEv(void *thiz);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int r, int h, unsigned int a, unsigned int b);
 extern "C" void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void *thiz, void *actor, int r, int h, void *v, int b);
-extern "C" void func_ov081_021261d4(void *c, void *p);
 extern "C" char data_ov081_02128d90;
-extern "C" char data_ov081_02128eb4;
 
-extern "C" int _ZN8Snowball13InitResourcesEv(char *c)
+int Snowball::InitResources()
 {
     void *f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov081_02128d90);
-    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x300, f, 1, -1) == 0) return 0;
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x300, f, 1, -1) == 0) return 0;
 
-    _ZN11ShadowModel12InitCylinderEv(c + 0x350);
+    _ZN11ShadowModel12InitCylinderEv((char *)&mShadowModel);
 
-    *(int*)(c + 0x9c) = -0x2000;
-    *(int*)(c + 0xa0) = -0x3c000;
-    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0x110, c, 0x1e000, 0x1e000, 0x200004, 0x40010);
+    unk_09c = -0x2000;
+    unk_0a0 = -0x3c000;
+    _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char *)this) + 0x110, ((char *)this), 0x1e000, 0x1e000, 0x200004, 0x40010);
 
-    *(int*)(c + 0x37c) = *(int*)(c + 0x5c);
-    *(int*)(c + 0x380) = *(int*)(c + 0x60);
-    *(int*)(c + 0x384) = *(int*)(c + 0x64);
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x32000;
-    *(short*)(c + 0x8e) = *(short*)(c + 0x94);
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(c + 0x144, c, 0x14000, 0x14000, 0, 0);
+    unk_37c = mPosX;
+    unk_380 = mPosY;
+    unk_384 = mPosZ;
+    *(int*)(((long long)(int)((char *)&mPosY))) += 0x32000;
+    unk_08e = unk_094;
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x144, ((char *)this), 0x14000, 0x14000, 0, 0);
 
-    func_ov081_021261d4(c, &data_ov081_02128eb4);
+    func_ov081_021261d4(((char *)this), &data_ov081_02128eb4);
     return 1;
 }

--- a/src/_ZN8Snowball6RenderEv.cpp
+++ b/src/_ZN8Snowball6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8Snowball6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Snowball.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x300]; Base base; };
-extern "C" int _ZN8Snowball6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Snowball::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8Snowball8BehaviorEv.cpp
+++ b/src/_ZN8Snowball8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8Snowball8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Snowball.h"
 struct Klass; typedef void (Klass::*PMF)();
 struct M { char pad[8]; PMF pmf; };
 struct CylinderClsn;
@@ -6,31 +11,30 @@ struct WithMeshClsn;
 extern "C" unsigned short DecIfAbove0_Short(unsigned short *p);
 extern "C" void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void *self, CylinderClsn *cc);
 extern "C" void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, WithMeshClsn *wm, unsigned int j);
-extern "C" void func_ov081_02126224(char *c);
 extern "C" void _ZN12CylinderClsn5ClearEv(CylinderClsn *self);
 extern "C" void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern "C" void _ZN12CylinderClsn6UpdateEv(CylinderClsn *self);
 
-extern "C" int _ZN8Snowball8BehaviorEv(char *c)
+int Snowball::Behavior()
 {
-    DecIfAbove0_Short((unsigned short *)(c + 0x100));
-    M *m = *(M **)(c + 0x378);
+    DecIfAbove0_Short((unsigned short *)((char *)&unk_100));
+    M *m = *(M **)((char *)&unk_378);
     if (m->pmf != 0)
-        (((Klass *)c)->*(m->pmf))();
-    int v = *(int *)(c + 0xa8) + *(int *)(c + 0x9c);
-    int hi = *(int *)(c + 0xa0);
+        (((Klass *)((char *)this))->*(m->pmf))();
+    int v = unk_0a8 + unk_09c;
+    int hi = unk_0a0;
     if (v >= hi)
         hi = v;
-    int tmp = *(int *)(c + 0xac);
-    *(int *)(c + 0xa8) = hi;
-    *(int *)(c + 0xac) = tmp;
-    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, (CylinderClsn *)(c + 0x110));
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (WithMeshClsn *)(c + 0x144), 0);
-    *(short *)(c + 0x8e) = *(short *)(c + 0x94);
-    func_ov081_02126224(c);
-    _ZN12CylinderClsn5ClearEv((CylinderClsn *)(c + 0x110));
-    void *p = _ZN5Actor13ClosestPlayerEv(c);
+    int tmp = unk_0ac;
+    unk_0a8 = hi;
+    unk_0ac = tmp;
+    _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((char *)this), (CylinderClsn *)((char *)&mMovingCylinderClsn));
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char *)this), (WithMeshClsn *)((char *)&mWithMeshClsn), 0);
+    unk_08e = unk_094;
+    func_ov081_02126224(((char *)this));
+    _ZN12CylinderClsn5ClearEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
+    void *p = _ZN5Actor13ClosestPlayerEv(((char *)this));
     if (p != 0 && *(unsigned char *)((char *)p + 0x6fb) == 0)
-        _ZN12CylinderClsn6UpdateEv((CylinderClsn *)(c + 0x110));
+        _ZN12CylinderClsn6UpdateEv((CylinderClsn *)((char *)&mMovingCylinderClsn));
     return 1;
 }

--- a/src/_ZN8SnowballD0Ev.c
+++ b/src/_ZN8SnowballD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8SnowballD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daSnowball_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN8SnowballD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daSnowball_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);


### PR DESCRIPTION
Batch 07 of the readable-tree migration. Promotes 183 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 97 VERIFIED, 86 BLIND, 0 WRONG/NO-REPRO. 7 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
