### PR TITLE
readable: strip 102 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov006_020f5f0c.c
+++ b/src/func_ov006_020f5f0c.c
@@ -42,7 +42,7 @@ void func_ov006_020f5f0c(char *self, int idx)
     *(u8*)(self + 0x53ee + e) = *(u8*)(self + 0x51b8 + n);
     *(u8*)(self + 0x53f0 + *(u8*)(self + 0x5406)) = (u8)idx;
     {
-        u8 *pc = (u8*)((long long)(int)(self + 0x5406) & 0xFFFFFFFFFFFFFFFFLL);
+        u8 *pc = (u8*)((long long)(int)(self + 0x5406));
         *pc = *pc + 1;
     }
     *(u8*)(self + 0x51bc + n) = 3;
@@ -50,7 +50,7 @@ void func_ov006_020f5f0c(char *self, int idx)
 
     if (*(u8*)(self + 0x540c) != 0) return;
     {
-        u8 *pd = (u8*)((long long)(int)(self + 0x540c) & 0xFFFFFFFFFFFFFFFFLL);
+        u8 *pd = (u8*)((long long)(int)(self + 0x540c));
         *pd = *pd + 1;
     }
     func_ov004_020ad79c(*(int*)(self + 0xa8), *(int*)(self + 0xb4));

