### PR TITLE
readable: consolidate 71 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov063_0211a564.c
+++ b/src/func_ov063_0211a564.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern void func_ov063_0211adfc(char *p);
 extern void func_ov063_0211a810(void *p, int x);
 extern void func_ov063_0211a76c(void *p, int x, int y);

--- a/src/func_ov063_0211a718.c
+++ b/src/func_ov063_0211a718.c
@@ -1,6 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov063_0211a718(char* o) {

--- a/src/func_ov063_0211a964.c
+++ b/src/func_ov063_0211a964.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern void func_ov063_0211a960(void *p);
 extern char data_02082214[];
 

--- a/src/func_ov063_0211aa34.c
+++ b/src/func_ov063_0211aa34.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern void _ZN5Model12SetPolygonIDEi(void* m, int id);
 
 void func_ov063_0211aa34(char* self)

--- a/src/func_ov063_0211c89c.c
+++ b/src/func_ov063_0211c89c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 extern u8 IsAreaShowing(int idx);

--- a/src/func_ov063_0211cb54.c
+++ b/src/func_ov063_0211cb54.c
@@ -1,5 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
+#include "types.h"
 struct Obj {
     char pad0[0x64];
     int f64;

--- a/src/func_ov063_0211d8cc.cpp
+++ b/src/func_ov063_0211d8cc.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov063_0211d8cc
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
-
-
 extern "C" {
 u8 DecIfAbove0_Byte(u8* p);
 void* _ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov063_0211dbb8.c
+++ b/src/func_ov063_0211dbb8.c
@@ -1,5 +1,4 @@
-typedef long long s64;
-typedef unsigned short u16;
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 extern void Vec3_Sub(Vec3* out, Vec3* a, Vec3* b);

--- a/src/func_ov064_02115f98.c
+++ b/src/func_ov064_02115f98.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern void Vec3_Sub(int* out, int* a, int* b);
 extern int Vec3_HorzLen(int* v);

--- a/src/func_ov064_0211616c.c
+++ b/src/func_ov064_0211616c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12;
+#include "types.h"
 typedef struct { short x, y, z; } Vector3_16f;
 struct Callback {};
 extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 id, u32 param, Fix12 x, Fix12 y, Fix12 z, const Vector3_16f* pos, struct Callback* cb);

--- a/src/func_ov064_02118ee4.c
+++ b/src/func_ov064_02118ee4.c
@@ -1,7 +1,4 @@
-typedef unsigned long long u64;
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef signed char s8;
+#include "types.h"
 void *_ZN5Actor10FindWithIDEj(u32 id);
 void func_ov064_02118ee4(char *c)
 {

--- a/src/func_ov064_0211915c.c
+++ b/src/func_ov064_0211915c.c
@@ -1,9 +1,8 @@
+#include "types.h"
 // @symbol func_ov064_0211915c
 // @emits daObjFl_Coin_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjFl_Coin_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-
 extern int _ZN5Actor13DistToCPlayerEv(void *self);
 
 int daObjFl_Coin_c_Behavior(char *a)

--- a/src/func_ov064_021193b4.c
+++ b/src/func_ov064_021193b4.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 struct Vec3 { int x, y, z; };
 struct Vec3_16 { s16 x, y, z; };
 

--- a/src/func_ov064_02119afc.cpp
+++ b/src/func_ov064_02119afc.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov064_02119afc
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
 extern "C" {
 void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* t, const Vector3& v);
 void* _ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov064_02119d28.c
+++ b/src/func_ov064_02119d28.c
@@ -1,8 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
+#include "types.h"
 extern s16 data_02082214[];
 extern void func_ov064_02119afc(char* c);
 extern void _Z14ApproachLinearRiii(int* p, int a, int b);

--- a/src/func_ov065_02116364.c
+++ b/src/func_ov065_02116364.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
+#include "types.h"
 typedef struct { s32 x, y, z; } Vec3;
 
 void* _ZN5Actor22ClosestNonVanishPlayerEv(void* self);

--- a/src/func_ov065_02116364.cpp
+++ b/src/func_ov065_02116364.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov065_02116364
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
 struct V3A { int w[3]; };
 
 extern "C" {

--- a/src/func_ov065_0211696c.c
+++ b/src/func_ov065_0211696c.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
 extern void Vec3_Asr(void* d, void* s, int sh);

--- a/src/func_ov065_021180d4.c
+++ b/src/func_ov065_021180d4.c
@@ -1,13 +1,7 @@
+#include "types.h"
 // @symbol func_ov065_021180d4
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
-
 struct Actor;
 
 struct Vector3_16;

--- a/src/func_ov065_02118634.c
+++ b/src/func_ov065_02118634.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov065_02118634
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef long long s64;
-
 struct Actor;
 
 

--- a/src/func_ov065_0211a1c8.c
+++ b/src/func_ov065_0211a1c8.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov065_0211a1c8
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,10 +7,6 @@
 // @emits daObjCtMecha03_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha03_c::Behavior - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern u16 DecIfAbove0_Short(u16* p);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
 extern int RandomIntInternal(int* seed);

--- a/src/func_ov065_0211ae08.c
+++ b/src/func_ov065_0211ae08.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov065_0211ae08
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,10 +7,6 @@
 // @emits daObjCtMecha05_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha05_c::Behavior - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);

--- a/src/func_ov065_0211b40c.c
+++ b/src/func_ov065_0211b40c.c
@@ -1,8 +1,7 @@
+#include "types.h"
 // @symbol func_ov065_0211b40c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-
 void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
    void* self, void* sm, struct Matrix4x3* m, int f, int g, u32 h);
 void func_ov065_0211b40c(char* c){

--- a/src/func_ov066_0211603c.c
+++ b/src/func_ov066_0211603c.c
@@ -1,8 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef signed char s8;
-
+#include "types.h"
 enum Bool { FALSE, TRUE };
 
 extern void *_ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/func_ov066_021165cc.c
+++ b/src/func_ov066_021165cc.c
@@ -1,6 +1,4 @@
-typedef int Fix12i;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_ov066_0211ae54[];
 extern int data_ov066_0211ae3c[];
 extern int data_ov066_0211ae94[];

--- a/src/func_ov066_02118e04.c
+++ b/src/func_ov066_02118e04.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void* _ZN5Actor13ClosestPlayerEv(void* self);
 extern void func_ov066_02119454(void* c, void* p);
 extern int RandomIntInternal(int* seed);

--- a/src/func_ov071_0211f524.cpp
+++ b/src/func_ov071_0211f524.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);

--- a/src/func_ov071_0211f8d0.cpp
+++ b/src/func_ov071_0211f8d0.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov071_0211f8d0
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
-
-
 extern "C" {
 int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void* self, Vector3* a, Vector3* out, int doStore);
 void _ZN12WithMeshClsn13SetLimMovFlagEv(void* self);

--- a/src/func_ov071_02120b14.cpp
+++ b/src/func_ov071_02120b14.cpp
@@ -1,16 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov071_02120b14
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
-
 extern "C" {
     void* _ZN5Actor7FindEggER12CylinderClsn(void* self, void* c);
     void* _ZN5Actor18FindExplosionActorER12CylinderClsn(void* self, void* c);

--- a/src/func_ov071_02121b08.c
+++ b/src/func_ov071_02121b08.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12;
+#include "types.h"
 typedef struct { short x, y, z; } Vector3_16f;
 struct Foo {
     char pad[0x5c];

--- a/src/func_ov072_0211f280.c
+++ b/src/func_ov072_0211f280.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov072_0211f280
 /* recovered: shared common types */
 #include "common.h"
@@ -5,9 +6,6 @@
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov072).
  */
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 struct Actor;
 
 

--- a/src/func_ov072_02120a44.c
+++ b/src/func_ov072_02120a44.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov072_02120a44
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -6,9 +7,6 @@
 // @emits daBgSnwmn_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daBgSnwmn_c::InitResources - recovered from vtable slot identity */
-typedef signed char s8;
-typedef unsigned int u32;
-
 extern int IsStarCollectedInLevel(s8 levelID, int starID);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 param, void *pos, void *ang, int a, int b);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);

--- a/src/func_ov072_02121368.c
+++ b/src/func_ov072_02121368.c
@@ -1,14 +1,10 @@
+#include "types.h"
 // @symbol func_ov072_02121368
 // @emits daBgSnwmn_c_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daBgSnwmn_c::Kill - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
-
 extern s16 data_02082214[];
 extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
 

--- a/src/func_ov073_021200e0.c
+++ b/src/func_ov073_021200e0.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
 enum Bool { FALSE, TRUE };

--- a/src/func_ov073_021222ec.c
+++ b/src/func_ov073_021222ec.c
@@ -1,4 +1,4 @@
-typedef unsigned short u16;
+#include "types.h"
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* t);
 

--- a/src/func_ov074_0211f38c.c
+++ b/src/func_ov074_0211f38c.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov074_0211f38c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef long long s64;
-
-
 extern u16 DecIfAbove0_Short(u16* p);
 extern s16 Vec3_VertAngle(const struct Vector3* v1, const struct Vector3* v0);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, const struct Vector3* pos, const struct Vector3_16* ang, int e, int f);

