### PR TITLE
readable: batch 14 - promote 190 files to readable form

### DIFF
--- a/src/func_ov072_02120a44.c
+++ b/src/func_ov072_02120a44.c
@@ -1,3 +1,11 @@
+// @symbol func_ov072_02120a44
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daBgSnwmn_c.h"
+// @emits daBgSnwmn_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daBgSnwmn_c::InitResources - recovered from vtable slot identity */
 typedef signed char s8;
 typedef unsigned int u32;
 
@@ -14,23 +22,20 @@ extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
 extern void _ZN13RaycastGroundC1Ev(void *self);
 extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *self, void *pos, void *act);
 extern int _ZN13RaycastGround10DetectClsnEv(void *self);
-extern void func_ov072_021208d8(void *thiz);
 extern void _ZN13RaycastGroundD1Ev(void *self);
 
-extern int data_ov072_02122c48[];
-extern int data_ov072_02122c40[];
-extern int data_ov072_02122c50[];
 extern int data_ov072_02122c70[];
 
-int func_ov072_02120a44(char *c)
+int daBgSnwmn_c_InitResources(char *c)
 {
+    struct daBgSnwmn_c *self = (struct daBgSnwmn_c *)(void *)c;
     char rg[0x50];
     int v[3];
     void *m;
 
     if (IsStarCollectedInLevel(0xa, 5) == 0)
     {
-        _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x111, 0, c + 0x5c, c + 0x8c, *(s8 *)(c + 0xcc), -1);
+        _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x111, 0, c + 0x5c, c + 0x8c, self->unk_0cc, -1);
         _ZN9ActorBase18MarkForDestructionEv(c);
     }
 
@@ -48,22 +53,22 @@ int func_ov072_02120a44(char *c)
 
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c + 0x1b0, c, data_ov072_02122c70, 0xc3000, 0x17c000, 0x800004, 0);
 
-    v[0] = *(int *)(c + 0x5c);
-    v[1] = *(int *)(c + 0x60);
-    v[2] = *(int *)(c + 0x64);
+    v[0] = self->unk_05c;
+    v[1] = self->unk_060;
+    v[2] = self->unk_064;
     v[1] += 0x14000;
     _ZN13RaycastGroundC1Ev(rg);
     _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(rg, v, 0);
     if (_ZN13RaycastGround10DetectClsnEv(rg))
-        *(int *)(c + 0x60) = *(int *)(rg + 0x44);
+        self->unk_060 = *(int *)(rg + 0x44);
     else
-        *(int *)(c + 0x60) = v[1];
+        self->unk_060 = v[1];
     (*(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)) += 0xc3000;
-    *(int *)(c + 0x9c) = 0;
-    *(int *)(c + 0xa0) = 0;
-    *(int *)(c + 0x80) = 0x1800;
-    *(int *)(c + 0x84) = 0x1800;
-    *(int *)(c + 0x88) = 0x1800;
+    self->unk_09c = 0;
+    self->unk_0a0 = 0;
+    self->unk_080 = 0x1800;
+    self->unk_084 = 0x1800;
+    self->unk_088 = 0x1800;
     func_ov072_021208d8(c);
     _ZN13RaycastGroundD1Ev(rg);
     return 1;

--- a/src/func_ov072_02120c00.c
+++ b/src/func_ov072_02120c00.c
@@ -1,16 +1,20 @@
-extern void *_ZN9ActorBasenwEj(unsigned);
-extern void _ZN5ActorC2Ev(void *);
-extern void _ZN5ModelC1Ev(void *);
-extern void _ZN15TextureSequenceC1Ev(void *);
-extern void _ZN11ShadowModelC1Ev(void *);
-extern void _ZN25MovingCylinderClsnWithPosC1Ev(void *);
-extern int VT0[];
+// @symbol func_ov072_02120c00
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ActorBase.h"
+#include "decl_Model.h"
+#include "decl_MovingCylinderClsnWithPos.h"
+#include "decl_ShadowModel.h"
+#include "decl_TextureSequence.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daBgSnwmn_c */
 int *func_ov072_02120c00(void)
 {
     int *p = (int *)_ZN9ActorBasenwEj(496);
     if (p) {
         _ZN5ActorC2Ev(p);
-        p[0] = (int)VT0;
+        p[0] = (int)_ZTV11daBgSnwmn_c;
         _ZN5ModelC1Ev((char *)p + 0xd4);
         _ZN5ModelC1Ev((char *)p + 0x124);
         _ZN15TextureSequenceC1Ev((char *)p + 0x174);

--- a/src/func_ov072_02120cfc.c
+++ b/src/func_ov072_02120cfc.c
@@ -1,4 +1,8 @@
-int func_ov072_02120cfc(void)
+// @symbol func_ov072_02120cfc
+// @emits BabyPenguin_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daPgBby_c::OnYoshiTryEat - recovered from vtable slot identity */
+int BabyPenguin_OnYoshiTryEat(void)
 {
     return 7;
 }

--- a/src/func_ov072_02120d04.cpp
+++ b/src/func_ov072_02120d04.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov072_02120d04
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern int Vec3_Dist(const Vector3* a, const Vector3* b);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);

--- a/src/func_ov072_02120ddc.c
+++ b/src/func_ov072_02120ddc.c
@@ -1,5 +1,8 @@
+// @symbol func_ov072_02120ddc
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 extern void func_ov072_02121d50(void *c, int n);
 void func_ov072_02120ddc(char *c)

--- a/src/func_ov072_02120f14.cpp
+++ b/src/func_ov072_02120f14.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov072_02120f14
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 struct RaycastGround { char buf[0x54]; };
 

--- a/src/func_ov072_021210c4.cpp
+++ b/src/func_ov072_021210c4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov072_021210c4
+/* recovered: shared common types */
+#include "common.h"
+
 struct RaycastGround { char buf[0x68 - 0x18]; };
 extern "C" {
 extern int _ZN6Player14IsFrontSlidingEv(void*);
@@ -7,13 +10,13 @@ extern int _ZN6Player17LostGrabbedObjectEv(void*);
 extern void* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void*, void*, void*);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void _ZN13RaycastGroundC1Ev(struct RaycastGround *self);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vec3 *v, void *actor);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vector3 *v, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround *self);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *self, void *shadow, void *mtx, int fix, int t1, unsigned int t2);
 extern void _ZN13RaycastGroundD1Ev(struct RaycastGround *self);
 extern char data_ov072_02122d3c[];
-struct M4x3 { int w[12]; };
+
 
 void func_ov072_021210c4(void *self);
 }
@@ -24,7 +27,7 @@ void func_ov072_021210c4(void *self)
     int idx;
     void *res;
     struct RaycastGround rg;
-    struct Vec3 v;
+    struct Vector3 v;
     int r5;
     int r4;
     long long tmp;
@@ -38,7 +41,7 @@ void func_ov072_021210c4(void *self)
             idx = (idx + 2) & 0xff;
         }
         res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(c, *(void**)(c + 0x360), data_ov072_02122d3c + idx * 0xc);
-        *(struct M4x3*)(c + 0xf0) = *(struct M4x3*)res;
+        *(struct Matrix4x3*)(c + 0xf0) = *(struct Matrix4x3*)res;
     } else {
         Matrix4x3_FromRotationY(c + 0xf0, *(short*)(c + 0x8e));
         *(int*)(c + 0x114) = *(int*)(c + 0x5c) >> 3;

--- a/src/func_ov072_02121368.c
+++ b/src/func_ov072_02121368.c
@@ -1,16 +1,20 @@
+// @symbol func_ov072_02121368
+// @emits daBgSnwmn_c_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daBgSnwmn_c::Kill - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef long long s64;
 
-struct Vector3 { int x, y, z; };
 
 extern s16 data_02082214[];
 extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
-extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *p);
 
-#define M(p) ((s64)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((s64)(int)(p))
 
-int func_ov072_02121368(char *self)
+int daBgSnwmn_c_Kill(char *self)
 {
     struct Vector3 v;
     char *other;

--- a/src/func_ov072_021217ac.cpp
+++ b/src/func_ov072_021217ac.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov072_021217ac
+/* recovered: shared common types */
+#include "common.h"
+
 class Actor;
 extern "C" int func_ov072_02121d50(Actor *a);
 extern "C" int func_0201267c(int id, void *p);

--- a/src/func_ov072_02121fa0.c
+++ b/src/func_ov072_02121fa0.c
@@ -1,8 +1,12 @@
-/* func_ov072_02121fa0 @ 0x2121fa0 (ov072) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+// @symbol func_ov072_02121fa0
+// @emits BabyPenguin_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daPgBby_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* BabyPenguin_OnTurnIntoEgg @ 0x2121fa0 (ov072) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void func_ov072_02121fa0(void) {
+void BabyPenguin_OnTurnIntoEgg(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov073_0211f2c0.c
+++ b/src/func_ov073_0211f2c0.c
@@ -1,7 +1,6 @@
-struct Mtx43
-{
-  int m[12];
-};
+// @symbol func_ov073_0211f2c0
+/* recovered: shared common types */
+#include "common.h"
 struct V3
 {
   int x;
@@ -16,7 +15,7 @@ extern void Matrix4x3_FromRotationY(void *m, short angle);
 extern void MulVec3Mat4x3(void *in, void *m, void *out);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void *data_0209f318;
-extern struct Mtx43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 extern char data_ov073_02123360;
 extern char data_ov073_021233c0;
 extern char data_ov073_021233f0;
@@ -36,7 +35,7 @@ void func_ov073_0211f2c0(char *c, int strength)
   int y;
   int z;
   func_0200d8c8(data_0209f318, c + 0x5c, strength);
-  data_020a0e68 = *((struct Mtx43 *) (c + 0x328));
+  data_020a0e68 = *((struct Matrix4x3 *) (c + 0x328));
   MulMat4x3Mat4x3(((char *) (*((void **) (c + 0x320)))) + ((*((int *) (c + 0x4bc))) * 0x30), &data_020a0e68, &data_020a0e68);
   *((int *) ((((int) c) + 0x4bc) & 0xFFFFFFFFFFFFFFFF)) ^= 1;
   ty = *((int *) (((char *) (&data_020a0e68)) + 0x28));

--- a/src/func_ov073_0211fa74.c
+++ b/src/func_ov073_0211fa74.c
@@ -1,19 +1,18 @@
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+// @symbol func_ov073_0211fa74
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void _Z14ApproachLinearRiii(int* p, int t, int s);
 extern void _ZN7Message7EndTalkEv(void);
-extern void _ZN5Sound22StopLoadedMusic_Layer3Ev(void);
-extern void func_02011cfc(void);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);
-extern void func_0200fa8c(void* t, int a);
 extern short _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, void* pos, void* rot, int a, int b);
 extern void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void* prev);
 extern void func_02012694(int a, void* p);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, void* pos);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
-extern void func_ov073_0211f144(void* c);
 extern void* data_0209f318;
 
 int func_ov073_0211fa74(char* c) {

--- a/src/func_ov073_0211fc78.c
+++ b/src/func_ov073_0211fc78.c
@@ -1,15 +1,17 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov073_0211fc78
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, struct Vector3* v, unsigned int d);
-extern void func_ov073_0211f144(void* actor);
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void Matrix4x3_FromRotationY(void* m, short ang);
 extern void MulVec3Mat4x3(void* in, void* m, void* out);
 extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, struct Vector3* v);
 extern void _ZN6Camera6SetPosERK7Vector3(void* cam, struct Vector3* v);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* self, void* actor, int b);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const struct Vector3* pos, unsigned int a, unsigned int b);
 extern void func_02012694(int a, void* p);
@@ -17,7 +19,6 @@ extern int func_ov073_0212157c(void* c, void* p);
 
 extern void* data_0209f318;
 extern int data_020a0e68[];
-extern void* data_ov073_02123410;
 
 int func_ov073_0211fc78(char* c) {
     struct Vector3 msgpos[2];

--- a/src/func_ov073_0211fe8c.c
+++ b/src/func_ov073_0211fe8c.c
@@ -1,11 +1,14 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov073_0211fe8c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct ActorBase;
 
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, struct Vector3* v, unsigned int d);
 extern void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern void _ZN6Player9StartTalkER9ActorBaseb(void* self, void* actor, int b);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void* actor);
-extern void func_ov073_0211f144(void* actor);
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void Matrix4x3_FromRotationY(void* m, short ang);
 extern void MulVec3Mat4x3(void* a, void* m, void* b);
@@ -15,7 +18,6 @@ extern int func_ov073_0212157c(void* c, void* p);
 
 extern void* data_0209f318;
 extern int data_020a0e68[];
-extern void* data_ov073_021233e0;
 
 int func_ov073_0211fe8c(char* c) {
     struct Vector3 look, pos, in, out;

--- a/src/func_ov073_0212128c.c
+++ b/src/func_ov073_0212128c.c
@@ -1,11 +1,12 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov073_0212128c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, struct Vector3* v);
 extern void _ZN6Camera6SetPosERK7Vector3(void* cam, struct Vector3* v);
 extern int _ZN6Player12GetTalkStateEv(void* self);
-extern void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int a);
-extern void func_02011d08(void);
 extern int func_ov073_0212157c(void* c, void* p);
 
 extern void* data_0209f318;

--- a/src/func_ov073_02121388.c
+++ b/src/func_ov073_02121388.c
@@ -1,5 +1,8 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov073_02121388
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, struct Vector3* v);
@@ -7,7 +10,6 @@ extern void _ZN6Camera6SetPosERK7Vector3(void* cam, struct Vector3* v);
 extern short Vec3_HorzAngle(const struct Vector3* a, const struct Vector3* b);
 extern void _Z14ApproachLinearRsss(short* p, short a, short b);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* self, void* actor, int b);
-extern void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int a);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const struct Vector3* pos, unsigned int a, unsigned int b);
 extern void func_02012694(int a, void* p);
 extern int func_ov073_0212157c(void* c, void* p);

--- a/src/func_ov073_02121ec0.c
+++ b/src/func_ov073_02121ec0.c
@@ -1,4 +1,8 @@
-int func_ov073_02121ec0(void)
+// @symbol func_ov073_02121ec0
+// @emits ChiefChilly_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daKing_Donketu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int ChiefChilly_OnAimedAtWithEgg(void)
 {
     return 409600;
 }

--- a/src/func_ov073_02122034.cpp
+++ b/src/func_ov073_02122034.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov073_02122034
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);
 extern int func_02012694(int, const Vector3&);

--- a/src/func_ov073_02122200.cpp
+++ b/src/func_ov073_02122200.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov073_02122200
+// @emits ChiefChilly_Kill
+/* recovered: renamed to Class_Method */
+/* daKing_Donketu_c::Kill - recovered from vtable slot identity */
 typedef short s16;
 struct CylinderClsn;
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(void* a, CylinderClsn* c);
@@ -8,7 +12,7 @@ extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* a);
 extern int data_02092138;
 
-extern "C" int func_ov073_02122200(char* thiz)
+extern "C" int ChiefChilly_Kill(char* thiz)
 {
     char* c = thiz;
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);

--- a/src/func_ov073_021223f4.cpp
+++ b/src/func_ov073_021223f4.cpp
@@ -1,5 +1,9 @@
 //cpp
-// func_ov073_021223f4 at 0x021223f4
+// @symbol func_ov073_021223f4
+// @emits CccArena_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjEwbIce_c::Kill - recovered from vtable slot identity */
+// CccArena_Kill at 0x021223f4
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov073).
 struct Vector3 { int x, y, z; };
 extern "C" {
@@ -7,8 +11,8 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int 
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 }
-extern "C" void func_ov073_021223f4(char* c);
-void func_ov073_021223f4(char* c) {
+extern "C" void CccArena_Kill(char* c);
+void CccArena_Kill(char* c) {
     Vector3 vec;
     Vector3 vec2;
     vec.x = *(int*)(c + 0x5c);

--- a/src/func_ov074_0211f154.c
+++ b/src/func_ov074_0211f154.c
@@ -1,8 +1,11 @@
+// @symbol func_ov074_0211f154
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov074_0211f154 at 0x0211f154
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov074).
  */
-struct Vector3 { int x, y, z; };
+
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void Matrix4x3_FromRotationY(void* m, short ang);
 extern void MulVec3Mat4x3(void* a, void* m, void* b);

--- a/src/func_ov074_0211f38c.c
+++ b/src/func_ov074_0211f38c.c
@@ -1,16 +1,20 @@
+// @symbol func_ov074_0211f38c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef long long s64;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 extern u16 DecIfAbove0_Short(u16* p);
 extern s16 Vec3_VertAngle(const struct Vector3* v1, const struct Vector3* v0);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const struct Vector3* pos, const struct Vector3_16* ang, int e, int f);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern s16 data_02082214[];
-extern u8 data_ov074_02122d80[];
 
 int func_ov074_0211f38c(u8* c){
     struct Vector3 p0, p1;
@@ -53,7 +57,7 @@ int func_ov074_0211f38c(u8* c){
         ang.x=Vec3_VertAngle(&p1, &p0);
         _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xc7, 0x1111, &p0, &ang, (signed char)c[0xcc], -1);
         {
-            u8* pc=(u8*)(((long long)(int)(c+0x602))&0xFFFFFFFFFFFFFFFFLL);
+            u8* pc=(u8*)(((long long)(int)(c+0x602)));
             *pc+=1;
         }
         *(short*)((c+0x500)+0xfc)=2;

--- a/src/func_ov074_0211fd74.cpp
+++ b/src/func_ov074_0211fd74.cpp
@@ -1,11 +1,16 @@
 //cpp
+// @symbol func_ov074_0211fd74
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
+
 
 extern "C" {
     int func_ov074_02121a20(void* c, int idx);
@@ -23,7 +28,6 @@ extern "C" {
     int __aeabi_idiv(int a, int b);
 }
 
-extern u8 data_ov074_02122d80[];
 
 extern "C" void func_ov074_0211fd74(void* self)
 {
@@ -48,9 +52,9 @@ L90:;
     if (_ZN9Animation8FinishedEv((void*)(c+0x260)) == 0) return;
     if (DecIfAbove0_Short((u16*)(c+0x5fc)) != 0) return;
 
-    Vec3 pos;
+    Vector3 pos;
     func_ov074_0212087c(&pos, self, *(u8*)(c+0x602));
-    Vec3 pp;
+    Vector3 pp;
     pp.x = pos.x;
     pp.y = pos.y;
     pp.z = pos.z;
@@ -64,7 +68,7 @@ L90:;
     u8* sp2 = (u8*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
         0xc8, sid, &pos, (void*)(c+0x8c), *(signed char*)(c+0xcc), -1);
     *(s32*)(sp2+0x43c) = *(s32*)(c+4);
-    Vec3 v2;
+    Vector3 v2;
     v2.x = *(s32*)(c+0x5d0);
     v2.y = *(s32*)(c+0x5d4);
     v2.z = *(s32*)(c+0x5d8);

--- a/src/func_ov074_02120d74.c
+++ b/src/func_ov074_02120d74.c
@@ -1,3 +1,8 @@
+// @symbol func_ov074_02120d74
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 #define false 0
 
 typedef signed char s8;
@@ -6,7 +11,7 @@ typedef unsigned short u16;
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern short data_02082214[];
 
@@ -15,10 +20,6 @@ extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN6Player12Unk_020c6a10Ej(char *p, unsigned int a);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(char *p, const struct Vector3 *v, unsigned int a, int b, unsigned int c, unsigned int d, unsigned int e);
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern int AngleDiff(int a, int b);
-extern void func_ov074_02121a4c(char *c, int idx);
-extern void func_ov074_021203e4(char *c, int i);
-extern void func_ov074_02120bb8(char *a, char *b, char *c, int d);
 extern void func_02012694(unsigned int a, void *b);
 extern char *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, const struct Vector3 *, const void *, int, int);
 

--- a/src/func_ov074_02121270.c
+++ b/src/func_ov074_02121270.c
@@ -1,14 +1,17 @@
+// @symbol func_ov074_02121270
+/* recovered: shared common types */
+#include "common.h"
 extern void MulMat4x3Mat4x3(void* out, void* a, void* b);
 extern void Vec3_LslInPlace(void* v, int n);
-struct M48 { int w[12]; };
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov074_02121270(char* r4, char* r8, int r7){
   char* dst;
   *(int*)r4 = 0;
   *(int*)(r4 + 4) = 0;
   *(int*)(r4 + 8) = 0;
-  data_020a0e68 = *(struct M48*)(r8 + 0x37c);
+  data_020a0e68 = *(struct Matrix4x3*)(r8 + 0x37c);
   dst = *(char**)(r8 + 0x224) + r7 * 0x30;
   MulMat4x3Mat4x3(dst, &data_020a0e68, &data_020a0e68);
   *(int*)r4 = *(int*)((char*)&data_020a0e68 + 0x24);

--- a/src/func_ov074_02121300.cpp
+++ b/src/func_ov074_02121300.cpp
@@ -1,19 +1,22 @@
 //cpp
+// @symbol func_ov074_02121300
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 typedef int Fix12;
-struct Vec3 { int x,y,z; };
-struct M43 { int w[12]; };
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+
+
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short a);
 extern void Matrix4x3_ApplyInPlaceToScale(void* m, Fix12 x, Fix12 y, Fix12 z);
-extern struct M43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 void func_ov074_02121300(char* c){
-  struct Vec3 v;
-  Vec3_Asr(&v, (struct Vec3*)(c+0x5c), 3);
+  struct Vector3 v;
+  Vec3_Asr(&v, (struct Vector3*)(c+0x5c), 3);
   Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c+0x8e));
   Matrix4x3_ApplyInPlaceToScale(&data_020a0e68, *(int*)(c+0x80), *(int*)(c+0x84), *(int*)(c+0x88));
-  *(struct M43*)(c+0x37c) = data_020a0e68;
+  *(struct Matrix4x3*)(c+0x37c) = data_020a0e68;
 }
 }

