### PR TITLE
readable: consolidate 70 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov080_02124088.cpp
+++ b/src/func_ov080_02124088.cpp
@@ -1,15 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov080_02124088
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
-
 #define LAUND(p) ((void*)((((long long)(int)(p)))))
 
 extern "C" {

--- a/src/func_ov080_021256f8.c
+++ b/src/func_ov080_021256f8.c
@@ -1,6 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-
+#include "types.h"
 typedef struct { int x, y, z; } Vec3;
 typedef struct { int m[12]; } Mtx;
 

--- a/src/func_ov080_02125de0.c
+++ b/src/func_ov080_02125de0.c
@@ -1,4 +1,4 @@
-typedef unsigned int u32;
+#include "types.h"
 extern void func_ov080_02125d64(char* c);
 extern char data_ov080_021277a8[];
 

--- a/src/func_ov080_02125f00.c
+++ b/src/func_ov080_02125f00.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned int u32;
+#include "types.h"
 void func_ov080_02125f00(u32* c){
   *(int*)((char*)c+0x140)=0;
   *(int*)((char*)c+0x144)=0;

--- a/src/func_ov080_02125fd0.c
+++ b/src/func_ov080_02125fd0.c
@@ -1,8 +1,5 @@
+#include "types.h"
 /* use unsigned loads / different shift form (>>8) cast s16 */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-
 extern void MulMat4x3Mat4x3(const void* m1, const void* m0, void* mF);
 extern void func_020553a4(void* m);
 extern void func_ov080_02125460(void* self);

--- a/src/func_ov080_02126124.c
+++ b/src/func_ov080_02126124.c
@@ -1,9 +1,8 @@
+#include "types.h"
 // @symbol func_ov080_02126124
 // @emits CrazedCrate_Kill
 /* recovered: renamed to Class_Method */
 /* daBttBk_c::Kill - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned int u32;
 void CrazedCrate_Kill(u32* c){
   *(int*)((char*)c+0x140)=0;
   *(int*)((char*)c+0x144)=0;

--- a/src/func_ov080_021265ec.c
+++ b/src/func_ov080_021265ec.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
+#include "types.h"
 extern void func_ov080_02126124(void* c);
 extern void func_ov080_02125de0(void* c, int a, int b, int d);
 struct Cell { int f0, f4, f8, fc, f10, f14; };

--- a/src/func_ov080_0212677c.c
+++ b/src/func_ov080_0212677c.c
@@ -1,8 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void func_ov080_02125fd0(char *c);
 extern void MulMat4x3Mat4x3(const void *a, const void *b, void *out);
 extern void func_020553a4(void *m);

--- a/src/func_ov080_02126a54.c
+++ b/src/func_ov080_02126a54.c
@@ -1,8 +1,4 @@
-
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
+#include "types.h"
 extern int __aeabi_idiv(int a, int b);
 extern void func_ov080_02126124(u32 *c);
 void func_ov080_02126a54(char *sl)

--- a/src/func_ov080_02126ca0.cpp
+++ b/src/func_ov080_02126ca0.cpp
@@ -1,4 +1,5 @@
 //cpp
+#include "types.h"
 // @symbol func_ov080_02126ca0
 /* recovered: renamed to Class_Method, RTTI class fields named, declarations from a shared header */
 #include "decl_common.h"
@@ -7,9 +8,6 @@
 // @emits daPicGate_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::InitResources - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 struct C;
 typedef void (C::*PMF)();
 struct Disp {

--- a/src/func_ov080_0212714c.c
+++ b/src/func_ov080_0212714c.c
@@ -1,7 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-
+#include "types.h"
 extern int _ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE(void *self, s16 a, s16 b, s16 c, int d);
 extern int DecIfAbove0_Byte(u8 *p);
 extern int Vec3_Dist(void *a, void *b);

--- a/src/func_ov080_0212758c.c
+++ b/src/func_ov080_0212758c.c
@@ -1,6 +1,4 @@
-typedef short s16;
-typedef unsigned short u16;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov080_0212758c(char *a0, char *a1)

--- a/src/func_ov081_021243cc.cpp
+++ b/src/func_ov081_021243cc.cpp
@@ -1,16 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov081_021243cc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
-
 extern "C" {
     void _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(void* c, void* v);
     void* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov081_02126a20.cpp
+++ b/src/func_ov081_02126a20.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov081_02126a20
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef short s16;
-
 typedef struct Mtx43 { int w[12]; } Mtx43;
 
 extern "C" void Matrix4x3_FromRotationY(void* m, int angle);

--- a/src/func_ov081_02127558.c
+++ b/src/func_ov081_02127558.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 extern int _Z15ApproachLinear2Riii(int* p, int a, int b);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* thiz, void* actor, int a, int b, unsigned int c, unsigned int d);
 extern int _ZN5Actor13DistToCPlayerEv(void* thiz);

--- a/src/func_ov084_021296cc.c
+++ b/src/func_ov084_021296cc.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol func_ov084_021296cc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
-
-
 extern void _ZN5Actor11UntrackStarERa(void *thiz, signed char *s);
 extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 a, struct Vector3 *pos, void *rot, int e, int f);
 extern void LinkSilverStarAndStarMarker(char *a, char *b);

--- a/src/func_ov084_0212abd4.c
+++ b/src/func_ov084_0212abd4.c
@@ -1,6 +1,4 @@
-
-typedef short s16;
-typedef unsigned short u16;
+#include "types.h"
 extern void func_ov084_02129cf4(void *self, int a);
 extern int _Z14ApproachLinearRiii(int *a, int b, int c);
 extern int _Z14ApproachLinearRsss(short *a, short b, short c);

--- a/src/func_ov084_0212c508.cpp
+++ b/src/func_ov084_0212c508.cpp
@@ -1,14 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov084_0212c508
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef signed char s8;
-typedef unsigned char u8;
-
 extern "C" s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
 extern "C" void func_ov084_0212c960(char *c, int i);
 extern "C" int _ZN6Player12GetTalkStateEv(char *c);

--- a/src/func_ov084_0212d2dc.c
+++ b/src/func_ov084_0212d2dc.c
@@ -1,6 +1,4 @@
-typedef int Fix12;
-typedef unsigned int u32;
-
+#include "types.h"
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f, void* g);
 extern void* _ZN8Particle6System12FromUniqueIDEj(u32 id);

--- a/src/func_ov084_0212d42c.c
+++ b/src/func_ov084_0212d42c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-
+#include "types.h"
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 unk, Fix12i x, Fix12i y, Fix12i z, void *rot, void *callback);
 