--- a/src/func_ov074_0211fd74.cpp
+++ b/src/func_ov074_0211fd74.cpp
@@ -1,17 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov074_0211fd74
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern "C" {
     int func_ov074_02121a20(void* c, int idx);
     int func_ov074_021207b8(void* c);

--- a/src/func_ov074_0212087c.c
+++ b/src/func_ov074_0212087c.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
-
+#include "types.h"
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 #define LI(v) ((int)(((long long)(v))))
 

--- a/src/func_ov074_02120d74.c
+++ b/src/func_ov074_02120d74.c
@@ -1,18 +1,10 @@
+#include "types.h"
 // @symbol func_ov074_02120d74
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
 #define false 0
-
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-
-
 extern short data_02082214[];
 
 extern unsigned char DecIfAbove0_Byte(unsigned char *p);

--- a/src/func_ov074_021223bc.cpp
+++ b/src/func_ov074_021223bc.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov074_021223bc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int Fix12;
-
 struct RaycastGround { char buf0[0x14]; int floor[12]; char buf1[0x50 - 0x14 - 0x30]; };
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 struct WithMeshClsn;

--- a/src/func_ov075_02114b60.c
+++ b/src/func_ov075_02114b60.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // Copies vector triple 0 from the source entry table (+0x24, stride 0x40)
 // into the destination table (+0x20, stride 0x34), then copies triples
 // 2..count-1 with a signed-short counter and moving element pointers.
-typedef unsigned int u32;
-typedef signed short s16;
-
 typedef struct SrcTbl {
     char _pad0[0x24];
     int a, b, c;

--- a/src/func_ov075_02115134.c
+++ b/src/func_ov075_02115134.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef int s32;
-
+#include "types.h"
 extern int func_ov075_02115290(int dummy, int col);
 extern void func_ov075_021149d0(char* dst, int val);
 extern void func_02012790(int x);

--- a/src/func_ov075_0211524c.c
+++ b/src/func_ov075_0211524c.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern u8 data_0209fc50[];
 extern u8 data_0209fc64[];
 extern int data_ov075_0211b594[];

--- a/src/func_ov075_02116ad4.c
+++ b/src/func_ov075_02116ad4.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int func_0203d9b4(void);
 extern void func_0200f13c(void);
 extern void *_ZN3G2S12GetBG2ScrPtrEv(void);

--- a/src/func_ov075_02116c8c.c
+++ b/src/func_ov075_02116c8c.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void PrepareVsMode(void);
 extern void LoadLevelNoReturn(u32 levelID, u32 arg1, u32 arg2, u32 arg3);
 extern void _ZN5Sound22StopLoadedMusic_Layer1Ej(unsigned int);

--- a/src/func_ov075_021173a8.c
+++ b/src/func_ov075_021173a8.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int func_0200f0bc(void);
 extern int LoadFile(int handle);
 extern void func_ov075_02116030(void *c, int v);

--- a/src/func_ov075_02117c0c.c
+++ b/src/func_ov075_02117c0c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int data_ov075_0211d8e8;
 extern int data_ov075_0211d930;
 extern int data_ov075_0211d888;

--- a/src/func_ov075_02117fe4.c
+++ b/src/func_ov075_02117fe4.c
@@ -1,11 +1,9 @@
+#include "types.h"
 /* func_ov075_02117fe4 @ 0x02117fe4 (ov075, size 0x264)
  * Per-player two-digit counter HUD: renders tens/ones OAM digits for each
  * player, then every 3 calls toggles a blink flag and refreshes per-player
  * state.
  */
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern u8 data_0209fc50;
 extern u8 data_0209b2ec[];
 extern u8 data_0209b2f0[];

--- a/src/func_ov075_02118248.c
+++ b/src/func_ov075_02118248.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_0209fc58;
 extern int data_ov075_0211d810;
 extern int data_ov075_0211d870;

--- a/src/func_ov075_02118378.c
+++ b/src/func_ov075_02118378.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov075_02116028(int *p, int v);
 extern int LoadFile(int handle);
 extern void func_ov075_02116030(void *c, int v);

--- a/src/func_ov075_021184b0.c
+++ b/src/func_ov075_021184b0.c
@@ -1,6 +1,5 @@
 //cpp
-typedef int Fix12;
-typedef unsigned char u8;
+#include "types.h"
 struct OamAttr { unsigned short attr0, attr1, attr2, attr3; };
 extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int, OamAttr*, int, int, int, int, int, int, int, int);
 extern "C" int _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi(int, OamAttr*, int, int, int, int, int, int);

--- a/src/func_ov075_021188b4.c
+++ b/src/func_ov075_021188b4.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int func_0203da9c(void);
 extern void* _ZN3G2S12GetBG3ScrPtrEv(void);
 extern void* _ZN3G2S12GetBG0ScrPtrEv(void);

--- a/src/func_ov075_02118d1c.c
+++ b/src/func_ov075_02118d1c.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
+#include "types.h"
 extern int func_0203d974(void);
 extern u8 func_020202dc(void);
 extern u8 func_02020168(void);

--- a/src/func_ov075_02118f38.c
+++ b/src/func_ov075_02118f38.c
@@ -1,5 +1,4 @@
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_ov075_02116028(int *p, int v);
 extern int LoadFile(int handle);
 extern void func_ov075_02116030(void *c, int v);

--- a/src/func_ov075_0211919c.c
+++ b/src/func_ov075_0211919c.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
+#include "types.h"
 extern int func_0200f0bc(void);
 extern u16* _ZN3G2S12GetBG2ScrPtrEv(void);
 extern u16* _ZN3G2S12GetBG3ScrPtrEv(void);

--- a/src/func_ov075_02119918.c
+++ b/src/func_ov075_02119918.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 extern u8 data_0209d454;
 extern int data_ov075_0211d71c[];
 

--- a/src/func_ov075_0211a2b8.cpp
+++ b/src/func_ov075_0211a2b8.cpp
@@ -1,13 +1,11 @@
 //cpp
+#include "types.h"
 // @symbol func_ov075_0211a2b8
 // @emits dScEntry_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::Behavior - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern "C" {
     void func_020551f0(void *s, int v);
     int func_ov075_02119dc4(void *c, void *arg);

--- a/src/func_ov075_0211a410.cpp
+++ b/src/func_ov075_0211a410.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov075_0211a410
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,12 +8,6 @@
 // @emits dScEntry_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
 extern "C" {
     void Enable3dEngines(void);
     void func_0200f2cc(void);

--- a/src/func_ov077_02123d40.cpp
+++ b/src/func_ov077_02123d40.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);

--- a/src/func_ov077_021241ac.c
+++ b/src/func_ov077_021241ac.c
@@ -1,7 +1,4 @@
-typedef long long s64;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 extern s16 data_02082214[];
 #define LA(p) ((int)(((s64)(int)(p))))
 

--- a/src/func_ov077_021256b4.c
+++ b/src/func_ov077_021256b4.c
@@ -1,13 +1,9 @@
+#include "types.h"
 // @symbol func_ov077_021256b4
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef long long s64;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern s16 data_02082214[];
 extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3 *a, struct Vector3 *out, int doStore);
 #define LA(p) ((int)(((s64)(int)(p))))

