### PR TITLE
readable: consolidate 90 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov006_020e1680.c
+++ b/src/func_ov006_020e1680.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef long long s64;
-typedef unsigned long long u64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 
 extern int _ZN4cstd4sqrtEy(u64);

--- a/src/func_ov006_020e1b54.c
+++ b/src/func_ov006_020e1b54.c
@@ -1,7 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern void func_02012718(void *a, int b);
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];

--- a/src/func_ov006_020e2868.c
+++ b/src/func_ov006_020e2868.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern int data_ov006_0212e478[];
 extern int data_ov006_0212e48c[];

--- a/src/func_ov006_020e2c08.c
+++ b/src/func_ov006_020e2c08.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* func_ov006_020e2c08 at 0x020e2c08 (ov006)
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void func_ov006_020e1dc8(char* self, int idx);
 extern int func_020126e8(int a);
 extern void func_020126ac(int a0, int a1, int a2, int a3, int s0);

--- a/src/func_ov006_020e3078.cpp
+++ b/src/func_ov006_020e3078.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 /* func_ov006_020e3078 at 0x020e3078 (ov006)
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct C;
 typedef void (C::*PMF0)();
 typedef void (C::*PMF1)(int);

--- a/src/func_ov006_020e3250.c
+++ b/src/func_ov006_020e3250.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern int data_0209d4b8;
 extern int data_ov006_0212e4dc[];
 

--- a/src/func_ov006_020e3578.c
+++ b/src/func_ov006_020e3578.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020e3578
 // @emits dScMgCurling_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCurling_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern char* func_020adc74(void* p);
 extern void* _ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(const void* src, void* dst);

--- a/src/func_ov006_020e3e4c.c
+++ b/src/func_ov006_020e3e4c.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 void func_ov006_020e3e4c(char *base, int i)
 {
     int n = i * 0x24;

--- a/src/func_ov006_020e440c.c
+++ b/src/func_ov006_020e440c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov006_020e440c(char *c, int idx)
 {
     int n = idx * 0x24;

--- a/src/func_ov006_020e4ed4.c
+++ b/src/func_ov006_020e4ed4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_02012718(void *a, int b);
 
 extern u8 data_020a0e40;

--- a/src/func_ov006_020e5a0c.c
+++ b/src/func_ov006_020e5a0c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern u8 data_020a0dea[];

--- a/src/func_ov006_020e5b7c.c
+++ b/src/func_ov006_020e5b7c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_02012718(int a, int b);

--- a/src/func_ov006_020e5e3c.c
+++ b/src/func_ov006_020e5e3c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov006_020e513c(char *self, int idx);
 extern int func_020126e8(int a);
 extern void func_020126ac(int a0, int a1, int a2, int a3, int s0);

--- a/src/func_ov006_020e6354.cpp
+++ b/src/func_ov006_020e6354.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 struct C;
 typedef void (C::*PMF0)();
 typedef void (C::*PMF1)(int);

--- a/src/func_ov006_020e6528.c
+++ b/src/func_ov006_020e6528.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int RandomIntInternal(int* seed);
 extern void SetBg2Offset(int a, int b);
 extern void SetBg0Offset(int a, int b);

--- a/src/func_ov006_020e6894.c
+++ b/src/func_ov006_020e6894.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020e6894
 // @emits dScMgCurling2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCurling2_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern char* func_020adc74(void* p);
 extern void DecompressLZ16(const void* src, void* dst);
 extern void* LoadFile(int handle);

--- a/src/func_ov006_020e7124.c
+++ b/src/func_ov006_020e7124.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef volatile unsigned int vu32;
-
+#include "types.h"
 extern void func_ov004_020b290c(void);
 extern void func_ov004_020b2980(void);
 extern void _ZN2GX15DisableAllBanksEv(void);

--- a/src/func_ov006_020e72c0.c
+++ b/src/func_ov006_020e72c0.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_020e72c0
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,10 +7,6 @@
 // @emits dScMgTrampoline2_c_Kill
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::Kill - recovered from vtable slot identity */
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
 int func_02053ea0(void);
 s32 GetGameLanguage(void);
 u32 LoadCompressedFileAt(unsigned int fileID, void *target);

