### PR TITLE
readable: batch 12 - promote 190 files to readable form

### DIFF
--- a/src/func_ov016_02112e1c.c
+++ b/src/func_ov016_02112e1c.c
@@ -1,3 +1,11 @@
+// @symbol func_ov016_02112e1c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjKi_Hasira_c.h"
+// @emits daObjKi_Hasira_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKi_Hasira_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -6,11 +14,9 @@ extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, void*, void*, int, int);
-extern char data_ov016_02114e24[];
-extern char data_ov016_02114e1c[];
-extern char data_ov016_02113cac[];
 
-int func_ov016_02112e1c(char* c) {
+int daObjKi_Hasira_c_InitResources(char* c) {
+    struct daObjKi_Hasira_c *self = (struct daObjKi_Hasira_c *)(void *)c;
   void* mdl;
   void* kcl;
   mdl = _ZN5Model8LoadFileER13SharedFilePtr(data_ov016_02114e24);
@@ -18,7 +24,7 @@ int func_ov016_02112e1c(char* c) {
   func_ov016_02112a9c(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   kcl = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov016_02114e1c);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, kcl, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov016_02113cac);
-  _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x3b, 0, c+0x5c, 0, *(signed char*)(c+0xcc), -1);
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, kcl, c+0x2ec, 0x199, self->unk_08e, data_ov016_02113cac);
+  _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x3b, 0, c+0x5c, 0, self->unk_0cc, -1);
   return 1;
 }

--- a/src/func_ov016_02112ef4.c
+++ b/src/func_ov016_02112ef4.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov016_02112ef4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjKi_Ita_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov016_02112ef4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjKi_Ita_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov016_02112f44.c
+++ b/src/func_ov016_02112f44.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov016_02112f44
+// @emits daObjKi_Ita_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKi_Ita_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov016_02112f44(int *t)
+int *daObjKi_Ita_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov016_02112fa8.c
+++ b/src/func_ov016_02112fa8.c
@@ -1,7 +1,11 @@
-extern int func_020b5e58(void *self, void *arg);
-extern char data_ov016_02114b8c;
+// @symbol func_ov016_02112fa8
+// @emits daObjKi_Ita_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKi_Ita_c::InitResources - recovered from vtable slot identity */
 
-int func_ov016_02112fa8(void *self)
+int daObjKi_Ita_c_InitResources(void *self)
 {
     return func_020b5e58(self, &data_ov016_02114b8c);
 }

--- a/src/func_ov018_021111a0.c
+++ b/src/func_ov018_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov018_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjSm_Lift_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov018_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjSm_Lift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov018_021111e4.c
+++ b/src/func_ov018_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov018_021111e4
+// @emits daObjSm_Lift_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjSm_Lift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov018_021111e4(int *t)
+int *daObjSm_Lift_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov018_0211123c.cpp
+++ b/src/func_ov018_0211123c.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov018_0211123c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjSm_Lift_c.h"
+// @emits daObjSm_Lift_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjSm_Lift_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Player {
     void IncMegaKillCount();
 };
@@ -7,9 +13,10 @@ struct Platform {
     void KillByMegaChar(Player &);
 };
 
-extern "C" void func_ov018_0211123c(char *c, void *p) {
+extern "C" void daObjSm_Lift_c_OnHitByMegaChar(char *c, void *p) {
+    struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
     ((Player *)p)->IncMegaKillCount();
     ((Platform *)c)->KillByMegaChar(*(Player *)p);
-    short val = *(short *)(c + 0x94);
-    *(short *)(c + 0x8e) = val + 0x4000;
+    short val = self->unk_094;
+    self->unk_08e = val + 0x4000;
 }

--- a/src/func_ov018_02111278.cpp
+++ b/src/func_ov018_02111278.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov018_02111278
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x,y,z; };
-struct Matrix4x3 { int m[12]; };
+
+
 void Vec3_Asr(struct Vector3* d, struct Vector3* s, int n);
 void Matrix4x3_FromTranslation(struct Matrix4x3* mF, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3* mF, short angY);

--- a/src/func_ov018_021112fc.c
+++ b/src/func_ov018_021112fc.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov018_021112fc
+// @emits daObjSm_Lift_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjSm_Lift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov018_021112fc(void *t)
+int daObjSm_Lift_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov018_02111340.cpp
+++ b/src/func_ov018_02111340.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov018_02111340
+// @emits daObjSm_Lift_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjSm_Lift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov018_02111340(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjSm_Lift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov018_02111b3c.c
+++ b/src/func_ov018_02111b3c.c
@@ -1,8 +1,12 @@
+// @symbol func_ov018_02111b3c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
+
 extern char* _ZN5Actor13ClosestPlayerEv(void);
 extern int Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
-extern void func_ov018_021123d0(char* c, int i);
 
 void func_ov018_02111b3c(char* c) {
   char* p = _ZN5Actor13ClosestPlayerEv();

--- a/src/func_ov018_02111d28.cpp
+++ b/src/func_ov018_02111d28.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Matrix4x3 { int m[12]; };
+// @symbol func_ov018_02111d28
+/* recovered: shared common types */
+#include "common.h"
+
 struct ShadowModel;
 struct Actor {
     void DropShadowRadHeight(ShadowModel &sm, Matrix4x3 &mf, int c, int d, unsigned int e);

--- a/src/func_ov018_021122ec.c
+++ b/src/func_ov018_021122ec.c
@@ -1,13 +1,21 @@
+// @symbol func_ov018_021122ec
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjSm_Lift_c.h"
+// @emits daObjSm_Lift_c_AfterClsn
+/* recovered: renamed to Class_Method */
+/* daObjSm_Lift_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
 extern int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
-extern int data_ov027_02113bf0[];
 extern int func_ov030_02113be8[];
-int func_ov018_021122ec(char* c){
+int daObjSm_Lift_c_AfterClsn(char* c){
+    struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c+0xd4, data_ov027_02113bf0[1], 0, 0x1000, 0);
-  *(int*)(c+0x130)=0x1000;
+  self->unk_130=0x1000;
   _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj((char*)c+0x138, func_ov030_02113be8[1], 0, 0x1000, 0);
-  *(int*)(c+0x98)=0;
-  *(int*)(c+0x374)=0;
-  *(int*)(c+0x37c)=0;
+  self->unk_098=0;
+  self->unk_374=0;
+  self->unk_37c=0;
   return 1;
 }

--- a/src/func_ov018_021126f8.c
+++ b/src/func_ov018_021126f8.c
@@ -1,8 +1,11 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov018_021126f8(int *t)
+// @symbol func_ov018_021126f8
+// @emits daSCre_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daSCre_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *daSCre_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov018_02112730.cpp
+++ b/src/func_ov018_02112730.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov018_02112730
+// @emits daSCre_c_Behavior
+/* recovered: shared common types, renamed to Class_Method */
+/* daSCre_c::Behavior - recovered from vtable slot identity */
 struct Vector3 { int x,y,z; };
 struct Vector3_16 { short x,y,z; };
 struct Actor {
@@ -6,7 +10,7 @@ struct Actor {
   static int Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
   void MarkForDestruction();
 };
-extern "C" int func_ov018_02112730(Actor* c){
+extern "C" int daSCre_c_Behavior(Actor* c){
   if (c->DistToCPlayer() < 0x64000) {
     Actor::Spawn(0xb2, (*(int*)((char*)c+8) & 0xf) | 0x40, *(Vector3*)((char*)c+0x5c), 0, *(signed char*)((char*)c+0xcc), -1);
   }

--- a/src/func_ov018_02112858.cpp
+++ b/src/func_ov018_02112858.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov018_02112858
+// @emits IceSheet_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjIceBoard_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov018_02112858(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void IceSheet_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov018_02112880.cpp
+++ b/src/func_ov018_02112880.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov018_02112880
+// @emits IceSheet_Kill
+/* recovered: renamed to Class_Method */
+/* daObjIceBoard_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned, void*);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
-void func_ov018_02112880(char* c){
+void IceSheet_Kill(char* c){
   _ZN5Sound9PlayBank3EjRK7Vector3(0x41, c+0x74);
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x74, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x75, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));

--- a/src/func_ov018_021128e0.cpp
+++ b/src/func_ov018_021128e0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov018_021128e0
+// @emits IceSheet_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjIceBoard_c::OnGroundPounded - recovered from vtable slot identity */
 struct C {
   virtual void p00(); virtual void p01(); virtual void p02(); virtual void p03();
   virtual void p04(); virtual void p05(); virtual void p06(); virtual void p07();
@@ -10,7 +14,7 @@ struct C {
   virtual void p28(); virtual void p29(); virtual void p30(); virtual void f7c();
 };
 struct A { char pad[8]; int kind; };
-extern "C" void func_ov018_021128e0(C *c, A *a){
+extern "C" void IceSheet_OnGroundPounded(C *c, A *a){
   if(a == 0) return;
   if(a->kind != 2) return;
   c->f7c();

--- a/src/func_ov019_0211127c.cpp
+++ b/src/func_ov019_0211127c.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov019_0211127c
+/* recovered: shared common types */
+#include "common.h"
+
 typedef int Fix12i;
 
 struct PathPtr {

--- a/src/func_ov019_0211131c.c
+++ b/src/func_ov019_0211131c.c
@@ -1,8 +1,11 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov019_0211131c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_PathPtr.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _Z11UpdateAngleRssis(short* a, short b, int n, short s);
-extern int _ZNK7PathPtr8NumNodesEv(void* p);
-extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* p, struct Vec3* v, unsigned int i);
-extern short Vec3_HorzAngle(struct Vec3* a, struct Vec3* b);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* p, struct Vector3* v, unsigned int i);
+extern short Vec3_HorzAngle(struct Vector3* a, struct Vector3* b);
 
 int func_ov019_0211131c(char* c) {
     _Z11UpdateAngleRssis(
@@ -13,9 +16,9 @@ int func_ov019_0211131c(char* c) {
     if (n >= _ZNK7PathPtr8NumNodesEv(c + 0x364) - 2) {
         *(short*)(c + 0x8e) = *(short*)(c + 0x94);
     } else {
-        struct Vec3 v;
+        struct Vector3 v;
         _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x364, &v, n + 1);
-        *(short*)(c + 0x8e) = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &v);
+        *(short*)(c + 0x8e) = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &v);
     }
     {
         int *pv = (int *)(((int)c + 0x380) & 0xFFFFFFFFFFFFFFFF);

--- a/src/func_ov019_021113b0.c
+++ b/src/func_ov019_021113b0.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov019_021113b0
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, struct Vector3 *out, unsigned int idx);
 extern int Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);

--- a/src/func_ov019_02111fec.c
+++ b/src/func_ov019_02111fec.c
@@ -1,8 +1,10 @@
-struct Vec3 { int x, y, z; };
-short Vec3_HorzAngle(const struct Vec3 *v0, const struct Vec3 *v1);
+// @symbol func_ov019_02111fec
+/* recovered: shared common types */
+#include "common.h"
+short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 int _Z14ApproachLinearRsss(short* dst, short target, short step);
 unsigned char NumStars(void);
-int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* thiz, void* actor, unsigned int msg, const struct Vec3* pos, unsigned int a, unsigned int b);
+int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* thiz, void* actor, unsigned int msg, const struct Vector3* pos, unsigned int a, unsigned int b);
 int _ZN6Player12GetTalkStateEv(void* p);
 void func_02012790(int x);
 void func_ov019_021122dc(void* c, int n);
@@ -16,9 +18,9 @@ int func_ov019_02111fec(char* c) {
     switch (*(unsigned char*)(c + 0x38f)) {
     case 0: {
         char* tgt = *(char**)(c + 0x378);
-        short ang = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), (struct Vec3*)(tgt + 0x5c));
+        short ang = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), (struct Vector3*)(tgt + 0x5c));
         if (_Z14ApproachLinearRsss((short*)(c + 0x8e), ang, 0x514) != 0) {
-            struct Vec3 pos;
+            struct Vector3 pos;
             int msg;
             int eq;
             int y;

--- a/src/func_ov020_021112b0.c
+++ b/src/func_ov020_021112b0.c
@@ -1,26 +1,29 @@
+// @symbol func_ov020_021112b0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov020_021112b0 at 0x021112b0 (ov020), size 0x90
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-struct Vec3 { int x, y, z; };
 
-extern char *Actor_ClosestPlayer(void *);
-extern void Vec3_Sub(struct Vec3 *d, struct Vec3 *a, struct Vec3 *b);
-extern short cstd_atan2(int, int);
-extern int Vec3_HorzLen(struct Vec3 *);
+
+extern void Vec3_Sub(struct Vector3 *d, struct Vector3 *a, struct Vector3 *b);
+extern int Vec3_HorzLen(struct Vector3 *);
 
 void func_ov020_021112b0(char *c)
 {
   char *p = Actor_ClosestPlayer(c);
   if (!p)
     return;
-  struct Vec3 *ps = (struct Vec3 *)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
-  struct Vec3 tmp;
+  struct Vector3 *ps = (struct Vector3 *)(((long long)(int)(p + 0x5c)));
+  struct Vector3 tmp;
   tmp.x = ps->x;
   tmp.y = ps->y;
   tmp.z = ps->z;
-  struct Vec3 d;
-  Vec3_Sub(&d, &tmp, (struct Vec3 *)(c + 0x5c));
+  struct Vector3 d;
+  Vec3_Sub(&d, &tmp, (struct Vector3 *)(c + 0x5c));
   *((short *)(c + 0x446)) = cstd_atan2(d.x, d.z);
   *((short *)(c + 0x444)) = cstd_atan2(d.y, Vec3_HorzLen(&d));
   *((short *)(c + 0x448)) = 0x4000;

--- a/src/func_ov020_02111340.c
+++ b/src/func_ov020_02111340.c
@@ -1,10 +1,13 @@
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+// @symbol func_ov020_02111340
+/* recovered: shared common types */
+#include "common.h"
+#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
 extern int RandomIntInternal(void *p);
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void *pos, void *rot, int e, int f);
 extern int data_0209e650[];
-struct Vec3 { int x, y, z; };
-struct Vec3_16 { short x, y, z; };
+
+
 
 void func_ov020_02111340(char *c)
 {
@@ -16,8 +19,8 @@ void func_ov020_02111340(char *c)
         if (found == 0)
             return;
         {
-            struct Vec3 pos;
-            struct Vec3_16 rot;
+            struct Vector3 pos;
+            struct Vector3_16 rot;
             int *fp = (int *)AT(found, 0x5c);
             int mul = 0x1f4 * bit;
             int x = fp[0];

--- a/src/func_ov020_02111fc4.cpp
+++ b/src/func_ov020_02111fc4.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov020_02111fc4
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 
 struct Actor {
     virtual void v0();

--- a/src/func_ov020_021127a4.cpp
+++ b/src/func_ov020_021127a4.cpp
@@ -1,6 +1,10 @@
 //cpp
+// @symbol func_ov020_021127a4
+// @emits BookShot_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBook_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern "C" {
-int func_ov020_021127a4(char* c){
+int BookShot_OnAimedAtWithEgg(char* c){
   int eq = (*(unsigned short*)(c+0xc)==0x147);
   if(eq) return 0;
   return 0x19000;

--- a/src/func_ov020_021127cc.c
+++ b/src/func_ov020_021127cc.c
@@ -1,3 +1,7 @@
-int func_ov020_021127cc(char* c){
+// @symbol func_ov020_021127cc
+// @emits BookShot_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daBook_c::OnYoshiTryEat - recovered from vtable slot identity */
+int BookShot_OnYoshiTryEat(char* c){
   unsigned int b = *(unsigned short*)(c+0xc)==0x147; return b ? 2 : 0;
 }

--- a/src/func_ov020_021127f4.c
+++ b/src/func_ov020_021127f4.c
@@ -1,17 +1,21 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5EnemyC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern void _ZN12WithMeshClsnC1Ev(void *);
-extern int VT0[];
+// @symbol func_ov020_021127f4
+/* recovered: vtable identified, globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Enemy.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, globals resolved */
+/* resolved: VT0 = _ZTV8BookShot */
 int *func_ov020_021127f4(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(1108);
     if (p) {
         _ZN5EnemyC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV8BookShot;
         _ZN9ModelAnimC1Ev((char *)p + 0x110);
         _ZN5ModelC1Ev((char *)p + 0x174);
         _ZN11ShadowModelC1Ev((char *)p + 0x1c4);

--- a/src/func_ov020_02112e94.c
+++ b/src/func_ov020_02112e94.c
@@ -1,6 +1,7 @@
-struct Vec3 { int x, y, z; };
-
-#define LAUNDER(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+// @symbol func_ov020_02112e94
+/* recovered: shared common types */
+#include "common.h"
+#define LAUNDER(p) ((long long)(int)(p))
 
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern int Vec3_Dist(const void *a, const void *b);

--- a/src/func_ov021_0211129c.c
+++ b/src/func_ov021_0211129c.c
@@ -1,3 +1,6 @@
+// @symbol func_ov021_0211129c
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
 struct Quaternion;
@@ -11,13 +14,13 @@ extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, s16 angY);
 extern void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void* self, void* mtx, s16 a);
 extern void Matrix4x3_ApplyInPlaceToTranslation(struct Matrix4x3 *mF, Fix12 x, Fix12 y, Fix12 z);
 
-struct M48 { int w[12]; };
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 extern const int data_ov021_02114a20[];
 extern const s16 data_ov021_02114740[];
 
 void func_ov021_0211129c(char* c) {
-    struct M48 mtx;
+    struct Matrix4x3 mtx;
     int i;
     char* tr;
     char* obj;
@@ -31,7 +34,7 @@ void func_ov021_0211129c(char* c) {
     Matrix4x3_ApplyInPlaceToRotationX((struct Matrix4x3*)&data_020a0e68, *(s16*)(c+0x8c));
     Matrix4x3_ApplyInPlaceToRotationZ((struct Matrix4x3*)&data_020a0e68, *(s16*)(c+0x90));
     Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3*)&data_020a0e68, *(s16*)(c+0x8e));
-    *(struct M48*)(c+0x2ec) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x2ec) = data_020a0e68;
     _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(c+0x124, c+0x2ec, *(s16*)(c+0x8e));
 
     tr = (char*)&data_ov021_02114a20[0];
@@ -50,10 +53,10 @@ void func_ov021_0211129c(char* c) {
                 v[1] = ny - 0x1e000;
             }
         }
-        *(struct M48*)&data_020a0e68 = *(struct M48*)(c+0x2ec);
+        *(struct Matrix4x3*)&data_020a0e68 = *(struct Matrix4x3*)(c+0x2ec);
         Matrix4x3_ApplyInPlaceToTranslation((struct Matrix4x3*)&data_020a0e68, v[0], v[1], v[2]);
         Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3*)&data_020a0e68, data_ov021_02114740[i]);
-        *(struct M48*)(obj+0x460) = data_020a0e68;
+        *(struct Matrix4x3*)(obj+0x460) = data_020a0e68;
         _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(transform, col, *(s16*)(c+0x8e));
         tr += 0xc;
         obj += 0x30;

--- a/src/func_ov021_02111434.c
+++ b/src/func_ov021_02111434.c
@@ -1,3 +1,6 @@
+// @symbol func_ov021_02111434
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
 
@@ -13,11 +16,9 @@ extern void Matrix4x3_ApplyInPlaceToRotationZ(struct Matrix4x3 *mF, s16 angZ);
 extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, s16 angY);
 extern void Matrix4x3_ApplyInPlaceToTranslation(struct Matrix4x3 *mF, Fix12 x, Fix12 y, Fix12 z);
 
-struct M48 {
-    int w[12];
-};
 
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 extern const int data_ov021_02114a20[];
 extern const s16 data_ov021_02114740[];
 
@@ -28,7 +29,7 @@ static asm unsigned conv_ov021(unsigned x) {
 
 int func_ov021_02111434(char *c)
 {
-    struct M48 mtx;
+    struct Matrix4x3 mtx;
     int i;
     char *src;
     char *tr;
@@ -46,7 +47,7 @@ int func_ov021_02111434(char *c)
     Matrix4x3_ApplyInPlaceToRotationZ((struct Matrix4x3 *)(&data_020a0e68), *((s16 *)(c + 0x90)));
     rv = 1;
     Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3 *)(&data_020a0e68), *((s16 *)(c + 0x8e)));
-    *((struct M48 *)(c + 0xf0)) = data_020a0e68;
+    *((struct Matrix4x3 *)(c + 0xf0)) = data_020a0e68;
     src = c + 0xf0;
     tr = (char *)(&data_ov021_02114a20[0]);
     i = 0;
@@ -63,11 +64,11 @@ int func_ov021_02111434(char *c)
                 v[rv] = ny - 0x1e000;
             }
         }
-        *((struct M48 *)(&data_020a0e68)) = *((struct M48 *)src);
+        *((struct Matrix4x3 *)(&data_020a0e68)) = *((struct Matrix4x3 *)src);
         Vec3_Asr(vo, (void *)v, 3);
         Matrix4x3_ApplyInPlaceToTranslation((struct Matrix4x3 *)(&data_020a0e68), vo[0], vo[rv], vo[2]);
         Matrix4x3_ApplyInPlaceToRotationY((struct Matrix4x3 *)(&data_020a0e68), data_ov021_02114740[i]);
-        *((struct M48 *)(obj + 0x33c)) = data_020a0e68;
+        *((struct Matrix4x3 *)(obj + 0x33c)) = data_020a0e68;
         tr += 0xc;
         obj += 0x50;
     }

--- a/src/func_ov021_02112024.cpp
+++ b/src/func_ov021_02112024.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov021_02112024
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x,y,z; };
-struct Matrix4x3 { int m[12]; };
+
+
 void InvMat4x3(struct Matrix4x3* d, struct Matrix4x3* s);
 void MulVec3Mat4x3(struct Vector3* v, struct Matrix4x3* m, struct Vector3* out);
 void Quaternion_FromVector3(void* q, struct Vector3* axis, struct Vector3* v);

--- a/src/func_ov021_0211228c.c
+++ b/src/func_ov021_0211228c.c
@@ -1,4 +1,8 @@
-int func_ov021_0211228c(void)
+// @symbol func_ov021_0211228c
+// @emits RollingRock_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daGrock_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int RollingRock_OnAimedAtWithEgg(void)
 {
     return 0;
 }

--- a/src/func_ov021_021122fc.cpp
+++ b/src/func_ov021_021122fc.cpp
@@ -1,18 +1,21 @@
 //cpp
+// @symbol func_ov021_021122fc
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void Vec3_Asr(void* dst, void* src, int n);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, short a, short b, short c);
 extern int _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* thiz, void* sm, void* m, int rad, int h, unsigned u);
