### PR TITLE
readable: consolidate 87 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_0202fb30.c
+++ b/src/func_0202fb30.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void IRQ_DisableIRQs(u32 mask);
 extern int func_02053c10(int enable);
 extern void IRQ_SetIRQHandler(u32 irq, void *handler);

--- a/src/func_02030500.c
+++ b/src/func_02030500.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 extern void func_02019028(void);
 extern void _ZN2GX15DisableAllBanksEv(void);
 extern void _ZN2GX12SetBankForBGEt(u16 b);

--- a/src/func_02030aa4.c
+++ b/src/func_02030aa4.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void func_0203da2c(int v);
 extern void func_0203da4c(void);
 extern u8 data_0209fc5c[];

--- a/src/func_02030b58.c
+++ b/src/func_02030b58.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_0203d9b4(void);
 extern int func_0203d950(int i);
 extern void func_02020214(unsigned int flags);

--- a/src/func_02030c38.c
+++ b/src/func_02030c38.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_0203d950(int i);
 extern void func_02030790(void);
 

--- a/src/func_02030dac.c
+++ b/src/func_02030dac.c
@@ -1,7 +1,5 @@
+#include "types.h"
 extern int func_0203d890(void);
-
-typedef unsigned char u8;
-typedef signed char s8;
 extern u8 data_0209fc5c[];
 extern s8 data_0209fc64[];
 extern u8 data_0209fc50;

--- a/src/func_02031028.c
+++ b/src/func_02031028.c
@@ -1,7 +1,4 @@
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_0209fc84;
 extern u8 data_0209fca0;
 extern u8 data_0209fc88;

--- a/src/func_02031154.c
+++ b/src/func_02031154.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_02031b84(int c);
 
 struct S { u8 b[8]; };

--- a/src/func_02031428.c
+++ b/src/func_02031428.c
@@ -1,9 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef unsigned long long u64;
-
 extern int func_02054d88(void);
 extern void MultiCopy_Int(int *dst, int *src, int len);
 

--- a/src/func_020316d8.c
+++ b/src/func_020316d8.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_0209fcdc[];
 extern u8 data_0209fc78[];
 extern u8 data_0209fc88[];

--- a/src/func_02031cd4.c
+++ b/src/func_02031cd4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u8 data_0209fcd8;
 extern u8 data_0209fc88;
 extern u8 data_0209fcc8;

--- a/src/func_02031e00.c
+++ b/src/func_02031e00.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void MultiStore_Int(int val, void *dst, int len);
 extern void func_02031b84(int c);
 

--- a/src/func_020321fc.c
+++ b/src/func_020321fc.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed short s16;
-
+#include "types.h"
 extern u8 data_0209fcb8;
 extern u8 data_0209fc6c;
 extern u8 data_0209fc8c;

--- a/src/func_020326ac.c
+++ b/src/func_020326ac.c
@@ -1,11 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef unsigned char u8;
-
 extern u8 data_0209fcc8;
 extern u8 data_0209fc7c;
 extern u8 data_0209fc78;

