### PR TITLE
readable: batch 11 - promote 188 files to readable form

### DIFF
--- a/src/func_ov006_020f9ffc.cpp
+++ b/src/func_ov006_020f9ffc.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov006_020f9ffc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo2_c.h"
+// @emits dScMgMCarlo2_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::Render - recovered from vtable slot identity */
 struct Node {
     virtual void m0();
     Node *next;
@@ -7,17 +15,14 @@ struct Node {
 };
 
 extern "C" void func_ov006_020c0aa8(void *c);
-extern "C" void func_ov004_020b1ea4(int a, int b, int c, int d, int e, int f, int g);
 extern "C" int  func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
-extern "C" void func_ov004_020b0d8c(void *c, int arg1, int arg2);
 extern "C" void func_ov006_020c1804(void *c);
 
-extern short data_ov006_02142564;
-extern int data_ov006_02133f18;
 extern Node *data_ov006_02142578;
 
-extern "C" int func_ov006_020f9ffc(char *c)
+extern "C" int dScMgMCarlo2_c_Render(char *c)
 {
+    struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
     short v;
     Node *n6;
     int i5;
@@ -33,7 +38,7 @@ extern "C" int func_ov006_020f9ffc(char *c)
 
     func_ov004_020afa20(data_ov006_02133f18, 0xe8, 0x18, -1, -1);
 
-    if (*(short *)(c + 0x5928) == 5)
+    if (self->unk_5928 == 5)
         func_ov004_020b0d8c(c, 0xe0, 0xa0);
 
     n6 = data_ov006_02142578;

--- a/src/func_ov006_020fa13c.c
+++ b/src/func_ov006_020fa13c.c
@@ -1,24 +1,16 @@
+// @symbol func_ov006_020fa13c
+// @emits dScMgMCarlo2_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
 
-extern int func_ov006_020f9668(void);
-extern int func_ov006_020f95f0(void);
 extern int func_ov006_020c1718(void* p);
-extern void func_ov006_020c1164(void* t, int a1, void* a2);
-extern int func_ov006_020f96e0(void);
-extern int func_ov006_020c16b4(void* c);
-extern void func_ov006_020c0d68(void* c);
-extern void func_ov004_020b0a54(int a);
 extern void func_ov006_020c19d0(void* c);
-extern void func_ov006_020f9000(void);
 
-extern int data_ov006_0213d700;
-extern int data_ov006_0213d6fc;
-extern s16 data_ov006_0213d6f4;
-extern s16 data_ov006_0213d6f8;
-extern int data_ov006_02142570;
-extern int data_ov006_02142574;
 
-int func_ov006_020fa13c(void* arg)
+int dScMgMCarlo2_c_Behavior(void* arg)
 {
     unsigned char* c = (unsigned char*)arg;
 

--- a/src/func_ov006_020fa4d4.cpp
+++ b/src/func_ov006_020fa4d4.cpp
@@ -1,18 +1,24 @@
 //cpp
+// @symbol func_ov006_020fa4d4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo2_c.h"
+// @emits dScMgMCarlo2_c_OnYoshiTryEat_020fa4d4
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern void func_ov006_020f9760(void* p);
 extern void func_ov006_020c1604(char* c, int unused, short a2, void* a3);
-extern void func_ov004_020adb1c(int self);
-extern int data_ov006_0213d6fc;
-void func_ov006_020fa4d4(char* c) {
+void dScMgMCarlo2_c_OnYoshiTryEat_020fa4d4(char* c) {
+    struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
   func_ov006_020f9760(c + 0x51a8);
   data_ov006_0213d6fc = 0;
-  *(short*)(c + 0x592e) = 0;
-  *(short*)(c + 0x511e) = 1;
+  self->unk_592e = 0;
+  self->unk_511e = 1;
   func_ov006_020c1604(c + 0x4f38, 4, 4, c + 0x592e);
-  *(short*)(c + 0x4f52) = 1;
-  *(short*)(c + 0x592a) = 0;
+  self->unk_4f52 = 1;
+  self->unk_592a = 0;
   func_ov004_020adb1c(0);
-  *(short*)(c + 0x5928) = 1;
+  self->unk_5928 = 1;
 }
 }

--- a/src/func_ov006_020fa56c.cpp
+++ b/src/func_ov006_020fa56c.cpp
@@ -1,16 +1,20 @@
 //cpp
-extern "C" void func_ov004_020b04d0(int v);
+// @symbol func_ov006_020fa56c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgMCarlo2_c.h"
+// @emits dScMgMCarlo2_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgMCarlo2_c::InitResources - recovered from vtable slot identity */
 extern "C" void func_ov006_0210a534(void *c);
 extern "C" int func_ov004_020ad674(void);
 extern "C" int LoadFile(int handle);
 extern "C" void DecompressLZ16(int src, int dst);
 extern "C" void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, unsigned int a, unsigned int b);
 extern "C" void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, unsigned int a, unsigned int b);
-extern "C" void Deallocate(void *ptr);
 extern "C" void func_ov006_020c0aa8(void *p);
 extern "C" int func_ov006_020c1a88(void *p);
-extern "C" void func_ov004_020b682c(void);
-extern "C" int data_ov006_0213d744[];
 extern "C" unsigned char data_0209d45c;
 extern "C" unsigned char data_0209d454;
 
@@ -36,8 +40,9 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int func_ov006_020fa56c(char *c)
+extern "C" int dScMgMCarlo2_c_InitResources(char *c)
 {
+    struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
     int handle;
     int f1, f2;
     func_ov004_020b04d0(0x20);
@@ -59,8 +64,8 @@ extern "C" int func_ov006_020fa56c(char *c)
     if (func_ov006_020c1a88((void *)(c + 0x4f38)) == 0) return 0;
     func_ov004_020b682c();
     ((Base *)c)->m48(-1);
-    *(short *)(c + 0x592a) = 0;
-    *(int *)(c + 0xa8) = 0xa;
-    *(int *)(c + 0xac) = *(int *)(c + 0xa8);
+    self->unk_592a = 0;
+    self->unk_0a8 = 0xa;
+    self->unk_0ac = self->unk_0a8;
     return 1;
 }

--- a/src/func_ov006_020fa780.c
+++ b/src/func_ov006_020fa780.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020fa780(int *t)
+// @symbol func_ov006_020fa780
+// @emits dScMgPachinko_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgPachinko_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020fed58.c
+++ b/src/func_ov006_020fed58.c
@@ -1,6 +1,10 @@
-extern void func_ov006_020fadfc(char *p);
-extern void func_ov006_020fad90(char *p);
-void func_ov006_020fed58(char *c, int n){
+// @symbol func_ov006_020fed58
+// @emits dScMgPachinko_c_OnYoshiTryEat_020fed58
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgPachinko_c_OnYoshiTryEat_020fed58(char *c, int n){
     *(int*)(c+0x5000+0xc10) = 0;
     if(n == 9){
         *(int*)(c+0xbc) = *(int*)(c+0xbc) + 1;

--- a/src/func_ov006_020fedc4.c
+++ b/src/func_ov006_020fedc4.c
@@ -1,3 +1,7 @@
+// @symbol func_ov006_020fedc4
+// @emits dScMgPachinko_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko_c::Render - recovered from vtable slot identity */
 void func_ov006_020fba48(void *c);
 void func_ov006_020fba28(void *c);
 void func_ov006_020fb74c(void *c);
@@ -9,7 +13,7 @@ void func_ov006_020fae20(void *c);
 void func_ov006_020fc144(void *c);
 void func_ov006_020fa7b8(void *c);
 
-int func_ov006_020fedc4(void *c)
+int dScMgPachinko_c_Render(void *c)
 {
     func_ov006_020fba48(c);
     func_ov006_020fba28(c);

--- a/src/func_ov006_020ff444.c
+++ b/src/func_ov006_020ff444.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_020ff444(int *t)
+// @symbol func_ov006_020ff444
+// @emits dScMgPachinko2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko2_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgPachinko2_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_02103cbc.c
+++ b/src/func_ov006_02103cbc.c
@@ -1,6 +1,11 @@
+// @symbol func_ov006_02103cbc
+// @emits dScMgPachinko2_c_OnYoshiTryEat_02103cbc
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b0aa0(int n);
-extern void func_ov006_02103bfc(char *p);
-void func_ov006_02103cbc(char *c, int n){
+void dScMgPachinko2_c_OnYoshiTryEat_02103cbc(char *c, int n){
     *(int*)(c+0x5000+0x660) = 0;
     if(n == 0x10){
         *(int*)(c+0xbc) = *(int*)(c+0xbc) + 1;

--- a/src/func_ov006_02103d28.c
+++ b/src/func_ov006_02103d28.c
@@ -1,12 +1,10 @@
-int func_ov006_02103d28(void* c){
-  extern int func_ov006_021004c0();
-  extern int func_ov006_02100488();
-  extern int func_ov006_02102624();
-  extern int func_ov006_02100314();
-  extern int func_ov006_02100140();
-  extern int func_ov006_02102de4();
-  extern int func_ov006_0210068c();
-  extern int func_ov006_020ff47c();
+// @symbol func_ov006_02103d28
+// @emits dScMgPachinko2_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko2_c::Render - recovered from vtable slot identity */
+int dScMgPachinko2_c_Render(void* c){
   func_ov006_021004c0(c);
   func_ov006_02100488(c);
   func_ov006_02102624(c);

--- a/src/func_ov006_02103ed0.c
+++ b/src/func_ov006_02103ed0.c
@@ -1,33 +1,27 @@
+// @symbol func_ov006_02103ed0
+// @emits dScMgPachinko2_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPachinko2_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern int LoadFile(int handle);
-extern int func_02054d88(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern unsigned func_02054de8(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 extern char *_ZN3G2S12GetBG2ScrPtrEv(void);
-extern void func_ov004_020af2f8(char *c, int a, int b, int d);
-extern char *_ZN3G2S13GetBG3CharPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_020562b4(const void *src, u32 offset, u32 count);
-extern void func_020564f4(const void *src, int offset, int count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_ov006_02103bfc(char *c);
-extern void func_ov006_02100084(char *c);
-extern void func_ov006_021024e0(int c);
-extern void func_ov006_020fffec(char *c);
-extern void func_ov004_020b04d0(int v);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int func_ov006_02103ed0(void *arg0)
+int dScMgPachinko2_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_021042b0.c
+++ b/src/func_ov006_021042b0.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_021042b0(int *t)
+// @symbol func_ov006_021042b0
+// @emits dScMgPanel_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPanel_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgPanel_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_021071fc.c
+++ b/src/func_ov006_021071fc.c
@@ -1,16 +1,18 @@
-extern void func_ov004_020adb1c(int self);
+// @symbol func_ov006_021071fc
+// @emits dScMgPanel_c_OnYoshiTryEat_021071fc
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPanel_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b0aa0(int arg);
 extern void func_ov006_021067a4(char *p);
 extern void func_ov006_021063a0(char *p);
 extern void func_ov006_02106168(char *p);
-extern void func_ov006_02104b24(char *p);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
-extern void SetSubBg0Offset(int a, int b);
 
 extern char *func_020beb68;
 extern unsigned char data_0209d454;
 
-void func_ov006_021071fc(char *self, int flag)
+void dScMgPanel_c_OnYoshiTryEat_021071fc(char *self, int flag)
 {
     char *p;
 

--- a/src/func_ov006_0210730c.c
+++ b/src/func_ov006_0210730c.c
@@ -1,10 +1,11 @@
+// @symbol func_ov006_0210730c
+// @emits dScMgPanel_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPanel_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void* a, int b, int c, int d);
-extern void func_ov006_02104d44(void* a);
-extern void func_ov006_02104d94(void* a);
-extern void func_ov006_021042e8(void* a);
-extern void func_ov006_02104b5c(void* a);
-extern void func_ov006_02105ab4(void* a);
-int func_ov006_0210730c(void* c){
+int dScMgPanel_c_Render(void* c){
   func_ov004_020b1e34(c, 0xe0, 0x14, 1);
   func_ov006_02104d44(c);
   func_ov006_02104d94(c);

--- a/src/func_ov006_02107358.cpp
+++ b/src/func_ov006_02107358.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov006_02107358
+// @emits dScMgPanel_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPanel_c::Behavior - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_02104ac4(void*);
-extern int func_ov006_02104354(void*);
 struct Ent{ int a; int b; };
 extern Ent data_ov006_02142888[];
-int func_ov006_02107358(char* c){
+int dScMgPanel_c_Behavior(char* c){
   int idx=*(int*)(c+0x4000+0xca8);
   Ent* e=&data_ov006_02142888[idx];
   int adj=e->b;

--- a/src/func_ov006_021073b0.c
+++ b/src/func_ov006_021073b0.c
@@ -1,39 +1,31 @@
+// @symbol func_ov006_021073b0
+// @emits dScMgPanel_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgPanel_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern int LoadFile(int handle);
-extern int func_02054d88(void);
 extern void DecompressLZ16(int src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern char *_ZN2G212GetBG2ScrPtrEv(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
-extern void func_020563d4(const void *src, u32 offset, u32 count);
-extern int GetOwnerLanguage(void);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern char *_ZN3G2S13GetBG3CharPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_020562b4(const void *src, u32 offset, u32 count);
 extern char *_ZN3G2S12GetBG2ScrPtrEv(void);
-extern void func_02056374(const void *src, u32 offset, u32 count);
-extern void func_020564f4(const void *src, int offset, int count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void func_ov004_020b0aa0(int arg);
 extern void func_ov006_021067a4(void *p);
-extern void func_ov006_02106758(char *c);
 extern void func_ov006_021063a0(void *p);
 extern void func_ov006_02106168(void *p);
-extern void func_ov006_02105118(char *p);
-extern void func_ov006_02104b24(char *p);
-extern void func_ov004_020b04d0(int v);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int func_ov006_021073b0(void *arg0)
+int dScMgPanel_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_02107920.cpp
+++ b/src/func_ov006_02107920.cpp
@@ -1,17 +1,18 @@
 //cpp
+// @symbol func_ov006_02107920
+// @emits dScMgRoulette_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ModelD1Ev(void *);
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_021079c8();
-extern void *data_ov006_0213e39c[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_02107920(char *c);
-void *func_ov006_02107920(char *c) {
+void *dScMgRoulette_c_OnYoshiTryEat(char *c);
+void *dScMgRoulette_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213e39c;
     _ZN5ModelD1Ev(c + 0x536c);
     _ZN5ModelD1Ev(c + 0x531c);

--- a/src/func_ov006_02107db8.cpp
+++ b/src/func_ov006_02107db8.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov006_02107db8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 int func_020124c4(int a, int b, int c, int d);
@@ -15,7 +18,7 @@ struct Obj {
 struct C;
 typedef void (C::*PMF)();
 
-struct M48 { int w[12]; };
+
 
 struct C {
     PMF pmf;            /* 0x0 */
@@ -31,7 +34,7 @@ extern "C" void func_ov006_02107db8(C *c)
     *(short *)(*(int *)(b + 0x20) + 0x82) = (short)(-*(short *)(b + 0xc2));
     c->obj.v3();
     Matrix4x3_FromTranslation(&data_020a0e68, 0, 0, 0);
-    *(M48 *)(b + 0x2c) = *(M48 *)&data_020a0e68;
+    *(Matrix4x3 *)(b + 0x2c) = *(Matrix4x3 *)&data_020a0e68;
     (c->*(c->pmf))();
     {
         short s = *(short *)(b + 0xcc);

--- a/src/func_ov006_021095cc.c
+++ b/src/func_ov006_021095cc.c
@@ -1,14 +1,17 @@
-extern void func_ov006_02107b14(void);
-extern void func_ov006_020c0e8c(int *t);
-extern void func_ov006_021092a0(int *o);
-extern void func_ov006_02108524(char *c);
+// @symbol func_ov006_021095cc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgRoulette_c.h"
+// @emits dScMgRoulette_c_OnYoshiTryEat_021095cc
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void);
 extern int *func_020beb68;
-extern void *data_ov006_021428c8;
-extern int func_020bc7d4;
 
-void func_ov006_021095cc(char *this)
+void dScMgRoulette_c_OnYoshiTryEat_021095cc(char *this)
 {
+    struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)this;
     int i;
     int *e;
     int n;
@@ -16,8 +19,8 @@ void func_ov006_021095cc(char *this)
     func_ov006_02107b14();
     func_ov006_020c0e8c((int *)(this + 0x4f38));
 
-    *(short *)(this + 0x53f2) = 0;
-    *(short *)(this + 0x53e8) = 0xa;
+    self->unk_53f2 = 0;
+    self->unk_53e8 = 0xa;
 
     e = (int *)(this + 0x51a8);
     for (i = 0; i < 5; i++) {
@@ -25,25 +28,25 @@ void func_ov006_021095cc(char *this)
         e = (int *)((char *)e + 0x34);
     }
 
-    *(int *)(this + 0x53f8) = 0;
-    *(short *)(this + 0x53f6) = 0;
+    self->unk_53f8 = 0;
+    self->unk_53f6 = 0;
     n = 0;
     if (func_020beb68 != 0) n = func_020beb68[0xa8 / 4];
     if (n >= 5) n = 5;
-    *(int *)(this + 0x53fc) = n;
+    self->unk_53fc = n;
 
     func_ov006_02108524(this + 0x530c);
 
     data_ov006_021428c8 = 0;
-    *(short *)(this + 0x53e4) = 0;
-    *(int *)(this + 0x53e0) = 0x100;
-    *(short *)(this + 0x53ea) = 0;
-    *(unsigned char *)(this + 0x53ec) = 0;
-    *(unsigned char *)(this + 0x53ed) = 0;
-    *(unsigned char *)(this + 0x53ee) = 0;
-    *(unsigned char *)(this + 0x53ef) = 0;
-    *(unsigned char *)(this + 0x53f0) = 0;
-    *(short *)(this + 0x53e6) = 1;
+    self->unk_53e4 = 0;
+    self->unk_53e0 = 0x100;
+    self->unk_53ea = 0;
+    self->unk_53ec = 0;
+    self->unk_53ed = 0;
+    self->unk_53ee = 0;
+    self->unk_53ef = 0;
+    self->unk_53f0 = 0;
+    self->unk_53e6 = 1;
 
     func_ov004_020b66d4();
     func_020bc7d4 = 1;

--- a/src/func_ov006_021096c8.c
+++ b/src/func_ov006_021096c8.c
@@ -1,37 +1,42 @@
+// @symbol func_ov006_021096c8
+// @emits dScMgRoulette_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::OnTurnIntoEgg - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 
 extern void func_ov004_020b0aa0(int a);
-extern int func_ov006_02107a6c(void);
 extern int func_ov006_020c1718(char *c);
 extern void func_ov004_020b56c8(void);
 extern u16 data_ov004_020bf9e4;
 
-int func_ov006_021096c8(char *self)
+int dScMgRoulette_c_OnTurnIntoEgg(char *self)
 {
     switch (*(s16 *)(self + 0x53e6)) {
     case 5:
         func_ov004_020b0aa0(0x1d);
         if (func_ov006_02107a6c() != 0)
-            (*(s16 *)(((long long)(int)(self + 0x53e6)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
         break;
     case 6:
         if (func_ov006_020c1718(self + 0x4f38) != 0) {
             *(u16 *)(self + 0x53e8) = 0x3c;
             *(int *)(self + 0x53f8) = 0;
-            (*(s16 *)(((long long)(int)(self + 0x53e6)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
         }
         break;
     case 7:
-        (*(s16 *)(((long long)(int)(self + 0x53e8)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(s16 *)(((long long)(int)(self + 0x53e8))))--;
         if (*(s16 *)(self + 0x53e8) == 0) {
             if (*(s16 *)(self + 0x53f2) != 0)
                 func_ov004_020b56c8();
-            (*(s16 *)(((long long)(int)(self + 0x53e6)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
         }
         break;
     case 8:
-        (*(s16 *)(((long long)(int)(self + 0x53e6)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(s16 *)(((long long)(int)(self + 0x53e6))))++;
         /* fall through */
     case 9:
     default:

--- a/src/func_ov006_0210980c.c
+++ b/src/func_ov006_0210980c.c
@@ -1,5 +1,10 @@
-extern void func_ov006_0210858c(void *p);
-int func_ov006_0210980c(char *c){
+// @symbol func_ov006_0210980c
+// @emits dScMgRoulette_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::CleanupResources - recovered from vtable slot identity */
+int dScMgRoulette_c_CleanupResources(char *c){
   func_ov006_0210858c(c + 0x530c);
   return 1;
 }

--- a/src/func_ov006_02109834.c
+++ b/src/func_ov006_02109834.c
@@ -1,4 +1,12 @@
-/* func_ov006_02109834 @ 0x02109834 (ov006, size 0x26c)
+// @symbol func_ov006_02109834
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgRoulette_c.h"
+// @emits dScMgRoulette_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::Render - recovered from vtable slot identity */
+/* dScMgRoulette_c_Render @ 0x02109834 (ov006, size 0x26c)
  * Race minigame frame update: updates the racers back-to-front, plays the
  * countdown beep (volume ramps over the last 3 seconds), shows the winner
  * banner with per-rank colors, and refreshes the board.
@@ -17,36 +25,22 @@ typedef struct Obj9 {
 } Obj9;
 
 extern int data_020a0db0;
-extern int data_ov006_02138c18;
-extern char data_ov006_02142ab4[];
-extern char data_ov006_02142ab8[];
-extern char data_ov006_0213e2e0[];
-extern char data_ov006_0213e34c[];
-extern char data_ov006_0213e350[];
-extern char data_ov006_0213e354[];
-extern char data_ov006_0213e370[];
-extern char data_ov006_0213e374[];
-extern char data_ov006_0213e378[];
 
 extern void func_ov004_020b1bc8(char *, int, int, int);
-extern void func_ov004_020b6430(void);
-extern void func_ov006_02108cc0(char *);
-extern void func_ov006_02109aa0(char *);
 extern void func_ov004_020af68c(int, int, int, int, int);
-extern int func_02053200(int);
 extern void func_ov004_020b2220(int, int, int, int, int, int, int);
 extern void func_ov006_020c0134(char *);
 extern void func_ov006_020c0aa8(char *);
-extern void func_ov006_02107d80(char *);
 extern void func_ov006_020c1804(char *);
 
-int func_ov006_02109834(char *c)
+int dScMgRoulette_c_Render(char *c)
 {
+    struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)c;
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);
     func_ov004_020b6430();
 
     {
-        int i = *(int *)(c + 0x53fc) - 1;
+        int i = self->unk_53fc - 1;
         for (; i >= 0; i--)
             func_ov006_02108cc0(((Obj9 *)c)->racers[i].b);
     }
@@ -54,11 +48,11 @@ int func_ov006_02109834(char *c)
     func_ov006_02109aa0(c);
 
     {
-        int idle = (int)(((long long)(*(int *)(c + 0x53c4) == 0)) & 0xFFFFFFFFFFFFFFFFLL);
+        int idle = (int)(((long long)(self->unk_53c4 == 0)));
         if (idle != 0) {
-            if (*(s16 *)(c + 0x53e6) < 8) {
+            if (self->unk_53e6 < 8) {
                 if (data_020a0db0 & 8) {
-                    s16 idx = *(s16 *)(c + 0x53d6);
+                    s16 idx = self->unk_53d6;
                     func_ov004_020af68c(data_ov006_02138c18,
                                         *(int *)(data_ov006_02142ab4 + idx * 8) >> 12,
                                         *(int *)(data_ov006_02142ab8 + idx * 8) >> 12,
@@ -68,8 +62,8 @@ int func_ov006_02109834(char *c)
         }
     }
 
-    if (*(s16 *)(c + 0x53e6) == 2) {
-        int t = *(s16 *)(c + 0x53e8);
+    if (self->unk_53e6 == 2) {
+        int t = self->unk_53e8;
         if (t <= 0xb4) {
             int u = t + 0x3b;
             s16 rem = u % 60;
@@ -82,7 +76,7 @@ int func_ov006_02109834(char *c)
     }
 
     {
-        s16 k = *(s16 *)(c + 0x53e4);
+        s16 k = self->unk_53e4;
         if (k != 0) {
             int off = k * 0xc;
             s16 hval = *(s16 *)(data_ov006_0213e2e0 + k * 2);
@@ -90,19 +84,19 @@ int func_ov006_02109834(char *c)
                 int d1 = *(int *)(data_ov006_0213e354 + off);
                 int b1 = *(int *)(data_ov006_0213e350 + off);
                 int a1 = *(int *)(data_ov006_0213e34c + off);
-                *(int *)(c + 0x470c) = a1;
-                *(int *)(c + 0x4710) = b1;
-                *(int *)(c + 0x4714) = d1;
+                self->unk_470c = a1;
+                self->unk_4710 = b1;
+                self->unk_4714 = d1;
             }
             {
                 int f2 = *(int *)(data_ov006_0213e378 + off);
                 int e2 = *(int *)(data_ov006_0213e374 + off);
                 int d2 = *(int *)(data_ov006_0213e370 + off);
-                *(int *)(c + 0x4700) = d2;
-                *(int *)(c + 0x4704) = e2;
-                *(int *)(c + 0x4708) = f2;
+                self->unk_4700 = d2;
+                self->unk_4704 = e2;
+                self->unk_4708 = f2;
             }
-            *(s16 *)(c + 0x4718) = hval;
+            self->unk_4718 = hval;
             func_ov006_020c0134(c + 0x4660);
         } else {
             func_ov006_020c0aa8(c + 0x4660);

--- a/src/func_ov006_0210a194.cpp
+++ b/src/func_ov006_0210a194.cpp
@@ -1,5 +1,13 @@
 //cpp
-/* func_ov006_0210a194 @ 0x0210a194 (ov006, size 0x26c)
+// @symbol func_ov006_0210a194
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgRoulette_c.h"
+// @emits dScMgRoulette_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgRoulette_c::InitResources - recovered from vtable slot identity */
+/* dScMgRoulette_c_InitResources @ 0x0210a194 (ov006, size 0x26c)
  * Minigame dual-screen graphics init: sets both sub BG layers, loads the
  * BG tiles/maps/palette and the shared OBJ tiles/palettes for both engines,
  * then initializes the board, cursor and slider objects.
@@ -33,27 +41,20 @@ extern "C" {
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-extern void func_ov004_020b04d0(int);
 extern void *LoadFile(int);
 extern int func_02054de8(void);
 extern void DecompressLZ16(void *, int);
 extern int _ZN3G2S12GetBG2ScrPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(void *, unsigned int, unsigned int);
-extern void Deallocate(void *);
-extern void SetSubBg0Offset(int, int);
-extern void SetSubBg2Offset(int, int);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(void *, unsigned int, unsigned int);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(void *, unsigned int, unsigned int);
 extern void func_ov006_020c0aa8(char *);
 extern int func_ov006_020c1a88(char *);
-extern int func_ov006_021085c0(char *);
-extern int func_ov004_020ad8b8(void);
-extern void func_ov004_020b682c(void);
-extern void func_ov006_02107b70(char *);
 
-int func_ov006_0210a194(char *c)
+int dScMgRoulette_c_InitResources(char *c)
 {
+    struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)c;
     void *f8, *f7, *f6, *f5;
 
     func_ov004_020b04d0(0x20);
@@ -103,8 +104,8 @@ int func_ov006_0210a194(char *c)
     if (func_ov006_021085c0(c + 0x530c) == 0)
         return 0;
 
-    *(int *)(c + 0xa8) = func_ov004_020ad8b8();
-    *(int *)(c + 0xac) = *(int *)(c + 0xa8);
+    self->unk_0a8 = func_ov004_020ad8b8();
+    self->unk_0ac = self->unk_0a8;
     func_ov004_020b682c();
     func_ov006_02107b70(c + 0x52ac);
     ((VtObj *)c)->m18(-1);

--- a/src/func_ov006_0210a4e8.cpp
+++ b/src/func_ov006_0210a4e8.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov006_0210a4e8
+// @emits dScMgSingle3DBase_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* dScMgSingle3DBase_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN8Particle10SysTrackerD1Ev(void*);
 extern int func_ov004_020b29c0(void*);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
 extern int data_ov006_0213e448[];
 extern void* data_020a0eac[];
-int func_ov006_0210a4e8(char* c){
+int dScMgSingle3DBase_c_OnYoshiTryEat(char* c){
   *(int*)c=(int)data_ov006_0213e448;
   _ZN8Particle10SysTrackerD1Ev(c+0x471c);
   func_ov004_020b29c0(c);

--- a/src/func_ov006_0210a600.c
+++ b/src/func_ov006_0210a600.c
@@ -1,4 +1,8 @@
-int func_ov006_0210a600(void)
+// @symbol func_ov006_0210a600
+// @emits dScMgFlower_c_OnHitByCannonBlastedChar
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
+int dScMgFlower_c_OnHitByCannonBlastedChar(void)
 {
     return 1;
 }

--- a/src/func_ov006_0210a608.c
+++ b/src/func_ov006_0210a608.c
@@ -1,6 +1,11 @@
-extern void CleanCommonModelDataArr(void);
+// @symbol func_ov006_0210a608
+// @emits dScMgFlower_c_AfterCleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::AfterCleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020b0840(int a, int b);
-void func_ov006_0210a608(int a, int b) {
+void dScMgFlower_c_AfterCleanupResources(int a, int b) {
     if (b == 2) {
         *(volatile int*)0x40004c8 = 0x296a5800;
         *(volatile int*)0x40004cc = 0x7fff;

--- a/src/func_ov006_0210a664.c
+++ b/src/func_ov006_0210a664.c
@@ -1,11 +1,16 @@
+// @symbol func_ov006_0210a664
+// @emits dScMgFlower_c_BeforeRender
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Particle.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::BeforeRender - recovered from vtable slot identity */
 typedef int Bool;
 
 struct Scene;
 
 extern Bool func_ov004_020b04f4(struct Scene* self);
-extern void _ZN8Particle9RenderAllEv(void);
 
-Bool func_ov006_0210a664(struct Scene* self)
+Bool dScMgFlower_c_BeforeRender(struct Scene* self)
 {
     if (!func_ov004_020b04f4(self))
         return 0;

--- a/src/func_ov006_0210a698.cpp
+++ b/src/func_ov006_0210a698.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol func_ov006_0210a698
+// @emits dScMgFlower_c_BeforeBehavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::BeforeBehavior - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov004_020b0620(void*);
 extern unsigned int data_020a0db0;
 int _ZN8Particle10SysTracker6UpdateEv(void*);
-int func_ov006_0210a698(void* c){
+int dScMgFlower_c_BeforeBehavior(void* c){
   if(func_ov004_020b0620(c)==0) return 0;
   if(data_020a0db0 & 1)
     _ZN8Particle10SysTracker6UpdateEv((char*)c+0x471c);

--- a/src/func_ov006_0210a6e4.cpp
+++ b/src/func_ov006_0210a6e4.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol func_ov006_0210a6e4
+// @emits dScMgFlower_c_AfterInitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::AfterInitResources - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov004_020b08f0(void*);
 int _ZN8Particle10SysTracker10InitialiseEv(void*);
-int func_ov006_0210a6e4(void* c){
+int dScMgFlower_c_AfterInitResources(void* c){
   func_ov004_020b08f0(c);
   return _ZN8Particle10SysTracker10InitialiseEv((char*)c+0x471c);
 }

--- a/src/func_ov006_0210a900.cpp
+++ b/src/func_ov006_0210a900.cpp
@@ -1,12 +1,14 @@
 //cpp
+// @symbol func_ov006_0210a900
+// @emits dScMgSlot1_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot1_c::OnYoshiTryEat - recovered from vtable slot identity */
 struct Heap;
 namespace Memory { void Deallocate(void* p, Heap* h); }
-extern "C" void func_ov004_020b29c0(void* c);
-extern void* data_ov006_0213eb40;
-extern void* data_ov006_0213e5d4;
-extern void func_020ad494(void);
 extern Heap* data_020a0eac;
-extern "C" void* func_ov006_0210a900(char* c) {
+extern "C" void* dScMgSlot1_c_OnYoshiTryEat(char* c) {
     *(void**)c = &data_ov006_0213eb40;
     *(void**)(c + 0x4660) = &data_ov006_0213e5d4;
     *(void**)(c + 0x4660) = (void*)&func_020ad494;

--- a/src/func_ov006_0210a9a8.cpp
+++ b/src/func_ov006_0210a9a8.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol func_ov006_0210a9a8
+// @emits dScMgSlot3_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_020c21e4(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *data_ov006_0213eaa8[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_0210a9a8(char *c);
-void *func_ov006_0210a9a8(char *c) {
+void *dScMgSlot3_c_OnYoshiTryEat(char *c);
+void *dScMgSlot3_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213eaa8;
     func_ov006_020c21e4(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_0210aa10.c
+++ b/src/func_ov006_0210aa10.c
@@ -1,6 +1,11 @@
-extern void func_ov004_020aeed8(void* a);
+// @symbol func_ov006_0210aa10
+// @emits dScMgSlot3_c_OnAimedAtWithEggReturnVec
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 
-void func_ov006_0210aa10(void* a)
+void dScMgSlot3_c_OnAimedAtWithEggReturnVec(void* a)
 {
     *(volatile unsigned short*)0x400000A = (*(volatile unsigned short*)0x400000A & 0x43) | 0x1118;
     func_ov004_020aeed8(a);

--- a/src/func_ov006_0210aa3c.c
+++ b/src/func_ov006_0210aa3c.c
@@ -1,6 +1,11 @@
-extern void func_ov004_020af094(void* a);
+// @symbol func_ov006_0210aa3c
+// @emits dScMgSlot3_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 
-void func_ov006_0210aa3c(void* a)
+void dScMgSlot3_c_OnAimedAtWithEgg(void* a)
 {
     *(volatile unsigned short*)0x400000A = (*(volatile unsigned short*)0x400000A & 0x43) | 0x1000;
     func_ov004_020af094(a);

--- a/src/func_ov006_0210aa60.cpp
+++ b/src/func_ov006_0210aa60.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_0210aa60
+// @emits dScMgSlot3_c_AfterClsn
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::AfterClsn - recovered from vtable slot identity */
 struct G2 { static void* GetBG1ScrPtr(); };
 
 extern "C" {
@@ -9,9 +15,8 @@ extern "C" {
 }
 
 extern unsigned char data_0209d45c;
-extern int data_ov006_0213e614[];
 
-extern "C" void func_ov006_0210aa60(void)
+extern "C" void dScMgSlot3_c_AfterClsn(void)
 {
     int idx;
 

--- a/src/func_ov006_0210b314.c
+++ b/src/func_ov006_0210b314.c
@@ -1,15 +1,19 @@
+// @symbol func_ov006_0210b314
+// @emits dScMgSlot3_c_OnYoshiTryEat_0210b314
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::OnYoshiTryEat - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned int u32;
 
 extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
-extern void func_ov004_020adb1c(int self);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 extern void func_02012790(unsigned int id);
 
 #pragma opt_strength_reduction off
 
-void func_ov006_0210b314(char *c, int mode)
+void dScMgSlot3_c_OnYoshiTryEat_0210b314(char *c, int mode)
 {
     if (mode == 3 || mode == 0x12) {
         *(int *)(c + 0xa8) = 0xc;
@@ -23,9 +27,9 @@ void func_ov006_0210b314(char *c, int mode)
         func_ov004_020b0cac(0xd, 0x80, 0xa8, 1, -1, 0xd);
     } else if (mode == 4) {
         if (*(int *)(c + 0x5004) < 5) {
-            *(int *)(int)(((long long)(int)(c + 0x5004)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+            *(int *)(int)(((long long)(int)(c + 0x5004))) += 1;
         }
-        *(int *)(int)(((long long)(int)(c + 0xbc)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(int *)(int)(((long long)(int)(c + 0xbc))) += 1;
         if (*(u32 *)(c + 0xbc) > 0x270e) {
             *(int *)(c + 0xbc) = 0x270e;
         }

--- a/src/func_ov006_0210b648.c
+++ b/src/func_ov006_0210b648.c
@@ -1,53 +1,52 @@
+// @symbol func_ov006_0210b648
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgSlot3_c.h"
+// @emits dScMgSlot3_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::Render - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 
-extern void func_ov006_020c1eb4(char *a);
-extern void func_ov006_020c201c(char *a);
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int b, void *attr, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9);
 extern void func_ov004_020af68c(void *a0, int a1, int a2, int a3, int a4);
-extern void _ZN5Sound12PlayBank2_2DEj(unsigned int s);
 extern void func_ov004_020b1bc8(char *a0, int a1, int a2, int a3);
 extern void func_ov004_020b1e34(char *a0, int a1, int a2, int a3);
 extern int func_ov004_020ad674(void);
-extern void func_ov004_020af948(void *a, int b, int c2, void *m);
-extern void func_ov004_020b2444(int a1, int a2, int num, int a4, int a5, int sel, int idx);
-extern void func_ov004_020afb20(void *a0, int a1, int a2, int a3, int a4, int a5, u16 a6);
 
 typedef struct T4fe4 {
     char pad[0x4fe4];
     int vals[3];
 } T4fe4;
 
-extern void *data_ov006_0213e9a4[];
-extern int data_ov006_0213e5dc;
 extern char *data_ov006_0213e5ec[];
-extern void *data_ov006_0213ac30;
-extern void *data_ov006_0213ac3c;
 
 #pragma opt_strength_reduction off
 
-int func_ov006_0210b648(char *c)
+int dScMgSlot3_c_Render(char *c)
 {
+    struct dScMgSlot3_c *self = (struct dScMgSlot3_c *)(void *)c;
     int i, j;
 
     func_ov006_020c1eb4(c + 0x4660);
     func_ov006_020c201c(c + 0x4f38);
 
-    if (*(int *)(c + 0x500c) > 0) {
+    if (self->unk_500c > 0) {
         for (i = 0; i < 3; i++) {
-            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[*(u8 *)(c + 0x503b) * 3 + i], 0x80, *(int *)(c + 0x500c) + 0x10, -1, 2, 0x1000, 0x1000, 0, 1);
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[self->unk_503b * 3 + i], 0x80, self->unk_500c + 0x10, -1, 2, 0x1000, 0x1000, 0, 1);
         }
         for (i = 0; i < 3; i++) {
-            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[*(u8 *)(c + 0x503c) * 3 + i], 0x80, *(int *)(c + 0x500c) + 0x60, -1, 2, 0x1000, 0x1000, 0, 1);
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[self->unk_503c * 3 + i], 0x80, self->unk_500c + 0x60, -1, 2, 0x1000, 0x1000, 0, 1);
         }
     } else {
         for (i = 0; i < 3; i++) {
-            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[*(u8 *)(c + 0x503b) * 3 + i], 0x80, 0x60, -1, 2, 0x1000, 0x1000, 0, 1);
+            _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, data_ov006_0213e9a4[self->unk_503b * 3 + i], 0x80, 0x60, -1, 2, 0x1000, 0x1000, 0, 1);
         }
     }
 
-    if (*(int *)(c + 0x5000) != 7) {
-        if (*(int *)(c + 0x5000) == 6) {
+    if (self->unk_5000 != 7) {
+        if (self->unk_5000 == 6) {
             int i2, j2;
             char *p = c;
             for (i2 = 0; i2 < 3; i2++) {
@@ -71,7 +70,7 @@ int func_ov006_0210b648(char *c)
                 for (j2 = 0, y = 0x30; j2 < 4; j2++) {
                     func_ov004_020af68c(data_ov006_0213e9a4[*(u8 *)(p + row + 0x501c) * 3 + i2],
                                         y - rem, 0x60, -1, -1);
-                    row = (row + 1) % *(u8 *)(c + 0x503a);
+                    row = (row + 1) % self->unk_503a;
                     y += 0x50;
                 }
                 p += 5;
@@ -79,7 +78,7 @@ int func_ov006_0210b648(char *c)
         }
     }
 
-    if (*(u8 *)(c + 0x503d) < 3 && (*(u8 *)(c + 0x503f) & 0x20)) {
+    if (self->unk_503d < 3 && (self->unk_503f & 0x20)) {
         int slot = 3;
         int ok = 1;
         int i3, j3;
@@ -87,10 +86,10 @@ int func_ov006_0210b648(char *c)
         for (i3 = 0; i3 < 3; i3++) {
             if (*(u8 *)(c + i3 + 0x502e) != 0) {
                 if (slot < 3) {
-                    if (*(u8 *)(c + 0x503b) != *(u8 *)(p + slot + 0x5031))
+                    if (self->unk_503b != *(u8 *)(p + slot + 0x5031))
                         ok = 0;
                 } else {
-                    u8 t = *(u8 *)(c + 0x503b);
+                    u8 t = self->unk_503b;
                     for (j3 = 0; j3 < 3; j3++) {
                         if (t == *(u8 *)(p + j3 + 0x5031)) {
                             slot = j3;
@@ -116,7 +115,7 @@ int func_ov006_0210b648(char *c)
                 }
                 y += 0x18;
             }
-            if ((*(u8 *)(c + 0x503f) & 0x3f) == 0x20) {
+            if ((self->unk_503f & 0x3f) == 0x20) {
                 _ZN5Sound12PlayBank2_2DEj(count > 1 ? 0x1ac : 0x1ab);
             }
         }
@@ -125,22 +124,22 @@ int func_ov006_0210b648(char *c)
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
 
-    if (*(int *)(c + 0x5000) == 3 && *(int *)(c + 0x5010) >= 0) {
-        func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 8), *(int *)(c + 0x5010) * 0x50 + 0x20, 0x28, 0);
-        func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 0x34), *(int *)(c + 0x5010) * 0x50 + 0x30, 0x28, 0);
-        if (*(int *)(c + 0x5010) == 1) {
-            func_ov004_020b2444(*(int *)(c + 0x5010) * 0x50 + 0x40, 0x28, 6, 0, 0, 0, 0x14);
+    if (self->unk_5000 == 3 && self->unk_5010 >= 0) {
+        func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 8), self->unk_5010 * 0x50 + 0x20, 0x28, 0);
+        func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 0x34), self->unk_5010 * 0x50 + 0x30, 0x28, 0);
+        if (self->unk_5010 == 1) {
+            func_ov004_020b2444(self->unk_5010 * 0x50 + 0x40, 0x28, 6, 0, 0, 0, 0x14);
         } else {
-            func_ov004_020b2444(*(int *)(c + 0x5010) * 0x50 + 0x40, 0x28, 3, 0, 0, 0, 0x14);
+            func_ov004_020b2444(self->unk_5010 * 0x50 + 0x40, 0x28, 3, 0, 0, 0, 0x14);
         }
-    } else if (*(int *)(c + 0x5000) == 4 && *(int *)(c + 0x5010) < 0) {
+    } else if (self->unk_5000 == 4 && self->unk_5010 < 0) {
         func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 8), 0x70, 0x28, 0);
         func_ov004_020af948(*(void **)(data_ov006_0213e5ec[func_ov004_020ad674()] + 0x38), 0x80, 0x28, 0);
         func_ov004_020b2444(0x90, 0x28, 3, 0, 0, 0, 0x28);
     }
 
-    func_ov004_020afb20(data_ov006_0213ac30, 0x18, 0x30, -1, 0, 0x1000, *(u16 *)(c + 0x5018));
-    func_ov004_020afb20(data_ov006_0213ac3c, 0x40, 0x10, -1, 0, 0x1000, *(u16 *)(c + 0x501a));
+    func_ov004_020afb20(data_ov006_0213ac30, 0x18, 0x30, -1, 0, 0x1000, self->unk_5018);
+    func_ov004_020afb20(data_ov006_0213ac3c, 0x40, 0x10, -1, 0, 0x1000, self->unk_501a);
 
     return 1;
 }

--- a/src/func_ov006_0210bcb0.cpp
+++ b/src/func_ov006_0210bcb0.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_0210bcb0
+// @emits dScMgSlot3_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::Behavior - recovered from vtable slot identity */
 struct Obj {
     char pad0[0x4f38];
     int field_4f38;
@@ -17,10 +23,9 @@ extern ObjFn data_ov006_02142bdc[];
 extern int data_0209e650;
 extern unsigned char data_0209d45c;
 
-extern "C" void func_ov006_020c2144(void *a);
 extern "C" int RandomIntInternal(int *seed);
 
-extern "C" int func_ov006_0210bcb0(Obj *self) {
+extern "C" int dScMgSlot3_c_Behavior(Obj *self) {
     int i;
     unsigned char t;
 
@@ -30,14 +35,14 @@ extern "C" int func_ov006_0210bcb0(Obj *self) {
 
     (self->*data_ov006_02142bdc[self->idx])();
 
-    pc = (unsigned char *)(((long long)(int)((char *)self + 0x503f)) & 0xFFFFFFFFFFFFFFFFLL);
+    pc = (unsigned char *)(((long long)(int)((char *)self + 0x503f)));
     *pc = *pc + 1;
     func_ov006_020c2144((char *)self + 0x4f38);
 
     for (i = 0; i < 3; i++) {
         if (self->idx == 1) {
-            ph1 = (unsigned short *)(((long long)(int)((char *)self + 0x5018)) & 0xFFFFFFFFFFFFFFFFLL);
-            ph2 = (unsigned short *)(((long long)(int)((char *)self + 0x501a)) & 0xFFFFFFFFFFFFFFFFLL);
+            ph1 = (unsigned short *)(((long long)(int)((char *)self + 0x5018)));
+            ph2 = (unsigned short *)(((long long)(int)((char *)self + 0x501a)));
             *ph1 = *ph1 - 0x200;
             *ph2 = *ph2 - 0x400;
             break;

--- a/src/func_ov006_0210bdb0.cpp
+++ b/src/func_ov006_0210bdb0.cpp
@@ -1,42 +1,33 @@
 //cpp
+// @symbol func_ov006_0210bdb0
+// @emits dScMgSlot3_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot3_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern "C" {
 
-extern int func_02054d88(void);
 extern u32 LoadCompressedFileAt(u16 fileID, void *target);
 extern int LoadFile(int handle);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void Deallocate(void *ptr);
-extern void *_ZN2G212GetBG1ScrPtrEv(void);
 extern void *_ZN2G212GetBG2ScrPtrEv(void);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern void *func_02054de8(void);
 extern void *_ZN3G2S12GetBG2ScrPtrEv(void);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *p, u16 a, u16 b, u16 c, u16 d);
-extern void func_ov006_020c2154(char *c);
-extern void func_ov006_020c1eb4(char *c);
 extern int RandomIntInternal(int *seed);
-extern void func_ov004_020b04d0(int v);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 extern int data_0209e650;
 extern int data_0208ee44;
-extern int func_020bc88c;
-extern int func_020bc878;
-extern int func_020bc8b8;
-extern int func_020bc888;
-extern int func_020bc860;
-extern int func_020bc890;
-extern int func_020bc8b4;
-extern int func_020bc864;
 
 }
 
@@ -62,7 +53,7 @@ struct Obj {
     virtual void m48(int a);
 };
 
-extern "C" int func_ov006_0210bdb0(void *arg0)
+extern "C" int dScMgSlot3_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
 

--- a/src/func_ov006_0210c4b8.c
+++ b/src/func_ov006_0210c4b8.c
@@ -1,6 +1,11 @@
+// @symbol func_ov006_0210c4b8
+// @emits dScMgSlot1_c_OnHitFromUnderneath
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot1_c::OnHitFromUnderneath - recovered from vtable slot identity */
 extern void func_ov004_020af04c(void* self);
-extern void SetSubBg1Offset(int a, int b);
-void func_ov006_0210c4b8(void* c) {
+void dScMgSlot1_c_OnHitFromUnderneath(void* c) {
     func_ov004_020af04c(c);
     SetSubBg1Offset(0x100, 0);
 }

--- a/src/func_ov006_0210c4dc.c
+++ b/src/func_ov006_0210c4dc.c
@@ -1,6 +1,11 @@
-extern void SetSubBg1Offset(int a, int b);
+// @symbol func_ov006_0210c4dc
+// @emits dScMgSlot1_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot1_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void func_ov004_020af27c(void* c);
-void func_ov006_0210c4dc(void* c) {
+void dScMgSlot1_c_OnHitByMegaChar(void* c) {
     SetSubBg1Offset(0, 0);
     func_ov004_020af27c(c);
 }

--- a/src/func_ov006_0210c674.c
+++ b/src/func_ov006_0210c674.c
@@ -1,11 +1,18 @@
-extern void func_ov006_0210c638(void* thiz);
-extern void func_ov006_0210c354(void* p);
-void func_ov006_0210c674(char* c, int i){
+// @symbol func_ov006_0210c674
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgSlot1_c.h"
+// @emits dScMgSlot1_c_OnYoshiTryEat_0210c674
+/* recovered: renamed to Class_Method */
+/* dScMgSlot1_c::OnYoshiTryEat - recovered from vtable slot identity */
+void dScMgSlot1_c_OnYoshiTryEat_0210c674(char* c, int i){
+    struct dScMgSlot1_c *self = (struct dScMgSlot1_c *)(void *)c;
   if(i == 4){
-    *(unsigned char*)(c+0x4706) = *(unsigned char*)(c+0x4709);
+    self->unk_4706 = self->unk_4709;
   } else if(i == 3){
     func_ov006_0210c638(c);
   }
   func_ov006_0210c354(c+0x4660);
-  *(int*)(c+0x46b4) = 0;
+  self->unk_46b4 = 0;
 }

--- a/src/func_ov006_0210d1fc.cpp
+++ b/src/func_ov006_0210d1fc.cpp
@@ -1,19 +1,22 @@
 //cpp
+// @symbol func_ov006_0210d1fc
+// @emits dScMgSlot1_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSlot1_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern "C" {
 
-extern int func_02054d88(void);
 extern u32 LoadCompressedFileAt(int fileID, void *target);
 extern char *_ZN2G213GetBG2CharPtrEv(void);
 extern int LoadFile(int handle);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void Deallocate(void *ptr);
 extern char *_ZN2G212GetBG2ScrPtrEv(void);
 extern char *func_02054fb0(void);
-extern void SetSubBg1Offset(int a, int b);
 extern char *func_02054de8(void);
 extern char *_ZN3G2S13GetBG0CharPtrEv(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
@@ -26,22 +29,10 @@ extern int func_ov004_020ad674(void);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *p, u16 a, u16 b, u16 c, u16 d);
-extern void func_ov004_020adb1c(int self);
-extern void func_ov006_0210c478(char *c);
-extern void func_ov004_020b04d0(int v);
 
-extern int data_ov006_0213e628[];
-extern unsigned char data_ov006_0213ea20[];
-extern unsigned char data_ov006_0213e9e0[];
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 extern int data_0208ee44;
-extern int func_020bc88c;
-extern int func_020bc878;
-extern int func_020bc860;
-extern int func_020bc8b8;
-extern int func_020bc890;
-extern int func_020bc8b4;
 
 }
 
@@ -67,7 +58,7 @@ struct Obj {
     virtual void m48(int a);   /* vtable offset 0x48 */
 };
 
-extern "C" int func_ov006_0210d1fc(void *arg0)
+extern "C" int dScMgSlot1_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     volatile unsigned short fill;

--- a/src/func_ov006_0210d7e0.cpp
+++ b/src/func_ov006_0210d7e0.cpp
@@ -1,13 +1,16 @@
 //cpp
-extern "C" int data_ov006_0213eefc;
+// @symbol func_ov006_0210d7e0
+// @emits dScMgSmartball_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" void func_0207328c(void* p, int a, int b, void* fn);
-extern "C" void func_ov006_0210d894(void);
 extern "C" void func_0203d47c(void);
-extern "C" void func_ov004_020b29c0(void* c);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* func_ov006_0210d7e0(void* c) {
+extern "C" void* dScMgSmartball_c_OnYoshiTryEat(void* c) {
     *(int**)c = &data_ov006_0213eefc;
     func_0207328c((char*)c + 0x599c, 0x40, 0x24, (void*)&func_ov006_0210d894);
     func_0207328c((char*)c + 0x48d4, 0x10, 8, (void*)&func_0203d47c);

--- a/src/func_ov006_021147ac.c
+++ b/src/func_ov006_021147ac.c
@@ -1,2 +1,7 @@
-extern int func_ov004_020ae128(void *);
-int func_ov006_021147ac(void *t) { return func_ov004_020ae128(t) != 0; }
+// @symbol func_ov006_021147ac
+// @emits dScMgSmartball_c_OnPushed
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::OnPushed - recovered from vtable slot identity */
+int dScMgSmartball_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_02118488.c
+++ b/src/func_ov006_02118488.c
@@ -1,31 +1,21 @@
+// @symbol func_ov006_02118488
+// @emits dScMgSmartball_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::Behavior - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
 typedef void (*VFunc)(void*);
 
-extern void func_ov006_02115480(char* c);
-extern void func_ov006_02115150(char* c);
-extern void func_ov006_02115a5c(char* c);
-extern int func_ov006_021156f8(char* c);
-extern int func_ov006_02111d74(char* c);
-extern void func_ov004_020ae20c(void);
 extern void func_ov004_020b0aa0(int a);
-extern int func_ov006_02111dcc(char* p, int val);
-extern void func_ov006_02111e48(char* o);
-extern void func_ov006_0211470c(int* a, char* b);
-extern void func_ov006_02115598(char* c, int* src, int v2, int v3, int v5);
-extern void _ZN5Sound12PlayBank2_2DEj(unsigned int s);
-extern void func_ov006_02114f98(char* self);
-extern void func_ov004_020b0a54(int a);
 extern unsigned int func_02012790(unsigned int a);
-extern void func_ov006_02114c04(char* c);
 
 extern unsigned char data_0209d454;
 extern unsigned char data_020a0e40;
 extern unsigned char data_020a0de8[];
 extern unsigned char data_020a0de9[];
-extern int func_020bc888;
-extern int func_020bc864;
 
-int func_ov006_02118488(void* arg)
+int dScMgSmartball_c_Behavior(void* arg)
 {
     char* c = (char*)arg;
     int vec[3];

--- a/src/func_ov006_02118a8c.cpp
+++ b/src/func_ov006_02118a8c.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov006_02118a8c
+// @emits dScMgSmartball_c_OnYoshiTryEat_02118a8c
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::OnYoshiTryEat - recovered from vtable slot identity */
 typedef unsigned short u16;
 extern "C" {
 void func_ov006_02115b0c(void);
 void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void* p, u16 a, u16 b, u16 c, u16 d);
-void func_ov006_02118a8c(void){
+void dScMgSmartball_c_OnYoshiTryEat_02118a8c(void){
   func_ov006_02115b0c();
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4000050, 0, 0x18, 4, 0xa);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4001050, 0, 0x18, 4, 0xa);

--- a/src/func_ov006_02118ae4.c
+++ b/src/func_ov006_02118ae4.c
@@ -1,12 +1,16 @@
-extern void SetSubBg1Offset(int a, int b);
+// @symbol func_ov006_02118ae4
+// @emits dScMgSmartball_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::Kill - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
 extern unsigned int func_02054e88(void);
 extern unsigned int LoadCompressedFileAt(int fileID, void *target);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454[];
-extern int data_ov006_0213eccc[];
 
-void func_ov006_02118ae4(void)
+void dScMgSmartball_c_Kill(void)
 {
     int f;
     *(volatile unsigned short *)0x400100a = (*(volatile unsigned short *)0x400100a & 0x43) | 4;

--- a/src/func_ov006_0211944c.c
+++ b/src/func_ov006_0211944c.c
@@ -1,29 +1,22 @@
+// @symbol func_ov006_0211944c
+// @emits dScMgSmartball_c_AfterCleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSmartball_c::AfterCleanupResources - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
-extern int data_ov006_0213ec98[];
-extern int data_ov006_0213ed10[];
-extern int data_ov006_0213ed88[];
-extern int data_ov006_0213ed4c[];
-extern int data_ov006_0213ecfc[];
-extern int data_ov006_0213ece8[];
-extern int data_ov006_0213ecac[];
-extern int data_ov006_0213ed9c[];
-extern int data_ov006_0213ed38[];
-extern int data_ov006_0213ed74[];
-extern int data_ov006_0213ed60[];
-extern int data_ov006_0213ed24[];
 
-extern void _ZN6Memory16operator_delete2EPv(void *p);
 extern void func_0207328c(void *p, int a, int b, void *cb);
 extern void func_0203d47c(void);
 extern void func_ov004_020b0840(char *c, int arg);
 
-void func_ov006_0211944c(char *c, int mode)
+void dScMgSmartball_c_AfterCleanupResources(char *c, int mode)
 {
     if (mode != 2)
         return;
 
     for (int i = 0; i < 0xd; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -37,7 +30,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x668) = 0;
 
     for (int i = 0; i < 0x19; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -51,7 +44,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x670) = 0;
 
     for (int i = 0; i < 8; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -77,7 +70,7 @@ void func_ov006_0211944c(char *c, int mode)
     }
 
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -90,7 +83,7 @@ void func_ov006_0211944c(char *c, int mode)
     }
 
     for (int i = 0; i < 6; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -104,7 +97,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x678) = 0;
 
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -118,7 +111,7 @@ void func_ov006_0211944c(char *c, int mode)
     *(int *)(c + 0x4000 + 0x67c) = 0;
 
     for (int i = 0; i < 2; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {

--- a/src/func_ov006_02119958.cpp
+++ b/src/func_ov006_02119958.cpp
@@ -1,14 +1,16 @@
 //cpp
+// @symbol func_ov006_02119958
+// @emits dScMgSound_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov006_020c3288(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *data_ov006_0213f844[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_02119958(char *c);
-void *func_ov006_02119958(char *c) {
+void *dScMgSound_c_OnYoshiTryEat(char *c);
+void *dScMgSound_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213f844;
     func_ov006_020c3288(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_0211c5b8.c
+++ b/src/func_ov006_0211c5b8.c
@@ -1,6 +1,10 @@
+// @symbol func_ov006_0211c5b8
+// @emits dScMgSound_c_Virtual50
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::Virtual50 - recovered from vtable slot identity */
 extern void func_ov006_020c2594(void *c);
 
-void func_ov006_0211c5b8(char *c)
+void dScMgSound_c_Virtual50(char *c)
 {
     func_ov006_020c2594(c + 0x4f38);
 }

--- a/src/func_ov006_0211c5d0.c
+++ b/src/func_ov006_0211c5d0.c
@@ -1,12 +1,14 @@
-extern void func_ov004_020adb1c(int arg);
+// @symbol func_ov006_0211c5d0
+// @emits dScMgSound_c_OnYoshiTryEat_0211c5d0
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_0211c478(int self);
 extern void func_ov006_0211c080(int self);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
-extern void _ZN5Sound22LoadAndSetMusic_Layer1Ei(int n);
 
-extern int *g_020beb68;
 
-void func_ov006_0211c5d0(int self, int r1)
+void dScMgSound_c_OnYoshiTryEat_0211c5d0(int self, int r1)
 {
     int *p;
     int *q;

--- a/src/func_ov006_0211c6c4.c
+++ b/src/func_ov006_0211c6c4.c
@@ -1,11 +1,11 @@
+// @symbol func_ov006_0211c6c4
+// @emits dScMgSound_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void* c, int a, int b, int d);
-extern void func_ov006_02119c74(void* c);
-extern void func_ov006_02119bdc(void* c);
-extern void func_ov006_02119bc4(void* c);
-extern void func_ov006_021199c0(void* c);
-extern void func_ov006_02119aa8(void* c);
-extern void func_ov006_020c29dc(void* c);
-int func_ov006_0211c6c4(char* c) {
+int dScMgSound_c_Render(char* c) {
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
     func_ov006_02119c74(c);
     func_ov006_02119bdc(c);

--- a/src/func_ov006_0211c720.c
+++ b/src/func_ov006_0211c720.c
@@ -1,4 +1,10 @@
-/* func_ov006_0211c720 @ 0x0211c720 (ov006, size 0x264)
+// @symbol func_ov006_0211c720
+// @emits dScMgSound_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::Behavior - recovered from vtable slot identity */
+/* dScMgSound_c_Behavior @ 0x0211c720 (ov006, size 0x264)
  * Slot-machine style minigame state machine (state at +0x5608):
  * 0=init, 1=intro countdown (+0x5618), 2=result countdown (+0x5616) with
  * win/lose handling and 9999-capped win counter, 3=retry countdown.
@@ -10,23 +16,9 @@ typedef short s16;
 extern char *data_ov004_020beb68;
 
 extern void func_ov004_020b0aa0(int);
-extern void func_ov006_0211b954(char *);
-extern void func_ov006_0211b80c(char *);
-extern void func_ov006_0211b5e0(char *);
-extern void func_ov006_0211b790(char *);
-extern void func_ov006_0211b9c8(char *);
-extern void func_ov006_02119ba4(char *);
-extern void func_ov006_02119a88(char *);
-extern void func_ov006_02119b00(char *);
-extern void func_ov006_02119a18(char *);
 extern void func_ov006_020c2594(char *);
-extern void func_ov004_020b67f8(void);
-extern void func_ov004_020b0a54(int);
-extern void func_ov004_020adb1c(int);
-extern void func_ov006_020c2440(char *);
-extern void func_ov006_020c2b8c(char *);
 
-int func_ov006_0211c720(char *c)
+int dScMgSound_c_Behavior(char *c)
 {
     switch (*(int *)(c + 0x5608)) {
     case 0:
@@ -34,7 +26,7 @@ int func_ov006_0211c720(char *c)
         break;
     case 1:
         if (*(u16 *)(c + 0x5618) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5618)) & 0xFFFFFFFFFFFFFFFFLL))--;
+            (*(u16 *)(int)(((long long)(int)(c + 0x5618))))--;
             if (*(u16 *)(c + 0x5618) == 0) {
                 func_ov004_020b0aa0(0x1d);
                 if (*(u8 *)(c + 0xc4) == 0) {
@@ -53,7 +45,7 @@ int func_ov006_0211c720(char *c)
         func_ov006_0211b954(c);
         func_ov006_0211b5e0(c);
         if (*(u16 *)(c + 0x5616) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5616)) & 0xFFFFFFFFFFFFFFFFLL))--;
+            (*(u16 *)(int)(((long long)(int)(c + 0x5616))))--;
             if (*(u16 *)(c + 0x5616) == 0) {
                 if (*(u8 *)(c + 0x5626) != 0) {
                     *(int *)(c + 0x50e0) = 0;
@@ -65,7 +57,7 @@ int func_ov006_0211c720(char *c)
                         char *g = data_ov004_020beb68;
                         if (g != 0) {
                             if (*(int *)(g + 0xb4) < 9999)
-                                (*(int *)(int)(((long long)(int)(g + 0xb4)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                                (*(int *)(int)(((long long)(int)(g + 0xb4))))++;
                             if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                                 *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
                         }
@@ -89,7 +81,7 @@ int func_ov006_0211c720(char *c)
         func_ov006_0211b954(c);
         func_ov006_0211b5e0(c);
         if (*(u16 *)(c + 0x5616) != 0) {
-            (*(u16 *)(int)(((long long)(int)(c + 0x5616)) & 0xFFFFFFFFFFFFFFFFLL))--;
+            (*(u16 *)(int)(((long long)(int)(c + 0x5616))))--;
             if (*(s16 *)(c + 0x5616) <= 0) {
                 *(int *)(c + 0x50e0) = 0;
                 func_ov006_020c2440(c + 0x4f38);

--- a/src/func_ov006_0211c984.c
+++ b/src/func_ov006_0211c984.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_0211c984
+// @emits dScMgSound_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSound_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -5,22 +11,18 @@ typedef unsigned char u8;
 extern int LoadFile(int handle);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern unsigned func_02054de8(void);
-extern void Deallocate(void *ptr);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056374(const void *src, u32 offset, u32 count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void DecompressLZ16(int src, void *dst);
 extern void func_ov006_020c225c(void *p);
 extern int func_ov006_020c3050(void *p);
 extern void func_ov006_0211c478(void *p);
 extern void func_ov006_0211c080(void *p);
-extern void func_ov004_020b6808(void);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int func_ov006_0211c984(void *arg0)
+int dScMgSound_c_InitResources(void *arg0)
 {
     u8 *r7 = (u8 *)arg0;
     int r6, r5, r4;

--- a/src/func_ov006_0211cbf4.c
+++ b/src/func_ov006_0211cbf4.c
@@ -1,8 +1,10 @@
-extern int VT[];
-extern void func_ov004_020b29c0(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov006_0211cbf4(int *t)
+// @symbol func_ov006_0211cbf4
+// @emits dScMgTeresa_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *dScMgTeresa_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_02120238.c
+++ b/src/func_ov006_02120238.c
@@ -1,8 +1,12 @@
-/* func_ov006_02120238 at 0x02120238 - thunk: func_ov004_020b0aa0(8) */
+// @symbol func_ov006_02120238
+// @emits dScMgTeresa_c_Virtual50
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::Virtual50 - recovered from vtable slot identity */
+/* dScMgTeresa_c_Virtual50 at 0x02120238 - thunk: func_ov004_020b0aa0(8) */
 
 extern int func_ov004_020b0aa0(int a);
 
-int func_ov006_02120238(void)
+int dScMgTeresa_c_Virtual50(void)
 {
     return func_ov004_020b0aa0(8);
 }

--- a/src/func_ov006_02120248.cpp
+++ b/src/func_ov006_02120248.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_02120248
+// @emits dScMgTeresa_c_OnYoshiTryEat_02120248
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 void func_ov006_0211fbf8(char* p);
 void func_ov006_0211dd6c(char* p);
@@ -13,7 +17,7 @@ void Deallocate(void* ptr);
 }
 struct G2S { static char* GetBG0CharPtr(); };
 
-extern "C" void func_ov006_02120248(char* self, int reset)
+extern "C" void dScMgTeresa_c_OnYoshiTryEat_02120248(char* self, int reset)
 {
     volatile unsigned short val;
     if (reset == 0) {

--- a/src/func_ov006_02120348.c
+++ b/src/func_ov006_02120348.c
@@ -1,13 +1,11 @@
+// @symbol func_ov006_02120348
+// @emits dScMgTeresa_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void*, int, int, int);
-extern void func_ov006_0211ddcc(void*);
-extern void func_ov006_0211e29c(void*);
-extern void func_ov006_0211e460(void*);
-extern void func_ov006_0211e118(void*);
-extern void func_ov006_0211e72c(void*);
-extern void func_ov006_0211d7ec(void*);
-extern void func_ov006_0211d75c(void*);
-extern void func_ov006_0211cca8(void*);
-int func_ov006_02120348(void* c){
+int dScMgTeresa_c_Render(void* c){
   func_ov004_020b1e34(c, 0xe0, 0x14, 1);
   func_ov006_0211ddcc(c);
   func_ov006_0211e29c(c);

--- a/src/func_ov006_021203ac.cpp
+++ b/src/func_ov006_021203ac.cpp
@@ -1,10 +1,17 @@
 //cpp
+// @symbol func_ov006_021203ac
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTeresa_c.h"
+// @emits dScMgTeresa_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern Entry data_ov006_02142eb0[];
 extern "C" int func_ov006_0211e4e0(C* c);
-extern "C" int func_ov006_021203ac(C* c) {
-    (c->*data_ov006_02142eb0[ *(int*)((char*)c + 0x4be8) ].pmf)();
+extern "C" int dScMgTeresa_c_Behavior(C* c) {
+    struct dScMgTeresa_c *self = (struct dScMgTeresa_c *)(void *)c;
+    (c->*data_ov006_02142eb0[ self->unk_4be8 ].pmf)();
     func_ov006_0211e4e0(c);
     return 1;
 }

--- a/src/func_ov006_021203fc.c
+++ b/src/func_ov006_021203fc.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_021203fc
+// @emits dScMgTeresa_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTeresa_c::InitResources - recovered from vtable slot identity */
 
 typedef unsigned int u32;
 typedef unsigned short u16;
@@ -7,28 +13,16 @@ extern void MultiStore16(u16 val, void *dst, int nbytes);
 extern void *LoadFile(int handle);
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(void *src, void *dst);
-extern void Deallocate(void *p);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056314(void *dst, u32 offset, u32 len);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void *_ZN3G2S12GetBG0ScrPtrEv(void);
-extern void func_ov004_020af2f8(char *self, int a, int b, int c);
 extern void *_ZN3G2S13GetBG0CharPtrEv(void);
 extern unsigned func_02054de8(void);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_02056374(const void *src, u32 offset, u32 count);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_ov004_020b04d0(int v);
-extern void func_ov006_0211fbf8(char *p);
-extern void func_ov006_0211d7b4(char *p);
-extern void func_ov006_0211dd6c(char *p);
-extern void func_ov006_0211f77c(char *p);
-extern void func_ov004_020b0cac(int c, int a1, int a2, int a3, int arg5, short arg6);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int func_020bc880;
-extern int func_020bc884;
-int func_ov006_021203fc(char *self)
+int dScMgTeresa_c_InitResources(char *self)
 {
   void *f1;
   void *f2;

--- a/src/func_ov006_02120880.cpp
+++ b/src/func_ov006_02120880.cpp
@@ -1,16 +1,16 @@
 //cpp
-extern "C" int data_ov006_0213fb34;
+// @symbol func_ov006_02120880
+// @emits dScMgTrampoline_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" int _ZTV17MgBounceAndPounce;
 extern "C" int data_020a0eac;
-extern "C" void func_ov006_02120938();
-extern "C" void func_ov006_020d1008();
-extern "C" void func_ov006_020ccfc8();
 extern "C" void func_0207328c(void *p, int a, int b, void (*fn)());
 extern "C" void _ZN8Particle10SysTrackerD1Ev(void *p);
-extern "C" void func_ov004_020b29c0(void *c);
-extern "C" void _ZN6Memory10DeallocateEPvP4Heap(void *p, void *heap);
 
-extern "C" void *func_ov006_02120880(char *thiz)
+extern "C" void *dScMgTrampoline_c_OnYoshiTryEat(char *thiz)
 {
     *(int**)thiz = &data_ov006_0213fb34;
     func_0207328c(thiz + 0x5cd0, 5, 0x24, &func_ov006_02120938);

--- a/src/func_ov006_0212101c.c
+++ b/src/func_ov006_0212101c.c
@@ -1,3 +1,7 @@
+// @symbol func_ov006_0212101c
+// @emits dScMgTrampoline_c_OnAttacked2
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnAttacked2 - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef signed short s16;
@@ -19,7 +23,7 @@ void func_02012718(void* a, int b);
 int func_02054d88(void);
 void MultiStore16(u16 val, void* dst, int nbytes);
 
-int func_ov006_0212101c(char* self)
+int dScMgTrampoline_c_OnAttacked2(char* self)
 {
     volatile u16 z;
     Vec2s v1;

--- a/src/func_ov006_021211bc.c
+++ b/src/func_ov006_021211bc.c
@@ -1,2 +1,7 @@
-extern int func_ov006_020e6e54(void *);
-int func_ov006_021211bc(void *t) { return func_ov006_020e6e54(t) != 0; }
+// @symbol func_ov006_021211bc
+// @emits dScMgTrampoline_c_OnPushed
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnPushed - recovered from vtable slot identity */
+int dScMgTrampoline_c_OnPushed(void *t) { return func_ov006_020e6e54(t) != 0; }

--- a/src/func_ov006_021211e0.cpp
+++ b/src/func_ov006_021211e0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov006_021211e0
+// @emits dScMgTrampoline_c_OnKicked
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnKicked - recovered from vtable slot identity */
 extern "C" {
 int func_ov006_020e6e78(char* self);
 void SetBg2Offset(int a, int b);
@@ -6,7 +10,7 @@ int func_ov004_020b04c0(void);
 }
 extern "C" unsigned char data_0209d45c;
 
-extern "C" int func_ov006_021211e0(char* self)
+extern "C" int dScMgTrampoline_c_OnKicked(char* self)
 {
     if (!func_ov006_020e6e78(self))
         return 0;

--- a/src/func_ov006_021212e0.c
+++ b/src/func_ov006_021212e0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov006_021212e0
+// @emits dScMgTrampoline_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int func_ov006_021212e0(void *t)
+int dScMgTrampoline_c_CleanupResources(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;

--- a/src/func_ov006_021212fc.c
+++ b/src/func_ov006_021212fc.c
@@ -1,22 +1,16 @@
-extern void func_ov006_0212093c(short* obj, int arg1);
-extern void func_ov006_02120c08(void);
+// @symbol func_ov006_021212fc
+// @emits dScMgTrampoline_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::Render - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
 extern void func_ov004_020afcf8(void* a0, void* a1, int a2, void* a3);
 extern int func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
-extern void func_ov004_020b1a5c(int a0, int a1);
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
-extern void func_ov006_020cd270(void);
-extern void func_ov006_020d09e0(void);
 
-extern int data_ov006_0213b0ec;
-extern int* data_ov006_0213fb04[];
-extern int data_ov006_02134ecc;
-extern int data_ov006_02140588;
-extern int data_ov006_0212f0c8[];
-extern void* data_ov006_02134f08;
-extern void* data_ov006_02134f00[];
 
-int func_ov006_021212fc(int self)
+int dScMgTrampoline_c_Render(int self)
 {
     int count;
     int a1v;

--- a/src/func_ov006_021214f8.cpp
+++ b/src/func_ov006_021214f8.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_021214f8
+// @emits dScMgTrampoline_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef void (C::*PMF)();
 struct C {
@@ -6,14 +12,9 @@ struct C {
     PMF pmf;
 };
 extern "C" {
-extern int data_ov006_02140588;
-extern void func_ov006_02120c40(void);
-extern void func_ov006_0212157c(void *c);
-extern void func_ov006_021209ac(short *o);
-extern void func_ov004_020adb1c(int self);
 }
 
-extern "C" int func_ov006_021214f8(char *c)
+extern "C" int dScMgTrampoline_c_Behavior(char *c)
 {
     int saved = data_ov006_02140588;
     func_ov006_02120c40();

--- a/src/func_ov006_02121f70.c
+++ b/src/func_ov006_02121f70.c
@@ -1,7 +1,11 @@
+// @symbol func_ov006_02121f70
+// @emits dScMgTrampoline_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
-extern void func_ov006_020c8a9c(int a0, int a1);
-extern int data_ov006_0213fb18[];
-int func_ov006_02121f70(void)
+int dScMgTrampoline_c_OnTurnIntoEgg(void)
 {
     func_ov006_020c8a9c(0, data_ov006_0213fb18[func_ov004_020ad674()]);
     return 1;

--- a/src/func_ov006_02121fa4.c
+++ b/src/func_ov006_02121fa4.c
@@ -1,61 +1,61 @@
+// @symbol func_ov006_02121fa4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline_c.h"
+// @emits dScMgTrampoline_c_OnYoshiTryEat_02121fa4
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *reg,
     unsigned short a, unsigned short b, int c, unsigned short d);
-extern void func_ov006_020cd424(unsigned int n, int arg1);
 extern void func_ov006_020d0b04(int a);
-extern void func_ov006_02120ca0(void);
 extern int func_ov004_020ad674(void);
-extern void func_ov006_020c8a9c(int a0, int a1);
-extern void func_ov006_02120a44(char *p);
 extern int RandomIntInternal(int *seed);
-extern void func_ov006_02121750(char *c, short v);
-extern int func_02054d88(void);
 extern void MultiStore16(unsigned short val, char *dst, int nbytes);
-extern void func_ov006_02121f04(char *o);
 
 extern volatile short data_020a0dbc[];
-extern int data_ov006_02142f60;
-extern int data_ov006_0213fb18[];
 extern int data_0209e650;
 
-void func_ov006_02121fa4(char *o)
+void dScMgTrampoline_c_OnYoshiTryEat_02121fa4(char *o)
 {
+    struct dScMgTrampoline_c *self = (struct dScMgTrampoline_c *)(void *)o;
     volatile unsigned short fill;
     int q;
 
     _ZN3G2x13SetBlendAlphaEPVttttt((volatile void *)0x4000050, 1, 0x3e, 0x10, 0x10);
 
-    *(short *)(o + 0x5db4) = data_020a0dbc[0];
-    *(short *)(o + 0x5db6) = data_020a0dbc[1];
-    *(short *)(o + 0x5db0) = data_020a0dbc[0];
-    *(short *)(o + 0x5db2) = data_020a0dbc[1];
+    self->unk_5db4 = data_020a0dbc[0];
+    self->unk_5db6 = data_020a0dbc[1];
+    self->unk_5db0 = data_020a0dbc[0];
+    self->unk_5db2 = data_020a0dbc[1];
 
     data_ov006_02142f60 = 0;
-    *(int *)(o + 0xbc) = 0;
-    if ((unsigned int)*(int *)(o + 0xbc) > 0x270e)
-        *(int *)(o + 0xbc) = 0x270e;
-    q = (((*(int *)(o + 0xbc) % 5) << 12)) / 4;
-    *(int *)(o + 0x5d94) =
+    self->unk_0bc = 0;
+    if ((unsigned int)self->unk_0bc > 0x270e)
+        self->unk_0bc = 0x270e;
+    q = (((self->unk_0bc % 5) << 12)) / 4;
+    self->unk_5d94 =
         (int)(((long long)(0x1000 - q) * 0x20 + 0x800) >> 12) +
         (int)(((long long)q * 0x50 + 0x800) >> 12);
-    *(int *)(o + 0x5d98) = *(int *)(o + 0x5d94);
-    *(int *)(o + 0x5d9c) = 0;
-    func_ov006_020cd424(*(int *)(o + 0xbc), *(int *)(o + 0x5d94));
+    self->unk_5d98 = self->unk_5d94;
+    self->unk_5d9c = 0;
+    func_ov006_020cd424(self->unk_0bc, self->unk_5d94);
 
-    func_ov006_020d0b04(*(int *)(o + 0xbc));
+    func_ov006_020d0b04(self->unk_0bc);
     func_ov006_02120ca0();
     func_ov006_020c8a9c(0, data_ov006_0213fb18[func_ov004_020ad674()]);
 
     func_ov006_02120a44(o + 0x5d84);
 
-    *(short *)(o + 0x5db8) = 0;
-    *(short *)(o + 0x5dc2) = 0;
-    *(short *)(o + 0x5dbc) =
+    self->unk_5db8 = 0;
+    self->unk_5dc2 = 0;
+    self->unk_5dbc =
         (((int)(((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13)
             * 0x2d0) >> 12) + 0x2d0;
-    *(short *)(o + 0x5dbe) = 0;
-    *(short *)(o + 0x5dc0) = 1;
-    *(int *)(o + 0x5da4) = 0;
-    *(int *)(o + 0x5da8) = 0;
+    self->unk_5dbe = 0;
+    self->unk_5dc0 = 1;
+    self->unk_5da4 = 0;
+    self->unk_5da8 = 0;
 
     func_ov006_02121750(o, 0);
 

--- a/src/func_ov006_02122198.cpp
+++ b/src/func_ov006_02122198.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov006_02122198
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline_c.h"
+// @emits dScMgTrampoline_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline_c::InitResources - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned char u8;
 typedef unsigned short u16;
@@ -6,18 +14,10 @@ typedef int s32;
 
 extern "C" {
 
-extern void func_ov006_0212231c(void *p);
-extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
-extern void InitialiseVramGlobals(void);
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 extern void func_ov006_020c0134(void *cam);
-extern int func_ov006_020cd658(unsigned char *a, int b);
-extern void func_ov006_02120d8c(void *a, int b);
-extern void func_ov006_020d0b2c(void);
-extern void func_ov004_020b04d0(int v);
 
 extern u8 data_0209d45c;
-extern s16 data_02082414;
 
 }
 
@@ -43,12 +43,13 @@ struct Obj {
     virtual void m48(int a);
 };
 
-extern "C" int func_ov006_02122198(char *base)
+extern "C" int dScMgTrampoline_c_InitResources(char *base)
 {
+    struct dScMgTrampoline_c *self = (struct dScMgTrampoline_c *)(void *)base;
     s32 fov;
 
-    *(s32 *)(base + 0x5d94) = 0x20;
-    *(s32 *)(base + 0x5d98) = *(s32 *)(base + 0x5d94);
+    self->unk_5d94 = 0x20;
+    self->unk_5d98 = self->unk_5d94;
     func_ov006_0212231c(base);
     data_0209d45c = 0x1d;
     _ZN3G3X6SetFogEbiii(0, 0, 2, 0x1000);
@@ -56,21 +57,21 @@ extern "C" int func_ov006_02122198(char *base)
     InitialiseVramGlobals();
     *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
     fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082414);
-    *(s32 *)(base + 0x470c) = 0;
-    *(s32 *)(base + 0x4710) = -0x64000;
-    *(s32 *)(base + 0x4714) = 0;
-    *(s32 *)(base + 0x4718) = 0;
-    *(s32 *)(base + 0x471c) = 0;
-    *(s32 *)(base + 0x4720) = fov;
-    *(u16 *)(base + 0x4724) = 0x400;
+    self->unk_470c = 0;
+    self->unk_4710 = -0x64000;
+    self->unk_4714 = 0;
+    self->unk_4718 = 0;
+    self->unk_471c = 0;
+    self->unk_4720 = fov;
+    self->unk_4724 = 0x400;
     func_ov006_020c0134(base + 0x466c);
-    *(s32 *)(base + 0x47c8) = 0;
-    *(s32 *)(base + 0x47cc) = 0x82000;
-    *(s32 *)(base + 0x47d0) = 0;
-    *(s32 *)(base + 0x47d4) = 0;
-    *(s32 *)(base + 0x47d8) = 0;
-    *(s32 *)(base + 0x47dc) = fov;
-    *(u16 *)(base + 0x47e0) = 0x400;
+    self->unk_47c8 = 0;
+    self->unk_47cc = 0x82000;
+    self->unk_47d0 = 0;
+    self->unk_47d4 = 0;
+    self->unk_47d8 = 0;
+    self->unk_47dc = fov;
+    self->unk_47e0 = 0x400;
     func_ov006_020c0134(base + 0x4728);
     if (func_ov006_020cd658((unsigned char *)(base + 0x500c), 4) == 0)
         return 0;

--- a/src/func_ov006_021226b0.cpp
+++ b/src/func_ov006_021226b0.cpp
@@ -1,19 +1,16 @@
 //cpp
-extern "C" int data_ov006_0213fc7c;
+// @symbol func_ov006_021226b0
+// @emits dScMgTrampoline2_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" int _ZTV17MgBounceAndPounce;
 extern "C" int data_020a0eac;
-extern "C" void func_ov006_02120938();
-extern "C" void func_ov006_02122c68();
-extern "C" void func_ov006_020eed64();
-extern "C" void func_ov006_021227c8();
-extern "C" void func_ov006_020d1008();
-extern "C" void func_ov006_020ca604();
 extern "C" void func_0207328c(void *p, int a, int b, void (*fn)());
 extern "C" void _ZN8Particle10SysTrackerD1Ev(void *p);
-extern "C" void func_ov004_020b29c0(void *c);
-extern "C" void _ZN6Memory10DeallocateEPvP4Heap(void *p, void *heap);
 
-extern "C" void *func_ov006_021226b0(char *thiz)
+extern "C" void *dScMgTrampoline2_c_OnYoshiTryEat(char *thiz)
 {
     *(int**)thiz = &data_ov006_0213fc7c;
     func_0207328c(thiz + 0x7ad0, 5, 0x24, &func_ov006_02120938);

--- a/src/func_ov006_02122814.cpp
+++ b/src/func_ov006_02122814.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol func_ov006_02122814
+/* recovered: shared common types */
+#include "common.h"
 extern "C" void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short angZ);
-struct M48 { int w[12]; };
-extern M48 data_020a0e68;
+
+extern Matrix4x3 data_020a0e68;
 struct C {
     virtual void v0();
     virtual void v1();
@@ -15,6 +18,6 @@ extern "C" void func_ov006_02122814(char *c);
 void func_ov006_02122814(char *c) {
     Matrix4x3_FromTranslation(&data_020a0e68, *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short *)(c + 0x74));
-    *(M48 *)(c + 0x1c) = data_020a0e68;
+    *(Matrix4x3 *)(c + 0x1c) = data_020a0e68;
     ((C *)c)->v5(c + 0x50);
 }

--- a/src/func_ov006_0212287c.c
+++ b/src/func_ov006_0212287c.c
@@ -1,9 +1,12 @@
+// @symbol func_ov006_0212287c
+/* recovered: shared common types */
+#include "common.h"
 extern void _Z15ApproachLinear2Rsss(short* a, short b, short c);
-struct Vec3 { int x,y,z; };
-extern void AddVec3(struct Vec3* a, struct Vec3* b, struct Vec3* c);
+
+extern void AddVec3(struct Vector3* a, struct Vector3* b, struct Vector3* c);
 void func_ov006_0212287c(unsigned char* o){
   _Z15ApproachLinear2Rsss((short*)(o+0x76), 0, 1);
   short* p = (short*)(((int)o + 0x74) & 0xFFFFFFFFFFFFFFFFULL);
   *p = *p + 0x400;
-  AddVec3((struct Vec3*)(o+0x5c), (struct Vec3*)(o+0x68), (struct Vec3*)(o+0x5c));
+  AddVec3((struct Vector3*)(o+0x5c), (struct Vector3*)(o+0x68), (struct Vector3*)(o+0x5c));
 }

--- a/src/func_ov006_02122f24.c
+++ b/src/func_ov006_02122f24.c
@@ -1,3 +1,7 @@
+// @symbol func_ov006_02122f24
+// @emits dScMgTrampoline2_c_OnAttacked2
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnAttacked2 - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
@@ -12,7 +16,7 @@ void func_02012718(void* a, int b);
 int func_02054d88(void);
 void MultiStore16(u16 val, char* dst, int nbytes);
 
-int func_ov006_02122f24(char* self)
+int dScMgTrampoline2_c_OnAttacked2(char* self)
 {
     u16 buf[5];
 

--- a/src/func_ov006_021230c4.c
+++ b/src/func_ov006_021230c4.c
@@ -1,2 +1,7 @@
-extern int func_ov006_020e6e54(void *);
-int func_ov006_021230c4(void *t) { return func_ov006_020e6e54(t) != 0; }
+// @symbol func_ov006_021230c4
+// @emits dScMgTrampoline2_c_OnPushed
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnPushed - recovered from vtable slot identity */
+int dScMgTrampoline2_c_OnPushed(void *t) { return func_ov006_020e6e54(t) != 0; }

--- a/src/func_ov006_021230e8.c
+++ b/src/func_ov006_021230e8.c
@@ -1,8 +1,12 @@
-extern int func_ov006_020e6e78(void *p);
-extern void SetBg2Offset(int a, int b);
+// @symbol func_ov006_021230e8
+// @emits dScMgTrampoline2_c_OnKicked
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnKicked - recovered from vtable slot identity */
 extern unsigned char data_0209d45c[];
 
-int func_ov006_021230e8(void *thiz)
+int dScMgTrampoline2_c_OnKicked(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
     if (!func_ov006_020e6e78(c)) return 0;

--- a/src/func_ov006_0212318c.c
+++ b/src/func_ov006_0212318c.c
@@ -1,12 +1,17 @@
-/* func_ov006_0212318c at 0x0212318c
+// @symbol func_ov006_0212318c
+// @emits dScMgTrampoline2_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::CleanupResources - recovered from vtable slot identity */
+/* dScMgTrampoline2_c_CleanupResources at 0x0212318c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
  */
 
-extern void func_ov006_020ceedc(void);
 extern void func_ov004_020ad90c(void);
 
-int func_ov006_0212318c(void)
+int dScMgTrampoline2_c_CleanupResources(void)
 {
     func_ov006_020ceedc();
     func_ov004_020ad90c();

--- a/src/func_ov006_021231ac.c
+++ b/src/func_ov006_021231ac.c
@@ -1,24 +1,18 @@
+// @symbol func_ov006_021231ac
+// @emits dScMgTrampoline2_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::Render - recovered from vtable slot identity */
 typedef unsigned short u16;
 
 extern void func_0203cd80(int* m, short angle);
-extern void func_ov006_02120c08(void);
-extern void func_ov006_020eef58(void);
-extern int GetOwnerLanguage(void);
 extern int func_ov004_020ad674(void);
 extern void func_ov004_020afcf8(void* a0, void* a1, int a2, void* a3);
 extern void func_ov004_020afa20(int a0, int a1, int a2, int a3, int a4);
-extern void func_ov004_020b1a5c(int a0, int a1);
-extern void func_ov006_020caadc(void);
-extern void func_ov006_020d09e0(void);
-extern void func_ov006_020ced84(void);
-extern void func_ov006_02122a4c(void);
 
-extern int data_ov006_0213b0f0;
-extern int data_ov006_02134ecc;
-extern int* data_ov006_0213fc48[];
-extern int data_ov006_02140830;
 
-int func_ov006_021231ac(char* self)
+int dScMgTrampoline2_c_Render(char* self)
 {
     int m[3];
     int count;

--- a/src/func_ov006_02124298.c
+++ b/src/func_ov006_02124298.c
@@ -1,7 +1,11 @@
+// @symbol func_ov006_02124298
+// @emits dScMgTrampoline2_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov004_020ad674(void);
-extern void func_ov006_020c8a9c(int a0, int a1);
-extern int data_ov006_0213fc20[];
-int func_ov006_02124298(void)
+int dScMgTrampoline2_c_OnTurnIntoEgg(void)
 {
     func_ov006_020c8a9c(0, data_ov006_0213fc20[func_ov004_020ad674()]);
     return 1;

--- a/src/func_ov006_021242cc.cpp
+++ b/src/func_ov006_021242cc.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov006_021242cc
+// @emits dScMgTrampoline2_c_OnYoshiTryEat_021242cc
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::OnYoshiTryEat - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
@@ -25,24 +31,14 @@ typedef struct {
 } T;
 
 extern "C" void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *p, u16 a, u16 b, u16 c, u16 d);
-extern "C" void func_ov006_020cad3c(int a);
-extern "C" void func_ov006_020cac9c(u32 a);
 extern "C" void func_ov006_020d0b04(u32 a);
-extern "C" void func_ov006_020cee5c(u32 a);
-extern "C" void func_ov006_020eeff0(void);
-extern "C" void func_ov006_02122b24(void);
-extern "C" void func_ov006_02120ca0(void);
 extern "C" s32 func_ov004_020ad674(void);
-extern "C" void func_ov006_020c8a9c(int a0, int a1);
-extern "C" int func_02054d88(void);
 extern "C" void MultiStore16(u16 val, char *dst, int nbytes);
 extern "C" void func_ov006_02124228(T *self);
 
 extern volatile s16 data_020a0dbc[];
-extern int data_ov006_021405bc;
-extern int data_ov006_0213fc20[];
 
-extern "C" void func_ov006_021242cc(T *self)
+extern "C" void dScMgTrampoline2_c_OnYoshiTryEat_021242cc(T *self)
 {
     _ZN3G2x13SetBlendAlphaEPVttttt((volatile void *)0x4000050, 1, 0x2e, 0x10, 0x10);
 

--- a/src/func_ov006_021243ec.cpp
+++ b/src/func_ov006_021243ec.cpp
@@ -1,26 +1,22 @@
 //cpp
+// @symbol func_ov006_021243ec
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgTrampoline2_c.h"
+// @emits dScMgTrampoline2_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScMgTrampoline2_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
 typedef int s32;
 
 extern "C" {
-extern void func_ov006_021245a8(void *p);
-extern void _ZN3G3X6SetFogEbiii(int a, int b, int c, int d);
-extern void InitialiseVramGlobals(void);
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 extern void func_ov006_020c0134(void *cam);
-extern int func_ov006_020cae9c(void *p, int n);
-extern void func_ov006_02120d8c(void *a, int b);
-extern void func_ov006_020d0b2c(void);
-extern void func_ov006_020cef14(char *p, int n);
-extern void func_ov006_020ef0d4(int p, int n);
-extern void func_ov006_02122c04(int p, int n);
-extern void func_ov004_020b04d0(int v);
 
 extern u8 data_0209d45c;
-extern s16 data_02082414;
-extern int data_ov006_021421b4;
 }
 
 struct Base {
@@ -45,8 +41,9 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int func_ov006_021243ec(char *base)
+extern "C" int dScMgTrampoline2_c_InitResources(char *base)
 {
+    struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)base;
     s32 fov;
 
     func_ov006_021245a8(base);
@@ -56,21 +53,21 @@ extern "C" int func_ov006_021243ec(char *base)
     InitialiseVramGlobals();
     *(u16 *)0x4000008 = (*(u16 *)0x4000008 & ~3) | 1;
     fov = _ZN4cstd4fdivEii(0xc0000, (s32)data_02082414);
-    *(s32 *)(base + 0x470c) = 0;
-    *(s32 *)(base + 0x4710) = -0x64000;
-    *(s32 *)(base + 0x4714) = 0;
-    *(s32 *)(base + 0x4718) = 0;
-    *(s32 *)(base + 0x471c) = 0;
-    *(s32 *)(base + 0x4720) = fov;
-    *(u16 *)(base + 0x4724) = 0x400;
+    self->unk_470c = 0;
+    self->unk_4710 = -0x64000;
+    self->unk_4714 = 0;
+    self->unk_4718 = 0;
+    self->unk_471c = 0;
+    self->unk_4720 = fov;
+    self->unk_4724 = 0x400;
     func_ov006_020c0134(base + 0x466c);
-    *(s32 *)(base + 0x47c8) = 0;
-    *(s32 *)(base + 0x47cc) = 0x82000;
-    *(s32 *)(base + 0x47d0) = 0;
-    *(s32 *)(base + 0x47d4) = 0;
-    *(s32 *)(base + 0x47d8) = 0;
-    *(s32 *)(base + 0x47dc) = fov;
-    *(u16 *)(base + 0x47e0) = 0x400;
+    self->unk_47c8 = 0;
+    self->unk_47cc = 0x82000;
+    self->unk_47d0 = 0;
+    self->unk_47d4 = 0;
+    self->unk_47d8 = 0;
+    self->unk_47dc = fov;
+    self->unk_47e0 = 0x400;
     func_ov006_020c0134(base + 0x4728);
     if (func_ov006_020cae9c(base + 0x500c, 5) == 0)
         return 0;

--- a/src/func_ov006_0212497c.cpp
+++ b/src/func_ov006_0212497c.cpp
@@ -1,16 +1,18 @@
 //cpp
+// @symbol func_ov006_0212497c
+// @emits dScMgBSC_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern int func_ov006_020c1c64(char *t);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
 extern void func_0203d47c();
-extern void *data_ov006_0213fec8[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_0212497c(char *c);
-void *func_ov006_0212497c(char *c) {
+void *dScMgBSC_c_OnYoshiTryEat(char *c);
+void *dScMgBSC_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0213fec8;
     func_0207328c(c + 0x51a8, 2, 8, (void*)&func_0203d47c);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_02125248.c
+++ b/src/func_ov006_02125248.c
@@ -1,7 +1,15 @@
-extern int func_ov004_020b6324(int);
+// @symbol func_ov006_02125248
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBSC_c.h"
+// @emits dScMgBSC_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::OnGroundPounded - recovered from vtable slot identity */
 
-int func_ov006_02125248(void *this) {
-    int x = *(int *)((char *)this + 0xb4);
+int dScMgBSC_c_OnGroundPounded(void *this) {
+    struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)this;
+    int x = self->unk_0b4;
     int v = x / 5;
     if ((unsigned int)v > 3) {
         v = 3;

--- a/src/func_ov006_0212527c.cpp
+++ b/src/func_ov006_0212527c.cpp
@@ -1,28 +1,36 @@
 //cpp
+// @symbol func_ov006_0212527c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBSC_c.h"
+// @emits dScMgBSC_c_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" int func_ov006_020c1718(int* r0);
 extern "C" void func_ov004_020b0aa0(int arg);
-extern "C" void func_ov004_020ad79c(int r0arg, int r1arg);
 
 extern short data_ov004_020bf9e4;
 
-extern "C" int func_ov006_0212527c(char* c, int mode)
+extern "C" int dScMgBSC_c_OnTurnIntoEgg(char* c, int mode)
 {
+    struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)c;
     int st;
     short fl;
-    if (*(int*)(c + 0x51b8) == 0xd) {
+    if (self->unk_51b8 == 0xd) {
         if (func_ov006_020c1718((int*)(c + 0x4f38)) != 0) {
             if (mode == 4) {
                 func_ov004_020b0aa0(0x1d);
-                *(int*)(c + 0x51b8) = 9;
+                self->unk_51b8 = 9;
             } else if (mode == 5) {
                 func_ov004_020b0aa0(0x1d);
-                *(int*)(c + 0x51b8) = 0xa;
+                self->unk_51b8 = 0xa;
             }
         } else {
             return 0;
         }
     }
-    st = *(int*)(c + 0x51b8);
+    st = self->unk_51b8;
     if (st >= 0xc) {
         fl = data_ov004_020bf9e4;
         if (fl == 1) goto do1;
@@ -30,7 +38,7 @@ extern "C" int func_ov006_0212527c(char* c, int mode)
     return 0;
 do1:
     if (st == 0xc && fl == 1) {
-        func_ov004_020ad79c(*(int*)(c + 0xa8), *(int*)(c + 0xb4));
+        func_ov004_020ad79c(self->unk_0a8, self->unk_0b4);
     }
     return 1;
 }

--- a/src/func_ov006_02125364.c
+++ b/src/func_ov006_02125364.c
@@ -1,11 +1,17 @@
-extern int func_ov004_020ad878(void);
-extern void func_ov004_020adb1c(int self);
+// @symbol func_ov006_02125364
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgBSC_c.h"
+// @emits dScMgBSC_c_OnYoshiTryEat_02125364
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void);
-extern int func_020bc7d4;
-void func_ov006_02125364(char* c, int mode){
+void dScMgBSC_c_OnYoshiTryEat_02125364(char* c, int mode){
+    struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)c;
   if(mode != 4 && mode != 5 && mode == 3){
-    *(int*)(c+0xb4) = func_ov004_020ad878();
-    func_ov004_020adb1c(*(int*)(c+0xb4));
+    self->unk_0b4 = func_ov004_020ad878();
+    func_ov004_020adb1c(self->unk_0b4);
   }
   func_ov004_020b66d4();
   func_020bc7d4 = 1;

--- a/src/func_ov006_021253bc.c
+++ b/src/func_ov006_021253bc.c
@@ -1,11 +1,15 @@
+// @symbol func_ov006_021253bc
+// @emits dScMgBSC_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::Render - recovered from vtable slot identity */
 extern void func_ov006_020c0aa8(void *a0);
 extern void func_ov004_020af68c(void *a0, int a1, int a2, int a3, int a4);
-extern void func_ov004_020b6430(void);
 extern void func_ov004_020b1bc8(void *a0, int a1, int a2, int a3);
 extern void func_ov004_020b1e34(void *a0, int a1, int a2, int a3);
 extern void func_ov006_020c1804(void *a0);
 
-extern void *data_ov006_0213fe8c[];
 
 typedef struct { int x, y; } Pair;
 typedef struct Obj {
@@ -21,7 +25,7 @@ typedef struct Obj {
     unsigned char b1[2];
 } Obj;
 
-int func_ov006_021253bc(Obj *self) {
+int dScMgBSC_c_Render(Obj *self) {
     int i;
 
     func_ov006_020c0aa8(&self->f4660);

--- a/src/func_ov006_021254c0.cpp
+++ b/src/func_ov006_021254c0.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov006_021254c0
+// @emits dScMgBSC_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern "C" Entry data_ov006_02142f94[];
 struct C { char pad[0x51b8]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int func_ov006_021254c0(C* c) {
+extern "C" int dScMgBSC_c_Behavior(C* c) {
     (c->*(data_ov006_02142f94[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_0212551c.cpp
+++ b/src/func_ov006_0212551c.cpp
@@ -1,21 +1,22 @@
 //cpp
+// @symbol func_ov006_0212551c
+// @emits dScMgBSC_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgBSC_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef int s32;
 extern "C" {
 extern unsigned char data_0209d45c[];
-extern int data_ov006_0213fe78[];
 extern int data_0208ee44[];
 extern void func_ov006_0210a534(void);
 extern s32 func_ov004_020ad674(void);
 extern u32 LoadCompressedFileAt(int fileID, void *target);
 extern int LoadFile(int handle);
-extern void Deallocate(void *ptr);
 extern void func_ov006_020c0aa8(void *p);
 extern int func_ov006_020c1a88(void *p);
-extern void func_ov004_020b04d0(int v);
-extern void func_ov004_020b682c(void);
-extern int func_ov004_020ad8b8(void);
-int func_ov006_0212551c(void *self);
+int dScMgBSC_c_InitResources(void *self);
 }
 extern "C" void _ZN3GXS11LoadOBJPlttEPKvjj(void const *a, unsigned int b, unsigned int c);
 struct Obj {
@@ -26,7 +27,7 @@ struct Obj {
     virtual void v16();virtual void v17();virtual void v18(int x);
     char pad[0x10000];
 };
-int func_ov006_0212551c(void *self) {
+int dScMgBSC_c_InitResources(void *self) {
     Obj *o = (Obj *)self;
     char *c = (char *)self;
     int fh;

--- a/src/func_ov006_0212573c.cpp
+++ b/src/func_ov006_0212573c.cpp
@@ -1,17 +1,19 @@
 //cpp
+// @symbol func_ov006_0212573c
+// @emits dScMgSnowball_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern int func_0207328c(void*, int, int, void*);
-extern void _ZN5ModelD1Ev(void *);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_02125800();
 extern void func_0203d47c();
-extern void *data_ov006_0214000c[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_0212573c(char *c);
-void *func_ov006_0212573c(char *c) {
+void *dScMgSnowball_c_OnYoshiTryEat(char *c);
+void *dScMgSnowball_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_0214000c;
     func_0207328c(c + 0xba14, 0x20, 0x24, (void*)&func_ov006_02125800);
     func_0207328c(c + 0xb5d8, 0x80, 8, (void*)&func_0203d47c);

--- a/src/func_ov006_02126948.c
+++ b/src/func_ov006_02126948.c
@@ -1,13 +1,17 @@
+// @symbol func_ov006_02126948
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct V3 { int x, y; volatile int z; };
-struct M48 { int w[12]; };
+
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void func_ov006_020c0134(void *self);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, short ang);
-extern struct M48 data_020a0e68;
-extern short data_02082314;
+extern struct Matrix4x3 data_020a0e68;
 
 #pragma opt_lifetimes off
 void func_ov006_02126948(char *c) {
@@ -40,5 +44,5 @@ void func_ov006_02126948(char *c) {
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short *)(c + 0xab7c));
     Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short *)(c + 0xab78));
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short *)(c + 0xab7a));
-    *(struct M48 *)(c + 0xabc0) = data_020a0e68;
+    *(struct Matrix4x3 *)(c + 0xabc0) = data_020a0e68;
 }

--- a/src/func_ov006_02127d10.c
+++ b/src/func_ov006_02127d10.c
@@ -1,3 +1,11 @@
+// @symbol func_ov006_02127d10
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgSnowball_c.h"
+// @emits dScMgSnowball_c_Render
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::Render - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 typedef unsigned char u8;
@@ -7,35 +15,24 @@ typedef int s32;
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
 extern void func_0203cd80(int *m, short angle);
 extern void func_ov006_02126a98(char *c);
-extern int func_ov004_020b04c0(void);
 extern void func_ov004_020b2220(int a1, int a2, int a3, int a4, int a5, int a6, int a7);
-extern void func_ov004_020b2444(int a1, int a2, int num, int a4, int a5, int sel, int idx);
 extern s32 func_ov004_020ad674(void);
-extern void func_ov004_020b0380(void* a0, int a1, int a2, void* a3);
-extern void func_ov006_02129690(void *a);
-extern void func_ov006_02125804(char *c);
 
-extern void* data_ov006_02139d24[2];
-extern void* data_ov006_02138d64[];
-extern void* data_ov006_02139c24;
-extern void* data_ov006_02139c80[];
-extern void* data_ov006_02139d18;
-extern void* data_ov006_02139c38;
-extern void* data_ov006_0213fff0[];
 
-int func_ov006_02127d10(char *c)
+int dScMgSnowball_c_Render(char *c)
 {
+    struct dScMgSnowball_c *self = (struct dScMgSnowball_c *)(void *)c;
     int m[3];
     int vecArr[3];
 
-    *(int*)(((long long)(int)(c + 0xb9d8)) & 0xFFFFFFFFFFFFFFFFLL) = *(int*)(((long long)(int)(c + 0xb9d8)) & 0xFFFFFFFFFFFFFFFFLL) + 1;
-    if (*(int*)(c + 0xb9d8) >= 0x20) {
-        *(int*)(c + 0xb9d8) = 0;
+    *(int*)(((long long)(int)(c + 0xb9d8))) = *(int*)(((long long)(int)(c + 0xb9d8))) + 1;
+    if (self->unk_b9d8 >= 0x20) {
+        self->unk_b9d8 = 0;
     }
 
     {
-        int base = *(int*)(c + 0xba04);
-        int t = (((*(int*)(c + 0xab3c) >> 0xc) - base) * 0x7c) / (*(int*)(c + 0xba00) - base);
+        int base = self->unk_ba04;
+        int t = (((self->unk_ab3c >> 0xc) - base) * 0x7c) / (self->unk_ba00 - base);
         func_ov004_020afdd0(data_ov006_02139d24[0], 0xf0, t + 0x22, -1, 0);
     }
     func_ov004_020afdd0(data_ov006_02139d24[1], 0xf0, 0x60, -1, 0);
@@ -51,13 +48,13 @@ int func_ov006_02127d10(char *c)
     *(int*)0x040004cc = 0x7fff;
 
     {
-        int v = *(int*)(c + 0xaba0);
+        int v = self->unk_aba0;
         int t = v / 2 + v * 4;
         vecArr[0] = t;
         vecArr[1] = t;
         vecArr[2] = t;
-        if (*(int*)(c + 0xaba0) > 0) {
-            void *self = (void*)(((long long)(int)(c + 0xaba4)) & 0xFFFFFFFFFFFFFFFFLL);
+        if (self->unk_aba0 > 0) {
+            void *self = (void*)(((long long)(int)(c + 0xaba4)));
             void (*fn)(void*, int*) = *(void(**)(void*, int*))((char*)(*(void**)self) + 0x14);
             fn(self, vecArr);
         }
@@ -68,18 +65,18 @@ int func_ov006_02127d10(char *c)
     for (int i1 = 0; i1 < 0x80; i1++) {
         char *p = c + i1;
         if (*(u8*)(p + 0xac58) == 1) {
-            int t6 = *(int*)(c + 0xab6c);
-            int t5 = *(int*)(((long long)(int)(c + i1 * 8 + 0xacdc)) & 0xFFFFFFFFFFFFFFFFLL);
+            int t6 = self->unk_ab6c;
+            int t5 = *(int*)(((long long)(int)(c + i1 * 8 + 0xacdc)));
             if (t5 >= t6 - 0x20000 && t5 < t6 + 0x1a0000 + (func_ov004_020b04c0() << 0xc)) {
                 if (*(int*)(c + i1 * 4 + 0xb0d8) == 1) {
-                    int cnt = *(int*)(c + 0xb9d8);
+                    int cnt = self->unk_b9d8;
                     int idx = (cnt / 4) & 7;
                     if (*(u8*)(p + 0xb2d8) == 1) idx += 8;
-                    int a1 = (*(int*)(c + i1 * 8 + 0xacd8) - *(int*)(c + 0xab68)) >> 0xc;
+                    int a1 = (*(int*)(c + i1 * 8 + 0xacd8) - self->unk_ab68) >> 0xc;
                     int a2 = ((t5 - t6) >> 0xc) - 0x110;
                     func_ov004_020afdd0(data_ov006_02138d64[idx], a1, a2, -1, -1);
                 } else {
-                    int a1 = (*(int*)(c + i1 * 8 + 0xacd8) - *(int*)(c + 0xab68)) >> 0xc;
+                    int a1 = (*(int*)(c + i1 * 8 + 0xacd8) - self->unk_ab68) >> 0xc;
                     int a2 = ((t5 - t6) >> 0xc) - 0x110;
                     func_ov004_020afdd0(data_ov006_02139c24, a1, a2, -1, 2);
                 }
@@ -89,14 +86,14 @@ int func_ov006_02127d10(char *c)
 
     for (int i2 = 0; i2 < 0x80; i2++) {
         if (*(u8*)(c + i2 + 0xb358) == 1) {
-            int t7 = *(int*)(c + 0xab6c);
-            int t6 = *(int*)(((long long)(int)(c + i2 * 8 + 0xb5dc)) & 0xFFFFFFFFFFFFFFFFLL);
+            int t7 = self->unk_ab6c;
+            int t6 = *(int*)(((long long)(int)(c + i2 * 8 + 0xb5dc)));
             if (t6 >= t7 - 0x40000 && t6 < t7 + 0x1c0000 + (func_ov004_020b04c0() << 0xc)) {
                 switch (*(int*)(c + i2 * 4 + 0xb3d8)) {
                 case 0:
                 case 1:
                 case 2: {
-                    int a1 = (*(int*)(c + i2 * 8 + 0xb5d8) - *(int*)(c + 0xab68)) >> 0xc;
+                    int a1 = (*(int*)(c + i2 * 8 + 0xb5d8) - self->unk_ab68) >> 0xc;
                     int a2 = ((t6 - t7) >> 0xc) - 0x110;
                     func_ov004_020afdd0(data_ov006_02139d18, a1, a2, -1, 1);
                     break;
@@ -104,7 +101,7 @@ int func_ov006_02127d10(char *c)
                 case 3: {
                     int v = *(int*)(c + i2 * 8 + 0xb5d8);
                     int sel = (v < 0x80000) ? 1 : 0;
-                    int a1 = (v - *(int*)(c + 0xab68)) >> 0xc;
+                    int a1 = (v - self->unk_ab68) >> 0xc;
                     int a2 = ((t6 - t7) >> 0xc) - 0x110;
                     func_ov004_020afdd0(data_ov006_02139c80[sel], a1, a2, -1, 1);
                     break;
@@ -115,23 +112,23 @@ int func_ov006_02127d10(char *c)
     }
 
     {
-        int a1 = (*(int*)(c + 0xab48) - *(int*)(c + 0xab68)) >> 0xc;
-        int a2 = ((*(int*)(c + 0xab4c) - *(int*)(c + 0xab6c)) >> 0xc) - 0x110;
+        int a1 = (self->unk_ab48 - self->unk_ab68) >> 0xc;
+        int a2 = ((self->unk_ab4c - self->unk_ab6c) >> 0xc) - 0x110;
         func_ov004_020afdd0(data_ov006_02139c38, a1, a2, -1, 2);
     }
 
     {
-        int t4 = *(int*)(c + 0xb9fc);
+        int t4 = self->unk_b9fc;
         if (t4 <= 0xf0 && t4 > 0x3c) {
             int q = t4 / 60;
             if (q >= 4) q = 3;
             func_ov004_020b2220(0x80, 0x60, q, -1, -1, 0x800, 0);
         } else {
-            int mode = *(int*)(c + 0xb9f4);
+            int mode = self->unk_b9f4;
             if (mode == 1 || mode == 2
-                || (mode == 3 && *(int*)(c + 0xba10) > 0)
-                || (mode == 4 && *(int*)(c + 0xba0c) <= 0x3c)) {
-                int v = *(int*)(c + 0xb9dc);
+                || (mode == 3 && self->unk_ba10 > 0)
+                || (mode == 4 && self->unk_ba0c <= 0x3c)) {
+                int v = self->unk_b9dc;
                 int q60 = v / 60;
                 int rem60 = v % 60;
                 int r7 = rem60 * 100;

--- a/src/func_ov006_021283a4.c
+++ b/src/func_ov006_021283a4.c
@@ -1,25 +1,17 @@
-extern void func_ov004_020b0cac(int a0, int a1, int a2, int a3, int a4, short a5);
+// @symbol func_ov006_021283a4
+// @emits dScMgSnowball_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::Behavior - recovered from vtable slot identity */
 extern void func_02012790(int a);
 extern void func_ov004_020b0aa0(int arg);
 extern int func_0203d614(int *p);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
-extern void func_0203d388(int *p, int angle);
-extern int func_0203d434(int *in);
-extern void func_0203d630(int *p, int m);
-extern void func_ov006_02125f68(char *c);
 extern void func_0203d6d0(int *o, int *a, int *b);
-extern void func_02012718(int a, int b);
 extern void _Z14ApproachLinearRsss(short *a, short b, short cc);
-extern void func_ov004_020adb1c(int self);
-extern void _ZN5Sound12PlayBank2_2DEj(unsigned int a);
-extern void func_ov004_020b67e8(int v);
-extern void func_ov004_020b0a54(int c);
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int cc, int d, int e, const void *f, void *g);
 extern int *_ZN8Particle6System12FromUniqueIDEj(unsigned int a);
-extern void func_ov006_0212a2e0(char *c);
-extern void func_ov006_02125890(char *c);
-extern void func_ov006_02126948(char *c);
-extern int __aeabi_idiv(int a, int b);
 
 extern unsigned char data_020a0e40[];
 extern unsigned char data_020a0de8[];
@@ -27,10 +19,10 @@ extern unsigned char data_020a0de9[];
 extern unsigned char data_020a0dea[];
 extern unsigned char data_020a0deb[];
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
-#define LNDR(e) ((int)(((long long)(e))&0xFFFFFFFFFFFFFFFFLL))
-#define C1 ((char*)(void*)(int)(((long long)(int)(c))&0xFFFFFFFFFFFFFFFFLL))
-#define C2 ((char*)(void*)(int)(((long long)(int)(C1))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define LNDR(e) ((int)(((long long)(e))))
+#define C1 ((char*)(void*)(int)(((long long)(int)(c))))
+#define C2 ((char*)(void*)(int)(((long long)(int)(C1))))
 #define ATS(off) AT(C1,off)
 #define ATI(off) AT(C2,off)
 #define I(o) (*(int*)(c + (o)))
@@ -49,7 +41,7 @@ struct SPS {
     int cc[3];
 };
 
-int func_ov006_021283a4(char *c) {
+int dScMgSnowball_c_Behavior(char *c) {
     int r5, r4;
     int idx, r3rec, r7, j;
     struct SPS s;
@@ -157,7 +149,7 @@ int func_ov006_021283a4(char *c) {
             I(0xaba0) = 0x37000;
         func_0203d6d0(s.b, (int*)AT(C1,0xab38), (int*)AT(c,0xab50));
         gate = (func_0203d614(s.b) >= 0x30000) ? 1 : 0;
-        if ((int)(((long long)gate) & 0xFFFFFFFFFFFFFFFFLL) != 0) {
+        if ((int)(((long long)gate)) != 0) {
             I(0xab50) = I(0xab38);
             I(0xab54) = I(0xab3c);
             if (I(0xaba0) < 0x10000)

--- a/src/func_ov006_02128fb8.c
+++ b/src/func_ov006_02128fb8.c
@@ -1,17 +1,22 @@
+// @symbol func_ov006_02128fb8
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgSnowball_c.h"
+// @emits dScMgSnowball_c_OnKicked
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::OnKicked - recovered from vtable slot identity */
 typedef unsigned char u8;
 
-extern void SetBg2Offset(int a, int b);
-extern void SetBg3Offset(int a, int b);
-extern void SetSubBg2Offset(int a, int b);
-extern void SetSubBg3Offset(int a, int b);
 extern int func_ov004_020ae140(char *self);
 
-#define V (*(int *)(c + 0xab6c) >> 12)
+#define V (self->unk_ab6c >> 12)
 
-int func_ov006_02128fb8(char *c)
+int dScMgSnowball_c_OnKicked(char *c)
 {
-    if (*(int *)(c + 0x4628) == 0) {
-        if (*(u8 *)(c + 0xb9f8) == 0) {
+    struct dScMgSnowball_c *self = (struct dScMgSnowball_c *)(void *)c;
+    if (self->unk_4628 == 0) {
+        if (self->unk_b9f8 == 0) {
             *(volatile unsigned short *)0x4000304 |= 0x8000;
             SetBg2Offset(0, V);
             SetBg3Offset(0, V);

--- a/src/func_ov006_021291b0.c
+++ b/src/func_ov006_021291b0.c
@@ -1,2 +1,7 @@
-extern int func_ov004_020ae128(void *);
-int func_ov006_021291b0(void *t) { return func_ov004_020ae128(t) != 0; }
+// @symbol func_ov006_021291b0
+// @emits dScMgSnowball_c_OnPushed
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::OnPushed - recovered from vtable slot identity */
+int dScMgSnowball_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_021291d4.c
+++ b/src/func_ov006_021291d4.c
@@ -1,2 +1,7 @@
-extern int func_ov004_020ae1a0(void *);
-int func_ov006_021291d4(void *t) { return func_ov004_020ae1a0(t) != 0; }
+// @symbol func_ov006_021291d4
+// @emits dScMgSnowball_c_OnAttacked2
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::OnAttacked2 - recovered from vtable slot identity */
+int dScMgSnowball_c_OnAttacked2(void *t) { return func_ov004_020ae1a0(t) != 0; }

--- a/src/func_ov006_021291f8.c
+++ b/src/func_ov006_021291f8.c
@@ -1,5 +1,9 @@
+// @symbol func_ov006_021291f8
+// @emits dScMgSnowball_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020adc5c(void *p);
-int func_ov006_021291f8(void *c) {
+int dScMgSnowball_c_CleanupResources(void *c) {
     func_ov004_020adc5c(*(void **)((char *)c + 0xabf4));
     return 1;
 }

--- a/src/func_ov006_0212921c.c
+++ b/src/func_ov006_0212921c.c
@@ -1,8 +1,11 @@
-extern void func_ov004_020adb1c(int self);
-extern void func_ov006_021279b0(void* a);
-extern void func_ov006_02126ee4(void* a);
+// @symbol func_ov006_0212921c
+// @emits dScMgSnowball_c_OnYoshiTryEat_0212921c
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_02126a98(void* a);
-void func_ov006_0212921c(void* c, int i){
+void dScMgSnowball_c_OnYoshiTryEat_0212921c(void* c, int i){
   func_ov004_020adb1c(0);
   func_ov006_021279b0(c);
   if(i != 0x13) return;

--- a/src/func_ov006_02129268.c
+++ b/src/func_ov006_02129268.c
@@ -1,3 +1,9 @@
+// @symbol func_ov006_02129268
+// @emits dScMgSnowball_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgSnowball_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -18,23 +24,15 @@ extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void DecompressLZ16(void *src, void *dst);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void _ZN3G3X6SetFogEbiii(int enable, int a, int b, int c);
-extern void InitialiseVramGlobals(void);
 extern void _ZN5Model17UpdateFileOffsetsER8BMD_File(void *file);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisPtr, void *file, int a, int b);
-extern void func_ov006_021279b0(void *p);
-extern void func_ov006_02126ee4(void *p);
 extern void func_ov006_02126a98(void *p);
 
 extern int data_0208ee44;
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern char data_ov006_0214009c;
-extern char data_ov006_021400bc;
-extern char data_ov006_021400dc;
-extern char data_ov006_021400fc;
 
-int func_ov006_02129268(void *arg0)
+int dScMgSnowball_c_InitResources(void *arg0)
 {
     u8 *r4 = (u8 *)arg0;
     void *buf;

--- a/src/func_ov006_0212a5c8.cpp
+++ b/src/func_ov006_0212a5c8.cpp
@@ -1,16 +1,17 @@
 //cpp
+// @symbol func_ov006_0212a5c8
+// @emits dScMgFlower_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern void func_ov006_020c3e70(char *t);
 extern int func_0207328c(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
-extern void func_ov004_020b29c0(void *c);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void func_ov006_0212a650();
-extern void *data_ov006_02140140[];
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *func_ov006_0212a5c8(char *c);
-void *func_ov006_0212a5c8(char *c) {
+void *dScMgFlower_c_OnYoshiTryEat(char *c);
+void *dScMgFlower_c_OnYoshiTryEat(char *c) {
     *(void ***)c = data_ov006_02140140;
     func_ov006_020c3e70(c + 0x51f8);
     func_0207328c(c + 0x4f38, 0x16, 0x20, (void*)&func_ov006_0212a650);

--- a/src/func_ov006_0212aa74.c
+++ b/src/func_ov006_0212aa74.c
@@ -1,4 +1,10 @@
-/* func_ov006_0212aa74 at 0x0212aa74
+// @symbol func_ov006_0212aa74
+// @emits dScMgFlower_c_OnYoshiTryEat_0212aa74
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::OnYoshiTryEat - recovered from vtable slot identity */
+/* dScMgFlower_c_OnYoshiTryEat_0212aa74 at 0x0212aa74
  *
  * Wraps a counter at this+0x5fe4 (increments while <= 0x14, else resets
  * to 0), then updates the sub-object at this+0x51f8 (func_ov006_020c3bc8)
@@ -10,13 +16,11 @@
  * counter address is rematerialized from the literal pool in its own
  * block instead of folding into the this+0x5000 base and if-converting.
  */
-extern void func_ov006_020c3bc8(void *sub);
-extern void func_ov006_0212a764(void *self);
 
-void func_ov006_0212aa74(char *self)
+void dScMgFlower_c_OnYoshiTryEat_0212aa74(char *self)
 {
     if (*(int *)(self + 0x5fe4) <= 0x14) {
-        (*(volatile int *)(((long long)(int)(self + 0x5fe4)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(volatile int *)(((long long)(int)(self + 0x5fe4))))++;
     } else {
         *(int *)(self + 0x5fe4) = 0;
     }

--- a/src/func_ov006_0212aacc.c
+++ b/src/func_ov006_0212aacc.c
@@ -1,28 +1,28 @@
+// @symbol func_ov006_0212aacc
+// @emits dScMgFlower_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::Render - recovered from vtable slot identity */
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef short s16;
 
 extern s16 data_02082214[];
-extern void SetSubBg2Offset(int a, int b);
-extern void SetSubBg3Offset(int a, int b);
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
 extern void func_ov004_020af770(void* a0, int a1, int a2, int a3, int a4, int a5, u16 a6);
-extern void func_ov006_020c3b2c(void* p);
-extern void func_ov006_020c3bf4(void* self);
 
-extern int* data_ov006_0213ab94[];
-extern int* data_ov006_0213abe0;
 
 struct S2 { int a, b; };
 
-int func_ov006_0212aacc(char* self)
+int dScMgFlower_c_Render(char* self)
 {
     int i;
     u8 (*barr)[0x20] = (u8 (*)[0x20])self;
     int (*iarr)[8] = (int (*)[8])self;
     u16 (*harr)[0x10] = (u16 (*)[0x10])self;
 
-    *(u16*)(((long long)(int)(self + 0x5ff4)) & 0xFFFFFFFFFFFFFFFFLL) += 0xc0;
+    *(u16*)(((long long)(int)(self + 0x5ff4))) += 0xc0;
     {
         int v = data_02082214[(*(u16*)(self + 0x5ff4) >> 4) << 1];
         int t = v + 0x80;

--- a/src/func_ov006_0212ac74.c
+++ b/src/func_ov006_0212ac74.c
@@ -1,3 +1,11 @@
+// @symbol func_ov006_0212ac74
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScMgFlower_c.h"
+// @emits dScMgFlower_c_Behavior
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
@@ -15,16 +23,7 @@ typedef struct Cell {
 
 extern void func_0203d6d0(V2 *out, V2 *a, V2 *b);
 extern int func_0203d614(V2 *p);
-extern void func_02012754(int id);
 extern void func_ov004_020b0aa0(int a);
-extern void func_ov004_020b0a54(int a);
-extern void func_ov004_020b0cac(int a, int a1, int a2, int a3, int arg5, short arg6);
-extern void func_ov006_020c3990(char *p);
-extern int func_ov006_020c3b80(char *p);
-extern void func_ov006_020c3908(char *p);
-extern void func_ov006_020c38b0(char *p);
-extern void func_ov006_020c3d18(char *p);
-extern void func_ov006_0212a654(char *p);
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];
@@ -37,8 +36,9 @@ extern u8 data_020a0deb[];
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 
-int func_ov006_0212ac74(char *c)
+int dScMgFlower_c_Behavior(char *c)
 {
+    struct dScMgFlower_c *self = (struct dScMgFlower_c *)(void *)c;
     int i;
     int k;
     int t;
@@ -46,44 +46,44 @@ int func_ov006_0212ac74(char *c)
     V2 d2;
     V2 d3;
 
-    if (*(u8 *)(c + 0xc4) == 0) {
-        *(u8 *)(c + 0xc3) = 1;
-        *(u8 *)(c + 0xc4) = 1;
-        *(u16 *)(c + 0xc0) = 0;
+    if (self->unk_0c4 == 0) {
+        self->unk_0c3 = 1;
+        self->unk_0c4 = 1;
+        self->unk_0c0 = 0;
     }
-    if (*(int *)(c + 0x5fd0) > 0) {
-        if (*(int *)(c + 0x5fc8) == -1) {
+    if (self->unk_5fd0 > 0) {
+        if (self->unk_5fc8 == -1) {
             *(int *)LA(c + 0x5fd0) -= 1;
-            if (*(int *)(c + 0x5fd0) <= 0) {
-                if (*(int *)(c + 0x5fd8) >= 1)
-                    *(int *)(c + 0x5fec) = 2;
+            if (self->unk_5fd0 <= 0) {
+                if (self->unk_5fd8 >= 1)
+                    self->unk_5fec = 2;
             }
         } else {
-            *(int *)(c + 0x5fd0) = 0x3c;
+            self->unk_5fd0 = 0x3c;
         }
     }
-    switch (*(int *)(c + 0x5fe8)) {
+    switch (self->unk_5fe8) {
     case 0:
-        *(int *)(c + 0x5fc0) = *(int *)(c + 0x5fb8);
-        *(int *)(c + 0x5fc4) = *(int *)(c + 0x5fbc);
+        self->unk_5fc0 = self->unk_5fb8;
+        self->unk_5fc4 = self->unk_5fbc;
         k = data_020a0e40[0];
         if (data_020a0de8[k * 4] != 0) {
             int b = data_020a0deb[k * 4];
             int a = data_020a0dea[k * 4];
-            *(int *)(c + 0x5fb8) = (b ? a : a) << 12;
-            *(int *)(c + 0x5fbc) = b << 12;
+            self->unk_5fb8 = (b ? a : a) << 12;
+            self->unk_5fbc = b << 12;
         }
-        if (*(int *)(c + 0x5fe4) > 0x14) {
-            if (*(int *)(c + 0x5fd8) > 0) {
-                for (i = 0; i < *(int *)(c + 0x5fd8); i++) {
+        if (self->unk_5fe4 > 0x14) {
+            if (self->unk_5fd8 > 0) {
+                for (i = 0; i < self->unk_5fd8; i++) {
                     *(u8 *)(c + i * 0x20 + 0x4f39) = 1;
                     *(u8 *)(c + i * 0x20 + 0x4f3b) = 1;
                 }
-                *(int *)(c + 0x5fd8) = 0;
+                self->unk_5fd8 = 0;
                 func_02012754(0x10d);
                 func_ov004_020b0aa0(0x1d);
             }
-        } else if (*(int *)(c + 0x5fc8) < 0) {
+        } else if (self->unk_5fc8 < 0) {
             int t;
             if (data_020a0de8[k * 4] != 0 && data_020a0de9[k * 4] != 0)
                 t = 1;
@@ -104,17 +104,17 @@ int func_ov006_0212ac74(char *c)
                             *(u8 *)(c + ii * 0x20 + 0x4f3a) = 1;
                             *(int *)(c + ii * 0x20 + 0x4f44) = 0;
                             *(int *)(c + ii * 0x20 + 0x4f48) = 0;
-                            *(int *)(c + 0x5fc8) = ii;
-                            *(int *)(c + ii * 0x20 + 0x4f4c) = *(int *)(c + 0x5fb8);
-                            *(int *)(c + ii * 0x20 + 0x4f50) = *(int *)(c + 0x5fbc);
+                            self->unk_5fc8 = ii;
+                            *(int *)(c + ii * 0x20 + 0x4f4c) = self->unk_5fb8;
+                            *(int *)(c + ii * 0x20 + 0x4f50) = self->unk_5fbc;
                             func_ov004_020b0aa0(0x1d);
-                            *(int *)(c + 0x5fec) = 2;
+                            self->unk_5fec = 2;
                             break;
                         }
                     }
                     q = (V2 *)((char *)q + 0x20);
                 }
-                if (*(int *)(c + 0x5fc8) < 0) {
+                if (self->unk_5fc8 < 0) {
                     int i2;
                     V2 *q2 = (V2 *)(c + 0x4f3c);
                     for (i2 = 0; i2 < 0x16; i2++) {
@@ -127,9 +127,9 @@ int func_ov006_0212ac74(char *c)
                                 *(u8 *)(c + i2 * 0x20 + 0x4f3a) = 1;
                                 *(int *)(c + i2 * 0x20 + 0x4f44) = 0;
                                 *(int *)(c + i2 * 0x20 + 0x4f48) = 0;
-                                *(int *)(c + 0x5fc8) = i2;
-                                *(int *)(c + i2 * 0x20 + 0x4f4c) = *(int *)(c + 0x5fb8);
-                                *(int *)(c + i2 * 0x20 + 0x4f50) = *(int *)(c + 0x5fbc);
+                                self->unk_5fc8 = i2;
+                                *(int *)(c + i2 * 0x20 + 0x4f4c) = self->unk_5fb8;
+                                *(int *)(c + i2 * 0x20 + 0x4f50) = self->unk_5fbc;
                                 break;
                             }
                         }
@@ -144,87 +144,87 @@ int func_ov006_0212ac74(char *c)
                 int j;
                 func_0203d6d0(&d3, (V2 *)(c + 0x5fb8), (V2 *)(c + 0x5fc0));
                 cells = (Cell *)(c + 0x4f3c);
-                j = *(int *)(c + 0x5fc8);
+                j = self->unk_5fc8;
                 cells[j].x += d3.x;
                 *(int *)LB((char *)cells + j * 0x20 + 4) += d3.z;
             } else {
-                if (*(u8 *)(c + *(int *)(c + 0x5fc8) * 0x20 + 0x4f39) == 0) {
-                    *(u8 *)(c + *(int *)(c + 0x5fc8) * 0x20 + 0x4f39) = 1;
-                    if (*(u8 *)(c + *(int *)(c + 0x5fc8) * 0x20 + 0x4f3b) == 0) {
+                if (*(u8 *)(c + self->unk_5fc8 * 0x20 + 0x4f39) == 0) {
+                    *(u8 *)(c + self->unk_5fc8 * 0x20 + 0x4f39) = 1;
+                    if (*(u8 *)(c + self->unk_5fc8 * 0x20 + 0x4f3b) == 0) {
                         t = 1;
-                        *(u8 *)(c + *(int *)(c + 0x5fc8) * 0x20 + 0x4f3b) = 1;
+                        *(u8 *)(c + self->unk_5fc8 * 0x20 + 0x4f3b) = 1;
                         func_ov006_020c3990(c + 0x51f8);
                     }
                 }
-                *(u8 *)(c + *(int *)(c + 0x5fc8) * 0x20 + 0x4f3a) = 0;
-                *(int *)(c + 0x5fc8) = -1;
+                *(u8 *)(c + self->unk_5fc8 * 0x20 + 0x4f3a) = 0;
+                self->unk_5fc8 = -1;
             }
             if (t != 0) {
                 *(int *)LA(c + 0x5fd8) -= 1;
-                if (*(u8 *)(c + 0x5fcc) == 1) {
-                    *(u8 *)(c + 0x5fcc) = 0;
-                    if (*(int *)(c + 0x5fd8) >= 1) {
+                if (self->unk_5fcc == 1) {
+                    self->unk_5fcc = 0;
+                    if (self->unk_5fd8 >= 1) {
                         func_ov004_020b0aa0(0x1d);
                         func_ov004_020b0cac(0x13, 0x80, 0x18, 0, -1, 0xd);
-                        *(int *)(c + 0x5fec) = 3;
+                        self->unk_5fec = 3;
                         func_02012754(0x104);
                     }
                 } else {
-                    *(u8 *)(c + 0x5fcc) = 1;
-                    if (*(int *)(c + 0x5fd8) >= 1) {
+                    self->unk_5fcc = 1;
+                    if (self->unk_5fd8 >= 1) {
                         func_ov004_020b0aa0(0x1d);
                         func_ov004_020b0cac(0x10, 0x80, 0x18, 0, -1, 0xd);
-                        *(int *)(c + 0x5fec) = 1;
+                        self->unk_5fec = 1;
                         func_02012754(0x103);
                     }
                 }
-                *(int *)(c + 0x5fd0) = 0x3c;
+                self->unk_5fd0 = 0x3c;
             }
         }
-        if (*(int *)(c + 0x5fd8) <= 0 && *(u8 *)(c + 0x5fcd) == 1) {
-            if (*(int *)(c + 0x5fd4) > 0) {
+        if (self->unk_5fd8 <= 0 && self->unk_5fcd == 1) {
+            if (self->unk_5fd4 > 0) {
                 *(int *)LA(c + 0x5fd4) -= 1;
-                if (*(int *)(c + 0x5fd4) <= 0) {
-                    *(int *)(c + 0x5fe8) = 1;
+                if (self->unk_5fd4 <= 0) {
+                    self->unk_5fe8 = 1;
                     func_ov004_020b0a54(0xc);
                 }
                 if (func_ov006_020c3b80(c + 0x51f8) != 0) {
-                    if (*(u8 *)(c + 0x5fcc) == 1)
+                    if (self->unk_5fcc == 1)
                         func_ov006_020c3908(c + 0x51f8);
                     else
                         func_ov006_020c38b0(c + 0x51f8);
                 }
             } else {
                 func_ov004_020b0aa0(0x1d);
-                if (*(int *)(c + 0x5fe4) > 0x14) {
-                    if (*(u8 *)(c + 0x5fcd) == 1) {
+                if (self->unk_5fe4 > 0x14) {
+                    if (self->unk_5fcd == 1) {
                         func_02012754(0x106);
-                        *(int *)(c + 0x5fec) = 4;
-                        *(int *)(c + 0x5fd4) = 0x3c;
+                        self->unk_5fec = 4;
+                        self->unk_5fd4 = 0x3c;
                     }
                 } else {
-                if (*(u8 *)(c + 0x5fcc) == 1) {
-                    *(int *)(c + 0x5fec) = 0;
+                if (self->unk_5fcc == 1) {
+                    self->unk_5fec = 0;
                     *(int *)LA(c + 0x5fdc) += 1;
-                    *(int *)(c + 0x5fe0) = 0;
-                    if (*(int *)(c + 0x5fdc) >= 3) {
+                    self->unk_5fe0 = 0;
+                    if (self->unk_5fdc >= 3) {
                         func_ov004_020b0cac(0x12, 0x80, 0x18, 0, -1, 0xd);
                         func_02012754(0x107);
                         *(int *)LA(c + 0x5ff0) += 3;
-                        if (*(int *)(c + 0x5ff0) > 0x270f)
-                            *(int *)(c + 0x5ff0) = 0x270f;
+                        if (self->unk_5ff0 > 0x270f)
+                            self->unk_5ff0 = 0x270f;
                     } else {
                         func_ov004_020b0cac(0x10, 0x80, 0x18, 0, -1, 0xd);
                         func_02012754(0x108);
                         *(int *)LA(c + 0x5ff0) += 1;
-                        if (*(int *)(c + 0x5ff0) > 0x270f)
-                            *(int *)(c + 0x5ff0) = 0x270f;
+                        if (self->unk_5ff0 > 0x270f)
+                            self->unk_5ff0 = 0x270f;
                     }
                 } else {
-                    *(int *)(c + 0x5fec) = 4;
+                    self->unk_5fec = 4;
                     *(int *)LA(c + 0x5fe0) += 1;
-                    *(int *)(c + 0x5fdc) = 0;
-                    if (*(int *)(c + 0x5fe0) >= 3) {
+                    self->unk_5fdc = 0;
+                    if (self->unk_5fe0 >= 3) {
                         func_ov004_020b0cac(0x11, 0x80, 0x18, 0, -1, 0xd);
                         func_02012754(0x105);
                     } else {
@@ -232,7 +232,7 @@ int func_ov006_0212ac74(char *c)
                         func_02012754(0x106);
                     }
                 }
-                *(int *)(c + 0x5fd4) = 0x3c;
+                self->unk_5fd4 = 0x3c;
                 }
             }
         }
@@ -240,12 +240,12 @@ int func_ov006_0212ac74(char *c)
         break;
     case 1:
         if (func_ov006_020c3b80(c + 0x51f8) != 0) {
-            if (*(u8 *)(c + 0x5fcc) == 1)
+            if (self->unk_5fcc == 1)
                 func_ov006_020c3908(c + 0x51f8);
             else
                 func_ov006_020c38b0(c + 0x51f8);
         }
-        *(u8 *)(c + 0xc3) = 0;
+        self->unk_0c3 = 0;
         func_ov006_0212a654(c);
         break;
     default:

--- a/src/func_ov006_0212b480.c
+++ b/src/func_ov006_0212b480.c
@@ -1,8 +1,13 @@
+// @symbol func_ov006_0212b480
+// @emits dScMgFlower_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScMgFlower_c::InitResources - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern int func_ov004_020ad8b8(void);
 extern void *func_020adc74(void *arg);
 extern char *_ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(int src, void *dst);
@@ -17,27 +22,12 @@ extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *p, u16 a, u16 b, u16 c, u16 d);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
-extern void func_ov006_0212a764(void *arg);
-extern void func_ov006_020c3d88(char *c);
-extern void func_ov006_020c3b2c(void *arg);
 
 extern int data_0208ee44;
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern int data_ov006_021401d0;
-extern int data_ov006_021401f4;
-extern int data_ov006_02140218;
-extern int data_ov006_0214023c;
-extern int data_ov006_02140260;
-extern int data_ov006_02140284;
-extern int data_ov006_021402a8;
-extern int data_ov006_021402c4;
-extern int func_020bc8a8;
-extern int func_020bc898;
-extern int func_020bc86c;
-extern int func_020bc8a4;
 
-int func_ov006_0212b480(void *arg0)
+int dScMgFlower_c_InitResources(void *arg0)
 {
     char *c = (char *)arg0;
     int h;

--- a/src/func_ov007_020b0da0.c
+++ b/src/func_ov007_020b0da0.c
@@ -1,21 +1,18 @@
+// @symbol func_ov007_020b0da0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef long long s64;
 
 extern short data_02082214[];
-extern void* data_ov007_0210342c;
-extern int data_ov007_02103340;
-extern int data_ov007_02103344;
 
-extern void* func_ov007_020aebac(void);
-extern void func_ov007_020bdeb0(int a);
-extern int _ZN4cstd3modEii(int a, int b);
-extern int _ZN4cstd3divEii(int a, int b);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Matrix4x3_LoadIdentity(void* mat);
-extern void func_ov007_020c39f8(void* mat, int rx, int ry, int rz);
 
-struct V3 { int x, y, z; };
+
 
 #pragma opt_common_subs off
 void func_ov007_020b0da0(void* arg0) {
@@ -37,7 +34,7 @@ void func_ov007_020b0da0(void* arg0) {
     }
 
     {
-        struct V3 out;
+        struct Vector3 out;
         out.y = 0;
         out.x = 0;
         out.z = 0;
@@ -49,7 +46,7 @@ void func_ov007_020b0da0(void* arg0) {
                 if (a >= 0x60 && a <= 0xa0) {
                     int b = *(u16*)(rp + 0xa);
                     if (b >= 0x40 && b <= 0x80) {
-                        int* pflag = (int*)(((long long)(int)(st + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+                        int* pflag = (int*)(((long long)(int)(st + 4)));
                         *pflag |= 2;
                         data_ov007_02103340 = counter;
                         func_ov007_020bdeb0(0x34);
@@ -133,6 +130,6 @@ void func_ov007_020b0da0(void* arg0) {
             }
         }
 
-        *(struct V3*)(mat + 0x24) = out;
+        *(struct Vector3*)(mat + 0x24) = out;
     }
 }

--- a/src/func_ov007_020baa10.c
+++ b/src/func_ov007_020baa10.c
@@ -1,17 +1,17 @@
+// @symbol func_ov007_020baa10
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef long long s64;
 
 extern s16 data_02082214[];
-extern char* data_ov007_02104ba0;
 
-extern void func_ov007_020c92d0(char* p);
-extern int _ZN4cstd3modEii(int a, int b);
-extern int _ZN4cstd3divEii(int a, int b);
-extern int func_ov007_020c3ba8(int d);
 
-struct V3 { int x, y, z; };
+
 
 void func_ov007_020baa10(void)
 {
@@ -73,7 +73,7 @@ void func_ov007_020baa10(void)
     }
     case 5:
         if (counter == 0) {
-            *(struct V3*)(a + 0x70) = *(struct V3*)(a + 0x7c);
+            *(struct Vector3*)(a + 0x70) = *(struct Vector3*)(a + 0x7c);
             *(int*)(a + 0x8c) = 0;
             *(int*)(a + 0x88) = *(int*)(a + 0x8c);
         }

--- a/src/func_ov007_020bee14.c
+++ b/src/func_ov007_020bee14.c
@@ -1,11 +1,12 @@
-extern void func_ov007_020ca5f0(int a, int b, void* v, int d, int e);
-extern void func_ov007_020cb3dc(int x);
-struct V3 { int x, y, z; };
-extern struct V3 data_ov007_020d7d60;
-extern int *data_ov007_02104bd4;
+// @symbol func_ov007_020bee14
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 void func_ov007_020bee14(void)
 {
-    struct V3 v = data_ov007_020d7d60;
+    struct Vector3 v = data_ov007_020d7d60;
     v.z += 0x200;
     func_ov007_020ca5f0(data_ov007_02104bd4[0], data_ov007_02104bd4[1], &v, 0x3e8, 1);
     func_ov007_020cb3dc(data_ov007_02104bd4[0]);

--- a/src/func_ov007_020c2390.c
+++ b/src/func_ov007_020c2390.c
@@ -1,11 +1,13 @@
-struct Vec3 { int x, y, z; };
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void NormalizeVec3(struct Vec3 *a, struct Vec3 *b);
+// @symbol func_ov007_020c2390
+/* recovered: shared common types */
+#include "common.h"
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern void NormalizeVec3(struct Vector3 *a, struct Vector3 *b);
 
 void func_ov007_020c2390(char *t)
 {
-    struct Vec3 v;
-    SubVec3((struct Vec3 *)(t + 4), (struct Vec3 *)(t + 0x10), &v);
+    struct Vector3 v;
+    SubVec3((struct Vector3 *)(t + 4), (struct Vector3 *)(t + 0x10), &v);
     NormalizeVec3(&v, &v);
     *(short *)(t + 0x1c) = v.x;
     *(short *)(t + 0x1e) = v.y;

--- a/src/func_ov007_020c25fc.c
+++ b/src/func_ov007_020c25fc.c
@@ -1,6 +1,8 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov007_020c25fc
+/* recovered: shared common types */
+#include "common.h"
 struct S { char _0[8]; unsigned short f8; char _a[0x1a]; int *f24; int *f28; };
-extern int func_ov007_020c2e90(struct S *s, struct V3 *b, struct V3 *c, int d, int e);
+extern int func_ov007_020c2e90(struct S *s, struct Vector3 *b, struct Vector3 *c, int d, int e);
 extern void func_ov007_020c2d44(struct S *s, int i);
 extern int func_ov007_020c2dfc(struct S *self, int idx, int v);
 extern void func_ov007_020c24d0(struct S *s, int i);
@@ -8,7 +10,7 @@ int func_ov007_020c25fc(struct S *self, int a1, int a2, int a3, int e, int v)
 {
     int ok = 1;
     if (self->f8 != 0) {
-        struct V3 loc1, loc2;
+        struct Vector3 loc1, loc2;
         loc1.x = a1; loc1.y = a2;
         loc2.x = self->f24[self->f8 - 1];
         loc2.y = self->f28[self->f8 - 1];

--- a/src/func_ov007_020c30ac.c
+++ b/src/func_ov007_020c30ac.c
@@ -1,13 +1,15 @@
-struct Vec3 { int x, y, z; };
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-int func_ov007_020c30ac(struct Vec3 *arr, int count, struct Vec3 *target, int arg4, int *out)
+// @symbol func_ov007_020c30ac
+/* recovered: shared common types */
+#include "common.h"
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+int func_ov007_020c30ac(struct Vector3 *arr, int count, struct Vector3 *target, int arg4, int *out)
 {
-    struct Vec3 diff; long long d2; int i; int bestIdx;
+    struct Vector3 diff; long long d2; int i; int bestIdx;
     long long best = 0x7fffffffffffffffLL;
     for (i = 0; i < count; i++) {
         SubVec3(arr, target, &diff);
         d2 = (long long)diff.x * diff.x + (long long)diff.y * diff.y + (long long)diff.z * diff.z;
-        arr = (struct Vec3 *)((char *)arr + 0xc);
+        arr = (struct Vector3 *)((char *)arr + 0xc);
         if (d2 < best) { bestIdx = i; best = d2; }
     }
     if (arg4 < 0 || (long long)arg4 * arg4 >= best) {

--- a/src/func_ov007_020c39f8.c
+++ b/src/func_ov007_020c39f8.c
@@ -1,13 +1,14 @@
-struct Mat43 { int m[12]; };
-
+// @symbol func_ov007_020c39f8
+/* recovered: shared common types */
+#include "common.h"
 extern short data_02082214[];
-extern void func_0205283c(struct Mat43 *out, short a, short b);
-extern void func_02052820(struct Mat43 *out, short a, short b);
-extern void func_02052800(struct Mat43 *out, short a, short b);
-extern void MulMat4x3Mat4x3(struct Mat43 *dst, struct Mat43 *a, struct Mat43 *b);
+extern void func_0205283c(struct Matrix4x3 *out, short a, short b);
+extern void func_02052820(struct Matrix4x3 *out, short a, short b);
+extern void func_02052800(struct Matrix4x3 *out, short a, short b);
+extern void MulMat4x3Mat4x3(struct Matrix4x3 *dst, struct Matrix4x3 *a, struct Matrix4x3 *b);
 
-void func_ov007_020c39f8(struct Mat43 *mat, int rx, int ry, int rz) {
-    struct Mat43 t;
+void func_ov007_020c39f8(struct Matrix4x3 *mat, int rx, int ry, int rz) {
+    struct Matrix4x3 t;
     int ix = (rx >> 4) * 2;
     int iy = (ry >> 4) * 2;
     int iz = (rz >> 4) * 2;

--- a/src/func_ov007_020c44e4.c
+++ b/src/func_ov007_020c44e4.c
@@ -1,12 +1,16 @@
+// @symbol func_ov007_020c44e4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-extern int func_ov007_020c3df4(int a, int b);
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
-struct Vec3i { int x, y, z; };
+
 
 int func_ov007_020c44e4(int count)
 {
@@ -30,8 +34,8 @@ int func_ov007_020c44e4(int count)
     *(u16*)(p + 0xc) = *(u16*)(p + 0xe);
 
     {
-        struct Vec3i z3 = {0, 0, 0};
-        *(struct Vec3i*)(p + 0x14) = z3;
+        struct Vector3 z3 = {0, 0, 0};
+        *(struct Vector3*)(p + 0x14) = z3;
 
     *(int*)(p + 0x24) = 0;
     *(int*)(p + 0x20) = *(int*)(p + 0x24);
@@ -42,8 +46,8 @@ int func_ov007_020c44e4(int count)
     *(u16*)(p + 0x34) = *(u16*)(p + 0x36);
 
         {
-            struct Vec3i z3b = {0, 0, 0};
-            *(struct Vec3i*)(p + 0x28) = z3b;
+            struct Vector3 z3b = {0, 0, 0};
+            *(struct Vector3*)(p + 0x28) = z3b;
         }
     }
 

--- a/src/func_ov007_020c5188.c
+++ b/src/func_ov007_020c5188.c
@@ -1,9 +1,9 @@
-struct Vec3 { int x, y, z; };
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void func_ov007_020c7560(void *self, int a, int b);
-extern void func_ov007_020c7b2c(int a, int b, int c);
-extern void func_ov007_020c81a0(void *node, int a, int b);
-extern void func_ov007_020c831c(void *s, int a, int b);
+// @symbol func_ov007_020c5188
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 
 #define DIVR(x) ((int)(((long long)(x) * -1000 + 0x800) >> 12))
 
@@ -20,17 +20,17 @@ void func_ov007_020c5188(char *sb, int arg1)
     int v18;
     int v1c;
     int v20;
-    struct Vec3 backup;
+    struct Vector3 backup;
     int *r7;
     int *r6;
 
     p = arg1;
     stride = *(int *)(*(char **)(sb + 0x1c) + 4);
     count = 1 << p;
-    backup = *(struct Vec3 *)(sb + 0x70);
+    backup = *(struct Vector3 *)(sb + 0x70);
     r7 = (int *)(sb + 0xb8);
     r6 = (int *)(sb + 0xc4);
-    AddVec3((struct Vec3 *)(sb + 0x88), (struct Vec3 *)(sb + 0x70), (struct Vec3 *)(sb + 0x70));
+    AddVec3((struct Vector3 *)(sb + 0x88), (struct Vector3 *)(sb + 0x70), (struct Vector3 *)(sb + 0x70));
 
     oc = 0;
     if (count > 0) {
@@ -84,5 +84,5 @@ void func_ov007_020c5188(char *sb, int arg1)
         } while (oc < count);
     }
 
-    *(struct Vec3 *)(sb + 0x70) = backup;
+    *(struct Vector3 *)(sb + 0x70) = backup;
 }

--- a/src/func_ov007_020c5fc8.c
+++ b/src/func_ov007_020c5fc8.c
@@ -1,18 +1,21 @@
+// @symbol func_ov007_020c5fc8
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
 typedef short s16;
 typedef long long s64;
 
-struct Vec3 { int x, y, z; };
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern int LenVec3(struct Vec3 *v);
+
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int LenVec3(struct Vector3 *v);
 
 void func_ov007_020c5fc8(char *sb, int idx, int t)
 {
     int i;
     int k;
     int inv;
-    struct Vec3 cur;
-    struct Vec3 prev;
+    struct Vector3 cur;
+    struct Vector3 prev;
 
     i = 0;
     if ((int)*(u16 *)((*(char ***)(sb + 0x38))[idx] + 8) <= 0)
@@ -49,8 +52,8 @@ void func_ov007_020c5fc8(char *sb, int idx, int t)
             char *p = (*(char ***)(sb + 0x3c))[idx];
             char *arr = *(char **)(p + 8);
             char *seg = ((char **)arr)[i - 1];
-            SubVec3(&prev, &cur, (struct Vec3 *)(seg + 0xc));
-            *(int *)(seg + 8) = LenVec3((struct Vec3 *)(seg + 0xc));
+            SubVec3(&prev, &cur, (struct Vector3 *)(seg + 0xc));
+            *(int *)(seg + 8) = LenVec3((struct Vector3 *)(seg + 0xc));
         }
 
         prev = cur;

--- a/src/func_ov007_020c6174.c
+++ b/src/func_ov007_020c6174.c
@@ -1,9 +1,13 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov007_020c6174
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Elem {
-    struct Vec3 **a;   /* 0x0 */
-    struct Vec3 **b;   /* 0x4 */
+    struct Vector3 **a;   /* 0x0 */
+    struct Vector3 **b;   /* 0x4 */
     int len;           /* 0x8 */
-    struct Vec3 v;     /* 0xc */
+    struct Vector3 v;     /* 0xc */
 };
 struct Node {
     char pad[8];
@@ -13,10 +17,10 @@ struct Node {
 struct T {
     int p0, p4, p8;
     char pad[0x2c - 0xc];
-    struct Vec3 **p2c;   /* 0x2c */
+    struct Vector3 **p2c;   /* 0x2c */
     char pad2[0x38 - 0x30];
     struct Node **p38;   /* 0x38 */
-    struct Vec3 **p3c;   /* 0x3c */
+    struct Vector3 **p3c;   /* 0x3c */
     struct Elem **p40;   /* 0x40 */
     struct Elem **p44;   /* 0x44 */
     unsigned short *p48; /* 0x48 */
@@ -25,10 +29,8 @@ struct T {
     unsigned short *p54; /* 0x54 */
 };
 
-extern void func_ov007_020c7694(struct Vec3 *a, struct Vec3 *b);
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern int LenVec3(struct Vec3 *v);
-extern void func_ov007_020c775c(struct Vec3 *t);
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int LenVec3(struct Vector3 *v);
 
 void func_ov007_020c6174(struct T *t, int idx, int flag)
 {

--- a/src/func_ov007_020c6314.c
+++ b/src/func_ov007_020c6314.c
@@ -1,13 +1,15 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov007_020c6314
+/* recovered: shared common types */
+#include "common.h"
 struct Elem {
-    struct Vec3** a;   /* 0x0 */
-    struct Vec3** b;   /* 0x4 */
+    struct Vector3** a;   /* 0x0 */
+    struct Vector3** b;   /* 0x4 */
     int len;           /* 0x8 */
-    struct Vec3 v;     /* 0xc */
+    struct Vector3 v;     /* 0xc */
 };
 
-extern void SubVec3(struct Vec3* a, struct Vec3* b, struct Vec3* c);
-extern int LenVec3(struct Vec3* v);
+extern void SubVec3(struct Vector3* a, struct Vector3* b, struct Vector3* c);
+extern int LenVec3(struct Vector3* v);
 
 void func_ov007_020c6314(char* t, int idx, int flag)
 {
@@ -18,7 +20,7 @@ void func_ov007_020c6314(char* t, int idx, int flag)
     case 0:
         for (i = 0; i < *(unsigned short*)((char*)(*(struct Elem***)(t + 0x38))[idx] + 8); i++) {
             e = (*(struct Elem****)(t + 0x34))[idx][i];
-            SubVec3((struct Vec3*)(t + 0x7c), &(*(struct Vec3***)(t + 0x2c))[idx][i], &e->v);
+            SubVec3((struct Vector3*)(t + 0x7c), &(*(struct Vector3***)(t + 0x2c))[idx][i], &e->v);
             e->len = LenVec3(&e->v);
         }
         break;
@@ -32,7 +34,7 @@ void func_ov007_020c6314(char* t, int idx, int flag)
     case 2:
         for (i = 0; i < *(unsigned short*)((char*)(*(struct Elem***)(t + 0x38))[idx] + 8); i++) {
             e = (*(struct Elem****)(t + 0x34))[idx][i];
-            SubVec3((struct Vec3*)(t + 0x7c), &(*(struct Vec3***)(t + 0x28))[idx][i], &e->v);
+            SubVec3((struct Vector3*)(t + 0x7c), &(*(struct Vector3***)(t + 0x28))[idx][i], &e->v);
             e->len = LenVec3(&e->v);
         }
         break;

--- a/src/func_ov007_020c64c4.c
+++ b/src/func_ov007_020c64c4.c
@@ -1,7 +1,10 @@
-struct Vec3 { int x, y, z; };
-extern void func_ov007_020c6314(void* c, int i, int b);
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern int LenVec3(struct Vec3 *a);
+// @symbol func_ov007_020c64c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int LenVec3(struct Vector3 *a);
 
 void func_ov007_020c64c4(char* c, int b) {
     char* r4;
@@ -10,8 +13,8 @@ void func_ov007_020c64c4(char* c, int b) {
         func_ov007_020c6314(c, i, b);
     }
     if (*(int*)(c + 4) != 2) return;
-    *(struct Vec3*)(c + 0x98) = *(struct Vec3*)(c + 0x70);
+    *(struct Vector3*)(c + 0x98) = *(struct Vector3*)(c + 0x70);
     r4 = *(char**)(c + 0xa4);
-    SubVec3(*(struct Vec3**)*(char**)r4, *(struct Vec3**)*(char**)(r4 + 4), (struct Vec3*)(r4 + 0xc));
-    *(int*)(r4 + 8) = LenVec3((struct Vec3*)(r4 + 0xc));
+    SubVec3(*(struct Vector3**)*(char**)r4, *(struct Vector3**)*(char**)(r4 + 4), (struct Vector3*)(r4 + 0xc));
+    *(int*)(r4 + 8) = LenVec3((struct Vector3*)(r4 + 0xc));
 }

--- a/src/func_ov007_020c7694.c
+++ b/src/func_ov007_020c7694.c
@@ -1,10 +1,11 @@
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov007_020c7694
+/* recovered: shared common types */
+#include "common.h"
 struct E {
     int f0;
     int f4;
     int len;            // 0x8
-    struct Vec3 v;      // 0xc
+    struct Vector3 v;      // 0xc
 };
 
 struct T {
@@ -15,10 +16,10 @@ struct T {
     int f10;            // 0x10
 };
 
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern int LenVec3(struct Vec3 *v);
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int LenVec3(struct Vector3 *v);
 
-void func_ov007_020c7694(struct T *t, struct Vec3 *base)
+void func_ov007_020c7694(struct T *t, struct Vector3 *base)
 {
     int n;
     int cnt;

--- a/src/func_ov007_020c775c.c
+++ b/src/func_ov007_020c775c.c
@@ -1,10 +1,11 @@
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov007_020c775c
+/* recovered: shared common types */
+#include "common.h"
 struct E {
-    struct Vec3 **p0;   // 0x0
-    struct Vec3 **p1;   // 0x4
+    struct Vector3 **p0;   // 0x0
+    struct Vector3 **p1;   // 0x4
     int len;            // 0x8
-    struct Vec3 v;      // 0xc
+    struct Vector3 v;      // 0xc
 };
 
 struct T {
@@ -15,8 +16,8 @@ struct T {
     int f10;            // 0x10
 };
 
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern int LenVec3(struct Vec3 *v);
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern int LenVec3(struct Vector3 *v);
 
 void func_ov007_020c775c(struct T *t)
 {

--- a/src/func_ov007_020c7c60.c
+++ b/src/func_ov007_020c7c60.c
@@ -1,23 +1,26 @@
-struct Vec3 { int x, y, z; };
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
-extern void func_02053320(int s, int *a, int *b, int *out);
+// @symbol func_ov007_020c7c60
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 
 void func_ov007_020c7c60(char **self, int r6, int r4)
 {
-    struct Vec3 d2, scaled, d1;
+    struct Vector3 d2, scaled, d1;
     int m, s;
 
-    SubVec3((struct Vec3 *)*(void **)self[0], (struct Vec3 *)*(void **)self[1], &d1);
-    SubVec3(&d1, (struct Vec3 *)(self + 3), &d2);
+    SubVec3((struct Vector3 *)*(void **)self[0], (struct Vector3 *)*(void **)self[1], &d1);
+    SubVec3(&d1, (struct Vector3 *)(self + 3), &d2);
 
     m = -r6;
     scaled.x = (int)(((long long)m * d2.x + 0x800) >> 12);
     scaled.y = (int)(((long long)m * d2.y + 0x800) >> 12);
     scaled.z = (int)(((long long)m * d2.z + 0x800) >> 12);
 
-    AddVec3((struct Vec3 *)(self[0] + 0x10), &scaled, (struct Vec3 *)(self[0] + 0x10));
-    SubVec3((struct Vec3 *)(self[1] + 0x10), &scaled, (struct Vec3 *)(self[1] + 0x10));
+    AddVec3((struct Vector3 *)(self[0] + 0x10), &scaled, (struct Vector3 *)(self[0] + 0x10));
+    SubVec3((struct Vector3 *)(self[1] + 0x10), &scaled, (struct Vector3 *)(self[1] + 0x10));
 
     s = -r4;
     func_02053320(s, (int *)(self[0] + 4), (int *)(self[0] + 0x10), (int *)(self[0] + 0x10));

--- a/src/func_ov007_020cc028.c
+++ b/src/func_ov007_020cc028.c
@@ -1,14 +1,15 @@
-extern void func_02017254(void *);
+// @symbol func_ov007_020cc028
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV9dScDSMT_c; VT1 = _ZTV8dScene_c; VT2 = _ZTV7dBase_c */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *func_ov007_020cc028(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV9dScDSMT_c;
     func_02017254((char *)t + 0x54);
-    t[0] = (int)VT1;
-    t[0] = (int)VT2;
+    t[0] = (int)_ZTV8dScene_c;
+    t[0] = (int)_ZTV7dBase_c;
     _ZN9ActorBaseD2Ev(t);
     return t;
 }

--- a/src/func_ov007_020cc070.c
+++ b/src/func_ov007_020cc070.c
@@ -1,11 +1,12 @@
-extern void func_02017254(void *);
+// @symbol func_ov007_020cc070
+// @emits dScDSMT_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* dScDSMT_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 extern void *G0;
-int *func_ov007_020cc070(int *t)
+int *dScDSMT_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     func_02017254((char *)t + 0x54);

--- a/src/func_ov007_020cc2ac.c
+++ b/src/func_ov007_020cc2ac.c
@@ -1,3 +1,7 @@
-void func_ov007_020cc2ac(void)
+// @symbol func_ov007_020cc2ac
+// @emits dScDSMT_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScDSMT_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScDSMT_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov007_020cc2b0.c
+++ b/src/func_ov007_020cc2b0.c
@@ -1,5 +1,10 @@
-extern void func_ov007_020b7040(void *);
-int func_ov007_020cc2b0(void *t)
+// @symbol func_ov007_020cc2b0
+// @emits dScDSMT_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScDSMT_c::Render - recovered from vtable slot identity */
+int dScDSMT_c_Render(void *t)
 {
     func_ov007_020b7040(t);
     return 1;

--- a/src/func_ov007_020cc2cc.c
+++ b/src/func_ov007_020cc2cc.c
@@ -1,35 +1,26 @@
+// @symbol func_ov007_020cc2cc
+// @emits dScDSMT_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Heap.h"
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScDSMT_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
-extern void _ZN5Sound22LoadAndSetMusic_Layer1Ei(int a);
-extern int func_0203da9c(void);
-extern u16* func_0203dabc(void);
-extern int func_0203dae4(void);
 extern int func_ov007_020b7090(u16 a0, u16 a1, u16 a2, u16 a3, int arg4);
-extern int func_02013c84(int charID, void* dest, int fileIndex, void* src);
-extern void StartFile(s8 levelID, u8 entranceID);
-extern int func_0201a458(void);
 extern int _ZN4Heap10SetDefaultEv(int heap);
-extern int LoadArchive(int idx);
-extern void LoadTextNarcs(void);
-extern void _ZN4Heap6RescueEv(int heap);
-extern void LoadOverlay(int id);
 extern void _ZN5Scene14StartSceneFadeEjjt(unsigned int a, unsigned int b, u16 c);
 extern void StartMinigameMenu(u8 returnToRecRoom);
-extern void _ZN5Scene9SetFadersEP15FaderBrightness(void* p);
 
-extern int data_ov007_02103260;
-extern unsigned short data_ov007_02104c28;
 extern char* data_0209b33c;
 extern char data_0209caa0;
-extern int data_0209d524;
-extern int overlay_64;
-extern int overlay_66;
 
-int func_ov007_020cc2cc(char* c)
+int dScDSMT_c_Behavior(char* c)
 {
     int result;
 

--- a/src/func_ov007_020cc45c.c
+++ b/src/func_ov007_020cc45c.c
@@ -1,12 +1,16 @@
-extern void _ZN5Scene20SetAndStopColorFaderEv(void);
-extern int func_ov007_020b6f4c(void);
+// @symbol func_ov007_020cc45c
+// @emits dScDSMT_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Scene.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScDSMT_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void);
 extern void func_0203cbc0(void* a);
 extern int data_0209d4a8;
-extern int data_0209b340[];
 extern void* data_0209b33c;
 
-int func_ov007_020cc45c(void) {
+int dScDSMT_c_CleanupResources(void) {
     data_0209d4a8 = 0;
     _ZN5Scene20SetAndStopColorFaderEv();
     data_0209b340[0] = func_ov007_020b6f4c();

--- a/src/func_ov009_02111234.cpp
+++ b/src/func_ov009_02111234.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov009_02111234
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -6,7 +9,7 @@ typedef unsigned int u32;
 typedef int s32;
 typedef long long s64;
 
-struct Vec3 { s32 x, y, z; };
+
 
 extern "C" {
     void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
@@ -31,9 +34,9 @@ extern "C" void func_ov009_02111234(void* self)
         return;
     }
 
-    Vec3 diff;
+    Vector3 diff;
     if (*(u8*)(c+0x180) != 0) {
-        Vec3 d1;
+        Vector3 d1;
         Vec3_Sub(&d1, (void*)(c+0x160), (void*)(c+0x5c));
         diff.x = d1.x;
         diff.y = d1.y;
@@ -42,7 +45,7 @@ extern "C" void func_ov009_02111234(void* self)
         *(s16*)(c+0x16c) = _ZN4cstd5atan2E5Fix12IiES1_(hl, *(s32*)(c+0x60) + 0xfd8f0000);
         *(s16*)(c+0x16e) = _ZN4cstd5atan2E5Fix12IiES1_(diff.z, diff.x);
     } else {
-        Vec3 d2;
+        Vector3 d2;
         Vec3_Sub(&d2, (void*)(f+0x5c), (void*)(c+0x5c));
         diff.x = d2.x;
         diff.y = d2.y;

--- a/src/func_ov009_0211145c.c
+++ b/src/func_ov009_0211145c.c
@@ -1,3 +1,6 @@
+// @symbol func_ov009_0211145c
+/* recovered: shared common types */
+#include "common.h"
 // NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
 // proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
 // to a draft until someone reproduces the bytes from real C.
@@ -6,10 +9,10 @@
  * interleave for -0x14000 / 0xff06a000 / func_0201267c (same wall as sibling
  * 021116ec avoids by not calling after the stores).
  */
-struct V3 { int x, y, z; };
+
 extern char* _ZN5Actor13ClosestPlayerEv(void* self);
-extern int Vec3_Sub(struct V3* dst, void* a, void* b);
-extern int Vec3_HorzLen(struct V3* v);
+extern int Vec3_Sub(struct Vector3* dst, void* a, void* b);
+extern int Vec3_HorzLen(struct Vector3* v);
 extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p1, void* pos, void* rot, int a, int b);
 extern void func_ov009_02111224(char* c, int r1);
 extern int func_0201267c(unsigned int a, void* b);
@@ -19,8 +22,8 @@ extern int data_0209e650;
 void func_ov009_0211145c(char* c) {
     if (*(unsigned char*)(c + 0x180) != 0) {
         char* p;
-        struct V3 copy;
-        struct V3 diff;
+        struct Vector3 copy;
+        struct Vector3 diff;
         int n;
         p = _ZN5Actor13ClosestPlayerEv(c);
         if (p == 0) {

--- a/src/func_ov009_021115d8.c
+++ b/src/func_ov009_021115d8.c
@@ -1,8 +1,9 @@
-
-struct V3 { int x, y, z; };
+// @symbol func_ov009_021115d8
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor13ClosestPlayerEv(void* self);
-extern int Vec3_Sub(struct V3* dst, void* a, void* b);
-extern int Vec3_HorzLen(struct V3* v);
+extern int Vec3_Sub(struct Vector3* dst, void* a, void* b);
+extern int Vec3_HorzLen(struct Vector3* v);
 extern int func_0201267c(unsigned int a, void* b);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN9ActorBase18MarkForDestructionEv(char* t);
@@ -12,8 +13,8 @@ void func_ov009_021115d8(char* c) {
     if (*(unsigned char*)(c+0x180) != 0) {
         char* p2 = _ZN5Actor13ClosestPlayerEv(c);
         if (p2 != 0) {
-            struct V3 copy;
-            struct V3 diff;
+            struct Vector3 copy;
+            struct Vector3 diff;
             int len;
             Vec3_Sub(&diff, c+0x5c, p2+0x5c);
             copy.x = diff.x;

--- a/src/func_ov009_021116ec.cpp
+++ b/src/func_ov009_021116ec.cpp
@@ -1,9 +1,12 @@
 //cpp
-struct Vec3 { int x, y, z; };
-struct Vec3_16 { short x, y, z; };
+// @symbol func_ov009_021116ec
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" {
 extern unsigned int RandomIntInternal(void* g);
-extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const Vec3* pos, const Vec3_16* rot, int e, int f);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const Vector3* pos, const Vector3_16* rot, int e, int f);
 extern void func_ov009_02111224(void* c, int r1);
 extern void* data_0209e650;
 }
@@ -13,9 +16,9 @@ extern "C" void func_ov009_021116ec(char* c)
     if (*(unsigned char*)(c + 0x180)) {
         int n = *(int*)(c + 8) & 0xf;
         if (n > 1) {
-            Vec3_16 rot = *(Vec3_16*)(c + 0x92);
+            Vector3_16 rot = *(Vector3_16*)(c + 0x92);
             for (int i = 0; i < n - 1; i++) {
-                Vec3 pos;
+                Vector3 pos;
                 pos.x = *(int*)(c + 0x5c) + (int)((RandomIntInternal(&data_0209e650) % 400) - 0xa0) * 4096;
                 pos.y = *(int*)(c + 0x60);
                 pos.z = *(int*)(c + 0x64) + (int)((RandomIntInternal(&data_0209e650) % 400) - 0xa0) * 4096;

--- a/src/func_ov009_02111a70.c
+++ b/src/func_ov009_02111a70.c
@@ -1,14 +1,17 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov009_02111a70
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjMcWater_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov009_02111a70(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjMcWater_c;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov009_02111abc.c
+++ b/src/func_ov009_02111abc.c
@@ -1,12 +1,15 @@
-extern void _ZN18TextureTransformerD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov009_02111abc
+// @emits daObjMcWater_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_TextureTransformer.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjMcWater_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov009_02111abc(int *t)
+int *daObjMcWater_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);

--- a/src/func_ov009_02111b1c.cpp
+++ b/src/func_ov009_02111b1c.cpp
@@ -1,15 +1,17 @@
 //cpp
+// @symbol func_ov009_02111b1c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 struct Vector3_16;
 
 extern "C" void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
     unsigned int a, unsigned int b, const Vector3&, const Vector3_16*, int, int);
 
 extern unsigned char data_0209f2d8[];
-extern Vector3 data_ov009_02113de0[];
-extern Vector3 data_ov009_02113e34[];
-extern Vector3 data_ov009_02113d8c[];
 struct D0209caa0 { int a, b, c; };
 extern D0209caa0 data_0209caa0;
 

--- a/src/func_ov009_02111bd4.cpp
+++ b/src/func_ov009_02111bd4.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov009_02111bd4
+// @emits daObjMcWater_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjMcWater_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN13SharedFilePtr7ReleaseEv(void*);
 int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov009_02113c68[];
 extern int data_ov009_02113c70[];
-int func_ov009_02111bd4(char* c){
+int daObjMcWater_c_CleanupResources(char* c){
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c68);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c70);
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))

--- a/src/func_ov009_02111c18.cpp
+++ b/src/func_ov009_02111c18.cpp
@@ -1,5 +1,9 @@
 //cpp
+// @symbol func_ov009_02111c18
+// @emits daObjMcWater_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjMcWater_c::Render - recovered from vtable slot identity */
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int func_ov009_02111c18(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+extern "C" int daObjMcWater_c_Render(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }

--- a/src/func_ov009_02111c4c.cpp
+++ b/src/func_ov009_02111c4c.cpp
@@ -1,11 +1,18 @@
 //cpp
+// @symbol func_ov009_02111c4c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjMcWater_c.h"
+// @emits daObjMcWater_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjMcWater_c::Behavior - recovered from vtable slot identity */
 class Animation {
 public:
 void Advance();
 };
 
-extern "C" int func_ov009_02111c4c(char *r0) {
-*(int *)(r0 + 0x32c) = 0x1000;
+extern "C" int daObjMcWater_c_Behavior(char *r0) {
+    struct daObjMcWater_c *self = (struct daObjMcWater_c *)(void *)r0;
+self->unk_32c = 0x1000;
 ((Animation *)(r0 + 0x320))->Advance();
 return 1;
 }

--- a/src/func_ov009_02111c74.cpp
+++ b/src/func_ov009_02111c74.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov009_02111c74
+// @emits daObjMcWater_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjMcWater_c::InitResources - recovered from vtable slot identity */
 typedef short s16;
 struct SharedFilePtr { int x; }; struct BMD_File; struct BTA_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct DataPtr { int f[2]; };
@@ -22,7 +26,7 @@ extern struct SharedFilePtr data_ov009_02113c70;
 extern struct CLPS_Block data_ov009_02112c38;
 extern int data_0209f32c;
 
-int func_ov009_02111c74(char *self){
+int daObjMcWater_c_InitResources(char *self){
     int b = (int)(data_0209f2d8 == 1);
     if (b == 0) {
         if (*(int*)((char*)&data_0209caa0 + 8) & 0x80000) {

--- a/src/func_ov010_021111a0.c
+++ b/src/func_ov010_021111a0.c
@@ -1,13 +1,16 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov010_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjC1_Trap_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov010_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV14daObjC1_Trap_c;
     _ZN5ModelD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov010_021111ec.c
+++ b/src/func_ov010_021111ec.c
@@ -1,11 +1,14 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov010_021111ec
+// @emits daObjC1_Trap_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjC1_Trap_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov010_021111ec(int *t)
+int *daObjC1_Trap_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0x320);

--- a/src/func_ov010_021113f0.c
+++ b/src/func_ov010_021113f0.c
@@ -1,13 +1,16 @@
+// @symbol func_ov010_021113f0
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short ang);
 extern void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void *self, void *m, short s);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov010_021113f0(char *c) {
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-    *(struct M*)(c+0x370) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x370) = data_020a0e68;
     _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(c+0x124, c+0x370, *(short*)(c+0x8e));
 }

--- a/src/func_ov010_0211146c.c
+++ b/src/func_ov010_0211146c.c
@@ -1,9 +1,12 @@
+// @symbol func_ov010_0211146c
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short ang);
 extern short data_02082214[];
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov010_0211146c(char *c) {
     int a = (int)(*(unsigned short*)(c+0x8e)) >> 4;
     int a2 = a << 1;
@@ -20,5 +23,5 @@ void func_ov010_0211146c(char *c) {
     Matrix4x3_FromTranslation(&data_020a0e68, X, Y, Z);
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-    *(struct M*)(c+0x33c) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x33c) = data_020a0e68;
 }

--- a/src/func_ov010_02111554.cpp
+++ b/src/func_ov010_02111554.cpp
@@ -1,10 +1,13 @@
 //cpp
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern "C" void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov010_02111554
+// @emits daObjC1_Trap_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjC1_Trap_c::CleanupResources - recovered from vtable slot identity */
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern "C" char data_ov025_02112d08[];
-extern "C" char data_ov024_02112d00[];
-extern "C" int func_ov010_02111554(char *self){
+extern "C" int daObjC1_Trap_c_CleanupResources(char *self){
   if(_ZN16MeshColliderBase9IsEnabledEv(self+0x124)){
     _ZN16MeshColliderBase7DisableEv(self+0x124);
   }

--- a/src/func_ov010_021115a8.cpp
+++ b/src/func_ov010_021115a8.cpp
@@ -1,9 +1,16 @@
 //cpp
+// @symbol func_ov010_021115a8
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjC1_Trap_c.h"
+// @emits daObjC1_Trap_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjC1_Trap_c::Render - recovered from vtable slot identity */
 extern "C" {
 struct A { char pad[0x320]; };
 struct B { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual void m5(bool); };
-int func_ov010_021115a8(char* c){
-  if(*(unsigned char*)(c+0x3ab) == 0){
+int daObjC1_Trap_c_Render(char* c){
+    struct daObjC1_Trap_c *self = (struct daObjC1_Trap_c *)(void *)c;
+  if(self->unk_3ab == 0){
     ((B*)(c+0x320))->m5(false);
   }
   return 1;

--- a/src/func_ov010_021115e0.cpp
+++ b/src/func_ov010_021115e0.cpp
@@ -1,12 +1,16 @@
 //cpp
+// @symbol func_ov010_021115e0
+// @emits daObjC1_Trap_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjC1_Trap_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 extern "C" int _ZN5Actor13DistToCPlayerEv(void* a);
 extern "C" void func_ov010_0211146c(void* c);
 extern "C" void func_ov010_021113f0(void* c);
 extern PMF data_ov010_02112d28[];
 
-extern "C" int func_ov010_021115e0(C* c);
-extern "C" int func_ov010_021115e0(C* c)
+extern "C" int daObjC1_Trap_c_Behavior(C* c);
+extern "C" int daObjC1_Trap_c_Behavior(C* c)
 {
     char* p = (char*)c;
     if (*(unsigned char*)(p + 0x3ab)) {

--- a/src/func_ov010_02111654.c
+++ b/src/func_ov010_02111654.c
@@ -1,4 +1,11 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov010_02111654
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "daObjC1_Trap_c.h"
+// @emits daObjC1_Trap_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjC1_Trap_c::InitResources - recovered from vtable slot identity */
 
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct Vector3* v, void* rot, int e, int f);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* p);
@@ -11,15 +18,12 @@ extern void func_020393c4(int* p, int v);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void* p, void* a);
 
 extern short data_02082214[];
-extern void* data_ov010_02112d08;
-extern void* data_ov010_02112d00;
-extern void* data_ov010_021122f8;
-extern int func_ov010_02111984[];
 
-int func_ov010_02111654(char* c)
+int daObjC1_Trap_c_InitResources(char* c)
 {
-    *(unsigned char*)(c + 0x3aa) = 0;
-    *(int*)(c + 0x3ac) = 0;
+    struct daObjC1_Trap_c *self = (struct daObjC1_Trap_c *)(void *)c;
+    self->unk_3aa = 0;
+    self->unk_3ac = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 0xff) {
         struct Vector3 v;
@@ -28,37 +32,37 @@ int func_ov010_02111654(char* c)
         int x, y, z;
         void* sp;
 
-        *(unsigned char*)(c + 0x3ab) = 1;
-        *(int*)(c + 0x3a4) = 0;
+        self->unk_3ab = 1;
+        self->unk_3a4 = 0;
 
-        idx = ((int)(*(unsigned short*)(c + 0x8e)) >> 4) * 2;
+        idx = ((int)(self->unk_08e) >> 4) * 2;
         sx = data_02082214[idx + 1];
         sz = data_02082214[idx];
-        z = *(int*)(c + 0x64) + sz * 0x15d;
-        x = *(int*)(c + 0x5c) - sx * 0x15d;
-        y = *(int*)(c + 0x60);
+        z = self->unk_064 + sz * 0x15d;
+        x = self->unk_05c - sx * 0x15d;
+        y = self->unk_060;
         v.x = x;
         v.y = y;
         v.z = z;
-        sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x24, 0, &v, c + 0x8c, *(signed char*)(c + 0xcc), -1);
+        sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x24, 0, &v, c + 0x8c, self->unk_0cc, -1);
         *(int*)((char*)sp + 0x3ac) = *(int*)(c + 4);
 
-        idx = ((int)(*(unsigned short*)(c + 0x8e)) >> 4) * 2;
+        idx = ((int)(self->unk_08e) >> 4) * 2;
         sz = data_02082214[idx];
         sx = data_02082214[idx + 1];
-        z = *(int*)(c + 0x64) - sz * 0x15d;
-        x = sx * 0x15d + *(int*)(c + 0x5c);
-        y = *(int*)(c + 0x60);
+        z = self->unk_064 - sz * 0x15d;
+        x = sx * 0x15d + self->unk_05c;
+        y = self->unk_060;
         v.x = x;
         v.y = y;
         v.z = z;
-        sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x24, 1, &v, c + 0x8c, *(signed char*)(c + 0xcc), -1);
+        sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x24, 1, &v, c + 0x8c, self->unk_0cc, -1);
         *(int*)((char*)sp + 0x3ac) = *(int*)(c + 4);
 
         return 1;
     }
 
-    *(unsigned char*)(c + 0x3ab) = 0;
+    self->unk_3ab = 0;
     {
         void* f = _ZN5Model8LoadFileER13SharedFilePtr(&data_ov010_02112d08);
         _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0x320, f, 1, -1);
@@ -67,12 +71,12 @@ int func_ov010_02111654(char* c)
     func_ov010_021113f0(c);
     {
         void* f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov010_02112d00);
-        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x124, f, c + 0x370, 0x1000, *(short*)(c + 0x8e), &data_ov010_021122f8);
+        _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x124, f, c + 0x370, 0x1000, self->unk_08e, &data_ov010_021122f8);
     }
     func_020393c4((int*)(c + 0x124), (int)func_ov010_02111984);
     _ZN16MeshColliderBase6EnableEP5Actor(c + 0x124, c);
-    *(unsigned short*)(c + 0x3a8) = 0;
-    *(int*)(c + 0x3a0) = 0;
+    self->unk_3a8 = 0;
+    self->unk_3a0 = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 1) {
         short* pa = (short*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);

--- a/src/func_ov010_0211184c.c
+++ b/src/func_ov010_0211184c.c
@@ -1,13 +1,15 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov010_0211184c
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern short Vec3_HorzAngle(const struct V3* v0, const struct V3* v1);
-extern int Vec3_HorzDist(const struct V3* a, const struct V3* b);
+extern short Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
+extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern short data_02082214[];
 void func_ov010_0211184c(char* c, char* arg2) {
     char* target;
     unsigned int id;
-    struct V3 va, vt;
-    struct V3 *sa, *st;
+    struct Vector3 va, vt;
+    struct Vector3 *sa, *st;
     short ang;
     short ang2;
     int dist;
@@ -23,8 +25,8 @@ void func_ov010_0211184c(char* c, char* arg2) {
     if (target == 0) return;
     b = (int)(*(unsigned short*)(arg2+0xc) == 0xbf);
     if (b == 0) return;
-    sa = (struct V3*)(((int)arg2 + 0x5c) & 0xFFFFFFFFFFFFFFFF);
-    st = (struct V3*)(((int)target + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    sa = (struct Vector3*)(((int)arg2 + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    st = (struct Vector3*)(((int)target + 0x5c) & 0xFFFFFFFFFFFFFFFF);
     va.x = sa->x;
     va.y = sa->y;
     va.z = sa->z;

--- a/src/func_ov012_021111a0.c
+++ b/src/func_ov012_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov012_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjC0_Switch_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov012_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjC0_Switch_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov012_021111e4.c
+++ b/src/func_ov012_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov012_021111e4
+// @emits daObjC0_Switch_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjC0_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov012_021111e4(int *t)
+int *daObjC0_Switch_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov012_0211123c.c
+++ b/src/func_ov012_0211123c.c
@@ -1,12 +1,16 @@
+// @symbol func_ov012_0211123c
+// @emits daObjC0_Switch_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjC0_Switch_c::OnGroundPounded - recovered from vtable slot identity */
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(char* t);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char* t);
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
 extern int data_0209caa0[];
-void func_ov012_0211123c(char* c) {
+void daObjC0_Switch_c_OnGroundPounded(char* c) {
     int* q;
     char* p;
     if (*(unsigned char*)(c+0x31e)) return;
-    q = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    q = (int*)(((long long)(int)(c + 0x60)));
     *q -= 0x64000;
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov012_021112ec.c
+++ b/src/func_ov012_021112ec.c
@@ -1,8 +1,12 @@
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov012_021112ec
+// @emits daObjC0_Switch_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjC0_Switch_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov012_021112ec(void *t)
+int daObjC0_Switch_c_CleanupResources(void *t)
 {
     _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     _ZN13SharedFilePtr7ReleaseEv(G0);

--- a/src/func_ov012_02111324.cpp
+++ b/src/func_ov012_02111324.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov012_02111324
+// @emits daObjC0_Switch_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjC0_Switch_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov012_02111324(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjC0_Switch_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov012_0211134c.cpp
+++ b/src/func_ov012_0211134c.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov012_0211134c
+// @emits daObjC0_Switch_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjC0_Switch_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int func_ov012_0211134c(void *c) {
+extern "C" int daObjC0_Switch_c_Behavior(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov012_02111370.c
+++ b/src/func_ov012_02111370.c
@@ -1,3 +1,9 @@
+// @symbol func_ov012_02111370
+// @emits daObjC0_Switch_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjC0_Switch_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -5,18 +11,15 @@ extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
-extern int data_ov012_021124a8[];
 extern int data_0209caa0[];
-extern int data_ov012_021124a0[];
-extern int data_ov012_02111cd0[];
 
-int func_ov012_02111370(char* c){
+int daObjC0_Switch_c_InitResources(char* c){
   void* mdl;
   void* kcl;
   mdl = _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124a8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, mdl, 1, -1);
   if(data_0209caa0[2] & 0x80000){
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x64000;
+    *(int*)(((long long)(int)(c + 0x60))) -= 0x64000;
     *(char*)(c+0x31e) = 1;
   }
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov013_021111d0.c
+++ b/src/func_ov013_021111d0.c
@@ -1,9 +1,13 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov013_021111d0
+// @emits daObjClockHuriko_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjClockHuriko_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov013_021111d0(int *t)
+int *daObjClockHuriko_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov013_02111214.c
+++ b/src/func_ov013_02111214.c
@@ -1,6 +1,10 @@
+// @symbol func_ov013_02111214
+// @emits daObjClockHuriko_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjClockHuriko_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int func_ov013_02111214(void)
+int daObjClockHuriko_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     return 1;

--- a/src/func_ov013_02111280.cpp
+++ b/src/func_ov013_02111280.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov013_02111280
+// @emits daObjClockHuriko_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjClockHuriko_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov013_02111280(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjClockHuriko_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov013_021112a8.c
+++ b/src/func_ov013_021112a8.c
@@ -1,8 +1,12 @@
+// @symbol func_ov013_021112a8
+// @emits daObjClockHuriko_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjClockHuriko_c::Behavior - recovered from vtable slot identity */
 void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void*);
 void func_ov013_02111238(char* t);
 extern signed char data_02092110[];
 
-int func_ov013_021112a8(char* c)
+int daObjClockHuriko_c_Behavior(char* c)
 {
     if (data_02092110[0] <= 0) {
         short* p90 = (short*)(c + 0x90);

--- a/src/func_ov013_0211133c.cpp
+++ b/src/func_ov013_0211133c.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol func_ov013_0211133c
+// @emits daObjClockHuriko_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjClockHuriko_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
-extern void data_ov054_02111238(void*);
 extern int __sinit_ov045_02112280[];
-int func_ov013_0211133c(char *c){
+int daObjClockHuriko_c_InitResources(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)__sinit_ov045_02112280);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   data_ov054_02111238(c);

--- a/src/func_ov014_021115ec.cpp
+++ b/src/func_ov014_021115ec.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov014_021115ec
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int s32;
-struct Vector3 { s32 x, y, z; };
+
 extern "C" {
     void _ZN5Sound15PlaySecretSoundEP5ActorPt(void *actor, u16 *snd);
     void *_ZN5Actor10FindWithIDEj(unsigned id);
@@ -28,7 +31,7 @@ extern "C" {
     extern void *data_ov014_02114980[];
 }
 static inline void inc604(u8 *self) {
-    u8 *p = (u8 *)(((long long)(int)(self + 0x604)) & 0xFFFFFFFFFFFFFFFFLL);
+    u8 *p = (u8 *)(((long long)(int)(self + 0x604)));
     *p = (u8)(*p + 1);
 }
 extern "C" void func_ov014_021115ec(u8 *self)
@@ -38,7 +41,7 @@ extern "C" void func_ov014_021115ec(u8 *self)
     _ZN5Sound15PlaySecretSoundEP5ActorPt(self, (u16 *)(self + 0x5fe));
     r4 = (u8 *)_ZN5Actor10FindWithIDEj(*(unsigned *)(self + 0x60c));
     {
-        s32 *src = (s32 *)(((long long)(int)(r4 + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        s32 *src = (s32 *)(((long long)(int)(r4 + 0x5c)));
         s32 fifth = 0x80;
         sp4.x = src[0];
         void *ap = self + 0x8c;
@@ -140,7 +143,7 @@ extern "C" void func_ov014_021115ec(u8 *self)
     case 8:
         if (DecIfAbove0_Short(self + 0x5fc) == 0) {
             {
-                unsigned *flag = (unsigned *)(((long long)(int)(r8 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned *flag = (unsigned *)(((long long)(int)(r8 + 0x154)));
                 *flag &= ~8u;
             }
             if (_ZN6Player12Unk_020ca150Eh(_ZN5Actor13ClosestPlayerEv(self), 4) != 0) {

--- a/src/func_ov014_02111fe0.c
+++ b/src/func_ov014_02111fe0.c
@@ -1,24 +1,27 @@
+// @symbol func_ov014_02111fe0
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef long long s64;
-struct Vec3 { Fix12i x, y, z; };
 
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern int LenVec3(struct Vec3* v);
+
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern int LenVec3(struct Vector3* v);
 extern int _ZN4cstd4fdivEii(int a, int b);
-extern void Vec3_Add(struct Vec3* out, struct Vec3* a, struct Vec3* b);
+extern void Vec3_Add(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 
 void func_ov014_02111fe0(char* c){
-    struct Vec3 v;
-    struct Vec3 out;
+    struct Vector3 v;
+    struct Vector3 out;
     int len, lim;
-    Vec3_Sub(&v, (struct Vec3*)(c + 0x5c), (struct Vec3*)(c + 0x5ec));
+    Vec3_Sub(&v, (struct Vector3*)(c + 0x5c), (struct Vector3*)(c + 0x5ec));
     len = LenVec3(&v);
     lim = *(int*)(c + 0x5f8) * 7 + 0xc8000;
     if (len <= lim) return;
     v.x = (int)(((s64)v.x * _ZN4cstd4fdivEii(lim, len) + 0x800) >> 12);
     v.y = (int)(((s64)v.y * _ZN4cstd4fdivEii(lim, len) + 0x800) >> 12);
     v.z = (int)(((s64)v.z * _ZN4cstd4fdivEii(lim, len) + 0x800) >> 12);
-    Vec3_Add(&out, (struct Vec3*)(c + 0x5ec), &v);
+    Vec3_Add(&out, (struct Vector3*)(c + 0x5ec), &v);
     *(int*)(c + 0x5c) = out.x;
     *(int*)(c + 0x60) = out.y;
     *(int*)(c + 0x64) = out.z;

--- a/src/func_ov014_02112788.c
+++ b/src/func_ov014_02112788.c
@@ -1,13 +1,17 @@
+// @symbol func_ov014_02112788
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
-extern void Matrix4x3_FromRotationXYZExt(void *m, int x, int y, int z);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, Fix12 a, Fix12 b, unsigned int g);
 
-struct M48 { int w[12]; };
-extern const struct M48 data_02082128;
+
+extern const struct Matrix4x3 data_02082128;
 
 void func_ov014_02112788(char* c) {
-    struct M48 tmp;
+    struct Matrix4x3 tmp;
     int i;
     int t;
     char* m;
@@ -32,7 +36,7 @@ void func_ov014_02112788(char* c) {
     e = c;
     o = c;
     for (; i < 7; i++) {
-        *(struct M48*)(m+0x1c) = tmp;
+        *(struct Matrix4x3*)(m+0x1c) = tmp;
         *(int*)(o+0x21c) = *(int*)(e+0x524) >> 3;
         *(int*)(o+0x220) = *(int*)(e+0x528) >> 3;
         *(int*)(o+0x224) = *(int*)(e+0x52c) >> 3;

--- a/src/func_ov014_02112ea8.cpp
+++ b/src/func_ov014_02112ea8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov014_02112ea8
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 struct Sound { static void PlayBank3(unsigned int id, const Vector3 &v); };
 namespace Particle { struct System { static void *NewSimple(unsigned int t, Fix12 x, Fix12 y, Fix12 z); }; }
 struct MeshColliderBase { int pad; int IsEnabled(); void Disable(); };

--- a/src/func_ov015_021111a0.c
+++ b/src/func_ov015_021111a0.c
@@ -1,9 +1,13 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov015_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjBkBillboard_c */
 int *func_ov015_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV18daObjBkBillboard_c;
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov015_021111d0.c
+++ b/src/func_ov015_021111d0.c
@@ -1,9 +1,13 @@
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov015_021111d0
+// @emits daObjBkBillboard_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjBkBillboard_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov015_021111d0(int *t)
+int *daObjBkBillboard_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov015_02111254.c
+++ b/src/func_ov015_02111254.c
@@ -1,6 +1,10 @@
+// @symbol func_ov015_02111254
+// @emits daObjBkBillboard_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjBkBillboard_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int func_ov015_02111254(void)
+int daObjBkBillboard_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     return 1;

--- a/src/func_ov015_02111278.cpp
+++ b/src/func_ov015_02111278.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov015_02111278
+// @emits daObjBkBillboard_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjBkBillboard_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov015_02111278(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjBkBillboard_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov015_021112a0.cpp
+++ b/src/func_ov015_021112a0.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov015_021112a0
+// @emits daObjBkBillboard_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBkBillboard_c::InitResources - recovered from vtable slot identity */
 struct BMD_File;
 struct SharedFilePtr;
 
@@ -10,10 +16,8 @@ struct ModelBase {
     void SetFile(BMD_File *, int, int);
 };
 
-extern int data_ov015_02114960;
-extern "C" void func_ov015_02111214(char *t);
 
-extern "C" int func_ov015_021112a0(char *c) {
+extern "C" int daObjBkBillboard_c_InitResources(char *c) {
     BMD_File *file = Model::LoadFile(*(SharedFilePtr *)&data_ov015_02114960);
     ((ModelBase *)(c + 0xd4))->SetFile(file, 1, -1);
     func_ov015_02111214(c);

--- a/src/func_ov015_021113c0.cpp
+++ b/src/func_ov015_021113c0.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov015_021113c0
+// @emits PoleBillboard_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjBk_Botaosi_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Player {
     void IncMegaKillCount();
 };
 
-extern "C" void func_ov015_021113c0(char *c, void *arg) {
+extern "C" void PoleBillboard_OnHitByMegaChar(char *c, void *arg) {
     unsigned char v = *(unsigned char *)(c + 0x397);
     if (v >= 2) return;
     ((Player *)arg)->IncMegaKillCount();

--- a/src/func_ov015_021113fc.c
+++ b/src/func_ov015_021113fc.c
@@ -1,8 +1,13 @@
-/* func_ov015_021113fc @ 0x21113fc (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
+// @symbol func_ov015_021113fc
+// @emits PoleBillboard_OnKicked
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBk_Botaosi_c::OnKicked - recovered from vtable slot identity */
+/* PoleBillboard_OnKicked @ 0x21113fc (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
  * ldr ip, [pc]; bx ip; .word 0x2111414
  */
-extern void func_ov015_02111414(void);
 
-void func_ov015_021113fc(void) {
+void PoleBillboard_OnKicked(void) {
     func_ov015_02111414();
 }

--- a/src/func_ov015_02111408.c
+++ b/src/func_ov015_02111408.c
@@ -1,8 +1,13 @@
-/* func_ov015_02111408 @ 0x2111408 (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
+// @symbol func_ov015_02111408
+// @emits PoleBillboard_OnAttacked2
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBk_Botaosi_c::OnAttacked2 - recovered from vtable slot identity */
+/* PoleBillboard_OnAttacked2 @ 0x2111408 (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
  * ldr ip, [pc]; bx ip; .word 0x2111414
  */
-extern void func_ov015_02111414(void);
 
-void func_ov015_02111408(void) {
+void PoleBillboard_OnAttacked2(void) {
     func_ov015_02111414();
 }

--- a/src/func_ov015_02111c3c.cpp
+++ b/src/func_ov015_02111c3c.cpp
@@ -1,5 +1,9 @@
 //cpp
-// func_ov015_02111c3c at 0x02111c3c
+// @symbol func_ov015_02111c3c
+// @emits KnockDownPlank_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjBk_Dossunbar_c::Kill - recovered from vtable slot identity */
+// KnockDownPlank_Kill at 0x02111c3c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov015).
 struct Vector3 { int x, y, z; };
 
@@ -10,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 void _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" void func_ov015_02111c3c(char* self);
-void func_ov015_02111c3c(char* self) {
+extern "C" void KnockDownPlank_Kill(char* self);
+void KnockDownPlank_Kill(char* self) {
     Vector3 vec;
     Vector3 vec2;
     vec.x = *(int*)(self + 0x5c);

--- a/src/func_ov015_02111cb8.cpp
+++ b/src/func_ov015_02111cb8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov015_02111cb8
+// @emits KnockDownPlank_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjBk_Dossunbar_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov015_02111cb8(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void KnockDownPlank_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov015_02111d28.c
+++ b/src/func_ov015_02111d28.c
@@ -1,6 +1,11 @@
-extern void func_02012664(int a, void *b);
+// @symbol func_ov015_02111d28
+// @emits PoleBillboard_AfterClsn
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBk_Botaosi_c::AfterClsn - recovered from vtable slot identity */
 
-void func_ov015_02111d28(char *self) {
+void PoleBillboard_AfterClsn(char *self) {
     *(int *)(self + 0xa4) = -0x14000;
     func_02012664(0xc3, self + 0x74);
 }

--- a/src/func_ov015_0211233c.cpp
+++ b/src/func_ov015_0211233c.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov015_0211233c
+// @emits MovingBarSmall_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjBk_Lift_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void *self, void *v);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void *);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *);
 struct Vector3 { int x, y, z; };
-void func_ov015_0211233c(char *c)
+void MovingBarSmall_Kill(char *c)
 {
     struct Vector3 v;
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x48, *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));

--- a/src/func_ov015_021123a0.cpp
+++ b/src/func_ov015_021123a0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov015_021123a0
+// @emits MovingBarSmall_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjBk_Lift_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov015_021123a0(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void MovingBarSmall_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov015_021123c8.cpp
+++ b/src/func_ov015_021123c8.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov015_021123c8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void*,void*,void*,int,int,int,unsigned int);
-struct M4x3 { int w[12]; };
+
 void func_ov015_021123c8(char* c){
-  *(struct M4x3*)(c+0x348) = *(struct M4x3*)(c+0xf0);
+  *(struct Matrix4x3*)(c+0x348) = *(struct Matrix4x3*)(c+0xf0);
   *(int*)(c+0x36c) = (*(int*)(c+0x5c) - *(int*)(c+0x384)) >> 3;
   *(int*)(c+0x370) = *(int*)(c+0x378) >> 3;
   *(int*)(c+0x374) = (*(int*)(c+0x64) - *(int*)(c+0x388)) >> 3;

--- a/src/func_ov015_02112bd0.c
+++ b/src/func_ov015_02112bd0.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov015_02112bd0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjBk_Ukisima_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov015_02112bd0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjBk_Ukisima_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov015_02112c20.c
+++ b/src/func_ov015_02112c20.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov015_02112c20
+// @emits daObjBk_Ukisima_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjBk_Ukisima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov015_02112c20(int *t)
+int *daObjBk_Ukisima_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov015_02112c84.c
+++ b/src/func_ov015_02112c84.c
@@ -1,11 +1,16 @@
+// @symbol func_ov015_02112c84
+// @emits daObjBk_Ukisima_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBk_Ukisima_c::CleanupResources - recovered from vtable slot identity */
 // Cross-overlay tail-call veneer. #pragma long_calls forces mwccarm to emit the pooled
 // `ldr ip,[pc]; bx ip` indirect tail-call (a plain near `b` otherwise) that the ROM uses
 // to reach another overlay. Loads the data pointer into r1; this stays in r0.
 #pragma long_calls on
-extern int func_020b66a8(void *thisp, void *data);
 extern char data_ov015_021147a4[];
 
-int func_ov015_02112c84(void *thisp)
+int daObjBk_Ukisima_c_CleanupResources(void *thisp)
 {
     return func_020b66a8(thisp, data_ov015_021147a4);
 }

--- a/src/func_ov015_02112c98.c
+++ b/src/func_ov015_02112c98.c
@@ -1,10 +1,15 @@
+// @symbol func_ov015_02112c98
+// @emits daObjBk_Ukisima_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBk_Ukisima_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b676c(unsigned char *self, struct Arg *a, short arg2);
-extern short data_ov015_02114794;
 extern struct Arg data_ov015_021147a4;
 
-int func_ov015_02112c98(unsigned char *self)
+int daObjBk_Ukisima_c_InitResources(unsigned char *self)
 {
     return func_ov002_020b676c(self, &data_ov015_021147a4, data_ov015_02114794);
 }

--- a/src/func_ov016_02111284.c
+++ b/src/func_ov016_02111284.c
@@ -1,7 +1,10 @@
+// @symbol func_ov016_02111284
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 
-struct Vector3 { int x, y, z; };
+
 
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* in, void* m, void* out);
@@ -12,7 +15,7 @@ extern unsigned char data_0209f220;
 extern int data_ov016_02114dbc;
 extern int data_020a0e68[];
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
 
 void func_ov016_02111284(char* c)
 {

--- a/src/func_ov016_021115c0.c
+++ b/src/func_ov016_021115c0.c
@@ -1,8 +1,12 @@
+// @symbol func_ov016_021115c0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN7PathPtrC1Ev(void* self);
 extern void _ZN7PathPtr6FromIDEj(void* self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, void* out, unsigned int idx);
 extern short Vec3_HorzAngle(const void* a, const void* b);
-extern int AngleDiff(int a, int b);
 extern void _Z14ApproachLinearRsss(short* p, short a, short b);
 extern short Vec3_VertAngle(const void* a, const void* b);
 extern void Vec3_Sub(void* out, void* a, void* b);
@@ -13,18 +17,17 @@ extern void Vec3_MulScalar(void* out, void* v, int s);
 extern void SubVec3(void* a, void* b, void* c);
 extern void func_02012694(int a, void* p);
 
-extern char data_ov016_02114d7c;
 
-struct Vec3 { int x, y, z; };
 
-#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+
+#define LA(p) ((void*)(unsigned long)(((long long)(int)(unsigned long)(p))))
 
 int func_ov016_021115c0(char* c)
 {
     char pp[8];
-    struct Vec3 node;
-    struct Vec3 diff;
-    struct Vec3 scaled;
+    struct Vector3 node;
+    struct Vector3 diff;
+    struct Vector3 scaled;
     int len;
     short ha;
 

--- a/src/func_ov016_02111758.cpp
+++ b/src/func_ov016_02111758.cpp
@@ -1,16 +1,18 @@
 //cpp
+// @symbol func_ov016_02111758
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Matrix4x3 { int m[12]; };
-typedef struct { int x, y, z; } Vector3;
+
 extern void Matrix4x3_FromRotationY(struct Matrix4x3 *m, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *m, short angX);
 extern void MulVec3Mat4x3(const Vector3 *v, const struct Matrix4x3 *m, Vector3 *out);
 extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(Vector3 *cur, const Vector3 *tgt, int step);
 extern int _ZN9Animation8FinishedEv(void *self);
-extern int func_ov018_02111bf0(void *self, void *arg);
 extern unsigned char data_0209f220;
 extern struct Matrix4x3 data_020a0e68;
-extern void *data_ov016_02114dac;
 
 int func_ov016_02111758(char *c) {
     Vector3 in;

--- a/src/func_ov016_021118b4.cpp
+++ b/src/func_ov016_021118b4.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol func_ov016_021118b4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Matrix4x3 { int m[12]; };
-typedef struct { int x, y, z; } Vector3;
+
 extern void Matrix4x3_FromRotationY(struct Matrix4x3 *m, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *m, short angX);
 extern void MulVec3Mat4x3(const Vector3 *v, const struct Matrix4x3 *m, Vector3 *out);
 extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(Vector3 *cur, const Vector3 *tgt, int step);
 extern int Vec3_Dist(const Vector3 *a, const Vector3 *b);
 extern int func_02012694(unsigned int id, void *pos);
-extern int func_ov018_02111bf0(void *self, void *arg);
 extern struct Matrix4x3 data_020a0e68;
 extern void *data_ov016_02114dbc;
 

--- a/src/func_ov016_021119ec.c
+++ b/src/func_ov016_021119ec.c
@@ -1,6 +1,11 @@
+// @symbol func_ov016_021119ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct Vector3 { int x, y, z; };
+
 
 extern int Vec3_Dist(const void* a, const void* b);
 extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(void* pos, const void* target, int step);
@@ -9,16 +14,14 @@ extern void Matrix4x3_FromRotationY(void* m, int ang);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, int ang);
 extern void MulVec3Mat4x3(const void* in, const void* m, void* out);
 extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void* self);
-extern int AngleDiff(int a, int b);
 extern int Vec3_HorzDist(const void* a, const void* b);
 extern void func_ov016_02111bf0(void* self, void* state);
 
 extern unsigned char data_0209f220;
 extern int data_020a0e68[];
-extern void* data_ov016_02114d9c;
 
 #pragma opt_propagation off
-#define LA(p) ((int*)(unsigned long)(((long long)(int)(unsigned long)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int*)(unsigned long)(((long long)(int)(unsigned long)(p))))
 
 int func_ov016_021119ec(char* c)
 {

--- a/src/func_ov016_02112a00.c
+++ b/src/func_ov016_02112a00.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov016_02112a00
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjKi_Hasira_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov016_02112a00(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjKi_Hasira_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov016_02112a44.c
+++ b/src/func_ov016_02112a44.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov016_02112a44
+// @emits daObjKi_Hasira_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKi_Hasira_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov016_02112a44(int *t)
+int *daObjKi_Hasira_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov016_02112ae4.c
+++ b/src/func_ov016_02112ae4.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov016_02112ae4
+// @emits daObjKi_Hasira_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKi_Hasira_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov016_02112ae4(void *t)
+int daObjKi_Hasira_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov016_02112b28.cpp
+++ b/src/func_ov016_02112b28.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov016_02112b28
+// @emits daObjKi_Hasira_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjKi_Hasira_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov016_02112b28(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjKi_Hasira_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }


### PR DESCRIPTION
Batch 11 of the readable-tree migration. Promotes 188 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 130 VERIFIED, 58 BLIND, 0 WRONG/NO-REPRO. 2 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
