### PR TITLE
config: name 130 vtables with real RTTI class names + alias-aware resolver

### DIFF
--- a/config/arm9/overlays/ov002/symbols.txt
+++ b/config/arm9/overlays/ov002/symbols.txt
@@ -1689,6 +1689,7 @@ data_ov002_0210837c kind:data(any) addr:0x0210837c
 OneUpMushroom_SpawnInfo kind:data(any) addr:0x02108388
 MegaMushroom_SpawnInfo kind:data(any) addr:0x021083a4
 _ZTV13OneUpMushroom kind:data(any) addr:0x021083c8
+_ZTV7da1up_c kind:data(any) addr:0x021083c8
 data_ov002_02108444 kind:data(any) addr:0x02108444
 data_ov002_02108450 kind:data(any) addr:0x02108450
 InvisiblePole_SpawnInfo kind:data(any) addr:0x0210845c
@@ -1720,10 +1721,12 @@ Coin_SpawnInfo kind:data(any) addr:0x02108790
 RedCoin_SpawnInfo kind:data(any) addr:0x021087ac
 BlueCoin_SpawnInfo kind:data(any) addr:0x021087c8
 _ZTV4Coin kind:data(any) addr:0x021087ec
+_ZTV8daCoin_c kind:data(any) addr:0x021087ec
 data_ov002_02108868 kind:data(any) addr:0x02108868
 data_ov002_02108874 kind:data(any) addr:0x02108874
 WingFeather_SpawnInfo kind:data(any) addr:0x02108884
 _ZTV11WingFeather kind:data(any) addr:0x021088a8
+_ZTV11daFeather_c kind:data(any) addr:0x021088a8
 data_ov002_02108924 kind:data(any) addr:0x02108924
 data_ov002_02108930 kind:data(any) addr:0x02108930
 Bubble_SpawnInfo kind:data(any) addr:0x02108940
@@ -1758,6 +1761,7 @@ data_ov002_02108ca0 kind:data(any) addr:0x02108ca0
 MegaMushroomTag_SpawnInfo kind:data(any) addr:0x02108cb4
 MegaMushroomCreateTag_SpawnInfo kind:data(any) addr:0x02108cd0
 _ZTV21MegaMushroomCreateTag kind:data(any) addr:0x02108cf4
+_ZTV16daObjKinokoTag_c kind:data(any) addr:0x02108cf4
 data_ov002_02108d70 kind:data(any) addr:0x02108d70
 data_ov002_02108d7c kind:data(any) addr:0x02108d7c
 data_ov002_02108d94 kind:data(any) addr:0x02108d94
@@ -1770,6 +1774,7 @@ data_ov002_02108ee8 kind:data(any) addr:0x02108ee8
 RedFlame_SpawnInfo kind:data(any) addr:0x02108ef8
 BlueFlame_SpawnInfo kind:data(any) addr:0x02108f14
 _ZTV9BlueFlame kind:data(any) addr:0x02108f38
+_ZTV11daObjFire_c kind:data(any) addr:0x02108f38
 data_ov002_02108fb4 kind:data(any) addr:0x02108fb4
 data_ov002_02108fc0 kind:data(any) addr:0x02108fc0
 data_ov002_02108fdc kind:data(any) addr:0x02108fdc
@@ -1818,6 +1823,7 @@ data_ov002_021095ac kind:data(any) addr:0x021095ac
 data_ov002_021095b8 kind:data(any) addr:0x021095b8
 Cap_SpawnInfo kind:data(any) addr:0x021095cc ambiguous
 _ZTV13WaterfallMist kind:data(any) addr:0x021095f0
+_ZTV15daObjMarioCap_c kind:data(any) addr:0x021095f0
 data_ov002_0210966c kind:data(any) addr:0x0210966c
 data_ov002_02109678 kind:data(any) addr:0x02109678
 PushBlock_SpawnInfo kind:data(any) addr:0x0210968c
@@ -1836,6 +1842,7 @@ data_ov002_02109788 kind:data(any) addr:0x02109788
 PowerFlower_SpawnInfo kind:data(any) addr:0x021097a0
 data_ov002_021097bc kind:data(any) addr:0x021097bc
 _ZTV9PushBlock kind:data(any) addr:0x02109800
+_ZTV18daObjPowerUpItem_c kind:data(any) addr:0x02109800
 data_ov002_0210987c kind:data(any) addr:0x0210987c
 data_ov002_02109884 kind:data(any) addr:0x02109884
 data_ov002_0210988c kind:data(any) addr:0x0210988c
@@ -1871,6 +1878,7 @@ data_ov002_02109ab4 kind:data(any) addr:0x02109ab4
 data_ov002_02109ac0 kind:data(any) addr:0x02109ac0
 SignPost_SpawnInfo kind:data(any) addr:0x02109ad4
 _ZTV8SignPost kind:data(any) addr:0x02109af8
+_ZTV15daObjTatefuda_c kind:data(any) addr:0x02109af8
 data_ov002_02109b78 kind:data(any) addr:0x02109b78
 data_ov002_02109b84 kind:data(any) addr:0x02109b84
 Seaweed_SpawnInfo kind:data(any) addr:0x02109b94
@@ -1879,6 +1887,7 @@ data_ov002_02109c34 kind:data(any) addr:0x02109c34
 data_ov002_02109c40 kind:data(any) addr:0x02109c40
 HealingHeart_SpawnInfo kind:data(any) addr:0x02109c50
 _ZTV7Seaweed kind:data(any) addr:0x02109c74
+_ZTV12daObjHeart_c kind:data(any) addr:0x02109c74
 data_ov002_02109cf0 kind:data(any) addr:0x02109cf0
 data_ov002_02109cfc kind:data(any) addr:0x02109cfc
 CannonHatch_SpawnInfo kind:data(any) addr:0x02109d14
@@ -2187,7 +2196,9 @@ SilverStar_SpawnInfo kind:data(any) addr:0x0210aa5c
 StarMarker_SpawnInfo kind:data(any) addr:0x0210aa78
 StarCamera_SpawnInfo kind:data(any) addr:0x0210aa94
 _ZTV10StarMarker kind:data(any) addr:0x0210aab8
+_ZTV12daStarBase_c kind:data(any) addr:0x0210aab8
 _ZTV9PowerStar kind:data(any) addr:0x0210ab3c
+_ZTV8daStar_c kind:data(any) addr:0x0210ab3c
 data_ov002_0210abb8 kind:data(any) addr:0x0210abb8
 data_ov002_0210abc4 kind:data(any) addr:0x0210abc4
 data_ov002_0210abd0 kind:data(any) addr:0x0210abd0
@@ -2209,6 +2220,7 @@ data_ov002_0210ad78 kind:data(any) addr:0x0210ad78
 data_ov002_0210ad84 kind:data(any) addr:0x0210ad84
 YoshiEgg_SpawnInfo kind:data(any) addr:0x0210ad90
 _ZTV8YoshiEgg kind:data(any) addr:0x0210adb4
+_ZTV8daYegg_c kind:data(any) addr:0x0210adb4
 _ZTV17ExclamationSwitch kind:data(any) addr:0x0210ae38
 data_ov002_0210aeb8 kind:data(any) addr:0x0210aeb8
 data_ov002_0210aec0 kind:data(any) addr:0x0210aec0
@@ -2232,10 +2244,12 @@ data_ov002_0210b0ac kind:data(any) addr:0x0210b0ac
 data_ov002_0210b0b8 kind:data(any) addr:0x0210b0b8
 Number_SpawnInfo kind:data(any) addr:0x0210b0c8
 _ZTV15InvisibleSecret kind:data(any) addr:0x0210b0ec
+_ZTV13daObjNumber_c kind:data(any) addr:0x0210b0ec
 data_ov002_0210b168 kind:data(any) addr:0x0210b168
 data_ov002_0210b174 kind:data(any) addr:0x0210b174
 OneUpLogo_SpawnInfo kind:data(any) addr:0x0210b188
 _ZTV9OneUpLogo kind:data(any) addr:0x0210b1ac
+_ZTV14daObj1UpLogo_c kind:data(any) addr:0x0210b1ac
 data_ov002_0210b228 kind:data(any) addr:0x0210b228
 data_ov002_0210b234 kind:data(any) addr:0x0210b234
 BlueCoinSwitch_SpawnInfo kind:data(any) addr:0x0210b248
@@ -2248,6 +2262,7 @@ EnemySwitchTag_SpawnInfo kind:data(any) addr:0x0210b324
 EnemySpawner_SpawnInfo kind:data(any) addr:0x0210b340
 _ZTV12EnemySpawner kind:data(any) addr:0x0210b364
 _ZTV14BlueCoinSwitch kind:data(any) addr:0x0210b3e8
+_ZTV11daESwitch_c kind:data(any) addr:0x0210b3e8
 data_ov002_0210b464 kind:data(any) addr:0x0210b464
 data_ov002_0210b470 kind:data(any) addr:0x0210b470
 AmbientSoundEffects_SpawnInfo kind:data(any) addr:0x0210b47c
@@ -2411,6 +2426,7 @@ data_ov002_0210bf54 kind:data(any) addr:0x0210bf54
 data_ov002_0210bf60 kind:data(any) addr:0x0210bf60
 Fireball_SpawnInfo kind:data(any) addr:0x0210bf70
 _ZTV8Fireball kind:data(any) addr:0x0210bf94
+_ZTV12daFPknBall_c kind:data(any) addr:0x0210bf94
 data_ov002_0210c010 kind:data(any) addr:0x0210c010
 data_ov002_0210c018 kind:data(any) addr:0x0210c018
 data_ov002_0210c020 kind:data(any) addr:0x0210c020
@@ -2621,6 +2637,7 @@ data_ov002_0210d608 kind:data(any) addr:0x0210d608
 data_ov002_0210d614 kind:data(any) addr:0x0210d614
 Bullet_SpawnInfo kind:data(any) addr:0x0210d630
 _ZTV6Bullet kind:data(any) addr:0x0210d654
+_ZTV24daPropeller_Heyho_Fire_c kind:data(any) addr:0x0210d654
 data_ov002_0210d6d0 kind:data(any) addr:0x0210d6d0
 data_ov002_0210d6dc kind:data(any) addr:0x0210d6dc
 data_ov002_0210d6f4 kind:data(any) addr:0x0210d6f4

--- a/config/arm9/overlays/ov009/symbols.txt
+++ b/config/arm9/overlays/ov009/symbols.txt
@@ -147,6 +147,7 @@ data_ov009_0211391c kind:data(any) addr:0x0211391c
 data_ov009_02113928 kind:data(any) addr:0x02113928
 Bird_SpawnInfo kind:data(any) addr:0x02113934 ambiguous
 _ZTV4Bird kind:data(any) addr:0x02113958
+_ZTV9daSBird_c kind:data(any) addr:0x02113958
 data_ov009_02113980 kind:data(any) addr:0x02113980 ambiguous
 data_ov009_02113998 kind:data(any) addr:0x02113998 ambiguous
 data_ov009_021139b0 kind:data(any) addr:0x021139b0 ambiguous
