### PR TITLE
readable: batch 08 - promote 190 files to readable form

### DIFF
--- a/src/_ZN8SnowballD1Ev.c
+++ b/src/_ZN8SnowballD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8SnowballD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8Snowball */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN8SnowballD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8Snowball;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN8Squasher13InitResourcesEv.cpp
+++ b/src/_ZN8Squasher13InitResourcesEv.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol _ZN8Squasher13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_FloatOnWaterPlatformWdwRectangle.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Squasher.h"
 extern "C" {
-struct Matrix4x3 { int m[12]; };
 int _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* m, int bmd, int a, int b);
 void _ZN11ShadowModel10InitCuboidEv(void* s);
@@ -10,24 +15,22 @@ int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* mc, int kcl, struct Matrix4x3* mtx, int scale, short s, void* clps);
 void func_020393d4(int* p, int v);
 void _ZN16MeshColliderBase6EnableEP5Actor(void* mc, void* a);
-extern void* data_ov023_02112088;
-extern void* _ZN32FloatOnWaterPlatformWdwRectangleD1Ev;
-extern void* data_ov064_0211ba4c;
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
-
-int _ZN8Squasher13InitResourcesEv(char* c) {
-  int bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov023_02112088);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, bmd, 1, -1);
-  _ZN11ShadowModel10InitCuboidEv(c+0x324);
-  func_ov026_02111308(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
-  int kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&_ZN32FloatOnWaterPlatformWdwRectangleD1Ev);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, kcl, (struct Matrix4x3*)(c+0x2ec), 0x1000, *(short*)(c+0x8e), &data_ov064_0211ba4c);
-  func_020393d4((int*)(c+0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  _ZN16MeshColliderBase6EnableEP5Actor(c+0x124, c);
-  *(short*)(c+0x31e) = 0;
-  *(short*)(c+0x320) = 0;
-  *(char*)(c+0x322) = 0;
-  return 1;
 }
+
+int Squasher::InitResources()
+{
+  int bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov023_02112088);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, bmd, 1, -1);
+  _ZN11ShadowModel10InitCuboidEv((char*)&mShadowModel);
+  func_ov026_02111308(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
+  int kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&_ZN32FloatOnWaterPlatformWdwRectangleD1Ev);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(((char*)this)+0x124, kcl, (struct Matrix4x3*)((char*)&unk_2ec), 0x1000, unk_08e, &data_ov064_0211ba4c);
+  func_020393d4((int*)((char*)&mMeshCollider), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  _ZN16MeshColliderBase6EnableEP5Actor(((char*)this)+0x124, ((char*)this));
+  unk_31e = 0;
+  unk_320 = 0;
+  unk_322 = 0;
+  return 1;
 }

--- a/src/_ZN8Squasher6RenderEv.cpp
+++ b/src/_ZN8Squasher6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8Squasher6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Squasher.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8Squasher6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int Squasher::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8SquasherD0Ev.c
+++ b/src/_ZN8SquasherD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8SquasherD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN8SquasherD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN8SquasherD1Ev.c
+++ b/src/_ZN8SquasherD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN8SquasherD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN8SquasherD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x324);
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN8WallSign6RenderEv.cpp
+++ b/src/_ZN8WallSign6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN8WallSign6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "WallSign.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN8WallSign6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int WallSign::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN8WallSignD0Ev.c
+++ b/src/_ZN8WallSignD0Ev.c
@@ -1,16 +1,18 @@
+// @symbol _ZN8WallSignD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *_ZN8WallSignD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daObjKanban_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8WallSignD1Ev.c
+++ b/src/_ZN8WallSignD1Ev.c
@@ -1,14 +1,17 @@
+// @symbol _ZN8WallSignD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjKanban_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *_ZN8WallSignD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daObjKanban_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN8YoshiEgg13InitResourcesEv.c
+++ b/src/_ZN8YoshiEgg13InitResourcesEv.c
@@ -1,3 +1,8 @@
+// @symbol _ZN8YoshiEgg13InitResourcesEv
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "YoshiEgg.h"
 typedef int Fix12;
 
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *f);
@@ -15,7 +20,6 @@ extern void LoadBlueCoinModel(void *p);
 
 extern char data_ov002_0210e6b0[];
 extern char data_ov002_0210eb78[];
-extern char *data_ov002_021000a0[];
 
 #pragma opt_strength_reduction off
 

