### PR TITLE
readable: consolidate 86 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_02064c2c.c
+++ b/src/func_02064c2c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void CpuCopy8(void *src, int dest, int size);
 
 int func_02064c2c(int dest, u16 a, u8 b, int c, int d, void *p, int n)

--- a/src/func_02064d6c.c
+++ b/src/func_02064d6c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void CpuCopy8(void *src, int dest, int size);
 
 int func_02064d6c(int dest, u16 a, u8 b, int c, int d, void *p, int n)

--- a/src/func_02065234.c
+++ b/src/func_02065234.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_020a94c0;
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int);

--- a/src/func_020652fc.c
+++ b/src/func_020652fc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_020a94c0;
 extern unsigned int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(unsigned int);

--- a/src/func_020656d4.c
+++ b/src/func_020656d4.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern void CpuCopy8(const void *src, void *dst, u32 size);  /* memcpy-like */
 extern int func_02065af0(void *pkt);
 

--- a/src/func_02065730.c
+++ b/src/func_02065730.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_02065730 at 0x02065730
  * Builds a 0x9c-byte struct on the stack, fills it from args/copies,
  * then calls func_02065af0(sp). Returns void.
@@ -15,10 +16,6 @@
  *
  * Parameters: r0=u16 type, r1=u32, r2=const void* src1, r3=u32, (stack)void* src2, (stack)u32 extra
  */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern void MultiCopy_Int(const void *src, void *dst, u32 size);  /* 0x0205a490 */
 extern void func_02065af0(void *pkt);
 

--- a/src/func_02065788.c
+++ b/src/func_02065788.c
@@ -1,3 +1,4 @@
+#include "types.h"
 /* func_02065788 at 0x02065788
  * Similar to func_02065730 but simpler: only one MultiCopy_Int.
  * Builds a 0x9c-byte packet on the stack and calls func_02065af0.
@@ -12,10 +13,6 @@
  *
  * Parameters: r0=u16, r1=u32, r2=const void* src, r3=u32
  */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern void MultiCopy_Int(const void *src, void *dst, u32 size);  /* 0x0205a490 */
 extern void func_02065af0(void *pkt);
 

--- a/src/func_020657d0.c
+++ b/src/func_020657d0.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct S657 {
     int kind;        /* +0 */
     int pad4;        /* +4 */

--- a/src/func_020658c0.c
+++ b/src/func_020658c0.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 s);
 extern int func_02065ae0(void);

--- a/src/func_02065c2c.c
+++ b/src/func_02065c2c.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern void CpuCopy8(const void *src, void *dst, unsigned int size);
 extern char *data_020a9db8;
 u8 *func_02065c2c(u8 *src, u8 *dst)

--- a/src/func_02065d5c.c
+++ b/src/func_02065d5c.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // Serializes a small record into a byte stream: writes the type byte, then
 // for type 4 appends the two halfwords at +2 and +4 little-endian. Returns
 // the advanced stream pointer, or 0 for type 0 / unknown types.
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 typedef struct Rec {
     u8 type;
     char _pad;

--- a/src/func_02065de4.c
+++ b/src/func_02065de4.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 extern char *data_020a9db8;
 extern void CpuCopy8(const void *src, void *dst, unsigned int size);
 int func_02065de4(u8 *a0, int idx)

--- a/src/func_0206610c.c
+++ b/src/func_0206610c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern char *data_020a9db8;
 
 extern void func_02065f08(int idx);

--- a/src/func_020662c0.c
+++ b/src/func_020662c0.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_0205a588(void *dst, int val, int len);
 extern u8 *func_02065d5c(void *src, void *dst);
 extern void CpuCopy8(void *dst, void *src, int len);

--- a/src/func_020664b4.c
+++ b/src/func_020664b4.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void *func_020619ac(int a, int b);
 extern void func_0206655c(void *p, int b);
 extern char *data_020a9db8;

--- a/src/func_0206655c.c
+++ b/src/func_0206655c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 *data_020a9db8;
 
 extern void func_02065c2c(u8 *a, u8 *b);

--- a/src/func_02066a94.c
+++ b/src/func_02066a94.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed char s8;
-
+#include "types.h"
 extern char *data_020a9db8;
 
 extern int func_02066fec(int a, int b, int c);

--- a/src/func_02066fec.c
+++ b/src/func_02066fec.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int *data_020a9db8;
 int func_02065edc(u32 x);
 int func_02066fb0(int a, int b, int c);

--- a/src/func_02067138.c
+++ b/src/func_02067138.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern int *data_020a9db8;
 
 extern int func_02065edc(unsigned int x);

--- a/src/func_02067250.c
+++ b/src/func_02067250.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int *data_020a9db8;
 int func_02065edc(u32 x);
 

--- a/src/func_020672a4.c
+++ b/src/func_020672a4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 prev);
 