@@ -171,6 +172,7 @@ Flag_SpawnInfo kind:data(any) addr:0x02113b7c ambiguous
 data_ov009_02113b80 kind:data(any) addr:0x02113b80 ambiguous
 data_ov009_02113b90 kind:data(any) addr:0x02113b90 ambiguous
 _ZTV8DockPole kind:data(any) addr:0x02113ba0
+_ZTV10daMcFlag_c kind:data(any) addr:0x02113ba0
 data_ov009_02113c08 kind:data(any) addr:0x02113c08 ambiguous
 data_ov009_02113c14 kind:data(any) addr:0x02113c14 ambiguous
 data_ov009_02113c20 kind:bss addr:0x02113c20

--- a/config/arm9/overlays/ov010/symbols.txt
+++ b/config/arm9/overlays/ov010/symbols.txt
@@ -124,6 +124,7 @@ data_ov010_02112b64 kind:data(any) addr:0x02112b64
 data_ov010_02112b70 kind:data(any) addr:0x02112b70
 LightBeam_SpawnInfo kind:data(any) addr:0x02112b84 ambiguous
 _ZTV4Trap kind:data(any) addr:0x02112ba8
+_ZTV15daObjC1Hikari_c kind:data(any) addr:0x02112ba8
 data_ov010_02112bdc kind:data(any) addr:0x02112bdc ambiguous
 data_ov010_02112bec kind:data(any) addr:0x02112bec ambiguous
 data_ov010_02112c08 kind:data(any) addr:0x02112c08 ambiguous
@@ -134,6 +135,7 @@ PeachPainting_SpawnInfo kind:data(any) addr:0x02112c44 ambiguous
 data_ov010_02112c4c kind:data(any) addr:0x02112c4c ambiguous
 data_ov010_02112c58 kind:data(any) addr:0x02112c58 ambiguous
 _ZTV13PeachPainting kind:data(any) addr:0x02112c68
+_ZTV14daObjC1Peach_c kind:data(any) addr:0x02112c68
 data_ov010_02112c88 kind:data(any) addr:0x02112c88 ambiguous
 data_ov010_02112ca8 kind:data(any) addr:0x02112ca8 ambiguous
 data_ov010_02112cc8 kind:data(any) addr:0x02112cc8 ambiguous

--- a/config/arm9/overlays/ov012/symbols.txt
+++ b/config/arm9/overlays/ov012/symbols.txt
@@ -105,6 +105,7 @@ BasementWater_SpawnInfo kind:data(any) addr:0x021123e4 ambiguous
 data_ov012_021123f4 kind:data(any) addr:0x021123f4 ambiguous
 data_ov012_02112404 kind:data(any) addr:0x02112404 ambiguous
 _ZTV12SwitchPillar kind:data(any) addr:0x02112408
+_ZTV14daObjC0Water_c kind:data(any) addr:0x02112408
 data_ov012_0211241c kind:data(any) addr:0x0211241c ambiguous
 data_ov012_02112428 kind:data(any) addr:0x02112428 ambiguous
 data_ov012_02112434 kind:data(any) addr:0x02112434 ambiguous

--- a/config/arm9/overlays/ov013/symbols.txt
+++ b/config/arm9/overlays/ov013/symbols.txt
@@ -101,6 +101,7 @@ ClockPaintingHandLong_SpawnInfo kind:data(any) addr:0x021121c0 ambiguous
 ClockPaintingHandShort_SpawnInfo kind:data(any) addr:0x021121dc ambiguous
 data_ov013_021121f8 kind:data(any) addr:0x021121f8 ambiguous
 _ZTV22ClockPaintingHandShort kind:data(any) addr:0x02112200
+_ZTV12daObjClock_c kind:data(any) addr:0x02112200
 data_ov013_02112258 kind:data(any) addr:0x02112258 ambiguous
 data_ov013_0211227c kind:data(any) addr:0x0211227c ambiguous
 data_ov013_02112280 kind:bss addr:0x02112280

--- a/config/arm9/overlays/ov015/symbols.txt
+++ b/config/arm9/overlays/ov015/symbols.txt
@@ -205,6 +205,7 @@ data_ov015_021143dc kind:data(any) addr:0x021143dc
 data_ov015_021143e8 kind:data(any) addr:0x021143e8
 KnockDownPlank_SpawnInfo kind:data(any) addr:0x021143fc ambiguous
 _ZTV13PoleBillboard kind:data(any) addr:0x02114420
+_ZTV17daObjBk_Botaosi_c kind:data(any) addr:0x02114420
 data_ov015_02114458 kind:data(any) addr:0x02114458 ambiguous
 data_ov015_02114498 kind:data(any) addr:0x02114498 ambiguous
 data_ov015_021144a0 kind:data(any) addr:0x021144a0
@@ -235,6 +236,7 @@ data_ov015_0211460c kind:data(any) addr:0x0211460c
 data_ov015_02114618 kind:data(any) addr:0x02114618
 TowerStep_SpawnInfo kind:data(any) addr:0x0211462c ambiguous
 _ZTV14MovingBarSmall kind:data(any) addr:0x02114650
+_ZTV14daObjBk_Lift_c kind:data(any) addr:0x02114650
 data_ov015_021146d0 kind:data(any) addr:0x021146d0
 data_ov015_021146dc kind:data(any) addr:0x021146dc
 RotatingBridge_SpawnInfo kind:data(any) addr:0x021146f0 ambiguous

--- a/config/arm9/overlays/ov016/symbols.txt
+++ b/config/arm9/overlays/ov016/symbols.txt
@@ -189,6 +189,7 @@ data_ov016_02114c4c kind:data(any) addr:0x02114c4c
 data_ov016_02114c58 kind:data(any) addr:0x02114c58
 SlidingBox_SpawnInfo kind:data(any) addr:0x02114c68
 _ZTV23FloatOnWaterPlatformJrb kind:data(any) addr:0x02114c8c
+_ZTV13daSlide_Box_c kind:data(any) addr:0x02114c8c
 data_ov016_02114d20 kind:bss addr:0x02114d20
 data_ov016_02114d28 kind:bss addr:0x02114d28
 data_ov016_02114d30 kind:bss addr:0x02114d30

--- a/config/arm9/overlays/ov017/symbols.txt
+++ b/config/arm9/overlays/ov017/symbols.txt
@@ -74,6 +74,7 @@ data_ov017_02111bc0 kind:data(any) addr:0x02111bc0
 ShipWater_SpawnInfo kind:data(any) addr:0x02111bd4 ambiguous
 data_ov017_02111be0 kind:data(any) addr:0x02111be0 ambiguous
 _ZTV9ShipWater kind:data(any) addr:0x02111bf8
+_ZTV14daObjKsWater_c kind:data(any) addr:0x02111bf8
 data_ov017_02111c20 kind:data(any) addr:0x02111c20 ambiguous
 data_ov017_02111c54 kind:data(any) addr:0x02111c54 ambiguous
 data_ov017_02111c80 kind:bss addr:0x02111c80

--- a/config/arm9/overlays/ov018/symbols.txt
+++ b/config/arm9/overlays/ov018/symbols.txt
@@ -145,6 +145,7 @@ data_ov018_02113988 kind:data(any) addr:0x02113988
 MotherPenguin_SpawnInfo kind:data(any) addr:0x02113998 ambiguous
 data_ov018_021139b0 kind:data(any) addr:0x021139b0 ambiguous
 _ZTV7SkiLift kind:data(any) addr:0x021139bc
+_ZTV10daPgMthr_c kind:data(any) addr:0x021139bc
 data_ov018_021139f4 kind:data(any) addr:0x021139f4 ambiguous
 BridgePenguin_SpawnInfo kind:data(any) addr:0x02113a00 ambiguous
 data_ov018_02113a38 kind:data(any) addr:0x02113a38

--- a/config/arm9/overlays/ov019/symbols.txt
+++ b/config/arm9/overlays/ov019/symbols.txt
@@ -102,6 +102,7 @@ data_ov019_021132d0 kind:data(any) addr:0x021132d0
 data_ov019_021132dc kind:data(any) addr:0x021132dc
 RacingPenguin_SpawnInfo kind:data(any) addr:0x021132ec ambiguous
 _ZTV13RacingPenguin kind:data(any) addr:0x02113310
+_ZTV10daPgRcer_c kind:data(any) addr:0x02113310
 data_ov019_02113344 kind:data(any) addr:0x02113344 ambiguous
 data_ov019_0211338c kind:data(any) addr:0x0211338c
 data_ov019_02113398 kind:data(any) addr:0x02113398

--- a/config/arm9/overlays/ov020/symbols.txt
+++ b/config/arm9/overlays/ov020/symbols.txt
@@ -212,11 +212,13 @@ _ZTV15BookShotSpawner kind:data(any) addr:0x021148d8
 data_ov020_021148e0 kind:data(any) addr:0x021148e0 ambiguous
 data_ov020_021148f0 kind:data(any) addr:0x021148f0 ambiguous
 _ZTV8BookShot kind:data(any) addr:0x0211495c
+_ZTV8daBook_c kind:data(any) addr:0x0211495c
 data_ov020_021149d8 kind:data(any) addr:0x021149d8
 data_ov020_021149e4 kind:data(any) addr:0x021149e4
 HauntedChair_SpawnInfo kind:data(any) addr:0x021149f0 ambiguous
 data_ov020_021149fc kind:data(any) addr:0x021149fc ambiguous
 _ZTV12HauntedChair kind:data(any) addr:0x02114a14
+_ZTV9daChair_c kind:data(any) addr:0x02114a14
 data_ov020_02114a18 kind:data(any) addr:0x02114a18 ambiguous
 data_ov020_02114aa0 kind:bss addr:0x02114aa0
 data_ov020_02114aa8 kind:bss addr:0x02114aa8

--- a/config/arm9/overlays/ov021/symbols.txt
+++ b/config/arm9/overlays/ov021/symbols.txt
@@ -200,6 +200,7 @@ data_ov021_0211480c kind:data(any) addr:0x0211480c
 data_ov021_02114818 kind:data(any) addr:0x02114818
 RollingRock_SpawnInfo kind:data(any) addr:0x02114824 ambiguous
 _ZTV11RollingRock kind:data(any) addr:0x02114848
+_ZTV9daGrock_c kind:data(any) addr:0x02114848
 data_ov021_02114860 kind:data(any) addr:0x02114860 ambiguous
 data_ov021_02114874 kind:data(any) addr:0x02114874 ambiguous
 data_ov021_0211487c kind:data(any) addr:0x0211487c ambiguous

--- a/config/arm9/overlays/ov022/symbols.txt
+++ b/config/arm9/overlays/ov022/symbols.txt
@@ -252,6 +252,7 @@ data_ov022_02114434 kind:data(any) addr:0x02114434
 data_ov022_02114440 kind:data(any) addr:0x02114440
 VolcanoFire_SpawnInfo kind:data(any) addr:0x02114458 ambiguous
 _ZTV13RollingLogLll kind:data(any) addr:0x0211447c
+_ZTV21daObj_volcanoCannon_c kind:data(any) addr:0x0211447c
 data_ov022_02114498 kind:data(any) addr:0x02114498 ambiguous
 data_ov022_02114500 kind:bss addr:0x02114500
 data_ov022_02114508 kind:bss addr:0x02114508

