### PR TITLE
readable: consolidate 78 files onto shared types.h (byte-verified)

### DIFF
--- a/src/ARMMathLoadState.c
+++ b/src/ARMMathLoadState.c
@@ -1,6 +1,4 @@
-typedef unsigned long long u64;
-typedef unsigned short u16;
-
+#include "types.h"
 struct ARMMathState {
     u64 div_numer;
     u64 div_denom;

--- a/src/ARMMathSaveState.c
+++ b/src/ARMMathSaveState.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Pair { u32 a, b; };
 
 struct ARMMathState {

--- a/src/BigBoo_Spawn.cpp
+++ b/src/BigBoo_Spawn.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned int u32;
 void* _ZN9ActorBasenwEj(u32 sz);
 void _ZN8CapEnemyC2Ev(void* t);
 void _ZN25MovingCylinderClsnWithPosC1Ev(void* t);

--- a/src/Boo_Spawn.cpp
+++ b/src/Boo_Spawn.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned int u32;
 void* _ZN9ActorBasenwEj(u32 sz);
 void _ZN8CapEnemyC2Ev(void* t);
 void _ZN25MovingCylinderClsnWithPosC1Ev(void* t);

--- a/src/CopyTexPalFromLevelModel.c
+++ b/src/CopyTexPalFromLevelModel.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Tex { char* name; char pad[0x10]; };   /* stride 0x14 */
 struct Pal { char* name; char pad[0xc]; };     /* stride 0x10 */
 

--- a/src/CountStarsCollectedInLevelToDisplay.c
+++ b/src/CountStarsCollectedInLevelToDisplay.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern u8 _ZN8SaveData26CountStarsCollectedInLevelEj(u32 courseID);
 
 u8 CountStarsCollectedInLevelToDisplay(s32 courseID) {

--- a/src/Crash.c
+++ b/src/Crash.c
@@ -1,9 +1,6 @@
+#include "types.h"
 // Crash function at 0x02019740
 // IRQ disable, set crash flag, save registers and call crash screen, then loop forever
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern void _ZN3IRQ7DisableEv(void);
 extern void _ZN4CP1516WaitForInterruptEv(void);
 extern void func_0201a03c(u32 r0, u32 r1);

--- a/src/DMASyncFillTransfer.c
+++ b/src/DMASyncFillTransfer.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* DMASyncFillTransfer at 0x0205a1b4
  * Synchronous 32-bit DMA fill: waits for the DMA channel to be free, writes
  * the fill value into the channel's DMA fill register (0x040000E0 + ch*4),
@@ -13,10 +14,6 @@
  * writeback `str r2,[r1,r0,lsl#2]!` (and, in turn, evacuates dst to ip at
  * entry exactly like the ROM).
  */
-
-typedef unsigned int u32;
-typedef volatile u32 vu32;
-
 extern void DMAStartTransferFB(u32 channel, void *src, void *dst, u32 cnt);
 
 void DMASyncFillTransfer(u32 channel, void *dst, u32 data, u32 size)

--- a/src/DMASyncHalfTransfer.c
+++ b/src/DMASyncHalfTransfer.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* DMASyncHalfTransfer at 0x0205a10c
  * Synchronous DMA transfer of numHalfs halfwords.
  * Waits for previous DMA, starts transfer, waits for completion.
  */
-
-typedef unsigned int u32;
-
 extern void DMAStartTransferFB(u32 channel, void *src, void *dst, u32 cnt);
 
 void DMASyncHalfTransfer(u32 channel, void *src, void *dst, u32 numHalfs)

--- a/src/DMASyncWordTransfer.c
+++ b/src/DMASyncWordTransfer.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* DMASyncWordTransfer at 0x0205a160
  * Synchronous 32-bit DMA transfer: waits for the DMA channel to be free,
  * starts a word copy, then waits again until completion.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 extern void DMAStartTransferFB(u8 channel, u32 src, u32 dest, u32 ctrl);
 
 static volatile u32* const DMA_BASE = (volatile u32*)0x040000b0;

--- a/src/DeathTable_ClearBit.c
+++ b/src/DeathTable_ClearBit.c
@@ -1,9 +1,5 @@
+#include "types.h"
 // DeathTable_ClearBit: clears the bit in the actor death table for the given deathTableID
-
-typedef signed char s8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern s8 LEVEL_ID;
 extern u32 ACTOR_DEATH_TABLE_ARR[];
 

--- a/src/DeathTable_GetBit.c
+++ b/src/DeathTable_GetBit.c
@@ -1,9 +1,5 @@
+#include "types.h"
 // DeathTable_GetBit: gets the bit from the actor death table for the given deathTableID
-
-typedef signed char s8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern s8 LEVEL_ID;
 extern u32 ACTOR_DEATH_TABLE_ARR[];
 

--- a/src/DeathTable_SetBit.c
+++ b/src/DeathTable_SetBit.c
@@ -1,9 +1,5 @@
+#include "types.h"
 // DeathTable_SetBit: sets the bit in the actor death table for the given deathTableID
-
-typedef signed char s8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern s8 LEVEL_ID;
 extern u32 ACTOR_DEATH_TABLE_ARR[];
 

--- a/src/DisableSoundPlayersForCredits.c
+++ b/src/DisableSoundPlayersForCredits.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* DisableSoundPlayersForCredits — sets all 10 sound players' sequence limit to 0.
  * Iterates the same player-default table at 0x0208e448, but ignores the maxSeq
  * field and passes 0 instead, disabling each player.
@@ -5,10 +6,6 @@
  * Callee: 0x0204fadc = Sound::Player::SetPlayableSeqCount(s32, s32)
  *   _ZN5Sound6Player19SetPlayableSeqCountEii
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 extern void _ZN5Sound6Player19SetPlayableSeqCountEii(s32 playerID, s32 maxSeq);
 
 typedef struct {

--- a/src/EnterBigBoosHaunt.c
+++ b/src/EnterBigBoosHaunt.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void LoadLevel(u32 levelID, u32 arg1, u32 arg2, u32 arg3, u32 arg4);
 
 void EnterBigBoosHaunt(void)

--- a/src/ExitMinigameMenu.c
+++ b/src/ExitMinigameMenu.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* ExitMinigameMenu at 0x0202ad78
  * Exits the minigame menu, either returning to rec room or fading to main menu.
  */
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern u8 RETURN_TO_REC_ROOM;  /* 0x0209f298 */
 extern u8 LEVEL_ID;            /* 0x0209f2f8 */
 

--- a/src/FS_InitFile.c
+++ b/src/FS_InitFile.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 void FS_InitFile(int *s)
 {
     s[0] = 0;

--- a/src/FUN_02029ab0.c
+++ b/src/FUN_02029ab0.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
+#include "types.h"
 extern void _ZN5Scene20SetAndStopColorFaderEv(void);
 
 typedef struct WipeEntry {

--- a/src/HitDeathPlane.c
+++ b/src/HitDeathPlane.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* HitDeathPlane at 0x02029b84
  * Handles player hitting a death plane: either restarts (SetNextLevel) or
  * triggers a scene fade, then always exits with StartExitFaderWipe.
  */
-
-typedef signed char s8;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern s8 NUM_LIVES[];
 
 extern void SetNextLevel(void);

--- a/src/InitControllerMode.c
+++ b/src/InitControllerMode.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 struct Ctrl { u8 mode; char pad[0x17]; };   /* stride 0x18 */
 struct Obj42 { char pad[0x42]; u8 f42; };
 

--- a/src/KillPlayer.c
+++ b/src/KillPlayer.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* KillPlayer at 0x02029b30
  * Kills the player: if lives remain, go to next level with reason 2,
  * otherwise trigger a game-over scene fade.  Then plays death sound.
  */
-
-typedef signed char s8;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern s8 NUM_LIVES[];
 
 extern void SetNextLevel(u32 reason);

--- a/src/LoadArchive.c
+++ b/src/LoadArchive.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct Entry {
     int field_0;     /* 0x0 */
     int field_4;     /* 0x4 */

--- a/src/LoadCompressedFileAt.c
+++ b/src/LoadCompressedFileAt.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *func_0201817c(u16 fileID);
 extern u32 func_02018ac4(void *buffer);
 extern void DecompressLZ16(void *source, void *dest);

--- a/src/LoadDebugFont.c
+++ b/src/LoadDebugFont.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN2GX11LoadBG1CharEPKvjj(const void *src, u32 offset, u32 size);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *src, u32 offset, u32 size);
 extern void func_02023408(void);

--- a/src/LoadFont3D.c
+++ b/src/LoadFont3D.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void* LoadFile(u32 fileID);
 extern void Deallocate(void* ptr);
 extern void* func_02054d88(void);

--- a/src/LoadLevel.c
+++ b/src/LoadLevel.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 extern s8 data_02092110;
 extern s8 data_02092118;
 extern s8 data_0209211c;

--- a/src/LoadLevelNoReturn.c
+++ b/src/LoadLevelNoReturn.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef signed char s8;
-
+#include "types.h"
 extern void LoadLevel(u32 levelID, u32 arg1, u32 arg2, u32 arg3, u32 arg4);
 
 extern s8 RETURN_LEVEL_ID;

--- a/src/LoadOverlay.c
+++ b/src/LoadOverlay.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 void func_02018c00(void *dst, int a, int id);
 int func_0203d7b8(void);
 struct Pair;

--- a/src/LoadTextNarcs.c
+++ b/src/LoadTextNarcs.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern s32 LoadArchive(s32 archiveID);
 extern s32 GetOwnerLanguage(void);
 

--- a/src/Message_DrawCenteredLine.c
+++ b/src/Message_DrawCenteredLine.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern short data_0209d6d4;
 extern int data_0209d708;
 extern int *data_0209d70c;

--- a/src/NormalizeVec3.c
+++ b/src/NormalizeVec3.c
@@ -1,8 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
-typedef unsigned long long u64;
-
+#include "types.h"
 void NormalizeVec3(int *v, int *out)
 {
     s64 sq;

--- a/src/NumStars.c
+++ b/src/NumStars.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* NumStars at 0x0201367c
  * Counts total stars collected across all levels and all star slots.
  */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
 extern int IsStarCollected(s8 courseID, s32 starID);
 
 u8 NumStars(void)

--- a/src/OS_SleepThread.c
+++ b/src/OS_SleepThread.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Node {
     char pad[0x64];
     u32 unk64;

--- a/src/OS_WakeupThread.c
+++ b/src/OS_WakeupThread.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Node {
     char pad[0x64];
     u32 unk64;

--- a/src/PrepareVsMode.c
+++ b/src/PrepareVsMode.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* PrepareVsMode at 0x0202ae2c
  * Sets up VS mode: marks current game mode, initializes player globals,
  * starts a scene fade, then sets save data default values.
  */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern unsigned char CURRENT_GAMEMODE[];
 extern unsigned char SAVE_DATA[];
 

--- a/src/ProcessKuppaScript.cpp
+++ b/src/ProcessKuppaScript.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed char s8;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
     short ReadUnalignedShort(unsigned char* p);
     unsigned int ReadUnalignedInt(unsigned char* p);
@@ -30,9 +24,6 @@ extern "C" {
     extern void* data_0209f318;
     extern s8 data_02092110;
 }
-
-typedef int Fix12i;
-
 struct FaderBrightness {
     Fix12i currInterp;
     Fix12i speed;

--- a/src/ResetInput.c
+++ b/src/ResetInput.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 GetControllerMode(int a0);
 extern void func_0205a588(void *a, int b, int c);
 extern u8 data_0209f21c;

--- a/src/SetNextLevel.c
+++ b/src/SetNextLevel.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 extern s8 data_0209f2f8;
 extern s8 data_0209211c;
 extern u8 data_0209f200;

--- a/src/SetNextStar.c
+++ b/src/SetNextStar.c
@@ -1,6 +1,5 @@
+#include "types.h"
 extern int SublevelToLevel(int i);
-
-typedef unsigned char u8;
 extern signed char data_02092110;
 extern u8 data_0209f1f0;
 extern u8 data_0209f2d8;

--- a/src/SetPlayerGlobals.c
+++ b/src/SetPlayerGlobals.c
@@ -1,8 +1,5 @@
+#include "types.h"
 // SetPlayerGlobals - initializes player globals: lives, health, controller mode
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
 extern u8 NUM_LIVES;
 extern u16 HEALTH_ARR[];
 extern u8 SAVE_DATA[];

--- a/src/ShowCrashScreen.c
+++ b/src/ShowCrashScreen.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned long long u64;
-
+#include "types.h"
 extern void *_ZN2G212GetBG1ScrPtrEv(void);
 extern u64 func_020427c4(void);
 extern void *func_0202e118(void);

--- a/src/StartEntranceFaderWipe.c
+++ b/src/StartEntranceFaderWipe.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int Fix12i;
-
+#include "types.h"
 struct Fader {
     Fix12i currInterp;
     Fix12i speed;

--- a/src/StartExitCharacterWipe.c
+++ b/src/StartExitCharacterWipe.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* StartExitCharacterWipe at 0x020298d8
  * Starts the exit wipe for the current character (per-character wipe table).
  */
-typedef unsigned char u8;
-
 extern u8 data_0209caa0[]; /* save data; +0x41 = current character */
 extern u8 data_020755bc[]; /* character -> wipe type table */
 extern void StartExitFaderWipe(int wipeType);

--- a/src/StartExitFaderWipe.c
+++ b/src/StartExitFaderWipe.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int Fix12i;
-
+#include "types.h"
 struct Fader {
     Fix12i currInterp;
     Fix12i speed;

--- a/src/StartFile.c
+++ b/src/StartFile.c
@@ -1,14 +1,9 @@
+#include "types.h"
 /* StartFile at 0x0202ae88
  * Starts a single-player game file: clears gamemode, loads level, sets player globals,
  * copies current character to NEXT_HAT_CHARACTER_ARR, sets player count to 1,
  * clears star-obtained/level flags, then starts a scene fade.
  */
-
-typedef signed char s8;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern u8 CURRENT_GAMEMODE[];
 extern u8 SAVE_DATA[];
 extern u8 NEXT_HAT_CHARACTER_ARR[];

--- a/src/StartMinigameMenu.c
+++ b/src/StartMinigameMenu.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* StartMinigameMenu at 0x0202adf4
  * Starts the minigame menu scene. r0 controls whether to return to rec room after.
  */
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern u8 RETURN_TO_REC_ROOM;  /* 0x0209f298 */
 
 extern void _ZN5Scene20SetAndStopColorFaderEv(void);

--- a/src/UnloadBlueCoinModel.c
+++ b/src/UnloadBlueCoinModel.c
@@ -1,10 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
-typedef signed short s16;
-typedef signed char s8;
-
+#include "types.h"
 struct SharedFilePtr { u32 data[4]; };
 
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);

--- a/src/UpdateMinimap.c
+++ b/src/UpdateMinimap.c
@@ -1,7 +1,6 @@
+#include "types.h"
 // UpdateMinimap: copies a 16-byte descriptor into data_0209f3c8 and stores
 // the four scalar params into data_0209f3c4 (+0x14..+0x20).
-typedef unsigned int u32;
-
 typedef struct MinimapDesc { u32 a, b, c, d; } MinimapDesc;
 
 typedef struct MinimapState {

--- a/src/WM_CheckStateEx.c
+++ b/src/WM_CheckStateEx.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0206152c(void);
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int n);
 extern unsigned int *data_020a89ac;

--- a/src/WM_SendCommand.c
+++ b/src/WM_SendCommand.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_020587e4(void *a, void **out, int c);
 extern void _ZN4CP1514FlushDataCacheEjj(u32 addr, u32 len);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);

--- a/src/_Z13CopyToViewMatPK9Matrix4x3.c
+++ b/src/_Z13CopyToViewMatPK9Matrix4x3.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     s32 m[12]; /* 4x3 matrix, 48 bytes */
 } Matrix4x3;

--- a/src/_Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
+++ b/src/_Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 /* LoadPathNodeObjects(LVL_Overlay::ObjSubTable&, int, unsigned) @ 0x20fe6b8 (ov002)
  * -- veneer: ldr r0,[r0,#4]; b func_0203accc. */
 extern "C" {
-typedef unsigned int u32;
 extern void func_0203accc(void*, int, u32);
 void _Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij(void* a, int b, u32 c) {
     func_0203accc(*(void**)((char*)a + 4), b, c);

--- a/src/_Z23LoadMinimapChangeObjecti5Fix12IiEh.c
+++ b/src/_Z23LoadMinimapChangeObjecti5Fix12IiEh.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef int Fix12i;
-
+#include "types.h"
 struct Node {
     int f0;          /* 0x00 value */
     u8 f4;           /* 0x04 */

--- a/src/_ZN10CheepCheep8BehaviorEv.cpp
+++ b/src/_ZN10CheepCheep8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN10CheepCheep8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
@@ -11,7 +12,6 @@ typedef void (Enemy::*PMF)();
 struct Holder { char pad[8]; PMF fn; };
 
 extern "C" {
-typedef unsigned int u32;
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(Enemy *thiz, WithMeshClsn *c);
 extern void _ZN12CylinderClsn5ClearEv(void *thiz);
 extern void _ZN12CylinderClsn6UpdateEv(void *thiz);

--- a/src/_ZN10KoopaShell8BehaviorEv.cpp
+++ b/src/_ZN10KoopaShell8BehaviorEv.cpp
@@ -1,13 +1,9 @@
 //cpp
+#include "types.h"
 /* _ZN10KoopaShell8BehaviorEv @ 0x0214d2e8 (ov102, size 0x264)
  * Enemy main behavior dispatcher: yoshi-eat handling, state PMF call,
  * collision update and ground/wall reactions.
  */
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 struct C {};
 typedef int (C::*PMF)();
 struct EState {

--- a/src/_ZN10LavaBubble8BehaviorEv.cpp
+++ b/src/_ZN10LavaBubble8BehaviorEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN10LavaBubble8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "LavaBubble.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int Fix12;
 struct Klass; typedef void (Klass::*PMF)();
 struct M { char pad[8]; PMF pmf; };
 struct CylinderClsn;

--- a/src/_ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt.c
+++ b/src/_ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* ModelAnim2::Func_020162C4 at 0x020162c4, size=0x5c
  * Updates otherAnim: fast path (same file) just updates flags+speed;
  * slow path stores new file, loads numFrames, calls SetAnimation.
  */
-
-typedef int s32;
-typedef unsigned short u16;
-
 struct BCA_File {
     u16 unk00;
     u16 numFrames;

--- a/src/_ZN10ModelAnim2C1Ev.c
+++ b/src/_ZN10ModelAnim2C1Ev.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* _ZN10ModelAnim2C1Ev at 0x020163a0 (64 bytes)
  * ModelAnim2::ModelAnim2() constructor - returns this.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-
 struct Animation {
     u32 vtable;
     Fix12i numFramesAndFlags;

--- a/src/_ZN10MrBlizzard13InitResourcesEv.cpp
+++ b/src/_ZN10MrBlizzard13InitResourcesEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN10MrBlizzard13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_PathPtr.h"
@@ -6,13 +7,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MrBlizzard.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 struct Vec3 { int x, y, z; };
 
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);

--- a/src/_ZN10PyramidTop8BehaviorEv.cpp
+++ b/src/_ZN10PyramidTop8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN10PyramidTop8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PyramidTop.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* actor, void* pt);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int bank, void* pos);
 

--- a/src/_ZN10RickshawBs13InitResourcesEv.c
+++ b/src/_ZN10RickshawBs13InitResourcesEv.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b676c(u8 *self, struct Arg *arg, s16 value);

--- a/src/_ZN10RickshawBs16CleanupResourcesEv.c
+++ b/src/_ZN10RickshawBs16CleanupResourcesEv.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b66a8(u8 *self, struct Arg *arg);

--- a/src/_ZN10StarMarker13InitResourcesEv.cpp
+++ b/src/_ZN10StarMarker13InitResourcesEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN10StarMarker13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "StarMarker.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 struct Vec3 { s32 x, y, z; };
 struct RaycastGround { char pad[0x50]; };
 

--- a/src/_ZN10StarSwitch13InitResourcesEv.cpp
+++ b/src/_ZN10StarSwitch13InitResourcesEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" void LoadSilverStarAndNumber(void);
 extern "C" int _ZN5Model8LoadFileER13SharedFilePtr(int p);
 extern "C" void _ZN5Event8ClearBitEj(unsigned int b);

--- a/src/_ZN11CommonModel13Func_020160ACEj.cpp
+++ b/src/_ZN11CommonModel13Func_020160ACEj.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct Holder {
     char _pad[0x24];
     u32 count;

--- a/src/_ZN11CommonModel9DoSetFileEPcii.c
+++ b/src/_ZN11CommonModel9DoSetFileEPcii.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* CommonModel::DoSetFile at 0x02016144, size=0x70
  * Loads model data from a BMD file, optionally sets material opacity and polygon ID.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct ModelComponents {
     void* modelFile;
     void* materials;

--- a/src/_ZN11RickshawBdw13InitResourcesEv.c
+++ b/src/_ZN11RickshawBdw13InitResourcesEv.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6958(u8 *self, struct Arg *arg);

--- a/src/_ZN11RickshawBdw16CleanupResourcesEv.c
+++ b/src/_ZN11RickshawBdw16CleanupResourcesEv.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b68b0(u8 *self, struct Arg *arg);

--- a/src/_ZN11RollingRock13InitResourcesEv.cpp
+++ b/src/_ZN11RollingRock13InitResourcesEv.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN11RollingRock13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RollingRock.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct Vec3 { s32 x, y, z; };
 struct Actor;
 

--- a/src/_ZN11WingFeather8BehaviorEv.cpp
+++ b/src/_ZN11WingFeather8BehaviorEv.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN11WingFeather8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "WingFeather.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
 extern "C" {
 void* _ZN5Actor13ClosestPlayerEv(void* self);
 int _ZN6Player15IsCollectingCapEv(void* self);

--- a/src/_ZN12ActorDerived18AfterInitResourcesEj.c
+++ b/src/_ZN12ActorDerived18AfterInitResourcesEj.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef struct ActorDerived { char pad[0]; } ActorDerived;
 
 extern void _ZN9ActorBase18MarkForDestructionEv(ActorDerived* self);

--- a/src/_ZN12HauntedChair13InitResourcesEv.cpp
+++ b/src/_ZN12HauntedChair13InitResourcesEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN12HauntedChair13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HauntedChair.h"
-typedef unsigned int u32;
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
 extern struct BMD_File* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char* self, struct BMD_File* f, int a, int b);

--- a/src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.c
@@ -1,8 +1,7 @@
+#include "types.h"
 // @symbol _ZN12MeshCollider8LoadFileER13SharedFilePtr
 /* recovered: named members + shared header */
 #include "MeshCollider.h"
-typedef unsigned char u8;
-
 struct SharedFilePtr {
     unsigned short fileID;
     u8 numRefs;

--- a/src/_ZN12MeshColliderC1Ev.c
+++ b/src/_ZN12MeshColliderC1Ev.c
@@ -1,10 +1,9 @@
+#include "types.h"
 /* _ZN12MeshColliderC1Ev - MeshCollider constructor.
  * Attempt 3: constructor returns self (C++ C1 ctors return this).
  * ROM has mov r0,r4 before final str+epilogue - this is "return self" pattern.
  * Adding return self fixes: pool offset (0x18->0x1c) AND mov r0,r4 at +0x20.
  */
-typedef unsigned int u32;
-
 struct MeshColliderBase { u32 _pad[8]; }; /* sizeof=0x20 */
 
 extern void _ZN16MeshColliderBaseC2Ev(struct MeshColliderBase* self);

--- a/src/_ZN12WithMeshClsn16UpdateContinuousEv.c
+++ b/src/_ZN12WithMeshClsn16UpdateContinuousEv.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN12WithMeshClsn16UpdateContinuousEv
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_SphereClsn.h"
@@ -5,8 +6,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "WithMeshClsn.h"
-typedef unsigned char u8;
-
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;

--- a/src/_ZN12WithMeshClsn18StopDetectingWaterEv.c
+++ b/src/_ZN12WithMeshClsn18StopDetectingWaterEv.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* _ZN12WithMeshClsn18StopDetectingWaterEv
  * Attempt 1: calls BgCh::StopDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void _ZN4BgCh18StopDetectingWaterEv(struct BgCh* self);

--- a/src/_ZN12WithMeshClsn19StartDetectingWaterEv.c
+++ b/src/_ZN12WithMeshClsn19StartDetectingWaterEv.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* _ZN12WithMeshClsn19StartDetectingWaterEv
  * Attempt 1: calls BgCh::StartDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void _ZN4BgCh19StartDetectingWaterEv(struct BgCh* self);

--- a/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
+++ b/src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol _ZN12WithMeshClsn22UpdateContinuousNoLavaEv
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "WithMeshClsn.h"
-typedef unsigned char u8;
-
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 78 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