--- a/src/_ZN8YoshiEgg6RenderEv.cpp
+++ b/src/_ZN8YoshiEgg6RenderEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN8YoshiEgg6RenderEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Player.h"
+/* recovered: named members + shared header, real C++ method */
+#include "YoshiEgg.h"
 struct Obj {
   virtual void v0();
   virtual void v1();
@@ -8,13 +13,14 @@ struct Obj {
   virtual void m(int a);
 };
 extern "C" {
-extern int _ZN6Player16IsInsideOfCannonEv(void*);
-int _ZN8YoshiEgg6RenderEv(char* c){
-  int b = (int)((*(unsigned int*)(c+0xb0) & 0x40000) != 0);
-  if(b) return 1;
-  if(_ZN6Player16IsInsideOfCannonEv(*(void**)(c+0x38c))) return 1;
-  if(*(unsigned char*)(*(char**)(c+0x38c)+0x6f5) < 1) return 1;
-  ((Obj*)(c+0x300))->m(0);
-  return 1;
 }
+
+int YoshiEgg::Render()
+{
+  int b = (int)((unk_0b0 & 0x40000) != 0);
+  if(b) return 1;
+  if(_ZN6Player16IsInsideOfCannonEv(*(void**)((char*)&mPlayer))) return 1;
+  if(*(unsigned char*)(*(char**)((char*)&mPlayer)+0x6f5) < 1) return 1;
+  ((Obj*)((char*)&mModelAnim))->m(0);
+  return 1;
 }

--- a/src/_ZN8YoshiEgg8BehaviorEv.cpp
+++ b/src/_ZN8YoshiEgg8BehaviorEv.cpp
@@ -1,26 +1,28 @@
 //cpp
+// @symbol _ZN8YoshiEgg8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "YoshiEgg.h"
 extern "C" {
 struct Vec3 { int x, y, z; };
 extern int data_020a0e68;
-extern void func_ov002_020ed684(void *c);
 extern void _ZN9Animation7AdvanceEv(void *c);
-extern void Matrix4x3_FromRotationZXYExt(void *m, int x, int y, int z);
 extern void MulVec3Mat4x3(void *in, void *mtx, void *out);
 extern void Vec3_Add(void *out, void *a, void *b);
 extern void _ZN9ModelBase12ApplyOpacityEj(void *self, unsigned int op, int z);
-extern void func_ov002_020ed998(void *c);
-extern void func_ov002_020ed7f8(void *c);
 extern void func_ov002_020edca4(void *c);
+}
 
-int _ZN8YoshiEgg8BehaviorEv(char *self)
+int YoshiEgg::Behavior()
 {
     Vec3 vin;
     Vec3 vmid;
     Vec3 vout;
-    func_ov002_020ed684(self);
-    _ZN9Animation7AdvanceEv(self + 0x350);
-    if (*(int *)(self + 0x3f0) != 1) {
-        if (*(unsigned char *)(*(char **)(self + 0x38c) + 0x6f5) < 0xa) {
+    func_ov002_020ed684(((char *)this));
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    if (unk_3f0 != 1) {
+        if (*(unsigned char *)(*(char **)((char *)&mPlayer) + 0x6f5) < 0xa) {
             short *ang;
             vin.z = 0;
             vin.z = -0x68000;
@@ -29,30 +31,29 @@ int _ZN8YoshiEgg8BehaviorEv(char *self)
             vmid.x = 0;
             vmid.y = 0;
             vmid.z = 0;
-            ang = (short *)(((int)*(char **)(self + 0x38c) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+            ang = (short *)(((int)*(char **)((char *)&mPlayer) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
             Matrix4x3_FromRotationZXYExt(&data_020a0e68, ang[0], ang[1], ang[2]);
             MulVec3Mat4x3(&vin, &data_020a0e68, &vmid);
-            Vec3_Add(&vout, *(char **)(self + 0x38c) + 0x5c, &vmid);
-            *(int *)(self + 0x5c) = vout.x;
-            *(int *)(self + 0x60) = vout.y;
-            *(int *)(self + 0x64) = vout.z;
+            Vec3_Add(&vout, *(char **)((char *)&mPlayer) + 0x5c, &vmid);
+            mPosX = vout.x;
+            mPosY = vout.y;
+            mPosZ = vout.z;
         }
-        _ZN9ModelBase12ApplyOpacityEj(self + 0x300, *(unsigned char *)(*(char **)(self + 0x38c) + 0x6f5), 0);
+        _ZN9ModelBase12ApplyOpacityEj(((char *)this) + 0x300, *(unsigned char *)(*(char **)((char *)&mPlayer) + 0x6f5), 0);
     } else {
-        _ZN9ModelBase12ApplyOpacityEj(self + 0x300, 0x1f, 0);
+        _ZN9ModelBase12ApplyOpacityEj(((char *)this) + 0x300, 0x1f, 0);
     }
-    func_ov002_020ed998(self);
-    func_ov002_020ed7f8(self);
+    func_ov002_020ed998(((char *)this));
+    func_ov002_020ed7f8(((char *)this));
     {
-        unsigned char idx = *(unsigned char *)(self + 0x420);
-        if (*(unsigned char *)(self + idx + 0x421) != 0) {
-            unsigned char *cp = (unsigned char *)(((int)self + 0x420) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char idx = unk_420;
+        if (*(unsigned char *)(((char *)this) + idx + 0x421) != 0) {
+            unsigned char *cp = (unsigned char *)(((int)((char *)this) + 0x420) & 0xFFFFFFFFFFFFFFFF);
             *cp = *cp + 1;
         }
     }
-    if (*(unsigned char *)(self + 0x420) >= 5) {
-        func_ov002_020edca4(self);
+    if (unk_420 >= 5) {
+        func_ov002_020edca4(((char *)this));
     }
     return 1;
-}
 }

--- a/src/_ZN8YoshiEggD0Ev.c
+++ b/src/_ZN8YoshiEggD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8YoshiEggD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daYegg_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN8YoshiEggD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daYegg_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN8YoshiEggD1Ev.c
+++ b/src/_ZN8YoshiEggD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN8YoshiEggD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8YoshiEgg */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN8YoshiEggD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8YoshiEgg;
     _ZN11ShadowModelD1Ev((char *)t + 0x364);
     _ZN9ModelAnimD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
+++ b/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol _ZN9ActorBase18AfterInitResourcesEj
+/* recovered: named members + shared header, real C++ method */
+#include "ActorBase.h"
 extern "C" {
 extern int data_020a4b88[]; extern int data_02099f24[]; extern int data_020a4b78[]; extern int data_020a4b98[];
 extern void func_0203b27c(void*, void*); extern void func_0204405c(void*, void*);
-void _ZN9ActorBase18AfterInitResourcesEj(char* c, unsigned int a){
-  if(a!=2) return;
-  func_0203b27c(data_020a4b88, c+0x28);
-  volatile int* p=data_02099f24; bool b=(p[0]==3); if(b){ *(bool*)(c+0x10)=true; return; }
-  func_0204405c(data_020a4b78, c+0x28);
-  func_0204405c(data_020a4b98, c+0x38);
-  *(bool*)(c+0xe)=true;
 }
+
+void ActorBase::AfterInitResources(unsigned int a)
+{
+  if(a!=2) return;
+  func_0203b27c(data_020a4b88, ((char*)this)+0x28);
+  volatile int* p=data_02099f24; bool b=(p[0]==3); if(b){ *(bool*)((char*)&unk_010)=true; return; }
+  func_0204405c(data_020a4b78, ((char*)this)+0x28);
+  func_0204405c(data_020a4b98, ((char*)this)+0x38);
+  *(bool*)((char*)&unk_00e)=true;
 }

--- a/src/_ZN9ActorBase18MarkForDestructionEv.cpp
+++ b/src/_ZN9ActorBase18MarkForDestructionEv.cpp
@@ -1,10 +1,14 @@
 //cpp
-extern "C" {
-void _ZN9ActorBase18MarkForDestructionEv(unsigned char *c){
-  if(*(unsigned char*)(c+0xf)!=0) return;
-  unsigned char b = (*(unsigned char*)(c+0xe)==2);
+// @symbol _ZN9ActorBase18MarkForDestructionEv
+/* recovered: named members + shared header, real C++ method */
+#include "ActorBase.h"
+
+
+void ActorBase::MarkForDestruction()
+{
+  if(mMarkedForDestruction!=0) return;
+  unsigned char b = (unk_00e==2);
   if(b!=0) return;
-  *(unsigned char*)(c+0xf)=1;
-  (*(void(**)(unsigned char*))(*(unsigned int*)c+0x30))(c);
-}
+  mMarkedForDestruction=1;
+  (*(void(**)(unsigned char*))(*(unsigned int*)((unsigned char *)this)+0x30))(((unsigned char *)this));
 }

--- a/src/_ZN9ActorBase9SceneNode5ResetEv.c
+++ b/src/_ZN9ActorBase9SceneNode5ResetEv.c
@@ -1,7 +1,9 @@
-void _ZN9ActorBase9SceneNode5ResetEv(char *p)
-{
-    *(int *)(p + 0x0) = 0;
-    *(int *)(p + 0x4) = 0;
-    *(int *)(p + 0x8) = 0;
-    *(int *)(p + 0xc) = 0;
+// @symbol _ZN9ActorBase9SceneNode5ResetEv
+/* recovered: named members + shared header */
+#include "ActorBase__SceneNode.h"
+void _ZN9ActorBase9SceneNode5ResetEv(struct ActorBase__SceneNode *self) {
+    self->unk_000 = 0;
+    self->unk_004 = 0;
+    self->unk_008 = 0;
+    self->unk_00c = 0;
 }

--- a/src/_ZN9ActorBase9SceneNodeC1Ev.c
+++ b/src/_ZN9ActorBase9SceneNodeC1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN9ActorBase9SceneNodeC1Ev
+/* recovered: named members + shared header */
+#include "ActorBase.h"
 // ActorBase::SceneNode::SceneNode() - C1 constructor
 // Address: 0x0203b4c4
 

--- a/src/_ZN9ActorBaseC1Ev.cpp
+++ b/src/_ZN9ActorBaseC1Ev.cpp
@@ -1,15 +1,13 @@
 //cpp
+// @symbol _ZN9ActorBaseC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ActorBase.h"
 extern "C" {
 void _ZN9ActorBase9SceneNodeC1Ev(void);
 int func_0203b438(void);
 int func_02043810(void);
-extern int data_02099edc;
-extern int data_02099e70;
-extern int data_020a4b60;
-extern int data_020a4b54;
-extern int data_020a4b64;
-extern int data_020a4b48;
-extern int data_020a4b6c;
 extern int data_020a4bb8;
 }
 

--- a/src/_ZN9ActorBaseD1Ev.c
+++ b/src/_ZN9ActorBaseD1Ev.c
@@ -1,9 +1,11 @@
-extern void func_020440e8(void *);
-extern int VT0[];
-int *_ZN9ActorBaseD1Ev(int *t)
-{
-    t[0] = (int)VT0;
-    func_020440e8((char *)t + 0x38);
-    func_020440e8((char *)t + 0x28);
-    return t;
+// @symbol _ZN9ActorBaseD1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ActorBase.h"
+int *_ZN9ActorBaseD1Ev(struct ActorBase *self) {
+    ((int *)self)[0] = (int)VT0;
+    func_020440e8((char *)&self->unk_038);
+    func_020440e8((char *)&self->unk_028);
+    return ((int *)self);
 }

--- a/src/_ZN9ActorBaseD2Ev.c
+++ b/src/_ZN9ActorBaseD2Ev.c
@@ -1,9 +1,11 @@
-extern void func_020440e8(void *);
-extern int VT0[];
-int *_ZN9ActorBaseD2Ev(int *t)
-{
-    t[0] = (int)VT0;
-    func_020440e8((char *)t + 0x38);
-    func_020440e8((char *)t + 0x28);
-    return t;
+// @symbol _ZN9ActorBaseD2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ActorBase.h"
+int *_ZN9ActorBaseD2Ev(struct ActorBase *self) {
+    ((int *)self)[0] = (int)VT0;
+    func_020440e8((char *)&self->unk_038);
+    func_020440e8((char *)&self->unk_028);
+    return ((int *)self);
 }

--- a/src/_ZN9ActorBasenwEj.cpp
+++ b/src/_ZN9ActorBasenwEj.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol _ZN9ActorBasenwEj
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ActorBase.h"
 struct Heap;
 extern "C" void *_ZN6Memory8AllocateEjiP4Heap(unsigned int size, int align, Heap *heap);
-extern "C" void func_0206e2f8(void *p, int a, unsigned int size);
 
 extern Heap *data_020a0eac;
 

--- a/src/_ZN9Animation12SetAnimationEti5Fix12IiEt.cpp
+++ b/src/_ZN9Animation12SetAnimationEti5Fix12IiEt.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol _ZN9Animation12SetAnimationEti5Fix12IiEt
+/* recovered: named members + shared header */
+#include "Animation.h"
 extern "C" {
-void _ZN9Animation12SetAnimationEti5Fix12IiEt(void* c,unsigned short a,int i,int fix,unsigned short b){
-  *(int*)((char*)c+4)=i|(a<<12);
-  *(int*)((char*)c+8)=b<<12;
-  *(int*)((char*)c+0xc)=fix;
+void _ZN9Animation12SetAnimationEti5Fix12IiEt(struct Animation *self, unsigned short a, int i, int fix, unsigned short b) {
+  *(int*)((char*)&self->mFrameCountAndFlags)=i|(a<<12);
+  *(int*)((char*)&self->unk_008)=b<<12;
+  *(int*)((char*)&self->unk_00c)=fix;
 }
 }

--- a/src/_ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File.c
+++ b/src/_ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File.c
@@ -1,6 +1,9 @@
-void _ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File(char* o, void* f){
-  *(char**)(o+8) = o + *(int*)(o+8);
-  *(char**)(o+0xc) = o + *(int*)(o+0xc);
-  *(char**)(o+0x10) = o + *(int*)(o+0x10);
-  *(char**)(o+0x14) = o + *(int*)(o+0x14);
+// @symbol _ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File
+/* recovered: named members + shared header */
+#include "Animation.h"
+void _ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File(struct Animation *self, void* f) {
+  *(char**)((char*)&self->unk_008) = ((char*)self) + self->unk_008;
+  *(char**)((char*)&self->unk_00c) = ((char*)self) + self->unk_00c;
+  *(char**)((char*)&self->unk_010) = ((char*)self) + self->unk_010;
+  *(char**)((char*)&self->unk_014) = ((char*)self) + self->unk_014;
 }

--- a/src/_ZN9Animation8FinishedEv.cpp
+++ b/src/_ZN9Animation8FinishedEv.cpp
@@ -1,8 +1,12 @@
 //cpp
-extern "C" {
-int _ZN9Animation8FinishedEv(void* c){
-  unsigned int f=*(unsigned int*)((char*)c+4);
-  int cur=*(int*)((char*)c+8);
+// @symbol _ZN9Animation8FinishedEv
+/* recovered: named members + shared header, real C++ method */
+#include "Animation.h"
+
+
+int Animation::Finished()
+{
+  unsigned int f=*(unsigned int*)((char*)&mFrameCountAndFlags);
+  int cur=*(int*)((char*)&unk_008);
   return cur>=(int)((f&0x3fffffff)-1);
-}
 }

--- a/src/_ZN9Animation8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN9Animation8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,8 @@
+// @symbol _ZN9Animation8LoadFileER13SharedFilePtr
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: named members + shared header */
+#include "Animation.h"
 typedef unsigned char u8;
 
 struct SharedFilePtr {
@@ -7,7 +12,6 @@ struct SharedFilePtr {
 };
 
 extern void _ZN13SharedFilePtr8LoadFileEv(struct SharedFilePtr* fp);
-extern void _ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File(char* file);
 
 char* _ZN9Animation8LoadFileER13SharedFilePtr(struct SharedFilePtr* filePtr)
 {

--- a/src/_ZN9Animation8SetFlagsEi.cpp
+++ b/src/_ZN9Animation8SetFlagsEi.cpp
@@ -1,6 +1,10 @@
 //cpp
-extern "C" {
-void _ZN9Animation8SetFlagsEi(void* c,int flags){
-  *(unsigned int*)((char*)c+4)=(*(unsigned int*)((char*)c+4)&0x3fffffff)|flags;
-}
+// @symbol _ZN9Animation8SetFlagsEi
+/* recovered: named members + shared header, real C++ method */
+#include "Animation.h"
+
+
+void Animation::SetFlags(int flags)
+{
+  *(unsigned int*)((char*)&mFrameCountAndFlags)=(*(unsigned int*)((char*)&mFrameCountAndFlags)&0x3fffffff)|flags;
 }

--- a/src/_ZN9AnimationC1Ev.cpp
+++ b/src/_ZN9AnimationC1Ev.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN9AnimationC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Animation.h"
 extern "C" {
-extern int data_0208e7e4[];
-void _ZN9AnimationC1Ev(void* c){
-  *(int*)((char*)c+0)=(int)data_0208e7e4;
-  *(int*)((char*)c+8)=0;
-  *(int*)((char*)c+0xc)=0x1000;
+void _ZN9AnimationC1Ev(struct Animation *self) {
+  *(int*)((char*)&self->unk_000)=(int)data_0208e7e4;
+  *(int*)((char*)&self->unk_008)=0;
+  *(int*)((char*)&self->unk_00c)=0x1000;
 }
 }

--- a/src/_ZN9AnimationC2Ev.cpp
+++ b/src/_ZN9AnimationC2Ev.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol _ZN9AnimationC2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Animation.h"
 extern "C" {
-extern int data_0208e7e4[];
-void _ZN9AnimationC2Ev(void* c){
-  *(int*)((char*)c+0)=(int)data_0208e7e4;
-  *(int*)((char*)c+8)=0;
-  *(int*)((char*)c+0xc)=0x1000;
+void _ZN9AnimationC2Ev(struct Animation *self) {
+  *(int*)((char*)&self->unk_000)=(int)data_0208e7e4;
+  *(int*)((char*)&self->unk_008)=0;
+  *(int*)((char*)&self->unk_00c)=0x1000;
 }
 }

--- a/src/_ZN9AnimationD0Ev.c
+++ b/src/_ZN9AnimationD0Ev.c
@@ -1,10 +1,14 @@
+// @symbol _ZN9AnimationD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "Animation.h"
 /* _ZN9AnimationD0Ev at 0x02015cc4
  * Single-vtable destructor (CodeWarrior 1.2):
  *   write own vtable to [this], call base/helper destructor, return this.
  * Call target: 0x0203cbcc
  */
 struct Obj { void *vtable; };
-extern void *vtbl_Animation[];
 extern void base_dtor_Animation(struct Obj *thiz); /* 0x0203cbcc */
 struct Obj *_ZN9AnimationD0Ev(struct Obj *thiz)
 {

--- a/src/_ZN9AnimationD1Ev.c
+++ b/src/_ZN9AnimationD1Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN9AnimationD1Ev
+/* recovered: named members + shared header */
+#include "Animation.h"
 /* Animation::~Animation() (complete-object destructor, D1) at 0x02015ce8
  * Trivial destructor: restores the Animation vtable pointer into self->vtable
  * (slot 0x0) and returns. The three Fix12i members need no teardown.

--- a/src/_ZN9AnimationD2Ev.c
+++ b/src/_ZN9AnimationD2Ev.c
@@ -1,3 +1,6 @@
+// @symbol _ZN9AnimationD2Ev
+/* recovered: named members + shared header */
+#include "Animation.h"
 /* Animation::~Animation() (base-object destructor, D2) at 0x02015cb4
  * Trivial destructor: restores the Animation vtable pointer into self->vtable
  * (slot 0x0) and returns. The three Fix12i members need no teardown.

--- a/src/_ZN9ArrowLift13InitResourcesEv.cpp
+++ b/src/_ZN9ArrowLift13InitResourcesEv.cpp
@@ -1,17 +1,23 @@
 //cpp
+// @symbol _ZN9ArrowLift13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "ArrowLift.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* bmd, int a, int b);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, int fix, int t, unsigned int u, unsigned int v);
-extern int data_ov029_02114270[];
-int _ZN9ArrowLift13InitResourcesEv(char* c){
-  void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
-  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x124, c, 0x32000, 0x64000, 0x800002, 0);
-  *(int*)(c+0x158) = 0;
-  *(char*)(c+0x15c) = *(int*)(c+8) & 1;
-  *(char*)(c+0x15d) = 0;
-  *(short*)(c+0x8e) = 0;
-  return 1;
 }
+
+int ArrowLift::InitResources()
+{
+  void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_02114270);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, m, 1, -1);
+  _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(((char*)this)+0x124, ((char*)this), 0x32000, 0x64000, 0x800002, 0);
+  unk_158 = 0;
+  unk_15c = mParam & 1;
+  unk_15d = 0;
+  unk_08e = 0;
+  return 1;
 }

--- a/src/_ZN9ArrowLift6RenderEv.cpp
+++ b/src/_ZN9ArrowLift6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN9ArrowLift6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ArrowLift.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN9ArrowLift6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int ArrowLift::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN9ArrowLiftD0Ev.c
+++ b/src/_ZN9ArrowLiftD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9ArrowLiftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj03_c */
 extern void *G0;
 int *_ZN9ArrowLiftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObjWc_Obj03_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9BlueFlameD0Ev.c
+++ b/src/_ZN9BlueFlameD0Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9BlueFlameD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daObjFire_c */
 extern void *G0;
 int *_ZN9BlueFlameD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daObjFire_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xe4);
     _ZN5ActorD2Ev(t);
     _ZN6Memory10DeallocateEPvP4Heap(t, G0);

--- a/src/_ZN9Butterfly13InitResourcesEv.cpp
+++ b/src/_ZN9Butterfly13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9Butterfly13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "Butterfly.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -27,9 +30,9 @@ extern SFP data_ov100_02148668;
 extern SFP data_ov100_02148608;
 extern int data_0209e650;
 
-extern "C" int _ZN9Butterfly13InitResourcesEv(void* self)
+int Butterfly::InitResources()
 {
-    u8* c = (u8*)self;
+    u8* c = (u8*)((void*)this);
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9d8);
     _ZN9Animation8LoadFileER13SharedFilePtr(&data_ov100_02148600);
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov100_02148668);
@@ -41,13 +44,13 @@ extern "C" int _ZN9Butterfly13InitResourcesEv(void* self)
     if (_ZN9ModelBase7SetFileEP8BMD_Fileii((void*)(c+0x138), data_ov100_02148668.b, 1, 1) == 0) return 0;
     if (_ZN11ShadowModel12InitCylinderEv((void*)(c+0x1b0)) == 0) return 0;
 
-    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((void*)(c+0x1d8), self, 0x32000, 0x32000, 0, 0);
+    _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_((void*)(c+0x1d8), ((void*)this), 0x32000, 0x32000, 0, 0);
 
     Vec3 v;
     v.x = 0;
     v.y = -0x32000;
     v.z = 0;
-    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x394), self, &v, 0x32000, 0x64000, 0x200000, 0);
+    _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj((void*)(c+0x394), ((void*)this), &v, 0x32000, 0x64000, 0x200000, 0);
 
     int sub = (int)(u8)(*(u32*)(c+8) & 0x30);
     if (sub != 0x10 && sub != 0x20) {

--- a/src/_ZN9Butterfly6RenderEv.cpp
+++ b/src/_ZN9Butterfly6RenderEv.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN9Butterfly6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Butterfly.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base2 { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(void*); };
 struct D { char pad[0xd4]; Base b1; char pad2[0x138-0xd8]; Base2 b2; };
-extern "C" int _ZN9Butterfly6RenderEv(D* d){
-  char* c=(char*)d;
+
+int Butterfly::Render()
+{
+  char* c=(char*)((D*)this);
   if(*(int*)(c+0x3e4)==4) return 1;
   if(*(unsigned char*)(c+0x3f1)!=0){
-    d->b1.m(0);
+    ((D*)this)->b1.m(0);
   } else {
-    d->b2.m(c+0x80);
+    ((D*)this)->b2.m(c+0x80);
   }
   return 1;
 }

--- a/src/_ZN9ButterflyD0Ev.c
+++ b/src/_ZN9ButterflyD0Ev.c
@@ -1,15 +1,18 @@
+// @symbol _ZN9ButterflyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daBtfly_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9ButterflyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daBtfly_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x394);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1d8);
     _ZN11ShadowModelD1Ev((char *)t + 0x1b0);

--- a/src/_ZN9CameraTagD0Ev.c
+++ b/src/_ZN9CameraTagD0Ev.c
@@ -1,7 +1,9 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
+// @symbol _ZN9CameraTagD0Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "CameraTag.h"
 int *_ZN9CameraTagD0Ev(int *t)
 {
     t[0] = (int)VT;

--- a/src/_ZN9DorrieCap6RenderEv.cpp
+++ b/src/_ZN9DorrieCap6RenderEv.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol _ZN9DorrieCap6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "DorrieCap.h"
 struct V { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN9DorrieCap6RenderEv(char* c){
-  unsigned int b = *(unsigned char*)(c+0xef);
+
+int DorrieCap::Render()
+{
+  unsigned int b = unk_0ef;
   if((b<<30)>>31){
     int buf[3];
     buf[0]=0x2c00; buf[1]=0x2c00; buf[2]=0x2c00;
-    ((V*)(c+0xf0))->g5(buf);
+    ((V*)((char*)&mModel))->g5(buf);
   }
   return 1;
-}
 }

--- a/src/_ZN9DorrieCap8BehaviorEv.cpp
+++ b/src/_ZN9DorrieCap8BehaviorEv.cpp
@@ -1,46 +1,49 @@
 //cpp
+// @symbol _ZN9DorrieCap8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "DorrieCap.h"
 extern "C" int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
 extern "C" void func_ov001_020ab110(char* c);
 extern "C" void func_ov001_020ab228(char* c, char* a1, int idx, int a3, unsigned char a5);
-extern "C" void func_ov065_02118c4c(char* c);
-extern "C" int func_ov065_021180d4(char* self);
 extern "C" void _ZN12CylinderClsn5ClearEv(void* self);
 extern "C" void _ZN12CylinderClsn6UpdateEv(void* self);
 
-
-extern "C" int _ZN9DorrieCap8BehaviorEv(char* p0){
-  char* p = *(char**)(p0+0x174);
+int DorrieCap::Behavior()
+{
+  char* p = *(char**)((char*)&unk_174);
   if(p == 0) return 1;
-  int b = (*(int*)(p0+0xb0) & 0x20000) != 0;
+  int b = (unk_0b0 & 0x20000) != 0;
   if(b != 0){
-    char* s = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x10d, 0x1210, p0+0x5c, p0+0x8c, *(signed char*)(p0+0xcc), -1);
+    char* s = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x10d, 0x1210, ((char*)this)+0x5c, ((char*)this)+0x8c, mAreaId, -1);
     if(s != 0){
-      *(int*)(s+0xd0) = *(int*)(p0+0xd0);
-      *(char**)(*(char**)(p0+0xd0)+0x360) = s;
+      *(int*)(s+0xd0) = mEatingPlayer;
+      *(char**)(*(char**)((char*)&mEatingPlayer)+0x360) = s;
       int* qs = (int*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFFull);
       *qs = *qs | 0x20000;
-      int* qt = (int*)(((int)p0 + 0xb0) & 0xFFFFFFFFFFFFFFFFull);
+      int* qt = (int*)(((int)((char*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFFull);
       *qt = *qt & ~0x20000;
-      *(int*)(p0+0xd0) = 0;
-      func_ov001_020ab110(p0+0xd4);
-      func_ov001_020ab228(p0+0xd4, p0, 2, 0, 0);
+      mEatingPlayer = 0;
+      func_ov001_020ab110((char*)&unk_0d4);
+      func_ov001_020ab228(((char*)this)+0xd4, ((char*)this), 2, 0, 0);
     }
     return 1;
   }
   p = (char*)(((int)p + 0xd8) & 0xFFFFFFFFFFFFFFFFull);
-  *(int*)(p0+0x5c) = *(int*)p;
-  *(int*)(p0+0x60) = *(int*)(p+4);
-  *(int*)(p0+0x64) = *(int*)(p+8);
-  *(short*)(p0+0x8c) = *(short*)(*(char**)(p0+0x174)+0xe4);
-  *(short*)(p0+0x8e) = *(short*)(*(char**)(p0+0x174)+0x8e);
-  if(((unsigned int)*(unsigned char*)(p0+0xef) << 30) >> 31){
-    func_ov065_02118c4c(p0);
-    if(func_ov065_021180d4(p0) != 0){
-      _ZN12CylinderClsn5ClearEv(p0+0x140);
+  mPosX = *(int*)p;
+  mPosY = *(int*)(p+4);
+  mPosZ = *(int*)(p+8);
+  unk_08c = *(short*)(*(char**)((char*)&unk_174)+0xe4);
+  unk_08e = *(short*)(*(char**)((char*)&unk_174)+0x8e);
+  if(((unsigned int)unk_0ef << 30) >> 31){
+    func_ov065_02118c4c(((char*)this));
+    if(func_ov065_021180d4(((char*)this)) != 0){
+      _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
       return 1;
     }
-    _ZN12CylinderClsn5ClearEv(p0+0x140);
-    _ZN12CylinderClsn6UpdateEv(p0+0x140);
+    _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
   }
   return 1;
 }

--- a/src/_ZN9DorrieCapD0Ev.c
+++ b/src/_ZN9DorrieCapD0Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9DorrieCapD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV12daDossyCap_c */
 extern void *G0;
 int *_ZN9DorrieCapD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daDossyCap_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x140);
     _ZN5ModelD1Ev((char *)t + 0xf0);
     func_ov001_020ab3a0((char *)t + 0xd4);

--- a/src/_ZN9DorrieCapD1Ev.c
+++ b/src/_ZN9DorrieCapD1Ev.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol _ZN9DorrieCapD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9DorrieCap */
 int *_ZN9DorrieCapD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9DorrieCap;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x140);
     _ZN5ModelD1Ev((char *)t + 0xf0);
     func_ov001_020ab3a0((char *)t + 0xd4);

--- a/src/_ZN9FaderWipe14LoadAndSetFileEt.cpp
+++ b/src/_ZN9FaderWipe14LoadAndSetFileEt.cpp
@@ -1,5 +1,10 @@
 //cpp
+// @symbol _ZN9FaderWipe14LoadAndSetFileEt
+/* recovered: named members + shared header, real C++ method */
+#include "FaderWipe.h"
 extern "C" void _ZN5Model14LoadAndSetFileEtii(void* m, unsigned short id, int a, int b);
-extern "C" void _ZN9FaderWipe14LoadAndSetFileEt(void* thiz, unsigned short id) {
-    _ZN5Model14LoadAndSetFileEtii((char*)thiz + 0x10, id, 0, -1);
+
+void FaderWipe::LoadAndSetFile(unsigned short id)
+{
+    _ZN5Model14LoadAndSetFileEtii((char*)((void*)this) + 0x10, id, 0, -1);
 }

--- a/src/_ZN9HugeCover13InitResourcesEv.cpp
+++ b/src/_ZN9HugeCover13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9HugeCover13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "HugeCover.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct BTA_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block; struct Actor;
 struct Model { int d; };
@@ -26,9 +29,9 @@ extern BTA_File data_ov032_02112f64;
 extern SharedFilePtr data_ov032_02113af4;
 extern CLPS_Block data_ov032_02112fb8;
 
-extern "C" int _ZN9HugeCover13InitResourcesEv(char* thiz)
+int HugeCover::InitResources()
 {
-    char* c = thiz;
+    char* c = ((char*)this);
     {
         BMD_File* bmd = _ZN5Model8LoadFileER13SharedFilePtr(*(SharedFilePtr*)&data_ov032_02113afc);
         _ZN9ModelBase7SetFileEP8BMD_Fileii((ModelBase*)(c + 0xd4), bmd, 1, 0x14);

--- a/src/_ZN9HugeCover6RenderEv.cpp
+++ b/src/_ZN9HugeCover6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN9HugeCover6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "HugeCover.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN9HugeCover6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int HugeCover::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN9HugeCoverD0Ev.c
+++ b/src/_ZN9HugeCoverD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9HugeCoverD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9HugeCoverD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjTdWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9HugeCoverD1Ev.c
+++ b/src/_ZN9HugeCoverD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9HugeCoverD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjTdWater_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9HugeCoverD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjTdWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9KoopaFlag13InitResourcesEv.cpp
+++ b/src/_ZN9KoopaFlag13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9KoopaFlag13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "KoopaFlag.h"
 typedef int Fix12;
 struct SharedFilePtr;
 struct BMD_File;
@@ -24,14 +27,14 @@ struct MovingCylinderClsn {
 extern SharedFilePtr data_ov062_0211e0d4;
 extern SharedFilePtr data_ov062_0211e0dc;
 
-extern "C" int _ZN9KoopaFlag13InitResourcesEv(char* c)
+int KoopaFlag::InitResources()
 {
-    ((ModelBase*)(c + 0x108))->SetFile(
+    ((ModelBase*)((char*)&mModelAnim))->SetFile(
         (BMD_File*)Model::LoadFile(data_ov062_0211e0d4), 1, -1);
-    ((ModelAnim*)(c + 0x108))->SetAnim(
+    ((ModelAnim*)((char*)&mModelAnim))->SetAnim(
         (BCA_File*)Animation::LoadFile(data_ov062_0211e0dc), 0, 0x1000, 0);
-    ((MovingCylinderClsn*)(c + 0xd4))->Init((Actor*)c, 0x35555, 0x294000, 0x280000c, 0);
-    *(unsigned char*)(c + 0x16e) = 0xff;
-    *(short*)(c + 0x16c) = 0;
+    ((MovingCylinderClsn*)((char*)&mMovingCylinderClsn))->Init((Actor*)((char*)this), 0x35555, 0x294000, 0x280000c, 0);
+    unk_16e = 0xff;
+    mVictoryTimer = 0;
     return 1;
 }

--- a/src/_ZN9KoopaFlag6RenderEv.cpp
+++ b/src/_ZN9KoopaFlag6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN9KoopaFlag6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "KoopaFlag.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0x108]; Base base; };
-extern "C" int _ZN9KoopaFlag6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int KoopaFlag::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN9KoopaFlagD0Ev.c
+++ b/src/_ZN9KoopaFlagD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9KoopaFlagD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV9daRFlag_c */
 extern void *G0;
 int *_ZN9KoopaFlagD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daRFlag_c;
     _ZN9ModelAnimD1Ev((char *)t + 0x108);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9LakituBro13InitResourcesEv.cpp
+++ b/src/_ZN9LakituBro13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9LakituBro13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "LakituBro.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef int Fix12;
@@ -18,36 +23,35 @@ extern "C" void _ZN11ShadowModel12InitCylinderEv(ShadowModel* thiz);
 extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File& a, BTP_File& b);
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(ModelAnim* thiz, BCA_File* f, int a, Fix12 b, u32 c);
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(TextureSequence* thiz, BTP_File& f, int a, Fix12 b, u32 c);
-extern "C" int func_ov085_0212e728(void* c, void* p);
 
 extern SharedFilePtr data_ov085_0213074c;
 extern SharedFilePtr data_ov085_02130744;
 extern SharedFilePtr data_ov085_0213073c;
 extern int data_ov085_021307d0;
-extern int data_ov085_02130790;
 extern int data_ov085_021307e0;
 extern char data_0209caa0[];
 
-extern "C" int _ZN9LakituBro13InitResourcesEv(char* thiz){
+int LakituBro::InitResources()
+{
   BMD_File* bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov085_0213074c);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii((ModelBase*)(thiz + 0x110), bmd, 1, -1);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii((ModelBase*)((char*)&mModelAnim1), bmd, 1, -1);
   _ZN9Animation8LoadFileER13SharedFilePtr(data_ov085_02130744);
   _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov085_0213073c);
-  _ZN11ShadowModel12InitCylinderEv((ShadowModel*)(thiz + 0x1f0));
-  _ZN11ShadowModel12InitCylinderEv((ShadowModel*)(thiz + 0x218));
+  _ZN11ShadowModel12InitCylinderEv((ShadowModel*)((char*)&mShadowModel1));
+  _ZN11ShadowModel12InitCylinderEv((ShadowModel*)((char*)&mShadowModel2));
   _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(
       *(BMD_File*)data_ov085_0213074c.f4, *(BTP_File*)data_ov085_0213073c.f4);
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
-      (ModelAnim*)(thiz + 0x110), (BCA_File*)data_ov085_02130744.f4, 0, 0x1000, 0);
+      (ModelAnim*)((char*)&mModelAnim1), (BCA_File*)data_ov085_02130744.f4, 0, 0x1000, 0);
   _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(
-      (TextureSequence*)(thiz + 0x1d8), *(BTP_File*)data_ov085_0213073c.f4, 0, 0x1000, 0);
-  *(int*)(thiz + 0x16c) = 0x1000;
-  *(int*)(thiz + 0x2d0) = *(int*)(thiz + 8) & 0xff;
-  if (*(int*)(thiz + 0x2d0) == 0xff)
-    *(int*)(thiz + 0x2d0) = 0;
-  switch (*(int*)(thiz + 0x2d0)) {
+      (TextureSequence*)((char*)&mTextureSequence), *(BTP_File*)data_ov085_0213073c.f4, 0, 0x1000, 0);
+  unk_16c = 0x1000;
+  unk_2d0 = unk_008 & 0xff;
+  if (unk_2d0 == 0xff)
+    unk_2d0 = 0;
+  switch (unk_2d0) {
   case 0:
-    func_ov085_0212e728(thiz, &data_ov085_021307d0);
+    func_ov085_0212e728(((char*)this), &data_ov085_021307d0);
     break;
   case 1:
     {
@@ -56,11 +60,11 @@ extern "C" int _ZN9LakituBro13InitResourcesEv(char* thiz){
         return 0;
       if (v & 0x10000)
         *(int*)(data_0209caa0 + 8) = v & ~0x10000;
-      *(u8*)(thiz + 0x2dc) = 1;
+      unk_2dc = 1;
       if (!(*(int*)(data_0209caa0 + 8) & 0x80))
-        func_ov085_0212e728(thiz, &data_ov085_02130790);
+        func_ov085_0212e728(((char*)this), &data_ov085_02130790);
       else
-        func_ov085_0212e728(thiz, &data_ov085_021307e0);
+        func_ov085_0212e728(((char*)this), &data_ov085_021307e0);
     }
     break;
   }

--- a/src/_ZN9LakituBro6RenderEv.cpp
+++ b/src/_ZN9LakituBro6RenderEv.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol _ZN9LakituBro6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "LakituBro.h"
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
-extern "C" {
-int _ZN9LakituBro6RenderEv(char* c){
-  if (*(unsigned char*)(c+0x2dc) == 1) return 1;
-  _ZN15TextureSequence6UpdateER15ModelComponents(c+0x1d8, c+0x118);
-  ((Sub*)(c+0x110))->g5(0);
+
+int LakituBro::Render()
+{
+  if (unk_2dc == 1) return 1;
+  _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this)+0x1d8, ((char*)this)+0x118);
+  ((Sub*)((char*)&mModelAnim1))->g5(0);
   return 1;
-}
 }

--- a/src/_ZN9LakituBro8BehaviorEv.cpp
+++ b/src/_ZN9LakituBro8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9LakituBro8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "LakituBro.h"
 struct C;
 typedef void (C::*PMF)();
 struct State { char pad[8]; PMF fn; };
@@ -6,18 +11,18 @@ extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);
 extern void _ZN9Animation7AdvanceEv(void*);
-extern int func_ov085_0212e858(void*);
-extern void func_ov085_0212e778(void*);
 }
 extern State data_ov085_021307d0;
 extern State data_ov085_021307e0;
 struct C { char pad[0x10000]; };
-extern "C" int _ZN9LakituBro8BehaviorEv(C* c){
-  char* p=(char*)c;
+
+int LakituBro::Behavior()
+{
+  char* p=(char*)((C*)this);
   DecIfAbove0_Short((unsigned short*)(p+0x100));
   State* st=*(State**)(p+0x1ec);
-  if(st->fn) (c->*st->fn)();
-  _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+  if(st->fn) (((C*)this)->*st->fn)();
+  _ZN5Actor9UpdatePosEP12CylinderClsn(((C*)this), 0);
   _ZN9Animation7AdvanceEv(p+0x160);
   _ZN9Animation7AdvanceEv(p+0x1d8);
   if(*(State**)(p+0x1ec)==&data_ov085_021307d0){
@@ -26,7 +31,7 @@ extern "C" int _ZN9LakituBro8BehaviorEv(C* c){
     *(short*)(p+0x90)=*(short*)(p+0x96);
   }
   if(*(State**)(p+0x1ec)==&data_ov085_021307e0) return 1;
-  if(*(int*)(p+0x2d0)==0) func_ov085_0212e858(c);
-  else func_ov085_0212e778(c);
+  if(*(int*)(p+0x2d0)==0) func_ov085_0212e858(((C*)this));
+  else func_ov085_0212e778(((C*)this));
   return 1;
 }

--- a/src/_ZN9LakituBroD0Ev.c
+++ b/src/_ZN9LakituBroD0Ev.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN9LakituBroD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daC_Jugem_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9LakituBroD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daC_Jugem_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x218);
     _ZN11ShadowModelD1Ev((char *)t + 0x1f0);
     _ZN15TextureSequenceD1Ev((char *)t + 0x1d8);

--- a/src/_ZN9LakituBroD1Ev.c
+++ b/src/_ZN9LakituBroD1Ev.c
@@ -1,11 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol _ZN9LakituBroD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9LakituBro */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9LakituBroD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9LakituBro;
     _ZN11ShadowModelD1Ev((char *)t + 0x218);
     _ZN11ShadowModelD1Ev((char *)t + 0x1f0);
     _ZN15TextureSequenceD1Ev((char *)t + 0x1d8);

--- a/src/_ZN9ModelAnimC1Ev.c
+++ b/src/_ZN9ModelAnimC1Ev.c
@@ -1,8 +1,11 @@
-extern void _ZN5ModelC2Ev(void* self);
-extern void _ZN9AnimationC2Ev(void* self);
+// @symbol _ZN9ModelAnimC1Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ModelAnim.h"
 
-extern unsigned int _ZTV9ModelAnim[];
-extern unsigned int VTable_Animation_ModelAnimThunk[];
 
 typedef struct {
     unsigned int* vtable;
@@ -12,11 +15,11 @@ typedef struct {
     unsigned int unk60;
 } ModelAnim;
 
-ModelAnim* _ZN9ModelAnimC1Ev(ModelAnim* this) {
-    _ZN5ModelC2Ev(this);
-    _ZN9AnimationC2Ev((char*)this + 0x50);
-    this->vtable = _ZTV9ModelAnim;
-    this->anim_vtable = VTable_Animation_ModelAnimThunk;
-    this->unk60 = 0;
-    return this;
+ModelAnim* _ZN9ModelAnimC1Ev(struct ModelAnim *self) {
+    _ZN5ModelC2Ev(((ModelAnim*)self));
+    _ZN9AnimationC2Ev((char*)&self->mAnimation);
+    ((ModelAnim*)self)->vtable = _ZTV9ModelAnim;
+    ((ModelAnim*)self)->anim_vtable = VTable_Animation_ModelAnimThunk;
+    ((ModelAnim*)self)->unk60 = 0;
+    return ((ModelAnim*)self);
 }

--- a/src/_ZN9ModelAnimC2Ev.c
+++ b/src/_ZN9ModelAnimC2Ev.c
@@ -1,8 +1,11 @@
-extern void _ZN5ModelC2Ev(void* self);
-extern void _ZN9AnimationC2Ev(void* self);
+// @symbol _ZN9ModelAnimC2Ev
+/* recovered: named members + shared header, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header */
+#include "ModelAnim.h"
 
-extern unsigned int _ZTV9ModelAnim[];
-extern unsigned int VTable_Animation_ModelAnimThunk[];
 
 typedef struct {
     unsigned int* vtable;
@@ -12,11 +15,11 @@ typedef struct {
     unsigned int unk60;
 } ModelAnim;
 
-ModelAnim* _ZN9ModelAnimC2Ev(ModelAnim* this) {
-    _ZN5ModelC2Ev(this);
-    _ZN9AnimationC2Ev((char*)this + 0x50);
-    this->vtable = _ZTV9ModelAnim;
-    this->anim_vtable = VTable_Animation_ModelAnimThunk;
-    this->unk60 = 0;
-    return this;
+ModelAnim* _ZN9ModelAnimC2Ev(struct ModelAnim *self) {
+    _ZN5ModelC2Ev(((ModelAnim*)self));
+    _ZN9AnimationC2Ev((char*)&self->mAnimation);
+    ((ModelAnim*)self)->vtable = _ZTV9ModelAnim;
+    ((ModelAnim*)self)->anim_vtable = VTable_Animation_ModelAnimThunk;
+    ((ModelAnim*)self)->unk60 = 0;
+    return ((ModelAnim*)self);
 }

--- a/src/_ZN9MontyMole6RenderEv.cpp
+++ b/src/_ZN9MontyMole6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN9MontyMole6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "MontyMole.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN9MontyMole6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int MontyMole::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN9MontyMole8BehaviorEv.cpp
+++ b/src/_ZN9MontyMole8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9MontyMole8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "MontyMole.h"
 struct C;
 typedef void (C::*PMF)();
 struct Entry { PMF pmf[1]; };
@@ -10,15 +13,17 @@ int func_ov080_02124208(void* c);
 void func_ov080_021243d8(char* t);
 void _ZN12CylinderClsn5ClearEv(void* c);
 void _ZN12CylinderClsn6UpdateEv(void* c);
-int _ZN9MontyMole8BehaviorEv(C* c){
-    char* p = (char*)c;
+}
+
+int MontyMole::Behavior()
+{
+    char* p = (char*)((C*)this);
     _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(p, p + 0x138);
-    int j = c->idx;
-    (c->*data_ov080_02128438[j].pmf[0])();
+    int j = ((C*)this)->idx;
+    (((C*)this)->*data_ov080_02128438[j].pmf[0])();
     func_ov080_02124208(p);
     func_ov080_021243d8(p);
     _ZN12CylinderClsn5ClearEv(p + 0x138);
     _ZN12CylinderClsn6UpdateEv(p + 0x138);
     return 1;
-}
 }

--- a/src/_ZN9MontyMoleD0Ev.c
+++ b/src/_ZN9MontyMoleD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9MontyMoleD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV11daChoropu_c */
 extern void *G0;
 int *_ZN9MontyMoleD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daChoropu_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x138);
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9OneUpLogo13InitResourcesEv.cpp
+++ b/src/_ZN9OneUpLogo13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9OneUpLogo13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpLogo.h"
 extern "C" {
 struct SharedFilePtr { int a, file; };
 extern SharedFilePtr data_ov002_02110a9c;
@@ -8,28 +11,29 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* self, void* btp, int a, int c, unsigned int n);
+}
 
-int _ZN9OneUpLogo13InitResourcesEv(char* self){
+int OneUpLogo::InitResources()
+{
   unsigned short n;
   {
-    unsigned int v = *(unsigned int*)(self+8);
+    unsigned int v = mParam;
     n = (unsigned short)(v > 8 ? 7 : (v - 1));
   }
   _ZN15TextureSequence8LoadFileER13SharedFilePtr(data_ov002_02110a9c);
-  if (_ZN9ModelBase7SetFileEP8BMD_Fileii(self+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_02110aa4), 1, -1) == 0)
+  if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this)+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_02110aa4), 1, -1) == 0)
     return 0;
   _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File((void*)data_ov002_02110aa4.file, (void*)data_ov002_02110a9c.file);
-  _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(self+0x124, (void*)data_ov002_02110a9c.file, 0x40000000, 0, n);
-  *(unsigned char*)(self+0x14e) = 0;
-  *(int*)(self+0x13c) = *(int*)(self+0x5c);
-  *(int*)(self+0x140) = *(int*)(self+0x60);
-  *(int*)(self+0x144) = *(int*)(self+0x64);
-  *(int*)(self+0xa8) = 0x14000;
-  *(int*)(self+0x9c) = -0x2000;
-  *(int*)(self+0xa0) = -0x32000;
-  *(short*)(self+0x14c) = 0;
-  *(int*)(self+0x138) = 0;
-  *(int*)(self+0x148) = 0;
+  _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(((char*)this)+0x124, (void*)data_ov002_02110a9c.file, 0x40000000, 0, n);
+  unk_14e = 0;
+  unk_13c = mPosX;
+  unk_140 = mPosY;
+  unk_144 = mPosZ;
+  unk_0a8 = 0x14000;
+  unk_09c = -0x2000;
+  unk_0a0 = -0x32000;
+  unk_14c = 0;
+  unk_138 = 0;
+  unk_148 = 0;
   return 1;
-}
 }

--- a/src/_ZN9OneUpLogo6RenderEv.cpp
+++ b/src/_ZN9OneUpLogo6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9OneUpLogo6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "OneUpLogo.h"
 typedef unsigned short u16;
 
 struct VObj {
@@ -14,13 +17,13 @@ extern "C" {
 void _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 
-extern "C" int _ZN9OneUpLogo6RenderEv(char* c)
+int OneUpLogo::Render()
 {
-    if (*(u16*)(c + 0x100 + 0x4c) != 0) {
-        *(u16*)(((long long)(int)(c + 0x14c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    if (*(u16*)(((char*)this) + 0x100 + 0x4c) != 0) {
+        *(u16*)(((long long)(int)((char*)&unk_14c))) -= 1;
         return 1;
     }
-    _ZN15TextureSequence6UpdateER15ModelComponents(c + 0x124, c + 0xdc);
-    ((VObj*)(c + 0xd4))->m5(0);
+    _ZN15TextureSequence6UpdateER15ModelComponents(((char*)this) + 0x124, ((char*)this) + 0xdc);
+    ((VObj*)((char*)&mModel))->m5(0);
     return 1;
 }

--- a/src/_ZN9OneUpLogoD0Ev.c
+++ b/src/_ZN9OneUpLogoD0Ev.c
@@ -1,12 +1,15 @@
+// @symbol _ZN9OneUpLogoD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObj1UpLogo_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9OneUpLogoD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObj1UpLogo_c;
     _ZN15TextureSequenceD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9PowerStar13InitResourcesEv.cpp
+++ b/src/_ZN9PowerStar13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9PowerStar13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "PowerStar.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -60,12 +63,12 @@ extern s32 _ZN9PowerStar13InitResourcesEv(void *arg0);
 #define S8(o) (*(s8 *)(t + (o)))
 #define U16(o) (*(u16 *)(t + (o)))
 #define S32(o) (*(s32 *)(t + (o)))
-#define LU32(o) (*(u32 *)((int)(((long long)(int)(t + (o))) & 0xFFFFFFFFFFFFFFFFLL)))
-#define LU16(o) (*(u16 *)((int)(((long long)(int)(t + (o))) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LU32(o) (*(u32 *)((int)(((long long)(int)(t + (o))))))
+#define LU16(o) (*(u16 *)((int)(((long long)(int)(t + (o))))))
 
-s32 _ZN9PowerStar13InitResourcesEv(void *arg0)
+s32 PowerStar::InitResources()
 {
-    char *t = (char *)arg0;
+    char *t = (char *)((void *)this);
     s32 ret;
     s32 b;
     u32 p;
@@ -211,7 +214,7 @@ s32 _ZN9PowerStar13InitResourcesEv(void *arg0)
     S32(0x448) = S32(0x5c);
     S32(0x44c) = S32(0x60);
     S32(0x450) = S32(0x64);
-    q = (s32 *)((int)(((long long)(int)(t + 0x448)) & 0xFFFFFFFFFFFFFFFFLL));
+    q = (s32 *)((int)(((long long)(int)(t + 0x448))));
     S32(0x454) = q[0];
     S32(0x458) = q[1];
     S32(0x45c) = q[2];

--- a/src/_ZN9PowerStar16CleanupResourcesEv.cpp
+++ b/src/_ZN9PowerStar16CleanupResourcesEv.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" void UnloadSilverStarAndNumber(void);
+// @symbol _ZN9PowerStar16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PowerStar.h"
 extern "C" void _ZN5Actor11UntrackStarERa(void* self, signed char* star);
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(void* p);
 
@@ -8,17 +12,18 @@ extern char data_ov002_02110924;
 extern char data_ov002_02110964;
 extern char data_ov002_02110934;
 
-extern "C" int _ZN9PowerStar16CleanupResourcesEv(char* self){
-    int b = (*(unsigned short*)(self + 0xc) == 0xb2);
+int PowerStar::CleanupResources()
+{
+    int b = (unk_00c == 0xb2);
     if (b) {
-        int v = *(int*)(self + 0x43c);
+        int v = unk_43c;
         if (v != 8) {
             if (v == 6)
                 UnloadSilverStarAndNumber();
-            _ZN5Actor11UntrackStarERa(self, (signed char*)(self + 0x498));
+            _ZN5Actor11UntrackStarERa(((char*)this), (signed char*)((char*)&unk_498));
         }
     } else {
-        _ZN5Actor11UntrackStarERa(self, (signed char*)(self + 0x498));
+        _ZN5Actor11UntrackStarERa(((char*)this), (signed char*)((char*)&unk_498));
         UnloadSilverStarAndNumber();
     }
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_02110944);

--- a/src/_ZN9PowerStar6RenderEv.cpp
+++ b/src/_ZN9PowerStar6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9PowerStar6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PowerStar.h"
 struct Thing { int x; };
 
 struct Sub {
@@ -25,18 +28,19 @@ struct Obj {
     unsigned short b2 : 1;  /* bit 2 */
 };
 
-extern "C" int _ZN9PowerStar6RenderEv(Obj *self) {
+int PowerStar::Render()
+{
     int locked;
-    if (self->arg80.x == 0) goto done;
-    locked = (self->fb0 & 0x40000) != 0;
+    if (((Obj *)this)->arg80.x == 0) goto done;
+    locked = (((Obj *)this)->fb0 & 0x40000) != 0;
     if (locked) goto done;
-    if (self->b1) goto callit;
+    if (((Obj *)this)->b1) goto callit;
 done:
     return 1;
 callit:
-    if (!self->b2)
-        self->sub30c.m5(&self->arg80);
+    if (!((Obj *)this)->b2)
+        ((Obj *)this)->sub30c.m5(&((Obj *)this)->arg80);
     else
-        self->sub370.m5(&self->arg80);
+        ((Obj *)this)->sub370.m5(&((Obj *)this)->arg80);
     return 1;
 }

--- a/src/_ZN9PowerStar8BehaviorEv.cpp
+++ b/src/_ZN9PowerStar8BehaviorEv.cpp
@@ -1,20 +1,21 @@
 //cpp
+// @symbol _ZN9PowerStar8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "PowerStar.h"
 struct C;
 typedef void (C::*PMF)();
 
 struct V3 { int x, y, z; };
 
 extern "C" {
-extern void func_ov002_020e700c(char *c);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(char *c, char *clsn);
 extern void func_ov002_020d718c(void *p);
-extern void func_ov002_020e84ec(char *c);
 extern void _ZN12CylinderClsn5ClearEv(char *c);
-extern void func_ov002_020e763c(char *c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char *c, void *clsn);
 extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(char *c, const void *v);
 extern void _ZN12CylinderClsn6UpdateEv(char *c);
-extern void func_ov002_020e7eb8(char *c);
 extern int data_0209b454;
 extern int data_ov002_0210aa0c[3];
 }
@@ -23,50 +24,50 @@ extern PMF data_ov002_021109d8[];
 
 struct C { char pad[0x800]; };
 
-extern "C" int _ZN9PowerStar8BehaviorEv(char *c)
+int PowerStar::Behavior()
 {
-    func_ov002_020e700c(c);
-    *(int *)(c + 0x4a8) = 0;
-    *(int *)(c + 0x4ac) = 0;
-    *(int *)(c + 0x4b0) = 0;
+    func_ov002_020e700c(((char *)this));
+    unk_4a8 = 0;
+    unk_4ac = 0;
+    unk_4b0 = 0;
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x150) != 0) {
-        int state = *(int *)(c + 0x440);
-        if (state >= 5 && state <= 7 && *(void **)(c + 0xd0) != 0) {
-            func_ov002_020d718c(*(void **)(c + 0xd0));
-            *(int *)(c + 0xd0) = 0;
-            *(int *)((int)(c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000;
-            func_ov002_020e84ec(c);
-            _ZN12CylinderClsn5ClearEv(c + 0x110);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char *)this), ((char *)this) + 0x150) != 0) {
+        int state = unk_440;
+        if (state >= 5 && state <= 7 && *(void **)((char *)&mEatingPlayer) != 0) {
+            func_ov002_020d718c(*(void **)((char *)&mEatingPlayer));
+            mEatingPlayer = 0;
+            *(int *)((int)((char *)&unk_0b0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000;
+            func_ov002_020e84ec(((char *)this));
+            _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
             return 1;
         }
         if ((data_0209b454 & 0x4000000) != 0) {
-            if ((int)((*(int *)(c + 0xb0) & 0x4000000) != 0) != 0) {
-                char *p = *(char **)(c + 0xd0);
+            if ((int)((unk_0b0 & 0x4000000) != 0) != 0) {
+                char *p = *(char **)((char *)&mEatingPlayer);
                 if (p != 0)
                     *(int *)((int)(p + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
             }
         }
-        func_ov002_020e84ec(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x110);
+        func_ov002_020e84ec(((char *)this));
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
         return 1;
     }
 
-    *(int *)(c + 0xd0) = 0;
-    func_ov002_020e763c(c);
-    (((C *)c)->*data_ov002_021109d8[*(int *)(c + 0x440)])();
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-    func_ov002_020e84ec(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x110);
+    mEatingPlayer = 0;
+    func_ov002_020e763c(((char *)this));
+    (((C *)((char *)this))->*data_ov002_021109d8[unk_440])();
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char *)this), 0);
+    func_ov002_020e84ec(((char *)this));
+    _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
     {
         V3 v;
         v.x = data_ov002_0210aa0c[0];
         v.y = data_ov002_0210aa0c[1];
         v.z = data_ov002_0210aa0c[2];
-        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x110, &v);
+        _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char *)this) + 0x110, &v);
     }
-    if (*(unsigned char *)(c + 0x49f) == 0)
-        _ZN12CylinderClsn6UpdateEv(c + 0x110);
-    func_ov002_020e7eb8(c);
+    if (unk_49f == 0)
+        _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
+    func_ov002_020e7eb8(((char *)this));
     return 1;
 }

--- a/src/_ZN9PowerStarD0Ev.c
+++ b/src/_ZN9PowerStarD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN9PowerStarD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daStar_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9PowerStarD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daStar_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x3d4);
     _ZN9ModelAnimD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);

--- a/src/_ZN9PowerStarD1Ev.c
+++ b/src/_ZN9PowerStarD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN9PowerStarD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9PowerStar */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9PowerStarD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9PowerStar;
     _ZN11ShadowModelD1Ev((char *)t + 0x3d4);
     _ZN9ModelAnimD1Ev((char *)t + 0x370);
     _ZN9ModelAnimD1Ev((char *)t + 0x30c);

--- a/src/_ZN9PushBlock6RenderEv.cpp
+++ b/src/_ZN9PushBlock6RenderEv.cpp
@@ -1,14 +1,19 @@
 //cpp
+// @symbol _ZN9PushBlock6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "PushBlock.h"
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual void g5(void*); };
-extern "C" int _ZN9PushBlock6RenderEv(char* c){
-  int f = (int)((*(int*)(c+0xb0) & 0x40000) != 0);
+
+int PushBlock::Render()
+{
+  int f = (int)((unk_0b0 & 0x40000) != 0);
   if (f != 0) return 1;
-  unsigned char st = *(unsigned char*)(c+0x3ca);
+  unsigned char st = unk_3ca;
   if (st < 0x2d && (st & 1)) return 1;
-  switch (*(int*)(c+0x3c0)) {
-  case 0: ((Sub*)(c+0xd4))->g5(c+0x80); break;
-  case 1: ((Sub*)(c+0x124))->g5(c+0x80); break;
-  case 2: ((Sub*)(c+0x124))->g5(c+0x80); break;
+  switch (unk_3c0) {
+  case 0: ((Sub*)((char*)&mModel1))->g5((char*)&mScaleX); break;
+  case 1: ((Sub*)((char*)&mModel2))->g5((char*)&mScaleX); break;
+  case 2: ((Sub*)((char*)&mModel2))->g5((char*)&mScaleX); break;
   }
   return 1;
 }

--- a/src/_ZN9PushBlockD0Ev.c
+++ b/src/_ZN9PushBlockD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol _ZN9PushBlockD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjPowerUpItem_c */
 extern void *G0;
 int *_ZN9PushBlockD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjPowerUpItem_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x200);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x1cc);
     _ZN11ShadowModelD1Ev((char *)t + 0x174);

--- a/src/_ZN9RabbitKey13InitResourcesEv.cpp
+++ b/src/_ZN9RabbitKey13InitResourcesEv.cpp
@@ -1,22 +1,25 @@
 //cpp
+// @symbol _ZN9RabbitKey13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "RabbitKey.h"
 extern "C" {
 void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* file, int a, int b);
 void _ZN11ShadowModel12InitCylinderEv(void* self);
 void func_ov085_0212d268(void* c, void* p);
 }
-extern char data_ov085_021305d8;
-extern char data_ov085_0213071c;
 
-extern "C" int _ZN9RabbitKey13InitResourcesEv(char* c)
+int RabbitKey::InitResources()
 {
     void* f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov085_021305d8);
-    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x110, f, 1, -1) == 0)
+    if (_ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0x110, f, 1, -1) == 0)
         return 0;
-    _ZN11ShadowModel12InitCylinderEv(c + 0x160);
-    *(int*)(c + 0x19c) = *(int*)(c + 8) & 0xff;
-    *(int*)(c + 0xa0) = -0x3c000;
-    *(int*)(c + 0x190) = 0;
-    func_ov085_0212d268(c, &data_ov085_0213071c);
+    _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
+    unk_19c = unk_008 & 0xff;
+    unk_0a0 = -0x3c000;
+    unk_190 = 0;
+    func_ov085_0212d268(((char*)this), &data_ov085_0213071c);
     return 1;
 }

--- a/src/_ZN9RabbitKey8BehaviorEv.cpp
+++ b/src/_ZN9RabbitKey8BehaviorEv.cpp
@@ -1,26 +1,31 @@
 //cpp
+// @symbol _ZN9RabbitKey8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "RabbitKey.h"
 extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(void* a, void* b);
-int _ZN9RabbitKey8BehaviorEv(char* c){
-  DecIfAbove0_Short((unsigned short*)(c+0x100));
-  void* o = *(void**)(c+0x188);
+}
+
+int RabbitKey::Behavior()
+{
+  DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
+  void* o = *(void**)((char*)&unk_188);
   if(*(int*)((char*)o+8)){
     char* base = (char*)o+8;
     int adj = *(int*)(base+4);
-    char* self = c + (adj>>1);
+    char* self = ((char*)this) + (adj>>1);
     void* fn;
     if(adj&1){ void* vt=*(void**)self; fn=*(void**)((char*)vt + *(int*)base); }
     else fn=*(void**)base;
     ((void(*)(char*))fn)(self);
   }
-  int s = *(int*)(c+0xa8) + *(int*)(c+0x9c);
-  int lim = *(int*)(c+0xa0);
+  int s = unk_0a8 + unk_09c;
+  int lim = unk_0a0;
   if(s >= lim) lim = s;
-  int t = *(int*)(c+0xac);
-  *(int*)(c+0xa8) = lim;
-  *(int*)(c+0xac) = t;
-  _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, 0);
+  int t = unk_0ac;
+  unk_0a8 = lim;
+  unk_0ac = t;
+  _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(((char*)this), 0);
   return 1;
-}
 }

--- a/src/_ZN9RabbitKeyD0Ev.c
+++ b/src/_ZN9RabbitKeyD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN9RabbitKeyD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObj_Mip_Key_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9RabbitKeyD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV15daObj_Mip_Key_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x160);
     _ZN5ModelD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN9RabbitKeyD1Ev.c
+++ b/src/_ZN9RabbitKeyD1Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol _ZN9RabbitKeyD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9RabbitKey */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9RabbitKeyD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9RabbitKey;
     _ZN11ShadowModelD1Ev((char *)t + 0x160);
     _ZN5ModelD1Ev((char *)t + 0x110);
     func_ov002_020aed18(t);

--- a/src/_ZN9SeesawBob6RenderEv.cpp
+++ b/src/_ZN9SeesawBob6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN9SeesawBob6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "SeesawBob.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN9SeesawBob6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int SeesawBob::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN9SeesawBob8BehaviorEv.cpp
+++ b/src/_ZN9SeesawBob8BehaviorEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9SeesawBob8BehaviorEv
+/* recovered: named members + shared header, real C++ method */
+#include "SeesawBob.h"
 typedef short s16;
 struct V3 { int x, y, z; };
 extern "C" {
@@ -9,33 +12,34 @@ void func_ov095_021358cc(void* c, void* a, void* b, int d, int e, int f, int g);
 void func_ov095_0213597c(char *t);
 int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
+}
 
-int _ZN9SeesawBob8BehaviorEv(char* c){
-    int b = (int)((*(int*)(c + 0xb0) & 8) != 0);
+int SeesawBob::Behavior()
+{
+    int b = (int)((unk_0b0 & 8) != 0);
     if (b != 0) {
-        if (_ZN16MeshColliderBase9IsEnabledEv(c + 0x124)) {
-            _ZN16MeshColliderBase7DisableEv(c + 0x124);
+        if (_ZN16MeshColliderBase9IsEnabledEv((char*)&mMeshCollider)) {
+            _ZN16MeshColliderBase7DisableEv((char*)&mMeshCollider);
         }
         return 1;
     }
-    if (*(unsigned char*)(c + 0x326) == 0) {
-        func_ov095_021358cc(c, c + 0x8c, c + 0x324, 0, 6, 3, 3);
+    if (unk_326 == 0) {
+        func_ov095_021358cc(((char*)this), ((char*)this) + 0x8c, ((char*)this) + 0x324, 0, 6, 3, 3);
     }
     {
-        int s = *(short*)(c + 0x324);
+        int s = unk_324;
         if (s < 0) s = (short)-s;
         if (s > 0xa) {
-            *(int*)(c + 0x320) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
-                *(unsigned int*)(c + 0x320), 3, 0x8b, c + 0x74, 0);
+            unk_320 = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+                unk_320, 3, 0x8b, ((char*)this) + 0x74, 0);
         }
     }
-    if (*(short*)(c + 0x8c) > 0x2000) *(short*)(c + 0x8c) = 0x2000;
-    if (*(short*)(c + 0x8c) < -0x2000) *(short*)(c + 0x8c) = -0x2000;
-    func_ov095_0213597c(c);
-    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0)) {
-        _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    if (unk_08c > 0x2000) unk_08c = 0x2000;
+    if (unk_08c < -0x2000) unk_08c = -0x2000;
+    func_ov095_0213597c(((char*)this));
+    if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0)) {
+        _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     }
-    *(unsigned char*)(c + 0x326) = 0;
+    unk_326 = 0;
     return 1;
-}
 }

--- a/src/_ZN9SeesawBobD0Ev.c
+++ b/src/_ZN9SeesawBobD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9SeesawBobD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjSeesaw_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9SeesawBobD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjSeesaw_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9SeesawBobD1Ev.c
+++ b/src/_ZN9SeesawBobD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9SeesawBobD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjSeesaw_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9SeesawBobD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjSeesaw_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9ShipWater6RenderEv.cpp
+++ b/src/_ZN9ShipWater6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN9ShipWater6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "ShipWater.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN9ShipWater6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int ShipWater::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN9ShipWaterD0Ev.c
+++ b/src/_ZN9ShipWaterD0Ev.c
@@ -1,16 +1,18 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9ShipWaterD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9ShipWaterD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjKsWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9ShipWaterD1Ev.c
+++ b/src/_ZN9ShipWaterD1Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9ShipWaterD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjKsWater_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9ShipWaterD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjKsWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
+++ b/src/_ZN9SolidHeap11VMemoryLeftEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN9SolidHeap11VMemoryLeftEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SolidHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SolidHeap.h"
 extern "C" {
-extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap11VMemoryLeftEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+unsigned int SolidHeap::VMemoryLeft()
+{
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)((char*)&unk_014), 4);
 }

--- a/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
+++ b/src/_ZN9SolidHeap14VDeallocateAllEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN9SolidHeap14VDeallocateAllEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SolidHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SolidHeap.h"
 extern "C" {
-extern void _ZN18SolidHeapAllocator5ResetEj(void*, unsigned int);
-
-void _ZN9SolidHeap14VDeallocateAllEv(char* self) {
-    _ZN18SolidHeapAllocator5ResetEj(*(void**)(self + 0x14), 3);
 }
+
+void SolidHeap::VDeallocateAll()
+{
+    _ZN18SolidHeapAllocator5ResetEj(*(void**)((char*)&unk_014), 3);
 }

--- a/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
+++ b/src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN9SolidHeap19VMaxAllocatableSizeEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SolidHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SolidHeap.h"
 extern "C" {
-extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap19VMaxAllocatableSizeEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+unsigned int SolidHeap::VMaxAllocatableSize()
+{
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)((char*)&unk_014), 4);
 }

--- a/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
+++ b/src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN9SolidHeap22VMaxAllocationUnitSizeEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_SolidHeapAllocator.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SolidHeap.h"
 extern "C" {
-extern unsigned int _ZN18SolidHeapAllocator10MemoryLeftEi(void*, int);
-
-unsigned int _ZN9SolidHeap22VMaxAllocationUnitSizeEv(char* self) {
-    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)(self + 0x14), 4);
 }
+
+unsigned int SolidHeap::VMaxAllocationUnitSize()
+{
+    return _ZN18SolidHeapAllocator10MemoryLeftEi(*(void**)((char*)&unk_014), 4);
 }

--- a/src/_ZN9SolidHeap7VSizeofEPv.cpp
+++ b/src/_ZN9SolidHeap7VSizeofEPv.cpp
@@ -1,7 +1,13 @@
 //cpp
+// @symbol _ZN9SolidHeap7VSizeofEPv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "SolidHeap.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual int m(void*); };
-extern "C" void Crash();
-extern "C" int _ZN9SolidHeap7VSizeofEPv(Base *c, void *a){
+
+int SolidHeap::VSizeof(void * a)
+{
   Crash();
   return -1;
 }

--- a/src/_ZN9Spindrift13InitResourcesEv.cpp
+++ b/src/_ZN9Spindrift13InitResourcesEv.cpp
@@ -1,26 +1,27 @@
 //cpp
+// @symbol _ZN9Spindrift13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Spindrift.h"
 struct BMD_File; struct BCA_File; struct Actor; struct Vector3_16;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
-extern "C" void AnimLoadFile(void *fp);
 struct ModelAnim { void SetAnim(BCA_File *f, int b, int c, unsigned int d); };
 struct ShadowModel { int InitCylinder(); };
 struct MovingCylinderClsn { void Init(Actor *a, int b, int c, unsigned int d, unsigned int e); };
 struct WithMeshClsn { void Init(Actor *a, int b, int c, void *d, int e); void StartDetectingWater(); };
-extern "C" char data_ov081_02128d60;
-extern "C" int data_ov081_02128d68[];
 
-extern "C" int _ZN9Spindrift13InitResourcesEv(Actor *self)
+int Spindrift::InitResources()
 {
-    char *s = (char*)self;
+    char *s = (char*)((Actor *)this);
     void *mf = ModelLoadFile(&data_ov081_02128d60);
     ((ModelBase*)(s + 0x110))->SetFile((BMD_File*)mf, 1, -1);
     AnimLoadFile(data_ov081_02128d68);
     ((ModelAnim*)(s + 0x110))->SetAnim((BCA_File*)data_ov081_02128d68[1], 0, 0x1000, 0);
     if (((ShadowModel*)(s + 0x174))->InitCylinder() == 0)
         return 0;
-    ((MovingCylinderClsn*)(s + 0x19c))->Init(self, 0x3c000, 0x78000, 0x200000, 0xa6efe0);
-    ((WithMeshClsn*)(s + 0x1d0))->Init(self, 0x3c000, 0x3c000, 0, 0);
+    ((MovingCylinderClsn*)(s + 0x19c))->Init(((Actor *)this), 0x3c000, 0x78000, 0x200000, 0xa6efe0);
+    ((WithMeshClsn*)(s + 0x1d0))->Init(((Actor *)this), 0x3c000, 0x3c000, 0, 0);
     ((WithMeshClsn*)(s + 0x1d0))->StartDetectingWater();
     *(int*)(s + 0x38c) = *(int*)(s + 0x5c);
     *(int*)(s + 0x390) = *(int*)(s + 0x60);

--- a/src/_ZN9Spindrift6RenderEv.cpp
+++ b/src/_ZN9Spindrift6RenderEv.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol _ZN9Spindrift6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Spindrift.h"
 struct Obj { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual void m5(int); };
-extern "C" int _ZN9Spindrift6RenderEv(char* r0) {
-  int b = (*(unsigned int*)(r0 + 0xb0) & 0x40000) ? 1 : 0; if (b) return 1;
-  Obj* o = (Obj*)(r0 + 0x110);
+
+int Spindrift::Render()
+{
+  int b = (unk_0b0 & 0x40000) ? 1 : 0; if (b) return 1;
+  Obj* o = (Obj*)((char*)&mModelAnim);
   o->m5(0);
   return 1;
 }

--- a/src/_ZN9Spindrift8BehaviorEv.cpp
+++ b/src/_ZN9Spindrift8BehaviorEv.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol _ZN9Spindrift8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_Enemy.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Spindrift.h"
 extern "C" {
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void *, void *, void *, unsigned);
-extern void func_ov081_021237ec(void *);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *, void *);
-extern int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(void *, void *);
-extern void func_ov081_02123b20(void *);
 extern void _ZN12CylinderClsn5ClearEv(void *);
 extern void _ZN12CylinderClsn6UpdateEv(void *);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *, void *);
-extern void func_ov081_02123910(void *);
 extern void _Z14ApproachLinearRiii(void *, int, int);
 extern void *_ZN5Actor13ClosestPlayerEv(void *);
 extern int Vec3_HorzDist(void *a, void *b);
@@ -19,72 +21,72 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *, void *);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *, void *, unsigned);
 extern int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *, void *, int, short, int, int, int);
 /* sig: (this, WithMeshClsn&, Fix12, short, bool, bool, Fix12) */
+}
 
-int _ZN9Spindrift8BehaviorEv(char *c)
+int Spindrift::Behavior()
 {
-    int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c + 0x1d0, c + 0x110, 3);
+    int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(((char *)this), ((char *)this) + 0x1d0, ((char *)this) + 0x110, 3);
     if (r != 0) {
         if (r == 2)
-            func_ov081_021237ec(c);
+            func_ov081_021237ec(((char *)this));
         return 1;
     }
 
-    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(c, c + 0x1d0) != 0) {
-        if (_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(c, c + 0x19c) != 0)
-            func_ov081_021237ec(c);
-        func_ov081_02123b20(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x19c);
-        if (*(unsigned char *)(c + 0x107) != 0 && *(unsigned short *)(c + 0x104) == 0) {
-            _ZN12CylinderClsn6UpdateEv(c + 0x19c);
+    if (_ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(((char *)this), ((char *)this) + 0x1d0) != 0) {
+        if (_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(((char *)this), ((char *)this) + 0x19c) != 0)
+            func_ov081_021237ec(((char *)this));
+        func_ov081_02123b20(((char *)this));
+        _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
+        if (unk_107 != 0 && unk_104 == 0) {
+            _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
         }
         return 1;
     }
 
-    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x19c);
-    func_ov081_02123910(c);
+    _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(((char *)this), ((char *)this) + 0x19c);
+    func_ov081_02123910(((char *)this));
 
-    switch (*(unsigned char *)(c + 0x39a)) {
+    switch (unk_39a) {
     case 0: {
-            _Z14ApproachLinearRiii(c + 0x98, 0x4000, 0x1000);
-            void *cp = _ZN5Actor13ClosestPlayerEv(c);
+            _Z14ApproachLinearRiii(((char *)this) + 0x98, 0x4000, 0x1000);
+            void *cp = _ZN5Actor13ClosestPlayerEv(((char *)this));
             if (cp != 0) {
                 int *src = (int *)(((int)cp + 0x5c) & 0xFFFFFFFFFFFFFFFFull);
                 int v3[3];
                 v3[0] = src[0];
                 v3[1] = src[1];
                 v3[2] = src[2];
-                if (Vec3_HorzDist(c + 0x38c, (void *)v3) > 0x3e8000) {
-                    *(short *)(c + 0x398) = Vec3_HorzAngle(c + 0x5c, c + 0x38c);
-                } else if (Vec3_HorzDist(c + 0x5c, (void *)v3) > 0x12c000) {
-                    *(short *)(c + 0x398) = Vec3_HorzAngle(c + 0x5c, (void *)v3);
+                if (Vec3_HorzDist(((char *)this) + 0x38c, (void *)v3) > 0x3e8000) {
+                    unk_398 = Vec3_HorzAngle(((char *)this) + 0x5c, ((char *)this) + 0x38c);
+                } else if (Vec3_HorzDist(((char *)this) + 0x5c, (void *)v3) > 0x12c000) {
+                    unk_398 = Vec3_HorzAngle(((char *)this) + 0x5c, (void *)v3);
                 }
                 goto after_st0;
             }
-            *(short *)(c + 0x398) = Vec3_HorzAngle(c + 0x5c, c + 0x38c);
+            unk_398 = Vec3_HorzAngle(((char *)this) + 0x5c, ((char *)this) + 0x38c);
         after_st0:
-            _Z14ApproachLinearRsss(c + 0x8e, *(short *)(c + 0x398), 0x200);
-            *(short *)(c + 0x94) = *(short *)(c + 0x8e);
+            _Z14ApproachLinearRsss(((char *)this) + 0x8e, unk_398, 0x200);
+            unk_094 = unk_08e;
         }
         break;
     case 1:
-        *(unsigned short *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFull) += 1;
-        if (*(unsigned short *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFull) >= 0x14)
-            *(unsigned char *)(c + 0x39a) = 0;
+        *(unsigned short *)(((int)((char *)this) + 0x100) & 0xFFFFFFFFFFFFFFFFull) += 1;
+        if (*(unsigned short *)(((int)((char *)this) + 0x100) & 0xFFFFFFFFFFFFFFFFull) >= 0x14)
+            unk_39a = 0;
         break;
     }
 
-    _ZN9Animation7AdvanceEv(c + 0x160);
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
-    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x1d0, 0);
+    _ZN9Animation7AdvanceEv((char *)&mAnimation);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char *)this), 0);
+    _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char *)this), ((char *)this) + 0x1d0, 0);
 
-    if (_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(c, c + 0x1d0, 0x3c000, 0x2888, 1, 1, 0x32000) != 0) {
-        *(int *)(c + 0x5c) = *(int *)(c + 0x68);
-        *(int *)(c + 0x60) = *(int *)(c + 0x6c);
-        *(int *)(c + 0x64) = *(int *)(c + 0x70);
+    if (_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(((char *)this), ((char *)this) + 0x1d0, 0x3c000, 0x2888, 1, 1, 0x32000) != 0) {
+        mPosX = unk_068;
+        mPosY = unk_06c;
+        mPosZ = unk_070;
     }
-    func_ov081_02123b20(c);
-    _ZN12CylinderClsn5ClearEv(c + 0x19c);
-    _ZN12CylinderClsn6UpdateEv(c + 0x19c);
+    func_ov081_02123b20(((char *)this));
+    _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
+    _ZN12CylinderClsn6UpdateEv((char *)&mCylinderClsn);
     return 1;
-}
 }

--- a/src/_ZN9SpindriftD0Ev.c
+++ b/src/_ZN9SpindriftD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN9SpindriftD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV8daHuwa_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9SpindriftD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daHuwa_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1d0);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x19c);
     _ZN11ShadowModelD1Ev((char *)t + 0x174);

--- a/src/_ZN9SpindriftD1Ev.c
+++ b/src/_ZN9SpindriftD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN9SpindriftD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9Spindrift */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9SpindriftD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9Spindrift;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x1d0);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x19c);
     _ZN11ShadowModelD1Ev((char *)t + 0x174);

--- a/src/_ZN9Submarine13InitResourcesEv.cpp
+++ b/src/_ZN9Submarine13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9Submarine13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Submarine.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BTA_File;
@@ -10,33 +15,32 @@ extern void _ZN9Animation8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(struct BMD_File &, struct BTA_File &);
 extern void _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(void *thisp, struct BTA_File &, int, int, unsigned int);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisp, struct BCA_File *, int, int, unsigned int);