--- a/config/arm9/overlays/ov024/symbols.txt
+++ b/config/arm9/overlays/ov024/symbols.txt
@@ -181,10 +181,12 @@ PyramidTop_SpawnInfo kind:data(any) addr:0x02113804 ambiguous
 PyramidTag_SpawnInfo kind:data(any) addr:0x02113820 ambiguous
 data_ov024_0211382c kind:data(any) addr:0x0211382c ambiguous
 _ZTV10PyramidTag kind:data(any) addr:0x02113844
+_ZTV21daObjDlPyramidDummy_c kind:data(any) addr:0x02113844
 data_ov024_021138a8 kind:data(any) addr:0x021138a8 ambiguous
 data_ov024_021138bc kind:data(any) addr:0x021138bc ambiguous
 data_ov024_021138c4 kind:data(any) addr:0x021138c4 ambiguous
 _ZTV10PyramidTop kind:data(any) addr:0x021138c8
+_ZTV16daObjDlPyramid_c kind:data(any) addr:0x021138c8
 data_ov024_021138d8 kind:data(any) addr:0x021138d8 ambiguous
 data_ov024_021138f0 kind:data(any) addr:0x021138f0 ambiguous
 data_ov024_021138fc kind:data(any) addr:0x021138fc ambiguous

--- a/config/arm9/overlays/ov025/symbols.txt
+++ b/config/arm9/overlays/ov025/symbols.txt
@@ -134,6 +134,7 @@ data_ov025_021138dc kind:data(any) addr:0x021138dc
 PyramidStep_SpawnInfo kind:data(any) addr:0x021138f0 ambiguous
 data_ov025_021138fc kind:data(any) addr:0x021138fc ambiguous
 _ZTV11PyramidStep kind:data(any) addr:0x02113914
+_ZTV14daObjDpBrock_c kind:data(any) addr:0x02113914
 data_ov025_02113934 kind:data(any) addr:0x02113934 ambiguous
 data_ov025_02113980 kind:data(any) addr:0x02113980 ambiguous
 data_ov025_02113994 kind:data(any) addr:0x02113994

--- a/config/arm9/overlays/ov026/symbols.txt
+++ b/config/arm9/overlays/ov026/symbols.txt
@@ -199,6 +199,7 @@ data_ov026_02113d0c kind:data(any) addr:0x02113d0c
 data_ov026_02113d18 kind:data(any) addr:0x02113d18
 Whirlpool_SpawnInfo kind:data(any) addr:0x02113d30 ambiguous
 _ZTV9Submarine kind:data(any) addr:0x02113d54
+_ZTV18daWater_Tatumaki_c kind:data(any) addr:0x02113d54
 data_ov026_02113d90 kind:data(any) addr:0x02113d90 ambiguous
 data_ov026_02113da8 kind:data(any) addr:0x02113da8 ambiguous
 data_ov026_02113dc4 kind:data(any) addr:0x02113dc4 ambiguous
@@ -208,6 +209,7 @@ data_ov026_02113de0 kind:data(any) addr:0x02113de0
 data_ov026_02113dec kind:data(any) addr:0x02113dec
 WaterSuction_SpawnInfo kind:data(any) addr:0x02113e00 ambiguous
 _ZTV12WaterSuction kind:data(any) addr:0x02113e24
+_ZTV17daWater_Suikomi_c kind:data(any) addr:0x02113e24
 data_ov026_02113e50 kind:data(any) addr:0x02113e50 ambiguous
 data_ov026_02113e6c kind:data(any) addr:0x02113e6c ambiguous
 data_ov026_02113e88 kind:data(any) addr:0x02113e88 ambiguous

--- a/config/arm9/overlays/ov029/symbols.txt
+++ b/config/arm9/overlays/ov029/symbols.txt
@@ -191,6 +191,7 @@ data_ov029_02113d7c kind:data(any) addr:0x02113d7c
 WaterDiamond_SpawnInfo kind:data(any) addr:0x02113d90 ambiguous
 data_ov029_02113da8 kind:data(any) addr:0x02113da8 ambiguous
 _ZTV9ArrowLift kind:data(any) addr:0x02113db4
+_ZTV15daObjWc_Obj03_c kind:data(any) addr:0x02113db4
 data_ov029_02113dc4 kind:data(any) addr:0x02113dc4 ambiguous
 data_ov029_02113e00 kind:data(any) addr:0x02113e00 ambiguous
 data_ov029_02113e30 kind:data(any) addr:0x02113e30
@@ -217,6 +218,7 @@ data_ov029_02114098 kind:data(any) addr:0x02114098
 data_ov029_021140a4 kind:data(any) addr:0x021140a4
 WDW_Water_SpawnInfo kind:data(any) addr:0x021140b8 ambiguous
 _ZTV19RotatingPlatformWdw kind:data(any) addr:0x021140dc
+_ZTV14daObjWc_Mizu_c kind:data(any) addr:0x021140dc
 data_ov029_021140ec kind:data(any) addr:0x021140ec ambiguous
 data_ov029_021140f8 kind:data(any) addr:0x021140f8 ambiguous
 data_ov029_02114108 kind:data(any) addr:0x02114108 ambiguous
@@ -224,6 +226,7 @@ data_ov029_0211415c kind:data(any) addr:0x0211415c
 data_ov029_02114168 kind:data(any) addr:0x02114168
 SwitchActivatedPlank_SpawnInfo kind:data(any) addr:0x0211417c ambiguous
 _ZTV20SwitchActivatedPlank kind:data(any) addr:0x021141a0
+_ZTV15daObjWc_Obj04_c kind:data(any) addr:0x021141a0
 data_ov029_021141cc kind:data(any) addr:0x021141cc ambiguous
 data_ov029_02114220 kind:bss addr:0x02114220
 data_ov029_02114228 kind:bss addr:0x02114228

--- a/config/arm9/overlays/ov030/symbols.txt
+++ b/config/arm9/overlays/ov030/symbols.txt
@@ -141,6 +141,7 @@ UkikiThief_SpawnInfo kind:data(any) addr:0x02115b90
 UkikiStar_SpawnInfo kind:data(any) addr:0x02115bac ambiguous
 data_ov030_02115bc8 kind:data(any) addr:0x02115bc8
 _ZTV13RollingLogTtm kind:data(any) addr:0x02115bfc
+_ZTV7daMky_c kind:data(any) addr:0x02115bfc
 data_ov030_02115c80 kind:bss addr:0x02115c80
 data_ov030_02115c88 kind:bss addr:0x02115c88
 data_ov030_02115c90 kind:bss addr:0x02115c90

--- a/config/arm9/overlays/ov031/symbols.txt
+++ b/config/arm9/overlays/ov031/symbols.txt
@@ -56,6 +56,7 @@ data_ov031_0211192c kind:data(any) addr:0x0211192c ambiguous
 SlideDecorationOrangeSmiley_SpawnInfo kind:data(any) addr:0x02111944 ambiguous
 SlideDecorationBlueSmiley_SpawnInfo kind:data(any) addr:0x02111960 ambiguous
 _ZTV25SlideDecorationSilverStar kind:data(any) addr:0x02111984
+_ZTV18daObjHsBillboard_c kind:data(any) addr:0x02111984
 data_ov031_02111994 kind:data(any) addr:0x02111994 ambiguous
 data_ov031_02111a00 kind:bss addr:0x02111a00
 data_ov031_02111a08 kind:bss addr:0x02111a08

--- a/config/arm9/overlays/ov032/symbols.txt
+++ b/config/arm9/overlays/ov032/symbols.txt
@@ -143,6 +143,7 @@ data_ov032_0211396c kind:data(any) addr:0x0211396c
 HugeWater_SpawnInfo kind:data(any) addr:0x02113980 ambiguous
 data_ov032_02113998 kind:data(any) addr:0x02113998 ambiguous
 _ZTV9HugeCover kind:data(any) addr:0x021139a4
+_ZTV14daObjTdWater_c kind:data(any) addr:0x021139a4
 data_ov032_021139b0 kind:data(any) addr:0x021139b0 ambiguous
 data_ov032_021139f4 kind:data(any) addr:0x021139f4 ambiguous
 data_ov032_02113a00 kind:data(any) addr:0x02113a00 ambiguous

--- a/config/arm9/overlays/ov035/symbols.txt
+++ b/config/arm9/overlays/ov035/symbols.txt
@@ -112,6 +112,7 @@ data_ov035_02112b88 kind:data(any) addr:0x02112b88
 data_ov035_02112b94 kind:data(any) addr:0x02112b94
 SpinningPlatform_SpawnInfo kind:data(any) addr:0x02112ba8 ambiguous
 _ZTV17RotatingClockHand kind:data(any) addr:0x02112bcc
+_ZTV16daObjCtMecha11_c kind:data(any) addr:0x02112bcc
 data_ov035_02112bdc kind:data(any) addr:0x02112bdc ambiguous
 data_ov035_02112bec kind:data(any) addr:0x02112bec ambiguous
 data_ov035_02112c08 kind:data(any) addr:0x02112c08 ambiguous

--- a/config/arm9/overlays/ov036/symbols.txt
+++ b/config/arm9/overlays/ov036/symbols.txt
@@ -176,6 +176,7 @@ ShipWing_SpawnInfo kind:data(any) addr:0x02113c14 ambiguous
 data_ov036_02113c20 kind:data(any) addr:0x02113c20 ambiguous
 data_ov036_02113c28 kind:data(any) addr:0x02113c28 ambiguous
 _ZTV18RotatingPlatformRr kind:data(any) addr:0x02113c38
+_ZTV14daObjRc_Hane_c kind:data(any) addr:0x02113c38
 data_ov036_02113c48 kind:data(any) addr:0x02113c48 ambiguous
 data_ov036_02113cb4 kind:data(any) addr:0x02113cb4
 data_ov036_02113cc0 kind:data(any) addr:0x02113cc0
@@ -184,6 +185,7 @@ DonutBlock_SpawnInfo kind:data(any) addr:0x02113cd4 ambiguous
 data_ov036_02113cec kind:data(any) addr:0x02113cec ambiguous
 data_ov036_02113cf4 kind:data(any) addr:0x02113cf4 ambiguous
 _ZTV8ShipWing kind:data(any) addr:0x02113cf8
+_ZTV16daObjRc_Tikuwa_c kind:data(any) addr:0x02113cf8
 data_ov036_02113d30 kind:data(any) addr:0x02113d30 ambiguous
 data_ov036_02113d78 kind:data(any) addr:0x02113d78
 data_ov036_02113d84 kind:data(any) addr:0x02113d84

--- a/config/arm9/overlays/ov039/symbols.txt
+++ b/config/arm9/overlays/ov039/symbols.txt
@@ -50,6 +50,7 @@ data_ov039_02111824 kind:data(any) addr:0x02111824
 Cloud_SpawnInfo kind:data(any) addr:0x02111834 ambiguous
 data_ov039_02111844 kind:data(any) addr:0x02111844 ambiguous
 _ZTV5Cloud kind:data(any) addr:0x02111858
