### PR TITLE
readable: strip 97 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov002_020c133c.c
+++ b/src/func_ov002_020c133c.c
@@ -23,7 +23,7 @@ void func_ov002_020c133c(char *a)
     if (_ZN6Player9GetHealthEv(a) <= 2)
         *(unsigned int *)(a + 0x624) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int *)(a + 0x624), 2, 0x27, (Vector3 *)(a + 0x74), 0);
     if (*(u8 *)(a + 0x71d) != 0) {
-        u8 *p = (u8 *)(((long long)(int)(a + 0x71d)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8 *p = (u8 *)(((long long)(int)(a + 0x71d)));
         *p = *p - 1;
         return;
     }

--- a/src/func_ov002_020c14b8.c
+++ b/src/func_ov002_020c14b8.c
@@ -94,8 +94,8 @@ void func_ov002_020c14b8(void *arg0)
         }
     }
 
-    *(unsigned short *)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
-    *(unsigned short *)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10;
+    *(unsigned short *)(((long long)(int)(c + 0x6ce))) &= ~1;
+    *(unsigned short *)(((long long)(int)(c + 0x6ce))) &= ~0x10;
     func_ov002_020c133c(c);
 
     if (savedY != (int)0x80000000)

--- a/src/func_ov002_020c1ad8.c
+++ b/src/func_ov002_020c1ad8.c
@@ -32,7 +32,7 @@ int func_ov002_020c1ad8(char* self, int ang)
     }
     if (func_ov002_020c19d0(self, 0x50, 0x32) == 0) return 0;
 
-    a = (int)((long long)(a + 0x8000) & 0xFFFFFFFFFFFFFFFFLL);
+    a = (int)((long long)(a + 0x8000));
     d = AngleDiff(*(s16*)(self + 0x6d2), (s16)a);
     if (d < 0x4000) {
         if (d < 0x1555) {

--- a/src/func_ov002_020c25a8.c
+++ b/src/func_ov002_020c25a8.c
@@ -127,13 +127,13 @@ int func_ov002_020c25a8(void *arg0, int arg1)
         _ZN12WithMeshClsn15ClearGroundFlagEv(c + 0x380);
 
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x380))
-        *(unsigned char*)(((long long)(int)(c + 0x6e9)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(unsigned char*)(((long long)(int)(c + 0x6e9))) |= 1;
 
     if (_ZNK12WithMeshClsn8IsOnWallEv(c + 0x380))
-        *(unsigned char*)(((long long)(int)(c + 0x6e9)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(unsigned char*)(((long long)(int)(c + 0x6e9))) |= 2;
 
     if (func_02035638(c + 0x380))
-        *(unsigned char*)(((long long)(int)(c + 0x6e9)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+        *(unsigned char*)(((long long)(int)(c + 0x6e9))) |= 4;
 
     if (*(unsigned char*)(c + 0x706) == 0)
         func_020371fc(c + 0x380);
@@ -184,7 +184,7 @@ int func_ov002_020c25a8(void *arg0, int arg1)
     }
 
     if (arg1 != 0) {
-        *(unsigned char*)(((long long)(int)(c + 0x6e9)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(unsigned char*)(((long long)(int)(c + 0x6e9))) |= 1;
         *(unsigned char*)(c + 0x6de) = 0;
         *(unsigned char*)(c + 0x712) = 0;
     }
@@ -201,8 +201,8 @@ int func_ov002_020c25a8(void *arg0, int arg1)
     *(int*)(c + 0x568) = wn.z;
 
     if (*(unsigned char*)(c + 0x706) == 0) {
-        *(int*)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL) -= *(int*)(c + 0x560) * 2;
-        *(int*)(((long long)(int)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL) -= *(int*)(c + 0x568) * 2;
+        *(int*)(((long long)(int)(c + 0x5c))) -= *(int*)(c + 0x560) * 2;
+        *(int*)(((long long)(int)(c + 0x64))) -= *(int*)(c + 0x568) * 2;
     }
 
     ret = func_ov002_020d0580(c);

--- a/src/func_ov002_020c2b08.c
+++ b/src/func_ov002_020c2b08.c
@@ -55,7 +55,7 @@ void func_ov002_020c2b08(void *arg0)
         }
 
         *(u16 *)(c + 0x6ba) = 0;
-        *(int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x690);
+        *(int *)(((long long)(int)(c + 0x60))) += *(int *)(c + 0x690);
         if (*(int *)(c + 0x60) < *(int *)(c + 0x644))
             *(int *)(c + 0x60) = *(int *)(c + 0x644);
         return;

--- a/src/func_ov002_020c2e78.cpp
+++ b/src/func_ov002_020c2e78.cpp
@@ -12,7 +12,7 @@ void func_ov002_020c2e78(char* c){
     return;
   }
   *(unsigned char*)(c+0x6e8) = w;
-  unsigned short *p = (unsigned short*)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF);
+  unsigned short *p = (unsigned short*)(((int)c + 0x6ce));
   *p |= 8;
 }
 }

--- a/src/func_ov002_020c3a48.c
+++ b/src/func_ov002_020c3a48.c
@@ -20,7 +20,7 @@ int func_ov002_020c3a48(char *self)
         if (_ZNK9Animation12WillHitFrameEi(anim, 0x5a)) {
             _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char *)(self + 0x6d9), 0, self + 0x74);
-            *(unsigned char *)(((long long)(int)(self + 0x6e5)) & 0xffffffffffffffffLL) += 1;
+            *(unsigned char *)(((long long)(int)(self + 0x6e5))) += 1;
         }
     } else {
         int buf[6];
@@ -32,7 +32,7 @@ int func_ov002_020c3a48(char *self)
         buf[5] = 0;
         func_ov002_020c37a4(self, (char *)(buf + 3));
         id = _ZNK6Player14GetBodyModelIDEjb(self, *(int *)(self + 8) & 0xff, 0);
-        anim = (char *)(((long long)(int)(*(char **)(self + (id << 2) + 0xdc) + 0x50)) & 0xffffffffffffffffLL);
+        anim = (char *)(((long long)(int)(*(char **)(self + (id << 2) + 0xdc) + 0x50)));
         r5 = (unsigned int)(*(int *)(anim + 8) << 4) >> 0x10;
         if (r5 == 0x6d || r5 == 0x8d) {
             _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
@@ -45,7 +45,7 @@ int func_ov002_020c3a48(char *self)
             _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char *)(self + 0x6d9), 4, self + 0x74);
             break;
         }
