### PR TITLE
credit: pair a same-commit .c->.cpp replacement as a rename (restores 85 misattributed matches); add sweep tools

### DIFF
--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -105,20 +105,57 @@ def first_matchers() -> dict[str, str]:
         cwd=REPO, capture_output=True, text=True, encoding="utf-8", errors="replace").stdout
     origin: dict[str, str] = {}   # live path -> author of the earliest add in its lineage
     handle = None
+    adds: list[str] = []
+    dels: list[str] = []
+
+    def flush(who):
+        """Apply one commit's adds/deletes, pairing a same-stem delete+add as a rename.
+
+        Promoting a matched function to a real C++ method changes its extension
+        (src/F.c -> src/F.cpp) and rewrites enough of the body that git's similarity
+        check falls under the rename threshold, so it arrives here as delete+add. That
+        is still the SAME function, so ending the lineage would hand the original
+        matcher's credit to whoever did the promotion (it moved 85 matches off five
+        contributors before this pairing existed). Pairing is deliberately limited to a
+        delete and an add of the same stem IN ONE COMMIT, which cannot be confused with
+        the false-match case the delete rule exists for: that is a delete in one commit
+        and a corrected add in a later one.
+        """
+        by_stem = {d.rsplit(".", 1)[0]: d for d in dels}
+        paired = set()
+        for new in adds:
+            old = by_stem.get(new.rsplit(".", 1)[0])
+            if old is not None and old != new:
+                origin[new] = origin.pop(old, who)   # same function, new extension
+                paired.add(old)
+                paired.add(new)
+        for a in adds:
+            if a not in paired:
+                origin.setdefault(a, who)
+        for d in dels:
+            if d not in paired:
+                origin.pop(d, None)
+        adds.clear()
+        dels.clear()
+
     for line in out.splitlines():
         if line.startswith("\x01"):
+            if handle:
+                flush(handle)
             name, _, email = line[1:].partition("\x02")
             handle = _handle_from(name, email)
         elif handle and line and line[0] in "ADR":
             parts = line.split("\t")
             code = parts[0]
             if code.startswith("A") and len(parts) >= 2:
-                origin.setdefault(parts[1].strip(), handle)
+                adds.append(parts[1].strip())
             elif code.startswith("D") and len(parts) >= 2:
-                origin.pop(parts[1].strip(), None)
+                dels.append(parts[1].strip())
             elif code.startswith("R") and len(parts) >= 3:
                 old, new = parts[1].strip(), parts[2].strip()
                 origin[new] = origin.pop(old, handle)  # carry the matcher's credit forward
+    if handle:
+        flush(handle)
     return origin
 
 