+_ZTV11daObjKumo_c kind:data(any) addr:0x02111858
 data_ov039_021118e0 kind:bss addr:0x021118e0
 data_ov039_021118e4 kind:bss addr:0x021118e4
 data_ov039_021118ec kind:bss addr:0x021118ec

--- a/config/arm9/overlays/ov045/symbols.txt
+++ b/config/arm9/overlays/ov045/symbols.txt
@@ -132,10 +132,12 @@ data_ov045_02112d74 kind:data(any) addr:0x02112d74
 data_ov045_02112d80 kind:data(any) addr:0x02112d80
 PoleLift_SpawnInfo kind:data(any) addr:0x02112d98 ambiguous
 _ZTV15FireSeaElevator kind:data(any) addr:0x02112dbc
+_ZTV18daObjKm2_Ami_Bou_c kind:data(any) addr:0x02112dbc
 data_ov045_02112e3c kind:data(any) addr:0x02112e3c
 data_ov045_02112e48 kind:data(any) addr:0x02112e48
 ExtendingPlatform_SpawnInfo kind:data(any) addr:0x02112e5c ambiguous
 _ZTV8PoleLift kind:data(any) addr:0x02112e80
+_ZTV17daObjKm2_Nobiru_c kind:data(any) addr:0x02112e80
 data_ov045_02112efc kind:data(any) addr:0x02112efc
 data_ov045_02112f08 kind:data(any) addr:0x02112f08
 data_ov045_02112f14 kind:data(any) addr:0x02112f14

--- a/config/arm9/overlays/ov052/symbols.txt
+++ b/config/arm9/overlays/ov052/symbols.txt
@@ -102,6 +102,7 @@ data_ov052_021125ac kind:data(any) addr:0x021125ac
 data_ov052_021125b8 kind:data(any) addr:0x021125b8
 SquarePathLift_SpawnInfo kind:data(any) addr:0x021125cc ambiguous
 _ZTV14SquarePathLift kind:data(any) addr:0x021125f0
+_ZTV14daObjEmmYuka_c kind:data(any) addr:0x021125f0
 data_ov052_02112610 kind:data(any) addr:0x02112610 ambiguous
 data_ov052_02112680 kind:bss addr:0x02112680
 data_ov052_02112688 kind:bss addr:0x02112688

--- a/config/arm9/overlays/ov056/symbols.txt
+++ b/config/arm9/overlays/ov056/symbols.txt
@@ -150,6 +150,7 @@ data_ov056_02113320 kind:data(any) addr:0x02113320
 data_ov056_0211332c kind:data(any) addr:0x0211332c
 BigMovingIceBlock_SpawnInfo kind:data(any) addr:0x02113344 ambiguous
 _ZTV17BigMovingIceBlock kind:data(any) addr:0x02113368
+_ZTV18daObjEwmIceBlock_c kind:data(any) addr:0x02113368
 data_ov056_021133a8 kind:data(any) addr:0x021133a8 ambiguous
 data_ov056_02113400 kind:bss addr:0x02113400
 data_ov056_02113408 kind:bss addr:0x02113408

--- a/config/arm9/overlays/ov060/symbols.txt
+++ b/config/arm9/overlays/ov060/symbols.txt
@@ -213,7 +213,9 @@ data_ov060_0211a5e4 kind:data(any) addr:0x0211a5e4
 Bowser_SpawnInfo kind:data(any) addr:0x0211a5f4
 BowserTail_SpawnInfo kind:data(any) addr:0x0211a610
 _ZTV10BowserTail kind:data(any) addr:0x0211a634
+_ZTV11daKpaTail_c kind:data(any) addr:0x0211a634
 _ZTV6Bowser kind:data(any) addr:0x0211a6b8
+_ZTV7daKpa_c kind:data(any) addr:0x0211a6b8
 data_ov060_0211a734 kind:data(any) addr:0x0211a734
 data_ov060_0211a73c kind:data(any) addr:0x0211a73c
 data_ov060_0211a744 kind:data(any) addr:0x0211a744
@@ -234,10 +236,12 @@ data_ov060_0211a7b4 kind:data(any) addr:0x0211a7b4
 data_ov060_0211a7c0 kind:data(any) addr:0x0211a7c0
 BowserFire_SpawnInfo kind:data(any) addr:0x0211a7d0
 _ZTV10BowserFire kind:data(any) addr:0x0211a7f4
+_ZTV11daKpaFire_c kind:data(any) addr:0x0211a7f4
 data_ov060_0211a870 kind:data(any) addr:0x0211a870
 data_ov060_0211a87c kind:data(any) addr:0x0211a87c
 BowserFireSeaArena_SpawnInfo kind:data(any) addr:0x0211a88c
 _ZTV18BowserFireSeaArena kind:data(any) addr:0x0211a8b0
+_ZTV10daKpa2Bg_c kind:data(any) addr:0x0211a8b0
 data_ov060_0211a930 kind:data(any) addr:0x0211a930
 data_ov060_0211a938 kind:data(any) addr:0x0211a938
 data_ov060_0211a940 kind:data(any) addr:0x0211a940
@@ -254,11 +258,13 @@ data_ov060_0211aa50 kind:data(any) addr:0x0211aa50
 data_ov060_0211aa5c kind:data(any) addr:0x0211aa5c
 SpikeBomb_SpawnInfo kind:data(any) addr:0x0211aa68
 _ZTV17BowserSkyPlatform kind:data(any) addr:0x0211aa8c
+_ZTV9daKirai_c kind:data(any) addr:0x0211aa8c
 data_ov060_0211ab08 kind:data(any) addr:0x0211ab08
 data_ov060_0211ab14 kind:data(any) addr:0x0211ab14
 data_ov060_0211ab20 kind:data(any) addr:0x0211ab20
 BowserShockwaves_SpawnInfo kind:data(any) addr:0x0211ab30
 _ZTV16BowserShockwaves kind:data(any) addr:0x0211ab54
+_ZTV9daFRing_c kind:data(any) addr:0x0211ab54
 data_ov060_0211abe0 kind:bss addr:0x0211abe0
 data_ov060_0211abe8 kind:bss addr:0x0211abe8
 data_ov060_0211abf0 kind:bss addr:0x0211abf0

--- a/config/arm9/overlays/ov062/symbols.txt
+++ b/config/arm9/overlays/ov062/symbols.txt
@@ -162,11 +162,13 @@ data_ov062_0211d9ac kind:data(any) addr:0x0211d9ac
 Chuckya_SpawnInfo kind:data(any) addr:0x0211d9bc ambiguous
 data_ov062_0211d9c0 kind:data(any) addr:0x0211d9c0 ambiguous
 _ZTV7Chuckya kind:data(any) addr:0x0211d9e0
+_ZTV10daHolhei_c kind:data(any) addr:0x0211d9e0
 data_ov062_0211da5c kind:data(any) addr:0x0211da5c
 data_ov062_0211da68 kind:data(any) addr:0x0211da68
 Koopa_SpawnInfo kind:data(any) addr:0x0211da74
 KoopaSmall_SpawnInfo kind:data(any) addr:0x0211da90
 _ZTV5Koopa kind:data(any) addr:0x0211dab4
+_ZTV8daNknk_c kind:data(any) addr:0x0211dab4
 data_ov062_0211db30 kind:data(any) addr:0x0211db30
 data_ov062_0211db38 kind:data(any) addr:0x0211db38
 data_ov062_0211db40 kind:data(any) addr:0x0211db40
@@ -177,10 +179,12 @@ data_ov062_0211db60 kind:data(any) addr:0x0211db60
 data_ov062_0211db6c kind:data(any) addr:0x0211db6c
 KoopaTheQuick_SpawnInfo kind:data(any) addr:0x0211db78
 _ZTV13KoopaTheQuick kind:data(any) addr:0x0211db9c
+_ZTV7daRNk_c kind:data(any) addr:0x0211db9c
 data_ov062_0211dc18 kind:data(any) addr:0x0211dc18
 data_ov062_0211dc24 kind:data(any) addr:0x0211dc24
 KoopaFlag_SpawnInfo kind:data(any) addr:0x0211dc30
 _ZTV9KoopaFlag kind:data(any) addr:0x0211dc54
+_ZTV9daRFlag_c kind:data(any) addr:0x0211dc54
 data_ov062_0211dcd0 kind:data(any) addr:0x0211dcd0
 data_ov062_0211dcd8 kind:data(any) addr:0x0211dcd8
 data_ov062_0211dce0 kind:data(any) addr:0x0211dce0
@@ -195,6 +199,7 @@ data_ov062_0211dd20 kind:data(any) addr:0x0211dd20
 data_ov062_0211dd2c kind:data(any) addr:0x0211dd2c
 Klepto_SpawnInfo kind:data(any) addr:0x0211dd38
 _ZTV6Klepto kind:data(any) addr:0x0211dd5c
+_ZTV9daJango_c kind:data(any) addr:0x0211dd5c
 data_ov062_0211dde0 kind:bss addr:0x0211dde0
 data_ov062_0211dde8 kind:bss addr:0x0211dde8
 data_ov062_0211ddf0 kind:bss addr:0x0211ddf0

--- a/config/arm9/overlays/ov063/symbols.txt
+++ b/config/arm9/overlays/ov063/symbols.txt
@@ -172,6 +172,7 @@ data_ov063_0211e7e0 kind:data(any) addr:0x0211e7e0
 _ZTV3Boo kind:data(any) addr:0x0211e828
 _ZTV10BigBooIcon kind:data(any) addr:0x0211e8ac
 _ZTV7BooCage kind:data(any) addr:0x0211e930
+_ZTV11daTBasket_c kind:data(any) addr:0x0211e930
 data_ov063_0211e9ac kind:data(any) addr:0x0211e9ac
 data_ov063_0211e9b4 kind:data(any) addr:0x0211e9b4
 data_ov063_0211e9bc kind:data(any) addr:0x0211e9bc
@@ -185,6 +186,7 @@ Bookshelf_SpawnInfo kind:data(any) addr:0x0211ea2c
 MerryGoRound_SpawnInfo kind:data(any) addr:0x0211ea48
 TrapDoor_SpawnInfo kind:data(any) addr:0x0211ea64
 _ZTV12MansionSteps kind:data(any) addr:0x0211ea88
+_ZTV11daTrsTrap_c kind:data(any) addr:0x0211ea88
 data_ov063_0211eb04 kind:data(any) addr:0x0211eb04
 data_ov063_0211eb10 kind:data(any) addr:0x0211eb10
 data_ov063_0211eb1c kind:data(any) addr:0x0211eb1c

--- a/config/arm9/overlays/ov064/symbols.txt
+++ b/config/arm9/overlays/ov064/symbols.txt
@@ -233,6 +233,7 @@ data_ov064_0211beb0 kind:data(any) addr:0x0211beb0
 data_ov064_0211bebc kind:data(any) addr:0x0211bebc
 LavaBubble_SpawnInfo kind:data(any) addr:0x0211bec8
 _ZTV10LavaBubble kind:data(any) addr:0x0211beec
