### PR TITLE
readable: strip 98 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/FS_CloseFile.c
+++ b/src/FS_CloseFile.c
@@ -7,6 +7,6 @@ int FS_CloseFile(char *self)
 
     *(int *)(self + 8) = 0;
     *(int *)(self + 0x10) = 0xc;
-    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x30;
+    *(int *)(((long long)(int)(self + 0xc))) &= ~0x30;
     return 1;
 }

--- a/src/Player_DisableInteraction.c
+++ b/src/Player_DisableInteraction.c
@@ -4,7 +4,7 @@ void Player_DisableInteraction(char *self)
     char *slot;
 
     *(unsigned char *)(self + 0x709) = 1;
-    slot = (char *)(((long long)(int)(self + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL);
+    slot = (char *)(((long long)(int)(self + 0x2ec)));
     tmp = *(unsigned int *)slot;
     tmp |= 4u;
     *(unsigned int *)slot = tmp;

--- a/src/Player_ReleaseHeldActor.c
+++ b/src/Player_ReleaseHeldActor.c
@@ -10,8 +10,8 @@ int Player_ReleaseHeldActor(char* c)
     if (is_bf != 0) {
         func_ov002_020db54c(p, 0x10000, 0x10000, *(short*)(c + 0x8e));
     }
-    *(int*)(((int)*(char**)(c + 0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000;
-    *(int*)(((int)*(char**)(c + 0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x100;
+    *(int*)(((int)*(char**)(c + 0x358) + 0xb0)) &= ~0x4000;
+    *(int*)(((int)*(char**)(c + 0x358) + 0xb0)) &= ~0x100;
     *(char**)(c + 0x358) = 0;
     return 1;
 }

--- a/src/_ZN6Player18St_CameraZoom_MainEv.cpp
+++ b/src/_ZN6Player18St_CameraZoom_MainEv.cpp
@@ -20,17 +20,17 @@ int _ZN6Player18St_CameraZoom_MainEv(Player* thiz) {
             unsigned int id;
             thiz->ChangeState(data_ov002_0211013c);
             id = thiz->GetBodyModelID(*(int*)(self + 8) & 0xff, 0);
-            int q = (int)((*(volatile int*)(self + id * 4 + 0xdc) + 0x50) & 0xFFFFFFFFFFFFFFFF);
+            int q = (int)((*(volatile int*)(self + id * 4 + 0xdc) + 0x50));
             *(int*)(q + 8) = 0;
             *(short*)(self + 0x94) = *(short*)(self + 0x8e);
             return 1;
         }
         if (*(unsigned char*)(self + 0x6de)) {
-            *(unsigned short*)(((int)self + 0x6ce) & 0xFFFFFFFFFFFFFFFF) &= ~4;
+            *(unsigned short*)(((int)self + 0x6ce)) &= ~4;
         }
         func_ov002_020cae10(self);
         if (*(unsigned short*)((char*)&data_0209f49e + data_020a0e40 * 0x18) & 0x8f03) {
-            *(unsigned short*)(((int)self + 0x6ce) & 0xFFFFFFFFFFFFFFFF) &= ~4;
+            *(unsigned short*)(((int)self + 0x6ce)) &= ~4;
         }
         func_ov002_020cac60(self);
     }

--- a/src/_ZN6Player18St_DizzyStars_InitEv.cpp
+++ b/src/_ZN6Player18St_DizzyStars_InitEv.cpp
@@ -7,6 +7,6 @@
 int Player::St_DizzyStars_Init()
 {
     mStateTimer = 0x12c;
-    *(int *)(((int)((char *)this) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80;
+    *(int *)(((int)((char *)this) + 0xb0)) |= 0x80;
     return 1;
 }

--- a/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
+++ b/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
@@ -25,7 +25,7 @@ extern void _ZN6Player9DropActorEv(struct Actor* a);
 int _ZN6Player18St_Grabbed_CleanupEv(struct Player* this_)
 {
     struct Actor* a;
-    *(u32*)(((long long)(int)((char*)this_ + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    *(u32*)(((long long)(int)((char*)this_ + 0x2ec))) &= ~2;
     a = this_->held;
     if (a) {
         int isBob = a->actorID == 0xbf;

--- a/src/_ZN6Player18St_YoshiPower_InitEv.cpp
+++ b/src/_ZN6Player18St_YoshiPower_InitEv.cpp
@@ -17,7 +17,7 @@ extern void func_ov002_020ed63c(void*, int);
 
 int Player::St_YoshiPower_Init()
 {
-    *(unsigned short*)(((int)((char*)this) + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+    *(unsigned short*)(((int)((char*)this) + 0x6ce)) |= 0x200;
     unk_6ee = 0;
     mEggParams = 0;
     if (unk_6be != 0) {
@@ -31,7 +31,7 @@ int Player::St_YoshiPower_Init()
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6d, 0x40000000, 0x1000, 0);
             mStateStep = 5;
             mStateTimer = 0x1e;
-            *(unsigned char*)(((int)((char*)this) + 0x6f4) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            *(unsigned char*)(((int)((char*)this) + 0x6f4)) -= 1;
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x101, ((char*)this)+0x74);
         } else if (*(void**)((char*)&mObjInMouth) == 0) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x6c, 0x40000000, 0x1000, 0);
@@ -52,7 +52,7 @@ int Player::St_YoshiPower_Init()
         _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x30, 0x40000000, 0x1000, 0);
         mStateStep = 6;
         *(void**)((char*)&mHeldObj) = **(void***)((char*)&mHeldObjQueue);
-        *(int*)(((int)*(void**)((char*)&mHeldObj) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+        *(int*)(((int)*(void**)((char*)&mHeldObj) + 0xb0)) |= 0x100;
         func_ov002_020ed63c(*(void**)((char*)&mHeldObj), 1);
         (*(int**)((char*)&mHeldObjQueue))[0] = 0;
         for (i = 1; i < 5; i++) {

--- a/src/_ZN6Player18St_YoshiPower_MainEv.cpp
+++ b/src/_ZN6Player18St_YoshiPower_MainEv.cpp
@@ -68,7 +68,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
             int t4 = (*(int*)((char*)*(void**)(c+0x160) + 0x58) >> 0xc) << 0x10;
             int id0 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
             dp = (char*)*(void**)(c + (id0<<2) + 0xdc);
-            dp = (char*)(((long long)(int)(dp + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+            dp = (char*)(((long long)(int)(dp + 0x50)));
             *(unsigned int*)(dp + 8) = (unsigned int)t4 >> 4;
             *(unsigned char*)(c+0x70c) = 1;
         }
@@ -103,7 +103,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
             }
             int id2 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
             if (_ZNK9Animation12WillHitFrameEi((char*)*(void**)(c + (id2<<2) + 0xdc) + 0x50, 0xa) != 0) {
-                Vec3* src = (Vec3*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                Vec3* src = (Vec3*)(((int)c + 0x5c));
                 dp = (char*)*(void**)(c+0x360);
                 *(int*)(dp+0x5c) = src->x;
                 *(int*)(dp+0x60) = src->y;
@@ -111,13 +111,13 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
                 Obj* o = *(Obj**)(c+0x360);
                 int cond = (*(unsigned short*)((char*)o+0xc) == 0xbf);
                 if (cond != 0) {
-                    *(int*)(((int)o + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+                    *(int*)(((int)o + 0xb0)) &= ~0x20000;
                     if (func_ov002_020d5ed0(*(void**)(c+0x360)) == 0) {
                         func_ov002_020d718c(c);
                     }
                 } else {
-                    *(int*)(((int)o + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40000;
-                    *(int*)(((int)*(void**)(c+0x360) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+                    *(int*)(((int)o + 0xb0)) |= 0x40000;
+                    *(int*)(((int)*(void**)(c+0x360) + 0xb0)) &= ~0x20000;
                     if ((*(Obj**)(c+0x360))->v18() == 4 || (*(Obj**)(c+0x360))->v18() == 2) {
                         *(unsigned char*)(c+0x6e3) = 3;
                         int f2 = 1;
@@ -175,7 +175,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
             return 1;
         }
         int id4 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
-        int* a50b = (int*)(((long long)(int)((char*)*(void**)(c + (id4<<2) + 0xdc) + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* a50b = (int*)(((long long)(int)((char*)*(void**)(c + (id4<<2) + 0xdc) + 0x50)));
         if ((unsigned short)(a50b[2] >> 0xc) == 0) {
             if (*(unsigned char*)(c+0x6de) != 0) {
                 _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_021101b4);
@@ -209,7 +209,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
             *(unsigned char*)(c+0x714) = z;
             if (*(unsigned char*)(c+0x714) == 0) {
                 int id6 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, z);
-                int* a50c = (int*)(((long long)(int)((char*)*(void**)(c + (id6<<2) + 0xdc) + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+                int* a50c = (int*)(((long long)(int)((char*)*(void**)(c + (id6<<2) + 0xdc) + 0x50)));
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(c+0x160), (void*)data_ov002_0210e3d8[1], 0x40000000, 0x1000, (unsigned int)(a50c[2] << 4) >> 0x10);
             }
         }
@@ -220,10 +220,10 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
                 int cond3 = (*(unsigned short*)((char*)obj0+0xc) == 0xbf);
                 if (cond3 != 0) {
                     func_ov002_020d5cec(obj0);
-                    *(unsigned short*)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+                    *(unsigned short*)(((int)c + 0x6ce)) &= ~2;
                 } else {
-                    *(int*)(((int)obj0 + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x80000;
-                    *(int*)(((int)*(void**)(c+0x360) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x40000;
+                    *(int*)(((int)obj0 + 0xb0)) |= 0x80000;
+                    *(int*)(((int)*(void**)(c+0x360) + 0xb0)) &= ~0x40000;
                 }
             }
             *(void**)(c+0x360) = 0;
@@ -239,7 +239,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
     case 5: {
         if (*(unsigned short*)(c+0x6a4) != 0) {
             int id8 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, 0);
-            int* a50d = (int*)(((long long)(int)((char*)*(void**)(c + (id8<<2) + 0xdc) + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* a50d = (int*)(((long long)(int)((char*)*(void**)(c + (id8<<2) + 0xdc) + 0x50)));
             if (((unsigned int)(a50d[2] << 4) >> 0x10) >= 4) {
                 int i2 = (*(unsigned short*)(c+0x8e) >> 4) * 2;
                 short* tbl = data_02082214;
@@ -251,7 +251,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
                 dir.x = data_02082214[(*(unsigned short*)(c+0x8e) >> 4) * 2];
                 dir.y = 0;
                 dir.z = data_02082214[(*(unsigned short*)(c+0x8e) >> 4) * 2 + 1];
-                *(void**)(c+0x628) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(c+0x628), 0x13c, pos.x, pos.y, pos.z, (Vec3s*)(((int)&dir) & 0xFFFFFFFFFFFFFFFFLL), 0);
+                *(void**)(c+0x628) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(c+0x628), 0x13c, pos.x, pos.y, pos.z, (Vec3s*)(((int)&dir)), 0);
                 *(void**)(c+0x62c) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(*(void**)(c+0x62c), 0x13d, pos.x, pos.y, pos.z, &dir, 0);
                 func_ov002_020dc09c(c);
                 _ZN12CylinderClsn5ClearEv(c+0x314);
@@ -260,7 +260,7 @@ int _ZN6Player18St_YoshiPower_MainEv(char* c)
                     int z2 = 0;
                     *(unsigned char*)(c+0x714) = z2;
                     int id9 = _ZNK6Player14GetBodyModelIDEjb(c, *(unsigned int*)(c+8) & 0xff, z2);
-                    int* a50e = (int*)(((long long)(int)((char*)*(void**)(c + (id9<<2) + 0xdc) + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+                    int* a50e = (int*)(((long long)(int)((char*)*(void**)(c + (id9<<2) + 0xdc) + 0x50)));
                     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(*(void**)(c+0x160), (void*)data_ov002_0210e3d8[1], 0x40000000, 0x1000, (unsigned int)(a50e[2] << 4) >> 0x10);
                 }
                 return 1;

--- a/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_MainEv.cpp
@@ -36,12 +36,12 @@ int Player::St_CrazedCrate_Main() {
             t += 0x8000;
             *(s16*)(self + 0x8e) = t;
             int half = 0x800;
-            int* xpos = (int*)(int)(((long long)(int)(self + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* xpos = (int*)(int)(((long long)(int)(self + 0x5c)));
             int* zpos;
             *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);
             *xpos += (int)(((s64)*(int*)(self + 0x98)
                      * data_02082214[(((int)*(u16*)(self + 0x94) >> 4) << 1) + 1] + half) >> 12);
-            zpos = (int*)(int)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+            zpos = (int*)(int)(((long long)(int)(self + 0x64)));
             *zpos += (int)(((s64)*(int*)(self + 0x98)
                      * data_02082214[((int)*(u16*)(self + 0x94) >> 4) << 1] + half) >> 12);
         }
@@ -51,7 +51,7 @@ int Player::St_CrazedCrate_Main() {
 
     if (*(u8*)(self + 0x6de) == 0) {
         if (*(u8*)(self + 0x6e1) < 2) {
-            (*(u8*)(int)(((long long)(int)(self + 0x6e1)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(int)(((long long)(int)(self + 0x6e1))))++;
             func_ov002_020e0f38(self, *(u8*)(self + 0x6e1));
         } else {
             if (*(int*)(self + 8) == 3) {

--- a/src/_ZN6Player19St_GroundPound_InitEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_InitEv.cpp
@@ -20,6 +20,6 @@ int Player::St_GroundPound_Init()
   _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), anim, 0x40000000, 0x1000, 0);
   *(char*)((char*)&mStateStep)=2;
   _ZN5Sound9PlayBank0EjRK7Vector3(6, (char*)((void*)this)+0x74);
-  *(int*)((int*)(((int)((void*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFF)) |= 0x20;
+  *(int*)((int*)(((int)((void*)this) + 0x2ec))) |= 0x20;
   return 1;
 }

--- a/src/_ZN6Player19St_TornadoSpin_MainEv.cpp
+++ b/src/_ZN6Player19St_TornadoSpin_MainEv.cpp
@@ -30,9 +30,9 @@ int _ZN6Player19St_TornadoSpin_MainEv(char* c)
     if (spd < 0) {
         *(int*)(c + 0xa8) = 0x1000;
     } else if (spd < 0x3c000) {
-        *(int*)(((s64)(int)(c + 0xa8)) & 0xFFFFFFFFFFFFFFFFLL) += 0x1000;
+        *(int*)(((s64)(int)(c + 0xa8))) += 0x1000;
     }
-    *(int*)(((s64)(int)(c + 0x688)) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(c + 0xa8);
+    *(int*)(((s64)(int)(c + 0x688))) += *(int*)(c + 0xa8);
     if (*(int*)(c + 0x688) < 0)
         *(int*)(c + 0x688) = 0;
     if (*(int*)(c + 0x688) > *(int*)(*(char**)(c + 0x364) + 0xdc) || (*(u8*)(c + 0x6e9) & 4) != 0) {
@@ -43,8 +43,8 @@ int _ZN6Player19St_TornadoSpin_MainEv(char* c)
         return 1;
     }
     if (*(s16*)(c + 0x69c) < 0x3000)
-        *(s16*)(((s64)(int)(c + 0x69c)) & 0xFFFFFFFFFFFFFFFFLL) += 0x100;
-    *(s16*)(((s64)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += *(s16*)(c + 0x69c);
+        *(s16*)(((s64)(int)(c + 0x69c))) += 0x100;
+    *(s16*)(((s64)(int)(c + 0x8e))) += *(s16*)(c + 0x69c);
     {
         int v = *(s16*)(c + 0x69c);
         if (v >= 0x1000) v = 0x1000;

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -67,14 +67,14 @@ int Player::St_CeilingGrate_Main()
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[mStateWork & 1], 0, 0x1000, 0);
         }
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)));
             if ((u32)(*(int*)(anim + 8) << 4) >> 0x10 < 0x21)
                 break;
         }
     case 1:
         func_ov002_020cf384(((char*)this));
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+            *(u8*)(((int)((char*)this) + 0x6e5)) ^= 1;
             mStateStep = 2;
             spd = mHorzSpeed >> 3;
             if (spd < 0x800)
@@ -88,13 +88,13 @@ int Player::St_CeilingGrate_Main()
         if (spd < 0x800)
             spd = 0x800;
         {
-            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+            char* anim = (char*)(((long long)(int)(*(char**)(((char*)this) + (_ZNK6Player14GetBodyModelIDEjb(((char*)this), mParam & 0xff, 0) << 2) + 0xdc) + 0x50)));
             *(int*)(anim + 0xc) = spd;
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
             _ZN5Sound9PlayBank0EjRK7Vector3(0xb2, ((char*)this) + 0x74);
             if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-                *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+                *(u8*)(((int)((char*)this) + 0x6e5)) ^= 1;
                 _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a60c[(mStateWork & 1) + 2], 0x40000000, 0x1000, 0);
             } else {
                 mStateStep = 1;

--- a/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
@@ -37,7 +37,7 @@ int Player::St_InYoshiMouth_Main()
                     return 1;
             }
             {
-                int *p = (int *)(int)(((long long)(int)(r4 + 0x5c)) & 0xffffffffffffffffLL);
+                int *p = (int *)(int)(((long long)(int)(r4 + 0x5c)));
                 mPosX = p[0];
                 mPosY = p[1];
                 mPosZ = p[2];
@@ -46,7 +46,7 @@ int Player::St_InYoshiMouth_Main()
             t = *(u16 *)(r4 + 0x6c6);
             if (*(u8 *)(r4 + 0x709) == 0 && *(u8 *)(r4 + 0x708) == 0) {
                 t = (u16)(t - d);
-                *(u8 *)(((long long)(int)((char *)&unk_6e6)) & 0xffffffffffffffffLL) += d;
+                *(u8 *)(((long long)(int)((char *)&unk_6e6))) += d;
                 if ((s16)t < 0)
                     t = 0;
             }
@@ -72,7 +72,7 @@ int Player::St_InYoshiMouth_Main()
         }
     case 2:
         if (mStateTimer == 0)
-            *(int *)(((long long)(int)((char *)&mBodyClsnFlags)) & 0xffffffffffffffffLL) |= 0x2000;
+            *(int *)(((long long)(int)((char *)&mBodyClsnFlags))) |= 0x2000;
         if (_ZN6Player12FinishedAnimEv(((char *)this))) {
             mStateStep = 3;
             mHurtDamage = 1;
@@ -82,7 +82,7 @@ int Player::St_InYoshiMouth_Main()
     case 3:
         {
             int d = func_ov002_020beb38(((char *)this));
-            *(u16 *)(((long long)(int)((char *)&mStateTimer)) & 0xffffffffffffffffLL) -= (d << 2);
+            *(u16 *)(((long long)(int)((char *)&mStateTimer))) -= (d << 2);
             mStateWork = d;
             if ((s16)mStateTimer <= 0) {
                 mStateTimer = 0;

--- a/src/_ZN6Player21St_DizzyStars_CleanupEv.cpp
+++ b/src/_ZN6Player21St_DizzyStars_CleanupEv.cpp
@@ -5,6 +5,6 @@ struct Player {
 int Player::St_DizzyStars_Cleanup()
 {
     char *self = (char *)this;
-    *(unsigned int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80u;
+    *(unsigned int *)(((long long)(int)(self + 0xb0))) &= ~0x80u;
     return 1;
 }

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -32,8 +32,8 @@ int Player::St_StuckInGround_Main()
     case 0:
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a578[mStateStep], 0x40000000, 0x1000, 0);
-            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
-                *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(u8*)(((int)((char*)this) + 0x6e5)) =
+                *(u8*)(((int)((char*)this) + 0x6e5)) + 1;
             return 1;
         }
         break;
@@ -43,8 +43,8 @@ int Player::St_StuckInGround_Main()
                 break;
         }
         _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_0210a584[mStateStep], 0x40000000, 0x1000, 0);
-        *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) =
-            *(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF) + 1;
+        *(u8*)(((int)((char*)this) + 0x6e5)) =
+            *(u8*)(((int)((char*)this) + 0x6e5)) + 1;
         break;
     case 2:
         {

--- a/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
+++ b/src/_ZN6Player21St_YoshiPower_CleanupEv.cpp
@@ -15,11 +15,11 @@ int Player::St_YoshiPower_Cleanup()
     if (r2 != 0) {
         int t = (int)((*(int*)(r2+0xb0) & 0x20000) != 0);
         if (t != 0) {
-            *(int*)(((int)r2 + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000;
+            *(int*)(((int)r2 + 0xb0)) &= ~0xe0000;
             func_ov002_020d718c(((char*)this));
             return 1;
         }
-        *(int*)(((int)r2 + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+        *(int*)(((int)r2 + 0xb0)) &= ~0x20000;
     }
     if (mUseAltBodyModel == 0) {
         char* q = *(char**)((char*)&mObjInMouth);

--- a/src/_ZN6Player22St_CrazedCrate_CleanupEv.cpp
+++ b/src/_ZN6Player22St_CrazedCrate_CleanupEv.cpp
@@ -8,7 +8,7 @@ struct Player {
 };
 
 int Player::St_CrazedCrate_Cleanup() {
-    *(int *)(((int)this + 0x2EC) & 0xFFFFFFFFFFFFFFFF) &= ~0x20;
+    *(int *)(((int)this + 0x2EC)) &= ~0x20;
     byte_6E1 = 0;
     return 1;
 }

--- a/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
@@ -52,7 +52,7 @@ int Player::St_GrabBowserTail_Main()
             mStateWork = 0;
         if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) == 0) {
             u8 v = mStateWork;
-            (*(u8*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)((char*)this) + 0x6e5)))++;
             if (v > 0x78) {
                 mStateStep = 2;
                 _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x7f, 0x40000000, 0x1000, 0);
@@ -76,17 +76,17 @@ int Player::St_GrabBowserTail_Main()
                     r3 = ((mDesiredAngleY - unk_6d4) << 9) >> 16;
                 if (r3 < -0x80) r3 = -0x80;
                 if (r3 > 0x80) r3 = 0x80;
-                *(s16*)(((int)((char*)this) + 0x69c) & 0xFFFFFFFFFFFFFFFFLL) += r3;
+                *(s16*)(((int)((char*)this) + 0x69c)) += r3;
                 if (mAngleYSpeed > 0x1000) mAngleYSpeed = 0x1000;
                 if (mAngleYSpeed < -0x1000) mAngleYSpeed = -0x1000;
             }
         } else {
             mStateArg = 0;
-            _Z15ApproachLinear2Rsss((s16*)(((int)((char*)this) + 0x69c) & 0xFFFFFFFFFFFFFFFFLL), 0, 0x40);
+            _Z15ApproachLinear2Rsss((s16*)(((int)((char*)this) + 0x69c)), 0, 0x40);
         }
         {
             s16 before = mAngleY;
-            *(s16*)(((int)((char*)this) + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += mAngleYSpeed;
+            *(s16*)(((int)((char*)this) + 0x8e)) += mAngleYSpeed;
             if ((mAngleYSpeed <= -0x100 && before < mAngleY) ||
                 (mAngleYSpeed >= 0x100 && before > mAngleY))
                 func_02012694(0xb4, ((char*)this) + 0x74);

--- a/src/_ZN6Player5ShockEj.cpp
+++ b/src/_ZN6Player5ShockEj.cpp
@@ -18,7 +18,7 @@ int Player::Shock(unsigned int j)
   mStateWork = 0;
   if (func_ov002_020d91e0(((char*)this), j<<8, 1, 0)) mStateWork = 1;
   if (mIsUnderwater) {
-    unsigned char* p = (unsigned char*)(((int)((char*)this) + 0x6e5) & 0xFFFFFFFFFFFFFFFF);
+    unsigned char* p = (unsigned char*)(((int)((char*)this) + 0x6e5));
     *p |= 2;
   }
   _ZN6Player11ChangeStateERNS_5StateE(((char*)this), &data_ov002_021100c4);

--- a/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
+++ b/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
@@ -3,7 +3,7 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 typedef int Fix12i;
-#define LAUNDER16(p) ((u16 *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER16(p) ((u16 *)(int)(((long long)(int)(p))))
 extern "C" {
 extern u8 data_0209f2d8;
 extern void *data_ov002_020ff480[];

--- a/src/_ZN6Player9DropActorEv.cpp
+++ b/src/_ZN6Player9DropActorEv.cpp
@@ -22,27 +22,27 @@ int Player::DropActor()
     if (present) {
         int held = ((s[0x2c] & 0x200) != 0);
         if (!held) {
-            u32* s_ptr1 = (u32*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* s_ptr1 = (u32*)(((int)s + 0xb0));
             *s_ptr1 &= ~0x4000u;
 
             u32* s_ptr2 = *(u32**)((char*)&mHeldObj);
-            u32* field_ptr2 = (u32*)(((int)s_ptr2 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* field_ptr2 = (u32*)(((int)s_ptr2 + 0xb0));
             *field_ptr2 &= ~0x100u;
 
             u32* s_ptr3 = *(u32**)((char*)&mHeldObj);
-            u32* field_ptr3 = (u32*)(((int)s_ptr3 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* field_ptr3 = (u32*)(((int)s_ptr3 + 0xb0));
             *field_ptr3 &= ~0x400u;
 
             u32* s_ptr4 = *(u32**)((char*)&mHeldObj);
-            u32* field_ptr4 = (u32*)(((int)s_ptr4 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* field_ptr4 = (u32*)(((int)s_ptr4 + 0xb0));
             *field_ptr4 &= ~0x2000u;
 
             u32* s_ptr5 = *(u32**)((char*)&mHeldObj);
-            u32* field_ptr5 = (u32*)(((int)s_ptr5 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* field_ptr5 = (u32*)(((int)s_ptr5 + 0xb0));
             *field_ptr5 &= ~0x800u;
 
             u32* s_ptr6 = *(u32**)((char*)&mHeldObj);
-            u32* field_ptr6 = (u32*)(((int)s_ptr6 + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+            u32* field_ptr6 = (u32*)(((int)s_ptr6 + 0xb0));
             *field_ptr6 &= ~0x1000u;
 
             *(u32**)((char*)&mHeldObj) = 0;

--- a/src/_ZN6Player9StartTalkER9ActorBaseb.cpp
+++ b/src/_ZN6Player9StartTalkER9ActorBaseb.cpp
@@ -54,7 +54,7 @@ int _ZN6Player9StartTalkER9ActorBaseb(char *thiz, ActorBase *actor, int b)
     } else {
         if (_ZN6Player7IsStateERNS_5StateE(thiz, &data_ov002_02110424) ||
             _ZN6Player7IsStateERNS_5StateE(thiz, &data_ov002_021105a4)) {
-            *(u16 *)(((long long)(thiz + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+            *(u16 *)(((long long)(thiz + 0x6ce))) |= 0x40;
             return 0;
         }
 

--- a/src/_ZN6Rabbit8BehaviorEv.c
+++ b/src/_ZN6Rabbit8BehaviorEv.c
@@ -120,7 +120,7 @@ int _ZN6Rabbit8BehaviorEv(void* arg0)
                     } else if (temp_r1 == 1 && _ZN6Player12GetTalkStateEv(temp_r4) == -1) {
                         _ZN6Player9DropActorEv(temp_r4);
                         *(u8*)(c + 0x427) = 2;
-                        *(u16*)(((long long)(int)((char*)temp_r4 + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800;
+                        *(u16*)(((long long)(int)((char*)temp_r4 + 0x6ce))) |= 0x800;
                     }
                 }
             }
@@ -136,7 +136,7 @@ int _ZN6Rabbit8BehaviorEv(void* arg0)
                 _ZN12CylinderClsn6UpdateEv(c + 0x110);
         }
         if (*(u8*)(c + 0x107) == 1) {
-            *(u8*)(((long long)(int)(c + 0x42a)) & 0xFFFFFFFFFFFFFFFFLL) = *(u8*)(((long long)(int)(c + 0x42a)) & 0xFFFFFFFFFFFFFFFFLL) + 1;
+            *(u8*)(((long long)(int)(c + 0x42a))) = *(u8*)(((long long)(int)(c + 0x42a))) + 1;
             if (*(u8*)(c + 0x42a) > 0x96) {
                 *(u8*)(c + 0x107) = 0;
                 *(u8*)(c + 0x42a) = 0;

--- a/src/_ZN6ShipUp8BehaviorEv.cpp
+++ b/src/_ZN6ShipUp8BehaviorEv.cpp
@@ -18,7 +18,7 @@ int ShipUp::Behavior()
   }
   func_020393a4((int*)((char*)&mMeshCollider), 0x2000000);
   if(mModelIndex == 0){
-    *(short*)(((int)((char*)this) + 0x320) & 0xFFFFFFFFFFFFFFFF) += 0xda;
+    *(short*)(((int)((char*)this) + 0x320)) += 0xda;
     unk_08c = (short)((*(short*)((char*)data_02082214 + ((unk_320>>4)<<2)) << 0xa) >> 0xc);
     if(_ZN5Actor13DistToCPlayerEv(((char*)this)) < 0xbb8000){
       unk_324 = _ZN5Sound8PlayLongEjjjRK7Vector3j(unk_324, 3, 0x8b, ((char*)this)+0x74, 0);

--- a/src/_ZN6Snufit8BehaviorEv.cpp
+++ b/src/_ZN6Snufit8BehaviorEv.cpp
@@ -85,7 +85,7 @@ int Snufit::Behavior()
         int idx;
         short tbl;
         int result;
-        p3d8 = (int *)(((int)c + 0x3d8) & 0xFFFFFFFFFFFFFFFF);
+        p3d8 = (int *)(((int)c + 0x3d8));
         *p3d8 += 0x200;
         ang = *(int *)(c + 0x3d8);
         idx = ((unsigned short)(short)ang >> 4) * 2;

--- a/src/_ZN6Thwomp8BehaviorEv.cpp
+++ b/src/_ZN6Thwomp8BehaviorEv.cpp
@@ -34,10 +34,10 @@ int Thwomp::Behavior()
                 *(unsigned short *)(p + 0xa0) = 0xa;
             }
         } else {
-            char *p = (char *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+            char *p = (char *)(((int)((char *)this) + 0x300));
             int t = *(unsigned short *)(p + 0xa0);
             if (t != 0) {
-                unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0));
                 *q = *q - 1;
             } else {
                 func_ov091_02133020(((char *)this));
@@ -55,10 +55,10 @@ int Thwomp::Behavior()
         } else {
             _ZN9Animation7AdvanceEv((char *)&mTextureSequence);
             if (_ZN9Animation8FinishedEv((char *)&mTextureSequence) != 0) {
-                char *p = (char *)(((int)((char *)this) + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                char *p = (char *)(((int)((char *)this) + 0x300));
                 int t = *(unsigned short *)(p + 0xa0);
                 if (t != 0) {
-                    unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0) & 0xFFFFFFFFFFFFFFFFLL);
+                    unsigned short *q = (unsigned short *)(((int)((char *)this) + 0x3a0));
                     *q = *q - 1;
                 } else {
                     func_ov091_02132f04(((char *)this));

--- a/src/_ZN6ToxBox13InitResourcesEv.c
+++ b/src/_ZN6ToxBox13InitResourcesEv.c
@@ -1,7 +1,7 @@
 typedef struct { int x, y, z; } Vec3;
 typedef struct { int m[12]; } Mtx43;
 
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *, void *, int, int);

--- a/src/_ZN6ToxBox8BehaviorEv.cpp
+++ b/src/_ZN6ToxBox8BehaviorEv.cpp
@@ -12,7 +12,7 @@ struct ToxBox {
     int state;
 };
 
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 
 extern "C" {
 void func_ov092_02131aec(void* c);

--- a/src/_ZN7Chuckya8BehaviorEv.cpp
+++ b/src/_ZN7Chuckya8BehaviorEv.cpp
@@ -92,7 +92,7 @@ extern "C" int _ZN7Chuckya8BehaviorEv(char* c)
     _ZN9Animation7AdvanceEv(c + 0x350);
 
     {
-        char* o = (char*)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF);
+        char* o = (char*)(((int)c + 0x300));
         (*(void(**)(void*))(*(int*)o + 0xc))(o);
     }
 

--- a/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
+++ b/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
@@ -95,7 +95,7 @@ extern "C" void _ZN7Message30DisplayCourseNameForStarSelectEj(struct Message *se
 
     data_0209d6c0 = 1;
     {
-        StarEntry* e = (StarEntry*)(int)(((long long)(int)((char*)data_0209d708 + 0x1470)) & 0xFFFFFFFFFFFFFFFFLL);
+        StarEntry* e = (StarEntry*)(int)(((long long)(int)((char*)data_0209d708 + 0x1470)));
         data_0209d6f0 = e;
         sum = data_0209d6fc + 0x28;
         sum += data_0209d70c[1];

--- a/src/_ZN7Minimap6RenderEv.cpp
+++ b/src/_ZN7Minimap6RenderEv.cpp
@@ -177,7 +177,7 @@ int Minimap::Render()
                 if (lvl >= 0) {
                     if (*p != 4) {
                         if (data_ov002_02111148 == lvl) {
-                            *(u8 *)(((int)((char*)this + i) + 0x22e) & 0xFFFFFFFFFFFFFFFF) += data_0208ee44;
+                            *(u8 *)(((int)((char*)this + i) + 0x22e)) += data_0208ee44;
                             if ((u32)this->unk22E[i] >= 0xc)
                                 this->unk22E[i] = 0;
                             {
@@ -235,7 +235,7 @@ int Minimap::Render()
         }
 
         if (!(data_0209caa0[1] & 0x40) && (data_0209caa0[2] & 0x20000)) {
-            *(u8 *)(((int)this + 0x256) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)this + 0x256)) += 1;
             if ((u32)this->unk256 >= 5)
                 this->unk256 = 0;
             if (this->unk248 >= 0) {

--- a/src/_ZN7Minimap8BehaviorEv.cpp
+++ b/src/_ZN7Minimap8BehaviorEv.cpp
@@ -115,9 +115,9 @@ extern s32  GetMinimapScale(s32 idx);
 extern void UpdateMinimap(s32 *a, s32 b, s32 c, s32 d, s32 e);
 }
 
-#define F218 (*(s32 *)(((int)self + 0x218) & 0xFFFFFFFFFFFFFFFF))
-#define FANG (*(s16 *)(((int)self + 0x21c) & 0xFFFFFFFFFFFFFFFF))
-#define F254 (*(u8 *)(((int)self + 0x254) & 0xFFFFFFFFFFFFFFFF))
+#define F218 (*(s32 *)(((int)self + 0x218)))
+#define FANG (*(s16 *)(((int)self + 0x21c)))
+#define F254 (*(u8 *)(((int)self + 0x254)))
 #define FMUL(a, b) ((s32)((((long long)(a) * (b)) + 0x800) >> 12))
 
 extern "C" s32 _ZN7Minimap8BehaviorEv(Minimap *self);
@@ -276,7 +276,7 @@ L4d8:
     self->f60 = self->f1dc + ((FMUL(self->v1f4.x, self->f1d4) + 0x800) >> 12);
     self->f64 = self->f1dc + ((FMUL(self->v1f4.z, self->f1d4) + 0x800) >> 12);
 
-    op = (Vector3 *)(((int)obj + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    op = (Vector3 *)(((int)obj + 0x5c));
     v14 = *op;
     _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v14);
     _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v14, &self->v1f4, self->f1f0, self->ang, &v8);
@@ -314,7 +314,7 @@ L738:
     for (i = 0; i < 4; i++) {
         Obj *o = data_0209f394[i];
         if (o != 0) {
-        v2c = *(Vector3 *)(((int)o + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        v2c = *(Vector3 *)(((int)o + 0x5c));
         _ZN7Minimap21FixTHIPaintingRoomPosER7Vector3(&v2c);
         _ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_(&v2c, &self->v1f4, self->f1f0, self->ang, &v8);
         self->a70[i] = (v8.x + 0x800) >> 12;

--- a/src/_ZN7Skeeter8BehaviorEv.cpp
+++ b/src/_ZN7Skeeter8BehaviorEv.cpp
@@ -63,7 +63,7 @@ extern "C" int _ZN7Skeeter8BehaviorEv(void* self)
         if (*(u8*)(c + 0x3a1) == 3) {
             _Z14ApproachLinearRsss((s16*)(c + 0x8c), -32767, 0x500);
             if (AngleDiff(*(s16*)(c + 0x8c), -32767) < 0x1000) {
-                s16* p8e = (s16*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+                s16* p8e = (s16*)(((int)c + 0x8e));
                 *p8e += 0x1000;
             }
         }

--- a/src/_ZN7Tornado8BehaviorEv.cpp
+++ b/src/_ZN7Tornado8BehaviorEv.cpp
@@ -21,7 +21,7 @@ int Tornado::Behavior()
     case 2: func_ov096_02136fd4(); break;
     }
     {
-        unsigned short *p = (unsigned short*)(((int)((char *)this) + 0x350) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *p = (unsigned short*)(((int)((char *)this) + 0x350));
         *p = *p + 1;
     }
     if (s != unk_35c) {

--- a/src/_ZN8BigBully8BehaviorEv.cpp
+++ b/src/_ZN8BigBully8BehaviorEv.cpp
@@ -32,13 +32,13 @@ int BigBully::Behavior()
         m = unk_0a0;
         if (t >= m) m = t;
         unk_0a8 = m;
-        p = (int*)(((int)((char*)this) + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        p = (int*)(((int)((char*)this) + 0x60));
         *p = *p + unk_0a8;
         _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(((char*)this), ((char*)this) + 0x174, 0);
         if (_ZNK12WithMeshClsn10IsOnGroundEv((char*)&mWithMeshClsn) != 0) {
             u8* q;
             func_0200fa8c(((char*)this), 0);
-            q = (u8*)(((int)((char*)this) + 0x3fe) & 0xFFFFFFFFFFFFFFFF);
+            q = (u8*)(((int)((char*)this) + 0x3fe));
             *q = *q + 1;
         }
         func_ov064_02116bac(((char*)this));

--- a/src/_ZN8CapEnemy12UpdateCapPosERK7Vector3RK10Vector3_16.cpp
+++ b/src/_ZN8CapEnemy12UpdateCapPosERK7Vector3RK10Vector3_16.cpp
@@ -27,11 +27,11 @@ void CapEnemy::UpdateCapPos(const Vector3& pos, const Vector3_16& rot)
     CapFlags* fl = (CapFlags*)(self + 0x17f);
     if (fl->b2 != 0 || fl->b1 == 0) {
         if ((*(unsigned char*)(self + 0x113) & 0xf) < 6) {
-            unsigned char* p = (unsigned char*)(((long long)(int)(self + 0x113)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char* p = (unsigned char*)(((long long)(int)(self + 0x113)));
             *p = *p | 0x80;
         }
     } else {
-        unsigned char* p = (unsigned char*)(((long long)(int)(self + 0x113)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char* p = (unsigned char*)(((long long)(int)(self + 0x113)));
         *p = *p & 7;
     }
     if (*(unsigned char*)(self + 0x113) >= 6) return;

--- a/src/_ZN8CapEnemy16GetCapEatenOffItERK7Vector3.c
+++ b/src/_ZN8CapEnemy16GetCapEatenOffItERK7Vector3.c
@@ -16,8 +16,8 @@ int _ZN8CapEnemy16GetCapEatenOffItERK7Vector3(unsigned char *c, const struct Vec
         unsigned char idx;
         *(int *)(p + 0xd0) = *(int *)(c + 0xd0);
         *(unsigned char **)(*(unsigned char **)(c + 0xd0) + 0x360) = p;
-        *(int *)(((int)p + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x20000;
-        *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x20000;
+        *(int *)(((int)p + 0xb0)) |= 0x20000;
+        *(int *)(((int)c + 0xb0)) &= ~0x20000;
         *(int *)(c + 0xd0) = 0;
         if (c[0x110] == 0) {
             idx = c[0x113] & 7;

--- a/src/_ZN8CapEnemy6AddCapEj.c
+++ b/src/_ZN8CapEnemy6AddCapEj.c
@@ -45,12 +45,12 @@ int _ZN8CapEnemy6AddCapEj(struct CapEnemy *this_, unsigned int param)
         return _ZN13SharedFilePtr7ReleaseEv(func_020ff028[this_->f113]);
     }
 
-    *(int *)(((long long)(int)((char *)this_ + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+    *(int *)(((long long)(int)((char *)this_ + 0xb0))) &= ~1;
     func_ov001_020ab228((char *)this_ + 0x164, (char *)this_, this_->f113, this_->f112, this_->f110 != 0);
 
     int result = func_02005e28((unsigned char *)this_);
     if (result != 0) {
-        unsigned char *p = (unsigned char *)(((long long)(int)((char *)this_ + 0x113)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char *)(((long long)(int)((char *)this_ + 0x113)));
         result = *p | 0x80;
         *p = result;
     }

--- a/src/_ZN8Fireball13InitResourcesEv.cpp
+++ b/src/_ZN8Fireball13InitResourcesEv.cpp
@@ -24,7 +24,7 @@ int Fireball::InitResources()
     {
         unsigned char v = unk_36d;
         if (v != 0 && v != 4) {
-            *(unsigned int*)(((int)((char*)&unk_12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+            *(unsigned int*)(((int)((char*)&unk_12c))) |= 0x8000;
         }
     }
     return 1;

--- a/src/_ZN8Fireball8BehaviorEv.cpp
+++ b/src/_ZN8Fireball8BehaviorEv.cpp
@@ -104,7 +104,7 @@ extern "C" int _ZN8Fireball8BehaviorEv(void* arg0) {
             found = _ZN5Actor10FindWithIDEj((u32)id134);
             if (found != 0) {
                 if (*(int*)(c + 0x130) & 0x10) {
-                    *(u32*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10000001;
+                    *(u32*)(((int)c + 0xb0)) &= ~0x10000001;
                     *(s16*)(c + 0x94) = Vec3_HorzAngle((char*)found + 0x5c, c + 0x5c);
                     *(int*)(c + 0x98) = 0xa000;
                     *(int*)(c + 0xa8) = 0x28000;
@@ -158,7 +158,7 @@ extern "C" int _ZN8Fireball8BehaviorEv(void* arg0) {
                 }
             }
         } else {
-            *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(int*)(((int)c + 0x128)) |= 1;
         }
     }
 
@@ -171,13 +171,13 @@ extern "C" int _ZN8Fireball8BehaviorEv(void* arg0) {
     *(int*)(c + 0xa4) = (lr * data_02082214[(*(u16*)(c + 0x94) >> 4) * 2]) / 4096;
     *(int*)(c + 0xa8) = (-*(int*)(c + 0x98) * data_02082214[(*(u16*)(c + 0x92) >> 4) * 2]) / 4096;
     *(int*)(c + 0xac) = (lr * data_02082214[(*(u16*)(c + 0x94) >> 4) * 2 + 1]) / 4096;
-    *(int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(c + 0xa4);
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(c + 0xa8);
-    *(int*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(c + 0xac);
+    *(int*)(((int)c + 0x5c)) += *(int*)(c + 0xa4);
+    *(int*)(((int)c + 0x60)) += *(int*)(c + 0xa8);
+    *(int*)(((int)c + 0x64)) += *(int*)(c + 0xac);
 
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     _ZN12CylinderClsn6UpdateEv(c + 0x110);
-    *(int*)(((int)c + 0x360) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(c + 0x98);
+    *(int*)(((int)c + 0x360)) += *(int*)(c + 0x98);
 
     if (*(int*)(c + 0x360) > *(int*)(c + 0x364)
         || _ZNK12WithMeshClsn8IsOnWallEv(c + 0x144) != 0
@@ -206,7 +206,7 @@ extern "C" int _ZN8Fireball8BehaviorEv(void* arg0) {
         _ZN9ActorBase18MarkForDestructionEv(c);
     }
 
-    *(u16*)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(u16*)(((int)c + 0x100)) += 1;
     func_ov002_020f8b24(c);
     return 1;
 }

--- a/src/_ZN8MantaRay8BehaviorEv.cpp
+++ b/src/_ZN8MantaRay8BehaviorEv.cpp
@@ -50,7 +50,7 @@ extern "C" int _ZN8MantaRay8BehaviorEv(char* c)
         Vec3_Sub(&diff, (Vector3*)(c + 0x5c), &node);
         len = LenVec3(&diff);
         if (len == 0 || len <= 0x258000) {
-            (*(int*)(((int)c + 0x384) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(int*)(((int)c + 0x384)))++;
             if (*(int*)(c + 0x384) >= *(int*)(c + 0x380))
                 *(int*)(c + 0x384) = 0;
         }

--- a/src/_ZN8MugenBgm8BehaviorEv.cpp
+++ b/src/_ZN8MugenBgm8BehaviorEv.cpp
@@ -81,7 +81,7 @@ int MugenBgm::Behavior()
         if ((*((s32 *) (c + 0x60))) < h)
         {
           *((s32 *) (c + 0x60)) = h;
-          *((u8 *) ((((int) c) + 0x103) & 0xFFFFFFFFFFFFFFFF)) |= 1;
+          *((u8 *) ((((int) c) + 0x103))) |= 1;
         }
       }
       _ZN13RaycastGroundD1Ev(&rc);

--- a/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
+++ b/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
@@ -18,7 +18,7 @@ extern int data_0209ee84;
 extern int data_0209ee8c;
 extern void* data_020a0ea0;
 
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 
 extern "C" void _ZN8Particle10SysTracker10InitialiseEv(struct Particle__SysTracker *self) {
     signed char v = data_0209f2f8;

--- a/src/_ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb.cpp
@@ -17,7 +17,7 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
     int result;
 
     if (*(unsigned char *)(self + 4) == 0) {
-        *(int *)(((long long)(int)(sys + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(int *)(((long long)(int)(sys + 0x1c))) |= 2;
         node = *(char **)(sys + 8);
         while (node != 0) {
             *(unsigned short *)(node + 0x2e) = *(unsigned short *)(node + 0x2c);
@@ -25,7 +25,7 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
         }
         return 1;
     } else {
-        *(int *)(((long long)(int)(sys + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+        *(int *)(((long long)(int)(sys + 0x1c))) &= ~2;
         node = *(char **)(sys + 8);
         while (node != 0) {
             wp.x = *(int *)(node + 0x14) + *(int *)(node + 0x8);
@@ -45,9 +45,9 @@ int _ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb(char *self, char *sys, int
                         cv.x = (cv.x < 0) ? 0x20000 : -0x20000;
                     }
                     MulVec3Mat4x3(&cv, &data_0209b41c, &out);
-                    *(int *)(((long long)(int)(node + 0x14)) & 0xFFFFFFFFFFFFFFFFLL) += out.x - wp.x;
-                    *(int *)(((long long)(int)(node + 0x18)) & 0xFFFFFFFFFFFFFFFFLL) += out.y - wp.y;
-                    *(int *)(((long long)(int)(node + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL) += out.z - wp.z;
+                    *(int *)(((long long)(int)(node + 0x14))) += out.x - wp.x;
+                    *(int *)(((long long)(int)(node + 0x18))) += out.y - wp.y;
+                    *(int *)(((long long)(int)(node + 0x1c))) += out.z - wp.z;
                 }
             }
             node = *(char **)node;

--- a/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -23,7 +23,7 @@ namespace Particle {
 
 void Particle::SimpleCallback::SpawnParticles(System& sys)
 {
-    *(u32*)(((int)&sys + 0x1c) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(u32*)(((int)&sys + 0x1c)) |= 2;
     sys.field_3a = this->field_4;
     func_02049d60(data_0209ee74->p);
 }

--- a/src/_ZN8Particle16FitWaterCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle16FitWaterCallback8OnUpdateERNS_6SystemEb.cpp
@@ -8,10 +8,10 @@ int _ZN8Particle16FitWaterCallback8OnUpdateERNS_6SystemEb(void* thiz, System* sy
     Node* node = sys->head;
     int v;
     if (b) {
-        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        int* flags = (int*)(((long)sys + 0x1c));
         *flags &= ~2;
     } else {
-        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        int* flags = (int*)(((long)sys + 0x1c));
         *flags |= 2;
         if (node == 0) return 0;
     }

--- a/src/_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb.cpp
@@ -6,10 +6,10 @@ extern "C" int _ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb(void* thi
 int _ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb(void* thiz, System* sys, int b) {
     Node* node = sys->head;
     if (b) {
-        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        int* flags = (int*)(((long)sys + 0x1c));
         *flags &= ~2;
     } else {
-        int* flags = (int*)(((long)sys + 0x1c) & 0xFFFFFFFFFFFFFFFF);
+        int* flags = (int*)(((long)sys + 0x1c));
         *flags |= 2;
         if (node == 0) return 0;
     }

--- a/src/_ZN8Particle24CheckWaterRippleCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle24CheckWaterRippleCallback8OnUpdateERNS_6SystemEb.cpp
@@ -27,9 +27,9 @@ bool Particle::CheckWaterRippleCallback::OnUpdate(Particle::System &sys, bool b)
 {
     Particle::Node *node = (Particle::Node*)sys.f0[2];
     if (b) {
-        *(int *)(((int)&sys + 0x1c) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+        *(int *)(((int)&sys + 0x1c)) &= ~2;
     } else {
-        *(int *)(((int)&sys + 0x1c) & 0xFFFFFFFFFFFFFFFF) |= 2;
+        *(int *)(((int)&sys + 0x1c)) |= 2;
         if (node == 0) return false;
     }
     while (node != 0) {

--- a/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
+++ b/src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp
@@ -72,15 +72,15 @@ int Platform::UpdateKillByMegaChar(short a, short b, short c, Fix12<int> d)
     RaycastLine ray;
     ray.SetObjAndLine(this->pos, vmid, (Actor*)this);
     if (ray.DetectClsn()) {
-        *(short*)((int)(((long long)(int)((char*)this + 0x94)) & 0xFFFFFFFFFFFFFFFFLL)) =
-            (short)(*(short*)((int)(((long long)(int)((char*)this + 0x94)) & 0xFFFFFFFFFFFFFFFFLL)) + 0x8000);
+        *(short*)((int)(((long long)(int)((char*)this + 0x94)))) =
+            (short)(*(short*)((int)(((long long)(int)((char*)this + 0x94)))) + 0x8000);
     }
-    *(short*)((int)(((long long)(int)((char*)this + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL)) =
-        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL)) + a);
-    *(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL)) =
-        (short)(*(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL)) + b);
-    *(short*)((int)(((long long)(int)((char*)this + 0x90)) & 0xFFFFFFFFFFFFFFFFLL)) =
-        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x90)) & 0xFFFFFFFFFFFFFFFFLL)) + c);
+    *(short*)((int)(((long long)(int)((char*)this + 0x8c)))) =
+        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x8c)))) + a);
+    *(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)))) =
+        (short)(*(short*)((int)(((long long)(unsigned int)((char*)this + 0x8e)))) + b);
+    *(short*)((int)(((long long)(int)((char*)this + 0x90)))) =
+        (short)(*(short*)((int)(((long long)(int)((char*)this + 0x90)))) + c);
     ((Actor*)this)->UpdatePos(0);
     if (DecIfAbove0_Byte(&this->f_31d) == 0) {
         ((PlatformVT*)this)->v31();

--- a/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
@@ -8,7 +8,7 @@ extern "C" int _ZN8SaveData14SaveDataToCartEPcjj(void* data, u32 size, u32 count
 struct SaveData { static int SaveFile(u32 idx, FileSaveData* data); };
 
 int SaveData::SaveFile(u32 idx, FileSaveData* data) {
-    int* ip = (int*)(((long long)(int)((char*)data + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* ip = (int*)(((long long)(int)((char*)data + 4)));
     *ip = *ip | 1;
     if (_ZN8SaveData14SaveDataToCartEPcjj(data, 0x44, idx) == 0)
         return 1;

--- a/src/_ZN8ShipWing8BehaviorEv.cpp
+++ b/src/_ZN8ShipWing8BehaviorEv.cpp
@@ -20,7 +20,7 @@ int ShipWing::Behavior()
         if (unk_4e8 == 0) {
             unk_4e9 = 0;
         } else {
-            unsigned char* pc9 = (unsigned char*)(((int)((char*)this) + 0x4e9) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char* pc9 = (unsigned char*)(((int)((char*)this) + 0x4e9));
             *pc9 = *pc9 + 1;
             unk_4e8 = 0;
         }

--- a/src/_ZN8SignPost8BehaviorEv.cpp
+++ b/src/_ZN8SignPost8BehaviorEv.cpp
@@ -4,7 +4,7 @@ typedef unsigned char u8;
 
 struct Vector3 { int x, y, z; };
 enum Bool { FALSE, TRUE };
-#define LD(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LD(p) ((int)(((long long)(int)(p))))
 
 extern "C" unsigned int data_0209b454;
 

--- a/src/_ZN8Squasher8BehaviorEv.c
+++ b/src/_ZN8Squasher8BehaviorEv.c
@@ -19,16 +19,16 @@ int _ZN8Squasher8BehaviorEv(char *c)
     switch (*(u8 *)(c + 0x322)) {
     case 0:
         if (_ZN5Actor13DistToCPlayerEv(c) < 0x3e8000) {
-            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)c + 0x322)))++;
             _ZN5Sound9PlayBank3EjRK7Vector3(0x43, (struct Vec3 *)(c + 0x74));
         }
         break;
     case 1:
-        *(s16 *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF) -= 0x40;
+        *(s16 *)(((int)c + 0x31e)) -= 0x40;
         if (*(s16 *)(c + 0x31e) <= -0x1000) {
             *(s16 *)(c + 0x31e) = -0x1000;
         }
-        *(s16 *)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF) += *(s16 *)(c + 0x31e);
+        *(s16 *)(((int)c + 0x8c)) += *(s16 *)(c + 0x31e);
         if (*(s16 *)(c + 0x8c) <= -0x4000) {
             struct Vec3 off;
             struct Vec3 pos;
@@ -56,33 +56,33 @@ int _ZN8Squasher8BehaviorEv(char *c)
             tmp[2] = off.z;
             func_0200fa04(c, tmp, 1);
 
-            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)c + 0x322)))++;
         }
         break;
     case 2:
         if (*(u16 *)(c + 0x320) >= 0x3c) {
-            u8 *st = (u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF);
+            u8 *st = (u8 *)(((int)c + 0x322));
             *(s16 *)(c + 0x31e) = 0x80;
             (*st)++;
             _ZN5Sound9PlayBank3EjRK7Vector3(0x45, (struct Vec3 *)(c + 0x74));
         } else {
-            (*(u16 *)(((int)c + 0x320) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u16 *)(((int)c + 0x320)))++;
         }
         break;
     case 3:
-        *(s16 *)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF) += *(s16 *)(c + 0x31e);
+        *(s16 *)(((int)c + 0x8c)) += *(s16 *)(c + 0x31e);
         if (*(s16 *)(c + 0x8c) >= 0) {
             *(s16 *)(c + 0x31e) = 0;
             *(s16 *)(c + 0x8c) = 0;
             *(s16 *)(c + 0x320) = 0;
-            (*(u8 *)(((int)c + 0x322) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)c + 0x322)))++;
         }
         break;
     case 4:
         if (*(u16 *)(c + 0x320) >= 0x3c) {
             *(u8 *)(c + 0x322) = 0;
         } else {
-            (*(u16 *)(((int)c + 0x320) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u16 *)(((int)c + 0x320)))++;
         }
         break;
     }

--- a/src/_ZN8YoshiEgg8BehaviorEv.cpp
+++ b/src/_ZN8YoshiEgg8BehaviorEv.cpp
@@ -31,7 +31,7 @@ int YoshiEgg::Behavior()
             vmid.x = 0;
             vmid.y = 0;
             vmid.z = 0;
-            ang = (short *)(((int)*(char **)((char *)&mPlayer) + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+            ang = (short *)(((int)*(char **)((char *)&mPlayer) + 0x8c));
             Matrix4x3_FromRotationZXYExt(&data_020a0e68, ang[0], ang[1], ang[2]);
             MulVec3Mat4x3(&vin, &data_020a0e68, &vmid);
             Vec3_Add(&vout, *(char **)((char *)&mPlayer) + 0x5c, &vmid);
@@ -48,7 +48,7 @@ int YoshiEgg::Behavior()
     {
         unsigned char idx = unk_420;
         if (*(unsigned char *)(((char *)this) + idx + 0x421) != 0) {
-            unsigned char *cp = (unsigned char *)(((int)((char *)this) + 0x420) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char *cp = (unsigned char *)(((int)((char *)this) + 0x420));
             *cp = *cp + 1;
         }
     }

--- a/src/_ZN9Animation7AdvanceEv.cpp
+++ b/src/_ZN9Animation7AdvanceEv.cpp
@@ -8,7 +8,7 @@ void _ZN9Animation7AdvanceEv(struct Animation* a) {
     if ((f & 0xc0000000) == 0) {
         a->frame = (a->frame + a->speed + (int)len) % (int)len;
     } else {
-        int *pFrame = (int *)(((int)a + 8) & 0xFFFFFFFFFFFFFFFF);
+        int *pFrame = (int *)(((int)a + 8));
         *pFrame = *pFrame + a->speed;
         if (a->frame < 0) {
             a->frame = 0;

--- a/src/_ZN9ArrowLift8BehaviorEv.cpp
+++ b/src/_ZN9ArrowLift8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int ArrowLift::Behavior()
     func_ov029_021117ac(((char*)this));
     if (unk_15d != 0) {
         char* p;
-        s16* a = (s16*)(((int)((char*)this) + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        s16* a = (s16*)(((int)((char*)this) + 0x8e));
         *a = *a + 0x400;
         p = _ZN5Actor10FindWithIDEj(unk_158);
         if (p != 0) {

--- a/src/_ZN9BlueFlame8BehaviorEv.c
+++ b/src/_ZN9BlueFlame8BehaviorEv.c
@@ -36,7 +36,7 @@ int _ZN9BlueFlame8BehaviorEv(char *self)
     *(int *)(self + 0x5c) = *(int *)(self + 0xd4);
     *(int *)(self + 0x60) = *(int *)(self + 0xd8);
     *(int *)(self + 0x64) = *(int *)(self + 0xdc);
-    *(int *)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xc0000;
+    *(int *)((int)(self + 0xb0)) &= ~0xc0000;
 
     if ((int)(*(unsigned short *)(self + 0xc) == 0x13d) != 0)
         func_020228dc(pos.x, pos.y, pos.z);

--- a/src/_ZN9Butterfly8BehaviorEv.cpp
+++ b/src/_ZN9Butterfly8BehaviorEv.cpp
@@ -59,7 +59,7 @@ extern "C" int _ZN9Butterfly8BehaviorEv(char* c)
             }
         }
         _ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn(c, 0);
-        (*(int*)(((int)c + 0x3e8) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(int*)(((int)c + 0x3e8)))++;
     }
 
     if (*(int*)(c + 0x3e4) != 4) {

--- a/src/_ZN9KoopaFlag8BehaviorEv.cpp
+++ b/src/_ZN9KoopaFlag8BehaviorEv.cpp
@@ -36,7 +36,7 @@ int KoopaFlag::Behavior()
     }
 
     if (mVictoryTimer != 0) {
-        *(unsigned short *)(((int)((char *)this) + 0x16C) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned short *)(((int)((char *)this) + 0x16C)) += 1;
         if (mVictoryTimer >= 0x5A) {
             if (_ZN5Sound7PlaySubEjjj5Fix12IiEb(0x1F, 0x7F, 0, 0x8777, 0) != 0) {
                 mVictoryTimer = 0;

--- a/src/_ZN9OneUpLogo8BehaviorEv.c
+++ b/src/_ZN9OneUpLogo8BehaviorEv.c
@@ -13,17 +13,17 @@ int _ZN9OneUpLogo8BehaviorEv(char *self)
 
     if (*(unsigned short *)(self + 0x14c) != 0) return 1;
 
-    *(int *)((int)(self + 0xa8) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(self + 0x9c);
+    *(int *)((int)(self + 0xa8)) += *(int *)(self + 0x9c);
     if (*(int *)(self + 0xa8) < *(int *)(self + 0xa0))
         *(int *)(self + 0xa8) = *(int *)(self + 0xa0);
-    *(int *)((int)(self + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(self + 0xa8);
+    *(int *)((int)(self + 0x60)) += *(int *)(self + 0xa8);
 
     switch (*(u8 *)(self + 0x14e)) {
     case 0:
         if (*(int *)(self + 0x60) < *(int *)(self + 0x140)) {
             *(int *)(self + 0x60) = *(int *)(self + 0x140);
             *(int *)(self + 0xa8) = 0xf000;
-            (*(u8 *)((int)(self + 0x14e) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8 *)((int)(self + 0x14e)))++;
         }
         break;
     case 1:
@@ -40,7 +40,7 @@ int _ZN9OneUpLogo8BehaviorEv(char *self)
     if (*(int *)(self + 0x138) != 0) {
         char *other = _ZN5Actor10FindWithIDEj(*(int *)(self + 0x138));
         if (other != 0) {
-            struct V3 *op = (struct V3 *)((int)(other + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            struct V3 *op = (struct V3 *)((int)(other + 0x5c));
             int oy;
             pos.x = op->x;
             pos.y = oy = op->y;

--- a/src/_ZN9PowerStar8BehaviorEv.cpp
+++ b/src/_ZN9PowerStar8BehaviorEv.cpp
@@ -36,7 +36,7 @@ int PowerStar::Behavior()
         if (state >= 5 && state <= 7 && *(void **)((char *)&mEatingPlayer) != 0) {
             func_ov002_020d718c(*(void **)((char *)&mEatingPlayer));
             mEatingPlayer = 0;
-            *(int *)((int)((char *)&unk_0b0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000;
+            *(int *)((int)((char *)&unk_0b0)) &= ~0xe0000;
             func_ov002_020e84ec(((char *)this));
             _ZN12CylinderClsn5ClearEv((char *)&mCylinderClsn);
             return 1;
@@ -45,7 +45,7 @@ int PowerStar::Behavior()
             if ((int)((unk_0b0 & 0x4000000) != 0) != 0) {
                 char *p = *(char **)((char *)&mEatingPlayer);
                 if (p != 0)
-                    *(int *)((int)(p + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+                    *(int *)((int)(p + 0xb0)) |= 0x4000000;
             }
         }
         func_ov002_020e84ec(((char *)this));

--- a/src/_ZN9Submarine13InitResourcesEv.cpp
+++ b/src/_ZN9Submarine13InitResourcesEv.cpp
@@ -37,7 +37,7 @@ int Submarine::InitResources()
     unk_1a8 = mPosX;
     unk_1ac = mPosY;
     unk_1b0 = mPosZ;
-    *(int *)(((int)((char *)this) + 0x1ac) & 0xFFFFFFFFFFFFFFFF) -= 0x64000;
+    *(int *)(((int)((char *)this) + 0x1ac)) -= 0x64000;
 
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(((char *)this) + 0x114, (struct BCA_File *)data_ov026_02113f04.file, 0, 0x1000, 0);
 

--- a/src/_ZN9TinyCover8BehaviorEv.c
+++ b/src/_ZN9TinyCover8BehaviorEv.c
@@ -15,7 +15,7 @@ int _ZN9TinyCover8BehaviorEv(int *t)
                 _ZN9ActorBase18MarkForDestructionEv(t);
             }
         } else {
-            int *p = (int*)(((int)t + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int*)(((int)t + 0x60));
             *p -= 0x1000;
             t[0xce] = _ZN5Sound8PlayLongEjjjRK7Vector3j(t[0xce], 3, 0x96, (char*)t + 0x74, 0);
             if (t[0x18] <= t[0xcd]) {

--- a/src/_ZN9TowerStep8BehaviorEv.cpp
+++ b/src/_ZN9TowerStep8BehaviorEv.cpp
@@ -12,7 +12,7 @@ extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 int TowerStep::Behavior()
 {
   if (DecIfAbove0_Byte((char*)&unk_31e) == 0) {
-    short* p = (short*)(((int)((char*)this) + 0x94) & 0xFFFFFFFFFFFFFFFF);
+    short* p = (short*)(((int)((char*)this) + 0x94));
     *p = *p + 0x100;
     unk_08e = unk_094;
     unk_320 = _ZN5Sound8PlayLongEjjjRK7Vector3j(unk_320, 3, 0x88, (void*)((char*)&unk_074), 0);

--- a/src/func_020050dc.c
+++ b/src/func_020050dc.c
@@ -5,6 +5,6 @@ int func_020050dc(void *obj)
 {
     func_0200cb58(obj, 0x1e);
     func_0200cce4(obj);
-    *(int *)(((long long)(int)((char *)obj + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+    *(int *)(((long long)(int)((char *)obj + 0x154))) |= 0x100;
     return 1;
 }

--- a/src/func_02005110.c
+++ b/src/func_02005110.c
@@ -31,7 +31,7 @@ int func_02005110(char *self)
   s32 horzAngle;
   s32 mode;
   {
-    struct Vec3 *p = (struct Vec3 *) (((long long) ((int) ((*((char **) (self + 0x110))) + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL);
+    struct Vec3 *p = (struct Vec3 *) (((long long) ((int) ((*((char **) (self + 0x110))) + 0x5c))));
     eye.x = p->x;
     eye.y = p->y;
     eye.z = p->z;
@@ -76,7 +76,7 @@ int func_02005110(char *self)
     }
     fall = 0x2000;
     {
-      struct Vec3 *rawpos = (struct Vec3 *) (((long long) ((int) ((*((char **) (self + 0x110))) + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL);
+      struct Vec3 *rawpos = (struct Vec3 *) (((long long) ((int) ((*((char **) (self + 0x110))) + 0x5c))));
       s32 fallDist = Vec3_Dist(*((struct Vec3 **) (self + 0x11c)), rawpos);
       s32 t = fallDist - 0x200000;
       if (t > 0)

--- a/src/func_02007484.c
+++ b/src/func_02007484.c
@@ -9,7 +9,7 @@ int func_02007484(char *self)
 
     char *info = *(char **)(self + 0x110);
 
-    int *sub = (int *)(((long long)(int)(info + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *sub = (int *)(((long long)(int)(info + 0x5c)));
 
     Math_Function_0203b0fc((int *)(self + 0x8c), sub[0], 0x28, 0x7fffffff);
     Math_Function_0203b0fc((int *)(self + 0x94), sub[2], 0x28, 0x7fffffff);

--- a/src/func_02007548.c
+++ b/src/func_02007548.c
@@ -3,7 +3,7 @@ extern void func_02007d0c(void *self, Vec3 *src, int a2, int a3, int a4);
 
 int func_02007548(int p0)
 {
-    int *base = (int *)((*(int *)(p0 + 0x110) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    int *base = (int *)((*(int *)(p0 + 0x110) + 0x5c));
     int y0 = base[1] + 0xffecd000;
     int tz = base[2];
     int tx = base[0];

--- a/src/func_020079ac.c
+++ b/src/func_020079ac.c
@@ -19,8 +19,8 @@ int func_020079ac(char *self, unsigned char *p, int tag) {
         *(int*)(self + 0xb4) = *(int*)(self + 0x84);
         *(int*)(self + 0xb8) = *(int*)(self + 0x88);
     }
-    *(short*)(((int)self + 0x1a2) & 0xFFFFFFFFFFFFFFFF) -= ReadUnalignedShort(p);
-    *(short*)(((int)self + 0x1a4) & 0xFFFFFFFFFFFFFFFF) += ReadUnalignedShort(p + 2);
+    *(short*)(((int)self + 0x1a2)) -= ReadUnalignedShort(p);
+    *(short*)(((int)self + 0x1a4)) += ReadUnalignedShort(p + 2);
     func_02007c9c((const Vector3*)(self + 0x8c), (const Vector3*)(self + 0xb0),
                   &dist, &vert, &horz);
     vert = (short)(vert + *(short*)(self + 0x1a2));

--- a/src/func_02008080.c
+++ b/src/func_02008080.c
@@ -7,7 +7,7 @@ int func_02008080(void *param_1)
     int *dst;
 
     a = func_0200e55c(0x13);
-    dst = (int *)(((int)param_1 + 0x90) & 0xFFFFFFFFFFFFFFFF);
+    dst = (int *)(((int)param_1 + 0x90));
     *dst = *dst + *(int *)((char *)a + 0x60);
     return 1;
 }

--- a/src/func_020080b0.c
+++ b/src/func_020080b0.c
@@ -4,7 +4,7 @@ extern struct Actor *func_0200e55c(unsigned int ownerID);
 int func_020080b0(char *c)
 {
     struct Actor *obj = func_0200e55c(0x13);
-    char *base = (char *)(((long long)(int)((char *)obj + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    char *base = (char *)(((long long)(int)((char *)obj + 0x5c)));
 
     int z = *(int *)(base + 8);
     int y = *(int *)(base + 4) + *(int *)(c + 0x170);

--- a/src/func_02008cb4.c
+++ b/src/func_02008cb4.c
@@ -78,13 +78,13 @@ int func_02008cb4(char* c)
             if (_ZN11RaycastLine10DetectClsnEv(&rc1) != 0) {
                 _ZNK11SurfaceInfo12CopyNormalToER7Vector3(rc1.surf, &n1);
                 if (DotVec3((Vec3*)(c + 0xec), &n1) > 0) {
-                    *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+                    *(u32*)(((int)c + 0x154)) &= ~0x80000;
                     _ZN11RaycastLineD1Ev(&rc1);
                     return 0;
                 }
                 _ZN11RaycastLine10GetClsnPosEv(&cp1, &rc1);
                 if (Vec3_Dist((Vec3*)(c + 0xe0), &cp1) < 0x80000) {
-                    *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+                    *(u32*)(((int)c + 0x154)) &= ~0x80000;
                     _ZN11RaycastLineD1Ev(&rc1);
                     return 0;
                 }
@@ -93,8 +93,8 @@ int func_02008cb4(char* c)
                     if ((f & 0x40000) && *(u8*)(c + 0x1a6) != 0 && !(f & 0x80100)) {
                         int a = _ZN4cstd5atan2E5Fix12IiES1_(n1.x, n1.z);
                         if (AngleDiff(a, _ZN4cstd5atan2E5Fix12IiES1_(*(int*)(c + 0xec), *(int*)(c + 0xf4))) > 0x6000) {
-                            *(s16*)(((int)c + 0x186) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
-                            *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) |= 0x80000;
+                            *(s16*)(((int)c + 0x186)) += 0x8000;
+                            *(u32*)(((int)c + 0x154)) |= 0x80000;
                         }
                     }
                 }
@@ -124,7 +124,7 @@ int func_02008cb4(char* c)
     Vec3_Sub(&dir2, (Vec3*)(c + 0x8c), &v0);
     len = LenVec3(&dir2);
     if (len == 0) {
-        *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+        *(u32*)(((int)c + 0x154)) &= ~0x80000;
         return 0;
     }
     Vec3_MulScalarInPlace(&dir2, _ZN4cstd4fdivEii(0x60000, len));
@@ -133,7 +133,7 @@ int func_02008cb4(char* c)
     func_0200897c(c, &rc2);
     _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(&rc2, &v0, &end2, 0);
     if (_ZN11RaycastLine10DetectClsnEv(&rc2) == 0) {
-        *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+        *(u32*)(((int)c + 0x154)) &= ~0x80000;
         _ZN11RaycastLineD1Ev(&rc2);
         return 0;
     }
@@ -166,7 +166,7 @@ int func_02008cb4(char* c)
         *(u8*)(c + 0x1a6) = 0;
         *(u16*)(c + 0x1a0) = 0;
     }
-    *(u32*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+    *(u32*)(((int)c + 0x154)) &= ~0x80000;
     _ZN11RaycastLineD1Ev(&rc2);
     return 1;
 }

--- a/src/func_020094c0.c
+++ b/src/func_020094c0.c
@@ -3,6 +3,6 @@ extern void func_02009e70(void *obj);
 void func_020094c0(void *self)
 {
     *(unsigned int *)((char *)self + 0x118) = *(unsigned int *)((char *)self + 0x110);
-    *(unsigned int *)((int *)(((int)self + 0x154) & 0xFFFFFFFFFFFFFFFF)) |= 4;
+    *(unsigned int *)((int *)(((int)self + 0x154))) |= 4;
     func_02009e70(self);
 }

--- a/src/func_020095e4.c
+++ b/src/func_020095e4.c
@@ -28,7 +28,7 @@ int func_020095e4(void *cam)
         r7 = (data_0209f4ae[off] == 2) ? 0x240 : 0x200;
         old186 = *(short *)(c + 0x186);
         {
-            short *p = (short *)(((int)c + 0x186) & 0xFFFFFFFFFFFFFFFFLL);
+            short *p = (short *)(((int)c + 0x186));
             int a = func_02008abc(cam);
             *p -= (int)(((long long)r7 * a + 0x800) >> 12);
         }
@@ -41,7 +41,7 @@ int func_020095e4(void *cam)
         *(short *)(c + 0x17c) = *(short *)(c + 0x19e) + *(short *)(c + 0x186);
         old17e = *(short *)(c + 0x17e);
         {
-            short *p = (short *)(((int)c + 0x17e) & 0xFFFFFFFFFFFFFFFFLL);
+            short *p = (short *)(((int)c + 0x17e));
             *p += (int)(((long long)r7 * (long long)func_02008a70(cam) + 0x800) >> 12);
         }
         {

--- a/src/func_020097ec.c
+++ b/src/func_020097ec.c
@@ -30,7 +30,7 @@ int func_020097ec(Obj *obj)
     Vec3i *src;
 
     func_0200cb58(obj, 0x18);
-    src = (Vec3i *)(((int)obj->other + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    src = (Vec3i *)(((int)obj->other + 0x5c));
     obj->vec.x = src->x;
     obj->vec.y = src->y;
     obj->vec.z = src->z;

--- a/src/func_020098e0.c
+++ b/src/func_020098e0.c
@@ -2,7 +2,7 @@ typedef short s16;
 typedef unsigned char u8;
 typedef long long s64;
 
-#define LP(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LP(p) ((long long)(int)(p))
 
 extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
 extern int func_020091f8(void *a, int b, int c, int d);

--- a/src/func_02009d30.c
+++ b/src/func_02009d30.c
@@ -10,9 +10,9 @@ int func_02009d30(int *p)
 
     {
         int *tmp = *(int **)((char *)p + 0x110);
-        short *sp = (short *)(((int)p + 0x100) & 0xFFFFFFFFFFFFFFFF);
+        short *sp = (short *)(((int)p + 0x100));
         short h = *(short *)((char *)tmp + 0x8e);
-        unsigned int *addr = (unsigned int *)(((int)p + 0x154) & 0xFFFFFFFFFFFFFFFF);
+        unsigned int *addr = (unsigned int *)(((int)p + 0x154));
         sp[0x43] = (short)(h + 0x8000);
         *addr = *addr & ~0x100u;
     }

--- a/src/func_0200c394.c
+++ b/src/func_0200c394.c
@@ -40,7 +40,7 @@ body:
                 o = *(void **)(self + 0x114);
                 if (o) {
                     int qb = (int)o + 0x5c;
-                    *(int *)(self + 0x120) = *(int *)(qb & 0xFFFFFFFFFFFFFFFFLL);
+                    *(int *)(self + 0x120) = *(int *)(qb);
                     *(int *)(self + 0x124) = *(int *)(qb + 4);
                     *(int *)(self + 0x128) = *(int *)(qb + 8);
                 } else {

--- a/src/func_0200c66c.c
+++ b/src/func_0200c66c.c
@@ -117,7 +117,7 @@ int func_0200c66c(char* self, Vector3* pos, void** out2, void** out1, int arg5)
                     *out1 = (void*)&data_020873dc;
                     if (*(unsigned char*)((char*)*out2 + 1) == 2) {
                         if (*(void**)(self + 0x140) != *out1)
-                            *(u32*)(((int)self + 0x154) & 0xFFFFFFFFFFFFFFFF) |= 4;
+                            *(u32*)(((int)self + 0x154)) |= 4;
                     }
                     res = hval;
                 } else if (b0 == 6) {
@@ -138,7 +138,7 @@ int func_0200c66c(char* self, Vector3* pos, void** out2, void** out1, int arg5)
                         }
                     }
                 }
-                *(u32*)(((int)self + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~0x100;
+                *(u32*)(((int)self + 0x154)) &= ~0x100;
             }
         }
         if (*out1 != (void*)&data_02087094) *(void**)(self + 0x140) = *out1;

--- a/src/func_0200ca14.c
+++ b/src/func_0200ca14.c
@@ -6,7 +6,7 @@ void func_0200ca14(int r0, unsigned int r1, int r2)
         return;
 
     if (r2 == 0)
-        *(unsigned *)(((long long)(int)(r0 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20000;
+        *(unsigned *)(((long long)(int)(r0 + 0x154))) |= 0x20000;
     else
-        *(unsigned *)(((long long)(int)(r0 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000;
+        *(unsigned *)(((long long)(int)(r0 + 0x154))) |= 0x10000;
 }

--- a/src/func_0200cae4.cpp
+++ b/src/func_0200cae4.cpp
@@ -9,7 +9,7 @@ struct C {
 };
 extern "C" int func_0200cae4(C* c){
   if(c->flags & 0x4000){
-    volatile unsigned int* flags = (volatile unsigned int*)(((int)c + 0x154) & 0xFFFFFFFFFFFFFFFF);
+    volatile unsigned int* flags = (volatile unsigned int*)(((int)c + 0x154));
     *flags &= ~0x4000u;
     *flags |= 0x8000u;
   }

--- a/src/func_0200cce4.c
+++ b/src/func_0200cce4.c
@@ -37,7 +37,7 @@ void func_0200cce4(char* cam)
     u32 d;
 
     if (*(char**)(cam + 0x110) != 0) {
-        Vector3* p = (Vector3*)(((int)*(char**)(cam + 0x110) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        Vector3* p = (Vector3*)(((int)*(char**)(cam + 0x110) + 0x5c));
         *(int*)(cam + 0x98) = p->x;
         *(int*)(cam + 0x9c) = p->y;
         *(int*)(cam + 0xa0) = p->z;
@@ -53,7 +53,7 @@ void func_0200cce4(char* cam)
             *(s16*)(*(char**)(cam + 0x110) + 0x8e), &tmp1);
 
         d = func_020093d4(cam, *(int*)(*(char**)(cam + 0x13c) + 0x10));
-        *(int*)(((int)cam + 0x84) & 0xFFFFFFFFFFFFFFFF) += d;
+        *(int*)(((int)cam + 0x84)) += d;
 
         {
             u32 d2 = func_020093f4(cam, -*(int*)(*(char**)(cam + 0x13c) + 0x20));
@@ -91,7 +91,7 @@ void func_0200cce4(char* cam)
         if (_ZN13RaycastGround10DetectClsnEv(&ground) != 0) {
             *(int*)(cam + 0x90) = d + ground._[0x11];
         }
-        *(int*)(((int)cam + 0x90) & 0xFFFFFFFFFFFFFFFF) += func_020093d4(cam, 0x3c286);
+        *(int*)(((int)cam + 0x90)) += func_020093d4(cam, 0x3c286);
         {
             int diff;
             int base;
@@ -116,5 +116,5 @@ void func_0200cce4(char* cam)
         _ZN13RaycastGroundD1Ev(&ground);
         _ZN11RaycastLineD1Ev(&line);
     }
-    *(int*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) |= 4;
+    *(int*)(((int)cam + 0x154)) |= 4;
 }

--- a/src/func_0200d064.c
+++ b/src/func_0200d064.c
@@ -7,7 +7,7 @@ void func_0200d064(int param_1, unsigned int param_2)
   if (param_2 == tmp)
   {
     volatile int dummy;
-    unsigned int *addr = (unsigned int *) ((param_1 + 0x154) & 0xFFFFFFFFFFFFFFFF);
+    unsigned int *addr = (unsigned int *) ((param_1 + 0x154));
     unsigned int val = *addr;
     val &= ~2u;
     *addr = val;

--- a/src/func_0200d1e4.c
+++ b/src/func_0200d1e4.c
@@ -12,7 +12,7 @@ extern s32 data_02086f14[3];
 void func_0200d1e4(char *self)
 {
     char *info = *(char **)(self + 0x110);
-    char *base = (char *)(((long long)(int)(info + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    char *base = (char *)(((long long)(int)(info + 0x5c)));
 
     *(s32 *)(self + 0x98) = *(s32 *)(base + 0);
     *(s32 *)(self + 0x9c) = *(s32 *)(base + 4);
@@ -32,7 +32,7 @@ void func_0200d1e4(char *self)
 
     int v2 = *(s32 *)(*(char **)(self + 0x13c) + 0x10);
     unsigned int dResult = func_020093d4(self, v2);
-    *(s32 *)(((long long)(int)(self + 0x84)) & 0xFFFFFFFFFFFFFFFFLL) += dResult;
+    *(s32 *)(((long long)(int)(self + 0x84))) += dResult;
 
     int v3 = *(s32 *)(*(char **)(self + 0x13c) + 0x20);
     unsigned int r0b = func_020093f4(self, v3);
@@ -46,7 +46,7 @@ void func_0200d1e4(char *self)
     angle = *(short *)(*(char **)(self + 0x110) + 0x8e);
     Vec3_RotateYAndTranslate(self + 0x8c, self + 0x80, angle, temp2);
 
-    *(s32 *)(((long long)(int)(self + 0x90)) & 0xFFFFFFFFFFFFFFFFLL) += (int)(dResult - 0x8b000);
+    *(s32 *)(((long long)(int)(self + 0x90))) += (int)(dResult - 0x8b000);
 
     *(s32 *)(self + 0xa4) = 0;
     *(s32 *)(self + 0xa8) = 0xc3f9d;

--- a/src/func_0200d4b0.c
+++ b/src/func_0200d4b0.c
@@ -10,7 +10,7 @@ void func_0200d4b0(char* self, unsigned int playerID, int arg2)
         char* other;
         *(short*)(self + 0x19a) = *(short*)(self + 0x17c);
         other = *(char**)(self + 0x110);
-        *(int*)(((int)other + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20000000;
+        *(int*)(((int)other + 0xb0)) |= 0x20000000;
         func_0200ee8c(arg2);
     }
 }

--- a/src/func_0200e5fc.c
+++ b/src/func_0200e5fc.c
@@ -17,7 +17,7 @@ void* func_0200e5fc(u32 idx) {
     if (data_0209b284[idx] != 0) return 0;
     flag = 0x11;
     b = (data_0209f2d8 == 2) ? 1 : 0;
-    if ((int)(((long long)b) & 0xFFFFFFFFFFFFFFFFLL) != 0) {
+    if ((int)(((long long)b)) != 0) {
         if (_ZN8SaveData19IsCharacterUnlockedEj(idx) == 0) return 0;
         flag = 0;
     }

--- a/src/func_0200f760.c
+++ b/src/func_0200f760.c
@@ -7,10 +7,10 @@ void func_0200f760(void *self, char *actor)
 {
     unsigned char *p;
 
-    *(u32 *)(((int)actor + 0x18) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    *(u32 *)(((int)actor + 0x18)) &= ~2;
     p = _ZN5Actor13ClosestPlayerEv(self);
     if (p == 0) return;
     if (p[0x6fb] != 0) {
-        *(u32 *)(((int)(actor + 0x18)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(u32 *)(((int)(actor + 0x18))) |= 2;
     }
 }

--- a/src/func_0200fa04.c
+++ b/src/func_0200fa04.c
@@ -12,12 +12,12 @@ int func_0200fa04(int a, Vector3* pos, int flag)
     RaycastGround rc;
     if (flag) {
         _ZN13RaycastGroundC1Ev(&rc);
-        *(int*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFLL) += 0x32000;
+        *(int*)(((int)pos + 4)) += 0x32000;
         _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(&rc, pos, 0);
         if (_ZN13RaycastGround10DetectClsnEv(&rc))
             pos->y = rc.clsnY;
         _ZN13RaycastGroundD1Ev(&rc);
     }
-    *(int*)(((int)pos + 4) & 0xFFFFFFFFFFFFFFFFLL) += 0x78000;
+    *(int*)(((int)pos + 4)) += 0x78000;
     return _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x1b, pos->x, pos->y, pos->z);
 }

--- a/src/func_02012468.c
+++ b/src/func_02012468.c
@@ -10,7 +10,7 @@ extern char data_0209b53c;
 
 int func_02012468(int a, int b, int c, int d, int e, int f, int g, short h)
 {
-    int dd = (int)(((long long)d) & 0xFFFFFFFFFFFFFFFFLL);
+    int dd = (int)(((long long)d));
     int x;
     char *p;
 

--- a/src/func_02016acc.c
+++ b/src/func_02016acc.c
@@ -6,7 +6,7 @@ void func_02016acc(char *a0, unsigned int mask)
 
     for (unsigned int i = 0; i < n; i++) {
         unsigned int nmask = ~mask;
-        *(unsigned int *)(((long long)(int)(q + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) &= nmask;
+        *(unsigned int *)(((long long)(int)(q + 0x24))) &= nmask;
         q += 0x30;
     }
 }

--- a/src/func_02016b24.c
+++ b/src/func_02016b24.c
@@ -12,7 +12,7 @@ void func_02016b24(struct Obj* o, u32 mask)
     char* p = o->pc;
     u32 i;
     for (i = 0; i < count; i++) {
-        *(u32*)(((int)p + 0x24) & 0xFFFFFFFFFFFFFFFFLL) |= mask;
+        *(u32*)(((int)p + 0x24)) |= mask;
         p += 0x30;
     }
 }

--- a/src/func_0201b388.c
+++ b/src/func_0201b388.c
@@ -58,7 +58,7 @@ void func_0201b388(int a0)
     n = data_0209d6a4;
     step = (a0 - 1) << 5;
 
-    sb = (u32)(((long long)(int)start) & 0xFFFFFFFFFFFFFFFFLL);
+    sb = (u32)(((long long)(int)start));
     for (j = 0; j < 0x10; j++)
     {
         for (i = 0; i < n; i++)

--- a/src/func_0201d850.c
+++ b/src/func_0201d850.c
@@ -66,7 +66,7 @@ void func_0201d850(u32 arg0)
     SetBg3Offset(0, 0);
 
     if (arg0 < 0xf) {
-        char *ep = (char *)(((int)data_0209d708 + 0x1468) & 0xFFFFFFFFFFFFFFFFLL);
+        char *ep = (char *)(((int)data_0209d708 + 0x1468));
         s32 base;
         s32 num;
         s32 n;
@@ -247,7 +247,7 @@ L_r4_else:
 
     data_0209d6b8 = 0;
     {
-        char *ep = (char *)(((int)data_0209d708 + 0x1470) & 0xFFFFFFFFFFFFFFFFLL);
+        char *ep = (char *)(((int)data_0209d708 + 0x1470));
         s32 base;
         s32 n;
         s32 tile;

--- a/src/func_0201eaac.c
+++ b/src/func_0201eaac.c
@@ -30,7 +30,7 @@ void func_0201eaac(void)
   data_0209d668 = 0;
   data_0209d654 = 0;
   data_0209d67c = 0;
-  data_0209d6a8 = 0 & 0xFFFFFFFFFFFFFFFF;
+  data_0209d6a8 = 0;
   data_0209d65c = 0;
   data_0209d66c = 0;
   data_0209d690 = 0;

--- a/src/func_02020768.c
+++ b/src/func_02020768.c
@@ -11,7 +11,7 @@ void func_02020768(char *thiz)
     if (*(unsigned char *)(thiz + 0x25) == 0)
         return;
 
-    acc = (int *)(((int)(thiz + 0x1c)) & 0xFFFFFFFFFFFFFFFF);
+    acc = (int *)(((int)(thiz + 0x1c)));
     *acc += data_0208ee44;
 
     if (*(int *)(thiz + 0x1c) < *(int *)(thiz + 0x18))
@@ -32,7 +32,7 @@ void func_02020768(char *thiz)
         return;
     }
 
-    cnt = (unsigned char *)(((int)(thiz + 0x24)) & 0xFFFFFFFFFFFFFFFF);
+    cnt = (unsigned char *)(((int)(thiz + 0x24)));
     *cnt -= 1;
     func_0202043c(thiz);
 }

--- a/src/func_02021cd4.c
+++ b/src/func_02021cd4.c
@@ -11,7 +11,7 @@ void func_02021cd4(char *self)
     *(unsigned short *)(elem + 0x28) = val;
 
     char *field = *(char **)(self + 0xc);
-    int *flagAddr = (int *)(((long long)(int)(field + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *flagAddr = (int *)(((long long)(int)(field + 0x1c)));
     int v = *flagAddr;
     v &= ~1;
     v |= 1;

--- a/src/func_02023624.c
+++ b/src/func_02023624.c
@@ -12,7 +12,7 @@ void* func_02023624(void)
         *(int**)self = data_0208e4b8;
         *(int**)self = _ZTV5Stage;
         {
-            unsigned char* f = (unsigned char*)(((long long)(int)(self + 0x13)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char* f = (unsigned char*)(((long long)(int)(self + 0x13)));
             *f |= 1;
             *f |= 4;
         }

--- a/src/func_0202f2c4.c
+++ b/src/func_0202f2c4.c
@@ -14,7 +14,7 @@ void func_0202f2c4(void)
 {
     int line;
 
-    *(int *)(((long long)(int)((char *)&data_023c0000 + 0x3ff8)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(int *)(((long long)(int)((char *)&data_023c0000 + 0x3ff8))) |= 2;
 
     line = *(volatile u16 *)0x4000006 + 1;
 


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 98 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