--- a/src/func_ov074_021222e0.cpp
+++ b/src/func_ov074_021222e0.cpp
@@ -1,13 +1,16 @@
 //cpp
-struct Vec3 { int x, y, z; };
-struct M48 { int w[12]; };
+// @symbol func_ov074_021222e0
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" {
-extern void Vec3_Asr(Vec3* d, Vec3* s, int sh);
+extern void Vec3_Asr(Vector3* d, Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationZXYExt(void* m, int x, int y, int z);
 extern void _ZN15MaterialChanger6UpdateER15ModelComponents(void*, void*);
-extern M48 data_020a0e68;
+extern Matrix4x3 data_020a0e68;
 }
 
 struct Obj210 {
@@ -21,13 +24,13 @@ struct Obj210 {
 
 extern "C" int func_ov074_021222e0(char* c)
 {
-    Vec3 v;
-    Vec3_Asr(&v, (Vec3*)(c + 0x5c), 3);
+    Vector3 v;
+    Vec3_Asr(&v, (Vector3*)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, 0x6400, 0);
     Matrix4x3_ApplyInPlaceToRotationZXYExt(&data_020a0e68, *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));
     Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, -0x6400, 0);
-    *(M48*)(c + 0x22c) = data_020a0e68;
+    *(Matrix4x3*)(c + 0x22c) = data_020a0e68;
 
     if (*(unsigned char*)(c + 0x60a) == 0) return 1;
 

--- a/src/func_ov074_021223bc.cpp
+++ b/src/func_ov074_021223bc.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov074_021223bc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50 - 0x14 - 0x30]; };
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 struct WithMeshClsn;
 struct CylinderClsn;
 struct ShadowModel;

--- a/src/func_ov075_02114300.cpp
+++ b/src/func_ov075_02114300.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov075_02114300
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x,y,z; };
-struct Vector3_16f { short x,y,z; };
+
+
 struct Matrix4x3;
 struct Sub { char pad[0x24]; char m[0x30]; };
 extern "C" void MulVec3Mat4x3(Matrix4x3* m, Vector3* in, Vector3* out);
 extern "C" void Vec3_MulScalarInPlace(Vector3* v, Fix12i s);
-extern "C" unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, Fix12i c, int d, int e, const Vector3_16f* f, void* g);
+extern "C" unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned a, unsigned b, Fix12i c, int d, int e, const Vector3_16* f, void* g);
 struct C {
     char pad0[0x14];
     char* mtxbase;
@@ -25,5 +28,5 @@ extern "C" void func_ov075_02114300(C* c)
     MulVec3Mat4x3((Matrix4x3*)s->m, &c->v1c, &tmp);
     Vec3_MulScalarInPlace(&tmp, 0x8000);
     tmp.y += 0x28000;
-    c->field_14c = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(c->field_14c, 0x140, tmp.x, tmp.y, tmp.z, (Vector3_16f*)0, (void*)0);
+    c->field_14c = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(c->field_14c, 0x140, tmp.x, tmp.y, tmp.z, (Vector3_16*)0, (void*)0);
 }

--- a/src/func_ov075_0211473c.cpp
+++ b/src/func_ov075_0211473c.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov075_0211473c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x,y,z; };
+
 extern "C" s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 int ApproachLinear(short&,short,short);
-extern short data_ov075_0211b52c[];
 extern "C" void func_ov075_0211473c(char* c){
   s16 a=Vec3_HorzAngle((Vector3*)(c+0x118),(Vector3*)(c+0x130));
   unsigned char idx=*(unsigned char*)(c+0x152);

--- a/src/func_ov075_02114cd8.cpp
+++ b/src/func_ov075_02114cd8.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Matrix4x3 { int m[12]; };
+// @symbol func_ov075_02114cd8
+/* recovered: shared common types */
+#include "common.h"
+
 struct Obj;
 extern "C" void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationY(Matrix4x3 *mf, short angY);

--- a/src/func_ov075_021151b4.c
+++ b/src/func_ov075_021151b4.c
@@ -1,17 +1,17 @@
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int m[12]; };
-
-extern void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
-extern void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
-extern struct Mtx43 data_020a0e68;
+// @symbol func_ov075_021151b4
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
+extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
+extern struct Matrix4x3 data_020a0e68;
 
 struct Entry { char pad[0x118]; int x, y, z; char rest[0x34]; };
 
 void func_ov075_021151b4(char *c, int idx)
 {
     struct Entry *e = ((struct Entry *)(c + 0x920)) + idx;
-    struct Vec3 *src = (struct Vec3 *)(((long long)(int)((char *)e + 0x118)) & 0xFFFFFFFFFFFFFFFFLL);
-    struct Vec3 v, out;
+    struct Vector3 *src = (struct Vector3 *)(((long long)(int)((char *)e + 0x118)));
+    struct Vector3 v, out;
     int y;
 
     v.x = src->x;
@@ -21,5 +21,5 @@ void func_ov075_021151b4(char *c, int idx)
     v.y = y + 0x32000;
     Vec3_Asr(&out, &v, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, out.x, out.y, out.z);
-    *(struct Mtx43 *)(c + 0x8d8) = data_020a0e68;
+    *(struct Matrix4x3 *)(c + 0x8d8) = data_020a0e68;
 }

--- a/src/func_ov075_021152d4.cpp
+++ b/src/func_ov075_021152d4.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Matrix4x3 { int m[12]; };
+// @symbol func_ov075_021152d4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Vector3;
 namespace G3i {
     void PerspectiveW_(int a1, int a2, int a3, int a4, int a5, int a6, bool b, Matrix4x3 *m);
@@ -9,7 +14,6 @@ extern "C" void _Z13CopyToViewMatPK9Matrix4x3(const Matrix4x3 *m);
 namespace Clipper { void Func_020156DC(void *a, int b, int c, int d, int e); }
 
 extern "C" short data_02082614[];
-extern "C" int data_ov075_0211c660;
 extern "C" int data_0209f43c;
 
 extern "C" void func_ov075_021152d4(char *self)

--- a/src/func_ov075_02115b28.c
+++ b/src/func_ov075_02115b28.c
@@ -1,13 +1,15 @@
-extern int data_ov075_0211d304[];
-extern void func_ov075_02115bc8(void);
-extern void func_ov075_02115bac(void);
+// @symbol func_ov075_02115b28
+// @emits dScEntry_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void func_0207328c(void*, int, int, void*);
 extern void _ZN9ActorBaseD2Ev(void*);
 extern void* data_020a0eac;
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
-int* func_ov075_02115b28(int* t){
+int* dScEntry_c_OnYoshiTryEat(int* t){
   t[0]=(int)data_ov075_0211d304;
   func_0207328c((char*)t+0x1b4, 4, 0x2c, (void*)func_ov075_02115bc8);
   func_0207328c((char*)t+0x70, 9, 0x24, (void*)func_ov075_02115bac);

--- a/src/func_ov075_0211a210.c
+++ b/src/func_ov075_0211a210.c
@@ -1,10 +1,13 @@
+// @symbol func_ov075_0211a210
+// @emits dScEntry_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::CleanupResources - recovered from vtable slot identity */
 extern void func_020308b4(signed char levelID);
-extern void Deallocate(void *ptr);
-extern void *data_0209b2e8;
 extern void *data_0209d4a8;
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void);
-extern void CleanCommonModelDataArr(void);
-int func_ov075_0211a210(signed char levelID)
+int dScEntry_c_CleanupResources(signed char levelID)
 {
     func_020308b4(levelID);
     if (data_0209b2e8 != (void *)0) {

--- a/src/func_ov075_0211a268.c
+++ b/src/func_ov075_0211a268.c
@@ -1,3 +1,7 @@
-void func_ov075_0211a268(void)
+// @symbol func_ov075_0211a268
+// @emits dScEntry_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::OnPendingDestroy - recovered from vtable slot identity */
+void dScEntry_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov075_0211a26c.cpp
+++ b/src/func_ov075_0211a26c.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol func_ov075_0211a26c
+// @emits dScEntry_c_Render
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::Render - recovered from vtable slot identity */
 struct C;
 typedef void (C::*PMF)();
 struct C { char pad[0x64]; PMF pp[1]; };
 extern "C" {
-extern void func_0203083c(void);
-int func_ov075_0211a26c(C *c){
+int dScEntry_c_Render(C *c){
   if(*(int*)&c->pp[0]!=0){
     PMF *p = c->pp;
     (c->**p)();

--- a/src/func_ov075_0211a2b8.cpp
+++ b/src/func_ov075_0211a2b8.cpp
@@ -1,4 +1,10 @@
 //cpp
+// @symbol func_ov075_0211a2b8
+// @emits dScEntry_c_Behavior
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -6,7 +12,6 @@ extern "C" {
     void func_020551f0(void *s, int v);
     int func_ov075_02119dc4(void *c, void *arg);
     extern int data_0209fc68;
-    extern int data_ov075_0211d930;
 }
 
 struct VObj {
@@ -34,7 +39,7 @@ struct Self {
     u8 f285;
 };
 
-extern "C" int func_ov075_0211a2b8(Self *c)
+extern "C" int dScEntry_c_Behavior(Self *c)
 {
     char *cc = (char *)c;
 

--- a/src/func_ov075_0211a410.cpp
+++ b/src/func_ov075_0211a410.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov075_0211a410
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScEntry_c.h"
+// @emits dScEntry_c_InitResources
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
@@ -36,22 +44,19 @@ extern "C" {
 
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-extern void* data_0209b2e8;
 extern u8 data_020a0e40;
 extern u8 data_0209f4ae[];
-extern void* data_ov075_0211d71c;
 extern void* data_0209d4a8;
-extern u8 data_0209b2f0[];
 extern s32 data_0208ee44;
-extern u8 data_02092778;
 
-extern "C" int func_ov075_0211a410(char* c)
+extern "C" int dScEntry_c_InitResources(char* c)
 {
+    struct dScEntry_c *self = (struct dScEntry_c *)(void *)c;
     Enable3dEngines();
     func_0200f2cc();
 
     {
-        int b = (*(u16*)(c + 0xc) == 7);
+        int b = (self->unk_00c == 7);
         if (b || *(s32*)(c + 8) != 0 || func_0203d9b4() != 0) {
             LoadTextNarcs();
             LoadArchive(0);
@@ -87,19 +92,19 @@ extern "C" int func_ov075_0211a410(char* c)
     SetSubBg3Offset(0, 0);
     data_0209d454 = 0x18;
 
-    *(u8*)(c + 0x283) = 0;
-    *(u8*)(c + 0x284) = 0;
-    *(u8*)(c + 0x285) = 0;
+    self->unk_283 = 0;
+    self->unk_284 = 0;
+    self->unk_285 = 0;
 
     if (data_0209b2e8 != 0) {
         Deallocate(data_0209b2e8);
         data_0209b2e8 = 0;
     }
-    *(u8*)(c + 0x287) = 0;
+    self->unk_287 = 0;
     LoadFont3D();
 
     {
-        int b6 = (*(u16*)(c + 0xc) == 6);
+        int b6 = (self->unk_00c == 6);
         if (b6) {
             func_ov075_02116ad4(c);
             if (*(s32*)(c + 8) == 0) {
@@ -123,7 +128,7 @@ extern "C" int func_ov075_0211a410(char* c)
     _ZN5Sound16LoadInitialGroupEi(0x2b);
 
     {
-        int b6b = (*(u16*)(c + 0xc) == 6);
+        int b6b = (self->unk_00c == 6);
         if (b6b) {
             if (*(u32*)(c + 8) < 2) {
                 _ZN5Sound22LoadAndSetMusic_Layer1Ei(0x4c);

--- a/src/func_ov075_0211a734.c
+++ b/src/func_ov075_0211a734.c
@@ -1,8 +1,12 @@
-/* func_ov075_0211a734 @ 0x211a734 (ov075) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
+// @symbol func_ov075_0211a734
+// @emits dScEntry_c_BeforeInitResources
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::BeforeInitResources - recovered from vtable slot identity */
+/* dScEntry_c_BeforeInitResources @ 0x211a734 (ov075) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
  * ldr ip, [pc]; bx ip; .word 0x202e66c
  */
 extern void _ZN5Scene19ResetFadersAndSoundEv(void);
 
-void func_ov075_0211a734(void) {
+void dScEntry_c_BeforeInitResources(void) {
     _ZN5Scene19ResetFadersAndSoundEv();
 }

--- a/src/func_ov075_0211aa00.c
+++ b/src/func_ov075_0211aa00.c
@@ -1,8 +1,11 @@
+// @symbol func_ov075_0211aa00
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short angY);
 extern void InvMat4x3(void* d, void* s);
-struct M48 { int w[12]; };
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov075_0211aa00(char* r4){
   Matrix4x3_FromTranslation(&data_020a0e68,
@@ -10,7 +13,7 @@ void func_ov075_0211aa00(char* r4){
     (*(int*)(r4 + 4) - 0xfa000) >> 3,
     *(int*)(r4 + 8) >> 3);
   Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(r4 + 0xe));
-  *(struct M48*)(r4 + 0x14) = data_020a0e68;
+  *(struct Matrix4x3*)(r4 + 0x14) = data_020a0e68;
   InvMat4x3(&data_020a0e68, &data_020a0e68);
-  *(struct M48*)(r4 + 0x44) = data_020a0e68;
+  *(struct Matrix4x3*)(r4 + 0x44) = data_020a0e68;
 }

--- a/src/func_ov075_0211ab38.c
+++ b/src/func_ov075_0211ab38.c
@@ -1,13 +1,15 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+// @symbol func_ov075_0211ab38
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void func_ov075_0211af84(char* self, int a, int b);
 
-void func_ov075_0211ab38(char* c, struct Vec3* arg2)
+void func_ov075_0211ab38(char* c, struct Vector3* arg2)
 {
-    struct Vec3 a;
-    struct Vec3 r;
-    struct Vec3 out;
+    struct Vector3 a;
+    struct Vector3 r;
+    struct Vector3 out;
     a.x = 0;
     a.y = 0x15e000;
     a.z = -0x320000;

--- a/src/func_ov075_0211af0c.c
+++ b/src/func_ov075_0211af0c.c
@@ -1,5 +1,8 @@
+// @symbol func_ov075_0211af0c
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 extern Fix12i Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 
 struct Elem { struct Vector3 pos; int dist; int pad[2]; };  /* 0x18 */

--- a/src/func_ov075_0211b1cc.c
+++ b/src/func_ov075_0211b1cc.c
@@ -1,16 +1,22 @@
+// @symbol func_ov075_0211b1cc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "dScEntry_c.h"
+// @emits dScEntry_c_OnYoshiTryEat_0211b1cc
+/* recovered: renamed to Class_Method */
+/* dScEntry_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
-extern int func_ov075_0211addc(void* c, int x);
-extern void func_ov075_0211abb0(void* c);
-extern void func_ov075_0211ad60(void* c);
 struct E { char pad[8]; int r8; int rc; char pad2[8]; };
-void func_ov075_0211b1cc(char* c) {
+void dScEntry_c_OnYoshiTryEat_0211b1cc(char* c) {
+    struct dScEntry_c *self = (struct dScEntry_c *)(void *)c;
   int i;
   if (DecIfAbove0_Short((unsigned short*)(c + 0xa2)) == 0) return;
-  for (i = 0; i < *(unsigned short*)(c + 0xa4); i++) {
-    struct E* e = (struct E*)(*(int*)(c + 0x80) + i * 0x18);
+  for (i = 0; i < self->unk_0a4; i++) {
+    struct E* e = (struct E*)(self->unk_080 + i * 0x18);
     e->r8 = func_ov075_0211addc(c, e->rc);
   }
   func_ov075_0211abb0(c);
   func_ov075_0211ad60(c);
-  *(short*)(c + 0xa0) += 0x1111;
+  self->unk_0a0 += 0x1111;
 }

--- a/src/func_ov075_0211b458.cpp
+++ b/src/func_ov075_0211b458.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov075_0211b458
+/* recovered: shared common types */
+#include "common.h"
+
 struct Foo;
 typedef void (Foo::*PMF)();
 extern "C" {

--- a/src/func_ov077_02123804.c
+++ b/src/func_ov077_02123804.c
@@ -1,4 +1,8 @@
-int func_ov077_02123804(void)
+// @symbol func_ov077_02123804
+// @emits Lakitu_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daJgm_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Lakitu_OnYoshiTryEat(void)
 {
     return 6;
 }

--- a/src/func_ov077_0212380c.c
+++ b/src/func_ov077_0212380c.c
@@ -1,4 +1,8 @@
-int func_ov077_0212380c(void)
+// @symbol func_ov077_0212380c
+// @emits Lakitu_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daJgm_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Lakitu_OnAimedAtWithEgg(void)
 {
     return 245760;
 }

--- a/src/func_ov077_02123a1c.cpp
+++ b/src/func_ov077_02123a1c.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3{int x,y,z;};
+// @symbol func_ov077_02123a1c
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C"{
 void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void*,Vector3 const&,unsigned int,int,short);
 void _ZN5Actor8PoofDustEv(void*);

--- a/src/func_ov077_02123c6c.cpp
+++ b/src/func_ov077_02123c6c.cpp
@@ -1,20 +1,24 @@
 //cpp
+// @symbol func_ov077_02123c6c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct V3 { int x, y, z; };
+
 struct RG { char buf[0x54]; };
 extern int func_02038420(void* w);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void* w);
-extern void* _ZNK12WithMeshClsn13GetWallResultEv(void* w);
-extern int _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* s, struct V3* v);
+extern int _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* s, struct Vector3* v);
 extern int _ZN13RaycastGroundC1Ev(struct RG* r);
-extern int _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG* r, struct V3* v, void* a);
+extern int _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RG* r, struct Vector3* v, void* a);
 extern int _ZN4BgCh19StartDetectingWaterEv(struct RG* r);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RG* r);
 extern int _ZN4BgCh18StopDetectingWaterEv(struct RG* r);
 extern int _ZN13RaycastGroundD1Ev(struct RG* r);
 void func_ov077_02123c6c(char* c, void* w){
-  struct V3 nrm;
-  struct V3 pos;
+  struct Vector3 nrm;
+  struct Vector3 pos;
   struct RG rg;
   func_02038420(w);
   if (_ZNK12WithMeshClsn8IsOnWallEv(w) != 0) {

--- a/src/func_ov077_02124038.cpp
+++ b/src/func_ov077_02124038.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov077_02124038
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
-extern int data_ov077_02127b28[];
 }
 
 struct Base {

--- a/src/func_ov077_02124564.c
+++ b/src/func_ov077_02124564.c
@@ -1,17 +1,19 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov077_02124564
+/* recovered: shared common types */
+#include "common.h"
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 void* _ZN5Actor22ClosestNonVanishPlayerEv(void* p);
-int Vec3_HorzDist(const struct Vec3* a, const struct Vec3* b);
+int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
 int func_ov077_02123880(void* c);
 void func_ov077_0212478c(void* c, int v);
 void func_ov077_0212390c(char* c);
 void func_ov077_02123814(char* c);
 void _ZN9Animation7AdvanceEv(void* p);
 void func_ov077_02123a74(void* thiz);
-void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* thiz, const struct Vec3* v);
+void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* thiz, const struct Vector3* v);
 void _ZN12CylinderClsn5ClearEv(void* p);
 void _ZN12CylinderClsn6UpdateEv(void* p);
-unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vec3* pos, unsigned int e);
+unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vector3* pos, unsigned int e);
 
 extern int data_ov077_02127b88[3];
 
@@ -21,7 +23,7 @@ int func_ov077_02124564(char* c) {
         char* p = (char*)_ZN5Actor22ClosestNonVanishPlayerEv(c);
         if (p == 0) goto store2;
         if (*(int*)(p + 0x60) >= *(int*)(c + 0x60)) goto store1;
-        if (Vec3_HorzDist((struct Vec3*)(c + 0x5c), (struct Vec3*)(p + 0x5c)) >= 0x190000) goto store1;
+        if (Vec3_HorzDist((struct Vector3*)(c + 0x5c), (struct Vector3*)(p + 0x5c)) >= 0x190000) goto store1;
         if (func_ov077_02123880(c) >= 4) goto store1;
         func_ov077_0212478c(c, 1);
         goto tail;
@@ -38,7 +40,7 @@ tail:
     _ZN9Animation7AdvanceEv(c + 0x1b0);
     func_ov077_02123a74(c);
     {
-        struct Vec3 pos;
+        struct Vector3 pos;
         pos.y = data_ov077_02127b88[1] + *(int*)(c + 0x414);
         pos.x = data_ov077_02127b88[0];
         pos.z = data_ov077_02127b88[2];
@@ -46,6 +48,6 @@ tail:
     }
     _ZN12CylinderClsn5ClearEv(c + 0x1c4);
     _ZN12CylinderClsn6UpdateEv(c + 0x1c4);
-    *(int*)(c + 0x410) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(int*)(c + 0x410), 3, 0x182, (struct Vec3*)(c + 0x74), 0);
+    *(int*)(c + 0x410) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(int*)(c + 0x410), 3, 0x182, (struct Vector3*)(c + 0x74), 0);
     return 1;
 }

--- a/src/func_ov077_02124aa4.cpp
+++ b/src/func_ov077_02124aa4.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov077_02124aa4
+// @emits Lakitu_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daJgm_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void func_ov077_02124aa4(void *self, void *p)
+void Lakitu_OnTurnIntoEgg(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 5, 0);

--- a/src/func_ov077_02124c18.c
+++ b/src/func_ov077_02124c18.c
@@ -1,4 +1,8 @@
-int func_ov077_02124c18(void)
+// @symbol func_ov077_02124c18
+// @emits Spiny_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daTgz_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Spiny_OnYoshiTryEat(void)
 {
     return 6;
 }

--- a/src/func_ov077_02124c20.c
+++ b/src/func_ov077_02124c20.c
@@ -1,4 +1,8 @@
-int func_ov077_02124c20(void)
+// @symbol func_ov077_02124c20
+// @emits Spiny_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daTgz_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Spiny_OnAimedAtWithEgg(void)
 {
     return 122880;
 }

--- a/src/func_ov077_02124c28.cpp
+++ b/src/func_ov077_02124c28.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov077_02124c28
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor;
 
 struct RaycastGround {

--- a/src/func_ov077_02124d08.cpp
+++ b/src/func_ov077_02124d08.cpp
@@ -1,7 +1,13 @@
 //cpp
+// @symbol func_ov077_02124d08
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 struct WithMeshClsn;
 struct Actor;
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50-0x14-0x30]; };
@@ -14,7 +20,6 @@ extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround* self);
 extern "C" void _ZN4BgCh19StartDetectingToxicEv(void* self);
 extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround* self, const Vector3& v, void* actor);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround* self);
-extern "C" int func_02037e20(int* p);
 extern "C" void _ZN5Actor8PoofDustEv(void* self);
 extern "C" void func_02012694(int a, void* b);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* self);
@@ -24,7 +29,6 @@ extern "C" void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void* self, Vector3* o
 extern "C" int _ZN4cstd4fdivEii(int a, int b);
 extern "C" s16 func_02010844(void* unused, Vector3* v, s16 angle);
 extern "C" int _ZNK12WithMeshClsn8IsOnWallEv(void* self);
-extern "C" void* _ZNK12WithMeshClsn13GetWallResultEv(void* self);
 
 extern "C" void func_ov077_02124d08(char* a, char* w) {
     RaycastGround rc;

--- a/src/func_ov077_021251d0.cpp
+++ b/src/func_ov077_021251d0.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov077_021251d0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void Vec3_Asr(void* d, void* s, int sh);
 void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
 void Matrix4x3_ApplyInPlaceToRotationZXYExt(void* m, int x, int y, int z);
-struct M48 { int w[12]; };
-extern M48 data_020a0e68;
+
+extern Matrix4x3 data_020a0e68;
 }
 struct Base {
   virtual void v0();
@@ -52,5 +55,5 @@ extern "C" void func_ov077_021251d0(void* c)
       *(short*)(r4+0x8c), *(short*)(r4+0x8e), *(short*)(r4+0x90));
   int r2 = b->m();
   Matrix4x3_ApplyInPlaceToTranslation(&data_020a0e68, 0, (-r2) >> 3, 0);
-  *(M48*)(r4+0x140) = data_020a0e68;
+  *(Matrix4x3*)(r4+0x140) = data_020a0e68;
 }

--- a/src/func_ov077_021253a4.cpp
+++ b/src/func_ov077_021253a4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov077_021253a4
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void*);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void*, void*);

--- a/src/func_ov077_02125480.cpp
+++ b/src/func_ov077_02125480.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov077_02125480
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);

--- a/src/func_ov077_02125550.cpp
+++ b/src/func_ov077_02125550.cpp
@@ -1,5 +1,11 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov077_02125550
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 extern void func_020383fc(void* p);
@@ -7,13 +13,11 @@ extern void func_02038420(void* p);
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(void* p);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
 extern void func_0201267c(int a, void* p);
-extern void _ZN12WithMeshClsn15ClearLimMovFlagEv(void* p);
 extern void func_ov077_02125e94(void* c, int a);
 extern void _ZN5Actor8PoofDustEv(void* c);
 extern void func_02012694(int a, void* p);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* c, void* p);
-extern void func_ov077_02124eb0(void* c);
 extern void _ZN12CylinderClsn5ClearEv(void* p);
 extern void _ZN12CylinderClsn6UpdateEv(void* p);
 }