-        *(int *)(((long long)(int)(self + 0x688)) & 0xffffffffffffffffLL) -= 0x21000;
+        *(int *)(((long long)(int)(self + 0x688))) -= 0x21000;
         if (_ZN6Player12FinishedAnimEv(self)) {
             func_ov002_020c3cf0(self);
             return 1;

--- a/src/func_ov002_020c3bdc.c
+++ b/src/func_ov002_020c3bdc.c
@@ -18,7 +18,7 @@ void func_ov002_020c3bdc(char* c){
     *(int*)(c + 0x9c) = -0x2000;
     if (*(unsigned char*)(c + 0x6de) == 0){
       _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x55, 0x40000000, 0x1000, 0);
-      *(unsigned char *)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) += 1;
+      *(unsigned char *)(((int)c + 0x6e5)) += 1;
     }
   } else {
     if (_ZN6Player12FinishedAnimEv(c)){

--- a/src/func_ov002_020c3cf0.c
+++ b/src/func_ov002_020c3cf0.c
@@ -2,5 +2,5 @@ void func_ov002_020c3cf0(char* self)
 {
     *(unsigned char*)(self + 0x6e3) = 0;
     *(unsigned char*)(self + 0x6e5) = *(unsigned char*)(self + 0x6e3);
-    (*(unsigned char*)(((int)self + 0x6e6) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(unsigned char*)(((int)self + 0x6e6)))++;
 }

--- a/src/func_ov002_020c4188.c
+++ b/src/func_ov002_020c4188.c
@@ -25,7 +25,7 @@ int func_ov002_020c4188(char* self)
     switch (*(u8*)(self + 0x71f)) {
     case 0:
         if (*(u8*)(self + 0x71e) == 6) {
-            (*(u8*)((int)(self + 0x71f) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)((int)(self + 0x71f)))++;
             goto case1;
         }
         if (*(u8*)(self + 0x71e) < 7) {
@@ -33,38 +33,38 @@ int func_ov002_020c4188(char* self)
         } else {
             _ZN6Camera9SetFlag_3Ev(p);
         }
-        (*(u8*)((int)(self + 0x71f) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)((int)(self + 0x71f)))++;
         if (*(u8*)(self + 0x71e) >= 7) {
             break;
         }
         return 0;
     case 1:
     case1:
-        *(int*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800000;
+        *(int*)((int)(self + 0xb0)) |= 0x800000;
         data_0209b454 |= 0x800000;
         *(u8*)(self + 0x720) = 0xa;
-        (*(u8*)((int)(self + 0x71f) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)((int)(self + 0x71f)))++;
         break;
     case 2:
         if (*(u8*)(self + 0x720) != 0) {
-            (*(u8*)((int)(self + 0x720) & 0xFFFFFFFFFFFFFFFFLL))--;
+            (*(u8*)((int)(self + 0x720)))--;
             break;
         }
         func_0201f32c(data_ov002_020ff26c[*(u8*)(self + 0x71e) - 1]);
         if (*(u8*)(self + 0x71e) == 6) {
             *(void**)(self + 0x364) = _ZN5Actor13SpawnSoundObjEj(self, 5);
         }
-        (*(u8*)((int)(self + 0x71f) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)((int)(self + 0x71f)))++;
         break;
     case 3:
         if (data_0209d660 != 0) {
             break;
         }
-        (*(u8*)((int)(self + 0x71f) & 0xFFFFFFFFFFFFFFFFLL))++;
-        *(int*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800000;
+        (*(u8*)((int)(self + 0x71f)))++;
+        *(int*)((int)(self + 0xb0)) &= ~0x800000;
         data_0209b454 &= ~0x800000;
         if (*(u8*)(self + 0x71e) >= 7) {
-            *(int*)(((int)p + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
+            *(int*)(((int)p + 0x154)) &= ~8;
         }
         func_0200d81c(p, *(u8*)(self + 0x6d8));
         if (*(u8*)(self + 0x71e) == 6) {
@@ -80,7 +80,7 @@ int func_ov002_020c4188(char* self)
         }
         *(u8*)(self + 0x71e) = 0;
         *(u8*)(self + 0x71f) = 0;
-        *(int*)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x800000;
+        *(int*)((int)(self + 0xb0)) &= ~0x800000;
         data_0209b454 &= ~0x800000;
         break;
     }

--- a/src/func_ov002_020c5d0c.c
+++ b/src/func_ov002_020c5d0c.c
@@ -7,7 +7,7 @@ int func_ov002_020c5d0c(char *c)
     u16 *p;
     if (*(int *)(c + 0x60) - *(int *)(c + 0x644) >= 0x100000)
         return 0;
-    p = (u16 *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (u16 *)(((int)c + 0x6ce));
     *p |= 0x400;
     return func_ov002_020c5dec(c, 1);
 }

--- a/src/func_ov002_020c5d60.c
+++ b/src/func_ov002_020c5d60.c
@@ -8,6 +8,6 @@ void func_ov002_020c5d60(void* c) {
   }
   if (*(int*)((char*)c+0x60) >= (int)0xf8ad0000) return;
   if (_ZN6Player7IsStateERNS_5StateE(c, data_ov002_02110064)) return;
-  (*(unsigned short *)(((int)c + 0x6ce) & 0xFFFFFFFFFFFFFFFF)) |= 0x400;
+  (*(unsigned short *)(((int)c + 0x6ce))) |= 0x400;
   func_ov002_020c5dec(c, 1);
 }

--- a/src/func_ov002_020c6adc.cpp
+++ b/src/func_ov002_020c6adc.cpp
@@ -7,7 +7,7 @@ int func_ov002_020c6adc(char* c)
     unsigned short v = (unsigned short)(*(unsigned short*)(c + 0x6ce) & 8);
     if (v == 0)
         return 0;
-    *(unsigned short*)((((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL)) &= ~8;
+    *(unsigned short*)((((long long)(int)(c + 0x6ce)))) &= ~8;
     _ZN6Player11ChangeStateERNS_5StateE(c, data_ov002_021102a4);
     return 1;
 }

--- a/src/func_ov002_020c75f0.c
+++ b/src/func_ov002_020c75f0.c
@@ -48,7 +48,7 @@ void func_ov002_020c75f0(char *c)
         case 7:
             *(u8 *)(c + 0x6de) = 1;
             *(u8 *)(c + 0x6df) = 0;
-            *(int *)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL) >>= 2;
+            *(int *)(((int)c + 0x98)) >>= 2;
             *(int *)(c + 0xa8) = -(*(int *)(c + 0xa8) >> 2);
             *(u8 *)(c + 0x70c) = 0;
             _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x13, 0x40000000, 0x1000, 0);

--- a/src/func_ov002_020c7cbc.c
+++ b/src/func_ov002_020c7cbc.c
@@ -20,7 +20,7 @@ int func_ov002_020c7cbc(char* self)
 
         if (*(signed char*)(self + 0x719) >= 0) {
             LoadKeyModels(*(signed char*)(self + 0x719));
-            *(u8*)(((long long)(int)(self + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10;
+            *(u8*)(((long long)(int)(self + 0x718))) |= 0x10;
             _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x53, 0x40000000, 0x1000, 0);
             return 1;
         }

--- a/src/func_ov002_020c8540.c
+++ b/src/func_ov002_020c8540.c
@@ -46,10 +46,10 @@ int func_ov002_020c8540(char* self)
         anim = (char*)((int*)(self + 0xdc))[id] + 0x50;
         if (_ZNK9Animation12WillHitFrameEi(anim, data_ov002_020ff110[s8])) {
             char* o;
-            { int* p = (int*)((long long)(int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL); *p |= 0x800000; }
+            { int* p = (int*)((long long)(int)(self + 0xb0)); *p |= 0x800000; }
             o = *(char**)(self + 0x368);
             if (o != 0) {
-                int* p = (int*)((long long)(int)(o + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+                int* p = (int*)((long long)(int)(o + 0xb0));
                 *p &= ~0x800000;
             }
             data_0209b454 |= 0x800000;
@@ -61,10 +61,10 @@ int func_ov002_020c8540(char* self)
         char* o;
         if (data_0209d660 != 0) return 1;
         data_0209b454 &= ~0x800000;
-        { int* p = (int*)((long long)(int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL); *p &= ~0x800000; }
+        { int* p = (int*)((long long)(int)(self + 0xb0)); *p &= ~0x800000; }
         o = *(char**)(self + 0x368);
         if (o != 0) {
-            int* p = (int*)((long long)(int)(o + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)((long long)(int)(o + 0xb0));
             *p |= 0x800000;
             *(char**)(self + 0x368) = 0;
         }

--- a/src/func_ov002_020c8b78.cpp
+++ b/src/func_ov002_020c8b78.cpp
@@ -49,7 +49,7 @@ extern "C" int func_ov002_020c8b78(char *self) {
         Vec3_RotateYAndTranslate(&v, self + 0x5c, *(s16 *)(self + 0x8e), data_ov002_0210f824);
         *(u8 *)(self + 0x722) = 1;
         {
-            u16 *fl = (u16 *)(((int)self + 0x6ce) & 0xFFFFFFFFFFFFFFFF);
+            u16 *fl = (u16 *)(((int)self + 0x6ce));
             *fl |= 0x400;
         }
         {

--- a/src/func_ov002_020c8d14.c
+++ b/src/func_ov002_020c8d14.c
@@ -54,7 +54,7 @@ int func_ov002_020c8d14(char *self)
     }
 
     id = _ZNK6Player14GetBodyModelIDEjb(self, *(int *)(self + 8) & 0xff, 0);
-    anim = (char *)(((long long)(int)((char *)((int *)(self + 0xdc))[id] + 0x50)) & 0xffffffffffffffffLL);
+    anim = (char *)(((long long)(int)((char *)((int *)(self + 0xdc))[id] + 0x50)));
     if ((unsigned int)(*(int *)(anim + 8) << 4) >> 0x10 >= 0x2f) {
         if (*(u8 *)(self + 0x706) == 0) {
             if (func_ov002_020d22ec(self, 0))

--- a/src/func_ov002_020c8f0c.cpp
+++ b/src/func_ov002_020c8f0c.cpp
@@ -2,9 +2,9 @@
 extern "C" {
 extern void EnterBigBoosHaunt(void);
 int func_ov002_020c8f0c(char* c){
-  int *p0 = (int*)(((int)c + 0x80) & 0xFFFFFFFFFFFFFFFF);
-  int *p1 = (int*)(((int)c + 0x84) & 0xFFFFFFFFFFFFFFFF);
-  int *p2 = (int*)(((int)c + 0x88) & 0xFFFFFFFFFFFFFFFF);
+  int *p0 = (int*)(((int)c + 0x80));
+  int *p1 = (int*)(((int)c + 0x84));
+  int *p2 = (int*)(((int)c + 0x88));
   *p0 -= 0x80;
   *p1 -= 0x80;
   *p2 -= 0x80;

--- a/src/func_ov002_020c91bc.c
+++ b/src/func_ov002_020c91bc.c
@@ -8,7 +8,7 @@ extern int data_ov002_0211013c;
 int func_ov002_020c91bc(char* c)
 {
     if (data_0209d660 != 0) return 1;
-    *(int *)((int)(c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x800000;
+    *(int *)((int)(c + 0xb0)) &= ~0x800000;
     data_0209b454 &= ~0x800000;
     if (_ZN6Player12FinishedAnimEv(c)) {
         if (*(unsigned char*)(c + 0x706) != 0)

--- a/src/func_ov002_020c92fc.c
+++ b/src/func_ov002_020c92fc.c
@@ -32,7 +32,7 @@ int func_ov002_020c92fc(char *self)
         *(unsigned short *)(self + 0x6a4) = 0x14;
         *(u8 *)(self + 0x6e3) = 0x14;
         *(int *)(self + 0xa8) = 0;
-        *(int *)((int)(self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x800000;
+        *(int *)((int)(self + 0xb0)) |= 0x800000;
         data_0209b454 |= 0x800000;
         return 0;
     }

--- a/src/func_ov002_020c9c4c.c
+++ b/src/func_ov002_020c9c4c.c
@@ -4,7 +4,7 @@ extern unsigned int data_ov002_020ff118[];
 
 void func_ov002_020c9c4c(char* c) {
     _ZN6Player7SetAnimEji5Fix12IiEj(c, data_ov002_020ff118[*(unsigned char*)(c+0x6e3)], 0x40000000, 0x1000, 0);
-    *(unsigned char*)(((int)c + 0x6e3) & 0xFFFFFFFFFFFFFFFFLL) += 7;
+    *(unsigned char*)(((int)c + 0x6e3)) += 7;
     *(char*)(c+0x743) = 1;
     *(char*)(c+0x716) = 1;
     *(char*)(c+0x713) = 0;

--- a/src/func_ov002_020c9e18.c
+++ b/src/func_ov002_020c9e18.c
@@ -2,5 +2,5 @@ void func_ov002_020c9e18(char *c)
 {
     if (*(unsigned char *)(c + 0x709) != 1) return;
     *(unsigned char *)(c + 0x709) = 0;
-    *(unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+    *(unsigned int *)(((long long)(int)(c + 0x2ec))) &= ~4;
 }

--- a/src/func_ov002_020ca940.c
+++ b/src/func_ov002_020ca940.c
@@ -38,7 +38,7 @@ void func_ov002_020ca940(char* self)
     if (*(u16*)(data_0209f49e + (u8)data_020a0e40 * 0x18) & 0x8000) {
         old = *(u8*)(self + 0x715);
         h = data_0209f318;
-        (*(u8*)(((long long)(int)((int)self + 0x715)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)(((long long)(int)((int)self + 0x715))))++;
 
         if (*(u8*)(self + 0x715) > 2) {
             *(u8*)(self + 0x715) = 0;
@@ -56,7 +56,7 @@ void func_ov002_020ca940(char* self)
                     if (_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_0211013c) ||
                         _ZN6Player7IsStateERNS_5StateE(self, &data_ov002_0211043c) ||
                         _ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110154)) {
-                        *(u16*)(((long long)(int)((int)self + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+                        *(u16*)(((long long)(int)((int)self + 0x6ce))) |= 4;
                         break;
                     }
                 }
@@ -87,6 +87,6 @@ void func_ov002_020ca940(char* self)
     if (_ZN6Player7IsStateERNS_5StateE(self, &data_ov002_02110664)) return;
 
     if ((u16)(*(u16*)(self + 0x6ce) & 4)) {
-        *(u16*)(((long long)(int)((int)self + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+        *(u16*)(((long long)(int)((int)self + 0x6ce))) &= ~4;
     }
 }

--- a/src/func_ov002_020caf68.c
+++ b/src/func_ov002_020caf68.c
@@ -2,7 +2,7 @@ extern void func_ov002_020e63a4(void *self);
 
 void func_ov002_020caf68(void *self) {
     *(unsigned int *)((char *)self + 0x37c) = 0;
-    *(unsigned int *)(((long long)(int)((char *)self + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4u;
-    *(unsigned int *)(((long long)(int)((char *)self + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL) |= 8u;
+    *(unsigned int *)(((long long)(int)((char *)self + 0x2ec))) &= ~4u;
+    *(unsigned int *)(((long long)(int)((char *)self + 0x2ec))) |= 8u;
     func_ov002_020e63a4(self);
 }

--- a/src/func_ov002_020cbea8.c
+++ b/src/func_ov002_020cbea8.c
@@ -2,7 +2,7 @@ typedef unsigned int u32;
 extern char *_ZN5Actor10FindWithIDEj(u32 id);
 extern int func_ov002_020cc01c(char *c);
 
-#define LA(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int)(((long long)(int)(p))))
 
 int func_ov002_020cbea8(char *c)
 {

--- a/src/func_ov002_020cd308.c
+++ b/src/func_ov002_020cd308.c
@@ -3,5 +3,5 @@ void func_ov002_020cd308(char* c){
   _ZN6Player7SetAnimEji5Fix12IiEj(c,0xae,0x40000000,0x1000,0);
   *(unsigned char*)(c+0x6e3)=6;
   *(unsigned short*)(c+0x6a4)=0x10;
-  *(unsigned char*)(((int)c+0x6e5)&0xFFFFFFFFFFFFFFFFLL)&=0xa;
+  *(unsigned char*)(((int)c+0x6e5))&=0xa;
 }

--- a/src/func_ov002_020cd3e0.cpp
+++ b/src/func_ov002_020cd3e0.cpp
@@ -6,7 +6,7 @@ void func_ov002_020cd3e0(char* c){
   _ZN6Player7SetAnimEji5Fix12IiEj(c, 0xa9, 0x40000000, 0x1000, 0);
   *(unsigned char*)(c+0x6e3)=2;
   *(short*)(c+0x6a4)=0xf;
-  *(unsigned char *)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) &= 0xfe;
+  *(unsigned char *)(((int)c + 0x6e5)) &= 0xfe;
   _ZN5Sound9PlayBank0EjRK7Vector3(0x14, c+0x74);
 }
 }

--- a/src/func_ov002_020cd448.cpp
+++ b/src/func_ov002_020cd448.cpp
@@ -21,11 +21,11 @@ void func_ov002_020cd448(char* self) {
     if (fl & 2) {
         if (*(short*)((char*)&data_0209f4a4 + data_020a0e40 * 0x18) != 0) goto tail;
         if (*(short*)(self + 0x92) > 0) {
-            short* q = (short*)(((int)self + 0x92) & 0xffffffffffffffff);
+            short* q = (short*)(((int)self + 0x92));
             *q += 0x200;
             if (*(short*)(self + 0x92) > 0x3f00) *(short*)(self + 0x92) = 0x3f00;
         } else {
-            short* q = (short*)(((int)self + 0x92) & 0xffffffffffffffff);
+            short* q = (short*)(((int)self + 0x92));
             *q -= 0x200;
             if (*(short*)(self + 0x92) < -0x3f00) *(short*)(self + 0x92) = -0x3f00;
         }

--- a/src/func_ov002_020cd550.c
+++ b/src/func_ov002_020cd550.c
@@ -11,7 +11,7 @@ extern void func_ov002_020cd448(char* self);
 
 /* the += / -= on 0x92 go through a materialized base (add r1,c,#0x92;
    ldrsh/strh [r1]); the (long long)-mask launder stops mwcc folding it. */
-#define LS16(p) (*(short*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LS16(p) (*(short*)(int)(((long long)(int)(p))))
 
 void func_ov002_020cd550(char* c)
 {

--- a/src/func_ov002_020cd71c.c
+++ b/src/func_ov002_020cd71c.c
@@ -22,7 +22,7 @@ void func_ov002_020cd71c(char *self)
 
     if (target > 0) {
         if (*(s16 *)(self + 0x69c) < 0) {
-            s16 *q = (s16 *)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFLL);
+            s16 *q = (s16 *)(((int)self + 0x69c));
             *q = *q + 0x40;
             if (*(s16 *)(self + 0x69c) > c)
                 *(s16 *)(self + 0x69c) = c;
@@ -31,7 +31,7 @@ void func_ov002_020cd71c(char *self)
         }
     } else if (target < 0) {
         if (*(s16 *)(self + 0x69c) > 0) {
-            s16 *q = (s16 *)(((int)self + 0x69c) & 0xFFFFFFFFFFFFFFFFLL);
+            s16 *q = (s16 *)(((int)self + 0x69c));
             *q = *q - 0x40;
             if (*(s16 *)(self + 0x69c) < -c)
                 *(s16 *)(self + 0x69c) = -c;
@@ -43,7 +43,7 @@ void func_ov002_020cd71c(char *self)
     }
 
     {
-        s16 *q = (s16 *)(((int)self + 0x8e) & 0xFFFFFFFFFFFFFFFFLL);
+        s16 *q = (s16 *)(((int)self + 0x8e));
         *q = *q + *(s16 *)(self + 0x69c);
     }
     *(s16 *)(self + 0x90) = -(*(s16 *)(self + 0x69c) << 3);

--- a/src/func_ov002_020ce798.c
+++ b/src/func_ov002_020ce798.c
@@ -14,7 +14,7 @@ extern void _ZN11RaycastLine10GetClsnPosEv(Vector3* res, void* self);
 
 /* the -= 0x4000 goes through a materialized base (add r1,c,#0x60; ldr/str [r1]);
    the (long long)-mask launder is what stops mwcc folding it to [c,#0x60]. */
-#define LDR_I(p) (*(int*)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LDR_I(p) (*(int*)(int)(((long long)(int)(p))))
 
 void func_ov002_020ce798(char* c)
 {

--- a/src/func_ov002_020ceb7c.c
+++ b/src/func_ov002_020ceb7c.c
@@ -17,7 +17,7 @@ extern void func_0200d72c(struct Camera *thiz, unsigned char playerID);
    (ldr rN,[pc]; add rN,c,rN) because 0x6e5 is not an ARM rotated immediate;
    the (long long)-mask launder is what stops mwcc folding it to [c,#0x6e5]. */
 #define LAUNDER_U8(p) \
-    ((unsigned char *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+    ((unsigned char *)(int)(((long long)(int)(p))))
 
 void func_ov002_020ceb7c(struct Camera *c)
 {

--- a/src/func_ov002_020cef84.cpp
+++ b/src/func_ov002_020cef84.cpp
@@ -87,7 +87,7 @@ extern "C" int func_ov002_020cef84(char *self)
                 int *dst = &tmp.f04;
                 int w0, w1;
                 *(int *)(self + 0xa8) = -0x1000;
-                *(unsigned char *)(((long long)(int)(self + 0x6e9)) & 0xffffffffffffffffLL) |= 8;
+                *(unsigned char *)(((long long)(int)(self + 0x6e9))) |= 8;
                 w0 = *(int *)(rl + 0x14);
                 w1 = *(int *)(rl + 0x18);
                 dst[0] = w1 ? w0 : w0;

--- a/src/func_ov002_020cfbdc.cpp
+++ b/src/func_ov002_020cfbdc.cpp
@@ -62,9 +62,9 @@ extern "C" int func_ov002_020cfbdc(char *self)
     _ZN11RaycastLineC1Ev(rl);
     _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(rl, &pts[1], &pts[2], self);
     if (_ZN11RaycastLine10DetectClsnEv(rl) != 0) {
-        *(int *)((int)(self + 0x5c) & 0xFFFFFFFFFFFFFFFFLL) += r5 * 0x60;
-        *(int *)((int)(self + 0x60) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80000;
-        *(int *)((int)(self + 0x64) & 0xFFFFFFFFFFFFFFFFLL) += r5 * 0x60;
+        *(int *)((int)(self + 0x5c)) += r5 * 0x60;
+        *(int *)((int)(self + 0x60)) -= 0x80000;
+        *(int *)((int)(self + 0x64)) += r5 * 0x60;
         _ZN6Player11ChangeStateERNS_5StateE(self, &data_ov002_021101b4);
         _ZN11RaycastLineD1Ev(rl);
         return 1;

--- a/src/func_ov002_020d0948.c
+++ b/src/func_ov002_020d0948.c
@@ -7,17 +7,17 @@ void func_ov002_020d0948(int self)
     int base = (short)(*(short*)(self + 0x8e) + 0x8000);
     if (*(unsigned char*)(self + 0x703) != 0) {
         int idx = (unsigned short)base >> 4;
-        int* p0 = (int*)(((long long)(int)(self + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
-        int* p1 = (int*)(((long long)(int)(self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
-        int* p2 = (int*)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p0 = (int*)(((long long)(int)(self + 0x5c)));
+        int* p1 = (int*)(((long long)(int)(self + 0x60)));
+        int* p2 = (int*)(((long long)(int)(self + 0x64)));
         *p0 = data_02082214[idx * 2] * 0x110 + *p0;
         *p1 = *p1 - 0x12c000;
         *p2 = data_02082214[idx * 2 + 1] * 0x110 + *p2;
     } else {
         int idx = (unsigned short)base >> 4;
-        int* p0 = (int*)(((long long)(int)(self + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
-        int* p1 = (int*)(((long long)(int)(self + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
-        int* p2 = (int*)(((long long)(int)(self + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p0 = (int*)(((long long)(int)(self + 0x5c)));
+        int* p1 = (int*)(((long long)(int)(self + 0x60)));
+        int* p2 = (int*)(((long long)(int)(self + 0x64)));
         *p0 = *p0 + (data_02082214[idx * 2] << 6);
         *p1 = *p1 - 0x64000;
         *p2 = *p2 + (data_02082214[idx * 2 + 1] << 6);

--- a/src/func_ov002_020d1f78.c
+++ b/src/func_ov002_020d1f78.c
@@ -42,7 +42,7 @@ void func_ov002_020d1f78(void *selfPtr, u32 param)
 
     if (*(int *)(self + 8) == 2 && flag == 0) {
         id = _ZNK6Player14GetBodyModelIDEjb(self, *(int *)(self + 8) & 0xff, 0);
-        anim = (char *)((long long)(((int *)(self + 0xdc))[id] + 0x50) & 0xFFFFFFFFFFFFFFFFLL);
+        anim = (char *)((long long)(((int *)(self + 0xdc))[id] + 0x50));
         w = *(u32 *)(anim + 8);
         _ZN6Player7SetAnimEji5Fix12IiEj(self, 0x3f, 0, 0x2800, (w << 4) >> 16);
     } else {

--- a/src/func_ov002_020d2fdc.c
+++ b/src/func_ov002_020d2fdc.c
@@ -32,7 +32,7 @@ int func_ov002_020d2fdc(char *self)
 
     if (data_0209f49c[data_020a0e40].flags & 0x800) {
         if (*(u8 *)(self + 0x6e5) < 0x1e) {
-            *(u8 *)(((int)self + 0x6e5) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+            *(u8 *)(((int)self + 0x6e5)) += 1;
             r5 = *(u8 *)(self + 0x6e5) * 0x111 + 0x1000;
         } else {
             *(u8 *)(self + 0x6ed) = 0x1e;
@@ -82,7 +82,7 @@ int func_ov002_020d2fdc(char *self)
                 _ZN6Player7SetAnimEji5Fix12IiEj(self, 0xd, 0x40000000, 0x1000, 0);
                 *(u8 *)(self + 0x6e3) = 1;
             }
-            *(int *)(((int)(char *)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFFLL) |= 0x2000;
+            *(int *)(((int)(char *)data_0209f318 + 0x154)) |= 0x2000;
         }
     } else {
         _ZN6Player7SetAnimEji5Fix12IiEj(self, 0xf, 0, 0x1000, 0);

--- a/src/func_ov002_020d4748.cpp
+++ b/src/func_ov002_020d4748.cpp
@@ -72,7 +72,7 @@ extern "C" void func_ov002_020d4748(char* c)
     } else {
         int i3 = data_020a0e40 * 0x18;
         if (*(unsigned char*)((char*)&data_0209f4ac + i3) != 0) {
-            unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x6e3)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x6e3)));
             unsigned char d;
             int b;
             int i4;

--- a/src/func_ov002_020d5ab4.c
+++ b/src/func_ov002_020d5ab4.c
@@ -19,7 +19,7 @@ int func_ov002_020d5ab4(char *self)
         return 0;
     }
 
-    rp = (short *)(((long long)(int)(*(char **)(self + 0xd0) + 0x8c)) & 0xffffffffffffffffLL);
+    rp = (short *)(((long long)(int)(*(char **)(self + 0xd0) + 0x8c)));
     *(short *)(self + 0x8c) = rp[0];
     *(short *)(self + 0x8e) = rp[1];
     *(short *)(self + 0x90) = rp[2];
@@ -27,7 +27,7 @@ int func_ov002_020d5ab4(char *self)
     *(short *)(self + 0x94) = *(short *)(self + 0x8e);
     *(short *)(self + 0x96) = *(short *)(self + 0x90);
 
-    pp = (int *)(((long long)(int)(*(char **)(self + 0xd0) + 0x5c)) & 0xffffffffffffffffLL);
+    pp = (int *)(((long long)(int)(*(char **)(self + 0xd0) + 0x5c)));
     pos.x = pp[0];
     pos.y = pp[1];
     pos.z = pp[2];
@@ -45,7 +45,7 @@ int func_ov002_020d5ab4(char *self)
     *(char **)((char *)spawned + 0x38c) = self;
     *(unsigned char *)(self + 0x6f5) = 0;
     *(short *)(self + 0x6a4) = 0xd2;
-    *(int *)(((long long)(int)(self + 0x2ec)) & 0xffffffffffffffffLL) &= ~2;
+    *(int *)(((long long)(int)(self + 0x2ec))) &= ~2;
     *(unsigned char *)(self + 0x6e3) = 3;
     *(int *)(self + 0x640) = 0;
     *(int *)(self + 0xd0) = 0;

--- a/src/func_ov002_020d5c6c.c
+++ b/src/func_ov002_020d5c6c.c
@@ -15,7 +15,7 @@ int func_ov002_020d5c6c(char* c)
         if (func_ov002_020d600c(p))
             goto change;
     }
-    *(u16*)(void*)(int)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    *(u16*)(void*)(int)(((long long)(int)(c + 0x6ce))) &= ~2;
     return 0;
 change:
     _ZN6Player11ChangeStateERNS_5StateE(c, &data_ov002_02110034);

--- a/src/func_ov002_020d6084.c
+++ b/src/func_ov002_020d6084.c
@@ -1,6 +1,6 @@
 int func_ov002_020d6084(char *c)
 {
-    unsigned int *p = (unsigned int *)(((long long)(int)(c + 0x2ec)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned int *p = (unsigned int *)(((long long)(int)(c + 0x2ec)));
     *p &= ~0x2000;
     *p &= ~2;
     *(unsigned char *)(c + 0x713) = 1;

--- a/src/func_ov002_020d6790.cpp
+++ b/src/func_ov002_020d6790.cpp
@@ -72,8 +72,8 @@ isbf_ret0:
         return 1;
     case 7:
         if (*(u8*)(self + 0x714) != 0) goto case7_ret1;
-        *(int*)(((long long)(int)(*(int*)(self + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40000;
-        *(int*)(((long long)(int)(*(int*)(self + 0x360) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+        *(int*)(((long long)(int)(*(int*)(self + 0x360) + 0xb0))) |= 0x40000;
+        *(int*)(((long long)(int)(*(int*)(self + 0x360) + 0xb0))) &= ~0x20000;
         *(u8*)(self + 0x714) = 1;
 case7_ret1:
         return 1;

--- a/src/func_ov002_020d7030.cpp
+++ b/src/func_ov002_020d7030.cpp
@@ -4,7 +4,7 @@ extern void func_ov002_020d71ec(void*, int);
 int func_ov002_020d7030(char* a, char* b) {
   int flag = (*(int*)(b + 0xb0) & 0x60000) != 0;
   if (flag) return 0;
-  *(int*)(((int)b + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20000;
+  *(int*)(((int)b + 0xb0)) |= 0x20000;
   *(void**)(b + 0xd0) = a;
   *(void**)(a + 0x360) = b;
   func_ov002_020d71ec(a, 1);

--- a/src/func_ov002_020d71ec.c
+++ b/src/func_ov002_020d71ec.c
@@ -24,7 +24,7 @@ void func_ov002_020d71ec(char* p, int arg1)
 
     if (arg1 != 2) {
         model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
-        sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+        sub = (char*)(((long long)(int)(model + 0x50)));
         shifted = ((u32)*(int*)(sub + 8) << 4) >> 0x10;
         *(struct P2*)&arr[0] = data_ov002_0210a34c;
         *(struct P2*)&arr[2] = data_ov002_0210a084;
@@ -37,7 +37,7 @@ void func_ov002_020d71ec(char* p, int arg1)
         if (arg1 == 1) {
             val = data_ov002_020ff0f8[shifted];
             model = *(char**)(p + _ZNK6Player14GetBodyModelIDEjb(p, *(u32*)(p + 8) & 0xff, 0) * 4 + 0xdc);
-            sub = (char*)(((long long)(int)(model + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+            sub = (char*)(((long long)(int)(model + 0x50)));
             val = ((u32)val << 0x10) >> 4;
             *(int*)(sub + 8) = val;
             *(int*)(*(int*)(p + 0x160) + 0x58) = val;

--- a/src/func_ov002_020d8158.c
+++ b/src/func_ov002_020d8158.c
@@ -11,7 +11,7 @@ extern struct State data_ov002_0211004c;
 void func_ov002_020d8158(char* c)
 {
     if (*(int*)(c + 8) != 3) {
-        *(u16*)(int)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1000;
+        *(u16*)(int)(((long long)(int)(c + 0x6ce))) &= ~0x1000;
         return;
     }
     if (_ZN6Player7IsStateERNS_5StateE(c, &data_ov002_02110034)) return;
@@ -21,6 +21,6 @@ void func_ov002_020d8158(char* c)
     func_ov002_020d8118(c);
     *(u8*)(c + 0x6f4) = 1;
     func_ov002_020bdc18(c);
-    *(u16*)(int)(((long long)(int)(c + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x1000;
+    *(u16*)(int)(((long long)(int)(c + 0x6ce))) &= ~0x1000;
     *(u8*)(c + 0x714) = 1;
 }

--- a/src/func_ov002_020d8360.c
+++ b/src/func_ov002_020d8360.c
@@ -51,7 +51,7 @@ int func_ov002_020d8360(void *self, void *other, unsigned int flags)
         }
         {
             Vector3 out, tr, v, cp;
-            int *p = (int *)(int)(((long long)(int)(o + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)(int)(((long long)(int)(o + 0x5c)));
             v.x = p[0];
             v.y = p[1];
             v.z = p[2];
@@ -82,7 +82,7 @@ int func_ov002_020d8360(void *self, void *other, unsigned int flags)
             if (flag != 0) {
                 *(int *)(c + 0xa8) = t98 + 0x20000;
                 {
-                    int *hp = (int *)(int)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+                    int *hp = (int *)(int)(((long long)(int)(c + 0x98)));
                     int half = *hp >> 1;
                     *hp = half;
                     return half;

--- a/src/func_ov002_020d853c.c
+++ b/src/func_ov002_020d853c.c
@@ -11,7 +11,7 @@ int func_ov002_020d853c(char* c, char* o) {
     int j = (*(unsigned char*)(c + 0x6e2) << 1) & 0xff;
     unsigned idx = _ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c + 8) & 0xff, 0);
     char* mp = *(char**)(c + 0xdc + idx * 4);
-    int v = ((int*)(((long long)(int)(mp + 0x50)) & 0xFFFFFFFFFFFFFFFFLL))[2];
+    int v = ((int*)(((long long)(int)(mp + 0x50))))[2];
     int k = (unsigned short)(v >> 12);
     if (k < data_ov002_0210a5dc[j] || k > data_ov002_0210a5dc[j + 1]) return 1;
     if (AngleDiff(Vec3_HorzAngle(c + 0x5c, o + 0x5c), *(short*)(c + 0x8e)) < 0x4000) return 0;

--- a/src/func_ov002_020d8838.c
+++ b/src/func_ov002_020d8838.c
@@ -3,5 +3,5 @@
 // the ldrh/strh reuse it, matching the ROM instead of folding the address.
 void func_ov002_020d8838(char *self)
 {
-    *(unsigned short *)(((long long)(int)(self + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+    *(unsigned short *)(((long long)(int)(self + 0x6ce))) |= 0x20;
 }

--- a/src/func_ov002_020d98b4.cpp
+++ b/src/func_ov002_020d98b4.cpp
@@ -14,7 +14,7 @@ extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 
 void func_ov002_020d98b4(char* self){
   int t = func_ov002_020beb38(self);
-  *(unsigned short*)(((int)self + 0x6a4) & 0xFFFFFFFFFFFFFFFF) -= t;
+  *(unsigned short*)(((int)self + 0x6a4)) -= t;
   {
     short* q = (short*)(self + 0x600);
     if (q[0x52] < 0) q[0x52] = 0;
@@ -31,6 +31,6 @@ void func_ov002_020d98b4(char* self){
     *(void**)(self+0x628) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
       *(unsigned int*)(self+0x628), 0xd6, s.x, s.y, s.z, 0, 0);
   }
-  *(int*)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x80;
+  *(int*)(((int)self + 0xb0)) |= 0x80;
 }
 }

--- a/src/func_ov002_020d9a4c.c
+++ b/src/func_ov002_020d9a4c.c
@@ -9,5 +9,5 @@ void func_ov002_020d9a4c(char *c) {
     int idx = _ZNK6Player14GetBodyModelIDEjb(c, *(int*)(c + 8) & 0xff, 0);
     int anim = *(int*)(c + idx * 4 + 0xdc);
     if (_ZNK9Animation12WillHitFrameEi((char*)anim + 0x50, data_ov002_02109dc4[*(u8*)(c + 0x6e3) & 7]) != 0)
-        *(u8*)(((long long)(int)(c + 0x6e5)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u8*)(((long long)(int)(c + 0x6e5))) |= 1;
 }

--- a/src/func_ov002_020d9c70.c
+++ b/src/func_ov002_020d9c70.c
@@ -40,7 +40,7 @@ void func_ov002_020d9c70(char *o)
     *(short *)(p + 0x96) = 0;
     {
         char *q = *(char **)(o + 0x358);
-        short *r = (short *)(int)(((long long)(int)(q + 0x92)) & 0xFFFFFFFFFFFFFFFFLL);
+        short *r = (short *)(int)(((long long)(int)(q + 0x92)));
         short first = r[0];
         *(short *)(q + 0x8c) = first;
         *(short *)(q + 0x8e) = r[1];

--- a/src/func_ov002_020d9dcc.c
+++ b/src/func_ov002_020d9dcc.c
@@ -21,7 +21,7 @@ int func_ov002_020d9dcc(char* c)
         return 0;
 
     p = *(char**)(c + 0x358);
-    if (p == 0 || (int)(((long long)(*(u16*)(p + 0xc) == 0xbf)) & 0xFFFFFFFFFFFFFFFFLL) == 0)
+    if (p == 0 || (int)(((long long)(*(u16*)(p + 0xc) == 0xbf))) == 0)
         return 0;
 
     if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) == 0 || *(u8*)(c + 0x6de) != 0) {
@@ -50,8 +50,8 @@ int func_ov002_020d9dcc(char* c)
             return 0;
         }
         if (AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x69c)) >= 0x4000) {
-            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) += 1;
-            *(s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFF) += 0x4000;
+            *(u8*)(((int)c + 0x6e5)) += 1;
+            *(s16*)(((int)c + 0x69c)) += 0x4000;
         }
     } else {
         if (diff > 0) {
@@ -59,8 +59,8 @@ int func_ov002_020d9dcc(char* c)
             return 0;
         }
         if (AngleDiff(*(s16*)(c + 0x8e), *(s16*)(c + 0x69c)) >= 0x4000) {
-            *(u8*)(((int)c + 0x6e5) & 0xFFFFFFFFFFFFFFFF) -= 1;
-            *(s16*)(((int)c + 0x69c) & 0xFFFFFFFFFFFFFFFF) -= 0x4000;
+            *(u8*)(((int)c + 0x6e5)) -= 1;
+            *(s16*)(((int)c + 0x69c)) -= 0x4000;
         }
     }
 

--- a/src/func_ov002_020da95c.c
+++ b/src/func_ov002_020da95c.c
@@ -1,4 +1,4 @@
-#define ADDR(p) ((int *)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define ADDR(p) ((int *)(((long long)(int)(p))))
 
 #pragma opt_propagation off
 int func_ov002_020da95c(char *c)

--- a/src/func_ov002_020da9d4.cpp
+++ b/src/func_ov002_020da9d4.cpp
@@ -12,11 +12,11 @@ extern "C" int func_ov002_020da9d4(char* self){
         if (e)
             func_ov002_020db54c(s, 0x10000, 0x10000, *(short*)(self + 0x8e));
     }
-    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0));
     *p &= ~0x4000;
-    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0));
     *p |= 0x2000;
-    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    p = (int*)(((int)*(char**)(self + 0x358) + 0xb0));
     *p &= ~0x100;
     *(char**)(self + 0x358) = 0;
     return 1;

--- a/src/func_ov002_020daa74.cpp
+++ b/src/func_ov002_020daa74.cpp
@@ -6,9 +6,9 @@ extern "C" int func_ov002_020daa74(char* self){
     int b = (s != 0);
     if (!b)
         return 0;
-    *(int*)(((int)s + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000;
-    *(int*)(((int)(*(char**)(self + 0x358)) + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x400;
-    *(int*)(((int)(*(char**)(self + 0x358)) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x100;
+    *(int*)(((int)s + 0xb0)) &= ~0x4000;
+    *(int*)(((int)(*(char**)(self + 0x358)) + 0xb0)) |= 0x400;
+    *(int*)(((int)(*(char**)(self + 0x358)) + 0xb0)) &= ~0x100;
     {
         char* s2 = *(char**)(self + 0x358);
         int e = (*(unsigned short*)(s2 + 0xc) == 0xbf);

--- a/src/func_ov002_020dacb4.c
+++ b/src/func_ov002_020dacb4.c
@@ -17,9 +17,9 @@ int func_ov002_020dacb4(char *p, char *actor)
     int t;
 
     *(char **)(p + 0x358) = actor;
-    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x400;
-    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x2000;
-    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0))) &= ~0x400;
+    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0))) &= ~0x2000;
+    *(int *)(((long long)(int)(*(char **)(p + 0x358) + 0xb0))) |= 0x100;
     *(int *)(p + 0x98) = 0;
 
     if (*(unsigned char *)(p + 0x706) != 0) {

--- a/src/func_ov002_020db54c.cpp
+++ b/src/func_ov002_020db54c.cpp
@@ -19,7 +19,7 @@ extern "C" void func_ov002_020db54c(unsigned char *self, int a, int b, short c)
     if (node != 0) {
         int bb = (int)(*(u16 *)((char *)node + 0xc) == 0xbf);
         if (bb != 0) {
-            struct Vector3 *src = (struct Vector3 *)(((int)node + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+            struct Vector3 *src = (struct Vector3 *)(((int)node + 0x5c));
             struct Vector3 v;
             int ty;
             v.x = src->x;

--- a/src/func_ov002_020dc560.c
+++ b/src/func_ov002_020dc560.c
@@ -9,7 +9,7 @@ extern unsigned char data_020a0e40;
 extern char data_0209f4a0[];
 extern short data_02082214[];
 
-#define ADDR(p) ((int *)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define ADDR(p) ((int *)(((long long)(int)(p))))
 
 void func_ov002_020dc560(char *self)
 {

--- a/src/func_ov002_020dd908.c
+++ b/src/func_ov002_020dd908.c
@@ -16,7 +16,7 @@ void func_ov002_020dd908(char* sb){
     int* p;
     if(o == 0) continue;
     if(*(int*)(o+0x37c) == 0) continue;
-    p = (int*)(((int)(o+0x5c)) & 0xFFFFFFFFFFFFFFFF);
+    p = (int*)(((int)(o+0x5c)));
     v.x = p[0];
     v.y = p[1];
     v.z = p[2];

--- a/src/func_ov002_020e1c20.c
+++ b/src/func_ov002_020e1c20.c
@@ -36,12 +36,12 @@ void func_ov002_020e1c20(char *c)
       *((int *) (c + 0x98)) = (int) (((((long long) (*((int *) (c + 0x98)))) * 0xf00) + 0x800) >> 12);
       if ((*((int *) (c + 0xa8))) < 0)
       {
-        int *p = (int *) (((long long) (c + 0xa8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *) (((long long) (c + 0xa8)));
         *p = *p + 0xc00;
       }
       else
       {
-        int *p = (int *) (((long long) (c + 0xa8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *) (((long long) (c + 0xa8)));
         *p = *p + 0x1000;
       }
       if ((*((int *) (c + 0xa8))) < 0x11000)
@@ -80,7 +80,7 @@ void func_ov002_020e1c20(char *c)
       _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x3f, 0, 0x1000, 0);
       {
         int id;
-        char *p = (char *) (((long long) ((int) ((*((char **) ((c + 0xdc) + (_ZNK6Player14GetBodyModelIDEjb(c, (*((int *) (c + 8))) & 0xff, 0) * 4)))) + 0x50))) & 0xFFFFFFFFFFFFFFFFLL);
+        char *p = (char *) (((long long) ((int) ((*((char **) ((c + 0xdc) + (_ZNK6Player14GetBodyModelIDEjb(c, (*((int *) (c + 8))) & 0xff, 0) * 4)))) + 0x50))));
         *((int *) (p + 0xc)) = 0x4000;
       }
     }

--- a/src/func_ov002_020e1e70.c
+++ b/src/func_ov002_020e1e70.c
@@ -34,7 +34,7 @@ void func_ov002_020e1e70(char *c)
     _ZN6Player7SetAnimEji5Fix12IiEj(c, 0x3f, 0, 0x1000, 0);
     {
       int id;
-      char *p = (char *) (((long long) ((int) ((*((char **) ((c + 0xdc) + (_ZNK6Player14GetBodyModelIDEjb(c, (*((int *) (c + 8))) & 0xff, 0) * 4)))) + 0x50))) & 0xFFFFFFFFFFFFFFFFLL);
+      char *p = (char *) (((long long) ((int) ((*((char **) ((c + 0xdc) + (_ZNK6Player14GetBodyModelIDEjb(c, (*((int *) (c + 8))) & 0xff, 0) * 4)))) + 0x50))));
       *((int *) (p + 0xc)) = 0x4000;
     }
     *((int *) (c + 0x620)) = func_02012120(*((int *) (c + 0x620)), *((unsigned char *) (c + 0x6d9)), 0x18, (const struct Vector3 *) (c + 0x74), 0);

--- a/src/func_ov002_020e28d4.c
+++ b/src/func_ov002_020e28d4.c
@@ -69,5 +69,5 @@ void func_ov002_020e28d4(char* c, int a, int b)
         return;
 
     if (*(int*)(c + 0x98) >= 0x10000)
-        *(int*)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x2000;
+        *(int*)(((long long)(int)(c + 0x98))) -= 0x2000;
 }

--- a/src/func_ov002_020e2ad0.c
+++ b/src/func_ov002_020e2ad0.c
@@ -3,7 +3,7 @@ void func_ov002_020e2ad0(char* p)
     if (*(int*)(p + 0x68c) <= 0x1000) return;
     if (*(unsigned short*)(p + 0x6c4) == 0) {
         *(int*)(p + 0xa8) = (int)(((long long)*(int*)(p + 0xa8) * 0x900 + 0x800) >> 12);
-        *(int*)(((long long)(int)(p + 0x98)) & 0xFFFFFFFFFFFFFFFFLL) >>= 1;
+        *(int*)(((long long)(int)(p + 0x98))) >>= 1;
         *(char*)(p + 0x71b) = 1;
     } else {
         if (*(int*)(p + 0x68c) < 0xb000) *(int*)(p + 0x68c) = 0xb000;

--- a/src/func_ov002_020e5948.c
+++ b/src/func_ov002_020e5948.c
@@ -157,7 +157,7 @@ void func_ov002_020e5948(void* arg0)
 
     if (data_0209f310[*(u8*)(c + 0x6D8)] != 0) {
         LoadSilverStarAndNumber();
-        *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u8*)(((long long)(int)(c + 0x718))) |= 1;
     }
 
     {
@@ -167,15 +167,15 @@ void func_ov002_020e5948(void* arg0)
         switch (b) {
         case 0:
             _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da40);
-            *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+            *(u8*)(((long long)(int)(c + 0x718))) |= 2;
             break;
         case 1:
             _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9a0);
-            *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+            *(u8*)(((long long)(int)(c + 0x718))) |= 4;
             break;
         case 2:
             _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210d9c0);
-            *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+            *(u8*)(((long long)(int)(c + 0x718))) |= 8;
             break;
         }
     }
@@ -343,7 +343,7 @@ void func_ov002_020e5948(void* arg0)
             _ZN9ModelBase7SetFileEP8BMD_Fileii(*(void**)(c + 0x1D8), _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210da38), 1, -1);
 
             if (data_0209f2f8 != 2 && data_0209f2f8 != 5 && data_0209f2f8 != 4) {
-                *(u8*)(((long long)(int)(c + 0x718)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x20;
+                *(u8*)(((long long)(int)(c + 0x718))) |= 0x20;
                 p = _Znwj(0x78);
                 if (p != 0) {
                     p = _ZN10ModelAnim2C1Ev(p);

--- a/src/func_ov002_020e640c.c
+++ b/src/func_ov002_020e640c.c
@@ -19,22 +19,22 @@ void func_ov002_020e640c(char *c)
 
     id = _ZNK6Player14GetBodyModelIDEjb(c, *(u32 *)(c + 8) & 0xff, 0);
     {
-        int *p = (int *)(int)(((long long)(int)(*(s32 *)(c + 0xdc + id * 4) + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(int)(((long long)(int)(*(s32 *)(c + 0xdc + id * 4) + 8)));
         md = (char *)p[2];
         mp = (char *)p[0];
     }
     r4p = *(char **)(mp + 8);
 
-    *(u16 *)(int)(((long long)(int)(md + 0x1bc)) & 0xFFFFFFFFFFFFFFFFLL) += *(s16 *)(c + 0x75e);
-    *(u16 *)(int)(((long long)(unsigned int)(md + 0x1be)) & 0xFFFFFFFFFFFFFFFFLL) += *(s16 *)(c + 0x760);
+    *(u16 *)(int)(((long long)(int)(md + 0x1bc))) += *(s16 *)(c + 0x75e);
+    *(u16 *)(int)(((long long)(unsigned int)(md + 0x1be))) += *(s16 *)(c + 0x760);
 
     {
         int b = *(u8 *)(c + 0x742);
         if (b == 0) {
         } else if (b == 1) {
-            *(u16 *)(int)(((long long)(int)(md + 0x326)) & 0xFFFFFFFFFFFFFFFFLL) += *(u16 *)(c + 0x762);
-            *(u16 *)(int)(((long long)(unsigned int)(md + 0x328)) & 0xFFFFFFFFFFFFFFFFLL) += *(u16 *)(c + 0x764);
-            *(u16 *)(int)(((long long)(int)(md + 0x32a)) & 0xFFFFFFFFFFFFFFFFLL) += *(u16 *)(c + 0x766);
+            *(u16 *)(int)(((long long)(int)(md + 0x326))) += *(u16 *)(c + 0x762);
+            *(u16 *)(int)(((long long)(unsigned int)(md + 0x328))) += *(u16 *)(c + 0x764);
+            *(u16 *)(int)(((long long)(int)(md + 0x32a))) += *(u16 *)(c + 0x766);
         } else if (b == 2) {
             *(s16 *)(md + 0x326) = *(s16 *)(c + 0x762);
             *(s16 *)(md + 0x328) = *(s16 *)(c + 0x764);
@@ -78,7 +78,7 @@ void func_ov002_020e640c(char *c)
                 *(s32 *)(c + 0x754) = *(s32 *)(c + 0x748);
                 *(s32 *)(c + 0x758) = *(s32 *)(c + 0x74c);
                 {
-                    u8 *q = (u8 *)(((long long)(int)(c + 0x743)) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8 *q = (u8 *)(((long long)(int)(c + 0x743)));
                     (*q)++;
                 }
             } else {

--- a/src/func_ov002_020e6b3c.c
+++ b/src/func_ov002_020e6b3c.c
@@ -10,7 +10,7 @@ struct B {
 };
 
 void func_ov002_020e6b3c(char *o) {
-    void **p = (void **)(((long long)(int)(o + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    void **p = (void **)(((long long)(int)(o + 8)));
     struct A *a = (struct A *)p[0];
     unsigned int n = a->count;
     struct B *b = (struct B *)p[1];

--- a/src/func_ov002_020e6b74.c
+++ b/src/func_ov002_020e6b74.c
@@ -1,6 +1,6 @@
 void func_ov002_020e6b74(char *c, int *src)
 {
-    char *base = (char *)(((long long)(int)(c + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    char *base = (char *)(((long long)(int)(c + 8)));
     void *obj = *(void **)base;
     unsigned int n = *(unsigned int *)((char *)obj + 0x24);
     char *dst = *(char **)(base + 4);

--- a/src/func_ov002_020e6bb0.c
+++ b/src/func_ov002_020e6bb0.c
@@ -10,7 +10,7 @@ int *func_ov002_020e6bb0(char *self)
     char *src;
     unsigned int i;
 
-    pp = (char **)(((long long)(int)(self + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+    pp = (char **)(((long long)(int)(self + 8)));
     base = *pp;
     count = *(unsigned int *)(base + 0x24);
     out = (int *)_ZN6Memory13operator_new2Ej(count << 2);

--- a/src/func_ov002_020e6d88.c
+++ b/src/func_ov002_020e6d88.c
@@ -3,10 +3,10 @@ void func_ov002_020e6d88(void* c) {
   *(int*)((char*)c+0x80) = 0;
   *(int*)((char*)c+0x84) = 0;
   *(int*)((char*)c+0x88) = 0;
-  *(unsigned short*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF) &= ~0x100;
-  _ZN5Actor11UntrackStarERa(c, (signed char*)(((int)c + 0x498) & 0xFFFFFFFFFFFFFFFF));
-  c = (void*)(int)((unsigned long long)(int)c & 0xFFFFFFFFFFFFFFFF);
-  *(unsigned short*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF) &= ~0x200;
+  *(unsigned short*)(((int)c + 0x4a2)) &= ~0x100;
+  _ZN5Actor11UntrackStarERa(c, (signed char*)(((int)c + 0x498)));
+  c = (void*)(int)((unsigned long long)(int)c);
+  *(unsigned short*)(((int)c + 0x4a2)) &= ~0x200;
   *(unsigned short*)((char*)c+0x492) = 0;
   *(unsigned short*)((char*)c+0x100) = 0;
 }

--- a/src/func_ov002_020e6df8.cpp
+++ b/src/func_ov002_020e6df8.cpp
@@ -30,7 +30,7 @@ void func_ov002_020e6df8(char* c)
       c + 0x110, c, &v, 0x64000, 0x96000, 1, 0);
   }
   {
-    unsigned short* p = (unsigned short*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF);
+    unsigned short* p = (unsigned short*)(((int)c + 0x4a2));
     *p = (*p & ~1) | 1;
     *p = *p | 2;
   }

--- a/src/func_ov002_020e6edc.c
+++ b/src/func_ov002_020e6edc.c
@@ -25,7 +25,7 @@ void func_ov002_020e6edc(char* c)
     v.z = data_ov002_0210aa0c.z;
     _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(c+0x110, (struct Actor*)c, &v, 0x64000, 0x96000, 1, 0);
     *(int*)(c+0x440) = 0xc;
-    p = (u16*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF);
+    p = (u16*)(((int)c + 0x4a2));
     *p = (*p & ~1) | 1;
     *p |= 2;
 }

--- a/src/func_ov002_020e7090.cpp
+++ b/src/func_ov002_020e7090.cpp
@@ -7,8 +7,8 @@ extern void func_02012790(int a);
 extern int data_0209b454;
 void func_ov002_020e7090(char* c, int arg){
   *(int*)(c+0x438) = arg;
-  *(int*)((*(int*)(c+0x438)+0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x4000000;
-  *(int*)(((int)c+0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x4000000;
+  *(int*)((*(int*)(c+0x438)+0xb0)) |= 0x4000000;
+  *(int*)(((int)c+0xb0)) |= 0x4000000;
   data_0209b454 |= 0x4000000;
   func_ov002_020e6fbc(c, 0);
   *(unsigned char*)(c+0x49c) = 1;

--- a/src/func_ov002_020e763c.c
+++ b/src/func_ov002_020e763c.c
@@ -38,8 +38,8 @@ void func_ov002_020e763c(char *self)
     switch (((Sub *)(self + 0x400))->state) {
     case 0:
     {
-        int *s1 = (int *)(((int)cam + 0x80) & 0xFFFFFFFFFFFFFFFFLL);
-        int *s2 = (int *)(((int)cam + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+        int *s1 = (int *)(((int)cam + 0x80));
+        int *s2 = (int *)(((int)cam + 0x8c));
         *(int *)(self + 0x460) = s1[0];
         *(int *)(self + 0x464) = s1[1];
         *(int *)(self + 0x468) = s1[2];
@@ -51,7 +51,7 @@ void func_ov002_020e763c(char *self)
         _ZN6Camera9SetFlag_3Ev(cam);
         if (func_ov002_020e7c90(self, cam) == 0)
             func_ov002_020e7934(self, cam);
-        *(u16 *)(((int)self + 0x496) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(u16 *)(((int)self + 0x496)) += 1;
         break;
     case 1:
         if (*(int *)(self + 0x440) != 2)
@@ -60,8 +60,8 @@ void func_ov002_020e763c(char *self)
         break;
     case 0x64:
     {
-        int *s1 = (int *)(((int)cam + 0x80) & 0xFFFFFFFFFFFFFFFFLL);
-        int *s2 = (int *)(((int)cam + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+        int *s1 = (int *)(((int)cam + 0x80));
+        int *s2 = (int *)(((int)cam + 0x8c));
         *(int *)(self + 0x460) = s1[0];
         *(int *)(self + 0x464) = s1[1];
         *(int *)(self + 0x468) = s1[2];
@@ -72,7 +72,7 @@ void func_ov002_020e763c(char *self)
         _ZN6Camera9SetFlag_3Ev(cam);
         if (func_ov002_020e7c90(self, cam) == 0)
             func_ov002_020e7934(self, cam);
-        *(u16 *)(((int)self + 0x496) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(u16 *)(((int)self + 0x496)) += 1;
         break;
     case 0x65:
         _ZN6Camera9SetLookAtERK7Vector3(cam, &v);
@@ -82,17 +82,17 @@ void func_ov002_020e763c(char *self)
     case 0x1f4:
         _ZN6Camera9SetLookAtERK7Vector3(cam, (Vec3 *)(self + 0x460));
         _ZN6Camera6SetPosERK7Vector3(cam, (Vec3 *)(self + 0x46c));
-        *(u16 *)(((int)self + 0x496) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(u16 *)(((int)self + 0x496)) += 1;
         break;
     case 0x1f5:
-        *(int *)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
-        *(int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x4000000;
+        *(int *)(((int)cam + 0x154)) &= ~8;
+        *(int *)(((int)self + 0xb0)) &= ~0x4000000;
         data_0209b454 &= ~0x4000000;
         ((Sub *)(self + 0x400))->state = 0xffff;
         *(s8 *)(self + 0xcc) = ((Sub *)(self + 0x400))->flag;
         break;
     default:
-        *(u16 *)(((int)self + 0x496) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(u16 *)(((int)self + 0x496)) += 1;
         break;
     }
 }

--- a/src/func_ov002_020e7d84.c
+++ b/src/func_ov002_020e7d84.c
@@ -6,7 +6,7 @@ void func_ov002_020e7d84(char* c)
 {
     func_02012694(0x53, c + 0x74);
     {
-        unsigned char* f = (unsigned char*)(((int)c + 0x1db) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* f = (unsigned char*)(((int)c + 0x1db));
         *f = (*f & ~1) | 1;
         *f &= ~2;
     }

--- a/src/func_ov002_020e7f2c.c
+++ b/src/func_ov002_020e7f2c.c
@@ -12,7 +12,7 @@ void func_ov002_020e7f2c(char* c)
 
     if (*(u16 *)((char*)c + 0x400 + 0x94) == 0)
         return;
-    (*(u16 *)(((long long)(int)(c + 0x494)) & 0xFFFFFFFFFFFFFFFFLL))--;
+    (*(u16 *)(((long long)(int)(c + 0x494))))--;
     if (*(u16 *)((char*)c + 0x400 + 0x94) == 0)
         *(u32 *)(c + 0x4bc) = 0;
     x = *(s32 *)(c + 0x5c);

--- a/src/func_ov002_020e8244.c
+++ b/src/func_ov002_020e8244.c
@@ -36,7 +36,7 @@ void func_ov002_020e8244(int* out, char* b)
     Vec3_LslInPlace((void*)(b + 0x4a8), 3);
     AddVec3((struct V3*)(b + 0x4a8), (struct V3*)(b + 0x5c), (struct V3*)(b + 0x4a8));
     {
-        int* p = (int*)((int)(((long long)(int)(b + 0x4ac)) & 0xFFFFFFFFFFFFFFFFLL));
+        int* p = (int*)((int)(((long long)(int)(b + 0x4ac))));
         *p = *(int*)(*(char**)(b + 0x31c) + 0xc) * 0xd + *p;
     }
     out[0] = *(int*)(b + 0x4a8);

--- a/src/func_ov002_020e8618.c
+++ b/src/func_ov002_020e8618.c
@@ -9,15 +9,15 @@ extern void _ZN5Event8ClearBitEj(unsigned int b);
 void func_ov002_020e8618(char* c){
   if(_ZN9Animation8FinishedEv(c+0x35c) == 0) return;
   func_ov002_020e7e58(c);
-  *(unsigned short*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+  *(unsigned short*)(((int)c + 0x4a2)) &= ~2;
   _ZN5Actor11UntrackStarERa(c, (signed char*)(c+0x498));
   if((int)(data_0209f2d8 == 1) != 0){
     _ZN9ActorBase18MarkForDestructionEv(c);
   }else{
     _ZN5Actor24KillAndTrackInDeathTableEv(c);
   }
-  *(int*)(((int)*(char**)(c+0x438) + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000000;
-  *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x4000000;
+  *(int*)(((int)*(char**)(c+0x438) + 0xb0)) &= ~0x4000000;
+  *(int*)(((int)c + 0xb0)) &= ~0x4000000;
   data_0209b454 &= ~0x4000000;
   _ZN5Event8ClearBitEj(0x1e);
   _ZN5Event8ClearBitEj(0x1d);

--- a/src/func_ov002_020e8abc.c
+++ b/src/func_ov002_020e8abc.c
@@ -26,8 +26,8 @@ void func_ov002_020e8abc(char *self)
         func_02035860(self + 0x150, self + 0x5c);
         *(int *)(self + 0x440) = *(int *)(self + 0x444);
         func_ov002_020e9464(self);
-        *(int *)(((long long)(int)(self + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
-        f = (u16 *)(((long long)(int)(self + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(((long long)(int)(self + 0x128))) |= 1;
+        f = (u16 *)(((long long)(int)(self + 0x4a2)));
         *f &= ~2;
         *f |= 8;
         *f &= ~0x30;
@@ -35,7 +35,7 @@ void func_ov002_020e8abc(char *self)
             return;
         }
         {
-            u8 *q = (u8 *)(((long long)(int)(a + 0x1db)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(((long long)(int)(a + 0x1db)));
             *q &= ~1;
             *q |= 2;
         }

--- a/src/func_ov002_020e8e80.c
+++ b/src/func_ov002_020e8e80.c
@@ -12,7 +12,7 @@ void func_ov002_020e8e80(char* c, int a)
 
     *(int*)(c + 0x438) = a;
     func_ov002_020e9464(c);
-    p = (int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int*)(((long long)(int)(c + 0xb0)));
     *p = *p & ~0x40000;
     func_ov002_020e8ef0(c, a);
 }

--- a/src/func_ov002_020e8ef0.cpp
+++ b/src/func_ov002_020e8ef0.cpp
@@ -56,12 +56,12 @@ extern "C" int func_ov002_020e8ef0(char* c, void* p)
         int b = (*(u16*)(c + 0xc) == 0xb3);
         if (b) {
             *(u32*)(c + 0x440) = 0xd;
-            *(u16*)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+            *(u16*)(((int)c + 0x4a2)) &= ~4;
             *(u16*)(c + 0x490) = 0;
             *(u32*)(c + 0x4b8) = 0;
             *(u32*)(c + 0x4b4) = *(u32*)(c + 0x4b8);
             func_02012790(0x2d);
-            *(u32*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(u32*)(((int)c + 0x128)) |= 1;
             _ZN12CylinderClsn5ClearEv(c + 0x110);
             func_ov002_020e6fbc(c, 0x14);
             *(u8*)(c + 0x49c) = 1;
@@ -155,12 +155,12 @@ extern "C" int func_ov002_020e8ef0(char* c, void* p)
         int b4 = (data_0209f2d8 == 1);
         if (!b4) {
             void* pp = *(void**)(c + 0x438);
-            *(u32*)(((int)pp + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
-            *(u32*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+            *(u32*)(((int)pp + 0xb0)) |= 0x4000000;
+            *(u32*)(((int)c + 0xb0)) |= 0x4000000;
             data_0209b454 |= 0x4000000;
         }
     }
-    *(u32*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    *(u32*)(((int)c + 0x128)) |= 1;
     _ZN12CylinderClsn5ClearEv(c + 0x110);
     {
         int b5 = (*(u16*)(c + 0xc) == 0xb2);

--- a/src/func_ov002_020e96a0.c
+++ b/src/func_ov002_020e96a0.c
@@ -16,8 +16,8 @@ void func_ov002_020e96a0(char *c)
     int *src;
     unsigned short t;
 
-    *(unsigned short *)(((int)c + 0x490) & 0xFFFFFFFFFFFFFFFF) += 1;
-    *(short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0x800;
+    *(unsigned short *)(((int)c + 0x490)) += 1;
+    *(short *)(((int)c + 0x8e)) += 0x800;
     t = *(unsigned short *)(c + 0x490);
     if (t >= 0x1e) {
         if (t == 0x1e) {
@@ -27,7 +27,7 @@ void func_ov002_020e96a0(char *c)
             _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(c, v, data_0209f310[*(unsigned char *)(p + 0x6d8)], 1, 0, p);
             _ZN5Actor11UntrackStarERa(c, (signed char *)(c + 0x498));
         }
-        *(unsigned short *)(((int)c + 0x4a2) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+        *(unsigned short *)(((int)c + 0x4a2)) &= ~2;
         if (*(unsigned short *)(c + 0x490) < 0x64) return;
         func_ov002_020e7e58(c);
         if ((int)(data_0209f2d8 == 1) != 0) {
@@ -37,11 +37,11 @@ void func_ov002_020e96a0(char *c)
         }
     } else {
         p = *(char **)(c + 0x438);
-        src = (int *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        src = (int *)(((int)p + 0x5c));
         *(int *)(c + 0x5c) = src[0];
         *(int *)(c + 0x60) = src[1];
         *(int *)(c + 0x64) = src[2];
-        *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) += 0x104000;
+        *(int *)(((int)c + 0x60)) += 0x104000;
         func_ov002_020e8098(c);
     }
 }

--- a/src/func_ov002_020ea06c.cpp
+++ b/src/func_ov002_020ea06c.cpp
@@ -5,7 +5,7 @@ extern void _ZN9Animation7AdvanceEv(void* a);
 extern void func_ov002_020e8098(void* c);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, Fix12i v);
 void func_ov002_020ea06c(char* c){
-  int* s = (int*)(((int)*(void**)(c+0x438) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+  int* s = (int*)(((int)*(void**)(c+0x438) + 0x5c));
   *(int*)(c+0x5c) = s[0];
   *(int*)(c+0x60) = s[1];
   *(int*)(c+0x64) = s[2];
@@ -18,6 +18,6 @@ void func_ov002_020ea06c(char* c){
   if (*(int*)(c+0x43c) == 9) {
     _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0, 0x7f000);
   }
-  ++*(unsigned char*)(((int)c + 0x4a1) & 0xFFFFFFFFFFFFFFFF);
+  ++*(unsigned char*)(((int)c + 0x4a1));
 }
 }

--- a/src/func_ov002_020ea100.cpp
+++ b/src/func_ov002_020ea100.cpp
@@ -41,16 +41,16 @@ void func_ov002_020ea100(char *c)
             *(u8 *)(c + 0x49c) = 2;
         }
 
-        int *posY = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *posY = (int *)(((long long)(int)(c + 0x60)));
 
         *(int *)(c + 0x440) = 6;
-        *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
-        *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(u16 *)(((long long)(int)(c + 0x4a2))) &= ~4;
+        *(u16 *)(((long long)(int)(c + 0x4a2))) |= 2;
         *(u16 *)(c + 0x490) = 0;
 
         {
-            int *src = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
-            int *cache = (int *)(((long long)(int)(c + 0x454)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *src = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)));
+            int *cache = (int *)(((long long)(int)(c + 0x454)));
             *(int *)(c + 0x454) = src[0];
             *(int *)(c + 0x458) = src[1];
             *(int *)(c + 0x45c) = src[2];
@@ -83,7 +83,7 @@ void func_ov002_020ea100(char *c)
 
         {
             struct VObj *vobj = (struct VObj *)(c + 0x3d4);
-            { u16 *_p = (u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL); *_p = (*_p & ~1) | 1; }
+            { u16 *_p = (u16 *)(((long long)(int)(c + 0x4a2))); *_p = (*_p & ~1) | 1; }
             vobj->unk0();
         }
 
@@ -92,8 +92,8 @@ void func_ov002_020ea100(char *c)
         }
     } else {
         if (func_ov002_020ca0f4(common) != 0) {
-            int *posY2 = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
-            int *s = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *posY2 = (int *)(((long long)(int)(c + 0x60)));
+            int *s = (int *)(((long long)(int)(*(int *)(c + 0x438) + 0x5c)));
             *(int *)(c + 0x5c) = s[0];
             *(int *)(c + 0x60) = s[1];
             *(int *)(c + 0x64) = s[2];
@@ -110,7 +110,7 @@ void func_ov002_020ea100(char *c)
             *(int *)(c + 0xa8) = 0x20000;
             *(int *)(c + 0x98) = 0xc000;
             func_ov002_020e9448((unsigned char *)c);
-            *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+            *(int *)(((long long)(int)(c + 0x128))) &= ~1;
         }
     }
 

--- a/src/func_ov002_020ea420.c
+++ b/src/func_ov002_020ea420.c
@@ -34,16 +34,16 @@ void func_ov002_020ea420(char *c) {
         }
         if (en != 0) {
             if (*(int *)(c + 0x80) != 0x1000 && (data_0209b454 & 0x4000000) == 0) {
-                *(int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+                *(int *)(((long long)(int)(c + 0xb0))) |= 0x4000000;
                 data_0209b454 |= 0x4000000;
             } else if (*(int *)(c + 0x80) == 0x1000) {
                 *(u16 *)(c + 0x492) = lim + 0xb;
-                *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+                *(u16 *)(((long long)(int)(c + 0x4a2))) |= 0x200;
                 _ZN9PowerStar13AddStarMarkerEv(c);
-                *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+                *(int *)(((long long)(int)(c + 0x128))) &= ~1;
             }
             if (*(u16 *)(c + 0x492) < (unsigned int)lim) {
-                *(u16 *)(((long long)(int)(c + 0x492)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(u16 *)(((long long)(int)(c + 0x492))) += 1;
                 if (*(u16 *)(c + 0x492) == lim) {
                     if (*(u16 *)(c + 0x496) == 0xffff)
                         *(u16 *)(c + 0x496) = 0x64;
@@ -53,10 +53,10 @@ void func_ov002_020ea420(char *c) {
                 if (*(u16 *)(c + 0x492) >= lim + 0xa) {
                     if (_Z14ApproachLinearRiii(&spd, 0x1000, step) != 0) {
                         _ZN9PowerStar13AddStarMarkerEv(c);
-                        *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+                        *(int *)(((long long)(int)(c + 0x128))) &= ~1;
                     }
                 } else {
-                    *(u16 *)(((long long)(int)(c + 0x492)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                    *(u16 *)(((long long)(int)(c + 0x492))) += 1;
                 }
                 {
                     int v = spd;
@@ -72,14 +72,14 @@ void func_ov002_020ea420(char *c) {
             }
             if (*(u16 *)(c + 0x492) >= lim + 0xa &&
                 (unsigned int)(*(u16 *)(c + 0x4a2) << 22) >> 31 == 0) {
-                *(u16 *)(((long long)(int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x200;
+                *(u16 *)(((long long)(int)(c + 0x4a2))) |= 0x200;
                 func_02012790(0x41);
             }
             *(u16 *)(c + 0x100) = 0;
         } else {
-            *(int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(int *)(((long long)(int)(c + 0x128))) |= 1;
             if (*(u16 *)(c + 0x492) != 0) {
-                *(u16 *)(((unsigned long long)(unsigned int)(c + 0x492)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(u16 *)(((unsigned long long)(unsigned int)(c + 0x492))) -= 1;
             } else if (*(int *)(c + 0x80) != 0) {
                 int step2;
                 if (*(u16 *)(c + 0x100) == 0)
@@ -92,7 +92,7 @@ void func_ov002_020ea420(char *c) {
                     step2 = 0x100;
                 }
                 if (_Z14ApproachLinearRiii(&spd2, 0, step2) != 0) {
-                    *(u16 *)(((unsigned long long)(unsigned int)(c + 0x4a2)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x200;
+                    *(u16 *)(((unsigned long long)(unsigned int)(c + 0x4a2))) &= ~0x200;
                     _ZN5Actor11UntrackStarERa(c, c + 0x498);
                 }
                 {
@@ -102,7 +102,7 @@ void func_ov002_020ea420(char *c) {
                     *(int *)(c + 0x88) = v2;
                 }
                 if ((data_0209b454 & 0x4000000) == 0) {
-                    *(int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+                    *(int *)(((long long)(int)(c + 0xb0))) |= 0x4000000;
                     data_0209b454 |= 0x4000000;
                     *(u16 *)(c + 0x496) = 0x64;
                 }

--- a/src/func_ov002_020ea7ac.c
+++ b/src/func_ov002_020ea7ac.c
@@ -5,7 +5,7 @@ extern void func_ov002_020e7d08(char *p);
 void func_ov002_020ea7ac(char* c){
   if(*(int*)(c+0xa8) <= -0x18000){
     func_ov002_020e9464(c);
-    *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int*)(((int)c + 0x128)) &= ~1;
   }else{
     if(*(int*)(c+0x9c) == 0){
       *(int*)(c+0x440) = 4;

--- a/src/func_ov002_020ea824.c
+++ b/src/func_ov002_020ea824.c
@@ -13,8 +13,8 @@ void func_ov002_020ea824(char* c)
     char* o = (char*)_ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x434));
     if (o == 0) { _ZN9ActorBase18MarkForDestructionEv(c); return; }
     if (Vec3_HorzDist(c + 0x5c, o + 0x5c) < *(int*)(c + 0x98)) {
-        int* src = (int*)(((long long)(int)(o + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
-        int* yp = (int*)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* src = (int*)(((long long)(int)(o + 0x5c)));
+        int* yp = (int*)(((long long)(int)(c + 0x60)));
         *(int*)(c + 0x5c) = src[0];
         *(int*)(c + 0x60) = src[1];
         *(int*)(c + 0x64) = src[2];

--- a/src/func_ov002_020ea90c.cpp
+++ b/src/func_ov002_020ea90c.cpp
@@ -25,7 +25,7 @@ extern "C" void func_ov002_020ea90c(char* self)
             *(s32*)(self + 0xa8) = 0x18000;
             *(s32*)(self + 0x440) = 3;
         } else {
-            Vector3* pp = (Vector3*)(((long long)(int)(other + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            Vector3* pp = (Vector3*)(((long long)(int)(other + 0x5c)));
             Vector3 v;
             int yv;
             v.x = pp->x;

--- a/src/func_ov002_020ed5b0.c
+++ b/src/func_ov002_020ed5b0.c
@@ -7,7 +7,7 @@ void func_ov002_020ed5b0(char* c)
     int* sp;
     short* m;
     src = *(char**)(c + 0x38c);
-    sp = (int*)((long long)(int)(src + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+    sp = (int*)((long long)(int)(src + 0x5c));
     *(int*)(c + 0x5c) = sp[0];
     *(int*)(c + 0x60) = sp[1];
     *(int*)(c + 0x64) = sp[2];
@@ -17,7 +17,7 @@ void func_ov002_020ed5b0(char* c)
     *(int*)(c + 0x3dc) = *(int*)(c + 0x60);
     *(int*)(c + 0x3e0) = *(int*)(c + 0x64);
     src = *(char**)(c + 0x38c);
-    m = (short*)((long long)(int)(src + 0x8c) & 0xFFFFFFFFFFFFFFFFLL);
+    m = (short*)((long long)(int)(src + 0x8c));
     *(short*)(c + 0x3e4) = m[0];
     *(short*)(c + 0x3e6) = m[1];
     *(short*)(c + 0x3e8) = m[2];

--- a/src/func_ov002_020edb3c.cpp
+++ b/src/func_ov002_020edb3c.cpp
@@ -60,7 +60,7 @@ end:
         int idx = *(unsigned char *)(self + 0x41c);
         *(int *)(self + (idx << 2) + 0x3fc) = *(int *)(found + 4);
         *(int *)(self + 0x410) = *(int *)(found + 4);
-        *(unsigned char *)(((long long)(int)(self + 0x41c)) & 0xffffffffffffffffLL) += 1;
+        *(unsigned char *)(((long long)(int)(self + 0x41c))) += 1;
     }
     return (int)found;
 }

--- a/src/func_ov002_020eea84.c
+++ b/src/func_ov002_020eea84.c
@@ -42,7 +42,7 @@ int func_ov002_020eea84(char *self, char *player)
         if (_ZNK10ClsnResult9GetClsnIDEv(&res) != 0xffffffff) {
             actor = _ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(&res));
             if (actor != 0 && (b = (int)(*(u16 *)(actor + 0xc) == 0x3a)) != 0) {
-                { int *s = (int *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFF); v.x = s[0]; v.y = s[1]; v.z = s[2]; }
+                { int *s = (int *)(((int)player + 0x5c)); v.x = s[0]; v.y = s[1]; v.z = s[2]; }
                 _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(player, &v, 3, 0xc000, 1, 0, 1);
                 _ZN10ClsnResultD1Ev(&res);
                 return 1;
@@ -56,7 +56,7 @@ int func_ov002_020eea84(char *self, char *player)
         if (_ZNK10ClsnResult9GetClsnIDEv(wr) != 0xffffffff) {
             actor = _ZN5Actor10FindWithIDEj(_ZNK10ClsnResult9GetClsnIDEv(wr));
             if (actor != 0 && (b = (int)(*(u16 *)(actor + 0xc) == 0x139)) != 0) {
-                { int *s = (int *)(((int)actor + 0x5c) & 0xFFFFFFFFFFFFFFFF); v2.x = s[0]; v2.y = s[1]; v2.z = s[2]; }
+                { int *s = (int *)(((int)actor + 0x5c)); v2.x = s[0]; v2.y = s[1]; v2.z = s[2]; }
                 if (_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(player, &v2, 1, 0xc000, 1, 0, 1) != 0)
                     _ZN5Sound9PlayBank0EjRK7Vector3(0xb5, actor + 0x74);
                 return 1;

--- a/src/func_ov002_020eeeb8.cpp
+++ b/src/func_ov002_020eeeb8.cpp
@@ -34,8 +34,7 @@ extern "C" int func_ov002_020eeeb8(void *unused, char *actor)
     _ZN11RaycastLineC1Ev(rl);
 
     Vector3 *pos =
-        (Vector3 *)(((long long)(int)(actor + 0x5c)) &
-                    0xffffffffffffffffLL);
+        (Vector3 *)(((long long)(int)(actor + 0x5c)));
     int x = pos->x;
     v1.x = x;
     int y = pos->y;

--- a/src/func_ov002_020ef070.cpp
+++ b/src/func_ov002_020ef070.cpp
@@ -29,7 +29,7 @@ extern "C" int func_ov002_020ef070(void *unused, char *actor)
 
     _ZN11RaycastLineC1Ev(rl);
 
-    Vector3 *pos = (Vector3 *)(((long long)(int)(actor + 0x5c)) & 0xffffffffffffffffLL);
+    Vector3 *pos = (Vector3 *)(((long long)(int)(actor + 0x5c)));
     int x = pos->x;
     v1.x = x;
     int y = pos->y;

--- a/src/func_ov002_020ef408.c
+++ b/src/func_ov002_020ef408.c
@@ -39,8 +39,8 @@ void func_ov002_020ef408(void *arg0)
         raw = *(s16 *)(c + 0x44a);
         v = data_02082214[((u16)(int)(long long)raw >> 4) * 2];
         *(s32 *)(c + 0x60) = *(s32 *)(c + 0x444) + (s32)(u32)((((long long)v << 15) + 0x800) >> 12);
-        *(u16 *)((int)(((long long)(int)(c + 0x44a)) & 0xFFFFFFFFFFFFFFFFLL)) =
-            (u16)(*(u16 *)((int)(((long long)(int)(c + 0x44a)) & 0xFFFFFFFFFFFFFFFFLL)) + 0x3000);
+        *(u16 *)((int)(((long long)(int)(c + 0x44a)))) =
+            (u16)(*(u16 *)((int)(((long long)(int)(c + 0x44a)))) + 0x3000);
         return;
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);

--- a/src/func_ov002_020ef670.c
+++ b/src/func_ov002_020ef670.c
@@ -105,14 +105,14 @@ void func_ov002_020ef670(char *c)
 
     if (looped == 0) return;
 
-    *(int *)(((int)c + 0x438) & 0xFFFFFFFFFFFFFFFF) += *(int *)(c + 0x43c);
+    *(int *)(((int)c + 0x438)) += *(int *)(c + 0x43c);
     if (*(int *)(c + 0x438) < 0) {
         if (_ZNK7PathPtr5LoopsEv(c + 0x430)) {
             *(int *)(c + 0x438) = _ZNK7PathPtr8NumNodesEv(c + 0x430) - 1;
         } else {
             *(unsigned char *)(c + 0x42b) = 0x14;
             *(int *)(c + 0x43c) = 1;
-            *(int *)(((unsigned)c + 0x438) & 0xFFFFFFFFFFFFFFFF) += *(int *)(c + 0x43c) * 2;
+            *(int *)(((unsigned)c + 0x438)) += *(int *)(c + 0x43c) * 2;
         }
     }
     if (*(int *)(c + 0x438) >= _ZNK7PathPtr8NumNodesEv(c + 0x430)) {
@@ -123,7 +123,7 @@ void func_ov002_020ef670(char *c)
         } else {
             *(unsigned char *)(c + 0x42b) = 0x14;
             *(int *)(c + 0x43c) = -1;
-            *(int *)(((long long)(int)(c + 0x438)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x43c) * 2;
+            *(int *)(((long long)(int)(c + 0x438))) += *(int *)(c + 0x43c) * 2;
         }
     }
 

--- a/src/func_ov002_020f05f4.c
+++ b/src/func_ov002_020f05f4.c
@@ -11,7 +11,7 @@ void func_ov002_020f05f4(char* c)
         a = (char*)_ZN5Actor15FindWithActorIDEjPS_(0xb4, a);
         if (a == 0) return;
         if (*(unsigned char*)(c + 0x10d) == *(unsigned char*)(a + 0x1d9)) {
-            int* base = (int*)(((long long)(int)(a + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* base = (int*)(((long long)(int)(a + 0x5c)));
             Vector3 pos;
             pos.x = base[0];
             pos.y = base[1];

--- a/src/func_ov002_020f1fcc.c
+++ b/src/func_ov002_020f1fcc.c
@@ -10,13 +10,13 @@ void func_ov002_020f1fcc(unsigned char *self)
     int i, v;
     if (*(unsigned short *)(s + 0x2e) == 0)
         return;
-    (*(unsigned short *)((int)(((long long)(int)(s + 0x2c)) & 0xFFFFFFFFFFFFFFFFLL)))++;
+    (*(unsigned short *)((int)(((long long)(int)(s + 0x2c)))))++;
     s = *(unsigned char **)(self + 0xd4);
     if (*(unsigned short *)(s + 0x2c) != 0x18)
         return;
     *(unsigned short *)(s + 0x2c) = 0;
     s = *(unsigned char **)(self + 0xd4);
-    (*(unsigned short *)((int)(((long long)(int)(s + 0x2e)) & 0xFFFFFFFFFFFFFFFFLL)))--;
+    (*(unsigned short *)((int)(((long long)(int)(s + 0x2e)))))--;
     s = *(unsigned char **)(self + 0xd4);
     v = *(unsigned short *)(s + 0x2e);
     if (v != 0) {
@@ -30,7 +30,7 @@ void func_ov002_020f1fcc(unsigned char *self)
     _ZN3G2x13SetBlendAlphaEPVttttt(
         (volatile void *)0x4001050, 0, 0x28, 0xc, 4);
     s = *(unsigned char **)(self + 0xd4);
-    (*(unsigned char *)((int)(((long long)(int)(s + 0x34)) & 0xFFFFFFFFFFFFFFFFLL)))++;
+    (*(unsigned char *)((int)(((long long)(int)(s + 0x34)))))++;
     for (i = 0; i < 3; i++) {
         s = *(unsigned char **)(self + 0xd4);
         ((unsigned short *)(s + 0x24))[i] = (i + 1) << 4;


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 97 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
