### PR TITLE
readable: consolidate 90 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov004_020aeed8.cpp
+++ b/src/func_ov004_020aeed8.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov004_020aeed8
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,10 +8,6 @@
 // @emits dScMgBase_c_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern "C" u8 data_0209d45c;
 extern "C" u8 data_0209d454;
 extern "C" u8 data_0209d460;

--- a/src/func_ov004_020af094.cpp
+++ b/src/func_ov004_020af094.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov004_020af094
 // @emits dScMgBase_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-typedef unsigned short u16;
-typedef short s16;
-
 extern "C" void _ZN4CP1527FlushAndInvalidateDataCacheEjj(void *addr, unsigned int size);
 extern "C" void _ZN2GX10LoadBGPlttEPKvjj(const void *src, unsigned int offset, unsigned int size);
 extern "C" void _ZN3GXS10LoadBGPlttEPKvjj(const void *src, unsigned int offset, unsigned int size);

--- a/src/func_ov004_020af5e0.c
+++ b/src/func_ov004_020af5e0.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Item {
     u32 w0;
     u32 val : 10;

--- a/src/func_ov004_020b0d8c.c
+++ b/src/func_ov004_020b0d8c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed int s32;
-
+#include "types.h"
 extern s32 GetGameLanguage(void);
 extern void Hud_RenderSprite(void *fn, s32 a, s32 b, s32 r3arg, s32 stack_arg);
 extern void **data_ov004_020bbfa8[];

--- a/src/func_ov004_020b1ba0.c
+++ b/src/func_ov004_020b1ba0.c
@@ -1,6 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 void func_ov004_020b1ba0(void *c, s32 delta)
 {
     s32 v = *(s32*)((char*)c + 0xa8) + delta;

--- a/src/func_ov004_020b1e34.c
+++ b/src/func_ov004_020b1e34.c
@@ -1,5 +1,5 @@
+#include "types.h"
 /* func_ov004_020b1e34 @ 0x20b1e34 (ov004) -- veneer: ldr r1,[r0,#0xb4]; b func_ov004_020b0e84. */
-typedef unsigned int u32;
 extern void func_ov004_020b0e84(void*, u32);
 
 void func_ov004_020b1e34(void* a) {

--- a/src/func_ov004_020b265c.c
+++ b/src/func_ov004_020b265c.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-typedef volatile unsigned int vu32;
-typedef volatile unsigned short vu16;
-
+#include "types.h"
 extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
 extern void _ZN3GXS15SetGraphicsModeEi(int a);
 extern void func_ov004_020b2980(void);

--- a/src/func_ov004_020b3194.c
+++ b/src/func_ov004_020b3194.c
@@ -1,5 +1,4 @@
-typedef signed short s16;
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_ov004_020bf3e8[];
 void func_ov004_020b3194(void *c)
 {

--- a/src/func_ov004_020b369c.c
+++ b/src/func_ov004_020b369c.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_ov004_020b369c at 0x020b369c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov004).
  */
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
 extern s16 data_02082214[];
 struct M { int _00, _01, _10, _11; };
 extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, struct M* a5);

--- a/src/func_ov004_020b38ac.c
+++ b/src/func_ov004_020b38ac.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern int func_02053200(int x);
 struct M { int _00, _01, _10, _11; };
 extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, struct M* a5);

--- a/src/func_ov004_020b39a4.c
+++ b/src/func_ov004_020b39a4.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_020731dc(int a, int b, void **node);
 extern void func_0203d704(int* o, int* a, int* b);
 extern void func_0203d388(int *p, int angle);

--- a/src/func_ov004_020b3b38.cpp
+++ b/src/func_ov004_020b3b38.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 struct M { int _00; int _01; int _10; int _11; };
 extern "C" {
 extern int _ZN4cstd4fdivEii(int, int);

--- a/src/func_ov004_020b3cb8.c
+++ b/src/func_ov004_020b3cb8.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern int func_02053200(int x);

--- a/src/func_ov004_020b3e9c.c
+++ b/src/func_ov004_020b3e9c.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern int func_02053200(int x);

--- a/src/func_ov004_020b410c.c
+++ b/src/func_ov004_020b410c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
+#include "types.h"
 extern int func_02053200(int x);
 struct M { int _00, _01, _10, _11; };
 extern void func_ov004_020b1c68(void* a0, int a1, int a2, int a3, int a4, struct M* a5);

--- a/src/func_ov004_020b4360.c
+++ b/src/func_ov004_020b4360.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern int func_02053200(int x);
 struct M { int _00, _01, _10, _11; };

--- a/src/func_ov004_020b45c0.c
+++ b/src/func_ov004_020b45c0.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern int _ZN4cstd4fdivEii(int a, int b);
 extern int func_02053200(int x);
 struct M { int _00, _01, _10, _11; };

--- a/src/func_ov004_020b484c.c
+++ b/src/func_ov004_020b484c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_020731dc(void* a, void* b, void** node);
 extern void func_0203d704(int* o, int* a, int* b);
 extern void func_0203d388(int* p, int angle);

--- a/src/func_ov004_020b53f0.c
+++ b/src/func_ov004_020b53f0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int func_ov004_020b04c0(void);
 extern void func_ov004_020b4b84(char* c, int* in);
 extern void func_ov004_020b5368(void);

--- a/src/func_ov004_020b6430.c
+++ b/src/func_ov004_020b6430.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int GetGameLanguage(void);
 extern void Hud_RenderSprite(void* a0, int a1, int a2, int a3, int a4);
 extern void func_ov004_020b653c(int arg);

--- a/src/func_ov004_020b8c18.c
+++ b/src/func_ov004_020b8c18.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern u16 *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern void func_ov004_020aea78(void *self, int a1, int a2, int a3);
 

--- a/src/func_ov004_020b8f78.cpp
+++ b/src/func_ov004_020b8f78.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-
+#include "types.h"
 struct Sub { virtual void f(); };
 
 extern "C" {

--- a/src/func_ov005_020c06cc.c
+++ b/src/func_ov005_020c06cc.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_0209f5bc[];
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];

--- a/src/func_ov005_020c1130.c
+++ b/src/func_ov005_020c1130.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_0209b304;
 extern int data_0208a170;
 

--- a/src/func_ov005_020c1688.c
+++ b/src/func_ov005_020c1688.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern char* LoadFile(int id);
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 a, u32 b);
 extern void _ZN3GXS10LoadBGPlttEPKvjj(const void* p, u32 a, u32 b);

--- a/src/func_ov005_020c1a20.c
+++ b/src/func_ov005_020c1a20.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov005_020c1a20
 // @emits dScMiniGm_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -5,10 +6,6 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMiniGm_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void _ZN2GX12SetBankForBGEt(u16 v);
 extern void _ZN2GX15SetBankForSubBGEt(u16 v);
 extern void _ZN2GX16SetBankForSubOBJEt(u16 v);

--- a/src/func_ov006_020c2be8.c
+++ b/src/func_ov006_020c2be8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern int func_ov006_020c2994(char* c);
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];