--- a/tools/name_evidence.py
+++ b/tools/name_evidence.py
@@ -1,0 +1,129 @@
+"""Naming-pass evidence gatherer.
+
+For an unnamed ``func_<addr>``, collect the material a human (or an LLM) needs to
+propose a real name: the function's own decompiled source, the functions it calls
+(callees -- especially the ones already NAMED, which pin behavior), and its call
+sites (callers, with a few lines of context each). Also scores every unnamed
+function so the worklist can lead with the well-constrained ones.
+
+This does not propose names -- it assembles evidence. Naming stays a human-reviewed
+judgement; a wrong name is worse than none.
+
+Usage:
+  python tools/name_evidence.py --worklist --top 40      # ranked candidates
+  python tools/name_evidence.py --func func_020ce6a0     # evidence for one
+  python tools/name_evidence.py --evidence-for a.txt --json out.json   # batch
+"""
+import argparse, json, pathlib, re, subprocess, sys
+from collections import Counter
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+FUNC_RE = re.compile(r"\bfunc_(?:ov\d+_)?[0-9a-fA-F]{6,8}\b")
+NAMED_CALL_RE = re.compile(r"\b(_ZN[0-9A-Za-z_]+|[A-Z][A-Za-z0-9_]*::[A-Za-z0-9_]+|[A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def src_path(sym):
+    for ext in (".c", ".cpp"):
+        p = SRC / f"{sym}{ext}"
+        if p.exists():
+            return p
+    return None
+
+
+def callers(sym):
+    """Files that reference sym, excluding its own definition file."""
+    out = subprocess.run(["git", "grep", "-l", "-F", sym, "--", "src/"],
+                         cwd=REPO, capture_output=True, text=True).stdout
+    return [l for l in out.splitlines() if l.strip() and not l.startswith(f"src/{sym}.")]
+
+
+def named_callees(text):
+    """Named (non-func_<addr>) symbols this source calls -- the behavior anchors."""
+    calls = set()
+    for m in NAMED_CALL_RE.finditer(text):
+        n = m.group(1)
+        if n.startswith(("if", "for", "while", "switch", "return", "sizeof")):
+            continue
+        if FUNC_RE.fullmatch(n):
+            continue
+        if n.startswith(("_ZN", "_ZL")) or "::" in n or n[0].isupper():
+            calls.add(n)
+    return sorted(calls)
+
+
+def evidence(sym):
+    p = src_path(sym)
+    if not p:
+        return {"func": sym, "error": "no src file"}
+    text = p.read_text(errors="ignore")
+    cs = callers(sym)
+    # a couple call-site context lines from up to 3 callers
+    ctx = []
+    for cf in cs[:3]:
+        try:
+            lines = (REPO / cf).read_text(errors="ignore").splitlines()
+        except OSError:
+            continue
+        for i, ln in enumerate(lines):
+            if sym in ln:
+                ctx.append({"file": cf, "line": ln.strip()[:200]})
+                break
+    return {
+        "func": sym,
+        "src": str(p.relative_to(REPO)),
+        "size_lines": text.count("\n") + 1,
+        "source": text,
+        "named_callees": named_callees(text),
+        "n_callers": len(cs),
+        "call_sites": ctx,
+    }
+
+
+def score(sym):
+    """Higher = better first target: many callers + calls named functions + small."""
+    p = src_path(sym)
+    if not p:
+        return -1, {}
+    text = p.read_text(errors="ignore")
+    nc = len(callers(sym))
+    anchors = len(named_callees(text))
+    lines = text.count("\n") + 1
+    s = nc * 2 + anchors * 3 - max(0, lines - 60) // 20
+    return s, {"n_callers": nc, "named_callees": anchors, "lines": lines}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--worklist", action="store_true")
+    ap.add_argument("--top", type=int, default=40)
+    ap.add_argument("--func")
+    ap.add_argument("--evidence-for", help="file with one func_<addr> per line")
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    if args.func:
+        print(json.dumps(evidence(args.func), indent=2))
+        return
+    if args.evidence_for:
+        syms = [l.strip() for l in open(args.evidence_for) if l.strip()]
+        out = [evidence(s) for s in syms]
+        (open(args.json, "w") if args.json else sys.stdout).write(json.dumps(out, indent=2))
+        return
+    if args.worklist:
+        syms = sorted(set(m.group(0) for f in SRC.glob("*")
+                          for m in [FUNC_RE.fullmatch(f.stem)] if m))
+        scored = []
+        for s in syms:
+            sc, meta = score(s)
+            if sc >= 0:
+                scored.append((sc, s, meta))
+        scored.sort(reverse=True)
+        for sc, s, meta in scored[:args.top]:
+            print(f"{sc:4}  {s:28} callers={meta['n_callers']:3} anchors={meta['named_callees']:2} lines={meta['lines']}")
+        if args.json:
+            json.dump([{"func": s, "score": sc, **meta} for sc, s, meta in scored], open(args.json, "w"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pgate.py
+++ b/tools/pgate.py
@@ -1,0 +1,97 @@
+"""Parallel link-gate: the same per-file verdict prepush_linkcheck.py produces, but
+across a thread pool instead of one file at a time.
+
+WHY THIS EXISTS
+---------------
+prepush_linkcheck.py resolves and link-checks each file serially. That is fine for the
+handful of files a normal match PR touches, but a readability sweep changes 100-200 files
+at once, and the serial walk then dominates the batch (about 8s for 15 files, so several
+minutes for a full batch on a 12-core box). Running the same linkcheck subprocesses
+concurrently cuts that by roughly 4-5x with identical verdicts -- checked file-for-file
+against prepush_linkcheck.py before this was used to gate anything.
+
+It is a speed tool, not a different check: symbol resolution and the verdict come from
+the same stamp_provenance/linkcheck path prepush_linkcheck uses. Use prepush_linkcheck.py
+for a normal PR; use this when a sweep makes the serial cost the bottleneck.
+
+Verdicts are the linkcheck ones (VERIFIED / BLIND-n / WRONG / NO-REPRO / NO-SYM / ...);
+see tools/linkcheck.py. WRONG and NO-REPRO are false matches and must block a push.
+
+Usage:
+  python tools/pgate.py --out gate.json --jobs 10 src/a.c src/b.cpp ...
+"""
+import argparse
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def load_symbol_fn():
+    """The (module, addr, size) resolver prepush_linkcheck.py uses."""
+    spec = importlib.util.spec_from_file_location("_sp", REPO / "tools" / "stamp_provenance.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.load_symbol
+
+
+def run_linkcheck(module, name, addr, size):
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "tools" / "linkcheck.py"),
+         "--module", module, "--name", name, "--addr", hex(addr), "--size", hex(size)],
+        cwd=REPO, capture_output=True, text=True)
+    try:
+        start = proc.stdout.find("{")
+        if start != -1:
+            rec, _ = json.JSONDecoder().raw_decode(proc.stdout[start:])
+            return rec.get("verdict", "ERROR"), rec.get("blind", 0)
+    except (ValueError, TypeError):
+        pass
+    return "ERROR", 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Link-verify many src files in parallel")
+    ap.add_argument("--out", required=True, help="write the JSON verdict list here")
+    ap.add_argument("--jobs", type=int, default=10)
+    ap.add_argument("files", nargs="+")
+    args = ap.parse_args()
+    load_symbol = load_symbol_fn()
+
+    jobs, rows = [], []
+    for f in args.files:
+        name = pathlib.Path(f).stem
+        sym = load_symbol(name)
+        if not sym:
+            rows.append({"file": f, "name": name, "verdict": "NO-SYM"})
+        else:
+            jobs.append((f, name, sym))
+
+    def work(job):
+        f, name, (module, addr, size) = job
+        verdict, blind = run_linkcheck(module, name, addr, size)
+        if verdict == "ERROR":  # one retry: ERROR is usually a flaky compile, not a bad file
+            verdict, blind = run_linkcheck(module, name, addr, size)
+        return {"file": f, "name": name, "module": module, "addr": hex(addr),
+                "verdict": verdict, "blind": blind}
+
+    with ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        rows.extend(ex.map(work, jobs))
+
+    json.dump(rows, open(args.out, "w"))
+    tally = Counter(r["verdict"] if not str(r["verdict"]).startswith("BLIND") else "BLIND" for r in rows)
+    print("pgate:", dict(tally))
+    bad = [r["file"] for r in rows if r["verdict"] in ("WRONG", "NO-REPRO")]
+    if bad:
+        print("FALSE MATCHES (must not be pushed):", *bad, sep="\n  ")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/typedef_transform.py
+++ b/tools/typedef_transform.py
@@ -1,0 +1,22 @@
+"""Replace inline fixed-width scalar typedefs (the ones include/types.h provides) with
+a single #include "types.h". Byte-neutral; the gate reverts anything that doesn't match.
+Usage: python typedef_transform.py <worktree> <slice-file>
+"""
+import re, sys
+
+WT, SLICE = sys.argv[1], sys.argv[2]
+PROV = r'(u8|u16|u32|s8|s16|s32|u64|s64|Fix12|Fix12i|f32|f64|vu8|vs8|vu16|vs16|vu32|vs32|OnYoshiEatReturnVal|bool)'
+TD = re.compile(r'^\s*typedef\s+[^;]*\b' + PROV + r'\s*;\s*$', re.M)
+
+for f in [l.strip() for l in open(SLICE) if l.strip()]:
+    p = f"{WT}/{f}"
+    t = open(p, encoding="utf8", errors="ignore").read()
+    if '#include "types.h"' in t:
+        continue
+    marked = TD.sub("__DROP__", t)
+    if "__DROP__" not in marked:
+        continue
+    lines = [l for l in marked.split("\n") if l.strip() != "__DROP__"]
+    ins = 1 if lines and lines[0].strip() == "//cpp" else 0
+    lines.insert(ins, '#include "types.h"')
+    open(p, "w", encoding="utf8").write("\n".join(lines))


### PR DESCRIPTION
## The bug

`first_matchers()` follows git's add/delete/rename classification. Promoting a matched function to a real C++ method (#883/#884/#885) changes its extension **and** rewrites enough of the body that git's similarity check falls under the rename threshold, so those files arrived as **delete + add**. Per the delete rule the lineage ended, and the add re-credited the function to whoever ran the promotion.

Measured effect on `contributions.json`: **85 matches moved off five contributors** onto the promoter.

| contributor | before | after the promotion |
|---|---|---|
| lunavyqo | 419 | 381 |
| andrewboudreau | 856 | 838 |
| ruspecial | 891 | 875 |
| lplaat | 62 | 50 |
| aitddlabs | 53 | 52 |

## The fix

Pair a delete and an add of the **same stem within one commit** as a rename, so credit carries. This is deliberately narrow and leaves the false-match rule intact: that case is a delete in one commit and a corrected add in a *later* one, which is still treated as a new lineage.

Recomputed with the fix: lplaat and aitddlabs return to their exact pre-promotion counts, andrewboudreau returns to 857 (856 + 1 genuinely new). The remaining movement between lunavyqo/ruspecial and andrewboudreau comes from andrew's own PRs in the same window, not from the promotion.

## Also included

The tools the readability sweeps used, since they are reusable:

- `pgate.py` — parallel link-gate; same verdicts as `prepush_linkcheck.py` (verified file-for-file) at ~4-5x the speed, which matters when a sweep changes 100-200 files
- `name_evidence.py` — assembles source, named callees and call sites for naming a `func_<addr>`; gathers evidence, does not propose names
- `typedef_transform.py` — swaps inline scalar typedefs for `#include "types.h"`

Tools-only PR, no `src/` changes.