### PR TITLE
readable: consolidate 84 files onto shared types.h (byte-verified)

### DIFF
--- a/src/_ZN13BigBrickBlock13InitResourcesEv.c
+++ b/src/_ZN13BigBrickBlock13InitResourcesEv.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
+#include "types.h"
 enum { false = 0, true = 1 };
 
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);

--- a/src/_ZN13BigBrickBlock8BehaviorEv.cpp
+++ b/src/_ZN13BigBrickBlock8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13BigBrickBlock8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBrickBlock.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern "C" int _ZN5Event6GetBitEj(unsigned int a);
 extern "C" void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *after);
 extern "C" void func_020393a4(int *p, int v);

--- a/src/_ZN13ExpandingHeap10VGetNodeIDEv.cpp
+++ b/src/_ZN13ExpandingHeap10VGetNodeIDEv.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VGetNodeID() at 0x0203c3e0 -- Heap vtable slot (VGetNodeID).
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap10VSetNodeIDEj.cpp
+++ b/src/_ZN13ExpandingHeap10VSetNodeIDEj.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VSetNodeID(unsigned) at 0x0203c3f8 -- Heap vtable slot.
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap11VDeallocateEPv.c
+++ b/src/_ZN13ExpandingHeap11VDeallocateEPv.c
@@ -1,9 +1,6 @@
+#include "types.h"
 // ExpandingHeap::VDeallocate(void* ptr)
 // Address: 0x0203c50c
-
-typedef unsigned int u32;
-typedef int s32;
-
 struct ExpandingHeapAllocator;
 
 extern void _ZN22ExpandingHeapAllocator10DeallocateEPv(struct ExpandingHeapAllocator* self, void* ptr);

--- a/src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp
+++ b/src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VMemoryLeft() at 0x0203c5ac -- Heap vtable slot.
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap11VReallocateEPvj.cpp
+++ b/src/_ZN13ExpandingHeap11VReallocateEPvj.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VReallocate(void*, unsigned) at 0x0203c568 -- Heap vtable slot.
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap12VResizeToFitEv.cpp
+++ b/src/_ZN13ExpandingHeap12VResizeToFitEv.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13ExpandingHeap12VResizeToFitEv
 /* recovered: named members + shared header, real C++ method */
 #include "ExpandingHeap.h"
 /* ExpandingHeap::VResizeToFit() at 0x0203c388 -- Heap vtable slot (VResizeToFit).
  * Resizing an ExpandingHeap to fit is a forbidden operation, so this override
  * always fails by returning 0 (the new size, 0 == failure). */
-
-typedef unsigned int u32;
-
 struct ExpandingHeap;
 
 u32 ExpandingHeap::VResizeToFit()

--- a/src/_ZN13ExpandingHeap14VDeallocateAllEv.cpp
+++ b/src/_ZN13ExpandingHeap14VDeallocateAllEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VDeallocateAll() at 0x0203c4b0 -- Heap vtable slot.
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14),
  * passing the InvokeDeallocate trampoline as the visitor. */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap7VSizeofEPv.cpp
+++ b/src/_ZN13ExpandingHeap7VSizeofEPv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VSizeof(void*) at 0x0203c444 -- Heap vtable slot.
  * Node headers carry their own size, so this ignores `this` and forwards
  * to the static ExpandingHeapAllocator::SizeofInternal(void*). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeap8VDestroyEv.c
+++ b/src/_ZN13ExpandingHeap8VDestroyEv.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // ExpandingHeap::VDestroy()
 // Address: 0x0203c72c
 // Destroys the allocator and sets allocator ptr to NULL
-
-typedef unsigned int u32;
-
 struct HeapAllocator;
 
 extern void _ZN13HeapAllocator7DestroyEv(struct HeapAllocator* self);