--- a/src/func_ov084_0212d564.c
+++ b/src/func_ov084_0212d564.c
@@ -1,10 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
+#include "types.h"
 #define AT(p, off) ((void*)(int)(((long long)(int)((char*)(p) + (off)))))
 
 struct Locals {

--- a/src/func_ov084_0212d564.cpp
+++ b/src/func_ov084_0212d564.cpp
@@ -1,11 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-typedef long long s64;
-
+#include "types.h"
 struct Locals {
     s16 acc[3];
     int tmp[3];

--- a/src/func_ov084_0212d86c.c
+++ b/src/func_ov084_0212d86c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 extern void func_02012694(u32 id, void *pos);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void *pos);
 extern void _ZN5Enemy9SpawnCoinEv(char *self);

--- a/src/func_ov084_0212ddbc.c
+++ b/src/func_ov084_0212ddbc.c
@@ -1,14 +1,7 @@
+#include "types.h"
 // @symbol func_ov084_0212ddbc
 /* recovered: shared common types */
 #include "common.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef signed short s16;
-typedef long long s64;
-
-
-
 extern int _Z14ApproachLinearRiii(s32 *p, int a, int b);
 extern int _ZN9Animation8FinishedEv(void *a);
 extern void func_0201267c(int a, void *p);

--- a/src/func_ov084_0212e010.cpp
+++ b/src/func_ov084_0212e010.cpp
@@ -1,9 +1,5 @@
 //cpp
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 
 extern "C" {

--- a/src/func_ov084_0212ec60.c
+++ b/src/func_ov084_0212ec60.c
@@ -1,9 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-
+#include "types.h"
 typedef struct Vec3 { int x, y, z; } Vec3;
 typedef struct Mtx43 { int w[12]; } Mtx43;
 

--- a/src/func_ov084_0212ef00.c
+++ b/src/func_ov084_0212ef00.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned int u32;
-
+#include "types.h"
 struct Actor;
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);

--- a/src/func_ov084_0212f460.c
+++ b/src/func_ov084_0212f460.c
@@ -1,8 +1,5 @@
 //cpp
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef short s16;
-
+#include "types.h"
 extern "C" {
 extern void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned, unsigned, unsigned, int, int);
 extern void *_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov084_0212f6d8.c
+++ b/src/func_ov084_0212f6d8.c
@@ -1,16 +1,10 @@
+#include "types.h"
 // @symbol func_ov084_0212f6d8
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
-
-
 extern void func_0201267c(unsigned int a, void *p);
 extern void _Z14ApproachLinearRsss(s16 *val, s16 target, s16 step);
 extern int _ZN9Animation8FinishedEv(void *anim);

--- a/src/func_ov085_0212b4b4.c
+++ b/src/func_ov085_0212b4b4.c
@@ -1,15 +1,10 @@
+#include "types.h"
 // @symbol func_ov085_0212b4b4
 // @emits PrincessPeach_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daPeach_c::Kill - recovered from vtable slot identity */
-
-typedef int s32;
-typedef short s16;
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef unsigned char u8;
 extern void *_ZN5Actor13ClosestPlayerEv(void *self);
 extern s32 Vec3_Dist(const Vector3 *a, const Vector3 *b);
 extern void func_ov085_0212bc78(void *c, void *p);

--- a/src/func_ov085_0212d038.c
+++ b/src/func_ov085_0212d038.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void func_02013868(int t, int x);
 extern void _ZN6Player17SetNoControlStateEhih(void* p, u8 a, int b, u8 c);
 extern int data_0209caa0[];

--- a/src/func_ov085_0212de5c.cpp
+++ b/src/func_ov085_0212de5c.cpp
@@ -1,7 +1,5 @@
 //cpp
-typedef int Fix12;
-typedef unsigned int u32;
-
+#include "types.h"
 struct PMF;
 struct Player;
 struct Actor {

--- a/src/func_ov085_0212e19c.c
+++ b/src/func_ov085_0212e19c.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov085_0212e19c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
-
 extern s16 _ZN5Actor18HorzAngleToCPlayerEv(void* c);
 extern void _Z14ApproachLinearRsss(s16* p, s16 a, s16 b);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* self, void* ab, unsigned int id, const struct Vector3* v, unsigned int a, unsigned int b);

--- a/src/func_ov085_0212e858.c
+++ b/src/func_ov085_0212e858.c
@@ -1,12 +1,7 @@
+#include "types.h"
 // @symbol func_ov085_0212e858
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-
-
-
-
 extern void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);
 extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 extern void Matrix4x3_ApplyInPlaceToRotationXYZExt(void *m, int x, int y, int z);

