### PR TITLE
types: use Fix12i in the 44 files that relied on the shared Fix12 (unblocks #865)

### DIFF
--- a/src/_ZN10LavaBubble8BehaviorEv.cpp
+++ b/src/_ZN10LavaBubble8BehaviorEv.cpp
@@ -9,7 +9,7 @@ struct CylinderClsn;
 struct WithMeshClsn;
 
 extern "C" {
-int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void* self, Fix12 d);
+int _ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE(void* self, Fix12i d);
 void _ZN9ActorBase18MarkForDestructionEv(void* self);
 unsigned short DecIfAbove0_Short(unsigned short* p);
 void* _ZN5Actor10FindWithIDEj(unsigned int id);

--- a/src/_ZN11RollingRock13InitResourcesEv.cpp
+++ b/src/_ZN11RollingRock13InitResourcesEv.cpp
@@ -13,7 +13,7 @@ extern "C" {
     void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* w, void* a, int r, int rr, void* v, void* vv);
     void _ZN12WithMeshClsn13SetLimMovFlagEv(void* w);
     void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* c, void* a, void* pos, int r, int rr, u32 e, u32 f);
-    // r0=this, r1=actor, r2=&pos, r3=r(Fix12), [sp]=rr, [sp+4]=e, [sp+8]=f
+    // r0=this, r1=actor, r2=&pos, r3=r(Fix12i), [sp]=rr, [sp+4]=e, [sp+8]=f
     u8 _ZN5Actor9TrackStarEjj(void* a, u32 x, u32 y);
 }
 

--- a/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
+++ b/src/_ZN17SlidingPlatformWf8BehaviorEv.cpp
@@ -9,7 +9,7 @@ extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(char* c, void* cc);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(char* c);
-extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12 a, Fix12 b);
+extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12i a, Fix12i b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 
 int SlidingPlatformWf::Behavior()

--- a/src/_ZN6Bowser8BehaviorEv.cpp
+++ b/src/_ZN6Bowser8BehaviorEv.cpp
@@ -23,7 +23,7 @@ void MovingCylinderClsnWithPos::SetPosRelativeToActor(const Vector3&);
 extern "C" {
 extern int RandomIntInternal(int* seed);
 extern s16 Vec3_HorzAngle(const Vector3* a, const Vector3* b);
-extern Fix12 Vec3_HorzDist(const Vector3* a, const Vector3* b);
+extern Fix12i Vec3_HorzDist(const Vector3* a, const Vector3* b);
 extern int data_0209e650;
 extern char* data_0209f318;
 }

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -10,13 +10,13 @@ extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void* self, void* f, int a, int b
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void* f);
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* anim, void* file, int b, int fix, unsigned int e);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void* f);
-extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, void* kcl, void* mtx, Fix12 r, short s, void* clps);
+extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void* self, void* kcl, void* mtx, Fix12i r, short s, void* clps);
 extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void* self, void* a);
-extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12 r, Fix12 h, void* p, void* q);
-extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
-extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, void* pos, Fix12 r, Fix12 h, unsigned int e, unsigned int g);
+extern void _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(void* self, void* a, Fix12i r, Fix12i h, void* p, void* q);
+extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* a, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
+extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void* self, void* a, void* pos, Fix12i r, Fix12i h, unsigned int e, unsigned int g);
 extern void* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int a, unsigned int b, void* pos, void* rot, int e, int f);
 
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -16,7 +16,7 @@ extern int Player_ScaleByCharFactor(void* c, int a);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 extern void Player_AdvanceAnims(void* c);
 

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -14,7 +14,7 @@ extern void ApproachAngle(short* cur, short target, int divisor, int band, int m
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, short a5);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void func_ov002_020d4540(void* c);
 extern void func_ov002_020cabe0(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -8,7 +8,7 @@
 #include "Player.h"
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern int func_ov002_020d36d8(void* c, int arg);

--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -20,7 +20,7 @@ extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020e28d4(char* c, int a, int b);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void Player_AdvanceAnims(char* c);
 
 extern u8 data_020a0e40;

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -13,7 +13,7 @@ extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void func_ov002_020c9e18(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(int a, int b, int cc);
 extern int _ZN4cstd5atan2E5Fix12IiES1_(int a, int b);
 extern void Player_AdvanceAnims(void* c);

--- a/src/_ZN6Player14St_Crouch_MainEv.cpp
+++ b/src/_ZN6Player14St_Crouch_MainEv.cpp
@@ -10,7 +10,7 @@ extern void func_ov002_020bf90c(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void func_ov002_020c06fc(void* c, u32 a);
 extern int func_ov002_020dd2f4(void* c);
 extern void func_ov002_020c0364(void* c, u32 a);

--- a/src/_ZN6Player14St_OnWall_MainEv.cpp
+++ b/src/_ZN6Player14St_OnWall_MainEv.cpp
@@ -12,10 +12,10 @@ extern void func_ov002_020cabe0(char* c);
 extern int func_ov002_020c5244();
 extern int func_ov002_020d36d8(char* c, int a);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12i a, int b);
 extern void _Z14ApproachLinearRsss(s16* v, s16 t, s16 s);
 extern int func_ov002_020bf224(char* c, int a, int b);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int func_ov002_020d4d88(char* c, int a, int b);
 extern void Player_AdvanceAnims(char* c);
 
@@ -92,7 +92,7 @@ int Player::St_OnWall_Main()
                 mTargetAngleY = ang - 0x4000;
                 anim = 0x5c;
             }
-            Fix12 spd = (Fix12)(((s64)mHorzSpeed * 0x600 + 0x800) >> 12);
+            Fix12i spd = (Fix12i)(((s64)mHorzSpeed * 0x600 + 0x800) >> 12);
             if (spd < 0x400)
                 spd = 0x400;
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), anim, 0, spd, 0);

--- a/src/_ZN6Player14St_Thrown_MainEv.cpp
+++ b/src/_ZN6Player14St_Thrown_MainEv.cpp
@@ -11,7 +11,7 @@ extern void func_ov002_020c06fc(char* c, u32 mask);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, const Vector3& v);
 extern void func_ov002_020bf9d4(char* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12i a, int b);
 extern void _Z15ApproachLinear2Rsss(s16* v, s16 target, s16 step);
 extern int _ZN6Player9GetHealthEv(void* c);
 extern int _ZN6Player12FinishedAnimEv(void* c);

--- a/src/_ZN6Player16St_SideFlip_MainEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_MainEv.cpp
@@ -11,7 +11,7 @@ extern int _ZN6Player7IsStateERNS_5StateE(void* c, void* s);
 extern void func_ov002_020e28d4(void* c, u32 a, u32 b);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void* v);
 extern void Player_AdvanceAnims(void* c);

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -16,7 +16,7 @@ extern void func_ov002_020e25f0(char* c, int a);
 extern void func_ov002_020c18b0(char* c, int a);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, char* v);
 extern void func_ov002_020dc560(char* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZN6Player12FinishedAnimEv(char* c);
 extern void Player_AdvanceAnims(char* c);
 

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -16,7 +16,7 @@ extern void func_ov002_020da9d4(void* c);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void func_ov002_020d4d88(void* c, int a, int b);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void Player_AdvanceAnims(void* c);
 
 extern int data_ov002_0211013c[];

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -20,7 +20,7 @@ extern int Player_ReleaseHeldActor(void* c);
 extern void ApproachAngle(short* cur, short target, int divisor, int band, int maxStep);
 extern int func_ov002_020bf224(void* c, int a, int b);
 extern void func_ov002_020d4d88(void* c, int a, int b);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void Player_AdvanceAnims(void* c);
 
 extern u8 data_020a0e40;

--- a/src/_ZN6Player17St_LedgeHang_MainEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_MainEv.cpp
@@ -7,7 +7,7 @@
 #include "Player.h"
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void Player_AdvanceAnims(void* c);
 

--- a/src/_ZN6Player17St_PunchKick_MainEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_MainEv.cpp
@@ -14,7 +14,7 @@ extern int func_ov002_020c0434(char* c);
 extern void func_ov002_020c0364(char* c, u32 arg);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int func_ov002_020bf9d4(char* c);
 extern void Player_AdvanceAnims(char* self);
 

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -11,7 +11,7 @@ extern void func_ov002_020c06fc(void* c, u32 flag);
 extern int func_ov002_020dd2f4(void* c);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 id);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern int func_ov002_020c0688(void* c);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);