+_ZTV7daBbl_c kind:data(any) addr:0x0211beec
 data_ov064_0211bf68 kind:data(any) addr:0x0211bf68
 data_ov064_0211bf70 kind:data(any) addr:0x0211bf70
 data_ov064_0211bf78 kind:data(any) addr:0x0211bf78
@@ -268,6 +269,7 @@ data_ov064_0211c2ec kind:data(any) addr:0x0211c2ec
 data_ov064_0211c2f8 kind:data(any) addr:0x0211c2f8
 JetStream_SpawnInfo kind:data(any) addr:0x0211c310
 _ZTV17BowserPuzzlePiece kind:data(any) addr:0x0211c334
+_ZTV18daWater_Hakidasi_c kind:data(any) addr:0x0211c334
 data_ov064_0211c3b0 kind:data(any) addr:0x0211c3b0
 data_ov064_0211c3b8 kind:data(any) addr:0x0211c3b8
 data_ov064_0211c3c0 kind:data(any) addr:0x0211c3c0
@@ -277,6 +279,7 @@ data_ov064_0211c3dc kind:data(any) addr:0x0211c3dc
 data_ov064_0211c3e8 kind:data(any) addr:0x0211c3e8
 WaterRing_SpawnInfo kind:data(any) addr:0x0211c3fc
 _ZTV9WaterRing kind:data(any) addr:0x0211c420
+_ZTV14daWater_Ring_c kind:data(any) addr:0x0211c420
 data_ov064_0211c49c kind:data(any) addr:0x0211c49c
 data_ov064_0211c4a4 kind:data(any) addr:0x0211c4a4
 data_ov064_0211c4ac kind:data(any) addr:0x0211c4ac
@@ -287,10 +290,12 @@ data_ov064_0211c4cc kind:data(any) addr:0x0211c4cc
 data_ov064_0211c4d8 kind:data(any) addr:0x0211c4d8
 TreasureChest_SpawnInfo kind:data(any) addr:0x0211c4e8
 _ZTV13TreasureChest kind:data(any) addr:0x0211c50c
+_ZTV11daObjTbox_c kind:data(any) addr:0x0211c50c
 data_ov064_0211c588 kind:data(any) addr:0x0211c588
 data_ov064_0211c594 kind:data(any) addr:0x0211c594
 Clam_SpawnInfo kind:data(any) addr:0x0211c5a4 ambiguous
 _ZTV4Clam kind:data(any) addr:0x0211c5c8
+_ZTV12daObjShell_c kind:data(any) addr:0x0211c5c8
 data_ov064_0211c610 kind:data(any) addr:0x0211c610 ambiguous
 data_ov064_0211c660 kind:bss addr:0x0211c660
 data_ov064_0211c668 kind:bss addr:0x0211c668

--- a/config/arm9/overlays/ov065/symbols.txt
+++ b/config/arm9/overlays/ov065/symbols.txt
@@ -178,6 +178,7 @@ data_ov065_0211cb60 kind:data(any) addr:0x0211cb60
 data_ov065_0211cb6c kind:data(any) addr:0x0211cb6c
 Snufit_SpawnInfo kind:data(any) addr:0x0211cb80 ambiguous
 _ZTV6Snufit kind:data(any) addr:0x0211cba4
+_ZTV15daYurei_Mucho_c kind:data(any) addr:0x0211cba4
 data_ov065_0211cc20 kind:data(any) addr:0x0211cc20
 data_ov065_0211cc28 kind:data(any) addr:0x0211cc28
 data_ov065_0211cc30 kind:data(any) addr:0x0211cc30
@@ -190,6 +191,7 @@ data_ov065_0211cc60 kind:data(any) addr:0x0211cc60
 data_ov065_0211cc6c kind:data(any) addr:0x0211cc6c
 Swoop_SpawnInfo kind:data(any) addr:0x0211cc7c ambiguous
 _ZTV5Swoop kind:data(any) addr:0x0211cca0
+_ZTV12daBasabasa_c kind:data(any) addr:0x0211cca0
 data_ov065_0211cd1c kind:data(any) addr:0x0211cd1c
 data_ov065_0211cd24 kind:data(any) addr:0x0211cd24
 data_ov065_0211cd2c kind:data(any) addr:0x0211cd2c
@@ -201,6 +203,7 @@ data_ov065_0211cd68 kind:data(any) addr:0x0211cd68
 Dorrie_SpawnInfo kind:data(any) addr:0x0211cd84 ambiguous
 DorrieCap_SpawnInfo kind:data(any) addr:0x0211cda0 ambiguous
 _ZTV9DorrieCap kind:data(any) addr:0x0211cdc4
+_ZTV12daDossyCap_c kind:data(any) addr:0x0211cdc4
 _ZTV6Dorrie kind:data(any) addr:0x0211ce48
 data_ov065_0211cec4 kind:data(any) addr:0x0211cec4
 data_ov065_0211cee4 kind:data(any) addr:0x0211cee4
@@ -219,6 +222,7 @@ data_ov065_0211cfd8 kind:data(any) addr:0x0211cfd8
 TtcRotatingCube_SpawnInfo kind:data(any) addr:0x0211cfe8 ambiguous
 TtcRotatingPrism_SpawnInfo kind:data(any) addr:0x0211d004 ambiguous
 _ZTV15TtcRotatingCube kind:data(any) addr:0x0211d028
+_ZTV20daObjCtRotateBlock_c kind:data(any) addr:0x0211d028
 data_ov065_0211d0a8 kind:data(any) addr:0x0211d0a8
 data_ov065_0211d0b4 kind:data(any) addr:0x0211d0b4
 data_ov065_0211d0c8 kind:data(any) addr:0x0211d0c8 ambiguous
@@ -232,6 +236,7 @@ data_ov065_0211d19c kind:data(any) addr:0x0211d19c
 TtcConveyorBeltSmall_SpawnInfo kind:data(any) addr:0x0211d1ac ambiguous
 TtcConveyorBeltLarge_SpawnInfo kind:data(any) addr:0x0211d1c8 ambiguous
 _ZTV20TtcConveyorBeltLarge kind:data(any) addr:0x0211d1ec
+_ZTV16daObjCtMecha04_c kind:data(any) addr:0x0211d1ec
 data_ov065_0211d26c kind:data(any) addr:0x0211d26c
 data_ov065_0211d270 kind:data(any) addr:0x0211d270
 data_ov065_0211d27c kind:data(any) addr:0x0211d27c
@@ -246,6 +251,7 @@ data_ov065_0211d364 kind:data(any) addr:0x0211d364
 TtcRotatingGear_SpawnInfo kind:data(any) addr:0x0211d374 ambiguous
 TtcRotatingTriangle_SpawnInfo kind:data(any) addr:0x0211d390 ambiguous
 _ZTV13TTC_MovingBar kind:data(any) addr:0x0211d3b4
+_ZTV18daObjCtKaitendai_c kind:data(any) addr:0x0211d3b4
 data_ov065_0211d434 kind:data(any) addr:0x0211d434
 data_ov065_0211d440 kind:data(any) addr:0x0211d440
 TtcMovingCubeA_SpawnInfo kind:data(any) addr:0x0211d454 ambiguous
@@ -256,6 +262,7 @@ data_ov065_0211d520 kind:data(any) addr:0x0211d520
 data_ov065_0211d530 kind:data(any) addr:0x0211d530
 TTC_MovingBeam_SpawnInfo kind:data(any) addr:0x0211d544 ambiguous
 _ZTV14TtcMovingCubeA kind:data(any) addr:0x0211d568
+_ZTV16daObjCtMecha09_c kind:data(any) addr:0x0211d568
 data_ov065_0211d600 kind:bss addr:0x0211d600
 data_ov065_0211d608 kind:bss addr:0x0211d608
 data_ov065_0211d610 kind:bss addr:0x0211d610

--- a/config/arm9/overlays/ov070/symbols.txt
+++ b/config/arm9/overlays/ov070/symbols.txt
@@ -133,6 +133,7 @@ data_ov070_02123120 kind:data(any) addr:0x02123120
 data_ov070_0212312c kind:data(any) addr:0x0212312c
 FlyGuy_SpawnInfo kind:data(any) addr:0x02123144 ambiguous
 _ZTV6FlyGuy kind:data(any) addr:0x02123168
+_ZTV19daPropeller_Heyho_c kind:data(any) addr:0x02123168
 data_ov070_02123184 kind:data(any) addr:0x02123184 ambiguous
 data_ov070_021231a0 kind:data(any) addr:0x021231a0 ambiguous
 data_ov070_021231e4 kind:data(any) addr:0x021231e4
@@ -147,6 +148,7 @@ data_ov070_0212323c kind:data(any) addr:0x0212323c
 data_ov070_02123248 kind:data(any) addr:0x02123248
 Amp_SpawnInfo kind:data(any) addr:0x02123254 ambiguous
 _ZTV3Amp kind:data(any) addr:0x02123278
+_ZTV7daBrq_c kind:data(any) addr:0x02123278
 data_ov070_021232f4 kind:data(any) addr:0x021232f4
 data_ov070_021232fc kind:data(any) addr:0x021232fc
 data_ov070_02123304 kind:data(any) addr:0x02123304
@@ -159,6 +161,7 @@ data_ov070_02123334 kind:data(any) addr:0x02123334
 data_ov070_02123340 kind:data(any) addr:0x02123340
 FlameChomp_SpawnInfo kind:data(any) addr:0x0212334c ambiguous
 _ZTV10FlameChomp kind:data(any) addr:0x02123370
+_ZTV8daKrpa_c kind:data(any) addr:0x02123370
 data_ov070_021233ec kind:data(any) addr:0x021233ec
 data_ov070_021233f4 kind:data(any) addr:0x021233f4
 data_ov070_021233fc kind:data(any) addr:0x021233fc
@@ -167,6 +170,7 @@ data_ov070_0212340c kind:data(any) addr:0x0212340c
 data_ov070_02123418 kind:data(any) addr:0x02123418
 FlameChompFire_SpawnInfo kind:data(any) addr:0x02123424 ambiguous
 _ZTV14FlameChompFire kind:data(any) addr:0x02123448
+_ZTV8daKpFr_c kind:data(any) addr:0x02123448
 data_ov070_021234c4 kind:data(any) addr:0x021234c4
 data_ov070_021234dc kind:data(any) addr:0x021234dc
 data_ov070_02123500 kind:bss addr:0x02123500

--- a/config/arm9/overlays/ov071/symbols.txt
+++ b/config/arm9/overlays/ov071/symbols.txt
@@ -119,6 +119,7 @@ data_ov071_02122bf0 kind:data(any) addr:0x02122bf0
 data_ov071_02122bfc kind:data(any) addr:0x02122bfc
 Scuttlebug_SpawnInfo kind:data(any) addr:0x02122c08 ambiguous
 _ZTV10Scuttlebug kind:data(any) addr:0x02122c2c
+_ZTV7daSpd_c kind:data(any) addr:0x02122c2c
 data_ov071_02122ca8 kind:data(any) addr:0x02122ca8
 data_ov071_02122cb0 kind:data(any) addr:0x02122cb0
 data_ov071_02122cb8 kind:data(any) addr:0x02122cb8