-extern "C" void func_ov026_02111ee0(void *c, void *p);
 
 struct FilePtr4 { int a; void *file; };
 extern struct FilePtr4 data_ov026_02113f0c;
 extern struct FilePtr4 data_ov026_02113f04;
 extern struct BTA_File data_ov026_02112f40;
-extern int data_ov026_02113f2c;
 
-extern "C" int _ZN9Submarine13InitResourcesEv(char *self) {
+int Submarine::InitResources()
+{
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(*(struct SharedFilePtr *)&data_ov026_02113f0c);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0x114, bmd, 1, -1);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x114, bmd, 1, -1);
 
     _ZN9Animation8LoadFileER13SharedFilePtr(*(struct SharedFilePtr *)&data_ov026_02113f04);
 
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*(struct BMD_File *)data_ov026_02113f0c.file, data_ov026_02112f40);
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(self + 0x178, data_ov026_02112f40, 0, 0x1000, 0);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char *)this) + 0x178, data_ov026_02112f40, 0, 0x1000, 0);
 
-    *(int *)(self + 0x184) = 0x1000;
-    *(int *)(self + 0x170) = 0x1000;
+    unk_184 = 0x1000;
+    unk_170 = 0x1000;
 
-    *(int *)(self + 0x1a8) = *(int *)(self + 0x5c);
-    *(int *)(self + 0x1ac) = *(int *)(self + 0x60);
-    *(int *)(self + 0x1b0) = *(int *)(self + 0x64);
-    *(int *)(((int)self + 0x1ac) & 0xFFFFFFFFFFFFFFFF) -= 0x64000;
+    unk_1a8 = mPosX;
+    unk_1ac = mPosY;
+    unk_1b0 = mPosZ;
+    *(int *)(((int)((char *)this) + 0x1ac) & 0xFFFFFFFFFFFFFFFF) -= 0x64000;
 