--- a/src/func_ov077_021256b4.c
+++ b/src/func_ov077_021256b4.c
@@ -1,12 +1,16 @@
+// @symbol func_ov077_021256b4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef long long s64;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
-struct Vector3 { int x, y, z; };
+
 extern s16 data_02082214[];
 extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
-extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *self);
-#define LA(p) ((int)(((s64)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int)(((s64)(int)(p))))
 int func_ov077_021256b4(char *o)
 {
     char *d0;

--- a/src/func_ov077_021258dc.c
+++ b/src/func_ov077_021258dc.c
@@ -1,5 +1,9 @@
+// @symbol func_ov077_021258dc
+// @emits Lakitu_Kill
+/* recovered: renamed to Class_Method */
+/* daJgm_c::Kill - recovered from vtable slot identity */
 extern void _ZN12CylinderClsn5ClearEv(void *);
-int func_ov077_021258dc(char *c)
+int Lakitu_Kill(char *c)
 {
     *(int *)(c + 0x98) = 0;
     _ZN12CylinderClsn5ClearEv((char *)c + 0x1b0);

--- a/src/func_ov077_02125bb4.c
+++ b/src/func_ov077_02125bb4.c
@@ -1,16 +1,17 @@
+// @symbol func_ov077_02125bb4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Particle.h"
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 
-struct Vector3 {
-    int x, y, z;
-};
+
 
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *c, void *p);
-extern void func_ov077_021250a8(void *c);
-extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void *p);
 extern void func_020383fc(void *p);
-extern int func_ov077_02124ce4(void *c);
 extern void func_02012694(int id, void *pos);
-extern void _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(Fix12i x, Fix12i y, Fix12i z);
 extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int uniqueID, unsigned int effectID,
     Fix12i x, Fix12i y, Fix12i z,
@@ -18,7 +19,6 @@ extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(void *p);
 extern void _ZN5Actor8PoofDustEv(void *c);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *c);
-extern void _ZN12WithMeshClsn15ClearLimMovFlagEv(void *p);
 extern void func_ov077_02125e94(void *c, int a);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, Fix12i x, Fix12i y, Fix12i z);
 extern void func_0201267c(int id, void *pos);
@@ -75,7 +75,7 @@ int func_ov077_02125bb4(char *c)
             *(short *)(c + 0x8e) = *(short *)(c + 0x94);
             *(short *)(c + 0x90) = *(short *)(c + 0x96);
             _ZN12WithMeshClsn15ClearLimMovFlagEv(c + 0x1e4);
-            *(unsigned int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000000u;
+            *(unsigned int *)(((long long)(int)(c + 0xb0))) |= 0x10000000u;
             func_ov077_02125e94(c, 1);
         } else {
             x = *(int *)(c + 0x5c);

--- a/src/func_ov077_02126194.cpp
+++ b/src/func_ov077_02126194.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov077_02126194
+// @emits Spiny_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daTgz_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
-void func_ov077_02126194(void *self, void *p)
+void Spiny_OnTurnIntoEgg(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 1, 0);

--- a/src/func_ov077_02126640.cpp
+++ b/src/func_ov077_02126640.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov077_02126640
+// @emits Spiny_Kill
+/* recovered: renamed to Class_Method */
+/* daTgz_c::Kill - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; Vector3() {} };
 extern "C" {
 void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void *thiz, const Vector3 &v);
@@ -12,7 +16,7 @@ extern int data_ov077_02127a5c[3];
 extern int data_ov077_02127cf8;
 }
 
-extern "C" int func_ov077_02126640(char *c)
+extern "C" int Spiny_Kill(char *c)
 {
     Vector3 v;
     char *a;

--- a/src/func_ov077_0212679c.c
+++ b/src/func_ov077_0212679c.c
@@ -1,5 +1,8 @@
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov077_0212679c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int Vec3_Dist(void *a, void *b);
 extern int func_ov077_02126300(void *c);
 extern int func_ov077_02126d5c(void *c, void *p);
@@ -8,14 +11,12 @@ extern void *_ZN5Actor13ClosestPlayerEv(void *thiz);
 extern short Vec3_HorzAngle(void *a, void *b);
 extern void _Z14ApproachLinearRsss(short *r, short a, short b);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int d);
-extern int __aeabi_idiv(int a, int b);
-extern char data_ov077_02127d18[];
 extern char data_ov077_02127cf8[];
 
 int func_ov077_0212679c(char *c)
 {
-    struct Vec3 pv;
-    struct Vec3 *pp;
+    struct Vector3 pv;
+    struct Vector3 *pp;
     int dist;
     char *p;
     unsigned short spd;
@@ -36,7 +37,7 @@ int func_ov077_0212679c(char *c)
     p = (char *)_ZN5Actor13ClosestPlayerEv(c);
     if (p != 0) {
         /* u64 launder forces base materialization after the null cmp */
-        pp = (struct Vec3 *)(void *)(unsigned long long)(unsigned long)(p + 0x5c);
+        pp = (struct Vector3 *)(void *)(unsigned long long)(unsigned long)(p + 0x5c);
         pv.x = pp->x;
         pv.y = pp->y;
         pv.z = pp->z;

--- a/src/func_ov077_02126ad0.c
+++ b/src/func_ov077_02126ad0.c
@@ -1,5 +1,9 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov077_02126ad0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int Vec3_Dist(void* a, void* b);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int cc, void* v, unsigned int d);
 extern int func_ov077_02126300(char* c);
@@ -8,11 +12,8 @@ extern int _ZNK12WithMeshClsn8IsOnWallEv(void* p);
 extern short Vec3_HorzAngle(void* a, void* b);
 extern void _Z14ApproachLinearRsss(short* a, short b, short cc);
 extern void* _ZN5Actor13ClosestPlayerEv(char* c);
-extern int _ZN6Player12GetHurtStateEv(void* p);
 
-extern char data_ov077_02127d18[];
 extern char data_ov077_02127cf8[];
