### PR TITLE
readable: strip 93 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_0202f428.c
+++ b/src/func_0202f428.c
@@ -20,8 +20,8 @@ void dWipe_c_AdvanceFade(char *obj)
     case 0:
         return;
     case 1:
-        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += self->unk_020;
-        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += self->unk_024;
+        *(int *)(((long long)(int)(obj + 0x1c))) += self->unk_020;
+        *(int *)(((long long)(int)(obj + 0x20))) += self->unk_024;
         if (self->unk_01c >= 0x200000) {
             self->unk_01c = 0x200000;
             self->unk_00f = 0;
@@ -32,8 +32,8 @@ void dWipe_c_AdvanceFade(char *obj)
     case 2:
         return;
     case 3:
-        *(int *)(((long long)(int)(obj + 0x1c)) & 0xffffffffffffffffLL) += self->unk_020;
-        *(int *)(((long long)(int)(obj + 0x20)) & 0xffffffffffffffffLL) += self->unk_024;
+        *(int *)(((long long)(int)(obj + 0x1c))) += self->unk_020;
+        *(int *)(((long long)(int)(obj + 0x20))) += self->unk_024;
         if (self->unk_01c <= 0) {
             int b;
             self->unk_01c = 0;

--- a/src/func_02034b40.c
+++ b/src/func_02034b40.c
@@ -59,14 +59,14 @@ int func_02034b40(char* self)
             } while (1);
 
             if (*(u8*)(self + 0xe) != 0) {
-                *(int*)(((long long)(int)(self + 8)) & 0xFFFFFFFFFFFFFFFFLL) += (data_0208ee44 << 10);
+                *(int*)(((long long)(int)(self + 8))) += (data_0208ee44 << 10);
                 if (arr[0] == 0)
                     *(u8*)(self + 0xc) = 0x78;
             }
         } else {
             _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(0, attr, 0x80, 0x80, -1, -1, 0x1000, 0x1000, 0, -1);
             _ZN3OAM9RenderSubEP7OamAttrii(attr, 0x80, 0x80);
-            *(unsigned char*)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) -= data_0208ee44;
+            *(unsigned char*)(((long long)(int)(self + 0xc))) -= data_0208ee44;
             *(int*)(self + 8) = 0;
         }
     }

--- a/src/func_02034da4.c
+++ b/src/func_02034da4.c
@@ -30,7 +30,7 @@ int dScMB_c_Behavior(void *arg0)
         data_0209d454 = 0x10;
         *(volatile u32 *)0x4000000 = (*(volatile u32 *)0x4000000 & ~0x1f00) | 0x1000;
         *(volatile u32 *)0x4001000 = (*(volatile u32 *)0x4001000 & ~0x1f00) | 0x1000;
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         break;
 
     case 1:
@@ -39,21 +39,21 @@ int dScMB_c_Behavior(void *arg0)
             *(int *)&data_020a0c64 = r;
             if (r == 0) break;
         }
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 2:
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 3:
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 4:
         func_0201a244((int)&func_02034fbc, 0, 0xf, 0, 0x1000);
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 5:
         if (func_0201a1bc() == 0) break;
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 6:
         if (func_0203d7b8() != 0) break;
@@ -61,18 +61,18 @@ int dScMB_c_Behavior(void *arg0)
         func_0200f13c();
         func_0203d930();
         func_020308b4();
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         /* fallthrough */
     case 7:
         if (func_020308a8() == 0) break;
         _ZN5Scene14StartSceneFadeEjjt(6, 0, 0x7fff);
         func_02012790(0x11f);
-        (*(int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x60)))++;
         break;
     }
 
     if (*(int *)(self + 0x60) < 8) {
-        (*(int *)(((int)self + 0x64) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(((int)self + 0x64)))++;
         if (*(int *)(self + 0x64) >= 0x1518) {
             data_0209fc54 = 1;
         }

--- a/src/func_020353e0.c
+++ b/src/func_020353e0.c
@@ -1,4 +1,4 @@
 void func_020353e0(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x40;
+    *(unsigned char *)(((long long)(int)(self + 4))) &= ~0x40;
 }

--- a/src/func_020353f4.c
+++ b/src/func_020353f4.c
@@ -1,4 +1,4 @@
 void func_020353f4(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+    *(unsigned char *)(((long long)(int)(self + 4))) |= 0x40;
 }

--- a/src/func_02035414.c
+++ b/src/func_02035414.c
@@ -1,4 +1,4 @@
 void func_02035414(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20;
+    *(unsigned char *)(((long long)(int)(self + 4))) &= ~0x20;
 }

--- a/src/func_02035428.c
+++ b/src/func_02035428.c
@@ -1,4 +1,4 @@
 void func_02035428(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+    *(unsigned char *)(((long long)(int)(self + 4))) |= 0x20;
 }

--- a/src/func_02035468.c
+++ b/src/func_02035468.c
@@ -1,4 +1,4 @@
 void func_02035468(char *self)
 {
-    *(unsigned char *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+    *(unsigned char *)(((long long)(int)(self + 4))) |= 4;
 }

--- a/src/func_02035550.c
+++ b/src/func_02035550.c
@@ -1,4 +1,4 @@
 void func_02035550(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x4000;
 }

--- a/src/func_0203558c.c
+++ b/src/func_0203558c.c
@@ -1,4 +1,4 @@
 void func_0203558c(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x1000;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x1000;
 }

--- a/src/func_020355b4.c
+++ b/src/func_020355b4.c
@@ -1,4 +1,4 @@
 void func_020355b4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x800;
 }

--- a/src/func_020355c8.c
+++ b/src/func_020355c8.c
@@ -1,4 +1,4 @@
 void func_020355c8(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x800;
 }

--- a/src/func_020355e8.c
+++ b/src/func_020355e8.c
@@ -1,4 +1,4 @@
 void func_020355e8(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x400;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x400;
 }

--- a/src/func_020355fc.c
+++ b/src/func_020355fc.c
@@ -1,4 +1,4 @@
 void func_020355fc(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x400;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x400;
 }

--- a/src/func_020356d4.c
+++ b/src/func_020356d4.c
@@ -1,4 +1,4 @@
 void func_020356d4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x40;
 }

--- a/src/func_0203573c.c
+++ b/src/func_0203573c.c
@@ -1,4 +1,4 @@
 void func_0203573c(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x20;
 }

--- a/src/func_02035770.c
+++ b/src/func_02035770.c
@@ -1,4 +1,4 @@
 void func_02035770(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x200;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) &= ~0x200;
 }