--- a/src/_ZN6Player17St_WindCarry_MainEv.cpp
+++ b/src/_ZN6Player17St_WindCarry_MainEv.cpp
@@ -4,7 +4,7 @@ struct State;
 struct Player {
     int St_WindCarry_Main();
     void ChangeState(State& st);
-    int SetAnim(unsigned int a, int b, Fix12 c, unsigned int d);
+    int SetAnim(unsigned int a, int b, Fix12i c, unsigned int d);
     int FinishedAnim();
 };
 

--- a/src/_ZN6Player18St_TurnAround_MainEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_MainEv.cpp
@@ -8,10 +8,10 @@
 extern "C" {
 extern void _ZN6Player11ChangeStateERNS_5StateE(void* c, void* s);
 extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);
-extern Fix12 Player_ScaleByCharFactor(void* c, Fix12 a);
+extern Fix12i Player_ScaleByCharFactor(void* c, Fix12i a);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 a);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZN6Player12FinishedAnimEv(void* c);
 extern int func_0201226c(int a0, int a1, int a2, int a3, int a4, s16 a5);
 extern void Player_AdvanceAnims(void* c);

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -16,14 +16,14 @@ extern int func_ov002_020c0688(void* c);
 extern int func_ov002_020e2ea0(void* c);
 extern int _ZN6Player6IsAnimEj(void* c, u32 anim);
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern void func_ov002_020c18b0(void* c, u32 a);
 extern void func_ov002_020e25f0(void* c, int a);
 extern void _ZN12CylinderClsn5ClearEv(void* c);
 extern void _ZN12CylinderClsn6UpdateEv(void* c);
 extern void func_ov002_020dc560(void* c);
 extern int func_ov002_020e0ccc(void* c, short* st);
-extern Fix12 _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, Fix12 b);
+extern Fix12i _ZN4cstd5atan2E5Fix12IiES1_(Fix12i a, Fix12i b);
 extern void _Z15ApproachLinear2Rsss(short* cur, short target, short step);
 extern void Player_AdvanceAnims(void* c);
 

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -8,7 +8,7 @@
 #include "Player.h"
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(void* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void* c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void* c, u32 a, int b);
 extern void func_ov002_020c5444(char* c);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, void* v);

--- a/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
@@ -5,7 +5,7 @@
 #include "Player.h"
 extern "C" {
 extern int _ZN6Player12FinishedAnimEv(char* c);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(char* c, u32 anim, int a, Fix12i b, u32 d);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void* v);
 extern void func_ov002_020daa74(char* c);
 extern void _Z15ApproachLinear2Rsss(s16* ref, s16 target, s16 step);

--- a/src/_ZN7HeaveHo8BehaviorEv.cpp
+++ b/src/_ZN7HeaveHo8BehaviorEv.cpp
@@ -16,7 +16,7 @@ int _ZNK12WithMeshClsn10IsOnGroundEv(void *self);
 void *_ZNK12WithMeshClsn14GetFloorResultEv(void *self);
 void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *self, Vector3 *v);
 int func_02010844(void *unused, Vector3 *v, s16 angle);
-int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, WithMeshClsn *wm, Fix12 a, s16 b, int c, int d, void *e);
+int _ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_(void *self, WithMeshClsn *wm, Fix12i a, s16 b, int c, int d, void *e);
 void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, WithMeshClsn *wm, unsigned int j);
 void func_ov077_02126dac(char *t);
 void func_ov077_02126528(char *c);

--- a/src/_ZN9LakituBro13InitResourcesEv.cpp
+++ b/src/_ZN9LakituBro13InitResourcesEv.cpp
@@ -18,8 +18,8 @@ extern "C" void _ZN9Animation8LoadFileER13SharedFilePtr(SharedFilePtr& f);
 extern "C" void _ZN15TextureSequence8LoadFileER13SharedFilePtr(SharedFilePtr& f);
 extern "C" void _ZN11ShadowModel12InitCylinderEv(ShadowModel* thiz);
 extern "C" void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(BMD_File& a, BTP_File& b);
-extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(ModelAnim* thiz, BCA_File* f, int a, Fix12 b, u32 c);
-extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(TextureSequence* thiz, BTP_File& f, int a, Fix12 b, u32 c);
+extern "C" void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(ModelAnim* thiz, BCA_File* f, int a, Fix12i b, u32 c);
+extern "C" void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(TextureSequence* thiz, BTP_File& f, int a, Fix12i b, u32 c);
 
 extern SharedFilePtr data_ov085_0213074c;
 extern SharedFilePtr data_ov085_02130744;

--- a/src/func_ov002_020b6d84.c
+++ b/src/func_ov002_020b6d84.c
@@ -4,7 +4,7 @@
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::Behavior - recovered from vtable slot identity */
 struct Vec3 {
-    Fix12 x, y, z;
+    Fix12i x, y, z;
 };
 
 struct Player {
@@ -18,7 +18,7 @@ struct Actor {
 };
 
 extern struct Player* _ZN5Actor13ClosestPlayerEv(struct Actor* self);
-extern u32 func_02022c3c(u32 uniqueID, u32 effectID, Fix12 x, Fix12 y, Fix12 z, const void* dir);
+extern u32 func_02022c3c(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir);
 
 int daObjLava_c_Behavior(struct Actor* self) {
     struct Vec3* v = (struct Vec3*)(((int)_ZN5Actor13ClosestPlayerEv(self) + 0x5c));

--- a/src/func_ov002_020c75f0.c
+++ b/src/func_ov002_020c75f0.c
@@ -5,7 +5,7 @@ extern int _ZNK9Animation12WillHitFrameEi(void *anim, int frame);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 a, void *v);
 extern void func_ov002_020c2f64(void *c);
 extern void _ZN6Player4HealEi(void *c, int amt);
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 anim, int a, Fix12i b, u32 d);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void *v);
 extern void func_02012694(u32 id, void *v);
 extern u8 data_0209f2fc;

--- a/src/func_ov002_020d869c.cpp
+++ b/src/func_ov002_020d869c.cpp
@@ -11,7 +11,7 @@ extern int _ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player(char *self, void 
 extern int _ZN6Player7IsInAirEv(char *p);
 extern int func_ov002_020d9298(char *c);
 extern void func_ov002_020db8bc(u8 *p, u8 val);
-extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12 x, Fix12 y, Fix12 z);
+extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 id, Fix12i x, Fix12i y, Fix12i z);
 extern void _ZN5Sound9PlayBank0EjRK7Vector3(u32 id, const Vector3 *pos);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, const Vector3 *pos);
 }

--- a/src/func_ov002_020dd5ec.c
+++ b/src/func_ov002_020dd5ec.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 anim, int a, Fix12 b, u32 d);
+extern void _ZN6Player7SetAnimEji5Fix12IiEj(void *c, u32 anim, int a, Fix12i b, u32 d);
 extern int _ZNK6Player14GetBodyModelIDEjb(void *c, u32 id, int b);
 extern int RandomIntInternal(int *seed);
 extern void _ZN5Sound13PlayCharVoiceEjjRK7Vector3(u32 a, u32 b, void *v);

--- a/src/func_ov002_020e28d4.c
+++ b/src/func_ov002_020e28d4.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12 a, int b);
+extern int _ZN4cstd5atan2E5Fix12IiES1_(Fix12i a, int b);
 extern int AngleDiff(int a, int b);
 extern void ApproachAngle(s16* cur, s16 target, int divisor, int band, int maxStep);
 extern void _Z14ApproachLinearRiii(int* a, int b, int c);

--- a/src/func_ov002_020e5948.c
+++ b/src/func_ov002_020e5948.c
@@ -11,16 +11,16 @@ extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(void* thiz, void* bmd, s32 a, s32 
 extern void func_ov002_020bec2c(void* p);
 extern void* _Znwj(u32 sz);
 extern void* _ZN10ModelAnim2C1Ev(void* thiz);
-extern void _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(void* thiz, u32 a, s32 b, Fix12 c, u16 d);
+extern void _ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt(void* thiz, u32 a, s32 b, Fix12i c, u16 d);
 extern s32 func_ov002_020e6bb0(void* p);
 extern void func_ov002_020e6780(void* p);
 extern void* _ZN9ModelAnimC1Ev(void* thiz);
-extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, s32 i, Fix12 fx, u32 j);
+extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, s32 i, Fix12i fx, u32 j);
 extern void* _ZN5ModelC1Ev(void* thiz);
 extern void _ZN11ShadowModel12InitCylinderEv(void* thiz);
 extern s32 _ZNK6Player14GetBodyModelIDEjb(void* thiz, u32 a, s32 b);
 extern void _ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File(void* bmd, void* btp);
-extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* thiz, void* f, s32 i, Fix12 fx, u32 j);
+extern void _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void* thiz, void* f, s32 i, Fix12i fx, u32 j);
 
 extern s8 data_0209f310[];
 extern u8 data_0209f2d8;

--- a/src/func_ov002_020f8b24.c
+++ b/src/func_ov002_020f8b24.c
@@ -2,11 +2,11 @@
 typedef struct { s32 x, y, z; } Vec3;
 typedef struct { s32 w[12]; } Mtx43;
 
-extern void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f);
-extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f, void* g);
+extern void* _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(u32 a, u32 b, Fix12i c, Fix12i d, Fix12i e, const void* f);
+extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 a, u32 b, Fix12i c, Fix12i d, Fix12i e, const void* f, void* g);
 extern void Vec3_Asr(Vec3* d, Vec3* s, int sh);
 extern void Matrix4x3_FromTranslation(Mtx43* m, s32 x, s32 y, s32 z);
-extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* thiz, void* sm, void* mtx, Fix12 f, Fix12 a, u32 b);
+extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(void* thiz, void* sm, void* mtx, Fix12i f, Fix12i a, u32 b);
 
 extern s32 data_ov002_02100320[];
 extern s32 data_ov002_02100334[];

--- a/src/func_ov060_021128c0.cpp
+++ b/src/func_ov060_021128c0.cpp
@@ -7,7 +7,7 @@
 #include "common.h"
 extern "C" {
     void* _ZN5Actor10FindWithIDEj(u32 id);
-    void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, const Vector3& v, u32 a, Fix12 b, u32 c, u32 d, u32 e);
+    void _ZN6Player4HurtERK7Vector3j5Fix12IiEjjj(void* self, const Vector3& v, u32 a, Fix12i b, u32 c, u32 d, u32 e);
     void _ZN5Actor9UpdatePosEP12CylinderClsn(void* self, void* cc);
     void func_02038408(void* p);
     void WithMeshClsn_UpdateContinuous_Veneer(void* p);

--- a/src/func_ov060_02116518.c
+++ b/src/func_ov060_02116518.c
@@ -1,8 +1,8 @@
 #include "types.h"
 extern u32 _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
-    u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f);
+    u32 a, u32 b, Fix12i c, Fix12i d, Fix12i e, const void* f);
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-    u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f, void* g);
+    u32 a, u32 b, Fix12i c, Fix12i d, Fix12i e, const void* f, void* g);
 extern void* _ZN8Particle6System12FromUniqueIDEj(u32 id);
 
 void func_ov060_02116518(char* self, u32 kind, int a2, int a3)
@@ -23,7 +23,7 @@ void func_ov060_02116518(char* self, u32 kind, int a2, int a3)
 
         if (kind == 0x9a) {
             *(int*)((char*)o + 0x44) = (int)(((long long)(*(int*)(self + 0x360)) * 0x2800 + 0x800) >> 12);
-            *(int*)((char*)o + 0x4c) = (short)(Fix12)(((long long)(*(int*)(self + 0x360)) * 0xa66 + 0x800) >> 12);
+            *(int*)((char*)o + 0x4c) = (short)(Fix12i)(((long long)(*(int*)(self + 0x360)) * 0xa66 + 0x800) >> 12);
         }
     }
 
@@ -41,5 +41,5 @@ void func_ov060_02116518(char* self, u32 kind, int a2, int a3)
         return;
 
     *(int*)((char*)o + 0x44) = (int)(((long long)(*(int*)(self + 0x360)) * 0x2800 + 0x800) >> 12);
-    *(int*)((char*)o + 0x4c) = (short)(Fix12)(((long long)(*(int*)(self + 0x360)) * 0xa66 + 0x800) >> 12);
+    *(int*)((char*)o + 0x4c) = (short)(Fix12i)(((long long)(*(int*)(self + 0x360)) * 0xa66 + 0x800) >> 12);
 }

