### PR TITLE
readable: consolidate 80 files onto shared types.h (byte-verified)

### DIFF
--- a/src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c
+++ b/src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/_ZN8Particle6System9NewRippleE5Fix12IiES2_S2_.c
+++ b/src/_ZN8Particle6System9NewRippleE5Fix12IiES2_S2_.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
+++ b/src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol _ZN8Particle7Manager9AddSystemEiR7Vector3
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__Manager.h"
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 

--- a/src/_ZN8Particle7Texture12AllocTexVramEjb.c
+++ b/src/_ZN8Particle7Texture12AllocTexVramEjb.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol _ZN8Particle7Texture12AllocTexVramEjb
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "Particle__Texture.h"
-typedef unsigned int u32;
-
-
-
 u32 _ZN8Particle7Texture12AllocTexVramEjb(u32 size, int isTexel4x4) {
     if (isTexel4x4) {
         u32 old = unk_0209ee88;

--- a/src/_ZN8PathLift17BaseInitResourcesEv.c
+++ b/src/_ZN8PathLift17BaseInitResourcesEv.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 void *_ZN9ActorBasenwEj(u32 sz);
 void func_ov004_020b2adc(void *p);
 void func_020733a8(void *o, int a, int b, void *f1, void *f2);

--- a/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8SaveData12ReadFileDataEjP12FileSaveData
 /* recovered: named members + shared header */
 #include "SaveData.h"
-typedef unsigned int u32;
-typedef int s32;
-
 struct FileSaveData { char data[0x44]; };
 
 extern "C" {

--- a/src/_ZN8SaveData13EraseSaveFileEjPc.c
+++ b/src/_ZN8SaveData13EraseSaveFileEjPc.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* _ZN8SaveData13EraseSaveFileEjPc at 0x02013cd4
  * Erases a save file slot by writing defaults then saving to cart.
  * Returns 1 on success, 0 on failure.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef char s8;
-
 struct FileSaveData { char data[0x44]; };
 
 extern void _ZN8SaveData16SetDefaultValuesEP12FileSaveData(struct FileSaveData* data);

--- a/src/_ZN8SaveData13GetCoinRecordEj.c
+++ b/src/_ZN8SaveData13GetCoinRecordEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN8SaveData13GetCoinRecordEj
 /* recovered: named members + shared header */
 #include "SaveData.h"
@@ -10,10 +11,6 @@
  * symbol is not yet in symbols.txt (wildcard pooled-global reloc, so this
  * extern name is not byte-verified). Kept as a named u8[] over data_0209cad2.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 extern u8 SAVE_DATA_COIN_RECORDS[]; /* &SAVE_DATA.coinRecords[0], 0x0209cad2 */
 
 u8 _ZN8SaveData13GetCoinRecordEj(u32 courseID)

--- a/src/_ZN8SaveData13PlayerLoseCapEv.c
+++ b/src/_ZN8SaveData13PlayerLoseCapEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* _ZN8SaveData13PlayerLoseCapEv at 0x02013ad4
  * SaveData::PlayerLoseCap - sets 0x1000000 << currentCharacter bit in flags1.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct SaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/_ZN8SaveData13SaveMinigamesEP16MinigameSaveData.c
+++ b/src/_ZN8SaveData13SaveMinigamesEP16MinigameSaveData.c
@@ -1,12 +1,7 @@
+#include "types.h"
 // @symbol _ZN8SaveData13SaveMinigamesEP16MinigameSaveData
 /* recovered: named members + shared header */
 #include "SaveData.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
 struct MinigameSaveData;
 
 extern int _ZN8SaveData14SaveDataToCartEPcjj(void* data, u32 size, u32 count);

--- a/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
+++ b/src/_ZN8SaveData14SaveDataToCartEPcjj.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN8SaveData14SaveDataToCartEPcjj
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "SaveData.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern "C" {
     int func_0203da3c(void);
     int func_0206045c(void);

--- a/src/_ZN8SaveData15SaveCurrentFileEv.c
+++ b/src/_ZN8SaveData15SaveCurrentFileEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* _ZN8SaveData15SaveCurrentFileEv at 0x02013b9c
  * Saves the current file and minigame data.
  */
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 struct MinigameSaveData { char data[0x2e4]; };
 
 extern u8 SAVE_DATA[];               /* 0x0209caa0 */

--- a/src/_ZN8SaveData16EraseAllSaveDataEv.c
+++ b/src/_ZN8SaveData16EraseAllSaveDataEv.c
@@ -1,13 +1,10 @@
+#include "types.h"
 /* _ZN8SaveData16EraseAllSaveDataEv at 0x02013e0c
  * Erases all three save files and resets minigame data.
  * Returns OR of all operation results (0 = all succeeded).
  */
 
 extern unsigned char SAVE_DATA[];
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 extern u32 _ZN8SaveData13EraseSaveFileEjPc(u32 fileID, char *saveArea);
 extern void _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData(void *mgData);
 extern u32 _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(void *mgData);

--- a/src/_ZN8SaveData16HasPlayerLostCapEv.c
+++ b/src/_ZN8SaveData16HasPlayerLostCapEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* _ZN8SaveData16HasPlayerLostCapEv at 0x02013b18
  * SaveData::HasPlayerLostCap - tests 0x1000000 << currentCharacter bit in flags1.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct SaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/_ZN8SaveData16ReadDataFromCartEPcjj.cpp
+++ b/src/_ZN8SaveData16ReadDataFromCartEPcjj.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 int func_0203da3c(void);
 u32 func_0206045c(void);

--- a/src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c
+++ b/src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN8SaveData16ReadMinigameDataEP16MinigameSaveData
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_SaveData.h"
@@ -6,11 +7,6 @@
 /* _ZN8SaveData16ReadMinigameDataEP16MinigameSaveData at 0x02013c0c
  * Reads minigame save data from cart. Returns 1 on success, 0 on failure/no data.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef signed int s32;
-
 struct MinigameSaveData { char data[0x2e4]; };
 
 extern void _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData(struct MinigameSaveData* data);

--- a/src/_ZN8SaveData19IsCharacterUnlockedEj.c
+++ b/src/_ZN8SaveData19IsCharacterUnlockedEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol _ZN8SaveData19IsCharacterUnlockedEj
 /* recovered: named members + shared header */
 #include "SaveData.h"
@@ -11,10 +12,6 @@
  * reloc, name not byte-verified). The [2] index and `1 << n` shift are
  * load-bearing.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 extern s32 SAVE_DATA[]; /* &SAVE_DATA as s32[]; [2] == flags2, base 0x0209caa0 */
 
 s32 _ZN8SaveData19IsCharacterUnlockedEj(u32 character)

--- a/src/_ZN8SaveData26CountStarsCollectedInLevelEj.c
+++ b/src/_ZN8SaveData26CountStarsCollectedInLevelEj.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol _ZN8SaveData26CountStarsCollectedInLevelEj
 /* recovered: named members + shared header */
 #include "SaveData.h"
 /* _ZN8SaveData26CountStarsCollectedInLevelEj at 0x02013768
  * Counts how many stars have been collected in a given course (0-7 stars).
  */
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern int IsStarCollected(s32 courseID, s32 starID);
 
 u8 _ZN8SaveData26CountStarsCollectedInLevelEj(u32 courseID)

--- a/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
+++ b/src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct FileSaveData { int _00; int _04; };
 
 extern "C" int _ZN8SaveData14SaveDataToCartEPcjj(void* data, u32 size, u32 count);

--- a/src/_ZN8Squasher8BehaviorEv.c
+++ b/src/_ZN8Squasher8BehaviorEv.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Vec3 { int x, y, z; };
 
 extern int _ZN5Actor13DistToCPlayerEv(char *self);

--- a/src/_ZN9ActorBase11AfterRenderEj.cpp
+++ b/src/_ZN9ActorBase11AfterRenderEj.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9ActorBase11AfterRenderEj
 /* recovered: named members + shared header, real C++ method */
 #include "ActorBase.h"
@@ -6,9 +7,6 @@
  * Post-render hook; vfSuccess is the VirtualFuncSuccess code from Render().
  * Base ActorBase does nothing; leaf classes override.
  */
-
-typedef unsigned int u32;
-
 struct ActorBase;
 
 void ActorBase::AfterRender(unsigned int vfSuccess_)

--- a/src/_ZN9ActorBase12BeforeRenderEv.cpp
+++ b/src/_ZN9ActorBase12BeforeRenderEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9ActorBase12BeforeRenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "ActorBase.h"
-typedef unsigned char u8;
-
 int ActorBase::BeforeRender()
 {
   if(mMarkedForDestruction!=0) goto ret0;

--- a/src/_ZN9ActorBase13AfterBehaviorEj.cpp
+++ b/src/_ZN9ActorBase13AfterBehaviorEj.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9ActorBase13AfterBehaviorEj
 /* recovered: named members + shared header, real C++ method */
 #include "ActorBase.h"
@@ -6,9 +7,6 @@
  * Post-behavior hook; vfSuccess is the VirtualFuncSuccess code from Behavior().
  * Base ActorBase does nothing; leaf classes override.
  */
-
-typedef unsigned int u32;
-
 struct ActorBase;
 
 void ActorBase::AfterBehavior(unsigned int vfSuccess_)

--- a/src/_ZN9ActorBase14BeforeBehaviorEv.cpp
+++ b/src/_ZN9ActorBase14BeforeBehaviorEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9ActorBase14BeforeBehaviorEv
 /* recovered: named members + shared header, real C++ method */
 #include "ActorBase.h"
-typedef unsigned char u8;
-
 int ActorBase::BeforeBehavior()
 {
   if(mMarkedForDestruction!=0) goto ret0;

--- a/src/_ZN9ActorBase21AfterCleanupResourcesEj.c
+++ b/src/_ZN9ActorBase21AfterCleanupResourcesEj.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* ActorBase::AfterCleanupResources(u32 vfSuccess) at 0x02043b2c
  *
  * Only runs when vfSuccess == VS_SUCCESS (2); otherwise returns immediately.
@@ -12,8 +13,6 @@
  * only reproduces from a real C++ virtual dispatch; a function-pointer-through-
  * a-data-field reads the vtable from r4 directly and swaps those two words).
  */
-
-typedef unsigned int u32;
 struct Heap;
 struct SceneNode { char b[0x14]; };
 struct PListNode { char b[0x10]; };

--- a/src/_ZN9ActorBase9SceneNodeC1Ev.c
+++ b/src/_ZN9ActorBase9SceneNodeC1Ev.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol _ZN9ActorBase9SceneNodeC1Ev
 /* recovered: named members + shared header */
 #include "ActorBase.h"
 // ActorBase::SceneNode::SceneNode() - C1 constructor
 // Address: 0x0203b4c4
-
-typedef unsigned int u32;
-
 struct SceneNode {
     struct SceneNode* parent;      // 0x00
     struct SceneNode* firstChild;  // 0x04

--- a/src/_ZN9ActorBase9Virtual34Ejj.cpp
+++ b/src/_ZN9ActorBase9Virtual34Ejj.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct Heap;
 struct ActorBase;
 

--- a/src/_ZN9ActorBase9Virtual38Ejj.cpp
+++ b/src/_ZN9ActorBase9Virtual38Ejj.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct Heap {
     char pad0[4];
     int field4;     /* 0x4 */

--- a/src/_ZN9Animation8LoadFileER13SharedFilePtr.c
+++ b/src/_ZN9Animation8LoadFileER13SharedFilePtr.c
@@ -1,10 +1,9 @@
+#include "types.h"
 // @symbol _ZN9Animation8LoadFileER13SharedFilePtr
 /* recovered: named members + shared header, declarations from a shared header */
 #include "decl_Animation.h"
 /* recovered: named members + shared header */
 #include "Animation.h"
-typedef unsigned char u8;
-
 struct SharedFilePtr {
     unsigned short fileID;
     u8 numRefs;

--- a/src/_ZN9Butterfly13InitResourcesEv.cpp
+++ b/src/_ZN9Butterfly13InitResourcesEv.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9Butterfly13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "Butterfly.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 struct Vec3 { s32 x, y, z; };
 struct SFP { void* a; void* b; };
 

--- a/src/_ZN9CameraTag8BehaviorEv.cpp
+++ b/src/_ZN9CameraTag8BehaviorEv.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9CameraTag8BehaviorEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "CameraTag.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned char u8;
-
 struct Vec3 { Fix12i x, y, z; };
 
 extern void Vec3_Sub(struct Vec3* out, struct Vec3* a, struct Vec3* b);

--- a/src/_ZN9FaderWipe11AdvanceFadeEv.cpp
+++ b/src/_ZN9FaderWipe11AdvanceFadeEv.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9FaderWipe11AdvanceFadeEv
 /* recovered: named members + shared header, real C++ method */
 #include "FaderWipe.h"
-typedef unsigned short u16;
-typedef int Fix12i;
-
 void _ZN5Fader13AdvanceInterpEv(void* thiz);
 void _ZN3G2x18SetBlendBrightnessEPVtts(volatile u16* p, u16 a, int b);
 void Matrix4x3_FromTranslation(void* m, int x, int y, int z);

--- a/src/_ZN9FaderWipeC1Ev.c
+++ b/src/_ZN9FaderWipeC1Ev.c
@@ -1,7 +1,4 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Model {
     u32 data[0x14]; /* 0x50 bytes */
 };

--- a/src/_ZN9LakituBro13InitResourcesEv.cpp
+++ b/src/_ZN9LakituBro13InitResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9LakituBro13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "LakituBro.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int Fix12;
-
 struct SharedFilePtr { int f0; void* f4; };
 struct BMD_File; struct BTP_File; struct BCA_File;
 struct ModelBase {};

--- a/src/_ZN9ModelAnim11UpdateVertsEv.c
+++ b/src/_ZN9ModelAnim11UpdateVertsEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* ModelAnim::UpdateVerts at 0x0201686c, size=0x30
  * Updates bone transforms then vertex positions from animation.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct ModelComponents {
     void* modelFile;
     void* materials;

--- a/src/_ZN9ModelAnim4CopyERKS_Pc.c
+++ b/src/_ZN9ModelAnim4CopyERKS_Pc.c
@@ -1,14 +1,9 @@
+#include "types.h"
 /* _ZN9ModelAnim4CopyERKS_Pc at 0x02016714 (52 bytes)
  * ModelAnim::Copy -- copies animation data from another ModelAnim into this one.
  * If newFile != NULL, stores newFile at this->file (0x60); otherwise copies src->file.
  * Also calls Animation::Copy (base class copy) on the sub-object at +0x50.
  */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-typedef int Fix12i;
-
 struct Animation {
     u32 vtable;
     Fix12i numFramesAndFlags;

--- a/src/_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj.c
+++ b/src/_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* ModelAnim::SetAnim at 0x02016748, size=0x5c
  * Sets animation; fast path (same file) updates flags+speed only.
  */
-
-typedef int s32;
-typedef unsigned short u16;
-
 struct BCA_File {
     u16 unk00;
     u16 numFrames;

--- a/src/_ZN9ModelAnim9Virtual10ER9Matrix4x3.c
+++ b/src/_ZN9ModelAnim9Virtual10ER9Matrix4x3.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* ModelAnim::Virtual10 at 0x0201682c, size=0x40
  * Updates bones from animation then calls Model::Virtual10 with a transform.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct ModelComponents {
     void* modelFile;
     void* materials;

--- a/src/_ZN9OneUpLogo6RenderEv.cpp
+++ b/src/_ZN9OneUpLogo6RenderEv.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9OneUpLogo6RenderEv
 /* recovered: named members + shared header, real C++ method */
 #include "OneUpLogo.h"
-typedef unsigned short u16;
-
 struct VObj {
     virtual void f0();
     virtual void f1();

--- a/src/_ZN9OneUpLogo8BehaviorEv.c
+++ b/src/_ZN9OneUpLogo8BehaviorEv.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct V3 { int x, y, z; };
 
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);

--- a/src/_ZN9PowerStar13AddStarMarkerEv.cpp
+++ b/src/_ZN9PowerStar13AddStarMarkerEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9PowerStar13AddStarMarkerEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "PowerStar.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern void SetStarMarker(int i, int v1, int v2);
 extern int IsStarCollectedInCurLevel(int starID);
 extern int data_0209f40c[];

--- a/src/_ZN9PowerStar13InitResourcesEv.cpp
+++ b/src/_ZN9PowerStar13InitResourcesEv.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9PowerStar13InitResourcesEv
 /* recovered: named members + shared header, real C++ method */
 #include "PowerStar.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
 struct Vec3 { s32 x, y, z; };
 struct SharedFilePtr { u32 id; void *ptr; };
 

--- a/src/_ZN9RabbitKey6RenderEv.cpp
+++ b/src/_ZN9RabbitKey6RenderEv.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9RabbitKey6RenderEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
@@ -8,10 +9,6 @@
  * bump the angle at this+0x8e by 0x500; run func_ov085_0212d2b8(this); then
  * virtual-call slot +0x14 on the sub-object at this+0x110 with arg 0. Returns 1.
  */
-
-typedef unsigned int u32;
-typedef signed short s16;
-
 struct SubVt {
     char _pad0[0x14];
     void (*fn14)(void* self, int a); /* 0x14 */

--- a/src/_ZN9SolidHeap10VGetNodeIDEv.cpp
+++ b/src/_ZN9SolidHeap10VGetNodeIDEv.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9SolidHeap10VGetNodeIDEv
 /* recovered: named members + shared header, real C++ method */
 #include "SolidHeap.h"
 /* SolidHeap::VGetNodeID() at 0x0203c3d8 -- Heap vtable slot (VGetNodeID).
  * SolidHeap has no need for node IDs (linear allocator, no per-node tagging),
  * so this override simply returns 0. */
-
-typedef unsigned int u32;
-
 struct SolidHeap;
 
 u32 SolidHeap::VGetNodeID()

--- a/src/_ZN9SolidHeap10VSetNodeIDEj.cpp
+++ b/src/_ZN9SolidHeap10VSetNodeIDEj.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9SolidHeap10VSetNodeIDEj
 /* recovered: named members + shared header, real C++ method */
 #include "SolidHeap.h"
 /* SolidHeap::VSetNodeID(u32 id) at 0x0203c3f0 -- Heap vtable slot (VSetNodeID).
  * SolidHeap has no need for node IDs (linear allocator), so this override
  * ignores the requested id and returns 0 (the previous node ID). */
-
-typedef unsigned int u32;
-
 struct SolidHeap;
 
 u32 SolidHeap::VSetNodeID(unsigned int id_)

--- a/src/_ZN9SolidHeap11VReallocateEPvj.cpp
+++ b/src/_ZN9SolidHeap11VReallocateEPvj.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* SolidHeap::VReallocate(void*, unsigned) at 0x0203c558 -- Heap vtable slot.
  * Forwards to the allocator (SolidHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class SolidHeapAllocator
 {
 public:

--- a/src/_ZN9SolidHeap12VResizeToFitEv.c
+++ b/src/_ZN9SolidHeap12VResizeToFitEv.c
@@ -1,7 +1,5 @@
+#include "types.h"
 /* SolidHeap::VResizeToFit at 0x0203c33c */
-
-typedef unsigned int u32;
-
 struct Heap {
     void* vtable;
     void* heapStart;

--- a/src/_ZN9SolidHeap8VDestroyEv.c
+++ b/src/_ZN9SolidHeap8VDestroyEv.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // ExpandingHeap::VDestroy()
 // Address: 0x0203c72c
 // Destroys the allocator and sets allocator ptr to NULL
-
-typedef unsigned int u32;
-
 struct HeapAllocator;
 
 extern void func_0204ebb8(struct HeapAllocator* self);

--- a/src/_ZN9SolidHeap9VAllocateEjj.cpp
+++ b/src/_ZN9SolidHeap9VAllocateEjj.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 /* SolidHeap::VAllocate(unsigned, unsigned) at 0x0203c6ac -- Heap vtable slot.
  * Forwards to the allocator (SolidHeapAllocator* at this+0x14). */
-
-typedef unsigned int u32;
-
 class SolidHeapAllocator
 {
 public:

--- a/src/_ZN9SolidHeapC1EPvjP4HeapP18SolidHeapAllocator.c
+++ b/src/_ZN9SolidHeapC1EPvjP4HeapP18SolidHeapAllocator.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Heap;
 struct SolidHeapAllocator;
 

--- a/src/_ZN9WaterRing13InitResourcesEv.cpp
+++ b/src/_ZN9WaterRing13InitResourcesEv.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol _ZN9WaterRing13InitResourcesEv
 /* recovered: named members + shared header, real C++ method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: named members + shared header, real C++ method */
 #include "WaterRing.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-
 struct Actor;
 struct BMD_File;
 struct BTA_File;

--- a/src/_ZNK10ClsnResult9GetClsnIDEv.cpp
+++ b/src/_ZNK10ClsnResult9GetClsnIDEv.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol _ZNK10ClsnResult9GetClsnIDEv
 /* recovered: named members + shared header, real C++ method */
 #include "ClsnResult.h"
 /* ClsnResult::GetClsnID() const at 0x02037f4c
  * Loads the u32 field at 0x1c (objID in the reference layout).
  */
-
-typedef unsigned int u32;
-
 struct ClsnResult;
 
 u32 ClsnResult::GetClsnID() const

--- a/src/_ZNK12WithMeshClsn10IsOnGroundEv.c
+++ b/src/_ZNK12WithMeshClsn10IsOnGroundEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* WithMeshClsn::IsOnGround() const at 0x020356e8
  * Reads the ON_GROUND flag (1 << 4 == 0x10) of this->flags (u32 at 0x10).
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct WithMeshClsn { char pad[0x10]; u32 flags; };
 
 s32 _ZNK12WithMeshClsn10IsOnGroundEv(const struct WithMeshClsn* self)

--- a/src/_ZNK12WithMeshClsn13GetLimMovFlagEv.c
+++ b/src/_ZNK12WithMeshClsn13GetLimMovFlagEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* WithMeshClsn::GetLimMovFlag() const at 0x02035694
  * Reads the LIMITED_MOVEMENT flag (1 << 7 == 0x80) of this->flags (u32 at 0x10).
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct WithMeshClsn { char pad[0x10]; u32 flags; };
 
 s32 _ZNK12WithMeshClsn13GetLimMovFlagEv(const struct WithMeshClsn* self)

--- a/src/_ZNK12WithMeshClsn13JustHitGroundEv.c
+++ b/src/_ZNK12WithMeshClsn13JustHitGroundEv.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* WithMeshClsn::JustHitGround() const at 0x0203571c
  * Reads the JUST_HIT_GROUND flag (1 << 5 == 0x20) of this->flags (u32 at 0x10).
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct WithMeshClsn { char pad[0x10]; u32 flags; };
 
 s32 _ZNK12WithMeshClsn13JustHitGroundEv(const struct WithMeshClsn* self)

--- a/src/_ZNK12WithMeshClsn15ShouldUpdatePosEv.c
+++ b/src/_ZNK12WithMeshClsn15ShouldUpdatePosEv.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* WithMeshClsn::ShouldUpdatePos() const at 0x02035564
  * True unless the NO_UPDATE_POS flag (1 << 13 == 0x2000) is set in
  * this->flags (u32 at 0x10).
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct WithMeshClsn { char pad[0x10]; u32 flags; };
 
 s32 _ZNK12WithMeshClsn15ShouldUpdatePosEv(const struct WithMeshClsn* self)

--- a/src/_ZNK12WithMeshClsn16ShouldUpdatePosYEv.c
+++ b/src/_ZNK12WithMeshClsn16ShouldUpdatePosYEv.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* WithMeshClsn::ShouldUpdatePosY() const at 0x02035578
  * True unless the NO_UPDATE_POS_Y flag (1 << 12 == 0x1000) is set in
  * this->flags (u32 at 0x10).
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 struct WithMeshClsn { char pad[0x10]; u32 flags; };
 
 s32 _ZNK12WithMeshClsn16ShouldUpdatePosYEv(const struct WithMeshClsn* self)

--- a/src/_ZNK6Camera12IsUnderwaterEv.c
+++ b/src/_ZNK6Camera12IsUnderwaterEv.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* Camera::IsUnderwater() const at 0x0200d890
  * Returns the IS_UNDERWATER (1<<0) bit of the camera flags word (@0x154).
  * Keeps the masked value (`flags & 1`) exactly as the original returns it.
  */
-
-typedef unsigned int u32;
-
 enum CameraFlags {
     IS_UNDERWATER = 1 << 0,
 };

--- a/src/_ZNK9Animation12WillHitFrameEi.cpp
+++ b/src/_ZNK9Animation12WillHitFrameEi.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 class Animation
 {
 public:

--- a/src/__sinit_02073e6c.c
+++ b/src/__sinit_02073e6c.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void func_020731dc(void *, void *, void **);
 extern void _ZN10FaderColorD1Ev(void);
 extern unsigned char data_02089af8[];

--- a/src/func_02005000.c
+++ b/src/func_02005000.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
+#include "types.h"
 extern s32 ApproachAngle(s16 *target, s16 from, s16 start, s16 speed, s16 max);
 extern void func_02009e70(void *self);
 typedef struct CameraDef CameraDef;

--- a/src/func_02005110.c
+++ b/src/func_02005110.c
@@ -1,10 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
+#include "types.h"
 struct Vec3
 {
   s32 x;

--- a/src/func_02005418.c
+++ b/src/func_02005418.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_02005418
 // @emits dScBoot_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -6,10 +7,6 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScBoot_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern u8 data_0209f5bc[];
 
 extern u8 data_0209f1e8;

--- a/src/func_02005a58.c
+++ b/src/func_02005a58.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_02005a58
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -24,10 +25,6 @@ extern char data_0208ee44;
 extern char data_0209f5e8;
 extern void func_0201a2f8(void);
 extern unsigned char data_0209f1e8;
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 int dScBoot_c_InitResources(char* c)
 {
     struct dScBoot_c *self = (struct dScBoot_c *)(void *)c;

--- a/src/func_020071e0.c
+++ b/src/func_020071e0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 extern void ApproachLinear(int *val, int target, int step);

--- a/src/func_02007758.c
+++ b/src/func_02007758.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef short s16;
-typedef signed char s8;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int SublevelToLevel(int i);
 extern void func_020070e8(void *a, int b, int c, int d, int e, int f, int g);
 extern s8 data_0209f2f8;

--- a/src/func_02008200.c
+++ b/src/func_02008200.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern struct Actor *func_0200e6d8(unsigned int arg0);
 extern void Math_Function_0203b0fc(int *p, int target, int scale, int max);
 

--- a/src/func_020082f8.c
+++ b/src/func_020082f8.c
@@ -1,7 +1,4 @@
-typedef int Fix12i;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern Fix12i _ZN4cstd4fdivEii(Fix12i a, Fix12i b);
 extern u16 data_0209b274;
 

--- a/src/func_0200897c.c
+++ b/src/func_0200897c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_0200897c @ 0x0200897c, size 0x5c, ARM.
  * Camera-cluster member taking (Camera *self, void *arg).
  * Always runs func_02035414(arg). Then, if the camera's owner Actor
@@ -12,10 +13,6 @@
  * bare `bne`; a `u8` bool masks with `ands #0xff`; only the (int-width) enum
  * bool gives the exact `cmp r0, #0`.
  */
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 enum Bool { FALSE, TRUE };
 
 typedef struct Actor {

--- a/src/func_02008cb4.c
+++ b/src/func_02008cb4.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 enum { false, true };
 
 typedef struct Vec3 { int x, y, z; } Vec3;

--- a/src/func_020091f8.c
+++ b/src/func_020091f8.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_020092c4(void *a, void *b, int c);
 extern void func_0200928c(void *cam);
 extern int ApproachAngle(void *p, int target, int a, int b, int c);

--- a/src/func_020098e0.c
+++ b/src/func_020098e0.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 #define LP(p) ((long long)(int)(p))
 
 extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);

--- a/src/func_0200b0fc.c
+++ b/src/func_0200b0fc.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_0200b0fc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_PathPtr.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
 extern void _ZN7PathPtrC1Ev(void *self);
 extern void _ZN7PathPtr6FromIDEj(void *self, unsigned int id);
 extern void _ZNK7PathPtr7GetNodeER7Vector3j(void *self, struct Vector3 *out, unsigned int idx);

--- a/src/func_0200b990.c
+++ b/src/func_0200b990.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct V3 { int x, y, z; } V3;
 typedef struct RaycastLine { char pad[0x14]; char surf[0x64]; } RaycastLine;
 

--- a/src/func_0200bb28.c
+++ b/src/func_0200bb28.c
@@ -1,16 +1,9 @@
+#include "types.h"
 // @symbol func_0200bb28
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef long long s64;
-typedef unsigned long long u64;
-
 extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
 extern u16 data_0209f49e[];

--- a/src/func_0200ca50.cpp
+++ b/src/func_0200ca50.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 class C;
 typedef int (C::*PMF)();
 

--- a/src/func_0200cf40.c
+++ b/src/func_0200cf40.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 extern void func_0200cb58(void *obj, int index);
 extern void func_0200d954(void *c, int arg);
 extern void func_0200cce4(void *c);

--- a/src/func_0200d1e4.c
+++ b/src/func_0200d1e4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern unsigned int func_020093f4(void *p, int x);
 extern unsigned int func_020093d4(void *p, int a);
 extern void Vec3_RotateYAndTranslate(void *dst, void *src, short angle, void *unk);

--- a/src/func_0200d7e0.c
+++ b/src/func_0200d7e0.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_0200d7e0 at 0x0200d7e0
  * Camera method: if playerID == CURR_PLAYER_ID, call Camera::ChangeState(state).
  */
-
-typedef unsigned char u8;
-
 struct Camera_State;
 struct Camera;
 

--- a/src/func_0200d81c.c
+++ b/src/func_0200d81c.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_0200d81c at 0x0200d81c
  * Camera method: if playerID == CURR_PLAYER_ID, call Camera::ChangeState(state).
  */
-
-typedef unsigned char u8;
-
 struct Camera_State;
 struct Camera;
 


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 80 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
