### PR TITLE
readable: strip 95 unnecessary no-op launder masks (byte-verified)

### DIFF
--- a/src/func_ov084_0212aab0.cpp
+++ b/src/func_ov084_0212aab0.cpp
@@ -15,7 +15,7 @@ extern "C" void func_ov084_0212aab0(char *c)
     }
     if (((WithMeshClsn *)(c + 0x1b4))->IsOnGround()) {
         *(int *)(c + 0x434) = 0;
-        int *p = (int *)(((int)c + 0x198) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)c + 0x198));
         *p &= ~4;
     } else {
         ApproachLinear(*(short *)(c + 0x94), *(short *)(c + 0x45c), 0x800);

--- a/src/func_ov084_0212ab48.c
+++ b/src/func_ov084_0212ab48.c
@@ -10,7 +10,7 @@ void func_ov084_0212ab48(char *c)
         *(int *)(c + 0xa8) = (int)(((long long)*(int *)(c + 0xa8) * 0x1800 + 0x800) >> 0xc);
     }
     *(short *)(c + 0x45c) = *(short *)(c + 0x45a);
-    p = (unsigned char *)(((int)c + 0x468) & 0xFFFFFFFFFFFFFFFF);
+    p = (unsigned char *)(((int)c + 0x468));
     *p &= ~1;
     *(short *)(c + 0x8e) = *(short *)(c + 0x94);
 }

--- a/src/func_ov084_0212abd4.c
+++ b/src/func_ov084_0212abd4.c
@@ -23,11 +23,11 @@ void func_ov084_0212abd4(char *self)
     _Z14ApproachLinearRiii((int *)(self + 0x98), *(int *)(self + 0x444), 0x500);
     if (((Flag *)(self + 0x468))->b0) {
         if (_Z14ApproachLinearRsss((short *)(self + 0x94), *(s16 *)(self + 0x45a), step)) {
-            *(unsigned char *)(((int)self + 0x468) & 0xFFFFFFFFFFFFFFFFLL) &= ~1;
+            *(unsigned char *)(((int)self + 0x468)) &= ~1;
             return;
         }
         {
-            unsigned char *p = (unsigned char *)(((int)self + 0x468) & 0xFFFFFFFFFFFFFFFFLL);
+            unsigned char *p = (unsigned char *)(((int)self + 0x468));
             *p = (*p & ~1) | 1;
         }
         return;
@@ -58,7 +58,7 @@ void func_ov084_0212abd4(char *self)
     {
         int bit = _ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs(
                       self, self + 0x1b4, (short *)(self + 0x45c));
-        unsigned char *p = (unsigned char *)(((int)self + 0x468) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *p = (unsigned char *)(((int)self + 0x468));
         bit &= 1;
         *p = (*p & ~1) | bit;
     }
@@ -83,8 +83,8 @@ void func_ov084_0212abd4(char *self)
             _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x370, data_ov084_02130ce8[1], 0, 0x1000, 0);
             
             if (*(u16 *)(self + 0x450) != 0) {
-                *(u16 *)(((int)self + 0x450) & 0xFFFFFFFFFFFFFFFFLL) =
-                    *(u16 *)(((int)self + 0x450) & 0xFFFFFFFFFFFFFFFFLL) - 1;
+                *(u16 *)(((int)self + 0x450)) =
+                    *(u16 *)(((int)self + 0x450)) - 1;
             } else if (((unsigned)RandomIntInternal(&data_0209e650) >> 16) & 3) {
                 *(s16 *)(self + 0x45c) = *(s16 *)(self + 0x94) + (s16)((unsigned)RandomIntInternal(&data_0209e650) >> 16);
                 *(u16 *)(self + 0x450) = 0x64;

--- a/src/func_ov084_0212d564.c
+++ b/src/func_ov084_0212d564.c
@@ -5,7 +5,7 @@ typedef unsigned int u32;
 typedef int s32;
 typedef long long s64;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 struct Locals {
     s16 acc[3];

--- a/src/func_ov084_0212d564.cpp
+++ b/src/func_ov084_0212d564.cpp
@@ -77,21 +77,21 @@ extern "C" void func_ov084_0212d564(char* c)
     sx = data_02082214[((u16)locals.acc[0] >> 4) * 2] * 0x32;
     sy = data_02082214[((u16)locals.acc[1] >> 4) * 2];
 
-    px = (int*)(int)(((long long)(int)(c + 0x1f8)) & 0xFFFFFFFFFFFFFFFFLL);
+    px = (int*)(int)(((long long)(int)(c + 0x1f8)));
     *px = *px + (int)(((s64)sx * sy + 0x800) >> 12);
 
     flag = (*(u16*)(c + 0xc) == 0xfb);
     if (flag != false) {
-        py = (int*)(int)(((long long)(int)(c + 0x1fc)) & 0xFFFFFFFFFFFFFFFFLL);
+        py = (int*)(int)(((long long)(int)(c + 0x1fc)));
         v = data_02082214[((u16)locals.acc[0] >> 4) * 2 + 1] * 0x32;
         *py = *py - (0x19000 - v);
     } else {
-        py = (int*)(int)(((long long)(int)(c + 0x1fc)) & 0xFFFFFFFFFFFFFFFFLL);
+        py = (int*)(int)(((long long)(int)(c + 0x1fc)));
         v = data_02082214[((u16)locals.acc[0] >> 4) * 2 + 1] * 0x32;
         *py = *py - (0x32000 - v);
     }
 
-    pz = (int*)(int)(((long long)(int)(c + 0x200)) & 0xFFFFFFFFFFFFFFFFLL);
+    pz = (int*)(int)(((long long)(int)(c + 0x200)));
     sz = data_02082214[((u16)locals.acc[1] >> 4) * 2 + 1];
     *pz = *pz + (int)(((s64)sx * sz + 0x800) >> 12);
 

--- a/src/func_ov084_0212d86c.c
+++ b/src/func_ov084_0212d86c.c
@@ -47,8 +47,8 @@ void func_ov084_0212d86c(char *r5)
             *(u8 *)(r5 + 0x21d) = 0xa;
             *(u16 *)(r5 + 0x218) = 0x1f40;
             {
-                u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
-                u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+                u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)));
+                u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)));
                 *p18c |= 1u;
                 *pb0 &= ~0x10000000u;
             }
@@ -122,8 +122,8 @@ second:
         *(u8 *)(r5 + 0x21d) = 0xa;
         *(u16 *)(r5 + 0x218) = 0x1f40;
         {
-            u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
-            u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
+            u32 *p18c = (u32 *)(((long long)(int)(r5 + 0x18c)));
+            u32 *pb0 = (u32 *)(((long long)(int)(r5 + 0xb0)));
             *p18c |= 1u;
             *pb0 &= ~0x10000000u;
         }

