### PR TITLE
readable: consolidate 74 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov002_020b2c44.cpp
+++ b/src/func_ov002_020b2c44.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020b2c44
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef short s16;
-typedef int Fix12i;
-
-
 struct Mtx43 { Fix12i a[12]; };
 struct RaycastGround { char buf[0x68 - 0x18]; };
 

--- a/src/func_ov002_020b363c.c
+++ b/src/func_ov002_020b363c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 void func_ov002_020b363c(char *c)
 {
     char *p = *(char**)(c + 0x328);

--- a/src/func_ov002_020b36dc.cpp
+++ b/src/func_ov002_020b36dc.cpp
@@ -1,9 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020b36dc
 // @emits BigBrickBlock_OnKicked
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnKicked - recovered from vtable slot identity */
-typedef unsigned short u16;
 struct State { int pad[2]; int field8; };
 struct Base {
     virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();

--- a/src/func_ov002_020b38a0.c
+++ b/src/func_ov002_020b38a0.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020b38a0
 // @emits BigBrickBlock_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBlockL_c::Kill - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
-
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(char *thiz, s8 *ref, u32 b, const struct Vector3 *v, u32 j);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const struct Vector3 *v, const void *v16, s32 e, s32 f);
 extern void _ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs(char *thiz, const struct Vector3 *v, u32 n, s32 f, short s);

--- a/src/func_ov002_020b4d58.c
+++ b/src/func_ov002_020b4d58.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct { int w[12]; } M48;
 
 extern void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);

--- a/src/func_ov002_020b5c4c.c
+++ b/src/func_ov002_020b5c4c.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020b5c4c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-typedef signed short s16;
-
-
-
 extern void func_020393a4(int *p, int v);
 extern int _Z14ApproachLinearRiii(int *p, int value, int speed);
 extern short data_02082214[];

--- a/src/func_ov002_020b62cc.c
+++ b/src/func_ov002_020b62cc.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020b62cc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-
-
 extern struct Matrix4x3 data_020a0e68;
 extern void InvMat4x3(struct Matrix4x3 *d, struct Matrix4x3 *s);
 extern void MulVec3Mat4x3(struct Vector3 *v, struct Matrix4x3 *m, struct Vector3 *out);

--- a/src/func_ov002_020b6494.c
+++ b/src/func_ov002_020b6494.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
+#include "types.h"
 extern s16 data_02082214[];
 extern u16 DecIfAbove0_Short(u16* p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, int a, int b);

--- a/src/func_ov002_020b6d84.c
+++ b/src/func_ov002_020b6d84.c
@@ -1,10 +1,8 @@
+#include "types.h"
 // @symbol func_ov002_020b6d84
 // @emits daObjLava_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::Behavior - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef int Fix12;
-
 struct Vec3 {
     Fix12 x, y, z;
 };

--- a/src/func_ov002_020b6fcc.cpp
+++ b/src/func_ov002_020b6fcc.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" {
 
 struct V16 { u16 x, y, z; };

--- a/src/func_ov002_020b74d0.c
+++ b/src/func_ov002_020b74d0.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern unsigned short DecIfAbove0_Short(unsigned short *p);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);

--- a/src/func_ov002_020b76ec.c
+++ b/src/func_ov002_020b76ec.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020b76ec
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
-
 extern u8 data_0209f2d8[];
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 a, const struct Vector3 *p);

--- a/src/func_ov002_020b781c.c
+++ b/src/func_ov002_020b781c.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020b781c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed short s16;
-typedef unsigned short u16;
-
-
-
 extern short data_02082214[];
 
 extern void func_ov002_020b6fcc(void *self);

--- a/src/func_ov002_020b7b70.c
+++ b/src/func_ov002_020b7b70.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_0209f2d8;
 
 int func_ov002_020b7b70(char* c)

--- a/src/func_ov002_020b91fc.c
+++ b/src/func_ov002_020b91fc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 struct Vector3_16f;
 struct Callback;
 extern u8 DecIfAbove0_Byte(u8* p);