--- a/src/func_ov006_020c6378.c
+++ b/src/func_ov006_020c6378.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern void func_ov006_020c49d8(void* this);
 

--- a/src/func_ov006_020c6a9c.c
+++ b/src/func_ov006_020c6a9c.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov006_020c6a9c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
-
-
 extern void AddVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int _Z15ApproachLinear2Rsss(short *v, short target, short step);
 

--- a/src/func_ov006_020c719c.c
+++ b/src/func_ov006_020c719c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern void func_ov006_020c6f8c(int);
 extern void func_ov006_020c8658(void *c);
 extern void func_ov006_020c8a9c(int a0, int a1);

--- a/src/func_ov006_020c7a30.c
+++ b/src/func_ov006_020c7a30.c
@@ -1,8 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
+#include "types.h"
 extern int _Z15ApproachLinear2Rsss(short *v, short t, short s);
 extern void func_ov006_020c8270(char *c);
 extern void func_ov006_020c85a0(char *c);

--- a/src/func_ov006_020c833c.c
+++ b/src/func_ov006_020c833c.c
@@ -1,13 +1,10 @@
+#include "types.h"
 /* func_ov006_020c833c @ 0x020c833c (ov006, size 0x264)
  * Bob-omb/enemy bounce update: on despawn timer expiry cleans up; plays the
  * bounce SFX on anim frames 12/24 near the camera plane; reflects and damps
  * the x-velocity at +/-0x6c000, restarting the walk anim; handles touch
  * states 1/2; otherwise steers the facing angle toward the motion sign.
  */
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
 extern int data_ov006_0214041c;
 extern char *data_ov006_0213b098[];
 extern int data_ov006_0213b008;

--- a/src/func_ov006_020c87d0.cpp
+++ b/src/func_ov006_020c87d0.cpp
@@ -1,11 +1,10 @@
 //cpp
