### PR TITLE
readable: consolidate 75 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov007_020ca5f0.c
+++ b/src/func_ov007_020ca5f0.c
@@ -1,8 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
+#include "types.h"
 extern void func_ov007_020c1448(void *a, int b, int c, int d, int e);
 extern void func_ov007_020c1404(void *c);
 extern int _ZN4cstd3divEii(int a, int b);

--- a/src/func_ov007_020ca86c.c
+++ b/src/func_ov007_020ca86c.c
@@ -1,9 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-typedef volatile u32 vu32;
-
+#include "types.h"
 typedef struct Vec { s32 x, y, z; } Vec;
 typedef struct VecN { s16 x, y, z; } VecN;
 

--- a/src/func_ov007_020cc168.c
+++ b/src/func_ov007_020cc168.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern u8 data_0209b340[];
 extern u8 data_0209b34b[];
 extern u8 data_0209b34e[];

--- a/src/func_ov007_020cc2cc.c
+++ b/src/func_ov007_020cc2cc.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov007_020cc2cc
 // @emits dScDSMT_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -6,11 +7,6 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScDSMT_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern int func_ov007_020b7090(u16 a0, u16 a1, u16 a2, u16 a3, int arg4);
 extern int _ZN4Heap10SetDefaultEv(int heap);

--- a/src/func_ov007_020cc600.c
+++ b/src/func_ov007_020cc600.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef signed int s32;
-
+#include "types.h"
 struct E { u8 pad[4]; u32 unk4; };
 
 extern void SetSoundMode(int mode);