--- a/src/func_02032f9c.c
+++ b/src/func_02032f9c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct {
     int m0;
     short m4;

--- a/src/func_02033390.cpp
+++ b/src/func_02033390.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
 extern u8 data_0209fc9c;
 extern u8 data_0209fc94;

--- a/src/func_02033464.c
+++ b/src/func_02033464.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int data_0209fd1c;
 extern u8 data_0209fcb0;
 extern u8 data_0209fc9c;

--- a/src/func_02033a80.c
+++ b/src/func_02033a80.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 data_0209fce8;
 extern u8 data_0209fc9c;
 extern u8 data_0209fc94;

--- a/src/func_02033ae0.c
+++ b/src/func_02033ae0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 extern int _ZN3G2S13GetBG0CharPtrEv(void);
 extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void MultiStore_Int(int a, int b, int n);

--- a/src/func_02034098.cpp
+++ b/src/func_02034098.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned char u8;
 extern short data_0209fce8;
 extern int data_0209fd08;
 extern int *data_0209fcf8;

--- a/src/func_020341a8.cpp
+++ b/src/func_020341a8.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned char u8;
 extern short data_0209fce8;
 extern int data_0209fd08;
 extern int *data_0209fcf8;

--- a/src/func_020345b0.c
+++ b/src/func_020345b0.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void *data_0209fcf8;
 extern s16 data_0209fce8;
 extern void *data_0209fd08;

--- a/src/func_02034b40.c
+++ b/src/func_02034b40.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern int func_02034d34(void* thiz);
 extern void _ZN3OAM5ResetEv(void);
 extern s32 func_0200f0bc(void);

--- a/src/func_02034d70.c
+++ b/src/func_02034d70.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_02034d70
 // @emits dScMB_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 /* recovered: renamed to Class_Method */
 /* dScMB_c::CleanupResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
-
 extern void* SCENE_RELATED;  /* 0x0209d4a8 */
 
 int dScMB_c_CleanupResources(void) {

--- a/src/func_02034da4.c
+++ b/src/func_02034da4.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_02034da4
 // @emits dScMB_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMB_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern void DecompressLZ16(void *src, int dst);
 extern int func_0201a244(int a0, int a1, int a2, int a3, int a4);
 extern void func_020308b4(void);

--- a/src/func_02034fbc.c
+++ b/src/func_02034fbc.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern int LoadArchive(int idx);
 extern void *func_0201a458(void);
 extern void *_ZN4Heap10SetDefaultEv(void *h);

--- a/src/func_0203506c.c
+++ b/src/func_0203506c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0203506c
 // @emits dScMB_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -5,11 +6,6 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMB_c::InitResources - recovered from vtable slot identity */
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_020352b4.c
+++ b/src/func_020352b4.c
@@ -1,3 +1,4 @@
+#include "types.h"
 extern void *_ZN9ActorBasenwEj(unsigned);
 extern void _ZN9ActorBaseC1Ev(void *);
 
@@ -7,9 +8,6 @@ extern int data_020943c4[];
 extern int data_0208eafc[];
 extern int data_0208eacc[];
 extern int data_0208eb2c[];
-
-typedef unsigned char u8;
-
 void *func_020352b4(void)
 {
     char *p = (char *)_ZN9ActorBasenwEj(0x68);

--- a/src/func_020357a0.c
+++ b/src/func_020357a0.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* func_020357a0
  * Attempt 1: calls BgCh::StopDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void func_020353e0(struct BgCh* self);

--- a/src/func_020357c0.c
+++ b/src/func_020357c0.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* func_020357c0
  * Attempt 1: calls BgCh::StopDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void func_020353f4(struct BgCh* self);

--- a/src/func_020357e0.c
+++ b/src/func_020357e0.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* func_020357e0
  * Attempt 1: calls BgCh::StopDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void func_02035414(struct BgCh* self);

--- a/src/func_02035800.c
+++ b/src/func_02035800.c
@@ -1,8 +1,7 @@
+#include "types.h"
 /* func_02035800
  * Attempt 1: calls BgCh::StopDetectingWater on this+0x134 then this+0x20.
  */
-typedef unsigned int u32;
-
 struct BgCh { u32 _pad[1]; };
 
 extern void func_02035428(struct BgCh* self);

--- a/src/func_02036acc.c
+++ b/src/func_02036acc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 typedef struct Vec3 { int x, y, z; } Vec3;

--- a/src/func_020371b0.c
+++ b/src/func_020371b0.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Actor {
     char pad[0xa4];
     int speed_x; /* 0xa4 */

--- a/src/func_02037318.c
+++ b/src/func_02037318.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 extern int _ZN6Player7IsInAirEv(void *player);
 

--- a/src/func_020398c8.c
+++ b/src/func_020398c8.c
@@ -1,12 +1,6 @@
+#include "types.h"
 // MeshCollider::MeshCollider() - C1 constructor returning this
 // Address: 0x020398c8
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int Fix12i;
-
 struct MeshColliderBase {
     void* vtable;             // 0x00
     void* actor;              // 0x04

--- a/src/func_0203b9bc.c
+++ b/src/func_0203b9bc.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 struct Col { u16 a, b, c, d; };
 
 extern volatile struct Col data_020a0df8[];

--- a/src/func_0203bb60.c
+++ b/src/func_0203bb60.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 struct R {
     u16 field_0;   /* 0x0 */
     u16 field_2;   /* 0x2 */

--- a/src/func_0203bc7c.c
+++ b/src/func_0203bc7c.c
@@ -1,8 +1,6 @@
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_loop_invariants off
-
-typedef unsigned short u16;
-
 typedef struct InputPair
 {
     u16 cur;

--- a/src/func_0203db64.c
+++ b/src/func_0203db64.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void CpuCopy8(void *dst, void *src, int n);
 extern void func_0205a588(void *dst, int c, int n);
 extern void func_02042778(void);

--- a/src/func_0203df40.c
+++ b/src/func_0203df40.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct {
     s32 unk0;
     u8 unk4, unk5, unk6, unk7, unk8, unk9, unkA, unkB;

--- a/src/func_0203e0ac.c
+++ b/src/func_0203e0ac.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_020a1040[];
 extern u8 data_020a1154[];
 extern u16 data_020a117c[4];

--- a/src/func_0203e20c.c
+++ b/src/func_0203e20c.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_020a0f04;
 extern u8 data_020a0f08;
 extern u8 data_020a0f0c;

--- a/src/func_0203e9a8.c
+++ b/src/func_0203e9a8.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void CpuCopy8(int a, void *b, int n);
 extern char data_020a0fb8[];
 extern int data_020a0f70;

--- a/src/func_0203ea5c.c
+++ b/src/func_0203ea5c.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct {
     s32 unk0;
     u8 unk4;

--- a/src/func_0203f714.c
+++ b/src/func_0203f714.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern void func_0203f6e8(s16 v);
 extern int func_0203f818(int arg);
 extern int func_02059640(void);

--- a/src/func_0203f920.c
+++ b/src/func_0203f920.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern void func_0203f650(int x);
 extern void func_0203f8a4(void);
 extern void func_0203f714(void);

--- a/src/func_02040014.c
+++ b/src/func_02040014.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_020a0f5c;
 extern u16 data_020a0f24;
 extern u8 data_020a0f9d[4];

--- a/src/func_02040504.c
+++ b/src/func_02040504.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern void func_02040820(void);
 extern void func_02040790(void);
 extern int data_020a0f5c;

--- a/src/func_020405b4.c
+++ b/src/func_020405b4.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern int func_0203fcec(void);
 extern int func_0203fcb0(void);
 extern int data_020a0f5c;

--- a/src/func_02040638.c
+++ b/src/func_02040638.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int s32;
-
+#include "types.h"
 extern void MultiCopy_Int(void* dst, void* src, u32 count);
 
 typedef struct ObjWithField0a {

--- a/src/func_02040a5c.c
+++ b/src/func_02040a5c.c
@@ -1,8 +1,6 @@
+#include "types.h"
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int savedState);
-
-typedef unsigned int u32;
-
 typedef struct {
     char pad[0xb50];
     u32 field_b50;

--- a/src/func_02040aa4.c
+++ b/src/func_02040aa4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 extern void func_0205cd5c(void *arg0, int arg1);

--- a/src/func_02040bb0.c
+++ b/src/func_02040bb0.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern char data_020a1fc0[];
 extern int data_020a0f38;
 extern char data_020a2400[];

--- a/src/func_02040c34.c
+++ b/src/func_02040c34.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct InitArrays {
     int ptrs[0x10];
     int zeros1[0x10];

--- a/src/func_02040f30.c
+++ b/src/func_02040f30.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 typedef struct 
 {
   u32 kind : 4;

--- a/src/func_0204175c.c
+++ b/src/func_0204175c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 /* Hardware IO registers */
 static volatile u32 * const REG_IE = (volatile u32 *)0x04000210;
 static volatile u32 * const REG_IF = (volatile u32 *)0x04000214;

--- a/src/func_020417d0.c
+++ b/src/func_020417d0.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 extern u32 data_020a1fc0[];
 extern void func_02041930(void);
 extern void func_020650d8(int a, int b, int c);

--- a/src/func_020418f0.c
+++ b/src/func_020418f0.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern u32 data_020a1fc0[];
 extern void func_02041e14(void);
 extern void func_02041930(void);

--- a/src/func_02041930.c
+++ b/src/func_02041930.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern char data_020a1fc0[];
 extern void func_020418f0(void);
 extern int func_02065138(int a, int b);

--- a/src/func_02041a00.c
+++ b/src/func_02041a00.c
@@ -1,8 +1,4 @@
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
+#include "types.h"
 extern char data_020a2400[];
 extern char data_020a1fc0[];
 extern void func_02041224(char *thiz, int n);

--- a/src/func_02041e14.c
+++ b/src/func_02041e14.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     u32 kind : 4;
     u32 chan : 4;

--- a/src/func_020424c0.c
+++ b/src/func_020424c0.c
@@ -1,7 +1,6 @@
+#include "types.h"
 #pragma opt_propagation off
 #pragma opt_loop_invariants off
-typedef unsigned int u32;
-
 typedef struct {
     int flag;
     char pad0[0x10];

--- a/src/func_020433b8.c
+++ b/src/func_020433b8.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int data_02099f24[];
 extern int data_020a4b88[];
 extern void func_0204335c(void* self);

--- a/src/func_02043880.c
+++ b/src/func_02043880.c
@@ -1,9 +1,5 @@
+#include "types.h"
 enum { false, true };
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 typedef struct Node {
     struct Node* prev;
     struct Node* next;

--- a/src/func_02043f98.c
+++ b/src/func_02043f98.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 struct Node {
     void* x0;
     struct Node* next;  /* 0x4 */

--- a/src/func_02044b30.c
+++ b/src/func_02044b30.c
@@ -1,8 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
+#include "types.h"
 extern s16 data_02082214[];
 extern u8 data_020a4bbc;
 extern u16 data_02099f94[8];

--- a/src/func_02044efc.c
+++ b/src/func_02044efc.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct { s32 m[12]; } Matrix4x3;
 
 typedef struct {

--- a/src/func_02044f74.c
+++ b/src/func_02044f74.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 void func_02048234(int* out, int a, int b, int c, int p0, int p1, int p2, int p3, int p4, int p5);
 void MulMat4x3Mat4x3(int* out, int a, int b, int c);
 

--- a/src/func_02045074.c
+++ b/src/func_02045074.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 void func_02045178(int* out, int a, int b, int c, int p0, int p1, int p2);
 void func_02048234(int* out, int a, int b, int c, int p0, int p1, int p2, int p3, int p4, int p5);
 void MulMat4x3Mat4x3(int* out, int a, int b, int c);

--- a/src/func_0204547c.c
+++ b/src/func_0204547c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     u8 b0; u8 b1; u16 h2;
     u8 b4; u8 b5; u16 h6;

--- a/src/func_02045a50.c
+++ b/src/func_02045a50.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 gTexPlttCur;    /* 0x020a4bcc */
 extern u32 gTexPlttEnd;    /* 0x020a4bd8 */
 

--- a/src/func_02045ad8.c
+++ b/src/func_02045ad8.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 gTexPlttCur;    /* 0x020a4bcc */
 extern u32 gTexPlttEnd;    /* 0x020a4bd8 */
 

--- a/src/func_02045d9c.c
+++ b/src/func_02045d9c.c
@@ -1,7 +1,5 @@
+#include "types.h"
 // func_02045d9c - Display/3D init: enable DTCM, configure DISPCNT, call G3X setup
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern void _ZN4CP1510EnableDTCMEv(void);
 extern void _ZN3G3X13SetClearColorEtiiib(u16 color, int r, int g, int b, int alpha);
 extern u16 func_02053ed0(void);

--- a/src/func_02046088.c
+++ b/src/func_02046088.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Sub Sub;
 struct Sub {
     char _pad[0x24];

--- a/src/func_02046120.c
+++ b/src/func_02046120.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Sub Sub;
 struct Sub {
     char _pad[0x24];

--- a/src/func_020462d0.c
+++ b/src/func_020462d0.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 typedef struct SrcA {
     int f0, f4, f8, fc, f10;
     u16 f14, f16;

--- a/src/func_02046590.c
+++ b/src/func_02046590.c
@@ -1,8 +1,6 @@
+#include "types.h"
 extern int _ZN4cstd6strcmpEPKcS1_(const char* a, const char* b);
 extern void Crash(void);
-
-typedef unsigned int u32;
-
 typedef struct {
     const char* name;
     char pad[0x2c];

--- a/src/func_020469e8.c
+++ b/src/func_020469e8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 struct Entry {
     u16 id;     /* +0x00 */
     u16 p2;

--- a/src/func_02046bbc.c
+++ b/src/func_02046bbc.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct Entry
 {
   u16 id;

--- a/src/func_02046d50.c
+++ b/src/func_02046d50.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct { s16 res; s16 pad; int name; } E8;
 
 int func_020471ac(const void* tbl, const char* name);

--- a/src/func_02046e28.c
+++ b/src/func_02046e28.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct MatAnimComp { u8 pad0; u8 which; u16 base; };
 struct MatAnimEntry { u16 matIdx; u8 pad2[6]; struct MatAnimComp comp[13]; };
 struct Material { u8 pad0[0x24]; u32 polyAttr; u32 diffAmb; u32 specEmi; };

--- a/src/func_02047144.c
+++ b/src/func_02047144.c
@@ -1,8 +1,6 @@
+#include "types.h"
 extern int _ZN4cstd6strcmpEPKcS1_(const char* a, const char* b);
 extern void Crash(void);
-
-typedef unsigned int u32;
-
 typedef struct {
     const char* name;
     char pad[0xc];

--- a/src/func_020471ac.c
+++ b/src/func_020471ac.c
@@ -1,8 +1,6 @@
+#include "types.h"
 extern int _ZN4cstd6strcmpEPKcS1_(const char* a, const char* b);
 extern void Crash(void);
-
-typedef unsigned int u32;
-
 typedef struct {
     const char* name;
     char pad[0x2c];

--- a/src/func_02048528.c
+++ b/src/func_02048528.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 data_02099fa4;
 extern unsigned int func_02049018(int *a);
 extern void func_0204f924(void *p, int v);

--- a/src/func_020485f0.c
+++ b/src/func_020485f0.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 data_02099fa4;
 extern unsigned int func_02049018(int *a);
 extern void func_0204f924(void *p, int v);

--- a/src/func_02048720.c
+++ b/src/func_02048720.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_02048720
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-
-
 typedef struct {
     void *obj;
     int dist;


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 87 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
