### PR TITLE
readable: strip 92 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov002_020f2210.c
+++ b/src/func_ov002_020f2210.c
@@ -1,5 +1,5 @@
-#define LP(x) ((void*)(int)(((long long)(int)(x)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LI(x) ((int)(((long long)(int)(x)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LP(x) ((void*)(int)(((long long)(int)(x))))
+#define LI(x) ((int)(((long long)(int)(x))))
 typedef unsigned short u16;
 typedef unsigned char u8;
 typedef short s16;

--- a/src/func_ov002_020f237c.c
+++ b/src/func_ov002_020f237c.c
@@ -22,7 +22,7 @@ extern void SetSubBg1Offset(int a, int b);
 
 void func_ov002_020f237c(struct Obj* self)
 {
-    *(s16*)(((long long)(int)((char*)self->scroll + 2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(s16*)(((long long)(int)((char*)self->scroll + 2))) -= 1;
     self->scroll->x0 += 1;
     SetSubBg0Offset(self->scroll->x0, self->scroll->y0);
     SetSubBg1Offset(self->scroll->x1, self->scroll->y1);

--- a/src/func_ov002_020f23f0.c
+++ b/src/func_ov002_020f23f0.c
@@ -24,15 +24,15 @@ int func_ov002_020f23f0(u8* self)
             void* o = data_0209f5bc;
             if (((int (**)(void*))*(void**)o)[5](o) != 0) {
                 {
-                    u16* p = (u16*)(((int)*(u8**)(self + 0xd4) + 8) & 0xFFFFFFFFFFFFFFFFLL);
+                    u16* p = (u16*)(((int)*(u8**)(self + 0xd4) + 8));
                     *p = *p + 1;
                 }
                 {
-                    u16* p = (u16*)(((int)*(u8**)(self + 0xd4) + 0xa) & 0xFFFFFFFFFFFFFFFFLL);
+                    u16* p = (u16*)(((int)*(u8**)(self + 0xd4) + 0xa));
                     *p = *p - 1;
                 }
                 if (*(u16*)(*(u8**)(self + 0xd4) + 8) == 8) {
-                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34));
                     *p = *p + 1;
                 }
             }
@@ -42,7 +42,7 @@ int func_ov002_020f23f0(u8* self)
         if (*(u8*)(self + 0x100) == 3) {
             data_ov002_02111144 = 1;
             {
-                u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34));
                 *p = *p + 1;
             }
         }
@@ -50,18 +50,18 @@ int func_ov002_020f23f0(u8* self)
     case 2:
         if ((data_020a0db0 & 1) == 0) {
             {
-                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 6) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 6));
                 *p = *p + 1;
             }
             {
-                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 4) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 4));
                 *p = *p - 1;
             }
             if (*(s16*)(*(u8**)(self + 0xd4) + 6) >= 0x80) {
                 int i;
                 int v;
                 {
-                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34));
                     *p = *p + 1;
                 }
                 i = 0;
@@ -81,7 +81,7 @@ int func_ov002_020f23f0(u8* self)
         break;
     case 4:
         if (*(u8*)(self + 0x100) == 4) {
-            u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+            u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34));
             *p = *p + 1;
         }
         func_ov002_020f237c(self);