--- a/src/func_ov006_020f639c.c
+++ b/src/func_ov006_020f639c.c
@@ -4,7 +4,7 @@ extern void func_ov006_020f56f8(char* p);
 void func_ov006_020f639c(char* c)
 {
     if (*(unsigned short*)(c + 0x5300 + 0xe2)) {
-        unsigned short* q = (unsigned short*)(((int)c + 0x53e2) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short* q = (unsigned short*)(((int)c + 0x53e2));
         *q = *q - 1;
         return;
     }

--- a/src/func_ov006_020f6538.c
+++ b/src/func_ov006_020f6538.c
@@ -19,8 +19,8 @@ void func_ov006_020f6538(char *c)
     if (*(unsigned short *)(c + 0x53e4) == 0)
         goto zero;
 
-    *(unsigned short *)(((int)c + 0x53e4) & 0xffffffffffffffffLL) =
-        *(unsigned short *)(((int)c + 0x53e4) & 0xffffffffffffffffLL) - 1;
+    *(unsigned short *)(((int)c + 0x53e4)) =
+        *(unsigned short *)(((int)c + 0x53e4)) - 1;
     if (*(short *)(c + 0x53e4) > 0)
         return;
 
@@ -33,7 +33,7 @@ void func_ov006_020f6538(char *c)
         p = func_020beb68;
         if (p != 0) {
             if (p->b4 < 0x270f)
-                *(int *)(((int)p + 0xb4) & 0xffffffffffffffffLL) += 1;
+                *(int *)(((int)p + 0xb4)) += 1;
             if (p->b4 > p->b8)
                 p->b8 = p->b4;
         }
@@ -46,7 +46,7 @@ void func_ov006_020f6538(char *c)
     p = func_020beb68;
     if (p != 0) {
         if (p->b4 > 0)
-            *(int *)(((int)p + 0xb4) & 0xffffffffffffffffLL) -= 1;
+            *(int *)(((int)p + 0xb4)) -= 1;
     }
     func_ov006_020c0d68(c + 0x4f38);
     return;

--- a/src/func_ov006_020f6678.c
+++ b/src/func_ov006_020f6678.c
@@ -6,7 +6,7 @@ void func_ov006_020f6678(char *c)
   char *h;
   if ((*((unsigned short *) (q + 0xe2))) != 0)
   {
-    h = (char *) ((((int) c) + 0x53e2) & 0xFFFFFFFFFFFFFFFF);
+    h = (char *) ((((int) c) + 0x53e2));
     *((unsigned short *) h) = (unsigned short) ((*((unsigned short *) h)) - 1);
     if ((*((short *) ((c + 0x5300) + 0xe2))) > 0)
     {

--- a/src/func_ov006_020f6830.c
+++ b/src/func_ov006_020f6830.c
@@ -7,7 +7,7 @@ void func_ov006_020f6830(char *o)
   if ((*((unsigned short *) (o + 0x53ec))) != 0)
   {
     i = 0x53ec;
-    *((unsigned short *) ((((int) o) + i) & 0xFFFFFFFFFFFFFFFF)) -= 1;
+    *((unsigned short *) ((((int) o) + i))) -= 1;
     return;
   }
   e = (unsigned char *) o;

--- a/src/func_ov006_020f6a00.c
+++ b/src/func_ov006_020f6a00.c
@@ -11,7 +11,7 @@ void func_ov006_020f6a00(char *this)
   idx = ((((unsigned short) (*((unsigned short *) ((this + 0x5300) + 0xea)))) << 1) - 1) - (*((short *) ((this + 0x5300) + 0xe8)));
   *((unsigned char *) ((this + (idx * 0x18)) + 0x51bb)) = 1;
   {
-    short *sp = (short *) (((int) this + 0x53e8) & 0xFFFFFFFFFFFFFFFF);
+    short *sp = (short *) (((int) this + 0x53e8));
     *sp = (*sp) + 1;
   }
   this = this + 0x5000;

--- a/src/func_ov006_020f6a78.c
+++ b/src/func_ov006_020f6a78.c
@@ -34,7 +34,7 @@ void func_ov006_020f6a78(char* c)
     if (w->ready < 3)
         return;
     w->slots[w->total * 2 - 1 - w->count].done = 1;
-    (*(short*)((long long)(int)(c + 0x53e8) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(short*)((long long)(int)(c + 0x53e8)))++;
     mode = w->mode;
     if (w->count < data_ov006_0212e93c[mode])
         return;

--- a/src/func_ov006_020f6b00.c
+++ b/src/func_ov006_020f6b00.c
@@ -12,7 +12,7 @@ void func_ov006_020f6b00(char *this)
     new_var = this + 0x5300;
     *((unsigned char *) ((this + (idx * 0x18)) + 0x51bb)) = 1;
     {
-        short *p = (short *) (((long long)(this + 0x53e8)) & 0xFFFFFFFFFFFFFFFFLL);
+        short *p = (short *) (((long long)(this + 0x53e8)));
         *p = (*p) + 1;
     }
     if ((*((short *) (new_var + 0xe8))) >= data_ov006_0212e924[*((unsigned char *) (this + 0x540a))])

--- a/src/func_ov006_020f6b78.c
+++ b/src/func_ov006_020f6b78.c
@@ -14,7 +14,7 @@ void func_ov006_020f6b78(char *this)
   {
   }
   {
-    short *p = (short *) (((int) (this + 0x53e8)) & 0xFFFFFFFFFFFFFFFF);
+    short *p = (short *) (((int) (this + 0x53e8)));
     *p = (*p) + 1;
   }
   r3 = this + 0x5300;

--- a/src/func_ov006_020f6c90.c
+++ b/src/func_ov006_020f6c90.c
@@ -20,7 +20,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 8 >> 15);
             u8 *entry;
         check0:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;
@@ -47,7 +47,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 9 >> 15);
             u8 *entry;
         check1:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;
@@ -74,7 +74,7 @@ void func_ov006_020f6c90(char *c)
             u32 idx = 1 + ((((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff) * 10 >> 15);
             u8 *entry;
         check2:
-            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)) & 0xFFFFFFFFFFFFFFFFLL);
+            entry = (u8 *)(((long long)(int)(c + idx + 0x53f2)));
             if (*entry < 2) {
                 *(u8 *)(p + 0x51b8) = idx;
                 (*entry)++;

--- a/src/func_ov006_020f7190.c
+++ b/src/func_ov006_020f7190.c
@@ -6,5 +6,5 @@ void func_ov006_020f7190(char *self)
 {
     func_ov006_020f7190_cb(self);
     if (*(unsigned short *)(self + 0x53e2))
-        *(unsigned short *)(((long long)(int)(self + 0x53e2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(unsigned short *)(((long long)(int)(self + 0x53e2))) -= 1;
 }

--- a/src/func_ov006_020f7ee4.cpp
+++ b/src/func_ov006_020f7ee4.cpp
@@ -28,7 +28,7 @@ void func_ov006_020f7ee4(char *c, int event)
 {
     switch (*(unsigned char *)(c + 0x2d)) {
     case 0:
-        *(short *)((long long)(c + 0x28) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(short *)((long long)(c + 0x28)) -= 1;
         if (*(short *)(c + 0x28) != 0)
             return;
         data_ov006_0213d56c--;

--- a/src/func_ov006_020f869c.c
+++ b/src/func_ov006_020f869c.c
@@ -20,7 +20,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
     switch (*(s16*)(c + 0x60a8)) {
     case 1:
         {
-            s16* p = (s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF);
+            s16* p = (s16*)(((int)c + 0x60a8));
             (*p)++;
         }
         if (c[0xc4] == 0) {
@@ -35,7 +35,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
             if (func_ov006_020f7b10() == 0) {
                 *(s16*)(c + 0x60ae) = 0;
                 {
-                    s16* p = (s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF);
+                    s16* p = (s16*)(((int)c + 0x60a8));
                     (*p)++;
                 }
             }
@@ -75,7 +75,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
                                 char *g = func_020beb68;
                                 if (g != 0) {
                                     if (*(int *)(g + 0xb4) > 0)
-                                        *(int *)(((int)g + 0xb4) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                                        *(int *)(((int)g + 0xb4)) -= 1;
                                 }
                             }
                             func_ov006_020c0d68(c + 0x4f38);
@@ -89,7 +89,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
                             }
                             c[0xc3] = 0;
                             {
-                                s16* p = (s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF);
+                                s16* p = (s16*)(((int)c + 0x60a8));
                                 (*p)++;
                             }
                         }
@@ -98,7 +98,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
                             char *g = func_020beb68;
                             if (g != 0) {
                                 if (*(int *)(g + 0xb4) < 0x270f)
-                                    *(int *)(((int)g + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+                                    *(int *)(((int)g + 0xb4)) += 1;
                                 if (*(int *)(g + 0xb4) > *(int *)(g + 0xb8))
                                     *(int *)(g + 0xb8) = *(int *)(g + 0xb4);
                             }
@@ -114,7 +114,7 @@ int dScMgMCarlo_c_Behavior(void* arg)
                         }
                         c[0xc3] = 0;
                         {
-                            s16* p = (s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF);
+                            s16* p = (s16*)(((int)c + 0x60a8));
                             (*p)++;
                         }
                     }

--- a/src/func_ov006_020f8a3c.c
+++ b/src/func_ov006_020f8a3c.c
@@ -25,7 +25,7 @@ int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
     switch (self->unk_60a8) {
     case 4:
         FreeGfxSlotsById(0x1d);
-        *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(s16*)(((int)c + 0x60a8)) += 1;
         break;
     case 5:
         if (func_ov006_020c1718(c + 0x4f38) != 0) {
@@ -37,7 +37,7 @@ int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
                 func_ov004_020b56c8(data_ov006_0213d568);
             }
             self->unk_60ae = 0;
-            *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(s16*)(((int)c + 0x60a8)) += 1;
         }
         break;
     case 6: {
@@ -55,11 +55,11 @@ int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
                     r3 = *(char**)(r3 + 4);
                 }
                 if (r3 != 0) *(u8*)(r3 + 0x2e) = 0;
-                *(s16*)(((int)c + 0x60ae) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(s16*)(((int)c + 0x60ae)) += 1;
             }
         } else {
             if (data_ov004_020bf9e4 <= 1)
-                *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(s16*)(((int)c + 0x60a8)) += 1;
         }
         break;
     }
@@ -69,7 +69,7 @@ int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
             return 1;
         func_ov006_020f7994();
         self->unk_60aa = 0x1e;
-        *(s16*)(((int)c + 0x60a8) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(s16*)(((int)c + 0x60a8)) += 1;
         break;
     }
     case 8:

--- a/src/func_ov006_020f9994.c
+++ b/src/func_ov006_020f9994.c
@@ -18,7 +18,7 @@ void func_ov006_020f9994(char *c, int b)
     switch (*(unsigned char *)(c + 0x2d)) {
     case 0:
         {
-            short *p = (short *)(((long long)(int)(c + 0x28)) & 0xffffffffffffffffLL);
+            short *p = (short *)(((long long)(int)(c + 0x28)));
             short v = *(short *)p;
             *(short *)p = (short)(v - 1);
         }

--- a/src/func_ov006_020fa13c.c
+++ b/src/func_ov006_020fa13c.c
@@ -17,7 +17,7 @@ int dScMgMCarlo2_c_Behavior(void* arg)
     switch (*(s16*)(c + 0x5928)) {
     case 1:
         {
-            s16* p = (s16*)(((int)c + 0x5928) & 0xFFFFFFFFFFFFFFFF);
+            s16* p = (s16*)(((int)c + 0x5928));
             (*p)++;
         }
         if (c[0xc4] == 0) {
@@ -32,7 +32,7 @@ int dScMgMCarlo2_c_Behavior(void* arg)
             if (func_ov006_020f9668() == 0) {
                 *(s16*)(c + 0x592e) = 0;
                 {
-                    s16* p = (s16*)(((int)c + 0x5928) & 0xFFFFFFFFFFFFFFFF);
+                    s16* p = (s16*)(((int)c + 0x5928));
                     (*p)++;
                 }
             }
@@ -72,7 +72,7 @@ int dScMgMCarlo2_c_Behavior(void* arg)
                             func_ov004_020b0a54(0x12);
                             c[0xc3] = 0;
                             {
-                                s16* p = (s16*)(((int)c + 0x5928) & 0xFFFFFFFFFFFFFFFF);
+                                s16* p = (s16*)(((int)c + 0x5928));
                                 (*p)++;
                             }
                         }

--- a/src/func_ov006_020fa844.c
+++ b/src/func_ov006_020fa844.c
@@ -3,7 +3,7 @@ typedef unsigned short u16;
 typedef signed short s16;
 typedef int s32;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern s32 data_ov006_0212eb44[];
 

--- a/src/func_ov006_020fb670.c
+++ b/src/func_ov006_020fb670.c
@@ -31,6 +31,6 @@ void func_ov006_020fb670(char *obj)
     r = (((unsigned int) RandomIntInternal(&data_0209d4b8)) >> 16) & 0x7fff;
     *((short *) ((obj + 0x5b00) + 0xc4)) = (short) ((((r << 5) >> 15) << 2) + 0x200);
   }
-  unsigned char *bp = (unsigned char *) (((int) obj + 0x5c34) & 0xFFFFFFFFFFFFFFFF);
+  unsigned char *bp = (unsigned char *) (((int) obj + 0x5c34));
   *bp = *bp + 1;
 }

--- a/src/func_ov006_020fbad4.c
+++ b/src/func_ov006_020fbad4.c
@@ -8,7 +8,7 @@ void func_ov006_020fbad4(char *c)
     unsigned short v = *((unsigned short *) (r2 + 0xfa));
     if (v != 0)
     {
-      unsigned short *p = (unsigned short *) (((long long) ((int) (c + 0x4cfa))) & 0xFFFFFFFFFFFFFFFFLL);
+      unsigned short *p = (unsigned short *) (((long long) ((int) (c + 0x4cfa))));
       *p = (*p) - 1;
       if ((*((short *) ((c + 0x4c00) + 0xfa))) < 0)
       {

--- a/src/func_ov006_020fbd38.c
+++ b/src/func_ov006_020fbd38.c
@@ -7,7 +7,7 @@ extern void func_ov006_020fbcb8(void *self, int x, int y, int k);
 
 #pragma opt_common_subs off
 #pragma opt_loop_invariants off
-#define AC (*(int *)(((long long)((int)a + 0x5c14)) & 0xffffffffffffffffLL))
+#define AC (*(int *)(((long long)((int)a + 0x5c14))))
 
 void func_ov006_020fbd38(void *arg0)
 {

--- a/src/func_ov006_020fe2bc.c
+++ b/src/func_ov006_020fe2bc.c
@@ -1,5 +1,5 @@
 void func_ov006_020fe2bc(char *c)
 {
     if (*(unsigned char *)(c + 0x5000 + 0xc32) == 0)
-        *(unsigned char *)(((long long)(int)(c + 0x5c32)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+        *(unsigned char *)(((long long)(int)(c + 0x5c32))) += 1;
 }

--- a/src/func_ov006_020fee24.c
+++ b/src/func_ov006_020fee24.c
@@ -42,7 +42,7 @@ s32 func_ov006_020fee24(char *c)
         }
         if (*(u16 *)(c + 0x5c2a) != 0) {
             func_ov006_020fb7e0(c);
-            (*(u16 *)(((long long)(int)(c + 0x5c2a)) & 0xffffffffffffffffLL))--;
+            (*(u16 *)(((long long)(int)(c + 0x5c2a))))--;
         } else {
             func_ov006_020fdd40(c);
             func_ov006_020fe2bc(c);
@@ -59,7 +59,7 @@ s32 func_ov006_020fee24(char *c)
         break;
     case 2:
         if (*(u16 *)(c + 0x5c18) != 0) {
-            (*(u16 *)(((long long)(int)(c + 0x5c18)) & 0xffffffffffffffffLL))--;
+            (*(u16 *)(((long long)(int)(c + 0x5c18))))--;
             if (*(s16 *)(c + 0x5c18) <= 0) {
                 func_ov004_020b0a54((void *)0x10);
                 *(u8 *)(c + 0xc3) = 0;

--- a/src/func_ov006_021001ac.c
+++ b/src/func_ov006_021001ac.c
@@ -7,14 +7,14 @@ void func_ov006_021001ac(char* p)
     for (i = 0; i < 0x10; i++, p += 0x18) {
         if (*(u8*)(p + 0x54b4) != 0) {
             if (*(u8*)(p + 0x54b7) == 0) {
-                *(int*)(((int)p + 0x54a4) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(p + 0x54a8);
-                *(int*)(((int)p + 0x54a8) & 0xFFFFFFFFFFFFFFFFLL) -= 0x200;
+                *(int*)(((int)p + 0x54a4)) += *(int*)(p + 0x54a8);
+                *(int*)(((int)p + 0x54a8)) -= 0x200;
                 if (*(u16*)(p + 0x54b0) == 0x30) {
-                    *(u8*)(((int)p + 0x54b7) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                    *(u8*)(((int)p + 0x54b7)) += 1;
                 }
             }
             if (*(u16*)(p + 0x54b0) != 0) {
-                *(u16*)(((int)p + 0x54b0) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(u16*)(((int)p + 0x54b0)) -= 1;
             } else {
                 *(u8*)(p + 0x54b5) = 0;
                 *(u8*)(p + 0x54b4) = 0;

--- a/src/func_ov006_02100380.c
+++ b/src/func_ov006_02100380.c
@@ -19,10 +19,10 @@ void func_ov006_02100380(char* c)
     for (i = 0; i < 16; i++, c += 0x18) {
         if (((View*)c)->active == 0)
             continue;
-        (*(u16*)((long long)(int)(c + 0x5330) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u16*)((long long)(int)(c + 0x5330)))++;
         if (((View*)c)->timer < 8)
             continue;
-        (*(u8*)((long long)(int)(c + 0x5335) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)((long long)(int)(c + 0x5335)))++;
         if (((View*)c)->stage >= 4) {
             ((View*)c)->active = 0;
             ((View*)c)->stage = 0;

--- a/src/func_ov006_0210265c.c
+++ b/src/func_ov006_0210265c.c
@@ -6,11 +6,11 @@ void func_ov006_0210265c(char *c)
     unsigned short *h;
     unsigned short t;
     if (*(unsigned short *)(c + 0x5674) == 0) return;
-    q = (unsigned char *)(((int)c + 0x5679) & 0xFFFFFFFFFFFFFFFF);
+    q = (unsigned char *)(((int)c + 0x5679));
     *q += 1;
     if (*(unsigned char *)(c + 0x5679) < 0x3c) return;
     *(unsigned char *)(c + 0x5679) = 0;
-    h = (unsigned short *)(((int)c + 0x5674) & 0xFFFFFFFFFFFFFFFF);
+    h = (unsigned short *)(((int)c + 0x5674));
     *h -= 1;
     t = *(unsigned short *)(c + 0x5674);
     if (t > 0xa)

--- a/src/func_ov006_02102864.c
+++ b/src/func_ov006_02102864.c
@@ -2,14 +2,14 @@ extern unsigned _ZN3G2S13GetBG2CharPtrEv(void);
 extern void MultiStore16(unsigned short val, char *dst, int nbytes);
 extern void func_ov006_021027e4(char *c, int x, int y, int layer);
 
-#define LA(p) (*(int *)((((int)(p)) + 0x5664) & 0xFFFFFFFFFFFFFFFF))
-#define LB(p) (*(int *)((((unsigned int)(p)) + 0x5664) & 0xFFFFFFFFFFFFFFFF))
-#define LC(p) (*(int *)(((int)((p) + 0x5664)) & 0xFFFFFFFFFFFFFFFF))
-#define LD(p) (*(int *)(((unsigned int)((p) + 0x5664)) & 0xFFFFFFFFFFFFFFFF))
-#define LE(p) (*(int *)(((long long)((int)(p) + 0x5664)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LF(p) (*(int *)(((long long)((unsigned int)(p) + 0x5664)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LG(p) (*(int *)(((unsigned long long)((int)(p) + 0x5664)) & 0xFFFFFFFFFFFFFFFFLL))
-#define LH(p) (*(int *)(((unsigned long long)((unsigned int)(p) + 0x5664)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) (*(int *)((((int)(p)) + 0x5664)))
+#define LB(p) (*(int *)((((unsigned int)(p)) + 0x5664)))
+#define LC(p) (*(int *)(((int)((p) + 0x5664))))
+#define LD(p) (*(int *)(((unsigned int)((p) + 0x5664))))
+#define LE(p) (*(int *)(((long long)((int)(p) + 0x5664))))
+#define LF(p) (*(int *)(((long long)((unsigned int)(p) + 0x5664))))
+#define LG(p) (*(int *)(((unsigned long long)((int)(p) + 0x5664))))
+#define LH(p) (*(int *)(((unsigned long long)((unsigned int)(p) + 0x5664))))
 
 #pragma opt_loop_invariants off
 #pragma opt_dead_assignments off
@@ -44,7 +44,7 @@ void func_ov006_02102864(char *c)
         tmp = 0;
         MultiStore16(tmp, dst, 0x6000);
 
-        i2 = (int)((long long)idx & 0xFFFFFFFFFFFFFFFFLL);
+        i2 = (int)((long long)idx);
         p1 = (int *)(c + i2 * 0x40 + 0x4660);
         p2 = (int *)(c + i2 * 0x40 + 0x4664);
         k = 0;
@@ -134,7 +134,7 @@ void func_ov006_02102864(char *c)
         } while (k < 2);
     }
     {
-        int i3 = (int)((unsigned long long)idx & 0xFFFFFFFFFFFFFFFFLL);
+        int i3 = (int)((unsigned long long)idx);
         *(int *)(c + i3 * 0x40 + 0x4000 + 0x678) = *(int *)(c + i3 * 0x40 + 0x4000 + 0x660);
         *(int *)(c + i3 * 0x40 + 0x4000 + 0x67c) = *(int *)(c + i3 * 0x40 + 0x4000 + 0x664);
     }

--- a/src/func_ov006_02102ef4.c
+++ b/src/func_ov006_02102ef4.c
@@ -4,7 +4,7 @@ void func_ov006_02102ef4(unsigned char *r0) {
     r0[0x5679] = 0;
     r0[0x567a] = 1;
     {
-        unsigned char *p = (unsigned char *)(((long long)(int)(r0 + 0x5678)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char *)(((long long)(int)(r0 + 0x5678)));
         *p += 1;
     }
 }

--- a/src/func_ov006_02103608.c
+++ b/src/func_ov006_02103608.c
@@ -9,11 +9,11 @@ extern void func_ov006_02102d6c(char *o, int i);
 void func_ov006_02103608(char *o, int i)
 {
     int v660, v664, t660;
-    *(int *)((char *)(((int)o + 0x4660) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) += *(int *)(o + i * 0x40 + 0x4668);
-    *(int *)((char *)(((int)o + 0x4664) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) += *(int *)(o + i * 0x40 + 0x466c);
-    *(int *)((char *)(((int)o + 0x4684) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) += 0x20;
-    *(int *)((char *)(((int)o + 0x466c) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) += *(int *)(o + i * 0x40 + 0x4684);
-    *(u16 *)((char *)(((int)o + 0x4690) & 0xFFFFFFFFFFFFFFFF) + i * 0x40) += *(u16 *)(o + i * 0x40 + 0x4692);
+    *(int *)((char *)(((int)o + 0x4660)) + i * 0x40) += *(int *)(o + i * 0x40 + 0x4668);
+    *(int *)((char *)(((int)o + 0x4664)) + i * 0x40) += *(int *)(o + i * 0x40 + 0x466c);
+    *(int *)((char *)(((int)o + 0x4684)) + i * 0x40) += 0x20;
+    *(int *)((char *)(((int)o + 0x466c)) + i * 0x40) += *(int *)(o + i * 0x40 + 0x4684);
+    *(u16 *)((char *)(((int)o + 0x4690)) + i * 0x40) += *(u16 *)(o + i * 0x40 + 0x4692);
     if (*(int *)(o + i * 0x40 + 0x466c) >= 0x8000)
         *(int *)(o + i * 0x40 + 0x466c) = 0x8000;
     t660 = *(int *)(o + i * 0x40 + 0x4664);

--- a/src/func_ov006_02104354.c
+++ b/src/func_ov006_02104354.c
@@ -8,17 +8,17 @@ void func_ov006_02104354(char *q)
     for (i = 0; i < 0x40; i++, q += 0x18) {
         if (*(u8 *)(q + 0x46b8) != 0) {
             if (*(u8 *)(q + 0x46b9) == 0) {
-                *(int *)(((int)q + 0x46a8) & 0xFFFFFFFFFFFFFFFF) += *(int *)(q + 0x46b0);
-                *(int *)(((int)q + 0x46ac) & 0xFFFFFFFFFFFFFFFF) += *(int *)(q + 0x46b4);
-                *(int *)(((int)q + 0x46b4) & 0xFFFFFFFFFFFFFFFF) -= 0x300;
+                *(int *)(((int)q + 0x46a8)) += *(int *)(q + 0x46b0);
+                *(int *)(((int)q + 0x46ac)) += *(int *)(q + 0x46b4);
+                *(int *)(((int)q + 0x46b4)) -= 0x300;
                 if (*(int *)(q + 0x46b0) > 0)
-                    *(int *)(((int)q + 0x46b0) & 0xFFFFFFFFFFFFFFFF) += 0xc00;
+                    *(int *)(((int)q + 0x46b0)) += 0xc00;
                 else
-                    *(int *)(((int)q + 0x46b0) & 0xFFFFFFFFFFFFFFFF) -= 0xc00;
+                    *(int *)(((int)q + 0x46b0)) -= 0xc00;
             }
-            *(u8 *)(((int)q + 0x46bc) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)q + 0x46bc)) += 1;
             if (*(u8 *)(q + 0x46bc) >= 4) {
-                *(u8 *)(((int)q + 0x46bb) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(u8 *)(((int)q + 0x46bb)) += 1;
                 if (*(u8 *)(q + 0x46bb) >= 5) {
                     *(u8 *)(q + 0x46b8) = 0;
                     *(u8 *)(q + 0x46bd) = 0;

--- a/src/func_ov006_0210446c.c
+++ b/src/func_ov006_0210446c.c
@@ -19,11 +19,11 @@ void func_ov006_0210446c(char *o, int a1, int a2, int a3)
             *(u8 *)(o + off + 0x46ba) = 0;
             *(u8 *)(o + off + 0x46bb) = 0;
             *(u8 *)(o + off + 0x46b9) = a3;
-            *(int *)((char *)(((int)o + 0x46b0) & 0xFFFFFFFFFFFFFFFF) + off) = 0;
+            *(int *)((char *)(((int)o + 0x46b0)) + off) = 0;
             *(int *)(o + off + 0x46b4) = 0;
             *(int *)(o + off + 0x46a8) = a1;
             *(int *)(o + off + 0x46ac) = a2;
-            w = (int *)((char *)(((int)o + 0x46b0) & 0xFFFFFFFFFFFFFFFF) + off);
+            w = (int *)((char *)(((int)o + 0x46b0)) + off);
             if (a3 != 0) {
                 *(u8 *)(o + off + 0x46be) = 0;
             } else {

--- a/src/func_ov006_02104580.c
+++ b/src/func_ov006_02104580.c
@@ -17,14 +17,14 @@ void func_ov006_02104580(char *o)
     u32 r2;
 
     if (*(u8 *)(o + 0x46a5) == 0) {
-        *(u8 *)(((int)o + 0x46a6) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)o + 0x46a6)) += 1;
         if (((*(u8 *)(o + 0x46a6) >> 1) & 1) != 0)
             *(int *)(o + 0x4694) = 0x2000;
         else
             *(int *)(o + 0x4694) = -0x2000;
 
         if (*(u8 *)(o + 0x46a7) != 0) {
-            *(u8 *)(((int)o + 0x46a7) & 0xFFFFFFFFFFFFFFFF) -= 1;
+            *(u8 *)(((int)o + 0x46a7)) -= 1;
         } else {
             r = ((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff;
             x = ((r * 7) >> 15) * 5;
@@ -41,20 +41,20 @@ void func_ov006_02104580(char *o)
         }
 
         if (*(u8 *)(o + 0x46a6) >= 0x3c) {
-            *(u8 *)(((int)o + 0x46a5) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8 *)(((int)o + 0x46a5)) += 1;
             *(u8 *)(o + 0x46a6) = 0;
             *(u8 *)(o + 0x46a7) = 0;
             *(int *)(o + 0x4694) = 0;
             *(int *)(o + 0x46a0) = 0x1000;
         }
     } else if (*(int *)(o + 0x4698) < 0x200000) {
-        *(int *)(((int)o + 0x4698) & 0xFFFFFFFFFFFFFFFF) += *(int *)(o + 0x46a0);
-        *(int *)(((int)o + 0x46a0) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+        *(int *)(((int)o + 0x4698)) += *(int *)(o + 0x46a0);
+        *(int *)(((int)o + 0x46a0)) += 0x200;
         if (*(int *)(o + 0x4698) >= 0x200000)
             *(int *)(o + 0x4698) = 0x200000;
 
         if (*(u8 *)(o + 0x46a7) != 0) {
-            *(u8 *)(((int)o + 0x46a7) & 0xFFFFFFFFFFFFFFFF) -= 1;
+            *(u8 *)(((int)o + 0x46a7)) -= 1;
         } else {
             y = *(int *)(o + 0x4698) >> 12;
             if (y >= 0 && y <= 0xc0)

--- a/src/func_ov006_02104920.c
+++ b/src/func_ov006_02104920.c
@@ -17,7 +17,7 @@ void func_ov006_02104920(char *c, int idx)
         SetSubBg0Offset(0, 0);
         data_0209d454 &= ~1;
         func_02012790(0x12f);
-        *(unsigned char *)(((int)c + 0x4fe2) & 0xffffffffffffffff) -= 1;
+        *(unsigned char *)(((int)c + 0x4fe2)) -= 1;
         return;
     }
     *(int *)(c + 0x468c + n) = data_ov006_0212ed00[cnt >> 3];

--- a/src/func_ov006_02104bb0.c
+++ b/src/func_ov006_02104bb0.c
@@ -2,7 +2,7 @@
 void func_ov006_02104bb0(char *c)
 {
   char *base;
-  unsigned short *p = (unsigned short *) (((long long) ((int) (c + 0x4682))) & 0xFFFFFFFFFFFFFFFFLL);
+  unsigned short *p = (unsigned short *) (((long long) ((int) (c + 0x4682))));
   *p = (*p) + 1;
   if ((*((unsigned short *) ((c + 0x4600) + 0x82))) < 8)
   {
@@ -10,7 +10,7 @@ void func_ov006_02104bb0(char *c)
   }
   *((unsigned short *) ((c + 0x4600) + 0x82)) = 0;
   {
-    int *q = (int *) (((long long) ((int) (c + 0x467c))) & 0xFFFFFFFFFFFFFFFFLL);
+    int *q = (int *) (((long long) ((int) (c + 0x467c))));
     *q = (*q) + 0x4000;
   }
   *((unsigned char *) (c + 0x4686)) = 2;

--- a/src/func_ov006_02104c08.c
+++ b/src/func_ov006_02104c08.c
@@ -1,10 +1,10 @@
 void func_ov006_02104c08(char* c) {
-  unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x4682)) & 0xFFFFFFFFFFFFFFFFLL);
+  unsigned short* h = (unsigned short*)(((long long)(int)(c + 0x4682)));
   *h = *h + 1;
   if (*(unsigned short*)(c + 0x4600 + 0x82) < 4) return;
   *(unsigned short*)(c + 0x4600 + 0x82) = 0;
   {
-    int* w = (int*)(((long long)(int)(c + 0x467c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int* w = (int*)(((long long)(int)(c + 0x467c)));
     *w = *w - 0x4000;
   }
   *(unsigned char*)(c + 0x4000 + 0x686) = 1;

--- a/src/func_ov006_02104c60.cpp
+++ b/src/func_ov006_02104c60.cpp
@@ -10,7 +10,7 @@ void func_ov006_02104c60(char *c)
 {
     unsigned short *ip;
     if (*(u8*)(c + 0x4000 + 0x684) == 0) return;
-    ip = (unsigned short*)(((int)c + 0x4680) & 0xFFFFFFFFFFFFFFFFLL);
+    ip = (unsigned short*)(((int)c + 0x4680));
     *ip = *ip - 1;
     if (*(short*)(c + 0x4600 + 0x80) <= 0) {
         *(short*)(c + 0x4600 + 0x80) = 0;

--- a/src/func_ov006_02104e80.c
+++ b/src/func_ov006_02104e80.c
@@ -4,5 +4,5 @@
 void func_ov006_02104e80(char *self)
 {
     if (*(unsigned char *)(self + 0x4677))
-        *(unsigned char *)(((long long)(int)(self + 0x4677)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(unsigned char *)(((long long)(int)(self + 0x4677))) -= 1;
 }

--- a/src/func_ov006_02104ecc.cpp
+++ b/src/func_ov006_02104ecc.cpp
@@ -5,12 +5,12 @@ extern "C" void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 
 extern "C" void func_ov006_02104ecc(char* c)
 {
-    int* a = (int*)(((int)c + 0x4660) & 0xFFFFFFFFFFFFFFFF);
+    int* a = (int*)(((int)c + 0x4660));
     *a += *(int*)(c + 0x4668);
-    int* b = (int*)(((int)c + 0x4668) & 0xFFFFFFFFFFFFFFFF);
+    int* b = (int*)(((int)c + 0x4668));
     *b -= 0x400;
     if ((*(int*)(c + 0x4660) >> 12) > -0x40) return;
-    int* e = (int*)(((int)c + 0x4cac) & 0xFFFFFFFFFFFFFFFF);
+    int* e = (int*)(((int)c + 0x4cac));
     (*e)++;
     *(unsigned char*)(c + 0x4675) = 4;
     *(int*)(c + 0x4660) = 0x10000;

--- a/src/func_ov006_02104fb4.c
+++ b/src/func_ov006_02104fb4.c
@@ -1,7 +1,7 @@
 void func_ov006_02104fb4(unsigned char* c){
   unsigned char* slot = c + 0x4600;
   if(*(unsigned short*)(slot + 0x70) != 0){
-    unsigned short* p = (unsigned short*)((long long)(int)(c + 0x4670) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short* p = (unsigned short*)((long long)(int)(c + 0x4670));
     *p = *p - 1;
     if(*(short*)(slot + 0x70) < 0) *(unsigned short*)(slot + 0x70) = 0;
   } else {

--- a/src/func_ov006_0210500c.c
+++ b/src/func_ov006_0210500c.c
@@ -1,7 +1,7 @@
 void func_ov006_0210500c(char *c)
 {
-    *(int *)(((int)c + 0x4660) & 0xFFFFFFFFFFFFFFFF) += *(int *)(c + 0x4668);
-    *(int *)(((int)c + 0x4668) & 0xFFFFFFFFFFFFFFFF) -= 0x400;
+    *(int *)(((int)c + 0x4660)) += *(int *)(c + 0x4668);
+    *(int *)(((int)c + 0x4668)) -= 0x400;
     if (*(int *)(c + 0x4660) >> 12 > 0x58) return;
     *(int *)(c + 0x4660) = 0x58000;
     *(unsigned char *)(c + 0x4675) = 2;

--- a/src/func_ov006_021051dc.c
+++ b/src/func_ov006_021051dc.c
@@ -16,8 +16,7 @@ void func_ov006_021051dc(char *c)
     int x;
 
     if (*(u16 *)(c + 0x4ec4) != 0) {
-        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4)) &
-                       0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4))))--;
         if (*(s16 *)(c + 0x4ec4) < 0)
             *(u16 *)(c + 0x4ec4) = 0;
         return;
@@ -53,8 +52,7 @@ void func_ov006_021051dc(char *c)
             int cell = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
 
             *(u8 *)(c + cell + 0x4efa) = 1;
-            (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)) &
-                          0xFFFFFFFFFFFFFFFFLL)) ^= 1;
+            (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)))) ^= 1;
             *(u16 *)(c + cell * 2 + 0x4e78) = 8;
         }
     }
@@ -62,6 +60,5 @@ void func_ov006_021051dc(char *c)
     func_ov006_02104cfc(c, idx);
     *(u16 *)(c + idx * 2 + 0x4e78) = 0;
     *(u16 *)(c + 0x4ec4) = 0x30;
-    (*(u8 *)(int)(((long long)(int)(c + 0x4fe5)) &
-                  0xFFFFFFFFFFFFFFFFLL))++;
+    (*(u8 *)(int)(((long long)(int)(c + 0x4fe5))))++;
 }

--- a/src/func_ov006_02105670.c
+++ b/src/func_ov006_02105670.c
@@ -2,7 +2,7 @@ void func_ov006_02105670(char *p)
 {
     if (((unsigned short *)(p + 0x4e00))[0x62] != 0)
     {
-        (*(unsigned short *)(((long long)(int)(p + 0x4ec4)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(unsigned short *)(((long long)(int)(p + 0x4ec4))))--;
         if (((short *)(p + 0x4e00))[0x62] < 0)
         {
             ((short *)(p + 0x4e00))[0x62] = 0;
@@ -15,7 +15,7 @@ void func_ov006_02105670(char *p)
         for (k = 0; k < *(int *)(p + 0x4cb8); k++)
         {
             *(unsigned char *)(p + k + 0x4efa) = 1;
-            *(unsigned char *)(((long long)(int)(p + k + 0x4f1e)) & 0xFFFFFFFFFFFFFFFFLL) ^= 1;
+            *(unsigned char *)(((long long)(int)(p + k + 0x4f1e))) ^= 1;
             *(unsigned char *)(p + k + 0x4f8a) = 1;
         }
         *(unsigned char *)(p + 0x4fe0) = 2;

--- a/src/func_ov006_02105854.c
+++ b/src/func_ov006_02105854.c
@@ -9,7 +9,7 @@ extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 void func_ov006_02105854(char *c)
 {
     if (*(u16 *)(c + 0x4ec4) != 0) {
-        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4)) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16 *)(int)(((long long)(int)(c + 0x4ec4))))--;
         if (*(s16 *)(c + 0x4ec4) < 0)
             *(u16 *)(c + 0x4ec4) = 0;
         return;
@@ -37,7 +37,7 @@ void func_ov006_02105854(char *c)
         return;
     }
 
-    (*(u8 *)(int)(((long long)(int)(c + 0x4fe4)) & 0xFFFFFFFFFFFFFFFFLL))--;
+    (*(u8 *)(int)(((long long)(int)(c + 0x4fe4))))--;
 
     if (*(u8 *)(c + 0x4fe4) == 0xff) {
         *(u8 *)(c + 0x4fe4) = 0;
@@ -72,7 +72,7 @@ void func_ov006_02105854(char *c)
             for (x = x0; x < wq; x++) {
                 int cell = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
                 *(u8 *)(c + cell + 0x4efa) = 1;
-                (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)) & 0xFFFFFFFFFFFFFFFFLL)) ^= 1;
+                (*(u8 *)(int)(((long long)(int)(c + cell + 0x4f1e)))) ^= 1;
                 *(u16 *)(c + cell * 2 + 0x4e78) = 8;
                 *(u8 *)(c + cell + 0x4f8a) = 1;
             }

--- a/src/func_ov006_02105c1c.c
+++ b/src/func_ov006_02105c1c.c
@@ -6,7 +6,7 @@ void func_ov006_02105c1c(char *base)
     do {
         if (*(unsigned char *)(base + i + 0x4f1e) != *(unsigned char *)(base + i + 0x4f42)) {
             *(unsigned char *)(base + i + 0x4efa) = 2;
-            *(unsigned short *)(base + (int)(((long long)i) & 0xFFFFFFFFFFFFFFFFLL) * 2 + 0x4e30) = 0;
+            *(unsigned short *)(base + (int)(((long long)i)) * 2 + 0x4e30) = 0;
         }
         i++;
     } while (i < *(int *)(base + 0x4cb8));

--- a/src/func_ov006_02105d20.c
+++ b/src/func_ov006_02105d20.c
@@ -7,9 +7,9 @@ void func_ov006_02105d20(char *c) {
     int tmp;
     if (*(unsigned char *)(c + 0x4fe9) == 0) return;
     if (*(unsigned char *)(c + 0x4feb) == 0) return;
-    tmp = *(volatile unsigned char *)(int *)(((int)c + 0x4feb) & 0xFFFFFFFFFFFFFFFF);
+    tmp = *(volatile unsigned char *)(int *)(((int)c + 0x4feb));
     --tmp;
-    *(volatile unsigned char *)(int *)(((int)c + 0x4feb) & 0xFFFFFFFFFFFFFFFF) = tmp;
+    *(volatile unsigned char *)(int *)(((int)c + 0x4feb)) = tmp;
     if (*(unsigned char *)(c + 0x4feb) != 0) return;
     found = 0;
     i = 0;

--- a/src/func_ov006_02105de4.c
+++ b/src/func_ov006_02105de4.c
@@ -60,7 +60,7 @@ void func_ov006_02105de4(char *c)
             int w, col, row;
 
             *(u8 *)(c + *(u8 *)(c + 0x4fe4) + 0x4fce) = i;
-            (*(u8 *)(int)(((long long)(int)(c + 0x4fe4)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8 *)(int)(((long long)(int)(c + 0x4fe4))))++;
             w = *(int *)(c + 0x4cbc);
             col = i % w;
             row = i / w;
@@ -83,7 +83,7 @@ void func_ov006_02105de4(char *c)
                     for (x = x0; x < wq; x++) {
                         int idx = *(int *)(c + 0x4cbc) * (row + y) + (col + x);
                         *(u8 *)(c + idx + 0x4efa) = 1;
-                        (*(u8 *)(int)(((long long)(int)(c + idx + 0x4f1e)) & 0xFFFFFFFFFFFFFFFFLL)) ^= 1;
+                        (*(u8 *)(int)(((long long)(int)(c + idx + 0x4f1e)))) ^= 1;
                         *(u16 *)(c + idx * 2 + 0x4e78) = 8;
                     }
                 }
@@ -91,7 +91,7 @@ void func_ov006_02105de4(char *c)
 
             *(u16 *)(c + i * 2 + 0x4e78) = 0;
             *(u8 *)(c + 0x4feb) = 0x28;
-            (*(u8 *)(int)(((long long)(int)(c + 0x4fe1)) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8 *)(int)(((long long)(int)(c + 0x4fe1))))++;
             _ZN5Sound12PlayBank2_2DEj(0x1fa);
             func_ov006_02104e80(c);
             return;

--- a/src/func_ov006_02106080.c
+++ b/src/func_ov006_02106080.c
@@ -16,7 +16,7 @@ void func_ov006_02106080(char* self, int x)
     int i, j;
     for (i = 0; i < n2; i++) {
         for (j = 0; j < n1; j++) {
-            unsigned char* p = (unsigned char*)((((int)self + ((*(int*)(self + 0x4cbc)) * (b + i) + (a + j))) + 0x4f1e) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char* p = (unsigned char*)((((int)self + ((*(int*)(self + 0x4cbc)) * (b + i) + (a + j))) + 0x4f1e));
             *p ^= 1;
         }
     }

--- a/src/func_ov006_021063a0.cpp
+++ b/src/func_ov006_021063a0.cpp
@@ -2,7 +2,7 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 #define RND ((((u32)RandomIntInternal(&data_0209d4b8)) >> 16) & 0x7fff)
 
 struct O

--- a/src/func_ov006_02106a08.c
+++ b/src/func_ov006_02106a08.c
@@ -1,20 +1,20 @@
 void func_ov006_02106a08(char *p, int idx)
 {
-    unsigned short *c = (unsigned short *)(int)(((long long)(int)(p + 0x4e30)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short *c = (unsigned short *)(int)(((long long)(int)(p + 0x4e30)));
     unsigned char *q;
     c[idx] = c[idx] + 1;
     if ((((int)*(unsigned short *)(p + idx * 2 + 0x4e30) >> 3) & 1) != 0)
     {
-        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)) & 0xFFFFFFFFFFFFFFFFLL);
+        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)));
         q[idx] = 1;
     }
     else
     {
-        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)) & 0xFFFFFFFFFFFFFFFFLL);
+        q = (unsigned char *)(int)(((long long)(int)(p + 0x4f66)));
         q[idx] = 0;
     }
     {
-        int idxL = (int)(((long long)idx) & 0xFFFFFFFFFFFFFFFFLL);
+        int idxL = (int)(((long long)idx));
         char *b = p + idxL * 2;
         b += 0x4e00;
         if (((unsigned short *)b)[0x18] < 0x40)

--- a/src/func_ov006_02106bc0.c
+++ b/src/func_ov006_02106bc0.c
@@ -22,7 +22,7 @@ void func_ov006_02106bc0(char *c) {
         fn(thisp, i);
     }
     if (*(unsigned short *)(c + 0x4ec0) == 0) return;
-    *(unsigned short *)(((long long)(int)(c + 0x4ec0)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(unsigned short *)(((long long)(int)(c + 0x4ec0))) -= 1;
     if (*(short *)(c + 0x4ec0) > 0) return;
     *(unsigned short *)(c + 0x4ec0) = 0;
     func_ov004_020b0a54(0x12);

--- a/src/func_ov006_0210713c.cpp
+++ b/src/func_ov006_0210713c.cpp
@@ -8,10 +8,10 @@ void func_ov006_0210713c(char* c) {
     *(unsigned char*)(c + 0x4fe8) = 2;
     return;
   }
-  *(unsigned char*)(((int)c + 0x4fe7) & 0xFFFFFFFFFFFFFFFF) += 1;
+  *(unsigned char*)(((int)c + 0x4fe7)) += 1;
   if (*(unsigned char*)(c + 0x4fe7) >= 8) {
     *(unsigned char*)(c + 0x4fe7) = 0;
-    *(unsigned char*)(((int)c + 0x4fe8) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(unsigned char*)(((int)c + 0x4fe8)) -= 1;
   }
   if (*(unsigned char*)(c + 0x4fe8) == 0)
     *(int*)(c + 0x4ca8) = 2;

--- a/src/func_ov006_021071fc.c
+++ b/src/func_ov006_021071fc.c
@@ -17,7 +17,7 @@ void dScMgPanel_c_OnYoshiTryEat_021071fc(char *self, int flag)
     char *p;
 
     if (flag == 0) {
-        int *q = (int *)(((int)self + 0xbc) & 0xFFFFFFFFFFFFFFFF);
+        int *q = (int *)(((int)self + 0xbc));
         *q += 1;
         if (*(unsigned int *)(self + 0xbc) > 0x270e)
             *(int *)(self + 0xbc) = 0x270e;

--- a/src/func_ov006_02107d20.c
+++ b/src/func_ov006_02107d20.c
@@ -1,7 +1,7 @@
 void func_ov006_02107d20(int *p, int val)
 {
     int i;
-    *(short *)(((long long)(int)((char *)p + 0x16)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(short *)(((long long)(int)((char *)p + 0x16))) += 1;
     for (i = 0; i < 5; i++) {
         if (p[i] == 0) {
             p[i] = val;

--- a/src/func_ov006_02107db8.cpp
+++ b/src/func_ov006_02107db8.cpp
@@ -29,7 +29,7 @@ struct C {
 extern "C" void func_ov006_02107db8(C *c)
 {
     char *b = (char *)c;
-    short *p = (short *)(((int)b + 0xc2) & 0xFFFFFFFFFFFFFFFF);
+    short *p = (short *)(((int)b + 0xc2));
     *p = (short)(*p + *(short *)(b + 0xc8));
     *(short *)(*(int *)(b + 0x20) + 0x82) = (short)(-*(short *)(b + 0xc2));
     c->obj.v3();

--- a/src/func_ov006_02107ea8.c
+++ b/src/func_ov006_02107ea8.c
@@ -34,11 +34,11 @@ void func_ov006_02107ea8(char *self)
         (int)((((long long)(*(int *)(self + 0xb8)) * 0x500) + 0x800) >> 12),
         *(int *)(self + 0xb0));
 
-    *(short *)(((int)self + 0xc0) & 0xFFFFFFFFFFFFFFFF) += *(short *)(self + 0xc6);
+    *(short *)(((int)self + 0xc0)) += *(short *)(self + 0xc6);
 
     *(int *)(self + 0xb4) = (int)((((long long)(*(int *)(self + 0xb4)) * 0x600) + 0x800) >> 12);
-    *(int *)(((int)self + 0xb4) & 0xFFFFFFFFFFFFFFFF) += d1;
-    *(int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) += *(int *)(self + 0xb4);
+    *(int *)(((int)self + 0xb4)) += d1;
+    *(int *)(((int)self + 0xb0)) += *(int *)(self + 0xb4);
 
     if (*(int *)(self + 0xb0) > 0x2c00) {
         *(int *)(self + 0xb0) = 0x2c00;

--- a/src/func_ov006_021082c4.c
+++ b/src/func_ov006_021082c4.c
@@ -3,7 +3,7 @@ extern struct Pair data_ov006_0213e2f8;
 
 void func_ov006_021082c4(char *p)
 {
-    *(int *)(((long long)(int)(p + 0xb8)) & 0xFFFFFFFFFFFFFFFFLL) += 0x140;
+    *(int *)(((long long)(int)(p + 0xb8))) += 0x140;
     *(short *)(p + 0xc4) = -*(short *)(p + 0xc2);
     *(struct Pair *)p = data_ov006_0213e2f8;
 }

--- a/src/func_ov006_021082fc.c
+++ b/src/func_ov006_021082fc.c
@@ -22,13 +22,13 @@ void func_ov006_021082fc(char *self)
     int t2 = _ZN4cstd4fdivEii(fm2, *(int *)(self + 0xb0));
     *(s16 *)(self + 0xc6) = (s16)t2;
 
-    s16 *pC0 = (s16 *)(((int)self + 0xc0) & 0xFFFFFFFFFFFFFFFF);
+    s16 *pC0 = (s16 *)(((int)self + 0xc0));
     *pC0 = *pC0 + *(s16 *)(self + 0xc6);
 
     *(int *)(self + 0xb4) = (int)(((s64)*(int *)(self + 0xb4) * 0xfe0 + 0x800) >> 12);
 
-    *(int *)(((int)self + 0xb4) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)self + 0xb4) & 0xFFFFFFFFFFFFFFFF) + r4;
-    *(int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) + *(int *)(self + 0xb4);
+    *(int *)(((int)self + 0xb4)) = *(int *)(((int)self + 0xb4)) + r4;
+    *(int *)(((int)self + 0xb0)) = *(int *)(((int)self + 0xb0)) + *(int *)(self + 0xb4);
 
     int B = *(int *)(self + 0xb0);
     if (B > 0x4200) {

--- a/src/func_ov006_02108f2c.c
+++ b/src/func_ov006_02108f2c.c
@@ -87,10 +87,10 @@ void func_ov006_02108f2c(Thing* t)
         s32* p;
         s32 q;
         d = func_020b9488;
-        p = (s32*)(((s32)t + 4) & 0xFFFFFFFFFFFFFFFF);
+        p = (s32*)(((s32)t + 4));
         q = -((t->unk30 - (d >> 1)) << 12) / d - 0x600;
         *p += (s32)((((s64)q << 14) + 0x800) >> 12);
-        *(s16*)(((s32)t + 0x30) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(s16*)(((s32)t + 0x30)) -= 1;
         if (t->unk30 == 0)
             t->unk32 = 6;
     } else if (state == 2) {

--- a/src/func_ov006_0210935c.c
+++ b/src/func_ov006_0210935c.c
@@ -2,7 +2,7 @@ extern struct P { int x, y; } data_ov006_02142ab4[];
 extern struct P data_ov006_02142ab8[];
 void func_ov006_02109530(int *out, int *a, int scale);
 
-#define LNDR(e) ((int)(((long long)(e)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LNDR(e) ((int)(((long long)(e))))
 
 struct S {
     char pad[0x18];

--- a/src/func_ov006_02109aac.c
+++ b/src/func_ov006_02109aac.c
@@ -22,8 +22,8 @@ extern void func_ov004_020b65e4(void);
 extern unsigned char data_ov006_02142ab4[];
 extern char *func_020beb68;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
-#define LNDR(e) ((int)(((long long)(e))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define LNDR(e) ((int)(((long long)(e))))
 #define I(o) (*(int*)(c + (o)))
 #define H(o) (*(short*)(c + (o)))
 #define B(o) (*(unsigned char*)(c + (o)))

--- a/src/func_ov006_0210ab94.c
+++ b/src/func_ov006_0210ab94.c
@@ -9,9 +9,9 @@ void func_ov006_0210ab94(char* c){
     }
     if (*(unsigned char*)(c + 0x503e) >= 0x3c) return;
     {
-        int* a = (int*)(((int)c + 0x4ff4) & 0xFFFFFFFFFFFFFFFF);
-        int* b = (int*)(((int)c + 0x4ff8) & 0xFFFFFFFFFFFFFFFF);
-        int* d = (int*)(((int)c + 0x4ffc) & 0xFFFFFFFFFFFFFFFF);
+        int* a = (int*)(((int)c + 0x4ff4));
+        int* b = (int*)(((int)c + 0x4ff8));
+        int* d = (int*)(((int)c + 0x4ffc));
         *a = *a + 0x10000;
         *b = *b - 0x10000;
         *d = *d + 0x10000;

--- a/src/func_ov006_0210ac3c.cpp
+++ b/src/func_ov006_0210ac3c.cpp
@@ -35,7 +35,7 @@ extern "C" void func_ov006_0210ac3c(char* c)
     if (DecIfAbove0_Byte((unsigned char*)(c + 0x503e)) == 0) {
         if (*(int*)(c + 0x5000) == 3) {
             if (*(int*)(c + 0xb4) < 0x270f)
-                *(int*)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(int*)(((int)c + 0xb4)) += 1;
             if (*(int*)(c + 0xb4) > *(int*)(c + 0xb8))
                 *(int*)(c + 0xb8) = *(int*)(c + 0xb4);
             ((Obj*)c)->v18(4);
@@ -54,10 +54,10 @@ extern "C" void func_ov006_0210ac3c(char* c)
             return;
         if (*(int*)(c + 0x5014) <= 0)
             return;
-        *(int*)(((int)c + 0x5014) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(int*)(((int)c + 0x5014)) -= 1;
         func_ov004_020b1ba0(c, 1);
         Sound::PlayBank2_2D(0x149);
-        *(unsigned char*)(((int)c + 0x503e) & 0xFFFFFFFFFFFFFFFF) += 5;
+        *(unsigned char*)(((int)c + 0x503e)) += 5;
         return;
     }
 

--- a/src/func_ov006_0210af64.c
+++ b/src/func_ov006_0210af64.c
@@ -58,7 +58,7 @@ void func_ov006_0210af64(char *c)
   i = 0;
   for (; i < 3; i++)
   {
-    if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x502e))) & 0xFFFFFFFFFFFFFFFFLL)))) == 0)
+    if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x502e))))))) == 0)
     {
       int *p = (int *) (c + (i * 4));
       int val;
@@ -66,11 +66,11 @@ void func_ov006_0210af64(char *c)
       int q2;
       u8 *dir;
       tab = data_ov006_0213e948;
-      p = (int *) ((int) (((long long) ((int) (((int) p) + 0x4fe4))) & 0xFFFFFFFFFFFFFFFFLL));
+      p = (int *) ((int) (((long long) ((int) (((int) p) + 0x4fe4)))));
       val = *p;
       ;
       q = (val >> 12) / 0x50;
-      if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x5040))) & 0xFFFFFFFFFFFFFFFFLL)))) == 1)
+      if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x5040))))))) == 1)
       {
         *p = val - tab[((*((u8 *) (c + 0x503d))) * 3) + i];
         if ((*p) < 0)
@@ -91,7 +91,7 @@ void func_ov006_0210af64(char *c)
         q2 = ((*p) >> 12) / 0x50;
         if (q2 != q)
         {
-          if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x5040))) & 0xFFFFFFFFFFFFFFFFLL)))) == new_var)
+          if ((*((u8 *) ((int) (((long long) ((int) ((c + i) + 0x5040))))))) == new_var)
           {
             *p = (q * 0x50) << 12;
           }
@@ -100,8 +100,8 @@ void func_ov006_0210af64(char *c)
             *p = (q2 * 0x50) << 12;
           }
           func_ov006_0210ab08(c, i);
-          *((u8 *) ((int) (((long long) ((int) ((c + i) + 0x502e))) & 0xFFFFFFFFFFFFFFFFLL))) = 1;
-          *((u8 *) ((int) (((long long) ((int) (c + 0x503d))) & 0xFFFFFFFFFFFFFFFFLL))) += new_var;
+          *((u8 *) ((int) (((long long) ((int) ((c + i) + 0x502e)))))) = 1;
+          *((u8 *) ((int) (((long long) ((int) (c + 0x503d)))))) += new_var;
           *((u8 *) (c + 0x503f)) = 0;
           _ZN5Sound12PlayBank2_2DEj(0x1a9);
         }

--- a/src/func_ov006_0210b1fc.c
+++ b/src/func_ov006_0210b1fc.c
@@ -11,7 +11,7 @@ void func_ov006_0210b1fc(char *p)
     }
 
     if (*(int *)(p + 0x500c) > 0) {
-        *(int *)(((int)p + 0x500c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+        *(int *)(((int)p + 0x500c)) -= 1;
         if (*(int *)(p + 0x500c) != 0)
             return;
         *(unsigned char *)(p + 0x503b) = *(unsigned char *)(p + 0x503c);
@@ -19,7 +19,7 @@ void func_ov006_0210b1fc(char *p)
         return;
     }
 
-    *(unsigned char *)(((int)p + 0x503e) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(unsigned char *)(((int)p + 0x503e)) -= 1;
     if (*(unsigned char *)(p + 0x503e) != 0)
         return;
 

--- a/src/func_ov006_0210b648.c
+++ b/src/func_ov006_0210b648.c
@@ -63,7 +63,7 @@ int dScMgSlot3_c_Render(char *c)
             int row, rem;
             int i2, j2;
             for (i2 = 0; i2 < 3; i2++) {
-                int a = *(int *)(((int)c + i2 * 4 + 0x4fe4) & 0xFFFFFFFFFFFFFFFF) >> 12;
+                int a = *(int *)(((int)c + i2 * 4 + 0x4fe4)) >> 12;
                 int y;
                 row = a / 0x50;
                 rem = a % 0x50;

--- a/src/func_ov006_0210c1a8.c
+++ b/src/func_ov006_0210c1a8.c
@@ -7,7 +7,7 @@ void func_ov006_0210c1a8(int *o)
     *o = *o - 1;
     if ((*o & 7) != 0)
         return;
-    *((unsigned char *)(((int)o + 4) & 0xFFFFFFFFFFFFFFFF)) ^= 1;
+    *((unsigned char *)(((int)o + 4))) ^= 1;
     if (*((unsigned char *)o + 4) != 0)
         data_0209d454 |= 2;
     else

--- a/src/func_ov006_0210c278.c
+++ b/src/func_ov006_0210c278.c
@@ -1,9 +1,9 @@
 void func_ov006_0210c278(unsigned char *o)
 {
     if (*(int*)(o + 4) <= 0) return;
-    int *p = (int*)(((int)o + 4) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int*)(((int)o + 4));
     *p = *p - 1;
     if ((*(int*)(o + 4) & 7) == 0) {
-        *((unsigned char*)(((int)o + 8) & 0xFFFFFFFFFFFFFFFF)) ^= 1;
+        *((unsigned char*)(((int)o + 8))) ^= 1;
     }
 }

--- a/src/func_ov006_0210c2d4.c
+++ b/src/func_ov006_0210c2d4.c
@@ -20,8 +20,8 @@ void func_ov006_0210c2d4(char *c)
     if (v <= 0) {
         return;
     }
-    *(int *)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) =
-        *(int *)(((int)c + 0x1c) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(int *)(((int)c + 0x1c)) =
+        *(int *)(((int)c + 0x1c)) + 1;
     func_ov004_020b1b08((void *)1);
     func_ov001_020ab3f0(c);
     sid = 0x163;

--- a/src/func_ov006_0210c410.c
+++ b/src/func_ov006_0210c410.c
@@ -12,7 +12,7 @@ void func_ov006_0210c410(char *c) {
             func_ov004_020b1b40(1);
             _ZN5Sound12PlayBank2_2DEj(0x149);
         }
-        int *p = (int *)(((int)c + 0x20) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)c + 0x20));
         *p = *p - 1;
     }
     func_ov001_020ab550(c);

--- a/src/func_ov006_0210c500.c
+++ b/src/func_ov006_0210c500.c
@@ -41,7 +41,7 @@ int func_ov006_0210c500(struct T *p)
     }
     if (ok) {
         if (p->f708 < 2) {
-            u8 *q = (u8 *)(int)(((long long)(int)((u8 *)p + 0x4708)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(int)(((long long)(int)((u8 *)p + 0x4708)));
             *q = *q + 1;
         }
         p->f709 = first;

--- a/src/func_ov006_0210d6b8.cpp
+++ b/src/func_ov006_0210d6b8.cpp
@@ -17,7 +17,7 @@ void *func_ov006_0210d6b8(void) {
     if (p) {
         func_ov004_020b2adc(p);
         *(void ***)p = data_ov006_0213eb40;
-        char *base = (char *)(((int)p + 0x4660) & 0xFFFFFFFFFFFFFFFF);
+        char *base = (char *)(((int)p + 0x4660));
         *(void **)base = (void *)&func_020ad494;
         *(void ***)base = data_ov006_0213e5d4;
         func_ov006_0210c2b0(p + 0x4684);

--- a/src/func_ov006_0210d8bc.c
+++ b/src/func_ov006_0210d8bc.c
@@ -2,7 +2,7 @@ extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 
 void func_ov006_0210d8bc(char *c)
 {
-    (*(int *)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFF)) += 1;
+    (*(int *)(((int)c + 0x40))) += 1;
     if (*(int *)(c + 0x40) == 1) {
         *(int *)(c + 0x34) = 0x14;
         *(unsigned char *)(c + 0x3c) = 1;

--- a/src/func_ov006_0210d93c.c
+++ b/src/func_ov006_0210d93c.c
@@ -42,20 +42,20 @@ void func_ov006_0210d93c(struct C* c)
     func_0203d388(&c->v[6], c->angle);
     func_0203d388(&c->v[7], c->angle);
 
-    *(int*)(((int)c + 0x48) & 0xFFFFFFFFFFFFFFFFLL) += c->dx - 0x10000;
-    *(int*)(((int)c + 0x4c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x50) & 0xFFFFFFFFFFFFFFFFLL) += c->dx - 0x10000;
-    *(int*)(((int)c + 0x54) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x58) & 0xFFFFFFFFFFFFFFFFLL) += c->dx - 0x10000;
-    *(int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += c->dx - 0x10000;
-    *(int*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x68) & 0xFFFFFFFFFFFFFFFFLL) += c->dx + 0x10000;
-    *(int*)(((int)c + 0x6c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x70) & 0xFFFFFFFFFFFFFFFFLL) += c->dx + 0x10000;
-    *(int*)(((int)c + 0x74) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x78) & 0xFFFFFFFFFFFFFFFFLL) += c->dx + 0x10000;
-    *(int*)(((int)c + 0x7c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
-    *(int*)(((int)c + 0x80) & 0xFFFFFFFFFFFFFFFFLL) += c->dx + 0x10000;
-    *(int*)(((int)c + 0x84) & 0xFFFFFFFFFFFFFFFFLL) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x48)) += c->dx - 0x10000;
+    *(int*)(((int)c + 0x4c)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x50)) += c->dx - 0x10000;
+    *(int*)(((int)c + 0x54)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x58)) += c->dx - 0x10000;
+    *(int*)(((int)c + 0x5c)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x60)) += c->dx - 0x10000;
+    *(int*)(((int)c + 0x64)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x68)) += c->dx + 0x10000;
+    *(int*)(((int)c + 0x6c)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x70)) += c->dx + 0x10000;
+    *(int*)(((int)c + 0x74)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x78)) += c->dx + 0x10000;
+    *(int*)(((int)c + 0x7c)) += c->dy + 0x28000;
+    *(int*)(((int)c + 0x80)) += c->dx + 0x10000;
+    *(int*)(((int)c + 0x84)) += c->dy + 0x28000;
 }

