### PR TITLE
readable: batch 15 - promote 155 files to readable form

### DIFF
--- a/src/func_ov085_0212ddc4.cpp
+++ b/src/func_ov085_0212ddc4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov085_0212ddc4
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN6Camera9SetFlag_3Ev(void* cam);
 extern void _ZN6Camera9SetLookAtERK7Vector3(void* cam, Vector3* v);

--- a/src/func_ov085_0212df84.cpp
+++ b/src/func_ov085_0212df84.cpp
@@ -1,8 +1,12 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov085_0212df84
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void*);
-extern "C" void func_ov002_020d228c(void*);
 extern "C" void _ZN6Camera9SetFlag_3Ev(void*);
 extern "C" void _ZN6Camera9SetLookAtERK7Vector3(void*, const Vector3*);
 extern "C" void _ZN6Camera6SetPosERK7Vector3(void*, const Vector3*);

--- a/src/func_ov085_0212e19c.c
+++ b/src/func_ov085_0212e19c.c
@@ -1,19 +1,22 @@
+// @symbol func_ov085_0212e19c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
+
 
 extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void* c);
 extern void _Z14ApproachLinearRsss(s16* p, s16 a, s16 b);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* ab, unsigned int id, const struct Vector3* v, unsigned int a, unsigned int b);
 extern void func_02012790(int x);
 extern int _ZN6Player12GetTalkStateEv(void* self);
-extern int func_ov085_0212e728(void* c, void* p);
 
 extern unsigned char data_0209d6bc;
 extern unsigned char data_0209f284;
-extern int data_ov085_02130830[];
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 int func_ov085_0212e19c(char* c)
 {

--- a/src/func_ov085_0212e310.cpp
+++ b/src/func_ov085_0212e310.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov085_0212e310
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-typedef struct { int x, y, z; } Vector3;
-struct Matrix4x3 { int m[12]; };
+
 
 extern void *_ZN5Actor13ClosestPlayerEv(void);
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int fix, bool loop);
@@ -12,10 +16,8 @@ extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(Vector3 *cur, const Vector3
 extern short Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);
 extern void _Z14ApproachLinearRsss(short *cur, short tgt, short step);
 extern int Vec3_Dist(const Vector3 *a, const Vector3 *b);
-extern int func_ov085_0212e728(void *c, void *p);
 
 extern struct Matrix4x3 data_020a0e68;
-extern char data_ov085_02130810[];
 
 int func_ov085_0212e310(char *c)
 {

--- a/src/func_ov085_0212e480.c
+++ b/src/func_ov085_0212e480.c
@@ -1,4 +1,8 @@
-int func_ov085_0212e480(char *p)
+// @symbol func_ov085_0212e480
+// @emits RabbitKey_Kill
+/* recovered: renamed to Class_Method */
+/* daObj_Mip_Key_c::Kill - recovered from vtable slot identity */
+int RabbitKey_Kill(char *p)
 {
     *(int *)(p + 0x64) = 2457600;
     *(int *)(p + 0x2c8) = 0;

--- a/src/func_ov085_0212e858.c
+++ b/src/func_ov085_0212e858.c
@@ -1,45 +1,48 @@
+// @symbol func_ov085_0212e858
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
 
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int m[12]; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
-extern void Matrix4x3_FromTranslation(struct Mtx43* m, int x, int y, int z);
+
+
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
+extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, int x, int y, int z);
 extern int _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void *self, void *sm, void *mtx, int fix, int t, u32 u);
 extern void* _ZN5Actor13ClosestPlayerEv(void *self);
-extern Fix12i Vec3_HorzDist(const struct Vec3* a, const struct Vec3* b);
-extern short Vec3_HorzAngle(const struct Vec3* v0, const struct Vec3* v1);
+extern Fix12i Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);
+extern short Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
-extern void MulVec3Mat4x3(const struct Vec3* v, const struct Mtx43* m, struct Vec3* res);
+extern void MulVec3Mat4x3(const struct Vector3* v, const struct Matrix4x3* m, struct Vector3* res);
 extern void func_ov002_020e4374(char* c, int* p1, int* p2);
 
 extern signed char data_0209f2f8;
-extern struct Mtx43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov085_0212e858(char *c)
 {
-    struct Vec3 p;
-    struct Vec3 z1;
-    struct Vec3 off;
-    struct Vec3 pp;
-    struct Vec3 t;
+    struct Vector3 p;
+    struct Vector3 z1;
+    struct Vector3 off;
+    struct Vector3 pp;
+    struct Vector3 t;
     char *pl;
     int p1, p2;
     signed char lvl;
-    struct Vec3 *ps;
+    struct Vector3 *ps;
 
-    Vec3_Asr(&t, (struct Vec3*)(c + 0x5c), 3);
+    Vec3_Asr(&t, (struct Vector3*)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, t.x, t.y, t.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68, *(short*)(c + 0x8c), *(short*)(c + 0x8e), *(short*)(c + 0x90));
-    *(struct Mtx43*)(c + 0x12c) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x12c) = data_020a0e68;
 
     Matrix4x3_FromTranslation(&data_020a0e68,
         *(int*)(c + 0x5c) >> 3,
         (*(int*)(c + 0x60) - 0x38000) >> 3,
         *(int*)(c + 0x64) >> 3);
-    *(struct Mtx43*)(c + 0x240) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x240) = data_020a0e68;
 
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0x1f0, c + 0x240, 0x46000, 0x258000, 0xf);
 
@@ -57,7 +60,7 @@ void func_ov085_0212e858(char *c)
     off.x = 0;
     off.y = 0;
     off.z = 0;
-    ps = (struct Vec3*)(((long long)(int)(pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    ps = (struct Vector3*)(((long long)(int)(pl + 0x5c)));
     pp.x = ps->x;
     pp.y = ps->y;
     pp.z = ps->z;
@@ -83,6 +86,6 @@ void func_ov085_0212e858(char *c)
 
     func_ov002_020e4374(pl, &p1, &p2);
 
-    *(struct Mtx43*)(c + 0x270) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x270) = data_020a0e68;
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(c, c + 0x218, c + 0x270, p2, p1, 0xf);
 }

--- a/src/func_ov089_021311c0.c
+++ b/src/func_ov089_021311c0.c
@@ -1,24 +1,27 @@
+// @symbol func_ov089_021311c0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-#define L(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define L(p) ((long long)(int)(p))
 
-struct V3 { int x, y, z; };
+
 
 extern char *data_0209f318;
 extern int data_0209b454;
-extern int data_0209b490;
 extern char data_020a0e68;
 extern void _ZN6Camera9SetFlag_3Ev(char *cam);
-extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct V3 *v);
+extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct Vector3 *v);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 a, int b);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 a, void *v);
 extern int Vec3_HorzDist(const void *a, const void *b);
 extern short Vec3_HorzAngle(const void *a, const void *b);
 extern void _ZN7Message7EndTalkEv(void);
 extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(void *a, void *b, int c);
-extern void Vec3_ApproachHorz(void *a, void *b, int c);
 extern char *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_ov089_02131dcc(char *c, char *p);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
@@ -32,9 +35,9 @@ extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 
 void func_ov089_021311c0(char *c)
 {
-    struct V3 v;
-    struct V3 z1;
-    struct V3 z2;
+    struct Vector3 v;
+    struct Vector3 z1;
+    struct Vector3 z2;
     char *cam = data_0209f318;
 
     switch (*(u8 *)(c + 0x442)) {
@@ -93,7 +96,7 @@ void func_ov089_021311c0(char *c)
         v.z = *(int *)(c + 0x64);
         v.y = v.y + 0x64000;
         _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(c + 0x434, &v, 0x28000);
-        _ZN6Camera9SetLookAtERK7Vector3(cam, (struct V3 *)(c + 0x434));
+        _ZN6Camera9SetLookAtERK7Vector3(cam, (struct Vector3 *)(c + 0x434));
         z2.x = 0;
         z2.y = 0;
         z2.z = 0;

--- a/src/func_ov089_0213162c.c
+++ b/src/func_ov089_0213162c.c
@@ -1,20 +1,23 @@
+// @symbol func_ov089_0213162c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-#define L(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define L(p) ((long long)(int)(p))
 
-struct V3 { int x, y, z; };
+
 
 extern char *data_0209f318;
 extern int data_0209b454;
-extern int data_02111b68;
 extern void func_020383fc(char *p);
 extern void _ZN6Camera9SetFlag_3Ev(char *cam);
-extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct V3 *v);
-extern void _ZN6Camera6SetPosERK7Vector3(char *cam, struct V3 *v);
+extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct Vector3 *v);
+extern void _ZN6Camera6SetPosERK7Vector3(char *cam, struct Vector3 *v);
 extern char *_ZN5Actor13ClosestPlayerEv(char *c);
-extern void func_ov089_02130fb4(char *c, int *p, int n);
 extern int Vec3_HorzDist(const void *a, const void *b);
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(char *p);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(char *p);
@@ -28,7 +31,7 @@ extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 
 void func_ov089_0213162c(char *c)
 {
-    struct V3 v;
+    struct Vector3 v;
     int p[3];
     char *cam = data_0209f318;
 
@@ -153,8 +156,8 @@ void func_ov089_0213162c(char *c)
         *tm = *tm + 1;
         if (*tm < 0x1e)
             return;
-        _ZN6Camera9SetLookAtERK7Vector3(cam, (struct V3 *)(c + 0x44c));
-        _ZN6Camera6SetPosERK7Vector3(cam, (struct V3 *)(c + 0x458));
+        _ZN6Camera9SetLookAtERK7Vector3(cam, (struct Vector3 *)(c + 0x44c));
+        _ZN6Camera6SetPosERK7Vector3(cam, (struct Vector3 *)(c + 0x458));
         cf = (int *)(int)L(cam + 0x154);
         *cf &= ~8;
         b0 = (int *)(int)L(c + 0xb0);

--- a/src/func_ov089_02131b18.c
+++ b/src/func_ov089_02131b18.c
@@ -1,16 +1,19 @@
+// @symbol func_ov089_02131b18
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-#define L(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define L(p) ((long long)(int)(p))
 
-struct V3 { int x, y, z; };
+
 
 extern void func_020383fc(char *p);
 extern char *data_0209f318;
 extern int data_0209b454;
 extern void _ZN6Camera9SetFlag_3Ev(char *cam);
-extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct V3 *v);
-extern void _ZN6Camera6SetPosERK7Vector3(char *cam, struct V3 *v);
+extern void _ZN6Camera9SetLookAtERK7Vector3(char *cam, struct Vector3 *v);
+extern void _ZN6Camera6SetPosERK7Vector3(char *cam, struct Vector3 *v);
 extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 a, u32 b, int c, int d, int e, void *f, void *g);
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(char *p);
@@ -22,7 +25,7 @@ extern void func_ov089_02131df4(char *thiz, char *player);
 void func_ov089_02131b18(char *c)
 {
     char *cam = data_0209f318;
-    struct V3 v;
+    struct Vector3 v;
     u8 st;
 
     func_020383fc(c + 0x260);
@@ -82,8 +85,8 @@ case1:
     }
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x260) == 0)
         return;