-struct Mtx { int w[12]; };
-extern struct Mtx data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 int func_ov021_021122fc(char* c){
   int tmp[3];
   Vec3_Asr(tmp, c+0x5c, 3);
   Matrix4x3_FromTranslation(&data_020a0e68, tmp[0], tmp[1], tmp[2]);
-  *(struct Mtx*)(c+0x188) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x188) = data_020a0e68;
   Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68, *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-  *(struct Mtx*)(c+0x12c) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x12c) = data_020a0e68;
   return _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x160, c+0x188, 0x1f4000, 0x1f4000, 0xf);
 }
 }

--- a/src/func_ov021_021123b0.c
+++ b/src/func_ov021_021123b0.c
@@ -1,18 +1,22 @@
+// @symbol func_ov021_021123b0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_02012694(int a, void *p);
 extern void _ZN6Player16IncMegaKillCountEv(void *p);
 extern void _ZN5Actor14TriplePoofDustEv(void *a);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, int x, int y, int z);
-extern void func_ov021_02112294(void *c);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *a);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void *pos);
-extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, struct Vec3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, struct Vector3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
 
 void func_ov021_021123b0(char *c)
 {
@@ -56,7 +60,7 @@ void func_ov021_021123b0(char *c)
 
     if (*(u8*)(c + 0x3be) == 4) return;
     {
-        struct Vec3 v;
+        struct Vector3 v;
         v.x = *(int*)(c + 0x5c);
         v.y = *(int*)(c + 0x60);
         v.z = *(int*)(c + 0x64);

--- a/src/func_ov022_021111a0.c
+++ b/src/func_ov022_021111a0.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov022_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021111e4.c
+++ b/src/func_ov022_021111e4.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_021111e4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov022_021111e4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021115a8.c
+++ b/src/func_ov022_021115a8.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov022_021115a8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_Koma_D_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_021115a8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjFl_Koma_D_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021115f8.c
+++ b/src/func_ov022_021115f8.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov022_021115f8
+// @emits daObjFl_Koma_D_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjFl_Koma_D_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov022_021115f8(int *t)
+int *daObjFl_Koma_D_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_0211165c.c
+++ b/src/func_ov022_0211165c.c
@@ -1,6 +1,11 @@
-extern int func_020b66a8(void *self, void *data);
+// @symbol func_ov022_0211165c
+// @emits daObjFl_Koma_D_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Koma_D_c::CleanupResources - recovered from vtable slot identity */
 extern int data_ov022_02113da4[];
-int func_ov022_0211165c(void *self)
+int daObjFl_Koma_D_c_CleanupResources(void *self)
 {
     return func_020b66a8(self, data_ov022_02113da4);
 }

--- a/src/func_ov022_02111670.c
+++ b/src/func_ov022_02111670.c
@@ -1,9 +1,13 @@
+// @symbol func_ov022_02111670
+// @emits daObjFl_Koma_D_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjFl_Koma_D_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b676c(unsigned char *self, struct Arg *a, short arg2);
 extern struct Arg data_ov022_02113da4;
 
-void func_ov022_02111670(unsigned char *c)
+void daObjFl_Koma_D_c_InitResources(unsigned char *c)
 {
     func_ov002_020b676c(c, &data_ov022_02113da4, 0x100);
 }

--- a/src/func_ov022_02111980.c
+++ b/src/func_ov022_02111980.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_02111980
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_London_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_02111980(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjFl_London_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_021119c4.c
+++ b/src/func_ov022_021119c4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_021119c4
+// @emits daObjFl_London_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjFl_London_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov022_021119c4(int *t)
+int *daObjFl_London_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_02111a64.c
+++ b/src/func_ov022_02111a64.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov022_02111a64
+// @emits daObjFl_London_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_London_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov022_02111a64(void *t)
+int daObjFl_London_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov022_02111aa8.cpp
+++ b/src/func_ov022_02111aa8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov022_02111aa8
+// @emits daObjFl_London_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjFl_London_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov022_02111aa8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjFl_London_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov022_02111ad0.c
+++ b/src/func_ov022_02111ad0.c
@@ -1,38 +1,46 @@
+// @symbol func_ov022_02111ad0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjFl_London_c.h"
+// @emits daObjFl_London_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjFl_London_c::Behavior - recovered from vtable slot identity */
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void* v);
-extern void func_ov022_02111a1c(char* t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* t, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* t);
 
-int func_ov022_02111ad0(char* c)
+int daObjFl_London_c_Behavior(char* c)
 {
+    struct daObjFl_London_c *self = (struct daObjFl_London_c *)(void *)c;
     if (DecIfAbove0_Byte((unsigned char*)c + 0x31e) == 0) {
-        if (*(unsigned char*)(c + 0x31f) == 0) {
-            short* p = (short*)((long long)(int)(c + 0x96) & 0xFFFFFFFFFFFFFFFFLL);
+        if (self->unk_31f == 0) {
+            short* p = (short*)((long long)(int)(c + 0x96));
             *p = *p - 0x100;
-            if (*(short*)(c + 0x96) <= -0x2000) {
-                *(short*)(c + 0x96) = -0x2000;
-                *(unsigned char*)(c + 0x31e) = 0xf;
-                *(unsigned char*)(c + 0x31f) = 1;
+            if (self->unk_096 <= -0x2000) {
+                self->unk_096 = -0x2000;
+                self->unk_31e = 0xf;
+                self->unk_31f = 1;
             }
         } else {
-            short* p = (short*)((long long)(int)(c + 0x96) & 0xFFFFFFFFFFFFFFFFLL);
+            short* p = (short*)((long long)(int)(c + 0x96));
             *p = *p + 0x100;
-            if (*(short*)(c + 0x96) >= 0) {
-                *(short*)(c + 0x96) = 0;
-                *(unsigned char*)(c + 0x31e) = 0xf;
-                *(unsigned char*)(c + 0x31f) = 0;
+            if (self->unk_096 >= 0) {
+                self->unk_096 = 0;
+                self->unk_31e = 0xf;
+                self->unk_31f = 0;
             }
         }
     } else {
-        if (*(unsigned char*)(c + 0x31e) == 1) {
-            if (*(unsigned char*)(c + 0x31f) == 0)
+        if (self->unk_31e == 1) {
+            if (self->unk_31f == 0)
                 _ZN5Sound9PlayBank3EjRK7Vector3(0x34, c + 0x74);
             else
                 _ZN5Sound9PlayBank3EjRK7Vector3(0x35, c + 0x74);
         }
     }
-    *(short*)(c + 0x90) = *(short*)(c + 0x96);
+    self->unk_090 = self->unk_096;
     func_ov022_02111a1c(c);
     if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
         _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov022_02111bdc.cpp
+++ b/src/func_ov022_02111bdc.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov022_02111bdc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjFl_London_c.h"
+// @emits daObjFl_London_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjFl_London_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 struct BMD_File;
 struct KCL_File;
@@ -16,20 +24,20 @@ struct MovingMeshCollider {
 extern SharedFilePtr data_ov022_02114580;
 extern SharedFilePtr data_ov022_02114578;
 extern CLPS_Block data_ov064_0211bb2c;
-extern "C" void func_ov022_02111a1c(char *t);
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int func_ov022_02111bdc(char *c)
+extern "C" int daObjFl_London_c_InitResources(char *c)
 {
+    struct daObjFl_London_c *self = (struct daObjFl_London_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov022_02114580);
     ((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);
     func_ov022_02111a1c(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov022_02114578);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, *(short *)(c + 0x8e), data_ov064_0211bb2c);
+    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bb2c);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    *(unsigned char *)(c + 0x31f) = 0;
-    *(unsigned char *)(c + 0x31e) = 0xf;
+    self->unk_31f = 0;
+    self->unk_31e = 0xf;
     return 1;
 }

--- a/src/func_ov022_02111cac.c
+++ b/src/func_ov022_02111cac.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_02111cac
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjFl_Seesaw_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_02111cac(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjFl_Seesaw_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov022_02111cf0.c
+++ b/src/func_ov022_02111cf0.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov022_02111cf0
+// @emits daObjFl_Seesaw_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjFl_Seesaw_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov022_02111cf0(int *t)
+int *daObjFl_Seesaw_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_02111d90.c
+++ b/src/func_ov022_02111d90.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov022_02111d90
+// @emits daObjFl_Seesaw_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Seesaw_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov022_02111d90(void *t)
+int daObjFl_Seesaw_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov022_02111dd4.cpp
+++ b/src/func_ov022_02111dd4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov022_02111dd4
+// @emits daObjFl_Seesaw_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjFl_Seesaw_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov022_02111dd4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjFl_Seesaw_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov022_02111dfc.c
+++ b/src/func_ov022_02111dfc.c
@@ -1,21 +1,29 @@
+// @symbol func_ov022_02111dfc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjFl_Seesaw_c.h"
+// @emits daObjFl_Seesaw_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjFl_Seesaw_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
 typedef short s16;
 extern void func_020393a4(int* p, int v);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
-extern void func_ov022_02111d48(char* t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12 a, Fix12 b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 
-int func_ov022_02111dfc(char* c) {
+int daObjFl_Seesaw_c_Behavior(char* c) {
+    struct daObjFl_Seesaw_c *self = (struct daObjFl_Seesaw_c *)(void *)c;
   func_020393a4((int*)(c+0x124), 0x650000);
   if (DecIfAbove0_Byte((unsigned char*)(c+0x320)) == 0) {
     int r1;
     s16* a = (s16*)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF);
-    *a += *(s16*)(c+0x31e);
-    r1 = *(s16*)(c+0x8c);
+    *a += self->unk_31e;
+    r1 = self->unk_08c;
     if (r1 >= 0x400 || r1 <= -0x400) {
-      *(s16*)(c+0x31e) = -*(s16*)(c+0x31e);
-      *(unsigned char*)(c+0x320) = 0x1e;
+      self->unk_31e = -self->unk_31e;
+      self->unk_320 = 0x1e;
     }
   }
   func_ov022_02111d48(c);

--- a/src/func_ov022_02111ea0.cpp
+++ b/src/func_ov022_02111ea0.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov022_02111ea0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjFl_Seesaw_c.h"
+// @emits daObjFl_Seesaw_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjFl_Seesaw_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 struct BMD_File;
 struct KCL_File;
@@ -16,19 +24,19 @@ struct MovingMeshCollider {
 extern SharedFilePtr data_ov022_021145a8;
 extern SharedFilePtr data_ov022_021145a0;
 extern CLPS_Block data_ov064_0211bacc;
-extern "C" void func_ov022_02111d48(char *t);
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int func_ov022_02111ea0(char *c)
+extern "C" int daObjFl_Seesaw_c_InitResources(char *c)
 {
+    struct daObjFl_Seesaw_c *self = (struct daObjFl_Seesaw_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov022_021145a8);
     ((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);
     func_ov022_02111d48(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov022_021145a0);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, *(short *)(c + 0x8e), data_ov064_0211bacc);
+    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov064_0211bacc);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-    *(short *)(c + 0x31e) = -0x10;
+    self->unk_31e = -0x10;
     return 1;
 }

--- a/src/func_ov022_02112380.c
+++ b/src/func_ov022_02112380.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov022_02112380
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjFl_Fall_Block_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov022_02112380(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV20daObjFl_Fall_Block_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov022_021123d0.c
+++ b/src/func_ov022_021123d0.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov022_021123d0
+// @emits daObjFl_Fall_Block_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjFl_Fall_Block_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov022_021123d0(int *t)
+int *daObjFl_Fall_Block_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_02112434.c
+++ b/src/func_ov022_02112434.c
@@ -1,6 +1,10 @@
-extern int func_0213a2cc(void *self, void *data);
-extern int data_ov022_0211427c[];
-int func_ov022_02112434(void *self)
+// @symbol func_ov022_02112434
+// @emits daObjFl_Fall_Block_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Fall_Block_c::CleanupResources - recovered from vtable slot identity */
+int daObjFl_Fall_Block_c_CleanupResources(void *self)
 {
     return func_0213a2cc(self, data_ov022_0211427c);
 }

--- a/src/func_ov022_02112448.c
+++ b/src/func_ov022_02112448.c
@@ -1,6 +1,10 @@
-extern int func_0213a794(void *self, void *data);
-extern int data_ov022_0211427c[];
-int func_ov022_02112448(void *self)
+// @symbol func_ov022_02112448
+// @emits daObjFl_Fall_Block_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Fall_Block_c::InitResources - recovered from vtable slot identity */
+int daObjFl_Fall_Block_c_InitResources(void *self)
 {
     return func_0213a794(self, data_ov022_0211427c);
 }

--- a/src/func_ov022_021126ac.c
+++ b/src/func_ov022_021126ac.c
@@ -1,6 +1,11 @@
+// @symbol func_ov022_021126ac
+// @emits daObjFlMaruta_c_AfterClsn
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFlMaruta_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ActorBase18MarkForDestructionEv(void *c);
-extern int data_ov025_02112654(void *c);
-int func_ov022_021126ac(char *c) {
+int daObjFlMaruta_c_AfterClsn(char *c) {
     int a = *(int*)(c+0x60);
     int b = *(int*)(c+0x118);
     if (a < b) {

--- a/src/func_ov024_021112c0.c
+++ b/src/func_ov024_021112c0.c
@@ -1,4 +1,6 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov024_021112c0
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *);
 extern void _ZN5Event6SetBitEj(unsigned int);
@@ -6,7 +8,7 @@ extern void _ZN7Minimap19UpdateLevelSpecificEv(void);
 
 void func_ov024_021112c0(char *c)
 {
-    struct V3 v;
+    struct Vector3 v;
     v.x = *(int *)(c + 0x5c);
     v.y = *(int *)(c + 0x60);
     v.z = *(int *)(c + 0x64);

--- a/src/func_ov025_021111a0.c
+++ b/src/func_ov025_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov025_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daDgr_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov025_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV7daDgr_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov025_021111e4.c
+++ b/src/func_ov025_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov025_021111e4
+// @emits daDgr_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daDgr_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov025_021111e4(int *t)
+int *daDgr_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov025_0211123c.cpp
+++ b/src/func_ov025_0211123c.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov025_0211123c
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor {
     virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
     virtual void f04(); virtual void f05(); virtual void f06(); virtual void f07();

--- a/src/func_ov025_021112e0.cpp
+++ b/src/func_ov025_021112e0.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov025_021112e0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov025_021112e0(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov025_02111384.cpp
+++ b/src/func_ov025_02111384.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol func_ov025_02111384
+// @emits daDgr_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDgr_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
 void _ZN13SharedFilePtr7ReleaseEv(void* self);
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
 extern int data_ov025_02113a68[];
-extern int data_ov036_02113a60[];
-int func_ov025_02111384(char* c) {
+int daDgr_c_CleanupResources(char* c) {
   _ZN13SharedFilePtr7ReleaseEv(data_ov025_02113a68);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113a60);
   if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))

--- a/src/func_ov025_021113c8.cpp
+++ b/src/func_ov025_021113c8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov025_021113c8
+// @emits daDgr_c_Render
+/* recovered: renamed to Class_Method */
+/* daDgr_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov025_021113c8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daDgr_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov025_021113f0.c
+++ b/src/func_ov025_021113f0.c
@@ -1,3 +1,9 @@
+// @symbol func_ov025_021113f0
+// @emits daDgr_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDgr_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned short u16;
@@ -7,19 +13,16 @@ typedef int s32;
 
 typedef struct { s32 x, y, z; } Vec3;
 
-extern void func_ov025_02111344(char *t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *self, s32 a, s32 b);
-extern void func_ov025_021112e0(char *self);
 extern void func_02012694(s32 a, void *b);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(char *self, Vec3 *pos, s32 fix);
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 effect, s32 x, s32 y, s32 z, const void *rot, void *cb);
-extern int func_ov025_0211123c(char *c);
 extern s16 data_02082214[];
 
-#define LAUNDER(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LAUNDER(p) ((long long)(int)(p))
 
-int func_ov025_021113f0(char *self)
+int daDgr_c_Behavior(char *self)
 {
     s32 loc[6];
     s32 n;

--- a/src/func_ov025_021117dc.cpp
+++ b/src/func_ov025_021117dc.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov025_021117dc
+// @emits daDgr_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDgr_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct Model { int d; };
@@ -6,8 +12,6 @@ struct ModelBase { int d; };
 struct MeshCollider { int d; };
 struct MovingMeshCollider { int d; };
 
-extern "C" void func_ov025_02111344(char* t);
-extern "C" void func_ov025_021112e0(char* self);
 extern "C" BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr&);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(ModelBase*, BMD_File*, int, int);
 extern "C" KCL_File* _ZN12MeshCollider8LoadFileER13SharedFilePtr(SharedFilePtr&);
@@ -20,7 +24,7 @@ extern SharedFilePtr data_ov025_02113a60;
 extern CLPS_Block data_ov025_02112c28;
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 
-extern "C" int func_ov025_021117dc(char* thiz)
+extern "C" int daDgr_c_InitResources(char* thiz)
 {
     char* c = thiz;
     func_ov025_02111344(c);

--- a/src/func_ov025_021118c8.c
+++ b/src/func_ov025_021118c8.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov025_021118c8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV7daDkk_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 int *func_ov025_021118c8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV7daDkk_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)VT2;

--- a/src/func_ov025_02111928.c
+++ b/src/func_ov025_02111928.c
@@ -1,14 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov025_02111928
+// @emits daDkk_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daDkk_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
 extern void *G0;
-int *func_ov025_02111928(int *t)
+int *daDkk_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov025_0211199c.c
+++ b/src/func_ov025_0211199c.c
@@ -1,4 +1,8 @@
-int func_ov025_0211199c(void)
+// @symbol func_ov025_0211199c
+// @emits daDkk_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daDkk_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int daDkk_c_OnAimedAtWithEgg(void)
 {
     return 843776;
 }

--- a/src/func_ov025_02111b64.cpp
+++ b/src/func_ov025_02111b64.cpp
@@ -1,20 +1,16 @@
 //cpp
+// @symbol func_ov025_02111b64
+// @emits daDkk_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDkk_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12i;
-extern "C" void func_ov091_02133020(char* c);
-extern "C" void func_ov091_02132ff4(char* c);
-extern "C" void func_ov091_02132f04(char* c);
-extern "C" void func_ov091_02132e98(char* c);
-extern "C" void func_ov091_02132e64(char* c);
-extern "C" void func_ov025_02111a84(char* c);
-extern "C" void func_ov025_021119f4(char* c);
-extern "C" int func_ov025_021119a4(char* c);
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void* p);
-extern "C" void func_ov091_02133098(char* c);
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, Fix12i a, Fix12i b);
-extern "C" int func_ov091_02132dc0(char* c);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void* p);
 
-extern "C" int func_ov025_02111b64(char* thiz)
+extern "C" int daDkk_c_Behavior(char* thiz)
 {
     char* c = thiz;
     switch (*(int*)(c + 0x398)) {

--- a/src/func_ov025_02111c24.cpp
+++ b/src/func_ov025_02111c24.cpp
@@ -1,32 +1,39 @@
 //cpp
+// @symbol func_ov025_02111c24
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "daDkk_c.h"
+// @emits daDkk_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* daDkk_c::InitResources - recovered from vtable slot identity */
 extern "C" {
-struct Vector3 { int x, y, z; };
 extern int func_ov091_02133254(void* c);
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);
 extern void _ZN11RaycastLine10GetClsnPosEv(void* out, void* self);
 extern void _ZN11RaycastLineD1Ev(void* self);
-extern int data_ov025_02113814[];
-int func_ov025_02111c24(char* c)
+int daDkk_c_InitResources(char* c)
 {
+    struct daDkk_c *self = (struct daDkk_c *)(void *)c;
     *(void**)(c + 0x320) = data_ov025_02113814;
     int r = func_ov091_02133254(c);
     if (*(int*)(c + 8) & 1) {
-        *(int*)(c + 0x398) = 6;
+        self->unk_398 = 6;
     } else {
-        *(int*)(c + 0x398) = 0;
+        self->unk_398 = 0;
         char rl[0x78];
         Vector3 va;
         Vector3 vb;
         Vector3 p1;
         Vector3 p2;
         _ZN11RaycastLineC1Ev(rl);
-        int x = *(int*)(c + 0x5c);
+        int x = self->unk_05c;
         vb.x = x;
-        int y = *(int*)(c + 0x60);
+        int y = self->unk_060;
         vb.y = y;
-        int z = *(int*)(c + 0x64);
+        int z = self->unk_064;
         va.x = x;
         vb.z = z;
         va.y = y;
@@ -36,7 +43,7 @@ int func_ov025_02111c24(char* c)
         if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
             _ZN11RaycastLine10GetClsnPosEv(&p1, rl);
             _ZN11RaycastLine10GetClsnPosEv(&p2, rl);
-            *(int*)(c + 0x390) = p2.y - 0x190000;
+            self->unk_390 = p2.y - 0x190000;
         }
         _ZN11RaycastLineD1Ev(rl);
     }

--- a/src/func_ov026_021111a0.c
+++ b/src/func_ov026_021111a0.c
@@ -1,11 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov026_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjWlPolelift_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
 int *func_ov026_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV17daObjWlPolelift_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov026_021111e0.c
+++ b/src/func_ov026_021111e0.c
@@ -1,11 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov026_021111e0
+// @emits daObjWlPolelift_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWlPolelift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
-int *func_ov026_021111e0(int *t)
+int *daObjWlPolelift_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x188);

--- a/src/func_ov026_02111234.cpp
+++ b/src/func_ov026_02111234.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov026_02111234
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void*,void*,void*,int,int,int,unsigned int);
-struct M4x3 { int w[12]; };
+
 void func_ov026_02111234(char* c){
-  *(struct M4x3*)(c+0x1b0) = *(struct M4x3*)(c+0xf0);
+  *(struct Matrix4x3*)(c+0x1b0) = *(struct Matrix4x3*)(c+0xf0);
   *(int*)(c+0x1d8) = *(int*)(c+0x1e0) >> 3;
   _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     c, c+0x188, c+0x1b0, 0x64000, 0xc8000, 0x64000, 0xf);

--- a/src/func_ov026_021112e4.c
+++ b/src/func_ov026_021112e4.c
@@ -1,6 +1,10 @@
+// @symbol func_ov026_021112e4
+// @emits daObjWlPolelift_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjWlPolelift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int func_ov026_021112e4(void)
+int daObjWlPolelift_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     return 1;

--- a/src/func_ov026_02111308.cpp
+++ b/src/func_ov026_02111308.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov026_02111308
+// @emits daObjWlPolelift_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjWlPolelift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov026_02111308(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjWlPolelift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_02111330.cpp
+++ b/src/func_ov026_02111330.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov026_02111330
+// @emits daObjWlPolelift_c_Behavior
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjWlPolelift_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -6,7 +12,6 @@ typedef unsigned int u32;
 typedef int s32;
 typedef unsigned long long u64;
 
-struct Vector3 { int x, y, z; };
 
 extern "C" {
     unsigned short DecIfAbove0_Short(unsigned short* p);
@@ -28,12 +33,11 @@ extern "C" {
     void _ZN13RaycastGroundD1Ev(void* self);
 }
 
-extern Vector3 data_ov026_02113a9c;
 
 struct RaycastGround { char pad[0x44]; s32 hitY; char pad2[8]; };
 
 
-extern "C" int func_ov026_02111330(void* self)
+extern "C" int daObjWlPolelift_c_Behavior(void* self)
 {
     u8* c = (u8*)self;
     Vector3 a, b, sub, rp, mul, rel;

--- a/src/func_ov026_02111598.cpp
+++ b/src/func_ov026_02111598.cpp
@@ -1,17 +1,21 @@
 //cpp
+// @symbol func_ov026_02111598
+// @emits daObjWlPolelift_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWlPolelift_c::InitResources - recovered from vtable slot identity */
 struct V3 { int x,y,z; V3(){} V3(const V3&o){x=o.x;y=o.y;z=o.z;} };
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern void _ZN11ShadowModel10InitCuboidEv(void*);
 extern void _ZN7PathPtr6FromIDEj(void*, unsigned int);
-extern int _ZNK7PathPtr8NumNodesEv(void*);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void*, void*, V3*, int, int, unsigned int, unsigned int);
-extern int func_ov053_021112a4(char*);
-extern int data_ov026_02113ea0[];
 extern int data_0209caa0[];
 extern V3 data_ov032_02113a9c;
-int func_ov026_02111598(char *c){
+int daObjWlPolelift_c_InitResources(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov026_02113ea0);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   if((data_0209caa0[1] & 0x204) == 0) return 0;

--- a/src/func_ov026_02111678.c
+++ b/src/func_ov026_02111678.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
+// @symbol func_ov026_02111678
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjWlPolelift_c */
 extern void _ZN7PathPtrC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
 int *func_ov026_02111678(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(484);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV17daObjWlPolelift_c;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN25MovingCylinderClsnWithPosC1Ev((char *)p + 0x124);
         _ZN7PathPtrC1Ev((char *)p + 0x164);

--- a/src/func_ov026_021116c8.c
+++ b/src/func_ov026_021116c8.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov026_021116c8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjWlKoopaShutter_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov026_021116c8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV21daObjWlKoopaShutter_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov026_0211170c.c
+++ b/src/func_ov026_0211170c.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov026_0211170c
+// @emits daObjWlKoopaShutter_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWlKoopaShutter_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov026_0211170c(int *t)
+int *daObjWlKoopaShutter_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov026_02111764.c
+++ b/src/func_ov026_02111764.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov026_02111764
+// @emits daObjWlKoopaShutter_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWlKoopaShutter_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov026_02111764(void *t)
+int daObjWlKoopaShutter_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov026_021117a8.cpp
+++ b/src/func_ov026_021117a8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov026_021117a8
+// @emits daObjWlKoopaShutter_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjWlKoopaShutter_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov026_021117a8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjWlKoopaShutter_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_021117d0.c
+++ b/src/func_ov026_021117d0.c
@@ -1,4 +1,8 @@
-int func_ov026_021117d0(void)
+// @symbol func_ov026_021117d0
+// @emits daObjWlKoopaShutter_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjWlKoopaShutter_c::Behavior - recovered from vtable slot identity */
+int daObjWlKoopaShutter_c_Behavior(void)
 {
     return 1;
 }

--- a/src/func_ov026_021117d8.c
+++ b/src/func_ov026_021117d8.c
@@ -1,3 +1,9 @@
+// @symbol func_ov026_021117d8
+// @emits daObjWlKoopaShutter_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWlKoopaShutter_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, int, int, int);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
@@ -5,11 +11,8 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void *, void *);
-extern char data_ov026_02113ebc[];
-extern char data_ov026_02113eb4[];
-extern char data_ov026_02112f74[];
 extern char data_0209caa0[];
-int func_ov026_021117d8(char *c){
+int daObjWlKoopaShutter_c_InitResources(char *c){
   void *m = (void*)_ZN5Model8LoadFileER13SharedFilePtr(data_ov026_02113ebc);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4,(int)m,1,-1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov026_021118b8.c
+++ b/src/func_ov026_021118b8.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov026_021118b8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjWlSubmarine_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov026_021118b8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjWlSubmarine_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov026_021118fc.c
+++ b/src/func_ov026_021118fc.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov026_021118fc
+// @emits daObjWlSubmarine_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWlSubmarine_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov026_021118fc(int *t)
+int *daObjWlSubmarine_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov026_02111954.c
+++ b/src/func_ov026_02111954.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov026_02111954
+// @emits daObjWlSubmarine_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWlSubmarine_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov026_02111954(void *t)
+int daObjWlSubmarine_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov026_02111998.cpp
+++ b/src/func_ov026_02111998.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov026_02111998
+// @emits daObjWlSubmarine_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjWlSubmarine_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov026_02111998(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjWlSubmarine_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_021119c0.c
+++ b/src/func_ov026_021119c0.c
@@ -1,3 +1,9 @@
+// @symbol func_ov026_021119c0
+// @emits daObjWlSubmarine_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWlSubmarine_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, int, int, int);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
@@ -5,11 +11,8 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void *, void *);
-extern char data_ov026_02113ee4[];
-extern char data_ov026_02113edc[];
-extern char data_ov026_02112fd4[];
 extern char data_0209caa0[];
-int func_ov026_021119c0(char *c){
+int daObjWlSubmarine_c_InitResources(char *c){
   void *m = (void*)_ZN5Model8LoadFileER13SharedFilePtr(data_ov026_02113ee4);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4,(int)m,1,-1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov026_02111d4c.cpp
+++ b/src/func_ov026_02111d4c.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov026_02111d4c
+// @emits daObjWlSubmarine_c_AfterClsn
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjWlSubmarine_c::AfterClsn - recovered from vtable slot identity */
 
 struct Player {
     char pad[0x5c];
@@ -15,15 +20,13 @@ struct Actor {
 
 extern "C" int Vec3_HorzDist(const Vector3* a, const Vector3* b);
 extern "C" int Vec3_Dist(const Vector3* a, const Vector3* b);
-extern "C" void func_ov026_02111ee0(void* c, void* p);
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
 extern "C" void MulVec3Mat4x3(const Vector3* in, const void* m, Vector3* out);
 
-extern void* data_ov026_02113f3c;
 extern char data_020a0e68;
 
-extern "C" int func_ov026_02111d4c(char* c)
+extern "C" int daObjWlSubmarine_c_AfterClsn(char* c)
 {
     Player* pl = ((Actor*)c)->ClosestPlayer();
     if (pl != 0) {

--- a/src/func_ov026_02111f30.c
+++ b/src/func_ov026_02111f30.c
@@ -1,13 +1,16 @@
+// @symbol func_ov026_02111f30
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov026_02111f30(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x130) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x130) = data_020a0e68;
 }

--- a/src/func_ov026_021122b0.c
+++ b/src/func_ov026_021122b0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov026_021122b0
+// @emits Submarine_Kill
+/* recovered: renamed to Class_Method */
+/* daWater_Tatumaki_c::Kill - recovered from vtable slot identity */
 extern void __sinit_ov045_02112280(void *);
-int func_ov026_021122b0(void *t)
+int Submarine_Kill(void *t)
 {
     __sinit_ov045_02112280(t);
     return 1;

--- a/src/func_ov027_0211123c.cpp
+++ b/src/func_ov027_0211123c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov027_0211123c
+// @emits SlidingIce_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjSlIceBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov027_0211123c(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void SlidingIce_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov027_021115c4.c
+++ b/src/func_ov027_021115c4.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol func_ov027_021115c4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV12daIDonketu_c */
 extern void func_ov002_020aed18(void *);
-extern int VT0[];
-extern int VT1[];
 int *func_ov027_021115c4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV12daIDonketu_c;
     t[0] = (int)VT1;
     _ZN11ShadowModelD1Ev((char *)t + 0x370);
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x33c);

--- a/src/func_ov027_02111618.c
+++ b/src/func_ov027_02111618.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
+// @symbol func_ov027_02111618
+// @emits daIDonketu_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_ShadowModel.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daIDonketu_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov002_020aed18(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
-int *func_ov027_02111618(int *t)
+int *daIDonketu_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov027_02111680.c
+++ b/src/func_ov027_02111680.c
@@ -1,5 +1,10 @@
-extern int func_ov064_02116110(char* self, short step);
-int func_ov027_02111680(char* self){
+// @symbol func_ov027_02111680
+// @emits daIDonketu_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daIDonketu_c::Kill - recovered from vtable slot identity */
+int daIDonketu_c_Kill(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov027_021116f0.cpp
+++ b/src/func_ov027_021116f0.cpp
@@ -1,18 +1,26 @@
 //cpp
+// @symbol func_ov027_021116f0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daIDonketu_c.h"
+// @emits daIDonketu_c_AfterClsn
+/* recovered: renamed to Class_Method */
+/* daIDonketu_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov064_0211616c(void*);
 extern void _ZN5Actor14TriplePoofDustEv(void*);
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void*,void*,unsigned int,void*,unsigned int);
-int func_ov027_021116f0(char* c){
+int daIDonketu_c_AfterClsn(char* c){
+    struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
   int r=func_ov064_0211616c(c);
   if(r==0) return r;
   _ZN5Actor14TriplePoofDustEv(c);
   int v[3];
-  v[0]=*(int*)(c+0x5c);
-  v[1]=*(int*)(c+0x60);
-  v[2]=*(int*)(c+0x64);
+  v[0]=self->unk_05c;
+  v[1]=self->unk_060;
+  v[2]=self->unk_064;
   v[1]+=0x64000;
   _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(
-    c, c+0x3fb, (*(unsigned char*)(c+0x3fa)|0x40)&0xff, v, 4);
+    c, c+0x3fb, (self->unk_3fa|0x40)&0xff, v, 4);
 }
 }

--- a/src/func_ov027_02111770.c
+++ b/src/func_ov027_02111770.c
@@ -1,20 +1,27 @@
+// @symbol func_ov027_02111770
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "daIDonketu_c.h"
+// @emits daIDonketu_c_Behavior
+/* recovered: shared common types, renamed to Class_Method */
+/* daIDonketu_c::Behavior - recovered from vtable slot identity */
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(char* c, char* a, char* b, unsigned int d);
 extern void _ZN5Actor14TriplePoofDustEv(char* c);
 struct V3 { int x, y, z; };
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(char* c, char* sc, unsigned int u, struct V3* v, unsigned int j);
 extern void _ZN9ActorBase18MarkForDestructionEv(char* c);
 extern int func_ov064_02116d1c(char* c);
-int func_ov027_02111770(char *c) {
+int daIDonketu_c_Behavior(char *c) {
+    struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
     int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c+0x174, c+0x110, 0);
     if (r != 0) {
         if (r == 2) {
             struct V3 v;
             _ZN5Actor14TriplePoofDustEv(c);
-            v.x = *(int*)(c+0x5c);
-            v.y = *(int*)(c+0x60);
-            v.z = *(int*)(c+0x64);
+            v.x = self->unk_05c;
+            v.y = self->unk_060;
+            v.z = self->unk_064;
             v.y = v.y + 0x64000;
-            _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(c, (char*)(c+0x3fb), (*(unsigned char*)(c+0x3fa) | 0x40) & 0xff, &v, 4);
+            _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(c, (char*)(c+0x3fb), (self->unk_3fa | 0x40) & 0xff, &v, 4);
             _ZN9ActorBase18MarkForDestructionEv(c);
         }
         return 1;

--- a/src/func_ov027_0211181c.cpp
+++ b/src/func_ov027_0211181c.cpp
@@ -1,13 +1,21 @@
 //cpp
+// @symbol func_ov027_0211181c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daIDonketu_c.h"
+// @emits daIDonketu_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daIDonketu_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern int func_ov064_02116ec0(void*);
 extern int _ZN5Actor9TrackStarEjj(void*, unsigned int, unsigned int);
-extern int data_ov027_021138f4[];
-int func_ov027_0211181c(char* c){
-  *(int*)(c+0x330) = (int)data_ov027_021138f4;
+int daIDonketu_c_InitResources(char* c){
+    struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
+  self->unk_330 = (int)data_ov027_021138f4;
   int r = func_ov064_02116ec0(c);
-  *(unsigned char*)(c+0x3fa) = *(int*)(c+8) & 0xf;
-  *(unsigned char*)(c+0x3fb) = _ZN5Actor9TrackStarEjj(c, *(unsigned char*)(c+0x3fa), 2);
+  self->unk_3fa = *(int*)(c+8) & 0xf;
+  self->unk_3fb = _ZN5Actor9TrackStarEjj(c, self->unk_3fa, 2);
   return r;
 }
 }

--- a/src/func_ov027_021118c8.c
+++ b/src/func_ov027_021118c8.c
@@ -1,18 +1,21 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol func_ov027_021118c8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10daPgDfdr_c; VT1 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *func_ov027_021118c8(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10daPgDfdr_c;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x398);
     _ZN15TextureSequenceD1Ev((char *)t + 0x384);
     _ZN9ModelAnimD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov027_02111924.c
+++ b/src/func_ov027_02111924.c
@@ -1,14 +1,17 @@
-extern void _ZN18MovingCylinderClsnD1Ev(void *);
+// @symbol func_ov027_02111924
+// @emits daPgDfdr_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daPgDfdr_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
-int *func_ov027_02111924(int *t)
+int *daPgDfdr_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x398);

--- a/src/func_ov027_02111994.cpp
+++ b/src/func_ov027_02111994.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Mtx { int w[12]; };
+// @symbol func_ov027_02111994
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" void Matrix4x3_FromRotationY(void*, short);
 extern "C" void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void*, void*, short);
 extern "C" void func_ov027_02111994(char *c) {
@@ -7,7 +10,7 @@ extern "C" void func_ov027_02111994(char *c) {
   *(int*)(c+0x360) = *(int*)(c+0x5c) >> 3;
   *(int*)(c+0x364) = *(int*)(c+0x60) >> 3;
   *(int*)(c+0x368) = *(int*)(c+0x64) >> 3;
-  *(struct Mtx*)(c+0x2ec) = *(struct Mtx*)(c+0x33c);
+  *(struct Matrix4x3*)(c+0x2ec) = *(struct Matrix4x3*)(c+0x33c);
   *(int*)(c+0x310) = *(int*)(c+0x5c);
   *(int*)(c+0x314) = *(int*)(c+0x60);
   *(int*)(c+0x318) = *(int*)(c+0x64);

--- a/src/func_ov027_02111d8c.c
+++ b/src/func_ov027_02111d8c.c
@@ -1,11 +1,14 @@
+// @symbol func_ov027_02111d8c
+// @emits daPgDfdr_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daPgDfdr_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void*);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
-extern void _ZN16MeshColliderBase7DisableEv(void*);
 extern void* data_ov027_02113c7c;
-extern void* data_ov035_02112ca4[];
 extern void* data_ov027_02113c94;
 extern void* data_ov027_02113c6c;
-int func_ov027_02111d8c(char* c){
+int daPgDfdr_c_CleanupResources(char* c){
   int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov027_02113c7c);
   for(i=0;i<3;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112ca4[i]);

--- a/src/func_ov027_02111dfc.c
+++ b/src/func_ov027_02111dfc.c
@@ -1,3 +1,7 @@
-void func_ov027_02111dfc(void)
+// @symbol func_ov027_02111dfc
+// @emits daPgDfdr_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daPgDfdr_c::OnPendingDestroy - recovered from vtable slot identity */
+void daPgDfdr_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov027_02111e00.cpp
+++ b/src/func_ov027_02111e00.cpp
@@ -1,5 +1,9 @@
 //cpp
+// @symbol func_ov027_02111e00
+// @emits daPgDfdr_c_Render
+/* recovered: renamed to Class_Method */
+/* daPgDfdr_c::Render - recovered from vtable slot identity */
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0x320]; Sub sub; };
 extern "C" void _ZN15TextureSequence6UpdateER15ModelComponents(void *, void *);
-extern "C" int func_ov027_02111e00(Base *c) { _ZN15TextureSequence6UpdateER15ModelComponents((char *)c + 0x384, (char *)c + 0x328); Sub *b = &c->sub; b->m(0); return 1; }
+extern "C" int daPgDfdr_c_Render(Base *c) { _ZN15TextureSequence6UpdateER15ModelComponents((char *)c + 0x384, (char *)c + 0x328); Sub *b = &c->sub; b->m(0); return 1; }

--- a/src/func_ov027_02111e34.cpp
+++ b/src/func_ov027_02111e34.cpp
@@ -1,15 +1,20 @@
 //cpp
+// @symbol func_ov027_02111e34
+// @emits daPgDfdr_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daPgDfdr_c::Behavior - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void* t, int a, int b);
-extern void func_ov027_02111cfc(void* c);
 extern void* _ZN5Actor13ClosestPlayerEv(void* c);
-extern int _ZN6Player16IsInsideOfCannonEv(void* p);
 extern void _ZN9Animation7AdvanceEv(void* a);
 extern void _ZN12CylinderClsn5ClearEv(void* a);
 extern void _ZN12CylinderClsn6UpdateEv(void* a);
 extern void func_ov027_02111994(char* c);
 
-int func_ov027_02111e34(char* c){
+int daPgDfdr_c_Behavior(char* c){
   _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
   func_ov027_02111cfc(c);
   if(_ZN6Player16IsInsideOfCannonEv(_ZN5Actor13ClosestPlayerEv(c))){

--- a/src/func_ov027_02111eb4.cpp
+++ b/src/func_ov027_02111eb4.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov027_02111eb4
+// @emits daPgDfdr_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daPgDfdr_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *o, void *f, int a, int b);
@@ -11,7 +17,6 @@ extern void *_ZN12MeshCollider8LoadFileER13SharedFilePtr(void *fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *o, void *kcl, void *m, int fx, short s, void *clps);
 extern void func_020393d4(void *p, int v);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *o, void *act, int a, int b, unsigned c, unsigned d);
-extern void func_ov027_02111d70(void *c, int b);
 extern void _ZN13RaycastGroundC1Ev(void *o);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *o, void *v, void *act);
 extern int _ZN13RaycastGround10DetectClsnEv(void *o);
@@ -20,13 +25,11 @@ extern void _ZN13RaycastGroundD1Ev(void *o);
 extern char data_ov027_02113c7c;
 extern char data_ov027_02113c94;
 extern char data_ov027_02113c6c;
-extern char data_ov027_021130e8;
-extern void *data_ov027_02112ca4[3];
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 
 struct RG { char pad[0x54]; };
 
-int func_ov027_02111eb4(void *cc)
+int daPgDfdr_c_InitResources(void *cc)
 {
     char *c = (char*)cc;
     int i;

--- a/src/func_ov027_0211207c.c
+++ b/src/func_ov027_0211207c.c
@@ -1,15 +1,19 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN9ModelAnimC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN18MovingCylinderClsnC1Ev(void *);
-extern int VT0[];
+// @symbol func_ov027_0211207c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_ModelAnim.h"
+#include "decl_MovingCylinderClsn.h"
+#include "decl_Platform.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10daPgDfdr_c */
 int *func_ov027_0211207c(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(988);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV10daPgDfdr_c;
         _ZN9ModelAnimC1Ev((char *)p + 0x320);
         _ZN15TextureSequenceC1Ev((char *)p + 0x384);
         _ZN18MovingCylinderClsnC1Ev((char *)p + 0x398);

--- a/src/func_ov027_02112618.cpp
+++ b/src/func_ov027_02112618.cpp
@@ -1,17 +1,20 @@
 //cpp
+// @symbol func_ov027_02112618
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void* _ZN5Actor13ClosestPlayerEv(void*);
 void Vec3_Asr(void* d, void* s, int sh);
-struct M48 { int w[12]; };
+
 void MulVec3Mat4x3(void* in, void* m, void* out);
 void Vec3_LslInPlace(void* v, int sh);
-extern struct M48 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 int func_ov027_02112618(char* c){
   void* p = _ZN5Actor13ClosestPlayerEv(c);
   *(void**)(c+0x13c4) = p;
   int v[3];
   Vec3_Asr(v, (char*)p+0x5c, 3);
-  data_020a0e68 = *(struct M48*)(c+0x1394);
+  data_020a0e68 = *(struct Matrix4x3*)(c+0x1394);
   int out[3];
   MulVec3Mat4x3(v, &data_020a0e68, out);
   Vec3_LslInPlace(out, 3);

--- a/src/func_ov029_021111a0.c
+++ b/src/func_ov029_021111a0.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov029_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWcObj01_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov029_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjWcObj01_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov029_021111f0.c
+++ b/src/func_ov029_021111f0.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov029_021111f0
+// @emits daObjWcObj01_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWcObj01_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov029_021111f0(int *t)
+int *daObjWcObj01_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov029_02111ac4.c
+++ b/src/func_ov029_02111ac4.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov029_02111ac4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV15daObjWc_Obj05_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov029_02111ac4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV15daObjWc_Obj05_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov029_02111b08.c
+++ b/src/func_ov029_02111b08.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov029_02111b08
+// @emits daObjWc_Obj05_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWc_Obj05_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov029_02111b08(int *t)
+int *daObjWc_Obj05_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov029_02111b60.c
+++ b/src/func_ov029_02111b60.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov029_02111b60
+// @emits daObjWc_Obj05_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjWc_Obj05_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov029_02111b60(void *t)
+int daObjWc_Obj05_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov029_02111ba4.cpp
+++ b/src/func_ov029_02111ba4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov029_02111ba4
+// @emits daObjWc_Obj05_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjWc_Obj05_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov029_02111ba4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjWc_Obj05_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov029_02111bcc.c
+++ b/src/func_ov029_02111bcc.c
@@ -1,3 +1,9 @@
+// @symbol func_ov029_02111bcc
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjWc_Obj05_c.h"
+// @emits daObjWc_Obj05_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjWc_Obj05_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -9,8 +15,9 @@ extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 extern void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void* self, void* mat, s16 s);
 
-int func_ov029_02111bcc(u8* thiz)
+int daObjWc_Obj05_c_Behavior(u8* thiz)
 {
+    struct daObjWc_Obj05_c *self = (struct daObjWc_Obj05_c *)(void *)thiz;
     func_020393a4((int*)(thiz + 0x124), 0x250000);
 
     switch (thiz[0x32c]) {
@@ -26,12 +33,12 @@ int func_ov029_02111bcc(u8* thiz)
     case 1: {
         int* p60 = (int*)(((int)thiz + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
         *p60 = *p60 - 0x14000;
-        *(int*)(thiz + 0x324) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
+        self->unk_324 = _ZN5Sound8PlayLongEjjjRK7Vector3j(
             *(unsigned*)(thiz + 0x324), 3, 0x8d, thiz + 0x74, 0);
         {
-            int v = *(int*)(thiz + 0x320) + (int)0xff5d8000;
-            if (*(int*)(thiz + 0x60) <= v) {
-                *(int*)(thiz + 0x60) = v;
+            int v = self->unk_320 + (int)0xff5d8000;
+            if (self->unk_060 <= v) {
+                self->unk_060 = v;
                 {
                     u8* p = (u8*)(((int)thiz + 0x32c) & 0xFFFFFFFFFFFFFFFFLL);
                     *p = *p + 1;
@@ -49,13 +56,13 @@ int func_ov029_02111bcc(u8* thiz)
         if (*(u16*)((u8*)(((unsigned)thiz + 0x300)) + 0x28) >= 0x6e) {
             int snd = _ZN5Sound8PlayLongEjjjRK7Vector3j(
                 *(unsigned*)(thiz + 0x324), 3, 0x8d, thiz + 0x74, 0);
-            *(int*)(thiz + 0x324) = snd;
+            self->unk_324 = snd;
             {
                 int* p60 = (int*)(((int)thiz + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
                 *p60 = *p60 + 0xa000;
             }
-            if (*(int*)(thiz + 0x60) >= *(int*)(thiz + 0x320)) {
-                *(int*)(thiz + 0x60) = *(int*)(thiz + 0x320);
+            if (self->unk_060 >= self->unk_320) {
+                self->unk_060 = self->unk_320;
                 thiz[0x32c] = 0;
                 {
                     /* Different launder spelling so CSE does not reuse case-2 head base */
@@ -78,7 +85,7 @@ int func_ov029_02111bcc(u8* thiz)
         _ZN8Platform19UpdateClsnPosAndRotEv(thiz);
     }
     _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(
-        thiz + 0x124, thiz + 0x2ec, *(s16*)(thiz + 0x8e));
+        thiz + 0x124, thiz + 0x2ec, self->unk_08e);
     thiz[0x32a] = 0;
     return 1;
 }

--- a/src/func_ov029_02111d6c.cpp
+++ b/src/func_ov029_02111d6c.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov029_02111d6c
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjWc_Obj05_c.h"
+// @emits daObjWc_Obj05_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjWc_Obj05_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* f, int a, int b);
@@ -8,31 +16,28 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* fp);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* thiz, void* kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
-extern int data_ov029_0211428c[];
-extern int data_ov029_02114284[];
-extern int data_ov029_0211306c[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
-extern void func_ov029_02111e60(void);
 
-int func_ov029_02111d6c(char* c)
+int daObjWc_Obj05_c_InitResources(char* c)
 {
+    struct daObjWc_Obj05_c *self = (struct daObjWc_Obj05_c *)(void *)c;
     void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_0211428c);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(c + 0xd4, f, 1, -1);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);
     void* mc = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov029_02114284);
     _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-        c + 0x124, mc, c + 0x2ec, 0x1000, *(short*)(c + 0x8e), data_ov029_0211306c);
+        c + 0x124, mc, c + 0x2ec, 0x1000, self->unk_08e, data_ov029_0211306c);
     func_020393d4(c + 0x124, (void*)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     func_020393c4(c + 0x124, (void*)&func_ov029_02111e60);
-    *(unsigned char*)(c + 0x32b) = 0;
-    *(unsigned char*)(c + 0x32a) = *(unsigned char*)(c + 0x32b);
-    *(short*)(c + 0x328) = 0;
+    self->unk_32b = 0;
+    self->unk_32a = self->unk_32b;
+    self->unk_328 = 0;
     if (*(int*)(c + 8) & 1)
-        *(unsigned char*)(c + 0x32c) = 3;
+        self->unk_32c = 3;
     else
-        *(unsigned char*)(c + 0x32c) = 0;
-    *(int*)(c + 0x320) = *(int*)(c + 0x60);
+        self->unk_32c = 0;
+    self->unk_320 = self->unk_060;
     return 1;
 }
 }

--- a/src/func_ov029_02111ea4.c
+++ b/src/func_ov029_02111ea4.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov029_02111ea4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV14daObjWcObj06_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov029_02111ea4(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV14daObjWcObj06_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov029_02111ef4.c
+++ b/src/func_ov029_02111ef4.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov029_02111ef4
+// @emits daObjWcObj06_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjWcObj06_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov029_02111ef4(int *t)
+int *daObjWcObj06_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov029_02112250.cpp
+++ b/src/func_ov029_02112250.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov029_02112250
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov029_02112250(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x344);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov030_021111a0.c
+++ b/src/func_ov030_021111a0.c
@@ -1,14 +1,17 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov030_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjHmBskt_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov030_021111a0(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV13daObjHmBskt_c;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov030_021111ec.c
+++ b/src/func_ov030_021111ec.c
@@ -1,12 +1,15 @@
-extern void _ZN12WithMeshClsnD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov030_021111ec
+// @emits daObjHmBskt_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjHmBskt_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov030_021111ec(int *t)
+int *daObjHmBskt_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);

--- a/src/func_ov030_0211124c.cpp
+++ b/src/func_ov030_0211124c.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov030_0211124c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void func_020383fc(void*);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, void*, void*, int, int);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
-struct V3 { int x,y,z; };
+
 int func_ov030_0211124c(char *c, char *mc){
   func_020383fc(mc);
   int g = _ZNK12WithMeshClsn10IsOnGroundEv(mc);
@@ -14,7 +17,7 @@ int func_ov030_0211124c(char *c, char *mc){
   int px = *(int*)(c+0x5c);
   int pz = *(int*)(c+0x64);
   int py = *(int*)(c+0x60) + 0x96000;
-  V3 p = { px, py, pz };
+  Vector3 p = { px, py, pz };
   _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, (unsigned char)((*(unsigned int*)(c+8))&0xf) | 0x20, &p, 0, *(signed char*)(c+0xcc), -1);
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xb, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0xd, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));

--- a/src/func_ov030_0211130c.c
+++ b/src/func_ov030_0211130c.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov030_0211130c
+// @emits daObjHmBskt_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHmBskt_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov030_0211130c(void *t)
+int daObjHmBskt_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov030_02111350.cpp
+++ b/src/func_ov030_02111350.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov030_02111350
+// @emits daObjHmBskt_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjHmBskt_c::Render - recovered from vtable slot identity */
 struct Obj { virtual void f0(); virtual void f1(); virtual void f2(); virtual void f3(); virtual void f4(); virtual void m(int); };
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-extern "C" int func_ov030_02111350(char *c){
+extern "C" int daObjHmBskt_c_Render(char *c){
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   ((Obj*)(c+0xd4))->m(0);

--- a/src/func_ov030_02111384.cpp
+++ b/src/func_ov030_02111384.cpp
@@ -1,20 +1,28 @@
 //cpp
+// @symbol func_ov030_02111384
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjHmBskt_c.h"
+// @emits daObjHmBskt_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjHmBskt_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(char *c, int a, int b);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(char *c, char *clsn);
-extern "C" int func_ov030_0211124c(char *c, char *mc);
-extern "C" int func_ov030_02111384(char *c) {
+extern "C" int daObjHmBskt_c_Behavior(char *c) {
+    struct daObjHmBskt_c *self = (struct daObjHmBskt_c *)(void *)c;
     volatile int dummy[4];
     (void)&dummy;
     _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
-    *(short*)(c+0x8e) = *(short*)(c+0x8e) + *(int*)(c+0x98);
-    if (*(int*)(c+0x9c) != 0) {
+    self->unk_08e = self->unk_08e + self->unk_098;
+    if (self->unk_09c != 0) {
         *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) & ~1;
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char*)0);
         func_ov030_0211124c(c, c+0x320);
-        int a0 = *(int*)(c+0x60);
-        int a1 = *(int*)(c+0x64);
-        int m = *(int*)(c+0x4dc);
-        int a2 = *(int*)(c+0x5c);
+        int a0 = self->unk_060;
+        int a1 = self->unk_064;
+        int m = self->unk_4dc;
+        int a2 = self->unk_05c;
         *(int*)(m + 0x5c) = a2;
         *(int*)(m + 0x60) = a0 + 0x3c000;
         *(int*)(m + 0x64) = a1;

--- a/src/func_ov030_02111410.cpp
+++ b/src/func_ov030_02111410.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov030_02111410
+// @emits daObjHmBskt_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjHmBskt_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
 typedef short s16;
 struct SharedFilePtr { int x; }; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
@@ -17,7 +21,7 @@ extern struct SharedFilePtr data_ov030_02115c88;
 extern struct SharedFilePtr data_ov030_02115c80;
 extern struct CLPS_Block data_ov030_02114ee4;
 
-int func_ov030_02111410(char *self){
+int daObjHmBskt_c_InitResources(char *self){
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov030_02115c88);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, -1);
     *(int*)(self + 0x9c) = 0;

--- a/src/func_ov030_0211172c.c
+++ b/src/func_ov030_0211172c.c
@@ -1,4 +1,8 @@
-int func_ov030_0211172c(void)
+// @symbol func_ov030_0211172c
+// @emits RollingLogTtm_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daMky_c::OnYoshiTryEat - recovered from vtable slot identity */
+int RollingLogTtm_OnYoshiTryEat(void)
 {
     return 7;
 }

--- a/src/func_ov030_02111734.c
+++ b/src/func_ov030_02111734.c
@@ -1,3 +1,6 @@
+// @symbol func_ov030_02111734
+/* recovered: shared common types */
+#include "common.h"
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* actor);
@@ -10,11 +13,11 @@ extern void func_ov030_02112094(void* c);
 extern char data_0209f43c;
 extern char data_0209b3ec;
 
-struct Vec3 { int x, y, z; };
+
 
 void func_ov030_02111734(char* c)
 {
-    struct Vec3 a, b, out, asr;
+    struct Vector3 a, b, out, asr;
     char rc[0x7c];
 
     if (DecIfAbove0_Byte((unsigned char*)(c + 0x3cb)))

--- a/src/func_ov030_02111b20.c
+++ b/src/func_ov030_02111b20.c
@@ -1,10 +1,14 @@
+// @symbol func_ov030_02111b20
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_PathPtr.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, struct Vector3* v, unsigned int i);
 extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern s16 Vec3_HorzAngle(const struct Vector3* a, const struct Vector3* b);
 extern void _Z11UpdateAngleRssis(short* p, short a, int b, short c);
-extern int _ZNK7PathPtr8NumNodesEv(void* self);
 
 int func_ov030_02111b20(char* c) {
   struct Vector3 v;
@@ -19,7 +23,7 @@ int func_ov030_02111b20(char* c) {
   *(s16*)(c+0x94) = *(s16*)(c+0x8e);
   if (d < *(int*)(c+0x98)) {
     n = _ZNK7PathPtr8NumNodesEv(c+0x398);
-    p = (int*)((long long)(int)(c + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int*)((long long)(int)(c + 0x3a0));
     n = n - 1;
     *p = *p + 1;
     if (*(int*)(c+0x3a0) >= n) return 1;

--- a/src/func_ov030_02111ea4.cpp
+++ b/src/func_ov030_02111ea4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov030_02111ea4
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 
 struct RaycastGround {

--- a/src/func_ov030_02112094.cpp
+++ b/src/func_ov030_02112094.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol func_ov030_02112094
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef struct M4x3 { int w[12]; } M4x3;
 
-struct Vec3 { int x, y, z; };
-struct Vec3s { short x, y, z; };
-struct Bundle { Vec3s rot; short _p; Vec3 trans; int _tail[2]; };
+
+
+struct Bundle { Vector3_16 rot; short _p; Vector3 trans; int _tail[2]; };
 
 extern "C" {
 extern int _ZN6Player14IsFrontSlidingEv(void*);
@@ -16,7 +21,6 @@ extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void MulMat4x3Mat4x3(void* a, void* b, void* out);
 extern void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
-extern char data_ov030_02115ddc[];
 extern M4x3 data_020a0e68;
 void func_ov030_02112094(void* self);
 }

--- a/src/func_ov030_02112a14.c
+++ b/src/func_ov030_02112a14.c
@@ -1,14 +1,21 @@
+// @symbol func_ov030_02112a14
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjHmMaruta_c.h"
+// @emits daObjHmMaruta_c_AfterClsn
+/* recovered: renamed to Class_Method */
+/* daObjHmMaruta_c::AfterClsn - recovered from vtable slot identity */
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *m, void *f, int i, int fix, unsigned int j);
 extern void _ZN7PathPtr6FromIDEj(void *p, unsigned int id);
 struct G { void *a; void *b; };
 extern struct G data_ov030_02115d18;
-int func_ov030_02112a14(char *c) {
+int daObjHmMaruta_c_AfterClsn(char *c) {
+    struct daObjHmMaruta_c *self = (struct daObjHmMaruta_c *)(void *)c;
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, data_ov030_02115d18.b, 0, 0x1000, 0);
-    *(int*)(c+0x130) = 0x1000;
+    self->unk_130 = 0x1000;
     _ZN7PathPtr6FromIDEj(c+0x398, *(int*)(c+8) & 0xff);
-    *(int*)(c+0x3a0) = 1;
-    *(char*)(c+0x3c7) = 0;
-    *(int*)(c+0x98) = 0x6000;
-    *(int*)(c+0x3b4) = 8;
+    self->unk_3a0 = 1;
+    self->unk_3c7 = 0;
+    self->unk_098 = 0x6000;
+    self->unk_3b4 = 8;
     return 1;
 }

--- a/src/func_ov030_02113094.c
+++ b/src/func_ov030_02113094.c
@@ -1,3 +1,6 @@
+// @symbol func_ov030_02113094
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -5,8 +8,8 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
 extern void func_ov030_021141a8(char* self, int a);

--- a/src/func_ov030_021145d4.c
+++ b/src/func_ov030_021145d4.c
@@ -1,8 +1,12 @@
-/* func_ov030_021145d4 @ 0x21145d4 (ov030) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+// @symbol func_ov030_021145d4
+// @emits RollingLogTtm_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daMky_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* RollingLogTtm_OnTurnIntoEgg @ 0x21145d4 (ov030) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void func_ov030_021145d4(void) {
+void RollingLogTtm_OnTurnIntoEgg(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov032_02111350.c
+++ b/src/func_ov032_02111350.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov032_02111350
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor13ClosestPlayerEv(void);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void* self);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);

--- a/src/func_ov032_021113fc.cpp
+++ b/src/func_ov032_021113fc.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol func_ov032_021113fc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
+
 
 extern "C" {
     void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* c, void* v);
@@ -19,8 +24,6 @@ extern "C" {
     void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, void* v, u32 a, int f, u32 c, u32 d, u32 e);
 }
 
-extern Vec3 data_ov032_021137cc;
-extern Vec3 data_ov032_021137d8;
 extern int data_ov032_02113abc[];
 extern int data_ov032_02113a7c[];
 
@@ -28,7 +31,7 @@ extern "C" void func_ov032_021113fc(void* self)
 {
     u8* c = (u8*)self;
 
-    Vec3 v1;
+    Vector3 v1;
     v1.x = data_ov032_021137cc.x;
     v1.y = data_ov032_021137cc.y;
     v1.z = data_ov032_021137cc.z;
@@ -57,7 +60,7 @@ extern "C" void func_ov032_021113fc(void* self)
         }
     }
 
-    Vec3 v2;
+    Vector3 v2;
     v2.x = data_ov032_021137d8.x;
     v2.y = data_ov032_021137d8.y;
     v2.z = data_ov032_021137d8.z;
@@ -81,7 +84,7 @@ extern "C" void func_ov032_021113fc(void* self)
     if (s3b0 == data_ov032_02113abc) return;
     if (s3b0 == data_ov032_02113a7c) return;
 
-    Vec3 hv;
+    Vector3 hv;
     hv.x = *(s32*)(c+0x5c);
     hv.y = *(s32*)(c+0x60);
     hv.z = *(s32*)(c+0x64);

--- a/src/func_ov032_02111b9c.cpp
+++ b/src/func_ov032_02111b9c.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov032_02111b9c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct BCA_File;
 
 extern "C" {
@@ -14,9 +19,6 @@ int Vec3_HorzDist(const Vector3* a, const Vector3* b);
 int AngleDiff(int a, int b);
 short Vec3_VertAngle(const Vector3* a, const Vector3* b);
 
-extern int data_ov032_02113a50;
-extern int data_ov032_02113a8c;
-extern int data_ov032_02113a48;
 extern int data_ov032_02113a7c;
 extern int data_ov032_02113abc;
 extern int data_0209e650;

--- a/src/func_ov032_02112044.cpp
+++ b/src/func_ov032_02112044.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov032_02112044
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
+
 extern void Vec3_Asr(void* d, void* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
@@ -11,7 +14,7 @@ typedef struct { int w[12]; } M48;
 
 void func_ov032_02112044(char* c)
 {
-    Vec3 v;
+    Vector3 v;
     Vec3_Asr(&v, c + 0x5c, 3);
     Matrix4x3_FromTranslation(data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(data_020a0e68, *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));

--- a/src/func_ov032_021124a8.c
+++ b/src/func_ov032_021124a8.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov032_021124a8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjTdFuta_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov032_021124a8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjTdFuta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov032_021124ec.c
+++ b/src/func_ov032_021124ec.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov032_021124ec
+// @emits daObjTdFuta_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjTdFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov032_021124ec(int *t)
+int *daObjTdFuta_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov032_02112544.c
+++ b/src/func_ov032_02112544.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov032_02112544
+// @emits daObjTdFuta_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjTdFuta_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov032_02112544(void *t)
+int daObjTdFuta_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov032_02112588.cpp
+++ b/src/func_ov032_02112588.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov032_02112588
+// @emits daObjTdFuta_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjTdFuta_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov032_02112588(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjTdFuta_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov032_021125b0.cpp
+++ b/src/func_ov032_021125b0.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov032_021125b0
+// @emits daObjTdFuta_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjTdFuta_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int func_ov032_021125b0(void *c) {
+extern "C" int daObjTdFuta_c_Behavior(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov032_021125d4.cpp
+++ b/src/func_ov032_021125d4.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov032_021125d4
+// @emits daObjTdFuta_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjTdFuta_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -7,10 +13,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern int _ZN5Event6GetBitEj(unsigned int);
-extern int data_ov032_02113ad4[];
-extern int data_ov032_02113acc[];
-extern int data_ov032_02112f98[];
-int func_ov032_021125d4(char *c){
+int daObjTdFuta_c_InitResources(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov032_02113ad4);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov033_021111a0.c
+++ b/src/func_ov033_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov033_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjTtFuta_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov033_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjTtFuta_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov033_021111e4.c
+++ b/src/func_ov033_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov033_021111e4
+// @emits daObjTtFuta_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjTtFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov033_021111e4(int *t)
+int *daObjTtFuta_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov033_0211123c.c
+++ b/src/func_ov033_0211123c.c
@@ -1,9 +1,13 @@
+// @symbol func_ov033_0211123c
+// @emits daObjTtFuta_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjTtFuta_c::OnGroundPounded - recovered from vtable slot identity */
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void *v);
 extern void _ZN5Event6SetBitEj(unsigned int b);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *c);
 
-void func_ov033_0211123c(char *self, char *other)
+void daObjTtFuta_c_OnGroundPounded(char *self, char *other)
 {
     int *v = (int *)(((int)other + 0x5c) & 0xFFFFFFFFFFFFFFFF);
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x28, v[0], v[1], v[2]);

--- a/src/func_ov033_02111280.c
+++ b/src/func_ov033_02111280.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov033_02111280
+// @emits daObjTtFuta_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjTtFuta_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov033_02111280(void *t)
+int daObjTtFuta_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov033_021112c4.cpp
+++ b/src/func_ov033_021112c4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov033_021112c4
+// @emits daObjTtFuta_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjTtFuta_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov033_021112c4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjTtFuta_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov033_021112ec.cpp
+++ b/src/func_ov033_021112ec.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov033_021112ec
+// @emits daObjTtFuta_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjTtFuta_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int func_ov033_021112ec(void *c) {
+extern "C" int daObjTtFuta_c_Behavior(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov033_02111310.cpp
+++ b/src/func_ov033_02111310.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov033_02111310
+// @emits daObjTtFuta_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjTtFuta_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
@@ -7,10 +13,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern int _ZN5Event6GetBitEj(unsigned int);
-extern int data_ov033_021124c8[];
-extern int data_ov033_021124c0[];
-extern int data_ov035_02111bfc[];
-int func_ov033_02111310(char *c){
+int daObjTtFuta_c_InitResources(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov033_021124c8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov034_02111788.cpp
+++ b/src/func_ov034_02111788.cpp
@@ -1,12 +1,16 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov034_02111788
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Vec3D { int x, y, z; ~Vec3D() {} };
 
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char *p);
-extern void _ZN5Actor10PoofDustAtERK7Vector3(void *self, const Vec3 *v);
+extern void _ZN5Actor10PoofDustAtERK7Vector3(void *self, const Vector3 *v);
 extern "C" int Math_Function_0203b14c(void *base, int a, int b, int c, int d);
-extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void *self, signed char *id, unsigned int starID, const Vec3 *pos, unsigned int how);
-extern void _ZN5Sound22StopLoadedMusic_Layer3Ev(void);
+extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void *self, signed char *id, unsigned int starID, const Vector3 *pos, unsigned int how);
 extern "C" void func_ov034_021125b8(void *c, int i);
 
 extern "C" int data_ov034_021138c4[];
@@ -15,14 +19,14 @@ extern "C" void func_ov034_02111788(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
     Vec3D starPos;
-    Vec3 v;
+    Vector3 v;
     int a, b;
     int i;
 
     if (DecIfAbove0_Byte(c + 0x8da) == 0) {
         unsigned int idx = *(unsigned char *)(c + 0x8dd);
         if (idx < 5) {
-            Vec3 *vp = (Vec3 *)(c + 0x3cc + idx * 0xc);
+            Vector3 *vp = (Vector3 *)(c + 0x3cc + idx * 0xc);
             v.x = vp->x;
             v.y = vp->y;
             v.z = vp->z;
@@ -64,7 +68,7 @@ extern "C" void func_ov034_02111788(void *thiz)
         starPos.y = py;
         starPos.z = pz;
     }
-    _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(c, (signed char *)(c + 0x8e3), *(unsigned char *)(c + 0x8e2), (const Vec3 *)(c + 0x5c), 4);
+    _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(c, (signed char *)(c + 0x8e3), *(unsigned char *)(c + 0x8e2), (const Vector3 *)(c + 0x5c), 4);
     _ZN5Sound22StopLoadedMusic_Layer3Ev();
     func_ov034_021125b8(c, 3);
 }

--- a/src/func_ov034_02111a64.c
+++ b/src/func_ov034_02111a64.c
@@ -1,10 +1,14 @@
+// @symbol func_ov034_02111a64
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void* c);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* self, void* actor, int b);
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern short Vec3_HorzAngle(const void* a, const void* b);
 extern void _Z14ApproachLinearRsss(short* p, short a, short b);
-extern int func_ov002_020c51d0(void* c, void* st);
 extern int _ZN9Animation8FinishedEv(void* a);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const void* pos, unsigned int a, unsigned int b);
 extern void func_0201267c(int a, void* p);
@@ -13,11 +17,11 @@ extern void func_ov034_021125b8(void* c, int i);
 extern void* data_0209f318[];
 extern short data_ov034_02113820[];
 
-struct Vec3 { int x, y, z; };
+
 
 void func_ov034_02111a64(char* c)
 {
-    struct Vec3 st;
+    struct Vector3 st;
     char* talk;
 
     _Z14ApproachLinearRiii((int*)(c + 0x98), 0, 0x1000);

--- a/src/func_ov034_02112284.c
+++ b/src/func_ov034_02112284.c
@@ -1,7 +1,11 @@
+// @symbol func_ov034_02112284
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* ab, unsigned int id, const struct Vector3* v, unsigned int a, unsigned int b);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern void _ZN6Camera9SetFlag_3Ev(void* self);
 extern void func_0201267c(int anim, char* p);
 extern void func_ov034_021125b8(char* c, int i);

--- a/src/func_ov034_02112348.c
+++ b/src/func_ov034_02112348.c
@@ -1,3 +1,8 @@
+// @symbol func_ov034_02112348
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Sub(void* out, void* a, void* b);
 extern int LenVec3(void* v);
 extern char* _ZN5Actor13ClosestPlayerEv(void* c);
@@ -10,14 +15,13 @@ extern short Vec3_HorzAngle(const void* a, const void* b);
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);
 
 extern int data_0209e650[];
-extern unsigned char data_ov034_0211433c[];
 extern int data_ov034_02114488[];
 
-struct Vec3 { int x, y, z; };
+
 
 void func_ov034_02112348(char* c)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     int len;
     char* player;
 

--- a/src/func_ov034_02112688.c
+++ b/src/func_ov034_02112688.c
@@ -1,20 +1,24 @@
+// @symbol func_ov034_02112688
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_strength_reduction off
 typedef unsigned char u8;
 typedef unsigned short u16;
-struct Vec3 { int x, y, z; };
+
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
-extern int func_ov034_02112650(char *sl, char *p, char *a);
-extern void _ZN6Player6BounceE5Fix12IiE(void *self, int f);
 extern void func_0201267c(int a, void *b);
 extern void func_ov034_021125b8(char *sl, int i);
-extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, struct Vec3 *v, unsigned int b, int c, unsigned int d, unsigned int e, unsigned int f);
+extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *self, struct Vector3 *v, unsigned int b, int c, unsigned int d, unsigned int e, unsigned int f);
 void func_ov034_02112688(char *sl)
 {
     int off; int zero; int i; char *a; char *p; int one; int two; int cc; int eight;
-    volatile struct Vec3 v0; struct Vec3 v; struct Vec3 hv;
+    volatile struct Vector3 v0; struct Vector3 v; struct Vector3 hv;
     off = 0x478; p = sl + off; i = 0; zero = 0; one = 1; two = 2; cc = 0xc000; eight = 8;
     for (; i < 5; i++, p += 0x40) {
-        unsigned int id; int flag; u16 type; struct Vec3 *src;
+        unsigned int id; int flag; u16 type; struct Vector3 *src;
         id = *(unsigned int *)(sl + (i << 6) + 0x49c);
         if (id == 0) continue;
         a = _ZN5Actor10FindWithIDEj(id);
@@ -22,7 +26,7 @@ void func_ov034_02112688(char *sl)
         type = *(u16 *)(a + 0xc);
         { int t = (int)(type == 0xbf); flag = t ? one : zero; }
         if (flag == 0) continue;
-        src = (struct Vec3 *)(((long long)(int)(a + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        src = (struct Vector3 *)(((long long)(int)(a + 0x5c)));
         v0.x = src->x; v0.y = src->y; v0.z = src->z;
         if (func_ov034_02112650(sl, p, a) != 0) {
             _ZN6Player6BounceE5Fix12IiE(a, 0x28000);

--- a/src/func_ov035_0211168c.c
+++ b/src/func_ov035_0211168c.c
@@ -1,9 +1,13 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT[];
+// @symbol func_ov035_0211168c
+/* recovered: globals resolved, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: globals resolved */
+/* resolved: VT = _ZTV16RotatingCogSmall */
 int *func_ov035_0211168c(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(816);
-    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)VT; }
+    if (p) { _ZN8PlatformC2Ev(p); p[0] = (int)_ZTV16RotatingCogSmall; }
     return p;
 }

--- a/src/func_ov036_021111a0.c
+++ b/src/func_ov036_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov036_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjRcBuranko_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov036_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjRcBuranko_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov036_021111e4.c
+++ b/src/func_ov036_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov036_021111e4
+// @emits daObjRcBuranko_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjRcBuranko_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov036_021111e4(int *t)
+int *daObjRcBuranko_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov036_02111284.c
+++ b/src/func_ov036_02111284.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov036_02111284
+// @emits daObjRcBuranko_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjRcBuranko_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov036_02111284(void *t)
+int daObjRcBuranko_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov036_021112c8.cpp
+++ b/src/func_ov036_021112c8.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov036_021112c8
+// @emits daObjRcBuranko_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjRcBuranko_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov036_021112c8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjRcBuranko_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov036_021112f0.c
+++ b/src/func_ov036_021112f0.c
@@ -1,10 +1,17 @@
+// @symbol func_ov036_021112f0
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjRcBuranko_c.h"
+// @emits daObjRcBuranko_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjRcBuranko_c::Behavior - recovered from vtable slot identity */
 extern int func_ov036_0211123c(char *t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
 
-int func_ov036_021112f0(char *c)
+int daObjRcBuranko_c_Behavior(char *c)
 {
-    if (*(short *)(c + 0x90) < 0) {
+    struct daObjRcBuranko_c *self = (struct daObjRcBuranko_c *)(void *)c;
+    if (self->unk_090 < 0) {
         short *p = (short *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
         *p = *p + 4;
     } else {

--- a/src/func_ov036_0211137c.cpp
+++ b/src/func_ov036_0211137c.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov036_0211137c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjRcBuranko_c.h"
+// @emits daObjRcBuranko_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjRcBuranko_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 struct BMD_File;
 struct KCL_File;
@@ -20,15 +26,16 @@ extern "C" void func_ov036_0211123c(char *t);
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int func_ov036_0211137c(char *c)
+extern "C" int daObjRcBuranko_c_InitResources(char *c)
 {
+    struct daObjRcBuranko_c *self = (struct daObjRcBuranko_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov036_02114028);
     ((ModelBase *)(c + 0xd4))->SetFile(f, 1, -1);
-    *(short *)(c + 0x90) = 0x2000;
+    self->unk_090 = 0x2000;
     func_ov036_0211123c(c);
     ((Platform *)c)->UpdateClsnPosAndRot();
     KCL_File *k = MeshCollider::LoadFile(data_ov036_02114020);
-    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, *(short *)(c + 0x8e), data_ov036_02112b68);
+    ((MovingMeshCollider *)(c + 0x124))->SetFile(k, *(Matrix4x3 *)(c + 0x2ec), 0x1000, self->unk_08e, data_ov036_02112b68);
     func_020393d4((int *)(c + 0x124), (int)&_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
     return 1;
 }

--- a/src/func_ov036_02111444.c
+++ b/src/func_ov036_02111444.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov036_02111444
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjRc_Kaitendai_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov036_02111444(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV19daObjRc_Kaitendai_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov036_02111494.c
+++ b/src/func_ov036_02111494.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov036_02111494
+// @emits daObjRc_Kaitendai_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjRc_Kaitendai_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov036_02111494(int *t)
+int *daObjRc_Kaitendai_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov036_021114f8.c
+++ b/src/func_ov036_021114f8.c
@@ -1,10 +1,14 @@
+// @symbol func_ov036_021114f8
+// @emits daObjRc_Kaitendai_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjRc_Kaitendai_c::CleanupResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b66a8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov036_02113b2c;
 
-int func_ov036_021114f8(u8 *self)
+int daObjRc_Kaitendai_c_CleanupResources(u8 *self)
 {
     return func_ov002_020b66a8(self, &data_ov036_02113b2c);
 }

--- a/src/func_ov036_0211150c.c
+++ b/src/func_ov036_0211150c.c
@@ -1,9 +1,13 @@
-extern short data_ov036_02113b18;
-extern short data_ov036_02113b1c;
+// @symbol func_ov036_0211150c
+// @emits daObjRc_Kaitendai_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjRc_Kaitendai_c::InitResources - recovered from vtable slot identity */
 extern int data_ov036_02113b2c;
 extern int func_ov002_020b676c(int *self, void *arg, int val);
 
-int func_ov036_0211150c(int *self)
+int daObjRc_Kaitendai_c_InitResources(int *self)
 {
     short v;
     v = data_ov036_02113b18;

--- a/src/func_ov036_02111618.c
+++ b/src/func_ov036_02111618.c
@@ -1,10 +1,13 @@
+// @symbol func_ov036_02111618
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short ang);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov036_02111618(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
@@ -12,5 +15,5 @@ void func_ov036_02111618(char *c) {
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
     Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(c+0x8c));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-    *(struct M*)(c+0xe0) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0xe0) = data_020a0e68;
 }

--- a/src/func_ov036_0211224c.cpp
+++ b/src/func_ov036_0211224c.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov036_0211224c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov036_0211224c(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0x46c);
+    o->m = *(Matrix4x3*)(self + 0x46c);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60) + *(int*)(self+0x4bc);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov043_021111a0.c
+++ b/src/func_ov043_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov043_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjKm1_Ukishima_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov043_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV19daObjKm1_Ukishima_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov043_021111e4.c
+++ b/src/func_ov043_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov043_021111e4
+// @emits daObjKm1_Ukishima_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm1_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov043_021111e4(int *t)
+int *daObjKm1_Ukishima_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov043_0211123c.c
+++ b/src/func_ov043_0211123c.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov043_0211123c
+// @emits daObjKm1_Ukishima_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Ukishima_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov043_0211123c(void *t)
+int daObjKm1_Ukishima_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov043_02111280.cpp
+++ b/src/func_ov043_02111280.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov043_02111280
+// @emits daObjKm1_Ukishima_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Ukishima_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov043_02111280(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjKm1_Ukishima_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov043_021112a8.cpp
+++ b/src/func_ov043_021112a8.cpp
@@ -1,14 +1,21 @@
 //cpp
+// @symbol func_ov043_021112a8
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjKm1_Ukishima_c.h"
+// @emits daObjKm1_Ukishima_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Ukishima_c::Behavior - recovered from vtable slot identity */
 extern "C" {
 extern unsigned char DecIfAbove0_Byte(unsigned char *p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
-int func_ov043_021112a8(char *c)
+int daObjKm1_Ukishima_c_Behavior(char *c)
 {
+    struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
     if (!DecIfAbove0_Byte((unsigned char *)(c + 0x31e))) {
-        *(unsigned char *)(c + 0x31e) = 0x3c;
+        self->unk_31e = 0x3c;
         *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) = *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) + 0x4000;
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);

--- a/src/func_ov043_02111320.c
+++ b/src/func_ov043_02111320.c
@@ -1,3 +1,11 @@
+// @symbol func_ov043_02111320
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjKm1_Ukishima_c.h"
+// @emits daObjKm1_Ukishima_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Ukishima_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *p, int file, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
@@ -5,21 +13,19 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *p);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *p, int kcl, void *mtx, int fix, short s, void *clps);
 extern void func_020393d4(void *p, int v);
-extern int data_ov047_021125e8[];
-extern int data_ov047_021125e0[];
-extern int data_ov043_02111c00[];
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-int func_ov043_02111320(char *c){
+int daObjKm1_Ukishima_c_InitResources(char *c){
+    struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
   int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov047_021125e8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov047_021125e0);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-    c+0x124, f, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov043_02111c00);
+    c+0x124, f, c+0x2ec, 0x199, self->unk_08e, data_ov043_02111c00);
   func_020393d4(c+0x124, (int)_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  *(short*)(c+0x94) = *(short*)(c+0x8e);
-  *(int*)(c+0x98) = 0xa000;
-  *(unsigned char*)(c+0x31e) = 0x3c;
+  self->unk_094 = self->unk_08e;
+  self->unk_098 = 0xa000;
+  self->unk_31e = 0x3c;
   return 1;
 }

--- a/src/func_ov043_021113fc.c
+++ b/src/func_ov043_021113fc.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov043_021113fc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm1_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov043_021113fc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV21daObjKm1_Kurumajiku_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov043_0211144c.c
+++ b/src/func_ov043_0211144c.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov043_0211144c
+// @emits daObjKm1_Kurumajiku_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm1_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov043_0211144c(int *t)
+int *daObjKm1_Kurumajiku_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov043_021114b0.c
+++ b/src/func_ov043_021114b0.c
@@ -1,10 +1,14 @@
+// @symbol func_ov043_021114b0
+// @emits daObjKm1_Kurumajiku_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov043_02112344;
 
-int func_ov043_021114b0(u8 *self)
+int daObjKm1_Kurumajiku_c_CleanupResources(u8 *self)
 {
     return func_ov002_020b6ac8(self, &data_ov043_02112344);
 }

--- a/src/func_ov043_021114c4.c
+++ b/src/func_ov043_021114c4.c
@@ -1,9 +1,13 @@
+// @symbol func_ov043_021114c4
+// @emits daObjKm1_Kurumajiku_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKm1_Kurumajiku_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6c54(unsigned char *self, char **arg, unsigned int actorID);
 extern struct Arg data_ov043_02112344;
 
-void func_ov043_021114c4(unsigned char *c)
+void daObjKm1_Kurumajiku_c_InitResources(unsigned char *c)
 {
     func_ov002_020b6c54(c, (char **)&data_ov043_02112344, 0x88u);
 }

--- a/src/func_ov045_021111a0.c
+++ b/src/func_ov045_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov045_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjKm2_Agaru_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov045_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV16daObjKm2_Agaru_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov045_021111e4.c
+++ b/src/func_ov045_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov045_021111e4
+// @emits daObjKm2_Agaru_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm2_Agaru_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov045_021111e4(int *t)
+int *daObjKm2_Agaru_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov045_0211123c.c
+++ b/src/func_ov045_0211123c.c
@@ -1,8 +1,12 @@
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov045_0211123c
+// @emits daObjKm2_Agaru_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Agaru_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov045_0211123c(void *t)
+int daObjKm2_Agaru_c_CleanupResources(void *t)
 {
     _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     _ZN13SharedFilePtr7ReleaseEv(G0);

--- a/src/func_ov045_02111274.cpp
+++ b/src/func_ov045_02111274.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov045_02111274
+// @emits daObjKm2_Agaru_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Agaru_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov045_02111274(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjKm2_Agaru_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov045_0211129c.c
+++ b/src/func_ov045_0211129c.c
@@ -1,25 +1,32 @@
+// @symbol func_ov045_0211129c
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjKm2_Agaru_c.h"
+// @emits daObjKm2_Agaru_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Agaru_c::Behavior - recovered from vtable slot identity */
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
-int func_ov045_0211129c(char *c)
+int daObjKm2_Agaru_c_Behavior(char *c)
 {
-    switch (*(unsigned char*)(c + 0x327)) {
+    struct daObjKm2_Agaru_c *self = (struct daObjKm2_Agaru_c *)(void *)c;
+    switch (self->unk_327) {
     case 0:
-        if (*(unsigned char*)(c + 0x326) != 0)
+        if (self->unk_326 != 0)
             *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
                 *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
         break;
     case 1:
-        if (*(unsigned short*)(c + 0x324) >= 0x14) {
+        if (self->unk_324 >= 0x14) {
             int lim;
             *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
                 *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + 0xa000;
-            lim = *(int*)(c + 0x320) + 0x5dc000;
-            if (*(int*)(c + 0x60) >= lim) {
-                *(int*)(c + 0x60) = lim;
+            lim = self->unk_320 + 0x5dc000;
+            if (self->unk_060 >= lim) {
+                self->unk_060 = lim;
                 *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
                     *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
-                *(unsigned short*)(c + 0x324) = 0;
+                self->unk_324 = 0;
             }
         } else {
             *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
@@ -27,15 +34,15 @@ int func_ov045_0211129c(char *c)
         }
         break;
     case 2:
-        if (*(unsigned short*)(c + 0x324) >= 0x14) {
+        if (self->unk_324 >= 0x14) {
             int lim;
             *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
                 *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) - 0xa000;
-            lim = *(int*)(c + 0x320);
-            if (*(int*)(c + 0x60) <= lim) {
-                *(int*)(c + 0x60) = lim;
-                *(unsigned char*)(c + 0x327) = 0;
-                *(unsigned short*)(c + 0x324) = 0;
+            lim = self->unk_320;
+            if (self->unk_060 <= lim) {
+                self->unk_060 = lim;
+                self->unk_327 = 0;
+                self->unk_324 = 0;
             }
         } else {
             *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
@@ -46,6 +53,6 @@ int func_ov045_0211129c(char *c)
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0x1f4000, 0))
         _ZN8Platform19UpdateClsnPosAndRotEv(c);
-    *(unsigned char*)(c + 0x326) = 0;
+    self->unk_326 = 0;
     return 1;
 }

--- a/src/func_ov045_021113ec.c
+++ b/src/func_ov045_021113ec.c
@@ -1,3 +1,11 @@
+// @symbol func_ov045_021113ec
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjKm2_Agaru_c.h"
+// @emits daObjKm2_Agaru_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Agaru_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *p, int file, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *p);
@@ -6,23 +14,20 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *p, int kcl, void *mtx, int fix, short s, void *clps);
 extern void func_020393d4(void *p, int v);
 extern void func_020393c4(void *p, int v);
-extern int data_ov045_02113188[];
-extern int data_ov045_02113180[];
-extern int data_ov045_021125d0[];
-extern int data_ov059_021114c8[];
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-int func_ov045_021113ec(char *c){
+int daObjKm2_Agaru_c_InitResources(char *c){
+    struct daObjKm2_Agaru_c *self = (struct daObjKm2_Agaru_c *)(void *)c;
   int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_02113188);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   f = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov045_02113180);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
-    c+0x124, f, c+0x2ec, 0x199, *(short*)(c+0x8e), data_ov045_021125d0);
+    c+0x124, f, c+0x2ec, 0x199, self->unk_08e, data_ov045_021125d0);
   func_020393d4(c+0x124, (int)_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
   func_020393c4(c+0x124, (int)data_ov059_021114c8);
   *(short*)(c+0x300+0x24) = 0;
-  *(unsigned char*)(c+0x327) = 0;
-  *(int*)(c+0x320) = *(int*)(c+0x60);
+  self->unk_327 = 0;
+  self->unk_320 = self->unk_060;
   return 1;
 }

--- a/src/func_ov045_02111b14.c
+++ b/src/func_ov045_02111b14.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov045_02111b14
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV19daObjKm2_Ukishima_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov045_02111b14(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV19daObjKm2_Ukishima_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov045_02111b64.c
+++ b/src/func_ov045_02111b64.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov045_02111b64
+// @emits daObjKm2_Ukishima_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm2_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov045_02111b64(int *t)
+int *daObjKm2_Ukishima_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;


### PR DESCRIPTION
Batch 12 of the readable-tree migration. Promotes 190 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 103 VERIFIED, 87 BLIND, 0 WRONG/NO-REPRO. 0 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