--- a/src/func_ov006_0210e014.c
+++ b/src/func_ov006_0210e014.c
@@ -24,10 +24,10 @@ void func_ov006_0210e014(Obj* self) {
     self->x14 = self->xc;
     if (self->x44 != 1 && self->x40 > 0) {
         if (self->x32 < 0x3000) {
-            (*(s16*)(((long long)(int)((char*)self + 0x32)) & 0xFFFFFFFFFFFFFFFFLL)) += 0x200;
+            (*(s16*)(((long long)(int)((char*)self + 0x32)))) += 0x200;
             if (self->x32 >= 0x3000) self->x32 = 0x3000;
         } else {
-            (*(s16*)(((unsigned long long)(unsigned int)((char*)self + 0x32)) & 0xFFFFFFFFFFFFFFFFLL)) -= 0x200;
+            (*(s16*)(((unsigned long long)(unsigned int)((char*)self + 0x32)))) -= 0x200;
             if (self->x32 < 0x3000) self->x32 = 0x3000;
         }
     }

--- a/src/func_ov006_0210e3e8.c
+++ b/src/func_ov006_0210e3e8.c
@@ -5,7 +5,7 @@ void func_ov006_0210e3e8(int *self) {
     self[4] = self[2];
     self[5] = self[3];
     if (self[0xd] > 0) {
-        *(int *)(((long long)(int)(b + 0x34)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(int *)(((long long)(int)(b + 0x34))) -= 1;
     }
     if (b[0x31] != 1) return;
     if (func_ov006_0210e120(self)) {

--- a/src/func_ov006_0210ef48.c
+++ b/src/func_ov006_0210ef48.c
@@ -61,7 +61,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     } else if (slot < 6) {
         if (c->cells[slot - 3] == 1 && c->cells[slot + 3] == 1) {
@@ -69,7 +69,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot - 3] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     } else {
         if (c->cells[slot - 6] == 1 && c->cells[slot - 3] == 1) {
@@ -77,7 +77,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot - 6] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     }
     i = slot % 3;
@@ -87,7 +87,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot / 3 + 3] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     } else if (i == 1) {
         if (c->cells[slot - 1] == 1 && c->cells[slot + 1] == 1) {
@@ -95,7 +95,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot / 3 + 3] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     } else {
         if (c->cells[slot - 2] == 1 && c->cells[slot - 1] == 1) {
@@ -103,7 +103,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[slot / 3 + 3] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
     }
     switch (slot) {
@@ -113,7 +113,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[6] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         break;
     case 2:
@@ -122,7 +122,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[7] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         break;
     case 4:
@@ -131,14 +131,14 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[6] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         if (c->cells[2] == 1 && c->cells[6] == 1) {
             c->lines[7] = 0x21d;
             c->f94 = 0xb5;
             c->marks[7] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         break;
     case 6:
@@ -147,7 +147,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[7] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         break;
     case 8:
@@ -156,7 +156,7 @@ void func_ov006_0210ef48(void* arg, int i)
             c->f94 = 0xb5;
             c->marks[6] = 1;
             count += 1;
-            (*(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(int*)(((int)c + 0x98)))++;
         }
         break;
     }

--- a/src/func_ov006_0210fb04.c
+++ b/src/func_ov006_0210fb04.c
@@ -3,7 +3,7 @@ extern void _ZN5Sound12PlayBank2_2DEj(unsigned int a);
 void func_ov006_0210fb04(char* self)
 {
     if (*(unsigned char*)(self + 0x73) != 0) {
-        ++*(int*)(((int)self + 0x78) & 0xFFFFFFFFFFFFFFFF);
+        ++*(int*)(((int)self + 0x78));
         return;
     }
     *(unsigned char*)(self + 0x74) = 1;

--- a/src/func_ov006_0210fb58.c
+++ b/src/func_ov006_0210fb58.c
@@ -14,8 +14,8 @@ typedef struct { int x, y; } V2;
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 
-#define LN(base, off) (*(int *)((((int)(base)) + (off)) & 0xFFFFFFFFFFFFFFFF))
-#define LM(base, off) (*(int *)((((unsigned int)(base)) + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LN(base, off) (*(int *)((((int)(base)) + (off))))
+#define LM(base, off) (*(int *)((((unsigned int)(base)) + (off))))
 
 void func_ov006_0210fb58(char *c)
 {

--- a/src/func_ov006_021100a8.c
+++ b/src/func_ov006_021100a8.c
@@ -6,16 +6,16 @@ void func_ov006_021100a8(char* c){
   *(int*)(c+0x10) = *(int*)(c+8);
   *(int*)(c+0x14) = *(int*)(c+0xc);
   if (*(int*)(c+0x7c) > 0) {
-    int* p = (int*)(((int)c + 0x7c) & 0xFFFFFFFFFFFFFFFF);
+    int* p = (int*)(((int)c + 0x7c));
     *p = *p - 1;
   }
   if (*(unsigned char*)(c+0x73) == 0 && *(int*)(c+0x7c) <= 0 && *(int*)(c+0x78) > 0) {
-    int* p = (int*)(((int)c + 0x78) & 0xFFFFFFFFFFFFFFFF);
+    int* p = (int*)(((int)c + 0x78));
     *p = *p - 1;
     func_ov006_0210fb04(c);
   }
   if (*(int*)(c+0x80) > 0) {
-    int* p = (int*)(((int)c + 0x80) & 0xFFFFFFFFFFFFFFFF);
+    int* p = (int*)(((int)c + 0x80));
     *p = *p - 1;
     if (*(int*)(c+0x80) == 0)
       func_ov006_0210fa6c(c);

--- a/src/func_ov006_021106b4.c
+++ b/src/func_ov006_021106b4.c
@@ -40,7 +40,7 @@ void func_ov006_021106b4(struct Obj *self)
     self->f10 = self->x;
     self->f14 = self->y;
     if (self->f38 > 0) {
-        *(int *)(((int)self + 0x38) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+        *(int *)(((int)self + 0x38)) -= 1;
         if (self->f38 == 0) self->b30 = 0;
         return;
     }
@@ -60,7 +60,7 @@ void func_ov006_021106b4(struct Obj *self)
             return;
         }
     }
-    *(int *)(((int)self + 0x34) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(int *)(((int)self + 0x34)) += 1;
     if (self->f34 < 0x3c) return;
     self->f34 = 0;
     if (self->b31 == 0) self->b31 = 1;

--- a/src/func_ov006_02110e28.c
+++ b/src/func_ov006_02110e28.c
@@ -42,20 +42,20 @@ void func_ov006_02110e28(struct C* c)
     func_0203d388(&c->v[6], c->angle);
     func_0203d388(&c->v[7], c->angle);
 
-    *(int*)(((int)c + 0x38) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x3c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x40) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x44) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x48) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x4c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x50) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x54) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x58) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x68) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x6c) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
-    *(int*)(((int)c + 0x70) & 0xFFFFFFFFFFFFFFFFLL) += c->dx;
-    *(int*)(((int)c + 0x74) & 0xFFFFFFFFFFFFFFFFLL) += c->dy;
+    *(int*)(((int)c + 0x38)) += c->dx;
+    *(int*)(((int)c + 0x3c)) += c->dy;
+    *(int*)(((int)c + 0x40)) += c->dx;
+    *(int*)(((int)c + 0x44)) += c->dy;
+    *(int*)(((int)c + 0x48)) += c->dx;
+    *(int*)(((int)c + 0x4c)) += c->dy;
+    *(int*)(((int)c + 0x50)) += c->dx;
+    *(int*)(((int)c + 0x54)) += c->dy;
+    *(int*)(((int)c + 0x58)) += c->dx;
+    *(int*)(((int)c + 0x5c)) += c->dy;
+    *(int*)(((int)c + 0x60)) += c->dx;
+    *(int*)(((int)c + 0x64)) += c->dy;
+    *(int*)(((int)c + 0x68)) += c->dx;
+    *(int*)(((int)c + 0x6c)) += c->dy;
+    *(int*)(((int)c + 0x70)) += c->dx;
+    *(int*)(((int)c + 0x74)) += c->dy;
 }