--- a/src/func_ov009_02111234.cpp
+++ b/src/func_ov009_02111234.cpp
@@ -1,16 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov009_02111234
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
-
-
 extern "C" {
     void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
     void* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov014_021115ec.cpp
+++ b/src/func_ov014_021115ec.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov014_021115ec
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
 extern "C" {
     void _ZN5Sound15PlaySecretSoundEP5ActorPt(void *actor, u16 *snd);
     void *_ZN5Actor10FindWithIDEj(unsigned id);

--- a/src/func_ov016_02111284.c
+++ b/src/func_ov016_02111284.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol func_ov016_02111284
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-
-
-
 extern void Matrix4x3_FromRotationY(void* m, int angle);
 extern void MulVec3Mat4x3(void* in, void* m, void* out);
 extern void* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov018_021118fc.c
+++ b/src/func_ov018_021118fc.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 struct Actor { char pad[0xc]; unsigned short kind; };
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
 struct Actor* func_ov018_021118fc(char* c) {

--- a/src/func_ov018_02111b3c.c
+++ b/src/func_ov018_02111b3c.c
@@ -1,10 +1,9 @@
+#include "types.h"
 // @symbol func_ov018_02111b3c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-
 extern char* _ZN5Actor13ClosestPlayerEv(void);
 extern int Vec3_Dist(const struct Vector3* a, const struct Vector3* b);
 

--- a/src/func_ov018_02111fac.c
+++ b/src/func_ov018_02111fac.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *target, void *self, int b);
 extern short Vec3_HorzAngle(void *a, void *b);
 extern int _Z14ApproachLinearRsss(void *dst, short a, short b);

--- a/src/func_ov020_021115ac.c
+++ b/src/func_ov020_021115ac.c
@@ -1,9 +1,8 @@
+#include "types.h"
 /* The ROM reserves a 12-byte frame it never touches; two address-taken volatile locals
  * reserve it with no emitted code (plain or non-address-taken volatiles are DCE'd before
  * frame layout). The 6g u64-mask launder on &vel forces the ROM's `add r0,r4,#0xa4` base. */
-typedef unsigned short u16;
 typedef struct { int x, y, z; } Vec3;
-typedef unsigned int u32;
 #define LDR(p) ((int)((((long long)(int)(p)))))
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov020_0211174c.c
+++ b/src/func_ov020_0211174c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef int s32;
-
+#include "types.h"
 extern void *Actor_FindWithID(unsigned int id);
 extern int func_ov020_021115ac(void *thiz);
 extern void Sound_PlayBank0(unsigned int id, void *pos);

--- a/src/func_ov020_02111c30.c
+++ b/src/func_ov020_02111c30.c
@@ -1,10 +1,4 @@
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern int func_ov020_02111418(char *c);
 extern void _ZN9Animation7AdvanceEv(void *);
 extern int _Z14ApproachLinearRiii(s32 *, int, int);

--- a/src/func_ov021_021123b0.c
+++ b/src/func_ov021_021123b0.c
@@ -1,14 +1,9 @@
+#include "types.h"
 // @symbol func_ov021_021123b0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_02012694(int a, void *p);
 extern void _ZN6Player16IncMegaKillCountEv(void *p);

--- a/src/func_ov021_02112544.cpp
+++ b/src/func_ov021_02112544.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 struct Vec3 {
     int x, y, z;
     Vec3() {}

--- a/src/func_ov024_02111350.c
+++ b/src/func_ov024_02111350.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 #define M(p) ((long long)(int)(p))
 
 extern int _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov025_021113f0.c
+++ b/src/func_ov025_021113f0.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_ov025_021113f0
 // @emits daDgr_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daDgr_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 typedef struct { s32 x, y, z; } Vec3;
 
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *self, s32 a, s32 b);

--- a/src/func_ov025_021119f4.c
+++ b/src/func_ov025_021119f4.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
+#include "types.h"
 extern int func_0201267c(int a, void *b);
 void func_ov025_021119f4(char *c)
 {

--- a/src/func_ov026_02111330.cpp
+++ b/src/func_ov026_02111330.cpp
@@ -1,18 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov026_02111330
 // @emits daObjWlPolelift_c_Behavior
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjWlPolelift_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef unsigned long long u64;
-
-
 extern "C" {
     unsigned short DecIfAbove0_Short(unsigned short* p);
     void _ZNK7PathPtr7GetNodeER7Vector3j(void* self, Vector3* out, unsigned int idx);

--- a/src/func_ov027_02112424.c
+++ b/src/func_ov027_02112424.c
@@ -1,6 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef s32 Fix12i;
+#include "types.h"
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir, void* callback);
 void func_ov027_02112424(char* c){

--- a/src/func_ov029_02111bcc.c
+++ b/src/func_ov029_02111bcc.c
@@ -1,13 +1,10 @@
+#include "types.h"
 // @symbol func_ov029_02111bcc
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjWc_Obj05_c.h"
 // @emits daObjWc_Obj05_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjWc_Obj05_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void func_020393a4(int* p, int v);
 extern int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned a, unsigned b, unsigned c, void* pos, unsigned e);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);

--- a/src/func_ov030_02112400.cpp
+++ b/src/func_ov030_02112400.cpp
@@ -1,5 +1,5 @@
 //cpp
-typedef unsigned short u16;
+#include "types.h"
 typedef void* (*Vfn)();
 
 struct Animation { void Advance(); };

--- a/src/func_ov030_02112578.c
+++ b/src/func_ov030_02112578.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *p);
 void *_ZN5Actor13ClosestPlayerEv(void *self);
 int func_ov030_02111b20(void *self);

--- a/src/func_ov030_02112a84.c
+++ b/src/func_ov030_02112a84.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct P2 { int a, b; } P2;
 
 typedef struct ClsnResult {

--- a/src/func_ov030_02112da0.c
+++ b/src/func_ov030_02112da0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_ov030_021141a8(void *a, int m);
 extern int Vec3_Dist(void *a, void *b);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *a, void *self, unsigned int, void *, unsigned int, unsigned int);

--- a/src/func_ov030_02113094.c
+++ b/src/func_ov030_02113094.c
@@ -1,12 +1,7 @@
+#include "types.h"
 // @symbol func_ov030_02113094
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct Actor;
 
 

--- a/src/func_ov032_021113fc.cpp
+++ b/src/func_ov032_021113fc.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov032_021113fc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern "C" {
     void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* c, void* v);
     void* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov032_02111830.c
+++ b/src/func_ov032_02111830.c
@@ -1,7 +1,4 @@
-
-typedef short s16;
-typedef unsigned int u32;
-typedef int Fix12i;
+#include "types.h"
 extern int data_0209f32c;
 extern int data_020a0e68;
 extern void *data_ov032_02113a50[];

--- a/src/func_ov034_02112688.c
+++ b/src/func_ov034_02112688.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov034_02112688
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Player.h"
@@ -5,9 +6,6 @@
 /* recovered: shared common types */
 #include "common.h"
 #pragma opt_strength_reduction off
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
 extern void func_0201267c(int a, void *b);
 extern void func_ov034_021125b8(char *sl, int i);

--- a/src/func_ov036_021114f8.c
+++ b/src/func_ov036_021114f8.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov036_021114f8
 // @emits daObjRc_Kaitendai_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjRc_Kaitendai_c::CleanupResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b66a8(u8 *self, struct Arg *arg);

--- a/src/func_ov043_021114b0.c
+++ b/src/func_ov043_021114b0.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov043_021114b0
 // @emits daObjKm1_Kurumajiku_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);

--- a/src/func_ov047_02111254.c
+++ b/src/func_ov047_02111254.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov047_02111254
 // @emits daObjKm3_Kurumajiku_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);

--- a/src/func_ov047_02111268.c
+++ b/src/func_ov047_02111268.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov047_02111268
 // @emits daObjKm3_Kurumajiku_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6c54(u8 *self, struct Arg *arg, unsigned int actorID);

--- a/src/func_ov047_021114ac.c
+++ b/src/func_ov047_021114ac.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov047_021114ac
 // @emits daObjKm3_Kuruma_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kuruma_c::CleanupResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b68b0(u8 *self, struct Arg *arg);

--- a/src/func_ov047_021114c0.c
+++ b/src/func_ov047_021114c0.c
@@ -1,8 +1,8 @@
+#include "types.h"
 // @symbol func_ov047_021114c0
 // @emits daObjKm3_Kuruma_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kuruma_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
 struct Arg { void *m[3]; };
 
 extern int func_ov002_020b6958(u8 *self, struct Arg *arg);

--- a/src/func_ov060_021128c0.cpp
+++ b/src/func_ov060_021128c0.cpp
@@ -1,18 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov060_021128c0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-typedef int Fix12;
-
-
 extern "C" {
     void* _ZN5Actor10FindWithIDEj(u32 id);
     void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, const Vector3& v, u32 a, Fix12 b, u32 c, u32 d, u32 e);

--- a/src/func_ov060_021130c0.c
+++ b/src/func_ov060_021130c0.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 #define LAUND(p) ((void*)((((long long)(int)(p)))))
 
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* player, void* actorBase, int isTalk);