--- a/src/func_ov006_020e7428.c
+++ b/src/func_ov006_020e7428.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Oam {
     u32 attr01;
     u16 attr2;

--- a/src/func_ov006_020e7954.c
+++ b/src/func_ov006_020e7954.c
@@ -1,7 +1,5 @@
+#include "types.h"
 #pragma opt_strength_reduction off
-
-typedef unsigned short u16;
-
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *p);
 extern int _ZN9Animation8LoadFileER13SharedFilePtr(void *p);
 extern void _ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File(int bmd, void *bma);

--- a/src/func_ov006_020e8214.c
+++ b/src/func_ov006_020e8214.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern int _ZNK9Animation12WillHitFrameEi(void* anim, int frame);
 
 void func_ov006_020e8214(char* c)

--- a/src/func_ov006_020e8928.c
+++ b/src/func_ov006_020e8928.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 #pragma opt_common_subs off
 
 extern int RandomIntInternal(int *seed);

--- a/src/func_ov006_020e8a44.cpp
+++ b/src/func_ov006_020e8a44.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 class C;
 typedef void (C::*PMF)(int);
 class C { public: int dummy; };

--- a/src/func_ov006_020e8e10.cpp
+++ b/src/func_ov006_020e8e10.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern "C" int func_ov004_020af770(int a0, int a1, int a2, int a3, int a4, int a5, u16 a6);
 
 struct Ent { u16 f0, f2, f4, f6; };

--- a/src/func_ov006_020e8f14.c
+++ b/src/func_ov006_020e8f14.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern s16 data_02082214[];
 extern int data_0209d4b8;