--- a/src/func_ov006_0211134c.c
+++ b/src/func_ov006_0211134c.c
@@ -58,7 +58,7 @@ void func_ov006_0211134c(Obj *c)
         if (c->fc <= 0xa0000)
             return;
         {
-            int *pf38 = (int *)(((int)c + 0x38) & 0xFFFFFFFFFFFFFFFFLL);
+            int *pf38 = (int *)(((int)c + 0x38));
             *pf38 = *pf38 - (c->fc - 0xa0000);
         }
         return;
@@ -93,11 +93,11 @@ void func_ov006_0211134c(Obj *c)
     }
 
     {
-        int *pf24 = (int *)(((int)c + 0x24) & 0xFFFFFFFFFFFFFFFFLL);
+        int *pf24 = (int *)(((int)c + 0x24));
         *pf24 = *pf24 - (c->fc - 0xa0000) / 16;
     }
     {
-        int *pfc = (int *)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFFLL);
+        int *pfc = (int *)(((int)c + 0xc));
         *pfc = *pfc + c->f24;
     }
     if (c->fc < 0xa0000) {

--- a/src/func_ov006_021116f0.c
+++ b/src/func_ov006_021116f0.c
@@ -11,8 +11,8 @@ void func_ov006_021116f0(void *arg0)
     *(s32 *)(c + 0x14) = *(s32 *)(c + 0xc);
     if (*(s32 *)(c + 0x34) <= 0)
         return;
-    *(s32 *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) =
-        *(s32 *)(((int)c + 0x34) & 0xFFFFFFFFFFFFFFFF) - 1;
+    *(s32 *)(((int)c + 0x34)) =
+        *(s32 *)(((int)c + 0x34)) - 1;
     if (*(s32 *)(c + 0x34) > 0)
         return;
     func_ov006_02114ec0(*(void **)(c + 4));

--- a/src/func_ov006_0211192c.c
+++ b/src/func_ov006_0211192c.c
@@ -51,7 +51,7 @@ void func_ov006_0211192c(C* c)
             c->f3c = 4;
     } else if (c->f3c > 0) {
         {
-            int* p = (int*)((long long)(int)&c->f3c & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)((long long)(int)&c->f3c);
             *p = *p - 1;
         }
         if (c->f3c < 4) {
@@ -81,12 +81,12 @@ void func_ov006_0211192c(C* c)
 done:
     if (c->f34 == 1) {
         if (c->f3c <= 0) {
-            int* p = (int*)((long long)(int)&c->f28 & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)((long long)(int)&c->f28);
             *p += 0x1000;
             if (c->f28 > 0x7000)
                 c->f28 = 0x7000;
         } else {
-            int* p = (int*)((long long)(int)&c->f28 & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)((long long)(int)&c->f28);
             *p -= 0x1000;
             if (c->f28 < 0)
                 c->f28 = 0;

--- a/src/func_ov006_02113f1c.c
+++ b/src/func_ov006_02113f1c.c
@@ -19,7 +19,7 @@ extern void func_ov006_02111e48(char *c);
 extern void func_ov006_021128fc(char *c);
 extern void func_ov006_02112ad8(char *c);
 
-#define LAUNDER(p) ((int)((long long)(int)(p) & 0xffffffffffffffffLL))
+#define LAUNDER(p) ((int)((long long)(int)(p)))
 
 void func_ov006_02113f1c(char *c)
 {

--- a/src/func_ov006_02114f98.c
+++ b/src/func_ov006_02114f98.c
@@ -3,5 +3,5 @@
 // the ROM instead of splitting the large offset.
 void func_ov006_02114f98(char *self)
 {
-    *(unsigned int *)(((long long)(int)(self + 0x5994)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+    *(unsigned int *)(((long long)(int)(self + 0x5994))) += 1;
 }

--- a/src/func_ov006_02114fd0.c
+++ b/src/func_ov006_02114fd0.c
@@ -1,5 +1,5 @@
 void func_ov006_02114fd0(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5984)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *a = (int *)(((long long)(int)(p + 0x5984)));
     *a = *a + 1;
 }

--- a/src/func_ov006_02114fec.c
+++ b/src/func_ov006_02114fec.c
@@ -1,5 +1,5 @@
 void func_ov006_02114fec(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5980)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *a = (int *)(((long long)(int)(p + 0x5980)));
     *a = *a + 1;
 }

--- a/src/func_ov006_02115008.c
+++ b/src/func_ov006_02115008.c
@@ -1,5 +1,5 @@
 void func_ov006_02115008(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x597c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *a = (int *)(((long long)(int)(p + 0x597c)));
     *a = *a + 1;
 }

--- a/src/func_ov006_02115024.c
+++ b/src/func_ov006_02115024.c
@@ -1,5 +1,5 @@
 void func_ov006_02115024(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5978)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *a = (int *)(((long long)(int)(p + 0x5978)));
     *a = *a + 1;
 }

--- a/src/func_ov006_02115060.c
+++ b/src/func_ov006_02115060.c
@@ -1,5 +1,5 @@
 void func_ov006_02115060(char *p)
 {
-    int *a = (int *)(((long long)(int)(p + 0x5964)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *a = (int *)(((long long)(int)(p + 0x5964)));
     *a = *a + 1;
 }

--- a/src/func_ov006_02115150.c
+++ b/src/func_ov006_02115150.c
@@ -8,10 +8,10 @@ void func_ov006_02115150(char* self)
     int i;
     char* obj = self + 0x48d4;
     for (i = 0; i < 0x10; i++) {
-        unsigned char* flag = (unsigned char*)(int)(((long long)(int)(self + i + 0x4804)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char* flag = (unsigned char*)(int)(((long long)(int)(self + i + 0x4804)));
         if (*flag != 0) {
-            *(int*)(((int)(self + i*8) + 0x4854) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(self + i*8 + 0x48d4);
-            *(int*)(((int)(self + i*8) + 0x4858) & 0xFFFFFFFFFFFFFFFFLL) += *(int*)(self + i*8 + 0x48d8);
+            *(int*)(((int)(self + i*8) + 0x4854)) += *(int*)(self + i*8 + 0x48d4);
+            *(int*)(((int)(self + i*8) + 0x4858)) += *(int*)(self + i*8 + 0x48d8);
             {
                 int m = Vec2_Len(obj) * 6 / 8;
                 if (func_0203d434(obj)) {
@@ -19,7 +19,7 @@ void func_ov006_02115150(char* self)
                 }
             }
             {
-                int* counter = (int*)(int)(((long long)(int)(self + i*4 + 0x4814)) & 0xFFFFFFFFFFFFFFFFLL);
+                int* counter = (int*)(int)(((long long)(int)(self + i*4 + 0x4814)));
                 *counter += 1;
                 if (*counter >= 0xf) {
                     *flag = 0;

--- a/src/func_ov006_02115480.c
+++ b/src/func_ov006_02115480.c
@@ -7,12 +7,12 @@ void func_ov006_02115480(char *o)
 {
     int i;
     for (i = 0; i < 5; i++) {
-        int *A = (int *)(((int)(o + i * 4) + 0x478c) & 0xFFFFFFFFFFFFFFFF);
-        int *E = (int *)(((int)(o + i * 4) + 0x47f0) & 0xFFFFFFFFFFFFFFFF);
-        int *D0 = (int *)(((int)(o + i * 8) + 0x47c8) & 0xFFFFFFFFFFFFFFFF);
-        int *D1 = (int *)(((int)(o + i * 8) + 0x47cc) & 0xFFFFFFFFFFFFFFFF);
-        int *B = (int *)(((int)(o + i * 4) + 0x47a0) & 0xFFFFFFFFFFFFFFFF);
-        int *C = (int *)(((int)(o + i * 4) + 0x47b4) & 0xFFFFFFFFFFFFFFFF);
+        int *A = (int *)(((int)(o + i * 4) + 0x478c));
+        int *E = (int *)(((int)(o + i * 4) + 0x47f0));
+        int *D0 = (int *)(((int)(o + i * 8) + 0x47c8));
+        int *D1 = (int *)(((int)(o + i * 8) + 0x47cc));
+        int *B = (int *)(((int)(o + i * 4) + 0x47a0));
+        int *C = (int *)(((int)(o + i * 4) + 0x47b4));
         if (*A > 0) {
             if (*E > 0) {
                 *E -= 1;

--- a/src/func_ov006_02115680.c
+++ b/src/func_ov006_02115680.c
@@ -18,6 +18,6 @@ void func_ov006_02115680(char *p, int idx)
             } while (i < *(int *)(p + 0x4674));
         }
     }
-    idx = (int)(((long long)idx) & 0xFFFFFFFFFFFFFFFFLL);
+    idx = (int)(((long long)idx));
     *(int *)(p + idx * 4 + 0x4784) = 0x14;
 }

--- a/src/func_ov006_02115a5c.c
+++ b/src/func_ov006_02115a5c.c
@@ -9,7 +9,7 @@ void func_ov006_02115a5c(char *p)
     int i, j;
     for (i = 0; i < n; i++) {
         for (j = 0; j < n; j++) {
-            int a = (i >= 13) ? 0 : *(int *)(int)(((long long)(int)(p + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+            int a = (i >= 13) ? 0 : *(int *)(int)(((long long)(int)(p + i * 4 + 0x4688)));
             int b = (j >= 13) ? 0 : *(int *)(p + j * 4 + 0x4688);
             func_ov006_02115830(p, i, j, a, b);
             n = *(int *)(p + 0x4668);

--- a/src/func_ov006_02115b0c.c
+++ b/src/func_ov006_02115b0c.c
@@ -120,7 +120,7 @@ void func_ov006_02115b0c(char *c)
     func_ov004_020adb1c(0);
 
     for (int i = 0; i < 0xd; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4688)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -132,7 +132,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 8; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4720)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -144,7 +144,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 0x19; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x46bc)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -156,7 +156,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4740)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -168,7 +168,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 6; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x474c)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -180,7 +180,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 3; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4764)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -192,7 +192,7 @@ void func_ov006_02115b0c(char *c)
         }
     }
     for (int i = 0; i < 2; i++) {
-        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)) & 0xFFFFFFFFFFFFFFFFLL);
+        int **slot = (int **)(((long long)(int)(c + i * 4 + 0x4770)));
         int *p = *slot;
         if (p != 0) {
             if (p != 0) {
@@ -346,7 +346,7 @@ void func_ov006_02115b0c(char *c)
                 p = func_ov006_02111b40(p, c, j, &tmp);
             }
             {
-                void **slot = (void **)(((long long)(int)(c + j * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+                void **slot = (void **)(((long long)(int)(c + j * 4 + 0x46bc)));
                 *slot = p;
                 if (*slot != 0)
                     *(int *)((char *)*slot + 0x34) = 0;
@@ -388,7 +388,7 @@ void func_ov006_02115b0c(char *c)
                 p = func_ov006_02111b40(p, c, n, &tmp);
             }
             {
-                void **slot = (void **)(((long long)(int)(c + n * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+                void **slot = (void **)(((long long)(int)(c + n * 4 + 0x46bc)));
                 *slot = p;
                 if (*slot != 0)
                     *(int *)((char *)*slot + 0x34) = 1;

--- a/src/func_ov006_02118488.c
+++ b/src/func_ov006_02118488.c
@@ -36,31 +36,31 @@ int dScMgSmartball_c_Behavior(void* arg)
             (**(VFunc**)o)(o);
 
             for (i = 0; i < *(int*)(c + 0x4668); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x4688)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4688)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x4670); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x46bc)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x46bc)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x466c); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x4720)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4720)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x4674); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x4740)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4740)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x4678); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x474c)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x474c)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x467c); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x4764)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4764)));
                 (**(VFunc**)o)(o);
             }
             for (i = 0; i < *(int*)(c + 0x4680); i++) {
-                o = *(char**)(((long long)(int)(c + i * 4 + 0x4770)) & 0xFFFFFFFFFFFFFFFFLL);
+                o = *(char**)(((long long)(int)(c + i * 4 + 0x4770)));
                 (**(VFunc**)o)(o);
             }
 