-    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x114, (struct BCA_File *)data_ov026_02113f04.file, 0, 0x1000, 0);
+    _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x114, (struct BCA_File *)data_ov026_02113f04.file, 0, 0x1000, 0);
 
-    func_ov026_02111ee0(self, &data_ov026_02113f2c);
+    func_ov026_02111ee0(((char *)this), &data_ov026_02113f2c);
     return 1;
 }

--- a/src/_ZN9Submarine6RenderEv.cpp
+++ b/src/_ZN9Submarine6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN9Submarine6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "Submarine.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0x114]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN9Submarine6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x178, (char *)c + 0x11c); Sub *b = &c->sub; b->m(0); return 1; }
+
+int Submarine::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x178, (char *)((Base *)this) + 0x11c); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN9Submarine8BehaviorEv.cpp
+++ b/src/_ZN9Submarine8BehaviorEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9Submarine8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "Submarine.h"
 typedef int (*dummy)();
 class C;
 typedef int (C::*PMF)();
@@ -10,43 +15,42 @@ extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* cc);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int fx, int t1, int t2, int s4, int s5);
-extern void func_ov026_02111f30(char* c);
 extern void _ZN9Animation7AdvanceEv(void* thiz);
 }
 
-extern "C" int _ZN9Submarine8BehaviorEv(char* c)
+int Submarine::Behavior()
 {
     volatile int v[3];
     int x, y, z;
 
-    DecIfAbove0_Short((unsigned short*)(c + 0x100));
+    DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
     {
-        char* obj = *(char**)(c + 0x110);
+        char* obj = *(char**)((char*)&unk_110);
         if (*(int*)(obj + 8) != 0) {
             PMF* pp = (PMF*)(obj + 8);
-            ((C*)c->**pp)();
+            ((C*)((char*)this)->**pp)();
         }
     }
-    _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
+    _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), 0);
 
