### PR TITLE
readable: strip 101 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov063_02118cd8.c
+++ b/src/func_ov063_02118cd8.c
@@ -5,15 +5,15 @@ void func_ov063_02118cd8(char *self) {
     if (*(unsigned short *)(self + 0x100) == 0) {
         unsigned int v = *(unsigned short *)(self + 0x5d4);
         if ((v << 25 >> 31) == 0) {
-            unsigned char *p = (unsigned char *)(((int)self + 0x5ca) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char *p = (unsigned char *)(((int)self + 0x5ca));
             (*p)--;
         }
     }
     if (*(unsigned char *)(self + 0x5ca) == 0) {
         unsigned short *p;
         if (func_ov063_0211a3d0(self) == 0) return;
-        *(int *)(((int)self + 0x19c) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
-        p = (unsigned short *)(((int)self + 0x5d4) & 0xFFFFFFFFFFFFFFFFLL);
+        *(int *)(((int)self + 0x19c)) |= 1;
+        p = (unsigned short *)(((int)self + 0x5d4));
         *p &= ~8;
         *(unsigned char *)(self + 0x5cc) = 4;
         *(unsigned short *)(self + 0x92) = 0;
@@ -23,7 +23,7 @@ void func_ov063_02118cd8(char *self) {
         return;
     }
     if (*(unsigned short *)(self + 0x100) == 0) {
-        *(int *)(((int)self + 0x584) & 0xFFFFFFFFFFFFFFFFLL) -= 0x255;
+        *(int *)(((int)self + 0x584)) -= 0x255;
     }
     if (func_ov063_0211a564(self, 0x28) != 0) {
         *(unsigned char *)(self + 0x5cc) = 1;

--- a/src/func_ov063_02118eac.c
+++ b/src/func_ov063_02118eac.c
@@ -16,8 +16,8 @@ void func_ov063_02118eac(char *c)
     v.x = *(int *)(c + 0x5c);
     v.y = *(int *)(c + 0x60);
     v.z = *(int *)(c + 0x64);
-    *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) =
-        *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) + 0x64000;
+    *(int *)(((int)c + 0x60)) =
+        *(int *)(((int)c + 0x60)) + 0x64000;
     if (*(unsigned int *)(c + 0x49c) == 0) {
         return;
     }

--- a/src/func_ov063_02118f74.c
+++ b/src/func_ov063_02118f74.c
@@ -12,7 +12,7 @@ void func_ov063_02118f74(char *c) {
     int r5v;
     unsigned char mode;
 
-    *(unsigned short *)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x40;
+    *(unsigned short *)(((long long)(int)(c + 0x5d4))) &= ~0x40;
     mode = *(unsigned char *)(c + 0x5ca);
     if (mode == 3) {
         a2 = 0x180;

--- a/src/func_ov063_02119074.c
+++ b/src/func_ov063_02119074.c
@@ -41,7 +41,7 @@ void func_ov063_02119074(char *self)
         char *r;
         s32 scale;
 
-        *(u16 *)(((long long)(int)(self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+        *(u16 *)(((long long)(int)(self + 0x5d4))) |= 8;
         *(unsigned char *)(self + 0x5ca) = 3;
         *(int *)(self + 0x584) =
             data_ov063_0211e1d0[*(unsigned char *)(self + 0x5cf) - 0xc];
@@ -59,7 +59,7 @@ void func_ov063_02119074(char *self)
                 _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f,
                                                  0x6b000, 1);
                 *(u16 *)(self + 0x500 + 0xc6) = 1;
-                *(u16 *)(((int)self + 0x5d4) & 0xFFFFFFFFFFFFFFFF) |= 0x200;
+                *(u16 *)(((int)self + 0x5d4)) |= 0x200;
             }
 
             *(int *)(self + 0x98) = 0x800;
@@ -81,10 +81,10 @@ void func_ov063_02119074(char *self)
             *(int *)(self + 0x590) * *(int *)(self + 0x584);
         *(int *)(self + 0x18c) =
             *(int *)(self + 0x594) * *(int *)(self + 0x584);
-        *(int *)(((long long)(int)(self + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        *(int *)(((long long)(int)(self + 0x19c))) &= ~1;
     } else {
-        *(u16 *)(((long long)((int)self + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL) &= ~8;
-        *(int *)(((int)self + 0x19c) & 0xFFFFFFFFFFFFFFFF) |= 1;
+        *(u16 *)(((long long)((int)self + 0x5d4))) &= ~8;
+        *(int *)(((int)self + 0x19c)) |= 1;
         func_ov063_0211adfc(self);
     }
 }

--- a/src/func_ov063_0211934c.cpp
+++ b/src/func_ov063_0211934c.cpp
@@ -40,7 +40,7 @@ extern "C" void func_ov063_0211934c(char *c)
             *(s16 *)(c + 0x92) = *(s16 *)(c + 0x570);
             *(s16 *)(c + 0x94) = *(s16 *)(c + 0x572);
             *(s16 *)(c + 0x96) = *(s16 *)(c + 0x574);
-            s16 *src = (s16 *)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFF);
+            s16 *src = (s16 *)(((int)c + 0x92));
             *(s16 *)(c + 0x8c) = src[0];
             *(s16 *)(c + 0x8e) = src[1];
             *(s16 *)(c + 0x90) = src[2];
@@ -49,7 +49,7 @@ extern "C" void func_ov063_0211934c(char *c)
             if (cap == 0)
                 return;
             {
-                u16 *p = (u16 *)(((int)cap + 0x5d4) & 0xFFFFFFFFFFFFFFFF);
+                u16 *p = (u16 *)(((int)cap + 0x5d4));
                 *p &= ~2;
             }
         }
@@ -62,7 +62,7 @@ extern "C" void func_ov063_0211934c(char *c)
         if (_ZN6Player9StartTalkER9ActorBaseb(r4, c, 1) == 0)
             return;
         {
-            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)));
             *q = *q + 1;
         }
         return;
@@ -73,7 +73,7 @@ extern "C" void func_ov063_0211934c(char *c)
         *(void **)(c + 0x48c) = _ZN5Actor10FindWithIDEj(*(u32 *)(c + 0x490));
         found = *(void **)(c + 0x48c);
         if (found != 0) {
-            s32 *cnt = (s32 *)(((long long)(int)((char *)found + 0x180)) & 0xFFFFFFFFFFFFFFFFLL);
+            s32 *cnt = (s32 *)(((long long)(int)((char *)found + 0x180)));
             *cnt = *cnt + 1;
         }
         found = *(void **)(c + 0x48c);
@@ -84,7 +84,7 @@ extern "C" void func_ov063_0211934c(char *c)
         }
         *(void **)(c + 0x48c) = 0;
         {
-            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)));
             *q = *q + 1;
         }
         func_0201267c(0xf8, c + 0x74);
@@ -102,13 +102,13 @@ extern "C" void func_ov063_0211934c(char *c)
             if (found != 0 && *(s32 *)((char *)found + 0x180) == 5) {
                 func_ov063_02116244((char *)found);
                 {
-                    u16 *p = (u16 *)(((long long)(int)(c + 0x5c6)) & 0xFFFFFFFFFFFFFFFFLL);
+                    u16 *p = (u16 *)(((long long)(int)(c + 0x5c6)));
                     *p = *p + 1;
                 }
             }
         }
         {
-            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *q = (u8 *)(((long long)(int)(c + 0x5ce)));
             *q = *q + 1;
         }
         return;
@@ -116,7 +116,7 @@ extern "C" void func_ov063_0211934c(char *c)
     case 3:
         if (*(u16 *)(c + 0x500 + 0xc6) != 0) {
             if (_ZN5Sound15PlaySecretSoundEP5ActorPt(
-                    c, (u16 *)(((long long)(int)(c + 0x5c6)) & 0xFFFFFFFFFFFFFFFFLL)) == 0)
+                    c, (u16 *)(((long long)(int)(c + 0x5c6)))) == 0)
                 return;
             _ZN9ActorBase18MarkForDestructionEv(c);
             if (((*(u8 *)(c + 0x113)) & 0xf) >= 6)
@@ -131,7 +131,7 @@ extern "C" void func_ov063_0211934c(char *c)
             *(s16 *)(c + 0x92) = *(s16 *)(c + 0x570);
             *(s16 *)(c + 0x94) = *(s16 *)(c + 0x572);
             *(s16 *)(c + 0x96) = *(s16 *)(c + 0x574);
-            s16 *src = (s16 *)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFF);
+            s16 *src = (s16 *)(((int)c + 0x92));
             *(s16 *)(c + 0x8c) = src[0];
             *(s16 *)(c + 0x8e) = src[1];
             *(s16 *)(c + 0x90) = src[2];
@@ -140,7 +140,7 @@ extern "C" void func_ov063_0211934c(char *c)
             if (cap2 == 0)
                 return;
             {
-                u16 *p = (u16 *)(((int)cap2 + 0x5d4) & 0xFFFFFFFFFFFFFFFF);
+                u16 *p = (u16 *)(((int)cap2 + 0x5d4));
                 *p &= ~2;
             }
         }
@@ -159,14 +159,14 @@ extern "C" void func_ov063_0211934c(char *c)
             *(s16 *)(c + 0x92) = *(s16 *)(c + 0x570);
             *(s16 *)(c + 0x94) = *(s16 *)(c + 0x572);
             *(s16 *)(c + 0x96) = *(s16 *)(c + 0x574);
-            s16 *src = (s16 *)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFF);
+            s16 *src = (s16 *)(((int)c + 0x92));
             *(s16 *)(c + 0x8c) = src[0];
             *(s16 *)(c + 0x8e) = src[1];
             *(s16 *)(c + 0x90) = src[2];
             
             cap3 = _ZN8CapEnemy15RespawnIfHasCapEv(c);
             if (cap3 != 0) {
-                u16 *p = (u16 *)(((int)cap3 + 0x5d4) & 0xFFFFFFFFFFFFFFFF);
+                u16 *p = (u16 *)(((int)cap3 + 0x5d4));
                 *p &= ~2;
             }
         }

--- a/src/func_ov063_0211975c.cpp
+++ b/src/func_ov063_0211975c.cpp
@@ -24,25 +24,25 @@ extern "C" void func_ov063_0211975c(char* self) {
         *(s16*)(self + 0x92) = *(s16*)(self + 0x570);
         *(s16*)(self + 0x94) = *(s16*)(self + 0x572);
         *(s16*)(self + 0x96) = *(s16*)(self + 0x574);
-        s16* src = (s16*)(((int)self + 0x92) & 0xFFFFFFFFFFFFFFFF);
+        s16* src = (s16*)(((int)self + 0x92));
         *(s16*)(self + 0x8c) = src[0];
         *(s16*)(self + 0x8e) = src[1];
         *(s16*)(self + 0x90) = src[2];
         char* r = (char*)_ZN8CapEnemy15RespawnIfHasCapEv(self);
         if (r == 0) return;
         {
-            u16* p = (u16*)(((int)r + 0x5d4) & 0xFFFFFFFFFFFFFFFF);
+            u16* p = (u16*)(((int)r + 0x5d4));
             *p &= ~2;
         }
     } else {
         *(u8*)(self + 0x5cc) = 5;
         *(u8*)(self + 0x5ce) = 0;
         {
-            int* q = (int*)(((int)self + 0x19c) & 0xFFFFFFFFFFFFFFFF);
+            int* q = (int*)(((int)self + 0x19c));
             *q |= 1;
         }
         {
-            u16* p = (u16*)(((int)self + 0x5d4) & 0xFFFFFFFFFFFFFFFF);
+            u16* p = (u16*)(((int)self + 0x5d4));
             *p &= ~8;
         }
     }