-    _ZN6Camera9SetLookAtERK7Vector3(cam, (struct V3 *)(int)L(c + 0x44c));
-    _ZN6Camera6SetPosERK7Vector3(cam, (struct V3 *)(int)L(c + 0x458));
+    _ZN6Camera9SetLookAtERK7Vector3(cam, (struct Vector3 *)(int)L(c + 0x44c));
+    _ZN6Camera6SetPosERK7Vector3(cam, (struct Vector3 *)(int)L(c + 0x458));
     {
         int *cf = (int *)(int)L(cam + 0x154);
         int *b0 = (int *)(int)L(c + 0xb0);

--- a/src/func_ov089_02131f04.cpp
+++ b/src/func_ov089_02131f04.cpp
@@ -1,8 +1,12 @@
 //cpp
+// @symbol func_ov089_02131f04
+// @emits Key_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daObjKey_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int func_ov089_02131df4(void *c, int a);
 extern int func_ov089_02131dcc(void *c, int a);
-int func_ov089_02131f04(char *c, int a){
+int Key_OnTurnIntoEgg(char *c, int a){
   int h=*(unsigned short*)(c+0xc); int eq; if(h==0x11a) eq=1; else eq=0;
   if(eq) return func_ov089_02131df4(c,a); return func_ov089_02131dcc(c,a);
 }

--- a/src/func_ov089_02131f4c.c
+++ b/src/func_ov089_02131f4c.c
@@ -1,4 +1,8 @@
-int func_ov089_02131f4c(void)
+// @symbol func_ov089_02131f4c
+// @emits Key_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daObjKey_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Key_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov089_02131f54.cpp
+++ b/src/func_ov089_02131f54.cpp
@@ -1,10 +1,13 @@
 //cpp
+// @symbol func_ov089_02131f54
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void Matrix4x3_FromRotationY(void* m, short angle);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* a, void* sm, void* mtx, int rad, int h, unsigned int x);
 
-struct M48 { int w[12]; };
-extern M48 data_02082128;
+
+extern Matrix4x3 data_02082128;
 extern char data_ov089_021328b4[];
 extern int data_ov002_02110964;
 
@@ -20,7 +23,7 @@ void func_ov089_02131f54(void* c){
     *(int*)(r4+0x1bc)=(*(int*)(r4+0x60)+0x64000)>>3;
     *(int*)(r4+0x1c0)=*(int*)(r4+0x64)>>3;
   }
-  *(M48*)(r4+0x1f0)=data_02082128;
+  *(Matrix4x3*)(r4+0x1f0)=data_02082128;
   *(int*)(r4+0x214)=*(int*)(r4+0x5c)>>3;
   *(int*)(r4+0x218)=*(int*)(r4+0x60)>>3;
   *(int*)(r4+0x21c)=*(int*)(r4+0x64)>>3;

--- a/src/func_ov090_02130f94.c
+++ b/src/func_ov090_02130f94.c
@@ -1,12 +1,15 @@
+// @symbol func_ov090_02130f94
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
-struct Mtx { int w[12]; };
-struct Vector3 { int x, y, z; };
-extern void MulMat4x3Mat4x3(struct Mtx* out, struct Mtx* a, struct Mtx* b);
+
+
+extern void MulMat4x3Mat4x3(struct Matrix4x3* out, struct Matrix4x3* a, struct Matrix4x3* b);
 extern void Vec3_Lsl(struct Vector3* out, const struct Vector3* in, int n);
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a0, unsigned int a1, int a2, int a3, int a4, int a5, int a6);
-extern struct Mtx data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov090_02130f94(char* c_)
 {
@@ -14,7 +17,7 @@ void func_ov090_02130f94(char* c_)
     int sh;
     char* c;
     int i;
-    struct Mtx* src;
+    struct Matrix4x3* src;
     int idx;
     int b;
     unsigned int id;
@@ -23,7 +26,7 @@ void func_ov090_02130f94(char* c_)
     b = (int)((*(int*)(c + 0xb0) & 8) != 0);
     if (b != 0) return;
 
-    src = (struct Mtx*)(c + 0x328);
+    src = (struct Matrix4x3*)(c + 0x328);
     i = 0;
     idx = 6;
     zero = 0;
@@ -34,7 +37,7 @@ void func_ov090_02130f94(char* c_)
         struct Vector3 r;
 
         data_020a0e68 = *src;
-        MulMat4x3Mat4x3((struct Mtx*)*(void**)(c + 0x320) + idx, &data_020a0e68, &data_020a0e68);
+        MulMat4x3Mat4x3((struct Matrix4x3*)*(void**)(c + 0x320) + idx, &data_020a0e68, &data_020a0e68);
         v.x = *(int*)((char*)&data_020a0e68 + 0x24);
         v.y = *(int*)((char*)&data_020a0e68 + 0x28);
         v.z = *(int*)((char*)&data_020a0e68 + 0x2c);

--- a/src/func_ov090_02131e50.c
+++ b/src/func_ov090_02131e50.c
@@ -1,8 +1,11 @@
+// @symbol func_ov090_02131e50
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov090_02131e50(char *c) {
     int src[3];
     int dst[3];
@@ -13,5 +16,5 @@ void func_ov090_02131e50(char *c) {
     Matrix4x3_FromTranslation(&data_020a0e68, dst[0], dst[1], dst[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x328) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x328) = data_020a0e68;
 }

--- a/src/func_ov090_02132618.c
+++ b/src/func_ov090_02132618.c
@@ -1,4 +1,8 @@
-int func_ov090_02132618(void)
+// @symbol func_ov090_02132618
+// @emits Skeeter_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daMenbo_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Skeeter_OnAimedAtWithEgg(void)
 {
     return 131072;
 }

--- a/src/func_ov090_02132620.cpp
+++ b/src/func_ov090_02132620.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov090_02132620
+// @emits Skeeter_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daMenbo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 class Player;
 
 class Actor {
@@ -7,7 +11,7 @@ void GivePlayerCoins(Player &player, unsigned char count, unsigned int unknown);
 void KillAndTrackInDeathTable();
 };
 
-extern "C" void func_ov090_02132620(char *c, void *player) {
+extern "C" void Skeeter_OnTurnIntoEgg(char *c, void *player) {
 Actor *r4 = (Actor *)c;
 unsigned char r2 = ((unsigned char *)r4)[0x10a];
 r4->GivePlayerCoins(*(Player *)player, r2 + 1, 0);

--- a/src/func_ov090_0213264c.c
+++ b/src/func_ov090_0213264c.c
@@ -1,4 +1,8 @@
-int func_ov090_0213264c(void)
+// @symbol func_ov090_0213264c
+// @emits Skeeter_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daMenbo_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Skeeter_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov090_02132730.cpp
+++ b/src/func_ov090_02132730.cpp
@@ -1,6 +1,11 @@
 //cpp
+// @symbol func_ov090_02132730
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 struct MovingCylinderClsnWithPos { int d; };
 struct Actor;
 struct Player;
@@ -11,7 +16,6 @@ extern "C" Player* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(
     Player*, const Vector3&, unsigned int, Fix12i, unsigned int, unsigned int, unsigned int);
 
-extern Vector3 data_ov090_02134200;
 
 extern "C" void func_ov090_02132730(char* thiz)
 {

--- a/src/func_ov090_021327e4.cpp
+++ b/src/func_ov090_021327e4.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov090_021327e4
+// @emits Skeeter_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daMenbo_c::Kill - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -15,7 +19,7 @@ void func_02012790(u32 a);
 void* _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(void* self, const Vector3& v, u32 n, int b, u16 t, void* p);
 }
 
-extern "C" int func_ov090_021327e4(char* c)
+extern "C" int Skeeter_Kill(char* c)
 {
     void* o;
     Vector3 num1;
@@ -33,7 +37,7 @@ extern "C" int func_ov090_021327e4(char* c)
                 *(signed char*)(c + 0xcc), -1);
         if (o != 0) {
             int idx = *(int*)(c + 0x3fc);
-            int* pf = (int*)((((long long)(int)(c + 0x3fc)) & 0xFFFFFFFFFFFFFFFFLL));
+            int* pf = (int*)((((long long)(int)(c + 0x3fc))));
             *(int*)(c + idx * 4 + 0x3ac) = *(int*)((char*)o + 4);
             *pf += 1;
             if (*(int*)(c + 0x3fc) >= 0x14)
@@ -53,9 +57,9 @@ extern "C" int func_ov090_021327e4(char* c)
             int slot = ((int*)(c + 0x3ac))[i];
             if ((0, slot) == key) {
                 *(int*)(c + 0x400) = i;
-                *(int*)((((long long)(int)(c + 0x378)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+                *(int*)((((long long)(int)(c + 0x378)))) += 1;
                 func_02012790(0x25);
-                num1 = *(Vector3*)((((long long)(int)((char*)*(void**)(c + 0x3a8) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));
+                num1 = *(Vector3*)((((long long)(int)((char*)*(void**)(c + 0x3a8) + 0x5c))));
                 _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(c, num1, *(int*)(c + 0x378), 0, 0, 0);
                 *(int*)(c + 0x3a8) = 0;
                 return 1;
@@ -63,7 +67,7 @@ extern "C" int func_ov090_021327e4(char* c)
         }
         goto Lreset;
     } else {
-        *(int*)((((long long)(int)(c + 0x400)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+        *(int*)((((long long)(int)(c + 0x400)))) += 1;
         if (*(int*)(c + 0x400) >= 0x14)
             *(int*)(c + 0x400) = 0;
         {
@@ -75,9 +79,9 @@ extern "C" int func_ov090_021327e4(char* c)
             if (r0 != r1)
                 goto Lreset;
         }
-        *(int*)((((long long)(int)(c + 0x378)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+        *(int*)((((long long)(int)(c + 0x378)))) += 1;
         func_02012790(0x25);
-        num2 = *(Vector3*)((((long long)(int)((char*)*(void**)(c + 0x3a8) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL));
+        num2 = *(Vector3*)((((long long)(int)((char*)*(void**)(c + 0x3a8) + 0x5c))));
         _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(c, num2, *(int*)(c + 0x378), 0, 0, 0);
         *(int*)(c + 0x3a8) = 0;
         return 1;
@@ -89,7 +93,7 @@ Lreset:
     *(int*)(c + 0x3a8) = 0;
 Ldecay:
     if (*(int*)(c + 0x378) == 5) {
-        *(int*)((((long long)(int)(c + 0x38c)) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+        *(int*)((((long long)(int)(c + 0x38c)))) += 1;
         if (*(int*)(c + 0x38c) > 0x1e) {
             _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
                 0xb2, *(int*)(c + 0x388) | 0x40, *(Vector3*)(c + 0x5c),

--- a/src/func_ov090_02132b14.c
+++ b/src/func_ov090_02132b14.c
@@ -1,10 +1,13 @@
+// @symbol func_ov090_02132b14
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern void MulMat4x3Mat4x3(struct Mtx43* dst, struct Mtx43* a, struct Mtx43* b);
@@ -12,8 +15,8 @@ extern void MulMat4x3Mat4x3(struct Mtx43* dst, struct Mtx43* a, struct Mtx43* b)
 extern struct Mtx43 data_020a0e68;
 
 void func_ov090_02132b14(char* self){
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3*)(self + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3*)(self + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(s16*)(self + 0x8c), *(s16*)(self + 0x8e), *(s16*)(self + 0x90));

--- a/src/func_ov090_021330c8.cpp
+++ b/src/func_ov090_021330c8.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov090_021330c8
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
+
 struct MovingCylinderClsnWithPos { int d; };
 struct Player;
 

--- a/src/func_ov090_02133200.c
+++ b/src/func_ov090_02133200.c
@@ -1,3 +1,9 @@
+// @symbol func_ov090_02133200
+// @emits MantaRay_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daManta_c::Kill - recovered from vtable slot identity */
 typedef unsigned int u32;
 typedef unsigned short u16;
 typedef short s16;
@@ -8,9 +14,8 @@ extern s16 Vec3_HorzAngle(void* a, void* b);
 extern int ApproachAngle(s16* angle, int target, int invFactor, int maxDelta, int minDelta);
 extern int func_ov090_021332e8(void* c, void* p);
 
-extern int data_ov090_02134584[];
 
-int func_ov090_02133200(char* c)
+int MantaRay_Kill(char* c)
 {
     if (Vec3_Dist(c + 0x5c, c + 0x374) > 0x3e8000) {
         *(u16*)(c + 0x100) = 0x32;

--- a/src/func_ov090_02133338.c
+++ b/src/func_ov090_02133338.c
@@ -1,13 +1,16 @@
+// @symbol func_ov090_02133338
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov090_02133338(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x328) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x328) = data_020a0e68;
 }

--- a/src/func_ov090_02133710.cpp
+++ b/src/func_ov090_02133710.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov090_02133710
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* out, void* m, void* in);
@@ -6,11 +9,11 @@ extern void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(voi
 extern void* _ZN5Actor10FindWithIDEj(unsigned int);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void*, void*, unsigned int, int, unsigned int, unsigned int, unsigned int);
 extern int data_020a0e68[];
-struct V3 { int x, y, z; };
+
 
 void func_ov090_02133710(char* c) {
-    struct V3 v;
-    struct V3 v2;
+    struct Vector3 v;
+    struct Vector3 v2;
     void* a;
     *(int*)(((int)c + 0x384) & 0xFFFFFFFFFFFFFFFF) += 1;
     if (*(int*)(c + 0x384) > 2) *(int*)(c + 0x384) = 0;

--- a/src/func_ov090_0213387c.c
+++ b/src/func_ov090_0213387c.c
@@ -1,6 +1,10 @@
+// @symbol func_ov090_0213387c
+// @emits CheepCheep_Kill
+/* recovered: renamed to Class_Method */
+/* daPukupuku_c::Kill - recovered from vtable slot identity */
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* anim, void* file, int a, int b, unsigned int u);
 extern int data_ov090_021345ac[];
-int func_ov090_0213387c(char *c) {
+int CheepCheep_Kill(char *c) {
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x30c, *(void**)((char*)data_ov090_021345ac+4), 0, 0x1000, 0);
     return 1;
 }

--- a/src/func_ov090_02133904.c
+++ b/src/func_ov090_02133904.c
@@ -1,13 +1,16 @@
+// @symbol func_ov090_02133904
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov090_02133904(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x328) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x328) = data_020a0e68;
 }

--- a/src/func_ov091_02131070.cpp
+++ b/src/func_ov091_02131070.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov091_02131070
+// @emits RotatingUpDownPlatformUtm_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjRotateUpdownLift_c::Kill - recovered from vtable slot identity */
 extern "C" {
 struct Vector3 { int x,y,z; };
 }
@@ -6,7 +10,7 @@ namespace Particle { struct System { static System* NewSimple(unsigned int, int,
 struct Actor { void PoofDustAt(const Vector3&); };
 namespace Sound { void PlayBank3(unsigned int, const Vector3&); }
 struct MeshColliderBase { int IsEnabled(); void Disable(); };
-extern "C" void func_ov091_02131070(char* c){
+extern "C" void RotatingUpDownPlatformUtm_Kill(char* c){
     Particle::System::NewSimple(0xbb, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
     Vector3 v = { *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64) };
     ((Actor*)c)->PoofDustAt(v);

--- a/src/func_ov091_021310fc.cpp
+++ b/src/func_ov091_021310fc.cpp
@@ -1,9 +1,14 @@
 //cpp
+// @symbol func_ov091_021310fc
+// @emits RotatingUpDownPlatformUtm_OnHitByMegaChar
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Platform.h"
+/* recovered: renamed to Class_Method */
+/* daObjRotateUpdownLift_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void func_02012694(int a, void* b);
-extern void _ZN8Platform14KillByMegaCharER6Player(void* self, void* p);
-void func_ov091_021310fc(char* self, void* p){
+void RotatingUpDownPlatformUtm_OnHitByMegaChar(char* self, void* p){
   unsigned short h = *(unsigned short*)(self+0xc);
   int eq = (h == 0x1e);
   if(eq) return;

--- a/src/func_ov091_02132000.c
+++ b/src/func_ov091_02132000.c
@@ -1,5 +1,8 @@
-struct Vector3 { int x, y, z; };
-extern void func_ov091_02131cb0(void *c, const struct Vector3 *v0, const struct Vector3 *v1);
+// @symbol func_ov091_02132000
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 
 void func_ov091_02132000(char *c)
 {

--- a/src/func_ov091_02132a0c.c
+++ b/src/func_ov091_02132a0c.c
@@ -1,4 +1,8 @@
-int func_ov091_02132a0c(void)
+// @symbol func_ov091_02132a0c
+// @emits daDsn_c_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daDsn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int daDsn_c_OnAimedAtWithEgg(void)
 {
     return 843776;
 }

--- a/src/func_ov091_02132d04.c
+++ b/src/func_ov091_02132d04.c
@@ -1,15 +1,17 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov091_02132d04
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
 extern void *G0;
 int *func_ov091_02132d04(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)VT1;

--- a/src/func_ov091_02132d6c.c
+++ b/src/func_ov091_02132d6c.c
@@ -1,13 +1,16 @@
-extern void _ZN11ShadowModelD1Ev(void *);
+// @symbol func_ov091_02132d6c
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void _ZN15TextureSequenceD1Ev(void *);
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
 int *func_ov091_02132d6c(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN11ShadowModelD1Ev((char *)t + 0x338);
     _ZN15TextureSequenceD1Ev((char *)t + 0x324);
     t[0] = (int)VT1;

--- a/src/func_ov091_02132dc0.cpp
+++ b/src/func_ov091_02132dc0.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov091_02132dc0
+/* recovered: shared common types */
+#include "common.h"
+
 struct Actor {
     virtual void f00(); virtual void f01(); virtual void f02(); virtual void f03();
     virtual void f04(); virtual void f05(); virtual void f06(); virtual void f07();

--- a/src/func_ov091_02133098.cpp
+++ b/src/func_ov091_02133098.cpp
@@ -1,15 +1,18 @@
 //cpp
+// @symbol func_ov091_02133098
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
     void* a, void* sm, void* mtx, int f, int t1, int t2, unsigned int x);
-struct M48 { int w[12]; };
+
 void func_ov091_02133098(void* c){
   char* r = (char*)c;
   int off = 0x20000;
   int d = *(int*)(r+0x60) - *(int*)(r+0x394);
   if(d <= 0x14000){ d = 0x14000; off = 0; }
   int rad = (int)(((long long)d * 0x60 + 0x800) >> 12);
-  int* pb8 = (int*)(((int)r + 0xb8) & 0xFFFFFFFFFFFFFFFF);
+  int* pb8 = (int*)(((int)r + 0xb8));
   int v1 = *(int*)(*(char**)(r+0x320)+0x10) - rad;
   if(v1 < 0xa000) v1 = 0xa000;
   int v2 = *(int*)(*(char**)(r+0x320)+0x14) - rad;
@@ -21,7 +24,7 @@ void func_ov091_02133098(void* c){
     *(int*)(r+0xb8) = t;
   }
   *pb8 = *pb8 >> 3;
-  *(M48*)(r+0x360) = *(M48*)(r+0xf0);
+  *(Matrix4x3*)(r+0x360) = *(Matrix4x3*)(r+0xf0);
   *(int*)(r+0x384) = *(int*)(r+0x5c) >> 3;
   *(int*)(r+0x388) = (*(int*)(r+0x60) - off) >> 3;
   *(int*)(r+0x38c) = *(int*)(r+0x64) >> 3;

--- a/src/func_ov091_02133254.cpp
+++ b/src/func_ov091_02133254.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov091_02133254
+/* recovered: shared common types */
+#include "common.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;
@@ -18,10 +21,10 @@ extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File &b, B
 extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, BTP_File *f, int a, int fix, unsigned int u);
 extern "C" int _ZN11ShadowModel10InitCuboidEv(void *self);
 
-struct V3 { int x, y, z; };
+
 struct RaycastGround { char buf[0x44]; int f44; char rest[8]; };
 extern "C" void _ZN13RaycastGroundC1Ev(RaycastGround *self);
-extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround *self, V3 *v, void *a);
+extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(RaycastGround *self, Vector3 *v, void *a);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(RaycastGround *self);
 extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround *self);
 
@@ -30,7 +33,7 @@ extern void *_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Ve
 extern "C" int func_ov091_02133254(char *self)
 {
     RaycastGround rg;
-    V3 v;
+    Vector3 v;
     BMD_File *bmd;
     KCL_File *kcl;
     void **p320;

--- a/src/func_ov091_021333fc.c
+++ b/src/func_ov091_021333fc.c
@@ -1,12 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov091_021333fc
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV11daObjPile_c; VT1 = _ZTV10dBgActor_c */
 int *func_ov091_021333fc(int *t)
 {
-    t[0] = (int)VT0;
-    t[0] = (int)VT1;
+    t[0] = (int)_ZTV11daObjPile_c;
+    t[0] = (int)_ZTV10dBgActor_c;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);

--- a/src/func_ov091_02133440.c
+++ b/src/func_ov091_02133440.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov091_02133440
+// @emits daObjPile_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daObjPile_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov091_02133440(int *t)
+int *daObjPile_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov091_021334b8.cpp
+++ b/src/func_ov091_021334b8.cpp
@@ -1,11 +1,15 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov091_021334b8
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
 extern "C" int _ZN5Actor18GetBitInDeathTableEv(void *c);
 extern "C" void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(void *c, Vector3 const &v, unsigned int n, int f, short s);
-extern "C" void _ZN5Actor17TrackInDeathTableEv(void *c);
-extern "C" void func_ov091_02133498(char *c);
 
 extern "C" void func_ov091_021334b8(char *c, int flag)
 {

--- a/src/func_ov091_021335d4.c
+++ b/src/func_ov091_021335d4.c
@@ -1,8 +1,12 @@
+// @symbol func_ov091_021335d4
+// @emits daObjPile_c_OnHitByMegaChar
+/* recovered: renamed to Class_Method */
+/* daObjPile_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void _ZN5Actor8PoofDustEv(void*);
 extern int func_02012694(int a, void* b);
 extern int func_ov091_021334b8(void* self, int b);
-void func_ov091_021335d4(char* self, void* arg)
+void daObjPile_c_OnHitByMegaChar(char* self, void* arg)
 {
     if (*(unsigned char*)(self + 0x320)) return;
     if (arg == 0) return;

--- a/src/func_ov091_02133648.cpp
+++ b/src/func_ov091_02133648.cpp
@@ -1,11 +1,18 @@
 //cpp
+// @symbol func_ov091_02133648
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjPile_c.h"
+// @emits daObjPile_c_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjPile_c::OnGroundPounded - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
 extern void func_ov091_021334b8(void* c, int f);
-void func_ov091_02133648(char* c, void* arg){
+void daObjPile_c_OnGroundPounded(char* c, void* arg){
+    struct daObjPile_c *self = (struct daObjPile_c *)(void *)c;
   if(arg==0) return;
-  if(*(unsigned char*)(c+0x31e)==0) return;
-  if(*(unsigned char*)(c+0x31f)) return;
+  if(self->unk_31e==0) return;
+  if(self->unk_31f) return;
   _ZN5Sound9PlayBank3EjRK7Vector3(0x62, c+0x74);
   int f = 0;
   if(*(int*)((char*)arg+8)==2) goto set;

--- a/src/func_ov091_021336cc.c
+++ b/src/func_ov091_021336cc.c
@@ -1,9 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov091_021336cc
+// @emits daObjPile_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjPile_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-int func_ov091_021336cc(void *t)
+int daObjPile_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov091_02133710.cpp
+++ b/src/func_ov091_02133710.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov091_02133710
+// @emits daObjPile_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjPile_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int func_ov091_02133710(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int daObjPile_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov091_021338ac.c
+++ b/src/func_ov091_021338ac.c
@@ -1,3 +1,11 @@
+// @symbol func_ov091_021338ac
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjPile_c.h"
+// @emits daObjPile_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daObjPile_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);
@@ -5,16 +13,14 @@ extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,Fix12,short,void*);
-extern int data_ov091_02135654[];
-extern int data_ov091_0213564c[];
-extern int data_ov002_0210d874[];
-int func_ov091_021338ac(char* c){
+int daObjPile_c_InitResources(char* c){
+    struct daObjPile_c *self = (struct daObjPile_c *)(void *)c;
   int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov091_02135654);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   int k = _ZN12MeshCollider8LoadFileER13SharedFilePtr(data_ov091_0213564c);
-  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, *(short*)(c+0x8e), (void*)data_ov002_0210d874);
-  *(unsigned char*)(c+0x31e) = 3;
+  _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c+0x124, k, c+0x2ec, 0x199, self->unk_08e, (void*)data_ov002_0210d874);
+  self->unk_31e = 3;
   return 1;
 }

--- a/src/func_ov091_021339fc.c
+++ b/src/func_ov091_021339fc.c
@@ -1,22 +1,28 @@
+// @symbol func_ov091_021339fc
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Enemy.h"
+#include "decl_Player.h"
+#include "decl_SaveData.h"
+/* recovered: shared common types */
+#include "common.h"
+// NONMATCHING: hand-written asm, not a C decompilation. Byte-exact via an asm hatch on a
+// proven mwccarm 1.2 register-allocation/scheduling wall; does NOT count as matched. Reverts
+// to a draft until someone reproduces the bytes from real C.
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_020aea30(void *c, void *a, u32 unused);
 extern void _ZN5Actor8PoofDustEv(void *a);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *a);
-extern void _ZN5Enemy22SpawnMegaCharParticlesER5ActorPc(void *self, void *a, char *nullArg);
 extern void _ZN6Player16IncMegaKillCountEv(void *p);
 extern void func_02012694(int a, void *p);
 extern int _ZN6Player15IsCollectingCapEv(void *p);
-extern void _ZN6Player8BlowAwayEs(void *p, short a);
 extern void _ZN6Player18SetNewHatCharacterEjjb(void *p, u32 a, u32 b, u32 c2);
-extern int _ZN8SaveData16HasPlayerLostCapEv(void);
-extern void _ZN8SaveData13PlayerLoseCapEv(void);
-extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 flags, struct Vec3 *pos, short *rot, int a, int b);
+extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 flags, struct Vector3 *pos, short *rot, int a, int b);
 
 void func_ov091_021339fc(char *c)
 {
@@ -69,9 +75,11 @@ void func_ov091_021339fc(char *c)
         if (*(u8*)(a + 0x6ff) != 0) return;
         if (*(u8*)(a + 0x6fd) != 0) return;
         {
-        u32 param, curHat0;
-        curHat0 = *(u32*)(a + 8);
-        param = 1;
+        u32 newHat, curHat0;
+        asm {
+            ldr curHat0, [a, #8]
+            mov newHat, #1
+        }
         if (hat != curHat0) {
             _ZN6Player18SetNewHatCharacterEjjb(a, hat, 0, 0);
         } else {
@@ -86,9 +94,8 @@ void func_ov091_021339fc(char *c)
             rot[1] = 0;
             rot[2] = 0;
             rot[1] = *(short*)(c + 0x94);
-            param = param | (curHat1 << 8);
             spawned = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-                0x10d, param, (struct Vec3*)(c + 0x5c), rot, *(signed char*)(c + 0xcc), -1);
+                0x10d, newHat | (curHat1 << 8), (struct Vector3*)(c + 0x5c), rot, *(signed char*)(c + 0xcc), -1);
             if (spawned == 0) return;
             *(u32*)((char*)spawned + 0x98) = 0x32000;
             *(u32*)((char*)spawned + 0xa4) = 0;

--- a/src/func_ov091_02133d30.cpp
+++ b/src/func_ov091_02133d30.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov091_02133d30
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int Fix12i;
 typedef short s16;
 typedef unsigned short u16;
 typedef signed char s8;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
 extern "C" {
 void func_02012694(u32 id, void *pos);
@@ -24,9 +27,9 @@ extern s16 data_02082214[];
 extern int data_0209e650;
 extern void *data_ov091_021356d0;
 
-struct Vector3_16f { s16 x, y, z; };
-struct Vec { Fix12i x, y, z; };
-struct Info { Vector3_16f vec; Vec pos; };
+
+
+struct Info { Vector3_16 vec; Vector3 pos; };
 
 struct Self {
     char pad0[0x5c];
@@ -50,7 +53,7 @@ struct Self {
 extern "C" int func_ov091_02133d30(Self *self)
 {
     Info info;
-    Vec tgt;
+    Vector3 tgt;
     void *spawned;
     void *player;
     s16 ang;

--- a/src/func_ov091_02133f60.c
+++ b/src/func_ov091_02133f60.c
@@ -1,9 +1,10 @@
-struct Vec3 { int x, y, z; };
-
+// @symbol func_ov091_02133f60
+/* recovered: shared common types */
+#include "common.h"
 void *_ZN5Actor13ClosestPlayerEv(void *thiz);
-short Vec3_HorzAngle(const struct Vec3 *a, const struct Vec3 *b);
+short Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
 int ApproachAngle(short *cur, int target, int a, int b, int c);
-int Vec3_Dist(const struct Vec3 *a, const struct Vec3 *b);
+int Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 int func_ov091_02134044(void *c, void *p);
 
 extern char data_ov091_021356b0[];
@@ -11,19 +12,19 @@ extern char data_ov091_021356b0[];
 int func_ov091_02133f60(char *c)
 {
     void *pl = _ZN5Actor13ClosestPlayerEv(c);
-    struct Vec3 v;
+    struct Vector3 v;
     short ang;
-    struct Vec3 *src;
+    struct Vector3 *src;
     if (pl == 0) goto done;
 
-    src = (struct Vec3*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    src = (struct Vector3*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFF);
     v.x = src->x;
     v.y = src->y;
     v.z = src->z;
-    ang = Vec3_HorzAngle((struct Vec3*)(c + 0x5c), &v);
+    ang = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &v);
     ApproachAngle((short*)(c + 0x94), ang, 0xa, 0x200, 0x100);
     if (*(unsigned short*)(c + 0x100) != 0) goto done;
-    if (Vec3_Dist((struct Vec3*)(c + 0x5c), &v) >= 0x3e8000) goto done;
+    if (Vec3_Dist((struct Vector3*)(c + 0x5c), &v) >= 0x3e8000) goto done;
     if (ang >= 0x1000) goto done;
     func_ov091_02134044(c, data_ov091_021356b0);
 done:

--- a/src/func_ov091_02134094.c
+++ b/src/func_ov091_02134094.c
@@ -1,13 +1,16 @@
+// @symbol func_ov091_02134094
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_Asr(void *dst, void *src, int n);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, short rx, short ry, short rz);
-struct M { int w[12]; };
-extern struct M data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void func_ov091_02134094(char *c) {
     int v[3];
     Vec3_Asr(v, c+0x5c, 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v[0], v[1], v[2]);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(short*)(c+0x8c), *(short*)(c+0x8e), *(short*)(c+0x90));
-    *(struct M*)(c+0x31c) = data_020a0e68;
+    *(struct Matrix4x3*)(c+0x31c) = data_020a0e68;
 }

--- a/src/func_ov091_02134484.c
+++ b/src/func_ov091_02134484.c
@@ -1,4 +1,8 @@
-int func_ov091_02134484(void)
+// @symbol func_ov091_02134484
+// @emits Stump_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daHyuhyu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Stump_OnAimedAtWithEgg(void)
 {
     return 126976;
 }

--- a/src/func_ov091_0213448c.c
+++ b/src/func_ov091_0213448c.c
@@ -1,8 +1,12 @@
-/* func_ov091_0213448c @ 0x213448c (ov091) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+// @symbol func_ov091_0213448c
+// @emits Stump_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daHyuhyu_c::OnTurnIntoEgg - recovered from vtable slot identity */
+/* Stump_OnTurnIntoEgg @ 0x213448c (ov091) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void func_ov091_0213448c(void) {
+void Stump_OnTurnIntoEgg(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov091_02134498.c
+++ b/src/func_ov091_02134498.c
@@ -1,4 +1,8 @@
-int func_ov091_02134498(void)
+// @symbol func_ov091_02134498
+// @emits Stump_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daHyuhyu_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Stump_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov092_021311b0.cpp
+++ b/src/func_ov092_021311b0.cpp
@@ -1,7 +1,10 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov092_021311b0
+/* recovered: shared common types */
+#include "common.h"
+
 typedef short s16;
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 extern "C" {
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
 int _ZNK12WithMeshClsn8IsOnWallEv(void *self);

--- a/src/func_ov092_021313b0.cpp
+++ b/src/func_ov092_021313b0.cpp
@@ -1,9 +1,12 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol func_ov092_021313b0
+/* recovered: shared common types */
+#include "common.h"
+
 typedef unsigned short u16;
 typedef short s16;
 
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 
 struct PathPtr {
     int GetNode(Vector3 &v, unsigned int i) const;

--- a/src/func_ov092_021315ac.c
+++ b/src/func_ov092_021315ac.c
@@ -1,7 +1,10 @@
-struct Vector3 { int x,y,z; };
+// @symbol func_ov092_021315ac
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, struct Vector3* v, int f);
 extern void func_02012694(int a, void* p);
-extern void func_ov092_02131578(char* c);
 void func_ov092_021315ac(char *c){
   *(int*)(c+0x98)=0;
   if(!*(unsigned short*)(c+0x500+0x64)){

--- a/src/func_ov092_02131a88.cpp
+++ b/src/func_ov092_02131a88.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov092_02131a88
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov092_02131a88(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov092_02131aec.cpp
+++ b/src/func_ov092_02131aec.cpp
@@ -1,23 +1,26 @@
 //cpp
+// @symbol func_ov092_02131aec
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M48 { int w[12]; };
-extern struct M48 data_020a0e68;
+
+extern struct Matrix4x3 data_020a0e68;
 void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
 void Matrix4x3_ApplyInPlaceToRotationZ(void* m, short angZ);
 void Matrix4x3_ApplyInPlaceToRotationY(void* m, short angY);
 void func_ov092_02131aec(void* c){
   char* r4 = (char*)c;
   if(*(unsigned char*)(r4+0x576) != 0){
-    data_020a0e68 = *(struct M48*)(r4+0x528);
+    data_020a0e68 = *(struct Matrix4x3*)(r4+0x528);
     Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(short*)(r4+0x8c));
     Matrix4x3_ApplyInPlaceToRotationZ(&data_020a0e68, *(short*)(r4+0x90));
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(r4+0x8e));
-    *(struct M48*)(r4+0xf0) = data_020a0e68;
+    *(struct Matrix4x3*)(r4+0xf0) = data_020a0e68;
     *(int*)(r4+0x114) = *(int*)(r4+0x5c) >> 3;
     *(int*)(r4+0x118) = *(int*)(r4+0x60) >> 3;
     *(int*)(r4+0x11c) = *(int*)(r4+0x64) >> 3;
   } else {
-    *(struct M48*)(r4+0xf0) = *(struct M48*)(r4+0x528);
+    *(struct Matrix4x3*)(r4+0xf0) = *(struct Matrix4x3*)(r4+0x528);
   }
 }
 }

--- a/src/func_ov094_021358b4.cpp
+++ b/src/func_ov094_021358b4.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol func_ov094_021358b4
+/* recovered: shared common types */
+#include "common.h"
+
 typedef int Fix12;
 typedef unsigned char u8;
 extern "C" {

--- a/src/func_ov094_02135ee0.cpp
+++ b/src/func_ov094_02135ee0.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov094_02135ee0
+/* recovered: shared common types */
+#include "common.h"
+
 struct Player { int GetTalkState(); };
 extern "C" void func_ov094_02136188(void *c, void *p);
 extern "C" short Vec3_HorzAngle(const void *a, const void *b);
@@ -13,13 +16,13 @@ extern "C" int func_ov094_02135ee0(void *self)
         func_ov094_02136188(self, &data_ov094_02136b60);
         return 1;
     }
-    Vec3 v = *(Vec3*)((char*)(*(Player**)(s + 0x3d0)) + 0x5c);
-    Vec3 w;
+    Vector3 v = *(Vector3*)((char*)(*(Player**)(s + 0x3d0)) + 0x5c);
+    Vector3 w;
     w.x = v.x;
     w.y = v.y;
     w.z = v.z;
     ApproachAngle(s + 0x94, Vec3_HorzAngle(s + 0x5c, &w), 0xa, 0x200, 0x100);
-    Vec3 u;
+    Vector3 u;
     v.y += 0xc8000;
     u.x = v.x - 0;
     u.y = v.y;

--- a/src/func_ov094_021361d8.c
+++ b/src/func_ov094_021361d8.c
@@ -1,10 +1,13 @@
+// @symbol func_ov094_021361d8
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
-extern void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void* m, int x, int y, int z);
 extern void _ZN9ModelBase12ApplyOpacityEj(void* self, unsigned int a, int b);
@@ -16,8 +19,8 @@ extern struct Mtx43 data_020a0e68;
 
 void func_ov094_021361d8(char* self){
     struct Mtx43 out;
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3*)(self + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3*)(self + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
     Matrix4x3_ApplyInPlaceToRotationXYZExt(&data_020a0e68,
         *(s16*)(self + 0x8c), *(s16*)(self + 0x8e), *(s16*)(self + 0x90));

--- a/src/func_ov094_021362e0.c
+++ b/src/func_ov094_021362e0.c
@@ -1,7 +1,10 @@
+// @symbol func_ov094_021362e0
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
 extern struct Mtx43 data_020a0e68;
@@ -10,7 +13,7 @@ extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(struct Mtx43* m, int x, int y
 
 void func_ov094_021362e0(char* c)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     char* m;
     int z = 0;
     if (*(int*)(c + 0x3cc) == 0) return;

--- a/src/func_ov095_021357d8.c
+++ b/src/func_ov095_021357d8.c
@@ -1,3 +1,9 @@
+// @symbol func_ov095_021357d8
+// @emits SeesawBob_OnGroundPounded
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjSeesaw_c::OnGroundPounded - recovered from vtable slot identity */
 #pragma opt_propagation off
 
 typedef short s16;
@@ -5,11 +11,9 @@ typedef unsigned short u16;
 typedef long long s64;
 extern int Vec3_Dist(void *a, void *b);
 extern s16 Vec3_HorzAngle(void *a, void *b);
-extern int func_ov095_0213579c(void *self, void *p);
-extern int AngleDiff(int a, int b);
 extern s16 data_02082214[];
 
-void func_ov095_021357d8(char *a, char *b)
+void SeesawBob_OnGroundPounded(char *a, char *b)
 {
     char *b5c = b + 0x5c;
     int dist = Vec3_Dist(a + 0x5c, b5c);
@@ -24,7 +28,7 @@ void func_ov095_021357d8(char *a, char *b)
     prod = (int)(((s64)dist * n + 0x800) >> 12);
     idx = idx + 1;
 
-    p = (s16 *)(((s64)(int)(a + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (s16 *)(((s64)(int)(a + 0x8c)));
     cur = *p;
     v = (int)(((s64)prod * data_02082214[idx] + 0x800) >> 12);
     v = (v + ((unsigned)(v >> 11) >> 20)) << 4;

--- a/src/func_ov095_02136090.cpp
+++ b/src/func_ov095_02136090.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol func_ov095_02136090
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, Vector3* v);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, Vector3* v, int fix);

--- a/src/func_ov095_02136104.cpp
+++ b/src/func_ov095_02136104.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x,y,z; };
+// @symbol func_ov095_02136104
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, Vector3* v);
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, Vector3* v, int fix);

--- a/src/func_ov095_02136298.cpp
+++ b/src/func_ov095_02136298.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov095_02136298
+// @emits SeesawBob_AfterClsn
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjSeesaw_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
 struct Vector3 { int x, y, z; };
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, const Vector3& v, unsigned int e);
 extern void _Z14ApproachLinearRiii(int& x, int target, int step);
 
-void func_ov095_02136298(char* c)
+void SeesawBob_AfterClsn(char* c)
 {
     *(unsigned int*)(c + 0x340) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
         *(unsigned int*)(c + 0x340), 3, 0x82, *(Vector3*)(c + 0x74), 0);

--- a/src/func_ov096_021357a4.c
+++ b/src/func_ov096_021357a4.c
@@ -1,4 +1,8 @@
-int func_ov096_021357a4(void)
+// @symbol func_ov096_021357a4
+// @emits Pokey_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daSanbo_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Pokey_OnYoshiTryEat(void)
 {
     return 4;
 }

--- a/src/func_ov096_021357ac.c
+++ b/src/func_ov096_021357ac.c
@@ -1,4 +1,8 @@
-int func_ov096_021357ac(void)
+// @symbol func_ov096_021357ac
+// @emits Pokey_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daSanbo_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int Pokey_OnAimedAtWithEgg(void)
 {
     return 245760;
 }

--- a/src/func_ov096_02135efc.cpp
+++ b/src/func_ov096_02135efc.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov096_02135efc
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef short s16;
 typedef int Fix12i;
 
-struct Vec3 { Fix12i x, y, z; };
+
 struct Mtx43 { Fix12i a[12]; };
 
-extern "C" void Vec3_Asr(struct Vec3* d, struct Vec3* s, int sh);
+extern "C" void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern "C" void Matrix4x3_FromTranslation(struct Mtx43* m, Fix12i x, Fix12i y, Fix12i z);
 extern "C" void Matrix4x3_ApplyInPlaceToTranslation(void* m, int x, int y, int z);
 extern "C" void Matrix4x3_ApplyInPlaceToRotationZXYExt(void* m, int x, int y, int z);
@@ -31,7 +34,7 @@ enum Bool { FALSE, TRUE };
 
 extern "C" void func_ov096_02135efc(char* c)
 {
-    struct Vec3 v;
+    struct Vector3 v;
     enum Bool b;
 
     if (*(int*)(c + 0x38c) == 5) {
@@ -39,7 +42,7 @@ extern "C" void func_ov096_02135efc(char* c)
         if (b) {
             int y1, y2;
 
-            Vec3_Asr(&v, (struct Vec3*)(c + 0x5c), 3);
+            Vec3_Asr(&v, (struct Vector3*)(c + 0x5c), 3);
             Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
 
             y1 = ((VObj*)c)->m29() >> 3;

--- a/src/func_ov096_02136134.cpp
+++ b/src/func_ov096_02136134.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct V3{int x,y,z;};
+// @symbol func_ov096_02136134
+/* recovered: shared common types */
+#include "common.h"
+
 struct Obj {
   virtual int d0();
   virtual int d1();
@@ -33,7 +36,7 @@ struct Obj {
   virtual int GetY();
 };
 extern "C" {
-extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int, void*);
 extern int func_ov096_02135800(char* c);
 extern short Vec3_HorzAngle(void*, void*);
@@ -44,7 +47,7 @@ extern int data_0209e650[];
 extern "C" int func_ov096_02136134(char* c){
   int cond = (*(unsigned short*)(c+0xc) == 0xf0);
   if(cond){
-    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x122, 2, (struct V3*)(c+0x5c), 0, *(signed char*)(c+0xcc), -1);
+    _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x122, 2, (struct Vector3*)(c+0x5c), 0, *(signed char*)(c+0xcc), -1);
   }
   {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, c+0x74);

--- a/src/func_ov096_021365d4.c
+++ b/src/func_ov096_021365d4.c
@@ -1,9 +1,11 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov096_021365d4
+/* recovered: shared common types */
+#include "common.h"
 void _Z14ApproachLinearRiii(int* dst, int target, int step);
 void func_ov096_021358c8(char* c);
 int func_ov096_02135838(char* c);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
-void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vec3* pos, const void* rot, int e, int f);
+void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vector3* pos, const void* rot, int e, int f);
 void func_ov096_02136928(char* c, int n);
 char* func_ov096_021357b4(char* c);
 void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
@@ -30,7 +32,7 @@ int func_ov096_021365d4(char* c) {
     if (func_ov096_02135838(c) < 4) {
         if (DecIfAbove0_Byte((unsigned char*)(c + 0x3ac)) == 0) {
             void* sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
-                0xf1, *(unsigned int*)(c + 4), (struct Vec3*)(c + 0x5c), c + 0x8c,
+                0xf1, *(unsigned int*)(c + 4), (struct Vector3*)(c + 0x5c), c + 0x8c,
                 *(signed char*)(c + 0xcc), -1);
             if (sp != 0) {
                 *(void**)(c + 0x394) = sp;

--- a/src/func_ov096_02136cd0.c
+++ b/src/func_ov096_02136cd0.c
@@ -1,9 +1,13 @@
+// @symbol func_ov096_02136cd0
+// @emits Pokey_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daSanbo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN5Actor15GivePlayerCoinsER6Playerhj(char *c, char *player, unsigned char r2, unsigned int r3);
 extern void _ZN9ActorBase18MarkForDestructionEv(char *c);
 
 enum Bool { FALSE, TRUE };
 
-void func_ov096_02136cd0(char *c, char *player) {
+void Pokey_OnTurnIntoEgg(char *c, char *player) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     enum Bool flag = (enum Bool)(v == 0xf0);
     if (flag) {

--- a/src/func_ov098_02137ccc.cpp
+++ b/src/func_ov098_02137ccc.cpp
@@ -1,5 +1,9 @@
 //cpp
-// func_ov098_02137ccc at 0x020bb3b8
+// @symbol func_ov098_02137ccc
+// @emits ArrowSignRight_Kill
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjYajirusi_c::Kill - recovered from vtable slot identity */
+// ArrowSignRight_Kill at 0x020bb3b8
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 struct Vector3 { int x, y, z; };
 
@@ -10,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 int _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" int func_ov098_02137ccc(char* self);
-int func_ov098_02137ccc(char* self) {
+extern "C" int ArrowSignRight_Kill(char* self);
+int ArrowSignRight_Kill(char* self) {
     Vector3 vec;
     Vector3 vec2;
     int x = *(int*)(self + 0x5c);

--- a/src/func_ov098_02137d40.cpp
+++ b/src/func_ov098_02137d40.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov098_02137d40
+// @emits ArrowSignRight_OnAttacked1
+/* recovered: renamed to Class_Method */
+/* daObjYajirusi_c::OnAttacked1 - recovered from vtable slot identity */
 struct VT{ int (*f[64])(void*); };
 struct O{ VT* vt; };
-extern "C" void func_ov098_02137d40(O* c, char* o){
+extern "C" void ArrowSignRight_OnAttacked1(O* c, char* o){
     unsigned r = (*(unsigned short*)(o+0xc) == 0xce) ? 1u : 0u;
     if(r == 0) return;
     c->vt->f[0x7c/4](c);

--- a/src/func_ov098_02137d80.c
+++ b/src/func_ov098_02137d80.c
@@ -1,7 +1,12 @@
+// @symbol func_ov098_02137d80
+// @emits ArrowSignRight_OnHitByMegaChar
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Platform.h"
+/* recovered: renamed to Class_Method */
+/* daObjYajirusi_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern int func_02012694();
 extern void _ZN6Player16IncMegaKillCountEv(void*);
-extern void _ZN8Platform14KillByMegaCharER6Player(void*,void*);
-void func_ov098_02137d80(void* a, void* b){
+void ArrowSignRight_OnHitByMegaChar(void* a, void* b){
   _ZN6Player16IncMegaKillCountEv(b);
   func_02012694(0x1e,(char*)a+0x74);
   _ZN8Platform14KillByMegaCharER6Player(a,b);

--- a/src/func_ov098_02138318.c
+++ b/src/func_ov098_02138318.c
@@ -1,4 +1,8 @@
-void func_ov098_02138318(char *c)
+// @symbol func_ov098_02138318
+// @emits ArrowSignRight_AfterClsn
+/* recovered: renamed to Class_Method */
+/* daObjYajirusi_c::AfterClsn - recovered from vtable slot identity */
+void ArrowSignRight_AfterClsn(char *c)
 {
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;

--- a/src/func_ov098_02138344.cpp
+++ b/src/func_ov098_02138344.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov098_02138344
+/* recovered: shared common types */
+#include "common.h"
+
 
 struct Obj {
     virtual void v0();
@@ -41,7 +44,7 @@ void _ZN5Actor9UpdatePosEP12CylinderClsn(void* thiz, void* clsn);
 void func_020383fc(void* p);
 void _Z14ApproachLinearRiii(int* dst, int target, int step);
 int _ZNK12WithMeshClsn10IsOnGroundEv(void* p);
-void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, const struct Vec3* v);
+void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, const struct Vector3* v);
 unsigned char DecIfAbove0_Byte(unsigned char* p);
 void func_ov098_02138b28(char* c, int i);
 void func_ov098_02139228(char* c);
@@ -61,7 +64,7 @@ extern "C" void func_ov098_02138344(char* c) {
     func_020383fc(c + 0x320);
     _Z14ApproachLinearRiii((int*)(c + 0x98), 0, 0x555);
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x320) != 0) {
-        _ZN5Sound9PlayBank3EjRK7Vector3(0x51, (struct Vec3*)(c + 0x74));
+        _ZN5Sound9PlayBank3EjRK7Vector3(0x51, (struct Vector3*)(c + 0x74));
         DecIfAbove0_Byte((unsigned char*)(c + 0x604));
         *(int*)(c + 0xa8) = *(unsigned char*)(c + 0x604) * 0xa000;
         *(int*)(c + 0x98) = *(unsigned char*)(c + 0x604) * 0x5000;

--- a/src/func_ov098_02138ce0.c
+++ b/src/func_ov098_02138ce0.c
@@ -1,11 +1,14 @@
+// @symbol func_ov098_02138ce0
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(
     void *thiz, void *actor, void *vec, int fix, int t, unsigned u1, unsigned u2);
 
-struct Vec3 { int x, y, z; };
+
 
 void func_ov098_02138ce0(char *c)
 {
-    struct Vec3 zero, a1, a2;
+    struct Vector3 zero, a1, a2;
 
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;
@@ -23,9 +26,9 @@ void func_ov098_02138ce0(char *c)
     *(int *)(c + 0xa8) = 0;
     *(int *)(c + 0xac) = 0;
 
-    ((struct Vec3 *)(((long long)(int)&zero) & 0xFFFFFFFFFFFFFFFFLL))->x = 0;
-    ((struct Vec3 *)(((long long)(int)&zero) & 0xFFFFFFFFFFFFFFFFLL))->y = 0;
-    ((struct Vec3 *)(((long long)(int)&zero) & 0xFFFFFFFFFFFFFFFFLL))->z = 0;
+    ((struct Vector3 *)(((long long)(int)&zero)))->x = 0;
+    ((struct Vector3 *)(((long long)(int)&zero)))->y = 0;
+    ((struct Vector3 *)(((long long)(int)&zero)))->z = 0;
 
     a1.x = zero.x;
     a1.y = zero.y;

--- a/src/func_ov098_02138e6c.cpp
+++ b/src/func_ov098_02138e6c.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov098_02138e6c
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
+
 
 struct Base {
     virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
@@ -21,7 +24,7 @@ extern "C" {
 void func_ov098_02138b28(void *c, int i);
 void *_ZN5Actor10FindWithIDEj(u32 id);
 int _ZN6Player7TryGrabER5Actor(void *f, void *a);
-void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, struct Vec3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
+void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, struct Vector3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
 }
 
 extern "C" void func_ov098_02138e6c(char *c)
@@ -88,7 +91,7 @@ extern "C" void func_ov098_02138e6c(char *c)
     if (b == 0) return;
 
     {
-        struct Vec3 v;
+        struct Vector3 v;
         v.x = *(int*)(c + 0x5c);
         v.y = *(int*)(c + 0x60);
         v.z = *(int*)(c + 0x64);

--- a/src/func_ov098_02139070.c
+++ b/src/func_ov098_02139070.c
@@ -1,16 +1,20 @@
-/* func_ov098_02139070 at 0x02139070
+// @symbol func_ov098_02139070
+// @emits Crate_Kill
+/* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjBlockS_c::Kill - recovered from vtable slot identity */
+/* Crate_Kill at 0x02139070
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
  */
-struct Vector3 { int x, y, z; };
 
-extern void func_ov098_02138e08(char* c);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
-extern void _ZN5Actor19DisappearPoofDustAtERK7Vector3(void* self, const struct Vector3* vec);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* pos);
 extern void func_ov098_02138b28(char* c, int i);
 
-void func_ov098_02139070(char* self) {
+void Crate_Kill(char* self) {
     struct Vector3 vec;
     struct Vector3 vec2;
     int x, y, z;

--- a/src/func_ov098_021390ec.cpp
+++ b/src/func_ov098_021390ec.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov098_021390ec
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
+
 struct ClsnResult { int GetClsnID() const; };
 struct SurfaceInfo { void CopyNormalTo(Vector3 &) const; };
 struct WithMeshClsn {

--- a/src/func_ov098_02139228.cpp
+++ b/src/func_ov098_02139228.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol func_ov098_02139228
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int s32;
 typedef unsigned int u32;
 typedef short s16;
@@ -6,7 +11,7 @@ typedef unsigned short u16;
 typedef unsigned char u8;
 typedef long long s64;
 
-struct Vector3 { s32 x, y, z; };
+
 
 struct C {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
@@ -28,14 +33,11 @@ extern int _Z14ApproachLinearRiii(int *a, int b, int c);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *self, Vector3 *out);
 extern int func_02037e58(u32 *p);
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
-extern int func_ov002_020f02c8(int x);
 extern int func_ov002_020f030c(int x);
 extern s32 Vec3_HorzLen(const Vector3 *v0);
 extern void Vec3_MulScalarInPlace(int *v, int s);
 extern void Vec3_Add(Vector3 *out, Vector3 *a, Vector3 *b);
-extern int AngleDiff(int a, int b);
 extern int _ZN4cstd4fdivEii(int a, int b);
-extern int func_ov002_020f035c(u32 sel, int r1);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, const Vector3 *pos);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(s32 x, s32 y, s32 z);
 extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, const Vector3 *pos, u32 e);

--- a/src/func_ov098_021396a4.cpp
+++ b/src/func_ov098_021396a4.cpp
@@ -1,9 +1,12 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov098_021396a4
+/* recovered: shared common types */
+#include "common.h"
+
 struct RaycastGround { char buf[0x68 - 0x18]; };
 extern "C" {
 extern void _ZN13RaycastGroundC1Ev(struct RaycastGround *self);
-extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vec3 *v, void *actor);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(struct RaycastGround *self, const struct Vector3 *v, void *actor);
 extern int _ZN13RaycastGround10DetectClsnEv(struct RaycastGround *self);
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern void _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(
@@ -16,7 +19,7 @@ void func_ov098_021396a4(void *self)
 {
     char *c = (char*)self;
     struct RaycastGround rg;
-    struct Vec3 v;
+    struct Vector3 v;
     int r5;
     int r4;
 

--- a/src/func_ov098_021397c8.cpp
+++ b/src/func_ov098_021397c8.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov098_021397c8
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov098_021397c8(char* self){
     Obj* o = (Obj*)self;
     volatile int tmp[3];
@@ -12,7 +15,7 @@ void func_ov098_021397c8(char* self){
     tmp[1] = origY;
     tmp[2] = *(int*)(self+0x64);
     tmp[1] = origY - *(int*)(self+0x5f4);
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = tmp[0];
     *(int*)(self+0x314) = tmp[1];
     *(int*)(self+0x318) = tmp[2];

--- a/src/func_ov098_02139850.c
+++ b/src/func_ov098_02139850.c
@@ -1,22 +1,23 @@
+// @symbol func_ov098_02139850
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef signed char s8;
 typedef unsigned char u8;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vector3 { int x, y, z; };
-struct M4x3 { int w[12]; };
 
-extern int data_ov098_0213bf60[];
-extern int data_ov098_0213bf64[];
-extern int data_ov098_0213bf68[];
+
+
 
 extern int func_ov002_020e496c(char* c);
 extern int _ZN6Player14IsFrontSlidingEv(char* p);
 extern int _ZN6Player17LostGrabbedObjectEv(char* p);
 extern void Math_Function_0203b14c(char* dst, int a, int b, int c, int d);
 extern char* _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(char* self, char* player, const struct Vector3* v);
-extern void Matrix4x3_FromRotationZXYExt(void* m, int x, int y, int z);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(char* self);
 
 void func_ov098_02139850(char* self)
@@ -44,7 +45,7 @@ void func_ov098_02139850(char* self)
         Math_Function_0203b14c(self + 0x4fc, *(int*)((char*)data_ov098_0213bf68 + r5 * 0xc), 0x800, 0x3e8000, 4);
         {
             char* res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(self, *(char**)(self + 0x5e4), (struct Vector3*)(self + 0x4f4));
-            *(struct M4x3*)(self + 0xf0) = *(struct M4x3*)res;
+            *(struct Matrix4x3*)(self + 0xf0) = *(struct Matrix4x3*)res;
         }
         *(u32*)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
     }

--- a/src/func_ov098_02139e44.cpp
+++ b/src/func_ov098_02139e44.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov098_02139e44
+// @emits Crate_OnGroundPounded
+/* recovered: renamed to Class_Method */
+/* daObjBlockS_c::OnGroundPounded - recovered from vtable slot identity */
 struct Base {
     virtual void v0();
     virtual void v1();
@@ -33,4 +37,4 @@ struct Base {
     virtual void v30();
     virtual void v31();
 };
-extern "C" void func_ov098_02139e44(Base *c) { c->v31(); }
+extern "C" void Crate_OnGroundPounded(Base *c) { c->v31(); }

--- a/src/func_ov098_02139e64.c
+++ b/src/func_ov098_02139e64.c
@@ -1,4 +1,8 @@
-int func_ov098_02139e64(unsigned char *c) {
+// @symbol func_ov098_02139e64
+// @emits Crate_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daObjBlockS_c::OnYoshiTryEat - recovered from vtable slot identity */
+int Crate_OnYoshiTryEat(unsigned char *c) {
   unsigned char v = c[0x606];
   if (v != 0) return 0;
   return 6;

--- a/src/func_ov098_02139e78.c
+++ b/src/func_ov098_02139e78.c
@@ -1,9 +1,13 @@
+// @symbol func_ov098_02139e78
+// @emits Crate_OnTurnIntoEgg
+/* recovered: renamed to Class_Method */
+/* daObjBlockS_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN6Player15IsCollectingCapEv(char* player);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(char* self, char* player, unsigned char n, unsigned int j);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(char* player, unsigned int n, char b1, char b2);
 extern void func_ov098_02138b28(char* c, int i);
 
-void func_ov098_02139e78(char* r5, char* r4){
+void Crate_OnTurnIntoEgg(char* r5, char* r4){
   if (_ZN6Player15IsCollectingCapEv(r4)) {
     if (*(unsigned char*)(r5 + 0x607) != 1) {
       _ZN5Actor15GivePlayerCoinsER6Playerhj(r5, r4, 3, 0);

--- a/src/func_ov098_02139f70.c
+++ b/src/func_ov098_02139f70.c
@@ -1,13 +1,15 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov098_02139f70
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 extern void *G0;
 int *func_ov098_02139f70(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov098_02139fc8.c
+++ b/src/func_ov098_02139fc8.c
@@ -1,11 +1,14 @@
-extern void _ZN18MovingMeshColliderD1Ev(void *);
-extern void _ZN5ModelD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
-extern int VT1[];
+// @symbol func_ov098_02139fc8
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV10dBgActor_c */
 int *func_ov098_02139fc8(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV10dBgActor_c;
     t[0] = (int)VT1;
     _ZN18MovingMeshColliderD1Ev((char *)t + 0x124);
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov098_0213a17c.cpp
+++ b/src/func_ov098_0213a17c.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov098_0213a17c
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);

--- a/src/func_ov098_0213a794.cpp
+++ b/src/func_ov098_0213a794.cpp
@@ -1,4 +1,9 @@
 //cpp
+// @symbol func_ov098_0213a794
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern "C" void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
@@ -10,14 +15,13 @@ extern "C" void _ZN13RaycastGroundC1Ev(void* self);
 extern "C" void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void* self, void* pos, void* actor);
 extern "C" int _ZN13RaycastGround10DetectClsnEv(void* self);
 extern "C" void _ZN13RaycastGroundD1Ev(void* self);
-extern void func_ov098_0213a8ec();
 
-struct V3 { int x, y, z; };
+
 struct RG { char b[0x4c]; };
 
 extern "C" int func_ov098_0213a794(char* self, char** fp){
   RG rc;
-  V3 v;
+  Vector3 v;
   int r2;
   int y;
   _ZN9ModelBase7SetFileEP8BMD_Fileii(self+0xd4, _ZN5Model8LoadFileER13SharedFilePtr((void*)fp[0]), 1, -1);

--- a/src/func_ov098_0213a984.c
+++ b/src/func_ov098_0213a984.c
@@ -1,9 +1,12 @@
+// @symbol func_ov098_0213a984
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 
-struct Mtx { int w[12]; };
 
-extern void Matrix4x3_FromTranslation(struct Mtx* m, int x, int y, int z);
+
+extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 extern s16 data_02082214[];
 
 void func_ov098_0213a984(char *c)
@@ -13,7 +16,7 @@ void func_ov098_0213a984(char *c)
     char *p;
     int idx;
 
-    Matrix4x3_FromTranslation((struct Mtx*)(c + 0xf0),
+    Matrix4x3_FromTranslation((struct Matrix4x3*)(c + 0xf0),
         *(int*)(c + 0x5c) >> 3,
         *(int*)(c + 0x60) >> 3,
         *(int*)(c + 0x64) >> 3);

--- a/src/func_ov098_0213aa28.c
+++ b/src/func_ov098_0213aa28.c
@@ -1,9 +1,11 @@
-struct Vector3 { int x, y, z; };
-
+// @symbol func_ov098_0213aa28
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void* self, struct Vector3* v, int f);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, struct Vector3* v);
 extern int _Z14ApproachLinearRsss(short* r, short t, short s);
-extern int func_ov002_020df300(char* p);
 extern short GetAngleToCamera(int i);
 extern int _ZN6Player22IsBeingShotOutOfCannonEv(char* c);
 
@@ -45,12 +47,12 @@ void func_ov098_0213aa28(char* c)
 
     switch (*(unsigned char*)(c + 0x185)) {
     case 0:
-        p60 = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+        p60 = (int*)(((long long)(int)(c + 0x60)));
         *p60 = *p60 + 0xa000;
         if (*(int*)(c + 0x60) < *(int*)(c + 0x160))
             goto end;
         *(int*)(c + 0x60) = *(int*)(c + 0x160);
-        state = (unsigned char*)(((long long)(int)(c + 0x185)) & 0xFFFFFFFFFFFFFFFFLL);
+        state = (unsigned char*)(((long long)(int)(c + 0x185)));
         (*state)++;
         *(int*)(c + 0x174) = 0;
         vs[1].x = *(int*)(c + 0x5c);
@@ -65,7 +67,7 @@ void func_ov098_0213aa28(char* c)
             goto end;
         if (!_Z14ApproachLinearRsss((short*)(c + 0x8e), *(short*)(c + 0x17a), 0x200))
             goto end;
-        state = (unsigned char*)(((long long)(int)(c + 0x185)) & 0xFFFFFFFFFFFFFFFFLL);
+        state = (unsigned char*)(((long long)(int)(c + 0x185)));
         (*state)++;
         *(int*)(c + 0x174) = 0;
         _ZN5Sound9PlayBank3EjRK7Vector3(0x14d, (struct Vector3*)(c + 0x74));
@@ -80,7 +82,7 @@ void func_ov098_0213aa28(char* c)
             goto end;
         _ZN5Sound9PlayBank3EjRK7Vector3(0x14e, (struct Vector3*)(c + 0x74));
         *(int*)(c + 0x174) = 0;
-        state = (unsigned char*)(((long long)(int)(c + 0x185)) & 0xFFFFFFFFFFFFFFFFLL);
+        state = (unsigned char*)(((long long)(int)(c + 0x185)));
         (*state)++;
         break;
 
@@ -88,7 +90,7 @@ void func_ov098_0213aa28(char* c)
         *(short*)(c + 0x8e) = GetAngleToCamera(*(unsigned char*)(*(char**)(c + 0x158) + 0x6d8)) + 0x4000;
         if (!_ZN6Player22IsBeingShotOutOfCannonEv(*(char**)(c + 0x158)))
             goto end;
-        state = (unsigned char*)(((long long)(int)(c + 0x185)) & 0xFFFFFFFFFFFFFFFFLL);
+        state = (unsigned char*)(((long long)(int)(c + 0x185)));
         (*state)++;
         *(int*)(c + 0x174) = 0;
         break;
@@ -96,7 +98,7 @@ void func_ov098_0213aa28(char* c)
     case 4:
     {
         unsigned char cnt = 0;
-        p60 = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+        p60 = (int*)(((long long)(int)(c + 0x60)));
         *p60 = *p60 - 0x32000;
         if (_Z14ApproachLinearRsss((short*)(c + 0x8c), 0, 0x800))
             cnt++;
@@ -107,7 +109,7 @@ void func_ov098_0213aa28(char* c)
         if (*(int*)(c + 0x60) > *(int*)(c + 0x160) - 0x190000)
             goto end;
         *(int*)(c + 0x180) = 2;
-        p13c = (int*)(((long long)(int)(c + 0x13c)) & 0xFFFFFFFFFFFFFFFFLL);
+        p13c = (int*)(((long long)(int)(c + 0x13c)));
         *p13c = *p13c & ~1;
         *(int*)(c + 0x60) = *(int*)(c + 0x160) - 0x190000;
         *(int*)(c + 0x158) = 0;
@@ -117,6 +119,6 @@ void func_ov098_0213aa28(char* c)
     }
     }
 end:
-    p174 = (int*)(((long long)(int)(c + 0x174)) & 0xFFFFFFFFFFFFFFFFLL);
+    p174 = (int*)(((long long)(int)(c + 0x174)));
     (*p174)++;
 }

--- a/src/func_ov098_0213b584.c
+++ b/src/func_ov098_0213b584.c
@@ -1,23 +1,23 @@
-struct Vec3 { int x, y, z; };
-struct Mtx43 { int w[12]; };
-
-void Vec3_Asr(struct Vec3 *d, struct Vec3 *s, int sh);
-void Matrix4x3_FromTranslation(struct Mtx43 *m, int x, int y, int z);
-void Matrix4x3_ApplyInPlaceToRotationY(struct Mtx43 *m, short angY);
+// @symbol func_ov098_0213b584
+/* recovered: shared common types */
+#include "common.h"
+void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
+void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
+void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *m, short angY);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
-    void *thiz, void *sm, struct Mtx43 *m, int radHeight, int a, unsigned int b);
+    void *thiz, void *sm, struct Matrix4x3 *m, int radHeight, int a, unsigned int b);
 
-extern struct Mtx43 data_020a0e68;
+extern struct Matrix4x3 data_020a0e68;
 
 void func_ov098_0213b584(char *c)
 {
-    struct Vec3 v;
-    Vec3_Asr(&v, (struct Vec3*)(c + 0x5c), 3);
+    struct Vector3 v;
+    Vec3_Asr(&v, (struct Vector3*)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, v.x, v.y, v.z);
-    *(struct Mtx43*)(c + 0x378) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x378) = data_020a0e68;
     Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short*)(c + 0x8e));
-    *(struct Mtx43*)(c + 0x31c) = data_020a0e68;
+    *(struct Matrix4x3*)(c + 0x31c) = data_020a0e68;
     _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
-        c, (void*)(c + 0x350), (struct Mtx43*)(c + 0x378),
+        c, (void*)(c + 0x350), (struct Matrix4x3*)(c + 0x378),
         *(int*)(c + 0x80) * 0xa0, 0x3e8000, 6);
 }

--- a/src/func_ov098_0213b6e0.cpp
+++ b/src/func_ov098_0213b6e0.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov098_0213b6e0
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
 extern void *_ZN5Actor10FindWithIDEj(unsigned);
 extern void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *thiz, const void *v, unsigned, int, unsigned, unsigned, unsigned);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 extern int func_ov098_0213b63c(char *c);
 
-struct Vector3 { int x, y, z; };
+
 
 int func_ov098_0213b6e0(char *c) {
     Vector3 vec;

--- a/src/func_ov098_0213b7e8.c
+++ b/src/func_ov098_0213b7e8.c
@@ -1,3 +1,7 @@
+// @symbol func_ov098_0213b7e8
+// @emits Cannon_Kill
+/* recovered: renamed to Class_Method */
+/* daCnn_c::Kill - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef unsigned short u16;
 
@@ -7,7 +11,7 @@ extern int _ZN4cstd4fdivEii(int a, int b);
 extern char *_ZN5Actor13ClosestPlayerEv(char *self);
 extern short Vec3_HorzAngle(const void *v0, const void *v1);
 
-void func_ov098_0213b7e8(char *c)
+void Cannon_Kill(char *c)
 {
     int state = *(int *)(c + 0x3c0);
     if (state == 0) {

--- a/src/func_ov098_0213b9d8.cpp
+++ b/src/func_ov098_0213b9d8.cpp
@@ -1,9 +1,12 @@
 //cpp
+// @symbol func_ov098_0213b9d8
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef int s32;
 typedef unsigned int u32;
 typedef unsigned short u16;
-struct Vector3 { s32 x, y, z; };
+
 struct Vector3_16;
 struct Actor;
 extern "C" Actor *_ZN5Actor13ClosestPlayerEv(void);
@@ -11,7 +14,7 @@ extern "C" s32 Vec3_HorzDist(const Vector3 *a, const Vector3 *b);
 extern "C" Actor *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32,u32,const Vector3*,const Vector3_16*,s32,s32);
 extern "C" void func_0201267c(u32 a, void *b, void *c, int d);
 extern s16 data_02082214[];
-#define M(x) ((long long)(int)(x) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(x) ((long long)(int)(x))
 
 extern "C" int func_ov098_0213b9d8(char *self)
 {

--- a/src/func_ov100_0214109c.cpp
+++ b/src/func_ov100_0214109c.cpp
@@ -1,10 +1,14 @@
 //cpp
+// @symbol func_ov100_0214109c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
-struct Vector3 { int x,y,z; };
-struct Vector3_16 { short x,y,z; };
+
+
 extern "C" {
 extern int Actor_Spawn(unsigned a, unsigned b, const struct Vector3 *pos, const struct Vector3_16 *rot, int i, int j);
-extern void ActorBase_MarkForDestruction(void *c);
 extern void Actor_SetRanges(void *c, Fix12 a, Fix12 b, Fix12 d, Fix12 e);
 
 void func_ov100_0214109c(void *t) {

--- a/src/func_ov100_0214117c.cpp
+++ b/src/func_ov100_0214117c.cpp
@@ -1,13 +1,17 @@
 //cpp
+// @symbol func_ov100_0214117c
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Actor.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
-struct V3 { int x, y, z; };
+
 
 extern "C" {
-extern int _ZN5Actor15IsPlayerInRangeEi(void* c, int r);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* c);
 extern int _ZN5Actor13DistToCPlayerEv(void* c);
 extern void _Z14ApproachLinearRiii(int* val, int target, int step);
-extern s16 Vec3_HorzAngle(const V3* a, const V3* b);
+extern s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern int RandomIntInternal(int* seed);
 extern void _Z14ApproachLinearRsss(s16* val, s16 target, s16 step);
 extern int data_0209e650;
@@ -35,7 +39,7 @@ extern "C" void func_ov100_0214117c(char* c)
     if (*(int*)(c + 0x3e8) >= 0x3c) {
         hAngle = *(s16*)(c + 0x3ec);
     } else {
-        hAngle = Vec3_HorzAngle((V3*)(c + 0x5c), (V3*)(c + 0x3d4));
+        hAngle = Vec3_HorzAngle((Vector3*)(c + 0x5c), (Vector3*)(c + 0x3d4));
     }
 
     {

--- a/src/func_ov100_021412d8.c
+++ b/src/func_ov100_021412d8.c
@@ -1,14 +1,17 @@
+// @symbol func_ov100_021412d8
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef signed char s8;
 
-struct Vec3 { int x, y, z; };
-struct Vec3_16 { s16 x, y, z; };
+
+
 
 extern int _ZN5Actor13DistToCPlayerEv(void* self);
 extern unsigned int RandomIntInternal(void* g);
-extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vec3* pos, const struct Vec3_16* rot, int e, int f);
+extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vector3* pos, const struct Vector3_16* rot, int e, int f);
 
 extern int data_0209e650;
 
@@ -25,11 +28,11 @@ void func_ov100_021412d8(char* sl)
             int sel;
             int i;
             int mask = typ & 0x30;
-            struct Vec3_16 rot;
+            struct Vector3_16 rot;
             int two = 2;
             int three = 3;
             i = 1;
-            rot = *(struct Vec3_16*)(sl + 0x92);
+            rot = *(struct Vector3_16*)(sl + 0x92);
             for (; i < 3; i++) {
                 if (i == sb) {
                     sel = 1;
@@ -40,7 +43,7 @@ void func_ov100_021412d8(char* sl)
                 }
                 rot.y = (s16)(rot.y + (s16)(RandomIntInternal(&data_0209e650) >> 0x10));
                 _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x150, mask | (sel << 6),
-                    (struct Vec3*)(sl + 0x5c), &rot, (int)*(s8*)(sl + 0xcc), -1);
+                    (struct Vector3*)(sl + 0x5c), &rot, (int)*(s8*)(sl + 0xcc), -1);
             }
             if (sb == 0) {
                 *(u8*)(sl + 0x3f0) = 1;

--- a/src/func_ov100_021415bc.c
+++ b/src/func_ov100_021415bc.c
@@ -1,9 +1,12 @@
+// @symbol func_ov100_021415bc
+/* recovered: shared common types */
+#include "common.h"
 #pragma opt_common_subs off
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
-struct Vec3 { int x, y, z; };
+#define M(p) ((long long)(int)(p))
+
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
-extern void Vec3_Sub(struct Vec3 *out, void *a, void *b);
-extern int Vec3_HorzLen(struct Vec3 *v);
+extern void Vec3_Sub(struct Vector3 *out, void *a, void *b);
+extern int Vec3_HorzLen(struct Vector3 *v);
 extern short Vec3_HorzAngle(const void *a, const void *b);
 extern short Vec3_VertAngle(const void *a, const void *b);
 extern void _Z14ApproachLinearRsss(short *dst, short target, short step);
@@ -13,8 +16,8 @@ extern short data_02082214[];
 void func_ov100_021415bc(char *c)
 {
     char *player;
-    struct Vec3 v;
-    struct Vec3 d;
+    struct Vector3 v;
+    struct Vector3 d;
 
     *(int *)(c + 0x5c) = *(int *)(c + 0x3d4);
     *(int *)(c + 0x60) = *(int *)(c + 0x3d8);
@@ -61,13 +64,13 @@ void func_ov100_021415bc(char *c)
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
 
         {
-        int *p = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((long long)(int)(c + 0x60)));
         *p = *p - ((int)(((long long)*(int *)(c + 0x98)
             * data_02082214[(*(unsigned short *)(c + 0x92) >> 4) * 2] + 0x800) >> 12)
             + (short)data_02082214[
             ((unsigned short)(short)((*(int *)(c + 0x3e8) << 16) / 100) >> 4) * 2 + 1]
             * (short)20 / 4);
-        int *cnt = (int *)(((long long)(int)(c + 0x3e8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *cnt = (int *)(((long long)(int)(c + 0x3e8)));
         *cnt = *cnt + 1;
         if (*(int *)(c + 0x3e8) > 100)
             *(int *)(c + 0x3e8) = 0;

--- a/src/func_ov100_02141fa8.c
+++ b/src/func_ov100_02141fa8.c
@@ -1,4 +1,8 @@
-int func_ov100_02141fa8(void)
+// @symbol func_ov100_02141fa8
+// @emits RollingIronBall_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daIbl_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int RollingIronBall_OnAimedAtWithEgg(void)
 {
     return 532480;
 }

--- a/src/func_ov100_02141fb0.cpp
+++ b/src/func_ov100_02141fb0.cpp
@@ -1,10 +1,15 @@
 //cpp
+// @symbol func_ov100_02141fb0
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_WithMeshClsn.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-struct Vec3 { int x, y, z; };
-struct Vec3s { short x, y, z; };
+
+
 
 struct Obj {
     virtual u32 v00(); virtual u32 v01(); virtual u32 v02(); virtual u32 v03();
@@ -19,14 +24,13 @@ struct Obj {
 };
 
 extern "C" void *_ZN5Actor10FindWithIDEj(u32 id);
-extern "C" void func_020ada40(char *c, Vec3s *s, void *a, int z);
-extern "C" void _ZN12WithMeshClsn15ClearGroundFlagEv(void *p);
+extern "C" void func_020ada40(char *c, Vector3_16 *s, void *a, int z);
 extern "C" void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, int x, int y, int z);
 extern "C" void _ZN5Actor8PoofDustEv(void *a);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *a);
 extern "C" void func_02012694(int a, void *p);
 extern "C" void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void *pos);
-extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, Vec3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
+extern "C" void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void *p, Vector3 *pos, u32 a, int b, u32 d, u32 e, u32 f);
 
 extern "C" void func_ov100_02141fb0(Obj *thiz)
 {
@@ -45,7 +49,7 @@ extern "C" void func_ov100_02141fb0(Obj *thiz)
     if (*(u8*)(a + 0x6fb) != 0) return;
     fl = *(u32*)(c + 0x394);
     if ((fl & 0x10) != 0) {
-        Vec3s s;
+        Vector3_16 s;
         u32 r = thiz->m();
         *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) += r;
         s.x = 0; s.y = 0; s.z = 0;
@@ -66,7 +70,7 @@ extern "C" void func_ov100_02141fb0(Obj *thiz)
         return;
     }
     {
-        Vec3 v;
+        Vector3 v;
         v.x = *(int*)(c + 0x5c);
         v.y = *(int*)(c + 0x60);
         v.z = *(int*)(c + 0x64);

--- a/src/func_ov100_02142918.cpp
+++ b/src/func_ov100_02142918.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov100_02142918
+// @emits Butterfly_Kill
+/* recovered: renamed to Class_Method */
+/* daBtfly_c::Kill - recovered from vtable slot identity */
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
@@ -26,7 +30,7 @@ void _ZN12CylinderClsn6UpdateEv(void* c);
 
 extern s16 data_02082214[];
 
-extern "C" void func_ov100_02142918(char* c)
+extern "C" void Butterfly_Kill(char* c)
 {
     int r;
     _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x374);
@@ -52,8 +56,8 @@ extern "C" void func_ov100_02142918(char* c)
         ang = *(u16*)(c + 0x94);
         *(int*)(c + 0xac) = (int)(((long long)*(int*)(c + 0x98) * data_02082214[((ang >> 4) << 1) + 1] + 0x800) >> 12);
         {
-            int* pa4 = (int*)((((long long)(int)(c + 0xa4)) & 0xFFFFFFFFFFFFFFFFLL));
-            int* pac = (int*)((((long long)(int)(c + 0xac)) & 0xFFFFFFFFFFFFFFFFLL));
+            int* pa4 = (int*)((((long long)(int)(c + 0xa4))));
+            int* pac = (int*)((((long long)(int)(c + 0xac))));
             *pa4 = *pa4 - *(int*)(c + 0xe0) * 3;
             *pac = *pac - *(int*)(c + 0xe8) * 3;
             *(int*)(c + 0x98) = Vec3_HorzLen(pa4);
@@ -65,8 +69,8 @@ extern "C" void func_ov100_02142918(char* c)
         goto Lend;
 
     {
-        int* pa4 = (int*)((((long long)(int)(c + 0xa4)) & 0xFFFFFFFFFFFFFFFFLL));
-        int* pac = (int*)((((long long)(int)(c + 0xac)) & 0xFFFFFFFFFFFFFFFFLL));
+        int* pa4 = (int*)((((long long)(int)(c + 0xa4))));
+        int* pac = (int*)((((long long)(int)(c + 0xac))));
         *pa4 = *pa4 + *(int*)(c + 0xd4) * 3;
         *pac = *pac + *(int*)(c + 0xdc) * 3;
         *(int*)(c + 0x98) = Vec3_HorzLen(pa4);

--- a/src/func_ov100_02142b90.c
+++ b/src/func_ov100_02142b90.c
@@ -1,10 +1,13 @@
+// @symbol func_ov100_02142b90
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vector3 { int x, y, z; };
+
 
 extern signed char data_0209f2f8;
 extern void* _ZN5Actor13ClosestPlayerEv(void* c);
@@ -30,7 +33,7 @@ void func_ov100_02142b90(char* c)
     if (pl == 0) return;
 
     {
-        struct Vector3* pp = (struct Vector3*)(((long long)(int)((char*)pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        struct Vector3* pp = (struct Vector3*)(((long long)(int)((char*)pl + 0x5c)));
         pos.x = pp->x;
         pos.y = pp->y;
         pos.z = pp->z;
@@ -60,7 +63,7 @@ void func_ov100_02142b90(char* c)
             (struct Vector3*)(c + 0x5c), (const void*)(c + 0x92), cc, -1);
         if (a == 0) return;
         {
-            u8* cnt = (u8*)(((long long)(int)(c + 0x3d2)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8* cnt = (u8*)(((long long)(int)(c + 0x3d2)));
             *cnt = *cnt + 1;
         }
         *(int*)((char*)a + 0x3a8) = (int)c;

--- a/src/func_ov100_02143370.cpp
+++ b/src/func_ov100_02143370.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov100_02143370
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3 { int x, y, z; };
+
 extern void _ZN11RaycastLineC1Ev(void* self);
 extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);

--- a/src/func_ov100_021435e8.cpp
+++ b/src/func_ov100_021435e8.cpp
@@ -1,11 +1,14 @@
 //cpp
+// @symbol func_ov100_021435e8
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 typedef unsigned int u32;
 typedef int s32;
 
-struct Vector3 { s32 x, y, z; };
+
 struct Vector3_16;
 
 extern "C" {

--- a/src/func_ov100_021437d4.c
+++ b/src/func_ov100_021437d4.c
@@ -1,32 +1,34 @@
-
+// @symbol func_ov100_021437d4
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef long long s64;
-struct Vec3 { int x, y, z; };
+
 extern short data_02082214[];
 extern char data_020a0e68[];
 extern void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
-extern void MulVec3Mat4x3(struct Vec3* in, void* m, struct Vec3* out);
-extern void Vec3_Add(struct Vec3* out, struct Vec3* a, struct Vec3* b);
+extern void MulVec3Mat4x3(struct Vector3* in, void* m, struct Vector3* out);
+extern void Vec3_Add(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
-extern int Vec3_HorzLen(struct Vec3* v);
+extern int Vec3_HorzLen(struct Vector3* v);
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* mF, int angX);
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void Vec3_MulScalar(struct Vec3* out, const struct Vec3* in, int scale);
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern void Vec3_MulScalar(struct Vector3* out, const struct Vector3* in, int scale);
 #define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
 
 
 void func_ov100_021437d4(char* thisx)
 {
-    struct Vec3 in, out, cur, delta, added, v48, v54, v60;
-    struct Vec3 *pos, *vel, *src;
+    struct Vector3 in, out, cur, delta, added, v48, v54, v60;
+    struct Vector3 *pos, *vel, *src;
     int *heights;
     int loop;
     int angOff;
     int idx, val, ang, hlen, angz;
 
-    pos = (struct Vec3*)(thisx + 0x6d8);
-    vel = (struct Vec3*)(thisx + 0x720);
+    pos = (struct Vector3*)(thisx + 0x6d8);
+    vel = (struct Vector3*)(thisx + 0x720);
     heights = (int*)(thisx + 0x78c);
 
     in.z = -0xfa000; in.x = 0; in.y = 0;
@@ -34,7 +36,7 @@ void func_ov100_021437d4(char* thisx)
 
     Matrix4x3_FromRotationXYZExt(data_020a0e68, *(s16*)(thisx + 0x8c), *(s16*)(thisx + 0x8e), *(s16*)(thisx + 0x90));
     MulVec3Mat4x3(&in, data_020a0e68, &out);
-    Vec3_Add(&added, (struct Vec3*)(thisx + 0x5c), &out);
+    Vec3_Add(&added, (struct Vector3*)(thisx + 0x5c), &out);
 
     {
         int ax = added.x, ay = added.y, az = added.z;
@@ -62,7 +64,7 @@ void func_ov100_021437d4(char* thisx)
     }
 
     for (; loop < 6; ) {
-        if (loop != 0) src = (struct Vec3*)((char*)pos - 0xc);
+        if (loop != 0) src = (struct Vector3*)((char*)pos - 0xc);
         else src = &cur;
         delta.x = vel->x + (pos->x - src->x);
         delta.z = vel->z + (pos->z - src->z);
@@ -86,8 +88,8 @@ void func_ov100_021437d4(char* thisx)
         *heights = *(int*)(thisx + 0x60) - 0xc8000;
         if (*heights - pos->y > 0xc8000) *heights = pos->y;
         angOff += 0x2000;
-        vel = (struct Vec3*)((char*)vel + 0xc);
-        pos = (struct Vec3*)((char*)pos + 0xc);
+        vel = (struct Vector3*)((char*)vel + 0xc);
+        pos = (struct Vector3*)((char*)pos + 0xc);
         loop++;
         heights = heights + 1;
     }

--- a/src/func_ov100_02143aa4.c
+++ b/src/func_ov100_02143aa4.c
@@ -1,8 +1,11 @@
+// @symbol func_ov100_02143aa4
+// @emits RollingIronBall_Kill
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daIbl_c::Kill - recovered from vtable slot identity */
 extern void _ZN9Animation7AdvanceEv(void *);
-extern void func_ov100_021437d4(void *);
-extern void func_ov100_0214344c(void *);
-extern void func_ov100_021435e8(void *);
-int func_ov100_02143aa4(char *c)
+int RollingIronBall_Kill(char *c)
 {
     *(int *)(c + 0x368) = 4096;
     _ZN9Animation7AdvanceEv((char *)c + 0x35c);

--- a/src/func_ov100_02143b68.cpp
+++ b/src/func_ov100_02143b68.cpp
@@ -1,15 +1,18 @@
 //cpp
+// @symbol func_ov100_02143b68
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12;
 typedef short s16;
 extern "C" {
 void Matrix4x3_FromRotationXYZExt(void* m, int x, int y, int z);
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* self, void* sm, void* mtx, Fix12 a, Fix12 b, unsigned int g);
 }
-struct Mtx { int w[12]; };
-extern Mtx data_02082128;
+
+extern Matrix4x3 data_02082128;
 
 extern "C" void func_ov100_02143b68(char* c) {
-  Mtx tmp;
+  Matrix4x3 tmp;
   int i;
   char* mdst;
   char* rd;
@@ -27,7 +30,7 @@ extern "C" void func_ov100_02143b68(char* c) {
   st = c;
   sm = c + 0x550;
   for (; i < 6; i++) {
-    *(Mtx*)(mdst+0x1c) = tmp;
+    *(Matrix4x3*)(mdst+0x1c) = tmp;
     *(int*)(st+0x3b0) = *(int*)(rd+0x6d8) >> 3;
     *(int*)(st+0x3b4) = *(int*)(rd+0x6dc) >> 3;
     *(int*)(st+0x3b8) = *(int*)(rd+0x6e0) >> 3;

--- a/src/func_ov100_021442d4.c
+++ b/src/func_ov100_021442d4.c
@@ -1,4 +1,8 @@
-int func_ov100_021442d4(void)
+// @symbol func_ov100_021442d4
+// @emits UnchainedChomp_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daWanwan2_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int UnchainedChomp_OnAimedAtWithEgg(void)
 {
     return 0;
 }

--- a/src/func_ov100_021443f4.c
+++ b/src/func_ov100_021443f4.c
@@ -1,9 +1,13 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern int VT0[];
+// @symbol func_ov100_021443f4
+/* recovered: vtable identified, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified */
+/* vtable identified: VT0 = _ZTV8daDoor_c */
 int *func_ov100_021443f4(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)_ZTV8daDoor_c;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);
     _ZN5ActorD2Ev(t);
     return t;

--- a/src/func_ov100_02144424.c
+++ b/src/func_ov100_02144424.c
@@ -1,9 +1,13 @@
-extern void _ZN9ModelAnimD1Ev(void *);
-extern void _ZN5ActorD2Ev(void *);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void *, void *);
-extern int VT0[];
+// @symbol func_ov100_02144424
+// @emits daDoor_c_OnYoshiTryEat
+/* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_ModelAnim.h"
+#include "decl_common.h"
+/* recovered: vtable identified, renamed to Class_Method */
+/* daDoor_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *func_ov100_02144424(int *t)
+int *daDoor_c_OnYoshiTryEat(int *t)
 {
     t[0] = (int)VT0;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);

--- a/src/func_ov100_02144a38.c
+++ b/src/func_ov100_02144a38.c
@@ -1,3 +1,8 @@
+// @symbol func_ov100_02144a38
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef unsigned int u32;
 typedef int s32;
 typedef int Fix12i;
@@ -5,30 +10,18 @@ typedef short s16;
 typedef unsigned char u8;
 typedef signed char s8;
 
-struct Vector3 { Fix12i x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
 
-extern int data_ov100_02148720;
-extern int data_ov100_02148718;
-extern int data_ov100_0214871c;
-extern struct Vector3 data_ov100_02148880;
-extern struct Vector3 data_ov100_0214879c;
-extern struct Vector3 data_ov100_021487f0;
-extern void* data_ov100_02148850;
-extern void* data_ov100_02148790;
-extern void* data_ov100_021487d8;
+
+
 extern void func_020072c0(void);
 extern char data_ov100_02148204[];
-extern char data_ov100_02148704;
 
 extern void _ZN6Player11OpenBigDoorEv(void* p);
 extern void func_020731dc(int a, int b, void** node);
-extern void func_ov100_02145170(char* r0, char* r1, struct Vector3* a, struct Vector3* b);
 extern void Vec3_RotateYAndTranslate(void* dst, void* src, short angle, void* unk);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
     u32 actorID, u32 param1, const struct Vector3* pos, const struct Vector3_16* rot,
     s32 areaID, s32 deathTableID);
-extern void func_ov089_0213115c(char* c, int i);
 
 int func_ov100_02144a38(char* c, char* p)
 {

--- a/src/func_ov100_02145170.c
+++ b/src/func_ov100_02145170.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x, y, z; };
+// @symbol func_ov100_02145170
+/* recovered: shared common types */
+#include "common.h"
 extern void Vec3_RotateYAndTranslate(struct Vector3 *res, const struct Vector3 *translation, short angY, const struct Vector3 *v);
 void func_ov100_02145170(char *r0, char *r1, struct Vector3 *a, struct Vector3 *b){
  struct Vector3 *v;

--- a/src/func_ov100_02145370.c
+++ b/src/func_ov100_02145370.c
@@ -1,13 +1,15 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void* Vec3_RotateYAndTranslate(void* out, void* base, short ang, struct Vec3* v);
+// @symbol func_ov100_02145370
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern void* Vec3_RotateYAndTranslate(void* out, void* base, short ang, struct Vector3* v);
 extern unsigned char data_0209f250[];
 extern char* data_0209f394[];
 extern int data_020a0ebc;
 void* func_ov100_02145370(char* c){
-  struct Vec3 v;
+  struct Vector3 v;
   char* r5 = data_0209f394[data_0209f250[0]];
-  Vec3_Sub(&v, (struct Vec3*)(r5+0x5c), (struct Vec3*)(c+0x5c));
+  Vec3_Sub(&v, (struct Vector3*)(r5+0x5c), (struct Vector3*)(c+0x5c));
   Vec3_RotateYAndTranslate(c+0x80, &data_020a0ebc, (short)(-(*(short*)(c+0x8e))), &v);
   return r5;
 }

--- a/src/func_ov100_0214542c.cpp
+++ b/src/func_ov100_0214542c.cpp
@@ -1,12 +1,17 @@
 //cpp
+// @symbol func_ov100_0214542c
+// @emits daDoor_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daDoor_c::CleanupResources - recovered from vtable slot identity */
 struct V { virtual void v0(); virtual void v1(); };
 struct Elem { void* a; void* b; char pad[8]; };
 extern Elem data_ov100_02148204[];
 extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void* p);
-extern void UnloadKeyModels(int i);
 extern void* data_ov100_02148744;
-int func_ov100_0214542c(char* c) {
+int daDoor_c_CleanupResources(char* c) {
   int idx = *(int*)(c + 8);
   Elem* e = &data_ov100_02148204[idx];
   V* obj;

--- a/src/func_ov100_021454c4.c
+++ b/src/func_ov100_021454c4.c
@@ -1,3 +1,7 @@
-void func_ov100_021454c4(void)
+// @symbol func_ov100_021454c4
+// @emits daDoor_c_OnPendingDestroy
+/* recovered: renamed to Class_Method */
+/* daDoor_c::OnPendingDestroy - recovered from vtable slot identity */
+void daDoor_c_OnPendingDestroy(void)
 {
 }

--- a/src/func_ov100_021454c8.cpp
+++ b/src/func_ov100_021454c8.cpp
@@ -1,19 +1,26 @@
 //cpp
+// @symbol func_ov100_021454c8
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daDoor_c.h"
+// @emits daDoor_c_Render
+/* recovered: renamed to Class_Method */
+/* daDoor_c::Render - recovered from vtable slot identity */
 extern "C" {
 extern unsigned char IsAreaShowing(int idx);
 }
 struct V1 { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct V2 { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void n(int); virtual void m(int); };
-extern "C" int func_ov100_021454c8(char* c){
-  if(IsAreaShowing((char)*(short*)(c+0x8c))==0){
-    if(IsAreaShowing((char)*(short*)(c+0x90))==0) goto done;
+extern "C" int daDoor_c_Render(char* c){
+    struct daDoor_c *self = (struct daDoor_c *)(void *)c;
+  if(IsAreaShowing((char)self->unk_08c)==0){
+    if(IsAreaShowing((char)self->unk_090)==0) goto done;
   }
   {
     V1* a = (V1*)(c+0xd4);
     a->m(0);
     V2* o = *(V2**)(c+0x138);
     if(o==0) goto done;
-    o->n(*(int*)(c+0xe8));
+    o->n(self->unk_0e8);
     V1* o2 = *(V1**)(c+0x138);
     o2->m(0);
   }

--- a/src/func_ov100_02145550.cpp
+++ b/src/func_ov100_02145550.cpp
@@ -1,4 +1,8 @@
 //cpp
+// @symbol func_ov100_02145550
+// @emits daDoor_c_Behavior
+/* recovered: renamed to Class_Method */
+/* daDoor_c::Behavior - recovered from vtable slot identity */
 struct Base {};
 typedef void (Base::*PMF)(int);
 struct CallbackNode {
@@ -6,7 +10,7 @@ struct CallbackNode {
     PMF callback;
 };
 extern int func_ov100_02145370(char *c);
-extern "C" int func_ov100_02145550(char *c) {
+extern "C" int daDoor_c_Behavior(char *c) {
     int res = func_ov100_02145370(c);
     CallbackNode *node = *(CallbackNode**)((char*)c + 0x140);
     if (*(int*)&node->callback != 0) {

--- a/src/func_ov100_021455a0.c
+++ b/src/func_ov100_021455a0.c
@@ -1,3 +1,9 @@
+// @symbol func_ov100_021455a0
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daDoor_c.h"
+// @emits daDoor_c_InitResources
+/* recovered: renamed to Class_Method */
+/* daDoor_c::InitResources - recovered from vtable slot identity */
 enum { false, true };
 
 typedef struct { int x, y, z; } Vec3;
@@ -42,8 +48,9 @@ extern int data_ov100_02148914;
 extern int data_ov100_021488b4;
 extern void func_ov100_021453d8(char *c, void *p, int a2);
 
-int func_ov100_021455a0(char *c)
+int daDoor_c_InitResources(char *c)
 {
+    struct daDoor_c *self = (struct daDoor_c *)(void *)c;
     unsigned int idx;
     struct Entry *e;
     void *f;
@@ -67,7 +74,7 @@ int func_ov100_021455a0(char *c)
         data_ov100_02148710 |= 1;
     }
 
-    Vec3_RotateYAndTranslate(c + 0x5c, c + 0x5c, *(short *)(c + 0x8e), &data_ov100_021487c0);
+    Vec3_RotateYAndTranslate(c + 0x5c, c + 0x5c, self->unk_08e, &data_ov100_021487c0);
 
     idx = *(unsigned int *)(c + 8);
     e = &data_ov100_02148204[idx];
@@ -82,11 +89,11 @@ int func_ov100_021455a0(char *c)
         } else if (e->b9 >= 0) {
             unsigned int t = *(unsigned int *)(c + 8);
             if (t >= 9 && t <= 0xd) {
-                *(signed char *)(c + 0x144) = (signed char)(t - 8);
-                LoadKeyModels(*(signed char *)(c + 0x144) + 1);
-                *(void **)(c + 0x13c) = func_02132894[*(signed char *)(c + 0x144) + 1];
+                self->unk_144 = (signed char)(t - 8);
+                LoadKeyModels(self->unk_144 + 1);
+                *(void **)(c + 0x13c) = func_02132894[self->unk_144 + 1];
                 if (*(int *)(c + 8) == 0xc)
-                    *(signed char *)(c + 0x144) = 0;
+                    self->unk_144 = 0;
             } else {
                 *(void **)(c + 0x13c) = &data_ov089_02132c50;
             }
@@ -100,7 +107,7 @@ int func_ov100_021455a0(char *c)
 
     Vec3_Asr(&tmp, (Vec3 *)(c + 0x5c), 3);
     Matrix4x3_FromTranslation(&data_020a0e68, tmp.x, tmp.y, tmp.z);
-    Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, *(short *)(c + 0x8e));
+    Matrix4x3_ApplyInPlaceToRotationY(&data_020a0e68, self->unk_08e);
     *(Mtx43 *)(c + 0xf0) = data_020a0e68;
 
     if (e->sfp2 != 0) {
@@ -115,31 +122,31 @@ int func_ov100_021455a0(char *c)
 
     {
         int w;
-        y = *(int *)(c + 0x60);
-        z = *(int *)(c + 0x64);
-        x = *(int *)(c + 0x5c);
+        y = self->unk_060;
+        z = self->unk_064;
+        x = self->unk_05c;
         w = y + 0xb4000;
-        *(int *)(c + 0xa4) = x;
-        *(int *)(c + 0xa8) = w;
+        self->unk_0a4 = x;
+        self->unk_0a8 = w;
         {
             unsigned char bi = data_0209f250;
-            *(int *)(c + 0xac) = z;
+            self->unk_0ac = z;
             r4 = data_0209f394[bi];
         }
     }
     func_ov100_02145370(c);
 
-    v = *(int *)(c + 0x80);
+    v = self->unk_080;
     if (v < 0)
         v = -v;
     if (v > 0x4b000)
         goto big;
-    v = *(int *)(c + 0x84);
+    v = self->unk_084;
     if (v < 0)
         v = -v;
     if (v > 0x32000)
         goto big;
-    v = *(int *)(c + 0x88);
+    v = self->unk_088;
     if (v < 0)
         v = -v;
     if (v > 0x1f4000)

--- a/src/func_ov100_02145988.cpp
+++ b/src/func_ov100_02145988.cpp
@@ -1,27 +1,29 @@
 //cpp
+// @symbol func_ov100_02145988
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 struct Camera;
 
-extern "C" int func_ov100_02144fcc(void);
 extern "C" int _Z14ApproachLinearRiii(int &x, int a, int b);
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char *p);
 extern "C" void func_02012694(int a, void *b, int c);
 extern "C" void _ZN6Camera14GoBehindPlayerEj(Camera *self, unsigned int a);
 extern "C" void func_ov100_02145f68(void *c, void *p, int a2);
-extern "C" void ChangeArea(int areaID);
 
-struct V3 { int x, y, z; };
-extern "C" void Vec3_RotateYAndTranslate(V3 *out, void *m, short angle, V3 *in);
+
+extern "C" void Vec3_RotateYAndTranslate(Vector3 *out, void *m, short angle, Vector3 *in);
 
 extern unsigned char data_0209f250;
 extern Camera *data_0209f318;
 extern char data_ov100_02148974;
 extern char data_020a0ebc;
-extern V3 data_ov100_02148948;
 
 extern "C" int func_ov100_02145988(char *self, char *arg1)
 {
     int r5;
-    V3 vec;
+    Vector3 vec;
     int gy, gz, vd;
 
     r5 = func_ov100_02144fcc();
@@ -57,6 +59,6 @@ extern "C" int func_ov100_02145988(char *self, char *arg1)
     vec.x = vd;
     vec.z = gz;
     vec.y = gy;
-    Vec3_RotateYAndTranslate((V3 *)(self + 0xa4), &data_020a0ebc, *(short *)(self + 0x8e), &vec);
+    Vec3_RotateYAndTranslate((Vector3 *)(self + 0xa4), &data_020a0ebc, *(short *)(self + 0x8e), &vec);
     return 1;
 }

--- a/src/func_ov100_02145c58.c
+++ b/src/func_ov100_02145c58.c
@@ -1,22 +1,21 @@
+// @symbol func_ov100_02145c58
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_Player.h"
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 /* func_ov100_02145c58 at 0x02145c58
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov100).
  */
-extern int func_ov100_02145e74(char* a, char* b);
 extern unsigned char NumStars(void);
-extern int func_ov100_02144f84(void);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(char* p, char* actor, unsigned int msg, void* vec, unsigned int e, unsigned int two);
 extern void _ZN6Player11OpenBigDoorEv(char* p);
 extern int func_ov100_02145f68(char* c, void* p, char* b);
-extern int _ZN6Player13TryTalkToDoorEh(char* p, unsigned char x);
-extern void func_ov100_02145e10(char* a, char* b);
 
-struct Vec3 { int x, y, z; };
 
-extern signed char data_ov100_02148390[];
+
 extern char data_0209caa0[];
-extern char data_ov100_02148984[];
-extern char data_ov100_02148994[];
 
 int func_ov100_02145c58(char* a, char* b) {
     signed char* entry;

--- a/src/func_ov100_02145f00.c
+++ b/src/func_ov100_02145f00.c
@@ -1,6 +1,8 @@
-struct Vec3 { int x, y, z; };
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
-extern void Vec3_RotateYAndTranslate(struct Vec3* out, void* m, int ang, struct Vec3* in);
+// @symbol func_ov100_02145f00
+/* recovered: shared common types */
+#include "common.h"
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern void Vec3_RotateYAndTranslate(struct Vector3* out, void* m, int ang, struct Vector3* in);
 
 extern unsigned char data_0209f250;
 extern char* data_0209f394[];
@@ -8,9 +10,9 @@ extern char data_020a0ebc[];
 
 char* func_ov100_02145f00(char* c)
 {
-    struct Vec3 tmp;
+    struct Vector3 tmp;
     char* p = data_0209f394[data_0209f250];
-    Vec3_Sub(&tmp, (struct Vec3*)(p + 0x5c), (struct Vec3*)(c + 0x5c));
-    Vec3_RotateYAndTranslate((struct Vec3*)(c + 0x80), data_020a0ebc, (short)(-*(short*)(c + 0x8e)), &tmp);
+    Vec3_Sub(&tmp, (struct Vector3*)(p + 0x5c), (struct Vector3*)(c + 0x5c));
+    Vec3_RotateYAndTranslate((struct Vector3*)(c + 0x80), data_020a0ebc, (short)(-*(short*)(c + 0x8e)), &tmp);
     return p;
 }

--- a/src/func_ov100_021463b0.cpp
+++ b/src/func_ov100_021463b0.cpp
@@ -1,22 +1,25 @@
 //cpp
-struct Vec3 { int x, y, z; };
+// @symbol func_ov100_021463b0
+/* recovered: shared common types */
+#include "common.h"
+
 extern "C" {
 int _Z14ApproachLinearRsss(short&, short, short);
 char* _ZN5Actor10FindWithIDEj(unsigned int id);
-void Vec3_Sub(Vec3* out, Vec3* a, Vec3* b);
-int Vec3_HorzLen(Vec3* v);
+void Vec3_Sub(Vector3* out, Vector3* a, Vector3* b);
+int Vec3_HorzLen(Vector3* v);
 int RandomIntInternal(int* seed);
 extern int data_0209e650;
 
 void func_ov100_021463b0(char* c)
 {
-    Vec3 v;
+    Vector3 v;
     char* o = c + 0x100;
     if (!_Z14ApproachLinearRsss(*(short*)(c + 0x94), *(short*)(o + 0x56), *(short*)(o + 0x54)))
         return;
     {
         char* a = _ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x13c));
-        Vec3_Sub(&v, (Vec3*)(c + 0x5c), (Vec3*)(a + 0x5c));
+        Vec3_Sub(&v, (Vector3*)(c + 0x5c), (Vector3*)(a + 0x5c));
     }
     if (Vec3_HorzLen(&v) >= 0xfa000) return;
     *(int*)(c + 0x98) = (((unsigned)RandomIntInternal(&data_0209e650) >> 15) & 0x1fff) + 0x2000;

--- a/src/func_ov100_02146468.c
+++ b/src/func_ov100_02146468.c
@@ -1,13 +1,15 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov100_02146468
+/* recovered: shared common types */
+#include "common.h"
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
-extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
-extern int Vec3_HorzLen(struct Vec3* v);
+extern int Vec3_HorzLen(struct Vector3* v);
 
 void func_ov100_02146468(char* r4){
-  struct Vec3 v;
+  struct Vector3 v;
   char* other = _ZN5Actor10FindWithIDEj(*(unsigned int*)(r4 + 0x13c));
-  Vec3_Sub(&v, (struct Vec3*)(r4 + 0x5c), (struct Vec3*)(other + 0x5c));
+  Vec3_Sub(&v, (struct Vector3*)(r4 + 0x5c), (struct Vector3*)(other + 0x5c));
   if (DecIfAbove0_Byte((unsigned char*)(r4 + 0x15a)) != 0) {
     if (Vec3_HorzLen(&v) < 0xfa000) return;
   }

--- a/src/func_ov100_021464f4.cpp
+++ b/src/func_ov100_021464f4.cpp
@@ -1,17 +1,20 @@
 //cpp
-struct V3 { int x, y, z; };
+// @symbol func_ov100_021464f4
+/* recovered: shared common types */
+#include "common.h"
+
 extern int data_0209e650;
 extern "C" int RandomIntInternal(int *seed);
 extern "C" void *_ZN5Actor13ClosestPlayerEv(void *thiz);
-extern "C" short Vec3_HorzAngle(struct V3 *a, struct V3 *b);
+extern "C" short Vec3_HorzAngle(struct Vector3 *a, struct Vector3 *b);
 extern "C" void _Z14ApproachLinearRsss(short *p, short target, short step);
-extern "C" void Vec3_Sub(struct V3 *out, struct V3 *a, struct V3 *b);
-extern "C" int Vec3_HorzLen(struct V3 *v);
+extern "C" void Vec3_Sub(struct Vector3 *out, struct Vector3 *a, struct Vector3 *b);
+extern "C" int Vec3_HorzLen(struct Vector3 *v);
 extern "C" void func_0201267c(int a, void *p);
 
 extern "C" void func_ov100_021464f4(char *c){
   void *pl;
-  struct V3 v;
+  struct Vector3 v;
   if(*(int*)(c+0x150) == 0){
     *(int*)(c+0x144) = (RandomIntInternal(&data_0209e650) & 0x3fff) + 0xd000;
     *(int*)(c+0x148) = (((unsigned int)RandomIntInternal(&data_0209e650) % 0x12c) + 0x1f4) << 12;
@@ -26,8 +29,8 @@ extern "C" void func_ov100_021464f4(char *c){
   }
   pl = _ZN5Actor13ClosestPlayerEv(c);
   if(pl == 0) return;
-  _Z14ApproachLinearRsss((short*)(c+0x94), Vec3_HorzAngle((struct V3*)((char*)pl+0x5c), (struct V3*)(c+0x5c)), *(short*)(c+0x154));
-  Vec3_Sub(&v, (struct V3*)(c+0x5c), (struct V3*)((char*)pl+0x5c));
+  _Z14ApproachLinearRsss((short*)(c+0x94), Vec3_HorzAngle((struct Vector3*)((char*)pl+0x5c), (struct Vector3*)(c+0x5c)), *(short*)(c+0x154));
+  Vec3_Sub(&v, (struct Vector3*)(c+0x5c), (struct Vector3*)((char*)pl+0x5c));
   if(Vec3_HorzLen(&v) <= *(int*)(c+0x148)) return;
   *(int*)(c+0x150) = -1;
   *(int*)(c+0x14c) = 3;

--- a/src/func_ov100_02146640.c
+++ b/src/func_ov100_02146640.c
@@ -1,15 +1,18 @@
+// @symbol func_ov100_02146640
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
 typedef short s16;
 
-struct Vec { Fix12i x, y, z; };
+
 
 extern int RandomIntInternal(int* seed);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
-extern s16 Vec3_HorzAngle(struct Vec* v0, struct Vec* v1);
+extern s16 Vec3_HorzAngle(struct Vector3* v0, struct Vector3* v1);
 extern int _Z14ApproachLinearRsss(s16* a, s16 b, s16 c);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* anim, void* file, int b, int fix, unsigned int e);
-extern void Vec3_Sub(struct Vec* out, struct Vec* a, struct Vec* b);
-extern int Vec3_HorzLen(struct Vec* v);
+extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
+extern int Vec3_HorzLen(struct Vector3* v);
 
 extern int data_0209e650;
 extern void* data_ov100_021489cc[];
@@ -17,7 +20,7 @@ extern void** data_ov100_021473b0[];
 
 void func_ov100_02146640(char* c)
 {
-    struct Vec d;
+    struct Vector3 d;
     int st = *(int*)(c + 0x150);
     if (st == 0) {
         unsigned r = RandomIntInternal(&data_0209e650);
@@ -31,14 +34,14 @@ void func_ov100_02146640(char* c)
 
     char* p = (char*)_ZN5Actor13ClosestPlayerEv(c);
     if (p) {
-        s16 ang = Vec3_HorzAngle((struct Vec*)(c + 0x5c), (struct Vec*)(p + 0x5c));
+        s16 ang = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), (struct Vector3*)(p + 0x5c));
         if (_Z14ApproachLinearRsss((s16*)(c + 0x94), ang, 0x400) != 0) {
             if (*(unsigned char*)(c + 0x15b) == 0) {
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
                     c + 0xd4, data_ov100_021489cc[1], 0, 0x1000, 0);
             }
         }
-        Vec3_Sub(&d, (struct Vec*)(c + 0x5c), (struct Vec*)(p + 0x5c));
+        Vec3_Sub(&d, (struct Vector3*)(c + 0x5c), (struct Vector3*)(p + 0x5c));
         if (Vec3_HorzLen(&d) >= *(int*)(c + 0x148))
             return;
         *(int*)(c + 0x150) = -1;

--- a/src/func_ov100_021467d4.c
+++ b/src/func_ov100_021467d4.c
@@ -1,4 +1,8 @@
-void func_ov100_021467d4(unsigned char *p)
+// @symbol func_ov100_021467d4
+// @emits Door_Kill
+/* recovered: renamed to Class_Method */
+/* daStarGate_c::Kill - recovered from vtable slot identity */
+void Door_Kill(unsigned char *p)
 {
     if (p[0x158] == 0)
         *(int *)(p + 0x14c) = 0;

--- a/src/func_ov100_02146828.c
+++ b/src/func_ov100_02146828.c
@@ -1,27 +1,31 @@
+// @symbol func_ov100_02146828
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-struct V3 { int x, y, z; };
-struct V16 { s16 x, y, z; };
+
+
 
 extern int data_0209caa0[];
 extern int data_0209f32c[];
 extern int data_0209e650;
 
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
-extern void Vec3_Sub(struct V3* out, void* a, void* b);
-extern int Vec3_HorzLen(struct V3* v);
+extern void Vec3_Sub(struct Vector3* out, void* a, void* b);
+extern int Vec3_HorzLen(struct Vector3* v);
 extern int RandomIntInternal(int* seed);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int area, int death);
-extern void func_ov100_0214629c(void* actor, int a);
 
 #pragma opt_loop_invariants off
 void func_ov100_02146828(char* self)
 {
-    struct V3 diff;
-    struct V16 rot;
-    struct V3 pos;
+    struct Vector3 diff;
+    struct Vector3_16 rot;
+    struct Vector3 pos;
     int n;
     int i;
     unsigned int kind;
@@ -41,7 +45,7 @@ void func_ov100_02146828(char* self)
     }
 
     {
-        struct V16 *sr = (struct V16*)(self + 0x92);
+        struct Vector3_16 *sr = (struct Vector3_16*)(self + 0x92);
         n = *(int*)(self + 8) & 0xf;
         rot = *sr;
         *(u8*)(self + 0x158) = 0;
@@ -78,7 +82,7 @@ void func_ov100_02146828(char* self)
                 0x158, kind, &pos, &rot, *(signed char*)(self + 0xcc), -1);
             if (a != 0) {
                 func_ov100_0214629c(a, *(int*)(self + 4));
-                (*(u8*)(((long long)(int)(self + 0x158)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(u8*)(((long long)(int)(self + 0x158))))++;
             }
         }
     }

--- a/src/func_ov100_02146dec.cpp
+++ b/src/func_ov100_02146dec.cpp
@@ -1,18 +1,22 @@
 //cpp
+// @symbol func_ov100_02146dec
+// @emits daObjPathLift_c_OnYoshiTryEat
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_Actor.h"
+#include "decl_Model.h"
+#include "decl_MovingMeshCollider.h"
+#include "decl_ShadowModel.h"
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjPathLift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
-extern void _ZN11ShadowModelD1Ev(void*);
 extern void func_0207328c(void* arr, int count, int size, void(*dtor)(void*));
-extern void _ZN18MovingMeshColliderD1Ev(void*);
-extern void _ZN5ModelD1Ev(void*);
-extern void _ZN5ActorD2Ev(void*);
-extern void _ZN6Memory10DeallocateEPvP4Heap(void*, void*);
-extern void* data_ov100_0214857c[];
 extern void* data_ov002_0210af70[];
 extern void* _ZTV17ExclamationSwitch[];
 extern void* data_020a0eac;
 
 
-void* func_ov100_02146dec(char* p){
+void* daObjPathLift_c_OnYoshiTryEat(char* p){
   *(void***)p = (void**)data_ov100_0214857c;
   _ZN11ShadowModelD1Ev(p+0x450);
   *(void***)p = (void**)data_ov002_0210af70;

--- a/src/func_ov100_02147054.c
+++ b/src/func_ov100_02147054.c
@@ -1,10 +1,12 @@
-extern int _ZN16MeshColliderBase9IsEnabledEv(void *);
-extern void _ZN16MeshColliderBase7DisableEv(void *);
+// @symbol func_ov100_02147054
+// @emits daObjPathLift_c_CleanupResources
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjPathLift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-extern int G1[];
-extern int G2[];
-int func_ov100_02147054(void *t)
+int daObjPathLift_c_CleanupResources(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov100_021470a4.cpp
+++ b/src/func_ov100_021470a4.cpp
@@ -1,9 +1,17 @@
 //cpp
+// @symbol func_ov100_021470a4
+/* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method, RTTI class fields named */
+#include "daObjPathLift_c.h"
+// @emits daObjPathLift_c_Render
+/* recovered: renamed to Class_Method */
+/* daObjPathLift_c::Render - recovered from vtable slot identity */
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 extern "C" {
-extern void func_ov002_020efc74(void* c);
-int func_ov100_021470a4(char* c){
-  unsigned short h = *(unsigned short*)(c+0x428);
+int daObjPathLift_c_Render(char* c){
+    struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
+  unsigned short h = self->unk_428;
   if(h < 0x5a){
     if(h & 1) return 1;
   }

--- a/src/func_ov100_021470f4.cpp
+++ b/src/func_ov100_021470f4.cpp
@@ -1,28 +1,33 @@
 //cpp
+// @symbol func_ov100_021470f4
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "daObjPathLift_c.h"
+// @emits daObjPathLift_c_Behavior
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjPathLift_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
 
-extern "C" void func_ov002_020efcf4(void* c);
 struct PathLift { void BaseBehavior(); };
 extern Fix12i Vec3_Dist(const Vector3* a, const Vector3* b);
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 namespace Sound { unsigned int PlayLong(unsigned int, unsigned int, unsigned int, const Vector3&, unsigned int); }
-extern "C" int func_ov100_0214700c(char* c);
 struct Platform2 { void UpdateClsnPosAndRot(); };
-extern "C" void func_ov100_02146e70(void* c);
 extern "C" void func_020393a4(int *p, int v);
 extern "C" void func_02039394(int *p, int v);
 struct MeshColliderBase { int IsEnabled(); void Enable(void *a); };
 struct Platform3 { int IsClsnInRange(Fix12i a, int b); };
 extern unsigned char data_0209f2d8;
 
-extern "C" int func_ov100_021470f4(char* c)
+extern "C" int daObjPathLift_c_Behavior(char* c)
 {
+    struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
     func_ov002_020efcf4(c);
     ((PathLift*)c)->BaseBehavior();
     if (Vec3_Dist((Vector3*)(c + 0x5c), (Vector3*)(c + 0x68)) != 0) {
         if (DecIfAbove0_Byte((unsigned char*)(c + 0x4b0)) == 0) {
-            *(unsigned int*)(c + 0x4a8) = Sound::PlayLong(*(unsigned int*)(c + 0x4a8), 3, 0x82, *(Vector3*)(c + 0x74), 0);
+            self->unk_4a8 = Sound::PlayLong(self->unk_4a8, 3, 0x82, *(Vector3*)(c + 0x74), 0);
         }
     }
     func_ov100_0214700c(c);

--- a/src/func_ov100_021471e0.cpp
+++ b/src/func_ov100_021471e0.cpp
@@ -1,5 +1,12 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov100_021471e0
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
+#include "daObjPathLift_c.h"
+// @emits daObjPathLift_c_InitResources
+/* recovered: shared common types, renamed to Class_Method */
+/* daObjPathLift_c::InitResources - recovered from vtable slot identity */
 struct Actor;
 struct RaycastGround {
   char pad[0x44];
@@ -22,13 +29,11 @@ void func_020393d4(int* p, int v);
 void func_020efaf0(char* c);
 }
 extern int data_ov002_0210d9f0;
-extern int data_ov100_02148a54;
-extern int data_ov100_02148a5c;
-extern int data_ov002_0210d7d4;
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern unsigned char data_0209f2d8;
 
-extern "C" int func_ov100_021471e0(char* c) {
+extern "C" int daObjPathLift_c_InitResources(char* c) {
+    struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
   Vector3 pos;
   _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov100_02148a54), 1, -1);
@@ -37,27 +42,27 @@ extern "C" int func_ov100_021471e0(char* c) {
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(
       c+0x124, _ZN12MeshCollider8LoadFileER13SharedFilePtr(&data_ov100_02148a5c),
-      c+0x2ec, 0x1000, *(short*)(c+0x8e), &data_ov002_0210d7d4);
+      c+0x2ec, 0x1000, self->unk_08e, &data_ov002_0210d7d4);
   func_020393d4((int*)(c+0x124), (int)&_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
-  *(int*)(c+0x440) = 0xa000;
-  *(int*)(c+0x98) = *(int*)(c+0x440);
+  self->unk_440 = 0xa000;
+  self->unk_098 = self->unk_440;
   func_020efaf0(c);
-  *(int*)(c+0x43c) = 1;
-  pos.x = *(int*)(c+0x5c);
-  pos.y = *(int*)(c+0x60);
-  pos.z = *(int*)(c+0x64);
+  self->unk_43c = 1;
+  pos.x = self->unk_05c;
+  pos.y = self->unk_060;
+  pos.z = self->unk_064;
   pos.y -= 0x14000;
   {
     RaycastGround rg;
     int b;
     rg.SetObjAndPos(pos, 0);
-    *(int*)(c+0x4ac) = pos.y;
+    self->unk_4ac = pos.y;
     if (rg.DetectClsn() != 0)
-      *(int*)(c+0x4ac) = rg.result;
-    *(unsigned char*)(c+0x42c) = 1;
+      self->unk_4ac = rg.result;
+    self->unk_42c = 1;
     b = (data_0209f2d8 == 1);
     if (b)
-      *(unsigned char*)(c+0x4b0) = 0xb4;
+      self->unk_4b0 = 0xb4;
   }
   return 1;
 }

--- a/src/func_ov102_02149220.cpp
+++ b/src/func_ov102_02149220.cpp
@@ -1,10 +1,14 @@
 //cpp
-struct Vector3 { int x,y,z; };
-struct Vector3_16 { short x,y,z; };
+// @symbol func_ov102_02149220
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" {
 extern void func_ov102_02149684(Vector3* out, void* self);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, Vector3*, Vector3_16*, int, int);
-extern void func_ov102_0214ad14(void*);
 extern void* func_ov102_0214b384(void*, int);
 void* func_ov102_02149220(char* c){
   Vector3 v;

--- a/src/func_ov102_02149288.cpp
+++ b/src/func_ov102_02149288.cpp
@@ -1,5 +1,8 @@
 //cpp
-struct Vector3{ int x,y,z; };
+// @symbol func_ov102_02149288
+/* recovered: shared common types */
+#include "common.h"
+
 struct Vector3_16;
 extern "C" {
 void func_ov102_02149684(Vector3* v, void* c);

--- a/src/func_ov102_021492d4.c
+++ b/src/func_ov102_021492d4.c
@@ -1,7 +1,10 @@
+// @symbol func_ov102_021492d4
+/* recovered: shared common types */
+#include "common.h"
 typedef short s16;
 typedef unsigned short u16;
-struct Vector3 { int x, y, z; };
-struct Vector3_16 { s16 x, y, z; };
+
+
 extern void func_ov102_02149684(int* dst, int* src);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, const struct Vector3* pos, const struct Vector3_16* rot, int a, int b);
 extern char data_020a0edc[];

--- a/src/func_ov102_02149384.cpp
+++ b/src/func_ov102_02149384.cpp
@@ -1,6 +1,9 @@
 //cpp
+// @symbol func_ov102_02149384
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct Vector3{int x,y,z;};
+
 extern void func_ov102_02149684(void*,void*);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int,unsigned int,Vector3*,void*,int,int);
 void* func_ov102_02149384(void* c){

--- a/src/func_ov102_021493dc.cpp
+++ b/src/func_ov102_021493dc.cpp
@@ -1,6 +1,9 @@
 //cpp
-struct Vector3 { int x,y,z; };
-struct Vector3_16 { short x,y,z; };
+// @symbol func_ov102_021493dc
+/* recovered: shared common types */
+#include "common.h"
+
+
 extern "C" int func_ov102_02149684(void* sp, void* c);
 extern "C" int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int,unsigned int,const Vector3&,const Vector3_16*,int,int);
 extern "C" void func_ov102_021493dc(void* c) {

--- a/src/func_ov102_02149428.c
+++ b/src/func_ov102_02149428.c
@@ -1,4 +1,6 @@
-struct Vector3 { int x,y,z; };
+// @symbol func_ov102_02149428
+/* recovered: shared common types */
+#include "common.h"
 extern int func_ov102_02149684(struct Vector3* out, void* b);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int,unsigned int,struct Vector3*,void*,int,int);
 extern int _ZN5Actor24KillAndTrackInDeathTableEv(void*);

--- a/src/func_ov102_021496a4.c
+++ b/src/func_ov102_021496a4.c
@@ -1,8 +1,12 @@
-extern int func_ov102_02149078(void *c);
-extern void func_ov102_02149da8(void *c, int i);
+// @symbol func_ov102_021496a4
+// @emits QuestionBlock_OnHitFromUnderneath
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHatenaBlock_c::OnHitFromUnderneath - recovered from vtable slot identity */
 typedef unsigned char u8;
 typedef short s16;
-void func_ov102_021496a4(void *c, void *x) {
+void QuestionBlock_OnHitFromUnderneath(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     *(int *)((char *)c + 0x9c) = -0x8000;
     *(int *)((char *)c + 0xa8) = 0x1e000;

--- a/src/func_ov102_02149710.c
+++ b/src/func_ov102_02149710.c
@@ -1,7 +1,11 @@
-extern int func_ov102_02149078(void *c);
+// @symbol func_ov102_02149710
+// @emits QuestionBlock_OnHitByMegaChar
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHatenaBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void _ZN6Player16IncMegaKillCountEv(void *p);
-extern void func_ov102_02149da8(void *c, int i);
-void func_ov102_02149710(void *c, void *player)
+void QuestionBlock_OnHitByMegaChar(void *c, void *player)
 {
     if (*(int*)((char*)c+0x3e8) == 1) return;
     if (func_ov102_02149078(c) != 0) return;

--- a/src/func_ov102_02149770.c
+++ b/src/func_ov102_02149770.c
@@ -1,8 +1,12 @@
+// @symbol func_ov102_02149770
+// @emits QuestionBlock_OnKicked
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHatenaBlock_c::OnKicked - recovered from vtable slot identity */
 
-extern int func_ov102_02149078(void *c);
-extern void func_ov102_02149da8(void *c, int i);
 typedef unsigned char u8;
-void func_ov102_02149770(void *c, void *x) {
+void QuestionBlock_OnKicked(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);
     if (r != 0) return;

--- a/src/func_ov102_021497c8.c
+++ b/src/func_ov102_021497c8.c
@@ -1,7 +1,11 @@
-extern int func_ov102_02149078(void* self);
-extern void func_ov102_02149da8(void* self, int a);
+// @symbol func_ov102_021497c8
+// @emits QuestionBlock_OnAttacked1
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHatenaBlock_c::OnAttacked1 - recovered from vtable slot identity */
 
-void func_ov102_021497c8(void* self, void* arg) {
+void QuestionBlock_OnAttacked1(void* self, void* arg) {
     int v = *(int*)((char*)self + 0x3e8);
     if (v == 1) return;
     if (func_ov102_02149078(self)) return;

--- a/src/func_ov102_02149820.c
+++ b/src/func_ov102_02149820.c
@@ -1,8 +1,12 @@
+// @symbol func_ov102_02149820
+// @emits QuestionBlock_OnGroundPounded
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daObjHatenaBlock_c::OnGroundPounded - recovered from vtable slot identity */
 
-extern int func_ov102_02149078(void *c);
-extern void func_ov102_02149da8(void *c, int i);
 typedef unsigned char u8;
-void func_ov102_02149820(void *c, void *x) {
+void QuestionBlock_OnGroundPounded(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);
     if (r != 0) return;

--- a/src/func_ov102_02149e38.cpp
+++ b/src/func_ov102_02149e38.cpp
@@ -1,12 +1,15 @@
 //cpp
+// @symbol func_ov102_02149e38
+/* recovered: shared common types */
+#include "common.h"
 extern "C" {
-struct M4 { int w[12]; };
+
 struct MMC { char p[0x124]; };
-struct Obj { char p[0x2ec]; M4 m; };
-int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, M4&, short);
+struct Obj { char p[0x2ec]; Matrix4x3 m; };
+int _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(MMC*, Matrix4x3&, short);
 void func_ov102_02149e38(char* self){
     Obj* o = (Obj*)self;
-    o->m = *(M4*)(self + 0xf0);
+    o->m = *(Matrix4x3*)(self + 0xf0);
     *(int*)(self+0x310) = *(int*)(self+0x5c);
     *(int*)(self+0x314) = *(int*)(self+0x60) + *(int*)(self+0x3dc);
     *(int*)(self+0x318) = *(int*)(self+0x64);

--- a/src/func_ov102_02149ff0.c
+++ b/src/func_ov102_02149ff0.c
@@ -1,4 +1,6 @@
-struct Mtx43 { int m[12]; };
+// @symbol func_ov102_02149ff0
+/* recovered: shared common types */
+#include "common.h"
 extern void Matrix4x3_FromRotationY(void *m, int angle);
 extern int data_0209caa0[];
 
@@ -13,5 +15,5 @@ void func_ov102_02149ff0(char *c)
     int b = (int)(*(unsigned short *)(c + 0xc) == 0x14);
     if (b == 0)
         return;
-    *(struct Mtx43 *)(c + 0x33c) = *(struct Mtx43 *)(c + 0xf0);
+    *(struct Matrix4x3 *)(c + 0x33c) = *(struct Matrix4x3 *)(c + 0xf0);
 }

--- a/src/func_ov102_0214aa10.c
+++ b/src/func_ov102_0214aa10.c
@@ -1,4 +1,8 @@
-int func_ov102_0214aa10(void)
+// @symbol func_ov102_0214aa10
+// @emits BobOmb_OnAimedAtWithEgg
+/* recovered: renamed to Class_Method */
+/* daBmb_c::OnAimedAtWithEgg - recovered from vtable slot identity */
+int BobOmb_OnAimedAtWithEgg(void)
 {
     return 204800;
 }

--- a/src/func_ov102_0214aa18.cpp
+++ b/src/func_ov102_0214aa18.cpp
@@ -1,4 +1,7 @@
 //cpp
+// @symbol func_ov102_0214aa18
+/* recovered: shared common types */
+#include "common.h"
 struct CylinderClsn { void Clear(); void Update(); };
 struct WithMeshClsn;
 struct Actor { void UpdatePos(CylinderClsn *c); };
@@ -9,7 +12,7 @@ extern "C" void func_ov102_0214ad40(char *c);
 extern "C" void func_ov102_0214c0b8(char *c);
 extern "C" void func_0200fc44(char *c, void *v, int x);
 
-struct V3 { int x, y, z; };
+
 
 extern "C" int func_ov102_0214aa18(Actor *self)
 {
@@ -26,7 +29,7 @@ extern "C" int func_ov102_0214aa18(Actor *self)
         ((CylinderClsn*)(s + 0x110))->Clear();
         ((CylinderClsn*)(s + 0x110))->Update();
         if (((WithMeshClsn2*)(s + 0x144))->JustHitGround()) {
-            V3 v;
+            Vector3 v;
             v.x = *(int*)(s + 0x5c);
             v.y = *(int*)(s + 0x60);
             v.z = *(int*)(s + 0x64);

--- a/src/func_ov102_0214adc8.c
+++ b/src/func_ov102_0214adc8.c
@@ -1,8 +1,13 @@
+// @symbol func_ov102_0214adc8
+// @emits BobOmb_OnTurnIntoEgg
+/* recovered: renamed to Class_Method, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: renamed to Class_Method */
+/* daBmb_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* pos);
 extern void GiveCoins(int who, int count);
 extern void _ZN6Player4HealEi(void* player, int amount);
-extern void func_ov102_0214baa0(void* thing);
-void func_ov102_0214adc8(void* thing, void* player)
+void BobOmb_OnTurnIntoEgg(void* thing, void* player)
 {
     unsigned char flag = *(unsigned char*)((char*)thing + 0x108);
     if (flag == 1) {

--- a/src/func_ov102_0214b988.cpp
+++ b/src/func_ov102_0214b988.cpp
@@ -1,10 +1,14 @@
 //cpp
-struct Vector3 { int x, y, z; };
+// @symbol func_ov102_0214b988
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
+
 
 extern "C" void *_ZN5Actor13ClosestPlayerEv(void *thiz);
 extern "C" int Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 extern "C" short Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
-extern "C" int AngleDiff(int a, int b);
 extern "C" void func_ov102_0214b384(void *thiz, int a);
 
 extern "C" void func_ov102_0214b988(void *thiz)
@@ -18,7 +22,7 @@ extern "C" void func_ov102_0214b988(void *thiz)
     if (!pl) return;
     if (Vec3_Dist((struct Vector3 *)(c + 0x5c), (struct Vector3 *)(pl + 0x5c)) > 0x190000) return;
     {
-        int *src = (int *)(((long long)(int)(pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *src = (int *)(((long long)(int)(pl + 0x5c)));
         v.x = src[0];
         v.y = src[1];
         v.z = src[2];

--- a/src/func_ov102_0214bd90.c
+++ b/src/func_ov102_0214bd90.c
@@ -1,13 +1,16 @@
-struct Vec3 { int x, y, z; };
+// @symbol func_ov102_0214bd90
+/* recovered: shared common types, declarations from a shared header */
+#include "decl_common.h"
+/* recovered: shared common types */
+#include "common.h"
 extern int _ZNK12WithMeshClsn13JustHitGroundEv(char* c);
-extern void func_0200fc44(char* c, struct Vec3* v, int a, int z);
+extern void func_0200fc44(char* c, struct Vector3* v, int a, int z);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(char* c);
 extern void func_ov102_0214beb4(char* c);
-extern void func_ov102_0214be1c(char* c);
 
 void func_ov102_0214bd90(char* r4){
   if (_ZNK12WithMeshClsn13JustHitGroundEv(r4 + 0x144)) {
-    struct Vec3 v;
+    struct Vector3 v;
     v.x = *(int*)(r4 + 0x5c);
     v.y = *(int*)(r4 + 0x60);
     v.z = *(int*)(r4 + 0x64);

--- a/src/func_ov102_0214c6e4.c
+++ b/src/func_ov102_0214c6e4.c
@@ -1,4 +1,8 @@
-int func_ov102_0214c6e4(unsigned char *p)
+// @symbol func_ov102_0214c6e4
+// @emits BobOmb_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daBmb_c::OnYoshiTryEat - recovered from vtable slot identity */
+int BobOmb_OnYoshiTryEat(unsigned char *p)
 {
     return p[263] == 0;
 }

--- a/src/func_ov102_0214ce60.cpp
+++ b/src/func_ov102_0214ce60.cpp
@@ -1,13 +1,16 @@
 //cpp
+// @symbol func_ov102_0214ce60
+/* recovered: shared common types */
+#include "common.h"
 typedef int Fix12i;
-struct Vector3 { int x, y, z; };
-struct M48 { int w[12]; };
+
+
 struct Player;
 struct ShadowModel;
 struct Matrix4x3;
 
 struct Actor {
-    M48& UpdateCarry(Player& p, const Vector3& v);
+    Matrix4x3& UpdateCarry(Player& p, const Vector3& v);
     void DropShadowRadHeight(ShadowModel& sm, Matrix4x3& m, Fix12i a, int b, unsigned int c);
 };
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);
@@ -20,7 +23,7 @@ extern "C" void func_ov102_0214ce60(char* c)
         v.x = 0x1e000;
         v.y = -0x1e000;
         v.z = 0x32000;
-        *(M48*)(c + 0x31c) = ((Actor*)c)->UpdateCarry(*(Player*)*(void**)(c + 0x3c0), v);
+        *(Matrix4x3*)(c + 0x31c) = ((Actor*)c)->UpdateCarry(*(Player*)*(void**)(c + 0x3c0), v);
     } else {
         Matrix4x3_FromRotationY(c + 0x31c, *(short*)(c + 0x8e));
         *(int*)(c + 0x340) = *(int*)(c + 0x5c) >> 3;

--- a/src/func_ov102_0214cfe4.cpp
+++ b/src/func_ov102_0214cfe4.cpp
@@ -1,7 +1,11 @@
 //cpp
+// @symbol func_ov102_0214cfe4
+// @emits BobOmb_Kill
+/* recovered: renamed to Class_Method */
+/* daBmb_c::Kill - recovered from vtable slot identity */
 extern "C" void _ZN5Actor8PoofDustEv(void *c);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *c);
-extern "C" int func_ov102_0214cfe4(char *c)
+extern "C" int BobOmb_Kill(char *c)
 {
     int flags;
     int b;

--- a/src/func_ov102_0214d6a0.c
+++ b/src/func_ov102_0214d6a0.c
@@ -1,4 +1,8 @@
-int func_ov102_0214d6a0(unsigned char *p)
+// @symbol func_ov102_0214d6a0
+// @emits KoopaShell_OnYoshiTryEat
+/* recovered: renamed to Class_Method */
+/* daShl_c::OnYoshiTryEat - recovered from vtable slot identity */
+int KoopaShell_OnYoshiTryEat(unsigned char *p)
 {
     return p[0x3c4] == 0 ? 6 : 5;
 }


### PR DESCRIPTION
Batch 15 of the readable-tree migration. Promotes 155 already-matched files to their readable form (shared headers, resolved vtable symbols, named members). Same bytes, same ROM. src-only, no header churn (headers landed in #866).

Local link-verification (parallel, mwccarm 1.2/sp2p3): 121 VERIFIED, 34 BLIND, 0 WRONG/NO-REPRO. 3 file(s) dropped as not reproducing against current main.

BLIND = instruction bytes verified, a few reloc slots reference an RTTI-recovered symbol not yet in config; not a wrong match.

Built with Claude Code.
