### PR TITLE
readable: consolidate 11 files onto shared types.h (byte-verified)

### DIFF
--- a/src/func_ov100_02144a38.c
+++ b/src/func_ov100_02144a38.c
@@ -1,18 +1,9 @@
+#include "types.h"
 // @symbol func_ov100_02144a38
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef unsigned int u32;
-typedef int s32;
-typedef int Fix12i;
-typedef short s16;
-typedef unsigned char u8;
-typedef signed char s8;
-
-
-
-
 extern void func_020072c0(void);
 extern char data_ov100_02148204[];
 

--- a/src/func_ov100_02146828.c
+++ b/src/func_ov100_02146828.c
@@ -1,15 +1,9 @@
+#include "types.h"
 // @symbol func_ov100_02146828
 /* recovered: shared common types, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-typedef unsigned char u8;
-
-
-
-
 extern int data_0209caa0[];
 extern int data_0209f32c[];
 extern int data_0209e650;

--- a/src/func_ov102_021492d4.c
+++ b/src/func_ov102_021492d4.c
@@ -1,10 +1,7 @@
+#include "types.h"
 // @symbol func_ov102_021492d4
 /* recovered: shared common types */
 #include "common.h"
-typedef short s16;
-typedef unsigned short u16;
-
-
 extern void func_ov102_02149684(int* dst, int* src);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int id, unsigned int p, const struct Vector3* pos, const struct Vector3_16* rot, int a, int b);
 extern char data_020a0edc[];

--- a/src/func_ov102_021496a4.c
+++ b/src/func_ov102_021496a4.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov102_021496a4
 // @emits QuestionBlock_OnHitFromUnderneath
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnHitFromUnderneath - recovered from vtable slot identity */
-typedef unsigned char u8;
-typedef short s16;
 void QuestionBlock_OnHitFromUnderneath(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     *(int *)((char *)c + 0x9c) = -0x8000;

--- a/src/func_ov102_02149770.c
+++ b/src/func_ov102_02149770.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov102_02149770
 // @emits QuestionBlock_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnKicked - recovered from vtable slot identity */
-
-typedef unsigned char u8;
 void QuestionBlock_OnKicked(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);

--- a/src/func_ov102_02149820.c
+++ b/src/func_ov102_02149820.c
@@ -1,11 +1,10 @@
+#include "types.h"
 // @symbol func_ov102_02149820
 // @emits QuestionBlock_OnGroundPounded
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnGroundPounded - recovered from vtable slot identity */
-
-typedef unsigned char u8;
 void QuestionBlock_OnGroundPounded(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);

--- a/src/func_ov102_02149c78.c
+++ b/src/func_ov102_02149c78.c
@@ -1,5 +1,4 @@
-typedef int s32;
-typedef unsigned short u16;
+#include "types.h"
 extern void _ZN5Actor10EarthquakeERK7Vector35Fix12IiE(void *, void *, s32);
 void func_ov102_02149c78(void *c)
 {

--- a/src/func_ov102_0214ab1c.c
+++ b/src/func_ov102_0214ab1c.c
@@ -1,6 +1,4 @@
-typedef unsigned short u16;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int _ZN5Enemy14UpdateYoshiEatER12WithMeshClsn(void *self, void *clsn);
 extern int _ZN6Player16IsInsideOfCannonEv(void *player);
 extern int _ZN6Player22IsBeingShotOutOfCannonEv(void *player);

--- a/src/func_ov102_0214baa0.c
+++ b/src/func_ov102_0214baa0.c
@@ -1,6 +1,4 @@
-typedef unsigned char u8;
-typedef short s16;
-
+#include "types.h"
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
 extern void _ZN12CylinderClsn5ClearEv(void *self);
 extern void func_0203568c(int *value, int target);

--- a/src/func_ov102_0214c84c.c
+++ b/src/func_ov102_0214c84c.c
@@ -1,7 +1,4 @@
-typedef unsigned int u32;
-typedef int Fix12i;
-typedef unsigned char u8;
-
+#include "types.h"
 extern int data_ov102_0214ea48[];
 
 extern void _ZN13RaycastGroundC1Ev(void *self);

--- a/src/nds_printf.c
+++ b/src/nds_printf.c
@@ -1,5 +1,4 @@
-typedef unsigned int u32;
-
+#include "types.h"
 extern void func_0201473c(void *arg0, u32 fmtAddr, u32 val);
 
 void nds_printf(void *arg0, u32 fmt, ...)


### PR DESCRIPTION
Replaces inline fixed-width typedef re-declarations (u16/u32/s32/...) with #include "types.h" in 11 files. Byte-neutral (typedefs do not affect codegen); verified byte-for-byte. Addresses the duplicate-typedef item from the quality review: ~1800 files independently re-declared the same scalar types instead of sharing the header.