--- a/src/func_ov060_02113740.c
+++ b/src/func_ov060_02113740.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct RaycastGround {
     char pre[0x10];

--- a/src/func_ov060_02113b5c.cpp
+++ b/src/func_ov060_02113b5c.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov060_02113b5c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
-
 struct RaycastGround { char buf[0x50]; };
 
 extern "C" {

--- a/src/func_ov060_021146d0.c
+++ b/src/func_ov060_021146d0.c
@@ -1,12 +1,8 @@
+#include "types.h"
 /* func_ov060_021146d0 at 0x021146d0 (ov060), size 0x188
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-
 extern void func_02012694(int a, void *b);
 extern void func_ov060_02111cc0(char *c, int idx, int m);
 extern void func_ov060_02115a84(char *c, char *arg);

--- a/src/func_ov060_02114b60.c
+++ b/src/func_ov060_02114b60.c
@@ -1,7 +1,4 @@
-
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern void func_02012694(int a, void *b);
 extern int _ZN5Actor14GetSubtractionEss(char *self, s16 a, s16 b);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(char *self);

--- a/src/func_ov060_02114d08.c
+++ b/src/func_ov060_02114d08.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int _ZN5Actor14GetSubtractionEss(void* actor, s16 a, s16 b);
 extern int _Z14ApproachLinearRsss(s16* dst, s16 target, int step);
 extern int func_ov060_02115744(void* c);

--- a/src/func_ov060_021153f8.c
+++ b/src/func_ov060_021153f8.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern int func_ov060_02111f08(void *arg0);
 extern int func_ov060_02115744(void *c);
 extern int func_ov060_02115718(void *c);

--- a/src/func_ov060_02115518.c
+++ b/src/func_ov060_02115518.c
@@ -1,7 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern int _ZN6Player9StartTalkER9ActorBaseb(void *player, void *actor, int flag);
 extern int _ZN6Player12GetTalkStateEv(void *player);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void *player, void *actor, unsigned int msg, void *pos, unsigned int a, unsigned int b);

--- a/src/func_ov060_02115c1c.c
+++ b/src/func_ov060_02115c1c.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 enum { false, true };
 
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov060_02115d68.cpp
+++ b/src/func_ov060_02115d68.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 class Actor;
 class Player;
 

--- a/src/func_ov060_02116518.c
+++ b/src/func_ov060_02116518.c
@@ -1,6 +1,4 @@
-typedef int Fix12;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
     u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f);
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov060_021169f8.c
+++ b/src/func_ov060_021169f8.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // @symbol func_ov060_021169f8
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-
-
 struct Actor;
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* self, void* c);
 extern void func_ov060_02116518(char* self, int a, int b, int c);

--- a/src/func_ov060_02116f90.c
+++ b/src/func_ov060_02116f90.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
 extern int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(u32 id, u32 a, int fix, int t1, int t2, void *vec);
 extern void func_ov060_0211712c(void *self);

--- a/src/func_ov060_021172e0.cpp
+++ b/src/func_ov060_021172e0.cpp
@@ -1,16 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov060_021172e0
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef int Fix12i;
-typedef short s16;
-typedef signed char s8;
-
-
-
-
 extern "C" {
     void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12i x, Fix12i y, Fix12i z);
     void _ZN9ActorBase18MarkForDestructionEv(void* self);

--- a/src/func_ov060_0211747c.c
+++ b/src/func_ov060_0211747c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Vec3 { int x, y, z; };
 
 extern void *_ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov060_02117db8.c
+++ b/src/func_ov060_02117db8.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 
 extern void Vec3_AsrInPlace(Vec3 *v, int n);

--- a/src/func_ov060_021188e8.c
+++ b/src/func_ov060_021188e8.c
@@ -1,10 +1,7 @@
+#include "types.h"
 /* func_ov060_021188e8 — set flag bit0 (0x13c), grow the uniform scale
  * (0x80/0x84/0x88) as timer(0x1ac) * 0x9000 / 14 + 0x1000; at timer == 0x1c
  * call func_ov060_021184bc and bump the timer. */
-
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 extern void func_ov060_021184bc(char* c);
 
 typedef struct {

--- a/src/func_ov062_02116010.c
+++ b/src/func_ov062_02116010.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov062_02116010
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-
 extern void *_ZN5Actor10FindWithIDEj(u32 id);
 extern void func_020ada40(void *c, void *v, void *a, int flag);
 extern void func_02012694(int a, void *p);

--- a/src/func_ov062_021164e8.cpp
+++ b/src/func_ov062_021164e8.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int Fix12;
-typedef short s16;
-typedef unsigned short u16;
+#include "types.h"
 struct BCA_File;
 struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
 

--- a/src/func_ov062_02117994.c
+++ b/src/func_ov062_02117994.c
@@ -1,7 +1,4 @@
-typedef int Fix12;
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Entry { char pad[4]; void *file; };
 extern struct Entry *data_ov062_0211cee8[];
 extern int data_ov062_0211cf0c[];

--- a/src/func_ov062_02117c98.c
+++ b/src/func_ov062_02117c98.c
@@ -1,9 +1,4 @@
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct { s32 x, y, z; } Vec3;
 typedef struct { s16 x, y, z; } V16;
 

--- a/src/func_ov062_02118a50.c
+++ b/src/func_ov062_02118a50.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov062_02118a50
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Animation.h"
@@ -5,9 +6,6 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *w);
 extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *s, struct Vector3 *v);
 extern s16 _ZN5Actor12ReflectAngleE5Fix12IiES1_s(void *self, int a, int b, s16 ang);

--- a/src/func_ov062_02118b4c.c
+++ b/src/func_ov062_02118b4c.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov062_02117724(void *c, int a, int b, int d, int e);
 extern int func_ov062_02117b60(void *c);
 extern int _Z14ApproachLinearRiii(int *val, int target, int step);

--- a/src/func_ov062_021199ac.c
+++ b/src/func_ov062_021199ac.c
@@ -1,14 +1,7 @@
+#include "types.h"
 // @symbol func_ov062_021199ac
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
-
-
 extern void *_ZN5Actor18ClosestWithActorIDEj(void *thiz, u32 id);
 
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);