--- a/src/func_02035784.c
+++ b/src/func_02035784.c
@@ -1,4 +1,4 @@
 void func_02035784(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+    *(unsigned int *)(((long long)(int)(self + 0x10))) |= 0x200;
 }

--- a/src/func_02036acc.c
+++ b/src/func_02036acc.c
@@ -1,6 +1,6 @@
 typedef unsigned char u8;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct ClsnResult { char pad[0x28]; } ClsnResult;

--- a/src/func_020371fc.cpp
+++ b/src/func_020371fc.cpp
@@ -32,7 +32,7 @@ void func_020371fc(char* self)
     if (_ZN6Player7IsInAirEv(*(void**)(self + 0x14))) return;
     {
         Vector3 pos;
-        Vector3* objpos = (Vector3*)(((int)*(char**)(self + 0x14) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        Vector3* objpos = (Vector3*)(((int)*(char**)(self + 0x14) + 0x5c));
         RaycastGround rg;
         pos.x = objpos->x;
         pos.y = objpos->y + *(int*)(self + 0x18);
@@ -43,7 +43,7 @@ void func_020371fc(char* self)
             int diff = objpos->y - cy;
             if (diff > 0 && diff < (*(int*)(self + 0x18) << 1)) {
                 objpos->y = cy;
-                *(unsigned char*)(((int)self + 0x90) & 0xFFFFFFFFFFFFFFFF) |= 4;
+                *(unsigned char*)(((int)self + 0x90)) |= 4;
                 _ZN10ClsnResultaSERKS_((ClsnResult*)(self + 0x94), &rg.clsn);
                 ((WithMeshClsn*)self)->SetGroundFlag();
             }

--- a/src/func_02037318.c
+++ b/src/func_02037318.c
@@ -7,13 +7,13 @@ void func_02037318(char *self)
 {
     const int *src;
 
-    *(u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x100;
+    *(u32 *)(((int)self + 0x10)) &= ~0x100;
     if (_ZNK12WithMeshClsn10IsOnGroundEv(self) == 0)
         return;
     if (_ZN6Player7IsInAirEv(*(void **)(self + 0x14)))
         return;
-    *(u32 *)(((int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
-    src = (const int *)(((int)self + 0x11c) & 0xFFFFFFFFFFFFFFFFLL);
+    *(u32 *)(((int)(self + 0x10))) |= 0x100;
+    src = (const int *)(((int)self + 0x11c));
     *(int *)(self + 0x1ac) = src[0];
     *(int *)(self + 0x1b0) = src[1];
     *(int *)(self + 0x1b4) = src[2];

--- a/src/func_02037b5c.c
+++ b/src/func_02037b5c.c
@@ -5,7 +5,7 @@ void func_02037b5c(char* c)
 {
     unsigned char* f;
     func_02037b1c(c);
-    f = (unsigned char*)(((int)c + 0x70) & 0xFFFFFFFFFFFFFFFF);
+    f = (unsigned char*)(((int)c + 0x70));
     *f &= ~1;
     *f &= ~4;
     *f &= ~8;

--- a/src/func_020408b0.c
+++ b/src/func_020408b0.c
@@ -37,7 +37,7 @@ void func_020408b0(unsigned short arg)
         p = (char *)data_020a0f54;
         data_020a0f28 = *(unsigned short *)(p + 0x36);
         p += 0x48;
-        ++*(unsigned short *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL);
+        ++*(unsigned short *)(int)(((long long)(int)(p)));
     }
     data_020a0f74 = _ZN6Memory8AllocateEji(0x420, 0x20);
     data_020a0f80 = _ZN6Memory8AllocateEji(0x100, 0x20);

--- a/src/func_02040f30.c
+++ b/src/func_02040f30.c
@@ -103,7 +103,7 @@ void func_02040f30(void *arg0)
       {
         return;
       }
-      m = (Cmd *) ((((int) thiz) + 0x14) & 0xFFFFFFFFFFFFFFFFLL);
+      m = (Cmd *) ((((int) thiz) + 0x14));
       switch (m->kind)
       {
         case 1:
@@ -122,7 +122,7 @@ void func_02040f30(void *arg0)
           void *p = *((void **) (data_020a1fc0 + 0x1c));
           void *a0 = *((void **) (((char *) p) + 8));
           *((int *) (data_020a1fc0 + 0x1c)) = 0;
-          *((int *) ((((int) p) + 0x28) & 0xFFFFFFFFFFFFFFFFLL)) += *((int *) (((char *) p) + 0x34));
+          *((int *) ((((int) p) + 0x28))) += *((int *) (((char *) p) + 0x34));
           func_0205cd5c(a0, 0);
           return;
         }

--- a/src/func_02041a94.c
+++ b/src/func_02041a94.c
@@ -5,7 +5,7 @@ void func_02041a94(char *base, char *node)
 {
     int *ctr;
     func_02041bbc((struct ListNode **)(base + 0x2708), (struct ListNode **)(base + 0x2700), (struct ListNode *)node);
-    ctr = (int *)(((long long)(int)(base + 0x2724)) & 0xFFFFFFFFFFFFFFFFLL);
+    ctr = (int *)(((long long)(int)(base + 0x2724)));
     *(int *)(node + 0x7c) = 0;
     *ctr -= 1;
 }

--- a/src/func_02041b60.c
+++ b/src/func_02041b60.c
@@ -8,7 +8,7 @@ struct ListNode *func_02041b60(char *base)
     node = *(struct ListNode **)((base + 0x2000) + 0x700);
     func_02041bbc((struct ListNode **)(base + 0x2700), (struct ListNode **)(base + 0x2708), node);
     *(int *)((char *)node + 0x7c) = 1;
-    ctr = (int *)(((long long)(int)(base + 0x2724)) & 0xFFFFFFFFFFFFFFFFLL);
+    ctr = (int *)(((long long)(int)(base + 0x2724)));
     *ctr += 1;
     return node;
 }

--- a/src/func_02041d28.c
+++ b/src/func_02041d28.c
@@ -29,7 +29,7 @@ void func_02041d28(char *r7, struct R6 *r6)
 
     if ((&data_020a1fc0)[3] != 0) {
         int bit;
-        int *q = (int *)(((int)r7 + 0x270c) & 0xFFFFFFFFFFFFFFFF);
+        int *q = (int *)(((int)r7 + 0x270c));
         mask = r6->f84;
         r6->f84 = 0;
         *q |= mask;

--- a/src/func_02041e14.c
+++ b/src/func_02041e14.c
@@ -39,7 +39,7 @@ extern Globals data_020a1fc0;
 
 void func_02041e14(void)
 {
-    Sub *s = (Sub *)(((int)&data_020a1fc0 + 0x440) & 0xFFFFFFFFFFFFFFFF);
+    Sub *s = (Sub *)(((int)&data_020a1fc0 + 0x440));
     Cmd cmd;
     Cmd cmd2;
 
@@ -50,10 +50,10 @@ void func_02041e14(void)
         return;
     }
 
-    *(int *)(((int)s + 0x270c) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
-    *(int *)(((int)s + 0x2710) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
-    *(int *)(((int)s + 0x271c) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
-    *(int *)(((int)s + 0x2728) & 0xFFFFFFFFFFFFFFFF) &= s->f2718;
+    *(int *)(((int)s + 0x270c)) &= s->f2718;
+    *(int *)(((int)s + 0x2710)) &= s->f2718;
+    *(int *)(((int)s + 0x271c)) &= s->f2718;
+    *(int *)(((int)s + 0x2728)) &= s->f2718;
 
     if (s->f2720 != 0 && s->f2724 == 0) {
         int v = s->f272c;
@@ -132,7 +132,7 @@ void func_02041e14(void)
             break;
         case 2:
             found->kind = 3;
-            *(int *)(((long long)(int)((char *)s + 0x271c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~mask;
+            *(int *)(((long long)(int)((char *)s + 0x271c))) &= ~mask;
             break;
         }
 
@@ -146,6 +146,6 @@ void func_02041e14(void)
         cmd2.byte8 = (u8)c;
         func_020656d4((u16)mask, &cmd2, 9, (u32)func_02042160);
         s->f2714 = 1;
-        *(int *)(((long long)(int)((char *)s + 0x270c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~mask;
+        *(int *)(((long long)(int)((char *)s + 0x270c))) &= ~mask;
     }
 }

--- a/src/func_02044334.cpp
+++ b/src/func_02044334.cpp
@@ -17,7 +17,7 @@ extern "C" void func_02044334(Obj *self)
         return;
     if (self->f4 == 0)
         return;
-    ctr = (short *)(((int)self + 6) & 0xFFFFFFFFFFFFFFFF);
+    ctr = (short *)(((int)self + 6));
     *ctr = *ctr - 1;
     if (self->f6 < 0)
         return;

--- a/src/func_020453c0.c
+++ b/src/func_020453c0.c
@@ -14,7 +14,7 @@ void func_020453c0(int *a, short *node, int *p2, int p3)
     int mla = idx * 0x24 + r6[5];
     unsigned short *dst;
     func_0204547c(r6, mla, r5, elem);
-    dst = (unsigned short*)(int)(((long long)(int)(elem + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+    dst = (unsigned short*)(int)(((long long)(int)(elem + 0x18)));
     *dst = (unsigned short)(*dst | *(unsigned short*)(elem + node[4] * 0x34 + 0x18));
     if (node[5] != 0)
         func_020453c0(a, (short*)((char*)node + (node[5] << 6)), r6, r5);

--- a/src/func_02045e44.c
+++ b/src/func_02045e44.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045e44(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= ~0xc0000000;
     *flags |= value << 30;
 }

--- a/src/func_02045ec4.c
+++ b/src/func_02045ec4.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045ec4(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= 0xffff;
     *flags |= value << 16;
 }

--- a/src/func_02045f4c.c
+++ b/src/func_02045f4c.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045f4c(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= 0xffff;
     *flags |= value << 16;
 }

--- a/src/func_02045fd4.c
+++ b/src/func_02045fd4.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02045fd4(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= 0xffff8000;
     *flags |= value;
 }

--- a/src/func_0204605c.c
+++ b/src/func_0204605c.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_0204605c(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= ~0x3f000000;
     *flags |= value << 24;
 }

--- a/src/func_02046088.c
+++ b/src/func_02046088.c
@@ -19,7 +19,7 @@ void func_02046088(Obj *self, int a, int b)
 
     for (i = 0; i < n; i++)
     {
-        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)));
         *p &= 0xc0ffff0f;
         *p |= b << 24;
         *p |= 0x80;

--- a/src/func_02046120.c
+++ b/src/func_02046120.c
@@ -19,7 +19,7 @@ void func_02046120(Obj *self, int a)
 
     for (i = 0; i < n; i++)
     {
-        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+        volatile u32 *p = (volatile u32 *)(((long long)(int)((int)self->data + i * 0x30 + 0x24)));
         *p &= 0xc0ffff0f;
         *p |= 0x40;
         *p |= 0x30;

--- a/src/func_02046208.c
+++ b/src/func_02046208.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02046208(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= ~0x1f0000;
     *flags |= value << 16;
 }

--- a/src/func_02046288.c
+++ b/src/func_02046288.c
@@ -4,7 +4,7 @@ struct Obj { void *pad0; struct Element *arr; };
 void func_02046288(struct Obj *self, unsigned int value, int index)
 {
     struct Element *e = &self->arr[index];
-    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *flags = (unsigned int *)(((long long)(int)&e->flags));
     *flags &= ~0x30;
     *flags |= value << 4;
 }

--- a/src/func_020462d0.c
+++ b/src/func_020462d0.c
@@ -95,7 +95,7 @@ void func_020462d0(Dst *d, Desc *h, ElemA *arr)
         if (c1 != -1) {
             u32 v = *(int *)((int)h->f18 + c1 * t14 + 0x10);
             shift = (v >> 0x1a) & 7;
-            *(int *)(((int)e + 0x1c) & 0xFFFFFFFFFFFFFFFF) |= v;
+            *(int *)(((int)e + 0x1c)) |= v;
         }
         idx2 = h->f28[i].f8;
         if (idx2 != -1) {
@@ -127,12 +127,12 @@ void func_020462d0(Dst *d, Desc *h, ElemA *arr)
             e2 = (ElemB *)((int)d->f8 + o34);
             e2->f18 = 0;
             if (s2->f10 != 0x1000)
-                *(u16 *)(((int)e2 + 0x18) & 0xFFFFFFFFFFFFFFFF) |= 1;
+                *(u16 *)(((int)e2 + 0x18)) |= 1;
             if (s2->f14 != 0x1000)
-                *(u16 *)(((int)e2 + 0x18) & 0xFFFFFFFFFFFFFFFF) |= 1;
+                *(u16 *)(((int)e2 + 0x18)) |= 1;
             if (s2->f18 != 0x1000)
-                *(u16 *)(((int)e2 + 0x18) & 0xFFFFFFFFFFFFFFFF) |= 1;
-            *(u16 *)(((int)e2 + 0x18) & 0xFFFFFFFFFFFFFFFF) |= e2[s2->f8].f18;
+                *(u16 *)(((int)e2 + 0x18)) |= 1;
+            *(u16 *)(((int)e2 + 0x18)) |= e2[s2->f8].f18;
             e2->fc = s2->f10;
             e2->f10 = s2->f14;
             e2->f14 = s2->f18;

--- a/src/func_02046e28.c
+++ b/src/func_02046e28.c
@@ -10,7 +10,7 @@ struct Model { u8 pad0[4]; struct Material *materials; };
 
 extern void Crash(void);
 
-#define LAUNDER(p) ((volatile u32 *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER(p) ((volatile u32 *)(int)(((long long)(int)(p))))
 
 void func_02046e28(struct Model *model, struct MatAnimData *anim, short frame)
 {

--- a/src/func_02047218.c
+++ b/src/func_02047218.c
@@ -2,7 +2,7 @@ typedef int fx32;
 typedef long long fx64;
 
 #define FX(a, b) ((fx32)(((fx64)(a) * (b) + 0x800) >> 12))
-#define PTR(base, off) ((fx32*)(int)(((long long)(int)((char*)(base) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define PTR(base, off) ((fx32*)(int)(((long long)(int)((char*)(base) + (off)))))
 
 void func_02047218(fx32 *m0, fx32 *m1, fx32 *dst, fx32 t)
 {

--- a/src/func_0204a730.c
+++ b/src/func_0204a730.c
@@ -40,7 +40,7 @@ extern void func_0204d150(void *, void *, u32);
 extern void func_0204d104(void *, void *, u32);
 extern void func_0204d0b8(void *, void *, u32);
 
-#define LP(T, e) ((T *)(int)(((long long)(int)(e)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LP(T, e) ((T *)(int)(((long long)(int)(e))))
 
 #pragma opt_common_subs off
 

--- a/src/func_0204b460.c
+++ b/src/func_0204b460.c
@@ -109,7 +109,7 @@ void func_0204b460(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204b81c.c
+++ b/src/func_0204b81c.c
@@ -111,7 +111,7 @@ void func_0204b81c(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204bbd8.c
+++ b/src/func_0204bbd8.c
@@ -97,7 +97,7 @@ void func_0204bbd8(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204be40.c
+++ b/src/func_0204be40.c
@@ -97,7 +97,7 @@ void func_0204be40(Self *self, Node *node)
     *(volatile u32 *)0x40004a4 = v;
     *(volatile u32 *)0x40004a4;
     {
-        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)) & 0xFFFFFFFFFFFFFFFFLL);
+        Cnt74 *qq = (Cnt74 *)(u32)(((s64)(int)((char *)c + 0x74)));
         qq->count++;
         if (c->cnt.count > c->cnt.limit)
             qq->count = c->cnt.start;

--- a/src/func_0204c304.c
+++ b/src/func_0204c304.c
@@ -116,7 +116,7 @@ void func_0204c304(Particle *self, u8 *mgr, List *freelist)
             p->h3a = self->h3a;
 
         {
-            Bf40 *q = (Bf40 *)(((s64)(int)((u8 *)p + 0x40)) & 0xFFFFFFFFFFFFFFFFLL);
+            Bf40 *q = (Bf40 *)(((s64)(int)((u8 *)p + 0x40)));
             q->f0 = (u16)((self->bf40.f0 * (self->bf40.f5 + 1)) >> 5);
             q->f5 = 0x1f;
         }

--- a/src/func_0204c584.c
+++ b/src/func_0204c584.c
@@ -216,7 +216,7 @@ void func_0204c584(u8 *self, List *list)
             *(u16 *)(p + 0x3a) = def->tex;
         }
         {
-            u16 *q = (u16 *)(((s64)(int)(p + 0x40)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *q = (u16 *)(((s64)(int)(p + 0x40)));
             *q = (u16)((*q & ~0x1f) | (*(u8 *)(self + 0x59) & 0x1f));
             *q = (u16)((*q & ~0x3e0) | 0x3e0);
         }

--- a/src/func_0204d0b8.c
+++ b/src/func_0204d0b8.c
@@ -1,7 +1,7 @@
 typedef unsigned short u16;
 
 void func_0204d0b8(void *p, int a, int b) {
-    u16 *c = (u16 *)(((long long)(int)((char *)p + 0x40)) & 0xFFFFFFFFFFFFFFFFLL);
+    u16 *c = (u16 *)(((long long)(int)((char *)p + 0x40)));
     u16 g = ((0xff - b) * 0x1f) / 0xff;
     *c = (*c & ~0x3e0) | ((g & 0x1f) << 5);
 }

--- a/src/func_0204d8e8.c
+++ b/src/func_0204d8e8.c
@@ -13,7 +13,7 @@ struct Node* func_0204d8e8(struct List* l, struct Node* n){
       n->prev->next = n->next;
     }
   }
-  int* pCnt = (int*)(((int)l + 4) & 0xFFFFFFFFFFFFFFFF);
+  int* pCnt = (int*)(((int)l + 4));
   *pCnt = *pCnt - 1;
   return n;
 }

--- a/src/func_0204d958.c
+++ b/src/func_0204d958.c
@@ -19,7 +19,7 @@ Node *func_0204d958(List *list)
             head->next->prev = 0;
         }
         {
-            int *cp = (int *)(((int)list + 4) & 0xFFFFFFFFFFFFFFFF);
+            int *cp = (int *)(((int)list + 4));
             *cp = *cp - 1;
         }
     }

--- a/src/func_0204d9a0.c
+++ b/src/func_0204d9a0.c
@@ -20,5 +20,5 @@ void func_0204d9a0(struct List* list, struct Node* node)
         list->tail->next = node;
         list->tail = node;
     }
-    *(int*)(((int)list + 4) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int*)(((int)list + 4)) += 1;
 }

--- a/src/func_0204dc84.c
+++ b/src/func_0204dc84.c
@@ -1,6 +1,6 @@
 void func_0204dc84(char *self)
 {
-    unsigned char *flags6 = (unsigned char *)(((long long)(int)(self + 6)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char *flags6 = (unsigned char *)(((long long)(int)(self + 6)));
     *flags6 &= ~3;
     *flags6 &= ~4;
     *(short *)(self + 4) = 0;

--- a/src/func_0204fce8.c
+++ b/src/func_0204fce8.c
@@ -21,7 +21,7 @@ void func_0204fce8(int *thiz, void *arg)
   }
 
   ((FP) thiz[6])(arg, thiz[0xc], data_020a5538, q, thiz[2], thiz[7]);
-  pcount = (int *) (((int) thiz + 0x20) & 0xFFFFFFFFFFFFFFFF);
+  pcount = (int *) (((int) thiz + 0x20));
   (*pcount)++;
   if (thiz[8] >= thiz[5])
   {

--- a/src/func_0204fda4.cpp
+++ b/src/func_0204fda4.cpp
@@ -11,7 +11,7 @@ extern "C" void func_0204fda4(char* c)
     int* p;
     func_0204f0b8(*(unsigned int*)(c + 0x28));
     _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(data_020a552c, c);
-    p = (int*)((((long long)(int)(c + 0xc)) & 0xFFFFFFFFFFFFFFFFLL));
+    p = (int*)((((long long)(int)(c + 0xc))));
     *p &= ~1;
     *p &= ~2;
 }

--- a/src/func_0204fde8.c
+++ b/src/func_0204fde8.c
@@ -7,7 +7,7 @@ extern void func_0204fda4(char* obj);
 void func_0204fde8(char* obj) {
     if ((int)(*(int*)(obj + 0xc) << 0x1e) >> 0x1f) {
         void* p;
-        int* flags = (int*)(((int)obj + 0xc) & 0xFFFFFFFFFFFFFFFF);
+        int* flags = (int*)(((int)obj + 0xc));
         func_0205abb8(*(int*)(obj + 0x2c), 0, 1 << *(int*)(obj + 0x28), 0);
         *flags &= ~2;
         p = func_0205afb4();

--- a/src/func_0204ffcc.c
+++ b/src/func_0204ffcc.c
@@ -3,5 +3,5 @@ extern void func_0205ac28(void *a, int b, int c, int d);
 void func_0204ffcc(char *self)
 {
     func_0205ac28(*(void **)(self + 0x2c), 0, 1 << *(int *)(self + 0x28), 0);
-    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(int *)(((long long)(int)(self + 0xc))) |= 2;
 }

--- a/src/func_020500a4.c
+++ b/src/func_020500a4.c
@@ -43,7 +43,7 @@ void func_020500a4(struct T *thiz)
         thiz->f30(e6, e5, quot, thiz->f8, thiz->f34);
     }
     {
-        int *pf18 = (int *)((int)&thiz->f18 & 0xFFFFFFFFFFFFFFFF);
+        int *pf18 = (int *)((int)&thiz->f18);
         *pf18 = *pf18 + 1;
         if (thiz->f18 >= thiz->f2c) thiz->f18 = 0;
     }

--- a/src/func_020520dc.c
+++ b/src/func_020520dc.c
@@ -6,7 +6,7 @@ void func_020520dc(char *self)
     if (*(int *)(self + 0x100) == 0)
         return;
 
-    *(int *)(((long long)(int)(self + 0x100)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(self + 0x100))) -= 1;
 
     if (*(int *)(self + 0x100) != 0)
         return;

--- a/src/func_0205212c.cpp
+++ b/src/func_0205212c.cpp
@@ -56,7 +56,7 @@ extern "C" void func_0205212c(Obj *self) {
         node = next;
     }
     IRQ::Restore(irq);
-    u32 *p = (u32*)(((int)self + 0xf0) & 0xFFFFFFFFFFFFFFFF);
+    u32 *p = (u32*)(((int)self + 0xf0));
     *p &= ~1u;
     *p &= ~4u;
     *p &= ~2u;

--- a/src/func_020522c4.c
+++ b/src/func_020522c4.c
@@ -25,7 +25,7 @@ void func_020522c4(void)
                     if (*(int *)(r + 0xf8) != 0) {
                         func_0204ffcc(r);
                         {
-                            int *flagsp = (int *)(((long long)(int)(r + 0xf0)) & 0xFFFFFFFFFFFFFFFFLL);
+                            int *flagsp = (int *)(((long long)(int)(r + 0xf0)));
                             *flagsp |= 2;
                             *flagsp &= ~4;
                         }

--- a/src/func_02052438.c
+++ b/src/func_02052438.c
@@ -1,6 +1,6 @@
 void func_02052438(char *self)
 {
     if (*(int *)(self + 8) < *(int *)(self + 0xc)) {
-        *(int *)(((long long)(int)(self + 8)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(int *)(((long long)(int)(self + 8))) += 1;
     }
 }

--- a/src/func_02057d30.c
+++ b/src/func_02057d30.c
@@ -13,5 +13,5 @@ void func_02057d30(RingS *s, const char *src, int len) {
         s->buf[i] = src[i];
     }
     s->count -= n;
-    *(int *)(((long long)(int)((char *)s + 4)) & 0xFFFFFFFFFFFFFFFFLL) += len;
+    *(int *)(((long long)(int)((char *)s + 4))) += len;
 }

--- a/src/func_02057d94.c
+++ b/src/func_02057d94.c
@@ -13,5 +13,5 @@ void func_02057d94(RingS *s, char c, int len) {
         s->buf[i] = c;
     }
     s->count -= n;
-    *(int *)(((long long)(int)((char *)s + 4)) & 0xFFFFFFFFFFFFFFFFLL) += len;
+    *(int *)(((long long)(int)((char *)s + 4))) += len;
 }

--- a/src/func_02057e00.c
+++ b/src/func_02057e00.c
@@ -5,5 +5,5 @@ void func_02057e00(char *self, unsigned char value)
         *(int *)self -= 1;
     }
 
-    *(int *)(((long long)(int)(self + 4)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int *)(((long long)(int)(self + 4))) += 1;
 }

--- a/src/func_020587e4.c
+++ b/src/func_020587e4.c
@@ -30,7 +30,7 @@ int func_020587e4(struct MsgQueue *self, u32 *msg, int flags) {
         *msg = self->msgArray[self->firstIndex];
     }
     self->firstIndex = (self->firstIndex + 1) % self->msgCount;
-    *(int *)(((long long)(int)&self->usedCount) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)&self->usedCount)) -= 1;
     OS_WakeupThread(&self->queueSend);
 
     _ZN3IRQ7RestoreEj(enabled);

--- a/src/func_02058894.c
+++ b/src/func_02058894.c
@@ -25,7 +25,7 @@ int func_02058894(struct Q *q, int val, int flag)
         int idx = (q->cap + q->head) % q->count;
         q->arr[idx] = val;
         {
-            int *headp = (int*)(((long long)((char*)q + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *headp = (int*)(((long long)((char*)q + 0x10)));
             *headp = *headp + 1;
         }
         OS_WakeupThread((char*)q + 2);

--- a/src/func_020589d4.c
+++ b/src/func_020589d4.c
@@ -8,10 +8,10 @@ int func_020589d4(struct Obj* o){
   int ret;
   if(o->field4 == 0){
     o->field4 = g;
-    *(int *)(((int)o + 8) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)o + 8) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(int *)(((int)o + 8)) = *(int *)(((int)o + 8)) + 1;
     ret = 1;
   } else if(o->field4 == g){
-    *(int *)(((int)o + 8) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)o + 8) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(int *)(((int)o + 8)) = *(int *)(((int)o + 8)) + 1;
     ret = 1;
   } else {
     ret = 0;

--- a/src/func_02058b08.c
+++ b/src/func_02058b08.c
@@ -27,12 +27,12 @@ void func_02058b08(struct Obj* self)
     for (;;) {
         if (self->f4 == 0) {
             self->f4 = cur;
-            *(int*)(((int)self + 8) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+            *(int*)(((int)self + 8)) += 1;
             func_020589ac(cur, self);
             break;
         }
         if (self->f4 == cur) {
-            *(int*)(((int)self + 8) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+            *(int*)(((int)self + 8)) += 1;
             break;
         }
         cur->f78 = self;

--- a/src/func_0205929c.c
+++ b/src/func_0205929c.c
@@ -22,7 +22,7 @@ void *func_0205929c(void *ap, void *bp)
     if (cur != 0) {
         cur->prev = b;
         if ((Block *)((char *)b + b->size) == cur) {
-            int *bsize = (int *)(((long long)(int)&b->size) & 0xFFFFFFFFFFFFFFFFLL);
+            int *bsize = (int *)(((long long)(int)&b->size));
             *bsize += cur->size;
             cur = cur->next;
             b->next = cur;
@@ -33,7 +33,7 @@ void *func_0205929c(void *ap, void *bp)
     if (prev != 0) {
         prev->next = b;
         if ((Block *)((char *)prev + prev->size) == b) {
-            int *psize = (int *)(((long long)(int)&prev->size) & 0xFFFFFFFFFFFFFFFFLL);
+            int *psize = (int *)(((long long)(int)&prev->size));
             *psize += b->size;
             prev->next = cur;
             if (cur != 0)

--- a/src/func_02059650.c
+++ b/src/func_02059650.c
@@ -13,5 +13,5 @@ long long func_02059650(void)
     if ((*(volatile u32*)0x4000214 & 8) && !(timer & 0x8000))
         counter = counter + 1;
     _ZN3IRQ7RestoreEj(tok);
-    return ((long long)counter << 16) | (int)(((long long)(int)timer) & 0xFFFFFFFFFFFFFFFFLL);
+    return ((long long)counter << 16) | (int)(((long long)(int)timer));
 }

--- a/src/func_02059834.c
+++ b/src/func_02059834.c
@@ -30,7 +30,7 @@ void func_02059834(void)
     u64 now;
     *(volatile unsigned short *)0x4000106 = 0;
     _ZN3IRQ11DisableIRQsEj(0x10);
-    *(int *)(((int)&data_023c0000 + 0x3ff8) & 0xFFFFFFFFFFFFFFFF) |= 0x10;
+    *(int *)(((int)&data_023c0000 + 0x3ff8)) |= 0x10;
     now = func_02059650();
     e = data_020a6444.head;
     if (e == 0) return;

--- a/src/func_02059f58.c
+++ b/src/func_02059f58.c
@@ -5,7 +5,7 @@ void func_02059f58(int channel)
 {
     unsigned int saved = _ZN3IRQ7DisableEv();
     int idx = channel * 6 + 5;
-    volatile unsigned short *reg = (volatile unsigned short *)(((long long)(int)(0x40000b0 + idx * 2)) & 0xFFFFFFFFFFFFFFFFLL);
+    volatile unsigned short *reg = (volatile unsigned short *)(((long long)(int)(0x40000b0 + idx * 2)));
     *reg &= ~0x3a00;
     *reg &= ~0x8000;
     (void)*reg;

--- a/src/func_0205a064.c
+++ b/src/func_0205a064.c
@@ -18,13 +18,13 @@ void func_0205a064(u32 ch, u32 src, u32 dst, u32 size, void (*cb)(u32), u32 cbAr
     if (cb != 0)
     {
         func_02056e98(ch, (u32)cb, cbArg);
-        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)) & 0xFFFFFFFFFFFFFFFFLL);
+        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)));
         *reg = dst;
         DMAStartTransfer(ch, (u32)reg, src, (size >> 2) | 0xc5000000);
     }
     else
     {
-        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)) & 0xFFFFFFFFFFFFFFFFLL);
+        reg = (u32 *)(int)(((long long)(int)(0x040000e0 + ch * 4)));
         *reg = dst;
         DMAStartTransfer(ch, (u32)reg, src, (size >> 2) | 0x85000000);
     }

--- a/src/func_0205b4d0.c
+++ b/src/func_0205b4d0.c
@@ -8,7 +8,7 @@ extern struct E7f60 data_020a7f60[];
 
 unsigned char func_0205b4d0(int index, void (*fn)(int), int arg) {
     struct E7f60 *e = &data_020a7f60[index];
-    unsigned char *t = (unsigned char *)(((long long)(int)((char *)e + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char *t = (unsigned char *)(((long long)(int)((char *)e + 8)));
     data_020a7f60[index].fn = fn;
     e->arg = arg;
     (*t)++;

--- a/src/func_0205b504.c
+++ b/src/func_0205b504.c
@@ -8,5 +8,5 @@ extern UnkStruct_020a7f60 data_020a7f60[];
 
 void func_0205b504(int idx)
 {
-    *(unsigned char *)((long long)((int)&data_020a7f60[idx] + 8) & 0xffffffffffffffffLL) += 1;
+    *(unsigned char *)((long long)((int)&data_020a7f60[idx] + 8)) += 1;
 }

--- a/src/func_0205ba64.c
+++ b/src/func_0205ba64.c
@@ -10,9 +10,9 @@ void func_0205ba64(int idx, void* val) {
     struct Bits96 *p = (struct Bits96 *)0x27ffc00;
     data_020a7fc8[idx] = val;
     if (val != 0) {
-        *(unsigned int *)(((int)p + 0x388) & 0xFFFFFFFFFFFFFFFF) |= (1u << idx);
+        *(unsigned int *)(((int)p + 0x388)) |= (1u << idx);
     } else {
-        *(unsigned int *)(((int)p + 0x388) & 0xFFFFFFFFFFFFFFFF) &= ~(1u << idx);
+        *(unsigned int *)(((int)p + 0x388)) &= ~(1u << idx);
     }
     _ZN3IRQ7RestoreEj(saved);
 }

--- a/src/func_0205c264.c
+++ b/src/func_0205c264.c
@@ -34,7 +34,7 @@ int func_0205c264(int *thiz)
         *(short *)(r4 + 6) = 0;
         *(int *)(r4 + 8) = 0;
     } else {
-        unsigned short *q = (unsigned short *)(int)(((long long)(int)((char *)thiz + 0x22)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short *q = (unsigned short *)(int)(((long long)(int)((char *)thiz + 0x22)));
         *(int *)r4 = thiz[2];
         *(int *)(r4 + 4) = *(unsigned short *)((char *)thiz + 0x22);
         *q = *q + 1;

--- a/src/func_0205c410.c
+++ b/src/func_0205c410.c
@@ -4,6 +4,6 @@ void func_0205c410(char* c)
     unsigned inc = *(unsigned*)(c + 0x34);
     unsigned b = *(unsigned*)(c + 0x28);
     unsigned a = *(unsigned*)(c + 0x2c);
-    *(unsigned*)(((long long)(int)(c + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+    *(unsigned*)(((long long)(int)(c + 0x28))) += inc;
     (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x40))(obj, a, b, inc);
 }

--- a/src/func_0205c448.c
+++ b/src/func_0205c448.c
@@ -4,6 +4,6 @@ void func_0205c448(char* c)
     unsigned inc = *(unsigned*)(c + 0x34);
     unsigned b = *(unsigned*)(c + 0x28);
     unsigned a = *(unsigned*)(c + 0x2c);
-    *(unsigned*)(((long long)(int)(c + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+    *(unsigned*)(((long long)(int)(c + 0x28))) += inc;
     (*(void (**)(char*, unsigned, unsigned, unsigned))(obj + 0x3c))(obj, a, b, inc);
 }

--- a/src/func_0205c4e4.c
+++ b/src/func_0205c4e4.c
@@ -2,7 +2,7 @@ extern int func_0205c5e4(void *self, int mode);
 
 void func_0205c4e4(char *self, unsigned short value)
 {
-    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+    *(int *)(((long long)(int)(self + 0xc))) |= 4;
     *(int *)(self + 0x2c) = *(int *)(self + 8);
     *(int *)(self + 0x34) = 0;
     *(unsigned short *)(self + 0x32) = 0;

--- a/src/func_0205c5e4.c
+++ b/src/func_0205c5e4.c
@@ -8,7 +8,7 @@ extern unsigned int (*data_02086758[])(char*);
    plain (u32*)(r + off) straight into the ldr/str addressing mode; the ROM
    instead materialises the address into a scratch register first.  Widening
    the address through a 64-bit value forces that explicit base add. */
-#define REG(x) ((unsigned int*)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+#define REG(x) ((unsigned int*)(((long long)(int)(x))))
 #define REGU(x) ((unsigned int*)(long long)(unsigned)(x))
 
 int func_0205c5e4(char* self, int idx) {

--- a/src/func_0205c788.c
+++ b/src/func_0205c788.c
@@ -5,7 +5,7 @@ extern void OS_WakeupThread(unsigned short *self);
 void func_0205c788(char *self, int arg)
 {
     func_0205d920((struct Node *)self);
-    *(int *)(((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xf;
+    *(int *)(((long long)(int)(self + 0xc))) &= ~0xf;
     *(int *)(self + 0x14) = arg;
     OS_WakeupThread((unsigned short *)(self + 0x18));
 }

--- a/src/func_0205c864.c
+++ b/src/func_0205c864.c
@@ -15,13 +15,13 @@ int func_0205c864(int *thiz)
         if (b == 0) {
             goto setflag;
         }
-        *(int *)(((long long)(int)((char*)thiz + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40;
+        *(int *)(((long long)(int)((char*)thiz + 0x10))) |= 0x40;
         do {
             OS_SleepThread((char*)thiz + 0xe);
         } while ((*(int*)((char*)thiz + 0x10) & 0x40) ? 1 : 0);
         goto done;
     setflag:
-        *(int *)(((long long)(int)((char*)thiz + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+        *(int *)(((long long)(int)((char*)thiz + 0x10))) |= 8;
     done:
         ;
     }

--- a/src/func_0205c9b8.c
+++ b/src/func_0205c9b8.c
@@ -10,7 +10,7 @@ unsigned int func_0205c9b8(char *thiz, int arg1, unsigned int arg2) {
     int r4;
     int sz;
     sz = *(int*)(thiz + 0x24) + *(int*)(thiz + 0x2c) + 0x20;
-    r5 = ((unsigned int)(sz & 0xFFFFFFFFFFFFFFFF) + 0x1f) & ~0x1f;
+    r5 = ((unsigned int)(sz) + 0x1f) & ~0x1f;
     if (r5 > arg2) goto done;
     r4 = (arg1 + 0x1f) & ~0x1f;
     FS_InitFile(s);
@@ -27,7 +27,7 @@ unsigned int func_0205c9b8(char *thiz, int arg1, unsigned int arg2) {
     *(int*)(thiz + 0x28) = r4;
     *(int*)(thiz + 0x38) = arg1;
     *(int(**)(void))(thiz + 0x44) = func_0205d28c;
-    *(int *)(((int)thiz + 0x10) & 0xFFFFFFFFFFFFFFFF) |= 4;
+    *(int *)(((int)thiz + 0x10)) |= 4;
 done:
     return r5;
 }

--- a/src/func_0205caa8.c
+++ b/src/func_0205caa8.c
@@ -11,7 +11,7 @@ int func_0205caa8(int *thiz)
         int *p;
         *(volatile int *)&thiz[4];
         func_0205c864(thiz);
-        *(int *)(((int)thiz + 0x10) & 0xFFFFFFFFFFFFFFFF) |= 0x80;
+        *(int *)(((int)thiz + 0x10)) |= 0x80;
         p = (int *)thiz[6];
         if (p != 0) {
             int n;
@@ -29,7 +29,7 @@ int func_0205caa8(int *thiz)
         thiz[11] = 0;
         thiz[13] = 0;
         thiz[12] = thiz[13];
-        *(int *)(((unsigned int)thiz + 0x10) & 0xFFFFFFFFFFFFFFFF) &= ~0xa2;
+        *(int *)(((unsigned int)thiz + 0x10)) &= ~0xa2;
     }
     _ZN3IRQ7RestoreEj(saved);
     return 1;

--- a/src/func_0205cb68.c
+++ b/src/func_0205cb68.c
@@ -15,7 +15,7 @@ int func_0205cb68(int *self, int a1, int a2, int a3, int a4, int a5, int a6, int
     self[0x11] = self[0xf]; /* 0x44 = self[0x3c] */
     self[0xe] = 0;   /* 0x38 */
     {
-        int *pp = (int *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFF);
+        int *pp = (int *)(((int)self + 0x10));
         *pp |= 2;    /* 0x10 */
     }
     return 1;

--- a/src/func_0205cd5c.c
+++ b/src/func_0205cd5c.c
@@ -22,7 +22,7 @@ void func_0205cd5c(struct T *self, int arg)
     int b = (int)((self->flags & 0x100) != 0);
 
     if (b) {
-        u32 *f = (u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFF);
+        u32 *f = (u32 *)(((int)self + 0x10));
         u32 v;
         char *t;
         int r;
@@ -41,7 +41,7 @@ void func_0205cd5c(struct T *self, int arg)
     {
         char *p = self->th;
         u32 irq = func_02059d1c();
-        u32 *f = (u32 *)(((int)self + 0x10) & 0xFFFFFFFFFFFFFFFF);
+        u32 *f = (u32 *)(((int)self + 0x10));
 
         *(int *)(p + 0x14) = arg;
         *f = *f & ~0x200;

--- a/src/func_0205cdf4.cpp
+++ b/src/func_0205cdf4.cpp
@@ -18,7 +18,7 @@ int func_0205cdf4(char *self, int arg1)
 
     *(int *)(self + 0x10) = arg1;
     *(int *)(self + 0x14) = 2;
-    *(int *)(((long long)(int)(self + 0xc)) & 0xffffffffffffffffLL) |= 1;
+    *(int *)(((long long)(int)(self + 0xc))) |= 1;
     saved = _ZN3IRQ7DisableEv();
     if (*(int *)(list + 0x10) & 0x80) {
         func_0205c788(self, 3);
@@ -26,12 +26,12 @@ int func_0205cdf4(char *self, int arg1)
         return 0;
     }
     if (mask & 0x1fc) {
-        *(int *)(((long long)(unsigned int)(self + 0xc)) & 0xffffffffffffffffLL) |= 4;
+        *(int *)(((long long)(unsigned int)(self + 0xc))) |= 4;
     }
     func_0205d8d8(self, list + 0x14);
     t = (*(int *)(list + 0x10) & 0x10) != 0;
     if (!t) {
-        *(int *)(((long long)(int)(list + 0x10)) & 0xffffffffffffffffLL) |= 0x10;
+        *(int *)(((long long)(int)(list + 0x10))) |= 0x10;
         _ZN3IRQ7RestoreEj(saved);
         if (*(int *)(list + 0x4c) & 0x200) {
             (*(void (**)(char *, int))(list + 0x48))(self, 9);

--- a/src/func_0205d044.c
+++ b/src/func_0205d044.c
@@ -26,7 +26,7 @@ void *func_0205d044(void *pool)
     int f1 = (int)((*(volatile u32 *)(c + 0x10) & 0x20) != 0);
 
     if (f1 != 0) {
-        u32 *p = (u32 *)(((int)(c + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32 *p = (u32 *)(((int)(c + 0x10)));
         *p &= ~0x20;
 
         Node *head = *(Node **)(c + 0x18);
@@ -55,7 +55,7 @@ void *func_0205d044(void *pool)
                 int wasSet = (int)((*(volatile u32 *)(c + 0x10) & 0x10) != 0);
                 int notSet = (int)(wasSet == 0);
                 if (notSet != 0) {
-                    u32 *p = (u32 *)(((int)(c + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+                    u32 *p = (u32 *)(((int)(c + 0x10)));
                     *p |= 0x10;
                 }
                 _ZN3IRQ7RestoreEj(irqSave);
@@ -80,7 +80,7 @@ void *func_0205d044(void *pool)
     {
         int f5 = (int)((*(volatile u32 *)(c + 0x10) & 0x10) != 0);
         if (f5 != 0) {
-            u32 *p = (u32 *)(((int)(c + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+            u32 *p = (u32 *)(((int)(c + 0x10)));
             *p &= ~0x10;
             if (*(u32 *)(c + 0x4c) & 0x400) {
                 int buf[0x11];
@@ -97,7 +97,7 @@ void *func_0205d044(void *pool)
     {
         int f7 = (int)((*(volatile u32 *)(c + 0x10) & 0x40) != 0);
         if (f7 != 0) {
-            u32 *p = (u32 *)(((int)(c + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+            u32 *p = (u32 *)(((int)(c + 0x10)));
             *p &= ~0x40;
             *p |= 8;
             OS_WakeupThread((u16 *)(c + 0xe));

--- a/src/func_0205d3f4.c
+++ b/src/func_0205d3f4.c
@@ -27,15 +27,15 @@ int func_0205d3f4(Obj *t)
     int woken = 0;
     u32 irq = _ZN3IRQ7DisableEv();
     int busy = (t->flags & 1) ? 1 : 0;
-    if ((int)(((long long)busy) & 0xFFFFFFFFFFFFFFFFLL) != 0) {
+    if ((int)(((long long)busy)) != 0) {
         woken = (t->owner->cur != t) ? 1 : 0;
         if (woken) {
-            *(u32 *)(int)(((long long)(int)((int)t + 0xc)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+            *(u32 *)(int)(((long long)(int)((int)t + 0xc))) |= 4;
         }
         do {
             OS_SleepThread(&t->queue);
             busy = (t->flags & 1) ? 1 : 0;
-        } while ((int)(((long long)busy) & 0xFFFFFFFFFFFFFFFFLL) != 0);
+        } while ((int)(((long long)busy)) != 0);
     }
     _ZN3IRQ7RestoreEj(irq);
     if (woken) {

--- a/src/func_0205d568.c
+++ b/src/func_0205d568.c
@@ -27,7 +27,7 @@ int func_0205d568(Node *node, int b, ...)
             return 0;
         }
     }
-    p = (unsigned int *)(((long long)(int)((char *)node + 0xc)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (unsigned int *)(((long long)(int)((char *)node + 0xc)));
     *p |= 0x10;
     *p &= ~0x20;
     return 1;


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 93 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