--- a/src/func_ov002_020b979c.c
+++ b/src/func_ov002_020b979c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void* _ZN5Actor10FindWithIDEj(u32 id);
 extern int _ZN6Player15IsCollectingCapEv(void* p);
 extern void _ZN6Player16InitWingFeathersEb(void* p, int b);

--- a/src/func_ov002_020b993c.c
+++ b/src/func_ov002_020b993c.c
@@ -1,8 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020b993c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef long long s64;
 struct ShadowModel; struct Matrix4x3;
 
 extern int _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(char* self, struct ShadowModel* sm, struct Matrix4x3* m, int fix, int t, u32 f);

--- a/src/func_ov002_020baa2c.c
+++ b/src/func_ov002_020baa2c.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* func_ov002_020baa2c at 0x020baa2c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (overlay ov002).
  */
-
-typedef int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct Vector3;
 extern s32 Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 

--- a/src/func_ov002_020bb42c.c
+++ b/src/func_ov002_020bb42c.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020bb42c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern s16 Vec3_HorzAngle(const struct Vector3* v0, const struct Vector3* v1);
 extern int _ZN6Player7TryGrabER5Actor(char* p, char* a);

--- a/src/func_ov002_020bb520.c
+++ b/src/func_ov002_020bb520.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020bb520
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
 enum { false, true };
 
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov002_020bbac8.c
+++ b/src/func_ov002_020bbac8.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_ov002_020bbac8 — teleport self to linked actor's position (+100fx up),
  * clear two fields, move the link pointer from 0x59c to 0x5a0.
  * No callees.
  */
-
-typedef unsigned int u32;
-
 typedef struct Vec3 {
     int x, y, z;
 } Vec3;

--- a/src/func_ov002_020bbb14.cpp
+++ b/src/func_ov002_020bbb14.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020bbb14
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
-
-
 extern "C" {
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* c);
 extern void WithMeshClsn_UpdateContinuous_Veneer(void* p);

--- a/src/func_ov002_020bcd38.c
+++ b/src/func_ov002_020bcd38.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern s16 ReadUnalignedShort(u8* p);
 extern int AngleDiff(int a, int b);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, int a, int b, int c, u32 d);

--- a/src/func_ov002_020bcdf0.c
+++ b/src/func_ov002_020bcdf0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct {
     unsigned int id;
     int val;

--- a/src/func_ov002_020bd06c.c
+++ b/src/func_ov002_020bd06c.c
@@ -1,14 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020bd06c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-typedef signed char s8;
-
-
-
 typedef struct ActorBase ActorBase;
 
 extern void _ZN9ActorBase18MarkForDestructionEv(void *thiz);

--- a/src/func_ov002_020bd3a0.c
+++ b/src/func_ov002_020bd3a0.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u16 ReadUnalignedUshort(u8* p);
 extern u16 data_0209b274;
 extern u8 data_020a0e40;

--- a/src/func_ov002_020be3b0.c
+++ b/src/func_ov002_020be3b0.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020be3b0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_ModelAnim2.h"
@@ -5,14 +6,6 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern u32 _ZNK6Player14GetBodyModelIDEjb(char* c, u32 a, char b);
 extern void _ZN5Model14SetPolygonModeEi(void* self, int mode);
 extern int func_ov002_020becf4(char* self, int v, int arg2);

--- a/src/func_ov002_020bf224.c
+++ b/src/func_ov002_020bf224.c
@@ -1,13 +1,8 @@
+#include "types.h"
 /* func_ov002_020bf224 — scale b by an s16 factor from a 0x18-stride table
  * indexed by byte data_020a0e40 (fx12 rounded multiply), clamped below by c.
  * No callees; data: data_020a0e40 (u8 index), data_0209f4a0 (s16 table).
  */
-
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef signed short s16;
-typedef long long s64;
-
 struct Entry {
     s16 val;             /* 0x0 */
     char _pad[0x16];

--- a/src/func_ov002_020bf5e0.c
+++ b/src/func_ov002_020bf5e0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     int x, y, z;
 } V3;

--- a/src/func_ov002_020bf90c.c
+++ b/src/func_ov002_020bf90c.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_02022b04(Fix12i x, Fix12i y, Fix12i z);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(Fix12i x, Fix12i y, Fix12i z);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, short a5);