-    x = *(int*)(c + 0x5c);
+    x = mPosX;
     v[0] = x;
-    y = *(int*)(c + 0x60);
+    y = mPosY;
     v[1] = y;
-    z = *(int*)(c + 0x64);
+    z = mPosZ;
     v[2] = z;
     y += 0x384000;
     v[1] = y;
 
-    *(void**)(c + 0x1b8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-        *(volatile unsigned int*)(c + 0x1b8), 0x139, v[0], v[1], z, 0, 0);
+    *(void**)((char*)&unk_1b8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        *(volatile unsigned int*)((char*)&unk_1b8), 0x139, v[0], v[1], z, 0, 0);
 
-    *(short*)(c + 0x8c) = *(short*)(c + 0x92);
-    *(short*)(c + 0x8e) = *(short*)(c + 0x94);
-    *(short*)(c + 0x90) = *(short*)(c + 0x96);
+    unk_08c = unk_092;
+    unk_08e = unk_094;
+    unk_090 = unk_096;
 
-    func_ov026_02111f30(c);
-    _ZN9Animation7AdvanceEv(c + 0x178);
-    _ZN9Animation7AdvanceEv(c + 0x164);
+    func_ov026_02111f30(((char*)this));
+    _ZN9Animation7AdvanceEv((char*)&mTextureTransformer);
+    _ZN9Animation7AdvanceEv((char*)&mAnimation);
     return 1;
 }

--- a/src/_ZN9SubmarineD0Ev.c
+++ b/src/_ZN9SubmarineD0Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN9SubmarineD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV18daWater_Tatumaki_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9SubmarineD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daWater_Tatumaki_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x178);
     _ZN9ModelAnimD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/_ZN9SubmarineD1Ev.c
+++ b/src/_ZN9SubmarineD1Ev.c
@@ -1,10 +1,14 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol _ZN9SubmarineD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9Submarine */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9SubmarineD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9Submarine;
     _ZN18TextureTransformerD1Ev((char *)t + 0x178);
     _ZN9ModelAnimD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/_ZN9TinyCover13InitResourcesEv.cpp
+++ b/src/_ZN9TinyCover13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9TinyCover13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "TinyCover.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -10,24 +15,20 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void* thiz, void* act);
 extern int _ZN5Event6GetBitEj(unsigned int n);
-extern int data_ov033_021124f0[];
-extern int data_ov033_02111bc8[];
-extern int data_ov033_021124e8[];
-extern int data_ov033_02111c1c[];
+}
 
-int _ZN9TinyCover13InitResourcesEv(char* c)
+int TinyCover::InitResources()
 {
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov033_021124f0);
-    _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, m, 1, 0x14);
+    _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, 0x14);
     _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(*(void**)((char*)data_ov033_021124f0 + 4), data_ov033_02111bc8);
-    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(c + 0x320, data_ov033_02111bc8, 0, 0x1000, 0);
-    _ZN8Platform21UpdateModelPosAndRotYEv(c);
-    _ZN8Platform19UpdateClsnPosAndRotEv(c);
+    _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj(((char*)this) + 0x320, data_ov033_02111bc8, 0, 0x1000, 0);
+    _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+    _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov033_021124e8);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, mc, c + 0x2ec, 0x1000, *(short*)(c + 0x8e), data_ov033_02111c1c);
-    _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
-    *(int*)(c + 0x334) = *(int*)(c + 0x60) - 0x3c000;
+        ((char*)this) + 0x124, mc, ((char*)this) + 0x2ec, 0x1000, unk_08e, data_ov033_02111c1c);
+    _ZN16MeshColliderBase6EnableEP5Actor(((char*)this) + 0x124, ((char*)this));
+    unk_334 = mPosY - 0x3c000;
     return _ZN5Event6GetBitEj(0xe) == 0;
-}
 }

--- a/src/_ZN9TinyCover6RenderEv.cpp
+++ b/src/_ZN9TinyCover6RenderEv.cpp
@@ -1,5 +1,12 @@
 //cpp
+// @symbol _ZN9TinyCover6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TinyCover.h"
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int _ZN9TinyCover6RenderEv(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+
+int TinyCover::Render()
+{
+ _ZN18TextureTransformer6UpdateER15ModelComponents((char *)((Base *)this) + 0x320, (char *)((Base *)this) + 0xdc); Sub *b = &((Base *)this)->sub; b->m(0); return 1;
+}

--- a/src/_ZN9TinyCoverD0Ev.c
+++ b/src/_ZN9TinyCoverD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9TinyCoverD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9TinyCoverD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN9TinyCoverD1Ev.c
+++ b/src/_ZN9TinyCoverD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9TinyCoverD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *_ZN9TinyCoverD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);

--- a/src/_ZN9TowerStep13InitResourcesEv.cpp
+++ b/src/_ZN9TowerStep13InitResourcesEv.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol _ZN9TowerStep13InitResourcesEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "TowerStep.h"
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* c, void* file, int a, int b);
@@ -8,20 +13,19 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* c, void* kcl, void* m, int fix, short s, void* clps);
 extern void func_020393d4(int* p, void* v);
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
-extern void* data_ov015_02114a8c;
-extern void* data_ov015_02114a84;
-extern void* data_ov015_02113654;
-int _ZN9TowerStep13InitResourcesEv(char* c) {
+}
+
+int TowerStep::InitResources()
+{
   void* f;
   f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov015_02114a8c);
-  _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
-  _ZN8Platform21UpdateModelPosAndRotYEv(c);
-  _ZN8Platform19UpdateClsnPosAndRotEv(c);
+  _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, f, 1, -1);
+  _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
+  _ZN8Platform19UpdateClsnPosAndRotEv(((char*)this));
   f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov015_02114a84);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-      c + 0x124, f, c + 0x2ec, 0x199, *(short*)(c + 0x8e), &data_ov015_02113654);
-  func_020393d4((int*)(c + 0x124), (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  *(unsigned char*)(c + 0x31e) = 0x3c;
+      ((char*)this) + 0x124, f, ((char*)this) + 0x2ec, 0x199, unk_08e, &data_ov015_02113654);
+  func_020393d4((int*)((char*)&mMeshCollider), (void*)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
+  unk_31e = 0x3c;
   return 1;
-}
 }

--- a/src/_ZN9TowerStep6RenderEv.cpp
+++ b/src/_ZN9TowerStep6RenderEv.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol _ZN9TowerStep6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "TowerStep.h"
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int _ZN9TowerStep6RenderEv(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+
+int TowerStep::Render()
+{
+ Base *b = &((Derived *)this)->base; b->m(0); return 1;
+}

--- a/src/_ZN9TowerStepD0Ev.c
+++ b/src/_ZN9TowerStepD0Ev.c
@@ -1,14 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9TowerStepD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Rotebar_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9TowerStepD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjBk_Rotebar_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9TowerStepD1Ev.c
+++ b/src/_ZN9TowerStepD1Ev.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol _ZN9TowerStepD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Rotebar_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9TowerStepD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjBk_Rotebar_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/_ZN9UkikiCageD0Ev.c
+++ b/src/_ZN9UkikiCageD0Ev.c
@@ -1,15 +1,16 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN9UkikiCageD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjHmMaruta_c; VT1 = _ZTV10dBgActor_c */
 extern void *G0;
 int *_ZN9UkikiCageD0Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjHmMaruta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN9UkikiCageD1Ev.c
+++ b/src/_ZN9UkikiCageD1Ev.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol _ZN9UkikiCageD1Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjHmMaruta_c; VT1 = _ZTV10dBgActor_c */
 int *_ZN9UkikiCageD1Ev(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjHmMaruta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/_ZN9WaterBomb13InitResourcesEv.cpp
+++ b/src/_ZN9WaterBomb13InitResourcesEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9WaterBomb13InitResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "WaterBomb.h"
 typedef int Fix12;
 struct BMD_File;
 struct SharedFilePtr { int h; };
@@ -48,67 +51,67 @@ struct Obj {
     int f3c8;                /* 0x3c8 */
 };
 
-extern "C" int _ZN9WaterBomb13InitResourcesEv(Obj* o)
+int WaterBomb::InitResources()
 {
     BMD_File* bmd;
     int kind;
 
-    kind = o->f8 & 0xf;
-    o->f3c8 = kind;
+    kind = ((Obj*)this)->f8 & 0xf;
+    ((Obj*)this)->f3c8 = kind;
 
-    if (o->f3c8 == 2)
+    if (((Obj*)this)->f3c8 == 2)
     {
         bmd = Model::LoadFile(data_ov002_0210da38);
-        if (((ModelBase*)&o->f300)->SetFile(bmd, 1, 0x16) == 0)
+        if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, 0x16) == 0)
             return 0;
     }
     else
     {
         Model::LoadFile(data_ov002_0210da38);
         bmd = Model::LoadFile(data_ov098_0213c91c);
-        if (((ModelBase*)&o->f300)->SetFile(bmd, 1, 0x16) == 0)
+        if (((ModelBase*)&((Obj*)this)->f300)->SetFile(bmd, 1, 0x16) == 0)
             return 0;
     }
 
-    if (((ShadowModel*)&o->f350)->InitCylinder() == 0)
+    if (((ShadowModel*)&((Obj*)this)->f350)->InitCylinder() == 0)
         return 0;
 
-    if (o->f3c8 == 0)
-        o->f3c4 = 0;
+    if (((Obj*)this)->f3c8 == 0)
+        ((Obj*)this)->f3c4 = 0;
     else
-        o->f3c4 = 1;
+        ((Obj*)this)->f3c4 = 1;
 
-    if (o->f3c8 != 0)
+    if (((Obj*)this)->f3c8 != 0)
     {
-        if (o->f3c8 == 2)
+        if (((Obj*)this)->f3c8 == 2)
         {
-            o->f80 = 0x800;
-            o->f84 = 0x800;
-            o->f88 = 0x800;
-            ((MovingCylinderClsn*)&o->f110)->Init((Actor*)o, 0x14000, 0x28000, 0x200004, 0);
-            ((WithMeshClsn*)&o->f144)->Init((Actor*)o, 0x1e000, 0x1e000, 0, 0);
+            ((Obj*)this)->f80 = 0x800;
+            ((Obj*)this)->f84 = 0x800;
+            ((Obj*)this)->f88 = 0x800;
+            ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x14000, 0x28000, 0x200004, 0);
+            ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x1e000, 0x1e000, 0, 0);
         }
         else
         {
-            o->f80 = 0x1000;
-            o->f84 = 0x1000;
-            o->f88 = 0x1000;
-            ((MovingCylinderClsn*)&o->f110)->Init((Actor*)o, 0x28000, 0x50000, 0x204004, 0);
-            ((WithMeshClsn*)&o->f144)->Init((Actor*)o, 0x32000, 0x32000, 0, 0);
+            ((Obj*)this)->f80 = 0x1000;
+            ((Obj*)this)->f84 = 0x1000;
+            ((Obj*)this)->f88 = 0x1000;
+            ((MovingCylinderClsn*)&((Obj*)this)->f110)->Init((Actor*)((Obj*)this), 0x28000, 0x50000, 0x204004, 0);
+            ((WithMeshClsn*)&((Obj*)this)->f144)->Init((Actor*)((Obj*)this), 0x32000, 0x32000, 0, 0);
         }
     }
 
-    o->f100 = 0;
-    o->f3b6 = 0;
-    *(short*)((char*)o + 0x300 + 0xb4) = 0;
-    o->f3a8 = o->f5c;
-    o->f3ac = o->f60;
-    o->f3b0 = o->f64;
+    ((Obj*)this)->f100 = 0;
+    ((Obj*)this)->f3b6 = 0;
+    *(short*)((char*)((Obj*)this) + 0x300 + 0xb4) = 0;
+    ((Obj*)this)->f3a8 = ((Obj*)this)->f5c;
+    ((Obj*)this)->f3ac = ((Obj*)this)->f60;
+    ((Obj*)this)->f3b0 = ((Obj*)this)->f64;
 
-    if ((unsigned int)(o->f3c8 - 1) <= 1)
+    if ((unsigned int)(((Obj*)this)->f3c8 - 1) <= 1)
     {
-        o->f9c = -0x3000;
-        o->fa0 = -0x50000;
+        ((Obj*)this)->f9c = -0x3000;
+        ((Obj*)this)->fa0 = -0x50000;
     }
 
     return 1;

--- a/src/_ZN9WaterBomb16CleanupResourcesEv.cpp
+++ b/src/_ZN9WaterBomb16CleanupResourcesEv.cpp
@@ -1,17 +1,21 @@
 //cpp
+// @symbol _ZN9WaterBomb16CleanupResourcesEv
+/* recovered: named members + shared header, real C++ method */
+#include "WaterBomb.h"
 extern "C" {
 struct SharedFilePtr { unsigned short fileID; unsigned char numRefs; char* filePtr; };
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr* self);
 extern struct SharedFilePtr data_ov002_0210da38;
 extern struct SharedFilePtr data_ov098_0213c91c;
+}
 
-int _ZN9WaterBomb16CleanupResourcesEv(char* c){
-  if (*(int*)(c+0x3c8) == 2) {
+int WaterBomb::CleanupResources()
+{
+  if (unk_3c8 == 2) {
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
   } else {
     _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da38);
     _ZN13SharedFilePtr7ReleaseEv(&data_ov098_0213c91c);
   }
   return 1;
-}
 }

--- a/src/_ZN9WaterBomb6RenderEv.cpp
+++ b/src/_ZN9WaterBomb6RenderEv.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol _ZN9WaterBomb6RenderEv
+/* recovered: named members + shared header, real C++ method */
+#include "WaterBomb.h"
 struct Obj {
     virtual void v0();
     virtual void v1();
@@ -7,11 +10,12 @@ struct Obj {
     virtual void v4();
     virtual void m(void *arg);
 };
-extern "C" int _ZN9WaterBomb6RenderEv(char *c)
+
+int WaterBomb::Render()
 {
-    if (*(int *)(c + 0x3c8) != 0) {
-        Obj *o = (Obj *)(c + 0x300);
-        o->m(c + 0x80);
+    if (unk_3c8 != 0) {
+        Obj *o = (Obj *)((char *)&mModel);
+        o->m((char *)&unk_080);
     }
     return 1;
 }

--- a/src/_ZN9WaterBomb8BehaviorEv.cpp
+++ b/src/_ZN9WaterBomb8BehaviorEv.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol _ZN9WaterBomb8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WaterBomb.h"
 extern "C" {
-extern int func_ov098_0213b6e0(char* c);
-extern void func_ov098_0213b584(char* c);
 extern void func_ov098_0213b63c(char* c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* a, void* b);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* a, void* b, unsigned int j);
@@ -10,19 +13,20 @@ extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
-extern int data_ov098_0213c930[];
+}
 
-int _ZN9WaterBomb8BehaviorEv(char* c) {
-    if (func_ov098_0213b6e0(c)) {
-        func_ov098_0213b584(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x110);
+int WaterBomb::Behavior()
+{
+    if (func_ov098_0213b6e0(((char*)this))) {
+        func_ov098_0213b584(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
         return 1;
     }
 
-    int idx = *(int*)(c + 0x3c4);
+    int idx = unk_3c4;
     char* ent = (char*)&data_ov098_0213c930[idx * 2];
     int adj = *(int*)(ent + 4);
-    char* self = c + (adj >> 1);
+    char* self = ((char*)this) + (adj >> 1);
     void* fn;
     if (adj & 1) {
         void* vt = *(void**)self;
@@ -32,23 +36,22 @@ int _ZN9WaterBomb8BehaviorEv(char* c) {
     }
     ((void (*)(char*))fn)(self);
 
-    if (*(int*)(c + 0x3c8) != 0) {
-        _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x110);
-        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, c + 0x144, 0);
-        if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x144)) {
-            if (*(int*)(c + 0x3c8) == 1) {
-                func_ov098_0213b63c(c);
+    if (unk_3c8 != 0) {
+        _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this) + 0x110);
+        _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char*)this), ((char*)this) + 0x144, 0);
+        if (_ZNK12WithMeshClsn8IsOnWallEv((char*)&mWithMeshClsn)) {
+            if (unk_3c8 == 1) {
+                func_ov098_0213b63c(((char*)this));
             } else {
-                _ZN9ActorBase18MarkForDestructionEv(c);
+                _ZN9ActorBase18MarkForDestructionEv(((char*)this));
             }
             return 0;
         }
-        func_ov098_0213b584(c);
-        _ZN12CylinderClsn5ClearEv(c + 0x110);
-        _ZN12CylinderClsn6UpdateEv(c + 0x110);
+        func_ov098_0213b584(((char*)this));
+        _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsn);
+        _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsn);
     } else {
-        DecIfAbove0_Short((unsigned short*)(c + 0x100));
+        DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
     }
     return 1;
-}
 }

--- a/src/_ZN9WaterBombD0Ev.c
+++ b/src/_ZN9WaterBombD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN9WaterBombD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV7daWbm_c */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9WaterBombD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daWbm_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN9WaterBombD1Ev.c
+++ b/src/_ZN9WaterBombD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol _ZN9WaterBombD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9WaterBomb */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9WaterBombD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9WaterBomb;
     _ZN11ShadowModelD1Ev((char *)t + 0x350);
     _ZN5ModelD1Ev((char *)t + 0x300);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x144);

--- a/src/_ZN9WaterRing8BehaviorEv.cpp
+++ b/src/_ZN9WaterRing8BehaviorEv.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol _ZN9WaterRing8BehaviorEv
+/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: named members + shared header, real C++ method */
+#include "WaterRing.h"
 extern "C" {
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* self, char* cc);
-extern void func_ov064_02119f1c(char* c);
 extern void _ZN12CylinderClsn5ClearEv(char* c);
 extern void _ZN12CylinderClsn6UpdateEv(char* c);
 extern void _ZN9Animation7AdvanceEv(char* c);
@@ -10,22 +14,22 @@ extern void _ZN9Animation7AdvanceEv(char* c);
 struct C;
 typedef void (C::*PMF)();
 