--- a/src/func_020672d0.c
+++ b/src/func_020672d0.c
@@ -1,8 +1,5 @@
+#include "types.h"
 extern void CpuCopy8(const void *src, void *dst, unsigned int size);
-
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 void func_020672d0(char *thiz, int a1, int a2, int a3, int a4)
 {
     char *base = (char *)0x27ffc40;

--- a/src/func_0206736c.c
+++ b/src/func_0206736c.c
@@ -1,8 +1,8 @@
+#include "types.h"
 /* func_0206736c at 0x0206736c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (arm9 main).
  */
-typedef unsigned int u32;
 extern u32 data_0208685c[];
 extern int func_02067480(u32 idx, u32 addr, u32 size);
 

--- a/src/func_02067480.c
+++ b/src/func_02067480.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern u32 data_0208685c[];
 
 int func_02067480(u32 idx, u32 addr, u32 size)

--- a/src/func_02067530.c
+++ b/src/func_02067530.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 extern char* data_020a9db8;
 
 struct Out { int f0; u32 f4; int f8; u8 fc; };

--- a/src/func_020678a4.c
+++ b/src/func_020678a4.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void func_020676e0(void *in, void *tbl, void *dst, void *aux);
 extern void CpuCopy8(void *dst, void *src, u32 size);
 extern int data_0208685c[];

--- a/src/func_02067928.c
+++ b/src/func_02067928.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *data_020a9db8;
 extern u8 data_020a9d28;
 

--- a/src/func_02067f2c.c
+++ b/src/func_02067f2c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
 extern void _ZN4CP1516DrainWriteBufferEv(void);
 extern void func_020688fc(u32 dest, u32 src, u32 arg2);

--- a/src/func_02067f68.c
+++ b/src/func_02067f68.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_020a9d2c[];
 extern u8 data_020a9d40[];
 extern u16 data_020a9d48[];

--- a/src/func_020681b8.c
+++ b/src/func_020681b8.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct G9d2c {
     u8 pad0[4];      /* 0 */
     u8 *p;           /* 4 */

--- a/src/func_02068410.c
+++ b/src/func_02068410.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct G9d2c {
     char pad[0xc];
     u8 state;   /* 0xc */

--- a/src/func_02068514.c
+++ b/src/func_02068514.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 int func_02068514(u16 *p)
 {
     u16 v = *p++;

--- a/src/func_0206879c.c
+++ b/src/func_0206879c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern char *data_020a9db4;
 
 struct Pair { s16 a; s16 b; };

--- a/src/func_02068844.c
+++ b/src/func_02068844.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char* data_020a9db4;
 
 #define B (data_020a9db4 + 0x1300)

--- a/src/func_020688fc.c
+++ b/src/func_020688fc.c
@@ -1,6 +1,4 @@
-
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern char *data_020a9db4;
 extern int data_0209a088;
 extern void func_020690b0(void);

--- a/src/func_02068a28.c
+++ b/src/func_02068a28.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern void func_020623ec(int a, int b, int c, int d, int e, int f);
 void func_02068a28(int a, int b, int c, int unused, u16 d)
 {

--- a/src/func_02068a54.c
+++ b/src/func_02068a54.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 extern void func_02068a74(void);

--- a/src/func_02068a74.c
+++ b/src/func_02068a74.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *data_020a9db4;
 extern int func_02062200(int x);
 

--- a/src/func_02068ae8.c
+++ b/src/func_02068ae8.c
@@ -1,10 +1,5 @@
+#include "types.h"
 #pragma opt_strength_reduction off
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed char s8;
-
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 prev);
 

--- a/src/func_02068dc8.c
+++ b/src/func_02068dc8.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern char* data_020a9db4;
 extern int func_02068e44(int, int, int);
 

--- a/src/func_02068e4c.c
+++ b/src/func_02068e4c.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern int _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(int state);
 extern void MultiStore_Int(int val, int *dst, int len);

--- a/src/func_020690b0.c
+++ b/src/func_020690b0.c
@@ -1,13 +1,10 @@
+#include "types.h"
 /* func_020690b0 @ 0x020690b0 (arm9, size 0x868)   [mwccarm 1.2/sp2p3, 2004/b56]
  * Wireless (WM) message-dispatch state machine. data_020a9db4 is the work-buffer
  * base; g+0x1f00 is a 16-entry table of 0x180-byte records, each holding a
  * WMBssDesc copy at +0xc0 (so +0xca/+0xcc/+0xce are the BSSID halfwords, +0xf6
  * gameInfoLength and +0xf8 the 0x80-byte gameInfo).
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern char *data_020a9db4;
 extern char *data_020a9db8;
 extern u16 data_020a9db0;

--- a/src/func_02069918.c
+++ b/src/func_02069918.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *data_020a9db4;
 
 #define DISPATCH(a, b) \

--- a/src/func_02069994.c
+++ b/src/func_02069994.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *data_020a9db4;
 extern char *data_020a9db8;
 

--- a/src/func_0206a29c.c
+++ b/src/func_0206a29c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 u16 func_02061960(void);
 
 typedef struct {

--- a/src/func_0206a4a0.c
+++ b/src/func_0206a4a0.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_0206a3a4(int arg0, int *out);
 extern void func_0206a458(int *out);
 extern void func_0206a424(int *out);

--- a/src/func_0206a600.c
+++ b/src/func_0206a600.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 func_0205b988(u32 a, u32 b, u32 c);
 extern void Crash(void);
 

--- a/src/func_0206bc8c.c
+++ b/src/func_0206bc8c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned long long u64;
-
+#include "types.h"
 #define READ8(a) ((((int)(a)) & 1) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 
 #pragma opt_strength_reduction off

--- a/src/func_0206bdb4.c
+++ b/src/func_0206bdb4.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned long long u64;
-
+#include "types.h"
 #define READ8(a) ((((int)(a)) & 1) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 #define READ8u(a) ((((int)(a)) & ((unsigned int)1)) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 #define WRITE8(a, v) \

--- a/src/func_0206c244.c
+++ b/src/func_0206c244.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned long long u64;
-
+#include "types.h"
 #define READ8(a) ((((int)(a)) & 1) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 #define WRITE8(a, v) \
     if (((int)(a)) & 1) \

--- a/src/func_0206c51c.c
+++ b/src/func_0206c51c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned long long u64;
-
+#include "types.h"
 #define READ8(a) ((((int)(a)) & 1) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 #define READ8u(a) ((((int)(a)) & ((unsigned int)1)) ? (((*(u16 *)((a) - 1)) & 0xff00) >> 8) : ((*(u16 *)(a)) & 0xff))
 #define WRITE8(a, v) \

--- a/src/func_0206c90c.c
+++ b/src/func_0206c90c.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 typedef struct { int a, b, c, d; } S;
 int func_0206c90c(S s){
     char* q = (char*)&s + 7;

--- a/src/func_0206ca7c.c
+++ b/src/func_0206ca7c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 struct Ring
 {
     u16 head;

--- a/src/func_0206cb0c.c
+++ b/src/func_0206cb0c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0206cf7c(int arg0);
 
 #pragma optimize_for_size on

--- a/src/func_0206cbc0.c
+++ b/src/func_0206cbc0.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Shared {
     char pad[0x1c];
     char *buf;

--- a/src/func_0206ce90.c
+++ b/src/func_0206ce90.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern void _ZN3IRQ11SetFIQStateEb(s32 state);
 extern void _ZN3IRQ11SetIRQStateEb(s32 state);
 extern void func_02057014(u32 arg);

--- a/src/func_0206cee0.c
+++ b/src/func_0206cee0.c
@@ -1,5 +1,4 @@
-
-typedef unsigned short u16;
+#include "types.h"
 extern int func_0206da18(void);
 extern int func_0206d9cc(void);
 extern void *func_02057158(unsigned int size);

--- a/src/func_0206cf98.c
+++ b/src/func_0206cf98.c
@@ -1,7 +1,7 @@
+#include "types.h"
 #pragma opt_common_subs off
 #pragma opt_loop_invariants off
 #pragma optimize_for_size on
-typedef unsigned int u32;
 #define LM(x) ((int*)(long long)(int)(x))
 #define LM2(x) ((int*)(long long)(unsigned)(x))
 

--- a/src/func_0206d32c.c
+++ b/src/func_0206d32c.c
@@ -1,7 +1,7 @@
+#include "types.h"
 #pragma opt_common_subs off
 #pragma opt_loop_invariants off
 #pragma optimize_for_size on
-typedef unsigned int u32;
 #define LM(x) ((int*)(long long)(int)(x))
 #define EB(t, n) ((struct Arr *)((char *)(t) + ((n) << 4)))
 #define LM2(x) ((int*)(long long)(unsigned)(x))

--- a/src/func_0206d890.c
+++ b/src/func_0206d890.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern u32 _ZN3IRQ11SetIRQStateEb_false(void); /* 0x0206da18 */
 extern u32 _ZN3IRQ11SetFIQStateEb_false(void); /* 0x0206d9cc */
 extern u32 _ZN4CP1517MPUGetDataRegion7Ev(void); /* 0x0206daa4 */

--- a/src/func_0206e184.c
+++ b/src/func_0206e184.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_0206e218(void *buf, int code);
 extern void cstd_strncpy(char *d, const char *s, u32 n);
 

--- a/src/func_0206e28c.c
+++ b/src/func_0206e28c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 int func_0206e28c(const u8* a, const u8* b, u32 n) {
     while (n != 0) {
         u8 ca = *a++;

--- a/src/func_0206e2cc.c
+++ b/src/func_0206e2cc.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 u8 *func_0206e2cc(u8 *p, int c, unsigned int n)
 {
     u8 ch = (u8)c;

--- a/src/func_020706b0.c
+++ b/src/func_020706b0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 char *func_020706b0(char *dst, const char *src) {
     u8 *s = (u8*)src;
     u8 *d = (u8*)dst;

--- a/src/func_02070b98.c
+++ b/src/func_02070b98.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 void func_02070c68(void* x);
 void func_020715e0(void* thiz, int val);
 

--- a/src/func_020715e0.c
+++ b/src/func_020715e0.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_02071698(void *thiz, int val);
 extern void func_02071644(void *thiz, int val);
 

--- a/src/func_02071698.c
+++ b/src/func_02071698.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 int func_02071698(u8* base, int idx)
 {
     u8* p = base + 5 + idx;

--- a/src/func_02071864.c
+++ b/src/func_02071864.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct Obj {
     int w0, w4, w8, wC, w10; /* 0x00 */
     int w14;                 /* 0x14 */

--- a/src/func_02071910.c
+++ b/src/func_02071910.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_02071910 at 0x02071910, size 0x64
  * Matched byte-for-byte with mwccarm 1.2/sp2p3
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned short u16;
-
 #pragma opt_strength_reduction off
 void* func_02071910(char* self)
 {

--- a/src/func_020719ec.c
+++ b/src/func_020719ec.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern unsigned char func_02071988(void);
 
 int func_020719ec(int unused, unsigned char *buf, unsigned int *pcount)

--- a/src/func_02071ccc.c
+++ b/src/func_02071ccc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Src {
     char* f0;
     int f4;

--- a/src/func_02071d3c.c
+++ b/src/func_02071d3c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct S6  { int v[6]; };
 struct S7  { int v[7]; };
 struct S21 { int v[21]; };

--- a/src/func_020729f4.c
+++ b/src/func_020729f4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *func_02071910(void *a, void *b);
 extern void func_02072dac(void *x, void *b);
 /* Unprototyped on purpose: the two call sites pass different argument lists.

--- a/src/func_ov001_020aa420.c
+++ b/src/func_ov001_020aa420.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     unsigned char b0 : 1;
     unsigned char b1 : 1;

--- a/src/func_ov001_020aaa54.cpp
+++ b/src/func_ov001_020aaa54.cpp
@@ -1,9 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 int _ZN6Player15IsCollectingCapEv(void* p);
 int func_ov001_020aa960(int x, void* arg);
 void* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov001_020ab5b0.c
+++ b/src/func_ov001_020ab5b0.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 void func_ov001_020ab5b0(char* r0, int r1, short r2, short r3, short s4, short s5){
   *(int*)(r0+0x14) = r1;
   *(u16*)(r0+4) = r2;

--- a/src/func_ov002_020ae73c.c
+++ b/src/func_ov002_020ae73c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-
+#include "types.h"
 extern s16 Vec3_HorzAngle(const void* v0, const void* v1);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void* v);
 extern unsigned short data_ov002_020ff01c[];

--- a/src/func_ov002_020ae8b8.c
+++ b/src/func_ov002_020ae8b8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 enum { false, true };
 
 extern u16 data_ov002_020ff01c[];

--- a/src/func_ov002_020ae968.c
+++ b/src/func_ov002_020ae968.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 enum { false, true };
 
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(unsigned int id, void* v);

--- a/src/func_ov002_020af2b0.c
+++ b/src/func_ov002_020af2b0.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020af2b0
 // @emits OneUpMushroom_OnTurnIntoEgg
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
@@ -8,9 +9,6 @@
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
-typedef unsigned int u32;
-typedef int Fix12i;
-
 struct Vec { Fix12i x, y, z; };
 struct Vector3_16;
 

--- a/src/func_ov002_020af3a8.c
+++ b/src/func_ov002_020af3a8.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020af3a8
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
@@ -7,10 +8,6 @@
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
 struct Vector3_16;
 
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vector3* v);

--- a/src/func_ov002_020af474.c
+++ b/src/func_ov002_020af474.c
@@ -1,5 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov002_020af474(char* o)

--- a/src/func_ov002_020af838.c
+++ b/src/func_ov002_020af838.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020af838
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
 struct Vector3_16;
 
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vector3* v, struct Vector3_16* rot, int e, int f);

--- a/src/func_ov002_020afa98.c
+++ b/src/func_ov002_020afa98.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020afa98
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vector3 *v);
 extern int func_ov002_020af248(char *c, int n);
 

--- a/src/func_ov002_020afd10.c
+++ b/src/func_ov002_020afd10.c
@@ -1,14 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020afd10
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
-
 extern int func_ov002_020af218(char* c, int n);
 extern int func_ov002_020af248(char* c, int n);
 

--- a/src/func_ov002_020b0a0c.c
+++ b/src/func_ov002_020b0a0c.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* func_ov002_020b0a0c at 0x020b0a0c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
  */
-
-typedef signed char s8;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern void LoadLevel(s8 levelID, u8 entranceID, s8 starID, u32 d, s8 e);
 extern u8 data_0209f2c0[];
 


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 86 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
