### PR TITLE
readable: strip 103 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov006_020d7a84.c
+++ b/src/func_ov006_020d7a84.c
@@ -26,7 +26,7 @@ void func_ov006_020d7a84(char *c, int i)
         s16 tv = data_02082214[
             ((*(u16 *)(c + i * 0x40 + 0x468c) >> 4) * 2) + 1];
 
-        *(int *)((char *)(((int)c + 0x4660) & 0xFFFFFFFFFFFFFFFF) +
+        *(int *)((char *)(((int)c + 0x4660)) +
                   i * 0x40) +=
             (int)(((s64)tv *
                    *(int *)(c + i * 0x40 + 0x4670) + 0x800) >> 12);
@@ -36,7 +36,7 @@ void func_ov006_020d7a84(char *c, int i)
         s16 tv = data_02082214[
             (*(u16 *)(c + i * 0x40 + 0x468c) >> 4) * 2];
 
-        *(int *)((char *)(((int)c + 0x4664) & 0xFFFFFFFFFFFFFFFF) +
+        *(int *)((char *)(((int)c + 0x4664)) +
                   i * 0x40) +=
             (int)(((s64)tv *
                    *(int *)(c + i * 0x40 + 0x4670) + 0x800) >> 12);

--- a/src/func_ov006_020d89c4.c
+++ b/src/func_ov006_020d89c4.c
@@ -15,7 +15,7 @@ void func_ov006_020d89c4(char* self)
     func_ov006_020d836c(self);
 
     if (*(u16*)(self + 0x62e8) != 0) {
-        (*(u16*)(((long long)(int)(self + 0x62e8)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16*)(((long long)(int)(self + 0x62e8))))--;
         if (*(s16*)(self + 0x62e8) < 0)
             *(u16*)(self + 0x62e8) = 0;
         return;
@@ -23,7 +23,7 @@ void func_ov006_020d89c4(char* self)
 
     for (j = 0; j < 0x70; j++) {
         u8 *row = (u8*)self + j*0x40;
-        u8 *q = (u8*)(((long long)(int)(row + 0x4698)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8 *q = (u8*)(((long long)(int)(row + 0x4698)));
         if (*q == 2) {
             if (((u8 (*)[0x40])(self + 0x4000))[j][0x697] == 6
              && ((u8 (*)[0x40])(self + 0x4000))[j][0x69b] == 4) {

--- a/src/func_ov006_020d8af8.c
+++ b/src/func_ov006_020d8af8.c
@@ -15,7 +15,7 @@ void func_ov006_020d8af8(char* self)
     func_ov006_020d836c(self);
 
     if (*(u16*)(self + 0x62e8) != 0) {
-        (*(u16*)(((long long)(int)(self + 0x62e8)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16*)(((long long)(int)(self + 0x62e8))))--;
         if (*(s16*)(self + 0x62e8) > 0)
             return;
         *(u16*)(self + 0x62e8) = 0;
@@ -28,7 +28,7 @@ void func_ov006_020d8af8(char* self)
     }
 
     if (*(u16*)(self + 0x62e0) != 0) {
-        (*(u16*)(((long long)(int)(self + 0x62e0)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16*)(((long long)(int)(self + 0x62e0))))--;
         return;
     }
 
@@ -40,14 +40,14 @@ void func_ov006_020d8af8(char* self)
         j++;
     } while (j < 0x70);
 
-    (*(u16*)(((long long)(int)(self + 0x62ea)) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(u16*)(((long long)(int)(self + 0x62ea))))++;
     if (*(u16*)(self + 0x62ea) < 4)
         return;
 
     if (found != 0) {
         arr[found - 1][0x4698] = 2;
         *(u16*)(self + 0x62ea) = 0;
-        (*(u16*)(((long long)(int)(self + 0x62ee)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u16*)(((long long)(int)(self + 0x62ee))))++;
         _ZN5Sound12PlayBank2_2DEj(0x1bc);
     } else {
         *(u16*)(self + 0x62ea) = 0;

--- a/src/func_ov006_020d8d84.c
+++ b/src/func_ov006_020d8d84.c
@@ -17,7 +17,7 @@ void func_ov006_020d8d84(char *self)
     func_ov006_020d836c(self);
 
     if (*(u16 *)(self + 0x62e8) != 0) {
-        (*(u16 *)(((long long)(int)(self + 0x62e8)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16 *)(((long long)(int)(self + 0x62e8))))--;
         if (*(s16 *)(self + 0x62e8) < 0)
             *(s16 *)(self + 0x62e8) = 0;
         return;

--- a/src/func_ov006_020d8f34.c
+++ b/src/func_ov006_020d8f34.c
@@ -8,7 +8,7 @@ void func_ov006_020d8f34(char *c)
 {
     if (*(u16 *)(c + 0x62e8) == 0)
         return;
-    *(u16 *)(((long long)(int)(c + 0x62e8)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(u16 *)(((long long)(int)(c + 0x62e8))) -= 1;
     if (*(s16 *)(c + 0x62e8) > 0)
         return;
     *(u16 *)(c + 0x62e8) = 0;

--- a/src/func_ov006_020d91b0.cpp
+++ b/src/func_ov006_020d91b0.cpp
@@ -12,7 +12,7 @@ void func_ov006_020d5b10(char *c);
 int dScMgBomroom_c_Behavior(char *c)
 {
     if (*(unsigned short *)(c + 0x6200 + 0xf0) != 0) {
-        unsigned short *t = (unsigned short *)(((int)c + 0x62f0) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *t = (unsigned short *)(((int)c + 0x62f0));
         *t = *t - 1;
         if (*(short *)(c + 0x6200 + 0xf0) <= 0)
             *(short *)(c + 0x6200 + 0xf0) = 0;

--- a/src/func_ov006_020da0ac.cpp
+++ b/src/func_ov006_020da0ac.cpp
@@ -33,7 +33,7 @@ extern "C" void func_ov006_020da0ac(C *c, Src *s)
     c->f4 = s->f0;
     c->f8 = s->f4;
     {
-        int *b = (int *)(((int)c + 4) & 0xFFFFFFFFFFFFFFFF);
+        int *b = (int *)(((int)c + 4));
         c->fc = b[0];
         c->f10 = b[1];
     }

--- a/src/func_ov006_020da420.c
+++ b/src/func_ov006_020da420.c
@@ -3,7 +3,7 @@ void func_ov006_020da420(char *c){
     int i;
     char *p;
     short arr[6];
-    short *a = (short *)(((int)arr) & 0xFFFFFFFFFFFFFFFF);
+    short *a = (short *)(((int)arr));
     a[0] = 0;
     a[1] = 0;
     a[2] = 0;

--- a/src/func_ov006_020da5e8.c
+++ b/src/func_ov006_020da5e8.c
@@ -2,8 +2,8 @@ int func_ov006_020da5e8(char *a, char *b);
 int func_ov006_020da5e8(char *a, char *b) {
     short arr1[6];
     short arr2[6];
-    short *p1 = (short *)(((int)arr1) & 0xFFFFFFFFFFFFFFFF);
-    short *p2 = (short *)(((int)arr2) & 0xFFFFFFFFFFFFFFFF);
+    short *p1 = (short *)(((int)arr1));
+    short *p2 = (short *)(((int)arr2));
     int max1, sec1;
     short max1i, sec1i;
     int max2, sec2;

--- a/src/func_ov006_020dabec.c
+++ b/src/func_ov006_020dabec.c
@@ -8,7 +8,7 @@ extern void func_ov006_020c19d0(void*);
 extern void func_ov004_020b65e4(void*);
 
 int dScMgCard_c_Behavior(char* c){
-  *(short*)(((int)c+0x5396) & 0xFFFFFFFFFFFFFFFF) += 1;
+  *(short*)(((int)c+0x5396)) += 1;
   func_ov006_020c19d0(c+0x4f38);
   func_ov004_020b65e4(func_ov006_020dac34(c));
   return 1;

--- a/src/func_ov006_020db720.c
+++ b/src/func_ov006_020db720.c
@@ -27,7 +27,7 @@ int dScMgCard_c_OnTurnIntoEgg(char* c)
         else if (r == 1)
             FreeGfxSlotsById(9);
         self->unk_538a = 0;
-        *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(s16*)(((int)c + 0x5388)) += 1;
         break;
     }
     case 0xf:
@@ -44,7 +44,7 @@ int dScMgCard_c_OnTurnIntoEgg(char* c)
                 func_ov004_020b5d74();
                 self->unk_538a = 0x1e;
             }
-            *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(s16*)(((int)c + 0x5388)) += 1;
         }
         break;
     case 0x10:
@@ -52,7 +52,7 @@ int dScMgCard_c_OnTurnIntoEgg(char* c)
             int r = func_ov006_020da5e8(c + 0x51a8, c + 0x5298);
             func_ov006_020da4ac(c + 0x51a8, 0);
             if (r == -1) {
-                *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(s16*)(((int)c + 0x5388)) += 1;
             } else {
                 return 1;
             }
@@ -77,7 +77,7 @@ int dScMgCard_c_OnTurnIntoEgg(char* c)
             b += 0x30;
         }
         self->unk_538a = 0x3c;
-        *(s16*)(((int)c + 0x5388) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(s16*)(((int)c + 0x5388)) += 1;
         break;
     }
     case 0x12:

--- a/src/func_ov006_020dc5c4.c
+++ b/src/func_ov006_020dc5c4.c
@@ -22,7 +22,7 @@ void func_ov006_020dc5c4(char *c, int i)
         *(u16 *)(c + 0x519c + off) = 0xb4;
         *(u8 *)(c + 0x51a1 + off) = 2;
         {
-            int *p = (int *)(((int)c + 0x51c8) & 0xFFFFFFFFFFFFFFFF);
+            int *p = (int *)(((int)c + 0x51c8));
             *st = 0;
             *counter = 0;
             *p = *p + 1;

--- a/src/func_ov006_020dc900.c
+++ b/src/func_ov006_020dc900.c
@@ -6,10 +6,10 @@ void func_ov006_020dc900(char *c)
 {
     int i;
     for (i = 0; i < 0x18; i++) {
-        char *p = c + (int)(((long long)i) & 0xFFFFFFFFFFFFFFFFLL) * 0x10;
+        char *p = c + (int)(((long long)i)) * 0x10;
         if (*(u8 *)(p + 0x5020) != 0 && *(u16 *)(p + 0x501c) != 0) {
-            *(u16 *)((int)(((long long)(int)(p + 0x501c)) & 0xFFFFFFFFFFFFFFFFLL)) -= 1;
-            if (*(s16 *)((int)(((long long)(int)(p + 0x501c)) & 0xFFFFFFFFFFFFFFFFLL)) <= 0)
+            *(u16 *)((int)(((long long)(int)(p + 0x501c)))) -= 1;
+            if (*(s16 *)((int)(((long long)(int)(p + 0x501c)))) <= 0)
                 *(u8 *)(p + 0x5021) = 1;
         }
     }

--- a/src/func_ov006_020dca04.c
+++ b/src/func_ov006_020dca04.c
@@ -11,19 +11,19 @@ void func_ov006_020dca04(char *o)
     for (i = 0; i < 0x20; i++, q += 0x18) {
         if (*(u8 *)(q + 0x4d28) != 0) {
             if (*(u16 *)(q + 0x4d24) != 0) {
-                *(u16 *)(((int)q + 0x4d24) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                *(u16 *)(((int)q + 0x4d24)) -= 1;
             } else {
                 *(u8 *)(o + i * 0x18 + 0x4d28) = 0;
                 *(u8 *)(o + i * 0x18 + 0x4d29) = 0;
                 return;
             }
-            *(int *)(((int)q + 0x4d14) & 0xFFFFFFFFFFFFFFFF) += *(int *)(q + 0x4d1c);
-            *(int *)(((int)q + 0x4d18) & 0xFFFFFFFFFFFFFFFF) += *(int *)(q + 0x4d20);
-            *(int *)(((int)q + 0x4d20) & 0xFFFFFFFFFFFFFFFF) += 0x180;
+            *(int *)(((int)q + 0x4d14)) += *(int *)(q + 0x4d1c);
+            *(int *)(((int)q + 0x4d18)) += *(int *)(q + 0x4d20);
+            *(int *)(((int)q + 0x4d20)) += 0x180;
             if (*(int *)(q + 0x4d1c) > 0x300)
-                *(int *)(((int)q + 0x4d1c) & 0xFFFFFFFFFFFFFFFF) -= 0x180;
+                *(int *)(((int)q + 0x4d1c)) -= 0x180;
             else if (*(int *)(q + 0x4d1c) < -0x300)
-                *(int *)(((int)q + 0x4d1c) & 0xFFFFFFFFFFFFFFFF) += 0x180;
+                *(int *)(((int)q + 0x4d1c)) += 0x180;
         }
     }
 }

--- a/src/func_ov006_020dcb1c.c
+++ b/src/func_ov006_020dcb1c.c
@@ -14,8 +14,8 @@ void func_ov006_020dcb1c(char *o, int a1)
 {
     int i, j, k;
     char *b = o + a1 * 0x18;
-    int *px = (int *)(((int)b + 0x4ac0) & 0xFFFFFFFFFFFFFFFF);
-    int *pz = (int *)(((int)b + 0x4ac4) & 0xFFFFFFFFFFFFFFFF);
+    int *px = (int *)(((int)b + 0x4ac0));
+    int *pz = (int *)(((int)b + 0x4ac4));
     for (i = 0, j = 0, k = 1; i < 4; i++, o += 0x18, j += 2, k += 2) {
         if (*(u8 *)(o + 0x4d28) == 0) {
             *(u8 *)(o + 0x4d28) = 1;

--- a/src/func_ov006_020dce3c.c
+++ b/src/func_ov006_020dce3c.c
@@ -5,14 +5,14 @@ void func_ov006_020dce3c(char* c)
     if (*(unsigned short*)(c + 0x4d08) == *(unsigned short*)(c + 0x4d0a))
         return;
     {
-        unsigned short* e = (unsigned short*)(((long long)(int)(c + 0x4d0c)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short* e = (unsigned short*)(((long long)(int)(c + 0x4d0c)));
         *e = *e + 1;
     }
     if (*(unsigned short*)(c + 0x4d0c) < 8)
         return;
     *(unsigned short*)(c + 0x4d0c) = 0;
     {
-        unsigned short* p = (unsigned short*)(((long long)(int)(c + 0x4d0a)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short* p = (unsigned short*)(((long long)(int)(c + 0x4d0a)));
         *p = *p + 1;
     }
 }

--- a/src/func_ov006_020dd658.c
+++ b/src/func_ov006_020dd658.c
@@ -38,7 +38,7 @@ void func_ov006_020dd658(char *self, int i) {
         *(u8 *)(self + 0x4675 + n) = 4;
         *(u8 *)(self + 0x4676 + n) = 0;
         *(u8 *)(self + 0x4677 + n) = 0;
-        (*(u16 *)(((long long)(int)(self + 0x4d08)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u16 *)(((long long)(int)(self + 0x4d08))))++;
 
         {
             int v1 = *(s32 *)(self + 0x4664 + n);

--- a/src/func_ov006_020dd880.c
+++ b/src/func_ov006_020dd880.c
@@ -8,7 +8,7 @@ extern int data_ov006_0212e3d0[];
 extern int data_ov006_0212e3e8[];
 extern int data_0209d4b8;
 
-#define LB(a) (*(unsigned char*)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LB(a) (*(unsigned char*)(((long long)(int)(a))))
 
 struct Obj {
     virtual int v00(); virtual int v01(); virtual int v02(); virtual int v03();

--- a/src/func_ov006_020de0e0.cpp
+++ b/src/func_ov006_020de0e0.cpp
@@ -10,7 +10,7 @@ extern unsigned char data_020a0de9[];
 extern "C" void func_ov006_020de0e0(char* self)
 {
   if (*(int*)(self+0x5000+0x1cc) == 0) return;
-  *(int*)(((int)self + 0x51cc) & 0xFFFFFFFFFFFFFFFF) -= 1;
+  *(int*)(((int)self + 0x51cc)) -= 1;
   unsigned int idx = data_020a0e40[0];
   int flag = 0;
   if (data_020a0de8[idx*4] != 0) {

--- a/src/func_ov006_020de1d4.c
+++ b/src/func_ov006_020de1d4.c
@@ -3,7 +3,7 @@ extern void func_ov006_020dc370(void*);
 
 void func_ov006_020de1d4(char* c) {
   if (*(int*)((c + 0x5000) + 0x1cc) != 0) {
-    int* p = (int*)(int)(((long long)(int)(c + 0x51cc)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* p = (int*)(int)(((long long)(int)(c + 0x51cc)));
     *p = *p - 1;
     if (*(int*)((c + 0x5000) + 0x1cc) < 0)
       *(int*)((c + 0x5000) + 0x1cc) = 0;

--- a/src/func_ov006_020de26c.cpp
+++ b/src/func_ov006_020de26c.cpp
@@ -43,7 +43,7 @@ extern "C" void func_ov006_020de26c(char *self) {
     if (count != 0) return;
 
     if (((int *)(self + 0x5000))[0x73] != 0) {
-        *(int *)(((long long)(int)(self + 0x51cc)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(int *)(((long long)(int)(self + 0x51cc))) -= 1;
         if (((int *)(self + 0x5000))[0x73] == 0x20 && ((unsigned char *)(self + 0x5000))[0x1df] == 0)
             func_ov006_020dc348(self);
         if (((int *)(self + 0x5000))[0x73] == 0x20 && ((unsigned char *)(self + 0x5000))[0x1df] != 0) {

--- a/src/func_ov006_020de5b0.c
+++ b/src/func_ov006_020de5b0.c
@@ -12,7 +12,7 @@ void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c);
 void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c){
     struct dScMgCoin_c *self = (struct dScMgCoin_c *)(void *)c;
     if (self->unk_51db != 0) {
-        *(unsigned char*)(((int)c + 0x51da) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char*)(((int)c + 0x51da)) += 1;
     } else {
         self->unk_51da = 0;
     }

--- a/src/func_ov006_020dec5c.c
+++ b/src/func_ov006_020dec5c.c
@@ -3,5 +3,5 @@ void func_ov006_020dec5c(char* self, int a, int b)
     if (*(unsigned char*)(self + 0x16) != 1)
         return;
     *(int*)self += a;
-    *(int*)(((int)self + 4) & 0xFFFFFFFFFFFFFFFFLL) += b;
+    *(int*)(((int)self + 4)) += b;
 }

--- a/src/func_ov006_020ded00.c
+++ b/src/func_ov006_020ded00.c
@@ -9,7 +9,7 @@ void func_ov006_020ded00(int this)
   {
     *((int *) (this + 4)) -= 6;
   }
-  if (DecIfAbove0_Byte((unsigned char *) ((this + 0x14) & 0xFFFFFFFFFFFFFFFF)))
+  if (DecIfAbove0_Byte((unsigned char *) ((this + 0x14))))
   {
     return;
   }

--- a/src/func_ov006_020deed8.c
+++ b/src/func_ov006_020deed8.c
@@ -23,7 +23,7 @@ void func_ov006_020deed8(int a0, void *a1, int a2, int a3, int s, int a5)
         if (r != 0) {
             if (a5_local == 2) {
                 if ((unsigned)(*(int *)(sl + 4) << 0x10) >> 0x1c == 3) {
-                    int *p = (int *)(((int)r + 4) & 0xFFFFFFFFFFFFFFFF);
+                    int *p = (int *)(((int)r + 4));
                     *p = (*p & ~0xf000) | 0x4000;
                 }
             }

--- a/src/func_ov006_020df1c0.cpp
+++ b/src/func_ov006_020df1c0.cpp
@@ -26,10 +26,10 @@ struct Obj {
 
 extern "C" void func_ov006_020df1c0(char* c)
 {
-    *(int*)(((int)c + 0x541c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(int*)(((int)c + 0x541c)) -= 1;
     if (*(int*)(c + 0x5000 + 0x41c) > 0) return;
     if (*(unsigned char*)(c + 0x5000 + 0x469) != 0) {
-        if (*(int*)(c + 0xb4) < 0x270f) *(int*)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+        if (*(int*)(c + 0xb4) < 0x270f) *(int*)(((int)c + 0xb4)) += 1;
         if (*(int*)(c + 0xb4) > *(int*)(c + 0xb8)) *(int*)(c + 0xb8) = *(int*)(c + 0xb4);
         func_ov004_020b0a54(0);
         *(int*)(c + 0x5000 + 0x418) = 7;

--- a/src/func_ov006_020df28c.c
+++ b/src/func_ov006_020df28c.c
@@ -13,11 +13,11 @@
     {
         int r4;
         int i;
-        int *pc = (int *)(((int)self + 0x541c) & 0xFFFFFFFFFFFFFFFFLL);
+        int *pc = (int *)(((int)self + 0x541c));
         *pc = *pc - 1;
         if (*(int *)(self + 0x5000 + 0x41c) > 0) return;
         for (i = 0; i < 3; i++) {
-            u8 *q = (u8 *)(((int)self + i + 0x5465) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(((int)self + i + 0x5465));
             if (*q == 0) {
                 *q = 1;
                 func_ov006_020def80(self, i);

--- a/src/func_ov006_020df540.c
+++ b/src/func_ov006_020df540.c
@@ -2,7 +2,7 @@ extern void func_ov004_020b0cac(int a, int b, int c, int d, int e, int f);
 
 void func_ov006_020df540(char *c)
 {
-    *(int *)(((long long)(int)(c + 0x541c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(c + 0x541c))) -= 1;
     if (*(int *)(c + 0x541c) > 0)
         return;
     func_ov004_020b0cac(0xf, 0x80, 0x38, 0, -1, 0xd);

--- a/src/func_ov006_020df5b8.c
+++ b/src/func_ov006_020df5b8.c
@@ -28,7 +28,7 @@ void func_ov006_020df5b8(char *c)
         *(int*)(c + 0x5458) = func_02012468(*(int*)(c + 0x5458), 2, 0x1cb, 2, 0, amp, 0, 0);
     }
 
-    *(u16*)(((long long)(int)(c + 0x545c)) & 0xFFFFFFFFFFFFFFFFLL) += *(s16*)(c + 0x545e);
+    *(u16*)(((long long)(int)(c + 0x545c))) += *(s16*)(c + 0x545e);
 
     {
         s16 vv = *(s16*)(c + 0x545e);
@@ -93,7 +93,7 @@ void func_ov006_020df5b8(char *c)
             int ta = *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420);
             *(int*)(c + *(int*)(c + 0x542c) * 4 + 0x5420) = tb;
             *(int*)(c + *(int*)(c + 0x5430) * 4 + 0x5420) = ta;
-            *(u8*)(((long long)(int)(c + 0x5460)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+            *(u8*)(((long long)(int)(c + 0x5460))) -= 1;
             if (*(u8*)(c + 0x5460) == 0) {
                 *(int*)(c + 0x541c) = 0x1e;
                 *(int*)(c + 0x5418) = 3;
@@ -176,5 +176,5 @@ void func_ov006_020df5b8(char *c)
         }
     }
 
-    *(int*)(((long long)(int)(c + 0x541c)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int*)(((long long)(int)(c + 0x541c))) += 1;
 }

--- a/src/func_ov006_020dfcd8.c
+++ b/src/func_ov006_020dfcd8.c
@@ -2,12 +2,12 @@ extern void func_ov006_020df024(char *o);
 
 void func_ov006_020dfcd8(char *o)
 {
-    int *p = (int *)(((int)o + 0x541c) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int *)(((int)o + 0x541c));
     *p = *p - 1;
     if (*(int *)(o + 0x5000 + 0x41c) > 0) return;
     func_ov006_020df024(o);
     if (*(unsigned char *)(o + 0x5000 + 0x46b) != 0) {
-        unsigned char *q = (unsigned char *)(((int)o + 0x546b) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char *q = (unsigned char *)(((int)o + 0x546b));
         *q = *q - 1;
     }
     *(int *)(o + 0x5000 + 0x418) = 2;

--- a/src/func_ov006_020dfd48.c
+++ b/src/func_ov006_020dfd48.c
@@ -14,7 +14,7 @@ void func_ov006_020dfd48(char *c)
     unsigned int r1;
     unsigned int r2;
 
-    (*(int *)(((int)c + 0x541c) & 0xFFFFFFFFFFFFFFFF))--;
+    (*(int *)(((int)c + 0x541c)))--;
     if (*(int *)(c + 0x541c) > 0) {
         return;
     }

--- a/src/func_ov006_020e0204.cpp
+++ b/src/func_ov006_020e0204.cpp
@@ -24,15 +24,15 @@ extern "C" int dScMgCup_c_Behavior(char *o)
     int i;
     (((C *)o)->*data_ov006_02141870[*(int *)(o + 0x5418)])();
     for (i = 0; i < 3; i++) {
-        Frame *f = &data_ov006_0213c0d8[*(int *)(((int)o + i * 4 + 0x5434) & 0xFFFFFFFFFFFFFFFF)][*(int *)(o + i * 4 + 0x5440)];
+        Frame *f = &data_ov006_0213c0d8[*(int *)(((int)o + i * 4 + 0x5434))][*(int *)(o + i * 4 + 0x5440)];
         int n = f->b;
         if (n != 0) {
-            *(int *)(((int)o + i * 4 + 0x544c) & 0xFFFFFFFFFFFFFFFF) += 1;
-            if (*(int *)(((int)o + i * 4 + 0x544c) & 0xFFFFFFFFFFFFFFFF) >= n) {
-                *(int *)(((int)o + i * 4 + 0x544c) & 0xFFFFFFFFFFFFFFFF) = 0;
-                *(int *)(((int)o + i * 4 + 0x5440) & 0xFFFFFFFFFFFFFFFF) += 1;
-                func_ov006_020dedfc(o, *(int *)(((int)o + i * 4 + 0x5434) & 0xFFFFFFFFFFFFFFFF),
-                                    *(int *)(((int)o + i * 4 + 0x5440) & 0xFFFFFFFFFFFFFFFF), i);
+            *(int *)(((int)o + i * 4 + 0x544c)) += 1;
+            if (*(int *)(((int)o + i * 4 + 0x544c)) >= n) {
+                *(int *)(((int)o + i * 4 + 0x544c)) = 0;
+                *(int *)(((int)o + i * 4 + 0x5440)) += 1;
+                func_ov006_020dedfc(o, *(int *)(((int)o + i * 4 + 0x5434)),
+                                    *(int *)(((int)o + i * 4 + 0x5440)), i);
             }
         }
     }

--- a/src/func_ov006_020e1680.c
+++ b/src/func_ov006_020e1680.c
@@ -7,7 +7,7 @@ typedef unsigned long long u64;
 extern int _ZN4cstd4sqrtEy(u64);
 extern u8 data_ov006_0212e458[];
 
-#define M(p) ((int *)(int)((long long)(int)(p) & 0xffffffffffffffffLL))
+#define M(p) ((int *)(int)((long long)(int)(p)))
 
 void func_ov006_020e1680(char *o)
 {

--- a/src/func_ov006_020e2868.c
+++ b/src/func_ov006_020e2868.c
@@ -47,7 +47,7 @@ void func_ov006_020e2868(char *c, int idx)
     *p660 += (int)(((long long)sn * *p668 + 0x800) >> 12);
     cs = data_02082214[((*pang) >> 4) * 2];
     *p664 += (int)(((long long)cs * *p668 + 0x800) >> 12);
-    *(u16 *)(c + 0x4684 + m) += *(u16 *)((int)(((int)c + m) & 0xFFFFFFFFFFFFFFFF) + 0x4682);
+    *(u16 *)(c + 0x4684 + m) += *(u16 *)((int)(((int)c + m)) + 0x4682);
 
     x = *p660;
     z = *p664;
@@ -107,7 +107,7 @@ void func_ov006_020e2868(char *c, int idx)
     pd = (int *)(c + 0x4668 + m);
     if (*(int *)(c + 0x4668 + m) <= 0) {
         *p668 = 0;
-        *(u8 *)((int)(((long long)(int)(c + m)) & 0xFFFFFFFFFFFFFFFFLL) + 0x4688) = 2;
+        *(u8 *)((int)(((long long)(int)(c + m))) + 0x4688) = 2;
     }
 
     func_ov006_020e20bc(c, idx);

--- a/src/func_ov006_020e2dbc.c
+++ b/src/func_ov006_020e2dbc.c
@@ -5,7 +5,7 @@ void func_ov006_020e2dbc(char *c)
     if (*(unsigned char*)(c + 0x4ee7) == 0) return;
     if (*(unsigned short*)(c + 0x4ee0) != 0)
     {
-        *(unsigned short *)(((int)c + 0x4ee0) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(unsigned short *)(((int)c + 0x4ee0)) -= 1;
         if ((short)*(unsigned short*)(c + 0x4ee0) <= 0)
             *(unsigned short*)(c + 0x4ee0) = 0;
         return;
@@ -27,7 +27,7 @@ void func_ov006_020e2dbc(char *c)
     }
     if (*(unsigned char*)(c + 0x4ee6) != 0)
         _ZN5Sound12PlayBank2_2DEj(0x1d7);
-    (*(unsigned char *)(((int)c + 0x4ee6) & 0xFFFFFFFFFFFFFFFF))++;
+    (*(unsigned char *)(((int)c + 0x4ee6)))++;
     *(int*)(c + 0x4eb0) = 0x80000;
     *(int*)(c + 0x4eb4) = 0xb0000;
     *(unsigned char*)(c + 0x4ee4) = 0;

--- a/src/func_ov006_020e2ebc.c
+++ b/src/func_ov006_020e2ebc.c
@@ -6,7 +6,7 @@ void func_ov006_020e2ebc(char *thiz)
     int i;
     char *p;
     if (*(unsigned short*)(thiz + 0x4ee2) != 0) {
-        *(unsigned short*)(((int)thiz + 0x4ee2) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(unsigned short*)(((int)thiz + 0x4ee2)) -= 1;
         if (*(short*)(thiz + 0x4ee2) <= 0)
             *(unsigned short*)(thiz + 0x4ee2) = 0;
         return;

--- a/src/func_ov006_020e2f78.c
+++ b/src/func_ov006_020e2f78.c
@@ -37,7 +37,7 @@ void func_ov006_020e2f78(char *c)
 
     if (t->f != 0)
     {
-        *(unsigned short *)(((int)c + 0x4ee2) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(unsigned short *)(((int)c + 0x4ee2)) -= 1;
         if ((short)t->f <= 0)
             t->f = 0;
         return;

--- a/src/func_ov006_020e3078.cpp
+++ b/src/func_ov006_020e3078.cpp
@@ -18,7 +18,7 @@ void func_ov006_020e1680(char* c);
 extern "C" void func_ov006_020e3078(char* c)
 {
     if (*(u16*)(c + 0x4ee2) != 0) {
-        u16* q = (u16*)((long long)(int)(c + 0x4ee2) & 0xFFFFFFFFFFFFFFFFLL);
+        u16* q = (u16*)((long long)(int)(c + 0x4ee2));
         *q = *q - 1;
         return;
     }
@@ -28,7 +28,7 @@ extern "C" void func_ov006_020e3078(char* c)
         *(u16*)(c + 0xc0) = 0;
     }
     if (*(u8*)(c + 0x4ee9) != 0) {
-        u8* q = (u8*)((long long)(int)(c + 0x4ee9) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* q = (u8*)((long long)(int)(c + 0x4ee9));
         *q = *q - 1;
     }
     (((C*)c)->*data_ov006_021418b0[*(u8*)(c + 0x4ee4)])();
@@ -42,7 +42,7 @@ extern "C" void func_ov006_020e3078(char* c)
                 *(int*)(p + 0x466c) = *(int*)(p + 0x4660);
                 *(int*)(p + 0x4670) = *(int*)(p + 0x4664);
                 if (*(u16*)(p + 0x4680) != 0) {
-                    u16* q = (u16*)((long long)(int)(p + 0x4680) & 0xFFFFFFFFFFFFFFFFLL);
+                    u16* q = (u16*)((long long)(int)(p + 0x4680));
                     *q = *q - 1;
                 }
                 (((C*)c)->*data_ov006_02141910[*(u8*)(p + 0x4688)])(i);

--- a/src/func_ov006_020e3948.c
+++ b/src/func_ov006_020e3948.c
@@ -7,9 +7,9 @@ void func_ov006_020e3948(char *p)
         {
             if (*(unsigned short *)(p + 0x4ff0) != 0)
             {
-                *(unsigned short *)(int)(((long long)(int)(p + 0x4ff0)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
-                *(int *)(int)(((long long)(int)(p + 0x4fe4)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(p + 0x4fec);
-                *(int *)(int)(((long long)(int)(p + 0x4fec)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x40;
+                *(unsigned short *)(int)(((long long)(int)(p + 0x4ff0))) -= 1;
+                *(int *)(int)(((long long)(int)(p + 0x4fe4))) += *(int *)(p + 0x4fec);
+                *(int *)(int)(((long long)(int)(p + 0x4fec))) -= 0x40;
             }
             else
             {

--- a/src/func_ov006_020e4b00.c
+++ b/src/func_ov006_020e4b00.c
@@ -8,7 +8,7 @@ void func_ov006_020e4b00(char *this) {
         volatile unsigned short *t;
         if (*(unsigned char*)(base + 0x487c) == 0) continue;
         if (*(unsigned short*)(base + 0x487a) == 0) continue;
-        t = (volatile unsigned short*)(((int)base + 0x487a) & 0xFFFFFFFFFFFFFFFF);
+        t = (volatile unsigned short*)(((int)base + 0x487a));
         *t = *t - 1;
         if (*t != 0) continue;
         *(unsigned char*)(base + 0x487d) = 1;

--- a/src/func_ov006_020e5b7c.c
+++ b/src/func_ov006_020e5b7c.c
@@ -39,7 +39,7 @@ void func_ov006_020e5b7c(char *c, int idx)
     *p660 += (int)(((long long)sn * *p668 + 0x800) >> 12);
     cs = data_02082214[((*pang) >> 4) * 2];
     *p664 += (int)(((long long)cs * *p668 + 0x800) >> 12);
-    *(u16 *)(c + 0x4684 + m) += *(u16 *)((int)(((int)c + m) & 0xFFFFFFFFFFFFFFFF) + 0x4682);
+    *(u16 *)(c + 0x4684 + m) += *(u16 *)((int)(((int)c + m)) + 0x4682);
 
     x = *p660;
     z = *p664;
@@ -75,7 +75,7 @@ void func_ov006_020e5b7c(char *c, int idx)
     pd = (int *)(c + 0x4668 + m);
     if (*(int *)(c + 0x4668 + m) <= 0) {
         *p668 = 0;
-        *(u8 *)((int)(((long long)(int)(c + m)) & 0xFFFFFFFFFFFFFFFFLL) + 0x4688) = 2;
+        *(u8 *)((int)(((long long)(int)(c + m))) + 0x4688) = 2;
     }
 
     func_ov006_020e5450(c, idx);

--- a/src/func_ov006_020e61c4.c
+++ b/src/func_ov006_020e61c4.c
@@ -5,7 +5,7 @@ void func_ov006_020e61c4(char *thiz)
     int i;
     char *p;
     if (*(unsigned short*)(thiz + 0x55B6) != 0) {
-        --*(volatile unsigned short*)(((int)thiz + 0x55B6) & 0xFFFFFFFFFFFFFFFF);
+        --*(volatile unsigned short*)(((int)thiz + 0x55B6));
         if (*(short*)(thiz + 0x55B6) <= 0)
             *(short*)(thiz + 0x55B6) = 0;
         return;

--- a/src/func_ov006_020e628c.c
+++ b/src/func_ov006_020e628c.c
@@ -28,7 +28,7 @@ void func_ov006_020e628c(char *c){
   int i;
   func_ov006_020e4b00(c);
   if (t->f != 0){
-    *(unsigned short *)(((int)c + 0x55b6) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(unsigned short *)(((int)c + 0x55b6)) -= 1;
     if ((short)t->f <= 0) t->f = 0;
     return;
   }

--- a/src/func_ov006_020e6354.cpp
+++ b/src/func_ov006_020e6354.cpp
@@ -14,7 +14,7 @@ extern PMF1 data_ov006_021419d8[];
 extern "C" void func_ov006_020e6354(char* c)
 {
     if (*(u16*)(c + 0x55b6) != 0) {
-        u16* q = (u16*)((long long)(int)(c + 0x55b6) & 0xFFFFFFFFFFFFFFFFLL);
+        u16* q = (u16*)((long long)(int)(c + 0x55b6));
         *q = *q - 1;
         return;
     }
@@ -24,7 +24,7 @@ extern "C" void func_ov006_020e6354(char* c)
         *(u16*)(c + 0xc0) = 0;
     }
     if (*(u8*)(c + 0x55bd) != 0) {
-        u8* q = (u8*)((long long)(int)(c + 0x55bd) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* q = (u8*)((long long)(int)(c + 0x55bd));
         *q = *q - 1;
     }
     (((C*)c)->*data_ov006_02141978[*(u8*)(c + 0x55b8)])();
@@ -38,7 +38,7 @@ extern "C" void func_ov006_020e6354(char* c)
                 *(int*)(p + 0x466c) = *(int*)(p + 0x4660);
                 *(int*)(p + 0x4670) = *(int*)(p + 0x4664);
                 if (*(u16*)(p + 0x4680) != 0) {
-                    u16* q = (u16*)((long long)(int)(p + 0x4680) & 0xFFFFFFFFFFFFFFFFLL);
+                    u16* q = (u16*)((long long)(int)(p + 0x4680));
                     *q = *q - 1;
                 }
                 (((C*)c)->*data_ov006_021419d8[*(u8*)(p + 0x4688)])(i);

--- a/src/func_ov006_020e7428.c
+++ b/src/func_ov006_020e7428.c
@@ -28,7 +28,7 @@ void func_ov006_020e7428(void)
     k = 0;
     for (i = 0; i < 0x80; i++) {
         data_ov006_02141a54[i].attr01 = 0;
-        *(u32 *)&data_ov006_02141a54[(int)(((long long)i) & 0xFFFFFFFFFFFFFFFFLL)].attr2 = 0;
+        *(u32 *)&data_ov006_02141a54[(int)(((long long)i))].attr2 = 0;
     }
 
     y = 0;
@@ -38,7 +38,7 @@ void func_ov006_020e7428(void)
         tx = 0;
         for (; x < 0x100; x += 0x40) {
             data_ov006_02141a54[k].attr01 = ((y & 0xff) | 0xc0000c00) | ((x & 0x1ff) << 16);
-            data_ov006_02141a54[k].attr2 = (u16)(((int)(((long long)tx) & 0xFFFFFFFFFFFFFFFFLL) + ((int)(((long long)ty) & 0xFFFFFFFFFFFFFFFFLL) << 5)) | 0xf000);
+            data_ov006_02141a54[k].attr2 = (u16)(((int)(((long long)tx)) + ((int)(((long long)ty)) << 5)) | 0xf000);
             tx += 8;
             k++;
         }

--- a/src/func_ov006_020e7818.c
+++ b/src/func_ov006_020e7818.c
@@ -10,7 +10,7 @@ void func_ov006_020e7818(char* self)
             *(short*)(self + 0x17a) = *(short*)(self + 0x17c);
             sb = 1;
             if (*(short*)(self + 0x178) > 0) {
-                *(short*)(int)(((long long)(int)(self + 0x178)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(short*)(int)(((long long)(int)(self + 0x178))) -= 1;
             }
         }
     }

--- a/src/func_ov006_020e7b44.cpp
+++ b/src/func_ov006_020e7b44.cpp
@@ -24,7 +24,7 @@ extern int data_ov006_0213c744[];
 
 extern "C" void func_ov006_020e7b44(char* c)
 {
-    int* p = (int*)(((int)c + 0x210) & 0xFFFFFFFFFFFFFFFFLL);
+    int* p = (int*)(((int)c + 0x210));
     int* d = data_ov006_0213c744;
     if (p[0] == d[0]) {
         if (p[1] == d[1]) return;

--- a/src/func_ov006_020e7be8.cpp
+++ b/src/func_ov006_020e7be8.cpp
@@ -7,7 +7,7 @@ extern void func_ov006_020e7818(void*);
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int, unsigned int, int, int, int, const void*, void*);
 extern int data_ov006_0213c704[2];
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 void func_ov006_020e7be8(char* c)
 {

--- a/src/func_ov006_020e81e0.c
+++ b/src/func_ov006_020e81e0.c
@@ -5,5 +5,5 @@ void func_ov006_020e81e0(char *self)
 {
     if (*(unsigned char *)(self + 0x5553)) return;
     *(unsigned char *)(self + 0x51f2) = 0x1e;
-    *(unsigned char *)(((long long)(int)(self + 0x5553)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(unsigned char *)(((long long)(int)(self + 0x5553))) += 1;
 }

--- a/src/func_ov006_020e8214.c
+++ b/src/func_ov006_020e8214.c
@@ -5,7 +5,7 @@ void func_ov006_020e8214(char* c)
 {
     u8 state = *(u8*)(c + 0x5553);
     if (state == 0) {
-        u8* p = (u8*)(((long long)(int)(c + 0x5553)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* p = (u8*)(((long long)(int)(c + 0x5553)));
         *(u8*)(c + 0x51f2) = 0x1e;
         (*p)++;
         return;
@@ -13,13 +13,13 @@ void func_ov006_020e8214(char* c)
     if (state != 1)
         return;
     if (_ZNK9Animation12WillHitFrameEi(c + 0x5034, 0)) {
-        u8* p = (u8*)(((long long)(int)(c + 0x5554)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* p = (u8*)(((long long)(int)(c + 0x5554)));
         (*p)++;
     }
     if (*(u8*)(c + 0x5554) < 1)
         return;
     {
-        u8* p = (u8*)(((long long)(int)(c + 0x5553)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* p = (u8*)(((long long)(int)(c + 0x5553)));
         (*p)++;
     }
     *(u8*)(c + 0x51f2) = 0x1f;

--- a/src/func_ov006_020e82c8.c
+++ b/src/func_ov006_020e82c8.c
@@ -9,7 +9,7 @@ void func_ov006_020e82c8(unsigned char *c)
     if (r2[0x553] != 0) {
         return;
     }
-    p = (unsigned char *)(((long long)(int)(c + 0x5553)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (unsigned char *)(((long long)(int)(c + 0x5553)));
     *p = (unsigned char)(*p + 1);
     k = 0x1f;
     r2[0x1f2] = k;

--- a/src/func_ov006_020e8928.c
+++ b/src/func_ov006_020e8928.c
@@ -10,7 +10,7 @@ extern int data_0209d4b8;
 void func_ov006_020e8928(char *o, int idx)
 {
     if (*(u16 *)(o + idx * 0x20 + 0x52d2) != 0) {
-        *(u16 *)((char *)(((int)o + 0x52d2) & 0xFFFFFFFFFFFFFFFF) + idx * 0x20) -= 1;
+        *(u16 *)((char *)(((int)o + 0x52d2)) + idx * 0x20) -= 1;
         if (*(short *)(o + idx * 0x20 + 0x52d2) < 0)
             *(u16 *)(o + idx * 0x20 + 0x52d2) = 0;
     } else {

--- a/src/func_ov006_020e8bd0.c
+++ b/src/func_ov006_020e8bd0.c
@@ -9,7 +9,7 @@ extern "C" void func_ov006_020e8bd0(char *c, int i)
     int x = *(int *)(b + off);
     x = x - (x >> 7);
     *(int *)(b + off) = x;
-    *(unsigned char *)(((int)c + 0x554e) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned char *)(((int)c + 0x554e)) += 1;
     {
         unsigned char ip = *(unsigned char *)(c + 0x554e);
         _ZN3G2x13SetBlendAlphaEPVttttt(

--- a/src/func_ov006_020e8f14.c
+++ b/src/func_ov006_020e8f14.c
@@ -102,7 +102,7 @@ void func_ov006_020e8f14(char *self, int i)
     *(u16 *) (self + 0x5548) = 0x90;
     if (*(u8 *) (self + 0x5550) == 0)
     {
-        u16 *p548 = (u16 *) ((long long) (int) (self + 0x5548) & 0xFFFFFFFFFFFFFFFFLL);
+        u16 *p548 = (u16 *) ((long long) (int) (self + 0x5548));
         *p548 = *p548 + 0x40;
     }
 

--- a/src/func_ov006_020e91a0.c
+++ b/src/func_ov006_020e91a0.c
@@ -36,7 +36,7 @@ void func_ov006_020e91a0(char* self, int idx)
     if (w > 0x18) return;
 
     {
-        u8* pc = (u8*)((long long)(int)(self + 0x554f) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* pc = (u8*)((long long)(int)(self + 0x554f));
         *pc = *pc + 1;
     }
     *(s16*)(self + 0x5214 + n) = 0x20;

--- a/src/func_ov006_020e96f4.cpp
+++ b/src/func_ov006_020e96f4.cpp
@@ -6,10 +6,10 @@ extern "C" void func_ov006_020e9374(void *c);
 
 extern "C" void func_ov006_020e96f4(char *thiz)
 {
-    *(unsigned short*)(((int)thiz + 0x554a) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned short*)(((int)thiz + 0x554a)) += 1;
     if (*(unsigned short*)(thiz + 0x554a) >= 4) {
         *(unsigned short*)(thiz + 0x554a) = 0;
-        *(unsigned char*)(((int)thiz + 0x554e) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char*)(((int)thiz + 0x554e)) += 1;
         _ZN3G2x13SetBlendAlphaEPVttttt(
             (volatile unsigned short*)0x4001050, 0, 4,
             *(unsigned char*)(thiz + 0x554e), 0x10 - *(unsigned char*)(thiz + 0x554e));

--- a/src/func_ov006_020e97b0.c
+++ b/src/func_ov006_020e97b0.c
@@ -5,7 +5,7 @@ extern void FreeGfxSlotsById(int arg);
 void func_ov006_020e97b0(char *c)
 {
     if (*(unsigned short*)(c + 0x5548) != 0) {
-        unsigned short *d = (unsigned short*)((int)(c + 0x5548) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *d = (unsigned short*)((int)(c + 0x5548));
         *d = *d - 1;
         if (*(short*)(c + 0x5548) < 0)
             *(short*)(c + 0x5548) = 0;

--- a/src/func_ov006_020e989c.cpp
+++ b/src/func_ov006_020e989c.cpp
@@ -49,7 +49,7 @@ extern "C" void func_ov006_020e989c(C70 *cc)
 
     func_ov006_020e8d08(c);
     if (*(u16 *)(c + 0x5548) != 0) {
-        (*(u16 *)(int)(((long long)(int)(c + 0x5548)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16 *)(int)(((long long)(int)(c + 0x5548))))--;
         if (*(u16 *)(c + 0x5548) == 0x40) {
             if (*(u8 *)(c + 0x5550) != 0) {
                 int idx = func_020beb68 != 0 ? *(int *)(func_020beb68 + 0xb4) : 0;
@@ -58,7 +58,7 @@ extern "C" void func_ov006_020e989c(C70 *cc)
                 if (func_020beb68 != 0) {
                     char *g = func_020beb68;
                     if (*(int *)(g + 0xb4) < 9999)
-                        (*(int *)(int)(((long long)(int)(g + 0xb4)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                        (*(int *)(int)(((long long)(int)(g + 0xb4))))++;
                     if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                         *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
                 }
@@ -85,7 +85,7 @@ extern "C" void func_ov006_020e989c(C70 *cc)
                     func_ov004_020b67e8(0x15);
                 func_ov004_020b0a54(0);
             } else {
-                (*(int *)(int)(((long long)(int)(c + 0xbc)) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(int *)(int)(((long long)(int)(c + 0xbc))))++;
                 if (*(u32 *)(c + 0xbc) > 0x270e)
                     *(u32 *)(c + 0xbc) = 0x270e;
                 cc->v18(-1);
@@ -112,7 +112,7 @@ extern "C" void func_ov006_020e989c(C70 *cc)
         }
         if (b != 0)
             func_ov006_020e95a4(c);
-        (*(u16 *)(int)(((long long)(int)(c + 0x554c)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u16 *)(int)(((long long)(int)(c + 0x554c))))++;
         if (*(u16 *)(c + 0x554c) == 0xb4)
             func_ov006_020e95a4(c);
         if (*(u16 *)(c + 0x554c) >= 0xb5)

--- a/src/func_ov006_020e9bbc.c
+++ b/src/func_ov006_020e9bbc.c
@@ -2,7 +2,7 @@ void func_ov006_020e9bbc(char* c)
 {
     char* r2 = c + 0x5500;
     if (*(unsigned short*)(r2 + 0x48) != 0) {
-        unsigned short* p = (unsigned short*)(((long long)(int)(c + 0x5548)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short* p = (unsigned short*)(((long long)(int)(c + 0x5548)));
         *p = *p - 1;
         if (*(short*)(r2 + 0x48) < 0)
             *(unsigned short*)(r2 + 0x48) = 0;

--- a/src/func_ov006_020e9c20.c
+++ b/src/func_ov006_020e9c20.c
@@ -14,7 +14,7 @@ void dScMg3DEsp_c_OnYoshiTryEat_020e9c20(char* c, int a)
     func_ov006_020e984c(c);
     self->unk_553c = 0;
     if (a == 0) {
-        int* p = (int*)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0xbc));
         *p += 1;
         if (self->unk_0bc > 0x270e) self->unk_0bc = 0x270e;
     } else if (a == 0x12) {

--- a/src/func_ov006_020ea3d0.c
+++ b/src/func_ov006_020ea3d0.c
@@ -23,8 +23,8 @@ void func_ov006_020ea3d0(int *arg)
             *(int *)(f + 4) = 0x8000;
         ph = *(u8 *)(f + 0xe);
         if (ph == 0) {
-            *(int *)(((int)f + 4) & 0xFFFFFFFFFFFFFFFF) += *(int *)(f + 8);
-            *(int *)(((int)f + 8) & 0xFFFFFFFFFFFFFFFF) -= 0x100;
+            *(int *)(((int)f + 4)) += *(int *)(f + 8);
+            *(int *)(((int)f + 8)) -= 0x100;
             if (*(u8 *)(f + 0xc) != 0) {
                 int v;
                 data_ov006_02141ff0[i].t--;
@@ -34,7 +34,7 @@ void func_ov006_020ea3d0(int *arg)
                 return;
             }
             *(u8 *)(f + 0xc) = 0x40;
-            *(u8 *)(((int)f + 0xe) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)f + 0xe)) += 1;
         } else if (ph == 1) {
             if (*(u8 *)(f + 0xc) != 0) {
                 int v;
@@ -45,12 +45,12 @@ void func_ov006_020ea3d0(int *arg)
                 return;
             }
             *(u8 *)(f + 0x10) = 0;
-            *(u8 *)(((int)f + 0xe) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)f + 0xe)) += 1;
             {
                 char *g = func_020beb68;
                 if (g != 0) {
                     if (*(int *)(g + 0xb4) < 0x270f)
-                        *(int *)(((int)g + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+                        *(int *)(((int)g + 0xb4)) += 1;
                     if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                         *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
                 }
@@ -58,10 +58,10 @@ void func_ov006_020ea3d0(int *arg)
             func_ov004_020adb1c(func_020beb68 != 0 ? *(int *)(func_020beb68 + 0xb4) : 0);
         } else {
             if (*(u8 *)(f + 0xf) != 0) {
-                *(u8 *)(((int)f + 0xc) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(u8 *)(((int)f + 0xc)) += 1;
                 if (*(u8 *)(f + 0xc) >= 8) {
                     *(u8 *)(f + 0xc) = 0;
-                    *(u8 *)(((int)f + 0xf) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(u8 *)(((int)f + 0xf)) -= 1;
                     if (arg != 0)
                         _Z14ApproachLinearRiii(arg, 0x32, 1);
                 }

--- a/src/func_ov006_020ea71c.c
+++ b/src/func_ov006_020ea71c.c
@@ -25,18 +25,18 @@ void func_ov006_020ea71c(void)
                 e->pos = 0xb8000;
             if (e->phase == 0) {
                 if (e->timer != 0) {
-                    *(u16 *)(((int)e + 0xc) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(u16 *)(((int)e + 0xc)) -= 1;
                     if ((s16)e->timer < 0)
                         e->timer = 0;
-                    *(int *)(((int)e + 4) & 0xFFFFFFFFFFFFFFFF) += e->vel;
-                    *(int *)(((int)e + 8) & 0xFFFFFFFFFFFFFFFF) += 0x100;
+                    *(int *)(((int)e + 4)) += e->vel;
+                    *(int *)(((int)e + 8)) += 0x100;
                 } else {
                     e->timer = 0x40;
-                    *(u8 *)(((int)e + 0x10) & 0xFFFFFFFFFFFFFFFF) += 1;
+                    *(u8 *)(((int)e + 0x10)) += 1;
                 }
             } else {
                 if (e->timer != 0) {
-                    *(u16 *)(((int)e + 0xc) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(u16 *)(((int)e + 0xc)) -= 1;
                     if ((s16)e->timer < 0)
                         e->timer = 0;
                 } else {

--- a/src/func_ov006_020eb018.cpp
+++ b/src/func_ov006_020eb018.cpp
@@ -14,7 +14,7 @@ extern "C" void func_ov006_020eb018(char *c)
     C *o = (C*)c;
     (o->*(o->pmf))();
     if (*(unsigned char*)(c + 0x95) != 5) return;
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int*)(((int)c + 0x60)) += 1;
     {
         int i = 0;
         int max = 0x200;

--- a/src/func_ov006_020eb1e0.c
+++ b/src/func_ov006_020eb1e0.c
@@ -13,8 +13,8 @@ void func_ov006_020eb1e0(char *c)
 
     _Z14ApproachLinearRiii((int *)(c + 0x48), 0, 0x200);
     if (_Z15ApproachLinear2Rsss((short *)(c + 0x78), 0, 1) != 0) {
-        int *p10 = (int *)(((int)c + 0x10) & 0xFFFFFFFFFFFFFFFF);
-        int *pd = (int *)(((int)data_ov006_0213c984) & 0xFFFFFFFFFFFFFFFF);
+        int *p10 = (int *)(((int)c + 0x10));
+        int *pd = (int *)(((int)data_ov006_0213c984));
         if (p10[0] == pd[0] &&
             (p10[1] == pd[1] || *(int *)(c + 0x10) == 0)) {
             *(unsigned char *)(c + 0x94) = 1;

--- a/src/func_ov006_020eb31c.cpp
+++ b/src/func_ov006_020eb31c.cpp
@@ -9,7 +9,7 @@ struct C {
 
 extern "C" void func_ov006_020eb31c(char* c)
 {
-    short* t = (short*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF);
+    short* t = (short*)(((int)c + 0x90));
     short v = (short)(*t - 1);
     *t = v;
     if (*(short*)(c+0x90) == 0) {

--- a/src/func_ov006_020eb3e4.c
+++ b/src/func_ov006_020eb3e4.c
@@ -13,10 +13,10 @@ void func_ov006_020eb3e4(char *c)
     short cnt;
 
     _Z14ApproachLinearRiii((int *)(c + 0x48), 0, 0x200);
-    *(short *)(((int)c + 0x78) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(short *)(((int)c + 0x78)) -= 1;
     if (*(short *)(c + 0x78) == 0) {
-        int *p10 = (int *)(((int)c + 0x10) & 0xFFFFFFFFFFFFFFFF);
-        int *pd = (int *)(((int)data_ov006_0213ca44) & 0xFFFFFFFFFFFFFFFF);
+        int *p10 = (int *)(((int)c + 0x10));
+        int *pd = (int *)(((int)data_ov006_0213ca44));
         if (p10[0] == pd[0] &&
             (p10[1] == pd[1] || *(int *)(c + 0x10) == 0)) {
             *(unsigned char *)(c + 0x94) = 1;

--- a/src/func_ov006_020eb610.cpp
+++ b/src/func_ov006_020eb610.cpp
@@ -7,8 +7,8 @@ int func_02012468(int a, int b, int c, int d, int e, int f, int g, int h);
 void func_ov006_020ebf20(char *p);
 }
 
-#define L(a) (*(int*)(((long long)(int)(a))      & 0xFFFFFFFFFFFFFFFFLL))
-#define M(a) (*(int*)(((long long)(unsigned)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define L(a) (*(int*)(((long long)(int)(a))))
+#define M(a) (*(int*)(((long long)(unsigned)(a))))
 
 extern "C" void func_ov006_020eb610(char *c)
 {

--- a/src/func_ov006_020eb7b0.c
+++ b/src/func_ov006_020eb7b0.c
@@ -6,7 +6,7 @@ typedef struct S {
 int func_ov006_020eb7b0(char* p)
 {
     if (*(unsigned char*)(p + 0x93) == 0) {
-        S* q = (S*)(long long)(((long long)(int)(p + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+        S* q = (S*)(long long)(((long long)(int)(p + 8)));
         int x = *(int*)p;
         if (x == q->a && (*(int*)(p + 4) == q->b || x == 0))
             return 1;

--- a/src/func_ov006_020eb9dc.c
+++ b/src/func_ov006_020eb9dc.c
@@ -30,9 +30,9 @@ struct Obj {
 
 void func_ov006_020eb9dc(struct Obj* c, int v)
 {
-    short* h = (short*)(int)(((long long)(int)&c->h8c) & 0xFFFFFFFFFFFFFFFFLL);
-    struct P2* p = (struct P2*)(int)(((long long)(int)&c->m8) & 0xFFFFFFFFFFFFFFFFLL);
-    struct P2* g = (struct P2*)(int)(((long long)(int)&data_ov006_0213c9f4) & 0xFFFFFFFFFFFFFFFFLL);
+    short* h = (short*)(int)(((long long)(int)&c->h8c));
+    struct P2* p = (struct P2*)(int)(((long long)(int)&c->m8));
+    struct P2* g = (struct P2*)(int)(((long long)(int)&data_ov006_0213c9f4));
 
     (*h)++;
     if (p->a == g->a &&

--- a/src/func_ov006_020ec134.c
+++ b/src/func_ov006_020ec134.c
@@ -63,7 +63,7 @@ void func_ov006_020ec134(struct C* c)
     g.x = 0;
     g.y = -0x10000;
     func_0203d388(&g, c->s7a[0]);
-    func_0203d704(&h, (V2*)((long long)(int)c->v18 & 0xFFFFFFFFFFFFFFFFLL) + 1, &g);
+    func_0203d704(&h, (V2*)((long long)(int)c->v18) + 1, &g);
     c->v18[0].x = h.x;
     c->v18[0].y = h.y;
 }

--- a/src/func_ov006_020ec2bc.c
+++ b/src/func_ov006_020ec2bc.c
@@ -59,7 +59,7 @@ void func_ov006_020ec2bc(struct C* c)
     g.y = -0x10000;
     c->s7a[0] = (s16)(c->s7a[1] + (((c->s7a[1] - c->s7a[2]) << 14) >> 16));
     func_0203d388(&g, c->s7a[0]);
-    func_0203d704(&h, (V2*)((long long)(int)c->v18 & 0xFFFFFFFFFFFFFFFFLL) + 1, &g);
+    func_0203d704(&h, (V2*)((long long)(int)c->v18) + 1, &g);
     c->v18[0].x = h.x;
     c->v18[0].y = h.y;
 }

--- a/src/func_ov006_020ec458.c
+++ b/src/func_ov006_020ec458.c
@@ -20,11 +20,11 @@ void func_ov006_020ec458(Obj* self) {
     s16 v = self->unk76;
     if (v < 0 && self->entries[0].val < -0x60000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)) & 0xFFFFFFFFFFFFFFFFLL)) += 0x170000;
+            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)))) += 0x170000;
         return;
     }
     if (v > 0 && self->entries[0].val > 0x160000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)) & 0xFFFFFFFFFFFFFFFFLL)) -= 0x170000;
+            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)))) -= 0x170000;
     }
 }

--- a/src/func_ov006_020ec6e8.c
+++ b/src/func_ov006_020ec6e8.c
@@ -39,7 +39,7 @@ void func_ov006_020ec6e8(char *c)
         int rb;
         s16 a;
         s16 d;
-        *(s16*)(int)(((long long)(int)(c + 0x78)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(s16*)(int)(((long long)(int)(c + 0x78))) -= 1;
         if (*(s16*)(c + 0x78) >= 0) return;
         *(s16*)(c + 0x78) = (s16)((((int)((unsigned int)(RandomIntInternal(&data_0209e650) & 0x7fffffff) >> 19) * 0x1e) >> 12) + 0x3c);
         ra = RandomIntInternal(&data_0209e650);

--- a/src/func_ov006_020ec93c.c
+++ b/src/func_ov006_020ec93c.c
@@ -20,11 +20,11 @@ void func_ov006_020ec93c(Obj* self) {
     s16 v = self->unk76;
     if (v < 0 && self->entries[0].val < -0x60000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)) & 0xFFFFFFFFFFFFFFFFLL)) += 0x170000;
+            (*(int*)(((long long)(int)((char*)self + (i << 3) + 0x18)))) += 0x170000;
         return;
     }
     if (v > 0 && self->entries[0].val > 0x160000) {
         for (i = 0; i < 5; i++)
-            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)) & 0xFFFFFFFFFFFFFFFFLL)) -= 0x170000;
+            (*(int*)(((unsigned long long)(unsigned int)((char*)self + (i << 3) + 0x18)))) -= 0x170000;
     }
 }

--- a/src/func_ov006_020ed274.c
+++ b/src/func_ov006_020ed274.c
@@ -8,7 +8,7 @@ void func_ov006_020ed274(char *c)
     int idx;
     int b;
     int w0, w1;
-    *(int *)(((int)c + 0x466c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(int *)(((int)c + 0x466c)) -= 1;
     if (*(int *)(c + 0x4000 + 0x66c) != 0)
     {
         idx = data_020a0e40[0];

--- a/src/func_ov006_020ed34c.c
+++ b/src/func_ov006_020ed34c.c
@@ -7,7 +7,7 @@ extern void func_ov006_020eb7f8(int c);
 void func_ov006_020ed34c(char *p)
 {
     int v;
-    *(int *)(((int)p + 0x466c) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((int)p + 0x466c)) -= 1;
     v = *(int *)(p + 0x466c);
     if (v == 0)
     {

--- a/src/func_ov006_020ed494.c
+++ b/src/func_ov006_020ed494.c
@@ -50,7 +50,7 @@ void func_ov006_020ed494(char *c)
         a.x = data_020a0dea[(unsigned int)idx * 4] << 12;
         a.y = data_020a0deb[(unsigned int)idx * 4] << 12;
         p = *(Thing **)(c + 0x4f60);
-        src = (V2 *)(int)(((long long)(int)((char *)p + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+        src = (V2 *)(int)(((long long)(int)((char *)p + 0x18)));
         vec[0] = src->x;
         vec[1] = src->y;
 
@@ -118,7 +118,7 @@ void func_ov006_020ed494(char *c)
                         ptr2 = (Thing *)(c + 0x4678);
                         do
                         {
-                            V2 *s2 = (V2 *)(int)(((long long)(int)((char *)ptr2 + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+                            V2 *s2 = (V2 *)(int)(((long long)(int)((char *)ptr2 + 0x18)));
                             vec[0] = s2->x;
                             vec[1] = s2->y;
                             func_ov006_020eb9dc(ptr2, func_0203d5dc(vec, &a));
@@ -131,7 +131,7 @@ void func_ov006_020ed494(char *c)
 
                 func_02012790(0xe);
                 {
-                    V2 *s3 = (V2 *)(int)(((long long)(int)((char *)sel + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+                    V2 *s3 = (V2 *)(int)(((long long)(int)((char *)sel + 0x18)));
                     vec[2] = s3->x;
                     vec[3] = s3->y;
                 }

--- a/src/func_ov006_020ee2c4.c
+++ b/src/func_ov006_020ee2c4.c
@@ -9,15 +9,15 @@ typedef struct { int a, b; } P;
 extern P data_ov006_0213cb7c;
 
 void func_ov006_020ee2c4(char* c){
-  *(int *)(((int)c + 0x500c) & 0xFFFFFFFFFFFFFFFF) += *(int*)(c + 0x5010) >> 12;
-  *(int *)(((int)c + 0x5010) & 0xFFFFFFFFFFFFFFFF) += 0x600;
+  *(int *)(((int)c + 0x500c)) += *(int*)(c + 0x5010) >> 12;
+  *(int *)(((int)c + 0x5010)) += 0x600;
   func_ov006_020c712c();
   int eq = (int)(data_ov006_02140434 == data_ov006_02140418);
   if(eq == 0) return;
   char* g = func_020beb68;
   if(g != 0){
     if(*(int*)(g+0xb4) < 0x270f){
-      *(int *)(((int)g + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+      *(int *)(((int)g + 0xb4)) += 1;
     }
     if(*(int*)(g+0xb4) > *(int*)(g+0xb8)){
       *(int*)(g+0xb8) = *(int*)(g+0xb4);

--- a/src/func_ov006_020ee44c.c
+++ b/src/func_ov006_020ee44c.c
@@ -11,7 +11,7 @@ struct G2
 extern struct G2 data_ov006_0213cb4c;
 void func_ov006_020ee44c(char *c)
 {
-  int *p = (int *) ((((int) c) + 0x500c) & 0xFFFFFFFFFFFFFFFF);
+  int *p = (int *) ((((int) c) + 0x500c));
   char *b = c + 0x5000;
   *p = (*p) + ((*((int *) ((c + 0x5000) + 0x10))) >> 12);
   if ((*((int *) (b + 0xc))) > 0x1000)

--- a/src/func_ov006_020ee508.c
+++ b/src/func_ov006_020ee508.c
@@ -5,7 +5,7 @@ extern void func_ov006_020ee3bc(char *c);
 extern int data_ov006_02140428;
 extern int data_ov006_02140304;
 void func_ov006_020ee508(char *c){
-    int *acc = (int*)(((int)c + 0x500c) & 0xFFFFFFFFFFFFFFFF);
+    int *acc = (int*)(((int)c + 0x500c));
     *acc = *acc + (((int*)(c+0x5000))[4] >> 12);
     if(((int*)(c+0x5000))[3] > 0x1000){
         *acc -= 0x1000;

--- a/src/func_ov006_020ef794.c
+++ b/src/func_ov006_020ef794.c
@@ -11,7 +11,7 @@ extern void func_ov006_020c42bc(void);
 
 void func_ov006_020ef794(char *self)
 {
-    s16 *p = (s16 *)(((int)self + 0x5a74) & 0xFFFFFFFFFFFFFFFF);
+    s16 *p = (s16 *)(((int)self + 0x5a74));
     *p = *p - 1;
     if (*(s16 *)(self + 0x5a74) == 0) {
         if (*(u8 *)(self + 0xc4) == 0) {

--- a/src/func_ov006_020efcf8.c
+++ b/src/func_ov006_020efcf8.c
@@ -10,7 +10,7 @@ extern void MultiCopy_Int(int *dst, int *src, int len);
 void func_ov006_020efcf8(void)
 {
     int v;
-    *(int *)(((int)data_023c0000 + 0x3ff8) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+    *(int *)(((int)data_023c0000 + 0x3ff8)) |= 2;
     v = data_04000006 + 1;
     if (v >= 0xc0) {
         func_ov006_020efdac();

--- a/src/func_ov006_020f0274.c
+++ b/src/func_ov006_020f0274.c
@@ -11,37 +11,37 @@ void func_ov006_020f0274(char *s)
         return;
 
     if (*(u8 *)(s + 0x47e1) == 0) {
-        *(int *)(((int)s + 0x47d4) & 0xFFFFFFFFFFFFFFFF) += *(int *)(s + 0x47d8);
-        *(int *)(((int)s + 0x47d8) & 0xFFFFFFFFFFFFFFFF) -= 0x100;
+        *(int *)(((int)s + 0x47d4)) += *(int *)(s + 0x47d8);
+        *(int *)(((int)s + 0x47d8)) -= 0x100;
         if (*(u8 *)(s + 0x47df) != 0) {
             int v;
-            (*(u8 *)(((int)s + 0x47df) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8 *)(((int)s + 0x47df)))--;
             v = *(u8 *)(s + 0x47df);
             if (v < 0)
                 *(u8 *)(s + 0x47df) = 0;
             return;
         }
         *(u8 *)(s + 0x47df) = 0x40;
-        *(u8 *)(((int)s + 0x47e1) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)s + 0x47e1)) += 1;
         return;
     }
 
     if (*(u8 *)(s + 0x47e1) == 1) {
         if (*(u8 *)(s + 0x47df) != 0) {
             int v;
-            (*(u8 *)(((int)s + 0x47df) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8 *)(((int)s + 0x47df)))--;
             v = *(u8 *)(s + 0x47df);
             if (v < 0)
                 *(u8 *)(s + 0x47df) = 0;
             return;
         }
         *(u8 *)(s + 0x47e3) = 0;
-        *(u8 *)(((int)s + 0x47e1) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)s + 0x47e1)) += 1;
         {
             char *g = func_020beb68;
             if (g != 0) {
                 if (*(int *)(g + 0xb4) < 0x270f)
-                    *(int *)(((int)g + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+                    *(int *)(((int)g + 0xb4)) += 1;
                 if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                     *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
             }
@@ -51,13 +51,13 @@ void func_ov006_020f0274(char *s)
     }
 
     if (*(u8 *)(s + 0x47e2) != 0) {
-        *(u8 *)(((int)s + 0x47df) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)s + 0x47df)) += 1;
         if (*(u8 *)(s + 0x47df) < 4)
             return;
         _ZN5Sound12PlayBank2_2DEj(0x1bc);
         *(u8 *)(s + 0x47df) = 0;
-        *(u8 *)(((int)s + 0x47e2) & 0xFFFFFFFFFFFFFFFF) -= 1;
-        *(u16 *)(((int)s + 0x5172) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)s + 0x47e2)) -= 1;
+        *(u16 *)(((int)s + 0x5172)) += 1;
         if (*(u16 *)(s + 0x5172) >= 0x32) {
             *(u16 *)(s + 0x5172) = 0x32;
             *(u8 *)(s + 0x51fb) = 0;

--- a/src/func_ov006_020f0eac.c
+++ b/src/func_ov006_020f0eac.c
@@ -9,14 +9,14 @@ void func_ov006_020f0eac(char *c)
 {
     if (*(u16 *)(c + 0x5172) != 0) {
         {
-            u8 *q = (u8 *)(((int)c + 0x51fb) & 0xFFFFFFFFFFFFFFFF);
+            u8 *q = (u8 *)(((int)c + 0x51fb));
             *q = *q + 1;
         }
         if (*(u8 *)(c + 0x51fb) < 0x3c)
             return;
         *(u8 *)(c + 0x51fb) = 0;
         {
-            u16 *p = (u16 *)(((int)c + 0x5172) & 0xFFFFFFFFFFFFFFFF);
+            u16 *p = (u16 *)(((int)c + 0x5172));
             *p = *p - 1;
         }
         if (*(s16 *)(c + 0x5172) <= 0)

--- a/src/func_ov006_020f10ec.c
+++ b/src/func_ov006_020f10ec.c
@@ -10,18 +10,18 @@ void func_ov006_020f10ec(char *q)
         if (*(u8 *)(q + 0x4670) != 0) {
             if (*(u8 *)(q + 0x4672) == 0) {
                 if (*(u16 *)(q + 0x466c) != 0) {
-                    *(u16 *)(((int)q + 0x466c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(u16 *)(((int)q + 0x466c)) -= 1;
                     if (*(short *)(q + 0x466c) < 0)
                         *(u16 *)(q + 0x466c) = 0;
-                    *(int *)(((int)q + 0x4664) & 0xFFFFFFFFFFFFFFFF) += *(int *)(q + 0x4668);
-                    *(int *)(((int)q + 0x4668) & 0xFFFFFFFFFFFFFFFF) += 0x100;
+                    *(int *)(((int)q + 0x4664)) += *(int *)(q + 0x4668);
+                    *(int *)(((int)q + 0x4668)) += 0x100;
                 } else {
                     *(u16 *)(q + 0x466c) = 0x40;
-                    *(u8 *)(((int)q + 0x4672) & 0xFFFFFFFFFFFFFFFF) += 1;
+                    *(u8 *)(((int)q + 0x4672)) += 1;
                 }
             } else {
                 if (*(u16 *)(q + 0x466c) != 0) {
-                    *(u16 *)(((int)q + 0x466c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(u16 *)(((int)q + 0x466c)) -= 1;
                     if (*(short *)(q + 0x466c) < 0)
                         *(u16 *)(q + 0x466c) = 0;
                 } else {

--- a/src/func_ov006_020f120c.c
+++ b/src/func_ov006_020f120c.c
@@ -16,7 +16,7 @@ void func_ov006_020f120c(char *base, int idx)
     *((int *) ((base + (i * 0x14)) + 0x4664)) = *((int *) ((base + (idx * 4)) + 0x49d8));
     *((int *) ((base + (i * 0x14)) + 0x4668)) = 0x1100;
     *((unsigned char *) ((base + (i * 0x14)) + 0x4672)) = 0;
-    *((unsigned short *) ((((int) base) + 0x5172) & 0xFFFFFFFFFFFFFFFF)) -= 0xa;
+    *((unsigned short *) ((((int) base) + 0x5172))) -= 0xa;
     if ((*((short *) (base + 0x5172))) < 0)
     {
       *((short *) (base + 0x5172)) = 0;

--- a/src/func_ov006_020f1ef8.c
+++ b/src/func_ov006_020f1ef8.c
@@ -11,7 +11,7 @@ void func_ov006_020f1ef8(char *o, int p1)
     v = *(int *)(o + 0xbc);
     while (v >= 5) v -= 5;
     if (v != 4)
-        *(unsigned short *)(((int)o + 0x516a) & 0xFFFFFFFFFFFFFFFF) += 8;
+        *(unsigned short *)(((int)o + 0x516a)) += 8;
     if (p1 == 0)
         *(short *)(o + 0x516a) = 0x80;
     *(unsigned char *)(o + 0x5459) = (unsigned char)p1;

--- a/src/func_ov006_020f1fcc.c
+++ b/src/func_ov006_020f1fcc.c
@@ -56,7 +56,7 @@ void func_ov006_020f1fcc(char *c)
 
         for (i = 0; i < 0x78; i++) {
             if (*(u8 *)(c + i + 0x52ed) == 1) {
-                u8 *p = (u8 *)(((long long)(int)(c + i + off)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8 *)(((long long)(int)(c + i + off)));
                 if (*p != 9) {
                     int dx2 = data_020a0de8[idx][2] - (((int *)(c + 0x47f8))[i] >> 12);
                     int dy2 = data_020a0de8[idx][3] - (((int *)(c + 0x49d8))[i] >> 12);

--- a/src/func_ov006_020f300c.cpp
+++ b/src/func_ov006_020f300c.cpp
@@ -56,7 +56,7 @@ extern "C" void func_ov006_020f300c(char *o)
         return;
 
     for (i = 0; i < 0x78; i++) {
-        unsigned char *p = (unsigned char *)(((int)o + i + 0x53dd) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char *)(((int)o + i + 0x53dd));
         if (*p == 1)
             *p = 0;
     }
@@ -64,7 +64,7 @@ extern "C" void func_ov006_020f300c(char *o)
     if (*(unsigned short *)(o + 0x516a) == 0)
         return;
     *(unsigned short *)(o + 0x5164) = 1;
-    *(unsigned short *)(((int)o + 0x516a) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(unsigned short *)(((int)o + 0x516a)) -= 1;
     if (*(short *)(o + 0x516a) > 0)
         return;
     *(unsigned short *)(o + 0x516a) = 0;

--- a/src/func_ov006_020f3294.c
+++ b/src/func_ov006_020f3294.c
@@ -17,9 +17,9 @@ void dScMgLuigi_c_OnYoshiTryEat_020f3294(char *c, int arg1)
     int *q;
 
     if (*(unsigned char *)(c + 0x5000 + 0x459) != 0) {
-        *(unsigned char *)(((int)c + 0x5457) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char *)(((int)c + 0x5457)) += 1;
 
-        q = (int *)(((int)c + 0xbc) & 0xFFFFFFFFFFFFFFFF);
+        q = (int *)(((int)c + 0xbc));
         *q += 1;
         if ((unsigned int)*(int *)(c + 0xbc) > 0x270e)
             *(int *)(c + 0xbc) = 0x270e;

--- a/src/func_ov006_020f3964.c
+++ b/src/func_ov006_020f3964.c
@@ -4,14 +4,14 @@ void func_ov006_020f3964(char* c)
         return;
 
     {
-        unsigned short* e = (unsigned short*)(((long long)(int)(c + 0x530c)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short* e = (unsigned short*)(((long long)(int)(c + 0x530c)));
         *e = *e + 1;
         if (*e < 0x14)
             return;
         *e = 0;
     }
     {
-        unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x5311)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x5311)));
         *p = *p + 1;
         *p = *p & 1;
     }

--- a/src/func_ov006_020f3d34.cpp
+++ b/src/func_ov006_020f3d34.cpp
@@ -21,11 +21,11 @@ extern "C" void func_ov006_020f3d34(char *self)
         *(unsigned char *)(self + 0x51ba + b * 0x18) = 0;
         func_02012790(0x26);
         Sound::PlayBank2_2D(0x13d);
-        (*(unsigned char *)(((int)self + 0x5337) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char *)(((int)self + 0x5337)))++;
         *(unsigned char *)(self + 0x5338) = 0;
     } else {
         func_02012790(0xe);
-        (*(unsigned char *)(((int)self + 0x533a) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char *)(((int)self + 0x533a)))++;
         func_ov004_020b5dd4();
         Sound::PlayBank2_2D(0x13e);
         if (*(unsigned char *)(self + 0x533a) < *(unsigned char *)(self + 0x533b)) {

--- a/src/func_ov006_020f4248.c
+++ b/src/func_ov006_020f4248.c
@@ -56,7 +56,7 @@ void func_ov006_020f4248(char *self, int idx)
   *((u8 *) ((self + 0x532c) + s)) = *((u8 *) ((self + 0x51b8) + n));
   *((u8 *) ((self + 0x532e) + (*((u8 *) (self + 0x5338))))) = (u8) idx;
   {
-    u8 *pc = (u8 *) (((long long) ((int) (self + 0x5338))) & 0xFFFFFFFFFFFFFFFFLL);
+    u8 *pc = (u8 *) (((long long) ((int) (self + 0x5338))));
     *pc = (*pc) + 1;
   }
   *((u8 *) ((self + 0x51bc) + n)) = 3;
@@ -66,7 +66,7 @@ void func_ov006_020f4248(char *self, int idx)
     return;
   }
   {
-    u8 *pd = (u8 *) (((long long) ((int) (self + 0x533e))) & 0xFFFFFFFFFFFFFFFFLL);
+    u8 *pd = (u8 *) (((long long) ((int) (self + 0x533e))));
     *pd = (*pd) + 1;
   }
   func_ov004_020ad79c(*((int *) (self + 0xa8)), *((int *) (self + 0xb4)));

--- a/src/func_ov006_020f456c.c
+++ b/src/func_ov006_020f456c.c
@@ -47,7 +47,7 @@ void func_ov006_020f456c(Ctx *c)
 
     if (c->h5322 != 0)
     {
-        p = (u16 *)(int)(((long long)(int)((char *)c + 0x5322)) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (u16 *)(int)(((long long)(int)((char *)c + 0x5322)));
         *p = (u16)(*p - 1);
         return;
     }

--- a/src/func_ov006_020f4888.c
+++ b/src/func_ov006_020f4888.c
@@ -8,7 +8,7 @@ extern char *func_020beb68;
 void func_ov006_020f4888(char *self)
 {
     if (*(unsigned short *)(self + 0x5324) != 0) {
-        *(unsigned short *)(((int)self + 0x5324) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(unsigned short *)(((int)self + 0x5324)) -= 1;
         if (*(short *)(self + 0x5324) <= 0) {
             *(unsigned short *)(self + 0x5324) = 0;
             if (*(unsigned char *)(self + 0x5337) >= *(unsigned short *)(self + 0x532a)) {
@@ -16,7 +16,7 @@ void func_ov006_020f4888(char *self)
                     func_ov004_020b67f8();
                 func_ov004_020b0a54(4);
                 if (*(int *)(self + 0xb4) < 0x270f) {
-                    int *c = (int *)(((int)self + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+                    int *c = (int *)(((int)self + 0xb4));
                     *c += 1;
                 }
                 if (*(int *)(self + 0xb4) > *(int *)(self + 0xb8))
@@ -26,7 +26,7 @@ void func_ov006_020f4888(char *self)
             } else {
                 func_ov004_020b0a54(5);
                 if (*(int *)(self + 0xb4) > 0) {
-                    int *c = (int *)(((int)self + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+                    int *c = (int *)(((int)self + 0xb4));
                     *c -= 1;
                 }
                 func_ov006_020c0d68(self + 0x4f38);

--- a/src/func_ov006_020f49ac.c
+++ b/src/func_ov006_020f49ac.c
@@ -5,7 +5,7 @@ void func_ov006_020f49ac(char *c)
     char *e;
     unsigned short *t;
     if (*(unsigned short *)(c + 0x5300 + 0x22) != 0) {
-        t = (unsigned short *)(((int)c + 0x5322) & 0xFFFFFFFFFFFFFFFF);
+        t = (unsigned short *)(((int)c + 0x5322));
         *t = *t - 1;
         if (*(short *)(c + 0x5300 + 0x22) > 0)
             return;

--- a/src/func_ov006_020f4ad4.c
+++ b/src/func_ov006_020f4ad4.c
@@ -5,7 +5,7 @@ void func_ov006_020f4ad4(unsigned char* c){
   if(n<3) return;
   k=*(short*)(c+0x5328);
   *(unsigned char*)(c+(0xb-k)*0x18+0x51bb)=1;
-  q=(short*)(((int)c+0x5328) & 0xFFFFFFFFFFFFFFFF);
+  q=(short*)(((int)c+0x5328));
   *q=*q+1;
   if(*(short*)(c+0x5328)>=0xc) *(int*)(c+0x5318)=4;
 }

--- a/src/func_ov006_020f4b30.c
+++ b/src/func_ov006_020f4b30.c
@@ -29,7 +29,7 @@ void func_ov006_020f4b30(char* c)
     if (w->ready < 2)
         return;
     w->slots[0xb - w->count].done = 1;
-    (*(short*)((long long)(int)(c + 0x5328) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(short*)((long long)(int)(c + 0x5328)))++;
     mode = w->mode;
     if (mode == 1) {
         if (w->count >= 10)

--- a/src/func_ov006_020f4bbc.c
+++ b/src/func_ov006_020f4bbc.c
@@ -5,7 +5,7 @@ void func_ov006_020f4bbc(unsigned char* c){
   if(n<1) return;
   k=*(short*)(c+0x5328);
   *(unsigned char*)(c+(0xb-k)*0x18+0x51bb)=1;
-  q=(short*)(((int)c+0x5328) & 0xFFFFFFFFFFFFFFFF);
+  q=(short*)(((int)c+0x5328));
   *q=*q+1;
   if(*(unsigned char*)(c+0x533c)==1){
     if(*(short*)(c+0x5328)>=5) *(int*)(c+0x5318)=2;

--- a/src/func_ov006_020f4cd8.c
+++ b/src/func_ov006_020f4cd8.c
@@ -20,7 +20,7 @@ void func_ov006_020f4cd8(char *c)
         for (k = 4; k < 12; k++) {
             slot = (int)((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 4 >> 15) + 1;
             for (;;) {
-                q = (u8 *)(((int)c + slot + 0x5330) & 0xFFFFFFFFFFFFFFFF);
+                q = (u8 *)(((int)c + slot + 0x5330));
                 if (*q < 2) {
                     *(u8 *)(p + 0x51b8) = slot;
                     *q += 1;
@@ -44,7 +44,7 @@ void func_ov006_020f4cd8(char *c)
         for (i = 2; i < 12; i++) {
             slot = (int)((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 5 >> 15) + 1;
             for (;;) {
-                q = (u8 *)(((int)c + slot + 0x5330) & 0xFFFFFFFFFFFFFFFF);
+                q = (u8 *)(((int)c + slot + 0x5330));
                 if (*q < 2) {
                     *(u8 *)(p + 0x51b8) = slot;
                     *q += 1;
@@ -68,7 +68,7 @@ void func_ov006_020f4cd8(char *c)
         for (i = 0; i < 12; i++) {
             slot = (int)((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 6 >> 15) + 1;
             for (;;) {
-                q = (u8 *)(((int)c + slot + 0x5330) & 0xFFFFFFFFFFFFFFFF);
+                q = (u8 *)(((int)c + slot + 0x5330));
                 if (*q < 2) {
                     *(u8 *)(p + 0x51b8) = slot;
                     *q += 1;

--- a/src/func_ov006_020f50c0.c
+++ b/src/func_ov006_020f50c0.c
@@ -6,5 +6,5 @@ void func_ov006_020f50c0(char *self)
 {
     func_ov006_020f50c0_cb(self);
     if (*(unsigned short *)(self + 0x5322))
-        *(unsigned short *)(((long long)(int)(self + 0x5322)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(unsigned short *)(((long long)(int)(self + 0x5322))) -= 1;
 }

--- a/src/func_ov006_020f5694.c
+++ b/src/func_ov006_020f5694.c
@@ -1,13 +1,13 @@
 void func_ov006_020f5694(char* c) {
   if (*(unsigned char*)(c + 0x5000 + 0x3d0) == 0) return;
   {
-    unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x53cc)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x53cc)));
     *h = *h + 1;
     if (*h < 0x14) return;
     *h = 0;
   }
   {
-    unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x53d1)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x53d1)));
     *p = *p + 1;
     *p = *p & 1;
   }

--- a/src/func_ov006_020f5a64.cpp
+++ b/src/func_ov006_020f5a64.cpp
@@ -22,12 +22,12 @@ extern "C" void func_ov006_020f5a64(char *c)
         *(unsigned char *)(c + 0x5000 + b * 0x18 + 0x1ba) = 0;
         func_02012790(0x26);
         Sound::PlayBank2_2D(0x13d);
-        *(unsigned char *)(((int)c + 0x5405) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char *)(((int)c + 0x5405)) += 1;
         *(unsigned char *)(c + 0x5406) = 0;
     } else {
         func_02012790(0xe);
         Sound::PlayBank2_2D(0x13e);
-        *(unsigned char *)(((int)c + 0x5408) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char *)(((int)c + 0x5408)) += 1;
         func_ov004_020b5dd4();
         if (*(unsigned char *)(c + 0x5408) < *(unsigned char *)(c + 0x5409)) {
             *sa = 5;


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 103 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
