### PR TITLE
readable: consolidate 88 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_0200e55c.c
+++ b/src/func_0200e55c.c
@@ -1,7 +1,5 @@
+#include "types.h"
 // func_0200e55c - find cutscene object by owner ID
-
-typedef unsigned int u32;
-
 struct Actor {
     void* vtable;    // 0x0
     u32 uniqueID;    // 0x4

--- a/src/func_0200e6d8.c
+++ b/src/func_0200e6d8.c
@@ -1,8 +1,5 @@
+#include "types.h"
 // func_0200e6d8 - find player actor by parameter
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct Actor {
     void* vtable;    // 0x0
     u32 uniqueID;    // 0x4

--- a/src/func_0200f13c.cpp
+++ b/src/func_0200f13c.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
+#include "types.h"
 extern "C" {
 s32 func_0200f0bc(void);
 u32 LoadCompressedFileAt(unsigned int fileID, void *target);

--- a/src/func_0200f220.c
+++ b/src/func_0200f220.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern s32 func_0200f0bc(void);
 extern unsigned _ZN3G2S13GetBG2CharPtrEv(void);
 extern u32 LoadCompressedFileAt(u32 fileID, void *target);

--- a/src/func_0200f2cc.c
+++ b/src/func_0200f2cc.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN2GX15DisableAllBanksEv(void);
 extern void _ZN2GX13SetBankForTexEt(u16 v);
 extern void _ZN2GX17SetBankForTexPlttEt(u16 v);

--- a/src/func_0200f4f4.c
+++ b/src/func_0200f4f4.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 /* 4x3 matrix: 12 s32 values = 48 bytes */
 typedef struct {
     s32 m[12];

--- a/src/func_0200f760.c
+++ b/src/func_0200f760.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern unsigned char *_ZN5Actor13ClosestPlayerEv(void *self);
 
 void func_0200f760(void *self, char *actor)

--- a/src/func_0200f7f0.c
+++ b/src/func_0200f7f0.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Actor { char _pad[0xd4]; };
 
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int soundID, unsigned int vol, unsigned int pan, Fix12i dist, int loop);

--- a/src/func_020105cc.c
+++ b/src/func_020105cc.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_020105cc
 /* recovered: shared common types */
 #include "common.h"
@@ -6,12 +7,6 @@
  * If flags & 0x380: play sound bank0 ID 0xa at camSpacePos.
  * Else if flags & 0x40: play sound bank0 ID 9 at camSpacePos.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
-
 struct Actor {
     char pad[0x74];
     struct Vector3 camSpacePos; /* 0x74 */

--- a/src/func_020116c4.c
+++ b/src/func_020116c4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 void func_02011ac4(void* slot, int counter, int a1, int a2, int a3, int s0, short s1);
 void func_02011698(char* table, char* n);
 

--- a/src/func_0201179c.c
+++ b/src/func_0201179c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_02011af8(void *c, int a1, int a2, int a3, int s0, short s1);
 extern void func_02011698(char *table, char *n);
 

--- a/src/func_0201186c.c
+++ b/src/func_0201186c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_02011b38(void *c, int a1, int a2, int a3, short a5);
 extern void func_02011698(char *table, char *n);
 

--- a/src/func_02011c8c.c
+++ b/src/func_02011c8c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_02011c8c — resets all sound player sequence limits from a default table.
  * Iterates 10 entries of a static array {s32 playerID, s32 maxSeq} at 0x0208e448,
  * calling Sound::Player::SetPlayableSeqCount(playerID, maxSeq) for each.
@@ -5,10 +6,6 @@
  * Callee: 0x0204fadc = Sound::Player::SetPlayableSeqCount(s32, s32)
  *   _ZN5Sound6Player19SetPlayableSeqCountEii
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
 extern void _ZN5Sound6Player19SetPlayableSeqCountEii(s32 playerID, s32 maxSeq);
 
 typedef struct {

--- a/src/func_02012194.c
+++ b/src/func_02012194.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 extern char data_0209b53c[];
 int func_02048a1c(int a0, int kind, int id);
 void* func_02011934(char* table, int id);

--- a/src/func_020132d8.cpp
+++ b/src/func_020132d8.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 extern "C" {
 void func_02012d64(void);
 void func_02013524(int *a, int b, int c);

--- a/src/func_020133bc.c
+++ b/src/func_020133bc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 extern void func_0204f070(void);
 extern void* _ZN6Memory8AllocateEj(u32 size);
 extern void* func_0205130c(u32 addr, u32 size);

--- a/src/func_02013944.c
+++ b/src/func_02013944.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct FileSaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/func_020139b8.c
+++ b/src/func_020139b8.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 /* SAVE_DATA layout (partial):
  *   0x04 = flags    (u32)
  *   0x41 = charID   (u8)

--- a/src/func_02013a00.c
+++ b/src/func_02013a00.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 /* SAVE_DATA layout (partial):
  *   0x04 = flags    (u32)
  *   0x41 = charID   (u8)

--- a/src/func_02013a44.c
+++ b/src/func_02013a44.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* func_02013a44 at 0x02013a44
  * SaveData: test if 0x8000000 << currentCharacter bit is set in flags1.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct SaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/func_02013a88.c
+++ b/src/func_02013a88.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_02013a88 at 0x02013a88
  * SaveData: clear 0x1000000 << currentCharacter bit in flags1, then SaveCurrentFile.
  * Player gets cap back (persisted).
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct SaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/func_02013c84.c
+++ b/src/func_02013c84.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
+#include "types.h"
 struct FileSaveData {
     u32 magic8000;
     u32 flags1;

--- a/src/func_02013f4c.c
+++ b/src/func_02013f4c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 data_0209cde4;
 extern u8 data_0209cdcc;
 extern void* data_020a0e9c;

--- a/src/func_0201473c.c
+++ b/src/func_0201473c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
+#include "types.h"
 extern s32 func_0206e3dc(char *buf, s32 size, u32 fmtAddr, u32 val);
 extern void nds_print(void *arg0, char *buf);
 extern char gPrintBuf[]; /* 0x0209cde8 */

--- a/src/func_02014f5c.c
+++ b/src/func_02014f5c.c
@@ -1,8 +1,5 @@
+#include "types.h"
 // func_02014f5c - find player by ID and call some player function
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct Actor {
     void* vtable;
     u32 uniqueID;

--- a/src/func_020165c4.c
+++ b/src/func_020165c4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 func_020462bc(int a);
 extern void* _ZN6Memory13operator_new2Ej(u32 size);
 extern void func_020462b4(int* p, int v);

--- a/src/func_02016b24.c
+++ b/src/func_02016b24.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Obj {
     char pad[8];
     char* p8;

--- a/src/func_02017060.c
+++ b/src/func_02017060.c
@@ -1,12 +1,10 @@
+#include "types.h"
 /* func_02017060 at 0x02017060
  * Reallocates a file/object on the game heap using its own reported size.
  * arg0 = ptr; if null returns 0.
  * Calls Heap::_Sizeof(gameHeap, ptr) [result discarded],
  * then calls func_020469e0(ptr) to get the target size,
  * then Heap::Reallocate(gameHeap, ptr, new_size). Returns result. */
-
-typedef unsigned int u32;
-
 struct Heap;
 
 extern struct Heap* gGameHeapPtr; /* at 0x020a0eac: Memory::gameHeapPtr */

--- a/src/func_0201787c.c
+++ b/src/func_0201787c.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_0201787c at 0x0201787c
  * SharedFilePtr LoadFile variant: loads file, if first ref and non-null, calls Model::UpdateFileOffsets.
  * Returns the raw file pointer.
  */
-
-typedef unsigned char u8;
-
 struct SharedFilePtr {
     unsigned short fileID;  /* 0x00 */
     u8 numRefs;             /* 0x02 */

--- a/src/func_020179b4.c
+++ b/src/func_020179b4.c
@@ -1,10 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
-typedef signed short s16;
-typedef signed char s8;
-
+#include "types.h"
 struct SharedFilePtr { u16 fileID; u8 numRefs; char* filePtr; };
 struct BMD_File { u32 data; };
 struct ModelBase { u32 vtable; u32 unk04; };

--- a/src/func_02017c24.c
+++ b/src/func_02017c24.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 LAST_USED_FILE_ID;
 extern void _ZN6Memory10DeallocateEPv(void *ptr);
 

--- a/src/func_02017fd0.c
+++ b/src/func_02017fd0.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     u32   unk0;
     void *ptr;      /* +4 */

--- a/src/func_02018908.c
+++ b/src/func_02018908.c
@@ -1,7 +1,5 @@
+#include "types.h"
 /* func_02018908 at 0x02018908 */
-
-typedef unsigned int u32;
-
 extern void func_0204ee10(void *self);
 extern void _ZN4Heap11_DeallocateEPv(void *heap, void *ptr);
 

--- a/src/func_02018934.c
+++ b/src/func_02018934.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_02018934 at 0x02018934
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned int u32;
-
 extern void FS_InitFile(int *s);
 extern int func_02018d98(int *s, int a);
 extern void *_ZN4Heap9_AllocateEji(void *heap, u32 size, int align);

--- a/src/func_02019440.c
+++ b/src/func_02019440.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_0209d4a8;
 extern int data_0209d4ac;
 extern int data_0209d4b0;

--- a/src/func_0201964c.c
+++ b/src/func_0201964c.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_0201964c at 0x0201964c
  * Timer constructor: calls ResetTimer() then returns this.
  * Likely Timer::Timer() C1 constructor.
  */
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-
 struct Timer {
     u32 field0;
     u32 field4;

--- a/src/func_02019780.c
+++ b/src/func_02019780.c
@@ -1,7 +1,5 @@
+#include "types.h"
 /* func_02019780 at 0x02019780 */
-
-typedef unsigned int u32;
-
 extern void func_02058c84(void);
 extern void func_0201a490(void);
 extern void func_02019ebc(void);

--- a/src/func_020199a4.c
+++ b/src/func_020199a4.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void func_0201a9ec(void *p);
 extern void func_02030838(void);
 extern void func_02019ac4(void);

--- a/src/func_02019ed0.c
+++ b/src/func_02019ed0.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_0209d4e4;
 extern void func_0205f77c(int a, int b, int c);
 void func_02019ed0(void){

--- a/src/func_02019ff4.c
+++ b/src/func_02019ff4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 enum IPCStatus {
     IPC_SUCCESS = 0,
     IPC_ERROR = -1,

--- a/src/func_0201a054.c
+++ b/src/func_0201a054.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_020427f8(void);
 extern u32 func_02042784(void);
 extern void func_02053a8c(void);

--- a/src/func_0201a244.c
+++ b/src/func_0201a244.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern int _ZN6Memory8AllocateEji(u32 sz, int align);
 extern void func_02058200(void *c, int f, int a, int p, int s, int x);
 extern void func_02057f38(void *c, int v);

--- a/src/func_0201a4e4.c
+++ b/src/func_0201a4e4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irqBit, void (*handler)(void));
 extern void _ZN3IRQ13VBlankHandlerEv(void);
 

--- a/src/func_0201a754.c
+++ b/src/func_0201a754.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern void UnloadOverlay(int id);
 extern int overlay_6;
 extern int overlay_4;

--- a/src/func_0201a798.c
+++ b/src/func_0201a798.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern void LoadOverlay(int id);
 extern int overlay_6;
 extern int overlay_4;

--- a/src/func_0201a96c.c
+++ b/src/func_0201a96c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct {
     char pad1[0x30];
     u32  field_0x30;  /* 0x30 */

--- a/src/func_0201a9ec.c
+++ b/src/func_0201a9ec.c
@@ -1,7 +1,5 @@
+#include "types.h"
 /* func_0201a9ec at 0x0201a9ec - thunk: func_0201a96c(self, 1) */
-
-typedef unsigned char u8;
-
 extern u8 func_0201a96c(void* self, u8 newVal);
 
 u8 func_0201a9ec(void* self)

--- a/src/func_0201ab6c.c
+++ b/src/func_0201ab6c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN7Message7AddCharEc(int c);
 
 struct S { u8 b[8]; };

--- a/src/func_0201aca4.c
+++ b/src/func_0201aca4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u8 NumStars(void);
 extern int func_020138dc(void);
 extern int _ZN8SaveData22NumGlowingRabbitsFoundEv(void);

--- a/src/func_0201adac.c
+++ b/src/func_0201adac.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_0201adac - calls Message::AddChar twice with font-encoded char and char+1.
  * Reads index from CURR_MSG_TEXT_CHAR bytes [3] and [4], looks up in gCharTable.
  * Attempt 3: correct types - S* (not S**), AddChar(int), u16 idx, reversed load order.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern void _ZN7Message7AddCharEc(int c);
 
 struct MsgTextChar {

--- a/src/func_0201adfc.c
+++ b/src/func_0201adfc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 #define LM(x) ((u32*)(long long)(int)(x))
 
 extern u8 data_0209d698;

--- a/src/func_0201b388.c
+++ b/src/func_0201b388.c
@@ -1,9 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern u8 data_0209d668;
 extern u8 data_0209d6c0;
 extern u8 data_0209d6a8;

--- a/src/func_0201b6f8.c
+++ b/src/func_0201b6f8.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8* data_0209d6f4;
 extern u8 data_0209d6a4;
 extern u8 data_0209d6b0;

--- a/src/func_0201b7cc.c
+++ b/src/func_0201b7cc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_0209d65c;
 extern u8 data_0209d6b8;
 extern u8 data_0209d678;

--- a/src/func_0201cd08.cpp
+++ b/src/func_0201cd08.cpp
@@ -1,7 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned char u8;
-typedef short s16;
 extern void func_0201eaac(void);
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);

--- a/src/func_0201cfb8.c
+++ b/src/func_0201cfb8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 data_0209d6d4;
 extern u8 data_0209d660;
 extern u8 data_0209d668;

--- a/src/func_0201d590.cpp
+++ b/src/func_0201d590.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned char u8;
 extern short data_0209d6d4;
 extern int data_0209d708;
 extern int *data_0209d70c;

--- a/src/func_0201d850.c
+++ b/src/func_0201d850.c
@@ -1,11 +1,5 @@
+#include "types.h"
 #pragma opt_strength_reduction off
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 extern u8 data_0209d660;
 extern u8 data_0209d6a8;
 extern u8 data_0209d65c;

--- a/src/func_0201ef50.c
+++ b/src/func_0201ef50.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 struct StarEntry
 {
   int m0;

--- a/src/func_0201f108.c
+++ b/src/func_0201f108.c
@@ -1,6 +1,5 @@
+#include "types.h"
 // func_0201f108 - fills BG0 screen buffer with sequential tile indices 0..0x3ff
-typedef unsigned short u16;
-
 extern u16* _ZN3G2S12GetBG0ScrPtrEv(void);
 
 void func_0201f108(void) {

--- a/src/func_0201f138.cpp
+++ b/src/func_0201f138.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct StarEntry {
     int m0;
     u16 m4;

--- a/src/func_0201f32c.c
+++ b/src/func_0201f32c.c
@@ -1,10 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 extern void *data_0209d70c;
 extern s16 data_0209d6d4;
 extern u8 data_0209d660;

--- a/src/func_02020820.c
+++ b/src/func_02020820.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_0202043c(void *self);
 
 void func_02020820(char *self, int *src, int arg2, int arg3, u8 arg5, u8 arg6)

--- a/src/func_020226fc.c
+++ b/src/func_020226fc.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct ParticleCallback;
 struct ParticleSys;
 

--- a/src/func_02022774.c
+++ b/src/func_02022774.c
@@ -1,10 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 /* PARTICLE_SYS_TRACKER is a global SysTracker*, so it IS the base pointer.
    Each access reloads the global since it's not cached. */
 extern char* PARTICLE_SYS_TRACKER;

--- a/src/func_020227ec.c
+++ b/src/func_020227ec.c
@@ -1,10 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022864.c
+++ b/src/func_02022864.c
@@ -1,10 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_020228dc.c
+++ b/src/func_020228dc.c
@@ -1,8 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-typedef signed short s16;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_0202293c.c
+++ b/src/func_0202293c.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_020229f0.c
+++ b/src/func_020229f0.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022a4c.c
+++ b/src/func_02022a4c.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022b04.c
+++ b/src/func_02022b04.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022c3c.c
+++ b/src/func_02022c3c.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022c80.c
+++ b/src/func_02022c80.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022cbc.c
+++ b/src/func_02022cbc.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern char* PARTICLE_SYS_TRACKER;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_02022d00.c
+++ b/src/func_02022d00.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* func_02022d00 at 0x02022d00 (68 bytes)
  * Particle::System::New wrapper -- passes args through and adds tracker->unk7f4 as callback.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
 struct ParticleCallback;
 struct ParticleSys;
 

--- a/src/func_02022d44.c
+++ b/src/func_02022d44.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* func_02022d44 at 0x02022d44 (60 bytes)
  * Particle::System::New wrapper -- passes args through and adds *tracker+0x7f0 as callback.
  */
-
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
 struct ParticleCallback;
 struct ParticleSys;
 

--- a/src/func_02029408.c
+++ b/src/func_02029408.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_0209f250;
 extern void *data_0209f394[];
 extern int func_020bd828(void *p);

--- a/src/func_0202ec9c.cpp
+++ b/src/func_0202ec9c.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" {
 
 struct Obj;

--- a/src/func_0202eddc.c
+++ b/src/func_0202eddc.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0202eddc
 // @emits dWipe_c_IsAtEnd
 /* recovered: renamed to Class_Method */
@@ -6,9 +7,6 @@
  * Attempt 5: use explicit early-return structure to get beq+bgt branch pattern.
  * ROM: beq -> ret1 block (add sp,#4; mov r0,#1; ldm; bx), bgt -> ret0 block.
  */
-typedef int s32;
-typedef unsigned int u32;
-
 struct FaderBrightness;
 extern int _ZN15FaderBrightness7IsAtEndEv(struct FaderBrightness* self);
 

--- a/src/func_0202ee38.c
+++ b/src/func_0202ee38.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0202ee38
 // @emits dWipe_c_IsAtStart
 /* recovered: renamed to Class_Method */
@@ -10,9 +11,6 @@
  * ret1: return 1; ret0: return 0
  * Same stmdb+sub sp,#4 prologue = 0x5c total.
  */
-typedef int s32;
-typedef unsigned int u32;
-
 struct FaderBrightness;
 extern int _ZN15FaderBrightness9IsAtStartEv(struct FaderBrightness* self);
 

--- a/src/func_0202ee94.c
+++ b/src/func_0202ee94.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned long long u64;
-
+#include "types.h"
 extern void MultiStore_Int(int val, int *dst, int len);
 extern u64 _ZN4cstd4sqrtEy(u64);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int, unsigned int);

--- a/src/func_0202efa0.c
+++ b/src/func_0202efa0.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_0202efa0 at 0x0202efa0 (arm9 main)
  *
  * Builds a 192-entry (one per scanline) 4-byte-per-line blend/fade gradient
@@ -10,10 +11,6 @@
  * (duration = *(s32*)(self+0x1c)). Finally the whole 0x600 region is cache
  * flushed. Looks like a per-scanline capture/blend wipe effect table.
  */
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
 extern void MultiStore_Int(int val, int *dst, int len);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int a, unsigned int b);
 

--- a/src/func_0202f2c4.c
+++ b/src/func_0202f2c4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_023c0000;
 extern u8 dat_0209f5fc;
 extern volatile u32 dat_0209f608;

--- a/src/func_0202f3a4.c
+++ b/src/func_0202f3a4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u32 dat_0209f60c;          /* source index */
 extern volatile u32 dat_0209f608; /* working index */
 extern u8 dat_0209f648[];         /* table base (stride 0x300) */

--- a/src/func_0202f58c.c
+++ b/src/func_0202f58c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_0202f290(void *o);
 
 extern u8 data_0209f5f8;

--- a/src/func_0202f708.c
+++ b/src/func_0202f708.c
@@ -1,14 +1,10 @@
+#include "types.h"
 // @symbol func_0202f708
 // @emits dWipe_c_SetForwardTime
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dWipe_c::SetForwardTime - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
 struct MyFader {
     u32 unk00;
     u32 unk04;

--- a/src/func_0202f928.c
+++ b/src/func_0202f928.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0202f928
 // @emits dWipe_c_SetBackwardTime
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -8,12 +9,6 @@
  * forwarded to the guard call with zero instructions, which keeps r2 live
  * from entry to the call and forces the cached `type` into r3 as in the ROM.
  * Without it every spelling colors `type` to r2 (3-word regperm miss). */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
 struct FaderBrightness;
 extern int _ZN15FaderBrightness15SetBackwardTimeEj(struct FaderBrightness *self, u32 time, u32 c);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 88 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
