### PR TITLE
readable: consolidate 90 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_02056e98.c
+++ b/src/func_02056e98.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct DMAIRQEntry {
     u32 handler;    /* +0 */
     u32 active;     /* +4 */

--- a/src/func_02057198.c
+++ b/src/func_02057198.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct {
     u32 lock;
     u16 owner;

--- a/src/func_02057228.c
+++ b/src/func_02057228.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed int s32;
-
+#include "types.h"
 typedef struct {
     u32 lock;
     u16 owner;

--- a/src/func_02057410.c
+++ b/src/func_02057410.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed char s8;
-typedef long long s64;
-
+#include "types.h"
 typedef struct Ctx {
     int n;
     char *cur;

--- a/src/func_02057d00.c
+++ b/src/func_02057d00.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_02057ce8(void *arg0, u32 fmtAddr, u32 val);
 
 void func_02057d00(void *arg0, u32 fmt, ...)

--- a/src/func_02057e48.c
+++ b/src/func_02057e48.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 prev);
 

--- a/src/func_02058048.c
+++ b/src/func_02058048.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Obj {
     char pad[0x64];
     u32 unk64;

--- a/src/func_0205816c.c
+++ b/src/func_0205816c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Obj {
     char pad[0x64];
     u32 unk64;

--- a/src/func_02058200.c
+++ b/src/func_02058200.c
@@ -1,5 +1,4 @@
-typedef unsigned u32;
-typedef unsigned short u16;
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 s);
 extern int func_02058538(void);

--- a/src/func_02058308.c
+++ b/src/func_02058308.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 typedef struct {
     char pad[0x14];
     int slots[16];

--- a/src/func_020587e4.c
+++ b/src/func_020587e4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct MsgQueue {
     u16 queueSend;      /* 0x00 */
     u16 queueReceive;   /* 0x02 */

--- a/src/func_02058b08.c
+++ b/src/func_02058b08.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 extern void func_020589ac(void* node, void* self);

--- a/src/func_02058df4.c
+++ b/src/func_02058df4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern char data_023c0000;
 extern void func_00000600(void);
 extern void func_00000000(void);

--- a/src/func_020590fc.c
+++ b/src/func_020590fc.c
@@ -1,10 +1,8 @@
+#include "types.h"
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int savedState);
 extern void * func_02059364(void *a, void *n);
 extern void * func_0205929c(void *a, void *n);
-
-typedef unsigned int u32;
-
 struct Elem { void *w0; void *w4; void *w8; };  /* 0xc */
 
 struct G637c {

--- a/src/func_0205950c.c
+++ b/src/func_0205950c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN4CP159EnableMPUEv(void);
 extern void _ZN4CP1510DisableMPUEv(void);
 

--- a/src/func_02059650.c
+++ b/src/func_02059650.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 tok);
 extern volatile u32 data_020a6438[2];

--- a/src/func_02059834.c
+++ b/src/func_02059834.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned long long u64;
-
+#include "types.h"
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 extern u64 func_02059650(void);
 extern void func_02059c18(void *p);

--- a/src/func_02059bc0.c
+++ b/src/func_02059bc0.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_02059624(u32 bit);
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 

--- a/src/func_02059c18.c
+++ b/src/func_02059c18.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern long long func_02059650(void *obj);
 extern void func_02056e4c(u32 idx, u32 handler, u32 arg);
 extern void func_02059824(void);

--- a/src/func_02059cb4.c
+++ b/src/func_02059cb4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 
 extern volatile u16 gCtrl1;    /* 0x020a644c */

--- a/src/func_02059e48.c
+++ b/src/func_02059e48.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_0205b858(void);
 extern int func_0205ba3c(int bit, int word);
 extern void func_0205ba64(int a, void *fn);

--- a/src/func_02059fd0.c
+++ b/src/func_02059fd0.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_02059fa8(int ch);
 extern void func_02056e98(int a, void *cb, int arg6);
 extern void DMAStartTransfer(int a, int src, int dst, u32 ctrl);

--- a/src/func_0205a064.c
+++ b/src/func_0205a064.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_02059fa8(int ch);
 extern void func_02056e98(u32 idx, u32 handler, u32 arg);
 extern void DMAStartTransfer(u32 ch, u32 reg, u32 src, u32 ctrl);

--- a/src/func_0205a21c.c
+++ b/src/func_0205a21c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 mask, void *handler);
 

--- a/src/func_0205a290.c
+++ b/src/func_0205a290.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 typedef void (*IrqFn)(int);
 
 struct G6460 {

--- a/src/func_0205a82c.c
+++ b/src/func_0205a82c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern u32 data_020a6480[];
 extern void func_0205b358(void);
 extern void func_0205b524(void);

--- a/src/func_0205aed0.c
+++ b/src/func_0205aed0.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 u32 _ZN3IRQ7DisableEv(void);
 void _ZN3IRQ7RestoreEj(u32 state);
 void func_0205b470(void *arg);

--- a/src/func_0205b554.c
+++ b/src/func_0205b554.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
 
 void func_0205b554(char *p)

--- a/src/func_0205b63c.c
+++ b/src/func_0205b63c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern unsigned char data_02086484[];
 
 u16 func_0205b63c(int x)

--- a/src/func_0205bad8.c
+++ b/src/func_0205bad8.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irqBits, void (*handler)(void));

--- a/src/func_0205bc88.c
+++ b/src/func_0205bc88.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void FS_InitFile(int* s);
 extern void func_0205c4e4(void* self, int value);
 extern int func_0205c5e4(void* self, int x);

--- a/src/func_0205c480.c
+++ b/src/func_0205c480.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 int func_0205c480(unsigned char *a, unsigned char *b, int n)
 {
     int i;

--- a/src/func_0205cbe4.c
+++ b/src/func_0205cbe4.c
@@ -1,9 +1,6 @@
+#include "types.h"
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int saved);
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 typedef struct Node {
     u32 f0;
     struct Node *next;

--- a/src/func_0205cd5c.c
+++ b/src/func_0205cd5c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct T {
     char pad0[0xc];
     u16 pending;

--- a/src/func_0205cfa4.c
+++ b/src/func_0205cfa4.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 saved);
 extern void OS_WakeupThread(u16 *p);

--- a/src/func_0205d044.c
+++ b/src/func_0205d044.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct Node {
     void *unk0;
     struct Node *next;

--- a/src/func_0205d23c.c
+++ b/src/func_0205d23c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Node {
     void *key;
     struct Node *next;

--- a/src/func_0205d3f4.c
+++ b/src/func_0205d3f4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Obj Obj;
 
 typedef struct Owner {

--- a/src/func_0205db88.c
+++ b/src/func_0205db88.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Storage {
     void *a;
     void *b;

--- a/src/func_0205dc7c.c
+++ b/src/func_0205dc7c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Node {
     struct Node* next;
     u32 lo;

--- a/src/func_0205e0b0.c
+++ b/src/func_0205e0b0.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct CacheInfo {
     u32 unk0;
     u32 base;

--- a/src/func_0205e6e4.c
+++ b/src/func_0205e6e4.c
@@ -1,6 +1,5 @@
+#include "types.h"
 #pragma opt_loop_invariants off
-typedef unsigned char u8;
-
 struct Obj {
   char pad00[0x14];
   int f14;       // 0x14

--- a/src/func_0205e89c.c
+++ b/src/func_0205e89c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 int func_0205e89c(u32 *ctx)
 {
     if (ctx == 0) return 1;

--- a/src/func_0205eb58.c
+++ b/src/func_0205eb58.c
@@ -1,9 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned long long u64;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 

--- a/src/func_0205edd8.cpp
+++ b/src/func_0205edd8.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned short u16;
+#include "types.h"
 extern "C" {
 int IPCSend(int a, int b, int c);
 }

--- a/src/func_0205eeac.cpp
+++ b/src/func_0205eeac.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned short u16;
+#include "types.h"
 extern "C" {
 int IPCSend(unsigned int a, unsigned int c, unsigned int b);
 }

--- a/src/func_0205f0e0.c
+++ b/src/func_0205f0e0.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 

--- a/src/func_0205f270.c
+++ b/src/func_0205f270.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_0205b858(void);
 extern int func_0205ba3c(int bit, int word);
 extern void func_0205ba64(int a, void *fn);

--- a/src/func_0205f300.c
+++ b/src/func_0205f300.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     u32 x : 12;
     u32 y : 12;

--- a/src/func_0205fab4.c
+++ b/src/func_0205fab4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int func_0205fbd0(int v);
 
 int func_0205fab4(int x)

--- a/src/func_0205fb58.c
+++ b/src/func_0205fb58.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0205ff20(int a, int b, int c, int d);
 extern void func_0205f8b0(int param);
 

--- a/src/func_0205ff20.c
+++ b/src/func_0205ff20.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 prev);
 

--- a/src/func_0206002c.c
+++ b/src/func_0206002c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void MultiStore32Bytes(unsigned val, int *dst, int len);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(unsigned int a, unsigned int b);
 extern void func_02058200(void *a, void *fn, int c, void *d, int e, int f);

--- a/src/func_020602bc.cpp
+++ b/src/func_020602bc.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" {
 extern char data_020a8180[];
 void OS_SleepThread(void *p);

--- a/src/func_020603c8.cpp
+++ b/src/func_020603c8.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned int u32;
+#include "types.h"
 extern "C" {
 extern char data_020a8180[];
 extern int data_020a6134[];

--- a/src/func_02060484.c
+++ b/src/func_02060484.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern char data_020a8180[];
 extern int data_020a6134[];
 void OS_SleepThread(void* p);

--- a/src/func_02060558.cpp
+++ b/src/func_02060558.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned int u32;
+#include "types.h"
 extern "C" {
 extern char data_020a8180[];
 extern int data_020a6134[];

--- a/src/func_02060918.c
+++ b/src/func_02060918.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct S8180 {
     char pad0[0x18];
     u32 f18;

--- a/src/func_02060a30.c
+++ b/src/func_02060a30.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int func_02060ebc(void *obj);
 extern void func_02060e38(void);
 

--- a/src/func_02060b64.c
+++ b/src/func_02060b64.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct G {
     char pad[0x18];
     u32 f18;

--- a/src/func_02060d1c.c
+++ b/src/func_02060d1c.c
@@ -1,5 +1,4 @@
-
-typedef unsigned int u32;
+#include "types.h"
 extern char data_020a8180[];
 extern char data_020a8780[];
 extern void func_02060d98(u32 a, u32 b);

--- a/src/func_02060e38.c
+++ b/src/func_02060e38.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Obj {
     char pad[0x64];
     u32 unk64;

--- a/src/func_02060f60.cpp
+++ b/src/func_02060f60.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 extern "C" int func_0205ba3c(int bit, int word);
 extern "C" void func_02059d8c(int x);
 extern "C" int IPCSend(unsigned int a, unsigned int c, unsigned int b);
-
-typedef unsigned short u16;
 extern "C" void OS_SleepThread(u16 *x);
 
 namespace CP15 {

--- a/src/func_02061138.c
+++ b/src/func_02061138.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irqBits, void (*handler)(void));

--- a/src/func_0206116c.c
+++ b/src/func_0206116c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 void func_0206116c(void)
 {
     u16 *p = (u16*)0x027fff96;

--- a/src/func_02061188.c
+++ b/src/func_02061188.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 typedef void (*Handler)(void *msg);
 
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);

--- a/src/func_02061674.c
+++ b/src/func_02061674.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0206152c(void);
 extern int WM_CheckStateEx(int a, int b);
 extern void func_0206116c(void);

--- a/src/func_020616e8.c
+++ b/src/func_020616e8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_0205b858(void);
 extern int func_0205ba3c(int bit, int word);
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int, unsigned int);

--- a/src/func_020618b8.c
+++ b/src/func_020618b8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void *WM_GetSystemWork(void);
 extern int func_0206152c(void);
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int n);

--- a/src/func_020619ac.c
+++ b/src/func_020619ac.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern int WM_GetSystemWork(void);
 extern int func_0206152c(void);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 a, u32 b);

--- a/src/func_02061b9c.c
+++ b/src/func_02061b9c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int *WM_GetSystemWork(void);
 extern int WM_CheckStateEx(int a, int b, int c);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 size);

--- a/src/func_02061c20.c
+++ b/src/func_02061c20.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int WM_GetSystemWork(void);
 extern int func_0206152c(void);
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int len);

--- a/src/func_02061d30.c
+++ b/src/func_02061d30.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern int WM_GetSystemWork(void);
 extern int WM_CheckStateEx(int count, int a, int b, int c, int d, int e);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 a, u32 b);

--- a/src/func_020620b0.c
+++ b/src/func_020620b0.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern int WM_CheckStateEx(int a, int b);
 extern void func_02062024(void *o);
 extern void WM_SetCallbackTable(int i, int val);

--- a/src/func_02062200.c
+++ b/src/func_02062200.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern int func_020614d0(int x);
 extern void WM_SetCallbackTable(int i, int val);
 extern int WM_SendCommand(int a, int b);

--- a/src/func_020625fc.c
+++ b/src/func_020625fc.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_020625fc at 0x020625fc
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int *WM_GetSystemWork(void);
 extern int WM_CheckStateEx(int a, int b, int c);
 extern void _ZN4CP1519InvalidateDataCacheEjj(unsigned int addr, unsigned int n);

--- a/src/func_02062778.c
+++ b/src/func_02062778.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern unsigned func_02062734(char* base, unsigned mask, unsigned acc, int count);
 
 unsigned func_02062778(char* a, unsigned short* b, int c)

--- a/src/func_020627e8.c
+++ b/src/func_020627e8.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int WM_GetSystemWork(void);
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int savedState);

--- a/src/func_02062aa4.cpp
+++ b/src/func_02062aa4.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" int WM_GetSystemWork(void);
 extern "C" void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 sz);
 extern "C" void MultiCopyHalf(const void *src, void *dst, u32 count);

--- a/src/func_02062d10.cpp
+++ b/src/func_02062d10.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern "C" void *WM_GetSystemWork(void);
 
 struct CP15 { static void InvalidateDataCache(u32 addr, u32 len); };

--- a/src/func_02062df0.c
+++ b/src/func_02062df0.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int WM_GetSystemWork(void);
 extern int WM_CheckStateEx(int count, ...);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);

--- a/src/func_020631dc.c
+++ b/src/func_020631dc.c
@@ -1,11 +1,6 @@
+#include "types.h"
 #pragma opt_common_subs off
 #pragma opt_strength_reduction off
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned long long u64;
-
 extern int WM_GetSystemWork(void);
 extern int WM_CheckStateEx(int count, ...);
 extern void _ZN4CP1519InvalidateDataCacheEjj(u32 addr, u32 len);

--- a/src/func_02063574.c
+++ b/src/func_02063574.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern int func_020614d0(void);
 extern void WM_SetCallbackTable(int i, int val);
 extern int WM_SendCommand(int a, int b, int c, int d, int e);

--- a/src/func_02063648.c
+++ b/src/func_02063648.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int data_020a9440[];
 extern int WM_CheckStateEx(int count, ...);
 extern void MultiCopy_Int(int *dst, int *src, int len);

--- a/src/func_02063718.c
+++ b/src/func_02063718.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void MultiCopy_Int(void *dst, void *src, int n);
 extern void func_02065bf4(void);
 extern int func_02065c1c(void);

--- a/src/func_02063980.c
+++ b/src/func_02063980.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Sub {
     u8 pad[0x68];
 } Sub;

--- a/src/func_02063ae4.c
+++ b/src/func_02063ae4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_02065a74(void);
 extern int func_0206491c(int a, int b);
 extern int func_02064888(int a, int b);

--- a/src/func_02063bc4.c
+++ b/src/func_02063bc4.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct {
     u8 status;      /* 0x0 */
     u8 byte1;       /* 0x1 */

--- a/src/func_02063ea8.c
+++ b/src/func_02063ea8.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void CpuCopy8(int a, void *b, int c);
 extern int func_02065a74(void);
 extern void func_02064470(void *self, int code, int idx);

--- a/src/func_02064554.c
+++ b/src/func_02064554.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern void CpuCopy8(int a, int b, int c);
 
 void func_02064554(int self, int sel, int idx, s16 a3)


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 90 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
