### PR TITLE
readable: strip 98 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_0205d5e8.c
+++ b/src/func_0205d5e8.c
@@ -8,7 +8,7 @@ int func_0205d5e8(char* self, int a1, int a2, int a3, int a4)
     *(int*)(self + 0x2c) = a2;
     *(int*)(self + 0x30) = a3;
     if(func_0205cdf4(self, 7) == 0) return 0;
-    p = (int*)((((long long)(int)(self + 0xc)) & 0xFFFFFFFFFFFFFFFFLL));
+    p = (int*)((((long long)(int)(self + 0xc))));
     *p |= 0x10;
     *p &= ~0x20;
     return 1;

--- a/src/func_0205d688.c
+++ b/src/func_0205d688.c
@@ -6,8 +6,8 @@ int func_0205d688(char *self, int a1, int a2, int a3)
   int a3v;
   int oldpos;
   oldpos = *((int *) (self + 0x28));
-  n = (int) (((long long) a2) & 0xFFFFFFFFFFFFFFFFLL);
-  a3v = (int) (((long long) a3) & 0xFFFFFFFFFFFFFFFFLL);
+  n = (int) (((long long) a2));
+  a3v = (int) (((long long) a3));
   {
     int avail = (*((int *) (self + 0x24))) - oldpos;
     if (n > avail)
@@ -24,7 +24,7 @@ int func_0205d688(char *self, int a1, int a2, int a3)
   *((int *) (self + 0x34)) = n;
   if (a3v == 0)
   {
-    *((int *) (((long long) ((int) (self + 0xc))) & 0xFFFFFFFFFFFFFFFFLL)) |= 4;
+    *((int *) (((long long) ((int) (self + 0xc))))) |= 4;
   }
   func_0205cdf4(self, 0);
   if (a3v == 0)

--- a/src/func_0205dc7c.c
+++ b/src/func_0205dc7c.c
@@ -29,7 +29,7 @@ void func_0205dc7c(u32* q) {
         collected = 0;
         r6 = q[1];
         r5 = q[1] + q[2];
-        r4 = r5 + (u32)((int)(((long long)(int)(q[2] + q[3])) & 0xFFFFFFFFFFFFFFFFLL) - q[2]);
+        r4 = r5 + (u32)((int)(((long long)(int)(q[2] + q[3]))) - q[2]);
         tail = 0;
         saved = _ZN3IRQ7DisableEv();
         prev = 0;

--- a/src/func_0205e280.c
+++ b/src/func_0205e280.c
@@ -9,7 +9,7 @@ typedef struct
 
 extern void func_0205e3d4(HashCtx* c);
 
-#define CNT (*(int*)(int)(((long long)(int)((char*)c + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL))
+#define CNT (*(int*)(int)(((long long)(int)((char*)c + 0x1c))))
 
 void func_0205e280(HashCtx* c)
 {

--- a/src/func_0205e6e4.c
+++ b/src/func_0205e6e4.c
@@ -23,12 +23,12 @@ int func_0205e6e4(struct Obj* obj, u8* p, int count) {
 body:
   {
     int i = obj->f1c;
-    *(int *)(((int)obj + 0x1c) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int *)(((int)obj + 0x1c)) += 1;
     obj->buf[i] = *p;
   }
-  *(int *)(((int)obj + 0x14) & 0xFFFFFFFFFFFFFFFF) += 8;
+  *(int *)(((int)obj + 0x14)) += 8;
   if (obj->f14 == 0) {
-    *(int *)(((int)obj + 0x18) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int *)(((int)obj + 0x18)) += 1;
     if (obj->f18 == 0) obj->f64 = 1;
   }
   if (obj->f1c == 0x40) func_0205e3d4(obj);

--- a/src/func_020600e0.c
+++ b/src/func_020600e0.c
@@ -13,7 +13,7 @@ void func_020600e0(int a0, int a1)
         Crash();
     } else {
         if (g->f14 != a1) Crash();
-        { int* pc = (int*)((gi + 0xc) & 0xFFFFFFFFFFFFFFFF); *pc = *pc - 1; }
+        { int* pc = (int*)((gi + 0xc)); *pc = *pc - 1; }
         if (g->fc == 0) {
             g->f8 = -3;
             g->f14 = 0;

--- a/src/func_02060188.c
+++ b/src/func_02060188.c
@@ -16,7 +16,7 @@ void func_02060188(int a0, int a1)
         g->f8 = a0;
         g->f14 = a1;
     }
-    { int* pc = (int*)((gi + 0xc) & 0xFFFFFFFFFFFFFFFF); *pc = *pc + 1; }
+    { int* pc = (int*)((gi + 0xc)); *pc = *pc + 1; }
     *g->f0 = 0;
     _ZN3IRQ7RestoreEj(s);
 }

--- a/src/func_02060228.c
+++ b/src/func_02060228.c
@@ -22,7 +22,7 @@ void func_02060228(void *fn)
     *(void **)(base + 0xd0) = base + 0x3c;
     *(void **)(base + 0x30) = fn;
     {
-        unsigned int *fp = (unsigned int *)(((long long)(int)(base + 0x34)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned int *fp = (unsigned int *)(((long long)(int)(base + 0x34)));
         *fp |= 8;
     }
     func_02058048(base + 0x3c);

--- a/src/func_02060310.c
+++ b/src/func_02060310.c
@@ -5,7 +5,7 @@ void func_02060310(int a, int b, int c)
 {
     if (a == 0xb && c != 0) {
         char *base = (char *)&data_020a8180;
-        unsigned int *addr = (unsigned int *)(((int)base + 0x34) & 0xFFFFFFFFFFFFFFFF);
+        unsigned int *addr = (unsigned int *)(((int)base + 0x34));
         unsigned int val = *addr;
         val &= ~0x20u;
         *addr = val;

--- a/src/func_02060484.c
+++ b/src/func_02060484.c
@@ -7,7 +7,7 @@ int func_0206062c(void* g);
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int flags);
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 int func_02060484(int a, int b, int c, int d, int e, int f)
 {

--- a/src/func_0206081c.c
+++ b/src/func_0206081c.c
@@ -7,7 +7,7 @@ void func_0206081c(char* obj) {
     CB cb = *(CB*)(obj + 0x28);
     void* arg = *(void**)(obj + 0x2c);
     unsigned int saved = _ZN3IRQ7DisableEv();
-    *(int *)(((int)obj + 0x34) & 0xFFFFFFFFFFFFFFFF) &= ~0xc;
+    *(int *)(((int)obj + 0x34)) &= ~0xc;
     OS_WakeupThread(obj + 0xd4);
     if (*(int*)(obj + 0x34) & 0x10) {
         func_02058048(obj + 0x3c);

--- a/src/func_02060918.c
+++ b/src/func_02060918.c
@@ -46,7 +46,7 @@ void func_02060918(u32 a0, u32 a1, u32 a2, u32 a3, u32 a4, u32 a5, int a6)
         OS_SleepThread(&t->fd4);
     }
     {
-        u32 *p34 = (u32 *)(((int)t + 0x34) & 0xFFFFFFFFFFFFFFFF);
+        u32 *p34 = (u32 *)(((int)t + 0x34));
         *p34 |= 4;
     }
     IRQ_Restore(mask);

--- a/src/func_02060e38.c
+++ b/src/func_02060e38.c
@@ -36,7 +36,7 @@ void func_02060e38(void) {
 
     *g->f0 = 0;
     s = _ZN3IRQ7DisableEv();
-    pf = (u32 *)((gi + 0x34) & 0xFFFFFFFFFFFFFFFF);
+    pf = (u32 *)((gi + 0x34));
     {
         u32 val = *pf;
         val &= ~0xc;

--- a/src/func_02060f60.cpp
+++ b/src/func_02060f60.cpp
@@ -28,7 +28,7 @@ extern "C" int func_02060f60(T *thiz, int v, int count) {
     int r;
 
     if (!(*(volatile int *)&thiz->f34 & 2)) {
-        int *p = (int *)(((int)thiz + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)thiz + 0x34));
         *p |= 2;
         if (func_0205ba3c(0xb, 1) == 0) {
             do {
@@ -43,7 +43,7 @@ extern "C" int func_02060f60(T *thiz, int v, int count) {
 
     do {
         thiz->f4 = v;
-        *(int *)(((int)thiz + 0x34) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+        *(int *)(((int)thiz + 0x34)) |= 0x20;
 
         while (IPCSend(0xb, v, 1) < 0) {
         }

--- a/src/func_02063718.c
+++ b/src/func_02063718.c
@@ -16,7 +16,7 @@ int func_02063718(char *p, char *q)
 {
     int t;
     int ret = 0;
-    int *st = (int *)((long long)(unsigned int)(p + 0x9c) & 0xFFFFFFFFFFFFFFFFLL);
+    int *st = (int *)((long long)(unsigned int)(p + 0x9c));
     int b;
     int i;
     char *ptr;
@@ -40,7 +40,7 @@ int func_02063718(char *p, char *q)
             if ((*(u16 *)(p + 8) >> i) & 1)
                 func_020647fc(ptr, *(int *)(p + 0x18), ptr + 0x1c, ((int *)p + i)[7]);
         }
-        if (*(int *)((long long)(unsigned int)(p + 0x9c) & 0xFFFFFFFFFFFFFFFFLL) == 4)
+        if (*(int *)((long long)(unsigned int)(p + 0x9c)) == 4)
             ret = func_02064e18(q, *(u16 *)(p + 8), *(u8 *)(p + 0xc), *(int *)(p + 0x14), 0);
         else
             ret = func_02064cd8(q, *(u16 *)(p + 8), *(u8 *)(p + 0xc), *(int *)(p + 0x14), 0);
@@ -53,7 +53,7 @@ int func_02063718(char *p, char *q)
             if ((*(u16 *)(p + 8) >> i) & 1)
                 func_020647fc(ptr, *(int *)(p + 0x18), (void *)((int *)p + i)[23], ((int *)p + i)[7]);
         }
-        if (*(int *)((long long)(unsigned int)(p + 0x9c) & 0xFFFFFFFFFFFFFFFFLL) == 4)
+        if (*(int *)((long long)(unsigned int)(p + 0x9c)) == 4)
             ret = func_02064e18(q, *(u16 *)(p + 8), *(u8 *)(p + 0xc), *(int *)(p + 0x14), 0);
         else
             ret = func_02064cd8(q, *(u16 *)(p + 8), *(u8 *)(p + 0xc), *(int *)(p + 0x14), 0);
@@ -64,6 +64,6 @@ int func_02063718(char *p, char *q)
         ret = func_02064a94(q, *(u16 *)(p + 8), *(u8 *)(p + 0xc), p + 0x14, *(u8 *)(p + 0x1d));
         break;
     }
-    *(int *)((long long)(unsigned int)(p + 0x9c) & 0xFFFFFFFFFFFFFFFFLL) = 0;
+    *(int *)((long long)(unsigned int)(p + 0x9c)) = 0;
     return ret;
 }

--- a/src/func_02064470.c
+++ b/src/func_02064470.c
@@ -35,7 +35,7 @@ void func_02064470(struct Self *self, int r1, int r2)
     self->fd = e->b2;
     if ((self->f8 & mask) == 0) goto after;
     {
-        unsigned short *p8 = (unsigned short *)(((int)self + 8) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *p8 = (unsigned short *)(((int)self + 8));
         *p8 = *p8 & ~mask;
     }
 

--- a/src/func_020647a4.c
+++ b/src/func_020647a4.c
@@ -1,6 +1,6 @@
 void func_020647a4(char *self, int value)
 {
-    *(int *)(((long long)(int)(self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int *)(((long long)(int)(self + 0x10))) += 1;
     *(int *)(self + 0xc) = value;
 
     int *arr = *(int **)(self + 0x14);

--- a/src/func_02064c2c.c
+++ b/src/func_02064c2c.c
@@ -12,14 +12,14 @@ int func_02064c2c(int dest, u16 a, u8 b, int c, int d, void *p, int n)
     CpuCopy8(&kind, dest, 1);
     pos = dest + 1;
     CpuCopy8(&a16, pos, 2);
-    pos = (int)(((long long)(pos + 2)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 2)));
     CpuCopy8(&b, pos, 1);
-    pos = (int)(((long long)(pos + 1)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 1)));
     CpuCopy8(&c, pos, 4);
-    pos = (int)(((long long)(pos + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 4)));
     CpuCopy8(&d, pos, 4);
-    len = (int)(((long long)n) & 0xFFFFFFFFFFFFFFFFLL);
-    pos = (int)(((long long)(pos + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+    len = (int)(((long long)n));
+    pos = (int)(((long long)(pos + 4)));
     CpuCopy8(p, pos, len);
     return (pos + len) - dest;
 }

--- a/src/func_02064d6c.c
+++ b/src/func_02064d6c.c
@@ -12,14 +12,14 @@ int func_02064d6c(int dest, u16 a, u8 b, int c, int d, void *p, int n)
     CpuCopy8(&kind, dest, 1);
     pos = dest + 1;
     CpuCopy8(&a16, pos, 2);
-    pos = (int)(((long long)(pos + 2)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 2)));
     CpuCopy8(&b, pos, 1);
-    pos = (int)(((long long)(pos + 1)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 1)));
     CpuCopy8(&c, pos, 4);
-    pos = (int)(((long long)(pos + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+    pos = (int)(((long long)(pos + 4)));
     CpuCopy8(&d, pos, 4);
-    len = (int)(((long long)n) & 0xFFFFFFFFFFFFFFFFLL);
-    pos = (int)(((long long)(pos + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+    len = (int)(((long long)n));
+    pos = (int)(((long long)(pos + 4)));
     CpuCopy8(p, pos, len);
     return (pos + len) - dest;
 }

--- a/src/func_02065c2c.c
+++ b/src/func_02065c2c.c
@@ -27,17 +27,17 @@ u8 *func_02065c2c(u8 *src, u8 *dst)
     case 8:
     {
       int lo = src[1];
-      u16 *p = (u16 *) ((((int) dst) + 2) & 0xFFFFFFFFFFFFFFFFLL);
+      u16 *p = (u16 *) ((((int) dst) + 2));
       r4 = src + 3;
       *((u16 *) (dst + 2)) = lo & 0xff;
-      *((u16 *) ((((int) dst) + 2) & 0xFFFFFFFFFFFFFFFFLL)) = (*p) | ((src[2] << 8) & 0xff00);
+      *((u16 *) ((((int) dst) + 2))) = (*p) | ((src[2] << 8) & 0xff00);
     }
       break;
 
     case 9:
     {
       int lo = src[1];
-      u16 *p = (u16 *) ((((int) dst) + 2) & 0xFFFFFFFFFFFFFFFFLL);
+      u16 *p = (u16 *) ((((int) dst) + 2));
       *((u16 *) (dst + 2)) = lo & 0xff;
       {
         int hi = src[2];

--- a/src/func_02065f08.c
+++ b/src/func_02065f08.c
@@ -8,7 +8,7 @@ void func_02065f08(int idx){
   r1 = *(unsigned short*)(b + 0x1d40);
   r3 = *(unsigned short*)(b + 0x1d42);
   if(r3 <= r1 && r1 <= r3 + 2){
-    unsigned short* p = (unsigned short*)(((int)b + 0x1d40) & 0xFFFFFFFFFFFFFFFF);
+    unsigned short* p = (unsigned short*)(((int)b + 0x1d40));
     *p = *p + 1;
     return;
   }

--- a/src/func_0206655c.c
+++ b/src/func_0206655c.c
@@ -10,7 +10,7 @@ extern void CpuCopy8(void *dst, void *src, int n);
 extern int func_02066fec(u32 a, int b, int c);
 extern u16 func_02065ef8(u16 a, u16 b);
 
-#define LD(t, x) ((t *)((((long long)(int)(x))) & 0xFFFFFFFFFFFFFFFFLL))
+#define LD(t, x) ((t *)((((long long)(int)(x)))))
 
 void func_0206655c(void *arg0, u32 arg1)
 {

--- a/src/func_02066a94.c
+++ b/src/func_02066a94.c
@@ -49,15 +49,15 @@ void func_02066a94(int arg0, char *arg1)
                 if (slot != -1) {
                     u32 off = (u8)slot * 0x5c4;
                     u32 mask = ~(1 << id);
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d46)) & 0xFFFFFFFFFFFFFFFFLL) &= mask;
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d48)) & 0xFFFFFFFFFFFFFFFFLL) |= (1 << id);
+                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d46))) &= mask;
+                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d48))) |= (1 << id);
                     *(s8 *)(data_020a9db8 + (id - 1) + 0x1526) = -1;
-                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d44)) & 0xFFFFFFFFFFFFFFFFLL) &= mask;
+                    *(u16 *)(((long long)(int)(data_020a9db8 + off + 0x1d44))) &= mask;
                 }
             }
             if (*(u16 *)(data_020a9db8 + 0x1536) & (1 << *(u16 *)(arg1 + 0x10))) {
-                *(u8 *)(((long long)(int)(data_020a9db8 + 0x1535)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
-                *(u16 *)(((long long)(int)(data_020a9db8 + 0x1536)) & 0xFFFFFFFFFFFFFFFFLL) &= ~(1 << *(u16 *)(arg1 + 0x10));
+                *(u8 *)(((long long)(int)(data_020a9db8 + 0x1535))) -= 1;
+                *(u16 *)(((long long)(int)(data_020a9db8 + 0x1536))) &= ~(1 << *(u16 *)(arg1 + 0x10));
             }
             {
                 u16 id2 = *(u16 *)(arg1 + 0x10);

--- a/src/func_020676e0.c
+++ b/src/func_020676e0.c
@@ -1,5 +1,5 @@
 extern void Crash(void);
-#define LD(x) (((int)(x)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LD(x) (((int)(x)))
 void func_020676e0(unsigned *self, unsigned *mode_p, unsigned *out, unsigned *cursor)
 {
     unsigned mode = *mode_p;

--- a/src/func_02067928.c
+++ b/src/func_02067928.c
@@ -78,7 +78,7 @@ int func_02067928(void *a, void *b)
     *(u16*)((char*)data_020a9db8 + 0x1d46 + idx * 0x5c4) = 1;
     *(void**)((char*)data_020a9db8 + idx * 0x5c4 + 0x1d3c) = b;
     *(u8*)((char*)data_020a9db8 + idx * 0x5c4 + 0x1d4a) = 1;
-    *(u8*)((((int)data_020a9db8) + 0x1524) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(u8*)((((int)data_020a9db8) + 0x1524)) += 1;
 
     _ZN3IRQ7RestoreEj(state);
     return 1;

--- a/src/func_02067bfc.c
+++ b/src/func_02067bfc.c
@@ -68,7 +68,7 @@ int func_02067bfc(Ctx *a, Ctx *b, unsigned int c)
             a = (Ctx *)localbuf;
             base = localbuf[10] - localbuf[8];
             CpuCopy8(ctx, cur, 0x160);
-            *(unsigned int *)((long long)(int)(cur + 0x60) & 0xFFFFFFFFFFFFFFFFLL) |= 0x406000;
+            *(unsigned int *)((long long)(int)(cur + 0x60)) |= 0x406000;
         }
 
         threshold = ctx->f2c + 0x160 + ctx->f3c;

--- a/src/func_02067f68.c
+++ b/src/func_02067f68.c
@@ -59,7 +59,7 @@ void func_02067f68(void)
             MultiCopyHalf(*(u8 **)(data_020a9d2c + 4) + 0x35e + i * 0x16, dst, 0x16);
             count++;
             dst += 0x16;
-            *(u16 *)(((int)*(u8 **)(data_020a9d2c + 4) + 0x4a8) & 0xFFFFFFFFFFFFFFFF) |= 2 << i;
+            *(u16 *)(((int)*(u8 **)(data_020a9d2c + 4) + 0x4a8)) |= 2 << i;
             if (count == 4) {
                 break;
             }

--- a/src/func_0206853c.c
+++ b/src/func_0206853c.c
@@ -12,5 +12,5 @@ void func_0206853c(char *self, void *src, unsigned int flags, int s)
     *(unsigned char *)(self + 0x358) = (unsigned char)cnt;
     *(short *)(self + 0x35a) = (short)(flags | 1);
     *(short *)(self + 0x35c) = (short)s;
-    *(unsigned char *)(((long long)(int)(self + 0x4ac)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(unsigned char *)(((long long)(int)(self + 0x4ac))) += 1;
 }

--- a/src/func_0206a424.c
+++ b/src/func_0206a424.c
@@ -1,6 +1,6 @@
 void func_0206a424(int *self)
 {
-    volatile unsigned short *reg = (volatile unsigned short *)(((long long)0x4000204) & 0xFFFFFFFFFFFFFFFFLL);
+    volatile unsigned short *reg = (volatile unsigned short *)(((long long)0x4000204));
     *reg = (self[0] << 2) | (*reg & ~0xc);
     *reg = (self[1] << 4) | (*reg & ~0x10);
 }

--- a/src/func_0206a4a0.c
+++ b/src/func_0206a4a0.c
@@ -45,7 +45,7 @@ int func_0206a4a0(void)
     if (card->w8 != *(int *)(io + 0xac) && card->b0) {
     setflag:
         {
-            u8 *p = (u8 *)(((int)card + 5) & 0xFFFFFFFFFFFFFFFF);
+            u8 *p = (u8 *)(((int)card + 5));
             ret = 0;
             *p |= 2;
         }

--- a/src/func_0206c8b4.c
+++ b/src/func_0206c8b4.c
@@ -4,15 +4,15 @@ int func_0206c8b4(double x)
     int hi, lo;
     int a, b, p;
 
-    a = (int)((long long)(int)&x & 0xffffffffffffffffLL);
-    p = (int)((long long)(a + 7) & 0xffffffffffffffffLL);
+    a = (int)((long long)(int)&x);
+    p = (int)((long long)(a + 7));
     if (p & 1)
         hi = (*(unsigned short *)(p - 1) & 0xff00) >> 8;
     else
         hi = *(unsigned short *)p & 0xff;
 
-    b = (int)((long long)(int)&x & 0xffffffffffffffffLL);
-    p = (int)((long long)(b + 6) & 0xffffffffffffffffLL);
+    b = (int)((long long)(int)&x);
+    p = (int)((long long)(b + 6));
     if (p & 1)
         lo = (*(unsigned short *)(p - 1) & 0xff00) >> 8;
     else

--- a/src/func_0206e030.c
+++ b/src/func_0206e030.c
@@ -2,7 +2,7 @@ void func_0206e030(char *self)
 {
     *(int *)(self + 0x24) = *(int *)(self + 0x1c);
     *(int *)(self + 0x28) = *(int *)(self + 0x20);
-    *(int *)(((long long)(int)(self + 0x28)) & 0xFFFFFFFFFFFFFFFFLL) -=
+    *(int *)(((long long)(int)(self + 0x28))) -=
         (*(int *)(self + 0x18) & *(int *)(self + 0x2c));
     *(int *)(self + 0x34) = *(int *)(self + 0x18);
 }

--- a/src/func_0206e06c.c
+++ b/src/func_0206e06c.c
@@ -28,13 +28,13 @@ int func_0206e06c(S6e06c *p)
         return 0;
 
     if (p->b8 >= 3)
-        *(unsigned int *)(((int)p + 8) & 0xFFFFFFFFFFFFFFFF) = (*(unsigned int *)(((int)p + 8) & 0xFFFFFFFFFFFFFFFF) & ~7) | 2;
+        *(unsigned int *)(((int)p + 8)) = (*(unsigned int *)(((int)p + 8)) & ~7) | 2;
 
     if (p->b8 == 2)
         *(int *)((char *)p + 0x28) = 0;
 
     if (p->b8 != 1) {
-        *(unsigned int *)(((int)p + 8) & 0xFFFFFFFFFFFFFFFF) &= ~7;
+        *(unsigned int *)(((int)p + 8)) &= ~7;
         return 0;
     }
 
@@ -43,7 +43,7 @@ int func_0206e06c(S6e06c *p)
         *(int *)((char *)p + 0x28) = 0;
         return -1;
     }
-    *(unsigned int *)(((int)p + 8) & 0xFFFFFFFFFFFFFFFF) &= ~7;
+    *(unsigned int *)(((int)p + 8)) &= ~7;
     *(int *)((char *)p + 0x18) = 0;
     *(int *)((char *)p + 0x28) = 0;
     return 0;

--- a/src/func_0206e450.c
+++ b/src/func_0206e450.c
@@ -8,7 +8,7 @@ int func_0206e450(char* obj, const void* src, unsigned int n)
         n = len - off;
     func_0206e310(*(char**)(obj) + off, src, n);
     {
-        int* p = (int*)(((long long)(int)(obj + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p = (int*)(((long long)(int)(obj + 8)));
         *p = *p + n;
     }
     return 1;

--- a/src/func_0206fd6c.c
+++ b/src/func_0206fd6c.c
@@ -50,7 +50,7 @@ unsigned char *func_0206fd6c(unsigned char *format_string, char **arg, print_for
     f.field_width           = 0;
     f.precision             = 0;
 
-    s = (unsigned char *)(((long long)(int)(format_string + 1)) & 0xFFFFFFFFFFFFFFFFLL);
+    s = (unsigned char *)(((long long)(int)(format_string + 1)));
     if ((c = *s) == '%') {
         f.conversion_char = (unsigned char)c;
         *format = f;

--- a/src/func_020707cc.c
+++ b/src/func_020707cc.c
@@ -1,7 +1,7 @@
 double func_020707cc(double x)
 {
-    int a = (int)((long long)(int)&x & 0xffffffffffffffffLL);
-    int *p = (int *)((long long)(a + 4) & 0xffffffffffffffffLL);
+    int a = (int)((long long)(int)&x);
+    int *p = (int *)((long long)(a + 4));
     *p &= 0x7fffffff;
     return x;
 }

--- a/src/func_02070b98.c
+++ b/src/func_02070b98.c
@@ -19,8 +19,8 @@ void func_02070b98(void* a0, int a1, int a2, void* d)
         *(u8*)(c + 4) += 1;
         (c + t)[5] = 0;
     }
-    *(s16*)(((int)c + 2) & 0xFFFFFFFFFFFFFFFF) -= *(u8*)(c + 4) - 1;
+    *(s16*)(((int)c + 2)) -= *(u8*)(c + 4) - 1;
     for (i = 0; i < *(u8*)(c + 4); i++) {
-        *(u8*)(((int)c + i + 5) & 0xFFFFFFFFFFFFFFFF) += 0x30;
+        *(u8*)(((int)c + i + 5)) += 0x30;
     }
 }

--- a/src/func_02071364.c
+++ b/src/func_02071364.c
@@ -54,8 +54,7 @@ void func_02071364(Decimal *result, const Decimal *x, const Decimal *y)
     result->exp = (short)(x->exp + y->exp);
 
     if (accumulator) {
-        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)) &
-                                    0xffffffffffffffffLL);
+        short *exp = (short *)(int)(((long long)(int)((char *)result + 2)));
         *--ip = (unsigned char)accumulator;
         *exp = *exp + 1;
     }

--- a/src/func_02071864.c
+++ b/src/func_02071864.c
@@ -38,7 +38,7 @@ void func_02071864(Obj *t, Wrap *w)
     t->b6c = (f80 != 0);
     t->h68 = data[1] << 4;
     p = data + 2;
-    *(u16 *)(int)(((long long)(int)((int)t + 0x68)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000;
+    *(u16 *)(int)(((long long)(int)((int)t + 0x68))) |= 0x4000;
     p = func_02071a50(p, &t->w60);
     if (f40) {
         p = func_02071a50(p, &t->w64);

--- a/src/func_ov001_020aa420.c
+++ b/src/func_ov001_020aa420.c
@@ -73,7 +73,7 @@ void func_ov001_020aa420(void) {
         if (reqFlag == 0) {
             if (node != 0) {
                 do {
-                    *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+                    *(u8 *)(((long long)(int)((char *)node + 0x1b))) &= ~2;
                     if (node->field19 == 1) {
                         *flagByte = 1;
                     }
@@ -100,7 +100,7 @@ void func_ov001_020aa420(void) {
                     if (node->flags.b0) {
                         if (node->soundHandle == -1) {
                             node->soundHandle = func_0202a8e0(node->field4, node->field18);
-                            *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+                            *(u8 *)(((long long)(int)((char *)node + 0x1b))) |= 2;
                             func_ov001_020aa6b0(node, 1);
                         }
                         handled = 1;
@@ -114,7 +114,7 @@ void func_ov001_020aa420(void) {
                         if (node->flags.b3) {
                             best = node;
                         } else {
-                            *(u8 *)(((long long)(int)((char *)node + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+                            *(u8 *)(((long long)(int)((char *)node + 0x1b))) |= 8;
                         }
                     }
                 } else {
@@ -125,7 +125,7 @@ void func_ov001_020aa420(void) {
         }
 
         if (func_ov001_020aa7b8(i, best) != 0) {
-            *(u8 *)(((long long)(int)((char *)best + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+            *(u8 *)(((long long)(int)((char *)best + 0x1b))) |= 2;
             best->soundHandle = func_0202a8e0(best->field4, best->field18);
             func_ov001_020aa6b0(best, 1);
             func_ov001_020aa6e4(i, best->field19, best);

--- a/src/func_ov001_020aaa54.cpp
+++ b/src/func_ov001_020aaa54.cpp
@@ -21,7 +21,7 @@ extern signed char data_0209f2f8;
 
 /* Route the +0x1b flag-byte address through 64-bit arithmetic so it is
  * materialized (add rX,base,#0x1b) for the read-modify-write, matching the ROM. */
-#define FLAGS1B(p) (*(u8*)(((int)(p) + 0x1b) & 0xffffffffffffffffLL))
+#define FLAGS1B(p) (*(u8*)(((int)(p) + 0x1b)))
 
 struct Node {
     u8 pad0[4];

--- a/src/func_ov001_020aadac.c
+++ b/src/func_ov001_020aadac.c
@@ -10,7 +10,7 @@ extern int data_0209f3e8[];
 extern unsigned char data_ov001_020ad62c[];
 extern int* data_ov001_020ad634[];
 
-#define LAUNDER_U8_PTR(p) ((unsigned char*)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER_U8_PTR(p) ((unsigned char*)(((long long)(int)(p))))
 
 void func_ov001_020aadac(void) {
     char* fp = data_0209f394;

--- a/src/func_ov001_020aaf40.c
+++ b/src/func_ov001_020aaf40.c
@@ -27,7 +27,7 @@ void func_ov001_020aaf40(void)
             while (node) {
                 if (*(int*)(node + 0x14) != -1 && *(unsigned char*)(node + 0x1a) != 0) {
                     int v;
-                    *(unsigned char *)(int)(((long long)(int)(node + 0x1a)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                    *(unsigned char *)(int)(((long long)(int)(node + 0x1a))) -= 1;
                     v = *(unsigned char*)(node + 0x1a);
                     if (v == 0) {
                         func_ov001_020aa6b0(node, 1);

--- a/src/func_ov001_020ab110.c
+++ b/src/func_ov001_020ab110.c
@@ -48,7 +48,7 @@ void func_ov001_020ab110(char *r4)
     *((int *)(r4 + 0x10)) = 0;
     *inline_fn(r4, 0x14) = -1;
     *((unsigned char *)(r4 + 0x1b)) = 0;
-    unsigned char *flag = (unsigned char *)(((long long)(int)(r4 + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char *flag = (unsigned char *)(((long long)(int)(r4 + 0x1b)));
     *flag |= 4;
     new_var = r4 + 0x18;
     *((unsigned char *)new_var) = 3;

--- a/src/func_ov001_020ab228.c
+++ b/src/func_ov001_020ab228.c
@@ -18,7 +18,7 @@ void func_ov001_020ab228(char* c, char* a1, int idx, int a3, unsigned char a5){
     *(unsigned char*)(c+0x1a) = 0;
     *(unsigned char*)(c+0x1b) = 0;
     {
-        unsigned char *p1b = (unsigned char *)(int)(((long long)(int)(c + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p1b = (unsigned char *)(int)(((long long)(int)(c + 0x1b)));
         *p1b = (*p1b & ~1) | (a5 & 1);
     }
     if(a5!=0 || a3==3) func_ov001_020aa6cc(idx);

--- a/src/func_ov001_020ab3c4.c
+++ b/src/func_ov001_020ab3c4.c
@@ -6,6 +6,6 @@ void *func_ov001_020ab3c4(void *r0) {
     *(int *)(ptr + 0xc) = 0;
     *(int *)(ptr + 0x10) = 0;
 
-    *(unsigned char *)(int)(((long long)(int)(ptr + 0x1b)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+    *(unsigned char *)(int)(((long long)(int)(ptr + 0x1b))) |= 4;
     return r0;
 }

--- a/src/func_ov001_020ab550.c
+++ b/src/func_ov001_020ab550.c
@@ -9,7 +9,7 @@ void func_ov001_020ab550(char *c)
     if (v <= 0) {
         return;
     }
-    p = (int *)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+    p = (int *)(((int)c + 0xc));
     *p = *p - data_0208ee44;
     v = *(int *)(c + 0xc);
     if (v > 0) {

--- a/src/func_ov002_020ada40.cpp
+++ b/src/func_ov002_020ada40.cpp
@@ -36,7 +36,7 @@ struct Player3 {
 };
 
 void func_ov002_020ada40(Player3* r0, short* r1, void* r2) {
-    *(int *)(((int)r0 + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x10000001;
+    *(int *)(((int)r0 + 0xb0)) &= ~0x10000001;
     r0->ang = Vec3_HorzAngle((const Vector3*)((char*)r2+0x5c), &r0->pos);
     r0->f98 = 0xa000;
     r0->fa8 = 0x28000;

--- a/src/func_ov002_020ae73c.c
+++ b/src/func_ov002_020ae73c.c
@@ -17,10 +17,10 @@ void func_ov002_020ae73c(char* c, char* arg)
         *(int*)(c + 0x98) = 0x14000;
 
     {
-        int *p = (int *)(((int)(c) + 0x98) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)(c) + 0x98));
         *p = *p / 6;
     }
     *(s16*)(c + 0x102) = 8;
-    *(int *)(((int)(c) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)(c) + 0xb0)) &= ~1;
     _ZN5Sound9PlayBank0EjRK7Vector3(0xa, c + 0x74);
 }

--- a/src/func_ov002_020ae8b8.c
+++ b/src/func_ov002_020ae8b8.c
@@ -21,5 +21,5 @@ void func_ov002_020ae8b8(char* c, char* arg)
         *(int*)(c + 0x98) = 0xa000;
         *(int*)(c + 0xa8) = 0x28000;
     }
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)c + 0xb0)) &= ~1;
 }

--- a/src/func_ov002_020ae968.c
+++ b/src/func_ov002_020ae968.c
@@ -17,6 +17,6 @@ void func_ov002_020ae968(char* c, char* arg)
     } else {
         *(int*)(c + 0x98) = 0x14000;
     }
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)c + 0xb0)) &= ~1;
     _ZN5Sound9PlayBank0EjRK7Vector3(9, (void*)(c + 0x74));
 }

--- a/src/func_ov002_020ae9f8.c
+++ b/src/func_ov002_020ae9f8.c
@@ -5,5 +5,5 @@ void func_ov002_020ae9f8(char *self)
     *(unsigned int *)(self + 0x98) = 0;
     *(unsigned int *)(self + 0xa8) = 0;
     *(unsigned short *)(self + 0x102) = 0xf;
-    *(unsigned int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1;
+    *(unsigned int *)(((long long)(int)(self + 0xb0))) &= ~0x1;
 }

--- a/src/func_ov002_020aea30.c
+++ b/src/func_ov002_020aea30.c
@@ -18,7 +18,7 @@ struct C {
 };
 extern "C" void func_ov002_020aea30(C* c, int a, int b) {
   if (c->f10c == 0) return;
-  (*(unsigned int*)((long long)(int)((char*)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL)) &= ~0x10000000;
+  (*(unsigned int*)((long long)(int)((char*)c + 0xb0))) &= ~0x10000000;
   c->f102 = 0;
   (c->*data_ov002_0210db80[c->f10c - 1])(a, b);
   c->f9c = -0x2000;

--- a/src/func_ov002_020aefa4.c
+++ b/src/func_ov002_020aefa4.c
@@ -1,4 +1,4 @@
 void func_ov002_020aefa4(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+    *(unsigned int *)(((long long)(int)(self + 0x12c))) |= 0x8000;
 }

--- a/src/func_ov002_020aefb8.c
+++ b/src/func_ov002_020aefb8.c
@@ -21,9 +21,9 @@ void func_ov002_020aefb8(char* self) {
     int *pz;
     ((Actor*)self)->UpdatePosWithHorzSpeedAndAng();
     if (((WithMeshClsn*)(self + 0x144))->IsOnGround()) {
-        px = (int*)(int)(((long long)(int)(self + 0xa4)) & 0xFFFFFFFFFFFFFFFFLL);
+        px = (int*)(int)(((long long)(int)(self + 0xa4)));
         *px += *(int*)(self + 0xd4) * 0xa;
-        pz = (int*)(int)(((long long)(int)(self + 0xac)) & 0xFFFFFFFFFFFFFFFFLL);
+        pz = (int*)(int)(((long long)(int)(self + 0xac)));
         *pz += *(int*)(self + 0xdc) * 0xa;
         if (((WithMeshClsn*)(self + 0x144))->JustHitGround()) {
             *(int*)(self + 0xa8) = -(*(int*)(self + 0xa8) << 2) / 10;

--- a/src/func_ov002_020af0c0.c
+++ b/src/func_ov002_020af0c0.c
@@ -1,5 +1,5 @@
 typedef struct Vector3 { int x, y, z; } Vector3;
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 extern short data_02082214[];
 #define SINE_TABLE data_02082214
 extern char* _ZN5Actor13ClosestPlayerEv(void*);

--- a/src/func_ov002_020af474.c
+++ b/src/func_ov002_020af474.c
@@ -12,7 +12,7 @@ void func_ov002_020af474(char* o)
     }
 
     {
-        s16* p = (s16*)(((long long)(int)(o + 0x92)) & 0xFFFFFFFFFFFFFFFFLL);
+        s16* p = (s16*)(((long long)(int)(o + 0x92)));
         *p = *p - 0x1000;
     }
 

--- a/src/func_ov002_020af684.cpp
+++ b/src/func_ov002_020af684.cpp
@@ -14,7 +14,7 @@ extern "C" void func_ov002_020af684(char* self, int target, char* player){
         if (found == 0)
             break;
         if (target == *(int*)((char*)found + 0x384)) {
-            (*(int *)(((int)found + 0x390) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(int *)(((int)found + 0x390)))--;
             break;
         }
     }

--- a/src/func_ov002_020af724.c
+++ b/src/func_ov002_020af724.c
@@ -12,12 +12,12 @@ void func_ov002_020af724(unsigned char *self)
     switch (*(int *)(self + 0x388)) {
     case 0:
         _ZN5Sound9PlayBank3EjRK7Vector3(0x69, (struct Vector3 *)(self + 0x74));
-        *(int *)((int)self + 0x388 & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(int *)((int)self + 0x388) += 1;
         break;
     case 1:
-        if (_ZNK12WithMeshClsn10IsOnGroundEv((void *)((int)self + 0x144 & 0xFFFFFFFFFFFFFFFF)) != 0) {
-            *(int *)((int)self + 0x128 & 0xFFFFFFFFFFFFFFFF) &= ~1;
-            *(int *)((int)self + 0x388 & 0xFFFFFFFFFFFFFFFF) += 1;
+        if (_ZNK12WithMeshClsn10IsOnGroundEv((void *)((int)self + 0x144)) != 0) {
+            *(int *)((int)self + 0x128) &= ~1;
+            *(int *)((int)self + 0x388) += 1;
         }
         break;
     case 2:

--- a/src/func_ov002_020af7cc.c
+++ b/src/func_ov002_020af7cc.c
@@ -2,7 +2,7 @@ void func_ov002_020af7cc(char* c)
 {
     *(unsigned char*)(c + 0x38e) = 1;
     if (*(int*)(c + 0x60) >= *(int*)(c + 0x37c) + 0x64000) return;
-    *(int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0x5000;
+    *(int*)(((long long)(int)(c + 0x60))) += 0x5000;
     if (*(int*)(c + 0x60) < *(int*)(c + 0x37c) + 0x64000) return;
     *(int*)(c + 0x60) = *(int*)(c + 0x37c) + 0x64000;
     *(int*)(c + 0x384) = 0;

--- a/src/func_ov002_020af908.c
+++ b/src/func_ov002_020af908.c
@@ -1,6 +1,6 @@
 extern void func_ov002_020af924(char *self);
 
 void func_ov002_020af908(char *self) {
-    *(short *)(int)(((long long)(int)(self + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0xc00;
+    *(short *)(int)(((long long)(int)(self + 0x8e))) += 0xc00;
     func_ov002_020af924(self);
 }

--- a/src/func_ov002_020af950.c
+++ b/src/func_ov002_020af950.c
@@ -19,8 +19,7 @@ void func_ov002_020af950(char *self)
       *((unsigned char *)(self + 0x38e)) = 1;
       func_ov002_020aefa4(self);
       Sound_PlayBank3(0x68, self + 0x74);
-      *((unsigned int *)(((long long)(int)(self + 0xb0)) &
-                         0xFFFFFFFFFFFFFFFFLL)) &= ~1;
+      *((unsigned int *)(((long long)(int)(self + 0xb0)))) &= ~1;
       return;
 
     case 1:
@@ -36,8 +35,7 @@ void func_ov002_020af950(char *self)
       if (*((unsigned short *)(self + 0x100)) != 0x25)
         return;
 
-      *((unsigned int *)(((long long)(int)(self + 0x128)) &
-                         0xFFFFFFFFFFFFFFFFLL)) &= ~1;
+      *((unsigned int *)(((long long)(int)(self + 0x128)))) &= ~1;
       *((int *)(self + 0x388)) = 1;
       *((int *)(self + 0x9c)) = 0;
       *((int *)(self + 0x98)) = 0xa000;

--- a/src/func_ov002_020afc68.cpp
+++ b/src/func_ov002_020afc68.cpp
@@ -8,7 +8,7 @@ extern "C" int _ZN5Actor15IsPlayerInRangeEi(void *self, int r);
 extern "C" void func_ov002_020afc68(unsigned char *self)
 {
     if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x144) != 0) {
-        int *p = (int *)(((int)self + 0x98) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)self + 0x98));
         *p += 0x19000;
         *(int *)(self + 0xa8) = 0;
     } else {

--- a/src/func_ov002_020afe4c.cpp
+++ b/src/func_ov002_020afe4c.cpp
@@ -17,7 +17,7 @@ void func_ov002_020afe4c(char* c) {
         }
         func_ov002_020af474(c);
         if (*(unsigned short*)(c+0x100) == 0x25) {
-            *(int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+            *(int *)(((int)c + 0x128)) &= ~1;
             *(int*)(c+0x388) = 1;
             *(int*)(c+0x98) = 0x8000;
         }

--- a/src/func_ov002_020aff10.c
+++ b/src/func_ov002_020aff10.c
@@ -13,7 +13,7 @@ void func_ov002_020aff10(char* c){
     if(*(unsigned short*)(c+0x100) == 0) _ZN5Sound9PlayBank3EjRK7Vector3(0x68, c+0x74);
     func_ov002_020af474(c);
     if(*(unsigned short*)(c+0x100) != 0x25) break;
-    *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int*)(((int)c + 0x128)) &= ~1;
     *(int*)(c+0x388) = 1;
     *(int*)(c+0x98) = 0x2000;
     break;

--- a/src/func_ov002_020b10e4.c
+++ b/src/func_ov002_020b10e4.c
@@ -49,7 +49,7 @@ void func_ov002_020b10e4(char* c)
                     int dist = Vec3_HorzDist((Vector3*)(c + 0x5c), (Vector3*)(ac + 0x5c));
                     if (dist < (radius << 3) && dy <= 0x1f4000 && dy >= 0) {
                         *(int*)(c + 0x398) = *(int*)(ac + 0x60) + 0x32000;
-                        ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 1;
+                        ((struct BF3ae*)((long long)(c + 0x3ae)))->sel = 1;
                         return;
                     }
                 }
@@ -77,12 +77,12 @@ void func_ov002_020b10e4(char* c)
             _ZNK10ClsnResult6CopyToERS_(rl + 0x10, cr);
             if (_ZNK10ClsnResult9GetClsnIDEv(cr) != (u32)-1 &&
                 _ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(cr)) != 0) {
-                ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 0;
+                ((struct BF3ae*)((long long)(c + 0x3ae)))->sel = 0;
             } else {
                 Vector3 pos;
                 _ZN11RaycastLine10GetClsnPosEv(&pos, rl);
                 *(int*)(c + 0x398) = pos.y;
-                ((struct BF3ae*)((long long)(c + 0x3ae) & 0xFFFFFFFFFFFFFFFFLL))->sel = 1;
+                ((struct BF3ae*)((long long)(c + 0x3ae)))->sel = 1;
             }
         }
         _ZN10ClsnResultD1Ev(cr);

--- a/src/func_ov002_020b12ec.c
+++ b/src/func_ov002_020b12ec.c
@@ -17,7 +17,7 @@ int func_ov002_020b12ec(char *self)
     }
     r3 = 0;
     *(unsigned int *)(self + 0xd0) = r3;
-    slot = (char *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+    slot = (char *)(((long long)(int)(self + 0xb0)));
     r1 = *(unsigned int *)slot;
     r1 &= ~0xe0000u;
     *(unsigned int *)slot = r1;

--- a/src/func_ov002_020b16c4.c
+++ b/src/func_ov002_020b16c4.c
@@ -19,7 +19,7 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsig
                                                           int e, int f);
 extern void _ZN9PowerStar13AddStarMarkerEv(void *o);
 
-#define LAUNDER(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER(p) ((int)(((long long)(int)(p))))
 
 void func_ov002_020b16c4(void *cc, void *pp)
 {

--- a/src/func_ov002_020b1a60.c
+++ b/src/func_ov002_020b1a60.c
@@ -1,17 +1,17 @@
 extern int _ZN9ActorBase18MarkForDestructionEv(void*);
 void func_ov002_020b1a60(void* c) {
   {
-    unsigned short* n = (unsigned short*)(((int)c + 0x3a8) & 0xFFFFFFFFFFFFFFFF);
+    unsigned short* n = (unsigned short*)(((int)c + 0x3a8));
     *n += 1;
   }
   {
-    int* s = (int*)(((int)*(void**)((char*)c+0x39c) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    int* s = (int*)(((int)*(void**)((char*)c+0x39c) + 0x5c));
     *(int*)((char*)c+0x5c) = s[0];
     *(int*)((char*)c+0x60) = s[1];
     *(int*)((char*)c+0x64) = s[2];
   }
   {
-    int* g = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+    int* g = (int*)(((int)c + 0x60));
     *g += 0xc8000;
   }
   if (*(unsigned short*)((char*)c+0x300+0xa8) < 0x41) return;

--- a/src/func_ov002_020b1ad4.c
+++ b/src/func_ov002_020b1ad4.c
@@ -29,7 +29,7 @@ void func_ov002_020b1ad4(char *self)
         if (data_0209f2f8 == 0xb) v <<= 1;
         *(int *)(self + 0x98) = v;
         *(int *)(self + 0xa8) = 0x14000;
-        ((struct Bits3ae *)(int)(((long long)(int)(self + 0x3ae)) & 0xFFFFFFFFFFFFFFFFLL))->field++;
+        ((struct Bits3ae *)(int)(((long long)(int)(self + 0x3ae))))->field++;
         _ZN12WithMeshClsn13SetLimMovFlagEv(self + 0x1ac);
         *(short *)(self + 0x3a8) = 0x1c2;
     }

--- a/src/func_ov002_020b1cc0.c
+++ b/src/func_ov002_020b1cc0.c
@@ -44,7 +44,7 @@ void func_ov002_020b1cc0(char *c)
             if (*(int *)(c + 0x60) <= *(int *)(p + 0x60)) {
                 *(int *)(c + 0x60) = *(int *)(p + 0x60);
                 _ZN5Sound9PlayBank3EjRK7Vector3(0x52, c + 0x74);
-                bf = (BF *)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFF);
+                bf = (BF *)(((int)c + 0x3ae));
                 bf->f1++;
                 v = ((BF *)(c + 0x3ae))->f1;
                 if (v < 3u)
@@ -52,7 +52,7 @@ void func_ov002_020b1cc0(char *c)
                 else
                     r3v = 0x555;
                 *(int *)(c + 0xa8) = -*(int *)(c + 0xa8) * r3v / 0x1000;
-                *(int *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 1;
+                *(int *)(((int)c + 0x98)) >>= 1;
                 if (*(int *)(c + 0xa8) >= -*(int *)(c + 0x9c))
                     return;
                 *(int *)(c + 0xa8) = 0;
@@ -76,7 +76,7 @@ void func_ov002_020b1cc0(char *c)
             if (*(u16 *)(c + 0x3a8) > 0xf000)
                 *(u16 *)(c + 0x3a8) = 0xf;
             _ZN5Sound9PlayBank3EjRK7Vector3(0x52, c + 0x74);
-            bf = (BF *)(((int)c + 0x3ae) & 0xFFFFFFFFFFFFFFFF);
+            bf = (BF *)(((int)c + 0x3ae));
             bf->f1++;
             v = ((BF *)(c + 0x3ae))->f1;
             if (v < 3u)
@@ -84,15 +84,15 @@ void func_ov002_020b1cc0(char *c)
             else
                 r3v = 0x555;
             *(int *)(c + 0xa8) = -*(int *)(c + 0xa8) * r3v / 0x1000;
-            *(int *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) >>= 1;
+            *(int *)(((int)c + 0x98)) >>= 1;
         }
     }
 
     if (n.x != 0 || n.z != 0) {
         int m6 = data_ov002_020ff078[attr];
-        int *pa = (int *)(((int)c + 0xa4) & 0xFFFFFFFFFFFFFFFF);
+        int *pa = (int *)(((int)c + 0xa4));
         *pa += n.x * m6;
-        *(int *)(((int)c + 0xac) & 0xFFFFFFFFFFFFFFFF) += n.z * m6;
+        *(int *)(((int)c + 0xac)) += n.z * m6;
         *(int *)(c + 0x98) = Vec3_HorzLen(pa);
         if (*(int *)(c + 0x98) > 0x1c000) {
             *(int *)(c + 0x98) = 0x1c000;

--- a/src/func_ov002_020b20b4.cpp
+++ b/src/func_ov002_020b20b4.cpp
@@ -12,9 +12,9 @@ void func_ov002_020b20b4(char* c){
   func_ov002_020b1008(c);
   if (((struct BF3ae*)(c+0x3ae))->b0) return;
   if (_ZN5Event6GetBitEj(*(unsigned char*)(c+0x3ab)) == 0) return;
-  ((struct BF3ae*)(int)(((long long)(int)((int)c + 0x3ae)) & 0xFFFFFFFFFFFFFFFFLL))->b0 = 1;
+  ((struct BF3ae*)(int)(((long long)(int)((int)c + 0x3ae))))->b0 = 1;
   *(int*)(c+0x3a4) = 4;
-  *(int*)(int)(((long long)(int)((int)c + 0x190)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+  *(int*)(int)(((long long)(int)((int)c + 0x190))) &= ~1;
   char* found = (char*)_ZN5Actor15FindWithActorIDEjPS_(0xa, 0);
   if (found) {
     *(short*)(c+0x3a8) = *(unsigned short*)(found+0x32a);

--- a/src/func_ov002_020b33dc.cpp
+++ b/src/func_ov002_020b33dc.cpp
@@ -18,7 +18,7 @@ extern "C" void _ZN12CylinderClsn6UpdateEv(char* cl);
 
 extern "C" int daObjAbuku_c_Behavior(char* self)
 {
-    *(short*)(((int)self + 0x10c) & 0xFFFFFFFFFFFFFFFF) += 0x400;
+    *(short*)(((int)self + 0x10c)) += 0x400;
     int v = *(volatile unsigned short*)(self + 0x10c);
     int x = v >> 4;
     short tv = data_02082214[2*x + 1];

--- a/src/func_ov002_020b4bfc.c
+++ b/src/func_ov002_020b4bfc.c
@@ -4,7 +4,7 @@ extern int _ZN16MeshColliderBase9IsEnabledEv(void*);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void*, void*);
 extern void _ZN16MeshColliderBase7DisableEv(void*);
 
-#define LD(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LD(p) ((int)(((long long)(int)(p))))
 
 int func_ov002_020b4bfc(char* c)
 {

--- a/src/func_ov002_020b6494.c
+++ b/src/func_ov002_020b6494.c
@@ -13,11 +13,11 @@ int func_ov002_020b6494(char* c){
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
   }
-  *(u16*)(((int)c + 0x328) & 0xFFFFFFFFFFFFFFFF) += 0x100;
+  *(u16*)(((int)c + 0x328)) += 0x100;
   {
-    u16 h = (u16)(((s64)*(s16*)(c+0x328)) & 0xFFFFFFFFFFFFFFFF);
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-      *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)
+    u16 h = (u16)(((s64)*(s16*)(c+0x328)));
+    *(int*)(((int)c + 0x60)) =
+      *(int*)(((int)c + 0x60))
       - (int)((((s64)*(int*)(c+0x324) * data_02082214[(h >> 4) * 2]) + 0x800) >> 0xc);
   }
   {

--- a/src/func_ov002_020b6718.cpp
+++ b/src/func_ov002_020b6718.cpp
@@ -4,7 +4,7 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(void*, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 int func_ov002_020b6718(char* c) {
-    short* p=(short*)(((long long)(int)(c+0x94))&0xFFFFFFFFFFFFFFFFLL);
+    short* p=(short*)(((long long)(int)(c+0x94)));
     *p = *p + *(short*)(c+0x96);
     *(short*)(c+0x8e) = *(short*)(c+0x94);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov002_020b6b38.c
+++ b/src/func_ov002_020b6b38.c
@@ -33,7 +33,7 @@ int func_ov002_020b6b38(struct Obj* c)
     int i;
     Vector3 mid;
     Vector3 res;
-    short* rzp = (short*)((long long)(int)((char*)c + 0x90) & 0xffffffffffffffffLL);
+    short* rzp = (short*)((long long)(int)((char*)c + 0x90));
     *rzp = *rzp + 0x100;
     {
         int b = (int)((c->flags & 8) != 0);

--- a/src/func_ov002_020b6d84.c
+++ b/src/func_ov002_020b6d84.c
@@ -23,7 +23,7 @@ extern struct Player* _ZN5Actor13ClosestPlayerEv(struct Actor* self);
 extern u32 func_02022c3c(u32 uniqueID, u32 effectID, Fix12 x, Fix12 y, Fix12 z, const void* dir);
 
 int daObjLava_c_Behavior(struct Actor* self) {
-    struct Vec3* v = (struct Vec3*)(((int)_ZN5Actor13ClosestPlayerEv(self) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    struct Vec3* v = (struct Vec3*)(((int)_ZN5Actor13ClosestPlayerEv(self) + 0x5c));
     self->uniqueID = func_02022c3c(self->uniqueID, 0xb7, v->x, v->y, v->z, 0);
     return 1;
 }

--- a/src/func_ov002_020b7200.c
+++ b/src/func_ov002_020b7200.c
@@ -12,8 +12,7 @@ int func_ov002_020b7200(char* c)
     if (*(int*)(c + 0x3f0) == 0xa || *(int*)(c + 0x3f0) == 0xf) {
         if (*(int*)(c + 0x3c0) != 0) {
             sp = (short*)((long long)(int)(
-                (char*)*(int*)(c + 0x3c0) + 0x8c) &
-                0xFFFFFFFFFFFFFFFFLL);
+                (char*)*(int*)(c + 0x3c0) + 0x8c));
             *(short*)(c + 0x92) = sp[0];
             *(short*)(c + 0x94) = sp[1];
             *(short*)(c + 0x96) = sp[2];
@@ -22,8 +21,7 @@ int func_ov002_020b7200(char* c)
             *(short*)(c + 0x90) = *(short*)(c + 0x96);
 
             ip = (int*)((long long)(int)(
-                (char*)*(int*)(c + 0x3c0) + 0x5c) &
-                0xFFFFFFFFFFFFFFFFLL);
+                (char*)*(int*)(c + 0x3c0) + 0x5c));
             *(int*)(c + 0x5c) = ip[0];
             *(int*)(c + 0x60) = ip[1];
             *(int*)(c + 0x64) = ip[2];

--- a/src/func_ov002_020b7330.c
+++ b/src/func_ov002_020b7330.c
@@ -22,7 +22,7 @@ int func_ov002_020b7330(char* self)
     if (state == 0xa || state == 0xf) {
         char* closest = (char*)_ZN5Actor13ClosestPlayerEv(self);
         if (closest != 0) {
-            s16* src = (s16*)((long long)(int)(closest + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+            s16* src = (s16*)((long long)(int)(closest + 0x8c));
             *(s16*)(self + 0x92) = src[0];
             *(s16*)(self + 0x94) = src[1];
             *(s16*)(self + 0x96) = src[2];

--- a/src/func_ov002_020b74d0.c
+++ b/src/func_ov002_020b74d0.c
@@ -31,7 +31,7 @@ int func_ov002_020b74d0(char *c) {
 
     {
         char *p = *(char **)(c + 0x3c0);
-        char *q = (char *)(((int)(p + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+        char *q = (char *)(((int)(p + 0x8c)));
         *(s16 *)(c + 0x92) = *(s16 *)(q + 0);
         *(s16 *)(c + 0x94) = *(s16 *)(q + 2);
         *(s16 *)(c + 0x96) = *(s16 *)(q + 4);
@@ -42,7 +42,7 @@ int func_ov002_020b74d0(char *c) {
 
     {
         char *p = *(char **)(c + 0x3c0);
-        char *q = (char *)(((int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        char *q = (char *)(((int)(p + 0x5c)));
         *(int *)(c + 0x5c) = *(int *)(q + 0);
         *(int *)(c + 0x60) = *(int *)(q + 4);
         *(int *)(c + 0x64) = *(int *)(q + 8);

--- a/src/func_ov002_020b76ec.c
+++ b/src/func_ov002_020b76ec.c
@@ -28,8 +28,8 @@ int func_ov002_020b76ec(char *self)
     *(int *)(self + 0xc8) = 0;
     *(u8 *)(self + 0x403) = 1;
 
-    *(u32 *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x40000u;
-    *(u32 *)(((int)self + 0x12c) & 0xFFFFFFFFFFFFFFFF) &= ~0x8000u;
+    *(u32 *)(((int)self + 0xb0)) &= ~0x40000u;
+    *(u32 *)(((int)self + 0x12c)) &= ~0x8000u;
 
     if (*(int *)(self + 0x3c0) == 0) {
         *(void **)(self + 0x3c0) = _ZN5Actor13ClosestPlayerEv(self);

--- a/src/func_ov002_020b7c30.c
+++ b/src/func_ov002_020b7c30.c
@@ -11,7 +11,7 @@ int func_ov002_020b7c30(void* c) {
   if (*(int*)((char*)c + 0x9c) != 0) {
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char*)c + 0x110);
     _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(c, (char*)c + 0x144, 0);
-    *(unsigned*)(((long long)(int)((char*)c + 0x12c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x8000;
+    *(unsigned*)(((long long)(int)((char*)c + 0x12c))) |= 0x8000;
     if (_ZNK12WithMeshClsn10IsOnGroundEv((char*)c + 0x144)) {
       *(int*)((char*)c + 0x98) = 0;
       func_ov002_020b6fcc(c);

--- a/src/func_ov002_020b92c4.cpp
+++ b/src/func_ov002_020b92c4.cpp
@@ -24,7 +24,7 @@ extern "C" void func_ov002_020b92c4(void* c) {
         int w2 = (int)(((long long)v2 * 0xfa0 + 0x800) >> 12);
         *(int*)((char*)c + 0x80) = w2;
         // materialized base for halfword at offset >= 0x100
-        short* p = (short*)(((int)c + 0x3c8) & 0xFFFFFFFFFFFFFFFF);
+        short* p = (short*)(((int)c + 0x3c8));
         *p = *p + 0x2000;
     } else {
         int ret = ApproachLinear(*(int*)((char*)c + 0x84), 0xfa0, 0x199);

--- a/src/func_ov002_020b94c4.c
+++ b/src/func_ov002_020b94c4.c
@@ -47,9 +47,9 @@ void func_ov002_020b94c4(char* c)
     if (X > 0)
         delta += X;
     if (a > 0)
-        *(s16*)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += delta;
+        *(s16*)(((long long)(int)(c + 0x8e))) += delta;
     else
-        *(s16*)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) -= delta;
+        *(s16*)(((long long)(int)(c + 0x8e))) -= delta;
 
     func_0203568c((int*)(c + 0x200), 0x3c000);
     func_02035684((int*)(c + 0x200), 0x3c000);

--- a/src/func_ov002_020bac18.c
+++ b/src/func_ov002_020bac18.c
@@ -6,9 +6,9 @@ extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bankId, const Vector3 *pos);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *thiz);
 
-#define LM(p) ((u8*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LMS(p) ((short*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LMI(p) ((int*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LM(p) ((u8*)(int)(((long long)(int)(p))))
+#define LMS(p) ((short*)(int)(((long long)(int)(p))))
+#define LMI(p) ((int*)(int)(((long long)(int)(p))))
 
 int func_ov002_020bac18(char *c)
 {

--- a/src/func_ov002_020bbac8.c
+++ b/src/func_ov002_020bbac8.c
@@ -29,8 +29,8 @@ void func_ov002_020bbac8(struct Obj* self)
     self->unk98 = 0;
     self->unkA8 = 0;
     other = self->unk59C;
-    py = (int*)(((long long)(int)((char*)self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
-    src = (Vec3*)(((long long)(int)((char*)other + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    py = (int*)(((long long)(int)((char*)self + 0x60)));
+    src = (Vec3*)(((long long)(int)((char*)other + 0x5c)));
     self->pos.x = src->x;
     self->pos.y = src->y;
     self->pos.z = src->z;

--- a/src/func_ov002_020bbc78.c
+++ b/src/func_ov002_020bbc78.c
@@ -7,7 +7,7 @@ void func_ov002_020bbc78(char *self)
     *(s32 *)(self + 0x5a0) = *(s32 *)(self + 0x59c);
     *(s32 *)(self + 0x59c) = 0;
     {
-        s32 *p = (s32 *)(((int)self + 0x338) & 0xFFFFFFFFFFFFFFFFLL);
+        s32 *p = (s32 *)(((int)self + 0x338));
         *p |= 0x2000;
         *p &= ~0x4000000;
     }

--- a/src/func_ov002_020bcdf0.c
+++ b/src/func_ov002_020bcdf0.c
@@ -68,7 +68,7 @@ void func_ov002_020bcdf0(char *self)
     if (*(int *)(self + 8) == 0) {
         if (cur.id == 0xbb) {
             id = _ZNK6Player14GetBodyModelIDEjb(self, *(int *)(self + 8) & 0xff, 0);
-            anim = (char *)(((long long)(int)((char *)((int *)(self + 0xdc))[id] + 0x50)) & 0xffffffffffffffffLL);
+            anim = (char *)(((long long)(int)((char *)((int *)(self + 0xdc))[id] + 0x50)));
             frame = (unsigned int)(*(int *)(anim + 8) << 4) >> 0x10;
             if (frame >= 0x1e)
                 goto particle;
@@ -102,6 +102,6 @@ particle:
     cur.id = base[*(u8 *)(self + 0x728) + 1].id;
     cur.val = base[*(u8 *)(self + 0x728) + 1].val;
     if (cur.id != 0) {
-        *(u8 *)(((long long)(int)(self + 0x728)) & 0xffffffffffffffffLL) += 1;
+        *(u8 *)(((long long)(int)(self + 0x728))) += 1;
     }
 }

--- a/src/func_ov002_020bd3a0.c
+++ b/src/func_ov002_020bd3a0.c
@@ -7,7 +7,7 @@ extern u8 data_020a0e40;
 extern u16 data_0209f49e;
 extern u16 data_0209f49c;
 
-#define LAUNDER(x) ((int)(((long long)(int)(x)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAUNDER(x) ((int)(((long long)(int)(x))))
 
 int func_ov002_020bd3a0(char* p0, u8* p1, unsigned int p2)
 {

--- a/src/func_ov002_020bd4c8.c
+++ b/src/func_ov002_020bd4c8.c
@@ -1,5 +1,5 @@
 int func_ov002_020bd4c8(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x24000000;
+    *(unsigned int *)(((long long)(int)(self + 0xb0))) |= 0x24000000;
     return 1;
 }

--- a/src/func_ov002_020bdb50.cpp
+++ b/src/func_ov002_020bdb50.cpp
@@ -21,7 +21,7 @@ void func_ov002_020bdb50(char* c, int arg) {
         int b1 = (*(unsigned short*)(obj+0xc) == 0xbf);
         if (b1) {
             func_ov002_020d5cec();
-            (*(unsigned short *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF)) &= ~2;
+            (*(unsigned short *)(((int)c + 0x6ce))) &= ~2;
         } else {
             char* vt = *(char**)obj;
             (*(void(**)(char*, char*))(vt+0x4c))(obj, c);

--- a/src/func_ov002_020bdd2c.c
+++ b/src/func_ov002_020bdd2c.c
@@ -6,7 +6,7 @@ void func_ov002_020bdd2c(void* c) {
   if (*(unsigned char*)((char*)c+0x703) == 1) {
     func_ov002_020db8bc((unsigned char*)c, 3);
     {
-      int* base = (int*)(((int)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFF);
+      int* base = (int*)(((int)data_0209f318 + 0x154));
       *base &= ~0x80;
     }
     func_ov002_020bd984(c, 0x31);

--- a/src/func_ov002_020bdf8c.c
+++ b/src/func_ov002_020bdf8c.c
@@ -12,6 +12,6 @@ void func_ov002_020bdf8c(char* c){
   }
   *(unsigned char*)(c+0x703) = 1;
   *(unsigned short*)(c+0x600+0xc2) = 0x258;
-  (*(unsigned int *)(((int)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFF)) |= 0x80;
+  (*(unsigned int *)(((int)data_0209f318 + 0x154))) |= 0x80;
   func_ov002_020bd9ec(c, 0x31);
 }

--- a/src/func_ov002_020bfec0.c
+++ b/src/func_ov002_020bfec0.c
@@ -34,7 +34,7 @@ int func_ov002_020bfec0(char* self)
         return 0;
     }
 
-    *(u8*)(((long long)(int)(self + 0x6eb)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    *(u8*)(((long long)(int)(self + 0x6eb))) |= 1;
 
     {
         int flag = *(int*)(self + 0x354);
@@ -64,15 +64,15 @@ int func_ov002_020bfec0(char* self)
 
     switch (state) {
     case 6:
-        *(int*)(((long long)(int)(self + 0x68c)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+        *(int*)(((long long)(int)(self + 0x68c))) += inc;
         if (*(int*)(self + 0x68c) >= 0xa000) *(int*)(self + 0x68c) = 0xa000;
         goto ret0;
     case 7:
-        *(int*)(((long long)(int)(self + 0x68c)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+        *(int*)(((long long)(int)(self + 0x68c))) += inc;
         if (*(int*)(self + 0x68c) >= 0x3c000) *(int*)(self + 0x68c) = 0x3c000;
         goto ret0;
     case 8:
-        *(int*)(((long long)(int)(self + 0x68c)) & 0xFFFFFFFFFFFFFFFFLL) += inc;
+        *(int*)(((long long)(int)(self + 0x68c))) += inc;
         if (*(int*)(self + 0x68c) < 0xa0000) goto ret0;
         /* fallthrough */
     case 9:

--- a/src/func_ov002_020c0108.c
+++ b/src/func_ov002_020c0108.c
@@ -22,7 +22,7 @@ extern char data_ov002_0211025c;
 extern s32 data_ov002_020ff200[];
 extern s16 data_02082214[];
 
-#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void *)(int)(((long long)(int)((char *)(p) + (off)))))
 
 int func_ov002_020c0108(char *self, int p1)
 {

--- a/src/func_ov002_020c04e0.c
+++ b/src/func_ov002_020c04e0.c
@@ -71,12 +71,12 @@ int func_ov002_020c04e0(char *c)
     accel = (int)(((long long)accelBase * speed + 0x800) >> 12);
 
     if (angDiff < 0x4000) {
-        int *p = (int *)(((int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)(c + 0x98)));
         int v = *p + (int)(((long long)accel * horzLen + 0x800) >> 12);
         *p = v;
         return v;
     } else {
-        int *p = (int *)(((int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)(c + 0x98)));
         int v = *p - (int)(((long long)accel * horzLen + 0x800) >> 12);
         *p = v;
         return v;

--- a/src/func_ov002_020c0cbc.c
+++ b/src/func_ov002_020c0cbc.c
@@ -16,7 +16,7 @@ int func_ov002_020c0cbc(char* c){
     case 2: t = 0; break;
   }
   if(*(int*)(c+0x558) <= t){
-    (*(unsigned short *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF)) |= 1;
+    (*(unsigned short *)(((int)c + 0x6ce))) |= 1;
     return 1;
   }
   return 0;


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 98 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
