### PR TITLE
readable: consolidate 89 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov006_0212551c.cpp
+++ b/src/func_ov006_0212551c.cpp
@@ -1,12 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov006_0212551c
 // @emits dScMgBSC_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef int s32;
 extern "C" {
 extern unsigned char data_0209d45c[];
 extern int data_0208ee44[];

--- a/src/func_ov006_02125890.c
+++ b/src/func_ov006_02125890.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Vec3 {
     int x, y, z;
 } Vec3;

--- a/src/func_ov006_02125bbc.c
+++ b/src/func_ov006_02125bbc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 #pragma opt_strength_reduction off
 
 int func_ov006_02125bbc(char *o, int *p)

--- a/src/func_ov006_021279b0.cpp
+++ b/src/func_ov006_021279b0.cpp
@@ -1,11 +1,6 @@
 //cpp
+#include "types.h"
 #pragma opt_strength_reduction off
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
 typedef struct Pair {
     s32 x;
     s32 y;

--- a/src/func_ov006_02127d10.c
+++ b/src/func_ov006_02127d10.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_02127d10
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -8,10 +9,6 @@
 /* dScMgSnowball_c::Render - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
 extern void func_0203cd80(int *m, short angle);
 extern void func_ov006_02126a98(char *c);

--- a/src/func_ov006_02128fb8.c
+++ b/src/func_ov006_02128fb8.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_02128fb8
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,8 +7,6 @@
 // @emits dScMgSnowball_c_OnKicked
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::OnKicked - recovered from vtable slot identity */
-typedef unsigned char u8;
-
 extern int func_ov004_020ae140(char *self);
 
 #define V (self->unk_ab6c >> 12)

--- a/src/func_ov006_02129268.c
+++ b/src/func_ov006_02129268.c
@@ -1,15 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_02129268
 // @emits dScMgSnowball_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef volatile unsigned int vu32;
-typedef volatile unsigned short vu16;
-
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern unsigned _ZN3G2S13GetBG2CharPtrEv(void);
 extern void *_ZN2G212GetBG3ScrPtrEv(void);

--- a/src/func_ov006_02129690.c
+++ b/src/func_ov006_02129690.c
@@ -1,7 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern void func_ov004_020af948(void* a, int b, int c, void* m);
 extern void DrawOamSprite(void* a, int b, int c, void* m);
 extern void* data_ov006_02139c6c[];

--- a/src/func_ov006_0212a2e0.cpp
+++ b/src/func_ov006_0212a2e0.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 class C { public: int dummy; };
 typedef void (C::*PMF)(int);
 

--- a/src/func_ov006_0212a654.c
+++ b/src/func_ov006_0212a654.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef signed int s32;
-
+#include "types.h"
 typedef struct Entry {
     u8 unk00; u8 unk01; u8 unk02; u8 unk03;
     s32 unk04; s32 unk08; s32 unk0c; s32 unk10;

--- a/src/func_ov006_0212aacc.c
+++ b/src/func_ov006_0212aacc.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_0212aacc
 // @emits dScMgFlower_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::Render - recovered from vtable slot identity */
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-
 extern s16 data_02082214[];
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
 extern void func_ov004_020af770(void* a0, int a1, int a2, int a3, int a4, int a5, u16 a6);

--- a/src/func_ov006_0212ac74.c
+++ b/src/func_ov006_0212ac74.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov006_0212ac74
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,10 +7,6 @@
 // @emits dScMgFlower_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 typedef struct V2 {
     int x;
     int z;

--- a/src/func_ov006_0212b480.c
+++ b/src/func_ov006_0212b480.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov006_0212b480
 // @emits dScMgFlower_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::InitResources - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void *func_020adc74(void *arg);
 extern char *_ZN2G213GetBG2CharPtrEv(void);
 extern void DecompressLZ16(int src, void *dst);

--- a/src/func_ov007_020ad660.c
+++ b/src/func_ov007_020ad660.c
@@ -1,9 +1,4 @@
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 extern short data_02082214[];
 

--- a/src/func_ov007_020ade58.c
+++ b/src/func_ov007_020ade58.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *data_ov007_0210342c[];
 extern u8 data_ov007_020ccbc4[];
 extern u8 data_ov007_020ccb7d[];

--- a/src/func_ov007_020ae070.c
+++ b/src/func_ov007_020ae070.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 extern void Sprite_SetAnimation(char *c, int r1, int r2, int r3, int sp0);
 

--- a/src/func_ov007_020ae2d0.c
+++ b/src/func_ov007_020ae2d0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 extern short data_02082214[];
 extern int _ZN4cstd3modEii(int, int);

--- a/src/func_ov007_020ae558.c
+++ b/src/func_ov007_020ae558.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 extern void Sprite_SetAnimation(char *c, int r1, int r2, int r3, int sp0);
 

--- a/src/func_ov007_020b0834.c
+++ b/src/func_ov007_020b0834.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov007_020c0638(int a, int b, int c, int d);
 extern void func_ov007_020b7d94(int kind);
 extern void func_ov007_020b2614(int a, int b, int c);

--- a/src/func_ov007_020b0a20.c
+++ b/src/func_ov007_020b0a20.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef signed short s16;
-
+#include "types.h"
 typedef struct SubC {
     int unk0;
     char pad4[8];

--- a/src/func_ov007_020b0da0.c
+++ b/src/func_ov007_020b0da0.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov007_020b0da0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
 extern short data_02082214[];
 
 extern int _ZN4cstd4fdivEii(int a, int b);

--- a/src/func_ov007_020b1390.c
+++ b/src/func_ov007_020b1390.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern char *data_ov007_0210342c;
 extern u8 data_ov007_020ccc44[];
 extern void func_ov007_020c0288(u16 *p, int count, int val);

--- a/src/func_ov007_020b1b74.c
+++ b/src/func_ov007_020b1b74.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov007_020b2614(int a, int b, int c);
 extern int _ZN4cstd3divEii(int a, int b);
 

--- a/src/func_ov007_020b1cf0.c
+++ b/src/func_ov007_020b1cf0.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov007_020b2614(int a, int b, int c);
 extern int _ZN4cstd3modEii(int a, int b);
 extern int func_ov007_020c1da0(int i);

--- a/src/func_ov007_020b283c.c
+++ b/src/func_ov007_020b283c.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 struct S
 {
   char _0[0xe8];

--- a/src/func_ov007_020b3190.c
+++ b/src/func_ov007_020b3190.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int func_ov007_020c1da0(int i);
 extern void func_ov007_020bdeb0(int i);
 

--- a/src/func_ov007_020b3360.c
+++ b/src/func_ov007_020b3360.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov007_020b3c54(void);
 extern int func_ov007_020b3708(void);
 extern void func_ov007_020c2090(char* c);

--- a/src/func_ov007_020b3708.c
+++ b/src/func_ov007_020b3708.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov007_020bdeb0(int a);
 extern char* data_ov007_02103360;
 extern char* data_ov007_0210342c;

--- a/src/func_ov007_020b3f20.c
+++ b/src/func_ov007_020b3f20.c
@@ -1,6 +1,4 @@
-
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern void *data_ov007_02103370[];
 extern u16 data_ov007_020d7584[];
 extern void *(*data_ov007_02103368)(u16);

--- a/src/func_ov007_020b413c.c
+++ b/src/func_ov007_020b413c.c
@@ -1,7 +1,4 @@
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct Sb {
     int p0;
     int f4;

--- a/src/func_ov007_020b42d8.c
+++ b/src/func_ov007_020b42d8.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct {
     char _0[4];
     int f4;

--- a/src/func_ov007_020b4c04.c
+++ b/src/func_ov007_020b4c04.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern void *func_ov007_020c3df4(int a, int b);
 extern void *func_ov007_020aea6c(int a, void *b, void *c);
 extern void *func_ov007_020c44e4(u8 x);

--- a/src/func_ov007_020b50e8.c
+++ b/src/func_ov007_020b50e8.c
@@ -1,9 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern char *data_ov007_0210342c;
 extern int data_ov007_02103428;
 

--- a/src/func_ov007_020b58e4.c
+++ b/src/func_ov007_020b58e4.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 inline char *inline_fn(char *arg0)
 {

--- a/src/func_ov007_020b5bf0.c
+++ b/src/func_ov007_020b5bf0.c
@@ -1,9 +1,4 @@
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern short data_02082214[];
 extern u8 data_ov007_0210342c[];
 

--- a/src/func_ov007_020b5f64.c
+++ b/src/func_ov007_020b5f64.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern u8 data_ov007_0210342c[];
 
 void func_ov007_020b5f64(char *self)

--- a/src/func_ov007_020b69c4.c
+++ b/src/func_ov007_020b69c4.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 *data_ov007_0210342c;
 
 extern void *func_ov007_020c9388(void *self);

--- a/src/func_ov007_020b6c54.c
+++ b/src/func_ov007_020b6c54.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void _ZN3G3X13SetClearColorEtiiib(u16 color, int r, int g, int b, int alpha);
 
 void func_ov007_020b6c54(void) {

--- a/src/func_ov007_020b6d40.c
+++ b/src/func_ov007_020b6d40.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char *data_ov007_0210342c;
 extern int data_ov007_020d7e28[];
 extern int data_ov007_020d7e38[];

--- a/src/func_ov007_020b7090.c
+++ b/src/func_ov007_020b7090.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct S {
     char pad0[0x10];
     int f10;                 // 0x10

--- a/src/func_ov007_020b7708.c
+++ b/src/func_ov007_020b7708.c
@@ -1,10 +1,8 @@
+#include "types.h"
 /* func_ov007_020b7708 — lazily create particle system slot idx in the table
  * at data_ov007_02103450 via Particle::Manager::AddSystem(data_ov007_0210344c,
  * 0, pos), then set flag bit1 (+0x1c) on the new system.
  */
-
-typedef unsigned int u32;
-
 struct PtclSys {
     char _pad0[0x1c];
     u32 flags;            /* 0x1c */

--- a/src/func_ov007_020b88c0.c
+++ b/src/func_ov007_020b88c0.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void MultiStore16(u16 val, s16 *dst, int nbytes);
 extern void func_ov007_020c43bc(char *a, char *b);
 extern void func_ov007_020c4388(char *a, char *b);

--- a/src/func_ov007_020b8b00.c
+++ b/src/func_ov007_020b8b00.c
@@ -1,6 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_ov007_020c3598(int a, int b, s8 *c, int d);
 extern void func_ov007_020b8d48(void *obj, unsigned int v);
 extern u8 data_ov007_020d7a38[];

--- a/src/func_ov007_020b8b80.c
+++ b/src/func_ov007_020b8b80.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int data_ov007_02103464;
 extern u8 data_ov007_02102df8[];
 extern int data_ov007_02103468;

--- a/src/func_ov007_020b8d48.c
+++ b/src/func_ov007_020b8d48.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern u32 data_ov007_02102dd8;
 extern u32 data_ov007_02103464;
 extern u8 data_ov007_02102df8[];

--- a/src/func_ov007_020b9880.c
+++ b/src/func_ov007_020b9880.c
@@ -1,11 +1,5 @@
+#include "types.h"
 #pragma opt_strength_reduction off
-
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-
 extern void *func_ov007_020c3df4(int a, int b);
 extern void *func_ov007_020c690c(int a0, int a1, int a2, int a3, void *a4, void *a5);
 extern void *func_ov007_020c9388(int a);

--- a/src/func_ov007_020b9ca8.c
+++ b/src/func_ov007_020b9ca8.c
@@ -1,11 +1,9 @@
+#include "types.h"
 /* func_ov007_020b9ca8 @ 0x020b9ca8 (ov007, size 0x264)
  * Minigame cursor/pen update: advances the shared pen state, spawns the
  * touch feedback (sound id 0x25..0x28 by rhythm), fades the music with pen
  * hold time, and updates the frame counter at +0x28.
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern char *data_ov007_0210342c;
 extern char *data_ov007_02104ba0;
 

--- a/src/func_ov007_020ba368.c
+++ b/src/func_ov007_020ba368.c
@@ -1,9 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern u8 data_ov007_02104ba0[];
 extern u8 data_ov007_02104b9c[];
 extern s16 data_ov007_02104b98[];

--- a/src/func_ov007_020baa10.c
+++ b/src/func_ov007_020baa10.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov007_020baa10
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
-
 extern s16 data_02082214[];
 
 

--- a/src/func_ov007_020bad8c.c
+++ b/src/func_ov007_020bad8c.c
@@ -1,9 +1,4 @@
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u8 data_ov007_02104ba0[];
 extern u16 data_ov007_020d7b54[];
 extern short data_02082214[];

--- a/src/func_ov007_020bbe60.c
+++ b/src/func_ov007_020bbe60.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef long long s64;
-
+#include "types.h"
 extern void func_ov007_020c6784(void *self, int count, int p2, int p3, int p4, int p5, int mode);
 
 extern char *data_ov007_0210342c;

--- a/src/func_ov007_020bc02c.c
+++ b/src/func_ov007_020bc02c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct { int f[12]; } Blk;
 
 #define LS(a) (*(short*)(((long long)(int)(a))))

--- a/src/func_ov007_020bc968.c
+++ b/src/func_ov007_020bc968.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern void Matrix4x3_LoadIdentity(void* mat);
 extern void func_ov007_020c39f8(void* mat, int a, int b, int c);
 extern void MulMat4x3Mat4x3(void* d, void* a, void* b);

--- a/src/func_ov007_020bce70.cpp
+++ b/src/func_ov007_020bce70.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Sub {
     char pad2[2];
     short field2;

--- a/src/func_ov007_020bd1c0.c
+++ b/src/func_ov007_020bd1c0.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 typedef struct { int a, b, c; } S12;
 
 extern char* data_ov007_0210342c;

--- a/src/func_ov007_020bd648.c
+++ b/src/func_ov007_020bd648.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_020541a4(void);
 extern void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
 extern void _ZN2GX12SetBankForBGEt(u16 x);

--- a/src/func_ov007_020be0dc.c
+++ b/src/func_ov007_020be0dc.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern char **data_ov007_02104bc0;
 extern int data_ov007_02103230;
 extern char *data_ov007_0210342c;

--- a/src/func_ov007_020be850.c
+++ b/src/func_ov007_020be850.c
@@ -1,5 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
+#include "types.h"
 extern char* data_ov007_0210342c;
 
 int func_ov007_020be850(void) {

--- a/src/func_ov007_020beaa0.c
+++ b/src/func_ov007_020beaa0.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Obj {
     u8 f0;
     u8 f1;

--- a/src/func_ov007_020beb80.c
+++ b/src/func_ov007_020beb80.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef long long s64;
+#include "types.h"
 typedef struct { int x, y, z; } Vec3i;
 typedef struct { short x, y, z; } Vec3s;
 

--- a/src/func_ov007_020bf304.c
+++ b/src/func_ov007_020bf304.c
@@ -1,8 +1,6 @@
+#include "types.h"
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
-
-typedef unsigned char u8;
-
 extern u8 data_ov007_02104bd4[];
 extern u8 data_ov007_0210342c[];
 

--- a/src/func_ov007_020bf428.c
+++ b/src/func_ov007_020bf428.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_ov007_020c3df4(int a, int b);
 extern int func_ov007_020cbbb0(int a, int b, int c, void *d);
 extern int func_ov007_020cbf8c(void *src);

--- a/src/func_ov007_020bffb8.c
+++ b/src/func_ov007_020bffb8.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov007_020bffb8(char *c)

--- a/src/func_ov007_020c0308.c
+++ b/src/func_ov007_020c0308.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* func_ov007_020c0308 — fill b*32 BG map entries at dst with sequential tile
  * numbers OR'd with palette (c & 0xf) << 12. No callees.
  */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 #pragma opt_strength_reduction off
 void func_ov007_020c0308(u16* dst, int b, int c)
 {

--- a/src/func_ov007_020c0638.c
+++ b/src/func_ov007_020c0638.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 extern void MultiCopyHalf(char *src, char *dst, int nbytes);
 

--- a/src/func_ov007_020c076c.c
+++ b/src/func_ov007_020c076c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
 extern void func_02056554(const void* src, int offset, int count);
 extern void func_02056494(const void* src, int offset, int count);

--- a/src/func_ov007_020c0d70.c
+++ b/src/func_ov007_020c0d70.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Anim {
     char pad[0x20];
     int mode;     /* 0x20 */

--- a/src/func_ov007_020c1448.c
+++ b/src/func_ov007_020c1448.c
@@ -1,7 +1,5 @@
+#include "types.h"
 #pragma opt_propagation off
-
-typedef unsigned int u32;
-
 #define reg_G3_TEXIMAGE_PARAM (*(volatile u32 *)0x040004a8)
 
 static inline void G3_TexImageParam(u32 addr, u32 texFmt, u32 texGen, u32 sizeS, u32 sizeT,

--- a/src/func_ov007_020c14d4.c
+++ b/src/func_ov007_020c14d4.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 data_ov007_02104be8;
 extern u32 data_ov007_02104be0;
 

--- a/src/func_ov007_020c1560.c
+++ b/src/func_ov007_020c1560.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 data_ov007_02104bdc;
 extern u32 data_ov007_02104be4;
 

--- a/src/func_ov007_020c1db0.c
+++ b/src/func_ov007_020c1db0.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 typedef struct Vec4 { u16 a, b, c, d; } Vec4;
 
 typedef struct T {

--- a/src/func_ov007_020c232c.c
+++ b/src/func_ov007_020c232c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov007_020c232c(char* o) {
     int a, b, c;
     if (*(int*)(o + 0x24) == 0) return;

--- a/src/func_ov007_020c28ac.c
+++ b/src/func_ov007_020c28ac.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void MultiStore_Int(int val, int *dst, int len);
 extern void MultiStore16(u16 val, char *dst, int nbytes);
 

--- a/src/func_ov007_020c31e0.c
+++ b/src/func_ov007_020c31e0.c
@@ -1,8 +1,4 @@
-
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
-typedef unsigned long long u64;
+#include "types.h"
 inline s64 inline_fn(int arg0)
 {
   return (s64) arg0;

--- a/src/func_ov007_020c3fe4.c
+++ b/src/func_ov007_020c3fe4.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 struct Inner {
     s32 x;      /* 0x00 */
     s32 y;      /* 0x04 */

--- a/src/func_ov007_020c43bc.cpp
+++ b/src/func_ov007_020c43bc.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef int s32;
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern "C" int _ZN4cstd4fdivEii(int a, int b);
 extern s16 data_02082214[];
 

--- a/src/func_ov007_020c44e4.c
+++ b/src/func_ov007_020c44e4.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov007_020c44e4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
 

--- a/src/func_ov007_020c5490.c
+++ b/src/func_ov007_020c5490.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef int s32;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 void func_ov007_020c5490(char* obj, int* m)
 {
     int i;

--- a/src/func_ov007_020c5a6c.cpp
+++ b/src/func_ov007_020c5a6c.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned short u16;
+#include "types.h"
 struct Vec3 { int v[3]; };
 
 extern "C" {

--- a/src/func_ov007_020c5c14.c
+++ b/src/func_ov007_020c5c14.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef long long s64;
+#include "types.h"
 struct Elem { int a, b, c; };
 
 extern void func_ov007_020bfe4c(void* p, int b, int c, int d, int* e);

--- a/src/func_ov007_020c5fc8.c
+++ b/src/func_ov007_020c5fc8.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol func_ov007_020c5fc8
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
-
 extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
 extern int LenVec3(struct Vector3 *v);
 

--- a/src/func_ov007_020c690c.c
+++ b/src/func_ov007_020c690c.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void* func_ov007_020c3df4(int a, int size);
 extern void func_ov007_020c684c(void* self);
 extern void* func_ov007_020c844c(void* p, int q);

--- a/src/func_ov007_020c798c.c
+++ b/src/func_ov007_020c798c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct Thing {
     int *field0;
     int field4;

--- a/src/func_ov007_020c8498.c
+++ b/src/func_ov007_020c8498.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov007_020c86c4(void* p);
 extern void func_ov007_020c897c(void* p);
 extern void func_ov007_020c8970(void* p);

--- a/src/func_ov007_020c86c4.c
+++ b/src/func_ov007_020c86c4.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 typedef struct S {
     s32 mode;
     u32 flags;

--- a/src/func_ov007_020c897c.c
+++ b/src/func_ov007_020c897c.c
@@ -1,7 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 struct S {
     s32 mode;
     u32 flags;

--- a/src/func_ov007_020c951c.c
+++ b/src/func_ov007_020c951c.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void *data_ov007_02104c20;
 extern void *data_ov007_02104c24;
 extern void *data_ov007_02104c1c;

--- a/src/func_ov007_020c95fc.c
+++ b/src/func_ov007_020c95fc.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Foo {
     int w0;
     int w4;

--- a/src/func_ov007_020ca308.c
+++ b/src/func_ov007_020ca308.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
+#include "types.h"
 extern short data_02082214[];
 extern int func_ov007_020c3ba8(int);
 extern int _ZN4cstd3divEii(int, int);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 89 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