--- a/src/func_ov062_021164e8.cpp
+++ b/src/func_ov062_021164e8.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 struct BCA_File;
-struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12 b, unsigned int c); };
+struct ModelAnim { void SetAnim(BCA_File *f, int a, Fix12i b, unsigned int c); };
 
 extern void *data_ov062_0211de00[];
 extern int data_ov062_0211dec0;

--- a/src/func_ov062_02117994.c
+++ b/src/func_ov062_02117994.c
@@ -3,14 +3,14 @@ struct Entry { char pad[4]; void *file; };
 extern struct Entry *data_ov062_0211cee8[];
 extern int data_ov062_0211cf0c[];
 
-extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int idx, Fix12 speed, u32 flags);
+extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char *anim, void *file, int idx, Fix12i speed, u32 flags);
 
 void func_ov062_02117994(char *c, int idx) {
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(
         c + 0x300,
         data_ov062_0211cee8[idx]->file,
         data_ov062_0211cf0c[idx],
-        *(Fix12*)(c + 0x3bc),
+        *(Fix12i*)(c + 0x3bc),
         0
     );
     *(u8*)(c + 0x398) = (u8)idx;

--- a/src/func_ov064_0211616c.c
+++ b/src/func_ov064_0211616c.c
@@ -1,7 +1,7 @@
 #include "types.h"
 typedef struct { short x, y, z; } Vector3_16f;
 struct Callback {};
-extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 id, u32 param, Fix12 x, Fix12 y, Fix12 z, const Vector3_16f* pos, struct Callback* cb);
+extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 id, u32 param, Fix12i x, Fix12i y, Fix12i z, const Vector3_16f* pos, struct Callback* cb);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
 int func_ov064_0211616c(char* c) {
     if (*(unsigned short*)(c + 0x100) > 0x1e) {
@@ -13,17 +13,17 @@ int func_ov064_0211616c(char* c) {
     *(void**)(c + 0x334) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(c + 0x334),
         *(u32*)(*(char**)(c + 0x330) + 0x30),
-        *(Fix12*)(c + 0x3a8),
-        *(Fix12*)(c + 0x3ac),
-        *(Fix12*)(c + 0x3b0),
+        *(Fix12i*)(c + 0x3a8),
+        *(Fix12i*)(c + 0x3ac),
+        *(Fix12i*)(c + 0x3b0),
         (const Vector3_16f*)0,
         (struct Callback*)0);
     *(void**)(c + 0x338) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(c + 0x338),
         *(u32*)(*(char**)(c + 0x330) + 0x30) + 1,
-        *(Fix12*)(c + 0x3a8),
-        *(Fix12*)(c + 0x3ac),
-        *(Fix12*)(c + 0x3b0),
+        *(Fix12i*)(c + 0x3a8),
+        *(Fix12i*)(c + 0x3ac),
+        *(Fix12i*)(c + 0x3b0),
         (const Vector3_16f*)0,
         (struct Callback*)0);
     return 0;

--- a/src/func_ov071_02121b08.c
+++ b/src/func_ov071_02121b08.c
@@ -2,12 +2,12 @@
 typedef struct { short x, y, z; } Vector3_16f;
 struct Foo {
     char pad[0x5c];
-    Fix12 x, y, z;
+    Fix12i x, y, z;
     char pad2[0x2c0];
     void* particleSys;
 };
 struct Callback {};
-extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 id, u32 param, Fix12 x, Fix12 y, Fix12 z, const Vector3_16f* pos, struct Callback* cb);
+extern void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(u32 id, u32 param, Fix12i x, Fix12i y, Fix12i z, const Vector3_16f* pos, struct Callback* cb);
 extern void _ZN9ActorBase18MarkForDestructionEv(struct Foo* self);
 void func_ov071_02121b08(struct Foo* c) {
     void* p = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(

--- a/src/func_ov074_021223bc.cpp
+++ b/src/func_ov074_021223bc.cpp
@@ -27,7 +27,7 @@ extern void _ZN13RaycastGroundD1Ev(RaycastGround *self);
 extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, CylinderClsn *cc);
 extern void _ZN5Enemy12UpdateWMClsnER12WithMeshClsnj(void *self, WithMeshClsn *wm, unsigned int j);
 extern void _ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j(
-    void *self, ShadowModel *sm, Matrix4x3 *mtx, Fix12 h, Fix12 g, unsigned int u);
+    void *self, ShadowModel *sm, Matrix4x3 *mtx, Fix12i h, Fix12i g, unsigned int u);
 extern struct Blob48 { int w[12]; } data_02082128;
 
 int func_ov074_021223bc(char *c)