--- a/src/func_ov002_020bfec0.c
+++ b/src/func_ov002_020bfec0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int _ZN6Player7IsStateERNS_5StateE(char* self, void* st);
 extern int _ZN6Player7IsInAirEv(char* self);
 extern int func_ov002_020e3078(char* self, void* s);

--- a/src/func_ov002_020c0364.c
+++ b/src/func_ov002_020c0364.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-
+#include "types.h"
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, void* st);
 extern int AngleDiff(int a, int b);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* thiz, void* st);

--- a/src/func_ov002_020c04e0.c
+++ b/src/func_ov002_020c04e0.c
@@ -1,9 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int Vec3_HorzLen(void *v);
 extern int AngleDiff(int a, int b);
 extern int func_ov002_020c031c(void *c);

--- a/src/func_ov002_020c06fc.c
+++ b/src/func_ov002_020c06fc.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Vec3 { s32 x, y, z; };
 
 #define FX(a, k) ((int)(((long long)(a) * (k) + 0x800) >> 12))

--- a/src/func_ov002_020c0d90.c
+++ b/src/func_ov002_020c0d90.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int Fix12i;
-
+#include "types.h"
 extern u32 func_02022a4c(Fix12i x, Fix12i y, Fix12i z);
 extern u32 func_02022d00(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, void* dir);
 extern int _ZN6Player7IsStateERNS_5StateE(char* self, void* st);

--- a/src/func_ov002_020c19d0.cpp
+++ b/src/func_ov002_020c19d0.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern "C" {
 void _ZN11RaycastLineC1Ev(void* self);
 void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, void* a, void* b, void* act);

--- a/src/func_ov002_020c1ad8.c
+++ b/src/func_ov002_020c1ad8.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* func_ov002_020c1ad8 at 0x020c1ad8 (ov002)
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern int func_ov002_020c0434(char* c);
 extern void func_ov002_020c0364(char* c, unsigned int arg);
 extern int _ZN6Player7IsStateERNS_5StateE(char* self, void* st);

--- a/src/func_ov002_020c1c84.c
+++ b/src/func_ov002_020c1c84.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern int func_ov002_020cf700(void* p);
 extern int func_ov002_020e0478(void* p);
 extern int AngleDiff(int a, int b);

--- a/src/func_ov002_020c200c.c
+++ b/src/func_ov002_020c200c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int func_ov002_020c1e44(void* a, int x);
 extern int _ZN6Player7IsStateERNS_5StateE(void* thiz, void* st);
 extern int _ZN6Player22IsBeingShotOutOfCannonEv(void* thiz);

--- a/src/func_ov002_020c231c.c
+++ b/src/func_ov002_020c231c.c
@@ -1,16 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020c231c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int _ZN6Player7IsStateERNS_5StateE(void *self, void *state);

--- a/src/func_ov002_020c2b08.c
+++ b/src/func_ov002_020c2b08.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 extern void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
 extern int SurfaceInfo_TestFlag0x20(int *p);

--- a/src/func_ov002_020c4188.c
+++ b/src/func_ov002_020c4188.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int* data_0209f318;
 extern int data_0209b454;
 extern short data_ov002_020ff26c[];

--- a/src/func_ov002_020c44c4.c
+++ b/src/func_ov002_020c44c4.c
@@ -1,18 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020c44c4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_SaveData.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
-
 extern u8 data_0209f2d8;
 extern int data_0209caa0[];
 extern s8 data_0209f2f8;

--- a/src/func_ov002_020c5d0c.c
+++ b/src/func_ov002_020c5d0c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_ov002_020c5dec(char *c, int a);
 
 int func_ov002_020c5d0c(char *c)