--- a/src/_ZN13ExpandingHeap9VAllocateEji.cpp
+++ b/src/_ZN13ExpandingHeap9VAllocateEji.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* ExpandingHeap::VAllocate(unsigned, int) at 0x0203c6bc -- Heap vtable slot.
  * Forwards to the allocator (ExpandingHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class ExpandingHeapAllocator
 {
 public:

--- a/src/_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator.c
+++ b/src/_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Heap;
 struct ExpandingHeapAllocator;
 

--- a/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
+++ b/src/_ZN13HeapAllocatorC1EjPvPvj.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13HeapAllocatorC1EjPvPvj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_NestedHeapIterator.h"
@@ -6,9 +7,6 @@
 /* recovered: named members + shared header */
 #include "HeapAllocator.h"
 extern "C" {
-
-typedef unsigned int u32;
-
 extern void* _ZN18NestedHeapIterator10FindNestedEPv(void* ptr);
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void* iter, void* node);
 

--- a/src/_ZN13RacingPenguin16CleanupResourcesEv.cpp
+++ b/src/_ZN13RacingPenguin16CleanupResourcesEv.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned int u32;
 struct SharedFilePtr { u32 data[4]; };
 void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern struct SharedFilePtr data_ov019_02113498;

--- a/src/_ZN13RollingLogLll16CleanupResourcesEv.c
+++ b/src/_ZN13RollingLogLll16CleanupResourcesEv.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 struct RollingLogLll {
     char pad[0x10c];
     char *sub;

--- a/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
+++ b/src/_ZN13RollingLogTtm13InitResourcesEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13RollingLogTtm13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_SaveData.h"
@@ -6,11 +7,6 @@
 /* recovered: named members + shared header, real C++ method */
 #include "RollingLogTtm.h"
 #define false 0
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *self, void *file, int a, int b);
 extern void *_ZN9Animation8LoadFileER13SharedFilePtr(void *fp);

--- a/src/_ZN13RollingLogTtm16CleanupResourcesEv.c
+++ b/src/_ZN13RollingLogTtm16CleanupResourcesEv.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 struct SharedFilePtr { u32 data[4]; };
 
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);

--- a/src/_ZN13RollingLogTtm8BehaviorEv.cpp
+++ b/src/_ZN13RollingLogTtm8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13RollingLogTtm8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_SaveData.h"
@@ -10,7 +11,6 @@ struct Vector3_16;
 struct Actor;
 
 extern "C" {
-typedef unsigned int u32;
 extern int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(Actor *thiz, int d);
 extern Actor *_ZN5Actor13ClosestPlayerEv(Actor *thiz);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const Vector3 *c, const Vector3_16 *d, int e, int f);

--- a/src/_ZN13SharedFilePtr9ConstructEj.c
+++ b/src/_ZN13SharedFilePtr9ConstructEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* SharedFilePtr::Construct(u32 ov0FileID) at 0x0201799c
  * Declared in SharedFilePtr.h as `SharedFilePtr& Construct(u32 ov0FileID);`.
  * Saves `this`, forwards to func_02017e48 (the real init helper -- it is still
@@ -7,9 +8,6 @@
  * The callee receives `this` in r0 (it is preserved across the call), matching
  * the `SharedFilePtr*`-first signature below.
  */
-
-typedef unsigned int u32;
-
 struct SharedFilePtr; /* { u16 fileID; u8 numRefs; char* filePtr; } -- see SharedFilePtr.h */
 
 extern void func_02017e48(struct SharedFilePtr* self); /* 0x02017e48 */

--- a/src/_ZN13SnowmanBreath8BehaviorEv.cpp
+++ b/src/_ZN13SnowmanBreath8BehaviorEv.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13SnowmanBreath8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Player.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SnowmanBreath.h"
-typedef unsigned char u8;
-
-
 extern u8 data_0209f2d8[];
 
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *self, void *actor, int b);

--- a/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
+++ b/src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13UpDownLiftBbh13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
@@ -9,9 +10,6 @@
  * -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  * natural signed /2 spelling; mwcc synthesizes add/lsr#31/asr#1 itself and
  * self-schedules the byte store into the ROM slot */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(int sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);

--- a/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
+++ b/src/_ZN13UpDownLiftBbh8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13UpDownLiftBbh8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "UpDownLiftBbh.h"
@@ -11,10 +12,6 @@ extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void* c);
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* c, int a, int b);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void* c);
 extern "C" int _ZN6Player7IsInAirEv(void* c);
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 int UpDownLiftBbh::Behavior()
 {
     int old;

--- a/src/_ZN13WaterfallMist13InitResourcesEv.cpp
+++ b/src/_ZN13WaterfallMist13InitResourcesEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13WaterfallMist13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WaterfallMist.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-typedef signed char s8;
-
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void *sfp);
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *bmd, int a, int b);

--- a/src/_ZN13WaterfallMist8BehaviorEv.cpp
+++ b/src/_ZN13WaterfallMist8BehaviorEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN13WaterfallMist8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "WaterfallMist.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 struct WithMeshClsn;
 struct Enemy { char pad[0x800]; };
 typedef void (Enemy::*PMF)();

