### PR TITLE
readable: consolidate 87 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_02048908.c
+++ b/src/func_02048908.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_02048908 at 0x02048908
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int data_02099fa8;
 extern int data_02099fac;
 extern u16 data_02099fa4;

--- a/src/func_02048a1c.c
+++ b/src/func_02048a1c.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern u32 data_02099fac;
 extern int data_020a4bec;
 int func_02049018(int *p);

--- a/src/func_02048d80.c
+++ b/src/func_02048d80.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern int data_02099fa8;
 extern int data_02099fac;
 extern u16 data_02099fa4;

--- a/src/func_02048fd4.c
+++ b/src/func_02048fd4.c
@@ -1,7 +1,6 @@
+#include "types.h"
 // Copies pair i (i in 0..8) from table data_020821c0 into
 // data_02099fa8 / data_02099fac.
-typedef unsigned int u32;
-
 extern u32 data_020821c0[];
 extern volatile u32 data_02099fa8;
 extern volatile u32 data_02099fac;

--- a/src/func_020490b0.cpp
+++ b/src/func_020490b0.cpp
@@ -1,9 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-
-typedef int s32;
-typedef unsigned short u16;
-
 extern s32 data_020a4c5c[];
 extern s32 data_020a4c4c[];
 extern u16 data_020a4c48[];

--- a/src/func_0204921c.c
+++ b/src/func_0204921c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_020a4c5c[];
 extern int data_020a4c4c[];
 extern u16 data_020a4c48[];

--- a/src/func_020494cc.c
+++ b/src/func_020494cc.c
@@ -1,6 +1,5 @@
+#include "types.h"
 /* func_020494cc at 0x020494cc, size=0x298 (sibling of func_0204921c) */
-typedef unsigned short u16;
-
 extern u16 data_020a4c48[];
 extern int data_020a4c4c[];
 extern int data_020a4c54[];