@@ -89,16 +89,16 @@ int func_ov002_020f23f0(u8* self)
     case 5:
         if ((data_020a0db0 & 1) == 0) {
             {
-                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 6) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 6));
                 *p = *p + 1;
             }
             {
-                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 4) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* p = (s16*)(((int)*(u8**)(self + 0xd4) + 4));
                 *p = *p - 1;
             }
             if (*(s16*)(*(u8**)(self + 0xd4) + 6) >= 0xe0) {
                 {
-                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* p = (u8*)(((int)*(u8**)(self + 0xd4) + 0x34));
                     *p = *p + 1;
                 }
                 data_0209d454 = data_0209d454 & ~3;

--- a/src/func_ov002_020f27e8.c
+++ b/src/func_ov002_020f27e8.c
@@ -6,11 +6,11 @@ void func_ov002_020f27e8(char *c)
 {
     if (*(unsigned char *)(c + 0x1ed) == 0) return;
 
-    *(unsigned char *)(((long long)(int)(c + 0x1ec)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(unsigned char *)(((long long)(int)(c + 0x1ec))) += 1;
 
     if (*(int *)(c + 0x1e4) != 0x1000) {
         if (*(unsigned char *)(c + 0x1ec) == data_ov002_02100140[*(unsigned short *)(c + 0x1ea) & 3]) {
-            *(int *)(((long long)(int)(c + 0x1e4)) & 0xFFFFFFFFFFFFFFFFLL) += 0x199;
+            *(int *)(((long long)(int)(c + 0x1e4))) += 0x199;
             if (*(int *)(c + 0x1e4) >= 0x1000) *(int *)(c + 0x1e4) = 0x1000;
         }
     }
@@ -18,7 +18,7 @@ void func_ov002_020f27e8(char *c)
     if (*(short *)(c + 0x1e8) != 0x800) {
         if (*(unsigned short *)(c + 0x1ea) >= 5) {
             if ((*(unsigned char *)(c + 0x1ec) & 3) == 3) {
-                *(short *)(((long long)(int)(c + 0x1e8)) & 0xFFFFFFFFFFFFFFFFLL) += 0x199;
+                *(short *)(((long long)(int)(c + 0x1e8))) += 0x199;
                 if (*(short *)(c + 0x1e8) >= 0x800) *(short *)(c + 0x1e8) = 0x800;
             }
         }
@@ -29,7 +29,7 @@ void func_ov002_020f27e8(char *c)
 
     if (*(unsigned char *)(c + 0x1ec) >= 0x1e) {
         *(unsigned char *)(c + 0x1ec) = 0;
-        *(unsigned short *)(((long long)(int)(c + 0x1ea)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(unsigned short *)(((long long)(int)(c + 0x1ea))) += 1;
     }
     if (*(unsigned short *)(c + 0x1ea) < 0xa) return;
     func_ov002_020f2984(c);

--- a/src/func_ov002_020f2f18.c
+++ b/src/func_ov002_020f2f18.c
@@ -6,8 +6,8 @@ void func_ov002_020f2f18(char* c, int a, int b)
     int i = 0;
     do {
         if (*(u8*)(c + 0x170) != 0) {
-            *(s32*)(((int)c + 0x160) & 0xFFFFFFFFFFFFFFFF) -= a;
-            *(s32*)(((int)c + 0x164) & 0xFFFFFFFFFFFFFFFF) -= b;
+            *(s32*)(((int)c + 0x160)) -= a;
+            *(s32*)(((int)c + 0x164)) -= b;
         }
         i++;
         c += 0x14;

--- a/src/func_ov002_020f2f64.c
+++ b/src/func_ov002_020f2f64.c
@@ -3,7 +3,7 @@ void func_ov002_020f2f64(char* self)
     int i;
     for (i = 0; i < 5; i++) {
         if (*(unsigned char*)(self + 0x170) != 0) {
-            (*(unsigned char*)(((int)self + 0x172) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(unsigned char*)(((int)self + 0x172)))++;
         }
         self += 0x14;
     }

--- a/src/func_ov002_020f40fc.c
+++ b/src/func_ov002_020f40fc.c
@@ -68,7 +68,7 @@ void func_ov002_020f40fc(char *c, int i)
     if (*(unsigned short*)(c + 0x36) < 0x70)
         return;
     {
-        int off2 = (int)((long long)i & 0xffffffffffffffffLL) * 0x4c;
+        int off2 = (int)((long long)i) * 0x4c;
         *(unsigned char*)(c + 0x47 + off2) += 1;
         *(unsigned short*)(c + 0x3c + off2) = 0;
         *(unsigned char*)(c + 0x48 + off) = 0;

--- a/src/func_ov002_020f4a2c.c
+++ b/src/func_ov002_020f4a2c.c
@@ -96,7 +96,7 @@ void func_ov002_020f4a2c(char *c, int i)
         char *p = c;
         for (j = 0; j < 4; j++) {
             if (*(unsigned char *)(p + 0x44) != 0) {
-                *(unsigned char *)(((long long)(int)(p + 0x47)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(unsigned char *)(((long long)(int)(p + 0x47))) += 1;
                 *(unsigned short *)(p + 0x3c) = 0;
                 *(unsigned char *)(p + 0x48) = 0;
                 *(int *)(p + 0x10) = 0x38000;

--- a/src/func_ov002_020f5990.cpp
+++ b/src/func_ov002_020f5990.cpp
@@ -30,7 +30,7 @@ void func_ov002_020f5990(char* c)
     int i;
     Sub* s = (Sub*)c;
     {
-        int* cnt = (int*)(((int)c + 0x1f8) & 0xFFFFFFFFFFFFFFFF);
+        int* cnt = (int*)(((int)c + 0x1f8));
         *cnt = *cnt + 1;
         *cnt = *cnt & 3;
     }

--- a/src/func_ov002_020f6c60.c
+++ b/src/func_ov002_020f6c60.c
@@ -48,7 +48,7 @@ int func_ov002_020f6c60(void *arg0, void *arg1, int arg2, int arg3)
     AddVec3((Vec3 *) (c + 0x5c), (Vec3 *) (data_0209f318 + 0x8c), (Vec3 *) (c + 0x5c));
     if (arg2 > 0x2bc)
     {
-      *((s32 *) ((((int) c) + 0x60) & 0xFFFFFFFFFFFFFFFF)) -= 0x96000;
+      *((s32 *) ((((int) c) + 0x60))) -= 0x96000;
     }
     if (arg2 != data_ov002_0210b614)
     {

--- a/src/func_ov002_020f7020.c
+++ b/src/func_ov002_020f7020.c
@@ -2,6 +2,6 @@
 // base to materialize (add r2,self,#0xb0) instead of folding the offset.
 int func_ov002_020f7020(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x2;
+    *(unsigned int *)(((long long)(int)(self + 0xb0))) &= ~0x2;
     return 1;
 }

--- a/src/func_ov002_020f72bc.c
+++ b/src/func_ov002_020f72bc.c
@@ -14,7 +14,7 @@ int func_ov002_020f72bc(char* c)
     *(u32*)(c + 0x84) = 0x3000;
     *(u32*)(c + 0x88) = 0x3000;
     {
-        s16* p = (s16*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        s16* p = (s16*)(((int)c + 0x8e));
         *p = *p + 0x400;
     }
     *(u8*)(c + 0x102) = 0x1f;

--- a/src/func_ov002_020f7410.c
+++ b/src/func_ov002_020f7410.c
@@ -14,7 +14,7 @@ int func_ov002_020f7410(unsigned char *self, unsigned char *in, int sel)
     int b = in[1] << 8;
     int t;
     if (a != 0 && sel == data_0209b274) {
-        register int *p = (int *)(((int)(*(unsigned char **)(self + 0xdc)) + 0x50) & 0xFFFFFFFFFFFFFFFF);
+        register int *p = (int *)(((int)(*(unsigned char **)(self + 0xdc)) + 0x50));
         p[0] = -0x5d00;
         p[1] = 0x1800;
         p[2] = -0x16000;

--- a/src/func_ov002_020f7538.c
+++ b/src/func_ov002_020f7538.c
@@ -77,7 +77,7 @@ int func_ov002_020f7538(char* c, unsigned char* arg1, int arg2) {
   Vec3_Add(&sum, (Vec3*)base, &scaled);
 
   {
-    char* dp = (char*)(((long long)(int)(*(char**)(c + 0xe0) + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    char* dp = (char*)(((long long)(int)(*(char**)(c + 0xe0) + 0x64)));
     *(int*)(dp) = sum.x;
     *(int*)(dp + 4) = sum.y;
     *(int*)(dp + 8) = sum.z;

--- a/src/func_ov002_020f79c0.c
+++ b/src/func_ov002_020f79c0.c
@@ -28,7 +28,7 @@ int func_ov002_020f79c0(char *self, void *unused, int mode)
         int t;
 
         {
-            short *p94 = (short *)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL);
+            short *p94 = (short *)(((long long)(int)(c + 0x94)));
             *p94 = *p94 + 0x200;
         }
         Math_Function_0203b0fc((int *)(c + 0xf4), 0x64000, 0x7a, 0x7fffffff);
@@ -49,18 +49,18 @@ int func_ov002_020f79c0(char *self, void *unused, int mode)
         h = *(unsigned short *)(c + 0xfc);
         t = data_02082214[(h >> 4) * 2 + 1];
         {
-            int *p60 = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p60 = (int *)(((long long)(int)(c + 0x60)));
             *p60 = *p60 + (int)((((long long)t * 0x96000LL) + 0x800) >> 12);
         }
 
         {
-            short *pfc = (short *)(((long long)(int)(c + 0xfc)) & 0xFFFFFFFFFFFFFFFFLL);
+            short *pfc = (short *)(((long long)(int)(c + 0xfc)));
             *pfc = *pfc + *(short *)(c + 0xfe);
         }
         ApproachAngle((short *)(c + 0xfe), 0x200, 0x14, 0x4000, 0);
 
         {
-            int *p5c = (int *)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p5c = (int *)(((long long)(int)(c + 0x5c)));
             *p5c = *p5c + *(int *)(c + 0xf8);
         }
         Math_Function_0203b0fc((int *)(c + 0xf8), 0, 0xcc, 0x7fffffff);

--- a/src/func_ov002_020feb50.cpp
+++ b/src/func_ov002_020feb50.cpp
@@ -41,7 +41,7 @@ extern "C" void func_ov002_020feb50(char* self) {
         *(s32*)(self + 0x354) = 1;
         _ZN5Sound4PlayEjjRK7Vector3(0, 0xa5, *(Vector3*)(self + 0x74));
         {
-            s16* p = (s16*)(((int)self + 0x94) & 0xFFFFFFFFFFFFFFFF);
+            s16* p = (s16*)(((int)self + 0x94));
             *p = *p - 0x8000;
         }
         *(s32*)(self + 0xa4) = 0;

--- a/src/func_ov003_020b060c.c
+++ b/src/func_ov003_020b060c.c
@@ -21,20 +21,20 @@ case0:
     do {
         char *e = c + (i << 1);
         if (*(unsigned short *)(e + 0x70) != 0) {
-            *(unsigned short *)(((long long)(int)(e + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) =
-                (unsigned short)(*(unsigned short *)(((long long)(int)(e + 0x70)) & 0xFFFFFFFFFFFFFFFFLL) - 1);
+            *(unsigned short *)(((long long)(int)(e + 0x70))) =
+                (unsigned short)(*(unsigned short *)(((long long)(int)(e + 0x70))) - 1);
         } else {
             short tgt = data_ov003_020b1774[i];
             if (*(short *)(e + 0x50) != tgt) {
                 if (i < 4) {
-                    short *q = (short *)(((long long)(int)(e + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+                    short *q = (short *)(((long long)(int)(e + 0x50)));
                     *q = (short)(*q + 0xc);
                     if (*(short *)(e + 0x50) >= tgt) {
                         *(short *)(e + 0x50) = tgt;
                         *(unsigned short *)(e + 0x70) = (unsigned short)ip;
                     }
                 } else {
-                    short *q = (short *)(((long long)(int)(e + 0x50)) & 0xFFFFFFFFFFFFFFFFLL);
+                    short *q = (short *)(((long long)(int)(e + 0x50)));
                     *q = (short)(*q - 0xc);
                     if (*(short *)(e + 0x50) <= tgt) {
                         *(short *)(e + 0x50) = tgt;
@@ -51,7 +51,7 @@ case0:
 
 case1:
     if (*(unsigned short *)(c + 0x70) != 0) {
-        unsigned short *p = (unsigned short *)(((long long)(int)(c + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short *p = (unsigned short *)(((long long)(int)(c + 0x70)));
         *p = (unsigned short)(*p - 1);
         return;
     }

--- a/src/func_ov003_020b1118.cpp
+++ b/src/func_ov003_020b1118.cpp
@@ -14,8 +14,8 @@ void *func_ov003_020b1118(void) {
         _ZN9ActorBaseC1Ev(p);
         *(void **)p = &data_0208e4b8;
         *(void **)p = &_ZTV5Stage;
-        *(unsigned char *)(int)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFF) |= 1;
-        *(unsigned char *)(int)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFF) |= 4;
+        *(unsigned char *)(int)(((int)p + 0x13)) |= 1;
+        *(unsigned char *)(int)(((int)p + 0x13)) |= 4;
         *(void **)p = &data_ov003_020b179c;
     }
     return p;

--- a/src/func_ov004_020adeb0.c
+++ b/src/func_ov004_020adeb0.c
@@ -5,11 +5,11 @@ void func_ov004_020adeb0(char* c)
 {
     _Z15ApproachLinear2Rsss((short*)(c + 0x1a), 0, 1);
     func_0203d630((int*)(c + 8), 0xff8);
-    int *p = (int*)(((int)c + 8) & 0xFFFFFFFFFFFFFFFF);
-    int *p2 = (int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int*)(((int)c + 8));
+    int *p2 = (int*)(((int)c + 0xc));
     *p += *(int*)(c + 0x10);
     *p2 += *(int*)(c + 0x14);
-    p = (int*)(((int)c + 4) & 0xFFFFFFFFFFFFFFFF);
+    p = (int*)(((int)c + 4));
     *(int*)c += *(int*)(c + 8);
     *p += *(int*)(c + 0xc);
 }

--- a/src/func_ov004_020af5e0.c
+++ b/src/func_ov004_020af5e0.c
@@ -20,8 +20,8 @@ int func_ov004_020af5e0(Item* src, Item* dst, int add)
         dst[i].w0 = src->w0;
         *(u32*)((char*)&dst[i] + 4) = *(u32*)((char*)src + 4);
         w = (add + src->val) & 0x3ff;
-        p = (u32*)(((long long)(int)((char*)q + 4)) & 0xFFFFFFFFFFFFFFFFLL);
-        *p = (*p & ~0x3ff) | ((u32)(((long long)(int)w) & 0xFFFFFFFFFFFFFFFFLL) & 0x3ff);
+        p = (u32*)(((long long)(int)((char*)q + 4)));
+        *p = (*p & ~0x3ff) | ((u32)(((long long)(int)w)) & 0x3ff);
         if (*(u16*)((char*)src + 6) == 0xffff)
             break;
         if (i == 0x1f) {

--- a/src/func_ov004_020b0620.cpp
+++ b/src/func_ov004_020b0620.cpp
@@ -106,7 +106,7 @@ extern "C" int dScMgBase_c_BeforeBehavior(char *self)
     _Z14ApproachLinearRiii((int *)(self + 0xac), *(int *)(self + 0xa8), data_0208ee44);
 
     {
-        int *p = (int *)(((int)self + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)self + 0x5c));
         *p = *p + 1;
     }
     if (*(int *)(self + 0x5c) >= 0x28)

--- a/src/func_ov004_020b0de0.c
+++ b/src/func_ov004_020b0de0.c
@@ -3,7 +3,7 @@ s32 GetGameLanguage(void);
 void RenderOamMainScreen(int a0, int a1, int a2, int a3, int a4);
 extern char* data_ov004_020bbfa8[];
 
-#define LAU(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LAU(p) ((int)(((long long)(int)(p))))
 
 void func_ov004_020b0de0(char* c)
 {

--- a/src/func_ov004_020b14f0.c
+++ b/src/func_ov004_020b14f0.c
@@ -1,6 +1,6 @@
 typedef long long s64;
 
-#define AT(p,off) ((int*)(int)(((s64)(int)((char*)(p)+(off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((int*)(int)(((s64)(int)((char*)(p)+(off)))))
 
 extern int func_ov004_020ad6f4(void* self, int a);
 extern int func_ov004_020adc3c(void* self);

--- a/src/func_ov004_020b2adc.c
+++ b/src/func_ov004_020b2adc.c
@@ -18,7 +18,7 @@ void *func_ov004_020b2adc(char *self)
     *(void **)self = &data_0208e4b8;
     *(void **)self = &_ZTV5Stage;
     {
-        unsigned char *p13 = (unsigned char *)(((long long)(int)(self + 0x13)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p13 = (unsigned char *)(((long long)(int)(self + 0x13)));
         *p13 |= 1;
         *p13 |= 4;
     }

--- a/src/func_ov004_020b3834.c
+++ b/src/func_ov004_020b3834.c
@@ -4,7 +4,7 @@ extern void func_ov004_020b37f0(int* obj);
 void func_ov004_020b3834(int* obj){
     char* c = (char*)obj;
     if (*(int*)(c + 0x24) < 0x30){
-        *(unsigned*)(((long long)(int)(c + 0x24)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(unsigned*)(((long long)(int)(c + 0x24))) += 1;
         return;
     }
     if (_Z15ApproachLinear2Rsss((short*)(c + 0x12), *(short*)(c + 0x16), 0x10)){

--- a/src/func_ov004_020b4d50.c
+++ b/src/func_ov004_020b4d50.c
@@ -5,7 +5,7 @@ extern int data_ov004_020b9488[];
 extern int data_ov004_020bfa18[];
 
 void func_ov004_020b4d50(char* c){
-  int* p = (int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+  int* p = (int*)(((int)c + 0xc));
   int g = data_ov004_020b9488[0];
   int n = -(((short)*(short*)(c+0x20) - (g >> 1)) << 12);
   int q = n / g;

--- a/src/func_ov005_020c21ec.c
+++ b/src/func_ov005_020c21ec.c
@@ -10,8 +10,8 @@ int *func_ov005_020c21ec(void)
         _ZN9ActorBaseC1Ev(p);
         p[0] = (int)data_0208e4b8;
         p[0] = (int)_ZTV5Stage;
-        *(unsigned char *)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFF) |= 1;
-        *(unsigned char *)(((int)p + 0x13) & 0xFFFFFFFFFFFFFFFF) |= 4;
+        *(unsigned char *)(((int)p + 0x13)) |= 1;
+        *(unsigned char *)(((int)p + 0x13)) |= 4;
         p[0] = (int)data_ov005_020c2490;
     }
     return p;

--- a/src/func_ov006_020c0364.c
+++ b/src/func_ov006_020c0364.c
@@ -51,7 +51,7 @@ void func_ov006_020c0364(char *c)
             Vector3 next;
             int *p;
 
-            p = (int *)(((long long)(int)(c + 0xe0)) & 0xFFFFFFFFFFFFFFFFLL);
+            p = (int *)(((long long)(int)(c + 0xe0)));
             *p = *p + 1;
 
             path = *(char **)(c + 0xb0);

--- a/src/func_ov006_020c057c.cpp
+++ b/src/func_ov006_020c057c.cpp
@@ -12,7 +12,7 @@ void func_ov006_020c057c(char* c) {
     int sp14[3];
     _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(c+0x18, (void*)*(int*)(c+0x14), 0, 0, 0x800, 0);
     if (*(int*)(c+0xe4) < 3) {
-        *(int *)(((int)c + 0xe4) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(int *)(((int)c + 0xe4)) += 1;
     } else {
         *(int*)(c+0xe4) = 0;
     }
@@ -26,7 +26,7 @@ void func_ov006_020c057c(char* c) {
         *(int*)(c+0xcc) = el[1];
         *(int*)(c+0xd0) = el[2];
     }
-    *(int *)(((int)c + 0xe0) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int *)(((int)c + 0xe0)) += 1;
     Vec3_Sub(sp8, c+0xc8, (char*)((int*)*(int*)(c+0xb0))[1] + *(int*)(c+0xe0) * 0xc);
     *(int*)(c+0xd4) = sp8[0];
     *(int*)(c+0xd8) = sp8[1];

--- a/src/func_ov006_020c07e8.cpp
+++ b/src/func_ov006_020c07e8.cpp
@@ -45,7 +45,7 @@ extern "C" void func_ov006_020c07e8(C* c)
         _Z11UpdateAngleRssis(&c->a0f0, d, 8, 0x200);
 
         {
-            int* p = (int*)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+            int* p = (int*)(((int)c + 0xb4));
             int* g = data_ov006_0213ac78;
             if (p[0] == g[0]) {
                 if (p[1] == g[1])

--- a/src/func_ov006_020c0b74.c
+++ b/src/func_ov006_020c0b74.c
@@ -14,7 +14,7 @@ void func_ov006_020c0b74(char *p) {
         return;
     }
     if (*(void **)(p + 0x7c) == *(void **)(p + 0x24c) && _ZNK9Animation12WillHitFrameEi(p + 0x6c, 0)) {
-        *(short *)((long long)(int)(p + 0x1d8) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(short *)((long long)(int)(p + 0x1d8)) -= 1;
         if (((Obj *)p)->field_1d8 == 0) {
             _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt(p + 0x1c, *(void **)(p + 0x254), 0, 0x40000000, 0x800, 0);
             return;

--- a/src/func_ov006_020c0f9c.cpp
+++ b/src/func_ov006_020c0f9c.cpp
@@ -16,7 +16,7 @@ extern "C" void func_ov006_020c0f9c(void *cc)
 
     if (_ZNK9Animation12WillHitFrameEi(c + 0x6c, 0)) {
         short cv = *(short*)(c + 0x100 + 0xde);
-        short *p = (short*)(((long)c + 0x1de) & 0xFFFFFFFFFFFFFFFF);
+        short *p = (short*)(((long)c + 0x1de));
         short old = *p;
         *p = old - 1;
         if (cv <= 0) {

--- a/src/func_ov006_020c11c0.cpp
+++ b/src/func_ov006_020c11c0.cpp
@@ -28,7 +28,7 @@ void func_ov006_020c11c0(char *c)
     if (f7c == *(void **)(c + 0x21c)) {
         if (_ZNK9Animation12WillHitFrameEi(c + 0x6c, 0)) {
             short cv = *(short *)(c + 0x100 + 0xde);
-            short *p = (short *)(((long)c + 0x1de) & 0xFFFFFFFFFFFFFFFF);
+            short *p = (short *)(((long)c + 0x1de));
             short old = *p;
             *p = old - 1;
             if (cv <= 0) {

--- a/src/func_ov006_020c14bc.cpp
+++ b/src/func_ov006_020c14bc.cpp
@@ -31,7 +31,7 @@ extern "C" void func_ov006_020c14bc(char* c)
 
     if (_ZNK9Animation12WillHitFrameEi(c + 0x6c, 0)) {
         short cv = *(short*)(c + 0x100 + 0xd8);
-        short* p = (short*)(((long)c + 0x1d8) & 0xFFFFFFFFFFFFFFFF);
+        short* p = (short*)(((long)c + 0x1d8));
         short old = *p;
         *p = old - 1;
         if (cv <= 0) {

--- a/src/func_ov006_020c19d0.cpp
+++ b/src/func_ov006_020c19d0.cpp
@@ -18,13 +18,13 @@ extern "C" void func_ov006_020c19d0(char* thiz)
     }
     _ZN14BlendModelAnim7AdvanceEv(c + 0x1c);
     if (_Z15ApproachLinear2Rsss(*(short*)(c + 0x1e0), 0, 1) != 0) {
-        short* p = (short*)(((int)c + 0x1e2) & 0xFFFFFFFFFFFFFFFF);
+        short* p = (short*)(((int)c + 0x1e2));
         *p = *p + 1;
         if (*(short*)(c + 0x100 + 0xe2) > 7)
             *(short*)(c + 0x100 + 0xe2) = 1;
         *(short*)(c + 0x1e0) = data_ov006_0212b89c[*(short*)(c + 0x100 + 0xe2)];
     }
-    short* q = (short*)(((int)c + 0x1e4) & 0xFFFFFFFFFFFFFFFF);
+    short* q = (short*)(((int)c + 0x1e4));
     *q = *q + 0x400;
     func_ov006_020c07e8(c + 0xdc);
 }

--- a/src/func_ov006_020c29dc.cpp
+++ b/src/func_ov006_020c29dc.cpp
@@ -44,10 +44,10 @@ void func_ov006_020c29dc(char *c)
     p = *(int **)(mc + 4);
     _ZN15TextureSequence6UpdateER15ModelComponents(c + 0xc8, mc);
     _ZN18TextureTransformer6UpdateER15ModelComponents(c + 0xdc, mc);
-    *(int *)(((int)p + 0x104) & 0xFFFFFFFFFFFFFFFFLL) -= *(int *)(c + 0x194);
-    *(int *)(((int)p + 0x108) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x198);
-    *(int *)(((int)p + 0x134) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x18c);
-    *(int *)(((int)p + 0x138) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0x190);
+    *(int *)(((int)p + 0x104)) -= *(int *)(c + 0x194);
+    *(int *)(((int)p + 0x108)) += *(int *)(c + 0x198);
+    *(int *)(((int)p + 0x134)) += *(int *)(c + 0x18c);
+    *(int *)(((int)p + 0x138)) += *(int *)(c + 0x190);
     ((Obj *)(c + 8))->m(0);
     ((Obj *)(c + 0x78))->m(&data_ov006_0212b8fc);
 }

--- a/src/func_ov006_020c2be8.c
+++ b/src/func_ov006_020c2be8.c
@@ -30,12 +30,12 @@ extern u8 data_020a0deb[];
             b -= o2; \
             int o3 = *(int*)((c) + 0x190); \
             int o4 = *(int*)((c) + 0x198); \
-            *(int*)(((s64)(int)((c) + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL) += (a - o1) >> 2; \
-            *(int*)(((s64)(int)((c) + 0x194)) & 0xFFFFFFFFFFFFFFFFLL) += b >> 2; \
+            *(int*)(((s64)(int)((c) + 0x18c))) += (a - o1) >> 2; \
+            *(int*)(((s64)(int)((c) + 0x194))) += b >> 2; \
             o3 = m - o3; \
-            *(int*)(((s64)(int)((c) + 0x190)) & 0xFFFFFFFFFFFFFFFFLL) += o3 >> 2; \
+            *(int*)(((s64)(int)((c) + 0x190))) += o3 >> 2; \
             o4 = m - o4; \
-            *(int*)(((s64)(int)((c) + 0x198)) & 0xFFFFFFFFFFFFFFFFLL) += o4 >> 2; \
+            *(int*)(((s64)(int)((c) + 0x198))) += o4 >> 2; \
         } \
     }
 

--- a/src/func_ov006_020c4060.c
+++ b/src/func_ov006_020c4060.c
@@ -15,7 +15,7 @@ extern int data_ov006_0213afa8[2];
 int func_ov006_020c4060(void) {
     int i;
     for (i = 0; i < data_ov006_02140328; i++) {
-        int* v = (int*)(((long long)(int)&data_ov006_02140324[i].x) & 0xFFFFFFFFFFFFFFFFLL);
+        int* v = (int*)(((long long)(int)&data_ov006_02140324[i].x));
         volatile int* q = (volatile int*)data_ov006_0213afa8;
         if (v[0] != data_ov006_0213afa8[0]
             || (v[1] != q[1] && data_ov006_02140324[i].x != 0))

--- a/src/func_ov006_020c4148.c
+++ b/src/func_ov006_020c4148.c
@@ -20,7 +20,7 @@ void func_ov006_020c4148(void)
 {
     int i;
     for (i = 0; i < data_ov006_02140328; i++) {
-        int *v = (int *)(((long long)(int)&data_ov006_02140324[i].x) & 0xFFFFFFFFFFFFFFFFLL);
+        int *v = (int *)(((long long)(int)&data_ov006_02140324[i].x));
         volatile int *q = (volatile int *)data_ov006_0213afc8;
         if (v[0] != data_ov006_0213afc8[0]
             || (v[1] != q[1] && data_ov006_02140324[i].x != 0))

--- a/src/func_ov006_020c42bc.c
+++ b/src/func_ov006_020c42bc.c
@@ -47,7 +47,7 @@ void func_ov006_020c42bc(void)
             ai = &oi->vel;
             for (j = t + 1; j < data_ov006_02140328; j++) {
                 if (func_ov006_020c4710(&data_ov006_02140324[j]) != 0) {
-                    oj = (struct Obj*)((long long)(int)&data_ov006_02140324[j] & 0xFFFFFFFFFFFFFFFFLL);
+                    oj = (struct Obj*)((long long)(int)&data_ov006_02140324[j]);
                     pj = &oj->pos;
                     Vec3_Sub(&v1, pi, pj);
                     Vec3_Sub(&v2, ai, &oj->vel);

--- a/src/func_ov006_020c4710.c
+++ b/src/func_ov006_020c4710.c
@@ -13,8 +13,8 @@ extern UID data_ov006_0213afb0;
 int func_ov006_020c4710(Actor *a)
 {
     int result = 0;
-    UID *p = (UID *)(int)(((long long)(int)&a->id) & 0xFFFFFFFFFFFFFFFFLL);
-    UID *c = (UID *)(int)(((long long)(int)&data_ov006_0213afa0) & 0xFFFFFFFFFFFFFFFFLL);
+    UID *p = (UID *)(int)(((long long)(int)&a->id));
+    UID *c = (UID *)(int)(((long long)(int)&data_ov006_0213afa0));
     int neq = 1;
     if (p->low == c->low) {
         if (p->high == c->high || a->id.low == 0)
@@ -23,8 +23,8 @@ int func_ov006_020c4710(Actor *a)
     if (neq != 0) {
         int flag = 1;
         int neq2 = flag;
-        UID *q = (UID *)(int)(((long long)(unsigned int)&a->id) & 0xFFFFFFFFFFFFFFFFLL);
-        UID *c2 = (UID *)(int)(((long long)(unsigned int)&data_ov006_0213afb0) & 0xFFFFFFFFFFFFFFFFLL);
+        UID *q = (UID *)(int)(((long long)(unsigned int)&a->id));
+        UID *c2 = (UID *)(int)(((long long)(unsigned int)&data_ov006_0213afb0));
         if (q->low == c2->low) {
             if (q->high == c2->high || a->id.low == 0)
                 neq2 = 0;

--- a/src/func_ov006_020c4c54.cpp
+++ b/src/func_ov006_020c4c54.cpp
@@ -16,7 +16,7 @@ struct Sub {
 };
 extern "C" void func_ov006_020c4c54(int this_) {
     Vector3 v;
-    int *p = (int*)(((int)this_ + 0x30) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int*)(((int)this_ + 0x30));
     Vector3 *d = &data_ov006_0213af98;
     if (p[0] == d->x) {
         if (p[1] == d->y)

--- a/src/func_ov006_020c4e8c.c
+++ b/src/func_ov006_020c4e8c.c
@@ -1,4 +1,4 @@
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 int func_ov006_020e6e3c(int a, int b);
 void func_ov006_020c4d3c(char* c);
 extern short data_02082214[];

--- a/src/func_ov006_020c627c.c
+++ b/src/func_ov006_020c627c.c
@@ -6,10 +6,10 @@ extern short data_02082214[];
 void func_ov006_020c627c(char* c)
 {
     int v, w;
-    *(short*)(((int)c + 0xea) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+    *(short*)(((int)c + 0xea)) += 0x200;
     {
         int a = (unsigned short)*(unsigned short*)(c + 0xea) >> 4;
-        *(int*)(((int)c + 0xac) & 0xFFFFFFFFFFFFFFFF) = data_02082214[a * 2] >> 3;
+        *(int*)(((int)c + 0xac)) = data_02082214[a * 2] >> 3;
     }
     AddVec3(c + 0x9c, c + 0xa8, c + 0x9c);
     v = *(int*)(c + 0xa8);

--- a/src/func_ov006_020c6400.c
+++ b/src/func_ov006_020c6400.c
@@ -11,7 +11,7 @@ void func_ov006_020c6400(char *self)
     Vec3 diff, scaled;
     int x, y;
     {
-        short *pa = (short*)(((long long)(int)(self+0xea)) & 0xFFFFFFFFFFFFFFFFLL);
+        short *pa = (short*)(((long long)(int)(self+0xea)));
         *pa += 0x200;
     }
     Vec3_Sub(&diff, (Vec3*)(self+0xb4), (Vec3*)(self+0x9c));

--- a/src/func_ov006_020c64e4.c
+++ b/src/func_ov006_020c64e4.c
@@ -22,14 +22,14 @@ void func_ov006_020c64e4(char *c)
     volatile int *q;
     unsigned base;
 
-    v = (int *)(((long long)(int)(c + 0x30)) & 0xFFFFFFFFFFFFFFFFLL);
+    v = (int *)(((long long)(int)(c + 0x30)));
     q = (volatile int *)data_ov006_0213af70;
     if (v[0] == data_ov006_0213af70[0]
         && (v[1] == q[1] || *(int *)(c + 0x30) == 0))
         return;
 
     base = (unsigned)(int)c;
-    v = (int *)(((long long)(int)(base + 0x30)) & 0xFFFFFFFFFFFFFFFFLL);
+    v = (int *)(((long long)(int)(base + 0x30)));
     q = (volatile int *)data_ov006_0213afc0;
     if (v[0] == data_ov006_0213afc0[0]
         && (v[1] == q[1] || *(int *)(c + 0x30) == 0))

--- a/src/func_ov006_020c66bc.c
+++ b/src/func_ov006_020c66bc.c
@@ -25,7 +25,7 @@ void func_ov006_020c66bc(char *c)
     int dx, dy, dz;
     int vx, vy;
 
-    *(short *)(((int)c + 0xea) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+    *(short *)(((int)c + 0xea)) += 0x200;
 
     dx = *(int *)(c + 0x20) - *(int *)(c + 0x9c);
     *(int *)(c + 0xa8) = (int)((((long long)dx << 8) + 0x800) >> 12);

--- a/src/func_ov006_020c6a9c.c
+++ b/src/func_ov006_020c6a9c.c
@@ -14,7 +14,7 @@ extern int _Z15ApproachLinear2Rsss(short *v, short target, short step);
 
 void func_ov006_020c6a9c(char *c)
 {
-    short *ang = (short *)(((int)c + 0xea) & 0xFFFFFFFFFFFFFFFFLL);
+    short *ang = (short *)(((int)c + 0xea));
     *ang = *ang + 0x200;
 
     *(int *)(c + 0xa8) = (int)(((*(int *)(c + 0x20) - *(int *)(c + 0x9c)) * 0x100LL + 0x800) >> 12);

--- a/src/func_ov006_020c7300.c
+++ b/src/func_ov006_020c7300.c
@@ -15,7 +15,7 @@ extern int data_ov006_0213b040[2];
 int func_ov006_020c7300(void) {
     int i;
     for (i = 0; i < data_ov006_02140418; i++) {
-        int* v = (int*)(((long long)(int)&data_ov006_02140420[i].x) & 0xFFFFFFFFFFFFFFFFLL);
+        int* v = (int*)(((long long)(int)&data_ov006_02140420[i].x));
         volatile int* q = (volatile int*)data_ov006_0213b040;
         if (v[0] != data_ov006_0213b040[0]
             || (v[1] != q[1] && data_ov006_02140420[i].x != 0))

--- a/src/func_ov006_020c762c.c
+++ b/src/func_ov006_020c762c.c
@@ -9,7 +9,7 @@ int func_ov006_020c762c(char *c)
     int r = 0;
     int m = 1;
 
-    p = (struct Pair *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF);
+    p = (struct Pair *)(((int)c + 0x3c));
     g = &data_ov006_0213b058;
     if (p->a == g->a) {
         if (p->b == g->b)
@@ -21,7 +21,7 @@ cl1:
     }
     if (m != 0) {
         m = 1;
-        p = (struct Pair *)(((long long)(int)(c + 0x3c)) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (struct Pair *)(((long long)(int)(c + 0x3c)));
         g = &data_ov006_0213b070;
         if (p->a == g->a) {
             if (p->b == g->b)

--- a/src/func_ov006_020c78ec.cpp
+++ b/src/func_ov006_020c78ec.cpp
@@ -7,7 +7,7 @@ extern "C" void func_ov006_020c8768(char *p);
 
 extern "C" void func_ov006_020c78ec(char *thiz)
 {
-    *(short *)(((int)thiz + 0x32) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(short *)(((int)thiz + 0x32)) -= 1;
     if (*(short*)(thiz + 0x32) == 0) {
         _Z14ApproachLinearRiii((&data_ov006_02140428)[0], 0, 1);
         _ZN5Sound12PlayBank2_2DEj(0x130);

--- a/src/func_ov006_020c8084.cpp
+++ b/src/func_ov006_020c8084.cpp
@@ -12,7 +12,7 @@ extern int data_ov006_0213b090[2];
 
 extern "C" void func_ov006_020c8084(char *c)
 {
-    int *p = (int*)(((long long)(int)(c + 0x3c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *p = (int*)(((long long)(int)(c + 0x3c)));
     int *g = data_ov006_0213b088;
     if (p[0] == g[0] && (p[1] == g[1] || *(int*)(c + 0x3c) == 0)) {
         *(int*)(c + 0x24) = 0;

--- a/src/func_ov006_020c8270.c
+++ b/src/func_ov006_020c8270.c
@@ -13,7 +13,7 @@ void func_ov006_020c8270(char* c)
     int t0, t1;
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((void*)(c + 0x4c), data_ov006_0214041c, 0x40000000, 0x800, 0);
     *(int*)(c + 0xa4) = 0;
-    p = (struct Pair*)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF);
+    p = (struct Pair*)(((int)c + 0x3c));
     g = &data_ov006_0213b068;
     if (p->a == g->a &&
         (p->b == g->b || *(int*)(c + 0x3c) == 0)) {

--- a/src/func_ov006_020c85bc.cpp
+++ b/src/func_ov006_020c85bc.cpp
@@ -13,7 +13,7 @@ extern "C" void func_ov006_020c85bc(char *o)
     *(unsigned char *)(o + 0x35) = 1;
     int zero = 0;
     *(int *)(o + 0x18) = zero;
-    int *base = (int *)(((int)o + 0x20) & 0xFFFFFFFFFFFFFFFF);
+    int *base = (int *)(((int)o + 0x20));
     *base = *base << 1;
     *(int *)(o + 0x24) = data_ov006_0213b00c;
     *(short *)(o + 0x10) = (short)zero;

--- a/src/func_ov006_020c8680.c
+++ b/src/func_ov006_020c8680.c
@@ -11,7 +11,7 @@ void func_ov006_020c8680(char* self)
     unsigned int r;
     int r5;
 
-    *(short*)(((long long)(int)(self + 0x32)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(short*)(((long long)(int)(self + 0x32))) -= 1;
     if (*(short*)(self + 0x32) == 0) {
         *(int*)(self + 0x18) = 0x100000;
         r = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;

--- a/src/func_ov006_020c8ba8.cpp
+++ b/src/func_ov006_020c8ba8.cpp
@@ -5,15 +5,15 @@ int ApproachLinear2(short&, short, short);
 extern "C" void func_ov006_020c8ba8(char* c)
 {
     if (*(short*)(c+0x18) == 0) return;
-    *(short*)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+    *(short*)(((int)c + 0x1c)) += 0x200;
     *(int*)(c+0x10) = (int)(((long long)*(int*)(c+0x10) * *(int*)(c+0x14) + 0x800) >> 12);
-    *(int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF) -= 0x40;
+    *(int*)(((int)c + 0xc)) -= 0x40;
     ApproachLinear(*(int*)(c+0x14), 0x800, 0x10);
     if (ApproachLinear2(*(short*)(c+0x1e), 0, 1) != 0) {
         if (*(short*)(c+0x1a) != 2)
             *(short*)(c+0x18) = 0;
     } else {
         *(int*)(c) += *(int*)(c+0x8);
-        *(int*)(((int)c + 0x4) & 0xFFFFFFFFFFFFFFFF) += *(int*)(c+0xc);
+        *(int*)(((int)c + 0x4)) += *(int*)(c+0xc);
     }
 }

--- a/src/func_ov006_020c8ddc.c
+++ b/src/func_ov006_020c8ddc.c
@@ -8,7 +8,7 @@ int func_ov006_020c8ddc(char *c)
     int result;
     int flag;
 
-    p = (int *)(((long long)(int)(c + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(int)(c + 0x70)));
     d = data_ov006_0213b13c;
     result = 0;
     flag = 1;
@@ -21,7 +21,7 @@ int func_ov006_020c8ddc(char *c)
     }
 after1:
     if (flag != 0) {
-        p = (int *)(((long long)(unsigned)(c + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (int *)(((long long)(unsigned)(c + 0x70)));
         d = data_ov006_0213b144;
         flag = 1;
         if (p[0] == d[0]) {

--- a/src/func_ov006_020c9098.c
+++ b/src/func_ov006_020c9098.c
@@ -19,7 +19,7 @@ extern "C" void func_ov006_020c9098(char *c)
     int *p;
     int *d;
 
-    p = (int *)(((long long)(int)(c + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(int)(c + 0x70)));
     d = data_ov006_0213b214;
     if (p[0] == d[0]) {
         if (p[1] != d[1]) {
@@ -29,7 +29,7 @@ extern "C" void func_ov006_020c9098(char *c)
         return;
     }
 check2:
-    p = (int *)(((long long)(unsigned)(c + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(unsigned)(c + 0x70)));
     d = data_ov006_0213b0fc;
     if (p[0] == d[0]) {
         if (p[1] != d[1]) {

--- a/src/func_ov006_020c91ac.cpp
+++ b/src/func_ov006_020c91ac.cpp
@@ -81,7 +81,7 @@ L70:
         else if (t > 0x1400) t = 0x1400;
         *(int *)(c + 0x3c) = t;
 
-        *(int *)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFF) +=
+        *(int *)(((int)c + 0x40)) +=
             (int)(((long long)data_ov006_02140574 * 0x400 + 0x800) >> 12);
 
         {
@@ -122,7 +122,7 @@ L1a4:
 L230:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF) *= -1;
+        *(int *)(((int)c + 0x3c)) *= -1;
     }
 
 L260:

--- a/src/func_ov006_020c97bc.cpp
+++ b/src/func_ov006_020c97bc.cpp
@@ -64,7 +64,7 @@ L70:
         else if (t > 0x1400) t = 0x1400;
         *(int *)(c + 0x3c) = t;
 
-        *(int *)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFF) +=
+        *(int *)(((int)c + 0x40)) +=
             (int)(((long long)data_ov006_02140574 * 0x400 + 0x800) >> 12);
 
         v40 = data_ov006_021405a8;
@@ -111,7 +111,7 @@ L1a4:
 L230:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFF) *= -1;
+        *(int *)(((int)c + 0x3c)) *= -1;
     }
 
 L260:

--- a/src/func_ov006_020c9d7c.c
+++ b/src/func_ov006_020c9d7c.c
@@ -10,7 +10,7 @@ void func_ov006_020c9d7c(char *c)
 {
     unsigned int r;
     int r5;
-    *(short*)(((long long)(int)(c + 0x6c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(short*)(((long long)(int)(c + 0x6c))) -= 1;
     if (*(short*)(c + 0x6c) == 0) {
     *(int*)(c + 0x28) = 0x100000;
     r = ((unsigned int)RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 0x13;

--- a/src/func_ov006_020c9efc.cpp
+++ b/src/func_ov006_020c9efc.cpp
@@ -16,7 +16,7 @@ struct Obj {
 };
 
 extern "C" void func_ov006_020c9efc(char* c){
-  *(short*)(((int)c+0x6c) & 0xFFFFFFFFFFFFFFFFLL) = *(short*)(((int)c+0x6c) & 0xFFFFFFFFFFFFFFFFLL) - 1;
+  *(short*)(((int)c+0x6c)) = *(short*)(((int)c+0x6c)) - 1;
   if(*(short*)(c+0x6c)==0){
     func_ov006_020c8c78(*(short*)(c+0x56),0xc0);
     data_ov006_02140598=data_ov006_02140598-1;

--- a/src/func_ov006_020ca070.cpp
+++ b/src/func_ov006_020ca070.cpp
@@ -61,7 +61,7 @@ L70:
         *(int *)(c + 0x24) = v;
     }
 
-    *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFFLL) *= -1;
+    *(int *)(((int)c + 0x3c)) *= -1;
     if (*(int *)(c + 0x40) <= -0x800) goto L260;
 
     if (*(s16 *)(c + 0x22) != 0) goto L1a4;
@@ -100,7 +100,7 @@ L1a4:
 L230:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFFLL) *= -1;
+        *(int *)(((int)c + 0x3c)) *= -1;
     }
 
 L260:

--- a/src/func_ov006_020ca7b8.c
+++ b/src/func_ov006_020ca7b8.c
@@ -15,7 +15,7 @@ extern int data_ov006_0213b10c[2];
 int func_ov006_020ca7b8(void) {
     int i;
     for (i = 0; i < data_ov006_021405bc; i++) {
-        int* v = (int*)(((long long)(int)&data_ov006_02140554[i].x) & 0xFFFFFFFFFFFFFFFFLL);
+        int* v = (int*)(((long long)(int)&data_ov006_02140554[i].x));
         volatile int* q = (volatile int*)data_ov006_0213b10c;
         if (v[0] != data_ov006_0213b10c[0]
             || (v[1] != q[1] && data_ov006_02140554[i].x != 0))

--- a/src/func_ov006_020ca8e0.cpp
+++ b/src/func_ov006_020ca8e0.cpp
@@ -26,7 +26,7 @@ extern "C" void func_ov006_020ca8e0(void) {
   q0 = data_ov006_0213b104[0];
   for (;;) {
 
-    int* v = (int*)(((long long)(int)(e + 0x70)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* v = (int*)(((long long)(int)(e + 0x70)));
     volatile int* q = (volatile int*)data_ov006_0213b104;
     if (v[0] == q0 && (v[1] == q[1] || *(int*)(e + 0x70) == 0)) {
 

--- a/src/func_ov006_020caf4c.c
+++ b/src/func_ov006_020caf4c.c
@@ -1,6 +1,6 @@
 extern int data_ov006_0213b0f4[];
 int func_ov006_020caf4c(int* r0) {
-    int* p = (int*)(((int)r0 + 0x64) & 0xFFFFFFFFFFFFFFFF);
+    int* p = (int*)(((int)r0 + 0x64));
     int* g = data_ov006_0213b0f4;
     int lr = 1;
     if (p[0] == g[0]) {

--- a/src/func_ov006_020cb1a8.c
+++ b/src/func_ov006_020cb1a8.c
@@ -20,7 +20,7 @@ extern "C" void func_ov006_020cb1a8(char *c)
     int *p;
     int *d;
 
-    p = (int *)(((long long)(int)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(int)(c + 0x64)));
     d = data_ov006_0213b1a4;
     if (p[0] == d[0]) {
         if (p[1] != d[1]) {
@@ -30,7 +30,7 @@ extern "C" void func_ov006_020cb1a8(char *c)
         return;
     }
 check2:
-    p = (int *)(((long long)(unsigned)(c + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(unsigned)(c + 0x64)));
     d = data_ov006_0213b1fc;
     if (p[0] == d[0]) {
         if (p[1] != d[1]) {

--- a/src/func_ov006_020cb690.cpp
+++ b/src/func_ov006_020cb690.cpp
@@ -22,7 +22,7 @@ void func_ov006_020cb690(char* c)
         *(int*)(c+0x64) = b ? a : a;
         *(int*)(c+0x68) = b;
     }
-    int* p20 = (int*)(((int)c + 0x20) & 0xFFFFFFFFFFFFFFFF);
+    int* p20 = (int*)(((int)c + 0x20));
     *p20 = *p20 + 0x20000;
     func_ov006_020cb5c4(c);
 }

--- a/src/func_ov006_020cb838.cpp
+++ b/src/func_ov006_020cb838.cpp
@@ -110,13 +110,13 @@ L134:
     }
 
     func_02012718(0x1b3, *(int *)(c + 0x1c) + 0x80000);
-    *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) *= -1;
+    *(int *)(((int)c + 0x34)) *= -1;
     goto L1dc;
 
 L1ac:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) *= -1;
+        *(int *)(((int)c + 0x34)) *= -1;
     }
 
 L1dc:

--- a/src/func_ov006_020cbd7c.cpp
+++ b/src/func_ov006_020cbd7c.cpp
@@ -96,13 +96,13 @@ L134:
     }
 
     func_02012718(0x1b3, *(int *)(c + 0x1c) + 0x80000);
-    *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) *= -1;
+    *(int *)(((int)c + 0x34)) *= -1;
     goto L1dc;
 
 L1ac:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) *= -1;
+        *(int *)(((int)c + 0x34)) *= -1;
     }
 
 L1dc:

--- a/src/func_ov006_020cc198.c
+++ b/src/func_ov006_020cc198.c
@@ -35,7 +35,7 @@ extern "C" void func_ov006_020cc198(char *c)
     if (b > 0)
         *(int *)(c + 0x34) = -*(int *)(c + 0x34);
 
-    p38 = (int *)(((long long)(int)(c + 0x38)) & 0xFFFFFFFFFFFFFFFFLL);
+    p38 = (int *)(((long long)(int)(c + 0x38)));
     *p38 += (int)((((long long)data_ov006_02140578 << 11) + 0x800) >> 12);
 
     ((VtObj *)c)->m4();

--- a/src/func_ov006_020cc408.cpp
+++ b/src/func_ov006_020cc408.cpp
@@ -91,13 +91,13 @@ L70:
 
 L130:
     func_ov006_020e6e3c(0x1b3, v);
-    *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFFLL) *= -1;
+    *(int *)(((int)c + 0x34)) *= -1;
     goto L180;
 
 L150:
     if (*(u16 *)(c + 0x18) == 3) {
         ((VtObj *)c)->m4();
-        *(int *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFFLL) *= -1;
+        *(int *)(((int)c + 0x34)) *= -1;
     }
 
 L180:

--- a/src/func_ov006_020cc8c8.c
+++ b/src/func_ov006_020cc8c8.c
@@ -19,7 +19,7 @@ void func_ov006_020cc8c8(char *p) {
     *(int *)(p + 0x34) = z;
     *(int *)(p + 0x38) = z;
     *(int *)(p + 0x3c) = z;
-    cur = (int *)(((long long)(int)(p + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    cur = (int *)(((long long)(int)(p + 0x64)));
     want = data_ov006_0213b204;
     if (cur[0] == want[0] && (cur[1] == want[1] || *(int *)(p + 0x64) == 0)) {
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(p + 0x6c, data_ov006_0214057c, 0x40000000, 0x800, 0);

--- a/src/func_ov006_020ccd04.c
+++ b/src/func_ov006_020ccd04.c
@@ -1,6 +1,6 @@
 extern int data_ov006_0213b17c[];
 int func_ov006_020ccd04(int* r0) {
-    int* p = (int *)(((int)r0 + 0x64) & 0xFFFFFFFFFFFFFFFF);
+    int* p = (int *)(((int)r0 + 0x64));
     int* g = data_ov006_0213b17c;
     int ret = 1;
     if (p[0] == g[0]) {

--- a/src/func_ov006_020cdc38.c
+++ b/src/func_ov006_020cdc38.c
@@ -3,7 +3,7 @@ typedef signed int s32;
 
 void func_ov006_020cdc38(void *arg0)
 {
-    *(u16 *)(((long long)(int)((char *)arg0 + 0x9a)) & 0xFFFFFFFFFFFFFFFFLL) += 0x100;
+    *(u16 *)(((long long)(int)((char *)arg0 + 0x9a))) += 0x100;
     if (*(u16 *)((char *)arg0 + 0x9a) & 0x8000) {
         *(s32 *)((char *)arg0 + 0x30) = 0xc00;
     } else {

--- a/src/func_ov006_020cdc8c.c
+++ b/src/func_ov006_020cdc8c.c
@@ -9,7 +9,7 @@ void func_ov006_020cdc8c(char *self)
     int d;
     int v;
     int base = 0x400;
-    u16 *pa = (u16 *)(((long long)(int)(self + 0x9a)) & 0xFFFFFFFFFFFFFFFFLL);
+    u16 *pa = (u16 *)(((long long)(int)(self + 0x9a)));
 
     *pa = *pa + 0x40;
 

--- a/src/func_ov006_020ce108.cpp
+++ b/src/func_ov006_020ce108.cpp
@@ -84,14 +84,14 @@ extern "C" void func_ov006_020ce108(char *a, Obj *o)
         Vec3_MulScalar(&t1, &vA, *(int *)(a + 0x88));
         AddVec3(p1, &t1, p1);
         AddVec3(&acc, &vA, &acc);
-        *(short *)(((int)o + 0x22) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(short *)(((int)o + 0x22)) += 1;
     } else if (lenB < 0xE000 && NormalizeVec3IfNonZero(&vB) != 0) {
         Vec3_MulScalarInPlace(&vB, 0xE000 - lenB);
         vB.y <<= 1;
         Vec3_MulScalar(&t2, &vB, *(int *)(a + 0x88));
         AddVec3(p1, &t2, p1);
         AddVec3(&acc, &vB, &acc);
-        *(short *)(((int)o + 0x22) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(short *)(((int)o + 0x22)) += 1;
     }
 
     Vec3_MulScalar(&t3, &acc, 0x100);

--- a/src/func_ov006_020ce674.c
+++ b/src/func_ov006_020ce674.c
@@ -1,6 +1,6 @@
 struct V2 { int x, y; };
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern void func_ov006_020ce8a0(char* self, void* other, struct V2* a, struct V2* b);
 extern void Vec2_Sub(struct V2* o, struct V2* a, struct V2* b);

--- a/src/func_ov006_020ceabc.c
+++ b/src/func_ov006_020ceabc.c
@@ -27,7 +27,7 @@ void func_ov006_020ceabc(char *self, int *v1, int *v2, int a3, short a4)
     *(int *)(self + 0x3c) = v2[1];
     *(int *)(self + 0x40) = v2[2];
     {
-        int *p38 = (int *)(int)(((long long)(int)(self + 0x38)) & 0xffffffffffffffffLL);
+        int *p38 = (int *)(int)(((long long)(int)(self + 0x38)));
         *(int *)(self + 0x44) = p38[0];
         *(int *)(self + 0x48) = p38[1];
         *(int *)(self + 0x4c) = p38[2];
@@ -37,7 +37,7 @@ void func_ov006_020ceabc(char *self, int *v1, int *v2, int a3, short a4)
     *(int *)(self + 0x18) = *(int *)(self + 0xc);
     *(int *)(self + 0x1c) = *(int *)(self + 0x10);
     {
-        int *p14 = (int *)(int)(((long long)(int)(self + 0x14)) & 0xffffffffffffffffLL);
+        int *p14 = (int *)(int)(((long long)(int)(self + 0x14)));
         *(int *)(self + 0x20) = p14[0];
         *(int *)(self + 0x24) = p14[1];
         *(int *)(self + 0x28) = p14[2];

--- a/src/func_ov006_020cf790.c
+++ b/src/func_ov006_020cf790.c
@@ -6,8 +6,8 @@ void func_ov006_020cf790(char* c) {
         *(unsigned char*)(c + 0x328) = 0;
         return;
     }
-    *(int*)(((int)c + 0x2C) & 0xFFFFFFFFFFFFFFFF) += 0x80;
-    *(int*)(((int)c + 0x30) & 0xFFFFFFFFFFFFFFFF) += 0x80;
-    *(int*)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) += 0x80;
+    *(int*)(((int)c + 0x2C)) += 0x80;
+    *(int*)(((int)c + 0x30)) += 0x80;
+    *(int*)(((int)c + 0x34)) += 0x80;
     func_ov006_020cf124(c);
 }

--- a/src/func_ov006_020cf820.c
+++ b/src/func_ov006_020cf820.c
@@ -9,7 +9,7 @@ extern void func_ov006_020cf124(char *c);
 extern int data_020a0db0;
 extern s16 data_02082214[];
 
-#define LA(p) ((int)(((s64)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int)(((s64)(int)(p))))
 
 void func_ov006_020cf820(char *c)
 {

--- a/src/func_ov006_020cfa44.c
+++ b/src/func_ov006_020cfa44.c
@@ -4,7 +4,7 @@ typedef unsigned short u16;
 
 typedef struct { int x, y, z; } Vec3;
 
-#define LA(p) ((int)(((s64)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((int)(((s64)(int)(p))))
 
 extern s16 data_02082214[];
 extern void func_ov006_020cfc74(char *o);

--- a/src/func_ov006_020d1a3c.cpp
+++ b/src/func_ov006_020d1a3c.cpp
@@ -51,7 +51,7 @@ extern "C" void func_ov006_020d1a3c(void *p)
             if (*(int *)(base + 0x53d8) >= 5) {
                 *(u8 *)(base + 0x53dc) = 1;
             } else {
-                *(int *)(((long long)(int)(base + 0x53d8)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(int *)(((long long)(int)(base + 0x53d8))) += 1;
                 *(u8 *)(base + 0x53dc) = 0;
             }
             *(u8 *)(base + 0x53de) = 1;

--- a/src/func_ov006_020d452c.c
+++ b/src/func_ov006_020d452c.c
@@ -23,10 +23,10 @@ void func_ov006_020d452c(void *thiz)
     for (; i < 4; y += 0x40, i++) {
         int *p = (int *)(c + i * 4);
         if (*(int *)((char *)p + 0x4714) != 0) {
-            int *t = (int *)(((int)p + 0x539c) & 0xFFFFFFFFFFFFFFFFLL);
+            int *t = (int *)(((int)p + 0x539c));
             (*t)++;
             if (*t >= 6) {
-                int *u = (int *)(((int)p + 0x53ac) & 0xFFFFFFFFFFFFFFFFLL);
+                int *u = (int *)(((int)p + 0x53ac));
                 *t = 0;
                 (*u)++;
                 if (*u >= 14)
@@ -41,8 +41,8 @@ void func_ov006_020d452c(void *thiz)
             int *cnt2;
             int tbl[13];
             if (*(c + i + 0x5398) == 0) {
-                cnt = (int *)(((int)p + 0x5378) & 0xFFFFFFFFFFFFFFFFLL);
-                cnt2 = (int *)(((int)p + 0x5388) & 0xFFFFFFFFFFFFFFFFLL);
+                cnt = (int *)(((int)p + 0x5378));
+                cnt2 = (int *)(((int)p + 0x5388));
                 (*cnt)++;
                 if (*cnt2 >= 12) {
                     if (*cnt >= 6) {
@@ -54,8 +54,8 @@ void func_ov006_020d452c(void *thiz)
                     (*cnt2)++;
                 }
             } else {
-                cnt = (int *)(((int)p + 0x5378) & 0xFFFFFFFFFFFFFFFFLL);
-                cnt2 = (int *)(((int)p + 0x5388) & 0xFFFFFFFFFFFFFFFFLL);
+                cnt = (int *)(((int)p + 0x5378));
+                cnt2 = (int *)(((int)p + 0x5388));
                 (*cnt)++;
                 if (*cnt2 >= 12) {
                     if (*cnt >= 5) {

--- a/src/func_ov006_020d48dc.cpp
+++ b/src/func_ov006_020d48dc.cpp
@@ -34,7 +34,7 @@ extern u8 data_0209d454;
 
 extern "C" int func_ov006_020d48dc(char* self)
 {
-    *(u16*)(((long long)(int)(self + 0x53bc)) & 0xFFFFFFFFFFFFFFFFLL) += 0xc0;
+    *(u16*)(((long long)(int)(self + 0x53bc))) += 0xc0;
     {
         u8 *p2 = (u8*)(self + 0x5300);
         u16 idx = *(u16*)(p2 + 0xbc);
@@ -51,13 +51,13 @@ extern "C" int func_ov006_020d48dc(char* self)
             int i;
             for (i = 0; i < 4; i++) {
                 if (*(int*)(self + i * 4 + 0x4714) != 0) {
-                    int *counterA = (int*)(((long long)(int)(self + i * 4 + 0x539c)) & 0xFFFFFFFFFFFFFFFFLL);
+                    int *counterA = (int*)(((long long)(int)(self + i * 4 + 0x539c)));
                     (*counterA)++;
                     Buf14 local = data_ov006_0213b880;
                     if (*counterA >= local.v[i]) {
                         int *counterB;
                         *counterA = 0;
-                        counterB = (int*)(((long long)(int)(self + i * 4 + 0x53ac)) & 0xFFFFFFFFFFFFFFFFLL);
+                        counterB = (int*)(((long long)(int)(self + i * 4 + 0x53ac)));
                         (*counterB)++;
                         if (*counterB >= 0xe)
                             *counterB = 0;

--- a/src/func_ov006_020d52f0.c
+++ b/src/func_ov006_020d52f0.c
@@ -13,7 +13,7 @@ void dScMgAmida_c_OnYoshiTryEat_020d52f0(char *c, int arg)
         int *p;
         if (self->unk_0bc >= 0x7cf)
             goto final;
-        p = (int *)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFF);
+        p = (int *)(((int)c + 0xbc));
         *p = *p + 1;
         if (self->unk_0bc > 0x270e)
             self->unk_0bc = 0x270e;

--- a/src/func_ov006_020d5b10.c
+++ b/src/func_ov006_020d5b10.c
@@ -17,7 +17,7 @@ void func_ov006_020d5b10(char *c)
     if (state == 1) {
         s32 v;
         s32 shifted;
-        *(s32*)(((long long)(int)(c + 0x62dc)) & 0xFFFFFFFFFFFFFFFFLL) += 0x3000;
+        *(s32*)(((long long)(int)(c + 0x62dc))) += 0x3000;
         v = *(s32*)(c+0x62dc);
         shifted = v >> 0xc;
         if (shifted >= 0xc0) {
@@ -37,7 +37,7 @@ void func_ov006_020d5b10(char *c)
     }
 
     if (*(u16*)(c+0x62f2) != 0) {
-        *(u16*)(((long long)(int)(c + 0x62f2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(u16*)(((long long)(int)(c + 0x62f2))) -= 1;
         if (*(u16*)(c+0x62f2) != 0) {
             return;
         }
@@ -48,7 +48,7 @@ void func_ov006_020d5b10(char *c)
     {
         s32 v;
         s32 shifted;
-        *(s32*)(((long long)(int)(c + 0x62dc)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x3000;
+        *(s32*)(((long long)(int)(c + 0x62dc))) -= 0x3000;
         v = *(s32*)(c+0x62dc);
         shifted = v >> 0xc;
         if (shifted <= 0) {

--- a/src/func_ov006_020d5d08.c
+++ b/src/func_ov006_020d5d08.c
@@ -5,12 +5,12 @@ void func_ov006_020d5d08(char *c)
     for (i = 0; i < 2; i++) {
         char *b = c + (i << 4);
         if (*(unsigned char *)(b + 0x6000 + 0x2bc)) {
-            unsigned short *h = (unsigned short *)(((int)b + 0x62b8) & 0xFFFFFFFFFFFFFFFF);
+            unsigned short *h = (unsigned short *)(((int)b + 0x62b8));
             *h = *h + 1;
             if (*h >= 4) {
                 unsigned char *p;
                 *h = 0;
-                p = (unsigned char *)(((int)b + 0x62be) & 0xFFFFFFFFFFFFFFFF);
+                p = (unsigned char *)(((int)b + 0x62be));
                 *p = *p + 1;
                 *p = *p & 3;
             }

--- a/src/func_ov006_020d64c8.c
+++ b/src/func_ov006_020d64c8.c
@@ -16,7 +16,7 @@ void func_ov006_020d64c8(char *o, int i)
     if (i == 0) {
         u8 v = *(u8 *)(o + i * 16 + 0x626f);
         if (v == 2 || v == 4) {
-            int *w = (int *)(((int)o + 0x62b4) & 0xFFFFFFFFFFFFFFFF);
+            int *w = (int *)(((int)o + 0x62b4));
             *w += 0x8000;
         }
     }

--- a/src/func_ov006_020d68a8.c
+++ b/src/func_ov006_020d68a8.c
@@ -7,20 +7,20 @@ typedef unsigned short u16;
 void func_ov006_020d68a8(char *o, int a1)
 {
     int i;
-    u8 *cur = (u8 *)(((int)(o + a1 * 0x40) + 0x469a) & 0xFFFFFFFFFFFFFFFF);
+    u8 *cur = (u8 *)(((int)(o + a1 * 0x40) + 0x469a));
     for (i = 0; i < 0x70; i++) {
         char *q = o + i * 0x40;
         if (*(u8 *)(q + 0x4698) != 0) {
             if (i != a1) {
                 u8 n = *cur;
                 if (n == 0) {
-                    u8 *st = (u8 *)(((int)q + 0x4697) & 0xFFFFFFFFFFFFFFFF);
+                    u8 *st = (u8 *)(((int)q + 0x4697));
                     if (*st != 5) {
                         *st = 3;
                         *(u16 *)(q + 0x4690) = 0x20;
                     }
                 } else {
-                    u8 *st = (u8 *)(((int)q + 0x4697) & 0xFFFFFFFFFFFFFFFF);
+                    u8 *st = (u8 *)(((int)q + 0x4697));
                     if (*st == 5) {
                         if (*(u8 *)(q + 0x4696) + 1 == n) {
                             *st = 3;

--- a/src/func_ov006_020d7604.c
+++ b/src/func_ov006_020d7604.c
@@ -23,13 +23,13 @@ void func_ov006_020d7604(void *a)
                     q = 0;
                     *(unsigned short *)(p + 0x4690) = (unsigned short)(cc * 8);
                     while (v >= 5) { v -= 5; q++; }
-                    ((unsigned char *)(int)(((long long)(int)(base + i * 64)) & 0xFFFFFFFFFFFFFFFFLL))[0x469c] = (unsigned char)(q * 10 + v);
+                    ((unsigned char *)(int)(((long long)(int)(base + i * 64))))[0x469c] = (unsigned char)(q * 10 + v);
                     ca++;
                     cc++;
                 } else {
                     int v;
                     int q;
-                    unsigned char *d = (unsigned char *)(int)(((long long)(int)(p + 0x469c)) & 0xFFFFFFFFFFFFFFFFLL);
+                    unsigned char *d = (unsigned char *)(int)(((long long)(int)(p + 0x469c)));
                     *d = (unsigned char)cb;
                     p[0x469b] = 3;
                     v = cb;

--- a/src/func_ov006_020d795c.c
+++ b/src/func_ov006_020d795c.c
@@ -14,12 +14,12 @@ void func_ov006_020d795c(char *o, int i)
     int b, v;
     {
         s16 tv = data_02082214[((*(u16 *)(o + i * 0x40 + 0x468c)) >> 4) * 2 + 1];
-        *(int *)((char *)(((int)o + 0x4660) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) +=
+        *(int *)((char *)(((int)o + 0x4660)) + i * 0x40) +=
             (int)(((s64)tv * *(int *)(o + i * 0x40 + 0x4670) + 0x800) >> 12);
     }
     {
         s16 tv = data_02082214[((*(u16 *)(o + i * 0x40 + 0x468c)) >> 4) * 2];
-        *(int *)((char *)(((int)o + 0x4664) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) +=
+        *(int *)((char *)(((int)o + 0x4664)) + i * 0x40) +=
             (int)(((s64)tv * *(int *)(o + i * 0x40 + 0x4670) + 0x800) >> 12);
     }
     b = *(u8 *)(o + i * 0x40 + 0x4696);


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 92 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