+#include "types.h"
 /* func_ov006_020c87d0 at 0x020c87d0 (ov006), size 0x16c
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
 typedef struct { int w[2]; } SharedFilePtr;
-typedef unsigned short u16;
-
 extern "C" {
 
 extern SharedFilePtr data_ov006_02140450;

--- a/src/func_ov006_020c91ac.cpp
+++ b/src/func_ov006_020c91ac.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020ca2ec(void *c);
 int _ZNK9Animation12WillHitFrameEi(void *thisPtr, int frame);

--- a/src/func_ov006_020c97bc.cpp
+++ b/src/func_ov006_020c97bc.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020ca2ec(void *c);
 void func_ov006_020bfec0(void *a0, void *a1, short *a2);

--- a/src/func_ov006_020ca070.cpp
+++ b/src/func_ov006_020ca070.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020c9aa0(char *c);
 void func_ov006_020c94e0(char *c);

--- a/src/func_ov006_020cb838.cpp
+++ b/src/func_ov006_020cb838.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020cc618(void *c);
 void func_ov006_020bfec0(void *a0, void *a1, short *a2);

--- a/src/func_ov006_020cbd7c.cpp
+++ b/src/func_ov006_020cbd7c.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020cc618(void *c);
 void func_ov006_020bfec0(void *a0, void *a1, short *a2);

--- a/src/func_ov006_020cc408.cpp
+++ b/src/func_ov006_020cc408.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 void func_ov006_020cbfd8(void *c);
 void func_ov006_020cbaec(void *c);

--- a/src/func_ov006_020cc618.c
+++ b/src/func_ov006_020cc618.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct { u32 a, b; } Pair;
 
 extern Pair data_ov006_0213b1f4;

--- a/src/func_ov006_020cc724.c
+++ b/src/func_ov006_020cc724.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 extern int _ZN9Animation8FinishedEv(void *self);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *file, int i, int fix, u32 j);
 extern int _Z14ApproachLinearRsss(s16 *a, s16 b, s16 c);

--- a/src/func_ov006_020ccae0.c
+++ b/src/func_ov006_020ccae0.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 extern int _ZN9Animation8FinishedEv(void *self);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *file, int i, int fix, u32 j);
 extern int _Z14ApproachLinearRsss(s16 *a, s16 b, s16 c);

--- a/src/func_ov006_020cdc38.c
+++ b/src/func_ov006_020cdc38.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef signed int s32;
-
+#include "types.h"
 void func_ov006_020cdc38(void *arg0)
 {
     *(u16 *)(((long long)(int)((char *)arg0 + 0x9a))) += 0x100;

--- a/src/func_ov006_020cdc8c.c
+++ b/src/func_ov006_020cdc8c.c
@@ -1,7 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-typedef int s32;
-typedef unsigned short u16;
-
 extern int _ZN4cstd4fdivEii(int a, int b);
 
 void func_ov006_020cdc8c(char *self)

--- a/src/func_ov006_020cf820.c
+++ b/src/func_ov006_020cf820.c
@@ -1,8 +1,4 @@
-typedef long long s64;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _Z15ApproachLinear2Riii(int *p, int a, int b);
 extern int _Z14ApproachLinearRiii(int *p, int a, int b);
 extern void func_ov006_020cf124(char *c);

--- a/src/func_ov006_020cfa44.c
+++ b/src/func_ov006_020cfa44.c
@@ -1,7 +1,4 @@
-typedef long long s64;
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 #define LA(p) ((int)(((s64)(int)(p))))

--- a/src/func_ov006_020d14c0.c
+++ b/src/func_ov006_020d14c0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Ctx {
     u8 pad_0000[0x46d8];
     int unk46d8;

--- a/src/func_ov006_020d1a3c.cpp
+++ b/src/func_ov006_020d1a3c.cpp
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-
+#include "types.h"
 struct Obj {
     virtual int m00(); virtual int m01(); virtual int m02(); virtual int m03();
     virtual int m04(); virtual int m05(); virtual int m06(); virtual int m07();

--- a/src/func_ov006_020d48dc.cpp
+++ b/src/func_ov006_020d48dc.cpp
@@ -1,9 +1,7 @@
 //cpp
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct Base {
     virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
     virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();

--- a/src/func_ov006_020d5384.cpp
+++ b/src/func_ov006_020d5384.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020d5384
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgAmida_c.h"
 // @emits dScMgAmida_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgAmida_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
-
 struct Obj {
     virtual void v00();
     virtual void v04();

--- a/src/func_ov006_020d5b10.c
+++ b/src/func_ov006_020d5b10.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int id);
 extern void func_ov006_020d8904(char* p);
 extern void SetBg2Offset(int a, int b);

--- a/src/func_ov006_020d61dc.c
+++ b/src/func_ov006_020d61dc.c
@@ -1,9 +1,6 @@
+#include "types.h"
 /* func_ov006_020d61dc — bump per-slot timer (stride 0x10 array at 0x6280);
  * every 5 ticks reset it and bump level; at level >= 4 set state=2, timer=0x20. */
