### PR TITLE
readable: consolidate 74 files onto shared types.h (byte-verified)

### DIFF
--- a/src/_ZN6Player15St_Respawn_MainEv.cpp
+++ b/src/_ZN6Player15St_Respawn_MainEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player15St_Respawn_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" {
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 a, int b, int f, u32 g);
 extern int _ZN6Player12FinishedAnimEv(void *c);

--- a/src/_ZN6Player15St_Talk_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Talk_CleanupEv.cpp
@@ -1,8 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct Player {
     char _pad0[0xb0];
     u32 flagB0;            /* 0xb0 */

--- a/src/_ZN6Player16CleanupResourcesEv.cpp
+++ b/src/_ZN6Player16CleanupResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player16CleanupResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef signed char s8;
-
 enum { false_, true_ };
 
 struct VB { virtual void v0(); virtual void v1(); };

--- a/src/_ZN6Player16SetRealCharacterEj.cpp
+++ b/src/_ZN6Player16SetRealCharacterEj.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player16SetRealCharacterEj
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_ModelAnim2.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct SharedFilePtr;
 
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(SharedFilePtr *self);

--- a/src/_ZN6Player16St_BurnLava_MainEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_MainEv.cpp
@@ -1,15 +1,11 @@
 //cpp
+#include "types.h"
 /* _ZN6Player16St_BurnLava_MainEv @ 0x020d5038 (ov002, size 0x264)
  * Player burn-in-lava state: kills the player once outside battle levels,
  * spawns smoke/steam particles with the burn SFX, then runs the 3-hop
  * bounce (halving y-velocity, hop height 0x14000/0xa000) until the burnt
  * anim finishes, then leaves via state change or death.
  */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern u8 data_ov002_0211117c;
 extern s8 data_0209f2f8;
 extern s16 data_02082214[];

--- a/src/_ZN6Player16St_DebugFly_MainEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_MainEv.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player16St_DebugFly_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern "C" int func_ov002_020bf224(int a, int b, int c);
 extern "C" void _ZN6Player11ChangeStateERNS_5StateE(char *self, void *st);
 extern "C" void Player_AdvanceAnims(char *self);

--- a/src/_ZN6Player16St_SideFlip_MainEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player16St_SideFlip_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020eeca8(void* a, void* b);
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);

--- a/src/_ZN6Player16St_Teleport_MainEv.cpp
+++ b/src/_ZN6Player16St_Teleport_MainEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player16St_Teleport_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 typedef struct Obj { s16 x, y, z; u16 param; } Obj;
 
 extern "C" {

--- a/src/_ZN6Player17SetNoControlStateEhih.cpp
+++ b/src/_ZN6Player17SetNoControlStateEhih.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17SetNoControlStateEhih
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
 struct State;
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, struct State* s);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, struct State* s);

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_ButtSlide_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020bf90c(char* c);
 extern void func_ov002_020c06fc(char* c, u32 a);

--- a/src/_ZN6Player17St_Headstand_MainEv.cpp
+++ b/src/_ZN6Player17St_Headstand_MainEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_Headstand_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct Obj {
     virtual void v0();
     virtual void v1();

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -1,18 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_HoldHeavy_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-typedef s32 Fix12;
-
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -1,18 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_HoldLight_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-typedef s32 Fix12;
-
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int func_ov002_020c0434(void* c);

--- a/src/_ZN6Player17St_LedgeHang_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_LedgeHang_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);

