### PR TITLE
readable: batch 13 - promote 188 files to readable form

### DIFF
--- a/src/func_ov045_02111bc8.c
+++ b/src/func_ov045_02111bc8.c
@@ -1,6 +1,10 @@
-extern int func_020b6424(void *self, void *data);
-extern int data_ov045_02112f08[];
-int func_ov045_02111bc8(void *self)
+// @symbol func_ov045_02111bc8
+// @emits daObjKm2_Ukishima_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Ukishima_c::CleanupResources - recovered from vtable slot identity */
+int daObjKm2_Ukishima_c_CleanupResources(void *self)
 {
     return func_020b6424(self, data_ov045_02112f08);
 }

--- a/src/func_ov045_02111bdc.c
+++ b/src/func_ov045_02111bdc.c
@@ -1,6 +1,10 @@
-extern int func_020b6584(void *self, void *data, int n);
-extern int data_ov045_02112f08[];
-int func_ov045_02111bdc(void *self)
+// @symbol func_ov045_02111bdc
+// @emits daObjKm2_Ukishima_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjKm2_Ukishima_c::InitResources - recovered from vtable slot identity */
+int daObjKm2_Ukishima_c_InitResources(void *self)
 {
     return func_020b6584(self, data_ov045_02112f08, 0xf50);
 }

--- a/src/func_ov047_021111a0.c
+++ b/src/func_ov047_021111a0.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov047_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV21daObjKm3_Kurumajiku_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov047_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV21daObjKm3_Kurumajiku_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov047_021111f0.c
+++ b/src/func_ov047_021111f0.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov047_021111f0
+// @emits daObjKm3_Kurumajiku_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm3_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov047_021111f0(int *t)
+int *daObjKm3_Kurumajiku_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov047_02111254.c
+++ b/src/func_ov047_02111254.c
@@ -1,10 +1,14 @@
+// @symbol func_ov047_02111254
+// @emits daObjKm3_Kurumajiku_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjKm3_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112258;
 
-int func_ov047_02111254(u8 *self)
+int daObjKm3_Kurumajiku_c_CleanupResources(u8 *self)
 {
     return func_ov002_020b6ac8(self, &data_ov047_02112258);
 }

--- a/src/func_ov047_02111268.c
+++ b/src/func_ov047_02111268.c
@@ -1,10 +1,14 @@
+// @symbol func_ov047_02111268
+// @emits daObjKm3_Kurumajiku_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKm3_Kurumajiku_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6c54(u8 *self, struct Arg *arg, unsigned int actorID);
 extern struct Arg data_ov047_02112258;
 
-int func_ov047_02111268(u8 *self)
+int daObjKm3_Kurumajiku_c_InitResources(u8 *self)
 {
     return func_ov002_020b6c54(self, &data_ov047_02112258, 0x97);
 }

--- a/src/func_ov047_021113bc.c
+++ b/src/func_ov047_021113bc.c
@@ -1,13 +1,16 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov047_021113bc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV20daObjKm3_Kaitendai_c */
 int *func_ov047_021113bc(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(800);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV20daObjKm3_Kaitendai_c;
         p[0] = (int)VT1;
     }
     return p;

--- a/src/func_ov047_021113f8.c
+++ b/src/func_ov047_021113f8.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov047_021113f8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjKm3_Kuruma_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov047_021113f8(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjKm3_Kuruma_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT2;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov047_02111448.c
+++ b/src/func_ov047_02111448.c
@@ -1,12 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
-extern int VT2[];
+// @symbol func_ov047_02111448
+// @emits daObjKm3_Kuruma_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjKm3_Kuruma_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov047_02111448(int *t)
+int *daObjKm3_Kuruma_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov047_021114ac.c
+++ b/src/func_ov047_021114ac.c
@@ -1,10 +1,14 @@
+// @symbol func_ov047_021114ac
+// @emits daObjKm3_Kuruma_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjKm3_Kuruma_c::CleanupResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b68b0(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112408;
 
-int func_ov047_021114ac(u8 *self)
+int daObjKm3_Kuruma_c_CleanupResources(u8 *self)
 {
     return func_ov002_020b68b0(self, &data_ov047_02112408);
 }

--- a/src/func_ov047_021114c0.c
+++ b/src/func_ov047_021114c0.c
@@ -1,10 +1,14 @@
+// @symbol func_ov047_021114c0
+// @emits daObjKm3_Kuruma_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjKm3_Kuruma_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6958(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112408;
 
-int func_ov047_021114c0(u8 *self)
+int daObjKm3_Kuruma_c_InitResources(u8 *self)
 {
     return func_ov002_020b6958(self, &data_ov047_02112408);
 }

--- a/src/func_ov052_021111a0.c
+++ b/src/func_ov052_021111a0.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov052_021111a0
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV13daObjEmmLog_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov052_021111a0(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV13daObjEmmLog_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov052_021111e4.c
+++ b/src/func_ov052_021111e4.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov052_021111e4
+// @emits daObjEmmLog_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjEmmLog_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov052_021111e4(int *t)
+int *daObjEmmLog_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov052_0211123c.c
+++ b/src/func_ov052_0211123c.c
@@ -1,8 +1,12 @@
+// @symbol func_ov052_0211123c
+// @emits daObjEmmLog_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daObjEmmLog_c::CleanupResources - recovered from vtable slot identity */
 extern int _ZN16MeshColliderBase9IsEnabledEv();
 extern int _ZN16MeshColliderBase7DisableEv();
 extern int _ZN13SharedFilePtr7ReleaseEv();
 extern int *data_ov056_021124d4[];
-int func_ov052_0211123c(char *c){
+int daObjEmmLog_c_CleanupResources(char *c){
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
     _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov056_021124d4[0]);

--- a/src/func_ov052_02111284.cpp
+++ b/src/func_ov052_02111284.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov052_02111284
+// @emits daObjEmmLog_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjEmmLog_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov052_02111284(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjEmmLog_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov052_021112ac.c
+++ b/src/func_ov052_021112ac.c
@@ -1,17 +1,24 @@
+// @symbol func_ov052_021112ac
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjEmmLog_c.h"
+// @emits daObjEmmLog_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjEmmLog_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
 extern void func_020393a4(int *p, int v);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, Fix12 a, int b);
 extern short data_02082214[];
-int func_ov052_021112ac(char *c)
+int daObjEmmLog_c_Behavior(char *c)
 {
+    struct daObjEmmLog_c *self = (struct daObjEmmLog_c *)(void *)c;
     func_020393a4((int*)(c + 0x124), 0x600000);
     short *p = (short*)(c + 0x300);
     int idx = (unsigned short)p[0xf] >> 4;
     int s = *(short*)((char*)data_02082214 + (idx << 2));
-    int m = (int)(((long long)*(int*)(c + 0x324) * s + 0x800) >> 12);
-    *(int*)(c + 0x60) = *(int*)(c + 0x320) + m;
+    int m = (int)(((long long)self->unk_324 * s + 0x800) >> 12);
+    self->unk_060 = self->unk_320 + m;
     short *q = (short*)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
     *q = (short)(*q + 0x200);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov052_02111348.cpp
+++ b/src/func_ov052_02111348.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov052_02111348
+// @emits daObjEmmLog_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjEmmLog_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
 struct SharedFilePtr; struct BMD_File; struct KCL_File; struct Matrix4x3; struct CLPS_Block;
 struct Model { int d; };
@@ -17,7 +21,7 @@ extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEs
 struct DataT { SharedFilePtr* a; SharedFilePtr* b; CLPS_Block* c; };
 extern DataT data_ov052_021124d4;
 
-extern "C" int func_ov052_02111348(char* thiz)
+extern "C" int daObjEmmLog_c_InitResources(char* thiz)
 {
     char* c = thiz;
     {

--- a/src/func_ov060_02111a28.cpp
+++ b/src/func_ov060_02111a28.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov060_02111a28
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct V3 { int x, y, z; };
+
 struct G { int w[2]; };
 extern G data_ov060_0211acb0;
 extern G data_ov060_0211ac00;
@@ -59,13 +62,13 @@ void func_ov060_02111a28(char *c)
         return;
 
     if (r1 == 1) {
-        V3 dust;
+        Vector3 dust;
         dust.x = *(int *)(c + 0x3d4);
         dust.y = *(int *)(c + 0x3d8);
         dust.z = *(int *)(c + 0x3dc);
         _ZN5Actor17HugeLandingDustAtER7Vector3b(c, &dust, 0);
     } else {
-        V3 dust;
+        Vector3 dust;
         dust.x = *(int *)(c + 0x3e0);
         dust.y = *(int *)(c + 0x3e4);
         dust.z = *(int *)(c + 0x3e8);
@@ -73,7 +76,7 @@ void func_ov060_02111a28(char *c)
     }
     _ZN5Sound4PlayEjjRK7Vector3(3, 0xb0, c + 0x74);
     {
-        V3 quake;
+        Vector3 quake;
         quake.x = *(int *)(c + 0x5c);
         quake.y = *(int *)(c + 0x60);
         quake.z = *(int *)(c + 0x64);

--- a/src/func_ov060_02111f08.c
+++ b/src/func_ov060_02111f08.c
@@ -1,5 +1,6 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov060_02111f08
+/* recovered: shared common types */
+#include "common.h"
 extern void* data_0209f318;
 extern short data_02082214[];
 
@@ -32,7 +33,7 @@ int func_ov060_02111f08(void* arg0)
     switch (*(unsigned char*)(self + 0x444)) {
     case 0:
         _ZN6Camera9SetFlag_3Ev(cam);
-        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)));
         sp.x = pv->x;
         sp.y = pv->y;
         sp.z = pv->z;
@@ -48,7 +49,7 @@ int func_ov060_02111f08(void* arg0)
         *(int*)(self + 0x43c) = *(int*)(self + 0x60) + 0xc8000;
         *(int*)(self + 0x440) = *(int*)(self + 0x64) + (int)(((long long)v * data_02082214[k * 2 + 1] + 0x800) >> 12);
         _ZN6Camera6SetPosERK7Vector3(cam, (struct Vector3*)(self + 0x438));
-        p = (unsigned char*)(((long long)(int)(self + 0x444)) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (unsigned char*)(((long long)(int)(self + 0x444)));
         *p = *p + 1;
         break;
     case 1:
@@ -56,16 +57,16 @@ int func_ov060_02111f08(void* arg0)
         if (_ZN6Player7IsInAirEv(player) != 0)
             *(unsigned char*)(self + 0x445) = 0;
         else {
-            p = (unsigned char*)(((long long)(int)(self + 0x445)) & 0xFFFFFFFFFFFFFFFFLL);
+            p = (unsigned char*)(((long long)(int)(self + 0x445)));
             *p = *p + 1;
         }
         if (*(unsigned char*)(self + 0x445) > 0x1e) {
-            p = (unsigned char*)(((long long)(int)(self + 0x444)) & 0xFFFFFFFFFFFFFFFFLL);
+            p = (unsigned char*)(((long long)(int)(self + 0x444)));
             *p = *p + 1;
         }
         break;
     case 2:
-        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        pv = (struct Vector3*)(((long long)(int)(player + 0x5c)));
         sp.x = pv->x;
         sp.y = pv->y;
         sp.z = pv->z;
@@ -82,7 +83,7 @@ int func_ov060_02111f08(void* arg0)
         _Z14ApproachLinearRiii((int*)(self + 0x434), *(int*)(self + 0x64), 0x1e000);
         func_020092c4(cam, (char*)cam + 0x8c, self + 0x438);
         if (func_020092c4(cam, (char*)cam + 0x80, self + 0x42c) != 0) {
-            p = (unsigned char*)(((long long)(int)(self + 0x444)) & 0xFFFFFFFFFFFFFFFFLL);
+            p = (unsigned char*)(((long long)(int)(self + 0x444)));
             *p = *p + 1;
         }
         break;
@@ -103,7 +104,7 @@ int func_ov060_02111f08(void* arg0)
             return 1;
         break;
     case 4:
-        *(int*)(((long long)(int)((char*)cam + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+        *(int*)(((long long)(int)((char*)cam + 0x154))) &= ~8;
         break;
     default:
         break;

--- a/src/func_ov060_02112434.cpp
+++ b/src/func_ov060_02112434.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov060_02112434
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct C;
 typedef void (C::*PMF)();

--- a/src/func_ov060_021128c0.cpp
+++ b/src/func_ov060_021128c0.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol func_ov060_021128c0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -6,7 +11,7 @@ typedef unsigned int u32;
 typedef int s32;
 typedef long long s64;
 typedef int Fix12;
-struct Vector3 { s32 x, y, z; };
+
 
 extern "C" {
     void* _ZN5Actor10FindWithIDEj(u32 id);
@@ -24,7 +29,6 @@ extern "C" {
 
 struct TabEnt { int off; int idx; };
 extern TabEnt data_ov060_0211aed4[];
-extern u8 data_ov060_02119268[];
 extern s16 data_02082214[];
 
 extern "C" void func_ov060_021128c0(char* c)

--- a/src/func_ov060_02113404.c
+++ b/src/func_ov060_02113404.c
@@ -1,9 +1,12 @@
+// @symbol func_ov060_02113404
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
-extern int func_ov060_02112350(void* c);
+
 extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 extern int _ZN5Actor14GetSubtractionEss(void* self, short a, short b);
-extern char data_ov060_0211ac60[];
 
 int func_ov060_02113404(char* c) {
   int r = 0;

--- a/src/func_ov060_02113b5c.cpp
+++ b/src/func_ov060_02113b5c.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov060_02113b5c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
+
 struct RaycastGround { char buf[0x50]; };
 
 extern "C" {

--- a/src/func_ov060_02113d20.cpp
+++ b/src/func_ov060_02113d20.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol func_ov060_02113d20
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 // func_ov060_02113d20 at 0x02113d20
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov060).
-struct Vector3 { int x, y, z; };
+
 
 struct Actor {
     Actor *ClosestWithActorID(unsigned int id);
 };
 
-extern "C" int func_ov060_02118544(void *c, void *v);
-extern "C" void func_ov060_021185c4(void *c);
 
 extern "C" int func_ov060_02113d20(Actor *self)
 {

--- a/src/func_ov060_021145d4.c
+++ b/src/func_ov060_021145d4.c
@@ -1,14 +1,17 @@
+// @symbol func_ov060_021145d4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *c);
 extern void func_0200fa04(void *c, void *v, int flag);
-extern void func_ov060_02111cc0(void *c, int a, int b);
 extern void func_02012694(int a, void *b);
 extern int _ZN6Player7IsInAirEv(void *p);
-extern int func_ov002_020c56f0(unsigned char* c, int arg);
 
-struct V3 { int x, y, z; };
+
 
 int func_ov060_021145d4(char *c){
-  struct V3 v;
+  struct Vector3 v;
   int b;
   if(_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x14c)){
     *(int*)(c + 0x98) = 0;

--- a/src/func_ov060_02115a84.cpp
+++ b/src/func_ov060_02115a84.cpp
@@ -1,14 +1,17 @@
 //cpp
+// @symbol func_ov060_02115a84
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct V3 { int x,y,z; };
+
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(void* p);
-extern void _ZN5Actor13LandingDustAtER7Vector3b(void* a, struct V3* v, int b);
+extern void _ZN5Actor13LandingDustAtER7Vector3b(void* a, struct Vector3* v, int b);
 extern void func_02012694(int id, void* p);
 void func_ov060_02115a84(char* c, char* arg){
   if(_ZNK12WithMeshClsn13JustHitGroundEv(c+0x14c)==0) return;
   *(unsigned short*)arg = *(unsigned short*)arg + 1;
   if(*(unsigned short*)arg >= 4) return;
-  struct V3 v;
+  struct Vector3 v;
   v.x = *(int*)(c+0x5c);
   v.y = *(int*)(c+0x60);
   v.z = *(int*)(c+0x64);

--- a/src/func_ov060_02115b0c.c
+++ b/src/func_ov060_02115b0c.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov060_02115b0c
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, struct Vector3* v, int f);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct Vector3* pos, void* rot, int e, int f);
 

--- a/src/func_ov060_021167ec.c
+++ b/src/func_ov060_021167ec.c
@@ -1,6 +1,6 @@
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
-
+// @symbol func_ov060_021167ec
+/* recovered: shared common types */
+#include "common.h"
 struct Actor {
     char pad[0x92];
     short f92;   /* 0x92 */

--- a/src/func_ov060_021168c4.cpp
+++ b/src/func_ov060_021168c4.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol func_ov060_021168c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 struct CylinderClsn;
 struct Actor;
 struct WithMeshClsn { int JustHitGround() const; };
@@ -11,7 +16,6 @@ struct Actor {
 };
 struct ActorBase { void MarkForDestruction(); };
 extern "C" int func_ov060_02116518(char* c, int a, int b, int d);
-extern "C" int func_ov060_021172c8(unsigned char* p, unsigned int n);
 extern Fix12i Vec3_HorzDist(const Vector3* a, const Vector3* b);
 
 extern "C" void func_ov060_021168c4(char* c)

--- a/src/func_ov060_021169b0.c
+++ b/src/func_ov060_021169b0.c
@@ -1,8 +1,13 @@
+// @symbol func_ov060_021169b0
+// @emits Bowser_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: renamed to Class_Method */
+/* daKpa_c::Kill - recovered from vtable slot identity */
 extern int RandomIntInternal(int* seed);
-extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void* thiz);
 extern int data_0209e650;
 
-void func_ov060_021169b0(char* thiz) {
+void Bowser_Kill(char* thiz) {
     *(int*)(thiz + 0xa8) = 0x1e000;
     *(int*)(thiz + 0x98) = 0xf000;
     *(short*)(thiz + 0x376) = (unsigned int)RandomIntInternal(&data_0209e650) >> 16;

--- a/src/func_ov060_021169f8.c
+++ b/src/func_ov060_021169f8.c
@@ -1,6 +1,9 @@
+// @symbol func_ov060_021169f8
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+
+
 struct Actor;
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* self, void* c);
 extern void func_ov060_02116518(char* self, int a, int b, int c);

--- a/src/func_ov060_021172e0.cpp
+++ b/src/func_ov060_021172e0.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov060_021172e0
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int s32;
 typedef int Fix12i;
 typedef short s16;
 typedef signed char s8;
 
-struct Vector3 { Fix12i x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 
 extern "C" {
     void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12i x, Fix12i y, Fix12i z);

--- a/src/func_ov060_02117624.cpp
+++ b/src/func_ov060_02117624.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol func_ov060_02117624
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M48 { int w[12]; };
+
 void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *thisp, void *sm, void *mtx, int rad, int t, unsigned int j);
-extern M48 data_020a0e68;
+extern Matrix4x3 data_020a0e68;
 void func_ov060_02117624(char *c) {
     if (*(unsigned char*)(c+0x379) == 0) return;
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x5c)>>3, *(int*)(c+0x364)>>3, *(int*)(c+0x64)>>3);
-    *(M48*)(c+0x32c) = data_020a0e68;
+    *(Matrix4x3*)(c+0x32c) = data_020a0e68;
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x304, c+0x32c, *(int*)(c+0x368) * *(int*)(c+0x360), 0x1e000, 0xf);
 }
 }

--- a/src/func_ov060_02117a64.c
+++ b/src/func_ov060_02117a64.c
@@ -1,13 +1,16 @@
+// @symbol func_ov060_02117a64
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, short ang);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void *m, short ang);
 extern void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void *self, void *m, short s);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov060_02117a64(char *c) {
     Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
     Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(c+0x8c));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-    *(struct M*)(c+0x2ec) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x2ec) = data_020a0e68;
     _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(c+0x374, c+0x2ec, *(short*)(c+0x8e));
 }

--- a/src/func_ov060_02117ae0.c
+++ b/src/func_ov060_02117ae0.c
@@ -1,14 +1,16 @@
-struct M48 { int w[12]; };
+// @symbol func_ov060_02117ae0
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void* d, void* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* mF, short angX);
 extern void Matrix4x3_ApplyInPlaceToRotationZ(void* mF, short angZ);
-extern struct M48 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov060_02117ae0(char* c) {
   int v[4];
   Vec3_Asr(&v, c+0x5c, 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
   Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(c+0x8c));
   Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(c+0x90));
-  *(struct M48*)(c+0x340) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x340) = data_020a0e68;
 }

--- a/src/func_ov060_02117d1c.c
+++ b/src/func_ov060_02117d1c.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov060_02117d1c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10daKpa3Bg_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov060_02117d1c(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10daKpa3Bg_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov060_02117d60.c
+++ b/src/func_ov060_02117d60.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov060_02117d60
+// @emits daKpa3Bg_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daKpa3Bg_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov060_02117d60(int *t)
+int *daKpa3Bg_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov060_021181e8.c
+++ b/src/func_ov060_021181e8.c
@@ -1,11 +1,19 @@
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov060_021181e8
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daKpa3Bg_c.h"
+// @emits daKpa3Bg_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daKpa3Bg_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void *data_ov060_02119514[];
 extern void *data_ov060_0211953c[];
-int func_ov060_021181e8(char *c)
+int daKpa3Bg_c_CleanupResources(char *c)
 {
+    struct daKpa3Bg_c *self = (struct daKpa3Bg_c *)(void *)c;
     _ZN16MeshColliderBase7DisableEv(c + 0x124);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov060_02119514[*(unsigned char *)(c + 0x329)]);
-    _ZN13SharedFilePtr7ReleaseEv(data_ov060_0211953c[*(unsigned char *)(c + 0x329)]);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov060_02119514[self->unk_329]);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov060_0211953c[self->unk_329]);
     return 1;
 }