--- a/src/func_ov078_021238ac.c
+++ b/src/func_ov078_021238ac.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-
+#include "types.h"
 struct Vec3 { int x, y, z; };
 struct M12 { int w[12]; };
 

--- a/src/func_ov078_02124470.c
+++ b/src/func_ov078_02124470.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
+#include "types.h"
 extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void* self);
 extern void ApproachAngle(void* dst, int target, int a, int b, int e);
 extern int KingBobOmb_SetState(void* c, void* p);

--- a/src/func_ov079_02123804.c
+++ b/src/func_ov079_02123804.c
@@ -1,16 +1,9 @@
+#include "types.h"
 // @symbol func_ov079_02123804
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
 extern s16 data_02082214[];
 extern int* data_ov079_021275ec[];
 

--- a/src/func_ov079_02124008.c
+++ b/src/func_ov079_02124008.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
 void Matrix4x3_ApplyInPlaceToRotationX(void*, s16);

--- a/src/func_ov079_02124638.c
+++ b/src/func_ov079_02124638.c
@@ -1,10 +1,4 @@
-typedef signed char s8;
-typedef unsigned char u8;
-typedef signed short s16;
-typedef unsigned short u16;
-typedef signed int s32;
-typedef unsigned int u32;
-typedef signed long long s64;
+#include "types.h"
 extern s16 SINE_TABLE[];
 
 void func_ov079_02124638(char* obj)