@@ -85,7 +85,7 @@ int dScMgSmartball_c_Behavior(void* arg)
                 if (*(int*)(c + 0x5954) >= 0x3c) {
                     *(int*)(c + 0x4660) = 1;
                 } else {
-                    int* p = (int*)(((int)c + 0x5954) & 0xFFFFFFFFFFFFFFFF);
+                    int* p = (int*)(((int)c + 0x5954));
                     (*p)++;
                 }
             } else {
@@ -105,7 +105,7 @@ int dScMgSmartball_c_Behavior(void* arg)
             if (*(unsigned char*)(c + 0x595c) != 0) {
                 int t;
                 {
-                    int* p = (int*)(((int)c + 0x5958) & 0xFFFFFFFFFFFFFFFF);
+                    int* p = (int*)(((int)c + 0x5958));
                     (*p)++;
                 }
                 if (*(int*)(c + 0x5958) == 0xb4) {
@@ -143,13 +143,13 @@ int dScMgSmartball_c_Behavior(void* arg)
             data_0209d454 |= 1;
         }
         if (*(int*)(c + 0x5998) > 0) {
-            int* p = (int*)(((int)c + 0x5998) & 0xFFFFFFFFFFFFFFFF);
+            int* p = (int*)(((int)c + 0x5998));
             *p -= 4;
         } else {
             int flag = 0;
             *(int*)(c + 0x5998) = 0;
             if (*(int*)(c + 0x5960) < 0x12c) {
-                int* p = (int*)(((int)c + 0x5960) & 0xFFFFFFFFFFFFFFFF);
+                int* p = (int*)(((int)c + 0x5960));
                 (*p)++;
             } else {
                 int idx = data_020a0e40;
@@ -174,11 +174,11 @@ int dScMgSmartball_c_Behavior(void* arg)
     }
 
     if (*(int*)(c + 0x4784) > 0) {
-        int* p = (int*)(((int)c + 0x4784) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0x4784));
         (*p)--;
     }
     if (*(int*)(c + 0x4788) > 0) {
-        int* p = (int*)(((int)c + 0x4788) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0x4788));
         (*p)--;
     }
 

--- a/src/func_ov006_02119a18.c
+++ b/src/func_ov006_02119a18.c
@@ -1,4 +1,4 @@
-#define A(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define A(p) ((int)(((long long)(int)(p))))
 extern unsigned short data_ov006_0212ee38[];
 
 void func_ov006_02119a18(char *b)

--- a/src/func_ov006_02119b00.c
+++ b/src/func_ov006_02119b00.c
@@ -10,14 +10,14 @@ void func_ov006_02119b00(char *o)
     if (*(u8 *)(o + 0x55f6) >= 2)
         return;
     {
-        u16 *p = (u16 *)(((int)o + 0x55f0) & 0xFFFFFFFFFFFFFFFF);
+        u16 *p = (u16 *)(((int)o + 0x55f0));
         *p = *p + 1;
     }
     if (*(u16 *)(o + 0x55f0) < data_ov006_0212ee28[*(u8 *)(o + 0x55f6)])
         return;
     *(u16 *)(o + 0x55f0) = 0;
     {
-        u8 *q = (u8 *)(((int)o + 0x55f6) & 0xFFFFFFFFFFFFFFFF);
+        u8 *q = (u8 *)(((int)o + 0x55f6));
         *q = *q + 1;
     }
 }