--- a/src/func_ov002_020c6f3c.cpp
+++ b/src/func_ov002_020c6f3c.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 struct C; typedef void (C::*PMF)();
 extern PMF data_ov002_0211075c[];
 struct Obj { char pad[0x118]; void *f118; };

--- a/src/func_ov002_020c6fe4.c
+++ b/src/func_ov002_020c6fe4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, u32 a, u32 b);
 extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);

--- a/src/func_ov002_020c70ac.c
+++ b/src/func_ov002_020c70ac.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 void func_ov002_020c70ac(char* c) {
     if (*(u16*)(c+0x6a4) != 0) {
         *(int*)(c+0xa8) = 0;

--- a/src/func_ov002_020c75f0.c
+++ b/src/func_ov002_020c75f0.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int Fix12;
-
+#include "types.h"
 extern int _ZN6Player6IsAnimEj(void *c, u32 anim);
 extern int _ZNK6Player14GetBodyModelIDEjb(void *c, u32 id, int b);
 extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);

--- a/src/func_ov002_020c7cbc.c
+++ b/src/func_ov002_020c7cbc.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int Fix12i;
-
+#include "types.h"
 extern u8 data_0209f2fc;
 extern signed char data_02092124;
 extern void LoadKeyModels(int idx);

--- a/src/func_ov002_020c7ff8.c
+++ b/src/func_ov002_020c7ff8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void *data_0209f318;
 extern void func_0200d4b0(void *g, u8 playerID, int x);
 extern void func_0200d508(void *g, u8 playerID);

--- a/src/func_ov002_020c8540.c
+++ b/src/func_ov002_020c8540.c
@@ -1,11 +1,7 @@
+#include "types.h"
 /* func_ov002_020c8540 at 0x020c8540 (ov002)
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
 extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, unsigned int a, int b);
 extern int _ZNK9Animation12WillHitFrameEi(void* thiz, int f);
 extern void func_0201f32c(int arg0);

--- a/src/func_ov002_020c8714.c
+++ b/src/func_ov002_020c8714.c
@@ -1,14 +1,10 @@
+#include "types.h"
 /* func_ov002_020c8714 @ 0x020c8714 (ov002, size 0x268)
  * Player cap-power ending update: while active, ducks the music, damps the
  * forward speed (or launches on variant 1), and streams the sparkle trail;
  * when the anim finishes either spawns the cap-return actor with the level
  * fanfare (mode 0x10) or spawns the star and hands the player to it.
  */
-typedef unsigned short u16;
-typedef signed char s8;
-typedef unsigned char u8;
-typedef long long s64;
-
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(int, int);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(char *, unsigned int, int, int, unsigned int);
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(int, unsigned int, int, int, int, int, int);

--- a/src/func_ov002_020c897c.c
+++ b/src/func_ov002_020c897c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, u32 a, u32 b);
 extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 extern void func_02012694(u32 a, void* v);

--- a/src/func_ov002_020c8b78.cpp
+++ b/src/func_ov002_020c8b78.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020c8b78
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
-
 struct ActorBase {};
 struct Animation { char pad[0x50]; int WillHitFrame(int) const; };
 

--- a/src/func_ov002_020c8d14.c
+++ b/src/func_ov002_020c8d14.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020c8d14
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Animation.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-
-
-
 extern int _ZNK6Player14GetBodyModelIDEjb(void *thiz, unsigned int a, int b);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int x, int y, int z);
 extern void func_ov002_020c9e18(char *self);

--- a/src/func_ov002_020c92fc.c
+++ b/src/func_ov002_020c92fc.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZNK6Player14GetBodyModelIDEjb(char *self, unsigned int a, int b);
 extern int _ZNK9Animation12WillHitFrameEi(void *anim, int f);
 extern int _ZN6Player12FinishedAnimEv(char *self);

--- a/src/func_ov002_020c94a4.c
+++ b/src/func_ov002_020c94a4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern signed char data_0209f2f8;
 extern u8 data_0209211c;
 extern u8 data_0209f200;