--- a/src/func_ov060_0211822c.cpp
+++ b/src/func_ov060_0211822c.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov060_0211822c
+// @emits daKpa3Bg_c_Render
+/* recovered: renamed to Class_Method */
+/* daKpa3Bg_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov060_0211822c(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daKpa3Bg_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov060_02118254.cpp
+++ b/src/func_ov060_02118254.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov060_02118254
+// @emits daKpa3Bg_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daKpa3Bg_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
@@ -11,7 +15,7 @@ struct C {
     unsigned char pad2[2];
     unsigned char flag;
 };
-extern "C" int func_ov060_02118254(C* c) {
+extern "C" int daKpa3Bg_c_Behavior(C* c) {
     (c->*(data_ov060_0211b1ac[c->idx].pmf))();
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov060_021182b0.cpp
+++ b/src/func_ov060_021182b0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov060_021182b0
+// @emits daKpa3Bg_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daKpa3Bg_c::InitResources - recovered from vtable slot identity */
 struct BMD_File; struct KCL_File; struct Actor; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
 struct Vector3;
@@ -23,8 +27,8 @@ extern "C" CLPS_Block* data_ov060_0211a980[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern "C" void func_ov060_021183f4();
 
-extern "C" int func_ov060_021182b0(char* self);
-int func_ov060_021182b0(char* self)
+extern "C" int daKpa3Bg_c_InitResources(char* self);
+int daKpa3Bg_c_InitResources(char* self)
 {
     int idx = *(int*)(self + 8) & 0xf;
     *(unsigned char*)(self + 0x329) = (unsigned char)idx;

--- a/src/func_ov060_021185c4.c
+++ b/src/func_ov060_021185c4.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov060_021185c4
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void func_02012694(int a, void* b);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, struct Vector3* v, int f);

--- a/src/func_ov060_02118728.c
+++ b/src/func_ov060_02118728.c
@@ -1,16 +1,20 @@
+// @symbol func_ov060_02118728
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 
-struct Vec3 { int x, y, z; };
+
 
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
-extern int Vec3_Dist(struct Vec3 *a, struct Vec3 *b);
+extern int Vec3_Dist(struct Vector3 *a, struct Vector3 *b);
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov060_021186d8(void *o);
 
 void func_ov060_02118728(char *c)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     void *player;
     char *bestActor;
     char *actor;
@@ -22,12 +26,12 @@ void func_ov060_02118728(char *c)
     if (player == 0) return;
 
     {
-        struct Vec3 *pp = (struct Vec3 *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
+        struct Vector3 *pp = (struct Vector3 *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFFULL);
         v.x = pp->x;
         v.y = pp->y;
         v.z = pp->z;
     }
-    best = Vec3_Dist((struct Vec3 *)(c + 0x5c), &v);
+    best = Vec3_Dist((struct Vector3 *)(c + 0x5c), &v);
     bestActor = c;
 
     for (i = 0; i < 8; i++) {
@@ -38,7 +42,7 @@ void func_ov060_02118728(char *c)
             if (*(int *)(actor + 0x170) != 3) return;
             if (((*(int *)(actor + 0xb0) & 8) ? 1 : 0) == 0) continue;
             {
-                int d = Vec3_Dist(&v, (struct Vec3 *)(actor + 0x5c));
+                int d = Vec3_Dist(&v, (struct Vector3 *)(actor + 0x5c));
                 if (d < best) {
                     best = d;
                     bestActor = actor;

--- a/src/func_ov062_02116010.c
+++ b/src/func_ov062_02116010.c
@@ -1,3 +1,8 @@
+// @symbol func_ov062_02116010
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef short s16;
@@ -6,14 +11,12 @@ extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_020ada40(void *c, void *v, void *a, int flag);
 extern void func_02012694(int a, void *p);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void *c);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player7TryGrabER5Actor(void *p, void *a);
 extern void func_ov062_02116cd8(void *c, void *p);
 extern int func_ov002_020db5f4(void *c, void *arg);
 extern int data_ov062_0211dea0[];
-extern int data_ov062_0211def0[];
 
-struct V3s { s16 x, y, z; };
+
 
 void func_ov062_02116010(char *c)
 {
@@ -21,7 +24,7 @@ void func_ov062_02116010(char *c)
     void *a;
     int b;
     int angle;
-    struct V3s v;
+    struct Vector3_16 v;
 
     id = *(u32 *)(c + 0x134);
     if (id != 0 &&

--- a/src/func_ov062_021165e8.c
+++ b/src/func_ov062_021165e8.c
@@ -1,9 +1,12 @@
+// @symbol func_ov062_021165e8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
-extern int func_ov062_02115f84(void* c);
 extern void func_ov062_02116cd8(void* c, void* p);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern int ApproachAngle(short* angle, int target, int a, int b, int c);
-extern int AngleDiff(int a, int b);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const void* v, unsigned int e);
 extern int Vec3_Dist(const void* a, const void* b);
 
@@ -11,14 +14,14 @@ extern char data_ov062_0211df00;
 extern char data_ov062_0211de70;
 extern char data_ov062_0211ded0;
 
-struct Vec3 { int x, y, z; };
+
 
 int func_ov062_021165e8(char* c)
 {
     char* player;
     int r;
-    volatile struct Vec3 pos;
-    struct Vec3* pp;
+    volatile struct Vector3 pos;
+    struct Vector3* pp;
 
     player = (char*)_ZN5Actor13ClosestPlayerEv(c);
     r = func_ov062_02115f84(c);
@@ -33,7 +36,7 @@ int func_ov062_021165e8(char* c)
     if (player == 0)
         return 1;
 
-    pp = (struct Vec3*)(int)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    pp = (struct Vector3*)(int)(((long long)(int)(player + 0x5c)));
     pos.x = pp->x;
     pos.y = pp->y;
     pos.z = pp->z;

--- a/src/func_ov062_02116d28.cpp
+++ b/src/func_ov062_02116d28.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov062_02116d28
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Matrix4x3 { int m[12]; };
+
 struct ShadowModel;
 struct Actor {
     void DropShadowRadHeight(ShadowModel &sm, Matrix4x3 &mtx, Fix12 a, int b, unsigned int c);

--- a/src/func_ov062_02116dbc.cpp
+++ b/src/func_ov062_02116dbc.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov062_02116dbc
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Matrix4x3 { int w[12]; };
+
 struct ShadowModel;
 
 extern Matrix4x3 data_02082128;

--- a/src/func_ov062_02116edc.cpp
+++ b/src/func_ov062_02116edc.cpp
@@ -1,11 +1,13 @@
 //cpp
+// @symbol func_ov062_02116edc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 int Math_Function_0203b14c(void*, int, int, int, int);
 void* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void*, int, void*);
-struct M48 { int w[12]; };
-extern int data_ov062_0211df10[];
-extern int data_ov062_0211df14[];
-extern int data_ov062_0211df18[];
+
 void func_ov062_02116edc(char* c){
   int idx = 0;
   if(*(int*)(*(int*)(c+0x3f8) + 8) == 2) idx = 1;
@@ -14,6 +16,6 @@ void func_ov062_02116edc(char* c){
   Math_Function_0203b14c(c+0x430, *(int*)((char*)data_ov062_0211df14 + k), 0x800, 0x3e8000, 4);
   Math_Function_0203b14c(c+0x434, *(int*)((char*)data_ov062_0211df18 + k), 0x800, 0x3e8000, 4);
   void* r = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(c, *(int*)(c+0x3f8), c+0x42c);
-  *(struct M48*)(c+0x31c) = *(struct M48*)r;
+  *(struct Matrix4x3*)(c+0x31c) = *(struct Matrix4x3*)r;
 }
 }

--- a/src/func_ov062_02117470.c
+++ b/src/func_ov062_02117470.c
@@ -1,4 +1,8 @@
-int func_ov062_02117470(void)
+// @symbol func_ov062_02117470
+// @emits Chuckya_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daHolhei_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Chuckya_OnAimedAtWithEgg(void)
 {
     return 827392;
 }

--- a/src/func_ov062_02117bf4.cpp
+++ b/src/func_ov062_02117bf4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov062_02117bf4
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 void func_0201267c(int id, char* p);
 void func_ov062_02117994(char* c, int idx);

--- a/src/func_ov062_02118334.c
+++ b/src/func_ov062_02118334.c
@@ -1,20 +1,19 @@
-
+// @symbol func_ov062_02118334
+/* recovered: shared common types */
+#include "common.h"
 struct Vec3
 {
   int x;
   int y;
   int z;
 };
-struct Mtx43
-{
-  int w[12];
-};
+
 void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
-void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
-void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx43 *m, short angY);
-void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *thiz, void *sm, struct Mtx43 *m, int radHeight, int a, unsigned int b);
-extern struct Mtx43 data_020a0e68;
-inline struct Mtx43 *inline_fn()
+void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *m, short angY);
+void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *thiz, void *sm, struct Matrix4x3 *m, int radHeight, int a, unsigned int b);
+extern struct Matrix4x3 data_020a0e68;
+inline struct Matrix4x3 *inline_fn()
 {
   return &data_020a0e68;
 }
@@ -29,7 +28,7 @@ void func_ov062_02118334(char *c)
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     new_var = (short *) (c + 0x8e);
     Matrix4x3_ApplyInPlaceToRotationY(inline_fn(), *new_var);
-    *((struct Mtx43 *) (c + 0x31c)) = data_020a0e68;
+    *((struct Matrix4x3 *) (c + 0x31c)) = data_020a0e68;
     {
       int b = (int) (((*((int *) (c + 0xb0))) & 0x40000) != 0);
       if (b != 0)
@@ -38,5 +37,5 @@ void func_ov062_02118334(char *c)
       }
     }
   }