--- a/src/_ZN14BlendModelAnim11UpdateVertsEv.c
+++ b/src/_ZN14BlendModelAnim11UpdateVertsEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* BlendModelAnim::UpdateVerts at 0x02016578, size=0x4c
  * Updates bones, then calls Func_0204531c(data, unk64) (blend) or UpdateVertsUsingBones based on unk64.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct ModelComponents {
     void* modelFile;
     void* materials;

--- a/src/_ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt.cpp
+++ b/src/_ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 /* BlendModelAnim::SetAnim at 0x020163e0, size=0x9c
  * Fast path (same file): update flags + speed only.
  * Slow path: store file, SetAnimation, then set up blend weight/step
  * (unk64 = current blend, unk68 = per-frame step = 1 / (numBlendFrames+1)).
  */
-
-typedef int s32;
-typedef unsigned short u16;
-
 struct BCA_File {
     u16 unk00;
     u16 numFrames;

--- a/src/_ZN14BlendModelAnim9DoSetFileEPcii.c
+++ b/src/_ZN14BlendModelAnim9DoSetFileEPcii.c
@@ -1,8 +1,5 @@
+#include "types.h"
 /* BlendModelAnim::DoSetFile at 0x02016604 */
-
-typedef unsigned int u32;
-typedef signed int s32;
-
 struct BlendModelAnim {
     u32 vtable;
 };

--- a/src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.c
+++ b/src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.c
@@ -1,8 +1,5 @@
+#include "types.h"
 /* BlendModelAnim::Virtual10 at 0x02016518, size=0x60 */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct ModelComponents {
     void* modelFile;
     void* materials;

--- a/src/_ZN14BlendModelAnimC1Ev.c
+++ b/src/_ZN14BlendModelAnimC1Ev.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* _ZN14BlendModelAnimC1Ev at 0x020166d4 (64 bytes)
  * BlendModelAnim::BlendModelAnim() constructor - returns this.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-
 struct Animation {
     u32 vtable;
     Fix12i numFramesAndFlags;

--- a/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
+++ b/src/_ZN14BlueCoinSwitch8BehaviorEv.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN14BlueCoinSwitch8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "BlueCoinSwitch.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
 extern void _ZN5Event8ClearBitEj(u32 bit);
 extern void _ZN5Event6SetBitEj(u32 bit);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* p);

--- a/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
+++ b/src/_ZN14EnemySwitchTag13InitResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN14EnemySwitchTag13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
-typedef unsigned int u32;
-typedef signed char s8;
-typedef unsigned char u8;
-
 extern int IsStarCollectedInLevel(s8 levelID, int starID);
 extern s8 data_0209f2f8;
 extern u8 data_0209f220;

--- a/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
+++ b/src/_ZN14EnemySwitchTag8BehaviorEv.cpp
@@ -1,12 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN14EnemySwitchTag8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Camera.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "EnemySwitchTag.h"
-typedef unsigned int u32;
-
 extern u32 _ZN5Sound8PlayLongEjjjRK7Vector3j(u32 a, u32 b, u32 c, void *v, u32 e);
 extern void *data_0209f318;
 

--- a/src/_ZN14MovingBarSmall13InitResourcesEv.cpp
+++ b/src/_ZN14MovingBarSmall13InitResourcesEv.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern "C" {
 void* _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);

--- a/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
+++ b/src/_ZN14UnknownVsEntry8BehaviorEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN14UnknownVsEntry8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "UnknownVsEntry.h"
-typedef unsigned char u8;
 extern void func_ov075_021152d4(void* self);
 extern int _ZN9Animation7AdvanceEv(void* a);
 extern u8 data_0209fc5c;

--- a/src/_ZN15FaderBrightness14SetForwardTimeEj.c
+++ b/src/_ZN15FaderBrightness14SetForwardTimeEj.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" Fix12i _ZN4cstd4fdivEii(Fix12i a, Fix12i b);
 
 struct Fader {

--- a/src/_ZN15FaderBrightness15SetBackwardTimeEj.c
+++ b/src/_ZN15FaderBrightness15SetBackwardTimeEj.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" Fix12i _ZN4cstd4fdivEii(Fix12i a, Fix12i b);
 
 struct Fader {

--- a/src/_ZN15InvisibleSecret6RenderEv.cpp
+++ b/src/_ZN15InvisibleSecret6RenderEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15InvisibleSecret6RenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "InvisibleSecret.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern "C" {
 extern void* _ZN5Actor15FindWithActorIDEjPS_(u32 id, void* prev);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* thiz);

--- a/src/_ZN15InvisibleSecret8BehaviorEv.cpp
+++ b/src/_ZN15InvisibleSecret8BehaviorEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15InvisibleSecret8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "InvisibleSecret.h"
-typedef unsigned char u8;
-
 struct V3 { int x, y, z; };
 
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);

--- a/src/_ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj.c
+++ b/src/_ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* _ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj at 0x020157ac
  * Sets the BMA file for a MaterialChanger. If the file is the same, updates flags and speed.
  * If different, stores the file and calls SetAnimation with the file's frame count.
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct BMA_File { u16 numFrames; };
 
 struct Animation {

--- a/src/_ZN15ModelComponents21UpdateVertsUsingBonesEv.c
+++ b/src/_ZN15ModelComponents21UpdateVertsUsingBonesEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct BMD_File {
     u32 scaleShift;  /* 0x00 */
     u32 numBones;    /* 0x04 */

--- a/src/_ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3.cpp
+++ b/src/_ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3.cpp
@@ -1,10 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern u32 data_020a4bd4;
 extern int data_02082190;
 extern void* data_020a4bd0;

--- a/src/_ZN15RotatingFirebar8BehaviorEv.cpp
+++ b/src/_ZN15RotatingFirebar8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15RotatingFirebar8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Player.h"
@@ -7,10 +8,6 @@
 #include "RotatingFirebar.h"
 #pragma opt_propagation off
 #pragma opt_dead_assignments off
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 #define LI(v) ((int)(((long long)(v))))
 

--- a/src/_ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj.c
+++ b/src/_ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* TextureSequence::SetFile at 0x020159ac, size=0x54
  * Sets animation file; fast path (same file) just updates flags+speed.
  */
-
-typedef int s32;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct BTP_File {
     u16 numFrames;
 };

--- a/src/_ZN15TextureSequence8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN15TextureSequence8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN15TextureSequence8LoadFileER13SharedFilePtr
 /* recovered: named members + shared header */
 #include "TextureSequence.h"
@@ -5,9 +6,6 @@
  * Loads a SharedFilePtr; if first reference and file is non-null, calls TextureSequence::UpdateFileOffsets.
  * Returns the BTP_File pointer.
  */
-
-typedef unsigned char u8;
-
 struct SharedFilePtr {
     unsigned short fileID;  /* 0x00 */
     u8 numRefs;             /* 0x02 */

--- a/src/_ZN15TextureSequenceC1Ev.c
+++ b/src/_ZN15TextureSequenceC1Ev.c
@@ -1,8 +1,5 @@
+#include "types.h"
 // TextureSequence constructor - C++ style to get correct return value
-
-typedef int Fix12i;
-typedef unsigned int u32;
-
 struct Animation {
     void** vtable;
     Fix12i numFramesAndFlags;

--- a/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
+++ b/src/_ZN15TtcRotatingCube13InitResourcesEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15TtcRotatingCube13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct SharedFilePtr;
 struct BMD_File;
 struct KCL_File;

--- a/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingCube8BehaviorEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15TtcRotatingCube8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingCube.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void *v);
 extern int _Z14ApproachLinearRsss(s16 *val, int target, int step);

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.c
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.c
@@ -1,9 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);

--- a/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
+++ b/src/_ZN15TtcRotatingGear8BehaviorEv.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN15TtcRotatingGear8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "TtcRotatingGear.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *c);

--- a/src/_ZN16MeshColliderBase14GetAngularVelYEv.c
+++ b/src/_ZN16MeshColliderBase14GetAngularVelYEv.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* MeshColliderBase::GetAngularVelY() at 0x02039428
  * Base implementation: a non-moving mesh collider has no angular velocity,
  * so this always returns 0. (MovingMeshCollider overrides it.)
  */
-
-typedef unsigned short u16;
-
 struct MeshColliderBase;
 
 u16 _ZN16MeshColliderBase14GetAngularVelYEv(struct MeshColliderBase* self)

--- a/src/_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.c
+++ b/src/_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct MeshColliderBase;
 struct Actor;
 struct ClsnResult;

--- a/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
+++ b/src/_ZN16RotatingCogSmall13InitResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN16RotatingCogSmall13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingCogSmall.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *c);

--- a/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
+++ b/src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN17SlidingPlatformWf13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 extern "C" {
     void* _ZN5Model8LoadFileER13SharedFilePtr(void* shared);
     void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* mb, void* bmd, int a, int b);

--- a/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
+++ b/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN17SlidingPlatformWf8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "SlidingPlatformWf.h"
-typedef int Fix12;
-typedef short s16;
-typedef unsigned short u16;
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* c, void* cc);

--- a/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
+++ b/src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_CylinderClsn.h"
 /* recovered: named members + shared header */
 #include "MovingCylinderClsn.h"
-typedef int Fix12i;
-typedef unsigned int u32;
-
 struct Actor { void* vtable; };
 
 

--- a/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c
+++ b/src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c
@@ -1,6 +1,4 @@
-typedef long long s64;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct {
     int head[4];        /* 0x00 */
     char result[0x60];  /* 0x10 */

--- a/src/_ZN18NestedHeapIterator10FindNestedEPv.c
+++ b/src/_ZN18NestedHeapIterator10FindNestedEPv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // NestedHeapIterator::FindNested(void* ptr) - static
 // Address: 0x0204dfe8
 // Finds the innermost NestedHeapIterator containing ptr; returns rootHeapIterator if none found
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct NestedHeapIterator;
 struct HeapAllocator;
 

--- a/src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.c
+++ b/src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void* _ZN18NestedHeapIterator4NextEP13HeapAllocator(void* self, void* cur);
 
 void* _ZN18NestedHeapIterator19RecursiveFindNestedEPv(void* self, void* addr)

--- a/src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp
+++ b/src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp
@@ -1,11 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol _ZN18NestedHeapIterator6RemoveEP13HeapAllocator
 /* recovered: named members + shared header, real C++ method */
 #include "NestedHeapIterator.h"
 struct HeapAllocator;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct NHI { void* head; void* tail; u16 count; u16 off; };
 
 void NestedHeapIterator::Remove(HeapAllocator * node_)

--- a/src/_ZN18NestedHeapIteratorC1Ej.c
+++ b/src/_ZN18NestedHeapIteratorC1Ej.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // @symbol _ZN18NestedHeapIteratorC1Ej
 /* recovered: named members + shared header */
 #include "NestedHeapIterator.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct Iter {
     void* head;
     void* tail;

--- a/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN18RickshawPlatformBs13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RickshawPlatformBs.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);

--- a/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
+++ b/src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN18RickshawPlatformBs16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RickshawPlatformBs.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);

--- a/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
+++ b/src/_ZN18RotatingPlatformRr8BehaviorEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN18RotatingPlatformRr8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformRr.h"
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
 extern s16 data_02082214[];
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
 

--- a/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
+++ b/src/_ZN18SolidHeapAllocator10MemoryLeftEi.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int _ZN4cstd3absEi(int x);
 
 int _ZN18SolidHeapAllocator10MemoryLeftEi(void *c, int align)

--- a/src/_ZN18SolidHeapAllocator10ReallocateEPvj.c
+++ b/src/_ZN18SolidHeapAllocator10ReallocateEPvj.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void MultiStore_Int(s32 val, void* dst, u32 count);
 
 u32 _ZN18SolidHeapAllocator10ReallocateEPvj(void* c, void* ptr, u32 size)

--- a/src/_ZN18SolidHeapAllocator10ResetStartEv.c
+++ b/src/_ZN18SolidHeapAllocator10ResetStartEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct FreeList { void* begin; void* end; int flags; };
 
 void _ZN18SolidHeapAllocator10ResetStartEv(void* c)

--- a/src/_ZN18SolidHeapAllocator14TryResizeToFitEv.c
+++ b/src/_ZN18SolidHeapAllocator14TryResizeToFitEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
+#include "types.h"
 struct H { void* begin; void* end; };
 s32 _ZN18SolidHeapAllocator14TryResizeToFitEv(void* self)
 {

--- a/src/_ZN18SolidHeapAllocator16AllocateForwardsEPvjj.c
+++ b/src/_ZN18SolidHeapAllocator16AllocateForwardsEPvjj.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol _ZN18SolidHeapAllocator16AllocateForwardsEPvjj
 /* recovered: named members + shared header */
 #include "SolidHeapAllocator.h"
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void MultiStore_Int(s32 val, void* dst, u32 count);
 
 void* _ZN18SolidHeapAllocator16AllocateForwardsEPvjj(void* freeBlockPair, u32 size, u32 align)

--- a/src/_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj.c
+++ b/src/_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol _ZN18SolidHeapAllocator17AllocateBackwardsEPvjj
 /* recovered: named members + shared header */
 #include "SolidHeapAllocator.h"
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void MultiStore_Int(s32 val, void* dst, u32 count);
 
 void* _ZN18SolidHeapAllocator17AllocateBackwardsEPvjj(void* freeBlockPair, u32 size, u32 align)

--- a/src/_ZN18SolidHeapAllocator5ResetEj.c
+++ b/src/_ZN18SolidHeapAllocator5ResetEj.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 extern void _ZN18SolidHeapAllocator10ResetStartEv(void* self);
 extern void _ZN18SolidHeapAllocator8ResetEndEv(void* self);
 

--- a/src/_ZN18SolidHeapAllocator8AllocateEji.c
+++ b/src/_ZN18SolidHeapAllocator8AllocateEji.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void* _ZN18SolidHeapAllocator16AllocateForwardsEPvjj(void* pair, u32 size, u32 align);
 extern void* _ZN18SolidHeapAllocator17AllocateBackwardsEPvjj(void* pair, u32 size, u32 align);
 

--- a/src/_ZN18SolidHeapAllocator9SaveStateEj.c
+++ b/src/_ZN18SolidHeapAllocator9SaveStateEj.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct FreeList
 {
     void *begin;

--- a/src/_ZN18SolidHeapAllocatorC1EPvj.c
+++ b/src/_ZN18SolidHeapAllocatorC1EPvj.c
@@ -1,10 +1,9 @@
+#include "types.h"
 // @symbol _ZN18SolidHeapAllocatorC1EPvj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_HeapAllocator.h"
 /* recovered: named members + shared header */
 #include "SolidHeapAllocator.h"
-typedef unsigned int u32;
-
 struct FreeList { void* begin; void* end; int flags; };
 
 

--- a/src/_ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj.c
+++ b/src/_ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* _ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj at 0x020158ac
  * Sets the BTA file for a TextureTransformer. If the file is the same, updates flags and speed.
  * If different, stores the file and calls SetAnimation with the file's frame count.
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct BTA_File { u16 numFrames; };
 
 struct Animation {

--- a/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
+++ b/src/_ZN19AmbientSoundEffects8BehaviorEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19AmbientSoundEffects8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "AmbientSoundEffects.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
 extern "C" {
 void Vec3_Sub(int* out, int* a, int* b);
 void Vec3_RotateYAndTranslate(int* out, int* in, short angle, int* src);

--- a/src/_ZN19CylinderClsnWithPos10GetOwnerIDEv.cpp
+++ b/src/_ZN19CylinderClsnWithPos10GetOwnerIDEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19CylinderClsnWithPos10GetOwnerIDEv
 /* recovered: named members + shared header, real C++ method */
 #include "CylinderClsnWithPos.h"
@@ -6,9 +7,6 @@
  * vtable slot 3. A positional cylinder has no owning Actor, so its owner ID
  * is always 0.
  */
-
-typedef unsigned int u32;
-
 struct CylinderClsnWithPos;
 
 u32 CylinderClsnWithPos::GetOwnerID()

--- a/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19RickshawPlatformBdw13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RickshawPlatformBdw.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);

--- a/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
+++ b/src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19RickshawPlatformBdw16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "RickshawPlatformBdw.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);

--- a/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19RotatingPlatformWdw13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef signed char s8;
-
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *m, void *f, int a, int b);
 extern void _ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File(void *bmd, void *bta);

--- a/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
+++ b/src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN19RotatingPlatformWdw8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingPlatformWdw.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef signed char s8;
-
 extern int IsAreaShowing(int idx);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void *m, void *actor);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, void *pos, unsigned e);

--- a/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
+++ b/src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN20TtcConveyorBeltLarge8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
@@ -8,10 +9,6 @@
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void func_020393c4(int* p, int v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern int _Z14ApproachLinearRiii(int* r, int t, int step);

--- a/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN21ArmedRotatingPlatform13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "ArmedRotatingPlatform.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4d58(u8 *self, struct Arg *arg);

--- a/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
+++ b/src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN21ArmedRotatingPlatform16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "ArmedRotatingPlatform.h"
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b4b6c(u8 *self, struct Arg *arg);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 84 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