@@ -130,10 +131,12 @@ data_ov071_02122ce4 kind:data(any) addr:0x02122ce4
 MrI_SpawnInfo kind:data(any) addr:0x02122cf0 ambiguous
 BigMrI_SpawnInfo kind:data(any) addr:0x02122d0c ambiguous
 _ZTV3MrI kind:data(any) addr:0x02122d30
+_ZTV8daEykn_c kind:data(any) addr:0x02122d30
 data_ov071_02122dac kind:data(any) addr:0x02122dac
 data_ov071_02122db8 kind:data(any) addr:0x02122db8
 MrI_Projectile_SpawnInfo kind:data(any) addr:0x02122dc4 ambiguous
 _ZTV14MrI_Projectile kind:data(any) addr:0x02122de8
+_ZTV8daEyBm_c kind:data(any) addr:0x02122de8
 data_ov071_02122e64 kind:data(any) addr:0x02122e64
 data_ov071_02122e6c kind:data(any) addr:0x02122e6c
 data_ov071_02122e74 kind:data(any) addr:0x02122e74

--- a/config/arm9/overlays/ov072/symbols.txt
+++ b/config/arm9/overlays/ov072/symbols.txt
@@ -114,6 +114,7 @@ data_ov072_02122780 kind:data(any) addr:0x02122780
 data_ov072_0212278c kind:data(any) addr:0x0212278c
 SnowmanBody_SpawnInfo kind:data(any) addr:0x0212279c ambiguous
 _ZTV11SnowmanBody kind:data(any) addr:0x021227c0
+_ZTV12daBgSnmBdy_c kind:data(any) addr:0x021227c0
 data_ov072_0212283c kind:data(any) addr:0x0212283c
 data_ov072_02122844 kind:data(any) addr:0x02122844
 data_ov072_0212284c kind:data(any) addr:0x0212284c
@@ -126,6 +127,7 @@ data_ov072_0212287c kind:data(any) addr:0x0212287c
 data_ov072_02122888 kind:data(any) addr:0x02122888
 SnowmanHead_SpawnInfo kind:data(any) addr:0x02122898 ambiguous
 _ZTV11SnowmanHead kind:data(any) addr:0x021228bc
+_ZTV12daBgSnmHed_c kind:data(any) addr:0x021228bc
 data_ov072_02122938 kind:data(any) addr:0x02122938
 data_ov072_02122944 kind:data(any) addr:0x02122944
 data_ov072_02122954 kind:data(any) addr:0x02122954 ambiguous
@@ -146,6 +148,7 @@ data_ov072_02122a54 kind:data(any) addr:0x02122a54
 data_ov072_02122a60 kind:data(any) addr:0x02122a60
 BabyPenguin_SpawnInfo kind:data(any) addr:0x02122a6c ambiguous
 _ZTV11BabyPenguin kind:data(any) addr:0x02122a90
+_ZTV9daPgBby_c kind:data(any) addr:0x02122a90
 data_ov072_02122b20 kind:bss addr:0x02122b20
 data_ov072_02122b28 kind:bss addr:0x02122b28
 data_ov072_02122b34 kind:bss addr:0x02122b34

--- a/config/arm9/overlays/ov077/symbols.txt
+++ b/config/arm9/overlays/ov077/symbols.txt
@@ -108,6 +108,7 @@ data_ov077_02127830 kind:data(any) addr:0x02127830
 data_ov077_0212783c kind:data(any) addr:0x0212783c
 Lakitu_SpawnInfo kind:data(any) addr:0x02127848 ambiguous
 _ZTV6Lakitu kind:data(any) addr:0x0212786c
+_ZTV7daJgm_c kind:data(any) addr:0x0212786c
 data_ov077_021278e8 kind:data(any) addr:0x021278e8
 data_ov077_021278f0 kind:data(any) addr:0x021278f0
 data_ov077_021278f8 kind:data(any) addr:0x021278f8
@@ -124,6 +125,7 @@ data_ov077_02127948 kind:data(any) addr:0x02127948
 data_ov077_02127954 kind:data(any) addr:0x02127954
 Spiny_SpawnInfo kind:data(any) addr:0x02127960
 _ZTV5Spiny kind:data(any) addr:0x02127984
+_ZTV7daTgz_c kind:data(any) addr:0x02127984
 data_ov077_02127a00 kind:data(any) addr:0x02127a00
 data_ov077_02127a08 kind:data(any) addr:0x02127a08
 data_ov077_02127a10 kind:data(any) addr:0x02127a10
@@ -139,6 +141,7 @@ data_ov077_02127a5c kind:data(any) addr:0x02127a5c
 data_ov077_02127a68 kind:data(any) addr:0x02127a68
 HeaveHo_SpawnInfo kind:data(any) addr:0x02127a74
 _ZTV7HeaveHo kind:data(any) addr:0x02127a98
+_ZTV9daPopoi_c kind:data(any) addr:0x02127a98
 data_ov077_02127b20 kind:bss addr:0x02127b20
 data_ov077_02127b28 kind:bss addr:0x02127b28
 data_ov077_02127b30 kind:bss addr:0x02127b30

--- a/config/arm9/overlays/ov078/symbols.txt
+++ b/config/arm9/overlays/ov078/symbols.txt
@@ -93,6 +93,7 @@ data_ov078_02126e0c kind:data(any) addr:0x02126e0c
 data_ov078_02126e18 kind:data(any) addr:0x02126e18
 KingBobOmb_SpawnInfo kind:data(any) addr:0x02126e28 ambiguous
 _ZTV10KingBobOmb kind:data(any) addr:0x02126e4c
+_ZTV12daBombking_c kind:data(any) addr:0x02126e4c
 data_ov078_02126ee0 kind:bss addr:0x02126ee0
 data_ov078_02126ee8 kind:bss addr:0x02126ee8
 data_ov078_02126ef0 kind:bss addr:0x02126ef0

--- a/config/arm9/overlays/ov079/symbols.txt
+++ b/config/arm9/overlays/ov079/symbols.txt
@@ -103,6 +103,7 @@ data_ov079_02127eac kind:data(any) addr:0x02127eac
 data_ov079_02127eb8 kind:data(any) addr:0x02127eb8
 BulletBill_SpawnInfo kind:data(any) addr:0x02127ec4
 _ZTV10BulletBill kind:data(any) addr:0x02127ee8
+_ZTV7daKlr_c kind:data(any) addr:0x02127ee8
 data_ov079_02127f64 kind:data(any) addr:0x02127f64
 data_ov079_02127f70 kind:data(any) addr:0x02127f70
 data_ov079_02127f7c kind:data(any) addr:0x02127f7c

--- a/config/arm9/overlays/ov080/symbols.txt
+++ b/config/arm9/overlays/ov080/symbols.txt
@@ -113,9 +113,11 @@ data_ov080_02127fd8 kind:data(any) addr:0x02127fd8
 MontyMole_SpawnInfo kind:data(any) addr:0x02127fec ambiguous
 MontyMoleRock_SpawnInfo kind:data(any) addr:0x02128008 ambiguous
 _ZTV13MontyMoleRock kind:data(any) addr:0x0212802c
+_ZTV14daChoro_Rock_c kind:data(any) addr:0x0212802c
 data_ov080_02128070 kind:data(any) addr:0x02128070 ambiguous
 data_ov080_0212808c kind:data(any) addr:0x0212808c ambiguous
 _ZTV9MontyMole kind:data(any) addr:0x021280b0
+_ZTV11daChoropu_c kind:data(any) addr:0x021280b0
 data_ov080_0212812c kind:data(any) addr:0x0212812c
 data_ov080_02128134 kind:data(any) addr:0x02128134
 data_ov080_0212813c kind:data(any) addr:0x0212813c
@@ -126,6 +128,7 @@ data_ov080_0212815c kind:data(any) addr:0x0212815c
 data_ov080_02128168 kind:data(any) addr:0x02128168
 CrazedCrate_SpawnInfo kind:data(any) addr:0x02128174 ambiguous
 _ZTV11CrazedCrate kind:data(any) addr:0x02128198
+_ZTV9daBttBk_c kind:data(any) addr:0x02128198
 data_ov080_02128214 kind:data(any) addr:0x02128214
 data_ov080_0212821c kind:data(any) addr:0x0212821c
 data_ov080_02128224 kind:data(any) addr:0x02128224

--- a/config/arm9/overlays/ov081/symbols.txt
+++ b/config/arm9/overlays/ov081/symbols.txt
@@ -121,6 +121,7 @@ data_ov081_02128840 kind:data(any) addr:0x02128840
 data_ov081_0212884c kind:data(any) addr:0x0212884c
 Spindrift_SpawnInfo kind:data(any) addr:0x02128858 ambiguous
 _ZTV9Spindrift kind:data(any) addr:0x0212887c
+_ZTV8daHuwa_c kind:data(any) addr:0x0212887c
 data_ov081_021288f8 kind:data(any) addr:0x021288f8
 data_ov081_02128900 kind:data(any) addr:0x02128900
 data_ov081_02128908 kind:data(any) addr:0x02128908
@@ -149,12 +150,14 @@ data_ov081_021289b0 kind:data(any) addr:0x021289b0
 data_ov081_021289bc kind:data(any) addr:0x021289bc
 MrBlizzard_SpawnInfo kind:data(any) addr:0x021289cc
 _ZTV10MrBlizzard kind:data(any) addr:0x021289f0
+_ZTV11daSnowman_c kind:data(any) addr:0x021289f0
 data_ov081_02128a6c kind:data(any) addr:0x02128a6c
 data_ov081_02128a74 kind:data(any) addr:0x02128a74
 data_ov081_02128a7c kind:data(any) addr:0x02128a7c
 data_ov081_02128a88 kind:data(any) addr:0x02128a88
 Snowball_SpawnInfo kind:data(any) addr:0x02128a98
 _ZTV8Snowball kind:data(any) addr:0x02128abc
+_ZTV12daSnowball_c kind:data(any) addr:0x02128abc
 data_ov081_02128b38 kind:data(any) addr:0x02128b38
 data_ov081_02128b40 kind:data(any) addr:0x02128b40
 data_ov081_02128b48 kind:data(any) addr:0x02128b48
@@ -177,10 +180,12 @@ data_ov081_02128bc8 kind:data(any) addr:0x02128bc8
 data_ov081_02128bd4 kind:data(any) addr:0x02128bd4
 Moneybag_SpawnInfo kind:data(any) addr:0x02128be0
 _ZTV8Moneybag kind:data(any) addr:0x02128c04
+_ZTV8daGmch_c kind:data(any) addr:0x02128c04
 data_ov081_02128c80 kind:data(any) addr:0x02128c80
 data_ov081_02128c8c kind:data(any) addr:0x02128c8c
 IceBlock_SpawnInfo kind:data(any) addr:0x02128ca0
 _ZTV8IceBlock kind:data(any) addr:0x02128cc4
+_ZTV15daObjIceBlock_c kind:data(any) addr:0x02128cc4
 data_ov081_02128d60 kind:bss addr:0x02128d60
 data_ov081_02128d68 kind:bss addr:0x02128d68
 data_ov081_02128d70 kind:bss addr:0x02128d70