--- a/src/func_ov063_02119894.c
+++ b/src/func_ov063_02119894.c
@@ -6,7 +6,7 @@ extern void func_ov063_02119b1c(char *c);
 
 void func_ov063_02119894(char *c)
 {
-    *(unsigned short *)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~0x40;
+    *(unsigned short *)(((int)c + 0x5d4)) &= ~0x40;
     if (*(unsigned short *)(c + 0x100) == 0) {
         unsigned r0 = (unsigned)RandomIntInternal(&data_0209e650);
         *(int *)(c + 0x588) = (int)(((r0 >> 16) & 0xfff) * 5);

--- a/src/func_ov063_02119960.c
+++ b/src/func_ov063_02119960.c
@@ -2,7 +2,7 @@ extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
 extern void func_ov063_02119e38(void *c, int a, int b, int d);
 extern void func_ov063_02119b1c(char *c);
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((long long)(int)(p))
 void func_ov063_02119960(char *c)
 {
     unsigned short *p = (unsigned short *)(int)M(c + 0x5d4);

--- a/src/func_ov063_02119a50.c
+++ b/src/func_ov063_02119a50.c
@@ -3,7 +3,7 @@ extern void func_ov063_0211a964(char *c, int arg1);
 extern void func_ov063_02119b1c(void *);
 
 void func_ov063_02119a50(char *c) {
-    *(unsigned short *)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) &= ~0x40;
+    *(unsigned short *)(((int)c + 0x5d4)) &= ~0x40;
     if (*(unsigned short *)(c + 0x100) >= 0x1e) {
         *(unsigned char *)(c + 0x5cc) = 1;
     } else {

--- a/src/func_ov063_02119ab0.c
+++ b/src/func_ov063_02119ab0.c
@@ -8,8 +8,8 @@ void func_ov063_02119ab0(char *self)
     *(int *)(self + 0x50c) = *(int *)(self + 0x64);
 
     if (*(unsigned short *)(self + 0x4a0) == 0xd4) {
-        *(int *)(((long long)(int)(self + 0x508)) & 0xFFFFFFFFFFFFFFFFLL) += 0x3c000;
+        *(int *)(((long long)(int)(self + 0x508))) += 0x3c000;
         return;
     }
-    *(int *)(((long long)(int)(self + 0x508)) & 0xFFFFFFFFFFFFFFFFLL) += 0xa000;
+    *(int *)(((long long)(int)(self + 0x508))) += 0xa000;
 }

--- a/src/func_ov063_02119e38.c
+++ b/src/func_ov063_02119e38.c
@@ -19,12 +19,12 @@ void func_ov063_02119e38(char *thiz, int a1, short a2, int a3) {
     if ((unsigned int)(*(unsigned short*)(thiz + 0x500 + 0xd4) << 0x17) >> 0x1f) {
     } else {
       if (*(unsigned short*)(thiz + 0x500 + 0xbe) != 0) {
-        unsigned short *q = (unsigned short*)(((long long)(int)(thiz + 0x5be)) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned short *q = (unsigned short*)(((long long)(int)(thiz + 0x5be)));
         *q = *q - 1;
       }
     }
     if (*(unsigned short*)(thiz + 0x500 + 0xc4) != 0) {
-      unsigned short *q = (unsigned short*)(((long long)(int)(thiz + 0x5c4)) & 0xFFFFFFFFFFFFFFFFLL);
+      unsigned short *q = (unsigned short*)(((long long)(int)(thiz + 0x5c4)));
       *q = *q - 1;
     }
 

--- a/src/func_ov063_0211a0dc.cpp
+++ b/src/func_ov063_0211a0dc.cpp
@@ -30,7 +30,7 @@ extern "C" int func_ov063_0211a0dc(char* c)
     if (*(s32*)(c + 0x1a4) & 0x207e0) {
         void* found;
 
-        *(u32*)(int)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u32*)(int)(((long long)(int)(c + 0x19c))) |= 1;
         found = _ZN5Actor10FindWithIDEj(*(u32*)(c + 0x1a8));
         if (found) {
             *(void**)(c + 0x488) = found;
@@ -39,7 +39,7 @@ extern "C" int func_ov063_0211a0dc(char* c)
                 int isBf = (int)(*(u16*)((char*)found + 0xc) == 0xbf);
                 if (isBf) {
                     if (*(s32*)((char*)found + 8) == 3) {
-                        u16* p = (u16*)(((long long)(int)(c + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+                        u16* p = (u16*)(((long long)(int)(c + 0x5d4)));
                         *p |= 0x40;
                     }
                 }
@@ -57,7 +57,7 @@ extern "C" int func_ov063_0211a0dc(char* c)
         return 0;
 
     if (*(u8*)((char*)r4 + 0x6f9) != 0) {
-        *(u32*)(int)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(u32*)(int)(((long long)(int)(c + 0x19c))) |= 1;
         *(void**)(c + 0x488) = _ZN5Actor10FindWithIDEj(*(u32*)(c + 0x1a8));
         return 1;
     }
@@ -101,7 +101,7 @@ found_kind:
             void* found2;
             s16 v[3];
 
-            *(u32*)(int)(((long long)(int)(c + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+            *(u32*)(int)(((long long)(int)(c + 0x19c))) |= 1;
             found2 = _ZN5Actor10FindWithIDEj(*(u32*)(c + 0x1a8));
             if (!found2)
                 goto ret0;
@@ -113,7 +113,7 @@ found_kind:
             func_020ada40(c, v, found2, 0);
 
             {
-                s16* ap = (s16*)(int)(((long long)(int)(c + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+                s16* ap = (s16*)(int)(((long long)(int)(c + 0x8e)));
                 *ap = (s16)(*ap + 0x8000);
             }
             return 1;

--- a/src/func_ov063_0211a3d0.cpp
+++ b/src/func_ov063_0211a3d0.cpp
@@ -23,7 +23,7 @@ extern "C" int func_ov063_0211a3d0(char* c)
         *(s32*)(c + 0x98) = 0x28000;
         *(s16*)(c + 0x94) = *(s16*)(*(char**)(c + 0x484) + 0x8e);
         *(s32*)(c + 0x5a0) = 1;
-        *(u16*)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFFLL) &= ~4;
+        *(u16*)(((int)c + 0x5d4)) &= ~4;
         goto fall;
     }
 
@@ -56,7 +56,7 @@ extern "C" int func_ov063_0211a3d0(char* c)
         *(void**)(c + 0x48c) = _ZN5Actor10FindWithIDEj(*(u32*)(c + 0x490));
         if (*(void**)(c + 0x48c) != 0) {
             if (*(u8*)(c + 0x5cf) != 2) {
-                *(s32*)(((int)*(char**)(c + 0x48c) + 0x180) & 0xFFFFFFFFFFFFFFFFLL) += 1;
+                *(s32*)(((int)*(char**)(c + 0x48c) + 0x180)) += 1;
             }
             func_ov063_02116244(*(char**)(c + 0x48c));
         }
@@ -66,7 +66,7 @@ extern "C" int func_ov063_0211a3d0(char* c)
 
 fall:
     *(s32*)(c + 0xa8) = 0x5000;
-    *(s16*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFFLL) += 0x800;
-    *(s16*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFFLL) += 0x800;
+    *(s16*)(((int)c + 0x90)) += 0x800;
+    *(s16*)(((int)c + 0x8e)) += 0x800;
     return 0;
 }

--- a/src/func_ov063_0211a564.c
+++ b/src/func_ov063_0211a564.c
@@ -23,7 +23,7 @@ int func_ov063_0211a564(char *c, int arg1)
             goto ret0;
         }
     }
-    (*(int *)(((int)c + 0x19c) & 0xFFFFFFFFFFFFFFFF)) &= ~1;
+    (*(int *)(((int)c + 0x19c))) &= ~1;
     func_ov063_0211a6f0(c);
     *(unsigned char *)(c + 0x5cc) = 1;
     return 1;

--- a/src/func_ov063_0211a634.c
+++ b/src/func_ov063_0211a634.c
@@ -19,7 +19,7 @@ int func_ov063_0211a634(char *thiz, int arg)
         rv = 0;
         goto done;
     }
-    pf = (int*)(((int)thiz + 0x19c) & 0xFFFFFFFFFFFFFFFF);
+    pf = (int*)(((int)thiz + 0x19c));
     *pf &= ~1;
     func_ov063_0211a6f0(thiz);
     *(unsigned char*)(thiz + 0x5cc) = 1;

--- a/src/func_ov063_0211a6f0.c
+++ b/src/func_ov063_0211a6f0.c
@@ -1,5 +1,5 @@
 void func_ov063_0211a6f0(char *c)
 {
     *(short *)(c + 0x94) = *(short *)(c + 0x5b4);
-    *(unsigned short *)(((int)c + 0x5d4) & 0xFFFFFFFFFFFFFFFF) |= 4;
+    *(unsigned short *)(((int)c + 0x5d4)) |= 4;
 }

--- a/src/func_ov063_0211a718.c
+++ b/src/func_ov063_0211a718.c
@@ -8,7 +8,7 @@ void func_ov063_0211a718(char* o) {
     s16 v;
     s16* p;
     a = (u16)(s16)((*(u16*)(o + 0x100) - 0x1f) << 13) >> 4;
-    p = (s16*)(((long long)(int)(o + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (s16*)(((long long)(int)(o + 0x8e)));
     v = *p;
     *p = v + (data_02082214[a * 2 + 1] << 10) / 4096;
 }

--- a/src/func_ov063_0211a76c.c
+++ b/src/func_ov063_0211a76c.c
@@ -16,10 +16,10 @@ void func_ov063_0211a76c(char* c, int cond, int val)
     if (cond == 0) return;
 
     {
-        short* p8e = (short*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        short* p8e = (short*)(((int)c + 0x8e));
         *p8e = *p8e + data_ov063_0211e7e0[*(unsigned short*)(c + 0x100)];
         {
-            short* p90 = (short*)(((int)c + 0x90) & 0xFFFFFFFFFFFFFFFF);
+            short* p90 = (short*)(((int)c + 0x90));
             *p90 = *p90 + data_ov063_0211e7e0[*(unsigned short*)(c + 0x100)];
         }
     }

--- a/src/func_ov063_0211a810.c
+++ b/src/func_ov063_0211a810.c
@@ -1,8 +1,8 @@
 extern short data_02082214[];
 void func_ov063_0211a810(char *r0, int cond)
 {
-    int *f = (int *)(((long long)(int)(r0 + 0x19c)) & 0xFFFFFFFFFFFFFFFFLL);
-    unsigned short *h = (unsigned short *)(((long long)(int)(r0 + 0x5d4)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *f = (int *)(((long long)(int)(r0 + 0x19c)));
+    unsigned short *h = (unsigned short *)(((long long)(int)(r0 + 0x5d4)));
     *f |= 1;
     *h &= ~4;
     *(short *)(r0 + 0x5b4) = *(short *)(r0 + 0x94);

--- a/src/func_ov063_0211aa34.c
+++ b/src/func_ov063_0211aa34.c
@@ -12,12 +12,12 @@ void func_ov063_0211aa34(char* self)
             if (cur + 0x14 >= tgt) {
                 *(u8*)(self + 0x5c8) = tgt;
             } else {
-                u8 *p = (u8*)(((long long)(int)(self + 0x5c8)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8*)(((long long)(int)(self + 0x5c8)));
                 *p += 0x14;
             }
         } else {
             if (cur - 0x14 > tgt) {
-                u8 *p = (u8*)(((long long)(int)(self + 0x5c8)) & 0xFFFFFFFFFFFFFFFFLL);
+                u8 *p = (u8*)(((long long)(int)(self + 0x5c8)));
                 *p -= 0x14;
             } else {
                 *(u8*)(self + 0x5c8) = tgt;

--- a/src/func_ov063_0211c770.c
+++ b/src/func_ov063_0211c770.c
@@ -2,6 +2,6 @@ extern signed char data_ov063_0211e26c[];
 int func_ov063_0211c770(unsigned char* c, int idx) {
     if ((unsigned int)idx > 3 || (short)idx < 0)
         return 1;
-    (*(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)) += data_ov063_0211e26c[idx] << 12;
+    (*(int *)(((int)c + 0x60))) += data_ov063_0211e26c[idx] << 12;
     return 0;
 }

--- a/src/func_ov063_0211c7b0.c
+++ b/src/func_ov063_0211c7b0.c
@@ -12,7 +12,7 @@ void BooCage_Kill(char *c) {
         return;
     }
     *(short*)(c + 0x100 + 0x3a) = 0x80;
-    t = (short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+    t = (short *)(((int)c + 0x8e));
     *t = (short)(*t + *(short*)(c + 0x100 + 0x3a));
     func_ov063_0211c82c(c);
     *(unsigned int*)(c + 0x148) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int*)(c + 0x148), 3, 0x8f, c + 0x74, 0);

--- a/src/func_ov063_0211c82c.c
+++ b/src/func_ov063_0211c82c.c
@@ -1,7 +1,7 @@
 unsigned char IsAreaShowing(int idx);
 void func_ov063_0211c82c(char* c){
     if (*(unsigned char*)(c + 0x152) == 0) {
-        *(unsigned char *)(((int)c + 0x152) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(unsigned char *)(((int)c + 0x152)) += 1;
         return;
     }
     if (*(int*)(c + 0x124) != 0 || IsAreaShowing(*(signed char*)(c + 0xcc))) {

--- a/src/func_ov063_0211c89c.c
+++ b/src/func_ov063_0211c89c.c
@@ -22,7 +22,7 @@ void func_ov063_0211c89c(char *c) {
     }
     p = _ZN5Actor13ClosestPlayerEv(c);
     {
-        int *q = (int*)(((long long)(int)(p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *q = (int*)(((long long)(int)(p + 0x5c)));
         pp.x = q[0];
         pp.y = q[1];
         pp.z = q[2];
@@ -38,7 +38,7 @@ void func_ov063_0211c89c(char *c) {
             Vec3_Dist((Vec3*)(c + 0x5c), &pp) < 0x320000) {
             short a = Vec3_HorzAngle((Vec3*)(c + 0x5c), &pp);
             if (a <= -0x7000 || a >= 0x7000)
-                *(u8*)(((long long)(int)(c + 0x157)) & 0xFFFFFFFFFFFFFFFFLL) |= 8;
+                *(u8*)(((long long)(int)(c + 0x157))) |= 8;
         }
         {
             u8 m = *(u8*)(c + 0x157) & 7;
@@ -48,7 +48,7 @@ void func_ov063_0211c89c(char *c) {
             }
             if (m == 1) return;
             if (m == 3) return;
-            *(u8*)(((long long)(int)(c + 0x157)) & 0xFFFFFFFFFFFFFFFFLL) &= 8;
+            *(u8*)(((long long)(int)(c + 0x157))) &= 8;
         }
         return;
     case 1:
@@ -63,7 +63,7 @@ void func_ov063_0211c89c(char *c) {
         }
         return;
     case 2:
-        *(int*)(((long long)(int)(c + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL) += 0x5000;
+        *(int*)(((long long)(int)(c + 0x5c))) += 0x5000;
         *(int*)(c + 0x148) = _ZN5Sound8PlayLongEjjjRK7Vector3j(*(unsigned int*)(c + 0x148), 3, 0x8d, (Vec3*)(c + 0x74), 0);
         _ZN5Sound15PlaySecretSoundEP5ActorPt(c, (u16*)(c + 0x14e));
         if (*(u16*)(c + 0x100 + 0x4c) > 0x65)

--- a/src/func_ov063_0211cae8.c
+++ b/src/func_ov063_0211cae8.c
@@ -1,6 +1,6 @@
 void func_02012790(int x);
 void func_ov063_0211cae8(unsigned char* c, int m){
-  unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x157)) & 0xFFFFFFFFFFFFFFFFLL);
+  unsigned char* p = (unsigned char*)(((long long)(int)(c + 0x157)));
   *p |= m;
   unsigned char v = c[0x157] & 7;
   if(v!=1 && v!=3 && v!=7){ func_02012790(0xe); return; }

--- a/src/func_ov063_0211cc18.c
+++ b/src/func_ov063_0211cc18.c
@@ -1,6 +1,6 @@
 typedef struct Vector3 { int x, y, z; } Vector3;
 
-#define LAUNDER(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define LAUNDER(p) ((long long)(int)(p))
 
 struct Obj {
     char pad0[0x60];

--- a/src/func_ov064_02115f98.c
+++ b/src/func_ov064_02115f98.c
@@ -24,7 +24,7 @@ void func_ov064_02115f98(char* a0, char* a1)
     int* p1;
     int tmpy;
 
-    p1 = (int*)(((long long)(int)(a1 + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    p1 = (int*)(((long long)(int)(a1 + 0x5c)));
     pos0[0] = *(int*)(a0 + 0x5c);
     y0 = *(int*)(a0 + 0x60);
     pos0[1] = y0;

--- a/src/func_ov064_02116220.c
+++ b/src/func_ov064_02116220.c
@@ -48,7 +48,7 @@ void func_ov064_02116220(char* c){
         *(int*)(c+0x398) = 4;
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x110,
             *(BCA_File**)(*(int*)(*(int*)(c+0x330) + 4) + 4), 0, 0x1000, 0);
-        *(unsigned int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1u;
+        *(unsigned int *)(((long long)(int)(c + 0xb0))) &= ~1u;
         ((ActorV*)c)->m90();
         *(int*)(c+0x3a8) = *(int*)(c+0x5c);
         *(int*)(c+0x3ac) = *(int*)(c+0x60);

--- a/src/func_ov064_021163c0.cpp
+++ b/src/func_ov064_021163c0.cpp
@@ -10,7 +10,7 @@ extern "C" void func_ov064_021163c0(char *c)
 {
     if (*(unsigned short *)(c + 0x100) == 0) {
         if (((WithMeshClsn *)(c + 0x174))->IsOnGround()) {
-            *(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF) = (short)((*(short *)(((int)c + 0x94) & 0xFFFFFFFFFFFFFFFF)) + 0x8000);
+            *(short *)(((int)c + 0x94)) = (short)((*(short *)(((int)c + 0x94))) + 0x8000);
         }
     }
     *(int *)(c + 0x98) = 0x5000;

--- a/src/func_ov064_02116460.cpp
+++ b/src/func_ov064_02116460.cpp
@@ -12,7 +12,7 @@ extern "C" void func_ov064_02116460(char *self)
         int lim = b ? 0x14 : 0xa;
         if (*(unsigned char *)(self + 0x3f9) < 2) {
             if (((WithMeshClsn *)(self + 0x174))->IsOnGround()) {
-                unsigned char *p = (unsigned char *)(((long long)(int)(self + 0x3f9)) & 0xFFFFFFFFFFFFFFFFLL);
+                unsigned char *p = (unsigned char *)(((long long)(int)(self + 0x3f9)));
                 *(int *)(self + 0xa8) = 0xf000;
                 *p = *p + 1;
             }

--- a/src/func_ov064_021165d8.cpp
+++ b/src/func_ov064_021165d8.cpp
@@ -44,9 +44,9 @@ extern "C" void func_ov064_021165d8(unsigned char* c)
 
     if (_ZNK12WithMeshClsn10IsOnGroundEv(c + 0x174) != 0
         && _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(c, 0x5dc000) != 0) {
-        *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(int*)(((int)c + 0xb0)) |= 1;
     } else {
-        *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+        *(int*)(((int)c + 0xb0)) &= ~1;
     }
 
     ((Base*)c)->m33();

--- a/src/func_ov064_02116ec0.cpp
+++ b/src/func_ov064_02116ec0.cpp
@@ -70,7 +70,7 @@ extern "C" int func_ov064_02116ec0(Obj* obj)
     {
         int b = (obj->fc == 0xd9);
         if (b) {
-            *(int *)(((int)obj + 0x358) & 0xFFFFFFFFFFFFFFFF) |= 0x40000;
+            *(int *)(((int)obj + 0x358)) |= 0x40000;
         }
     }
     obj->f3a8 = obj->f5c;

--- a/src/func_ov064_02117a44.cpp
+++ b/src/func_ov064_02117a44.cpp
@@ -26,13 +26,13 @@ extern "C" int func_ov064_02117a44(char* c) {
     *(int*)(c+0x64) = *(int*)(c+0x350);
     r = 1;
     if (*(unsigned char*)(c+0x33b) == 1) {
-      ++*(int*)(((int)c + 0x344) & 0xFFFFFFFFFFFFFFFF);
+      ++*(int*)(((int)c + 0x344));
       if (*(int*)(c+0x344) >= *(int*)(c+0x340)) {
         *(int*)(c+0x344) = *(int*)(c+0x340) - 2;
         r = -1;
       }
     } else {
-      --*(int*)(((int)c + 0x344) & 0xFFFFFFFFFFFFFFFF);
+      --*(int*)(((int)c + 0x344));
       if (*(int*)(c+0x344) < 0) {
         *(int*)(c+0x344) = r;
         r = -1;

--- a/src/func_ov064_02117d24.c
+++ b/src/func_ov064_02117d24.c
@@ -14,14 +14,14 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern "C" int func_ov064_02117d24(char* c) {
     int idx = *(unsigned char*)(c + 0x33b);
     (((C*)c)->*data_ov064_0211c750[idx].pmf)();
-    unsigned short* p338 = (unsigned short*)(((long long)(int)(c + 0x338)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short* p338 = (unsigned short*)(((long long)(int)(c + 0x338)));
     *p338 = (unsigned short)(*p338 + 1);
     if (idx != *(unsigned char*)(c + 0x33b)) {
         *(short*)((char*)c + 0x300 + 0x38) = 0;
     }
     int target = *(unsigned char*)(c + 0x33a) ? -0x28000 : 0;
     if (_Z14ApproachLinearRiii((int*)(c + 0x320), target, 0x5000)) {
-        short* pAng = (short*)(((long long)(int)(c + 0x328)) & 0xFFFFFFFFFFFFFFFFLL);
+        short* pAng = (short*)(((long long)(int)(c + 0x328)));
         *pAng = (short)(*pAng + 0xa00);
         unsigned short h = *(unsigned short*)((char*)c + 0x300 + 0x28);
         short s = data_02082214[(h >> 4) * 2];

--- a/src/func_ov064_02118da0.cpp
+++ b/src/func_ov064_02118da0.cpp
@@ -8,7 +8,7 @@ void func_ov064_02118da0(char* c){
   char* a = _ZN5Actor15FindWithActorIDEjPS_(0x4f, 0);
   (void)&pad;
   if(a!=0){
-    Vec* p = (Vec*)(((int)a + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    Vec* p = (Vec*)(((int)a + 0x5c));
     *(int*)(c+0x320) = *(int*)(a+4);
     int z = p->z;
     int x = p->x;
@@ -17,7 +17,7 @@ void func_ov064_02118da0(char* c){
     *(int*)(a+0x60) = y;
     *(int*)(a+0x64) = z;
     *(unsigned char*)(c+0x339) = 0;
-    *(unsigned char*)(((int)c + 0x336) & 0xFFFFFFFFFFFFFFFF) = *(unsigned char*)(((int)c + 0x336) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(unsigned char*)(((int)c + 0x336)) = *(unsigned char*)(((int)c + 0x336)) + 1;
     return;
   }
   _ZN9ActorBase18MarkForDestructionEv(c);

--- a/src/func_ov064_02118e24.cpp
+++ b/src/func_ov064_02118e24.cpp
@@ -32,8 +32,8 @@ extern "C" void func_ov064_02118e24(void *thiz, int a1, int a2, int a3)
     }
 
     {
-        int *px = (int *)(((int)c + 0x5c) & 0xFFFFFFFFFFFFFFFF);
-        int *pz = (int *)(((int)c + 0x64) & 0xFFFFFFFFFFFFFFFF);
+        int *px = (int *)(((int)c + 0x5c));
+        int *pz = (int *)(((int)c + 0x64));
         *px += a1;
         *pz += a2;
     }

--- a/src/func_ov064_0211915c.c
+++ b/src/func_ov064_0211915c.c
@@ -12,7 +12,7 @@ int daObjFl_Coin_c_Behavior(char *a)
     case 0:
         if (*(u8 *)(a + 0xd4) == 3) {
             if (_ZN5Actor13DistToCPlayerEv(a) < 0x3e8000) {
-                (*(u8 *)(((int)a + 0xd5) & 0xFFFFFFFFFFFFFFFF))++;
+                (*(u8 *)(((int)a + 0xd5)))++;
             }
         }
         break;

--- a/src/func_ov064_021193b4.c
+++ b/src/func_ov064_021193b4.c
@@ -23,7 +23,7 @@ extern void _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(
 
 extern int data_020a0e68;
 
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((long long)(int)(p))
 
 int func_ov064_021193b4(char *c)
 {

--- a/src/func_ov064_02119c60.c
+++ b/src/func_ov064_02119c60.c
@@ -3,7 +3,7 @@ extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 
 int func_ov064_02119c60(char *c)
 {
-    unsigned char *p = (unsigned char*)(((long long)(int)(c+0x380)) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned char *p = (unsigned char*)(((long long)(int)(c+0x380)));
     *p -= 2;
     if (*(unsigned char*)(c+0x380) < 2)
         *(unsigned char*)(c+0x380) = 2;

--- a/src/func_ov064_02119d28.c
+++ b/src/func_ov064_02119d28.c
@@ -13,13 +13,13 @@ int func_ov064_02119d28(char* c) {
     func_ov064_02119afc(c);
     if (*(u16*)(c + 0x100) < 0x1e) {
         if (*(u8*)(c + 0x380) >= 2) {
-            u8 *p = (u8*)(((int)c + 0x380) & 0xFFFFFFFFFFFFFFFFLL);
+            u8 *p = (u8*)(((int)c + 0x380));
             *p = *p - 1;
         }
     }
     spd = (*(int*)(c + 0x37c) == 1) ? 0x333 : 0x199;
     {
-        int *q = (int*)(((int)c + 0x374) & 0xFFFFFFFFFFFFFFFFLL);
+        int *q = (int*)(((int)c + 0x374));
         *q = *q + 0x1000;
     }
     {
@@ -31,13 +31,13 @@ int func_ov064_02119d28(char* c) {
         _Z14ApproachLinearRiii((int*)(c + 0x80), v, spd);
     }
     {
-        int *q = (int*)(((int)c + 0x378) & 0xFFFFFFFFFFFFFFFFLL);
+        int *q = (int*)(((int)c + 0x378));
         *q = *q + 0x800;
     }
     {
         s16 b = *(int*)(c + 0x378);
         int idx2 = ((u16)b >> 4) * 2;
-        s16 *w = (s16*)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFFLL);
+        s16 *w = (s16*)(((int)c + 0x92));
         *w = *w + (int)((((s64)data_02082214[idx2] << 8) + 0x800) >> 12);
     }
     *(int*)(c + 0x88) = *(int*)(c + 0x80);

--- a/src/func_ov064_0211a2c4.cpp
+++ b/src/func_ov064_0211a2c4.cpp
@@ -25,5 +25,5 @@ extern "C" void WaterRing_Kill(char *thiz)
             *(unsigned char*)(thiz + 0x174),
             v, 4);
     }
-    *(int*)(((int)thiz + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 1;
+    *(int*)(((int)thiz + 0xb0)) |= 1;
 }

--- a/src/func_ov064_0211a380.c
+++ b/src/func_ov064_0211a380.c
@@ -1,6 +1,6 @@
 void func_ov064_0211a380(char *c)
 {
     if (*(unsigned char *)(c + 0x173) == 0) {
-        *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 1;
+        *(int *)(((int)c + 0xb0)) |= 1;
     }
 }

--- a/src/func_ov064_0211a49c.c
+++ b/src/func_ov064_0211a49c.c
@@ -4,5 +4,5 @@ void func_ov064_0211a49c(char *c)
         *(unsigned short *)(c + 0x170) = 0x2d;
     }
 
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)c + 0xb0)) &= ~1;
 }

--- a/src/func_ov065_02115ff0.c
+++ b/src/func_ov065_02115ff0.c
@@ -70,7 +70,7 @@ void func_ov065_02115ff0(char* c)
         return;
     }
     {
-        int b = (int)(((long long)(*(unsigned short*)(p + 0xc) == 0xbf)) & 0xFFFFFFFFFFFFFFFFLL);
+        int b = (int)(((long long)(*(unsigned short*)(p + 0xc) == 0xbf)));
         if (b == 0) return;
     }
     if (*(unsigned char*)(p + 0x6f9) == 1 || _ZN6Player9IsOnShellEv(p) == 1) {

--- a/src/func_ov065_02116364.c
+++ b/src/func_ov065_02116364.c
@@ -63,7 +63,7 @@ int func_ov065_02116364(void* self)
                 Matrix4x3_ApplyInPlaceToRotationX(&data_020a0e68, *(s16*)(c + 0x8c));
                 MulVec3Mat4x3(&spv, &data_020a0e68, &sout);
                 *(s32*)(sp2 + 0xa4) = sout.x;
-                cnt = (s32*)((s64)(s32)(c + 0x3dc) & 0xFFFFFFFFFFFFFFFFLL);
+                cnt = (s32*)((s64)(s32)(c + 0x3dc));
                 *(s32*)(sp2 + 0xa8) = sout.y;
                 *(s32*)(sp2 + 0xac) = sout.z;
                 *cnt = *cnt + 1;
@@ -73,7 +73,7 @@ int func_ov065_02116364(void* self)
     }
     if (_ZN9Animation8FinishedEv((void*)(c + 0x350)) != 0) {
         if (pl != 0) {
-            s32 *bp = (s32*)((s64)(s32)(pl + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+            s32 *bp = (s32*)((s64)(s32)(pl + 0x5c));
             d.x = bp[0];
             d.y = bp[1];
             d.z = bp[2];

--- a/src/func_ov065_02116744.c
+++ b/src/func_ov065_02116744.c
@@ -48,7 +48,7 @@ int func_ov065_02116744(char *c)
 
     pl = _ZN5Actor22ClosestNonVanishPlayerEv(c);
     if (pl != 0) {
-        pos = (int *)(((int)pl + 0x5c) & 0xffffffffffffffffLL);
+        pos = (int *)(((int)pl + 0x5c));
         dp[0] = pos[0];
         dp[1] = pos[1];
         dp[2] = pos[2];

--- a/src/func_ov065_0211696c.c
+++ b/src/func_ov065_0211696c.c
@@ -32,10 +32,10 @@ void func_ov065_0211696c(char* c)
     *(int*)(c + 0x3c0) = data_020a0e68[9];
     *(int*)(c + 0x3c4) = data_020a0e68[10];
     *(int*)(c + 0x3c8) = data_020a0e68[11];
-    *(int*)(((int)c + 0x3c0) & 0xFFFFFFFFFFFFFFFF) <<= 3;
-    *(int*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF) <<= 3;
-    *(int*)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFF) -= 0xa000;
-    *(int*)(((int)c + 0x3c8) & 0xFFFFFFFFFFFFFFFF) <<= 3;
+    *(int*)(((int)c + 0x3c0)) <<= 3;
+    *(int*)(((int)c + 0x3c4)) <<= 3;
+    *(int*)(((int)c + 0x3c4)) -= 0xa000;
+    *(int*)(((int)c + 0x3c8)) <<= 3;
 
     Matrix4x3_FromTranslation(data_020a0e68,
         *(int*)(c + 0x5c) >> 3,

--- a/src/func_ov065_021175b0.c
+++ b/src/func_ov065_021175b0.c
@@ -11,6 +11,6 @@ int func_ov065_021175b0(char* c)
     *(short*)(c + 0x100) = ((r >> 8) & 0x1f) + 0x32;
     func_02012694(0xf9, c + 0x74, c + 0x100, ((r >> 8) & 0x1f) + 0x32);
     *(int*)(c + 0x35c) = 0x1000;
-    (*(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF)) &= ~1;
+    (*(int *)(((int)c + 0xb0))) &= ~1;
     return 1;
 }

--- a/src/func_ov065_02117780.c
+++ b/src/func_ov065_02117780.c
@@ -7,7 +7,7 @@ extern int data_ov065_0211d6e0;
 int func_ov065_02117780(char *c) {
     int r2, v60;
     char *p;
-    *(short *)(int)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL) += 0x1000;
+    *(short *)(int)(((long long)(int)(c + 0x94))) += 0x1000;
     p = _ZN5Actor13ClosestPlayerEv(c);
     v60 = *(int *)(c + 0x60);
     r2 = v60 - 0xc8000;

--- a/src/func_ov065_02117888.c
+++ b/src/func_ov065_02117888.c
@@ -10,7 +10,7 @@ int func_ov065_02117888(char* c)
     char* p = _ZN5Actor22ClosestNonVanishPlayerEv();
     if (p) {
         Vector3 v;
-        int* q = (int*)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        int* q = (int*)(((int)p + 0x5c));
         v.x = q[0];
         v.y = q[1];
         v.z = q[2];

--- a/src/func_ov065_02118634.c
+++ b/src/func_ov065_02118634.c
@@ -39,7 +39,7 @@ void func_ov065_02118634(char* self)
     }
 
     if (*(int*)(self + 0x1130) != 0 || found != 0) {
-        (*(u8*)(((int)self + 0x11b4) & 0xFFFFFFFFFFFFFFFFLL))++;
+        (*(u8*)(((int)self + 0x11b4)))++;
         *(int*)(self + 0x98) = 0;
         *(s16*)(self + 0x11a6) = 0;
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0xec, data_ov065_0211d768[1], 0x40000000, 0x1000, 0);
@@ -72,7 +72,7 @@ void func_ov065_02118634(char* self)
         }
 
         {
-            s16* pang = (s16*)(((int)self + 0x8e) & 0xFFFFFFFFFFFFFFFFLL);
+            s16* pang = (s16*)(((int)self + 0x8e));
             *pang = *pang + *(s16*)(self + 0x11a6);
         }
         *(s16*)(self + 0x94) = *(s16*)(self + 0x8e);

--- a/src/func_ov065_0211aa38.c
+++ b/src/func_ov065_0211aa38.c
@@ -7,13 +7,13 @@ void func_ov065_0211aa38(char *r0, char *r1)
   int v = (*((int *) (r0 + 0x38c))) << 2;
   int c = data_02082214[idx * 2];
   int res1 = (int) (((((long long) v) * c) + 0x800) >> 12);
-  r1 = (char *)((long long)(int)(r1 + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+  r1 = (char *)((long long)(int)(r1 + 0x5c));
   int ip = *(int *)r1;
   *(int *)r1 = ip + res1;
   unsigned short ang2 = *((unsigned short *) (r0 + 0x8e));
   int idx2 = ang2 >> 4;
   int v2 = (*((int *) (r0 + 0x38c))) << 2;
-  char *r0b = (char *)((long long)(int)(r1 + 8) & 0xFFFFFFFFFFFFFFFFLL);
+  char *r0b = (char *)((long long)(int)(r1 + 8));
   int s = data_02082214[(idx2 * 2) + 1];
   int lr = *(int *)r0b;
   int res2 = (int) (((((long long) v2) * s) + 0x800) >> 12);

--- a/src/func_ov065_0211ae08.c
+++ b/src/func_ov065_0211ae08.c
@@ -21,8 +21,8 @@ extern s16 data_02082214[];
 extern u8 data_0209f2c0;
 extern int data_0209e650;
 
-#define I32(off) (*(int*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
-#define I8(off)  (*(u8*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
+#define I32(off) (*(int*)(((int)c + (off))))
+#define I8(off)  (*(u8*)(((int)c + (off))))
 
 int daObjCtMecha05_c_Behavior(char* c)
 {

--- a/src/func_ov066_0211603c.c
+++ b/src/func_ov066_0211603c.c
@@ -51,11 +51,11 @@ int func_ov066_0211603c(char *self)
         goto other;
 
     if (*(u8 *)(actor + 0x6f9) == 1) {
-        (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(s8 *)(((int)self + 0x4d8)))--;
         hit = 1;
     }
     if (flags & 0x10) {
-        (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(s8 *)(((int)self + 0x4d8)))--;
         if (*(s8 *)(self + 0x4d8) <= 0)
             _ZN6Player16IncMegaKillCountEv(actor);
         hit = 1;
@@ -66,11 +66,11 @@ other:
         if (flags & 0x427e0) {
             if (flags & 0x40) {
                 if (*(int *)(actor + 8) == 2)
-                    (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+                    (*(s8 *)(((int)self + 0x4d8)))--;
             }
             if (flags & 0x40000)
                 *(s16 *)(self + 0x4d4) = 1;
-            (*(s8 *)(((int)self + 0x4d8) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(s8 *)(((int)self + 0x4d8)))--;
             hit = 1;
         }
     }

--- a/src/func_ov066_021162e8.c
+++ b/src/func_ov066_021162e8.c
@@ -1,6 +1,6 @@
 struct S{int w[3];}; extern struct S data_ov066_0211ad18;
 void func_ov066_021162e8(int* c){
-    int* p=(int*)(((long long)(int)((char*)c+0x338))&0xFFFFFFFFFFFFFFFFLL);
+    int* p=(int*)(((long long)(int)((char*)c+0x338)));
     *p|=2;
     *(int*)((char*)c+0x324)=0x64000;
     *(int*)((char*)c+0x328)=0x64000;

--- a/src/func_ov066_0211632c.c
+++ b/src/func_ov066_0211632c.c
@@ -2,7 +2,7 @@ extern int data_ov066_0211ad18[];
 
 void func_ov066_0211632c(char *self)
 {
-    int *p338 = (int *)(((long long)(int)(self + 0x338)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *p338 = (int *)(((long long)(int)(self + 0x338)));
     *p338 &= ~2;
     *(int *)(self + 0x324) = 0x9c000;
     *(int *)(self + 0x328) = 0x164000;

--- a/src/func_ov066_02116390.c
+++ b/src/func_ov066_02116390.c
@@ -26,5 +26,5 @@ void func_ov066_02116390(void* thiz)
             _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(c + 0x448, data_ov066_0211aebc[1], 0x40000000, 0x1000, 0);
         *(unsigned short*)(c + 0x66c) = 8;
     }
-    *(unsigned char*)(((int)c + 0x66e) & 0xFFFFFFFFFFFFFFFF) ^= 1;
+    *(unsigned char*)(((int)c + 0x66e)) ^= 1;
 }

--- a/src/func_ov066_021164ec.c
+++ b/src/func_ov066_021164ec.c
@@ -6,9 +6,9 @@ void func_ov066_021164ec(char *c)
 {
     if (*(int*)(c + 0x498) != 0) return;
     if ((unsigned short)(*(int*)(c + 0x3b8) >> 0xc) != 0) return;
-    *(int*)(((int)c + 0x33c) & 0xFFFFFFFFFFFFFFFF) |= 0x427f0;
+    *(int*)(((int)c + 0x33c)) |= 0x427f0;
     *(int*)(c + 0xb0) = 0x10000000;
-    *(int*)(((int)c + 0x338) & 0xFFFFFFFFFFFFFFFF) |= 2;
+    *(int*)(((int)c + 0x338)) |= 2;
     if (*(int*)(c + 0x49c) == 2) {
         _ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt((char*)c + 0x360, data_ov066_0211ae64.b, 4, 0, 0x1000, 0);
     } else {

--- a/src/func_ov066_021165cc.c
+++ b/src/func_ov066_021165cc.c
@@ -26,7 +26,7 @@ void func_ov066_021165cc(char* c)
     }
     *(int*)(c + 0x3bc) = 0x1000;
     {
-        int* p = (int*)(((int)c + 0x33c) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0x33c));
         *p = *p & 0xfffbd82f;
         *(int*)(c + 0xb0) = 0;
     }

--- a/src/func_ov066_02116ac4.c
+++ b/src/func_ov066_02116ac4.c
@@ -10,10 +10,10 @@ void func_ov066_02116ac4(char* c, int strength) {
     s1 = *(int*)(c + 0x60);
     s2 = *(int*)(c + 0x64);
     if (*(int*)(c + 0x49c) == 1)
-        *(int*)(((long)c + 0x5c) & 0xFFFFFFFFFFFFFFFF) -= 0x80000;
+        *(int*)(((long)c + 0x5c)) -= 0x80000;
     else
-        *(int*)(((long)c + 0x5c) & 0xFFFFFFFFFFFFFFFF) += 0x80000;
-    *(int*)(((long)c + 0x64) & 0xFFFFFFFFFFFFFFFF) += 0x80000;
+        *(int*)(((long)c + 0x5c)) += 0x80000;
+    *(int*)(((long)c + 0x64)) += 0x80000;
     _ZN5Actor15HugeLandingDustEb(c, 1);
     func_02012694(0x143, c + 0x74);
     *(int*)(c + 0x5c) = s0;

--- a/src/func_ov066_02116db0.c
+++ b/src/func_ov066_02116db0.c
@@ -53,7 +53,7 @@ int func_ov066_02116db0(void *thiz)
         if (*(int *)(c + 0x498) == 0) {
             char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
             if (p != 0) {
-                Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
                 *(int *)(c + 0x4bc) = pp->x;
                 *(int *)(c + 0x4c0) = pp->y;
                 *(int *)(c + 0x4c4) = pp->z;
@@ -70,8 +70,8 @@ int func_ov066_02116db0(void *thiz)
                 Matrix4x3_FromRotationY(data_020a0e68, ang);
                 MulVec3Mat4x3(&in, data_020a0e68, &out);
 
-                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) += out.x;
-                *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) += out.z;
+                *(int *)(((int)c + 0x4bc)) += out.x;
+                *(int *)(((int)c + 0x4c4)) += out.z;
             }
 
             if ((unsigned short)(*(int *)(c + 0x3b8) >> 0xc) == 0)

--- a/src/func_ov066_021171b0.c
+++ b/src/func_ov066_021171b0.c
@@ -25,12 +25,12 @@ int func_ov066_021171b0(void *thiz)
         if (p == 0)
             break;
         {
-            Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+            Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
             *(int *)(c + 0x4bc) = pp->x;
             *(int *)(c + 0x4c0) = pp->y;
             *(int *)(c + 0x4c4) = pp->z;
         }
-        *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) -= 0xc8000;
+        *(int *)(((int)c + 0x4c4)) -= 0xc8000;
         if (*(int *)(c + 0x4c4) < (int)0xff3ae000) {
             *(int *)(c + 0x4c4) = (int)0xff3ae000;
         } else if (*(int *)(c + 0x4c4) > (int)0xff8c6000) {
@@ -40,13 +40,13 @@ int func_ov066_021171b0(void *thiz)
             *(short *)(c + 0x94) = -0x4000;
             *(int *)(c + 0x4bc) = 0x334000;
             if (*(int *)(c + 0x49c) == 1) {
-                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0xf2000;
+                *(int *)(((int)c + 0x4bc)) -= 0xf2000;
             }
         } else {
             *(short *)(c + 0x94) = 0x4000;
             *(int *)(c + 0x4bc) = (int)0xffe8e000;
             if (*(int *)(c + 0x49c) == 1) {
-                *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0xf2000;
+                *(int *)(((int)c + 0x4bc)) -= 0xf2000;
             }
         }
         func_02012694(0x144, c + 0x74);
@@ -109,7 +109,7 @@ int func_ov066_021171b0(void *thiz)
         *(int *)(c + 0x98) = 0;
         func_ov066_02116ac4(c, 0x7d0000);
         *(unsigned short *)(c + 0x4d0) = 0xf;
-        *(int *)(((int)c + 0x494) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(int *)(((int)c + 0x494)) += 1;
         if (*(int *)(c + 0x494) < 3)
             *(int *)(c + 0x4a0) = 3;
         else

--- a/src/func_ov066_021175e8.c
+++ b/src/func_ov066_021175e8.c
@@ -48,15 +48,15 @@ int func_ov066_021175e8(void *thiz)
         if (data_ov066_0211ae0c == *(int *)(c + 0x49c)) {
             char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
             if (p != 0) {
-                Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
                 *(int *)(c + 0x4bc) = pp->x;
                 *(int *)(c + 0x4c0) = pp->y;
                 *(int *)(c + 0x4c4) = pp->z;
-                *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) -= 0xc8000;
+                *(int *)(((int)c + 0x4c4)) -= 0xc8000;
                 if (*(int *)(c + 0x49c) == 1)
-                    *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) += 0x58000;
+                    *(int *)(((int)c + 0x4bc)) += 0x58000;
                 else
-                    *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0x58000;
+                    *(int *)(((int)c + 0x4bc)) -= 0x58000;
                 if (*(int *)(c + 0x4c4) < -0xc52000)
                     *(int *)(c + 0x4c4) = -0xc52000;
                 else if (*(int *)(c + 0x4c4) > -0x73a000)
@@ -95,7 +95,7 @@ int func_ov066_021175e8(void *thiz)
             if (func_ov066_02116a68(c) == 0) {
                 char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
                 if (p != 0) {
-                    Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                    Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
                     v.x = pp->x;
                     v.y = pp->y;
                     v.z = pp->z;
@@ -116,9 +116,9 @@ int func_ov066_021175e8(void *thiz)
     case 3:
         if (*(int *)(c + 0x4c8) < 0x2710) {
             if (*(unsigned short *)(c + 0x4d0) != 0)
-                *(int *)(((int)c + 0x4c8) & 0xFFFFFFFFFFFFFFFF) += 0x1a;
+                *(int *)(((int)c + 0x4c8)) += 0x1a;
             else
-                *(int *)(((int)c + 0x4c8) & 0xFFFFFFFFFFFFFFFF) += 0x130;
+                *(int *)(((int)c + 0x4c8)) += 0x130;
         }
         _Z14ApproachLinearRiii((int *)(c + 0x98), 0x258000, *(int *)(c + 0x4c8));
         if (func_ov066_02116b78(c) == 1) {

--- a/src/func_ov066_02117bf0.c
+++ b/src/func_ov066_02117bf0.c
@@ -45,11 +45,11 @@ int func_ov066_02117bf0(void *thiz)
         if (data_ov066_0211ae0c == *(int *)(c + 0x49c)) {
             char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
             if (p != 0) {
-                Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
                 *(int *)(c + 0x4bc) = pp->x;
                 *(int *)(c + 0x4c0) = pp->y;
                 *(int *)(c + 0x4c4) = pp->z;
-                *(int *)(((int)c + 0x4c4) & 0xFFFFFFFFFFFFFFFF) -= 0xc8000;
+                *(int *)(((int)c + 0x4c4)) -= 0xc8000;
                 if (*(int *)(c + 0x4c4) < -0xc52000)
                     *(int *)(c + 0x4c4) = -0xc52000;
                 else if (*(int *)(c + 0x4c4) > -0x73a000)
@@ -58,14 +58,14 @@ int func_ov066_02117bf0(void *thiz)
             if (*(int *)(c + 0x4c4) > -0xa68000) {
                 if (*(int *)(c + 0x4bc) < 0) {
                     if (*(int *)(c + 0x49c) == 1)
-                        *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) += 0x1c2000;
+                        *(int *)(((int)c + 0x4bc)) += 0x1c2000;
                     else
-                        *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) += 0x12c000;
+                        *(int *)(((int)c + 0x4bc)) += 0x12c000;
                 } else {
                     if (*(int *)(c + 0x49c) == 1)
-                        *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0x12c000;
+                        *(int *)(((int)c + 0x4bc)) -= 0x12c000;
                     else
-                        *(int *)(((int)c + 0x4bc) & 0xFFFFFFFFFFFFFFFF) -= 0x1c2000;
+                        *(int *)(((int)c + 0x4bc)) -= 0x1c2000;
                 }
             }
             func_02012694(0x144, c + 0x74);
@@ -82,7 +82,7 @@ int func_ov066_02117bf0(void *thiz)
             if (func_ov066_02116a68(c) == 0) {
                 char *p = (char *)_ZN5Actor13ClosestPlayerEv(c);
                 if (p != 0) {
-                    Vec3 *pp = (Vec3 *)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+                    Vec3 *pp = (Vec3 *)(((int)p + 0x5c));
                     v.x = pp->x;
                     v.y = pp->y;
                     v.z = pp->z;
@@ -103,9 +103,9 @@ int func_ov066_02117bf0(void *thiz)
     case 2:
         if (*(int *)(c + 0x4c8) < 0x2710) {
             if (*(unsigned short *)(c + 0x4d0) != 0)
-                *(int *)(((int)c + 0x4c8) & 0xFFFFFFFFFFFFFFFF) += 0x1a;
+                *(int *)(((int)c + 0x4c8)) += 0x1a;
             else
-                *(int *)(((int)c + 0x4c8) & 0xFFFFFFFFFFFFFFFF) += 0x130;
+                *(int *)(((int)c + 0x4c8)) += 0x130;
         }
         _Z14ApproachLinearRiii((int *)(c + 0x98), 0x258000, *(int *)(c + 0x4c8));
         if (func_ov066_02116b78(c) == 1) {

--- a/src/func_ov066_02118188.c
+++ b/src/func_ov066_02118188.c
@@ -73,7 +73,7 @@ int func_ov066_02118188(void *thiz)
                     *(int *)(c + 0x4a0) = 4;
                     break;
                 }
-                *(int *)(((int)c + 0x494) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(int *)(((int)c + 0x494)) += 1;
             }
         }
 

--- a/src/func_ov066_021184e0.c
+++ b/src/func_ov066_021184e0.c
@@ -16,7 +16,7 @@ int func_ov066_021184e0(char *c)
     switch (*(int *)(c + 0x4a0)) {
     case 0:
         if (data_ov066_0211ae0c == *(int *)(c + 0x49c)) {
-            int *p = (int *)((long long)(int)(c + 0x4a0) & 0xFFFFFFFFFFFFFFFFLL);
+            int *p = (int *)((long long)(int)(c + 0x4a0));
             *(int *)(c + 0x9c) = -0x14000;
             *(int *)(c + 0xa8) = 0x64000;
             *p = *p + 1;

--- a/src/func_ov066_02118a50.c
+++ b/src/func_ov066_02118a50.c
@@ -16,7 +16,7 @@ s32 func_ov066_02118a50(char* c) {
         data_ov066_0211ae0c = data_ov066_0211abe0;
     }
     {
-        unsigned char* p = (unsigned char*)(((int)c + 0x4d9) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* p = (unsigned char*)(((int)c + 0x4d9));
         *p += 1;
     }
     data_ov066_0211ae10 += 1;

--- a/src/func_ov066_02118b28.c
+++ b/src/func_ov066_02118b28.c
@@ -16,7 +16,7 @@ s32 func_ov066_02118b28(char* c) {
         data_ov066_0211ae0c = data_ov066_0211abe0;
     }
     {
-        unsigned char* p = (unsigned char*)(((int)c + 0x4d9) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* p = (unsigned char*)(((int)c + 0x4d9));
         *p += 1;
     }
     data_ov066_0211ae10 += 1;

--- a/src/func_ov066_02118c00.c
+++ b/src/func_ov066_02118c00.c
@@ -16,7 +16,7 @@ s32 func_ov066_02118c00(char* c) {
         data_ov066_0211ae0c = data_ov066_0211abe0;
     }
     {
-        unsigned char* p = (unsigned char*)(((int)c + 0x4d9) & 0xFFFFFFFFFFFFFFFF);
+        unsigned char* p = (unsigned char*)(((int)c + 0x4d9));
         *p += 1;
     }
     data_ov066_0211ae10 += 1;

--- a/src/func_ov066_02118cdc.cpp
+++ b/src/func_ov066_02118cdc.cpp
@@ -34,7 +34,7 @@ int func_ov066_02118cdc(char* c) {
         } else {
             data_ov066_0211ae0c = data_ov066_0211abe0;
         }
-        volatile int* tmp = (volatile int*)(((int)c + 0x494) & 0xFFFFFFFFFFFFFFFF);
+        volatile int* tmp = (volatile int*)(((int)c + 0x494));
         *tmp = *tmp + 1;
         *tmp = *tmp & 1;
     }

--- a/src/func_ov066_0211903c.c
+++ b/src/func_ov066_0211903c.c
@@ -76,7 +76,7 @@ int func_ov066_0211903c(char* self) {
                 _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x14, 0x15666);
             }
 
-            *(unsigned short*)(((int)*(void**)(self + 0x490) + 0x6ce) & 0xFFFFFFFFFFFFFFFF) |= 0x400;
+            *(unsigned short*)(((int)*(void**)(self + 0x490) + 0x6ce)) |= 0x400;
             _ZN7Message11PrepareTalkEv();
             if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void**)(self + 0x490), self, msgid, &out, 0, 0) == 1) {
                 *(int*)(self + 0x498) = 1;
@@ -86,7 +86,7 @@ int func_ov066_0211903c(char* self) {
     } else {
         if (*(void**)(self + 0x490) != 0) {
             if (_ZN6Player12GetTalkStateEv(*(void**)(self + 0x490)) < 0) {
-                *(int*)(((int)cam + 0x154) & 0xFFFFFFFFFFFFFFFF) &= ~8;
+                *(int*)(((int)cam + 0x154)) &= ~8;
                 _ZN7Message7EndTalkEv();
                 if (data_ov066_0211abe0 == 3) {
                     _ZN5Sound22LoadAndSetMusic_Layer3Ej(0x2d);

--- a/src/func_ov070_0211f48c.c
+++ b/src/func_ov070_0211f48c.c
@@ -12,7 +12,7 @@ int _ZN9Animation8FinishedEv(void* a);
 int FlyGuy_ChangeState(void* c, void* p);
 extern char data_ov070_0212359c[];
 
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 
 int func_ov070_0211f48c(char* c) {
     char* pl;

--- a/src/func_ov070_0211f62c.c
+++ b/src/func_ov070_0211f62c.c
@@ -7,7 +7,7 @@ int func_ov070_0211f62c(char *c)
 {
     if (func_02015bcc(c + 0x350) != 0) {
         if (data_0209f2f8 != 0x16)
-            *(int *)(((long long)(int)(c + 0x3c4)) & 0xFFFFFFFFFFFFFFFFLL) += 0x12c000;
+            *(int *)(((long long)(int)(c + 0x3c4))) += 0x12c000;
         *(int *)(c + 0x3d8) = 0;
         *(short *)(c + 0x3cc) = 0x5a;
         FlyGuy_ChangeState(c, &data_ov070_0212359c);

--- a/src/func_ov070_0211f6e0.c
+++ b/src/func_ov070_0211f6e0.c
@@ -48,7 +48,7 @@ int func_ov070_0211f6e0(char* c)
         }
         if (*(s32*)(c + 0x3dc) == 1) {
             if (data_0209f2f8 != 0x16)
-                *(s32 *)(((long long)(s32)(c + 0x3c4)) & 0xFFFFFFFFFFFFFFFFLL) += 0x12c000;
+                *(s32 *)(((long long)(s32)(c + 0x3c4))) += 0x12c000;
             *(s32*)(c + 0x3d8) = 0;
             *(u16*)(c + 0x3cc) = 0x5a;
             FlyGuy_ChangeState(c, &data_ov070_0212359c);
@@ -84,7 +84,7 @@ int func_ov070_0211f6e0(char* c)
             *(s32*)(c + 0x3c0) = *(s32*)(c + 0x5c);
             *(s32*)(c + 0x3c4) = *(s32*)(c + 0x60);
             *(s32*)(c + 0x3c8) = *(s32*)(c + 0x64);
-            *(s32 *)(((long long)(s32)(c + 0x3c4)) & 0xFFFFFFFFFFFFFFFFLL) += 0xc8000;
+            *(s32 *)(((long long)(s32)(c + 0x3c4))) += 0xc8000;
         }
         *(s32*)(c + 0x5c) = *(s32*)(c + 0x68);
         *(s32*)(c + 0x60) = *(s32*)(c + 0x6c);

--- a/src/func_ov070_0211fae4.c
+++ b/src/func_ov070_0211fae4.c
@@ -34,7 +34,7 @@ int func_ov070_0211fae4(void *arg)
             *(int *)(c + 0x3c0) = *(int *)(c + 0x5c);
             *(int *)(c + 0x3c4) = *(int *)(c + 0x60);
             *(int *)(c + 0x3c8) = *(int *)(c + 0x64);
-            *(int *)(((int)c + 0x3c4) & 0xFFFFFFFFFFFFFFFFLL) += 0xc8000;
+            *(int *)(((int)c + 0x3c4)) += 0xc8000;
         }
         *(int *)(c + 0x5c) = *(int *)(c + 0x68);
         *(int *)(c + 0x60) = *(int *)(c + 0x6c);
@@ -51,7 +51,7 @@ int func_ov070_0211fae4(void *arg)
     vin.z = 0;
 
     {
-    int *q = (int *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFFLL);
+    int *q = (int *)(((int)player + 0x5c));
     vb.x = q[0];
     vb.y = q[1];
     vb.z = q[2];

--- a/src/func_ov070_0211fd98.c
+++ b/src/func_ov070_0211fd98.c
@@ -61,7 +61,7 @@ int func_ov070_0211fd98(char *c)
     if (Vec3_Dist(c + 0x5c, c + 0x3c0) < 0x5dc000) {
         p = _ZN5Actor22ClosestNonVanishPlayerEv(c);
         if (p) {
-            int *pos = (int *)(((int)p + 0x5c) & 0xffffffffffffffffLL);
+            int *pos = (int *)(((int)p + 0x5c));
             t.x = pos[0];
             t.y = pos[1];
             t.z = pos[2];

--- a/src/func_ov070_02120910.cpp
+++ b/src/func_ov070_02120910.cpp
@@ -13,7 +13,7 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a
 int func_ov070_02120910(char* c)
 {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
-    *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int*)(((int)c + 0xb0)) &= ~1;
     *(int*)(c + 0x9c) = -0x2000;
     *(int*)(c + 0xa0) = -0x3c000;
     *(int*)(c + 0x5c) = *(int*)(c + 0x404);

--- a/src/func_ov070_02121438.cpp
+++ b/src/func_ov070_02121438.cpp
@@ -14,7 +14,7 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a
 extern "C" int Amp_Kill(char* c)
 {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
-    int* p_b0 = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    int* p_b0 = (int*)(((int)c + 0xb0));
     *p_b0 = *p_b0 & ~1;
     *(int*)(c + 0x9c) = -0x2000;
     *(int*)(c + 0xa0) = -0x3c000;

--- a/src/func_ov070_02121a64.c
+++ b/src/func_ov070_02121a64.c
@@ -5,13 +5,13 @@ int func_ov070_02121a64(char* c)
     switch (*(int*)c) {
     case 0:
         if (*(unsigned int*)(c + 0xc) < *(unsigned int*)(c + 8)) {
-            unsigned int* p = (unsigned int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+            unsigned int* p = (unsigned int*)(((int)c + 0xc));
             *p = *p + 1;
         }
         break;
     case 1:
         {
-            unsigned int* p = (unsigned int*)(((int)c + 0xc) & 0xFFFFFFFFFFFFFFFF);
+            unsigned int* p = (unsigned int*)(((int)c + 0xc));
             *p = *p + 1;
             *p = *p % *(unsigned int*)(c + 8);
         }

--- a/src/func_ov071_0211f6f8.cpp
+++ b/src/func_ov071_0211f6f8.cpp
@@ -24,7 +24,7 @@ struct Base {
 extern "C" int func_ov071_0211f6f8(char* c)
 {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
-    *(int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int*)(((int)c + 0xb0)) &= ~1;
     *(int*)(c + 0x98) = 0xa000;
     *(int*)(c + 0xa8) = 0x28000;
     *(short*)(c + 0x3a8) = 0x2d;

--- a/src/func_ov071_0211f7d4.c
+++ b/src/func_ov071_0211f7d4.c
@@ -29,7 +29,7 @@ extern "C" int func_ov071_0211f7d4(Actor *self)
         WithMeshClsn *wm = (WithMeshClsn*)(s + 0x194);
         *(int*)(s + 0xa8) = 0;
         wm->ClearLimMovFlag();
-        *(int *)(((long long)(int)(s + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 1;
+        *(int *)(((long long)(int)(s + 0xb0))) |= 1;
         short z = 0;
         short ang = *(short*)(s + 0x94);
         *(short*)(s + 0x8c) = z;

--- a/src/func_ov071_0211f8d0.cpp
+++ b/src/func_ov071_0211f8d0.cpp
@@ -35,11 +35,11 @@ extern "C" int func_ov071_0211f8d0(char* self)
     int y, z, x, y2;
 
     zero = 0;
-    pb0 = (int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+    pb0 = (int *)(((int)self + 0xb0));
     *pb0 = (*pb0) & 0xfff7fffe;
 
     parent = *(char **)(self + 0xd0);
-    pos = (Vector3 *)(((int)self + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    pos = (Vector3 *)(((int)self + 0x5c));
     mul = 0x5a000;
     *(int *)(self + 0x98) = *(int *)(parent + 0x98) + 0x7000;
     *(int *)(self + 0xa8) = zero;
@@ -47,13 +47,13 @@ extern "C" int func_ov071_0211f8d0(char* self)
     parent = *(char **)(self + 0xd0);
     rnd = 0x800;
     *(s16 *)(self + 0x8e) = *(s16 *)(parent + 0x8e);
-    py = (int *)(((int)self + 0x60) & 0xFFFFFFFFFFFFFFFF);
-    pz = (int *)(((int)self + 0x64) & 0xFFFFFFFFFFFFFFFF);
+    py = (int *)(((int)self + 0x60));
+    pz = (int *)(((int)self + 0x64));
     *(s16 *)(self + 0x94) = *(s16 *)(self + 0x8e);
 
     parent = *(char **)(self + 0xd0);
     one = 1;
-    srcv = (Vector3 *)(((int)parent + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    srcv = (Vector3 *)(((int)parent + 0x5c));
     *(int *)(self + 0x5c) = srcv->x;
     *(int *)(self + 0x60) = srcv->y;
     *(int *)(self + 0x64) = srcv->z;

--- a/src/func_ov071_0211fa54.c
+++ b/src/func_ov071_0211fa54.c
@@ -6,7 +6,7 @@ int func_ov071_0211fa54(void* thiz)
     char* c = (char*)thiz;
     int b0 = (int)((*(int*)(c + 0xb0) & 0x40000) != 0);
     if (b0 != 0) {
-        int* src = (int*)(((int)(*(char**)(c + 0xd0)) + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+        int* src = (int*)(((int)(*(char**)(c + 0xd0)) + 0x5c));
         *(int*)(c + 0x5c) = src[0];
         *(int*)(c + 0x60) = src[1];
         *(int*)(c + 0x64) = src[2];

--- a/src/func_ov071_0211fd58.cpp
+++ b/src/func_ov071_0211fd58.cpp
@@ -11,7 +11,7 @@ int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
 int func_0201267c(int, void*);
 int func_ov071_0211fd58(char* c){
   _ZN9Animation7AdvanceEv(c+0x124);
-  int* p = (int*)(((int)c + 0x3a0) & 0xFFFFFFFFFFFFFFFF);
+  int* p = (int*)(((int)c + 0x3a0));
   *p -= 0xf000;
   if(*(int*)(c+0x3a0) <= 0){
     char* b = c+0x300;

--- a/src/func_ov071_0211fe38.c
+++ b/src/func_ov071_0211fe38.c
@@ -5,7 +5,7 @@ extern struct G data_ov071_02122f88;
 
 int func_ov071_0211fe38(char *c)
 {
-    int *p3a0 = (int *)(((long long)(int)(c + 0x3a0)) & 0xFFFFFFFFFFFFFFFFLL);
+    int *p3a0 = (int *)(((long long)(int)(c + 0x3a0)));
     *(int *)(c + 0x9c) = -0x2000;
     *(int *)(c + 0xa0) = -0x3c000;
     *(int *)(c + 0x98) = 0xf000;

--- a/src/func_ov071_02120028.c
+++ b/src/func_ov071_02120028.c
@@ -36,7 +36,7 @@ int func_ov071_02120028(char *c)
         *(int*)(c + 0x390) = *(int*)(c + 0x5c);
         *(int*)(c + 0x394) = *(int*)(c + 0x60);
         *(int*)(c + 0x398) = *(int*)(c + 0x64);
-        *(int*)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000001;
+        *(int*)(((long long)(int)(c + 0xb0))) |= 0x10000001;
         Scuttlebug_SetState(c, 2);
     }
     func_ov071_0211f29c(c);

--- a/src/func_ov071_02120200.c
+++ b/src/func_ov071_02120200.c
@@ -2,7 +2,7 @@ extern void _ZN12CylinderClsn5ClearEv(void* p);
 
 int func_ov071_02120200(char* c)
 {
-    int* p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+    int* p = (int*)(((int)c + 0xb0));
     int z;
     short ang;
 

--- a/src/func_ov071_0212070c.c
+++ b/src/func_ov071_0212070c.c
@@ -20,30 +20,30 @@ int func_ov071_0212070c(char* c)
     if (delta > hi) {
         v = *(int *)(c + 0x1f4);
         if (v >= 0) {
-            p = (int *)(((int)c + 0x1f4) & 0xFFFFFFFFFFFFFFFF);
+            p = (int *)(((int)c + 0x1f4));
             *p = *p + delta;
             *(unsigned char *)(c + 0x216) = 0x2e;
         } else {
             if (*(unsigned char *)(c + 0x216) == 0)
                 *(int *)(c + 0x1f4) = 0;
-            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216)));
         }
     } else if (delta < -hi) {
         v = *(int *)(c + 0x1f4);
         /* fallthrough ADD when v <= 0 (target: bgt to Dec) */
         if (v <= 0) {
-            p = (int *)(((int)c + 0x1f4) & 0xFFFFFFFFFFFFFFFF);
+            p = (int *)(((int)c + 0x1f4));
             *p = *p + delta;
             *(unsigned char *)(c + 0x216) = 0x2e;
         } else {
             if (*(unsigned char *)(c + 0x216) == 0)
                 *(int *)(c + 0x1f4) = 0;
-            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+            DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216)));
         }
     } else {
         if (*(unsigned char *)(c + 0x216) == 0)
             *(int *)(c + 0x1f4) = 0;
-        DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216) & 0xFFFFFFFFFFFFFFFF));
+        DecIfAbove0_Byte((unsigned char *)(((int)c + 0x216)));
     }
 
     v = *(int *)(c + 0x1f4);

--- a/src/func_ov071_02120860.cpp
+++ b/src/func_ov071_02120860.cpp
@@ -20,7 +20,7 @@ int func_ov071_02120860(char* c)
         _ZN9Animation8SetFlagsEi(c + 0x138, 0x40000000);
         *(int*)(c + 0x144) = 0x1000;
         *(int*)(c + 0x140) = 0;
-        st = (unsigned char*)(((int)c + 0x214) & 0xFFFFFFFFFFFFFFFFLL);
+        st = (unsigned char*)(((int)c + 0x214));
         *st = *st + 1;
         /* fall through */
     case 2:
@@ -30,7 +30,7 @@ int func_ov071_02120860(char* c)
             _ZN9Animation8SetFlagsEi(c + 0x138, 0x40000000);
             *(int*)(c + 0x144) = 0x1000;
             *(int*)(c + 0x140) = 0;
-            st = (unsigned char*)(((int)c + 0x214) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char*)(((int)c + 0x214));
             *st = *st + 1;
         }
         _ZN9Animation7AdvanceEv(c + 0x138);
@@ -38,7 +38,7 @@ int func_ov071_02120860(char* c)
     case 3:
     case 6:
         if (_ZN9Animation8FinishedEv(c + 0x138) != 0) {
-            st = (unsigned char*)(((int)c + 0x214) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char*)(((int)c + 0x214));
             *st = *st + 1;
         }
         _ZN9Animation7AdvanceEv(c + 0x138);

--- a/src/func_ov071_02120a20.c
+++ b/src/func_ov071_02120a20.c
@@ -1,7 +1,7 @@
 int func_ov071_02120a20(char *c)
 {
     if (*(unsigned char *)(c + 0x214) == 0) {
-        (*(volatile unsigned char *)(((int)c + 0x214) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(volatile unsigned char *)(((int)c + 0x214)))++;
         return 1;
     }
 

--- a/src/func_ov071_0212110c.c
+++ b/src/func_ov071_0212110c.c
@@ -21,7 +21,7 @@ int func_ov071_0212110c(char *self)
     *(unsigned char*)(self + 0x215) = 0x2e;
     *(short*)(self + 0x210) = 0;
     func_0201267c(0x119, self + 0x74);
-    *(int *)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)self + 0xb0)) &= ~1;
     *(int*)(self + 0x1e8) = 2;
     *(int*)(self + 0x1fc) = 0x500;
     return 1;

--- a/src/func_ov072_0211f1dc.cpp
+++ b/src/func_ov072_0211f1dc.cpp
@@ -15,7 +15,7 @@ int func_ov072_0211f1dc(char* c){
   *(short*)(c+0x94) = *(short*)(c+0x8e);
   if (d < *(int*)(c+0x398)) {
     n = _ZNK7PathPtr8NumNodesEv(c+0x380);
-    idx = (int*)(((int)c + 0x388) & 0xFFFFFFFFFFFFFFFFLL);
+    idx = (int*)(((int)c + 0x388));
     *idx = *idx + 1;
     if (*(int*)(c+0x388) >= n - 1) return 1;
   }

--- a/src/func_ov072_0211f578.c
+++ b/src/func_ov072_0211f578.c
@@ -1,6 +1,6 @@
 int func_ov072_0211f578(char *c)
 {
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)c + 0xb0)) &= ~1;
     *(int *)(c + 0x394) = 5;
     return 1;
 }

--- a/src/func_ov072_0211f63c.c
+++ b/src/func_ov072_0211f63c.c
@@ -1,6 +1,6 @@
 int func_ov072_0211f63c(char *c)
 {
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)c + 0xb0)) &= ~1;
     *(int *)(c + 0x394) = 4;
     return 1;
 }

--- a/src/func_ov072_0211f65c.cpp
+++ b/src/func_ov072_0211f65c.cpp
@@ -39,7 +39,7 @@ extern "C" int func_ov072_0211f65c(unsigned char* thiz)
                 func_0201267c(0x114, thiz + 0x74);
                 *(int*)(thiz + 0xa8) = 0x1d000;
                 *(int*)(thiz + 0x98) = 0xe000;
-                st = (unsigned char*)(((int)thiz + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+                st = (unsigned char*)(((int)thiz + 0x3a2));
                 *st = *st + 1;
             }
         }
@@ -57,7 +57,7 @@ extern "C" int func_ov072_0211f65c(unsigned char* thiz)
             *(short*)(thiz + 0x8c) = 0;
             *(short*)(thiz + 0x8e) = (short)-0x4000;
             *(int*)(thiz + 0x98) = 0;
-            st = (unsigned char*)(((int)thiz + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char*)(((int)thiz + 0x3a2));
             *st = *st + 1;
         }
         break;

--- a/src/func_ov072_0211f9c4.c
+++ b/src/func_ov072_0211f9c4.c
@@ -3,7 +3,7 @@ int func_ov072_0211f9c4(char *c)
     *(int *)(c + 0x9c) = -0x2000;
     *(int *)(c + 0xa0) = -0x3c000;
     {
-        int *p = (int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)c + 0xb0));
         *p &= ~1;
     }
     *(int *)(c + 0x388) = 0;

--- a/src/func_ov072_0211fa08.cpp
+++ b/src/func_ov072_0211fa08.cpp
@@ -15,12 +15,12 @@ int func_ov072_0211fa08(char* c){
   switch(*(unsigned char*)(c+0x3a2)){
   case 0:
     if(_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(int*)(c+0x390), c, 0xb0, v, 0, 0) == 0) break;
-    st = (unsigned char*)(((int)c + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+    st = (unsigned char*)(((int)c + 0x3a2));
     *st = *st + 1;
     break;
   case 1:
     if(_ZN6Player12GetTalkStateEv((void*)*(int*)(c+0x390)) != -1) break;
-    st = (unsigned char*)(((int)c + 0x3a2) & 0xFFFFFFFFFFFFFFFFLL);
+    st = (unsigned char*)(((int)c + 0x3a2));
     *st = *st + 1;
     break;
   case 2:

--- a/src/func_ov072_0211fb7c.c
+++ b/src/func_ov072_0211fb7c.c
@@ -15,7 +15,7 @@ int func_ov072_0211fb7c(char *c) {
     func_0203568c((int*)(c + 0x180), *(int*)(c + 0x398));
     func_02035684((int*)(c + 0x180), *(int*)(c + 0x398));
     _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(c, *(int*)(c + 0x398), *(int*)(c + 0x398), 0x1000000, 0x1000000);
-    p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int*)(((int)c + 0xb0));
     *p = *p | 1;
     *(int*)(c + 0x394) = 0;
     return 1;

--- a/src/func_ov072_0212001c.c
+++ b/src/func_ov072_0212001c.c
@@ -26,14 +26,14 @@ int SnowmanBody_Kill(char *c)
         *(void **)(c + 0x32c) = _ZN5Actor13ClosestPlayerEv(c);
         if (Vec3_HorzDist(c + 0x5c, *(char **)(c + 0x32c) + 0x5c) < 0x118000) {
             if (_ZN6Player9StartTalkER9ActorBaseb(*(void **)(c + 0x32c), c, 1)) {
-                st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+                st = (unsigned char *)(((int)c + 0x334));
                 *st = *st + 1;
             }
         }
         break;
     case 1:
         if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(*(void **)(c + 0x32c), c, 0xb1, &v, 0, 2)) {
-            st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char *)(((int)c + 0x334));
             *st = *st + 1;
         }
         break;
@@ -49,7 +49,7 @@ int SnowmanBody_Kill(char *c)
                 0,
                 *(signed char *)(c + 0xcc),
                 -1);
-            st = (unsigned char *)(((int)c + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char *)(((int)c + 0x334));
             *st = *st + 1;
         }
         break;

--- a/src/func_ov072_021201d4.c
+++ b/src/func_ov072_021201d4.c
@@ -31,7 +31,7 @@ int func_ov072_021201d4(char *self)
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x10f, *(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
             _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x110, *(int *)(self + 0x5c), *(int *)(self + 0x60), *(int *)(self + 0x64));
             _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x20, 0x14, 0x7f, 0x15666, 0);
-            st = (unsigned char *)(((int)self + 0x334) & 0xFFFFFFFFFFFFFFFFLL);
+            st = (unsigned char *)(((int)self + 0x334));
             *st = *st + 1;
         }
         break;

--- a/src/func_ov072_02120308.c
+++ b/src/func_ov072_02120308.c
@@ -1,6 +1,6 @@
 int func_ov072_02120308(char *base)
 {
-    *(int *)(((int)base + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~1;
+    *(int *)(((int)base + 0xb0)) &= ~1;
     *(int *)(base + 0x9c) = -0x2000;
     *(int *)(base + 0xa0) = -0x3c000;
     *(int *)(base + 0xa8) = 0x2d000;


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 101 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
