### PR TITLE
readable: consolidate 90 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov006_02100554.c
+++ b/src/func_ov006_02100554.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* func_ov006_02100554 at 0x02100554
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
  */
-typedef unsigned char u8;
-
 extern int func_ov004_020adbe0(void);
 extern void func_ov006_021004f4(void *c, int a);
 extern void func_ov006_021006f4(void *c);

--- a/src/func_ov006_021009b8.c
+++ b/src/func_ov006_021009b8.c
@@ -1,7 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int data_ov006_0212ec80[];
 
 void func_ov006_021009b8(char *p, int i)

--- a/src/func_ov006_02100bac.c
+++ b/src/func_ov006_02100bac.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int y, int x);
 extern void func_ov006_020ff4ec(char* self);
 extern s16 data_02082214[];

--- a/src/func_ov006_02100e3c.c
+++ b/src/func_ov006_02100e3c.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef signed int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Sub {
     /* 0x00 */ s32 unk00;
     /* 0x04 */ s32 unk04;

--- a/src/func_ov006_021012cc.c
+++ b/src/func_ov006_021012cc.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int Sound_PlayIfNotActive(int a, int b, int c, int d);
 extern int data_ov006_0212ec30[];
 

--- a/src/func_ov006_021016ec.c
+++ b/src/func_ov006_021016ec.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int Sound_PlayIfNotActive(int a, int b, int c, int d);
 
 void func_ov006_021016ec(char* p, int i)

--- a/src/func_ov006_02101af0.c
+++ b/src/func_ov006_02101af0.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int Sound_PlayIfNotActive(int a, int b, int c, int d);
 
 void func_ov006_02101af0(char* p, int i)

--- a/src/func_ov006_02101e88.c
+++ b/src/func_ov006_02101e88.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern int RandomIntInternal(int* seed);
 extern int Sound_PlayIfNotActive(int a, int b, int c, int d);
 extern int* data_ov006_0213db84[];

--- a/src/func_ov006_021020c4.c
+++ b/src/func_ov006_021020c4.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern void func_ov006_02101e88(char* p, int i);
 extern int* data_ov006_0213db6c[];
 

--- a/src/func_ov006_0210246c.cpp
+++ b/src/func_ov006_0210246c.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 class C;
 typedef void (C::*PMF)(int);
 class C { public: int dummy; };

--- a/src/func_ov006_021027e4.c
+++ b/src/func_ov006_021027e4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 u32 _ZN3G2S13GetBG2CharPtrEv(void);
 
 #pragma opt_loop_invariants off

--- a/src/func_ov006_02102c3c.c
+++ b/src/func_ov006_02102c3c.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_02102d6c.c
+++ b/src/func_ov006_02102d6c.c
@@ -1,13 +1,10 @@
+#include "types.h"
 /* func_ov006_02102d6c at 0x02102d6c
  *
  * Resets entry i of a 0x40-stride array at this+0x4660: reverses and
  * quarters its velocity, clears counters, and tail-calls func_02012718
  * (sound: id 0x19c) with the entry's handle.
  */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct Entry {
     u32 handle;    /* +0x00 (this+0x4660) */
     int a;         /* +0x04 = 0xa8000 */

--- a/src/func_ov006_02102f3c.c
+++ b/src/func_ov006_02102f3c.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_02103608.c
+++ b/src/func_ov006_02103608.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 

--- a/src/func_ov006_0210371c.c
+++ b/src/func_ov006_0210371c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 

--- a/src/func_ov006_02103d78.c
+++ b/src/func_ov006_02103d78.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 extern void func_ov006_02100084(void *c);
 extern void func_ov006_021024e0(void *c);
 extern void func_ov006_020fffec(void *c);

--- a/src/func_ov006_02103ed0.c
+++ b/src/func_ov006_02103ed0.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_02103ed0
 // @emits dScMgPachinko2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko2_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int LoadFile(int handle);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_ov006_02104354.c
+++ b/src/func_ov006_02104354.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #pragma opt_common_subs off
 
 void func_ov006_02104354(char *q)

--- a/src/func_ov006_0210446c.c
+++ b/src/func_ov006_0210446c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 

--- a/src/func_ov006_02104580.c
+++ b/src/func_ov006_02104580.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 extern void func_ov006_0210446c(char *o, int x, int y, int mode);

--- a/src/func_ov006_02104c60.cpp
+++ b/src/func_ov006_02104c60.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned char u8;
+#include "types.h"
 struct C;
 typedef void (C::*PMF)();
 extern "C" {

--- a/src/func_ov006_021051dc.c
+++ b/src/func_ov006_021051dc.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov006_02104cfc(char *c, int i);
 
 void func_ov006_021051dc(char *c)

--- a/src/func_ov006_02105730.c
+++ b/src/func_ov006_02105730.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 typedef struct WarpEntry {
     u8 a;
     u8 b;

--- a/src/func_ov006_02105854.c
+++ b/src/func_ov006_02105854.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov006_02104eb8(char *p);
 extern void func_ov006_02104e70(unsigned char *p);
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);

--- a/src/func_ov006_02105de4.c
+++ b/src/func_ov006_02105de4.c
@@ -1,11 +1,9 @@
+#include "types.h"
 /* func_ov006_02105de4 @ 0x02105de4 (ov006, size 0x264)
  * Touch-grid minigame: find the cursor slot whose fixed-point position is
  * within 16px of the level's target cell, mark it captured, flip a 2x2/3x3
  * quad of grid cells around it and start their flash timers.
  */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 typedef struct Obj {
     char _p0[0x4cb8];
     int count;                       /* 0x4cb8 */

--- a/src/func_ov006_021063a0.cpp
+++ b/src/func_ov006_021063a0.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 #define RND ((((u32)RandomIntInternal(&data_0209d4b8)) >> 16) & 0x7fff)
 

--- a/src/func_ov006_021073b0.c
+++ b/src/func_ov006_021073b0.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_021073b0
 // @emits dScMgPanel_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPanel_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int LoadFile(int handle);
 extern void DecompressLZ16(int src, void *dst);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);

--- a/src/func_ov006_021082fc.c
+++ b/src/func_ov006_021082fc.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 struct M48 { int w[12]; };
 struct Vec3 { int x, y, z; };
 

--- a/src/func_ov006_02108e24.c
+++ b/src/func_ov006_02108e24.c
@@ -1,6 +1,4 @@
-
-typedef short s16;
-typedef unsigned char u8;
+#include "types.h"
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int);
 extern int data_ov006_021428c8;
 extern u8 data_020a0e40;

--- a/src/func_ov006_02108f2c.c
+++ b/src/func_ov006_02108f2c.c
@@ -1,8 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
+#include "types.h"
 enum { false = 0, true = 1 };
 
 typedef struct Thing {

--- a/src/func_ov006_021096c8.c
+++ b/src/func_ov006_021096c8.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_021096c8
 // @emits dScMgRoulette_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgRoulette_c::OnTurnIntoEgg - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-
 extern void FreeGfxSlotsById(int a);
 extern int func_ov006_020c1718(char *c);
 extern void func_ov004_020b56c8(void);

--- a/src/func_ov006_02109834.c
+++ b/src/func_ov006_02109834.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_02109834
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -11,10 +12,6 @@
  * countdown beep (volume ramps over the last 3 seconds), shows the winner
  * banner with per-rank colors, and refreshes the board.
  */
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-
 typedef struct Racer {
     char b[0x34];
 } Racer;

--- a/src/func_ov006_0210a194.cpp
+++ b/src/func_ov006_0210a194.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_0210a194
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -12,9 +13,6 @@
  * BG tiles/maps/palette and the shared OBJ tiles/palettes for both engines,
  * then initializes the board, cursor and slider objects.
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct VtObj {
     virtual void d0();
     virtual void d1();

--- a/src/func_ov006_0210a534.cpp
+++ b/src/func_ov006_0210a534.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern "C" {
 int LoadFile(int handle);
 void DecompressLZ16(int src, void* dst);

--- a/src/func_ov006_0210a708.c
+++ b/src/func_ov006_0210a708.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef signed int s32;
-typedef volatile unsigned int vu32;
-
+#include "types.h"
 extern void func_ov004_020b290c(void);
 extern void func_ov004_020b2980(void);
 extern void _ZN2GX12SetBankForBGEt(u16 a);

--- a/src/func_ov006_0210af64.c
+++ b/src/func_ov006_0210af64.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_0210b314.c
+++ b/src/func_ov006_0210b314.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_0210b314
 // @emits dScMgSlot3_c_OnYoshiTryEat_0210b314
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::OnYoshiTryEat - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern int RandomIntInternal(int *seed);
 extern int data_0209e650;
 extern void func_02012790(unsigned int id);

--- a/src/func_ov006_0210b648.c
+++ b/src/func_ov006_0210b648.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_0210b648
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,9 +7,6 @@
 // @emits dScMgSlot3_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::Render - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int b, void *attr, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9);
 extern void Hud_RenderSprite(void *a0, int a1, int a2, int a3, int a4);
 extern void func_ov004_020b1bc8(char *a0, int a1, int a2, int a3);

--- a/src/func_ov006_0210bdb0.cpp
+++ b/src/func_ov006_0210bdb0.cpp
@@ -1,14 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_0210bdb0
 // @emits dScMgSlot3_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" {
 
 extern u32 LoadCompressedFileAt(u16 fileID, void *target);

--- a/src/func_ov006_0210c500.c
+++ b/src/func_ov006_0210c500.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct T {
     u8 pad[0x46c0];
     u8 grid[3][0x15];

--- a/src/func_ov006_0210d1fc.cpp
+++ b/src/func_ov006_0210d1fc.cpp
@@ -1,14 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_0210d1fc
 // @emits dScMgSlot1_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot1_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" {
 
 extern u32 LoadCompressedFileAt(int fileID, void *target);

--- a/src/func_ov006_0210e014.c
+++ b/src/func_ov006_0210e014.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // Latches +0x8/+0xc into +0x10/+0x14, then unless byte +0x44 == 1 or +0x40 <= 0
 // eases the s16 angle at +0x32 toward 0x3000 by 0x200 steps (clamped), and tail
 // calls func_ov006_0210d93c.
-typedef short s16;
-typedef unsigned char u8;
-
 typedef struct Obj {
     char _pad0[8];     // 0x00
     int x8;            // 0x08

--- a/src/func_ov006_0210e4f4.c
+++ b/src/func_ov006_0210e4f4.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int GetOwnerLanguage(void);
 extern void func_ov004_020afdd0(void *a0, int a1, int a2, int a3, int a4);
 extern void RenderOamBothScreens(void *a0, int a1, int a2, int a3, int a4, void *a5);

--- a/src/func_ov006_0210eca4.c
+++ b/src/func_ov006_0210eca4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *_ZN3G2S12GetBG3ScrPtrEv(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 

--- a/src/func_ov006_0210ef48.c
+++ b/src/func_ov006_0210ef48.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct {
     int f0;          /* 0x00 */
     void* f4;        /* 0x04 */

--- a/src/func_ov006_0210f914.c
+++ b/src/func_ov006_0210f914.c
@@ -1,8 +1,7 @@
+#include "types.h"
 // Reset: forwards self to func_ov006_02114738, fills data_ov006_02142c1c with
 // 0..8, calls func_ov006_0210f998, then zeroes the per-slot state arrays
 // (+0x31/+0x3c/+0x60 x9, +0x6c/+0x8c x8) and +0x94/+0x98.
-typedef unsigned char u8;
-
 typedef struct Obj {
     char _pad0[0x31]; // 0x00
     u8 byteA[9];      // 0x31

--- a/src/func_ov006_0210fb58.c
+++ b/src/func_ov006_0210fb58.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 extern void _ZN5Sound12PlayBank2_2DEj(unsigned int id);

--- a/src/func_ov006_0211134c.c
+++ b/src/func_ov006_0211134c.c
@@ -1,6 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-typedef unsigned char u8;
-
 typedef struct Obj {
     char _0[4];
     char *p;

--- a/src/func_ov006_021116f0.c
+++ b/src/func_ov006_021116f0.c
@@ -1,6 +1,4 @@
-typedef int s32;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_02114ec0(void *self);
 
 void func_ov006_021116f0(void *arg0)

--- a/src/func_ov006_02112ad8.c
+++ b/src/func_ov006_02112ad8.c
@@ -1,11 +1,5 @@
+#include "types.h"
 /* The equal-arm owner selection below preserves mwccarm's address rematerialization. */
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-typedef unsigned long long u64;
-
 typedef struct V2 {
     int x;
     int z;

--- a/src/func_ov006_02113f1c.c
+++ b/src/func_ov006_02113f1c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct V2 {
     int x;
     int z;

--- a/src/func_ov006_02114458.c
+++ b/src/func_ov006_02114458.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_02114738(char *o);
 
 void func_ov006_02114458(char *o)

--- a/src/func_ov006_021156f8.c
+++ b/src/func_ov006_021156f8.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_ov006_02111df4(char *o);
 extern int func_ov006_0210e4c8(char *o);
 extern int func_ov006_0210d898(char *o);

--- a/src/func_ov006_02115830.c
+++ b/src/func_ov006_02115830.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct { int x, y; } V2;
 
 extern void func_ov006_021146cc(int *a, int *b);

--- a/src/func_ov006_02115b0c.c
+++ b/src/func_ov006_02115b0c.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // MATCHING (abverify MATCH, mwccarm 1.2/sp2p3, canonical flags)
 /* func_ov006_02115b0c at 0x02115b0c (ov006), size 0x18bc (6,332 bytes, 1583 insns)
  * Compiler mwccarm 1.2/sp2p3, flags:
@@ -47,10 +48,6 @@
  *    un-strength-reduced; does not break the div/mod-by-32 shift idioms.
  */
 #pragma opt_strength_reduction off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 typedef struct V2 { int x, y; } V2;
 
 extern void func_ov004_020adb1c(int a);

--- a/src/func_ov006_02118a8c.cpp
+++ b/src/func_ov006_02118a8c.cpp
@@ -1,9 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_02118a8c
 // @emits dScMgSmartball_c_OnYoshiTryEat_02118a8c
 /* recovered: renamed to Class_Method */
 /* dScMgSmartball_c::OnYoshiTryEat - recovered from vtable slot identity */
-typedef unsigned short u16;
 extern "C" {
 void func_ov006_02115b0c(void);
 void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void* p, u16 a, u16 b, u16 c, u16 d);

--- a/src/func_ov006_02119b00.c
+++ b/src/func_ov006_02119b00.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u16 data_ov006_0212ee28[];
 
 void func_ov006_02119b00(char *o)

--- a/src/func_ov006_0211a9fc.c
+++ b/src/func_ov006_0211a9fc.c
@@ -1,12 +1,9 @@
+#include "types.h"
 /* func_ov006_0211a9fc at 0x0211a9fc
  *
  * Activates entry i of a 0x24-stride array at this+0x51b8: sets flags,
  * clears counters, and loads its duration from data_ov006_0212ee70[type].
  */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct Entry {
     u32 value;     /* +0x00 (this+0x51b8) */
     u32 counter;   /* +0x04 */

--- a/src/func_ov006_0211b654.c
+++ b/src/func_ov006_0211b654.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u8 data_ov006_0212ee30[];
 
 struct Slot {

--- a/src/func_ov006_0211b790.c
+++ b/src/func_ov006_0211b790.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 void func_ov006_0211b790(char* base)
 {
     if (*(u8*)(base + 0x5626) == 0) {

--- a/src/func_ov006_0211bf44.c
+++ b/src/func_ov006_0211bf44.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern u8 data_020a0e40[];
 extern u8 data_020a0de8[];
 extern u8 data_020a0de9[];

--- a/src/func_ov006_0211c080.c
+++ b/src/func_ov006_0211c080.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int RandomIntInternal(int *seed);
 extern int data_0209d4b8;
 extern u8 data_ov006_0212ee10[];

--- a/src/func_ov006_0211c720.c
+++ b/src/func_ov006_0211c720.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_0211c720
 // @emits dScMgSound_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -9,10 +10,6 @@
  * 0=init, 1=intro countdown (+0x5618), 2=result countdown (+0x5616) with
  * win/lose handling and 9999-capped win counter, 3=retry countdown.
  */
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-
 extern char *data_ov004_020beb68;
 
 extern void FreeGfxSlotsById(int);

--- a/src/func_ov006_0211c984.c
+++ b/src/func_ov006_0211c984.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_0211c984
 // @emits dScMgSound_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSound_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern int LoadFile(int handle);
 extern void _ZN2GX11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern unsigned _ZN3G2S13GetBG2CharPtrEv(void);

--- a/src/func_ov006_0211cd24.c
+++ b/src/func_ov006_0211cd24.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #define E_W0  (*(int*)((char*)self + 0x4bd0 + off))
 #define E_W8  (*(int*)((char*)self + 0x4bd8 + off))
 #define E_HC  (*(unsigned short*)((char*)self + 0x4bdc + off))

--- a/src/func_ov006_0211d018.c
+++ b/src/func_ov006_0211d018.c
@@ -1,8 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned char u8;
+#include "types.h"
 void func_ov006_0211d018(char *base, int idx)
 {
   int off = idx * 0x1c;

--- a/src/func_ov006_0211d0f8.c
+++ b/src/func_ov006_0211d0f8.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 #define CNT16(b,i) (*(u16*)((b) + 0x4bdc + (i)*0x1c))
 #define CNT8(b,i)  (*(u8 *)((b) + 0x4be3 + (i)*0x1c))
 #define VEL(b,i)   (*(int*)((b) + 0x4bd4 + (i)*0x1c))

--- a/src/func_ov006_0211d224.c
+++ b/src/func_ov006_0211d224.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 void func_ov006_0211d224(char* c, int i) {
     int b = i * 0x1c;
     int t;

--- a/src/func_ov006_0211d924.c
+++ b/src/func_ov006_0211d924.c
@@ -1,8 +1,5 @@
+#include "types.h"
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
 void func_ov006_0211d924(char* p, int i)

--- a/src/func_ov006_0211e5cc.c
+++ b/src/func_ov006_0211e5cc.c
@@ -1,9 +1,7 @@
+#include "types.h"
 /* func_ov006_0211e5cc — once no entry (stride 0x24, 16 of them) is active
  * with stage <= 2, trigger FreeGfxSlotsById(0xc) and bump the one-shot
  * latch byte at 0x4c20 (skipped while the latch is set). */
-
-typedef unsigned char u8;
-
 extern void FreeGfxSlotsById(int arg);
 
 typedef struct {

--- a/src/func_ov006_0211e8a8.c
+++ b/src/func_ov006_0211e8a8.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 extern int data_ov006_0212efec[];
 
 extern int* _ZN3G2S13GetBG0CharPtrEv(void);

--- a/src/func_ov006_0211ee34.c
+++ b/src/func_ov006_0211ee34.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov006_0211f454(char *c, int i);
 extern void func_ov006_0211f34c(char *c, int i);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *reg,

--- a/src/func_ov006_0211f34c.c
+++ b/src/func_ov006_0211f34c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov006_0211f34c(char *o, int i)
 {
     int m = i * 0x24;

--- a/src/func_ov006_0211fb1c.c
+++ b/src/func_ov006_0211fb1c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 extern u8 data_020a0e40;

--- a/src/func_ov006_0211fe78.c
+++ b/src/func_ov006_0211fe78.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov006_0211d5a8(char *c);
 extern void func_ov006_0211f9fc(char *c);
 extern void func_ov006_0211e0c8(char *c);

--- a/src/func_ov006_021203fc.c
+++ b/src/func_ov006_021203fc.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_021203fc
 // @emits dScMgTeresa_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::InitResources - recovered from vtable slot identity */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
 extern void *_ZN2G212GetBG2ScrPtrEv(void);
 extern void MultiStore16(u16 val, void *dst, int nbytes);
 extern void *LoadFile(int handle);

--- a/src/func_ov006_02120b30.c
+++ b/src/func_ov006_02120b30.c
@@ -1,10 +1,9 @@
+#include "types.h"
 /* func_ov006_02120b30 at 0x02120b30
  *
  * Initializes a particle/effect descriptor with fixed parameters and
  * tail-calls func_ov006_02120bc8.
  */
-typedef unsigned short u16;
-
 struct Desc {
     char _pad0[4];
     int a;       /* +0x04 = 0x110000 */

--- a/src/func_ov006_0212101c.c
+++ b/src/func_ov006_0212101c.c
@@ -1,11 +1,8 @@
+#include "types.h"
 // @symbol func_ov006_0212101c
 // @emits dScMgTrampoline_c_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnAttacked2 - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-
 typedef struct UnkObj UnkObj;
 struct UnkObj {
     int (**vt)(UnkObj*);

--- a/src/func_ov006_021218fc.c
+++ b/src/func_ov006_021218fc.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int data_ov006_02140588;
 extern int data_ov006_0213b0ec;
 extern int data_ov006_0214058c;

--- a/src/func_ov006_02121d64.cpp
+++ b/src/func_ov006_02121d64.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
     void func_ov006_020d0ac0(void);
     int func_02054d88(void);

--- a/src/func_ov006_02122198.cpp
+++ b/src/func_ov006_02122198.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_02122198
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,11 +8,6 @@
 // @emits dScMgTrampoline_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::InitResources - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
 extern "C" {
 
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);

--- a/src/func_ov006_0212231c.c
+++ b/src/func_ov006_0212231c.c
@@ -1,8 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int LoadFile(int handle);
 extern s32 GetGameLanguage(void);
 extern char *_ZN2G213GetBG2CharPtrEv(void);

--- a/src/func_ov006_02122f24.c
+++ b/src/func_ov006_02122f24.c
@@ -1,11 +1,8 @@
+#include "types.h"
 // @symbol func_ov006_02122f24
 // @emits dScMgTrampoline2_c_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnAttacked2 - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-
 extern char* data_0209f5bc;
 extern int data_ov006_0213fbc4;
 

--- a/src/func_ov006_021231ac.c
+++ b/src/func_ov006_021231ac.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_021231ac
 // @emits dScMgTrampoline2_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::Render - recovered from vtable slot identity */
-typedef unsigned short u16;
-
 extern void func_0203cd80(int* m, short angle);
 extern int GetGameLanguage(void);
 extern void DrawOamSprite(void* a0, void* a1, int a2, void* a3);

--- a/src/func_ov006_02124088.c
+++ b/src/func_ov006_02124088.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov006_020d0ac0(void);
 extern int func_02054d88(void);
 extern void MultiStore16(u16 val, char *dst, int nbytes);

--- a/src/func_ov006_021242cc.cpp
+++ b/src/func_ov006_021242cc.cpp
@@ -1,16 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_021242cc
 // @emits dScMgTrampoline2_c_OnYoshiTryEat_021242cc
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnYoshiTryEat - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
 typedef struct {
     u8 pad0[0xbc];
     u32 unkBC;

--- a/src/func_ov006_021243ec.cpp
+++ b/src/func_ov006_021243ec.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_021243ec
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,11 +8,6 @@
 // @emits dScMgTrampoline2_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-
 extern "C" {
 extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
 extern void Camera_UpdateMatrices(void *cam);

--- a/src/func_ov006_021245a8.c
+++ b/src/func_ov006_021245a8.c
@@ -1,8 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int LoadFile(int handle);
 extern s32 GetGameLanguage(void);
 extern char *_ZN2G213GetBG2CharPtrEv(void);

--- a/src/func_ov006_02124cb4.c
+++ b/src/func_ov006_02124cb4.c
@@ -1,7 +1,5 @@
+#include "types.h"
 #pragma opt_strength_reduction off
-
-typedef unsigned char u8;
-
 extern int data_ov004_020bfa18;
 
 extern void func_ov004_020ad79c(int a, int b);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 90 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