--- a/src/func_ov089_021311c0.c
+++ b/src/func_ov089_021311c0.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov089_021311c0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 #define L(p) ((long long)(int)(p))
 
 

--- a/src/func_ov089_0213162c.c
+++ b/src/func_ov089_0213162c.c
@@ -1,12 +1,9 @@
+#include "types.h"
 // @symbol func_ov089_0213162c
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
 #define L(p) ((long long)(int)(p))
 
 

--- a/src/func_ov089_02131b18.c
+++ b/src/func_ov089_02131b18.c
@@ -1,9 +1,7 @@
+#include "types.h"
 // @symbol func_ov089_02131b18
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 #define L(p) ((long long)(int)(p))
 
 

--- a/src/func_ov090_02133200.c
+++ b/src/func_ov090_02133200.c
@@ -1,14 +1,10 @@
+#include "types.h"
 // @symbol func_ov090_02133200
 // @emits MantaRay_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daManta_c::Kill - recovered from vtable slot identity */
-typedef unsigned int u32;
-typedef unsigned short u16;
-typedef short s16;
-typedef int s32;
-
 extern s32 Vec3_Dist(void* a, void* b);
 extern s16 Vec3_HorzAngle(void* a, void* b);
 extern int ApproachAngle(s16* angle, int target, int invFactor, int maxDelta, int minDelta);

