### PR TITLE
readable: batch 09 - promote 188 files to readable form

### DIFF
--- a/src/func_ov002_020b067c.c
+++ b/src/func_ov002_020b067c.c
@@ -1,7 +1,11 @@
+// @symbol func_ov002_020b067c
+// @emits daBar_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daBar_c::InitResources - recovered from vtable slot identity */
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(char* c, int a, int b, int d, int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* thiz, char* actor, int b, int d, unsigned int e, unsigned int f);
 
-int func_ov002_020b067c(char* c)
+int daBar_c_InitResources(char* c)
 {
     int r5 = (((*(int*)(c + 8) & 0xff) - 0xa) * 0xa) << 0xc;
     int half;

--- a/src/func_ov002_020b14d8.c
+++ b/src/func_ov002_020b14d8.c
@@ -1,8 +1,11 @@
+// @symbol func_ov002_020b14d8
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
 enum { false = 0, true = 1 };
 
-struct M12 { int w[12]; };
+
 
 struct BF3ae {
     unsigned char b0 : 1;
@@ -24,8 +27,8 @@ void func_ov002_020b14d8(char *c)
     *(int*)(c + 0x108) = *(int*)(c + 0x5c) >> 3;
     *(int*)(c + 0x10c) = *(int*)(c + 0x60) >> 3;
     *(int*)(c + 0x110) = *(int*)(c + 0x64) >> 3;
-    *(struct M12*)(c + 0x120) = *(struct M12*)(c + 0xe4);
-    *(struct M12*)(c + 0x368) = *(struct M12*)data_02082128;
+    *(struct Matrix4x3*)(c + 0x120) = *(struct Matrix4x3*)(c + 0xe4);
+    *(struct Matrix4x3*)(c + 0x368) = *(struct Matrix4x3*)data_02082128;
     *(int*)(c + 0x38c) = *(int*)(c + 0x5c) >> 3;
     *(int*)(c + 0x390) = *(int*)(c + 0x60) >> 3;
     *(int*)(c + 0x394) = *(int*)(c + 0x64) >> 3;

--- a/src/func_ov002_020b18f0.c
+++ b/src/func_ov002_020b18f0.c
@@ -1,13 +1,16 @@
+// @symbol func_ov002_020b18f0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 struct Vector3_16;
 extern int _ZN5Event6GetBitEj(unsigned int b);
-extern int SublevelToLevel(int i);
 extern void _ZN5Event6SetBitEj(unsigned int b);
 extern void _ZN9PowerStar13AddStarMarkerEv(char* c);
 extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct Vector3* v, struct Vector3_16* rot, int e, int f);
 extern signed char data_0209f2f8;
-extern short data_0209f358[];
 
 void func_ov002_020b18f0(char* c)
 {
@@ -19,7 +22,7 @@ void func_ov002_020b18f0(char* c)
     if (SublevelToLevel(data_0209f2f8) >= 0xf) return;
     if (c == 0) return;
     if (data_0209f358[*(unsigned char*)(c + 0x6d8)] < 0x64) return;
-    p = (struct Vector3*)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (struct Vector3*)(((long long)(int)(c + 0x5c)));
     vec.x = p->x;
     y = p->y;
     vec.y = y;

--- a/src/func_ov002_020b2150.cpp
+++ b/src/func_ov002_020b2150.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol func_ov002_020b2150
+// @emits VirtualDoor_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daChScene_c::Kill - recovered from vtable slot identity */
 extern "C" {
-extern void func_ov002_020b13e0(void*);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void*);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
-void func_ov002_020b2150(char* c){
+void VirtualDoor_Kill(char* c){
   func_ov002_020b13e0(c);
   if(_ZNK12WithMeshClsn8IsOnWallEv(c+0x1ac)) *(int*)(c+0x98)=0;
   if(_ZNK12WithMeshClsn10IsOnGroundEv(c+0x1ac)){

--- a/src/func_ov002_020b2a34.c
+++ b/src/func_ov002_020b2a34.c
@@ -1,12 +1,15 @@
-extern void func_ov002_020b16c4(char* c, char* p);
-extern void func_ov002_020b1674(char* c, char* p);
-extern void func_ov002_020b1884(char* c, char* p);
+// @symbol func_ov002_020b2a34
+// @emits Coin_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daCoin_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-void func_ov002_020b2a34(char* c, char* p)
+void Coin_OnTurnIntoEgg(char* c, char* p)
 {
     int state = *(int*)(c + 0x3a0);
     if (state == 1) {
-        *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x50000;
+        *(int*)(((long long)(int)(c + 0x60))) += 0x50000;
         func_ov002_020b16c4(c, p);
         return;
     }

--- a/src/func_ov002_020b2a90.c
+++ b/src/func_ov002_020b2a90.c
@@ -1,4 +1,8 @@
-int func_ov002_020b2a90(void)
+// @symbol func_ov002_020b2a90
+// @emits Coin_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Coin_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov002_020b2c44.cpp
+++ b/src/func_ov002_020b2c44.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol func_ov002_020b2c44
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef short s16;
 typedef int Fix12i;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 struct RaycastGround { char buf[0x68 - 0x18]; };
 
 extern "C" {
-void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
+void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
 void Matrix4x3_FromTranslation(struct Mtx43 *m, Fix12i x, Fix12i y, Fix12i z);
 void Matrix4x3_ApplyInPlaceToRotationY(void *m, s16 ang);
 void Matrix4x3_ApplyInPlaceToRotationZ(void *m, s16 ang);
@@ -17,7 +20,7 @@ void Matrix4x3_FromRotationY(void *m, int angle);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *sm, void *mtx, Fix12i a, Fix12i b, u32 u);
 void _ZN13RaycastGroundC1Ev(struct RaycastGround *self);
-void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vec3 *v, void *actor);
+void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vector3 *v, void *actor);
 int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround *self);
 void _ZN13RaycastGroundD1Ev(struct RaycastGround *self);
 }
@@ -28,11 +31,11 @@ extern unsigned char data_0209f2d8;
 extern "C" void func_ov002_020b2c44(char *c)
 {
     struct RaycastGround rg;
-    struct Vec3 pos;
-    struct Vec3 v;
+    struct Vector3 pos;
+    struct Vector3 v;
     int b;
 
-    Vec3_Asr(&v, (struct Vec3 *)(c + 0x5c), 3);
+    Vec3_Asr(&v, (struct Vector3 *)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(s16 *)(c + 0x8e));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(s16 *)(c + 0x90));

--- a/src/func_ov002_020b3298.c
+++ b/src/func_ov002_020b3298.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov002_020b3298
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12daObjAbuku_c */
 int *func_ov002_020b3298(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daObjAbuku_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020b32c8.c
+++ b/src/func_ov002_020b32c8.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov002_020b32c8
+// @emits daObjAbuku_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjAbuku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020b32c8(int *t)
+int *daObjAbuku_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b33dc.cpp
+++ b/src/func_ov002_020b33dc.cpp
@@ -1,18 +1,22 @@
 //cpp
+// @symbol func_ov002_020b33dc
+// @emits daObjAbuku_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjAbuku_c::Behavior - recovered from vtable slot identity */
 typedef long long s64;
 extern short data_02082214[];
 extern "C" void _Z14ApproachLinearRiii(int* p, int b, int c);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(char* self, void* c);
 extern "C" char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN6Player4HealEi(char* self, int amt);
-extern "C" void func_ov002_020b330c(char* c);
 extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
-extern "C" int func_ov002_020b3344(char* c);
 extern "C" void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
 extern "C" void _ZN12CylinderClsn5ClearEv(char* cl);
 extern "C" void _ZN12CylinderClsn6UpdateEv(char* cl);
 
-extern "C" int func_ov002_020b33dc(char* self)
+extern "C" int daObjAbuku_c_Behavior(char* self)
 {
     *(short*)(((int)self + 0x10c) & 0xFFFFFFFFFFFFFFFF) += 0x400;
     int v = *(volatile unsigned short*)(self + 0x10c);

--- a/src/func_ov002_020b3518.cpp
+++ b/src/func_ov002_020b3518.cpp
@@ -1,9 +1,16 @@
 //cpp
+// @symbol func_ov002_020b3518
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjAbuku_c.h"
+// @emits daObjAbuku_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjAbuku_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
-int func_ov002_020b3518(char* c){
+int daObjAbuku_c_InitResources(char* c){
+    struct daObjAbuku_c *self = (struct daObjAbuku_c *)(void *)c;
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0xd4, c, 0x96000, 0x96000, 0x100002, 0);
-  *(short*)(c+0x10e)=0x12c;
+  self->unk_10e=0x12c;
   return 1;
 }
 }

--- a/src/func_ov002_020b36b4.cpp
+++ b/src/func_ov002_020b36b4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020b36b4
+// @emits BigBrickBlock_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjBlockL_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov002_020b36b4(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void BigBrickBlock_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov002_020b36dc.cpp
+++ b/src/func_ov002_020b36dc.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020b36dc
+// @emits BigBrickBlock_OnKicked
+/* recovered: renamed to Class_Method */
+/* daObjBlockL_c::OnKicked - recovered from vtable slot identity */
 typedef unsigned short u16;
 struct State { int pad[2]; int field8; };
 struct Base {
@@ -13,7 +17,7 @@ struct Base {
     virtual void m();
 };
 
-extern "C" void func_ov002_020b36dc(Base *self, struct State *st)
+extern "C" void BigBrickBlock_OnKicked(Base *self, struct State *st)
 {
     int b1 = (int)(*(u16 *)((char *)self + 0xc) == 0x2e);
     int r1;

--- a/src/func_ov002_020b3788.cpp
+++ b/src/func_ov002_020b3788.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov002_020b3788
+// @emits BigBrickBlock_OnAttacked2
+/* recovered: renamed to Class_Method */
+/* daObjBlockL_c::OnAttacked2 - recovered from vtable slot identity */
 struct Sub { virtual void v0(); };
 extern "C" {
-void func_ov002_020b3788(char *c, char *arg1){
+void BigBrickBlock_OnAttacked2(char *c, char *arg1){
   struct Vt { int dummy[0x7c/4]; void (*fn)(void*); };
   int b = (*(unsigned short*)(c+0xc) == 0x11);
   if (b) {

--- a/src/func_ov002_020b37ec.c
+++ b/src/func_ov002_020b37ec.c
@@ -1,4 +1,8 @@
-void func_ov002_020b37ec(void *c) {
+// @symbol func_ov002_020b37ec
+// @emits BigBrickBlock_OnAttacked1
+/* recovered: renamed to Class_Method */
+/* daObjBlockL_c::OnAttacked1 - recovered from vtable slot identity */
+void BigBrickBlock_OnAttacked1(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int b = (int)(v == 0x11);
     if (b) return;

--- a/src/func_ov002_020b382c.cpp
+++ b/src/func_ov002_020b382c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020b382c
+// @emits BigBrickBlock_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjBlockL_c::OnGroundPounded - recovered from vtable slot identity */
 struct Arg { char pad[8]; int f8; };
 struct Obj {
   virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -10,7 +14,7 @@ struct Obj {
   virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
   virtual void v28(); virtual void v29(); virtual void v30(); virtual void target();
 };
-extern "C" void func_ov002_020b382c(Obj* o, Arg* a) {
+extern "C" void BigBrickBlock_OnGroundPounded(Obj* o, Arg* a) {
   if (a->f8 == 3) return;
   int b = (*(unsigned short*)((char*)o+0xc) == 0x11);
   if (b != 0) {

--- a/src/func_ov002_020b38a0.c
+++ b/src/func_ov002_020b38a0.c
@@ -1,10 +1,15 @@
+// @symbol func_ov002_020b38a0
+// @emits BigBrickBlock_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjBlockL_c::Kill - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vector3 { s32 x, y, z; };
 
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(char *thiz, s8 *ref, u32 b, const struct Vector3 *v, u32 j);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const struct Vector3 *v, const void *v16, s32 e, s32 f);
@@ -12,12 +17,10 @@ extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char *thiz, const struct
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 kind, s32 x, s32 y, s32 z);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(char *thiz, const struct Vector3 *v);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, const struct Vector3 *v);
-extern void func_ov002_020b363c(char *c);
-extern int func_ov002_020b36a0(char *c);
 extern void _ZN5Actor13SpawnSoundObjEj(char *thiz, u32 a);
 extern void _ZN9ActorBase18MarkForDestructionEv(char *thiz);
 
-void func_ov002_020b38a0(char *c)
+void BigBrickBlock_Kill(char *c)
 {
     struct Vector3 tmp[4];
     u32 kind;

--- a/src/func_ov002_020b41f8.cpp
+++ b/src/func_ov002_020b41f8.cpp
@@ -1,10 +1,13 @@
 //cpp
-struct V3{int x,y,z;};
+// @symbol func_ov002_020b41f8
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
-void func_ov002_020b41b8(struct V3*, char*);
-int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
+void func_ov002_020b41b8(struct Vector3*, char*);
+int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 void func_ov002_020b41f8(char* c){
-  struct V3 v;
+  struct Vector3 v;
   func_ov002_020b41b8(&v, c);
   char* r = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x11d, 0, &v, 0, *(signed char*)(c+0xcc), -1);
   if(r) *(unsigned char*)(r+0x3c6)=0xb4;

--- a/src/func_ov002_020b4250.cpp
+++ b/src/func_ov002_020b4250.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov002_020b4250
+// @emits BigBrickBlock_AfterClsn
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjBlockL_c::AfterClsn - recovered from vtable slot identity */
 struct V3{int x,y,z;};
 extern "C" {
 void func_ov002_020b41b8(struct V3*, char*);
 int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
-void func_ov002_020b4250(char* c){
+void BigBrickBlock_AfterClsn(char* c){
   struct V3 v;
   func_ov002_020b41b8(&v, c);
   _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x115, 0, &v, 0, *(signed char*)(c+0xcc), -1);

--- a/src/func_ov002_020b429c.cpp
+++ b/src/func_ov002_020b429c.cpp
@@ -1,10 +1,13 @@
 //cpp
-struct V3{int x,y,z;};
+// @symbol func_ov002_020b429c
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
-void func_ov002_020b41b8(struct V3*, char*);
-int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
+void func_ov002_020b41b8(struct Vector3*, char*);
+int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 void func_ov002_020b429c(char* c){
-  struct V3 v;
+  struct Vector3 v;
   func_ov002_020b41b8(&v, c);
   _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x114, 0, &v, 0, *(signed char*)(c+0xcc), -1);
 }

--- a/src/func_ov002_020b42e4.c
+++ b/src/func_ov002_020b42e4.c
@@ -1,6 +1,8 @@
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
-
+// @symbol func_ov002_020b42e4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Actor {
     char pad4[4];
     int f4;     // 0x4
@@ -9,7 +11,6 @@ struct Actor {
 };
 
 extern void _ZN5Actor11UntrackStarERa(char *thiz, signed char *star);
-extern void func_ov002_020b41b8(int *dst, char *src);
 extern struct Actor *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
     unsigned int a, unsigned int b, const struct Vector3 *pos,
     const struct Vector3_16 *rot, int e, int f);

--- a/src/func_ov002_020b4714.c
+++ b/src/func_ov002_020b4714.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020b4714
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* from);
 extern void _ZN5Actor13LandingDustAtER7Vector3b(char* thiz, struct Vector3* v, int flag);
 extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vector3* pos, void* rot, int e, int f);
@@ -12,7 +14,7 @@ void func_ov002_020b4714(char* a) {
             struct Vector3 v;
             struct Vector3* p;
             char* spawned;
-            p = (struct Vector3*)(((long long)(int)(b + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            p = (struct Vector3*)(((long long)(int)(b + 0x5c)));
             v.x = p->x;
             v.y = p->y;
             v.z = p->z;

--- a/src/func_ov002_020b4fc4.c
+++ b/src/func_ov002_020b4fc4.c
@@ -1,4 +1,8 @@
-void func_ov002_020b4fc4(char *p)
+// @symbol func_ov002_020b4fc4
+// @emits QuestionSwitch_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjHatenaSwitch_c::OnGroundPounded - recovered from vtable slot identity */
+void QuestionSwitch_OnGroundPounded(char *p)
 {
     p[1816] = 0;
 }

--- a/src/func_ov002_020b503c.cpp
+++ b/src/func_ov002_020b503c.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov002_020b503c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov002_020b503c(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0x6d0);
+    o->m = *(Matrix4x3*)(self + 0x6d0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov002_020b50a0.c
+++ b/src/func_ov002_020b50a0.c
@@ -1,13 +1,15 @@
-struct M48 { int w[12]; };
+// @symbol func_ov002_020b50a0
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void* d, void* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* mF, short angY);
-extern struct M48 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov002_020b50a0(char* c) {
   int v[4];
   Vec3_Asr(&v, c+0x5c, 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
-  *(struct M48*)(c+0x6d0) = data_020a0e68;
-  *(struct M48*)(c+0xf0) = *(struct M48*)(c+0x6d0);
+  *(struct Matrix4x3*)(c+0x6d0) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0xf0) = *(struct Matrix4x3*)(c+0x6d0);
 }

--- a/src/func_ov002_020b599c.c
+++ b/src/func_ov002_020b599c.c
@@ -1,3 +1,7 @@
-void func_ov002_020b599c(void)
+// @symbol func_ov002_020b599c
+// @emits BlueFlame_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daObjFire_c::OnTurnIntoEgg - recovered from vtable slot identity */
+void BlueFlame_OnTurnIntoEgg(void)
 {
 }

--- a/src/func_ov002_020b59a0.c
+++ b/src/func_ov002_020b59a0.c
@@ -1,4 +1,8 @@
-int func_ov002_020b59a0(void)
+// @symbol func_ov002_020b59a0
+// @emits BlueFlame_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daObjFire_c::OnYoshiTryEat - recovered from vtable slot identity */
+int BlueFlame_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov002_020b5a18.c
+++ b/src/func_ov002_020b5a18.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b5a18
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b5a18(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b5a70.c
+++ b/src/func_ov002_020b5a70.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b5a70
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b5a70(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b5ab4.cpp
+++ b/src/func_ov002_020b5ab4.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov002_020b5ab4
+/* recovered: shared common types */
+#include "common.h"
 typedef int s32;
 typedef signed char s8;
-struct Vector3 { s32 x, y, z; };
+
 struct Actor;
 
 struct RaycastGround {

--- a/src/func_ov002_020b5c4c.c
+++ b/src/func_ov002_020b5c4c.c
@@ -1,23 +1,26 @@
+// @symbol func_ov002_020b5c4c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
 typedef signed short s16;
 
-struct Vec3 { int x, y, z; };
+
 
 extern void func_020393a4(int *p, int v);
-extern int func_ov002_020b5ab4(char *c);
 extern int _Z14ApproachLinearRiii(int *p, int value, int speed);
 extern short data_02082214[];
 extern int Vec3_HorzDist(void *a, void *b);
 extern short _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern void _Z14ApproachLinearRsss(short *p, short value, short speed);
-extern void func_ov002_020b5b98(char *c);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 
 int func_ov002_020b5c4c(char *c)
 {
-    struct Vec3 tpos;
+    struct Vector3 tpos;
     int dist;
     short atanRes;
     short angleDiff;
@@ -30,7 +33,7 @@ int func_ov002_020b5c4c(char *c)
     if (func_ov002_020b5ab4(c) != 0) {
         if (_Z14ApproachLinearRiii((int *)(c + 0x330),
                 *(void **)(c + 0x33c) != 0 ? -0x28000 : 0, 0x5000) != 0) {
-            short *ctr = (short *)((long long)(int)(c + 0x338) & 0xFFFFFFFFFFFFFFFFLL);
+            short *ctr = (short *)((long long)(int)(c + 0x338));
             short cval = *ctr;
             char *st = c + 0x300;
             *ctr = (short)(cval + 0xa00);
@@ -44,7 +47,7 @@ int func_ov002_020b5c4c(char *c)
             val1 = val2;
         } else {
             char *target = *(char **)(c + 0x33c);
-            struct Vec3 *tp = (struct Vec3 *)((long long)(int)(target + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            struct Vector3 *tp = (struct Vector3 *)((long long)(int)(target + 0x5c));
             tpos.x = tp->x;
             tpos.y = tp->y;
             tpos.z = tp->z;

--- a/src/func_ov002_020b5e58.cpp
+++ b/src/func_ov002_020b5e58.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov002_020b5e58
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
 
 extern "C" BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, BMD_File *f, int a, int b);
-extern "C" void func_ov002_020b5b98(char *t);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern "C" KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr &f);
 extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
@@ -13,21 +17,20 @@ extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEs
 extern "C" void func_020393c4(void *p, void *v);
 extern "C" void func_020393d4(void *p, void *v);
 
-struct V3 { int x, y, z; };
+
 struct RaycastGround { char buf[0x44]; int f44; char rest[8]; };
 extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround *self);
-extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround *self, V3 *v, void *a);
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround *self, Vector3 *v, void *a);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround *self);
 extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround *self);
 
-extern char func_ov002_020b5fc4;
 extern char _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern "C" signed char data_0209f2f8;
 
 extern "C" int func_ov002_020b5e58(char *self, char *fp)
 {
     RaycastGround rg;
-    V3 v;
+    Vector3 v;
     BMD_File *bmd;
     KCL_File *kcl;
     int vy, vz, vx;

--- a/src/func_ov002_020b5fd8.c
+++ b/src/func_ov002_020b5fd8.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b5fd8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b5fd8(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6030.c
+++ b/src/func_ov002_020b6030.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b6030
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6030(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6074.cpp
+++ b/src/func_ov002_020b6074.cpp
@@ -1,22 +1,25 @@
 //cpp
+// @symbol func_ov002_020b6074
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x,y,z; };
-struct M43 { int w[12]; };
-extern void Matrix4x3_FromQuaternion(void* q, struct M43* m);
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+
+
+extern void Matrix4x3_FromQuaternion(void* q, struct Matrix4x3* m);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
-extern void MulMat4x3Mat4x3(struct M43* a, void* b, void* c);
+extern void MulMat4x3Mat4x3(struct Matrix4x3* a, void* b, void* c);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short a);
-extern struct M43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov002_020b6074(char* c){
-  struct M43 q;
-  struct Vec3 v;
+  struct Matrix4x3 q;
+  struct Vector3 v;
   Matrix4x3_FromQuaternion(c+0x320, &q);
-  Vec3_Asr(&v, (struct Vec3*)(c+0x5c), 3);
+  Vec3_Asr(&v, (struct Vector3*)(c+0x5c), 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
   MulMat4x3Mat4x3(&q, &data_020a0e68, &data_020a0e68);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
-  *(struct M43*)(c+0xf0) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0xf0) = data_020a0e68;
 
 }
 }

--- a/src/func_ov002_020b62cc.c
+++ b/src/func_ov002_020b62cc.c
@@ -1,11 +1,14 @@
+// @symbol func_ov002_020b62cc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int w[12]; };
+
+
 extern struct Matrix4x3 data_020a0e68;
 extern void InvMat4x3(struct Matrix4x3 *d, struct Matrix4x3 *s);
 extern void MulVec3Mat4x3(struct Vector3 *v, struct Matrix4x3 *m, struct Vector3 *out);
-extern void Quaternion_FromVector3(int *q, struct Vector3 *a, struct Vector3 *b);
-extern void Quaternion_Normalize(int *q);
 
 void func_ov002_020b62cc(unsigned char *self, unsigned char *arg)
 {

--- a/src/func_ov002_020b6388.c
+++ b/src/func_ov002_020b6388.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b6388
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b6388(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b63e0.c
+++ b/src/func_ov002_020b63e0.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b63e0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b63e0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b660c.c
+++ b/src/func_ov002_020b660c.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b660c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b660c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6664.c
+++ b/src/func_ov002_020b6664.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b6664
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6664(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6814.c
+++ b/src/func_ov002_020b6814.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b6814
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b6814(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b686c.c
+++ b/src/func_ov002_020b686c.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b686c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b686c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b69e4.c
+++ b/src/func_ov002_020b69e4.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b69e4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020b69e4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6a3c.c
+++ b/src/func_ov002_020b6a3c.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b6a3c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020b6a3c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b6c54.c
+++ b/src/func_ov002_020b6c54.c
@@ -1,12 +1,16 @@
+// @symbol func_ov002_020b6c54
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_strength_reduction off
-struct Vec3 { int x, y, z; };
+
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(char* thiz, void* file, int a, int b);
-extern int func_ov002_020b6a80(char* c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(char* thiz, void* kcl, char* mtx, int fix, short s, char* block);
-extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vec3* pos, void* rot, int a, int b);
+extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, struct Vector3* pos, void* rot, int a, int b);
 int func_ov002_020b6c54(char* sb, char** arg, unsigned int actorID){
   int i;
   void* m;
@@ -19,7 +23,7 @@ int func_ov002_020b6c54(char* sb, char** arg, unsigned int actorID){
   for(i = 0; i < 4; i++){
     char* sp;
     *(int*)(sb + (int)((unsigned long long)i & 0xFFFFFFFFFFFFFFFFull)*4 + 0x320) = 0;
-    sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(actorID, 0, (struct Vec3*)(sb+0x5c), 0, *(signed char*)(sb+0xcc), -1);
+    sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(actorID, 0, (struct Vector3*)(sb+0x5c), 0, *(signed char*)(sb+0xcc), -1);
     if(sp != 0) *(int*)(sb + i*4 + 0x320) = *(int*)(sp+4);
   }
   return 1;

--- a/src/func_ov002_020b6d4c.c
+++ b/src/func_ov002_020b6d4c.c
@@ -1,8 +1,11 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov002_020b6d4c(int *t)
+// @symbol func_ov002_020b6d4c
+// @emits daObjLava_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjLava_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *daObjLava_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b6d84.c
+++ b/src/func_ov002_020b6d84.c
@@ -1,3 +1,7 @@
+// @symbol func_ov002_020b6d84
+// @emits daObjLava_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjLava_c::Behavior - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef int Fix12;
 
@@ -18,7 +22,7 @@ struct Actor {
 extern struct Player* _ZN5Actor13ClosestPlayerEv(struct Actor* self);
 extern u32 func_02022c3c(u32 uniqueID, u32 effectID, Fix12 x, Fix12 y, Fix12 z, const void* dir);
 
-int func_ov002_020b6d84(struct Actor* self) {
+int daObjLava_c_Behavior(struct Actor* self) {
     struct Vec3* v = (struct Vec3*)(((int)_ZN5Actor13ClosestPlayerEv(self) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
     self->uniqueID = func_02022c3c(self->uniqueID, 0xb7, v->x, v->y, v->z, 0);
     return 1;

--- a/src/func_ov002_020b6dd0.c
+++ b/src/func_ov002_020b6dd0.c
@@ -1,4 +1,8 @@
-int func_ov002_020b6dd0(void)
+// @symbol func_ov002_020b6dd0
+// @emits daObjLava_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjLava_c::InitResources - recovered from vtable slot identity */
+int daObjLava_c_InitResources(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b76ec.c
+++ b/src/func_ov002_020b76ec.c
@@ -1,12 +1,16 @@
+// @symbol func_ov002_020b76ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+
+
 
 extern u8 data_0209f2d8[];
-extern void GiveLives(int delta);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 a, const struct Vector3 *p);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(

--- a/src/func_ov002_020b781c.c
+++ b/src/func_ov002_020b781c.c
@@ -1,7 +1,12 @@
+// @symbol func_ov002_020b781c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed short s16;
 typedef unsigned short u16;
 
-struct Vector3 { int x, y, z; };
+
 
 extern short data_02082214[];
 
@@ -13,7 +18,6 @@ extern char *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *self, void *out);
 extern int func_02037e58(void *p);
 extern short _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
-extern int func_ov002_020f02c8(int x);
 extern void func_ov002_020f030c(int x);
 extern int Vec3_HorzLen(void *v);
 extern void Vec3_MulScalarInPlace(void *v, int s);

--- a/src/func_ov002_020b7cdc.c
+++ b/src/func_ov002_020b7cdc.c
@@ -1,4 +1,8 @@
-int func_ov002_020b7cdc(int *p)
+// @symbol func_ov002_020b7cdc
+// @emits PoppingLavaBubbles_Kill
+/* recovered: renamed to Class_Method */
+/* daObjWaterfall_c::Kill - recovered from vtable slot identity */
+int PoppingLavaBubbles_Kill(int *p)
 {
     p[39] = 0; return 1;
 }

--- a/src/func_ov002_020b7e1c.cpp
+++ b/src/func_ov002_020b7e1c.cpp
@@ -1,6 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+// @symbol func_ov002_020b7e1c
+/* recovered: shared common types */
+#include "common.h"
+
+
 struct WithMeshClsn { int IsOnGround() const; };
 struct ActorBase { void MarkForDestruction(); };
 struct Actor : ActorBase {

--- a/src/func_ov002_020b81e0.c
+++ b/src/func_ov002_020b81e0.c
@@ -1,3 +1,7 @@
+// @symbol func_ov002_020b81e0
+// @emits WaterfallMist_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daObjMarioCap_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN6Player17SetNoControlStateEhih(char* p, unsigned char a, int b, unsigned char d);
 extern void _ZN6Player18SetNewHatCharacterEjjb(char* p, unsigned int a, unsigned int b, int d);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* bca, int a, int b, unsigned int e);
@@ -5,7 +9,7 @@ extern void func_ov002_020b7f2c(char* c, void* p);
 extern void* data_ov002_0210de30[];
 extern int data_ov002_0210df54;
 
-void func_ov002_020b81e0(char* c, char* arg)
+void WaterfallMist_OnTurnIntoEgg(char* c, char* arg)
 {
     if (_ZN6Player17SetNoControlStateEhih(arg, 8, -1, 0) == 1) {
         _ZN6Player18SetNewHatCharacterEjjb(arg, *(int*)(c + 0x3f4) & 0xff, 1, 0);

--- a/src/func_ov002_020b8270.c
+++ b/src/func_ov002_020b8270.c
@@ -1,4 +1,8 @@
-int func_ov002_020b8270(char* c){
+// @symbol func_ov002_020b8270
+// @emits WaterfallMist_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daObjMarioCap_c::OnYoshiTryEat - recovered from vtable slot identity */
+int WaterfallMist_OnYoshiTryEat(char* c){
   if(*(int*)(c+0x3f0)==2) return 0;
   return 4;
 }

--- a/src/func_ov002_020b8bf0.c
+++ b/src/func_ov002_020b8bf0.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b8bf0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjPushblock_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov002_020b8bf0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjPushblock_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b8c3c.c
+++ b/src/func_ov002_020b8c3c.c
@@ -1,12 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020b8c3c
+// @emits daObjPushblock_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjPushblock_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020b8c3c(int *t)
+int *daObjPushblock_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);

--- a/src/func_ov002_020b8d14.cpp
+++ b/src/func_ov002_020b8d14.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020b8d14
+// @emits daObjPushblock_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjPushblock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov002_020b8d14(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void daObjPushblock_c_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov002_020b8d3c.c
+++ b/src/func_ov002_020b8d3c.c
@@ -1,6 +1,13 @@
-void func_ov002_020b8d3c(char* r0, char* r1){
+// @symbol func_ov002_020b8d3c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjPushblock_c.h"
+// @emits daObjPushblock_c_OnPushed
+/* recovered: renamed to Class_Method */
+/* daObjPushblock_c::OnPushed - recovered from vtable slot identity */
+void daObjPushblock_c_OnPushed(char* r0, char* r1){
+    struct daObjPushblock_c *self = (struct daObjPushblock_c *)(void *)r0;
   if(r1==0) return;
-  *(short*)(r0+0x94)=*(short*)(r1+0x8e);
-  if(*(int*)(r1+8)==2) *(int*)(r0+0x98)=0x8000;
-  else *(int*)(r0+0x98)=0x4000;
+  self->unk_094=*(short*)(r1+0x8e);
+  if(*(int*)(r1+8)==2) self->unk_098=0x8000;
+  else self->unk_098=0x4000;
 }

--- a/src/func_ov002_020b8d68.c
+++ b/src/func_ov002_020b8d68.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov002_020b8d68
+// @emits daObjPushblock_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjPushblock_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov002_020b8d68(void *t)
+int daObjPushblock_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov002_020b8dac.cpp
+++ b/src/func_ov002_020b8dac.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020b8dac
+// @emits daObjPushblock_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjPushblock_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov002_020b8dac(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjPushblock_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov002_020b8dd4.c
+++ b/src/func_ov002_020b8dd4.c
@@ -1,10 +1,16 @@
+// @symbol func_ov002_020b8dd4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjPushblock_c.h"
+// @emits daObjPushblock_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjPushblock_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
-typedef struct { int m[12]; } Matrix4x3;
-typedef struct { int x, y, z; } Vector3;
 
 extern Matrix4x3 data_020a0e68;
 
-extern int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void *c, s16 a, s16 b, s16 d, int fix);
 extern void Matrix4x3_FromRotationY(Matrix4x3 *m, int angle);
 extern void MulVec3Mat4x3(Vector3 *v, Matrix4x3 *m, Vector3 *dst);
 extern void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
@@ -22,10 +28,10 @@ extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void *thiz, int a, i
 extern int Vec3_Dist(Vector3 *a, Vector3 *b);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, Vector3 *pos, unsigned int e);
 extern int Vec3_HorzDist(Vector3 *a, Vector3 *b);
-extern void func_ov002_020f0438(void *thiz);
 
-int func_ov002_020b8dd4(char *c)
+int daObjPushblock_c_Behavior(char *c)
 {
+    struct daObjPushblock_c *self = (struct daObjPushblock_c *)(void *)c;
     Vector3 v;
     Vector3 dst;
     volatile Vector3 pos;
@@ -36,24 +42,24 @@ int func_ov002_020b8dd4(char *c)
         return 1;
     }
 
-    if (*(int *)(c + 0x98) != 0) {
+    if (self->unk_098 != 0) {
         v.x = 0;
         dst.x = 0;
         dst.y = 0;
         dst.z = 0;
         v.y = 0x96000;
         v.z = 0x96000;
-        Matrix4x3_FromRotationY(&data_020a0e68, *(s16 *)(c + 0x94));
+        Matrix4x3_FromRotationY(&data_020a0e68, self->unk_094);
         MulVec3Mat4x3(&v, &data_020a0e68, &dst);
         AddVec3(&dst, (Vector3 *)(c + 0x5c), &dst);
         _ZN13RaycastGroundC1Ev(ray);
         _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(ray, &dst, 0);
         if (_ZN13RaycastGround10DetectClsnEv(ray) != 0) {
-            if (*(int *)(c + 0x4e8) != *(int *)(ray + 0x44)) {
-                *(int *)(c + 0x98) = 0;
+            if (self->unk_4e8 != *(int *)(ray + 0x44)) {
+                self->unk_098 = 0;
             }
         } else {
-            *(int *)(c + 0x98) = 0;
+            self->unk_098 = 0;
         }
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
         func_020383fc(c + 0x320);
@@ -66,19 +72,19 @@ int func_ov002_020b8dd4(char *c)
     func_02039394((int *)(c + 0x124), 0x96000);
     _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0x3e8000, 0x96000);
 
-    if (*(int *)(c + 0x98) != 0 && Vec3_Dist((Vector3 *)(c + 0x5c), (Vector3 *)(c + 0x68)) != 0) {
-        *(unsigned int *)(c + 0x4ec) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int *)(c + 0x4ec), 3, 0x97, (Vector3 *)(c + 0x74), 0);
+    if (self->unk_098 != 0 && Vec3_Dist((Vector3 *)(c + 0x5c), (Vector3 *)(c + 0x68)) != 0) {
+        self->unk_4ec = _ZN5Sound8PlayLongEjjjRK7Vector3j(self->unk_4ec, 3, 0x97, (Vector3 *)(c + 0x74), 0);
     }
 
     if (Vec3_HorzDist((Vector3 *)(c + 0x4dc), (Vector3 *)(c + 0x5c)) >= 0x12c000) {
-        if (*(int *)(c + 0x4f0) != 0) {
-            if (*(unsigned short *)(*(int *)(c + 0x4f0) + 0xc) == 0x149) {
-                pos.x = *(int *)(c + 0x4dc);
-                pos.y = *(int *)(c + 0x4e0);
-                pos.z = *(int *)(c + 0x4e4);
-                pos.y = *(int *)(c + 0x4e0) + 0x96000;
+        if (self->unk_4f0 != 0) {
+            if (*(unsigned short *)(self->unk_4f0 + 0xc) == 0x149) {
+                pos.x = self->unk_4dc;
+                pos.y = self->unk_4e0;
+                pos.z = self->unk_4e4;
+                pos.y = self->unk_4e0 + 0x96000;
                 q = *(char **)(c + 0x4f0);
-                *(int *)(q + 0x5c) = *(int *)(c + 0x4dc);
+                *(int *)(q + 0x5c) = self->unk_4dc;
                 *(int *)(q + 0x60) = pos.y;
                 *(int *)(q + 0x64) = pos.z;
                 func_ov002_020f0438(*(void **)(c + 0x4f0));
@@ -87,6 +93,6 @@ int func_ov002_020b8dd4(char *c)
         }
     }
 
-    *(int *)(c + 0x98) = 0;
+    self->unk_098 = 0;
     return 1;
 }

--- a/src/func_ov002_020b8fe0.cpp
+++ b/src/func_ov002_020b8fe0.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov002_020b8fe0
+// @emits daObjPushblock_c_InitResources
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjPushblock_c::InitResources - recovered from vtable slot identity */
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -22,9 +28,8 @@ extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround *self);
 
 extern SharedFilePtr data_ov002_0210df9c;
 extern SharedFilePtr data_ov002_0210df94;
-extern char data_ov002_0210d7b4;
 
-extern "C" int func_ov002_020b8fe0(char *self)
+extern "C" int daObjPushblock_c_InitResources(char *self)
 {
     RaycastGround rg;
     V3 v;

--- a/src/func_ov002_020b9450.cpp
+++ b/src/func_ov002_020b9450.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020b9450
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);

--- a/src/func_ov002_020b993c.c
+++ b/src/func_ov002_020b993c.c
@@ -1,14 +1,17 @@
+// @symbol func_ov002_020b993c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef long long s64;
 struct ShadowModel; struct Matrix4x3;
-struct M48 { int w[12]; };
+
 extern int _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(char* self, struct ShadowModel* sm, struct Matrix4x3* m, int fix, int t, u32 f);
 int func_ov002_020b993c(char* c)
 {
     int r3;
     int b = (int)((*(int*)(c + 0xb0) & 0x40000) != 0);
     if (b != 0) return b;
-    *(struct M48*)(c+0x19c) = *(struct M48*)(c+0x140);
+    *(struct Matrix4x3*)(c+0x19c) = *(struct Matrix4x3*)(c+0x140);
     *(int*)(c+0x1c4) = *(int*)(c+0x3bc) >> 3;
     r3 = 0x78000;
     if (*(int*)(c+0x3c0) == 0) {

--- a/src/func_ov002_020b9a1c.c
+++ b/src/func_ov002_020b9a1c.c
@@ -1,9 +1,12 @@
+// @symbol func_ov002_020b9a1c
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromRotationY(void* m, int angle);
-struct M48 { int w[12]; };
+
 void func_ov002_020b9a1c(char* t){
   Matrix4x3_FromRotationY(t+0x140, *(short*)(t+0x8e));
   *(int*)(t+0x164) = *(int*)(t+0x5c) >> 3;
   *(int*)(t+0x168) = *(int*)(t+0x60) >> 3;
   *(int*)(t+0x16c) = *(int*)(t+0x64) >> 3;
-  *(struct M48*)(t+0xf0) = *(struct M48*)(t+0x140);
+  *(struct Matrix4x3*)(t+0xf0) = *(struct Matrix4x3*)(t+0x140);
 }

--- a/src/func_ov002_020b9e04.c
+++ b/src/func_ov002_020b9e04.c
@@ -1,4 +1,8 @@
-int func_ov002_020b9e04(void)
+// @symbol func_ov002_020b9e04
+// @emits PushBlock_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daObjPowerUpItem_c::OnYoshiTryEat - recovered from vtable slot identity */
+int PushBlock_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov002_020b9f80.cpp
+++ b/src/func_ov002_020b9f80.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov002_020b9f80
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov002_020b9f80(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60) - *(int*)(self+0x32c);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov002_020b9fec.c
+++ b/src/func_ov002_020b9fec.c
@@ -1,5 +1,9 @@
+// @symbol func_ov002_020b9fec
+// @emits StarSwitch_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjSwitch_c::OnGroundPounded - recovered from vtable slot identity */
 extern int func_ov002_020ba4d8();
-void func_ov002_020b9fec(char* c){
+void StarSwitch_OnGroundPounded(char* c){
   if(*(int*)(c+0x340)!=0) return;
   func_ov002_020ba4d8(c,1);
 }

--- a/src/func_ov002_020ba0f8.cpp
+++ b/src/func_ov002_020ba0f8.cpp
@@ -1,9 +1,13 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020ba0f8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void func_ov002_020ba01c(void* c, int a, int b, int d, int e);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int n, struct Vector3* v);
-extern "C" void func_ov002_020e7104(void* p, int n);
 extern void _ZN5Event8ClearBitEj(unsigned int n);
 extern "C" void func_ov002_020ba4d8(void* c, int i);
 

--- a/src/func_ov002_020ba4c0.c
+++ b/src/func_ov002_020ba4c0.c
@@ -1,4 +1,8 @@
-void func_ov002_020ba4c0(char *p)
+// @symbol func_ov002_020ba4c0
+// @emits PushBlock_Kill
+/* recovered: renamed to Class_Method */
+/* daObjPowerUpItem_c::Kill - recovered from vtable slot identity */
+void PushBlock_Kill(char *p)
 {
     *(short *)(p + 0x338) = 0;
     *(char *)(p + 0x34f) = 5;

--- a/src/func_ov002_020bab0c.c
+++ b/src/func_ov002_020bab0c.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020bab0c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov002_020bab0c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bab64.c
+++ b/src/func_ov002_020bab64.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020bab64
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov002_020bab64(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bafc0.c
+++ b/src/func_ov002_020bafc0.c
@@ -1,10 +1,13 @@
+// @symbol func_ov002_020bafc0
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern void Matrix4x3_ApplyInPlaceToTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(struct Mtx43* m, int x, int y, int z);
@@ -12,8 +15,8 @@ extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(struct Mtx43* m, int x, int y
 extern struct Mtx43 data_020a0e68;
 
 void func_ov002_020bafc0(char* self){
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3*)(self + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3*)(self + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, 0x8c00, 0);
     Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68,

--- a/src/func_ov002_020bb23c.cpp
+++ b/src/func_ov002_020bb23c.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol func_ov002_020bb23c
+// @emits SignPost_OnAttacked1
+/* recovered: renamed to Class_Method */
+/* daObjTatefuda_c::OnAttacked1 - recovered from vtable slot identity */
 struct Base { virtual void v0();virtual void v1();virtual void v2();virtual void v3();virtual void v4();virtual void v5();virtual void v6();virtual void v7();virtual void v8();virtual void v9();virtual void v10();virtual void v11();virtual void v12();virtual void v13();virtual void v14();virtual void v15();virtual void v16();virtual void v17();virtual void v18();virtual void v19();virtual void v20();virtual void v21();virtual void v22();virtual void v23();virtual void v24();virtual void v25();virtual void v26();virtual void v27();virtual void v28();virtual void v29();virtual void v30(); virtual void M(); };
 struct Other { char p[0xc]; unsigned short id; };
-extern "C" void func_ov002_020bb23c(Base* c, Other* o){
+extern "C" void SignPost_OnAttacked1(Base* c, Other* o){
   int b=(o->id==0xce); if(b) c->M();
 }

--- a/src/func_ov002_020bb27c.c
+++ b/src/func_ov002_020bb27c.c
@@ -1,3 +1,7 @@
+// @symbol func_ov002_020bb27c
+// @emits SignPost_OnGroundPounded
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjTatefuda_c::OnGroundPounded - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Vector3 { int x, y, z; };
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* v);
@@ -7,9 +11,9 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 /* The ROM materializes `self + off` into a scratch register instead of folding the
    offset into the ldr/str. The 64-bit identity mask launders the address so mwccarm
    emits `add rN, self, #off` + `ldr/str [rN]`. */
-#define LD(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LD(p) ((int)(((long long)(int)(p))))
 
-void func_ov002_020bb27c(char* self, char* arg){
+void SignPost_OnGroundPounded(char* self, char* arg){
   if (*(u8*)(self+0x58e) == 0) return;
   if (*(u8*)(self+0x58f) != 0) return;
   _ZN5Sound9PlayBank3EjRK7Vector3(0x62, (struct Vector3*)(self+0x74));

--- a/src/func_ov002_020bb374.cpp
+++ b/src/func_ov002_020bb374.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol func_ov002_020bb374
+// @emits SignPost_OnHitByMegaChar
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Platform.h"
+/* recovered: renamed to Class_Method */
+/* daObjTatefuda_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void func_02012694(int a, void* b);
-extern void _ZN8Platform14KillByMegaCharER6Player(void* self, void* p);
-void func_ov002_020bb374(char* self, void* p){
+void SignPost_OnHitByMegaChar(char* self, void* p){
   _ZN6Player16IncMegaKillCountEv(p);
   func_02012694(0x1d, self+0x74);
   _ZN8Platform14KillByMegaCharER6Player(self, p);

--- a/src/func_ov002_020bb3b8.cpp
+++ b/src/func_ov002_020bb3b8.cpp
@@ -1,5 +1,9 @@
 //cpp
-// func_ov002_020bb3b8 at 0x020bb3b8
+// @symbol func_ov002_020bb3b8
+// @emits SignPost_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjTatefuda_c::Kill - recovered from vtable slot identity */
+// SignPost_Kill at 0x020bb3b8
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 struct Vector3 { int x, y, z; };
 
@@ -10,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 int func_ov002_020bae9c(void* self);
 }
 
-extern "C" int func_ov002_020bb3b8(char* self);
-int func_ov002_020bb3b8(char* self) {
+extern "C" int SignPost_Kill(char* self);
+int SignPost_Kill(char* self) {
     Vector3 vec;
     Vector3 vec2;
     int x = *(int*)(self + 0x5c);

--- a/src/func_ov002_020bb42c.c
+++ b/src/func_ov002_020bb42c.c
@@ -1,12 +1,15 @@
+// @symbol func_ov002_020bb42c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player7TryGrabER5Actor(char* p, char* a);
-extern void func_ov002_020bbd5c(char* c, int i);
 
 void func_ov002_020bb42c(char* self){
   char* other;

--- a/src/func_ov002_020bb520.c
+++ b/src/func_ov002_020bb520.c
@@ -1,13 +1,16 @@
+// @symbol func_ov002_020bb520
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 enum { false, true };
-struct Vector3 { int x, y, z; };
+
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player9StartTalkER9ActorBaseb(char* p, char* a, int b);
-extern void func_ov002_020bbd5c(char* c, int i);
 
 int func_ov002_020bb520(char* self){
   unsigned int id = *(unsigned int*)(self+0x344);

--- a/src/func_ov002_020bbb14.cpp
+++ b/src/func_ov002_020bbb14.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol func_ov002_020bbb14
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 
-struct V3 { int x, y, z; };
+
 
 extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
@@ -35,12 +38,12 @@ extern "C" void func_ov002_020bbb14(char* self);
 void func_ov002_020bbb14(char* self)
 {
     int b;
-    struct V3 vec;
+    struct Vector3 vec;
     void* found;
     unsigned id;
 
     {
-        s16* pa = (s16*)((long long)(int)(self + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+        s16* pa = (s16*)((long long)(int)(self + 0x8c));
         *pa = *pa + 0x2000;
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(self, 0);

--- a/src/func_ov002_020bc414.c
+++ b/src/func_ov002_020bc414.c
@@ -1,9 +1,13 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov002_020bc414
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjWakame_c */
 int *func_ov002_020bc414(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daObjWakame_c;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020bc444.c
+++ b/src/func_ov002_020bc444.c
@@ -1,9 +1,13 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov002_020bc444
+// @emits daObjWakame_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWakame_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020bc444(int *t)
+int *daObjWakame_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bc4c8.c
+++ b/src/func_ov002_020bc4c8.c
@@ -1,7 +1,12 @@
+// @symbol func_ov002_020bc4c8
+// @emits daObjWakame_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWakame_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov002_020bc4c8(void)
+int daObjWakame_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     _ZN13SharedFilePtr7ReleaseEv(G1);

--- a/src/func_ov002_020bc4f8.cpp
+++ b/src/func_ov002_020bc4f8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov002_020bc4f8
+// @emits daObjWakame_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjWakame_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov002_020bc4f8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjWakame_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov002_020bc520.c
+++ b/src/func_ov002_020bc520.c
@@ -1,5 +1,9 @@
+// @symbol func_ov002_020bc520
+// @emits daObjWakame_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjWakame_c::Behavior - recovered from vtable slot identity */
 extern void _ZN9Animation7AdvanceEv(void *);
-int func_ov002_020bc520(void *t)
+int daObjWakame_c_Behavior(void *t)
 {
     _ZN9Animation7AdvanceEv((char *)t + 0x124);
     return 1;

--- a/src/func_ov002_020bc540.cpp
+++ b/src/func_ov002_020bc540.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol func_ov002_020bc540
+// @emits daObjWakame_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWakame_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char*, void*, int, int);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char*, void*, int, int, unsigned int);
-extern void func_ov002_020bc488(char*);
-extern int data_ov002_0210e0dc[];
-extern int data_ov002_0210e0d4[];
-int func_ov002_020bc540(char* c){
+int daObjWakame_c_InitResources(char* c){
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e0dc);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
   void* a = _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_0210e0d4);

--- a/src/func_ov002_020bd06c.c
+++ b/src/func_ov002_020bd06c.c
@@ -1,11 +1,14 @@
+// @symbol func_ov002_020bd06c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef short s16;
 typedef signed char s8;
 
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 typedef struct ActorBase ActorBase;
 
 extern void _ZN9ActorBase18MarkForDestructionEv(void *thiz);

--- a/src/func_ov002_020bd250.cpp
+++ b/src/func_ov002_020bd250.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020bd250
+/* recovered: shared common types */
+#include "common.h"
+
 struct Player {
     void Hurt(const Vector3&, unsigned int, int, unsigned int, unsigned int, unsigned int);
 };

--- a/src/func_ov002_020bd45c.cpp
+++ b/src/func_ov002_020bd45c.cpp
@@ -1,6 +1,10 @@
 //cpp
-struct Vector3{int x,y,z;};
-extern "C" unsigned int ReadUnalignedInt(unsigned char *p);
+// @symbol func_ov002_020bd45c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 namespace Sound{ void PlayBank0(unsigned int, const Vector3 &); }
 extern "C" int func_ov002_020bd45c(unsigned char *c, unsigned char *p){
     unsigned int v=ReadUnalignedInt(p);

--- a/src/func_ov002_020bd480.cpp
+++ b/src/func_ov002_020bd480.cpp
@@ -1,6 +1,10 @@
 //cpp
-struct Vector3{int x,y,z;};
-extern "C" unsigned int ReadUnalignedInt(unsigned char *p);
+// @symbol func_ov002_020bd480
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 namespace Sound{ void PlayCharVoice(unsigned int, unsigned int, const Vector3 &); }
 extern "C" int func_ov002_020bd480(unsigned char *c, unsigned char *p){
     unsigned int v=ReadUnalignedInt(p);

--- a/src/func_ov002_020be3b0.c
+++ b/src/func_ov002_020be3b0.c
@@ -1,36 +1,31 @@
+// @symbol func_ov002_020be3b0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_ModelAnim2.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern u32 _ZNK6Player14GetBodyModelIDEjb(char* c, u32 a, char b);
 extern void _ZN5Model14SetPolygonModeEi(void* self, int mode);
 extern int func_ov002_020becf4(char* self, int v, int arg2);
-extern int __aeabi_idiv(int a, int b);
-extern int __aeabi_idivmod(int a, int b);
 extern void func_ov002_020e6b74(char* c, int* src);
-extern void func_ov002_020e6b3c(void* model);
 extern void func_ov002_020d80d0(char* c);
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
-extern void _ZN10ModelAnim24CopyERKS_Pcj(void* self, void* src, char* p, u32 n);
-extern void _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(void* self, u32 a, int b, int c, unsigned short d);
 extern void _ZN13SharedFilePtr7ReleaseEv(void* self);
 extern int _ZN6Player7IsStateERNS_5StateE(char* self, void* s);
 extern unsigned int _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, const struct Vector3* v);
-extern void _ZN6Player18TurnOffToonShadingEj(char* c, u32 j);
-extern void func_ov002_020e69c0(void* unused);
-extern void func_ov002_020e6a78(char* c, int b);
-extern void func_ov002_020bdb50(char* c, int arg);
 
-extern u8 data_ov002_020ff14c[];
 extern void* data_ov002_020ff480[];
-extern void* data_ov002_020ff790[];
 extern u8 data_02092128[];
 extern int data_ov002_021104b4;
-extern char data_ov002_02110804[];
 
 void func_ov002_020be3b0(char* c)
 {
@@ -62,17 +57,17 @@ void func_ov002_020be3b0(char* c)
         }
         *(u16*)(c + 0x740) = 0;
         *(u16*)(c + 0x73e) = data_ov002_020ff14c[var_r4];
-        *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+        *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
         *(u32*)(c + 8) = *(u8*)(c + 0x6dc);
         break;
     }
     case 2:
-        *(u16*)(((long long)(int)(c + 0x740)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x740)) & 0xFFFFFFFFFFFFFFFFLL) + 0x199);
+        *(u16*)(((long long)(int)(c + 0x740))) = (u16)(*(u16*)(((long long)(int)(c + 0x740))) + 0x199);
         if ((u32)*(u16*)(c + 0x740) >= 0x1000) {
             *(u16*)(c + 0x740) = 0x1000;
         }
         if (*(u16*)(c + 0x73e) == 0) {
-            *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+            *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
             *(u16*)(c + 0x73e) = data_ov002_020ff14c[var_r4 + 1];
         }
         *(u32*)(c + 8) = *(u8*)(c + 0x6dc);
@@ -94,7 +89,7 @@ void func_ov002_020be3b0(char* c)
             void* t2;
             func_ov002_020e6b3c(case3_m1);
             func_ov002_020e6b3c(case3_m2);
-            *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+            *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
             *(u16*)(c + 0x73e) = data_ov002_020ff14c[var_r4 + 2];
             t1 = *(void**)(c + (_ZNK6Player14GetBodyModelIDEjb(c, *(u8*)(c + 0x6dd), 0) * 4) + 0xdc);
             _ZN5Model14SetPolygonModeEi(t1, 2);
@@ -118,7 +113,7 @@ void func_ov002_020be3b0(char* c)
                     *(char**)((char*)data_ov002_020ff480[*(u32*)(c + 0x63c) + *(u8*)(c + 0x6dd)] + 4),
                     0);
             }
-            *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) = (u8)(*(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) | 0x40);
+            *(u8*)(((long long)(int)(c + 0x718))) = (u8)(*(u8*)(((long long)(int)(c + 0x718))) | 0x40);
         }
         *(u32*)(c + 8) = *(u8*)(c + 0x6dc);
         break;
@@ -133,7 +128,7 @@ void func_ov002_020be3b0(char* c)
         }
         if (*(u16*)(c + 0x73e) == 0) {
             u32 mm;
-            *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+            *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
             *(u16*)(c + 0x73e) = data_ov002_020ff14c[var_r4 + 3];
             *(u32*)(c + 8) = *(u8*)(c + 0x6dd);
             data_02092128[*(u8*)(c + 0x6d8)] = (u8)(*(u32*)(c + 8));
@@ -160,7 +155,7 @@ void func_ov002_020be3b0(char* c)
                 *(u32*)((char*)data_ov002_020ff790[mm] + 4),
                 0, 0x1000, 0);
             _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff480[*(u32*)(c + 0x63c) + *(u8*)(c + 0x6dc)]);
-            *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) = (u8)(*(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) & ~0x40);
+            *(u8*)(((long long)(int)(c + 0x718))) = (u8)(*(u8*)(((long long)(int)(c + 0x718))) & ~0x40);
             func_ov002_020bdb50(c, 0);
         } else {
             u8 a, b;
@@ -182,7 +177,7 @@ void func_ov002_020be3b0(char* c)
         break;
     case 5:
         if (*(u16*)(c + 0x73e) == 0) {
-            *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+            *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
             *(u16*)(c + 0x73e) = data_ov002_020ff14c[var_r4 + 4];
             if (*(u8*)(c + 0x6dd) != *(u8*)(c + 0x6d9) &&
                 _ZN6Player7IsStateERNS_5StateE(c, &data_ov002_021104b4) == 0) {
@@ -192,12 +187,12 @@ void func_ov002_020be3b0(char* c)
         break;
     case 6: {
         int divv = data_ov002_020ff14c[var_r4 + 4];
-        *(u16*)(((long long)(int)(c + 0x740)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x740)) & 0xFFFFFFFFFFFFFFFFLL) - __aeabi_idiv(0x1000, divv));
+        *(u16*)(((long long)(int)(c + 0x740))) = (u16)(*(u16*)(((long long)(int)(c + 0x740))) - __aeabi_idiv(0x1000, divv));
         if (*(s16*)(c + 0x740) < 0) {
             *(u16*)(c + 0x740) = 0;
         }
         if (*(u16*)(c + 0x73e) == 0) {
-            *(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73c)) & 0xFFFFFFFFFFFFFFFFLL) + 1);
+            *(u16*)(((long long)(int)(c + 0x73c))) = (u16)(*(u16*)(((long long)(int)(c + 0x73c))) + 1);
         }
         break;
     }
@@ -209,7 +204,7 @@ void func_ov002_020be3b0(char* c)
     }
 
     if (*(u16*)(c + 0x73e) != 0) {
-        *(u16*)(((long long)(int)(c + 0x73e)) & 0xFFFFFFFFFFFFFFFFLL) = (u16)(*(u16*)(((long long)(int)(c + 0x73e)) & 0xFFFFFFFFFFFFFFFFLL) - 1);
+        *(u16*)(((long long)(int)(c + 0x73e))) = (u16)(*(u16*)(((long long)(int)(c + 0x73e))) - 1);
     }
     {
         char* dummy = data_ov002_02110804;

--- a/src/func_ov002_020bf40c.c
+++ b/src/func_ov002_020bf40c.c
@@ -1,20 +1,22 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov002_020bf40c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct RaycastGround { char pad[0x50]; };
 extern unsigned char NumStars(void);
-extern void AddVec3(struct Vec3* a, struct Vec3* b, struct Vec3* c);
-extern void func_0200d858(void* self, const struct Vec3* offset);
+extern void AddVec3(struct Vector3* a, struct Vector3* b, struct Vector3* c);
 extern void _ZN13RaycastGroundC1Ev(struct RaycastGround* r);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround* r, struct Vec3* p, char* a);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround* r, struct Vector3* p, char* a);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround* r);
 extern void _ZN13RaycastGroundD1Ev(struct RaycastGround* r);
-extern struct Vec3 data_ov002_0210a590;
 extern void* data_0209f318;
 int func_ov002_020bf40c(char* c){
-  struct Vec3 pos;
-  struct Vec3 off;
+  struct Vector3 pos;
+  struct Vector3 off;
   struct RaycastGround rg;
   if(NumStars() < 0x50 || *(int*)(c+8) != 0){
-    AddVec3((struct Vec3*)(c+0x5c), &data_ov002_0210a590, (struct Vec3*)(c+0x5c));
+    AddVec3((struct Vector3*)(c+0x5c), &data_ov002_0210a590, (struct Vector3*)(c+0x5c));
     off.x = data_ov002_0210a590.x;
     off.y = data_ov002_0210a590.y;
     off.z = data_ov002_0210a590.z;

--- a/src/func_ov002_020bf9d4.cpp
+++ b/src/func_ov002_020bf9d4.cpp
@@ -1,14 +1,18 @@
 //cpp
+// @symbol func_ov002_020bf9d4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 // func_ov002_020bf9d4 at 0x020bf9d4
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
-struct VecFx32 { int x, y, z; };
+
 extern "C" {
 int func_0200fccc(char* s, int r1);
 void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
-extern int data_0208e430;
 }
 extern "C" void func_ov002_020bf9d4(char* c){
-  VecFx32 v;
+  Vector3 v;
   if (data_0208e430 == 0x2e) return;
   if (*(unsigned char*)(c + 0x703) == 0){
     func_0200fccc(c, 0);

--- a/src/func_ov002_020c16ec.c
+++ b/src/func_ov002_020c16ec.c
@@ -1,5 +1,10 @@
+// @symbol func_ov002_020c16ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct SurfaceInfo { char dummy; };
-struct Vector3 { int x, y, z; };
+
 
 struct Obj {
     char pad554[0x554];
@@ -15,11 +20,7 @@ struct Obj {
     int f670;   // 0x670
 };
 
-extern int func_02037e90(int *p);
 extern int func_02037e38(unsigned int *p);
-extern int func_02037e48(unsigned int *p);
-extern int func_02037e68(unsigned int *p);
-extern int func_02037e84(int *p);
 extern int func_02037e58(unsigned int *p);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(struct SurfaceInfo *s, struct Vector3 *out);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);

--- a/src/func_ov002_020c179c.cpp
+++ b/src/func_ov002_020c179c.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov002_020c179c
+/* recovered: shared common types */
+#include "common.h"
 // func_ov002_020c179c at 0x020c179c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
-struct Vector3 { int x, y, z; };
+
 extern "C" {
 extern void _ZN13RaycastGroundC1Ev(void* self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* self, void* pos, void* act);

--- a/src/func_ov002_020c2270.cpp
+++ b/src/func_ov002_020c2270.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020c2270
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);

--- a/src/func_ov002_020c231c.c
+++ b/src/func_ov002_020c231c.c
@@ -1,20 +1,22 @@
+// @symbol func_ov002_020c231c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
 
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void func_ov002_020c14b8(void *self);
+
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);
 extern int _ZN6Player6IsAnimEj(void *self, u32 id);
-extern int func_ov002_020c2270(void *self, struct Vec3 *a, struct Vec3 *b);
 
 extern char data_ov002_0211013c;
-extern char data_ov002_02110184;
 extern char data_ov002_02110304;
 extern char data_ov002_02110364;
 extern char data_ov002_021104e4;
@@ -24,8 +26,8 @@ extern s16 data_02082214[];
 
 int func_ov002_020c231c(char *self)
 {
-    struct Vec3 tmp;
-    struct Vec3 pos;
+    struct Vector3 tmp;
+    struct Vector3 pos;
     u8 f70f;
     s32 p60;
     s32 d;
@@ -40,11 +42,11 @@ int func_ov002_020c231c(char *self)
         if (f70f == 0)
             return 0;
 
-        SubVec3((struct Vec3 *)(self + 0x5c), (struct Vec3 *)(self + 0x548), &tmp);
+        SubVec3((struct Vector3 *)(self + 0x5c), (struct Vector3 *)(self + 0x548), &tmp);
         tmp.x >>= 1;
         tmp.y >>= 1;
         tmp.z >>= 1;
-        AddVec3((struct Vec3 *)(self + 0x548), &tmp, (struct Vec3 *)(self + 0x5c));
+        AddVec3((struct Vector3 *)(self + 0x548), &tmp, (struct Vector3 *)(self + 0x5c));
         func_ov002_020c14b8(self);
 
         if (*(s32 *)(self + 0x644) == (s32)0x80000000)
@@ -81,7 +83,7 @@ int func_ov002_020c231c(char *self)
                 pos.x = xx;
                 pos.y = p60;
                 pos.z = zz;
-                if (func_ov002_020c2270(self, (struct Vec3 *)(self + 0x5c), &pos))
+                if (func_ov002_020c2270(self, (struct Vector3 *)(self + 0x5c), &pos))
                     return 1;
             }
         }

--- a/src/func_ov002_020c37a4.cpp
+++ b/src/func_ov002_020c37a4.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov002_020c37a4
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
+
 extern unsigned int _ZNK6Player14GetBodyModelIDEjb(char* c, unsigned int a, int b);
-extern void MulVec3Mat4x3(void* a, void* b, struct Vec3* out);
-extern void Vec3_MulScalar(struct Vec3* out, struct Vec3* in, int s);
-extern void Vec3_RotateYAndTranslate(struct Vec3* out, struct Vec3* in, int ang, char* arg);
+extern void MulVec3Mat4x3(void* a, void* b, struct Vector3* out);
+extern void Vec3_MulScalar(struct Vector3* out, struct Vector3* in, int s);
+extern void Vec3_RotateYAndTranslate(struct Vector3* out, struct Vector3* in, int ang, char* arg);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
   unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
 
@@ -12,8 +15,8 @@ void func_ov002_020c37a4(char* self, char* arg){
   unsigned int id = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self+8) & 0xff, 0);
   int r6 = *(int*)(*(int*)(self + (id << 2) + 0xdc) + 0x14) + 0x180;
   unsigned int id2 = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self+8) & 0xff, 0);
-  struct Vec3 v;
-  struct Vec3 s;
+  struct Vector3 v;
+  struct Vector3 s;
   MulVec3Mat4x3((void*)(r6 + 0x24), (void*)(*(int*)(self + (id2 << 2) + 0xdc) + 0x1c), &v);
   Vec3_MulScalar(&s, &v, 0x8000);
   v = s;

--- a/src/func_ov002_020c38a0.c
+++ b/src/func_ov002_020c38a0.c
@@ -1,21 +1,22 @@
-struct Vec3 { int x, y, z; };
-extern void func_ov002_020c37a4(void *c, struct Vec3 *v);
+// @symbol func_ov002_020c38a0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, int cc, unsigned int d);
-extern void func_ov002_020c3148(void *c);
-extern int func_ov002_020c2fec(void *c, struct Vec3 *out);
-extern int Vec3_HorzLen(struct Vec3 *v);
+extern int Vec3_HorzLen(struct Vector3 *v);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 extern void _Z15ApproachLinear2Rsss(short *r, short a, short b);
 
-#define LA(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int)(((long long)(int)(p))))
 
 void func_ov002_020c38a0(char *c)
 {
     struct {
-        struct Vec3 a;
-        struct Vec3 d;
-        struct Vec3 e;
-        struct Vec3 b;
+        struct Vector3 a;
+        struct Vector3 d;
+        struct Vector3 e;
+        struct Vector3 b;
     } s;
     int hlen;
     int ang;

--- a/src/func_ov002_020c44c4.c
+++ b/src/func_ov002_020c44c4.c
@@ -1,3 +1,9 @@
+// @symbol func_ov002_020c44c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_SaveData.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned short u16;
@@ -5,24 +11,17 @@ typedef short s16;
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vector3 { Fix12i x, y, z; };
+
 
 extern u8 data_0209f2d8;
 extern int data_0209caa0[];
 extern s8 data_0209f2f8;
 extern u8 data_0209f264;
-extern u32 data_ov002_0210e14c;
-extern struct Vector3 data_ov002_0210f3b0;
-extern void* data_ov002_0210f350;
 extern void func_020072c0(void);
 
-extern int SublevelToLevel(int i);
-extern unsigned int _ZN8SaveData26CountStarsCollectedInLevelEj(unsigned int level);
 extern void func_020731dc(int a, int b, void** node);
 extern void Vec3_RotateYAndTranslate(int* out, int* in, short angle, int* src);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* player, void* actor, unsigned int id, const void* pos, unsigned int a, unsigned int b);
-extern void func_ov100_02145070(int v);
-extern int func_ov100_02145014(void);
 extern void func_02012694(unsigned int id, const struct Vector3* v);
 extern unsigned int func_02012790(unsigned int a);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, unsigned int a, int b, int fix, unsigned int d);

--- a/src/func_ov002_020c47f4.cpp
+++ b/src/func_ov002_020c47f4.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020c47f4
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 extern "C" {
 short Vec3_VertAngle(const Vector3* v1, const Vector3* v0);
 int _Z15ApproachLinear2Rsss(short& dst, short to, short step);

--- a/src/func_ov002_020c5444.cpp
+++ b/src/func_ov002_020c5444.cpp
@@ -1,10 +1,13 @@
 //cpp
-struct VecFx32 { int x, y, z; };
+// @symbol func_ov002_020c5444
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
 }
 extern "C" void func_ov002_020c5444(char* c){
-  VecFx32 v;
+  Vector3 v;
   ((int*)&v)[0] = *(int*)(c + 0x5c);
   ((int*)&v)[1] = *(int*)(c + 0x60);
   ((int*)&v)[2] = *(int*)(c + 0x64);

--- a/src/func_ov002_020c647c.cpp
+++ b/src/func_ov002_020c647c.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol func_ov002_020c647c
+/* recovered: shared common types */
+#include "common.h"
 // func_ov002_020c647c at 0x020c647c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);

--- a/src/func_ov002_020c72a4.cpp
+++ b/src/func_ov002_020c72a4.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020c72a4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 struct RaycastGround {
     char pad0[0x14];
@@ -12,8 +17,6 @@ struct RaycastGround {
 };
 extern "C" void _ZN4BgCh19StartDetectingWaterEv(RaycastGround*);
 extern "C" int func_02037e78(int* p);
-extern "C" void func_ov002_020c71e0(void*);
-extern int data_0209212c;
 extern int data_0209f32c;
 
 extern "C" void func_ov002_020c72a4(void* thisptr)

--- a/src/func_ov002_020c8a4c.cpp
+++ b/src/func_ov002_020c8a4c.cpp
@@ -1,14 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020c8a4c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Player { unsigned int SetAnim(unsigned int, int, int, unsigned int); };
 extern "C" short Vec3_HorzAngle(const Vector3*, const Vector3*);
-extern "C" int func_02053274(const Vector3*, const Vector3*);
 extern "C" void func_020731dc(void*, void*, void*);
 extern "C" void Vec3_RotateYAndTranslate(Vector3*, const Vector3*, int, const Vector3*);
-extern "C" void func_ov002_020ca108(char* c);
-extern int data_ov002_0210e150;
-extern int data_ov002_0210f8cc[3];
-extern int data_ov002_0210f89c;
 extern void func_020072c0(void);
 
 extern "C" int func_ov002_020c8a4c(char* self);

--- a/src/func_ov002_020c8b78.cpp
+++ b/src/func_ov002_020c8b78.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov002_020c8b78
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 
-struct Vector3 { int x, y, z; };
+
 struct ActorBase {};
 struct Animation { char pad[0x50]; int WillHitFrame(int) const; };
 

--- a/src/func_ov002_020c8d14.c
+++ b/src/func_ov002_020c8d14.c
@@ -1,9 +1,13 @@
+// @symbol func_ov002_020c8d14
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 
-struct V3 { int x, y, z; };
+
 
 extern int _ZNK6Player14GetBodyModelIDEjb(void *thiz, unsigned int a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void *thiz, int f);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void func_ov002_020c9e18(char *self);
 extern int func_ov002_020d22ec(char *self, int arg);
@@ -14,7 +18,7 @@ extern int data_ov002_0211013c;
 
 int func_ov002_020c8d14(char *self)
 {
-    struct V3 v;
+    struct Vector3 v;
     int val;
     int id;
     char *anim;

--- a/src/func_ov002_020c8f80.cpp
+++ b/src/func_ov002_020c8f80.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020c8f80
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 struct Animation { int WillHitFrame(int) const; };
 namespace Sound { void PlayBank0(unsigned int, const Vector3 &); }
 struct Player {
@@ -12,9 +15,9 @@ extern "C" int func_ov002_020c8f80(Player *thiz)
 {
     char *p = (char *)thiz;
 
-    *(int *)(((long long)(int)(p + 0x80)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80;
-    *(int *)(((long long)(int)(p + 0x84)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80;
-    *(int *)(((long long)(int)(p + 0x88)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80;
+    *(int *)(((long long)(int)(p + 0x80))) -= 0x80;
+    *(int *)(((long long)(int)(p + 0x84))) -= 0x80;
+    *(int *)(((long long)(int)(p + 0x88))) -= 0x80;
 
     unsigned int id = thiz->GetBodyModelID(*(int *)(p + 8) & 0xff, false);
     Animation *anim = (Animation *)(*(char **)(p + id * 4 + 0xdc) + 0x50);

--- a/src/func_ov002_020c9998.c
+++ b/src/func_ov002_020c9998.c
@@ -1,6 +1,9 @@
+// @symbol func_ov002_020c9998
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+
+
 extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*, unsigned int, int, Fix12i, unsigned int);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, const struct Vector3*, const struct Vector3_16*, int, int);
 void func_ov002_020c9998(void* c) {

--- a/src/func_ov002_020c9a04.c
+++ b/src/func_ov002_020c9a04.c
@@ -1,10 +1,12 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov002_020c9a04
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, unsigned int a, int b, int f, unsigned int g);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 
 void func_ov002_020c9a04(char *c)
 {
-    struct V3 v;
+    struct Vector3 v;
 
     *(unsigned char *)(c + 0x6e3) = 0x11;
     _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x9a, 0x40000000, 0x1000, 0);

--- a/src/func_ov002_020cb354.cpp
+++ b/src/func_ov002_020cb354.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020cb354
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" int _ZN6Player6IsAnimEj(void*, unsigned int);
 extern "C" int _ZNK6Player14GetBodyModelIDEjb(void*, unsigned int, bool);
 extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, const Vector3&);
@@ -11,7 +14,7 @@ extern "C" int func_ov002_020cb354(void* thisptr)
     if (a == 0) return a;
     int idx = _ZNK6Player14GetBodyModelIDEjb(thisptr, *(unsigned int*)(p + 8) & 0xff, 0);
     int* m = *(int**)(p + (idx << 2) + 0xdc);
-    int* q = (int*)(((int)m + 0x50) & 0xFFFFFFFFFFFFFFFF);
+    int* q = (int*)(((int)m + 0x50));
     if ((int)((unsigned int)((q[2]) << 4) >> 0x10) < 8) {
         unsigned char f = *(unsigned char*)(p + 0x70c);
         if (f != 0) return f;

--- a/src/func_ov002_020ce5f8.c
+++ b/src/func_ov002_020ce5f8.c
@@ -1,8 +1,11 @@
+// @symbol func_ov002_020ce5f8
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-struct Vector3 { int x, y, z; };
+
 
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* st);
 extern int func_ov002_020ceb54(char* c);
@@ -41,7 +44,7 @@ int func_ov002_020ce5f8(char* c) {
 
     if (func_ov002_020ceb54(c) == 0) {
         if (*(u8*)(c + 0x70c) == 0) {
-            *(u8*)((((long long)(int)(c + 0x70c))) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(u8*)((((long long)(int)(c + 0x70c)))) |= 1;
             _ZN5Sound9PlayBank0EjRK7Vector3(0x17, (struct Vector3*)(c + 0x74));
             *(int*)(c + 0x628) = 0;
         }

--- a/src/func_ov002_020cec2c.c
+++ b/src/func_ov002_020cec2c.c
@@ -1,3 +1,8 @@
+// @symbol func_ov002_020cec2c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov002_020cec2c at 0x020cec2c (ov002), size 0x184
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
@@ -6,9 +11,8 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef signed char s8;
 
-struct Vector3 { int x, y, z; };
 
-extern int func_ov002_020ceb54(char *p);
+
 extern void _ZN6Player4HealEi(char *self, int a);
 extern int _ZN6Player9GetHealthEv(char *self);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vector3 *v, unsigned int d);
@@ -51,7 +55,7 @@ int func_ov002_020cec2c(char *self)
     }
 
     {
-        u16 *p = (u16 *)(((long long)(int)(self + 0x6ca)) & 0xFFFFFFFFFFFFFFFFLL);
+        u16 *p = (u16 *)(((long long)(int)(self + 0x6ca)));
         *p = *p + 1;
     }
 

--- a/src/func_ov002_020cede0.cpp
+++ b/src/func_ov002_020cede0.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020cede0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN13RaycastGroundC1Ev(void* self);
 extern void _ZN4BgCh19StartDetectingWaterEv(void* self);
@@ -9,7 +14,6 @@ extern int _ZN13RaycastGround10DetectClsnEv(void* self);
 extern int func_02037e78(int* p);
 extern void _ZN13RaycastGroundD1Ev(void* self);
 extern int data_0209f32c;
-extern int data_0209212c;
 extern signed char data_0209f2f8;
 }
 

--- a/src/func_ov002_020cf20c.cpp
+++ b/src/func_ov002_020cf20c.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol func_ov002_020cf20c
+/* recovered: shared common types */
+#include "common.h"
 // func_ov002_020cf20c at 0x020cf20c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);

--- a/src/func_ov002_020cfbdc.cpp
+++ b/src/func_ov002_020cfbdc.cpp
@@ -1,12 +1,16 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020cfbdc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_ClsnResult.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
-extern int _ZNK10ClsnResult9GetClsnIDEv(void *self);
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov002_020d0948(void *self);
 extern void _ZN11RaycastLineC1Ev(void *self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void *self, void *a, void *b, void *act);
 extern int _ZN11RaycastLine10DetectClsnEv(void *self);

--- a/src/func_ov002_020d2e74.cpp
+++ b/src/func_ov002_020d2e74.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov002_020d2e74
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef short s16;
 
-struct Vector3 { int x, y, z; };
+
 
 struct Player {
     char pad8[8];

--- a/src/func_ov002_020d4c30.cpp
+++ b/src/func_ov002_020d4c30.cpp
@@ -1,12 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020d4c30
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 typedef int Fix12i;
 
-extern "C" unsigned int func_02022d00(unsigned int uniqueID, unsigned int effectID,
-                                      Fix12i x, Fix12i y, Fix12i z, void *dir);
 extern "C" void func_0201251c(int a, int b, int c, int d);
 extern int data_0209f32c;
-extern int data_0208e430;
 
 struct Sound {
     static void PlayBank0(unsigned int id, const Vector3 &v);

--- a/src/func_ov002_020d6368.c
+++ b/src/func_ov002_020d6368.c
@@ -1,9 +1,13 @@
+// @symbol func_ov002_020d6368
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef long long s64;
 typedef struct { int x, y, z; } Vec3;
-struct Vector3_16 { short x, y, z; };
+
 
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, Vec3 *pos, void *rot, int e, int f);
-extern int func_ov002_020d6334(void *self, int val);
 extern short data_02082214[];
 
 #pragma opt_strength_reduction off

--- a/src/func_ov002_020d6c60.cpp
+++ b/src/func_ov002_020d6c60.cpp
@@ -1,16 +1,19 @@
 //cpp
-extern "C" int func_ov002_020d82f0(void* c);
+// @symbol func_ov002_020d6c60
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
 extern "C" void func_ov002_020d7030(void* c, void* d);
 extern "C" void _ZN6Player18SetNewHatCharacterEjjb(void* self, unsigned int j1, unsigned int j2, int b);
 extern "C" void func_ov002_020c9e40(void* c);
-extern "C" int func_ov002_020d5f34(char* c, void* st);
 extern "C" void func_ov002_020d71ec(void* c, int x);
 
-struct V3 { int x, y, z; };
+
 
 extern "C" int func_ov002_020d6c60(char* p0, char* p1){
-  V3 v;
+  Vector3 v;
   int b;
   int y;
   int* q;

--- a/src/func_ov002_020d7430.cpp
+++ b/src/func_ov002_020d7430.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov002_020d7430
+/* recovered: shared common types */
+#include "common.h"
+
 struct Obj {
   virtual int v0(); virtual int v1(); virtual int v2(); virtual int v3();
   virtual int v4(); virtual int v5(); virtual int v6(); virtual int v7();
@@ -8,7 +11,7 @@ struct Obj {
   virtual int v16(); virtual int v17(); virtual int v18(); virtual int v19(char* c);
 };
 extern "C" {
-extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char* c, Vec3* v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char* c, Vector3* v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
 extern void func_ov002_020c9e18(char* c);
 extern int _ZN6Player7IsStateERNS_5StateE(char* c, void* s);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* s);
@@ -19,7 +22,7 @@ extern char data_ov002_0211013c;
 void func_ov002_020d7430(char* c){
   Obj* o = *(Obj**)(c+0x360);
   if(o->v18() == 2){
-    Vec3 v;
+    Vector3 v;
     v.x = *(int*)(c+0x5c);
     v.y = *(int*)(c+0x60);
     v.z = *(int*)(c+0x64);

--- a/src/func_ov002_020d8854.cpp
+++ b/src/func_ov002_020d8854.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov002_020d8854
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
+
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern void Vec3_RotateYAndTranslate(struct Vec3* out, struct Vec3* in, int ang, struct Vec3* tr);
+extern void Vec3_RotateYAndTranslate(struct Vector3* out, struct Vector3* in, int ang, struct Vector3* tr);
 extern int func_ov002_020d8944(char* a, char* b, char* other);
-extern void func_ov002_020d8d10(char* self, struct Vec3* v);
+extern void func_ov002_020d8d10(char* self, struct Vector3* v);
 
 void func_ov002_020d8854(char* self){
   char* other = (char*)_ZN5Actor10FindWithIDEj(*(unsigned int*)(self+0x338));
@@ -22,13 +25,13 @@ void func_ov002_020d8854(char* self){
     }
   }
   {
-    struct Vec3 out;
-    struct Vec3 tr;
-    struct Vec3 cp;
+    struct Vector3 out;
+    struct Vector3 tr;
+    struct Vector3 cp;
     tr.x = 0;
     tr.y = 0x50000;
     tr.z = 0x64000;
-    Vec3_RotateYAndTranslate(&out, (struct Vec3*)(self+0x5c), *(short*)(self+0x8e), &tr);
+    Vec3_RotateYAndTranslate(&out, (struct Vector3*)(self+0x5c), *(short*)(self+0x8e), &tr);
     cp = out;
     func_ov002_020d8d10(self, &cp);
   }

--- a/src/func_ov002_020d8a50.c
+++ b/src/func_ov002_020d8a50.c
@@ -1,32 +1,29 @@
+// @symbol func_ov002_020d8a50
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 struct RaycastLine { int head[5]; int surf; int rest[25]; };
 
 extern int _ZNK6Player14GetBodyModelIDEjb(char* p, unsigned int j, int b);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void func_ov002_020dbf4c(char* c);
-extern void func_ov002_020dbe70(char* c);
-extern void func_ov002_020dbd94(char* c);
-extern void func_ov002_020dbbc0(char* c);
-extern void func_ov002_020d8854(char* self);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
-extern int _ZNK9Animation12WillHitFrameEi(void* a, int frame);
-extern void func_ov002_020ef070(void* a, char* self);
-extern void func_ov002_020eeeb8(void* a, char* self);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, struct Vector3* v);
 extern void _ZN11RaycastLineC1Ev(struct RaycastLine* r);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(struct RaycastLine* r, struct Vector3* a, struct Vector3* b, void* actor);
 extern int _ZN11RaycastLine10DetectClsnEv(struct RaycastLine* r);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* s, struct Vector3* n);
 extern void _ZN11RaycastLine10GetClsnPosEv(struct Vector3* ret, struct RaycastLine* r);
-extern void func_ov002_020d8d10(char* self, struct Vector3* pos);
 extern void _ZN11RaycastLineD1Ev(struct RaycastLine* r);
 
-extern u16 data_ov002_0210a5cc[];
 extern s16 data_02082214[];
 
 void func_ov002_020d8a50(char* self, int which)
@@ -38,7 +35,7 @@ void func_ov002_020d8a50(char* self, int which)
     int frame;
 
     model = *(char**)(self + _ZNK6Player14GetBodyModelIDEjb(self, *(u32*)(self + 8) & 0xff, 0) * 4 + 0xdc);
-    anim = (char*)((long long)(int)(model + 0x50) & 0xFFFFFFFFFFFFFFFFLL);
+    anim = (char*)((long long)(int)(model + 0x50));
     frame = (u16)(*(int*)(anim + 8) >> 12);
     if (frame < data_ov002_0210a5cc[i2] || frame > data_ov002_0210a5cc[i2 + 1]) {
         flag = 0;
@@ -86,7 +83,7 @@ void func_ov002_020d8a50(char* self, int which)
             return;
     }
 
-    *(u16*)((long long)(int)(self + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+    *(u16*)((long long)(int)(self + 0x6ce)) &= ~0x20;
     _ZN5Sound9PlayBank0EjRK7Vector3(0xb5, (struct Vector3*)(self + 0x74));
 
     {

--- a/src/func_ov002_020d8d10.c
+++ b/src/func_ov002_020d8d10.c
@@ -1,3 +1,6 @@
+// @symbol func_ov002_020d8d10
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov002_020d8d10 at 0x020d8d10
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
@@ -12,13 +15,13 @@ struct Callback;
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 effect, Fix12i x, Fix12i y, Fix12i z, const void* rot, struct Callback* cb);
 
-struct Vector3_16f { s16 x, y, z; };
-struct Vec { Fix12i x, y, z; };
+
+
 struct Self { char pad0[8]; int state; char pad2[0x82]; s16 angle; };
 
-void func_ov002_020d8d10(struct Self* self, struct Vec* pos)
+void func_ov002_020d8d10(struct Self* self, struct Vector3* pos)
 {
-    struct Vector3_16f vec;
+    struct Vector3_16 vec;
 
     vec.x = data_02082214[((unsigned short)(short)(self->angle + 0x8000) >> 4) * 2];
     vec.y = 0;

--- a/src/func_ov002_020d93ac.cpp
+++ b/src/func_ov002_020d93ac.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov002_020d93ac
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern "C" {
 int func_ov002_020d93ac(char *self);

--- a/src/func_ov002_020d94cc.cpp
+++ b/src/func_ov002_020d94cc.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov002_020d94cc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef short s16;
 typedef signed char s8;
 
-struct Vector3 { int x, y, z; };
+
 
 extern "C" {
 int func_ov002_020d94cc(char *self);

--- a/src/func_ov002_020d98b4.cpp
+++ b/src/func_ov002_020d98b4.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov002_020d98b4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
-extern int func_ov002_020beb38(char* c);
+
 extern unsigned int _ZNK6Player14GetBodyModelIDEjb(char* c, unsigned int a, int b);
-extern void MulVec3Mat4x3(void* a, void* b, struct Vec3* out);
-extern void Vec3_MulScalar(struct Vec3* out, struct Vec3* in, int s);
+extern void MulVec3Mat4x3(void* a, void* b, struct Vector3* out);
+extern void Vec3_MulScalar(struct Vector3* out, struct Vector3* in, int s);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
   unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
 
@@ -19,8 +23,8 @@ void func_ov002_020d98b4(char* self){
     unsigned int id = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self+8) & 0xff, 0);
     int r5 = *(int*)(*(int*)(self + (id << 2) + 0xdc) + 0x14) + 0x2d0;
     unsigned int id2 = _ZNK6Player14GetBodyModelIDEjb(self, *(int*)(self+8) & 0xff, 0);
-    struct Vec3 v;
-    struct Vec3 s;
+    struct Vector3 v;
+    struct Vector3 s;
     MulVec3Mat4x3((void*)(r5 + 0x24), (void*)(*(int*)(self + (id2 << 2) + 0xdc) + 0x1c), &v);
     Vec3_MulScalar(&s, &v, 0x8000);
     s.y += 0x50000;

--- a/src/func_ov002_020db54c.cpp
+++ b/src/func_ov002_020db54c.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020db54c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
+
 struct State;
 extern "C" void func_02035860(void *a, struct Vector3 *v);
 extern struct State data_ov002_021101cc;

--- a/src/func_ov002_020db8d8.cpp
+++ b/src/func_ov002_020db8d8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020db8d8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
+
 extern unsigned char data_0209f2d8;
 extern int _ZNK6Player14GetBodyModelIDEjb(void *c, unsigned int a, bool b);
 extern void MulVec3Mat4x3(void *out, void *mtx, void *vec);
@@ -9,10 +12,10 @@ extern void func_ov002_020dc174(char *c, void *r1, int r2, int r3, unsigned int 
 
 void func_ov002_020db8d8(char *self)
 {
-    volatile Vec3 backup;
-    Vec3 tmp;
-    Vec3 dir;
-    Vec3 scaled;
+    volatile Vector3 backup;
+    Vector3 tmp;
+    Vector3 dir;
+    Vector3 scaled;
     int model;
     char *m;
     int b;

--- a/src/func_ov002_020dbc94.c
+++ b/src/func_ov002_020dbc94.c
@@ -1,10 +1,14 @@
-extern void func_ov002_020dc174(char* c, void* v, int r2, int r3, unsigned int a5, unsigned int a6);
+// @symbol func_ov002_020dbc94
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern unsigned char data_0209f2d8;
 
-struct V3 { int x, y, z; };
+
 
 void func_ov002_020dbc94(char* c) {
-    struct V3 v;
+    struct Vector3 v;
     int b = (int)(data_0209f2d8 == 1);
     if (b) {
         int r2 = 0x82000;

--- a/src/func_ov002_020dd908.c
+++ b/src/func_ov002_020dd908.c
@@ -1,12 +1,15 @@
-struct Vec3 { int x, y, z; };
-extern int Vec3_Dist(const struct Vec3* a, const struct Vec3* b);
-extern void func_ov002_020dd8f4(char* p);
+// @symbol func_ov002_020dd908
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern int Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 extern unsigned char data_0209f2d8;
 extern unsigned char data_0209f21c;
 extern char* data_0209f394[];
 void func_ov002_020dd908(char* sb){
   int i;
-  struct Vec3 v;
+  struct Vector3 v;
   if((int)(data_0209f2d8 == 1) == 0) return;
   for(i = 0; i < data_0209f21c; i++){
     char* o = data_0209f394[i];
@@ -18,7 +21,7 @@ void func_ov002_020dd908(char* sb){
     v.y = p[1];
     v.z = p[2];
     v.y = *(int*)(sb+0x60);
-    if(Vec3_Dist((struct Vec3*)(sb+0x5c), &v) >= 0x12c000) continue;
+    if(Vec3_Dist((struct Vector3*)(sb+0x5c), &v) >= 0x12c000) continue;
     func_ov002_020dd8f4(o);
   }
 }

--- a/src/func_ov002_020de428.c
+++ b/src/func_ov002_020de428.c
@@ -1,6 +1,9 @@
+// @symbol func_ov002_020de428
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 struct Actor {
     char pad74[0x74];
     struct Vector3 vec; /* 0x74 */

--- a/src/func_ov002_020df840.c
+++ b/src/func_ov002_020df840.c
@@ -1,13 +1,17 @@
+// @symbol func_ov002_020df840
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
-extern char data_ov002_02110244;
 
 struct Player {
     char pad8[8];

--- a/src/func_ov002_020e25d4.cpp
+++ b/src/func_ov002_020e25d4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020e25d4
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, const Vector3 *v);
 

--- a/src/func_ov002_020e2c84.c
+++ b/src/func_ov002_020e2c84.c
@@ -1,23 +1,25 @@
+// @symbol func_ov002_020e2c84
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 
-struct Vector3 { int x, y, z; };
+
 struct Camera;
 
-extern void func_ov002_020e301c(char *c);
 extern int func_ov002_020e3078(char *self, void *s);
 extern int func_ov002_020e2ea0(char *self);
 extern void _ZN6Player11ChangeStateERNS_5StateE(char *self, void *state);
 extern int func_ov002_020d91e0(char *thiz, int damage, int doPre);
 extern void func_0200d8c8(struct Camera *cam, const struct Vector3 *v, int strength);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(unsigned int a, unsigned int b, const struct Vector3 *v);
-extern int func_ov002_020c0cbc(char *c);
 extern int _ZN6Player7IsStateERNS_5StateE(char *self, void *state);
 extern int func_ov002_020c5dec(char *c, int r1);
 extern void func_ov002_020db8bc(unsigned char *p, unsigned char val);
 
 extern char data_ov002_02110454;
-extern char data_ov002_02110484;
 extern char data_ov002_02110094;
 extern char data_ov002_0211010c;
 extern struct Camera *data_0209f318;
@@ -44,7 +46,7 @@ int func_ov002_020e2c84(char *self)
 
         if (func_ov002_020d91e0(self, 0x400, 1) != 0) {
             {
-                u8 *p = (u8 *)(((long long)(int)(self + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8 *)(((long long)(int)(self + 0x6e3)));
                 *p &= 1;
             }
             _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_0211010c);
@@ -59,7 +61,7 @@ int func_ov002_020e2c84(char *self)
             if (func_ov002_020d91e0(self, 0x200, 1) != 0) {
                 if (_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110094) != 0) {
                     {
-                        u8 *p = (u8 *)(((long long)(int)(self + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+                        u8 *p = (u8 *)(((long long)(int)(self + 0x6e3)));
                         *p &= 1;
                     }
                     _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_0211010c);

--- a/src/func_ov002_020e444c.c
+++ b/src/func_ov002_020e444c.c
@@ -1,29 +1,33 @@
+// @symbol func_ov002_020e444c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_ClsnResult.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int Fix12i;
 
-struct Mtx43 { int w[12]; };
 
-extern int func_ov002_020e3f90(void);
-extern void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
+
+extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
 extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
-extern void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx43 *mF, s16 angY);
-extern void Matrix4x3_ApplyInPlaceToRotationX(struct Mtx43 *mF, s16 angX);
-extern void Matrix4x3_ApplyInPlaceToRotationZ(struct Mtx43 *mF, s16 angZ);
+extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, s16 angY);
+extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *mF, s16 angX);
+extern void Matrix4x3_ApplyInPlaceToRotationZ(struct Matrix4x3 *mF, s16 angZ);
 extern int _ZNK6Player14GetBodyModelIDEjb(void *self, u32 unk, int b);
 extern int func_ov002_020becf4(void *self, u32 v, int arg2);
 extern int func_ov002_020d225c(void *o);
-extern void Matrix4x3_ApplyInPlaceToTranslation(struct Mtx43 *mF, Fix12i x, Fix12i y, Fix12i z);
+extern void Matrix4x3_ApplyInPlaceToTranslation(struct Matrix4x3 *mF, Fix12i x, Fix12i y, Fix12i z);
 extern void func_ov002_020e4374(void *c, int *p1, int *p2);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
-extern int _ZNK10ClsnResult9GetClsnIDEv(void *self);
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *self, void *sm, void *mtx, Fix12i a, Fix12i b, u32 flags);
 
-extern struct Mtx43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov002_020e444c(char *c)
 {
@@ -35,7 +39,7 @@ void func_ov002_020e444c(char *c)
         if (*(u8 *)(c + 0x6fd) != 0)
             y -= 0x70000;
         Matrix4x3_FromTranslation(&data_020a0e68, *(int *)(c + 0x5c) >> 3, y >> 3, *(int *)(c + 0x64) >> 3);
-        *(struct Mtx43 *)(c + 0x5bc) = data_020a0e68;
+        *(struct Matrix4x3 *)(c + 0x5bc) = data_020a0e68;
 
         {
             int out[3];
@@ -55,10 +59,10 @@ void func_ov002_020e444c(char *c)
         if (*(u8 *)(c + 0x6fd) == 0) {
             int bodyID = _ZNK6Player14GetBodyModelIDEjb(c, *(u32 *)(c + 8) & 0xff, 0);
             char *p = *(char **)(c + bodyID * 4 + 0xdc);
-            *(struct Mtx43 *)(p + 0x1c) = data_020a0e68;
-            *(struct Mtx43 *)(c + 0x190) = data_020a0e68;
+            *(struct Matrix4x3 *)(p + 0x1c) = data_020a0e68;
+            *(struct Matrix4x3 *)(c + 0x190) = data_020a0e68;
         } else {
-            *(struct Mtx43 *)(c + 0x10c) = data_020a0e68;
+            *(struct Matrix4x3 *)(c + 0x10c) = data_020a0e68;
         }
 
         {
@@ -66,7 +70,7 @@ void func_ov002_020e444c(char *c)
             if (r0 != 9 && r0 != 8) {
                 char *q = *(char **)(c + r0 * 4 + 0x154);
                 if (q != 0) {
-                    *(struct Mtx43 *)(q + 0x1c) = data_020a0e68;
+                    *(struct Matrix4x3 *)(q + 0x1c) = data_020a0e68;
                 }
             }
         }
@@ -75,7 +79,7 @@ void func_ov002_020e444c(char *c)
             int z = (int)(((long long)(*(int *)(c + 0x574)) * 0x2400 + 0x800) >> 12) + 0xc000;
             Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, 0x7000, z);
             char *p = *(char **)(c + 0x1d8);
-            *(struct Mtx43 *)(p + 0x1c) = data_020a0e68;
+            *(struct Matrix4x3 *)(p + 0x1c) = data_020a0e68;
         }
     }
 

--- a/src/func_ov002_020e6df8.cpp
+++ b/src/func_ov002_020e6df8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020e6df8
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 struct BCA_File;
 struct Actor;
 

--- a/src/func_ov002_020e6edc.c
+++ b/src/func_ov002_020e6edc.c
@@ -1,10 +1,13 @@
+// @symbol func_ov002_020e6edc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int s32;
 typedef short s16;
 typedef unsigned short u16;
 struct Actor;
 struct BCA_File;
-struct Vector3 { s32 x, y, z; };
+
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* self, struct BCA_File* f, int a, int fix, u32 b);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(char* self, struct Actor* a, const struct Vector3* pos, int r, u32 f1, u32 f2, u32 f3);
 extern char data_ov002_02110934[];

--- a/src/func_ov002_020e7218.c
+++ b/src/func_ov002_020e7218.c
@@ -1,15 +1,17 @@
-struct V3 { int x, y, z; };
-
-extern void _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(void* self, struct V3* pos, unsigned int n, int flag, unsigned short t, void* src);
-extern void func_ov002_020e7554(void* c);
+// @symbol func_ov002_020e7218
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(void* self, struct Vector3* pos, unsigned int n, int flag, unsigned short t, void* src);
 extern signed char data_0209f310[];
 
 void func_ov002_020e7218(char* c, char* a, int gate) {
     if (gate == 0) {
-        struct V3 pos[2];
+        struct Vector3 pos[2];
         int b;
         int* v;
-        v = (int*)((int)(((long long)(int)(a + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));
+        v = (int*)((int)(((long long)(int)(a + 0x5c))));
         pos[0].x = v[0];
         pos[0].y = v[1];
         pos[0].z = v[2];
@@ -21,6 +23,6 @@ void func_ov002_020e7218(char* c, char* a, int gate) {
         pos[1].y = pos[0].y;
         _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(c, &pos[1], data_0209f310[*(unsigned char*)(a + 0x6d8)], b, 0x15, a);
     }
-    *(unsigned short*)((int)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL)) |= 0x40;
+    *(unsigned short*)((int)(((long long)(int)(c + 0x4a2)))) |= 0x40;
     func_ov002_020e7554(c);
 }

--- a/src/func_ov002_020e7934.cpp
+++ b/src/func_ov002_020e7934.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020e7934
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 
 extern "C" {

--- a/src/func_ov002_020e7d08.cpp
+++ b/src/func_ov002_020e7d08.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020e7d08
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 struct Actor;
 
 struct RaycastGround {

--- a/src/func_ov002_020e7eb8.cpp
+++ b/src/func_ov002_020e7eb8.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov002_020e7eb8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct V3 { int x, y, z; };
-extern void func_ov002_020e8244(V3* out, char* c);
+
+extern void func_ov002_020e8244(Vector3* out, char* c);
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
   int a0, unsigned int a1, int a2, int a3, int a4, void* a5, void* a6);
 void func_ov002_020e7eb8(char* c){
-  V3 v;
+  Vector3 v;
   int b = (*(unsigned short*)(c+0xc) == 0xb3);
   if (b == 0) return;
   func_ov002_020e8244(&v, c);

--- a/src/func_ov002_020e7fcc.c
+++ b/src/func_ov002_020e7fcc.c
@@ -1,21 +1,25 @@
+// @symbol func_ov002_020e7fcc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vec { Fix12i x, y, z; };
+
 struct Callback;
 
 extern int _ZN9Animation8FinishedEv(void* anim);
-extern void func_ov002_020e8244(struct Vec* out, void* thiz);
+extern void func_ov002_020e8244(struct Vector3* out, void* thiz);
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 effect, Fix12i x, Fix12i y, Fix12i z, const void* rot, struct Callback* cb);
-extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 effect, Fix12i x, Fix12i y, Fix12i z);
 
 void func_ov002_020e7fcc(char* c)
 {
     void* obj;
-    struct Vec v1;
-    struct Vec v2;
+    struct Vector3 v1;
+    struct Vector3 v2;
 
     obj = *(void**)(c + 0x31c);
 

--- a/src/func_ov002_020e8098.cpp
+++ b/src/func_ov002_020e8098.cpp
@@ -1,18 +1,21 @@
 //cpp
+// @symbol func_ov002_020e8098
+/* recovered: shared common types */
+#include "common.h"
 typedef long long s64;
-struct Vec3 { int x, y, z; };
+
 
 extern "C" int  _ZN9Animation8FinishedEv(void* anim);
-extern "C" void func_ov002_020e8244(Vec3* out, char* self);
-extern "C" void SubVec3(Vec3* a, Vec3* b, Vec3* c);
-extern "C" void AddVec3(Vec3* a, Vec3* b, Vec3* c);
+extern "C" void func_ov002_020e8244(Vector3* out, char* self);
+extern "C" void SubVec3(Vector3* a, Vector3* b, Vector3* c);
+extern "C" void AddVec3(Vector3* a, Vector3* b, Vector3* c);
 extern "C" void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int c, int d, int e, const void* f, void* g);
 
 extern "C" void func_ov002_020e8098(char* self)
 {
-    Vec3 vc;
-    Vec3 v;
+    Vector3 vc;
+    Vector3 v;
     if (_ZN9Animation8FinishedEv(self + 0x35c)) return;
     func_ov002_020e8244(&v, self);
     vc.x = v.x;
@@ -20,11 +23,11 @@ extern "C" void func_ov002_020e8098(char* self)
     vc.z = v.z;
     if (*(int*)(self + 0x440) != 0xd)
         vc.y = v.y + 0x32000;
-    SubVec3(&vc, (Vec3*)(self + 0x5c), &vc);
+    SubVec3(&vc, (Vector3*)(self + 0x5c), &vc);
     vc.x = (int)(((s64)vc.x * *(int*)(self + 0x80) + 0x800) >> 0xc);
     vc.y = (int)(((s64)vc.y * *(int*)(self + 0x84) + 0x800) >> 0xc);
     vc.z = (int)(((s64)vc.z * *(int*)(self + 0x88) + 0x800) >> 0xc);
-    AddVec3(&vc, (Vec3*)(self + 0x5c), &vc);
+    AddVec3(&vc, (Vector3*)(self + 0x5c), &vc);
     *(void**)(self + 0x4b4) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(unsigned int*)(self + 0x4b4), 0x115, vc.x, vc.y, vc.z, 0, 0);
     *(void**)(self + 0x4b8) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov002_020e81e0.cpp
+++ b/src/func_ov002_020e81e0.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov002_020e81e0
+/* recovered: shared common types */
+#include "common.h"
 
-struct Vector3_16f { int x, y, z; };
+
 
 struct Obj {
     char pad5c[0x5c];
@@ -15,12 +18,12 @@ namespace Particle {
 struct Callback;
 struct System {
     static System *New(unsigned int a, unsigned int b, int c, int d, int e,
-                       const Vector3_16f *p, Callback *cb);
+                       const Vector3 *p, Callback *cb);
 };
 }
 
 extern "C" void func_ov002_020e81e0(Obj *self) {
-    Vector3_16f v;
+    Vector3 v;
     v.x = self->f5c;
     v.y = self->f60;
     v.z = self->f64;

--- a/src/func_ov002_020e8398.c
+++ b/src/func_ov002_020e8398.c
@@ -1,10 +1,13 @@
+// @symbol func_ov002_020e8398
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef long long s64;
 enum { false, true };
 struct ShadowModel;
 struct Matrix4x3;
-struct M48 { int w[12]; };
-extern struct M48 data_02082128;
+
+extern struct Matrix4x3 data_02082128;
 extern int _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(char *self, struct ShadowModel *sm, struct Matrix4x3 *m, int fix, int t, u32 f);
 
 #pragma opt_common_subs off
@@ -46,7 +49,7 @@ void func_ov002_020e8398(char *c)
 
     t = delta + 0x28000;
 
-    *(struct M48 *)(c + 0x3fc) = data_02082128;
+    *(struct Matrix4x3 *)(c + 0x3fc) = data_02082128;
 
     *(int *)(c + 0x420) = *(int *)(c + 0x5c) >> 3;
     *(int *)(c + 0x424) = *(int *)(c + 0x60) >> 3;

--- a/src/func_ov002_020e84ec.c
+++ b/src/func_ov002_020e84ec.c
@@ -1,28 +1,32 @@
+// @symbol func_ov002_020e84ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef short s16;
 
-struct Vec3 { int x, y, z; };
-struct M48 { int w[12]; };
+
+
 struct Flags { unsigned short b0 : 1; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
-extern void func_ov002_020e8398(void* self);
 
 void func_ov002_020e84ec(char* self)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     s16* ang;
     int t;
 
     if (*(int*)(self + 0x43c) == 8) {
-        Vec3_Asr(&v, (struct Vec3*)(self + 0x5c), 3);
+        Vec3_Asr(&v, (struct Vector3*)(self + 0x5c), 3);
         Matrix4x3_FromTranslation(self + 0x328, v.x, v.y, v.z);
     } else if (*(void**)(self + 0xc8) != 0) {
-        *(struct M48*)(self + 0x328) = *(struct M48*)(*(char**)(self + 0xc8));
+        *(struct Matrix4x3*)(self + 0x328) = *(struct Matrix4x3*)(*(char**)(self + 0xc8));
     } else if (!((struct Flags*)(self + 0x4a2))->b0) {
-        ang = (s16*)((int)(((long long)(int)(self + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL));
+        ang = (s16*)((int)(((long long)(int)(self + 0x8e))));
         t = *ang + 0xc00;
         *ang = t;
         Matrix4x3_FromRotationY(self + 0x328, *(s16*)(self + 0x8e));
@@ -36,6 +40,6 @@ void func_ov002_020e84ec(char* self)
         *(int*)(self + 0x354) = *(int*)(self + 0x64) >> 3;
     }
 
-    *(struct M48*)(self + 0x38c) = *(struct M48*)(self + 0x328);
+    *(struct Matrix4x3*)(self + 0x38c) = *(struct Matrix4x3*)(self + 0x328);
     func_ov002_020e8398(self);
 }

--- a/src/func_ov002_020e86ec.c
+++ b/src/func_ov002_020e86ec.c
@@ -1,15 +1,17 @@
+// @symbol func_ov002_020e86ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Flags { unsigned short b0 : 1, b1 : 1, b2 : 1, b3 : 1, fld : 2; };
-struct V3 { int x, y, z; };
+
 
 extern int _ZNK12WithMeshClsn12TouchesWaterEv(void* c);
-extern void _ZN12WithMeshClsn15ClearGroundFlagEv(void* c);
-extern void _ZN12WithMeshClsn22ClearJustHitGroundFlagEv(void* c);
-extern void _ZN12WithMeshClsn18StopDetectingWaterEv(void* c);
 extern void _ZN12WithMeshClsn19StartDetectingWaterEv(void* c);
 extern void _ZN13RaycastGroundC1Ev(void* r);
 extern void _ZN13RaycastGroundD1Ev(void* r);
 extern void _ZN4BgCh19StartDetectingWaterEv(void* r);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* r, struct V3* p, void* a);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* r, struct Vector3* p, void* a);
 extern int _ZN13RaycastGround10DetectClsnEv(void* r);
 extern int func_02037e78(void* p);
 extern void func_ov002_020e9448(void* p);
@@ -17,7 +19,7 @@ extern void func_ov002_020e9448(void* p);
 extern int data_0209f32c;
 
 void func_ov002_020e86ec(char* self) {
-    struct V3 v;
+    struct Vector3 v;
     char rc[0x54];
     int tx, ty, tz, ta;
 

--- a/src/func_ov002_020e88a8.c
+++ b/src/func_ov002_020e88a8.c
@@ -1,29 +1,32 @@
+// @symbol func_ov002_020e88a8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Flags { unsigned short b0 : 1, b1 : 1, b2 : 1, b3 : 1, fld : 2; };
-struct V3 { int x, y, z; };
+
 
 extern void func_02012694(int a, void* p);
 extern char* _ZNK12WithMeshClsn14GetFloorResultEv(void* c);
 extern int func_02037e38(void* p);
 extern int func_02037e58(void* p);
-extern void func_ov002_020e947c(void* self, struct V3* p, int d);
-extern void func_ov002_020e8abc(void* self);
+extern void func_ov002_020e947c(void* self, struct Vector3* p, int d);
 extern void func_ov002_020e9448(void* self);
 extern char* _ZN5Actor13ClosestPlayerEv(void* self);
-extern char* _ZN5Actor14FarthestPlayerEv(void* self);
-extern int Vec3_Dist(struct V3* a, struct V3* b);
-extern short Vec3_HorzAngle(struct V3* a, struct V3* b);
+extern int Vec3_Dist(struct Vector3* a, struct Vector3* b);
+extern short Vec3_HorzAngle(struct Vector3* a, struct Vector3* b);
 
-extern char data_02082714[];
 extern signed char data_0209f2f8;
 
 void func_ov002_020e88a8(char* self) {
-    struct V3 v;
-    struct V3 w;
+    struct Vector3 v;
+    struct Vector3 w;
     char* p;
     int r;
 
     if (((struct Flags*)(self + 0x4a2))->b3) {
-        ((struct Flags*)((int)(((long long)(int)(self + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL)))->b3 = 0;
+        ((struct Flags*)((int)(((long long)(int)(self + 0x4a2)))))->b3 = 0;
         *(unsigned short*)(self + 0x100) = 0;
     }
     func_02012694(0x55, self + 0x74);
@@ -53,13 +56,13 @@ void func_ov002_020e88a8(char* self) {
     p = _ZN5Actor13ClosestPlayerEv(self);
     if (p == 0) return;
     {
-        int* s = (int*)((int)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));
+        int* s = (int*)((int)(((long long)(int)(p + 0x5c))));
         v.x = s[0];
         v.y = s[1];
         v.z = s[2];
     }
-    if (Vec3_Dist((struct V3*)(self + 0x5c), &v) < 0x4b0000) {
-        *(short*)(self + 0x94) = Vec3_HorzAngle(&v, (struct V3*)(self + 0x5c));
+    if (Vec3_Dist((struct Vector3*)(self + 0x5c), &v) < 0x4b0000) {
+        *(short*)(self + 0x94) = Vec3_HorzAngle(&v, (struct Vector3*)(self + 0x5c));
         if (*(int*)(self + 0xd8) >= *(short*)(data_02082714 + 0x56)) {
             if (data_0209f2f8 != 0x1d) return;
             if (func_02037e58(_ZNK12WithMeshClsn14GetFloorResultEv(self + 0x150) + 4) != 5) return;
@@ -72,7 +75,7 @@ void func_ov002_020e88a8(char* self) {
         char* q = _ZN5Actor14FarthestPlayerEv(self);
         if (q != 0) {
             q = q + 0x5c;
-            *(short*)(self + 0x94) = Vec3_HorzAngle((struct V3*)(self + 0x5c), (struct V3*)q);
+            *(short*)(self + 0x94) = Vec3_HorzAngle((struct Vector3*)(self + 0x5c), (struct Vector3*)q);
         }
     }
 }

--- a/src/func_ov002_020e8edc.c
+++ b/src/func_ov002_020e8edc.c
@@ -1,5 +1,10 @@
-extern void func_ov002_020e8e80(void);
+// @symbol func_ov002_020e8edc
+// @emits PowerStar_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daStar_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-void func_ov002_020e8edc(void) {
+void PowerStar_OnTurnIntoEgg(void) {
     func_ov002_020e8e80();
 }

--- a/src/func_ov002_020e8ee8.c
+++ b/src/func_ov002_020e8ee8.c
@@ -1,4 +1,8 @@
-int func_ov002_020e8ee8(void)
+// @symbol func_ov002_020e8ee8
+// @emits PowerStar_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daStar_c::OnYoshiTryEat - recovered from vtable slot identity */
+int PowerStar_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov002_020e9840.c
+++ b/src/func_ov002_020e9840.c
@@ -1,3 +1,6 @@
+// @symbol func_ov002_020e9840
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov002_020e9840 at 0x020e9840 (ov002), size 0x1a8
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
@@ -5,7 +8,7 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void func_ov002_020e9590(char *self);
@@ -33,7 +36,7 @@ void func_ov002_020e9840(char *self)
         if (*(u8 *)(self + 0x49d) != data_0209f344[data_0209f208]) return;
         if (*(u16 *)(actor + 0x1d4) != 0) return;
 
-        *(u16 *)(((long long)(int)(self + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(u16 *)(((long long)(int)(self + 0x4a2))) |= 2;
         func_ov002_020e8dd8((unsigned char *)self);
         func_02012694(0x54, (struct Vector3 *)(self + 0x74));
         return;
@@ -41,13 +44,13 @@ void func_ov002_020e9840(char *self)
 
     if ((unsigned)(*(u8 *)(actor + 0x1db) << 31) >> 31 == 0) return;
 
-    *(u16 *)(((unsigned long long)(unsigned int)(self + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+    *(u16 *)(((unsigned long long)(unsigned int)(self + 0x4a2))) &= ~8;
     *(u16 *)(self + 0x100) = 0xf;
     *(int *)(self + 0x440) = 8;
     *(int *)(self + 0xa8) = 0x20000;
     func_ov002_020e9448((unsigned char *)self);
 
-    *(int *)(((long long)(int)(self + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    *(int *)(((long long)(int)(self + 0x128))) &= ~1;
 
     {
         int r0 = (data_0209f2d8 == 1) ? 1 : 0;
@@ -55,7 +58,7 @@ void func_ov002_020e9840(char *self)
         if (r0 == 0) return;
         if (r3 == 0) return;
 
-        *(u16 *)(((long long)(int)(self + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+        *(u16 *)(((long long)(int)(self + 0x4a2))) |= 8;
         *(int *)(self + 0x98) = 0xc000;
         *(s16 *)(self + 0x94) = GetAngleToCamera(*(u8 *)((char *)r3 + 0x6d8)) + 0x8000;
     }

--- a/src/func_ov002_020ea9d0.c
+++ b/src/func_ov002_020ea9d0.c
@@ -1,3 +1,8 @@
+// @symbol func_ov002_020ea9d0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -5,7 +10,7 @@ typedef unsigned short u16;
 typedef int s32;
 typedef unsigned int u32;
 
-struct Vec3 { s32 x, y, z; };
+
 struct Vec1 { s32 a; };
 
 extern s32 data_0209b454;
@@ -17,21 +22,19 @@ extern void func_02012694(u32 id, void *v);
 extern void func_ov002_020e9448(void *p);
 extern char *_ZN5Actor10FindWithIDEj(u32 id);
 extern s32 Vec3_HorzDist(void *a, void *b);
-extern void func_ov002_020e947c(void *c, struct Vec3 *p, s32 n);
+extern void func_ov002_020e947c(void *c, struct Vector3 *p, s32 n);
 extern s32 func_ov002_020e8dd8(void *self);
-extern void func_ov002_020e7e24(void *self);
-extern void func_ov002_020e7d08(void *self);
 
 void func_ov002_020ea9d0(void *arg0)
 {
     char *c = (char *)arg0;
     char *other;
     s32 area;
-    struct Vec3 *op;
-    struct Vec3 v0;
-    struct Vec3 v1;
-    struct Vec3 v2;
-    struct Vec3 v3;
+    struct Vector3 *op;
+    struct Vector3 v0;
+    struct Vector3 v1;
+    struct Vector3 v2;
+    struct Vector3 v3;
 
     if (*(u8 *)(c + 0x49d) != 0) {
         func_ov002_020e9590(c);
@@ -40,7 +43,7 @@ void func_ov002_020ea9d0(void *arg0)
             return;
         }
     }
-    *(u32 *)((int)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL)) |= 0x4000000;
+    *(u32 *)((int)(((long long)(int)(c + 0xb0)))) |= 0x4000000;
     data_0209b454 |= 0x4000000;
     *(u16 *)(c + 0x496) = 0;
     func_02012694(0x57, c + 0x74);
@@ -53,7 +56,7 @@ void func_ov002_020ea9d0(void *arg0)
             *(s32 *)(c + 0x440) = 3;
         } else {
             *(s32 *)(c + 0x440) = 2;
-            op = (struct Vec3 *)((int)(((long long)(int)(other + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));
+            op = (struct Vector3 *)((int)(((long long)(int)(other + 0x5c))));
             *(struct Vec1 *)&v0.x = *(struct Vec1 *)&op->x;
             *(struct Vec1 *)&v0.y = *(struct Vec1 *)&op->y;
             *(struct Vec1 *)&v0.z = *(struct Vec1 *)&op->z;

--- a/src/func_ov002_020ec388.c
+++ b/src/func_ov002_020ec388.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov002_020ec388
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daWarpkun_c */
 int *func_ov002_020ec388(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daWarpkun_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020ec3b8.c
+++ b/src/func_ov002_020ec3b8.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov002_020ec3b8
+// @emits daWarpkun_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daWarpkun_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020ec3b8(int *t)
+int *daWarpkun_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020ec3fc.c
+++ b/src/func_ov002_020ec3fc.c
@@ -1,4 +1,8 @@
-int func_ov002_020ec3fc(void)
+// @symbol func_ov002_020ec3fc
+// @emits daWarpkun_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daWarpkun_c::CleanupResources - recovered from vtable slot identity */
+int daWarpkun_c_CleanupResources(void)
 {
     return 1;
 }

--- a/src/func_ov002_020ec404.c
+++ b/src/func_ov002_020ec404.c
@@ -1,3 +1,7 @@
-void func_ov002_020ec404(void)
+// @symbol func_ov002_020ec404
+// @emits daWarpkun_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daWarpkun_c::OnPendingDestroy - recovered from vtable slot identity */
+void daWarpkun_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov002_020ec408.c
+++ b/src/func_ov002_020ec408.c
@@ -1,4 +1,8 @@
-int func_ov002_020ec408(void)
+// @symbol func_ov002_020ec408
+// @emits daWarpkun_c_Render
+/* recovered: renamed to Class_Method */
+/* daWarpkun_c::Render - recovered from vtable slot identity */
+int daWarpkun_c_Render(void)
 {
     return 1;
 }

--- a/src/func_ov002_020ec4c4.c
+++ b/src/func_ov002_020ec4c4.c
@@ -1,8 +1,12 @@
+// @symbol func_ov002_020ec4c4
+// @emits daWarpkun_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daWarpkun_c::InitResources - recovered from vtable slot identity */
 
 typedef int Fix12i;
 extern int _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *, Fix12i, Fix12i, Fix12i, Fix12i);
 extern int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, void *, Fix12i, Fix12i, unsigned int, unsigned int);
-int func_ov002_020ec4c4(void *c)
+int daWarpkun_c_InitResources(void *c)
 {
   int v = *((int *) (((char *) c) + 8));
   int r = (((*((int *) (((char *) c) + 8))) & 0xf) + 1) << 0x12;

--- a/src/func_ov002_020ec728.c
+++ b/src/func_ov002_020ec728.c
@@ -1,9 +1,12 @@
+// @symbol func_ov002_020ec728
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
-extern unsigned char func_ov002_020ec640(char* p);
+
 extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char* thiz, const struct Vector3* v, unsigned int n, Fix12i f, short s);
 extern int func_ov002_020ec628(char* p);
-extern void func_ov002_020ec80c(char* thiz, const struct Vector3* v, int a, Fix12i f, int s);
 
 void func_ov002_020ec728(char* c)
 {

--- a/src/func_ov002_020ecfc8.c
+++ b/src/func_ov002_020ecfc8.c
@@ -1,9 +1,13 @@
+// @symbol func_ov002_020ecfc8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* m, void* f, int a, Fix12i b, unsigned int d);
 extern int func_ov002_020ec654(void* c);
-extern void* func_ov002_020edb3c(void* c, int a, int b);
 extern void func_0203568c(void* p, int v);
 extern s16 Vec3_HorzAngle(const struct Vector3* a, const struct Vector3* b);
 extern void func_ov002_020edca4(void* c);

--- a/src/func_ov002_020ed0d4.c
+++ b/src/func_ov002_020ed0d4.c
@@ -1,10 +1,12 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020ed0d4
+// @emits daWarpkun_c_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daWarpkun_c::Kill - recovered from vtable slot identity */
 
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
-extern void Matrix4x3_FromRotationZXYExt(void* m, int x, int y, int z);
 extern void MulVec3Mat4x3(void* a, void* m, void* out);
-extern int func_ov002_020cf700(void* c);
-extern int func_ov002_020d0d2c(void* c);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 extern void Vec3_Add(void* out, void* a, void* b);
 extern int Vec3_HorzDist(void* a, void* b);
@@ -14,7 +16,6 @@ extern void Math_Function_0203b14c(void* ptr, int target, int rate, int limit, i
 extern void ApproachAngle(void* cur, short target, int divisor, int band, int maxStep);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* file, int a, int b, unsigned int c);
 extern int func_ov002_020ec654(unsigned char* p);
-extern void func_ov002_020ed738(char* c);
 extern void _ZN12CylinderClsn5ClearEv(void* self);
 extern int Vec3_Dist(void* a, void* b);
 extern void func_02038420(void* self);
@@ -23,7 +24,7 @@ extern int data_020a0e68[];
 extern void* data_ov002_0210e6b0[];
 extern void* data_ov002_0210eb78[];
 
-void func_ov002_020ed0d4(char* self)
+void daWarpkun_c_Kill(char* self)
 {
     struct Vector3 in, out;
     char* com;
@@ -35,7 +36,7 @@ void func_ov002_020ed0d4(char* self)
 
     com = *(char**)(self + 0x38c);
     *(int*)(self + 0x3f4) = -0x68000;
-    p = (int*)((((long long)(int)(com + 0xa4))) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int*)((((long long)(int)(com + 0xa4))));
     *(int*)(self + 0xa4) = p[0];
     *(int*)(self + 0xa8) = p[1];
     *(int*)(self + 0xac) = p[2];
@@ -55,8 +56,8 @@ void func_ov002_020ed0d4(char* self)
             if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x144) != 0) {
                 *(short*)(self + 0x3e4) = *(short*)(*(char**)(self + 0x38c) + 0x8c);
                 *(short*)(self + 0x3e8) = *(short*)(*(char**)(self + 0x38c) + 0x90);
-                pt1 = (int*)((((long long)(int)(com + 0x68))) & 0xFFFFFFFFFFFFFFFFLL);
-                pt2 = (int*)((((long long)(int)(com + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL);
+                pt1 = (int*)((((long long)(int)(com + 0x68))));
+                pt2 = (int*)((((long long)(int)(com + 0x5c))));
                 t1.x = pt1[0];
                 t1.y = pt1[1];
                 t1.z = pt1[2];
@@ -78,8 +79,8 @@ void func_ov002_020ed0d4(char* self)
         } else {
             *(short*)(self + 0x3e4) = *(short*)(com + 0x8c);
             *(short*)(self + 0x3e8) = *(short*)(com + 0x90);
-            pv1 = (int*)((((long long)(int)(com + 0x68))) & 0xFFFFFFFFFFFFFFFFLL);
-            pv2 = (int*)((((long long)(int)(com + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL);
+            pv1 = (int*)((((long long)(int)(com + 0x68))));
+            pv2 = (int*)((((long long)(int)(com + 0x5c))));
             v1.x = pv1[0];
             v1.y = pv1[1];
             v1.z = pv1[2];

--- a/src/func_ov002_020ed6cc.c
+++ b/src/func_ov002_020ed6cc.c
@@ -1,5 +1,8 @@
+// @symbol func_ov002_020ed6cc
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 extern Fix12i Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 int func_ov002_020ed6cc(void* c) {

--- a/src/func_ov002_020ed738.cpp
+++ b/src/func_ov002_020ed738.cpp
@@ -1,16 +1,19 @@
 //cpp
-struct V3 { int x, y, z; };
+// @symbol func_ov002_020ed738
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 extern void* _ZNK12WithMeshClsn14GetFloorResultEv(void* self);
-extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, struct V3* out);
-extern int func_02010844(void* unused, struct V3* v, short angle);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, struct Vector3* out);
+extern int func_02010844(void* unused, struct Vector3* v, short angle);
 extern void _Z11UpdateAngleRssis(short* a, int b, int c, short d);
 void func_ov002_020ed738(char* c) {
     int e4 = 0;
     int e6 = 0;
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c+0x144)) {
-        struct V3 n;
+        struct Vector3 n;
         void* fr = _ZNK12WithMeshClsn14GetFloorResultEv(c+0x144);
         _ZNK11SurfaceInfo12CopyNormalToER7Vector3((char*)fr+4, &n);
         e4 = func_02010844(c, &n, *(short*)(c+0x8e));

--- a/src/func_ov002_020edca4.c
+++ b/src/func_ov002_020edca4.c
@@ -1,14 +1,17 @@
+// @symbol func_ov002_020edca4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
 
-extern void func_ov002_020ec728(char* c);
+
 extern int func_ov002_020ec610(unsigned char* p);
 extern void _ZN5Actor11UntrackStarERa(struct Actor* self, signed char* r);
 extern struct Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const struct Vector3* pos, const void* v, int e, int f);
-extern void func_ov002_020e7218(char* c, char* a, int x);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 a, int b, int c, int d);
 extern void _ZN9ActorBase18MarkForDestructionEv(struct Actor* self);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, const struct Vector3* pos);

--- a/src/func_ov002_020eddc4.c
+++ b/src/func_ov002_020eddc4.c
@@ -1,3 +1,8 @@
+// @symbol func_ov002_020eddc4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov002_020eddc4 at 0x020eddc4
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
@@ -6,13 +11,12 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
+
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
 extern int func_ov002_020ed63c(char* c, int i);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Actor* self, const struct Vector3* pos, u32 a, int fix, u32 b, u32 c, u32 d);
 extern void func_ov002_020edca4(char* c);
-extern void func_ov002_020ec728(char* c);
 
 int func_ov002_020eddc4(char* self)
 {

--- a/src/func_ov002_020ee5d0.c
+++ b/src/func_ov002_020ee5d0.c
@@ -1,16 +1,19 @@
+// @symbol func_ov002_020ee5d0
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vec3 { int x, y, z; };
-struct Matrix4x3 { int w[12]; };
+
+
 extern struct Matrix4x3 data_020a0e68;
-extern void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
+extern void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
 extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToTranslation(struct Matrix4x3 *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void *m, int x, int y, int z);
 
 void func_ov002_020ee5d0(unsigned char *self, int arg)
 {
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3 *)(self + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3 *)(self + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, arg >> 3, 0);
     Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68,

--- a/src/func_ov002_020ef670.c
+++ b/src/func_ov002_020ef670.c
@@ -1,10 +1,12 @@
+// @symbol func_ov002_020ef670
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-extern int func_ov002_020efebc(int *p);
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
-extern void func_ov002_020efbdc(char *c);
-extern int _ZNK7PathPtr5LoopsEv(void *p);
-extern int _ZNK7PathPtr8NumNodesEv(void *p);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, void *out, unsigned idx);
 extern void Vec3_Sub(void *out, void *a, void *b);
 extern int LenVec3(void *v);
@@ -12,19 +14,15 @@ extern int _ZN4cstd4fdivEii(int a, int b);
 extern int Vec3_HorzDist(void *a, void *b);
 extern short Vec3_HorzAngle(void *a, void *b);
 extern short Vec3_VertAngle(void *a, void *b);
-extern int AngleDiff(int a, int b);
 extern void _Z14ApproachLinearRsss(short *r, short a, short b);
-extern int func_ov002_020efe68(char *c);
 extern void Vec3_MulScalar(void *out, void *v, int s);
 extern void SubVec3(void *a, void *b, void *c);
-extern int func_ov002_020efe7c(int *p);
-extern void func_ov002_020efa54(char *c, int i);
 
-struct V3 { int x, y, z; };
+
 
 void func_ov002_020ef670(char *c)
 {
-    struct V3 prev, node, diff1, diff2, scaled1, scaled2;
+    struct Vector3 prev, node, diff1, diff2, scaled1, scaled2;
     int looped;
     int ad2;
     int ad1;

--- a/src/func_ov002_020efc74.cpp
+++ b/src/func_ov002_020efc74.cpp
@@ -1,15 +1,18 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov002_020efc74
+/* recovered: shared common types */
+#include "common.h"
+
 struct Obj {
     virtual void v0();
     virtual void v1();
     virtual void v2();
     virtual void v3();
     virtual void v4();
-    virtual void v5(Vec3* p);
+    virtual void v5(Vector3* p);
 };
 extern "C" int func_ov002_020efe9c(int* self);
-extern Vec3 data_ov002_0210af00;
+extern Vector3 data_ov002_0210af00;
 extern "C" void func_ov002_020efc74(void* self) {
     char* p = (char*)self;
     if (func_ov002_020efe9c((int*)self) == 0) return;
@@ -17,7 +20,7 @@ extern "C" void func_ov002_020efc74(void* self) {
     int i = 0;
     Obj* obj = (Obj*)(p + 0x320);
     do {
-        Vec3 local = data_ov002_0210af00;
+        Vector3 local = data_ov002_0210af00;
         obj->v5(&local);
         i++;
         obj = (Obj*)((char*)obj + 0x50);

--- a/src/func_ov002_020efcf4.c
+++ b/src/func_ov002_020efcf4.c
@@ -1,10 +1,11 @@
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov002_020efcf4
+/* recovered: shared common types */
+#include "common.h"
 extern int func_ov002_020efe9c(int *p);
 extern int _ZNK7PathPtr8NumNodesEv(void *p);
-extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, struct Vec3 *out, unsigned int idx);
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *p, struct Vector3 *out, unsigned int idx);
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
 extern int _ZNK7PathPtr5LoopsEv(void *p);
 
 void func_ov002_020efcf4(int *sl) {
@@ -14,7 +15,7 @@ void func_ov002_020efcf4(int *sl) {
     int i;
     int r6;
     char *obj;
-    struct Vec3 node;
+    struct Vector3 node;
     int one;
 
     if (func_ov002_020efe9c(sl) == 0)
@@ -33,9 +34,9 @@ void func_ov002_020efcf4(int *sl) {
 
         if (i == 0) {
             if (idx < _ZNK7PathPtr8NumNodesEv(c + 0x430) && idx >= 0) {
-                struct Vec3 diff;
+                struct Vector3 diff;
                 _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x430, &node, idx);
-                Vec3_Sub(&diff, &node, (struct Vec3 *)(c + 0x5c));
+                Vec3_Sub(&diff, &node, (struct Vector3 *)(c + 0x5c));
                 if (LenVec3(&diff) < 0xc8000) {
                     if (found == 0) {
                         found = one;

--- a/src/func_ov002_020effb8.c
+++ b/src/func_ov002_020effb8.c
@@ -1,3 +1,6 @@
+// @symbol func_ov002_020effb8
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -5,16 +8,16 @@ typedef unsigned short u16;
 typedef int s32;
 typedef unsigned int u32;
 
-struct Vec3 { s32 x, y, z; };
+
 
 #define FXMUL(a, b) ((s32)(u32)(((((long long)(a)) * (b)) + 0x800) >> 12))
 #define TERM(v, w) ((FXMUL(v, w) + 8) >> 4)
 
-extern s32 Vec3_Equal(struct Vec3 *a, struct Vec3 *b);
+extern s32 Vec3_Equal(struct Vector3 *a, struct Vector3 *b);
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 
-void func_ov002_020effb8(struct Vec3 *out, s32 t, struct Vec3 *a, struct Vec3 *b,
-                         struct Vec3 *c, struct Vec3 *d)
+void func_ov002_020effb8(struct Vector3 *out, s32 t, struct Vector3 *a, struct Vector3 *b,
+                         struct Vector3 *c, struct Vector3 *d)
 {
     s32 s0, s1;
     s32 t4, u, u4;

--- a/src/func_ov002_020f03c4.c
+++ b/src/func_ov002_020f03c4.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov002_020f03c4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV9daSCoin_c */
 int *func_ov002_020f03c4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9daSCoin_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov002_020f03f4.c
+++ b/src/func_ov002_020f03f4.c
@@ -1,9 +1,13 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov002_020f03f4
+// @emits daSCoin_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daSCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020f03f4(int *t)
+int *daSCoin_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020f0438.cpp
+++ b/src/func_ov002_020f0438.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov002_020f0438
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor {
   char pad[0x5c];
   Vector3 pos;          // 0x5c

--- a/src/func_ov002_020f069c.c
+++ b/src/func_ov002_020f069c.c
@@ -1,6 +1,10 @@
+// @symbol func_ov002_020f069c
+// @emits daSCoin_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daSCoin_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int func_ov002_020f069c(void)
+int daSCoin_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     return 1;

--- a/src/func_ov002_020f06c0.cpp
+++ b/src/func_ov002_020f06c0.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov002_020f06c0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daSCoin_c.h"
+// @emits daSCoin_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daSCoin_c::Behavior - recovered from vtable slot identity */
 class ActorBase {
 public:
     void MarkForDestruction();
@@ -13,26 +21,24 @@ public:
     void Update();
 };
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char* p);
-extern "C" void func_ov002_020f05f4(void *o);
-extern "C" void func_ov002_020f051c(void *o);
-extern "C" void func_ov002_020f0438(void *o);
 
-extern "C" int func_ov002_020f06c0(char *c)
+extern "C" int daSCoin_c_Behavior(char *c)
 {
-    if (*(unsigned char *)(c + 0x113)) {
+    struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
+    if (self->unk_113) {
         if (DecIfAbove0_Byte((unsigned char *)(c + 0x113)) == 0) {
             func_ov002_020f05f4(c);
             ((ActorBase *)c)->MarkForDestruction();
         }
         return 1;
     }
-    if (*(unsigned char *)(c + 0x10f) == 0) {
-        unsigned char st = *(unsigned char *)(c + 0x10e);
+    if (self->unk_10f == 0) {
+        unsigned char st = self->unk_10e;
         if (st == 0 || st == 0xf) {
             {
                 Actor *o = 0;
-                *(unsigned char *)(c + 0x10f) = 1;
-                *(int *)(c + 0x108) = *(int *)(c + 4);
+                self->unk_10f = 1;
+                self->unk_108 = *(int *)(c + 4);
                 for (;;) {
                     o = Actor::FindWithActorID(0x149, o);
                     if (o == 0) break;
@@ -44,16 +50,16 @@ extern "C" int func_ov002_020f06c0(char *c)
             }
         }
     }
-    if (*(unsigned char *)(c + 0x10f) == 1 && *(unsigned char *)(c + 0x110) == 5) {
+    if (self->unk_10f == 1 && self->unk_110 == 5) {
         ((ActorBase *)c)->MarkForDestruction();
         return 1;
     }
     func_ov002_020f051c(c);
-    if (*(int *)(c + 0xf8)) {
+    if (self->unk_0f8) {
         func_ov002_020f0438(c);
     }
     ((CylinderClsn *)(c + 0xd4))->Clear();
-    if (*(unsigned char *)(c + 0x111) == 0) {
+    if (self->unk_111 == 0) {
         ((CylinderClsn *)(c + 0xd4))->Update();
     }
     return 1;

--- a/src/func_ov002_020f07dc.c
+++ b/src/func_ov002_020f07dc.c
@@ -1,14 +1,21 @@
+// @symbol func_ov002_020f07dc
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daSCoin_c.h"
+// @emits daSCoin_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daSCoin_c::InitResources - recovered from vtable slot identity */
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, int radius, int height, unsigned int flags, unsigned int vulnFlags);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int data_ov002_0210d9a8;
-int func_ov002_020f07dc(char* c){
+int daSCoin_c_InitResources(char* c){
+    struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0x64000, 0x40000, 0x800002, 0);
-    *(unsigned char*)(c + 0x10d) = *(unsigned int*)(c + 8) & 0xf;
-    *(unsigned char*)(c + 0x10e) = (*(unsigned int*)(c + 8) >> 8) & 0xf;
-    *(unsigned char*)(c + 0x10f) = 0;
-    *(int*)(c + 0x108) = 0;
-    *(unsigned char*)(c + 0x110) = 0;
-    *(unsigned char*)(c + 0x113) = 0;
+    self->unk_10d = *(unsigned int*)(c + 8) & 0xf;
+    self->unk_10e = (*(unsigned int*)(c + 8) >> 8) & 0xf;
+    self->unk_10f = 0;
+    self->unk_108 = 0;
+    self->unk_110 = 0;
+    self->unk_113 = 0;
     _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9a8);
     return 1;
 }

--- a/src/func_ov002_020f11b0.c
+++ b/src/func_ov002_020f11b0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020f11b0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjBC_Switch_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov002_020f11b0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjBC_Switch_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020f11f4.c
+++ b/src/func_ov002_020f11f4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov002_020f11f4
+// @emits daObjBC_Switch_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjBC_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov002_020f11f4(int *t)
+int *daObjBC_Switch_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov002_020f124c.c
+++ b/src/func_ov002_020f124c.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov002_020f124c
+// @emits daObjBC_Switch_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBC_Switch_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov002_020f124c(void *t)
+int daObjBC_Switch_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov002_020f1290.cpp
+++ b/src/func_ov002_020f1290.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov002_020f1290
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjBC_Switch_c.h"
+// @emits daObjBC_Switch_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjBC_Switch_c::Render - recovered from vtable slot identity */
 struct Base {
     virtual void v0();
     virtual void v1();
@@ -8,8 +14,9 @@ struct Base {
     virtual void m(int);
 };
 
-extern "C" int func_ov002_020f1290(char *o) {
-    if (*(int *)(o + 0x60) > *(int *)(o + 0x320)) {
+extern "C" int daObjBC_Switch_c_Render(char *o) {
+    struct daObjBC_Switch_c *self = (struct daObjBC_Switch_c *)(void *)o;
+    if (self->unk_060 > self->unk_320) {
         Base *bp = (Base *)(o + 0xd4);
         bp->m(0);
     }

--- a/src/func_ov002_020f12c8.c
+++ b/src/func_ov002_020f12c8.c
@@ -1,3 +1,9 @@
+// @symbol func_ov002_020f12c8
+// @emits daObjBC_Switch_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBC_Switch_c::Behavior - recovered from vtable slot identity */
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -8,17 +14,15 @@ typedef unsigned int u32;
 extern u8 IsAreaShowing(s32 idx);
 extern s32 _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 a, s32 vol);
 extern void _ZN5Event6SetBitEj(u32 bit);
-extern void _ZN16MeshColliderBase7DisableEv(void *self);
 extern void _ZN5Actor8PoofDustEv(void *self);
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-extern s32 func_02012310(s32 a, s32 b, s32 c);
 extern void *_ZN5Actor15FindWithActorIDEjPS_(u32 id, void *prev);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern s32 _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, s32 a, s32 b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 
-s32 func_ov002_020f12c8(void *arg0)
+s32 daObjBC_Switch_c_Behavior(void *arg0)
 {
     char *c = (char *)arg0;
     u16 t;
@@ -30,8 +34,8 @@ s32 func_ov002_020f12c8(void *arg0)
     }
     if (*(u8 *)(c + 0x32c) == 1) {
         if (*(s32 *)(c + 0x60) > *(s32 *)(c + 0x320)) {
-            *(s32 *)((int)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL)) =
-                *(s32 *)((int)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL)) - 0x14000;
+            *(s32 *)((int)(((long long)(int)(c + 0x60)))) =
+                *(s32 *)((int)(((long long)(int)(c + 0x60)))) - 0x14000;
             if (*(s32 *)(c + 0x60) <= *(s32 *)(c + 0x320)) {
                 *(s32 *)(c + 0x60) = *(s32 *)(c + 0x320);
                 _ZN5Event6SetBitEj(*(u8 *)(c + 0x32d));

--- a/src/func_ov002_020f1468.c
+++ b/src/func_ov002_020f1468.c
@@ -1,3 +1,11 @@
+// @symbol func_ov002_020f1468
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjBC_Switch_c.h"
+// @emits daObjBC_Switch_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjBC_Switch_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
 typedef short s16;
 
@@ -12,13 +20,10 @@ extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10C
     void* mc, void* f, void* mtx, Fix12i fx, short s, void* clps);
 extern void func_020393c4(void* p, void* v);
 
-extern char data_ov002_02110acc;
-extern char data_ov002_02110ac4;
-extern char data_ov002_0210d6f4;
-extern void func_ov002_020f15b8(void);
 
-int func_ov002_020f1468(char* c)
+int daObjBC_Switch_c_InitResources(char* c)
 {
+    struct daObjBC_Switch_c *self = (struct daObjBC_Switch_c *)(void *)c;
     void* bmd;
     void* kcl;
     int y;
@@ -29,27 +34,27 @@ int func_ov002_020f1468(char* c)
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_02110acc);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, bmd, 1, -1);
 
-    *(unsigned char*)(c + 0x32d) = *(int*)(c + 8) & 0xf;
+    self->unk_32d = *(int*)(c + 8) & 0xf;
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
 
     kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov002_02110ac4);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, kcl, c + 0x2ec, 0x199, *(s16*)(c + 0x8e),
+        c + 0x124, kcl, c + 0x2ec, 0x199, self->unk_08e,
         &data_ov002_0210d6f4);
 
     func_020393c4(c + 0x124, (void*)&func_ov002_020f15b8);
 
-    *(unsigned char*)(c + 0x32c) = 0;
+    self->unk_32c = 0;
 
     /* Keep p out of the mid-block so y colors r1 and c+0x300 colors r0,
        and so set_fa rematerializes add r0,r4,#0x300 after ldrh clobbers r0. */
-    y = *(int*)(c + 0x60);
-    *(int*)((char*)c + 0x320) = y - 0x64000;
+    y = self->unk_060;
+    self->unk_320 = y - 0x64000;
     x = *(unsigned int*)(c + 8);
-    *(unsigned short*)(c + 0x32a) = (x >> 8) & 0xff;
-    *(unsigned char*)(c + 0x32e) = *(signed char*)(c + 0xcc);
-    val = *(unsigned short*)(c + 0x32a);
+    self->unk_32a = (x >> 8) & 0xff;
+    self->unk_32e = self->unk_0cc;
+    val = self->unk_32a;
     p = (unsigned short*)(c + 0x300);
 
     /* ROM: if (val==0xff || val==0) store 0xfa; else *= 10 */

--- a/src/func_ov002_020f6f48.c
+++ b/src/func_ov002_020f6f48.c
@@ -1,7 +1,10 @@
+// @symbol func_ov002_020f6f48
+/* recovered: shared common types */
+#include "common.h"
 typedef int s32;
 typedef short s16;
 typedef long long s64;
-struct Vector3 { s32 x, y, z; };
+
 extern s16 Vec3_VertAngle(const struct Vector3* v1, const struct Vector3* v0);
 extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
 extern void ApproachAngle(s16* target, s16 cur, int a, int step, int flag);

--- a/src/func_ov002_020f7038.c
+++ b/src/func_ov002_020f7038.c
@@ -1,10 +1,12 @@
-extern void func_ov002_020f6514(unsigned char* self, void* tbl, unsigned char arg);
+// @symbol func_ov002_020f7038
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int p2, int p3, int p4, void* p5, void* p6);
-extern unsigned short data_0209b274;
-extern int data_ov002_0210bc88;
 
-struct Vector3 { int x, y, z; };
+
 
 int func_ov002_020f7038(char* c, int a, int arg)
 {
@@ -15,11 +17,11 @@ int func_ov002_020f7038(char* c, int a, int arg)
     }
     if (*(int*)(c + 0x60) >= 0x514000) {
         if (*(int*)(c + 0xf8) < 0x3c000) {
-            *(int*)(((long long)(int)(c + 0xf8)) & 0xFFFFFFFFFFFFFFFFLL) += 0x5000;
+            *(int*)(((long long)(int)(c + 0xf8))) += 0x5000;
         }
     } else {
         if (*(int*)(c + 0xf8) > 0x1a000) {
-            *(int*)(((long long)(int)(c + 0xf8)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x2000;
+            *(int*)(((long long)(int)(c + 0xf8))) -= 0x2000;
         }
     }
     {
@@ -28,7 +30,7 @@ int func_ov002_020f7038(char* c, int a, int arg)
             func_ov002_020f6514((unsigned char*)obj, &data_ov002_0210bc88, 1);
         }
     }
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -=
+    *(int*)(((long long)(int)(c + 0x60))) -=
         (int)(((long long)*(int*)(c + 0xf8) * 0x199 + 0x800) >> 12);
     {
         struct Vector3 pos;

--- a/src/func_ov002_020f71c4.c
+++ b/src/func_ov002_020f71c4.c
@@ -1,9 +1,13 @@
+// @symbol func_ov002_020f71c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int p2, int p3, int p4, void* p5, void* p6);
-extern unsigned short data_0209b274;
 
-struct Vector3 { int x, y, z; };
+
 
 int func_ov002_020f71c4(char* c, int a, int arg)
 {

--- a/src/func_ov002_020f897c.c
+++ b/src/func_ov002_020f897c.c
@@ -1,11 +1,14 @@
+// @symbol func_ov002_020f897c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int s32;
 typedef short s16;
 typedef signed char s8;
 typedef unsigned char u8;
 
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 
 extern void* _ZN5Actor18ClosestWithActorIDEj(void* self, u32 id);
 extern int RandomIntInternal(int* seed);

--- a/src/func_ov002_020f92e4.c
+++ b/src/func_ov002_020f92e4.c
@@ -1,4 +1,8 @@
-int func_ov002_020f92e4(char *p)
+// @symbol func_ov002_020f92e4
+// @emits Fireball_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daFPknBall_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Fireball_OnYoshiTryEat(char *p)
 {
     unsigned char b = *(unsigned char *)(p + 0x36d);
     if (b != 0 && b != 4)


### PR DESCRIPTION
Batch 09 of the readable-tree migration. Promotes 188 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 134 VERIFIED, 54 BLIND, 0 WRONG/NO-REPRO. 2 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