--- a/src/func_ov084_0212e010.cpp
+++ b/src/func_ov084_0212e010.cpp
@@ -40,13 +40,13 @@ extern "C" void func_ov084_0212e010(char* self)
     int b;
 
     if (*(u8*)(self + 0x21d) != 0) {
-        short* hp = (short*)(((long long)(int)(self + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+        short* hp = (short*)(((long long)(int)(self + 0x8e)));
         *hp = (s16)(*hp + *(s16*)(self + 0x218));
         ApproachLinear_s((short*)(self + 0x218), 0, 0xc8);
         func_ov084_0212d42c(self);
         if (_ZN9Animation8FinishedEv(self + 0x160) == 0)
             return;
-        (*(u8*)(((int)self + 0x21d) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(u8*)(((int)self + 0x21d)))--;
         if (*(u8*)(self + 0x21d) != 0)
             return;
         func_02012694(0x11f, self + 0x74);
@@ -59,8 +59,8 @@ extern "C" void func_ov084_0212e010(char* self)
     if (ApproachLinear_i((int*)(self + 0x204), 0, *(int*)(self + 0x214)) == 0)
         return;
     {
-        u32* p0 = (u32*)(((long long)(int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL);
-        u32* p1 = (u32*)(((long long)(int)(self + 0x18c)) & 0xFFFFFFFFFFFFFFFFLL);
+        u32* p0 = (u32*)(((long long)(int)(self + 0xb0)));
+        u32* p1 = (u32*)(((long long)(int)(self + 0x18c)));
         *p0 &= ~0x10000000;
         *p1 |= 1;
     }
@@ -74,10 +74,10 @@ extern "C" void func_ov084_0212e010(char* self)
             other = (char*)_ZN5Actor10FindWithIDEj(*(u32*)(self + 0x1f0));
             if (other == 0)
                 return;
-            (*(u8*)(((int)other + 0x21a) & 0xFFFFFFFFFFFFFFFF))--;
+            (*(u8*)(((int)other + 0x21a)))--;
             if (*(u8*)(self + 0x21e) != 0)
                 return;
-            (*(u8*)(((int)other + 0x21b) & 0xFFFFFFFFFFFFFFFF))++;
+            (*(u8*)(((int)other + 0x21b)))++;
             if (*(u8*)(self + 0x220) != 0) {
                 buf1.x = *(int*)(self + 0x5c);
                 buf1.y = *(int*)(self + 0x60);
@@ -140,7 +140,7 @@ extern "C" void func_ov084_0212e010(char* self)
     if (*(u16*)(self + 0xc) != 0xfb)
         b = 0;
     if (b != false)
-        (*(u8*)(((int)other + 0x21a) & 0xFFFFFFFFFFFFFFFF))++;
+        (*(u8*)(((int)other + 0x21a)))++;
     b = *(u16*)(self + 0xc) == 0xfd;
     if (b != false) {
         *(int*)(self + 0x1ec) = 3;

--- a/src/func_ov084_0212ec60.c
+++ b/src/func_ov084_0212ec60.c
@@ -7,7 +7,7 @@ typedef unsigned int u32;
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
-#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off))) & 0xFFFFFFFFFFFFFFFFLL))
+#define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern void Vec3_Asr(Vec3* d, Vec3* s, int sh);
 extern void Matrix4x3_FromTranslation(Mtx43* m, int x, int y, int z);

--- a/src/func_ov084_0212f204.c
+++ b/src/func_ov084_0212f204.c
@@ -11,7 +11,7 @@ void func_ov084_0212f204(char* r4){
   {
     char* p = *(char**)(r4 + 0x460);
     if (p != 0) {
-      struct Vector3* pp = (struct Vector3*)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+      struct Vector3* pp = (struct Vector3*)(((int)p + 0x5c));
       v.x = pp->x;
       v.y = pp->y;
       v.z = pp->z;

--- a/src/func_ov084_0212fc10.c
+++ b/src/func_ov084_0212fc10.c
@@ -8,7 +8,7 @@ void func_ov084_0212fc10(char *c)
     *(int *)(c + 0x84) = 0x1000;
     *(int *)(c + 0x88) = 0x1000;
     *(unsigned char *)(c + 0x45c) = 1;
-    *(int *)(((long long)(int)(c + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x10000000;
+    *(int *)(((long long)(int)(c + 0xb0))) |= 0x10000000;
     func_02016748(c + 0x110, data_ov084_02130df4[1], 0, 0x1000, 0);
     if (*(int *)(c + 0x464) < 0x4b0000)
         *(int *)(c + 0x458) = 1;

--- a/src/func_ov085_021291ac.c
+++ b/src/func_ov085_021291ac.c
@@ -23,7 +23,7 @@ extern void func_ov085_02129524(char *c, int i);
 extern s8 data_0209f2f8;
 extern int data_0209caa0[];
 extern u8 data_ov085_0212f27c[];
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 void func_ov085_021291ac(char *c)
 {
     char *p;

--- a/src/func_ov085_0212a220.c
+++ b/src/func_ov085_0212a220.c
@@ -17,7 +17,7 @@ int func_ov085_0212a220(char* c)
     switch (*(u8*)(c + 0x368)) {
     case 0:
         if (_ZN6Player9StartTalkER9ActorBaseb(*(void**)(c + 0x35c), c, 1) != 0)
-            *(u8*)(((int)c + 0x368) & 0xFFFFFFFFFFFFFFFF) += 1;
+            *(u8*)(((int)c + 0x368)) += 1;
         break;
     case 1:
         if (_Z14ApproachLinearRsss((s16*)(c + 0x8e),
@@ -30,7 +30,7 @@ int func_ov085_0212a220(char* c)
             v.y = v.y + 0xa0000;
             if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(
                     *(void**)(c + 0x35c), c, 0xd0, &v, 0, 0) != 0)
-                *(u8*)(((int)c + 0x368) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(u8*)(((int)c + 0x368)) += 1;
         }
         break;
     case 2:

--- a/src/func_ov085_0212a828.cpp
+++ b/src/func_ov085_0212a828.cpp
@@ -17,7 +17,7 @@ void func_ov085_0212a828(char* c)
     if ((*(int*)(c + 0x130) & 0x1000) == 0) return;
     if (_ZN6Player7TryGrabER5Actor(o, c) == 0) return;
     *(void**)(c + 0x45c) = o;
-    *(int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
+    *(int*)(((int)c + 0x128)) |= 2;
     if (*(unsigned char*)(c + 0x426) == 0) {
         func_ov085_0212bc78(c, data_ov085_021306ac);
     } else {

--- a/src/func_ov085_0212a904.c
+++ b/src/func_ov085_0212a904.c
@@ -37,7 +37,7 @@ int func_ov085_0212a904(void *thiz)
         if (_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(r4, self, 0x148, &vec, 0, 0)) {
             func_02012790(0xa);
             {
-                int *p = (int *)(((int)self + 0x41c) & 0xFFFFFFFFFFFFFFFF);
+                int *p = (int *)(((int)self + 0x41c));
                 (*p)++;
             }
         }
@@ -48,13 +48,13 @@ int func_ov085_0212a904(void *thiz)
                 func_02012790(0x5e);
                 _ZN7Message13DisplaySavingEt(0x295);
                 {
-                    int *p = (int *)(((int)self + 0x41c) & 0xFFFFFFFFFFFFFFFF);
+                    int *p = (int *)(((int)self + 0x41c));
                     (*p)++;
                 }
             } else if (gb == 2) {
                 func_02012790(0x98);
                 {
-                    unsigned short *hp = (unsigned short *)(((int)r4 + 0x6ce) & 0xFFFFFFFFFFFFFFFF);
+                    unsigned short *hp = (unsigned short *)(((int)r4 + 0x6ce));
                     *hp &= ~0x800;
                 }
                 _ZN7Message7EndTalkEv();
@@ -64,7 +64,7 @@ int func_ov085_0212a904(void *thiz)
         break;
     case 2:
         if (data_0209d660 == 0) {
-            unsigned short *hp = (unsigned short *)(((int)r4 + 0x6ce) & 0xFFFFFFFFFFFFFFFF);
+            unsigned short *hp = (unsigned short *)(((int)r4 + 0x6ce));
             *hp &= ~0x800;
             _ZN7Message7EndTalkEv();
             func_ov085_0212bc78(self, data_ov085_021306bc);

--- a/src/func_ov085_0212aaec.c
+++ b/src/func_ov085_0212aaec.c
@@ -27,7 +27,7 @@ int func_ov085_0212aaec(char *self)
     unsigned int id;
 
     player = *(void **)(self + 0x460);
-    pq = (int *)(((int)player + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    pq = (int *)(((int)player + 0x5c));
     pos.x = *(int *)(self + 0x5c);
     pos.y = *(int *)(self + 0x60);
     pos.z = *(int *)(self + 0x64);

--- a/src/func_ov085_0212ac4c.c
+++ b/src/func_ov085_0212ac4c.c
@@ -30,7 +30,7 @@ int func_ov085_0212ac4c(char *c)
                 *(short *)(c + 0x94) = *(short *)(obj + 0x8e);
             }
         }
-        p128 = (int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL);
+        p128 = (int *)(((long long)(int)(c + 0x128)));
         b = 0;
         *p128 = (*p128) & ~2;
         *(int *)(c + 0x45c) = b;

--- a/src/func_ov085_0212ad8c.c
+++ b/src/func_ov085_0212ad8c.c
@@ -4,8 +4,8 @@ extern struct G data_ov085_021305c0;
 
 int func_ov085_0212ad8c(char *c)
 {
-    int *a = (int *)(((int)c + 0x12c) & 0xFFFFFFFFFFFFFFFF);
-    int *b = (int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF);
+    int *a = (int *)(((int)c + 0x12c));
+    int *b = (int *)(((int)c + 0x128));
     *(int *)(c + 0x9c) = -0x1000;
     *(unsigned char *)(c + 0x426) = 1;
     *a &= ~0x1000;

--- a/src/func_ov085_0212ae08.c
+++ b/src/func_ov085_0212ae08.c
@@ -49,7 +49,7 @@ int func_ov085_0212ae08(char *c)
 
     if (*(s32 *)(c + 0x41c) == 0) {
         {
-            int *ps = (int *)(((long long)(int)(pl + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+            int *ps = (int *)(((long long)(int)(pl + 0x5c)));
             pv.x = ps[0];
             pv.y = ps[1];
             pv.z = ps[2];
@@ -187,7 +187,7 @@ int func_ov085_0212ae08(char *c)
     /* talk ended */
     _ZN6Player9DropActorEv(pl);
     {
-        s32 *p128 = (s32 *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL);
+        s32 *p128 = (s32 *)(((long long)(int)(c + 0x128)));
         *p128 = *p128 & ~2;
     }
     *(s32 *)(c + 0x98) = 0;
@@ -240,7 +240,7 @@ int func_ov085_0212ae08(char *c)
             func_02012790(0xa);
             *(u8 *)(c + 0x427) = 0;
             {
-                u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL);
+                u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)));
                 *pf = (u16)(*pf | 0x800);
             }
         }
@@ -249,7 +249,7 @@ int func_ov085_0212ae08(char *c)
 no_spawn:
     if (*(u8 *)(c + 0x427) == 2) {
         {
-            u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL);
+            u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)));
             *pf = (u16)(*pf & ~0x800);
         }
         *(u8 *)(c + 0x427) = 0;
@@ -272,7 +272,7 @@ do_306bc:
     goto final_return;
 flag_path:
     {
-        u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)) & 0xFFFFFFFFFFFFFFFFLL);
+        u16 *pf = (u16 *)(((long long)(int)(pl + 0x6ce)));
         *pf = (u16)(*pf | 0x800);
     }
     *(char **)(c + 0x460) = pl;

--- a/src/func_ov085_0212cd0c.cpp
+++ b/src/func_ov085_0212cd0c.cpp
@@ -11,11 +11,11 @@ extern "C" void func_ov085_0212cd0c(char* c)
     _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x28, 0x7f, 0, 0x7444, 0);
     _ZN7Message7EndTalkEv();
     {
-        int* p = (int*)(((int)data_0209f318 + 0x154) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)data_0209f318 + 0x154));
         *p = *p & ~8;
     }
     {
-        unsigned short* p = (unsigned short*)(((int)(*(char**)(c + 0x18c)) + 0x6ce) & 0xFFFFFFFFFFFFFFFF);
+        unsigned short* p = (unsigned short*)(((int)(*(char**)(c + 0x18c)) + 0x6ce));
         *p = *p & ~0x800;
     }
     _ZN9ActorBase18MarkForDestructionEv(c);

--- a/src/func_ov085_0212d108.c
+++ b/src/func_ov085_0212d108.c
@@ -25,7 +25,7 @@ int func_ov085_0212d108(char* c)
     int zero;
     Vector3* ppos;
 
-    ap = (s16*)(((long long)(int)(c + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+    ap = (s16*)(((long long)(int)(c + 0x8c)));
     *ap = (s16)(*ap + 0x1000);
     if (*(unsigned short*)(c + 0x100) != 0) {
         return 1;
@@ -36,7 +36,7 @@ int func_ov085_0212d108(char* c)
     }
 
     zero = 0;
-    ppos = (Vector3*)(((long long)(int)(player + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+    ppos = (Vector3*)(((long long)(int)(player + 0x5c)));
     v.x = zero;
     v.y = zero;
     v.z = zero;

--- a/src/func_ov085_0212d73c.c
+++ b/src/func_ov085_0212d73c.c
@@ -33,10 +33,10 @@ int func_ov085_0212d73c(char *c)
     _Z14ApproachLinearRiii((int *)(c + 0x98), 0x28000, 0x2000);
     _Z14ApproachLinearRsss((s16 *)(c + 0x94), Vec3_HorzAngle((Vector3 *)(c + 0x5c), &data_ov085_0213084c), (s16)*(int *)(c + 0x2cc));
     *(s16 *)(c + 0x8e) = *(s16 *)(c + 0x94);
-    *(int *)(((int)c + 0x2cc) & 0xFFFFFFFFFFFFFFFF) += 5;
+    *(int *)(((int)c + 0x2cc)) += 5;
     if (*(int *)(c + 0x2cc) > 0x800)
         *(int *)(c + 0x2cc) = 0x800;
-    *(int *)(((int)c + 0x2c8) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int *)(((int)c + 0x2c8)) += 1;
     if (*(int *)(c + 0x2c8) < 0x19)
         return 1;
     v[1].x = -0x50c000;

--- a/src/func_ov085_0212d9b8.c
+++ b/src/func_ov085_0212d9b8.c
@@ -11,8 +11,8 @@ int func_ov085_0212d9b8(char* c)
     void* pl = _ZN5Actor13ClosestPlayerEv();
     if (pl == 0) return 1;
 
-    *(int*)(((int)c + 0x2c8) & 0xFFFFFFFFFFFFFFFFLL) += 1;
-    *(int*)(((int)c + 0x2cc) & 0xFFFFFFFFFFFFFFFFLL) += 0x500;
+    *(int*)(((int)c + 0x2c8)) += 1;
+    *(int*)(((int)c + 0x2cc)) += 0x500;
 
     {
         int v = (short)*(int*)(c + 0x2cc);

--- a/src/func_ov085_0212dbdc.c
+++ b/src/func_ov085_0212dbdc.c
@@ -13,7 +13,7 @@ int func_ov085_0212dbdc(char* c)
     int* pp;
     if (p == 0)
         return 1;
-    pp = (int*)(((int)c + 0x2c8) & 0xFFFFFFFFFFFFFFFF);
+    pp = (int*)(((int)c + 0x2c8));
     *pp = *pp + 1;
     switch (*(int*)(c + 0x2c8)) {
     case 1:

--- a/src/func_ov085_0212dd10.cpp
+++ b/src/func_ov085_0212dd10.cpp
@@ -13,7 +13,7 @@ int func_ov085_0212dd10(char* c)
     {
         short v = *(short*)(c + 0x8e);
         short w = v + 0x8000;
-        int* t = (int*)(((int)c + 0x2c8) & 0xFFFFFFFFFFFFFFFF);
+        int* t = (int*)(((int)c + 0x2c8));
         *(short*)(p + 0x8c) = 0;
         *(short*)(p + 0x8e) = w;
         *(short*)(p + 0x90) = 0;

--- a/src/func_ov085_0212de5c.cpp
+++ b/src/func_ov085_0212de5c.cpp
@@ -46,7 +46,7 @@ extern "C" int func_ov085_0212de5c(PlayerObj *c)
     c->v8c = 0x1000;
     c->v90 = 0x800;
     {
-        int *pp = (int *)(((int)c + 0x2c8) & 0xFFFFFFFFFFFFFFFF);
+        int *pp = (int *)(((int)c + 0x2c8));
         int n = *pp + 1;
         *pp = n;
     }

--- a/src/func_ov085_0212e4a4.c
+++ b/src/func_ov085_0212e4a4.c
@@ -25,7 +25,7 @@ int func_ov085_0212e4a4(unsigned int self)
             *(int *)(self + 0x5c) = v.x;
             *(int *)(self + 0x60) = v.y;
             *(int *)(self + 0x64) = v.z;
-            *(int *)(((long long)((int)(self + 0x5c))) & 0xFFFFFFFFFFFFFFFFLL) -= 0x3e8000;
+            *(int *)(((long long)((int)(self + 0x5c)))) -= 0x3e8000;
             *(int *)(self + 0x60) = *(int *)(p + 0x644) + 0x3e8000;
             *(int *)(self + 0x2a4) = *(int *)(self + 0x5c);
             *(int *)(self + 0x2a8) = *(int *)(self + 0x60);

--- a/src/func_ov085_0212e5ac.c
+++ b/src/func_ov085_0212e5ac.c
@@ -21,7 +21,7 @@ int func_ov085_0212e5ac(char* self)
     pl = data_0209f318;
     in.x = 0; in.y = 0; in.z = 0;
     out.x = 0; out.y = 0; out.z = 0;
-    src = (Vector3*)(((int)pl + 0x8c) & 0xFFFFFFFFFFFFFFFF);
+    src = (Vector3*)(((int)pl + 0x8c));
     plpos.x = src->x;
     plpos.y = src->y;
     plpos.z = src->z;
@@ -42,13 +42,13 @@ int func_ov085_0212e5ac(char* self)
     in.z = Vec3_HorzDist(&plpos, (Vector3*)(self + 0x5c));
     Matrix4x3_FromRotationY(data_020a0e68, Vec3_HorzAngle(&plpos, (Vector3*)(self + 0x5c)));
     MulVec3Mat4x3(&in, data_020a0e68, &out);
-    *(int*)(((int)self + 0x5c) & 0xFFFFFFFFFFFFFFFF) += out.x;
+    *(int*)(((int)self + 0x5c)) += out.x;
     if (data_0209f2f8 == 0x2f) {
         if (*(int*)(self + 0x5c) > 0x79e000) {
             *(int*)(self + 0x5c) = 0x79e000;
         }
     }
-    *(int*)(((int)self + 0x64) & 0xFFFFFFFFFFFFFFFF) += out.z;
+    *(int*)(((int)self + 0x64)) += out.z;
     *(short*)(self + 0x94) = 0x8000 - *(short*)(pl + 0x17c);
     *(short*)(self + 0x92) = -*(short*)(pl + 0x17e);
     return 1;

--- a/src/func_ov090_021310b4.c
+++ b/src/func_ov090_021310b4.c
@@ -40,7 +40,7 @@ void func_ov090_021310b4(char* c)
 
     if (*(unsigned int*)(c + 0x134) == 0) return;
     if ((p = (char*)_ZN5Actor10FindWithIDEj(*(unsigned int*)(c + 0x134))) == 0) return;
-    flags = (int)(((long long)*(int*)(c + 0x130)) & 0xFFFFFFFFFFFFFFFFLL);
+    flags = (int)(((long long)*(int*)(c + 0x130)));
 
     if (flags & 0x2400) {
         *(int*)(c + 0x10c) = 2;
@@ -88,7 +88,7 @@ void func_ov090_021310b4(char* c)
     }
     {
         int b = (*(unsigned short*)(p + 0xc) == 0xbf) ? 1 : 0;
-        if ((int)(((long long)b) & 0xFFFFFFFFFFFFFFFFLL) == 0) return;
+        if ((int)(((long long)b)) == 0) return;
     }
     if (*(unsigned char*)(p + 0x6f9) == 1 || _ZN6Player9IsOnShellEv(p) == 1) {
         cv.x = *(int*)(c + 0x5c);

--- a/src/func_ov090_021314a0.cpp
+++ b/src/func_ov090_021314a0.cpp
@@ -10,7 +10,7 @@ int func_ov090_021314a0(char* c){
   if(p == 0) goto out;
   if(AngleDiff(*(short*)(c+0x94), _ZN5Actor18HorzAngleToCPlayerEv(c)) >= 0x2000) goto out;
   {
-    int* sv = (int*)(((int)p + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    int* sv = (int*)(((int)p + 0x5c));
     int v[3];
     v[0] = sv[0];
     v[1] = sv[1];

--- a/src/func_ov090_02131584.c
+++ b/src/func_ov090_02131584.c
@@ -9,7 +9,7 @@ int func_ov090_02131584(char *c)
     *(int *)(c + 0x98) = 0;
     v = ((unsigned int)*(int *)(c + 0x364) << 4) >> 0x10;
     if (v >= 0x3b)
-        *(int *)(((int)c + 0x390) & 0xFFFFFFFFFFFFFFFF) += 1;
+        *(int *)(((int)c + 0x390)) += 1;
     if (*(int *)(c + 0x390) > 2 || func_ov090_021314a0(c) == 1)
         func_ov090_02131e00(c, &data_ov090_02134514);
     if (*(unsigned char *)(c + 0x39c) == 1)

--- a/src/func_ov090_02131c48.c
+++ b/src/func_ov090_02131c48.c
@@ -26,7 +26,7 @@ int func_ov090_02131c48(char* c)
     if (*(u16*)(c + 0x394) == 0
         && _ZNK12WithMeshClsn8IsOnWallEv(c + 0x150)
         && AngleDiff(*(s16*)(c + 0x94), *(s16*)(c + 0x39a)) < 0x200) {
-        s16* p = (s16*)(((int)c + 0x39a) & 0xFFFFFFFFFFFFFFFF);
+        s16* p = (s16*)(((int)c + 0x39a));
         *p = *p + 0x4000;
         *(s16*)(c + 0x394) = 8;
     }
@@ -35,7 +35,7 @@ int func_ov090_02131c48(char* c)
         ApproachAngle((s16*)(c + 0x94), *(s16*)(c + 0x39a), 1, 0x1000, 0x1000);
     } else {
         if (_ZN9Animation8FinishedEv(c + 0x35c)) {
-            int* q = (int*)(((int)c + 0x390) & 0xFFFFFFFFFFFFFFFF);
+            int* q = (int*)(((int)c + 0x390));
             *q = *q + 1;
             if (*(int*)(c + 0x390) > 0x14)
                 func_ov090_02131e00(c, &data_ov090_02134504);

--- a/src/func_ov090_02133710.cpp
+++ b/src/func_ov090_02133710.cpp
@@ -15,7 +15,7 @@ void func_ov090_02133710(char* c) {
     struct Vector3 v;
     struct Vector3 v2;
     void* a;
-    *(int*)(((int)c + 0x384) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(int*)(((int)c + 0x384)) += 1;
     if (*(int*)(c + 0x384) > 2) *(int*)(c + 0x384) = 0;
     v.x = 0;
     v.y = 0;

--- a/src/func_ov091_02132f04.cpp
+++ b/src/func_ov091_02132f04.cpp
@@ -9,9 +9,9 @@ void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 int _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void*, struct Vector3*, int);
 int func_0201267c(int, void*);
 void func_ov091_02132f04(char* c){
-  int *pa8 = (int*)(((int)c + 0xa8) & 0xFFFFFFFFFFFFFFFFLL);
+  int *pa8 = (int*)(((int)c + 0xa8));
   int a = *pa8;
-  int *p60 = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+  int *p60 = (int*)(((int)c + 0x60));
   a = a - 0x4000;
   *pa8 = a;
   a = *p60 + *(int*)(c+0xa8);

--- a/src/func_ov091_02133020.c
+++ b/src/func_ov091_02133020.c
@@ -2,7 +2,7 @@ extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
 void func_ov091_02133020(char *c)
 {
-    (*(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)) += 0xa000;
+    (*(int *)(((int)c + 0x60))) += 0xa000;
     if (*(int *)(c + 0x60) < *(int *)(c + 0x390))
         return;
     *(int *)(c + 0x60) = *(int *)(c + 0x390);

--- a/src/func_ov091_021334b8.cpp
+++ b/src/func_ov091_021334b8.cpp
@@ -15,17 +15,17 @@ extern "C" void func_ov091_021334b8(char *c, int flag)
 {
     if (flag != 0) {
         unsigned char n = *(unsigned char *)(c + 0x31e);
-        int *p = (int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)c + 0x60));
         int m = n * 0x3c;
         int y = *p;
         *p = y - (m << 12);
         *(unsigned char *)(c + 0x31e) = 0;
     } else {
-        int *p = (int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFFLL);
+        int *p = (int *)(((int)c + 0x60));
         int y = *p;
         *p = y - 0x3c000;
         int off = 0x31e;
-        unsigned char *q = (unsigned char *)(((int)c + off) & 0xFFFFFFFFFFFFFFFFLL);
+        unsigned char *q = (unsigned char *)(((int)c + off));
         *q = *q - 1;
     }
     *(unsigned char *)(c + 0x31f) = 0xf;

--- a/src/func_ov091_02133738.cpp
+++ b/src/func_ov091_02133738.cpp
@@ -32,7 +32,7 @@ int func_ov091_02133738(char* c)
             int* p;
             if ((val > 0 && diff < -100) || (val < 0 && diff > 100))
                 *(int*)(c + 0x324) = 0;
-            p = (int*)(((int)c + 0x324) & 0xFFFFFFFFFFFFFFFF);
+            p = (int*)(((int)c + 0x324));
             *p = *p + diff;
             {
                 int a = *(int*)(c + 0x324);

--- a/src/func_ov091_02133c6c.c
+++ b/src/func_ov091_02133c6c.c
@@ -15,13 +15,13 @@ extern "C" int func_ov091_02133c6c(char* c){
   v.x = 0;
   v.y = 0;
   v.z = 0x1e000;
-  a = (short*)(((int)c + 0x92) & 0xFFFFFFFFFFFFFFFFLL);
+  a = (short*)(((int)c + 0x92));
   *a = (short)(*a - 0x80);
   Matrix4x3_FromRotationY(data_020a0e68, *(short*)(c+0x94));
   Matrix4x3_ApplyInPlaceToRotationX(data_020a0e68, *(short*)(c+0x92));
   MulVec3Mat4x3(&v, data_020a0e68, (Vector3*)(c+0xa4));
   {
-    unsigned short *hp = (unsigned short*)(((int)c + 0x100) & 0xFFFFFFFFFFFFFFFFLL);
+    unsigned short *hp = (unsigned short*)(((int)c + 0x100));
     if (*hp == 0
         || _ZNK12WithMeshClsn10IsOnGroundEv(c+0x144) != 0
         || _ZNK12WithMeshClsn8IsOnWallEv(c+0x144) != 0

--- a/src/func_ov091_02133f60.c
+++ b/src/func_ov091_02133f60.c
@@ -17,7 +17,7 @@ int func_ov091_02133f60(char *c)
     struct Vector3 *src;
     if (pl == 0) goto done;
 
-    src = (struct Vector3*)(((int)pl + 0x5c) & 0xFFFFFFFFFFFFFFFF);
+    src = (struct Vector3*)(((int)pl + 0x5c));
     v.x = src->x;
     v.y = src->y;
     v.z = src->z;

--- a/src/func_ov092_02130fcc.c
+++ b/src/func_ov092_02130fcc.c
@@ -5,9 +5,9 @@ void func_ov092_02130fcc(char *c)
     int limit;
     int cur;
 
-    cur = *(int *)(((long long)(int)((char *)c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    cur = *(int *)(((long long)(int)((char *)c + 0x60)));
     cur -= 0x5000;
-    *(int *)(((long long)(int)((char *)c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) = cur;
+    *(int *)(((long long)(int)((char *)c + 0x60))) = cur;
     limit = *(int *)(c + 0x55c) - 0x3e8000;
     cur = *(int *)(c + 0x60);
     if (cur >= limit)

--- a/src/func_ov092_02131010.cpp
+++ b/src/func_ov092_02131010.cpp
@@ -6,7 +6,7 @@
 // LandingDustAt bool-arg mov above the stores, exactly as the ROM has it.
 struct Vector3 { int x, y, z; };
 typedef short s16;
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 extern "C" {
 void *_ZN5Actor13ClosestPlayerEv(void *self);
 int func_ov002_020de328(void);

--- a/src/func_ov092_021314d0.c
+++ b/src/func_ov092_021314d0.c
@@ -5,7 +5,7 @@ void func_ov092_021314d0(char* c) {
   if (*(unsigned char*)(c+0x574) == 3) {
     func_ov092_021313b0(c);
   } else {
-    *(int*)(((int)c + 0x570) & 0xFFFFFFFFFFFFFFFF) = *(int*)(((int)c + 0x570) & 0xFFFFFFFFFFFFFFFF) + 1;
+    *(int*)(((int)c + 0x570)) = *(int*)(((int)c + 0x570)) + 1;
     int* arr = *(int**)(c+0x56c);
     int v = arr[*(int*)(c+0x570)];
     if (v != -1) {
@@ -17,7 +17,7 @@ void func_ov092_021314d0(char* c) {
   }
   *(unsigned char*)(c+0x575) = (*(s16*)(c+0x92) >> 0xe) & 3;
   {
-    unsigned char* f = (unsigned char*)(((int)c + 0x575) & 0xFFFFFFFFFFFFFFFF);
+    unsigned char* f = (unsigned char*)(((int)c + 0x575));
     *f = *f | ((*(s16*)(c+0x94) >> 0xc) & 0xc);
     *f = *f | ((*(s16*)(c+0x96) >> 0xa) & 0x30);
   }

--- a/src/func_ov092_021316d8.c
+++ b/src/func_ov092_021316d8.c
@@ -2,7 +2,7 @@ typedef signed char s8;
 typedef short s16;
 typedef unsigned short u16;
 typedef unsigned char u8;
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 extern s16 data_02082214[];
 extern s8 data_ov092_0213208c[];
 extern void func_ov092_021314d0(void *c);

--- a/src/func_ov092_02131878.c
+++ b/src/func_ov092_02131878.c
@@ -5,7 +5,7 @@ extern short Vec3_HorzAngle(const Vector3* a, const Vector3* b);
 extern int data_ov092_02132074[];
 extern int data_ov092_02132080[];
 extern short data_02082214[];
-#define LA(p) (((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL)
+#define LA(p) (((long long)(int)(p)))
 
 void func_ov092_02131878(char* c, char* a1, unsigned int a2){
   unsigned char f = *(unsigned char*)(c+0x575);

--- a/src/func_ov094_021358b4.cpp
+++ b/src/func_ov094_021358b4.cpp
@@ -15,7 +15,7 @@ extern "C" int func_ov094_021358b4(void *t) {
     char *c = (char*)t;
     if (*(int*)(c+0x3e8) == 0) {
         if (*(u8*)(c+0x3e4) != 0) {
-            u8 *cd = (u8*)(((int)c + 0x3e4) & 0xFFFFFFFFFFFFFFFF);
+            u8 *cd = (u8*)(((int)c + 0x3e4));
             *cd = *cd - 1;
             *(short*)(c+0x92) = 0;
             *(int*)(c+0xa8) = 0x14000;
@@ -24,7 +24,7 @@ extern "C" int func_ov094_021358b4(void *t) {
             *(int*)(c+0xa4) = 0;
             *(int*)(c+0xa8) = 0;
             *(int*)(c+0xac) = 0;
-            int *p = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+            int *p = (int*)(((int)c + 0x60));
             *(int*)(c+0x5c) = *(int*)(c+0x3d8);
             *(int*)(c+0x60) = *(int*)(c+0x3dc);
             *(int*)(c+0x64) = *(int*)(c+0x3e0);
@@ -33,7 +33,7 @@ extern "C" int func_ov094_021358b4(void *t) {
     } else {
         ApproachLinear((struct Vector3*)(c+0x5c), (struct Vector3*)(c+0x3d8), 0x2000);
         if (*(u8*)(c+0x3e4) < 0x1f) {
-            u8 *cd = (u8*)(((int)c + 0x3e4) & 0xFFFFFFFFFFFFFFFF);
+            u8 *cd = (u8*)(((int)c + 0x3e4));
             *cd = *cd + 1;
         } else {
             *(u8*)(c+0x3e4) = 0x1f;

--- a/src/func_ov094_02135c28.c
+++ b/src/func_ov094_02135c28.c
@@ -69,7 +69,7 @@ int func_ov094_02135c28(void* thiz)
     buf.v[4] = 0;
     buf.v[5] = 0;
 
-    p3e8 = (int*)(((int)c + 0x3e8) & 0xFFFFFFFFFFFFFFFF);
+    p3e8 = (int*)(((int)c + 0x3e8));
     *p3e8 += 0x200;
     ang = *(int*)(c + 0x3e8);
     idx = ((u16)(short)ang >> 4) * 2;

--- a/src/func_ov094_02136024.c
+++ b/src/func_ov094_02136024.c
@@ -11,7 +11,7 @@ short Vec3_HorzAngle(const Vec3* a, const Vec3* b);
 int func_ov094_02136188(void* c, PMF* p);
 extern char data_020a0e68[];
 extern PMF data_ov094_02136b60;
-#define LA(p) ((char*)(unsigned)(((long long)(unsigned)(unsigned)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define LA(p) ((char*)(unsigned)(((long long)(unsigned)(unsigned)(p))))
 
 int func_ov094_02136024(char* c){
   char* p = _ZN5Actor13ClosestPlayerEv();

--- a/src/func_ov095_02135cdc.c
+++ b/src/func_ov095_02135cdc.c
@@ -32,7 +32,7 @@ void func_ov095_02135cdc(char* self, char* other)
 	*(unsigned char*)(self + 0x326) = 1;
 	r = func_ov095_0213579c(self, other);
 
-	pa = (s16*)(int)(((long long)(int)(self + 0x8c)) & 0xFFFFFFFFFFFFFFFFLL);
+	pa = (s16*)(int)(((long long)(int)(self + 0x8c)));
 	*pa += ((struct SubA*)(self + 0x300))->f24;
 	x = (int)(((s64)dist * r + 0x800) >> 12);
 	d = (s16)AngleDiff(ang, *(s16*)(self + 0x8e));
@@ -44,7 +44,7 @@ void func_ov095_02135cdc(char* self, char* other)
 		acc = (int)(((s64)y * 0x51LL + 0x800) >> 12);
 
 	dv = acc / 4096;
-	*(s16*)(int)(((long long)(int)(self + 0x324)) & 0xFFFFFFFFFFFFFFFFLL) += dv;
+	*(s16*)(int)(((long long)(int)(self + 0x324))) += dv;
 	lim = (int)(((s64)r * 0x32000LL + 0x800) >> 12) / 4096;
 	if (((struct SubA*)(self + 0x300))->f24 > lim) ((struct SubA*)(self + 0x300))->f24 = lim;
 	if (((struct SubA*)(self + 0x300))->f24 < -lim) ((struct SubA*)(self + 0x300))->f24 = -lim;

--- a/src/func_ov095_02136178.c
+++ b/src/func_ov095_02136178.c
@@ -14,7 +14,7 @@ void func_ov095_02136178(char* c)
 
     _Z14ApproachLinearRiii((int*)(c + 0xa8), -0xa000, -0x2000);
     {
-        int* p = (int*)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0x60));
         int v = *p + *(int*)(c + 0xa8);
         *p = v;
     }

--- a/src/func_ov095_02136298.cpp
+++ b/src/func_ov095_02136298.cpp
@@ -13,7 +13,7 @@ void SeesawBob_AfterClsn(char* c)
     *(unsigned int*)(c + 0x340) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
         *(unsigned int*)(c + 0x340), 3, 0x82, *(Vector3*)(c + 0x74), 0);
     _Z14ApproachLinearRiii(*(int*)(c + 0xa8), 0xa000, 0x2000);
-    (*(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF)) += *(int*)(c + 0xa8);
+    (*(int *)(((int)c + 0x60))) += *(int*)(c + 0xa8);
     if (*(int*)(c + 0x60) < *(int*)(c + 0x334)) return;
     *(int*)(c + 0x60) = *(int*)(c + 0x334);
     *(char*)(c + 0x346) = 0;

--- a/src/func_ov096_02136e54.c
+++ b/src/func_ov096_02136e54.c
@@ -7,8 +7,8 @@ extern s16 data_02082214[];
 void func_ov096_02136e54(void* c, int a)
 {
     char* cc = (char*)c;
-    s16* pang = (s16*)(((long long)(int)(cc + 0x35a)) & 0xFFFFFFFFFFFFFFFFLL);
-    s16* pw = (s16*)(((long long)(int)(cc + 0x8e)) & 0xFFFFFFFFFFFFFFFFLL);
+    s16* pang = (s16*)(((long long)(int)(cc + 0x35a)));
+    s16* pw = (s16*)(((long long)(int)(cc + 0x8e)));
 
     u16 idx = *(u16*)(cc + 0x35a);
     s16 d = data_02082214[(idx >> 4) * 2 + 1];
@@ -29,7 +29,7 @@ void func_ov096_02136e54(void* c, int a)
     *pw += 0x2c00;
     *(s32*)(cc + 0xd8) = *(s32*)(cc + 0x80) * 0x514;
     *(s32*)(cc + 0xdc) = *(s32*)(cc + 0x84) * 0xfa0;
-    *(s32*)(((long long)(int)(cc + 0x80)) & 0xFFFFFFFFFFFFFFFFLL) <<= 1;
-    *(s32*)(((long long)(int)(cc + 0x84)) & 0xFFFFFFFFFFFFFFFFLL) <<= 2;
-    *(s32*)(((long long)(int)(cc + 0x88)) & 0xFFFFFFFFFFFFFFFFLL) <<= 1;
+    *(s32*)(((long long)(int)(cc + 0x80))) <<= 1;
+    *(s32*)(((long long)(int)(cc + 0x84))) <<= 2;
+    *(s32*)(((long long)(int)(cc + 0x88))) <<= 1;
 }

--- a/src/func_ov096_02136fd4.c
+++ b/src/func_ov096_02136fd4.c
@@ -3,7 +3,7 @@ typedef int Fix12i;
 extern void func_ov096_02136e54(Actor* t, int x);
 extern Actor* _ZN5Actor13ClosestPlayerEv(Actor* self);
 extern Fix12i Vec3_HorzDist(const void* a, const void* b);
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((long long)(int)(p))
 void func_ov096_02136fd4(Actor* thiz)
 {
     char* c = (char*)thiz;

--- a/src/func_ov096_021372c0.c
+++ b/src/func_ov096_021372c0.c
@@ -7,7 +7,7 @@ extern void func_ov096_02136e54(void *self, int n);
 void func_ov096_021372c0(void *self);
 }
 
-#define M(p) ((long long)(int)(p) & 0xFFFFFFFFFFFFFFFFLL)
+#define M(p) ((long long)(int)(p))
 
 void func_ov096_021372c0(void *self)
 {

--- a/src/func_ov098_021381e8.c
+++ b/src/func_ov098_021381e8.c
@@ -10,5 +10,5 @@ void func_ov098_021381e8(char *c)
     func_ov098_02138ce0(c);
     func_ov098_02139850(c);
     func_ov098_021397c8(c);
-    (*(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF)) &= ~0xe0000;
+    (*(int *)(((int)c + 0xb0))) &= ~0xe0000;
 }

--- a/src/func_ov098_02138238.c
+++ b/src/func_ov098_02138238.c
@@ -38,7 +38,7 @@ void func_ov098_02138238(void *thiz)
     if (t4 == false) {
       void *p = *(void **)(c + 0xd0);
       if (p != 0) {
-        int *src = (int *)(int)(((long long)(int)((char *)p + 0x5c)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *src = (int *)(int)(((long long)(int)((char *)p + 0x5c)));
         *(int *)(c + 0x5c) = src[0];
         *(int *)(c + 0x60) = src[1];
         *(int *)(c + 0x64) = src[2];

--- a/src/func_ov098_02138318.c
+++ b/src/func_ov098_02138318.c
@@ -7,5 +7,5 @@ void ArrowSignRight_AfterClsn(char *c)
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;
     *(int *)(c + 0x98) = 0;
-    *(int *)(((int)c + 0x57c) & 0xFFFFFFFFFFFFFFFF) &= ~0x2000;
+    *(int *)(((int)c + 0x57c)) &= ~0x2000;
 }

--- a/src/func_ov098_02138484.c
+++ b/src/func_ov098_02138484.c
@@ -2,11 +2,11 @@ void func_ov098_02138484(char *c)
 {
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;
-    *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) &= ~0x80000;
+    *(int *)(((int)c + 0xb0)) &= ~0x80000;
     *(unsigned char *)(c + 0x604) = 3;
     *(int *)(c + 0xa8) = *(unsigned char *)(c + 0x604) * 0xa000;
     *(int *)(c + 0x98) = *(unsigned char *)(c + 0x604) * 0x5000;
     *(int *)(c + 0xd0) = 0;
     *(int *)(c + 0x5e4) = 0;
-    *(int *)(((int)c + 0x57c) & 0xFFFFFFFFFFFFFFFF) &= ~0x2000;
+    *(int *)(((int)c + 0x57c)) &= ~0x2000;
 }

--- a/src/func_ov098_021385e0.c
+++ b/src/func_ov098_021385e0.c
@@ -1,6 +1,6 @@
 extern short data_02082214[];
 
-#define ADDR(p) ((int *)(((long long)(int)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define ADDR(p) ((int *)(((long long)(int)(p))))
 
 void func_ov098_021385e0(char *self)
 {

--- a/src/func_ov098_02138818.c
+++ b/src/func_ov098_02138818.c
@@ -31,5 +31,5 @@ void func_ov098_02138818(char *self)
     *(void **)(self + 0x5e8) = *(void **)(self + 0x5e4);
     *(void **)(self + 0x5e4) = 0;
 
-    *(int *)(((long long)(int)(self + 0x57c)) & 0xFFFFFFFFFFFFFFFFLL) |= 0x2000;
+    *(int *)(((long long)(int)(self + 0x57c))) |= 0x2000;
 }

--- a/src/func_ov098_021389cc.c
+++ b/src/func_ov098_021389cc.c
@@ -1,7 +1,7 @@
 void func_ov098_021389cc(char *c)
 {
     *(int *)(c + 0x98) = 0;
-    *(int *)(((int)c + 0x57c) & 0xFFFFFFFFFFFFFFFF) &= ~0x2000;
+    *(int *)(((int)c + 0x57c)) &= ~0x2000;
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;
 }

--- a/src/func_ov098_02138e6c.cpp
+++ b/src/func_ov098_02138e6c.cpp
@@ -51,7 +51,7 @@ extern "C" void func_ov098_02138e6c(char *c)
     if (*(u32*)(c + 0x588) == 0) return;
 
     if ((*(u32*)(c + 0x584) & 0x40000) != 0) {
-        u32 *pp = (u32 *)(((int)c + 0x57c) & 0xFFFFFFFFFFFFFFFF);
+        u32 *pp = (u32 *)(((int)c + 0x57c));
         *(u8*)(c + 0x606) = 0x3c;
         *pp = *pp & ~0x8000u;
     }

--- a/src/func_ov098_02139228.cpp
+++ b/src/func_ov098_02139228.cpp
@@ -87,7 +87,7 @@ extern "C" int func_ov098_02139228(char *c)
     _Z14ApproachLinearRiii((int *)(c + 0x5f4), *(s32 *)(c + 0x5f0), 0x800);
 
     if ((*(s32 *)(c + 0x4e0) | *(s32 *)(c + 0x98)) == 0) {
-        int *p = (int *)(((int)c + 0x57c) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)c + 0x57c));
         *p &= ~0x2000;
         return 0;
     }

--- a/src/func_ov098_02139850.c
+++ b/src/func_ov098_02139850.c
@@ -47,7 +47,7 @@ void func_ov098_02139850(char* self)
             char* res = _ZN5Actor11UpdateCarryER6PlayerRK7Vector3(self, *(char**)(self + 0x5e4), (struct Vector3*)(self + 0x4f4));
             *(struct Matrix4x3*)(self + 0xf0) = *(struct Matrix4x3*)res;
         }
-        *(u32*)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) |= 0x4000000;
+        *(u32*)(((int)self + 0xb0)) |= 0x4000000;
     }
     return;
 
@@ -66,7 +66,7 @@ other:
         *(int*)(self + 0x4f8) = 0;
         *(int*)(self + 0x4fc) = 0;
         if (_ZNK12WithMeshClsn10IsOnGroundEv(self + 0x320) != 0) {
-            *(u32*)(((int)self + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x4000000;
+            *(u32*)(((int)self + 0xb0)) &= ~0x4000000;
         }
     }
 }

--- a/src/func_ov098_0213ad08.c
+++ b/src/func_ov098_0213ad08.c
@@ -29,7 +29,7 @@ void func_ov098_0213ad08(char* self) {
         *(int*)(self + 0x180) = 3;
         *(u8*)(self + 0x185) = 0;
         *(char**)(self + 0x158) = a;
-        *(int*)(((int)self + 0x13c) & 0xFFFFFFFFFFFFFFFF) |= 1;
+        *(int*)(((int)self + 0x13c)) |= 1;
         _ZN5Sound9PlayBank3EjRK7Vector3(0x14b, self + 0x74);
     }
 }

--- a/src/func_ov098_0213b7e8.c
+++ b/src/func_ov098_0213b7e8.c
@@ -22,7 +22,7 @@ void Cannon_Kill(char *c)
             }
         } else {
             if (_Z14ApproachLinearRiii((int *)(c + 0x3bc), 0x300, *(int *)(c + 0x3b8)) != 0)
-                *(int *)(((int)c + 0x3c0) & 0xFFFFFFFFFFFFFFFF) += 1;
+                *(int *)(((int)c + 0x3c0)) += 1;
         }
         *(int *)(c + 0x3b8) = _ZN4cstd4fdivEii((int)(((long long)*(int *)(c + 0x3b8) * 0xb00 + 0x800) >> 12), 0x1000);
         *(int *)(c + 0x84) = *(int *)(c + 0x3bc);
@@ -32,7 +32,7 @@ void Cannon_Kill(char *c)
         int approach = _Z14ApproachLinearRiii((int *)(c + 0x3bc), 0x1000, *(int *)(c + 0x3b8));
         if (approach != 0) {
             char *player;
-            int *pst = (int *)(((int)c + 0x3c0) & 0xFFFFFFFFFFFFFFFF);
+            int *pst = (int *)(((int)c + 0x3c0));
             *pst = *pst + 1;
             *(int *)(c + 0xa8) = (*(u8 *)(c + 0x3b6) << 13) + 0x30000;
             *(int *)(c + 0x98) = 0x6000;

--- a/src/func_ov100_02140e44.cpp
+++ b/src/func_ov100_02140e44.cpp
@@ -29,7 +29,7 @@ void _ZN12CylinderClsn6UpdateEv(void* c);
 
 extern s16 data_02082214[];
 
-#define L(p) ((int)(((s64)(int)(p)) & 0xffffffffffffffffLL))
+#define L(p) ((int)(((s64)(int)(p))))
 
 extern "C" void func_ov100_02140e44(char* c)
 {

--- a/src/func_ov100_0214109c.cpp
+++ b/src/func_ov100_0214109c.cpp
@@ -26,7 +26,7 @@ void func_ov100_0214109c(void *t) {
         return;
     }
     if (st <= 0x14) return;
-    (*(int *)(((int)c + 0x3e0) & 0xFFFFFFFFFFFFFFFF)) += 0x40;
+    (*(int *)(((int)c + 0x3e0))) += 0x40;
     if (*(int*)(c+0x3e0) < 0x800) return;
     Actor_SetRanges(c, 0x32000, 0x32000, 0x1000000, 0x320000);
     *(short*)(c+0x3ee) = 0;

--- a/src/func_ov100_0214117c.cpp
+++ b/src/func_ov100_0214117c.cpp
@@ -31,7 +31,7 @@ extern "C" void func_ov100_0214117c(char* c)
         *(int*)(c + 0x98) = 0;
         *(int*)(c + 0x3e8) = 0;
         *(int*)(c + 0x3e4) = 6;
-        *(int*)(((long long)(int)(c + 0xb0)) & 0xffffffffffffffffLL) &= ~0x10000;
+        *(int*)(((long long)(int)(c + 0xb0))) &= ~0x10000;
     } else {
         _Z14ApproachLinearRiii((int*)(c + 0x98), 0x8000, 0x800);
     }

--- a/src/func_ov100_02141470.c
+++ b/src/func_ov100_02141470.c
@@ -15,7 +15,7 @@ void func_ov100_02141470(char *c)
         Vec3_VertAngle(c + 0x5c, c + 0x3d4), 0x50);
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);
 
-    p = (int *)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL);
+    p = (int *)(((long long)(int)(c + 0x60)));
     *p = *p - ((int)(((long long)*(int *)(c + 0x98)
         * data_02082214[(*(unsigned short *)(c + 0x92) >> 4) * 2] + 0x800) >> 12)
         + (short)data_02082214[
@@ -23,7 +23,7 @@ void func_ov100_02141470(char *c)
         * (short)20 / 4);
 
     {
-        int *cnt = (int *)(((long long)(int)(c + 0x3e8)) & 0xFFFFFFFFFFFFFFFFLL);
+        int *cnt = (int *)(((long long)(int)(c + 0x3e8)));
         *cnt = *cnt + 1;
         if (*(int *)(c + 0x3e8) > 100)
             *(int *)(c + 0x3e8) = 0;

--- a/src/func_ov100_02141fb0.cpp
+++ b/src/func_ov100_02141fb0.cpp
@@ -51,7 +51,7 @@ extern "C" void func_ov100_02141fb0(Obj *thiz)
     if ((fl & 0x10) != 0) {
         Vector3_16 s;
         u32 r = thiz->m();
-        *(int *)(((int)c + 0x60) & 0xFFFFFFFFFFFFFFFF) += r;
+        *(int *)(((int)c + 0x60)) += r;
         s.x = 0; s.y = 0; s.z = 0;
         func_020ada40(c, &s, a, 0);
         _ZN12WithMeshClsn15ClearGroundFlagEv(c + 0x110);

--- a/src/func_ov100_021424c0.c
+++ b/src/func_ov100_021424c0.c
@@ -57,7 +57,7 @@ int func_ov100_021424c0(char *c)
         *(u8 *)(c + 0x3d0) = 3;
         if (*(u8 *)(c + 0x3d0) != 4 && _ZNK12WithMeshClsn10IsOnGroundEv(c + 0x110) != 0) {
             *(int *)(c + 0xa8) = 0;
-            *(int *)(int)(((long long)(int)(c + 0x60)) & 0xFFFFFFFFFFFFFFFFLL) += 0xf000;
+            *(int *)(int)(((long long)(int)(c + 0x60))) += 0xf000;
         } else {
             func_ov100_02142130(c);
         }
@@ -86,8 +86,8 @@ int func_ov100_021424c0(char *c)
             } else if (*(u8 *)(c + 0x3d0) == 4) {
                 _Z14ApproachLinearRiii(c + 0x98, 0x23000, 0x400);
             } else {
-                *(int *)(int)(((long long)(int)(c + 0xa4)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0xd4);
-                *(int *)(int)(((long long)(int)(c + 0xac)) & 0xFFFFFFFFFFFFFFFFLL) += *(int *)(c + 0xdc);
+                *(int *)(int)(((long long)(int)(c + 0xa4))) += *(int *)(c + 0xd4);
+                *(int *)(int)(((long long)(int)(c + 0xac))) += *(int *)(c + 0xdc);
                 *(int *)(c + 0x98) = Vec3_HorzLen(c + 0xa4);
             }
         }

--- a/src/func_ov100_0214272c.cpp
+++ b/src/func_ov100_0214272c.cpp
@@ -59,8 +59,8 @@ ground:
         int *pa4;
         int *pac;
 
-        pa4 = (int *)(((int)c + 0xa4) & 0xFFFFFFFFFFFFFFFFLL);
-        pac = (int *)(((int)c + 0xac) & 0xFFFFFFFFFFFFFFFFLL);
+        pa4 = (int *)(((int)c + 0xa4));
+        pac = (int *)(((int)c + 0xac));
 
         *pa4 = *pa4 + *(int *)(c + 0xd4) * 3;
         *pac = *pac + *(int *)(c + 0xdc) * 3;

--- a/src/func_ov100_021437d4.c
+++ b/src/func_ov100_021437d4.c
@@ -15,7 +15,7 @@ extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void Matrix4x3_ApplyInPlaceToRotationX(void* mF, int angX);
 extern void Vec3_Sub(struct Vector3* out, struct Vector3* a, struct Vector3* b);
 extern void Vec3_MulScalar(struct Vector3* out, const struct Vector3* in, int scale);
-#define M(p) ((long long)(int)(p) & 0xffffffffffffffffLL)
+#define M(p) ((long long)(int)(p))
 
 
 void func_ov100_021437d4(char* thisx)

--- a/src/func_ov100_02144528.c
+++ b/src/func_ov100_02144528.c
@@ -50,7 +50,7 @@ int func_ov100_02144528(char* c, char* pl)
                 if (data_ov100_02148704[0] != 0)
                     _ZN6Player11OpenBigDoorEv(pl);
             } else {
-                unsigned char* q = (unsigned char*)(((int)c + 0x145) & 0xFFFFFFFFFFFFFFFF);
+                unsigned char* q = (unsigned char*)(((int)c + 0x145));
                 *q += 1;
             }
         } else {

--- a/src/func_ov100_02144730.cpp
+++ b/src/func_ov100_02144730.cpp
@@ -48,13 +48,13 @@ extern "C" int func_ov100_02144730(char* self, char* arg1)
         *(s8*)(arg1 + 0xcc) = t;
         ChangeArea(t);
         {
-            int* p = (int*)(((long long)(int)(*(char**)&data_0209f318 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((long long)(int)(*(char**)&data_0209f318 + 0x154)));
             *p &= ~0xc00;
         }
         func_02012694(*(int*)(self + 8) == 0x10 ? 7 : 5, self + 0x74);
     } else if (*(s8*)(self + 0x144) != 0) {
         if (_ZNK9Animation12WillHitFrameEi(self + 0x124, (u16)(_ZNK9Animation13GetFrameCountEv(self + 0x124) - 0x1c)) != 0) {
-            int* p = (int*)(((long long)(int)(*(char**)&data_0209f318 + 0x154)) & 0xFFFFFFFFFFFFFFFFLL);
+            int* p = (int*)(((long long)(int)(*(char**)&data_0209f318 + 0x154)));
             *p &= ~0xc00;
             if (*(int*)(self + 8) != 0xd) {
                 _ZN5Sound13PlayCharVoiceEjjRK7Vector3(*(unsigned char*)(&data_0209caa0 + 0x41), 0x21, self + 0x74);

--- a/src/func_ov100_02145080.c
+++ b/src/func_ov100_02145080.c
@@ -17,7 +17,7 @@ int func_ov100_02145080(char* c, void* arg1)
             goto ret1;
         _ZN5Sound7PlaySubEjjj5Fix12IiEb(0x2b, 0x7f, 0, 0x7222, 0);
         {
-            unsigned char* p = (unsigned char*)(((int)c + 0x145) & 0xFFFFFFFFFFFFFFFF);
+            unsigned char* p = (unsigned char*)(((int)c + 0x145));
             *p += 1;
         }
         return 0;

--- a/src/func_ov100_02146280.c
+++ b/src/func_ov100_02146280.c
@@ -1,6 +1,6 @@
 void func_ov100_02146280(char *c)
 {
     if (*(unsigned char *)(c + 0x158) != 0) {
-        (*(unsigned char *)(((int)c + 0x158) & 0xFFFFFFFFFFFFFFFF))--;
+        (*(unsigned char *)(((int)c + 0x158)))--;
     }
 }

--- a/src/func_ov100_0214629c.cpp
+++ b/src/func_ov100_0214629c.cpp
@@ -14,7 +14,7 @@ void func_ov100_0214629c(char* c, int a1)
     *(unsigned char*)(c + 0x159) = 0;
     *(int*)(c + 0x13c) = a1;
     if (*(unsigned char*)(c + 0x15c) != 0) {
-        short* p = (short*)(((long long)(int)(c + 0x94)) & 0xFFFFFFFFFFFFFFFFLL);
+        short* p = (short*)(((long long)(int)(c + 0x94)));
         *p = *p & 0x8000;
         unsigned char v = *(unsigned char*)(c + 0x15c);
         if (v == 3) {

--- a/src/func_ov100_021464f4.cpp
+++ b/src/func_ov100_021464f4.cpp
@@ -24,7 +24,7 @@ extern "C" void func_ov100_021464f4(char *c){
     *(int*)(c+0x130) = 0x1000;
   }
   if(*(int*)(c+0x98) < *(int*)(c+0x144)){
-    int *p98 = (int*)(((int)c + 0x98) & 0xFFFFFFFFFFFFFFFF);
+    int *p98 = (int*)(((int)c + 0x98));
     *p98 += 0x800;
   }
   pl = _ZN5Actor13ClosestPlayerEv(c);

--- a/src/func_ov102_0214aa18.cpp
+++ b/src/func_ov102_0214aa18.cpp
@@ -37,7 +37,7 @@ extern "C" int func_ov102_0214aa18(Actor *self)
         }
         if (((WithMeshClsn2*)(s + 0x144))->IsOnGround() == 0)
             return 1;
-        int *fl = (int*)(((int)s + 0x128) & 0xFFFFFFFFFFFFFFFF);
+        int *fl = (int*)(((int)s + 0x128));
         *fl = *fl & ~2;
         *(unsigned char*)(s + 0x3f5) = 3;
         func_ov102_0214c0b8(s);

--- a/src/func_ov102_0214ab1c.c
+++ b/src/func_ov102_0214ab1c.c
@@ -22,7 +22,7 @@ int func_ov102_0214ab1c(u8 *self)
         goto ret0;
     }
 
-    *(unsigned int *)(((int)(self + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x10000000u;
+    *(unsigned int *)(((int)(self + 0xb0))) &= ~0x10000000u;
 
     void *player = *(void **)(self + 0xd0);
     if (player != 0) {
@@ -33,7 +33,7 @@ int func_ov102_0214ab1c(u8 *self)
             goto shocked;
         }
         if (func_ov102_0214b248(self) == 0) {
-            *(unsigned int *)(((int)(self) + 0xb0) & 0xFFFFFFFFFFFFFFFFLL) &= ~0xe0000u;
+            *(unsigned int *)(((int)(self) + 0xb0)) &= ~0xe0000u;
             self[0x107] = 0;
             return 1;
         }
@@ -49,7 +49,7 @@ after_cannon:
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(self + 0x300, *(void **)((char *)&data_ov102_0214e9c0 + 4), 0, 0x1000, 0);
         *(u16 *)(self + 0x3e8) = 0x200;
         *(int *)(self + 0x9c) = -0x2000;
-        *(unsigned int *)(((int)(self + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~2u;
+        *(unsigned int *)(((int)(self + 0x128))) &= ~2u;
     }
 
     if (r4 == 2) {
@@ -64,7 +64,7 @@ after_cannon:
 
     if (self[0x107] != 0) {
         if (*(u16 *)(self + 0x104) == 5) {
-            *(unsigned int *)(((int)(self + 0x128)) & 0xFFFFFFFFFFFFFFFFLL) &= ~0x8000u;
+            *(unsigned int *)(((int)(self + 0x128))) &= ~0x8000u;
         }
     }
 

--- a/src/func_ov102_0214ad40.c
+++ b/src/func_ov102_0214ad40.c
@@ -17,7 +17,7 @@ void func_ov102_0214ad40(char *c)
     func_ov102_0214b384(c, 4);
     *(unsigned char *)(c + 0x3f5) = 3;
     {
-        int *p = (int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF);
+        int *p = (int *)(((int)c + 0x128));
         int v = *p;
         *p = v & ~2;
     }

--- a/src/func_ov102_0214ae1c.c
+++ b/src/func_ov102_0214ae1c.c
@@ -13,7 +13,7 @@ extern void func_ov102_0214baa0(void *c);
 void func_ov102_0214ae1c(char *c) {
     Vec3 v;
     int y, z, w;
-    *(unsigned int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~0x8000;
+    *(unsigned int *)(((int)c + 0x128)) &= ~0x8000;
     y = *(int *)(c + 0x60);
     z = *(int *)(c + 0x64);
     w = y + 0x78000;

--- a/src/func_ov102_0214b128.cpp
+++ b/src/func_ov102_0214b128.cpp
@@ -11,7 +11,7 @@ extern void _ZN12WithMeshClsn15ClearGroundFlagEv(void*);
 void func_ov102_0214b128(char* c) {
     int t;
     if (_ZN5Actor7FindEggER12CylinderClsn(c, c + 0x110) || (*(int*)(c + 0x130) & 0x20000)) {
-        int* p = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0xb0));
         *(short*)(c + 0x3ea) = 4;
         *p = *p & ~1;
         *(int*)(c + 0x98) = 0;

--- a/src/func_ov102_0214b248.cpp
+++ b/src/func_ov102_0214b248.cpp
@@ -24,7 +24,7 @@ extern "C" int func_ov102_0214b248(char *c)
     {
         unsigned short st = *(unsigned short *)(c + 0x3ea);
         if (st != 0 && st <= 4) {
-            *(int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~0x8000;
+            *(int *)(((int)c + 0x128)) &= ~0x8000;
             if (*(unsigned short *)(c + 0x3ea) == 1) {
                 func_ov102_0214ae1c(c);
                 return 0;
@@ -41,7 +41,7 @@ extern "C" int func_ov102_0214b248(char *c)
                 func_ov002_020ef228(c + 0x144, (int)c);
             }
             {
-                int *f = (int *)(((long long)(int)(c + 0x128)) & 0xFFFFFFFFFFFFFFFFLL);
+                int *f = (int *)(((long long)(int)(c + 0x128)));
                 *f &= ~4;
                 if (*(unsigned short *)(c + 0x3ea) == 2) {
                     *f |= 0x4000;

--- a/src/func_ov102_0214b384.c
+++ b/src/func_ov102_0214b384.c
@@ -4,5 +4,5 @@ void func_ov102_0214b384(void *arg0, unsigned int arg1) {
     if (cur == 0 || cur > arg1) {
         *(unsigned short *)(p + 0x3ea) = (unsigned short)arg1;
     }
-    *(unsigned int *)(((long long)(int)(p + 0xb0)) & 0xFFFFFFFFFFFFFFFFLL) &= ~1u;
+    *(unsigned int *)(((long long)(int)(p + 0xb0))) &= ~1u;
 }

--- a/src/func_ov102_0214ba30.cpp
+++ b/src/func_ov102_0214ba30.cpp
@@ -16,7 +16,7 @@ extern "C" void func_ov102_0214ba30(char* c)
     }
     func_ov102_0214c0b8(c);
     {
-        int* f = (int*)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF);
+        int* f = (int*)(((int)c + 0xb0));
         *f = *f | 0x10000001;
     }
     *(unsigned char*)(c + 0x3f3) = 1;

--- a/src/func_ov102_0214baa0.c
+++ b/src/func_ov102_0214baa0.c
@@ -7,9 +7,9 @@ extern void func_0203568c(int *value, int target);
 extern void func_02035684(int *value, int target);
 
 #define LAUNDER_PTR(ptr) \
-    ((int *)(int)(((long long)(int)(ptr)) & 0xffffffffffffffffLL))
+    ((int *)(int)(((long long)(int)(ptr))))
 #define LAUNDER_32(base, offset) \
-    ((int *)(int)(((long long)((int)(base) + (offset))) & 0xffffffffffffffffLL))
+    ((int *)(int)(((long long)((int)(base) + (offset)))))
 
 void func_ov102_0214baa0(char *self)
 {

--- a/src/func_ov102_0214bd20.cpp
+++ b/src/func_ov102_0214bd20.cpp
@@ -14,7 +14,7 @@ extern "C" void func_ov102_0214bd20(char* c)
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x300, (void*)data_ov102_0214e9c8.w[1], 0, 0x1000, 0);
     func_ov102_0214b384(c, 0x96);
     {
-        int* p = (int*)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF);
+        int* p = (int*)(((int)c + 0x128));
         *p = *p | 2;
         *p = *p & ~4;
     }

--- a/src/func_ov102_0214beb4.c
+++ b/src/func_ov102_0214beb4.c
@@ -6,13 +6,13 @@ extern int data_0209e650;
 void func_ov102_0214beb4(char* c)
 {
     *(int*)(c + 0x3dc) = 1;
-    *(unsigned char*)(((int)c + 0x3f2) & 0xFFFFFFFFFFFFFFFF) += 1;
+    *(unsigned char*)(((int)c + 0x3f2)) += 1;
     char* o = *(char**)(c + 0x38c);
     if (o == 0) {
         *(short*)(c + 0x300 + 0xee) = Vec3_HorzAngle(c + 0x5c, c + 0x3c4);
         if (Vec3_Dist(c + 0x5c, c + 0x3c4) >= 0x500000) return;
         unsigned int r = RandomIntInternal(&data_0209e650);
-        *(short*)(((int)c + 0x3ee) & 0xFFFFFFFFFFFFFFFF) += (short)(r >> 0x10);
+        *(short*)(((int)c + 0x3ee)) += (short)(r >> 0x10);
         return;
     }
     *(short*)(c + 0x300 + 0xee) = Vec3_HorzAngle(c + 0x5c, o + 0x5c);

--- a/src/func_ov102_0214d020.c
+++ b/src/func_ov102_0214d020.c
@@ -1,6 +1,6 @@
 int func_ov102_0214d020(char *c)
 {
-    *(int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) |= 2;
-    *(int *)(((int)c + 0x128) & 0xFFFFFFFFFFFFFFFF) &= ~4;
+    *(int *)(((int)c + 0x128)) |= 2;
+    *(int *)(((int)c + 0x128)) &= ~4;
     return 1;
 }

--- a/src/func_ov102_0214d044.cpp
+++ b/src/func_ov102_0214d044.cpp
@@ -17,8 +17,8 @@ extern "C" int func_ov102_0214d044(char* c)
 copy:
     {
         void* base = *(void**)(c + 0x3c0);
-        int* s = (int*)(((int)base + 0x5c) & 0xFFFFFFFFFFFFFFFF);
-        short* a = (short*)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF);
+        int* s = (int*)(((int)base + 0x5c));
+        short* a = (short*)(((int)c + 0x8e));
         int v0 = s[0];
         int ret = 1;
         *(int*)(c + 0x5c) = v0;

--- a/src/func_ov102_0214d0bc.cpp
+++ b/src/func_ov102_0214d0bc.cpp
@@ -3,7 +3,7 @@ extern "C" {
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
 int func_ov102_0214d0bc(char* c){
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0x110, c, 0, 0, 0x100002, 0);
-  (*(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF)) &= ~3;
+  (*(int *)(((int)c + 0xb0))) &= ~3;
   *(unsigned char*)(c+0x3c6) = 0x64;
   return 1;
 }

--- a/src/func_ov102_0214d114.c
+++ b/src/func_ov102_0214d114.c
@@ -3,7 +3,7 @@ extern void _ZN12CylinderClsn6UpdateEv(void *self);
 
 int func_ov102_0214d114(char *c)
 {
-    *(short *)(((int)c + 0x8e) & 0xFFFFFFFFFFFFFFFF) += 0x1000;
+    *(short *)(((int)c + 0x8e)) += 0x1000;
     _ZN12CylinderClsn5ClearEv(c + 0x378);
     _ZN12CylinderClsn6UpdateEv(c + 0x378);
     return 1;

--- a/src/func_ov102_0214d1b8.c
+++ b/src/func_ov102_0214d1b8.c
@@ -3,8 +3,8 @@ int func_ov102_0214d1b8(char *c)
     *(int *)(c + 0x98) = 0;
 
     if (*(unsigned char *)(c + 0x3c5) != 0) {
-        *(int *)(((int)c + 0xb0) & 0xFFFFFFFFFFFFFFFF) |= 0x80;
-        *(int *)(((int)c + 0x12c) & 0xFFFFFFFFFFFFFFFF) |= 0x1000;
+        *(int *)(((int)c + 0xb0)) |= 0x80;
+        *(int *)(((int)c + 0x12c)) |= 0x1000;
         *(int *)(c + 0x9c) = 0;
     }
 

--- a/src/nds_printt.c
+++ b/src/nds_printt.c
@@ -22,7 +22,7 @@ void nds_printt(unsigned short *dest, char *str, int value)
         } else if (c >= 0x41 && c <= 0x5a) {
             out = c;
         } else {
-            out = (int)(((long long)(int)c) & 0xFFFFFFFFFFFFFFFFLL);
+            out = (int)(((long long)(int)c));
         }
         func_020147bc(p, (char)out);
     }


### PR DESCRIPTION
Removes the no-op & 0xFFFFFFFFFFFFFFFF mask from 95 files where it was not load-bearing -- the file still reproduces the ROM byte-for-byte without it. Masks that the match genuinely needs were kept. This is the "compiler-steering macro" readability item: keep the launder only on the sites that require it.