--- a/src/func_ov006_0211b654.c
+++ b/src/func_ov006_0211b654.c
@@ -24,9 +24,9 @@ void func_ov006_0211b654(struct Mgr* m, int n)
             if (m->slot[i].f1c == 0) {
                 m->slot[i].f1c = 1;
                 m->slot[i].f00 = *s00;
-                int* d04 = (int*)(((int)m + i * 0x24 + 0x51b4) & 0xFFFFFFFFFFFFFFFF);
+                int* d04 = (int*)(((int)m + i * 0x24 + 0x51b4));
                 *d04 = *s04 - 0x8000;
-                u16* d18 = (u16*)(((int)m + i * 0x24 + 0x51c8) & 0xFFFFFFFFFFFFFFFF);
+                u16* d18 = (u16*)(((int)m + i * 0x24 + 0x51c8));
                 m->slot[i].f10 = *d04;
                 m->slot[i].f1e = *g;
                 m->slot[i].f22 = *g;

--- a/src/func_ov006_0211bf44.c
+++ b/src/func_ov006_0211bf44.c
@@ -59,7 +59,7 @@ void func_ov006_0211bf44(char* base, int slot)
     *(u16*)(entry + 0xf0) = 0;
     *(u8*)(entry + 0xf7) = 0;
     {
-        u8* counter = (u8*)(int)(((long long)(int)(base + 0x5624)) & 0xFFFFFFFFFFFFFFFFLL);
+        u8* counter = (u8*)(int)(((long long)(int)(base + 0x5624)));
         *counter = *counter + 1;
     }
     _ZN5Sound12PlayBank2_2DEj(0x201);

--- a/src/func_ov006_0211c080.c
+++ b/src/func_ov006_0211c080.c
@@ -12,7 +12,7 @@ extern int data_ov006_0212efb0[];
 extern u16 *data_ov006_0213f6fc[];
 
 #define RND (((u32)RandomIntInternal(&data_0209d4b8) >> 16) & 0x7fff)
-#define LAUNDER(p) ((int)((long long)(int)(p) & 0xffffffffffffffffLL))
+#define LAUNDER(p) ((int)((long long)(int)(p)))
 
 void func_ov006_0211c080(char *o)
 {

--- a/src/func_ov006_0211d69c.c
+++ b/src/func_ov006_0211d69c.c
@@ -7,10 +7,10 @@ void func_ov006_0211d69c(char *obj)
     {
         return;
     }
-    (*(unsigned short *)(((long long)(int)(obj + 0x4c18)) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(unsigned short *)(((long long)(int)(obj + 0x4c18))))++;
     if (*(unsigned short *)(obj + 0x4c18) >= data_ov006_0212efdc[*(unsigned char *)(obj + 0x4c24)])
     {
-        (*(unsigned char *)(((long long)(int)(obj + 0x4c24)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char *)(((long long)(int)(obj + 0x4c24))))++;
         *(unsigned short *)(obj + 0x4c18) = 0;
         if (*(unsigned char *)(obj + 0x4c24) & 1)
         {


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 102 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