-extern char data_ov077_02127d08[];
 
 int func_ov077_02126ad0(char* c)
 {

--- a/src/func_ov078_02123aa0.c
+++ b/src/func_ov078_02123aa0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov078_02123aa0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_MontyMoleRock.h"
+/* recovered: shared common types */
+#include "common.h"
 extern short Vec3_HorzAngle(const void* a, const void* b);
-extern int _ZN13MontyMoleRockD0Ev(void* t);
 extern char* _ZN5Actor13ClosestPlayerEv(void* c);
 extern int Vec3_Dist(const void* a, const void* b);
 extern int func_ov078_02125c48(void* c, void* p);
@@ -8,14 +12,14 @@ extern void ApproachAngle(short* a, short b, short c, short d, int e);
 extern int data_ov078_0212703c[];
 extern int data_ov078_0212710c[];
 
-struct Vec3 { int x,y,z; };
+
 
 int func_ov078_02123aa0(char* c){
     short ang = Vec3_HorzAngle(c+0x5c, c+0x4e0);
     if(_ZN13MontyMoleRockD0Ev(c) == 1) return 1;
     char* p = _ZN5Actor13ClosestPlayerEv(c);
     if(p != 0){
-        struct Vec3 v = *(struct Vec3*)(p+0x5c);
+        struct Vector3 v = *(struct Vector3*)(p+0x5c);
         if(Vec3_Dist(c+0x4d4, &v) < 0x640000){
             if(*(int*)(c+0x4d8) - 0x64000 < v.y){
                 func_ov078_02125c48(c, data_ov078_0212703c);

--- a/src/func_ov078_021240a0.c
+++ b/src/func_ov078_021240a0.c
@@ -1,8 +1,11 @@
+// @symbol func_ov078_021240a0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void* c);
-extern void func_ov078_02125c24(char* c, int a);
 extern int _ZN5Actor18HorzAngleToCPlayerEv(char* c);
 extern void ApproachAngle(short* p, int target, int a, int b, int c);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* pl, char* c, int b);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int f);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* pl, char* c, int m, void* v, int a, int b);
@@ -17,15 +20,14 @@ extern void _ZN6Player12Unk_020c6a10Ej(void* p, unsigned int a);
 
 extern unsigned char data_0209f220;
 extern char data_ov078_0212705c;
-extern char data_ov078_0212702c;
 extern int data_0209e650;
 
-struct V3 { int x, y, z; };
+
 
 int func_ov078_021240a0(char* c)
 {
 #pragma opt_propagation off
-    struct V3 v;
+    struct Vector3 v;
     short msg;
     int lim;
 
@@ -100,7 +102,7 @@ int func_ov078_021240a0(char* c)
                 if (a != 0) {
                     int b = (int)(*(unsigned short*)(a + 0xc) == 0xbf);
                     if (b != 0) {
-                        v = *(struct V3*)(a + 0x5c);
+                        v = *(struct Vector3*)(a + 0x5c);
                         if (*(int*)(c + 0x60) > v.y)
                             _ZN6Player12Unk_020c6a10Ej(a, 1);
                     }

--- a/src/func_ov078_02124cf4.cpp
+++ b/src/func_ov078_02124cf4.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov078_02124cf4
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct ActorBase;
 
 extern "C" {
@@ -12,8 +17,6 @@ int Player_StartTalk(void* self, ActorBase& a, bool b);
 void Sound_ChangeMusicVolume(unsigned int a, int fix);
 int Player_ShowMessage(void* self, ActorBase& a, unsigned int b, const Vector3* v, unsigned int d, unsigned int e);
 
-extern int data_ov078_021270ac;
-extern int data_ov078_021270ec;
 extern int data_ov078_0212705c;
 extern unsigned char data_0209f220;
 }

--- a/src/func_ov078_02124f28.cpp
+++ b/src/func_ov078_02124f28.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov078_02124f28
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern int _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(void* self, void* bca, int a, int b, int fix, unsigned short t);
 extern int func_ov078_02125c48(void* c, void* p);
 extern int Vec3_Dist(const void* a, const void* b);
 extern void _ZN6Player9DropActorEv(void* self);
 extern int data_ov078_02126ee0[];
-extern int data_ov078_0212708c;
 
-struct Vec3 { int x, y, z; };
+
 
 int func_ov078_02124f28(unsigned char* c)
 {
@@ -27,7 +31,7 @@ int func_ov078_02124f28(unsigned char* c)
             return 1;
         }
         {
-            Vec3 copy = *(Vec3*)(obj + 0x5c);
+            Vector3 copy = *(Vector3*)(obj + 0x5c);
             if (Vec3_Dist(c + 0x4d4, &copy) > 0x640000)
                 goto drop;
             if (*(int*)(c + 0x4d8) - 0xa000 <= copy.y)
@@ -61,7 +65,7 @@ flags:
             *(short*)(c + 0x8e) = t;
         }
         {
-            int* p354 = (int*)(((long long)(int)(c + 0x354)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p354 = (int*)(((long long)(int)(c + 0x354)));
             *p354 = *p354 & ~2;
         }
         func_ov078_02125c48(c, &data_ov078_0212708c);

--- a/src/func_ov078_021250f8.c
+++ b/src/func_ov078_021250f8.c
@@ -1,16 +1,16 @@
-struct Vector3 { int x, y, z; };
-
-extern int func_ov078_02123804(char* c);
-extern void func_ov078_02123864(char* c);
+// @symbol func_ov078_021250f8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void func_ov102_0214b384(void* a, int b);
-extern int _ZNK9Animation12WillHitFrameEi(void* self, int frame);
 extern void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 extern void Matrix4x3_FromRotationY(void* m, int ang);
 extern int Vec3_HorzLen(void* v);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short ang);
-extern void func_ov102_0214ad14(void* c);
 extern void MulVec3Mat4x3(void* a, void* m, void* b);
 extern int _ZN9Animation8FinishedEv(void* self);
 extern void func_ov078_02125c48(void* c, void* p);

--- a/src/func_ov078_02125448.c
+++ b/src/func_ov078_02125448.c
@@ -1,32 +1,32 @@
+// @symbol func_ov078_02125448
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct Vec3 { int x, y, z; };
+
 
 extern void func_02012694(int a, void* p);
-extern int func_ov078_02123804(char* c);
-extern void func_ov078_02123864(char* c);
 extern char* _ZN5Actor13ClosestPlayerEv(void* c);
 extern int Vec3_Dist(const void* a, const void* b);
 extern int func_ov078_02125c48(void* c, void* p);
 extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void* c);
 extern void ApproachAngle(short* a, short b, short c, short d, int e);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern int AngleDiff(int a, int b);
 extern int _ZN6Player7TryGrabER5Actor(void* p, void* a);
 extern int func_ov002_020db5f4(char* c, char* arg);
 extern int _ZN5Actor13DistToCPlayerEv(void* c);
 
 extern int data_ov078_021270fc[];
 extern int data_ov078_0212707c[];
-extern int data_ov078_0212706c[];
 extern unsigned char data_0209f220[];
-extern int data_ov078_0212704c[];
 
 int func_ov078_02125448(char* c)
 {
     char* p;
     char* a;
-    struct Vec3 v;
+    struct Vector3 v;
     int isType;
     int index;
     int empty;
@@ -46,7 +46,7 @@ int func_ov078_02125448(char* c)
 
     p = _ZN5Actor13ClosestPlayerEv(c);
     if (p != 0) {
-        v = *(struct Vec3*)(p + 0x5c);
+        v = *(struct Vector3*)(p + 0x5c);
         if (Vec3_Dist(c + 0x4d4, &v) > 0x640000
             || (*(int*)(c + 0x4d8) - 0xa000) > v.y) {
             *(int*)(c + 0x98) = 0;
@@ -57,7 +57,7 @@ int func_ov078_02125448(char* c)
         ApproachAngle((short*)(c + 0x94), _ZN5Actor18HorzAngleToCPlayerEv(c), 0xa, 0x200, 0x100);
         {
             s16 ang = *(s16*)(c + 0x94);
-            int* pf = (int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* pf = (int*)(((long long)(int)(c + 0xb0)));
             *(s16*)(c + 0x8e) = ang;
             *pf = *pf & ~0x80;
         }
@@ -71,7 +71,7 @@ int func_ov078_02125448(char* c)
                     if (AngleDiff(_ZN5Actor18HorzAngleToCPlayerEv(c), *(short*)(c + 0x8e)) > 0x2800) {
                         if ((*(int*)(c + 0x39c) & 0x1000) != 0) {
                             {
-                                int* pf = (int*)(((long long)(unsigned)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+                                int* pf = (int*)(((long long)(unsigned)(c + 0xb0)));
                                 *pf = *pf | 0x80;
                             }
                             if (_ZN6Player7TryGrabER5Actor(a, c) != 0) {

--- a/src/func_ov078_02125790.cpp
+++ b/src/func_ov078_02125790.cpp
@@ -1,25 +1,28 @@
 //cpp
-struct Mtx43 { int m[12]; };
-struct Vec3 { int x, y, z; };
-extern int func_ov078_02123804(char* c);
+// @symbol func_ov078_02125790
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern int _ZN5Actor18HorzAngleToCPlayerEv(void* a);
 extern void ApproachAngle(short* p, int target, int step, int band, int max);
-extern int _ZNK9Animation12WillHitFrameEi(void* a, int f);
-extern void func_ov078_02125c24(char* c, int v);
 extern void func_02012694(int a, void* b);
-extern void MulMat4x3Mat4x3(void* d, Mtx43* a, Mtx43* b);
-extern void Vec3_Lsl(Vec3* d, Vec3* s, int sh);
-extern int _ZN5Actor17HugeLandingDustAtER7Vector3b(void* a, Vec3* v, int b);
+extern void MulMat4x3Mat4x3(void* d, Matrix4x3* a, Matrix4x3* b);
+extern void Vec3_Lsl(Vector3* d, Vector3* s, int sh);
+extern int _ZN5Actor17HugeLandingDustAtER7Vector3b(void* a, Vector3* v, int b);
 extern int _ZN9Animation8FinishedEv(void* a);
 extern void func_ov078_02125c48(char* c, void* p);
-extern Mtx43 data_020a0e68;
+extern Matrix4x3 data_020a0e68;
 extern int data_ov078_0212703c;
 
 extern "C" int func_ov078_02125790(char* self)
 {
-  Vec3 s;
-  Vec3 d;
-  Vec3 v;
+  Vector3 s;
+  Vector3 d;
+  Vector3 v;
   if (func_ov078_02123804(self) == 1) return 1;
   ApproachAngle((short*)(self + 0x94), _ZN5Actor18HorzAngleToCPlayerEv(self), 1, 0x500, 0x500);
   *(short*)(self + 0x8e) = *(short*)(self + 0x94);
@@ -29,7 +32,7 @@ extern "C" int func_ov078_02125790(char* self)
     s.x = 0;
     s.y = 0;
     s.z = 0;
-    data_020a0e68 = *(Mtx43*)(self + 0x2e8);
+    data_020a0e68 = *(Matrix4x3*)(self + 0x2e8);
     MulMat4x3Mat4x3((char*)*(void**)(self + 0x2e0) + 0x120, &data_020a0e68, &data_020a0e68);
     s.x = data_020a0e68.m[9];
     s.y = data_020a0e68.m[10];

--- a/src/func_ov078_02125950.cpp
+++ b/src/func_ov078_02125950.cpp
@@ -1,14 +1,16 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov078_02125950
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Player { int GetTalkState(); };
 
 extern "C" short Vec3_HorzAngle(const Vector3 *a, const Vector3 *b);
 void ApproachLinear(short &v, short t, short step);
 extern "C" void _ZN7Message7EndTalkEv();
-extern "C" void func_02011d44();
-extern "C" void _ZN5Sound22LoadAndSetMusic_Layer3Ej(unsigned int x);
 extern "C" void func_ov078_02125c48(char *c, void *p);
-extern void *data_ov078_0212701c;
 
 extern "C" int func_ov078_02125950(char *c)
 {

--- a/src/func_ov078_021259ec.c
+++ b/src/func_ov078_021259ec.c
@@ -1,21 +1,20 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov078_021259ec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct ActorBase;
 
-extern void _ZN5Sound22StopLoadedMusic_Layer3Ev(void);
-extern void func_02011cfc(void);
 extern void ApproachLinear(short* a, short b, short c);
-extern int func_ov078_02123804(char* c);
 extern void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern int Vec3_Dist(struct Vector3* a, struct Vector3* b);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* player, void* actor, int b);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* player, void* actor, unsigned int msgid, struct Vector3* v, unsigned int arg4, unsigned int arg5);
 extern void func_02012694(int a, void* b);
 extern int func_ov078_02125c48(char* c, void* p);
 
 extern unsigned char data_0209f220;
-extern void* data_ov078_0212700c;
-extern void* data_ov078_0212701c;
 
 int func_ov078_021259ec(char* c)
 {
@@ -26,7 +25,7 @@ int func_ov078_021259ec(char* c)
     unsigned int b;
 
     if (*(unsigned char*)(c + 0x506) == 1) {
-        unsigned char *p = (unsigned char*)(((long long)(int)(c + 0x50a)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char*)(((long long)(int)(c + 0x50a)));
         *p += 1;
         if (*(unsigned char*)(c + 0x50a) > 0xc8) {
             *(int*)(c + 0xb0) = 0x10000003;

--- a/src/func_ov078_02125c98.cpp
+++ b/src/func_ov078_02125c98.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov078_02125c98
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov078_02125c98 at 0x02125c98 (ov078), size 0x148
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
@@ -14,12 +17,12 @@ struct RaycastGround {
   void SetObjAndPos(const Vector3& pos, Actor* a);
   int DetectClsn();
 };
-struct Mtx { int w[12]; };
+
 extern "C" {
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* self);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, int fix, int t, unsigned int j);
 }
-extern Mtx data_02082128;
+extern Matrix4x3 data_02082128;
 
 extern "C" void func_ov078_02125c98(char* c) {
   int h = *(int*)(c+0x60);
@@ -41,7 +44,7 @@ extern "C" void func_ov078_02125c98(char* c) {
   int r8 = 0x15e000 - (int)(((long long)ip * 0x180 + 0x800) >> 12);
   if (r8 < 0xa000)
     r8 = 0xa000;
-  *(Mtx*)(c+0x434) = data_02082128;
+  *(Matrix4x3*)(c+0x434) = data_02082128;
   *(int*)(c+0x458) = *(int*)(c+0x5c) >> 3;
   *(int*)(c+0x45c) = *(int*)(c+0x60) >> 3;
   *(int*)(c+0x460) = *(int*)(c+0x64) >> 3;

--- a/src/func_ov078_02125de0.c
+++ b/src/func_ov078_02125de0.c
@@ -1,9 +1,9 @@
-struct Vec3 { int x, y, z; };
-struct Matrix4x3 { int m[12]; };
-
+// @symbol func_ov078_02125de0
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void MulMat4x3Mat4x3(void *dst, void *a, void *b);
-extern void Vec3_Lsl(struct Vec3 *d, struct Vec3 *s, int sh);
+extern void Vec3_Lsl(struct Vector3 *d, struct Vector3 *s, int sh);
 extern unsigned int _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void Matrix4x3_ApplyInPlaceToTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, int x, int y, int z);
@@ -11,7 +11,7 @@ extern struct Matrix4x3 data_020a0e68;
 
 void func_ov078_02125de0(char *c)
 {
-    struct Vec3 lv;
+    struct Vector3 lv;
     int i;
 
     Matrix4x3_FromRotationY(c + 0x2e8, *(short*)(c + 0x8e));
@@ -27,7 +27,7 @@ void func_ov078_02125de0(char *c)
     *(int*)(c + 0x4ec) = *(int*)(c + 0x4c8);
     *(int*)(c + 0x4f0) = *(int*)(c + 0x4cc);
     *(int*)(c + 0x4f4) = *(int*)(c + 0x4d0);
-    Vec3_Lsl(&lv, (struct Vec3*)(c + 0x4ec), 3);
+    Vec3_Lsl(&lv, (struct Vector3*)(c + 0x4ec), 3);
     *(int*)(c + 0x4ec) = lv.x;
     *(int*)(c + 0x4f0) = lv.y;
     *(int*)(c + 0x4f4) = lv.z;

--- a/src/func_ov078_02125f8c.cpp
+++ b/src/func_ov078_02125f8c.cpp
@@ -1,15 +1,19 @@
 //cpp
-struct M48 { int w[12]; };
-struct Vector3 { int x,y,z; };
+// @symbol func_ov078_02125f8c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" {
-extern struct M48* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void* self, void* player, struct Vector3* pos);
-extern struct Vector3 data_ov078_0212711c[];
+extern struct Matrix4x3* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void* self, void* player, struct Vector3* pos);
 void func_ov078_02125f8c(char* c){
     void* player = *(void**)(c+0x494);
     int idx = 0;
     if(player == 0) return;
     if(*(int*)((char*)player+8) == 2) idx = 1;
-    struct M48* res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(c, player, &data_ov078_0212711c[idx]);
-    *(struct M48*)(c+0x2e8) = *res;
+    struct Matrix4x3* res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(c, player, &data_ov078_0212711c[idx]);
+    *(struct Matrix4x3*)(c+0x2e8) = *res;
 }
 }

--- a/src/func_ov078_021265f4.c
+++ b/src/func_ov078_021265f4.c
@@ -1,4 +1,8 @@
-int func_ov078_021265f4(void)
+// @symbol func_ov078_021265f4
+// @emits KingBobOmb_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBombking_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int KingBobOmb_OnAimedAtWithEgg(void)
 {
     return 1024000;
 }

--- a/src/func_ov079_02123804.c
+++ b/src/func_ov079_02123804.c
@@ -1,16 +1,20 @@
+// @symbol func_ov079_02123804
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern s16 data_02082214[];
 extern int* data_ov079_021275ec[];
 
 extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
-extern int AngleDiff(int a, int b);
 extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char* self, const struct Vector3* pos, u32 n, int fix, s16 s);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* self, void* bca, int n, int fix, u32 flags);
 

--- a/src/func_ov079_02123a8c.cpp
+++ b/src/func_ov079_02123a8c.cpp
@@ -1,5 +1,10 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov079_02123a8c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct Actor {
     virtual void vf00();  virtual void vf01();  virtual void vf02();  virtual void vf03();
@@ -14,12 +19,11 @@ struct Actor {
 };
 
 extern "C" int Vec3_Dist(void* a, void* b);
-extern "C" int _ZN16MeshColliderBase9IsEnabledEv(void* m);
 extern "C" void _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* actor);
 
 extern "C" int func_ov079_02123a8c(Actor *self)
 {
-    Vec3 v;
+    Vector3 v;
 
     if (*(unsigned char*)((char*)self + 0x404) == 0)
         return 0;

--- a/src/func_ov079_02123b54.c
+++ b/src/func_ov079_02123b54.c
@@ -1,8 +1,12 @@
-/* func_ov079_02123b54 @ 0x2123b54 (ov079) -- tail-call veneer to func_ov079_02123d4c (0x2123d4c).
+// @symbol func_ov079_02123b54
+// @emits Whomp_OnAimedAtWithEggReturnVec
+/* recovered: renamed to Class_Method */
+/* daBtn_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
+/* Whomp_OnAimedAtWithEggReturnVec @ 0x2123b54 (ov079) -- tail-call veneer to func_ov079_02123d4c (0x2123d4c).
  * ldr ip, [pc]; bx ip; .word 0x2123d4c
  */
 extern void func_ov079_02123d4c(void);
 
-void func_ov079_02123b54(void) {
+void Whomp_OnAimedAtWithEggReturnVec(void) {
     func_ov079_02123d4c();
 }

--- a/src/func_ov079_02123b60.c
+++ b/src/func_ov079_02123b60.c
@@ -1,5 +1,9 @@
+// @symbol func_ov079_02123b60
+// @emits Whomp_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBtn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern short data_02082214[];
-int func_ov079_02123b60(char* c){
+int Whomp_OnAimedAtWithEgg(char* c){
     int idx;
     if(*(unsigned char*)(c+0x414)!=0){
         idx = ((int)*(unsigned short*)(c+0x8c) >> 4);

--- a/src/func_ov079_02123bcc.c
+++ b/src/func_ov079_02123bcc.c
@@ -1,5 +1,8 @@
+// @symbol func_ov079_02123bcc
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16; typedef unsigned short u16; typedef long long s64;
-struct Vector3 { int x, y, z; };
+
 extern int Vec3_HorzDist(const struct Vector3 *a, const struct Vector3 *b);
 extern s16 data_02082214[];
 

--- a/src/func_ov079_02123e60.cpp
+++ b/src/func_ov079_02123e60.cpp
@@ -1,16 +1,19 @@
 //cpp
+// @symbol func_ov079_02123e60
+// @emits Whomp_OnHitByMegaChar
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daBtn_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
-struct Vector3 { int x, y, z; };
 extern void _ZN6Player16IncMegaKillCountEv(void* thiz);
 extern void func_02012694(int a, void* v);
 extern void func_ov079_02123d4c(void* out, void* c);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* thiz, const Vector3& v);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* thiz);
-extern int _ZN16MeshColliderBase9IsEnabledEv(void* thiz);
-extern void _ZN16MeshColliderBase7DisableEv(void* thiz);
 
-void func_ov079_02123e60(char* c, void* player)
+void Whomp_OnHitByMegaChar(char* c, void* player)
 {
     if (*(unsigned char*)(c + 0x414) != 0) return;
     if (*(int*)(c + 0x10c) == 8) return;

--- a/src/func_ov079_021243e0.c
+++ b/src/func_ov079_021243e0.c
@@ -1,14 +1,17 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void* m);
-extern void _ZN16MeshColliderBase7DisableEv(void* m);
+// @symbol func_ov079_021243e0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void* m, void* actor);
 extern void* _ZN5Actor13ClosestPlayerEv(void* c);
 extern int Vec3_Dist(void* a, void* b);
 
-struct Vec3 { int x, y, z; };
+
 
 int func_ov079_021243e0(char* c, int r4)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     char* player;
     int dist;
     int y;

--- a/src/func_ov079_02125240.cpp
+++ b/src/func_ov079_02125240.cpp
@@ -1,23 +1,25 @@
 //cpp
-struct V3 { int x, y, z; };
+// @symbol func_ov079_02125240
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 struct Anim { int _pad; void *f; };
 extern struct Anim *data_ov079_021275ec[];
-extern void func_ov079_0212522c(void);
 
 extern "C" int _ZNK12WithMeshClsn10IsOnGroundEv(void *thiz);
-extern "C" void func_01ffb098(void *p);
-extern "C" void func_01ffb0bc(void *p);
 extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *thiz, void *file, int a, int b, unsigned int e);
-extern "C" void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *thiz, struct V3 *v, int f);
+extern "C" void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *thiz, struct Vector3 *v, int f);
 extern "C" void func_020393c4(int *p, int v);
-extern "C" void func_ov079_02123d4c(struct V3 *out, void *c);
-extern "C" void func_0200fa04(void *c, struct V3 *v, int b);
-extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(void *thiz, struct V3 *v, int b);
+extern "C" void func_ov079_02123d4c(struct Vector3 *out, void *c);
+extern "C" void func_0200fa04(void *c, struct Vector3 *v, int b);
+extern "C" void _ZN5Actor13LandingDustAtER7Vector3b(void *thiz, struct Vector3 *v, int b);
 
 extern "C" void func_ov079_02125240(char *c){
-  struct V3 v;
-  struct V3 a;
-  struct V3 b;
+  struct Vector3 v;
+  struct Vector3 a;
+  struct Vector3 b;
   if(*(unsigned char*)(c+0x40c)) return;
   if(!_ZNK12WithMeshClsn10IsOnGroundEv(c+0x110)) return;
   *(int*)(c+0xa8) = 0;

--- a/src/func_ov079_021266fc.c
+++ b/src/func_ov079_021266fc.c
@@ -1,4 +1,8 @@
-int func_ov079_021266fc(void)
+// @symbol func_ov079_021266fc
+// @emits BulletBill_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daKlr_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int BulletBill_OnAimedAtWithEgg(void)
 {
     return 0;
 }

--- a/src/func_ov079_02126704.c
+++ b/src/func_ov079_02126704.c
@@ -1,15 +1,19 @@
+// @symbol func_ov079_02126704
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
-extern void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, Fix12 a, Fix12 b, unsigned int g);
 
-struct M48 { int w[12]; };
+
 
 void func_ov079_02126704(char* c) {
   Matrix4x3_FromRotationXYZExt(c+0x328, *(s16*)(c+0x8c), *(s16*)(c+0x8e), *(s16*)(c+0x90));
   *(int*)(c+0x34c) = *(int*)(c+0x5c) >> 3;
   *(int*)(c+0x350) = *(int*)(c+0x60) >> 3;
   *(int*)(c+0x354) = *(int*)(c+0x64) >> 3;
-  *(struct M48*)(c+0x378) = *(struct M48*)(c+0x328);
+  *(struct Matrix4x3*)(c+0x378) = *(struct Matrix4x3*)(c+0x328);
   _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c+0x3ac, c+0x328, 0x50000, 0x50000, 0xf);
 }

--- a/src/func_ov079_02126dbc.c
+++ b/src/func_ov079_02126dbc.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov079_02126dbc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV18daObjBkKillerdai_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov079_02126dbc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV18daObjBkKillerdai_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov079_02126e00.c
+++ b/src/func_ov079_02126e00.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov079_02126e00
+// @emits daObjBkKillerdai_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjBkKillerdai_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov079_02126e00(int *t)
+int *daObjBkKillerdai_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov079_02126ecc.cpp
+++ b/src/func_ov079_02126ecc.cpp
@@ -1,10 +1,18 @@
 //cpp
+// @symbol func_ov079_02126ecc
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_Platform.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjBkKillerdai_c.h"
+// @emits daObjBkKillerdai_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjBkKillerdai_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
-extern void _ZN8Platform14KillByMegaCharER6Player(void*, void*);
-void func_ov079_02126ecc(char *c, void *p){
+void daObjBkKillerdai_c_OnHitByMegaChar(char *c, void *p){
+    struct daObjBkKillerdai_c *self = (struct daObjBkKillerdai_c *)(void *)c;
   _ZN6Player16IncMegaKillCountEv(p);
   _ZN8Platform14KillByMegaCharER6Player(c, p);
-  *(short*)(c+0x8e) = *(short*)(c+0x94);
+  self->unk_08e = self->unk_094;
 }
 }

--- a/src/func_ov079_02126f04.c
+++ b/src/func_ov079_02126f04.c
@@ -1,10 +1,14 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov079_02126f04
+// @emits daObjBkKillerdai_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjBkKillerdai_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void* data_ov079_02127f64[];
 extern void* data_ov079_02128300;
 extern void* data_ov079_021282f0;
-int func_ov079_02126f04(char *t){
+int daObjBkKillerdai_c_CleanupResources(char *t){
   if(_ZN16MeshColliderBase9IsEnabledEv(t+0x124))
     _ZN16MeshColliderBase7DisableEv(t+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov079_02127f64[0]);

--- a/src/func_ov079_02126f64.cpp
+++ b/src/func_ov079_02126f64.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov079_02126f64
+// @emits daObjBkKillerdai_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjBkKillerdai_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov079_02126f64(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjBkKillerdai_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov079_02127090.cpp
+++ b/src/func_ov079_02127090.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov079_02127090
+// @emits daObjBkKillerdai_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjBkKillerdai_c::InitResources - recovered from vtable slot identity */
 struct SharedFilePtr { int x; };
 extern "C" {
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(struct SharedFilePtr &f);
@@ -15,10 +19,10 @@ extern int data_ov079_02127f64[];
 extern signed char data_0209f2f8;
 extern int data_0209caa0[];
 extern unsigned char data_0209f220;
-int func_ov079_02127090(void *self);
+int daObjBkKillerdai_c_InitResources(void *self);
 }
 
-int func_ov079_02127090(void *self)
+int daObjBkKillerdai_c_InitResources(void *self)
 {
     char *c = (char*)self;
     void *m;

--- a/src/func_ov079_02127280.cpp
+++ b/src/func_ov079_02127280.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov079_02127280
+// @emits FortressWall_Kill
+/* recovered: renamed to Class_Method */
+/* daObjBk_Kabe_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned, void*);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
-void func_ov079_02127280(char* c){
+void FortressWall_Kill(char* c){
   _ZN5Sound9PlayBank3EjRK7Vector3(0xf, c+0x74);
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x121, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   int b = (int)(*(unsigned short*)(c+0xc) == 0x30);

--- a/src/func_ov079_021272e0.cpp
+++ b/src/func_ov079_021272e0.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov079_021272e0
+// @emits FortressWall_OnHitByCannonBlastedChar
+/* recovered: renamed to Class_Method */
+/* daObjBk_Kabe_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
 struct Base {
     virtual void v0();
     virtual void v1();
@@ -33,4 +37,4 @@ struct Base {
     virtual void v30();
     virtual void v31();
 };
-extern "C" void func_ov079_021272e0(Base *c) { c->v31(); }
+extern "C" void FortressWall_OnHitByCannonBlastedChar(Base *c) { c->v31(); }

--- a/src/func_ov080_02123858.c
+++ b/src/func_ov080_02123858.c
@@ -1,4 +1,8 @@
-int func_ov080_02123858(void)
+// @symbol func_ov080_02123858
+// @emits MontyMole_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daChoropu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int MontyMole_OnAimedAtWithEgg(void)
 {
     return 163840;
 }

--- a/src/func_ov080_02123924.cpp
+++ b/src/func_ov080_02123924.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov080_02123924
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { Fix12i x, y, z; };
+
 struct BCA_File;
 struct AnimData { int f[2]; };
 extern "C" {

--- a/src/func_ov080_02123a34.cpp
+++ b/src/func_ov080_02123a34.cpp
@@ -1,10 +1,14 @@
 //cpp
-struct V16 { short x, y, z; };
-struct V3 { int x, y, z; };
+// @symbol func_ov080_02123a34
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" {
 extern void _ZN9Animation7AdvanceEv(void*);
-extern int _ZNK9Animation12WillHitFrameEi(void*, int);
-extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, V3*, V16*, int, int);
+extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, Vector3*, Vector3_16*, int, int);
 extern int _ZN5Actor13DistToCPlayerEv(void*);
 extern void func_0201267c(unsigned int, void*);
 extern int _ZN9Animation8FinishedEv(void*);
@@ -18,15 +22,15 @@ extern "C" void func_ov080_02123a34(char* c)
 {
     _ZN9Animation7AdvanceEv(c + 0x124);
     if (_ZNK9Animation12WillHitFrameEi(c + 0x124, 0xa)) {
-        V16 v16;
-        V3 pos;
+        Vector3_16 v16;
+        Vector3 pos;
         unsigned short ax, ay;
         void* a;
         int d;
         short s;
         int idx;
         int px, py, pz;
-        V16* pAng = &v16;
+        Vector3_16* pAng = &v16;
 
         ax = *(unsigned short*)(c + 0x8c);
         ay = *(unsigned short*)(c + 0x8e);

--- a/src/func_ov080_02123c24.c
+++ b/src/func_ov080_02123c24.c
@@ -1,3 +1,8 @@
+// @symbol func_ov080_02123c24
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN9Animation7AdvanceEv(void *anim);
 extern int _ZN9Animation8FinishedEv(void *anim);
 extern unsigned int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
@@ -6,12 +11,10 @@ extern int RandomIntInternal(int *seed);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int a, int b, unsigned int u);
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 
-struct Vector3 { int x, y, z; };
+
 
 extern short Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
-extern int AngleDiff(int a, int b);
 
-extern int data_ov080_021276c4[];
 extern int data_0209e650[];
 
 struct G { int w[2]; };

--- a/src/func_ov080_02124088.cpp
+++ b/src/func_ov080_02124088.cpp
@@ -1,21 +1,24 @@
 //cpp
+// @symbol func_ov080_02124088
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-struct Vector3 { int x, y, z; };
 
-#define LAUND(p) ((void*)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+
+#define LAUND(p) ((void*)((((long long)(int)(p)))))
 
 extern "C" {
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* file, int a, int b, unsigned int e);
 extern void func_0201267c(unsigned int id, const Vector3* v);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& v);
-extern void func_ov080_02124360(void* c);
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int a, const Vector3& pos, const void* vec16, int b, int c2);
 
-extern int data_ov080_021283d8[];
 }
 
 extern "C" void func_ov080_02124088(char* c)

--- a/src/func_ov080_02124208.c
+++ b/src/func_ov080_02124208.c
@@ -1,12 +1,16 @@
+// @symbol func_ov080_02124208
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(void* self, void* clsn, void* player);
-extern void _ZN6Player6BounceE5Fix12IiE(void* player, int v);
 extern void _ZN6Player16IncMegaKillCountEv(void* player);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* player, void* pos, unsigned int a, int b, unsigned int d, unsigned int e, unsigned int f);
-extern void func_ov080_02124088(void* self);
 extern void func_02012694(int a, void* p);
 
-struct Vec3 { int x, y, z; };
+
 
 void func_ov080_02124208(char* c)
 {
@@ -50,7 +54,7 @@ void func_ov080_02124208(char* c)
     }
 
     {
-        struct Vec3 pos;
+        struct Vector3 pos;
         pos.x = *(int*)(c + 0x5c);
         pos.y = *(int*)(c + 0x60);
         pos.z = *(int*)(c + 0x64);

--- a/src/func_ov080_02124ac4.c
+++ b/src/func_ov080_02124ac4.c
@@ -1,4 +1,8 @@
-int func_ov080_02124ac4(void)
+// @symbol func_ov080_02124ac4
+// @emits CrazedCrate_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daBttBk_c::OnYoshiTryEat - recovered from vtable slot identity */
+int CrazedCrate_OnYoshiTryEat(void)
 {
     return 1;
 }

--- a/src/func_ov080_02124acc.cpp
+++ b/src/func_ov080_02124acc.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov080_02124acc
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 void* func_02010304(void* a, void* b);
 void func_ov080_0212513c(void* c, int n);

--- a/src/func_ov080_02124c3c.cpp
+++ b/src/func_ov080_02124c3c.cpp
@@ -1,7 +1,10 @@
 //cpp
+// @symbol func_ov080_02124c3c
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef long long s64;
-struct Vector3 { int x, y, z; };
+
 struct Mtx43 { int a[12]; };
 extern "C" {
 void Matrix4x3_ApplyInPlaceToTranslation(Mtx43* m, int x, int y, int z);

--- a/src/func_ov080_02124eb0.c
+++ b/src/func_ov080_02124eb0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov080_02124eb0
+// @emits MontyMole_Kill
+/* recovered: renamed to Class_Method */
+/* daChoropu_c::Kill - recovered from vtable slot identity */
 extern void _ZN12CylinderClsn5ClearEv(void *);
-int func_ov080_02124eb0(char *c)
+int MontyMole_Kill(char *c)
 {
     *(int *)(c + 0x98) = 0;
     _ZN12CylinderClsn5ClearEv((char *)c + 0x14c);

--- a/src/func_ov080_02124edc.cpp
+++ b/src/func_ov080_02124edc.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov080_02124edc
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" {
 void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);

--- a/src/func_ov080_02125318.cpp
+++ b/src/func_ov080_02125318.cpp
@@ -1,5 +1,9 @@
 //cpp
-// func_ov080_02125318 at 0x02125318
+// @symbol func_ov080_02125318
+// @emits CrazedCrate_OnTurnIntoEgg
+/* recovered: shared common types, renamed to Class_Method */
+/* daBttBk_c::OnTurnIntoEgg - recovered from vtable slot identity */
+// CrazedCrate_OnTurnIntoEgg at 0x02125318
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov080).
 struct Vector3 { int x, y, z; };
 
@@ -12,8 +16,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 void _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" void func_ov080_02125318(char* self, void* player);
-void func_ov080_02125318(char* self, void* player) {
+extern "C" void CrazedCrate_OnTurnIntoEgg(char* self, void* player);
+void CrazedCrate_OnTurnIntoEgg(char* self, void* player) {
     if (_ZN6Player15IsCollectingCapEv(player)) {
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, player, 5, 0);
     }

--- a/src/func_ov080_02125428.c
+++ b/src/func_ov080_02125428.c
@@ -1,8 +1,11 @@
-extern int VT[];
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern void *HEAP;
-int *func_ov080_02125428(int *t)
+// @symbol func_ov080_02125428
+// @emits daPicGate_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::OnYoshiTryEat - recovered from vtable slot identity */
+int *daPicGate_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov080_02125d64.c
+++ b/src/func_ov080_02125d64.c
@@ -1,5 +1,8 @@
+// @symbol func_ov080_02125d64
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 extern Fix12i Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 
 struct Elem { struct Vector3 pos; int dist; int pad[2]; };  /* 0x18 */

--- a/src/func_ov080_02126124.c
+++ b/src/func_ov080_02126124.c
@@ -1,6 +1,10 @@
+// @symbol func_ov080_02126124
+// @emits CrazedCrate_Kill
+/* recovered: renamed to Class_Method */
+/* daBttBk_c::Kill - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned int u32;
-void func_ov080_02126124(u32* c){
+void CrazedCrate_Kill(u32* c){
   *(int*)((char*)c+0x140)=0;
   *(int*)((char*)c+0x144)=0;
   *(int*)((char*)c+0x148)=0;

--- a/src/func_ov080_02126bfc.c
+++ b/src/func_ov080_02126bfc.c
@@ -1,6 +1,10 @@
+// @symbol func_ov080_02126bfc
+// @emits daPicGate_c_CleanupResources
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::CleanupResources - recovered from vtable slot identity */
 extern int func_0203cbc0(void *a);
 
-int func_ov080_02126bfc(void *c)
+int daPicGate_c_CleanupResources(void *c)
 {
     func_0203cbc0(*(void **)((char *)c + 0x1a0));
     return 1;

--- a/src/func_ov080_02126c1c.c
+++ b/src/func_ov080_02126c1c.c
@@ -1,3 +1,7 @@
-void func_ov080_02126c1c(void)
+// @symbol func_ov080_02126c1c
+// @emits daPicGate_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::OnPendingDestroy - recovered from vtable slot identity */
+void daPicGate_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov080_02126c20.cpp
+++ b/src/func_ov080_02126c20.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov080_02126c20
+// @emits daPicGate_c_Render
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::Render - recovered from vtable slot identity */
 struct C;
 typedef int (C::*PMF)();
 struct Entry { char pad[0x10]; PMF pmf; };
 struct C { char pad[0x1a4]; Entry *ep; };
-extern "C" int func_ov080_02126c20(C *c) {
+extern "C" int daPicGate_c_Render(C *c) {
   (c->*c->ep->pmf)();
   return 1;
 }

--- a/src/func_ov080_02126c60.cpp
+++ b/src/func_ov080_02126c60.cpp
@@ -1,9 +1,13 @@
 //cpp
+// @symbol func_ov080_02126c60
+// @emits daPicGate_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef int (C::*PMF)();
 struct Entry { char pad[0x8]; PMF pmf; };
 struct C { char pad[0x1a4]; Entry *ep; };
-extern "C" int func_ov080_02126c60(C *c) {
+extern "C" int daPicGate_c_Behavior(C *c) {
   (c->*c->ep->pmf)();
   return 1;
 }

--- a/src/func_ov080_02126ca0.cpp
+++ b/src/func_ov080_02126ca0.cpp
@@ -1,4 +1,12 @@
 //cpp
+// @symbol func_ov080_02126ca0
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daPicGate_c.h"
+// @emits daPicGate_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daPicGate_c::InitResources - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -9,24 +17,20 @@ struct Disp {
     int pad[4];
 };
 
-extern "C" void* _ZN6Memory13operator_new2Ej(unsigned int n);
-extern "C" int func_ov080_02125630(void* c, int a);
 extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b, int c, int d);
-extern "C" void func_ov080_0212555c(void* c);
 
-extern u8 data_ov080_02127714[];
-extern void* data_ov080_02127834;
 extern Disp data_ov080_02128628[];
 extern int data_0209caa0[];
 
-extern "C" int func_ov080_02126ca0(char* c)
+extern "C" int daPicGate_c_InitResources(char* c)
 {
+    struct daPicGate_c *self = (struct daPicGate_c *)(void *)c;
     unsigned int m = (unsigned char)((*(unsigned int*)(c + 8) >> 0xd) & 3);
 
     if (m >= 2) {
-        *(u8*)(c + 0x1bb) = 2;
-        *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
-        *(u16*)(c + 0x1b8) = (u16)(*(u8*)(c + 0x1ba) * *(u8*)(c + 0x1bb));
+        self->unk_1bb = 2;
+        self->unk_1ba = self->unk_1bb;
+        self->unk_1b8 = (u16)(self->unk_1ba * self->unk_1bb);
     } else {
         unsigned int idx = (unsigned char)(*(unsigned int*)(c + 8) & 0xf) + 1;
         switch (idx) {
@@ -35,28 +39,28 @@ extern "C" int func_ov080_02126ca0(char* c)
         case 2:
             break;
         case 3:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[0];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[0];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 4:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[1];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[1];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 5:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[2];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[2];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 6:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[3];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[3];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 7:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[4];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[4];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 8:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[5];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[5];
+            self->unk_1ba = self->unk_1bb;
             break;
         case 9:
         case 10:
@@ -67,15 +71,15 @@ extern "C" int func_ov080_02126ca0(char* c)
         case 15:
             break;
         case 16:
-            *(u8*)(c + 0x1bb) = data_ov080_02127714[6];
-            *(u8*)(c + 0x1ba) = *(u8*)(c + 0x1bb);
+            self->unk_1bb = data_ov080_02127714[6];
+            self->unk_1ba = self->unk_1bb;
             break;
         }
-        *(u16*)(c + 0x1b8) = (u16)(*(u8*)(c + 0x1ba) * *(u8*)(c + 0x1bb));
+        self->unk_1b8 = (u16)(self->unk_1ba * self->unk_1bb);
     }
 
-    *(void**)(c + 0x1a0) = _ZN6Memory13operator_new2Ej((unsigned)(*(u16*)(c + 0x1b8)) * 0x18u);
-    *(int*)(c + 0x1a8) = func_ov080_02125630(c, (int)((unsigned char)((*(unsigned int*)(c + 8) >> 8) & 0x1f)));
+    *(void**)(c + 0x1a0) = _ZN6Memory13operator_new2Ej((unsigned)(self->unk_1b8) * 0x18u);
+    self->unk_1a8 = func_ov080_02125630(c, (int)((unsigned char)((*(unsigned int*)(c + 8) >> 8) & 0x1f)));
     *(void**)(c + 0x1ac) = &data_ov080_02127834;
     {
         unsigned int mi = (unsigned char)((*(unsigned int*)(c + 8) >> 0xd) & 3);
@@ -108,7 +112,7 @@ extern "C" int func_ov080_02126ca0(char* c)
         unsigned int f = *(unsigned int*)(c + 8);
         if ((unsigned char)((f >> 8) & 0x1f) == 7) {
             if ((unsigned char)((f >> 0xd) & 3) == 1) {
-                *(int*)(c + 0x1b0) = *(int*)(c + 0x5c);
+                self->unk_1b0 = self->unk_05c;
                 if (data_0209caa0[2] & 0x40000) {
                     int* p = (int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFF);
                     *p = *p + 0x802000;

--- a/src/func_ov080_02126fbc.c
+++ b/src/func_ov080_02126fbc.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov080_02126fbc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov080_02126fbc(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov080_02127014.c
+++ b/src/func_ov080_02127014.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov080_02127014
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov080_02127014(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov080_021274ac.c
+++ b/src/func_ov080_021274ac.c
@@ -1,4 +1,6 @@
-struct V3 { int x, y, z; };
+// @symbol func_ov080_021274ac
+/* recovered: shared common types */
+#include "common.h"
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* o, int bmd, int a, int b);
 extern void func_ov080_02127094(char* t);
@@ -7,14 +9,14 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* o, int kcl, void* mtx, int fix, short s, void* clps);
 extern void func_020393d4(int* p, int v);
 extern void func_020393c4(int* p, int v);
-extern void Vec3_Sub(struct V3* out, struct V3* a, struct V3* b);
-extern int LenVec3(struct V3* v);
-extern short Vec3_HorzAngle(struct V3* a, struct V3* b);
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern int LenVec3(struct Vector3* v);
+extern short Vec3_HorzAngle(struct Vector3* a, struct Vector3* b);
 extern int AngleDiff(int a, int b);
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 extern int func_ov080_02127658;
 int func_ov080_021274ac(char* self, char** arg) {
-    struct V3 d;
+    struct Vector3 d;
     _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, _ZN5Model8LoadFileER13SharedFilePtr(arg[0]), 1, -1);
     func_ov080_02127094(self);
     _ZN8Platform19UpdateClsnPosAndRotEv(self);
@@ -24,8 +26,8 @@ int func_ov080_021274ac(char* self, char** arg) {
     *(int*)(self + 0x320) = *(int*)(self + 0x5c);
     *(int*)(self + 0x324) = *(int*)(self + 0x60);
     *(int*)(self + 0x328) = *(int*)(self + 0x64);
-    Vec3_Sub(&d, (struct V3*)(self + 0x5c), (struct V3*)(self + 0x320));
+    Vec3_Sub(&d, (struct Vector3*)(self + 0x5c), (struct Vector3*)(self + 0x320));
     LenVec3(&d);
-    *(int*)(self + 0x338) = AngleDiff(Vec3_HorzAngle((struct V3*)(self + 0x5c), (struct V3*)(self + 0x320)), *(short*)(self + 0x8e));
+    *(int*)(self + 0x338) = AngleDiff(Vec3_HorzAngle((struct Vector3*)(self + 0x5c), (struct Vector3*)(self + 0x320)), *(short*)(self + 0x8e));
     return 1;
 }

--- a/src/func_ov081_021237e4.c
+++ b/src/func_ov081_021237e4.c
@@ -1,4 +1,8 @@
-int func_ov081_021237e4(void)
+// @symbol func_ov081_021237e4
+// @emits Spindrift_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daHuwa_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Spindrift_OnAimedAtWithEgg(void)
 {
     return 245760;
 }

--- a/src/func_ov081_02123910.cpp
+++ b/src/func_ov081_02123910.cpp
@@ -1,6 +1,13 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { short x, y, z; };
+// @symbol func_ov081_02123910
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Enemy.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
 
 struct VObj {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -15,12 +22,7 @@ struct VObj {
 
 extern "C" {
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern void _ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player(void* self, Vector3_16* v, void* player, int unused);
-extern void func_ov081_021237ec(void* c);
-extern int _ZN6Player9IsOnShellEv(void* p);
-extern int func_ov002_020e10a8(void* p);
 extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(void* self, void* cyl, void* player);
-extern void _ZN6Player10SpinBounceE5Fix12IiE(void* p, int f);
 extern short Vec3_HorzAngle(void* a, void* b);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* p, void* v, unsigned n, int f, unsigned a, unsigned b, unsigned c);
 }

--- a/src/func_ov081_02123fd8.cpp
+++ b/src/func_ov081_02123fd8.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov081_02123fd8
+// @emits Spindrift_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daHuwa_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void func_ov081_02123fd8(void *self, void *p)
+void Spindrift_OnTurnIntoEgg(void *self, void *p)
 {
     if (!_ZN6Player15IsCollectingCapEv(p))
         _ZN6Player20RegisterEggCoinCountEjbb(p, 3, 0, 0);

--- a/src/func_ov081_02124038.c
+++ b/src/func_ov081_02124038.c
@@ -1,4 +1,8 @@
-int func_ov081_02124038(void)
+// @symbol func_ov081_02124038
+// @emits Spindrift_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daHuwa_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Spindrift_OnYoshiTryEat(void)
 {
     return 6;
 }

--- a/src/func_ov081_02124134.c
+++ b/src/func_ov081_02124134.c
@@ -1,8 +1,10 @@
-struct V3{int x,y,z;};
+// @symbol func_ov081_02124134
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int RandomIntInternal(int* seed);
 extern void func_02012790(int);
-extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 extern int data_0209e650;
 
 void func_ov081_02124134(char* c){
@@ -37,6 +39,6 @@ void func_ov081_02124134(char* c){
     *(int*)(c+0x400) = 0;
   }
   if (*(int*)(c+0x41c) == 2) {
-    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xdf, 0x300, (struct V3*)(c+0x44c), 0, *(signed char*)(c+0xcc), -1);
+    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xdf, 0x300, (struct Vector3*)(c+0x44c), 0, *(signed char*)(c+0xcc), -1);
   }
 }

--- a/src/func_ov081_0212423c.c
+++ b/src/func_ov081_0212423c.c
@@ -1,6 +1,9 @@
+// @symbol func_ov081_0212423c
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct Vector3 { int x, y, z; };
+
 
 extern s16 data_ov081_021289a4;
 extern s16 data_ov081_021289a6;

--- a/src/func_ov081_021243cc.cpp
+++ b/src/func_ov081_021243cc.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov081_021243cc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vec3 { s32 x, y, z; };
-struct V16 { s16 x, y, z; };
+
+
 
 extern "C" {
     void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* c, void* v);
@@ -20,13 +23,13 @@ extern "C" {
     void func_ov081_02124134(void* self);
 }
 
-extern Vec3 data_ov081_02128998;
+extern Vector3 data_ov081_02128998;
 extern void* data_ov081_02128e24;
 
 extern "C" void func_ov081_021243cc(void* self)
 {
     u8* c = (u8*)self;
-    Vec3 v;
+    Vector3 v;
     v.x = data_ov081_02128998.x;
     v.y = data_ov081_02128998.y;
     v.z = data_ov081_02128998.z;
@@ -63,7 +66,7 @@ extern "C" void func_ov081_021243cc(void* self)
             hit = 1;
         }
         if (flags & 0x10) {
-            V16 vv;
+            Vector3_16 vv;
             vv.x = (s16)-0x1200;
             vv.y = 0;
             vv.z = 0;
@@ -79,7 +82,7 @@ extern "C" void func_ov081_021243cc(void* self)
             hit = 1;
         }
         if (hit == 0) {
-            Vec3 hv;
+            Vector3 hv;
             hv.x = *(s32*)(c+0x5c);
             hv.y = *(s32*)(c+0x60);
             hv.z = *(s32*)(c+0x64);

--- a/src/func_ov081_021249f4.c
+++ b/src/func_ov081_021249f4.c
@@ -1,14 +1,17 @@
+// @symbol func_ov081_021249f4
+/* recovered: shared common types */
+#include "common.h"
 extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned a, unsigned b, int c, int d, int e, const void *f, void *g);
 extern int ApproachAngle(short *angle, int target, int a, int b, int max);
 extern void func_ov081_02125488(void *c, void *p);
 extern char data_ov081_02128e84[];
 
-struct Vec3 { int x, y, z; };
+
 
 int func_ov081_021249f4(char *c)
 {
-    struct Vec3 pos;
+    struct Vector3 pos;
     void *cb;
     int t;
 
@@ -36,7 +39,7 @@ int func_ov081_021249f4(char *c)
         func_ov081_02125488(c, data_ov081_02128e84);
     }
     {
-        short *ang = (short *)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL);
+        short *ang = (short *)(((long long)(int)(c + 0x94)));
         *ang = (short)(*ang + 0x2000);
         *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     }

--- a/src/func_ov081_02124b98.cpp
+++ b/src/func_ov081_02124b98.cpp
@@ -1,8 +1,13 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov081_02124b98
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern "C" int _ZNK9Animation12WillHitFrameEi(void* self, int frame);
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void* actor);
 extern "C" int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 extern "C" void Matrix4x3_FromRotationY(void* m, int ang);
@@ -13,7 +18,6 @@ extern "C" int _ZN9Animation8FinishedEv(void* self);
 extern "C" void func_ov081_02125488(void* c, void* p);
 
 extern "C" int data_020a0e68[];
-extern "C" void* data_ov081_02128e14;
 
 extern "C" int func_ov081_02124b98(char* c) {
     Vector3 in, out, v[2];

--- a/src/func_ov081_02124e64.c
+++ b/src/func_ov081_02124e64.c
@@ -1,9 +1,12 @@
-extern int func_ov081_0212423c();
+// @symbol func_ov081_02124e64
+// @emits Spindrift_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daHuwa_c::Kill - recovered from vtable slot identity */
 extern int func_ov081_02125488();
-extern int func_ov081_021245e8();
-extern int data_ov081_02128e34[];
 extern int data_ov081_02128e64[];
-int func_ov081_02124e64(char *c){
+int Spindrift_Kill(char *c){
   func_ov081_0212423c(c, 0);
   if(*(unsigned short*)(c+0x100)==0)
     func_ov081_02125488(c, data_ov081_02128e34);

--- a/src/func_ov081_02124f7c.c
+++ b/src/func_ov081_02124f7c.c
@@ -1,13 +1,16 @@
+// @symbol func_ov081_02124f7c
+/* recovered: shared common types */
+#include "common.h"
 extern void func_02012694(int a0, void *a1);
 extern unsigned _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned a, unsigned b, int c, int d, int e, const void *f, void *g);
 
-struct Vec3 { int x, y, z; };
+
 
 int func_ov081_02124f7c(char *thiz)
 {
     int n;
-    struct Vec3 pos;
+    struct Vector3 pos;
     void *cb;
 
     *(int *)(thiz + 0xa8) = 0x3c000;

--- a/src/func_ov081_021250c8.c
+++ b/src/func_ov081_021250c8.c
@@ -1,8 +1,11 @@
+// @symbol func_ov081_021250c8
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov081_021250c8 at 0x021250c8
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
  */
-struct Vec3 { int x, y, z; };
+
 struct PathPtr { int a, b; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
@@ -11,22 +14,22 @@ extern int func_ov081_02125488(void *c, void *p);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
 extern void _ZN7PathPtrC1Ev(struct PathPtr *self);
 extern void _ZN7PathPtr6FromIDEj(struct PathPtr *self, unsigned int id);
-extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vec3 *v, unsigned int i);
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
-extern short Vec3_HorzAngle(struct Vec3 *a, struct Vec3 *b);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vector3 *v, unsigned int i);
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
+extern short Vec3_HorzAngle(struct Vector3 *a, struct Vector3 *b);
 extern void ApproachAngle(void *p, int a, int b, int c, int d);
 extern int _ZN4cstd4fdivEii(int a, int b);
-extern void Vec3_MulScalar(struct Vec3 *out, struct Vec3 *in, int s);
-extern void SubVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
+extern void Vec3_MulScalar(struct Vector3 *out, struct Vector3 *in, int s);
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern char data_ov081_02128e54[];
 extern char data_ov081_02128da0[];
 
 int func_ov081_021250c8(char *c) {
     struct PathPtr p;
-    struct Vec3 node;
-    struct Vec3 diff;
-    struct Vec3 scaled;
+    struct Vector3 node;
+    struct Vector3 diff;
+    struct Vector3 scaled;
     int len;
 
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x150)) {
@@ -40,9 +43,9 @@ int func_ov081_021250c8(char *c) {
     _ZN7PathPtr6FromIDEj(&p, *(unsigned int*)(c + 0x418));
     _ZNK7PathPtr7GetNodeER7Vector3j(&p, &node, *(unsigned int*)(c + 0x424));
     node.y = *(int*)(c + 0x60);
-    Vec3_Sub(&diff, (struct Vec3*)(c + 0x5c), &node);
+    Vec3_Sub(&diff, (struct Vector3*)(c + 0x5c), &node);
     len = LenVec3(&diff);
-    ApproachAngle(c + 0x94, Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &node), 1, 0x1000, 0x500);
+    ApproachAngle(c + 0x94, Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &node), 1, 0x1000, 0x500);
     if (len == 0) goto epi;
     if (len > *(int*)(c + 0x458)) goto work;
 epi:
@@ -51,7 +54,7 @@ work:
     {
         int q = _ZN4cstd4fdivEii(*(int*)(c + 0x458), len);
         Vec3_MulScalar(&scaled, &diff, q);
-        SubVec3((struct Vec3*)(c + 0x5c), &scaled, (struct Vec3*)(c + 0x5c));
+        SubVec3((struct Vector3*)(c + 0x5c), &scaled, (struct Vector3*)(c + 0x5c));
     }
     return 1;
 }

--- a/src/func_ov081_02125208.c
+++ b/src/func_ov081_02125208.c
@@ -1,4 +1,8 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov081_02125208
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct PathPtr { int a, b; };
 
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
@@ -7,16 +11,14 @@ extern int func_ov081_02125488(void *c, void *p);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
 extern void _ZN7PathPtrC1Ev(struct PathPtr *self);
 extern void _ZN7PathPtr6FromIDEj(struct PathPtr *self, unsigned int id);
-extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vec3 *v, unsigned int i);
-extern short Vec3_HorzAngle(struct Vec3 *a, struct Vec3 *b);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vector3 *v, unsigned int i);
+extern short Vec3_HorzAngle(struct Vector3 *a, struct Vector3 *b);
 extern void ApproachAngle(void *p, int a, int b, int c, int d);
-extern int AngleDiff(int a, int b);
 extern char data_ov081_02128d88[];
-extern char data_ov081_02128e74[];
 
 int func_ov081_02125208(char *c) {
     struct PathPtr p;
-    struct Vec3 node;
+    struct Vector3 node;
     int st;
     int z;
     int n;
@@ -36,9 +38,9 @@ int func_ov081_02125208(char *c) {
     _ZN7PathPtrC1Ev(&p);
     _ZN7PathPtr6FromIDEj(&p, *(unsigned int*)(c + 0x418));
     _ZNK7PathPtr7GetNodeER7Vector3j(&p, &node, *(unsigned int*)(c + 0x424));
-    ApproachAngle(c + 0x94, Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &node), 1, 0x1000, 0x500);
+    ApproachAngle(c + 0x94, Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &node), 1, 0x1000, 0x500);
 
-    if (AngleDiff(*(short*)(c + 0x94), Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &node)) >= 0x100) {
+    if (AngleDiff(*(short*)(c + 0x94), Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &node)) >= 0x100) {
         goto exit;
     }
 

--- a/src/func_ov081_0212538c.c
+++ b/src/func_ov081_0212538c.c
@@ -1,26 +1,28 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov081_0212538c
+/* recovered: shared common types */
+#include "common.h"
 struct PathPtr { int a, b; };
 
 extern void _ZN7PathPtrC1Ev(struct PathPtr *self);
 extern void _ZN7PathPtr6FromIDEj(struct PathPtr *self, unsigned int id);
-extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vec3 *v, unsigned int i);
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
+extern void _ZNK7PathPtr7GetNodeER7Vector3j(struct PathPtr *self, struct Vector3 *v, unsigned int i);
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int b);
 extern void *data_ov081_02128d98[];
 
 int func_ov081_0212538c(char *c)
 {
     struct PathPtr pp;
-    struct Vec3 node;
-    struct Vec3 diff;
+    struct Vector3 node;
+    struct Vector3 diff;
     int len;
 
     _ZN7PathPtrC1Ev(&pp);
     _ZN7PathPtr6FromIDEj(&pp, *(unsigned int *)(c + 0x418));
     _ZNK7PathPtr7GetNodeER7Vector3j(&pp, &node, *(unsigned int *)(c + 0x424));
     node.y = *(int *)(c + 0x60);
-    Vec3_Sub(&diff, (struct Vec3 *)(c + 0x5c), &node);
+    Vec3_Sub(&diff, (struct Vector3 *)(c + 0x5c), &node);
     len = LenVec3(&diff);
     *(int *)(c + 0x458) = 0xa000;
     *(int *)(c + 0x408) = 0;
@@ -28,7 +30,7 @@ int func_ov081_0212538c(char *c)
         *(int *)(c + 0x5c) = node.x;
         *(int *)(c + 0x60) = node.y;
         *(int *)(c + 0x64) = node.z;
-        (*(int *)(((long long)(int)(c + 0x424)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((long long)(int)(c + 0x424))))++;
         if (*(int *)(c + 0x424) >= *(int *)(c + 0x420))
             *(int *)(c + 0x424) = 0;
         *(int *)(c + 0x408) = 1;

--- a/src/func_ov081_021254d8.cpp
+++ b/src/func_ov081_021254d8.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Matrix4x3 { int m[12]; };
+// @symbol func_ov081_021254d8
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); };
 

--- a/src/func_ov081_02125eb8.c
+++ b/src/func_ov081_02125eb8.c
@@ -1,4 +1,8 @@
-int func_ov081_02125eb8(void)
+// @symbol func_ov081_02125eb8
+// @emits MrBlizzard_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daSnowman_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int MrBlizzard_OnAimedAtWithEgg(void)
 {
     return 622592;
 }

--- a/src/func_ov081_021261b8.c
+++ b/src/func_ov081_021261b8.c
@@ -1,4 +1,8 @@
-int func_ov081_021261b8(char *p)
+// @symbol func_ov081_021261b8
+// @emits MrBlizzard_Kill
+/* recovered: renamed to Class_Method */
+/* daSnowman_c::Kill - recovered from vtable slot identity */
+int MrBlizzard_Kill(char *p)
 {
     *(int *)(p + 0x388) = 0;
     *(short *)(p + 0x100) = 200;

--- a/src/func_ov081_02126224.c
+++ b/src/func_ov081_02126224.c
@@ -1,13 +1,16 @@
+// @symbol func_ov081_02126224
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov081_02126224(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x31c) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x31c) = data_020a0e68;
 }

--- a/src/func_ov081_021265b8.c
+++ b/src/func_ov081_021265b8.c
@@ -1,4 +1,8 @@
-int func_ov081_021265b8(void)
+// @symbol func_ov081_021265b8
+// @emits Moneybag_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daGmch_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Moneybag_OnYoshiTryEat(void)
 {
     return 6;
 }

--- a/src/func_ov081_021265c0.c
+++ b/src/func_ov081_021265c0.c
@@ -1,4 +1,8 @@
-int func_ov081_021265c0(void)
+// @symbol func_ov081_021265c0
+// @emits Moneybag_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daGmch_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Moneybag_OnAimedAtWithEgg(void)
 {
     return 235520;
 }

--- a/src/func_ov081_02126700.cpp
+++ b/src/func_ov081_02126700.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3{int x,y,z;};
+// @symbol func_ov081_02126700
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C"{
 void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void*,Vector3 const&,unsigned int,int,short);
 void _ZN5Actor8PoofDustEv(void*);

--- a/src/func_ov081_02126a20.cpp
+++ b/src/func_ov081_02126a20.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov081_02126a20
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef unsigned char u8;
 typedef short s16;
@@ -15,8 +18,8 @@ extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12Ii
 
 extern Mtx43 data_020a0e68;
 
-struct Vec3i { int x, y, z; };
-extern Vec3i data_ov081_02128ef8;
+
+extern Vector3 data_ov081_02128ef8;
 
 struct VObj {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();

--- a/src/func_ov081_02126c8c.cpp
+++ b/src/func_ov081_02126c8c.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov081_02126c8c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int n, const Vector3& v);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
-extern int data_ov081_02128edc[];
 }
 
 struct Base {

--- a/src/func_ov081_02127070.cpp
+++ b/src/func_ov081_02127070.cpp
@@ -1,7 +1,12 @@
 //cpp
+// @symbol func_ov081_02127070
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern "C" Fix12i Vec3_Dist(const Vector3* a, const Vector3* b);
 extern "C" s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern "C" void ApproachLinear(s16& v, s16 target, s16 step);
@@ -24,9 +29,6 @@ struct Obj {
     char field1e4[0x3d0-0x1e4];
     Vector3 target;       // 0x3d0
 };
-extern "C" int func_ov081_02126950(void* self, void* clsn);
-extern "C" void func_ov081_02126758(void* self);
-extern "C" void func_ov081_021265c8(void* self);
 
 extern "C" int func_ov081_02127070(Obj* self)
 {

--- a/src/func_ov081_021273e8.c
+++ b/src/func_ov081_021273e8.c
@@ -1,7 +1,11 @@
+// @symbol func_ov081_021273e8
+// @emits Snowball_Kill
+/* recovered: renamed to Class_Method */
+/* daSnowball_c::Kill - recovered from vtable slot identity */
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char*, void*, int, int, unsigned int);
 struct S2 { int w[2]; };
 extern struct S2 data_ov081_02128ee4;
-int func_ov081_021273e8(char *c) {
+int Snowball_Kill(char *c) {
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov081_02128ee4.w[1], 0x40000000, 0x1000, 0);
     *(int*)(c+0x130) = 0x1000;
     *(int*)(c+0x98) = 0;

--- a/src/func_ov081_02127a7c.cpp
+++ b/src/func_ov081_02127a7c.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov081_02127a7c
+// @emits Moneybag_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daGmch_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void func_ov081_02127a7c(void *self, void *p)
+void Moneybag_OnTurnIntoEgg(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 5, 0);

--- a/src/func_ov081_02127be0.cpp
+++ b/src/func_ov081_02127be0.cpp
@@ -1,9 +1,12 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { unsigned short x, y, z; };
+// @symbol func_ov081_02127be0
+/* recovered: shared common types */
+#include "common.h"
+
+struct Vector3_16_local { unsigned short x, y, z; };
 struct ActorBase { void MarkForDestruction(); };
 struct Actor {
-    static Actor* Spawn(unsigned int a, unsigned int b, const Vector3& v, const Vector3_16* v16, int e, int f);
+    static Actor* Spawn(unsigned int a, unsigned int b, const Vector3& v, const Vector3_16_local* v16, int e, int f);
 };
 
 extern "C" void func_ov081_02127be0(char* c)
@@ -20,7 +23,7 @@ extern "C" void func_ov081_02127be0(char* c)
     pos.z = src->z;
 
     char* o2 = *(char**)(c + 0x364);
-    Vector3_16 rot;
+    Vector3_16_local rot;
     {
         int b = *(unsigned short*)(o2 + 0x8e);
         int a = *(unsigned short*)(o2 + 0x8c);

--- a/src/func_ov081_02127ccc.cpp
+++ b/src/func_ov081_02127ccc.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov081_02127ccc
+// @emits IceBlock_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjIceBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void func_ov081_02127ccc(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void IceBlock_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov081_02127cf4.c
+++ b/src/func_ov081_02127cf4.c
@@ -1,15 +1,19 @@
-/* func_ov081_02127cf4 at 0x02127cf4
+// @symbol func_ov081_02127cf4
+// @emits IceBlock_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjIceBlock_c::Kill - recovered from vtable slot identity */
+/* IceBlock_Kill at 0x02127cf4
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
  */
-struct Vector3 { int x, y, z; };
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* pos);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const struct Vector3* vec);
-extern void func_ov081_02127be0(void* self);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
 
-void func_ov081_02127cf4(char* c) {
+void IceBlock_Kill(char* c) {
   struct Vector3 vec;
   struct Vector3 vec2;
   _ZN5Sound9PlayBank3EjRK7Vector3(0x41, (const struct Vector3*)(c + 0x74));

--- a/src/func_ov084_02129168.cpp
+++ b/src/func_ov084_02129168.cpp
@@ -1,16 +1,17 @@
 //cpp
+// @symbol func_ov084_02129168
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern int Vec3_HorzLen(void* v);
 extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int a, int b, unsigned int e);
-extern void _ZN12WithMeshClsn13SetLimMovFlagEv(void* thiz);
-extern void _ZN12WithMeshClsn12Unk_0203589cEv(void* thiz);
-extern void _ZN12WithMeshClsn22ClearJustHitGroundFlagEv(void* thiz);
-extern void _ZN12WithMeshClsn15ClearGroundFlagEv(void* thiz);
 extern void func_02012694(int a, void* v);
-extern int data_ov084_02130cc0[];
 
 void func_ov084_02129168(char* c, char* actor)
 {

--- a/src/func_ov084_02129238.cpp
+++ b/src/func_ov084_02129238.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov084_02129238
+/* recovered: shared common types */
+#include "common.h"
 typedef int s32;
-struct Vector3 { s32 x, y, z; };
+
 struct Actor;
 
 struct RaycastGround {

--- a/src/func_ov084_021294d0.cpp
+++ b/src/func_ov084_021294d0.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov084_021294d0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
 extern char* _ZNK12WithMeshClsn14GetFloorResultEv(void*);
@@ -14,7 +17,7 @@ extern void _ZN10ClsnResultD1Ev(void*);
 extern int data_02099368[];
 }
 
-struct V3 { int x, y, z; };
+
 
 extern "C" void func_ov084_021294d0(char* c)
 {
@@ -27,7 +30,7 @@ extern "C" void func_ov084_021294d0(char* c)
         func_ov084_021296cc(c);
         _ZN5Enemy9SpawnCoinEv(c);
         func_ov084_02129498(c);
-        V3 v;
+        Vector3 v;
         v.x = 0; v.y = 0x6c000; v.z = 0;
         _ZN8CapEnemy10ReleaseCapERK7Vector3(c, &v);
         *(int*)(c + 0x5c) = *(int*)(c + 0x41c);
@@ -72,7 +75,7 @@ action:
         *(int*)(c + 0x5c) = *(int*)(c + 0x41c);
         *(int*)(c + 0x60) = *(int*)(c + 0x420);
         *(int*)(c + 0x64) = *(int*)(c + 0x424);
-        V3 v2;
+        Vector3 v2;
         v2.x = 0; v2.y = 0x6c000; v2.z = 0;
         _ZN8CapEnemy10ReleaseCapERK7Vector3(c, &v2);
         _ZN8CapEnemy15RespawnIfHasCapEv(c);

--- a/src/func_ov084_021296cc.c
+++ b/src/func_ov084_021296cc.c
@@ -1,10 +1,13 @@
+// @symbol func_ov084_021296cc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 
 extern void _ZN5Actor11UntrackStarERa(void *thiz, signed char *s);
-extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 a, struct Vec3 *pos, void *rot, int e, int f);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 a, struct Vector3 *pos, void *rot, int e, int f);
 extern void LinkSilverStarAndStarMarker(char *a, char *b);
 extern void _ZN5Actor13SpawnSoundObjEj(void *c, u32 id);
 extern u8 data_0209f208[];
@@ -17,10 +20,10 @@ void func_ov084_021296cc(char *c)
         char *b;
         _ZN5Actor11UntrackStarERa(c, (signed char *)(c + 0x465));
         a = (char *)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-            0xb4, 0x50, (struct Vec3 *)(c + 0x41c), 0,
+            0xb4, 0x50, (struct Vector3 *)(c + 0x41c), 0,
             *(signed char *)(c + 0xcc), -1);
         b = (char *)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-            0xb3, 0x10, (struct Vec3 *)(c + 0x5c), 0,
+            0xb3, 0x10, (struct Vector3 *)(c + 0x5c), 0,
             *(signed char *)(c + 0xcc), -1);
         if (a != 0 && b != 0) {
             *(int *)(b + 0x434) = *(int *)(a + 4);
@@ -36,10 +39,10 @@ void func_ov084_021296cc(char *c)
         return;
     _ZN5Actor11UntrackStarERa(c, (signed char *)(c + 0x465));
     _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        0xb4, *(u8 *)(c + 0x466) | 0x30, (struct Vec3 *)(c + 0x5c), 0,
+        0xb4, *(u8 *)(c + 0x466) | 0x30, (struct Vector3 *)(c + 0x5c), 0,
         *(signed char *)(c + 0xcc), -1);
     _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-        0xb3, *(u8 *)(c + 0x466) | 0x30, (struct Vec3 *)(c + 0x5c), 0,
+        0xb3, *(u8 *)(c + 0x466) | 0x30, (struct Vector3 *)(c + 0x5c), 0,
         *(signed char *)(c + 0xcc), -1);
     *(u8 *)(c + 0x464) = 3;
     *(int *)(c + 8) &= 0xff0f;

--- a/src/func_ov084_02129cf4.c
+++ b/src/func_ov084_02129cf4.c
@@ -1,57 +1,60 @@
+// @symbol func_ov084_02129cf4
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vec3 { int x, y, z; };
+
 
 extern void *_ZN5Actor13ClosestPlayerEv(void);
-extern Fix12i Vec3_Dist(const struct Vec3 *a, const struct Vec3 *b);
-extern short Vec3_HorzAngle(const struct Vec3 *a, const struct Vec3 *b);
+extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
+extern short Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *c);
 
 void func_ov084_02129cf4(char *c, Fix12i distThresh)
 {
-    struct Vec3 ppos;
+    struct Vector3 ppos;
 
     *(void **)(c + 0x438) = _ZN5Actor13ClosestPlayerEv();
 
     if (*(void **)(c + 0x438) == 0
-        || (Vec3_Dist((struct Vec3*)(c+0x5c), (struct Vec3*)(c+0x41c)) > distThresh
+        || (Vec3_Dist((struct Vector3*)(c+0x5c), (struct Vector3*)(c+0x41c)) > distThresh
             && *(unsigned char*)(c+0x113) >= 6)) {
-        *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), (struct Vec3*)(c+0x41c));
+        *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vector3*)(c+0x5c), (struct Vector3*)(c+0x41c));
         *(int*)(c+0x440) = 0x61a8000;
         return;
     }
 
     {
-        int *ppos_src = (int *)(int)((long long)(int)(*(char **)(c + 0x438) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+        int *ppos_src = (int *)(int)((long long)(int)(*(char **)(c + 0x438) + 0x5c));
         ppos.x = ppos_src[0];
         ppos.y = ppos_src[1];
         ppos.z = ppos_src[2];
     }
 
     if (*(unsigned char*)(c+0x113) < 6) {
-        if (Vec3_Dist((struct Vec3*)(c+0x5c), (struct Vec3*)(c+0x41c)) > distThresh
+        if (Vec3_Dist((struct Vector3*)(c+0x5c), (struct Vector3*)(c+0x41c)) > distThresh
             && !_ZNK12WithMeshClsn8IsOnWallEv(c+0x1b4)) {
             *(int*)(c+0x440) = 0x61a8000;
-            *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), (struct Vec3*)(c+0x41c));
+            *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vector3*)(c+0x5c), (struct Vector3*)(c+0x41c));
             return;
         }
 
-        if (Vec3_Dist((struct Vec3*)(c+0x5c), &ppos) < *(int*)(c+0x448)) {
-            *(int*)(c+0x440) = Vec3_Dist((struct Vec3*)(c+0x5c), &ppos);
+        if (Vec3_Dist((struct Vector3*)(c+0x5c), &ppos) < *(int*)(c+0x448)) {
+            *(int*)(c+0x440) = Vec3_Dist((struct Vector3*)(c+0x5c), &ppos);
             if (*(unsigned short*)(c+0x400+0x58) != 0) {
-                *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), &ppos);
+                *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vector3*)(c+0x5c), &ppos);
                 return;
             }
-            *(short*)(c+0x400+0x5a) = Vec3_HorzAngle(&ppos, (struct Vec3*)(c+0x5c));
+            *(short*)(c+0x400+0x5a) = Vec3_HorzAngle(&ppos, (struct Vector3*)(c+0x5c));
             return;
         }
         *(int*)(c+0x440) = 0x61a8000;
         return;
     }
 
-    if (Vec3_Dist((struct Vec3*)(c+0x41c), &ppos) > distThresh) {
+    if (Vec3_Dist((struct Vector3*)(c+0x41c), &ppos) > distThresh) {
         *(int*)(c+0x440) = 0x61a8000;
         return;
     }
-    *(int*)(c+0x440) = Vec3_Dist((struct Vec3*)(c+0x5c), &ppos);
-    *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vec3*)(c+0x5c), &ppos);
+    *(int*)(c+0x440) = Vec3_Dist((struct Vector3*)(c+0x5c), &ppos);
+    *(short*)(c+0x400+0x5a) = Vec3_HorzAngle((struct Vector3*)(c+0x5c), &ppos);
 }

--- a/src/func_ov084_0212a580.cpp
+++ b/src/func_ov084_0212a580.cpp
@@ -1,6 +1,9 @@
 //cpp
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { unsigned short x, y, z; };
+// @symbol func_ov084_0212a580
+/* recovered: shared common types */
+#include "common.h"
+
+struct Vector3_16_local { unsigned short x, y, z; };
 
 extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
@@ -10,14 +13,14 @@ extern short data_02082214[];
 }
 
 struct CapEnemy {
-    void UpdateCapPos(const Vector3&, const Vector3_16&);
+    void UpdateCapPos(const Vector3&, const Vector3_16_local&);
 };
 
 extern "C" void func_ov084_0212a580(char* c){
-    Vector3_16 s16;
+    Vector3_16_local s16;
     Vector3 pos;
     Vector3 arg;
-    Vector3_16 arg16;
+    Vector3_16_local arg16;
 
     Matrix4x3_FromRotationY(c + 0x38c, *(short*)(c + 0x8e));
     *(int*)(c + 0x3b0) = *(int*)(c + 0x5c) >> 3;

--- a/src/func_ov084_0212b30c.cpp
+++ b/src/func_ov084_0212b30c.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" int func_ov084_0212b30c(char *c) {
+// @symbol func_ov084_0212b30c
+// @emits Goomba_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daKrb_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+extern "C" int Goomba_OnAimedAtWithEgg(char *c) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     int b = (v == (unsigned short)0xc8) ? 1 : 0;
     if (b) return 0x41000;

--- a/src/func_ov084_0212b344.cpp
+++ b/src/func_ov084_0212b344.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov084_0212b344
+// @emits Goomba_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daKrb_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 void _ZN8CapEnemy15RespawnIfHasCapEv(char *self);
 int _ZN6Player15IsCollectingCapEv(char *p);
@@ -35,7 +39,7 @@ struct Obj {
     virtual int GetState();
 };
 
-extern "C" void func_ov084_0212b344(char *self, char *player)
+extern "C" void Goomba_OnTurnIntoEgg(char *self, char *player)
 {
     Obj *o = (Obj *)self;
     int b5, b4;

--- a/src/func_ov084_0212bfc0.cpp
+++ b/src/func_ov084_0212bfc0.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" int func_ov084_0212bfc0(char *c) {
+// @symbol func_ov084_0212bfc0
+// @emits Goomba_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daKrb_c::OnYoshiTryEat - recovered from vtable slot identity */
+extern "C" int Goomba_OnYoshiTryEat(char *c) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     int b = (v == (unsigned short)0xc8) ? 1 : 0;
     if (b) return 0x6;

--- a/src/func_ov084_0212c1a0.c
+++ b/src/func_ov084_0212c1a0.c
@@ -1,36 +1,36 @@
+// @symbol func_ov084_0212c1a0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 
-struct Vec3 { int x, y, z; };
 
-extern s16 Vec3_HorzAngle(struct Vec3* v0, struct Vec3* v1);
+
+extern s16 Vec3_HorzAngle(struct Vector3* v0, struct Vector3* v1);
 extern int _ZN6Player12GetTalkStateEv(void* p);
 extern int _Z14ApproachLinearRsss(s16* p, s16 target, s16 step);
-extern void func_ov084_0212c9f0(char* c, int arg1, unsigned int arg2);
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
-extern void OpenCannonInCurLevel(void);
 extern void func_ov084_0212c960(char* c, int a);
-extern int func_ov084_0212cae0(char* c);
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern void func_ov002_020bc990(void* actor);
-extern int func_ov084_0212ccb4(char* c);
 
 extern char* data_0209f318;
 extern signed char data_0209f2f8;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 void func_ov084_0212c1a0(char* c)
 {
     char* r5 = *(char**)(c + 0x194);
     char* r4 = data_0209f318;
-    struct Vec3 v;
+    struct Vector3 v;
     s16 ang;
     int* src = (int*)AT(r5, 0x5c);
 
     v.x = src[0];
     v.y = src[1];
     v.z = src[2];
-    ang = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &v);
+    ang = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &v);
 
     switch (*(unsigned char*)(c + 0x1e8)) {
     case 0:

--- a/src/func_ov084_0212c4a0.c
+++ b/src/func_ov084_0212c4a0.c
@@ -1,5 +1,9 @@
+// @symbol func_ov084_0212c4a0
+// @emits Goomba_Kill
+/* recovered: renamed to Class_Method */
+/* daKrb_c::Kill - recovered from vtable slot identity */
 extern void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int, void*);
-void func_ov084_0212c4a0(char* r5) {
+void Goomba_Kill(char* r5) {
     void* r1;
     r1 = _ZN5Actor15FindWithActorIDEjPS_(0xe, 0);
     while (r1) {

--- a/src/func_ov084_0212c508.cpp
+++ b/src/func_ov084_0212c508.cpp
@@ -1,23 +1,22 @@
 //cpp
+// @symbol func_ov084_0212c508
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef signed char s8;
 typedef unsigned char u8;
-struct Vector3 { int x, y, z; };
+
 extern "C" s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern "C" int func_ov084_0212cac0(char *c);
-extern "C" int IsCannonOpenInCurLevel(void);
 extern "C" void func_ov084_0212c960(char *c, int i);
 extern "C" int _ZN6Player12GetTalkStateEv(char *c);
 extern "C" int _Z14ApproachLinearRsss(s16 *a, s16 b, s16 c);
-extern "C" int func_ov084_0212caa8(char *c);
 extern "C" s8 NumRedCoins(void);
-extern "C" void func_ov084_0212c9f0(char *c, int arg1, unsigned int arg2);
-extern "C" int ObjectMessageIDToActualMessageID(int id);
 extern "C" int func_ov084_0212ca60(char *c);
 extern "C" void func_02012790(int a);
 extern int data_0209caa0[];
-extern u8 data_0209f288;
 extern s8 data_0209f2f8;
 extern u8 data_0209d660;
 extern u8 data_0209d6bc;
@@ -116,7 +115,7 @@ extern "C" void func_ov084_0212c508(char *self)
                 goto skip_inc;
         do_inc:
             {
-                u8 *p = (u8 *)(((long long)(int)(self + 0x1eb)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8 *)(((long long)(int)(self + 0x1eb)));
                 *p = (u8)(*p + 1);
             }
         skip_inc:

--- a/src/func_ov084_0212c9f0.c
+++ b/src/func_ov084_0212c9f0.c
@@ -1,5 +1,8 @@
+// @symbol func_ov084_0212c9f0
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct Vector3 { int x, y, z; };
+
 extern void func_02012694(int a, void* p, int c);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* ab, unsigned int id, const struct Vector3* v, unsigned int a, unsigned int b);
 

--- a/src/func_ov084_0212cae0.c
+++ b/src/func_ov084_0212cae0.c
@@ -1,21 +1,22 @@
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int m[12]; };
+// @symbol func_ov084_0212cae0
+/* recovered: shared common types */
+#include "common.h"
 extern char *data_0209f318;
-extern struct Mtx43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
-extern void MulVec3Mat4x3(struct Vec3 *v, struct Mtx43 *m, struct Vec3 *out);
-extern void Vec3_Add(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int func_ov084_0212cda0(int arg0, struct Vec3 *out, struct Vec3 *target);
-extern void _ZN6Camera9SetLookAtERK7Vector3(void *cam, struct Vec3 *v);
-extern void _ZN6Camera6SetPosERK7Vector3(void *cam, struct Vec3 *v);
+extern void MulVec3Mat4x3(struct Vector3 *v, struct Matrix4x3 *m, struct Vector3 *out);
+extern void Vec3_Add(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int func_ov084_0212cda0(int arg0, struct Vector3 *out, struct Vector3 *target);
+extern void _ZN6Camera9SetLookAtERK7Vector3(void *cam, struct Vector3 *v);
+extern void _ZN6Camera6SetPosERK7Vector3(void *cam, struct Vector3 *v);
 
 int func_ov084_0212cae0(char *self)
 {
     int ok2, ok1;
     char *cam;
     char *actor;
-    struct Vec3 vF, vG, vA, vB, vC, vD, vE;
+    struct Vector3 vF, vG, vA, vB, vC, vD, vE;
     unsigned id = *(unsigned int *)(self + 0x198);
     cam = data_0209f318;
     if (id != 0) {
@@ -30,7 +31,7 @@ body:
     vC.x = ok1; vC.y = ok1; vC.z = ok1;
     Matrix4x3_FromRotationY(&data_020a0e68, *(short *)(actor + 0x8e));
     MulVec3Mat4x3(&vA, &data_020a0e68, &vC);
-    Vec3_Add(&vD, (struct Vec3 *)(actor + 0x5c), &vC);
+    Vec3_Add(&vD, (struct Vector3 *)(actor + 0x5c), &vC);
     {
         int dx = vD.x; int dy = vD.y; int z = ok1;
         *(volatile int *)&vC.x = z; *(volatile int *)&vA.x = dx;
@@ -39,7 +40,7 @@ body:
         *(volatile int *)&vC.z = z; *(volatile int *)&vA.z = dz;
     }
     MulVec3Mat4x3(&vB, &data_020a0e68, &vC);
-    Vec3_Add(&vE, (struct Vec3 *)(actor + 0x5c), &vC);
+    Vec3_Add(&vE, (struct Vector3 *)(actor + 0x5c), &vC);
     {
         int ey = vE.y; int ex = vE.x;
         vB.y = ey;

--- a/src/func_ov084_0212ccb4.cpp
+++ b/src/func_ov084_0212ccb4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov084_0212ccb4
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct Camera {
     char pad[0x80];

--- a/src/func_ov084_0212cda0.c
+++ b/src/func_ov084_0212cda0.c
@@ -1,14 +1,16 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Sub(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
-extern int LenVec3(struct Vec3 *v);
+// @symbol func_ov084_0212cda0
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern int LenVec3(struct Vector3 *v);
 extern int Math_Function_0203b14c(int *a, int b, int c, int d, int e);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalarInPlace(int *v, int s);
-extern void Vec3_Add(struct Vec3 *out, struct Vec3 *a, struct Vec3 *b);
+extern void Vec3_Add(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
 
-int func_ov084_0212cda0(int arg0, struct Vec3 *out, struct Vec3 *target)
+int func_ov084_0212cda0(int arg0, struct Vector3 *out, struct Vector3 *target)
 {
-    struct Vec3 d;
+    struct Vector3 d;
     int len;
     int r5;
     int scratch;
@@ -19,7 +21,7 @@ int func_ov084_0212cda0(int arg0, struct Vec3 *out, struct Vec3 *target)
     r5 = Math_Function_0203b14c(&scratch, 0, 0x400, 0x100000, 0x1000);
     Vec3_MulScalarInPlace((int*)&d, _ZN4cstd4fdivEii(scratch, len));
     {
-        struct Vec3 res;
+        struct Vector3 res;
         Vec3_Add(&res, target, &d);
         out->x = res.x;
         out->y = res.y;

--- a/src/func_ov084_0212ce50.cpp
+++ b/src/func_ov084_0212ce50.cpp
@@ -1,16 +1,19 @@
 //cpp
+// @symbol func_ov084_0212ce50
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void Matrix4x3_FromRotationY(void* m, short angle);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* a, void* sm, void* mtx, int rad, int h, unsigned int x);
-struct M48 { int w[12]; };
-extern M48 data_02082128;
+
+extern Matrix4x3 data_02082128;
 void func_ov084_0212ce50(void* c){
   char* r4 = (char*)c;
   Matrix4x3_FromRotationY(r4+0x124, *(short*)(r4+0x8e));
   *(int*)(r4+0x148) = *(int*)(r4+0x5c) >> 3;
   *(int*)(r4+0x14c) = (*(int*)(r4+0x60) + 0x4000) >> 3;
   *(int*)(r4+0x150) = *(int*)(r4+0x64) >> 3;
-  *(M48*)(r4+0x19c) = data_02082128;
+  *(Matrix4x3*)(r4+0x19c) = data_02082128;
   *(int*)(r4+0x1c0) = *(int*)(r4+0x5c) >> 3;
   *(int*)(r4+0x1c4) = (*(int*)(r4+0x60) - 0x8000) >> 3;
   *(int*)(r4+0x1c8) = *(int*)(r4+0x64) >> 3;

--- a/src/func_ov084_0212dc30.c
+++ b/src/func_ov084_0212dc30.c
@@ -1,6 +1,7 @@
-struct Vector3 { int x, y, z; };
-
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+// @symbol func_ov084_0212dc30
+/* recovered: shared common types */
+#include "common.h"
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern int _Z14ApproachLinearRiii(int *cur, int target, int step);
 extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);

--- a/src/func_ov084_0212ddbc.c
+++ b/src/func_ov084_0212ddbc.c
@@ -1,10 +1,13 @@
+// @symbol func_ov084_0212ddbc
+/* recovered: shared common types */
+#include "common.h"
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef signed short s16;
 typedef long long s64;
 
-struct Vec3 { int x, y, z; };
+
 
 extern int _Z14ApproachLinearRiii(s32 *p, int a, int b);
 extern int _ZN9Animation8FinishedEv(void *a);
@@ -22,7 +25,7 @@ extern s16 data_02082214[];
 
 void func_ov084_0212ddbc(char *c)
 {
-    struct Vec3 pos;
+    struct Vector3 pos;
     s16 ang;
     int b;
     int speed;
@@ -91,8 +94,8 @@ cold:
     if (*(s32 *)(c + 0x204) <= (*(s32 *)(c + 0x210) >> 1))
         return;
     {
-        u32 *p18c = (u32 *)(((long long)(int)(c + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
-        u32 *pb0 = (u32 *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32 *p18c = (u32 *)(((long long)(int)(c + 0x18c)));
+        u32 *pb0 = (u32 *)(((long long)(int)(c + 0xb0)));
         *p18c &= ~1u;
         *pb0 |= 0x10000000u;
     }

--- a/src/func_ov084_0212e998.c
+++ b/src/func_ov084_0212e998.c
@@ -1,4 +1,8 @@
-int func_ov084_0212e998(void* c) {
+// @symbol func_ov084_0212e998
+// @emits FirePiranhaPlantBig_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daFPkn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int FirePiranhaPlantBig_OnAimedAtWithEgg(void* c) {
     int flags = *(int*)((char*)c + 0x18c);
     if (flags & 1) {
         return *(int*)((char*)c + 0x204) * 100;

--- a/src/func_ov084_0212e9d4.cpp
+++ b/src/func_ov084_0212e9d4.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov084_0212e9d4
+// @emits FirePiranhaPlantBig_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daFPkn_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int func_ov084_0212e9d4(void *c, void *player) {
+int FirePiranhaPlantBig_OnTurnIntoEgg(void *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, 1, 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov084_0212e9f8.cpp
+++ b/src/func_ov084_0212e9f8.cpp
@@ -1,5 +1,9 @@
 //cpp
-extern "C" int func_ov084_0212e9f8(void *c) {
+// @symbol func_ov084_0212e9f8
+// @emits FirePiranhaPlantBig_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daFPkn_c::OnYoshiTryEat - recovered from vtable slot identity */
+extern "C" int FirePiranhaPlantBig_OnYoshiTryEat(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xfc) r = 1; else r = 0;

--- a/src/func_ov084_0212ec58.c
+++ b/src/func_ov084_0212ec58.c
@@ -1,4 +1,8 @@
-int func_ov084_0212ec58(void)
+// @symbol func_ov084_0212ec58
+// @emits PiranhaPlant_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daPkn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int PiranhaPlant_OnAimedAtWithEgg(void)
 {
     return 286720;
 }

--- a/src/func_ov084_0212f204.c
+++ b/src/func_ov084_0212f204.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov084_0212f204
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor13ClosestPlayerEv(void);
 extern int Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 extern short Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);

--- a/src/func_ov084_0212f6d8.c
+++ b/src/func_ov084_0212f6d8.c
@@ -1,18 +1,22 @@
+// @symbol func_ov084_0212f6d8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
 
-extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);
+
 extern void func_0201267c(unsigned int a, void *p);
 extern void _Z14ApproachLinearRsss(s16 *val, s16 target, s16 step);
 extern int _ZN9Animation8FinishedEv(void *anim);
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void _ZN6Player16IncMegaKillCountEv(void *player);
 extern void func_02012694(unsigned int a, void *p);
-extern void func_ov084_0212ebb4(void *c);
 extern int _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *player, const void *pos, u32 a, int fix, u32 b, u32 c, u32 d);
 
 void func_ov084_0212f6d8(char *c)

--- a/src/func_ov084_0212fa7c.c
+++ b/src/func_ov084_0212fa7c.c
@@ -1,19 +1,22 @@
+// @symbol func_ov084_0212fa7c
+// @emits FirePiranhaPlantBig_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Animation.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daFPkn_c::Kill - recovered from vtable slot identity */
 typedef struct BCA_File BCA_File;
 
 extern int _ZN9Animation8FinishedEv(void *a);
-extern int _ZNK9Animation12WillHitFrameEi(void *a, int f);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *m, BCA_File *f, int a, int fix, unsigned int j);
-extern int func_ov084_0212f1d0(char *c);
 extern void func_02012694(int a, void *v);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int d);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int fix, int e);
-extern void func_ov084_0212ef00(char *self);
 
 extern int *data_ov084_02130df4;
-extern int *data_ov084_02130e0c;
 
-void func_ov084_0212fa7c(char *c) {
+void FirePiranhaPlantBig_Kill(char *c) {
     *(unsigned char *)(c + 0x45c) = 1;
     if (_ZN9Animation8FinishedEv(c + 0x160) || _ZNK9Animation12WillHitFrameEi(c + 0x160, 0)) {
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, (BCA_File *)((int *)&data_ov084_02130df4)[1], 0, 0x1000, 0);

--- a/src/func_ov085_021295bc.c
+++ b/src/func_ov085_021295bc.c
@@ -1,6 +1,6 @@
-struct Matrix4x3 { int m[12]; };
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov085_021295bc
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(struct Matrix4x3 *mF, short angX);

--- a/src/func_ov085_02129dbc.cpp
+++ b/src/func_ov085_02129dbc.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov085_02129dbc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Actor { Actor *ClosestPlayer(); };
 
 extern "C" int Vec3_HorzDist(const void *a, const void *b);
 extern "C" short Vec3_HorzAngle(const void *a, const void *b);
 extern "C" short Vec3_VertAngle(const void *a, const void *b);
-extern "C" int AngleDiff(int a, int b);
 extern "C" void _Z14ApproachLinearRsss(short *dst, short target, short rate);
 
-struct V3 { int x, y, z; };
+
 
 extern "C" void func_ov085_02129dbc(Actor *self)
 {
@@ -15,8 +19,8 @@ extern "C" void func_ov085_02129dbc(Actor *self)
     Actor *p = self->ClosestPlayer();
     if (p == 0)
         return;
-    V3 v;
-    V3 *psrc = (V3 *)(((long long)(int)((char *)p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    Vector3 v;
+    Vector3 *psrc = (Vector3 *)(((long long)(int)((char *)p + 0x5c)));
     v = *psrc;
     int hd = Vec3_HorzDist(s + 0x5c, &v);
     v.y = v.y - 0x1e000;

--- a/src/func_ov085_0212a0b8.c
+++ b/src/func_ov085_0212a0b8.c
@@ -1,7 +1,10 @@
-extern void Actor__UpdatePos(void*, void*);
-extern int func_ov085_02129ebc(void*, void*);
-extern int func_ov085_02129f8c(void*);
-int func_ov085_0212a0b8(char* c){
+// @symbol func_ov085_0212a0b8
+// @emits Toad_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daKinopio_c::Kill - recovered from vtable slot identity */
+int Toad_Kill(char* c){
   Actor__UpdatePos(c, c+0x160);
   func_ov085_02129ebc(c, c+0x194);
   func_ov085_02129f8c(c);

--- a/src/func_ov085_0212a904.c
+++ b/src/func_ov085_0212a904.c
@@ -1,10 +1,12 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov085_0212a904
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+/* recovered: shared common types */
+#include "common.h"
 extern short Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
 extern int ApproachAngle(void *p, int from, int start, int speed, int max);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *thiz, void *actor, unsigned int msg, const struct Vector3 *vec, unsigned int a, unsigned int b);
 extern void func_02012790(int a);
-extern void _ZN7Message13DisplaySavingEt(unsigned short a);
 extern void _ZN7Message7EndTalkEv(void);
 extern void func_ov085_0212bc78(void *c, void *p);
 

--- a/src/func_ov085_0212aaec.c
+++ b/src/func_ov085_0212aaec.c
@@ -1,12 +1,16 @@
+// @symbol func_ov085_0212aaec
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Message.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef int Fix12;
-struct Vector3 { int x, y, z; };
+
 
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 extern int _ZN6Player12GetTalkStateEv(void *p);
 extern int _Z14ApproachLinearRsss(s16 *p, s16 a, s16 b);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12 dist, int loop);
-extern void _ZN7Message11PrepareTalkEv(void);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *self, void *ab, unsigned int id, const struct Vector3 *v, unsigned int a, unsigned int b);
 extern void _ZN7Message7EndTalkEv(void);
 extern int func_ov085_0212bc78(void *c, void *p);

--- a/src/func_ov085_0212b4b4.c
+++ b/src/func_ov085_0212b4b4.c
@@ -1,22 +1,19 @@
+// @symbol func_ov085_0212b4b4
+// @emits PrincessPeach_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daPeach_c::Kill - recovered from vtable slot identity */
 
 typedef int s32;
 typedef short s16;
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
-typedef struct 
-{
-  s32 x;
-  s32 y;
-  s32 z;
-} Vector3;
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern s32 Vec3_Dist(const Vector3 *a, const Vector3 *b);
 extern void func_ov085_0212bc78(void *c, void *p);
-extern int func_ov085_0212a788(void *c);
 extern void func_02012694(int a, void *b);
-extern void func_02022a4c(s32 x, s32 y, s32 z);
-extern int func_02022cbc(int a, int b, s32 x, s32 y, s32 z, int f);
 extern void _ZN7PathPtrC1Ev(void *);
 extern void _ZN7PathPtr6FromIDEj(void *, u32);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *, Vector3 *, u32);
@@ -27,10 +24,8 @@ extern s32 LenVec3(const Vector3 *v);
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalar(Vector3 *out, const Vector3 *v, int s);
 extern void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
-extern int AngleDiff(int a, int b);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *);
-extern char data_ov085_0213069c[];
-int func_ov085_0212b4b4(char *c)
+int PrincessPeach_Kill(char *c)
 {
   void *pl;
   char pathptr[8];
@@ -119,7 +114,7 @@ int func_ov085_0212b4b4(char *c)
     *((s32 *) (c + 0x60)) = node.y;
     *((s32 *) (c + 0x64)) = node.z;
     {
-      s32 *p = (s32 *) ((int) (((long long) ((int) (c + 0x448))) & 0xFFFFFFFFFFFFFFFFLL));
+      s32 *p = (s32 *) ((int) (((long long) ((int) (c + 0x448)))));
       *p = (*p) + (*((s32 *) (c + 0x44c)));
     }
     if ((*((s32 *) (c + 0x448))) >= (*((s32 *) (c + 0x444))))

--- a/src/func_ov085_0212bcc8.c
+++ b/src/func_ov085_0212bcc8.c
@@ -1,30 +1,30 @@
-struct Vec3 { int x, y, z; };
-struct Mtx { int w[12]; };
-
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+// @symbol func_ov085_0212bcc8
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern void MulMat4x3Mat4x3(void* a, void* b, void* dst);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void* thiz, void* sm, void* mtx, int f, int a, unsigned int b);
 
-extern struct Mtx data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov085_0212bcc8(char* c)
 {
     char tmp[0x30];
-    struct Vec3 t;
-    Vec3_Asr(&t, (struct Vec3*)(c + 0x5c), 3);
+    struct Vector3 t;
+    Vec3_Asr(&t, (struct Vector3*)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, t.x, t.y, t.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));
-    *(struct Mtx*)(c + 0x31c) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x31c) = data_020a0e68;
     MulMat4x3Mat4x3(*(void**)(c + 0x314), (void*)(c + 0x31c), tmp);
     Matrix4x3_FromTranslation(&data_020a0e68,
         *(int*)(c + 0x5c) >> 3,
         (*(int*)(c + 0x60) - 0xe000) >> 3,
         *(int*)(c + 0x64) >> 3);
-    *(struct Mtx*)(c + 0x390) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x390) = data_020a0e68;
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
         c, (void*)(c + 0x368), (void*)(c + 0x390), 0x46000, 0x258000, 0xf);
 }

--- a/src/func_ov085_0212bdbc.cpp
+++ b/src/func_ov085_0212bdbc.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov085_0212bdbc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern int _ZN6Player14IsFrontSlidingEv(void*);
 extern int _ZN6Player17LostGrabbedObjectEv(void*);
 extern void* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(void*, void*, void*);
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void*,void*,void*,int,int,unsigned int);
-extern char data_ov085_021306ec[];
 extern int data_020a0e68[];
-struct M4x3 { int w[12]; };
+
 
 void func_ov085_0212bdbc(char* c){
     int idx;
@@ -22,9 +26,9 @@ void func_ov085_0212bdbc(char* c){
         idx = (idx + 2) & 0xff;
     }
     res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(c, *(void**)(c + 0x45c), data_ov085_021306ec + idx * 0xc);
-    *(struct M4x3*)(c + 0x31c) = *(struct M4x3*)res;
+    *(struct Matrix4x3*)(c + 0x31c) = *(struct Matrix4x3*)res;
     Matrix4x3_FromTranslation(data_020a0e68, *(int*)(c + 0x5c) >> 3, (*(int*)(c + 0x60) - 0xc000) >> 3, *(int*)(c + 0x64) >> 3);
-    *(struct M4x3*)(c + 0x390) = *(struct M4x3*)data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x390) = *(struct Matrix4x3*)data_020a0e68;
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
         c, c + 0x368, c + 0x390, 0x46000, 0x258000, 0xf);
 }

--- a/src/func_ov085_0212bedc.cpp
+++ b/src/func_ov085_0212bedc.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol func_ov085_0212bedc
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x; int y; int z; };
-struct Mtx43 { int m[12]; };
+struct Vector3_local { int x; int y; int z; };
 
-extern "C" int Vec3_HorzDist(const Vector3 *a, const Vector3 *b);
-extern "C" short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
+
+extern "C" int Vec3_HorzDist(const Vector3_local *a, const Vector3_local *b);
+extern "C" short Vec3_HorzAngle(const Vector3_local *v0, const Vector3_local *v1);
 extern "C" void Matrix4x3_FromRotationY(void *m, int angle);
-extern "C" void MulVec3Mat4x3(const Vector3 *v, const Mtx43 *m, Vector3 *res);
-extern "C" void Matrix4x3_FromTranslation(Mtx43 *m, int x, int y, int z);
+extern "C" void MulVec3Mat4x3(const Vector3_local *v, const Matrix4x3 *m, Vector3_local *res);
+extern "C" void Matrix4x3_FromTranslation(Matrix4x3 *m, int x, int y, int z);
 
 struct ShadowModel;
 struct Matrix4x3;
@@ -16,7 +19,7 @@ struct Actor {
     void DropShadowRadHeight(ShadowModel &, Matrix4x3 &, Fix12, Fix12, unsigned int);
 };
 
-extern Mtx43 data_020a0e68;
+extern Matrix4x3 data_020a0e68;
 
 struct Obj {
     char pad5c[0x5c];
@@ -25,14 +28,14 @@ struct Obj {
     int v64;
     char pad3c0[0x3c0 - 0x68];
     char shadowmodel[0x28];
-    Mtx43 mtx;
+    Matrix4x3 mtx;
 };
 
 extern "C" void func_ov085_0212bedc(Obj *c)
 {
-    Vector3 v;
-    Vector3 res;
-    Vector3 vd;
+    Vector3_local v;
+    Vector3_local res;
+    Vector3_local vd;
 
     v.x = 0; v.y = 0; v.z = 0;
     res.x = 0; res.y = 0; res.z = 0;
@@ -42,8 +45,8 @@ extern "C" void func_ov085_0212bedc(Obj *c)
     vd.y = c->v60;
     vd.z = c->v64;
     vd.x = 0x1086000;
-    v.z = Vec3_HorzDist((Vector3 *)&c->v5c, &vd);
-    Matrix4x3_FromRotationY(&data_020a0e68, Vec3_HorzAngle((Vector3 *)&c->v5c, &vd));
+    v.z = Vec3_HorzDist((Vector3_local *)&c->v5c, &vd);
+    Matrix4x3_FromRotationY(&data_020a0e68, Vec3_HorzAngle((Vector3_local *)&c->v5c, &vd));
     MulVec3Mat4x3(&v, &data_020a0e68, &res);
     {
         int t;

--- a/src/func_ov085_0212c150.cpp
+++ b/src/func_ov085_0212c150.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Mtx { int w[12]; };
+// @symbol func_ov085_0212c150
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void func_0203c178(void *m, int a, int b, int c);
 extern void MulMat3x3Mat3x3(void *a, void *b, void *c);
@@ -12,8 +15,8 @@ extern "C" void _ZN9ModelAnim6RenderEPK7Vector3(void *self, void *v);
 extern "C" void _ZN9ModelBase12ApplyOpacityEj(void *self, unsigned int a, unsigned int b);
 void func_ov085_0212c150(void *self) {
     char *c = (char *)self;
-    Mtx tmp;
-    tmp = *(Mtx *)(c + 0x31c);
+    Matrix4x3 tmp;
+    tmp = *(Matrix4x3 *)(c + 0x31c);
     *(int *)(c + 0x340) = 0x421800 - *(int *)(c + 0x340);
     func_0203c178(&data_020a0e68, -0x1000, 0x1000, 0x1000);
     MulMat3x3Mat3x3((void *)(c + 0x31c), &data_020a0e68, (void *)(c + 0x31c));
@@ -23,5 +26,5 @@ void func_ov085_0212c150(void *self) {
     _ZN9ModelBase12ApplyOpacityEj((void *)(c + 0x300), 0xff, 0);
     func_02016b24((void *)(c + 0x300), 0x80);
     func_02016acc((void *)(c + 0x300), 0x40);
-    *(Mtx *)(c + 0x31c) = tmp;
+    *(Matrix4x3 *)(c + 0x31c) = tmp;
 }

--- a/src/func_ov085_0212cc18.c
+++ b/src/func_ov085_0212cc18.c
@@ -1,4 +1,8 @@
-int func_ov085_0212cc18(unsigned char *c) {
+// @symbol func_ov085_0212cc18
+// @emits Rabbit_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daMip_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Rabbit_OnYoshiTryEat(unsigned char *c) {
   unsigned char v = c[0x107];
   if (v != 0) return 0;
   return 7;

--- a/src/func_ov085_0212cd80.c
+++ b/src/func_ov085_0212cd80.c
@@ -1,20 +1,24 @@
-struct Vector3 { int x, y, z; };
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+// @symbol func_ov085_0212cd80
+// @emits Rabbit_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_Message.h"
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daMip_c::Kill - recovered from vtable slot identity */
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 extern int ApproachLinear(int* ref, int target, int step);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int f, unsigned char g);
 extern void func_02012790(int a);
-extern void _ZN7Message13DisplaySavingEt(unsigned short a);
-extern void func_ov085_0212cd0c(void* self);
 extern void StartMinigameMenu(unsigned char a);
 extern void _ZN7Message7EndTalkEv(void);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* actor, unsigned int msg, const void* pos, unsigned int a, unsigned int b);
-extern int _ZN6Player18HasFinishedTalkingEv(void* p);
 
 extern unsigned char data_0209d684;
 extern unsigned char data_0209d660;
 
-int func_ov085_0212cd80(char* self)
+int Rabbit_Kill(char* self)
 {
     char* other = *(char**)(self + 0x18c);
     volatile struct Vector3 v;

--- a/src/func_ov085_0212d2b8.cpp
+++ b/src/func_ov085_0212d2b8.cpp
@@ -1,21 +1,24 @@
 //cpp
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int w[12]; };
-extern "C" Mtx43 data_020a0e68;
-extern "C" void Vec3_Asr(Vec3* d, Vec3* s, int sh);
-extern "C" void Matrix4x3_FromTranslation(Mtx43* m, int x, int y, int z);
+// @symbol func_ov085_0212d2b8
+/* recovered: shared common types */
+#include "common.h"
+
+
+extern "C" Matrix4x3 data_020a0e68;
+extern "C" void Vec3_Asr(Vector3* d, Vector3* s, int sh);
+extern "C" void Matrix4x3_FromTranslation(Matrix4x3* m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, int x, int y, int z);
 extern "C" void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
     void *thiz, void *sm, void *mtx, int f, int t, unsigned int u);
 
 extern "C" void func_ov085_0212d2b8(char *thiz)
 {
-    Vec3 v;
-    Vec3_Asr(&v, (Vec3*)(thiz + 0x5c), 3);
+    Vector3 v;
+    Vec3_Asr(&v, (Vector3*)(thiz + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(thiz + 0x8c), *(short*)(thiz + 0x8e), *(short*)(thiz + 0x90));
-    *(Mtx43*)(thiz + 0x12c) = data_020a0e68;
+    *(Matrix4x3*)(thiz + 0x12c) = data_020a0e68;
     Matrix4x3_FromTranslation(&data_020a0e68,
         *(int*)(thiz + 0x5c) >> 3,
         (*(int*)(thiz + 0x60) - 0x32000) >> 3,

--- a/src/func_ov085_0212db04.cpp
+++ b/src/func_ov085_0212db04.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov085_0212db04
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, Vector3* v);


### PR DESCRIPTION
Batch 14 of the readable-tree migration. Promotes 190 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 153 VERIFIED, 37 BLIND, 0 WRONG/NO-REPRO. 0 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
