### PR TITLE
readable: strip 155 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/ApproachAngle.c
+++ b/src/ApproachAngle.c
@@ -5,7 +5,7 @@ int ApproachAngle(short *cur, short target, int divisor, int band, int maxStep)
     int diff;
     short c;
     c = *cur;
-    diff = (int)(((long long)(short)(target - c)) & 0xFFFFFFFFFFFFFFFFLL);
+    diff = (int)(((long long)(short)(target - c)));
     if (c != target) {
         int step = (short)__aeabi_idiv(diff, divisor);
         if (step > maxStep || step < -maxStep) {

--- a/src/DMASyncFillTransfer.c
+++ b/src/DMASyncFillTransfer.c
@@ -4,7 +4,7 @@
  * then starts a source-fixed word DMA from that register (ctrl 0x85000000 =
  * enable | 32-bit | src-fixed | immediate) and waits for completion.
  *
- * The identity `& 0xFFFFFFFFFFFFFFFF` on the fill-register address is the
+ * The identity `` on the fill-register address is the
  * u64-laundering idiom (see notes/mwccarm-codegen.md, 6m): it routes the
  * address through 64-bit arithmetic so mwccarm cannot fold it into the
  * store's addressing mode, which makes the compiler materialize the address
@@ -34,7 +34,7 @@ void DMASyncFillTransfer(u32 channel, void *dst, u32 data, u32 size)
     while (*dmaCtrl & 0x80000000)
         ;
 
-    fillReg = (vu32 *)(((u32)0x040000e0 + (channel << 2)) & 0xFFFFFFFFFFFFFFFF);
+    fillReg = (vu32 *)(((u32)0x040000e0 + (channel << 2)));
     *fillReg = data;
     DMAStartTransferFB(channel, (void *)fillReg, dst, (size >> 2) | 0x85000000);
 

--- a/src/MulVec3Mat4x3.c
+++ b/src/MulVec3Mat4x3.c
@@ -6,8 +6,8 @@ void MulVec3Mat4x3(Vector3* v, Matrix4x3* m, Vector3* dst)
     int y = v->y;
     int x = v->x;
     int z = v->z;
-    int* py = (int*)(int)(((long long)(int)((char*)dst + 4)) & 0xFFFFFFFFFFFFFFFFLL);
-    int* pz = (int*)(int)(((long long)(int)((char*)dst + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* py = (int*)(int)(((long long)(int)((char*)dst + 4)));
+    int* pz = (int*)(int)(((long long)(int)((char*)dst + 8)));
 
     dst->x = (int)(((long long)x * m->m[0] + (long long)y * m->m[3] + (long long)z * m->m[6]) >> 12);
     dst->x += m->m[9];

--- a/src/START_INTRO_MINIMAP_ZOOM.c
+++ b/src/START_INTRO_MINIMAP_ZOOM.c
@@ -6,18 +6,18 @@ void START_INTRO_MINIMAP_ZOOM(char* c){
   if (*(unsigned char*)(*(char**)(c+4) + 0x595d) != 0)
     return;
   if (*(short*)(c+0x36) < *(short*)(c+0x34)) {
-    short* p = (short*)(((int)c + 0x36) & 0xFFFFFFFFFFFFFFFF);
+    short* p = (short*)(((int)c + 0x36));
     *p = *p + 8;
     if (*(short*)(c+0x36) > *(short*)(c+0x34))
       *(short*)(c+0x36) = *(short*)(c+0x34);
   } else {
-    short* p = (short*)(((int)c + 0x36) & 0xFFFFFFFFFFFFFFFF);
+    short* p = (short*)(((int)c + 0x36));
     *p = *p - 8;
     if (*(short*)(c+0x36) < *(short*)(c+0x34))
       *(short*)(c+0x36) = *(short*)(c+0x34);
   }
   {
-    short* q = (short*)(((int)c + 0x32) & 0xFFFFFFFFFFFFFFFF);
+    short* q = (short*)(((int)c + 0x32));
     *q = *q + *(short*)(c+0x36);
   }
   func_ov006_02110e28(c);

--- a/src/ShowCrashScreen.c
+++ b/src/ShowCrashScreen.c
@@ -90,7 +90,7 @@ void ShowCrashScreen(void)
             int *tail;
             { i = 0; if (i < 17) do { nds_printf(scr + (i + 3) * 0x40 + 0x28, data_0208e5e4,
                     &buf.c[i * 3], regs[i]); i++; } while (i < 17); }
-            tail = (int *)(int)(((long long)(int)(data_0209cddc + 0x19)) & 0xFFFFFFFFFFFFFFFFLL);
+            tail = (int *)(int)(((long long)(int)(data_0209cddc + 0x19)));
             nds_printf(scr + 0x528, data_0208e5f0, tail[0]);
             nds_printf(scr + 0x568, data_0208e5fc, tail[1]);
         }

--- a/src/StarSelect_Spawn.cpp
+++ b/src/StarSelect_Spawn.cpp
@@ -15,7 +15,7 @@ void* StarSelect_Spawn(void){
     _ZN9ActorBaseC1Ev(p);
     *(void***)p = (void**)data_0208e4b8;
     *(void***)p = (void**)_ZTV5Stage;
-    unsigned char* fl = (unsigned char*)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFF);
+    unsigned char* fl = (unsigned char*)(((int)p + 0x13));
     *fl |= 1;
     *fl |= 4;
     *(void***)p = (void**)data_ov003_020b1704;

--- a/src/UpdateMinimap.c
+++ b/src/UpdateMinimap.c
@@ -14,7 +14,7 @@ extern MinimapState data_0209f3c4;
 
 void UpdateMinimap(MinimapDesc *desc, u32 a, u32 b, u32 c, u32 d)
 {
-    *(MinimapDesc *)(((long long)(int)&data_0209f3c8) & 0xFFFFFFFFFFFFFFFFLL) = *desc;
+    *(MinimapDesc *)(((long long)(int)&data_0209f3c8)) = *desc;
     data_0209f3c4.f14 = a;
     data_0209f3c4.f18 = b;
     data_0209f3c4.f1c = c;

--- a/src/Vec3_AsrInPlace.c
+++ b/src/Vec3_AsrInPlace.c
@@ -1,7 +1,7 @@
 int *Vec3_AsrInPlace(int *v, int sh)
 {
     v[0] >>= sh;
-    *(int *)(((long long)(int)(v + 1)) & 0xFFFFFFFFFFFFFFFFLL) >>= sh;
-    *(int *)(((long long)(int)(v + 2)) & 0xFFFFFFFFFFFFFFFFLL) >>= sh;
+    *(int *)(((long long)(int)(v + 1))) >>= sh;
+    *(int *)(((long long)(int)(v + 2))) >>= sh;
     return v;
 }

--- a/src/Vec3_LslInPlace.c
+++ b/src/Vec3_LslInPlace.c
@@ -1,7 +1,7 @@
 int *Vec3_LslInPlace(int *v, int sh)
 {
     v[0] <<= sh;
-    *(int *)(((long long)(int)(v + 1)) & 0xFFFFFFFFFFFFFFFFLL) <<= sh;
-    *(int *)(((long long)(int)(v + 2)) & 0xFFFFFFFFFFFFFFFFLL) <<= sh;
+    *(int *)(((long long)(int)(v + 1))) <<= sh;
+    *(int *)(((long long)(int)(v + 2))) <<= sh;
     return v;
 }

--- a/src/_ZN10BowserFire13InitResourcesEv.cpp
+++ b/src/_ZN10BowserFire13InitResourcesEv.cpp
@@ -33,7 +33,7 @@ extern "C" int _ZN10BowserFire13InitResourcesEv(char* c) {
     *(int*)(c + 0x36c) = 0;
     *(unsigned char*)(c + 0x378) = (*(unsigned int*)(c + 8) >> 4) & 3;
     if (*(int*)(c + 0x35c) == 0)
-        *(int*)(((int)c + 0x2e8) & 0xFFFFFFFFFFFFFFFF) |= 1;
+        *(int*)(((int)c + 0x2e8)) |= 1;
     *(int*)(c + 0x360) = 0x2000;
     *(int*)(c + 0x380) = 0;
     *(int*)(c + 0x37c) = *(int*)(c + 0x380);

--- a/src/_ZN10BowserFire8BehaviorEv.cpp
+++ b/src/_ZN10BowserFire8BehaviorEv.cpp
@@ -15,9 +15,9 @@ struct CylinderClsn { void Clear(); void Update(); };
 int BowserFire::Behavior()
 {
     Actor *self = (Actor*)((char *)this);
-    *(int*)(((int)((char *)this) + 0x370) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int*)(((int)((char *)this) + 0x370)) += 1;
     (self->*data_ov060_0211afb4[unk_35c].pmf)();
-    *(unsigned short*)(((int)((char *)this) + 0x374) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned short*)(((int)((char *)this) + 0x374)) += 1;
     if (unk_09c != 0) {
         WithMeshClsn_UpdateDiscreteNoLava_veneer((char *)&mWithMeshClsn);
         if (unk_35c != 4) {

--- a/src/_ZN10DonutBlock8BehaviorEv.cpp
+++ b/src/_ZN10DonutBlock8BehaviorEv.cpp
@@ -12,8 +12,8 @@ struct Platform {
 
 int DonutBlock::Behavior()
 {
-    short *s = (short *)(((int)((char *)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF);
-    short *t = (short *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFF);
+    short *s = (short *)(((int)((char *)this) + 0x8e));
+    short *t = (short *)(((int)((char *)this) + 0x300));
     *s = (short)(*s + t[0x1e / 2]);
     int b = (int)((unk_0b0 & 8) != 0);
     if (b != 0) {

--- a/src/_ZN10KoopaShell8BehaviorEv.cpp
+++ b/src/_ZN10KoopaShell8BehaviorEv.cpp
@@ -49,7 +49,7 @@ int _ZN10KoopaShell8BehaviorEv(char *c)
         if (*(u8 *)(c + 0x107) != 0) {
             *(s16 *)(c + 0x3bc) = *(s16 *)(c + 0x94);
             func_ov102_0214d1f8(c, &data_ov102_0214ea78);
-            *(u32 *)(int)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80000;
+            *(u32 *)(int)(((long long)(int)(c + 0xb0))) &= ~0x80000;
             *(u8 *)(c + 0x107) = 0;
         }
         func_ov102_0214ce60(c);

--- a/src/_ZN10MrBlizzard13InitResourcesEv.cpp
+++ b/src/_ZN10MrBlizzard13InitResourcesEv.cpp
@@ -116,7 +116,7 @@ int MrBlizzard::InitResources()
         unk_0b0 = 0x10000000;
         func_ov081_02125488(((char *)this), &data_ov081_02128e54);
     } else {
-        *(s32 *)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x118000;
+        *(s32 *)(((int)((char *)this) + 0x60)) -= 0x118000;
         func_ov081_02125488(((char *)this), &data_ov081_02128e84);
         if (mType == 3) {
             unk_108 = 0;

--- a/src/_ZN10PyramidTag8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTag8BehaviorEv.cpp
@@ -19,7 +19,7 @@ int PyramidTag::Behavior()
     }
     char* a = _ZN5Actor10FindWithIDEj(id);
     if(a){
-      unsigned char* p = (unsigned char*)(((int)a + 0x3b6) & 0xFFFFFFFFFFFFFFFF);
+      unsigned char* p = (unsigned char*)(((int)a + 0x3b6));
       *p += 1;
     }
     _ZN9ActorBase18MarkForDestructionEv(((char*)this));

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int PyramidTop::Behavior()
     switch (state) {
     case 0:
         if (unk_3b6 == 4) {
-            (*(u8*)(((long long)(int)((char*)&unk_3b7)) & 0xffffffffffffffffLL))++;
+            (*(u8*)(((long long)(int)((char*)&unk_3b7))))++;
         }
         break;
     case 1:
@@ -35,7 +35,7 @@ int PyramidTop::Behavior()
         }
         break;
     }
-    (*(u16*)(((long long)(int)((char*)&unk_3b2)) & 0xffffffffffffffffLL))++;
+    (*(u16*)(((long long)(int)((char*)&unk_3b2))))++;
     if (state != unk_3b7) {
         unk_3b2 = 0;
     }

--- a/src/_ZN10StarMarker13InitResourcesEv.cpp
+++ b/src/_ZN10StarMarker13InitResourcesEv.cpp
@@ -75,7 +75,7 @@ int StarMarker::InitResources()
         void *sp;
         sp = _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, mStarID | 0x60, ((char *)this) + 0x5c, (void *)0, (s8)mAreaId, -1);
         if (sp != 0) {
-            u16 *p = (u16 *)(((int)sp + 0x4a2) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *p = (u16 *)(((int)sp + 0x4a2));
             *p = (u16)(*p | 0x80);
         }
         _ZN9ModelBase7SetFileEP8BMD_Fileii(((char *)this) + 0x114, _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0211093c), 1, 0x18);
@@ -86,7 +86,7 @@ int StarMarker::InitResources()
     if (kind == 4) {
         u8 *p;
         mState = 2;
-        p = (u8 *)(((int)((char *)this) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (u8 *)(((int)((char *)this) + 0x1db));
         *p = (u8)(*p | 2);
         v4.x = 0;
         v4.y = -0x50000;
@@ -102,15 +102,15 @@ int StarMarker::InitResources()
     } else if (kind & 1) {
         mState = 1;
         if (kind & 2) {
-            u8 *p = (u8 *)(((int)((char *)this) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *p = (u8 *)(((int)((char *)this) + 0x1db));
             *p = (u8)((*p & ~1) | 1);
         }
         {
-            u8 *p = (u8 *)(((int)((char *)this) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *p = (u8 *)(((int)((char *)this) + 0x1db));
             *p = (u8)(*p | 8);
         }
     } else {
-        u8 *p = (u8 *)(((int)((char *)this) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL);
+        u8 *p = (u8 *)(((int)((char *)this) + 0x1db));
         u8 nv = (u8)((((int)kind >> 1) & 1) ^ 1);
         *p = (u8)((*p & ~2) | ((nv & 1) << 1));
     }
@@ -134,7 +134,7 @@ int StarMarker::InitResources()
     }
 
     if (((u32)(mFlags << 0x1e) >> 0x1f) == 0) {
-        s32 *p = (s32 *)(((int)((char *)this) + 0xec) & 0xFFFFFFFFFFFFFFFFLL);
+        s32 *p = (s32 *)(((int)((char *)this) + 0xec));
         *p = *p | 1;
     }
     r3 = 0;

--- a/src/_ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv.cpp
+++ b/src/_ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv.cpp
@@ -22,7 +22,7 @@ void StarMarker::SpawnRedCoinStarIfNecessary()
   star = (char*)_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0xb2, mStarID, &v, 0, mAreaId, -1);
   if(star == 0) return;
   _ZN9PowerStar13AddStarMarkerEv(star);
-  *(unsigned short*)(((int)star + 0x4a2) & 0xFFFFFFFFFFFFFFFF) |= 0x1000;
+  *(unsigned short*)(((int)star + 0x4a2)) |= 0x1000;
   *(int*)(star+0x434) = unk_004;
-  *(unsigned char*)(((int)((char*)this) + 0x1db) & 0xFFFFFFFFFFFFFFFF) |= 4;
+  *(unsigned char*)(((int)((char*)this) + 0x1db)) |= 4;
 }

--- a/src/_ZN10StarMarker8BehaviorEv.cpp
+++ b/src/_ZN10StarMarker8BehaviorEv.cpp
@@ -25,23 +25,23 @@ int StarMarker::Behavior()
         if (mStarID == data_0209f344[data_0209f208]) {
             mAppearTimer = 0;
             if (((unsigned int)(mFlags << 0x1f) >> 0x1f) == 0) {
-                *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
-                *(int *)((((int)((char *)this)) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+                *(unsigned char *)((((int)((char *)this)) + 0x1db)) |= 2;
+                *(int *)((((int)((char *)this)) + 0xec)) &= ~1;
             }
         } else {
             mAppearTimer = 0x2a;
         }
-        *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+        *(unsigned char *)((((int)((char *)this)) + 0x1db)) &= ~8;
     }
     if (mState != 0) {
         if (mAppearTimer != 0) {
             if (((unsigned int)(mFlags << 0x1e) >> 0x1f) == 0) {
                 if (mStarID == data_0209f344[data_0209f208]) {
-                    *(unsigned short *)((((int)((char *)this)) + 0x1d4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                    *(unsigned short *)((((int)((char *)this)) + 0x1d4)) -= 1;
                     if (mAppearTimer == 0) {
                         if (((unsigned int)(mFlags << 0x1f) >> 0x1f) == 0) {
-                            *(unsigned char *)((((int)((char *)this)) + 0x1db) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
-                            *(int *)((((int)((char *)this)) + 0xec) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+                            *(unsigned char *)((((int)((char *)this)) + 0x1db)) |= 2;
+                            *(int *)((((int)((char *)this)) + 0xec)) &= ~1;
                         }
                     }
                 }
@@ -50,7 +50,7 @@ int StarMarker::Behavior()
         Matrix4x3_FromTranslation(((char *)this) + 0x130, mPosX >> 3, mPosY >> 3,
                                   mPosZ >> 3);
     } else {
-        *(short *)((((int)((char *)this)) + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += 0x400;
+        *(short *)((((int)((char *)this)) + 0x8e)) += 0x400;
         Matrix4x3_FromRotationY(((char *)this) + 0x130, unk_08e);
         unk_154 = mPosX >> 3;
         unk_158 = mPosY >> 3;

--- a/src/_ZN10StarSwitch13InitResourcesEv.cpp
+++ b/src/_ZN10StarSwitch13InitResourcesEv.cpp
@@ -35,7 +35,7 @@ extern "C" int _ZN10StarSwitch13InitResourcesEv(char *c) {
         int b = 0;
         if (*(u16*)(c + 0xc) == 0xc) b = 1;
         if (b) {
-            *(int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+            *(int*)(((long long)(int)(c + 0xb0))) |= 0x4000000;
             *(int*)(c + 0x33c) = 2;
             *(u8*)(c + 0x351) = *(unsigned int*)(c + 8);
             if (*(u8*)(c + 0x351) == 0xff)
@@ -71,10 +71,10 @@ extern "C" int _ZN10StarSwitch13InitResourcesEv(char *c) {
         if (h == 0xff || h == 0)
             *(u16*)(c + 0x300 + 0x3a) = 0x190;
         else
-            *(u16*)(((long long)(int)(c + 0x33a)) & 0xFFFFFFFFFFFFFFFFLL) *= 0xa;
+            *(u16*)(((long long)(int)(c + 0x33a))) *= 0xa;
     }
     *(u8*)(c + 0x34f) = 5;
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x5000;
+    *(int*)(((long long)(int)(c + 0x60))) += 0x5000;
     *(u8*)(c + 0x34d) = 1;
     return 1;
 }

--- a/src/_ZN11CommonModel13Func_020160ACEj.cpp
+++ b/src/_ZN11CommonModel13Func_020160ACEj.cpp
@@ -32,7 +32,7 @@ void CommonModel::Func_020160AC(u32 arg)
     u32 i;
 
     for (i = 0; i < n; i++) {
-        u32 *f = (u32 *)(((long long)(int)((char *)p + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32 *f = (u32 *)(((long long)(int)((char *)p + 0x24)));
         *f |= arg;
         p++;
     }

--- a/src/_ZN11PyramidLift13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidLift13InitResourcesEv.cpp
@@ -58,7 +58,7 @@ int PyramidLift::InitResources()
             *(int*)(ip+0x380) = mPosY;
             prod = n * k;
             *(int*)(ip+0x384) = mPosZ;
-            py = (int*)(((int)ip + 0x380) & 0xFFFFFFFFFFFFFFFFLL);
+            py = (int*)(((int)ip + 0x380));
             *py = *py - prod;
             ip = ip + 0xc;
         } while (n < 10);

--- a/src/_ZN11PyramidLift8BehaviorEv.cpp
+++ b/src/_ZN11PyramidLift8BehaviorEv.cpp
@@ -30,7 +30,7 @@ int PyramidLift::Behavior()
             unk_0a8 = -0xa000;
         }
         {
-            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4));
             *pa = *pa + 1;
         }
         break;
@@ -41,11 +41,11 @@ int PyramidLift::Behavior()
         int* p = (int*)(((char*)this) + idx * 0xc + 0x380);
         int lim = *p + 0x14000;
         if (v <= lim) {
-            unsigned char *pb = (unsigned char*)(((int)((char*)this) + 0x3f8) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char *pb = (unsigned char*)(((int)((char*)this) + 0x3f8));
             *pb = *pb + 1;
         }
         {
-            int *py = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            int *py = (int*)(((int)((char*)this) + 0x60));
             *py = *py + unk_0a8;
         }
         if (mPosY < 0x80000) {
@@ -64,7 +64,7 @@ int PyramidLift::Behavior()
         int d = (int)(((long long)s * 0xa + 0x800) >> 0xc);
         mPosY = d + 0x80000;
         {
-            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *pa = (unsigned short*)(((int)((char*)this) + 0x3f4));
             if (mShakeTimer >= 8) {
                 unk_0a8 = z;
                 mPosY = 0x80000;

--- a/src/_ZN11PyramidStep13InitResourcesEv.cpp
+++ b/src/_ZN11PyramidStep13InitResourcesEv.cpp
@@ -42,11 +42,11 @@ int PyramidStep::InitResources()
         case 0:
             break;
         case 1:
-            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0xfa000;
-            *(unsigned short*)(((int)((char *)this) + 0x370) & 0xFFFFFFFFFFFFFFFF) += 0x32;
+            *(int*)(((int)((char *)this) + 0x60)) -= 0xfa000;
+            *(unsigned short*)(((int)((char *)this) + 0x370)) += 0x32;
             break;
         case 2:
-            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) -= 0x1f4000;
+            *(int*)(((int)((char *)this) + 0x60)) -= 0x1f4000;
             unk_372 = 1;
             unk_0a8 = v;
             break;

--- a/src/_ZN11PyramidStep8BehaviorEv.cpp
+++ b/src/_ZN11PyramidStep8BehaviorEv.cpp
@@ -26,8 +26,8 @@ int PyramidStep::Behavior()
         break;
     }
     {
-        unsigned short* p370 = (unsigned short*)(((int)c + 0x370) & 0xFFFFFFFFFFFFFFFF);
-        int* p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short* p370 = (unsigned short*)(((int)c + 0x370));
+        int* p60 = (int*)(((int)c + 0x60));
         *p370 = (unsigned short)(*p370 + 1);
         *p60 = *p60 + *(int*)(c + 0xa8);
     }

--- a/src/_ZN11RollingRock8BehaviorEv.c
+++ b/src/_ZN11RollingRock8BehaviorEv.c
@@ -36,7 +36,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
         if (*(u8*)(c + 0x3be) != 4) {
             s16 *p8c;
             func_ov021_021127b4(c);
-            p8c = (s16 *)(int)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+            p8c = (s16 *)(int)(((long long)(int)(c + 0x8c)));
             *p8c = (s16)(*p8c + (*(int*)(c + 0x98) >> 12) * 0x43);
             *(s16*)(c + 0x8e) = *(s16*)(c + 0x94);
             func_ov021_02112544(c);
@@ -80,7 +80,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
                 struct Vector3_16 v16;
                 u32 rnd;
                 u8 *p3bf;
-                p3bf = (u8 *)(int)(((long long)(int)(c + 0x3bf)) & 0xFFFFFFFFFFFFFFFFLL);
+                p3bf = (u8 *)(int)(((long long)(int)(c + 0x3bf)));
                 *p3bf = (u8)(*p3bf + 1);
                 *(u16*)(c + 0x100) = 0;
                 v16 = *(struct Vector3_16*)(c + 0x92);
@@ -100,7 +100,7 @@ int _ZN11RollingRock8BehaviorEv(char *c)
             }
         }
         {
-            u16 *p100 = (u16 *)(int)(((long long)(int)(c + 0x100)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *p100 = (u16 *)(int)(((long long)(int)(c + 0x100)));
             *p100 = (u16)(*p100 + 1);
         }
     }

--- a/src/_ZN11VirtualDoor13InitResourcesEv.cpp
+++ b/src/_ZN11VirtualDoor13InitResourcesEv.cpp
@@ -8,7 +8,7 @@ extern void Matrix4x3_ApplyInPlaceToRotationY(void* m, short angY);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* m, short angX);
 extern void InvMat4x3(void* out, void* in);
 
-#define M(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define M(p) ((int)(((long long)(int)(p))))
 
 int _ZN11VirtualDoor13InitResourcesEv(char* c)
 {

--- a/src/_ZN11VirtualDoor8BehaviorEv.cpp
+++ b/src/_ZN11VirtualDoor8BehaviorEv.cpp
@@ -34,7 +34,7 @@ int _ZN11VirtualDoor8BehaviorEv(char *c) {
             InvMat4x3(&data_020a0e68, &data_020a0e68);
             MulVec3Mat4x3(out1, &data_020a0e68, player + 0x5c);
         }
-        *(int *)((((int)c) + 0x98) & 0xFFFFFFFFFFFFFFFFLL) -= 0x20000;
+        *(int *)((((int)c) + 0x98)) -= 0x20000;
         if (*(int *)(c + 0x98) < -0x300000) {
             *(int *)(c + 0x98) = -0x300000;
             if (data_02092110 < 0) {
@@ -87,8 +87,7 @@ int _ZN11VirtualDoor8BehaviorEv(char *c) {
                                             func_02012790(0x19);
                                         }
                                     } else {
-                                        int t = (signed char)(int)((*(unsigned int *)(c + 8) >> 0x18) &
-                                                                   0xFFFFFFFFFFFFFFFFLL);
+                                        int t = (signed char)(int)((*(unsigned int *)(c + 8) >> 0x18));
                                         if (t == 0x1b || t == 0x12) {
                                             func_ov002_020b0a0c(c);
                                             _ZN5Scene20SetAndStopColorFaderEv();

--- a/src/_ZN12MansionSteps8BehaviorEv.cpp
+++ b/src/_ZN12MansionSteps8BehaviorEv.cpp
@@ -17,10 +17,10 @@ int MansionSteps::Behavior()
   int idx = unk_140;
   C* obj = (C*)((char*)this);
   (obj->*data_ov063_0211ef38[idx])();
-  unsigned short* ctr = (unsigned short*)(((int)((char*)this) + 0x14c) & 0xFFFFFFFFFFFFFFFF);
+  unsigned short* ctr = (unsigned short*)(((int)((char*)this) + 0x14c));
   *ctr = *ctr + 1;
   if (before != unk_150) {
-    unsigned short* base = (unsigned short*)(((int)((char*)this) + 0x100) & 0xFFFFFFFFFFFFFFFF);
+    unsigned short* base = (unsigned short*)(((int)((char*)this) + 0x100));
     base[0x4c/2] = 0;
   }
   func_ov063_0211c684(((char*)this));

--- a/src/_ZN12PiranhaPlant13InitResourcesEv.cpp
+++ b/src/_ZN12PiranhaPlant13InitResourcesEv.cpp
@@ -53,7 +53,7 @@ extern "C" int _ZN12PiranhaPlant13InitResourcesEv(char* c)
     *(int*)(c + 0x448) = *(int*)(c + 0x64);
     {
         s16 *tbl = data_02082214;
-        Vector3* home = (Vector3*)(((int)c + 0x440) & 0xFFFFFFFFFFFFFFFFLL);
+        Vector3* home = (Vector3*)(((int)c + 0x440));
         *(Vector3*)(c + 0x44c) = *home;
         unsigned short angh = *(unsigned short*)(c + 0x8e);
         int ang = angh >> 4;

--- a/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp
@@ -42,7 +42,7 @@ void WithMeshClsn::UpdateDiscreteNoLava()
         unk_018, *(void **)((char *)&mActor));
     unk_128 = unk_1b8;
     if (src->y - p68->y > 0) {
-        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags)) & 0xffffffffffffffffLL) |= 0x20;
+        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags))) |= 0x20;
     }
     if (_ZN10SphereClsn10DetectClsnEv((char *)&mSphereClsn)) {
         p6c = (struct Vector3 *)((char *)&unk_06c);
@@ -52,9 +52,9 @@ void WithMeshClsn::UpdateDiscreteNoLava()
         if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
             if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
-                *(int *)(((long long)(int)((char *)src + 4)) & 0xffffffffffffffffLL) += p6c->y;
+                *(int *)(((long long)(int)((char *)src + 4))) += p6c->y;
             }
-            *(int *)(((long long)(int)((char *)src + 8)) & 0xffffffffffffffffLL) += p6c->z;
+            *(int *)(((long long)(int)((char *)src + 8))) += p6c->z;
         }
     }
     if (onGround == 0)

--- a/src/_ZN12WithMeshClsn20UpdateExtraContinousEv.cpp
+++ b/src/_ZN12WithMeshClsn20UpdateExtraContinousEv.cpp
@@ -24,10 +24,10 @@ extern u32 data_02099368[];
 #pragma opt_common_subs off
 
 #define V3D(v, p, dy) { s32 _x, _y, _z; _z = (p)->z; _y = (p)->y; _x = (p)->x; _y = _y + (dy); (v).x = _x; (v).y = _y; (v).z = _z; }
-#define FLAGP (*(u8 *)(((long long)(int)(t + 0x90)) & 0xFFFFFFFFFFFFFFFFLL))
+#define FLAGP (*(u8 *)(((long long)(int)(t + 0x90))))
 #define FLAGQ (*(u8 *)(((long long)(int)(t + 0x90)) | 0LL))
-#define LNDR(T, a) ((T *)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LND32(a)   ((s32)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LNDR(T, a) ((T *)(((long long)(int)(a))))
+#define LND32(a)   ((s32)(((long long)(int)(a))))
 #define V3C(v, p) { s32 _x, _y, _z; _z = (p)->z; _y = (p)->y; _x = (p)->x; (v).x = _x; (v).y = _y; (v).z = _z; }
 
 int  _ZNK12WithMeshClsn10IsOnGroundEv(void *);

--- a/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
+++ b/src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp
@@ -24,7 +24,7 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
 
     onGround = _ZNK12WithMeshClsn10IsOnGroundEv(((char *)this));
     _ZN12WithMeshClsn19ClearAllGroundFlagsEv(((char *)this));
-    v.x = *(int *)(((long long)(int)src) & 0xffffffffffffffffLL);
+    v.x = *(int *)(((long long)(int)src));
     sy = src->y;
     v.y = sy;
     v.z = src->z;
@@ -33,7 +33,7 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
         unk_018, *(void **)((char *)&mActor));
     unk_128 = unk_1b8;
     if (src->y - *(int *)(obj + 0x6c) > 0) {
-        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags)) & 0xffffffffffffffffLL) |= 0x20;
+        *(unsigned char *)(((long long)(int)((char *)&mClsnFlags))) |= 0x20;
     }
     if (func_02038a38((char *)&mSphereClsn)) {
         p6c = (struct Vector3 *)((char *)&unk_06c);
@@ -43,9 +43,9 @@ void WithMeshClsn::UpdateDiscreteNoLava_2()
         if (_ZNK12WithMeshClsn15ShouldUpdatePosEv(((char *)this))) {
             src->x += p6c->x;
             if (_ZNK12WithMeshClsn16ShouldUpdatePosYEv(((char *)this))) {
-                *(int *)(((long long)(int)((char *)src + 4)) & 0xffffffffffffffffLL) += p6c->y;
+                *(int *)(((long long)(int)((char *)src + 4))) += p6c->y;
             }
-            *(int *)(((long long)(int)((char *)src + 8)) & 0xffffffffffffffffLL) += p6c->z;
+            *(int *)(((long long)(int)((char *)src + 8))) += p6c->z;
         }
     }
     if (onGround == 0)

--- a/src/_ZN13PoleBillboard8BehaviorEv.cpp
+++ b/src/_ZN13PoleBillboard8BehaviorEv.cpp
@@ -28,14 +28,14 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             *(short *)(c + 0x390) = 0;
             *(unsigned char *)(c + 0x397) = 0;
         } else {
-            *(short *)(((int)c + 0x394) & 0xFFFFFFFFFFFFFFFFLL) -= 8;
+            *(short *)(((int)c + 0x394)) -= 8;
         }
-        *(short *)(((int)c + 0x390) & 0xFFFFFFFFFFFFFFFFLL) += 0x400;
+        *(short *)(((int)c + 0x390)) += 0x400;
         break;
     }
     case 2: {
-        short *p392 = (short *)(((long long)(int)(c + 0x392)) & 0xFFFFFFFFFFFFFFFFLL);
-        short *p8c = (short *)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+        short *p392 = (short *)(((long long)(int)(c + 0x392)));
+        short *p8c = (short *)(((long long)(int)(c + 0x8c)));
         int amt = *(signed char *)(c + 0x396) << 0x17;
         *p392 = *p392 + (amt >> 16);
         *p8c = *p8c + *(short *)(c + 0x300 + 0x92);
@@ -43,7 +43,7 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             if (*(short *)(c + 0x8c) < -0x4000) {
                 *(short *)(c + 0x8c) = -0x4000;
                 *(short *)(c + 0x392) = 0;
-                (*(unsigned char *)(((int)c + 0x397) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(unsigned char *)(((int)c + 0x397)))++;
                 struct Vector3 pos;
                 pos.x = *(int *)(c + 0x5c);
                 pos.y = *(int *)(c + 0x60);
@@ -52,8 +52,8 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
                 _ZN5Sound9PlayBank3EjRK7Vector3(0x44, (struct Vector3 *)(c + 0x74));
             }
         } else {
-            *(int *)(((int)c + 0x38c) & 0xFFFFFFFFFFFFFFFFLL) += 0x2000;
-            *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x38c);
+            *(int *)(((int)c + 0x38c)) += 0x2000;
+            *(int *)(((int)c + 0x60)) += *(int *)(c + 0x38c);
             {
                 int lim = *(int *)(c + 0x388) + 0x46000;
                 if (*(int *)(c + 0x60) > lim) {
@@ -63,7 +63,7 @@ int _ZN13PoleBillboard8BehaviorEv(char *c)
             if (*(short *)(c + 0x8c) > 0x4000) {
                 *(short *)(c + 0x8c) = 0x4000;
                 *(short *)(c + 0x392) = 0;
-                (*(unsigned char *)(((int)c + 0x397) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(unsigned char *)(((int)c + 0x397)))++;
                 struct Vector3 pos;
                 pos.x = *(int *)(c + 0x5c);
                 pos.y = *(int *)(c + 0x60);

--- a/src/_ZN13RaycastGround10DetectClsnEv.cpp
+++ b/src/_ZN13RaycastGround10DetectClsnEv.cpp
@@ -31,7 +31,7 @@ int RaycastGround::DetectClsn()
         ClsnObj* p = func_020393b4(obj);
         if (func_02035354(this, p) != 0) continue;
         if (p != 0 && ((p->flags & 2) ? flag : 0) != 0) {
-            int* pv = (int*)(((long long)(int)&p->vec[0]) & 0xFFFFFFFFFFFFFFFFLL);
+            int* pv = (int*)(((long long)(int)&p->vec[0]));
             pos.x = pv[0];
             pos.y = pv[1];
             pos.z = pv[2];
@@ -43,7 +43,7 @@ int RaycastGround::DetectClsn()
             } else {
                 pos.y = pos.y + func_0203938c(obj);
             }
-            Vec3* selfpos = (Vec3*)(((long long)(int)&this->f38) & 0xFFFFFFFFFFFFFFFFLL);
+            Vec3* selfpos = (Vec3*)(((long long)(int)&this->f38));
             if (selfpos->y < pos.y - thr) continue;
             if (Vec3_HorzDist(selfpos, &pos) > thr) continue;
         }

--- a/src/_ZN13RollingLogLll16CleanupResourcesEv.c
+++ b/src/_ZN13RollingLogLll16CleanupResourcesEv.c
@@ -9,6 +9,6 @@ int _ZN13RollingLogLll16CleanupResourcesEv(struct RollingLogLll *self)
 {
     char *p = self->sub;
     if (p)
-        *(u16 *)(((long long)(int)(p + 0x324)) & 0xffffffffffffffffLL) -= 1;
+        *(u16 *)(((long long)(int)(p + 0x324))) -= 1;
     return 1;
 }

--- a/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
@@ -48,7 +48,7 @@ int RollingLogTtm::InitResources()
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(((char *)this) + 0x194, ((char *)this), 0x32000, 0x32000, 0, 0);
     unk_09c = -0x2000;
     unk_0a0 = -0x3c000;
-    py = (int *)(((int)((char *)this) + 0x384) & 0xFFFFFFFFFFFFFFFFLL);
+    py = (int *)(((int)((char *)this) + 0x384));
     unk_380 = mPosX;
     unk_384 = mPosY;
     unk_388 = mPosZ;

--- a/src/_ZN13SharedFilePtr7ReleaseEv.c
+++ b/src/_ZN13SharedFilePtr7ReleaseEv.c
@@ -10,7 +10,7 @@ void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self)
     if (self->numRefs == 0)
         return;
 
-    *(unsigned char *)(((long long)(int)((char *)self + 2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(unsigned char *)(((long long)(int)((char *)self + 2))) -= 1;
 
     if (self->numRefs != 0)
         return;

--- a/src/_ZN13SharedFilePtr8LoadFileEv.c
+++ b/src/_ZN13SharedFilePtr8LoadFileEv.c
@@ -16,6 +16,6 @@ void *_ZN13SharedFilePtr8LoadFileEv(struct SharedFilePtr *self)
         return 0;
     }
 
-    *(unsigned char *)(((long long)(int)((char *)self + 2)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(unsigned char *)(((long long)(int)((char *)self + 2))) += 1;
     return self->filePtr;
 }

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -48,7 +48,7 @@ int SnowmanBreath::Behavior()
                 break;
             }
             {
-                u8 *state = (u8 *)(((int)((char *)this) + 0x13d2) & 0xFFFFFFFFFFFFFFFF);
+                u8 *state = (u8 *)(((int)((char *)this) + 0x13d2));
                 *state = *state + 1;
             }
             break;
@@ -63,7 +63,7 @@ int SnowmanBreath::Behavior()
                 break;
             }
             {
-                u8 *state = (u8 *)(((int)((char *)this) + 0x13d2) & 0xFFFFFFFFFFFFFFFF);
+                u8 *state = (u8 *)(((int)((char *)this) + 0x13d2));
                 *state = *state + 1;
             }
             break;
@@ -76,7 +76,7 @@ int SnowmanBreath::Behavior()
         }
     } else {
         if (func_ov027_02112618(((char *)this)) != 0) {
-            int *timer = (int *)(((int)((char *)this) + 0x13c8) & 0xFFFFFFFFFFFFFFFF);
+            int *timer = (int *)(((int)((char *)this) + 0x13c8));
             *timer = *timer + 1;
             base = ((char *)this) + 0x1000;
             if ((*(int *)(base + 0x3c8) & 7) != 0) {

--- a/src/_ZN13TTC_MovingBar8BehaviorEv.cpp
+++ b/src/_ZN13TTC_MovingBar8BehaviorEv.cpp
@@ -44,7 +44,7 @@ int TTC_MovingBar::Behavior() {
 
             {
                 s16 *p = (s16 *)(
-                    ((int)c + 0x92) & 0xFFFFFFFFFFFFFFFFLL);
+                    ((int)c + 0x92));
                 *p *= (s16)-1;
             }
         }
@@ -58,7 +58,7 @@ int TTC_MovingBar::Behavior() {
 
     {
         s16 *p = (s16 *)(
-            ((int)c + 0x94) & 0xFFFFFFFFFFFFFFFFLL);
+            ((int)c + 0x94));
         *p = (s16)(*p + *(s16 *)((char *)c + 0x96));
     }
 

--- a/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
+++ b/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
@@ -21,7 +21,7 @@ int UpDownLiftBbh::Behavior()
     *(void**)((char*)&unk_324) = _ZN5Actor13ClosestPlayerEv(((char*)this));
     old = mState;
     (((Plat*)((char*)this))->*data_ov095_02137910[old])();
-    *(u16*)(((int)((char*)this) + 0x344) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(u16*)(((int)((char*)this) + 0x344)) += 1;
     if (old != mState) *(u16*)(((char*)&unk_300) + 0x44) = 0;
     _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));
     if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(((char*)this), 0, 0) != 0)

--- a/src/_ZN14BlendModelAnim7AdvanceEv.c
+++ b/src/_ZN14BlendModelAnim7AdvanceEv.c
@@ -4,6 +4,6 @@ void _ZN14BlendModelAnim7AdvanceEv(char *self)
 {
     _ZN9Animation7AdvanceEv(self + 0x50);
     if (*(int *)(self + 0x64) < 0x1000) {
-        *(int *)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(self + 0x68);
+        *(int *)(((long long)(int)(self + 0x64))) += *(int *)(self + 0x68);
     }
 }

--- a/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
+++ b/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
@@ -17,14 +17,14 @@ extern void _ZN12CylinderClsn6UpdateEv(void* p);
 int BlueCoinSwitch::Behavior()
 {
     if (unk_10a != 0) {
-        *(u16*)(((int)((char*)this) + 0x10a) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(u16*)(((int)((char*)this) + 0x10a)) -= 1;
         if (unk_10a == 0) {
-            *(u32*)(((int)((char*)this) + 0xec) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+            *(u32*)(((int)((char*)this) + 0xec)) &= ~1;
             _ZN5Event8ClearBitEj(mEventID);
         }
     }
     if (unk_0f8 != 0) {
-        *(u32*)(((long long)(int)((char*)&unk_0ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u32*)(((long long)(int)((char*)&unk_0ec))) |= 1;
         _ZN5Event6SetBitEj(mEventID);
         if (unk_10c != 0) {
             unk_10a = unk_108;

--- a/src/_ZN14SquarePathLift8BehaviorEv.cpp
+++ b/src/_ZN14SquarePathLift8BehaviorEv.cpp
@@ -44,13 +44,13 @@ int SquarePathLift::Behavior()
         SubVec3(((char *)this) + 0x5c, &scaled2, ((char *)this) + 0x5c);
     }
     if (looped) {
-        *(int *)(((int)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFF) += mPathDir;
+        *(int *)(((int)((char *)this) + 0x328)) += mPathDir;
         if (mNodeIndex < 0) {
             if (_ZNK7PathPtr5LoopsEv((char *)&mPath)) {
                 mNodeIndex = _ZNK7PathPtr8NumNodesEv((char *)&mPath) - 1;
             } else {
                 mPathDir = 1;
-                *(int *)(((unsigned)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFF) += mPathDir * 2;
+                *(int *)(((unsigned)((char *)this) + 0x328)) += mPathDir * 2;
             }
         }
         if (mNodeIndex >= _ZNK7PathPtr8NumNodesEv((char *)&mPath)) {
@@ -58,7 +58,7 @@ int SquarePathLift::Behavior()
                 mNodeIndex = 0;
             } else {
                 mPathDir = -1;
-                *(int *)(((long long)(int)((char *)&mNodeIndex)) & 0xFFFFFFFFFFFFFFFFLL) += mPathDir * 2;
+                *(int *)(((long long)(int)((char *)&mNodeIndex))) += mPathDir * 2;
             }
         }
     }

--- a/src/_ZN14UnchainedChomp13InitResourcesEv.cpp
+++ b/src/_ZN14UnchainedChomp13InitResourcesEv.cpp
@@ -113,7 +113,7 @@ extern "C" int _ZN14UnchainedChomp13InitResourcesEv(unsigned char* thiz)
     }
 
     /* u64-mask launder: materialize add r1,r4,#0x60; ldr/str [r1] for y += 0x64000 */
-    *(int *)(((int)thiz + 0x60) & 0xFFFFFFFFFFFFFFFF) += 0x64000;
+    *(int *)(((int)thiz + 0x60)) += 0x64000;
     *(int*)(thiz + 0x80) = 0x1000;
     *(int*)(thiz + 0x84) = 0x1000;
     *(int*)(thiz + 0x88) = 0x1000;

--- a/src/_ZN14UnchainedChomp8BehaviorEv.cpp
+++ b/src/_ZN14UnchainedChomp8BehaviorEv.cpp
@@ -114,7 +114,7 @@ int UnchainedChomp::Behavior()
         Vec3_Sub(&diff, (Vector3 *)(c + 0x5c), &node);
 
         if (LenVec3(&diff) < 0x190000) {
-            *(int *)(((long long)(int)(c + 0x6b4)) & 0xffffffffffffffffLL) += 1;
+            *(int *)(((long long)(int)(c + 0x6b4))) += 1;
             if (*(int *)(c + 0x6b4) >= *(int *)(c + 0x6b0)) {
                 *(int *)(c + 0x6b4) = 0;
             }

--- a/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
+++ b/src/_ZN15FireSeaElevator13InitResourcesEv.cpp
@@ -19,7 +19,7 @@ int FireSeaElevator::InitResources()
     void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_021131b0);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(((char*)this) + 0xd4, m, 1, -1);
     if (unk_008 != 0xffff) {
-        int* p = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)((char*)this) + 0x60));
         *p -= 0x12c000;
     }
     _ZN8Platform21UpdateModelPosAndRotYEv(((char*)this));

--- a/src/_ZN15FireSeaElevator8BehaviorEv.cpp
+++ b/src/_ZN15FireSeaElevator8BehaviorEv.cpp
@@ -17,16 +17,16 @@ int FireSeaElevator::Behavior()
     if (unk_008 != 0xffff) {
         int idx = unk_354 >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
-        *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) + (int)(((long long)s * 0x7000 + 0x800) >> 12);
+        *(int*)(((int)((char *)this) + 0x60)) =
+            *(int*)(((int)((char *)this) + 0x60)) + (int)(((long long)s * 0x7000 + 0x800) >> 12);
     } else {
         int idx = unk_354 >> 4;
         int s = *(short*)((char*)data_02082214 + (idx << 2));
-        *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-            *(int*)(((int)((char *)this) + 0x60) & 0xFFFFFFFFFFFFFFFF) - (int)(((long long)s * 0x3000 + 0x800) >> 12);
+        *(int*)(((int)((char *)this) + 0x60)) =
+            *(int*)(((int)((char *)this) + 0x60)) - (int)(((long long)s * 0x3000 + 0x800) >> 12);
     }
-    *(short*)(((int)((char *)this) + 0x354) & 0xFFFFFFFFFFFFFFFF) =
-        *(short*)(((int)((char *)this) + 0x354) & 0xFFFFFFFFFFFFFFFF) + 0x100;
+    *(short*)(((int)((char *)this) + 0x354)) =
+        *(short*)(((int)((char *)this) + 0x354)) + 0x100;
     _ZN8Platform21UpdateModelPosAndRotYEv(((char *)this));
     if (_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(((char *)this), 0x400000, 0)) {
         _ZN8Platform19UpdateClsnPosAndRotEv(((char *)this));

--- a/src/_ZN15IceSlideManager8BehaviorEv.cpp
+++ b/src/_ZN15IceSlideManager8BehaviorEv.cpp
@@ -12,7 +12,7 @@ int IceSlideManager::Behavior()
   switch (unk_0d6) {
   case 0:
     if (_ZN5Actor13DistToCPlayerEv(((char*)this)) < 0x180000) {
-      unsigned char* p = (unsigned char*)(((int)((char*)this) + 0xd6) & 0xFFFFFFFFFFFFFFFF);
+      unsigned char* p = (unsigned char*)(((int)((char*)this) + 0xd6));
       _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x15666, 0);
       *p += 1;
     }

--- a/src/_ZN15InvisibleSecret8BehaviorEv.cpp
+++ b/src/_ZN15InvisibleSecret8BehaviorEv.cpp
@@ -17,17 +17,17 @@ int InvisibleSecret::Behavior()
 
     if (unk_14c != 0) return 1;
 
-    *(int *)((int)((char *)&mVertSpeed) & 0xFFFFFFFFFFFFFFFFLL) += unk_09c;
+    *(int *)((int)((char *)&mVertSpeed)) += unk_09c;
     if (mVertSpeed < unk_0a0)
         mVertSpeed = unk_0a0;
-    *(int *)((int)((char *)&mPosY) & 0xFFFFFFFFFFFFFFFFLL) += mVertSpeed;
+    *(int *)((int)((char *)&mPosY)) += mVertSpeed;
 
     switch (unk_14e) {
     case 0:
         if (mPosY < mStartPosY) {
             mPosY = mStartPosY;
             mVertSpeed = 0xf000;
-            (*(u8 *)((int)((char *)&unk_14e) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8 *)((int)((char *)&unk_14e)))++;
         }
         break;
     case 1:
@@ -44,7 +44,7 @@ int InvisibleSecret::Behavior()
     if (unk_138 != 0) {
         char *other = _ZN5Actor10FindWithIDEj(unk_138);
         if (other != 0) {
-            struct V3 *op = (struct V3 *)((int)(other + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            struct V3 *op = (struct V3 *)((int)(other + 0x5c));
             int oy;
             pos.x = op->x;
             pos.y = oy = op->y;

--- a/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
+++ b/src/_ZN15RollingIronBall16CleanupResourcesEv.cpp
@@ -10,7 +10,7 @@ int RollingIronBall::CleanupResources()
     char *file = *(char **)((char *)&unk_3a8);
 
     if (file != 0) {
-        (*(unsigned char *)(((int)file + 0x3d2) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(unsigned char *)(((int)file + 0x3d2)))--;
     }
 
     _ZN13SharedFilePtr7ReleaseEv(&data_ov100_02148668);

--- a/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
@@ -25,17 +25,17 @@ int TtcRotatingCube::Behavior()
             if (DecIfAbove0_Short((u16 *)((char *)&mWaitTimer)) != 0)
                 break;
             _ZN5Sound9PlayBank3EjRK7Vector3(0x5b, ((char *)this) + 0x74);
-            (*(u8 *)(((int)((char *)this) + 0x376) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)((char *)this) + 0x376)))++;
             unk_0a8 = -0x5000;
             break;
         case 1:
-            *(int *)(((int)((char *)this) + 0xa8) & 0xFFFFFFFFFFFFFFFF) += 0x800;
-            *(int *)(((int)((char *)this) + 0x370) & 0xFFFFFFFFFFFFFFFF) += unk_0a8;
+            *(int *)(((int)((char *)this) + 0xa8)) += 0x800;
+            *(int *)(((int)((char *)this) + 0x370)) += unk_0a8;
             if (unk_370 < 0)
                 break;
             unk_370 = 0;
             mWaitTimer = 6;
-            (*(u8 *)(((int)((char *)this) + 0x376) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)((char *)this) + 0x376)))++;
             break;
         case 2:
             if (DecIfAbove0_Short((u16 *)((char *)&mWaitTimer)) != 0)
@@ -47,7 +47,7 @@ int TtcRotatingCube::Behavior()
             mWaitTimer = data_ov065_0211cfa4[data_0209f2c0];
             if (data_0209f2c0 == 2)
                 mWaitTimer = (unsigned int)RandomIntInternal(&data_0209e650) % 7 * 0x14 + 5;
-            *(s16 *)(((int)((char *)this) + 0x378) & 0xFFFFFFFFFFFFFFFF) += data_ov065_0211cfa8[unk_377];
+            *(s16 *)(((int)((char *)this) + 0x378)) += data_ov065_0211cfa8[unk_377];
             break;
         }
     }

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.c
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.c
@@ -56,7 +56,7 @@ Lchk:
         }
 
         {
-            u8 *tog = (u8 *)(((int)c + 0x32e) & 0xFFFFFFFFFFFFFFFF);
+            u8 *tog = (u8 *)(((int)c + 0x32e));
             u8 tv = *tog;
             *tog = tv ^ 1;
             {

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
@@ -60,7 +60,7 @@ Lchk:
         }
 
         {
-            u8 *tog = (u8 *)(((int)((char *)this) + 0x32e) & 0xFFFFFFFFFFFFFFFF);
+            u8 *tog = (u8 *)(((int)((char *)this) + 0x32e));
             u8 tv = *tog;
             *tog = tv ^ 1;
             {

--- a/src/_ZN16BowserShockwaves8BehaviorEv.cpp
+++ b/src/_ZN16BowserShockwaves8BehaviorEv.cpp
@@ -19,7 +19,7 @@ int BowserShockwaves::Behavior()
   int d;
   int s;
   int m0, m1, m2, m3;
-  ((*(unsigned short *)(((int)((char*)this) + 0x214) & 0xFFFFFFFFFFFFFFFF)))++;
+  ((*(unsigned short *)(((int)((char*)this) + 0x214))))++;
   pl = (char*)_ZN5Actor13ClosestPlayerEv(((char*)this));
   n = *(unsigned short*)(((char*)this)+0x200+0x14);
   s = n * 0x22;

--- a/src/_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
+++ b/src/_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
@@ -30,11 +30,11 @@ void MeshColliderBase::UpdatePosWithVelocity(MeshColliderBase& a1, Actor* a2, Cl
     this->m12(vel);
     a3.x = a3.x + vel.x;
     {
-        int* py = (int*)(((long long)(int)&a3.y) & 0xFFFFFFFFFFFFFFFFLL);
+        int* py = (int*)(((long long)(int)&a3.y));
         *py = *py + vel.y;
     }
     {
-        int* pz = (int*)(((long long)(int)&a3.z) & 0xFFFFFFFFFFFFFFFFLL);
+        int* pz = (int*)(((long long)(int)&a3.z));
         *pz = *pz + vel.z;
     }
 }

--- a/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
+++ b/src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp
@@ -24,11 +24,11 @@ extern "C" void _ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10Cl
 {
     int angY = self->GetAngularVelY();
     if (a6) {
-        short* py = (short*)(((long long)(int)&a6->y) & 0xFFFFFFFFFFFFFFFFLL);
+        short* py = (short*)(((long long)(int)&a6->y));
         *py = *py + angY;
     }
     if (a5) {
-        short* py = (short*)(((long long)(int)&a5->y) & 0xFFFFFFFFFFFFFFFFLL);
+        short* py = (short*)(((long long)(int)&a5->y));
         *py = *py + angY;
     }
 }

--- a/src/_ZN16RotatingCogSmall8BehaviorEv.cpp
+++ b/src/_ZN16RotatingCogSmall8BehaviorEv.cpp
@@ -26,7 +26,7 @@ int RotatingCogSmall::Behavior()
 
     if (_Z14ApproachLinearRsss((short*)((char*)&unk_08e), unk_322, 0xc8) != 0 &&
         DecIfAbove0_Short((unsigned short*)((char*)&unk_31e)) == 0) {
-        short* p = (short*)(((int)((char*)this) + 0x322) & 0xFFFFFFFFFFFFFFFF);
+        short* p = (short*)(((int)((char*)this) + 0x322));
         *p = *p + unk_324;
         unsigned char k = data_0209f2c0[0];
         unk_31e = data_ov035_02111ef4[mRotationState][k];

--- a/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
+++ b/src/_ZN17BigMovingIceBlock8BehaviorEv.cpp
@@ -66,7 +66,7 @@ int BigMovingIceBlock::Behavior()
     }
 
     if (looped) {
-        int *pn = (int *)(((int)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFF);
+        int *pn = (int *)(((int)((char *)this) + 0x328));
         *pn = *pn + mPathDir;
         if (mPathNodeIdx < 0) {
             if (_ZNK7PathPtr5LoopsEv((char *)&mPath))
@@ -74,7 +74,7 @@ int BigMovingIceBlock::Behavior()
             else {
                 int *pn2;
                 mPathDir = 1;
-                pn2 = (int *)(((unsigned int)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFF);
+                pn2 = (int *)(((unsigned int)((char *)this) + 0x328));
                 *pn2 = *pn2 + mPathDir * 2;
             }
         }
@@ -84,7 +84,7 @@ int BigMovingIceBlock::Behavior()
             else {
                 int *pn3;
                 mPathDir = -1;
-                pn3 = (int *)(((int)((char *)&mPathNodeIdx)) & 0xFFFFFFFFFFFFFFFF);
+                pn3 = (int *)(((int)((char *)&mPathNodeIdx)));
                 *pn3 = *pn3 + mPathDir * 2;
             }
         }

--- a/src/_ZN17RotatingClockHand8BehaviorEv.cpp
+++ b/src/_ZN17RotatingClockHand8BehaviorEv.cpp
@@ -26,7 +26,7 @@ int RotatingClockHand::Behavior()
             unk_322 = unk_320;
         } else {
             if ((int)unk_320 < (int)unk_322 - 5) {
-                short *q = (short*)(((int)((char *)this) + 0x92) & 0xFFFFFFFFFFFFFFFF);
+                short *q = (short*)(((int)((char *)this) + 0x92));
                 *q = (short)(*q * unk_31e);
             } else {
                 unk_092 = 0;
@@ -36,7 +36,7 @@ int RotatingClockHand::Behavior()
     func_020393a4((int*)((char *)&mMeshCollider), 0x180000);
     func_02039394((int*)((char *)&mMeshCollider), 0x1000);
     {
-        short *s = (short*)(((int)((char *)this) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+        short *s = (short*)(((int)((char *)this) + 0x8c));
         *s = (short)(*s + unk_092);
     }
     func_ov035_021118a8(((char *)this));

--- a/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
+++ b/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
@@ -18,7 +18,7 @@ int SlidingPlatformWf::Behavior()
 {
   if (DecIfAbove0_Byte((unsigned char*)((char*)&unk_31e)) == 0) {
     if (DecIfAbove0_Short((unsigned short*)((char*)&unk_320)) == 0) {
-      s16* a = (s16*)(((int)((char*)this) + 0x94) & 0xffffffffffffffff);
+      s16* a = (s16*)(((int)((char*)this) + 0x94));
       s16 v = data_ov091_02134504[unk_322];
       unk_320 = v;
       *a += 0x8000;

--- a/src/_ZN18BowserFireSeaArena8BehaviorEv.cpp
+++ b/src/_ZN18BowserFireSeaArena8BehaviorEv.cpp
@@ -7,14 +7,14 @@
 
 int BowserFireSeaArena::Behavior()
 {
-    short *a = (short *)(((int)((char *)this) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
-    short *b = (short *)(((int)((char *)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+    short *a = (short *)(((int)((char *)this) + 0x8c));
+    short *b = (short *)(((int)((char *)this) + 0x8e));
 
     *a = *a + unk_31e;
     *b = *b + unk_320;
 
     {
-        short *d = (short *)(((int)((char *)this) + 0x90) & 0xFFFFFFFFFFFFFFFF);
+        short *d = (short *)(((int)((char *)this) + 0x90));
         *d = *d + unk_322;
     }
 

--- a/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c
+++ b/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c
@@ -60,25 +60,25 @@ int _ZN18MovingMeshCollider10DetectClsnER10SphereClsn(char* self, char* sphere)
         d[11] = FMUL(d[5], *(int*)(self + 0x50));
         func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
         _ZN10ClsnResultaSERKS_(sphere + 0x10, loc.result);
-        *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u8*)(((s64)(int)(sphere + 0x70))) |= 1;
         if (loc.flags & 4) {
             if (*(u8*)(sphere + 0x70) & 4) {
                 r &= ~1;
             } else {
                 _ZN10SphereClsn14SetFloorResultERK10ClsnResult(sphere, loc.floorRes);
             }
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 4;
             if (*(int*)(sphere + 0x100) < loc.f_100) {
                 func_0203794c(sphere, &loc.f_fc);
             }
         }
         if (loc.flags & 8) {
             func_02037888(sphere, loc.wallRes);
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 8;
         }
         if (loc.flags & 0x10) {
             func_0203782c(sphere, loc.undRes);
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 0x10;
         }
     }
     _ZN10SphereClsnD1Ev(&loc);

--- a/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
+++ b/src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp
@@ -15,9 +15,9 @@ int RotatingPlatformRr::InitResources()
   unk_118 = unk_008 & 1;
   unk_119 = (unk_008 >> 8) & 1;
   if (unk_118 != 0) {
-    *(s16 *)(((int)((char*)this) + 0x8c) & 0xFFFFFFFFFFFFFFFF) += 0x2400;
-    *(s16 *)(((int)((char*)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
-    *(s16 *)(((int)((char*)this) + 0x90) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
+    *(s16 *)(((int)((char*)this) + 0x8c)) += 0x2400;
+    *(s16 *)(((int)((char*)this) + 0x8e)) += 0x8000;
+    *(s16 *)(((int)((char*)this) + 0x90)) += 0x8000;
   }
   unk_110 = unk_08c;
   unk_112 = unk_08e;

--- a/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
+++ b/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
@@ -25,7 +25,7 @@ int RotatingPlatformRr::Behavior()
         unk_08c = unk_110 + (int)((((s64)data_02082214[idx + 1] << 11) + 0x800) >> 12);
     }
     {
-        u16 *p = (u16 *)(((int)((char*)this) + 0x116) & 0xFFFFFFFFFFFFFFFF);
+        u16 *p = (u16 *)(((int)((char*)this) + 0x116));
         *p = *p + 1;
     }
     if (unk_119 != 0) {

--- a/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
+++ b/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
@@ -15,8 +15,8 @@ int _ZN18SolidHeapAllocator10MemoryLeftEi(void *c, int align)
 
     a = (u32)_ZN4cstd3absEi(align);
     mask = a - 1u;
-    fb = (int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
-    aligned = (mask + (u32)*(int *)(((long long)(int)((char *)c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL)) & ~(a - 1u);
+    fb = (int *)(((long long)(int)((char *)c + 0x24)));
+    aligned = (mask + (u32)*(int *)(((long long)(int)((char *)c + 0x24)))) & ~(a - 1u);
     end = (u32)fb[1];
     if (!(a - 1u)) {
     }
@@ -27,5 +27,5 @@ int _ZN18SolidHeapAllocator10MemoryLeftEi(void *c, int align)
     new_var2 = (char *)c;
     new_var3 = &fb;
     fb = *new_var3;
-    return (int)(end - ((mask + (u32)*(int *)(((long long)(int)(new_var2 + 0x24)) & 0xFFFFFFFFFFFFFFFFLL)) & ~(a - 1u)));
+    return (int)(end - ((mask + (u32)*(int *)(((long long)(int)(new_var2 + 0x24)))) & ~(a - 1u)));
 }

--- a/src/_ZN18SolidHeapAllocator10ResetStartEv.c
+++ b/src/_ZN18SolidHeapAllocator10ResetStartEv.c
@@ -9,6 +9,6 @@ void _ZN18SolidHeapAllocator10ResetStartEv(void* c)
 
     begin = *(void **)((char *)c + 0x18);
     fl = (struct FreeList *)((char *)c + 0x24);
-    *(void **)(((long long)(int)fl) & 0xFFFFFFFFFFFFFFFFLL) = begin;
+    *(void **)(((long long)(int)fl)) = begin;
     fl->flags = 0;
 }

--- a/src/_ZN18SolidHeapAllocator9SaveStateEj.c
+++ b/src/_ZN18SolidHeapAllocator9SaveStateEj.c
@@ -21,7 +21,7 @@ int _ZN18SolidHeapAllocator9SaveStateEj(void *c, u32 arg)
     int *p;
 
     fb = inline_fn(c);
-    saved = *(void **)(((long long)(int)fb) & 0xFFFFFFFFFFFFFFFFLL);
+    saved = *(void **)(((long long)(int)fb));
     p = (int *)_ZN18SolidHeapAllocator16AllocateForwardsEPvjj(fb, 0x10, 4);
     if (!p)
         return 0;

--- a/src/_ZN19BowserPuzzleManager8BehaviorEv.cpp
+++ b/src/_ZN19BowserPuzzleManager8BehaviorEv.cpp
@@ -27,7 +27,7 @@ int BowserPuzzleManager::Behavior() {
     if (id != 0)
         p = _ZN5Actor10FindWithIDEj(id);
     if (p == 0 || *(unsigned char*)(p + 0xd6) == 0) {
-        unsigned short* ctr = (unsigned short*)(int)(((long long)(int)(cc + 0x334)) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short* ctr = (unsigned short*)(int)(((long long)(int)(cc + 0x334)));
         *ctr = *ctr + 1;
     }
     func_ov064_02119010(cc);

--- a/src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp
+++ b/src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp
@@ -70,7 +70,7 @@ extern "C" int _ZN19FirePiranhaPlantBig13InitResourcesEv(char *c)
         *(int *)(c + 0x210) = 0x800;
         *(int *)(c + 0x214) = 0x52;
         *(int *)(c + 0x1ec) = 1;
-        *(int *)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFF) |= 0x8000;
+        *(int *)(((int)c + 0x190)) |= 0x8000;
     } else {
         cond = (id == 0xfd);
         if (cond != 0) {

--- a/src/_ZN19FloatingFloorLllBig8BehaviorEv.cpp
+++ b/src/_ZN19FloatingFloorLllBig8BehaviorEv.cpp
@@ -10,7 +10,7 @@ extern "C" int _ZN19FloatingFloorLllBig8BehaviorEv(char *c)
 {
     int val = *(unsigned short *)(c + 0x324) >> 4;
     *(int *)(c + 0x60) = data_02082214[val].a * (short)0x1e + *(int *)(c + 0x320);
-    *(short *)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) += 0x400;
+    *(short *)(((int)c + 0x324)) += 0x400;
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     if (_ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0))
         _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/_ZN19RotatingPlatformLll8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformLll8BehaviorEv.cpp
@@ -10,13 +10,13 @@ int RotatingPlatformLll::Behavior()
 {
     func_020393a4((int*)((char*)&mMeshCollider), 0x150000);
     if (unk_324) {
-        int* py = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        int* py = (int*)(((int)((char*)this) + 0x60));
         *py = *py - 0x2000;
         int lim = unk_320 - 0xc8000;
         if (mPosY < lim) mPosY = lim;
         unk_324 = 0;
     } else {
-        int* py = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        int* py = (int*)(((int)((char*)this) + 0x60));
         *py = *py + 0x2000;
         int lim = unk_320;
         if (mPosY > lim) mPosY = lim;

--- a/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
@@ -25,7 +25,7 @@ int RotatingPlatformWdw::Behavior()
     mAreaId = -1;
 
     /* area id at 0x340: ROM does add r0,r4,#0x300; ldrsb r0,[r0,#0x40] */
-    if (IsAreaShowing(*(s8 *)((u8 *)(((int)((u8 *)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL) + 0x40)) == 0) {
+    if (IsAreaShowing(*(s8 *)((u8 *)(((int)((u8 *)this) + 0x300)) + 0x40)) == 0) {
         mAreaId = *(s8 *)((u8 *)(((unsigned)((u8 *)this) + 0x300)) + 0x40);
         if (_ZN16MeshColliderBase9IsEnabledEv((u8 *)&mMeshCollider) != 0) {
             _ZN16MeshColliderBase7DisableEv((u8 *)&mMeshCollider);
@@ -39,12 +39,12 @@ int RotatingPlatformWdw::Behavior()
     t = mTargetPosY;
     if (mPosY != t) {
         if (mPosY < t) {
-            int *p = (int *)(((int)((u8 *)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)(((int)((u8 *)this) + 0x60));
             *p = *p + 0xa000;
             if (mPosY > mTargetPosY)
                 mPosY = mTargetPosY;
         } else {
-            int *p = (int *)(((int)((u8 *)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)(((int)((u8 *)this) + 0x60));
             *p = *p - 0xa000;
             if (mPosY < mTargetPosY)
                 mPosY = mTargetPosY;
@@ -58,7 +58,7 @@ int RotatingPlatformWdw::Behavior()
 
     {
         /* angle at 0x342: pool offset 0x342 */
-        s16 *q = (s16 *)(((int)((u8 *)this) + 0x342) & 0xFFFFFFFFFFFFFFFFLL);
+        s16 *q = (s16 *)(((int)((u8 *)this) + 0x342));
         *q = (s16)(*q + 0x200);
         /* index from (u16)angle at 0x342 via 0x300+0x42 */
         i = *(u16 *)((u8 *)(((unsigned)((u8 *)this) + 0x300)) + 0x42) >> 4;

--- a/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
+++ b/src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp
@@ -20,7 +20,7 @@ int _ZN20SwitchActivatedPlank8BehaviorEv(struct SwitchActivatedPlank *self) {
         if(_ZN5Event6GetBitEj(self->unk_3a4) == 0) break;
 
         {
-            unsigned char* st_ptr = (unsigned char*)(((int)((char*)self) + 0x3a2) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char* st_ptr = (unsigned char*)(((int)((char*)self) + 0x3a2));
             *st_ptr = *st_ptr + 1;
         }
 

--- a/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
+++ b/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
@@ -76,25 +76,25 @@ extern "C" int _ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn(char* self, 
         d[11] = FMUL(d[5], *(int*)(self + 0x50));
         func_02037a6c(sphere, d[6], d[7], d[8], d[9], d[10], d[11]);
         _ZN10ClsnResultaSERKS_(sphere + 0x10, loc.result);
-        *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u8*)(((s64)(int)(sphere + 0x70))) |= 1;
         if (loc.flags & 4) {
             if (*(u8*)(sphere + 0x70) & 4) {
                 r &= ~1;
             } else {
                 _ZN10SphereClsn14SetFloorResultERK10ClsnResult(sphere, func_02037938(&loc));
             }
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 4;
             if (*(int*)(sphere + 0x100) < loc.f_100) {
                 func_0203794c(sphere, &loc.f_fc);
             }
         }
         if (loc.flags & 8) {
             func_02037888(sphere, func_020378dc(&loc));
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 8;
         }
         if (loc.flags & 0x10) {
             func_0203782c(sphere, func_02037880(&loc));
-            *(u8*)(((s64)(int)(sphere + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+            *(u8*)(((s64)(int)(sphere + 0x70))) |= 0x10;
         }
     }
     _ZN10SphereClsnD1Ev(&loc);

--- a/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp
@@ -11,7 +11,7 @@ extern unsigned char data_0209f2c0[];
 int ClockPaintingHandShort::Behavior()
 {
   if (data_02092110[0] <= 0) {
-    short* p = (short*)(((int)((char*)this) + 0x90) & 0xFFFFFFFFFFFFFFFF);
+    short* p = (short*)(((int)((char*)this) + 0x90));
     *p = *p + data_ov013_021116ac[mHandIndex];
   } else if (IsAreaShowing(unk_0cc) && mHandIndex == 0) {
     unsigned short d = (unsigned short)(-unk_090);

--- a/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp
@@ -55,7 +55,7 @@ void* _ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj(void* c, vo
     t2.end = t1.start;
     void* allocNode = _ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt(&t2, 0x5544);
 
-    unsigned short* flagsPtr = (unsigned short*)((long long)(int)((char*)allocNode + 2) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short* flagsPtr = (unsigned short*)((long long)(int)((char*)allocNode + 2));
     void* usedList = (char*)c + 8;
     *flagsPtr &= ~0x8000;
     *flagsPtr |= (z & 1) << 15;

--- a/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp
@@ -49,7 +49,7 @@ int RotatingUpDownPlatform::InitResources()
     _ZNK7PathPtr7GetNodeER7Vector3j(((char*)this) + 0x344, ((char*)this) + 0x338, *(unsigned*)((char*)&unk_328));
 
     if (Vec3_equal(((char*)this) + 0x338, ((char*)this) + 0x32c)) {
-        int* p = (int*)(((int)((char*)this) + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p = (int*)(((int)((char*)this) + 0x328));
         *p = *p + 1;
         _ZNK7PathPtr7GetNodeER7Vector3j(((char*)this) + 0x344, ((char*)this) + 0x338, *(unsigned*)((char*)&unk_328));
     }

--- a/src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp
+++ b/src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp
@@ -22,7 +22,7 @@ int RotatingUpDownPlatform::Behavior()
     char *s = (char*)((Platform *)this);
     int old = *(int*)(s + 0x320);
     (((Platform *)this)->*data_ov091_021354e0[old].pmf)();
-    *(unsigned short*)(((int)s + 0x354) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned short*)(((int)s + 0x354)) += 1;
     if (old != *(int*)(s + 0x320)) {
         *(short*)(s + 0x354) = 0;
         func_020393d4(s + 0x124, 0);
@@ -33,7 +33,7 @@ int RotatingUpDownPlatform::Behavior()
         int rate = 0x5000;
         int saved = *(int*)(s + 0x60);
         ApproachLinearI((int*)(s + 0x34c), (*(unsigned char*)(s + 0x356) != 0) ? 0x1e000 : 0, rate);
-        *(int*)(((int)s + 0x60) & 0xFFFFFFFFFFFFFFFF) -= *(int*)(s + 0x34c);
+        *(int*)(((int)s + 0x60)) -= *(int*)(s + 0x34c);
         *(int*)(s + 0x60) = saved;
     }
     ((Platform *)this)->UpdateModelPosAndRotY();

--- a/src/_ZN23FloatOnWaterPlatformJrb8BehaviorEv.c
+++ b/src/_ZN23FloatOnWaterPlatformJrb8BehaviorEv.c
@@ -31,27 +31,27 @@ int _ZN23FloatOnWaterPlatformJrb8BehaviorEv(char *a)
             _ZN9ActorBase18MarkForDestructionEv(a);
             break;
         }
-        (*(u8 *)(((int)a + 0x4f4) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8 *)(((int)a + 0x4f4)))++;
         /* fallthrough */
     case 1:
         _ZN5Actor9UpdatePosEP12CylinderClsn(a, 0);
         WithMeshClsn_UpdateContinuous_Veneer(a + 0x324);
         if (_ZNK12WithMeshClsn10IsOnGroundEv(a + 0x324)) {
-            (*(u8 *)(((int)a + 0x4f4) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)a + 0x4f4)))++;
             *(int *)(a + 0x4e0) = *(int *)(a + 0x5c);
             *(int *)(a + 0x4e4) = *(int *)(a + 0x60);
             *(int *)(a + 0x4e8) = *(int *)(a + 0x64);
         }
         break;
     case 2: {
-        s16 *src = (s16 *)(((int)*(char **)(a + 0x320) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+        s16 *src = (s16 *)(((int)*(char **)(a + 0x320) + 0x8c));
         int spd;
         *(s16 *)(a + 0x8c) = src[0];
         *(s16 *)(a + 0x8e) = src[1];
         *(s16 *)(a + 0x90) = src[2];
         *(s16 *)(a + 0x94) = *(s16 *)(a + 0x8e);
         *(int *)(a + 0x98) = data_02082214[(*(u16 *)(a + 0x8c) >> 4) * 2] * 0x8c;
-        *(int *)(((int)a + 0x4ec) & 0xFFFFFFFFFFFFFFFF) += *(int *)(a + 0x98);
+        *(int *)(((int)a + 0x4ec)) += *(int *)(a + 0x98);
         spd = *(int *)(a + 0x4ec);
         if (spd >= 0x4ff000)
             *(int *)(a + 0x4ec) = 0x4ff000;

--- a/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp
@@ -44,7 +44,7 @@ int RotatingUpDownPlatformUtm::InitResources()
     void *kcl;
 
     if (mSpawnParam == 0xffff) {
-        int *p = (int*)(((int)((char *)this) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int*)(((int)((char *)this) + 0xb0));
         *p = *p & ~2;
         _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(((char *)this), 0, 0x1000, 0, 0);
         return 1;

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
@@ -19,7 +19,7 @@ int FloatOnWaterPlatformWdwSquare::Behavior()
         if (((u8*)this)[0x326] != 0) {
             func_02012694(0x17b, ((u8*)this) + 0x74);
             {
-                u8* p = (u8*)(((int)((u8*)this) + 0x327) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((int)((u8*)this) + 0x327));
                 *p = *p + 1;
             }
         }
@@ -29,17 +29,17 @@ int FloatOnWaterPlatformWdwSquare::Behavior()
     case 3:
         _ZN5Actor9UpdatePosEP12CylinderClsn(((u8*)this), 0);
         {
-            int* p = (int*)(((int)((u8*)this) + 0x320) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((int)((u8*)this) + 0x320));
             *p = *p + unk_098;
         }
         if (unk_320 >= 0x177000) {
             unk_320 = 0;
             {
-                u8* p = (u8*)(((int)((u8*)this) + 0x327) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((int)((u8*)this) + 0x327));
                 *p = *p + 1;
             }
             {
-                u8* base = (u8*)(((int)((u8*)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* base = (u8*)(((int)((u8*)this) + 0x300));
                 *(u16*)(base + 0x24) = 0;
             }
         }
@@ -48,24 +48,24 @@ int FloatOnWaterPlatformWdwSquare::Behavior()
     case 4:
         if (*(u16*)((u8*)(((unsigned)((u8*)this) + 0x300)) + 0x24) >= 0x3c) {
             {
-                s16* p = (s16*)(((int)((u8*)this) + 0x94) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* p = (s16*)(((int)((u8*)this) + 0x94));
                 *p = *p + 0x8000;
             }
             if (((u8*)this)[0x327] == 4) {
                 ((u8*)this)[0x327] = 0;
             } else {
                 {
-                    u8* p = (u8*)(((int)((u8*)this) + 0x327) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* p = (u8*)(((int)((u8*)this) + 0x327));
                     *p = *p + 1;
                 }
                 func_02012694(0x17b, ((u8*)this) + 0x74);
             }
             {
-                u8* b2 = (u8*)(((int)((u8*)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* b2 = (u8*)(((int)((u8*)this) + 0x300));
                 *(u16*)(b2 + 0x24) = 0;
             }
         } else {
-            u16* p = (u16*)(((int)((u8*)this) + 0x324) & 0xFFFFFFFFFFFFFFFFLL);
+            u16* p = (u16*)(((int)((u8*)this) + 0x324));
             *p = *p + 1;
         }
         break;

--- a/src/_ZN3Amp8BehaviorEv.cpp
+++ b/src/_ZN3Amp8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int Amp::Behavior()
 {
     int *p;
     func_ov070_02120d34(((char *)this));
-    p = (int *)(((int)((char *)this) + 0x414) & 0xFFFFFFFFFFFFFFFF);
+    p = (int *)(((int)((char *)this) + 0x414));
     *p += data_ov070_0212365c[1];
     _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(((char *)this) + 0x1d8, ((char *)this) + 0x410);
     _ZN12CylinderClsn5ClearEv((char *)&mMovingCylinderClsnWithPos);

--- a/src/_ZN3Boo13InitResourcesEv.c
+++ b/src/_ZN3Boo13InitResourcesEv.c
@@ -44,8 +44,8 @@ extern struct H data_020a0e68;
 #define U32(o) (*(unsigned int *)(c + (o)))
 #define S32(o) (*(int *)(c + (o)))
 #define PTR(o) (*(char **)(c + (o)))
-#define FLAGS16 (*(unsigned short *)((long long)(c + 0x5d4) & 0xFFFFFFFFFFFFFFFFLL))
-#define FLAGS16T (*(unsigned short *)((long long)((char *)((long long)c & 0xFFFFFFFFFFFFFFFFLL) + 0x5d4) & 0xFFFFFFFFFFFFFFFFLL))
+#define FLAGS16 (*(unsigned short *)((long long)(c + 0x5d4)))
+#define FLAGS16T (*(unsigned short *)((long long)((char *)((long long)c) + 0x5d4)))
 
 int _ZN3Boo13InitResourcesEv(char *c)
 {
@@ -124,7 +124,7 @@ int _ZN3Boo13InitResourcesEv(char *c)
         U16(0x4a0) = 0xd4;
         _ZN5Model8LoadFileER13SharedFilePtr(&data_ov063_0211edec);
     } else if (U8(0x5cf) == 0 || U8(0x5cf) == 1 || U8(0x5cf) == 2 || U8(0x5cf) == 6 || (unsigned)(unsigned char)(U8(0x5cf) + 0xf8) <= 3) {
-        *(int *)((long long)(c + 0x1a0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+        *(int *)((long long)(c + 0x1a0)) |= 0x8000;
         FLAGS16 |= 2;
         if (U8(0x5cf) == 6) {
             U16(0x4a0) = 0x120;
@@ -242,7 +242,7 @@ int _ZN3Boo13InitResourcesEv(char *c)
         }
     } else {
         if ((unsigned)U8(0x5cf) < 0xc) {
-            *(int *)((long long)(c + 0x19c) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(int *)((long long)(c + 0x19c)) |= 1;
         }
         if (U8(0x5cf) == 4) {
             S8(0xcc) = -1;

--- a/src/_ZN3Boo16CleanupResourcesEv.cpp
+++ b/src/_ZN3Boo16CleanupResourcesEv.cpp
@@ -48,7 +48,7 @@ int Boo::CleanupResources()
     if (((O *)this)->f494 != 0) {
         ((O *)this)->f48c = _ZN5Actor10FindWithIDEj(((O *)this)->f494);
         if (((O *)this)->f48c != 0) {
-            cnt = (int *)(((int)((O *)this)->f48c + 0x5a0) & 0xFFFFFFFFFFFFFFFF);
+            cnt = (int *)(((int)((O *)this)->f48c + 0x5a0));
             (*cnt)++;
         }
         ((O *)this)->f48c = 0;

--- a/src/_ZN3HUD17UpdateHealthMeterEv.cpp
+++ b/src/_ZN3HUD17UpdateHealthMeterEv.cpp
@@ -26,9 +26,9 @@ void HUD::UpdateHealthMeter()
     if ((unsigned char)(data_0209f2c4 | data_0209f20c | data_0209f294) != 0)
         return;
     if (mHealthMeterHoldTimer != 0)
-        *(unsigned short *)((((int)((char *)this)) + 0x6a) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+        *(unsigned short *)((((int)((char *)this)) + 0x6a)) -= data_0208ee44;
     if (mHealthTickTimer != 0)
-        *(unsigned short *)((((int)((char *)this)) + 0x6c) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+        *(unsigned short *)((((int)((char *)this)) + 0x6c)) -= data_0208ee44;
     if (_ZN5Event6GetBitEj(0x1d)) {
         unsigned char s = mHealthMeterState;
         if (s != 0) {
@@ -54,7 +54,7 @@ void HUD::UpdateHealthMeter()
     case 1:
         if (mHealthMeterHoldTimer == 0) {
             if (mHealthMeterY != 0x19) {
-                *(short *)((((int)((char *)this)) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
+                *(short *)((((int)((char *)this)) + 0x68)) -= 4;
                 if (mHealthMeterY <= 0x19)
                     mHealthMeterY = 0x19;
             }
@@ -124,7 +124,7 @@ void HUD::UpdateHealthMeter()
     case 5:
         if (mHealthMeterHoldTimer != 0)
             return;
-        *(short *)((((int)((char *)this)) + 0x68) & 0xFFFFFFFFFFFFFFFFLL) -= 4;
+        *(short *)((((int)((char *)this)) + 0x68)) -= 4;
         if (mHealthMeterY >= -0x18)
             return;
         mHealthMeterY = -0x18;

--- a/src/_ZN3IRQ13DmaTimHandlerEv.c
+++ b/src/_ZN3IRQ13DmaTimHandlerEv.c
@@ -25,7 +25,7 @@ void _ZN3IRQ13DmaTimHandlerEv(u32 idx)
   {
     fn(data_020a60c4[idx].arg);
   }
-  *(volatile u32 *)(((int)data_023c0000 + 0x3ff8) & 0xFFFFFFFFFFFFFFFF) |= mask;
+  *(volatile u32 *)(((int)data_023c0000 + 0x3ff8)) |= mask;
   if (data_020a60c4[idx].flag != 0)
   {
     return;

--- a/src/_ZN3IRQ13VBlankHandlerEv.c
+++ b/src/_ZN3IRQ13VBlankHandlerEv.c
@@ -21,6 +21,6 @@ void _ZN3IRQ13VBlankHandlerEv(void)
   }
   new_var = &data_0209d4fc;
   OS_WakeupThread(new_var);
-  *(int *)(((int)data_023c0000 + 0x3ff8) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+  *(int *)(((int)data_023c0000 + 0x3ff8)) |= 1;
   func_02019100();
 }

--- a/src/_ZN4Bird13InitResourcesEv.cpp
+++ b/src/_ZN4Bird13InitResourcesEv.cpp
@@ -21,7 +21,7 @@ int Bird::InitResources()
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char*)this)+0xd4, a, 0, 0x1000, 0);
     _ZN11ShadowModel12InitCylinderEv((char*)&mShadowModel);
     {
-        int *p60 = (int *)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p60 = (int *)(((int)((char*)this) + 0x60));
         int y = *p60;
         int zero = 0;
         *p60 = y + 0xa000;

--- a/src/_ZN4Clam8BehaviorEv.c
+++ b/src/_ZN4Clam8BehaviorEv.c
@@ -39,7 +39,7 @@ int _ZN4Clam8BehaviorEv(char *c)
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x10c, u.v1[0], u.v1[1], u.v1[2]);
             *(u16 *)(c + 0x170) = 0xa;
             *(u16 *)(c + 0x16e) = 0;
-            *(int *)(int)(((long long)(int)(c + 0x150)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+            *(int *)(int)(((long long)(int)(c + 0x150))) &= ~1;
         } else {
             if (*(u16 *)(c + 0x16e) > 0x96 &&
                 _ZN5Actor13DistToCPlayerEv(c) < 0x1f4000) {
@@ -55,7 +55,7 @@ int _ZN4Clam8BehaviorEv(char *c)
                     *(int *)(data_ov064_0211c9cc + 4), 0x40000000, 0x1000, 0);
             } else {
                 if (*(u16 *)(c + 0x170) != 0)
-                    (*(u16 *)(int)(((long long)(int)(c + 0x170)) & 0xFFFFFFFFFFFFFFFFLL))--;
+                    (*(u16 *)(int)(((long long)(int)(c + 0x170))))--;
             }
         }
         break;
@@ -68,18 +68,18 @@ int _ZN4Clam8BehaviorEv(char *c)
         } else {
             if (_ZNK9Animation12WillHitFrameEi(c + 0x124, 8) == 0) {
                 if (_ZNK9Animation12WillHitFrameEi(c + 0x124, 0xf) != 0)
-                    *(int *)(int)(((long long)(int)(c + 0x150)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+                    *(int *)(int)(((long long)(int)(c + 0x150))) |= 1;
             }
         }
         break;
     }
 
-    (*(u16 *)(int)(((long long)(int)(c + 0x16e)) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(u16 *)(int)(((long long)(int)(c + 0x16e))))++;
 
     if (*(int *)(c + 0x15c) != 0) {
         char *p = _ZN5Actor10FindWithIDEj(*(int *)(c + 0x15c));
         if (p != 0) {
-            int isPlayer = (int)(((long long)(*(u16 *)(p + 0xc) == 0xbf)) & 0xFFFFFFFFFFFFFFFFLL);
+            int isPlayer = (int)(((long long)(*(u16 *)(p + 0xc) == 0xbf)));
             if (isPlayer != 0) {
                 u.v3[0] = *(int *)(c + 0x5c);
                 u.v3[1] = *(int *)(c + 0x60);

--- a/src/_ZN4Coin13InitResourcesEv.c
+++ b/src/_ZN4Coin13InitResourcesEv.c
@@ -56,8 +56,8 @@ int _ZN4Coin13InitResourcesEv(char* c)
         *(s32*)(c + 0xa8) = 0x14000;
         *(s32*)(c + 0x9c) = -0x4000;
         *(s32*)(c + 0xa0) = -0x37000;
-        *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
-            (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~0xe0) | 0x40;
+        *(u8*)(((int)c + 0x3ae)) =
+            (*(u8*)(((int)c + 0x3ae)) & ~0xe0) | 0x40;
         goto shared140;
     }
     if (t == 1 || t == 7) {
@@ -68,7 +68,7 @@ int _ZN4Coin13InitResourcesEv(char* c)
     }
     /* default */
     *(s32*)(c + 0xa8) = 0x24000;
-    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(u8*)(((int)c + 0x3ae)) |= 2;
     goto block_11;
 case5:
     {
@@ -82,11 +82,11 @@ case5:
 block_11:
     *(s32*)(c + 0x9c) = -0x4000;
     *(s32*)(c + 0xa0) = -0x37000;
-    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0;
+    *(u8*)(((int)c + 0x3ae)) &= ~0xe0;
     goto shared140;
 case17:
-    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
-        (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~0xe0) | 0xe0;
+    *(u8*)(((int)c + 0x3ae)) =
+        (*(u8*)(((int)c + 0x3ae)) & ~0xe0) | 0xe0;
     *(s32*)(c + 0x398) = *(s32*)(c + 0x60) - 0x1f4000;
     if (*(s32*)(c + 0x3a4) == 7) {
         r5 = 0x32000;
@@ -165,7 +165,7 @@ shared140:;
     t = *(s32*)(c + 0x3a4);
     if (t == 8) {
         *(s16*)(c + 0x3a8) = 0x2d;
-        *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(s32*)(((int)c + 0x190)) |= 1;
     } else {
         if (t == 6) {
             int b3;
@@ -173,7 +173,7 @@ shared140:;
             b3 = (b3 == 1);
             if (b3 == false) {
                 *(u16*)(c + 0x3a8) = 0xffffu;
-                *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+                *(s32*)(((int)c + 0x190)) |= 1;
                 goto after438;
             }
         }
@@ -181,8 +181,8 @@ shared140:;
     after438:;
     }
 
-    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) =
-        (*(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) & ~1) | 1;
+    *(u8*)(((int)c + 0x3ae)) =
+        (*(u8*)(((int)c + 0x3ae)) & ~1) | 1;
 
     t = *(s32*)(c + 0x3a4);
     if (t == 1 || t == 7) {
@@ -197,12 +197,12 @@ shared140:;
 case17b:
     *(u8*)(c + 0x3aa) = 0;
     if (*(s32*)(c + 0x3a0) == 2 && (u32)*(u8*)(c + 0x3ab) < 8) {
-        *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
-        *(s32*)(((int)c + 0x190) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u8*)(((int)c + 0x3ae)) &= ~1;
+        *(s32*)(((int)c + 0x190)) |= 1;
     }
 switch2end:;
 
-    *(u8*)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1c;
+    *(u8*)(((int)c + 0x3ae)) &= ~0x1c;
     *(s32*)(c + 0xd4) = 0;
     return 1;
 }

--- a/src/_ZN4Coin8BehaviorEv.cpp
+++ b/src/_ZN4Coin8BehaviorEv.cpp
@@ -24,7 +24,7 @@ extern void _ZN12CylinderClsn6UpdateEv(char *c);
 int Coin::Behavior()
 {
     if ((unsigned int)(unk_3ae << 0x1e) >> 0x1f) {
-        *(unsigned char *)(((int)((char *)this) + 0x3ae) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+        *(unsigned char *)(((int)((char *)this) + 0x3ae)) &= ~2;
         _ZN5Sound9PlayBank3EjRK7Vector3(0x30, ((char *)this) + 0x74);
     }
     if ((int)(mActorID == 0x122) != 0) {
@@ -32,7 +32,7 @@ int Coin::Behavior()
             mAreaId = -1;
     }
     if (func_ov002_020b10a0(((char *)this)) != 0) return 1;
-    *(short *)(((int)((char *)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0xc00;
+    *(short *)(((int)((char *)this) + 0x8e)) += 0xc00;
     if (func_ov002_020b12ec(((char *)this)) != 0) {
         func_ov002_020b14d8(((char *)this));
         _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);

--- a/src/_ZN4Fish8BehaviorEv.cpp
+++ b/src/_ZN4Fish8BehaviorEv.cpp
@@ -54,7 +54,7 @@ int Fish::Behavior()
             (((C*)this)->*data_ov100_02148a1c[((C*)this)->idx].pmf)();
             _ZN5Actor9UpdatePosEP12CylinderClsn(((C*)this), 0);
             {
-                int* cp = (int*)(((int)((C*)this) + 0x150) & 0xFFFFFFFFFFFFFFFF);
+                int* cp = (int*)(((int)((C*)this) + 0x150));
                 *cp = *cp + 1;
             }
         }

--- a/src/_ZN4Toad13InitResourcesEv.c
+++ b/src/_ZN4Toad13InitResourcesEv.c
@@ -78,7 +78,7 @@ int _ZN4Toad13InitResourcesEv(char* r4)
                 goto after_inc;
         }
         {
-            u16 *pm = (u16*)(((long long)(int)(r4 + 0x208)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *pm = (u16*)(((long long)(int)(r4 + 0x208)));
             *pm = (u16)(*pm + 1);
         }
     after_inc: ;

--- a/src/_ZN4Tree13InitResourcesEv.cpp
+++ b/src/_ZN4Tree13InitResourcesEv.cpp
@@ -27,7 +27,7 @@ int _ZN4Tree13InitResourcesEv(char* self) {
     *(int*)(p + 8) = *(int*)(self + 0x64);
     Vec3_AsrInPlace(p, 3);
     {
-        int* q = (int*)(((int)p + 4) & 0xFFFFFFFFFFFFFFFF);
+        int* q = (int*)(((int)p + 4));
         *q = *q + 0x1e000;
     }
     ((CylinderClsnWithPos*)(p + 0xc))->Init(*(Vector3*)(self + 0x5c), 0x35555, 0x1f4000, 0x380000c, 0);

--- a/src/_ZN5Actor14BeforeBehaviorEv.cpp
+++ b/src/_ZN5Actor14BeforeBehaviorEv.cpp
@@ -31,7 +31,7 @@ int _ZN5Actor14BeforeBehaviorEv(char* self)
 
     signed char c = *(signed char*)(self + 0xcc);
     if (c >= 0 && !IsAreaShowing(c)) {
-        *(u32*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x38;
+        *(u32*)((int)(self + 0xb0)) |= 0x38;
         *(int*)(self + 0x74) = 0x7fffffff;
         *(int*)(self + 0x78) = 0x7fffffff;
         *(int*)(self + 0x7c) = 0x7fffffff;
@@ -55,17 +55,17 @@ int _ZN5Actor14BeforeBehaviorEv(char* self)
             if (data_0209f274)
                 thresh <<= 1;
             if (r > thresh) {
-                *(u32*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x18;
+                *(u32*)((int)(self + 0xb0)) |= 0x18;
                 if (*(u32*)(self + 0xb0) & 0x10000)
                     return 0;
             } else {
-                u32* p = (u32*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+                u32* p = (u32*)((int)(self + 0xb0));
                 *p &= ~0x38;
                 if (r > *(int*)(self + 0xc0))
                     *p |= 0x10;
             }
         } else {
-            *(u32*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x38;
+            *(u32*)((int)(self + 0xb0)) &= ~0x38;
         }
     }
 

--- a/src/_ZN5Actor15GivePlayerCoinsER6Playerhj.c
+++ b/src/_ZN5Actor15GivePlayerCoinsER6Playerhj.c
@@ -50,7 +50,7 @@ void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *c, void *p, unsigned char h, u3
   amt = h * data_02075238[j];
   GiveCoins(*((unsigned char *) (((char *) p) + 0x6d8)), amt);
   _ZN6Player4HealEi(p, amt << 8);
-  src = (struct Vector3 *) (((int) p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+  src = (struct Vector3 *) (((int) p + 0x5c));
   vec.x = src->x;
   vec.y = src->y;
   vec.z = src->z;

--- a/src/_ZN5Actor18AfterInitResourcesEj.c
+++ b/src/_ZN5Actor18AfterInitResourcesEj.c
@@ -6,5 +6,5 @@ extern void _ZN12ActorDerived18AfterInitResourcesEj(ActorDerived *self, u32 resu
 void _ZN5Actor18AfterInitResourcesEj(char *self, u32 result)
 {
     _ZN12ActorDerived18AfterInitResourcesEj((ActorDerived *)self, result);
-    *(int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x38;
+    *(int *)(((long long)(int)(self + 0xb0))) |= 0x38;
 }

--- a/src/_ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn.cpp
+++ b/src/_ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn.cpp
@@ -24,8 +24,8 @@ struct Actor {
 void Actor::UpdatePosWithOnlySpeed(CylinderClsn *clsn) {
     AddVec3(&pos, &speed, &pos);
     if (clsn != 0) {
-        *(s32 *)(((long long)(int)(&pos.x)) & 0xFFFFFFFFFFFFFFFFLL) += clsn->dx;
-        *(s32 *)(((long long)(int)(&pos.z)) & 0xFFFFFFFFFFFFFFFFLL) += clsn->dz;
+        *(s32 *)(((long long)(int)(&pos.x))) += clsn->dx;
+        *(s32 *)(((long long)(int)(&pos.z))) += clsn->dz;
     }
     func_02010da4((int *)this);
 }

--- a/src/_ZN5Actor25OnAimedAtWithEggReturnVecEv.cpp
+++ b/src/_ZN5Actor25OnAimedAtWithEggReturnVecEv.cpp
@@ -22,5 +22,5 @@ extern "C" void _ZN5Actor25OnAimedAtWithEggReturnVecEv(Vec *ret, Base *self)
     ret->x = *(s32 *)(a + 0x5c);
     ret->y = *(s32 *)(a + 0x60);
     ret->z = *(s32 *)(a + 0x64);
-    *(s32 *)(((long long)(int)((char *)ret + 4)) & 0xFFFFFFFFFFFFFFFFLL) += self->m74();
+    *(s32 *)(((long long)(int)((char *)ret + 4))) += self->m74();
 }

--- a/src/_ZN5Bully8BehaviorEv.c
+++ b/src/_ZN5Bully8BehaviorEv.c
@@ -42,7 +42,7 @@ int _ZN5Bully8BehaviorEv(char* self) {
             }
             void* f = _ZN5Actor10FindWithIDEj(*(unsigned*)(self + 0x3fc));
             if (f) {
-                *(u8*)(((long long)(int)((char*)f + 0x3fe)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(u8*)(((long long)(int)((char*)f + 0x3fe))) += 1;
             }
         }
         return 1;

--- a/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
+++ b/src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp
@@ -35,7 +35,7 @@ void Enemy::SpawnMegaCharParticles(Actor &a, char *p)
     dst.x = *(s32 *)(self + 0x5c);
     dst.y = *(s32 *)(self + 0x60);
     {
-        Vector3 *pv = (Vector3 *)(((long long)(int)(ap + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        Vector3 *pv = (Vector3 *)(((long long)(int)(ap + 0x5c)));
         dst.z = *(s32 *)(self + 0x64);
         src.x = pv->x;
         src.y = pv->y;

--- a/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
+++ b/src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp
@@ -49,7 +49,7 @@ struct VB {
 
 struct M48 { int w[12]; };
 
-#define LAUNDER(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER(p) ((int)(((long long)(int)(p))))
 
 extern "C" int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(
     void *cc, void *ww, void *mm, unsigned int flags)

--- a/src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp
+++ b/src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp
@@ -20,11 +20,11 @@ int _ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn(char* self, char* cls
                 }
             }
         }
-        f = (int*)(((int)clsn + 0x18) & 0xFFFFFFFFFFFFFFFF);
+        f = (int*)(((int)clsn + 0x18));
         *f = *f | 0x20000;
         goto done;
     }
-    f = (int*)(((int)clsn + 0x18) & 0xFFFFFFFFFFFFFFFF);
+    f = (int*)(((int)clsn + 0x18));
     *f = *f & ~0x20000;
 done:
     return 0;

--- a/src/_ZN5Pokey13InitResourcesEv.cpp
+++ b/src/_ZN5Pokey13InitResourcesEv.cpp
@@ -70,7 +70,7 @@ int Pokey::InitResources()
             *(void**)((char*)&unk_390) = _ZN5Actor10FindWithIDEj(mParam);
             unk_394 = 0;
             {
-                int* p = (int*)(((int)*(char**)((char*)&unk_390) + 0x36c) & 0xFFFFFFFFFFFFFFFF);
+                int* p = (int*)(((int)*(char**)((char*)&unk_390) + 0x36c));
                 unk_36c = p[0];
                 unk_370 = p[1];
                 unk_374 = p[2];

--- a/src/_ZN5Scene14BeforeBehaviorEv.cpp
+++ b/src/_ZN5Scene14BeforeBehaviorEv.cpp
@@ -79,7 +79,7 @@ int _ZN5Scene14BeforeBehaviorEv(char* self)
 
     if ((*(u8*)(self + 0x13) & 1) != 0) {
         if (func_020431c4(self) == 0) {
-            u8* p13 = (u8*)(((long long)(int)(self + 0x13)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8* p13 = (u8*)(((long long)(int)(self + 0x13)));
             *p13 &= ~1;
             *p13 &= ~4;
         }

--- a/src/_ZN5Shark8BehaviorEv.cpp
+++ b/src/_ZN5Shark8BehaviorEv.cpp
@@ -51,7 +51,7 @@ extern "C" int _ZN5Shark8BehaviorEv(char* c)
         Vec3_Sub(&diff, (Vector3*)(c + 0x5c), &node);
         len = LenVec3(&diff);
         if (len == 0 || len <= 0x258000) {
-            (*(int*)(((int)c + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(int*)(((int)c + 0x390)))++;
             if (*(int*)(c + 0x390) >= *(int*)(c + 0x38c))
                 *(int*)(c + 0x390) = 0;
         }

--- a/src/_ZN5Stage16CheckCameraInputEv.cpp
+++ b/src/_ZN5Stage16CheckCameraInputEv.cpp
@@ -64,11 +64,11 @@ void Stage::CheckCameraInput()
                                 if (mask == 0) mask = 0x200;
                             }
                             if ((data_020a0de8[i].touched && data_020a0de8[i].held) ? 1 : 0)
-                                *(u16*)(((int)cam + 6) & 0xFFFFFFFFFFFFFFFFLL) |= mask;
+                                *(u16*)(((int)cam + 6)) |= mask;
                             else
-                                *(u16*)(((int)cam + 6) & 0xFFFFFFFFFFFFFFFFLL) |= mask & (mask ^ data_0209f368[i]);
+                                *(u16*)(((int)cam + 6)) |= mask & (mask ^ data_0209f368[i]);
                             data_0209f368[i] = mask;
-                            *(u16*)(((int)cam + 4) & 0xFFFFFFFFFFFFFFFFLL) |= mask;
+                            *(u16*)(((int)cam + 4)) |= mask;
                             *st = 1;
                         }
                     } else if (*st == 1) {
@@ -87,7 +87,7 @@ void Stage::CheckCameraInput()
                         && ((state2 == 1 && data_020a0de8[i].x >= 0xd7 && data_020a0de8[i].y >= 0x8d)
                             || (state2 == 2 && data_020a0de8[i].x >= 0xd7 && data_020a0de8[i].y >= 0x73 && data_020a0de8[i].y < 0x97))) {
                         data_ov002_02111180 = 0x10;
-                        *(u16*)(((int)cam + 6) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+                        *(u16*)(((int)cam + 6)) |= 0x8000;
                         *st = 2;
                         cam->f14 = 0;
                     } else if (*st == 2) {

--- a/src/_ZN5Stage22RenderModelTransparentEv.cpp
+++ b/src/_ZN5Stage22RenderModelTransparentEv.cpp
@@ -22,7 +22,7 @@ extern char *data_0209f340;
 
 void Stage::RenderModelTransparent()
 {
-    char *p = (char *)(((int)((char *)this) + 0x874) & 0xFFFFFFFFFFFFFFFF);
+    char *p = (char *)(((int)((char *)this) + 0x874));
     char *arr = *(char **)(*(char **)p + 8);
     char *q = ((char *)this) + 0x8bc;
     int i;
@@ -33,9 +33,9 @@ void Stage::RenderModelTransparent()
             for (j = 0; j < *(u16 *)(arr + 0x30); j++) {
                 char *e = *(char **)(p + 4) + *bp * 0x30;
                 if ((*(int *)(e + 0x24) & 0x1f0000) != 0x1f0000)
-                    *(int *)(((int)e + 0x24) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000000;
+                    *(int *)(((int)e + 0x24)) &= ~0x80000000;
                 else
-                    *(int *)(((int)e + 0x24) & 0xFFFFFFFFFFFFFFFF) |= 0x80000000;
+                    *(int *)(((int)e + 0x24)) |= 0x80000000;
                 bp++;
             }
         }

--- a/src/_ZN5Stage6RenderEv.cpp
+++ b/src/_ZN5Stage6RenderEv.cpp
@@ -100,7 +100,7 @@ int Stage::Render() {
         Renderable* t = *(Renderable**)((char*)this + 0x9bc);
         if (t != 0) {
             int* dst = (int*)((char*)t + 0x1c);
-            int* src = (int*)((long long)(int)(data_0209f318 + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+            int* src = (int*)((long long)(int)(data_0209f318 + 0x8c));
             dst[9] = src[0] >> 3;
             dst[10] = src[1] >> 3;
             dst[11] = src[2] >> 3;
@@ -133,7 +133,7 @@ int Stage::Render() {
             char* p = data_0209f394[j];
             if (p != 0) {
                 u8 bit = *(u8*)(p + 0x6ff);
-                int* q = (int*)((long long)(int)(p + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                int* q = (int*)((long long)(int)(p + 0x5c));
                 x ^= (u8)(q[2] ^ (q[0] ^ q[1]));
                 y |= (u8)((bit & 1) << j);
             }

--- a/src/_ZN5Stage9LoadModelEv.cpp
+++ b/src/_ZN5Stage9LoadModelEv.cpp
@@ -13,7 +13,7 @@ void _ZN5Stage9LoadModelEv(char* self) {
     unsigned int i;
     char* p;
 
-    p = (char*)(((long long)(int)(self + 0x874)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (char*)(((long long)(int)(self + 0x874)));
     list = ((char**)p)[0];
     node = ((char**)p)[1];
     count = *(unsigned int*)(list + 0x24);

--- a/src/_ZN5Stage9PS_UpdateEv.cpp
+++ b/src/_ZN5Stage9PS_UpdateEv.cpp
@@ -114,7 +114,7 @@ extern u8 data_020a0de9[]; /* touch: pressed  [slot*4]   */
 extern volatile u8 data_020a0dea[]; /* touch: x        [slot*4]   */
 extern volatile u8 data_020a0deb[]; /* touch: y        [slot*4]   */
 
-#define DE8P(off) ((u8 *)((long long)(int)(data_020a0de8 + (off)) & 0xFFFFFFFFFFFFFFFFLL))
+#define DE8P(off) ((u8 *)((long long)(int)(data_020a0de8 + (off))))
 #define REG16(a) (*(volatile u16 *)(a))
 #define REG32(a) (*(volatile u32 *)(a))
 

--- a/src/_ZN5StageC1Ev.c
+++ b/src/_ZN5StageC1Ev.c
@@ -1,4 +1,4 @@
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
 extern int _ZN9ActorBasenwEj(unsigned int);
 extern int _ZN9ActorBaseC1Ev(void *);
 extern int _ZN8Particle10SysTrackerC1Ev(void *);

--- a/src/_ZN5Unagi13InitResourcesEv.cpp
+++ b/src/_ZN5Unagi13InitResourcesEv.cpp
@@ -84,7 +84,7 @@ check_param2:
     if (mVariant != 2)
         goto ret0_a;
     /* u64-mask forces add r2,r4,#0x3f4 materialization (ROM shape) */
-    *(int*)(((int)((char*)this) + 0x3f4) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80000;
+    *(int*)(((int)((char*)this) + 0x3f4)) -= 0x80000;
     unk_410 = 8;
     if (unk_410 >= unk_40c)
         unk_410 = 4;

--- a/src/_ZN5Unagi6RenderEv.c
+++ b/src/_ZN5Unagi6RenderEv.c
@@ -17,7 +17,7 @@ int _ZN5Unagi6RenderEv(struct Unagi *self) {
     dp = data_ov016_02114908;
     for (i = 1; i < 7; i++) {
         short mv = ((short*)(((char*)self) + 0x400 + 0x18))[i];
-        unsigned short* curr = (unsigned short*)(((int)base + 0x1e) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short* curr = (unsigned short*)(((int)base + 0x1e));
         *curr = *curr + (unsigned short)(short)(mv * dp->w2);
         dp++;
         base += 0x34;

--- a/src/_ZN6BobOmb13InitResourcesEv.cpp
+++ b/src/_ZN6BobOmb13InitResourcesEv.cpp
@@ -90,8 +90,8 @@ int BobOmb::InitResources()
     ((Obj*)this)->fa0 = -0x37000;
 
     if (((Obj*)this)->f3f5 == 2) {
-        *(unsigned int*)(((int)((Obj*)this) + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
-        *(unsigned int*)(((int)((Obj*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1u;
+        *(unsigned int*)(((int)((Obj*)this) + 0x128)) |= 2;
+        *(unsigned int*)(((int)((Obj*)this) + 0xb0)) &= ~1u;
         ((Obj*)this)->f108 = 0;
     } else if (((Obj*)this)->f3f5 == 4) {
         ((Obj*)this)->f108 = 0;

--- a/src/_ZN6Camera10LookAtExitER5Actor.cpp
+++ b/src/_ZN6Camera10LookAtExitER5Actor.cpp
@@ -24,7 +24,7 @@ void Camera::LookAtExit(struct Actor &actor)
     *(s16 *)((char *)this + 0x186) = -*(s16 *)(a + 0x8e);
     ChangeState(&data_0209b0f8);
     {
-        int *fp = (int *)(((int)this + 0x154) & 0xFFFFFFFFFFFFFFFF);
+        int *fp = (int *)(((int)this + 0x154));
         *fp |= 0x10;
     }
 }

--- a/src/_ZN6Camera14GoBehindPlayerEj.cpp
+++ b/src/_ZN6Camera14GoBehindPlayerEj.cpp
@@ -20,9 +20,9 @@ void Camera::GoBehindPlayer(unsigned int j)
         return;
 
     /* different launder spellings to defeat CSE across the call */
-    *(unsigned int *)(((int)&unk_154) & 0xFFFFFFFFFFFFFFFF) &= 0xfffffaf7u;
+    *(unsigned int *)(((int)&unk_154)) &= 0xfffffaf7u;
     func_0200cb58((void *)((int)this), 0xa);
-    *(unsigned int *)(((long long)(int)((int)&unk_154)) & 0xFFFFFFFFFFFFFFFFLL) |= 4u;
+    *(unsigned int *)(((long long)(int)((int)&unk_154))) |= 4u;
 
     slot4 = unk_13c;
     slotc = 0;

--- a/src/_ZN6Camera25SaveCameraStateBeforeTalkEv.cpp
+++ b/src/_ZN6Camera25SaveCameraStateBeforeTalkEv.cpp
@@ -13,5 +13,5 @@ void Camera::SaveCameraStateBeforeTalk()
     *(unsigned int *)((char *)&unk_0bc) = *(unsigned int *)((char *)&unk_08c);
     *(unsigned int *)((char *)&unk_0c0) = *(unsigned int *)((char *)&unk_090);
     *(unsigned int *)((char *)&unk_0c4) = *(unsigned int *)((char *)&unk_094);
-    *(unsigned int *)((int *)(((int)((void *)this) + 0x154) & 0xFFFFFFFFFFFFFFFF)) |= 0x4000U;
+    *(unsigned int *)((int *)(((int)((void *)this) + 0x154))) |= 0x4000U;
 }

--- a/src/_ZN6Camera8BehaviorEv.cpp
+++ b/src/_ZN6Camera8BehaviorEv.cpp
@@ -49,9 +49,9 @@ int Camera::Behavior()
     *(s32 *)(c + 0xd4) = *(s32 *)(c + 0x8c);
     *(s32 *)(c + 0xd8) = *(s32 *)(c + 0x90);
     *(s32 *)(c + 0xdc) = *(s32 *)(c + 0x94);
-    *(u32 *)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1000u;
+    *(u32 *)(((int)c + 0x154)) &= ~0x1000u;
     if (*(u32 *)(c + 0x140) != (u32)&data_0208733c) {
-        *(u32 *)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x60u;
+        *(u32 *)(((int)c + 0x154)) &= ~0x60u;
     }
     temp_r1 = *(s32 *)(c + 0x154);
     if (!(temp_r1 & 8)) {
@@ -60,7 +60,7 @@ int Camera::Behavior()
     } else {
 block_7:
         if (temp_r1 & 0xc000) {
-            *(u32 *)((long long)(int)(c + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xc000u;
+            *(u32 *)((long long)(int)(c + 0x154)) &= ~0xc000u;
             _ZN6Camera11ChangeStateEPNS_5StateE(c, &data_0209b008);
         }
         *(s16 *)(c + 0x17c) = Vec3_HorzAngle(c + 0x80, c + 0x8c);
@@ -85,15 +85,15 @@ block_7:
                 if (_Z15ApproachLinear2Rsss(*(short *)(c + 0x18c), 0, 0x10) != 0) {
                     *(s16 *)(c + 0x18a) = 0;
                 } else {
-                    *(s16 *)(((long long)(int)(c + 0x18a)) & 0xFFFFFFFFFFFFFFFFLL) =
-                        (s16)(*(s16 *)(((long long)(int)(c + 0x18a)) & 0xFFFFFFFFFFFFFFFFLL) + 0x3000);
+                    *(s16 *)(((long long)(int)(c + 0x18a))) =
+                        (s16)(*(s16 *)(((long long)(int)(c + 0x18a))) + 0x3000);
                 }
             }
         }
         if (*(s16 *)(c + 0x18e) != 0) {
-            *(s16 *)(((long long)(int)(c + 0x192)) & 0xFFFFFFFFFFFFFFFFLL) =
-                (s16)(*(s16 *)(((long long)(int)(c + 0x192)) & 0xFFFFFFFFFFFFFFFFLL) + *(s16 *)(c + 0x194));
-            _Z15ApproachLinear2Rsss(*(short *)(((long long)(int)(c + 0x18e)) & 0xFFFFFFFFFFFFFFFFLL), 0, *(s16 *)(c + 0x190));
+            *(s16 *)(((long long)(int)(c + 0x192))) =
+                (s16)(*(s16 *)(((long long)(int)(c + 0x192))) + *(s16 *)(c + 0x194));
+            _Z15ApproachLinear2Rsss(*(short *)(((long long)(int)(c + 0x18e))), 0, *(s16 *)(c + 0x190));
         }
         {
             int condA = 1;
@@ -143,16 +143,16 @@ block_7:
             if (!(*(s32 *)(c + 0x154) & 1)) {
                 if (*(u8 *)(m + 0x706) != 0 || *(u8 *)(m + 0x707) != 0) {
                     if (*(s32 *)(c + 0x90) <= t2) {
-                        *(u32 *)((long long)(int)(c + 0x154) & 0xFFFFFFFFFFFFFFFFLL) |= 1u;
+                        *(u32 *)((long long)(int)(c + 0x154)) |= 1u;
                     }
                 }
             } else if (*(s32 *)(c + 0x90) > t2) {
-                *(u32 *)((long long)(int)(c + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~1u;
+                *(u32 *)((long long)(int)(c + 0x154)) &= ~1u;
             }
         }
     }
     {
-        u32 *pf = (u32 *)(((long long)(int)(c + 0x154)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32 *pf = (u32 *)(((long long)(int)(c + 0x154)));
         *pf &= 0xfff8fdfbu;
         if (*(s32 *)(c + 0x118) != 0) {
             *(s32 *)(c + 0x118) = 0;

--- a/src/_ZN6Camera9SetFlag_3Ev.cpp
+++ b/src/_ZN6Camera9SetFlag_3Ev.cpp
@@ -11,7 +11,7 @@ extern "C" void FUN_02029a68(u32 flags);
 
 void Camera::SetFlag_3()
 {
-    u32 *p = (u32 *)(((int)this + 0x154) & 0xFFFFFFFFFFFFFFFF);
+    u32 *p = (u32 *)(((int)this + 0x154));
     u32 v = *p | 8;
     *p = v;
     FUN_02029a68(v);

--- a/src/_ZN6Coffin8BehaviorEv.cpp
+++ b/src/_ZN6Coffin8BehaviorEv.cpp
@@ -23,7 +23,7 @@ int Coffin::Behavior()
 
     {
         unsigned short *timer =
-            (unsigned short *)(((int)((char *)this) + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
+            (unsigned short *)(((int)((char *)this) + 0x328));
         *timer = *timer + 1;
     }
     func_ov071_02122414(((char *)this));

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -67,7 +67,7 @@ int Dorrie::InitResources()
         unk_1198 = mPosY;
         unk_119c = mPosZ;
         /* u64-mask launder: materialize add r2,sl,#0x5c; ldr/str [r2] */
-        *(int*)(((int)((char*)this) + 0x5c) & 0xFFFFFFFFFFFFFFFF) += 0x7d0000;
+        *(int*)(((int)((char*)this) + 0x5c)) += 0x7d0000;
     }
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(
         ((char*)this) + 0xf50, ((char*)this), 0x1e0000, 0xa0000, 0, 0);

--- a/src/_ZN6Eyerok13InitResourcesEv.cpp
+++ b/src/_ZN6Eyerok13InitResourcesEv.cpp
@@ -133,7 +133,7 @@ int Eyerok::InitResources()
 
     if (*(s32*)(c + 0x49C) == 0) {
         void* r;
-        *(s32*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL) -= 0x7C000;
+        *(s32*)(((int)c + 0x64)) -= 0x7C000;
         *(s32*)(c + 0x4A4) = *(s32*)(c + 0x5C);
         *(s32*)(c + 0x4A8) = *(s32*)(c + 0x60);
         *(s32*)(c + 0x4AC) = *(s32*)(c + 0x64);
@@ -170,15 +170,15 @@ int Eyerok::InitResources()
         *(s32*)(c + 0x4B8) = *(s32*)(c + 0x64);
         if (*(s32*)(c + 0x49C) == 1) {
             _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x674, data_ov066_0211ae14[1], c + 0x83C, 0x199, *(s16*)(c + 0x8E), &func_02112c08);
-            *(s32*)(((int)c + 0x4A4) & 0xFFFFFFFFFFFFFFFFLL) -= 0x31F000;
+            *(s32*)(((int)c + 0x4A4)) -= 0x31F000;
         } else {
             _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(c + 0x674, data_ov066_0211aeac[1], c + 0x83C, 0x199, *(s16*)(c + 0x8E), &func_02112d48);
-            *(s32*)(((int)c + 0x4A4) & 0xFFFFFFFFFFFFFFFFLL) += 0x31F000;
+            *(s32*)(((int)c + 0x4A4)) += 0x31F000;
         }
         func_020393d4(c + 0x674, &_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_);
         func_020393c4(c + 0x674, &func_ov066_0211a35c);
         func_020398fc(c + 0x674);
-        *(s32*)(((int)c + 0x4AC) & 0xFFFFFFFFFFFFFFFFLL) -= 0x32000;
+        *(s32*)(((int)c + 0x4AC)) -= 0x32000;
         *(s8*)(c + 0x4D8) = 3;
         data_ov066_0211ae00 = 0;
         func_ov066_02119454(c, data_ov066_0211b05c);

--- a/src/_ZN6Eyerok8BehaviorEv.cpp
+++ b/src/_ZN6Eyerok8BehaviorEv.cpp
@@ -135,7 +135,7 @@ extern "C" int _ZN6Eyerok8BehaviorEv(char *c)
 
         {
             int o4d4 = 0x4d4;
-            u16 *p = (u16 *)(((long long)(int)(c + o4d4)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *p = (u16 *)(((long long)(int)(c + o4d4)));
             u16 v = *p;
             char *c400 = c + 0x400;
             *p = (u16)(v + 1);

--- a/src/_ZN6Goomba16CleanupResourcesEv.cpp
+++ b/src/_ZN6Goomba16CleanupResourcesEv.cpp
@@ -27,7 +27,7 @@ int Goomba::CleanupResources()
     if (id != 0) {
       char* a = _ZN5Actor10FindWithIDEj(id);
       if (a != 0) {
-        unsigned char *p = (unsigned char*)(((int)a + 0x602) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char*)(((int)a + 0x602));
         *p = *p - 1;
       }
     }

--- a/src/_ZN6Player11St_Fly_MainEv.cpp
+++ b/src/_ZN6Player11St_Fly_MainEv.cpp
@@ -78,7 +78,7 @@ skip:
                 }
             } else {
                 *(s32 *)(c + 0x9c) = -0x2000;
-                *(s32 *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) = *(s32 *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) + 0xe00;
+                *(s32 *)(((int)c + 0x98)) = *(s32 *)(((int)c + 0x98)) + 0xe00;
             }
             if (this->FinishedAnim() != 0) {
                 *(s32 *)(c + 0x9c) = 0;
@@ -122,7 +122,7 @@ skip:
             if (*(u8 *)(c + 0x70c) == 0) {
                 _ZN5Sound9PlayBank0EjRK7Vector3(0xb9, c + 0x74);
                 func_ov002_020e25f0(c, 2);
-                *(u8 *)(((int)c + 0x70c) & 0xFFFFFFFFFFFFFFFF) = *(u8 *)(((int)c + 0x70c) & 0xFFFFFFFFFFFFFFFF) + 1;
+                *(u8 *)(((int)c + 0x70c)) = *(u8 *)(((int)c + 0x70c)) + 1;
             }
             {
                 char *m = *(char **)(c + this->GetBodyModelID(*(u32 *)(c + 8) & 0xff, 0) * 4 + 0xdc);

--- a/src/_ZN6Player11St_Owl_MainEv.cpp
+++ b/src/_ZN6Player11St_Owl_MainEv.cpp
@@ -43,7 +43,7 @@ int Player::St_Owl_Main()
     switch (st) {
     case 0:
         if (mAttachOffsetY <= mPosY) {
-            (*(unsigned char*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)((char*)this) + 0x6e3)))++;
             mVertAccel = -0x2c00;
         }
         if (mIsAirborne != 0) {

--- a/src/_ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj.cpp
+++ b/src/_ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj.cpp
@@ -68,7 +68,7 @@ int _ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj(char *thiz, ActorBase *act
 finish:
     *(u8 *)(thiz + 0x6e5) = 0;
     *(u8 *)(thiz + 0x70c) = d & 3;
-    *(u8 *)(((long long)(thiz + 0x70c)) & 0xFFFFFFFFFFFFFFFFLL) |= (e & 3) << 2;
+    *(u8 *)(((long long)(thiz + 0x70c))) |= (e & 3) << 2;
 
     if (!(data_ov002_0210e15c & 1)) {
         data_ov002_0210f224[0] = 0;

--- a/src/_ZN6Player12St_Hurt_MainEv.cpp
+++ b/src/_ZN6Player12St_Hurt_MainEv.cpp
@@ -71,8 +71,8 @@ extern "C" int _ZN6Player12St_Hurt_MainEv(char* c)
             func_ov002_020d98b4(c);
             return 1;
         }
-        *(s32*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80;
-        *(unsigned char*)(((long long)(int)(c + 0x6e5)) & 0xFFFFFFFFFFFFFFFFLL) &= 0xf0;
+        *(s32*)(((long long)(int)(c + 0xb0))) &= ~0x80;
+        *(unsigned char*)(((long long)(int)(c + 0x6e5))) &= 0xf0;
         if (_ZN6Player12FinishedAnimEv(c)) {
             if ((*(u8*)(c + 0x6e3) & 1) == 0) {
                 *(s16*)(c + 0x94) = *(s16*)(c + 0x94) + 0x8000;

--- a/src/_ZN6Player12St_Jump_InitEv.cpp
+++ b/src/_ZN6Player12St_Jump_InitEv.cpp
@@ -93,11 +93,11 @@ skipclear:
     *(int *)(c + 0x98) = (int)(((long long)*(int *)(c + 0x98) * 0xccc + 0x800) >> 12);
 
     if (AngleDiff(*(s16 *)(c + 0x94), *(s16 *)(c + 0x8e)) >= 0x4000) {
-        *(int *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 2;
+        *(int *)(((int)c + 0x98)) >>= 2;
     }
 
     if (func_ov002_020c19d0(c, 0x64, 0x32) != 0) {
-        *(u16 *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF) |= 0x200;
+        *(u16 *)(((int)c + 0x6ce)) |= 0x200;
         *(int *)(c + 0x98) = 0;
     }
     return 1;

--- a/src/_ZN6Player12St_Spin_MainEv.c
+++ b/src/_ZN6Player12St_Spin_MainEv.c
@@ -31,10 +31,10 @@ int _ZN6Player12St_Spin_MainEv(struct Player *thiz)
     }
     if (*(u16*)((char*)data_0209f49c + (&data_020a0e40)[0] * 0x18) & 2) {
         thiz->field_a0 = -0x9000;
-        *(s16 *)(int)(((long long)(int)((char *)thiz + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0x2000;
+        *(s16 *)(int)(((long long)(int)((char *)thiz + 0x8e))) += 0x2000;
     } else {
         thiz->field_a0 = -0xc000;
-        *(s16 *)(int)(((long long)(int)((char *)thiz + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0x1800;
+        *(s16 *)(int)(((long long)(int)((char *)thiz + 0x8e))) += 0x1800;
     }
     Player_AdvanceAnims(thiz);
     return 1;

--- a/src/_ZN6Player12St_Talk_MainEv.cpp
+++ b/src/_ZN6Player12St_Talk_MainEv.cpp
@@ -38,8 +38,8 @@ int Player::St_Talk_Main()
     if (mNoCtrlKind == 0) {
         char* p = *(char**)((char*)&mTalkActor);
         if (p != 0)
-            *(u32*)(((int)p + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x800000;
-        *(u32*)(((int)((char*)this) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x800000;
+            *(u32*)(((int)p + 0xb0)) |= 0x800000;
+        *(u32*)(((int)((char*)this) + 0xb0)) |= 0x800000;
         data_0209b454 |= 0x800000;
         mNoCtrlKind = 1;
     }
@@ -101,7 +101,7 @@ int Player::St_Talk_Main()
             mTargetAngleY = mAngleY;
             char* cam = data_0209f318;
             func_0200d81c(cam, mPlayerNo);
-            *(u32*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~8;
+            *(u32*)(((int)cam + 0x154)) &= ~8;
             unk_742 = 4;
         }
         break;

--- a/src/_ZN6Player12St_Wait_MainEv.cpp
+++ b/src/_ZN6Player12St_Wait_MainEv.cpp
@@ -175,7 +175,7 @@ int Player::St_Wait_Main()
         }
         }
         if (func_ov002_020d22ec(((char*)this), 0)) {
-            (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
+            (*(unsigned int*)(((int)r4 + 0x154))) &= ~0x2000;
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
         }
         break;
@@ -203,7 +203,7 @@ int Player::St_Wait_Main()
         }
         if (*(unsigned short*)(data_0209f49e+data_020a0e40*0x18) & 2) {
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211019c);
-            (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
+            (*(unsigned int*)(((int)r4 + 0x154))) &= ~0x2000;
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, ((char*)this)+0x74);
             return 1;
         }

--- a/src/_ZN6Player13InitFireYoshiEv.cpp
+++ b/src/_ZN6Player13InitFireYoshiEv.cpp
@@ -9,7 +9,7 @@ extern int data_ov002_0211004c;
 
 void Player::InitFireYoshi()
 {
-    u16 *p = (u16 *)(((int)((char *)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL);
+    u16 *p = (u16 *)(((int)((char *)this) + 0x6ce));
     *p |= 0x1000;
     if (mObjInMouth == 0)
         return;

--- a/src/_ZN6Player13St_Climb_InitEv.cpp
+++ b/src/_ZN6Player13St_Climb_InitEv.cpp
@@ -20,7 +20,7 @@ int Player::St_Climb_Init() {
     char* self = (char*)this;
     Player_ReleaseHeldActor(self);
 
-    int* bitfield = (int*)(((int)self + 0x2ec) & 0xFFFFFFFFFFFFFFFF);
+    int* bitfield = (int*)(((int)self + 0x2ec));
     *bitfield |= 4;
     *bitfield &= ~8;
 

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -57,7 +57,7 @@ int Player::St_Crawl_Main()
             }
             int shifted = mHorzSpeed >> 2;
             int id3 = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
-            char* anim3 = (char*)(((long long)(int)((char*)((int*)((char*)&mBodyModels))[id3] + 0x50)) & 0xffffffffffffffffLL);
+            char* anim3 = (char*)(((long long)(int)((char*)((int*)((char*)&mBodyModels))[id3] + 0x50)));
             *(int*)(anim3 + 0xc) = shifted;
             if (func_ov002_020d36d8(((char*)this), 1))
                 return 1;

--- a/src/_ZN6Player14St_Squish_InitEv.cpp
+++ b/src/_ZN6Player14St_Squish_InitEv.cpp
@@ -19,7 +19,7 @@ int Player::St_Squish_Init()
   *(unsigned char*)((char*)&unk_716) = 1;
   *(int*)((char*)&mAttachOffsetY) = *(int*)((char*)&mPosY);
   {
-    int *p = (int *)(((int)((void*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int *)(((int)((void*)this) + 0x2ec));
     *p |= 4;
   }
   return 1;

--- a/src/_ZN6Player15St_Balloon_MainEv.cpp
+++ b/src/_ZN6Player15St_Balloon_MainEv.cpp
@@ -31,7 +31,7 @@ extern "C" State data_ov002_021105a4;
 extern "C" s32 _ZN6Player15St_Balloon_MainEv(char *c)
 {
     if (*(u8 *)(c + 0x70c) != 0) {
-        (*(u8 *)(((int)c + 0x70c) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(u8 *)(((int)c + 0x70c)))--;
     }
     *(s32 *)(c + 0x684) = *(s32 *)(c + 0x60);
     *(s32 *)(c + 0x9c) = 0;
@@ -53,13 +53,13 @@ extern "C" s32 _ZN6Player15St_Balloon_MainEv(char *c)
 
     if ((flags & 2) && *(u16 *)(c + 0x6a6) == 0) {
         if (*(u16 *)(c + 0x6a4) == 0) {
-            *(s32 *)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFF) += 0xc000;
+            *(s32 *)(((int)c + 0xa8)) += 0xc000;
             if (*(s32 *)(c + 0xa8) < 0xc000)
                 *(s32 *)(c + 0xa8) = 0xc000;
             if (*(s32 *)(c + 0xa8) > 0x10000)
                 *(s32 *)(c + 0xa8) = 0x10000;
         } else {
-            *(s32 *)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFF) += 0x6000;
+            *(s32 *)(((int)c + 0xa8)) += 0x6000;
             if (*(s32 *)(c + 0xa8) < 0x6000)
                 *(s32 *)(c + 0xa8) = 0x6000;
             if (*(s32 *)(c + 0xa8) > 0xc000)

--- a/src/_ZN6Player15St_DeadPit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_InitEv.cpp
@@ -25,13 +25,13 @@ int Player::St_DeadPit_Init()
         int b = (*(u16*)(*(char**)((char*)&mObjInMouth) + 0xc) == 0xbf);
         if (b) {
             func_ov002_020d5cec(*(char**)((char*)&mObjInMouth));
-            *(u16*)(((int)((char*)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+            *(u16*)(((int)((char*)this) + 0x6ce)) &= ~2;
             *(int*)(*(char**)((char*)&mObjInMouth) + 0xd0) = 0;
         }
         mUseAltBodyModel = 0;
-        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x80000;
-        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x40000;
-        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x20000;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0)) |= 0x80000;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0)) &= ~0x40000;
+        *(int*)(((int)*(char**)((char*)&mObjInMouth) + 0xb0)) &= ~0x20000;
         *(char**)((char*)&mObjInMouth) = 0;
     }
     Player_DisableInteraction(((char*)this));
@@ -57,7 +57,7 @@ int Player::St_DeadPit_Init()
         case 2:
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 7, 0x40000000, 0x1000, t);
             mVertSpeed = 0xa000;
-            *(int*)(((int)((char*)this) + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 1;
+            *(int*)(((int)((char*)this) + 0x98)) >>= 1;
             mIsAirborne = 1;
             mLandSoundPlayed = 0;
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0xb, ((char*)this) + 0x74);

--- a/src/_ZN6Player15St_Respawn_InitEv.cpp
+++ b/src/_ZN6Player15St_Respawn_InitEv.cpp
@@ -21,8 +21,8 @@ int _ZN6Player15St_Respawn_InitEv(Player* thiz) {
     *(int*)(self + 0x5c) = *(int*)(self + 0x53c);
     *(int*)(self + 0x60) = *(int*)(self + 0x540);
     *(int*)(self + 0x64) = *(int*)(self + 0x544);
-    *(int*)(((int)ptr_60) & 0xFFFFFFFFFFFFFFFF) += 0x3e8000;
-    func_02035860(((void*)(((int)ptr_380) & 0xFFFFFFFFFFFFFFFF)), ((void*)(((int)ptr_5c) & 0xFFFFFFFFFFFFFFFF)));
+    *(int*)(((int)ptr_60)) += 0x3e8000;
+    func_02035860(((void*)(((int)ptr_380))), ((void*)(((int)ptr_5c))));
     *(int*)(self + 0x68) = *(int*)(self + 0x5c);
     *(int*)(self + 0x6c) = *(int*)(self + 0x60);
     *(int*)(self + 0x70) = *(int*)(self + 0x64);
@@ -31,7 +31,7 @@ int _ZN6Player15St_Respawn_InitEv(Player* thiz) {
     *(unsigned char*)(self + 0x713) = 1;
     *(unsigned char*)(self + 0x716) = 0;
     if (*(unsigned char*)(self + 0x6d8) == data_0209f250) {
-        func_0200cf40(*(char**)((int)&data_0209f318 & 0xFFFFFFFFFFFFFFFF));
+        func_0200cf40(*(char**)((int)&data_0209f318));
     }
     thiz->SetAnim(0x54, 0x40000000, 0x1000, 0);
     *(unsigned char*)(self + 0x6e3) = 0;

--- a/src/_ZN6Player15St_Respawn_MainEv.cpp
+++ b/src/_ZN6Player15St_Respawn_MainEv.cpp
@@ -34,7 +34,7 @@ int Player::St_Respawn_Main()
             if (mIsAirborne == 0) {
                 u32 zero = 0;
                 _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0x55, 0x40000000, 0x1000, zero);
-                *(u8 *)(((int)((char *)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(u8 *)(((int)((char *)this) + 0x6e3)) += 1;
             }
         }
         break;
@@ -43,7 +43,7 @@ int Player::St_Respawn_Main()
         if (_ZN6Player12FinishedAnimEv(((char *)this)) != 0) {
             int z = 0;
             _ZN6Player7SetAnimEji5Fix12IiEj(((char *)this), 0x47, z, 0x1000, z);
-            *(u8 *)(((int)((char *)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)((char *)this) + 0x6e3)) += 1;
         }
         break;
     case 2:

--- a/src/_ZN6Player15St_Talk_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Talk_CleanupEv.cpp
@@ -23,12 +23,12 @@ int _ZN6Player15St_Talk_CleanupEv(Player* this_)
 {
     void* p = this_->field368;
     if (p) {
-        *(u32*)(((long long)(int)((char*)p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800000;
+        *(u32*)(((long long)(int)((char*)p + 0xb0))) &= ~0x800000;
         this_->field368 = 0;
     }
-    *(u32*)(((long long)(int)((char*)this_ + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800000;
+    *(u32*)(((long long)(int)((char*)this_ + 0xb0))) &= ~0x800000;
     data_0209b454 &= ~0x800000;
-    *(u32*)(((long long)(int)((char*)data_0209f318 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+    *(u32*)(((long long)(int)((char*)data_0209f318 + 0x154))) &= ~8;
     if (this_->flag725) {
         _ZN5Sound22LoadAndSetMusic_Layer1Ei(0x39);
         this_->flag725 = 0;

--- a/src/_ZN6Player15St_Wait_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Wait_CleanupEv.cpp
@@ -11,7 +11,7 @@ extern int data_0209caa0[];
 int Player::St_Wait_Cleanup()
 {
     void* r4 = data_0209f318;
-    (*(unsigned int*)(((int)r4 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~0x2000;
+    (*(unsigned int*)(((int)r4 + 0x154))) &= ~0x2000;
     mSleepStage = 0;
     do {
         unsigned char v = data_0209f2d8;

--- a/src/_ZN6Player16IncMegaKillCountEv.cpp
+++ b/src/_ZN6Player16IncMegaKillCountEv.cpp
@@ -26,7 +26,7 @@ void Player::IncMegaKillCount()
   {
     return;
   }
-  ++(*((unsigned short *) (((int) ((char *)&unk_6d0)) & 0xFFFFFFFFFFFFFFFFLL)));
+  ++(*((unsigned short *) (((int) ((char *)&unk_6d0)))));
   new_var3 = -1;
   st = ((char *)this);
   st = st + 0x600;

--- a/src/_ZN6Player16St_BurnLava_MainEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_MainEv.cpp
@@ -63,13 +63,13 @@ int _ZN6Player16St_BurnLava_MainEv(char *c)
     if (*(u8 *)(c + 0x6e3) == 0) {
         func_ov002_020e28d4(c, 0x1000, 0x1000);
         if (*(u8 *)(c + 0x6de) == 0) {
-            (*(u8 *)(int)(((long long)(int)(c + 0x6e5)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8 *)(int)(((long long)(int)(c + 0x6e5))))++;
             if (*(u8 *)(c + 0x6e5) >= 3) {
                 _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x17, 0x40000000, 0x1000, 0);
                 *(int *)(c + 0x98) = 0;
-                (*(u8 *)(int)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(u8 *)(int)(((long long)(int)(c + 0x6e3))))++;
             } else {
-                (*(int *)(int)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL)) >>= 1;
+                (*(int *)(int)(((long long)(int)(c + 0x98)))) >>= 1;
                 *(u8 *)(c + 0x6de) = 1;
                 *(u8 *)(c + 0x6df) = 0;
                 if (*(u8 *)(c + 0x6e5) == 1)

--- a/src/_ZN6Player16St_Shell_CleanupEv.cpp
+++ b/src/_ZN6Player16St_Shell_CleanupEv.cpp
@@ -12,7 +12,7 @@ int Player::St_Shell_Cleanup()
   if (p != 0) {
     *(int*)(p + 0x3c0) = 0;
     mRidingShell = 0;
-    *(int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += 0x46000;
+    *(int*)(((int)((char*)this) + 0x60)) += 0x46000;
     mIsAirborne = 1;
     mLandSoundPlayed = 0;
     func_ov002_020bd8c0(((char*)this), 0x33);

--- a/src/_ZN6Player16St_Teleport_MainEv.cpp
+++ b/src/_ZN6Player16St_Teleport_MainEv.cpp
@@ -38,10 +38,10 @@ int Player::St_Teleport_Main()
     switch (mStateStep) {
     case 0:
         if (mOpacity > 1) {
-            (*(u8*)(((int)((char*)this) + 0x6f5) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8*)(((int)((char*)this) + 0x6f5)))--;
             break;
         }
-        (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8*)(((int)((char*)this) + 0x6e5)))++;
         if (mStateWork >= 0x10) {
             Obj* obj = GetTeleportDestObj((u8)(unk_6e8 - 1));
             int tx = obj->x << 12;
@@ -69,10 +69,10 @@ int Player::St_Teleport_Main()
                 if (data_0209f32c > mPosY + 0x64000)
                     mIsUnderwater = 1;
             }
-            (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8*)(((int)((char*)this) + 0x6e5)))--;
             break;
         }
-        (*(u8*)(((int)((char*)this) + 0x6f5) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8*)(((int)((char*)this) + 0x6f5)))++;
         func_02020388(mPlayerNo);
         if (mOpacity >= 0x1f) {
             int hit = 0;

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -48,7 +48,7 @@ int Player::St_ButtSlide_Main()
                 mStateWork = 0;
                 break;
             }
-            (*(u8*)(((int)((char*)this) + 0x6e7) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8*)(((int)((char*)this) + 0x6e7)))++;
             if (mSlideStoppedTimer >= 0x1e) {
                 unk_6e6 = 2;
                 mStateWork = 0;
@@ -89,7 +89,7 @@ int Player::St_ButtSlide_Main()
             }
             if (mStateWork == 0 && unk_558 >= 0xfc1) {
                 mVertSpeed = -mPrevVertSpeed / 2;
-                (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF))++;
+                (*(u8*)(((int)((char*)this) + 0x6e5)))++;
             } else {
                 unk_6e6 = 0;
                 mVertSpeed = 0;
@@ -98,7 +98,7 @@ int Player::St_ButtSlide_Main()
         } else {
             func_ov002_020dc560(((char*)this));
         }
-        (*(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8*)(((int)((char*)this) + 0x6e3)))++;
         if (mStateStep > 0x1e
             && mPosY - mGroundY > 0x1f4000) {
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101b4);

--- a/src/_ZN6Player17St_LedgeHang_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_MainEv.cpp
@@ -46,8 +46,8 @@ int Player::St_LedgeHang_Main()
     if (mStateStep == 0) {
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x21, 0, 0x1000, 0);
-            *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
-                *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(u8*)(((int)((char*)this) + 0x6e3)) =
+                *(u8*)(((int)((char*)this) + 0x6e3)) + 1;
         }
     } else {
         if ((!func_ov002_020cfaf0(((char*)this))

--- a/src/_ZN6Player17St_SlideKick_InitEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_InitEv.cpp
@@ -17,7 +17,7 @@ int Player::St_SlideKick_Init()
     unsigned int r = (unsigned int)RandomIntInternal(&data_ov002_0210e160);
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(p[0x6d9], data_ov002_020ff130[(r >> 4) & 1], *(Vector3*)(p + 0x74));
     _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x67, 0x40000000, 0x1000, 0);
-    int* yv = (int*)(((int)p + 0x98) & 0xFFFFFFFFFFFFFFFF);
+    int* yv = (int*)(((int)p + 0x98));
     *(int*)(p + 0xa8) = 0x14000;
     yv[0] += 0xf000;
     if (*(int*)(p + 0x98) > 0x28000) *(int*)(p + 0x98) = 0x28000;

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -86,8 +86,8 @@ La8:
     goto L18c;
 
 L14c:
-    *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) =
-        *(u8*)(((int)((char*)this) + 0x6e3) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(u8*)(((int)((char*)this) + 0x6e3)) =
+        *(u8*)(((int)((char*)this) + 0x6e3)) + 1;
     if (mStateStep <= 0x1e)
         goto L18c;
     if (mPosY - mGroundY <= 0x64000)
@@ -98,7 +98,7 @@ L18c:
     {
         int id = _ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0);
         void* anim = *(void**)(((char*)this) + (id << 2) + 0xdc);
-        u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50)) & 0xFFFFFFFFFFFFFFFFLL) + 8);
+        u32 w = *(u32*)((char*)(((long long)(int)((char*)anim + 0x50))) + 8);
         if ((u16)(w >> 12) < 4)
             goto L1d8;
         func_ov002_020dbaec(((char*)this));

--- a/src/_ZN6Player17St_WindCarry_MainEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_MainEv.cpp
@@ -39,7 +39,7 @@ int Player::St_WindCarry_Main()
             else
                 speed = __aeabi_idiv(0x2710000, (val + 0xc8000) >> 12);
             if (*(int*)(c + 0xa8) < speed) {
-                int* p = (int*)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFF);
+                int* p = (int*)(((int)c + 0xa8));
                 *p = *p + (speed >> 3);
                 if (*(int*)(c + 0xa8) > speed) *(int*)(c + 0xa8) = speed;
             }
@@ -49,7 +49,7 @@ int Player::St_WindCarry_Main()
     if (*(u8*)(c + 0x6e3) == 0 && FinishedAnim() != 0) {
         SetAnim(0x73, 0, 0x1000, 0);
         {
-            u8* q = (u8*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFF);
+            u8* q = (u8*)(((int)c + 0x6e3));
             *q = *q + 1;
         }
     }

--- a/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
+++ b/src/_ZN6Player18SetNewHatCharacterEjjb.cpp
@@ -23,9 +23,9 @@ void Player::SetNewHatCharacter(unsigned int p1, unsigned int p2, bool p3)
   if (p1 == old) return;
   unk_6dc = (unsigned char)old;
   mHatCharacter = (unsigned char)p1;
-  *(unsigned short*)((char*)(((int)((char*)this) + 0x700) & 0xFFFFFFFFFFFFFFFF) + 0x3c) = 1;
+  *(unsigned short*)((char*)(((int)((char*)this) + 0x700)) + 0x3c) = 1;
   if (p1 != mCharacter) {
-    *(unsigned short*)((char*)(((int)((char*)this) + 0x73c) & 0xFFFFFFFFFFFFFFFF)) |= 0x8000;
+    *(unsigned short*)((char*)(((int)((char*)this) + 0x73c))) |= 0x8000;
   }
   func_ov002_020bdb50(((char*)this), p2);
   func_ov002_020bda48(((char*)this));


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 155 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
