### PR TITLE
validate: check renamed src files (--diff-filter=AM dropped every R entry)

### DIFF
--- a/tools/pr_linkcheck.py
+++ b/tools/pr_linkcheck.py
@@ -83,6 +83,43 @@ def build_symbol_index():
     return idx
 
 
+def _changed_paths(base):
+    """Paths this branch adds, modifies, or RENAMES, relative to ``base``.
+
+    Renames have to be in scope. ``--diff-filter=AM`` excludes ``R``, and git pairs a
+    moved file as a rename whenever the content is similar enough -- so `git mv` plus an
+    edit to the `#include` line lands as `R098`, is filtered out, and the branch is
+    reported green having compiled nothing. That is exactly the shape of a directory
+    reorganisation, and of any change that renames a file to its real symbol while
+    touching the body.
+
+    The one rename that is genuinely safe to skip is a move that keeps the filename AND
+    the content byte-for-byte (`R100`, same basename): the symbol is unchanged, and the
+    bytes cannot move because headers resolve from `-i include`, never relative to the
+    source's own directory (candidates are compiled from a temp copy -- see
+    reloc_audit.winning_object). A rename that changes the basename changes the symbol
+    the file claims, so it is re-checked even at 100% similarity."""
+    out = subprocess.run(
+        ["git", "diff", "--name-status", "-M", "--diff-filter=AMR", f"{base}...HEAD"],
+        cwd=REPO, capture_output=True, text=True, check=True).stdout
+    paths = []
+    for line in out.splitlines():
+        fields = line.split("\t")
+        if len(fields) < 2:
+            continue
+        status = fields[0]
+        if status.startswith("R") and len(fields) >= 3:
+            old, new = fields[1], fields[2]
+            if (status == "R100"
+                    and pathlib.PurePosixPath(old).name
+                    == pathlib.PurePosixPath(new).name):
+                continue
+            paths.append(new)
+        else:
+            paths.append(fields[1])
+    return paths
+
+
 def changed_src_files(args):
     """Every compiled file the PR/branch puts at risk.
 
@@ -99,10 +136,7 @@ def changed_src_files(args):
             cwd=REPO, capture_output=True, text=True, check=True).stdout
         paths = out.splitlines()
     else:
-        out = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=AM", f"{args.base}...HEAD"],
-            cwd=REPO, capture_output=True, text=True, check=True).stdout
-        paths = out.splitlines()
+        paths = _changed_paths(args.base)
     keep, headers = [], []
     for p in paths:
         p = p.strip().replace("\\", "/")

--- a/tools/test_pr_linkcheck_renames.py
+++ b/tools/test_pr_linkcheck_renames.py
@@ -1,0 +1,81 @@
+"""The rename cases `_changed_paths` has to get right.
+
+Regression test for the hole where `--diff-filter=AM` dropped every `R` entry, so a
+`git mv` plus an edit to the `#include` line was reported green having compiled nothing.
+Builds throwaway git repos rather than asserting against this repo's history, so the
+cases stay readable and the test does not rot as main moves.
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import pr_linkcheck as PL  # noqa: E402
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+def _commit(repo, msg):
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", msg)
+
+
+class RenameScope(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        _git(self.repo, "init", "-q", ".")
+        (self.repo / "src").mkdir()
+        # big enough that git pairs a small edit as a rename rather than add+delete
+        body = "".join(f"int f{i}(void) {{ return {i}; }}\n" for i in range(60))
+        (self.repo / "src" / "moved_edited.c").write_text('#include "old.h"\n' + body)
+        (self.repo / "src" / "moved_clean.c").write_text(body)
+        (self.repo / "src" / "renamed.c").write_text(body)
+        (self.repo / "src" / "plain.c").write_text("int p(void) { return 0; }\n")
+        _commit(self.repo, "base")
+        self._orig_repo = PL.REPO
+        PL.REPO = self.repo
+
+    def tearDown(self):
+        PL.REPO = self._orig_repo
+        self.tmp.cleanup()
+
+    def _changed(self):
+        return set(PL._changed_paths("HEAD~1"))
+
+    def test_move_with_edit_is_checked(self):
+        """The case that was silently skipped: `git mv` + an edited include line."""
+        (self.repo / "src" / "sub").mkdir()
+        _git(self.repo, "mv", "src/moved_edited.c", "src/sub/moved_edited.c")
+        p = self.repo / "src" / "sub" / "moved_edited.c"
+        p.write_text(p.read_text().replace("old.h", "new.h"))
+        _commit(self.repo, "move+edit")
+        self.assertIn("src/sub/moved_edited.c", self._changed())
+
+    def test_pure_move_same_name_is_skipped(self):
+        """Same basename, byte-identical content: the symbol and the bytes cannot move."""
+        (self.repo / "src" / "sub").mkdir()
+        _git(self.repo, "mv", "src/moved_clean.c", "src/sub/moved_clean.c")
+        _commit(self.repo, "pure move")
+        self.assertEqual(self._changed(), set())
+
+    def test_rename_to_a_new_symbol_is_checked(self):
+        """R100 but a different basename -- the file now claims a different symbol."""
+        _git(self.repo, "mv", "src/renamed.c", "src/RealName.c")
+        _commit(self.repo, "rename symbol")
+        self.assertIn("src/RealName.c", self._changed())
+
+    def test_plain_add_and_modify_still_reported(self):
+        (self.repo / "src" / "plain.c").write_text("int p(void) { return 1; }\n")
+        (self.repo / "src" / "added.c").write_text("int a(void) { return 0; }\n")
+        _commit(self.repo, "add+modify")
+        self.assertEqual(self._changed(), {"src/plain.c", "src/added.c"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The hole

`pr_linkcheck.changed_src_files` diffed with `--diff-filter=AM`, which excludes `R`.
Git pairs a moved file as a rename whenever content is similar enough, so **`git mv`
plus an edit to the body lands as `R0NN`, is filtered out, and the branch goes green
having compiled nothing.**

Measured, not hypothetical — over the last 40 commits on `main`, **20 `src/` files were
renamed with an edit and the gate compiled none of them**. That is the #891–#899 batches
which rename `func_<addr>` files to real symbols and rewrite definitions, call sites and
header decls:

| | |
|---|---|
| `R097` | `func_0207328c.c` → `__destroy_arr.c` |
| `R089` | `func_ov004_020ad674.c` → `GetGameLanguage.c` |
| `R066` | `func_0203d6d0.c` → `Vec2_Sub.c` |

**Nothing landed broken** — I link-checked all 20 by hand: 19 `VERIFIED`, 1 `BLIND-1`
with `diffs: []`. The gate simply was not looking.

## The fix

`--diff-filter=AMR` with `--name-status -M`, taking the destination path.

One rename is still skipped: a move that keeps the filename **and** the content
byte-for-byte (`R100`, same basename). The symbol is unchanged, and the bytes cannot
move — headers resolve from `-i include`, never relative to the source's own directory,
since candidates compile from a temp copy in `reloc_audit.winning_object`. A rename that
changes the basename changes the symbol the file claims, so it is re-checked even at
100% similarity.

## Validation

- `tools/test_pr_linkcheck_renames.py` — 4 cases: move+edit checked, pure move skipped,
  rename-to-new-symbol checked, plain add/modify unaffected.
- Differential against real history: over 39 commit ranges the new filter **loses
  nothing** the old one found — identical on 33, strictly more on 6.
- Existing suite: `python -m unittest discover -s tools -p "test_*.py"` → 39 passed.

Tools/CI only, no `src/` changes, per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJbwQmti26NSY5YGc4SeM2