### PR TITLE
readable: batch 10 - promote 190 files to readable form

### DIFF
--- a/src/func_ov002_020f9370.c
+++ b/src/func_ov002_020f9370.c
@@ -1,8 +1,11 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov002_020f9370(int *t)
+// @symbol func_ov002_020f9370
+// @emits daSoundObj_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daSoundObj_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *daSoundObj_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020f94fc.cpp
+++ b/src/func_ov002_020f94fc.cpp
@@ -1,22 +1,28 @@
 //cpp
+// @symbol func_ov002_020f94fc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daSoundObj_c.h"
+// @emits daSoundObj_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daSoundObj_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef int (C::*PMF)(void*);
 extern PMF data_ov002_0211110c[];
-extern int data_0208e430;
-extern int data_0209b49c;
-extern int data_0209b490;
 
 extern "C" {
 void _ZN9ActorBase18MarkForDestructionEv(C* c);
 void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int d, int f, bool g);
 
-int func_ov002_020f94fc(char* cc)
+int daSoundObj_c_Behavior(char* cc)
 {
+    struct daSoundObj_c *self = (struct daSoundObj_c *)(void *)cc;
     C* c = (C*)cc;
     int sel = *(int*)(cc + 8);
     int r = (c->*data_ov002_0211110c[sel])(cc + 0xdc);
-    if (r == 0 && *(int*)(cc + 0xd4) == data_0208e430
-        && (*(unsigned short*)(cc + 0xdc) <= 0xa || data_0209b49c > 0x7f)) {
+    if (r == 0 && self->unk_0d4 == data_0208e430
+        && (self->unk_0dc <= 0xa || data_0209b49c > 0x7f)) {
         goto skip;
     }
     _ZN9ActorBase18MarkForDestructionEv(c);
@@ -25,7 +31,7 @@ int func_ov002_020f94fc(char* cc)
     }
 skip:
     if (*(int*)(cc + 8) != 6) {
-        if (data_0209b490 < *(int*)(cc + 0xd8)) *(unsigned short*)(cc + 0xdc) = *(unsigned short*)(cc + 0xde);
+        if (data_0209b490 < self->unk_0d8) self->unk_0dc = self->unk_0de;
     }
     return 1;
 }

--- a/src/func_ov002_020f95e0.c
+++ b/src/func_ov002_020f95e0.c
@@ -1,16 +1,17 @@
+// @symbol func_ov002_020f95e0
+// @emits daSoundObj_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daSoundObj_c::InitResources - recovered from vtable slot identity */
 #pragma opt_loop_invariants off
 
-extern int data_ov002_0210c080[];
-extern int data_ov002_0210c084[];
-extern unsigned short data_ov002_0210c088[];
-extern unsigned char data_ov002_0210c08a[];
-extern int data_0208e430;
 
 extern void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *prev);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *thiz);
 extern void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int d, int e);
 
-int func_ov002_020f95e0(void *self)
+int daSoundObj_c_InitResources(void *self)
 {
     char *c = (char *)self;
     void *a;

--- a/src/func_ov002_020feb50.cpp
+++ b/src/func_ov002_020feb50.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov002_020feb50
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern "C" char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN5Sound4PlayEjjRK7Vector3(unsigned int a, unsigned int b, Vector3 const & v);

--- a/src/func_ov002_020fed7c.c
+++ b/src/func_ov002_020fed7c.c
@@ -1,13 +1,16 @@
+// @symbol func_ov002_020fed7c
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov002_020fed7c(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x31c) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x31c) = data_020a0e68;
 }

--- a/src/func_ov003_020ad660.c
+++ b/src/func_ov003_020ad660.c
@@ -1,12 +1,14 @@
+// @symbol func_ov003_020ad660
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dScTitle_c; VT1 = _ZTV8dScene_c; VT2 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *func_ov003_020ad660(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV10dScTitle_c;
+    t[0] = (int)_ZTV8dScene_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/func_ov003_020ad69c.c
+++ b/src/func_ov003_020ad69c.c
@@ -1,11 +1,15 @@
+// @symbol func_ov003_020ad69c
+// @emits dScTitle_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *self);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, void *heap);
-extern int data_ov003_020b1650[];
 extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void *data_020a0eac;
 
-int *func_ov003_020ad69c(int *t)
+int *dScTitle_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)data_ov003_020b1650;
     t[0] = (int)_ZTV5Stage;

--- a/src/func_ov003_020ad7a0.c
+++ b/src/func_ov003_020ad7a0.c
@@ -1,3 +1,7 @@
-void func_ov003_020ad7a0(void)
+// @symbol func_ov003_020ad7a0
+// @emits dScTitle_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScTitle_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov003_020ad7a4.cpp
+++ b/src/func_ov003_020ad7a4.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov003_020ad7a4
+// @emits dScTitle_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::Render - recovered from vtable slot identity */
 extern "C" {
 extern int data_0209b2f4;
-extern int data_0209b2f8;
-extern int data_0209e664;
 extern char data_0209e674[];
 }
 struct OamTmp { int x; };
 namespace OAM { void EnableSubOAM(OamTmp*); }
