### PR TITLE
readable: consolidate 85 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov002_020d45c0.c
+++ b/src/func_ov002_020d45c0.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int Player_ScaleByCharFactor(void* c, int a);
 extern void func_02022b04(int x, int y, int z);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int x, int y, int z);

--- a/src/func_ov002_020d5c6c.c
+++ b/src/func_ov002_020d5c6c.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct State;
 extern struct State data_ov002_02110034;
 extern int func_ov002_020d600c(void* p);

--- a/src/func_ov002_020d6790.cpp
+++ b/src/func_ov002_020d6790.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct Obj {
   virtual int v0(); virtual int v1(); virtual int v2(); virtual int v3();
   virtual int v4(); virtual int v5(); virtual int v6(); virtual int v7();

--- a/src/func_ov002_020d6998.cpp
+++ b/src/func_ov002_020d6998.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020d6998
 /* recovered: shared common types */
 #include "common.h"
@@ -24,14 +25,6 @@ struct VObj {
     virtual int V18();
 };
 extern "C" {
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-
-
-
-
 typedef int (*VFunc)(void*);
 
 extern int func_ov002_020bea7c(char* c);

--- a/src/func_ov002_020d71ec.c
+++ b/src/func_ov002_020d71ec.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct P2 { int a, b; };
 
 extern int _ZNK6Player14GetBodyModelIDEjb(void* self, u32 a, int b);

--- a/src/func_ov002_020d8158.c
+++ b/src/func_ov002_020d8158.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct State;
 extern int _ZN6Player7IsStateERNS_5StateE(void* self, struct State* s);
 extern void func_ov002_020d8118(char* c);

--- a/src/func_ov002_020d8a50.c
+++ b/src/func_ov002_020d8a50.c
@@ -1,15 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020d8a50
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
-
 struct RaycastLine { int head[5]; int surf; int rest[25]; };
 
 extern int _ZNK6Player14GetBodyModelIDEjb(char* p, unsigned int j, int b);

--- a/src/func_ov002_020d8d10.c
+++ b/src/func_ov002_020d8d10.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020d8d10
 /* recovered: shared common types */
 #include "common.h"
@@ -5,11 +6,6 @@
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned short u16;
-
 extern s16 data_02082214[];
 struct Callback;
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov002_020d91e0.c
+++ b/src/func_ov002_020d91e0.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov002_020da9d4(void* p);
 extern int _ZN8SaveData16HasPlayerLostCapEv(void);
 extern void _ZN6Player4HealEi(void* thiz, int amt);

--- a/src/func_ov002_020d93ac.cpp
+++ b/src/func_ov002_020d93ac.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020d93ac
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
-
-
 extern "C" {
 int func_ov002_020d93ac(char *self);
 short GetAngleToCamera(int i);

--- a/src/func_ov002_020d94cc.cpp
+++ b/src/func_ov002_020d94cc.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020d94cc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef short s16;
-typedef signed char s8;
-
-
-
 extern "C" {
 int func_ov002_020d94cc(char *self);
 short GetAngleToCamera(int i);

--- a/src/func_ov002_020d99a4.c
+++ b/src/func_ov002_020d99a4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_ov002_02109dcc[];
 extern int data_ov002_0210a6ec[];
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *self, unsigned int a, int b, int c, unsigned int d);

--- a/src/func_ov002_020d9a4c.c
+++ b/src/func_ov002_020d9a4c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZNK6Player14GetBodyModelIDEjb(void *self, unsigned int a, int b);
 extern int _ZNK9Animation12WillHitFrameEi(void *self, int frame);
 

--- a/src/func_ov002_020d9aac.c
+++ b/src/func_ov002_020d9aac.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _Z14ApproachLinearRiii(int* v, int target, int step);
 
 void func_ov002_020d9aac(char* c)

--- a/src/func_ov002_020d9dcc.c
+++ b/src/func_ov002_020d9dcc.c
@@ -1,11 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef long long s64;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 extern int AngleDiff(int a, int b);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 

--- a/src/func_ov002_020db54c.cpp
+++ b/src/func_ov002_020db54c.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020db54c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-
 struct State;
 extern "C" void func_02035860(void *a, struct Vector3 *v);
 extern struct State data_ov002_021101cc;

--- a/src/func_ov002_020db704.c
+++ b/src/func_ov002_020db704.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int _Z14ApproachLinearRiii(int *p, int value, int speed);
 
 extern int data_ov002_020ff230[];

--- a/src/func_ov002_020dd2f4.c
+++ b/src/func_ov002_020dd2f4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-
+#include "types.h"
 extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12i y, Fix12i x);
 extern int AngleDiff(int a, int b);
 extern int func_ov002_020c0cbc(void* c);

--- a/src/func_ov002_020dd5ec.c
+++ b/src/func_ov002_020dd5ec.c
@@ -1,8 +1,4 @@
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef int Fix12;
+#include "types.h"
 extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 anim, int a, Fix12 b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void *c, u32 id, int b);
 extern int RandomIntInternal(int *seed);

--- a/src/func_ov002_020dde74.cpp
+++ b/src/func_ov002_020dde74.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 struct State;
 struct Player;
 extern "C" int _ZN6Player11ChangeStateERNS_5StateE(Player* thiz, State* s);

--- a/src/func_ov002_020de428.c
+++ b/src/func_ov002_020de428.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020de428
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-
 struct Actor {
     char pad74[0x74];
     struct Vector3 vec; /* 0x74 */

--- a/src/func_ov002_020df840.c
+++ b/src/func_ov002_020df840.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020df840
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
-
-
 extern u8 data_020a0e40;
 extern u16 data_0209f49c[];
 

--- a/src/func_ov002_020e17f8.c
+++ b/src/func_ov002_020e17f8.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Player {
     char pad8[8];
     int field_8;

--- a/src/func_ov002_020e2664.c
+++ b/src/func_ov002_020e2664.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 enum { false, true };
 
 extern int func_ov002_020d5c6c(char* c);

--- a/src/func_ov002_020e28d4.c
+++ b/src/func_ov002_020e28d4.c
@@ -1,11 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef long long s64;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef s32 Fix12;
-
+#include "types.h"
 extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
 extern int AngleDiff(int a, int b);
 extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);

--- a/src/func_ov002_020e2c84.c
+++ b/src/func_ov002_020e2c84.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020e2c84
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-
-
 struct Camera;
 
 extern int func_ov002_020e3078(char *self, void *s);

--- a/src/func_ov002_020e4374.c
+++ b/src/func_ov002_020e4374.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 void func_ov002_020e4374(char* c, int* p1, int* p2)
 {
     int v;

--- a/src/func_ov002_020e444c.c
+++ b/src/func_ov002_020e444c.c
@@ -1,17 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020e444c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_ClsnResult.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int Fix12i;
-
-
-
 extern void Matrix4x3_FromTranslation(struct Matrix4x3 *m, int x, int y, int z);
 extern void Vec3_RotateYAndTranslate(int *out, int *in, short angle, int *src);
 extern void Matrix4x3_ApplyInPlaceToRotationY(struct Matrix4x3 *mF, s16 angY);

--- a/src/func_ov002_020e4bb8.c
+++ b/src/func_ov002_020e4bb8.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov002_020be3b0(char* c);
 extern u32 _ZNK6Player14GetBodyModelIDEjb(char* c, u32 a, char b);
 extern void _ZN10ModelAnim24CopyERKS_Pcj(void* self, void* src, char* p, u32 n);

--- a/src/func_ov002_020e5948.c
+++ b/src/func_ov002_020e5948.c
@@ -1,15 +1,8 @@
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 #pragma opt_propagation off
 #pragma opt_loop_invariants off
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef s32 Fix12;
-
 extern void _ZN9Animation8LoadFileER13SharedFilePtr(void* sfp);
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void* sfp);
 extern void _ZN15TextureSequence8LoadFileER13SharedFilePtr(void* sfp);

--- a/src/func_ov002_020e6edc.c
+++ b/src/func_ov002_020e6edc.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020e6edc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-typedef unsigned short u16;
 struct Actor;
 struct BCA_File;
 

--- a/src/func_ov002_020e7554.c
+++ b/src/func_ov002_020e7554.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern char* _ZN5Actor15FindWithActorIDEjPS_(u32 actorID, char* prev);
 extern char* _ZN5Actor10FindWithIDEj(u32 id);
 extern int RandomIntInternal(int* seed);

--- a/src/func_ov002_020e763c.c
+++ b/src/func_ov002_020e763c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef signed char s8;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 
 typedef struct Sub {

--- a/src/func_ov002_020e7e24.c
+++ b/src/func_ov002_020e7e24.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 struct Actor {
     char pad[0x49e];
     unsigned char obj; /* 0x49e */

--- a/src/func_ov002_020e7f2c.c
+++ b/src/func_ov002_020e7f2c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 a, u32 b, s32 x, s32 y, s32 z, void* rot, void* cb);
 

--- a/src/func_ov002_020e7fcc.c
+++ b/src/func_ov002_020e7fcc.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020e7fcc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Animation.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
 struct Callback;
 
 extern int _ZN9Animation8FinishedEv(void* anim);

--- a/src/func_ov002_020e8398.c
+++ b/src/func_ov002_020e8398.c
@@ -1,8 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020e8398
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef long long s64;
 enum { false, true };
 struct ShadowModel;
 struct Matrix4x3;

--- a/src/func_ov002_020e84ec.c
+++ b/src/func_ov002_020e84ec.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020e84ec
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef short s16;
-
-
-
 struct Flags { unsigned short b0 : 1; };
 
 extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);

--- a/src/func_ov002_020e8abc.c
+++ b/src/func_ov002_020e8abc.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
 extern void func_02035860(char *o, void *src);

--- a/src/func_ov002_020e8dd8.c
+++ b/src/func_ov002_020e8dd8.c
@@ -1,5 +1,4 @@
-
-typedef unsigned char u8;
+#include "types.h"
 extern signed char data_0209f2f8;
 extern unsigned char data_0209f264;
 extern void _ZN9PowerStar13AddStarMarkerEv(void);

--- a/src/func_ov002_020e8ef0.cpp
+++ b/src/func_ov002_020e8ef0.cpp
@@ -1,10 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
     void* _ZN5Actor10FindWithIDEj(u32 id);
     void LinkSilverStarAndStarMarker(void* a, void* b);

--- a/src/func_ov002_020e930c.c
+++ b/src/func_ov002_020e930c.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_ov002_020e930c at 0x020e930c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
-typedef unsigned char u8;
-
 extern void* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern int _ZN5Event6GetBitEj(unsigned int bit);
 extern int func_ov002_020e8ef0(void* a, void* b);

--- a/src/func_ov002_020e9840.c
+++ b/src/func_ov002_020e9840.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020e9840
 /* recovered: shared common types */
 #include "common.h"
@@ -5,11 +6,6 @@
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
-
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void func_ov002_020e9590(char *self);
 extern int func_ov002_020e8dd8(unsigned char *self);

--- a/src/func_ov002_020e9af4.c
+++ b/src/func_ov002_020e9af4.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32, int);
 extern int _ZN6Player12GetTalkStateEv(void*);
 extern void _ZN7Message13DisplaySavingEt(u16);

--- a/src/func_ov002_020e9d18.c
+++ b/src/func_ov002_020e9d18.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-typedef signed char s8;
-
+#include "types.h"
 enum { false, true };
 
 typedef struct Vec3 { int x, y, z; } Vec3;

--- a/src/func_ov002_020ea100.cpp
+++ b/src/func_ov002_020ea100.cpp
@@ -1,9 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int func_ov002_020e73ac(char *arg);
 extern int _ZN6Player12Unk_020c9e5cEh(void *thisPtr, int state);
 extern void func_ov002_020e6fbc(char *c, int arg);

--- a/src/func_ov002_020ea410.c
+++ b/src/func_ov002_020ea410.c
@@ -1,5 +1,5 @@
+#include "types.h"
 /* func_ov002_020ea410 @ 0x20ea410 (ov002) -- veneer: ldr r1,[r0,#0x438]; b func_ov002_020e8ef0. */
-typedef unsigned int u32;
 extern void func_ov002_020e8ef0(void*, u32);
 
 void func_ov002_020ea410(void* a) {

--- a/src/func_ov002_020ea420.c
+++ b/src/func_ov002_020ea420.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 struct BF { u16 pad : 7; u16 b7 : 1; u16 b8 : 1; u16 b9 : 1; u16 rest : 6; };
 
 enum { false, true };

--- a/src/func_ov002_020ea9d0.c
+++ b/src/func_ov002_020ea9d0.c
@@ -1,16 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020ea9d0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
-
 struct Vec1 { s32 a; };
 
 extern s32 data_0209b454;

--- a/src/func_ov002_020ec670.c
+++ b/src/func_ov002_020ec670.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct ClsnResult;
 struct Actor;
 extern int func_0203567c(int p);

--- a/src/func_ov002_020ecb0c.c
+++ b/src/func_ov002_020ecb0c.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Vec3 { s32 x, y, z; };
 struct Vec3_16f { s16 x, y, z; };
 struct Spawn { struct Vec3_16f rot; struct Vec3 pos; };

--- a/src/func_ov002_020ecd18.cpp
+++ b/src/func_ov002_020ecd18.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Vec3 { s32 x, y, z; Vec3() {} Vec3(const Vec3 &o) { x = o.x; y = o.y; z = o.z; } };
 
 extern "C" {

--- a/src/func_ov002_020edca4.c
+++ b/src/func_ov002_020edca4.c
@@ -1,11 +1,9 @@
+#include "types.h"
 // @symbol func_ov002_020edca4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 struct Actor;
 
 

--- a/src/func_ov002_020eddc4.c
+++ b/src/func_ov002_020eddc4.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov002_020eddc4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
@@ -7,9 +8,6 @@
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct Actor;
 
 

--- a/src/func_ov002_020ef408.c
+++ b/src/func_ov002_020ef408.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 extern s32 func_ov002_020efebc(void *c);

--- a/src/func_ov002_020effb8.c
+++ b/src/func_ov002_020effb8.c
@@ -1,15 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020effb8
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
-
-
 #define FXMUL(a, b) ((s32)(u32)(((((long long)(a)) * (b)) + 0x800) >> 12))
 #define TERM(v, w) ((FXMUL(v, w) + 8) >> 4)
 

--- a/src/func_ov002_020f12c8.c
+++ b/src/func_ov002_020f12c8.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_ov002_020f12c8
 // @emits daObjBC_Switch_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjBC_Switch_c::Behavior - recovered from vtable slot identity */
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
 extern u8 IsAreaShowing(s32 idx);
 extern s32 _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 a, s32 vol);
 extern void _ZN5Event6SetBitEj(u32 bit);

--- a/src/func_ov002_020f20f4.c
+++ b/src/func_ov002_020f20f4.c
@@ -1,6 +1,4 @@
-
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 struct OamAttr;
 void _ZN3OAM9RenderSubEP7OamAttriiii(struct OamAttr *a, int b, int c, int d, int e);
 int RandomIntInternal(int *seed);

--- a/src/func_ov002_020f2210.c
+++ b/src/func_ov002_020f2210.c
@@ -1,8 +1,6 @@
+#include "types.h"
 #define LP(x) ((void*)(int)(((long long)(int)(x))))
 #define LI(x) ((int)(((long long)(int)(x))))
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
 extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
 

--- a/src/func_ov002_020f23f0.c
+++ b/src/func_ov002_020f23f0.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov002_020f237c(u8* self);
 extern void func_ov002_020f1fcc(u8* self);
 extern void func_ov002_020f2340(u8* self);

--- a/src/func_ov002_020f26e0.c
+++ b/src/func_ov002_020f26e0.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 struct OamAttr;
 
 struct OamEnt {

--- a/src/func_ov002_020f2790.c
+++ b/src/func_ov002_020f2790.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
+#include "types.h"
 struct ParticleCallback;
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 unk, Fix12i x, Fix12i y, Fix12i z, void* rot, struct ParticleCallback* callback);

--- a/src/func_ov002_020f2990.c
+++ b/src/func_ov002_020f2990.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct OamAttr;
 extern int GetOwnerLanguage(void);
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(

--- a/src/func_ov002_020f2a88.c
+++ b/src/func_ov002_020f2a88.c
@@ -1,6 +1,4 @@
-
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 void func_ov002_020f2a88(char *c, int i)
 {
   unsigned long new_var;

--- a/src/func_ov002_020f2f18.c
+++ b/src/func_ov002_020f2f18.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
-
+#include "types.h"
 void func_ov002_020f2f18(char* c, int a, int b)
 {
     int i = 0;

--- a/src/func_ov002_020f2f9c.c
+++ b/src/func_ov002_020f2f9c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZN8SaveData19IsCharacterUnlockedEj(u32 c);
 extern int func_ov002_020f5a94(void);
 

--- a/src/func_ov002_020f3ae8.c
+++ b/src/func_ov002_020f3ae8.c
@@ -1,10 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef long long s64;
+#include "types.h"
 extern s16 data_02082214[];
 struct Ent
 {

--- a/src/func_ov002_020f3d38.c
+++ b/src/func_ov002_020f3d38.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
+#include "types.h"
 void func_ov002_020f3d38(char *c, int i)
 {
     int off = i * 0x4c;

--- a/src/func_ov002_020f4710.c
+++ b/src/func_ov002_020f4710.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern short data_02082214[];
 extern int data_ov002_02100100[];
 extern int data_ov002_02100110[];

--- a/src/func_ov002_020f4d70.c
+++ b/src/func_ov002_020f4d70.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern short data_02082214[];
 extern int data_ov002_021000e0[];
 extern int data_ov002_021000f0[];

--- a/src/func_ov002_020f5990.cpp
+++ b/src/func_ov002_020f5990.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
+#include "types.h"
 struct C;
 typedef void (C::*PMF)(int);
 

--- a/src/func_ov002_020f5cd0.c
+++ b/src/func_ov002_020f5cd0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
+#include "types.h"
 struct E {
     s32 f0;       /* 0x00 */
     s32 f4;       /* 0x04 */

--- a/src/func_ov002_020f5d34.c
+++ b/src/func_ov002_020f5d34.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern int func_ov002_020f5a94(void);
 extern void func_ov002_020f2958(void *c);
 

--- a/src/func_ov002_020f5fe4.c
+++ b/src/func_ov002_020f5fe4.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void SetSubBg0Offset(int a, int b);
 extern void SetSubBg1Offset(int a, int b);
 extern void SetSubBg2Offset(int a, int b);

--- a/src/func_ov002_020f6514.c
+++ b/src/func_ov002_020f6514.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
+#include "types.h"
 struct Ent { void *p0; void *p4; };
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *f, int b, int c, unsigned int d);
 extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void *self, void *f, int b, int c, unsigned int d);

--- a/src/func_ov002_020f6c60.c
+++ b/src/func_ov002_020f6c60.c
@@ -1,9 +1,4 @@
-
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 typedef struct 
 {
   s32 x;

--- a/src/func_ov002_020f72bc.c
+++ b/src/func_ov002_020f72bc.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Callback;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov002_020f897c.c
+++ b/src/func_ov002_020f897c.c
@@ -1,15 +1,7 @@
+#include "types.h"
 // @symbol func_ov002_020f897c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-typedef signed char s8;
-typedef unsigned char u8;
-
-
-
-
 extern void* _ZN5Actor18ClosestWithActorIDEj(void* self, u32 id);
 extern int RandomIntInternal(int* seed);
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);

--- a/src/func_ov002_020f8b24.c
+++ b/src/func_ov002_020f8b24.c
@@ -1,8 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef int Fix12;
-
+#include "types.h"
 typedef struct { s32 x, y, z; } Vec3;
 typedef struct { s32 w[12]; } Mtx43;
 

--- a/src/func_ov002_020feb50.cpp
+++ b/src/func_ov002_020feb50.cpp
@@ -1,15 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov002_020feb50
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern "C" char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern "C" void _ZN5Sound4PlayEjjRK7Vector3(unsigned int a, unsigned int b, Vector3 const & v);
 extern "C" void _ZN5Actor13SmallPoofDustEv(char* self);

--- a/src/func_ov003_020ad814.cpp
+++ b/src/func_ov003_020ad814.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov003_020ad814
 // @emits dScTitle_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -11,12 +12,6 @@
  * data_ov003_020b1180; otherwise moves the cursor by row (+0x35) or column
  * (+1) with repeat delay at +0x50, wrapping the index modulo 0x36.
  */
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 struct VObj {
     virtual void v0();
     virtual void v1();

--- a/src/func_ov003_020ada9c.cpp
+++ b/src/func_ov003_020ada9c.cpp
@@ -1,13 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov003_020ada9c
 // @emits dScTitle_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScTitle_c::InitResources - recovered from vtable slot identity */
 extern "C" {
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern void UnloadArchives(void);
 extern void Enable3dEngines(void);
 extern void func_020233f4(void);

--- a/src/func_ov003_020adcbc.cpp
+++ b/src/func_ov003_020adcbc.cpp
@@ -1,6 +1,6 @@
 //cpp
+#include "types.h"
 extern "C" {
-typedef unsigned short u16;
 short* _ZN2G212GetBG0ScrPtrEv(void);
 void MultiStore16(u16 val, short* dst, int n);
 struct E { volatile signed char* ptr; int pad; };

--- a/src/func_ov003_020b0b3c.c
+++ b/src/func_ov003_020b0b3c.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov003_020b0b3c
 // @emits dScGameOver_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScGameOver_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void _ZN2GX12SetBankForBGEt(u16 v);
 extern void _ZN2GX13SetBankForOBJEt(u16 v);
 extern void _ZN2GX15SetBankForSubBGEt(u16 v);

--- a/src/func_ov004_020ae3b4.c
+++ b/src/func_ov004_020ae3b4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int* func_02054efc(void);
 extern int* func_02054ea8(void);
 extern int* _ZN2G213GetBG2CharPtrEv(void);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 85 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