-extern "C" int _ZN9WaterRing8BehaviorEv(char* r4);
-extern "C" int _ZN9WaterRing8BehaviorEv(char* r4){
-  DecIfAbove0_Short((unsigned short*)(r4 + 0x100));
-  char* obj = *(char**)(r4 + 0x370);
+int WaterRing::Behavior()
+{
+  DecIfAbove0_Short((unsigned short*)((char*)&unk_100));
+  char* obj = *(char**)((char*)&unk_370);
   if (*(int*)(obj + 8) != 0) {
     PMF* p = (PMF*)(obj + 8);
-    C* c = (C*)r4;
+    C* c = (C*)((char*)this);
     (c->**p)();
   }
-  _ZN5Actor9UpdatePosEP12CylinderClsn(r4, r4 + 0x110);
-  *(short*)(r4 + 0x8c) = *(short*)(r4 + 0x92);
-  *(short*)(r4 + 0x8e) = *(short*)(r4 + 0x94);
-  *(short*)(r4 + 0x90) = *(short*)(r4 + 0x96);
-  func_ov064_02119f1c(r4);
-  _ZN12CylinderClsn5ClearEv(r4 + 0x110);
-  _ZN12CylinderClsn6UpdateEv(r4 + 0x110);
-  _ZN9Animation7AdvanceEv(r4 + 0x35c);
+  _ZN5Actor9UpdatePosEP12CylinderClsn(((char*)this), ((char*)this) + 0x110);
+  unk_08c = unk_092;
+  unk_08e = unk_094;
+  unk_090 = unk_096;
+  func_ov064_02119f1c(((char*)this));
+  _ZN12CylinderClsn5ClearEv((char*)&mMovingCylinderClsnWithPos);
+  _ZN12CylinderClsn6UpdateEv((char*)&mMovingCylinderClsnWithPos);
+  _ZN9Animation7AdvanceEv((char*)&mTextureTransformer);
   return 1;
 }

--- a/src/_ZN9WaterRingD0Ev.c
+++ b/src/_ZN9WaterRingD0Ev.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN9WaterRingD0Ev
+/* recovered: named members + shared header, vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified */
+/* vtable identified: VT0 = _ZTV14daWater_Ring_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
 int *_ZN9WaterRingD0Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daWater_Ring_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x35c);
     _ZN5ModelD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZN9WaterRingD1Ev.c
+++ b/src/_ZN9WaterRingD1Ev.c
@@ -1,12 +1,16 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
+// @symbol _ZN9WaterRingD1Ev
+/* recovered: named members + shared header, vtable identified, globals resolved, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_TextureTransformer.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: named members + shared header, vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV9WaterRing */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *_ZN9WaterRingD1Ev(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9WaterRing;
     _ZN18TextureTransformerD1Ev((char *)t + 0x35c);
     _ZN5ModelD1Ev((char *)t + 0x30c);
     _ZN12WithMeshClsnD1Ev((char *)t + 0x150);

--- a/src/_ZNK10ClsnResult6CopyToERS_.c
+++ b/src/_ZNK10ClsnResult6CopyToERS_.c
@@ -1,12 +1,14 @@
-void _ZNK10ClsnResult6CopyToERS_(const char *thiz, char *dst)
-{
-    *(long long *)(dst + 4) = *(const long long *)(thiz + 4);
-    *(int *)(dst + 0xc) = *(const int *)(thiz + 0xc);
-    *(int *)(dst + 0x10) = *(const int *)(thiz + 0x10);
-    *(int *)(dst + 0x14) = *(const int *)(thiz + 0x14);
-    *(unsigned short *)(dst + 0x18) = *(const unsigned short *)(thiz + 0x18);
-    *(unsigned short *)(dst + 0x1a) = *(const unsigned short *)(thiz + 0x1a);
-    *(int *)(dst + 0x1c) = *(const int *)(thiz + 0x1c);
-    *(int *)(dst + 0x20) = *(const int *)(thiz + 0x20);
-    *(int *)(dst + 0x24) = *(const int *)(thiz + 0x24);
+// @symbol _ZNK10ClsnResult6CopyToERS_
+/* recovered: named members + shared header */
+#include "ClsnResult.h"
+void _ZNK10ClsnResult6CopyToERS_(struct ClsnResult *self, char *dst) {
+    *(long long *)(dst + 4) = *(const long long *)((const char *)&self->unk_004);
+    *(int *)(dst + 0xc) = *(const int *)((const char *)&self->unk_00c);
+    *(int *)(dst + 0x10) = *(const int *)((const char *)&self->unk_010);
+    *(int *)(dst + 0x14) = *(const int *)((const char *)&self->unk_014);
+    *(unsigned short *)(dst + 0x18) = *(const unsigned short *)((const char *)&self->unk_018);
+    *(unsigned short *)(dst + 0x1a) = *(const unsigned short *)((const char *)&self->unk_01a);
+    *(int *)(dst + 0x1c) = *(const int *)((const char *)&self->unk_01c);
+    *(int *)(dst + 0x20) = *(const int *)((const char *)&self->unk_020);
+    *(int *)(dst + 0x24) = *(const int *)((const char *)&self->unk_024);
 }

--- a/src/_ZNK9Animation13GetFrameCountEv.cpp
+++ b/src/_ZNK9Animation13GetFrameCountEv.cpp
@@ -1,7 +1,11 @@
 //cpp
-extern "C" {
-unsigned int _ZNK9Animation13GetFrameCountEv(void* c){
-  unsigned int v=*(unsigned int*)((char*)c+4);
+// @symbol _ZNK9Animation13GetFrameCountEv
+/* recovered: named members + shared header, real C++ method */
+#include "Animation.h"
+
+
+unsigned int Animation::GetFrameCount() const
+{
+  unsigned int v=*(unsigned int*)((char*)&mFrameCountAndFlags);
   return ((v&0x3fffffff)<<4)>>16;
-}
 }

--- a/src/func_02005418.c
+++ b/src/func_02005418.c
@@ -1,3 +1,11 @@
+// @symbol func_02005418
+// @emits dScBoot_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_SaveData.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScBoot_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -15,30 +23,19 @@ extern u8 data_020a0dea[];
 extern u8 data_020a0deb[];
 extern u8 data_0209d454;
 
-extern int func_0201a1bc(void);
-extern void func_0201fe08(void);
-extern void func_02005348(void *self);
-extern int func_0203da3c(void);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
-extern int GetOwnerLanguage(void);
 extern u32 func_02054e88(void);
 extern u32 LoadCompressedFileAt(u16 fileID, void *target);
 extern int LoadFile(int handle);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void Deallocate(void *ptr);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
-extern void func_0201cd08(int arg);
-extern void SetSubBg0Offset(int a, int b);
-extern void SetSubBg1Offset(int a, int b);
 extern void func_02012790(int a);
-extern void _ZN7Message21DisplaySaveStatusTextEt(u16 a);
-extern void _ZN8SaveData16EraseAllSaveDataEv(void);
 
-#define LADR(p) ((void *)(unsigned int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LADR(p) ((void *)(unsigned int)(((long long)(int)(p))))
 
 #pragma opt_common_subs off
 
-int func_02005418(void *arg0)
+int dScBoot_c_Behavior(void *arg0)
 {
     char *c = (char *)arg0;
     u16 h58, h5a;

--- a/src/func_02005a58.c
+++ b/src/func_02005a58.c
@@ -1,30 +1,23 @@
-extern void _ZN2GX15DisableAllBanksEv(void);
+// @symbol func_02005a58
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScBoot_c.h"
+// @emits dScBoot_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScBoot_c::InitResources - recovered from vtable slot identity */
 extern void _ZN2GX12SetBankForBGEt(unsigned short b);
 extern void _ZN2GX13SetBankForOBJEt(unsigned short b);
 extern void _ZN2GX15SetBankForSubBGEt(unsigned short b);
 extern void _ZN2GX16SetBankForSubOBJEt(unsigned short b);
-extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
-extern void _ZN3GXS15SetGraphicsModeEi(int a);
-extern void _ZN2GX6DispOnEv(void);
-extern void SetBg0Offset(int a, int b);
-extern void* func_02054efc(void);
 extern void DecompressLZ16(const void* src, void* dst);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
 extern void* _ZN2G212GetBG0ScrPtrEv(void);
-extern void SetSubBg0Offset(int a, int b);
-extern void SetSubBg1Offset(int a, int b);
-extern void SetSubBg2Offset(int a, int b);
 extern unsigned func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, unsigned int a, unsigned int b);
 extern void* _ZN3G2S12GetBG2ScrPtrEv(void);
-extern void func_020233f4(void);
-extern void _ZN5Sound6Play2DEjj(unsigned int a, unsigned int b);
 extern int func_0201a244(void* fn, int a, int b, int c, int d);
 
-extern char data_020918c4;
-extern char data_020914e0;
-extern char data_020916d8;
-extern char data_02091570;
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 extern char data_0208ee44;
@@ -35,8 +28,9 @@ extern unsigned char data_0209f1e8;
 typedef unsigned int u32;
 typedef unsigned short u16;
 
-int func_02005a58(char* c)
+int dScBoot_c_InitResources(char* c)
 {
+    struct dScBoot_c *self = (struct dScBoot_c *)(void *)c;
     _ZN2GX15DisableAllBanksEv();
     _ZN2GX12SetBankForBGEt(1);
     _ZN2GX13SetBankForOBJEt(2);
@@ -90,10 +84,10 @@ int func_02005a58(char* c)
     *(volatile u32*)0x4000000 = (*(volatile u32*)0x4000000 & ~0x1f00) | 0x100;
     *(volatile u32*)0x4001000 = (*(volatile u32*)0x4001000 & ~0x1f00) | 0x400;
 
-    *(unsigned short*)(c + 0x50) = 0x3c;
-    *(unsigned char*)(c + 0x52) = 0;
-    *(unsigned char*)(c + 0x54) = 0;
-    *(unsigned char*)(c + 0x55) = 0;
+    self->unk_050 = 0x3c;
+    self->unk_052 = 0;
+    self->unk_054 = 0;
+    self->unk_055 = 0;
     *(int*)(&data_0208ee44) = 1;
     func_020233f4();
 

--- a/src/func_020070e8.c
+++ b/src/func_020070e8.c
@@ -1,8 +1,9 @@
-struct Vector3 { int x, y, z; };
-extern void func_02007c9c(const struct Vector3 *v0, const struct Vector3 *v1, int *outDist, short *outVertAng, short *outHorzAng);
-extern void Math_Function_0203b0fc(int *p, int target, int scale, int max);
+// @symbol func_020070e8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int ApproachAngle(short *angle, int targetAngle, int invFactor, int maxDelta, int minDelta);
-extern void func_02007c14(struct Vector3 *res, const struct Vector3 *trans, int mag, short ang, short angY);
 
 void func_020070e8(int *thiz, int p1, int p2, int p3, short flagV, short targetH, short flagH)
 {

--- a/src/func_02007b98.c
+++ b/src/func_02007b98.c
@@ -1,8 +1,11 @@
+// @symbol func_02007b98
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 
-struct Vector3 {
-    Fix12i x, y, z;
-};
+
 
 struct Actor {
     char pad0[0x5c];
@@ -25,7 +28,6 @@ struct Data {
 
 extern short ReadUnalignedShort(const void *p);
 extern void AddVec3(const struct Vector3 *a, const struct Vector3 *b, struct Vector3 *dest);
-extern int func_02007cec(void *self, const struct Vector3 *v, int a);
 
 int func_02007b98(struct Camera *cam, struct Data *data) {
     struct Vector3 v;

--- a/src/func_020084b0.c
+++ b/src/func_020084b0.c
@@ -1,3 +1,6 @@
+// @symbol func_020084b0
+/* recovered: shared common types */
+#include "common.h"
 // func_020084b0 @ 0x020084b0 - Camera/Actor member, size 0x50.
 // Reads a packed unaligned Vector3_16 (x,y,z s16) from a data record,
 // converts each component to Fix12i (<<12) and stores them as a Vector3
@@ -6,7 +9,7 @@
 typedef short s16;
 typedef int s32;
 
-struct Vector3 { s32 x, y, z; };
+
 
 struct Camera {
     char pad[0x8c];

--- a/src/func_02009138.c
+++ b/src/func_02009138.c
@@ -1,20 +1,21 @@
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int m[12]; };
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
+// @symbol func_02009138
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
 extern int Math_Function_0203b14c(int *p, int a, int b, int c, int d);
-extern void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
-extern void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx43 *m, short ang);
-extern void Matrix4x3_ApplyInPlaceToRotationX(struct Mtx43 *m, short ang);
-extern void MulVec3Mat4x3(struct Vec3 *v, struct Mtx43 *m, struct Vec3 *res);
-extern struct Mtx43 data_020a0e68;
+extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
+extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *m, short ang);
+extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *m, short ang);
+extern void MulVec3Mat4x3(struct Vector3 *v, struct Matrix4x3 *m, struct Vector3 *res);
+extern struct Matrix4x3 data_020a0e68;
 
 int func_02009138(int *thiz, int arg)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     int len;
     int r;
-    Vec3_Sub(&v, (struct Vec3*)((char*)thiz + 0x8c), (struct Vec3*)((char*)thiz + 0x80));
+    Vec3_Sub(&v, (struct Vector3*)((char*)thiz + 0x8c), (struct Vector3*)((char*)thiz + 0x80));
     len = LenVec3(&v);
     r = Math_Function_0203b14c(&len, arg, 0x300, 0x60000, 0x200);
     v.x = 0;
@@ -23,6 +24,6 @@ int func_02009138(int *thiz, int arg)
     Matrix4x3_FromTranslation(&data_020a0e68, thiz[0x20], thiz[0x21], thiz[0x22]);
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)((char*)thiz + 0x17c));
     Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)((char*)thiz + 0x17e));
-    MulVec3Mat4x3(&v, &data_020a0e68, (struct Vec3*)((char*)thiz + 0x8c));
+    MulVec3Mat4x3(&v, &data_020a0e68, (struct Vector3*)((char*)thiz + 0x8c));
     return (r == 0) ? 1 : 0;
 }

--- a/src/func_020092c4.c
+++ b/src/func_020092c4.c
@@ -1,14 +1,16 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
+// @symbol func_020092c4
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
 extern int Math_Function_0203b14c(int *a, int b, int c, int d, int e);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalarInPlace(int *v, int s);
-extern void Vec3_Add(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
+extern void Vec3_Add(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
 
-int func_020092c4(int arg0, struct Vec3 *out, struct Vec3 *target)
+int func_020092c4(int arg0, struct Vector3 *out, struct Vector3 *target)
 {
-    struct Vec3 d;
+    struct Vector3 d;
     int len;
     int r5;
     int scratch;
@@ -19,7 +21,7 @@ int func_020092c4(int arg0, struct Vec3 *out, struct Vec3 *target)
     r5 = Math_Function_0203b14c(&scratch, 0, 0x200, 0x40000, 0x8000);
     Vec3_MulScalarInPlace((int*)&d, _ZN4cstd4fdivEii(scratch, len));
     {
-        struct Vec3 res;
+        struct Vector3 res;
         Vec3_Add(&res, target, &d);
         out->x = res.x;
         out->y = res.y;

--- a/src/func_02009374.c
+++ b/src/func_02009374.c
@@ -1,3 +1,8 @@
+// @symbol func_02009374
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_02009374 @ 0x02009374, size 0x60, ARM.
  * Camera member: scans the 12-slot STAR_MARKERS array; for each live marker,
  * computes the squared 3D distance (Fix12, 64-bit) from the camera's ownerPos
@@ -7,9 +12,7 @@
 
 typedef int Fix12i; /* 20.12 fixed point */
 
-struct Vector3 {
-    Fix12i x, y, z;
-};
+
 
 /* Marker actor: only its world position (Actor::pos @ 0x5c) is touched here. */
 struct Actor {
@@ -24,8 +27,6 @@ struct Camera {
 };
 
 extern struct Actor *STAR_MARKERS[12];                  /* 0x0209f40c */
-extern long long Vec3_DistSq(const struct Vector3 *a,   /* 0x0203cf94 */
-                             const struct Vector3 *b);
 
 int func_02009374(struct Camera *self) {
     int i;

--- a/src/func_02009414.c
+++ b/src/func_02009414.c
@@ -1,11 +1,10 @@
-struct Vector3 {
-    int x, y, z;
-};
-
-extern int func_02008b4c(void* a0, void* p1, void* p2, void* tbl);
+// @symbol func_02009414
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 extern short Vec3_VertAngle(const struct Vector3 *v1, const struct Vector3 *v0);
-extern void func_020089f8(void *obj);
 
 int func_02009414(char *obj) {
     int r4 = 1;

--- a/src/func_0200af20.c
+++ b/src/func_0200af20.c
@@ -1,9 +1,12 @@
+// @symbol func_0200af20
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef long long s64;
-struct Vector3 { int x, y, z; };
+
 
 extern signed char data_0209f2f8;
-extern int data_02086f38[];
-extern int data_02086f48[];
 extern short data_02082214[];
 extern char data_0209f43c[];
 
@@ -74,5 +77,5 @@ void func_0200af20(char *c, struct Vector3 *v1, struct Vector3 *v2, short *out)
 
     *out = 0xe38;
     _ZN7Clipper13Func_020156DCEv(data_0209f43c, *(int *)(c + 0xf8), *out, *(int *)(c + 0xfc), *(int *)(c + 0x100));
-    *(int *)(int)(((long long)(int)(c + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    *(int *)(int)(((long long)(int)(c + 0x154))) &= ~1;
 }

--- a/src/func_0200b0fc.c
+++ b/src/func_0200b0fc.c
@@ -1,9 +1,15 @@
+// @symbol func_0200b0fc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern void _ZN7PathPtrC1Ev(void *self);
 extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
@@ -11,16 +17,11 @@ extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, struct Vector3 *out, uns
 extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
 extern int LenVec3(struct Vector3 *v);
 extern int NormalizeVec3IfNonZero(struct Vector3 *v);
-extern void func_0203cf00(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
 extern int DotVec3(const struct Vector3 *a, const struct Vector3 *b);
-extern unsigned int func_0203ad54(void *c);
-extern int _ZNK7PathPtr8NumNodesEv(void *self);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalarInPlace(int *v, int s);
 extern void Vec3_Add(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
 extern void Vec3_MulScalar(struct Vector3 *out, const struct Vector3 *in, int scale);
-extern int _ZNK7PathPtr5LoopsEv(void *self);
-extern unsigned int func_0203ad44(void *c);
 extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int func_020092c4(void *arg0, struct Vector3 *out, struct Vector3 *target);
 extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
@@ -122,7 +123,7 @@ void func_0200b0fc(char *c, char *a)
         lenBack = LenVec3(&diffBack);
         lenFwd = LenVec3(&tmp);
         if (lenFwd < lenBack) {
-            u8 *p = (u8*)((long long)(c + 0x1a7) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *p = (u8*)((long long)(c + 0x1a7));
             *p = *p + 1;
         }
     } else if (_ZNK7PathPtr5LoopsEv(path) != 0) {
@@ -146,7 +147,7 @@ void func_0200b0fc(char *c, char *a)
         lenA = LenVec3(&diffFwd2);
         lenB = LenVec3(&diffPrev);
         if (lenB < lenA) {
-            u8 *p = (u8*)((long long)(c + 0x1a7) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *p = (u8*)((long long)(c + 0x1a7));
             *p = *p - 1;
         }
     } else if (_ZNK7PathPtr5LoopsEv(path) != 0) {

--- a/src/func_0200bb28.c
+++ b/src/func_0200bb28.c
@@ -1,3 +1,8 @@
+// @symbol func_0200bb28
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -9,24 +14,20 @@ typedef unsigned long long u64;
 extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
 extern u16 data_0209f49e[];
-extern s32 data_02086cc8[];
-extern s32 data_02086d50[];
 
 extern u32 func_02012790(u32 a);
 extern s32 ApproachAngle(s16* cur, s16 target, s32 div, s32 band, s32 step);
 extern u16 DecIfAbove0_Short(u16* p);
 extern void _Z14ApproachLinearRsss(s16* p, s16 t, s16 r);
-extern void func_0200c9e0(void* c, s32* a, s32* b);
-extern s32 _ZN4cstd4sqrtEy(u64 v);
 extern void Vec3_RotateYAndTranslate(s32* out, s32* in, s16 ang, s32* src);
 extern s32 Math_Function_0203b14c(s32* p, s32 tgt, s32 rate, s32 lim, s32 step);
 extern s32 _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(s32* v, s32* t, s32 rate);
 
-#define L0(p) ((s32)(((long long)(s32)(p)) & 0xFFFFFFFFFFFFFFFFLL))
-#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p)) & 0xFFFFFFFFFFFFFFFFULL))
-#define L2(p) ((s32)((((long long)(s32)(p)) | 0LL) & 0xFFFFFFFFFFFFFFFFLL))
-#define L3(p) ((s32)(((unsigned long long)(s32)(p)) & 0xFFFFFFFFFFFFFFFFULL))
-struct Vec3 { s32 x, y, z; };
+#define L0(p) ((s32)(((long long)(s32)(p))))
+#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p))ULL))
+#define L2(p) ((s32)((((long long)(s32)(p)) | 0LL)))
+#define L3(p) ((s32)(((unsigned long long)(s32)(p))ULL))
+
 
 
 
@@ -35,9 +36,9 @@ void func_0200bb28(char* c, char* a1)
 {
     s32 flag4000;
     s32 sp_speed;
-    struct Vec3 vsrc;
-    struct Vec3 vin;
-    struct Vec3 vout;
+    struct Vector3 vsrc;
+    struct Vector3 vin;
+    struct Vector3 vout;
     s32* tbl;
     s32 comp;
     s32 m;

--- a/src/func_0200bec4.c
+++ b/src/func_0200bec4.c
@@ -1,12 +1,13 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_0200bec4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Data02086f2c { int unk0, unk4, unk8; };
 extern struct Data02086f2c data_02086f2c;
 
-extern unsigned int func_020093f4(void *p, int x);
 extern void Vec3_RotateYAndTranslate(struct Vector3 *out, void *a, short ang, int *t);
 extern void _ZN11RaycastLineC1Ev(void *self);
-extern void func_0200897c(void *self, void *arg);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void *self, const struct Vector3 *a, const struct Vector3 *b, void *actor);
 extern int _ZN11RaycastLine10DetectClsnEv(void *self);
 extern void _ZN11RaycastLine10GetClsnPosEv(struct Vector3 *out, void *self);
@@ -14,7 +15,6 @@ extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, const struct Vector3 *p, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
 extern void SubVec3(struct Vector3 *a, void *b, struct Vector3 *c);
-extern unsigned int func_020093d4(void *p, int a);
 extern int Vec3_HorzLen(void *v);
 extern void Vec3_MulScalar(void *out, void *in, int scale);
 extern void AddVec3(struct Vector3 *a, void *b, struct Vector3 *c);

--- a/src/func_0200cbe0.c
+++ b/src/func_0200cbe0.c
@@ -1,18 +1,21 @@
+// @symbol func_0200cbe0
+/* recovered: shared common types */
+#include "common.h"
 struct Vector3;
-struct Vec3 { int x, y, z; };
 
-extern int func_020092c4(void *self, struct Vec3 *out, struct Vec3 *target);
+
+extern int func_020092c4(void *self, struct Vector3 *out, struct Vector3 *target);
 extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 extern short Vec3_VertAngle(const struct Vector3 *v1, const struct Vector3 *v0);
 
 void func_0200cbe0(void *self)
 {
-    int r1 = func_020092c4(self, (struct Vec3 *)((char *)self + 0x80), (struct Vec3 *)((char *)self + 0xb0));
-    int r2 = func_020092c4(self, (struct Vec3 *)((char *)self + 0x8c), (struct Vec3 *)((char *)self + 0xbc));
+    int r1 = func_020092c4(self, (struct Vector3 *)((char *)self + 0x80), (struct Vector3 *)((char *)self + 0xb0));
+    int r2 = func_020092c4(self, (struct Vector3 *)((char *)self + 0x8c), (struct Vector3 *)((char *)self + 0xbc));
 
     if (r2 != 0) {
         if (r1 != 0) {
-            *(int *)(((long long)(int)((char *)self + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x8000;
+            *(int *)(((long long)(int)((char *)self + 0x154))) &= ~0x8000;
         }
     }
 

--- a/src/func_0200d8c8.c
+++ b/src/func_0200d8c8.c
@@ -1,9 +1,14 @@
+// @symbol func_0200d8c8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* Camera ground-pound jitter: if the target point is within range, accumulate
  * a jitter offset (unk134) scaled by 0x9000/distance, clamped to 0xc000. */
 
 typedef int Fix12i; /* 20.12 fixed-point */
 
-struct Vector3 { Fix12i x, y, z; }; /* 0xc */
+ /* 0xc */
 
 struct Camera {
 	char _pad0[0x8c];
@@ -16,7 +21,6 @@ struct Camera {
  *   0x0203cfdc = Vec3_Dist(const Vector3&, const Vector3&) -> Vec3_Dist
  *   0x02053258 = cstd::fdiv(int, int)                      -> _ZN4cstd4fdivEii */
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
-extern int cstd_fdiv(int numerator, int denominator);
 
 void func_0200d8c8(struct Camera *cam, const struct Vector3 *v, int strength)
 {

--- a/src/func_020105cc.c
+++ b/src/func_020105cc.c
@@ -1,3 +1,6 @@
+// @symbol func_020105cc
+/* recovered: shared common types */
+#include "common.h"
 /* func_020105cc at 0x020105cc
  * Plays a sound effect based on flags bitmask.
  * If flags & 0x380: play sound bank0 ID 0xa at camSpacePos.
@@ -7,9 +10,7 @@
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vector3 {
-    Fix12i x, y, z;
-};
+
 
 struct Actor {
     char pad[0x74];

--- a/src/func_0201267c.cpp
+++ b/src/func_0201267c.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_0201267c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 void _ZN5Sound4PlayEjjRK7Vector3(unsigned int bank, unsigned int id, const Vector3 *v);
 void func_0201267c(unsigned int id, const Vector3 *v)
 {

--- a/src/func_02012694.cpp
+++ b/src/func_02012694.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_02012694
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 void _ZN5Sound4PlayEjjRK7Vector3(unsigned int bank, unsigned int id, const Vector3 *v);
 void func_02012694(unsigned int id, const Vector3 *v)
 {

--- a/src/func_02014a20.c
+++ b/src/func_02014a20.c
@@ -1,8 +1,13 @@
-/* func_02014a20 @ 0x2014a20 (arm9) -- tail-call veneer to _ZN18MovingCylinderClsn10GetOwnerIDEv (0x201493c).
+// @symbol func_02014a20
+// @emits dCcAcPos_c_GetOwnerID
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_MovingCylinderClsn.h"
+/* recovered: renamed to Class_Method */
+/* dCcAcPos_c::GetOwnerID - recovered from vtable slot identity */
+/* dCcAcPos_c_GetOwnerID @ 0x2014a20 (arm9) -- tail-call veneer to _ZN18MovingCylinderClsn10GetOwnerIDEv (0x201493c).
  * ldr ip, [pc]; bx ip; .word 0x201493c
  */
-extern void _ZN18MovingCylinderClsn10GetOwnerIDEv(void);
 
-void func_02014a20(void) {
+void dCcAcPos_c_GetOwnerID(void) {
     _ZN18MovingCylinderClsn10GetOwnerIDEv();
 }

--- a/src/func_020171c8.cpp
+++ b/src/func_020171c8.cpp
@@ -1,3 +1,7 @@
 //cpp
+// @symbol func_020171c8
+// @emits dFdDummy_c_SetForwardTime
+/* recovered: renamed to Class_Method */
+/* dFdDummy_c::SetForwardTime - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void m(); };
-extern "C" void func_020171c8(Base *c){ *(int*)((char*)c+8)=0x1000; c->m(); }
+extern "C" void dFdDummy_c_SetForwardTime(Base *c){ *(int*)((char*)c+8)=0x1000; c->m(); }

--- a/src/func_020171f0.cpp
+++ b/src/func_020171f0.cpp
@@ -1,3 +1,7 @@
 //cpp
+// @symbol func_020171f0
+// @emits dFdDummy_c_SetBackwardTime
+/* recovered: renamed to Class_Method */
+/* dFdDummy_c::SetBackwardTime - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(); };
-extern "C" void func_020171f0(Base *c){ *(int*)((char*)c+8)=-0x1000; c->m(); }
+extern "C" void dFdDummy_c_SetBackwardTime(Base *c){ *(int*)((char*)c+8)=-0x1000; c->m(); }

--- a/src/func_0201721c.c
+++ b/src/func_0201721c.c
@@ -1,8 +1,13 @@
-/* func_0201721c @ 0x201721c (arm9) -- tail-call veneer to _ZN5Fader13AdvanceInterpEv (0x20175e8).
+// @symbol func_0201721c
+// @emits dFdDummy_c_AdvanceFade
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Fader.h"
+/* recovered: renamed to Class_Method */
+/* dFdDummy_c::AdvanceFade - recovered from vtable slot identity */
+/* dFdDummy_c_AdvanceFade @ 0x201721c (arm9) -- tail-call veneer to _ZN5Fader13AdvanceInterpEv (0x20175e8).
  * ldr ip, [pc]; bx ip; .word 0x20175e8
  */
-extern void _ZN5Fader13AdvanceInterpEv(void);
 
-void func_0201721c(void) {
+void dFdDummy_c_AdvanceFade(void) {
     _ZN5Fader13AdvanceInterpEv();
 }

--- a/src/func_0202ecfc.c
+++ b/src/func_0202ecfc.c
@@ -1,2 +1,7 @@
-extern void func_02017610(void *);
-void func_0202ecfc(void *t) { func_02017610(t); }
+// @symbol func_0202ecfc
+// @emits dWipe_c_SetToStart
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dWipe_c::SetToStart - recovered from vtable slot identity */
+void dWipe_c_SetToStart(void *t) { func_02017610(t); }

--- a/src/func_0202ed08.c
+++ b/src/func_0202ed08.c
@@ -1,8 +1,13 @@
-/* func_0202ed08 @ 0x202ed08 (arm9) -- tail-call veneer to _ZN15FaderBrightness8SetToEndEv (0x201761c).
+// @symbol func_0202ed08
+// @emits dWipe_c_SetToEnd
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_FaderBrightness.h"
+/* recovered: renamed to Class_Method */
+/* dWipe_c::SetToEnd - recovered from vtable slot identity */
+/* dWipe_c_SetToEnd @ 0x202ed08 (arm9) -- tail-call veneer to _ZN15FaderBrightness8SetToEndEv (0x201761c).
  * ldr ip, [pc]; bx ip; .word 0x201761c
  */
-extern void _ZN15FaderBrightness8SetToEndEv(void);
 
-void func_0202ed08(void) {
+void dWipe_c_SetToEnd(void) {
     _ZN15FaderBrightness8SetToEndEv();
 }

--- a/src/func_0202ed7c.cpp
+++ b/src/func_0202ed7c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_0202ed7c
+// @emits dWipe_c_IsBetweenStartAndEnd
+/* recovered: renamed to Class_Method */
+/* dWipe_c::IsBetweenStartAndEnd - recovered from vtable slot identity */
 struct FaderBrightness {
     virtual void m00();
     virtual void m04();
@@ -13,7 +17,7 @@ struct FaderBrightness {
 
 extern "C" int _ZN15FaderBrightness20IsBetweenStartAndEndEv(struct FaderBrightness *thiz);
 
-extern "C" int func_0202ed7c(struct FaderBrightness *thiz)
+extern "C" int dWipe_c_IsBetweenStartAndEnd(struct FaderBrightness *thiz)
 {
     if (thiz->field_14 == 1)
         return _ZN15FaderBrightness20IsBetweenStartAndEndEv(thiz);

--- a/src/func_0202eddc.c
+++ b/src/func_0202eddc.c
@@ -1,4 +1,8 @@
-/* func_0202eddc - IsAtEnd wrapper.
+// @symbol func_0202eddc
+// @emits dWipe_c_IsAtEnd
+/* recovered: renamed to Class_Method */
+/* dWipe_c::IsAtEnd - recovered from vtable slot identity */
+/* dWipe_c_IsAtEnd - IsAtEnd wrapper.
  * Attempt 5: use explicit early-return structure to get beq+bgt branch pattern.
  * ROM: beq -> ret1 block (add sp,#4; mov r0,#1; ldm; bx), bgt -> ret0 block.
  */
@@ -19,7 +23,7 @@ struct MyFader {
     s32 interpVal;  /* 0x1c */
 };
 
-int func_0202eddc(struct MyFader* self)
+int dWipe_c_IsAtEnd(struct MyFader* self)
 {
     int result;
     if (self->type == 1)

--- a/src/func_0202ee38.c
+++ b/src/func_0202ee38.c
@@ -1,4 +1,8 @@
-/* func_0202ee38 - IsAtStart wrapper.
+// @symbol func_0202ee38
+// @emits dWipe_c_IsAtStart
+/* recovered: renamed to Class_Method */
+/* dWipe_c::IsAtStart - recovered from vtable slot identity */
+/* dWipe_c_IsAtStart - IsAtStart wrapper.
  * Attempt 1: same goto pattern as func_0202eddc. ROM structure:
  * if unk14==1: call IsAtStart, return result.
  * else if unk10==0: goto ret1 (return 1)
@@ -23,7 +27,7 @@ struct MyFader {
     s32 interpVal;  /* 0x1c */
 };
 
-int func_0202ee38(struct MyFader* self)
+int dWipe_c_IsAtStart(struct MyFader* self)
 {
     int result;
     if (self->type == 1)

--- a/src/func_0202f428.c
+++ b/src/func_0202f428.c
@@ -1,41 +1,48 @@
-extern void _ZN10FaderColor11AdvanceFadeEv(void);
-extern void func_0202fb30(void *o);
+// @symbol func_0202f428
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_FaderColor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dWipe_c.h"
+// @emits dWipe_c_AdvanceFade
+/* recovered: renamed to Class_Method */
+/* dWipe_c::AdvanceFade - recovered from vtable slot identity */
 extern void _ZN3G2x18SetBlendBrightnessEPVtts(unsigned short *p, unsigned short a, int b);
-extern void func_0202f290(void *o);
 
-void func_0202f428(char *obj)
+void dWipe_c_AdvanceFade(char *obj)
 {
-    if (*(int *)(obj + 0x14) == 1) {
+    struct dWipe_c *self = (struct dWipe_c *)(void *)obj;
+    if (self->unk_014 == 1) {
         _ZN10FaderColor11AdvanceFadeEv();
         return;
     }
-    switch (*(int *)(obj + 0x10)) {
+    switch (self->unk_010) {
     case 0:
         return;
     case 1:
-        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += *(int *)(obj + 0x20);
-        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += *(int *)(obj + 0x24);
-        if (*(int *)(obj + 0x1c) >= 0x200000) {
-            *(int *)(obj + 0x1c) = 0x200000;
-            *(char *)(obj + 0xf) = 0;
+        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += self->unk_020;
+        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += self->unk_024;
+        if (self->unk_01c >= 0x200000) {
+            self->unk_01c = 0x200000;
+            self->unk_00f = 0;
             func_0202fb30(obj);
-            *(int *)(obj + 0x10) = 2;
+            self->unk_010 = 2;
         }
         break;
     case 2:
         return;
     case 3:
-        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += *(int *)(obj + 0x20);
-        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += *(int *)(obj + 0x24);
-        if (*(int *)(obj + 0x1c) <= 0) {
+        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += self->unk_020;
+        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += self->unk_024;
+        if (self->unk_01c <= 0) {
             int b;
-            *(int *)(obj + 0x1c) = 0;
-            *(char *)(obj + 0xf) = 0;
-            b = (*(int *)(obj + 0x14) == 0) ? 0x10 : -0x10;
+            self->unk_01c = 0;
+            self->unk_00f = 0;
+            b = (self->unk_014 == 0) ? 0x10 : -0x10;
             _ZN3G2x18SetBlendBrightnessEPVtts((unsigned short *)0x4000050, 0x3f, b);
             _ZN3G2x18SetBlendBrightnessEPVtts((unsigned short *)0x4001050, 0x3f, b);
             func_0202fb30(obj);
-            *(int *)(obj + 0x10) = 4;
+            self->unk_010 = 4;
         }
         break;
     case 4:

--- a/src/func_0202f708.c
+++ b/src/func_0202f708.c
@@ -1,3 +1,9 @@
+// @symbol func_0202f708
+// @emits dWipe_c_SetForwardTime
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dWipe_c::SetForwardTime - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -24,15 +30,11 @@ extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int addr, unsigned
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *data, unsigned int offset, unsigned int size);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *data, unsigned int offset, unsigned int size);
 extern void func_0202f58c(struct MyFader *self);
-extern void func_0202f2c4(void);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(unsigned int irq, void (*handler)(void));
 extern void _ZN3IRQ10EnableIRQsEj(unsigned int irq);
-extern int func_02053c10(int enable);
 
-extern u8 data_0209f600[];
-extern u8 data_020926c8[];
 
-int func_0202f708(struct MyFader *self, u32 frames)
+int dWipe_c_SetForwardTime(struct MyFader *self, u32 frames)
 {
     if (self->state == 0 || self->state == 2) {
         int t;

--- a/src/func_0202f928.c
+++ b/src/func_0202f928.c
@@ -1,3 +1,9 @@
+// @symbol func_0202f928
+// @emits dWipe_c_SetBackwardTime
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dWipe_c::SetBackwardTime - recovered from vtable slot identity */
 /* The third parameter (param_2) is load-bearing: it arrives in r2 and is
  * forwarded to the guard call with zero instructions, which keeps r2 live
  * from entry to the call and forces the cached `type` into r3 as in the ROM.
@@ -15,12 +21,8 @@ extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irqBits, void (*handler)(void));
 extern void _ZN3IRQ10EnableIRQsEj(u32 irqBits);
-extern int func_02053c10(int enable);
 extern void func_0202f58c(void *self);
-extern void func_0202f2c4(void);
 
-extern u8 data_0209f604[];
-extern u8 data_020926cc[];
 
 struct MyFader {
     u32 unk00;
@@ -35,7 +37,7 @@ struct MyFader {
     u32 unk24;      /* 0x24 */
 };
 
-int func_0202f928(struct MyFader *self, u32 param_1, u32 param_2)
+int dWipe_c_SetBackwardTime(struct MyFader *self, u32 param_1, u32 param_2)
 {
     s32 type, unk10;
 

--- a/src/func_02034ac0.c
+++ b/src/func_02034ac0.c
@@ -1,3 +1,7 @@
+// @symbol func_02034ac0
+// @emits dScMB_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* dScMB_c::OnYoshiTryEat - recovered from vtable slot identity */
 struct MultiBootScene { void **vtable; };
 struct Heap;
 extern void *_ZTV14MultiBootScene[];
@@ -8,7 +12,7 @@ extern void _ZN9ActorBaseD2Ev(struct MultiBootScene *thiz);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);
 extern struct Heap *_ZN6Memory11gameHeapPtrE;
 
-struct MultiBootScene *func_02034ac0(struct MultiBootScene *thiz)
+struct MultiBootScene *dScMB_c_OnYoshiTryEat(struct MultiBootScene *thiz)
 {
     thiz->vtable = (void **)_ZTV14MultiBootScene;
     _ZN10FaderColorD1Ev((char *)thiz + 0x50);

--- a/src/func_02034d70.c
+++ b/src/func_02034d70.c
@@ -1,14 +1,19 @@
+// @symbol func_02034d70
+// @emits dScMB_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Scene.h"
+/* recovered: renamed to Class_Method */
+/* dScMB_c::CleanupResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef signed char s8;
 typedef int s32;
 
-extern void _ZN5Scene20SetAndStopColorFaderEv(void);
 
 extern void* SCENE_RELATED;  /* 0x0209d4a8 */
 
-int func_02034d70(void) {
+int dScMB_c_CleanupResources(void) {
     SCENE_RELATED = 0;
     _ZN5Scene20SetAndStopColorFaderEv();
     return 1;

--- a/src/func_02034d9c.c
+++ b/src/func_02034d9c.c
@@ -1,4 +1,8 @@
-int func_02034d9c(void)
+// @symbol func_02034d9c
+// @emits dScMB_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMB_c::Render - recovered from vtable slot identity */
+int dScMB_c_Render(void)
 {
     return 1;
 }

--- a/src/func_02034da4.c
+++ b/src/func_02034da4.c
@@ -1,29 +1,23 @@
+// @symbol func_02034da4
+// @emits dScMB_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMB_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-extern int func_0203d8fc(void);
-extern int func_0200f0bc(void);
 extern void DecompressLZ16(void *src, int dst);
-extern int func_0201a1bc(void);
 extern int func_0201a244(int a0, int a1, int a2, int a3, int a4);
-extern int func_0203d7b8(void);
-extern void func_0200f220(void);
-extern void func_0200f13c(void);
-extern void func_0203d930(void);
 extern void func_020308b4(void);
-extern int func_020308a8(void);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
 extern void func_02012790(int x);
-extern void func_02034fbc(void);
 
-extern void *data_0208a0e4[];
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern u8 data_020a0c64[];
-extern u8 data_0209fc54;
 
-int func_02034da4(void *arg0)
+int dScMB_c_Behavior(void *arg0)
 {
     char *self = (char *)arg0;
 

--- a/src/func_0203506c.c
+++ b/src/func_0203506c.c
@@ -1,34 +1,28 @@
+// @symbol func_0203506c
+// @emits dScMB_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMB_c::InitResources - recovered from vtable slot identity */
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern void func_02053b98(void);
-extern void func_02030aa4(int arg);
-extern void func_0200f2cc(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void SetBg1Offset(int a, int b);
-extern void SetSubBg1Offset(int a, int b);
-extern void _ZN2GX6DispOnEv(void);
-extern void func_02034b1c(void *c, int a);
-extern void _ZN5Scene9SetFadersEP15FaderBrightness(void *p);
 extern int func_0201a244(int a0, int a1, int a2, int a3, int a4);
 
-extern u8 data_0209446c[];
-extern u8 data_0209444c[];
-extern u8 data_020945d0[];
 extern u8 data_0209d45c[];
 extern u8 data_0209d454[];
-extern u8 data_020a0c68[];
 extern u8 data_0209d4a8[];
 extern u8 data_0208ee44[];
 extern u8 func_0201a2f8[];
-extern u8 data_020a0c64[];
 
-int func_0203506c(void *arg0)
+int dScMB_c_InitResources(void *arg0)
 {
     void *self = arg0;
     volatile u16 sp4;

--- a/src/func_02035860.c
+++ b/src/func_02035860.c
@@ -1,13 +1,14 @@
-struct Vec3 { int x, y, z; };
-
-void func_02035860(char *o, struct Vec3 *src)
+// @symbol func_02035860
+/* recovered: shared common types */
+#include "common.h"
+void func_02035860(char *o, struct Vector3 *src)
 {
     char *base = *(char **)(o + 0x14);
-    struct Vec3 *d1 = (struct Vec3 *)(((long long)(int)(base + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    struct Vector3 *d1 = (struct Vector3 *)(((long long)(int)(base + 0x5c)));
     d1->x = src->x;
     d1->y = src->y;
     d1->z = src->z;
-    struct Vec3 *d2 = (struct Vec3 *)(((long long)(int)(base + 0x68)) & 0xFFFFFFFFFFFFFFFFLL);
+    struct Vector3 *d2 = (struct Vector3 *)(((long long)(int)(base + 0x68)));
     d2->x = src->x;
     d2->y = src->y;
     d2->z = src->z;

--- a/src/func_020371fc.cpp
+++ b/src/func_020371fc.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_020371fc
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 struct ClsnResult { char data[0x34]; };
 

--- a/src/func_02037a04.c
+++ b/src/func_02037a04.c
@@ -1,7 +1,9 @@
-struct Vec3 { int x, y, z; };
-struct Obj { char pad[0x58]; struct Vec3 a; struct Vec3 b; };
+// @symbol func_02037a04
+/* recovered: shared common types */
+#include "common.h"
+struct Obj { char pad[0x58]; struct Vector3 a; struct Vector3 b; };
 
-void func_02037a04(struct Obj *o, struct Vec3 *d1, struct Vec3 *d2)
+void func_02037a04(struct Obj *o, struct Vector3 *d1, struct Vector3 *d2)
 {
     d1->x = o->a.x;
     d1->y = o->a.y;

--- a/src/func_02037a38.c
+++ b/src/func_02037a38.c
@@ -1,5 +1,7 @@
-struct Vec3 { int x, y, z; };
-struct Obj { char pad[0x4c]; struct Vec3 d; struct Vec3 a; struct Vec3 b; };
+// @symbol func_02037a38
+/* recovered: shared common types */
+#include "common.h"
+struct Obj { char pad[0x4c]; struct Vector3 d; struct Vector3 a; struct Vector3 b; };
 
 void func_02037a38(struct Obj *o)
 {

--- a/src/func_02037eb0.c
+++ b/src/func_02037eb0.c
@@ -1,8 +1,10 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_02037eb0
+/* recovered: shared common types */
+#include "common.h"
 struct AB { int a; int b; };
-struct Obj { int a; int b; struct Vec3 v; };
+struct Obj { int a; int b; struct Vector3 v; };
 
-void func_02037eb0(struct Obj *o, struct AB ab, struct Vec3 *v)
+void func_02037eb0(struct Obj *o, struct AB ab, struct Vector3 *v)
 {
     o->a = ab.a;
     o->b = ab.b;

--- a/src/func_0203842c.cpp
+++ b/src/func_0203842c.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_0203842c
+/* recovered: shared common types */
+#include "common.h"
 
 extern "C" {
 int func_020393b4(void *p);
@@ -24,11 +27,11 @@ public:
     virtual int v7(void *arg);
 };
 
-struct Vec3 { int x, y, z; };
+
 
 struct Info {
     char pad0[0x5c];
-    Vec3 pos;
+    Vector3 pos;
     char pad1[0xb0 - 0x68];
     int pB0;
     int pB4;
@@ -56,8 +59,8 @@ extern "C" int func_0203842c(char *self)
         if (info != 0) {
             int active = (info->pB0 & 2) ? 1 : 0;
             if (active != 0) {
-                Vec3 v;
-                Vec3 *src = (Vec3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+                Vector3 v;
+                Vector3 *src = (Vector3 *)((unsigned long long)(unsigned int)((char *)info + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
                 v.x = src->x;
                 v.y = src->y;
                 v.z = src->z;

--- a/src/func_02039658.c
+++ b/src/func_02039658.c
@@ -1,2 +1,5 @@
-extern int G[];
-void func_02039658(int *p) { p[0] = (int)G; }
+// @symbol func_02039658
+/* recovered: globals resolved */
+/* resolved: G = _ZTV16MeshColliderBase */
+extern int _ZTV16MeshColliderBase[];
+void func_02039658(int *p) { p[0] = (int)_ZTV16MeshColliderBase; }

--- a/src/func_020397fc.c
+++ b/src/func_020397fc.c
@@ -1,9 +1,11 @@
-extern void func_02038224(void *);
-extern void func_02039658(void *);
-extern int VT0[];
+// @symbol func_020397fc
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT0 = _ZTV12MeshCollider */
 int *func_020397fc(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12MeshCollider;
     func_02038224((char *)t + 0x24);
     func_02039658(t);
     return t;

--- a/src/func_0203a420.c
+++ b/src/func_0203a420.c
@@ -1,2 +1,5 @@
-extern int VT[]; extern int func_020397fc();
-int func_0203a420(int *x) { x[0] = (int)VT; func_020397fc(x); return (int)x; }
+// @symbol func_0203a420
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV18MovingMeshCollider */
+extern int _ZTV18MovingMeshCollider[]; extern int func_020397fc();
+int func_0203a420(int *x) { x[0] = (int)_ZTV18MovingMeshCollider; func_020397fc(x); return (int)x; }

--- a/src/func_0203ce80.c
+++ b/src/func_0203ce80.c
@@ -1,10 +1,13 @@
+// @symbol func_0203ce80
+/* recovered: shared common types */
+#include "common.h"
 /* func_0203ce80 at 0x0203ce80, size=0x3c
  * Normalizes *src in-place (NormalizeVec3(src,src)), then copies to *dst field-by-field.
  */
 
 typedef int Fix12i;
 
-struct Vector3 { Fix12i x, y, z; };
+
 
 extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 

--- a/src/func_0204488c.c
+++ b/src/func_0204488c.c
@@ -1,5 +1,10 @@
+// @symbol func_0204488c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 struct Matrix3x3_Vecs { struct Vector3 v0, v1, v2; };
 
 struct Part {
@@ -13,20 +18,8 @@ struct Entry {
     struct Part* parts;
 };
 
-extern void Geometry_MatrixMultiply3x3(void* m);
 extern void func_020458a8(struct Matrix3x3_Vecs* dst, struct Matrix3x3_Vecs* src);
-extern void func_020553a4(void* m);
-extern void func_02055388(void* m);
-extern void MulMat3x3Mat3x3(void* a, void* b, void* c);
-extern void func_02052514(void* dst, void* src);
-extern void func_02055998(int* m);
-extern void func_01ffde98(int a, int b, int c);
 
-extern void* data_020a4bd0;
-extern int data_020a4bd4;
-extern unsigned char data_020a4bbc;
-extern short data_020a4bc0;
-extern short data_020a4bc4;
 
 void func_0204488c(char* self, int index, int* color)
 {

--- a/src/func_020458a8.c
+++ b/src/func_020458a8.c
@@ -1,3 +1,6 @@
+// @symbol func_020458a8
+/* recovered: shared common types */
+#include "common.h"
 /* func_020458a8 at 0x020458a8, size=0x38
  * Normalizes each of 3 source Vector3s into corresponding destination Vector3s.
  * NormalizeVec3(src, dst): normalizes src into dst.
@@ -5,7 +8,7 @@
 
 typedef int Fix12i;
 
-struct Vector3 { Fix12i x, y, z; };
+
 
 struct Matrix3x3_Vecs {
     struct Vector3 v0;

--- a/src/func_02048720.c
+++ b/src/func_02048720.c
@@ -1,24 +1,23 @@
+// @symbol func_02048720
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 
 typedef struct {
     void *obj;
     int dist;
 } SoundSlot;
 
-extern u32 data_02099fac;
-extern int data_02099fb0;
 extern SoundSlot data_020a4bf8[2];
 extern SoundSlot data_020a4c18[];
 
-extern void *func_02050cdc(int kind, int id);
-extern int func_02049018(struct Vec3 *v);
-extern int func_0204fa2c(int *p, int a);
-extern void func_0204f934(int **p);
 
-void *func_02048720(struct Vec3 *v, int kind, int id)
+void *func_02048720(struct Vector3 *v, int kind, int id)
 {
     u32 lim;
     void *elem;

--- a/src/func_02049018.c
+++ b/src/func_02049018.c
@@ -1,5 +1,7 @@
-struct Vec3 { int x, y, z; };
-int func_02049018(struct Vec3 *v)
+// @symbol func_02049018
+/* recovered: shared common types */
+#include "common.h"
+int func_02049018(struct Vector3 *v)
 {
     int tx = v->x >> 12;
     int ty = (v->y >> 12) * 2;

--- a/src/func_0204ae2c.c
+++ b/src/func_0204ae2c.c
@@ -1,8 +1,11 @@
+// @symbol func_0204ae2c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-struct V3 { int x, y, z; };
+
 struct H2 { u16 a, b; };
 
 struct Src {
@@ -23,7 +26,7 @@ struct Obj {
     int m14;     /* 0x14 */
     void *m18;   /* 0x18 */
     int m1c;     /* 0x1c */
-    struct V3 m20;  /* 0x20 */
+    struct Vector3 m20;  /* 0x20 */
     int m2c;     /* 0x2c */
     int m30;     /* 0x30 */
     int m34;     /* 0x34 */
@@ -47,7 +50,7 @@ struct Obj {
     int m70;     /* 0x70 */
 };
 
-void func_0204ae2c(struct Obj *o, void *p18, struct V3 *src3)
+void func_0204ae2c(struct Obj *o, void *p18, struct Vector3 *src3)
 {
     o->m18 = p18;
     o->m1c = 0;

--- a/src/func_0204d9f0.c
+++ b/src/func_0204d9f0.c
@@ -1,3 +1,8 @@
+// @symbol func_0204d9f0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_0204d9f0 at 0x0204d9f0, size=0x5c
  * LCG RNG: generates 2 random values for x,y (z=0), normalizes the vector.
  */
@@ -5,9 +10,8 @@
 typedef int s32;
 typedef unsigned int u32;
 
-struct Vector3 { s32 x, y, z; };
 
-extern s32 LCG_STATE_0204d9f0;
+
 
 extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 

--- a/src/func_0204da4c.c
+++ b/src/func_0204da4c.c
@@ -1,3 +1,8 @@
+// @symbol func_0204da4c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_0204da4c at 0x0204da4c, size=0x68
  * LCG RNG: generates 3 random values for x,y,z, then normalizes the vector.
  */
@@ -5,9 +10,8 @@
 typedef int s32;
 typedef unsigned int u32;
 
-struct Vector3 { s32 x, y, z; };
 
-extern s32 LCG_STATE_0204da4c;
+
 
 extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 

--- a/src/func_ov002_020ad660.cpp
+++ b/src/func_ov002_020ad660.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov002_020ad660
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *o);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *o);
@@ -46,9 +49,9 @@ struct VB {
     virtual int m29();
 };
 
-struct M48 { int w[12]; };
 
-#define LAUNDER(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+#define LAUNDER(p) ((int)(((long long)(int)(p))))
 
 extern "C" int func_ov002_020ad660(void *cc, void *pp, void *r5p, int flags)
 {
@@ -87,7 +90,7 @@ extern "C" int func_ov002_020ad660(void *cc, void *pp, void *r5p, int flags)
             *(short *)(c + 0x8c), *(short *)(c + 0x8e), *(short *)(c + 0x90));
         Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0,
             (-((VB *)(void *)c)->m29()) >> 3, 0);
-        *(M48 *)(r5 + 0x1c) = *(M48 *)&data_020a0e68;
+        *(Matrix4x3 *)(r5 + 0x1c) = *(Matrix4x3 *)&data_020a0e68;
     }
     return 1;
 }

--- a/src/func_ov002_020ae844.c
+++ b/src/func_ov002_020ae844.c
@@ -1,8 +1,11 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020ae844
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern int func_ov002_020ae968(void *c, void *a);
 
 int func_ov002_020ae844(void *c, void *a) {
     s16 angle = Vec3_HorzAngle((struct Vector3 *)((char *)a + 0x5c), (struct Vector3 *)((char *)c + 0x5c));

--- a/src/func_ov002_020aedbc.c
+++ b/src/func_ov002_020aedbc.c
@@ -1,10 +1,13 @@
-extern void func_ov001_020ab3a0(void *);
-extern void _ZN5ModelD1Ev(void *);
+// @symbol func_ov002_020aedbc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11dCapEnemy_c */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
 int *func_ov002_020aedbc(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11dCapEnemy_c;
     func_ov001_020ab3a0((char *)t + 0x164);
     _ZN5ModelD1Ev((char *)t + 0x114);
     func_ov002_020aed18(t);

--- a/src/func_ov002_020aeee4.cpp
+++ b/src/func_ov002_020aeee4.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov002_020aeee4
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int uniqueID, unsigned int effectID,
@@ -7,7 +10,7 @@ unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 
 extern unsigned char data_0209f2d8;
 
-struct Vec3 { int x, y, z; };
+
 
 extern "C" void func_ov002_020aeee4(char* c) {
     int t1 = (*(unsigned short*)(c + 0xc) == 0x115);
@@ -20,12 +23,12 @@ extern "C" void func_ov002_020aeee4(char* c) {
         if (t3 == false) return;
     }
 
-    Vec3 pos;
+    Vector3 pos;
     pos.x = *(int*)(c + 0x5c);
     pos.y = *(int*)(c + 0x60);
     pos.z = *(int*)(c + 0x64);
     pos.y += 0x1e000;
-    volatile Vec3* vp = &pos;
+    volatile Vector3* vp = &pos;
     *(unsigned int*)(c + 0x394) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(volatile unsigned int*)(c + 0x394), effectID, vp->x, vp->y, pos.z, 0, 0);
 }

--- a/src/func_ov002_020af2b0.c
+++ b/src/func_ov002_020af2b0.c
@@ -1,4 +1,10 @@
-/* func_ov002_020af2b0 at 0x020af2b0
+// @symbol func_ov002_020af2b0
+// @emits OneUpMushroom_OnTurnIntoEgg
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* da1up_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* OneUpMushroom_OnTurnIntoEgg at 0x020af2b0
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
@@ -8,14 +14,11 @@ typedef int Fix12i;
 struct Vec { Fix12i x, y, z; };
 struct Vector3_16;
 
-extern void func_ov002_020af684(void* self, int, int);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec* v);
-extern void GiveLives(int delta);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
-extern void func_ov002_020bdf8c(int);
 
-void func_ov002_020af2b0(char* c, int arg1)
+void OneUpMushroom_OnTurnIntoEgg(char* c, int arg1)
 {
     int t = *(int*)(c + 0x384);
     if (t == 0xb) {

--- a/src/func_ov002_020af3a0.c
+++ b/src/func_ov002_020af3a0.c
@@ -1,4 +1,8 @@
-int func_ov002_020af3a0(void)
+// @symbol func_ov002_020af3a0
+// @emits OneUpMushroom_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* da1up_c::OnYoshiTryEat - recovered from vtable slot identity */
+int OneUpMushroom_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov002_020af3a8.c
+++ b/src/func_ov002_020af3a8.c
@@ -1,3 +1,8 @@
+// @symbol func_ov002_020af3a8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov002_020af3a8 at 0x020af3a8
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
@@ -5,14 +10,11 @@
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vec { Fix12i x, y, z; };
+
 struct Vector3_16;
 
-extern int func_ov002_020af1dc(char* c);
-extern void func_ov002_020bdf8c(int);
-extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec* v);
-extern void GiveLives(int delta);
-extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vector3* v);
+extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vector3* v, struct Vector3_16* rot, int e, int f);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
 
 void func_ov002_020af3a8(char* c)
@@ -28,8 +30,8 @@ void func_ov002_020af3a8(char* c)
     } else {
         unsigned is114 = (h == 0x114);
         if (is114) {
-            struct Vec vec;
-            _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, (struct Vec*)(c + 0x74));
+            struct Vector3 vec;
+            _ZN5Sound9PlayBank3EjRK7Vector3(0x6e, (struct Vector3*)(c + 0x74));
             GiveLives(1);
             vec.x = *(Fix12i*)(c + 0x5c);
             vec.y = *(Fix12i*)(c + 0x60);

--- a/src/func_ov002_020af4ec.cpp
+++ b/src/func_ov002_020af4ec.cpp
@@ -1,13 +1,16 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov002_020af4ec
+/* recovered: shared common types */
+#include "common.h"
+
 struct RaycastGround { char buf[0x50]; };
 extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 extern void _ZN13RaycastGroundC1Ev(struct RaycastGround* self);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround* self, const struct Vec3* v, void* actor);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround* self, const struct Vector3* v, void* actor);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround* self);
 extern void _ZN13RaycastGroundD1Ev(struct RaycastGround* self);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* shadow, void* mtx, int height, int rad, unsigned int x);
@@ -20,8 +23,8 @@ void func_ov002_020af4ec(void* self)
     char* c = (char*)self;
     int height;
     struct RaycastGround rg;
-    struct Vec3 v2;
-    struct Vec3 v1;
+    struct Vector3 v2;
+    struct Vector3 v1;
 
     if ((unsigned)(*(int*)(c + 0x384) - 0xb) <= 1) {
         Matrix4x3_FromRotationY(c + 0x31c, *(short*)(c + 0x8e));
@@ -29,7 +32,7 @@ void func_ov002_020af4ec(void* self)
         *(int*)(c + 0x344) = *(int*)(c + 0x60) >> 3;
         *(int*)(c + 0x348) = *(int*)(c + 0x64) >> 3;
     } else {
-        Vec3_Asr(&v1, (struct Vec3*)(c + 0x5c), 3);
+        Vec3_Asr(&v1, (struct Vector3*)(c + 0x5c), 3);
         Matrix4x3_FromTranslation(c + 0x31c, v1.x, v1.y, v1.z);
     }
 

--- a/src/func_ov002_020af838.c
+++ b/src/func_ov002_020af838.c
@@ -1,15 +1,18 @@
+// @symbol func_ov002_020af838
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vec { Fix12i x, y, z; };
+
 struct Vector3_16;
 
-extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
+extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vector3* v, struct Vector3_16* rot, int e, int f);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
 
 void func_ov002_020af838(char* c)
 {
-    struct Vec vec;
+    struct Vector3 vec;
 
     vec.x = *(Fix12i*)(c + 0x378);
     vec.y = *(Fix12i*)(c + 0x37c);

--- a/src/func_ov002_020afa50.c
+++ b/src/func_ov002_020afa50.c
@@ -1,6 +1,11 @@
-extern void func_ov002_020afa6c(char *self);
+// @symbol func_ov002_020afa50
+// @emits dCapEnemy_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dCapEnemy_c::Kill - recovered from vtable slot identity */
 
-void func_ov002_020afa50(char *self) {
-    *(short *)(int)(((long long)(int)(self + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0xc00;
+void dCapEnemy_c_Kill(char *self) {
+    *(short *)(int)(((long long)(int)(self + 0x8e))) += 0xc00;
     func_ov002_020afa6c(self);
 }

--- a/src/func_ov002_020afa98.c
+++ b/src/func_ov002_020afa98.c
@@ -1,18 +1,17 @@
+// @symbol func_ov002_020afa98
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec { s32 x, y, z; };
 
-extern void func_ov002_020aefa4(char *self);
-extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec *v);
-extern void func_ov002_020aefb8(char *self);
-extern void func_ov002_020afde4(char *c);
-extern void func_ov002_020aeee4(char *c);
-extern void func_ov002_020af3a8(char *c);
+
+extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vector3 *v);
 extern int func_ov002_020af248(char *c, int n);
-extern void func_ov002_020af474(char *o);
 
 void func_ov002_020afa98(char *c)
 {
@@ -25,8 +24,8 @@ void func_ov002_020afa98(char *c)
         *(s32 *)(c + 0x388) = 3;
         *(u8 *)(c + 0x38e) = 1;
         func_ov002_020aefa4(c);
-        _ZN5Sound9PlayBank3EjRK7Vector3(0x68, (struct Vec *)(c + 0x74));
-        *(u32 *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        _ZN5Sound9PlayBank3EjRK7Vector3(0x68, (struct Vector3 *)(c + 0x74));
+        *(u32 *)(((long long)(int)(c + 0xb0))) &= ~1;
         return;
     case 1:
         func_ov002_020aefb8(c);
@@ -46,7 +45,7 @@ void func_ov002_020afa98(char *c)
         func_ov002_020af474(c);
         if (*(u16 *)(c + 0x100) != 0x25)
             return;
-        *(u32 *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        *(u32 *)(((long long)(int)(c + 0x128))) &= ~1;
         *(s32 *)(c + 0x388) = 1;
         *(u32 *)(c + 0x98) = 0x8000;
         return;

--- a/src/func_ov002_020afd10.c
+++ b/src/func_ov002_020afd10.c
@@ -1,15 +1,16 @@
+// @symbol func_ov002_020afd10
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vec3 { Fix12i x, y, z; };
 
-extern void func_ov002_020aefb8(char* self);
+
 extern int func_ov002_020af218(char* c, int n);
-extern int _ZN5Actor15IsPlayerInRangeEi(void* thiz, int n);
-extern void func_ov002_020afc68(char* c);
 extern int func_ov002_020af248(char* c, int n);
-extern void func_ov002_020af3a8(char* c);
-extern void func_ov002_020aeee4(char* c);
 
 void func_ov002_020afd10(char* c)
 {

--- a/src/func_ov002_020aff10.c
+++ b/src/func_ov002_020aff10.c
@@ -1,11 +1,11 @@
-struct Vec3 { int x, y, z; };
-extern void func_ov002_020aefb8(char* c);
+// @symbol func_ov002_020aff10
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void* v);
-extern void func_ov002_020af474(char* c);
-extern void func_ov002_020af3a8(char* c);
 extern void func_ov002_020af248(char* c, int n);
 extern void func_ov002_020af218(char* c, int n);
-extern void func_ov002_020aeee4(char* c);
 void func_ov002_020aff10(char* c){
   func_ov002_020aefb8(c);
   switch(*(int*)(c+0x388)){

--- a/src/func_ov002_020b05d0.c
+++ b/src/func_ov002_020b05d0.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov002_020b05d0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daBar_c */
 int *func_ov002_020b05d0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV7daBar_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020b0600.c
+++ b/src/func_ov002_020b0600.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov002_020b0600
+// @emits daBar_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daBar_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020b0600(int *t)
+int *daBar_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b0644.c
+++ b/src/func_ov002_020b0644.c
@@ -1,4 +1,8 @@
-int func_ov002_020b0644(void)
+// @symbol func_ov002_020b0644
+// @emits daBar_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daBar_c::CleanupResources - recovered from vtable slot identity */
+int daBar_c_CleanupResources(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b064c.c
+++ b/src/func_ov002_020b064c.c
@@ -1,3 +1,7 @@
-void func_ov002_020b064c(void)
+// @symbol func_ov002_020b064c
+// @emits daBar_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daBar_c::OnPendingDestroy - recovered from vtable slot identity */
+void daBar_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov002_020b0650.c
+++ b/src/func_ov002_020b0650.c
@@ -1,4 +1,8 @@
-int func_ov002_020b0650(void)
+// @symbol func_ov002_020b0650
+// @emits daBar_c_Render
+/* recovered: renamed to Class_Method */
+/* daBar_c::Render - recovered from vtable slot identity */
+int daBar_c_Render(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b0658.cpp
+++ b/src/func_ov002_020b0658.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov002_020b0658
+// @emits daBar_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daBar_c::Behavior - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12CylinderClsn6UpdateEv(void*);
-int func_ov002_020b0658(char* c){
+int daBar_c_Behavior(char* c){
   _ZN12CylinderClsn5ClearEv(c+0xd4);
   _ZN12CylinderClsn6UpdateEv(c+0xd4);
   return 1;


### PR DESCRIPTION
Batch 08 of the readable-tree migration. Promotes 190 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 122 VERIFIED, 68 BLIND, 0 WRONG/NO-REPRO. 0 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