-
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 typedef struct {
     char _pad0[8];
     u16 timer;   /* +0x08 */

--- a/src/func_ov006_020d6278.cpp
+++ b/src/func_ov006_020d6278.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 class C;
 typedef void (C::*PMF)(int);
 class C { public: int dummy; };

--- a/src/func_ov006_020d64c8.c
+++ b/src/func_ov006_020d64c8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov006_020d5d90(char *o, int i);
 
 #pragma opt_common_subs off

--- a/src/func_ov006_020d65c8.cpp
+++ b/src/func_ov006_020d65c8.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 class C;
 typedef void (C::*PMF)(int);
 class C { public: int dummy; };

--- a/src/func_ov006_020d68a8.c
+++ b/src/func_ov006_020d68a8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_020d6b88.c
+++ b/src/func_ov006_020d6b88.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 void func_02012718(void *a, int b);
 
 void func_ov006_020d6b88(char *this, int idx)

--- a/src/func_ov006_020d6d7c.c
+++ b/src/func_ov006_020d6d7c.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 void func_02012718(void *a, int b);
 
 typedef struct { u8 f0, f1, f2, f3; } Tab;

--- a/src/func_ov006_020d6e8c.c
+++ b/src/func_ov006_020d6e8c.c
@@ -1,8 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef long long s64;
-typedef unsigned long long u64;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 extern s64 _ZN4cstd4sqrtEy(u64 x);

--- a/src/func_ov006_020d795c.c
+++ b/src/func_ov006_020d795c.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_020d7a84.c
+++ b/src/func_ov006_020d7a84.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_020d7f5c.c
+++ b/src/func_ov006_020d7f5c.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 void func_ov006_020d6b88(char *this, int idx);
 void func_ov006_020d6c90(char *this, int idx);
 void func_ov006_020d6e8c(char *this, int idx);

--- a/src/func_ov006_020d836c.cpp
+++ b/src/func_ov006_020d836c.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 struct C;
 typedef void (C::*PMF)(int);
 extern "C" {

--- a/src/func_ov006_020d893c.c
+++ b/src/func_ov006_020d893c.c
@@ -1,10 +1,6 @@
+#include "types.h"
 /* func_ov006_020d893c — zero-init all 0x70 entries (stride 0x40, array at 0x4660):
  * 11 words, 4 halfwords, 10 bytes per entry. */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 typedef struct {
     u32 w0;      /* +0x00 */
     u32 w1;

--- a/src/func_ov006_020d89c4.c
+++ b/src/func_ov006_020d89c4.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_020d836c(char* c);
 extern int func_ov004_020adbc0(void);
 extern void func_ov004_020adb1c(int a);

--- a/src/func_ov006_020d8af8.c
+++ b/src/func_ov006_020d8af8.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_020d836c(char* c);
 extern int func_ov006_020d8c88(char* c);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int i);

--- a/src/func_ov006_020d8d84.c
+++ b/src/func_ov006_020d8d84.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_020d836c(char *c);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int i);
 extern void func_ov006_020d634c(char *c, int i);

--- a/src/func_ov006_020d8f34.c
+++ b/src/func_ov006_020d8f34.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov004_020b0a54(int);
 
 void func_ov006_020d8f34(char *c)

--- a/src/func_ov006_020d9244.c
+++ b/src/func_ov006_020d9244.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020d9244
 // @emits dScMgBomroom_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBomroom_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int LoadFile(int handle);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_ov006_020d978c.cpp
+++ b/src/func_ov006_020d978c.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
 extern int _Z14ApproachLinearRiii(int *a, int b, int c);
 extern int _Z15ApproachLinear2Rsss(s16 *a, s16 b, s16 c);

--- a/src/func_ov006_020da4ac.c
+++ b/src/func_ov006_020da4ac.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 int func_ov006_020da4ac(char *self, s16 *out)
 {
     s16 counts[6] = {0};

--- a/src/func_ov006_020db9dc.c
+++ b/src/func_ov006_020db9dc.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_020db9dc
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,9 +7,6 @@
 // @emits dScMgCard_c_OnYoshiTryEat_020db9dc
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnYoshiTryEat - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-
 extern void func_ov006_020c1604(char *c, int unused, short a2, int a3);
 extern void func_ov004_020b66d4(void);
 extern int data_ov006_0214176c;

--- a/src/func_ov006_020dbaf0.cpp
+++ b/src/func_ov006_020dbaf0.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020dbaf0
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -12,10 +13,6 @@
  * engines, sets blending, patches the OAM attr template list, spawns the two
  * rows of 5 slot sprites, and resets the shared counters.
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 typedef struct Slot6 {
     char b[0x30];
 } Slot6;

--- a/src/func_ov006_020dc5c4.c
+++ b/src/func_ov006_020dc5c4.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern void func_ov006_020dc26c(char *c);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 extern u16 data_ov006_0212e33c[];

--- a/src/func_ov006_020dc900.c
+++ b/src/func_ov006_020dc900.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 void func_ov006_020dc900(char *c)
 {
     int i;

--- a/src/func_ov006_020dca04.c
+++ b/src/func_ov006_020dca04.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 #pragma opt_common_subs off
 #pragma opt_strength_reduction off
 

--- a/src/func_ov006_020dcb1c.c
+++ b/src/func_ov006_020dcb1c.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_020dd000.c
+++ b/src/func_ov006_020dd000.c
@@ -1,5 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
+#include "types.h"
 extern void func_ov006_020dc370(char *c);
 extern void func_ov006_020dc960(char *c, int i);
 extern void func_ov006_020dd4b0(char *c, int i);

--- a/src/func_ov006_020dd658.c
+++ b/src/func_ov006_020dd658.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Pair { int a; int b; };
 
 extern int data_ov006_0212e418[];

--- a/src/func_ov006_020dd880.c
+++ b/src/func_ov006_020dd880.c
@@ -1,6 +1,5 @@
 //cpp
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" int RandomIntInternal(int *seed);
 extern "C" void func_ov006_020ddcf8(char *c, int idx);
 

--- a/src/func_ov006_020dda94.c
+++ b/src/func_ov006_020dda94.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int data_0209d4b8;
 extern int data_ov006_0212e3a0[];
 extern int data_ov006_0212e3b8[];

--- a/src/func_ov006_020dde28.c
+++ b/src/func_ov006_020dde28.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_ov006_020dde28 — bump per-entry timer (stride 0x1c array at 0x4660);
  * when it reaches the table threshold for the current frame index, advance
  * the frame index (mod 4) and reset the timer.
  * Data: data_ov006_0212e32c = u16 threshold table. */
-
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern u16 data_ov006_0212e32c[];
 
 typedef struct {

--- a/src/func_ov006_020de440.cpp
+++ b/src/func_ov006_020de440.cpp
@@ -1,10 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct C;
 typedef void (C::*PMF)(int);
 

--- a/src/func_ov006_020de704.c
+++ b/src/func_ov006_020de704.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020de704
 // @emits dScMgCoin_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int LoadFile(int handle);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_ov006_020df024.c
+++ b/src/func_ov006_020df024.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct { u8 pad; u8 lo:4; u8 hi:4; } Entry094;
 typedef struct { int a, b; } Pair6;
 

--- a/src/func_ov006_020df28c.c
+++ b/src/func_ov006_020df28c.c
@@ -1,5 +1,4 @@
-    typedef unsigned char u8;
-    
+#include "types.h"
     extern void func_ov006_020def80(void *self, int i);
     extern void func_ov006_020c2594(void *c);
     extern void func_ov004_020b1b78(void *c, int val);

--- a/src/func_ov006_020df5b8.c
+++ b/src/func_ov006_020df5b8.c
@@ -1,10 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef short s16;
-typedef unsigned int u32;
-
 extern int func_02012468(int a, int b, int c, int d, int e, int f, int g, short h);
 extern void func_ov006_020deaf0(char* p, int key, int a, int b);
 extern int RandomIntInternal(int* seed);

--- a/src/func_ov006_020e0308.cpp
+++ b/src/func_ov006_020e0308.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020e0308
 // @emits dScMgCup_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -11,9 +12,6 @@
  * the three sliders from the table at data_ov006_0213c0a8, then calls
  * virtual +0x48 with mode 3.
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct VtObj {
     virtual void d0();
     virtual void d1();

--- a/src/func_ov006_020e091c.c
+++ b/src/func_ov006_020e091c.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 void func_ov006_020e091c(char *base, int i)
 {
     int n = i * 0x24;

--- a/src/func_ov006_020e0edc.c
+++ b/src/func_ov006_020e0edc.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov006_020e0edc(char *c, int idx)
 {
     char *b = c;


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 90 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