--- a/src/func_020497a0.c
+++ b/src/func_020497a0.c
@@ -1,6 +1,4 @@
-typedef signed short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct EchoChan {
     int l;
     int r;

--- a/src/func_02049d78.c
+++ b/src/func_02049d78.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_0204d958(void *p);
 extern void func_0204d9a0(void *p, int r);
 extern void func_0204d8e8(void *p, void *q);

--- a/src/func_02049ee8.c
+++ b/src/func_02049ee8.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_0204a5c8(void* o);
 
 typedef struct Node {

--- a/src/func_02049f58.c
+++ b/src/func_02049f58.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_02049f58 at 0x02049f58
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern void func_0204a730(void* o, void* n);
 extern int func_0204d8e8(void* p, void* n);
 extern void func_0204d9a0(void* p, int v);

--- a/src/func_0204a0dc.c
+++ b/src/func_0204a0dc.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN2GX12BeginLoadTexEv(void);
 extern u32 _ZN2GX7LoadTexEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN2GX10EndLoadTexEv(void);

--- a/src/func_0204a17c.cpp
+++ b/src/func_0204a17c.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Vector3;
 
 namespace Particle {

--- a/src/func_0204a5c8.c
+++ b/src/func_0204a5c8.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_0204a5c8 at 0x0204a5c8, size 0x168
  * Matched byte-for-byte with mwccarm 1.2/sp2p3
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void func_0204af3c(void* p);
 extern void func_0204af38(void* p);
 extern void func_0204b244(void* self, void* node);

--- a/src/func_0204a730.c
+++ b/src/func_0204a730.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_0204a730 @ 0x0204a730 (arm9, size 0x6fc)   [mwccarm 1.2/sp2p3]
  * Levers that matched (notes 6ap): group B = u32 byte-hoist at function scope with
  * s32 k demoted into the loop block after var_r5; group A = flags declared plain u32
@@ -5,14 +6,6 @@
  * stack hole at [sp,#0x2c] while the plain reads stay value-numberable, which blocks
  * the lsl/lsr re-fold. Do not "simplify" the volatile store or the shifts re-fold.
  */
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef long long s64;
-
 typedef struct { s32 x, y, z; } Vec3;
 
 extern void func_0204c584(void *self, void *arg);

--- a/src/func_0204ae2c.c
+++ b/src/func_0204ae2c.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol func_0204ae2c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-
 struct H2 { u16 a, b; };
 
 struct Src {

--- a/src/func_0204af3c.c
+++ b/src/func_0204af3c.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int s32;
 typedef s32 fx32;
 
 #define reg_G3_TEXIMAGE_PARAM (*(volatile u32 *)0x040004a8)

--- a/src/func_0204b460.c
+++ b/src/func_0204b460.c
@@ -1,9 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 typedef struct {

--- a/src/func_0204b81c.c
+++ b/src/func_0204b81c.c
@@ -1,9 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 typedef struct {

--- a/src/func_0204bbd8.c
+++ b/src/func_0204bbd8.c
@@ -1,9 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 typedef struct {

--- a/src/func_0204be40.c
+++ b/src/func_0204be40.c
@@ -1,9 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 typedef struct {

--- a/src/func_0204c0a8.c
+++ b/src/func_0204c0a8.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 struct S {
     int x00;    /* 0x00 */
     int x04;    /* 0x04 */

--- a/src/func_0204c304.c
+++ b/src/func_0204c304.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 
 typedef struct Node { struct Node *next; struct Node *prev; } Node;

--- a/src/func_0204d0b8.c
+++ b/src/func_0204d0b8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 void func_0204d0b8(void *p, int a, int b) {
     u16 *c = (u16 *)(((long long)(int)((char *)p + 0x40)));
     u16 g = ((0xff - b) * 0x1f) / 0xff;

--- a/src/func_0204d150.c
+++ b/src/func_0204d150.c
@@ -1,5 +1,4 @@
-
-typedef unsigned char u8;
+#include "types.h"
 #pragma opt_strength_reduction off
 void func_0204d150(char *r0, char *r1, int r2)
 {

--- a/src/func_0204d1b4.c
+++ b/src/func_0204d1b4.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern int __aeabi_idiv(int a, int b);
 extern u32 data_020a4d30;
 struct Dst

--- a/src/func_0204d294.c
+++ b/src/func_0204d294.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 /* Three-stop RGB555 colour ramp entry. */
 struct ColorRamp
 {

--- a/src/func_0204d9f0.c
+++ b/src/func_0204d9f0.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0204d9f0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
@@ -6,13 +7,6 @@
 /* func_0204d9f0 at 0x0204d9f0, size=0x5c
  * LCG RNG: generates 2 random values for x,y (z=0), normalizes the vector.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
-
-
-
 extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 
 void func_0204d9f0(struct Vector3* out)

--- a/src/func_0204da4c.c
+++ b/src/func_0204da4c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_0204da4c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
@@ -6,13 +7,6 @@
 /* func_0204da4c at 0x0204da4c, size=0x68
  * LCG RNG: generates 3 random values for x,y,z, then normalizes the vector.
  */
-
-typedef int s32;
-typedef unsigned int u32;
-
-
-
-
 extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 
 void func_0204da4c(struct Vector3* out)

--- a/src/func_0204eda4.c
+++ b/src/func_0204eda4.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 struct Pair { void* a; u32 idx; };
 
 extern int func_0205d568(int r0, struct Pair p);

--- a/src/func_0204ef9c.c
+++ b/src/func_0204ef9c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 int func_0204ef9c(void* p) {
     if (*(u32*)p != 0x4352414e) return 0;
     if (*(u16*)((char*)p + 4) != 0xfffe) return 0;

--- a/src/func_0204effc.c
+++ b/src/func_0204effc.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern void func_0205227c(void);
 extern void func_02050258(void);
 extern void func_0205abb8(int a, int b, int c, int d);

--- a/src/func_0204f2d4.c
+++ b/src/func_0204f2d4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct HeapAllocator HeapAllocator;
 typedef struct HeapObj HeapObj;
 struct HeapObj {

--- a/src/func_0204f364.c
+++ b/src/func_0204f364.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern char data_020a4d54[];
 extern char data_020a4d60[];
 

--- a/src/func_0204f5a0.c
+++ b/src/func_0204f5a0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct Obj2;
 
 extern void func_0204f3e0(void *c);

--- a/src/func_0204f600.c
+++ b/src/func_0204f600.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void func_0205adc4(u8 arg);
 extern void func_0204f4bc(void *thiz);
 extern void *func_0205afb4(void);

--- a/src/func_0204f82c.c
+++ b/src/func_0204f82c.c
@@ -1,9 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-typedef short s16;
-
+#include "types.h"
 extern s16 data_02086384[];
 extern int func_0205acfc(int a, int b, int c);
 

--- a/src/func_0204f958.c
+++ b/src/func_0204f958.c
@@ -1,8 +1,8 @@
+#include "types.h"
 /* func_0204f958 at 0x0204f958
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned char u8;
 extern u8 *_ZN18NestedHeapIterator4NextEP13HeapAllocator(void *iter, void *alloc);
 extern void func_0204f558(u8 *thiz, int val);
 extern char data_020a4d6c[];

--- a/src/func_0204f9c4.c
+++ b/src/func_0204f9c4.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_0204f9c4 at 0x0204f9c4
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned char u8;
-
 extern void func_0204f5a0(u8 *thiz, int arg1);
 
 extern u8 data_020a4d6c[];

--- a/src/func_0204fa3c.c
+++ b/src/func_0204fa3c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *func_020511d4(void *a, u32 elemSize, u32 p2, u32 p3, u32 p4);
 extern void *func_0205130c(unsigned int addr, unsigned int size);
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(void *iter, void *alloc);

--- a/src/func_0204fafc.c
+++ b/src/func_0204fafc.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct HeapAllocator;
 struct NestedHeapIterator;
 

--- a/src/func_020503a4.c
+++ b/src/func_020503a4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 typedef struct G {
     int f0, f4, f8, fc, f10, f14, f18, f1c, f20, f24, f28, f2c, f30, f34;
     char f38[0x10];

--- a/src/func_02050fd4.c
+++ b/src/func_02050fd4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct SolidHeapAllocator;
 struct HeapAllocator;
 

--- a/src/func_02051024.c
+++ b/src/func_02051024.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct SolidHeapWithIter {
     void* allocator;       // 0x00
     void* nhi_first;       // 0x04

--- a/src/func_02051074.c
+++ b/src/func_02051074.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef struct SolidHeapAllocator SolidHeapAllocator;
 extern u32 _ZN18SolidHeapAllocator10MemoryLeftEi(SolidHeapAllocator *self, u32 align);
 u32 func_02051074(SolidHeapAllocator **pHeap)

--- a/src/func_0205117c.c
+++ b/src/func_0205117c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef signed int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct SolidHeapWithIter {
     void* allocator;       // 0x00
     void* nhi_first;       // 0x04

--- a/src/func_020511d4.c
+++ b/src/func_020511d4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct HeapAllocator HeapAllocator;
 
 typedef struct NestedHeapIterator {

--- a/src/func_0205179c.c
+++ b/src/func_0205179c.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern int* _ZN5Sound17InfoSequenceEntry9GetWithIDEj(unsigned int id);
 extern int* _ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(unsigned int id);
 extern int func_02051514(int a, int b);

--- a/src/func_02051bd0.c
+++ b/src/func_02051bd0.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_02051bd0 at 0x02051bd0
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int *_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj(unsigned int id);
 extern int func_0204f63c(void **p, int idx, int r7);
 extern int func_020509b0(unsigned int i);

--- a/src/func_02051f1c.c
+++ b/src/func_02051f1c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Elem { u8 pad0[4]; u16 f4; u8 pad6[2]; u8 f8; u8 f9; };
 
 extern int *func_02050c14(u32 id);

--- a/src/func_020520a4.c
+++ b/src/func_020520a4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct HeapAllocator HeapAllocator;
 typedef struct NestedHeapIterator {
     int unk[8];

--- a/src/func_0205212c.cpp
+++ b/src/func_0205212c.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 struct HeapAllocator;
 
 struct IRQ {

--- a/src/func_020523e0.c
+++ b/src/func_020523e0.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 struct Elem {
     int first;  /* 0x0 */
     int x4;     /* 0x4 */

--- a/src/func_02053130.c
+++ b/src/func_02053130.c
@@ -1,7 +1,4 @@
-typedef signed int s32;
-typedef signed long long s64;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN4cstd16reciprocal_asyncE5Fix12IiE(s32 x);
 extern void func_02053008(s32 x);
 extern s64 _ZN4cstd11ldiv_resultEv(void);

--- a/src/func_020538b8.c
+++ b/src/func_020538b8.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_020538b8 at 0x020538b8
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef int s32;
-typedef short s16;
-typedef unsigned short u16;
-
 extern s32 _ZN4cstd4fdivEii(s32 numerator, s32 denominator);
 extern s16 data_02086214[];
 

--- a/src/func_02053d9c.c
+++ b/src/func_02053d9c.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern u16 data_020a6088[];
 
 void func_02053d9c(void)

--- a/src/func_02053ee0.c
+++ b/src/func_02053ee0.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_02053ee0 @ 0x02053ee0 -- clear OBJ ext-palette enable bit in sub-engine
  * DISPCNT, then disable the VRAM bank assignment via DisableVramBanks. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 DisableVramBanks(u16 *bankBitsPtr);
 extern u16 data_020a60a0;
 

--- a/src/func_02053f08.c
+++ b/src/func_02053f08.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_02053f08 @ 0x02053f08 -- clear BG ext-palette enable bit in sub-engine
  * DISPCNT, then disable the VRAM bank assignment via DisableVramBanks. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 DisableVramBanks(u16 *bankBitsPtr);
 extern u16 data_020a609e;
 

--- a/src/func_02053f30.c
+++ b/src/func_02053f30.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a609c;
 

--- a/src/func_02053f44.c
+++ b/src/func_02053f44.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a609a;
 

--- a/src/func_02053f58.c
+++ b/src/func_02053f58.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a6088;
 

--- a/src/func_02053f6c.c
+++ b/src/func_02053f6c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a608e;
 

--- a/src/func_02053f80.c
+++ b/src/func_02053f80.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a6094;
 

--- a/src/func_02053f94.c
+++ b/src/func_02053f94.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a6092;
 

--- a/src/func_02053fa8.c
+++ b/src/func_02053fa8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a6090;
 

--- a/src/func_02053fbc.c
+++ b/src/func_02053fbc.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_02053fbc @ 0x02053fbc -- clear OBJ ext-palette enable bit in main-engine
  * DISPCNT, then disable the VRAM bank assignment via DisableVramBanks. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 DisableVramBanks(u16 *bankBitsPtr);
 extern u16 data_020a6098;
 

--- a/src/func_02053fe0.c
+++ b/src/func_02053fe0.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_02053fe0 @ 0x02053fe0 -- clear BG ext-palette enable bit in main-engine
  * DISPCNT, then disable the VRAM bank assignment via DisableVramBanks. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 DisableVramBanks(u16 *bankBitsPtr);
 extern u16 data_020a6096;
 

--- a/src/func_02054004.c
+++ b/src/func_02054004.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a608c;
 

--- a/src/func_02054018.c
+++ b/src/func_02054018.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 DisableVramBanks(u16*);
 extern u16 data_020a608a;
 

--- a/src/func_020540f0.c
+++ b/src/func_020540f0.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_020540f0 @ 0x020540f0 -- clear OBJ ext-palette enable bit in sub-engine
  * DISPCNT, then unmap the VRAM bank back to LCDC via func_020541b8. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 func_020541b8(u16 *bankBitsPtr);
 extern u16 data_020a60a0;
 

--- a/src/func_02054118.c
+++ b/src/func_02054118.c
@@ -1,8 +1,6 @@
+#include "types.h"
 /* func_02054118 @ 0x02054118 -- clear BG ext-palette enable bit in sub-engine
  * DISPCNT, then unmap the VRAM bank back to LCDC via func_020541b8. */
-typedef unsigned short u16;
-typedef volatile unsigned long vu32;
-
 extern u16 func_020541b8(u16 *bankBitsPtr);
 extern u16 data_020a609e;
 

--- a/src/func_02054140.c
+++ b/src/func_02054140.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a609c;
 

--- a/src/func_02054154.c
+++ b/src/func_02054154.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a609a;
 

--- a/src/func_02054168.c
+++ b/src/func_02054168.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a6092;
 

--- a/src/func_0205417c.c
+++ b/src/func_0205417c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a6090;
 

--- a/src/func_02054190.c
+++ b/src/func_02054190.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a608c;
 

--- a/src/func_020541a4.c
+++ b/src/func_020541a4.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 func_020541b8(u16*);
 extern u16 data_020a608a;
 

--- a/src/func_020541b8.c
+++ b/src/func_020541b8.c
@@ -1,11 +1,9 @@
+#include "types.h"
 /* func_020541b8 at 0x020541b8
  * Takes a pointer to a VRAM bank bits field, clears it, merges bits into
  * the global VRAM register, then calls Vram__Map with those bits.
  * Returns the original bits value.
  */
-
-typedef unsigned short u16;
-
 extern u16 gVramReg;  /* at 0x020a6088 */
 extern void Vram__Map(u16 bits);
 

--- a/src/func_02054748.c
+++ b/src/func_02054748.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 struct VramReg { u16 w0; u16 pad[6]; u16 w0e; };
 extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);

--- a/src/func_020556d0.c
+++ b/src/func_020556d0.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern int func_02055490(int *out);
 extern int func_02055464(int *out);
 

--- a/src/func_02055fb4.c
+++ b/src/func_02055fb4.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_02055fb4 at 0x02055fb4 (likely _ZN3GXS11LoadBG3CharEPKvjj)
  * Loads BG3 char data using DMA if a channel is assigned, else CPU copy.
  */
-
-typedef unsigned int u32;
-
 extern u32 RENDER_DMA_CHANNEL;
 
 extern void *_ZN3G2S13GetBG3CharPtrEv(void);

--- a/src/func_020560d4.c
+++ b/src/func_020560d4.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_020560d4 at 0x020560d4 (likely _ZN3GXS11LoadBG2CharEPKvjj)
  * Loads BG2 char data using DMA if a channel is assigned, else CPU copy.
  */
-
-typedef unsigned int u32;
-
 extern u32 RENDER_DMA_CHANNEL;
 
 extern void *_ZN2G213GetBG2CharPtrEv(void);

--- a/src/func_020562b4.c
+++ b/src/func_020562b4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 gDmaChannel;
 
 extern void *_ZN3G2S12GetBG3ScrPtrEv(void);

--- a/src/func_02056314.c
+++ b/src/func_02056314.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern s32 RENDER_DMA_CHANNEL;
 
 void *_ZN2G212GetBG3ScrPtrEv(void);

--- a/src/func_02056374.c
+++ b/src/func_02056374.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 gDmaChannel;
 
 extern void *_ZN3G2S12GetBG2ScrPtrEv(void);

--- a/src/func_020563d4.c
+++ b/src/func_020563d4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 gDmaChannel;
 
 extern void *_ZN2G212GetBG2ScrPtrEv(void);

--- a/src/func_02056e4c.c
+++ b/src/func_02056e4c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct TimerIRQEntry {
     u32 handler;    /* +0 */
     u32 active;     /* +4 */


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 87 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