--- a/config/arm9/overlays/ov084/symbols.txt
+++ b/config/arm9/overlays/ov084/symbols.txt
@@ -145,6 +145,7 @@ Goomba_SpawnInfo kind:data(any) addr:0x021308ec
 GoombaSmall_SpawnInfo kind:data(any) addr:0x02130908
 GoombaLarge_SpawnInfo kind:data(any) addr:0x02130924
 _ZTV6Goomba kind:data(any) addr:0x02130948
+_ZTV7daKrb_c kind:data(any) addr:0x02130948
 data_ov084_021309c4 kind:data(any) addr:0x021309c4
 data_ov084_021309cc kind:data(any) addr:0x021309cc
 data_ov084_021309d4 kind:data(any) addr:0x021309d4
@@ -155,12 +156,14 @@ data_ov084_021309f4 kind:data(any) addr:0x021309f4
 data_ov084_02130a00 kind:data(any) addr:0x02130a00
 BobOmbBuddy_SpawnInfo kind:data(any) addr:0x02130a14
 _ZTV11BobOmbBuddy kind:data(any) addr:0x02130a38
+_ZTV14daRedBombhei_c kind:data(any) addr:0x02130a38
 data_ov084_02130ab4 kind:data(any) addr:0x02130ab4
 data_ov084_02130ac0 kind:data(any) addr:0x02130ac0
 FirePiranhaPlant_SpawnInfo kind:data(any) addr:0x02130acc
 FirePiranhaPlantBig_SpawnInfo kind:data(any) addr:0x02130ae8
 FirePiranhaPlantSmall_SpawnInfo kind:data(any) addr:0x02130b04
 _ZTV19FirePiranhaPlantBig kind:data(any) addr:0x02130b28
+_ZTV8daFPkn_c kind:data(any) addr:0x02130b28
 data_ov084_02130ba4 kind:data(any) addr:0x02130ba4
 data_ov084_02130bac kind:data(any) addr:0x02130bac
 data_ov084_02130bb4 kind:data(any) addr:0x02130bb4
@@ -174,6 +177,7 @@ data_ov084_02130bec kind:data(any) addr:0x02130bec
 data_ov084_02130bf8 kind:data(any) addr:0x02130bf8
 PiranhaPlant_SpawnInfo kind:data(any) addr:0x02130c04
 _ZTV12PiranhaPlant kind:data(any) addr:0x02130c28
+_ZTV7daPkn_c kind:data(any) addr:0x02130c28
 data_ov084_02130cc0 kind:bss addr:0x02130cc0
 data_ov084_02130cc8 kind:bss addr:0x02130cc8
 data_ov084_02130cd0 kind:bss addr:0x02130cd0

--- a/config/arm9/overlays/ov085/symbols.txt
+++ b/config/arm9/overlays/ov085/symbols.txt
@@ -151,6 +151,7 @@ data_ov085_0212fe5c kind:data(any) addr:0x0212fe5c
 Toad_SpawnInfo kind:data(any) addr:0x0212fe6c
 data_ov085_0212fe88 kind:data(any) addr:0x0212fe88
 _ZTV4Toad kind:data(any) addr:0x0212feb8
+_ZTV11daKinopio_c kind:data(any) addr:0x0212feb8
 data_ov085_0212ff34 kind:data(any) addr:0x0212ff34
 data_ov085_0212ff3c kind:data(any) addr:0x0212ff3c
 data_ov085_0212ff44 kind:data(any) addr:0x0212ff44
@@ -165,6 +166,7 @@ data_ov085_0212ff84 kind:data(any) addr:0x0212ff84
 data_ov085_0212ff90 kind:data(any) addr:0x0212ff90
 PrincessPeach_SpawnInfo kind:data(any) addr:0x0212ff9c
 _ZTV13PrincessPeach kind:data(any) addr:0x0212ffc0
+_ZTV9daPeach_c kind:data(any) addr:0x0212ffc0
 data_ov085_0212ffff kind:data(any) addr:0x0212ffff
 data_ov085_0213003c kind:data(any) addr:0x0213003c
 data_ov085_02130044 kind:data(any) addr:0x02130044
@@ -186,6 +188,7 @@ data_ov085_021300bc kind:data(any) addr:0x021300bc
 data_ov085_021300c8 kind:data(any) addr:0x021300c8
 Rabbit_SpawnInfo kind:data(any) addr:0x021300d4
 _ZTV6Rabbit kind:data(any) addr:0x021300f8
+_ZTV7daMip_c kind:data(any) addr:0x021300f8
 data_ov085_02130174 kind:data(any) addr:0x02130174
 data_ov085_0213017c kind:data(any) addr:0x0213017c
 data_ov085_02130184 kind:data(any) addr:0x02130184
@@ -194,6 +197,7 @@ data_ov085_02130194 kind:data(any) addr:0x02130194
 data_ov085_021301a0 kind:data(any) addr:0x021301a0
 RabbitKey_SpawnInfo kind:data(any) addr:0x021301b4 ambiguous
 _ZTV9RabbitKey kind:data(any) addr:0x021301d8
+_ZTV15daObj_Mip_Key_c kind:data(any) addr:0x021301d8
 data_ov085_0213020b kind:data(any) addr:0x0213020b ambiguous
 data_ov085_02130212 kind:data(any) addr:0x02130212 ambiguous
 data_ov085_02130254 kind:data(any) addr:0x02130254
@@ -222,10 +226,12 @@ data_ov085_02130304 kind:data(any) addr:0x02130304
 data_ov085_02130310 kind:data(any) addr:0x02130310
 LakituBro_SpawnInfo kind:data(any) addr:0x02130320 ambiguous
 _ZTV9LakituBro kind:data(any) addr:0x02130344
+_ZTV11daC_Jugem_c kind:data(any) addr:0x02130344
 data_ov085_021303c0 kind:data(any) addr:0x021303c0
 data_ov085_021303cc kind:data(any) addr:0x021303cc
 WallSign_SpawnInfo kind:data(any) addr:0x021303dc
 _ZTV8WallSign kind:data(any) addr:0x02130400
+_ZTV13daObjKanban_c kind:data(any) addr:0x02130400
 data_ov085_02130480 kind:bss addr:0x02130480
 data_ov085_02130488 kind:bss addr:0x02130488
 data_ov085_02130490 kind:bss addr:0x02130490

--- a/config/arm9/overlays/ov089/symbols.txt
+++ b/config/arm9/overlays/ov089/symbols.txt
@@ -37,6 +37,7 @@ data_ov089_02132b58 kind:data(any) addr:0x02132b58
 Key_SpawnInfo kind:data(any) addr:0x02132b68
 LastStar_SpawnInfo kind:data(any) addr:0x02132b84
 _ZTV3Key kind:data(any) addr:0x02132ba8
+_ZTV10daObjKey_c kind:data(any) addr:0x02132ba8
 data_ov089_02132c40 kind:bss addr:0x02132c40
 data_ov089_02132c48 kind:bss addr:0x02132c48
 data_ov089_02132c50 kind:bss addr:0x02132c50

--- a/config/arm9/overlays/ov090/symbols.txt
+++ b/config/arm9/overlays/ov090/symbols.txt
@@ -85,6 +85,7 @@ data_ov090_0213412c kind:data(any) addr:0x0213412c
 data_ov090_02134138 kind:data(any) addr:0x02134138
 Skeeter_SpawnInfo kind:data(any) addr:0x02134144 ambiguous
 _ZTV7Skeeter kind:data(any) addr:0x02134168
+_ZTV9daMenbo_c kind:data(any) addr:0x02134168
 data_ov090_021341e4 kind:data(any) addr:0x021341e4
 data_ov090_021341ec kind:data(any) addr:0x021341ec
 data_ov090_021341f4 kind:data(any) addr:0x021341f4
@@ -101,12 +102,14 @@ data_ov090_021342e4 kind:data(any) addr:0x021342e4
 data_ov090_021342f0 kind:data(any) addr:0x021342f0
 CheepCheep_SpawnInfo kind:data(any) addr:0x02134300 ambiguous
 _ZTV10CheepCheep kind:data(any) addr:0x02134324
+_ZTV12daPukupuku_c kind:data(any) addr:0x02134324
 data_ov090_021343a0 kind:data(any) addr:0x021343a0
 data_ov090_021343a8 kind:data(any) addr:0x021343a8
 data_ov090_021343b0 kind:data(any) addr:0x021343b0
 data_ov090_021343bc kind:data(any) addr:0x021343bc
 Shark_SpawnInfo kind:data(any) addr:0x021343c8 ambiguous
 _ZTV5Shark kind:data(any) addr:0x021343ec
+_ZTV9daShark_c kind:data(any) addr:0x021343ec
 data_ov090_02134480 kind:bss addr:0x02134480
 data_ov090_02134488 kind:bss addr:0x02134488
 data_ov090_02134490 kind:bss addr:0x02134490

--- a/config/arm9/overlays/ov091/symbols.txt
+++ b/config/arm9/overlays/ov091/symbols.txt
@@ -118,6 +118,7 @@ data_ov091_02134c30 kind:data(any) addr:0x02134c30
 data_ov091_02134c34 kind:data(any) addr:0x02134c34
 data_ov091_02134c38 kind:data(any) addr:0x02134c38
 _ZTV25RotatingUpDownPlatformUtm kind:data(any) addr:0x02134c5c
+_ZTV23daObjRotateUpdownLift_c kind:data(any) addr:0x02134c5c
 data_ov091_02134cdc kind:data(any) addr:0x02134cdc
 data_ov091_02134d1c kind:data(any) addr:0x02134d1c
 data_ov091_02134e44 kind:data(any) addr:0x02134e44
@@ -129,6 +130,7 @@ data_ov091_02134e70 kind:data(any) addr:0x02134e70
 ArrowPathLift_SpawnInfo kind:data(any) addr:0x02134e80 ambiguous
 SquareMetalNetLift_SpawnInfo kind:data(any) addr:0x02134e9c ambiguous
 _ZTV22RotatingUpDownPlatform kind:data(any) addr:0x02134ec0
+_ZTV13daLinelift2_c kind:data(any) addr:0x02134ec0
 data_ov091_02134f40 kind:data(any) addr:0x02134f40
 data_ov091_02134f4c kind:data(any) addr:0x02134f4c
 SlidingPlatformBdw_SpawnInfo kind:data(any) addr:0x02134f60 ambiguous
@@ -163,6 +165,7 @@ data_ov091_0213536c kind:data(any) addr:0x0213536c
 data_ov091_02135378 kind:data(any) addr:0x02135378
 Fwoosh_SpawnInfo kind:data(any) addr:0x02135388 ambiguous
 _ZTV5Stump kind:data(any) addr:0x021353ac
+_ZTV10daHyuhyu_c kind:data(any) addr:0x021353ac
 data_ov091_02135440 kind:bss addr:0x02135440
 data_ov091_02135448 kind:bss addr:0x02135448
 data_ov091_02135450 kind:bss addr:0x02135450

