### PR TITLE
readable: consolidate 73 files onto shared types.h (byte-verified)

### DIFF
--- a/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
+++ b/src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef long long s64;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct {
     int head[4];         /* 0x00 */
     char result[0x60];   /* 0x10 */

--- a/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
+++ b/src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN22ClockPaintingHandShort13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "ClockPaintingHandShort.h"
-typedef unsigned int u32;
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, int, int, int);
 

--- a/src/_ZN22ExpandingHeapAllocator10DeallocateEPv.c
+++ b/src/_ZN22ExpandingHeapAllocator10DeallocateEPv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct MemoryNodeTarget {
     void* start;
     void* end;

--- a/src/_ZN22ExpandingHeapAllocator10ReallocateEPvj.cpp
+++ b/src/_ZN22ExpandingHeapAllocator10ReallocateEPvj.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 /* ExpandingHeapAllocator::Reallocate(void* ptr, u32 size) at 0x0204e1e8
  * Grows a block in place by swallowing the free node that directly follows it,
  * or shrinks it and hands the tail back to the free list.
@@ -6,10 +7,6 @@
  * The user pointer sits 0x10 bytes past its MemoryNode header; the allocator's
  * free-node list head lives at this+0x24, and this+0x20 holds the flag word whose
  * low bit asks for freshly-gained bytes to be zero filled. */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern "C" {
 
 struct MemoryNode {

--- a/src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c
+++ b/src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN22ExpandingHeapAllocator14SizeofInternalEPv
 /* recovered: named members + shared header */
 #include "ExpandingHeapAllocator.h"
@@ -6,10 +7,6 @@
  * MemoryNode header sits immediately before the user data; its `size` field (see
  * MemoryNode in Memory.h) lives 3 words (0xc bytes) ahead of the user pointer,
  * i.e. ((s32*)userPtr)[-3]. */
-
-typedef int s32;
-typedef unsigned int u32;
-
 u32 _ZN22ExpandingHeapAllocator14SizeofInternalEPv(void *userPtr)
 {
     return ((s32 *)userPtr)[-3]; /* MemoryNode.size, header at userPtr - 0xc */

--- a/src/_ZN22ExpandingHeapAllocator8AllocateEji.c
+++ b/src/_ZN22ExpandingHeapAllocator8AllocateEji.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void* _ZN22ExpandingHeapAllocator17AllocateBackwardsEjj(void* self, u32 size, u32 align);
 extern void* _ZN22ExpandingHeapAllocator16AllocateForwardsEjj(void* self, u32 size, u32 align);
 

--- a/src/_ZN22ExpandingHeapAllocator9GetNodeIDEv.c
+++ b/src/_ZN22ExpandingHeapAllocator9GetNodeIDEv.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* ExpandingHeapAllocator::GetNodeID() at 0x0204e0e0
  * Returns the current nodeID assigned to subsequently allocated nodes. nodeID is
  * a u16 field at offset 0x34 of ExpandingHeapAllocator (26 * sizeof(u16)); see
  * Memory.h. */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 u32 _ZN22ExpandingHeapAllocator9GetNodeIDEv(u16 *self)
 {
     return self[26]; /* nodeID at +0x34 */

--- a/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
+++ b/src/_ZN22ExpandingHeapAllocatorC1EPvj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN22ExpandingHeapAllocatorC1EPvj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_HeapAllocator.h"
@@ -7,9 +8,6 @@
 // magic 'HPXE', zeroes the two u16 counters at +0x34/+0x36, clears bit 0 of
 // the +0x36 flags, creates the initial free node ('FR') spanning the heap
 // range at +0x18/+0x1c, and initializes the node list head/tail at +0x24.
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 typedef struct {
     void *start;
     void *end;

--- a/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
+++ b/src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp
@@ -1,15 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN25RotatingUpDownPlatformUtm8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Platform.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "RotatingUpDownPlatformUtm.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct RaycastGround { char pad[0x54]; } RaycastGround;
 

--- a/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
+++ b/src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "FloatOnWaterPlatformWdwSquare.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void func_02012694(int a, void* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* clsn);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);

--- a/src/_ZN2GX10EndLoadTexEv.c
+++ b/src/_ZN2GX10EndLoadTexEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern s32 RENDER_DMA_CHANNEL;    /* 0x02099fd0 */
 extern u32 GX_texBank;            /* 0x020a60b8 */
 extern u32 GX_texSlotA;           /* 0x020a60ac */

--- a/src/_ZN2GX11LoadTexPlttEPKvjj.c
+++ b/src/_ZN2GX11LoadTexPlttEPKvjj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* GX::LoadTexPltt at 0x02056924
  * Loads a texture palette into VRAM. If a DMA channel is configured
  * (RENDER_DMA_CHANNEL != -1), uses async DMA; otherwise uses MultiCopy_Int.
@@ -9,10 +10,6 @@
  * Unknown callee at 0x02059fd0 is a DMA transfer function:
  *   func_02059fd0(dmaChannel, src, dest, size, 0, 0)
  */
-
-typedef unsigned int u32;
-typedef int s32;
-
 extern u32 GX_texPlttSlotBase;   /* 0x020a60b0: palette VRAM base address */
 extern s32 RENDER_DMA_CHANNEL;   /* 0x02099fd0: DMA channel (-1 if none) */
 

--- a/src/_ZN2GX12BeginLoadTexEv.c
+++ b/src/_ZN2GX12BeginLoadTexEv.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0205417c(void);
 extern u16 data_02086324[];
 extern u16 data_02086326[];

--- a/src/_ZN2GX12SetBankForBGEt.cpp
+++ b/src/_ZN2GX12SetBankForBGEt.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct GXState { u16 lcdc; u16 bg; u16 obj; };
 extern "C" GXState data_020a6088;
 extern "C" void Vram__Map(u16 bits);

--- a/src/_ZN2GX13SetBankForOBJEt.cpp
+++ b/src/_ZN2GX13SetBankForOBJEt.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct GXState { u16 lcdc; u16 pad; u16 obj; };
 extern "C" GXState data_020a6088;
 extern "C" void Vram__Map(u16 bits);

--- a/src/_ZN2GX13SetBankForTexEt.cpp
+++ b/src/_ZN2GX13SetBankForTexEt.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct GXState {
     u16 lcdc;
     u16 pad;

--- a/src/_ZN2GX14EndLoadTexPlttEv.c
+++ b/src/_ZN2GX14EndLoadTexPlttEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
 extern u32 GXi_SavedTexPlttBankB; /* 0x020a60b4 */
 extern u32 GXi_SavedTexPlttBankA; /* 0x020a60b0 */

--- a/src/_ZN2GX15SetBankForSubBGEt.c
+++ b/src/_ZN2GX15SetBankForSubBGEt.c
@@ -1,5 +1,4 @@
-
-typedef unsigned short u16;
+#include "types.h"
 struct VramReg
 {
   u16 w0;

--- a/src/_ZN2GX15SetGraphicsModeEiii.c
+++ b/src/_ZN2GX15SetGraphicsModeEiii.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern u16 data_02099fcc;
 extern u16 data_020a6084;
 void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c){

--- a/src/_ZN2GX16BeginLoadTexPlttEv.c
+++ b/src/_ZN2GX16BeginLoadTexPlttEv.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_02054168(void);
 extern int data_020a60b4;
 extern u16 data_02086314[];

--- a/src/_ZN2GX16SetBankForSubOBJEt.c
+++ b/src/_ZN2GX16SetBankForSubOBJEt.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct VramReg { u16 w0; u16 pad[9]; u16 f14; };
 extern struct VramReg gVramReg;
 extern void Vram__Map(u16 bits);

--- a/src/_ZN2GX17SetBankForTexPlttEt.c
+++ b/src/_ZN2GX17SetBankForTexPlttEt.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct VramReg { u16 w0; u16 pad[4]; u16 fa; };
 extern struct VramReg gVramReg;
 extern void Vram__Map(u16 bits);

--- a/src/_ZN2GX22SetBankForSubBGExtPlttEt.c
+++ b/src/_ZN2GX22SetBankForSubBGExtPlttEt.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct VramReg { u16 w0; u16 pad[0xa]; u16 f16; };
 extern struct VramReg gVramReg;
 extern void Vram__Map(u16 bits);

--- a/src/_ZN2GX23SetBankForSubOBJExtPlttEt.c
+++ b/src/_ZN2GX23SetBankForSubOBJExtPlttEt.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct VramReg { u16 w0; u16 pad[0xb]; u16 f18; };
 extern struct VramReg gVramReg;
 extern void Vram__Map(u16 bits);

--- a/src/_ZN2GX6DispOnEv.c
+++ b/src/_ZN2GX6DispOnEv.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern u16 data_02099fcc;
 extern u16 data_020a6084;
 void _ZN2GX6DispOnEv(void){

--- a/src/_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii.cpp
+++ b/src/_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 struct Matrix2x2 { int m[4]; };
 
 extern "C" {

--- a/src/_ZN3GXS11LoadBG0CharEPKvjj.c
+++ b/src/_ZN3GXS11LoadBG0CharEPKvjj.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* _ZN3GXS11LoadBG0CharEPKvjj at 0x020561f4
  * Loads BG0 char data using DMA if a channel is assigned, else CPU copy.
  */
-
-typedef unsigned int u32;
-
 extern u32 RENDER_DMA_CHANNEL;
 
 extern void *_ZN3G2S13GetBG0CharPtrEv(void);

--- a/src/_ZN3GXS13LoadBGExtPlttEPKvjj.c
+++ b/src/_ZN3GXS13LoadBGExtPlttEPKvjj.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
+#include "types.h"
 /* DMA transfer function for GX (nitroSDK internal) */
 extern void FUN_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
 extern void MultiCopy_Int(const void* src, void* dst, u32 count);

--- a/src/_ZN3GXS14LoadOBJExtPlttEPKvjj.c
+++ b/src/_ZN3GXS14LoadOBJExtPlttEPKvjj.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
+#include "types.h"
 /* DMA transfer function for GX (nitroSDK internal) */
 extern void FUN_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
 extern void MultiCopy_Int(const void* src, void* dst, u32 count);

--- a/src/_ZN3GXS16EndLoadBGExtPlttEv.c
+++ b/src/_ZN3GXS16EndLoadBGExtPlttEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
 extern u32 GXi_SavedSubBGExtPlttBank; /* saved bank: 0x020a60a4 */
 

--- a/src/_ZN3GXS17EndLoadOBJExtPlttEv.c
+++ b/src/_ZN3GXS17EndLoadOBJExtPlttEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
 extern u32 GXi_SavedSubOBJExtPlttBank; /* saved bank: 0x020a60a8 */
 

--- a/src/_ZN3HUD13InitResourcesEv.cpp
+++ b/src/_ZN3HUD13InitResourcesEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
     int GetOwnerLanguage(void);
     void* LoadFile(int handle);

--- a/src/_ZN3HUD19RenderCameraButtonsEv.cpp
+++ b/src/_ZN3HUD19RenderCameraButtonsEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct OamAttr;
 
 class OAM {

--- a/src/_ZN3HUD8BehaviorEv.cpp
+++ b/src/_ZN3HUD8BehaviorEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct VObj {
     virtual void v0();
     virtual void v1();

--- a/src/_ZN3IRQ13DmaTimHandlerEv.c
+++ b/src/_ZN3IRQ13DmaTimHandlerEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
+#include "types.h"
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 typedef struct
 {

--- a/src/_ZN3IRQ13GetIRQHandlerEj.c
+++ b/src/_ZN3IRQ13GetIRQHandlerEj.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void* data_02099fe4;
 extern char data_020a60c4[];
 void* _ZN3IRQ13GetIRQHandlerEj(u32 mask){

--- a/src/_ZN3IRQ13SetIRQHandlerEjPFvvE.c
+++ b/src/_ZN3IRQ13SetIRQHandlerEjPFvvE.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef void(*Fn)(void);
 extern Fn data_02099fe4[];
 struct Ent{ Fn fn; int en; int pad; };

--- a/src/_ZN3IRQ13VBlankHandlerEv.c
+++ b/src/_ZN3IRQ13VBlankHandlerEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
+#include "types.h"
 extern int data_0209d514;
 extern int data_0208ee44;
 extern u8 data_0209d4f0;

--- a/src/_ZN3IRQ15ClearInterruptsEj.c
+++ b/src/_ZN3IRQ15ClearInterruptsEj.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
+#include "types.h"
 #define IME (*(volatile u16*)0x4000208)
 #define IF  (*(volatile u32*)0x4000214)
 u32 _ZN3IRQ15ClearInterruptsEj(u32 mask){u16 ime=IME;IME=0;u32 old=IF;IF=mask;(void)IME;IME=ime;return old;}

--- a/src/_ZN3IRQ24IPCRxFifoNotEmptyHandlerEv.c
+++ b/src/_ZN3IRQ24IPCRxFifoNotEmptyHandlerEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 saved);
 

--- a/src/_ZN3OAM5FlushEv.c
+++ b/src/_ZN3OAM5FlushEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
 
 extern u32 _ZN3OAM10bufferMainE;

--- a/src/_ZN3OAM5ResetEv.cpp
+++ b/src/_ZN3OAM5ResetEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 void MultiCopy_Int(int *dst, int *src, int len);
 void MultiCopy32Bytes(int *src, int *dst, int len);

--- a/src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi.c
+++ b/src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi.c
@@ -1,10 +1,4 @@
-
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
+#include "types.h"
 typedef struct OamAttr
 {
   u32 yb : 8;

--- a/src/_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c
+++ b/src/_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol _ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_OAM.h"
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "OAM.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
 typedef struct OamAttr {
     u32 yb : 8, objMode : 2, mode : 2, mosaic : 1, dep : 1, shape : 2, xc : 9, aff : 5, size : 2;
     u32 tile : 10, prio : 2, pal : 4, hi2 : 16;

--- a/src/_ZN4Clam8BehaviorEv.c
+++ b/src/_ZN4Clam8BehaviorEv.c
@@ -1,12 +1,10 @@
+#include "types.h"
 /* _ZN4Clam8BehaviorEv @ 0x0211aa58 (ov064, size 0x26c)
  * Chain-chomp-like enemy bark/lunge update: state 0 barks on anim frame
  * 0x19 (smoke puff, 10-frame shake), lunges (state 1) after 150 frames if
  * the player is near; state 1 returns to idle after 150 frames, toggling
  * the collision bit on anim frames 8/15. Hurts a touched player each frame.
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern char data_ov064_0211c9cc[];
 extern char data_ov064_0211c9bc[];
 

--- a/src/_ZN4Coin13InitResourcesEv.c
+++ b/src/_ZN4Coin13InitResourcesEv.c
@@ -1,15 +1,8 @@
+#include "types.h"
 #pragma opt_common_subs off
 
 #define false 0
 #define true 1
-
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 typedef struct { void* sfp; void* bmd; } FileEntry;
 typedef struct { u32 w[12]; } Blob48;
 

--- a/src/_ZN4Fish13InitResourcesEv.cpp
+++ b/src/_ZN4Fish13InitResourcesEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN4Fish13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Fish.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void*,int,int,int);

--- a/src/_ZN4Heap13SetupRootHeapEv.c
+++ b/src/_ZN4Heap13SetupRootHeapEv.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 struct Heap;
 struct HeapS;
 extern void *data_020a0ea4;

--- a/src/_ZN4Heap14CreateRootHeapEPvj.c
+++ b/src/_ZN4Heap14CreateRootHeapEPvj.c
@@ -1,7 +1,7 @@
+#include "types.h"
 // @symbol _ZN4Heap14CreateRootHeapEPvj
 /* recovered: named members + shared header */
 #include "Heap.h"
-typedef unsigned int u32;
 struct Heap;
 struct ExpandingHeapAllocator;
 struct HeapS {

--- a/src/_ZN4Heap15CreateSolidHeapEjPS_i.c
+++ b/src/_ZN4Heap15CreateSolidHeapEjPS_i.c
@@ -1,7 +1,7 @@
+#include "types.h"
 // @symbol _ZN4Heap15CreateSolidHeapEjPS_i
 /* recovered: named members + shared header */
 #include "Heap.h"
-typedef unsigned int u32;
 struct Heap;
 struct SolidHeapAllocator;
 struct HeapS {

--- a/src/_ZN4Heap18InitializeGameHeapEjPS_.c
+++ b/src/_ZN4Heap18InitializeGameHeapEjPS_.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // Heap::InitializeGameHeap(u32 size, Heap* root)
 // Address: 0x0203c24c
 // Creates an ExpandingHeap and stores it to Memory::gameHeapPtr
-
-typedef unsigned int u32;
-typedef int s32;
-
 struct Heap {
     void* heapStart;
     u32   heapSize;

--- a/src/_ZN4Heap18InitializeRootHeapEv.cpp
+++ b/src/_ZN4Heap18InitializeRootHeapEv.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* Heap::InitializeRootHeap() at 0x0203cae8 -- clears Memory::rootParamOffset
  * then tail-calls Heap::SetupRootHeap(). */
-
-typedef unsigned int u32;
-
 namespace Memory
 {
     extern u32 rootParamOffset;

--- a/src/_ZN4Heap19CreateExpandingHeapEjPS_i.c
+++ b/src/_ZN4Heap19CreateExpandingHeapEjPS_i.c
@@ -1,7 +1,7 @@
+#include "types.h"
 // @symbol _ZN4Heap19CreateExpandingHeapEjPS_i
 /* recovered: named members + shared header */
 #include "Heap.h"
-typedef unsigned int u32;
 struct Heap;
 struct ExpandingHeapAllocator;
 struct HeapS {

--- a/src/_ZN4Heap24CreateSolidHeapAllocatorEPvjj.c
+++ b/src/_ZN4Heap24CreateSolidHeapAllocatorEPvjj.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol _ZN4Heap24CreateSolidHeapAllocatorEPvjj
 /* recovered: named members + shared header */
 #include "Heap.h"
 // Heap::CreateSolidHeapAllocator(void* address, u32 size, u32 flags)
 // Address: 0x0204ebc4
 // Try: compute avail only in second condition to defer sub
-
-typedef unsigned int u32;
-
 struct SolidHeapAllocator;
 
 extern struct SolidHeapAllocator* _ZN18SolidHeapAllocatorC1EPvj(

--- a/src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
+++ b/src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol _ZN4Heap28CreateExpandingHeapAllocatorEPvjj
 /* recovered: named members + shared header */
 #include "Heap.h"
 // Heap::CreateExpandingHeapAllocator(void* address, u32 size, u32 flags)
 // Address: 0x0204e3c0
 // Inline avail expression in || to defer sub r3,r1,r0 after bhi
-
-typedef unsigned int u32;
-
 struct ExpandingHeapAllocator;
 
 extern struct ExpandingHeapAllocator* _ZN22ExpandingHeapAllocatorC1EPvj(

--- a/src/_ZN4Heap8AllocateEj.cpp
+++ b/src/_ZN4Heap8AllocateEj.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* Heap::Allocate(unsigned) at 0x0203c28c -- convenience overload that
  * forwards to Heap::Allocate(unsigned, int) with default alignment 4. */
-
-typedef unsigned int u32;
-
 class Heap
 {
 public:

--- a/src/_ZN4HeapC1EPvjP4Heap.c
+++ b/src/_ZN4HeapC1EPvjP4Heap.c
@@ -1,9 +1,9 @@
+#include "types.h"
 // @symbol _ZN4HeapC1EPvjP4Heap
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Heap.h"
-typedef unsigned int u32;
 struct Heap;
 struct HeapS {
     void *vtable;

--- a/src/_ZN4Trap8BehaviorEv.cpp
+++ b/src/_ZN4Trap8BehaviorEv.cpp
@@ -1,17 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN4Trap8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Message.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Trap.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
 extern "C" {
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(const Vector3* v, const Matrix4x3* m, Vector3* res);

--- a/src/_ZN5Actor11UntrackStarERa.c
+++ b/src/_ZN5Actor11UntrackStarERa.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* _ZN5Actor11UntrackStarERa at 0x0200ff60
  * Actor::UntrackStar(s8& starID)
  * If starID >= 0, calls SetStarMarker to clear it, then sets starID = -1.
  */
-
-typedef signed char s8;
-typedef unsigned char u8;
-typedef int s32;
-
 struct Actor;
 
 extern void SetStarMarker(s32 id, struct Actor *starMarker, u8 type); /* 0x0202a660 */

--- a/src/_ZN5Actor12BeforeRenderEv.c
+++ b/src/_ZN5Actor12BeforeRenderEv.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* Actor::BeforeRender — checks flags before rendering.
  * Calls ActorBase::BeforeRender(); if it returns 0, returns 0.
  * Otherwise checks: WRONG_AREA (bit5=0x20) -> return 0,
@@ -7,9 +8,6 @@
  * Callee: 0x02043ac8 = ActorBase::BeforeRender()
  *   _ZN9ActorBase12BeforeRenderEv
  */
-
-typedef unsigned int u32;
-
 struct Actor {
     char _pad[0xb0];
     u32 flags;

--- a/src/_ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player.c
+++ b/src/_ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
-
+#include "types.h"
 int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(char *self, char *clsn, char *player)
 {
     volatile s32 pad[4];

--- a/src/_ZN5Actor18AfterInitResourcesEj.c
+++ b/src/_ZN5Actor18AfterInitResourcesEj.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef struct ActorDerived { char pad[0]; } ActorDerived;
 
 extern void _ZN12ActorDerived18AfterInitResourcesEj(ActorDerived *self, u32 result);

--- a/src/_ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j.c
+++ b/src/_ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* Actor::DropShadowScaleXYZ — drops a shadow with separate X/Y/Z scales.
  * Reads flags@0xb0, tests OFF_SHADOW_RANGE (bit4=0x10).
  * If flag is set, returns immediately; otherwise calls ShadowModel::InitModel.
@@ -5,11 +6,6 @@
  * Callee: 0x02015e64 = ShadowModel::InitModel(Matrix4x3*, Fix12i, Fix12i, Fix12i, u32)
  *   _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef int Fix12i;
-
 struct Matrix4x3;
 struct ShadowModel;
 

--- a/src/_ZN5Actor18FindExplosionActorER12CylinderClsn.c
+++ b/src/_ZN5Actor18FindExplosionActorER12CylinderClsn.c
@@ -1,7 +1,5 @@
+#include "types.h"
 // Actor::FindExplosionActor - find the actor that caused an explosion hit
-
-typedef unsigned int u32;
-
 struct CylinderClsn {
     void* vtable;
     int radius;

--- a/src/_ZN5Actor19BeforeInitResourcesEv.c
+++ b/src/_ZN5Actor19BeforeInitResourcesEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct Actor {
     char pad[0xb0];
     u32 flags;

--- a/src/_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j.c
+++ b/src/_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* Actor::DropShadowRadHeight — drops a shadow with radius/depth (not XYZ).
  * Reads flags@0xb0, tests OFF_SHADOW_RANGE (bit4=0x10).
  * If flag is set, returns immediately; otherwise calls ShadowModel::InitModel
@@ -7,11 +8,6 @@
  * Callee: 0x02015e64 = ShadowModel::InitModel(Matrix4x3*, Fix12i, Fix12i, Fix12i, u8)
  *   _ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef int Fix12i;
-
 struct Matrix4x3;
 struct ShadowModel;
 

--- a/src/_ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn.c
+++ b/src/_ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // Actor::MakeVanishLuigiWork(CylinderClsn&): clears bit 1 of the cylinder's
 // flags (+0x18), then re-sets it if the closest player has +0x6fb set
 // (vanish-cap state). Callee: _ZN5Actor13ClosestPlayerEv @ 0x02010ad8.
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 
 void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *self, char *clsn)

--- a/src/_ZN5Actor7FindEggER12CylinderClsn.c
+++ b/src/_ZN5Actor7FindEggER12CylinderClsn.c
@@ -1,7 +1,5 @@
+#include "types.h"
 // Actor::FindEgg - find the egg actor that hit us
-
-typedef unsigned int u32;
-
 struct CylinderClsn {
     void* vtable;
     int radius;

--- a/src/_ZN5ActorC2Ev.cpp
+++ b/src/_ZN5ActorC2Ev.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5ActorC2Ev
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Actor.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
 extern "C" {
 extern int data_0208e4b8;
 extern int data_0208e3a4;

--- a/src/_ZN5Crate8BehaviorEv.cpp
+++ b/src/_ZN5Crate8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Crate8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Actor.h"
@@ -6,10 +7,6 @@
 /* recovered: named members + shared header, real C++ method */
 #include "Crate.h"
 /* _ZN5Crate8BehaviorEv at 0x02139b0c */
-typedef unsigned int u32;
-typedef unsigned char u8;
-
-
 enum Bool { FALSE, TRUE };
 
 extern u32 data_0209b454;

--- a/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
+++ b/src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 struct WithMeshClsn;
 struct Enemy;
 typedef int (Enemy::*PMF)(WithMeshClsn&);
 extern PMF data_ov002_0210dbc0[];
 extern "C" {
-typedef unsigned int u32;
 extern void DecIfAbove0_Short(short *p);
 extern int _ZN5Actor9UpdatePosEP12CylinderClsn(Enemy *thiz, void *clsn);
 extern int _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(Enemy *thiz, WithMeshClsn *clsn, u32 sel);

--- a/src/_ZN5Enemy12KillByAttackER5Actor.cpp
+++ b/src/_ZN5Enemy12KillByAttackER5Actor.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Enemy12KillByAttackER5Actor
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Enemy.h"
-typedef unsigned short u16;
 extern "C" void _ZN5Enemy12KillByAttackER5Actor(void *self, void *actor, void *c2, void *c3)
 {
     void *r8 = self;

--- a/src/_ZN5Event6GetBitEj.c
+++ b/src/_ZN5Event6GetBitEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* Event::GetBit(u32 bit) at 0x02029ee0
  * Free function in namespace Event (no `this`). Returns nonzero if bit `bit`
  * is set in the global event bitfield EVENT_FIELD. Declared in SM64DS_2.h:
@@ -6,10 +7,6 @@
  * Reloc resolves to EVENT_FIELD at 0x0209f34c (symbols.txt: data_0209f34c).
  * The `1 << n` shift is load-bearing.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 extern s32 EVENT_FIELD; /* 0x0209f34c */
 
 s32 _ZN5Event6GetBitEj(u32 bit)


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 73 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