--- a/src/func_ov084_0212d2dc.c
+++ b/src/func_ov084_0212d2dc.c
@@ -1,6 +1,6 @@
 #include "types.h"
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-    u32 a, u32 b, Fix12 c, Fix12 d, Fix12 e, const void* f, void* g);
+    u32 a, u32 b, Fix12i c, Fix12i d, Fix12i e, const void* f, void* g);
 extern void* _ZN8Particle6System12FromUniqueIDEj(u32 id);
 
 extern int data_ov084_02130e24[];
@@ -16,7 +16,7 @@ void func_ov084_0212d2dc(char* c)
     if (*(u32*)(c + 0x224) != 0) {
         o = _ZN8Particle6System12FromUniqueIDEj(*(u32*)(c + 0x224));
         if (o != 0) {
-            *(int*)((char*)o + 0x50) = (short)(Fix12)(((long long)(*(int*)(c + 0x210)) * 0x2800 + 0x800) >> 12);
+            *(int*)((char*)o + 0x50) = (short)(Fix12i)(((long long)(*(int*)(c + 0x210)) * 0x2800 + 0x800) >> 12);
         }
     }
 
@@ -27,5 +27,5 @@ void func_ov084_0212d2dc(char* c)
     o = _ZN8Particle6System12FromUniqueIDEj(*(u32*)(c + 0x228));
     if (o == 0)
         return;
-    *(int*)((char*)o + 0x50) = (short)(Fix12)(((long long)(*(int*)(c + 0x210)) * 0x2800 + 0x800) >> 12);
+    *(int*)((char*)o + 0x50) = (short)(Fix12i)(((long long)(*(int*)(c + 0x210)) * 0x2800 + 0x800) >> 12);
 }

--- a/src/func_ov085_0212de5c.cpp
+++ b/src/func_ov085_0212de5c.cpp
@@ -6,7 +6,7 @@ struct Actor {
     Player *ClosestPlayer();
     short HorzAngleToCPlayer();
 };
-namespace Sound { void PlaySub(u32, u32, u32, Fix12, bool); }
+namespace Sound { void PlaySub(u32, u32, u32, Fix12i, bool); }
 extern "C" void func_0201f32c(int);
 extern "C" int func_ov085_0212e728(void *c, void *p);
 extern unsigned char data_0209d66c;

--- a/src/func_ov094_021358b4.cpp
+++ b/src/func_ov094_021358b4.cpp
@@ -4,7 +4,7 @@
 /* recovered: shared common types */
 #include "common.h"
 extern "C" {
-extern void ApproachLinear(struct Vector3 *a, const struct Vector3 *b, Fix12 f);
+extern void ApproachLinear(struct Vector3 *a, const struct Vector3 *b, Fix12i f);
 extern int func_ov094_02136188(void *c, void *p);
 extern int data_ov094_02136b60[];
 }


### PR DESCRIPTION
Migrates the 44 `src/` files that used the bare name `Fix12` and took it from `include/types.h`.

**Why:** #865 reserves `Fix12` for the real C++ class template (the ROM's own mangled symbols spell it out: `cstd::atan2(Fix12<int>, Fix12<int>)`), which is right. But those 44 files then have no definition and fail to compile -- I checked by removing the typedef and re-running the gate: `NO-SYM` on every one. They lost their local typedefs to the types.h consolidation sweep, so this is fallout from that, not from #865.

`Fix12i` is the same `s32` and is already the spelling most of `src/` uses, so switching these frees the name with no semantic change.

**Verified:** all 44 byte-checked -- 18 VERIFIED, 26 BLIND, 0 WRONG/NO-REPRO. Re-ran with #865's typedef removal simulated on top: still 18/26/0, so #865 can merge cleanly after this.