### PR TITLE
readable: strip 100 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov006_0211d924.c
+++ b/src/func_ov006_0211d924.c
@@ -3,7 +3,7 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
 void func_ov006_0211d924(char* p, int i)
 {

--- a/src/func_ov006_0211dec0.c
+++ b/src/func_ov006_0211dec0.c
@@ -11,7 +11,7 @@ void func_ov006_0211dec0(void *arg) {
         v = *(unsigned char *)(p + 0x4a73);
         if (v == 0) {
             if (*(int *)(p + 0x4a6c) != 0) {
-                *(int *)(((long long)(int)(p + 0x4a6c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(int *)(((long long)(int)(p + 0x4a6c))) -= 1;
                 if ((short)*(int *)(p + 0x4a6c) < 0) {
                     *(int *)(p + 0x4a6c) = 0;
                 }
@@ -19,20 +19,20 @@ void func_ov006_0211dec0(void *arg) {
                 _ZN5Sound12PlayBank2_2DEj(0x1bc);
                 *(int *)(p + 0x4a68) = -0x400;
                 *(int *)(p + 0x4a6c) = 0x10;
-                *(unsigned char *)(((long long)(int)(p + 0x4a73)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(unsigned char *)(((long long)(int)(p + 0x4a73))) += 1;
                 *(unsigned char *)(p + 0x4a71) = 1;
             }
         } else if (v == 1) {
-            *(int *)(((long long)(int)(p + 0x4a64)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(p + 0x4a68);
-            *(int *)(((long long)(int)(p + 0x4a68)) & 0xFFFFFFFFFFFFFFFFLL) -= 0x80;
+            *(int *)(((long long)(int)(p + 0x4a64))) += *(int *)(p + 0x4a68);
+            *(int *)(((long long)(int)(p + 0x4a68))) -= 0x80;
             if (*(int *)(p + 0x4a6c) != 0) {
-                *(int *)(((long long)(int)(p + 0x4a6c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(int *)(((long long)(int)(p + 0x4a6c))) -= 1;
                 if ((short)*(int *)(p + 0x4a6c) < 0) {
                     *(int *)(p + 0x4a6c) = 0;
                 }
             } else {
                 *(int *)(p + 0x4a6c) = 0x18;
-                *(unsigned char *)(((long long)(int)(p + 0x4a73)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(unsigned char *)(((long long)(int)(p + 0x4a73))) += 1;
             }
         }
     }

--- a/src/func_ov006_0211e184.c
+++ b/src/func_ov006_0211e184.c
@@ -1,5 +1,5 @@
-#define LI(i) ((int)(((long long)(i)) & 0xFFFFFFFFFFFFFFFFLL) * 0x10)
-#define A(p) ((int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LI(i) ((int)(((long long)(i))) * 0x10)
+#define A(p) ((int)(((long long)(int)(p))))
 
 void func_ov006_0211e184(char *base)
 {

--- a/src/func_ov006_0211e318.c
+++ b/src/func_ov006_0211e318.c
@@ -2,10 +2,10 @@ extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 void func_ov006_0211e318(char *c){
   if (*(unsigned char*)(c + 0x4c1c) == 0) return;
   if (*(unsigned short*)(c + 0x4c14) == 0) return;
-  *(unsigned char*)(((int)c + 0x4c1a) & 0xFFFFFFFFFFFFFFFF) = *(unsigned char*)(((int)c + 0x4c1a) & 0xFFFFFFFFFFFFFFFF) + 1;
+  *(unsigned char*)(((int)c + 0x4c1a)) = *(unsigned char*)(((int)c + 0x4c1a)) + 1;
   if (*(unsigned char*)(c + 0x4c1a) >= 0x3c){
     *(unsigned char*)(c + 0x4c1a) = 0;
-    *(unsigned short*)(((int)c + 0x4c14) & 0xFFFFFFFFFFFFFFFF) = *(unsigned short*)(((int)c + 0x4c14) & 0xFFFFFFFFFFFFFFFF) - 1;
+    *(unsigned short*)(((int)c + 0x4c14)) = *(unsigned short*)(((int)c + 0x4c14)) - 1;
     if (*(short*)(c + 0x4c14) < 0) *(short*)(c + 0x4c14) = 0;
     if (*(unsigned short*)(c + 0x4c14) != 0)
       _ZN5Sound12PlayBank2_2DEj(0xa7);

--- a/src/func_ov006_0211e4e0.c
+++ b/src/func_ov006_0211e4e0.c
@@ -1,4 +1,4 @@
-#define A(p) ((unsigned char *)(int)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define A(p) ((unsigned char *)(int)(((long long)(int)(p))))
 
 void func_ov006_0211e4e0(char *base)
 {

--- a/src/func_ov006_0211e5cc.c
+++ b/src/func_ov006_0211e5cc.c
@@ -36,5 +36,5 @@ void func_ov006_0211e5cc(char* c)
     if (found != 0)
         return;
     FreeGfxSlotsById(0xc);
-    (*(u8*)((long long)(int)(c + 0x4c20) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(u8*)((long long)(int)(c + 0x4c20)))++;
 }

--- a/src/func_ov006_0211e8a8.c
+++ b/src/func_ov006_0211e8a8.c
@@ -7,7 +7,7 @@ extern int* _ZN3G2S13GetBG0CharPtrEv(void);
 extern void func_ov006_0211e55c(char* c, int idx);
 extern void func_02012718(void* a, int b);
 
-#define A(a) (*(u8*)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define A(a) (*(u8*)(((long long)(int)(a))))
 
 void func_ov006_0211e8a8(char* c, int idx)
 {

--- a/src/func_ov006_0211f34c.c
+++ b/src/func_ov006_0211f34c.c
@@ -3,24 +3,24 @@ typedef unsigned short u16;
 void func_ov006_0211f34c(char *o, int i)
 {
     int m = i * 0x24;
-    int xt = *(int *)((char *)(((int)o + 0x4660) & 0xFFFFFFFFFFFFFFFF) + m) >> 12;
-    int yt = *(int *)((char *)(((int)o + 0x4664) & 0xFFFFFFFFFFFFFFFF) + m) >> 12;
+    int xt = *(int *)((char *)(((int)o + 0x4660)) + m) >> 12;
+    int yt = *(int *)((char *)(((int)o + 0x4664)) + m) >> 12;
     if (xt + 8 > 0xfe) {
-        u16 *pa = (u16 *)((char *)(((int)o + 0x466c) & 0xFFFFFFFFFFFFFFFF) + m);
+        u16 *pa = (u16 *)((char *)(((int)o + 0x466c)) + m);
         *pa = 0x8000 - *pa;
-        *(int *)((char *)(((int)o + 0x4660) & 0xFFFFFFFFFFFFFFFF) + m) = 0xf6000;
+        *(int *)((char *)(((int)o + 0x4660)) + m) = 0xf6000;
     } else if (xt - 8 < 2) {
-        u16 *pa = (u16 *)((char *)(((int)o + 0x466c) & 0xFFFFFFFFFFFFFFFF) + m);
+        u16 *pa = (u16 *)((char *)(((int)o + 0x466c)) + m);
         *pa = 0x8000 - *pa;
-        *(int *)((char *)(((int)o + 0x4660) & 0xFFFFFFFFFFFFFFFF) + m) = 0xa000;
+        *(int *)((char *)(((int)o + 0x4660)) + m) = 0xa000;
     }
     if (yt + 8 > 0xbe) {
-        u16 *pa = (u16 *)((char *)(((int)o + 0x466c) & 0xFFFFFFFFFFFFFFFF) + m);
+        u16 *pa = (u16 *)((char *)(((int)o + 0x466c)) + m);
         *pa = -*pa;
-        *(int *)((char *)(((int)o + 0x4664) & 0xFFFFFFFFFFFFFFFF) + m) = 0xb6000;
+        *(int *)((char *)(((int)o + 0x4664)) + m) = 0xb6000;
     } else if (yt - 8 < 2) {
-        u16 *pa = (u16 *)((char *)(((int)o + 0x466c) & 0xFFFFFFFFFFFFFFFF) + m);
+        u16 *pa = (u16 *)((char *)(((int)o + 0x466c)) + m);
         *pa = -*pa;
-        *(int *)((char *)(((int)o + 0x4664) & 0xFFFFFFFFFFFFFFFF) + m) = 0xa000;
+        *(int *)((char *)(((int)o + 0x4664)) + m) = 0xa000;
     }
 }

--- a/src/func_ov006_0211fb1c.c
+++ b/src/func_ov006_0211fb1c.c
@@ -1,6 +1,6 @@
 typedef unsigned char u8;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];

--- a/src/func_ov006_0211fd44.c
+++ b/src/func_ov006_0211fd44.c
@@ -15,7 +15,7 @@ void func_ov006_0211fd44(char *c)
     func_ov006_0211f6fc(c);
     func_ov006_0211e184(c);
     if (*(unsigned short *)(c + 0x4c0c) == 0) return;
-    *(unsigned short *)(((int)c + 0x4c0c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(unsigned short *)(((int)c + 0x4c0c)) -= 1;
     if (*(short *)(c + 0x4c0c) > 0) return;
     *(unsigned short *)(c + 0x4c0c) = 0;
     if (*(unsigned char *)(c + 0x4000 + 0xc1f) != 0) {
@@ -24,7 +24,7 @@ void func_ov006_0211fd44(char *c)
         p = func_020beb68;
         if (p != 0) {
             if (p->b4 < 0x270f) {
-                *(int *)(((int)p + 0xb4) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(int *)(((int)p + 0xb4)) += 1;
             }
             if (p->b4 > p->b8) {
                 p->b8 = p->b4;

--- a/src/func_ov006_02120008.c
+++ b/src/func_ov006_02120008.c
@@ -13,7 +13,7 @@ void func_ov006_02120008(char *c)
   if (g[0xb] != 0)
   {
     new_var = ((int) c) + 0x4c16;
-    *((unsigned short *) (new_var & 0xFFFFFFFFFFFFFFFF)) = (*((unsigned short *) (new_var & 0xFFFFFFFFFFFFFFFF))) - 1;
+    *((unsigned short *) (new_var)) = (*((unsigned short *) (new_var))) - 1;
     if (((unsigned short *) (c + 0x4c00))[0xb] == 0)
     {
       FreeGfxSlotsById(0xd);

--- a/src/func_ov006_02120ab8.c
+++ b/src/func_ov006_02120ab8.c
@@ -15,7 +15,7 @@ void func_ov006_02120ab8(char *this)
     *((short *) (this + 0x20)) = 0;
   }
   {
-    int *p = (int *) (((int) this + 4) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int *) (((int) this + 4));
     *p = *p + (*((int *) (this + 0x14)));
   }
   _Z14ApproachLinearRiii((int *) (this + 8), *((int *) (this + 0x10)), 0x1800);

--- a/src/func_ov006_02121778.c
+++ b/src/func_ov006_02121778.c
@@ -8,7 +8,7 @@ extern int data_ov006_0213faa8[];
 void func_ov006_02121778(char *c)
 {
     int idx, b;
-    *(int *)(((long long)(int)(c + 0x5d90)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(c + 0x5d90))) -= 1;
     if (*(int *)(c + 0x5000 + 0xd90) != 0)
     {
         idx = data_020a0e40[0];

--- a/src/func_ov006_021218fc.c
+++ b/src/func_ov006_021218fc.c
@@ -54,7 +54,7 @@ void func_ov006_021218fc(char *c)
             {
                 int amt = data_ov006_02140588 * 2;
                 if (amt > 0xb4) amt = 0xb4;
-                *(int *)(((int)c + 0x5d90) & 0xFFFFFFFFFFFFFFFFLL) -= amt;
+                *(int *)(((int)c + 0x5d90)) -= amt;
             }
         }
     }

--- a/src/func_ov006_02121d64.cpp
+++ b/src/func_ov006_02121d64.cpp
@@ -27,7 +27,7 @@ extern "C" void func_ov006_02121d64(char *c)
     int counter;
 
     func_ov006_020d0ac0();
-    *(int *)(((long long)(int)(c + 0x5d90)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(c + 0x5d90))) -= 1;
     counter = *(int *)(c + 0x5d90);
 
     if (counter == 0) {
@@ -59,7 +59,7 @@ extern "C" void func_ov006_02121d64(char *c)
         *(s16 *)(c + 0x5db0) = (s16)(mixRaw >> 12);
         *(s16 *)(c + 0x5db2) = data_ov006_0212e048;
 
-        *(s16 *)(((long long)(int)(c + 0x5db2)) & 0xFFFFFFFFFFFFFFFFLL) +=
+        *(s16 *)(((long long)(int)(c + 0x5db2))) +=
             ((((int)((unsigned int)(RandomIntInternal(&data_0209e650) &
                               ~0x80000000) >> 19) -
                0x800) << 2) >> 12);

--- a/src/func_ov006_02123b24.c
+++ b/src/func_ov006_02123b24.c
@@ -8,7 +8,7 @@ extern int data_ov006_0213fbd0[];
 void func_ov006_02123b24(char *c)
 {
     int idx, b;
-    *(int *)(((long long)(int)(c + 0x7b84)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(c + 0x7b84))) -= 1;
     if (*(int *)(c + 0x7000 + 0xb84) != 0)
     {
         idx = data_020a0e40[0];

--- a/src/func_ov006_02124088.c
+++ b/src/func_ov006_02124088.c
@@ -24,7 +24,7 @@ void func_ov006_02124088(char *c)
     int counter;
 
     func_ov006_020d0ac0();
-    *(int *)(((long long)(int)(c + 0x7b84)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(int *)(((long long)(int)(c + 0x7b84))) -= 1;
     counter = *(int *)(c + 0x7b84);
 
     if (counter == 0) {
@@ -54,7 +54,7 @@ void func_ov006_02124088(char *c)
         *(s16 *)(c + 0x7b9c) = (s16)(mixRaw >> 12);
         *(s16 *)(c + 0x7b9e) = data_ov006_0212e048;
 
-        *(s16 *)(((long long)(int)(c + 0x7b9e)) & 0xFFFFFFFFFFFFFFFFLL) +=
+        *(s16 *)(((long long)(int)(c + 0x7b9e))) +=
             ((((int)((unsigned int)(RandomIntInternal(&data_0209e650) & ~0x80000000) >> 19) - 0x800) << 2) >> 12);
 
         func_ov004_020ae5c4(c, old9c, old9e, *(s16 *)(c + 0x7b9c), *(s16 *)(c + 0x7b9e), 2, 0xc);

--- a/src/func_ov006_02124bb4.c
+++ b/src/func_ov006_02124bb4.c
@@ -8,7 +8,7 @@ void func_ov006_02124bb4(char *c)
     int *cnt;
     int *p;
 
-    cnt = (int *)(((int)c + 0x51bc) & 0xFFFFFFFFFFFFFFFF);
+    cnt = (int *)(((int)c + 0x51bc));
     *cnt = *cnt - 1;
     if (*(int *)(c + 0x5000 + 0x1bc) > 0)
         return;
@@ -18,7 +18,7 @@ void func_ov006_02124bb4(char *c)
     {
         if (*(int *)(c + 0xb4) < 0x270f)
         {
-            p = (int *)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+            p = (int *)(((int)c + 0xb4));
             *p = *p + 1;
         }
         if (*(int *)(c + 0xb4) > *(int *)(c + 0xb8))
@@ -32,7 +32,7 @@ void func_ov006_02124bb4(char *c)
     {
         if (*(int *)(c + 0xb4) > 0)
         {
-            p = (int *)(((int)c + 0xb4) & 0xFFFFFFFFFFFFFFFF);
+            p = (int *)(((int)c + 0xb4));
             *p = *p - 1;
         }
         func_ov004_020b0a54(5);

--- a/src/func_ov006_02124cb4.c
+++ b/src/func_ov006_02124cb4.c
@@ -9,16 +9,16 @@ extern void func_ov004_020ad79c(int a, int b);
 void func_ov006_02124cb4(char *o)
 {
     int i;
-    *(u8 *)(((int)o + 0x51ce) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(u8 *)(((int)o + 0x51ce)) += 1;
     if (*(u8 *)(o + 0x51ce) < 4)
         return;
     *(u8 *)(o + 0x51ce) = 0;
     for (i = 0; i < 2; i++)
-        *(u8 *)(((int)o + i + 0x51cc) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(u8 *)(((int)o + i + 0x51cc)) += 1;
     if (*(u8 *)(o + *(int *)(o + 0x51c4) + 0x51cc) < 4)
         return;
     *(int *)(o + 0x51bc) = 0x1e;
-    *(int *)(((int)o + 0x51b8) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int *)(((int)o + 0x51b8)) += 1;
     o[0xc3] = 0;
     {
         u8 x = *(u8 *)(o + *(int *)(o + 0x51c0) + 0x51ca);

--- a/src/func_ov006_02124dc0.c
+++ b/src/func_ov006_02124dc0.c
@@ -6,11 +6,11 @@ void func_ov006_02124dc0(void* arg0)
 {
     char* c = (char*)arg0;
 
-    *(s32*)(((int)c + 0x51bc) & 0xFFFFFFFFFFFFFFFF) =
-        *(s32*)(((int)c + 0x51bc) & 0xFFFFFFFFFFFFFFFF) - 1;
+    *(s32*)(((int)c + 0x51bc)) =
+        *(s32*)(((int)c + 0x51bc)) - 1;
     if (*(s32*)(c + 0x51bc) > 0)
         return;
     _ZN5Sound12PlayBank2_2DEj(0x148);
-    *(s32*)(((int)c + 0x51b8) & 0xFFFFFFFFFFFFFFFF) =
-        *(s32*)(((int)c + 0x51b8) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(s32*)(((int)c + 0x51b8)) =
+        *(s32*)(((int)c + 0x51b8)) + 1;
 }

--- a/src/func_ov006_02124e1c.cpp
+++ b/src/func_ov006_02124e1c.cpp
@@ -10,5 +10,5 @@ extern "C" void func_ov006_02124e1c(char* c)
     if (b == 0) return;
 
     *(int*)(c + 0x51bc) = 0x1e;
-    (*(int *)(((int)c + 0x51b8) & 0xFFFFFFFFFFFFFFFF)) += 1;
+    (*(int *)(((int)c + 0x51b8))) += 1;
 }

--- a/src/func_ov006_021250e4.c
+++ b/src/func_ov006_021250e4.c
@@ -43,5 +43,5 @@ void func_ov006_021250e4(char* base)
         *(unsigned short*)(base + 0xc0) = 0;
     }
 
-    *(int*)(((int)base + 0x51b8) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int*)(((int)base + 0x51b8)) += 1;
 }

--- a/src/func_ov006_02125890.c
+++ b/src/func_ov006_02125890.c
@@ -15,13 +15,13 @@ void func_ov006_02125890(char *o)
     for (i = 0; i < 0x20; i++, w += 0x24, pw += 0x24, vw += 0x24) {
         if (*(u8 *)(w + 0xba34)) {
             if (*(int *)(w + 0xba2c) > 0) {
-                *(int *)(((int)w + 0xba2c) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                *(int *)(((int)w + 0xba2c)) -= 1;
                 if (*(int *)(w + 0xba2c) <= 0) {
                     *(u8 *)(o + i * 0x24 + 0xba34) = 0;
                     return;
                 }
             }
-            *(int *)(((int)w + 0xba28) & 0xFFFFFFFFFFFFFFFF) -= 0x200;
+            *(int *)(((int)w + 0xba28)) -= 0x200;
             AddVec3((Vec3 *)pw, (Vec3 *)vw, (Vec3 *)pw);
             if (*(int *)(w + 0xba28) < 0 && *(int *)(w + 0xba1c) < 0) {
                 *(u8 *)(o + i * 0x24 + 0xba34) = 0;

--- a/src/func_ov006_021279b0.cpp
+++ b/src/func_ov006_021279b0.cpp
@@ -49,7 +49,7 @@ extern s32 data_02092768[4];
 #define I(o) (*(s32 *)(c + (o)))
 #define H(o) (*(u16 *)(c + (o)))
 #define B(o) (*(u8 *)(c + (o)))
-#define AT(p, o) ((void *)(int)(((long long)(int)((char *)(p) + (o))) & 0xffffffffffffffffLL))
+#define AT(p, o) ((void *)(int)(((long long)(int)((char *)(p) + (o)))))
 
 extern "C" void func_ov006_021279b0(char *c)
 {

--- a/src/func_ov006_0212a654.c
+++ b/src/func_ov006_0212a654.c
@@ -16,7 +16,7 @@ typedef struct Obj {
     u8 unk5fcd;
 } Obj;
 
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 #define A1(off) ((int)M((int)M((char *)self + (int)M(i) * 32) + (off)))
 #define A2(off) ((int)M((int)M((char *)self + (unsigned)i * 32) + (off)))
 #define B1(off) (*(u8 *)A1(off))

--- a/src/func_ov007_020aebac.c
+++ b/src/func_ov007_020aebac.c
@@ -3,7 +3,7 @@ extern char *data_ov007_0210342c;
 int func_ov007_020aebac(void)
 {
     char *q = *(char **)(*(char **)(data_ov007_0210342c + 0x28));
-    unsigned char *b = (unsigned char *)(((long long)(int)(q + 0xb)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char *b = (unsigned char *)(((long long)(int)(q + 0xb)));
     if (b[0] == 0 && b[1] == 0 && b[2] == 0 && *(int *)(q + 4) == 0)
         return 1;
     return 0;

--- a/src/func_ov007_020b2370.cpp
+++ b/src/func_ov007_020b2370.cpp
@@ -5,7 +5,7 @@ void func_ov007_020be9ac(void* a, void* b, void* c);
 void func_ov007_020bbff0(void* c);
 }
 extern char* data_ov007_0210342c;
-#define LAUNDER(x) ((char*)(int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+#define LAUNDER(x) ((char*)(int)(((long long)(int)(x))))
 
 extern "C" void func_ov007_020b2370(void){
   char* g = *(char**)&data_ov007_0210342c;

--- a/src/func_ov007_020b413c.c
+++ b/src/func_ov007_020b413c.c
@@ -30,8 +30,8 @@ typedef struct G2 {
     R8 *f17c;
 } G2;
 
-#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))&0xFFFFFFFFFFFFFFFFLL))
-#define MASK(p) ((void*)(int)(((long long)(int)(p))&0xFFFFFFFFFFFFFFFFLL))
+#define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
+#define MASK(p) ((void*)(int)(((long long)(int)(p))))
 
 extern G2 *data_ov007_0210342c;
 extern unsigned char data_ov007_020d7610[];

--- a/src/func_ov007_020b4c04.c
+++ b/src/func_ov007_020b4c04.c
@@ -72,7 +72,7 @@ void *func_ov007_020b4c04(int arg0)
             if (arg0 != 0) {
                 *(s16 *)(r6 + 0xc) = 0x48;
             } else {
-                s32 *p = (s32 *)(((long long)(int)(r6 + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+                s32 *p = (s32 *)(((long long)(int)(r6 + 0x10)));
                 *p = *p + 0xc;
             }
         }

--- a/src/func_ov007_020b7708.c
+++ b/src/func_ov007_020b7708.c
@@ -21,6 +21,6 @@ void func_ov007_020b7708(int idx, void* pos)
         struct PtclSys* s;
         data_ov007_02103450[idx] = _ZN8Particle7Manager9AddSystemEiR7Vector3(data_ov007_0210344c, 0, pos);
         s = data_ov007_02103450[idx];
-        *(u32*)(((long long)(int)((char*)s + 0x1c)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(u32*)(((long long)(int)((char*)s + 0x1c))) |= 2;
     }
 }

--- a/src/func_ov007_020b8690.c
+++ b/src/func_ov007_020b8690.c
@@ -9,8 +9,8 @@ extern int func_ov007_020c44c4(char* p);
 
 #pragma opt_propagation off
 void func_ov007_020b8690(void) {
-    int *pa = (int *)(int)((long long)(int)&data_ov007_0210345c & 0xFFFFFFFFFFFFFFFFLL);
-    short *pb = (short *)(int)((long long)(int)&data_ov007_02103458 & 0xFFFFFFFFFFFFFFFFLL);
+    int *pa = (int *)(int)((long long)(int)&data_ov007_0210345c);
+    short *pb = (short *)(int)((long long)(int)&data_ov007_02103458);
     int v = 0;
     *pa = v;
     *pb = v;

--- a/src/func_ov007_020b88c0.c
+++ b/src/func_ov007_020b88c0.c
@@ -40,7 +40,7 @@ void func_ov007_020b88c0(void)
         r = i;
         do {
             data_ov007_02103484[r] = 4;
-            data_ov007_02103484[(int)(((long long)r) & 0xFFFFFFFFFFFFFFFFLL) + w - 1] = 6;
+            data_ov007_02103484[(int)(((long long)r)) + w - 1] = 6;
             i++;
             r += w;
         } while (i < h);

--- a/src/func_ov007_020b8d48.c
+++ b/src/func_ov007_020b8d48.c
@@ -75,7 +75,7 @@ void func_ov007_020b8d48(int a, int c)
         u32 s = *src++ & palmask;
         *dst = (*dst & mask) | (s << shift);
         if (rem != 0) {
-            u32 *d2 = (u32 *)(int)(((long long)(int)(dst + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+            u32 *d2 = (u32 *)(int)(((long long)(int)(dst + 8)));
             *d2 = (*d2 & ~mask) | (s >> rshift);
         }
         dst++;

--- a/src/func_ov007_020b9ca8.c
+++ b/src/func_ov007_020b9ca8.c
@@ -87,6 +87,6 @@ void func_ov007_020b9ca8(void)
         *(u16 *)(*(char **)(data_ov007_0210342c + 0x54)) != 0) {
         *(int *)(data_ov007_02104ba0 + 0x28) = 0;
     } else {
-        (*(int *)(int)(((long long)(int)(data_ov007_02104ba0 + 0x28)) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(int *)(int)(((long long)(int)(data_ov007_02104ba0 + 0x28))))++;
     }
 }

--- a/src/func_ov007_020b9fc0.c
+++ b/src/func_ov007_020b9fc0.c
@@ -7,7 +7,7 @@ int func_ov007_020b9fc0(void) {
     char *p1 = *(char **)(base + 4);
     char *p2 = *(char **)(base + 8);
     int *addr4 = (int *)(p2 + 0x50);
-    int *addr1 = (int *)(((long long)(int)(p1 + 0x50)) & 0xffffffffffffffffLL);
+    int *addr1 = (int *)(((long long)(int)(p1 + 0x50)));
 
     if (*addr1 < 0x1f000) {
         char *c = (char *)data_ov007_02104ba0;

--- a/src/func_ov007_020ba2e0.c
+++ b/src/func_ov007_020ba2e0.c
@@ -43,6 +43,6 @@ void func_ov007_020ba2e0(void)
     data_ov007_02104ba0->x40 = 0x1000;
     data_ov007_02104ba0->x44->x18 = 0x800;
     data_ov007_02104ba0->x3c = data_ov007_02104ba0->x44->x18;
-    (*(int *)((long long)(int)((char *)data_ov007_02104ba0 + 0x24) & 0xFFFFFFFFFFFFFFFFLL)) += 1;
+    (*(int *)((long long)(int)((char *)data_ov007_02104ba0 + 0x24))) += 1;
     data_ov007_02104ba0->f8->f2 = 5;
 }

--- a/src/func_ov007_020ba368.c
+++ b/src/func_ov007_020ba368.c
@@ -33,7 +33,7 @@ int func_ov007_020ba368(int t)
     }
 
     if (t == 0) {
-        int *p = (int *)(((s64)(int)(*(char **)data_ov007_02104ba0 + 0x20)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((s64)(int)(*(char **)data_ov007_02104ba0 + 0x20)));
         *p += 1;
         if (*(int *)(*(char **)data_ov007_02104ba0 + 0x20) >= 5) {
             *(int *)(*(char **)data_ov007_02104ba0 + 0x20) = 0;

--- a/src/func_ov007_020bb09c.c
+++ b/src/func_ov007_020bb09c.c
@@ -122,8 +122,8 @@ int func_ov007_020bb09c(void)
             if (n <= 0) return n;
             {
                 char* e = *(char**)(*(char**)(r5 + 0x38) + (n - 1) * 4);
-                int* p14 = (int*)(((long long)(int)(r5 + 0x14)) & 0xFFFFFFFFFFFFFFFFLL);
-                int* p8 = (int*)(((long long)(int)(r5 + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+                int* p14 = (int*)(((long long)(int)(r5 + 0x14)));
+                int* p8 = (int*)(((long long)(int)(r5 + 8)));
                 *p14 = *p14 - *(unsigned short*)(e + 0xa);
                 *p8 = *p8 - 1;
                 *(short*)(*(char**)((char*)BA0 + 8) + 2) = 6;
@@ -145,8 +145,8 @@ int func_ov007_020bb09c(void)
         if (n >= lim) return lim;
         {
             char* e = *(char**)(*(char**)(r5 + 0x38) + n * 4);
-            int* p14 = (int*)(((long long)(int)(r5 + 0x14)) & 0xFFFFFFFFFFFFFFFFLL);
-            int* p8 = (int*)(((long long)(int)(r5 + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p14 = (int*)(((long long)(int)(r5 + 0x14)));
+            int* p8 = (int*)(((long long)(int)(r5 + 8)));
             *p14 = *p14 + *(unsigned short*)(e + 0xa);
             *p8 = *p8 + 1;
             *(short*)(*(char**)(*(char* volatile*)&data_ov007_02104ba0 + 8) + 2) = 7;

--- a/src/func_ov007_020bbd24.cpp
+++ b/src/func_ov007_020bbd24.cpp
@@ -29,7 +29,7 @@ extern "C" int func_ov007_020bbd24(int param)
     if (r5 == 1) {
         data_ov007_02104ba0->f34 = 0;
     } else if (r5 == 0) {
-        int *fp = (int *)(((int)data_ov007_02104ba0 + 0x34) & 0xFFFFFFFFFFFFFFFF);
+        int *fp = (int *)(((int)data_ov007_02104ba0 + 0x34));
         *fp += r4;
     }
 
@@ -37,7 +37,7 @@ extern "C" int func_ov007_020bbd24(int param)
 
     switch (param) {
     case 0: {
-        int *q = (int *)(((int)&data_ov007_02104b9c->f4->f50) & 0xFFFFFFFFFFFFFFFF);
+        int *q = (int *)(((int)&data_ov007_02104b9c->f4->f50));
         int v = *q;
         if (v <= 0x5000) {
             *q = v + 0x7d0;

--- a/src/func_ov007_020bbf98.c
+++ b/src/func_ov007_020bbf98.c
@@ -7,7 +7,7 @@ void func_ov007_020bbf98(int** o, unsigned int mask){
   if (n <= 0) return;
   off = i;
   do {
-    fld = (int*)(((int)((char*)base[1] + off) + 0x24) & 0xFFFFFFFFFFFFFFFF);
+    fld = (int*)(((int)((char*)base[1] + off) + 0x24));
     i++;
     fld[0] = (fld[0] & ~0xf) | mask;
     off += 0x30;

--- a/src/func_ov007_020bc02c.c
+++ b/src/func_ov007_020bc02c.c
@@ -3,7 +3,7 @@ typedef short s16;
 
 typedef struct { int f[12]; } Blk;
 
-#define LS(a) (*(short*)(((long long)(int)(a)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LS(a) (*(short*)(((long long)(int)(a))))
 
 extern void func_ov007_020bc968(char *c, void *other);
 extern void func_ov007_020bc894(char *c);

--- a/src/func_ov007_020bc7dc.c
+++ b/src/func_ov007_020bc7dc.c
@@ -22,7 +22,7 @@ void func_ov007_020bc7dc(char* c)
     if (*(int*)(c + 0x98) == 0)
         return;
 
-    *(short*)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(short*)(((long long)(int)(c + 0x8c))) -= 1;
     if (*(short*)(c + 0x8c) <= 0)
         *(short*)(c + 0x8c) = 0;
 }

--- a/src/func_ov007_020be0dc.c
+++ b/src/func_ov007_020be0dc.c
@@ -76,7 +76,7 @@ int func_ov007_020be0dc(void)
         }
 
         {
-            int *pp = (int *)(((int)BASE1 + 0x18) & 0xFFFFFFFFFFFFFFFF);
+            int *pp = (int *)(((int)BASE1 + 0x18));
             int d = func_020538b8(pp[0], pp[2]);
             int e = _ZN4cstd3divEii(d << 0xc, 0xffff);
             unsigned int scale = ((e * 0x12) >> 0xc) & 0xff;

--- a/src/func_ov007_020beb80.c
+++ b/src/func_ov007_020beb80.c
@@ -12,14 +12,14 @@ extern void func_02053380(void *a, void *b);
 void func_ov007_020beb80(char *self) {
     char *B = *(char **)(*(char **)(self + 4));
     char *P = *(char **)(B + 0xc);
-    int *q = (int *)(int)(((long long)(unsigned)(P + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *q = (int *)(int)(((long long)(unsigned)(P + 0x18)));
     int r;
     Vec3s dd;
     char *e;
     int frames;
     int vel;
     int sc;
-    Vec3i *tp = (Vec3i *)(int)(((long long)(int)(P + 0x24)) & 0xFFFFFFFFFFFFFFFFLL);
+    Vec3i *tp = (Vec3i *)(int)(((long long)(int)(P + 0x24)));
     r = func_020538b8(q[0], q[2]);
     dd.x = (short)(tp->x - *(int *)(self + 0xc));
     dd.y = (short)(tp->y - *(int *)(self + 0x10));
@@ -50,10 +50,10 @@ void func_ov007_020beb80(char *self) {
             }
             *(u8 *)(e + 0x58) = (u8)(((frames << 2) >> 12) + 1);
             *(int *)(e + 0x4c) = vel;
-            *(int *)(((int)e + 0x1c) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+            *(int *)(((int)e + 0x1c)) &= ~2;
             *(Vec3i *)(e + 0x20) = *tp;
         } else {
-            *(int *)(((int)e + 0x1c) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+            *(int *)(((int)e + 0x1c)) |= 2;
         }
     }
 }

--- a/src/func_ov007_020bffb8.c
+++ b/src/func_ov007_020bffb8.c
@@ -6,8 +6,8 @@ extern s16 data_02082214[];
 
 void func_ov007_020bffb8(char *c)
 {
-    s32 *out = (s32 *)(((int)c + 8) & 0xFFFFFFFFFFFFFFFF);
-    s32 *base = (s32 *)(((int)c + 0x14) & 0xFFFFFFFFFFFFFFFF);
+    s32 *out = (s32 *)(((int)c + 8));
+    s32 *base = (s32 *)(((int)c + 0x14));
     s32 angleA = *(u16 *)(c + 0x30);
     s32 angleB = *(u16 *)(c + 0x32);
     s32 indexA;

--- a/src/func_ov007_020c03b0.c
+++ b/src/func_ov007_020c03b0.c
@@ -28,12 +28,12 @@ void func_ov007_020c03b0(Arg *arg) {
     int bit1, bit2;
     int f;
 
-    pa = (Node *volatile *)(((long long)(int)arr_a) & 0xffffffffffffffffLL);
+    pa = (Node *volatile *)(((long long)(int)arr_a));
     pa[0] = 0;
     pa[1] = 0;
     pa[2] = 0;
     pa[3] = 0;
-    pb = (int *)(((long long)(int)arr_b) & 0xffffffffffffffffLL);
+    pb = (int *)(((long long)(int)arr_b));
     pb[0] = 0;
     pb[1] = 0;
     pb[2] = 0;

--- a/src/func_ov007_020c0d70.c
+++ b/src/func_ov007_020c0d70.c
@@ -18,7 +18,7 @@ struct AnimData {
     u32 count;      /* 0xc */
 };
 
-#define AT16(p, off) (*(short *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT16(p, off) (*(short *)(int)(((long long)(int)((char *)(p) + (off)))))
 
 void func_ov007_020c0d70(struct Anim *a, struct AnimData *d)
 {

--- a/src/func_ov007_020c24d0.c
+++ b/src/func_ov007_020c24d0.c
@@ -27,11 +27,11 @@ void func_ov007_020c24d0(struct S *s, int arg1)
         return;
     if (arg1 >= s->count)
         return;
-    (*(unsigned short *)(((int)s + 8) & 0xFFFFFFFFFFFFFFFF))--;
+    (*(unsigned short *)(((int)s + 8)))--;
     if (arg1 == s->count)
         return;
 
-    i = (int)(((long long)arg1) & 0xFFFFFFFFFFFFFFFF);
+    i = (int)(((long long)arg1));
     while (i < s->count) {
         switch (s->state) {
         case 0:

--- a/src/func_ov007_020c25fc.c
+++ b/src/func_ov007_020c25fc.c
@@ -22,7 +22,7 @@ int func_ov007_020c25fc(struct S *self, int a1, int a2, int a3, int e, int v)
         self->f28[self->f8] = a2;
         func_ov007_020c2d44(self, self->f8);
         {
-            unsigned short *p = (unsigned short *)(((int)self + 8) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *p = (unsigned short *)(((int)self + 8));
             *p = *p + 1;
         }
         if (func_ov007_020c2dfc(self, self->f8 - 1, v) != 0)

--- a/src/func_ov007_020c4128.c
+++ b/src/func_ov007_020c4128.c
@@ -4,7 +4,7 @@ extern void func_ov007_020c4388(char* r0, int r1);
 extern void SubVec3(Vec3 *a, Vec3 *b, Vec3 *c);
 extern void func_ov007_020c421c(char *r4);
 
-#define ADDR(p) ((int *)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define ADDR(p) ((int *)(((long long)(int)(p))))
 
 void func_ov007_020c4128(char *self, char *dest, int arg2)
 {

--- a/src/func_ov007_020c41dc.c
+++ b/src/func_ov007_020c41dc.c
@@ -2,7 +2,7 @@ extern void func_ov007_020c43bc(void *self, int arg);
 
 void func_ov007_020c41dc(char *a0, char *a1, int a2)
 {
-    int *slot = (int *)(((int)a1 + 0x10) & 0xFFFFFFFFFFFFFFFF);
+    int *slot = (int *)(((int)a1 + 0x10));
     int addend = *(int *)(a0 + 0x10);
     int value = *slot;
     int old = *(int *)(a1 + 0x10);

--- a/src/func_ov007_020c5014.c
+++ b/src/func_ov007_020c5014.c
@@ -1,6 +1,6 @@
 extern int _ZN4cstd3divEii(int, int);
 
-#define AMAT(p) (*(int*)((long long)(int)(p) & 0xffffffffffffffffLL))
+#define AMAT(p) (*(int*)((long long)(int)(p)))
 
 #pragma opt_common_subs off
 int func_ov007_020c5014(char* c, int x) {

--- a/src/func_ov007_020c55bc.c
+++ b/src/func_ov007_020c55bc.c
@@ -47,7 +47,7 @@ void func_ov007_020c55bc(struct Self *self, int m1, int m2)
             do {
                 row = (int *)self->f2c[i];
                 p = self->f34[i][j];
-                q = (int *)(((int)p + 0xc) & 0xFFFFFFFFFFFFFFFFLL);
+                q = (int *)(((int)p + 0xc));
                 b7c = self->f7c;
                 b80 = self->f80;
                 e = (int *)((char *)row + k);

--- a/src/func_ov007_020c56bc.c
+++ b/src/func_ov007_020c56bc.c
@@ -42,7 +42,7 @@ void func_ov007_020c56bc(char* sl, int sb, int r2, int r3, int p4, int fp)
                         {
                             int* q;
                             r6[0] = r6[0] + r5;
-                            q = (int*)(int)(((long long)(int)((char*)r6 + 4)) & 0xFFFFFFFFFFFFFFFFLL);
+                            q = (int*)(int)(((long long)(int)((char*)r6 + 4)));
                             *q = *q + r0v;
                         }
                         break;

--- a/src/func_ov007_020c5948.c
+++ b/src/func_ov007_020c5948.c
@@ -1,6 +1,6 @@
 struct Vec3 { int x; int y; int z; };
 
-#define LAUNDER(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LAUNDER(p) ((long long)(int)(p))
 
 extern void AddVec3(struct Vec3 *a, struct Vec3 *b, struct Vec3 *c);
 

--- a/src/func_ov007_020c5d5c.c
+++ b/src/func_ov007_020c5d5c.c
@@ -9,7 +9,7 @@ int func_ov007_020c5d5c(int *o)
     int *p = ((int **) o[0xe])[i];
     unsigned short h = *((unsigned short *) (((char *) p) + 8));
     int *t = (int *) (((char *) p) + 0x20)[0];
-    sum += ((int *) (*((int **) (((char *) p) + (0x20 & 0xFFFFFFFFFFFFFFFFu)))))[h - 1];
+    sum += ((int *) (*((int **) (((char *) p) + (0x20u)))))[h - 1];
   }
 
   return sum;

--- a/src/func_ov007_020c65bc.c
+++ b/src/func_ov007_020c65bc.c
@@ -40,7 +40,7 @@ int func_ov007_020c65bc(struct T *t, int a1, int a2, int a3)
     if (func_ov007_020c25fc(b, a1 << 12, a2 << 12, g->f8, g->fc, g->f10) != 0)
     {
       int idx = m + 1;
-      int *p = (int *)(((int)t + 0x14) & 0xFFFFFFFFFFFFFFFF);
+      int *p = (int *)(((int)t + 0x14));
       b->f20[idx] = a3;
       *p = *p + 1;
       func_ov007_020bfe4c(t->fa8, b->f24[idx], b->f28[idx], -(*((int *) (t->fa8 + 0x2c))), t->f24 + (idx * 0xc));

--- a/src/func_ov007_020c684c.c
+++ b/src/func_ov007_020c684c.c
@@ -14,7 +14,7 @@ void func_ov007_020c684c(char *o)
     *(int *)(o + 0x88) = *(int *)(o + 0x8c);
     *(Vec3 *)(o + 0x7c) = *(Vec3 *)(o + 0x70);
     *(Vec3 *)(o + 0x98) = *(Vec3 *)(o + 0x70);
-    tp = (Vec3 *)(((long long)(int)&tmp) & 0xFFFFFFFFFFFFFFFFLL);
+    tp = (Vec3 *)(((long long)(int)&tmp));
     tp->a = 0;
     tp->b = 0;
     tp->c = 0;

--- a/src/func_ov007_020c704c.c
+++ b/src/func_ov007_020c704c.c
@@ -46,9 +46,9 @@ int func_ov007_020c704c(S *self, Vec3 *b, int r2arg, int r3arg, int radius)
         spd = func_020531a4(sum);
         ratio = _ZN4cstd4fdivEii(r2arg, spd);
 
-        q = (int *)(int)(((s64)(int)((char *)self + 0x10)) & 0xFFFFFFFFFFFFFFFFLL);
+        q = (int *)(int)(((s64)(int)((char *)self + 0x10)));
         *q = *q + (int)((ratio * sdx + 0x800) >> 12);
-        self = (S *)(int)(((s64)(int)((char *)self + 0x14)) & 0xFFFFFFFFFFFFFFFFLL);
+        self = (S *)(int)(((s64)(int)((char *)self + 0x14)));
         *(int *)self = *(int *)self + (int)((ratio * sdy + 0x800) >> 12);
         return 1;
     }

--- a/src/func_ov007_020c7a84.c
+++ b/src/func_ov007_020c7a84.c
@@ -5,12 +5,12 @@ void func_ov007_020c7a84(char *p, int f1, int f2)
     int m1 = (int)(((long long)f1 * t + 0x800) >> 12);
     int m2 = (int)(((long long)f2 * *(int *)(a + 0xc) + 0x800) >> 12);
     int nm1 = -m1;
-    int *pa18 = (int *)(int)(((long long)(int)(a + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *pa18 = (int *)(int)(((long long)(int)(a + 0x18)));
     *pa18 = *pa18 + (nm1 - m2);
     {
         char *b = *(char **)(p + 4);
         int m3 = (int)(((long long)f2 * *(int *)(b + 0xc) + 0x800) >> 12);
-        int *pb18 = (int *)(int)(((long long)(int)(b + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *pb18 = (int *)(int)(((long long)(int)(b + 0x18)));
         *pb18 = *pb18 - (nm1 + m3);
     }
 }

--- a/src/func_ov007_020c7b2c.c
+++ b/src/func_ov007_020c7b2c.c
@@ -5,7 +5,7 @@ struct B { struct P *p; int f4; int f8; int fc; int f10; int f14; };
 struct J { struct B *a; struct B *b; int f8; int fc; int f10; };
 
 #define FXM(a, b) ((int)(((s64)(a) * (b) + 0x800) >> 12))
-#define AT(p, off) (*(int *)(int)(((long long)(int)((char *)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) (*(int *)(int)(((long long)(int)((char *)(p) + (off)))))
 
 void func_ov007_020c7b2c(struct J *self, int m1, int m2)
 {

--- a/src/func_ov007_020c80c8.c
+++ b/src/func_ov007_020c80c8.c
@@ -3,21 +3,21 @@ void func_ov007_020c80c8(char *o, int a, int s)
     if (!(*(int *)(o + 0x20) & 1)) {
         if (*(short *)(o + 0x1c) == 0x1000) {
             int m = (int)(((long long)a * *(int *)(o + 0xc) + 0x800) >> 12);
-            int *p = (int *)(int)(((long long)(int)(o + 0xc)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)(int)(((long long)(int)(o + 0xc)));
             *p += (*(int *)(o + 0x18) - m) >> s;
         } else {
             int m = (int)(((long long)a * *(int *)(o + 0xc) + 0x800) >> 12);
-            int *p18 = (int *)(int)(((long long)(int)(o + 0x18)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p18 = (int *)(int)(((long long)(int)(o + 0x18)));
             int m2;
             int *p0c;
             *p18 -= m;
             m2 = (int)(((long long)*(int *)(o + 0x18) * (*(short *)(o + 0x1c) >> s) + 0x800) >> 12);
-            p0c = (int *)(int)(((long long)(int)((char *)o + 0xc)) & 0xFFFFFFFFFFFFFFFFLL);
+            p0c = (int *)(int)(((long long)(int)((char *)o + 0xc)));
             *p0c += m2;
         }
         {
             int *base = *(int **)o;
-            int *q = (int *)(int)(((long long)(int)((char *)base + 8)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *q = (int *)(int)(((long long)(int)((char *)base + 8)));
             *q += *(int *)(o + 0xc) >> s;
         }
     }

--- a/src/func_ov007_020c81a0.c
+++ b/src/func_ov007_020c81a0.c
@@ -18,16 +18,16 @@ void func_ov007_020c81a0(struct T* o, int factor, int shift)
 {
     if (!(o->f20 & 1)) {
         if (o->f1c == 0x1000) {
-            *(int *)((int)&o->f4 & 0xFFFFFFFFFFFFFFFF) += (o->f10 - (int)(((s64)factor * o->f4 + 0x800) >> 0xc)) >> shift;
-            *(int *)((int)&o->f8 & 0xFFFFFFFFFFFFFFFF) += (o->f14 - (int)(((s64)factor * o->f8 + 0x800) >> 0xc)) >> shift;
+            *(int *)((int)&o->f4) += (o->f10 - (int)(((s64)factor * o->f4 + 0x800) >> 0xc)) >> shift;
+            *(int *)((int)&o->f8) += (o->f14 - (int)(((s64)factor * o->f8 + 0x800) >> 0xc)) >> shift;
         } else {
-            *(int *)((int)&o->f10 & 0xFFFFFFFFFFFFFFFF) -= (int)(((s64)factor * o->f4 + 0x800) >> 0xc);
-            *(int *)((int)&o->f14 & 0xFFFFFFFFFFFFFFFF) -= (int)(((s64)factor * o->f8 + 0x800) >> 0xc);
-            *(int *)((int)&o->f4 & 0xFFFFFFFFFFFFFFFF) += (int)(((s64)o->f10 * (o->f1c >> shift) + 0x800) >> 0xc);
-            *(int *)((int)&o->f8 & 0xFFFFFFFFFFFFFFFF) += (int)(((s64)o->f14 * (o->f1c >> shift) + 0x800) >> 0xc);
+            *(int *)((int)&o->f10) -= (int)(((s64)factor * o->f4 + 0x800) >> 0xc);
+            *(int *)((int)&o->f14) -= (int)(((s64)factor * o->f8 + 0x800) >> 0xc);
+            *(int *)((int)&o->f4) += (int)(((s64)o->f10 * (o->f1c >> shift) + 0x800) >> 0xc);
+            *(int *)((int)&o->f8) += (int)(((s64)o->f14 * (o->f1c >> shift) + 0x800) >> 0xc);
         }
         o->f0[0] += o->f4 >> shift;
-        *(int *)((int)&o->f0[1] & 0xFFFFFFFFFFFFFFFF) += o->f8 >> shift;
+        *(int *)((int)&o->f0[1]) += o->f8 >> shift;
     }
 
     o->f14 = 0;

--- a/src/func_ov007_020c831c.c
+++ b/src/func_ov007_020c831c.c
@@ -14,8 +14,8 @@ void func_ov007_020c831c(struct S *s, int shift, int r2arg)
             func_02053320(s->s1c >> r2arg, &s->v10, &s->v4, &s->v4);
         }
         *s->p += s->v4 >> r2arg;
-        *(int *)(((unsigned long long)((int)s->p + 4)) & 0xFFFFFFFFFFFFFFFF) += s->v8 >> r2arg;
-        *(int *)(((unsigned long long)((int)s->p + 8)) & 0xFFFFFFFFFFFFFFFF) += s->vc >> r2arg;
+        *(int *)(((unsigned long long)((int)s->p + 4))) += s->v8 >> r2arg;
+        *(int *)(((unsigned long long)((int)s->p + 8))) += s->vc >> r2arg;
     }
     s->v18 = 0;
     s->v14 = s->v18;

--- a/src/func_ov007_020c8498.c
+++ b/src/func_ov007_020c8498.c
@@ -25,7 +25,7 @@ void func_ov007_020c8498(char* r5)
     if(*(int*)(r5 + 8) == 0) return;
 
     if(*(int*)(r5 + 8) == 1){
-        int* v14 = (int*)((((long long)(int)(r5 + 0x14)) & 0xFFFFFFFFFFFFFFFFLL));
+        int* v14 = (int*)((((long long)(int)(r5 + 0x14))));
         *v14 += *(int*)(r5 + 0x18);
         if(*(int*)(r5 + 0x14) > 0x1000){
             *(int*)(r5 + 0x14) = 0x1000;

--- a/src/func_ov007_020c90c0.c
+++ b/src/func_ov007_020c90c0.c
@@ -10,7 +10,7 @@ void func_ov007_020c90c0(char *c)
 
     {
         int speed = *(int *)(c + 8);
-        short *pos = (short *)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+        short *pos = (short *)(((int)c + 0xc));
         short old = *pos;
 
         speed <<= 16;

--- a/src/func_ov007_020c92d0.c
+++ b/src/func_ov007_020c92d0.c
@@ -17,7 +17,7 @@ void func_ov007_020c92d0(char *state)
         *(short *)(state + 10) = *(short *)(state + 8);
         *(int *)(state + 4) = 0;
     } else if ((unsigned int)*(int *)(state + 12) < 0xffffffffU) {
-        int *counter = (int *)(((long long)((int)state + 12)) & 0xffffffffffffffffLL);
+        int *counter = (int *)(((long long)((int)state + 12)));
         ++*counter;
     }
 

--- a/src/func_ov007_020c9f10.c
+++ b/src/func_ov007_020c9f10.c
@@ -12,14 +12,14 @@ void func_ov007_020c9f10(T* self, Vec3* pos, int w, int h)
 {
     Vec3* pe = &self->e;
     Vec3* pd = &self->d;
-    Vec3* pc = (Vec3*)(((int)self + 0x2c) & 0xFFFFFFFFFFFFFFFF);
-    int* qd = (int*)(((int)self + 0x3c) & 0xFFFFFFFFFFFFFFFF);
-    int* qe = (int*)(((int)self + 0x48) & 0xFFFFFFFFFFFFFFFF);
+    Vec3* pc = (Vec3*)(((int)self + 0x2c));
+    int* qd = (int*)(((int)self + 0x3c));
+    int* qe = (int*)(((int)self + 0x48));
     *pe = *pos;
     *pd = *pe;
     *pc = *pd;
     {
-        Vec3* pb = (Vec3*)(((int)self + 0x20) & 0xFFFFFFFFFFFFFFFF);
+        Vec3* pb = (Vec3*)(((int)self + 0x20));
         *pb = *pc;
         self->a = *pb;
         pb->x -= w / 2;

--- a/src/func_ov007_020ca1d4.c
+++ b/src/func_ov007_020ca1d4.c
@@ -17,7 +17,7 @@ void func_ov007_020ca1d4(char *self, int arg1) {
             }
         }
     } else {
-        (*(int *)(((int)self + 4) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(int *)(((int)self + 4)))--;
         if (*(int *)(self + 4) <= 0)
             *(int *)(self + 4) = 0;
     }

--- a/src/func_ov007_020ca308.c
+++ b/src/func_ov007_020ca308.c
@@ -59,13 +59,13 @@ void func_ov007_020ca308(char *self, char *t, int i)
                     p = ((int *)p)[j];
                     p = *(int *)p;
                     p = ((int *)p)[cur];
-                    *(int *)((p + 0x18) & 0xFFFFFFFFFFFFFFFFLL) += val;
+                    *(int *)((p + 0x18)) += val;
                 } else if (i == 1) {
                     int p = *(int *)(*(int *)(t + 4) + 8);
                     p = ((int *)p)[cur];
                     p = *(int *)p;
                     p = ((int *)p)[j];
-                    *(int *)((p + 0x18) & 0xFFFFFFFFFFFFFFFFLL) += val;
+                    *(int *)((p + 0x18)) += val;
                 }
                 j++;
                 ph += step;

--- a/src/func_ov007_020ca578.c
+++ b/src/func_ov007_020ca578.c
@@ -29,5 +29,5 @@ void func_ov007_020ca578(char* self, int i, int j, int t)
         val = (int)(((s64)(0x1000 - t) * lo + (s64)t * hi) >> 0xc);
     }
 
-    *(int*)(((int)lr + 0x18) & 0xFFFFFFFFFFFFFFFFLL) += val;
+    *(int*)(((int)lr + 0x18)) += val;
 }

--- a/src/func_ov007_020ccad0.c
+++ b/src/func_ov007_020ccad0.c
@@ -20,7 +20,7 @@ int *func_ov007_020ccad0(void)
         _ZN9ActorBaseC1Ev(p);
         p[0] = (int)data_0208e4b8;
         p[0] = (int)_ZTV5Stage;
-        f = (unsigned char *)((long long)(int)((char *)p + 0x13) & 0xFFFFFFFFFFFFFFFFLL);
+        f = (unsigned char *)((long long)(int)((char *)p + 0x13));
         *f |= 1;
         *f |= 4;
         p[0] = (int)data_ov007_021032e8;

--- a/src/func_ov009_021115d8.c
+++ b/src/func_ov009_021115d8.c
@@ -35,5 +35,5 @@ void func_ov009_021115d8(char* c) {
     *(short*)(c+0x92) = 5000 - (unsigned int)RandomIntInternal(&data_0209e650) % 4000;
     *(int*)(c+0x174) = 0x28000;
     *(int*)(c+0x17c) = 3;
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x10000;
+    *(int *)(((int)c + 0xb0)) &= ~0x10000;
 }

--- a/src/func_ov010_0211125c.c
+++ b/src/func_ov010_0211125c.c
@@ -1,5 +1,5 @@
 void func_ov010_0211125c(unsigned char* c) {
-    (*(short *)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF)) += 0x400;
+    (*(short *)(((int)c + 0x90))) += 0x400;
     if (*(short*)(c + 0x90) > 0) {
         *(short*)(c + 0x90) = 0;
         *(int*)(c + 0x3a0) = 0;

--- a/src/func_ov010_021112b4.c
+++ b/src/func_ov010_021112b4.c
@@ -1,6 +1,6 @@
 extern char *func_ov010_0211139c(char *c);
 
-#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x)) & 0xffffffffffffffffLL))
+#define LAUNDER_ADDR(x) ((int)(((long long)(int)(x))))
 
 void func_ov010_021112b4(char *c)
 {

--- a/src/func_ov010_02111654.c
+++ b/src/func_ov010_02111654.c
@@ -79,7 +79,7 @@ int daObjC1_Trap_c_InitResources(char* c)
     self->unk_3a0 = 0;
 
     if ((*(int*)(c + 8) & 0xff) == 1) {
-        short* pa = (short*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        short* pa = (short*)(((int)c + 0x8e));
         *pa = *pa + 0x8000;
     }
     return 1;

--- a/src/func_ov010_0211184c.c
+++ b/src/func_ov010_0211184c.c
@@ -25,8 +25,8 @@ void func_ov010_0211184c(char* c, char* arg2) {
     if (target == 0) return;
     b = (int)(*(unsigned short*)(arg2+0xc) == 0xbf);
     if (b == 0) return;
-    sa = (struct Vector3*)(((int)arg2 + 0x5c) & 0xFFFFFFFFFFFFFFFF);
-    st = (struct Vector3*)(((int)target + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    sa = (struct Vector3*)(((int)arg2 + 0x5c));
+    st = (struct Vector3*)(((int)target + 0x5c));
     va.x = sa->x;
     va.y = sa->y;
     va.z = sa->z;

--- a/src/func_ov013_021112a8.c
+++ b/src/func_ov013_021112a8.c
@@ -11,9 +11,9 @@ int daObjClockHuriko_c_Behavior(char* c)
     if (data_02092110[0] <= 0) {
         short* p90 = (short*)(c + 0x90);
         if (*p90 > 0) {
-            *(short*)(((long long)(int)(c + 0x124)) & 0xffffffffffffffffLL) -= 8;
+            *(short*)(((long long)(int)(c + 0x124))) -= 8;
         } else {
-            *(short*)(((long long)(int)(c + 0x124)) & 0xffffffffffffffffLL) += 8;
+            *(short*)(((long long)(int)(c + 0x124))) += 8;
         }
         *p90 = (short)(*p90 + *(short*)(c + 0x124));
         short w = *(short*)(c + 0x124);

--- a/src/func_ov014_02111a6c.cpp
+++ b/src/func_ov014_02111a6c.cpp
@@ -11,6 +11,6 @@ extern "C" void func_ov014_02111a6c(char* c){
   *(char*)(c+0x604)=0;
   *(short*)(c+0x600)=0;
   *(short*)(c+0x500+0xfc)=0x3c;
-  *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~3;
+  *(int*)(((int)c + 0xb0)) &= ~3;
   *(int*)(c+0x60)=*(int*)(c+0x5f0)+0xc8000;
 }

--- a/src/func_ov015_02111414.c
+++ b/src/func_ov015_02111414.c
@@ -5,7 +5,7 @@ void func_ov015_02111414(char* c, char* other) {
     short ang;
     if (*(unsigned char*)(c+0x397) >= 2) return;
     if (*(unsigned char*)(c+0x397) == 0)
-        (*(unsigned char*)(long long)(((int)c + 0x397) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char*)(long long)(((int)c + 0x397)))++;
     ang = Vec3_HorzAngle(c+0x5c, other+0x5c);
     d = AngleDiff(ang, *(short*)(c+0x8e));
     if (d < 0x2000) {
@@ -19,7 +19,7 @@ set1:
     if (*(unsigned char*)(c+0x397) == 1) {
         if (*(short*)(c+0x394) >= 0x320) {
             if (*(int*)(other+0x60) > *(int*)(c+0x60) + 0x64000)
-                (*(unsigned char*)(long long)(((int)c + 0x397) & 0xFFFFFFFFFFFFFFFFLL))++;
+                (*(unsigned char*)(long long)(((int)c + 0x397)))++;
         }
     }
     *(short*)(c+0x394) = 0x640;

--- a/src/func_ov015_02111d4c.c
+++ b/src/func_ov015_02111d4c.c
@@ -2,7 +2,7 @@ extern void func_ov015_02111fb8(void *self, int idx);
 
 void func_ov015_02111d4c(char *c)
 {
-    *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(int *)(((int)c + 0x334)) -= 1;
     if (*(int *)(c + 0x334) > 0)
         return;
 

--- a/src/func_ov015_02111df4.c
+++ b/src/func_ov015_02111df4.c
@@ -4,8 +4,8 @@ extern void func_ov015_02111fb8(void *self, int idx);
 void func_ov015_02111df4(char *c)
 {
     Math_Function_0203b14c((int *)(c + 0x5c), *(int *)(c + 0x320), 0x800, 0xb4000, 0x28000);
-    *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) =
-        *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) - 1;
+    *(int *)(((int)c + 0x334)) =
+        *(int *)(((int)c + 0x334)) - 1;
     if (*(int *)(c + 0x334) > 0) {
         return;
     }

--- a/src/func_ov015_02111eec.c
+++ b/src/func_ov015_02111eec.c
@@ -4,7 +4,7 @@ void func_ov015_02111eec(char *c)
 {
   Math_Function_0203b0fc((int *)(c + 0x5c), *(int *)(c + 0x320) - 0x168000, 0x800, 0x46000);
   {
-    int *p = (int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF);
+    int *p = (int *)(((int)c + 0x334));
     *p = *p - 1;
   }
   if (*(int *)(c + 0x334) > 0)

--- a/src/func_ov015_02111f6c.c
+++ b/src/func_ov015_02111f6c.c
@@ -2,7 +2,7 @@ extern void func_ov015_02111fb8(void *self, int idx);
 
 void func_ov015_02111f6c(char *c)
 {
-    *(int *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFF) -= 1;
+    *(int *)(((int)c + 0x334)) -= 1;
     if (*(int *)(c + 0x334) > 0)
         return;
 

--- a/src/func_ov016_02112b50.c
+++ b/src/func_ov016_02112b50.c
@@ -19,7 +19,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern s16 data_02082214[];
 extern void *data_0209f318;
 #pragma opt_common_subs off
-inline int inline_fn(int arg0) { return arg0 & 0xFFFFFFFFFFFFFFFFLL; }
+inline int inline_fn(int arg0) { return arg0; }
 
 int func_ov016_02112b50(char *c)
 {

--- a/src/func_ov019_0211131c.c
+++ b/src/func_ov019_0211131c.c
@@ -10,7 +10,7 @@ extern short Vec3_HorzAngle(struct Vector3* a, struct Vector3* b);
 int func_ov019_0211131c(char* c) {
     _Z11UpdateAngleRssis(
         (short*)(c + 0x94),
-        *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+        *(short *)((char *)(((int)c + 0x300)) + 0x8c),
         2, 0x600);
     int n = *(int*)(c + 0x36c);
     if (n >= _ZNK7PathPtr8NumNodesEv(c + 0x364) - 2) {
@@ -21,7 +21,7 @@ int func_ov019_0211131c(char* c) {
         *(short*)(c + 0x8e) = Vec3_HorzAngle((struct Vector3*)(c + 0x5c), &v);
     }
     {
-        int *pv = (int *)(((int)c + 0x380) & 0xFFFFFFFFFFFFFFFF);
+        int *pv = (int *)(((int)c + 0x380));
         *pv = *pv - *(int*)(c + 0x98);
     }
     return *(int*)(c + 0x380) < 0 ? 1 : 0;

--- a/src/func_ov019_021113b0.c
+++ b/src/func_ov019_021113b0.c
@@ -7,9 +7,9 @@ extern short Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 void func_ov019_021113b0(char *c)
 {
     struct Vector3 v;
-    int *cnt = (int *)(((int)c + 0x36c) & 0xFFFFFFFFFFFFFFFF);
+    int *cnt = (int *)(((int)c + 0x36c));
     *cnt = *cnt + 1;
     _ZNK7PathPtr7GetNodeER7Vector3j(c + 0x364, &v, *(int *)(c + 0x36c));
     *(int *)(c + 0x380) = Vec3_Dist((struct Vector3 *)(c + 0x5c), &v);
-    *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c) = Vec3_HorzAngle((struct Vector3 *)(c + 0x5c), &v);
+    *(short *)((char *)(((int)c + 0x300)) + 0x8c) = Vec3_HorzAngle((struct Vector3 *)(c + 0x5c), &v);
 }

--- a/src/func_ov019_02111558.c
+++ b/src/func_ov019_02111558.c
@@ -14,7 +14,7 @@ extern int func_0201267c(int a, void *pos);
 extern void *data_ov019_021134a8[];
 extern void *data_ov019_02113468[];
 
-#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LB(off) (*(unsigned char *)(((int)c + (off))))
 
 int func_ov019_02111558(void *thiz)
 {
@@ -63,7 +63,7 @@ int func_ov019_02111558(void *thiz)
         if (_ZN6Player12GetTalkStateEv(*(void **)(c + 0x378)) == 2) {
             if (*(unsigned char *)(c + 0x395) == 0) {
                 _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(
-                    c, (signed char *)(((int)c + 0x396) & 0xFFFFFFFFFFFFFFFF),
+                    c, (signed char *)(((int)c + 0x396)),
                     (unsigned int)(unsigned char)((*(unsigned int *)(c + 8) >> 8) & 0xf),
                     c + 0x5c, 4);
             }

--- a/src/func_ov019_021117a8.c
+++ b/src/func_ov019_021117a8.c
@@ -8,7 +8,7 @@ extern int func_ov019_0211140c(int* self, void* clsn);
 extern void func_0201267c(int a, void* p);
 extern int func_ov019_021122dc(void* c, int s);
 
-#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LB(off) (*(unsigned char *)(((int)c + (off))))
 
 #pragma opt_common_subs off
 int func_ov019_021117a8(char* c) {
@@ -18,11 +18,11 @@ int func_ov019_021117a8(char* c) {
         int n = _ZNK7PathPtr8NumNodesEv(c+0x364);
         _ZNK7PathPtr7GetNodeER7Vector3j(c+0x364, node, n - 1);
         *(int*)(c+0x380) = Vec3_Dist(c+0x5c, node);
-        *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c) =
+        *(short *)((char *)(((int)c + 0x300)) + 0x8c) =
             Vec3_HorzAngle(c+0x5c, node);
         _Z14ApproachLinearRsss(
             (short*)(c+0x8e),
-            *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+            *(short *)((char *)(((int)c + 0x300)) + 0x8c),
             0x200);
         *(short*)(c+0x94) = *(short*)(c+0x8e);
         if (*(int*)(c+0x380) < *(int*)(c+0x98)) {

--- a/src/func_ov019_0211197c.c
+++ b/src/func_ov019_0211197c.c
@@ -3,7 +3,7 @@ typedef unsigned int u32;
 
 typedef struct { int x, y, z; } Vector3;
 
-#define LB(off) (*(u8 *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LB(off) (*(u8 *)(((int)c + (off))))
 
 extern int func_ov019_0211131c(void *self);
 extern void func_ov019_021113b0(void *self);
@@ -54,7 +54,7 @@ int func_ov019_0211197c(void *self)
             }
             {
                 u8 *o = *(u8 **)(c + 0x378);
-                u8 *p = (u8 *)(((int)o + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                u8 *p = (u8 *)(((int)o + 0x5c));
                 Vector3 v;
                 v.x = *(int *)p;
                 v.y = *(int *)(p + 4);
@@ -90,7 +90,7 @@ int func_ov019_0211197c(void *self)
             }
             {
                 u8 *o = *(u8 **)(c + 0x378);
-                u8 *p = (u8 *)(((int)o + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                u8 *p = (u8 *)(((int)o + 0x5c));
                 Vector3 v;
                 v.x = *(int *)p;
                 v.y = *(int *)(p + 4);

--- a/src/func_ov019_02111dec.c
+++ b/src/func_ov019_02111dec.c
@@ -12,7 +12,7 @@ extern int func_ov019_021122dc(void* c, int s);
 extern int data_ov019_02113460[];
 extern int data_ov019_02113470[];
 
-#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LB(off) (*(unsigned char *)(((int)c + (off))))
 
 int func_ov019_02111dec(char* c) {
     switch (*(unsigned char*)(c+0x38f)) {
@@ -24,7 +24,7 @@ int func_ov019_02111dec(char* c) {
     case 1:
         _Z11UpdateAngleRssis(
             (short*)(c+0x94),
-            *(short *)((char *)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFF) + 0x8c),
+            *(short *)((char *)(((int)c + 0x300)) + 0x8c),
             2, 0x800);
         *(short*)(c+0x8e) = *(short*)(c+0x94);
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, c+0x174);

--- a/src/func_ov019_02111fec.c
+++ b/src/func_ov019_02111fec.c
@@ -12,7 +12,7 @@ int _ZN6Player18HasFinishedTalkingEv(void* p);
 
 extern unsigned char data_0209d684;
 
-#define LB(off) (*(unsigned char *)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFF))
+#define LB(off) (*(unsigned char *)(((int)c + (off))))
 
 int func_ov019_02111fec(char* c) {
     switch (*(unsigned char*)(c + 0x38f)) {

--- a/src/func_ov020_021115ac.c
+++ b/src/func_ov020_021115ac.c
@@ -4,7 +4,7 @@
 typedef unsigned short u16;
 typedef struct { int x, y, z; } Vec3;
 typedef unsigned int u32;
-#define LDR(p) ((int)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LDR(p) ((int)((((long long)(int)(p)))))
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern int _ZN5Actor24BumpedUnderneathByPlayerER6Player(void *thiz, void *player);

--- a/src/func_ov020_0211174c.c
+++ b/src/func_ov020_0211174c.c
@@ -10,7 +10,7 @@ extern void func_ov063_0211cae8(void *found, unsigned int mask);
 extern void ActorBase_MarkForDestruction(void *thiz);
 extern u8 data_ov020_02114828[];
 
-#define LDR(p) ((int)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LDR(p) ((int)((((long long)(int)(p)))))
 
 void func_ov020_0211174c(char *c)
 {

--- a/src/func_ov020_021119dc.c
+++ b/src/func_ov020_021119dc.c
@@ -8,13 +8,13 @@
         char* c = (char*)thiz;
         func_0203568c((int*)(c + 0x25c), 0x64000);
         if (*(unsigned short*)(c + 0x104) != 0) {
-            unsigned short* p = (unsigned short*)(((int)c + 0x104) & 0xFFFFFFFFFFFFFFFF);
+            unsigned short* p = (unsigned short*)(((int)c + 0x104));
             *p = (unsigned short)(*p - 1);
             if (*(unsigned short*)(c + 0x104) != 0) {
-                int* q = (int*)(((int)c + 0x234) & 0xFFFFFFFFFFFFFFFF);
+                int* q = (int*)(((int)c + 0x234));
                 *q = *q | 1;
             } else {
-                int* q = (int*)(((int)c + 0x234) & 0xFFFFFFFFFFFFFFFF);
+                int* q = (int*)(((int)c + 0x234));
                 *q = *q & ~1;
             }
         }

--- a/src/func_ov020_02111c30.c
+++ b/src/func_ov020_02111c30.c
@@ -49,8 +49,8 @@ void func_ov020_02111c30(char *c)
         return;
     }
 
-    (*(u16 *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFF))++;
-    if (*(u16 *)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFF) < 5)
+    (*(u16 *)(((int)c + 0x100)))++;
+    if (*(u16 *)(((int)c + 0x100)) < 5)
         return;
 
     func_ov020_021112b0(c);

--- a/src/func_ov020_02111ee0.cpp
+++ b/src/func_ov020_02111ee0.cpp
@@ -20,7 +20,7 @@ int func_ov020_02111ee0(char* c){
     *(unsigned char*)(c+0x450) = 1;
     *(short*)(c+0x100) = 0;
     {
-      int* p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+      int* p60 = (int*)(((int)c + 0x60));
       *p60 = *p60 + 0x32000;
     }
     *(int*)(c+0x43c) = -0x19000;

--- a/src/func_ov020_02111fc4.cpp
+++ b/src/func_ov020_02111fc4.cpp
@@ -21,7 +21,7 @@ extern "C" void func_ov020_02111fc4(char* thiz)
     Vector3 v;
     char* p = _ZN5Actor13ClosestPlayerEv();
     {
-        int* s = (int*)(int)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+        int* s = (int*)(int)(((int)p + 0x5c));
         v.x = s[0];
         v.y = s[1];
         v.z = s[2];
@@ -35,7 +35,7 @@ extern "C" void func_ov020_02111fc4(char* thiz)
     *(int*)(c + 0x98) = 0x5000;
     *(short*)(c + 0x100) = 0;
     {
-        int* p234 = (int*)(int)(((int)c + 0x234) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p234 = (int*)(int)(((int)c + 0x234));
         *p234 = *p234 & ~1;
     }
     func_0201267c(0x166, c + 0x74);

--- a/src/func_ov020_02112b00.c
+++ b/src/func_ov020_02112b00.c
@@ -37,7 +37,7 @@ typedef struct {
 void func_ov020_02112b00(char *c)
 {
     WithMeshClsn_UpdateContinuous_Veneer(c + 0x1bc);
-    (*(u16 *)(((int)c + 0x39e) & 0xFFFFFFFFFFFFFFFF))++;
+    (*(u16 *)(((int)c + 0x39e)))++;
 
     if (ST->counter <= 0x46) {
         if (ST->counter < 0x32)
@@ -51,7 +51,7 @@ void func_ov020_02112b00(char *c)
         }
     } else {
         if (ST->timer != 0) {
-            (*(u16 *)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u16 *)(((int)c + 0x3a0)))--;
             if (ST->timer == 0) {
                 void *player;
                 func_0201267c(0x5d, c + 0x74);
@@ -59,7 +59,7 @@ void func_ov020_02112b00(char *c)
                 if (player == 0)
                     return;
                 {
-                    Vector3 *pp = (Vector3 *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                    Vector3 *pp = (Vector3 *)(((int)player + 0x5c));
                     Vector3 playerPos;
                     Vector3 diff;
                     s32 r;
@@ -76,7 +76,7 @@ void func_ov020_02112b00(char *c)
                 }
             } else {
                 if (ST->timer > 0x14) {
-                    *(s16 *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0x2710;
+                    *(s16 *)(((int)c + 0x8e)) += 0x2710;
                 }
             }
         } else {

--- a/src/func_ov021_02112544.cpp
+++ b/src/func_ov021_02112544.cpp
@@ -61,8 +61,8 @@ extern "C" void func_ov021_02112544(char* self)
                 *(int*)(self + 0x3b8), 3, 0x8a, self + 0x74, 0);
         }
         {
-            int *pa4 = (int *)(int)(((long long)(int)(self + 0xa4)) & 0xFFFFFFFFFFFFFFFFLL);
-            int *pac = (int *)(int)(((long long)(int)(self + 0xac)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *pa4 = (int *)(int)(((long long)(int)(self + 0xa4)));
+            int *pac = (int *)(int)(((long long)(int)(self + 0xac)));
             *pa4 = *pa4 + normal.x * 5;
             *pac = *pac + normal.z * 5;
         }


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 100 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