-extern "C" int func_ov003_020ad7a4(void)
+extern "C" int dScTitle_c_Render(void)
 {
     OamTmp tmp;
     OAM::EnableSubOAM(&tmp);

--- a/src/func_ov003_020ad814.cpp
+++ b/src/func_ov003_020ad814.cpp
@@ -1,5 +1,11 @@
 //cpp
-/* func_ov003_020ad814 @ 0x020ad814 (ov003, size 0x26c)
+// @symbol func_ov003_020ad814
+// @emits dScTitle_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::Behavior - recovered from vtable slot identity */
+/* dScTitle_c_Behavior @ 0x020ad814 (ov003, size 0x26c)
  * Level-select cursor update: on confirm (or minigame-active flag) starts the
  * scene fade / loads the picked level from the 8-byte entry table at
  * data_ov003_020b1180; otherwise moves the cursor by row (+0x35) or column
@@ -26,8 +32,6 @@ extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];
 extern u16 data_020a0e58[];
 extern u32 data_0209b2f4;
-extern s8 data_ov003_020b1180[];
-extern u8 data_ov003_020b1181[];
 extern u8 data_0209f2d8;
 extern u16 data_0209f5e8[];
 
@@ -35,13 +39,10 @@ extern "C" {
 extern void func_02012790(int idx);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
 extern void _ZN5Sound22StopLoadedMusic_Layer1Ej(u32 a);
-extern void LoadLevelNoReturn(int levelID, u32 a1, u32 a2, u32 a3);
-extern void SetPlayerGlobals(void);
-extern void SetNumPlayers(int n);
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void func_ov003_020ad6ec(char *c);
 
-int func_ov003_020ad814(char *c)
+int dScTitle_c_Behavior(char *c)
 {
     if (data_0209f5bc->v5()) {
         int r3 = 0;

--- a/src/func_ov003_020ada80.c
+++ b/src/func_ov003_020ada80.c
@@ -1,5 +1,9 @@
+// @symbol func_ov003_020ada80
+// @emits dScTitle_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void *);
-int func_ov003_020ada80(void *t)
+int dScTitle_c_CleanupResources(void *t)
 {
     _ZN5Sound21UnsetPlayerVoiceGroupEv(t);
     return 1;

--- a/src/func_ov003_020ada9c.cpp
+++ b/src/func_ov003_020ada9c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov003_020ada9c
+// @emits dScTitle_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScTitle_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -30,7 +34,7 @@ namespace GX {
 namespace G2 { unsigned short *GetBG0ScrPtr(); }
 namespace Sound { void LoadInitialGroup(int); void LoadAndSetMusic_Layer1(int); }
 
-extern "C" int func_ov003_020ada9c(int arg)
+extern "C" int dScTitle_c_InitResources(int arg)
 {
     UnloadArchives();
     Enable3dEngines();

--- a/src/func_ov003_020ade54.c
+++ b/src/func_ov003_020ade54.c
@@ -1,12 +1,16 @@
-extern int data_ov003_020b1704[];
-extern void _ZN5ModelD1Ev(void*);
+// @symbol func_ov003_020ade54
+// @emits dScStarSel_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScStarSel_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_0207328c(void*, int, int, void*);
 extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void _ZN9ActorBaseD2Ev(void*);
 extern void* data_020a0eac;
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
-int* func_ov003_020ade54(int* t){
+int* dScStarSel_c_OnYoshiTryEat(int* t){
   t[0]=(int)data_ov003_020b1704;
   func_0207328c((char*)t+0x64, 2, 0x50, (void*)_ZN5ModelD1Ev);
   t[0]=(int)_ZTV5Stage;

--- a/src/func_ov003_020ae6f0.c
+++ b/src/func_ov003_020ae6f0.c
@@ -1,3 +1,7 @@
-void func_ov003_020ae6f0(void)
+// @symbol func_ov003_020ae6f0
+// @emits dScStarSel_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScStarSel_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScStarSel_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov003_020af86c.cpp
+++ b/src/func_ov003_020af86c.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol func_ov003_020af86c
+// @emits dScStarSel_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScStarSel_c::CleanupResources - recovered from vtable slot identity */
 class Sound {
 public:
     static void UnsetPlayerVoiceGroup();
 };
 
-extern void CleanCommonModelDataArr(void);
 
-extern "C" int func_ov003_020af86c(void) {
+extern "C" int dScStarSel_c_CleanupResources(void) {
     CleanCommonModelDataArr();
     Sound::UnsetPlayerVoiceGroup();
     unsigned short *p = (unsigned short *)0x4000304;

--- a/src/func_ov003_020b0580.c
+++ b/src/func_ov003_020b0580.c
@@ -1,12 +1,14 @@
+// @symbol func_ov003_020b0580
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13dScGameOver_c; VT1 = _ZTV8dScene_c; VT2 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *func_ov003_020b0580(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV13dScGameOver_c;
+    t[0] = (int)_ZTV8dScene_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/func_ov003_020b05bc.c
+++ b/src/func_ov003_020b05bc.c
@@ -1,10 +1,12 @@
+// @symbol func_ov003_020b05bc
+// @emits dScGameOver_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* dScGameOver_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 extern void *G0;
-int *func_ov003_020b05bc(int *t)
+int *dScGameOver_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov003_020b0810.c
+++ b/src/func_ov003_020b0810.c
@@ -1,3 +1,7 @@
-void func_ov003_020b0810(void)
+// @symbol func_ov003_020b0810
+// @emits dScGameOver_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScGameOver_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScGameOver_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov003_020b0814.cpp
+++ b/src/func_ov003_020b0814.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov003_020b0814
+// @emits dScGameOver_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Stage.h"
+/* recovered: renamed to Class_Method */
+/* dScGameOver_c::Render - recovered from vtable slot identity */
 extern "C" {
 typedef int s32;
 typedef int Fix12i;
@@ -9,9 +15,8 @@ extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
     bool32 sub, struct OamAttri *data, s32 x, s32 y,
     s32 palette, s32 priority, Fix12i scaleX, Fix12i scaleY,
     s32 rotation, s32 mode);
-extern void _ZN5Stage20RenderBouncingArrowsEv(void);
-int func_ov003_020b0814(char *c);
-int func_ov003_020b0814(char *c) {
+int dScGameOver_c_Render(char *c);
+int dScGameOver_c_Render(char *c) {
     int i;
     for (i = 0; i < 8; i++) {
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(

--- a/src/func_ov003_020b0b34.c
+++ b/src/func_ov003_020b0b34.c
@@ -1,4 +1,8 @@
-int func_ov003_020b0b34(void)
+// @symbol func_ov003_020b0b34
+// @emits dScGameOver_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScGameOver_c::CleanupResources - recovered from vtable slot identity */
+int dScGameOver_c_CleanupResources(void)
 {
     return 1;
 }

--- a/src/func_ov003_020b0b3c.c
+++ b/src/func_ov003_020b0b3c.c
@@ -1,25 +1,17 @@
+// @symbol func_ov003_020b0b3c
+// @emits dScGameOver_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScGameOver_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern void func_02019028(void);
-extern void _ZN2GX15DisableAllBanksEv(void);
 extern void _ZN2GX12SetBankForBGEt(u16 v);
 extern void _ZN2GX13SetBankForOBJEt(u16 v);
 extern void _ZN2GX15SetBankForSubBGEt(u16 v);
 extern void _ZN2GX16SetBankForSubOBJEt(u16 v);
-extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
-extern void _ZN3GXS15SetGraphicsModeEi(int a);
-extern void _ZN2GX6DispOnEv(void);
-extern void SetBg0Offset(int a, int b);
-extern void SetBg1Offset(int a, int b);
-extern void SetBg2Offset(int a, int b);
-extern void SetSubBg0Offset(int a, int b);
-extern void SetSubBg1Offset(int a, int b);
-extern void SetSubBg2Offset(int a, int b);
-extern void LoadDebugFont(void);
-extern void LoadFont(u8 a);
-extern int GetOwnerLanguage(void);
 extern int LoadFile(int handle);
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern void *_ZN2G212GetBG2ScrPtrEv(void);
@@ -28,22 +20,16 @@ extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern void *_ZN3G2S12GetBG2ScrPtrEv(void);
 extern u32 func_02054e88(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_0201cebc(int a);
-extern void func_ov003_020b0730(void *self, int a);
-extern void _ZN5Sound16LoadInitialGroupEi(int a);
-extern void _ZN5Sound22LoadAndSetMusic_Layer1Ei(int a);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 extern u8 data_0209f204;
 extern int data_0208ee44;
-extern short data_ov003_020b1764[];
 
-int func_ov003_020b0b3c(void *arg)
+int dScGameOver_c_InitResources(void *arg)
 {
     char *c = (char *)arg;
     int f;

--- a/src/func_ov004_020ae128.c
+++ b/src/func_ov004_020ae128.c
@@ -1,4 +1,11 @@
+// @symbol func_ov004_020ae128
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_OnPushed
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnPushed - recovered from vtable slot identity */
 
-int func_ov004_020ae128(void *c) {
-    return *(int *)((char *)c + 0x4628) == 0;
+int dScMgBase_c_OnPushed(void *c) {
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
+    return self->unk_4628 == 0;
 }

--- a/src/func_ov004_020ae140.cpp
+++ b/src/func_ov004_020ae140.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov004_020ae140
+// @emits dScMgBase_c_OnKicked
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnKicked - recovered from vtable slot identity */
 struct Obj {
     virtual void v00(); virtual void v04(); virtual void v08(); virtual void v0c();
     virtual void v10(); virtual void v14(); virtual void v18(); virtual void v1c();
@@ -12,9 +16,9 @@ struct Obj {
     virtual void method78();
 };
 
-extern "C" int func_ov004_020ae140(Obj* self);
+extern "C" int dScMgBase_c_OnKicked(Obj* self);
 
-int func_ov004_020ae140(Obj* self) {
+int dScMgBase_c_OnKicked(Obj* self) {
     void* base = (char*)self + 0x4000;
     int v2 = *(int*)((char*)base + 0x628);
     int v1 = *(int*)((char*)base + 0x62c);

--- a/src/func_ov004_020ae198.c
+++ b/src/func_ov004_020ae198.c
@@ -1,4 +1,8 @@
-int func_ov004_020ae198(void)
+// @symbol func_ov004_020ae198
+// @emits dScMgBase_c_OnAttacked1
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnAttacked1 - recovered from vtable slot identity */
+int dScMgBase_c_OnAttacked1(void)
 {
     return 1;
 }

--- a/src/func_ov004_020ae1a0.c
+++ b/src/func_ov004_020ae1a0.c
@@ -1,4 +1,8 @@
-int func_ov004_020ae1a0(void)
+// @symbol func_ov004_020ae1a0
+// @emits dScMgBase_c_OnAttacked2
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnAttacked2 - recovered from vtable slot identity */
+int dScMgBase_c_OnAttacked2(void)
 {
     return 1;
 }

--- a/src/func_ov004_020aeed8.cpp
+++ b/src/func_ov004_020aeed8.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov004_020aeed8
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_OnAimedAtWithEggReturnVec
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -10,7 +18,6 @@ extern "C" u8 data_0209d458;
 
 extern "C" int _ZN2GX10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
 extern "C" int _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern "C" void MultiCopy_Int(int* dst, int* src, int len);
 
 struct Obj {
     virtual int f00();
@@ -42,8 +49,9 @@ struct Obj {
     virtual int f68();
 };
 
-extern "C" void func_ov004_020aeed8(char* c)
+extern "C" void dScMgBase_c_OnAimedAtWithEggReturnVec(char* c)
 {
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     Obj* o = (Obj*)c;
 
     data_0209d45c = 0;
@@ -51,7 +59,7 @@ extern "C" void func_ov004_020aeed8(char* c)
 
     *(u32*)0x4000000 &= ~0x1f00;
     *(u32*)0x4001000 &= ~0x1f00;
-    *(u16*)0x4000304 = (*(u32*)(c + 0x224) << 15) | (*(u16*)0x4000304 & ~0x8000);
+    *(u16*)0x4000304 = (self->unk_224 << 15) | (*(u16*)0x4000304 & ~0x8000);
     *(u32*)0x4000000 = (*(u32*)0x4000000 & ~0xe000) | ((u32)data_0209d460 << 13);
     *(u32*)0x4001000 = (*(u32*)0x4001000 & ~0xe000) | ((u32)data_0209d458 << 13);
 
@@ -67,8 +75,8 @@ extern "C" void func_ov004_020aeed8(char* c)
         MultiCopy_Int((int*)(c + 0x2228), (int*)src, 0x2000);
     }
 
-    data_0209d45c = (u8)*(u32*)(c + 0x21c);
-    data_0209d454 = (u8)*(u32*)(c + 0x220);
+    data_0209d45c = (u8)self->unk_21c;
+    data_0209d454 = (u8)self->unk_220;
 
     if (o->f68() == 2)
         return;

--- a/src/func_ov004_020af04c.cpp
+++ b/src/func_ov004_020af04c.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol func_ov004_020af04c
+// @emits dScMgBase_c_OnHitFromUnderneath
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnHitFromUnderneath - recovered from vtable slot identity */
 extern "C" void func_02012e1c(char *c);
-extern "C" void func_ov004_020b91fc(char *c);
 extern "C" void Enable3dEngines();
 
 struct Base {
@@ -38,7 +43,7 @@ struct Obj : Base {
     char pad[0x4627];
 };
 
-extern "C" void func_ov004_020af04c(Obj *self) {
+extern "C" void dScMgBase_c_OnHitFromUnderneath(Obj *self) {
     func_02012e1c((char*)self);
     *(int*)((char*)self + 0x4628) = 0;
     func_ov004_020b91fc((char*)self + 0xf4);

--- a/src/func_ov004_020af094.cpp
+++ b/src/func_ov004_020af094.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov004_020af094
+// @emits dScMgBase_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 typedef unsigned short u16;
 typedef short s16;
 
-extern "C" void func_02019028(void);
-extern "C" void MultiCopy_Int(int *dst, int *src, int len);
 extern "C" void _ZN4CP1527FlushAndInvalidateDataCacheEjj(void *addr, unsigned int size);
 extern "C" void _ZN2GX10LoadBGPlttEPKvjj(const void *src, unsigned int offset, unsigned int size);
 extern "C" void _ZN3GXS10LoadBGPlttEPKvjj(const void *src, unsigned int offset, unsigned int size);
@@ -14,9 +18,6 @@ extern "C" void DecompressLZ16(void *src, void *dst);
 
 extern "C" unsigned char data_0209d45c;
 extern "C" unsigned char data_0209d454;
-extern "C" char data_ov004_020bea28[];
-extern "C" char data_ov004_020beac8[];
-extern "C" void *data_ov004_020bbf94[];
 
 struct Base {
     virtual void d0();
@@ -53,7 +54,7 @@ struct Obj : Base {
     char pad[0x4700];
 };
 
-extern "C" void func_ov004_020af094(Obj *self)
+extern "C" void dScMgBase_c_OnAimedAtWithEgg(Obj *self)
 {
     char *c = (char *)self;
 

--- a/src/func_ov004_020af27c.c
+++ b/src/func_ov004_020af27c.c
@@ -1,17 +1,25 @@
-extern void func_02012e78(void);
+// @symbol func_ov004_020af27c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnHitByMegaChar - recovered from vtable slot identity */
 
-void func_ov004_020af27c(void *c)
+void dScMgBase_c_OnHitByMegaChar(void *c)
 {
-    if (*(int*)((char*)c+0x4630) != 0) return;
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
+    if (self->unk_4630 != 0) return;
     func_02012e78();
-    *(short*)((char*)c+0x4634) = -0x80;
-    *(short*)((char*)c+0x4636) = 0x30;
-    *(short*)((char*)c+0x4638) = 0x180;
-    *(short*)((char*)c+0x463a) = 0x60;
-    *(short*)((char*)c+0x463c) = 0x80;
-    *(short*)((char*)c+0x463e) = 0xe0;
-    *(unsigned char*)((char*)c+0xc3) = 0;
-    *(int*)((char*)c+0x4628) = 1;
-    *(short*)((char*)c+0x4646) = -1;
-    *(int*)((char*)c+0x4640) = 0;
+    self->unk_4634 = -0x80;
+    self->unk_4636 = 0x30;
+    self->unk_4638 = 0x180;
+    self->unk_463a = 0x60;
+    self->unk_463c = 0x80;
+    self->unk_463e = 0xe0;
+    self->unk_0c3 = 0;
+    self->unk_4628 = 1;
+    self->unk_4646 = -1;
+    self->unk_4640 = 0;
 }

--- a/src/func_ov004_020b04e0.c
+++ b/src/func_ov004_020b04e0.c
@@ -1,4 +1,8 @@
-int func_ov004_020b04e0(void)
+// @symbol func_ov004_020b04e0
+// @emits dScMgBase_c_OnHitByCannonBlastedChar
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
+int dScMgBase_c_OnHitByCannonBlastedChar(void)
 {
     return 0;
 }

--- a/src/func_ov004_020b04e8.c
+++ b/src/func_ov004_020b04e8.c
@@ -1,3 +1,7 @@
-void func_ov004_020b04e8(void)
+// @symbol func_ov004_020b04e8
+// @emits dScMgBase_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScMgBase_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov004_020b04ec.c
+++ b/src/func_ov004_020b04ec.c
@@ -1,4 +1,8 @@
-int func_ov004_020b04ec(void)
+// @symbol func_ov004_020b04ec
+// @emits dScMgBase_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::Render - recovered from vtable slot identity */
+int dScMgBase_c_Render(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b04f4.cpp
+++ b/src/func_ov004_020b04f4.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov004_020b04f4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_BeforeRender
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::BeforeRender - recovered from vtable slot identity */
 // NONMATCHING: register allocation (div=17). Logic verified correct vs ROM; not
 // byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
 // Counts as decompiled, not matched.
@@ -6,19 +14,13 @@ typedef short s16;
 
 struct Scene;
 extern "C" int _ZN5Scene12BeforeRenderEv(struct Scene *);
-extern "C" int func_ov004_020ae858(void *c);
-extern "C" void func_ov004_020b31b4(void *c);
-extern "C" void func_ov004_020b8714(void *c);
-extern "C" void func_ov004_020add88(void *c);
-extern "C" void func_ov004_020b0de0(void *c);
 
-extern char data_ov004_020bf648[];
-extern char data_ov004_020bebe8[];
 
 struct Ent { char pad[0x1a]; s16 f; char pad2[4]; };
 
-extern "C" int func_ov004_020b04f4(void *c)
+extern "C" int dScMgBase_c_BeforeRender(void *c)
 {
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     int i;
     char *p;
     int i2;
@@ -28,12 +30,12 @@ extern "C" int func_ov004_020b04f4(void *c)
     if (_ZN5Scene12BeforeRenderEv((struct Scene *)c) == 0)
         return 0;
 
-    if (*(int *)((char *)c + 0x4628) != 0) {
+    if (self->unk_4628 != 0) {
         func_ov004_020ae858(c);
         return 0;
     }
 
-    if (*(int *)((char *)c + 0xf0) == 0) {
+    if (self->unk_0f0 == 0) {
         p = data_ov004_020bf648;
         for (i = 0; i < 3; i++, p += 0x134) {
             if (*(int *)(p + 0x20) == 0x1d) continue;

--- a/src/func_ov004_020b0618.c
+++ b/src/func_ov004_020b0618.c
@@ -1,4 +1,8 @@
-int func_ov004_020b0618(void)
+// @symbol func_ov004_020b0618
+// @emits dScMgBase_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::Behavior - recovered from vtable slot identity */
+int dScMgBase_c_Behavior(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b0620.cpp
+++ b/src/func_ov004_020b0620.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol func_ov004_020b0620
+// @emits dScMgBase_c_BeforeBehavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::BeforeBehavior - recovered from vtable slot identity */
 extern "C" {
 int func_ov004_020b8ee0(char *p);
 void func_ov004_020aeb24(char *c);
@@ -33,14 +40,11 @@ extern Scene *data_0209f5bc;
 extern unsigned char data_020a0e40;
 extern unsigned short data_020a0e5a[];
 extern unsigned char data_020a0de8[];
-extern char data_ov004_020bf648[];
-extern char data_ov004_020bebe8[];
 extern int data_0208ee44;
 
-extern "C" int _ZN5Scene14BeforeBehaviorEv();
 
 #pragma opt_strength_reduction off
-extern "C" int func_ov004_020b0620(char *self)
+extern "C" int dScMgBase_c_BeforeBehavior(char *self)
 {
     int mode;
     unsigned short flags;

--- a/src/func_ov004_020b0840.c
+++ b/src/func_ov004_020b0840.c
@@ -1,16 +1,23 @@
+// @symbol func_ov004_020b0840
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_AfterCleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::AfterCleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void);
 extern void func_ov004_020b0aa0(int arg);
 extern void func_0203cbc0(void);
 extern void func_02012e1c(void);
 extern void _ZN5Sound22StopLoadedMusic_Layer1Ej(unsigned int x);
-extern void func_ov004_020b2c84(void);
-extern void _ZN5Scene21AfterCleanupResourcesEj(char* c, unsigned int x);
 extern int data_0209b308[];
 extern int data_0209d4a8[];
-extern int data_ov004_020beb74[];
 extern int data_ov004_020beb60[];
 
-void func_ov004_020b0840(char* c, int arg){
+void dScMgBase_c_AfterCleanupResources(char* c, int arg){
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
   if (arg == 2) {
     if (data_0209b308[4] == 0)
       func_ov004_020ad90c();
@@ -21,7 +28,7 @@ void func_ov004_020b0840(char* c, int arg){
       func_0203cbc0();
       data_ov004_020beb60[0] = 0;
     }
-    if (*(int*)(c + 0x4628) != 0) {
+    if (self->unk_4628 != 0) {
       func_02012e1c();
       _ZN5Sound22StopLoadedMusic_Layer1Ej(1);
     }

--- a/src/func_ov004_020b08f0.cpp
+++ b/src/func_ov004_020b08f0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov004_020b08f0
+// @emits dScMgBase_c_AfterInitResources
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::AfterInitResources - recovered from vtable slot identity */
 extern "C" {
     void LoadFont(int n);
     void func_ov004_020ae330();
@@ -17,7 +21,7 @@ struct Scene {
     void AfterInitResources(unsigned int flags);
 };
 
-extern "C" void func_ov004_020b08f0(Scene* self, unsigned int flags) {
+extern "C" void dScMgBase_c_AfterInitResources(Scene* self, unsigned int flags) {
     self->targetMethod();
     LoadFont(2);
     func_ov004_020ae330();

--- a/src/func_ov004_020b0930.cpp
+++ b/src/func_ov004_020b0930.cpp
@@ -1,4 +1,13 @@
 //cpp
+// @symbol func_ov004_020b0930
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBase_c.h"
+// @emits dScMgBase_c_BeforeInitResources
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::BeforeInitResources - recovered from vtable slot identity */
 struct Obj {
     virtual void v0();  virtual void v1();  virtual void v2();  virtual void v3();
     virtual void v4();  virtual void v5();  virtual void v6();  virtual void v7();
@@ -12,14 +21,7 @@ struct Obj {
 };
 
 extern "C" {
-extern int _ZN5Scene19BeforeInitResourcesEv(void* thiz);
-extern void func_02019028(void);
 extern void Enable3dEngines(void);
-extern void* _ZN6Memory13operator_new2Ej(unsigned int sz);
-extern void func_ov004_020b8a8c(char* p);
-extern void func_ov004_020b2cb8(void);
-extern void _ZN5Scene9SetFadersEP15FaderBrightness(void* f);
-extern void func_0202ec9c(void* f, int a);
 
 extern char data_0209b308[];
 extern void* data_ov004_020beb60;
@@ -28,21 +30,22 @@ extern char data_0209f61c[];
 extern unsigned char data_0209d460[];
 extern unsigned char data_0209d458[];
 
-int func_ov004_020b0930(char* c)
+int dScMgBase_c_BeforeInitResources(char* c)
 {
+    struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     if (_ZN5Scene19BeforeInitResourcesEv(c) == 0) return 0;
     if (((Obj*)c)->v26() == 0)
         func_02019028();
     else
         Enable3dEngines();
-    *(int*)(c + 0xc8) = *(int*)(data_0209b308 + 0x28);
+    self->unk_0c8 = *(int*)(data_0209b308 + 0x28);
     if (data_ov004_020beb60 == 0)
         data_ov004_020beb60 = _ZN6Memory13operator_new2Ej(0x4000);
     if (data_ov004_020beb68 != 0)
         *(int*)(data_ov004_020beb68 + 0xb0) = 0;
-    *(int*)(c + 0xb4) = 0;
-    *(int*)(c + 0xb8) = 0;
-    *(unsigned char*)(c + 0x465c) = 0;
+    self->unk_0b4 = 0;
+    self->unk_0b8 = 0;
+    self->unk_465c = 0;
     func_ov004_020b8a8c(c + 0x4000);
     ((Obj*)c)->v33();
     func_ov004_020b2cb8();

--- a/src/func_ov004_020b27f4.c
+++ b/src/func_ov004_020b27f4.c
@@ -1,12 +1,14 @@
-extern void SetBg1Offset(int a, int b);
+// @symbol func_ov004_020b27f4
+// @emits dScMgBase_c_AfterClsn
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::AfterClsn - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
-extern void* func_02054ea8(void);
 extern unsigned int LoadCompressedFileAt(int fileID, void *target);
-extern void *_ZN2G212GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d45c[];
-extern int data_ov004_020bbff8[];
 
-void func_ov004_020b27f4(void)
+void dScMgBase_c_AfterClsn(void)
 {
     int f;
     *(volatile unsigned short *)0x400000a = *(volatile unsigned short *)0x400000a & ~3;

--- a/src/func_ov004_020b2880.c
+++ b/src/func_ov004_020b2880.c
@@ -1,12 +1,16 @@
-extern void SetSubBg1Offset(int a, int b);
+// @symbol func_ov004_020b2880
+// @emits dScMgBase_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::Kill - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
 extern unsigned int func_02054e88(void);
 extern unsigned int LoadCompressedFileAt(int fileID, void *target);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454[];
-extern int data_ov004_020bc00c[];
 
-void func_ov004_020b2880(void)
+void dScMgBase_c_Kill(void)
 {
     int f;
     *(volatile unsigned short *)0x400100a = (*(volatile unsigned short *)0x400100a & 0x43) | 0x10;

--- a/src/func_ov004_020b298c.c
+++ b/src/func_ov004_020b298c.c
@@ -1,3 +1,7 @@
-void func_ov004_020b298c(void)
+// @symbol func_ov004_020b298c
+// @emits dScMgBase_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnGroundPounded - recovered from vtable slot identity */
+void dScMgBase_c_OnGroundPounded(void)
 {
 }

--- a/src/func_ov004_020b2990.c
+++ b/src/func_ov004_020b2990.c
@@ -1,3 +1,7 @@
-void func_ov004_020b2990(void)
+// @symbol func_ov004_020b2990
+// @emits dScMgBase_c_Virtual50
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::Virtual50 - recovered from vtable slot identity */
+void dScMgBase_c_Virtual50(void)
 {
 }

--- a/src/func_ov004_020b2994.c
+++ b/src/func_ov004_020b2994.c
@@ -1,4 +1,8 @@
-int func_ov004_020b2994(void)
+// @symbol func_ov004_020b2994
+// @emits dScMgBase_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnTurnIntoEgg - recovered from vtable slot identity */
+int dScMgBase_c_OnTurnIntoEgg(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b299c.c
+++ b/src/func_ov004_020b299c.c
@@ -1,3 +1,7 @@
-void func_ov004_020b299c(void)
+// @symbol func_ov004_020b299c
+// @emits dScMgBase_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgBase_c_OnYoshiTryEat(void)
 {
 }

--- a/src/func_ov004_020b2a18.cpp
+++ b/src/func_ov004_020b2a18.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol func_ov004_020b2a18
+// @emits dScMgBase_c_OnYoshiTryEat_020b2a18
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBase_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 typedef struct Heap Heap;
 void* func_ov004_020b929c(void* self);
 void _ZN9ActorBaseD2Ev(void* t);
 void _ZN6Memory10DeallocateEPvP4Heap(void* p, Heap* h);
-extern void* data_ov004_020bc0c0;
 extern void* data_ov004_020beb68;
 extern void* _ZTV5Stage;
 extern void* data_0208e4b8;
 extern Heap* data_020a0eac;
-void* func_ov004_020b2a18(void* self){
+void* dScMgBase_c_OnYoshiTryEat_020b2a18(void* self){
   char* t=(char*)self;
   *(void**)t = &data_ov004_020bc0c0;
   *(void**)&data_ov004_020beb68 = 0;

--- a/src/func_ov005_020bfec0.c
+++ b/src/func_ov005_020bfec0.c
@@ -1,12 +1,14 @@
+// @symbol func_ov005_020bfec0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11dScMiniGm_c; VT1 = _ZTV8dScene_c; VT2 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *func_ov005_020bfec0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV11dScMiniGm_c;
+    t[0] = (int)_ZTV8dScene_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/func_ov005_020bfefc.c
+++ b/src/func_ov005_020bfefc.c
@@ -1,11 +1,15 @@
+// @symbol func_ov005_020bfefc
+// @emits dScMiniGm_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMiniGm_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *self);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, void *heap);
-extern int data_ov005_020c2490[];
 extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void *data_020a0eac;
 
-int *func_ov005_020bfefc(int *t)
+int *dScMiniGm_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)data_ov005_020c2490;
     t[0] = (int)_ZTV5Stage;

--- a/src/func_ov005_020c0b00.c
+++ b/src/func_ov005_020c0b00.c
@@ -1,3 +1,7 @@
-void func_ov005_020c0b00(void)
+// @symbol func_ov005_020c0b00
+// @emits dScMiniGm_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScMiniGm_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScMiniGm_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov005_020c14a0.c
+++ b/src/func_ov005_020c14a0.c
@@ -1,24 +1,25 @@
+// @symbol func_ov005_020c14a0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMiniGm_c.h"
+// @emits dScMiniGm_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMiniGm_c::Behavior - recovered from vtable slot identity */
 
 extern int func_02012790(int);
-extern int func_ov005_020bff4c(char* c);
 extern int RandomIntInternal(int* seed);
-extern void _ZN5Scene20SetAndStopColorFaderEv(void);
-extern void ExitMinigameMenu(void);
 extern void _ZN5Sound22StopLoadedMusic_Layer1Ej(unsigned int);
-extern void func_ov005_020c0878(char* c);
-extern void func_ov005_020c06cc(char* c);
-extern void func_ov005_020c0378(char* c);
-extern void func_ov005_020c0250(char* c);
-extern void func_ov005_020c0140(char* c);
 
 extern unsigned char data_020a0e40;
 extern unsigned short data_020a0e5a[];
 extern unsigned char data_0209b300;
-extern int data_0209d4b8;
 extern int data_0209e650;
 extern unsigned char data_0209b304;
 
-int func_ov005_020c14a0(char* c) {
+int dScMiniGm_c_Behavior(char* c) {
+    struct dScMiniGm_c *self = (struct dScMiniGm_c *)(void *)c;
     if ((data_020a0e5a[data_020a0e40 << 1] & 0xfff) != 0) {
         func_02012790(0xe);
     }
@@ -29,32 +30,32 @@ int func_ov005_020c14a0(char* c) {
     RandomIntInternal(&data_0209d4b8);
     RandomIntInternal(&data_0209e650);
 
-    if (*(int*)(c+0x90) > 0) {
+    if (self->unk_090 > 0) {
         *(int*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
-        if (*(int*)(c+0x90) == 0) {
+        if (self->unk_090 == 0) {
             data_0209b304 = 0;
-            *(unsigned char*)(c+0x54) = 1;
+            self->unk_054 = 1;
         }
-    } else if (*(int*)(c+0x94) > 0) {
+    } else if (self->unk_094 > 0) {
         *(int*)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
-        if (*(int*)(c+0x94) == 0) {
+        if (self->unk_094 == 0) {
             data_0209b304 = 1;
-            *(unsigned char*)(c+0x54) = 1;
+            self->unk_054 = 1;
         }
-    } else if (*(int*)(c+0x98) > 1) {
+    } else if (self->unk_098 > 1) {
         *(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFULL) -= 1;
-        if (*(int*)(c+0x98) == 1) {
+        if (self->unk_098 == 1) {
             _ZN5Scene20SetAndStopColorFaderEv();
             ExitMinigameMenu();
             _ZN5Sound22StopLoadedMusic_Layer1Ej(0x1e);
-            *(unsigned char*)(c+0xac) = 1;
+            self->unk_0ac = 1;
             return 1;
         }
     } else {
         *(int*)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFFULL) += 1;
-        if (*(int*)(c+0x8c) >= 0x40) *(int*)(c+0x8c) = 0;
+        if (self->unk_08c >= 0x40) self->unk_08c = 0;
         *(int*)(((int)c + 0x9c) & 0xFFFFFFFFFFFFFFFFULL) += 1;
-        if (*(int*)(c+0x9c) >= 0x40) *(int*)(c+0x9c) = 0;
+        if (self->unk_09c >= 0x40) self->unk_09c = 0;
     }
     func_ov005_020c0878(c);
     func_ov005_020c06cc(c);

--- a/src/func_ov005_020c1654.c
+++ b/src/func_ov005_020c1654.c
@@ -1,7 +1,11 @@
-extern int data_0208a174[];
-extern void func_ov005_020c0030(int);
+// @symbol func_ov005_020c1654
+// @emits dScMiniGm_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMiniGm_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void);
-int func_ov005_020c1654(int c)
+int dScMiniGm_c_CleanupResources(int c)
 {
     if (data_0208a174[0] >= 0) {
         func_ov005_020c0030(c);

--- a/src/func_ov005_020c1a20.c
+++ b/src/func_ov005_020c1a20.c
@@ -1,48 +1,31 @@
+// @symbol func_ov005_020c1a20
+// @emits dScMiniGm_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMiniGm_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern void LoadTextNarcs(void);
-extern int LoadArchive(int idx);
-extern void _ZN5Sound19LoadGroupAndSetBankEii(int a, int b);
-extern void func_02019028(void);
-extern void func_ov005_020bffc8(void *a0, int a1, int r2, int r3);
-extern int func_ov005_020bfff4(void *a, int b, int c);
-extern void _ZN2GX15DisableAllBanksEv(void);
-extern void _ZN2GX13SetBankForTexEt(u16 v);
 extern void _ZN2GX12SetBankForBGEt(u16 v);
 extern void _ZN2GX15SetBankForSubBGEt(u16 v);
 extern void _ZN2GX16SetBankForSubOBJEt(u16 v);
 extern void _ZN2GX13SetBankForOBJEt(u16 v);
-extern void _ZN2GX17SetBankForTexPlttEt(u16 v);
-extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
-extern void _ZN3GXS15SetGraphicsModeEi(int a);
-extern void _ZN2GX6DispOnEv(void);
-extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
-extern void InitialiseVramGlobals(void);
-extern void func_020233f4(void);
-extern void SetBg2Offset(int a, int b);
 extern int LoadFile(int handle);
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void *_ZN2G212GetBG2ScrPtrEv(void);
-extern int GetOwnerLanguage(void);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void SetSubBg2Offset(int a, int b);
-extern void SetSubBg3Offset(int a, int b);
 extern void *func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void SetSubBg0Offset(int a, int b);
 extern void *_ZN3G2S13GetBG0CharPtrEv(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 extern void *_ZN3G2S12GetBG0ScrPtrEv(void);
-extern void func_ov005_020c16e4(void *self);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void _ZN5Scene9SetFadersEP15FaderBrightness(void *p);
-extern void _ZN5Sound22LoadAndSetMusic_Layer1Ei(int a);
 
 extern u8 data_0209f5f8;
 extern u32 data_0209caa0[];
@@ -50,9 +33,6 @@ extern u8 data_0209b300;
 extern u8 data_0209b304;
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int data_0208a170;
-extern u8 data_0209f1d8;
-extern u8 data_0209b2fc;
 extern int data_0208ee44;
 extern char data_0209f61c;
 
@@ -66,7 +46,7 @@ typedef struct Entry {
 
 extern Entry data_ov005_020c24d8[];
 
-int func_ov005_020c1a20(void *arg0)
+int dScMiniGm_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     int i, j;

--- a/src/func_ov006_020c0134.c
+++ b/src/func_ov006_020c0134.c
@@ -1,16 +1,21 @@
+// @symbol func_ov006_020c0134
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov006_020c0134 at 0x020c0134
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
  */
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int data[12]; };
+
+struct Matrix4x3_local { int data[12]; };
 
 struct Camera {
-    struct Matrix4x3 viewMat;  /* 0x00 */
+    struct Matrix4x3_local viewMat;  /* 0x00 */
     char pad30[0x30];          /* 0x30 */
-    struct Matrix4x3 projMat;  /* 0x60 */
+    struct Matrix4x3_local projMat;  /* 0x60 */
     char pad90[0x10];          /* 0x90 */
     struct Vector3 eye;        /* 0xa0 */
     struct Vector3 target;     /* 0xac */
@@ -19,10 +24,9 @@ struct Camera {
 
 extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int NormalizeVec3IfNonZero(struct Vector3 *v);
-extern void func_0203cebc(struct Vector3 *out, struct Vector3 *tmp, struct Vector3 *a, struct Vector3 *b);
-extern int _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(int,int,int,int,int,int,int,struct Matrix4x3 *);
-extern int _ZN3G3i7LookAt_EPK7Vector3S2_S2_bP9Matrix4x3(struct Vector3 *,struct Vector3 *,struct Vector3 *,int,struct Matrix4x3 *);
-extern void _Z13CopyToViewMatPK9Matrix4x3(struct Matrix4x3 *);
+extern int _ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3(int,int,int,int,int,int,int,struct Matrix4x3_local *);
+extern int _ZN3G3i7LookAt_EPK7Vector3S2_S2_bP9Matrix4x3(struct Vector3 *,struct Vector3 *,struct Vector3 *,int,struct Matrix4x3_local *);
+extern void _Z13CopyToViewMatPK9Matrix4x3(struct Matrix4x3_local *);
 extern int _ZN7Clipper13Func_020156DCEv(void *,int,int,int,int);
 
 extern short data_02082214[];

--- a/src/func_ov006_020c06dc.cpp
+++ b/src/func_ov006_020c06dc.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov006_020c06dc
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Matrix4x3 { int w[12]; };
-struct Mtx43 { int w[12]; };
+
+
 
 extern "C" void Matrix4x3_ApplyInPlaceToRotationX(Matrix4x3* mF, s16 angX);
-extern "C" void Matrix4x3_FromTranslation(Mtx43* m, int x, int y, int z);
+extern "C" void Matrix4x3_FromTranslation(Matrix4x3* m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3* mF, s16 angY);
 
 extern Matrix4x3 data_020a0e68;
@@ -29,7 +32,7 @@ extern "C" void func_ov006_020c06dc(char* thiz)
         char* m = *(char**)(c + 0x2c);
         *(Matrix4x3*)(m + 0x120) = data_020a0e68;
     }
-    Matrix4x3_FromTranslation((Mtx43*)&data_020a0e68, *(int*)(c + 0xc8), *(int*)(c + 0xcc), *(int*)(c + 0xd0));
+    Matrix4x3_FromTranslation((Matrix4x3*)&data_020a0e68, *(int*)(c + 0xc8), *(int*)(c + 0xcc), *(int*)(c + 0xd0));
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c + 0xea));
     *(Matrix4x3*)(c + 0x34) = data_020a0e68;
 }

--- a/src/func_ov006_020c092c.cpp
+++ b/src/func_ov006_020c092c.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov006_020c092c
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct BCA_File;
 struct Model { int d; };
@@ -16,10 +19,10 @@ extern "C" void _ZN5Model12SetPolygonIDEi(Model*, int);
 extern "C" void _ZN11ShadowModel12InitCylinderEv(ShadowModel*);
 extern "C" void func_ov006_020c057c(void*);
 
-struct V3 { int x, y, z; };
-struct V3s { short x, y, z; };
-extern V3 data_020a0ebc;
-extern V3s data_020a0edc;
+
+
+extern Vector3 data_020a0ebc;
+extern Vector3_16 data_020a0edc;
 
 extern "C" void func_ov006_020c092c(char* thiz)
 {

--- a/src/func_ov006_020c0aa8.c
+++ b/src/func_ov006_020c0aa8.c
@@ -1,15 +1,18 @@
+// @symbol func_ov006_020c0aa8
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov006_020c0aa8 at 0x020c0aa8
  *
  * Camera preset init: sets eye/target vectors and angle, then
  * tail-calls func_ov006_020c0134. Sibling of func_ov006_020c225c.
  */
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int data[12]; };
+
+struct Matrix4x3_local { int data[12]; };
 
 struct Camera {
-    struct Matrix4x3 viewMat;  /* 0x00 */
+    struct Matrix4x3_local viewMat;  /* 0x00 */
     char pad30[0x30];          /* 0x30 */
-    struct Matrix4x3 projMat;  /* 0x60 */
+    struct Matrix4x3_local projMat;  /* 0x60 */
     char pad90[0x10];          /* 0x90 */
     struct Vector3 eye;        /* 0xa0 */
     struct Vector3 target;     /* 0xac */

--- a/src/func_ov006_020c0af8.c
+++ b/src/func_ov006_020c0af8.c
@@ -1,9 +1,12 @@
-struct S48 { int w[12]; };
-extern volatile struct S48 data_ov006_0213ad28;
+// @symbol func_ov006_020c0af8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 void func_ov006_020c0af8(char* c)
 {
-    struct S48 tmp;
-    *(volatile struct S48*)&tmp = data_ov006_0213ad28;
-    *(struct S48*)(c + 0x38) = *(struct S48*)&data_ov006_0213ad28;
-    *(struct S48*)(c + 0xa8) = tmp;
+    struct Matrix4x3 tmp;
+    *(volatile struct Matrix4x3*)&tmp = data_ov006_0213ad28;
+    *(struct Matrix4x3*)(c + 0x38) = *(struct Matrix4x3*)&data_ov006_0213ad28;
+    *(struct Matrix4x3*)(c + 0xa8) = tmp;
 }

--- a/src/func_ov006_020c1804.cpp
+++ b/src/func_ov006_020c1804.cpp
@@ -1,12 +1,12 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov006_020c1804
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
-extern void func_0203cd80(struct Vec3 *m, short angle);
-extern void func_0203ccd4(struct Vec3 *m, short angle);
-extern void func_02016a14(void *self, int a);
-extern void func_02016a04(void *self, int a);
-extern void func_020169d8(char *self, int index, unsigned int value);
-extern void func_ov006_020c07a0(char *t);
+extern void func_0203cd80(struct Vector3 *m, short angle);
 void func_ov006_020c1804(void *self);
 }
 
@@ -24,7 +24,7 @@ struct Obj {
 void func_ov006_020c1804(void *self)
 {
     char *c = (char*)self;
-    struct Vec3 v1, v2;
+    struct Vector3 v1, v2;
     unsigned int p1, p2;
     short ang;
     unsigned char b[3];

--- a/src/func_ov006_020c1a88.c
+++ b/src/func_ov006_020c1a88.c
@@ -1,18 +1,17 @@
-struct V3 { int x, y, z; };
-struct V3s { short x, y, z; };
+// @symbol func_ov006_020c1a88
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern struct Vector3 data_020a0ebc;
+extern struct Vector3_16 data_020a0edc;
 
-extern struct V3 data_020a0ebc;
-extern struct V3s data_020a0edc;
-
-extern void _ZN11ShadowModel8CleanAllEv(void);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int b, int c);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void *self, void *file, int b, int c, int scale, unsigned short e);
-extern void _ZN5Model12HideMaterialEii(void *self, int a, int b);
-extern void func_ov006_020c0af8(char *c);
-extern void func_ov006_020c1764(char *c);
-extern void func_ov006_020c092c(char *c);
 
 int func_ov006_020c1a88(char *c)
 {
@@ -55,9 +54,9 @@ int func_ov006_020c1a88(char *c)
         return 0;
     }
     ip = *(void **)(c + 0x98);
-    *(int *)(((long long)(int)((char *)ip + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
-    *(int *)(((long long)(int)((char *)ip + 0x114)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
-    *(int *)(((long long)(int)((char *)ip + 0xe4)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(int *)(((long long)(int)((char *)ip + 0x24))) &= ~1;
+    *(int *)(((long long)(int)((char *)ip + 0x114))) &= ~1;
+    *(int *)(((long long)(int)((char *)ip + 0xe4))) |= 2;
     func_ov006_020c092c(c + 0xdc);
     *(short *)(c + 0x1e0) = 0;
     *(short *)(c + 0x1e2) = 1;

--- a/src/func_ov006_020c1eb4.c
+++ b/src/func_ov006_020c1eb4.c
@@ -1,15 +1,18 @@
+// @symbol func_ov006_020c1eb4
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov006_020c1eb4 at 0x020c1eb4
  *
  * Camera preset init: sets eye/target vectors and angle, then
  * tail-calls func_ov006_020c0134. Sibling of func_ov006_020c225c.
  */
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int data[12]; };
+
+struct Matrix4x3_local { int data[12]; };
 
 struct Camera {
-    struct Matrix4x3 viewMat;  /* 0x00 */
+    struct Matrix4x3_local viewMat;  /* 0x00 */
     char pad30[0x30];          /* 0x30 */
-    struct Matrix4x3 projMat;  /* 0x60 */
+    struct Matrix4x3_local projMat;  /* 0x60 */
     char pad90[0x10];          /* 0x90 */
     struct Vector3 eye;        /* 0xa0 */
     struct Vector3 target;     /* 0xac */

--- a/src/func_ov006_020c1f4c.cpp
+++ b/src/func_ov006_020c1f4c.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov006_020c1f4c
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Mtx43 { int w[12]; };
+
 extern "C" {
-void Matrix4x3_FromTranslation(Mtx43* m, int x, int y, int z);
-void Matrix4x3_ApplyInPlaceToRotationY(Mtx43* m, s16 a);
-void Matrix4x3_ApplyInPlaceToRotationX(Mtx43* m, s16 a);
-void Matrix4x3_ApplyInPlaceToRotationZ(Mtx43* m, s16 a);
-extern Mtx43 data_020a0e68;
+void Matrix4x3_FromTranslation(Matrix4x3* m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3* m, s16 a);
+void Matrix4x3_ApplyInPlaceToRotationX(Matrix4x3* m, s16 a);
+void Matrix4x3_ApplyInPlaceToRotationZ(Matrix4x3* m, s16 a);
+extern Matrix4x3 data_020a0e68;
 }
 
 struct Vtbl {
@@ -16,12 +19,12 @@ struct Vtbl {
   virtual void v3();   // offset 0xc
 };
 
-struct Sub { char pad[0x120]; Mtx43 m; };
+struct Sub { char pad[0x120]; Matrix4x3 m; };
 
 extern "C" void func_ov006_020c1f4c(char* c){
   Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x8c), *(int*)(c+0x90), *(int*)(c+0x94));
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(s16*)(c+0x9a));
-  *(Mtx43*)(c+0x2c) = data_020a0e68;
+  *(Matrix4x3*)(c+0x2c) = data_020a0e68;
   ((Vtbl*)(c+0x10))->v3();
   data_020a0e68 = (*(Sub**)(c+0x24))->m;
   Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16*)(c+0xa4));

--- a/src/func_ov006_020c225c.c
+++ b/src/func_ov006_020c225c.c
@@ -1,14 +1,17 @@
+// @symbol func_ov006_020c225c
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov006_020c225c at 0x020c225c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
  */
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int data[12]; };
+
+struct Matrix4x3_local { int data[12]; };
 
 struct Camera {
-    struct Matrix4x3 viewMat;  /* 0x00 */
+    struct Matrix4x3_local viewMat;  /* 0x00 */
     char pad30[0x30];          /* 0x30 */
-    struct Matrix4x3 projMat;  /* 0x60 */
+    struct Matrix4x3_local projMat;  /* 0x60 */
     char pad90[0x10];          /* 0x90 */
     struct Vector3 eye;        /* 0xa0 */
     struct Vector3 target;     /* 0xac */

--- a/src/func_ov006_020c2290.c
+++ b/src/func_ov006_020c2290.c
@@ -1,7 +1,9 @@
-struct Mtx { int w[12]; };
-extern struct Mtx data_020a0e68;
-extern void Matrix4x3_FromTranslation(struct Mtx* m, int x, int y, int z);
+// @symbol func_ov006_020c2290
+/* recovered: shared common types */
+#include "common.h"
+extern struct Matrix4x3 data_020a0e68;
+extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 void func_ov006_020c2290(char* c) {
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x180), *(int*)(c+0x184), *(int*)(c+0x188));
-    *(struct Mtx*)(c+0x24) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x24) = data_020a0e68;
 }

--- a/src/func_ov006_020c3050.c
+++ b/src/func_ov006_020c3050.c
@@ -1,14 +1,10 @@
-struct Mtx { int w[12]; };
-extern struct Mtx data_020a0e68;
+// @symbol func_ov006_020c3050
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern struct Matrix4x3 data_020a0e68;
 
-extern char data_ov006_0213ae48[];
-extern char data_ov006_0213ae60[];
-extern char data_ov006_0213aea8[];
-extern char data_ov006_0213ae00[];
-extern char data_ov006_0213ae30[];
-extern char data_ov006_0213ae78[];
-extern char data_ov006_0213ae90[];
-extern char data_ov006_0213ae18[];
 
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);
@@ -17,9 +13,7 @@ extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int b, int
 extern void func_02016b24(void *o, unsigned int mask);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void *bmd, void *btp);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);
-extern void func_ov006_020c2848(char *c);
-extern void func_ov006_020c2290(char *c);
-extern void Matrix4x3_FromTranslation(struct Mtx *m, int x, int y, int z);
+extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
 
 int func_ov006_020c3050(char *c)
 {
@@ -78,6 +72,6 @@ int func_ov006_020c3050(char *c)
         return 0;
 
     Matrix4x3_FromTranslation(&data_020a0e68, 0, 0, 0);
-    *(struct Mtx *)(c + 0x94) = data_020a0e68;
+    *(struct Matrix4x3 *)(c + 0x94) = data_020a0e68;
     return 1;
 }

--- a/src/func_ov006_020c3528.cpp
+++ b/src/func_ov006_020c3528.cpp
@@ -1,20 +1,23 @@
 //cpp
+// @symbol func_ov006_020c3528
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 struct Q{int a,b,c,d;};
-struct M43{int w[12];};
-struct V3{int x,y,z;};
+
+
 void Matrix4x3_FromQuaternion(void* q, void* m);
 void MulVec3Mat3x3(void* a, void* b, void* d);
 void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 void MulMat4x3Mat4x3(void* d, void* a, void* b);
-extern struct V3 data_ov006_0212c9e4;
-extern struct M43 data_020a0e68;
+extern struct Vector3 data_ov006_0212c9e4;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov006_020c3528(char* c){
-  struct M43 sp;
+  struct Matrix4x3 sp;
   Matrix4x3_FromQuaternion((char*)c+0x30, &sp);
   MulVec3Mat3x3(&data_ov006_0212c9e4, &sp, (char*)c+0x24);
   Matrix4x3_FromTranslation(&data_020a0e68, *(int*)c, *(int*)(c+4), *(int*)(c+8));
   MulMat4x3Mat4x3(&sp, &data_020a0e68, &data_020a0e68);
-  *(struct M43*)((char*)c+0x60) = data_020a0e68;
+  *(struct Matrix4x3*)((char*)c+0x60) = data_020a0e68;
 }
 }

--- a/src/func_ov006_020c35a8.cpp
+++ b/src/func_ov006_020c35a8.cpp
@@ -1,18 +1,21 @@
 //cpp
+// @symbol func_ov006_020c35a8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void func_ov006_020c3528(char* c);
 }
-struct Vec3 { int x, y, z; };
+
 struct Obj {
     virtual void m0();
     virtual void m1();
     virtual void m2();
     virtual void m3();
     virtual void m4();
-    virtual void m5(Vec3* v);
+    virtual void m5(Vector3* v);
 };
 extern "C" void func_ov006_020c35a8(char* c) {
     func_ov006_020c3528(c);
-    Vec3 v; v.z=0x1000; v.y=0x1000; v.x=0x1000;
+    Vector3 v; v.z=0x1000; v.y=0x1000; v.x=0x1000;
     ((Obj*)(c + 0x44))->m5(&v);
 }

--- a/src/func_ov006_020c3b2c.c
+++ b/src/func_ov006_020c3b2c.c
@@ -1,15 +1,18 @@
+// @symbol func_ov006_020c3b2c
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov006_020c3b2c at 0x020c3b2c
  *
  * Camera preset init: sets eye/target vectors and angle, then
  * tail-calls func_ov006_020c0134. Sibling of func_ov006_020c225c.
  */
-struct Vector3 { int x, y, z; };
-struct Matrix4x3 { int data[12]; };
+
+struct Matrix4x3_local { int data[12]; };
 
 struct Camera {
-    struct Matrix4x3 viewMat;  /* 0x00 */
+    struct Matrix4x3_local viewMat;  /* 0x00 */
     char pad30[0x30];          /* 0x30 */
-    struct Matrix4x3 projMat;  /* 0x60 */
+    struct Matrix4x3_local projMat;  /* 0x60 */
     char pad90[0x10];          /* 0x90 */
     struct Vector3 eye;        /* 0xa0 */
     struct Vector3 target;     /* 0xac */

--- a/src/func_ov006_020c3bf4.cpp
+++ b/src/func_ov006_020c3bf4.cpp
@@ -1,8 +1,11 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov006_020c3bf4
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
-extern void func_0203cd80(struct Vec3 *v, int a);
-extern void func_0203ccd4(struct Vec3 *v, short angle);
+extern void func_0203cd80(struct Vector3 *v, int a);
+extern void func_0203ccd4(struct Vector3 *v, short angle);
 extern void func_02016a14(void *p, int a);
 extern void func_02016a04(void *p, int a);
 extern void func_ov006_020c35a8(char *c);
@@ -10,7 +13,7 @@ extern int data_ov006_0213aee8[12];
 void func_ov006_020c3bf4(void *self);
 }
 
-struct M48 { int w[12]; };
+
 
 struct Obj {
     virtual void f0() = 0;
@@ -24,7 +27,7 @@ struct Obj {
 void func_ov006_020c3bf4(void *self)
 {
     char *c = (char*)self;
-    struct Vec3 v;
+    struct Vector3 v;
     unsigned int packed;
     int i;
 
@@ -42,7 +45,7 @@ void func_ov006_020c3bf4(void *self)
     func_02016a14(c + 0xd18, 0x2bff);
     func_02016a04(c + 0xd18, 0x1211);
 
-    *(struct M48*)(c + 0xd34) = *(struct M48*)data_ov006_0213aee8;
+    *(struct Matrix4x3*)(c + 0xd34) = *(struct Matrix4x3*)data_ov006_0213aee8;
 
     ((Obj*)(c + 0xd18))->f5(0);
 

--- a/src/func_ov006_020c4c00.c
+++ b/src/func_ov006_020c4c00.c
@@ -1,9 +1,11 @@
-struct Mtx { int w[12]; };
-extern struct Mtx data_020a0e68;
-extern void Matrix4x3_FromTranslation(struct Mtx* m, int x, int y, int z);
-extern void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx* m, short angY);
+// @symbol func_ov006_020c4c00
+/* recovered: shared common types */
+#include "common.h"
+extern struct Matrix4x3 data_020a0e68;
+extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
+extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3* m, short angY);
 void func_ov006_020c4c00(char* c) {
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x9c), *(int*)(c+0xa0), *(int*)(c+0xa4));
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0xe6));
-    *(struct Mtx*)(c+0x54) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x54) = data_020a0e68;
 }

--- a/src/func_ov006_020c4c54.cpp
+++ b/src/func_ov006_020c4c54.cpp
@@ -1,26 +1,30 @@
 //cpp
-struct Vec3 { int x, y, z; };
-extern "C" void Vec3_MulScalar(Vec3 *res, Vec3 *v, int scalar);
-extern Vec3 data_ov006_0213af98;
+// @symbol func_ov006_020c4c54
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+extern "C" void Vec3_MulScalar(Vector3 *res, Vector3 *v, int scalar);
 struct Sub {
     virtual void v0();
     virtual void v1();
     virtual void v2();
     virtual void v3();
     virtual void v4();
-    virtual void m5(Vec3 *p);
+    virtual void m5(Vector3 *p);
 };
 extern "C" void func_ov006_020c4c54(int this_) {
-    Vec3 v;
+    Vector3 v;
     int *p = (int*)(((int)this_ + 0x30) & 0xFFFFFFFFFFFFFFFF);
-    Vec3 *d = &data_ov006_0213af98;
+    Vector3 *d = &data_ov006_0213af98;
     if (p[0] == d->x) {
         if (p[1] == d->y)
             return;
         if (((volatile int*)this_)[0xc] == 0)
             return;
     }
-    Vec3_MulScalar(&v, (Vec3*)(this_ + 0xcc), *(int*)(this_ + 0xd8));
+    Vec3_MulScalar(&v, (Vector3*)(this_ + 0xcc), *(int*)(this_ + 0xd8));
     Sub *s = (Sub*)(this_ + 0x38);
     s->m5(&v);
 }

--- a/src/func_ov006_020c53f8.c
+++ b/src/func_ov006_020c53f8.c
@@ -1,7 +1,10 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+// @symbol func_ov006_020c53f8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void ApproachLinear(short *a, short b, short c);
-extern void func_ov006_020c49d8(void *c);
 
 void func_ov006_020c53f8(char *c)
 {
@@ -21,7 +24,7 @@ void func_ov006_020c53f8(char *c)
         *(int*)(c + 0xa8) = -ac;
         *(int*)(c + 0xac) = 0;
     }
-    AddVec3((struct Vec3*)(c + 0x9c), (struct Vec3*)(c + 0xa8), (struct Vec3*)(c + 0x9c));
+    AddVec3((struct Vector3*)(c + 0x9c), (struct Vector3*)(c + 0xa8), (struct Vector3*)(c + 0x9c));
     if (*(int*)(c + 0xa8) > 0)
         ApproachLinear((short*)(c + 0xe6), 0x3000, 0x200);
     else

--- a/src/func_ov006_020c5530.c
+++ b/src/func_ov006_020c5530.c
@@ -1,7 +1,10 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+// @symbol func_ov006_020c5530
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void ApproachLinear(short *a, short b, short c);
-extern void func_ov006_020c49d8(void *c);
 
 void func_ov006_020c5530(char *c)
 {
@@ -21,7 +24,7 @@ void func_ov006_020c5530(char *c)
         *(int*)(c + 0xa8) = ac;
         *(int*)(c + 0xac) = 0;
     }
-    AddVec3((struct Vec3*)(c + 0x9c), (struct Vec3*)(c + 0xa8), (struct Vec3*)(c + 0x9c));
+    AddVec3((struct Vector3*)(c + 0x9c), (struct Vector3*)(c + 0xa8), (struct Vector3*)(c + 0x9c));
     if (*(int*)(c + 0xa8) > 0)
         ApproachLinear((short*)(c + 0xe6), 0x3000, 0x200);
     else

--- a/src/func_ov006_020c5bf8.c
+++ b/src/func_ov006_020c5bf8.c
@@ -1,7 +1,10 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+// @symbol func_ov006_020c5bf8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void ApproachLinear(short *a, short b, short c);
-extern void func_ov006_020c49d8(void *c);
 
 void func_ov006_020c5bf8(char *c)
 {
@@ -17,7 +20,7 @@ void func_ov006_020c5bf8(char *c)
     } else if (ac > 0 && *(int*)(c + 0xa0) > *(int*)(c + 0x24) + *(int*)(c + 0x1c)) {
         *(int*)(c + 0xac) = -ac;
     }
-    AddVec3((struct Vec3*)(c + 0x9c), (struct Vec3*)(c + 0xa8), (struct Vec3*)(c + 0x9c));
+    AddVec3((struct Vector3*)(c + 0x9c), (struct Vector3*)(c + 0xa8), (struct Vector3*)(c + 0x9c));
     if (*(int*)(c + 0xa8) > 0)
         ApproachLinear((short*)(c + 0xe6), 0x3000, 0x200);
     else

--- a/src/func_ov006_020c6088.c
+++ b/src/func_ov006_020c6088.c
@@ -1,7 +1,10 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+// @symbol func_ov006_020c6088
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void _Z14ApproachLinearRsss(short *a, short b, short c);
-extern void func_ov006_020c49d8(void *c);
 
 void func_ov006_020c6088(char *c)
 {
@@ -44,7 +47,7 @@ after_y:
 after_x:;
     }
 
-    AddVec3((struct Vec3*)(c + 0x9c), (struct Vec3*)(c + 0xa8), (struct Vec3*)(c + 0x9c));
+    AddVec3((struct Vector3*)(c + 0x9c), (struct Vector3*)(c + 0xa8), (struct Vector3*)(c + 0x9c));
     if (*(int*)(c + 0xa8) > 0)
         _Z14ApproachLinearRsss((short*)(c + 0xe6), 0x3000, 0x200);
     else

--- a/src/func_ov006_020c61c4.c
+++ b/src/func_ov006_020c61c4.c
@@ -1,6 +1,9 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *out);
-extern void func_ov006_020c49d8(void *this);
+// @symbol func_ov006_020c61c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *out);
 void func_ov006_020c61c4(int this) {
     int f24 = *(int*)(this + 0x24);
     int a0  = *(int*)(this + 0xa0);
@@ -11,6 +14,6 @@ void func_ov006_020c61c4(int this) {
         ((int*)this)[43] = -((int*)this)[43];
         ((short*)this)[117] = 0;
     }
-    AddVec3((struct Vec3*)(this + 0x9c), (struct Vec3*)(this + 0xa8), (struct Vec3*)(this + 0x9c));
+    AddVec3((struct Vector3*)(this + 0x9c), (struct Vector3*)(this + 0xa8), (struct Vector3*)(this + 0x9c));
     func_ov006_020c49d8((void*)this);
 }

--- a/src/func_ov006_020c6a9c.c
+++ b/src/func_ov006_020c6a9c.c
@@ -1,23 +1,16 @@
+// @symbol func_ov006_020c6a9c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 
-struct Vec3 { int x, y, z; };
 
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int _Z15ApproachLinear2Rsss(short *v, short target, short step);
-extern int func_ov006_020e6e3c(int a, int b);
 
-extern void func_ov006_020c63dc(char *c);
-extern void func_ov006_020c6348(char *c);
-extern void func_ov006_020c6248(char *c);
-extern void func_ov006_020c6188(char *c);
-extern void func_ov006_020c5ec8(char *c);
-extern void func_ov006_020c5cf4(char *c);
-extern void func_ov006_020c5aa4(char *c);
-extern void func_ov006_020c57d4(char *c);
-extern void func_ov006_020c561c(char *c);
-extern void func_ov006_020c54f4(char *c);
-extern void func_ov006_020c5370(char *c);
 
 void func_ov006_020c6a9c(char *c)
 {
@@ -27,7 +20,7 @@ void func_ov006_020c6a9c(char *c)
     *(int *)(c + 0xa8) = (int)(((*(int *)(c + 0x20) - *(int *)(c + 0x9c)) * 0x100LL + 0x800) >> 12);
     *(int *)(c + 0xac) = (int)(((*(int *)(c + 0x24) - *(int *)(c + 0xa0)) * 0x100LL + 0x800) >> 12);
     *(int *)(c + 0xb0) = (int)(((*(int *)(c + 0x28) - *(int *)(c + 0xa4)) * 0x100LL + 0x800) >> 12);
-    AddVec3((struct Vec3 *)(c + 0x9c), (struct Vec3 *)(c + 0xa8), (struct Vec3 *)(c + 0x9c));
+    AddVec3((struct Vector3 *)(c + 0x9c), (struct Vector3 *)(c + 0xa8), (struct Vector3 *)(c + 0x9c));
 
     if ((*(int *)(c + 0xa8) < 0 ? -*(int *)(c + 0xa8) : *(int *)(c + 0xa8)) < 0x10 &&
         (*(int *)(c + 0xac) < 0 ? -*(int *)(c + 0xac) : *(int *)(c + 0xac)) < 0x10) {

--- a/src/func_ov006_020c76e0.cpp
+++ b/src/func_ov006_020c76e0.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov006_020c76e0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, short angY);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov006_020c76e0(char *c) {
   Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x14), *(int*)(c+0x18), *(int*)(c+0x1c));
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x2e));
-  *(struct M*)(c+0x68) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x68) = data_020a0e68;
 }
 }

--- a/src/func_ov006_020c7860.cpp
+++ b/src/func_ov006_020c7860.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov006_020c7860
+/* recovered: shared common types */
+#include "common.h"
 struct C; typedef void (C::*PMF)();
 extern "C" {
 extern void _Z14ApproachLinearRiii(int &, int, int);
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void func_ov006_020bfec0(void* a, char* b, short* d);
 extern void func_ov006_020c76e0(char *c);
 extern void _ZN9Animation7AdvanceEv(void *);
@@ -15,7 +18,7 @@ struct C { char pad[0x3c]; PMF m; };
 extern "C" void func_ov006_020c7860(char *c);
 extern "C" void func_ov006_020c7860(char *c) {
     _Z14ApproachLinearRiii(*(int*)(c + 0x24), data_ov006_0213b010, data_ov006_0213b018);
-    AddVec3((struct Vec3*)(c + 0x14), (struct Vec3*)(c + 0x20), (struct Vec3*)(c + 0x14));
+    AddVec3((struct Vector3*)(c + 0x14), (struct Vector3*)(c + 0x20), (struct Vector3*)(c + 0x14));
     { C *o = (C*)c; (o->*o->m)(); }
     func_ov006_020bfec0(*(void**)&data_ov006_02141a40, c + 0x14, (short*)(c + 0x36));
     func_ov006_020c76e0(c);

--- a/src/func_ov006_020c8ecc.cpp
+++ b/src/func_ov006_020c8ecc.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov006_020c8ecc
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Matrix4x3 { int m[12]; };
+
 extern struct Matrix4x3 data_020a0e68;
 void Matrix4x3_FromTranslation(struct Matrix4x3 *mF, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, short angY);

--- a/src/func_ov006_020c9aa0.cpp
+++ b/src/func_ov006_020c9aa0.cpp
@@ -1,21 +1,22 @@
 //cpp
-struct V3 { int x, y, z; };
+// @symbol func_ov006_020c9aa0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
-int DotVec3(const V3 *a, const V3 *b);
-void Vec3_MulScalar(V3 *out, const V3 *in, int scale);
-void SubVec3(V3 *a, V3 *b, V3 *c);
-void AddVec3(V3 *a, V3 *b, V3 *c);
+int DotVec3(const Vector3 *a, const Vector3 *b);
+void Vec3_MulScalar(Vector3 *out, const Vector3 *in, int scale);
+void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
 int _ZN4cstd4fdivEii(int a, int b);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thisPtr, void *file, int i, int fix, unsigned int flags);
 void func_ov006_020e6df0(int a0, int a1, int a2);
 void func_ov006_020c97bc(char *c);
 }
 
-extern int data_ov006_02140574;
-extern void *data_ov006_0213b22c[];
-extern int data_ov006_021405b0;
-extern int data_ov006_0213b1b4[2];
 
 struct VtObj {
     virtual void d0();
@@ -27,9 +28,9 @@ struct VtObj {
 
 extern "C" void func_ov006_020c9aa0(char *c)
 {
-    V3 tmp;
-    V3 tmp2;
-    V3 tmp3;
+    Vector3 tmp;
+    Vector3 tmp2;
+    Vector3 tmp3;
     int r5v;
     int r4v;
     int dot;
@@ -41,21 +42,21 @@ extern "C" void func_ov006_020c9aa0(char *c)
     r4v = *(int *)(c + 0x14);
     if (r5v < 0) r5v = -r5v;
     {
-        int *src = (int *)(((long long)(int)(c + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *src = (int *)(((long long)(int)(c + 4)));
         tmp.x = src[0];
         tmp.y = src[1];
         tmp.z = src[2];
     }
 
-    dot = DotVec3((V3 *)(c + 0x3c), &tmp);
+    dot = DotVec3((Vector3 *)(c + 0x3c), &tmp);
     scale = (int)(((long long)dot * 0x1200 + 0x800) >> 12);
     Vec3_MulScalar(&tmp2, &tmp, scale);
-    SubVec3((V3 *)(c + 0x3c), &tmp2, (V3 *)(c + 0x3c));
+    SubVec3((Vector3 *)(c + 0x3c), &tmp2, (Vector3 *)(c + 0x3c));
 
     fdivr = _ZN4cstd4fdivEii(r4v, r4v + r5v);
     scale = (int)(((long long)data_ov006_02140574 * fdivr + 0x800) >> 12);
     Vec3_MulScalar(&tmp3, &tmp, scale);
-    AddVec3((V3 *)(c + 0x3c), &tmp3, (V3 *)(c + 0x3c));
+    AddVec3((Vector3 *)(c + 0x3c), &tmp3, (Vector3 *)(c + 0x3c));
 
     vx = *(int *)(c + 0x3c);
     if (vx < -0x2800) vx = -0x2800;

--- a/src/func_ov006_020cafdc.cpp
+++ b/src/func_ov006_020cafdc.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov006_020cafdc
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Matrix4x3 { int m[12]; };
+
 extern struct Matrix4x3 data_020a0e68;
 void Matrix4x3_FromTranslation(struct Matrix4x3 *mF, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, short angY);

--- a/src/func_ov006_020cbaec.cpp
+++ b/src/func_ov006_020cbaec.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol func_ov006_020cbaec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct V3 { int x, y, z; };
-struct Vector3_16f { s16 x, y, z; };
+
+
 
 struct VtObj {
     virtual void d0();
@@ -13,10 +18,10 @@ struct VtObj {
 };
 
 extern "C" {
-int DotVec3(const V3 *a, const V3 *b);
-void Vec3_MulScalar(V3 *out, const V3 *in, int scale);
-void SubVec3(V3 *a, V3 *b, V3 *c);
-void AddVec3(V3 *a, V3 *b, V3 *c);
+int DotVec3(const Vector3 *a, const Vector3 *b);
+void Vec3_MulScalar(Vector3 *out, const Vector3 *in, int scale);
+void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
 int _ZN4cstd4fdivEii(int a, int b);
 void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int c, int d, int e, const void *f, void *g);
@@ -26,16 +31,12 @@ int func_ov006_020e6e3c(int a, int b);
 void func_ov006_020cb838(char *c);
 }
 
-extern int data_ov006_02140544;
-extern int data_ov006_02140570;
-extern void *data_ov006_0214059c;
-extern int data_ov006_0213b1ac[2];
 
 extern "C" void func_ov006_020cbaec(char *c)
 {
-    V3 tmp;
-    V3 tmp2;
-    V3 tmp4;
+    Vector3 tmp;
+    Vector3 tmp2;
+    Vector3 tmp4;
     int r5v;
     int r4v;
     int dot;
@@ -46,23 +47,23 @@ extern "C" void func_ov006_020cbaec(char *c)
     r4v = *(int *)(c + 0x14);
     if (r5v < 0) r5v = -r5v;
     {
-        int *src = (int *)(((long long)(int)(c + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *src = (int *)(((long long)(int)(c + 4)));
         tmp.x = src[0];
         tmp.y = src[1];
         tmp.z = src[2];
     }
 
-    dot = DotVec3((V3 *)(c + 0x34), &tmp);
+    dot = DotVec3((Vector3 *)(c + 0x34), &tmp);
     scale = (int)(((long long)dot * 0x1400 + 0x800) >> 12);
     Vec3_MulScalar(&tmp2, &tmp, scale);
-    SubVec3((V3 *)(c + 0x34), &tmp2, (V3 *)(c + 0x34));
+    SubVec3((Vector3 *)(c + 0x34), &tmp2, (Vector3 *)(c + 0x34));
 
     fdivr = _ZN4cstd4fdivEii(r4v, r4v + r5v);
 
     *(int *)(c + 0x40) = data_ov006_02140544;
 
     {
-        Vector3_16f v;
+        Vector3_16 v;
         v.x = (s16)tmp.x;
         v.y = (s16)tmp.y;
         v.z = (s16)tmp.z;
@@ -78,7 +79,7 @@ extern "C" void func_ov006_020cbaec(char *c)
 
     scale = (int)(((long long)data_ov006_02140570 * fdivr + 0x800) >> 12);
     Vec3_MulScalar(&tmp4, &tmp, scale);
-    AddVec3((V3 *)(c + 0x34), &tmp4, (V3 *)(c + 0x34));
+    AddVec3((Vector3 *)(c + 0x34), &tmp4, (Vector3 *)(c + 0x34));
 
     {
         int v = *(int *)(c + 0x34);

--- a/src/func_ov006_020cbfd8.cpp
+++ b/src/func_ov006_020cbfd8.cpp
@@ -1,11 +1,16 @@
 //cpp
-struct V3 { int x, y, z; };
+// @symbol func_ov006_020cbfd8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
-int DotVec3(const V3 *a, const V3 *b);
-void Vec3_MulScalar(V3 *out, const V3 *in, int scale);
-void SubVec3(V3 *a, V3 *b, V3 *c);
-void AddVec3(V3 *a, V3 *b, V3 *c);
+int DotVec3(const Vector3 *a, const Vector3 *b);
+void Vec3_MulScalar(Vector3 *out, const Vector3 *in, int scale);
+void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
+void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
 int _ZN4cstd4fdivEii(int a, int b);
 void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
     void *thisPtr, void *file, int i, int fix, unsigned int flags);
@@ -13,10 +18,6 @@ void func_ov006_020e6df0(int a0, int a1, int a2);
 void func_ov006_020cbd7c(char *c);
 }
 
-extern int data_ov006_02140544;
-extern int data_ov006_02140578;
-extern void *data_ov006_0213b22c[];
-extern int data_ov006_0213b1bc[2];
 
 struct VtObj {
     virtual void d0();
@@ -28,9 +29,9 @@ struct VtObj {
 
 extern "C" void func_ov006_020cbfd8(char *c)
 {
-    V3 tmp;
-    V3 tmp2;
-    V3 tmp3;
+    Vector3 tmp;
+    Vector3 tmp2;
+    Vector3 tmp3;
     int r5v;
     int r4v;
     int dot;
@@ -43,24 +44,23 @@ extern "C" void func_ov006_020cbfd8(char *c)
     if (r5v < 0) r5v = -r5v;
 
     {
-        int *src = (int *)(((long long)(int)(c + 4)) &
-                           0xFFFFFFFFFFFFFFFFLL);
+        int *src = (int *)(((long long)(int)(c + 4)));
         tmp.x = src[0];
         tmp.y = src[1];
         tmp.z = src[2];
     }
 
-    dot = DotVec3((V3 *)(c + 0x34), &tmp);
+    dot = DotVec3((Vector3 *)(c + 0x34), &tmp);
     scale = (int)(((long long)dot * 0x1200 + 0x800) >> 12);
     Vec3_MulScalar(&tmp2, &tmp, scale);
-    SubVec3((V3 *)(c + 0x34), &tmp2, (V3 *)(c + 0x34));
+    SubVec3((Vector3 *)(c + 0x34), &tmp2, (Vector3 *)(c + 0x34));
 
     fdivr = _ZN4cstd4fdivEii(r4v, r4v + r5v);
     *(int *)(c + 0x40) = data_ov006_02140544;
 
     scale = (int)(((long long)data_ov006_02140578 * fdivr + 0x800) >> 12);
     Vec3_MulScalar(&tmp3, &tmp, scale);
-    AddVec3((V3 *)(c + 0x34), &tmp3, (V3 *)(c + 0x34));
+    AddVec3((Vector3 *)(c + 0x34), &tmp3, (Vector3 *)(c + 0x34));
 
     vx = *(int *)(c + 0x34);
     if (vx < -0x1000) vx = -0x1000;

--- a/src/func_ov006_020cd12c.c
+++ b/src/func_ov006_020cd12c.c
@@ -1,10 +1,13 @@
-extern void data_ov007_020cd72c(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern int VT0[];
+// @symbol func_ov006_020cd12c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18dMgTrmpln3DMario_c */
 int *func_ov006_020cd12c(int *t)
 {
     data_ov007_020cd72c(t);
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18dMgTrmpln3DMario_c;
     _ZN9ModelAnimC1Ev((char *)t + 0x6c);
     return t;
 }

--- a/src/func_ov006_020cd864.c
+++ b/src/func_ov006_020cd864.c
@@ -1,25 +1,16 @@
-struct Vec3 { int x, y, z; };
-
-extern int data_ov006_02140820;
-extern int data_ov006_02140840;
-extern struct Vec3 data_ov006_02140938;
-extern struct Vec3 data_ov006_02140884;
-extern void* data_ov006_02140920;
-extern void* data_ov006_0214086c;
+// @symbol func_ov006_020cd864
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void func_020072c0(void);
 
 extern void func_020731dc(int a, int b, void** node);
-extern void func_0203cc28(int* p, int angle);
-extern void func_0203ce80(struct Vec3* dst, struct Vec3* src);
-extern void func_0203cf00(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void Quaternion_FromVector3(int* q, struct Vec3* v, struct Vec3* axis);
-extern void Quaternion_Normalize(int* q);
-extern void func_ov006_020cdc38(void* o);
 
 void func_ov006_020cd864(char* arg) {
-  struct Vec3 a;
-  struct Vec3 b;
-  struct Vec3 c;
+  struct Vector3 a;
+  struct Vector3 b;
+  struct Vector3 c;
   if ((data_ov006_02140820 & 1) == 0) {
     data_ov006_02140938.x = 0;
     data_ov006_02140938.y = 0x1000;
@@ -35,13 +26,13 @@ void func_ov006_020cd864(char* arg) {
     data_ov006_02140840 |= 1;
   }
   func_0203cc28((int*)(arg + 0x38), 0x100);
-  func_0203ce80(&a, (struct Vec3*)(arg + 0x38));
-  func_0203cf00(&b, (struct Vec3*)(arg + 0x38), &data_ov006_02140884);
+  func_0203ce80(&a, (struct Vector3*)(arg + 0x38));
+  func_0203cf00(&b, (struct Vector3*)(arg + 0x38), &data_ov006_02140884);
   *(int*)(arg + 0x44) = b.x;
   *(int*)(arg + 0x48) = b.y;
   *(int*)(arg + 0x4c) = b.z;
-  func_0203ce80(&c, (struct Vec3*)(arg + 0x44));
-  Quaternion_FromVector3((int*)(arg + 0x74), &data_ov006_02140938, (struct Vec3*)(arg + 0x38));
+  func_0203ce80(&c, (struct Vector3*)(arg + 0x44));
+  Quaternion_FromVector3((int*)(arg + 0x74), &data_ov006_02140938, (struct Vector3*)(arg + 0x38));
   Quaternion_Normalize((int*)(arg + 0x74));
   func_ov006_020cdc38(arg);
 }

--- a/src/func_ov006_020cdaec.c
+++ b/src/func_ov006_020cdaec.c
@@ -1,25 +1,16 @@
-struct Vec3 { int x, y, z; };
-
-extern int data_ov006_02140808;
-extern int data_ov006_02140810;
-extern struct Vec3 data_ov006_02140860;
-extern struct Vec3 data_ov006_02140890;
-extern void* data_ov006_0214095c;
-extern void* data_ov006_02140878;
+// @symbol func_ov006_020cdaec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void func_020072c0(void);
 
 extern void func_020731dc(int a, int b, void** node);
-extern void func_0203cc28(int* p, int angle);
-extern void func_0203ce80(struct Vec3* dst, struct Vec3* src);
-extern void func_0203cf00(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void Quaternion_FromVector3(int* q, struct Vec3* v, struct Vec3* axis);
-extern void Quaternion_Normalize(int* q);
-extern void func_ov006_020cdc8c(void* o);
 
 void func_ov006_020cdaec(char* arg) {
-  struct Vec3 a;
-  struct Vec3 b;
-  struct Vec3 c;
+  struct Vector3 a;
+  struct Vector3 b;
+  struct Vector3 c;
   if ((data_ov006_02140808 & 1) == 0) {
     data_ov006_02140860.x = 0;
     data_ov006_02140860.y = 0x1000;
@@ -35,13 +26,13 @@ void func_ov006_020cdaec(char* arg) {
     data_ov006_02140810 |= 1;
   }
   func_0203cc28((int*)(arg + 0x38), 0x100);
-  func_0203ce80(&a, (struct Vec3*)(arg + 0x38));
-  func_0203cf00(&b, (struct Vec3*)(arg + 0x38), &data_ov006_02140890);
+  func_0203ce80(&a, (struct Vector3*)(arg + 0x38));
+  func_0203cf00(&b, (struct Vector3*)(arg + 0x38), &data_ov006_02140890);
   *(int*)(arg + 0x44) = b.x;
   *(int*)(arg + 0x48) = b.y;
   *(int*)(arg + 0x4c) = b.z;
-  func_0203ce80(&c, (struct Vec3*)(arg + 0x44));
-  Quaternion_FromVector3((int*)(arg + 0x74), &data_ov006_02140860, (struct Vec3*)(arg + 0x38));
+  func_0203ce80(&c, (struct Vector3*)(arg + 0x44));
+  Quaternion_FromVector3((int*)(arg + 0x74), &data_ov006_02140860, (struct Vector3*)(arg + 0x38));
   Quaternion_Normalize((int*)(arg + 0x74));
   func_ov006_020cdc8c(arg);
 }

--- a/src/func_ov006_020ce108.cpp
+++ b/src/func_ov006_020ce108.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov006_020ce108
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
@@ -11,11 +16,7 @@ extern int DotVec3(const Vector3 *a, const Vector3 *b);
 extern int NormalizeVec3IfNonZero(Vector3 *v);
 extern void Vec3_MulScalarInPlace(Vector3 *v, int s);
 
-extern int data_ov006_0213b33c[2];
 extern Vector3 data_020a0ebc;
-extern int data_ov006_0212e070[];
-extern int data_ov006_021405b4[];
-extern int data_ov006_021405a8[];
 }
 
 struct Obj {

--- a/src/func_ov006_020ce8a0.cpp
+++ b/src/func_ov006_020ce8a0.cpp
@@ -1,28 +1,31 @@
 //cpp
-struct Vec3 { int x,y,z; };
-extern "C" void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern "C" int DotVec3(struct Vec3* a, struct Vec3* b);
+// @symbol func_ov006_020ce8a0
+/* recovered: shared common types */
+#include "common.h"
+
+extern "C" void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern "C" int DotVec3(struct Vector3* a, struct Vector3* b);
 
 struct Obj {
-  virtual struct Vec3* GetA();
-  virtual struct Vec3* GetB();
+  virtual struct Vector3* GetA();
+  virtual struct Vector3* GetB();
 };
 
 extern "C" void func_ov006_020ce8a0(char* self, struct Obj* o, int* outR5, int* outR4){
-  struct Vec3 a, b, sa, sb;
-  struct Vec3* p;
+  struct Vector3 a, b, sa, sb;
+  struct Vector3* p;
   int t;
   p=o->GetA();
   a.x=p->x; a.y=p->y; a.z=p->z;
   p=o->GetB();
   b.x=p->x; b.y=p->y; b.z=p->z;
-  Vec3_Sub(&sa,&a,(struct Vec3*)(self+8));
-  Vec3_Sub(&sb,&b,(struct Vec3*)(self+0x14));
+  Vec3_Sub(&sa,&a,(struct Vector3*)(self+8));
+  Vec3_Sub(&sb,&b,(struct Vector3*)(self+0x14));
   sa.y += 0xc000;
-  t=DotVec3((struct Vec3*)(self+0x38),&sa);
-  outR5[0]=DotVec3((struct Vec3*)(self+0x44),&sa);
+  t=DotVec3((struct Vector3*)(self+0x38),&sa);
+  outR5[0]=DotVec3((struct Vector3*)(self+0x44),&sa);
   outR5[1]=t;
-  t=DotVec3((struct Vec3*)(self+0x50),&sb);
-  outR4[0]=DotVec3((struct Vec3*)(self+0x5c),&sb);
+  t=DotVec3((struct Vector3*)(self+0x50),&sb);
+  outR4[0]=DotVec3((struct Vector3*)(self+0x5c),&sb);
   outR4[1]=t;
 }

--- a/src/func_ov006_020ce988.cpp
+++ b/src/func_ov006_020ce988.cpp
@@ -1,22 +1,25 @@
 //cpp
-struct Mtx { int w[12]; };
+// @symbol func_ov006_020ce988
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
-void Matrix4x3_FromQuaternion(const void* q, struct Mtx* mF);
-void Matrix4x3_FromTranslation(struct Mtx* m, int x, int y, int z);
-void MulMat4x3Mat4x3(struct Mtx* a, struct Mtx* b, struct Mtx* out);
+void Matrix4x3_FromQuaternion(const void* q, struct Matrix4x3* mF);
+void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
+void MulMat4x3Mat4x3(struct Matrix4x3* a, struct Matrix4x3* b, struct Matrix4x3* out);
 void _ZN18TextureTransformer6UpdateER15ModelComponents(void* t, void* mc);
 void _ZN9ModelBase12ApplyOpacityEj(void* mb, unsigned int op, int z);
 }
-extern struct Mtx data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 struct VtO { int dummy[0x14/4]; void (*f)(void*, void*); };
 
 extern "C" void func_ov006_020ce988(char* c){
-    struct Mtx tmp;
+    struct Matrix4x3 tmp;
     Matrix4x3_FromQuaternion(c+0x74, &tmp);
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+8), *(int*)(c+0xc), *(int*)(c+0x10));
     MulMat4x3Mat4x3(&tmp, &data_020a0e68, &data_020a0e68);
-    *(struct Mtx*)(*(char**)(c+0x190) + 0x1c) = data_020a0e68;
+    *(struct Matrix4x3*)(*(char**)(c+0x190) + 0x1c) = data_020a0e68;
     _ZN18TextureTransformer6UpdateER15ModelComponents(c+0x194, *(char**)(c+0x190) + 8);
     _ZN9ModelBase12ApplyOpacityEj(*(void**)(c+0x190), *(unsigned char*)(c+0x9c), 0);
     {

--- a/src/func_ov006_020d10b8.cpp
+++ b/src/func_ov006_020d10b8.cpp
@@ -1,13 +1,16 @@
 //cpp
-extern "C" int data_ov006_0213b918;
+// @symbol func_ov006_020d10b8
+// @emits dScMgAmida_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgAmida_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" void func_0207328c(void* p, int a, int b, void* fn);
-extern "C" void func_ov006_020d116c(void);
 extern "C" void func_0203d47c(void);
-extern "C" void func_ov004_020b29c0(void* c);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* func_ov006_020d10b8(void* c) {
+extern "C" void* dScMgAmida_c_OnYoshiTryEat(void* c) {
     *(int**)c = &data_ov006_0213b918;
     func_0207328c((char*)c + 0x4768, 0x80, 0x18, (void*)&func_ov006_020d116c);
     func_0207328c((char*)c + 0x4744, 4, 8, (void*)&func_0203d47c);

--- a/src/func_ov006_020d11a0.cpp
+++ b/src/func_ov006_020d11a0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_020d11a0
+// @emits dScMgAmida_c_Kill
+/* recovered: renamed to Class_Method */
+/* dScMgAmida_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void SetSubBg1Offset(int a, int b);
 extern int func_ov004_020ad674(void);
@@ -8,8 +12,8 @@ extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454;
 extern int data_ov006_0213b838[];
 }
-extern "C" void func_ov006_020d11a0(void);
-extern "C" void func_ov006_020d11a0(void) {
+extern "C" void dScMgAmida_c_Kill(void);
+extern "C" void dScMgAmida_c_Kill(void) {
     volatile unsigned short *reg = (volatile unsigned short*)0x400100a;
     int id;
     void *t;

--- a/src/func_ov006_020d52f0.c
+++ b/src/func_ov006_020d52f0.c
@@ -1,22 +1,29 @@
-extern void func_ov004_020adb1c(int self);
-extern void func_ov006_020d3ba0(char *c);
-void func_ov006_020d52f0(char *c, int arg)
+// @symbol func_ov006_020d52f0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgAmida_c.h"
+// @emits dScMgAmida_c_OnYoshiTryEat_020d52f0
+/* recovered: renamed to Class_Method */
+/* dScMgAmida_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgAmida_c_OnYoshiTryEat_020d52f0(char *c, int arg)
 {
+    struct dScMgAmida_c *self = (struct dScMgAmida_c *)(void *)c;
     if (arg == 0) {
         int *p;
-        if (*(unsigned int *)(c + 0xbc) >= 0x7cf)
+        if (self->unk_0bc >= 0x7cf)
             goto final;
         p = (int *)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFF);
         *p = *p + 1;
-        if (*(unsigned int *)(c + 0xbc) > 0x270e)
-            *(unsigned int *)(c + 0xbc) = 0x270e;
+        if (self->unk_0bc > 0x270e)
+            self->unk_0bc = 0x270e;
     } else {
         *(int *)((c + 0x5000) + 0x3e8) = 0;
-        *(int *)(c + 0xbc) = 0;
-        if (*(unsigned int *)(c + 0xbc) > 0x270e)
-            *(unsigned int *)(c + 0xbc) = 0x270e;
+        self->unk_0bc = 0;
+        if (self->unk_0bc > 0x270e)
+            self->unk_0bc = 0x270e;
         func_ov004_020adb1c(*(int *)((c + 0x5000) + 0x3e8));
-        *(int *)(c + 0xb4) = *(int *)((c + 0x5000) + 0x3e8);
+        self->unk_0b4 = *(int *)((c + 0x5000) + 0x3e8);
     }
 final:
     func_ov006_020d3ba0(c);

--- a/src/func_ov006_020d5384.cpp
+++ b/src/func_ov006_020d5384.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020d5384
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgAmida_c.h"
+// @emits dScMgAmida_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgAmida_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -73,21 +79,22 @@ extern "C" {
     extern u8 data_0209d454;
 }
 
-extern "C" int func_ov006_020d5384(Obj *c)
+extern "C" int dScMgAmida_c_InitResources(Obj *c)
 {
+    struct dScMgAmida_c *self = (struct dScMgAmida_c *)(void *)c;
     volatile u16 sp4;
     volatile u16 sp6;
     void *f;
 
-    *(int *)((char *)c + 0x470c) = _ZN6Memory8AllocateEj(0x15800);
-    *(int *)((char *)c + 0x4710) = _ZN6Memory8AllocateEj(0x15800);
+    self->unk_470c = _ZN6Memory8AllocateEj(0x15800);
+    self->unk_4710 = _ZN6Memory8AllocateEj(0x15800);
 
     if (c->v90() != 0) {
-        *(int *)((char *)c + 0x4700) = 0x78;
-        *(int *)((char *)c + 0x53e4) = 2;
+        self->unk_4700 = 0x78;
+        self->unk_53e4 = 2;
     } else {
-        *(int *)((char *)c + 0x4700) = 0x98;
-        *(int *)((char *)c + 0x53e4) = 2;
+        self->unk_4700 = 0x98;
+        self->unk_53e4 = 2;
     }
 
     data_0208ee44 = 1;
@@ -192,8 +199,8 @@ extern "C" int func_ov006_020d5384(Obj *c)
         Deallocate(f);
     }
 
-    *(int *)((char *)c + 0x53d4) = 0;
-    *(int *)((char *)c + 0x53e8) = *(int *)((char *)c + 0xbc) * 5;
+    self->unk_53d4 = 0;
+    self->unk_53e8 = self->unk_0bc * 5;
     func_ov006_020d3ba0(c);
     return 1;
 }

--- a/src/func_ov006_020d5924.cpp
+++ b/src/func_ov006_020d5924.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov006_020d5924
+// @emits dScMgAmida_c_AfterCleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgAmida_c::AfterCleanupResources - recovered from vtable slot identity */
 extern "C" { void* func_ov004_020b0840(void*, int); }
 namespace Memory { void Deallocate(void*); }
-extern "C" void* func_ov006_020d5924(char* c, int r1){
+extern "C" void* dScMgAmida_c_AfterCleanupResources(char* c, int r1){
   if(r1!=2) return c;
   Memory::Deallocate(*(void**)(c+0x4000+0x70c));
   Memory::Deallocate(*(void**)(c+0x4000+0x710));

--- a/src/func_ov006_020d5a78.c
+++ b/src/func_ov006_020d5a78.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020d5a78(int *t)
+// @symbol func_ov006_020d5a78
+// @emits dScMgBomroom_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBomroom_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgBomroom_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020d9104.c
+++ b/src/func_ov006_020d9104.c
@@ -1,7 +1,10 @@
-extern void func_ov006_020d907c(void*);
-extern void G2x_SetBlendAlpha(volatile void*,unsigned short,unsigned short,unsigned short,unsigned short);
-extern void SetBg0Offset(int,int);
-void func_ov006_020d9104(unsigned char* c){
+// @symbol func_ov006_020d9104
+// @emits dScMgBomroom_c_OnYoshiTryEat_020d9104
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBomroom_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgBomroom_c_OnYoshiTryEat_020d9104(unsigned char* c){
   func_ov006_020d907c(c);
   unsigned char* a=c+0x6200;
   unsigned char* b=c+0x6000;

--- a/src/func_ov006_020d9160.c
+++ b/src/func_ov006_020d9160.c
@@ -1,12 +1,10 @@
-int func_ov006_020d9160(void* c){
-  extern int func_ov006_020d5dfc();
-  extern int func_ov006_020d6098();
-  extern int func_ov006_020d5e5c();
-  extern int func_ov006_020d672c();
-  extern int func_ov006_020d7524();
-  extern int func_ov006_020d63d4();
-  extern int func_ov006_020d5c88();
-  extern int func_ov006_020d5ab0();
+// @symbol func_ov006_020d9160
+// @emits dScMgBomroom_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBomroom_c::Render - recovered from vtable slot identity */
+int dScMgBomroom_c_Render(void* c){
   func_ov006_020d5dfc(c);
   func_ov006_020d6098(c);
   func_ov006_020d5e5c(c);

--- a/src/func_ov006_020d91b0.cpp
+++ b/src/func_ov006_020d91b0.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov006_020d91b0
+// @emits dScMgBomroom_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgBomroom_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef void (C::*PMF)();
 extern "C" {
 extern PMF data_ov006_021416e0[];
 void func_ov006_020d5d08(char *c);
 void func_ov006_020d5b10(char *c);
-int func_ov006_020d91b0(char *c)
+int dScMgBomroom_c_Behavior(char *c)
 {
     if (*(unsigned short *)(c + 0x6200 + 0xf0) != 0) {
         unsigned short *t = (unsigned short *)(((int)c + 0x62f0) & 0xFFFFFFFFFFFFFFFF);

--- a/src/func_ov006_020d9244.c
+++ b/src/func_ov006_020d9244.c
@@ -1,34 +1,28 @@
+// @symbol func_ov006_020d9244
+// @emits dScMgBomroom_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBomroom_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern int LoadFile(int handle);
-extern int func_02054d88(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern char *_ZN2G212GetBG2ScrPtrEv(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
-extern void func_020563d4(const void *src, u32 offset, u32 count);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern char *_ZN3G2S13GetBG3CharPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_020562b4(const void *src, u32 offset, u32 count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void func_02056554(const void *src, u32 offset, u32 count);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *p, u16 a, u16 b, u16 c, u16 d);
-extern void func_ov006_020d907c(void *p);
-extern void func_ov006_020d6630(void *p);
-extern void func_ov006_020d62e0(void *p);
-extern void func_ov006_020d604c(void *p);
-extern void func_ov004_020b04d0(int v);
-extern void func_ov004_020adb1c(int v);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int func_ov006_020d9244(void *arg0)
+int dScMgBomroom_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_020d9638.cpp
+++ b/src/func_ov006_020d9638.cpp
@@ -1,17 +1,17 @@
 //cpp
+// @symbol func_ov006_020d9638
+// @emits dScMgCard_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_020d96f0();
-extern void func_ov006_020d96e0();
-extern void *data_ov006_0213bdb4[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020d9638(char *c);
-void *func_ov006_020d9638(char *c) {
+void *dScMgCard_c_OnYoshiTryEat(char *c);
+void *dScMgCard_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213bdb4;
     func_0207328c(c + 0x5298, 5, 0x30, (void*)&func_ov006_020d96f0);
     func_0207328c(c + 0x51a8, 5, 0x30, (void*)&func_ov006_020d96e0);

--- a/src/func_ov006_020da994.c
+++ b/src/func_ov006_020da994.c
@@ -1,7 +1,11 @@
+// @symbol func_ov006_020da994
+// @emits dScMgCard_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::CleanupResources - recovered from vtable slot identity */
 extern int data_ov006_0214176c[];
 extern int data_ov006_02141768[];
 extern int data_ov006_02141770[];
-int func_ov006_020da994(void){
+int dScMgCard_c_CleanupResources(void){
   data_ov006_0214176c[0]=0;
   data_ov006_02141768[0]=0;
   data_ov006_02141770[0]=0;

--- a/src/func_ov006_020da9c4.cpp
+++ b/src/func_ov006_020da9c4.cpp
@@ -1,25 +1,28 @@
 //cpp
+// @symbol func_ov006_020da9c4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCard_c.h"
+// @emits dScMgCard_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::Render - recovered from vtable slot identity */
 struct Node {
     virtual void m0();
     char pad[0x2c];
 };
 
 extern "C" void func_ov006_020c0aa8(void *c);
-extern "C" int  func_ov006_020da5e8(void *a, void *b);
-extern "C" int  func_ov006_020da4ac(void *a, int b);
 extern "C" int  func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
 extern "C" void func_ov004_020b1bc8(char *a0, int a1, int a2, int a3);
 extern "C" void func_ov004_020b1e34(void *a0, int a1, int a2, int a3);
-extern "C" void func_ov004_020adb1c(int self);
-extern "C" void func_ov004_020b6430(void);
-extern "C" void func_ov006_020d9a14(char *thiz);
 extern "C" void func_ov006_020c1804(void *c);
 
-extern int data_ov006_02134010[6];
 extern int data_ov006_02134028;
 
-extern "C" int func_ov006_020da9c4(char *c)
+extern "C" int dScMgCard_c_Render(char *c)
 {
+    struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     int skip;
     short v;
     int i;
@@ -27,11 +30,11 @@ extern "C" int func_ov006_020da9c4(char *c)
 
     func_ov006_020c0aa8(c + 0x4660);
 
-    v = *(short *)(c + 0x5388);
+    v = self->unk_5388;
     if (v > 3 && v < 0x11) {
         skip = -1;
         if (v > 0xe) {
-            if (*(short *)(c + 0x5396) & 8) {
+            if (self->unk_5396 & 8) {
                 if (func_ov006_020da5e8(c + 0x51a8, c + 0x5298) == 1) {
                     skip = 6 - func_ov006_020da4ac(c + 0x51a8, 0);
                 }
@@ -52,9 +55,9 @@ extern "C" int func_ov006_020da9c4(char *c)
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
 
-    if (*(short *)(c + 0x5398) < *(int *)(c + 0xb4))
-        *(short *)(c + 0x5398) = *(int *)(c + 0xb4);
-    func_ov004_020adb1c(*(short *)(c + 0x5398));
+    if (self->unk_5398 < self->unk_0b4)
+        self->unk_5398 = self->unk_0b4;
+    func_ov004_020adb1c(self->unk_5398);
 
     func_ov004_020b6430();
 
@@ -67,12 +70,12 @@ extern "C" int func_ov006_020da9c4(char *c)
         Node *node = &bank[4];
         do {
             unsigned char cfg = *(unsigned char *)(cfgp + 0x5000 + 0x1d2);
-            if (*(short *)(c + 0x538e) == cfg)
+            if (self->unk_538e == cfg)
                 goto chk1;
-            if (*(short *)(c + 0x5390) != cfg)
+            if (self->unk_5390 != cfg)
                 goto docall1;
         chk1:
-            if (!(*(short *)(c + 0x5396) & 8))
+            if (!(self->unk_5396 & 8))
                 goto skip1;
         docall1:
             node->m0();
@@ -89,12 +92,12 @@ extern "C" int func_ov006_020da9c4(char *c)
         Node *node = &bank[4];
         do {
             unsigned char cfg = *(unsigned char *)(cfgp + 0x5000 + 0x2c2);
-            if (*(short *)(c + 0x5392) == cfg)
+            if (self->unk_5392 == cfg)
                 goto chk2;
-            if (*(short *)(c + 0x5394) != cfg)
+            if (self->unk_5394 != cfg)
                 goto docall2;
         chk2:
-            if (!(*(short *)(c + 0x5396) & 8))
+            if (!(self->unk_5396 & 8))
                 goto skip2;
         docall2:
             node->m0();

--- a/src/func_ov006_020dabec.c
+++ b/src/func_ov006_020dabec.c
@@ -1,8 +1,13 @@
+// @symbol func_ov006_020dabec
+// @emits dScMgCard_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::Behavior - recovered from vtable slot identity */
 extern void func_ov006_020c19d0(void*);
-extern void* func_ov006_020dac34(void*);
 extern void func_ov004_020b65e4(void*);
 
-int func_ov006_020dabec(char* c){
+int dScMgCard_c_Behavior(char* c){
   *(short*)(((int)c+0x5396) & 0xFFFFFFFFFFFFFFFF) += 1;
   func_ov006_020c19d0(c+0x4f38);
   func_ov004_020b65e4(func_ov006_020dac34(c));

--- a/src/func_ov006_020db6ec.c
+++ b/src/func_ov006_020db6ec.c
@@ -1,7 +1,15 @@
-extern int func_ov004_020b6324(int);
+// @symbol func_ov006_020db6ec
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCard_c.h"
+// @emits dScMgCard_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::OnGroundPounded - recovered from vtable slot identity */
 
-int func_ov006_020db6ec(void *this) {
-    int x = *(int *)((char *)this + 0xb4);
+int dScMgCard_c_OnGroundPounded(void *this) {
+    struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)this;
+    int x = self->unk_0b4;
     int v;
     if (x < 5) {
         v = 1;

--- a/src/func_ov006_020db720.c
+++ b/src/func_ov006_020db720.c
@@ -1,30 +1,32 @@
+// @symbol func_ov006_020db720
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCard_c.h"
+// @emits dScMgCard_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::OnTurnIntoEgg - recovered from vtable slot identity */
 typedef short s16;
 
-extern int func_ov006_020da5e8(void* a, void* b);
 extern void func_ov004_020b0aa0(int arg);
 extern int func_ov006_020c1718(void* p);
-extern void func_ov004_020b5ed0(void);
-extern int func_ov006_020da4ac(void* a, int b);
 extern void func_ov004_020b56c8(int a);
-extern void func_ov004_020b5d74(void);
 extern int _Z15ApproachLinear2Rsss(s16* r, s16 t, s16 s);
-extern void func_ov006_020d99a4(void* c);
 
-extern int data_ov006_0213bd48[];
-extern int data_ov004_020bfa18;
 extern s16 data_ov004_020bf9e4;
 extern void* func_020beb68;
 
-int func_ov006_020db720(char* c)
+int dScMgCard_c_OnTurnIntoEgg(char* c)
 {
-    switch (*(s16*)(c + 0x5388)) {
+    struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
+    switch (self->unk_5388) {
     case 0xe: {
         int r = func_ov006_020da5e8(c + 0x51a8, c + 0x5298);
         if (r == -1)
             func_ov004_020b0aa0(0xa);
         else if (r == 1)
             func_ov004_020b0aa0(9);
-        *(s16*)(c + 0x538a) = 0;
+        self->unk_538a = 0;
         *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
         break;
     }
@@ -33,14 +35,14 @@ int func_ov006_020db720(char* c)
             int r = func_ov006_020da5e8(c + 0x51a8, c + 0x5298);
             if (r == -1) {
                 func_ov004_020b5ed0();
-                *(s16*)(c + 0x538a) = 0;
+                self->unk_538a = 0;
             } else if (r == 1) {
                 int v = data_ov006_0213bd48[func_ov006_020da4ac(c + 0x51a8, 0)];
                 func_ov004_020b56c8(v * data_ov004_020bfa18);
-                *(s16*)(c + 0x538a) = 0;
+                self->unk_538a = 0;
             } else {
                 func_ov004_020b5d74();
-                *(s16*)(c + 0x538a) = 0x1e;
+                self->unk_538a = 0x1e;
             }
             *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
         }
@@ -74,7 +76,7 @@ int func_ov006_020db720(char* c)
             a += 0x30;
             b += 0x30;
         }
-        *(s16*)(c + 0x538a) = 0x3c;
+        self->unk_538a = 0x3c;
         *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
         break;
     }

--- a/src/func_ov006_020db9dc.c
+++ b/src/func_ov006_020db9dc.c
@@ -1,30 +1,35 @@
+// @symbol func_ov006_020db9dc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCard_c.h"
+// @emits dScMgCard_c_OnYoshiTryEat_020db9dc
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::OnYoshiTryEat - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 
 extern void func_ov006_020c1604(char *c, int unused, short a2, int a3);
-extern void func_ov006_020da974(int v);
-extern void func_ov006_020da00c(char *p);
 extern void func_ov004_020b66d4(void);
-extern int func_020bc7d4;
 extern int data_ov006_0214176c;
 extern int data_ov006_02141768;
 extern int data_ov006_02141770;
-extern int data_ov006_0213bc44;
 
-void func_ov006_020db9dc(char *c)
+void dScMgCard_c_OnYoshiTryEat_020db9dc(char *c)
 {
+    struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     int i;
     char *p1, *p2;
 
-    *(s16 *)(c + 0x538c) = 0;
-    *(s16 *)(c + 0x538e) = 6;
-    *(s16 *)(c + 0x5390) = 6;
-    *(s16 *)(c + 0x5392) = 6;
-    *(s16 *)(c + 0x5394) = 6;
+    self->unk_538c = 0;
+    self->unk_538e = 6;
+    self->unk_5390 = 6;
+    self->unk_5392 = 6;
+    self->unk_5394 = 6;
     func_ov006_020c1604(c + 0x4f38, 4, 5, (int)(c + 0x538c));
 
-    *(s16 *)(c + 0x511e) = 1;
-    *(s16 *)(c + 0x4f52) = 2;
+    self->unk_511e = 1;
+    self->unk_4f52 = 2;
     func_ov006_020da974(5);
 
     p1 = c + 0x51a8;
@@ -42,7 +47,7 @@ void func_ov006_020db9dc(char *c)
     data_ov006_0214176c = 0;
     data_ov006_02141768 = 0;
     data_ov006_02141770 = 0;
-    *(char *)(c + 0x539a) = 0;
+    self->unk_539a = 0;
     data_ov006_0213bc44 = 1;
-    *(s16 *)(c + 0x5388) = 1;
+    self->unk_5388 = 1;
 }

--- a/src/func_ov006_020dbaf0.cpp
+++ b/src/func_ov006_020dbaf0.cpp
@@ -1,5 +1,13 @@
 //cpp
-/* func_ov006_020dbaf0 @ 0x020dbaf0 (ov006, size 0x264)
+// @symbol func_ov006_020dbaf0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCard_c.h"
+// @emits dScMgCard_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgCard_c::InitResources - recovered from vtable slot identity */
+/* dScMgCard_c_InitResources @ 0x020dbaf0 (ov006, size 0x264)
  * Minigame graphics init: loads/decompresses the OBJ tiles+palettes for both
  * engines, sets blending, patches the OAM attr template list, spawns the two
  * rows of 5 slot sprites, and resets the shared counters.
@@ -43,28 +51,22 @@ struct VtObj {
 extern "C" {
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int data_ov006_0213bcb0[];
 extern u32 *data_ov006_02134028;
 extern char *data_ov004_020beb68;
 
-extern void func_ov004_020b04d0(int);
 extern void func_ov006_0210a534(char *);
 extern void *LoadFile(int);
 extern int func_ov004_020ad674(void);
 extern void DecompressLZ16(void *, u32);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(void *, u32, u32);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(void *, u32, u32);
-extern void Deallocate(void *);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *, int, int, int, int);
 extern void func_ov006_020c0aa8(char *);
 extern int func_ov006_020c1a88(char *);
-extern void func_ov006_020da0ac(char *, int *);
-extern int func_ov004_020ad8b8(void);
-extern int func_ov004_020ad878(void);
-extern void func_ov004_020b682c(void);
 
-int func_ov006_020dbaf0(char *c)
+int dScMgCard_c_InitResources(char *c)
 {
+    struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     void *f7, *f6, *f5, *f4;
     int v[2];
 
@@ -117,16 +119,16 @@ int func_ov006_020dbaf0(char *c)
         }
     }
 
-    *(u16 *)(c + 0x5388) = 0;
-    *(u16 *)(c + 0x538a) = 0;
-    *(int *)(c + 0xa8) = func_ov004_020ad8b8();
-    *(int *)(c + 0xac) = *(int *)(c + 0xa8);
+    self->unk_5388 = 0;
+    self->unk_538a = 0;
+    self->unk_0a8 = func_ov004_020ad8b8();
+    self->unk_0ac = self->unk_0a8;
     {
         int r = func_ov004_020ad878();
         if (data_ov004_020beb68 != 0)
             *(int *)(data_ov004_020beb68 + 0xb4) = r;
     }
-    *(u16 *)(c + 0x5398) = 0;
+    self->unk_5398 = 0;
     func_ov004_020b682c();
     ((VtObj *)c)->m18(-1);
     return 1;

--- a/src/func_ov006_020dbe64.c
+++ b/src/func_ov006_020dbe64.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020dbe64(int *t)
+// @symbol func_ov006_020dbe64
+// @emits dScMgCoin_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgCoin_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020de5b0.c
+++ b/src/func_ov006_020de5b0.c
@@ -1,23 +1,28 @@
-extern void func_ov006_020ddf9c(char *c);
+// @symbol func_ov006_020de5b0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCoin_c.h"
+// @emits dScMgCoin_c_OnYoshiTryEat_020de5b0
+/* recovered: renamed to Class_Method */
+/* dScMgCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b0aa0(int n);
-extern void func_ov006_020dd334(char *c);
-extern void func_ov006_020dc7b4(char *c);
-extern void func_ov006_020dc2f8(char *c);
 extern int func_ov004_020adc1c(void);
-void func_ov006_020de5b0(char *c);
-void func_ov006_020de5b0(char *c){
-    if (*(unsigned char*)(c + 0x51db) != 0) {
+void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c);
+void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c){
+    struct dScMgCoin_c *self = (struct dScMgCoin_c *)(void *)c;
+    if (self->unk_51db != 0) {
         *(unsigned char*)(((int)c + 0x51da) & 0xFFFFFFFFFFFFFFFF) += 1;
     } else {
-        *(unsigned char*)(c + 0x51da) = 0;
+        self->unk_51da = 0;
     }
-    *(int*)(c + 0xa8) = 0;
-    *(int*)(c + 0xac) = *(int*)(c + 0xa8);
+    self->unk_0a8 = 0;
+    self->unk_0ac = self->unk_0a8;
     func_ov006_020ddf9c(c);
     func_ov004_020b0aa0(0x1d);
     func_ov006_020dd334(c);
     func_ov006_020dc7b4(c);
     func_ov006_020dc2f8(c);
-    *(int*)(c + 0x51d4) = func_ov004_020adc1c();
-    *(int*)(c + 0x51c8) = 0;
+    self->unk_51d4 = func_ov004_020adc1c();
+    self->unk_51c8 = 0;
 }

--- a/src/func_ov006_020de63c.c
+++ b/src/func_ov006_020de63c.c
@@ -1,3 +1,7 @@
+// @symbol func_ov006_020de63c
+// @emits dScMgCoin_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgCoin_c::Render - recovered from vtable slot identity */
 void func_ov006_020dccb8(void *c);
 void func_ov006_020dcd74(void *c);
 void func_ov006_020dc814(void *c);
@@ -9,7 +13,7 @@ void func_ov006_020dc870(void *c);
 void func_ov006_020dcea8(void *c);
 void func_ov006_020dcc48(void *c);
 
-int func_ov006_020de63c(void *c)
+int dScMgCoin_c_Render(void *c)
 {
     func_ov006_020dccb8(c);
     func_ov006_020dcd74(c);

--- a/src/func_ov006_020de69c.cpp
+++ b/src/func_ov006_020de69c.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020de69c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCoin_c.h"
+// @emits dScMgCoin_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgCoin_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern Entry data_ov006_02141810[];
@@ -8,10 +14,11 @@ void func_ov006_020dc754(void *c);
 void func_ov006_020dc298(void *c);
 void func_ov006_020dc900(void *c);
 void func_ov006_020dce3c(void *c);
-int func_ov006_020de69c(C *c);
+int dScMgCoin_c_Behavior(C *c);
 }
-int func_ov006_020de69c(C *c) {
-    int idx = *(int *)((char *)c + 0x51c8);
+int dScMgCoin_c_Behavior(C *c) {
+    struct dScMgCoin_c *self = (struct dScMgCoin_c *)(void *)c;
+    int idx = self->unk_51c8;
     (c->*data_ov006_02141810[idx].pmf)();
     func_ov006_020dc754(c);
     func_ov006_020dc298(c);

--- a/src/func_ov006_020de704.c
+++ b/src/func_ov006_020de704.c
@@ -1,29 +1,25 @@
+// @symbol func_ov006_020de704
+// @emits dScMgCoin_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCoin_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern int LoadFile(int handle);
-extern int func_02054d88(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern char *_ZN3G2S13GetBG3CharPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_020562b4(const void *src, u32 offset, u32 count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_ov006_020ddf9c(char *c);
-extern void func_ov006_020dd334(char *c);
-extern void func_ov006_020dc7b4(char *c);
-extern void func_ov006_020dc2f8(char *c);
-extern void func_ov004_020b04d0(int v);
 extern int func_ov004_020adc1c(void);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 extern int data_0208ee44;
 
-int func_ov006_020de704(void *arg0) {
+int dScMgCoin_c_InitResources(void *arg0) {
     char *c = (char*)arg0;
     int a, b, d;
 

--- a/src/func_ov006_020dea1c.cpp
+++ b/src/func_ov006_020dea1c.cpp
@@ -1,17 +1,18 @@
 //cpp
+// @symbol func_ov006_020dea1c
+// @emits dScMgCup_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCup_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern int func_ov006_020c3288(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
 extern void func_0203d47c();
-extern void func_ov006_020deac4();
-extern void *data_ov006_0213c154[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020dea1c(char *c);
-void *func_ov006_020dea1c(char *c) {
+void *dScMgCup_c_OnYoshiTryEat(char *c);
+void *dScMgCup_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213c154;
     func_0207328c(c + 0x53e8, 3, 8, (void*)&func_0203d47c);
     func_0207328c(c + 0x50e8, 0x20, 0x18, (void*)&func_ov006_020deac4);

--- a/src/func_ov006_020dfed4.c
+++ b/src/func_ov006_020dfed4.c
@@ -1,5 +1,9 @@
+// @symbol func_ov006_020dfed4
+// @emits dScMgCup_c_Virtual50
+/* recovered: renamed to Class_Method */
+/* dScMgCup_c::Virtual50 - recovered from vtable slot identity */
 extern void func_ov006_020c2594(void*);
 
-void func_ov006_020dfed4(char* p) {
+void dScMgCup_c_Virtual50(char* p) {
     func_ov006_020c2594(p + 0x4f38);
 }

--- a/src/func_ov006_020e0204.cpp
+++ b/src/func_ov006_020e0204.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020e0204
+// @emits dScMgCup_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCup_c::Behavior - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
 
 class C { public: int dummy; };
@@ -12,11 +18,8 @@ typedef struct Frame {
 
 extern "C" Frame *data_ov006_0213c0d8[];
 
-extern "C" void func_ov006_020dedfc(char *o, int a, int b, int i);
-extern "C" void func_ov006_020debfc(char *p);
-extern "C" void func_ov006_020c2b8c(char *p);
 
-extern "C" int func_ov006_020e0204(char *o)
+extern "C" int dScMgCup_c_Behavior(char *o)
 {
     int i;
     (((C *)o)->*data_ov006_02141870[*(int *)(o + 0x5418)])();

--- a/src/func_ov006_020e0308.cpp
+++ b/src/func_ov006_020e0308.cpp
@@ -1,5 +1,11 @@
 //cpp
-/* func_ov006_020e0308 @ 0x020e0308 (ov006, size 0x26c)
+// @symbol func_ov006_020e0308
+// @emits dScMgCup_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCup_c::InitResources - recovered from vtable slot identity */
+/* dScMgCup_c_InitResources @ 0x020e0308 (ov006, size 0x26c)
  * Minigame sub-screen setup: configures sub BG1/BG2 control, loads the
  * board tiles/map/palette files, sets the touch UI margins, initializes
  * the three sliders from the table at data_ov006_0213c0a8, then calls
@@ -49,30 +55,19 @@ extern "C" {
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 extern int data_0208ee44;
-extern int data_ov004_020bc880;
-extern int data_ov004_020bc884;
-extern int data_ov004_020bc8a8;
-extern int data_ov004_020bc898;
-extern int data_ov004_020bc8a4;
-extern int data_ov004_020bc86c;
 extern Pair6 data_ov006_0213c0a8[];
 
 extern void func_ov006_020c225c(char *);
 extern int func_ov006_020c3050(char *);
-extern void SetSubBg0Offset(int, int);
-extern void SetSubBg2Offset(int, int);
 extern int func_02054de8(void);
 extern void LoadCompressedFileAt(int, int);
 extern void *LoadFile(int);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(void *, unsigned int, unsigned int);
-extern void Deallocate(void *);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern int _ZN3G2S12GetBG2ScrPtrEv(void);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(void *, unsigned int, unsigned int);
-extern void func_ov004_020b6808(void);
-extern void func_ov006_020dec3c(char *);
 
-int func_ov006_020e0308(char *c)
+int dScMgCup_c_InitResources(char *c)
 {
     void *f;
 

--- a/src/func_ov006_020e065c.c
+++ b/src/func_ov006_020e065c.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020e065c(int *t)
+// @symbol func_ov006_020e065c
+// @emits dScMgCurling_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgCurling_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020e3470.c
+++ b/src/func_ov006_020e3470.c
@@ -1,12 +1,19 @@
+// @symbol func_ov006_020e3470
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCurling_c.h"
+// @emits dScMgCurling_c_OnYoshiTryEat_020e3470
+/* recovered: renamed to Class_Method */
+/* dScMgCurling_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_020e3388(void*);
 extern void func_ov006_020e3250(void*);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void*,unsigned short,unsigned short,unsigned short,unsigned short);
 extern int func_ov004_020adc1c(void);
-void func_ov006_020e3470(unsigned char* c){
-  *(int*)(c+0x4eac)=0;
+void dScMgCurling_c_OnYoshiTryEat_020e3470(unsigned char* c){
+    struct dScMgCurling_c *self = (struct dScMgCurling_c *)(void *)c;
+  self->unk_4eac=0;
   func_ov006_020e3388(c);
   func_ov006_020e3250(c);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4000050,0,0xd,2,0x10);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4001050,0,4,2,0x10);
-  *(int*)(c+0x4ed8)=func_ov004_020adc1c();
+  self->unk_4ed8=func_ov004_020adc1c();
 }

--- a/src/func_ov006_020e34ec.c
+++ b/src/func_ov006_020e34ec.c
@@ -1,10 +1,13 @@
+// @symbol func_ov006_020e34ec
+// @emits dScMgCurling_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling_c::Render - recovered from vtable slot identity */
 extern int func_ov004_020adc1c(char*);
 extern int func_ov004_020b19f0(int);
-extern int func_ov006_020e1554(char*);
-extern int func_ov006_020e1c68(char*);
-extern int _ZN6Player16St_WallJump_InitEv(char*);
-extern int func_ov006_020e0694(char*);
-int func_ov006_020e34ec(char*c){
+int dScMgCurling_c_Render(char*c){
   func_ov004_020b19f0(func_ov004_020adc1c(c));
   func_ov006_020e1554(c);
   func_ov006_020e1c68(c);

--- a/src/func_ov006_020e3528.cpp
+++ b/src/func_ov006_020e3528.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov006_020e3528
+// @emits dScMgCurling_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgCurling_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf[1]; };
 extern Entry data_ov006_02141950[];
 struct C { char pad[0x4eac]; int idx; };
 extern "C" int func_ov006_020e12d0(C*);
-extern "C" int func_ov006_020e3528(C* c){
+extern "C" int dScMgCurling_c_Behavior(C* c){
   int j = c->idx;
   (c->*data_ov006_02141950[j].pmf[0])();
   func_ov006_020e12d0(c);

--- a/src/func_ov006_020e3578.c
+++ b/src/func_ov006_020e3578.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_020e3578
+// @emits dScMgCurling_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 
@@ -6,29 +12,20 @@ extern void* _ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(const void* src, void* dst);
 extern void* LoadFile(int handle);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void Deallocate(void* ptr);
-extern void func_020563d4(const void* src, u32 off, u32 cnt);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern unsigned func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void func_02056374(const void* src, u32 off, u32 cnt);
 extern void func_ov004_020adc5c(void* p);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern void func_ov006_020e3388(char* self);
-extern void func_ov006_020e3378(char* p);
 extern void func_ov006_020e3250(char* c);
-extern void func_ov006_020e2dbc(char* c);
-extern void func_ov006_020e13a4(char* c);
-extern void func_ov004_020b04d0(int v);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16* p, u16 a, u16 b, u16 c, u16 d);
 extern int func_ov004_020adc1c(void);
 
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
-extern char data_ov006_0213c394;
-extern char data_ov006_0213c3b4;
 
-int func_ov006_020e3578(char* self)
+int dScMgCurling_c_InitResources(char* self)
 {
     char* a = func_020adc74(&data_ov006_0213c394);
     char* b = func_020adc74(&data_ov006_0213c3b4);

--- a/src/func_ov006_020e3878.c
+++ b/src/func_ov006_020e3878.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020e3878(int *t)
+// @symbol func_ov006_020e3878
+// @emits dScMgCurling2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling2_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgCurling2_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020e6774.c
+++ b/src/func_ov006_020e6774.c
@@ -1,12 +1,19 @@
+// @symbol func_ov006_020e6774
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgCurling2_c.h"
+// @emits dScMgCurling2_c_OnYoshiTryEat_020e6774
+/* recovered: renamed to Class_Method */
+/* dScMgCurling2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_020e668c(void*);
 extern void func_ov006_020e6528(void*);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void*,unsigned short,unsigned short,unsigned short,unsigned short);
 extern int func_ov004_020adc1c(void);
-void func_ov006_020e6774(unsigned char* c){
-  *(int*)(c+0x5580)=0;
+void dScMgCurling2_c_OnYoshiTryEat_020e6774(unsigned char* c){
+    struct dScMgCurling2_c *self = (struct dScMgCurling2_c *)(void *)c;
+  self->unk_5580=0;
   func_ov006_020e668c(c);
   func_ov006_020e6528(c);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4000050,0,0xd,2,0x10);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4001050,0,4,2,0x10);
-  *(int*)(c+0x55ac)=func_ov004_020adc1c();
+  self->unk_55ac=func_ov004_020adc1c();
 }

--- a/src/func_ov006_020e67f0.c
+++ b/src/func_ov006_020e67f0.c
@@ -1,12 +1,12 @@
-int func_ov006_020e67f0(int c){
+// @symbol func_ov006_020e67f0
+// @emits dScMgCurling2_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling2_c::Render - recovered from vtable slot identity */
+int dScMgCurling2_c_Render(int c){
   extern int func_ov004_020adc1c();
   extern int func_ov004_020b19f0();
-  extern int func_ov006_020e4a84();
-  extern int func_ov006_020e4fe8();
-  extern int func_ov006_020e507c();
-  extern int func_ov006_020e38b0();
-  extern int func_ov006_020e3bc4();
-  extern int func_ov006_020e4b78();
   func_ov004_020adc1c();
   func_ov004_020b19f0();
   func_ov006_020e4a84(c);

--- a/src/func_ov006_020e683c.cpp
+++ b/src/func_ov006_020e683c.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov006_020e683c
+// @emits dScMgCurling2_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling2_c::Behavior - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_020e4800(void*);
-extern int func_ov006_020e3948(void*);
 struct Ent{ int a; int b; };
 extern Ent data_ov006_02141a18[];
-int func_ov006_020e683c(char* c){
+int dScMgCurling2_c_Behavior(char* c){
   int idx=*(int*)(c+0x5000+0x580);
   Ent* e=&data_ov006_02141a18[idx];
   int adj=e->b;

--- a/src/func_ov006_020e6894.c
+++ b/src/func_ov006_020e6894.c
@@ -1,38 +1,34 @@
+// @symbol func_ov006_020e6894
+// @emits dScMgCurling2_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgCurling2_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 
 extern char* func_020adc74(void* p);
-extern int func_02054d88(void);
 extern void DecompressLZ16(const void* src, void* dst);
 extern void* LoadFile(int handle);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void Deallocate(void* ptr);
-extern void func_02056314(void* dst, u32 offset, u32 len);
 extern char* _ZN2G212GetBG2ScrPtrEv(void);
 extern void MultiStore16(u16 val, char* dst, int nbytes);
-extern void func_020563d4(const void* src, u32 off, u32 cnt);
 extern void func_02056554(const void* src, int offset, int count);
 extern char* _ZN2G212GetBG0ScrPtrEv(void);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern unsigned func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void func_02056374(const void* src, u32 off, u32 cnt);
 extern void func_ov004_020adc5c(void* p);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern void func_ov006_020e668c(char* c);
-extern void func_ov006_020e667c(char* p);
 extern void func_ov006_020e6528(char* c);
-extern void func_ov006_020e5ffc(char* self);
-extern void func_ov006_020e48d4(char* c);
-extern void func_ov004_020b04d0(int v);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16* p, u16 a, u16 b, u16 c, u16 d);
 extern int func_ov004_020adc1c(void);
 
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
-extern char data_ov006_0213c5a0;
 
-int func_ov006_020e6894(char* self)
+int dScMgCurling2_c_InitResources(char* self)
 {
     char* r6 = func_020adc74(&data_ov006_0213c5a0);
     void* f;

--- a/src/func_ov006_020e6bf4.c
+++ b/src/func_ov006_020e6bf4.c
@@ -1,12 +1,15 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void func_ov004_020b2adc(void *);
-extern int VT0[];
+// @symbol func_ov006_020e6bf4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15dScMgCurling2_c */
 int *func_ov006_020e6bf4(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(21956);
     if (p) {
         func_ov004_020b2adc(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV15dScMgCurling2_c;
     }
     return p;
 }

--- a/src/func_ov006_020e6cac.c
+++ b/src/func_ov006_020e6cac.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_020e6cac
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline2_c.h"
+// @emits dScMgTrampoline2_c_OnAimedAtWithEggReturnVec
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 void _ZN2GX15SetBankForSubBGEt(unsigned int);
 void _ZN2GX16SetBankForSubOBJEt(unsigned int);
 void func_ov006_020e740c(void);
@@ -7,13 +13,14 @@ void func_ov006_020e759c(void);
 extern unsigned char data_0209e660;
 extern unsigned char data_0209f5f8;
 
-void func_ov006_020e6cac(char *this) {
-    _ZN2GX15SetBankForSubBGEt(*(int*)(this + 0xa0));
-    _ZN2GX16SetBankForSubOBJEt(*(int*)(this + 0x4660));
+void dScMgTrampoline2_c_OnAimedAtWithEggReturnVec(char *this) {
+    struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)this;
+    _ZN2GX15SetBankForSubBGEt(self->unk_0a0);
+    _ZN2GX16SetBankForSubOBJEt(self->unk_4660);
     data_0209e660 = 1;
     func_ov006_020e740c();
     func_ov004_020aeed8(this);
-    if (*(unsigned short*)(this + 0x4664) == 1) {
+    if (self->unk_4664 == 1) {
         func_ov006_020e7508();
     } else {
         func_ov006_020e759c();

--- a/src/func_ov006_020e6d24.cpp
+++ b/src/func_ov006_020e6d24.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020e6d24
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline2_c.h"
+// @emits dScMgTrampoline2_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern "C" {
 void func_ov006_020e73c4(void);
 void _ZN3GXS11LoadOBJPlttEPKvjj(void const *p, unsigned int a, unsigned int b);
@@ -9,15 +15,16 @@ void _ZN2GX16SetBankForSubOBJEt(unsigned short x);
 void func_ov004_020af094(void *c);
 extern void *data_ov006_02141a48[];
 extern unsigned char data_0209e660;
-void func_ov006_020e6d24(char *c);
+void dScMgTrampoline2_c_OnAimedAtWithEgg(char *c);
 }
-void func_ov006_020e6d24(char *c) {
+void dScMgTrampoline2_c_OnAimedAtWithEgg(char *c) {
+    struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)c;
     func_ov006_020e73c4();
     _ZN3GXS11LoadOBJPlttEPKvjj(data_ov006_02141a48[0], 0x100, 0x100);
     data_0209e660 = 0;
-    *(int *)(c + 0xa0) = func_02053eb0();
+    self->unk_0a0 = func_02053eb0();
     _ZN2GX15SetBankForSubBGEt(0x80);
-    *(int *)(c + 0x4660) = func_02053ea0();
+    self->unk_4660 = func_02053ea0();
     _ZN2GX16SetBankForSubOBJEt(0x100);
     func_ov004_020af094(c);
 }

--- a/src/func_ov006_020e6d8c.c
+++ b/src/func_ov006_020e6d8c.c
@@ -1,6 +1,10 @@
-/* func_ov006_020e6d8c @ 0x20e6d8c (ov006) -- tail-call veneer to func_ov004_020af04c (co-loaded ov004). */
+// @symbol func_ov006_020e6d8c
+// @emits dScMgTrampoline2_c_OnHitFromUnderneath
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnHitFromUnderneath - recovered from vtable slot identity */
+/* dScMgTrampoline2_c_OnHitFromUnderneath @ 0x20e6d8c (ov006) -- tail-call veneer to func_ov004_020af04c (co-loaded ov004). */
 extern void func_ov004_020af04c(void);
 
-void func_ov006_020e6d8c(void) {
+void dScMgTrampoline2_c_OnHitFromUnderneath(void) {
     func_ov004_020af04c();
 }

--- a/src/func_ov006_020e6d98.c
+++ b/src/func_ov006_020e6d98.c
@@ -1,6 +1,10 @@
-/* func_ov006_020e6d98 @ 0x20e6d98 (ov006) -- tail-call veneer to func_ov004_020af27c (co-loaded ov004). */
+// @symbol func_ov006_020e6d98
+// @emits dScMgTrampoline2_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnHitByMegaChar - recovered from vtable slot identity */
+/* dScMgTrampoline2_c_OnHitByMegaChar @ 0x20e6d98 (ov006) -- tail-call veneer to func_ov004_020af27c (co-loaded ov004). */
 extern void func_ov004_020af27c(void);
 
-void func_ov006_020e6d98(void) {
+void dScMgTrampoline2_c_OnHitByMegaChar(void) {
     func_ov004_020af27c();
 }

--- a/src/func_ov006_020e6e4c.c
+++ b/src/func_ov006_020e6e4c.c
@@ -1,4 +1,8 @@
-int func_ov006_020e6e4c(void)
+// @symbol func_ov006_020e6e4c
+// @emits dScMgTrampoline2_c_OnHitByCannonBlastedChar
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
+int dScMgTrampoline2_c_OnHitByCannonBlastedChar(void)
 {
     return 2;
 }

--- a/src/func_ov006_020e6e54.c
+++ b/src/func_ov006_020e6e54.c
@@ -1,2 +1,7 @@
-extern int func_ov004_020ae128(void *);
-int func_ov006_020e6e54(void *t) { return func_ov004_020ae128(t) != 0; }
+// @symbol func_ov006_020e6e54
+// @emits dScMgJump2_c_OnPushed
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::OnPushed - recovered from vtable slot identity */
+int dScMgJump2_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_020e6e78.cpp
+++ b/src/func_ov006_020e6e78.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol func_ov006_020e6e78
+// @emits dScMgJump2_c_OnKicked
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::OnKicked - recovered from vtable slot identity */
 extern "C" int func_ov004_020ae140(void* self);
 extern "C" void func_ov006_020c0134(int arg);
-extern "C" void func_ov006_020e7508(void);
-extern "C" void func_ov006_020e759c(void);
 
-extern unsigned char data_0209d464;
-extern int data_ov006_02141a44;
 extern unsigned char data_0209f5f8;
 
-extern "C" int func_ov006_020e6e78(char* self)
+extern "C" int dScMgJump2_c_OnKicked(char* self)
 {
     if (func_ov004_020ae140(self) == 0) return 0;
     if (*(int*)(self + 0x4628) == 0) {

--- a/src/func_ov006_020e72c0.c
+++ b/src/func_ov006_020e72c0.c
@@ -1,3 +1,11 @@
+// @symbol func_ov006_020e72c0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline2_c.h"
+// @emits dScMgTrampoline2_c_Kill
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::Kill - recovered from vtable slot identity */
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef int s32;
@@ -13,21 +21,19 @@ void _ZN2GX16SetBankForSubOBJEt(unsigned int);
 void _ZN2GX15SetBankForSubBGEt(unsigned int);
 void *_ZN3G2S12GetBG1ScrPtrEv(void);
 
-extern unsigned int data_ov006_0213c5fc[];
-extern unsigned int data_ov006_0213c5e8[];
-extern unsigned int data_ov006_0213c610[];
 extern unsigned char data_0209d454;
 
-void func_ov006_020e72c0(char *c) {
-  *(int*)(c + 0x4660) = func_02053ea0();
+void dScMgTrampoline2_c_Kill(char *c) {
+    struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)c;
+  self->unk_4660 = func_02053ea0();
   _ZN2GX16SetBankForSubOBJEt(0x100);
   LoadCompressedFileAt(data_ov006_0213c5fc[func_ov004_020ad674()], (void*)0x6600000);
   {
     char *dst = (char*)0x6600000; dst += 0x2000;
     DecompressLZ16((void*)data_ov006_0213c5e8[func_ov004_020ad674()], dst);
   }
-  _ZN2GX16SetBankForSubOBJEt(*(int*)(c + 0x4660));
-  *(int*)(c + 0xa0) = func_02053eb0();
+  _ZN2GX16SetBankForSubOBJEt(self->unk_4660);
+  self->unk_0a0 = func_02053eb0();
   _ZN2GX15SetBankForSubBGEt(0x80);
   {
     volatile u16 *p = (volatile u16*)0x400100a;
@@ -42,5 +48,5 @@ void func_ov006_020e72c0(char *c) {
     LoadCompressedFileAt(data_ov006_0213c610[i], (void*)func_02054e88());
   }
   LoadCompressedFileAt(0x5b, _ZN3G2S12GetBG1ScrPtrEv());
-  _ZN2GX15SetBankForSubBGEt(*(int*)(c + 0xa0));
+  _ZN2GX15SetBankForSubBGEt(self->unk_0a0);
 }

--- a/src/func_ov006_020e76e4.c
+++ b/src/func_ov006_020e76e4.c
@@ -1,13 +1,15 @@
-extern void _ZN18TextureTransformerD1Ev(void*);
-extern void func_ov006_020e80d8(void*);
-extern void _ZN5ModelD1Ev(void*);
+// @symbol func_ov006_020e76e4
+// @emits dScMg3DEsp_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN8Particle10SysTrackerD1Ev(void*);
-extern void func_ov004_020b29c0(void*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
-extern int data_ov006_0213c8c4;
 extern int data_ov006_0213e448;
 extern void* data_020a0eac;
-void* func_ov006_020e76e4(char* p){
+void* dScMg3DEsp_c_OnYoshiTryEat(char* p){
   *(int*)p = (int)&data_ov006_0213c8c4;
   _ZN18TextureTransformerD1Ev(p + 0x51f4);
   func_ov006_020e80d8(p + 0x4fd8);

--- a/src/func_ov006_020e777c.cpp
+++ b/src/func_ov006_020e777c.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov006_020e777c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M48 { int w[12]; };
-extern M48 data_020a0e68;
+
+extern Matrix4x3 data_020a0e68;
 void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 }
 struct ModelComponents;
@@ -27,7 +30,7 @@ void func_ov006_020e777c(char *c)
     zero = (void*)i;
     do {
         if (*(int*)(c + i*4 + 0x168) != 0) {
-            *(M48*)(r5 + 0x1c) = data_020a0e68;
+            *(Matrix4x3*)(r5 + 0x1c) = data_020a0e68;
             ((MaterialChanger*)r4)->Update(*(ModelComponents*)(r5 + 8));
             ((Obj*)r5)->m(zero);
         }

--- a/src/func_ov006_020e7b0c.c
+++ b/src/func_ov006_020e7b0c.c
@@ -1,5 +1,8 @@
-struct S{ int w[12]; };
-extern struct S data_ov006_0213c85c;
+// @symbol func_ov006_020e7b0c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 void func_ov006_020e7b0c(char* c){
-  *(struct S*)(c+0x28)=data_ov006_0213c85c;
+  *(struct Matrix4x3*)(c+0x28)=data_ov006_0213c85c;
 }

--- a/src/func_ov006_020e9c10.c
+++ b/src/func_ov006_020e9c10.c
@@ -1,8 +1,12 @@
-/* func_ov006_020e9c10 at 0x020e9c10 - thunk: func_ov004_020b0aa0(8) */
+// @symbol func_ov006_020e9c10
+// @emits dScMg3DEsp_c_Virtual50
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::Virtual50 - recovered from vtable slot identity */
+/* dScMg3DEsp_c_Virtual50 at 0x020e9c10 - thunk: func_ov004_020b0aa0(8) */
 
 extern int func_ov004_020b0aa0(int a);
 
-int func_ov006_020e9c10(void)
+int dScMg3DEsp_c_Virtual50(void)
 {
     return func_ov004_020b0aa0(8);
 }

--- a/src/func_ov006_020e9c20.c
+++ b/src/func_ov006_020e9c20.c
@@ -1,24 +1,30 @@
-extern void func_ov006_020e984c(char* c);
-extern void func_ov006_020e7fb0(char* c);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
+// @symbol func_ov006_020e9c20
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMg3DEsp_c.h"
+// @emits dScMg3DEsp_c_OnYoshiTryEat_020e9c20
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern char* func_020beb68;
 
-void func_ov006_020e9c20(char* c, int a)
+void dScMg3DEsp_c_OnYoshiTryEat_020e9c20(char* c, int a)
 {
+    struct dScMg3DEsp_c *self = (struct dScMg3DEsp_c *)(void *)c;
     func_ov006_020e984c(c);
-    *(int*)(c + 0x553c) = 0;
+    self->unk_553c = 0;
     if (a == 0) {
         int* p = (int*)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFF);
         *p += 1;
-        if (*(unsigned int*)(c + 0xbc) > 0x270e) *(unsigned int*)(c + 0xbc) = 0x270e;
+        if (self->unk_0bc > 0x270e) self->unk_0bc = 0x270e;
     } else if (a == 0x12) {
         if (func_020beb68 != 0) *(int*)(func_020beb68 + 0xb4) = 0;
-        *(unsigned int*)(c + 0xbc) = 0;
-        if (*(unsigned int*)(c + 0xbc) > 0x270e) *(unsigned int*)(c + 0xbc) = 0x270e;
+        self->unk_0bc = 0;
+        if (self->unk_0bc > 0x270e) self->unk_0bc = 0x270e;
     }
     {
         char* dest = (char*)(c + 0x4fd8);
-        *(int*)(c + 0x51e4) = 0;
+        self->unk_51e4 = 0;
         func_ov006_020e7fb0(dest);
     }
     func_ov004_020b0cac(0xd, 0x80, 0xa8, 1, -1, 0xd);

--- a/src/func_ov006_020e9cec.c
+++ b/src/func_ov006_020e9cec.c
@@ -1,7 +1,12 @@
+// @symbol func_ov006_020e9cec
+// @emits dScMg3DEsp_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov006_020e9cec(void)
+int dScMg3DEsp_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     _ZN13SharedFilePtr7ReleaseEv(G1);

--- a/src/func_ov006_020e9d1c.cpp
+++ b/src/func_ov006_020e9d1c.cpp
@@ -1,29 +1,33 @@
 //cpp
-extern "C" void func_ov006_020e81a4(char *c);
-extern "C" void func_ov006_020e8e10(char *c);
-extern "C" void func_ov006_020e8b18(char *c);
-extern "C" void func_ov006_020e8354(char *c);
+// @symbol func_ov006_020e9d1c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMg3DEsp_c.h"
+// @emits dScMg3DEsp_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::Render - recovered from vtable slot identity */
 extern "C" void func_ov006_020c0134(char *c);
-extern "C" void func_ov006_020e7b44(char *c);
 
 struct ModelComponents;
 struct TextureTransformer { void Update(ModelComponents &m); };
 
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void vcall(int); };
 
-extern "C" int func_ov006_020e9d1c(char *c)
+extern "C" int dScMg3DEsp_c_Render(char *c)
 {
+    struct dScMg3DEsp_c *self = (struct dScMg3DEsp_c *)(void *)c;
     func_ov006_020e81a4(c);
     func_ov006_020e8e10(c);
     func_ov006_020e8b18(c);
     func_ov006_020e8354(c);
-    *(int *)(c + 0x4700) = 0;
-    *(int *)(c + 0x4704) = 0xd0000;
-    *(int *)(c + 0x4708) = 0x40000;
-    *(int *)(c + 0x470c) = 0xffed3000;
-    *(int *)(c + 0x4710) = 0xe0000;
-    *(int *)(c + 0x4714) = 0x40000;
-    *(short *)(c + 0x4718) = 0xc00;
+    self->unk_4700 = 0;
+    self->unk_4704 = 0xd0000;
+    self->unk_4708 = 0x40000;
+    self->unk_470c = 0xffed3000;
+    self->unk_4710 = 0xe0000;
+    self->unk_4714 = 0x40000;
+    self->unk_4718 = 0xc00;
     func_ov006_020c0134(c + 0x4660);
     ((TextureTransformer *)(c + 0x51f4))->Update(*(ModelComponents *)(c + 0x4f40));
     ((Obj *)(c + 0x4f38))->vcall(0);

--- a/src/func_ov006_020e9e00.cpp
+++ b/src/func_ov006_020e9e00.cpp
@@ -1,13 +1,18 @@
 //cpp
+// @symbol func_ov006_020e9e00
+// @emits dScMg3DEsp_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMg3DEsp_c::Behavior - recovered from vtable slot identity */
 class C;
 typedef void (C::*PMF)();
 
 extern "C" PMF data_ov006_02141f2c[];
 extern "C" void func_ov006_020e8a44(C *self);
 extern "C" void _ZN9Animation7AdvanceEv(void *anim);
-extern "C" void func_ov006_020e7be8(void *o);
 
-extern "C" int func_ov006_020e9e00(C *self)
+extern "C" int dScMg3DEsp_c_Behavior(C *self)
 {
     char *f = (char *)self;
     int idx = *(int *)(f + 0x553c);

--- a/src/func_ov006_020e9e70.cpp
+++ b/src/func_ov006_020e9e70.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_020e9e70
+// @emits dScMg3DEsp_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* dScMg3DEsp_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
 void InitialiseVramGlobals(void);
@@ -39,7 +43,7 @@ struct Obj {
     virtual void v48(int arg);
 };
 
-extern "C" int func_ov006_020e9e70(void* arg0)
+extern "C" int dScMg3DEsp_c_InitResources(void* arg0)
 {
     char* c = (char*)arg0;
     M48 tmp;

--- a/src/func_ov006_020ea2c8.cpp
+++ b/src/func_ov006_020ea2c8.cpp
@@ -1,12 +1,15 @@
 //cpp
-extern "C" int data_ov006_0213cab8;
+// @symbol func_ov006_020ea2c8
+// @emits dScMgHanachan_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" void func_0207328c(void* p, int a, int b, void* fn);
-extern "C" void func_ov006_020ea324(void);
-extern "C" void func_ov004_020b29c0(void* c);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* func_ov006_020ea2c8(void* c) {
+extern "C" void* dScMgHanachan_c_OnYoshiTryEat(void* c) {
     *(int**)c = &data_ov006_0213cab8;
     func_0207328c((char*)c + 0x4678, 0xf, 0x98, (void*)&func_ov006_020ea324);
     func_ov004_020b29c0(c);

--- a/src/func_ov006_020ecec8.c
+++ b/src/func_ov006_020ecec8.c
@@ -1,5 +1,9 @@
+// @symbol func_ov006_020ecec8
+// @emits dScMgHanachan_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int func_ov006_020ecec8(void *t)
+int dScMgHanachan_c_CleanupResources(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;

--- a/src/func_ov006_020ecee4.c
+++ b/src/func_ov006_020ecee4.c
@@ -1,10 +1,12 @@
+// @symbol func_ov006_020ecee4
+// @emits dScMgHanachan_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::Render - recovered from vtable slot identity */
 #pragma opt_common_subs off
 
 extern void func_ov004_020b1e34(void *a, int b, int c, int d);
-extern void func_ov006_020ea670(void);
-extern void func_ov006_020ea350(void);
-extern void func_ov006_020eac38(void *a);
-extern void func_ov006_020ea914(void *a);
 extern int func_ov004_020ad674(void);
 extern void func_ov004_020afcf8(void *a, int b, int c, int d);
 extern void func_ov004_020b2220(int a, int b, void *c, int d, int e, int f, int g);
@@ -15,14 +17,12 @@ typedef struct { int a; int b; } Pair;
 #define PAIR1(s) ((Pair *)(int)(((unsigned long long)(unsigned int)((char *)(s) + 0x4660)) & 0xFFFFFFFFFFFFFFFFULL))
 
 extern Pair data_ov006_0213c9ac;
-extern int data_ov006_0213c958;
 extern Pair data_ov006_0213c994;
 extern Pair data_ov006_0213ca3c;
 extern Pair data_ov006_0213ca34;
 extern Pair data_ov006_0213ca2c;
-extern void *data_ov006_0213ca9c[];
 
-int func_ov006_020ecee4(void *a0)
+int dScMgHanachan_c_Render(void *a0)
 {
     char *self = (char *)a0;
     int i;

--- a/src/func_ov006_020ed18c.cpp
+++ b/src/func_ov006_020ed18c.cpp
@@ -1,16 +1,16 @@
 //cpp
-extern "C" void func_ov006_020eb610(char *c);
-extern "C" void func_ov006_020eb558(char *c);
-extern "C" void func_ov006_020ea71c();
-extern "C" void func_ov006_020ea3d0(char *c);
+// @symbol func_ov006_020ed18c
+// @emits dScMgHanachan_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::Behavior - recovered from vtable slot identity */
 
-extern unsigned short data_ov006_02141fcc;
-extern int data_ov006_0213c958;
 
 struct C;
 typedef void (C::*PMF)();
 
-extern "C" int func_ov006_020ed18c(char *c)
+extern "C" int dScMgHanachan_c_Behavior(char *c)
 {
     data_ov006_02141fcc = data_ov006_02141fcc + 0x800;
     (((C *)c)->*(*(PMF *)(c + 0x4660)))();

--- a/src/func_ov006_020eda48.c
+++ b/src/func_ov006_020eda48.c
@@ -1,25 +1,30 @@
-extern void func_ov004_020adb1c(int self);
-extern void func_ov006_020ea8e0(void);
-extern unsigned char func_ov006_020ea658(void);
-extern void func_ov006_020ed8a4(void* self);
+// @symbol func_ov006_020eda48
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgHanachan_c.h"
+// @emits dScMgHanachan_c_OnYoshiTryEat_020eda48
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern char* func_020beb68;
 
-void func_ov006_020eda48(char* c, int state)
+void dScMgHanachan_c_OnYoshiTryEat_020eda48(char* c, int state)
 {
+    struct dScMgHanachan_c *self = (struct dScMgHanachan_c *)(void *)c;
     if (state == 1) {
-        unsigned int v = *(unsigned int*)(c + 0xbc) + 1;
-        *(unsigned int*)(c + 0xbc) = v;
-        if (*(unsigned int*)(c + 0xbc) > 0x270e) *(unsigned int*)(c + 0xbc) = 0x270e;
+        unsigned int v = self->unk_0bc + 1;
+        self->unk_0bc = v;
+        if (self->unk_0bc > 0x270e) self->unk_0bc = 0x270e;
     } else if (state == 0x12) {
-        *(unsigned int*)(c + 0xbc) = 0;
-        if (*(unsigned int*)(c + 0xbc) > 0x270e) *(unsigned int*)(c + 0xbc) = 0x270e;
+        self->unk_0bc = 0;
+        if (self->unk_0bc > 0x270e) self->unk_0bc = 0x270e;
         if (func_020beb68 != 0) *(int*)(func_020beb68 + 0xb4) = 0;
-        func_ov004_020adb1c(*(int*)(c + 0xb4));
-        *(int*)(c + 0x4670) = 0x14;
+        func_ov004_020adb1c(self->unk_0b4);
+        self->unk_4670 = 0x14;
     } else {
-        int v = *(int*)(c + 0xbc);
+        int v = self->unk_0bc;
         if (func_020beb68 != 0) *(int*)(func_020beb68 + 0xb4) = v;
-        *(int*)(c + 0x4670) = 0x14;
+        self->unk_4670 = 0x14;
     }
     func_ov006_020ea8e0();
     func_ov006_020ea658();

--- a/src/func_ov006_020edb04.cpp
+++ b/src/func_ov006_020edb04.cpp
@@ -1,17 +1,18 @@
 //cpp
+// @symbol func_ov006_020edb04
+// @emits dScMgHanachan_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgHanachan_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef volatile unsigned int vu32;
 
-extern "C" void func_ov006_020edcb0(void);
 extern "C" void *LoadFile(int handle);
 extern "C" void DecompressLZ16(void *src, void *dst);
 extern "C" void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern "C" void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern "C" void Deallocate(void *ptr);
-extern "C" void func_ov004_020b04d0(int v);
 
-extern int data_ov006_0213c954;
-extern vu32 *data_ov006_02137560[];
 
 struct Obj {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -24,7 +25,7 @@ struct Obj {
     int unkAC;
 };
 
-extern "C" int func_ov006_020edb04(Obj *obj)
+extern "C" int dScMgHanachan_c_InitResources(Obj *obj)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020edf54.cpp
+++ b/src/func_ov006_020edf54.cpp
@@ -1,17 +1,19 @@
 //cpp
+// @symbol func_ov006_020edf54
+// @emits dScMgJump_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ModelD1Ev(void *);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void _ZN6Player18St_LevelEnter_MainEv();
-extern void func_ov006_020c893c();
-extern void *data_ov006_0213cbe4[];
 extern void *_ZTV17MgBounceAndPounce[];
 extern void *data_020a0eac;
-void *func_ov006_020edf54(char *c);
-void *func_ov006_020edf54(char *c) {
+void *dScMgJump_c_OnYoshiTryEat(char *c);
+void *dScMgJump_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213cbe4;
     func_0207328c(c + 0x5294, 6, 0xf0, (void*)&_ZN6Player18St_LevelEnter_MainEv);
     func_0207328c(c + 0x506c, 3, 0xb8, (void*)&func_ov006_020c893c);

--- a/src/func_ov006_020edffc.c
+++ b/src/func_ov006_020edffc.c
@@ -1,8 +1,13 @@
+// @symbol func_ov006_020edffc
+// @emits dScMgJump_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void func_ov004_020ad90c(void);
-extern void *data_ov006_02142184;
 
-int func_ov006_020edffc(void) {
+int dScMgJump_c_CleanupResources(void) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov006_02142184);
     data_ov006_02142184 = 0;
     func_ov004_020ad90c();

--- a/src/func_ov006_020ee034.c
+++ b/src/func_ov006_020ee034.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_020ee034
+// @emits dScMgJump_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump_c::Render - recovered from vtable slot identity */
 typedef unsigned short u16;
 
 typedef struct { int w[12]; } M48;
@@ -9,17 +15,10 @@ extern void func_ov004_020afcf8(void *a0, void *a1, int a2, void *a3);
 extern void func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
 extern void func_0203cd80(int *m, short angle);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
-extern void func_02045e44(void *self, unsigned int value, int index);
-extern void func_ov006_020c70d0(void);
-extern void func_ov006_020c425c(void);
 
-extern int data_ov006_02140428;
-extern int *data_ov006_0213cbb4[];
-extern int data_ov006_02134cf8;
 extern int data_020a0e68;
-extern int data_ov006_0213cb8c[3];
 
-int func_ov006_020ee034(void *self)
+int dScMgJump_c_Render(void *self)
 {
     char *c = (char *)self;
 
@@ -84,7 +83,7 @@ int func_ov006_020ee034(void *self)
         *(int *)((char *)p + 0x18) = *(int *)(c + 0x500c);
 
         {
-            void *obj2 = (void *)(((long long)(int)(c + 0x501c)) & 0xFFFFFFFFFFFFFFFFLL);
+            void *obj2 = (void *)(((long long)(int)(c + 0x501c)));
             ((void (**)(void *, void *))(*(int *)obj2))[5](obj2, &t);
         }
     }

--- a/src/func_ov006_020ee27c.cpp
+++ b/src/func_ov006_020ee27c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_020ee27c
+// @emits dScMgJump_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgJump_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct C { char pad[0x5004]; PMF m; };
-extern "C" int func_ov006_020ee27c(C* c) { (c->*c->m)(); return 1; }
+extern "C" int dScMgJump_c_Behavior(C* c) { (c->*c->m)(); return 1; }

--- a/src/func_ov006_020ee690.cpp
+++ b/src/func_ov006_020ee690.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov006_020ee690
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "dScMgJump_c.h"
+// @emits dScMgJump_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* dScMgJump_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
@@ -9,9 +17,6 @@ extern s32 func_ov004_020ad674(void);
 extern int LoadFile(int handle);
 extern void DecompressLZ16(void *src, void *dst);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(void const *src, unsigned int offset, unsigned int size);
-extern void Deallocate(void *ptr);
-extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
-extern void InitialiseVramGlobals(void);
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 extern void func_ov006_020c0134(void *cam);
 extern int func_ov006_020c4684(char *ptr, int n);
@@ -19,14 +24,9 @@ extern int func_ov006_020c7574(char *base, int count);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int b, int c);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
-extern void func_ov004_020b04d0(int v);
 
-extern int data_ov006_0213cbc8[];
 extern u8 data_0209d45c;
 extern s16 data_02082614;
-extern void *data_ov006_02142188;
-extern void *data_ov006_02142190;
-extern void *data_ov006_02142184;
 
 struct Mtx43 { int m[12]; };
 extern struct Mtx43 data_020a0e68;
@@ -54,8 +54,9 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int func_ov006_020ee690(char *base)
+extern "C" int dScMgJump_c_InitResources(char *base)
 {
+    struct dScMgJump_c *self = (struct dScMgJump_c *)(void *)base;
     s32 idx;
     int buf1, buf2;
     s32 fov;
@@ -76,22 +77,22 @@ extern "C" int func_ov006_020ee690(char *base)
     *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
     fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082614);
 
-    *(s32 *)(base + 0x470c) = 0;
-    *(s32 *)(base + 0x4710) = -0x64000;
-    *(s32 *)(base + 0x4714) = 0;
-    *(s32 *)(base + 0x4718) = 0;
-    *(s32 *)(base + 0x471c) = 0;
-    *(s32 *)(base + 0x4720) = fov;
-    *(u16 *)(base + 0x4724) = 0x800;
+    self->unk_470c = 0;
+    self->unk_4710 = -0x64000;
+    self->unk_4714 = 0;
+    self->unk_4718 = 0;
+    self->unk_471c = 0;
+    self->unk_4720 = fov;
+    self->unk_4724 = 0x800;
     func_ov006_020c0134(base + 0x466c);
 
-    *(s32 *)(base + 0x47c8) = 0;
-    *(s32 *)(base + 0x47cc) = 0x82000;
-    *(s32 *)(base + 0x47d0) = 0;
-    *(s32 *)(base + 0x47d4) = 0;
-    *(s32 *)(base + 0x47d8) = 0;
-    *(s32 *)(base + 0x47dc) = fov;
-    *(u16 *)(base + 0x47e0) = 0x800;
+    self->unk_47c8 = 0;
+    self->unk_47cc = 0x82000;
+    self->unk_47d0 = 0;
+    self->unk_47d4 = 0;
+    self->unk_47d8 = 0;
+    self->unk_47dc = fov;
+    self->unk_47e0 = 0x800;
     func_ov006_020c0134(base + 0x4728);
 
     if (func_ov006_020c4684(base + 0x5294, 6) == 0)

--- a/src/func_ov006_020ee8dc.cpp
+++ b/src/func_ov006_020ee8dc.cpp
@@ -1,15 +1,21 @@
 //cpp
-extern "C" int data_ov006_02140428;
+// @symbol func_ov006_020ee8dc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgJump_c.h"
+// @emits dScMgJump_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgJump_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" short _Z15ApproachLinear2Rsss(short &r, short b, short c);
-extern "C" void func_ov006_020c8a9c(int a0, int a1);
-extern "C" void func_ov006_020c72dc(void);
 extern "C" void func_02012790(int a0);
 
-extern "C" int func_ov006_020ee8dc(char *thiz, int sel)
+extern "C" int dScMgJump_c_OnTurnIntoEgg(char *thiz, int sel)
 {
+    struct dScMgJump_c *self = (struct dScMgJump_c *)(void *)thiz;
     if (sel == 0) {
-        if (*(unsigned int*)(thiz + 0xbc) % 5 == 4) {
-            if (_Z15ApproachLinear2Rsss(*(short*)(thiz + 0x5014), 0, 1) != 0) {
+        if (self->unk_0bc % 5 == 4) {
+            if (_Z15ApproachLinear2Rsss(self->unk_5014, 0, 1) != 0) {
                 if ((&data_ov006_02140428)[0] < 3) {
                     func_ov006_020c72dc();
                     func_02012790(0x26);

--- a/src/func_ov006_020eec9c.cpp
+++ b/src/func_ov006_020eec9c.cpp
@@ -1,18 +1,19 @@
 //cpp
+// @symbol func_ov006_020eec9c
+// @emits dScMgJump2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ModelD1Ev(void *);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void _ZN6Player18St_LevelEnter_MainEv();
-extern void func_ov006_020c893c();
-extern void func_ov006_020eed64();
-extern void *data_ov006_0213ccfc[];
 extern void *_ZTV17MgBounceAndPounce[];
 extern void *data_020a0eac;
-void *func_ov006_020eec9c(char *c);
-void *func_ov006_020eec9c(char *c) {
+void *dScMgJump2_c_OnYoshiTryEat(char *c);
+void *dScMgJump2_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213ccfc;
     _ZN5ModelD1Ev(c + 0x5a14);
     func_0207328c(c + 0x57d4, 0x10, 0x24, (void*)&func_ov006_020eed64);

--- a/src/func_ov006_020ef110.c
+++ b/src/func_ov006_020ef110.c
@@ -1,8 +1,12 @@
+// @symbol func_ov006_020ef110
+// @emits dScMgJump2_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void func_ov004_020ad90c(void);
 extern void *data_ov006_021421b8;
 
-int func_ov006_020ef110(void) {
+int dScMgJump2_c_CleanupResources(void) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov006_021421b8);
     data_ov006_021421b8 = 0;
     func_ov004_020ad90c();

--- a/src/func_ov006_020ef148.c
+++ b/src/func_ov006_020ef148.c
@@ -1,27 +1,22 @@
+// @symbol func_ov006_020ef148
+// @emits dScMgJump2_c_Render
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* dScMgJump2_c::Render - recovered from vtable slot identity */
 typedef unsigned short u16;
 
-extern void func_ov004_020b1a5c(int a0, int a1);
-extern void func_ov006_020eef58(void);
-extern void func_ov006_020ef2b8(void);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
-extern void func_02045e44(void* self, unsigned int value, int index);
-extern void func_ov006_020c70d0(void);
-extern void func_ov006_020c425c(void);
 extern int func_ov004_020ad674(void);
 extern void func_ov004_020afcf8(void* a0, void* a1, int a2, void* a3);
 extern void func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
 
-extern int data_ov006_02140308;
 extern int data_020a0e68;
-extern int data_ov006_0213ccb0;
-extern int data_ov006_02140428;
-extern int data_ov006_02134cf8;
-extern int* data_ov006_0213cccc[];
 
 struct M48 { int w[12]; };
 struct S3 { int a, b, c; };
 
-int func_ov006_020ef148(char* self)
+int dScMgJump2_c_Render(char* self)
 {
     struct S3 local;
     void* p;
@@ -44,7 +39,7 @@ int func_ov006_020ef148(char* self)
     }
     *(int*)((char*)p + 0x18) = *(int*)(self + 0x5a64);
     {
-        void** vobj = (void**)(((long long)(int)(self + 0x5a14)) & 0xFFFFFFFFFFFFFFFFLL);
+        void** vobj = (void**)(((long long)(int)(self + 0x5a14)));
         (*(void(**)(void*, void*))((char*)*vobj + 0x14))((void*)vobj, &local);
     }
 

--- a/src/func_ov006_020ef3e0.cpp
+++ b/src/func_ov006_020ef3e0.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020ef3e0
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgJump2_c.h"
+// @emits dScMgJump2_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
 struct C;
 typedef void (C::*PMF)();
@@ -7,14 +13,15 @@ extern "C" {
 unsigned int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, Fix12 c, Fix12 d, Fix12 e, const Vector3_16f* f);
 void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
 void func_ov006_020eef90(void);
-int func_ov006_020ef3e0(char *c);
+int dScMgJump2_c_Behavior(char *c);
 }
-int func_ov006_020ef3e0(char *c)
+int dScMgJump2_c_Behavior(char *c)
 {
-    *(unsigned int*)(c + 0x5a6c) =
+    struct dScMgJump2_c *self = (struct dScMgJump2_c *)(void *)c;
+    self->unk_5a6c =
         _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-            *(unsigned int*)(c + 0x5a6c), 0xf0, 0x400000, 0x800000, -0x480000, 0);
-    void *o = _ZN8Particle6System12FromUniqueIDEj(*(unsigned int*)(c + 0x5a6c));
+            self->unk_5a6c, 0xf0, 0x400000, 0x800000, -0x480000, 0);
+    void *o = _ZN8Particle6System12FromUniqueIDEj(self->unk_5a6c);
     if (o != 0) {
         *(int*)((char*)o + 0x50) = 0x4000;
         *(unsigned char*)((char*)o + 0x58) = 0x2c;

--- a/src/func_ov006_020ef834.cpp
+++ b/src/func_ov006_020ef834.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov006_020ef834
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgJump2_c.h"
+// @emits dScMgJump2_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
@@ -10,24 +18,16 @@ extern s32 func_ov004_020ad674(void);
 extern int LoadFile(int handle);
 extern void DecompressLZ16(int src, int dst);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void Deallocate(void *ptr);
-extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
-extern void InitialiseVramGlobals(void);
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 extern void func_ov006_020c0134(void *cam);
 extern int func_ov006_020c4684(void *ptr, int n);
-extern void func_ov006_020ef0d4(int a, int b);
 extern int func_ov006_020c7574(void *base, int count);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *ref);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *bmdFile, int a, int b);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
-extern void func_ov004_020b04d0(int v);
 
-extern int data_ov006_0213cce0[];
 extern u8 data_0209d45c;
 extern s16 data_02082614;
-extern int data_ov006_02140314;
-extern int data_ov006_021421c4;
 extern int *data_ov006_021421b8;
 
 typedef struct { int e[12]; } Mtx43T;
@@ -56,8 +56,9 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int func_ov006_020ef834(char *base)
+extern "C" int dScMgJump2_c_InitResources(char *base)
 {
+    struct dScMgJump2_c *self = (struct dScMgJump2_c *)(void *)base;
     int a, b;
     s32 fov;
     void *bmdFile;
@@ -75,22 +76,22 @@ extern "C" int func_ov006_020ef834(char *base)
     *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
     fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082614);
 
-    *(s32 *)(base + 0x470c) = 0;
-    *(s32 *)(base + 0x4710) = -0x64000;
-    *(s32 *)(base + 0x4714) = 0;
-    *(s32 *)(base + 0x4718) = 0;
-    *(s32 *)(base + 0x471c) = 0;
-    *(s32 *)(base + 0x4720) = fov;
-    *(u16 *)(base + 0x4724) = 0x800;
+    self->unk_470c = 0;
+    self->unk_4710 = -0x64000;
+    self->unk_4714 = 0;
+    self->unk_4718 = 0;
+    self->unk_471c = 0;
+    self->unk_4720 = fov;
+    self->unk_4724 = 0x800;
     func_ov006_020c0134(base + 0x466c);
 
-    *(s32 *)(base + 0x47c8) = 0;
-    *(s32 *)(base + 0x47cc) = 0x82000;
-    *(s32 *)(base + 0x47d0) = 0;
-    *(s32 *)(base + 0x47d4) = 0;
-    *(s32 *)(base + 0x47d8) = 0;
-    *(s32 *)(base + 0x47dc) = fov;
-    *(u16 *)(base + 0x47e0) = 0x800;
+    self->unk_47c8 = 0;
+    self->unk_47cc = 0x82000;
+    self->unk_47d0 = 0;
+    self->unk_47d4 = 0;
+    self->unk_47d8 = 0;
+    self->unk_47dc = fov;
+    self->unk_47e0 = 0x800;
     func_ov006_020c0134(base + 0x4728);
 
     if (func_ov006_020c4684(base + 0x5234, 6) == 0)

--- a/src/func_ov006_020efa84.c
+++ b/src/func_ov006_020efa84.c
@@ -1,6 +1,11 @@
-extern void func_ov006_020c8a9c(int a0, int a1);
+// @symbol func_ov006_020efa84
+// @emits dScMgJump2_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-int func_ov006_020efa84(void)
+int dScMgJump2_c_OnTurnIntoEgg(void)
 {
     func_ov006_020c8a9c(0, 0);
     return 1;

--- a/src/func_ov006_020efaa8.c
+++ b/src/func_ov006_020efaa8.c
@@ -1,10 +1,10 @@
-extern void func_ov006_020c72b4(void);
-extern void func_ov006_020c719c(int a, int b);
-extern void func_ov006_020c44b4(int a, int b);
-extern void func_ov006_020eeff0(void);
-extern void func_ov006_020ef7f8(char* c);
-extern int data_ov006_02140328;
-void func_ov006_020efaa8(char* c){
+// @symbol func_ov006_020efaa8
+// @emits dScMgJump2_c_OnYoshiTryEat_020efaa8
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgJump2_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgJump2_c_OnYoshiTryEat_020efaa8(char* c){
   func_ov006_020c72b4();
   func_ov006_020c719c(0, 0);
   data_ov006_02140328 = 3;

--- a/src/func_ov006_020efc30.c
+++ b/src/func_ov006_020efc30.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020efc30(int *t)
+// @symbol func_ov006_020efc30
+// @emits dScMgLuigi_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgLuigi_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020efc68.c
+++ b/src/func_ov006_020efc68.c
@@ -1,11 +1,13 @@
+// @symbol func_ov006_020efc68
+// @emits dScMgLuigi_c_AfterCleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::AfterCleanupResources - recovered from vtable slot identity */
 typedef unsigned short u16;
-extern void *_ZN3IRQ13GetIRQHandlerEj(unsigned int irq);
-extern void _ZN3IRQ11DisableIRQsEj(unsigned int mask);
-extern int func_02053c10(int enable);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(unsigned int irq, void *handler);
 extern int func_ov004_020b0840(int a, int b);
-extern void func_ov006_020efcf8(void);
-int func_ov006_020efc68(int a, int irq){
+int dScMgLuigi_c_AfterCleanupResources(int a, int irq){
     if(irq == 2 && _ZN3IRQ13GetIRQHandlerEj(2) == (void*)func_ov006_020efcf8){
         u16 ime;
         do {

--- a/src/func_ov006_020f3294.c
+++ b/src/func_ov006_020f3294.c
@@ -1,14 +1,17 @@
-extern void func_ov004_020adb1c(int self);
+// @symbol func_ov006_020f3294
+// @emits dScMgLuigi_c_OnYoshiTryEat_020f3294
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b0aa0(int arg);
 extern void func_ov006_020f2ec0(char *c);
-extern void func_ov006_020f2e20(char *c);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 
 extern char *func_020beb68;
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 
-void func_ov006_020f3294(char *c, int arg1)
+void dScMgLuigi_c_OnYoshiTryEat_020f3294(char *c, int arg1)
 {
     char *p;
     int *q;

--- a/src/func_ov006_020f33c0.c
+++ b/src/func_ov006_020f33c0.c
@@ -1,11 +1,11 @@
+// @symbol func_ov006_020f33c0
+// @emits dScMgLuigi_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::Render - recovered from vtable slot identity */
 extern int func_ov004_020b1e34(void* c, int a, int b, int d);
-extern void func_ov006_020f04ec(void* c);
-extern void func_ov006_020f01d8(void* c);
-extern void func_ov006_020f100c(void* c);
-extern void func_ov006_020f12c8(void* c);
-extern void func_ov006_020f0e28(void* c);
-extern void func_ov006_020f0f7c(void* c);
-int func_ov006_020f33c0(void* c) {
+int dScMgLuigi_c_Render(void* c) {
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
     func_ov006_020f04ec(c);
     func_ov006_020f01d8(c);

--- a/src/func_ov006_020f3414.cpp
+++ b/src/func_ov006_020f3414.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov006_020f3414
+// @emits dScMgLuigi_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern Entry data_ov006_02142234[];
 struct C { char pad[0x4f78]; int idx; };
-extern "C" int func_ov006_020f3414(C* c) {
+extern "C" int dScMgLuigi_c_Behavior(C* c) {
     int j = c->idx;
     (c->*data_ov006_02142234[j].pmf)();
     return 1;

--- a/src/func_ov006_020f3460.c
+++ b/src/func_ov006_020f3460.c
@@ -1,35 +1,31 @@
+// @symbol func_ov006_020f3460
+// @emits dScMgLuigi_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgLuigi_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern int func_020adc74(void* p);
-extern int func_02054d88(void);
 extern void DecompressLZ16(int src, void* dst);
 extern int LoadFile(int handle);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void Deallocate(void* p);
-extern void func_02056314(void* dst, u32 offset, u32 len);
 extern char* _ZN2G213GetBG2CharPtrEv(void);
 extern char* _ZN2G212GetBG2ScrPtrEv(void);
 extern void MultiStore16(u16 val, char* dst, int nbytes);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern unsigned func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);
-extern void func_02056374(const void* src, u32 offset, u32 count);
 extern char* _ZN3G2S12GetBG3ScrPtrEv(void);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void* p, u32 a, u32 b);
 extern void func_ov006_020f2ec0(void* c);
-extern void func_ov006_020f2e20(char* c);
 extern void func_ov004_020adc5c(int a);
-extern void func_ov004_020b04d0(int v);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern void* data_ov006_0213cfa0;
-extern int func_020bc888;
-extern int func_020bc864;
 
-int func_ov006_020f3460(void* arg0) {
+int dScMgLuigi_c_InitResources(void* arg0) {
     char* c = (char*)arg0;
     char* b;
     volatile u16 sp8;

--- a/src/func_ov006_020f3888.cpp
+++ b/src/func_ov006_020f3888.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol func_ov006_020f3888
+// @emits dScMgMemory_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *data_ov006_0213d1b8[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020f3888(char *c);
-void *func_ov006_020f3888(char *c) {
+void *dScMgMemory_c_OnYoshiTryEat(char *c);
+void *dScMgMemory_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213d1b8;
     func_ov006_020c1c64(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_020f523c.c
+++ b/src/func_ov006_020f523c.c
@@ -1,5 +1,13 @@
-extern int func_ov004_020b63a0(int);
+// @symbol func_ov006_020f523c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory_c.h"
+// @emits dScMgMemory_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::OnGroundPounded - recovered from vtable slot identity */
 
-int func_ov006_020f523c(char* p) {
-    return func_ov004_020b63a0(*(unsigned char*)(p + 0x533b));
+int dScMgMemory_c_OnGroundPounded(char* p) {
+    struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)p;
+    return func_ov004_020b63a0(self->unk_533b);
 }

--- a/src/func_ov006_020f5250.c
+++ b/src/func_ov006_020f5250.c
@@ -1,11 +1,18 @@
+// @symbol func_ov006_020f5250
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory_c.h"
+// @emits dScMgMemory_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov006_020c1718(int* p);
 extern void func_ov004_020b0aa0(int n);
 
-int func_ov006_020f5250(char* c) {
-    if (*(int*)(c + 0x5314) == 3 && *(int*)(c + 0x5318) == 0) {
+int dScMgMemory_c_OnTurnIntoEgg(char* c) {
+    struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)c;
+    if (self->unk_5314 == 3 && self->unk_5318 == 0) {
         if (func_ov006_020c1718((int*)(c + 0x4f38)) == 0) return 0;
-        *(int*)(c + 0x5318) = 1;
+        self->unk_5318 = 1;
         func_ov004_020b0aa0(0x1d);
     }
-    return *(int*)(c + 0x5314) == 4;
+    return self->unk_5314 == 4;
 }

--- a/src/func_ov006_020f52c4.c
+++ b/src/func_ov006_020f52c4.c
@@ -1,19 +1,26 @@
-extern void func_ov006_020f4f94(void *c);
+// @symbol func_ov006_020f52c4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory_c.h"
+// @emits dScMgMemory_c_OnYoshiTryEat_020f52c4
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void *o);
 extern char *func_020beb68;
-extern int func_020bc7d4;
 
-void func_ov006_020f52c4(char *c)
+void dScMgMemory_c_OnYoshiTryEat_020f52c4(char *c)
 {
+    struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)c;
     char *o;
     int v;
     func_ov006_020f4f94(c);
-    *(int *)(c + 0x5314) = 0;
+    self->unk_5314 = 0;
     o = func_020beb68;
     v = 0;
     if (o != 0) v = *(int *)(o + 0xa8);
     if (v >= 3) v = 3;
     func_ov004_020b66d4(o);
     func_020bc7d4 = 1;
-    *(unsigned char *)(c + 0x533b) = (unsigned char)v;
+    self->unk_533b = (unsigned char)v;
 }

--- a/src/func_ov006_020f5324.c
+++ b/src/func_ov006_020f5324.c
@@ -1,11 +1,13 @@
+// @symbol func_ov006_020f5324
+// @emits dScMgMemory_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::Render - recovered from vtable slot identity */
 extern void func_ov006_020c0aa8(char*);
 extern void func_ov004_020b1bc8(char*, int, int, int);
-extern void func_ov004_020b6430(void);
-extern void func_ov006_020f38f0(char* c);
-extern void func_ov006_020f392c(char *c);
-extern void func_ov006_020f3e68(char*);
 extern void func_ov006_020c1804(char*);
-int func_ov006_020f5324(char* c){
+int dScMgMemory_c_Render(char* c){
   func_ov006_020c0aa8(c + 0x4660);
   func_ov004_020b1bc8(c, 0xc, 0xc, 0);
   func_ov004_020b6430();

--- a/src/func_ov006_020f5388.cpp
+++ b/src/func_ov006_020f5388.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov006_020f5388
+// @emits dScMgMemory_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern "C" Entry data_ov006_021422dc[];
 struct C { char pad[0x5314]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int func_ov006_020f5388(C* c) {
+extern "C" int dScMgMemory_c_Behavior(C* c) {
     (c->*(data_ov006_021422dc[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_020f53e4.cpp
+++ b/src/func_ov006_020f53e4.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020f53e4
+// @emits dScMgMemory_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef int s32;
@@ -23,10 +29,8 @@ namespace GXS { void LoadOBJPltt(void const *, unsigned int, unsigned int); }
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int func_020bc7d4;
-extern int data_ov006_0213d0c4[];
 
-extern "C" int func_ov006_020f53e4(char *self)
+extern "C" int dScMgMemory_c_InitResources(char *self)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020f55b8.cpp
+++ b/src/func_ov006_020f55b8.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol func_ov006_020f55b8
+// @emits dScMgMemory2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *data_ov006_0213d4d4[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020f55b8(char *c);
-void *func_ov006_020f55b8(char *c) {
+void *dScMgMemory2_c_OnYoshiTryEat(char *c);
+void *dScMgMemory2_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213d4d4;
     func_ov006_020c1c64(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_020f730c.c
+++ b/src/func_ov006_020f730c.c
@@ -1,5 +1,13 @@
-extern int func_ov004_020b63a0(int);
+// @symbol func_ov006_020f730c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory2_c.h"
+// @emits dScMgMemory2_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::OnGroundPounded - recovered from vtable slot identity */
 
-int func_ov006_020f730c(char* p) {
-    return func_ov004_020b63a0(*(unsigned char*)(p + 0x5409));
+int dScMgMemory2_c_OnGroundPounded(char* p) {
+    struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)p;
+    return func_ov004_020b63a0(self->unk_5409);
 }

--- a/src/func_ov006_020f7320.c
+++ b/src/func_ov006_020f7320.c
@@ -1,11 +1,18 @@
+// @symbol func_ov006_020f7320
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory2_c.h"
+// @emits dScMgMemory2_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov006_020c1718(int* p);
 extern void func_ov004_020b0aa0(int n);
 
-int func_ov006_020f7320(char* c) {
-    if (*(int*)(c + 0x53d4) == 3 && *(int*)(c + 0x53d8) == 0) {
+int dScMgMemory2_c_OnTurnIntoEgg(char* c) {
+    struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)c;
+    if (self->unk_53d4 == 3 && self->unk_53d8 == 0) {
         if (func_ov006_020c1718((int*)(c + 0x4f38)) == 0) return 0;
-        *(int*)(c + 0x53d8) = 1;
+        self->unk_53d8 = 1;
         func_ov004_020b0aa0(0x1d);
     }
-    return *(int*)(c + 0x53d4) == 4;
+    return self->unk_53d4 == 4;
 }

--- a/src/func_ov006_020f7394.c
+++ b/src/func_ov006_020f7394.c
@@ -1,19 +1,26 @@
-extern void func_ov006_020f7064(void *c);
+// @symbol func_ov006_020f7394
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMemory2_c.h"
+// @emits dScMgMemory2_c_OnYoshiTryEat_020f7394
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void *o);
 extern char *func_020beb68;
-extern int func_020bc7d4;
 
-void func_ov006_020f7394(char *c)
+void dScMgMemory2_c_OnYoshiTryEat_020f7394(char *c)
 {
+    struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)c;
     char *o;
     int v;
     func_ov006_020f7064(c);
-    *(int *)(c + 0x53d4) = 0;
+    self->unk_53d4 = 0;
     o = func_020beb68;
     v = 0;
     if (o != 0) v = *(int *)(o + 0xa8);
     if (v >= 5) v = 5;
     func_ov004_020b66d4(o);
     func_020bc7d4 = 1;
-    *(unsigned char *)(c + 0x5409) = (unsigned char)v;
+    self->unk_5409 = (unsigned char)v;
 }

--- a/src/func_ov006_020f73f4.c
+++ b/src/func_ov006_020f73f4.c
@@ -1,11 +1,13 @@
+// @symbol func_ov006_020f73f4
+// @emits dScMgMemory2_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::Render - recovered from vtable slot identity */
 extern void func_ov006_020c0aa8(char*);
 extern void func_ov004_020b1bc8(char*, int, int, int);
-extern void func_ov004_020b6430(void);
-extern void func_ov006_020f5620(char *thiz);
-extern void func_ov006_020f565c(char *c);
-extern void func_ov006_020f5b98(char*);
 extern void func_ov006_020c1804(char*);
-int func_ov006_020f73f4(char* c){
+int dScMgMemory2_c_Render(char* c){
   func_ov006_020c0aa8(c + 0x4660);
   func_ov004_020b1bc8(c, 0xc, 0xc, 0);
   func_ov004_020b6430();

--- a/src/func_ov006_020f7458.cpp
+++ b/src/func_ov006_020f7458.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov006_020f7458
+// @emits dScMgMemory2_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern "C" Entry data_ov006_021423e0[];
 struct C { char pad[0x53d4]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int func_ov006_020f7458(C* c) {
+extern "C" int dScMgMemory2_c_Behavior(C* c) {
     (c->*(data_ov006_021423e0[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_020f74b4.cpp
+++ b/src/func_ov006_020f74b4.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_020f74b4
+// @emits dScMgMemory2_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMemory2_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef int s32;
@@ -23,10 +29,8 @@ namespace GXS { void LoadOBJPltt(void const *, unsigned int, unsigned int); }
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int func_020bc7d4;
-extern int data_ov006_0213d370[];
 
-extern "C" int func_ov006_020f74b4(char *self)
+extern "C" int dScMgMemory2_c_InitResources(char *self)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020f76a8.cpp
+++ b/src/func_ov006_020f76a8.cpp
@@ -1,16 +1,17 @@
 //cpp
+// @symbol func_ov006_020f76a8
+// @emits dScMgMCarlo_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_020f7730();
-extern void *data_ov006_0213d664[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020f76a8(char *c);
-void *func_ov006_020f76a8(char *c) {
+void *dScMgMCarlo_c_OnYoshiTryEat(char *c);
+void *dScMgMCarlo_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213d664;
     func_0207328c(c + 0x51a8, 0x50, 0x30, (void*)&func_ov006_020f7730);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_020f85b0.cpp
+++ b/src/func_ov006_020f85b0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_020f85b0
+// @emits dScMgMCarlo_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::Render - recovered from vtable slot identity */
 struct Node {
     virtual void f0();
     Node* next;
@@ -15,7 +19,7 @@ void func_ov006_020c1804(char* p);
 }
 extern Node* data_ov006_02142504;
 
-extern "C" int func_ov006_020f85b0(char* c)
+extern "C" int dScMgMCarlo_c_Render(char* c)
 {
     func_ov006_020c0aa8(c + 0x4660);
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);

--- a/src/func_ov006_020f869c.c
+++ b/src/func_ov006_020f869c.c
@@ -1,30 +1,19 @@
+// @symbol func_ov006_020f869c
+// @emits dScMgMCarlo_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
 
-extern int func_ov006_020f7b10(void);
-extern int func_ov006_020f7a90(void);
 extern int func_ov006_020c1718(void* p);
-extern void func_ov006_020c1164(void* t, int a1, void* a2);
-extern int func_ov006_020f7b90(void);
-extern int func_ov006_020c16b4(void* c);
-extern void func_ov006_020c0d68(void* c);
-extern void func_ov004_020b0a54(int a);
-extern void func_ov004_020ad79c(int a, int b);
-extern void func_ov004_020adb1c(int a);
-extern void func_ov006_020c0c80(void* c);
 extern void func_ov004_020b65e4(void);
 extern void func_ov006_020c19d0(void* c);
-extern void func_ov006_020f7740(void);
 
 extern char *func_020beb68;
-extern int data_ov006_0213d574;
-extern int data_ov006_0213d564;
-extern int data_ov006_0213d56c;
-extern int data_ov006_0213d570;
 extern int data_ov006_0213d568;
-extern int data_ov006_021424fc;
-extern int data_ov006_02142508;
 
-int func_ov006_020f869c(void* arg)
+int dScMgMCarlo_c_Behavior(void* arg)
 {
     unsigned char* c = (unsigned char*)arg;
 

--- a/src/func_ov006_020f8a3c.c
+++ b/src/func_ov006_020f8a3c.c
@@ -1,23 +1,28 @@
+// @symbol func_ov006_020f8a3c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo_c.h"
+// @emits dScMgMCarlo_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned char u8;
 
 extern void func_ov004_020b0aa0(int arg);
 extern int func_ov006_020c1718(void* p);
-extern void func_ov004_020b5e40(int x);
 extern void func_ov004_020b56c8(char* p);
 extern int _Z15ApproachLinear2Rsss(s16* r, s16 t, s16 s);
-extern void func_ov006_020f7994(void);
 
-extern int data_ov006_0213d570;
 extern char* data_ov006_0213d568;
-extern void* data_ov006_02142500;
 extern char* data_ov006_02142504;
 extern unsigned short data_ov004_020bf9e4;
 extern void* func_020beb68;
 
-int func_ov006_020f8a3c(char* c)
+int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
 {
-    switch (*(s16*)(c + 0x60a8)) {
+    struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
+    switch (self->unk_60a8) {
     case 4:
         func_ov004_020b0aa0(0x1d);
         *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
@@ -27,11 +32,11 @@ int func_ov006_020f8a3c(char* c)
             int v = data_ov006_0213d570;
             if (v != 0) {
                 func_ov004_020b5e40(v);
-                *(s16*)(c + 0x60aa) = -1;
+                self->unk_60aa = -1;
             } else {
                 func_ov004_020b56c8(data_ov006_0213d568);
             }
-            *(s16*)(c + 0x60ae) = 0;
+            self->unk_60ae = 0;
             *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
         }
         break;
@@ -42,8 +47,8 @@ int func_ov006_020f8a3c(char* c)
                 char* r3;
                 int i;
                 int n;
-                *(s16*)(c + 0x60aa) = 0x10;
-                n = *(s16*)(c + 0x60ae);
+                self->unk_60aa = 0x10;
+                n = self->unk_60ae;
                 r3 = data_ov006_02142504;
                 for (i = 0; i < n; i++) {
                     if (r3 == 0) break;
@@ -63,7 +68,7 @@ int func_ov006_020f8a3c(char* c)
         if ((p != 0 ? *(int*)((char*)p + 0xa8) : 0) != 0)
             return 1;
         func_ov006_020f7994();
-        *(s16*)(c + 0x60aa) = 0x1e;
+        self->unk_60aa = 0x1e;
         *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
         break;
     }

--- a/src/func_ov006_020f8c68.c
+++ b/src/func_ov006_020f8c68.c
@@ -1,20 +1,27 @@
+// @symbol func_ov006_020f8c68
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo_c.h"
+// @emits dScMgMCarlo_c_OnYoshiTryEat_020f8c68
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::OnYoshiTryEat - recovered from vtable slot identity */
 void func_ov006_020f7c10(char* p);
 void func_ov006_020c1604(char* c, int unused, short a2, int a3);
 void func_ov004_020b66d4(char* p);
 
-extern int data_ov006_0213d564;
-extern int func_020bc7d4;
 
-void func_ov006_020f8c68(char* c)
+void dScMgMCarlo_c_OnYoshiTryEat_020f8c68(char* c)
 {
+    struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     func_ov006_020f7c10(c + 0x51a8);
     data_ov006_0213d564 = 0;
-    *(short*)(c + 0x60ae) = 0;
-    *(short*)(c + 0x511e) = 1;
+    self->unk_60ae = 0;
+    self->unk_511e = 1;
     func_ov006_020c1604(c + 0x4f38, 4, 4, (int)(c + 0x60ae));
-    *(short*)(c + 0x4f52) = 1;
-    *(short*)(c + 0x60aa) = 0;
-    *(short*)(c + 0x60a8) = 1;
+    self->unk_4f52 = 1;
+    self->unk_60aa = 0;
+    self->unk_60a8 = 1;
     func_ov004_020b66d4(c + 0x6000);
     func_020bc7d4 = 1;
 }

--- a/src/func_ov006_020f8d08.cpp
+++ b/src/func_ov006_020f8d08.cpp
@@ -1,17 +1,19 @@
 //cpp
+// @symbol func_ov006_020f8d08
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo_c.h"
+// @emits dScMgMCarlo_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo_c::InitResources - recovered from vtable slot identity */
 extern "C" {
-extern void func_ov004_020b04d0(int v);
 extern void func_ov006_0210a534(void *c);
 extern int func_ov004_020ad674(void);
 extern int LoadFile(int handle);
 extern void DecompressLZ16(void *src, void *dst);
-extern void Deallocate(void *ptr);
 extern void func_ov006_020c0aa8(void *p);
 extern int func_ov006_020c1a88(void *p);
-extern void func_ov004_020b682c(void);
-extern int func_ov004_020ad8b8(void);
-extern int func_ov004_020ad878(void);
-extern int data_ov006_0213d5b4[];
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 extern void *func_020beb68;
@@ -26,8 +28,9 @@ struct Obj {
     virtual void v16(); virtual void v17(); virtual void v18(int x);
 };
 
-extern "C" int func_ov006_020f8d08(char *c)
+extern "C" int dScMgMCarlo_c_InitResources(char *c)
 {
+    struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     void *a;
     void *b;
 
@@ -48,13 +51,13 @@ extern "C" int func_ov006_020f8d08(char *c)
     if (func_ov006_020c1a88(c + 0x4f38) == 0) return 0;
 
     func_ov004_020b682c();
-    *(int *)(c + 0xa8) = func_ov004_020ad8b8();
-    *(int *)(c + 0xac) = *(int *)(c + 0xa8);
+    self->unk_0a8 = func_ov004_020ad8b8();
+    self->unk_0ac = self->unk_0a8;
     {
         int v = func_ov004_020ad878();
         if (func_020beb68) *(int *)((char *)func_020beb68 + 0xb4) = v;
     }
     ((Obj *)c)->v18(-1);
-    *(short *)(c + 0x60aa) = 0;
+    self->unk_60aa = 0;
     return 1;
 }

--- a/src/func_ov006_020f8f68.cpp
+++ b/src/func_ov006_020f8f68.cpp
@@ -1,16 +1,17 @@
 //cpp
+// @symbol func_ov006_020f8f68
+// @emits dScMgMCarlo2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_020f8ff0();
-extern void *data_ov006_0213d7e8[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_020f8f68(char *c);
-void *func_ov006_020f8f68(char *c) {
+void *dScMgMCarlo2_c_OnYoshiTryEat(char *c);
+void *dScMgMCarlo2_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213d7e8;
     func_0207328c(c + 0x51a8, 0x28, 0x30, (void*)&func_ov006_020f8ff0);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_020f9fe0.c
+++ b/src/func_ov006_020f9fe0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov006_020f9fe0
+// @emits dScMgMCarlo2_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int func_ov006_020f9fe0(void *t)
+int dScMgMCarlo2_c_CleanupResources(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;


### PR DESCRIPTION
Batch 10 of the readable-tree migration. Promotes 190 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 135 VERIFIED, 55 BLIND, 0 WRONG/NO-REPRO. 0 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