-  _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, (void *) (c + 0x364), (struct Mtx43 *) (c + 0x31c), 0x50000, 0x50000, 0xf);
+  _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, (void *) (c + 0x364), (struct Matrix4x3 *) (c + 0x31c), 0x50000, 0x50000, 0xf);
 }

--- a/src/func_ov062_02118a50.c
+++ b/src/func_ov062_02118a50.c
@@ -1,14 +1,16 @@
+// @symbol func_ov062_02118a50
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
+
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *w);
-extern void *_ZNK12WithMeshClsn13GetWallResultEv(void *w);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *s, struct Vector3 *v);
 extern s16 _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *self, int a, int b, s16 ang);
-extern void func_ov062_02118004(void *c, int a1);
-extern void func_ov062_02117994(char *c, int idx);
-extern int _ZNK9Animation12WillHitFrameEi(void *anim, int f);
-extern void func_ov062_021175c0(void *c);
 extern int _ZN9Animation8FinishedEv(void *anim);
 
 void func_ov062_02118a50(char *c)
@@ -26,7 +28,7 @@ void func_ov062_02118a50(char *c)
 
     {
         if (*(u16 *)(c + 0x3c6) != 0) {
-            u16 *p = (u16 *)(((long long)(int)(c + 0x3c6)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *p = (u16 *)(((long long)(int)(c + 0x3c6)));
             *p = (u16)(*p - 1);
             if (*(u16 *)((c + 0x300) + 0xc6) != 0) return;
             func_ov062_02117994(c, 8); return;

--- a/src/func_ov062_02119608.cpp
+++ b/src/func_ov062_02119608.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" int func_ov062_02119608(void *c) {
+// @symbol func_ov062_02119608
+// @emits Koopa_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daNknk_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+extern "C" int Koopa_OnAimedAtWithEgg(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xcb) r = 1; else r = 0;

--- a/src/func_ov062_02119628.cpp
+++ b/src/func_ov062_02119628.cpp
@@ -1,5 +1,9 @@
 //cpp
-/* func_ov062_02119628 at 0x02119628 (ov062), size 0x80
+// @symbol func_ov062_02119628
+// @emits Koopa_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daNknk_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* Koopa_OnTurnIntoEgg at 0x02119628 (ov062), size 0x80
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
@@ -17,7 +21,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, bool b, bool c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char b, unsigned int n);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void func_ov062_02119628(Actor *c, void *player) {
+void Koopa_OnTurnIntoEgg(Actor *c, void *player) {
 #pragma optimize_for_size on
     if (c->f108 == 3) {
         if (c->Slot18() == 6 && _ZN6Player15IsCollectingCapEv(player) == 0) {

--- a/src/func_ov062_021196a8.c
+++ b/src/func_ov062_021196a8.c
@@ -1,4 +1,8 @@
-int func_ov062_021196a8(char* c){
+// @symbol func_ov062_021196a8
+// @emits Koopa_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daNknk_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Koopa_OnYoshiTryEat(char* c){
   if(*(int*)(c+0x394)==0) return 6;
   return 5;
 }

--- a/src/func_ov062_021199ac.c
+++ b/src/func_ov062_021199ac.c
@@ -1,10 +1,13 @@
+// @symbol func_ov062_021199ac
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int s32;
 typedef unsigned int u32;
 
-struct Vector3 { s32 x, y, z; };
+
 
 extern void *_ZN5Actor18ClosestWithActorIDEj(void *thiz, u32 id);
 
@@ -52,7 +55,7 @@ int func_ov062_021199ac(char *self)
         fixed2 = (s32)(((long long)selfK * 0xb33 + 0x800) >> 12);
         if (fixed1 < fixed2)
             return 1;
-        *(s32 *)(((long long)(int)(self + 0x98)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x2000;
+        *(s32 *)(((long long)(int)(self + 0x98))) -= 0x2000;
         goto ret0;
     } else {
         if (dist >= 0x12c000)

--- a/src/func_ov062_0211a1f4.c
+++ b/src/func_ov062_0211a1f4.c
@@ -1,10 +1,17 @@
+// @symbol func_ov062_0211a1f4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_Timer.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 struct VVec3 { volatile int x, y, z; };
 
 extern s8 data_0209f2f8;
@@ -15,19 +22,12 @@ extern int data_ov062_0211e014[];
 extern int data_ov062_0211e024[];
 extern int data_ov062_0211e02c[];
 
-extern int _ZN6Player12Unk_020c4f40Et(int p, u16 a);
 extern void _ZN5Sound7PlaySubEjjj5Fix12IiEb(u32 a, u32 b, u32 c, int d, int e);
 extern int _ZN6Player12GetTalkStateEv(int p);
 extern void func_02012694(u32 a, void *b);
-extern void _ZN5Sound22LoadAndSetMusic_Layer2Ej(u32 a);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *m, int f, int a, u32 b, int e);
-extern void _ZN5Timer10StartTimerEv(void *t);
 extern void func_0201267c(u32 a, void *b);
-extern int func_ov062_02119af0(char *p);
-extern void func_ov062_02119800(void *c);
 extern char *_ZN5Actor10FindWithIDEj(u32 id);
-extern void _ZN5Timer9StopTimerEv(void *t);
-extern int func_ov062_021199ac(void *c);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 extern int _ZN5Actor14GetSubtractionEss(void *c, s16 a, int b);
 extern int _ZN6Player22IsBeingShotOutOfCannonEv(int p);
@@ -35,7 +35,6 @@ extern int Vec3_Dist(const void *a, const void *b);
 extern void _Z14ApproachLinearRiii(int *r, int a, int b);
 extern void _Z14ApproachLinearRsss(s16 *r, s16 a, s16 b);
 extern int _ZN9Animation8FinishedEv(void *a);
-extern void func_ov062_02119954(void *c);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *c);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 a, int x, int y, int z);
 

--- a/src/func_ov062_0211a740.cpp
+++ b/src/func_ov062_0211a740.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov062_0211a740
+// @emits Koopa_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daNknk_c::Kill - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -19,13 +23,13 @@ extern int data_ov062_0211e034[];
 extern s8 data_0209f2f8;
 extern u8 data_0209d684;
 extern char data_0209d4c8[];
-extern "C" void func_ov062_0211a740(char* c)
+extern "C" void Koopa_Kill(char* c)
 {
     switch (*(u8*)(c + 0x390)) {
     case 0:
         if (_Z14ApproachLinearRsss((s16*)(c + 0x94), *(s16*)(c + 0x3a8), 0x800) != 0) {
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x300), (void*)data_ov062_0211e03c[1], 0, 0x1000, 0);
-            *(u8*)((((long long)(int)(c + 0x390)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+            *(u8*)((((long long)(int)(c + 0x390)))) += 1;
             func_0201267c(0xec, c + 0x74);
             if (*(int*)(*(int*)(c + 0x398) + 8) == 0) {
                 func_02012790(0xa);
@@ -57,7 +61,7 @@ extern "C" void func_ov062_0211a740(char* c)
                 v.z = z;
             }
             if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void**)(c + 0x398), c, msg, &v, 1, 0) != 0)
-                *(u8*)((((long long)(int)(c + 0x390)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+                *(u8*)((((long long)(int)(c + 0x390)))) += 1;
         }
         return;
     case 2:

--- a/src/func_ov062_0211aac0.c
+++ b/src/func_ov062_0211aac0.c
@@ -1,16 +1,18 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+// @symbol func_ov062_0211aac0
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short angY);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, int a, int b, unsigned int g);
-struct M48 { int w[12]; };
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov062_0211aac0(char* r6){
-  struct Vec3 v;
-  Vec3_Asr(&v, (struct Vec3*)(r6 + 0x5c), 3);
+  struct Vector3 v;
+  Vec3_Asr(&v, (struct Vector3*)(r6 + 0x5c), 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(r6 + 0x8e));
-  *(struct M48*)(r6 + 0x31c) = data_020a0e68;
+  *(struct Matrix4x3*)(r6 + 0x31c) = data_020a0e68;
   _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(r6, r6 + 0x364, r6 + 0x31c, 0xa0000, 0xa0000, 0xf);
 }

--- a/src/func_ov062_0211b3ac.cpp
+++ b/src/func_ov062_0211b3ac.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov062_0211b3ac
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
-struct Vector3 { int x, y, z; };
+
 struct PathPtr { int a, b; };
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern "C" void _ZN7PathPtrC1Ev(PathPtr* self);
@@ -20,7 +23,7 @@ extern "C" int func_ov062_0211b3ac(char* sl)
     int bestDist;
 
     {
-        int *ctr = (int *)(((long long)(int)(sl + 0x460)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *ctr = (int *)(((long long)(int)(sl + 0x460)));
         *ctr = *ctr + 1;
         *ctr = *ctr & 7;
     }
@@ -36,7 +39,7 @@ extern "C" int func_ov062_0211b3ac(char* sl)
     best.x = bestIdx; best.y = bestIdx; best.z = bestIdx;
 
     if (player != 0) {
-        int *pp = (int *)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *pp = (int *)(((long long)(int)(player + 0x5c)));
         ppos.x = *pp;
         i = bestIdx;
         ppos.y = pp[1];

--- a/src/func_ov062_0211b930.cpp
+++ b/src/func_ov062_0211b930.cpp
@@ -1,8 +1,11 @@
 //cpp
+// @symbol func_ov062_0211b930
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 struct BCA_File;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+
+
 
 struct BlendModelAnim {
     int SetAnim(BCA_File& f, int a, int b, Fix12 spd, unsigned short t);

--- a/src/func_ov062_0211ba84.c
+++ b/src/func_ov062_0211ba84.c
@@ -1,7 +1,12 @@
+// @symbol func_ov062_0211ba84
+// @emits KoopaFlag_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daRFlag_c::Kill - recovered from vtable slot identity */
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef short s16;
-typedef struct { int x, y, z; } Vector3;
 extern char *_ZN5Actor13ClosestPlayerEv(char *self);
 extern int func_ov062_0211c658(char *c, void *p);
 extern s16 Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
@@ -10,13 +15,12 @@ extern void _Z14ApproachLinearRsss(s16 *cur, s16 tgt, s16 step);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void *m, s16 angX);
 extern void MulVec3Mat4x3(const Vector3 *v, void *m, Vector3 *out);
-extern void func_ov062_0211b51c(char *c);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(char *self);
 extern void *data_ov062_0211e17c;
 extern signed char data_0209f2f8;
 extern int data_020a0e68[];
 
-int func_ov062_0211ba84(char *c)
+int KoopaFlag_Kill(char *c)
 {
     Vector3 v;
     Vector3 t;

--- a/src/func_ov062_0211c2f4.cpp
+++ b/src/func_ov062_0211c2f4.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol func_ov062_0211c2f4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef signed char s8;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 
 struct PathPtr {
     int a;
@@ -20,12 +25,10 @@ extern s16 Vec3_HorzAngle(const void *a, const void *b);
 extern int ApproachAngle(void *p, int target, int a, int b, int c);
 extern void Vec3_Sub(Vector3 *out, Vector3 *a, Vector3 *b);
 extern int LenVec3(Vector3 *v);
-extern int func_ov062_0211b3ac(void *c);
 extern int RandomIntInternal(int *seed);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void MulVec3Mat4x3(Vector3 *in, void *m, void *out);
 extern void func_ov062_0211c658(void *c, void *p);
-extern int AngleDiff(int a, int b);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalar(void *out, Vector3 *in, int s);
 extern void SubVec3(void *a, void *b, void *c);

--- a/src/func_ov062_0211ce78.c
+++ b/src/func_ov062_0211ce78.c
@@ -1,4 +1,8 @@
-int func_ov062_0211ce78(void)
+// @symbol func_ov062_0211ce78
+// @emits Klepto_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daJango_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Klepto_OnAimedAtWithEgg(void)
 {
     return 458752;
 }

--- a/src/func_ov063_021160c4.c
+++ b/src/func_ov063_021160c4.c
@@ -1,3 +1,7 @@
-int func_ov063_021160c4(void* c) {
+// @symbol func_ov063_021160c4
+// @emits Boo_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daTrs_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Boo_OnAimedAtWithEgg(void* c) {
     return *(int *)((char *)c + 0x18c) / 2;
 }

--- a/src/func_ov063_021162c8.cpp
+++ b/src/func_ov063_021162c8.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov063_021162c8
+/* recovered: shared common types */
+#include "common.h"
 struct Vector3; struct Vector3_16;
 struct CapEnemy { void ReleaseCap(const Vector3 &v); };
 struct Actor {
@@ -6,14 +9,14 @@ struct Actor {
                         const Vector3_16 *p, int e, int f);
 };
 extern "C" void func_0201267c(int a, void *b);
-struct V3 { int x, y, z; };
+
 extern "C" void func_ov063_021162c8(char *self)
 {
     if ((unsigned int)(*(unsigned short*)(self + 0x5d4) << 0x19) >> 0x1f) {
         *(unsigned char*)(self + 0x5cc) = 4;
     } else {
         *(unsigned char*)(self + 0x5cc) = 3;
-        V3 v;
+        Vector3 v;
         v.x = *(int*)(self + 0x564);
         v.y = *(int*)(self + 0x568);
         v.z = *(int*)(self + 0x56c);
@@ -29,7 +32,7 @@ extern "C" void func_ov063_021162c8(char *self)
                 if (*(unsigned short*)(self + 0x4a0) == 0x121)
                     *(unsigned short*)((char*)a + 0x3a8) = 0;
             }
-            unsigned short *ip = (unsigned short *)(((long long)(int)(self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *ip = (unsigned short *)(((long long)(int)(self + 0x5d4)));
             *ip = (unsigned short)(*ip & ~2);
         }
     }

--- a/src/func_ov063_0211640c.c
+++ b/src/func_ov063_0211640c.c
@@ -1,3 +1,8 @@
+// @symbol func_ov063_0211640c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_propagation off
 typedef int s32;
 typedef unsigned int u32;
@@ -5,10 +10,10 @@ typedef unsigned short u16;
 typedef signed short s16;
 typedef unsigned char u8;
 
-struct Matrix4x3 { int m[12]; };
-struct Vec3 { int x, y, z; };
 
-extern void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
+
+
+extern void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void _ZN9ModelBase12ApplyOpacityEj(void *self, u32 a, int z);
 extern void func_020167a4(void *p);
@@ -16,13 +21,12 @@ extern void _ZN15ModelComponents21UpdateVertsUsingBonesEv(void *p);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void *m, s16 ang);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *sm, void *mtx, int a, int b, u32 g);
-extern void func_ov063_021160d4(void *c);
 
 extern struct Matrix4x3 data_020a0e68;
 
 void func_ov063_0211640c(char *c)
 {
-    struct Vec3 pos, t1, t2;
+    struct Vector3 pos, t1, t2;
     s16 ang;
 
     if (((u32)(*(u16 *)(c + 0x5d4) << 0x1c) >> 0x1f) == 0)

--- a/src/func_ov063_02116e14.cpp
+++ b/src/func_ov063_02116e14.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov063_02116e14
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct V3 { int x, y, z; };
+
 extern "C" {
 void func_ov063_02119e38(char* c, int a, int b, int d);
 int func_ov063_0211a0dc(char* c);
 int func_ov063_0211adb4(char* c);
 void func_0201267c(int a, void* p);
-int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
+int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 
 void func_ov063_02116e14(char* c){
     *(unsigned short*)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~0x40;
@@ -32,7 +35,7 @@ void func_ov063_02116e14(char* c){
     *(unsigned char*)(c + 0x5cc) = 3;
     {
         char* r = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-            *(unsigned short*)(c + 0x4a0), 0, (struct V3*)(c + 0x504), 0,
+            *(unsigned short*)(c + 0x4a0), 0, (struct Vector3*)(c + 0x504), 0,
             *(signed char*)(c + 0x5d0), -1);
         if (r != 0) {
             *(int*)(r + 0xa4) = 0;

--- a/src/func_ov063_02116fac.c
+++ b/src/func_ov063_02116fac.c
@@ -1,3 +1,8 @@
+// @symbol func_ov063_02116fac
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef unsigned int u32;
@@ -7,11 +12,10 @@ extern void func_0201267c(unsigned int id, void* p);
 extern void _Z14ApproachLinearRiii(int* p, int target, int step);
 extern short Vec3_HorzAngle(const void* a, const void* b);
 extern void _Z14ApproachLinearRsss(short* p, short target, int step);
-extern char* func_ov063_0211a964(char* c, int n);
 
-struct Vec3 { int x, y, z; };
+
 struct Frame {
-    struct Vec3 v;
+    struct Vector3 v;
     int pad[10];
 };
 

--- a/src/func_ov063_02117650.c
+++ b/src/func_ov063_02117650.c
@@ -1,5 +1,6 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov063_02117650
+/* recovered: shared common types */
+#include "common.h"
 extern void *_ZN5Actor13ClosestPlayerEv(void);
 extern int RandomIntInternal(int *seed);
 extern int Vec3_HorzDist(struct Vector3 *a, struct Vector3 *b);

--- a/src/func_ov063_02118ddc.cpp
+++ b/src/func_ov063_02118ddc.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov063_02118ddc
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x,y,z; };
+
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vector3* v, const void* w, int s0, int s1);
 extern int func_02012694(int a, char* p);
 void func_ov063_02118ddc(char* c){

--- a/src/func_ov063_0211c480.cpp
+++ b/src/func_ov063_0211c480.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" int func_ov063_0211c480(void *c) {
+// @symbol func_ov063_0211c480
+// @emits Boo_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daTrs_c::OnYoshiTryEat - recovered from vtable slot identity */
+extern "C" int Boo_OnYoshiTryEat(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xd1) r = 1; else r = 0;

--- a/src/func_ov063_0211c684.c
+++ b/src/func_ov063_0211c684.c
@@ -1,13 +1,16 @@
+// @symbol func_ov063_0211c684
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov063_0211c684(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0xf0) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0xf0) = data_020a0e68;
 }

--- a/src/func_ov063_0211c6f8.cpp
+++ b/src/func_ov063_0211c6f8.cpp
@@ -1,13 +1,16 @@
 //cpp
-struct M48 { int w[12]; };
+// @symbol func_ov063_0211c6f8
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern "C" void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void* self, void* mtx, short s);
-extern "C" struct M48 data_020a0e68;
+extern "C" struct Matrix4x3 data_020a0e68;
 extern "C" void func_ov063_0211c6f8(char* c);
 extern "C" void func_ov063_0211c6f8(char* c) {
   Matrix4x3_FromTranslation(&data_020a0e68, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68, *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-  *(struct M48*)(c+0x324) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x324) = data_020a0e68;
   _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(c+0x15c, c+0x324, *(short*)(c+0x8e));
 }

--- a/src/func_ov063_0211c7b0.c
+++ b/src/func_ov063_0211c7b0.c
@@ -1,6 +1,11 @@
-extern void func_ov063_0211c82c(char *c);
+// @symbol func_ov063_0211c7b0
+// @emits BooCage_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daTBasket_c::Kill - recovered from vtable slot identity */
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int e);
-void func_ov063_0211c7b0(char *c) {
+void BooCage_Kill(char *c) {
     short *t;
     if (*(unsigned char*)(c + 0x150) != 0) {
         *(short*)(c + 0x100 + 0x3a) = 0;

--- a/src/func_ov063_0211d5f4.c
+++ b/src/func_ov063_0211d5f4.c
@@ -1,19 +1,22 @@
+// @symbol func_ov063_0211d5f4
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vec3 { int x, y, z; };
+
 
 extern void Matrix4x3_FromRotationY(void* m, int angle);
-extern void MulVec3Mat4x3(struct Vec3* in, void* m, struct Vec3* out);
-extern void AddVec3(struct Vec3* a, struct Vec3* b, struct Vec3* c);
+extern void MulVec3Mat4x3(struct Vector3* in, void* m, struct Vector3* out);
+extern void AddVec3(struct Vector3* a, struct Vector3* b, struct Vector3* c);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void* self, void* sm, void* mtx, int fx, int t, unsigned int u);
 extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void* self, void* sm, void* mtx, int fx, int t1, int t2, unsigned int u);
 
-extern struct Vec3 data_020a0e68;
+extern struct Vector3 data_020a0e68;
 
 void func_ov063_0211d5f4(char* self)
 {
-    struct Vec3 in, out;
+    struct Vector3 in, out;
 
     in.x = 0x40000;
     in.y = 0;
@@ -23,7 +26,7 @@ void func_ov063_0211d5f4(char* self)
     in.z = -0x10000;
     Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(self + 0x8e));
     MulVec3Mat4x3(&in, &data_020a0e68, &out);
-    AddVec3(&out, (struct Vec3*)(self + 0x5c), &out);
+    AddVec3(&out, (struct Vector3*)(self + 0x5c), &out);
     Matrix4x3_FromRotationY(self + 0x45c, *(s16*)(self + 0x8e));
     *(int*)(self + 0x480) = out.x >> 3;
     *(int*)(self + 0x484) = *(int*)(self + 0x60) >> 3;
@@ -37,7 +40,7 @@ void func_ov063_0211d5f4(char* self)
     in.x = -0x60000;
     Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(self + 0x8e));
     MulVec3Mat4x3(&in, &data_020a0e68, &out);
-    AddVec3(&out, (struct Vec3*)(self + 0x5c), &out);
+    AddVec3(&out, (struct Vector3*)(self + 0x5c), &out);
     Matrix4x3_FromRotationY(self + 0x3fc, *(s16*)(self + 0x8e));
     *(int*)(self + 0x420) = out.x >> 3;
     *(int*)(self + 0x424) = *(int*)(self + 0x60) >> 3;
@@ -51,7 +54,7 @@ void func_ov063_0211d5f4(char* self)
     in.z = -0x10000;
     Matrix4x3_FromRotationY(&data_020a0e68, *(s16*)(self + 0x8e));
     MulVec3Mat4x3(&in, &data_020a0e68, &out);
-    AddVec3(&out, (struct Vec3*)(self + 0x5c), &out);
+    AddVec3(&out, (struct Vector3*)(self + 0x5c), &out);
     Matrix4x3_FromRotationY(self + 0x42c, *(s16*)(self + 0x8e));
     *(int*)(self + 0x450) = out.x >> 3;
     *(int*)(self + 0x454) = *(int*)(self + 0x60) >> 3;

--- a/src/func_ov063_0211d828.cpp
+++ b/src/func_ov063_0211d828.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov063_0211d828
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov063_0211d828(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0x33c);
+    o->m = *(Matrix4x3*)(self + 0x33c);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov063_0211d8cc.cpp
+++ b/src/func_ov063_0211d8cc.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov063_0211d8cc
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef long long s64;
 
-struct Vector3 { int x, y, z; };
+
 
 extern "C" {
 u8 DecIfAbove0_Byte(u8* p);

--- a/src/func_ov064_02115f84.c
+++ b/src/func_ov064_02115f84.c
@@ -1,3 +1,7 @@
+// @symbol func_ov064_02115f84
+// @emits daBDonketu_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBDonketu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 struct UnknownStruct {
     char pad[0x24];
     int value;
@@ -8,7 +12,7 @@ struct Context {
     struct UnknownStruct* ptr;
 };
 
-int func_ov064_02115f84(void* c) {
+int daBDonketu_c_OnAimedAtWithEgg(void* c) {
     struct UnknownStruct* r1 = ((struct Context*)c)->ptr;
     int r0 = 0x14000;
     if (r1 != 0) {

--- a/src/func_ov064_02116110.cpp
+++ b/src/func_ov064_02116110.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol func_ov064_02116110
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 int _ZN5Actor13ClosestPlayerEv(char *self);
 short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);

--- a/src/func_ov064_021166f0.c
+++ b/src/func_ov064_021166f0.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov064_021166f0
+/* recovered: shared common types */
+#include "common.h"
 extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 extern void _Z14ApproachLinearRsss(short *a, short b, short c);
 struct Actor { char pad; };

--- a/src/func_ov064_0211712c.c
+++ b/src/func_ov064_0211712c.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov064_0211712c
+/* recovered: shared common types */
+#include "common.h"
 extern void func_0201267c(unsigned int id, const struct Vector3 *v);
 
 void func_ov064_0211712c(char *p) {

--- a/src/func_ov064_021171b0.c
+++ b/src/func_ov064_021171b0.c
@@ -1,5 +1,10 @@
-extern int func_ov064_02116110(char* self, short step);
-int func_ov064_021171b0(char* self){
+// @symbol func_ov064_021171b0
+// @emits daDonketu_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDonketu_c::Kill - recovered from vtable slot identity */
+int daDonketu_c_Kill(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov064_0211755c.c
+++ b/src/func_ov064_0211755c.c
@@ -1,5 +1,10 @@
-extern int func_ov064_02116110(char* self, short step);
-int func_ov064_0211755c(char* self){
+// @symbol func_ov064_0211755c
+// @emits daBDonketu_c_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daBDonketu_c::Kill - recovered from vtable slot identity */
+int daBDonketu_c_Kill(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov064_021175cc.cpp
+++ b/src/func_ov064_021175cc.cpp
@@ -1,18 +1,26 @@
 //cpp
+// @symbol func_ov064_021175cc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daBDonketu_c.h"
+// @emits daBDonketu_c_AfterClsn
+/* recovered: renamed to Class_Method */
+/* daBDonketu_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
-extern int func_ov064_0211616c(void*);
 extern void _ZN5Actor14TriplePoofDustEv(void*);
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void*,void*,unsigned int,void*,unsigned int);
-int func_ov064_021175cc(char* c){
+int daBDonketu_c_AfterClsn(char* c){
+    struct daBDonketu_c *self = (struct daBDonketu_c *)(void *)c;
   int r=func_ov064_0211616c(c);
   if(r==0) return r;
   _ZN5Actor14TriplePoofDustEv(c);
   int v[3];
-  v[0]=*(int*)(c+0x5c);
-  v[1]=*(int*)(c+0x60);
-  v[2]=*(int*)(c+0x64);
+  v[0]=self->unk_05c;
+  v[1]=self->unk_060;
+  v[2]=self->unk_064;
   v[1]+=0x64000;
   _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(
-    c, c+0x3fd, (*(unsigned char*)(c+0x3fc)|0x40)&0xff, v, 4);
+    c, c+0x3fd, (self->unk_3fc|0x40)&0xff, v, 4);
 }
 }

--- a/src/func_ov064_02117978.c
+++ b/src/func_ov064_02117978.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov064_02117978
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV17daObjFl_Amilift_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov064_02117978(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV17daObjFl_Amilift_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov064_021179bc.c
+++ b/src/func_ov064_021179bc.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov064_021179bc
+// @emits daObjFl_Amilift_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjFl_Amilift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov064_021179bc(int *t)
+int *daObjFl_Amilift_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov064_02117a44.cpp
+++ b/src/func_ov064_02117a44.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov064_02117a44
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 void _ZN5Actor9UpdatePosEP12CylinderClsn(char* self, void* c);
 int Vec3_HorzDist(const void* a, const void* b);

--- a/src/func_ov064_02117c24.c
+++ b/src/func_ov064_02117c24.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov064_02117c24
+/* recovered: shared common types */
+#include "common.h"
 extern void func_ov064_02117a14(char *c, struct Vector3 *a, struct Vector3 *b);
 
 void func_ov064_02117c24(char *c)

--- a/src/func_ov064_02117cc4.c
+++ b/src/func_ov064_02117cc4.c
@@ -1,8 +1,12 @@
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov064_02117cc4
+// @emits daObjFl_Amilift_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Amilift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov064_02117cc4(void *t)
+int daObjFl_Amilift_c_CleanupResources(void *t)
 {
     _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     _ZN13SharedFilePtr7ReleaseEv(G0);

--- a/src/func_ov064_02117cfc.cpp
+++ b/src/func_ov064_02117cfc.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov064_02117cfc
+// @emits daObjFl_Amilift_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjFl_Amilift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov064_02117cfc(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjFl_Amilift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov064_02117e44.cpp
+++ b/src/func_ov064_02117e44.cpp
@@ -1,4 +1,11 @@
 //cpp
+// @symbol func_ov064_02117e44
+// @emits daObjFl_Amilift_c_InitResources
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_PathPtr.h"
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjFl_Amilift_c::InitResources - recovered from vtable slot identity */
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -16,7 +23,6 @@ extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEs
 extern "C" void func_020393d4(void *p, void *v);
 extern "C" void func_020393c4(void *p, void *v);
 extern "C" void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
-extern "C" int _ZNK7PathPtr8NumNodesEv(void *self);
 extern "C" void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, Vector3 *v, unsigned int idx);
 extern "C" void func_ov064_02117a14(char *self, Vector3 *a, Vector3 *b);
 
@@ -24,11 +30,10 @@ extern SharedFilePtr data_ov064_0211c730;
 extern SharedFilePtr data_ov064_0211c728;
 extern CLPS_Block data_ov064_0211bb6c;
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
-extern "C" void func_ov064_02117fd4();
 
 struct V3 { int x, y, z; };
 
-extern "C" int func_ov064_02117e44(char *self)
+extern "C" int daObjFl_Amilift_c_InitResources(char *self)
 {
     BMD_File *bmd;
     KCL_File *kcl;

--- a/src/func_ov064_02118760.c
+++ b/src/func_ov064_02118760.c
@@ -1,8 +1,12 @@
+// @symbol func_ov064_02118760
+// @emits RotatingFirebar_AfterClsn
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjFl_KomaU_c::AfterClsn - recovered from vtable slot identity */
 typedef unsigned int u32;
 struct Vector3 { int x, y, z; };
 struct Vector3_16 { short x, y, z; };
 void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 p, const struct Vector3 *pos, const struct Vector3_16 *rot, int a, int b);
-int func_ov064_02118760(char *c)
+int RotatingFirebar_AfterClsn(char *c)
 {
   int yadj;
   int zcopy;

--- a/src/func_ov064_02118b08.c
+++ b/src/func_ov064_02118b08.c
@@ -1,4 +1,8 @@
-int func_ov064_02118b08(void)
+// @symbol func_ov064_02118b08
+// @emits LavaBubble_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daBbl_c::OnYoshiTryEat - recovered from vtable slot identity */
+int LavaBubble_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov064_02118c10.c
+++ b/src/func_ov064_02118c10.c
@@ -1,8 +1,11 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov064_02118c10(int *t)
+// @symbol func_ov064_02118c10
+// @emits daObjFl_Coin_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjFl_Coin_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *daObjFl_Coin_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov064_02118c48.c
+++ b/src/func_ov064_02118c48.c
@@ -1,9 +1,12 @@
+// @symbol func_ov064_02118c48
+/* recovered: shared common types */
+#include "common.h"
 // Spawns actor 0x120 (param 2) at this actor's position with the signed byte
 // param at +0xcc; if this actor stores a link ID at +0x320, finds that actor,
 // copies its unique ID (+4) into the spawned actor's +0xd4, and bumps the
 // found actor's byte refcount at +0xd6.
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+
+
 extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vector3* pos, const struct Vector3_16* rot, int e, int f);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 
@@ -19,5 +22,5 @@ void func_ov064_02118c48(char* r5)
     if (found == 0)
         return;
     *(int*)(spawned + 0xd4) = *(int*)(found + 4);
-    (*(unsigned char*)((long long)(int)(found + 0xd6) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+    (*(unsigned char*)((long long)(int)(found + 0xd6))) += 1;
 }

--- a/src/func_ov064_02118d3c.c
+++ b/src/func_ov064_02118d3c.c
@@ -1,6 +1,11 @@
+// @symbol func_ov064_02118d3c
+// @emits LavaBubble_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daBbl_c::Kill - recovered from vtable slot identity */
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov064_02118c48(void *c);
-void func_ov064_02118d3c(char *c){
+void LavaBubble_Kill(char *c){
   if (*(unsigned char*)(c+0x33a) != 0) {
     unsigned int id = *(unsigned int*)(c+0x320);
     if (id != 0) {

--- a/src/func_ov064_02118e24.cpp
+++ b/src/func_ov064_02118e24.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov064_02118e24
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int n, const struct Vector3 *v);
 

--- a/src/func_ov064_02119010.c
+++ b/src/func_ov064_02119010.c
@@ -1,8 +1,10 @@
-struct Mtx { int w[12]; };
-extern void Matrix4x3_FromTranslation(struct Mtx* m, int x, int y, int z);
+// @symbol func_ov064_02119010
+/* recovered: shared common types */
+#include "common.h"
+extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 void func_ov064_02119010(char* c) {
     int x = *(int*)((char*)c + 0x5c) >> 3;
     int y = (*(int*)((char*)c + 0x60) + *(int*)((char*)c + 0x330)) >> 3;
     int z = *(int*)((char*)c + 0x64) >> 3;
-    Matrix4x3_FromTranslation((struct Mtx*)((char*)c + 0xf0), x, y, z);
+    Matrix4x3_FromTranslation((struct Matrix4x3*)((char*)c + 0xf0), x, y, z);
 }

--- a/src/func_ov064_0211915c.c
+++ b/src/func_ov064_0211915c.c
@@ -1,8 +1,12 @@
+// @symbol func_ov064_0211915c
+// @emits daObjFl_Coin_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjFl_Coin_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 
 extern int _ZN5Actor13DistToCPlayerEv(void *self);
 
-int func_ov064_0211915c(char *a)
+int daObjFl_Coin_c_Behavior(char *a)
 {
     switch (*(u8 *)(a + 0xd5)) {
     case 0:

--- a/src/func_ov064_02119284.c
+++ b/src/func_ov064_02119284.c
@@ -1,7 +1,14 @@
-int func_ov064_02119284(char *p)
+// @symbol func_ov064_02119284
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjFl_Coin_c.h"
+// @emits daObjFl_Coin_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjFl_Coin_c::InitResources - recovered from vtable slot identity */
+int daObjFl_Coin_c_InitResources(char *p)
 {
-    *(char *)(p + 0xd5) = 0;
-    *(char *)(p + 0xd4) = 0;
-    *(char *)(p + 0xd6) = 0;
+    struct daObjFl_Coin_c *self = (struct daObjFl_Coin_c *)(void *)p;
+    self->unk_0d5 = 0;
+    self->unk_0d4 = 0;
+    self->unk_0d6 = 0;
     return 1;
 }

--- a/src/func_ov064_02119afc.cpp
+++ b/src/func_ov064_02119afc.cpp
@@ -1,8 +1,13 @@
 //cpp
+// @symbol func_ov064_02119afc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned int u32;
-struct Vector3 { int x, y, z; };
+
 
 extern "C" {
 void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* t, const Vector3& v);
@@ -13,7 +18,6 @@ short _ZN5Actor18HorzAngleToCPlayerEv(void* t);
 void _ZN6Player4HealEi(void* p, int amt);
 void func_ov064_02119ecc(void* c, void* p);
 extern Vector3 data_ov064_0211c3d0;
-extern int data_ov064_0211c944;
 }
 
 static inline void CopyVec(Vector3* d, const Vector3* s)

--- a/src/func_ov064_02119ea0.c
+++ b/src/func_ov064_02119ea0.c
@@ -1,7 +1,11 @@
+// @symbol func_ov064_02119ea0
+// @emits BowserPuzzlePiece_Kill
+/* recovered: renamed to Class_Method */
+/* daWater_Hakidasi_c::Kill - recovered from vtable slot identity */
 typedef signed short s16;
 typedef int s32;
 extern s32 _ZN5Actor18HorzAngleToCPlayerEv(void* self);
-s32 func_ov064_02119ea0(char* c) {
+s32 BowserPuzzlePiece_Kill(char* c) {
     *(s16*)(c + 0x100) = 0xc8;
     s32 angle = _ZN5Actor18HorzAngleToCPlayerEv(c);
     *(s16*)(c + 0x388) = (s16)angle;

--- a/src/func_ov064_02119f1c.cpp
+++ b/src/func_ov064_02119f1c.cpp
@@ -1,18 +1,21 @@
 //cpp
+// @symbol func_ov064_02119f1c
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x,y,z; };
-struct M43 { int w[12]; };
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+
+
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN9ModelBase12ApplyOpacityEj(void* m, unsigned int j, int k);
-extern struct M43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov064_02119f1c(char* c){
-  struct Vec3 v;
-  Vec3_Asr(&v, (struct Vec3*)(c+0x5c), 3);
+  struct Vector3 v;
+  Vec3_Asr(&v, (struct Vector3*)(c+0x5c), 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
   Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68, *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
   _ZN9ModelBase12ApplyOpacityEj(c+0x30c, *(unsigned char*)(c+0x380), 1);
-  *(struct M43*)(c+0x328) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x328) = data_020a0e68;
 }
 }

--- a/src/func_ov064_0211a2c4.cpp
+++ b/src/func_ov064_0211a2c4.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov064_0211a2c4
+// @emits WaterRing_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daWater_Ring_c::Kill - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; };
 extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
 struct Actor {
     void UntrackAndSpawnStar(signed char &a, unsigned int b, const Vector3 &c, unsigned int d);
 };
 
-extern "C" void func_ov064_0211a2c4(char *thiz)
+extern "C" void WaterRing_Kill(char *thiz)
 {
     Vector3 v;
     if (*(unsigned char*)(thiz + 0x173) == 0) return;

--- a/src/func_ov064_0211a39c.cpp
+++ b/src/func_ov064_0211a39c.cpp
@@ -1,13 +1,17 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov064_0211a39c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Vec3_16 {};
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(char*);
 extern char* _ZN5Actor13ClosestPlayerEv(char*);
-extern void _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(char*, Vec3*, unsigned int, int, unsigned short, char*);
-extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, Vec3*, Vec3_16*, int, int);
+extern void _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(char*, Vector3*, unsigned int, int, unsigned short, char*);
+extern char* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, Vector3*, Vec3_16*, int, int);
 extern int _ZN9Animation8FinishedEv(char*);
-extern void func_ov064_0211a6ec(char*, int);
 
 void func_ov064_0211a39c(char* c)
 {
@@ -16,7 +20,7 @@ void func_ov064_0211a39c(char* c)
     {
         char* p = _ZN5Actor13ClosestPlayerEv(c);
 
-        Vec3 v1;
+        Vector3 v1;
         v1.x = *(int*)(c + 0x5c);
         v1.y = *(int*)(c + 0x60);
         v1.z = *(int*)(c + 0x64);
@@ -24,7 +28,7 @@ void func_ov064_0211a39c(char* c)
 
         if (*(unsigned char*)(c + 0x173) == 0)
         {
-            Vec3 v2;
+            Vector3 v2;
             v2.x = v1.x;
             v2.y = v1.y;
             v2.z = v1.z;

--- a/src/func_ov065_02116364.cpp
+++ b/src/func_ov065_02116364.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol func_ov065_02116364
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
+
 struct V3A { int w[3]; };
 
 extern "C" {
@@ -27,15 +32,14 @@ extern int data_020a0e68;
 struct SFP { void* a; void* b; };
 extern SFP data_ov065_0211d600;
 extern int data_ov065_0211d670;
-extern int data_ov065_0211d680;
 
 extern "C" int func_ov065_02116364(void* self)
 {
     u8* c = (u8*)self;
-    struct { Vec3 pp; Vec3 spv; Vec3 sout; Vec3 d; Vec3 tgt; } L;
+    struct { Vector3 pp; Vector3 spv; Vector3 sout; Vector3 d; Vector3 tgt; } L;
     u8* pl = (u8*)_ZN5Actor22ClosestNonVanishPlayerEv(self);
     if (pl != 0) {
-        *(V3A*)(int)(((long long)(int)&L.pp) & 0xFFFFFFFFFFFFFFFFLL) = *(V3A*)(int)(((long long)(int)(pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        *(V3A*)(int)(((long long)(int)&L.pp)) = *(V3A*)(int)(((long long)(int)(pl + 0x5c)));
         L.tgt = L.pp;
         *(s16*)(c+0x3e0) = Vec3_HorzAngle((void*)(c+0x5c), &L.tgt);
         ApproachAngle((void*)(c+0x94), *(s16*)(c+0x3e0), 1, 0x500, 0x500);
@@ -58,7 +62,7 @@ extern "C" int func_ov065_02116364(void* self)
                 *(s32*)(sp2+0xa4) = L.sout.x;
                 *(s32*)(sp2+0xa8) = L.sout.y;
                 *(s32*)(sp2+0xac) = L.sout.z;
-                *(s32*)(int)(((long long)(int)(c + 0x3dc)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(s32*)(int)(((long long)(int)(c + 0x3dc))) += 1;
                 *(u16*)(c+0x100) = 4;
             }
         }
@@ -66,7 +70,7 @@ extern "C" int func_ov065_02116364(void* self)
 
     if (_ZN9Animation8FinishedEv((void*)(c+0x350)) != 0) {
         if (pl != 0) {
-            s32* dsrc = (s32*)(int)(((long long)(int)(pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            s32* dsrc = (s32*)(int)(((long long)(int)(pl + 0x5c)));
             L.d.x = dsrc[0];
             L.d.y = dsrc[1];
             L.d.z = dsrc[2];

--- a/src/func_ov065_021165d8.cpp
+++ b/src/func_ov065_021165d8.cpp
@@ -1,25 +1,29 @@
 //cpp
+// @symbol func_ov065_021165d8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct V{int x,y,z;};
+
 extern char* _ZN5Actor22ClosestNonVanishPlayerEv(void);
-extern short Vec3_HorzAngle(const void*,const struct V*);
-extern short Vec3_VertAngle(const void*,const struct V*);
-extern int Vec3_Dist(const void*,const struct V*);
+extern short Vec3_HorzAngle(const void*,const struct Vector3*);
+extern short Vec3_VertAngle(const void*,const struct Vector3*);
+extern int Vec3_Dist(const void*,const struct Vector3*);
 extern void Matrix4x3_FromRotationY(void*,short);
 extern void MulVec3Mat4x3(void*,void*,void*);
 extern void ApproachAngle(void*,short,int,int,int);
 extern int func_ov065_0211691c(void*,void*);
 extern int data_020a0e68[];
-extern int data_ov075_0211d650[];
 int func_ov065_021165d8(char*c){
   short r4=0;
   char*p=_ZN5Actor22ClosestNonVanishPlayerEv();
   if(p!=0){
-    struct V tmp=*(struct V*)(p+0x5c);
-    struct V v;
-    struct V a; a.x=tmp.x; a.y=tmp.y; a.z=tmp.z;
+    struct Vector3 tmp=*(struct Vector3*)(p+0x5c);
+    struct Vector3 v;
+    struct Vector3 a; a.x=tmp.x; a.y=tmp.y; a.z=tmp.z;
     *(short*)(c+0x3e0)=Vec3_HorzAngle(c+0x5c,&a);
-    struct V b; b.x=tmp.x; b.y=tmp.y; b.z=tmp.z;
+    struct Vector3 b; b.x=tmp.x; b.y=tmp.y; b.z=tmp.z;
     r4=Vec3_VertAngle(c+0x5c,&b);
     if(Vec3_Dist(c+0x5c,&tmp)>=0x1f4000){
       *(int*)(c+0xa4)=0;*(int*)(c+0xa8)=0;*(int*)(c+0xac)=0;

--- a/src/func_ov065_02116f0c.c
+++ b/src/func_ov065_02116f0c.c
@@ -1,4 +1,8 @@
-int func_ov065_02116f0c(void)
+// @symbol func_ov065_02116f0c
+// @emits Snufit_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daYurei_Mucho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Snufit_OnAimedAtWithEgg(void)
 {
     return 0;
 }

--- a/src/func_ov065_02116f14.cpp
+++ b/src/func_ov065_02116f14.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov065_02116f14
+// @emits Snufit_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daYurei_Mucho_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int func_ov065_02116f14(char *c, void *player) {
+int Snufit_OnTurnIntoEgg(char *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, (unsigned char)(*(unsigned char*)(c+0x10a)+1), 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov065_02116f40.c
+++ b/src/func_ov065_02116f40.c
@@ -1,4 +1,8 @@
-int func_ov065_02116f40(void)
+// @symbol func_ov065_02116f40
+// @emits Snufit_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daYurei_Mucho_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Snufit_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov065_02117404.cpp
+++ b/src/func_ov065_02117404.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov065_02117404
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 int Vec3_Dist(const Vector3* a, const Vector3* b);

--- a/src/func_ov065_021177e4.cpp
+++ b/src/func_ov065_021177e4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov065_021177e4
+// @emits Snufit_Kill
+/* recovered: renamed to Class_Method */
+/* daYurei_Mucho_c::Kill - recovered from vtable slot identity */
 struct Vector3 {
     int x, y, z;
     Vector3(int a, int b, int c) : x(a), y(b), z(c) {}
@@ -10,10 +14,10 @@ extern "C" {
 extern P2 data_ov065_0211d6a0;
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, int file, int frame, int speed, unsigned int flags);
 extern void func_02012694(int id, void *pos);
-extern int func_ov065_021177e4(int *t);
+extern int Snufit_Kill(int *t);
 }
 
-int func_ov065_021177e4(int *t)
+int Snufit_Kill(int *t)
 {
     t[0x27] = -0x1000;
     t[0x28] = -0xa000;

--- a/src/func_ov065_02117994.c
+++ b/src/func_ov065_02117994.c
@@ -1,10 +1,13 @@
+// @symbol func_ov065_02117994
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
@@ -13,8 +16,8 @@ extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_
 extern struct Mtx43 data_020a0e68;
 
 void func_ov065_02117994(char* self){
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3*)(self + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3*)(self + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(s16*)(self + 0x8c), *(s16*)(self + 0x8e), *(s16*)(self + 0x90));

--- a/src/func_ov065_02117eac.c
+++ b/src/func_ov065_02117eac.c
@@ -1,4 +1,8 @@
-int func_ov065_02117eac(void)
+// @symbol func_ov065_02117eac
+// @emits Swoop_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBasabasa_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Swoop_OnAimedAtWithEgg(void)
 {
     return 0;
 }

--- a/src/func_ov065_02117eb4.cpp
+++ b/src/func_ov065_02117eb4.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov065_02117eb4
+// @emits Swoop_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daBasabasa_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int func_ov065_02117eb4(char *c, void *player) {
+int Swoop_OnTurnIntoEgg(char *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, (unsigned char)(*(unsigned char*)(c+0x10a)+1), 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov065_02117ee0.c
+++ b/src/func_ov065_02117ee0.c
@@ -1,4 +1,8 @@
-int func_ov065_02117ee0(void)
+// @symbol func_ov065_02117ee0
+// @emits Swoop_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daBasabasa_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Swoop_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov065_021180d4.c
+++ b/src/func_ov065_021180d4.c
@@ -1,3 +1,6 @@
+// @symbol func_ov065_021180d4
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -6,7 +9,7 @@ typedef unsigned int u32;
 typedef long long s64;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
+
 struct Vector3_16;
 
 extern s16 data_02082214[];
@@ -44,8 +47,7 @@ int func_ov065_021180d4(char* self)
         int idx;
         int speed;
 
-        pv = (struct Vector3*)(((long long)(int)((char*)actor + 0x5c)) &
-                   0xFFFFFFFFFFFFFFFFLL);
+        pv = (struct Vector3*)(((long long)(int)((char*)actor + 0x5c)));
         vec.x = pv->x;
         vec.y = pv->y;
         vec.z = pv->z;

--- a/src/func_ov065_02118634.c
+++ b/src/func_ov065_02118634.c
@@ -1,3 +1,8 @@
+// @symbol func_ov065_02118634
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
@@ -6,9 +11,8 @@ typedef unsigned int u32;
 typedef long long s64;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
 
-extern void* data_ov065_0211d768[];
+
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* self, void* bca, int n, int fix, u32 flags);

--- a/src/func_ov065_02118c4c.c
+++ b/src/func_ov065_02118c4c.c
@@ -1,14 +1,16 @@
-struct M48 { int w[12]; };
+// @symbol func_ov065_02118c4c
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void* d, void* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* mF, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* mF, short angX);
-extern struct M48 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov065_02118c4c(char* c) {
   int v[4];
   Vec3_Asr(&v, c+0x5c, 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
   Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(c+0x8c));
-  *(struct M48*)(c+0x10c) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x10c) = data_020a0e68;
 }

--- a/src/func_ov065_021195e4.c
+++ b/src/func_ov065_021195e4.c
@@ -1,4 +1,8 @@
-int func_ov065_021195e4(void)
+// @symbol func_ov065_021195e4
+// @emits DorrieCap_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daDossyCap_c::OnYoshiTryEat - recovered from vtable slot identity */
+int DorrieCap_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov065_021198a0.cpp
+++ b/src/func_ov065_021198a0.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov065_021198a0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov065_021198a0(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60) + *(int*)(self+0x370);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov065_02119f3c.c
+++ b/src/func_ov065_02119f3c.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov065_02119f3c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha03_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov065_02119f3c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha03_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x330);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov065_02119f88.c
+++ b/src/func_ov065_02119f88.c
@@ -1,12 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov065_02119f88
+// @emits daObjCtMecha03_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjCtMecha03_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov065_02119f88(int *t)
+int *daObjCtMecha03_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x330);

--- a/src/func_ov065_02119fe8.cpp
+++ b/src/func_ov065_02119fe8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov065_02119fe8
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
 
 extern "C" void Matrix4x3_FromRotationZXYExt(void* m, int x, int y, int z);

--- a/src/func_ov065_0211a15c.c
+++ b/src/func_ov065_0211a15c.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov065_0211a15c
+// @emits daObjCtMecha03_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha03_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov065_0211a15c(void *t)
+int daObjCtMecha03_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov065_0211a1a0.cpp
+++ b/src/func_ov065_0211a1a0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov065_0211a1a0
+// @emits daObjCtMecha03_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha03_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov065_0211a1a0(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjCtMecha03_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov065_0211a1c8.c
+++ b/src/func_ov065_0211a1c8.c
@@ -1,3 +1,11 @@
+// @symbol func_ov065_0211a1c8
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjCtMecha03_c.h"
+// @emits daObjCtMecha03_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha03_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -5,8 +13,6 @@ typedef unsigned char u8;
 extern u16 DecIfAbove0_Short(u16* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
 extern int RandomIntInternal(int* seed);
-extern int func_ov065_0211a114(char* c);
-extern void func_ov065_02119fe8(char* self);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 
@@ -15,8 +21,9 @@ extern int data_0209e650;
 
 #define I16(off) (*(short*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
 
-int func_ov065_0211a1c8(char* c)
+int daObjCtMecha03_c_Behavior(char* c)
 {
+    struct daObjCtMecha03_c *self = (struct daObjCtMecha03_c *)(void *)c;
     if (data_0209f2c0 != 3) {
         if (*(unsigned short*)(c + 0x300 + 0x26) != 0) {
             if (DecIfAbove0_Short((u16*)(c + 0x326)) == 0) {
@@ -54,7 +61,7 @@ int func_ov065_0211a1c8(char* c)
             }
             I16(0x322) = I16(0x322) + *(short*)(c + 0x300 + 0x24);
         }
-        *(short*)(c + 0x90) = *(short*)(c + 0x300 + 0x22);
+        self->unk_090 = *(short*)(c + 0x300 + 0x22);
     }
 
     func_ov065_0211a114(c);

--- a/src/func_ov065_0211a358.cpp
+++ b/src/func_ov065_0211a358.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov065_0211a358
+// @emits daObjCtMecha03_c_InitResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha03_c::InitResources - recovered from vtable slot identity */
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -8,7 +14,6 @@ struct CLPS_Block;
 extern struct BMD_File *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thisp, struct BMD_File *, int, int);
 extern void _ZN11ShadowModel10InitCuboidEv(void *thisp);
-extern "C" int func_ov065_0211a114(char *c);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *thisp);
 extern struct KCL_File *_ZN12MeshCollider8LoadFileER13SharedFilePtr(struct SharedFilePtr &);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
@@ -20,11 +25,9 @@ extern "C" void func_020393d4(int *p, int v);
 extern struct SharedFilePtr data_ov065_0211d88c;
 extern struct SharedFilePtr data_ov065_0211d894;
 extern unsigned char data_0209f2c0;
-extern short data_ov065_0211c0b0[];
-extern int func_02112198;
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 
-extern "C" int func_ov065_0211a358(char *self) {
+extern "C" int daObjCtMecha03_c_InitResources(char *self) {
     struct BMD_File *bmd;
     struct KCL_File *kcl;
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov065_0211d88c);

--- a/src/func_ov065_0211a45c.c
+++ b/src/func_ov065_0211a45c.c
@@ -1,13 +1,17 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN8PlatformC2Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern int VT0[];
+// @symbol func_ov065_0211a45c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_ActorBase.h"
+#include "decl_Platform.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha03_c */
 int *func_ov065_0211a45c(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(904);
     if (p) {
         _ZN8PlatformC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV16daObjCtMecha03_c;
         _ZN11ShadowModelC1Ev((char *)p + 0x330);
     }
     return p;

--- a/src/func_ov065_0211ab60.c
+++ b/src/func_ov065_0211ab60.c
@@ -1,14 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov065_0211ab60
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV16daObjCtMecha05_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov065_0211ab60(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV16daObjCtMecha05_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x33c);
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov065_0211abac.c
+++ b/src/func_ov065_0211abac.c
@@ -1,12 +1,15 @@
-extern void _ZN11ShadowModelD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov065_0211abac
+// @emits daObjCtMecha05_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjCtMecha05_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov065_0211abac(int *t)
+int *daObjCtMecha05_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x33c);

--- a/src/func_ov065_0211ac0c.c
+++ b/src/func_ov065_0211ac0c.c
@@ -1,5 +1,6 @@
-struct V3 { int x, y, z; };
-
+// @symbol func_ov065_0211ac0c
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* a, void* b, void* c);
 extern void AddVec3(void* a, void* b, void* c);
@@ -8,8 +9,8 @@ extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S
 
 void func_ov065_0211ac0c(int c)
 {
-    struct V3 v1;
-    struct V3 v2;
+    struct Vector3 v1;
+    struct Vector3 v2;
     int d;
 
     d = *(int*)(c + 0x60) - *(int*)(c + 0x338);

--- a/src/func_ov065_0211ad04.c
+++ b/src/func_ov065_0211ad04.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov065_0211ad04
+// @emits daObjCtMecha05_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha05_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov065_0211ad04(void *t)
+int daObjCtMecha05_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov065_0211ad48.cpp
+++ b/src/func_ov065_0211ad48.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov065_0211ad48
+// @emits daObjCtMecha05_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha05_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov065_0211ad48(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjCtMecha05_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov065_0211ae08.c
+++ b/src/func_ov065_0211ae08.c
@@ -1,14 +1,20 @@
+// @symbol func_ov065_0211ae08
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjCtMecha05_c.h"
+// @emits daObjCtMecha05_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daObjCtMecha05_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
-extern void func_ov065_0211ac0c(void* c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 extern u16 DecIfAbove0_Short(u16* p);
 extern int RandomIntInternal(int* seed);
-extern void func_ov065_0211ad70(char* c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
 
 extern s16 data_02082214[];
@@ -18,15 +24,16 @@ extern int data_0209e650;
 #define I32(off) (*(int*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
 #define I8(off)  (*(u8*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
 
-int func_ov065_0211ae08(char* c)
+int daObjCtMecha05_c_Behavior(char* c)
 {
+    struct daObjCtMecha05_c *self = (struct daObjCtMecha05_c *)(void *)c;
     if (data_0209f2c0 == 3) {
         int ang;
-        ang = *(u16*)(c + 0x94);
-        *(int*)(c + 0x5c) = *(int*)(c + 0x320) +
+        ang = self->unk_094;
+        self->unk_05c = self->unk_320 +
             (int)(((long long)data_02082214[(ang >> 4) << 1] * 0xfa000 + 0x800) >> 12);
-        ang = *(u16*)(c + 0x94);
-        *(int*)(c + 0x64) = *(int*)(c + 0x328) +
+        ang = self->unk_094;
+        self->unk_064 = self->unk_328 +
             (int)(((long long)data_02082214[((ang >> 4) << 1) + 1] * 0xfa000 + 0x800) >> 12);
         _ZN8Platform21UpdateModelPosAndRotYEv(c);
         func_ov065_0211ac0c(c);
@@ -35,53 +42,53 @@ int func_ov065_0211ae08(char* c)
         return 1;
     }
 
-    *(int*)(c + 0x330) = *(int*)(c + 0x32c);
-    I32(0x32c) += *(int*)(c + 0x98);
+    self->unk_330 = self->unk_32c;
+    I32(0x32c) += self->unk_098;
 
-    switch (*(u8*)(c + 0x336)) {
+    switch (self->unk_336) {
     case 0:
         if (DecIfAbove0_Short((u16*)(c + 0x334)) != 0) goto Lend;
         if (data_0209f2c0 == 2) {
             int v = (u16)((unsigned)RandomIntInternal(&data_0209e650) >> 16);
             if (v % 2 == 0) {
-                *(s16*)(c + 0x334) = v % 100 + 20;
+                self->unk_334 = v % 100 + 20;
             }
         }
         I8(0x336)++;
-        *(int*)(c + 0x98) = -0x8000;
+        self->unk_098 = -0x8000;
         goto Lend;
 
     case 1:
         I32(0x98) += 0xbae;
-        if (*(int*)(c + 0x98) > 0) {
+        if (self->unk_098 > 0) {
             if (DecIfAbove0_Short((u16*)(c + 0x334)) != 0) {
-                *(int*)(c + 0x98) = 0;
+                self->unk_098 = 0;
                 goto Lend;
             }
             I8(0x336)++;
-            *(int*)(c + 0x98) = 0x1d000;
+            self->unk_098 = 0x1d000;
         }
         goto Lend;
 
     case 2: {
-        int d = *(int*)(c + 0x32c);
+        int d = self->unk_32c;
         if (d != 0xfa000) {
-            int val = (int)(((long long)(0xfa000 - d) * (0xfa000 - *(int*)(c + 0x330)) + 0x800) >> 12);
+            int val = (int)(((long long)(0xfa000 - d) * (0xfa000 - self->unk_330) + 0x800) >> 12);
             if (val >= 0) goto L280;
         }
         {
-            int sp = *(int*)(c + 0x98);
+            int sp = self->unk_098;
             if (sp <= -0x8000) goto L280;
             if (sp >= 0x8000) goto L280;
             I8(0x336)++;
-            *(int*)(c + 0x98) = 0;
-            *(s16*)(c + 0x334) = 0x1e;
+            self->unk_098 = 0;
+            self->unk_334 = 0x1e;
             goto Lend;
         }
       L280:
         {
-            int m = (*(int*)(c + 0x32c) < 0xfa000) ? 0x6666 : -0x6666;
-            int sp = *(int*)(c + 0x98);
+            int m = (self->unk_32c < 0xfa000) ? 0x6666 : -0x6666;
+            int sp = self->unk_098;
             int delta;
             if ((int)(((long long)sp * m + 0x800) >> 12) >= 0)
                 delta = m;
@@ -90,7 +97,7 @@ int func_ov065_0211ae08(char* c)
             I32(0x98) += delta;
             if (data_0209f2c0 != 2) goto Lend;
         }
-        if ((int)(((long long)*(int*)(c + 0x32c) * *(int*)(c + 0x330) + 0x800) >> 12) >= 0) goto Lend;
+        if ((int)(((long long)self->unk_32c * self->unk_330 + 0x800) >> 12) >= 0) goto Lend;
         if ((RandomIntInternal(&data_0209e650) & 3) != 0) goto Lend;
         func_ov065_0211ad70(c);
         goto Lend;
@@ -98,8 +105,8 @@ int func_ov065_0211ae08(char* c)
 
     case 3:
         if (DecIfAbove0_Short((u16*)(c + 0x334)) != 0) goto Lend;
-        *(int*)(c + 0x98) = -0x5000;
-        if (*(int*)(c + 0x32c) < 0)
+        self->unk_098 = -0x5000;
+        if (self->unk_32c < 0)
             func_ov065_0211ad70(c);
         goto Lend;
     }

--- a/src/func_ov065_0211b1d4.cpp
+++ b/src/func_ov065_0211b1d4.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov065_0211b1d4
+// @emits daObjCtMecha05_c_InitResources
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjCtMecha05_c::InitResources - recovered from vtable slot identity */
 struct BMD_File; struct KCL_File; struct Actor; struct Vector3; struct Matrix4x3;
 struct CLPS_Block; struct SharedFilePtr;
-extern "C" void *ModelLoadFile(void *fp);
 struct ModelBase { void SetFile(BMD_File *f, int b, int c); };
 struct ShadowModel { void InitCuboid(); };
 struct Platform { void UpdateModelPosAndRotY(); void UpdateClsnPosAndRot(); };
-extern "C" void *MeshColliderLoadFile(void *fp);
 struct MovingMeshCollider {
     void SetFile(KCL_File *f, const Matrix4x3 &m, int fix, short sh, CLPS_Block &b);
 };
@@ -21,16 +25,11 @@ struct RaycastGround {
     int DetectClsn();
     ~RaycastGround();
 };
-extern "C" char data_ov065_0211d904;
-extern "C" char data_ov065_0211d90c;
-extern "C" char func_02112258;
 extern "C" unsigned char data_0209f2c0;
-extern "C" short data_ov065_0211c0c8;
-extern "C" void UpdatePosWithTransformSym();
 
 struct V3 { int x, y, z; };
 
-extern "C" int func_ov065_0211b1d4(char *self)
+extern "C" int daObjCtMecha05_c_InitResources(char *self)
 {
     void *mf = ModelLoadFile(&data_ov065_0211d904);
     ((ModelBase*)(self + 0xd4))->SetFile((BMD_File*)mf, 1, -1);

--- a/src/func_ov065_0211b40c.c
+++ b/src/func_ov065_0211b40c.c
@@ -1,5 +1,8 @@
+// @symbol func_ov065_0211b40c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
-struct Matrix4x3 { int w[12]; };
+
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
    void* self, void* sm, struct Matrix4x3* m, int f, int g, u32 h);
 void func_ov065_0211b40c(char* c){

--- a/src/func_ov066_02116c6c.c
+++ b/src/func_ov066_02116c6c.c
@@ -1,5 +1,8 @@
+// @symbol func_ov066_02116c6c
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 extern int _ZN9Animation8FinishedEv(void* self);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
 extern void _ZN5Actor16TriplePoofDustAtERK7Vector3(void* self, const struct Vector3* v);

--- a/src/func_ov066_0211903c.c
+++ b/src/func_ov066_0211903c.c
@@ -1,20 +1,18 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov066_0211903c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern void _ZN6Player17SetNoControlStateEhih(void* self, unsigned char a, int b, unsigned char c);
 extern void func_020092c4(void* cam, void* out, void* target);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, struct Vector3* v, unsigned int d, unsigned int e);
 extern void func_02012694(int a, void* b);
 extern int _ZN6Player12GetTalkStateEv(void* self);
 extern void _ZN7Message7EndTalkEv(void);
-extern void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int a);
-extern void func_02011d2c(void);
-extern void func_ov066_02119454(void* c, void* p);
-extern void _ZN5Sound22StopLoadedMusic_Layer3Ev(void);
-extern void func_02011cfc(void);
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void* self, signed char* a, unsigned int b, struct Vector3* v, unsigned int d);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
 extern void Matrix4x3_FromRotationY(void* m, short ang);
@@ -24,7 +22,6 @@ extern void* data_0209f318;
 extern int data_020a0e68[];
 extern unsigned char data_ov066_0211abe0;
 extern unsigned char data_ov066_0211ae0c;
-extern void* data_ov066_0211b0cc;
 
 int func_ov066_0211903c(char* self) {
     struct Vector3 v1, v2, in, out, star;

--- a/src/func_ov066_0211a2dc.c
+++ b/src/func_ov066_0211a2dc.c
@@ -1,4 +1,8 @@
-int func_ov066_0211a2dc(void)
+// @symbol func_ov066_0211a2dc
+// @emits Eyerok_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daIwante_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Eyerok_OnAimedAtWithEgg(void)
 {
     return 163840;
 }

--- a/src/func_ov070_0211f0a4.cpp
+++ b/src/func_ov070_0211f0a4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov070_0211f0a4
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct Actor {
     void SmallPoofDust();

--- a/src/func_ov070_0211f368.cpp
+++ b/src/func_ov070_0211f368.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov070_0211f368
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 extern "C" unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f, void* g);
 extern "C" unsigned _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned a, unsigned b, Fix12i c, Fix12i d, Fix12i e, void* f);
 extern "C" void ApproachAngle(short* v, int a, int b, int c, int d);
 extern "C" void _Z14ApproachLinearRsss(short* v, int a, int b);
-extern "C" int func_ov070_0211f0a4(void* c);
 
 extern "C" int func_ov070_0211f368(char* c)
 {

--- a/src/func_ov070_0211f48c.c
+++ b/src/func_ov070_0211f48c.c
@@ -1,6 +1,6 @@
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
-
+// @symbol func_ov070_0211f48c
+/* recovered: shared common types */
+#include "common.h"
 char* _ZN5Actor13ClosestPlayerEv(void* self);
 short Vec3_HorzAngle(void* a, void* b);
 void ApproachAngle(short* p, int target, int a, int b, int limit);

--- a/src/func_ov070_02120070.cpp
+++ b/src/func_ov070_02120070.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov070_02120070
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vec3 { int x, y, z; };
+
 extern void Vec3_Asr(void* d, void* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
@@ -11,7 +14,7 @@ typedef struct { int w[12]; } M48;
 
 void func_ov070_02120070(char* c)
 {
-    Vec3 v;
+    Vector3 v;
     Vec3_Asr(&v, c + 0x5c, 3);
     Matrix4x3_FromTranslation(data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(data_020a0e68, *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));

--- a/src/func_ov070_021204e4.c
+++ b/src/func_ov070_021204e4.c
@@ -1,4 +1,8 @@
-int func_ov070_021204e4(void)
+// @symbol func_ov070_021204e4
+// @emits FlyGuy_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daPropeller_Heyho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int FlyGuy_OnAimedAtWithEgg(void)
 {
     return 176128;
 }

--- a/src/func_ov070_021204ec.cpp
+++ b/src/func_ov070_021204ec.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov070_021204ec
+// @emits FlyGuy_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daPropeller_Heyho_c::OnTurnIntoEgg - recovered from vtable slot identity */
 class Player;
 
 class Actor {
@@ -7,7 +11,7 @@ void GivePlayerCoins(Player &player, unsigned char count, unsigned int unknown);
 void KillAndTrackInDeathTable();
 };
 
-extern "C" void func_ov070_021204ec(char *c, void *player) {
+extern "C" void FlyGuy_OnTurnIntoEgg(char *c, void *player) {
 Actor *r4 = (Actor *)c;
 unsigned char r2 = ((unsigned char *)r4)[0x10a];
 r4->GivePlayerCoins(*(Player *)player, r2 + 1, 0);

--- a/src/func_ov070_02120518.c
+++ b/src/func_ov070_02120518.c
@@ -1,4 +1,8 @@
-int func_ov070_02120518(void)
+// @symbol func_ov070_02120518
+// @emits FlyGuy_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daPropeller_Heyho_c::OnYoshiTryEat - recovered from vtable slot identity */
+int FlyGuy_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov070_02120644.cpp
+++ b/src/func_ov070_02120644.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov070_02120644
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern void _ZN6Player16IncMegaKillCountEv(void* thiz);

--- a/src/func_ov070_02120724.c
+++ b/src/func_ov070_02120724.c
@@ -1,11 +1,15 @@
+// @symbol func_ov070_02120724
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct M12 { int w[12]; };
-struct Vec3 { int x, y, z; };
 
-extern void Matrix4x3_FromRotationXYZExt(void *m, int x, int y, int z);
+
+
 extern void _ZN13RaycastGroundC1Ev(void *rg);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *rg, struct Vec3 *pos, void *actor);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *rg, struct Vector3 *pos, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(void *rg);
 extern void _ZN13RaycastGroundD1Ev(void *rg);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
@@ -31,7 +35,7 @@ void func_ov070_02120724(char *c)
         *(int*)(c + 0x114) = *(int*)(c + 0x404) >> 3;
         *(int*)(c + 0x118) = *(int*)(c + 0x408) >> 3;
         *(int*)(c + 0x11c) = *(int*)(c + 0x40c) >> 3;
-        *(struct M12*)(c + 0x154) = *(struct M12*)(c + 0xf0);
+        *(struct Matrix4x3*)(c + 0x154) = *(struct Matrix4x3*)(c + 0xf0);
         *(int*)(c + 0x3f8) = *(int*)(c + 0x404) >> 3;
         *(int*)(c + 0x3fc) = *(int*)(c + 0x408) >> 3;
         *(int*)(c + 0x400) = *(int*)(c + 0x40c) >> 3;
@@ -40,7 +44,7 @@ void func_ov070_02120724(char *c)
     g = 0x1f4000;
     if (data_0209f2f8[0] == 0x11) {
         struct RG rg;
-        struct Vec3 pos;
+        struct Vector3 pos;
         int y;
         pos.x = *(int*)(c + 0x5c);
         y = *(int*)(c + 0x60);

--- a/src/func_ov070_02120910.cpp
+++ b/src/func_ov070_02120910.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov070_02120910
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
-extern int data_ov070_0212360c[];
 
 int func_ov070_02120910(char* c)
 {

--- a/src/func_ov070_021209e4.cpp
+++ b/src/func_ov070_021209e4.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov070_021209e4
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 typedef long long s64;
-struct Vec3 { int x, y, z; };
-struct Vector3 { int x, y, z; };
+
+
 struct Animation { void Advance(); };
 
 void _Z14ApproachLinearRiii(int *val, int target, int step);
-void AddVec3(Vec3 *a, Vec3 *b, Vec3 *c);
+void AddVec3(Vector3 *a, Vector3 *b, Vector3 *c);
 unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, Vector3 *v, unsigned int d);
 unsigned char DecIfAbove0_Byte(unsigned char *p);
 int func_ov070_02120644(char *c);
@@ -47,7 +50,7 @@ int func_ov070_021209e4(char *c) {
         *(int*)(c + 0x418) = (int)(((s64)ip * sinv + 0x800) >> 0xc);
     }
 
-    AddVec3((Vec3*)(c + 0x404), (Vec3*)(c + 0x410), (Vec3*)(c + 0x404));
+    AddVec3((Vector3*)(c + 0x404), (Vector3*)(c + 0x410), (Vector3*)(c + 0x404));
 
     *(short*)(c + 0x42e) = (short)(*(short*)(c + 0x42e) + 0x4000);
 

--- a/src/func_ov070_021211bc.c
+++ b/src/func_ov070_021211bc.c
@@ -1,4 +1,8 @@
-int func_ov070_021211bc(void)
+// @symbol func_ov070_021211bc
+// @emits FlameChomp_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daKrpa_c::OnYoshiTryEat - recovered from vtable slot identity */
+int FlameChomp_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov070_021211c4.cpp
+++ b/src/func_ov070_021211c4.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov070_021211c4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov070_02121880(void* c, int n);
 extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern void _ZN6Player16IncMegaKillCountEv(void* thiz);
 

--- a/src/func_ov070_02121438.cpp
+++ b/src/func_ov070_02121438.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov070_02121438
+// @emits Amp_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daBrq_c::Kill - recovered from vtable slot identity */
 extern "C" {
-struct Vector3 { int x, y, z; };
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
-extern int data_ov070_021234c4;
 }
 
-extern "C" int func_ov070_02121438(char* c)
+extern "C" int Amp_Kill(char* c)
 {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
     int* p_b0 = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);

--- a/src/func_ov070_0212156c.c
+++ b/src/func_ov070_0212156c.c
@@ -1,6 +1,8 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov070_0212156c
+/* recovered: shared common types */
+#include "common.h"
 extern short data_02082214[];
-void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct V3 *pos, void *v16, int d, int e);
+void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, struct Vector3 *pos, void *v16, int d, int e);
 void func_0201267c(int a, void *p);
 void func_ov070_02121880(void *c, int i);
 void _ZN9Animation7AdvanceEv(void *thiz);
@@ -12,7 +14,7 @@ void _ZN12CylinderClsn6UpdateEv(void *thiz);
 
 int func_ov070_0212156c(char *c){
   if(*(int*)(c+0x398) == 0x1e){
-    struct V3 pos;
+    struct Vector3 pos;
     int idx = (int)*(unsigned short*)(c+0x8e) >> 4;
     int s = data_02082214[idx*2+1];
     int cn = data_02082214[idx*2];

--- a/src/func_ov070_02121bdc.c
+++ b/src/func_ov070_02121bdc.c
@@ -1,4 +1,8 @@
-int func_ov070_02121bdc(void)
+// @symbol func_ov070_02121bdc
+// @emits FlameChompFire_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daKpFr_c::OnYoshiTryEat - recovered from vtable slot identity */
+int FlameChompFire_OnYoshiTryEat(void)
 {
     return 5;
 }

--- a/src/func_ov070_02121be4.cpp
+++ b/src/func_ov070_02121be4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov070_02121be4
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 struct RaycastGround { char buf[0x54]; };
 

--- a/src/func_ov070_02121d50.cpp
+++ b/src/func_ov070_02121d50.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov070_02121d50
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct SurfaceInfo { void CopyNormalTo(Vector3& v) const; };
 struct WithMeshClsn {
     bool IsOnGround() const;
@@ -9,7 +14,6 @@ struct WithMeshClsn {
 namespace cstd { int fdiv(int a, int b); }
 
 extern "C" void func_020383fc(void* c);
-extern "C" void func_ov070_02121c8c(void* c);
 
 extern "C" void func_ov070_02121d50(int* self, WithMeshClsn* clsn) {
     Vector3 n;

--- a/src/func_ov070_02121fb0.c
+++ b/src/func_ov070_02121fb0.c
@@ -1,4 +1,8 @@
-int func_ov070_02121fb0(char *p)
+// @symbol func_ov070_02121fb0
+// @emits FlameChomp_Kill
+/* recovered: renamed to Class_Method */
+/* daKrpa_c::Kill - recovered from vtable slot identity */
+int FlameChomp_Kill(char *p)
 {
     *(int *)(p + 0x98) = 40960;
     *(char *)(p + 0x32c) = 105;

--- a/src/func_ov071_0211f0a4.c
+++ b/src/func_ov071_0211f0a4.c
@@ -1,4 +1,8 @@
-int func_ov071_0211f0a4(void)
+// @symbol func_ov071_0211f0a4
+// @emits Scuttlebug_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daSpd_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Scuttlebug_OnYoshiTryEat(void)
 {
     return 6;
 }

--- a/src/func_ov071_0211f0ac.c
+++ b/src/func_ov071_0211f0ac.c
@@ -1,4 +1,8 @@
-int func_ov071_0211f0ac(void)
+// @symbol func_ov071_0211f0ac
+// @emits Scuttlebug_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daSpd_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Scuttlebug_OnAimedAtWithEgg(void)
 {
     return 204800;
 }

--- a/src/func_ov071_0211f148.cpp
+++ b/src/func_ov071_0211f148.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol func_ov071_0211f148
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 struct WithMeshClsn;
 struct Actor;
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
@@ -18,7 +23,6 @@ extern "C" void* _ZNK12WithMeshClsn14GetFloorResultEv(void* self);
 extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vector3* out);
 extern "C" int _ZN4cstd4fdivEii(int a, int b);
 extern "C" int _ZNK12WithMeshClsn8IsOnWallEv(void* self);
-extern "C" void* _ZNK12WithMeshClsn13GetWallResultEv(void* self);
 
 extern "C" void func_ov071_0211f148(char* a, char* w) {
     RaycastGround rc;

--- a/src/func_ov071_0211f6f8.cpp
+++ b/src/func_ov071_0211f6f8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov071_0211f6f8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);

--- a/src/func_ov071_0211f8d0.cpp
+++ b/src/func_ov071_0211f8d0.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov071_0211f8d0
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef long long s64;
 
-struct Vector3 { int x, y, z; };
+
 
 extern "C" {
 int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void* self, Vector3* a, Vector3* out, int doStore);

--- a/src/func_ov071_0211fb24.cpp
+++ b/src/func_ov071_0211fb24.cpp
@@ -1,15 +1,17 @@
 //cpp
+// @symbol func_ov071_0211fb24
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern void _Z14ApproachLinearRsss(short& dst, short a, short b);
 extern void _ZN9Animation7AdvanceEv(void* thiz);
 extern int Vec3_Dist(const Vector3* a, const Vector3* b);
 extern void func_ov071_021202ec(void* c, int n);
-extern void func_ov071_0211f0b4(char* c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* cc);
-extern void func_ov071_0211f148(void* c, void* p);
-extern void func_ov071_0211f29c(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void* thiz);
 extern void func_0201267c(int a, void* v);

--- a/src/func_ov071_0211ff84.c
+++ b/src/func_ov071_0211ff84.c
@@ -1,5 +1,8 @@
+// @symbol func_ov071_0211ff84
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 extern int Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 extern void func_ov071_021202ec(char* c, int i);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, Fix12 b, unsigned int g);

--- a/src/func_ov071_02120580.cpp
+++ b/src/func_ov071_02120580.cpp
@@ -1,11 +1,15 @@
 //cpp
+// @symbol func_ov071_02120580
+// @emits Scuttlebug_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daSpd_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void* p);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void* a, void* p, unsigned char h, unsigned int j);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void* p, unsigned int n, int b1, int b2);
 extern void func_ov071_021202ec(void* a, int idx);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* a);
-void func_ov071_02120580(char* a, void* p) {
+void Scuttlebug_OnTurnIntoEgg(char* a, void* p) {
   volatile int force_stack;
   int *bp;
   int t;

--- a/src/func_ov071_02120a48.cpp
+++ b/src/func_ov071_02120a48.cpp
@@ -1,11 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov071_02120a48
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" char *_ZN5Actor22ClosestNonVanishPlayerEv(void *self);
 extern "C" int Vec3_Dist(const void *a, const void *b);
 extern "C" short Vec3_HorzAngle(const void *a, const void *b);
-extern "C" int AngleDiff(int a, int b);
 extern "C" int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, Vector3 *a, Vector3 *b, bool c);
-extern "C" void func_ov071_02121634(void *self, int a);
 extern "C" void func_ov071_02120a48(char *c)
 {
     char *p = _ZN5Actor22ClosestNonVanishPlayerEv(c);

--- a/src/func_ov071_02120b14.cpp
+++ b/src/func_ov071_02120b14.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov071_02120b14
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
-struct Vec3_16f { s16 x, y, z; };
+
+
 
 extern "C" {
     void* _ZN5Actor7FindEggER12CylinderClsn(void* self, void* c);
@@ -57,7 +60,7 @@ idCheck:
         return;
     }
 
-    struct Vec3 hv;
+    struct Vector3 hv;
     hv.x = *(s32*)(c+0x5c);
     hv.y = *(s32*)(c+0x60);
     hv.z = *(s32*)(c+0x64);

--- a/src/func_ov071_021214f4.c
+++ b/src/func_ov071_021214f4.c
@@ -1,4 +1,8 @@
-int func_ov071_021214f4(char* c) {
+// @symbol func_ov071_021214f4
+// @emits Scuttlebug_Kill
+/* recovered: renamed to Class_Method */
+/* daSpd_c::Kill - recovered from vtable slot identity */
+int Scuttlebug_Kill(char* c) {
     *(unsigned char*)(c+0x212) = 0xf0;
     *(unsigned char*)(c+0x213) = 0;
     *(int*)(c+0x1f4) = 0;

--- a/src/func_ov071_02121b00.c
+++ b/src/func_ov071_02121b00.c
@@ -1,4 +1,8 @@
-int func_ov071_02121b00(void)
+// @symbol func_ov071_02121b00
+// @emits MrI_Projectile_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daEyBm_c::OnYoshiTryEat - recovered from vtable slot identity */
+int MrI_Projectile_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov071_02121ba4.cpp
+++ b/src/func_ov071_02121ba4.cpp
@@ -1,9 +1,13 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov071_02121ba4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, const struct Vector3 *v, unsigned int a, int fix, unsigned int b, unsigned int d, unsigned int e);
-extern void func_ov071_02121b08(void *c);
 
 void func_ov071_02121ba4(char *c){
   void *o;

--- a/src/func_ov071_021220c8.cpp
+++ b/src/func_ov071_021220c8.cpp
@@ -1,8 +1,12 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov071_021220c8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" void _Z14ApproachLinearRsss(short &dst, short a, short b);
 extern "C" unsigned short DecIfAbove0_Short(unsigned short *p);
-extern "C" void func_ov071_021223c8(void *c, int i);
 extern "C" void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int n, Vector3 *v);
 
 extern "C" void func_ov071_021220c8(char *c)

--- a/src/func_ov072_0211f280.c
+++ b/src/func_ov072_0211f280.c
@@ -1,3 +1,6 @@
+// @symbol func_ov072_0211f280
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov072_0211f280 at 0x0211f280
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov072).
@@ -6,7 +9,7 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 
 struct Actor;
-struct Vector3 { int x, y, z; };
+
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(struct Actor* actor, const struct Vector3* pos, u32 a, int fix, u32 b, u32 c, u32 d);

--- a/src/func_ov072_0211f330.c
+++ b/src/func_ov072_0211f330.c
@@ -1,6 +1,9 @@
+// @symbol func_ov072_0211f330
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef long long s64;
-struct Vector3 { int x, y, z; };
+
 extern void func_020383fc(void* p);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 extern char* _ZNK12WithMeshClsn14GetFloorResultEv(void* self);

--- a/src/func_ov072_0211f598.c
+++ b/src/func_ov072_0211f598.c
@@ -1,13 +1,14 @@
+// @symbol func_ov072_0211f598
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int c);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vector3* v, unsigned int d);
-extern void func_ov072_0211f158(char* c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* c, void* cc);
-extern void func_ov072_0211f330(char* c, void* mc);
-extern void func_ov072_0211f280(char* c);
-extern void func_ov072_0211fcb0(char* c, int i);
 
 int func_ov072_0211f598(char* c) {
   _Z14ApproachLinearRiii((int*)(c+0x98), 0x28000, 0x400);

--- a/src/func_ov072_0211f65c.cpp
+++ b/src/func_ov072_0211f65c.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov072_0211f65c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 int Vec3_HorzDist(const void* a, const void* b);
 short Vec3_HorzAngle(const void* a, const void* b);
@@ -14,7 +19,6 @@ void func_ov072_0211f158(void* c);
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
 void func_ov072_0211f330(void* c, void* p);
 void func_ov072_0211f280(void* c);
-extern Vector3 data_ov072_02122b58;
 }
 
 extern "C" int func_ov072_0211f65c(unsigned char* thiz)

--- a/src/func_ov072_0211f81c.cpp
+++ b/src/func_ov072_0211f81c.cpp
@@ -1,22 +1,20 @@
 //cpp
+// @symbol func_ov072_0211f81c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 extern "C" void _Z14ApproachLinearRiii(int* p, int a, int b);
 extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
 extern "C" void func_0203568c(int *p, int v);
 extern "C" void func_02035684(int *p, int v);
 extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, Fix12 a, Fix12 b, Fix12 c, Fix12 d);
-extern "C" int func_ov072_0211f1dc(char* c);
-extern "C" int func_ov072_0211f0a4(char* c);
-extern "C" void func_ov072_0211fcb0(char* c, int i);
 extern "C" void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12 a, Fix12 b, Fix12 c);
 extern "C" int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, const struct Vector3* v, unsigned e);
-extern "C" void func_ov072_0211f158(char* c);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
-extern "C" void func_ov072_0211f330(char* c, void* mc);
-extern "C" void func_ov072_0211f280(char* c);
 extern "C" int Vec3_Dist(const void* a, const void* b);
-extern const struct Vector3 data_ov072_02122b40;
 
 extern "C" int func_ov072_0211f81c(char* c) {
     int t;

--- a/src/func_ov072_0212001c.c
+++ b/src/func_ov072_0212001c.c
@@ -1,3 +1,7 @@
+// @symbol func_ov072_0212001c
+// @emits SnowmanBody_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daBgSnmBdy_c::Kill - recovered from vtable slot identity */
 struct Vec3 { int x, y, z; };
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern int Vec3_HorzDist(void *a, void *b);
@@ -8,7 +12,7 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned id, unsigned 
 extern void _ZN9Animation7AdvanceEv(void *anim);
 extern int _Z14ApproachLinearRsss(short *p, short to, short step);
 
-int func_ov072_0212001c(char *c)
+int SnowmanBody_Kill(char *c)
 {
     struct Vec3 v;
     unsigned char *st;

--- a/src/func_ov072_021201d4.c
+++ b/src/func_ov072_021201d4.c
@@ -1,5 +1,10 @@
+// @symbol func_ov072_021201d4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 
 extern int _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *self, const struct Vector3 *v, Fix12i mag);
@@ -7,7 +12,6 @@ extern int func_0201267c(int a, void *b);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12i dist, int loop);
 extern unsigned char DecIfAbove0_Byte(unsigned char *p);
-extern void func_ov072_021205d4(void *self, int a);
 
 int func_ov072_021201d4(char *self)
 {

--- a/src/func_ov072_02120450.cpp
+++ b/src/func_ov072_02120450.cpp
@@ -1,10 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov072_02120450
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 typedef int Fix12i;
 
 void ApproachLinear(short& v, short target, short step);
 struct Animation { void Advance(); };
-extern "C" void func_ov072_021205d4(void* c, int a);
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char* p);
 
 struct ActorBase {};

--- a/src/func_ov072_02120824.c
+++ b/src/func_ov072_02120824.c
@@ -1,12 +1,16 @@
+// @symbol func_ov072_02120824
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daBgSnwmn_c */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
 int *func_ov072_02120824(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV11daBgSnwmn_c;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b0);
     _ZN11ShadowModelD1Ev((char *)t + 0x188);
     _ZN15TextureSequenceD1Ev((char *)t + 0x174);

--- a/src/func_ov072_02120874.c
+++ b/src/func_ov072_02120874.c
@@ -1,12 +1,16 @@
+// @symbol func_ov072_02120874
+// @emits daBgSnwmn_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daBgSnwmn_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
-extern void _ZN11ShadowModelD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
 extern void *G0;
-int *func_ov072_02120874(int *t)
+int *daBgSnwmn_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b0);

--- a/src/func_ov072_02120980.c
+++ b/src/func_ov072_02120980.c
@@ -1,8 +1,12 @@
+// @symbol func_ov072_02120980
+// @emits daBgSnwmn_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daBgSnwmn_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-extern int G2[];
-int func_ov072_02120980(void)
+int daBgSnwmn_c_CleanupResources(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     _ZN13SharedFilePtr7ReleaseEv(G1);

--- a/src/func_ov072_021209bc.c
+++ b/src/func_ov072_021209bc.c
@@ -1,3 +1,7 @@
-void func_ov072_021209bc(void)
+// @symbol func_ov072_021209bc
+// @emits daBgSnwmn_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daBgSnwmn_c::OnPendingDestroy - recovered from vtable slot identity */
+void daBgSnwmn_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov072_021209c0.cpp
+++ b/src/func_ov072_021209c0.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov072_021209c0
+// @emits daBgSnwmn_c_Render
+/* recovered: renamed to Class_Method */
+/* daBgSnwmn_c::Render - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int func_ov072_021209c0(char* c){
+int daBgSnwmn_c_Render(char* c){
   _ZN15TextureSequence6UpdateER15ModelComponents(c+0x174, c+0xdc);
   ((Sub*)(c+0xd4))->g5(c+0x80);
   ((Sub*)(c+0x124))->g5(c+0x80);

--- a/src/func_ov072_02120a08.cpp
+++ b/src/func_ov072_02120a08.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov072_02120a08
+// @emits daBgSnwmn_c_Behavior
+/* recovered: shared common types, renamed to Class_Method */
+/* daBgSnwmn_c::Behavior - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; };
 extern "C" {
 void _ZN9Animation7AdvanceEv(void *self);
@@ -7,7 +11,7 @@ void _ZN12CylinderClsn5ClearEv(void *self);
 void _ZN12CylinderClsn6UpdateEv(void *self);
 }
 extern const Vector3 data_ov072_02122c70;
-extern "C" int func_ov072_02120a08(char *c)
+extern "C" int daBgSnwmn_c_Behavior(char *c)
 {
     _ZN9Animation7AdvanceEv(c + 0x174);
     _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1b0, &data_ov072_02122c70);


### PR DESCRIPTION
Batch 13 of the readable-tree migration. Promotes 188 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 140 VERIFIED, 48 BLIND, 0 WRONG/NO-REPRO. 2 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