--- a/src/func_ov006_020e91a0.c
+++ b/src/func_ov006_020e91a0.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_020e989c.cpp
+++ b/src/func_ov006_020e989c.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct C70 {
     virtual void v0();
     virtual void v1();

--- a/src/func_ov006_020ea3d0.c
+++ b/src/func_ov006_020ea3d0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void _Z14ApproachLinearRiii(int *p, int target, int step);
 extern void func_ov004_020adb1c(int self);
 extern char *func_020beb68;

--- a/src/func_ov006_020ea71c.c
+++ b/src/func_ov006_020ea71c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct Ent71c {
     int _0;      /* 0x00 */
     int pos;     /* 0x04 */

--- a/src/func_ov006_020eb0c8.cpp
+++ b/src/func_ov006_020eb0c8.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern "C" int _Z15ApproachLinear2Rsss(s16 &v, s16 target, s16 step);
 extern "C" void Math_Function_0203b0fc(int *p, int target, int scale, int max);
 extern "C" void func_ov006_020ec134(void *self);

--- a/src/func_ov006_020ed494.c
+++ b/src/func_ov006_020ed494.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct V2 { int x, y; } V2;
 
 typedef struct Thing

--- a/src/func_ov006_020ed8a4.c
+++ b/src/func_ov006_020ed8a4.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct { int a, b; } Pair;
 
 extern int func_ov006_020ebe6c(void);

--- a/src/func_ov006_020edb04.cpp
+++ b/src/func_ov006_020edb04.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020edb04
 // @emits dScMgHanachan_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgHanachan_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef volatile unsigned int vu32;
-
 extern "C" void *LoadFile(int handle);
 extern "C" void DecompressLZ16(void *src, void *dst);
 extern "C" void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_ov006_020edcb0.c
+++ b/src/func_ov006_020edcb0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int LoadFile(int handle);
 extern int func_02054d88(void);
 extern void DecompressLZ16(int dst, int src);

--- a/src/func_ov006_020ee034.c
+++ b/src/func_ov006_020ee034.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020ee034
 // @emits dScMgJump_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgJump_c::Render - recovered from vtable slot identity */
-typedef unsigned short u16;
-
 typedef struct { int w[12]; } M48;
 typedef struct { int w[3]; } V3;
 

--- a/src/func_ov006_020ee3ec.c
+++ b/src/func_ov006_020ee3ec.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void* func_ov006_020c7300(void* c);
 extern void* func_ov006_020c4060(void* r);
 extern void func_ov004_020b0a54(int a);

--- a/src/func_ov006_020ee690.cpp
+++ b/src/func_ov006_020ee690.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020ee690
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,11 +8,6 @@
 // @emits dScMgJump_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* dScMgJump_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-
 extern "C" {
 extern s32 GetGameLanguage(void);
 extern int LoadFile(int handle);

--- a/src/func_ov006_020ef148.c
+++ b/src/func_ov006_020ef148.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020ef148
 // @emits dScMgJump2_c_Render
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* dScMgJump2_c::Render - recovered from vtable slot identity */
-typedef unsigned short u16;
-
 extern void Matrix4x3_FromTranslation(void* m, int x, int y, int z);
 extern int GetGameLanguage(void);
 extern void DrawOamSprite(void* a0, void* a1, int a2, void* a3);

--- a/src/func_ov006_020ef2b8.c
+++ b/src/func_ov006_020ef2b8.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 void func_0203cd80(int* m, int x);
 void func_0203ccd4(int *m, short angle);
 

--- a/src/func_ov006_020ef794.c
+++ b/src/func_ov006_020ef794.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_ov006_020ef794 at 0x020ef794 (ov006), size 0x64
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef unsigned char u8;
-typedef short s16;
-
 extern void func_ov006_020c7490(void);
 extern void func_ov006_020ef768(char *self);
 extern void func_ov006_020c42bc(void);

--- a/src/func_ov006_020ef834.cpp
+++ b/src/func_ov006_020ef834.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020ef834
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,12 +8,6 @@
 // @emits dScMgJump2_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
 extern "C" {
 extern s32 GetGameLanguage(void);
 extern int LoadFile(int handle);

--- a/src/func_ov006_020efc68.c
+++ b/src/func_ov006_020efc68.c
@@ -1,10 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020efc68
 // @emits dScMgLuigi_c_AfterCleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::AfterCleanupResources - recovered from vtable slot identity */
-typedef unsigned short u16;
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(unsigned int irq, void *handler);
 extern int func_ov004_020b0840(int a, int b);
 int dScMgLuigi_c_AfterCleanupResources(int a, int irq){

--- a/src/func_ov006_020efcf8.c
+++ b/src/func_ov006_020efcf8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern char data_023c0000[];
 extern volatile u16 data_04000006;
 extern int data_0209f608;

--- a/src/func_ov006_020efdac.c
+++ b/src/func_ov006_020efdac.c
@@ -1,10 +1,9 @@
+#include "types.h"
 /* func_ov006_020efdac at 0x020efdac
  *
  * Copies a global index (data_0209f60c -> data_0209f608) and tail-calls
  * MultiCopy_Int to copy the 0x300-byte record at that index to 0x04000040.
  */
-typedef unsigned int u32;
-
 struct Record { char _pad[0x300]; };
 
 extern u32 data_0209f60c;

--- a/src/func_ov006_020efdf0.c
+++ b/src/func_ov006_020efdf0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 
 struct Px {

--- a/src/func_ov006_020f0274.c
+++ b/src/func_ov006_020f0274.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov004_020adb1c(int self);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 extern char *func_020beb68;

--- a/src/func_ov006_020f0eac.c
+++ b/src/func_ov006_020f0eac.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
+#include "types.h"
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int x);
 extern void func_02012790(int x);
 extern void func_ov006_020f1ef8(void *c, int x);

--- a/src/func_ov006_020f10ec.c
+++ b/src/func_ov006_020f10ec.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 #pragma opt_common_subs off
 
 void func_ov006_020f10ec(char *q)

--- a/src/func_ov006_020f13cc.c
+++ b/src/func_ov006_020f13cc.c
@@ -1,10 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 extern int data_ov006_0212e8b8[];

--- a/src/func_ov006_020f192c.c
+++ b/src/func_ov006_020f192c.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern int data_ov006_0212e868[];
 extern s16 data_02082214[];
 

--- a/src/func_ov006_020f1a70.c
+++ b/src/func_ov006_020f1a70.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern int data_ov006_0212e858[];
 extern s16 data_02082214[];
 

--- a/src/func_ov006_020f1b98.c
+++ b/src/func_ov006_020f1b98.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern void func_ov006_020f1dbc(char *self, int idx);
 extern int data_ov006_0212e8d8[];
 extern short data_02082214[];

--- a/src/func_ov006_020f1cb4.c
+++ b/src/func_ov006_020f1cb4.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern int data_ov006_0212e8c8[];
 extern s16 data_02082214[];
 

--- a/src/func_ov006_020f1fcc.c
+++ b/src/func_ov006_020f1fcc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern unsigned char data_020a0e40;
 extern unsigned char data_020a0de8[][4];
 extern unsigned char data_020a0de9[][4];

--- a/src/func_ov006_020f2cb8.c
+++ b/src/func_ov006_020f2cb8.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 int RandomIntInternal(int *seed);
 char *_ZN2G212GetBG3ScrPtrEv(void);
 void MultiStore16(u16 val, char *dst, int nbytes);

--- a/src/func_ov006_020f2ec0.c
+++ b/src/func_ov006_020f2ec0.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef signed char s8;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 struct S20
 {
     s32 a;      /* +0x00 */

--- a/src/func_ov006_020f3460.c
+++ b/src/func_ov006_020f3460.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_020f3460
 // @emits dScMgLuigi_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int func_020adc74(void* p);
 extern void DecompressLZ16(int src, void* dst);
 extern int LoadFile(int handle);

--- a/src/func_ov006_020f4248.c
+++ b/src/func_ov006_020f4248.c
@@ -1,5 +1,4 @@
-
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_020f43c4.c
+++ b/src/func_ov006_020f43c4.c
@@ -1,8 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern s16 data_02082214[];
 extern u16* data_ov006_0213d09c[];

--- a/src/func_ov006_020f456c.c
+++ b/src/func_ov006_020f456c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 typedef struct Car {
     u8 pad00[0x13];
     u8 b13;

--- a/src/func_ov006_020f4b30.c
+++ b/src/func_ov006_020f4b30.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_ov006_020f4b30 — once at least 2 items are ready, mark slot
  * (11 - count) done (stride 0x18 array at 0x51a8), bump count; then per
  * mode: mode 1 -> state 4 at count >= 10, else state 3/4 at count >= 8. */
-
-typedef unsigned char u8;
-
 typedef struct {
     char _pad0[0x13];
     u8 done;     /* +0x13 */

--- a/src/func_ov006_020f4cd8.c
+++ b/src/func_ov006_020f4cd8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int data_0209d4b8;
 int RandomIntInternal(int *seed);
 

--- a/src/func_ov006_020f53e4.cpp
+++ b/src/func_ov006_020f53e4.cpp
@@ -1,14 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020f53e4
 // @emits dScMgMemory_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgMemory_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern "C" {
 void func_ov006_0210a534(void);
 s32 GetGameLanguage(void);

--- a/src/func_ov006_020f5744.c
+++ b/src/func_ov006_020f5744.c
@@ -1,7 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
+#include "types.h"
 extern s16 _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern s16 data_02082214[];
 void func_ov006_020f5744(char *base, int i)

--- a/src/func_ov006_020f5cb4.c
+++ b/src/func_ov006_020f5cb4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 typedef struct Car {
     /* 0x00 */ s32 x;
     /* 0x04 */ u8 unk04[0x12 - 0x04];

--- a/src/func_ov006_020f5f0c.c
+++ b/src/func_ov006_020f5f0c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_020a0e40;
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_020f6088.c
+++ b/src/func_ov006_020f6088.c
@@ -1,8 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern s16 data_02082214[];
 extern u16* data_ov006_0213d338[];

--- a/src/func_ov006_020f6a78.c
+++ b/src/func_ov006_020f6a78.c
@@ -1,11 +1,8 @@
+#include "types.h"
 /* func_ov006_020f6a78 — once at least 3 items are queued, mark slot
  * (total*2 - 1 - count) done (stride 0x18 array at 0x51a8), bump count;
  * when count reaches the per-mode threshold (data_ov006_0212e93c),
  * set state 5 (mode 1) or 4 (otherwise). */
-
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int data_ov006_0212e93c[];
 
 typedef struct {

--- a/src/func_ov006_020f6c90.c
+++ b/src/func_ov006_020f6c90.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern void func_ov006_020f6f88(char *obj);
 extern int data_0209d4b8;

--- a/src/func_ov006_020f74b4.cpp
+++ b/src/func_ov006_020f74b4.cpp
@@ -1,14 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_020f74b4
 // @emits dScMgMemory2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgMemory2_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern "C" {
 void func_ov006_0210a534(void);
 s32 GetGameLanguage(void);

--- a/src/func_ov006_020f8154.c
+++ b/src/func_ov006_020f8154.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void *data_ov006_0213d564;
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];

--- a/src/func_ov006_020f8a3c.c
+++ b/src/func_ov006_020f8a3c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_020f8a3c
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,9 +7,6 @@
 // @emits dScMgMCarlo_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo_c::OnTurnIntoEgg - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned char u8;
-
 extern void FreeGfxSlotsById(int arg);
 extern int func_ov006_020c1718(void* p);
 extern void func_ov004_020b56c8(char* p);

--- a/src/func_ov006_020f9000.cpp
+++ b/src/func_ov006_020f9000.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Node {
     virtual void m0();
     virtual void m1(s16 i);

--- a/src/func_ov006_020f9760.c
+++ b/src/func_ov006_020f9760.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Node {
     void* vt;
     struct Node* prev;

--- a/src/func_ov006_020f9bec.c
+++ b/src/func_ov006_020f9bec.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void *data_ov006_0213d6fc;
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];

--- a/src/func_ov006_020fa844.c
+++ b/src/func_ov006_020fa844.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef int s32;
-
+#include "types.h"
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern s32 data_ov006_0212eb44[];

--- a/src/func_ov006_020fae90.c
+++ b/src/func_ov006_020fae90.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int data_ov006_0212eb70[];
 
 void func_ov006_020fae90(u8 *c)

--- a/src/func_ov006_020faf6c.c
+++ b/src/func_ov006_020faf6c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #pragma opt_common_subs off
 
 extern int _ZN4cstd4sqrtEy(unsigned long long val);

--- a/src/func_ov006_020fbcb8.c
+++ b/src/func_ov006_020fbcb8.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 u32 _ZN3G2S13GetBG2CharPtrEv(void);
 
 #pragma opt_loop_invariants off

--- a/src/func_ov006_020fbd38.c
+++ b/src/func_ov006_020fbd38.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *_ZN3G2S13GetBG2CharPtrEv(void);
 extern void MultiStore16(unsigned short val, char *dst, int nbytes);
 extern void func_ov006_020fbcb8(void *self, int x, int y, int k);

--- a/src/func_ov006_020fc1f8.c
+++ b/src/func_ov006_020fc1f8.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_ov006_0212eb3c[];
 extern u8 data_ov006_0212eb34[];
 

--- a/src/func_ov006_020fc2ec.c
+++ b/src/func_ov006_020fc2ec.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_ov006_0212eb10[];
 extern u8 data_ov006_0212eb1c[];
 extern s32 data_ov006_0212eb60[];

--- a/src/func_ov006_020fc500.c
+++ b/src/func_ov006_020fc500.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern unsigned char data_ov006_0212eb0c[];
 extern unsigned char data_ov006_0212eb14[];
 extern int data_ov006_0212eb50[];

--- a/src/func_ov006_020fca1c.c
+++ b/src/func_ov006_020fca1c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #pragma opt_common_subs off
 
 extern void func_ov006_020fb8fc(char *c, int a2, int a3, int a4, int a5, int a6);

--- a/src/func_ov006_020fd088.c
+++ b/src/func_ov006_020fd088.c
@@ -1,5 +1,4 @@
-
-typedef unsigned short u16;
+#include "types.h"
 extern void func_ov006_020fdaf0(char *, int);
 extern void func_ov006_020fca1c(char *, int);
 extern void func_ov006_020fc9b0(char *, int);

--- a/src/func_ov006_020fe90c.c
+++ b/src/func_ov006_020fe90c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov006_020fe90c(char* base, int i)

--- a/src/func_ov006_020fee24.c
+++ b/src/func_ov006_020fee24.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 extern void FreeGfxSlotsById(int arg);
 extern void func_ov006_020feba8(void *c);
 extern void func_ov006_020fc844(u8 *c);

--- a/src/func_ov006_020ff4ec.c
+++ b/src/func_ov006_020ff4ec.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_ov006_020ff4ec at 0x020ff4ec
  *
  * Resets two 0x20-byte slot entries: flag=1, id=0xff, two counters=0.
  */
-typedef unsigned char u8;
-
 struct Slot {
     u8 active;   /* +0x00 (this+0x563b) */
     u8 count;    /* +0x01 */

--- a/src/func_ov006_021001ac.c
+++ b/src/func_ov006_021001ac.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov006_021001ac(char* p)
 {
     int i;

--- a/src/func_ov006_02100380.c
+++ b/src/func_ov006_02100380.c
@@ -1,9 +1,6 @@
+#include "types.h"
 /* func_ov006_02100380 — for each of 16 active entries (stride 0x18 array at
  * 0x5330): every 8 ticks bump a stage byte; after 4 stages clear the entry. */
-
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 typedef struct {
     char _pad0[0x5330];
     u16 timer;   /* +0x5330 */


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 90 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