--- a/src/func_ov002_020c965c.c
+++ b/src/func_ov002_020c965c.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov002_020c7ff8(void* thiz);
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* thiz, int a, int b, int c, u32 d);
 

--- a/src/func_ov002_020ca940.c
+++ b/src/func_ov002_020ca940.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 enum { false, true };
 
 extern u8 data_0209f2d8;

--- a/src/func_ov002_020caf98.cpp
+++ b/src/func_ov002_020caf98.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Ret { int pad; int y; };
 
 struct Arg {

--- a/src/func_ov002_020cbea8.c
+++ b/src/func_ov002_020cbea8.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern char *_ZN5Actor10FindWithIDEj(u32 id);
 extern int func_ov002_020cc01c(char *c);
 

--- a/src/func_ov002_020cc05c.c
+++ b/src/func_ov002_020cc05c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-typedef long long s64;
+#include "types.h"
 extern u8 data_020a0e40;
 extern s16 data_0209f4a2[];
 void func_ov002_020cc05c(char *self)

--- a/src/func_ov002_020cc660.c
+++ b/src/func_ov002_020cc660.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
+#include "types.h"
 extern s32 ApproachAngle(s16 *target, s16 from, s16 start, s16 speed, s16 max);
 void func_ov002_020cc660(char *self, int angle){
  s16 v,w; int delta; int third;

--- a/src/func_ov002_020cd550.c
+++ b/src/func_ov002_020cd550.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct S18 { short f0; char pad[0x16]; };
 
 extern u8 data_020a0e40;

--- a/src/func_ov002_020ce5f8.c
+++ b/src/func_ov002_020ce5f8.c
@@ -1,12 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020ce5f8
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
-
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* st);
 extern int func_ov002_020ceb54(char* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, const struct Vector3* pos);

--- a/src/func_ov002_020ce8bc.c
+++ b/src/func_ov002_020ce8bc.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef s32 Fix12i;
-
+#include "types.h"
 extern u32 func_02022cbc(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir);
 extern char* data_0209f32c;
 

--- a/src/func_ov002_020ce9c8.c
+++ b/src/func_ov002_020ce9c8.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef int Fix12i;
-
+#include "types.h"
 extern u32 func_02022c80(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir);
 extern u32 func_02022cbc(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir);
 extern u32 func_02022d00(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, void* dir);

--- a/src/func_ov002_020cec2c.c
+++ b/src/func_ov002_020cec2c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020cec2c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
@@ -7,12 +8,6 @@
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed char s8;
-
-
-
 extern void _ZN6Player4HealEi(char *self, int a);
 extern int _ZN6Player9GetHealthEv(char *self);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, const struct Vector3 *v, unsigned int d);

--- a/src/func_ov002_020d0178.c
+++ b/src/func_ov002_020d0178.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 
 extern void _ZN13RaycastGroundC1Ev(void* self);

--- a/src/func_ov002_020d12b0.cpp
+++ b/src/func_ov002_020d12b0.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 struct State;
 extern u8 data_020a0e40;
 extern u8 data_0209f49e[];

--- a/src/func_ov002_020d1f78.c
+++ b/src/func_ov002_020d1f78.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned int u32;
-typedef int Fix12i;
-
+#include "types.h"
 typedef struct { u8 pad[0x18]; } Rec18;
 
 extern u8 data_020a0e40;

--- a/src/func_ov002_020d2e74.cpp
+++ b/src/func_ov002_020d2e74.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020d2e74
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef short s16;
-
-
-
 struct Player {
     char pad8[8];
     int field_8;             /* 0x8 */

--- a/src/func_ov002_020d2f24.c
+++ b/src/func_ov002_020d2f24.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int _ZNK6Player14GetBodyModelIDEjb(void* thiz, u32 a, int b);
 
 void func_ov002_020d2f24(char* thiz)

--- a/src/func_ov002_020d2fdc.c
+++ b/src/func_ov002_020d2fdc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct { u16 flags; char pad[22]; } Entry24;
 
 extern u8 data_020a0e40;


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 74 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
