### PR TITLE
readable: strip 100 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov022_021112ac.c
+++ b/src/func_ov022_021112ac.c
@@ -59,7 +59,7 @@ int func_ov022_021112ac(void *thiz)
             *(void **)((unsigned char *)s + 0x10c) = c;
             *(int *)((unsigned char *)s + 0x118) = *(int *)(c + 0x60);
             {
-                unsigned short *t = (unsigned short *)((long long)(int)(c + 0x324) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned short *t = (unsigned short *)((long long)(int)(c + 0x324));
                 *t = *t + 1;
             }
             *(unsigned char *)(c + 0x31f) = 2;
@@ -67,7 +67,7 @@ int func_ov022_021112ac(void *thiz)
         break;
     }
 
-    ip = (short *)((long long)(int)(c + 0x94) & 0xFFFFFFFFFFFFFFFFLL);
+    ip = (short *)((long long)(int)(c + 0x94));
     *ip = (short)(*ip + *(short *)(c + 0x96));
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
     func_020393a4(c + 0x124, 0x780000);

--- a/src/func_ov022_02111dfc.c
+++ b/src/func_ov022_02111dfc.c
@@ -18,7 +18,7 @@ int daObjFl_Seesaw_c_Behavior(char* c) {
   func_020393a4((int*)(c+0x124), 0x650000);
   if (DecIfAbove0_Byte((unsigned char*)(c+0x320)) == 0) {
     int r1;
-    s16* a = (s16*)(((int)c + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+    s16* a = (s16*)(((int)c + 0x8c));
     *a += self->unk_31e;
     r1 = self->unk_08c;
     if (r1 >= 0x400 || r1 <= -0x400) {

--- a/src/func_ov024_02111350.c
+++ b/src/func_ov024_02111350.c
@@ -1,7 +1,7 @@
 typedef short s16;
 typedef unsigned short u16;
 
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     unsigned int a, unsigned int b, int c, int d, int e, void* v, void* cb);

--- a/src/func_ov025_021119f4.c
+++ b/src/func_ov025_021119f4.c
@@ -5,8 +5,8 @@ typedef int s32;
 extern int func_0201267c(int a, void *b);
 void func_ov025_021119f4(char *c)
 {
-    *(u8*)(((int)c + 0x39e) & 0xFFFFFFFFFFFFFFFFLL) =
-        *(u8*)(((int)c + 0x39e) & 0xFFFFFFFFFFFFFFFFLL) - 1;
+    *(u8*)(((int)c + 0x39e)) =
+        *(u8*)(((int)c + 0x39e)) - 1;
     if (*(u8 *)(c + 0x39e) != 0) return;
     if (*(u8 *)(c + 0x39f) != 4) {
         *(s32 *)(c + 0x398) = 5;

--- a/src/func_ov025_02111a84.cpp
+++ b/src/func_ov025_02111a84.cpp
@@ -25,8 +25,8 @@ void func_ov025_02111a84(char* c)
     v[1].z = *(int*)(c + 0x64);
     _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(c, v[1], 0x7d0000);
     *(unsigned char*)(c + 0x39e) = 0x3c;
-    *(unsigned char*)(((int)c + 0x39f) & 0xFFFFFFFFFFFFFFFFLL) =
-        *(unsigned char*)(((int)c + 0x39f) & 0xFFFFFFFFFFFFFFFFLL) + 1;
+    *(unsigned char*)(((int)c + 0x39f)) =
+        *(unsigned char*)(((int)c + 0x39f)) + 1;
     *(int*)(c + 0x398) = 6;
     v[0].x = *(int*)(c + 0x5c);
     v[0].y = *(int*)(c + 0x60);

--- a/src/func_ov026_02111b24.c
+++ b/src/func_ov026_02111b24.c
@@ -37,7 +37,7 @@ int func_ov026_02111b24(char* self)
         _Z14ApproachLinearRiii((int*)(self + 0x198), 0x100, 0x1000);
         _Z14ApproachLinearRiii((int*)(self + 0x194), *(int*)(self + 0x1ac) - 0x64000, 0x4000);
         {
-            s16* q = (s16*)(int)(((long long)(int)(self + 0x1b4)) & 0xFFFFFFFFFFFFFFFFLL);
+            s16* q = (s16*)(int)(((long long)(int)(self + 0x1b4)));
             *q += *(s16*)(self + 0x1b6);
         }
         v1.y = *(int*)(self + 0x194);
@@ -54,7 +54,7 @@ int func_ov026_02111b24(char* self)
             *(s16*)(player + 0x90) = 0;
         }
         {
-            int* pp = (int*)(int)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* pp = (int*)(int)(((long long)(int)(player + 0x5c)));
             pv.x = pp[0];
             pv.y = pp[1];
             pv.z = pp[2];

--- a/src/func_ov026_02111cb4.c
+++ b/src/func_ov026_02111cb4.c
@@ -13,7 +13,7 @@ int func_ov026_02111cb4(char *c)
   char *p = Actor_ClosestPlayer(c);
   if (p)
   {
-    struct Vec3 *sp = (struct Vec3 *) (((int) p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    struct Vec3 *sp = (struct Vec3 *) (((int) p + 0x5c));
     struct Vec3 t;
     t.x = sp->x;
     t.y = sp->y;

--- a/src/func_ov027_02111a28.c
+++ b/src/func_ov027_02111a28.c
@@ -6,7 +6,7 @@ extern int data_ov027_02113c8c[];
 int func_ov027_02111a28(char* c) {
     int d = *(int*)(c+0x3d4);
     if (d == 0) {
-        unsigned char* p = (unsigned char*)(((int)c + 0x3d9) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* p = (unsigned char*)(((int)c + 0x3d9));
         *p = *p + 1;
         if (*(unsigned char*)(c+0x3d9) >= 9) *(unsigned char*)(c+0x3d9) = 0;
         func_ov027_02111d70(c, 0);
@@ -18,7 +18,7 @@ int func_ov027_02111a28(char* c) {
             *(int*)(c+0x98) = d;
             *(int*)(c+0x3d4) = 0;
         } else {
-            int* q = (int*)(((int)c + 0x3d4) & 0xFFFFFFFFFFFFFFFF);
+            int* q = (int*)(((int)c + 0x3d4));
             *q = *q - v;
         }
     }

--- a/src/func_ov027_02111e34.cpp
+++ b/src/func_ov027_02111e34.cpp
@@ -18,9 +18,9 @@ int daPgDfdr_c_Behavior(char* c){
   _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
   func_ov027_02111cfc(c);
   if(_ZN6Player16IsInsideOfCannonEv(_ZN5Actor13ClosestPlayerEv(c))){
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~2;
+    *(int *)(((int)c + 0xb0)) &= ~2;
   } else {
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 2;
+    *(int *)(((int)c + 0xb0)) |= 2;
   }
   _ZN9Animation7AdvanceEv(c+0x370);
   _ZN9Animation7AdvanceEv(c+0x384);

--- a/src/func_ov029_02111bcc.c
+++ b/src/func_ov029_02111bcc.c
@@ -24,14 +24,14 @@ int daObjWc_Obj05_c_Behavior(u8* thiz)
     case 0:
         if (thiz[0x32a] != 0) {
             if (thiz[0x32b] == 0) {
-                u8* p = (u8*)(((int)thiz + 0x32c) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((int)thiz + 0x32c));
                 *p = *p + 1;
             }
         }
         thiz[0x32b] = thiz[0x32a];
         break;
     case 1: {
-        int* p60 = (int*)(((int)thiz + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p60 = (int*)(((int)thiz + 0x60));
         *p60 = *p60 - 0x14000;
         self->unk_324 = _ZN5Sound8PlayLongEjjjRK7Vector3j(
             *(unsigned*)(thiz + 0x324), 3, 0x8d, thiz + 0x74, 0);
@@ -40,11 +40,11 @@ int daObjWc_Obj05_c_Behavior(u8* thiz)
             if (self->unk_060 <= v) {
                 self->unk_060 = v;
                 {
-                    u8* p = (u8*)(((int)thiz + 0x32c) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* p = (u8*)(((int)thiz + 0x32c));
                     *p = *p + 1;
                 }
                 {
-                    u8* base = (u8*)(((int)thiz + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* base = (u8*)(((int)thiz + 0x300));
                     *(u16*)(base + 0x28) = 0;
                 }
             }
@@ -58,7 +58,7 @@ int daObjWc_Obj05_c_Behavior(u8* thiz)
                 *(unsigned*)(thiz + 0x324), 3, 0x8d, thiz + 0x74, 0);
             self->unk_324 = snd;
             {
-                int* p60 = (int*)(((int)thiz + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+                int* p60 = (int*)(((int)thiz + 0x60));
                 *p60 = *p60 + 0xa000;
             }
             if (self->unk_060 >= self->unk_320) {
@@ -66,12 +66,12 @@ int daObjWc_Obj05_c_Behavior(u8* thiz)
                 thiz[0x32c] = 0;
                 {
                     /* Different launder spelling so CSE does not reuse case-2 head base */
-                    u8* b2 = (u8*)(((int)thiz + 0x300) & 0xFFFFFFFFFFFFFFFFLL);
+                    u8* b2 = (u8*)(((int)thiz + 0x300));
                     *(u16*)(b2 + 0x28) = 0;
                 }
             }
         } else {
-            u16* p = (u16*)(((int)thiz + 0x328) & 0xFFFFFFFFFFFFFFFFLL);
+            u16* p = (u16*)(((int)thiz + 0x328));
             *p = *p + 1;
         }
         break;

--- a/src/func_ov030_02111384.cpp
+++ b/src/func_ov030_02111384.cpp
@@ -16,7 +16,7 @@ extern "C" int daObjHmBskt_c_Behavior(char *c) {
     _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
     self->unk_08e = self->unk_08e + self->unk_098;
     if (self->unk_09c != 0) {
-        *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) = *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) & ~1;
+        *(int *)(((int)c + 0xb0)) = *(int *)(((int)c + 0xb0)) & ~1;
         _ZN5Actor9UpdatePosEP12CylinderClsn(c, (char*)0);
         func_ov030_0211124c(c, c+0x320);
         int a0 = self->unk_060;

--- a/src/func_ov030_02111a00.c
+++ b/src/func_ov030_02111a00.c
@@ -21,7 +21,7 @@ int func_ov030_02111a00(char* c)
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
         c + 0xd4, data_ov030_02115bc8[*(unsigned char*)(c + 0x3ca)][1], 0, 0x1000, 0);
     {
-        unsigned char* p = (unsigned char*)(((int)c + 0x3ca) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* p = (unsigned char*)(((int)c + 0x3ca));
         *(int*)(c + 0x130) = 0x1000;
         (*p)++;
     }

--- a/src/func_ov030_02112c14.c
+++ b/src/func_ov030_02112c14.c
@@ -26,21 +26,21 @@ int func_ov030_02112c14(void *arg0)
   s16 s;
   int mul = 0x4b000;
   int rnd = 0x800;
-  *((int *) ((int) (((s64) ((int) (c + 0xb0))) & 0xFFFFFFFFFFFFFFFFLL))) &= ~0x80000;
+  *((int *) ((int) (((s64) ((int) (c + 0xb0)))))) &= ~0x80000;
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0xd4, data_ov030_02115d08[1], 0x40000000, 0x1000, 0);
   *((int *) (c + 0x98)) = 0xa000;
   *((int *) (c + 0xa8)) = 0;
   other = *((u8 **) (c + 0x3a8));
-  pos = (int *) ((int) (((s64) ((int) (c + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL));
+  pos = (int *) ((int) (((s64) ((int) (c + 0x5c)))));
   s = *((s16 *) (other + 0x8e));
   *((s16 *) (c + 0x8e)) = s;
   s = *((s16 *) (c + 0x8e));
-  py = (int *) ((int) (((s64) ((int) (c + 0x60))) & 0xFFFFFFFFFFFFFFFFLL));
-  pz = (int *) ((int) (((s64) ((int) (c + 0x64))) & 0xFFFFFFFFFFFFFFFFLL));
+  py = (int *) ((int) (((s64) ((int) (c + 0x60)))));
+  pz = (int *) ((int) (((s64) ((int) (c + 0x64)))));
   *((s16 *) (c + 0x94)) = s;
   other = *((u8 **) (c + 0x3a8));
   {
-    int *op = (int *) ((int) (((s64) ((int) (other + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL));
+    int *op = (int *) ((int) (((s64) ((int) (other + 0x5c)))));
     int t0 = op[0];
     *((int *) (c + 0x5c)) = t0;
     int t1 = op[1];

--- a/src/func_ov030_02112da0.c
+++ b/src/func_ov030_02112da0.c
@@ -13,7 +13,7 @@ extern u8 data_0209d684;
 int func_ov030_02112da0(char *a) {
     int b = (int)((*(u32 *)(a + 0xb0) & 0x40000) != 0);
     if (b != 0) {
-        int p = (int)((long long)(int)(*(char **)(a + 0x3a8) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+        int p = (int)((long long)(int)(*(char **)(a + 0x3a8) + 0x5c));
         *(int *)(a + 0x5c) = *(int *)p;
         *(int *)(a + 0x60) = *(int *)(p + 4);
         *(int *)(a + 0x64) = *(int *)(p + 8);
@@ -34,9 +34,9 @@ int func_ov030_02112da0(char *a) {
             if (b2 != 0) {
                 char *s = *(char **)(a + 0x3a8);
                 int off = 0x3c7;
-                int *p = (int *)((long long)(int)(s + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                int *p = (int *)((long long)(int)(s + 0x5c));
                 int x = *p;
-                u8 *st = (u8 *)(((int)a + off) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *st = (u8 *)(((int)a + off));
                 *(int *)(a + 0x5c) = x;
                 *(int *)(a + 0x60) = p[1];
                 *(int *)(a + 0x64) = p[2];
@@ -55,13 +55,13 @@ int func_ov030_02112da0(char *a) {
                 *(int *)(a + 0x60) > *(int *)(a + 0x384) - 0x12c000) {
                 if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(char **)(a + 0x3a8), a, 0xc1, 0, 0, 0) != 0) {
                     func_0201267c(0xd1, a + 0x74);
-                    (*(u8 *)(((int)a + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+                    (*(u8 *)(((int)a + 0x3c7)))++;
                 }
             }
             {
                 char *s = *(char **)(a + 0x3a8);
                 u8 val = 0x3c;
-                int *p = (int *)((long long)(int)(s + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+                int *p = (int *)((long long)(int)(s + 0x5c));
                 *(int *)(a + 0x5c) = *p;
                 *(int *)(a + 0x60) = p[1];
                 *(int *)(a + 0x64) = p[2];
@@ -76,12 +76,12 @@ int func_ov030_02112da0(char *a) {
                     *(int *)(a + 0x3b8) = 8;
                     func_ov030_021141a8(a, 7);
                 } else if (g == 2) {
-                    (*(u8 *)(((int)a + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+                    (*(u8 *)(((int)a + 0x3c7)))++;
                 }
             }
             break;
         case 3:
-            if (DecIfAbove0_Byte((u8 *)(((int)a + 0x3c6) & 0xFFFFFFFFFFFFFFFFLL)) == 0) {
+            if (DecIfAbove0_Byte((u8 *)(((int)a + 0x3c6))) == 0) {
                 *(u8 *)(a + 0x3c7) = 1;
             }
             break;

--- a/src/func_ov030_02112ff8.c
+++ b/src/func_ov030_02112ff8.c
@@ -4,7 +4,7 @@ extern void func_02015024(void *p);
 
 int func_ov030_02112ff8(char *c)
 {
-    *(int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x80000;
+    *(int *)(((long long)(int)(c + 0xb0))) &= ~0x80000;
     if (func_0203cfdc(c + 0x380, c + 0x5c) < 0x514000 &&
         *(int *)(c + 0x60) > *(int *)(c + 0x384) - 0x12c000) {
         *(unsigned char *)(c + 0x3c7) = 0;

--- a/src/func_ov030_02113094.c
+++ b/src/func_ov030_02113094.c
@@ -25,7 +25,7 @@ int func_ov030_02113094(char* self)
     {
         int b = (int)((*(u32*)(self + 0xb0) & 0x40000) != 0);
         if (b != 0) {
-            int p = (int)((((int)*(char**)(self + 0x3a8)) + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            int p = (int)((((int)*(char**)(self + 0x3a8)) + 0x5c));
             *(int*)(self + 0x5c) = *(int*)p;
             *(int*)(self + 0x60) = *(int*)(p + 4);
             *(int*)(self + 0x64) = *(int*)(p + 8);
@@ -39,9 +39,9 @@ int func_ov030_02113094(char* self)
             if (*(u8*)(self + 0x3c8) != 0) {
                 struct Actor* a = _ZN5Actor10FindWithIDEj(*(u32*)(self + 0x3ac));
                 *(char**)((char*)a + 0xd0) = *(char**)(self + 0x3a8);
-                *(u32*)(((int)a + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x40000;
+                *(u32*)(((int)a + 0xb0)) |= 0x40000;
             }
-            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)self + 0x3c7)))++;
         } else {
             int b3 = (int)((*(u32*)(self + 0xb0) & 0x20000) != 0);
             if (b3 != 0) break;
@@ -55,7 +55,7 @@ int func_ov030_02113094(char* self)
         int msg = (*(u8*)(self + 0x3c8) != 0) ? 0xc2 : 0xc3;
         if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(char**)(self + 0x3a8), self, (s16)msg, 0, 0, 0) != 0) {
             func_0201267c(0xd1, self + 0x74);
-            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)self + 0x3c7)))++;
         }
         {
             int b4 = (int)((*(u32*)(self + 0xb0) & 0x80000) != 0);
@@ -68,7 +68,7 @@ int func_ov030_02113094(char* self)
     case 2:
         if (_ZN6Player12GetTalkStateEv(*(char**)(self + 0x3a8)) == -1) {
             _ZN6Player9DropActorEv(*(char**)(self + 0x3a8));
-            (*(u8*)(((int)self + 0x3c7) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)self + 0x3c7)))++;
         }
         break;
     case 3: {

--- a/src/func_ov032_02111254.c
+++ b/src/func_ov032_02111254.c
@@ -10,7 +10,7 @@ int func_ov032_02111254(char *c) {
     int d;
     if (pl == 0 || *(unsigned short*)(c+0x400+0x2a) != 0)
         return 0;
-    s = (int*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+    s = (int*)(((int)pl + 0x5c));
     *(int*)(c+0x418) = s[0];
     *(int*)(c+0x41c) = s[1];
     *(int*)(c+0x420) = s[2];

--- a/src/func_ov032_02111620.cpp
+++ b/src/func_ov032_02111620.cpp
@@ -77,7 +77,7 @@ player_path:
     {
         int vec[3];
         unsigned int n;
-        int *p = (int *)(((int)r5 + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)r5 + 0x5c));
         vec[0] = p[0];
         vec[1] = p[1];
         vec[2] = p[2];

--- a/src/func_ov032_02111830.c
+++ b/src/func_ov032_02111830.c
@@ -31,7 +31,7 @@ int func_ov032_02111830(char *c)
         }
     }
     if (*(int*)(c + 0x424) > 0 && *(int*)(c + 0x424) < 5) {
-        int *p424 = (int*)(((int)c + 0x424) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p424 = (int*)(((int)c + 0x424));
         (*p424)++;
         if (*(int*)(c + 0x424) == 4) {
 
@@ -95,8 +95,8 @@ afterblock: ;
                 *(s16*)(c + 0x400 + 0x2a) = 0x64;
                 *(s16*)(c + 0x400 + 0x30) = *(s16*)(c + 0x8e);
                 *(int*)(c + 0xb0) = 3;
-                *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
-                *(int*)(((int)c + 0x168) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+                *(int*)(((int)c + 0x128)) &= ~2;
+                *(int*)(((int)c + 0x168)) &= ~2;
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x34c, data_ov032_02113a50[1], 0, 0x1000, 0);
                 func_ov032_02111ff4(c, &data_ov032_02113a8c);
                 return 1;

--- a/src/func_ov032_02111b50.c
+++ b/src/func_ov032_02111b50.c
@@ -1,8 +1,8 @@
 int func_ov032_02111b50(char *c)
 {
     *(short *)(c + 0x430) = -0x4000;
-    *(int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
-    *(int *)(((int)c + 0x168) & 0xFFFFFFFFFFFFFFFF) |= 2;
+    *(int *)(((int)c + 0x128)) |= 2;
+    *(int *)(((int)c + 0x168)) |= 2;
     *(unsigned char *)(c + 0x428) = 0;
     *(int *)(c + 0x98) = 0xa000;
     *(int *)(c + 0x424) = 0;

--- a/src/func_ov033_0211123c.c
+++ b/src/func_ov033_0211123c.c
@@ -9,7 +9,7 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void *c);
 
 void daObjTtFuta_c_OnGroundPounded(char *self, char *other)
 {
-    int *v = (int *)(((int)other + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    int *v = (int *)(((int)other + 0x5c));
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x28, v[0], v[1], v[2]);
     _ZN5Sound9PlayBank3EjRK7Vector3(0xf, self + 0x74);
     _ZN5Event6SetBitEj(0xe);

--- a/src/func_ov034_02111788.cpp
+++ b/src/func_ov034_02111788.cpp
@@ -31,7 +31,7 @@ extern "C" void func_ov034_02111788(void *thiz)
             v.y = vp->y;
             v.z = vp->z;
             _ZN5Actor10PoofDustAtERK7Vector3(c, &v);
-            (*(unsigned char *)(((int)c + 0x8dd) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char *)(((int)c + 0x8dd)))++;
             *(unsigned char *)(c + 0x8da) = 5;
         }
     }
@@ -56,7 +56,7 @@ extern "C" void func_ov034_02111788(void *thiz)
     if (b != 0) return;
 
     if (*(unsigned char *)(c + 0x8dc) < 5) {
-        (*(unsigned char *)(((int)c + 0x8dc) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char *)(((int)c + 0x8dc)))++;
         return;
     }
 

--- a/src/func_ov034_02111bb0.c
+++ b/src/func_ov034_02111bb0.c
@@ -7,12 +7,12 @@ void func_ov034_02111bb0(char *p) {
     *(int*)(p+0x8e4) = 0;
     for (i = 0; i < 5; i++) {
         SetAnim(anim, ((void**)data_ov034_021138b0[i])[1], 0x40000000, 0x1000, 0);
-        int *f = (int*)(((int)(p + (i<<6)) + 0x490) & 0xFFFFFFFFFFFFFFFF);
+        int *f = (int*)(((int)(p + (i<<6)) + 0x490));
         *f |= 4;
         anim += 0x64;
     }
     if (*(unsigned char*)(p+0x8db) > 1) {
-        unsigned char *q = (unsigned char*)(((int)p + 0x8db) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char *q = (unsigned char*)(((int)p + 0x8db));
         *q = *q - 1;
     }
 }

--- a/src/func_ov034_02111e68.c
+++ b/src/func_ov034_02111e68.c
@@ -74,7 +74,7 @@ void func_ov034_02111e68(char *c)
             *((int *) (c + 0x9c)) = -0x4000;
           }
         }
-        (*(int *)(((int)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFF)) &= ~8;
+        (*(int *)(((int)data_0209f318 + 0x154))) &= ~8;
         *((unsigned char *) (c + 0x8e1)) = 0;
         func_ov034_021125b8(c, 4);
       }

--- a/src/func_ov036_021112f0.c
+++ b/src/func_ov036_021112f0.c
@@ -12,14 +12,14 @@ int daObjRcBuranko_c_Behavior(char *c)
 {
     struct daObjRcBuranko_c *self = (struct daObjRcBuranko_c *)(void *)c;
     if (self->unk_090 < 0) {
-        short *p = (short *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
+        short *p = (short *)(((int)c + 0x31e));
         *p = *p + 4;
     } else {
-        short *p = (short *)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
+        short *p = (short *)(((int)c + 0x31e));
         *p = *p - 4;
     }
     {
-        short *q = (short *)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF);
+        short *q = (short *)(((int)c + 0x90));
         *q = *q + ((short *)(c + 0x300))[15];
     }
     func_ov036_0211123c(c);

--- a/src/func_ov043_021112a8.cpp
+++ b/src/func_ov043_021112a8.cpp
@@ -16,7 +16,7 @@ int daObjKm1_Ukishima_c_Behavior(char *c)
     struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
     if (!DecIfAbove0_Byte((unsigned char *)(c + 0x31e))) {
         self->unk_31e = 0x3c;
-        *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) = *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) + 0x4000;
+        *(short *)(((int)c + 0x94)) = *(short *)(((int)c + 0x94)) + 0x4000;
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov045_0211129c.c
+++ b/src/func_ov045_0211129c.c
@@ -13,31 +13,31 @@ int daObjKm2_Agaru_c_Behavior(char *c)
     switch (self->unk_327) {
     case 0:
         if (self->unk_326 != 0)
-            *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
-                *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(unsigned char*)(((int)c + 0x327)) =
+                *(unsigned char*)(((int)c + 0x327)) + 1;
         break;
     case 1:
         if (self->unk_324 >= 0x14) {
             int lim;
-            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-                *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + 0xa000;
+            *(int*)(((int)c + 0x60)) =
+                *(int*)(((int)c + 0x60)) + 0xa000;
             lim = self->unk_320 + 0x5dc000;
             if (self->unk_060 >= lim) {
                 self->unk_060 = lim;
-                *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) =
-                    *(unsigned char*)(((int)c + 0x327) & 0xFFFFFFFFFFFFFFFF) + 1;
+                *(unsigned char*)(((int)c + 0x327)) =
+                    *(unsigned char*)(((int)c + 0x327)) + 1;
                 self->unk_324 = 0;
             }
         } else {
-            *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
-                *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(unsigned short*)(((int)c + 0x324)) =
+                *(unsigned short*)(((int)c + 0x324)) + 1;
         }
         break;
     case 2:
         if (self->unk_324 >= 0x14) {
             int lim;
-            *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-                *(int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) - 0xa000;
+            *(int*)(((int)c + 0x60)) =
+                *(int*)(((int)c + 0x60)) - 0xa000;
             lim = self->unk_320;
             if (self->unk_060 <= lim) {
                 self->unk_060 = lim;
@@ -45,8 +45,8 @@ int daObjKm2_Agaru_c_Behavior(char *c)
                 self->unk_324 = 0;
             }
         } else {
-            *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) =
-                *(unsigned short*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF) + 1;
+            *(unsigned short*)(((int)c + 0x324)) =
+                *(unsigned short*)(((int)c + 0x324)) + 1;
         }
         break;
     }

--- a/src/func_ov052_021112ac.c
+++ b/src/func_ov052_021112ac.c
@@ -19,7 +19,7 @@ int daObjEmmLog_c_Behavior(char *c)
     int s = *(short*)((char*)data_02082214 + (idx << 2));
     int m = (int)(((long long)self->unk_324 * s + 0x800) >> 12);
     self->unk_060 = self->unk_320 + m;
-    short *q = (short*)(((int)c + 0x31e) & 0xFFFFFFFFFFFFFFFF);
+    short *q = (short*)(((int)c + 0x31e));
     *q = (short)(*q + 0x200);
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov055_02111288.c
+++ b/src/func_ov055_02111288.c
@@ -1,6 +1,6 @@
 int func_ov055_02111288(char *dst, char *src)
 {
-    int *vec = (int *)(((int)src + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    int *vec = (int *)(((int)src + 0x5c));
     int x = vec[0];
     int z = vec[2];
     int y = vec[1];

--- a/src/func_ov060_021123a0.c
+++ b/src/func_ov060_021123a0.c
@@ -1,6 +1,6 @@
 void func_ov060_021123a0(unsigned char* c, int f) {
     if (f)
-        (*(int *)(((int)c + 0x378) & 0xFFFFFFFFFFFFFFFF)) &= ~1;
+        (*(int *)(((int)c + 0x378))) &= ~1;
     else
-        (*(int *)(((int)c + 0x378) & 0xFFFFFFFFFFFFFFFF)) |= 1;
+        (*(int *)(((int)c + 0x378))) |= 1;
 }

--- a/src/func_ov060_02112434.cpp
+++ b/src/func_ov060_02112434.cpp
@@ -32,13 +32,13 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
     int s0 = Actor_GetSubtraction(thiz, *(short*)(thiz + 0x8e), *(short*)(thiz + 0x406));
     int s1 = Actor_GetSubtraction(thiz, *(short*)(thiz + 0x8e), *(short*)(thiz + 0x408));
 
-    *(int*)(int)(((long long)(int)(thiz + 0x418)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xff;
+    *(int*)(int)(((long long)(int)(thiz + 0x418))) &= ~0xff;
     if (s0 < 0x2000)
-        *(int*)(int)(((long long)(int)(thiz + 0x418)) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(int*)(int)(((long long)(int)(thiz + 0x418))) |= 2;
     if (s1 < 0x3800)
-        *(int*)(int)(((long long)((int)thiz + 0x418)) & 0xFFFFFFFFFFFFFFFFLL) |= 4;
+        *(int*)(int)(((long long)((int)thiz + 0x418))) |= 4;
     if (*(int*)(thiz + 0x3f4) < 0x3e8000)
-        *(int*)(((int)thiz + 0x418) & 0xFFFFFFFFFFFFFFFF) |= 0x10;
+        *(int*)(((int)thiz + 0x418)) |= 0x10;
     if (*(int*)(thiz + 0x3ec) < 0x352000)
         *(int*)(int)(((unsigned long long)((unsigned)thiz + 0x418))) |= 8;
 
@@ -55,8 +55,8 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
             thiz[0x41c] = 0xff;
             return;
         }
-        *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c)) & 0xFFFFFFFFFFFFFFFFLL) =
-            *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c)) & 0xFFFFFFFFFFFFFFFFLL) + 0x14;
+        *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c))) =
+            *(unsigned char*)(int)(((long long)(int)(thiz + 0x41c))) + 0x14;
         return;
     }
     {
@@ -64,8 +64,8 @@ extern "C" void func_ov060_02112434(unsigned char* thiz)
         if (v <= 0) {
             thiz[0x41c] = 0;
         } else {
-            *(unsigned char*)(int)(((long long)((int)thiz + 0x41c)) & 0xFFFFFFFFFFFFFFFFLL) =
-                *(unsigned char*)(int)(((long long)((int)thiz + 0x41c)) & 0xFFFFFFFFFFFFFFFFLL) - 0x14;
+            *(unsigned char*)(int)(((long long)((int)thiz + 0x41c))) =
+                *(unsigned char*)(int)(((long long)((int)thiz + 0x41c))) - 0x14;
         }
     }
 }

--- a/src/func_ov060_021125f0.c
+++ b/src/func_ov060_021125f0.c
@@ -18,7 +18,7 @@ void func_ov060_021125f0(char *c)
     *(unsigned char *)(c + 0x425) = 0;
     *(int *)(c + 0x410) = 0;
     {
-        int *q = (int *)(((long long)(int)(c + 0x378)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *q = (int *)(((long long)(int)(c + 0x378)));
         *q &= ~1;
     }
     *(int *)(c + 0x40c) = 1;
@@ -35,13 +35,13 @@ void func_ov060_021125f0(char *c)
     if (a != 0) {
         *(int *)(a + 0x110) = 1;
         {
-            char *p = (char *)(((long long)(int)(a + 0x100)) & 0xFFFFFFFFFFFFFFFFLL);
+            char *p = (char *)(((long long)(int)(a + 0x100)));
             *(short *)(p + 0x14) = 0;
         }
     }
     *(short *)(c + 0x8c) = 0;
     {
-        char *p = (char *)(((long long)(int)(c + 0x300)) & 0xFFFFFFFFFFFFFFFFLL);
+        char *p = (char *)(((long long)(int)(c + 0x300)));
         *(short *)(p + 0xfc) = 0;
     }
     {

--- a/src/func_ov060_021128c0.cpp
+++ b/src/func_ov060_021128c0.cpp
@@ -62,11 +62,11 @@ extern "C" void func_ov060_021128c0(char* c)
         fn(base);
     }
 
-    *(u16*)(((int)c + 0x3fc) & 0xFFFFFFFFFFFFFFFFLL) =
-        *(u16*)(((int)c + 0x3fc) & 0xFFFFFFFFFFFFFFFFLL) + 1;
+    *(u16*)(((int)c + 0x3fc)) =
+        *(u16*)(((int)c + 0x3fc)) + 1;
     if (*(s32*)(c + 0x40c) != idx) {
         *(u8*)(c + 0x423) = 0;
-        *(u16*)((char*)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL) + 0xfc) = 0;
+        *(u16*)((char*)(((int)c + 0x300)) + 0xfc) = 0;
     }
 
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, c + 0x360);
@@ -96,9 +96,9 @@ extern "C" void func_ov060_021128c0(char* c)
 
     if (data_ov060_02119268[idx] != 0) {
         if (!_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x14c)) {
-            char* p400 = (char*)(((int)c + 0x400) & 0xFFFFFFFFFFFFFFFFLL);
-            s32* px = (s32*)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
-            s32* pz = (s32*)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFFLL);
+            char* p400 = (char*)(((int)c + 0x400));
+            s32* px = (s32*)(((int)c + 0x5c));
+            s32* pz = (s32*)(((int)c + 0x64));
             s16* tab = data_02082214;
             *(s32*)(c + 0x5c) = *(s32*)(c + 0x3c8);
             *(s32*)(c + 0x60) = *(s32*)(c + 0x3cc);
@@ -122,5 +122,5 @@ extern "C" void func_ov060_021128c0(char* c)
         return;
     *(s32*)(c + 0x40c) = 2;
     *(u8*)(c + 0x423) = 0;
-    *(u16*)((char*)(((int)c + 0x300) & 0xFFFFFFFFFFFFFFFFLL) + 0xfc) = 0;
+    *(u16*)((char*)(((int)c + 0x300)) + 0xfc) = 0;
 }

--- a/src/func_ov060_02112bfc.c
+++ b/src/func_ov060_02112bfc.c
@@ -34,7 +34,7 @@ void func_ov060_02112bfc(char* c){
         i += 1;
     }
     if (r6 != 0) {
-        short* q = (short*)(((int)found + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+        short* q = (short*)(((int)found + 0x8c));
         *(int*)(c + 0x40c) = 0;
         *(short*)(found + 0x31e) = 0;
         *(short*)(found + 0x320) = 0;

--- a/src/func_ov060_02112ddc.cpp
+++ b/src/func_ov060_02112ddc.cpp
@@ -15,16 +15,16 @@ extern "C" void func_ov060_02112ddc(char *self)
         if (func_ov060_02113404(self) == 0) break;
         *(short*)(self + 0x3fe) = 0;
         if (*(unsigned char*)(self + 0x414) == 2) { *(unsigned char*)(self + 0x423) = 0xa; break; }
-        p = (unsigned char*)((long long)((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (unsigned char*)((long long)((int)self + 0x423));
         *p += 1;
         break;
     case 3:
         if (func_ov060_021130c0(self) == 0) break;
-        p = (unsigned char*)((long long)((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+        p = (unsigned char*)((long long)((int)self + 0x423));
         *p += 1;
         break;
     case 10:
-        if (func_ov060_02112ee0(self) != 0) { p = (unsigned char*)((long long)((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL); *p += 1; }
+        if (func_ov060_02112ee0(self) != 0) { p = (unsigned char*)((long long)((int)self + 0x423)); *p += 1; }
         break;
     case 11: break;
     }

--- a/src/func_ov060_02112ee0.cpp
+++ b/src/func_ov060_02112ee0.cpp
@@ -14,7 +14,7 @@ extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callba
 extern void func_ov060_02113260(void *c);
 }
 
-#define LAUND(p) ((void *)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LAUND(p) ((void *)((((long long)(int)(p)))))
 
 extern "C" int func_ov060_02112ee0(void *cc)
 {

--- a/src/func_ov060_021130c0.c
+++ b/src/func_ov060_021130c0.c
@@ -2,7 +2,7 @@ typedef unsigned int u32;
 typedef unsigned short u16;
 typedef unsigned char u8;
 
-#define LAUND(p) ((void*)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LAUND(p) ((void*)((((long long)(int)(p)))))
 
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* player, void* actorBase, int isTalk);
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int a, int b);

--- a/src/func_ov060_02113260.c
+++ b/src/func_ov060_02113260.c
@@ -12,5 +12,5 @@ void func_ov060_02113260(char *c)
     *(int *)(c + 0xa8) = 0;
     *(int *)(c + 0x9c) = 0;
     *(unsigned char *)(c + 0x426) = 0;
-    *(int *)(((int)c + 0x378) & 0xFFFFFFFFFFFFFFFF) |= 1;
+    *(int *)(((int)c + 0x378)) |= 1;
 }

--- a/src/func_ov060_021132a4.c
+++ b/src/func_ov060_021132a4.c
@@ -3,7 +3,7 @@ typedef struct { int x, y, z; } Vector3;
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(unsigned int a, unsigned int b, int fix, int t1, int t2, void *v, void *cb);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int d);
 
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((long long)(int)(p))
 
 int func_ov060_021132a4(char *c)
 {

--- a/src/func_ov060_02113404.c
+++ b/src/func_ov060_02113404.c
@@ -14,7 +14,7 @@ int func_ov060_02113404(char* c) {
   if (*(int*)(c+0x134) == *(int*)(data_ov060_0211ac60+4)) {
     char* base = *(char**)(c+0x3a0);
     if (base != 0) {
-      int* o = (int*)(((int)base + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+      int* o = (int*)(((int)base + 0x5c));
       struct Vector3 v;
       s16 ang;
       v.x = o[0];

--- a/src/func_ov060_021134ac.c
+++ b/src/func_ov060_021134ac.c
@@ -17,7 +17,7 @@ void func_ov060_021134ac(void* thiz)
             func_ov060_02111cc0(c, 5, 0x40000000);
         }
         {
-            int* p = (int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF);
+            int* p = (int*)(((int)c + 0x98));
             *p = *p >> 1;
         }
     }
@@ -25,7 +25,7 @@ void func_ov060_021134ac(void* thiz)
         if (!_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x14c)) {
             *(int*)(c + 0x98) = 0;
             {
-                unsigned char* p = (unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+                unsigned char* p = (unsigned char*)(((int)c + 0x423));
                 *p = *p + 1;
             }
         }

--- a/src/func_ov060_02113564.c
+++ b/src/func_ov060_02113564.c
@@ -12,7 +12,7 @@ void func_ov060_02113564(char *c)
     *(int *)(c + 0x9c) = -0x2000;
     *(short *)(c + 0x8e) = (short)(*(short *)(c + 0x408) + 0x8000);
     *(short *)(c + 0x3fe) = 0;
-    *(unsigned char *)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned char *)(((int)c + 0x423)) += 1;
     *(int *)(c + 0x364) = 0xb4000;
     func_02012694(0xb1, (void *)(c + 0x74), 0xb4000);
 }

--- a/src/func_ov060_021135fc.c
+++ b/src/func_ov060_021135fc.c
@@ -17,7 +17,7 @@ void func_ov060_021135fc(char *c)
     py = py + 0x32000;
     base.y = py;
 
-    *(int*)(int)(((long long)(int)(c+0x378)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    *(int*)(int)(((long long)(int)(c+0x378))) |= 1;
 
     if (*(unsigned char*)(c+0x414) == 2) {
         Vector3 pos;

--- a/src/func_ov060_02113740.c
+++ b/src/func_ov060_02113740.c
@@ -54,7 +54,7 @@ void func_ov060_02113740(char *c)
         _ZN13RaycastGroundD1Ev(&rc);
     }
 
-    *(int*)(((long long)(int)(c + 0x418)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000;
+    *(int*)(((long long)(int)(c + 0x418))) |= 0x10000;
 
     switch (*(u8*)(c + 0x423)) {
     case 0:
@@ -68,7 +68,7 @@ void func_ov060_02113740(char *c)
         *p8c += 0x800;
         *p90 += 0x800;
         if ((*(s16*)(c + 0x8c) & 0xffff) == 0)
-            (*(u8*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)c + 0x423)))++;
         func_ov060_02113a94(c);
         return;
     }
@@ -82,7 +82,7 @@ void func_ov060_02113740(char *c)
             *(int*)(c + 0x9c) = 0;
             *(u8*)(c + 0x41d) = 0xff;
             *(s16*)(c + 0x3fe) = 0;
-            (*(u8*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)c + 0x423)))++;
             return;
         }
         func_ov060_02113a94(c);
@@ -105,7 +105,7 @@ void func_ov060_02113740(char *c)
             }
         }
         if (func_ov060_021145d4(c)) {
-            (*(u8*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+            (*(u8*)(((int)c + 0x423)))++;
             if (hit == 0) {
                 func_ov060_02115b0c(c);
             } else {
@@ -129,7 +129,7 @@ void func_ov060_02113740(char *c)
     case 3:
         if (Bowser_IsAnimAtLastFrame(c) != 0) {
             *(int*)(c + 0x40c) = 0;
-            *(int*)(((int)c + 0x418) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10000;
+            *(int*)(((int)c + 0x418)) &= ~0x10000;
             *(int*)(c + 0x9c) = -0x2000;
         }
         return;

--- a/src/func_ov060_02113b5c.cpp
+++ b/src/func_ov060_02113b5c.cpp
@@ -66,7 +66,7 @@ extern "C" void func_ov060_02113b5c(char* c)
             if (_ZNK12WithMeshClsn13JustHitGroundEv(c + 0x14c) == 0) {
                 *(s32*)(c + 0x98) = 0;
                 *(u8*)(c + 0x427) = 0;
-                u8* p = (u8*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+                u8* p = (u8*)(((int)c + 0x423));
                 *p = *p + 1;
                 func_ov060_02111cc0(c, 0xd, 0x40000000);
             }
@@ -78,7 +78,7 @@ extern "C" void func_ov060_02113b5c(char* c)
     }
 
     if (func_ov060_02113d20(c) != 0) {
-        signed char* q = (signed char*)(((int)c + 0x41e) & 0xFFFFFFFFFFFFFFFFLL);
+        signed char* q = (signed char*)(((int)c + 0x41e));
         *q = *q - 1;
         if (*(signed char*)(c + 0x400 + 0x1e) <= 0) {
             *(s32*)(c + 0x40c) = 4;

--- a/src/func_ov060_02113d8c.cpp
+++ b/src/func_ov060_02113d8c.cpp
@@ -32,7 +32,7 @@ extern "C" void func_ov060_02113d8c(char *r4)
         func_ov060_02111cc0(r4, 0x19, 0);
         *(int *)(r4 + 0x98) = 0x2a000;
         if (Bowser_IsAnimAtLastFrame(r4) != 0) {
-            u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)));
             *p = *p + 1;
             if (*(u16 *)((r4 + 0x300) + 0xfe) > 0xa)
                 *(u8 *)(r4 + 0x423) = 3;
@@ -65,7 +65,7 @@ extern "C" void func_ov060_02113d8c(char *r4)
                 *(int *)(r4 + 0x3f8) = 0x1000;
             }
             {
-                u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)) & 0xFFFFFFFFFFFFFFFFLL);
+                u16 *p = (u16 *)(((long long)(int)(r4 + 0x3fe)));
                 *p = *p + 1;
             }
         }

--- a/src/func_ov060_02113ff4.c
+++ b/src/func_ov060_02113ff4.c
@@ -8,13 +8,13 @@ int func_ov060_02113ff4(char *c, unsigned short arg1, int arg2)
     if (f == 0) {
         func_ov060_02111cc0(c, 0x13, 0x40000000);
         if (Bowser_IsAnimAtLastFrame(c) != 0) {
-            unsigned char *p = (unsigned char *)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char *p = (unsigned char *)(((int)c + 0x423));
             *p = *p + 1;
         }
     } else if (f == 1) {
         func_ov060_02111cc0(c, 0x12, 0x40000000);
         if (Bowser_IsAnimAtLastFrame(c) != 0) {
-            unsigned char *p = (unsigned char *)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char *p = (unsigned char *)(((int)c + 0x423));
             *p = *p + 1;
         }
     } else {
@@ -23,7 +23,7 @@ int func_ov060_02113ff4(char *c, unsigned short arg1, int arg2)
     r = 0;
     *(int *)(c + 0x98) = 0;
     {
-        short *q = (short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        short *q = (short *)(((int)c + 0x8e));
         *q += arg2;
     }
     if (*(unsigned short *)(c + 0x3fc) >= arg1)

--- a/src/func_ov060_02114300.c
+++ b/src/func_ov060_02114300.c
@@ -13,14 +13,14 @@ void func_ov060_02114300(char *c)
             *(int*)(c + 0xa8) = 0x32000;
             *(int*)(c + 0x98) = 0x19000;
             *(short*)(c + 0x3fe) = 0;
-            v = *(unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF) + 1;
-            *(unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF) = (unsigned char)v;
+            v = *(unsigned char*)(((int)c + 0x423)) + 1;
+            *(unsigned char*)(((int)c + 0x423)) = (unsigned char)v;
             func_02012694(0xb1, c + 0x74, v);
         }
     } else if (k == 1) {
         if (!func_ov060_021145d4(c)) return;
         {
-            unsigned char *p = (unsigned char*)(((int)c + 0x423) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char *p = (unsigned char*)(((int)c + 0x423));
             *p = *p + 1;
         }
     } else {

--- a/src/func_ov060_021143b8.c
+++ b/src/func_ov060_021143b8.c
@@ -29,7 +29,7 @@ void func_ov060_021143b8(char* self)
             *(int*)(self + 0x5c) = *(int*)(self + 0x3c8);
             *(int*)(self + 0x64) = *(int*)(self + 0x3d0);
         }
-        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char*)(((int)self + 0x423)))++;
         *(int*)(self + 0x3f8) = 0x1000;
         return;
     }
@@ -47,11 +47,11 @@ void func_ov060_021143b8(char* self)
             func_0200fa04(self, vec, 0);
             func_ov060_02111cc0(self, 0xc, 0x40000000);
         }
-        *(int*)(((int)self + 0x418) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10000;
+        *(int*)(((int)self + 0x418)) &= ~0x10000;
         *(int*)(self + 0x98) = 0;
         *(int*)(self + 0xa8) = 0;
         *(int*)(self + 0x60) = *(int*)(self + 0x3cc);
-        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char*)(((int)self + 0x423)))++;
         func_ov060_02115b0c(self);
         if (*(unsigned char*)(self + 0x414) == 1) {
             void* a;

--- a/src/func_ov060_021146d0.c
+++ b/src/func_ov060_021146d0.c
@@ -22,7 +22,7 @@ void func_ov060_021146d0(char *c) {
         func_02012694(0xb1, c + 0x74);
     } else {
         if (*(u16*)(c + 0x8c) > 0xc00) {
-            s16 *p8c = (s16*)(((long long)(int)((char*)c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+            s16 *p8c = (s16*)(((long long)(int)((char*)c + 0x8c)));
             *p8c = *p8c - 0xc00;
         } else {
             *(u16*)(c + 0x8c) = 0;
@@ -33,7 +33,7 @@ void func_ov060_021146d0(char *c) {
         if (st == 0) {
             func_ov060_02111cc0(c, 1, 0x40000000);
             {
-                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)));
                 *p = *p + 1;
             }
             *(u16*)(c + 0x300 + 0xfe) = 0;
@@ -47,7 +47,7 @@ void func_ov060_021146d0(char *c) {
             *(int*)(c + 0xa8) = 0;
             *(int*)(c + 0x98) = 0;
             {
-                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8*)(((long long)(int)((char*)c + 0x423)));
                 *p = *p + 1;
             }
             return;

--- a/src/func_ov060_02114858.c
+++ b/src/func_ov060_02114858.c
@@ -84,12 +84,12 @@ void func_ov060_02114858(void *self)
       }
     }
     {
-      u16 *pt = (u16 *) ((((int) c) + 0x400) & 0xFFFFFFFFFFFFFFFFLL);
+      u16 *pt = (u16 *) ((((int) c) + 0x400));
       *pt = (*pt) + 1;
     }
   }
   {
-    int *p = (int *) ((((int) c) + 0x418) & 0xFFFFFFFFFFFFFFFFLL);
+    int *p = (int *) ((((int) c) + 0x418));
     *p |= 0x20000;
   }
   if (Bowser_IsAnimAtLastFrame(c) == 0)
@@ -103,7 +103,7 @@ void func_ov060_02114858(void *self)
       func_ov060_02111cc0(c, 0x16, 0x40000000);
       func_02012694(0xb5, c + 0x74);
     {
-      u8 *ps = (u8 *) ((((int) c) + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+      u8 *ps = (u8 *) ((((int) c) + 0x423));
       *ps = (*ps) + 1;
     }
       return;
@@ -111,7 +111,7 @@ void func_ov060_02114858(void *self)
     case 1:
       func_ov060_02111cc0(c, 0x15, 0);
     {
-      u8 *ps = (u8 *) ((((int) c) + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+      u8 *ps = (u8 *) ((((int) c) + 0x423));
       *ps = (*ps) + 1;
     }
       return;
@@ -119,7 +119,7 @@ void func_ov060_02114858(void *self)
     case 2:
       func_ov060_02111cc0(c, 0x17, 0x40000000);
     {
-      u8 *ps = (u8 *) ((((int) c) + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+      u8 *ps = (u8 *) ((((int) c) + 0x423));
       *ps = (*ps) + 1;
     }
       return;
@@ -127,7 +127,7 @@ void func_ov060_02114858(void *self)
     case 3:
       *((s32 *) (c + 0x40c)) = 0;
     {
-      int *p = (int *) (((long long) ((int) (c + 0x418))) & 0xFFFFFFFFFFFFFFFFLL);
+      int *p = (int *) (((long long) ((int) (c + 0x418))));
       *p &= ~0x20000;
     }
       return;

--- a/src/func_ov060_02114b60.c
+++ b/src/func_ov060_02114b60.c
@@ -7,7 +7,7 @@ extern int _ZN5Actor14GetSubtractionEss(char *self, s16 a, s16 b);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(char *self);
 void func_ov060_02114b60(char *c)
 {
-  int *pflag = (int *) ((((int) c) + 0x378) & 0xFFFFFFFFFFFFFFFFLL);
+  int *pflag = (int *) ((((int) c) + 0x378));
   *pflag |= 1;
   switch (*((u8 *) (c + 0x423)))
   {
@@ -23,7 +23,7 @@ void func_ov060_02114b60(char *c)
       return;
     }
     {
-      u8 *ps = (u8 *) ((((int) c) + 0x423) & 0xFFFFFFFFFFFFFFFFLL);
+      u8 *ps = (u8 *) ((((int) c) + 0x423));
       *ps = (*ps) + 1;
     }
       *((s16 *) (c + 0x8e)) = *((s16 *) (c + 0x406));
@@ -32,12 +32,12 @@ void func_ov060_02114b60(char *c)
     case 1:
     {
       int r4 = 0;
-      u16 *pd = (u16 *) ((((int) c) + 0x3fe) & 0xFFFFFFFFFFFFFFFFLL);
+      u16 *pd = (u16 *) ((((int) c) + 0x3fe));
       char *base3 = c + 0x300;
       int sub;
       u16 h = *pd;
       u16 h2 = *((u16 *) (base3 + 0xfe));
-      *((u16 *) ((((int) c) + 0x3fe) & 0xFFFFFFFFFFFFFFFFLL)) = h - 1;
+      *((u16 *) ((((int) c) + 0x3fe))) = h - 1;
       if (h2 != 0)
       {
         *((int *) (c + 0x98)) = 0x64000;

--- a/src/func_ov060_02114d08.c
+++ b/src/func_ov060_02114d08.c
@@ -31,20 +31,20 @@ void func_ov060_02114d08(char* self)
     if (*(unsigned char*)(self + 0x423) == 0) {
         *(short*)(self + 0x3fe) = 0;
         if (func_ov060_02115744(self) == 0) return;
-        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char*)(((int)self + 0x423)))++;
         return;
     }
     if (*(unsigned char*)(self + 0x423) <= 2) {
         if (func_ov060_02115718(self) == 0) return;
-        (*(u16*)(((int)self + 0x3fe) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u16*)(((int)self + 0x3fe)))++;
         if (*(int*)(self + 0x418) & 0x20000) {
             if (*(u16*)(self + 0x3fe) < 5) return;
-            *(int*)(((int)self + 0x418) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x20000;
+            *(int*)(((int)self + 0x418)) &= ~0x20000;
             return;
         }
         if (r4 >= 0x2000) return;
         *(int*)(self + 0x12c) = 0;
-        (*(unsigned char*)(((int)self + 0x423) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(unsigned char*)(((int)self + 0x423)))++;
         *(short*)(self + 0x3fe) = 0;
         return;
     }

--- a/src/func_ov060_02115060.c
+++ b/src/func_ov060_02115060.c
@@ -13,7 +13,7 @@ void func_ov060_02115060(char *c)
     {
       func_ov060_021150c4(c);
     }
-    (*((unsigned char *) ((((unsigned int) c) + 0x415) & 0xFFFFFFFFFFFFFFFF)))++;
+    (*((unsigned char *) ((((unsigned int) c) + 0x415))))++;
     return;
   }
   *((unsigned char *) (c + 0x415)) = 0;

--- a/src/func_ov060_021151d4.c
+++ b/src/func_ov060_021151d4.c
@@ -39,7 +39,7 @@ setE:
     *(int *)(a + 0x40c) = 0xe;
 tail:
     {
-        unsigned char *p = (unsigned char *)(((long long)(int)(a + 0x415)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char *)(((long long)(int)(a + 0x415)));
         *p = *p + 1;
     }
     return;

--- a/src/func_ov060_02115314.c
+++ b/src/func_ov060_02115314.c
@@ -12,7 +12,7 @@ void func_ov060_02115314(char* c)
         } else {
             *(int*)(c + 0x40c) = 0xe;
         }
-        unsigned char* q = (unsigned char*)(((int)c + 0x415) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* q = (unsigned char*)(((int)c + 0x415));
         *q = *q + 1;
         *(int*)(c + 0x3f8) = 0x1000;
     } else {

--- a/src/func_ov060_021153f8.c
+++ b/src/func_ov060_021153f8.c
@@ -7,7 +7,7 @@ extern int func_ov060_021156ec(void *c);
 extern void func_ov060_02111cc0(char *c, int idx, int extra);
 extern void func_ov060_02115518(void *c);
 
-#define P423(c) ((u8 *)(((long long)(int)((c) + 0x423)) & 0xFFFFFFFFFFFFFFFFLL))
+#define P423(c) ((u8 *)(((long long)(int)((c) + 0x423))))
 
 void func_ov060_021153f8(char *c)
 {

--- a/src/func_ov060_02115518.c
+++ b/src/func_ov060_02115518.c
@@ -26,7 +26,7 @@ void func_ov060_02115518(char *self)
     }
       *((int *) (self + 0x40c)) = 6;
     {
-      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424))) & 0xFFFFFFFFFFFFFFFFLL));
+      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424)))));
       *p = (*p) + 1;
     }
       return;
@@ -77,7 +77,7 @@ void func_ov060_02115518(char *self)
       }
     }
     {
-      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424))) & 0xFFFFFFFFFFFFFFFFLL));
+      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424)))));
       *p = (*p) + 1;
     }
       func_02012694(0xb7, self + 0x74);
@@ -97,7 +97,7 @@ void func_ov060_02115518(char *self)
       *((int *) (self + 0x40c)) = 0;
     }
     {
-      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424))) & 0xFFFFFFFFFFFFFFFFLL));
+      u8 *p = (u8 *) ((void *) (((long long) ((int) (self + 0x424)))));
       *p = (*p) + 1;
     }
       new_var = (u8 *) (self + 0x444);

--- a/src/func_ov060_02115b84.cpp
+++ b/src/func_ov060_02115b84.cpp
@@ -12,11 +12,11 @@ extern "C" void func_ov060_02115b84(char* c) {
   int idx = *(int*)(c + 0x110);
   (((C*)c)->*data_ov060_0211ae9c[idx])();
   if (*(int*)(r5 + 0x40c) == 4) {
-    int* f = (int*)(((int)c + 0xec) & 0xFFFFFFFFFFFFFFFF);
+    int* f = (int*)(((int)c + 0xec));
     *f = *f | 1;
   }
   {
-    unsigned short* h = (unsigned short*)(((int)c + 0x114) & 0xFFFFFFFFFFFFFFFF);
+    unsigned short* h = (unsigned short*)(((int)c + 0x114));
     *h = *h + 1;
   }
   if (idx != *(int*)(c + 0x110)) {

--- a/src/func_ov060_02115c1c.c
+++ b/src/func_ov060_02115c1c.c
@@ -36,7 +36,7 @@ void func_ov060_02115c1c(char *self)
 
     if (*(short *)(r1 + 0x600 + 0x9c) != 0) goto set_default;
     if (*(u16 *)(self + 0x100 + 0x16) == 0) goto tail;
-    *(u16 *)(((long long)(int)(self + 0x116)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+    *(u16 *)(((long long)(int)(self + 0x116))) -= 1;
     if (*(u16 *)(self + 0x100 + 0x16) != 0) goto tail;
 
 do_drop:
@@ -51,5 +51,5 @@ set_default:
     *(u16 *)(self + 0x100 + 0x16) = 0x96;
 
 tail:
-    *(int *)(((long long)(int)(self + 0xec)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+    *(int *)(((long long)(int)(self + 0xec))) |= 1;
 }

--- a/src/func_ov060_02115d68.cpp
+++ b/src/func_ov060_02115d68.cpp
@@ -13,7 +13,7 @@ extern "C" int _ZN6Player15IsCollectingCapEv(Player *p);
 extern "C" int _ZN6Player7TryGrabER5Actor(Player *p, Actor &a);
 
 extern "C" void func_ov060_02115d68(char *self) {
-    u32 *p = (u32 *)((char *)(((int)self + 0xec) & 0xFFFFFFFFFFFFFFFF));
+    u32 *p = (u32 *)((char *)(((int)self + 0xec)));
     Actor *r5 = _ZN5Actor10FindWithIDEj(*(u32 *)(self + 0x108));
     *p &= ~1u;
     if (*(s32 *)((char *)r5 + 0x40c) != 0x13) goto skip_13;
@@ -29,10 +29,10 @@ skip_13:
     if (_ZN6Player15IsCollectingCapEv((Player *)r4)) return;
     if (!_ZN6Player7TryGrabER5Actor((Player *)r4, *(Actor *)self)) return;
     s16 *ip = (s16 *)((char *)r5 + 0x8c);
-    *(s16 *)((char *)r4 + 0x8c) = *(s16 *)((int)ip & 0xFFFFFFFFFFFFFFFF);
+    *(s16 *)((char *)r4 + 0x8c) = *(s16 *)((int)ip);
     *(s16 *)((char *)r4 + 0x8e) = ip[1];
     *(s16 *)((char *)r4 + 0x90) = ip[2];
-    *(s16 *)((char *)r4 + 0x92) = *(s16 *)((int)ip & 0xFFFFFFFFFFFFFFFF);
+    *(s16 *)((char *)r4 + 0x92) = *(s16 *)((int)ip);
     *(s16 *)((char *)r4 + 0x94) = ip[1];
     *(s16 *)((char *)r4 + 0x96) = ip[2];
     *(s32 *)(self + 0x110) = 2;

--- a/src/func_ov060_021167c8.c
+++ b/src/func_ov060_021167c8.c
@@ -1,6 +1,6 @@
 void func_ov060_021167c8(char *c)
 {
-    *(int *)(((int)c + 0x2e8) & 0xFFFFFFFFFFFFFFFF) |= 1;
+    *(int *)(((int)c + 0x2e8)) |= 1;
     *(int *)(c + 0x360) = 0x2000;
     *(int *)(c + 0x368) = 0x10;
 }

--- a/src/func_ov060_021169f8.c
+++ b/src/func_ov060_021169f8.c
@@ -15,7 +15,7 @@ void func_ov060_021169f8(char* sl)
     int i;
     char* a;
     if (*(int*)(sl+0x360) < 0x5000) {
-        *(int*)(((int)sl + 0x360) & 0xFFFFFFFFFFFFFFFF) += 0x200;
+        *(int*)(((int)sl + 0x360)) += 0x200;
     }
     _ZN5Actor9UpdatePosEP12CylinderClsn(sl, 0);
     func_ov060_02116518(sl, 0x9a, 1, 0x78000);

--- a/src/func_ov060_02116f90.c
+++ b/src/func_ov060_02116f90.c
@@ -21,10 +21,10 @@ void func_ov060_02116f90(char *self) {
     if (*(int *)(self + 0x36c) == 0) {
         *(int *)(self + 0x37c) = _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
             *(int *)(self + 0x37c), 0x9e, *(int *)(self + 0x5c), *(int *)(self + 0x60) + 0x37000, *(int *)(self + 0x64), 0);
-        *(int *)(((int)self + 0x2e8) & 0xFFFFFFFFFFFFFFFF) |= 1;
+        *(int *)(((int)self + 0x2e8)) |= 1;
         func_ov060_0211712c(self);
         if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x110)) {
-            (*(int *)(((int)self + 0x36c) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(int *)(((int)self + 0x36c)))++;
             if (*(int *)(self + 0x35c) == 7) {
                 *(int *)(self + 0x360) = 0x6000;
             } else {
@@ -38,9 +38,9 @@ void func_ov060_02116f90(char *self) {
         }
     } else {
         func_ov060_02116518(self, 0x9c, 1, *(int *)(self + 0x360) * 0xc);
-        *(int *)(((int)self + 0x2e8) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+        *(int *)(((int)self + 0x2e8)) &= ~1;
         if (*(u16 *)(self + 0x374) > *(int *)(self + 0x360) * 0xa / 0x1000 + 5) {
-            *(int *)(((int)self + 0x360) & 0xFFFFFFFFFFFFFFFF) -= 0x266;
+            *(int *)(((int)self + 0x360)) -= 0x266;
             if (*(int *)(self + 0x360) <= 0)
                 func_ov060_021172e0(self);
         }

--- a/src/func_ov060_0211712c.c
+++ b/src/func_ov060_0211712c.c
@@ -4,11 +4,11 @@ void func_ov060_0211712c(char *p)
 {
     short ang = (short)(((*(int *)(p + 0x370) + *(unsigned short *)(p + 0x376)) & 0x3f) << 10);
     int bi = (unsigned short)ang >> 4;
-    int *px = (int *)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *px = (int *)(((long long)(int)(p + 0x5c)));
     int *pz;
     *px = *px + ((data_02082214[((int)*(unsigned short *)(p + 0x94) >> 4) * 2]
                   * data_02082214[bi * 2]) << 2) / 0x1000;
-    pz = (int *)(((long long)(int)(p + 0x64)) & 0xFFFFFFFFFFFFFFFFLL);
+    pz = (int *)(((long long)(int)(p + 0x64)));
     *pz = *pz + ((data_02082214[((int)*(unsigned short *)(p + 0x94) >> 4) * 2 + 1]
                   * data_02082214[bi * 2 + 1]) << 2) / 0x1000;
 }

--- a/src/func_ov060_02117db8.c
+++ b/src/func_ov060_02117db8.c
@@ -105,8 +105,8 @@ void func_ov060_02117db8(char *self) {
     }
 
     {
-        int *pa = (int *)(((int)self + 0xa8) & 0xFFFFFFFFFFFFFFFF);
-        int *pypos = (int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        int *pa = (int *)(((int)self + 0xa8));
+        int *pypos = (int *)(((int)self + 0x60));
         *pa = *pa + *(int *)(self + 0x9c);
         if (*(int *)(self + 0xa8) <= *(int *)(self + 0xa0))
             *(int *)(self + 0xa8) = *(int *)(self + 0xa0);
@@ -114,6 +114,6 @@ void func_ov060_02117db8(char *self) {
     }
     if ((u16)*(u16 *)(self + 0x326) > 0x12cu)
         _ZN9ActorBase18MarkForDestructionEv(self);
-    (*(u16 *)(((int)self + 0x326) & 0xFFFFFFFFFFFFFFFF))++;
+    (*(u16 *)(((int)self + 0x326)))++;
     (void)live;
 }

--- a/src/func_ov060_021184bc.c
+++ b/src/func_ov060_021184bc.c
@@ -9,7 +9,7 @@ void func_ov060_021184bc(char *c)
     char *a;
 
     ClearSpikeBomb(*(int *)(c + 0x1a8));
-    *(int *)(((int)c + 0x13c) & 0xFFFFFFFFFFFFFFFF) |= 1;
+    *(int *)(((int)c + 0x13c)) |= 1;
     *(int *)(c + 0x170) = 3;
     a = 0;
     for (i = 0; i < 8; i++)

--- a/src/func_ov060_021186d8.c
+++ b/src/func_ov060_021186d8.c
@@ -5,7 +5,7 @@ void func_ov060_021186d8(unsigned char* c) {
     *(int*)(c + 0x88) = 0x1000;
     *(unsigned char*)(c + 0x1ae) = 0xff;
     *(int*)(c + 0x170) = 0;
-    (*(int *)(((int)c + 0x13c) & 0xFFFFFFFFFFFFFFFF)) &= ~1;
+    (*(int *)(((int)c + 0x13c))) &= ~1;
     *(short*)(c + 0x1ac) = 0;
     *(int*)(c + 0x1a8) = AddSpikeBomb(c);
 }

--- a/src/func_ov060_02118834.c
+++ b/src/func_ov060_02118834.c
@@ -8,9 +8,9 @@ void func_ov060_02118834(char *c)
     *(int*)(c + 0x80) = v;
     *(int*)(c + 0x84) = v;
     *(int*)(c + 0x88) = v;
-    *(unsigned char *)(((int)c + 0x1ae) & 0xFFFFFFFFFFFFFFFF) -= 0xa;
+    *(unsigned char *)(((int)c + 0x1ae)) -= 0xa;
     if (*(unsigned char*)(c + 0x1ae) < 0xa) *(unsigned char*)(c + 0x1ae) = 0;
-    *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) += *(int*)(c + 0xa8);
+    *(int *)(((int)c + 0x60)) += *(int*)(c + 0xa8);
     if (*(unsigned short*)(c + 0x100 + 0xac) == 0x1c) func_ov060_021184bc(c);
-    *(unsigned short *)(((int)c + 0x1ac) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned short *)(((int)c + 0x1ac)) += 1;
 }

--- a/src/func_ov060_021188e8.c
+++ b/src/func_ov060_021188e8.c
@@ -22,12 +22,12 @@ void func_ov060_021188e8(char* c)
 {
     Work* w = (Work*)c;
     int scale;
-    (*(u32*)((long long)(int)(c + 0x13c) & 0xFFFFFFFFFFFFFFFFLL)) |= 1;
+    (*(u32*)((long long)(int)(c + 0x13c))) |= 1;
     scale = (w->timer * 9 << 12) / 14 + 0x1000;
     w->scaleX = scale;
     w->scaleY = scale;
     w->scaleZ = scale;
     if (w->timer == 0x1c)
         func_ov060_021184bc(c);
-    (*(u16*)((long long)(int)(c + 0x1ac) & 0xFFFFFFFFFFFFFFFFLL))++;
+    (*(u16*)((long long)(int)(c + 0x1ac)))++;
 }

--- a/src/func_ov062_021161a8.c
+++ b/src/func_ov062_021161a8.c
@@ -19,7 +19,7 @@ int func_ov062_021161a8(char *c)
   }
   if (_ZN9Animation8FinishedEv(c + 0x350))
   {
-    int *q = (int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *q = (int *)(((long long)(int)(c + 0x128)));
     *q &= ~2;
     Chuckya_ChangeState(c, data_ov062_0211ded0);
   }

--- a/src/func_ov062_021164e8.cpp
+++ b/src/func_ov062_021164e8.cpp
@@ -31,7 +31,7 @@ do_block:
     {
         void *m = *(void **)(c + 0x3f8);
         *(u16 *)(c + 0x94) = *(s16 *)((char *)m + 0x8e);
-        *(int *)((long long)(int)(c + 0x128) & 0xFFFFFFFFFFFFFFFFLL) |= 2;
+        *(int *)((long long)(int)(c + 0x128)) |= 2;
         Chuckya_ChangeState(c, &data_ov062_0211dec0);
         if (*(int *)((char *)*(void **)(c + 0x3f8) + 8) == 2) {
             *(int *)(c + 0xa8) = 0x50000;

--- a/src/func_ov062_02116a08.c
+++ b/src/func_ov062_02116a08.c
@@ -50,7 +50,7 @@
                 *(unsigned int *)(c + 0x3ec), 3, 0x18a, c + 0x74, 0);
 
         if (pl != 0 && *(unsigned short *)(c + 0x3e8) == 0) {
-            pos = (int *)(((int)pl + 0x5c) & 0xffffffffffffffffLL);
+            pos = (int *)(((int)pl + 0x5c));
             L.vd1[0] = pos[0];
             L.vd1[1] = pos[1];
             L.vd1[2] = pos[2];

--- a/src/func_ov062_02117c98.c
+++ b/src/func_ov062_02117c98.c
@@ -7,7 +7,7 @@ typedef unsigned char u8;
 typedef struct { s32 x, y, z; } Vec3;
 typedef struct { s16 x, y, z; } V16;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern void* _ZN5Actor10FindWithIDEj(u32 id);
 extern void func_020ada40(void* self, void* v, void* a, int f);
@@ -39,7 +39,7 @@ void func_ov062_02117c98(void* self)
         return;
 
     flags = *(s32*)(c + 0x130);
-    r5 = (int)(((long long)(int)0) & 0xFFFFFFFFFFFFFFFFLL);
+    r5 = (int)(((long long)(int)0));
 
     if (flags & 0x10) {
         V16 v;
@@ -90,7 +90,7 @@ void func_ov062_02117c98(void* self)
         struct { Vec3 sv; Vec3 hv; } L;
         int shell;
         shell = (*(u16*)(f + 0xc) == 0xbf) ? 1 : r5;
-        if ((int)(((long long)shell) & 0xFFFFFFFFFFFFFFFFLL) == 0)
+        if ((int)(((long long)shell)) == 0)
             goto tail;
         if (*(u8*)(f + 0x6f9) != 0) {
             if (*(s32*)(c + 0x390) == 0) {

--- a/src/func_ov062_0211811c.c
+++ b/src/func_ov062_0211811c.c
@@ -4,14 +4,14 @@ extern void func_ov062_02117994(char *c, int idx);
 void func_ov062_0211811c(char *c) {
     char *b = c + 0x300;
     if (*(unsigned short*)(b + 0xc6) != 0) {
-        unsigned short *p = (unsigned short*)(((int)c + 0x3c6) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *p = (unsigned short*)(((int)c + 0x3c6));
         *p = (unsigned short)(*p - 1);
         return;
     }
     if (_ZNK9Animation12WillHitFrameEi(c + 0x350, (unsigned short)(_ZNK9Animation13GetFrameCountEv(c + 0x350) - 1)) == 0)
         return;
     {
-        unsigned short *q = (unsigned short*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *q = (unsigned short*)(((int)c + 0x3c4));
         *q = (unsigned short)(*q + 1);
     }
     func_ov062_02117994(c, 2);

--- a/src/func_ov062_021181a0.c
+++ b/src/func_ov062_021181a0.c
@@ -12,7 +12,7 @@ void func_ov062_021181a0(char *c) {
     }
     if (_ZN9Animation8FinishedEv(c + 0x350) == 0) return;
     {
-        unsigned short *p = (unsigned short*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *p = (unsigned short*)(((int)c + 0x3c4));
         *p = (unsigned short)(*p + 1);
     }
     {

--- a/src/func_ov062_02118258.c
+++ b/src/func_ov062_02118258.c
@@ -1,6 +1,6 @@
 typedef struct Vector3 { int x, y, z; } Vector3;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern void* _ZN5Actor13ClosestPlayerEv(void*);
 extern int Vec3_Dist(const Vector3* a, const Vector3* b);

--- a/src/func_ov062_02118588.c
+++ b/src/func_ov062_02118588.c
@@ -26,7 +26,7 @@ void func_ov062_02118588(char *c)
         }
     }
     if (match != 0) {
-        int *hp = (int *)(((long long)(int)(c + 0x98)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *hp = (int *)(((long long)(int)(c + 0x98)));
         *(int *)(c + 0x390) = 0;
         *(int *)(c + 0x38c) = 4;
         *hp = *hp / 2;
@@ -40,7 +40,7 @@ void func_ov062_02118588(char *c)
 
     {
         if (*(unsigned short *)(c + 0x3c6) != 0) {
-            unsigned short *q = (unsigned short *)(((long long)(int)(c + 0x3c6)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *q = (unsigned short *)(((long long)(int)(c + 0x3c6)));
             char *p = c + 0x300;
             *q = (unsigned short)(*q - 1);
             if (*(unsigned short *)(p + 0xc6) != 0)

--- a/src/func_ov062_02118718.c
+++ b/src/func_ov062_02118718.c
@@ -34,12 +34,12 @@ void func_ov062_02118718(char *c)
                 _ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs(c, c + 0x144, (short*)(c + 0x3c2));
             if (!*(unsigned char*)(c + 0x3cc)) {
                 if (*(unsigned short*)(c + 0x3c8) != 0) {
-                    *(unsigned short*)(((int)c + 0x3c8) & 0xFFFFFFFFFFFFFFFF) -= 1;
+                    *(unsigned short*)(((int)c + 0x3c8)) -= 1;
                 } else {
                     if (((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 0x8000)
-                        *(short*)(((int)c + 0x3c2) & 0xFFFFFFFFFFFFFFFF) -= ((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 0x1fff;
+                        *(short*)(((int)c + 0x3c2)) -= ((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 0x1fff;
                     else
-                        *(short*)(((int)c + 0x3c2) & 0xFFFFFFFFFFFFFFFF) += ((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 0x1fff;
+                        *(short*)(((int)c + 0x3c2)) += ((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 0x1fff;
                     *(unsigned short*)(c + 0x3c8) = 0x14;
                 }
             }
@@ -67,7 +67,7 @@ void func_ov062_02118718(char *c)
 
     *(short*)(c + 0x94) = *(short*)(c + 0x3c2);
     *(int*)(c + 0x38c) = 2;
-    *(int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF) += *(int*)(c + 0x98) / 5;
+    *(int*)(((int)c + 0x98)) += *(int*)(c + 0x98) / 5;
     *(int*)(c + 0xa8) = dist / 30;
     func_ov062_02117994(c, 6);
     *(short*)(c + 0x3c6) = 0x14;

--- a/src/func_ov062_02118b4c.c
+++ b/src/func_ov062_02118b4c.c
@@ -26,7 +26,7 @@ void func_ov062_02118b4c(char *self) {
     }
 
     if (*(int *)(self + 0x3b8) >= 0x61a8000) {
-        *(s16 *)(((int)self + 0x3c0) & 0xFFFFFFFFFFFFFFFF) += 0x8000;
+        *(s16 *)(((int)self + 0x3c0)) += 0x8000;
         *(int *)(self + 0x3b8) = 0;
     }
     if (*(u16 *)(self + 0x100) > 0x1e && *(int *)(self + 0x3b8) > 0x320000) {

--- a/src/func_ov062_02118de8.cpp
+++ b/src/func_ov062_02118de8.cpp
@@ -16,7 +16,7 @@ extern "C" void func_ov062_02118de8(char *c)
         return;
     }
     if (_ZNK9Animation12WillHitFrameEi(c + 0x350, (unsigned short)(_ZNK9Animation13GetFrameCountEv(c + 0x350) - 1)) != 0) {
-        unsigned short *hp = (unsigned short*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short *hp = (unsigned short*)(((int)c + 0x3c4));
         *hp += 1;
     } else {
         func_ov062_02118058(c);

--- a/src/func_ov062_02119be0.c
+++ b/src/func_ov062_02119be0.c
@@ -41,7 +41,7 @@ void func_ov062_02119be0(char* self)
         if (*(unsigned short*)(self + 0x100) != 0)
             return;
         {
-            Vec3* pp = (Vec3*)(((int)*(char**)(self + 0x398) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+            Vec3* pp = (Vec3*)(((int)*(char**)(self + 0x398) + 0x5c));
             playerPos.x = pp->x;
             playerPos.y = pp->y;
             playerPos.z = pp->z;
@@ -51,7 +51,7 @@ void func_ov062_02119be0(char* self)
         if (Player_StartTalk(*(void**)(self + 0x398), self, 1) == 0)
             return;
         *(short*)(self + 0x3a8) = Vec3_HorzAngle((Vec3*)(self + 0x5c), &playerPos);
-        (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char*)(((int)self + 0x390)))++;
         ModelAnim_SetAnim(self + 0x300, data_ov062_0211e03c[1], 0, 0x1000, 0);
         if (*(unsigned char*)(self + 0x3b4) == 0) {
             Sound_StopLoadedMusic_Layer2();
@@ -63,7 +63,7 @@ void func_ov062_02119be0(char* self)
         return;
     case 1:
         if (ApproachLinear((short*)(self + 0x94), *(short*)(self + 0x3a8), 0x800) != 0)
-            (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)self + 0x390)))++;
         *(short*)(self + 0x8e) = *(short*)(self + 0x94);
         return;
     case 2:
@@ -93,12 +93,12 @@ void func_ov062_02119be0(char* self)
         msgPos.y = y;
         msgPos.z = z;
         if (Player_ShowMessage(*(void**)(self + 0x398), self, msg, &msgPos, 0, 0) != 0)
-            (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)self + 0x390)))++;
         return;
     case 3:
         if (Player_GetTalkState(*(void**)(self + 0x398)) != 0xFFFFFFFF)
             return;
-        (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char*)(((int)self + 0x390)))++;
         ModelAnim_SetAnim(self + 0x300, data_ov062_0211e034[1], 0, 0x1000, 0);
         *(unsigned short*)(self + 0x100) = 0x3c;
         if (*(unsigned char*)(self + 0x3af) != 0) {
@@ -116,7 +116,7 @@ void func_ov062_02119be0(char* self)
         return;
     case 4:
         {
-            Vec3* pp = (Vec3*)(((int)*(char**)(self + 0x398) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+            Vec3* pp = (Vec3*)(((int)*(char**)(self + 0x398) + 0x5c));
             playerPos.x = pp->x;
             playerPos.y = pp->y;
             playerPos.z = pp->z;
@@ -124,18 +124,18 @@ void func_ov062_02119be0(char* self)
         if (Vec3_Dist((Vec3*)(self + 0x5c), &playerPos) >= 0x190000)
             return;
         if (Player_StartTalk(*(void**)(self + 0x398), self, 0) != 0)
-            (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)self + 0x390)))++;
         return;
     case 5:
         if (Player_GetTalkState(*(void**)(self + 0x398)) != 0)
             return;
         *(short*)(self + 0x3a8) = Vec3_HorzAngle((Vec3*)(self + 0x5c), (Vec3*)(*(char**)(self + 0x398) + 0x5c));
         ModelAnim_SetAnim(self + 0x300, data_ov062_0211e03c[1], 0, 0x1000, 0);
-        (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(unsigned char*)(((int)self + 0x390)))++;
         return;
     case 6:
         if (ApproachLinear((short*)(self + 0x94), *(short*)(self + 0x3a8), 0x800) != 0)
-            (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)self + 0x390)))++;
         *(short*)(self + 0x8e) = *(short*)(self + 0x94);
         return;
     case 7:
@@ -156,7 +156,7 @@ void func_ov062_02119be0(char* self)
         msgPos.y = y;
         msgPos.z = z;
         if (Player_ShowMessage(*(void**)(self + 0x398), self, msg, &msgPos, 0, 0) != 0)
-            (*(unsigned char*)(((int)self + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(unsigned char*)(((int)self + 0x390)))++;
         return;
     case 8:
         if (Player_GetTalkState(*(void**)(self + 0x398)) != 0xFFFFFFFF)

--- a/src/func_ov062_0211a1f4.c
+++ b/src/func_ov062_0211a1f4.c
@@ -49,7 +49,7 @@ void func_ov062_0211a1f4(char *a)
     switch (*(u8 *)(a + 0x390)) {
     case 0:
         if (_ZN6Player12Unk_020c4f40Et(*(int *)(a + 0x398), 0x5a) != 0)
-            (*(u8 *)(((int)a + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8 *)(((int)a + 0x390)))++;
         return;
     case 1:
         _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x1f, 0x14, 0x7f, 0x6b000, 0);
@@ -59,7 +59,7 @@ void func_ov062_0211a1f4(char *a)
         func_02012694(0x4d, a + 0x74);
         _ZN5Sound22LoadAndSetMusic_Layer2Ej(0x41);
         *(u8 *)(a + 0x3b5) = 1;
-        (*(u8 *)(((int)a + 0x390) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8 *)(((int)a + 0x390)))++;
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(a + 0x300, data_ov062_0211e014[1], 0x40000000, 0x1000, 0);
         data_ov002_02111184 = 1;
         _ZN5Timer10StartTimerEv(&data_0209d4c8);

--- a/src/func_ov062_0211b2fc.c
+++ b/src/func_ov062_0211b2fc.c
@@ -19,7 +19,7 @@ void func_ov062_0211b2fc(char* c){
   v[0].z = 0x14000;
   if (*(int*)(c+0x468) == 0 && *(int*)(c+0x44c) == 0) {
     if (*(unsigned short*)(c+0x444) == 0) {
-      short* a = (short*)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF);
+      short* a = (short*)(((int)c + 0x94));
       *a = *a - 0x100;
     }
     v[0].z = 0x28000;

--- a/src/func_ov062_0211c2f4.cpp
+++ b/src/func_ov062_0211c2f4.cpp
@@ -69,7 +69,7 @@ extern "C" int func_ov062_0211c2f4(char *self) {
 arrived:
     *(int *)(self + 0x460) = 7;
     if (*(u8 *)(self + 0x448) == 2 || (u8)(s8)(data_0209f2f8 - 0x18) <= 1) {
-        (*(int *)(((int)self + 0x474) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(int *)(((int)self + 0x474)))++;
         if (*(int *)(self + 0x474) >= 4)
             *(int *)(self + 0x474) = 0;
     } else if (func_ov062_0211b3ac(self) == 0) {
@@ -77,7 +77,7 @@ arrived:
         if (*(int *)(self + 0x474) != r) {
             *(int *)(self + 0x474) = r;
         } else {
-            int *p = (int *)(((int)self + 0x474) & 0xFFFFFFFFFFFFFFFF);
+            int *p = (int *)(((int)self + 0x474));
             (*p)++;
             *p &= 3;
         }

--- a/src/func_ov062_0211c6a8.c
+++ b/src/func_ov062_0211c6a8.c
@@ -32,9 +32,9 @@ void func_ov062_0211c6a8(char* c)
             *(int*)(c + 0x450) = data_020a0e68[9];
             *(int*)(c + 0x454) = data_020a0e68[10];
             *(int*)(c + 0x458) = data_020a0e68[11];
-            *(int*)(((int)c + 0x450) & 0xFFFFFFFFFFFFFFFF) <<= 3;
-            *(int*)(((int)c + 0x454) & 0xFFFFFFFFFFFFFFFF) <<= 3;
-            *(int*)(((int)c + 0x458) & 0xFFFFFFFFFFFFFFFF) <<= 3;
+            *(int*)(((int)c + 0x450)) <<= 3;
+            *(int*)(((int)c + 0x454)) <<= 3;
+            *(int*)(((int)c + 0x458)) <<= 3;
             if (*(int*)(c + 0x468) == 1)
             {
                 Matrix4x3_FromTranslation(data_020a0e68, -0xd000, 0x3000, -0x4000);

--- a/src/func_ov063_021160d4.c
+++ b/src/func_ov063_021160d4.c
@@ -33,6 +33,6 @@ void func_ov063_021160d4(char *c)
   SubVec3((Vec3 *) (c + 0x534), (Vec3 *) (c + 0x5c), (Vec3 *) (c + 0x534));
   SubVec3((Vec3 *) (c + 0x534), (Vec3 *) (c + 0x540), (Vec3 *) (c + 0x534));
   Vec3_MulScalarInPlace((Vec3 *) (c + 0x534), 0x6800);
-  p = (int *) (((int) c + 0x53c) & 0xFFFFFFFFFFFFFFFF);
+  p = (int *) (((int) c + 0x53c));
   *p += *((int *) (c + 0x598));
 }

--- a/src/func_ov063_02116a1c.c
+++ b/src/func_ov063_02116a1c.c
@@ -23,14 +23,14 @@ void func_ov063_02116a1c(void *cc)
 
     a = *(unsigned char *)(c + 0x5cc);
     if (a == 0) {
-        *(unsigned short *)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~8;
+        *(unsigned short *)(((int)c + 0x5d4)) &= ~8;
         if (NumStars() < 0xf) {
             _ZN9ActorBase18MarkForDestructionEv(c);
             return;
         }
         if (((unsigned)(*(unsigned short *)(c + 0x5d4)) << 0x1b) >> 0x1f) {
-            unsigned short *fp = (unsigned short *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
-            unsigned char *st = (unsigned char *)(((long long)(int)(c + 0x5cc)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short *fp = (unsigned short *)(((long long)(int)(c + 0x5d4)));
+            unsigned char *st = (unsigned char *)(((long long)(int)(c + 0x5cc)));
             *fp |= 8;
             *(unsigned char *)(c + 0x5c8) = 0xb4;
             scale = *(int *)(c + 0x584);
@@ -43,7 +43,7 @@ void func_ov063_02116a1c(void *cc)
         }
     } else if (a == 1) {
         if (*(int *)(c + 0x580) < 0x3e8000) {
-            unsigned char *st = (unsigned char *)(((long long)(int)(c + 0x5cc)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char *st = (unsigned char *)(((long long)(int)(c + 0x5cc)));
             *st += 1;
             func_0201267c(0xf8, c + 0x74);
         }
@@ -58,7 +58,7 @@ void func_ov063_02116a1c(void *cc)
             /* invert: laundered RMW as THEN, plain zero as ELSE
                -> movls/strbls + bls + unpredicated RMW */
             if (*(unsigned char *)(c + 0x5c8) > 0x14) {
-                unsigned char *p = (unsigned char *)(((long long)(int)(c + 0x5c8)) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned char *p = (unsigned char *)(((long long)(int)(c + 0x5c8)));
                 *p = (unsigned char)(*p - 0x14);
             } else {
                 *(unsigned char *)(c + 0x5c8) = 0;

--- a/src/func_ov063_02116bf4.c
+++ b/src/func_ov063_02116bf4.c
@@ -3,8 +3,8 @@
     
     void func_ov063_02116bf4(char* c)
     {
-        unsigned short *ip = (unsigned short *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
-        int *r3 = (int *)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short *ip = (unsigned short *)(((long long)(int)(c + 0x5d4)));
+        int *r3 = (int *)(((long long)(int)(c + 0x19c)));
         unsigned char st;
     
         *ip = (unsigned short)(*ip & ~8);
@@ -26,12 +26,12 @@
                         *(int*)(p + 0x498) = *(int*)(c + 0x498);
                     }
                     {
-                        unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cb)) & 0xFFFFFFFFFFFFFFFFLL);
+                        unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cb)));
                         *q = *q + 1;
                     }
                 }
                 {
-                    unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cc)) & 0xFFFFFFFFFFFFFFFFLL);
+                    unsigned char *q = (unsigned char *)(((long long)(int)(c + 0x5cc)));
                     *q = *q + 1;
                 }
             }

--- a/src/func_ov063_02116e14.cpp
+++ b/src/func_ov063_02116e14.cpp
@@ -12,7 +12,7 @@ void func_0201267c(int a, void* p);
 int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct Vector3*, void*, int, int);
 
 void func_ov063_02116e14(char* c){
-    *(unsigned short*)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~0x40;
+    *(unsigned short*)(((int)c + 0x5d4)) &= ~0x40;
     if (*(unsigned short*)(c + 0x500 + 0xc0) == 0) {
         func_ov063_02119e38(c, 0x64, 0x200, 0x800);
     }
@@ -43,6 +43,6 @@ void func_ov063_02116e14(char* c){
             *(int*)(r + 0xac) = 0;
         }
     }
-    *(unsigned short*)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    *(unsigned short*)(((long long)(int)(c + 0x5d4))) &= ~2;
 }
 }

--- a/src/func_ov063_02116fac.c
+++ b/src/func_ov063_02116fac.c
@@ -19,8 +19,8 @@ struct Frame {
     int pad[10];
 };
 
-#define L16(c, off) ((u16*)(((int)(c) + (off)) & 0xFFFFFFFFFFFFFFFFLL))
-#define L8(c, off)  ((u8*)(((int)(c) + (off)) & 0xFFFFFFFFFFFFFFFFLL))
+#define L16(c, off) ((u16*)(((int)(c) + (off))))
+#define L8(c, off)  ((u8*)(((int)(c) + (off))))
 
 void func_ov063_02116fac(char* c)
 {

--- a/src/func_ov063_02117364.c
+++ b/src/func_ov063_02117364.c
@@ -45,14 +45,14 @@ void func_ov063_02117364(void* c)
     pos.z = *(s32*)((char*)c + 0x64);
 
     if (((Sub*)((char*)c + 0x500))->fc2 != 0)
-        (*(u16*)(((int)c + 0x5c2) & 0xFFFFFFFFFFFFFFFFLL))--;
+        (*(u16*)(((int)c + 0x5c2)))--;
 
     if (*(u8*)((char*)c + 0x5c9) == 0) {
         if (*(u8*)((char*)c + 0x5c8) == 0) {
             if (((Sub*)((char*)c + 0x500))->fc2 != 0)
                 return;
             {
-                FlagW* fw = (FlagW*)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFFLL);
+                FlagW* fw = (FlagW*)(((int)c + 0x5d4));
                 fw->flag ^= 1;
             }
             func_ov063_02117650(c);
@@ -85,7 +85,7 @@ void func_ov063_02117364(void* c)
     if (((Sub*)((char*)c + 0x500))->fc2 != 0)
         return;
     *(u8*)((char*)c + 0x5cc) = 1;
-    *(u32*)(((int)c + 0x19c) & 0xFFFFFFFFFFFFFFFFLL) &= ~1u;
+    *(u32*)(((int)c + 0x19c)) &= ~1u;
     ((Sub*)((char*)c + 0x500))->fbe = ((u32)RandomIntInternal(&data_0209e650) >> 16 & 0x3f) + 0x3c;
     ((Sub*)((char*)c + 0x500))->fc4 = ((u32)RandomIntInternal(&data_0209e650) >> 16) % 150 + 0x12c;
     *(u32*)((char*)c + 0x5dc) = 0;

--- a/src/func_ov063_02117650.c
+++ b/src/func_ov063_02117650.c
@@ -12,7 +12,7 @@ void func_ov063_02117650(char *self)
     struct Vector3 ppos;
     struct Vector3 npos;
     char *p;
-    int neg1 = (int)(-1LL & 0xffffffffffffffffLL);
+    int neg1 = (int)(-1LL);
 
     p = (char *)_ZN5Actor13ClosestPlayerEv();
     if (p == 0) {
@@ -20,7 +20,7 @@ void func_ov063_02117650(char *self)
     }
 
     {
-        int *pp = (int *)(((long long)(int)(p + 0x5c)) & 0xffffffffffffffffLL);
+        int *pp = (int *)(((long long)(int)(p + 0x5c)));
         ppos.x = pp[0];
         ppos.y = pp[1];
         ppos.z = pp[2];

--- a/src/func_ov063_021177b0.c
+++ b/src/func_ov063_021177b0.c
@@ -23,7 +23,7 @@ extern short data_02082214[];
 void func_ov063_021177b0(char* c)
 {
     if (*(unsigned short*)(c + 0x100) == 0) {
-        unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x5ca)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x5ca)));
         *p = (unsigned char)(*p - 1);
     }
 
@@ -44,7 +44,7 @@ void func_ov063_021177b0(char* c)
                 int t;
 
                 {
-                    int* src = (int*)(((long long)(int)((char*)pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+                    int* src = (int*)(((long long)(int)((char*)pl + 0x5c)));
                     v.x = src[0];
                     v.y = src[1];
                     v.z = src[2];
@@ -75,7 +75,7 @@ void func_ov063_021177b0(char* c)
                 func_020092c4(cam, (char*)cam + 0x80, &mid);
             }
         } else {
-            *(unsigned short*)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x400;
+            *(unsigned short*)(((long long)(int)(c + 0x5d4))) |= 0x400;
             _ZN6Camera9SetFlag_3Ev(cam);
         }
 
@@ -83,7 +83,7 @@ void func_ov063_021177b0(char* c)
             return;
 
         {
-            unsigned short* pf = (unsigned short*)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned short* pf = (unsigned short*)(((long long)(int)(c + 0x5d4)));
             *pf = (unsigned short)(*pf & ~8);
         }
         *(unsigned char*)(c + 0x5cc) = 8;
@@ -116,7 +116,7 @@ void func_ov063_021177b0(char* c)
     }
 
     if (*(unsigned short*)(c + 0x100) == 0) {
-        int* p584 = (int*)(((long long)(int)(c + 0x584)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p584 = (int*)(((long long)(int)(c + 0x584)));
         int dec = 0x255;
         *p584 = *p584 - dec;
     }
@@ -124,7 +124,7 @@ void func_ov063_021177b0(char* c)
         return;
     *(unsigned char*)(c + 0x5cc) = 6;
     {
-        int* p19c = (int*)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p19c = (int*)(((long long)(int)(c + 0x19c)));
         *p19c |= 1;
     }
     *(unsigned char*)(c + 0x5c9) = 0;

--- a/src/func_ov063_02117b0c.c
+++ b/src/func_ov063_02117b0c.c
@@ -2,7 +2,7 @@ typedef unsigned char u8;
 typedef unsigned short u16;
 typedef short s16;
 
-#define LAUND(p) ((void *)((((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)))
+#define LAUND(p) ((void *)((((long long)(int)(p)))))
 
 extern void *_ZN5Actor13ClosestPlayerEv(void *o);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *pl, void *a, int b);

--- a/src/func_ov063_02118458.c
+++ b/src/func_ov063_02118458.c
@@ -37,13 +37,13 @@ void func_ov063_02118458(void* self)
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x380,
                     *(void**)(&data_ov063_0211edd4 + 1), 0x40000000, 0x1000, 0);
             } else if (*(u8*)(c + 0x5d2) != 0) {
-                *(u8*)(((long long)(int)(c + 0x5d2)) & 0xFFFFFFFFFFFFFFFFLL) -= 1;
+                *(u8*)(((long long)(int)(c + 0x5d2))) -= 1;
                 *(int*)(c + 0x3d8) = 0;
                 func_02012694(0x158, c + 0x74);
             } else {
                 int rnd;
                 *(u8*)(c + 0x5cc) = 1;
-                *(int*)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+                *(int*)(((long long)(int)(c + 0x19c))) &= ~1;
                 rnd = ((unsigned int)RandomIntInternal(&data_0209e650) >> 16) & 0x3f;
                 *(u16*)(c + 0x5be) = rnd + 0xb4;
                 _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x380,
@@ -52,7 +52,7 @@ void func_ov063_02118458(void* self)
         } else {
             int rnd;
             *(u8*)(c + 0x5cc) = 1;
-            *(int*)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+            *(int*)(((long long)(int)(c + 0x19c))) &= ~1;
             rnd = ((unsigned int)RandomIntInternal(&data_0209e650) >> 16) & 0x3f;
             *(u16*)(c + 0x5be) = rnd + 0xb4;
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x380,

--- a/src/func_ov063_0211873c.c
+++ b/src/func_ov063_0211873c.c
@@ -46,7 +46,7 @@ void func_ov063_0211873c(char* self)
         return;
     }
     if (*(u16*)(self + 0x500 + 0xc4) == 0) {
-        int* p = (int*)(((long long)(int)(self + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int* p = (int*)(((long long)(int)(self + 0x19c)));
         *(u8*)(self + 0x5cc) = 6;
         *p |= 1;
         *(u8*)(self + 0x5c9) = 0;

--- a/src/func_ov063_02118914.c
+++ b/src/func_ov063_02118914.c
@@ -23,12 +23,12 @@ void func_ov063_02118914(char *c)
     *(s32 *)(c + 0x88) = scale;
     *(s32 *)(c + 0x188) = *(s32 *)(c + 0x590) * *(s32 *)(c + 0x584);
     *(s32 *)(c + 0x18c) = *(s32 *)(c + 0x594) * *(s32 *)(c + 0x584);
-    *(u16 *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
-    *(u32 *)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
-    *(u16 *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x100;
+    *(u16 *)(((long long)(int)(c + 0x5d4))) |= 8;
+    *(u32 *)(((long long)(int)(c + 0x19c))) |= 1;
+    *(u16 *)(((long long)(int)(c + 0x5d4))) |= 0x100;
     *(s32 *)(c + 0x5c) = -*(s32 *)(c + 0x51c);
-    *(s16 *)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL) += 0x8000;
-    *(s16 *)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL) += 0x8000;
+    *(s16 *)(((long long)(int)(c + 0x8e))) += 0x8000;
+    *(s16 *)(((long long)(int)(c + 0x94))) += 0x8000;
     *(u8 *)(c + 0x5ce) = zero;
-    *(u32 *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2;
+    *(u32 *)(((long long)(int)(c + 0xb0))) &= ~2;
 }

--- a/src/func_ov063_021189f4.c
+++ b/src/func_ov063_021189f4.c
@@ -19,7 +19,7 @@ void func_ov063_021189f4(char *c)
         if (*(u8 *)(c + 0x5cf) == 0xd) {
             if (*(u16 *)(c + 0x500 + 0xc6) < 0x4b) {
                 _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x6b000, 1);
-                *(u16 *)(((long long)(int)(c + 0x5c6)) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(u16 *)(((long long)(int)(c + 0x5c6))) += 1;
             } else {
                 int r = _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, *(s32 *)(c + 0x57c) >> 0xc, 0, 0x7f000, 1);
                 if (r != 0)

--- a/src/func_ov063_02118b98.c
+++ b/src/func_ov063_02118b98.c
@@ -12,7 +12,7 @@ void func_ov063_02118b98(char *c)
 {
     u16 v;
 
-    *(u16 *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x40;
+    *(u16 *)(((long long)(int)(c + 0x5d4))) &= ~0x40;
     func_ov063_0211adfc(c);
 
     v = *(u16 *)(c + 0x100);


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 100 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