--- a/config/arm9/overlays/ov094/symbols.txt
+++ b/config/arm9/overlays/ov094/symbols.txt
@@ -37,6 +37,7 @@ data_ov094_02136a1c kind:data(any) addr:0x02136a1c
 data_ov094_02136a28 kind:data(any) addr:0x02136a28
 HootTheOwl_SpawnInfo kind:data(any) addr:0x02136a34 ambiguous
 _ZTV10HootTheOwl kind:data(any) addr:0x02136a58
+_ZTV7daOwl_c kind:data(any) addr:0x02136a58
 data_ov094_02136ae0 kind:bss addr:0x02136ae0
 data_ov094_02136ae8 kind:bss addr:0x02136ae8
 data_ov094_02136af0 kind:bss addr:0x02136af0

--- a/config/arm9/overlays/ov096/symbols.txt
+++ b/config/arm9/overlays/ov096/symbols.txt
@@ -66,10 +66,12 @@ data_ov096_0213798c kind:data(any) addr:0x0213798c
 Pokey_SpawnInfo kind:data(any) addr:0x02137998 ambiguous
 PokeySegment_SpawnInfo kind:data(any) addr:0x021379b4 ambiguous
 _ZTV5Pokey kind:data(any) addr:0x021379d8
+_ZTV9daSanbo_c kind:data(any) addr:0x021379d8
 data_ov096_02137a54 kind:data(any) addr:0x02137a54
 data_ov096_02137a60 kind:data(any) addr:0x02137a60
 Tornado_SpawnInfo kind:data(any) addr:0x02137a6c ambiguous
 _ZTV7Tornado kind:data(any) addr:0x02137a90
+_ZTV7daTor_c kind:data(any) addr:0x02137a90
 data_ov096_02137b20 kind:bss addr:0x02137b20
 data_ov096_02137b28 kind:bss addr:0x02137b28
 data_ov096_02137b30 kind:bss addr:0x02137b30

--- a/config/arm9/overlays/ov098/symbols.txt
+++ b/config/arm9/overlays/ov098/symbols.txt
@@ -109,6 +109,7 @@ data_ov098_0213c388 kind:data(any) addr:0x0213c388
 ArrowSignLeft_SpawnInfo kind:data(any) addr:0x0213c398 ambiguous
 ArrowSignRight_SpawnInfo kind:data(any) addr:0x0213c3b4 ambiguous
 _ZTV14ArrowSignRight kind:data(any) addr:0x0213c3d8
+_ZTV15daObjYajirusi_c kind:data(any) addr:0x0213c3d8
 MgShellSmash_SpawnInfo kind:data(any) addr:0x0213c434 ambiguous
 data_ov098_0213c458 kind:data(any) addr:0x0213c458
 data_ov098_0213c460 kind:data(any) addr:0x0213c460
@@ -141,6 +142,7 @@ data_ov098_0213c664 kind:data(any) addr:0x0213c664
 data_ov098_0213c670 kind:data(any) addr:0x0213c670
 Cannon_SpawnInfo kind:data(any) addr:0x0213c67c ambiguous
 _ZTV6Cannon kind:data(any) addr:0x0213c6a0
+_ZTV7daCnn_c kind:data(any) addr:0x0213c6a0
 data_ov098_0213c71c kind:data(any) addr:0x0213c71c
 data_ov098_0213c724 kind:data(any) addr:0x0213c724
 data_ov098_0213c72c kind:data(any) addr:0x0213c72c
@@ -148,6 +150,7 @@ data_ov098_0213c734 kind:data(any) addr:0x0213c734
 data_ov098_0213c740 kind:data(any) addr:0x0213c740
 WaterBomb_SpawnInfo kind:data(any) addr:0x0213c74c ambiguous
 _ZTV9WaterBomb kind:data(any) addr:0x0213c770
+_ZTV7daWbm_c kind:data(any) addr:0x0213c770
 data_ov098_0213c78c kind:data(any) addr:0x0213c78c ambiguous
 data_ov098_0213c800 kind:bss addr:0x0213c800
 data_ov098_0213c808 kind:bss addr:0x0213c808

--- a/config/arm9/overlays/ov100/symbols.txt
+++ b/config/arm9/overlays/ov100/symbols.txt
@@ -154,6 +154,7 @@ data_ov100_02147e60 kind:data(any) addr:0x02147e60
 data_ov100_02147e6c kind:data(any) addr:0x02147e6c
 Butterfly_SpawnInfo kind:data(any) addr:0x02147e78
 _ZTV9Butterfly kind:data(any) addr:0x02147e9c
+_ZTV9daBtfly_c kind:data(any) addr:0x02147e9c
 data_ov100_02147f18 kind:data(any) addr:0x02147f18
 data_ov100_02147f20 kind:data(any) addr:0x02147f20
 data_ov100_02147f28 kind:data(any) addr:0x02147f28
@@ -163,6 +164,7 @@ data_ov100_02147f40 kind:data(any) addr:0x02147f40
 data_ov100_02147f4c kind:data(any) addr:0x02147f4c
 RollingIronBall_SpawnInfo kind:data(any) addr:0x02147f58
 _ZTV15RollingIronBall kind:data(any) addr:0x02147f7c
+_ZTV7daIbl_c kind:data(any) addr:0x02147f7c
 data_ov100_02147ff8 kind:data(any) addr:0x02147ff8
 data_ov100_02148000 kind:data(any) addr:0x02148000
 data_ov100_02148008 kind:data(any) addr:0x02148008
@@ -204,6 +206,7 @@ data_ov100_02148380 kind:data(any) addr:0x02148380
 data_ov100_02148390 kind:data(any) addr:0x02148390
 StarDoor_SpawnInfo kind:data(any) addr:0x021483a8
 _ZTV4Door kind:data(any) addr:0x021483cc
+_ZTV12daStarGate_c kind:data(any) addr:0x021483cc
 data_ov100_02148448 kind:data(any) addr:0x02148448
 data_ov100_02148450 kind:data(any) addr:0x02148450
 data_ov100_02148458 kind:data(any) addr:0x02148458
@@ -215,6 +218,7 @@ data_ov100_02148480 kind:data(any) addr:0x02148480
 data_ov100_0214848c kind:data(any) addr:0x0214848c
 Fish_SpawnInfo kind:data(any) addr:0x02148498
 _ZTV4Fish kind:data(any) addr:0x021484bc
+_ZTV8daFish_c kind:data(any) addr:0x021484bc
 data_ov100_02148538 kind:data(any) addr:0x02148538
 data_ov100_02148544 kind:data(any) addr:0x02148544
 PathLift_SpawnInfo kind:data(any) addr:0x02148558

--- a/config/arm9/overlays/ov102/symbols.txt
+++ b/config/arm9/overlays/ov102/symbols.txt
@@ -182,12 +182,14 @@ CapBlockMario_SpawnInfo kind:data(any) addr:0x0214e420
 CapBlockLuigi_SpawnInfo kind:data(any) addr:0x0214e43c
 CapBlockWario_SpawnInfo kind:data(any) addr:0x0214e458
 _ZTV13QuestionBlock kind:data(any) addr:0x0214e47c
+_ZTV18daObjHatenaBlock_c kind:data(any) addr:0x0214e47c
 data_ov102_0214e4fc kind:data(any) addr:0x0214e4fc
 data_ov102_0214e508 kind:data(any) addr:0x0214e508
 data_ov102_0214e514 kind:data(any) addr:0x0214e514
 data_ov102_0214e524 kind:data(any) addr:0x0214e524
 BobOmb_SpawnInfo kind:data(any) addr:0x0214e534
 _ZTV6BobOmb kind:data(any) addr:0x0214e558
+_ZTV7daBmb_c kind:data(any) addr:0x0214e558
 data_ov102_0214e5d4 kind:data(any) addr:0x0214e5d4
 data_ov102_0214e5dc kind:data(any) addr:0x0214e5dc
 data_ov102_0214e5e4 kind:data(any) addr:0x0214e5e4
@@ -200,6 +202,7 @@ data_ov102_0214e614 kind:data(any) addr:0x0214e614
 data_ov102_0214e620 kind:data(any) addr:0x0214e620
 KoopaShell_SpawnInfo kind:data(any) addr:0x0214e62c
 _ZTV10KoopaShell kind:data(any) addr:0x0214e650
+_ZTV7daShl_c kind:data(any) addr:0x0214e650
 data_ov102_0214e6e0 kind:bss addr:0x0214e6e0
 data_ov102_0214e6e8 kind:bss addr:0x0214e6e8
 data_ov102_0214e6f0 kind:bss addr:0x0214e6f0

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -61,8 +61,7 @@ def build_name_index():
     fallback used only for symbols whose address is NOT encoded in the name."""
     idx = {}
     for module, path in R.iter_symbol_files(include_itcm_dtcm=True):
-        for (mod_addr), name in R.load_syms_file(path, module).items():
-            mod, addr = mod_addr
+        for name, (mod, addr) in R.iter_syms_pairs(path, module):
             idx.setdefault(name, (mod, addr))
     return idx
 

--- a/tools/relocs.py
+++ b/tools/relocs.py
@@ -98,6 +98,17 @@ def load_syms_file(path, module: str | None = None):
     return d
 
 
+def iter_syms_pairs(path, module: str | None = None):
+    """Yield ``(name, (module, addr))`` for every symbols.txt line, without keying by
+    address, so aliases (two names at one address -- a guessed vtable name and its
+    RTTI-recovered real name) are both preserved instead of one overwriting the other."""
+    key_module = normalize_module(module) if module is not None else None
+    for line in pathlib.Path(path).read_text(errors="ignore").splitlines():
+        m = _SYM_RE.match(line)
+        if m:
+            yield m.group(1), (key_module, int(m.group(2), 16))
+
+
 def load_relocs():
     return load_relocs_file(RELOCS)
 


### PR DESCRIPTION
Names 130 actor vtables with the real Nintendo class names recovered from the ROM's RTTI (e.g. `_ZTV10BowserFire` -> also `_ZTV11daKpaFire_c`, `_ZTV10BulletBill` -> `_ZTV7daKlr_c`), and fixes the symbol resolver so aliases actually work.

## The tool fix
`reloc_audit.build_name_index` read symbols through the address-keyed `load_syms_file`, so two names at one address collapsed to one -- a guessed name and its real RTTI name could not coexist. New `relocs.iter_syms_pairs` yields every `(name, addr)` pair without collapsing, so both spellings resolve. Main's config has zero duplicate-address names today, so this is inert until aliases are added.

## The aliases
The migrated readable sources reference the real RTTI vtable names; config only had the guessed names, so those relocation slots read BLIND. This adds the RTTI name at the same address as its guessed counterpart, keeping both.

Scoped to the **130 vtables referenced from a single overlay**. Two base-class vtables that appear across many overlays (`daBDonketu_c`... no -- `dBgActor_c`, `daManta_c`) are deliberately excluded: their vtable lives at a different address in each overlay, so a global alias would mis-link. Verified: across all 157 sources referencing the 130 names, **zero WRONG / zero regression**; the guessed names still resolve.

These slots now resolve, but most files stay BLIND on a separate `G`-global placeholder (a different follow-up). No src changes; no bytes change.

Built with Claude Code.