--- a/src/func_ov091_02131160.c
+++ b/src/func_ov091_02131160.c
@@ -1,7 +1,4 @@
-typedef signed short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern void Matrix4x3_FromRotationY(void *m, s16 ang);
 extern int _ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j(void *self, void *sm, void *mtx, int a, int b, int d, unsigned int e);
 extern s16 data_02082214[];

--- a/src/func_ov091_02133d30.cpp
+++ b/src/func_ov091_02133d30.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov091_02133d30
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned short u16;
-typedef signed char s8;
-
 #define AT(p,off) ((void*)(int)(((long long)(int)((char*)(p)+(off)))))
 
 extern "C" {

--- a/src/func_ov092_021313b0.cpp
+++ b/src/func_ov092_021313b0.cpp
@@ -1,11 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov092_021313b0
 /* recovered: shared common types */
 #include "common.h"
-
-typedef unsigned short u16;
-typedef short s16;
-
 #define LA(p) (((long long)(int)(p)))
 
 struct PathPtr {

--- a/src/func_ov092_021316d8.c
+++ b/src/func_ov092_021316d8.c
@@ -1,7 +1,4 @@
-typedef signed char s8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
+#include "types.h"
 #define LA(p) (((long long)(int)(p)))
 extern s16 data_02082214[];
 extern s8 data_ov092_0213208c[];

--- a/src/func_ov094_021358b4.cpp
+++ b/src/func_ov094_021358b4.cpp
@@ -1,10 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov094_021358b4
 /* recovered: shared common types */
 #include "common.h"
-
-typedef int Fix12;
-typedef unsigned char u8;
 extern "C" {
 extern void ApproachLinear(struct Vector3 *a, const struct Vector3 *b, Fix12 f);
 extern int func_ov094_02136188(void *c, void *p);

--- a/src/func_ov094_02135c28.c
+++ b/src/func_ov094_02135c28.c
@@ -1,8 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-
+#include "types.h"
 extern int _ZN5Actor13ClosestPlayerEv(void* thiz);
 extern int _ZN6Player9StartTalkER9ActorBaseb(void* thiz, void* ab, int b);
 extern int _ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj(void* thiz, void* ab, u32 a, const void* v, u32 c, u32 d);

--- a/src/func_ov095_021357d8.c
+++ b/src/func_ov095_021357d8.c
@@ -1,3 +1,4 @@
+#include "types.h"
 // @symbol func_ov095_021357d8
 // @emits SeesawBob_OnGroundPounded
 /* recovered: renamed to Class_Method, declarations from a shared header */
@@ -5,10 +6,6 @@
 /* recovered: renamed to Class_Method */
 /* daObjSeesaw_c::OnGroundPounded - recovered from vtable slot identity */
 #pragma opt_propagation off
-
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
 extern int Vec3_Dist(void *a, void *b);
 extern s16 Vec3_HorzAngle(void *a, void *b);
 extern s16 data_02082214[];

--- a/src/func_ov095_02136368.c
+++ b/src/func_ov095_02136368.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
-
+#include "types.h"
 void func_ov095_02136368(char* c)
 {
     if (*(u8*)(c + 0x346) == 0) {

--- a/src/func_ov096_02135efc.cpp
+++ b/src/func_ov096_02135efc.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov096_02135efc
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef short s16;
-typedef int Fix12i;
-
-
 struct Mtx43 { Fix12i a[12]; };
 
 extern "C" void Vec3_Asr(struct Vector3* d, struct Vector3* s, int sh);

--- a/src/func_ov096_02136264.c
+++ b/src/func_ov096_02136264.c
@@ -1,7 +1,4 @@
-
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
+#include "types.h"
 extern s16 data_02082214[];
 extern void func_ov096_02136928(char* c, int n);
 extern void func_ov096_02135948(char* c);

--- a/src/func_ov096_0213670c.c
+++ b/src/func_ov096_0213670c.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef int s32;
+#include "types.h"
 extern void *func_ov096_021357b4(void *c);
 void func_ov096_0213670c(void *c) {
     s32 r4 = (s32)c;

--- a/src/func_ov096_02136754.c
+++ b/src/func_ov096_02136754.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef short s16;
-typedef long long s64;
+#include "types.h"
 extern s16 data_02082214[];
 extern void func_ov096_02136928(char* c, int n);
 extern void func_ov096_02135948(char* c);

--- a/src/func_ov096_02136e54.c
+++ b/src/func_ov096_02136e54.c
@@ -1,7 +1,4 @@
-typedef int s32;
-typedef unsigned short u16;
-typedef signed short s16;
-
+#include "types.h"
 extern s16 data_02082214[];
 
 void func_ov096_02136e54(void* c, int a)

--- a/src/func_ov098_02138818.c
+++ b/src/func_ov098_02138818.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 struct W4 { u32 w[4]; };
 
 extern struct W4 data_ov098_0213c4e0;

--- a/src/func_ov098_02138e6c.cpp
+++ b/src/func_ov098_02138e6c.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov098_02138e6c
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
 struct Base {
     virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3();
     virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();

--- a/src/func_ov098_021390ec.cpp
+++ b/src/func_ov098_021390ec.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov098_021390ec
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned int u32;
-
-
 struct ClsnResult { int GetClsnID() const; };
 struct SurfaceInfo { void CopyNormalTo(Vector3 &) const; };
 struct WithMeshClsn {

--- a/src/func_ov098_02139228.cpp
+++ b/src/func_ov098_02139228.cpp
@@ -1,18 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov098_02139228
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef int s32;
-typedef unsigned int u32;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-typedef long long s64;
-
-
-
 struct C {
     virtual void v00(); virtual void v01(); virtual void v02(); virtual void v03();
     virtual void v04(); virtual void v05(); virtual void v06(); virtual void v07();

--- a/src/func_ov098_02139850.c
+++ b/src/func_ov098_02139850.c
@@ -1,18 +1,9 @@
+#include "types.h"
 // @symbol func_ov098_02139850
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef signed char s8;
-typedef unsigned char u8;
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
-
-
 extern int func_ov002_020e496c(char* c);
 extern int _ZN6Player14IsFrontSlidingEv(char* p);
 extern int _ZN6Player17LostGrabbedObjectEv(char* p);

--- a/src/func_ov098_0213a36c.cpp
+++ b/src/func_ov098_0213a36c.cpp
@@ -1,10 +1,7 @@
 //cpp
+#include "types.h"
 // func_ov098_0213a36c at 0x0213a36c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 struct CylinderClsn;
 
 struct Actor {

--- a/src/func_ov098_0213a984.c
+++ b/src/func_ov098_0213a984.c
@@ -1,11 +1,7 @@
+#include "types.h"
 // @symbol func_ov098_0213a984
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
-
-
 extern void Matrix4x3_FromTranslation(struct Matrix4x3* m, int x, int y, int z);
 extern s16 data_02082214[];
 

--- a/src/func_ov098_0213ad08.c
+++ b/src/func_ov098_0213ad08.c
@@ -1,5 +1,4 @@
-typedef unsigned char u8;
-typedef unsigned short u16;
+#include "types.h"
 enum { false, true };
 extern char* _ZN5Actor10FindWithIDEj(unsigned int id);
 extern void func_ov102_0214ae1c(char* a);

--- a/src/func_ov098_0213b7e8.c
+++ b/src/func_ov098_0213b7e8.c
@@ -1,10 +1,8 @@
+#include "types.h"
 // @symbol func_ov098_0213b7e8
 // @emits Cannon_Kill
 /* recovered: renamed to Class_Method */
 /* daCnn_c::Kill - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef unsigned short u16;
-
 extern int _Z14ApproachLinearRiii(int *v, int step, int rate);
 extern void func_ov098_0213b63c(char *c);
 extern int _ZN4cstd4fdivEii(int a, int b);

--- a/src/func_ov098_0213b9d8.cpp
+++ b/src/func_ov098_0213b9d8.cpp
@@ -1,12 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov098_0213b9d8
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef int s32;
-typedef unsigned int u32;
-typedef unsigned short u16;
-
 struct Vector3_16;
 struct Actor;
 extern "C" Actor *_ZN5Actor13ClosestPlayerEv(void);

--- a/src/func_ov100_02140e44.cpp
+++ b/src/func_ov100_02140e44.cpp
@@ -1,13 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov100_02140e44
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef long long s64;
-
-
-
 extern "C" {
 void _Z14ApproachLinearRiii(int* p, int a, int b);
 void* _ZN5Actor13ClosestPlayerEv(void* self);

--- a/src/func_ov100_021412d8.c
+++ b/src/func_ov100_021412d8.c
@@ -1,14 +1,7 @@
+#include "types.h"
 // @symbol func_ov100_021412d8
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef signed char s8;
-
-
-
-
 extern int _ZN5Actor13DistToCPlayerEv(void* self);
 extern unsigned int RandomIntInternal(void* g);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, const struct Vector3* pos, const struct Vector3_16* rot, int e, int f);

--- a/src/func_ov100_02141fb0.cpp
+++ b/src/func_ov100_02141fb0.cpp
@@ -1,16 +1,10 @@
 //cpp
+#include "types.h"
 // @symbol func_ov100_02141fb0
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-
-
-
-
 struct Obj {
     virtual u32 v00(); virtual u32 v01(); virtual u32 v02(); virtual u32 v03();
     virtual u32 v04(); virtual u32 v05(); virtual u32 v06(); virtual u32 v07();

--- a/src/func_ov100_021424c0.c
+++ b/src/func_ov100_021424c0.c
@@ -1,13 +1,9 @@
+#include "types.h"
 /* func_ov100_021424c0 @ 0x021424c0 (ov100, size 0x26c)
  * Bob-omb buddy/enemy walk update: handles yoshi-eat (poof on eaten),
  * steering toward the current target angle, water/ground handling with
  * landing dust and rolling sound, speed cap 0x23000, and collision update.
  */
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned char u8;
-typedef unsigned int u32;
-
 extern void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(char *, char *);
 extern int func_ov002_020ad660(char *, char *, char *, int);
 extern int _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int, int, int, int);

--- a/src/func_ov100_02142918.cpp
+++ b/src/func_ov100_02142918.cpp
@@ -1,12 +1,9 @@
 //cpp
+#include "types.h"
 // @symbol func_ov100_02142918
 // @emits Butterfly_Kill
 /* recovered: renamed to Class_Method */
 /* daBtfly_c::Kill - recovered from vtable slot identity */
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
 extern "C" {
 void _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(void* self, void* c);
 int func_020ad660(void* a, void* b, void* d, int e);

--- a/src/func_ov100_02142b90.c
+++ b/src/func_ov100_02142b90.c
@@ -1,14 +1,7 @@
+#include "types.h"
 // @symbol func_ov100_02142b90
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
-
 extern signed char data_0209f2f8;
 extern void* _ZN5Actor13ClosestPlayerEv(void* c);
 extern int Vec3_HorzDist(const struct Vector3* a, const struct Vector3* b);

--- a/src/func_ov100_021435e8.cpp
+++ b/src/func_ov100_021435e8.cpp
@@ -1,14 +1,8 @@
 //cpp
+#include "types.h"
 // @symbol func_ov100_021435e8
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef short s16;
-typedef unsigned int u32;
-typedef int s32;
-
-
 struct Vector3_16;
 
 extern "C" {

--- a/src/func_ov100_021446f8.c
+++ b/src/func_ov100_021446f8.c
@@ -1,4 +1,4 @@
-typedef unsigned char u8;
+#include "types.h"
 extern void _ZN6Player11OpenBigDoorEv(void *player);
 extern void func_ov100_02144950(void *a, void *b, int c);
 void func_ov100_021446f8(void *r0, void *r1) {

--- a/src/func_ov100_02144730.cpp
+++ b/src/func_ov100_02144730.cpp
@@ -1,8 +1,5 @@
 //cpp
-typedef short s16;
-typedef unsigned short u16;
-typedef signed char s8;
-
+#include "types.h"
 extern "C" {
 void _ZN9Animation7AdvanceEv(void* self);
 int _ZNK9Animation13GetFrameCountEv(void* self);


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 70 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
