### PR TITLE
readable: consolidate 83 files onto shared types.h (byte-verified)

### DIFF
--- a/src/_ZN5Event6SetBitEj.c
+++ b/src/_ZN5Event6SetBitEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* Event::SetBit(u32 bit) at 0x02029ec4
  * Free function in namespace Event (no `this`). Sets bit `bit` in the global
  * event bitfield EVENT_FIELD. Declared in SM64DS_2.h:
@@ -6,10 +7,6 @@
  * Reloc resolves to EVENT_FIELD at 0x0209f34c (symbols.txt: data_0209f34c).
  * The `1 << n` shift is load-bearing.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 extern s32 EVENT_FIELD; /* 0x0209f34c */
 
 void _ZN5Event6SetBitEj(u32 bit)

--- a/src/_ZN5Koopa8BehaviorEv.cpp
+++ b/src/_ZN5Koopa8BehaviorEv.cpp
@@ -1,14 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Koopa8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Enemy.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Koopa.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(void *self, void *wm, void *ma, unsigned int j);
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void *self, void *c);
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *self, void *c);

--- a/src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp
+++ b/src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp
@@ -1,11 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Model13LoadTexAndPalER8BMD_File
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Model.h"
-typedef unsigned int u32;
-
 extern "C" {
 
 

--- a/src/_ZN5Model14LoadAndSetFileEtii.c
+++ b/src/_ZN5Model14LoadAndSetFileEtii.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct ModelBase16f9c {
     u32 vtable;
     void *unk04;

--- a/src/_ZN5Model17LoadTextureToVramEPcj.c
+++ b/src/_ZN5Model17LoadTextureToVramEPcj.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol _ZN5Model17LoadTextureToVramEPcj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Model.h"
-typedef unsigned int u32;
-
-
-
 u32 _ZN5Model17LoadTextureToVramEPcj(char* texData, u32 size) {
     u32 vramOffset = _ZN5Model13GetVramOffsetEj(size);
     _ZN2GX12BeginLoadTexEv();

--- a/src/_ZN5Model8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN5Model8LoadFileER13SharedFilePtr.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN5Model8LoadFileER13SharedFilePtr
 /* recovered: named members + shared header */
 #include "Model.h"
@@ -6,9 +7,6 @@
  * calls UpdateFileOffsets, AddToCommonModelDataArr, and ReallocateModelFile.
  * Returns the BMD_File pointer.
  */
-
-typedef unsigned char u8;
-
 struct SharedFilePtr {
     unsigned short fileID;  /* 0x00 */
     u8 numRefs;             /* 0x02 */

--- a/src/_ZN5Model9Virtual10ER9Matrix4x3.c
+++ b/src/_ZN5Model9Virtual10ER9Matrix4x3.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct Matrix4x3 {
     s32 m[12];
 };

--- a/src/_ZN5Scene12BeforeRenderEv.c
+++ b/src/_ZN5Scene12BeforeRenderEv.c
@@ -1,12 +1,10 @@
+#include "types.h"
 /* Scene::BeforeRender — delegates to ActorBase::BeforeRender and returns its result as bool.
  * ActorBase::BeforeRender returns 0 or non-zero; Scene converts to bool (0 or 1).
  *
  * Callee: 0x02043ac8 = ActorBase::BeforeRender()
  *   _ZN9ActorBase12BeforeRenderEv
  */
-
-typedef unsigned int u32;
-
 struct Scene;
 
 extern int _ZN9ActorBase12BeforeRenderEv(struct Scene* self);

--- a/src/_ZN5Scene14BeforeBehaviorEv.cpp
+++ b/src/_ZN5Scene14BeforeBehaviorEv.cpp
@@ -1,11 +1,9 @@
 //cpp
+#include "types.h"
 /* Scene::BeforeBehavior() at 0x0202e3d4, size 0x1fc
  * Matched byte-for-byte with mwccarm 1.2/sp2p3
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct A {
     virtual void v0();
     virtual void v1();

--- a/src/_ZN5Scene14StartSceneFadeEjjt.c
+++ b/src/_ZN5Scene14StartSceneFadeEjjt.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol _ZN5Scene14StartSceneFadeEjjt
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Scene.h"
 /* recovered: named members + shared header */
 #include "Scene.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-
-
 struct FaderColor {
     int vtable_dummy; // 0x0
     int currInterp;   // 0x4

--- a/src/_ZN5Scene16SpawnIfNecessaryEv.c
+++ b/src/_ZN5Scene16SpawnIfNecessaryEv.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_02092660;
 extern u16 data_02092664;
 extern int data_0209f5b8;

--- a/src/_ZN5Scene19ResetFadersAndSoundEv.c
+++ b/src/_ZN5Scene19ResetFadersAndSoundEv.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef struct ActorBase { char pad[0]; } ActorBase;
 typedef struct FaderBrightness { char pad[0]; } FaderBrightness;
 typedef struct Scene { char pad[0]; } Scene;

--- a/src/_ZN5Scene20SetAndStopColorFaderEv.c
+++ b/src/_ZN5Scene20SetAndStopColorFaderEv.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef struct FaderBrightness {
     char pad[8];
     u32 state;  /* offset 8 */

--- a/src/_ZN5Scene21AfterCleanupResourcesEj.cpp
+++ b/src/_ZN5Scene21AfterCleanupResourcesEj.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
   unsigned char data_02092660;
   void _ZN9ActorBase21AfterCleanupResourcesEj(void* thiz, u32 x);

--- a/src/_ZN5Scene22BeforeCleanupResourcesEv.c
+++ b/src/_ZN5Scene22BeforeCleanupResourcesEv.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Scene {
     char pad[0];
 };

--- a/src/_ZN5Scene22ResetHardwareRegistersEv.cpp
+++ b/src/_ZN5Scene22ResetHardwareRegistersEv.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 struct Matrix2x2 { int m[4]; };
 
 extern "C" {

--- a/src/_ZN5Sound15PlaySecretSoundEP5ActorPt.c
+++ b/src/_ZN5Sound15PlaySecretSoundEP5ActorPt.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Actor { char _pad[0xd4]; };
 
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12i dist, int loop);

--- a/src/_ZN5Sound20PlaySmallSecretSoundEP5ActorPt.c
+++ b/src/_ZN5Sound20PlaySmallSecretSoundEP5ActorPt.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Actor { char _pad[0xd4]; };
 
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12i dist, int loop);

--- a/src/_ZN5Stage10CheckInputEv.cpp
+++ b/src/_ZN5Stage10CheckInputEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef signed char s8;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 struct TouchData { u8 touched; u8 tapped; u8 x; u8 y; };
 struct PadData { u16 held; u16 pressed; };
 struct Ctrl {

--- a/src/_ZN5Stage10LoadSkyboxEv.c
+++ b/src/_ZN5Stage10LoadSkyboxEv.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 typedef struct {
     char data[0x50];
 } Model;

--- a/src/_ZN5Stage11RenderModelEv.cpp
+++ b/src/_ZN5Stage11RenderModelEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Stage11RenderModelEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct Info {
     char pad[0x14];
     u8 count;

--- a/src/_ZN5Stage12SetVramBanksEv.c
+++ b/src/_ZN5Stage12SetVramBanksEv.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN2GX15DisableAllBanksEv(void);
 extern void _ZN2GX13SetBankForTexEt(u16);
 extern void _ZN2GX17SetBankForTexPlttEt(u16);

--- a/src/_ZN5Stage13UpdateMessageEv.cpp
+++ b/src/_ZN5Stage13UpdateMessageEv.cpp
@@ -1,10 +1,5 @@
 //cpp
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_0209d660;
 extern u8 data_0209d654;
 extern s16 data_0209d6d4;

--- a/src/_ZN5Stage14GraphCallback2EP12SceneRelated.c
+++ b/src/_ZN5Stage14GraphCallback2EP12SceneRelated.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol _ZN5Stage14GraphCallback2EP12SceneRelated
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Stage.h"
 // Stage::GraphCallback2 - sets BG3 affine transform from SceneRelated
-typedef int s32;
-typedef unsigned short u16;
-typedef volatile u16 vu16;
-
 struct Matrix2x2 {
     s32 unk0;
     s32 unk4;

--- a/src/_ZN5Stage14LoadGraphics2DEbi.cpp
+++ b/src/_ZN5Stage14LoadGraphics2DEbi.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 void SetBg0Offset(int a, int b);
 void LoadFont(u8 arg);

--- a/src/_ZN5Stage16CheckCameraInputEv.cpp
+++ b/src/_ZN5Stage16CheckCameraInputEv.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct TouchInfo {
     u8 touched;
     u8 held;

--- a/src/_ZN5Stage16CleanupResourcesEv.cpp
+++ b/src/_ZN5Stage16CleanupResourcesEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Stage16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
@@ -6,10 +7,6 @@
  * Releases the level file handles, tears down fader/mesh-collider/message
  * state and unloads the level overlays/archive. Returns 1.
  */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned int u32;
-
 extern "C" {
 extern void *data_020756f0[];   /* 12 SharedFilePtr* released on cleanup */
 extern u8 data_0209f2d8;

--- a/src/_ZN5Stage17PS_UpdateSaveMenuEb.c
+++ b/src/_ZN5Stage17PS_UpdateSaveMenuEb.c
@@ -1,10 +1,9 @@
+#include "types.h"
 // @symbol _ZN5Stage17PS_UpdateSaveMenuEb
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Stage.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
 extern u16 *_ZN3G2S12GetBG1ScrPtrEv(void);
 
 void _ZN5Stage17PS_UpdateSaveMenuEb(int b)

--- a/src/_ZN5Stage17UpdateMenuButtonsEb.c
+++ b/src/_ZN5Stage17UpdateMenuButtonsEb.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol _ZN5Stage17UpdateMenuButtonsEb
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Stage.h"
-
-    typedef unsigned char u8;
-    typedef unsigned short u16;
     extern u8 data_0209f2c4;
     extern unsigned short *_ZN3G2S12GetBG1ScrPtrEv(void);
     void _ZN5Stage17UpdateMenuButtonsEb(int b)

--- a/src/_ZN5Stage19RenderVsModeNewStarEv.cpp
+++ b/src/_ZN5Stage19RenderVsModeNewStarEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 extern u16 data_0209f308;
 extern u8 data_0209f204;

--- a/src/_ZN5Stage20PS_UpdateOptionsMenuEv.cpp
+++ b/src/_ZN5Stage20PS_UpdateOptionsMenuEv.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 namespace G2S { u16 *GetBG1ScrPtr(); }
 
 extern u8 data_0209f2e4;

--- a/src/_ZN5Stage22RenderModelTransparentEv.cpp
+++ b/src/_ZN5Stage22RenderModelTransparentEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Stage22RenderModelTransparentEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct VBase {
     virtual void m0();
     virtual void m1();

--- a/src/_ZN5Stage23LoadTextureTransformersEv.cpp
+++ b/src/_ZN5Stage23LoadTextureTransformersEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Stage23LoadTextureTransformersEv
 /* recovered: named members + shared header, real C++ method */
 #include "Stage.h"
-typedef unsigned int u32;
 struct Entry { int x; void* bta; char pad[4]; };
 struct Info { char a[0x10]; struct Entry* entries; unsigned char count; };
 extern struct Info* data_0209f340;

--- a/src/_ZN5Stage6RenderEv.cpp
+++ b/src/_ZN5Stage6RenderEv.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-
+#include "types.h"
 struct Animation {
     void Advance();
 };

--- a/src/_ZN5Stage7PS_InitEv.c
+++ b/src/_ZN5Stage7PS_InitEv.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_0209d454;
 extern u8 data_0209d45c;
 extern u8 data_0209f1ec;

--- a/src/_ZN5Stage7PS_InitEv.cpp
+++ b/src/_ZN5Stage7PS_InitEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern "C" int SublevelToLevel(int i);
 
 struct Sound {

--- a/src/_ZN5Stage8BehaviorEv.cpp
+++ b/src/_ZN5Stage8BehaviorEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed char s8;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
     void ProcessKuppaScript();
     void func_02032f54();

--- a/src/_ZN5Stage8CanPauseEv.c
+++ b/src/_ZN5Stage8CanPauseEv.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern unsigned char data_0209f2d8;
 extern int data_0209fc68;
 extern unsigned char data_0209f2bc;

--- a/src/_ZN5Stage9LC_UpdateEv.cpp
+++ b/src/_ZN5Stage9LC_UpdateEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef short s16;
-typedef signed int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 int IsButtonInputValid(void);
 void _ZN5Stage17UpdateMenuButtonsEb(int b);

--- a/src/_ZN5Stage9PS_UpdateEv.cpp
+++ b/src/_ZN5Stage9PS_UpdateEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // Cases 0/2/3/8/0xa..0x13 BYTE-EXACT.
 /*
  * Stage::PS_Update @ 0x0202635c size 0x30ac, mwccarm 1.2/sp2p3 -O4,p -lang c++
@@ -21,13 +22,6 @@
  *   after the displayed-level normalization, makes MWCC schedule the case-1
  *   literal loads in ROM order without changing behavior.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef short s16;
-typedef signed int s32;
-typedef unsigned int u32;
-
 extern "C" {
 int IsButtonInputValid(void);
 int func_02029408(void);

--- a/src/_ZN5Stage9VE_UpdateEv.cpp
+++ b/src/_ZN5Stage9VE_UpdateEv.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern "C" {
 extern u8 data_0209f244;
 extern u8 data_0209f22c;

--- a/src/_ZN5Unagi8BehaviorEv.cpp
+++ b/src/_ZN5Unagi8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Unagi8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Unagi.h"
-typedef short s16;
-typedef unsigned short u16;
-
 struct C;
 typedef void (C::*PMF)();
 

--- a/src/_ZN5Whomp13InitResourcesEv.cpp
+++ b/src/_ZN5Whomp13InitResourcesEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN5Whomp13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Whomp.h"
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct SharedFilePtr;
 struct BMD_File;
 struct BTP_File;

--- a/src/_ZN6Bowser8BehaviorEv.cpp
+++ b/src/_ZN6Bowser8BehaviorEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Bowser8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Bowser.h"
-typedef int Fix12;
-typedef short s16;
-typedef unsigned char u8;
-
-
 struct Actor {
     Actor* ClosestPlayer();
     static Actor* FindWithActorID(unsigned id, Actor* a);

--- a/src/_ZN6Bullet13InitResourcesEv.cpp
+++ b/src/_ZN6Bullet13InitResourcesEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Bullet13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Bullet.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
 struct Actor;
 struct Vector3_16;
 struct BMD_File;

--- a/src/_ZN6Camera13InitResourcesEv.cpp
+++ b/src/_ZN6Camera13InitResourcesEv.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Camera_State { void *a, *b; };
 
 struct Camera {

--- a/src/_ZN6Camera8BehaviorEv.cpp
+++ b/src/_ZN6Camera8BehaviorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Camera8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Camera.h"
@@ -6,14 +7,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Camera.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef s32 Fix12i;
-
 enum Bool { FALSE, TRUE };
 
 extern "C" {

--- a/src/_ZN6Camera9SetFlag_3Ev.cpp
+++ b/src/_ZN6Camera9SetFlag_3Ev.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct Camera {
     char pad[0x154];
     u32 flags;

--- a/src/_ZN6CameraC1Ev.c
+++ b/src/_ZN6CameraC1Ev.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // @symbol _ZN6CameraC1Ev
 /* recovered: named members + shared header */
 #include "Camera.h"
-typedef unsigned int u32;
-typedef int s32;
-
 /* 4x3 matrix: 48 bytes */
 typedef struct { s32 m[12]; } Matrix4x3;
 

--- a/src/_ZN6Cannon13InitResourcesEv.cpp
+++ b/src/_ZN6Cannon13InitResourcesEv.cpp
@@ -1,10 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Cannon13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Cannon.h"
-typedef unsigned char u8;
 extern "C" void *_ZN5Model8LoadFileER13SharedFilePtr(void *fp);
 extern "C" void _ZN9ModelBase7SetFileEP8BMD_Fileii(void *thiz, void *file, int a, int b);
 extern "C" void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *thiz, void *actor, int r, int h, unsigned int a, unsigned int b);

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Dorrie13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Dorrie.h"
-typedef int Fix12;
-typedef short s16;
-typedef unsigned char u8;
-
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* f);

--- a/src/_ZN6Eyerok13InitResourcesEv.cpp
+++ b/src/_ZN6Eyerok13InitResourcesEv.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Eyerok13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Eyerok.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
-
 extern int data_ov066_0211ae6c[];
 extern int data_ov066_0211ae4c[];
 extern int data_ov066_0211aeb4[];

--- a/src/_ZN6Lakitu16CleanupResourcesEv.c
+++ b/src/_ZN6Lakitu16CleanupResourcesEv.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
-
+#include "types.h"
 struct SharedFilePtr { u16 fileID; u8 numRefs; char* filePtr; };
 
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);

--- a/src/_ZN6Memory8AllocateEj.cpp
+++ b/src/_ZN6Memory8AllocateEj.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 class Heap;
 
 namespace Memory

--- a/src/_ZN6Memory8AllocateEji.cpp
+++ b/src/_ZN6Memory8AllocateEji.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* Memory::Allocate(unsigned, int) at 0x0203c1d8 -- convenience overload that
  * forwards to Memory::Allocate(unsigned, int, Heap*) with a null heap. */
-
-typedef unsigned int u32;
-
 class Heap;
 
 namespace Memory

--- a/src/_ZN6Memory8AllocateEjiP4Heap.c
+++ b/src/_ZN6Memory8AllocateEjiP4Heap.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // Memory::Allocate(u32 size, s32 align, Heap* heap)
 // Address: 0x0203c210
 // If heap is NULL, uses Memory::defaultHeapPtr. Then calls Heap::Allocate.
-
-typedef unsigned int u32;
-typedef int s32;
-
 struct Heap {
     void* heapStart;  // 0x00
     u32   heapSize;   // 0x04

--- a/src/_ZN6Player11OpenBigDoorEv.cpp
+++ b/src/_ZN6Player11OpenBigDoorEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player11OpenBigDoorEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
@@ -6,9 +7,6 @@
  * Sets a u8 flag at offset 0x70b (1803) in the Player object to 1.
  * Player.h has only `u8 unk70b` here, so keep the typed offset access.
  */
-
-typedef unsigned char u8;
-
 struct Player;
 
 void Player::OpenBigDoor()

--- a/src/_ZN6Player11St_Fly_MainEv.cpp
+++ b/src/_ZN6Player11St_Fly_MainEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 struct State;
 
 struct Player {

--- a/src/_ZN6Player12St_Bonk_MainEv.cpp
+++ b/src/_ZN6Player12St_Bonk_MainEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Bonk_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct Camera;
 
 extern "C" {

--- a/src/_ZN6Player12St_Hurt_InitEv.cpp
+++ b/src/_ZN6Player12St_Hurt_InitEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Hurt_InitEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
-
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* thiz, u32 anim, int a, int fix, u32 b);
 extern int _ZNK6Player14GetBodyModelIDEjb(char* thiz, u32 a, int b);
 extern void func_ov002_020d93ac(char* thiz);

--- a/src/_ZN6Player12St_Hurt_MainEv.cpp
+++ b/src/_ZN6Player12St_Hurt_MainEv.cpp
@@ -1,10 +1,5 @@
 //cpp
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" {
 extern void func_ov002_020d9a4c(char *c);
 extern void func_ov002_020d99a4(unsigned char *self);

--- a/src/_ZN6Player12St_Jump_InitEv.cpp
+++ b/src/_ZN6Player12St_Jump_InitEv.cpp
@@ -1,10 +1,5 @@
 //cpp
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" {
 extern int func_ov002_020e2be4(char *c);
 extern int func_ov002_020e2b6c(char *c);

--- a/src/_ZN6Player12St_Jump_MainEv.cpp
+++ b/src/_ZN6Player12St_Jump_MainEv.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Jump_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 extern "C" {
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int func_ov002_020eeca8(void*, void*);
 extern int func_ov002_020e28d4(void*, int, int);
 extern int _ZN6Player11ChangeStateERNS_5StateE(void*, void*);

--- a/src/_ZN6Player12St_Land_InitEv.cpp
+++ b/src/_ZN6Player12St_Land_InitEv.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 class Player {
 public:
     int St_Land_Init();

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Land_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern int func_ov002_020c0434(void* c);
 extern void func_ov002_020c0364(void* c, u32 arg);

--- a/src/_ZN6Player12St_Spin_MainEv.c
+++ b/src/_ZN6Player12St_Spin_MainEv.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
 extern char data_ov002_02110424;

--- a/src/_ZN6Player12St_Talk_MainEv.cpp
+++ b/src/_ZN6Player12St_Talk_MainEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Talk_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-typedef int s32;
-
 extern "C" {
 extern int _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, int t);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -1,17 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12St_Walk_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int func_ov002_020c5244(void);

--- a/src/_ZN6Player12Unk_020c6a10Ej.cpp
+++ b/src/_ZN6Player12Unk_020c6a10Ej.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player12Unk_020c6a10Ej
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, void* st);
 extern int func_ov002_020d91e0(void* thiz, u32 a, int b);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);

--- a/src/_ZN6Player13InitFireYoshiEv.cpp
+++ b/src/_ZN6Player13InitFireYoshiEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player13InitFireYoshiEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned short u16;
-
 extern "C" void _ZN6Player11ChangeStateERNS_5StateE(char *c, void *st);
 extern int data_ov002_0211004c;
 

--- a/src/_ZN6Player13OnYoshiTryEatEv.cpp
+++ b/src/_ZN6Player13OnYoshiTryEatEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player13OnYoshiTryEatEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
@@ -6,9 +7,6 @@
  * Overrides Actor's slot 17; returns an OnYoshiEatReturnVal of 1
  * (Yoshi cannot eat the Player). The implicit Player* this is unused.
  */
-
-typedef unsigned int u32;
-
 struct Player;
 
 u32 Player::OnYoshiTryEat()

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -1,17 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player13St_Crawl_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);

--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player13St_Shell_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_ClsnResult.h"
@@ -6,14 +7,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-typedef s32 Fix12;
-
 extern "C" {
 extern void* _ZN5Actor10FindWithIDEj(u32 id);
 extern void func_ov002_020eeca8(void* c, int arg);

--- a/src/_ZN6Player14InitMetalWarioEv.cpp
+++ b/src/_ZN6Player14InitMetalWarioEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14InitMetalWarioEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_ModelAnim2.h"
@@ -6,10 +7,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern "C" void func_ov002_020bda48(char *self);
 extern "C" u32 _ZNK6Player14GetBodyModelIDEjb(char *self, u32 a, bool b);
 extern "C" void func_ov002_020bd9ec(char *self, u32 a);

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14St_Cannon_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern short GetAngleToCamera(int i);
 extern void func_0200d6f0(void* thiz, u8 pid);

--- a/src/_ZN6Player14St_Crouch_MainEv.cpp
+++ b/src/_ZN6Player14St_Crouch_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14St_Crouch_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020bf90c(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);

--- a/src/_ZN6Player14St_OnWall_MainEv.cpp
+++ b/src/_ZN6Player14St_OnWall_MainEv.cpp
@@ -1,18 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14St_OnWall_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Player.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef long long s64;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020c0364(char* c, u32 a);
 extern void func_ov002_020cabe0(char* c);

--- a/src/_ZN6Player14St_Squish_MainEv.cpp
+++ b/src/_ZN6Player14St_Squish_MainEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14St_Squish_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern u8 data_ov002_0211117c;
 extern char data_ov002_0211013c;
 extern char data_ov002_021101b4;

--- a/src/_ZN6Player14St_Thrown_MainEv.cpp
+++ b/src/_ZN6Player14St_Thrown_MainEv.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player14St_Thrown_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
-
 extern "C" {
 extern void func_ov002_020bf90c(char* c);
 extern void func_ov002_020c06fc(char* c, u32 mask);

--- a/src/_ZN6Player15St_DeadHit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadHit_MainEv.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player15St_DeadHit_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" {
 extern void func_ov002_020d94cc(char *c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void *v);

--- a/src/_ZN6Player15St_DeadPit_InitEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_InitEv.cpp
@@ -1,11 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player15St_DeadPit_InitEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
 extern "C" {
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern u8 data_0209f2d8;
 extern u8 data_0209f250;
 

--- a/src/_ZN6Player15St_DeadPit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_MainEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player15St_DeadPit_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);

--- a/src/_ZN6Player15St_Grabbed_MainEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_MainEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player15St_Grabbed_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern "C" void Player_AdvanceAnims(char* self);
 extern "C" void _ZN6Player9DropActorEv(char* a);
 extern "C" unsigned int _ZNK6Player14GetBodyModelIDEjb(char* self, unsigned int a, int b);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 83 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