--- a/src/func_ov079_02124b08.c
+++ b/src/func_ov079_02124b08.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern void func_ov079_02124ed4(void *self);
 extern void func_ov079_02124dec(void *self);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *m, void *file, int a, int b, unsigned int u);

--- a/src/func_ov079_021256d4.c
+++ b/src/func_ov079_021256d4.c
@@ -1,7 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZN9Animation8FinishedEv(void* a);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* f, int a, int b, unsigned int c);
 extern void func_ov079_02123bcc(void* c);

--- a/src/func_ov079_021258fc.c
+++ b/src/func_ov079_021258fc.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZN9Animation8FinishedEv(void *a);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, void *bca, int a, int fix, unsigned int e);
 extern int Vec3_HorzDist(const void *a, const void *b);

--- a/src/func_ov079_02125b44.c
+++ b/src/func_ov079_02125b44.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern int _ZN9Animation8FinishedEv(void* self);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* self, void* bca, int frame, int rate, unsigned int flags);
 extern void _ZN9Animation7AdvanceEv(void* self);

--- a/src/func_ov079_0212682c.c
+++ b/src/func_ov079_0212682c.c
@@ -1,9 +1,4 @@
-
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef unsigned char u8;
+#include "types.h"
 struct Vec3
 {
   int x;


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 71 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