--- a/src/_ZN6Player17St_NoControl_MainEv.cpp
+++ b/src/_ZN6Player17St_NoControl_MainEv.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_NoControl_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-typedef int s32;
-
 extern "C" {
 extern short GetAngleToCamera(int i);
 extern void func_ov002_020c9718(char* c);

--- a/src/_ZN6Player17St_PunchKick_MainEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_MainEv.cpp
@@ -1,17 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_PunchKick_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Player.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020d8a50(void* c, u32 a);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player17St_SlideKick_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020bf90c(void* c);
 extern void func_ov002_020c06fc(void* c, u32 flag);

--- a/src/_ZN6Player17St_WindCarry_MainEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_MainEv.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int Fix12;
-typedef unsigned char u8;
-
+#include "types.h"
 struct State;
 struct Player {
     int St_WindCarry_Main();

--- a/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
+++ b/src/_ZN6Player18St_Grabbed_CleanupEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 /* Player::St_Grabbed_Cleanup — clear flag bit1 at +0x2ec; if a held actor
  * (+0x35c) exists with actorID 0xbf, drop it and clear the slot. Returns 1.
  * Callee: _ZN6Player9DropActorEv (called with the held actor as arg).
  */
 extern "C" {
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct Actor {
     char _pad0[0xc];
     u16 actorID;          /* 0xc */

--- a/src/_ZN6Player18St_LevelEnter_InitEv.cpp
+++ b/src/_ZN6Player18St_LevelEnter_InitEv.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player18St_LevelEnter_InitEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
-
 typedef struct RaycastGround {
     char pre[0x10];
     char result[0x34];

--- a/src/_ZN6Player18St_TurnAround_MainEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player18St_TurnAround_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);

--- a/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
+++ b/src/_ZN6Player20St_CeilingGrate_MainEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player20St_CeilingGrate_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(char* c, void* st);
 extern int _ZN6Player12FinishedAnimEv(char* c);

--- a/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
+++ b/src/_ZN6Player20St_InYoshiMouth_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player20St_InYoshiMouth_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
 extern "C" {
 extern int func_ov002_020d5cec(char *c);
 extern void Vec3_RotateYAndTranslate(Vector3 *res, Vector3 *trans, short angY, Vector3 *add);

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player20St_StomachSlide_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern void func_ov002_020bf90c(void* c);
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);

--- a/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
+++ b/src/_ZN6Player21St_JumpQuicksand_MainEv.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player21St_JumpQuicksand_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern char data_ov002_02110424;
 
 extern "C" {

--- a/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
+++ b/src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player21St_OpeningWakeUp_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern int _ZN6Player12FinishedAnimEv(void* thiz);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, int a, int b, int c, u32 d);
 extern void Player_AdvanceAnims(void* thiz);

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -1,17 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player21St_StuckInGround_MainEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);

--- a/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player22St_GrabBowserTail_MainEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(char* c);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12 b, u32 d);

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
 extern "C" {
 extern int _ZN6Player8HasNoCapEv(char* c);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player6RenderEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct VObj {
     virtual void d00();
     virtual void d04();

--- a/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
+++ b/src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int Fix12i;
+#include "types.h"
 #define LAUNDER16(p) ((u16 *)(int)(((long long)(int)(p))))
 extern "C" {
 extern u8 data_0209f2d8;

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef signed char s8;
-typedef short s16;
-typedef int s32;
-typedef long long s64;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct C3;
 typedef int (C3::*PMF)();
 struct State {

--- a/src/_ZN6Player9DropActorEv.cpp
+++ b/src/_ZN6Player9DropActorEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN6Player9DropActorEv
 /* recovered: named members + shared header, real C++ method */
 #include "Player.h"
-typedef unsigned int u32;
-typedef unsigned long long u64;
 struct State;
 struct Player;
 extern "C" int _ZN6Player7IsStateERNS_5StateE(Player* thiz, State* s);

--- a/src/_ZN6Player9StartTalkER9ActorBaseb.cpp
+++ b/src/_ZN6Player9StartTalkER9ActorBaseb.cpp
@@ -1,7 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned char u8;
-typedef unsigned short u16;
 struct State;
 struct ActorBase;
 

--- a/src/_ZN7Clipper13Func_020156DCEv.cpp
+++ b/src/_ZN7Clipper13Func_020156DCEv.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Clipper13Func_020156DCEv
 /* recovered: named members + shared header */
 #include "Clipper.h"
-typedef int Fix12i;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern "C" {
 
 void _ZN7Clipper13Func_0201559CEv(void* self);

--- a/src/_ZN7HeaveHo8BehaviorEv.cpp
+++ b/src/_ZN7HeaveHo8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7HeaveHo8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "HeaveHo.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef int Fix12;
 struct Klass; typedef void (Klass::*PMF)();
 struct M { char pad[8]; PMF pmf; };
 struct CylinderClsn;

--- a/src/_ZN7Message11DisplayTextEt.cpp
+++ b/src/_ZN7Message11DisplayTextEt.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Message11DisplayTextEt
 /* recovered: named members + shared header */
 #include "Message.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct StarEntry {
     int m0;
     u16 m4;

--- a/src/_ZN7Message11PrepareTalkEv.c
+++ b/src/_ZN7Message11PrepareTalkEv.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* _ZN7Message11PrepareTalkEv at 0x0201ab38, size=0x34
  * Message::PrepareTalk - ducks music volume to 0x40 at rate 0xc999/4096,
  * sets the "in talk" flag at 0x0209d664 to 1.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
 extern u8 unk_0209d664;  /* 0x0209d664 */
 
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, Fix12i speed);

--- a/src/_ZN7Message12UpdateWindowEv.cpp
+++ b/src/_ZN7Message12UpdateWindowEv.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed short s16;
-
+#include "types.h"
 extern "C" {
     void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(unsigned int vol, int t);
     int func_0201fb4c(void);

--- a/src/_ZN7Message13DisplaySavingEt.cpp
+++ b/src/_ZN7Message13DisplaySavingEt.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Message13DisplaySavingEt
 /* recovered: named members + shared header */
 #include "Message.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-
 struct StarEntry {
     int m0;
     u16 m4;

--- a/src/_ZN7Message28DisplayStarNameForStarSelectEj.cpp
+++ b/src/_ZN7Message28DisplayStarNameForStarSelectEj.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Message28DisplayStarNameForStarSelectEj
 /* recovered: named members + shared header */
 #include "Message.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct StarEntry {
     int m0;
     int m4;

--- a/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
+++ b/src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Message30DisplayCourseNameForStarSelectEj
 /* recovered: named members + shared header, named members + shared header */
 #include "Message.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct StarEntry {
     int m0;
     u16 m4;

--- a/src/_ZN7Message6UpdateEv.cpp
+++ b/src/_ZN7Message6UpdateEv.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Struct6f0 {
     u8 unk0, unk1, unk2, unk3;
     u16 unk4;

--- a/src/_ZN7Message7DisplayEj.cpp
+++ b/src/_ZN7Message7DisplayEj.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Message7DisplayEj
 /* recovered: named members + shared header, real C++ method */
 #include "Message.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern "C" {
 extern u8 data_0209d660;
 extern short data_0209d6d4;

--- a/src/_ZN7Message7EndTalkEv.c
+++ b/src/_ZN7Message7EndTalkEv.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* _ZN7Message7EndTalkEv at 0x0201ab04, size=0x34
  * Message::EndTalk - restores music volume to 0x7f at rate 0x64cc/4096,
  * clears the "in talk" flag at 0x0209d664.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
 extern u8 unk_0209d664;  /* 0x0209d664 */
 
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, Fix12i speed);

--- a/src/_ZN7Minimap13InitResourcesEv.cpp
+++ b/src/_ZN7Minimap13InitResourcesEv.cpp
@@ -1,14 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Minimap13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Minimap.h"
 #pragma opt_strength_reduction off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 extern "C" {
     int func_0202a980(void);
     int LoadFile(int handle);

--- a/src/_ZN7Minimap19UpdateLevelSpecificEv.cpp
+++ b/src/_ZN7Minimap19UpdateLevelSpecificEv.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 extern s8 data_0209f2f8;
 extern u8 data_0209f220;

--- a/src/_ZN7Minimap6RenderEv.cpp
+++ b/src/_ZN7Minimap6RenderEv.cpp
@@ -1,13 +1,6 @@
 //cpp
+#include "types.h"
 #pragma opt_strength_reduction off
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef long long s64;
-
 struct Player {
     int unk0, unk4;
     int unk8;                   // 0x008

--- a/src/_ZN7SkiLift16CleanupResourcesEv.cpp
+++ b/src/_ZN7SkiLift16CleanupResourcesEv.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned int u32;
 struct SharedFilePtr { u32 data[4]; };
 void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 extern struct SharedFilePtr data_ov036_02113c00;

--- a/src/_ZN7Wiggler13InitResourcesEv.cpp
+++ b/src/_ZN7Wiggler13InitResourcesEv.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN7Wiggler13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "Wiggler.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 extern int _ZN5Actor9TrackStarEjj(void *self, u32 a, u32 b);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void *shared);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void *shared);

--- a/src/_ZN8BigBully13InitResourcesEv.cpp
+++ b/src/_ZN8BigBully13InitResourcesEv.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8BigBully13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBully.h"
 extern "C" {
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef short s16;
-typedef unsigned int u32;
-
 typedef struct Actor Actor;
 struct RaycastGround { char buf[0x50]; };
 

--- a/src/_ZN8BigBully8BehaviorEv.cpp
+++ b/src/_ZN8BigBully8BehaviorEv.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8BigBully8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "BigBully.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void* a, u16* p);
 extern int func_ov064_02116d1c(void* c);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void* c, void* clsn, unsigned f);

--- a/src/_ZN8BookShot13InitResourcesEv.cpp
+++ b/src/_ZN8BookShot13InitResourcesEv.cpp
@@ -1,8 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8BookShot13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "BookShot.h"
-typedef unsigned int u32;
 struct Actor; struct Vector3; struct Vector3_16; struct BMD_File;
 typedef struct { int w[2]; } SharedFilePtr;
 

--- a/src/_ZN8CapEnemy14UnloadCapModelEv.c
+++ b/src/_ZN8CapEnemy14UnloadCapModelEv.c
@@ -1,10 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
-typedef signed short s16;
-typedef signed char s8;
-
+#include "types.h"
 struct CapEnemy {
     u8 pad[0x113];
     u8 capID;     // 0x113

--- a/src/_ZN8CapEnemy6AddCapEj.c
+++ b/src/_ZN8CapEnemy6AddCapEj.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void *this_, void *file, int a, int b);
 extern int _ZN13SharedFilePtr7ReleaseEv(void *sfp);

--- a/src/_ZN8CapEnemyC2Ev.c
+++ b/src/_ZN8CapEnemyC2Ev.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 struct Model {
     u32 data[0x14]; /* 0x50 bytes */
 };

--- a/src/_ZN8Goomboss13InitResourcesEv.c
+++ b/src/_ZN8Goomboss13InitResourcesEv.c
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
+#include "types.h"
 struct SharedFilePtr;
 struct BMD_File;
 struct BCA_File;

--- a/src/_ZN8MugenBgm8BehaviorEv.cpp
+++ b/src/_ZN8MugenBgm8BehaviorEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8MugenBgm8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "MugenBgm.h"
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned int u32;
 typedef struct 
 {
   s32 x;

--- a/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
+++ b/src/_ZN8Particle10SysTracker10InitialiseEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8Particle10SysTracker10InitialiseEv
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Heap.h"
@@ -6,10 +7,6 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__SysTracker.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" void DecompressLZ16(const void* src, void* dst);
 
 

--- a/src/_ZN8Particle13ScaleCallback14SpawnParticlesERNS_6SystemE.c
+++ b/src/_ZN8Particle13ScaleCallback14SpawnParticlesERNS_6SystemE.c
@@ -1,11 +1,5 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct System;
-
-typedef short s16;
-
 struct ScaleCallback {
     u32 vtable;     /* 0x00 */
     u16 unk04;      /* 0x04 */

--- a/src/_ZN8Particle13ScaleCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle13ScaleCallback8OnUpdateERNS_6SystemEb.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct System;
 
 struct ScaleCallback {

--- a/src/_ZN8Particle14BubbleCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle14BubbleCallback8OnUpdateERNS_6SystemEb.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Node {
     Node *next;       /* 0x00 */
     char pad4[4];

--- a/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
+++ b/src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef signed short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct SomeGlobal { char pad[4]; void* p; };
 extern SomeGlobal* data_0209ee74;
 

--- a/src/_ZN8Particle14SplashCallback8OnUpdateERNS_6SystemEb.cpp
+++ b/src/_ZN8Particle14SplashCallback8OnUpdateERNS_6SystemEb.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Node {
     Node *next;       /* 0x00 */
     char pad4[4];

--- a/src/_ZN8Particle17CheckLavaCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle17CheckLavaCallback8OnUpdateERNS_6SystemEb.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Particle;
 
 struct ParticleList {

--- a/src/_ZN8Particle19SetSelfDestructFlagEj.c
+++ b/src/_ZN8Particle19SetSelfDestructFlagEj.c
@@ -1,7 +1,7 @@
+#include "types.h"
 // @symbol _ZN8Particle19SetSelfDestructFlagEj
 /* recovered: named members + shared header */
 #include "Particle.h"
-typedef unsigned int u32;
 extern char* data_0209ee74;
 void _ZN8Particle19SetSelfDestructFlagEj(u32 idx)
 {

--- a/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
+++ b/src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle.h"
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
-
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
     Fix12i x, Fix12i y, Fix12i z,

--- a/src/_ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb.c
@@ -1,6 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct ParticleNode {
     void* next;
     void* prev;

--- a/src/_ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE.c
+++ b/src/_ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol _ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE
 /* recovered: named members + shared header */
 #include "Particle__EndingStarGlitterCallback.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int s32;
-typedef short s16;
-
 struct System;
 
 /* EndingStarGlitterCallback fields at large offsets (around 0x300) */

--- a/src/_ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb.c
@@ -1,10 +1,9 @@
+#include "types.h"
 // @symbol _ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__EndingStarGlitterCallback.h"
-typedef signed int s32;
-typedef unsigned int u32;
 typedef int Bool;
 
 /* forward declarations */

--- a/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
+++ b/src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp
@@ -1,12 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__Jitter.h"
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
 extern "C" void _ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3(struct Particle__Jitter *self, char* p, int* v) {
     u32 s;
     int r;

--- a/src/_ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj.c
+++ b/src/_ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj.c
@@ -1,8 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/_ZN8Particle6System12FromUniqueIDEj.c
+++ b/src/_ZN8Particle6System12FromUniqueIDEj.c
@@ -1,6 +1,5 @@
+#include "types.h"
 // Particle::System::FromUniqueID - looks up a Particle::System by unique ID
-typedef unsigned int u32;
-
 struct ParticleSysTracker {
     u32 unk0;
     u32 unk4;

--- a/src/_ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_.c
+++ b/src/_ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 74 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