--- a/src/func_ov062_0211a1f4.c
+++ b/src/func_ov062_0211a1f4.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov062_0211a1f4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Player.h"
@@ -5,13 +6,6 @@
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-
 struct VVec3 { volatile int x, y, z; };
 
 extern s8 data_0209f2f8;

--- a/src/func_ov062_0211b3ac.cpp
+++ b/src/func_ov062_0211b3ac.cpp
@@ -1,9 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov062_0211b3ac
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-
 struct PathPtr { int a, b; };
 extern "C" void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern "C" void _ZN7PathPtrC1Ev(PathPtr* self);

--- a/src/func_ov062_0211ba84.c
+++ b/src/func_ov062_0211ba84.c
@@ -1,12 +1,10 @@
+#include "types.h"
 // @symbol func_ov062_0211ba84
 // @emits KoopaFlag_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daRFlag_c::Kill - recovered from vtable slot identity */
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef short s16;
 extern char *_ZN5Actor13ClosestPlayerEv(char *self);
 extern int func_ov062_0211c658(char *c, void *p);
 extern s16 Vec3_HorzAngle(const Vector3 *v0, const Vector3 *v1);

--- a/src/func_ov062_0211c2f4.cpp
+++ b/src/func_ov062_0211c2f4.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov062_0211c2f4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned int u32;
-
-
-
 struct PathPtr {
     int a;
     int b;

--- a/src/func_ov063_0211640c.c
+++ b/src/func_ov063_0211640c.c
@@ -1,18 +1,10 @@
+#include "types.h"
 // @symbol func_ov063_0211640c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 #pragma opt_propagation off
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-
-
-
-
 extern void Vec3_Asr(struct Vector3 *d, struct Vector3 *s, int sh);
 extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 extern void _ZN9ModelBase12ApplyOpacityEj(void *self, u32 a, int z);

--- a/src/func_ov063_02116fac.c
+++ b/src/func_ov063_02116fac.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov063_02116fac
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef signed short s16;
-
 extern void func_0201267c(unsigned int id, void* p);
 extern void _Z14ApproachLinearRiii(int* p, int target, int step);
 extern short Vec3_HorzAngle(const void* a, const void* b);

--- a/src/func_ov063_02117364.c
+++ b/src/func_ov063_02117364.c
@@ -1,11 +1,4 @@
-typedef signed int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-typedef int Fix12i;
-
+#include "types.h"
 struct ParticleCallback;
 
 typedef struct { s32 x, y, z; } Vec3;

--- a/src/func_ov063_02117b0c.c
+++ b/src/func_ov063_02117b0c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 #define LAUND(p) ((void *)((((long long)(int)(p)))))
 
 extern void *_ZN5Actor13ClosestPlayerEv(void *o);

--- a/src/func_ov063_0211873c.c
+++ b/src/func_ov063_0211873c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov063_02119e38(void* self, int m, int a, int b);
 extern int func_ov063_0211a0dc(void* self);
 extern void func_02012694(int id, void* p);

--- a/src/func_ov063_02118914.c
+++ b/src/func_ov063_02118914.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 void func_ov063_02118914(char *c)
 {
     int zero = 0;

--- a/src/func_ov063_021189f4.c
+++ b/src/func_ov063_021189f4.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, s32 d, int e);
 extern int _ZN5Sound15PlaySecretSoundEP5ActorPt(void *actor, u16 *p);
 extern void func_ov063_02119074(char *c);

--- a/src/func_ov063_02118b98.c
+++ b/src/func_ov063_02118b98.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov063_0211adfc(char *p);
 extern void func_ov063_02118eac(void *c);
 extern void func_ov063_02118e5c(void *c);

--- a/src/func_ov063_0211934c.cpp
+++ b/src/func_ov063_0211934c.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
+#include "types.h"
 extern "C" {
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *a);
 extern void func_0201267c(u32 id, void *p);

--- a/src/func_ov063_0211975c.cpp
+++ b/src/func_ov063_0211975c.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef signed char s8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern "C" int func_ov063_0211a3d0(void* p);
 extern "C" void func_0201267c(int a, char* b);
 extern "C" {


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 75 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
