### PR TITLE
Add the source-to-.nds ROM build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,18 @@ tools/claims_key.txt
 tools/claims_handle.txt
 /scratchpad/
 
+# ML / LoRA training work: datasets are derived from the match corpus and the
+# checkpoints are large binaries. Local-only, and never near a match PR.
+/tools/dataset/
+/notes/training/
+/notes/training.zip
+/unsloth_compiled_cache/
+/out/
+/wsl-bridge/
+
+# local MCP server wiring (machine-specific, may hold endpoints or tokens)
+/.mcp.json
+
 # generated Chaos Viewer data: the shared copy lives on the chaos-data branch
 # (raw URL in tangos.json / chaosviewer.config.json); regenerate locally on
 # demand with tools/chaos_db_ci.py. Never commit it to main - it goes stale and

--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -6,3 +6,11813 @@
     .ctor       start:0x02086b60 end:0x02086bbc kind:rodata align:4
     .data       start:0x02086bc0 end:0x0209b000 kind:data align:32
     .bss        start:0x0209b000 end:0x020aa420 kind:bss align:32
+src/Entry.c:
+    .text start:0x02004800 end:0x020048d8
+
+src/func_020048d8.c:
+    complete
+    .text start:0x020048d8 end:0x0200497c
+
+src/AutoloadCallback.c:
+    complete
+    .text start:0x020049ec end:0x020049f0
+
+src/_ZN4CP1511SystemSetupEv.c:
+    .text start:0x020049f0 end:0x02004ad8
+
+src/func_02005000.c:
+    complete
+    .text start:0x02005000 end:0x02005060
+
+src/func_02005060.c:
+    complete
+    .text start:0x02005060 end:0x02005098
+
+src/func_02005098.c:
+    .text start:0x02005098 end:0x020050dc
+
+src/func_020050dc.c:
+    complete
+    .text start:0x020050dc end:0x02005110
+
+src/func_02005110.c:
+    complete
+    .text start:0x02005110 end:0x02005324
+
+src/func_02005324.c:
+    complete
+    .text start:0x02005324 end:0x02005348
+
+src/func_02005348.c:
+    complete
+    .text start:0x02005348 end:0x02005418
+
+src/func_02005418.c:
+    complete
+    .text start:0x02005418 end:0x02005a58
+
+src/func_02005a58.c:
+    complete
+    .text start:0x02005a58 end:0x02005d94
+
+src/_ZN8CapEnemy12Unk_02005d94Ev.cpp:
+    .text start:0x02005d94 end:0x02005e28
+
+src/func_02005e28.c:
+    complete
+    .text start:0x02005e28 end:0x02005ed8
+
+src/func_02005ed8.c:
+    complete
+    .text start:0x02005ed8 end:0x02005f0c
+
+src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp:
+    .text start:0x02005f0c end:0x02005fa0
+
+src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp:
+    .text start:0x02006054 end:0x020060f4
+
+src/_ZN8CapEnemy16GetCapEatenOffItERK7Vector3.c:
+    complete
+    .text start:0x020060f4 end:0x020061b0
+
+src/_ZN8CapEnemy10ReleaseCapERK7Vector3.c:
+    complete
+    .text start:0x020061b0 end:0x02006280
+
+src/_ZN8CapEnemy14RenderCapModelEPK7Vector3.cpp:
+    complete
+    .text start:0x02006280 end:0x020062b8
+
+src/_ZN8CapEnemy12UpdateCapPosERK7Vector3RK10Vector3_16.cpp:
+    .text start:0x020062b8 end:0x020063b0
+
+src/_ZN8CapEnemy6AddCapEj.c:
+    .text start:0x020063b0 end:0x020064e0
+
+src/_ZN8CapEnemy14UnloadCapModelEv.c:
+    complete
+    .text start:0x020064e0 end:0x0200651c
+
+src/_ZN8CapEnemyD2Ev.c:
+    complete
+    .text start:0x0200651c end:0x02006554
+
+src/_ZN8CapEnemyC2Ev.c:
+    complete
+    .text start:0x02006554 end:0x02006588
+
+src/main.c:
+    .text start:0x02007000 end:0x0200705c
+
+src/_ZN6CameraD1Ev.c:
+    complete
+    .text start:0x0200705c end:0x02007098
+
+src/_ZN6CameraD0Ev.c:
+    complete
+    .text start:0x02007098 end:0x020070e8
+
+src/func_020070e8.c:
+    complete
+    .text start:0x020070e8 end:0x020071a8
+
+src/func_020071a8.c:
+    complete
+    .text start:0x020071a8 end:0x020071e0
+
+src/func_020071e0.c:
+    complete
+    .text start:0x020071e0 end:0x020072c0
+
+src/func_020072c0.c:
+    complete
+    .text start:0x020072c0 end:0x020072c4
+
+src/func_020072c4.c:
+    complete
+    .text start:0x020072c4 end:0x020073a0
+
+src/func_020073a0.c:
+    complete
+    .text start:0x020073a0 end:0x02007414
+
+src/func_02007414.c:
+    complete
+    .text start:0x02007414 end:0x02007450
+
+src/func_02007450.c:
+    complete
+    .text start:0x02007450 end:0x02007484
+
+src/func_02007484.c:
+    complete
+    .text start:0x02007484 end:0x020074e8
+
+src/func_020074e8.c:
+    complete
+    .text start:0x020074e8 end:0x0200751c
+
+src/func_0200751c.c:
+    complete
+    .text start:0x0200751c end:0x02007548
+
+src/func_02007548.c:
+    complete
+    .text start:0x02007548 end:0x020075b4
+
+src/func_020075b4.c:
+    complete
+    .text start:0x020075b4 end:0x0200762c
+
+src/func_0200762c.c:
+    complete
+    .text start:0x0200762c end:0x02007698
+
+src/func_02007698.c:
+    complete
+    .text start:0x02007698 end:0x02007758
+
+src/func_02007758.c:
+    complete
+    .text start:0x02007758 end:0x020077f0
+
+src/func_020077f0.c:
+    complete
+    .text start:0x020077f0 end:0x02007870
+
+src/func_02007870.c:
+    complete
+    .text start:0x02007870 end:0x020078c4
+
+src/func_020078c4.c:
+    complete
+    .text start:0x020078c4 end:0x02007910
+
+src/func_02007910.c:
+    complete
+    .text start:0x02007910 end:0x020079ac
+
+src/func_020079ac.c:
+    complete
+    .text start:0x020079ac end:0x02007a8c
+
+src/func_02007a8c.c:
+    complete
+    .text start:0x02007a8c end:0x02007b0c
+
+src/func_02007b0c.c:
+    complete
+    .text start:0x02007b0c end:0x02007b98
+
+src/func_02007b98.c:
+    complete
+    .text start:0x02007b98 end:0x02007c14
+
+src/func_02007c14.c:
+    complete
+    .text start:0x02007c14 end:0x02007c9c
+
+src/func_02007c9c.c:
+    complete
+    .text start:0x02007c9c end:0x02007cec
+
+src/func_02007cec.c:
+    complete
+    .text start:0x02007cec end:0x02007d0c
+
+src/func_02007d0c.c:
+    complete
+    .text start:0x02007d0c end:0x02007d58
+
+src/func_02007d58.c:
+    complete
+    .text start:0x02007d58 end:0x02007e5c
+
+src/func_02007e5c.c:
+    complete
+    .text start:0x02007e5c end:0x02007f14
+
+src/func_02007f14.c:
+    complete
+    .text start:0x02007f14 end:0x02007fcc
+
+src/func_02007fcc.c:
+    complete
+    .text start:0x02007fcc end:0x02008008
+
+src/func_02008008.c:
+    complete
+    .text start:0x02008008 end:0x02008028
+
+src/func_02008028.c:
+    complete
+    .text start:0x02008028 end:0x02008080
+
+src/func_02008080.c:
+    complete
+    .text start:0x02008080 end:0x020080b0
+
+src/func_020080b0.c:
+    complete
+    .text start:0x020080b0 end:0x020080f0
+
+src/func_020080f0.c:
+    complete
+    .text start:0x020080f0 end:0x0200814c
+
+src/func_0200814c.c:
+    complete
+    .text start:0x0200814c end:0x02008200
+
+src/func_02008200.c:
+    complete
+    .text start:0x02008200 end:0x020082a0
+
+src/func_020082a0.c:
+    complete
+    .text start:0x020082a0 end:0x020082f8
+
+src/func_020082f8.c:
+    complete
+    .text start:0x020082f8 end:0x0200840c
+
+src/func_0200840c.c:
+    complete
+    .text start:0x0200840c end:0x02008450
+
+src/func_02008450.c:
+    complete
+    .text start:0x02008450 end:0x02008474
+
+src/func_02008474.c:
+    complete
+    .text start:0x02008474 end:0x020084b0
+
+src/func_020084b0.c:
+    complete
+    .text start:0x020084b0 end:0x02008500
+
+src/func_02008500.c:
+    complete
+    .text start:0x02008500 end:0x02008550
+
+src/func_02008550.cpp:
+    complete
+    .text start:0x02008550 end:0x0200897c
+
+src/func_0200897c.c:
+    complete
+    .text start:0x0200897c end:0x020089d8
+
+src/func_020089d8.c:
+    complete
+    .text start:0x020089d8 end:0x020089f8
+
+src/func_020089f8.c:
+    complete
+    .text start:0x020089f8 end:0x02008a70
+
+src/func_02008a70.c:
+    complete
+    .text start:0x02008a70 end:0x02008abc
+
+src/func_02008abc.c:
+    complete
+    .text start:0x02008abc end:0x02008b08
+
+src/func_02008b08.c:
+    complete
+    .text start:0x02008b08 end:0x02008b4c
+
+src/func_02008b4c.c:
+    .text start:0x02008b4c end:0x02008cb4
+
+src/func_02008cb4.c:
+    complete
+    .text start:0x02008cb4 end:0x02009138
+
+src/func_02009138.c:
+    complete
+    .text start:0x02009138 end:0x020091f8
+
+src/func_020091f8.c:
+    complete
+    .text start:0x020091f8 end:0x0200928c
+
+src/func_0200928c.c:
+    complete
+    .text start:0x0200928c end:0x020092c4
+
+src/func_020092c4.c:
+    complete
+    .text start:0x020092c4 end:0x02009374
+
+src/func_02009374.c:
+    .text start:0x02009374 end:0x020093d4
+
+src/func_020093d4.c:
+    complete
+    .text start:0x020093d4 end:0x020093f4
+
+src/func_020093f4.c:
+    complete
+    .text start:0x020093f4 end:0x02009414
+
+src/func_02009414.c:
+    complete
+    .text start:0x02009414 end:0x020094a8
+
+src/func_020094a8.c:
+    complete
+    .text start:0x020094a8 end:0x020094c0
+
+src/func_020094c0.c:
+    complete
+    .text start:0x020094c0 end:0x020094e4
+
+src/func_020094e4.c:
+    complete
+    .text start:0x020094e4 end:0x02009540
+
+src/func_02009540.c:
+    complete
+    .text start:0x02009540 end:0x020095c4
+
+src/func_020095c4.c:
+    complete
+    .text start:0x020095c4 end:0x020095e4
+
+src/func_020095e4.c:
+    complete
+    .text start:0x020095e4 end:0x020097ec
+
+src/func_020097ec.c:
+    complete
+    .text start:0x020097ec end:0x0200985c
+
+src/func_0200985c.c:
+    complete
+    .text start:0x0200985c end:0x0200987c
+
+src/func_0200987c.c:
+    complete
+    .text start:0x0200987c end:0x020098b8
+
+src/func_020098b8.c:
+    complete
+    .text start:0x020098b8 end:0x020098e0
+
+src/func_020098e0.c:
+    complete
+    .text start:0x020098e0 end:0x02009a8c
+
+src/func_02009a8c.c:
+    .text start:0x02009a8c end:0x02009aa8
+
+src/func_02009aa8.c:
+    complete
+    .text start:0x02009aa8 end:0x02009d30
+
+src/func_02009d30.c:
+    complete
+    .text start:0x02009d30 end:0x02009d70
+
+src/func_02009d70.c:
+    complete
+    .text start:0x02009d70 end:0x02009d90
+
+src/func_02009d90.c:
+    complete
+    .text start:0x02009d90 end:0x02009db0
+
+src/func_02009db0.c:
+    complete
+    .text start:0x02009db0 end:0x02009dd0
+
+src/func_02009dd0.c:
+    complete
+    .text start:0x02009dd0 end:0x02009df0
+
+src/func_02009df0.c:
+    complete
+    .text start:0x02009df0 end:0x02009e10
+
+src/func_02009e10.c:
+    complete
+    .text start:0x02009e10 end:0x02009e30
+
+src/func_02009e30.c:
+    complete
+    .text start:0x02009e30 end:0x02009e50
+
+src/func_02009e50.c:
+    complete
+    .text start:0x02009e50 end:0x02009e70
+
+src/func_0200af0c.c:
+    complete
+    .text start:0x0200af0c end:0x0200af20
+
+src/func_0200af20.c:
+    complete
+    .text start:0x0200af20 end:0x0200b0fc
+
+src/func_0200b0fc.c:
+    complete
+    .text start:0x0200b0fc end:0x0200b590
+
+src/func_0200b590.c:
+    complete
+    .text start:0x0200b590 end:0x0200b798
+
+src/func_0200b798.c:
+    complete
+    .text start:0x0200b798 end:0x0200b990
+
+src/func_0200b990.c:
+    complete
+    .text start:0x0200b990 end:0x0200bb28
+
+src/func_0200bb28.c:
+    complete
+    .text start:0x0200bb28 end:0x0200bec4
+
+src/func_0200bec4.c:
+    complete
+    .text start:0x0200bec4 end:0x0200c394
+
+src/func_0200c394.c:
+    complete
+    .text start:0x0200c394 end:0x0200c66c
+
+src/func_0200c66c.c:
+    complete
+    .text start:0x0200c66c end:0x0200c9e0
+
+src/func_0200c9e0.c:
+    complete
+    .text start:0x0200c9e0 end:0x0200ca14
+
+src/func_0200ca14.c:
+    complete
+    .text start:0x0200ca14 end:0x0200ca50
+
+src/func_0200ca50.cpp:
+    complete
+    .text start:0x0200ca50 end:0x0200cae4
+
+src/func_0200cae4.cpp:
+    complete
+    .text start:0x0200cae4 end:0x0200cb58
+
+src/func_0200cb58.c:
+    complete
+    .text start:0x0200cb58 end:0x0200cb70
+
+src/_ZN6Camera11ChangeStateEPNS_5StateE.cpp:
+    .text start:0x0200cb70 end:0x0200cbe0
+
+src/func_0200cbe0.c:
+    complete
+    .text start:0x0200cbe0 end:0x0200cc5c
+
+src/_ZN6Camera25SaveCameraStateBeforeTalkEv.cpp:
+    complete
+    .text start:0x0200cc5c end:0x0200ccac
+
+src/_ZN6Camera6SetPosERK7Vector3.c:
+    complete
+    .text start:0x0200ccac end:0x0200ccc8
+
+src/_ZN6Camera9SetLookAtERK7Vector3.c:
+    complete
+    .text start:0x0200ccc8 end:0x0200cce4
+
+src/func_0200cce4.c:
+    complete
+    .text start:0x0200cce4 end:0x0200cf40
+
+src/func_0200cf40.c:
+    complete
+    .text start:0x0200cf40 end:0x0200d048
+
+src/_ZN6Camera9SetFlag_3Ev.cpp:
+    complete
+    .text start:0x0200d048 end:0x0200d064
+
+src/func_0200d064.c:
+    complete
+    .text start:0x0200d064 end:0x0200d0ac
+
+src/func_0200d0ac.c:
+    complete
+    .text start:0x0200d0ac end:0x0200d10c
+
+src/func_0200d10c.c:
+    complete
+    .text start:0x0200d10c end:0x0200d148
+
+src/func_0200d148.c:
+    complete
+    .text start:0x0200d148 end:0x0200d184
+
+src/_ZN6Camera10LookAtExitER5Actor.cpp:
+    complete
+    .text start:0x0200d184 end:0x0200d1e4
+
+src/func_0200d1e4.c:
+    complete
+    .text start:0x0200d1e4 end:0x0200d304
+
+src/_ZN6Camera14GoBehindPlayerEj.cpp:
+    .text start:0x0200d304 end:0x0200d3f8
+
+src/func_0200d3f8.c:
+    complete
+    .text start:0x0200d3f8 end:0x0200d438
+
+src/func_0200d438.c:
+    complete
+    .text start:0x0200d438 end:0x0200d474
+
+src/func_0200d474.c:
+    complete
+    .text start:0x0200d474 end:0x0200d4b0
+
+src/func_0200d4b0.c:
+    complete
+    .text start:0x0200d4b0 end:0x0200d508
+
+src/func_0200d508.c:
+    complete
+    .text start:0x0200d508 end:0x0200d544
+
+src/func_0200d544.c:
+    complete
+    .text start:0x0200d544 end:0x0200d580
+
+src/func_0200d580.c:
+    complete
+    .text start:0x0200d580 end:0x0200d5c0
+
+src/func_0200d5c0.c:
+    complete
+    .text start:0x0200d5c0 end:0x0200d5fc
+
+src/func_0200d5fc.c:
+    complete
+    .text start:0x0200d5fc end:0x0200d63c
+
+src/func_0200d63c.c:
+    complete
+    .text start:0x0200d63c end:0x0200d678
+
+src/func_0200d678.c:
+    complete
+    .text start:0x0200d678 end:0x0200d6b4
+
+src/func_0200d6b4.c:
+    complete
+    .text start:0x0200d6b4 end:0x0200d6f0
+
+src/func_0200d6f0.c:
+    complete
+    .text start:0x0200d6f0 end:0x0200d72c
+
+src/func_0200d72c.c:
+    complete
+    .text start:0x0200d72c end:0x0200d768
+
+src/func_0200d768.c:
+    complete
+    .text start:0x0200d768 end:0x0200d7a4
+
+src/func_0200d7a4.c:
+    complete
+    .text start:0x0200d7a4 end:0x0200d7e0
+
+src/func_0200d7e0.c:
+    complete
+    .text start:0x0200d7e0 end:0x0200d81c
+
+src/func_0200d81c.c:
+    complete
+    .text start:0x0200d81c end:0x0200d858
+
+src/func_0200d858.c:
+    complete
+    .text start:0x0200d858 end:0x0200d890
+
+src/_ZNK6Camera12IsUnderwaterEv.c:
+    complete
+    .text start:0x0200d890 end:0x0200d89c
+
+src/func_0200d89c.c:
+    complete
+    .text start:0x0200d89c end:0x0200d8ac
+
+src/func_0200d8ac.c:
+    complete
+    .text start:0x0200d8ac end:0x0200d8c8
+
+src/func_0200d8c8.c:
+    complete
+    .text start:0x0200d8c8 end:0x0200d954
+
+src/func_0200d954.c:
+    complete
+    .text start:0x0200d954 end:0x0200d9d0
+
+src/_ZN6Camera16CleanupResourcesEv.c:
+    complete
+    .text start:0x0200d9d0 end:0x0200da00
+
+src/_ZN6Camera16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x0200da00 end:0x0200da04
+
+src/_ZN6Camera6RenderEv.cpp:
+    .text start:0x0200da04 end:0x0200debc
+
+src/_ZN6Camera8BehaviorEv.cpp:
+    .text start:0x0200debc end:0x0200e338
+
+src/_ZN6Camera13InitResourcesEv.cpp:
+    .text start:0x0200e338 end:0x0200e444
+
+src/_ZN6CameraC1Ev.c:
+    complete
+    .text start:0x0200e444 end:0x0200e494
+
+src/func_0200e494.c:
+    complete
+    .text start:0x0200e494 end:0x0200e4e4
+
+src/func_0200e4e4.c:
+    complete
+    .text start:0x0200e4e4 end:0x0200e55c
+
+src/func_0200e55c.c:
+    complete
+    .text start:0x0200e55c end:0x0200e5ac
+
+src/func_0200e5ac.c:
+    complete
+    .text start:0x0200e5ac end:0x0200e5fc
+
+src/func_0200e5fc.c:
+    complete
+    .text start:0x0200e5fc end:0x0200e6d8
+
+src/func_0200e6d8.c:
+    complete
+    .text start:0x0200e6d8 end:0x0200e728
+
+src/func_0200e728.c:
+    complete
+    .text start:0x0200e728 end:0x0200e748
+
+src/ReadUnalignedInt.c:
+    complete
+    .text start:0x0200e748 end:0x0200e768
+
+src/ReadUnalignedShort.c:
+    complete
+    .text start:0x0200e768 end:0x0200e780
+
+src/ReadUnalignedUshort.c:
+    complete
+    .text start:0x0200e780 end:0x0200e798
+
+src/EndKuppaScript.cpp:
+    .text start:0x0200e798 end:0x0200e8d4
+
+src/ProcessKuppaScript.cpp:
+    complete
+    .text start:0x0200e8d4 end:0x0200ee68
+
+src/func_0200ee68.c:
+    complete
+    .text start:0x0200ee68 end:0x0200ee8c
+
+src/func_0200ee8c.c:
+    complete
+    .text start:0x0200ee8c end:0x0200eec8
+
+src/func_0200eec8.c:
+    complete
+    .text start:0x0200eec8 end:0x0200eedc
+
+src/StartIntroCutscene.c:
+    complete
+    .text start:0x0200eedc end:0x0200ef04
+
+src/RunKuppaScript.c:
+    complete
+    .text start:0x0200ef04 end:0x0200ef80
+
+src/ContinueKuppaScriptIfNecessary.c:
+    complete
+    .text start:0x0200ef80 end:0x0200f04c
+
+src/ResetKuppaScript.c:
+    complete
+    .text start:0x0200f04c end:0x0200f0bc
+
+src/func_0200f0bc.c:
+    complete
+    .text start:0x0200f0bc end:0x0200f13c
+
+src/func_0200f13c.cpp:
+    complete
+    .text start:0x0200f13c end:0x0200f220
+
+src/func_0200f220.c:
+    complete
+    .text start:0x0200f220 end:0x0200f2cc
+
+src/func_0200f2cc.c:
+    complete
+    .text start:0x0200f2cc end:0x0200f450
+
+src/SetNumPlayers.c:
+    complete
+    .text start:0x0200f450 end:0x0200f468
+
+src/func_0200f468.c:
+    complete
+    .text start:0x0200f468 end:0x0200f46c
+
+src/func_0200f46c.c:
+    complete
+    .text start:0x0200f46c end:0x0200f470
+
+src/_Z13CopyToViewMatPK9Matrix4x3.c:
+    complete
+    .text start:0x0200f470 end:0x0200f4b4
+
+src/func_0200f4b4.c:
+    complete
+    .text start:0x0200f4b4 end:0x0200f4f4
+
+src/func_0200f4f4.c:
+    complete
+    .text start:0x0200f4f4 end:0x0200f558
+
+src/Initialise3dGraphics.cpp:
+    complete
+    .text start:0x0200f558 end:0x0200f658
+
+src/_ZN5Actor17DetectRaycastClsnER7Vector3S1_b.cpp:
+    complete
+    .text start:0x0200f658 end:0x0200f70c
+
+src/_ZN5Actor22IsTooFarAwayFromPlayerE5Fix12IiE.cpp:
+    complete
+    .text start:0x0200f70c end:0x0200f760
+
+src/func_0200f760.c:
+    complete
+    .text start:0x0200f760 end:0x0200f7a8
+
+src/_ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn.c:
+    complete
+    .text start:0x0200f7a8 end:0x0200f7f0
+
+src/func_0200f7f0.c:
+    complete
+    .text start:0x0200f7f0 end:0x0200f874
+
+src/_ZN5Sound20PlaySmallSecretSoundEP5ActorPt.c:
+    complete
+    .text start:0x0200f874 end:0x0200f8f8
+
+src/_ZN5Sound15PlaySecretSoundEP5ActorPt.c:
+    complete
+    .text start:0x0200f8f8 end:0x0200f97c
+
+src/_ZN5Actor13SpawnSoundObjEj.c:
+    complete
+    .text start:0x0200f97c end:0x0200f9b8
+
+src/_ZN5Actor24KillAndTrackInDeathTableEv.c:
+    complete
+    .text start:0x0200f9b8 end:0x0200f9d4
+
+src/_ZN5Actor19UntrackInDeathTableEv.cpp:
+    complete
+    .text start:0x0200f9d4 end:0x0200f9e4
+
+src/_ZN5Actor17TrackInDeathTableEv.cpp:
+    complete
+    .text start:0x0200f9e4 end:0x0200f9f4
+
+src/_ZN5Actor18GetBitInDeathTableEv.cpp:
+    complete
+    .text start:0x0200f9f4 end:0x0200fa04
+
+src/func_0200fa04.c:
+    complete
+    .text start:0x0200fa04 end:0x0200fa8c
+
+src/func_0200fa8c.c:
+    complete
+    .text start:0x0200fa8c end:0x0200fac4
+
+src/_ZN5Actor13LandingDustAtER7Vector3b.cpp:
+    .text start:0x0200fac4 end:0x0200fb4c
+
+src/_ZN5Actor15HugeLandingDustEb.c:
+    complete
+    .text start:0x0200fb4c end:0x0200fb84
+
+src/_ZN5Actor17HugeLandingDustAtER7Vector3b.cpp:
+    .text start:0x0200fb84 end:0x0200fc0c
+
+src/_ZN5Actor11LandingDustEb.c:
+    complete
+    .text start:0x0200fc0c end:0x0200fc44
+
+src/func_0200fc44.c:
+    complete
+    .text start:0x0200fc44 end:0x0200fccc
+
+src/func_0200fccc.c:
+    complete
+    .text start:0x0200fccc end:0x0200fd04
+
+src/_ZN5Actor19DisappearPoofDustAtERK7Vector3.c:
+    complete
+    .text start:0x0200fd04 end:0x0200fd40
+
+src/_ZN5Actor13SmallPoofDustEv.c:
+    complete
+    .text start:0x0200fd40 end:0x0200fd74
+
+src/_ZN5Actor16TriplePoofDustAtERK7Vector3.c:
+    complete
+    .text start:0x0200fd74 end:0x0200fdc8
+
+src/_ZN5Actor14TriplePoofDustEv.c:
+    complete
+    .text start:0x0200fdc8 end:0x0200fdfc
+
+src/_ZN5Actor10PoofDustAtERK7Vector3.c:
+    complete
+    .text start:0x0200fdfc end:0x0200fe3c
+
+src/_ZN5Actor8PoofDustEv.c:
+    complete
+    .text start:0x0200fe3c end:0x0200fe70
+
+src/UnloadBlueCoinModel.c:
+    complete
+    .text start:0x0200fe70 end:0x0200fe9c
+
+src/LoadBlueCoinModel.c:
+    complete
+    .text start:0x0200fe9c end:0x0200fec8
+
+src/_ZN5Actor17GetWaterHeightWDWEv.c:
+    complete
+    .text start:0x0200fec8 end:0x0200ff14
+
+src/_ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j.c:
+    complete
+    .text start:0x0200ff14 end:0x0200ff60
+
+src/_ZN5Actor11UntrackStarERa.c:
+    complete
+    .text start:0x0200ff60 end:0x0200ff94
+
+src/_ZN5Actor9TrackStarEjj.c:
+    complete
+    .text start:0x0200ff94 end:0x02010044
+
+src/_ZN5Actor11SpawnNumberERK7Vector3jbtPS_.c:
+    complete
+    .text start:0x02010044 end:0x020100dc
+
+src/_ZN5Actor25OnAimedAtWithEggReturnVecEv.cpp:
+    complete
+    .text start:0x020100dc end:0x02010124
+
+src/_ZN5Actor16OnAimedAtWithEggEv.c:
+    complete
+    .text start:0x02010124 end:0x0201012c
+
+src/_ZN5Actor19OnHitFromUnderneathERS_.c:
+    complete
+    .text start:0x0201012c end:0x02010130
+
+src/_ZN5Actor15OnHitByMegaCharER6Player.c:
+    complete
+    .text start:0x02010130 end:0x02010134
+
+src/_ZN5Actor24OnHitByCannonBlastedCharERS_.c:
+    complete
+    .text start:0x02010134 end:0x02010138
+
+src/_ZN5Actor8OnPushedERS_.c:
+    complete
+    .text start:0x02010138 end:0x0201013c
+
+src/_ZN5Actor8OnKickedERS_.c:
+    complete
+    .text start:0x0201013c end:0x02010140
+
+src/_ZN5Actor11OnAttacked2ERS_.c:
+    complete
+    .text start:0x02010140 end:0x02010144
+
+src/_ZN5Actor11OnAttacked1ERS_.c:
+    complete
+    .text start:0x02010144 end:0x02010148
+
+src/_ZN5Actor15OnGroundPoundedERS_.c:
+    complete
+    .text start:0x02010148 end:0x0201014c
+
+src/_ZN5Actor9Virtual50Ev.c:
+    complete
+    .text start:0x0201014c end:0x02010154
+
+src/_ZN5Actor13OnTurnIntoEggER6Player.cpp:
+    complete
+    .text start:0x02010154 end:0x02010160
+
+src/_ZN5Actor13OnYoshiTryEatEv.c:
+    complete
+    .text start:0x02010160 end:0x02010168
+
+src/_ZN5Actor10EarthquakeERK7Vector35Fix12IiE.cpp:
+    complete
+    .text start:0x02010168 end:0x02010180
+
+src/_ZN5Actor11UpdateCarryER6PlayerRK7Vector3.cpp:
+    complete
+    .text start:0x02010180 end:0x020102b0
+
+src/_ZN5Actor13SpawnFireballERK7Vector3PK10Vector3_165Fix12IiES7_j.c:
+    complete
+    .text start:0x020102b0 end:0x02010304
+
+src/func_02010304.cpp:
+    complete
+    .text start:0x02010304 end:0x02010374
+
+src/_ZN5Actor18FindExplosionActorER12CylinderClsn.c:
+    complete
+    .text start:0x02010374 end:0x020103b4
+
+src/_ZN5Actor7FindEggER12CylinderClsn.c:
+    complete
+    .text start:0x020103b4 end:0x020103f4
+
+src/_ZN5Actor14GetSubtractionEss.cpp:
+    complete
+    .text start:0x020103f4 end:0x02010428
+
+src/_ZN5Actor12ReflectAngleE5Fix12IiES1_s.c:
+    complete
+    .text start:0x02010428 end:0x0201045c
+
+src/_ZN5Actor15IsPlayerInRangeERK7Vector3i.c:
+    complete
+    .text start:0x0201045c end:0x02010498
+
+src/_ZN5Actor15IsPlayerInRangeE5Fix12IiES1_S1_i.c:
+    complete
+    .text start:0x02010498 end:0x020104dc
+
+src/_ZN5Actor15IsPlayerInRangeEi.c:
+    complete
+    .text start:0x020104dc end:0x02010518
+
+src/_ZN5Actor24BumpedUnderneathByPlayerER6Player.cpp:
+    complete
+    .text start:0x02010518 end:0x0201054c
+
+src/_ZN5Actor16JumpedOnByPlayerER12CylinderClsnR6Player.c:
+    complete
+    .text start:0x0201054c end:0x020105cc
+
+src/func_020105cc.c:
+    complete
+    .text start:0x020105cc end:0x0201061c
+
+src/_ZN5Actor15GivePlayerCoinsER6Playerhj.c:
+    complete
+    .text start:0x0201061c end:0x02010714
+
+src/_ZN5Actor10SpawnCoinsERK7Vector3j5Fix12IiEs.c:
+    complete
+    .text start:0x02010714 end:0x02010844
+
+src/func_02010844.c:
+    complete
+    .text start:0x02010844 end:0x020108c4
+
+src/_ZN5Actor18ClosestWithActorIDEj.c:
+    complete
+    .text start:0x020108c4 end:0x0201092c
+
+src/_ZN5Actor18HorzAngleToFPlayerEv.c:
+    complete
+    .text start:0x0201092c end:0x02010958
+
+src/_ZN5Actor14FarthestPlayerEv.c:
+    complete
+    .text start:0x02010958 end:0x0201097c
+
+src/_ZN5Actor23HorzAngleToCPlayerOrAngEv.c:
+    complete
+    .text start:0x0201097c end:0x020109b8
+
+src/_ZN5Actor18HorzAngleToCPlayerEv.c:
+    complete
+    .text start:0x020109b8 end:0x020109e4
+
+src/_ZN5Actor13DistToCPlayerEv.c:
+    complete
+    .text start:0x020109e4 end:0x02010a08
+
+src/_ZN5Actor22ClosestNonVanishPlayerEv.c:
+    complete
+    .text start:0x02010a08 end:0x02010ad8
+
+src/_ZN5Actor13ClosestPlayerEv.c:
+    complete
+    .text start:0x02010ad8 end:0x02010b9c
+
+src/_ZN5Actor18DropShadowScaleXYZER11ShadowModelR9Matrix4x35Fix12IiES5_S5_j.c:
+    complete
+    .text start:0x02010b9c end:0x02010be8
+
+src/_ZN5Actor19DropShadowRadHeightER11ShadowModelR9Matrix4x35Fix12IiES5_j.c:
+    complete
+    .text start:0x02010be8 end:0x02010c30
+
+src/_ZN5Actor9UpdatePosEP12CylinderClsn.c:
+    complete
+    .text start:0x02010c30 end:0x02010c5c
+
+src/_ZN5Actor28UpdatePosWithHorzSpeedAndAngEv.c:
+    complete
+    .text start:0x02010c5c end:0x02010d40
+
+src/_ZN5Actor22UpdatePosWithOnlySpeedEP12CylinderClsn.cpp:
+    complete
+    .text start:0x02010d40 end:0x02010da4
+
+src/func_02010da4.c:
+    complete
+    .text start:0x02010da4 end:0x02010e08
+
+src/_ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_.cpp:
+    complete
+    .text start:0x02010e08 end:0x02010e2c
+
+src/_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii.c:
+    complete
+    .text start:0x02010e2c end:0x02010e78
+
+src/func_02010e78.c:
+    complete
+    .text start:0x02010e78 end:0x02010ecc
+
+src/_ZN5Actor4NextEPKS_.cpp:
+    complete
+    .text start:0x02010ecc end:0x02010ef0
+
+src/_ZN5Actor15FindWithActorIDEjPS_.c:
+    complete
+    .text start:0x02010ef0 end:0x02010f3c
+
+src/_ZN5Actor10FindWithIDEj.cpp:
+    complete
+    .text start:0x02010f3c end:0x02010f6c
+
+src/_ZN5Actor11AfterRenderEj.cpp:
+    complete
+    .text start:0x02010f6c end:0x02010f78
+
+src/_ZN5Actor12BeforeRenderEv.c:
+    complete
+    .text start:0x02010f78 end:0x02010fc8
+
+src/_ZN5Actor13AfterBehaviorEj.cpp:
+    complete
+    .text start:0x02010fc8 end:0x02010fd4
+
+src/_ZN5Actor14BeforeBehaviorEv.cpp:
+    .text start:0x02010fd4 end:0x02011214
+
+src/_ZN5Actor21AfterCleanupResourcesEj.cpp:
+    complete
+    .text start:0x02011214 end:0x02011220
+
+src/_ZN5Actor22BeforeCleanupResourcesEv.c:
+    complete
+    .text start:0x02011220 end:0x02011244
+
+src/_ZN5Actor18AfterInitResourcesEj.c:
+    complete
+    .text start:0x02011244 end:0x02011268
+
+src/_ZN5Actor19BeforeInitResourcesEv.c:
+    complete
+    .text start:0x02011268 end:0x020112c8
+
+src/_ZN5ActorD2Ev.cpp:
+    .text start:0x020112c8 end:0x02011314
+
+src/_ZN5ActorD0Ev.c:
+    complete
+    .text start:0x02011314 end:0x02011374
+
+src/_ZN5ActorD1Ev.cpp:
+    .text start:0x02011374 end:0x020113c0
+
+src/_ZN5ActorC1Ev.cpp:
+    complete
+    .text start:0x020113c0 end:0x02011508
+
+src/func_02011508.c:
+    complete
+    .text start:0x02011508 end:0x0201150c
+
+src/_ZN5ActorC2Ev.cpp:
+    complete
+    .text start:0x0201150c end:0x02011654
+
+src/func_02011654.c:
+    complete
+    .text start:0x02011654 end:0x02011698
+
+src/func_02011698.c:
+    complete
+    .text start:0x02011698 end:0x020116c4
+
+src/func_020116c4.c:
+    complete
+    .text start:0x020116c4 end:0x0201179c
+
+src/func_0201179c.c:
+    complete
+    .text start:0x0201179c end:0x0201186c
+
+src/func_0201186c.c:
+    complete
+    .text start:0x0201186c end:0x02011934
+
+src/func_02011934.c:
+    complete
+    .text start:0x02011934 end:0x02011974
+
+src/func_02011974.c:
+    complete
+    .text start:0x02011974 end:0x020119c8
+
+src/func_020119c8.c:
+    complete
+    .text start:0x020119c8 end:0x02011a28
+
+src/func_02011a28.c:
+    complete
+    .text start:0x02011a28 end:0x02011a5c
+
+src/func_02011a5c.c:
+    complete
+    .text start:0x02011a5c end:0x02011aa0
+
+src/func_02011aa0.c:
+    complete
+    .text start:0x02011aa0 end:0x02011ac4
+
+src/func_02011ac4.c:
+    complete
+    .text start:0x02011ac4 end:0x02011af8
+
+src/func_02011af8.c:
+    complete
+    .text start:0x02011af8 end:0x02011b38
+
+src/func_02011b38.c:
+    complete
+    .text start:0x02011b38 end:0x02011b7c
+
+src/func_02011b7c.c:
+    complete
+    .text start:0x02011b7c end:0x02011c24
+
+src/func_02011c24.c:
+    complete
+    .text start:0x02011c24 end:0x02011c54
+
+src/func_02011c54.c:
+    complete
+    .text start:0x02011c54 end:0x02011c8c
+
+src/func_02011c8c.c:
+    complete
+    .text start:0x02011c8c end:0x02011cc8
+
+src/DisableSoundPlayersForCredits.c:
+    complete
+    .text start:0x02011cc8 end:0x02011cfc
+
+src/func_02011cfc.c:
+    complete
+    .text start:0x02011cfc end:0x02011d08
+
+src/func_02011d08.c:
+    complete
+    .text start:0x02011d08 end:0x02011d14
+
+src/func_02011d14.c:
+    complete
+    .text start:0x02011d14 end:0x02011d20
+
+src/func_02011d20.c:
+    complete
+    .text start:0x02011d20 end:0x02011d2c
+
+src/func_02011d2c.c:
+    complete
+    .text start:0x02011d2c end:0x02011d38
+
+src/func_02011d38.c:
+    complete
+    .text start:0x02011d38 end:0x02011d44
+
+src/func_02011d44.c:
+    complete
+    .text start:0x02011d44 end:0x02011d50
+
+src/func_02011d50.c:
+    complete
+    .text start:0x02011d50 end:0x02011d5c
+
+src/func_02011d5c.c:
+    complete
+    .text start:0x02011d5c end:0x02011db4
+
+src/func_02011db4.c:
+    complete
+    .text start:0x02011db4 end:0x02011dc0
+
+src/func_02011dc0.c:
+    complete
+    .text start:0x02011dc0 end:0x02011dcc
+
+src/func_02011dcc.c:
+    complete
+    .text start:0x02011dcc end:0x02011e28
+
+src/Player_PlaySoundEffect.c:
+    complete
+    .text start:0x02011e28 end:0x02011e94
+
+src/func_02011e94.c:
+    complete
+    .text start:0x02011e94 end:0x02011ee4
+
+src/func_02011ee4.c:
+    complete
+    .text start:0x02011ee4 end:0x02011f30
+
+src/_ZN5Sound21ResetPlayerVoiceGroupEv.c:
+    complete
+    .text start:0x02011f30 end:0x02011f7c
+
+src/func_02011f7c.c:
+    complete
+    .text start:0x02011f7c end:0x02011fe8
+
+src/_ZN5Sound21UnsetPlayerVoiceGroupEv.c:
+    complete
+    .text start:0x02011fe8 end:0x02011ffc
+
+src/_ZN5Sound16LoadInitialGroupEi.cpp:
+    complete
+    .text start:0x02011ffc end:0x0201200c
+
+src/_ZN5Sound19LoadGroupAndSetBankEii.c:
+    complete
+    .text start:0x0201200c end:0x02012120
+
+src/func_02012120.c:
+    complete
+    .text start:0x02012120 end:0x02012154
+
+src/_ZN5Sound13PlayCharVoiceEjjRK7Vector3.cpp:
+    complete
+    .text start:0x02012154 end:0x02012174
+
+src/func_02012174.c:
+    complete
+    .text start:0x02012174 end:0x02012194
+
+src/func_02012194.c:
+    complete
+    .text start:0x02012194 end:0x0201226c
+
+src/func_0201226c.c:
+    complete
+    .text start:0x0201226c end:0x02012310
+
+src/func_02012310.c:
+    complete
+    .text start:0x02012310 end:0x02012328
+
+src/_ZN5Sound8PlayLongEjjjRK7Vector3j.c:
+    complete
+    .text start:0x02012328 end:0x020123c8
+
+src/func_020123c8.c:
+    complete
+    .text start:0x020123c8 end:0x02012468
+
+src/func_02012468.c:
+    complete
+    .text start:0x02012468 end:0x020124c4
+
+src/Sound_PlayIfNotActive.c:
+    complete
+    .text start:0x020124c4 end:0x0201251c
+
+src/func_0201251c.c:
+    complete
+    .text start:0x0201251c end:0x02012590
+
+src/_ZN5Sound4PlayEjjRK7Vector3.c:
+    complete
+    .text start:0x02012590 end:0x0201264c
+
+src/_ZN5Sound9PlayBank0EjRK7Vector3.cpp:
+    complete
+    .text start:0x0201264c end:0x02012664
+
+src/_ZN5Sound9PlayBank3EjRK7Vector3.cpp:
+    complete
+    .text start:0x02012664 end:0x0201267c
+
+src/func_0201267c.cpp:
+    complete
+    .text start:0x0201267c end:0x02012694
+
+src/func_02012694.cpp:
+    complete
+    .text start:0x02012694 end:0x020126ac
+
+src/func_020126ac.c:
+    complete
+    .text start:0x020126ac end:0x020126e8
+
+src/func_020126e8.c:
+    complete
+    .text start:0x020126e8 end:0x02012718
+
+src/func_02012718.c:
+    complete
+    .text start:0x02012718 end:0x02012754
+
+src/_ZN5Sound12PlayBank2_2DEj.cpp:
+    complete
+    .text start:0x02012754 end:0x02012768
+
+src/_ZN5Sound12PlayBank3_2DEj.cpp:
+    complete
+    .text start:0x02012768 end:0x0201277c
+
+src/func_0201277c.c:
+    complete
+    .text start:0x0201277c end:0x02012790
+
+src/func_02012790.c:
+    complete
+    .text start:0x02012790 end:0x020127a4
+
+src/func_020127a4.c:
+    complete
+    .text start:0x020127a4 end:0x020127ec
+
+src/func_020127ec.c:
+    complete
+    .text start:0x020127ec end:0x02012840
+
+src/_ZN5Sound6Play2DEjj.cpp:
+    complete
+    .text start:0x02012840 end:0x02012860
+
+src/func_02012860.c:
+    complete
+    .text start:0x02012860 end:0x020128c4
+
+src/_ZN5Sound22StopLoadedMusic_Layer2Ev.c:
+    complete
+    .text start:0x020128c4 end:0x02012940
+
+src/_ZN5Sound22LoadAndSetMusic_Layer2Ej.c:
+    complete
+    .text start:0x02012940 end:0x02012998
+
+src/_ZN5Sound8EndMusicEjj.c:
+    complete
+    .text start:0x02012998 end:0x02012a68
+
+src/_ZN5Sound8SetMusicEjj.c:
+    complete
+    .text start:0x02012a68 end:0x02012af8
+
+src/_ZN5Sound22StopLoadedMusic_Layer3Ev.c:
+    complete
+    .text start:0x02012af8 end:0x02012bbc
+
+src/_ZN5Sound22LoadAndSetMusic_Layer3Ej.cpp:
+    complete
+    .text start:0x02012bbc end:0x02012be0
+
+src/_ZN5Sound7PlaySubEjjj5Fix12IiEb.cpp:
+    complete
+    .text start:0x02012be0 end:0x02012d2c
+
+src/_ZN5Sound17ChangeMusicVolumeEj5Fix12IiE.c:
+    complete
+    .text start:0x02012d2c end:0x02012d64
+
+src/func_02012d64.c:
+    complete
+    .text start:0x02012d64 end:0x02012dbc
+
+src/func_02012dbc.c:
+    complete
+    .text start:0x02012dbc end:0x02012dd0
+
+src/func_02012dd0.c:
+    complete
+    .text start:0x02012dd0 end:0x02012e1c
+
+src/func_02012e1c.c:
+    complete
+    .text start:0x02012e1c end:0x02012e78
+
+src/func_02012e78.c:
+    complete
+    .text start:0x02012e78 end:0x02012ee4
+
+src/_ZN5Sound12UnpauseMusicEv.c:
+    complete
+    .text start:0x02012ee4 end:0x02012f90
+
+src/_ZN5Sound10PauseMusicEv.c:
+    complete
+    .text start:0x02012f90 end:0x02013050
+
+src/_ZN5Sound22StopLoadedMusic_Layer1Ej.cpp:
+    complete
+    .text start:0x02013050 end:0x02013078
+
+src/func_02013078.c:
+    complete
+    .text start:0x02013078 end:0x0201320c
+
+src/_ZN5Sound22LoadAndSetMusic_Layer1Ei.c:
+    complete
+    .text start:0x0201320c end:0x020132d8
+
+src/func_020132d8.cpp:
+    complete
+    .text start:0x020132d8 end:0x020133bc
+
+src/func_020133bc.c:
+    complete
+    .text start:0x020133bc end:0x020134c8
+
+src/func_020134c8.c:
+    complete
+    .text start:0x020134c8 end:0x020134d8
+
+src/func_020134d8.c:
+    complete
+    .text start:0x020134d8 end:0x02013524
+
+src/func_02013524.c:
+    complete
+    .text start:0x02013524 end:0x02013548
+
+src/GetLevelPart.c:
+    complete
+    .text start:0x02013548 end:0x02013558
+
+src/SublevelToLevel.c:
+    complete
+    .text start:0x02013558 end:0x02013568
+
+src/func_02013568.c:
+    complete
+    .text start:0x02013568 end:0x02013580
+
+src/func_02013580.c:
+    complete
+    .text start:0x02013580 end:0x02013598
+
+src/func_02013598.c:
+    complete
+    .text start:0x02013598 end:0x020135d0
+
+src/func_020135d0.c:
+    complete
+    .text start:0x020135d0 end:0x0201361c
+
+src/func_0201361c.c:
+    complete
+    .text start:0x0201361c end:0x02013638
+
+src/func_02013638.c:
+    complete
+    .text start:0x02013638 end:0x02013650
+
+src/_ZN8SaveData21SetCoinRecordIfHigherEah.c:
+    complete
+    .text start:0x02013650 end:0x0201366c
+
+src/_ZN8SaveData13GetCoinRecordEj.c:
+    complete
+    .text start:0x0201366c end:0x0201367c
+
+src/NumStars.c:
+    complete
+    .text start:0x0201367c end:0x020136dc
+
+src/CollectStarInLevel.c:
+    complete
+    .text start:0x020136dc end:0x020136f8
+
+src/IsStarCollectedInLevel.c:
+    complete
+    .text start:0x020136f8 end:0x02013714
+
+src/CountStarsCollectedInLevelToDisplay.c:
+    complete
+    .text start:0x02013714 end:0x02013768
+
+src/_ZN8SaveData26CountStarsCollectedInLevelEj.c:
+    complete
+    .text start:0x02013768 end:0x020137a8
+
+src/CollectStar.c:
+    complete
+    .text start:0x020137a8 end:0x020137e0
+
+src/IsStarCollected.c:
+    complete
+    .text start:0x020137e0 end:0x020137fc
+
+src/OpenCannonInLevel.c:
+    complete
+    .text start:0x020137fc end:0x02013818
+
+src/IsCannonOpenInLevel.c:
+    complete
+    .text start:0x02013818 end:0x02013834
+
+src/OpenCannon.c:
+    complete
+    .text start:0x02013834 end:0x02013850
+
+src/IsCannonOpen.c:
+    complete
+    .text start:0x02013850 end:0x02013868
+
+src/func_02013868.c:
+    complete
+    .text start:0x02013868 end:0x02013890
+
+src/func_02013890.c:
+    complete
+    .text start:0x02013890 end:0x020138dc
+
+src/func_020138dc.c:
+    complete
+    .text start:0x020138dc end:0x02013910
+
+src/_ZN8SaveData17SetCharacterIntroEi.c:
+    complete
+    .text start:0x02013910 end:0x0201392c
+
+src/_ZN8SaveData19IsCharacterUnlockedEj.c:
+    complete
+    .text start:0x0201392c end:0x02013944
+
+src/func_02013944.c:
+    complete
+    .text start:0x02013944 end:0x02013984
+
+src/_ZN8SaveData22NumGlowingRabbitsFoundEv.cpp:
+    complete
+    .text start:0x02013984 end:0x020139b8
+
+src/func_020139b8.c:
+    complete
+    .text start:0x020139b8 end:0x02013a00
+
+src/func_02013a00.c:
+    complete
+    .text start:0x02013a00 end:0x02013a44
+
+src/func_02013a44.c:
+    complete
+    .text start:0x02013a44 end:0x02013a88
+
+src/func_02013a88.c:
+    complete
+    .text start:0x02013a88 end:0x02013ad4
+
+src/_ZN8SaveData13PlayerLoseCapEv.c:
+    complete
+    .text start:0x02013ad4 end:0x02013b18
+
+src/_ZN8SaveData16HasPlayerLostCapEv.c:
+    complete
+    .text start:0x02013b18 end:0x02013b5c
+
+src/_ZN8SaveData16CanPlayerHaveCapEv.cpp:
+    complete
+    .text start:0x02013b5c end:0x02013b9c
+
+src/_ZN8SaveData15SaveCurrentFileEv.c:
+    complete
+    .text start:0x02013b9c end:0x02013be0
+
+src/_ZN8SaveData13SaveMinigamesEP16MinigameSaveData.c:
+    complete
+    .text start:0x02013be0 end:0x02013c0c
+
+src/_ZN8SaveData16ReadMinigameDataEP16MinigameSaveData.c:
+    complete
+    .text start:0x02013c0c end:0x02013c5c
+
+src/_ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData.cpp:
+    .text start:0x02013c5c end:0x02013c84
+
+src/func_02013c84.c:
+    complete
+    .text start:0x02013c84 end:0x02013cd4
+
+src/_ZN8SaveData13EraseSaveFileEjPc.c:
+    complete
+    .text start:0x02013cd4 end:0x02013d14
+
+src/_ZN8SaveData8SaveFileEjP12FileSaveData.cpp:
+    complete
+    .text start:0x02013d14 end:0x02013d54
+
+src/_ZN8SaveData12ReadFileDataEjP12FileSaveData.cpp:
+    complete
+    .text start:0x02013d54 end:0x02013dc4
+
+src/_ZN8SaveData16SetDefaultValuesEP12FileSaveData.cpp:
+    .text start:0x02013dc4 end:0x02013e0c
+
+src/_ZN8SaveData16EraseAllSaveDataEv.c:
+    complete
+    .text start:0x02013e0c end:0x02013e64
+
+src/func_02013e64.c:
+    complete
+    .text start:0x02013e64 end:0x02013e80
+
+src/_ZN12ActorDerivedD1Ev.c:
+    complete
+    .text start:0x02013e80 end:0x02013ea4
+
+src/_ZN12ActorDerivedD0Ev.c:
+    complete
+    .text start:0x02013ea4 end:0x02013edc
+
+src/func_02013edc.c:
+    complete
+    .text start:0x02013edc end:0x02013ee8
+
+src/_ZN12ActorDerived5SpawnEjP9ActorBaseii.cpp:
+    complete
+    .text start:0x02013ee8 end:0x02013ef4
+
+src/_ZN12ActorDerived18AfterInitResourcesEj.c:
+    complete
+    .text start:0x02013ef4 end:0x02013f28
+
+src/func_02013f28.c:
+    complete
+    .text start:0x02013f28 end:0x02013f4c
+
+src/func_02013f4c.c:
+    complete
+    .text start:0x02013f4c end:0x02014150
+
+src/InitCrashScreen.c:
+    complete
+    .text start:0x02014150 end:0x02014214
+
+src/ResetCrashScreen.c:
+    complete
+    .text start:0x02014214 end:0x02014244
+
+src/ShowCrashScreen.c:
+    complete
+    .text start:0x02014244 end:0x02014620
+
+src/nds_printt.c:
+    .text start:0x02014620 end:0x0201470c
+
+src/nds_printf.c:
+    complete
+    .text start:0x0201470c end:0x0201473c
+
+src/func_0201473c.c:
+    complete
+    .text start:0x0201473c end:0x02014770
+
+src/nds_print.c:
+    complete
+    .text start:0x02014770 end:0x020147bc
+
+src/func_020147bc.c:
+    complete
+    .text start:0x020147bc end:0x020147d4
+
+src/_ZN19CylinderClsnWithPos4InitERK7Vector35Fix12IiES4_jj.c:
+    complete
+    .text start:0x020147d4 end:0x02014818
+
+src/_ZN19CylinderClsnWithPos10GetOwnerIDEv.cpp:
+    complete
+    .text start:0x02014818 end:0x02014820
+
+src/_ZN19CylinderClsnWithPos6GetPosEv.c:
+    complete
+    .text start:0x02014820 end:0x02014828
+
+src/_ZN19CylinderClsnWithPosD0Ev.c:
+    complete
+    .text start:0x02014828 end:0x02014854
+
+src/_ZN19CylinderClsnWithPosD1Ev.c:
+    complete
+    .text start:0x02014854 end:0x02014878
+
+src/_ZN19CylinderClsnWithPosC1Ev.c:
+    complete
+    .text start:0x02014878 end:0x0201489c
+
+src/_ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3.c:
+    complete
+    .text start:0x0201489c end:0x020148c8
+
+src/_ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj.c:
+    complete
+    .text start:0x020148c8 end:0x0201490c
+
+src/_ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj.c:
+    complete
+    .text start:0x0201490c end:0x0201493c
+
+src/_ZN18MovingCylinderClsn10GetOwnerIDEv.cpp:
+    complete
+    .text start:0x0201493c end:0x02014948
+
+src/_ZN18MovingCylinderClsn6GetPosEv.cpp:
+    complete
+    .text start:0x02014948 end:0x02014954
+
+src/_ZN18MovingCylinderClsnD2Ev.c:
+    .text start:0x02014954 end:0x02014978
+
+src/_ZN18MovingCylinderClsnD0Ev.c:
+    complete
+    .text start:0x02014978 end:0x020149a4
+
+src/_ZN18MovingCylinderClsnD1Ev.c:
+    .text start:0x020149a4 end:0x020149c8
+
+src/_ZN18MovingCylinderClsnC1Ev.c:
+    complete
+    .text start:0x020149c8 end:0x020149f4
+
+src/_ZN18MovingCylinderClsnC2Ev.c:
+    complete
+    .text start:0x020149f4 end:0x02014a20
+
+src/func_02014a20.c:
+    complete
+    .text start:0x02014a20 end:0x02014a2c
+
+src/_ZN25MovingCylinderClsnWithPos6GetPosEv.c:
+    complete
+    .text start:0x02014a2c end:0x02014a34
+
+src/_ZN25MovingCylinderClsnWithPosD0Ev.c:
+    complete
+    .text start:0x02014a34 end:0x02014a60
+
+src/_ZN25MovingCylinderClsnWithPosD1Ev.c:
+    .text start:0x02014a60 end:0x02014a84
+
+src/_ZN25MovingCylinderClsnWithPosC1Ev.c:
+    complete
+    .text start:0x02014a84 end:0x02014aa8
+
+src/_ZN12CylinderClsn7ProcessEv.cpp:
+    complete
+    .text start:0x02014aa8 end:0x02014f44
+
+src/func_02014f44.c:
+    complete
+    .text start:0x02014f44 end:0x02014f5c
+
+src/func_02014f5c.c:
+    .text start:0x02014f5c end:0x02014fa4
+
+src/func_02014fa4.c:
+    complete
+    .text start:0x02014fa4 end:0x02014ff0
+
+src/_ZN12CylinderClsn6UpdateEv.cpp:
+    complete
+    .text start:0x02014ff0 end:0x02015024
+
+src/_ZN12CylinderClsn5ClearEv.cpp:
+    complete
+    .text start:0x02015024 end:0x02015040
+
+src/_ZN12CylinderClsn4InitE5Fix12IiES1_jj.cpp:
+    complete
+    .text start:0x02015040 end:0x02015058
+
+src/_ZN12CylinderClsnD2Ev.c:
+    complete
+    .text start:0x02015058 end:0x0201507c
+
+src/_ZN12CylinderClsnD0Ev.c:
+    complete
+    .text start:0x0201507c end:0x020150a8
+
+src/_ZN12CylinderClsnD1Ev.c:
+    complete
+    .text start:0x020150a8 end:0x020150cc
+
+src/_ZN12CylinderClsnC2Ev.cpp:
+    complete
+    .text start:0x020150cc end:0x020150e8
+
+src/_ZN7Clipper13Func_020150E8ER7Vector35Fix12IiEPh.c:
+    complete
+    .text start:0x020150e8 end:0x02015560
+
+src/_ZN7Clipper13Func_02015560ER9Matrix4x3R7Vector35Fix12IiES3_.c:
+    complete
+    .text start:0x02015560 end:0x0201559c
+
+src/_ZN7Clipper13Func_0201559CEv.c:
+    complete
+    .text start:0x0201559c end:0x020156dc
+
+src/_ZN7Clipper13Func_020156DCEv.cpp:
+    complete
+    .text start:0x020156dc end:0x020156fc
+
+src/_ZN7ClipperD0Ev.c:
+    .text start:0x020156fc end:0x02015720
+
+src/_ZN7ClipperD1Ev.c:
+    complete
+    .text start:0x02015720 end:0x02015730
+
+src/_ZN7ClipperC1Ev.c:
+    complete
+    .text start:0x02015730 end:0x0201577c
+
+src/_ZN15MaterialChanger7PrepareER8BMD_FileR8BMA_File.cpp:
+    complete
+    .text start:0x0201577c end:0x02015788
+
+src/_ZN15MaterialChanger6UpdateER15ModelComponents.cpp:
+    complete
+    .text start:0x02015788 end:0x020157ac
+
+src/_ZN15MaterialChanger7SetFileER8BMA_Filei5Fix12IiEj.c:
+    complete
+    .text start:0x020157ac end:0x02015800
+
+src/_ZN15MaterialChangerD0Ev.c:
+    complete
+    .text start:0x02015800 end:0x0201582c
+
+src/_ZN15MaterialChangerD1Ev.c:
+    complete
+    .text start:0x0201582c end:0x02015850
+
+src/_ZN15MaterialChangerC1Ev.c:
+    complete
+    .text start:0x02015850 end:0x0201587c
+
+src/_ZN18TextureTransformer7PrepareER8BMD_FileR8BTA_File.cpp:
+    complete
+    .text start:0x0201587c end:0x02015888
+
+src/_ZN18TextureTransformer6UpdateER15ModelComponents.cpp:
+    complete
+    .text start:0x02015888 end:0x020158ac
+
+src/_ZN18TextureTransformer7SetFileER8BTA_Filei5Fix12IiEj.c:
+    complete
+    .text start:0x020158ac end:0x02015900
+
+src/_ZN18TextureTransformerD0Ev.c:
+    complete
+    .text start:0x02015900 end:0x0201592c
+
+src/_ZN18TextureTransformerD1Ev.c:
+    complete
+    .text start:0x0201592c end:0x02015950
+
+src/_ZN18TextureTransformerC1Ev.c:
+    complete
+    .text start:0x02015950 end:0x0201597c
+
+src/_ZN15TextureSequence7PrepareER8BMD_FileR8BTP_File.cpp:
+    complete
+    .text start:0x0201597c end:0x02015988
+
+src/_ZN15TextureSequence6UpdateER15ModelComponents.cpp:
+    complete
+    .text start:0x02015988 end:0x020159ac
+
+src/_ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj.c:
+    complete
+    .text start:0x020159ac end:0x02015a00
+
+src/_ZN15TextureSequenceD0Ev.c:
+    complete
+    .text start:0x02015a00 end:0x02015a2c
+
+src/_ZN15TextureSequenceD1Ev.c:
+    .text start:0x02015a2c end:0x02015a50
+
+src/_ZN15TextureSequenceC1Ev.c:
+    complete
+    .text start:0x02015a50 end:0x02015a7c
+
+src/_ZN9Animation4CopyERKS_.c:
+    complete
+    .text start:0x02015a7c end:0x02015a98
+
+src/_ZNK9Animation12WillHitFrameEi.cpp:
+    .text start:0x02015a98 end:0x02015bcc
+
+src/_ZN9Animation8FinishedEv.cpp:
+    complete
+    .text start:0x02015bcc end:0x02015bec
+
+src/_ZN9Animation8GetFlagsEv.c:
+    complete
+    .text start:0x02015bec end:0x02015bf8
+
+src/_ZN9Animation8SetFlagsEi.cpp:
+    complete
+    .text start:0x02015bf8 end:0x02015c0c
+
+src/_ZNK9Animation13GetFrameCountEv.cpp:
+    complete
+    .text start:0x02015c0c end:0x02015c20
+
+src/_ZN9Animation12SetAnimationEti5Fix12IiEt.cpp:
+    complete
+    .text start:0x02015c20 end:0x02015c3c
+
+src/_ZN9Animation7AdvanceEv.cpp:
+    .text start:0x02015c3c end:0x02015cb4
+
+src/_ZN9AnimationD2Ev.c:
+    complete
+    .text start:0x02015cb4 end:0x02015cc4
+
+src/_ZN9AnimationD0Ev.c:
+    .text start:0x02015cc4 end:0x02015ce8
+
+src/_ZN9AnimationD1Ev.c:
+    complete
+    .text start:0x02015ce8 end:0x02015cf8
+
+src/_ZN9AnimationC1Ev.cpp:
+    complete
+    .text start:0x02015cf8 end:0x02015d18
+
+src/_ZN9AnimationC2Ev.cpp:
+    complete
+    .text start:0x02015d18 end:0x02015d38
+
+src/_ZN11ShadowModel9RenderAllEv.c:
+    complete
+    .text start:0x02015d38 end:0x02015e14
+
+src/_ZN11ShadowModel8CleanAllEv.cpp:
+    complete
+    .text start:0x02015e14 end:0x02015e64
+
+src/_ZN11ShadowModel9InitModelEP9Matrix4x35Fix12IiES3_S3_j.c:
+    complete
+    .text start:0x02015e64 end:0x02015ebc
+
+src/_ZN11ShadowModel12InitCylinderEv.cpp:
+    .text start:0x02015ebc end:0x02015ed8
+
+src/_ZN11ShadowModel10InitCuboidEv.cpp:
+    .text start:0x02015ed8 end:0x02015ef4
+
+src/_ZN11ShadowModel9DoSetFileEPcii.c:
+    complete
+    .text start:0x02015ef4 end:0x02015f80
+
+src/_ZN11ShadowModelD0Ev.c:
+    complete
+    .text start:0x02015f80 end:0x02015ff8
+
+src/_ZN11ShadowModelD1Ev.c:
+    complete
+    .text start:0x02015ff8 end:0x02016068
+
+src/_ZN11ShadowModelC1Ev.c:
+    complete
+    .text start:0x02016068 end:0x0201609c
+
+src/_ZN11CommonModel13Func_0201609CEj.cpp:
+    complete
+    .text start:0x0201609c end:0x020160ac
+
+src/_ZN11CommonModel13Func_020160ACEj.cpp:
+    complete
+    .text start:0x020160ac end:0x02016104
+
+src/_ZN11CommonModel6RenderEPK7Vector3.c:
+    complete
+    .text start:0x02016104 end:0x02016144
+
+src/_ZN11CommonModel9DoSetFileEPcii.c:
+    complete
+    .text start:0x02016144 end:0x020161b4
+
+src/_ZN11CommonModelD0Ev.c:
+    complete
+    .text start:0x020161b4 end:0x020161e0
+
+src/_ZN11CommonModelD1Ev.c:
+    complete
+    .text start:0x020161e0 end:0x02016204
+
+src/_ZN11CommonModelC1Ev.c:
+    complete
+    .text start:0x02016204 end:0x02016254
+
+src/_ZN10ModelAnim24CopyERKS_Pcj.c:
+    complete
+    .text start:0x02016254 end:0x0201628c
+
+src/func_0201628c.c:
+    complete
+    .text start:0x0201628c end:0x020162a4
+
+src/func_020162a4.c:
+    complete
+    .text start:0x020162a4 end:0x020162c4
+
+src/_ZN10ModelAnim213Func_020162C4Eji5Fix12IiEt.c:
+    complete
+    .text start:0x020162c4 end:0x02016320
+
+src/_ZN10ModelAnim2D0Ev.c:
+    complete
+    .text start:0x02016320 end:0x02016364
+
+src/_ZN10ModelAnim2D1Ev.c:
+    complete
+    .text start:0x02016364 end:0x020163a0
+
+src/_ZN10ModelAnim2C1Ev.c:
+    complete
+    .text start:0x020163a0 end:0x020163e0
+
+src/_ZN14BlendModelAnim7SetAnimER8BCA_Fileii5Fix12IiEt.cpp:
+    complete
+    .text start:0x020163e0 end:0x0201647c
+
+src/_ZN14BlendModelAnim7AdvanceEv.c:
+    complete
+    .text start:0x0201647c end:0x020164b0
+
+src/_ZN14BlendModelAnim9Virtual18EjPK7Vector3.c:
+    .text start:0x020164b0 end:0x020164e4
+
+src/_ZN14BlendModelAnim6RenderEPK7Vector3.c:
+    .text start:0x020164e4 end:0x02016518
+
+src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.c:
+    complete
+    .text start:0x02016518 end:0x02016578
+
+src/_ZN14BlendModelAnim11UpdateVertsEv.c:
+    complete
+    .text start:0x02016578 end:0x020165c4
+
+src/func_020165c4.c:
+    complete
+    .text start:0x020165c4 end:0x02016604
+
+src/_ZN14BlendModelAnim9DoSetFileEPcii.c:
+    complete
+    .text start:0x02016604 end:0x02016644
+
+src/_ZN14BlendModelAnimD0Ev.c:
+    complete
+    .text start:0x02016644 end:0x02016690
+
+src/_ZN14BlendModelAnimD1Ev.c:
+    .text start:0x02016690 end:0x020166d4
+
+src/_ZN14BlendModelAnimC1Ev.c:
+    complete
+    .text start:0x020166d4 end:0x02016714
+
+src/_ZN9ModelAnim4CopyERKS_Pc.c:
+    complete
+    .text start:0x02016714 end:0x02016748
+
+src/_ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj.c:
+    complete
+    .text start:0x02016748 end:0x020167a4
+
+src/func_020167a4.c:
+    complete
+    .text start:0x020167a4 end:0x020167c4
+
+src/_ZN9ModelAnim9Virtual18EjPK7Vector3.c:
+    .text start:0x020167c4 end:0x020167f8
+
+src/_ZN9ModelAnim6RenderEPK7Vector3.c:
+    .text start:0x020167f8 end:0x0201682c
+
+src/_ZN9ModelAnim9Virtual10ER9Matrix4x3.c:
+    complete
+    .text start:0x0201682c end:0x0201686c
+
+src/_ZN9ModelAnim11UpdateVertsEv.c:
+    complete
+    .text start:0x0201686c end:0x0201689c
+
+src/_ZN9ModelAnimD2Ev.c:
+    complete
+    .text start:0x0201689c end:0x020168d8
+
+src/_ZN9ModelAnimD0Ev.c:
+    complete
+    .text start:0x020168d8 end:0x0201691c
+
+src/_ZN9ModelAnimD1Ev.c:
+    complete
+    .text start:0x0201691c end:0x02016958
+
+src/_ZN9ModelAnimC1Ev.c:
+    complete
+    .text start:0x02016958 end:0x02016998
+
+src/_ZN9ModelAnimC2Ev.c:
+    complete
+    .text start:0x02016998 end:0x020169d8
+
+src/func_020169d8.c:
+    complete
+    .text start:0x020169d8 end:0x020169f4
+
+src/func_020169f4.c:
+    complete
+    .text start:0x020169f4 end:0x02016a04
+
+src/func_02016a04.c:
+    complete
+    .text start:0x02016a04 end:0x02016a14
+
+src/func_02016a14.c:
+    complete
+    .text start:0x02016a14 end:0x02016a24
+
+src/_ZN5Model12ShowMaterialEii.cpp:
+    complete
+    .text start:0x02016a24 end:0x02016a58
+
+src/_ZN5Model12HideMaterialEii.cpp:
+    complete
+    .text start:0x02016a58 end:0x02016a8c
+
+src/_ZN5Model14SetPolygonModeEi.cpp:
+    complete
+    .text start:0x02016a8c end:0x02016a9c
+
+src/_ZN9ModelBase12ApplyOpacityEj.cpp:
+    complete
+    .text start:0x02016a9c end:0x02016aac
+
+src/func_02016aac.c:
+    complete
+    .text start:0x02016aac end:0x02016abc
+
+src/_ZN5Model12SetPolygonIDEi.cpp:
+    complete
+    .text start:0x02016abc end:0x02016acc
+
+src/func_02016acc.c:
+    complete
+    .text start:0x02016acc end:0x02016b24
+
+src/func_02016b24.c:
+    complete
+    .text start:0x02016b24 end:0x02016b78
+
+src/_ZN5Model6RenderEPK7Vector3.c:
+    complete
+    .text start:0x02016b78 end:0x02016bb8
+
+src/_ZN5Model9Virtual10ER9Matrix4x3.c:
+    complete
+    .text start:0x02016bb8 end:0x02016bf8
+
+src/_ZN5Model9DoSetFileEPcii.cpp:
+    complete
+    .text start:0x02016bf8 end:0x02016c98
+
+src/_ZN5Model11UpdateVertsEv.cpp:
+    complete
+    .text start:0x02016c98 end:0x02016ca8
+
+src/_ZN5ModelD2Ev.c:
+    .text start:0x02016ca8 end:0x02016ce0
+
+src/_ZN5ModelD0Ev.c:
+    complete
+    .text start:0x02016ce0 end:0x02016d20
+
+src/_ZN5ModelD1Ev.c:
+    .text start:0x02016d20 end:0x02016d58
+
+src/_ZN5ModelC1Ev.c:
+    complete
+    .text start:0x02016d58 end:0x02016da8
+
+src/_ZN5ModelC2Ev.c:
+    complete
+    .text start:0x02016da8 end:0x02016df8
+
+src/CleanCommonModelDataArr.c:
+    .text start:0x02016df8 end:0x02016e70
+
+src/func_02016e70.c:
+    complete
+    .text start:0x02016e70 end:0x02016f08
+
+src/_ZN5Model23AddToCommonModelDataArrER8BMD_File.c:
+    complete
+    .text start:0x02016f08 end:0x02016f9c
+
+src/_ZN5Model14LoadAndSetFileEtii.c:
+    complete
+    .text start:0x02016f9c end:0x02016fd4
+
+src/_ZN9ModelBase7SetFileEP8BMD_Fileii.cpp:
+    complete
+    .text start:0x02016fd4 end:0x02016ff4
+
+src/func_02016ff4.cpp:
+    complete
+    .text start:0x02016ff4 end:0x02017060
+
+src/func_02017060.c:
+    complete
+    .text start:0x02017060 end:0x020170b8
+
+src/_ZN9ModelBaseD2Ev.c:
+    complete
+    .text start:0x020170b8 end:0x020170e8
+
+src/_ZN9ModelBaseD0Ev.c:
+    complete
+    .text start:0x020170e8 end:0x02017120
+
+src/_ZN9ModelBaseD1Ev.c:
+    complete
+    .text start:0x02017120 end:0x02017150
+
+src/_ZN9ModelBaseC1Ev.c:
+    complete
+    .text start:0x02017150 end:0x02017168
+
+src/_ZThn80_N9ModelAnimD0Ev.cpp:
+    .text start:0x02017168 end:0x02017178
+
+src/_ZThn80_N9ModelAnimD1Ev.cpp:
+    .text start:0x02017178 end:0x02017188
+
+src/_ZThn80_N14BlendModelAnimD0Ev.cpp:
+    .text start:0x02017188 end:0x02017198
+
+src/_ZThn80_N14BlendModelAnimD1Ev.cpp:
+    .text start:0x02017198 end:0x020171a8
+
+src/_ZThn80_N10ModelAnim2D0Ev.cpp:
+    .text start:0x020171a8 end:0x020171b8
+
+src/_ZThn80_N10ModelAnim2D1Ev.cpp:
+    .text start:0x020171b8 end:0x020171c8
+
+src/func_020171c8.cpp:
+    complete
+    .text start:0x020171c8 end:0x020171f0
+
+src/func_020171f0.cpp:
+    complete
+    .text start:0x020171f0 end:0x0201721c
+
+src/func_0201721c.c:
+    complete
+    .text start:0x0201721c end:0x02017228
+
+src/func_02017228.c:
+    complete
+    .text start:0x02017228 end:0x02017254
+
+src/func_02017254.c:
+    complete
+    .text start:0x02017254 end:0x02017278
+
+src/func_02017278.c:
+    complete
+    .text start:0x02017278 end:0x020172c0
+
+src/_ZN9FaderWipe14LoadAndSetFileEt.cpp:
+    complete
+    .text start:0x020172c0 end:0x020172d8
+
+src/_ZN9FaderWipe11AdvanceFadeEv.cpp:
+    .text start:0x020172d8 end:0x02017418
+
+src/_ZN9FaderWipeD0Ev.c:
+    complete
+    .text start:0x02017418 end:0x02017450
+
+src/_ZN9FaderWipeD1Ev.c:
+    complete
+    .text start:0x02017450 end:0x02017480
+
+src/_ZN9FaderWipeC1Ev.c:
+    complete
+    .text start:0x02017480 end:0x020174e0
+
+src/_ZN10FaderColor11AdvanceFadeEv.cpp:
+    complete
+    .text start:0x020174e0 end:0x02017574
+
+src/_ZN5ColorD1Ev.c:
+    complete
+    .text start:0x02017574 end:0x02017598
+
+src/_ZN10FaderColorD0Ev.c:
+    complete
+    .text start:0x02017598 end:0x020175c4
+
+src/_ZN10FaderColorD1Ev.c:
+    complete
+    .text start:0x020175c4 end:0x020175e8
+
+src/_ZN5Fader13AdvanceInterpEv.cpp:
+    .text start:0x020175e8 end:0x02017610
+
+src/_ZN15FaderBrightness10SetToStartEv.cpp:
+    complete
+    .text start:0x02017610 end:0x0201761c
+
+src/_ZN15FaderBrightness8SetToEndEv.cpp:
+    complete
+    .text start:0x0201761c end:0x02017628
+
+src/_ZN15FaderBrightness20IsBetweenStartAndEndEv.cpp:
+    complete
+    .text start:0x02017628 end:0x02017670
+
+src/_ZN15FaderBrightness7IsAtEndEv.cpp:
+    complete
+    .text start:0x02017670 end:0x02017684
+
+src/_ZN15FaderBrightness9IsAtStartEv.cpp:
+    complete
+    .text start:0x02017684 end:0x02017698
+
+src/_ZN15FaderBrightness14SetForwardTimeEj.cpp:
+    complete
+    .text start:0x02017698 end:0x020176d8
+
+src/_ZN15FaderBrightness15SetBackwardTimeEj.cpp:
+    complete
+    .text start:0x020176d8 end:0x02017720
+
+src/_ZN15FaderBrightness11AdvanceFadeEv.cpp:
+    complete
+    .text start:0x02017720 end:0x020177c4
+
+src/func_020177c4.c:
+    complete
+    .text start:0x020177c4 end:0x020177e8
+
+src/_ZN15FaderBrightnessD0Ev.c:
+    complete
+    .text start:0x020177e8 end:0x02017814
+
+src/_ZN15FaderBrightnessD1Ev.c:
+    complete
+    .text start:0x02017814 end:0x02017838
+
+src/func_02017838.c:
+    complete
+    .text start:0x02017838 end:0x02017848
+
+src/_ZN5FaderD0Ev.c:
+    .text start:0x02017848 end:0x0201786c
+
+src/_ZN5FaderD1Ev.c:
+    complete
+    .text start:0x0201786c end:0x0201787c
+
+src/func_0201787c.c:
+    complete
+    .text start:0x0201787c end:0x020178b4
+
+src/func_020178b4.c:
+    complete
+    .text start:0x020178b4 end:0x020178cc
+
+src/func_020178cc.c:
+    complete
+    .text start:0x020178cc end:0x020178e4
+
+src/_ZN15TextureSequence8LoadFileER13SharedFilePtr.c:
+    complete
+    .text start:0x020178e4 end:0x0201791c
+
+src/SharedFilePtr_Destruct_TexSeq.c:
+    complete
+    .text start:0x0201791c end:0x02017934
+
+src/SharedFilePtr_Construct_TexSeq.c:
+    complete
+    .text start:0x02017934 end:0x0201794c
+
+src/_ZN9Animation8LoadFileER13SharedFilePtr.c:
+    complete
+    .text start:0x0201794c end:0x02017984
+
+src/SharedFilePtr_Destruct_Anim.c:
+    complete
+    .text start:0x02017984 end:0x0201799c
+
+src/_ZN13SharedFilePtr9ConstructEj.c:
+    complete
+    .text start:0x0201799c end:0x020179b4
+
+src/func_020179b4.c:
+    complete
+    .text start:0x020179b4 end:0x02017a0c
+
+src/func_02017a0c.c:
+    complete
+    .text start:0x02017a0c end:0x02017a24
+
+src/func_02017a24.c:
+    complete
+    .text start:0x02017a24 end:0x02017a3c
+
+src/_ZN5Model8LoadFileER13SharedFilePtr.c:
+    complete
+    .text start:0x02017a3c end:0x02017a8c
+
+src/_ZN13SharedFilePtr19ReallocateModelFileEv.cpp:
+    complete
+    .text start:0x02017a8c end:0x02017a9c
+
+src/func_02017a9c.c:
+    complete
+    .text start:0x02017a9c end:0x02017ab4
+
+src/func_02017ab4.c:
+    complete
+    .text start:0x02017ab4 end:0x02017acc
+
+src/func_02017acc.c:
+    complete
+    .text start:0x02017acc end:0x02017ae4
+
+src/func_02017ae4.c:
+    complete
+    .text start:0x02017ae4 end:0x02017afc
+
+src/_ZN12MeshCollider8LoadFileER13SharedFilePtr.c:
+    complete
+    .text start:0x02017afc end:0x02017b34
+
+src/SharedFilePtr_Destruct_Clsn.c:
+    complete
+    .text start:0x02017b34 end:0x02017b4c
+
+src/func_02017b4c.c:
+    complete
+    .text start:0x02017b4c end:0x02017b64
+
+src/_ZN13SharedFilePtr7ReleaseEv.c:
+    complete
+    .text start:0x02017b64 end:0x02017bc4
+
+src/_ZN13SharedFilePtr8LoadFileEv.c:
+    complete
+    .text start:0x02017bc4 end:0x02017c24
+
+src/func_02017c24.c:
+    complete
+    .text start:0x02017c24 end:0x02017c54
+
+src/_ZN13SharedFilePtr4LoadEv.cpp:
+    complete
+    .text start:0x02017c54 end:0x02017e0c
+
+src/func_02017e0c.c:
+    complete
+    .text start:0x02017e0c end:0x02017e34
+
+src/func_02017e34.c:
+    complete
+    .text start:0x02017e34 end:0x02017e48
+
+src/func_02017e48.c:
+    complete
+    .text start:0x02017e48 end:0x02017e60
+
+src/func_02017e60.c:
+    complete
+    .text start:0x02017e60 end:0x02017e94
+
+src/func_02017e94.c:
+    complete
+    .text start:0x02017e94 end:0x02017f34
+
+src/UnloadOverlay.c:
+    complete
+    .text start:0x02017f34 end:0x02017fd0
+
+src/func_02017fd0.c:
+    complete
+    .text start:0x02017fd0 end:0x02018028
+
+src/LoadOverlay.c:
+    complete
+    .text start:0x02018028 end:0x02018100
+
+src/LoadCompressedFileAt.c:
+    complete
+    .text start:0x02018100 end:0x02018144
+
+src/Deallocate.c:
+    complete
+    .text start:0x02018144 end:0x0201816c
+
+src/LoadFile.c:
+    complete
+    .text start:0x0201816c end:0x0201817c
+
+src/func_0201817c.c:
+    complete
+    .text start:0x0201817c end:0x0201818c
+
+src/func_0201818c.c:
+    complete
+    .text start:0x0201818c end:0x02018270
+
+src/func_02018270.c:
+    complete
+    .text start:0x02018270 end:0x020182ac
+
+src/LoadFileAt.c:
+    complete
+    .text start:0x020182ac end:0x020182bc
+
+src/func_020182bc.c:
+    complete
+    .text start:0x020182bc end:0x020182ec
+
+src/func_020182ec.c:
+    complete
+    .text start:0x020182ec end:0x0201834c
+
+src/func_0201834c.c:
+    complete
+    .text start:0x0201834c end:0x02018434
+
+src/func_02018434.c:
+    complete
+    .text start:0x02018434 end:0x02018474
+
+src/func_02018474.c:
+    complete
+    .text start:0x02018474 end:0x020184e0
+
+src/func_020184e0.c:
+    complete
+    .text start:0x020184e0 end:0x02018568
+
+src/func_02018568.c:
+    complete
+    .text start:0x02018568 end:0x02018598
+
+src/func_02018598.c:
+    complete
+    .text start:0x02018598 end:0x020185c0
+
+src/func_020185c0.c:
+    complete
+    .text start:0x020185c0 end:0x020186c0
+
+src/func_020186c0.c:
+    complete
+    .text start:0x020186c0 end:0x02018770
+
+src/func_02018770.c:
+    complete
+    .text start:0x02018770 end:0x020187b0
+
+src/UnloadArchives.c:
+    complete
+    .text start:0x020187b0 end:0x020187f4
+
+src/LoadTextNarcs.c:
+    complete
+    .text start:0x020187f4 end:0x02018864
+
+src/UnloadArchive.c:
+    complete
+    .text start:0x02018864 end:0x020188a8
+
+src/LoadArchive.c:
+    complete
+    .text start:0x020188a8 end:0x02018908
+
+src/func_02018908.c:
+    complete
+    .text start:0x02018908 end:0x02018934
+
+src/func_02018934.c:
+    complete
+    .text start:0x02018934 end:0x020189f0
+
+src/func_020189f0.c:
+    complete
+    .text start:0x020189f0 end:0x02018a24
+
+src/func_02018a24.c:
+    complete
+    .text start:0x02018a24 end:0x02018a40
+
+src/func_02018a40.c:
+    complete
+    .text start:0x02018a40 end:0x02018a58
+
+src/func_02018a58.cpp:
+    complete
+    .text start:0x02018a58 end:0x02018aa4
+
+src/func_02018aa4.c:
+    complete
+    .text start:0x02018aa4 end:0x02018ac4
+
+src/func_02018ac4.c:
+    complete
+    .text start:0x02018ac4 end:0x02018ad0
+
+src/FS_LoadOverlay.c:
+    .text start:0x02018ad0 end:0x02018b64
+
+src/func_02018b64.c:
+    complete
+    .text start:0x02018b64 end:0x02018c00
+
+src/func_02018c00.c:
+    complete
+    .text start:0x02018c00 end:0x02018cbc
+
+src/func_02018cbc.c:
+    complete
+    .text start:0x02018cbc end:0x02018d48
+
+src/func_02018d48.c:
+    complete
+    .text start:0x02018d48 end:0x02018d98
+
+src/func_02018d98.c:
+    complete
+    .text start:0x02018d98 end:0x02018dc4
+
+src/func_02018dc4.c:
+    complete
+    .text start:0x02018dc4 end:0x02018e00
+
+src/func_02018e00.c:
+    complete
+    .text start:0x02018e00 end:0x02018e3c
+
+src/func_02018e3c.c:
+    complete
+    .text start:0x02018e3c end:0x02018e68
+
+src/func_02018e68.c:
+    complete
+    .text start:0x02018e68 end:0x02018ea0
+
+src/_ZN5Scene14GraphCallback3Ev.c:
+    complete
+    .text start:0x02018ea0 end:0x02018ea8
+
+src/_ZN5Scene14GraphCallback2Ev.c:
+    complete
+    .text start:0x02018ea8 end:0x02018eb0
+
+src/_ZN5Scene14GraphCallback1Ev.c:
+    complete
+    .text start:0x02018eb0 end:0x02018eb8
+
+src/_ZN5Scene14GraphCallback0Ev.c:
+    complete
+    .text start:0x02018eb8 end:0x02018ec0
+
+src/func_02018ec0.c:
+    complete
+    .text start:0x02018ec0 end:0x02018efc
+
+src/func_02018efc.c:
+    complete
+    .text start:0x02018efc end:0x02018f38
+
+src/SetSubBg3Offset.c:
+    complete
+    .text start:0x02018f38 end:0x02018f54
+
+src/SetSubBg2Offset.c:
+    complete
+    .text start:0x02018f54 end:0x02018f70
+
+src/SetSubBg1Offset.c:
+    complete
+    .text start:0x02018f70 end:0x02018f8c
+
+src/SetSubBg0Offset.c:
+    complete
+    .text start:0x02018f8c end:0x02018fa8
+
+src/SetBg3Offset.c:
+    complete
+    .text start:0x02018fa8 end:0x02018fc4
+
+src/SetBg2Offset.c:
+    complete
+    .text start:0x02018fc4 end:0x02018fe0
+
+src/SetBg1Offset.c:
+    complete
+    .text start:0x02018fe0 end:0x02018ffc
+
+src/SetBg0Offset.c:
+    complete
+    .text start:0x02018ffc end:0x02019018
+
+src/func_02019018.c:
+    complete
+    .text start:0x02019018 end:0x02019028
+
+src/func_02019028.c:
+    complete
+    .text start:0x02019028 end:0x02019070
+
+src/Enable3dEngines.c:
+    complete
+    .text start:0x02019070 end:0x020190b8
+
+src/func_020190b8.c:
+    complete
+    .text start:0x020190b8 end:0x02019100
+
+src/func_02019100.c:
+    complete
+    .text start:0x02019100 end:0x02019144
+
+src/func_02019144.c:
+    complete
+    .text start:0x02019144 end:0x02019390
+
+src/func_02019390.c:
+    complete
+    .text start:0x02019390 end:0x02019404
+
+src/func_02019404.c:
+    complete
+    .text start:0x02019404 end:0x02019440
+
+src/func_02019440.c:
+    complete
+    .text start:0x02019440 end:0x02019510
+
+src/SetSoundMode.c:
+    complete
+    .text start:0x02019510 end:0x02019574
+
+src/GetSoundMode.c:
+    complete
+    .text start:0x02019574 end:0x02019584
+
+src/_ZN5Timer7GetTimeEv.cpp:
+    .text start:0x02019584 end:0x020195c0
+
+src/_ZN5Timer9StopTimerEv.cpp:
+    .text start:0x020195c0 end:0x02019604
+
+src/_ZN5Timer10StartTimerEv.cpp:
+    .text start:0x02019604 end:0x02019638
+
+src/_ZN5Timer10ResetTimerEv.cpp:
+    complete
+    .text start:0x02019638 end:0x0201964c
+
+src/func_0201964c.c:
+    complete
+    .text start:0x0201964c end:0x02019664
+
+src/TurnBacklightOff.c:
+    complete
+    .text start:0x02019664 end:0x02019698
+
+src/TurnBacklightOn.c:
+    complete
+    .text start:0x02019698 end:0x020196cc
+
+src/func_020196cc.c:
+    complete
+    .text start:0x020196cc end:0x0201973c
+
+src/func_0201973c.c:
+    complete
+    .text start:0x0201973c end:0x02019740
+
+src/Crash.c:
+    complete
+    .text start:0x02019740 end:0x02019780
+
+src/func_02019780.c:
+    complete
+    .text start:0x02019780 end:0x020197b8
+
+src/func_020197b8.c:
+    complete
+    .text start:0x020197b8 end:0x020199a4
+
+src/func_020199a4.c:
+    complete
+    .text start:0x020199a4 end:0x02019a58
+
+src/func_02019a58.c:
+    complete
+    .text start:0x02019a58 end:0x02019ac4
+
+src/func_02019ac4.c:
+    complete
+    .text start:0x02019ac4 end:0x02019dfc
+
+src/func_02019dfc.c:
+    complete
+    .text start:0x02019dfc end:0x02019e60
+
+src/func_02019e60.c:
+    complete
+    .text start:0x02019e60 end:0x02019ebc
+
+src/func_02019ebc.c:
+    .text start:0x02019ebc end:0x02019ed0
+
+src/func_02019ed0.c:
+    complete
+    .text start:0x02019ed0 end:0x02019f10
+
+src/func_02019f10.c:
+    complete
+    .text start:0x02019f10 end:0x02019f64
+
+src/func_02019f64.c:
+    complete
+    .text start:0x02019f64 end:0x02019ff4
+
+src/func_02019ff4.c:
+    complete
+    .text start:0x02019ff4 end:0x0201a028
+
+src/func_0201a028.c:
+    complete
+    .text start:0x0201a028 end:0x0201a03c
+
+src/func_0201a03c.c:
+    complete
+    .text start:0x0201a03c end:0x0201a054
+
+src/func_0201a054.c:
+    complete
+    .text start:0x0201a054 end:0x0201a1bc
+
+src/func_0201a1bc.c:
+    complete
+    .text start:0x0201a1bc end:0x0201a244
+
+src/func_0201a244.c:
+    complete
+    .text start:0x0201a244 end:0x0201a2f8
+
+src/func_0201a2f8.c:
+    .text start:0x0201a2f8 end:0x0201a3e4
+
+src/func_0201a3e4.c:
+    complete
+    .text start:0x0201a3e4 end:0x0201a428
+
+src/func_0201a428.c:
+    complete
+    .text start:0x0201a428 end:0x0201a458
+
+src/func_0201a458.c:
+    .text start:0x0201a458 end:0x0201a490
+
+src/func_0201a490.c:
+    complete
+    .text start:0x0201a490 end:0x0201a4bc
+
+src/func_0201a4bc.c:
+    complete
+    .text start:0x0201a4bc end:0x0201a4d0
+
+src/func_0201a4d0.c:
+    complete
+    .text start:0x0201a4d0 end:0x0201a4e4
+
+src/func_0201a4e4.c:
+    complete
+    .text start:0x0201a4e4 end:0x0201a534
+
+src/_ZN3IRQ13VBlankHandlerEv.c:
+    complete
+    .text start:0x0201a534 end:0x0201a5cc
+
+src/func_0201a5cc.c:
+    complete
+    .text start:0x0201a5cc end:0x0201a5f8
+
+src/func_0201a5f8.c:
+    complete
+    .text start:0x0201a5f8 end:0x0201a614
+
+src/func_0201a614.c:
+    .text start:0x0201a614 end:0x0201a694
+
+src/func_0201a694.c:
+    .text start:0x0201a694 end:0x0201a754
+
+src/func_0201a754.c:
+    .text start:0x0201a754 end:0x0201a798
+
+src/func_0201a798.c:
+    .text start:0x0201a798 end:0x0201a7dc
+
+src/GetSceneOverlayID.c:
+    .text start:0x0201a7dc end:0x0201a888
+
+src/IsMinigameActorID.c:
+    complete
+    .text start:0x0201a888 end:0x0201a8b4
+
+src/func_0201a8b4.c:
+    .text start:0x0201a8b4 end:0x0201a96c
+
+src/func_0201a96c.c:
+    complete
+    .text start:0x0201a96c end:0x0201a9ec
+
+src/func_0201a9ec.c:
+    complete
+    .text start:0x0201a9ec end:0x0201a9fc
+
+src/func_0201a9fc.c:
+    complete
+    .text start:0x0201a9fc end:0x0201aa18
+
+src/func_0201aa18.c:
+    complete
+    .text start:0x0201aa18 end:0x0201aa50
+
+src/func_0201aa50.c:
+    complete
+    .text start:0x0201aa50 end:0x0201aaa4
+
+src/func_0201aaa4.c:
+    complete
+    .text start:0x0201aaa4 end:0x0201aab0
+
+src/func_0201aab0.c:
+    complete
+    .text start:0x0201aab0 end:0x0201aac8
+
+src/func_0201aac8.c:
+    complete
+    .text start:0x0201aac8 end:0x0201aad4
+
+src/func_0201aad4.c:
+    complete
+    .text start:0x0201aad4 end:0x0201aaec
+
+src/func_0201aaec.c:
+    complete
+    .text start:0x0201aaec end:0x0201ab04
+
+src/_ZN7Message7EndTalkEv.c:
+    complete
+    .text start:0x0201ab04 end:0x0201ab38
+
+src/_ZN7Message11PrepareTalkEv.c:
+    complete
+    .text start:0x0201ab38 end:0x0201ab6c
+
+src/func_0201ab6c.c:
+    complete
+    .text start:0x0201ab6c end:0x0201aca4
+
+src/func_0201aca4.c:
+    .text start:0x0201aca4 end:0x0201adac
+
+src/func_0201adac.c:
+    complete
+    .text start:0x0201adac end:0x0201adfc
+
+src/func_0201adfc.c:
+    complete
+    .text start:0x0201adfc end:0x0201b100
+
+src/func_0201b100.c:
+    complete
+    .text start:0x0201b100 end:0x0201b388
+
+src/func_0201b388.c:
+    complete
+    .text start:0x0201b388 end:0x0201b5a8
+
+src/_ZN7Message7AddCharEc.cpp:
+    complete
+    .text start:0x0201b5a8 end:0x0201b6f8
+
+src/func_0201b6f8.c:
+    complete
+    .text start:0x0201b6f8 end:0x0201b7cc
+
+src/func_0201b7cc.c:
+    complete
+    .text start:0x0201b7cc end:0x0201bbc8
+
+src/_ZN7Message12UpdateWindowEv.cpp:
+    complete
+    .text start:0x0201bbc8 end:0x0201c0b8
+
+src/_ZN7Message6UpdateEv.cpp:
+    .text start:0x0201c0b8 end:0x0201cb2c
+
+src/func_0201cb2c.c:
+    complete
+    .text start:0x0201cb2c end:0x0201cb7c
+
+src/_ZN5Stage13UpdateMessageEv.cpp:
+    .text start:0x0201cb7c end:0x0201cd08
+
+src/func_0201cd08.cpp:
+    complete
+    .text start:0x0201cd08 end:0x0201ce10
+
+src/_ZN7Message21DisplaySaveStatusTextEt.cpp:
+    .text start:0x0201ce10 end:0x0201cebc
+
+src/func_0201cebc.c:
+    complete
+    .text start:0x0201cebc end:0x0201cf80
+
+src/_ZN7Message21DisplayLevelClearTextEta.c:
+    complete
+    .text start:0x0201cf80 end:0x0201cfb8
+
+src/func_0201cfb8.c:
+    complete
+    .text start:0x0201cfb8 end:0x0201d018
+
+src/_ZN7Message22DisplayOptionsMenuTextEt.cpp:
+    .text start:0x0201d018 end:0x0201d0f8
+
+src/LoadControllerModeText.c:
+    complete
+    .text start:0x0201d0f8 end:0x0201d304
+
+src/_ZN7Message25DisplayControllerModeTextEt.cpp:
+    .text start:0x0201d304 end:0x0201d418
+
+src/func_0201d418.c:
+    complete
+    .text start:0x0201d418 end:0x0201d590
+
+src/func_0201d590.cpp:
+    complete
+    .text start:0x0201d590 end:0x0201d6a0
+
+src/Message_DrawCenteredLine.c:
+    complete
+    .text start:0x0201d6a0 end:0x0201d850
+
+src/func_0201d850.c:
+    complete
+    .text start:0x0201d850 end:0x0201e044
+
+src/_ZN7Message16DisplayPauseTextEth.cpp:
+    .text start:0x0201e044 end:0x0201e12c
+
+src/_ZN7Message19DisplayDontSaveTextEt.cpp:
+    .text start:0x0201e12c end:0x0201e220
+
+src/func_0201e220.cpp:
+    complete
+    .text start:0x0201e220 end:0x0201e314
+
+src/_ZN7Message19DisplaySaveMenuTextEt.c:
+    complete
+    .text start:0x0201e314 end:0x0201e36c
+
+src/_ZN7Message11DisplayTextEt.cpp:
+    complete
+    .text start:0x0201e36c end:0x0201e574
+
+src/_ZN7Message7DisplayEj.cpp:
+    complete
+    .text start:0x0201e574 end:0x0201e6bc
+
+src/_ZN7Message28DisplayStarNameForStarSelectEj.cpp:
+    complete
+    .text start:0x0201e6bc end:0x0201e81c
+
+src/_ZN7Message30DisplayCourseNameForStarSelectEj.cpp:
+    complete
+    .text start:0x0201e81c end:0x0201eaac
+
+src/func_0201eaac.c:
+    complete
+    .text start:0x0201eaac end:0x0201eb94
+
+src/_ZN7Message13DisplaySavingEt.cpp:
+    .text start:0x0201eb94 end:0x0201ef38
+
+src/func_0201ef38.c:
+    complete
+    .text start:0x0201ef38 end:0x0201ef50
+
+src/func_0201ef50.c:
+    complete
+    .text start:0x0201ef50 end:0x0201f108
+
+src/func_0201f108.c:
+    complete
+    .text start:0x0201f108 end:0x0201f138
+
+src/func_0201f138.cpp:
+    .text start:0x0201f138 end:0x0201f32c
+
+src/func_0201f32c.c:
+    .text start:0x0201f32c end:0x0201fb4c
+
+src/func_0201fb4c.c:
+    .text start:0x0201fb4c end:0x0201fc10
+
+src/ObjectMessageIDToActualMessageID.c:
+    complete
+    .text start:0x0201fc10 end:0x0201fc88
+
+src/func_0201fc88.c:
+    complete
+    .text start:0x0201fc88 end:0x0201fcac
+
+src/_ZN7Message15ResetAllGlobalsEv.c:
+    complete
+    .text start:0x0201fcac end:0x0201fcd4
+
+src/LoadFont.cpp:
+    complete
+    .text start:0x0201fcd4 end:0x0201fe08
+
+src/func_0201fe08.c:
+    complete
+    .text start:0x0201fe08 end:0x0201fec8
+
+src/func_0201fec8.c:
+    complete
+    .text start:0x0201fec8 end:0x0201ffcc
+
+src/func_0201ffcc.c:
+    complete
+    .text start:0x0201ffcc end:0x02020028
+
+src/func_02020028.c:
+    complete
+    .text start:0x02020028 end:0x02020054
+
+src/GetControllerMode.c:
+    complete
+    .text start:0x02020054 end:0x02020078
+
+src/func_02020078.c:
+    complete
+    .text start:0x02020078 end:0x020200b8
+
+src/func_020200b8.c:
+    complete
+    .text start:0x020200b8 end:0x020200e0
+
+src/func_020200e0.c:
+    complete
+    .text start:0x020200e0 end:0x02020124
+
+src/func_02020124.c:
+    complete
+    .text start:0x02020124 end:0x02020168
+
+src/func_02020168.c:
+    complete
+    .text start:0x02020168 end:0x02020190
+
+src/func_02020190.c:
+    complete
+    .text start:0x02020190 end:0x020201c0
+
+src/func_020201c0.c:
+    complete
+    .text start:0x020201c0 end:0x020201f0
+
+src/func_020201f0.c:
+    complete
+    .text start:0x020201f0 end:0x02020214
+
+src/func_02020214.c:
+    complete
+    .text start:0x02020214 end:0x02020254
+
+src/func_02020254.c:
+    complete
+    .text start:0x02020254 end:0x0202027c
+
+src/func_0202027c.c:
+    complete
+    .text start:0x0202027c end:0x0202029c
+
+src/func_0202029c.c:
+    complete
+    .text start:0x0202029c end:0x020202dc
+
+src/func_020202dc.c:
+    complete
+    .text start:0x020202dc end:0x02020304
+
+src/func_02020304.c:
+    complete
+    .text start:0x02020304 end:0x02020334
+
+src/func_02020334.c:
+    complete
+    .text start:0x02020334 end:0x02020364
+
+src/func_02020364.c:
+    complete
+    .text start:0x02020364 end:0x02020388
+
+src/func_02020388.c:
+    complete
+    .text start:0x02020388 end:0x020203c4
+
+src/WarpPlayer.c:
+    complete
+    .text start:0x020203c4 end:0x02020414
+
+src/IsPlayerWarping.c:
+    complete
+    .text start:0x02020414 end:0x0202043c
+
+src/func_0202043c.c:
+    complete
+    .text start:0x0202043c end:0x0202044c
+
+src/func_0202044c.c:
+    complete
+    .text start:0x0202044c end:0x0202048c
+
+src/func_0202048c.cpp:
+    complete
+    .text start:0x0202048c end:0x02020768
+
+src/func_02020768.c:
+    complete
+    .text start:0x02020768 end:0x02020820
+
+src/func_02020820.c:
+    complete
+    .text start:0x02020820 end:0x02020884
+
+src/_ZN3OAM16LoadAffineParamsEP7OamAttrPiP9Matrix2x2.c:
+    complete
+    .text start:0x02020884 end:0x0202096c
+
+src/_ZN3OAM12GetObjHeightEii.c:
+    complete
+    .text start:0x0202096c end:0x02020980
+
+src/_ZN3OAM11GetObjWidthEii.c:
+    complete
+    .text start:0x02020980 end:0x02020994
+
+src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiEi.c:
+    complete
+    .text start:0x02021024 end:0x020214a4
+
+src/_ZN3OAM6RenderEbP7OamAttriiiiP9Matrix2x2.c:
+    complete
+    .text start:0x020214a4 end:0x02021788
+
+src/_ZN3OAM5ResetEv.cpp:
+    complete
+    .text start:0x02021788 end:0x02021864
+
+src/_ZN3OAM5FlushEv.c:
+    complete
+    .text start:0x02021864 end:0x02021898
+
+src/_ZN3OAM4LoadEv.c:
+    complete
+    .text start:0x02021898 end:0x0202194c
+
+src/_ZN3OAM9RenderSubEP7OamAttrii.c:
+    complete
+    .text start:0x0202194c end:0x0202199c
+
+src/_ZN3OAM9RenderSubEP7OamAttriiii.c:
+    complete
+    .text start:0x0202199c end:0x020219f0
+
+src/_ZN3OAM12EnableSubOAMEv.c:
+    complete
+    .text start:0x020219f0 end:0x02021a04
+
+src/func_02021a04.c:
+    complete
+    .text start:0x02021a04 end:0x02021a48
+
+src/func_02021a48.c:
+    complete
+    .text start:0x02021a48 end:0x02021a74
+
+src/func_02021a74.c:
+    complete
+    .text start:0x02021a74 end:0x02021b58
+
+src/_ZNK8Particle10SysTracker8Contents8FindDataEj.c:
+    complete
+    .text start:0x02021b58 end:0x02021b98
+
+src/func_02021b98.c:
+    complete
+    .text start:0x02021b98 end:0x02021bec
+
+src/func_02021bec.c:
+    complete
+    .text start:0x02021bec end:0x02021c90
+
+src/func_02021c90.c:
+    complete
+    .text start:0x02021c90 end:0x02021cd4
+
+src/func_02021cd4.c:
+    complete
+    .text start:0x02021cd4 end:0x02021d1c
+
+src/func_02021d1c.cpp:
+    complete
+    .text start:0x02021d1c end:0x02021e40
+
+src/_ZN8Particle21CleanParticleCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x02021e40 end:0x02021e70
+
+src/_ZN8Particle12ClipCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x02021e70 end:0x0202202c
+
+src/_ZN8Particle16FitWaterCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x0202202c end:0x020220a4
+
+src/_ZN8Particle24CheckWaterRippleCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x020220a4 end:0x02022160
+
+src/_ZN8Particle18CheckWaterCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x02022160 end:0x020221dc
+
+src/_ZN8Particle25EndingStarGlitterCallback8OnUpdateERNS_6SystemEb.c:
+    complete
+    .text start:0x020221dc end:0x0202222c
+
+src/_ZN8Particle25EndingStarGlitterCallback14SpawnParticlesERNS_6SystemE.c:
+    complete
+    .text start:0x0202222c end:0x02022260
+
+src/func_02022260.c:
+    complete
+    .text start:0x02022260 end:0x02022298
+
+src/func_02022298.c:
+    complete
+    .text start:0x02022298 end:0x020222f0
+
+src/_ZN8Particle17CheckLavaCallback8OnUpdateERNS_6SystemEb.c:
+    complete
+    .text start:0x020222f0 end:0x02022328
+
+src/_ZN8Particle17CheckLavaCallback14SpawnParticlesERNS_6SystemE.cpp:
+    complete
+    .text start:0x02022328 end:0x02022418
+
+src/_ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb.c:
+    complete
+    .text start:0x02022418 end:0x02022464
+
+src/_ZN8Particle14BubbleCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x02022464 end:0x020224fc
+
+src/_ZN8Particle14SplashCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x020224fc end:0x020225a8
+
+src/_ZN8Particle13ScaleCallback8OnUpdateERNS_6SystemEb.c:
+    complete
+    .text start:0x020225a8 end:0x020225d0
+
+src/_ZN8Particle13ScaleCallback14SpawnParticlesERNS_6SystemE.c:
+    complete
+    .text start:0x020225d0 end:0x020225fc
+
+src/func_020225fc.c:
+    complete
+    .text start:0x020225fc end:0x02022630
+
+src/_ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb.cpp:
+    complete
+    .text start:0x02022630 end:0x02022640
+
+src/_ZN8Particle14SimpleCallback14SpawnParticlesERNS_6SystemE.cpp:
+    .text start:0x02022640 end:0x02022680
+
+src/_ZN8Particle14SimpleCallbackC2Ev.cpp:
+    complete
+    .text start:0x02022680 end:0x020226a4
+
+src/func_020226a4.c:
+    complete
+    .text start:0x020226a4 end:0x020226c8
+
+src/_ZN8Particle8Callback8OnUpdateERNS_6SystemEb.c:
+    complete
+    .text start:0x020226c8 end:0x020226d0
+
+src/_ZN8Particle8Callback14SpawnParticlesERNS_6SystemE.c:
+    complete
+    .text start:0x020226d0 end:0x020226d4
+
+src/_ZN8Particle19SetSelfDestructFlagEj.c:
+    complete
+    .text start:0x020226d4 end:0x020226fc
+
+src/func_020226fc.c:
+    complete
+    .text start:0x020226fc end:0x02022774
+
+src/func_02022774.c:
+    complete
+    .text start:0x02022774 end:0x020227ec
+
+src/func_020227ec.c:
+    complete
+    .text start:0x020227ec end:0x02022864
+
+src/func_02022864.c:
+    complete
+    .text start:0x02022864 end:0x020228dc
+
+src/func_020228dc.c:
+    complete
+    .text start:0x020228dc end:0x0202293c
+
+src/func_0202293c.c:
+    complete
+    .text start:0x0202293c end:0x02022998
+
+src/_ZN8Particle6System9NewRippleE5Fix12IiES2_S2_.c:
+    complete
+    .text start:0x02022998 end:0x020229f0
+
+src/func_020229f0.c:
+    complete
+    .text start:0x020229f0 end:0x02022a4c
+
+src/func_02022a4c.c:
+    complete
+    .text start:0x02022a4c end:0x02022aa8
+
+src/_ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_.c:
+    complete
+    .text start:0x02022aa8 end:0x02022b04
+
+src/func_02022b04.c:
+    complete
+    .text start:0x02022b04 end:0x02022b58
+
+src/_ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_.c:
+    .text start:0x02022b58 end:0x02022bb4
+
+src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c:
+    complete
+    .text start:0x02022bb4 end:0x02022bf8
+
+src/_ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj.c:
+    complete
+    .text start:0x02022bf8 end:0x02022c3c
+
+src/func_02022c3c.c:
+    complete
+    .text start:0x02022c3c end:0x02022c80
+
+src/func_02022c80.c:
+    complete
+    .text start:0x02022c80 end:0x02022cbc
+
+src/func_02022cbc.c:
+    complete
+    .text start:0x02022cbc end:0x02022d00
+
+src/func_02022d00.c:
+    complete
+    .text start:0x02022d00 end:0x02022d44
+
+src/func_02022d44.c:
+    complete
+    .text start:0x02022d44 end:0x02022d80
+
+src/_ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE.c:
+    complete
+    .text start:0x02022d80 end:0x02022e68
+
+src/_ZN8Particle6System12FromUniqueIDEj.c:
+    complete
+    .text start:0x02022e68 end:0x02022e98
+
+src/_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_.c:
+    complete
+    .text start:0x02022e98 end:0x02022ee0
+
+src/_ZN8Particle9RenderAllEv.c:
+    complete
+    .text start:0x02022ee0 end:0x02022f20
+
+src/_ZN8Particle10SysTracker6UpdateEv.c:
+    complete
+    .text start:0x02022f20 end:0x02022f40
+
+src/_ZN8Particle10SysTracker10InitialiseEv.cpp:
+    .text start:0x02022f40 end:0x020230ec
+
+src/_ZN8Particle7Texture12AllocPalVramEjb.c:
+    complete
+    .text start:0x020230ec end:0x02023134
+
+src/_ZN8Particle7Texture12AllocTexVramEjb.c:
+    complete
+    .text start:0x02023134 end:0x02023178
+
+src/func_02023178.c:
+    complete
+    .text start:0x02023178 end:0x02023194
+
+src/_ZN8Particle10SysTrackerD1Ev.cpp:
+    .text start:0x02023194 end:0x02023204
+
+src/_ZN8Particle10SysTrackerC1Ev.c:
+    complete
+    .text start:0x02023204 end:0x020233d4
+
+src/func_020233d4.c:
+    complete
+    .text start:0x020233d4 end:0x020233f0
+
+src/func_020233f0.c:
+    complete
+    .text start:0x020233f0 end:0x020233f4
+
+src/func_020233f4.c:
+    complete
+    .text start:0x020233f4 end:0x02023408
+
+src/func_02023408.c:
+    complete
+    .text start:0x02023408 end:0x0202341c
+
+src/LoadDebugFont.c:
+    complete
+    .text start:0x0202341c end:0x0202345c
+
+src/func_0202345c.c:
+    complete
+    .text start:0x0202345c end:0x02023498
+
+src/func_02023498.c:
+    complete
+    .text start:0x02023498 end:0x02023544
+
+src/func_02023544.c:
+    complete
+    .text start:0x02023544 end:0x02023598
+
+src/_ZN5SceneD2Ev.c:
+    complete
+    .text start:0x02023598 end:0x020235d4
+
+src/_ZN9BootSceneD0Ev.c:
+    complete
+    .text start:0x020235d4 end:0x02023624
+
+src/func_02023624.c:
+    complete
+    .text start:0x02023624 end:0x02023688
+
+src/_ZN5StageD2Ev.c:
+    complete
+    .text start:0x02023688 end:0x020236f0
+
+src/_ZN5StageD0Ev.c:
+    complete
+    .text start:0x020236f0 end:0x0202376c
+
+src/_ZN5Stage9VE_UpdateEv.cpp:
+    complete
+    .text start:0x0202376c end:0x02023a80
+
+src/_ZN5Stage7VE_InitEv.cpp:
+    complete
+    .text start:0x02023a80 end:0x02023be0
+
+src/_ZN5Stage20RenderBouncingArrowsEv.cpp:
+    .text start:0x02023be0 end:0x02023db8
+
+src/_ZN5Stage9LC_RenderEv.cpp:
+    complete
+    .text start:0x02023db8 end:0x020242c8
+
+src/_ZN5Stage9LC_UpdateEv.cpp:
+    complete
+    .text start:0x020242c8 end:0x02024c70
+
+src/_ZN5Stage16CheckCameraInputEv.cpp:
+    complete
+    .text start:0x02024c70 end:0x020250d0
+
+src/_ZN5Stage12RenderNumberEhiibi.cpp:
+    .text start:0x020250d0 end:0x020251d0
+
+src/_ZN5Stage9PS_RenderEv.cpp:
+    .text start:0x020251d0 end:0x02025d20
+
+src/_ZN5Stage25PS_UpdateOkAndBackButtonsEb.cpp:
+    complete
+    .text start:0x02025d20 end:0x02025e74
+
+src/_ZN5Stage17PS_UpdateSaveMenuEb.c:
+    complete
+    .text start:0x02025e74 end:0x02025f60
+
+src/_ZN5Stage20PS_UpdateOptionsMenuEv.cpp:
+    complete
+    .text start:0x02025f60 end:0x02026148
+
+src/_ZN5Stage17UpdateMenuButtonsEb.c:
+    complete
+    .text start:0x02026148 end:0x02026290
+
+src/_ZN5Stage10PS_CleanupEv.c:
+    complete
+    .text start:0x02026290 end:0x0202635c
+
+src/_ZN5Stage9PS_UpdateEv.cpp:
+    complete
+    .text start:0x0202635c end:0x02029408
+
+src/func_02029408.c:
+    .text start:0x02029408 end:0x0202942c
+
+src/_ZN5Stage7PS_InitEv.c:
+    complete
+    .text start:0x0202942c end:0x02029600
+
+src/func_02029600.c:
+    complete
+    .text start:0x02029600 end:0x02029654
+
+src/IsButtonInputValid.c:
+    complete
+    .text start:0x02029654 end:0x020297f4
+
+src/_ZN5Stage14GraphCallback2EP12SceneRelated.c:
+    .text start:0x020297f4 end:0x02029838
+
+src/_ZN5Stage14GraphCallback1Ev.c:
+    complete
+    .text start:0x02029838 end:0x02029854
+
+src/UpdateMinimap.c:
+    complete
+    .text start:0x02029854 end:0x020298a0
+
+src/StartEntranceFaderWipe.c:
+    .text start:0x020298a0 end:0x020298d8
+
+src/StartExitCharacterWipe.c:
+    complete
+    .text start:0x020298d8 end:0x020298fc
+
+src/StartExitFaderWipe.c:
+    .text start:0x020298fc end:0x02029934
+
+src/FUN_02029934.cpp:
+    complete
+    .text start:0x02029934 end:0x02029980
+
+src/FUN_02029980.cpp:
+    complete
+    .text start:0x02029980 end:0x020299f4
+
+src/FUN_020299f4.cpp:
+    complete
+    .text start:0x020299f4 end:0x02029a68
+
+src/FUN_02029a68.c:
+    complete
+    .text start:0x02029a68 end:0x02029ab0
+
+src/FUN_02029ab0.c:
+    complete
+    .text start:0x02029ab0 end:0x02029b04
+
+src/EnterBigBoosHaunt.c:
+    complete
+    .text start:0x02029b04 end:0x02029b30
+
+src/KillPlayer.c:
+    complete
+    .text start:0x02029b30 end:0x02029b84
+
+src/HitDeathPlane.c:
+    complete
+    .text start:0x02029b84 end:0x02029bd4
+
+src/ExitLevel.c:
+    complete
+    .text start:0x02029bd4 end:0x02029bf4
+
+src/SetNextLevel.c:
+    complete
+    .text start:0x02029bf4 end:0x02029d1c
+
+src/SetNextStar.c:
+    complete
+    .text start:0x02029d1c end:0x02029dbc
+
+src/DeathTable_ClearBit.c:
+    complete
+    .text start:0x02029dbc end:0x02029e0c
+
+src/DeathTable_SetBit.c:
+    complete
+    .text start:0x02029e0c end:0x02029e58
+
+src/DeathTable_GetBit.c:
+    complete
+    .text start:0x02029e58 end:0x02029ea4
+
+src/_ZN5Event8ClearBitEj.c:
+    complete
+    .text start:0x02029ea4 end:0x02029ec4
+
+src/_ZN5Event6SetBitEj.c:
+    complete
+    .text start:0x02029ec4 end:0x02029ee0
+
+src/_ZN5Event6GetBitEj.c:
+    complete
+    .text start:0x02029ee0 end:0x02029ef8
+
+src/_ZN5Stage19RenderVsModeNewStarEv.cpp:
+    complete
+    .text start:0x02029ef8 end:0x0202a130
+
+src/FUN_0202a130.c:
+    complete
+    .text start:0x0202a130 end:0x0202a168
+
+src/_ZN5Stage21RenderVsModeCountdownEv.cpp:
+    complete
+    .text start:0x0202a168 end:0x0202a55c
+
+src/NumVsStarsObtained.c:
+    complete
+    .text start:0x0202a55c end:0x0202a5ac
+
+src/GiveVsStars.c:
+    complete
+    .text start:0x0202a5ac end:0x0202a5c4
+
+src/_ZN5Stage15IsPauseDisabledEv.c:
+    complete
+    .text start:0x0202a5c4 end:0x0202a608
+
+src/ClearSpikeBomb.c:
+    complete
+    .text start:0x0202a608 end:0x0202a628
+
+src/AddSpikeBomb.c:
+    complete
+    .text start:0x0202a628 end:0x0202a660
+
+src/SetStarMarker.c:
+    complete
+    .text start:0x0202a660 end:0x0202a67c
+
+src/OpenCannonInCurLevel.c:
+    complete
+    .text start:0x0202a67c end:0x0202a694
+
+src/IsCannonOpenInCurLevel.c:
+    complete
+    .text start:0x0202a694 end:0x0202a6ac
+
+src/CollectStarInCurLevel.c:
+    complete
+    .text start:0x0202a6ac end:0x0202a6c8
+
+src/IsStarCollectedInCurLevel.c:
+    complete
+    .text start:0x0202a6c8 end:0x0202a6e4
+
+src/NumRedCoins.c:
+    complete
+    .text start:0x0202a6e4 end:0x0202a734
+
+src/GiveRedCoins.c:
+    complete
+    .text start:0x0202a734 end:0x0202a770
+
+src/NumCoins.c:
+    complete
+    .text start:0x0202a770 end:0x0202a7b8
+
+src/GiveCoins.c:
+    complete
+    .text start:0x0202a7b8 end:0x0202a814
+
+src/GiveHealth.c:
+    complete
+    .text start:0x0202a814 end:0x0202a850
+
+src/func_0202a850.c:
+    complete
+    .text start:0x0202a850 end:0x0202a87c
+
+src/InitControllerMode.c:
+    complete
+    .text start:0x0202a87c end:0x0202a8b0
+
+src/SetControllerMode.c:
+    complete
+    .text start:0x0202a8b0 end:0x0202a8e0
+
+src/func_0202a8e0.c:
+    complete
+    .text start:0x0202a8e0 end:0x0202a93c
+
+src/_ZN5Stage11GetSkyboxIDEv.c:
+    complete
+    .text start:0x0202a93c end:0x0202a958
+
+src/func_0202a958.c:
+    complete
+    .text start:0x0202a958 end:0x0202a96c
+
+src/func_0202a96c.c:
+    complete
+    .text start:0x0202a96c end:0x0202a980
+
+src/func_0202a980.c:
+    complete
+    .text start:0x0202a980 end:0x0202a994
+
+src/_Z23LoadMinimapChangeObjecti5Fix12IiEh.c:
+    complete
+    .text start:0x0202a994 end:0x0202aa2c
+
+src/HideArea.c:
+    complete
+    .text start:0x0202aa2c end:0x0202aa4c
+
+src/ShowArea.c:
+    complete
+    .text start:0x0202aa4c end:0x0202aa6c
+
+src/IsAreaShowing.c:
+    complete
+    .text start:0x0202aa6c end:0x0202aa88
+
+src/ChangeArea.c:
+    complete
+    .text start:0x0202aa88 end:0x0202aac0
+
+src/GiveLives.c:
+    complete
+    .text start:0x0202aac0 end:0x0202aaec
+
+src/LoadLevel.c:
+    complete
+    .text start:0x0202aaec end:0x0202acc0
+
+src/LoadLevelNoReturn.c:
+    complete
+    .text start:0x0202acc0 end:0x0202acfc
+
+src/SetPlayerGlobals.c:
+    complete
+    .text start:0x0202acfc end:0x0202ad78
+
+src/ExitMinigameMenu.c:
+    complete
+    .text start:0x0202ad78 end:0x0202adf4
+
+src/StartMinigameMenu.c:
+    complete
+    .text start:0x0202adf4 end:0x0202ae2c
+
+src/PrepareVsMode.c:
+    complete
+    .text start:0x0202ae2c end:0x0202ae74
+
+src/func_0202ae74.c:
+    complete
+    .text start:0x0202ae74 end:0x0202ae88
+
+src/StartFile.c:
+    complete
+    .text start:0x0202ae88 end:0x0202af08
+
+src/StartWithFarCamera.c:
+    complete
+    .text start:0x0202af08 end:0x0202af28
+
+src/GetStarCameraSetting.c:
+    complete
+    .text start:0x0202af28 end:0x0202af48
+
+src/GetMinimapScale.c:
+    complete
+    .text start:0x0202af48 end:0x0202af80
+
+src/func_0202af80.c:
+    complete
+    .text start:0x0202af80 end:0x0202af9c
+
+src/GetMinimapID.c:
+    complete
+    .text start:0x0202af9c end:0x0202b044
+
+src/func_0202b044.c:
+    complete
+    .text start:0x0202b044 end:0x0202b060
+
+src/func_0202b060.c:
+    complete
+    .text start:0x0202b060 end:0x0202b07c
+
+src/GetTeleportDestObj.c:
+    complete
+    .text start:0x0202b07c end:0x0202b090
+
+src/func_0202b090.c:
+    complete
+    .text start:0x0202b090 end:0x0202b0ac
+
+src/GetViewObj.c:
+    complete
+    .text start:0x0202b0ac end:0x0202b0c4
+
+src/func_0202b0c4.c:
+    complete
+    .text start:0x0202b0c4 end:0x0202b0e0
+
+src/func_0202b0e0.c:
+    complete
+    .text start:0x0202b0e0 end:0x0202b0fc
+
+src/_ZN5Stage10LoadSkyboxEv.c:
+    complete
+    .text start:0x0202b0fc end:0x0202b164
+
+src/_ZN5Stage22RenderModelTransparentEv.cpp:
+    complete
+    .text start:0x0202b164 end:0x0202b268
+
+src/_ZN5Stage11RenderModelEv.cpp:
+    complete
+    .text start:0x0202b268 end:0x0202b3d8
+
+src/CopyTexPalFromLevelModel.c:
+    complete
+    .text start:0x0202b3d8 end:0x0202b534
+
+src/_ZN5Stage23LoadTextureTransformersEv.cpp:
+    .text start:0x0202b534 end:0x0202b5ec
+
+src/_ZN5Stage9LoadModelEv.cpp:
+    complete
+    .text start:0x0202b5ec end:0x0202b67c
+
+src/_ZN5Stage9RenderFogEv.cpp:
+    complete
+    .text start:0x0202b67c end:0x0202b710
+
+src/_ZN5Stage7LoadFogEv.cpp:
+    .text start:0x0202b710 end:0x0202b818
+
+src/_ZN5Stage8CanPauseEv.c:
+    complete
+    .text start:0x0202b818 end:0x0202b8a0
+
+src/_ZN5Stage16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x0202b8a0 end:0x0202b8a4
+
+src/_ZN5Stage6RenderEv.cpp:
+    .text start:0x0202b8a4 end:0x0202bbbc
+
+src/_ZN5Stage8BehaviorEv.cpp:
+    complete
+    .text start:0x0202bbbc end:0x0202c2ac
+
+src/_ZN5Stage10CheckInputEv.cpp:
+    .text start:0x0202c2ac end:0x0202c830
+
+src/_ZN3Fog4InitEt5Fix12IiES1_.cpp:
+    complete
+    .text start:0x0202c830 end:0x0202c8b8
+
+src/SetTouchScreenDelay.c:
+    complete
+    .text start:0x0202c8b8 end:0x0202c8f8
+
+src/ResetInput.c:
+    complete
+    .text start:0x0202c8f8 end:0x0202c9a8
+
+src/_ZN5Stage16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0202c9a8 end:0x0202cc0c
+
+src/_ZN5Stage14LoadGraphics2DEbi.cpp:
+    complete
+    .text start:0x0202d690 end:0x0202ddc8
+
+src/_ZN5Stage19BeforeInitResourcesEv.cpp:
+    complete
+    .text start:0x0202ddc8 end:0x0202ddd4
+
+src/IsLevelTinyHugeIslandOutside.c:
+    complete
+    .text start:0x0202ddd4 end:0x0202ddf4
+
+src/IsLevelInsideCastle.c:
+    complete
+    .text start:0x0202ddf4 end:0x0202de24
+
+src/GetSoundGroupID.c:
+    complete
+    .text start:0x0202de24 end:0x0202de64
+
+src/_Z19UnloadLevelOverlaysi.c:
+    complete
+    .text start:0x0202de64 end:0x0202deac
+
+src/func_0202deac.c:
+    complete
+    .text start:0x0202deac end:0x0202ded4
+
+src/_Z17LoadLevelOverlaysi.cpp:
+    complete
+    .text start:0x0202ded4 end:0x0202df70
+
+src/_Z26LoadOrUnloadObjectOverlaysPFviEi.cpp:
+    .text start:0x0202df70 end:0x0202e088
+
+src/_ZN5StageC1Ev.c:
+    complete
+    .text start:0x0202e088 end:0x0202e118
+
+src/func_0202e118.c:
+    complete
+    .text start:0x0202e118 end:0x0202e140
+
+src/_ZN5SceneD1Ev.c:
+    complete
+    .text start:0x0202e140 end:0x0202e170
+
+src/_ZN5SceneD0Ev.c:
+    complete
+    .text start:0x0202e170 end:0x0202e1b4
+
+src/_ZN5Scene20SetAndStopColorFaderEv.c:
+    complete
+    .text start:0x0202e1b4 end:0x0202e1e0
+
+src/_ZN5Scene9SetFadersEP15FaderBrightness.cpp:
+    complete
+    .text start:0x0202e1e0 end:0x0202e26c
+
+src/_ZN5Scene16SpawnIfNecessaryEv.c:
+    complete
+    .text start:0x0202e26c end:0x0202e300
+
+src/_ZN5Scene18PrepareToSpawnBootEv.c:
+    complete
+    .text start:0x0202e300 end:0x0202e348
+
+src/_ZN5Scene14StartSceneFadeEjjt.c:
+    complete
+    .text start:0x0202e348 end:0x0202e36c
+
+src/_ZN5Scene15SetSceneToSpawnEjj.c:
+    complete
+    .text start:0x0202e36c end:0x0202e398
+
+src/_ZN5Scene11AfterRenderEj.cpp:
+    complete
+    .text start:0x0202e398 end:0x0202e3a4
+
+src/_ZN5Scene12BeforeRenderEv.c:
+    complete
+    .text start:0x0202e3a4 end:0x0202e3c8
+
+src/_ZN5Scene13AfterBehaviorEj.cpp:
+    complete
+    .text start:0x0202e3c8 end:0x0202e3d4
+
+src/_ZN5Scene14BeforeBehaviorEv.cpp:
+    complete
+    .text start:0x0202e3d4 end:0x0202e5d0
+
+src/_ZN5Scene21AfterCleanupResourcesEj.cpp:
+    .text start:0x0202e5d0 end:0x0202e5f0
+
+src/_ZN5Scene22BeforeCleanupResourcesEv.c:
+    complete
+    .text start:0x0202e5f0 end:0x0202e62c
+
+src/_ZN5Scene18AfterInitResourcesEj.cpp:
+    complete
+    .text start:0x0202e62c end:0x0202e638
+
+src/_ZN5Scene19BeforeInitResourcesEv.c:
+    complete
+    .text start:0x0202e638 end:0x0202e66c
+
+src/_ZN5Scene19ResetFadersAndSoundEv.c:
+    complete
+    .text start:0x0202e66c end:0x0202e6c8
+
+src/_ZN5Scene20Initialise3dGraphicsEv.c:
+    complete
+    .text start:0x0202e6c8 end:0x0202e73c
+
+src/_ZN5Stage12SetVramBanksEv.c:
+    complete
+    .text start:0x0202e73c end:0x0202e78c
+
+src/_ZN2GX15DisableAllBanksEv.c:
+    complete
+    .text start:0x0202e78c end:0x0202e7d4
+
+src/_ZN5Scene22ResetHardwareRegistersEv.cpp:
+    complete
+    .text start:0x0202e7d4 end:0x0202ec9c
+
+src/func_0202ec9c.cpp:
+    complete
+    .text start:0x0202ec9c end:0x0202ecfc
+
+src/func_0202ecfc.c:
+    .text start:0x0202ecfc end:0x0202ed08
+
+src/func_0202ed08.c:
+    complete
+    .text start:0x0202ed08 end:0x0202ed14
+
+src/func_0202ed14.c:
+    complete
+    .text start:0x0202ed14 end:0x0202ed48
+
+src/func_0202ed48.c:
+    complete
+    .text start:0x0202ed48 end:0x0202ed7c
+
+src/func_0202ed7c.cpp:
+    complete
+    .text start:0x0202ed7c end:0x0202eddc
+
+src/func_0202eddc.c:
+    complete
+    .text start:0x0202eddc end:0x0202ee38
+
+src/func_0202ee38.c:
+    complete
+    .text start:0x0202ee38 end:0x0202ee94
+
+src/func_0202ee94.c:
+    complete
+    .text start:0x0202ee94 end:0x0202efa0
+
+src/func_0202efa0.c:
+    .text start:0x0202efa0 end:0x0202f290
+
+src/func_0202f290.c:
+    complete
+    .text start:0x0202f290 end:0x0202f2c4
+
+src/func_0202f2c4.c:
+    complete
+    .text start:0x0202f2c4 end:0x0202f3a4
+
+src/func_0202f3a4.c:
+    complete
+    .text start:0x0202f3a4 end:0x0202f428
+
+src/func_0202f428.c:
+    complete
+    .text start:0x0202f428 end:0x0202f58c
+
+src/func_0202f58c.c:
+    complete
+    .text start:0x0202f58c end:0x0202f708
+
+src/func_0202f708.c:
+    .text start:0x0202f708 end:0x0202f928
+
+src/func_0202f928.c:
+    .text start:0x0202f928 end:0x0202fb30
+
+src/func_0202fb30.c:
+    complete
+    .text start:0x0202fb30 end:0x0202fbc8
+
+src/func_0202fbc8.c:
+    complete
+    .text start:0x0202fbc8 end:0x0202fc08
+
+src/func_0202fc08.c:
+    complete
+    .text start:0x0202fc08 end:0x0202fc40
+
+src/func_0202fc40.c:
+    complete
+    .text start:0x0202fc40 end:0x0202fc98
+
+src/_ZN4ViewD1Ev.c:
+    complete
+    .text start:0x0202fc98 end:0x0202fcc8
+
+src/_ZN4ViewD0Ev.c:
+    complete
+    .text start:0x0202fcc8 end:0x0202fd0c
+
+src/_ZN4View6RenderEv.c:
+    complete
+    .text start:0x0202fd0c end:0x0202fd2c
+
+src/func_0202fd2c.c:
+    complete
+    .text start:0x0202fd2c end:0x0202fd4c
+
+src/Quaternion_FromVector3.c:
+    complete
+    .text start:0x0202fd4c end:0x0202fef8
+
+src/Quaternion_SLerp.c:
+    complete
+    .text start:0x0202fef8 end:0x0202ffec
+
+src/Matrix4x3_FromQuaternion.c:
+    complete
+    .text start:0x020301c4 end:0x020301e8
+
+src/Matrix3x3_FromQuaternion.c:
+    complete
+    .text start:0x020301e8 end:0x02030450
+
+src/Quaternion_Normalize.c:
+    complete
+    .text start:0x02030450 end:0x02030500
+
+src/func_02030500.c:
+    complete
+    .text start:0x02030500 end:0x02030790
+
+src/func_02030790.c:
+    complete
+    .text start:0x02030790 end:0x02030838
+
+src/func_02030838.c:
+    complete
+    .text start:0x02030838 end:0x0203083c
+
+src/func_0203083c.c:
+    complete
+    .text start:0x0203083c end:0x020308a8
+
+src/func_020308a8.c:
+    complete
+    .text start:0x020308a8 end:0x020308b4
+
+src/func_020308b4.c:
+    complete
+    .text start:0x020308b4 end:0x020308d0
+
+src/func_020308d0.c:
+    complete
+    .text start:0x020308d0 end:0x02030958
+
+src/func_02030958.c:
+    complete
+    .text start:0x02030958 end:0x02030994
+
+src/func_02030994.c:
+    complete
+    .text start:0x02030994 end:0x02030a38
+
+src/func_02030a38.c:
+    complete
+    .text start:0x02030a38 end:0x02030a6c
+
+src/func_02030a6c.c:
+    complete
+    .text start:0x02030a6c end:0x02030a78
+
+src/func_02030a78.c:
+    complete
+    .text start:0x02030a78 end:0x02030aa4
+
+src/func_02030aa4.c:
+    complete
+    .text start:0x02030aa4 end:0x02030b58
+
+src/func_02030b58.c:
+    complete
+    .text start:0x02030b58 end:0x02030c38
+
+src/func_02030c38.c:
+    complete
+    .text start:0x02030c38 end:0x02030ca0
+
+src/func_02030ca0.c:
+    complete
+    .text start:0x02030ca0 end:0x02030dac
+
+src/func_02030dac.c:
+    complete
+    .text start:0x02030dac end:0x02030e4c
+
+src/func_02030e4c.c:
+    complete
+    .text start:0x02030e4c end:0x02030fa8
+
+src/func_02030fa8.c:
+    complete
+    .text start:0x02030fa8 end:0x02031028
+
+src/func_02031028.c:
+    complete
+    .text start:0x02031028 end:0x02031154
+
+src/func_02031154.c:
+    complete
+    .text start:0x02031154 end:0x0203128c
+
+src/func_0203128c.c:
+    .text start:0x0203128c end:0x020313d8
+
+src/func_020313d8.c:
+    .text start:0x020313d8 end:0x02031428
+
+src/func_02031428.c:
+    complete
+    .text start:0x02031428 end:0x020316d8
+
+src/func_020316d8.c:
+    complete
+    .text start:0x020316d8 end:0x020318a4
+
+src/func_020318a4.c:
+    complete
+    .text start:0x020318a4 end:0x020319fc
+
+src/func_020319fc.c:
+    complete
+    .text start:0x020319fc end:0x02031b84
+
+src/func_02031b84.c:
+    complete
+    .text start:0x02031b84 end:0x02031cd4
+
+src/func_02031cd4.c:
+    complete
+    .text start:0x02031cd4 end:0x02031e00
+
+src/func_02031e00.c:
+    complete
+    .text start:0x02031e00 end:0x020321fc
+
+src/func_020321fc.c:
+    complete
+    .text start:0x020321fc end:0x020326ac
+
+src/func_020326ac.c:
+    .text start:0x020326ac end:0x02032f04
+
+src/_ZN7Message16SetTextGlobalsVSEv.c:
+    complete
+    .text start:0x02032f04 end:0x02032f54
+
+src/func_02032f54.c:
+    complete
+    .text start:0x02032f54 end:0x02032f9c
+
+src/func_02032f9c.c:
+    complete
+    .text start:0x02032f9c end:0x020331fc
+
+src/func_020331fc.c:
+    complete
+    .text start:0x020331fc end:0x02033390
+
+src/func_02033390.cpp:
+    complete
+    .text start:0x02033390 end:0x02033464
+
+src/func_02033464.c:
+    complete
+    .text start:0x02033464 end:0x020337ec
+
+src/func_020337ec.c:
+    complete
+    .text start:0x020337ec end:0x020338b0
+
+src/func_020338b0.cpp:
+    complete
+    .text start:0x020338b0 end:0x020339c0
+
+src/_ZN7Message17DisplayVsExitTextEt.cpp:
+    .text start:0x020339c0 end:0x02033a80
+
+src/func_02033a80.c:
+    complete
+    .text start:0x02033a80 end:0x02033ae0
+
+src/func_02033ae0.c:
+    complete
+    .text start:0x02033ae0 end:0x02033bb8
+
+src/func_02033bb8.c:
+    complete
+    .text start:0x02033bb8 end:0x02033e50
+
+src/func_02033e50.c:
+    complete
+    .text start:0x02033e50 end:0x02034098
+
+src/func_02034098.cpp:
+    complete
+    .text start:0x02034098 end:0x020341a8
+
+src/func_020341a8.cpp:
+    complete
+    .text start:0x020341a8 end:0x02034358
+
+src/_ZN7Message18DisplayPauseTextVSEt.cpp:
+    .text start:0x02034358 end:0x02034414
+
+src/func_02034414.cpp:
+    complete
+    .text start:0x02034414 end:0x02034504
+
+src/func_02034504.c:
+    complete
+    .text start:0x02034504 end:0x020345b0
+
+src/func_020345b0.c:
+    .text start:0x020345b0 end:0x02034954
+
+src/LoadFont3D.c:
+    complete
+    .text start:0x02034954 end:0x020349e0
+
+src/_ZN7Message10LoadTextVSEv.c:
+    complete
+    .text start:0x020349e0 end:0x02034a78
+
+src/func_02034a78.c:
+    complete
+    .text start:0x02034a78 end:0x02034ac0
+
+src/func_02034ac0.c:
+    complete
+    .text start:0x02034ac0 end:0x02034b1c
+
+src/func_02034b1c.c:
+    complete
+    .text start:0x02034b1c end:0x02034b40
+
+src/func_02034b40.c:
+    complete
+    .text start:0x02034b40 end:0x02034d24
+
+src/func_02034d24.c:
+    complete
+    .text start:0x02034d24 end:0x02034d2c
+
+src/func_02034d2c.c:
+    complete
+    .text start:0x02034d2c end:0x02034d34
+
+src/func_02034d34.cpp:
+    complete
+    .text start:0x02034d34 end:0x02034d70
+
+src/func_02034d70.c:
+    complete
+    .text start:0x02034d70 end:0x02034d9c
+
+src/func_02034d9c.c:
+    complete
+    .text start:0x02034d9c end:0x02034da4
+
+src/func_02034da4.c:
+    complete
+    .text start:0x02034da4 end:0x02034fbc
+
+src/func_02034fbc.c:
+    .text start:0x02034fbc end:0x0203506c
+
+src/func_0203506c.c:
+    complete
+    .text start:0x0203506c end:0x020352b4
+
+src/func_020352b4.c:
+    complete
+    .text start:0x020352b4 end:0x02035354
+
+src/func_02035354.c:
+    complete
+    .text start:0x02035354 end:0x02035394
+
+src/func_02035394.c:
+    complete
+    .text start:0x02035394 end:0x020353b0
+
+src/func_020353b0.c:
+    complete
+    .text start:0x020353b0 end:0x020353d4
+
+src/func_020353d4.c:
+    complete
+    .text start:0x020353d4 end:0x020353e0
+
+src/func_020353e0.c:
+    complete
+    .text start:0x020353e0 end:0x020353f4
+
+src/func_020353f4.c:
+    complete
+    .text start:0x020353f4 end:0x02035408
+
+src/func_02035408.c:
+    complete
+    .text start:0x02035408 end:0x02035414
+
+src/func_02035414.c:
+    complete
+    .text start:0x02035414 end:0x02035428
+
+src/func_02035428.c:
+    complete
+    .text start:0x02035428 end:0x0203543c
+
+src/func_0203543c.c:
+    complete
+    .text start:0x0203543c end:0x02035448
+
+src/_ZN4BgCh19StartDetectingToxicEv.cpp:
+    complete
+    .text start:0x02035448 end:0x0203545c
+
+src/func_0203545c.c:
+    complete
+    .text start:0x0203545c end:0x02035468
+
+src/func_02035468.c:
+    complete
+    .text start:0x02035468 end:0x0203547c
+
+src/func_0203547c.c:
+    complete
+    .text start:0x0203547c end:0x02035488
+
+src/_ZN4BgCh18StopDetectingWaterEv.cpp:
+    complete
+    .text start:0x02035488 end:0x0203549c
+
+src/_ZN4BgCh19StartDetectingWaterEv.cpp:
+    complete
+    .text start:0x0203549c end:0x020354b0
+
+src/func_020354b0.c:
+    complete
+    .text start:0x020354b0 end:0x020354bc
+
+src/_ZN4BgCh21StopDetectingOrdinaryEv.cpp:
+    complete
+    .text start:0x020354bc end:0x020354d0
+
+src/func_020354d0.c:
+    complete
+    .text start:0x020354d0 end:0x020354e0
+
+src/func_020354e0.c:
+    complete
+    .text start:0x020354e0 end:0x02035504
+
+src/func_02035504.c:
+    complete
+    .text start:0x02035504 end:0x02035514
+
+src/func_02035514.c:
+    complete
+    .text start:0x02035514 end:0x0203553c
+
+src/func_0203553c.c:
+    complete
+    .text start:0x0203553c end:0x02035550
+
+src/func_02035550.c:
+    complete
+    .text start:0x02035550 end:0x02035564
+
+src/_ZNK12WithMeshClsn15ShouldUpdatePosEv.c:
+    complete
+    .text start:0x02035564 end:0x02035578
+
+src/_ZNK12WithMeshClsn16ShouldUpdatePosYEv.c:
+    complete
+    .text start:0x02035578 end:0x0203558c
+
+src/func_0203558c.c:
+    complete
+    .text start:0x0203558c end:0x020355a0
+
+src/func_020355a0.c:
+    complete
+    .text start:0x020355a0 end:0x020355b4
+
+src/func_020355b4.c:
+    complete
+    .text start:0x020355b4 end:0x020355c8
+
+src/func_020355c8.c:
+    complete
+    .text start:0x020355c8 end:0x020355dc
+
+src/func_020355dc.c:
+    complete
+    .text start:0x020355dc end:0x020355e8
+
+src/func_020355e8.c:
+    complete
+    .text start:0x020355e8 end:0x020355fc
+
+src/func_020355fc.c:
+    complete
+    .text start:0x020355fc end:0x02035610
+
+src/_ZNK12WithMeshClsn12TouchesWaterEv.cpp:
+    complete
+    .text start:0x02035610 end:0x02035620
+
+src/_ZNK12WithMeshClsn14GetResultFlag1Ev.c:
+    complete
+    .text start:0x02035620 end:0x0203562c
+
+src/_ZNK12WithMeshClsn8IsOnWallEv.c:
+    complete
+    .text start:0x0203562c end:0x02035638
+
+src/func_02035638.c:
+    complete
+    .text start:0x02035638 end:0x02035644
+
+src/func_02035644.c:
+    complete
+    .text start:0x02035644 end:0x0203564c
+
+src/func_0203564c.c:
+    complete
+    .text start:0x0203564c end:0x0203565c
+
+src/_ZNK12WithMeshClsn13GetWallResultEv.cpp:
+    complete
+    .text start:0x0203565c end:0x0203566c
+
+src/_ZNK12WithMeshClsn14GetFloorResultEv.cpp:
+    complete
+    .text start:0x0203566c end:0x0203567c
+
+src/func_0203567c.c:
+    complete
+    .text start:0x0203567c end:0x02035684
+
+src/func_02035684.c:
+    complete
+    .text start:0x02035684 end:0x0203568c
+
+src/func_0203568c.c:
+    complete
+    .text start:0x0203568c end:0x02035694
+
+src/_ZNK12WithMeshClsn13GetLimMovFlagEv.c:
+    complete
+    .text start:0x02035694 end:0x020356a0
+
+src/_ZN12WithMeshClsn15ClearLimMovFlagEv.cpp:
+    complete
+    .text start:0x020356a0 end:0x020356b4
+
+src/_ZN12WithMeshClsn13SetLimMovFlagEv.cpp:
+    complete
+    .text start:0x020356b4 end:0x020356c8
+
+src/func_020356c8.c:
+    complete
+    .text start:0x020356c8 end:0x020356d4
+
+src/func_020356d4.c:
+    complete
+    .text start:0x020356d4 end:0x020356e8
+
+src/_ZNK12WithMeshClsn10IsOnGroundEv.c:
+    complete
+    .text start:0x020356e8 end:0x020356f4
+
+src/_ZN12WithMeshClsn15ClearGroundFlagEv.cpp:
+    complete
+    .text start:0x020356f4 end:0x02035708
+
+src/_ZN12WithMeshClsn13SetGroundFlagEv.cpp:
+    complete
+    .text start:0x02035708 end:0x0203571c
+
+src/_ZNK12WithMeshClsn13JustHitGroundEv.c:
+    complete
+    .text start:0x0203571c end:0x02035728
+
+src/_ZN12WithMeshClsn22ClearJustHitGroundFlagEv.cpp:
+    complete
+    .text start:0x02035728 end:0x0203573c
+
+src/func_0203573c.c:
+    complete
+    .text start:0x0203573c end:0x02035750
+
+src/_ZN12WithMeshClsn19ClearAllGroundFlagsEv.cpp:
+    complete
+    .text start:0x02035750 end:0x02035764
+
+src/func_02035764.c:
+    complete
+    .text start:0x02035764 end:0x02035770
+
+src/func_02035770.c:
+    complete
+    .text start:0x02035770 end:0x02035784
+
+src/func_02035784.c:
+    complete
+    .text start:0x02035784 end:0x02035798
+
+src/func_02035798.c:
+    complete
+    .text start:0x02035798 end:0x020357a0
+
+src/func_020357a0.c:
+    complete
+    .text start:0x020357a0 end:0x020357c0
+
+src/func_020357c0.c:
+    complete
+    .text start:0x020357c0 end:0x020357e0
+
+src/func_020357e0.c:
+    complete
+    .text start:0x020357e0 end:0x02035800
+
+src/func_02035800.c:
+    complete
+    .text start:0x02035800 end:0x02035820
+
+src/_ZN12WithMeshClsn18StopDetectingWaterEv.c:
+    complete
+    .text start:0x02035820 end:0x02035840
+
+src/_ZN12WithMeshClsn19StartDetectingWaterEv.c:
+    complete
+    .text start:0x02035840 end:0x02035860
+
+src/func_02035860.c:
+    complete
+    .text start:0x02035860 end:0x0203589c
+
+src/_ZN12WithMeshClsn12Unk_0203589cEv.cpp:
+    complete
+    .text start:0x0203589c end:0x020358ac
+
+src/_ZN12WithMeshClsn20UpdateExtraContinousEv.cpp:
+    complete
+    .text start:0x020358ac end:0x02036318
+
+src/_ZN12WithMeshClsn22UpdateContinuousNoLavaEv.c:
+    complete
+    .text start:0x02036318 end:0x020366b4
+
+src/_ZN12WithMeshClsn16UpdateContinuousEv.c:
+    complete
+    .text start:0x020366b4 end:0x02036acc
+
+src/func_02036acc.c:
+    complete
+    .text start:0x02036acc end:0x02036ee4
+
+src/_ZN12WithMeshClsn22UpdateDiscreteNoLava_2Ev.cpp:
+    .text start:0x02036ee4 end:0x02037024
+
+src/_ZN12WithMeshClsn20UpdateDiscreteNoLavaEv.cpp:
+    .text start:0x02037024 end:0x020371b0
+
+src/func_020371b0.c:
+    complete
+    .text start:0x020371b0 end:0x020371fc
+
+src/func_020371fc.cpp:
+    complete
+    .text start:0x020371fc end:0x02037318
+
+src/func_02037318.c:
+    complete
+    .text start:0x02037318 end:0x02037388
+
+src/_ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_.c:
+    complete
+    .text start:0x02037388 end:0x020373b8
+
+src/func_020373b8.c:
+    complete
+    .text start:0x020373b8 end:0x020373f8
+
+src/_ZN12WithMeshClsnD1Ev.c:
+    complete
+    .text start:0x020373f8 end:0x02037430
+
+src/_ZN12WithMeshClsnC1Ev.c:
+    .text start:0x02037430 end:0x02037464
+
+src/func_02037464.c:
+    complete
+    .text start:0x02037464 end:0x0203748c
+
+src/_ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor.c:
+    complete
+    .text start:0x0203748c end:0x020374b8
+
+src/func_020374b8.c:
+    complete
+    .text start:0x020374b8 end:0x020374d4
+
+src/func_020374d4.c:
+    complete
+    .text start:0x020374d4 end:0x020374f0
+
+src/func_020374f0.c:
+    complete
+    .text start:0x020374f0 end:0x02037534
+
+src/_ZN13RaycastGroundD1Ev.c:
+    complete
+    .text start:0x02037534 end:0x02037570
+
+src/_ZN13RaycastGroundC1Ev.c:
+    complete
+    .text start:0x02037570 end:0x020375b0
+
+src/func_020375b0.cpp:
+    .text start:0x020375b0 end:0x020375c0
+
+src/func_020375c0.c:
+    .text start:0x020375c0 end:0x020375d0
+
+src/_ZN11RaycastLine10GetClsnPosEv.c:
+    complete
+    .text start:0x020375d0 end:0x020375ec
+
+src/func_020375ec.c:
+    complete
+    .text start:0x020375ec end:0x02037608
+
+src/func_02037608.c:
+    complete
+    .text start:0x02037608 end:0x02037670
+
+src/_ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor.cpp:
+    complete
+    .text start:0x02037670 end:0x02037710
+
+src/func_02037710.c:
+    complete
+    .text start:0x02037710 end:0x02037764
+
+src/_ZN11RaycastLineD1Ev.c:
+    .text start:0x02037764 end:0x020377b0
+
+src/_ZN11RaycastLineC1Ev.cpp:
+    complete
+    .text start:0x020377b0 end:0x0203780c
+
+src/func_0203780c.cpp:
+    .text start:0x0203780c end:0x0203781c
+
+src/func_0203781c.c:
+    .text start:0x0203781c end:0x0203782c
+
+src/func_0203782c.c:
+    complete
+    .text start:0x0203782c end:0x02037880
+
+src/func_02037880.c:
+    complete
+    .text start:0x02037880 end:0x02037888
+
+src/func_02037888.c:
+    complete
+    .text start:0x02037888 end:0x020378dc
+
+src/func_020378dc.c:
+    complete
+    .text start:0x020378dc end:0x020378e4
+
+src/_ZN10SphereClsn14SetFloorResultERK10ClsnResult.c:
+    complete
+    .text start:0x020378e4 end:0x02037938
+
+src/func_02037938.c:
+    complete
+    .text start:0x02037938 end:0x02037940
+
+src/func_02037940.c:
+    complete
+    .text start:0x02037940 end:0x0203794c
+
+src/func_0203794c.c:
+    complete
+    .text start:0x0203794c end:0x02037968
+
+src/func_02037968.c:
+    complete
+    .text start:0x02037968 end:0x0203798c
+
+src/func_0203798c.c:
+    complete
+    .text start:0x0203798c end:0x0203799c
+
+src/func_0203799c.c:
+    complete
+    .text start:0x0203799c end:0x020379c0
+
+src/func_020379c0.c:
+    complete
+    .text start:0x020379c0 end:0x020379d0
+
+src/func_020379d0.c:
+    complete
+    .text start:0x020379d0 end:0x020379f4
+
+src/func_020379f4.c:
+    complete
+    .text start:0x020379f4 end:0x02037a04
+
+src/func_02037a04.c:
+    complete
+    .text start:0x02037a04 end:0x02037a38
+
+src/func_02037a38.c:
+    complete
+    .text start:0x02037a38 end:0x02037a6c
+
+src/func_02037a6c.c:
+    complete
+    .text start:0x02037a6c end:0x02037b1c
+
+src/func_02037b1c.c:
+    complete
+    .text start:0x02037b1c end:0x02037b5c
+
+src/func_02037b5c.c:
+    complete
+    .text start:0x02037b5c end:0x02037c00
+
+src/_ZN10SphereClsn15SetObjAndSphereERK7Vector35Fix12IiEP5Actor.c:
+    complete
+    .text start:0x02037c00 end:0x02037c40
+
+src/func_02037c40.c:
+    complete
+    .text start:0x02037c40 end:0x02037cb0
+
+src/_ZN10SphereClsnD1Ev.c:
+    .text start:0x02037cb0 end:0x02037d18
+
+src/_ZN10SphereClsnC1Ev.c:
+    complete
+    .text start:0x02037d18 end:0x02037d84
+
+src/func_02037d84.cpp:
+    .text start:0x02037d84 end:0x02037d94
+
+src/func_02037d94.c:
+    .text start:0x02037d94 end:0x02037da4
+
+src/func_02037da4.cpp:
+    .text start:0x02037da4 end:0x02037db4
+
+src/func_02037db4.c:
+    .text start:0x02037db4 end:0x02037dc4
+
+src/func_02037dc4.c:
+    complete
+    .text start:0x02037dc4 end:0x02037dcc
+
+src/_ZNK11SurfaceInfo12CopyNormalToER7Vector3.c:
+    complete
+    .text start:0x02037dcc end:0x02037de8
+
+src/func_02037de8.c:
+    complete
+    .text start:0x02037de8 end:0x02037e14
+
+src/func_02037e14.c:
+    complete
+    .text start:0x02037e14 end:0x02037e20
+
+src/func_02037e20.c:
+    complete
+    .text start:0x02037e20 end:0x02037e2c
+
+src/func_02037e2c.c:
+    complete
+    .text start:0x02037e2c end:0x02037e38
+
+src/func_02037e38.c:
+    complete
+    .text start:0x02037e38 end:0x02037e48
+
+src/func_02037e48.c:
+    complete
+    .text start:0x02037e48 end:0x02037e58
+
+src/func_02037e58.c:
+    complete
+    .text start:0x02037e58 end:0x02037e68
+
+src/func_02037e68.c:
+    complete
+    .text start:0x02037e68 end:0x02037e78
+
+src/SurfaceInfo_TestFlag0x20.c:
+    complete
+    .text start:0x02037e78 end:0x02037e84
+
+src/func_02037e84.c:
+    complete
+    .text start:0x02037e84 end:0x02037e90
+
+src/func_02037e90.c:
+    complete
+    .text start:0x02037e90 end:0x02037e9c
+
+src/func_02037e9c.c:
+    complete
+    .text start:0x02037e9c end:0x02037eb0
+
+src/func_02037eb0.c:
+    complete
+    .text start:0x02037eb0 end:0x02037ee4
+
+src/func_02037ee4.c:
+    complete
+    .text start:0x02037ee4 end:0x02037ee8
+
+src/func_02037ee8.c:
+    complete
+    .text start:0x02037ee8 end:0x02037eec
+
+src/func_02037eec.c:
+    complete
+    .text start:0x02037eec end:0x02037f18
+
+src/func_02037f18.c:
+    complete
+    .text start:0x02037f18 end:0x02037f44
+
+src/func_02037f44.c:
+    complete
+    .text start:0x02037f44 end:0x02037f4c
+
+src/_ZNK10ClsnResult9GetClsnIDEv.cpp:
+    complete
+    .text start:0x02037f4c end:0x02037f54
+
+src/func_02037f54.c:
+    complete
+    .text start:0x02037f54 end:0x02037f5c
+
+src/func_02037f5c.c:
+    complete
+    .text start:0x02037f5c end:0x02037f64
+
+src/func_02037f64.c:
+    complete
+    .text start:0x02037f64 end:0x02037f94
+
+src/func_02037f94.c:
+    complete
+    .text start:0x02037f94 end:0x02037fc0
+
+src/func_02037fc0.c:
+    complete
+    .text start:0x02037fc0 end:0x02037fd4
+
+src/func_02037fd4.c:
+    complete
+    .text start:0x02037fd4 end:0x02037fec
+
+src/func_02037fec.c:
+    complete
+    .text start:0x02037fec end:0x02038018
+
+src/_ZN10ClsnResultaSERKS_.cpp:
+    complete
+    .text start:0x02038018 end:0x0203806c
+
+src/_ZNK10ClsnResult6CopyToERS_.c:
+    complete
+    .text start:0x0203806c end:0x020380c0
+
+src/func_020380c0.c:
+    complete
+    .text start:0x020380c0 end:0x020380ec
+
+src/func_020380ec.c:
+    complete
+    .text start:0x020380ec end:0x02038114
+
+src/func_02038114.c:
+    complete
+    .text start:0x02038114 end:0x02038144
+
+src/_ZN10ClsnResultD1Ev.c:
+    complete
+    .text start:0x02038144 end:0x0203816c
+
+src/_ZN10ClsnResultC1Ev.c:
+    complete
+    .text start:0x0203816c end:0x0203819c
+
+src/func_0203819c.c:
+    complete
+    .text start:0x0203819c end:0x020381cc
+
+src/func_020381cc.c:
+    complete
+    .text start:0x020381cc end:0x0203821c
+
+src/func_0203821c.c:
+    complete
+    .text start:0x0203821c end:0x02038224
+
+src/func_02038224.c:
+    complete
+    .text start:0x02038224 end:0x02038228
+
+src/func_02038228.c:
+    complete
+    .text start:0x02038228 end:0x02038234
+
+src/func_02038234.c:
+    complete
+    .text start:0x02038234 end:0x02038298
+
+src/func_02038298.c:
+    complete
+    .text start:0x02038298 end:0x02038324
+
+src/func_02038324.cpp:
+    complete
+    .text start:0x02038324 end:0x020383e4
+
+src/func_020383e4.c:
+    complete
+    .text start:0x020383e4 end:0x020383f0
+
+src/func_020383f0.c:
+    complete
+    .text start:0x020383f0 end:0x020383fc
+
+src/WithMeshClsn_UpdateContinuous_Veneer.c:
+    complete
+    .text start:0x020383fc end:0x02038408
+
+src/func_02038408.c:
+    complete
+    .text start:0x02038408 end:0x02038414
+
+src/func_02038414.c:
+    complete
+    .text start:0x02038414 end:0x02038420
+
+src/WithMeshClsn_UpdateDiscreteNoLava_veneer.c:
+    complete
+    .text start:0x02038420 end:0x0203842c
+
+src/func_0203842c.cpp:
+    complete
+    .text start:0x0203842c end:0x0203859c
+
+src/func_0203859c.cpp:
+    complete
+    .text start:0x0203859c end:0x02038638
+
+src/_ZN11RaycastLine10DetectClsnEv.cpp:
+    complete
+    .text start:0x02038638 end:0x02038824
+
+src/func_02038824.cpp:
+    complete
+    .text start:0x02038824 end:0x02038a38
+
+src/func_02038a38.cpp:
+    complete
+    .text start:0x02038a38 end:0x02038b78
+
+src/_ZN10SphereClsn10DetectClsnEv.cpp:
+    complete
+    .text start:0x02038b78 end:0x02038ea4
+
+src/func_02038ea4.cpp:
+    complete
+    .text start:0x02038ea4 end:0x02038f44
+
+src/_ZN13RaycastGround10DetectClsnEv.cpp:
+    complete
+    .text start:0x02038f44 end:0x02039140
+
+src/_ZN16MeshColliderBase7DisableEv.c:
+    complete
+    .text start:0x02039140 end:0x02039184
+
+src/_ZN16MeshColliderBase6EnableEP5Actor.cpp:
+    .text start:0x02039184 end:0x020391f0
+
+src/func_020391f0.c:
+    complete
+    .text start:0x020391f0 end:0x020391f4
+
+src/_ZN5Stage18ResetMeshCollidersEv.c:
+    complete
+    .text start:0x020391f4 end:0x02039218
+
+src/func_02039218.c:
+    complete
+    .text start:0x02039218 end:0x0203923c
+
+src/_ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp:
+    complete
+    .text start:0x0203923c end:0x0203929c
+
+src/_ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.c:
+    complete
+    .text start:0x0203929c end:0x020392f8
+
+src/_ZN16MeshColliderBase25UpdateAngsWithAngularVelYERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp:
+    complete
+    .text start:0x020392f8 end:0x02039348
+
+src/_ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_.cpp:
+    complete
+    .text start:0x02039348 end:0x0203938c
+
+src/func_0203938c.c:
+    complete
+    .text start:0x0203938c end:0x02039394
+
+src/func_02039394.c:
+    complete
+    .text start:0x02039394 end:0x0203939c
+
+src/func_0203939c.c:
+    complete
+    .text start:0x0203939c end:0x020393a4
+
+src/func_020393a4.c:
+    complete
+    .text start:0x020393a4 end:0x020393ac
+
+src/func_020393ac.c:
+    complete
+    .text start:0x020393ac end:0x020393b4
+
+src/func_020393b4.c:
+    complete
+    .text start:0x020393b4 end:0x020393bc
+
+src/func_020393bc.c:
+    complete
+    .text start:0x020393bc end:0x020393c4
+
+src/func_020393c4.c:
+    complete
+    .text start:0x020393c4 end:0x020393cc
+
+src/func_020393cc.c:
+    complete
+    .text start:0x020393cc end:0x020393d4
+
+src/func_020393d4.c:
+    complete
+    .text start:0x020393d4 end:0x020393dc
+
+src/_ZN16MeshColliderBase9IsEnabledEv.cpp:
+    complete
+    .text start:0x020393dc end:0x020393f0
+
+src/func_020393f0.c:
+    complete
+    .text start:0x020393f0 end:0x020393fc
+
+src/func_020393fc.c:
+    complete
+    .text start:0x020393fc end:0x02039404
+
+src/func_02039404.c:
+    complete
+    .text start:0x02039404 end:0x0203940c
+
+src/_ZN16MeshColliderBase11GetVelocityER7Vector3.c:
+    complete
+    .text start:0x0203940c end:0x02039428
+
+src/_ZN16MeshColliderBase14GetAngularVelYEv.c:
+    complete
+    .text start:0x02039428 end:0x02039430
+
+src/_ZN16MeshColliderBase12TransformPosERK7Vector3RS0_.c:
+    complete
+    .text start:0x02039430 end:0x02039438
+
+src/_ZN16MeshColliderBase10BeforeClsnER10ClsnResultP5ActorR7Vector3P10Vector3_16S7_.cpp:
+    complete
+    .text start:0x02039438 end:0x02039470
+
+src/_ZN16MeshColliderBase10DetectClsnER10SphereClsn.c:
+    complete
+    .text start:0x02039470 end:0x02039478
+
+src/_ZN16MeshColliderBase10DetectClsnER11RaycastLine.c:
+    complete
+    .text start:0x02039478 end:0x02039480
+
+src/_ZN16MeshColliderBase10DetectClsnER13RaycastGround.c:
+    complete
+    .text start:0x02039480 end:0x02039488
+
+src/_ZN4BgCh21ShouldPassThroughImplEPvRK4CLPSRKS_b.c:
+    complete
+    .text start:0x02039488 end:0x020395fc
+
+src/func_020395fc.c:
+    complete
+    .text start:0x020395fc end:0x02039620
+
+src/_ZN16MeshColliderBase9Virtual08Ev.c:
+    complete
+    .text start:0x02039620 end:0x02039624
+
+src/func_02039624.c:
+    complete
+    .text start:0x02039624 end:0x02039658
+
+src/func_02039658.c:
+    complete
+    .text start:0x02039658 end:0x02039668
+
+src/_ZN16MeshColliderBaseD0Ev.c:
+    complete
+    .text start:0x02039668 end:0x0203968c
+
+src/_ZN16MeshColliderBaseD2Ev.c:
+    complete
+    .text start:0x0203968c end:0x0203969c
+
+src/_ZN16MeshColliderBaseC2Ev.c:
+    complete
+    .text start:0x0203969c end:0x020396c0
+
+src/func_020396c0.c:
+    complete
+    .text start:0x020396c0 end:0x020396d0
+
+src/func_020396d0.c:
+    complete
+    .text start:0x020396d0 end:0x020396d8
+
+src/_ZN12MeshCollider9Virtual08Ev.cpp:
+    complete
+    .text start:0x020396d8 end:0x020396dc
+
+src/func_020396dc.c:
+    complete
+    .text start:0x020396dc end:0x020396f0
+
+src/_ZN12MeshCollider7SetFileEP8KCL_FileR10CLPS_Block.c:
+    complete
+    .text start:0x020396f0 end:0x02039760
+
+src/_ZN12MeshCollider17UpdateFileOffsetsER8KCL_File.c:
+    complete
+    .text start:0x02039760 end:0x02039794
+
+src/func_02039794.c:
+    complete
+    .text start:0x02039794 end:0x020397b8
+
+src/func_020397b8.c:
+    complete
+    .text start:0x020397b8 end:0x020397dc
+
+src/func_020397dc.c:
+    complete
+    .text start:0x020397dc end:0x020397fc
+
+src/func_020397fc.c:
+    complete
+    .text start:0x020397fc end:0x0203982c
+
+src/_ZN12MeshColliderD0Ev.c:
+    complete
+    .text start:0x0203982c end:0x02039864
+
+src/_ZN12MeshColliderD1Ev.c:
+    complete
+    .text start:0x02039864 end:0x02039894
+
+src/_ZN12MeshColliderC1Ev.c:
+    complete
+    .text start:0x02039894 end:0x020398c8
+
+src/func_020398c8.c:
+    complete
+    .text start:0x020398c8 end:0x020398fc
+
+src/func_020398fc.c:
+    complete
+    .text start:0x020398fc end:0x02039908
+
+src/_ZN18MovingMeshCollider11GetVelocityER7Vector3.c:
+    complete
+    .text start:0x02039908 end:0x02039924
+
+src/_ZN18MovingMeshCollider14GetAngularVelYEv.cpp:
+    complete
+    .text start:0x02039924 end:0x02039930
+
+src/_ZN18MovingMeshCollider12TransformPosERK7Vector3RS0_.c:
+    complete
+    .text start:0x02039930 end:0x02039970
+
+src/_ZN18MovingMeshCollider10DetectClsnER11RaycastLine.c:
+    .text start:0x02039970 end:0x02039a3c
+
+src/_ZN18MovingMeshCollider10DetectClsnER10SphereClsn.c:
+    complete
+    .text start:0x02039a3c end:0x02039cb8
+
+src/_ZN18MovingMeshCollider10DetectClsnER13RaycastGround.c:
+    .text start:0x02039cb8 end:0x02039db8
+
+src/func_02039db8.c:
+    complete
+    .text start:0x02039db8 end:0x02039e18
+
+src/func_02039e18.c:
+    complete
+    .text start:0x02039e18 end:0x02039e30
+
+src/func_02039e30.c:
+    complete
+    .text start:0x02039e30 end:0x02039e48
+
+src/func_02039e48.c:
+    complete
+    .text start:0x02039e48 end:0x02039e60
+
+src/_ZN18MovingMeshCollider17GetTriangleOriginEsR7Vector3.c:
+    complete
+    .text start:0x02039e60 end:0x02039ec0
+
+src/_ZN18MovingMeshCollider9GetNormalEsR7Vector3.c:
+    complete
+    .text start:0x02039ec0 end:0x02039f20
+
+src/_ZN18MovingMeshCollider9TransformERK9Matrix4x3s.cpp:
+    complete
+    .text start:0x02039f20 end:0x0203a1dc
+
+src/_ZN18MovingMeshCollider9Virtual08Ev.cpp:
+    complete
+    .text start:0x0203a1dc end:0x0203a1e0
+
+src/_ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c:
+    complete
+    .text start:0x0203a1e0 end:0x0203a420
+
+src/func_0203a420.c:
+    complete
+    .text start:0x0203a420 end:0x0203a444
+
+src/_ZN18MovingMeshColliderD0Ev.c:
+    complete
+    .text start:0x0203a444 end:0x0203a470
+
+src/_ZN18MovingMeshColliderD1Ev.c:
+    complete
+    .text start:0x0203a470 end:0x0203a494
+
+src/_ZN18MovingMeshColliderC1Ev.c:
+    complete
+    .text start:0x0203a494 end:0x0203a4b8
+
+src/func_0203a4b8.c:
+    complete
+    .text start:0x0203a4b8 end:0x0203a4dc
+
+src/_ZN21ExtendingMeshCollider9GetNormalEsR7Vector3.c:
+    complete
+    .text start:0x0203a4dc end:0x0203a594
+
+src/_ZN21ExtendingMeshCollider10DetectClsnER11RaycastLine.c:
+    .text start:0x0203a594 end:0x0203a660
+
+src/_ZN21ExtendingMeshCollider10DetectClsnER10SphereClsn.cpp:
+    complete
+    .text start:0x0203a660 end:0x0203a8fc
+
+src/_ZN21ExtendingMeshCollider10DetectClsnER13RaycastGround.cpp:
+    complete
+    .text start:0x0203a8fc end:0x0203aa0c
+
+src/_ZN21ExtendingMeshCollider9Virtual08Ev.cpp:
+    complete
+    .text start:0x0203aa0c end:0x0203aa10
+
+src/func_0203aa10.c:
+    complete
+    .text start:0x0203aa10 end:0x0203aa74
+
+src/func_0203aa74.c:
+    complete
+    .text start:0x0203aa74 end:0x0203aad0
+
+src/func_0203aad0.c:
+    complete
+    .text start:0x0203aad0 end:0x0203aad8
+
+src/_ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE.c:
+    complete
+    .text start:0x0203aad8 end:0x0203ab04
+
+src/_ZN21ExtendingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block.c:
+    complete
+    .text start:0x0203ab04 end:0x0203ab3c
+
+src/_ZN21ExtendingMeshColliderD0Ev.c:
+    complete
+    .text start:0x0203ab3c end:0x0203ab68
+
+src/_ZN21ExtendingMeshColliderD1Ev.c:
+    complete
+    .text start:0x0203ab68 end:0x0203ab8c
+
+src/_ZN21ExtendingMeshColliderC1Ev.c:
+    complete
+    .text start:0x0203ab8c end:0x0203abb0
+
+src/func_0203abb0.c:
+    complete
+    .text start:0x0203abb0 end:0x0203abcc
+
+src/func_0203abcc.c:
+    complete
+    .text start:0x0203abcc end:0x0203abd4
+
+src/func_0203abd4.c:
+    complete
+    .text start:0x0203abd4 end:0x0203ac00
+
+src/func_0203ac00.c:
+    complete
+    .text start:0x0203ac00 end:0x0203ac1c
+
+src/func_0203ac1c.c:
+    complete
+    .text start:0x0203ac1c end:0x0203ac2c
+
+src/func_0203ac2c.c:
+    complete
+    .text start:0x0203ac2c end:0x0203ac50
+
+src/func_0203ac50.c:
+    complete
+    .text start:0x0203ac50 end:0x0203ac60
+
+src/func_0203ac60.c:
+    complete
+    .text start:0x0203ac60 end:0x0203ac70
+
+src/func_0203ac70.c:
+    complete
+    .text start:0x0203ac70 end:0x0203ac80
+
+src/_ZN7PathPtr6FromIDEj.cpp:
+    complete
+    .text start:0x0203ac80 end:0x0203aca0
+
+src/func_0203aca0.c:
+    complete
+    .text start:0x0203aca0 end:0x0203acbc
+
+src/func_0203acbc.c:
+    complete
+    .text start:0x0203acbc end:0x0203accc
+
+src/func_0203accc.c:
+    complete
+    .text start:0x0203accc end:0x0203acdc
+
+src/_ZNK7PathPtr7GetNodeER7Vector3j.c:
+    complete
+    .text start:0x0203acdc end:0x0203ad34
+
+src/_ZNK7PathPtr5LoopsEv.cpp:
+    complete
+    .text start:0x0203ad34 end:0x0203ad44
+
+src/func_0203ad44.c:
+    complete
+    .text start:0x0203ad44 end:0x0203ad54
+
+src/func_0203ad54.c:
+    complete
+    .text start:0x0203ad54 end:0x0203ad60
+
+src/_ZNK7PathPtr8NumNodesEv.cpp:
+    complete
+    .text start:0x0203ad60 end:0x0203ad6c
+
+src/func_0203ad6c.c:
+    complete
+    .text start:0x0203ad6c end:0x0203ad74
+
+src/_ZN7PathPtrC1Ev.c:
+    complete
+    .text start:0x0203ad74 end:0x0203ad84
+
+src/func_0203ad84.c:
+    complete
+    .text start:0x0203ad84 end:0x0203adbc
+
+src/DecIfAbove0_Short.c:
+    complete
+    .text start:0x0203adbc end:0x0203add4
+
+src/DecIfAbove0_Byte.c:
+    complete
+    .text start:0x0203add4 end:0x0203adec
+
+src/_Z14ApproachLinearRsss.cpp:
+    complete
+    .text start:0x0203adec end:0x0203ae58
+
+src/_Z14ApproachLinearRiii.cpp:
+    complete
+    .text start:0x0203ae58 end:0x0203aed8
+
+src/_Z15ApproachLinear2Rsss.cpp:
+    complete
+    .text start:0x0203aed8 end:0x0203af34
+
+src/_Z15ApproachLinear2Riii.cpp:
+    complete
+    .text start:0x0203af34 end:0x0203af90
+
+src/_Z11UpdateAngleRssis.cpp:
+    complete
+    .text start:0x0203af90 end:0x0203b008
+
+src/ApproachAngle.c:
+    complete
+    .text start:0x0203b008 end:0x0203b0e8
+
+src/AngleDiff.c:
+    complete
+    .text start:0x0203b0e8 end:0x0203b0fc
+
+src/Math_Function_0203b0fc.c:
+    complete
+    .text start:0x0203b0fc end:0x0203b14c
+
+src/Math_Function_0203b14c.c:
+    complete
+    .text start:0x0203b14c end:0x0203b20c
+
+src/func_0203b20c.c:
+    complete
+    .text start:0x0203b20c end:0x0203b244
+
+src/func_0203b244.c:
+    complete
+    .text start:0x0203b244 end:0x0203b27c
+
+src/func_0203b27c.c:
+    complete
+    .text start:0x0203b27c end:0x0203b2ec
+
+src/func_0203b2ec.c:
+    complete
+    .text start:0x0203b2ec end:0x0203b358
+
+src/func_0203b358.c:
+    complete
+    .text start:0x0203b358 end:0x0203b394
+
+src/func_0203b394.c:
+    complete
+    .text start:0x0203b394 end:0x0203b3c0
+
+src/func_0203b3c0.c:
+    complete
+    .text start:0x0203b3c0 end:0x0203b438
+
+src/func_0203b438.c:
+    complete
+    .text start:0x0203b438 end:0x0203b4ac
+
+src/_ZN9ActorBase9SceneNode5ResetEv.c:
+    complete
+    .text start:0x0203b4ac end:0x0203b4c4
+
+src/_ZN9ActorBase9SceneNodeC1Ev.c:
+    complete
+    .text start:0x0203b4c4 end:0x0203b4dc
+
+src/_ZN4cstd5atan2E5Fix12IiES1_.c:
+    .text start:0x0203b4dc end:0x0203b684
+
+src/func_0203b684.c:
+    complete
+    .text start:0x0203b684 end:0x0203b6a4
+
+src/Vec3_RotateYAndTranslate.c:
+    complete
+    .text start:0x0203b6a4 end:0x0203b770
+
+src/Vec3_VertAngle.c:
+    complete
+    .text start:0x0203b770 end:0x0203b7ac
+
+src/Vec3_HorzAngle.c:
+    complete
+    .text start:0x0203b7ac end:0x0203b7dc
+
+src/Vec3_ApproachHorz.c:
+    complete
+    .text start:0x0203b7dc end:0x0203b89c
+
+src/_Z14ApproachLinearR7Vector3RKS_5Fix12IiE.cpp:
+    complete
+    .text start:0x0203b89c end:0x0203b958
+
+src/func_0203b958.c:
+    complete
+    .text start:0x0203b958 end:0x0203b98c
+
+src/NoOpDestructor.c:
+    complete
+    .text start:0x0203b98c end:0x0203b990
+
+src/RandomIntInternal.c:
+    complete
+    .text start:0x0203b990 end:0x0203b9b4
+
+src/func_0203b9b4.c:
+    complete
+    .text start:0x0203b9b4 end:0x0203b9bc
+
+src/func_0203b9bc.c:
+    complete
+    .text start:0x0203b9bc end:0x0203bb14
+
+src/func_0203bb14.c:
+    complete
+    .text start:0x0203bb14 end:0x0203bb5c
+
+src/func_0203bb5c.c:
+    complete
+    .text start:0x0203bb5c end:0x0203bb60
+
+src/func_0203bb60.c:
+    complete
+    .text start:0x0203bb60 end:0x0203bbc0
+
+src/func_0203bbc0.c:
+    complete
+    .text start:0x0203bbc0 end:0x0203bc50
+
+src/func_0203bc50.c:
+    complete
+    .text start:0x0203bc50 end:0x0203bc7c
+
+src/func_0203bc7c.c:
+    complete
+    .text start:0x0203bc7c end:0x0203bd24
+
+src/func_0203bd24.c:
+    complete
+    .text start:0x0203bd24 end:0x0203bd28
+
+src/Matrix4x3_FromRotationZ.c:
+    complete
+    .text start:0x0203bd28 end:0x0203bd6c
+
+src/Matrix4x3_FromRotationY.c:
+    complete
+    .text start:0x0203bd6c end:0x0203bdb0
+
+src/Matrix4x3_FromRotationX.c:
+    complete
+    .text start:0x0203bdb0 end:0x0203bdf4
+
+src/Matrix4x3_FromRotationZXYExt.c:
+    complete
+    .text start:0x0203bdf4 end:0x0203be9c
+
+src/Matrix4x3_FromRotationXYZExt.c:
+    complete
+    .text start:0x0203be9c end:0x0203bf44
+
+src/Matrix4x3_FromTranslation.c:
+    complete
+    .text start:0x0203bf44 end:0x0203bf90
+
+src/Matrix4x3_ApplyInPlaceToRotationZ.c:
+    complete
+    .text start:0x0203bf90 end:0x0203bfc0
+
+src/Matrix4x3_ApplyInPlaceToRotationY.c:
+    complete
+    .text start:0x0203bfc0 end:0x0203bff0
+
+src/Matrix4x3_ApplyInPlaceToRotationX.c:
+    complete
+    .text start:0x0203bff0 end:0x0203c020
+
+src/Matrix4x3_ApplyInPlaceToRotationZXYExt.c:
+    complete
+    .text start:0x0203c020 end:0x0203c0b4
+
+src/Matrix4x3_ApplyInPlaceToRotationXYZExt.c:
+    complete
+    .text start:0x0203c0b4 end:0x0203c148
+
+src/Matrix4x3_ApplyInPlaceToScale.c:
+    complete
+    .text start:0x0203c148 end:0x0203c178
+
+src/func_0203c178.c:
+    .text start:0x0203c178 end:0x0203c184
+
+src/Matrix4x3_ApplyInPlaceToTranslation.c:
+    complete
+    .text start:0x0203c184 end:0x0203c1b4
+
+src/_ZN6Memory10DeallocateEPv.cpp:
+    complete
+    .text start:0x0203c1b4 end:0x0203c1c4
+
+src/_ZN6Memory8AllocateEj.cpp:
+    complete
+    .text start:0x0203c1c4 end:0x0203c1d8
+
+src/_ZN6Memory8AllocateEji.cpp:
+    complete
+    .text start:0x0203c1d8 end:0x0203c1e8
+
+src/_ZN6Memory10DeallocateEPvP4Heap.cpp:
+    .text start:0x0203c1e8 end:0x0203c210
+
+src/_ZN6Memory8AllocateEjiP4Heap.c:
+    complete
+    .text start:0x0203c210 end:0x0203c24c
+
+src/_ZN4Heap18InitializeGameHeapEjPS_.c:
+    complete
+    .text start:0x0203c24c end:0x0203c274
+
+src/_ZN4Heap7_SizeofEPv.cpp:
+    complete
+    .text start:0x0203c274 end:0x0203c280
+
+src/_ZN4Heap11_DeallocateEPv.cpp:
+    complete
+    .text start:0x0203c280 end:0x0203c28c
+
+src/_ZN4Heap8AllocateEj.cpp:
+    complete
+    .text start:0x0203c28c end:0x0203c29c
+
+src/_ZN4Heap9_AllocateEji.cpp:
+    complete
+    .text start:0x0203c29c end:0x0203c2a8
+
+src/_ZN4Heap20RestoreFromTemporaryEv.c:
+    complete
+    .text start:0x0203c2a8 end:0x0203c2d8
+
+src/_ZN4Heap28InitializeSolidHeapAsDefaultEjPS_i.cpp:
+    complete
+    .text start:0x0203c2d8 end:0x0203c2e4
+
+src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c:
+    complete
+    .text start:0x0203c2e4 end:0x0203c324
+
+src/_ZN4Heap10SetDefaultEv.cpp:
+    .text start:0x0203c324 end:0x0203c33c
+
+src/_ZN9SolidHeap12VResizeToFitEv.c:
+    complete
+    .text start:0x0203c33c end:0x0203c388
+
+src/_ZN13ExpandingHeap12VResizeToFitEv.cpp:
+    complete
+    .text start:0x0203c388 end:0x0203c390
+
+src/_ZN4Heap11ResizeToFitEv.c:
+    .text start:0x0203c390 end:0x0203c3d8
+
+src/_ZN9SolidHeap10VGetNodeIDEv.cpp:
+    complete
+    .text start:0x0203c3d8 end:0x0203c3e0
+
+src/_ZN13ExpandingHeap10VGetNodeIDEv.cpp:
+    complete
+    .text start:0x0203c3e0 end:0x0203c3f0
+
+src/_ZN9SolidHeap10VSetNodeIDEj.cpp:
+    complete
+    .text start:0x0203c3f0 end:0x0203c3f8
+
+src/_ZN13ExpandingHeap10VSetNodeIDEj.cpp:
+    complete
+    .text start:0x0203c3f8 end:0x0203c408
+
+src/_ZN4Heap9SetNodeIDEj.cpp:
+    complete
+    .text start:0x0203c408 end:0x0203c428
+
+src/_ZN9SolidHeap7VSizeofEPv.cpp:
+    .text start:0x0203c428 end:0x0203c444
+
+src/_ZN13ExpandingHeap7VSizeofEPv.cpp:
+    complete
+    .text start:0x0203c444 end:0x0203c454
+
+src/_ZN4Heap6SizeofEPv.cpp:
+    .text start:0x0203c454 end:0x0203c49c
+
+src/_ZN9SolidHeap14VDeallocateAllEv.cpp:
+    .text start:0x0203c49c end:0x0203c4b0
+
+src/_ZN13ExpandingHeap14VDeallocateAllEv.cpp:
+    complete
+    .text start:0x0203c4b0 end:0x0203c4cc
+
+src/_ZN22ExpandingHeapAllocator16InvokeDeallocateEPvPS_j.cpp:
+    complete
+    .text start:0x0203c4cc end:0x0203c4e4
+
+src/_ZN9SolidHeap11VDeallocateEPv.cpp:
+    .text start:0x0203c4e4 end:0x0203c50c
+
+src/_ZN13ExpandingHeap11VDeallocateEPv.c:
+    complete
+    .text start:0x0203c50c end:0x0203c538
+
+src/_ZN4Heap10DeallocateEPv.cpp:
+    complete
+    .text start:0x0203c538 end:0x0203c558
+
+src/_ZN9SolidHeap11VReallocateEPvj.cpp:
+    complete
+    .text start:0x0203c558 end:0x0203c568
+
+src/_ZN13ExpandingHeap11VReallocateEPvj.cpp:
+    complete
+    .text start:0x0203c568 end:0x0203c578
+
+src/_ZN4Heap10ReallocateEPvj.cpp:
+    complete
+    .text start:0x0203c578 end:0x0203c598
+
+src/_ZN9SolidHeap11VMemoryLeftEv.cpp:
+    .text start:0x0203c598 end:0x0203c5ac
+
+src/_ZN13ExpandingHeap11VMemoryLeftEv.cpp:
+    complete
+    .text start:0x0203c5ac end:0x0203c5bc
+
+src/_ZN9SolidHeap19VMaxAllocatableSizeEv.cpp:
+    .text start:0x0203c5bc end:0x0203c5d0
+
+src/_ZN13ExpandingHeap19VMaxAllocatableSizeEv.cpp:
+    .text start:0x0203c5d0 end:0x0203c5e4
+
+src/_ZN9SolidHeap22VMaxAllocationUnitSizeEv.cpp:
+    .text start:0x0203c5e4 end:0x0203c5f8
+
+src/_ZN13ExpandingHeap22VMaxAllocationUnitSizeEv.cpp:
+    .text start:0x0203c5f8 end:0x0203c60c
+
+src/_ZN4Heap21MaxAllocationUnitSizeEv.cpp:
+    complete
+    .text start:0x0203c60c end:0x0203c62c
+
+src/_ZN9SolidHeap7VRescueEv.cpp:
+    complete
+    .text start:0x0203c62c end:0x0203c630
+
+src/_ZN13ExpandingHeap7VRescueEv.cpp:
+    complete
+    .text start:0x0203c630 end:0x0203c634
+
+src/_ZN4Heap6RescueEv.cpp:
+    complete
+    .text start:0x0203c634 end:0x0203c654
+
+src/_ZN9SolidHeap7VIntactEv.cpp:
+    complete
+    .text start:0x0203c654 end:0x0203c65c
+
+src/_ZN13ExpandingHeap7VIntactEv.cpp:
+    complete
+    .text start:0x0203c65c end:0x0203c664
+
+src/_ZN4Heap6IntactEv.cpp:
+    complete
+    .text start:0x0203c664 end:0x0203c6ac
+
+src/_ZN9SolidHeap9VAllocateEjj.cpp:
+    complete
+    .text start:0x0203c6ac end:0x0203c6bc
+
+src/_ZN13ExpandingHeap9VAllocateEji.cpp:
+    complete
+    .text start:0x0203c6bc end:0x0203c6cc
+
+src/_ZN4Heap8AllocateEji.cpp:
+    .text start:0x0203c6cc end:0x0203c70c
+
+src/_ZN9SolidHeap8VDestroyEv.c:
+    complete
+    .text start:0x0203c70c end:0x0203c72c
+
+src/_ZN13ExpandingHeap8VDestroyEv.c:
+    complete
+    .text start:0x0203c72c end:0x0203c74c
+
+src/_ZN4Heap8_DestroyEv.cpp:
+    complete
+    .text start:0x0203c74c end:0x0203c758
+
+src/_ZN4Heap7DestroyEv.cpp:
+    complete
+    .text start:0x0203c758 end:0x0203c7a0
+
+src/_ZN4Heap15CreateSolidHeapEjPS_i.c:
+    complete
+    .text start:0x0203c7a0 end:0x0203c844
+
+src/_ZN4Heap19CreateExpandingHeapEjPS_i.c:
+    complete
+    .text start:0x0203c844 end:0x0203c8e8
+
+src/_ZN4Heap14CreateRootHeapEPvj.c:
+    complete
+    .text start:0x0203c8e8 end:0x0203c970
+
+src/_ZN9SolidHeapD0Ev.c:
+    complete
+    .text start:0x0203c970 end:0x0203c99c
+
+src/_ZN9SolidHeapD1Ev.c:
+    complete
+    .text start:0x0203c99c end:0x0203c9c0
+
+src/_ZN13ExpandingHeapD0Ev.c:
+    complete
+    .text start:0x0203c9c0 end:0x0203c9ec
+
+src/_ZN13ExpandingHeapD1Ev.c:
+    complete
+    .text start:0x0203c9ec end:0x0203ca10
+
+src/_ZN4HeapD2Ev.c:
+    complete
+    .text start:0x0203ca10 end:0x0203ca20
+
+src/_ZN4HeapD0Ev.c:
+    complete
+    .text start:0x0203ca20 end:0x0203ca44
+
+src/_ZN4HeapD1Ev.c:
+    complete
+    .text start:0x0203ca44 end:0x0203ca54
+
+src/_ZN9SolidHeapC1EPvjP4HeapP18SolidHeapAllocator.c:
+    complete
+    .text start:0x0203ca54 end:0x0203ca80
+
+src/_ZN13ExpandingHeapC1EPvjP4HeapP22ExpandingHeapAllocator.c:
+    complete
+    .text start:0x0203ca80 end:0x0203caac
+
+src/_ZN4HeapC1EPvjP4Heap.c:
+    complete
+    .text start:0x0203caac end:0x0203cae8
+
+src/_ZN4Heap18InitializeRootHeapEv.cpp:
+    .text start:0x0203cae8 end:0x0203cb04
+
+src/_ZN4Heap13SetupRootHeapEv.c:
+    complete
+    .text start:0x0203cb04 end:0x0203cbc0
+
+src/func_0203cbc0.c:
+    complete
+    .text start:0x0203cbc0 end:0x0203cbcc
+
+src/_ZN6Memory16operator_delete2EPv.cpp:
+    complete
+    .text start:0x0203cbcc end:0x0203cbd8
+
+src/_ZN6Memory13operator_new2Ej.cpp:
+    complete
+    .text start:0x0203cbd8 end:0x0203cbe4
+
+src/_Znwj.cpp:
+    complete
+    .text start:0x0203cbe4 end:0x0203cbf0
+
+src/_ZdlPv.cpp:
+    .text start:0x0203cbf0 end:0x0203cc0c
+
+src/func_0203cc0c.c:
+    complete
+    .text start:0x0203cc0c end:0x0203cc28
+
+src/func_0203cc28.c:
+    complete
+    .text start:0x0203cc28 end:0x0203ccd4
+
+src/func_0203ccd4.c:
+    complete
+    .text start:0x0203ccd4 end:0x0203cd80
+
+src/func_0203cd80.c:
+    complete
+    .text start:0x0203cd80 end:0x0203ce2c
+
+src/NormalizeVec3IfNonZero.c:
+    complete
+    .text start:0x0203ce2c end:0x0203ce80
+
+src/func_0203ce80.c:
+    complete
+    .text start:0x0203ce80 end:0x0203cebc
+
+src/func_0203cebc.c:
+    complete
+    .text start:0x0203cebc end:0x0203cf00
+
+src/func_0203cf00.c:
+    complete
+    .text start:0x0203cf00 end:0x0203cf40
+
+src/Vec3_HorzDist.c:
+    complete
+    .text start:0x0203cf40 end:0x0203cf78
+
+src/Vec3_HorzLen.c:
+    complete
+    .text start:0x0203cf78 end:0x0203cf94
+
+src/func_0203cf94.c:
+    complete
+    .text start:0x0203cf94 end:0x0203cfdc
+
+src/Vec3_Dist.c:
+    complete
+    .text start:0x0203cfdc end:0x0203d024
+
+src/func_0203d024.c:
+    complete
+    .text start:0x0203d024 end:0x0203d064
+
+src/Vec3_Equal.c:
+    complete
+    .text start:0x0203d064 end:0x0203d0a0
+
+src/Vec3_LslInPlace.c:
+    complete
+    .text start:0x0203d0a0 end:0x0203d0d0
+
+src/Vec3_Lsl.c:
+    complete
+    .text start:0x0203d0d0 end:0x0203d108
+
+src/Vec3_AsrInPlace.c:
+    complete
+    .text start:0x0203d108 end:0x0203d138
+
+src/Vec3_Asr.c:
+    complete
+    .text start:0x0203d138 end:0x0203d170
+
+src/Vec3_DivScalarInPlace.c:
+    complete
+    .text start:0x0203d170 end:0x0203d224
+
+src/Vec3_MulScalarInPlace.c:
+    complete
+    .text start:0x0203d224 end:0x0203d290
+
+src/Vec3_MulScalar.c:
+    complete
+    .text start:0x0203d290 end:0x0203d2fc
+
+src/Vec3_Sub.c:
+    complete
+    .text start:0x0203d2fc end:0x0203d340
+
+src/Vec3_Add.c:
+    complete
+    .text start:0x0203d340 end:0x0203d384
+
+src/func_0203d384.c:
+    complete
+    .text start:0x0203d384 end:0x0203d388
+
+src/func_0203d388.c:
+    complete
+    .text start:0x0203d388 end:0x0203d434
+
+src/func_0203d434.c:
+    complete
+    .text start:0x0203d434 end:0x0203d47c
+
+src/NullDestructor_0203d47c.c:
+    complete
+    .text start:0x0203d47c end:0x0203d480
+
+src/func_0203d480.c:
+    complete
+    .text start:0x0203d480 end:0x0203d4d0
+
+src/func_0203d4d0.c:
+    complete
+    .text start:0x0203d4d0 end:0x0203d524
+
+src/func_0203d524.c:
+    complete
+    .text start:0x0203d524 end:0x0203d570
+
+src/func_0203d570.c:
+    complete
+    .text start:0x0203d570 end:0x0203d5bc
+
+src/func_0203d5bc.c:
+    complete
+    .text start:0x0203d5bc end:0x0203d5dc
+
+src/func_0203d5dc.c:
+    complete
+    .text start:0x0203d5dc end:0x0203d614
+
+src/Vec2_Len.c:
+    complete
+    .text start:0x0203d614 end:0x0203d630
+
+src/func_0203d630.c:
+    complete
+    .text start:0x0203d630 end:0x0203d680
+
+src/func_0203d680.c:
+    complete
+    .text start:0x0203d680 end:0x0203d6d0
+
+src/Vec2_Sub.c:
+    complete
+    .text start:0x0203d6d0 end:0x0203d704
+
+src/func_0203d704.c:
+    complete
+    .text start:0x0203d704 end:0x0203d738
+
+src/func_0203d738.c:
+    complete
+    .text start:0x0203d738 end:0x0203d73c
+
+src/func_0203d73c.c:
+    complete
+    .text start:0x0203d73c end:0x0203d740
+
+src/func_0203d740.c:
+    complete
+    .text start:0x0203d740 end:0x0203d744
+
+src/_ZN4cstd4sqrtEy.c:
+    complete
+    .text start:0x0203d744 end:0x0203d7b8
+
+src/func_0203d7b8.c:
+    complete
+    .text start:0x0203d7b8 end:0x0203d7d4
+
+src/func_0203d7d4.c:
+    complete
+    .text start:0x0203d7d4 end:0x0203d81c
+
+src/func_0203d81c.c:
+    complete
+    .text start:0x0203d81c end:0x0203d854
+
+src/func_0203d854.c:
+    complete
+    .text start:0x0203d854 end:0x0203d868
+
+src/func_0203d868.c:
+    complete
+    .text start:0x0203d868 end:0x0203d880
+
+src/GetOwnerLanguage.c:
+    complete
+    .text start:0x0203d880 end:0x0203d890
+
+src/func_0203d890.c:
+    complete
+    .text start:0x0203d890 end:0x0203d8a0
+
+src/func_0203d8a0.c:
+    complete
+    .text start:0x0203d8a0 end:0x0203d8d4
+
+src/func_0203d8d4.c:
+    complete
+    .text start:0x0203d8d4 end:0x0203d8e8
+
+src/func_0203d8e8.c:
+    complete
+    .text start:0x0203d8e8 end:0x0203d8fc
+
+src/func_0203d8fc.c:
+    complete
+    .text start:0x0203d8fc end:0x0203d918
+
+src/func_0203d918.c:
+    complete
+    .text start:0x0203d918 end:0x0203d930
+
+src/func_0203d930.c:
+    complete
+    .text start:0x0203d930 end:0x0203d950
+
+src/func_0203d950.c:
+    complete
+    .text start:0x0203d950 end:0x0203d974
+
+src/func_0203d974.c:
+    complete
+    .text start:0x0203d974 end:0x0203d9b4
+
+src/func_0203d9b4.c:
+    complete
+    .text start:0x0203d9b4 end:0x0203d9f4
+
+src/func_0203d9f4.c:
+    complete
+    .text start:0x0203d9f4 end:0x0203da2c
+
+src/func_0203da2c.c:
+    complete
+    .text start:0x0203da2c end:0x0203da3c
+
+src/func_0203da3c.c:
+    complete
+    .text start:0x0203da3c end:0x0203da4c
+
+src/func_0203da4c.c:
+    complete
+    .text start:0x0203da4c end:0x0203da80
+
+src/func_0203da80.c:
+    complete
+    .text start:0x0203da80 end:0x0203da9c
+
+src/func_0203da9c.c:
+    complete
+    .text start:0x0203da9c end:0x0203daac
+
+src/func_0203daac.c:
+    complete
+    .text start:0x0203daac end:0x0203dabc
+
+src/func_0203dabc.c:
+    complete
+    .text start:0x0203dabc end:0x0203dad4
+
+src/func_0203dad4.c:
+    complete
+    .text start:0x0203dad4 end:0x0203dae4
+
+src/func_0203dae4.c:
+    complete
+    .text start:0x0203dae4 end:0x0203dafc
+
+src/func_0203dafc.c:
+    complete
+    .text start:0x0203dafc end:0x0203db0c
+
+src/func_0203db0c.c:
+    complete
+    .text start:0x0203db0c end:0x0203db24
+
+src/GetAngleToCamera.c:
+    complete
+    .text start:0x0203db24 end:0x0203db3c
+
+src/func_0203db3c.c:
+    complete
+    .text start:0x0203db3c end:0x0203db4c
+
+src/GetPlayerFlagByte.c:
+    complete
+    .text start:0x0203db4c end:0x0203db64
+
+src/func_0203db64.c:
+    complete
+    .text start:0x0203db64 end:0x0203df40
+
+src/func_0203df40.c:
+    complete
+    .text start:0x0203df40 end:0x0203e0ac
+
+src/func_0203e0ac.c:
+    complete
+    .text start:0x0203e0ac end:0x0203e20c
+
+src/func_0203e20c.c:
+    complete
+    .text start:0x0203e20c end:0x0203e978
+
+src/func_0203e978.c:
+    complete
+    .text start:0x0203e978 end:0x0203e9a8
+
+src/func_0203e9a8.c:
+    complete
+    .text start:0x0203e9a8 end:0x0203ea5c
+
+src/func_0203ea5c.c:
+    complete
+    .text start:0x0203ea5c end:0x0203f604
+
+src/func_0203f604.c:
+    complete
+    .text start:0x0203f604 end:0x0203f644
+
+src/func_0203f644.c:
+    complete
+    .text start:0x0203f644 end:0x0203f650
+
+src/func_0203f650.c:
+    complete
+    .text start:0x0203f650 end:0x0203f6a4
+
+src/func_0203f6a4.c:
+    complete
+    .text start:0x0203f6a4 end:0x0203f6b4
+
+src/func_0203f6b4.c:
+    complete
+    .text start:0x0203f6b4 end:0x0203f6e8
+
+src/func_0203f6e8.c:
+    complete
+    .text start:0x0203f6e8 end:0x0203f714
+
+src/func_0203f714.c:
+    .text start:0x0203f714 end:0x0203f818
+
+src/func_0203f818.c:
+    complete
+    .text start:0x0203f818 end:0x0203f8a4
+
+src/func_0203f8a4.c:
+    complete
+    .text start:0x0203f8a4 end:0x0203f920
+
+src/func_0203f920.c:
+    complete
+    .text start:0x0203f920 end:0x0203f9d4
+
+src/func_0203f9d4.c:
+    complete
+    .text start:0x0203f9d4 end:0x0203fa50
+
+src/func_0203fa50.c:
+    complete
+    .text start:0x0203fa50 end:0x0203faa8
+
+src/func_0203faa8.c:
+    complete
+    .text start:0x0203faa8 end:0x0203fb5c
+
+src/func_0203fb5c.c:
+    complete
+    .text start:0x0203fb5c end:0x0203fb98
+
+src/func_0203fb98.c:
+    complete
+    .text start:0x0203fb98 end:0x0203fbc4
+
+src/func_0203fbc4.c:
+    complete
+    .text start:0x0203fbc4 end:0x0203fbfc
+
+src/Wireless_Reset.c:
+    complete
+    .text start:0x0203fbfc end:0x0203fc38
+
+src/func_0203fc38.c:
+    complete
+    .text start:0x0203fc38 end:0x0203fc74
+
+src/func_0203fc74.c:
+    complete
+    .text start:0x0203fc74 end:0x0203fcb0
+
+src/func_0203fcb0.c:
+    complete
+    .text start:0x0203fcb0 end:0x0203fcec
+
+src/func_0203fcec.c:
+    complete
+    .text start:0x0203fcec end:0x0203fd28
+
+src/func_0203fd28.c:
+    complete
+    .text start:0x0203fd28 end:0x0203fd64
+
+src/func_0203fd64.c:
+    complete
+    .text start:0x0203fd64 end:0x0203fdac
+
+src/func_0203fdac.c:
+    complete
+    .text start:0x0203fdac end:0x0203fec4
+
+src/func_0203fec4.c:
+    complete
+    .text start:0x0203fec4 end:0x02040014
+
+src/func_02040014.c:
+    complete
+    .text start:0x02040014 end:0x020401e8
+
+src/func_020401e8.c:
+    complete
+    .text start:0x020401e8 end:0x020402a0
+
+src/func_020402a0.c:
+    complete
+    .text start:0x020402a0 end:0x02040384
+
+src/func_02040384.c:
+    complete
+    .text start:0x02040384 end:0x02040388
+
+src/func_02040388.c:
+    complete
+    .text start:0x02040388 end:0x02040408
+
+src/func_02040408.c:
+    complete
+    .text start:0x02040408 end:0x02040504
+
+src/func_02040504.c:
+    complete
+    .text start:0x02040504 end:0x020405b4
+
+src/func_020405b4.c:
+    complete
+    .text start:0x020405b4 end:0x02040634
+
+src/func_02040634.c:
+    complete
+    .text start:0x02040634 end:0x02040638
+
+src/func_02040638.c:
+    complete
+    .text start:0x02040638 end:0x0204068c
+
+src/func_0204068c.c:
+    complete
+    .text start:0x0204068c end:0x020406b4
+
+src/func_020406b4.c:
+    complete
+    .text start:0x020406b4 end:0x02040704
+
+src/func_02040704.c:
+    complete
+    .text start:0x02040704 end:0x02040714
+
+src/func_02040714.c:
+    complete
+    .text start:0x02040714 end:0x02040724
+
+src/func_02040724.c:
+    complete
+    .text start:0x02040724 end:0x02040790
+
+src/func_02040790.c:
+    complete
+    .text start:0x02040790 end:0x02040820
+
+src/func_02040820.c:
+    complete
+    .text start:0x02040820 end:0x020408b0
+
+src/func_020408b0.c:
+    complete
+    .text start:0x020408b0 end:0x02040a5c
+
+src/func_02040a5c.c:
+    complete
+    .text start:0x02040a5c end:0x02040a84
+
+src/func_02040a84.c:
+    complete
+    .text start:0x02040a84 end:0x02040a94
+
+src/func_02040a94.c:
+    complete
+    .text start:0x02040a94 end:0x02040aa4
+
+src/func_02040aa4.c:
+    complete
+    .text start:0x02040aa4 end:0x02040bb0
+
+src/func_02040bb0.c:
+    complete
+    .text start:0x02040bb0 end:0x02040c34
+
+src/func_02040c34.c:
+    complete
+    .text start:0x02040c34 end:0x02040f30
+
+src/func_02040f30.c:
+    complete
+    .text start:0x02040f30 end:0x02041224
+
+src/func_02041224.c:
+    complete
+    .text start:0x02041224 end:0x020412f0
+
+src/func_020412f0.c:
+    complete
+    .text start:0x020412f0 end:0x0204175c
+
+src/func_0204175c.c:
+    complete
+    .text start:0x0204175c end:0x020417d0
+
+src/func_020417d0.c:
+    complete
+    .text start:0x020417d0 end:0x020418f0
+
+src/func_020418f0.c:
+    complete
+    .text start:0x020418f0 end:0x02041930
+
+src/func_02041930.c:
+    complete
+    .text start:0x02041930 end:0x02041a00
+
+src/func_02041a00.c:
+    complete
+    .text start:0x02041a00 end:0x02041a94
+
+src/func_02041a94.c:
+    complete
+    .text start:0x02041a94 end:0x02041ae8
+
+src/func_02041ae8.c:
+    complete
+    .text start:0x02041ae8 end:0x02041b24
+
+src/func_02041b24.c:
+    complete
+    .text start:0x02041b24 end:0x02041b60
+
+src/func_02041b60.c:
+    complete
+    .text start:0x02041b60 end:0x02041bbc
+
+src/func_02041bbc.c:
+    complete
+    .text start:0x02041bbc end:0x02041c2c
+
+src/func_02041c2c.c:
+    complete
+    .text start:0x02041c2c end:0x02041c64
+
+src/func_02041c64.c:
+    complete
+    .text start:0x02041c64 end:0x02041ce0
+
+src/func_02041ce0.c:
+    complete
+    .text start:0x02041ce0 end:0x02041d28
+
+src/func_02041d28.c:
+    complete
+    .text start:0x02041d28 end:0x02041e14
+
+src/func_02041e14.c:
+    complete
+    .text start:0x02041e14 end:0x02042160
+
+src/func_02042160.c:
+    complete
+    .text start:0x02042160 end:0x020421b4
+
+src/func_020421b4.c:
+    complete
+    .text start:0x020421b4 end:0x02042200
+
+src/func_02042200.c:
+    complete
+    .text start:0x02042200 end:0x02042254
+
+src/func_02042254.c:
+    complete
+    .text start:0x02042254 end:0x020423c8
+
+src/func_020423c8.c:
+    complete
+    .text start:0x020423c8 end:0x020423dc
+
+src/func_020423dc.c:
+    complete
+    .text start:0x020423dc end:0x020424c0
+
+src/func_020424c0.c:
+    complete
+    .text start:0x020424c0 end:0x02042668
+
+src/func_02042668.c:
+    complete
+    .text start:0x02042668 end:0x020426f0
+
+src/func_020426f0.c:
+    complete
+    .text start:0x020426f0 end:0x020426f8
+
+src/func_020426f8.c:
+    complete
+    .text start:0x020426f8 end:0x0204271c
+
+src/func_0204271c.c:
+    complete
+    .text start:0x0204271c end:0x02042748
+
+src/func_02042748.c:
+    complete
+    .text start:0x02042748 end:0x02042778
+
+src/func_02042778.c:
+    complete
+    .text start:0x02042778 end:0x02042784
+
+src/func_02042784.c:
+    .text start:0x02042784 end:0x020427c4
+
+src/func_020427c4.c:
+    .text start:0x020427c4 end:0x020427f8
+
+src/func_020427f8.c:
+    complete
+    .text start:0x020427f8 end:0x02042804
+
+src/_ZN8SaveData16ReadDataFromCartEPcjj.cpp:
+    complete
+    .text start:0x02042804 end:0x02042c3c
+
+src/_ZN8SaveData14SaveDataToCartEPcjj.cpp:
+    .text start:0x02042c3c end:0x02042f68
+
+src/func_02042f68.c:
+    complete
+    .text start:0x02042f68 end:0x02042fe4
+
+src/func_02042fe4.c:
+    complete
+    .text start:0x02042fe4 end:0x02042ffc
+
+src/func_02042ffc.c:
+    complete
+    .text start:0x02042ffc end:0x0204302c
+
+src/func_0204302c.c:
+    complete
+    .text start:0x0204302c end:0x02043060
+
+src/func_02043060.c:
+    complete
+    .text start:0x02043060 end:0x02043098
+
+src/func_02043098.c:
+    complete
+    .text start:0x02043098 end:0x02043180
+
+src/func_02043180.c:
+    complete
+    .text start:0x02043180 end:0x020431c4
+
+src/func_020431c4.c:
+    complete
+    .text start:0x020431c4 end:0x0204322c
+
+src/func_0204322c.c:
+    complete
+    .text start:0x0204322c end:0x02043288
+
+src/func_02043288.c:
+    complete
+    .text start:0x02043288 end:0x020432e4
+
+src/func_020432e4.c:
+    complete
+    .text start:0x020432e4 end:0x0204335c
+
+src/func_0204335c.c:
+    complete
+    .text start:0x0204335c end:0x020433b8
+
+src/func_020433b8.c:
+    complete
+    .text start:0x020433b8 end:0x02043444
+
+src/_ZN9ActorBasenwEj.cpp:
+    .text start:0x02043444 end:0x02043494
+
+src/_ZN9ActorBase13OnHeapCreatedEv.cpp:
+    complete
+    .text start:0x02043494 end:0x0204349c
+
+src/_ZN9ActorBase9Virtual38Ejj.cpp:
+    complete
+    .text start:0x0204349c end:0x0204357c
+
+src/_ZN9ActorBase9Virtual34Ejj.cpp:
+    complete
+    .text start:0x0204357c end:0x02043810
+
+src/func_02043810.c:
+    complete
+    .text start:0x02043810 end:0x02043824
+
+src/_ZN9ActorBase18MarkForDestructionEv.cpp:
+    complete
+    .text start:0x02043824 end:0x02043880
+
+src/func_02043880.c:
+    complete
+    .text start:0x02043880 end:0x02043ac0
+
+src/_ZN9ActorBase16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x02043ac0 end:0x02043ac4
+
+src/_ZN9ActorBase11AfterRenderEj.cpp:
+    complete
+    .text start:0x02043ac4 end:0x02043ac8
+
+src/_ZN9ActorBase12BeforeRenderEv.cpp:
+    complete
+    .text start:0x02043ac8 end:0x02043af0
+
+src/_ZN9ActorBase6RenderEv.cpp:
+    complete
+    .text start:0x02043af0 end:0x02043af8
+
+src/_ZN9ActorBase13AfterBehaviorEj.cpp:
+    complete
+    .text start:0x02043af8 end:0x02043afc
+
+src/_ZN9ActorBase14BeforeBehaviorEv.cpp:
+    complete
+    .text start:0x02043afc end:0x02043b24
+
+src/_ZN9ActorBase8BehaviorEv.cpp:
+    complete
+    .text start:0x02043b24 end:0x02043b2c
+
+src/_ZN9ActorBase21AfterCleanupResourcesEj.c:
+    .text start:0x02043b2c end:0x02043bac
+
+src/_ZN9ActorBase22BeforeCleanupResourcesEv.cpp:
+    .text start:0x02043bac end:0x02043bf0
+
+src/_ZN9ActorBase16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02043bf0 end:0x02043bf8
+
+src/_ZN9ActorBase18AfterInitResourcesEj.cpp:
+    complete
+    .text start:0x02043bf8 end:0x02043c78
+
+src/_ZN9ActorBase19BeforeInitResourcesEv.cpp:
+    complete
+    .text start:0x02043c78 end:0x02043c80
+
+src/_ZN9ActorBase13InitResourcesEv.cpp:
+    complete
+    .text start:0x02043c80 end:0x02043c88
+
+src/_ZN9ActorBase7ProcessEMS_FivEMS_FbvEMS_FvjE.cpp:
+    complete
+    .text start:0x02043c88 end:0x02043d48
+
+src/_ZN9ActorBaseD2Ev.c:
+    .text start:0x02043d48 end:0x02043d78
+
+src/_ZN9ActorBaseD0Ev.c:
+    complete
+    .text start:0x02043d78 end:0x02043dbc
+
+src/_ZN9ActorBaseD1Ev.c:
+    .text start:0x02043dbc end:0x02043dec
+
+src/_ZN9ActorBaseC1Ev.cpp:
+    complete
+    .text start:0x02043dec end:0x02043f4c
+
+src/func_02043f4c.c:
+    complete
+    .text start:0x02043f4c end:0x02043f98
+
+src/func_02043f98.c:
+    complete
+    .text start:0x02043f98 end:0x02043fdc
+
+src/func_02043fdc.cpp:
+    complete
+    .text start:0x02043fdc end:0x0204405c
+
+src/func_0204405c.c:
+    complete
+    .text start:0x0204405c end:0x020440e8
+
+src/func_020440e8.c:
+    complete
+    .text start:0x020440e8 end:0x02044104
+
+src/func_02044104.c:
+    complete
+    .text start:0x02044104 end:0x02044120
+
+src/func_02044120.c:
+    complete
+    .text start:0x02044120 end:0x020441bc
+
+src/func_020441bc.c:
+    complete
+    .text start:0x020441bc end:0x020441cc
+
+src/func_020441cc.cpp:
+    complete
+    .text start:0x020441cc end:0x0204424c
+
+src/func_0204424c.c:
+    complete
+    .text start:0x0204424c end:0x02044284
+
+src/func_02044284.cpp:
+    complete
+    .text start:0x02044284 end:0x02044334
+
+src/func_02044334.cpp:
+    complete
+    .text start:0x02044334 end:0x020443c8
+
+src/_ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3.cpp:
+    complete
+    .text start:0x020443c8 end:0x02044534
+
+src/func_02044534.c:
+    complete
+    .text start:0x02044534 end:0x0204488c
+
+src/func_0204488c.c:
+    complete
+    .text start:0x0204488c end:0x02044b30
+
+src/func_02044b30.c:
+    .text start:0x02044b30 end:0x02044dc4
+
+src/func_02044dc4.c:
+    complete
+    .text start:0x02044dc4 end:0x02044e50
+
+src/func_02044e50.c:
+    complete
+    .text start:0x02044e50 end:0x02044efc
+
+src/func_02044efc.c:
+    complete
+    .text start:0x02044efc end:0x02044f74
+
+src/func_02044f74.c:
+    complete
+    .text start:0x02044f74 end:0x0204504c
+
+src/_ZN15ModelComponents21UpdateVertsUsingBonesEv.c:
+    complete
+    .text start:0x0204504c end:0x02045074
+
+src/func_02045074.c:
+    complete
+    .text start:0x02045074 end:0x02045178
+
+src/func_02045178.c:
+    complete
+    .text start:0x02045178 end:0x0204531c
+
+src/func_0204531c.c:
+    complete
+    .text start:0x0204531c end:0x02045394
+
+src/_ZN15ModelComponents11UpdateBonesEP8BCA_Filei.cpp:
+    complete
+    .text start:0x02045394 end:0x020453c0
+
+src/func_020453c0.c:
+    complete
+    .text start:0x020453c0 end:0x0204547c
+
+src/func_0204547c.c:
+    complete
+    .text start:0x0204547c end:0x020456a0
+
+src/func_020456a0.c:
+    complete
+    .text start:0x020456a0 end:0x020457f0
+
+src/func_020457f0.c:
+    complete
+    .text start:0x020457f0 end:0x020458a8
+
+src/func_020458a8.c:
+    complete
+    .text start:0x020458a8 end:0x020458e0
+
+src/_ZN5Model13LoadTexAndPalER8BMD_File.cpp:
+    .text start:0x020458e0 end:0x02045a50
+
+src/func_02045a50.c:
+    complete
+    .text start:0x02045a50 end:0x02045ad8
+
+src/func_02045ad8.c:
+    complete
+    .text start:0x02045ad8 end:0x02045b58
+
+src/_ZN5Model17LoadTextureToVramEPcj.c:
+    complete
+    .text start:0x02045c10 end:0x02045c60
+
+src/_ZN5Model13GetVramOffsetEj.cpp:
+    .text start:0x02045c60 end:0x02045ce0
+
+src/func_02045ce0.c:
+    complete
+    .text start:0x02045ce0 end:0x02045cf0
+
+src/func_02045cf0.c:
+    complete
+    .text start:0x02045cf0 end:0x02045d00
+
+src/func_02045d00.c:
+    complete
+    .text start:0x02045d00 end:0x02045d10
+
+src/func_02045d10.c:
+    complete
+    .text start:0x02045d10 end:0x02045d20
+
+src/InitialiseVramGlobals.c:
+    complete
+    .text start:0x02045d20 end:0x02045d9c
+
+src/func_02045d9c.c:
+    complete
+    .text start:0x02045d9c end:0x02045e2c
+
+src/func_02045e2c.c:
+    complete
+    .text start:0x02045e2c end:0x02045e44
+
+src/func_02045e44.c:
+    complete
+    .text start:0x02045e44 end:0x02045e70
+
+src/func_02045e70.c:
+    complete
+    .text start:0x02045e70 end:0x02045ec4
+
+src/func_02045ec4.c:
+    complete
+    .text start:0x02045ec4 end:0x02045ef8
+
+src/func_02045ef8.c:
+    complete
+    .text start:0x02045ef8 end:0x02045f4c
+
+src/func_02045f4c.c:
+    complete
+    .text start:0x02045f4c end:0x02045f80
+
+src/func_02045f80.c:
+    complete
+    .text start:0x02045f80 end:0x02045fd4
+
+src/func_02045fd4.c:
+    complete
+    .text start:0x02045fd4 end:0x02046008
+
+src/func_02046008.c:
+    complete
+    .text start:0x02046008 end:0x0204605c
+
+src/func_0204605c.c:
+    complete
+    .text start:0x0204605c end:0x02046088
+
+src/func_02046088.c:
+    complete
+    .text start:0x02046088 end:0x02046120
+
+src/func_02046120.c:
+    complete
+    .text start:0x02046120 end:0x020461b4
+
+src/func_020461b4.c:
+    complete
+    .text start:0x020461b4 end:0x02046208
+
+src/func_02046208.c:
+    complete
+    .text start:0x02046208 end:0x02046234
+
+src/func_02046234.c:
+    complete
+    .text start:0x02046234 end:0x02046288
+
+src/func_02046288.c:
+    complete
+    .text start:0x02046288 end:0x020462b4
+
+src/func_020462b4.c:
+    complete
+    .text start:0x020462b4 end:0x020462bc
+
+src/func_020462bc.c:
+    complete
+    .text start:0x020462bc end:0x020462d0
+
+src/func_020462d0.c:
+    complete
+    .text start:0x020462d0 end:0x02046564
+
+src/func_02046564.c:
+    complete
+    .text start:0x02046564 end:0x02046590
+
+src/func_02046590.c:
+    complete
+    .text start:0x02046590 end:0x020465fc
+
+src/_ZN5Model17UpdateFileOffsetsER8BMD_File.cpp:
+    .text start:0x020465fc end:0x020468a0
+
+src/_ZN15TextureSequence17UpdateFileOffsetsER8BTP_File.cpp:
+    .text start:0x020468a0 end:0x020469ac
+
+src/_ZN9Animation17UpdateFileOffsets_ZN9AnimationER8BCA_File.c:
+    complete
+    .text start:0x020469ac end:0x020469e0
+
+src/func_020469e0.c:
+    complete
+    .text start:0x020469e0 end:0x020469e8
+
+src/func_020469e8.c:
+    complete
+    .text start:0x020469e8 end:0x02046b64
+
+src/func_02046b64.c:
+    complete
+    .text start:0x02046b64 end:0x02046bbc
+
+src/func_02046bbc.c:
+    complete
+    .text start:0x02046bbc end:0x02046d50
+
+src/func_02046d50.c:
+    complete
+    .text start:0x02046d50 end:0x02046e28
+
+src/func_02046e28.c:
+    complete
+    .text start:0x02046e28 end:0x020470e8
+
+src/func_020470e8.c:
+    complete
+    .text start:0x020470e8 end:0x02047144
+
+src/func_02047144.c:
+    complete
+    .text start:0x02047144 end:0x020471ac
+
+src/func_020471ac.c:
+    complete
+    .text start:0x020471ac end:0x02047218
+
+src/func_02047218.c:
+    complete
+    .text start:0x02047218 end:0x02047910
+
+src/func_02047910.c:
+    complete
+    .text start:0x02047910 end:0x02048234
+
+src/func_02048234.c:
+    complete
+    .text start:0x02048234 end:0x02048528
+
+src/func_02048528.c:
+    complete
+    .text start:0x02048528 end:0x020485f0
+
+src/func_020485f0.c:
+    complete
+    .text start:0x020485f0 end:0x02048720
+
+src/func_02048720.c:
+    complete
+    .text start:0x02048720 end:0x02048908
+
+src/func_02048908.c:
+    complete
+    .text start:0x02048908 end:0x02048a18
+
+src/func_02048a18.c:
+    complete
+    .text start:0x02048a18 end:0x02048a1c
+
+src/func_02048a1c.c:
+    complete
+    .text start:0x02048a1c end:0x02048af4
+
+src/func_02048af4.c:
+    .text start:0x02048af4 end:0x02048c30
+
+src/func_02048c30.c:
+    .text start:0x02048c30 end:0x02048d80
+
+src/func_02048d80.c:
+    .text start:0x02048d80 end:0x02048e54
+
+src/func_02048e54.c:
+    complete
+    .text start:0x02048e54 end:0x02048e74
+
+src/func_02048e74.c:
+    complete
+    .text start:0x02048e74 end:0x02048e94
+
+src/func_02048e94.c:
+    complete
+    .text start:0x02048e94 end:0x02048eb4
+
+src/_ZN5Sound13Func_02048eb4Ev.cpp:
+    complete
+    .text start:0x02048eb4 end:0x02048ec4
+
+src/_ZN5Sound13Func_02048ec4Ev.cpp:
+    complete
+    .text start:0x02048ec4 end:0x02048ed4
+
+src/func_02048ed4.c:
+    complete
+    .text start:0x02048ed4 end:0x02048ee4
+
+src/_ZN5Sound13Func_02048ee4Ev.cpp:
+    complete
+    .text start:0x02048ee4 end:0x02048ef4
+
+src/func_02048ef4.c:
+    complete
+    .text start:0x02048ef4 end:0x02048f04
+
+src/func_02048f04.c:
+    complete
+    .text start:0x02048f04 end:0x02048f14
+
+src/func_02048f14.c:
+    complete
+    .text start:0x02048f14 end:0x02048f24
+
+src/func_02048f24.c:
+    complete
+    .text start:0x02048f24 end:0x02048f34
+
+src/func_02048f34.c:
+    complete
+    .text start:0x02048f34 end:0x02048fd4
+
+src/func_02048fd4.c:
+    complete
+    .text start:0x02048fd4 end:0x02049018
+
+src/func_02049018.c:
+    complete
+    .text start:0x02049018 end:0x020490b0
+
+src/func_020490b0.cpp:
+    complete
+    .text start:0x020490b0 end:0x0204921c
+
+src/func_0204921c.c:
+    complete
+    .text start:0x0204921c end:0x020494cc
+
+src/func_020494cc.c:
+    complete
+    .text start:0x020494cc end:0x02049764
+
+src/func_02049764.c:
+    complete
+    .text start:0x02049764 end:0x020497a0
+
+src/func_020497a0.c:
+    complete
+    .text start:0x020497a0 end:0x020499bc
+
+src/func_020499bc.c:
+    complete
+    .text start:0x020499bc end:0x02049ba8
+
+src/func_02049ba8.c:
+    complete
+    .text start:0x02049ba8 end:0x02049c48
+
+src/func_02049c48.c:
+    complete
+    .text start:0x02049c48 end:0x02049cd8
+
+src/func_02049cd8.c:
+    complete
+    .text start:0x02049cd8 end:0x02049d60
+
+src/func_02049d60.c:
+    complete
+    .text start:0x02049d60 end:0x02049d78
+
+src/func_02049d78.c:
+    complete
+    .text start:0x02049d78 end:0x02049e0c
+
+src/_ZN8Particle7Manager9AddSystemEiR7Vector3.c:
+    complete
+    .text start:0x02049e0c end:0x02049ee8
+
+src/func_02049ee8.c:
+    complete
+    .text start:0x02049ee8 end:0x02049f58
+
+src/func_02049f58.c:
+    complete
+    .text start:0x02049f58 end:0x0204a028
+
+src/func_0204a028.c:
+    complete
+    .text start:0x0204a028 end:0x0204a0dc
+
+src/func_0204a0dc.c:
+    complete
+    .text start:0x0204a0dc end:0x0204a17c
+
+src/func_0204a17c.cpp:
+    .text start:0x0204a17c end:0x0204a4c8
+
+src/func_0204a4c8.c:
+    complete
+    .text start:0x0204a4c8 end:0x0204a5bc
+
+src/func_0204a5bc.c:
+    complete
+    .text start:0x0204a5bc end:0x0204a5c8
+
+src/func_0204a5c8.c:
+    complete
+    .text start:0x0204a5c8 end:0x0204a730
+
+src/func_0204a730.c:
+    .text start:0x0204a730 end:0x0204ae2c
+
+src/func_0204ae2c.c:
+    complete
+    .text start:0x0204ae2c end:0x0204af38
+
+src/func_0204af38.c:
+    complete
+    .text start:0x0204af38 end:0x0204af3c
+
+src/func_0204af3c.c:
+    complete
+    .text start:0x0204af3c end:0x0204b028
+
+src/func_0204b028.c:
+    complete
+    .text start:0x0204b028 end:0x0204b244
+
+src/func_0204b244.c:
+    complete
+    .text start:0x0204b244 end:0x0204b460
+
+src/func_0204b460.c:
+    complete
+    .text start:0x0204b460 end:0x0204b81c
+
+src/func_0204b81c.c:
+    complete
+    .text start:0x0204b81c end:0x0204bbd8
+
+src/func_0204bbd8.c:
+    complete
+    .text start:0x0204bbd8 end:0x0204be40
+
+src/func_0204be40.c:
+    complete
+    .text start:0x0204be40 end:0x0204c0a8
+
+src/func_0204c0a8.c:
+    complete
+    .text start:0x0204c0a8 end:0x0204c0e8
+
+src/func_0204c0e8.c:
+    complete
+    .text start:0x0204c0e8 end:0x0204c194
+
+src/func_0204c194.c:
+    complete
+    .text start:0x0204c194 end:0x0204c24c
+
+src/func_0204c24c.c:
+    complete
+    .text start:0x0204c24c end:0x0204c304
+
+src/func_0204c304.c:
+    .text start:0x0204c304 end:0x0204c584
+
+src/func_0204c584.c:
+    .text start:0x0204c584 end:0x0204cd5c
+
+src/func_0204cd5c.c:
+    complete
+    .text start:0x0204cd5c end:0x0204cebc
+
+src/func_0204cebc.c:
+    complete
+    .text start:0x0204cebc end:0x0204d0b8
+
+src/func_0204d0b8.c:
+    complete
+    .text start:0x0204d0b8 end:0x0204d104
+
+src/func_0204d104.c:
+    complete
+    .text start:0x0204d104 end:0x0204d150
+
+src/func_0204d150.c:
+    complete
+    .text start:0x0204d150 end:0x0204d1b4
+
+src/func_0204d1b4.c:
+    complete
+    .text start:0x0204d1b4 end:0x0204d294
+
+src/func_0204d294.c:
+    .text start:0x0204d294 end:0x0204d440
+
+src/func_0204d440.c:
+    complete
+    .text start:0x0204d440 end:0x0204d4d0
+
+src/_ZN8Particle14RadiusConverge4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
+    .text start:0x0204d4d0 end:0x0204d57c
+
+src/_ZN8Particle10LimitPlane4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
+    .text start:0x0204d57c end:0x0204d680
+
+src/_ZN8Particle4Turn4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
+    .text start:0x0204d680 end:0x0204d758
+
+src/_ZN8Particle8Converge4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
+    .text start:0x0204d758 end:0x0204d7ec
+
+src/_ZN8Particle6Jitter4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    .text start:0x0204d7ec end:0x0204d8b0
+
+src/_ZN8Particle12Acceleration4FuncERNS_10EffectDataEPcR7Vector3.cpp:
+    complete
+    .text start:0x0204d8b0 end:0x0204d8e8
+
+src/func_0204d8e8.c:
+    complete
+    .text start:0x0204d8e8 end:0x0204d958
+
+src/func_0204d958.c:
+    complete
+    .text start:0x0204d958 end:0x0204d9a0
+
+src/func_0204d9a0.c:
+    complete
+    .text start:0x0204d9a0 end:0x0204d9f0
+
+src/func_0204d9f0.c:
+    complete
+    .text start:0x0204d9f0 end:0x0204da4c
+
+src/func_0204da4c.c:
+    .text start:0x0204da4c end:0x0204dab4
+
+src/func_0204dab4.c:
+    .text start:0x0204dab4 end:0x0204dc84
+
+src/func_0204dc84.c:
+    complete
+    .text start:0x0204dc84 end:0x0204dcc0
+
+src/func_0204dcc0.c:
+    complete
+    .text start:0x0204dcc0 end:0x0204dcfc
+
+src/_ZN18NestedHeapIterator8PreviousEP13HeapAllocator.cpp:
+    complete
+    .text start:0x0204dcfc end:0x0204dd10
+
+src/_ZN18NestedHeapIterator4NextEP13HeapAllocator.cpp:
+    complete
+    .text start:0x0204dd10 end:0x0204dd28
+
+src/_ZN18NestedHeapIterator6RemoveEP13HeapAllocator.cpp:
+    complete
+    .text start:0x0204dd28 end:0x0204dd98
+
+src/_ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_.c:
+    complete
+    .text start:0x0204dd98 end:0x0204de0c
+
+src/_ZN18NestedHeapIterator8AddFirstEP13HeapAllocator.cpp:
+    .text start:0x0204de0c end:0x0204de74
+
+src/_ZN18NestedHeapIterator7AddLastEP13HeapAllocator.cpp:
+    .text start:0x0204de74 end:0x0204dee0
+
+src/_ZN18NestedHeapIterator4InitEP13HeapAllocator.cpp:
+    complete
+    .text start:0x0204dee0 end:0x0204df20
+
+src/_ZN18NestedHeapIteratorC1Ej.c:
+    complete
+    .text start:0x0204df20 end:0x0204df38
+
+src/_ZN13HeapAllocator6RemoveEv.cpp:
+    .text start:0x0204df38 end:0x0204df54
+
+src/_ZN13HeapAllocatorC1EjPvPvj.cpp:
+    .text start:0x0204df54 end:0x0204dfe8
+
+src/_ZN18NestedHeapIterator10FindNestedEPv.c:
+    complete
+    .text start:0x0204dfe8 end:0x0204e014
+
+src/_ZN18NestedHeapIterator19RecursiveFindNestedEPv.c:
+    complete
+    .text start:0x0204e014 end:0x0204e084
+
+src/_ZN22ExpandingHeapAllocator14SizeofInternalEPv.c:
+    complete
+    .text start:0x0204e084 end:0x0204e08c
+
+src/_ZN22ExpandingHeapAllocator13DeallocateAllEPPFvPvPS_jEj.cpp:
+    complete
+    .text start:0x0204e08c end:0x0204e0e0
+
+src/_ZN22ExpandingHeapAllocator9GetNodeIDEv.c:
+    complete
+    .text start:0x0204e0e0 end:0x0204e0e8
+
+src/_ZN22ExpandingHeapAllocator9SetNodeIDEj.cpp:
+    complete
+    .text start:0x0204e0e8 end:0x0204e0f8
+
+src/_ZN22ExpandingHeapAllocator18MaxAllocatableSizeEi.cpp:
+    complete
+    .text start:0x0204e0f8 end:0x0204e180
+
+src/_ZN22ExpandingHeapAllocator10MemoryLeftEv.cpp:
+    complete
+    .text start:0x0204e180 end:0x0204e1a8
+
+src/_ZN22ExpandingHeapAllocator10DeallocateEPv.c:
+    complete
+    .text start:0x0204e1a8 end:0x0204e1e8
+
+src/_ZN22ExpandingHeapAllocator10ReallocateEPvj.cpp:
+    complete
+    .text start:0x0204e1e8 end:0x0204e370
+
+src/_ZN22ExpandingHeapAllocator8AllocateEji.c:
+    complete
+    .text start:0x0204e370 end:0x0204e3b4
+
+src/_ZN13HeapAllocator7DestroyEv.cpp:
+    complete
+    .text start:0x0204e3b4 end:0x0204e3c0
+
+src/_ZN4Heap28CreateExpandingHeapAllocatorEPvjj.c:
+    complete
+    .text start:0x0204e3c0 end:0x0204e40c
+
+src/_ZN22ExpandingHeapAllocator8FreeNodeEP10MemoryNodePNS0_6TargetE.cpp:
+    complete
+    .text start:0x0204e40c end:0x0204e504
+
+src/_ZN22ExpandingHeapAllocator17AllocateBackwardsEjj.cpp:
+    complete
+    .text start:0x0204e504 end:0x0204e5c8
+
+src/_ZN22ExpandingHeapAllocator16AllocateForwardsEjj.cpp:
+    complete
+    .text start:0x0204e5c8 end:0x0204e690
+
+src/_ZN22ExpandingHeapAllocator12AllocateNodeEP10MemoryNodeS1_Pvjj.cpp:
+    complete
+    .text start:0x0204e690 end:0x0204e828
+
+src/_ZN22ExpandingHeapAllocatorC1EPvj.c:
+    complete
+    .text start:0x0204e828 end:0x0204e8b0
+
+src/_ZN22ExpandingHeapAllocator10CreateNodeEPN10MemoryNode6TargetEt.cpp:
+    complete
+    .text start:0x0204e8b0 end:0x0204e8e0
+
+src/_ZN22ExpandingHeapAllocator8LinkNodeEP10MemoryNodeS1_S1_.cpp:
+    complete
+    .text start:0x0204e8e0 end:0x0204e910
+
+src/_ZN22ExpandingHeapAllocator10UnlinkNodeEP10MemoryNodeS1_.cpp:
+    complete
+    .text start:0x0204e910 end:0x0204e938
+
+src/_ZN10MemoryNode6TargetC1EP10MemoryNode.cpp:
+    complete
+    .text start:0x0204e938 end:0x0204e964
+
+src/_ZN18SolidHeapAllocator10ReallocateEPvj.c:
+    complete
+    .text start:0x0204e964 end:0x0204ea08
+
+src/_ZN18SolidHeapAllocator14TryResizeToFitEv.c:
+    complete
+    .text start:0x0204ea08 end:0x0204ea3c
+
+src/_ZN18SolidHeapAllocator9LoadStateEj.c:
+    complete
+    .text start:0x0204ea3c end:0x0204ea98
+
+src/_ZN18SolidHeapAllocator9SaveStateEj.c:
+    complete
+    .text start:0x0204ea98 end:0x0204eaf0
+
+src/_ZN18SolidHeapAllocator10MemoryLeftEi.c:
+    complete
+    .text start:0x0204eaf0 end:0x0204eb30
+
+src/_ZN18SolidHeapAllocator5ResetEj.c:
+    complete
+    .text start:0x0204eb30 end:0x0204eb70
+
+src/_ZN18SolidHeapAllocator8AllocateEji.c:
+    complete
+    .text start:0x0204eb70 end:0x0204ebb8
+
+src/func_0204ebb8.c:
+    complete
+    .text start:0x0204ebb8 end:0x0204ebc4
+
+src/_ZN4Heap24CreateSolidHeapAllocatorEPvjj.c:
+    complete
+    .text start:0x0204ebc4 end:0x0204ec10
+
+src/_ZN18SolidHeapAllocator8ResetEndEv.c:
+    complete
+    .text start:0x0204ec10 end:0x0204ec40
+
+src/_ZN18SolidHeapAllocator10ResetStartEv.c:
+    complete
+    .text start:0x0204ec40 end:0x0204ec58
+
+src/_ZN18SolidHeapAllocator17AllocateBackwardsEPvjj.c:
+    complete
+    .text start:0x0204ec58 end:0x0204ecd4
+
+src/_ZN18SolidHeapAllocator16AllocateForwardsEPvjj.c:
+    complete
+    .text start:0x0204ecd4 end:0x0204ed54
+
+src/_ZN18SolidHeapAllocatorC1EPvj.c:
+    complete
+    .text start:0x0204ed54 end:0x0204eda4
+
+src/func_0204eda4.c:
+    complete
+    .text start:0x0204eda4 end:0x0204ede8
+
+src/func_0204ede8.c:
+    complete
+    .text start:0x0204ede8 end:0x0204ee10
+
+src/func_0204ee10.c:
+    complete
+    .text start:0x0204ee10 end:0x0204ee40
+
+src/func_0204ee40.c:
+    complete
+    .text start:0x0204ee40 end:0x0204ef9c
+
+src/func_0204ef9c.c:
+    complete
+    .text start:0x0204ef9c end:0x0204efe0
+
+src/func_0204efe0.c:
+    complete
+    .text start:0x0204efe0 end:0x0204effc
+
+src/func_0204effc.c:
+    complete
+    .text start:0x0204effc end:0x0204f03c
+
+src/func_0204f03c.c:
+    complete
+    .text start:0x0204f03c end:0x0204f070
+
+src/func_0204f070.c:
+    complete
+    .text start:0x0204f070 end:0x0204f0b8
+
+src/func_0204f0b8.c:
+    complete
+    .text start:0x0204f0b8 end:0x0204f0d8
+
+src/func_0204f0d8.c:
+    complete
+    .text start:0x0204f0d8 end:0x0204f11c
+
+src/func_0204f11c.c:
+    complete
+    .text start:0x0204f11c end:0x0204f138
+
+src/func_0204f138.c:
+    complete
+    .text start:0x0204f138 end:0x0204f15c
+
+src/func_0204f15c.c:
+    complete
+    .text start:0x0204f15c end:0x0204f194
+
+src/func_0204f194.c:
+    complete
+    .text start:0x0204f194 end:0x0204f1e8
+
+src/func_0204f1e8.c:
+    complete
+    .text start:0x0204f1e8 end:0x0204f214
+
+src/func_0204f214.cpp:
+    complete
+    .text start:0x0204f214 end:0x0204f278
+
+src/func_0204f278.cpp:
+    complete
+    .text start:0x0204f278 end:0x0204f2d4
+
+src/func_0204f2d4.c:
+    complete
+    .text start:0x0204f2d4 end:0x0204f364
+
+src/func_0204f364.c:
+    complete
+    .text start:0x0204f364 end:0x0204f3e0
+
+src/func_0204f3e0.c:
+    complete
+    .text start:0x0204f3e0 end:0x0204f400
+
+src/func_0204f400.c:
+    complete
+    .text start:0x0204f400 end:0x0204f460
+
+src/func_0204f460.c:
+    complete
+    .text start:0x0204f460 end:0x0204f4bc
+
+src/func_0204f4bc.c:
+    complete
+    .text start:0x0204f4bc end:0x0204f504
+
+src/func_0204f504.c:
+    complete
+    .text start:0x0204f504 end:0x0204f558
+
+src/func_0204f558.c:
+    complete
+    .text start:0x0204f558 end:0x0204f5a0
+
+src/func_0204f5a0.c:
+    complete
+    .text start:0x0204f5a0 end:0x0204f600
+
+src/func_0204f600.c:
+    complete
+    .text start:0x0204f600 end:0x0204f630
+
+src/func_0204f630.c:
+    complete
+    .text start:0x0204f630 end:0x0204f63c
+
+src/func_0204f63c.cpp:
+    complete
+    .text start:0x0204f63c end:0x0204f6f8
+
+src/func_0204f6f8.c:
+    complete
+    .text start:0x0204f6f8 end:0x0204f720
+
+src/func_0204f720.c:
+    complete
+    .text start:0x0204f720 end:0x0204f73c
+
+src/func_0204f73c.c:
+    complete
+    .text start:0x0204f73c end:0x0204f76c
+
+src/func_0204f76c.c:
+    complete
+    .text start:0x0204f76c end:0x0204f79c
+
+src/func_0204f79c.c:
+    complete
+    .text start:0x0204f79c end:0x0204f7cc
+
+src/func_0204f7cc.c:
+    complete
+    .text start:0x0204f7cc end:0x0204f7fc
+
+src/func_0204f7fc.c:
+    complete
+    .text start:0x0204f7fc end:0x0204f82c
+
+src/func_0204f82c.c:
+    complete
+    .text start:0x0204f82c end:0x0204f86c
+
+src/func_0204f86c.c:
+    complete
+    .text start:0x0204f86c end:0x0204f89c
+
+src/func_0204f89c.c:
+    complete
+    .text start:0x0204f89c end:0x0204f8cc
+
+src/func_0204f8cc.c:
+    complete
+    .text start:0x0204f8cc end:0x0204f914
+
+src/func_0204f914.c:
+    complete
+    .text start:0x0204f914 end:0x0204f924
+
+src/func_0204f924.c:
+    complete
+    .text start:0x0204f924 end:0x0204f934
+
+src/func_0204f934.c:
+    complete
+    .text start:0x0204f934 end:0x0204f94c
+
+src/func_0204f94c.c:
+    complete
+    .text start:0x0204f94c end:0x0204f958
+
+src/func_0204f958.c:
+    complete
+    .text start:0x0204f958 end:0x0204f9c4
+
+src/func_0204f9c4.c:
+    complete
+    .text start:0x0204f9c4 end:0x0204fa2c
+
+src/func_0204fa2c.c:
+    complete
+    .text start:0x0204fa2c end:0x0204fa3c
+
+src/func_0204fa3c.c:
+    complete
+    .text start:0x0204fa3c end:0x0204fadc
+
+src/_ZN5Sound6Player19SetPlayableSeqCountEii.c:
+    complete
+    .text start:0x0204fadc end:0x0204fafc
+
+src/func_0204fafc.c:
+    complete
+    .text start:0x0204fafc end:0x0204fc40
+
+src/func_0204fc40.c:
+    complete
+    .text start:0x0204fc40 end:0x0204fce8
+
+src/func_0204fce8.c:
+    complete
+    .text start:0x0204fce8 end:0x0204fda4
+
+src/func_0204fda4.cpp:
+    complete
+    .text start:0x0204fda4 end:0x0204fde8
+
+src/func_0204fde8.c:
+    complete
+    .text start:0x0204fde8 end:0x0204fe5c
+
+src/func_0204fe5c.c:
+    complete
+    .text start:0x0204fe5c end:0x0204fed0
+
+src/func_0204fed0.cpp:
+    complete
+    .text start:0x0204fed0 end:0x0204ff48
+
+src/func_0204ff48.c:
+    complete
+    .text start:0x0204ff48 end:0x0204ff9c
+
+src/func_0204ff9c.c:
+    complete
+    .text start:0x0204ff9c end:0x0204ffcc
+
+src/func_0204ffcc.c:
+    complete
+    .text start:0x0204ffcc end:0x02050008
+
+src/func_02050008.c:
+    complete
+    .text start:0x02050008 end:0x02050038
+
+src/func_02050038.c:
+    complete
+    .text start:0x02050038 end:0x020500a4
+
+src/func_020500a4.c:
+    .text start:0x020500a4 end:0x020501b8
+
+src/func_020501b8.c:
+    complete
+    .text start:0x020501b8 end:0x02050258
+
+src/func_02050258.c:
+    complete
+    .text start:0x02050258 end:0x020502b8
+
+src/func_020502b8.c:
+    complete
+    .text start:0x020502b8 end:0x020503a4
+
+src/func_020503a4.c:
+    .text start:0x020503a4 end:0x020506fc
+
+src/func_020506fc.c:
+    complete
+    .text start:0x020506fc end:0x02050798
+
+src/func_02050798.c:
+    complete
+    .text start:0x02050798 end:0x020507e0
+
+src/func_020507e0.c:
+    complete
+    .text start:0x020507e0 end:0x020508a0
+
+src/func_020508a0.c:
+    complete
+    .text start:0x020508a0 end:0x02050950
+
+src/func_02050950.c:
+    complete
+    .text start:0x02050950 end:0x02050970
+
+src/func_02050970.c:
+    complete
+    .text start:0x02050970 end:0x0205097c
+
+src/func_0205097c.c:
+    complete
+    .text start:0x0205097c end:0x02050988
+
+src/func_02050988.c:
+    complete
+    .text start:0x02050988 end:0x02050994
+
+src/func_02050994.c:
+    complete
+    .text start:0x02050994 end:0x020509b0
+
+src/func_020509b0.c:
+    complete
+    .text start:0x020509b0 end:0x020509d8
+
+src/func_020509d8.c:
+    complete
+    .text start:0x020509d8 end:0x02050a5c
+
+src/func_02050a5c.c:
+    complete
+    .text start:0x02050a5c end:0x02050a84
+
+src/func_02050a84.cpp:
+    complete
+    .text start:0x02050a84 end:0x02050ae8
+
+src/func_02050ae8.cpp:
+    complete
+    .text start:0x02050ae8 end:0x02050b4c
+
+src/func_02050b4c.cpp:
+    complete
+    .text start:0x02050b4c end:0x02050bb0
+
+src/_ZN5Sound23InfoInstrumentBankEntry9GetWithIDEj.cpp:
+    complete
+    .text start:0x02050bb0 end:0x02050c14
+
+src/func_02050c14.cpp:
+    complete
+    .text start:0x02050c14 end:0x02050c78
+
+src/_ZN5Sound17InfoSequenceEntry9GetWithIDEj.cpp:
+    complete
+    .text start:0x02050c78 end:0x02050cdc
+
+src/func_02050cdc.c:
+    complete
+    .text start:0x02050cdc end:0x02050d2c
+
+src/func_02050d2c.c:
+    complete
+    .text start:0x02050d2c end:0x02050d3c
+
+src/func_02050d3c.c:
+    complete
+    .text start:0x02050d3c end:0x02050d54
+
+src/func_02050d54.c:
+    complete
+    .text start:0x02050d54 end:0x02050f34
+
+src/func_02050f34.c:
+    complete
+    .text start:0x02050f34 end:0x02050fb0
+
+src/func_02050fb0.c:
+    complete
+    .text start:0x02050fb0 end:0x02050fd4
+
+src/func_02050fd4.c:
+    complete
+    .text start:0x02050fd4 end:0x02051024
+
+src/func_02051024.c:
+    complete
+    .text start:0x02051024 end:0x02051064
+
+src/func_02051064.c:
+    .text start:0x02051064 end:0x02051074
+
+src/func_02051074.c:
+    complete
+    .text start:0x02051074 end:0x020510a4
+
+src/func_020510a4.c:
+    complete
+    .text start:0x020510a4 end:0x0205117c
+
+src/func_0205117c.c:
+    complete
+    .text start:0x0205117c end:0x020511d4
+
+src/func_020511d4.c:
+    complete
+    .text start:0x020511d4 end:0x02051244
+
+src/func_02051244.c:
+    complete
+    .text start:0x02051244 end:0x020512f0
+
+src/func_020512f0.c:
+    complete
+    .text start:0x020512f0 end:0x0205130c
+
+src/func_0205130c.c:
+    complete
+    .text start:0x0205130c end:0x020513a8
+
+src/func_020513a8.c:
+    complete
+    .text start:0x020513a8 end:0x020513e4
+
+src/func_020513e4.c:
+    complete
+    .text start:0x020513e4 end:0x02051420
+
+src/func_02051420.c:
+    complete
+    .text start:0x02051420 end:0x02051454
+
+src/func_02051454.c:
+    complete
+    .text start:0x02051454 end:0x020514b4
+
+src/func_020514b4.c:
+    complete
+    .text start:0x020514b4 end:0x02051514
+
+src/func_02051514.c:
+    complete
+    .text start:0x02051514 end:0x02051574
+
+src/func_02051574.c:
+    complete
+    .text start:0x02051574 end:0x020515d4
+
+src/func_020515d4.c:
+    complete
+    .text start:0x020515d4 end:0x02051634
+
+src/func_02051634.c:
+    complete
+    .text start:0x02051634 end:0x020516d4
+
+src/func_020516d4.c:
+    complete
+    .text start:0x020516d4 end:0x0205179c
+
+src/func_0205179c.c:
+    complete
+    .text start:0x0205179c end:0x020518a0
+
+src/func_020518a0.c:
+    complete
+    .text start:0x020518a0 end:0x020518dc
+
+src/func_020518dc.c:
+    complete
+    .text start:0x020518dc end:0x02051918
+
+src/func_02051918.c:
+    complete
+    .text start:0x02051918 end:0x02051a28
+
+src/func_02051a28.c:
+    complete
+    .text start:0x02051a28 end:0x02051a48
+
+src/func_02051a48.c:
+    complete
+    .text start:0x02051a48 end:0x02051a68
+
+src/func_02051a68.c:
+    complete
+    .text start:0x02051a68 end:0x02051a88
+
+src/func_02051a88.c:
+    complete
+    .text start:0x02051a88 end:0x02051a98
+
+src/func_02051a98.c:
+    complete
+    .text start:0x02051a98 end:0x02051bd0
+
+src/func_02051bd0.c:
+    complete
+    .text start:0x02051bd0 end:0x02051e60
+
+src/func_02051e60.c:
+    complete
+    .text start:0x02051e60 end:0x02051f1c
+
+src/func_02051f1c.c:
+    complete
+    .text start:0x02051f1c end:0x02051fb4
+
+src/func_02051fb4.cpp:
+    complete
+    .text start:0x02051fb4 end:0x02052008
+
+src/func_02052008.c:
+    complete
+    .text start:0x02052008 end:0x020520a4
+
+src/func_020520a4.c:
+    complete
+    .text start:0x020520a4 end:0x020520dc
+
+src/func_020520dc.c:
+    complete
+    .text start:0x020520dc end:0x0205212c
+
+src/func_0205212c.cpp:
+    complete
+    .text start:0x0205212c end:0x02052208
+
+src/func_02052208.c:
+    complete
+    .text start:0x02052208 end:0x02052234
+
+src/func_02052234.c:
+    complete
+    .text start:0x02052234 end:0x0205227c
+
+src/func_0205227c.c:
+    complete
+    .text start:0x0205227c end:0x020522c4
+
+src/func_020522c4.c:
+    complete
+    .text start:0x020522c4 end:0x020523e0
+
+src/func_020523e0.c:
+    complete
+    .text start:0x020523e0 end:0x02052420
+
+src/func_02052420.c:
+    complete
+    .text start:0x02052420 end:0x02052438
+
+src/func_02052438.c:
+    complete
+    .text start:0x02052438 end:0x02052458
+
+src/func_02052458.c:
+    .text start:0x02052458 end:0x02052494
+
+src/func_02052494.c:
+    complete
+    .text start:0x02052494 end:0x020524c4
+
+src/func_020524c4.c:
+    complete
+    .text start:0x020524c4 end:0x020524e4
+
+src/Matrix3x3_LoadIdentity.c:
+    complete
+    .text start:0x020524f0 end:0x02052514
+
+src/MulVec3Mat3x3.c:
+    complete
+    .text start:0x020525a0 end:0x02052624
+
+src/MulMat3x3Mat3x3.c:
+    complete
+    .text start:0x02052624 end:0x020527c0
+
+src/Matrix4x3_LoadIdentity.c:
+    complete
+    .text start:0x020527c0 end:0x020527e8
+
+src/MulVec3Mat4x3.c:
+    complete
+    .text start:0x02052858 end:0x02052914
+
+src/MulMat4x3Mat4x3.c:
+    complete
+    .text start:0x02052914 end:0x02052b34
+
+src/InvMat4x3.c:
+    complete
+    .text start:0x02052b34 end:0x02052ec8
+
+src/_ZN4cstd3modEii.c:
+    complete
+    .text start:0x02052ef4 end:0x02052f4c
+
+src/_ZN4cstd3divEii.c:
+    complete
+    .text start:0x02052f4c end:0x02052fa4
+
+src/_ZN4cstd10fdiv_asyncE5Fix12IiE5Fix12IiE.c:
+    complete
+    .text start:0x02052fa4 end:0x02052fdc
+
+src/func_02052fdc.c:
+    complete
+    .text start:0x02052fdc end:0x02053008
+
+src/func_02053008.c:
+    complete
+    .text start:0x02053008 end:0x02053090
+
+src/_ZN4cstd16reciprocal_asyncE5Fix12IiE.c:
+    complete
+    .text start:0x02053090 end:0x020530cc
+
+src/_ZN4cstd11fdiv_resultEv.c:
+    complete
+    .text start:0x020530cc end:0x02053108
+
+src/_ZN4cstd11ldiv_resultEv.c:
+    complete
+    .text start:0x02053108 end:0x02053130
+
+src/func_02053130.c:
+    .text start:0x02053130 end:0x020531a4
+
+src/func_020531a4.c:
+    complete
+    .text start:0x020531a4 end:0x02053200
+
+src/func_02053200.c:
+    complete
+    .text start:0x02053200 end:0x0205321c
+
+src/_ZN4cstd4ldivEii.c:
+    complete
+    .text start:0x0205321c end:0x02053258
+
+src/_ZN4cstd4fdivEii.c:
+    complete
+    .text start:0x02053258 end:0x02053274
+
+src/func_02053274.c:
+    complete
+    .text start:0x02053274 end:0x02053320
+
+src/func_02053320.c:
+    complete
+    .text start:0x02053320 end:0x02053380
+
+src/func_02053380.c:
+    complete
+    .text start:0x02053380 end:0x020534ec
+
+src/NormalizeVec3.c:
+    complete
+    .text start:0x020534ec end:0x02053644
+
+src/func_02053644.c:
+    complete
+    .text start:0x02053644 end:0x020536e4
+
+src/LenVec3.c:
+    complete
+    .text start:0x020536e4 end:0x02053770
+
+src/CrossVec3.c:
+    complete
+    .text start:0x02053770 end:0x0205380c
+
+src/DotVec3.c:
+    complete
+    .text start:0x0205380c end:0x02053850
+
+src/SubVec3.c:
+    complete
+    .text start:0x02053850 end:0x02053884
+
+src/AddVec3.c:
+    complete
+    .text start:0x02053884 end:0x020538b8
+
+src/func_020538b8.c:
+    complete
+    .text start:0x020538b8 end:0x02053a8c
+
+src/func_02053a8c.c:
+    complete
+    .text start:0x02053a8c end:0x02053a90
+
+src/func_02053a90.c:
+    complete
+    .text start:0x02053a90 end:0x02053abc
+
+src/_ZN3GXS15SetGraphicsModeEi.cpp:
+    complete
+    .text start:0x02053abc end:0x02053ad8
+
+src/_ZN2GX15SetGraphicsModeEiii.c:
+    complete
+    .text start:0x02053ad8 end:0x02053b4c
+
+src/_ZN2GX6DispOnEv.c:
+    complete
+    .text start:0x02053b4c end:0x02053b98
+
+src/func_02053b98.c:
+    complete
+    .text start:0x02053b98 end:0x02053be0
+
+src/func_02053be0.c:
+    complete
+    .text start:0x02053be0 end:0x02053c10
+
+src/func_02053c10.c:
+    complete
+    .text start:0x02053c10 end:0x02053c40
+
+src/func_02053c40.c:
+    complete
+    .text start:0x02053c40 end:0x02053d9c
+
+src/func_02053d9c.c:
+    complete
+    .text start:0x02053d9c end:0x02053e1c
+
+src/func_02053e1c.c:
+    complete
+    .text start:0x02053e1c end:0x02053e34
+
+src/func_02053e34.c:
+    complete
+    .text start:0x02053e34 end:0x02053e4c
+
+src/func_02053e4c.c:
+    complete
+    .text start:0x02053e4c end:0x02053ea0
+
+src/func_02053ea0.c:
+    complete
+    .text start:0x02053ea0 end:0x02053eb0
+
+src/func_02053eb0.c:
+    complete
+    .text start:0x02053eb0 end:0x02053ec0
+
+src/func_02053ec0.c:
+    complete
+    .text start:0x02053ec0 end:0x02053ed0
+
+src/func_02053ed0.c:
+    complete
+    .text start:0x02053ed0 end:0x02053ee0
+
+src/func_02053ee0.c:
+    complete
+    .text start:0x02053ee0 end:0x02053f08
+
+src/func_02053f08.c:
+    complete
+    .text start:0x02053f08 end:0x02053f30
+
+src/func_02053f30.c:
+    complete
+    .text start:0x02053f30 end:0x02053f44
+
+src/func_02053f44.c:
+    complete
+    .text start:0x02053f44 end:0x02053f58
+
+src/func_02053f58.c:
+    complete
+    .text start:0x02053f58 end:0x02053f6c
+
+src/func_02053f6c.c:
+    complete
+    .text start:0x02053f6c end:0x02053f80
+
+src/func_02053f80.c:
+    complete
+    .text start:0x02053f80 end:0x02053f94
+
+src/func_02053f94.c:
+    complete
+    .text start:0x02053f94 end:0x02053fa8
+
+src/func_02053fa8.c:
+    complete
+    .text start:0x02053fa8 end:0x02053fbc
+
+src/func_02053fbc.c:
+    complete
+    .text start:0x02053fbc end:0x02053fe0
+
+src/func_02053fe0.c:
+    complete
+    .text start:0x02053fe0 end:0x02054004
+
+src/func_02054004.c:
+    complete
+    .text start:0x02054004 end:0x02054018
+
+src/func_02054018.c:
+    complete
+    .text start:0x02054018 end:0x0205402c
+
+src/DisableVramBanks.c:
+    complete
+    .text start:0x0205402c end:0x020540f0
+
+src/func_020540f0.c:
+    complete
+    .text start:0x020540f0 end:0x02054118
+
+src/func_02054118.c:
+    complete
+    .text start:0x02054118 end:0x02054140
+
+src/func_02054140.c:
+    complete
+    .text start:0x02054140 end:0x02054154
+
+src/func_02054154.c:
+    complete
+    .text start:0x02054154 end:0x02054168
+
+src/func_02054168.c:
+    complete
+    .text start:0x02054168 end:0x0205417c
+
+src/func_0205417c.c:
+    complete
+    .text start:0x0205417c end:0x02054190
+
+src/func_02054190.c:
+    complete
+    .text start:0x02054190 end:0x020541a4
+
+src/func_020541a4.c:
+    complete
+    .text start:0x020541a4 end:0x020541b8
+
+src/func_020541b8.c:
+    complete
+    .text start:0x020541b8 end:0x020541f0
+
+src/_ZN2GX23SetBankForSubOBJExtPlttEt.c:
+    complete
+    .text start:0x020541f0 end:0x0205427c
+
+src/_ZN2GX22SetBankForSubBGExtPlttEt.c:
+    complete
+    .text start:0x0205427c end:0x02054308
+
+src/_ZN2GX16SetBankForSubOBJEt.c:
+    complete
+    .text start:0x02054308 end:0x02054384
+
+src/_ZN2GX15SetBankForSubBGEt.c:
+    complete
+    .text start:0x02054384 end:0x02054430
+
+src/func_02054430.c:
+    .text start:0x02054430 end:0x02054450
+
+src/_ZN2GX17SetBankForTexPlttEt.c:
+    complete
+    .text start:0x02054450 end:0x02054544
+
+src/_ZN2GX13SetBankForTexEt.cpp:
+    complete
+    .text start:0x02054544 end:0x02054748
+
+src/func_02054748.c:
+    complete
+    .text start:0x02054748 end:0x0205485c
+
+src/_ZN2GX13SetBankForOBJEt.cpp:
+    complete
+    .text start:0x0205485c end:0x020549c8
+
+src/_ZN2GX12SetBankForBGEt.cpp:
+    complete
+    .text start:0x020549c8 end:0x02054c80
+
+src/Vram__Map.c:
+    complete
+    .text start:0x02054c80 end:0x02054d38
+
+src/_ZN3G2S13GetBG3CharPtrEv.c:
+    complete
+    .text start:0x02054d38 end:0x02054d88
+
+src/func_02054d88.c:
+    complete
+    .text start:0x02054d88 end:0x02054de8
+
+src/_ZN3G2S13GetBG2CharPtrEv.c:
+    complete
+    .text start:0x02054de8 end:0x02054e30
+
+src/_ZN2G213GetBG2CharPtrEv.c:
+    complete
+    .text start:0x02054e30 end:0x02054e88
+
+src/_ZN3G2S13GetBG1CharPtrEv.c:
+    complete
+    .text start:0x02054e88 end:0x02054ea8
+
+src/func_02054ea8.c:
+    complete
+    .text start:0x02054ea8 end:0x02054edc
+
+src/_ZN3G2S13GetBG0CharPtrEv.c:
+    complete
+    .text start:0x02054edc end:0x02054efc
+
+src/func_02054efc.c:
+    complete
+    .text start:0x02054efc end:0x02054f30
+
+src/_ZN3G2S12GetBG3ScrPtrEv.c:
+    complete
+    .text start:0x02054f30 end:0x02054fb0
+
+src/_ZN2G212GetBG3ScrPtrEv.cpp:
+    complete
+    .text start:0x02054fb0 end:0x0205503c
+
+src/_ZN3G2S12GetBG2ScrPtrEv.c:
+    complete
+    .text start:0x0205503c end:0x020550bc
+
+src/_ZN2G212GetBG2ScrPtrEv.c:
+    complete
+    .text start:0x020550bc end:0x02055148
+
+src/_ZN3G2S12GetBG1ScrPtrEv.c:
+    complete
+    .text start:0x02055148 end:0x02055168
+
+src/_ZN2G212GetBG1ScrPtrEv.c:
+    complete
+    .text start:0x02055168 end:0x0205519c
+
+src/_ZN3G2S12GetBG0ScrPtrEv.c:
+    complete
+    .text start:0x0205519c end:0x020551bc
+
+src/_ZN2G212GetBG0ScrPtrEv.c:
+    complete
+    .text start:0x020551bc end:0x020551f0
+
+src/func_020551f0.c:
+    complete
+    .text start:0x020551f0 end:0x02055238
+
+src/_ZN3G2x18SetBlendBrightnessEPVtts.cpp:
+    complete
+    .text start:0x02055238 end:0x0205525c
+
+src/_ZN3G2x13SetBlendAlphaEPVttttt.cpp:
+    complete
+    .text start:0x0205525c end:0x02055278
+
+src/_ZN3G2x12SetBGyAffineEPVtP9Matrix2x2iiii.cpp:
+    complete
+    .text start:0x02055278 end:0x0205532c
+
+src/func_0205532c.c:
+    complete
+    .text start:0x0205532c end:0x0205536c
+
+src/Geometry_MatrixMultiply3x3.c:
+    complete
+    .text start:0x0205536c end:0x02055388
+
+src/func_02055388.c:
+    complete
+    .text start:0x02055388 end:0x020553a4
+
+src/func_020553a4.c:
+    complete
+    .text start:0x020553a4 end:0x020553c0
+
+src/func_02055454.c:
+    .text start:0x02055454 end:0x02055464
+
+src/func_02055464.c:
+    complete
+    .text start:0x02055464 end:0x02055490
+
+src/func_02055490.c:
+    complete
+    .text start:0x02055490 end:0x020554bc
+
+src/func_020554bc.c:
+    complete
+    .text start:0x020554bc end:0x02055574
+
+src/_ZN3G3X13SetClearColorEtiiib.cpp:
+    complete
+    .text start:0x02055574 end:0x020555a4
+
+src/func_020555a4.c:
+    complete
+    .text start:0x020555a4 end:0x020555bc
+
+src/_ZN3G3X11SetFogTableEPv.cpp:
+    complete
+    .text start:0x020555bc end:0x020555d0
+
+src/_ZN3G3X6SetFogEbiii.cpp:
+    complete
+    .text start:0x020555d0 end:0x02055624
+
+src/func_02055624.c:
+    complete
+    .text start:0x02055624 end:0x020556d0
+
+src/func_020556d0.c:
+    complete
+    .text start:0x020556d0 end:0x02055780
+
+src/func_02055780.c:
+    complete
+    .text start:0x02055780 end:0x020557b4
+
+src/func_020557b4.c:
+    complete
+    .text start:0x020557b4 end:0x0205583c
+
+src/func_0205583c.c:
+    complete
+    .text start:0x0205583c end:0x02055998
+
+src/func_02055998.c:
+    complete
+    .text start:0x02055998 end:0x02055a64
+
+src/_ZN3G3i7LookAt_EPK7Vector3S2_S2_bP9Matrix4x3.cpp:
+    complete
+    .text start:0x02055a64 end:0x02055bfc
+
+src/_ZN3G3i13PerspectiveW_E5Fix12IiES1_S1_S1_S1_S1_bP9Matrix4x3.c:
+    .text start:0x02055bfc end:0x02055dec
+
+src/_ZN3GXS17EndLoadOBJExtPlttEv.c:
+    complete
+    .text start:0x02055dec end:0x02055e38
+
+src/_ZN3GXS14LoadOBJExtPlttEPKvjj.c:
+    complete
+    .text start:0x02055e38 end:0x02055eac
+
+src/_ZN3GXS19BeginLoadOBJExtPlttEv.cpp:
+    complete
+    .text start:0x02055eac end:0x02055ed0
+
+src/_ZN3GXS16EndLoadBGExtPlttEv.c:
+    complete
+    .text start:0x02055ed0 end:0x02055f1c
+
+src/_ZN3GXS13LoadBGExtPlttEPKvjj.c:
+    complete
+    .text start:0x02055f1c end:0x02055f90
+
+src/_ZN3GXS18BeginLoadBGExtPlttEv.cpp:
+    complete
+    .text start:0x02055f90 end:0x02055fb4
+
+src/func_02055fb4.c:
+    complete
+    .text start:0x02055fb4 end:0x02056014
+
+src/func_02056014.c:
+    complete
+    .text start:0x02056014 end:0x02056074
+
+src/func_02056074.c:
+    complete
+    .text start:0x02056074 end:0x020560d4
+
+src/func_020560d4.c:
+    complete
+    .text start:0x020560d4 end:0x02056134
+
+src/_ZN3GXS11LoadBG1CharEPKvjj.c:
+    complete
+    .text start:0x02056134 end:0x02056194
+
+src/_ZN2GX11LoadBG1CharEPKvjj.c:
+    complete
+    .text start:0x02056194 end:0x020561f4
+
+src/_ZN3GXS11LoadBG0CharEPKvjj.c:
+    complete
+    .text start:0x020561f4 end:0x02056254
+
+src/_ZN2GX11LoadBG0CharEPKvjj.c:
+    complete
+    .text start:0x02056254 end:0x020562b4
+
+src/func_020562b4.c:
+    complete
+    .text start:0x020562b4 end:0x02056314
+
+src/func_02056314.c:
+    complete
+    .text start:0x02056314 end:0x02056374
+
+src/func_02056374.c:
+    complete
+    .text start:0x02056374 end:0x020563d4
+
+src/func_020563d4.c:
+    complete
+    .text start:0x020563d4 end:0x02056434
+
+src/func_02056434.c:
+    complete
+    .text start:0x02056434 end:0x02056494
+
+src/func_02056494.c:
+    complete
+    .text start:0x02056494 end:0x020564f4
+
+src/func_020564f4.c:
+    complete
+    .text start:0x020564f4 end:0x02056554
+
+src/func_02056554.c:
+    complete
+    .text start:0x02056554 end:0x020565b4
+
+src/func_020565b4.c:
+    complete
+    .text start:0x020565b4 end:0x02056614
+
+src/_ZN2GX7LoadOBJEPKvjj.c:
+    complete
+    .text start:0x02056614 end:0x02056674
+
+src/func_02056674.c:
+    complete
+    .text start:0x02056674 end:0x020566dc
+
+src/func_020566dc.c:
+    complete
+    .text start:0x020566dc end:0x02056738
+
+src/_ZN3GXS11LoadOBJPlttEPKvjj.c:
+    complete
+    .text start:0x02056738 end:0x020567a0
+
+src/_ZN2GX11LoadOBJPlttEPKvjj.c:
+    complete
+    .text start:0x020567a0 end:0x02056808
+
+src/_ZN3GXS10LoadBGPlttEPKvjj.c:
+    complete
+    .text start:0x02056808 end:0x02056870
+
+src/_ZN2GX10LoadBGPlttEPKvjj.c:
+    complete
+    .text start:0x02056870 end:0x020568cc
+
+src/_ZN2GX14EndLoadTexPlttEv.c:
+    complete
+    .text start:0x020568cc end:0x02056924
+
+src/_ZN2GX11LoadTexPlttEPKvjj.c:
+    complete
+    .text start:0x02056924 end:0x02056998
+
+src/_ZN2GX16BeginLoadTexPlttEv.c:
+    complete
+    .text start:0x02056998 end:0x020569e0
+
+src/_ZN2GX10EndLoadTexEv.c:
+    complete
+    .text start:0x020569e0 end:0x02056a50
+
+src/_ZN2GX7LoadTexEPKvjj.cpp:
+    complete
+    .text start:0x02056a50 end:0x02056b9c
+
+src/_ZN2GX12BeginLoadTexEv.c:
+    complete
+    .text start:0x02056b9c end:0x02056c1c
+
+src/Copy48BytesFixed.c:
+    complete
+    .text start:0x02056c1c end:0x02056c40
+
+src/_ZN3IRQ19Tim3OverflowHandlerEv.cpp:
+    .text start:0x02056c40 end:0x02056c50
+
+src/_ZN3IRQ19Tim2OverflowHandlerEv.cpp:
+    .text start:0x02056c50 end:0x02056c60
+
+src/_ZN3IRQ19Tim1OverflowHandlerEv.cpp:
+    .text start:0x02056c60 end:0x02056c70
+
+src/_ZN3IRQ19Tim0OverflowHandlerEv.cpp:
+    .text start:0x02056c70 end:0x02056c80
+
+src/_ZN3IRQ11Dma3HandlerEv.cpp:
+    .text start:0x02056c80 end:0x02056c90
+
+src/_ZN3IRQ11Dma2HandlerEv.cpp:
+    .text start:0x02056c90 end:0x02056ca0
+
+src/_ZN3IRQ11Dma1HandlerEv.cpp:
+    .text start:0x02056ca0 end:0x02056cb0
+
+src/_ZN3IRQ11Dma0HandlerEv.cpp:
+    .text start:0x02056cb0 end:0x02056cc0
+
+src/_ZN3IRQ13DmaTimHandlerEv.c:
+    complete
+    .text start:0x02056cc0 end:0x02056d60
+
+src/_ZN3IRQ12EmptyHandlerEv.c:
+    complete
+    .text start:0x02056d60 end:0x02056d64
+
+src/_ZN3IRQ15ClearInterruptsEj.c:
+    complete
+    .text start:0x02056d64 end:0x02056d98
+
+src/_ZN3IRQ11DisableIRQsEj.c:
+    complete
+    .text start:0x02056d98 end:0x02056de0
+
+src/_ZN3IRQ10EnableIRQsEj.c:
+    complete
+    .text start:0x02056de0 end:0x02056e18
+
+src/_ZN3IRQ7SetIRQsEj.c:
+    complete
+    .text start:0x02056e18 end:0x02056e4c
+
+src/func_02056e4c.c:
+    complete
+    .text start:0x02056e4c end:0x02056e98
+
+src/func_02056e98.c:
+    complete
+    .text start:0x02056e98 end:0x02056ee4
+
+src/_ZN3IRQ13GetIRQHandlerEj.c:
+    complete
+    .text start:0x02056ee4 end:0x02056f70
+
+src/_ZN3IRQ13SetIRQHandlerEjPFvvE.c:
+    complete
+    .text start:0x02056f70 end:0x02057000
+
+src/func_02057000.c:
+    complete
+    .text start:0x02057000 end:0x02057014
+
+src/func_020570a8.c:
+    complete
+    .text start:0x020570a8 end:0x020570b8
+
+src/func_020570b8.c:
+    complete
+    .text start:0x020570b8 end:0x020570c0
+
+src/func_020570c0.c:
+    .text start:0x020570c0 end:0x020570d8
+
+src/func_020570d8.c:
+    .text start:0x020570d8 end:0x020570f0
+
+src/func_020570f0.c:
+    complete
+    .text start:0x020570f0 end:0x0205710c
+
+src/func_0205710c.c:
+    complete
+    .text start:0x0205710c end:0x02057128
+
+src/func_02057128.c:
+    .text start:0x02057128 end:0x02057140
+
+src/func_02057140.c:
+    .text start:0x02057140 end:0x02057158
+
+src/func_02057158.c:
+    complete
+    .text start:0x02057158 end:0x02057178
+
+src/func_02057178.c:
+    complete
+    .text start:0x02057178 end:0x02057198
+
+src/func_02057198.c:
+    complete
+    .text start:0x02057198 end:0x02057218
+
+src/func_02057218.c:
+    complete
+    .text start:0x02057218 end:0x02057228
+
+src/func_02057228.c:
+    complete
+    .text start:0x02057228 end:0x020572b8
+
+src/func_020572b8.c:
+    complete
+    .text start:0x020572b8 end:0x020572c8
+
+src/func_020572c8.c:
+    complete
+    .text start:0x020572c8 end:0x02057320
+
+src/func_02057320.cpp:
+    complete
+    .text start:0x02057320 end:0x02057410
+
+src/func_02057410.c:
+    .text start:0x02057410 end:0x02057ce8
+
+src/func_02057ce8.c:
+    complete
+    .text start:0x02057ce8 end:0x02057d00
+
+src/func_02057d00.c:
+    complete
+    .text start:0x02057d00 end:0x02057d30
+
+src/func_02057d30.c:
+    complete
+    .text start:0x02057d30 end:0x02057d94
+
+src/func_02057d94.c:
+    complete
+    .text start:0x02057d94 end:0x02057e00
+
+src/func_02057e00.c:
+    complete
+    .text start:0x02057e00 end:0x02057e30
+
+src/func_02057e30.c:
+    complete
+    .text start:0x02057e30 end:0x02057e34
+
+src/func_02057e34.c:
+    complete
+    .text start:0x02057e34 end:0x02057e48
+
+src/func_02057e48.c:
+    complete
+    .text start:0x02057e48 end:0x02057e7c
+
+src/func_02057e7c.c:
+    complete
+    .text start:0x02057e7c end:0x02057e84
+
+src/func_02057e84.c:
+    complete
+    .text start:0x02057e84 end:0x02057f38
+
+src/func_02057f38.c:
+    complete
+    .text start:0x02057f38 end:0x02057f54
+
+src/func_02057f54.c:
+    complete
+    .text start:0x02057f54 end:0x0205801c
+
+src/func_0205801c.c:
+    complete
+    .text start:0x0205801c end:0x02058048
+
+src/func_02058048.c:
+    complete
+    .text start:0x02058048 end:0x0205807c
+
+src/OS_WakeupThread.c:
+    complete
+    .text start:0x0205807c end:0x020580f0
+
+src/OS_SleepThread.c:
+    complete
+    .text start:0x020580f0 end:0x02058158
+
+src/func_02058158.c:
+    complete
+    .text start:0x02058158 end:0x0205816c
+
+src/func_0205816c.c:
+    complete
+    .text start:0x0205816c end:0x020581a8
+
+src/func_020581a8.cpp:
+    .text start:0x020581a8 end:0x02058200
+
+src/func_02058200.c:
+    complete
+    .text start:0x02058200 end:0x02058308
+
+src/func_02058308.c:
+    .text start:0x02058308 end:0x02058488
+
+src/func_02058488.c:
+    complete
+    .text start:0x02058488 end:0x020584d0
+
+src/func_020584d0.c:
+    .text start:0x020584d0 end:0x02058538
+
+src/func_02058538.c:
+    complete
+    .text start:0x02058538 end:0x02058568
+
+src/ARMSaveContext.c:
+    complete
+    .text start:0x020585cc end:0x02058618
+
+src/ARMRestoreContext.c:
+    complete
+    .text start:0x02058618 end:0x0205865c
+
+src/func_0205865c.c:
+    complete
+    .text start:0x0205865c end:0x02058690
+
+src/func_02058690.c:
+    complete
+    .text start:0x02058690 end:0x02058764
+
+src/func_02058764.c:
+    complete
+    .text start:0x02058764 end:0x020587dc
+
+src/func_020587dc.c:
+    complete
+    .text start:0x020587dc end:0x020587e4
+
+src/func_020587e4.c:
+    .text start:0x020587e4 end:0x02058894
+
+src/func_02058894.c:
+    .text start:0x02058894 end:0x02058940
+
+src/func_02058940.c:
+    complete
+    .text start:0x02058940 end:0x02058960
+
+src/func_02058960.c:
+    complete
+    .text start:0x02058960 end:0x02058988
+
+src/func_02058988.c:
+    complete
+    .text start:0x02058988 end:0x020589ac
+
+src/func_020589ac.c:
+    complete
+    .text start:0x020589ac end:0x020589d4
+
+src/func_020589d4.c:
+    complete
+    .text start:0x020589d4 end:0x02058a44
+
+src/func_02058a44.c:
+    complete
+    .text start:0x02058a44 end:0x02058a94
+
+src/func_02058a94.c:
+    complete
+    .text start:0x02058a94 end:0x02058b08
+
+src/func_02058b08.c:
+    complete
+    .text start:0x02058b08 end:0x02058b9c
+
+src/func_02058b9c.c:
+    complete
+    .text start:0x02058b9c end:0x02058bb0
+
+src/_ZN4CP1514FlushDataCacheEv.c:
+    complete
+    .text start:0x02058bb0 end:0x02058bdc
+
+src/_ZN4CP1527FlushAndInvalidateDataCacheEv.c:
+    complete
+    .text start:0x02058bdc end:0x02058c08
+
+src/_ZN4CP1519InvalidateDataCacheEjj.c:
+    complete
+    .text start:0x02058c08 end:0x02058c24
+
+src/_ZN4CP1514FlushDataCacheEjj.c:
+    complete
+    .text start:0x02058c24 end:0x02058c40
+
+src/_ZN4CP1527FlushAndInvalidateDataCacheEjj.c:
+    complete
+    .text start:0x02058c40 end:0x02058c5c
+
+src/_ZN4CP1516DrainWriteBufferEv.c:
+    complete
+    .text start:0x02058c5c end:0x02058c68
+
+src/_ZN4CP1526InvalidateInstructionCacheEjj.c:
+    complete
+    .text start:0x02058c68 end:0x02058c84
+
+src/func_02058c84.c:
+    complete
+    .text start:0x02058c84 end:0x02058cd0
+
+src/func_02058cd0.c:
+    complete
+    .text start:0x02058cd0 end:0x02058d58
+
+src/func_02058d58.c:
+    complete
+    .text start:0x02058d58 end:0x02058d6c
+
+src/func_02058d6c.c:
+    complete
+    .text start:0x02058d6c end:0x02058d80
+
+src/OS_GetInitArenaLo.c:
+    complete
+    .text start:0x02058d80 end:0x02058df4
+
+src/func_02058df4.c:
+    .text start:0x02058df4 end:0x02058ea0
+
+src/func_02058ea0.c:
+    complete
+    .text start:0x02058ea0 end:0x02058eb4
+
+src/func_02058eb4.c:
+    complete
+    .text start:0x02058eb4 end:0x02058ec8
+
+src/func_02058ec8.c:
+    complete
+    .text start:0x02058ec8 end:0x02058f28
+
+src/func_02058f28.c:
+    complete
+    .text start:0x02058f28 end:0x02059040
+
+src/func_02059040.c:
+    complete
+    .text start:0x02059040 end:0x020590fc
+
+src/func_020590fc.c:
+    complete
+    .text start:0x020590fc end:0x02059170
+
+src/func_02059170.c:
+    complete
+    .text start:0x02059170 end:0x0205929c
+
+src/func_0205929c.c:
+    complete
+    .text start:0x0205929c end:0x02059364
+
+src/func_02059364.c:
+    complete
+    .text start:0x02059364 end:0x0205938c
+
+src/func_0205938c.c:
+    complete
+    .text start:0x0205938c end:0x020593a8
+
+src/_ZN4CP1510EnableDTCMEv.c:
+    complete
+    .text start:0x020593a8 end:0x020593b8
+
+src/_ZN4CP1518GetDTCMBaseAddressEv.c:
+    complete
+    .text start:0x020593b8 end:0x020593cc
+
+src/_ZN4CP159EnableMPUEv.c:
+    complete
+    .text start:0x020593cc end:0x020593dc
+
+src/_ZN4CP1510DisableMPUEv.c:
+    complete
+    .text start:0x020593dc end:0x020593ec
+
+src/_ZN4CP1514MPUDataRegion1Ej.c:
+    complete
+    .text start:0x020593ec end:0x020593f4
+
+src/func_020593f4.c:
+    complete
+    .text start:0x020593f4 end:0x02059468
+
+src/func_0205947c.c:
+    complete
+    .text start:0x0205947c end:0x0205950c
+
+src/func_0205950c.c:
+    complete
+    .text start:0x0205950c end:0x02059578
+
+src/func_02059578.c:
+    complete
+    .text start:0x02059578 end:0x02059594
+
+src/func_02059594.c:
+    complete
+    .text start:0x02059594 end:0x02059624
+
+src/func_02059624.c:
+    complete
+    .text start:0x02059624 end:0x02059640
+
+src/func_02059640.c:
+    .text start:0x02059640 end:0x02059650
+
+src/func_02059650.c:
+    complete
+    .text start:0x02059650 end:0x02059700
+
+src/func_02059700.c:
+    complete
+    .text start:0x02059700 end:0x02059788
+
+src/func_02059788.c:
+    complete
+    .text start:0x02059788 end:0x02059824
+
+src/func_02059834.c:
+    complete
+    .text start:0x02059834 end:0x02059950
+
+src/func_02059950.c:
+    complete
+    .text start:0x02059950 end:0x020599e8
+
+src/func_020599e8.cpp:
+    complete
+    .text start:0x020599e8 end:0x02059a60
+
+src/func_02059a60.c:
+    .text start:0x02059a60 end:0x02059ba0
+
+src/func_02059ba0.c:
+    complete
+    .text start:0x02059ba0 end:0x02059bb0
+
+src/func_02059bb0.c:
+    complete
+    .text start:0x02059bb0 end:0x02059bc0
+
+src/func_02059bc0.c:
+    complete
+    .text start:0x02059bc0 end:0x02059c18
+
+src/func_02059c18.c:
+    complete
+    .text start:0x02059c18 end:0x02059cb4
+
+src/func_02059cb4.c:
+    complete
+    .text start:0x02059cb4 end:0x02059d08
+
+src/_ZN3IRQ6EnableEv.cpp:
+    complete
+    .text start:0x02059d08 end:0x02059d1c
+
+src/_ZN3IRQ7DisableEv.cpp:
+    complete
+    .text start:0x02059d1c end:0x02059d30
+
+src/_ZN3IRQ7RestoreEj.cpp:
+    complete
+    .text start:0x02059d30 end:0x02059d48
+
+src/_ZN3IRQ10DisableAllEv.cpp:
+    complete
+    .text start:0x02059d48 end:0x02059d5c
+
+src/_ZN3IRQ10RestoreAllEj.cpp:
+    complete
+    .text start:0x02059d5c end:0x02059d74
+
+src/ARMProcessorMode.c:
+    complete
+    .text start:0x02059d74 end:0x02059d80
+
+src/_ZN4CP1516WaitForInterruptEv.c:
+    complete
+    .text start:0x02059d80 end:0x02059d8c
+
+src/func_02059dd4.c:
+    complete
+    .text start:0x02059dd4 end:0x02059e04
+
+src/func_02059e04.c:
+    complete
+    .text start:0x02059e04 end:0x02059e48
+
+src/func_02059e48.c:
+    complete
+    .text start:0x02059e48 end:0x02059eb0
+
+src/func_02059eb0.c:
+    complete
+    .text start:0x02059eb0 end:0x02059f2c
+
+src/func_02059f2c.c:
+    complete
+    .text start:0x02059f2c end:0x02059f48
+
+src/func_02059f48.c:
+    .text start:0x02059f48 end:0x02059f58
+
+src/func_02059f58.c:
+    complete
+    .text start:0x02059f58 end:0x02059fa8
+
+src/func_02059fa8.c:
+    complete
+    .text start:0x02059fa8 end:0x02059fd0
+
+src/func_02059fd0.c:
+    complete
+    .text start:0x02059fd0 end:0x0205a064
+
+src/func_0205a064.c:
+    complete
+    .text start:0x0205a064 end:0x0205a10c
+
+src/DMASyncHalfTransfer.c:
+    complete
+    .text start:0x0205a10c end:0x0205a160
+
+src/DMASyncWordTransfer.c:
+    complete
+    .text start:0x0205a160 end:0x0205a1b4
+
+src/DMASyncFillTransfer.c:
+    complete
+    .text start:0x0205a1b4 end:0x0205a21c
+
+src/func_0205a21c.c:
+    complete
+    .text start:0x0205a21c end:0x0205a290
+
+src/func_0205a290.c:
+    complete
+    .text start:0x0205a290 end:0x0205a358
+
+src/func_0205a358.cpp:
+    complete
+    .text start:0x0205a358 end:0x0205a448
+
+src/MultiStore16.c:
+    complete
+    .text start:0x0205a448 end:0x0205a460
+
+src/MultiCopyHalf.c:
+    complete
+    .text start:0x0205a460 end:0x0205a47c
+
+src/MultiStore_Int.c:
+    complete
+    .text start:0x0205a47c end:0x0205a490
+
+src/MultiCopy_Int.c:
+    complete
+    .text start:0x0205a490 end:0x0205a4a8
+
+src/MultiStore32Bytes.c:
+    complete
+    .text start:0x0205a4a8 end:0x0205a4f4
+
+src/MultiCopy32Bytes.c:
+    complete
+    .text start:0x0205a4f4 end:0x0205a52c
+
+src/Copy32Bytes.c:
+    complete
+    .text start:0x0205a52c end:0x0205a548
+
+src/Copy36Bytes.c:
+    complete
+    .text start:0x0205a548 end:0x0205a564
+
+src/Copy48Bytes.c:
+    complete
+    .text start:0x0205a564 end:0x0205a588
+
+src/func_0205a74c.c:
+    complete
+    .text start:0x0205a74c end:0x0205a754
+
+src/DecompressLZ16.c:
+    complete
+    .text start:0x0205a754 end:0x0205a82c
+
+src/func_0205a82c.c:
+    complete
+    .text start:0x0205a82c end:0x0205a86c
+
+src/Snd_SendCommand.c:
+    complete
+    .text start:0x0205a86c end:0x0205a8c4
+
+src/func_0205a8c4.c:
+    complete
+    .text start:0x0205a8c4 end:0x0205a8f0
+
+src/func_0205a8f0.c:
+    complete
+    .text start:0x0205a8f0 end:0x0205a924
+
+src/func_0205a924.c:
+    complete
+    .text start:0x0205a924 end:0x0205a958
+
+src/func_0205a958.c:
+    complete
+    .text start:0x0205a958 end:0x0205a98c
+
+src/func_0205a98c.c:
+    complete
+    .text start:0x0205a98c end:0x0205a9b8
+
+src/func_0205a9b8.c:
+    complete
+    .text start:0x0205a9b8 end:0x0205a9e4
+
+src/func_0205a9e4.c:
+    complete
+    .text start:0x0205a9e4 end:0x0205aa10
+
+src/func_0205aa10.c:
+    complete
+    .text start:0x0205aa10 end:0x0205aa68
+
+src/func_0205aa68.c:
+    complete
+    .text start:0x0205aa68 end:0x0205aa9c
+
+src/func_0205aa9c.c:
+    complete
+    .text start:0x0205aa9c end:0x0205aac8
+
+src/func_0205aac8.c:
+    complete
+    .text start:0x0205aac8 end:0x0205aaf4
+
+src/func_0205aaf4.c:
+    complete
+    .text start:0x0205aaf4 end:0x0205ab28
+
+src/func_0205ab28.c:
+    complete
+    .text start:0x0205ab28 end:0x0205ab6c
+
+src/func_0205ab6c.c:
+    complete
+    .text start:0x0205ab6c end:0x0205abb8
+
+src/func_0205abb8.c:
+    complete
+    .text start:0x0205abb8 end:0x0205ac28
+
+src/func_0205ac28.c:
+    complete
+    .text start:0x0205ac28 end:0x0205ac5c
+
+src/func_0205ac5c.c:
+    complete
+    .text start:0x0205ac5c end:0x0205ac84
+
+src/func_0205ac84.c:
+    complete
+    .text start:0x0205ac84 end:0x0205acac
+
+src/func_0205acac.c:
+    complete
+    .text start:0x0205acac end:0x0205acd4
+
+src/func_0205acd4.c:
+    complete
+    .text start:0x0205acd4 end:0x0205acfc
+
+src/func_0205acfc.c:
+    complete
+    .text start:0x0205acfc end:0x0205ad24
+
+src/func_0205ad24.c:
+    complete
+    .text start:0x0205ad24 end:0x0205ad3c
+
+src/func_0205ad3c.c:
+    complete
+    .text start:0x0205ad3c end:0x0205ad54
+
+src/func_0205ad54.c:
+    complete
+    .text start:0x0205ad54 end:0x0205ad6c
+
+src/func_0205ad6c.c:
+    complete
+    .text start:0x0205ad6c end:0x0205ad98
+
+src/func_0205ad98.c:
+    complete
+    .text start:0x0205ad98 end:0x0205adc4
+
+src/func_0205adc4.c:
+    complete
+    .text start:0x0205adc4 end:0x0205adf8
+
+src/func_0205adf8.c:
+    complete
+    .text start:0x0205adf8 end:0x0205ae30
+
+src/func_0205ae30.c:
+    complete
+    .text start:0x0205ae30 end:0x0205ae64
+
+src/func_0205ae64.c:
+    complete
+    .text start:0x0205ae64 end:0x0205aed0
+
+src/func_0205aed0.c:
+    complete
+    .text start:0x0205aed0 end:0x0205af00
+
+src/func_0205af00.c:
+    complete
+    .text start:0x0205af00 end:0x0205af20
+
+src/func_0205af20.c:
+    complete
+    .text start:0x0205af20 end:0x0205af4c
+
+src/func_0205af4c.c:
+    complete
+    .text start:0x0205af4c end:0x0205af78
+
+src/func_0205af78.c:
+    complete
+    .text start:0x0205af78 end:0x0205afb4
+
+src/func_0205afb4.c:
+    complete
+    .text start:0x0205afb4 end:0x0205afe0
+
+src/func_0205afe0.c:
+    complete
+    .text start:0x0205afe0 end:0x0205b070
+
+src/func_0205b070.c:
+    complete
+    .text start:0x0205b070 end:0x0205b1a4
+
+src/func_0205b1a4.c:
+    complete
+    .text start:0x0205b1a4 end:0x0205b1d8
+
+src/func_0205b1d8.c:
+    complete
+    .text start:0x0205b1d8 end:0x0205b274
+
+src/func_0205b274.c:
+    complete
+    .text start:0x0205b274 end:0x0205b358
+
+src/func_0205b358.c:
+    complete
+    .text start:0x0205b358 end:0x0205b470
+
+src/func_0205b470.c:
+    complete
+    .text start:0x0205b470 end:0x0205b4d0
+
+src/func_0205b4d0.c:
+    complete
+    .text start:0x0205b4d0 end:0x0205b504
+
+src/func_0205b504.c:
+    complete
+    .text start:0x0205b504 end:0x0205b524
+
+src/func_0205b524.c:
+    complete
+    .text start:0x0205b524 end:0x0205b554
+
+src/func_0205b554.c:
+    complete
+    .text start:0x0205b554 end:0x0205b5d4
+
+src/func_0205b5d4.c:
+    complete
+    .text start:0x0205b5d4 end:0x0205b608
+
+src/func_0205b608.c:
+    complete
+    .text start:0x0205b608 end:0x0205b63c
+
+src/func_0205b63c.c:
+    complete
+    .text start:0x0205b63c end:0x0205b6b0
+
+src/func_0205b6b0.c:
+    complete
+    .text start:0x0205b6b0 end:0x0205b6f4
+
+src/func_0205b6f4.c:
+    complete
+    .text start:0x0205b6f4 end:0x0205b78c
+
+src/func_0205b78c.c:
+    complete
+    .text start:0x0205b78c end:0x0205b858
+
+src/func_0205b858.c:
+    complete
+    .text start:0x0205b858 end:0x0205b864
+
+src/_ZN3IRQ24IPCRxFifoNotEmptyHandlerEv.c:
+    complete
+    .text start:0x0205b864 end:0x0205b988
+
+src/IPCSend.c:
+    complete
+    .text start:0x0205b988 end:0x0205ba3c
+
+src/func_0205ba3c.c:
+    complete
+    .text start:0x0205ba3c end:0x0205ba64
+
+src/func_0205ba64.c:
+    complete
+    .text start:0x0205ba64 end:0x0205bad8
+
+src/func_0205bad8.c:
+    complete
+    .text start:0x0205bad8 end:0x0205bbdc
+
+src/func_0205bbdc.c:
+    complete
+    .text start:0x0205bbdc end:0x0205bbe4
+
+src/func_0205bbe4.c:
+    complete
+    .text start:0x0205bbe4 end:0x0205bc0c
+
+src/func_0205bc0c.c:
+    complete
+    .text start:0x0205bc0c end:0x0205bc88
+
+src/func_0205bc88.c:
+    complete
+    .text start:0x0205bc88 end:0x0205c048
+
+src/func_0205c048.c:
+    complete
+    .text start:0x0205c048 end:0x0205c264
+
+src/func_0205c264.c:
+    complete
+    .text start:0x0205c264 end:0x0205c378
+
+src/func_0205c378.c:
+    complete
+    .text start:0x0205c378 end:0x0205c410
+
+src/func_0205c410.c:
+    complete
+    .text start:0x0205c410 end:0x0205c448
+
+src/func_0205c448.c:
+    complete
+    .text start:0x0205c448 end:0x0205c480
+
+src/func_0205c480.c:
+    complete
+    .text start:0x0205c480 end:0x0205c4e4
+
+src/func_0205c4e4.c:
+    complete
+    .text start:0x0205c4e4 end:0x0205c528
+
+src/func_0205c528.cpp:
+    complete
+    .text start:0x0205c528 end:0x0205c5e4
+
+src/func_0205c5e4.c:
+    complete
+    .text start:0x0205c5e4 end:0x0205c788
+
+src/func_0205c788.c:
+    complete
+    .text start:0x0205c788 end:0x0205c7c4
+
+src/func_0205c7c4.c:
+    complete
+    .text start:0x0205c7c4 end:0x0205c7e4
+
+src/func_0205c7e4.c:
+    complete
+    .text start:0x0205c7e4 end:0x0205c864
+
+src/func_0205c864.c:
+    complete
+    .text start:0x0205c864 end:0x0205c91c
+
+src/func_0205c91c.c:
+    complete
+    .text start:0x0205c91c end:0x0205c9b8
+
+src/func_0205c9b8.c:
+    complete
+    .text start:0x0205c9b8 end:0x0205caa8
+
+src/func_0205caa8.c:
+    complete
+    .text start:0x0205caa8 end:0x0205cb68
+
+src/func_0205cb68.c:
+    complete
+    .text start:0x0205cb68 end:0x0205cbe4
+
+src/func_0205cbe4.c:
+    complete
+    .text start:0x0205cbe4 end:0x0205cc80
+
+src/func_0205cc80.c:
+    complete
+    .text start:0x0205cc80 end:0x0205cd34
+
+src/func_0205cd34.c:
+    complete
+    .text start:0x0205cd34 end:0x0205cd5c
+
+src/func_0205cd5c.c:
+    .text start:0x0205cd5c end:0x0205cdf4
+
+src/func_0205cdf4.cpp:
+    complete
+    .text start:0x0205cdf4 end:0x0205cf5c
+
+src/func_0205cf5c.c:
+    complete
+    .text start:0x0205cf5c end:0x0205cfa4
+
+src/func_0205cfa4.c:
+    complete
+    .text start:0x0205cfa4 end:0x0205d044
+
+src/func_0205d044.c:
+    complete
+    .text start:0x0205d044 end:0x0205d23c
+
+src/func_0205d23c.c:
+    complete
+    .text start:0x0205d23c end:0x0205d28c
+
+src/func_0205d28c.c:
+    complete
+    .text start:0x0205d28c end:0x0205d2b0
+
+src/func_0205d2b0.c:
+    complete
+    .text start:0x0205d2b0 end:0x0205d2dc
+
+src/func_0205d2dc.c:
+    complete
+    .text start:0x0205d2dc end:0x0205d304
+
+src/func_0205d304.c:
+    complete
+    .text start:0x0205d304 end:0x0205d368
+
+src/func_0205d368.c:
+    complete
+    .text start:0x0205d368 end:0x0205d3d4
+
+src/FS_ReadFile.c:
+    complete
+    .text start:0x0205d3d4 end:0x0205d3e4
+
+src/func_0205d3e4.c:
+    complete
+    .text start:0x0205d3e4 end:0x0205d3f4
+
+src/func_0205d3f4.c:
+    complete
+    .text start:0x0205d3f4 end:0x0205d4a0
+
+src/func_0205d4a0.c:
+    complete
+    .text start:0x0205d4a0 end:0x0205d4cc
+
+src/FS_CloseFile.c:
+    complete
+    .text start:0x0205d4cc end:0x0205d518
+
+src/func_0205d518.c:
+    complete
+    .text start:0x0205d518 end:0x0205d568
+
+src/func_0205d568.c:
+    complete
+    .text start:0x0205d568 end:0x0205d5e8
+
+src/func_0205d5e8.c:
+    complete
+    .text start:0x0205d5e8 end:0x0205d644
+
+src/func_0205d644.c:
+    complete
+    .text start:0x0205d644 end:0x0205d688
+
+src/func_0205d688.c:
+    complete
+    .text start:0x0205d688 end:0x0205d714
+
+src/func_0205d714.c:
+    complete
+    .text start:0x0205d714 end:0x0205d874
+
+src/FS_InitFile.c:
+    complete
+    .text start:0x0205d874 end:0x0205d89c
+
+src/func_0205d89c.c:
+    complete
+    .text start:0x0205d89c end:0x0205d8d8
+
+src/func_0205d8d8.c:
+    complete
+    .text start:0x0205d8d8 end:0x0205d920
+
+src/func_0205d920.c:
+    complete
+    .text start:0x0205d920 end:0x0205d94c
+
+src/func_0205d94c.c:
+    complete
+    .text start:0x0205d94c end:0x0205d96c
+
+src/func_0205d96c.c:
+    complete
+    .text start:0x0205d96c end:0x0205da94
+
+src/func_0205da94.c:
+    complete
+    .text start:0x0205da94 end:0x0205db24
+
+src/func_0205db24.c:
+    complete
+    .text start:0x0205db24 end:0x0205db2c
+
+src/func_0205db2c.c:
+    complete
+    .text start:0x0205db2c end:0x0205db78
+
+src/func_0205db78.c:
+    complete
+    .text start:0x0205db78 end:0x0205db88
+
+src/func_0205db88.c:
+    complete
+    .text start:0x0205db88 end:0x0205dc0c
+
+src/func_0205dc0c.c:
+    complete
+    .text start:0x0205dc0c end:0x0205dc60
+
+src/func_0205dc60.c:
+    complete
+    .text start:0x0205dc60 end:0x0205dc7c
+
+src/func_0205dc7c.c:
+    complete
+    .text start:0x0205dc7c end:0x0205dd9c
+
+src/func_0205dd9c.c:
+    complete
+    .text start:0x0205dd9c end:0x0205de9c
+
+src/func_0205de9c.c:
+    complete
+    .text start:0x0205de9c end:0x0205df40
+
+src/func_0205df40.c:
+    complete
+    .text start:0x0205df40 end:0x0205dffc
+
+src/func_0205dffc.c:
+    complete
+    .text start:0x0205dffc end:0x0205e088
+
+src/func_0205e088.c:
+    complete
+    .text start:0x0205e088 end:0x0205e0b0
+
+src/func_0205e0b0.c:
+    complete
+    .text start:0x0205e0b0 end:0x0205e0f4
+
+src/func_0205e0f4.c:
+    complete
+    .text start:0x0205e0f4 end:0x0205e280
+
+src/func_0205e280.c:
+    complete
+    .text start:0x0205e280 end:0x0205e3d4
+
+src/func_0205e3d4.c:
+    complete
+    .text start:0x0205e3d4 end:0x0205e6e4
+
+src/func_0205e6e4.c:
+    complete
+    .text start:0x0205e6e4 end:0x0205e7e0
+
+src/func_0205e7e0.c:
+    complete
+    .text start:0x0205e7e0 end:0x0205e89c
+
+src/func_0205e89c.c:
+    complete
+    .text start:0x0205e89c end:0x0205e904
+
+src/func_0205e904.c:
+    complete
+    .text start:0x0205e904 end:0x0205e91c
+
+src/ARMMathLoadState.c:
+    complete
+    .text start:0x0205e91c end:0x0205e988
+
+src/ARMMathSaveState.c:
+    complete
+    .text start:0x0205e988 end:0x0205e9fc
+
+src/func_0205e9fc.c:
+    complete
+    .text start:0x0205e9fc end:0x0205ea10
+
+src/func_0205ea10.c:
+    complete
+    .text start:0x0205ea10 end:0x0205ea28
+
+src/func_0205ea28.c:
+    complete
+    .text start:0x0205ea28 end:0x0205eb58
+
+src/func_0205eb58.c:
+    complete
+    .text start:0x0205eb58 end:0x0205edc8
+
+src/func_0205edc8.c:
+    complete
+    .text start:0x0205edc8 end:0x0205edd8
+
+src/func_0205edd8.cpp:
+    complete
+    .text start:0x0205edd8 end:0x0205eeac
+
+src/func_0205eeac.cpp:
+    complete
+    .text start:0x0205eeac end:0x0205efc0
+
+src/func_0205efc0.c:
+    complete
+    .text start:0x0205efc0 end:0x0205efe0
+
+src/func_0205efe0.c:
+    complete
+    .text start:0x0205efe0 end:0x0205f040
+
+src/func_0205f040.c:
+    complete
+    .text start:0x0205f040 end:0x0205f0e0
+
+src/func_0205f0e0.c:
+    complete
+    .text start:0x0205f0e0 end:0x0205f1e4
+
+src/func_0205f1e4.c:
+    complete
+    .text start:0x0205f1e4 end:0x0205f270
+
+src/func_0205f270.c:
+    complete
+    .text start:0x0205f270 end:0x0205f300
+
+src/func_0205f300.c:
+    complete
+    .text start:0x0205f300 end:0x0205f5c0
+
+src/func_0205f5c0.c:
+    complete
+    .text start:0x0205f5c0 end:0x0205f5fc
+
+src/func_0205f5fc.c:
+    complete
+    .text start:0x0205f5fc end:0x0205f650
+
+src/func_0205f650.c:
+    .text start:0x0205f650 end:0x0205f66c
+
+src/func_0205f66c.c:
+    complete
+    .text start:0x0205f66c end:0x0205f68c
+
+src/func_0205f68c.c:
+    complete
+    .text start:0x0205f68c end:0x0205f77c
+
+src/func_0205f77c.cpp:
+    complete
+    .text start:0x0205f77c end:0x0205f8b0
+
+src/func_0205f8b0.c:
+    complete
+    .text start:0x0205f8b0 end:0x0205f8e0
+
+src/func_0205f8e0.c:
+    complete
+    .text start:0x0205f8e0 end:0x0205f958
+
+src/func_0205f958.c:
+    complete
+    .text start:0x0205f958 end:0x0205f994
+
+src/func_0205f994.c:
+    complete
+    .text start:0x0205f994 end:0x0205f9ac
+
+src/func_0205f9ac.c:
+    complete
+    .text start:0x0205f9ac end:0x0205f9e8
+
+src/func_0205f9e8.c:
+    complete
+    .text start:0x0205f9e8 end:0x0205fa78
+
+src/func_0205fa78.c:
+    complete
+    .text start:0x0205fa78 end:0x0205fab4
+
+src/func_0205fab4.c:
+    complete
+    .text start:0x0205fab4 end:0x0205fb1c
+
+src/func_0205fb1c.c:
+    complete
+    .text start:0x0205fb1c end:0x0205fb58
+
+src/func_0205fb58.c:
+    complete
+    .text start:0x0205fb58 end:0x0205fbd0
+
+src/func_0205fbd0.c:
+    complete
+    .text start:0x0205fbd0 end:0x0205fc44
+
+src/func_0205fc44.c:
+    complete
+    .text start:0x0205fc44 end:0x0205fcfc
+
+src/func_0205fcfc.c:
+    complete
+    .text start:0x0205fcfc end:0x0205fde8
+
+src/func_0205fde8.c:
+    complete
+    .text start:0x0205fde8 end:0x0205feac
+
+src/func_0205feac.c:
+    complete
+    .text start:0x0205feac end:0x0205ff00
+
+src/func_0205ff00.c:
+    complete
+    .text start:0x0205ff00 end:0x0205ff08
+
+src/func_0205ff08.c:
+    complete
+    .text start:0x0205ff08 end:0x0205ff20
+
+src/func_0205ff20.c:
+    complete
+    .text start:0x0205ff20 end:0x0205ff70
+
+src/func_0205ff70.c:
+    complete
+    .text start:0x0205ff70 end:0x0205ff80
+
+src/func_0205ff80.c:
+    complete
+    .text start:0x0205ff80 end:0x0205ff90
+
+src/func_0205ff90.c:
+    complete
+    .text start:0x0205ff90 end:0x0205ffb0
+
+src/func_0205ffb0.c:
+    complete
+    .text start:0x0205ffb0 end:0x0205ffd0
+
+src/func_0205ffd0.c:
+    complete
+    .text start:0x0205ffd0 end:0x0206002c
+
+src/func_0206002c.c:
+    complete
+    .text start:0x0206002c end:0x020600e0
+
+src/func_020600e0.c:
+    complete
+    .text start:0x020600e0 end:0x02060188
+
+src/func_02060188.c:
+    complete
+    .text start:0x02060188 end:0x02060228
+
+src/func_02060228.c:
+    complete
+    .text start:0x02060228 end:0x020602bc
+
+src/func_020602bc.cpp:
+    .text start:0x020602bc end:0x02060310
+
+src/func_02060310.c:
+    complete
+    .text start:0x02060310 end:0x02060364
+
+src/func_02060364.c:
+    complete
+    .text start:0x02060364 end:0x02060398
+
+src/func_02060398.c:
+    complete
+    .text start:0x02060398 end:0x020603c8
+
+src/func_020603c8.cpp:
+    complete
+    .text start:0x020603c8 end:0x0206045c
+
+src/func_0206045c.c:
+    complete
+    .text start:0x0206045c end:0x02060470
+
+src/func_02060470.c:
+    complete
+    .text start:0x02060470 end:0x02060484
+
+src/func_02060484.c:
+    complete
+    .text start:0x02060484 end:0x02060558
+
+src/func_02060558.cpp:
+    complete
+    .text start:0x02060558 end:0x0206062c
+
+src/func_0206062c.cpp:
+    complete
+    .text start:0x0206062c end:0x0206071c
+
+src/func_0206071c.c:
+    complete
+    .text start:0x0206071c end:0x020607e8
+
+src/func_020607e8.c:
+    complete
+    .text start:0x020607e8 end:0x0206081c
+
+src/func_0206081c.c:
+    complete
+    .text start:0x0206081c end:0x02060890
+
+src/func_02060890.c:
+    complete
+    .text start:0x02060890 end:0x0206090c
+
+src/func_0206090c.c:
+    complete
+    .text start:0x0206090c end:0x02060918
+
+src/func_02060918.c:
+    complete
+    .text start:0x02060918 end:0x02060a30
+
+src/func_02060a30.c:
+    complete
+    .text start:0x02060a30 end:0x02060a64
+
+src/func_02060a64.c:
+    complete
+    .text start:0x02060a64 end:0x02060b64
+
+src/func_02060b64.c:
+    complete
+    .text start:0x02060b64 end:0x02060cac
+
+src/func_02060cac.c:
+    complete
+    .text start:0x02060cac end:0x02060d1c
+
+src/func_02060d1c.c:
+    complete
+    .text start:0x02060d1c end:0x02060d98
+
+src/func_02060d98.c:
+    complete
+    .text start:0x02060d98 end:0x02060e38
+
+src/func_02060e38.c:
+    complete
+    .text start:0x02060e38 end:0x02060ebc
+
+src/func_02060ebc.c:
+    complete
+    .text start:0x02060ebc end:0x02060f60
+
+src/func_02060f60.cpp:
+    complete
+    .text start:0x02060f60 end:0x020610ac
+
+src/_ZN3IRQ21GameCardIREQMCHandlerEv.cpp:
+    complete
+    .text start:0x020610ac end:0x020610fc
+
+src/func_02061138.c:
+    complete
+    .text start:0x02061138 end:0x0206116c
+
+src/func_0206116c.c:
+    complete
+    .text start:0x0206116c end:0x02061188
+
+src/func_02061188.c:
+    complete
+    .text start:0x02061188 end:0x02061428
+
+src/WM_CheckStateEx.c:
+    complete
+    .text start:0x02061428 end:0x020614d0
+
+src/func_020614d0.c:
+    complete
+    .text start:0x020614d0 end:0x0206152c
+
+src/func_0206152c.c:
+    complete
+    .text start:0x0206152c end:0x02061548
+
+src/WM_GetSystemWork.c:
+    complete
+    .text start:0x02061548 end:0x02061558
+
+src/WM_SendCommand.c:
+    complete
+    .text start:0x02061558 end:0x0206165c
+
+src/WM_SetCallbackTable.c:
+    complete
+    .text start:0x0206165c end:0x02061674
+
+src/func_02061674.c:
+    complete
+    .text start:0x02061674 end:0x020616e8
+
+src/func_020616e8.c:
+    complete
+    .text start:0x020616e8 end:0x020618b8
+
+src/func_020618b8.c:
+    complete
+    .text start:0x020618b8 end:0x02061960
+
+src/func_02061960.c:
+    complete
+    .text start:0x02061960 end:0x020619ac
+
+src/func_020619ac.c:
+    complete
+    .text start:0x020619ac end:0x02061ab0
+
+src/func_02061ab0.c:
+    complete
+    .text start:0x02061ab0 end:0x02061b9c
+
+src/func_02061b9c.c:
+    complete
+    .text start:0x02061b9c end:0x02061c20
+
+src/func_02061c20.c:
+    complete
+    .text start:0x02061c20 end:0x02061c88
+
+src/func_02061c88.c:
+    complete
+    .text start:0x02061c88 end:0x02061ce4
+
+src/func_02061ce4.c:
+    complete
+    .text start:0x02061ce4 end:0x02061d30
+
+src/func_02061d30.c:
+    complete
+    .text start:0x02061d30 end:0x02061e38
+
+src/func_02061e38.c:
+    complete
+    .text start:0x02061e38 end:0x02061ee4
+
+src/func_02061ee4.cpp:
+    complete
+    .text start:0x02061ee4 end:0x02061fdc
+
+src/func_02061fdc.c:
+    complete
+    .text start:0x02061fdc end:0x02062024
+
+src/func_02062024.c:
+    complete
+    .text start:0x02062024 end:0x020620b0
+
+src/func_020620b0.c:
+    complete
+    .text start:0x020620b0 end:0x020621b8
+
+src/func_020621b8.c:
+    complete
+    .text start:0x020621b8 end:0x02062200
+
+src/func_02062200.c:
+    complete
+    .text start:0x02062200 end:0x02062240
+
+src/func_02062240.c:
+    complete
+    .text start:0x02062240 end:0x020622a8
+
+src/func_020622a8.c:
+    complete
+    .text start:0x020622a8 end:0x020622f0
+
+src/func_020622f0.c:
+    complete
+    .text start:0x020622f0 end:0x02062338
+
+src/func_02062338.c:
+    complete
+    .text start:0x02062338 end:0x02062380
+
+src/func_02062380.c:
+    complete
+    .text start:0x02062380 end:0x020623ec
+
+src/func_020623ec.c:
+    complete
+    .text start:0x020623ec end:0x02062428
+
+src/func_02062428.c:
+    complete
+    .text start:0x02062428 end:0x0206259c
+
+src/func_0206259c.c:
+    complete
+    .text start:0x0206259c end:0x020625fc
+
+src/func_020625fc.c:
+    complete
+    .text start:0x020625fc end:0x02062734
+
+src/func_02062734.c:
+    complete
+    .text start:0x02062734 end:0x02062778
+
+src/func_02062778.c:
+    complete
+    .text start:0x02062778 end:0x020627e8
+
+src/func_020627e8.c:
+    complete
+    .text start:0x020627e8 end:0x02062990
+
+src/func_02062990.c:
+    complete
+    .text start:0x02062990 end:0x02062aa4
+
+src/func_02062aa4.cpp:
+    complete
+    .text start:0x02062aa4 end:0x02062bdc
+
+src/func_02062bdc.cpp:
+    complete
+    .text start:0x02062bdc end:0x02062d10
+
+src/func_02062d10.cpp:
+    complete
+    .text start:0x02062d10 end:0x02062df0
+
+src/func_02062df0.c:
+    complete
+    .text start:0x02062df0 end:0x020631dc
+
+src/func_020631dc.c:
+    complete
+    .text start:0x020631dc end:0x020634fc
+
+src/func_020634fc.c:
+    complete
+    .text start:0x020634fc end:0x02063574
+
+src/func_02063574.c:
+    complete
+    .text start:0x02063574 end:0x020635d8
+
+src/func_020635d8.c:
+    complete
+    .text start:0x020635d8 end:0x02063648
+
+src/func_02063648.c:
+    complete
+    .text start:0x02063648 end:0x02063718
+
+src/func_02063718.c:
+    complete
+    .text start:0x02063718 end:0x02063980
+
+src/func_02063980.c:
+    complete
+    .text start:0x02063980 end:0x02063ae4
+
+src/func_02063ae4.c:
+    complete
+    .text start:0x02063ae4 end:0x02063bc4
+
+src/func_02063bc4.c:
+    complete
+    .text start:0x02063bc4 end:0x02063d3c
+
+src/func_02063d3c.c:
+    complete
+    .text start:0x02063d3c end:0x02063da0
+
+src/func_02063da0.c:
+    complete
+    .text start:0x02063da0 end:0x02063e08
+
+src/func_02063e08.c:
+    complete
+    .text start:0x02063e08 end:0x02063ea8
+
+src/func_02063ea8.c:
+    complete
+    .text start:0x02063ea8 end:0x02064470
+
+src/func_02064470.c:
+    complete
+    .text start:0x02064470 end:0x02064554
+
+src/func_02064554.c:
+    complete
+    .text start:0x02064554 end:0x02064674
+
+src/func_02064674.c:
+    .text start:0x02064674 end:0x0206470c
+
+src/func_020647a4.c:
+    complete
+    .text start:0x020647a4 end:0x020647d8
+
+src/func_020647d8.c:
+    complete
+    .text start:0x020647d8 end:0x020647fc
+
+src/func_020647fc.c:
+    .text start:0x020647fc end:0x02064888
+
+src/func_02064888.c:
+    complete
+    .text start:0x02064888 end:0x0206491c
+
+src/func_0206491c.c:
+    .text start:0x0206491c end:0x02064a28
+
+src/func_02064a28.c:
+    complete
+    .text start:0x02064a28 end:0x02064a94
+
+src/func_02064a94.c:
+    complete
+    .text start:0x02064a94 end:0x02064b2c
+
+src/func_02064b2c.c:
+    complete
+    .text start:0x02064b2c end:0x02064bac
+
+src/func_02064bac.c:
+    complete
+    .text start:0x02064bac end:0x02064c2c
+
+src/func_02064c2c.c:
+    complete
+    .text start:0x02064c2c end:0x02064cd8
+
+src/func_02064cd8.c:
+    complete
+    .text start:0x02064cd8 end:0x02064d6c
+
+src/func_02064d6c.c:
+    complete
+    .text start:0x02064d6c end:0x02064e18
+
+src/func_02064e18.c:
+    complete
+    .text start:0x02064e18 end:0x02064eac
+
+src/func_02064eac.c:
+    complete
+    .text start:0x02064eac end:0x02064f54
+
+src/func_02064f54.c:
+    complete
+    .text start:0x02064f54 end:0x02064fe8
+
+src/func_02064fe8.c:
+    complete
+    .text start:0x02064fe8 end:0x02065050
+
+src/func_02065050.c:
+    complete
+    .text start:0x02065050 end:0x020650a0
+
+src/func_020650a0.c:
+    complete
+    .text start:0x020650a0 end:0x020650d8
+
+src/func_020650d8.c:
+    complete
+    .text start:0x020650d8 end:0x02065138
+
+src/func_02065138.c:
+    complete
+    .text start:0x02065138 end:0x02065170
+
+src/func_02065170.c:
+    complete
+    .text start:0x02065170 end:0x02065234
+
+src/func_02065234.c:
+    complete
+    .text start:0x02065234 end:0x020652fc
+
+src/func_020652fc.c:
+    complete
+    .text start:0x020652fc end:0x020653cc
+
+src/func_020653cc.c:
+    complete
+    .text start:0x020653cc end:0x020654d0
+
+src/func_020654d0.c:
+    complete
+    .text start:0x020654d0 end:0x02065500
+
+src/func_02065500.c:
+    complete
+    .text start:0x02065500 end:0x02065538
+
+src/func_02065538.c:
+    complete
+    .text start:0x02065538 end:0x020656d4
+
+src/func_020656d4.c:
+    complete
+    .text start:0x020656d4 end:0x02065730
+
+src/func_02065730.c:
+    complete
+    .text start:0x02065730 end:0x02065788
+
+src/func_02065788.c:
+    complete
+    .text start:0x02065788 end:0x020657d0
+
+src/func_020657d0.c:
+    complete
+    .text start:0x020657d0 end:0x020657fc
+
+src/func_020657fc.c:
+    complete
+    .text start:0x020657fc end:0x020658c0
+
+src/func_020658c0.c:
+    complete
+    .text start:0x020658c0 end:0x02065970
+
+src/func_02065970.c:
+    complete
+    .text start:0x02065970 end:0x020659a0
+
+src/func_020659a0.c:
+    complete
+    .text start:0x020659a0 end:0x020659f8
+
+src/func_020659f8.c:
+    .text start:0x020659f8 end:0x02065a4c
+
+src/func_02065a4c.c:
+    complete
+    .text start:0x02065a4c end:0x02065a74
+
+src/func_02065a74.c:
+    complete
+    .text start:0x02065a74 end:0x02065a84
+
+src/func_02065a84.c:
+    complete
+    .text start:0x02065a84 end:0x02065a94
+
+src/func_02065a94.c:
+    complete
+    .text start:0x02065a94 end:0x02065ad0
+
+src/func_02065ad0.c:
+    complete
+    .text start:0x02065ad0 end:0x02065ae0
+
+src/func_02065ae0.c:
+    complete
+    .text start:0x02065ae0 end:0x02065af0
+
+src/func_02065af0.c:
+    complete
+    .text start:0x02065af0 end:0x02065b88
+
+src/func_02065b88.c:
+    complete
+    .text start:0x02065b88 end:0x02065b94
+
+src/func_02065b94.c:
+    complete
+    .text start:0x02065b94 end:0x02065ba0
+
+src/func_02065ba0.c:
+    complete
+    .text start:0x02065ba0 end:0x02065bb0
+
+src/func_02065bb0.c:
+    complete
+    .text start:0x02065bb0 end:0x02065bc0
+
+src/func_02065bc0.c:
+    complete
+    .text start:0x02065bc0 end:0x02065bd0
+
+src/func_02065bd0.c:
+    complete
+    .text start:0x02065bd0 end:0x02065be0
+
+src/func_02065be0.c:
+    complete
+    .text start:0x02065be0 end:0x02065bf4
+
+src/func_02065bf4.c:
+    complete
+    .text start:0x02065bf4 end:0x02065c1c
+
+src/func_02065c1c.c:
+    complete
+    .text start:0x02065c1c end:0x02065c2c
+
+src/func_02065c2c.c:
+    complete
+    .text start:0x02065c2c end:0x02065d5c
+
+src/func_02065d5c.c:
+    complete
+    .text start:0x02065d5c end:0x02065de4
+
+src/func_02065de4.c:
+    .text start:0x02065de4 end:0x02065eb8
+
+src/func_02065eb8.c:
+    complete
+    .text start:0x02065eb8 end:0x02065edc
+
+src/func_02065edc.c:
+    complete
+    .text start:0x02065edc end:0x02065ef8
+
+src/func_02065ef8.c:
+    complete
+    .text start:0x02065ef8 end:0x02065f08
+
+src/func_02065f08.c:
+    complete
+    .text start:0x02065f08 end:0x02065f78
+
+src/func_02065f78.c:
+    complete
+    .text start:0x02065f78 end:0x0206610c
+
+src/func_0206610c.c:
+    .text start:0x0206610c end:0x020662c0
+
+src/func_020662c0.c:
+    complete
+    .text start:0x020662c0 end:0x02066470
+
+src/func_02066470.c:
+    complete
+    .text start:0x02066470 end:0x020664b4
+
+src/func_020664b4.c:
+    complete
+    .text start:0x020664b4 end:0x0206655c
+
+src/func_0206655c.c:
+    complete
+    .text start:0x0206655c end:0x02066a94
+
+src/func_02066a94.c:
+    .text start:0x02066a94 end:0x02066fb0
+
+src/func_02066fb0.c:
+    .text start:0x02066fb0 end:0x02066fec
+
+src/func_02066fec.c:
+    complete
+    .text start:0x02066fec end:0x0206703c
+
+src/func_0206703c.cpp:
+    complete
+    .text start:0x0206703c end:0x02067138
+
+src/func_02067138.c:
+    complete
+    .text start:0x02067138 end:0x02067194
+
+src/func_02067194.c:
+    complete
+    .text start:0x02067194 end:0x020671b4
+
+src/func_020671b4.c:
+    complete
+    .text start:0x020671b4 end:0x02067250
+
+src/func_02067250.c:
+    complete
+    .text start:0x02067250 end:0x020672a4
+
+src/func_020672a4.c:
+    complete
+    .text start:0x020672a4 end:0x020672d0
+
+src/func_020672d0.c:
+    complete
+    .text start:0x020672d0 end:0x0206736c
+
+src/func_0206736c.c:
+    complete
+    .text start:0x0206736c end:0x02067480
+
+src/func_02067480.c:
+    complete
+    .text start:0x02067480 end:0x02067530
+
+src/func_02067530.c:
+    complete
+    .text start:0x02067530 end:0x02067604
+
+src/func_02067604.c:
+    .text start:0x02067604 end:0x020676e0
+
+src/func_020676e0.c:
+    complete
+    .text start:0x020676e0 end:0x020678a4
+
+src/func_020678a4.c:
+    complete
+    .text start:0x020678a4 end:0x02067928
+
+src/func_02067928.c:
+    complete
+    .text start:0x02067928 end:0x02067b68
+
+src/func_02067b68.c:
+    complete
+    .text start:0x02067b68 end:0x02067bfc
+
+src/func_02067bfc.c:
+    complete
+    .text start:0x02067bfc end:0x02067e70
+
+src/func_02067e70.c:
+    complete
+    .text start:0x02067e70 end:0x02067ee4
+
+src/func_02067ee4.c:
+    complete
+    .text start:0x02067ee4 end:0x02067f2c
+
+src/func_02067f2c.c:
+    complete
+    .text start:0x02067f2c end:0x02067f68
+
+src/func_02067f68.c:
+    complete
+    .text start:0x02067f68 end:0x02068188
+
+src/func_02068188.c:
+    complete
+    .text start:0x02068188 end:0x020681b8
+
+src/func_020681b8.c:
+    complete
+    .text start:0x020681b8 end:0x0206834c
+
+src/func_0206834c.c:
+    complete
+    .text start:0x0206834c end:0x02068398
+
+src/func_02068410.c:
+    complete
+    .text start:0x02068410 end:0x02068484
+
+src/func_02068484.c:
+    complete
+    .text start:0x02068484 end:0x020684a8
+
+src/func_020684a8.c:
+    complete
+    .text start:0x020684a8 end:0x020684d0
+
+src/func_020684d0.c:
+    complete
+    .text start:0x020684d0 end:0x02068514
+
+src/func_02068514.c:
+    complete
+    .text start:0x02068514 end:0x0206853c
+
+src/func_0206853c.c:
+    complete
+    .text start:0x0206853c end:0x020685cc
+
+src/func_020685cc.c:
+    complete
+    .text start:0x020685cc end:0x02068680
+
+src/func_02068680.c:
+    complete
+    .text start:0x02068680 end:0x0206879c
+
+src/func_0206879c.c:
+    complete
+    .text start:0x0206879c end:0x020687f8
+
+src/func_020687f8.c:
+    complete
+    .text start:0x020687f8 end:0x0206881c
+
+src/func_0206881c.c:
+    complete
+    .text start:0x0206881c end:0x02068834
+
+src/func_02068834.c:
+    complete
+    .text start:0x02068834 end:0x02068844
+
+src/func_02068844.c:
+    complete
+    .text start:0x02068844 end:0x020688b4
+
+src/func_020688b4.c:
+    complete
+    .text start:0x020688b4 end:0x020688cc
+
+src/func_020688cc.c:
+    complete
+    .text start:0x020688cc end:0x020688e4
+
+src/func_020688e4.c:
+    complete
+    .text start:0x020688e4 end:0x020688fc
+
+src/func_020688fc.c:
+    complete
+    .text start:0x020688fc end:0x02068a28
+
+src/func_02068a28.c:
+    complete
+    .text start:0x02068a28 end:0x02068a54
+
+src/func_02068a54.c:
+    complete
+    .text start:0x02068a54 end:0x02068a74
+
+src/func_02068a74.c:
+    complete
+    .text start:0x02068a74 end:0x02068ae8
+
+src/func_02068ae8.c:
+    .text start:0x02068ae8 end:0x02068d08
+
+src/func_02068d08.c:
+    complete
+    .text start:0x02068d08 end:0x02068dc8
+
+src/func_02068dc8.c:
+    complete
+    .text start:0x02068dc8 end:0x02068e44
+
+src/func_02068e44.c:
+    complete
+    .text start:0x02068e44 end:0x02068e4c
+
+src/func_02068e4c.c:
+    .text start:0x02068e4c end:0x02069038
+
+src/func_02069038.c:
+    complete
+    .text start:0x02069038 end:0x020690b0
+
+src/func_020690b0.c:
+    complete
+    .text start:0x020690b0 end:0x02069918
+
+src/func_02069918.c:
+    complete
+    .text start:0x02069918 end:0x02069994
+
+src/func_02069994.c:
+    complete
+    .text start:0x02069994 end:0x0206a230
+
+src/func_0206a230.c:
+    complete
+    .text start:0x0206a230 end:0x0206a29c
+
+src/func_0206a29c.c:
+    complete
+    .text start:0x0206a29c end:0x0206a318
+
+src/func_0206a318.c:
+    complete
+    .text start:0x0206a318 end:0x0206a37c
+
+src/func_0206a37c.c:
+    complete
+    .text start:0x0206a37c end:0x0206a3a4
+
+src/func_0206a3a4.c:
+    complete
+    .text start:0x0206a3a4 end:0x0206a424
+
+src/func_0206a424.c:
+    complete
+    .text start:0x0206a424 end:0x0206a458
+
+src/func_0206a458.c:
+    complete
+    .text start:0x0206a458 end:0x0206a4a0
+
+src/func_0206a4a0.c:
+    complete
+    .text start:0x0206a4a0 end:0x0206a5c0
+
+src/func_0206a5c0.c:
+    complete
+    .text start:0x0206a5c0 end:0x0206a600
+
+src/func_0206a600.c:
+    .text start:0x0206a600 end:0x0206a634
+
+src/func_0206a634.c:
+    complete
+    .text start:0x0206a634 end:0x0206a694
+
+src/func_0206a694.c:
+    complete
+    .text start:0x0206a694 end:0x0206a6d0
+
+src/func_0206a6d0.c:
+    complete
+    .text start:0x0206a6d0 end:0x0206a88c
+
+src/func_0206a88c.c:
+    complete
+    .text start:0x0206a88c end:0x0206a928
+
+src/func_0206bc8c.c:
+    complete
+    .text start:0x0206bc8c end:0x0206bdb4
+
+src/func_0206bdb4.c:
+    complete
+    .text start:0x0206bdb4 end:0x0206c244
+
+src/func_0206c244.c:
+    complete
+    .text start:0x0206c244 end:0x0206c51c
+
+src/func_0206c51c.c:
+    complete
+    .text start:0x0206c51c end:0x0206c8b4
+
+src/func_0206c8b4.c:
+    complete
+    .text start:0x0206c8b4 end:0x0206c90c
+
+src/func_0206c90c.c:
+    complete
+    .text start:0x0206c90c end:0x0206c93c
+
+src/func_0206c93c.c:
+    complete
+    .text start:0x0206c93c end:0x0206c9f4
+
+src/func_0206c9f4.c:
+    complete
+    .text start:0x0206c9f4 end:0x0206ca44
+
+src/func_0206ca44.c:
+    complete
+    .text start:0x0206ca44 end:0x0206ca7c
+
+src/func_0206ca7c.c:
+    complete
+    .text start:0x0206ca7c end:0x0206cb0c
+
+src/func_0206cb0c.c:
+    complete
+    .text start:0x0206cb0c end:0x0206cbc0
+
+src/func_0206cbc0.c:
+    complete
+    .text start:0x0206cbc0 end:0x0206ccd8
+
+src/func_0206ccd8.c:
+    complete
+    .text start:0x0206ccd8 end:0x0206cd44
+
+src/_ZN4cstd8__assertEPKcPKcPKci.cpp:
+    complete
+    .text start:0x0206cd44 end:0x0206cd9c
+
+src/func_0206cd9c.c:
+    complete
+    .text start:0x0206cd9c end:0x0206ce20
+
+src/func_0206ce20.c:
+    complete
+    .text start:0x0206ce20 end:0x0206ce90
+
+src/func_0206da64.c:
+    complete
+    .text start:0x0206da64 end:0x0206da94
+
+src/func_0206da94.c:
+    complete
+    .text start:0x0206da94 end:0x0206da9c
+
+src/func_0206da9c.c:
+    complete
+    .text start:0x0206da9c end:0x0206daa4
+
+src/_ZN4CP1517MPUGetDataRegion7Ev.c:
+    complete
+    .text start:0x0206daa4 end:0x0206daac
+
+src/_ZN4CP1514MPUDataRegion7Ej.c:
+    complete
+    .text start:0x0206daac end:0x0206dab4
+
+src/func_0206dab4.c:
+    complete
+    .text start:0x0206dab4 end:0x0206dabc
+
+src/_ZN4cstd14__builtin_trapEv.c:
+    complete
+    .text start:0x0206dabc end:0x0206dac4
+
+src/func_0206dac4.c:
+    complete
+    .text start:0x0206dac4 end:0x0206dbf8
+
+src/func_0206dbf8.c:
+    complete
+    .text start:0x0206dbf8 end:0x0206dc4c
+
+src/func_0206dc4c.c:
+    complete
+    .text start:0x0206dc4c end:0x0206dc7c
+
+src/func_0206dc7c.c:
+    complete
+    .text start:0x0206dc7c end:0x0206dcd4
+
+src/func_0206dcd4.c:
+    complete
+    .text start:0x0206dcd4 end:0x0206dd30
+
+src/func_0206dd30.c:
+    complete
+    .text start:0x0206dd30 end:0x0206dd7c
+
+src/func_0206dd7c.c:
+    complete
+    .text start:0x0206dd7c end:0x0206ddcc
+
+src/func_0206ddcc.c:
+    complete
+    .text start:0x0206ddcc end:0x0206de14
+
+src/func_0206de14.c:
+    complete
+    .text start:0x0206de14 end:0x0206df14
+
+src/func_0206df14.c:
+    complete
+    .text start:0x0206df14 end:0x0206df84
+
+src/_ZN4cstd3absEi.c:
+    complete
+    .text start:0x0206df84 end:0x0206df90
+
+src/func_0206df90.c:
+    complete
+    .text start:0x0206df90 end:0x0206e030
+
+src/func_0206e030.c:
+    complete
+    .text start:0x0206e030 end:0x0206e068
+
+src/func_0206e068.c:
+    complete
+    .text start:0x0206e068 end:0x0206e06c
+
+src/func_0206e06c.c:
+    complete
+    .text start:0x0206e06c end:0x0206e184
+
+src/func_0206e184.c:
+    complete
+    .text start:0x0206e184 end:0x0206e218
+
+src/func_0206e218.c:
+    complete
+    .text start:0x0206e218 end:0x0206e240
+
+src/func_0206e240.c:
+    complete
+    .text start:0x0206e240 end:0x0206e254
+
+src/func_0206e254.c:
+    complete
+    .text start:0x0206e254 end:0x0206e28c
+
+src/func_0206e28c.c:
+    complete
+    .text start:0x0206e28c end:0x0206e2cc
+
+src/func_0206e2cc.c:
+    complete
+    .text start:0x0206e2cc end:0x0206e2f8
+
+src/func_0206e2f8.c:
+    complete
+    .text start:0x0206e2f8 end:0x0206e310
+
+src/func_0206e310.c:
+    complete
+    .text start:0x0206e310 end:0x0206e330
+
+src/func_0206e3dc.c:
+    complete
+    .text start:0x0206e3dc end:0x0206e450
+
+src/func_0206e450.c:
+    complete
+    .text start:0x0206e450 end:0x0206e4a4
+
+src/func_0206e4a4.c:
+    complete
+    .text start:0x0206e4a4 end:0x0206ece0
+
+src/func_0206ece0.c:
+    .text start:0x0206ece0 end:0x0206f338
+
+src/func_0206f338.c:
+    complete
+    .text start:0x0206f338 end:0x0206f46c
+
+src/func_0206f46c.c:
+    .text start:0x0206f46c end:0x0206f820
+
+src/func_0206f820.c:
+    .text start:0x0206f820 end:0x0206fb08
+
+src/func_0206fb08.c:
+    .text start:0x0206fb08 end:0x0206fd6c
+
+src/func_0206fd6c.c:
+    complete
+    .text start:0x0206fd6c end:0x02070348
+
+src/func_02070348.c:
+    complete
+    .text start:0x02070348 end:0x0207037c
+
+src/func_0207037c.c:
+    complete
+    .text start:0x0207037c end:0x020704cc
+
+src/_ZN4cstd6strchrEPKcc.cpp:
+    complete
+    .text start:0x020704cc end:0x02070508
+
+src/_ZN4cstd6strcmpEPKcS1_.cpp:
+    complete
+    .text start:0x02070508 end:0x0207063c
+
+src/_ZN4cstd7strncpyEPcPKcj.c:
+    complete
+    .text start:0x0207063c end:0x020706b0
+
+src/func_020706b0.c:
+    complete
+    .text start:0x020706b0 end:0x02070788
+
+src/_ZN4cstd6strlenEPKc.c:
+    complete
+    .text start:0x02070788 end:0x020707a4
+
+src/func_020707a4.c:
+    complete
+    .text start:0x020707a4 end:0x020707cc
+
+src/func_020707cc.c:
+    complete
+    .text start:0x020707cc end:0x020707f4
+
+src/func_020707f4.c:
+    complete
+    .text start:0x020707f4 end:0x020708b4
+
+src/func_020708b4.c:
+    .text start:0x020708b4 end:0x02070b98
+
+src/func_02070b98.c:
+    complete
+    .text start:0x02070b98 end:0x02070c68
+
+src/func_02070c68.c:
+    .text start:0x02070c68 end:0x02070ec0
+
+src/func_02070ec0.c:
+    complete
+    .text start:0x02070ec0 end:0x020712a0
+
+src/func_020712a0.c:
+    complete
+    .text start:0x020712a0 end:0x02071364
+
+src/func_02071364.c:
+    complete
+    .text start:0x02071364 end:0x02071510
+
+src/func_02071510.c:
+    .text start:0x02071510 end:0x020715e0
+
+src/func_020715e0.c:
+    complete
+    .text start:0x020715e0 end:0x02071644
+
+src/func_02071694.c:
+    complete
+    .text start:0x02071694 end:0x02071698
+
+src/func_02071698.c:
+    complete
+    .text start:0x02071698 end:0x02071708
+
+src/func_02071708.c:
+    complete
+    .text start:0x02071708 end:0x02071784
+
+src/func_02071784.c:
+    complete
+    .text start:0x02071784 end:0x02071790
+
+src/func_0207180c.c:
+    complete
+    .text start:0x0207180c end:0x02071844
+
+src/func_02071844.c:
+    complete
+    .text start:0x02071844 end:0x02071864
+
+src/func_02071864.c:
+    complete
+    .text start:0x02071864 end:0x02071910
+
+src/func_02071910.c:
+    complete
+    .text start:0x02071910 end:0x02071974
+
+src/func_02071974.c:
+    complete
+    .text start:0x02071974 end:0x02071988
+
+src/func_02071988.c:
+    complete
+    .text start:0x02071988 end:0x0207199c
+
+src/func_0207199c.c:
+    complete
+    .text start:0x0207199c end:0x020719ac
+
+src/func_020719ac.c:
+    complete
+    .text start:0x020719ac end:0x020719b4
+
+src/func_020719b4.c:
+    complete
+    .text start:0x020719b4 end:0x020719ec
+
+src/func_020719ec.c:
+    complete
+    .text start:0x020719ec end:0x02071a50
+
+src/func_02071a50.c:
+    complete
+    .text start:0x02071a50 end:0x02071af8
+
+src/ReadSignedVarInt.c:
+    complete
+    .text start:0x02071af8 end:0x02071ba0
+
+src/func_02071ba0.c:
+    complete
+    .text start:0x02071ba0 end:0x02071be8
+
+src/func_02071be8.c:
+    complete
+    .text start:0x02071be8 end:0x02071ccc
+
+src/func_02071ccc.c:
+    complete
+    .text start:0x02071ccc end:0x02071d3c
+
+src/func_02071d3c.c:
+    complete
+    .text start:0x02071d3c end:0x02071f1c
+
+src/func_02071f1c.c:
+    complete
+    .text start:0x02071f1c end:0x02071f88
+
+src/func_02071f88.c:
+    complete
+    .text start:0x02071f88 end:0x02072014
+
+src/func_02072014.c:
+    complete
+    .text start:0x02072014 end:0x02072168
+
+src/func_020729f4.c:
+    complete
+    .text start:0x020729f4 end:0x02072d90
+
+src/func_02072d90.c:
+    complete
+    .text start:0x02072d90 end:0x02072dac
+
+src/func_02072dac.c:
+    complete
+    .text start:0x02072dac end:0x02072ed0
+
+src/func_02072ed0.c:
+    complete
+    .text start:0x02072ed0 end:0x02072f3c
+
+src/func_02072f3c.c:
+    complete
+    .text start:0x02072f3c end:0x02072f94
+
+src/func_02072f94.c:
+    complete
+    .text start:0x02072f94 end:0x02072fcc
+
+src/func_02072fcc.c:
+    complete
+    .text start:0x02072fcc end:0x020731dc
+
+src/func_020731dc.c:
+    complete
+    .text start:0x020731dc end:0x020731fc
+
+src/func_020731fc.c:
+    complete
+    .text start:0x020731fc end:0x02073220
+
+src/func_02073220.c:
+    complete
+    .text start:0x02073220 end:0x0207322c
+
+src/func_0207322c.c:
+    complete
+    .text start:0x0207322c end:0x02073238
+
+src/func_02073238.c:
+    complete
+    .text start:0x02073238 end:0x02073244
+
+src/func_02073244.c:
+    complete
+    .text start:0x02073244 end:0x0207328c
+
+src/func_0207359c.c:
+    complete
+    .text start:0x0207359c end:0x020735c8
+
+src/func_020735c8.c:
+    complete
+    .text start:0x020735c8 end:0x020735ec
+
+src/func_020735ec.c:
+    complete
+    .text start:0x020735ec end:0x02073618
+
+src/func_02073618.c:
+    complete
+    .text start:0x02073618 end:0x0207363c
+
+src/func_0207363c.c:
+    complete
+    .text start:0x0207363c end:0x02073660
+
+src/func_02073660.c:
+    complete
+    .text start:0x02073660 end:0x0207368c
+
+src/func_0207368c.c:
+    complete
+    .text start:0x0207368c end:0x020736b0
+
+src/func_020736b0.c:
+    complete
+    .text start:0x020736b0 end:0x020736c0
+
+src/func_020736c0.c:
+    complete
+    .text start:0x020736c0 end:0x020736e4
+
+src/func_020736e4.c:
+    complete
+    .text start:0x020736e4 end:0x020736f4
+
+src/__sinit_02073a24.c:
+    .init start:0x02073a24 end:0x02073e6c
+
+src/__sinit_02073e6c.c:
+    .init start:0x02073e6c end:0x02074d90
+
+src/__sinit_02074d90.c:
+    .init start:0x02074d90 end:0x02074da8
+
+src/__sinit_02074da8.c:
+    .init start:0x02074da8 end:0x02074dbc
+
+src/__sinit_02074dbc.c:
+    .init start:0x02074dbc end:0x02074dc0
+
+src/__sinit_02074dc0.c:
+    .init start:0x02074dc0 end:0x02074dc4
+
+src/__sinit_02074dc4.c:
+    .init start:0x02074dc4 end:0x02074e0c
+
+src/__sinit_02074e0c.c:
+    .init start:0x02074e0c end:0x02074e44
+
+src/__sinit_02074e44.c:
+    .init start:0x02074e44 end:0x02074e80
+
+src/__sinit_02074e80.c:
+    .init start:0x02074e80 end:0x02074e84
+
+src/__sinit_02074e84.cpp:
+    .init start:0x02074e84 end:0x02074edc
+
+src/__sinit_02074edc.c:
+    .init start:0x02074edc end:0x02074f80
+
+src/__sinit_02074f80.c:
+    .init start:0x02074f80 end:0x02074fb8
+
+src/__sinit_02074fb8.c:
+    .init start:0x02074fb8 end:0x02074fe4
+
+src/__sinit_02074fe4.c:
+    .init start:0x02074fe4 end:0x0207501c
+
+src/__sinit_0207501c.c:
+    .init start:0x0207501c end:0x02075054
+
+src/__sinit_02075054.c:
+    .init start:0x02075054 end:0x020750b4
+
+src/__sinit_020750b4.c:
+    .init start:0x020750b4 end:0x020750b8
+
+src/__sinit_020750b8.c:
+    .init start:0x020750b8 end:0x020750ec
+
+src/__sinit_020750ec.c:
+    .init start:0x020750ec end:0x0207511c
+
+src/__sinit_0207511c.c:
+    .init start:0x0207511c end:0x02075150
+
+src/__sinit_02075150.c:
+    .init start:0x02075150 end:0x02075154
+
+src/__sinit_02075154.c:
+    .init start:0x02075154 end:0x02075230

--- a/config/arm9/overlays/ov000/delinks.txt
+++ b/config/arm9/overlays/ov000/delinks.txt
@@ -2,3 +2,6 @@
     .ctor       start:0x020aa4c8 end:0x020aa4c8 kind:rodata align:4
     .data       start:0x020aa4e0 end:0x020bf4e0 kind:data align:32
     .bss        start:0x020bf4e0 end:0x020bf4e0 kind:bss align:32
+src/func_ov000_020aa420.c:
+    complete
+    .text start:0x020aa420 end:0x020aa4c8

--- a/config/arm9/overlays/ov001/delinks.txt
+++ b/config/arm9/overlays/ov001/delinks.txt
@@ -3,3 +3,93 @@
     .ctor       start:0x020ab7e4 end:0x020ab7e4 kind:rodata align:4
     .data       start:0x020ab800 end:0x020ad620 kind:data align:32
     .bss        start:0x020ad620 end:0x020ad660 kind:bss align:32
+src/func_ov001_020aa420.c:
+    complete
+    .text start:0x020aa420 end:0x020aa6b0
+
+src/func_ov001_020aa6b0.c:
+    complete
+    .text start:0x020aa6b0 end:0x020aa6cc
+
+src/func_ov001_020aa6cc.c:
+    complete
+    .text start:0x020aa6cc end:0x020aa6e4
+
+src/func_ov001_020aa6e4.cpp:
+    complete
+    .text start:0x020aa6e4 end:0x020aa79c
+
+src/func_ov001_020aa79c.c:
+    complete
+    .text start:0x020aa79c end:0x020aa7b8
+
+src/func_ov001_020aa7b8.cpp:
+    complete
+    .text start:0x020aa7b8 end:0x020aa858
+
+src/func_ov001_020aa858.cpp:
+    complete
+    .text start:0x020aa858 end:0x020aa960
+
+src/func_ov001_020aa960.cpp:
+    complete
+    .text start:0x020aa960 end:0x020aaa54
+
+src/func_ov001_020aaa54.cpp:
+    complete
+    .text start:0x020aaa54 end:0x020aadac
+
+src/func_ov001_020aadac.c:
+    complete
+    .text start:0x020aadac end:0x020aaf40
+
+src/func_ov001_020aaf40.c:
+    complete
+    .text start:0x020aaf40 end:0x020ab110
+
+src/func_ov001_020ab110.c:
+    .text start:0x020ab110 end:0x020ab228
+
+src/func_ov001_020ab228.c:
+    complete
+    .text start:0x020ab228 end:0x020ab2e4
+
+src/func_ov001_020ab2e4.c:
+    complete
+    .text start:0x020ab2e4 end:0x020ab374
+
+src/func_ov001_020ab374.c:
+    complete
+    .text start:0x020ab374 end:0x020ab3a0
+
+src/func_ov001_020ab3a0.c:
+    complete
+    .text start:0x020ab3a0 end:0x020ab3c4
+
+src/func_ov001_020ab3c4.c:
+    complete
+    .text start:0x020ab3c4 end:0x020ab3f0
+
+src/func_ov001_020ab3f0.c:
+    complete
+    .text start:0x020ab3f0 end:0x020ab41c
+
+src/func_ov001_020ab41c.c:
+    complete
+    .text start:0x020ab41c end:0x020ab450
+
+src/TouchArea_Update.c:
+    complete
+    .text start:0x020ab450 end:0x020ab54c
+
+src/func_ov001_020ab54c.c:
+    complete
+    .text start:0x020ab54c end:0x020ab550
+
+src/func_ov001_020ab550.c:
+    complete
+    .text start:0x020ab550 end:0x020ab5b0
+
+src/func_ov001_020ab5b0.c:
+    complete
+    .text start:0x020ab5b0 end:0x020ab5f8

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -4,3 +4,5745 @@
     .ctor       start:0x021080d0 end:0x02108138 kind:rodata align:4
     .data       start:0x02108140 end:0x0210d9a0 kind:data align:32
     .bss        start:0x0210d9a0 end:0x021111a0 kind:bss align:32
+src/func_ov002_020ad660.cpp:
+    complete
+    .text start:0x020ad660 end:0x020ad838
+
+src/_ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj.cpp:
+    complete
+    .text start:0x020ad838 end:0x020ada40
+
+src/func_ov002_020ada40.cpp:
+    complete
+    .text start:0x020ada40 end:0x020adb40
+
+src/_ZN5Enemy22SpawnMegaCharParticlesER5ActorPc.cpp:
+    .text start:0x020adb40 end:0x020addc0
+
+src/_ZN5Enemy27SpawnParticlesIfHitOtherObjER12CylinderClsn.cpp:
+    complete
+    .text start:0x020addc0 end:0x020ade78
+
+src/_ZN5Enemy24AngleAwayFromWallOrCliffER12WithMeshClsnRs.cpp:
+    complete
+    .text start:0x020ae244 end:0x020ae2b8
+
+src/_ZN5Enemy15IsGoingOffCliffER12WithMeshClsn5Fix12IiEsbbS3_.cpp:
+    .text start:0x020ae2b8 end:0x020ae454
+
+src/func_ov002_020ae454.cpp:
+    complete
+    .text start:0x020ae454 end:0x020ae4cc
+
+src/func_ov002_020ae4cc.cpp:
+    complete
+    .text start:0x020ae4cc end:0x020ae5c8
+
+src/func_ov002_020ae5c8.c:
+    complete
+    .text start:0x020ae5c8 end:0x020ae608
+
+src/func_ov002_020ae608.c:
+    complete
+    .text start:0x020ae608 end:0x020ae64c
+
+src/func_ov002_020ae64c.c:
+    complete
+    .text start:0x020ae64c end:0x020ae6a8
+
+src/_ZN5Enemy11UpdateDeathER12WithMeshClsn.cpp:
+    complete
+    .text start:0x020ae6a8 end:0x020ae73c
+
+src/func_ov002_020ae73c.c:
+    complete
+    .text start:0x020ae73c end:0x020ae80c
+
+src/func_ov002_020ae80c.c:
+    complete
+    .text start:0x020ae80c end:0x020ae844
+
+src/func_ov002_020ae844.c:
+    complete
+    .text start:0x020ae844 end:0x020ae87c
+
+src/func_ov002_020ae87c.c:
+    complete
+    .text start:0x020ae87c end:0x020ae890
+
+src/func_ov002_020ae890.c:
+    complete
+    .text start:0x020ae890 end:0x020ae8b8
+
+src/func_ov002_020ae8b8.c:
+    complete
+    .text start:0x020ae8b8 end:0x020ae954
+
+src/func_ov002_020ae954.c:
+    complete
+    .text start:0x020ae954 end:0x020ae968
+
+src/func_ov002_020ae968.c:
+    complete
+    .text start:0x020ae968 end:0x020ae9f8
+
+src/func_ov002_020ae9f8.c:
+    complete
+    .text start:0x020ae9f8 end:0x020aea24
+
+src/func_ov002_020aea24.c:
+    complete
+    .text start:0x020aea24 end:0x020aea2c
+
+src/func_ov002_020aea2c.c:
+    complete
+    .text start:0x020aea2c end:0x020aea30
+
+src/func_ov002_020aea30.c:
+    complete
+    .text start:0x020aea30 end:0x020aeabc
+
+src/_ZN5Enemy9SpawnCoinEv.cpp:
+    complete
+    .text start:0x020aeabc end:0x020aebf8
+
+src/_ZN5Enemy12UpdateWMClsnER12WithMeshClsnj.cpp:
+    complete
+    .text start:0x020aebf8 end:0x020aed18
+
+src/func_ov002_020aed18.c:
+    complete
+    .text start:0x020aed18 end:0x020aed3c
+
+src/_ZN5EnemyD0Ev.c:
+    .text start:0x020aed3c end:0x020aed74
+
+src/_ZN5EnemyD2Ev.c:
+    complete
+    .text start:0x020aed74 end:0x020aed98
+
+src/func_ov002_020aed98.cpp:
+    complete
+    .text start:0x020aed98 end:0x020aedbc
+
+src/func_ov002_020aedbc.c:
+    .text start:0x020aedbc end:0x020aedf4
+
+src/_ZN8CapEnemyD0Ev.c:
+    .text start:0x020aedf4 end:0x020aee40
+
+src/_ZN13OneUpMushroomD1Ev.c:
+    complete
+    .text start:0x020aee40 end:0x020aee88
+
+src/_ZN13OneUpMushroomD0Ev.c:
+    complete
+    .text start:0x020aee88 end:0x020aeee4
+
+src/func_ov002_020aeee4.cpp:
+    complete
+    .text start:0x020aeee4 end:0x020aefa4
+
+src/func_ov002_020aefa4.c:
+    complete
+    .text start:0x020aefa4 end:0x020aefb8
+
+src/func_ov002_020aefb8.c:
+    .text start:0x020aefb8 end:0x020af0c0
+
+src/func_ov002_020af0c0.c:
+    complete
+    .text start:0x020af0c0 end:0x020af1dc
+
+src/func_ov002_020af1dc.c:
+    complete
+    .text start:0x020af1dc end:0x020af218
+
+src/func_ov002_020af218.c:
+    complete
+    .text start:0x020af218 end:0x020af248
+
+src/func_ov002_020af248.c:
+    complete
+    .text start:0x020af248 end:0x020af2b0
+
+src/func_ov002_020af2b0.c:
+    complete
+    .text start:0x020af2b0 end:0x020af3a0
+
+src/func_ov002_020af3a0.c:
+    complete
+    .text start:0x020af3a0 end:0x020af3a8
+
+src/func_ov002_020af3a8.c:
+    complete
+    .text start:0x020af3a8 end:0x020af474
+
+src/func_ov002_020af474.c:
+    complete
+    .text start:0x020af474 end:0x020af4ec
+
+src/func_ov002_020af4ec.cpp:
+    complete
+    .text start:0x020af4ec end:0x020af684
+
+src/func_ov002_020af684.cpp:
+    complete
+    .text start:0x020af684 end:0x020af724
+
+src/func_ov002_020af724.c:
+    complete
+    .text start:0x020af724 end:0x020af7cc
+
+src/func_ov002_020af7cc.c:
+    complete
+    .text start:0x020af7cc end:0x020af838
+
+src/func_ov002_020af838.c:
+    complete
+    .text start:0x020af838 end:0x020af908
+
+src/func_ov002_020af908.c:
+    complete
+    .text start:0x020af908 end:0x020af924
+
+src/func_ov002_020af924.c:
+    complete
+    .text start:0x020af924 end:0x020af950
+
+src/func_ov002_020af950.c:
+    complete
+    .text start:0x020af950 end:0x020afa50
+
+src/func_ov002_020afa50.c:
+    complete
+    .text start:0x020afa50 end:0x020afa6c
+
+src/func_ov002_020afa6c.c:
+    complete
+    .text start:0x020afa6c end:0x020afa98
+
+src/func_ov002_020afa98.c:
+    complete
+    .text start:0x020afa98 end:0x020afbb4
+
+src/func_ov002_020afbb4.c:
+    complete
+    .text start:0x020afbb4 end:0x020afc44
+
+src/func_ov002_020afc44.c:
+    complete
+    .text start:0x020afc44 end:0x020afc68
+
+src/func_ov002_020afc68.cpp:
+    complete
+    .text start:0x020afc68 end:0x020afd10
+
+src/func_ov002_020afd10.c:
+    complete
+    .text start:0x020afd10 end:0x020afde4
+
+src/func_ov002_020afde4.cpp:
+    complete
+    .text start:0x020afde4 end:0x020afe4c
+
+src/func_ov002_020afe4c.cpp:
+    complete
+    .text start:0x020afe4c end:0x020aff10
+
+src/func_ov002_020aff10.c:
+    complete
+    .text start:0x020aff10 end:0x020affe8
+
+src/_ZN13OneUpMushroom16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020affe8 end:0x020b006c
+
+src/_ZN13OneUpMushroom16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020b006c end:0x020b0070
+
+src/_ZN13OneUpMushroom6RenderEv.cpp:
+    complete
+    .text start:0x020b0070 end:0x020b00e8
+
+src/_ZN13OneUpMushroom8BehaviorEv.cpp:
+    .text start:0x020b00e8 end:0x020b01c0
+
+src/_ZN13OneUpMushroom13InitResourcesEv.cpp:
+    .text start:0x020b01c0 end:0x020b0530
+
+src/MegaMushroom_Spawn.c:
+    complete
+    .text start:0x020b0530 end:0x020b0580
+
+src/OneUpMushroom_Spawn.c:
+    complete
+    .text start:0x020b0580 end:0x020b05d0
+
+src/func_ov002_020b05d0.c:
+    .text start:0x020b05d0 end:0x020b0600
+
+src/func_ov002_020b0600.c:
+    .text start:0x020b0600 end:0x020b0644
+
+src/func_ov002_020b0644.c:
+    complete
+    .text start:0x020b0644 end:0x020b064c
+
+src/func_ov002_020b064c.c:
+    complete
+    .text start:0x020b064c end:0x020b0650
+
+src/func_ov002_020b0650.c:
+    complete
+    .text start:0x020b0650 end:0x020b0658
+
+src/func_ov002_020b0658.cpp:
+    complete
+    .text start:0x020b0658 end:0x020b067c
+
+src/func_ov002_020b067c.c:
+    complete
+    .text start:0x020b067c end:0x020b0710
+
+src/InvisiblePole_Spawn.c:
+    .text start:0x020b0710 end:0x020b0748
+
+src/_ZN13InvisiblePoleD1Ev.cpp:
+    .text start:0x020b0748 end:0x020b076c
+
+src/_ZN13InvisiblePoleD0Ev.c:
+    complete
+    .text start:0x020b076c end:0x020b07a4
+
+src/_ZN13InvisiblePole16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b07a4 end:0x020b07ac
+
+src/_ZN13InvisiblePole16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020b07ac end:0x020b07b0
+
+src/_ZN13InvisiblePole6RenderEv.c:
+    complete
+    .text start:0x020b07b0 end:0x020b07b8
+
+src/_ZN13InvisiblePole8BehaviorEv.c:
+    complete
+    .text start:0x020b07b8 end:0x020b07c0
+
+src/_ZN13InvisiblePole13InitResourcesEv.c:
+    complete
+    .text start:0x020b07c0 end:0x020b07c8
+
+src/CameraTag_Spawn.c:
+    complete
+    .text start:0x020b07c8 end:0x020b07f8
+
+src/_ZN9CameraTagD1Ev.cpp:
+    .text start:0x020b07f8 end:0x020b081c
+
+src/_ZN9CameraTagD0Ev.c:
+    .text start:0x020b081c end:0x020b0854
+
+src/_ZN9CameraTag16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b0854 end:0x020b085c
+
+src/_ZN9CameraTag16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020b085c end:0x020b0860
+
+src/_ZN9CameraTag6RenderEv.c:
+    complete
+    .text start:0x020b0860 end:0x020b0868
+
+src/_ZN9CameraTag8BehaviorEv.cpp:
+    .text start:0x020b0868 end:0x020b0938
+
+src/_ZN9CameraTag13InitResourcesEv.cpp:
+    complete
+    .text start:0x020b0938 end:0x020b0980
+
+src/VirtualDoor_Spawn.c:
+    complete
+    .text start:0x020b0980 end:0x020b09b0
+
+src/_ZN11VirtualDoorD1Ev.cpp:
+    .text start:0x020b09b0 end:0x020b09d4
+
+src/_ZN11VirtualDoorD0Ev.c:
+    .text start:0x020b09d4 end:0x020b0a0c
+
+src/func_ov002_020b0a0c.c:
+    complete
+    .text start:0x020b0a0c end:0x020b0a70
+
+src/_ZN11VirtualDoor16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b0a70 end:0x020b0a78
+
+src/_ZN11VirtualDoor16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020b0a78 end:0x020b0a7c
+
+src/_ZN11VirtualDoor6RenderEv.c:
+    complete
+    .text start:0x020b0a7c end:0x020b0a84
+
+src/_ZN11VirtualDoor8BehaviorEv.cpp:
+    complete
+    .text start:0x020b0a84 end:0x020b0d88
+
+src/_ZN11VirtualDoor13InitResourcesEv.cpp:
+    complete
+    .text start:0x020b0d88 end:0x020b0f24
+
+src/Exit_Spawn.c:
+    complete
+    .text start:0x020b0f24 end:0x020b0f54
+
+src/_ZN4CoinD1Ev.cpp:
+    .text start:0x020b0f54 end:0x020b0fa4
+
+src/_ZN4CoinD0Ev.c:
+    complete
+    .text start:0x020b0fa4 end:0x020b1008
+
+src/func_ov002_020b1008.c:
+    complete
+    .text start:0x020b1008 end:0x020b10a0
+
+src/func_ov002_020b10a0.c:
+    complete
+    .text start:0x020b10a0 end:0x020b10e4
+
+src/func_ov002_020b10e4.c:
+    complete
+    .text start:0x020b10e4 end:0x020b12ec
+
+src/func_ov002_020b12ec.c:
+    complete
+    .text start:0x020b12ec end:0x020b1328
+
+src/func_ov002_020b1328.c:
+    complete
+    .text start:0x020b1328 end:0x020b1384
+
+src/func_ov002_020b1384.cpp:
+    complete
+    .text start:0x020b1384 end:0x020b13e0
+
+src/func_ov002_020b13e0.cpp:
+    complete
+    .text start:0x020b13e0 end:0x020b14d8
+
+src/func_ov002_020b14d8.c:
+    complete
+    .text start:0x020b14d8 end:0x020b1674
+
+src/func_ov002_020b1674.cpp:
+    complete
+    .text start:0x020b1674 end:0x020b16c4
+
+src/func_ov002_020b16c4.c:
+    complete
+    .text start:0x020b16c4 end:0x020b1884
+
+src/func_ov002_020b1884.c:
+    complete
+    .text start:0x020b1884 end:0x020b18f0
+
+src/func_ov002_020b18f0.c:
+    complete
+    .text start:0x020b18f0 end:0x020b19dc
+
+src/func_ov002_020b19dc.c:
+    complete
+    .text start:0x020b19dc end:0x020b1a60
+
+src/func_ov002_020b1a60.c:
+    complete
+    .text start:0x020b1a60 end:0x020b1ad4
+
+src/func_ov002_020b1ad4.c:
+    complete
+    .text start:0x020b1ad4 end:0x020b1bfc
+
+src/func_ov002_020b1bfc.cpp:
+    complete
+    .text start:0x020b1bfc end:0x020b1cc0
+
+src/func_ov002_020b1cc0.c:
+    complete
+    .text start:0x020b1cc0 end:0x020b2070
+
+src/func_ov002_020b2070.cpp:
+    complete
+    .text start:0x020b2070 end:0x020b20b4
+
+src/func_ov002_020b20b4.cpp:
+    complete
+    .text start:0x020b20b4 end:0x020b2150
+
+src/func_ov002_020b2150.cpp:
+    .text start:0x020b2150 end:0x020b2198
+
+src/_ZN4Coin16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b2198 end:0x020b2284
+
+src/_ZN4Coin6RenderEv.cpp:
+    complete
+    .text start:0x020b2284 end:0x020b2324
+
+src/_ZN4Coin8BehaviorEv.cpp:
+    .text start:0x020b2324 end:0x020b2508
+
+src/_ZN4Coin13InitResourcesEv.c:
+    complete
+    .text start:0x020b2508 end:0x020b2a34
+
+src/func_ov002_020b2a34.c:
+    complete
+    .text start:0x020b2a34 end:0x020b2a90
+
+src/func_ov002_020b2a90.c:
+    complete
+    .text start:0x020b2a90 end:0x020b2a98
+
+src/BlueCoin_Spawn.c:
+    complete
+    .text start:0x020b2a98 end:0x020b2af0
+
+src/RedCoin_Spawn.c:
+    complete
+    .text start:0x020b2af0 end:0x020b2b48
+
+src/Coin_Spawn.c:
+    complete
+    .text start:0x020b2b48 end:0x020b2ba0
+
+src/_ZN11WingFeatherD1Ev.cpp:
+    .text start:0x020b2ba0 end:0x020b2be8
+
+src/_ZN11WingFeatherD0Ev.c:
+    complete
+    .text start:0x020b2be8 end:0x020b2c44
+
+src/func_ov002_020b2c44.cpp:
+    complete
+    .text start:0x020b2c44 end:0x020b2e30
+
+src/_ZN11WingFeather16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b2e30 end:0x020b2e54
+
+src/_ZN11WingFeather6RenderEv.cpp:
+    complete
+    .text start:0x020b2e54 end:0x020b2e9c
+
+src/_ZN11WingFeather8BehaviorEv.cpp:
+    complete
+    .text start:0x020b2e9c end:0x020b311c
+
+src/_ZN11WingFeather13InitResourcesEv.cpp:
+    .text start:0x020b311c end:0x020b3248
+
+src/WingFeather_Spawn.c:
+    complete
+    .text start:0x020b3248 end:0x020b3298
+
+src/func_ov002_020b3298.c:
+    .text start:0x020b3298 end:0x020b32c8
+
+src/func_ov002_020b32c8.c:
+    .text start:0x020b32c8 end:0x020b330c
+
+src/func_ov002_020b330c.cpp:
+    complete
+    .text start:0x020b330c end:0x020b3344
+
+src/func_ov002_020b3344.c:
+    complete
+    .text start:0x020b3344 end:0x020b33dc
+
+src/func_ov002_020b33dc.cpp:
+    .text start:0x020b33dc end:0x020b3518
+
+src/func_ov002_020b3518.cpp:
+    complete
+    .text start:0x020b3518 end:0x020b3568
+
+src/Bubble_Spawn.c:
+    .text start:0x020b3568 end:0x020b35a0
+
+src/_ZN13BigBrickBlockD1Ev.c:
+    .text start:0x020b35a0 end:0x020b35e4
+
+src/_ZN13BigBrickBlockD0Ev.c:
+    .text start:0x020b35e4 end:0x020b363c
+
+src/func_ov002_020b363c.c:
+    complete
+    .text start:0x020b363c end:0x020b36a0
+
+src/func_ov002_020b36a0.c:
+    complete
+    .text start:0x020b36a0 end:0x020b36b4
+
+src/func_ov002_020b36b4.cpp:
+    complete
+    .text start:0x020b36b4 end:0x020b36dc
+
+src/func_ov002_020b36dc.cpp:
+    complete
+    .text start:0x020b36dc end:0x020b3788
+
+src/func_ov002_020b3788.cpp:
+    complete
+    .text start:0x020b3788 end:0x020b37ec
+
+src/func_ov002_020b37ec.c:
+    complete
+    .text start:0x020b37ec end:0x020b382c
+
+src/func_ov002_020b382c.cpp:
+    complete
+    .text start:0x020b382c end:0x020b38a0
+
+src/func_ov002_020b38a0.c:
+    complete
+    .text start:0x020b38a0 end:0x020b3ab0
+
+src/_ZN13BigBrickBlock16CleanupResourcesEv.cpp:
+    .text start:0x020b3ab0 end:0x020b3b14
+
+src/_ZN13BigBrickBlock6RenderEv.cpp:
+    complete
+    .text start:0x020b3b14 end:0x020b3c0c
+
+src/_ZN13BigBrickBlock8BehaviorEv.cpp:
+    .text start:0x020b3c0c end:0x020b3d78
+
+src/_ZN13BigBrickBlock13InitResourcesEv.c:
+    complete
+    .text start:0x020b3d78 end:0x020b406c
+
+src/FortressTowerWall_Spawn.c:
+    complete
+    .text start:0x020b406c end:0x020b409c
+
+src/BlackBrickBlock_Spawn.c:
+    complete
+    .text start:0x020b409c end:0x020b40cc
+
+src/BrickBlockSwitchActivated_Spawn.c:
+    complete
+    .text start:0x020b40cc end:0x020b40fc
+
+src/BigBrickBlock_Spawn.c:
+    complete
+    .text start:0x020b40fc end:0x020b412c
+
+src/BrickBlock_Spawn.c:
+    complete
+    .text start:0x020b412c end:0x020b415c
+
+src/_ZN10BrickBlockD1Ev.cpp:
+    .text start:0x020b415c end:0x020b4180
+
+src/_ZN10BrickBlockD0Ev.c:
+    .text start:0x020b4180 end:0x020b41b8
+
+src/func_ov002_020b41b8.c:
+    complete
+    .text start:0x020b41b8 end:0x020b41f8
+
+src/func_ov002_020b41f8.cpp:
+    complete
+    .text start:0x020b41f8 end:0x020b4250
+
+src/func_ov002_020b4250.cpp:
+    complete
+    .text start:0x020b4250 end:0x020b429c
+
+src/func_ov002_020b429c.cpp:
+    complete
+    .text start:0x020b429c end:0x020b42e4
+
+src/func_ov002_020b42e4.c:
+    complete
+    .text start:0x020b42e4 end:0x020b4394
+
+src/_ZN10BrickBlock16CleanupResourcesEv.cpp:
+    .text start:0x020b4394 end:0x020b440c
+
+src/_ZN10BrickBlock8BehaviorEv.cpp:
+    complete
+    .text start:0x020b440c end:0x020b451c
+
+src/_ZN10BrickBlock13InitResourcesEv.cpp:
+    complete
+    .text start:0x020b451c end:0x020b45e0
+
+src/SilverStarBlockTag_Spawn.c:
+    complete
+    .text start:0x020b45e0 end:0x020b4610
+
+src/GreenShellBlockTag_Spawn.c:
+    complete
+    .text start:0x020b4610 end:0x020b4640
+
+src/MegaMushroomBlockTag_Spawn.c:
+    complete
+    .text start:0x020b4640 end:0x020b4670
+
+src/OneUpMushroomBlockTag_Spawn.c:
+    complete
+    .text start:0x020b4670 end:0x020b46a0
+
+src/_ZN21MegaMushroomCreateTagD1Ev.cpp:
+    .text start:0x020b46a0 end:0x020b46d0
+
+src/_ZN21MegaMushroomCreateTagD0Ev.c:
+    complete
+    .text start:0x020b46d0 end:0x020b4714
+
+src/func_ov002_020b4714.c:
+    complete
+    .text start:0x020b4714 end:0x020b47ec
+
+src/func_ov002_020b47ec.c:
+    complete
+    .text start:0x020b47ec end:0x020b482c
+
+src/_ZN21MegaMushroomCreateTag16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b482c end:0x020b4850
+
+src/_ZN21MegaMushroomCreateTag8BehaviorEv.cpp:
+    .text start:0x020b4850 end:0x020b49a8
+
+src/_ZN21MegaMushroomCreateTag13InitResourcesEv.c:
+    complete
+    .text start:0x020b49a8 end:0x020b4a00
+
+src/MegaMushroomCreateTag_Spawn.c:
+    complete
+    .text start:0x020b4a00 end:0x020b4a38
+
+src/MegaMushroomTag_Spawn.c:
+    complete
+    .text start:0x020b4a38 end:0x020b4a70
+
+src/func_ov002_020b4a70.c:
+    complete
+    .text start:0x020b4a70 end:0x020b4af8
+
+src/func_ov002_020b4af8.c:
+    complete
+    .text start:0x020b4af8 end:0x020b4b6c
+
+src/func_ov002_020b4b6c.c:
+    complete
+    .text start:0x020b4b6c end:0x020b4bc4
+
+src/func_ov002_020b4bc4.cpp:
+    complete
+    .text start:0x020b4bc4 end:0x020b4bfc
+
+src/func_ov002_020b4bfc.c:
+    complete
+    .text start:0x020b4bfc end:0x020b4d58
+
+src/func_ov002_020b4d58.c:
+    complete
+    .text start:0x020b4d58 end:0x020b4ed8
+
+src/_ZN14QuestionSwitchD1Ev.cpp:
+    complete
+    .text start:0x020b4ed8 end:0x020b4f44
+
+src/_ZN14QuestionSwitchD0Ev.c:
+    complete
+    .text start:0x020b4f44 end:0x020b4fc4
+
+src/func_ov002_020b4fc4.c:
+    complete
+    .text start:0x020b4fc4 end:0x020b4fd0
+
+src/func_ov002_020b4fd0.c:
+    complete
+    .text start:0x020b4fd0 end:0x020b503c
+
+src/func_ov002_020b503c.cpp:
+    complete
+    .text start:0x020b503c end:0x020b50a0
+
+src/func_ov002_020b50a0.c:
+    complete
+    .text start:0x020b50a0 end:0x020b512c
+
+src/_ZN14QuestionSwitch16CleanupResourcesEv.cpp:
+    .text start:0x020b512c end:0x020b51ac
+
+src/_ZN14QuestionSwitch6RenderEv.cpp:
+    complete
+    .text start:0x020b51ac end:0x020b51dc
+
+src/_ZN14QuestionSwitch8BehaviorEv.cpp:
+    complete
+    .text start:0x020b51dc end:0x020b5500
+
+src/_ZN14QuestionSwitch13InitResourcesEv.cpp:
+    .text start:0x020b5500 end:0x020b567c
+
+src/func_ov002_020b567c.c:
+    complete
+    .text start:0x020b567c end:0x020b56c4
+
+src/func_ov002_020b56c4.c:
+    complete
+    .text start:0x020b56c4 end:0x020b56d8
+
+src/QuestionSwitch_Spawn.c:
+    complete
+    .text start:0x020b56d8 end:0x020b5734
+
+src/_ZN9BlueFlameD1Ev.cpp:
+    .text start:0x020b5734 end:0x020b5764
+
+src/_ZN9BlueFlameD0Ev.c:
+    complete
+    .text start:0x020b5764 end:0x020b57a8
+
+src/_ZN9BlueFlame8BehaviorEv.c:
+    complete
+    .text start:0x020b57a8 end:0x020b5940
+
+src/_ZN9BlueFlame13InitResourcesEv.c:
+    complete
+    .text start:0x020b5940 end:0x020b599c
+
+src/func_ov002_020b599c.c:
+    complete
+    .text start:0x020b599c end:0x020b59a0
+
+src/func_ov002_020b59a0.c:
+    complete
+    .text start:0x020b59a0 end:0x020b59a8
+
+src/BlueFlame_Spawn.c:
+    complete
+    .text start:0x020b59a8 end:0x020b59e0
+
+src/RedFlame_Spawn.c:
+    complete
+    .text start:0x020b59e0 end:0x020b5a18
+
+src/func_ov002_020b5a18.c:
+    .text start:0x020b5a18 end:0x020b5a70
+
+src/func_ov002_020b5a70.c:
+    .text start:0x020b5a70 end:0x020b5ab4
+
+src/func_ov002_020b5ab4.cpp:
+    .text start:0x020b5ab4 end:0x020b5b98
+
+src/func_ov002_020b5b98.c:
+    complete
+    .text start:0x020b5b98 end:0x020b5be0
+
+src/func_ov002_020b5be0.c:
+    complete
+    .text start:0x020b5be0 end:0x020b5c24
+
+src/func_ov002_020b5c24.cpp:
+    complete
+    .text start:0x020b5c24 end:0x020b5c4c
+
+src/func_ov002_020b5c4c.c:
+    complete
+    .text start:0x020b5c4c end:0x020b5e58
+
+src/func_ov002_020b5e58.cpp:
+    .text start:0x020b5e58 end:0x020b5f9c
+
+src/func_ov002_020b5f9c.c:
+    complete
+    .text start:0x020b5f9c end:0x020b5fc4
+
+src/func_ov002_020b5fc4.c:
+    complete
+    .text start:0x020b5fc4 end:0x020b5fd8
+
+src/func_ov002_020b5fd8.c:
+    .text start:0x020b5fd8 end:0x020b6030
+
+src/func_ov002_020b6030.c:
+    .text start:0x020b6030 end:0x020b6074
+
+src/func_ov002_020b6074.cpp:
+    complete
+    .text start:0x020b6074 end:0x020b60fc
+
+src/func_ov002_020b60fc.c:
+    complete
+    .text start:0x020b60fc end:0x020b6144
+
+src/func_ov002_020b6144.cpp:
+    complete
+    .text start:0x020b6144 end:0x020b616c
+
+src/func_ov002_020b616c.c:
+    complete
+    .text start:0x020b616c end:0x020b6244
+
+src/func_ov002_020b6244.c:
+    complete
+    .text start:0x020b6244 end:0x020b62cc
+
+src/func_ov002_020b62cc.c:
+    complete
+    .text start:0x020b62cc end:0x020b6374
+
+src/func_ov002_020b6374.c:
+    complete
+    .text start:0x020b6374 end:0x020b6388
+
+src/func_ov002_020b6388.c:
+    .text start:0x020b6388 end:0x020b63e0
+
+src/func_ov002_020b63e0.c:
+    .text start:0x020b63e0 end:0x020b6424
+
+src/func_ov002_020b6424.c:
+    complete
+    .text start:0x020b6424 end:0x020b646c
+
+src/func_ov002_020b646c.cpp:
+    complete
+    .text start:0x020b646c end:0x020b6494
+
+src/func_ov002_020b6494.c:
+    complete
+    .text start:0x020b6494 end:0x020b6584
+
+src/func_ov002_020b6584.c:
+    complete
+    .text start:0x020b6584 end:0x020b660c
+
+src/func_ov002_020b660c.c:
+    .text start:0x020b660c end:0x020b6664
+
+src/func_ov002_020b6664.c:
+    .text start:0x020b6664 end:0x020b66a8
+
+src/func_ov002_020b66a8.c:
+    complete
+    .text start:0x020b66a8 end:0x020b66f0
+
+src/func_ov002_020b66f0.cpp:
+    complete
+    .text start:0x020b66f0 end:0x020b6718
+
+src/func_ov002_020b6718.cpp:
+    complete
+    .text start:0x020b6718 end:0x020b676c
+
+src/func_ov002_020b676c.cpp:
+    complete
+    .text start:0x020b676c end:0x020b6814
+
+src/func_ov002_020b6814.c:
+    .text start:0x020b6814 end:0x020b686c
+
+src/func_ov002_020b686c.c:
+    .text start:0x020b686c end:0x020b68b0
+
+src/func_ov002_020b68b0.cpp:
+    complete
+    .text start:0x020b68b0 end:0x020b68f8
+
+src/func_ov002_020b68f8.cpp:
+    complete
+    .text start:0x020b68f8 end:0x020b6920
+
+src/func_ov002_020b6920.cpp:
+    complete
+    .text start:0x020b6920 end:0x020b6958
+
+src/func_ov002_020b6958.c:
+    complete
+    .text start:0x020b6958 end:0x020b69e4
+
+src/func_ov002_020b69e4.c:
+    .text start:0x020b69e4 end:0x020b6a3c
+
+src/func_ov002_020b6a3c.c:
+    .text start:0x020b6a3c end:0x020b6a80
+
+src/func_ov002_020b6a80.c:
+    complete
+    .text start:0x020b6a80 end:0x020b6ac8
+
+src/func_ov002_020b6ac8.cpp:
+    complete
+    .text start:0x020b6ac8 end:0x020b6b10
+
+src/func_ov002_020b6b10.cpp:
+    complete
+    .text start:0x020b6b10 end:0x020b6b38
+
+src/func_ov002_020b6b38.c:
+    complete
+    .text start:0x020b6b38 end:0x020b6c54
+
+src/func_ov002_020b6c54.c:
+    complete
+    .text start:0x020b6c54 end:0x020b6d28
+
+src/func_ov002_020b6d28.c:
+    complete
+    .text start:0x020b6d28 end:0x020b6d4c
+
+src/func_ov002_020b6d4c.c:
+    .text start:0x020b6d4c end:0x020b6d84
+
+src/func_ov002_020b6d84.c:
+    complete
+    .text start:0x020b6d84 end:0x020b6dd0
+
+src/func_ov002_020b6dd0.c:
+    complete
+    .text start:0x020b6dd0 end:0x020b6dd8
+
+src/PoppingLavaBubbles_Spawn.c:
+    complete
+    .text start:0x020b6dd8 end:0x020b6e08
+
+src/_ZN18PoppingLavaBubblesD1Ev.cpp:
+    .text start:0x020b6e08 end:0x020b6e2c
+
+src/_ZN18PoppingLavaBubblesD0Ev.c:
+    .text start:0x020b6e2c end:0x020b6e64
+
+src/_ZN18PoppingLavaBubbles8BehaviorEv.cpp:
+    complete
+    .text start:0x020b6e64 end:0x020b6eac
+
+src/_ZN18PoppingLavaBubbles13InitResourcesEv.cpp:
+    complete
+    .text start:0x020b6eac end:0x020b6ee8
+
+src/WaterfallMist_Spawn.c:
+    complete
+    .text start:0x020b6ee8 end:0x020b6f18
+
+src/_ZN13WaterfallMistD1Ev.c:
+    complete
+    .text start:0x020b6f18 end:0x020b6f68
+
+src/_ZN13WaterfallMistD0Ev.c:
+    complete
+    .text start:0x020b6f68 end:0x020b6fcc
+
+src/func_ov002_020b6fcc.cpp:
+    complete
+    .text start:0x020b6fcc end:0x020b71e8
+
+src/func_ov002_020b71e8.c:
+    complete
+    .text start:0x020b71e8 end:0x020b71f0
+
+src/func_ov002_020b71f0.c:
+    complete
+    .text start:0x020b71f0 end:0x020b7200
+
+src/func_ov002_020b7200.c:
+    complete
+    .text start:0x020b7200 end:0x020b7330
+
+src/func_ov002_020b7330.c:
+    complete
+    .text start:0x020b7330 end:0x020b74d0
+
+src/func_ov002_020b74d0.c:
+    complete
+    .text start:0x020b74d0 end:0x020b76ec
+
+src/func_ov002_020b76ec.c:
+    complete
+    .text start:0x020b76ec end:0x020b781c
+
+src/func_ov002_020b781c.c:
+    complete
+    .text start:0x020b781c end:0x020b7b70
+
+src/func_ov002_020b7b70.c:
+    complete
+    .text start:0x020b7b70 end:0x020b7c30
+
+src/func_ov002_020b7c30.c:
+    complete
+    .text start:0x020b7c30 end:0x020b7cdc
+
+src/func_ov002_020b7cdc.c:
+    complete
+    .text start:0x020b7cdc end:0x020b7cec
+
+src/func_ov002_020b7cec.cpp:
+    complete
+    .text start:0x020b7cec end:0x020b7d58
+
+src/func_ov002_020b7d58.c:
+    complete
+    .text start:0x020b7d58 end:0x020b7d6c
+
+src/func_ov002_020b7d6c.c:
+    complete
+    .text start:0x020b7d6c end:0x020b7d94
+
+src/func_ov002_020b7d94.c:
+    complete
+    .text start:0x020b7d94 end:0x020b7d9c
+
+src/func_ov002_020b7d9c.cpp:
+    complete
+    .text start:0x020b7d9c end:0x020b7e08
+
+src/func_ov002_020b7e08.c:
+    complete
+    .text start:0x020b7e08 end:0x020b7e1c
+
+src/func_ov002_020b7e1c.cpp:
+    .text start:0x020b7e1c end:0x020b7f24
+
+src/func_ov002_020b7f24.c:
+    complete
+    .text start:0x020b7f24 end:0x020b7f2c
+
+src/func_ov002_020b7f2c.cpp:
+    complete
+    .text start:0x020b7f2c end:0x020b7f7c
+
+src/func_ov002_020b7f7c.c:
+    complete
+    .text start:0x020b7f7c end:0x020b81e0
+
+src/func_ov002_020b81e0.c:
+    complete
+    .text start:0x020b81e0 end:0x020b8270
+
+src/func_ov002_020b8270.c:
+    complete
+    .text start:0x020b8270 end:0x020b8284
+
+src/_ZN13WaterfallMist16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020b8284 end:0x020b8394
+
+src/_ZN13WaterfallMist16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020b8394 end:0x020b83c4
+
+src/_ZN13WaterfallMist6RenderEv.cpp:
+    complete
+    .text start:0x020b83c4 end:0x020b84a8
+
+src/_ZN13WaterfallMist8BehaviorEv.cpp:
+    complete
+    .text start:0x020b84a8 end:0x020b86d0
+
+src/_ZN13WaterfallMist13InitResourcesEv.cpp:
+    .text start:0x020b86d0 end:0x020b8b98
+
+src/Cap_Spawn.c:
+    complete
+    .text start:0x020b8b98 end:0x020b8bf0
+
+src/func_ov002_020b8bf0.c:
+    .text start:0x020b8bf0 end:0x020b8c3c
+
+src/func_ov002_020b8c3c.c:
+    .text start:0x020b8c3c end:0x020b8c9c
+
+src/func_ov002_020b8c9c.cpp:
+    complete
+    .text start:0x020b8c9c end:0x020b8d14
+
+src/func_ov002_020b8d14.cpp:
+    complete
+    .text start:0x020b8d14 end:0x020b8d3c
+
+src/func_ov002_020b8d3c.c:
+    complete
+    .text start:0x020b8d3c end:0x020b8d68
+
+src/func_ov002_020b8d68.c:
+    .text start:0x020b8d68 end:0x020b8dac
+
+src/func_ov002_020b8dac.cpp:
+    complete
+    .text start:0x020b8dac end:0x020b8dd4
+
+src/func_ov002_020b8dd4.c:
+    complete
+    .text start:0x020b8dd4 end:0x020b8fe0
+
+src/func_ov002_020b8fe0.cpp:
+    complete
+    .text start:0x020b8fe0 end:0x020b910c
+
+src/PushBlock_Spawn.c:
+    .text start:0x020b910c end:0x020b9148
+
+src/_ZN9PushBlockD1Ev.cpp:
+    .text start:0x020b9148 end:0x020b9198
+
+src/_ZN9PushBlockD0Ev.c:
+    complete
+    .text start:0x020b9198 end:0x020b91fc
+
+src/func_ov002_020b91fc.c:
+    complete
+    .text start:0x020b91fc end:0x020b92b8
+
+src/func_ov002_020b92b8.c:
+    complete
+    .text start:0x020b92b8 end:0x020b92c4
+
+src/func_ov002_020b92c4.cpp:
+    complete
+    .text start:0x020b92c4 end:0x020b9450
+
+src/func_ov002_020b9450.cpp:
+    complete
+    .text start:0x020b9450 end:0x020b94c4
+
+src/func_ov002_020b94c4.c:
+    complete
+    .text start:0x020b94c4 end:0x020b96c0
+
+src/func_ov002_020b96c0.c:
+    complete
+    .text start:0x020b96c0 end:0x020b9704
+
+src/func_ov002_020b9704.cpp:
+    complete
+    .text start:0x020b9704 end:0x020b9750
+
+src/func_ov002_020b9750.cpp:
+    complete
+    .text start:0x020b9750 end:0x020b979c
+
+src/func_ov002_020b979c.c:
+    complete
+    .text start:0x020b979c end:0x020b993c
+
+src/func_ov002_020b993c.c:
+    complete
+    .text start:0x020b993c end:0x020b9a1c
+
+src/func_ov002_020b9a1c.c:
+    complete
+    .text start:0x020b9a1c end:0x020b9a7c
+
+src/_ZN9PushBlock16CleanupResourcesEv.c:
+    complete
+    .text start:0x020b9a7c end:0x020b9aac
+
+src/_ZN9PushBlock6RenderEv.cpp:
+    complete
+    .text start:0x020b9aac end:0x020b9b70
+
+src/_ZN9PushBlock8BehaviorEv.cpp:
+    .text start:0x020b9b70 end:0x020b9c00
+
+src/_ZN9PushBlock13InitResourcesEv.cpp:
+    .text start:0x020b9c00 end:0x020b9e04
+
+src/func_ov002_020b9e04.c:
+    complete
+    .text start:0x020b9e04 end:0x020b9e0c
+
+src/PowerFlower_Spawn.c:
+    complete
+    .text start:0x020b9e0c end:0x020b9e64
+
+src/_ZN10StarSwitchD1Ev.c:
+    .text start:0x020b9e64 end:0x020b9ea8
+
+src/_ZN10StarSwitchD0Ev.c:
+    .text start:0x020b9ea8 end:0x020b9f00
+
+src/func_ov002_020b9f00.c:
+    complete
+    .text start:0x020b9f00 end:0x020b9f80
+
+src/func_ov002_020b9f80.cpp:
+    complete
+    .text start:0x020b9f80 end:0x020b9fec
+
+src/func_ov002_020b9fec.c:
+    complete
+    .text start:0x020b9fec end:0x020ba01c
+
+src/func_ov002_020ba01c.cpp:
+    complete
+    .text start:0x020ba01c end:0x020ba0bc
+
+src/func_ov002_020ba0bc.c:
+    complete
+    .text start:0x020ba0bc end:0x020ba0f8
+
+src/func_ov002_020ba0f8.cpp:
+    .text start:0x020ba0f8 end:0x020ba1ac
+
+src/func_ov002_020ba1ac.c:
+    complete
+    .text start:0x020ba1ac end:0x020ba2ac
+
+src/func_ov002_020ba2ac.c:
+    complete
+    .text start:0x020ba2ac end:0x020ba2d0
+
+src/func_ov002_020ba2d0.c:
+    complete
+    .text start:0x020ba2d0 end:0x020ba3a8
+
+src/func_ov002_020ba3a8.c:
+    complete
+    .text start:0x020ba3a8 end:0x020ba3fc
+
+src/func_ov002_020ba3fc.cpp:
+    complete
+    .text start:0x020ba3fc end:0x020ba4c0
+
+src/func_ov002_020ba4c0.c:
+    complete
+    .text start:0x020ba4c0 end:0x020ba4d8
+
+src/func_ov002_020ba4d8.cpp:
+    complete
+    .text start:0x020ba4d8 end:0x020ba520
+
+src/func_ov002_020ba520.cpp:
+    complete
+    .text start:0x020ba520 end:0x020ba568
+
+src/_ZN10StarSwitch16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020ba568 end:0x020ba5f4
+
+src/_ZN10StarSwitch6RenderEv.cpp:
+    complete
+    .text start:0x020ba5f4 end:0x020ba624
+
+src/_ZN10StarSwitch8BehaviorEv.cpp:
+    .text start:0x020ba624 end:0x020ba83c
+
+src/_ZN10StarSwitch13InitResourcesEv.cpp:
+    complete
+    .text start:0x020ba83c end:0x020baa2c
+
+src/func_ov002_020baa2c.c:
+    complete
+    .text start:0x020baa2c end:0x020baa98
+
+src/func_ov002_020baa98.c:
+    complete
+    .text start:0x020baa98 end:0x020baaac
+
+src/StarSwitch_Spawn.c:
+    complete
+    .text start:0x020baaac end:0x020baadc
+
+src/ExclamationSwitch_Spawn.c:
+    complete
+    .text start:0x020baadc end:0x020bab0c
+
+src/func_ov002_020bab0c.c:
+    .text start:0x020bab0c end:0x020bab64
+
+src/func_ov002_020bab64.c:
+    .text start:0x020bab64 end:0x020baba8
+
+src/func_ov002_020baba8.cpp:
+    complete
+    .text start:0x020baba8 end:0x020babf0
+
+src/func_ov002_020babf0.cpp:
+    complete
+    .text start:0x020babf0 end:0x020bac18
+
+src/func_ov002_020bac18.c:
+    complete
+    .text start:0x020bac18 end:0x020bad10
+
+src/func_ov002_020bad10.c:
+    complete
+    .text start:0x020bad10 end:0x020badd0
+
+src/_ZN8SignPostD1Ev.c:
+    .text start:0x020badd0 end:0x020bae2c
+
+src/_ZN8SignPostD0Ev.c:
+    .text start:0x020bae2c end:0x020bae9c
+
+src/func_ov002_020bae9c.c:
+    complete
+    .text start:0x020bae9c end:0x020baf80
+
+src/func_ov002_020baf80.c:
+    complete
+    .text start:0x020baf80 end:0x020bafc0
+
+src/func_ov002_020bafc0.c:
+    complete
+    .text start:0x020bafc0 end:0x020bb060
+
+src/func_ov002_020bb060.c:
+    complete
+    .text start:0x020bb060 end:0x020bb23c
+
+src/func_ov002_020bb23c.cpp:
+    complete
+    .text start:0x020bb23c end:0x020bb27c
+
+src/func_ov002_020bb27c.c:
+    complete
+    .text start:0x020bb27c end:0x020bb374
+
+src/func_ov002_020bb374.cpp:
+    .text start:0x020bb374 end:0x020bb3b8
+
+src/func_ov002_020bb3b8.cpp:
+    complete
+    .text start:0x020bb3b8 end:0x020bb42c
+
+src/func_ov002_020bb42c.c:
+    complete
+    .text start:0x020bb42c end:0x020bb520
+
+src/func_ov002_020bb520.c:
+    complete
+    .text start:0x020bb520 end:0x020bb614
+
+src/func_ov002_020bb9f0.c:
+    complete
+    .text start:0x020bb9f0 end:0x020bb9fc
+
+src/func_ov002_020bb9fc.c:
+    complete
+    .text start:0x020bb9fc end:0x020bba24
+
+src/func_ov002_020bba24.c:
+    complete
+    .text start:0x020bba24 end:0x020bba28
+
+src/func_ov002_020bba28.cpp:
+    complete
+    .text start:0x020bba28 end:0x020bbac8
+
+src/func_ov002_020bbac8.c:
+    complete
+    .text start:0x020bbac8 end:0x020bbb14
+
+src/func_ov002_020bbb14.cpp:
+    complete
+    .text start:0x020bbb14 end:0x020bbc78
+
+src/func_ov002_020bbc78.c:
+    complete
+    .text start:0x020bbc78 end:0x020bbcb8
+
+src/func_ov002_020bbcb8.cpp:
+    complete
+    .text start:0x020bbcb8 end:0x020bbd50
+
+src/func_ov002_020bbd50.c:
+    complete
+    .text start:0x020bbd50 end:0x020bbd5c
+
+src/func_ov002_020bbd5c.cpp:
+    complete
+    .text start:0x020bbd5c end:0x020bbda4
+
+src/func_ov002_020bbda4.cpp:
+    complete
+    .text start:0x020bbda4 end:0x020bbdec
+
+src/_ZN8SignPost16CleanupResourcesEv.cpp:
+    .text start:0x020bbdec end:0x020bbe30
+
+src/_ZN8SignPost6RenderEv.cpp:
+    .text start:0x020bbe30 end:0x020bbea4
+
+src/_ZN8SignPost8BehaviorEv.cpp:
+    complete
+    .text start:0x020bbea4 end:0x020bc240
+
+src/_ZN8SignPost13InitResourcesEv.cpp:
+    .text start:0x020bc240 end:0x020bc3c8
+
+src/SignPost_Spawn.c:
+    complete
+    .text start:0x020bc3c8 end:0x020bc414
+
+src/func_ov002_020bc414.c:
+    .text start:0x020bc414 end:0x020bc444
+
+src/func_ov002_020bc444.c:
+    .text start:0x020bc444 end:0x020bc488
+
+src/func_ov002_020bc488.c:
+    complete
+    .text start:0x020bc488 end:0x020bc4c8
+
+src/func_ov002_020bc4c8.c:
+    complete
+    .text start:0x020bc4c8 end:0x020bc4f8
+
+src/func_ov002_020bc4f8.cpp:
+    complete
+    .text start:0x020bc4f8 end:0x020bc520
+
+src/func_ov002_020bc520.c:
+    complete
+    .text start:0x020bc520 end:0x020bc540
+
+src/func_ov002_020bc540.cpp:
+    .text start:0x020bc540 end:0x020bc5a8
+
+src/Seaweed_Spawn.c:
+    .text start:0x020bc5a8 end:0x020bc5e0
+
+src/_ZN7SeaweedD1Ev.cpp:
+    .text start:0x020bc5e0 end:0x020bc618
+
+src/_ZN7SeaweedD0Ev.c:
+    complete
+    .text start:0x020bc618 end:0x020bc664
+
+src/func_ov002_020bc664.c:
+    complete
+    .text start:0x020bc664 end:0x020bc6a4
+
+src/_ZN7Seaweed16CleanupResourcesEv.c:
+    complete
+    .text start:0x020bc6a4 end:0x020bc6d4
+
+src/_ZN7Seaweed6RenderEv.cpp:
+    complete
+    .text start:0x020bc6d4 end:0x020bc6fc
+
+src/_ZN7Seaweed8BehaviorEv.c:
+    complete
+    .text start:0x020bc6fc end:0x020bc81c
+
+src/_ZN7Seaweed13InitResourcesEv.cpp:
+    .text start:0x020bc81c end:0x020bc8b4
+
+src/HealingHeart_Spawn.c:
+    complete
+    .text start:0x020bc8b4 end:0x020bc8f4
+
+src/_ZN11CannonHatchD1Ev.c:
+    .text start:0x020bc8f4 end:0x020bc938
+
+src/_ZN11CannonHatchD0Ev.c:
+    .text start:0x020bc938 end:0x020bc990
+
+src/func_ov002_020bc990.c:
+    complete
+    .text start:0x020bc990 end:0x020bc9b0
+
+src/_ZN11CannonHatch16CleanupResourcesEv.cpp:
+    .text start:0x020bc9b0 end:0x020bc9f4
+
+src/_ZN11CannonHatch6RenderEv.cpp:
+    complete
+    .text start:0x020bc9f4 end:0x020bca78
+
+src/_ZN11CannonHatch8BehaviorEv.cpp:
+    complete
+    .text start:0x020bca78 end:0x020bcc20
+
+src/_ZN11CannonHatch13InitResourcesEv.cpp:
+    complete
+    .text start:0x020bcc20 end:0x020bcccc
+
+src/CannonHatch_Spawn.c:
+    complete
+    .text start:0x020bcccc end:0x020bccfc
+
+src/func_ov002_020bccfc.c:
+    complete
+    .text start:0x020bccfc end:0x020bcd18
+
+src/func_ov002_020bcd18.c:
+    complete
+    .text start:0x020bcd18 end:0x020bcd38
+
+src/func_ov002_020bcd38.c:
+    .text start:0x020bcd38 end:0x020bcdf0
+
+src/func_ov002_020bcdf0.c:
+    complete
+    .text start:0x020bcdf0 end:0x020bd06c
+
+src/func_ov002_020bd06c.c:
+    complete
+    .text start:0x020bd06c end:0x020bd20c
+
+src/func_ov002_020bd20c.c:
+    complete
+    .text start:0x020bd20c end:0x020bd250
+
+src/func_ov002_020bd250.cpp:
+    .text start:0x020bd250 end:0x020bd354
+
+src/func_ov002_020bd354.c:
+    complete
+    .text start:0x020bd354 end:0x020bd3a0
+
+src/func_ov002_020bd3a0.c:
+    complete
+    .text start:0x020bd3a0 end:0x020bd438
+
+src/func_ov002_020bd438.c:
+    complete
+    .text start:0x020bd438 end:0x020bd45c
+
+src/func_ov002_020bd45c.cpp:
+    .text start:0x020bd45c end:0x020bd480
+
+src/func_ov002_020bd480.cpp:
+    .text start:0x020bd480 end:0x020bd4ac
+
+src/func_ov002_020bd4ac.c:
+    complete
+    .text start:0x020bd4ac end:0x020bd4c8
+
+src/func_ov002_020bd4c8.c:
+    complete
+    .text start:0x020bd4c8 end:0x020bd4e0
+
+src/func_ov002_020bd4e0.c:
+    complete
+    .text start:0x020bd4e0 end:0x020bd600
+
+src/func_ov002_020bd600.c:
+    complete
+    .text start:0x020bd600 end:0x020bd664
+
+src/func_ov002_020bd664.cpp:
+    .text start:0x020bd664 end:0x020bd828
+
+src/_ZN6Player8CanPauseEv.cpp:
+    complete
+    .text start:0x020bd828 end:0x020bd8ac
+
+src/func_ov002_020bd8ac.c:
+    complete
+    .text start:0x020bd8ac end:0x020bd8c0
+
+src/func_ov002_020bd8c0.cpp:
+    complete
+    .text start:0x020bd8c0 end:0x020bd928
+
+src/func_ov002_020bd928.cpp:
+    complete
+    .text start:0x020bd928 end:0x020bd984
+
+src/func_ov002_020bd984.cpp:
+    complete
+    .text start:0x020bd984 end:0x020bd9ec
+
+src/func_ov002_020bd9ec.cpp:
+    complete
+    .text start:0x020bd9ec end:0x020bda48
+
+src/func_ov002_020bda48.c:
+    complete
+    .text start:0x020bda48 end:0x020bda98
+
+src/_ZN6Player8HasNoCapEv.cpp:
+    complete
+    .text start:0x020bda98 end:0x020bdb50
+
+src/func_ov002_020bdb50.cpp:
+    complete
+    .text start:0x020bdb50 end:0x020bdc18
+
+src/func_ov002_020bdc18.c:
+    complete
+    .text start:0x020bdc18 end:0x020bdc58
+
+src/_ZN6Player16IncMegaKillCountEv.cpp:
+    .text start:0x020bdc58 end:0x020bdd2c
+
+src/func_ov002_020bdd2c.c:
+    complete
+    .text start:0x020bdd2c end:0x020bdd9c
+
+src/func_ov002_020bdd9c.cpp:
+    complete
+    .text start:0x020bdd9c end:0x020bde14
+
+src/_ZN6Player14InitMetalWarioEv.cpp:
+    .text start:0x020bde14 end:0x020bdef0
+
+src/func_ov002_020bdef0.cpp:
+    complete
+    .text start:0x020bdef0 end:0x020bdf4c
+
+src/_ZN6Player15InitVanishLuigiEv.c:
+    complete
+    .text start:0x020bdf4c end:0x020bdf8c
+
+src/func_ov002_020bdf8c.c:
+    complete
+    .text start:0x020bdf8c end:0x020be008
+
+src/func_ov002_020be008.cpp:
+    complete
+    .text start:0x020be008 end:0x020be0f8
+
+src/_ZN6Player18SetNewHatCharacterEjjb.cpp:
+    complete
+    .text start:0x020be0f8 end:0x020be1e0
+
+src/_ZN6Player16SetRealCharacterEj.cpp:
+    .text start:0x020be1e0 end:0x020be324
+
+src/_ZN6Player18TurnOffToonShadingEj.cpp:
+    .text start:0x020be324 end:0x020be3b0
+
+src/func_ov002_020be3b0.c:
+    .text start:0x020be3b0 end:0x020bea7c
+
+src/func_ov002_020bea7c.c:
+    complete
+    .text start:0x020bea7c end:0x020bea94
+
+src/_ZN6Player15IsCollectingCapEv.cpp:
+    complete
+    .text start:0x020bea94 end:0x020beabc
+
+src/func_ov002_020beabc.cpp:
+    complete
+    .text start:0x020beabc end:0x020beb38
+
+src/func_ov002_020beb38.c:
+    complete
+    .text start:0x020beb38 end:0x020bebd4
+
+src/func_ov002_020bebd4.cpp:
+    complete
+    .text start:0x020bebd4 end:0x020bec2c
+
+src/func_ov002_020bec2c.cpp:
+    complete
+    .text start:0x020bec2c end:0x020bec84
+
+src/func_ov002_020bec84.c:
+    complete
+    .text start:0x020bec84 end:0x020bec9c
+
+src/func_ov002_020bec9c.cpp:
+    complete
+    .text start:0x020bec9c end:0x020becc8
+
+src/_ZNK6Player14GetBodyModelIDEjb.cpp:
+    complete
+    .text start:0x020becc8 end:0x020becf4
+
+src/func_ov002_020becf4.cpp:
+    complete
+    .text start:0x020becf4 end:0x020bed98
+
+src/_ZN6Player12FinishedAnimEv.cpp:
+    complete
+    .text start:0x020bed98 end:0x020bedd4
+
+src/Player_AdvanceAnims.cpp:
+    complete
+    .text start:0x020bedd4 end:0x020beecc
+
+src/_ZN6Player6IsAnimEj.cpp:
+    complete
+    .text start:0x020beecc end:0x020bef2c
+
+src/_ZN6Player7SetAnimEji5Fix12IiEj.cpp:
+    complete
+    .text start:0x020bef2c end:0x020bf13c
+
+src/func_ov002_020bf13c.c:
+    complete
+    .text start:0x020bf13c end:0x020bf224
+
+src/func_ov002_020bf224.c:
+    complete
+    .text start:0x020bf224 end:0x020bf27c
+
+src/func_ov002_020bf27c.c:
+    complete
+    .text start:0x020bf27c end:0x020bf2d8
+
+src/func_ov002_020bf2d8.c:
+    complete
+    .text start:0x020bf2d8 end:0x020bf30c
+
+mods/Player_ScaleByCharFactor.c:
+    complete
+    .text start:0x020bf30c end:0x020bf340
+
+src/func_ov002_020bf340.c:
+    complete
+    .text start:0x020bf340 end:0x020bf36c
+
+src/func_ov002_020bf36c.cpp:
+    complete
+    .text start:0x020bf36c end:0x020bf40c
+
+src/func_ov002_020bf40c.c:
+    complete
+    .text start:0x020bf40c end:0x020bf4e4
+
+src/_ZN6Player4HealEi.cpp:
+    .text start:0x020bf4e4 end:0x020bf548
+
+src/_ZN6Player9GetHealthEv.cpp:
+    complete
+    .text start:0x020bf548 end:0x020bf56c
+
+src/func_ov002_020bf56c.cpp:
+    complete
+    .text start:0x020bf56c end:0x020bf5e0
+
+src/func_ov002_020bf5e0.c:
+    complete
+    .text start:0x020bf5e0 end:0x020bf800
+
+src/func_ov002_020bf800.cpp:
+    complete
+    .text start:0x020bf800 end:0x020bf88c
+
+src/func_ov002_020bf88c.c:
+    complete
+    .text start:0x020bf88c end:0x020bf90c
+
+src/func_ov002_020bf90c.c:
+    complete
+    .text start:0x020bf90c end:0x020bf9d4
+
+src/func_ov002_020bf9d4.cpp:
+    complete
+    .text start:0x020bf9d4 end:0x020bfa74
+
+src/func_ov002_020bfec0.c:
+    complete
+    .text start:0x020bfec0 end:0x020c0108
+
+src/func_ov002_020c0108.c:
+    complete
+    .text start:0x020c0108 end:0x020c031c
+
+src/func_ov002_020c031c.cpp:
+    complete
+    .text start:0x020c031c end:0x020c0364
+
+src/func_ov002_020c0364.c:
+    complete
+    .text start:0x020c0364 end:0x020c0434
+
+src/func_ov002_020c0434.c:
+    complete
+    .text start:0x020c0434 end:0x020c04ac
+
+src/func_ov002_020c04ac.c:
+    complete
+    .text start:0x020c04ac end:0x020c04e0
+
+src/func_ov002_020c04e0.c:
+    complete
+    .text start:0x020c04e0 end:0x020c0688
+
+src/func_ov002_020c0688.cpp:
+    complete
+    .text start:0x020c0688 end:0x020c06fc
+
+src/func_ov002_020c06fc.c:
+    .text start:0x020c06fc end:0x020c0cbc
+
+src/func_ov002_020c0cbc.c:
+    complete
+    .text start:0x020c0cbc end:0x020c0d90
+
+src/func_ov002_020c0d90.c:
+    complete
+    .text start:0x020c0d90 end:0x020c0fb4
+
+src/func_ov002_020c0fb4.c:
+    .text start:0x020c0fb4 end:0x020c1234
+
+src/func_ov002_020c1234.cpp:
+    .text start:0x020c1234 end:0x020c133c
+
+src/func_ov002_020c133c.c:
+    complete
+    .text start:0x020c133c end:0x020c14b8
+
+src/func_ov002_020c14b8.c:
+    complete
+    .text start:0x020c14b8 end:0x020c16ec
+
+src/func_ov002_020c16ec.c:
+    complete
+    .text start:0x020c16ec end:0x020c179c
+
+src/func_ov002_020c179c.cpp:
+    complete
+    .text start:0x020c179c end:0x020c18b0
+
+src/func_ov002_020c18b0.c:
+    complete
+    .text start:0x020c18b0 end:0x020c19d0
+
+src/func_ov002_020c19d0.cpp:
+    complete
+    .text start:0x020c19d0 end:0x020c1ad8
+
+src/func_ov002_020c1ad8.c:
+    complete
+    .text start:0x020c1ad8 end:0x020c1c84
+
+src/func_ov002_020c1c84.c:
+    complete
+    .text start:0x020c1c84 end:0x020c1e44
+
+src/func_ov002_020c1e44.c:
+    complete
+    .text start:0x020c1e44 end:0x020c1eb4
+
+src/func_ov002_020c1eb4.cpp:
+    .text start:0x020c1eb4 end:0x020c200c
+
+src/func_ov002_020c200c.c:
+    complete
+    .text start:0x020c200c end:0x020c2138
+
+src/func_ov002_020c2138.cpp:
+    complete
+    .text start:0x020c2138 end:0x020c2270
+
+src/func_ov002_020c2270.cpp:
+    complete
+    .text start:0x020c2270 end:0x020c231c
+
+src/func_ov002_020c231c.c:
+    complete
+    .text start:0x020c231c end:0x020c25a8
+
+src/func_ov002_020c25a8.c:
+    complete
+    .text start:0x020c25a8 end:0x020c29d4
+
+src/func_ov002_020c29d4.cpp:
+    .text start:0x020c29d4 end:0x020c2b08
+
+src/func_ov002_020c2b08.c:
+    complete
+    .text start:0x020c2b08 end:0x020c2db8
+
+src/func_ov002_020c2db8.c:
+    complete
+    .text start:0x020c2db8 end:0x020c2e78
+
+src/func_ov002_020c2e78.cpp:
+    complete
+    .text start:0x020c2e78 end:0x020c2ef0
+
+src/_ZN6Player7CanWarpEv.cpp:
+    complete
+    .text start:0x020c2ef0 end:0x020c2f3c
+
+src/_ZN6Player7IsInAirEv.cpp:
+    complete
+    .text start:0x020c2f3c end:0x020c2f64
+
+src/func_ov002_020c2f64.c:
+    complete
+    .text start:0x020c2f64 end:0x020c2fec
+
+src/func_ov002_020c2fec.c:
+    complete
+    .text start:0x020c2fec end:0x020c3148
+
+src/func_ov002_020c3148.c:
+    complete
+    .text start:0x020c3148 end:0x020c3160
+
+src/func_ov002_020c3160.c:
+    complete
+    .text start:0x020c3160 end:0x020c37a4
+
+src/func_ov002_020c37a4.cpp:
+    complete
+    .text start:0x020c37a4 end:0x020c38a0
+
+src/func_ov002_020c38a0.c:
+    complete
+    .text start:0x020c38a0 end:0x020c3a48
+
+src/func_ov002_020c3a48.c:
+    complete
+    .text start:0x020c3a48 end:0x020c3bdc
+
+src/func_ov002_020c3bdc.c:
+    complete
+    .text start:0x020c3bdc end:0x020c3cf0
+
+src/func_ov002_020c3cf0.c:
+    complete
+    .text start:0x020c3cf0 end:0x020c3d1c
+
+src/func_ov002_020c3d1c.c:
+    complete
+    .text start:0x020c3d1c end:0x020c3d6c
+
+src/_ZN6Player17St_EndingFly_InitEv.cpp:
+    .text start:0x020c3d6c end:0x020c3dbc
+
+src/func_ov002_020c3dbc.c:
+    complete
+    .text start:0x020c3dbc end:0x020c3dd0
+
+src/_ZN6Player21St_OpeningWakeUp_MainEv.cpp:
+    .text start:0x020c3dd0 end:0x020c3e8c
+
+src/func_ov002_020c3e8c.c:
+    complete
+    .text start:0x020c3e8c end:0x020c3ea0
+
+src/func_ov002_020c3ea0.c:
+    complete
+    .text start:0x020c3ea0 end:0x020c3ed8
+
+src/_ZN6Player21St_OpeningWakeUp_InitEv.cpp:
+    .text start:0x020c3ed8 end:0x020c3f18
+
+src/func_ov002_020c3f18.c:
+    complete
+    .text start:0x020c3f18 end:0x020c3f2c
+
+src/func_ov002_020c3f2c.c:
+    complete
+    .text start:0x020c3f2c end:0x020c3f40
+
+src/_ZN6Player15St_Respawn_MainEv.cpp:
+    .text start:0x020c3f40 end:0x020c4088
+
+src/_ZN6Player15St_Respawn_InitEv.cpp:
+    .text start:0x020c4088 end:0x020c4188
+
+src/func_ov002_020c4188.c:
+    complete
+    .text start:0x020c4188 end:0x020c43c4
+
+src/func_ov002_020c43c4.c:
+    complete
+    .text start:0x020c43c4 end:0x020c44c4
+
+src/func_ov002_020c44c4.c:
+    complete
+    .text start:0x020c44c4 end:0x020c4760
+
+src/_ZN6Player15St_Talk_CleanupEv.cpp:
+    complete
+    .text start:0x020c4760 end:0x020c47f4
+
+src/func_ov002_020c47f4.cpp:
+    complete
+    .text start:0x020c47f4 end:0x020c48e0
+
+src/_ZN6Player12St_Talk_MainEv.cpp:
+    .text start:0x020c48e0 end:0x020c4bd8
+
+src/_ZN6Player12St_Talk_InitEv.cpp:
+    .text start:0x020c4bd8 end:0x020c4c60
+
+src/_ZN6Player12ShowMessage2ER9ActorBasejPK7Vector3jj.cpp:
+    complete
+    .text start:0x020c4c60 end:0x020c4ec0
+
+src/_ZN6Player11ShowMessageER9ActorBasejPK7Vector3jj.cpp:
+    complete
+    .text start:0x020c4ec0 end:0x020c4efc
+
+src/_ZN6Player18HasFinishedTalkingEv.cpp:
+    complete
+    .text start:0x020c4efc end:0x020c4f40
+
+src/_ZN6Player12Unk_020c4f40Et.cpp:
+    complete
+    .text start:0x020c4f40 end:0x020c4fa0
+
+src/_ZN6Player9StartTalkER9ActorBaseb.cpp:
+    complete
+    .text start:0x020c4fa0 end:0x020c51d0
+
+src/func_ov002_020c51d0.cpp:
+    complete
+    .text start:0x020c51d0 end:0x020c5244
+
+src/func_ov002_020c5244.c:
+    complete
+    .text start:0x020c5244 end:0x020c524c
+
+src/_ZN6Player12GetTalkStateEv.cpp:
+    complete
+    .text start:0x020c524c end:0x020c52bc
+
+src/_ZN6Player21St_StuckInGround_MainEv.cpp:
+    .text start:0x020c52bc end:0x020c5444
+
+src/func_ov002_020c5444.cpp:
+    complete
+    .text start:0x020c5444 end:0x020c54e8
+
+src/_ZN6Player21St_StuckInGround_InitEv.cpp:
+    complete
+    .text start:0x020c54e8 end:0x020c5560
+
+src/_ZN6Player24St_BowserEarthquake_MainEv.cpp:
+    .text start:0x020c5560 end:0x020c568c
+
+src/_ZN6Player24St_BowserEarthquake_InitEv.cpp:
+    .text start:0x020c568c end:0x020c56f0
+
+src/func_ov002_020c56f0.c:
+    complete
+    .text start:0x020c56f0 end:0x020c5780
+
+src/_ZN6Player15St_DeadPit_MainEv.cpp:
+    .text start:0x020c5780 end:0x020c59c0
+
+src/_ZN6Player15St_DeadPit_InitEv.cpp:
+    complete
+    .text start:0x020c59c0 end:0x020c5cc8
+
+src/_ZN6Player14EnterWhirlpoolEv.cpp:
+    complete
+    .text start:0x020c5cc8 end:0x020c5cd8
+
+src/func_ov002_020c5cd8.c:
+    complete
+    .text start:0x020c5cd8 end:0x020c5d0c
+
+src/func_ov002_020c5d0c.c:
+    complete
+    .text start:0x020c5d0c end:0x020c5d60
+
+src/func_ov002_020c5d60.c:
+    complete
+    .text start:0x020c5d60 end:0x020c5dec
+
+src/func_ov002_020c5dec.cpp:
+    complete
+    .text start:0x020c5dec end:0x020c5e34
+
+src/_ZN6Player15St_DeadHit_MainEv.cpp:
+    .text start:0x020c5e34 end:0x020c6010
+
+src/_ZN6Player15St_DeadHit_InitEv.cpp:
+    .text start:0x020c6010 end:0x020c607c
+
+src/func_ov002_020c607c.cpp:
+    complete
+    .text start:0x020c607c end:0x020c61ac
+
+src/func_ov002_020c61ac.c:
+    complete
+    .text start:0x020c61ac end:0x020c647c
+
+src/func_ov002_020c647c.cpp:
+    complete
+    .text start:0x020c647c end:0x020c6538
+
+src/func_ov002_020c6538.cpp:
+    complete
+    .text start:0x020c6538 end:0x020c65f8
+
+src/_ZN6Player17St_Squish_CleanupEv.cpp:
+    complete
+    .text start:0x020c65f8 end:0x020c662c
+
+src/_ZN6Player14St_Squish_MainEv.cpp:
+    .text start:0x020c662c end:0x020c6908
+
+src/func_ov002_020c6908.cpp:
+    complete
+    .text start:0x020c6908 end:0x020c69a0
+
+src/_ZN6Player14St_Squish_InitEv.cpp:
+    .text start:0x020c69a0 end:0x020c6a10
+
+src/_ZN6Player12Unk_020c6a10Ej.cpp:
+    .text start:0x020c6a10 end:0x020c6adc
+
+src/func_ov002_020c6adc.cpp:
+    complete
+    .text start:0x020c6adc end:0x020c6b3c
+
+src/_ZN6Player16St_Teleport_MainEv.cpp:
+    .text start:0x020c6b3c end:0x020c6dc4
+
+src/_ZN6Player16St_Teleport_InitEv.cpp:
+    complete
+    .text start:0x020c6dc4 end:0x020c6e14
+
+src/func_ov002_020c6e14.c:
+    complete
+    .text start:0x020c6e14 end:0x020c6f34
+
+src/_ZN6Player21St_LevelEnter_CleanupEv.cpp:
+    complete
+    .text start:0x020c6f34 end:0x020c6f3c
+
+src/func_ov002_020c6f3c.cpp:
+    complete
+    .text start:0x020c6f3c end:0x020c6fe4
+
+src/func_ov002_020c6fe4.c:
+    complete
+    .text start:0x020c6fe4 end:0x020c70ac
+
+src/func_ov002_020c70ac.c:
+    .text start:0x020c70ac end:0x020c7194
+
+src/func_ov002_020c7194.cpp:
+    complete
+    .text start:0x020c7194 end:0x020c71e0
+
+src/func_ov002_020c71e0.cpp:
+    complete
+    .text start:0x020c71e0 end:0x020c72a4
+
+src/func_ov002_020c72a4.cpp:
+    .text start:0x020c72a4 end:0x020c7350
+
+src/func_ov002_020c7350.cpp:
+    complete
+    .text start:0x020c7350 end:0x020c75f0
+
+src/func_ov002_020c75f0.c:
+    complete
+    .text start:0x020c75f0 end:0x020c7838
+
+src/_ZN6Player18St_LevelEnter_InitEv.cpp:
+    complete
+    .text start:0x020c7838 end:0x020c7cbc
+
+src/func_ov002_020c7cbc.c:
+    complete
+    .text start:0x020c7cbc end:0x020c7dd0
+
+src/func_ov002_020c7dd0.cpp:
+    .text start:0x020c7dd0 end:0x020c7e84
+
+src/_ZN6Player15IsEnteringLevelEv.cpp:
+    complete
+    .text start:0x020c7e84 end:0x020c7ed4
+
+src/_ZN6Player20IsStateEnteringLevelEv.cpp:
+    complete
+    .text start:0x020c7ed4 end:0x020c7f10
+
+src/func_ov002_020c7f10.cpp:
+    complete
+    .text start:0x020c7f10 end:0x020c7ff8
+
+src/func_ov002_020c7ff8.c:
+    complete
+    .text start:0x020c7ff8 end:0x020c8128
+
+src/_ZN6Player20St_NoControl_CleanupEv.cpp:
+    complete
+    .text start:0x020c8128 end:0x020c816c
+
+src/_ZN6Player17St_NoControl_MainEv.cpp:
+    .text start:0x020c816c end:0x020c84b0
+
+src/func_ov002_020c84b0.c:
+    complete
+    .text start:0x020c84b0 end:0x020c8540
+
+src/func_ov002_020c8540.c:
+    complete
+    .text start:0x020c8540 end:0x020c8714
+
+src/func_ov002_020c8714.c:
+    complete
+    .text start:0x020c8714 end:0x020c897c
+
+src/func_ov002_020c897c.c:
+    complete
+    .text start:0x020c897c end:0x020c8a4c
+
+src/func_ov002_020c8a4c.cpp:
+    .text start:0x020c8a4c end:0x020c8b54
+
+src/func_ov002_020c8b54.c:
+    complete
+    .text start:0x020c8b54 end:0x020c8b78
+
+src/func_ov002_020c8b78.cpp:
+    .text start:0x020c8b78 end:0x020c8cb0
+
+src/func_ov002_020c8cb0.cpp:
+    complete
+    .text start:0x020c8cb0 end:0x020c8d14
+
+src/func_ov002_020c8d14.c:
+    complete
+    .text start:0x020c8d14 end:0x020c8f0c
+
+src/func_ov002_020c8f0c.cpp:
+    complete
+    .text start:0x020c8f0c end:0x020c8f80
+
+src/func_ov002_020c8f80.cpp:
+    .text start:0x020c8f80 end:0x020c904c
+
+src/func_ov002_020c904c.c:
+    complete
+    .text start:0x020c904c end:0x020c9128
+
+src/func_ov002_020c9128.cpp:
+    complete
+    .text start:0x020c9128 end:0x020c91bc
+
+src/func_ov002_020c91bc.c:
+    complete
+    .text start:0x020c91bc end:0x020c924c
+
+src/func_ov002_020c924c.c:
+    complete
+    .text start:0x020c924c end:0x020c9288
+
+src/func_ov002_020c9288.cpp:
+    complete
+    .text start:0x020c9288 end:0x020c92fc
+
+src/func_ov002_020c92fc.c:
+    complete
+    .text start:0x020c92fc end:0x020c94a4
+
+src/func_ov002_020c94a4.c:
+    complete
+    .text start:0x020c94a4 end:0x020c965c
+
+src/func_ov002_020c965c.c:
+    complete
+    .text start:0x020c965c end:0x020c9718
+
+src/func_ov002_020c9718.c:
+    complete
+    .text start:0x020c9718 end:0x020c976c
+
+src/_ZN6Player17St_NoControl_InitEv.cpp:
+    complete
+    .text start:0x020c976c end:0x020c97e0
+
+src/func_ov002_020c97e0.c:
+    complete
+    .text start:0x020c97e0 end:0x020c97f8
+
+src/func_ov002_020c97f8.cpp:
+    complete
+    .text start:0x020c97f8 end:0x020c9840
+
+src/func_ov002_020c9840.cpp:
+    complete
+    .text start:0x020c9840 end:0x020c98a4
+
+src/func_ov002_020c98a4.cpp:
+    complete
+    .text start:0x020c98a4 end:0x020c990c
+
+src/func_ov002_020c990c.c:
+    complete
+    .text start:0x020c990c end:0x020c9998
+
+src/func_ov002_020c9998.c:
+    complete
+    .text start:0x020c9998 end:0x020c9a04
+
+src/func_ov002_020c9a04.c:
+    complete
+    .text start:0x020c9a04 end:0x020c9ac0
+
+src/func_ov002_020c9ac0.cpp:
+    complete
+    .text start:0x020c9ac0 end:0x020c9b10
+
+src/func_ov002_020c9b10.c:
+    complete
+    .text start:0x020c9b10 end:0x020c9b5c
+
+src/func_ov002_020c9b5c.c:
+    complete
+    .text start:0x020c9b5c end:0x020c9b7c
+
+src/func_ov002_020c9b7c.c:
+    complete
+    .text start:0x020c9b7c end:0x020c9c00
+
+src/func_ov002_020c9c00.c:
+    complete
+    .text start:0x020c9c00 end:0x020c9c4c
+
+src/func_ov002_020c9c4c.c:
+    complete
+    .text start:0x020c9c4c end:0x020c9cc0
+
+src/func_ov002_020c9cc0.c:
+    complete
+    .text start:0x020c9cc0 end:0x020c9d1c
+
+src/func_ov002_020c9d1c.c:
+    complete
+    .text start:0x020c9d1c end:0x020c9d68
+
+src/func_ov002_020c9d68.cpp:
+    complete
+    .text start:0x020c9d68 end:0x020c9de4
+
+src/func_ov002_020c9de4.c:
+    complete
+    .text start:0x020c9de4 end:0x020c9e18
+
+src/func_ov002_020c9e18.c:
+    complete
+    .text start:0x020c9e18 end:0x020c9e40
+
+src/Player_DisableInteraction.c:
+    complete
+    .text start:0x020c9e40 end:0x020c9e5c
+
+src/_ZN6Player12Unk_020c9e5cEh.cpp:
+    .text start:0x020c9e5c end:0x020ca0f4
+
+src/func_ov002_020ca0f4.c:
+    complete
+    .text start:0x020ca0f4 end:0x020ca108
+
+src/func_ov002_020ca108.cpp:
+    complete
+    .text start:0x020ca108 end:0x020ca144
+
+src/_ZN6Player11OpenBigDoorEv.cpp:
+    complete
+    .text start:0x020ca144 end:0x020ca150
+
+src/_ZN6Player12Unk_020ca150Eh.cpp:
+    .text start:0x020ca150 end:0x020ca1b8
+
+src/_ZN6Player17SetNoControlStateEhih.cpp:
+    .text start:0x020ca1b8 end:0x020ca270
+
+src/func_ov002_020ca270.cpp:
+    complete
+    .text start:0x020ca270 end:0x020ca2ac
+
+src/_ZN6Player15JumpIntoBooCageER7Vector3.cpp:
+    complete
+    .text start:0x020ca2ac end:0x020ca344
+
+src/_ZN6Player13TryTalkToDoorEh.cpp:
+    complete
+    .text start:0x020ca344 end:0x020ca3d0
+
+src/_ZN6Player21IsOpeningDoorWithStarEv.cpp:
+    .text start:0x020ca3d0 end:0x020ca410
+
+src/_ZN6Player16TryTalkToKeyDoorEv.cpp:
+    complete
+    .text start:0x020ca410 end:0x020ca488
+
+src/_ZN6Player12Unk_020ca488Ev.cpp:
+    complete
+    .text start:0x020ca488 end:0x020ca498
+
+src/_ZN6Player16TryEnterStarDoorER7Vector3s.cpp:
+    complete
+    .text start:0x020ca498 end:0x020ca5cc
+
+src/_ZN6Player17PlayMammaMiaSoundEv.cpp:
+    complete
+    .text start:0x020ca708 end:0x020ca724
+
+src/_ZN6Player24TryExitWhiteDoorWithStarEv.cpp:
+    .text start:0x020ca724 end:0x020ca78c
+
+src/func_ov002_020ca78c.c:
+    complete
+    .text start:0x020ca78c end:0x020ca7f4
+
+src/_ZN6Player16St_DebugFly_MainEv.cpp:
+    complete
+    .text start:0x020ca7f4 end:0x020ca8d0
+
+src/_ZN6Player16St_DebugFly_InitEv.cpp:
+    .text start:0x020ca8d0 end:0x020ca8f8
+
+src/_ZN6Player12Unk_020ca8f8Ev.cpp:
+    .text start:0x020ca8f8 end:0x020ca940
+
+src/func_ov002_020ca940.c:
+    complete
+    .text start:0x020ca940 end:0x020cabe0
+
+src/func_ov002_020cabe0.cpp:
+    complete
+    .text start:0x020cabe0 end:0x020cac20
+
+src/_ZN6Player15St_Null_CleanupEv.cpp:
+    complete
+    .text start:0x020cac20 end:0x020cac28
+
+src/_ZN6Player12St_Null_MainEv.cpp:
+    complete
+    .text start:0x020cac28 end:0x020cac30
+
+src/func_ov002_020cac30.c:
+    complete
+    .text start:0x020cac30 end:0x020cac38
+
+src/_ZN6Player21St_CameraZoom_CleanupEv.cpp:
+    complete
+    .text start:0x020cac38 end:0x020cac60
+
+src/func_ov002_020cac60.c:
+    complete
+    .text start:0x020cac60 end:0x020cad10
+
+src/_ZN6Player18St_CameraZoom_MainEv.cpp:
+    .text start:0x020cad10 end:0x020cae10
+
+src/func_ov002_020cae10.c:
+    complete
+    .text start:0x020cae10 end:0x020caef4
+
+src/_ZN6Player18St_CameraZoom_InitEv.cpp:
+    complete
+    .text start:0x020caef4 end:0x020caf68
+
+src/func_ov002_020caf68.c:
+    complete
+    .text start:0x020caf68 end:0x020caf98
+
+src/func_ov002_020caf98.cpp:
+    complete
+    .text start:0x020caf98 end:0x020cb15c
+
+src/_ZN6Player17St_Headstand_MainEv.cpp:
+    .text start:0x020cb15c end:0x020cb2f0
+
+src/_ZN6Player17St_Headstand_InitEv.cpp:
+    .text start:0x020cb2f0 end:0x020cb354
+
+src/func_ov002_020cb354.cpp:
+    complete
+    .text start:0x020cb354 end:0x020cb400
+
+src/func_ov002_020cb400.cpp:
+    complete
+    .text start:0x020cb400 end:0x020cb474
+
+src/func_ov002_020cb474.cpp:
+    complete
+    .text start:0x020cb474 end:0x020cb568
+
+src/_ZN6Player16St_Climb_CleanupEv.cpp:
+    .text start:0x020cb568 end:0x020cb5bc
+
+src/_ZN6Player13St_Climb_InitEv.cpp:
+    .text start:0x020cbd34 end:0x020cbea8
+
+src/func_ov002_020cbea8.c:
+    complete
+    .text start:0x020cbea8 end:0x020cc01c
+
+src/func_ov002_020cc01c.cpp:
+    complete
+    .text start:0x020cc01c end:0x020cc05c
+
+src/func_ov002_020cc05c.c:
+    complete
+    .text start:0x020cc05c end:0x020cc140
+
+src/_ZN6Player9IsOnShellEv.cpp:
+    .text start:0x020cc140 end:0x020cc16c
+
+src/func_ov002_020cc16c.c:
+    complete
+    .text start:0x020cc16c end:0x020cc1f4
+
+src/func_ov002_020cc1f4.c:
+    complete
+    .text start:0x020cc1f4 end:0x020cc228
+
+src/_ZN6Player16St_Shell_CleanupEv.cpp:
+    complete
+    .text start:0x020cc228 end:0x020cc27c
+
+src/_ZN6Player13St_Shell_MainEv.cpp:
+    .text start:0x020cc27c end:0x020cc660
+
+src/func_ov002_020cc660.c:
+    complete
+    .text start:0x020cc660 end:0x020cc780
+
+src/_ZN6Player13St_Shell_InitEv.cpp:
+    complete
+    .text start:0x020cc780 end:0x020cc7d0
+
+src/_ZN6Player17St_HurtWater_MainEv.cpp:
+    complete
+    .text start:0x020cc7d0 end:0x020cc910
+
+src/_ZN6Player17St_HurtWater_InitEv.cpp:
+    .text start:0x020cc910 end:0x020cc9c0
+
+src/_ZN6Player23St_MetalWaterWater_MainEv.cpp:
+    complete
+    .text start:0x020cc9c0 end:0x020ccc3c
+
+src/_ZN6Player23St_MetalWaterWater_InitEv.cpp:
+    complete
+    .text start:0x020ccc3c end:0x020ccccc
+
+src/_ZN6Player24St_MetalWaterGround_MainEv.cpp:
+    .text start:0x020ccccc end:0x020cd0d0
+
+src/_ZN6Player24St_MetalWaterGround_InitEv.cpp:
+    complete
+    .text start:0x020cd0d0 end:0x020cd190
+
+src/func_ov002_020cd190.c:
+    complete
+    .text start:0x020cd190 end:0x020cd1e4
+
+src/_ZN6Player15St_Swim_CleanupEv.cpp:
+    complete
+    .text start:0x020cd1e4 end:0x020cd218
+
+src/func_ov002_020cd218.cpp:
+    complete
+    .text start:0x020cd218 end:0x020cd28c
+
+src/func_ov002_020cd28c.c:
+    complete
+    .text start:0x020cd28c end:0x020cd2c4
+
+src/func_ov002_020cd2c4.c:
+    complete
+    .text start:0x020cd2c4 end:0x020cd308
+
+src/func_ov002_020cd308.c:
+    complete
+    .text start:0x020cd308 end:0x020cd364
+
+src/func_ov002_020cd364.c:
+    complete
+    .text start:0x020cd364 end:0x020cd39c
+
+src/func_ov002_020cd39c.c:
+    complete
+    .text start:0x020cd39c end:0x020cd3e0
+
+src/func_ov002_020cd3e0.cpp:
+    complete
+    .text start:0x020cd3e0 end:0x020cd448
+
+src/func_ov002_020cd448.cpp:
+    complete
+    .text start:0x020cd448 end:0x020cd550
+
+src/func_ov002_020cd550.c:
+    complete
+    .text start:0x020cd550 end:0x020cd71c
+
+src/func_ov002_020cd71c.c:
+    complete
+    .text start:0x020cd71c end:0x020cd94c
+
+src/_ZN6Player12St_Swim_MainEv.cpp:
+    complete
+    .text start:0x020cd94c end:0x020ce324
+
+src/func_ov002_020ce324.c:
+    complete
+    .text start:0x020ce324 end:0x020ce550
+
+src/_ZN6Player12St_Swim_InitEv.cpp:
+    .text start:0x020ce550 end:0x020ce5f8
+
+src/func_ov002_020ce5f8.c:
+    complete
+    .text start:0x020ce5f8 end:0x020ce798
+
+src/func_ov002_020ce798.c:
+    complete
+    .text start:0x020ce798 end:0x020ce8bc
+
+src/func_ov002_020ce8bc.c:
+    complete
+    .text start:0x020ce8bc end:0x020ce9c8
+
+src/func_ov002_020ce9c8.c:
+    complete
+    .text start:0x020ce9c8 end:0x020ceaf4
+
+src/func_ov002_020ceaf4.c:
+    complete
+    .text start:0x020ceaf4 end:0x020ceb54
+
+src/func_ov002_020ceb54.c:
+    complete
+    .text start:0x020ceb54 end:0x020ceb7c
+
+src/func_ov002_020ceb7c.c:
+    complete
+    .text start:0x020ceb7c end:0x020cec2c
+
+src/func_ov002_020cec2c.c:
+    complete
+    .text start:0x020cec2c end:0x020cedb0
+
+src/func_ov002_020cedb0.c:
+    complete
+    .text start:0x020cedb0 end:0x020cede0
+
+src/func_ov002_020cede0.cpp:
+    complete
+    .text start:0x020cede0 end:0x020cef84
+
+src/func_ov002_020cef84.cpp:
+    complete
+    .text start:0x020cef84 end:0x020cf20c
+
+src/func_ov002_020cf20c.cpp:
+    complete
+    .text start:0x020cf20c end:0x020cf2f8
+
+src/func_ov002_020cf2f8.c:
+    complete
+    .text start:0x020cf2f8 end:0x020cf384
+
+src/func_ov002_020cf384.c:
+    complete
+    .text start:0x020cf384 end:0x020cf398
+
+src/_ZN6Player20St_CeilingGrate_MainEv.cpp:
+    .text start:0x020cf398 end:0x020cf6bc
+
+src/_ZN6Player20St_CeilingGrate_InitEv.cpp:
+    .text start:0x020cf6bc end:0x020cf700
+
+src/func_ov002_020cf700.c:
+    complete
+    .text start:0x020cf700 end:0x020cf714
+
+src/_ZN6Player14St_OnWall_MainEv.cpp:
+    .text start:0x020cf714 end:0x020cfa90
+
+src/_ZN6Player14St_OnWall_InitEv.cpp:
+    complete
+    .text start:0x020cfa90 end:0x020cfaf0
+
+src/func_ov002_020cfaf0.cpp:
+    complete
+    .text start:0x020cfaf0 end:0x020cfbdc
+
+src/func_ov002_020cfbdc.cpp:
+    .text start:0x020cfbdc end:0x020cfd84
+
+src/func_ov002_020cfd84.cpp:
+    complete
+    .text start:0x020cfd84 end:0x020cfea4
+
+src/func_ov002_020d0178.c:
+    complete
+    .text start:0x020d0178 end:0x020d0580
+
+src/func_ov002_020d0580.cpp:
+    .text start:0x020d0580 end:0x020d06c0
+
+src/func_ov002_020d06c0.cpp:
+    .text start:0x020d06c0 end:0x020d0824
+
+src/_ZN6Player17St_LedgeGrab_MainEv.cpp:
+    .text start:0x020d0824 end:0x020d08b0
+
+src/_ZN6Player17St_LedgeGrab_InitEv.cpp:
+    complete
+    .text start:0x020d08b0 end:0x020d092c
+
+src/_ZN6Player20St_LedgeHang_CleanupEv.cpp:
+    .text start:0x020d092c end:0x020d0948
+
+src/func_ov002_020d0948.c:
+    .text start:0x020d0948 end:0x020d0a44
+
+src/_ZN6Player17St_LedgeHang_MainEv.cpp:
+    .text start:0x020d0a44 end:0x020d0c54
+
+src/_ZN6Player17St_LedgeHang_InitEv.cpp:
+    .text start:0x020d0c54 end:0x020d0d2c
+
+src/func_ov002_020d0d2c.cpp:
+    complete
+    .text start:0x020d0d2c end:0x020d0d78
+
+src/_ZN6Player17St_WallSlide_MainEv.cpp:
+    .text start:0x020d0d78 end:0x020d0e8c
+
+src/_ZN6Player17St_WallSlide_InitEv.cpp:
+    complete
+    .text start:0x020d0e8c end:0x020d0ee0
+
+src/_ZN6Player13St_Crawl_MainEv.cpp:
+    .text start:0x020d0ee0 end:0x020d112c
+
+src/_ZN6Player13St_Crawl_InitEv.cpp:
+    complete
+    .text start:0x020d112c end:0x020d1164
+
+src/func_ov002_020d1164.cpp:
+    complete
+    .text start:0x020d1164 end:0x020d1204
+
+src/func_ov002_020d1204.cpp:
+    complete
+    .text start:0x020d1204 end:0x020d12b0
+
+src/func_ov002_020d12b0.cpp:
+    complete
+    .text start:0x020d12b0 end:0x020d1354
+
+src/_ZN6Player14St_Crouch_MainEv.cpp:
+    .text start:0x020d1354 end:0x020d15e0
+
+src/_ZN6Player14St_Crouch_InitEv.cpp:
+    .text start:0x020d15e0 end:0x020d16bc
+
+src/_ZN6Player17St_HoldHeavy_MainEv.cpp:
+    .text start:0x020d16bc end:0x020d19a8
+
+src/_ZN6Player17St_HoldHeavy_InitEv.cpp:
+    complete
+    .text start:0x020d19a8 end:0x020d19fc
+
+src/_ZN6Player20St_HoldLight_CleanupEv.cpp:
+    complete
+    .text start:0x020d19fc end:0x020d1a1c
+
+src/_ZN6Player17St_HoldLight_MainEv.cpp:
+    .text start:0x020d1a1c end:0x020d1ea0
+
+src/_ZN6Player17St_HoldLight_InitEv.cpp:
+    .text start:0x020d1ea0 end:0x020d1f78
+
+src/func_ov002_020d1f78.c:
+    complete
+    .text start:0x020d1f78 end:0x020d2184
+
+src/_ZN6Player21St_WaitQuicksand_MainEv.cpp:
+    complete
+    .text start:0x020d2184 end:0x020d2224
+
+src/_ZN6Player21St_WaitQuicksand_InitEv.cpp:
+    complete
+    .text start:0x020d2224 end:0x020d225c
+
+src/func_ov002_020d225c.c:
+    complete
+    .text start:0x020d225c end:0x020d228c
+
+src/func_ov002_020d228c.cpp:
+    complete
+    .text start:0x020d228c end:0x020d22ec
+
+src/func_ov002_020d22ec.c:
+    complete
+    .text start:0x020d22ec end:0x020d2378
+
+src/_ZN6Player15St_Wait_CleanupEv.cpp:
+    complete
+    .text start:0x020d2378 end:0x020d2404
+
+src/_ZN6Player12St_Wait_MainEv.cpp:
+    .text start:0x020d2404 end:0x020d2da0
+
+src/func_ov002_020d2da0.c:
+    complete
+    .text start:0x020d2da0 end:0x020d2e74
+
+src/func_ov002_020d2e74.cpp:
+    complete
+    .text start:0x020d2e74 end:0x020d2f24
+
+src/func_ov002_020d2f24.c:
+    complete
+    .text start:0x020d2f24 end:0x020d2fdc
+
+src/func_ov002_020d2fdc.c:
+    complete
+    .text start:0x020d2fdc end:0x020d32bc
+
+src/_ZN6Player12St_Wait_InitEv.cpp:
+    complete
+    .text start:0x020d32bc end:0x020d3498
+
+src/func_ov002_020d3498.c:
+    complete
+    .text start:0x020d3498 end:0x020d34bc
+
+src/_ZN6Player18St_TurnAround_MainEv.cpp:
+    .text start:0x020d34bc end:0x020d369c
+
+src/_ZN6Player18St_TurnAround_InitEv.cpp:
+    complete
+    .text start:0x020d369c end:0x020d36d8
+
+src/func_ov002_020d36d8.c:
+    complete
+    .text start:0x020d36d8 end:0x020d38c0
+
+src/_ZN6Player12St_Walk_MainEv.cpp:
+    .text start:0x020d38c0 end:0x020d3b9c
+
+src/func_ov002_020d413c.c:
+    complete
+    .text start:0x020d413c end:0x020d4270
+
+src/_ZN6Player12St_Walk_InitEv.cpp:
+    .text start:0x020d4270 end:0x020d4540
+
+src/func_ov002_020d4540.c:
+    complete
+    .text start:0x020d4540 end:0x020d454c
+
+src/func_ov002_020d454c.cpp:
+    complete
+    .text start:0x020d454c end:0x020d45c0
+
+src/func_ov002_020d45c0.c:
+    complete
+    .text start:0x020d45c0 end:0x020d4748
+
+src/func_ov002_020d4748.cpp:
+    complete
+    .text start:0x020d4748 end:0x020d4c30
+
+src/func_ov002_020d4c30.cpp:
+    .text start:0x020d4c30 end:0x020d4d88
+
+src/func_ov002_020d4d88.c:
+    complete
+    .text start:0x020d4d88 end:0x020d4de8
+
+src/_ZN6Player12St_Bonk_MainEv.cpp:
+    .text start:0x020d4de8 end:0x020d4f8c
+
+src/_ZN6Player12St_Bonk_InitEv.cpp:
+    complete
+    .text start:0x020d4f8c end:0x020d4fe4
+
+src/_ZN6Player8BlowAwayEs.cpp:
+    complete
+    .text start:0x020d4fe4 end:0x020d5038
+
+src/_ZN6Player16St_BurnLava_MainEv.cpp:
+    complete
+    .text start:0x020d5038 end:0x020d529c
+
+src/_ZN6Player16St_BurnLava_InitEv.cpp:
+    .text start:0x020d529c end:0x020d5338
+
+src/func_ov002_020d5338.cpp:
+    complete
+    .text start:0x020d5338 end:0x020d53ac
+
+src/_ZN6Player16St_BurnFire_InitEv.cpp:
+    complete
+    .text start:0x020d5750 end:0x020d57d8
+
+src/_ZN6Player4BurnEv.cpp:
+    .text start:0x020d57d8 end:0x020d5834
+
+src/_ZN6Player19St_Electrocute_MainEv.c:
+    complete
+    .text start:0x020d5834 end:0x020d59b0
+
+src/_ZN6Player19St_Electrocute_InitEv.cpp:
+    complete
+    .text start:0x020d59b0 end:0x020d5a1c
+
+src/_ZN6Player5ShockEj.cpp:
+    .text start:0x020d5a1c end:0x020d5ab4
+
+src/func_ov002_020d5ab4.c:
+    complete
+    .text start:0x020d5ab4 end:0x020d5c6c
+
+src/func_ov002_020d5c6c.c:
+    complete
+    .text start:0x020d5c6c end:0x020d5cec
+
+src/func_ov002_020d5cec.cpp:
+    complete
+    .text start:0x020d5cec end:0x020d5ed0
+
+src/func_ov002_020d5ed0.cpp:
+    complete
+    .text start:0x020d5ed0 end:0x020d5f34
+
+src/func_ov002_020d5f34.cpp:
+    complete
+    .text start:0x020d5f34 end:0x020d5f98
+
+src/func_ov002_020d5f98.cpp:
+    complete
+    .text start:0x020d5f98 end:0x020d600c
+
+src/func_ov002_020d600c.cpp:
+    complete
+    .text start:0x020d600c end:0x020d6048
+
+src/func_ov002_020d6048.cpp:
+    complete
+    .text start:0x020d6048 end:0x020d6084
+
+src/func_ov002_020d6084.c:
+    complete
+    .text start:0x020d6084 end:0x020d60b8
+
+src/_ZN6Player20St_InYoshiMouth_MainEv.cpp:
+    .text start:0x020d60b8 end:0x020d62f8
+
+src/_ZN6Player20St_InYoshiMouth_InitEv.cpp:
+    .text start:0x020d62f8 end:0x020d6334
+
+src/func_ov002_020d6334.c:
+    complete
+    .text start:0x020d6334 end:0x020d6368
+
+src/func_ov002_020d6368.c:
+    complete
+    .text start:0x020d6368 end:0x020d6474
+
+src/_ZN6Player15St_Swallow_MainEv.cpp:
+    .text start:0x020d6474 end:0x020d666c
+
+src/_ZN6Player15St_Swallow_InitEv.cpp:
+    complete
+    .text start:0x020d666c end:0x020d6708
+
+src/_ZN6Player20RegisterEggCoinCountEjbb.cpp:
+    complete
+    .text start:0x020d6708 end:0x020d674c
+
+src/func_ov002_020d674c.c:
+    complete
+    .text start:0x020d674c end:0x020d6790
+
+src/func_ov002_020d6790.cpp:
+    complete
+    .text start:0x020d6790 end:0x020d6998
+
+src/func_ov002_020d6998.cpp:
+    complete
+    .text start:0x020d6998 end:0x020d6c60
+
+src/func_ov002_020d6c60.cpp:
+    .text start:0x020d6c60 end:0x020d6dac
+
+src/func_ov002_020d7030.cpp:
+    complete
+    .text start:0x020d7030 end:0x020d708c
+
+src/func_ov002_020d708c.c:
+    complete
+    .text start:0x020d708c end:0x020d718c
+
+src/func_ov002_020d718c.c:
+    complete
+    .text start:0x020d718c end:0x020d71a0
+
+src/func_ov002_020d71a0.c:
+    complete
+    .text start:0x020d71a0 end:0x020d71ec
+
+src/func_ov002_020d71ec.c:
+    complete
+    .text start:0x020d71ec end:0x020d736c
+
+src/_ZN6Player21St_YoshiPower_CleanupEv.cpp:
+    .text start:0x020d736c end:0x020d7430
+
+src/func_ov002_020d7430.cpp:
+    complete
+    .text start:0x020d7430 end:0x020d7504
+
+src/_ZN6Player18St_YoshiPower_MainEv.cpp:
+    .text start:0x020d7504 end:0x020d7ed0
+
+src/_ZN6Player18St_YoshiPower_InitEv.cpp:
+    .text start:0x020d7ed0 end:0x020d80d0
+
+src/func_ov002_020d80d0.c:
+    complete
+    .text start:0x020d80d0 end:0x020d8118
+
+src/func_ov002_020d8118.c:
+    complete
+    .text start:0x020d8118 end:0x020d8158
+
+src/func_ov002_020d8158.c:
+    complete
+    .text start:0x020d8158 end:0x020d8228
+
+src/_ZN6Player13InitFireYoshiEv.cpp:
+    complete
+    .text start:0x020d8228 end:0x020d8274
+
+src/_ZN6Player21St_DizzyStars_CleanupEv.cpp:
+    complete
+    .text start:0x020d8274 end:0x020d828c
+
+src/_ZN6Player18St_DizzyStars_MainEv.cpp:
+    complete
+    .text start:0x020d828c end:0x020d82cc
+
+src/_ZN6Player18St_DizzyStars_InitEv.cpp:
+    complete
+    .text start:0x020d82cc end:0x020d82f0
+
+src/func_ov002_020d82f0.c:
+    complete
+    .text start:0x020d82f0 end:0x020d8360
+
+src/func_ov002_020d8360.c:
+    complete
+    .text start:0x020d8360 end:0x020d853c
+
+src/func_ov002_020d853c.c:
+    complete
+    .text start:0x020d853c end:0x020d85fc
+
+src/func_ov002_020d85fc.cpp:
+    complete
+    .text start:0x020d85fc end:0x020d869c
+
+src/func_ov002_020d869c.cpp:
+    .text start:0x020d869c end:0x020d8838
+
+src/func_ov002_020d8838.c:
+    complete
+    .text start:0x020d8838 end:0x020d8854
+
+src/func_ov002_020d8854.cpp:
+    complete
+    .text start:0x020d8854 end:0x020d8944
+
+src/func_ov002_020d8944.cpp:
+    .text start:0x020d8944 end:0x020d8a50
+
+src/func_ov002_020d8a50.c:
+    complete
+    .text start:0x020d8a50 end:0x020d8d10
+
+src/func_ov002_020d8d10.c:
+    complete
+    .text start:0x020d8d10 end:0x020d8e70
+
+src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp:
+    .text start:0x020d8e70 end:0x020d91b8
+
+src/func_ov002_020d91b8.c:
+    .text start:0x020d91b8 end:0x020d91e0
+
+src/func_ov002_020d91e0.c:
+    complete
+    .text start:0x020d91e0 end:0x020d9298
+
+src/func_ov002_020d9298.cpp:
+    complete
+    .text start:0x020d9298 end:0x020d932c
+
+src/_ZN6Player6BounceE5Fix12IiE.cpp:
+    complete
+    .text start:0x020d932c end:0x020d93ac
+
+src/func_ov002_020d93ac.cpp:
+    .text start:0x020d93ac end:0x020d94cc
+
+src/func_ov002_020d94cc.cpp:
+    .text start:0x020d94cc end:0x020d9654
+
+src/_ZN6Player15St_Hurt_CleanupEv.cpp:
+    complete
+    .text start:0x020d9654 end:0x020d966c
+
+src/_ZN6Player12St_Hurt_MainEv.cpp:
+    complete
+    .text start:0x020d966c end:0x020d98b4
+
+src/func_ov002_020d98b4.cpp:
+    .text start:0x020d98b4 end:0x020d99a4
+
+src/func_ov002_020d99a4.c:
+    complete
+    .text start:0x020d99a4 end:0x020d9a4c
+
+src/func_ov002_020d9a4c.c:
+    complete
+    .text start:0x020d9a4c end:0x020d9aac
+
+src/func_ov002_020d9aac.c:
+    complete
+    .text start:0x020d9aac end:0x020d9b68
+
+src/_ZN6Player12St_Hurt_InitEv.cpp:
+    .text start:0x020d9b68 end:0x020d9c44
+
+src/_ZN6Player12GetHurtStateEv.cpp:
+    complete
+    .text start:0x020d9c44 end:0x020d9c70
+
+src/func_ov002_020d9c70.c:
+    complete
+    .text start:0x020d9c70 end:0x020d9dcc
+
+src/func_ov002_020d9dcc.c:
+    complete
+    .text start:0x020d9dcc end:0x020d9fc4
+
+src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp:
+    complete
+    .text start:0x020d9fc4 end:0x020d9fec
+
+src/_ZN6Player19St_SwingPlayer_InitEv.cpp:
+    complete
+    .text start:0x020da3b0 end:0x020da41c
+
+src/_ZN6Player25St_GrabBowserTail_CleanupEv.cpp:
+    .text start:0x020da41c end:0x020da438
+
+src/_ZN6Player22St_GrabBowserTail_MainEv.cpp:
+    complete
+    .text start:0x020da438 end:0x020da794
+
+src/_ZN6Player22St_GrabBowserTail_InitEv.cpp:
+    .text start:0x020da794 end:0x020da7f4
+
+src/_ZN6Player9DropActorEv.cpp:
+    complete
+    .text start:0x020da7f4 end:0x020da95c
+
+src/func_ov002_020da95c.c:
+    complete
+    .text start:0x020da95c end:0x020da9d4
+
+src/func_ov002_020da9d4.cpp:
+    complete
+    .text start:0x020da9d4 end:0x020daa74
+
+src/func_ov002_020daa74.cpp:
+    complete
+    .text start:0x020daa74 end:0x020dab14
+
+src/Player_ReleaseHeldActor.c:
+    complete
+    .text start:0x020dab14 end:0x020daba0
+
+src/_ZN6Player7TryGrabER5Actor.cpp:
+    complete
+    .text start:0x020daba0 end:0x020dacb4
+
+src/func_ov002_020dacb4.c:
+    complete
+    .text start:0x020dacb4 end:0x020dae6c
+
+src/_ZN6Player13St_Throw_MainEv.cpp:
+    .text start:0x020dae6c end:0x020dafd4
+
+src/_ZN6Player13St_Throw_InitEv.cpp:
+    complete
+    .text start:0x020dafd4 end:0x020db0a4
+
+src/_ZN6Player17St_Thrown_CleanupEv.cpp:
+    complete
+    .text start:0x020db0a4 end:0x020db0bc
+
+src/_ZN6Player14St_Thrown_MainEv.cpp:
+    .text start:0x020db0bc end:0x020db2e8
+
+src/_ZN6Player14St_Thrown_InitEv.cpp:
+    complete
+    .text start:0x020db2e8 end:0x020db368
+
+src/_ZN6Player18St_Grabbed_CleanupEv.cpp:
+    complete
+    .text start:0x020db368 end:0x020db3bc
+
+src/_ZN6Player15St_Grabbed_MainEv.cpp:
+    .text start:0x020db3bc end:0x020db4d8
+
+src/_ZN6Player15St_Grabbed_InitEv.cpp:
+    complete
+    .text start:0x020db4d8 end:0x020db54c
+
+src/func_ov002_020db54c.cpp:
+    complete
+    .text start:0x020db54c end:0x020db5f4
+
+src/func_ov002_020db5f4.cpp:
+    complete
+    .text start:0x020db5f4 end:0x020db674
+
+src/func_ov002_020db674.c:
+    complete
+    .text start:0x020db674 end:0x020db704
+
+src/func_ov002_020db704.c:
+    complete
+    .text start:0x020db704 end:0x020db8bc
+
+src/func_ov002_020db8bc.c:
+    complete
+    .text start:0x020db8bc end:0x020db8d8
+
+src/func_ov002_020db8d8.cpp:
+    complete
+    .text start:0x020db8d8 end:0x020dba0c
+
+src/func_ov002_020dba0c.c:
+    complete
+    .text start:0x020dba0c end:0x020dbaec
+
+src/func_ov002_020dbaec.c:
+    complete
+    .text start:0x020dbaec end:0x020dbbc0
+
+src/func_ov002_020dbbc0.c:
+    complete
+    .text start:0x020dbbc0 end:0x020dbc94
+
+src/func_ov002_020dbc94.c:
+    complete
+    .text start:0x020dbc94 end:0x020dbd94
+
+src/func_ov002_020dbd94.c:
+    complete
+    .text start:0x020dbd94 end:0x020dbe70
+
+src/func_ov002_020dbe70.c:
+    complete
+    .text start:0x020dbe70 end:0x020dbf4c
+
+src/func_ov002_020dbf4c.c:
+    complete
+    .text start:0x020dbf4c end:0x020dc020
+
+src/func_ov002_020dc020.c:
+    complete
+    .text start:0x020dc020 end:0x020dc09c
+
+src/func_ov002_020dc09c.c:
+    complete
+    .text start:0x020dc09c end:0x020dc174
+
+src/func_ov002_020dc174.c:
+    complete
+    .text start:0x020dc174 end:0x020dc1d0
+
+src/_ZN6Player17St_SlideKick_MainEv.cpp:
+    .text start:0x020dc1d0 end:0x020dc3e0
+
+src/_ZN6Player17St_SlideKick_InitEv.cpp:
+    complete
+    .text start:0x020dc3e0 end:0x020dc48c
+
+src/_ZN6Player17St_SweepKick_MainEv.cpp:
+    complete
+    .text start:0x020dc48c end:0x020dc510
+
+src/_ZN6Player17St_SweepKick_InitEv.cpp:
+    complete
+    .text start:0x020dc510 end:0x020dc560
+
+src/func_ov002_020dc560.c:
+    .text start:0x020dc560 end:0x020dc740
+
+src/_ZN6Player17St_ButtSlide_MainEv.cpp:
+    .text start:0x020dc740 end:0x020dca80
+
+src/_ZN6Player17St_ButtSlide_InitEv.cpp:
+    complete
+    .text start:0x020dca80 end:0x020dcafc
+
+src/func_ov002_020dcafc.c:
+    complete
+    .text start:0x020dcafc end:0x020dcc28
+
+src/_ZN6Player20St_StomachSlide_MainEv.cpp:
+    .text start:0x020dcc28 end:0x020dd104
+
+src/_ZN6Player20St_StomachSlide_InitEv.cpp:
+    complete
+    .text start:0x020dd104 end:0x020dd17c
+
+src/_ZN6Player12St_Dive_InitEv.cpp:
+    complete
+    .text start:0x020dd17c end:0x020dd240
+
+src/_ZN6Player8IsDivingEv.cpp:
+    complete
+    .text start:0x020dd240 end:0x020dd26c
+
+src/_ZN6Player17LostGrabbedObjectEv.cpp:
+    complete
+    .text start:0x020dd26c end:0x020dd2b0
+
+src/_ZN6Player14IsFrontSlidingEv.cpp:
+    complete
+    .text start:0x020dd2b0 end:0x020dd2f4
+
+src/func_ov002_020dd2f4.c:
+    complete
+    .text start:0x020dd2f4 end:0x020dd3c4
+
+src/_ZN6Player17St_PunchKick_MainEv.cpp:
+    .text start:0x020dd3c4 end:0x020dd5ec
+
+src/func_ov002_020dd5ec.c:
+    complete
+    .text start:0x020dd5ec end:0x020dd79c
+
+src/_ZN6Player17St_PunchKick_InitEv.cpp:
+    .text start:0x020dd79c end:0x020dd824
+
+src/func_ov002_020dd824.cpp:
+    complete
+    .text start:0x020dd824 end:0x020dd8b8
+
+src/func_ov002_020dd8b8.cpp:
+    complete
+    .text start:0x020dd8b8 end:0x020dd8f4
+
+src/func_ov002_020dd8f4.c:
+    complete
+    .text start:0x020dd8f4 end:0x020dd908
+
+src/func_ov002_020dd908.c:
+    complete
+    .text start:0x020dd908 end:0x020dd9e0
+
+src/_ZN6Player22St_GroundPound_CleanupEv.cpp:
+    complete
+    .text start:0x020dd9e0 end:0x020dd9f8
+
+src/_ZN6Player19St_GroundPound_InitEv.cpp:
+    .text start:0x020dddf0 end:0x020dde74
+
+src/func_ov002_020dde74.cpp:
+    complete
+    .text start:0x020dde74 end:0x020ddfdc
+
+src/_ZN6Player19St_TornadoSpin_MainEv.cpp:
+    complete
+    .text start:0x020ddfdc end:0x020de2a0
+
+src/_ZN6Player19St_TornadoSpin_InitEv.cpp:
+    .text start:0x020de2a0 end:0x020de328
+
+src/func_ov002_020de328.c:
+    complete
+    .text start:0x020de328 end:0x020de33c
+
+src/func_ov002_020de33c.c:
+    complete
+    .text start:0x020de33c end:0x020de3b4
+
+src/_ZN6Player18St_Balloon_CleanupEv.cpp:
+    .text start:0x020de3b4 end:0x020de3d0
+
+src/func_ov002_020de3d0.c:
+    complete
+    .text start:0x020de3d0 end:0x020de428
+
+src/func_ov002_020de428.c:
+    complete
+    .text start:0x020de428 end:0x020de45c
+
+src/_ZN6Player15St_Balloon_MainEv.cpp:
+    complete
+    .text start:0x020de45c end:0x020de8ac
+
+src/_ZN6Player15St_Balloon_InitEv.cpp:
+    .text start:0x020de8ac end:0x020de968
+
+src/func_ov002_020de968.cpp:
+    .text start:0x020de968 end:0x020dea00
+
+src/_ZN6Player16InitBalloonMarioEv.cpp:
+    .text start:0x020dea00 end:0x020deab8
+
+src/_ZN6Player17St_WindCarry_MainEv.cpp:
+    .text start:0x020deab8 end:0x020dec0c
+
+src/_ZN6Player17St_WindCarry_InitEv.cpp:
+    .text start:0x020dec0c end:0x020dec70
+
+src/func_ov002_020dec70.c:
+    complete
+    .text start:0x020dec70 end:0x020dedf0
+
+src/_ZN6Player21St_JumpQuicksand_MainEv.cpp:
+    complete
+    .text start:0x020dedf0 end:0x020deeac
+
+src/_ZN6Player21St_JumpQuicksand_InitEv.cpp:
+    complete
+    .text start:0x020deeac end:0x020deefc
+
+src/_ZN6Player17St_Cannon_CleanupEv.cpp:
+    complete
+    .text start:0x020deefc end:0x020def14
+
+src/_ZN6Player14St_Cannon_MainEv.cpp:
+    .text start:0x020def14 end:0x020df208
+
+src/_ZN6Player14St_Cannon_InitEv.cpp:
+    complete
+    .text start:0x020df208 end:0x020df288
+
+src/_ZN6Player16IsInsideOfCannonEv.cpp:
+    complete
+    .text start:0x020df288 end:0x020df2c4
+
+src/_ZN6Player22IsBeingShotOutOfCannonEv.cpp:
+    complete
+    .text start:0x020df2c4 end:0x020df300
+
+src/func_ov002_020df300.c:
+    complete
+    .text start:0x020df300 end:0x020df34c
+
+src/func_ov002_020df34c.cpp:
+    .text start:0x020df34c end:0x020df3c8
+
+src/_ZN6Player14St_Owl_CleanupEv.cpp:
+    complete
+    .text start:0x020df3c8 end:0x020df3ec
+
+src/_ZN6Player11St_Owl_MainEv.cpp:
+    .text start:0x020df3ec end:0x020df740
+
+src/_ZN6Player11St_Owl_InitEv.cpp:
+    .text start:0x020df740 end:0x020df7ac
+
+src/func_ov002_020df7ac.c:
+    complete
+    .text start:0x020df7ac end:0x020df7f4
+
+src/func_ov002_020df7f4.cpp:
+    complete
+    .text start:0x020df7f4 end:0x020df840
+
+src/func_ov002_020df840.c:
+    complete
+    .text start:0x020df840 end:0x020df8f0
+
+src/_ZN6Player11St_Fly_MainEv.cpp:
+    .text start:0x020dfdf0 end:0x020e027c
+
+src/_ZN6Player11St_Fly_InitEv.cpp:
+    complete
+    .text start:0x020e027c end:0x020e032c
+
+src/func_ov002_020e032c.c:
+    complete
+    .text start:0x020e032c end:0x020e03b8
+
+src/_ZN6Player16InitWingFeathersEb.cpp:
+    .text start:0x020e03b8 end:0x020e0478
+
+src/func_ov002_020e0478.cpp:
+    complete
+    .text start:0x020e0478 end:0x020e04a4
+
+src/func_ov002_020e04a4.c:
+    complete
+    .text start:0x020e04a4 end:0x020e04ec
+
+src/_ZN6Player12St_Land_MainEv.cpp:
+    .text start:0x020e04ec end:0x020e088c
+
+src/_ZN6Player12St_Land_InitEv.cpp:
+    .text start:0x020e088c end:0x020e0a64
+
+src/func_ov002_020e0a64.c:
+    complete
+    .text start:0x020e0a64 end:0x020e0aa8
+
+src/_ZN6Player21St_SmallLaunchUp_MainEv.cpp:
+    complete
+    .text start:0x020e0aa8 end:0x020e0adc
+
+src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp:
+    complete
+    .text start:0x020e0adc end:0x020e0b50
+
+src/_ZN6Player17St_SlopeJump_MainEv.cpp:
+    complete
+    .text start:0x020e0b50 end:0x020e0c04
+
+src/_ZN6Player17St_SlopeJump_InitEv.cpp:
+    complete
+    .text start:0x020e0c04 end:0x020e0ccc
+
+src/func_ov002_020e0ccc.cpp:
+    complete
+    .text start:0x020e0ccc end:0x020e0d28
+
+src/_ZN6Player22St_CrazedCrate_CleanupEv.cpp:
+    complete
+    .text start:0x020e0d28 end:0x020e0d48
+
+src/_ZN6Player19St_CrazedCrate_MainEv.cpp:
+    .text start:0x020e0d48 end:0x020e0f38
+
+src/func_ov002_020e0f38.cpp:
+    complete
+    .text start:0x020e0f38 end:0x020e0fac
+
+src/_ZN6Player19St_CrazedCrate_InitEv.cpp:
+    .text start:0x020e0fac end:0x020e1020
+
+src/_ZN6Player10SpinBounceE5Fix12IiE.cpp:
+    complete
+    .text start:0x020e1020 end:0x020e10a8
+
+src/func_ov002_020e10a8.cpp:
+    complete
+    .text start:0x020e10a8 end:0x020e10d4
+
+src/_ZN6Player15St_Spin_CleanupEv.cpp:
+    complete
+    .text start:0x020e10d4 end:0x020e10ec
+
+src/_ZN6Player12St_Spin_MainEv.c:
+    complete
+    .text start:0x020e10ec end:0x020e119c
+
+src/_ZN6Player12St_Spin_InitEv.cpp:
+    complete
+    .text start:0x020e119c end:0x020e1238
+
+src/_ZN6Player16St_LongJump_MainEv.cpp:
+    complete
+    .text start:0x020e1238 end:0x020e127c
+
+src/_ZN6Player16St_LongJump_InitEv.cpp:
+    complete
+    .text start:0x020e127c end:0x020e13c0
+
+src/_ZN6Player16St_SideFlip_MainEv.cpp:
+    .text start:0x020e13c0 end:0x020e162c
+
+src/_ZN6Player17St_WaterJump_InitEv.cpp:
+    complete
+    .text start:0x020e162c end:0x020e16a4
+
+src/_ZN6Player21St_HeadstandJump_InitEv.cpp:
+    complete
+    .text start:0x020e16a4 end:0x020e1714
+
+src/_ZN6Player16St_WallJump_MainEv.cpp:
+    .text start:0x020e1714 end:0x020e17f8
+
+src/func_ov002_020e17f8.c:
+    .text start:0x020e17f8 end:0x020e18a8
+
+src/_ZN6Player16St_BackFlip_InitEv.cpp:
+    .text start:0x020e18a8 end:0x020e1990
+
+src/_ZN6Player24St_SlideKickRecover_InitEv.cpp:
+    .text start:0x020e1990 end:0x020e1a10
+
+src/_ZN6Player16St_SideFlip_InitEv.cpp:
+    .text start:0x020e1a10 end:0x020e1af8
+
+src/_ZN6Player12St_Fall_MainEv.cpp:
+    .text start:0x020e1af8 end:0x020e1b80
+
+src/_ZN6Player12St_Fall_InitEv.cpp:
+    .text start:0x020e1b80 end:0x020e1c20
+
+src/func_ov002_020e1c20.c:
+    complete
+    .text start:0x020e1c20 end:0x020e1e70
+
+src/func_ov002_020e1e70.c:
+    complete
+    .text start:0x020e1e70 end:0x020e200c
+
+src/func_ov002_020e200c.c:
+    complete
+    .text start:0x020e200c end:0x020e2118
+
+src/_ZN6Player12St_Jump_MainEv.cpp:
+    .text start:0x020e2118 end:0x020e22c0
+
+src/_ZN6Player12St_Jump_InitEv.cpp:
+    complete
+    .text start:0x020e22c0 end:0x020e25d4
+
+src/func_ov002_020e25d4.cpp:
+    complete
+    .text start:0x020e25d4 end:0x020e25f0
+
+src/func_ov002_020e25f0.c:
+    complete
+    .text start:0x020e25f0 end:0x020e2664
+
+src/func_ov002_020e2664.c:
+    .text start:0x020e2664 end:0x020e28d4
+
+src/func_ov002_020e28d4.c:
+    complete
+    .text start:0x020e28d4 end:0x020e2ad0
+
+src/func_ov002_020e2ad0.c:
+    complete
+    .text start:0x020e2ad0 end:0x020e2b6c
+
+src/func_ov002_020e2b6c.cpp:
+    complete
+    .text start:0x020e2b6c end:0x020e2ba8
+
+src/func_ov002_020e2ba8.cpp:
+    complete
+    .text start:0x020e2ba8 end:0x020e2be4
+
+src/func_ov002_020e2be4.cpp:
+    complete
+    .text start:0x020e2be4 end:0x020e2c84
+
+src/func_ov002_020e2c84.c:
+    complete
+    .text start:0x020e2c84 end:0x020e2ea0
+
+src/func_ov002_020e2ea0.cpp:
+    complete
+    .text start:0x020e2ea0 end:0x020e301c
+
+src/func_ov002_020e301c.c:
+    complete
+    .text start:0x020e301c end:0x020e3078
+
+src/func_ov002_020e3078.c:
+    complete
+    .text start:0x020e3078 end:0x020e308c
+
+src/_ZN6Player7IsStateERNS_5StateE.c:
+    complete
+    .text start:0x020e308c end:0x020e30a0
+
+src/_ZN6Player11ChangeStateERNS_5StateE.cpp:
+    .text start:0x020e30a0 end:0x020e32d4
+
+src/_ZN6Player16CleanupResourcesEv.cpp:
+    .text start:0x020e32d4 end:0x020e3a04
+
+src/_ZN6Player16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x020e3a04 end:0x020e3a08
+
+src/_ZN6Player6RenderEv.cpp:
+    .text start:0x020e3a08 end:0x020e3e00
+
+src/func_ov002_020e3e00.cpp:
+    .text start:0x020e3e00 end:0x020e3f90
+
+src/func_ov002_020e3f90.c:
+    complete
+    .text start:0x020e3f90 end:0x020e4374
+
+src/func_ov002_020e4374.c:
+    complete
+    .text start:0x020e4374 end:0x020e444c
+
+src/func_ov002_020e444c.c:
+    complete
+    .text start:0x020e444c end:0x020e4768
+
+src/func_ov002_020e4768.cpp:
+    complete
+    .text start:0x020e4768 end:0x020e496c
+
+src/func_ov002_020e496c.c:
+    complete
+    .text start:0x020e496c end:0x020e4990
+
+src/func_ov002_020e4990.c:
+    complete
+    .text start:0x020e4990 end:0x020e4bb8
+
+src/func_ov002_020e4bb8.c:
+    complete
+    .text start:0x020e4bb8 end:0x020e4d24
+
+src/_ZN6Player8BehaviorEv.cpp:
+    .text start:0x020e4d24 end:0x020e558c
+
+src/func_ov002_020e5948.c:
+    complete
+    .text start:0x020e5948 end:0x020e6330
+
+src/func_ov002_020e6330.c:
+    complete
+    .text start:0x020e6330 end:0x020e6350
+
+src/func_ov002_020e6350.c:
+    complete
+    .text start:0x020e6350 end:0x020e63a4
+
+src/func_ov002_020e63a4.c:
+    complete
+    .text start:0x020e63a4 end:0x020e640c
+
+src/func_ov002_020e640c.c:
+    complete
+    .text start:0x020e640c end:0x020e6780
+
+src/func_ov002_020e6780.c:
+    complete
+    .text start:0x020e6780 end:0x020e67a8
+
+src/_ZN6PlayerD0Ev.cpp:
+    complete
+    .text start:0x020e67a8 end:0x020e6858
+
+src/_ZN6PlayerD2Ev.cpp:
+    complete
+    .text start:0x020e6858 end:0x020e68f4
+
+src/_ZN6PlayerC1Ev.cpp:
+    complete
+    .text start:0x020e68f4 end:0x020e69b8
+
+src/_ZN6Player13OnYoshiTryEatEv.cpp:
+    complete
+    .text start:0x020e69b8 end:0x020e69c0
+
+src/func_ov002_020e69c0.c:
+    complete
+    .text start:0x020e69c0 end:0x020e6a08
+
+src/Color_Interp.c:
+    complete
+    .text start:0x020e6a08 end:0x020e6a78
+
+src/func_ov002_020e6a78.c:
+    complete
+    .text start:0x020e6a78 end:0x020e6ad4
+
+src/func_ov002_020e6ad4.c:
+    complete
+    .text start:0x020e6ad4 end:0x020e6b3c
+
+src/func_ov002_020e6b3c.c:
+    complete
+    .text start:0x020e6b3c end:0x020e6b74
+
+src/func_ov002_020e6b74.c:
+    complete
+    .text start:0x020e6b74 end:0x020e6bb0
+
+src/func_ov002_020e6bb0.c:
+    complete
+    .text start:0x020e6bb0 end:0x020e6c0c
+
+src/_ZN6PlayerC3Ev.cpp:
+    complete
+    .text start:0x020e6c0c end:0x020e6c40
+
+src/_ZN9PowerStarD1Ev.c:
+    complete
+    .text start:0x020e6c40 end:0x020e6c90
+
+src/_ZN9PowerStarD0Ev.c:
+    complete
+    .text start:0x020e6c90 end:0x020e6cf4
+
+src/_ZN10StarMarkerD1Ev.cpp:
+    .text start:0x020e6cf4 end:0x020e6d34
+
+src/_ZN10StarMarkerD0Ev.c:
+    complete
+    .text start:0x020e6d34 end:0x020e6d88
+
+src/func_ov002_020e6d88.c:
+    complete
+    .text start:0x020e6d88 end:0x020e6df8
+
+src/func_ov002_020e6df8.cpp:
+    complete
+    .text start:0x020e6df8 end:0x020e6edc
+
+src/func_ov002_020e6edc.c:
+    complete
+    .text start:0x020e6edc end:0x020e6fbc
+
+src/func_ov002_020e6fbc.cpp:
+    complete
+    .text start:0x020e6fbc end:0x020e700c
+
+src/func_ov002_020e700c.c:
+    complete
+    .text start:0x020e700c end:0x020e7090
+
+src/func_ov002_020e7090.cpp:
+    complete
+    .text start:0x020e7090 end:0x020e7104
+
+src/func_ov002_020e7104.c:
+    .text start:0x020e7104 end:0x020e717c
+
+src/UnloadSilverStarAndNumber.c:
+    complete
+    .text start:0x020e717c end:0x020e71a8
+
+src/LoadSilverStarAndNumber.c:
+    complete
+    .text start:0x020e71a8 end:0x020e71d4
+
+src/LinkSilverStarAndStarMarker.c:
+    complete
+    .text start:0x020e71d4 end:0x020e7218
+
+src/func_ov002_020e7218.c:
+    complete
+    .text start:0x020e7218 end:0x020e72d8
+
+src/_ZN10StarMarker27SpawnRedCoinStarIfNecessaryEv.cpp:
+    complete
+    .text start:0x020e72d8 end:0x020e73ac
+
+src/func_ov002_020e73ac.cpp:
+    complete
+    .text start:0x020e73ac end:0x020e7454
+
+src/func_ov002_020e7454.c:
+    complete
+    .text start:0x020e7454 end:0x020e7554
+
+src/func_ov002_020e7554.c:
+    .text start:0x020e7554 end:0x020e763c
+
+src/func_ov002_020e763c.c:
+    complete
+    .text start:0x020e763c end:0x020e7934
+
+src/func_ov002_020e7934.cpp:
+    complete
+    .text start:0x020e7934 end:0x020e7c90
+
+src/func_ov002_020e7c90.cpp:
+    complete
+    .text start:0x020e7c90 end:0x020e7d08
+
+src/func_ov002_020e7d08.cpp:
+    complete
+    .text start:0x020e7d08 end:0x020e7d84
+
+src/func_ov002_020e7d84.c:
+    complete
+    .text start:0x020e7d84 end:0x020e7e14
+
+src/func_ov002_020e7e14.c:
+    complete
+    .text start:0x020e7e14 end:0x020e7e24
+
+src/func_ov002_020e7e24.c:
+    complete
+    .text start:0x020e7e24 end:0x020e7e58
+
+src/func_ov002_020e7e58.cpp:
+    complete
+    .text start:0x020e7e58 end:0x020e7eb4
+
+src/func_ov002_020e7eb4.c:
+    complete
+    .text start:0x020e7eb4 end:0x020e7eb8
+
+src/func_ov002_020e7eb8.cpp:
+    complete
+    .text start:0x020e7eb8 end:0x020e7f2c
+
+src/func_ov002_020e7f2c.c:
+    complete
+    .text start:0x020e7f2c end:0x020e7fcc
+
+src/func_ov002_020e7fcc.c:
+    complete
+    .text start:0x020e7fcc end:0x020e8098
+
+src/func_ov002_020e8098.cpp:
+    complete
+    .text start:0x020e8098 end:0x020e81e0
+
+src/func_ov002_020e81e0.cpp:
+    .text start:0x020e81e0 end:0x020e8244
+
+src/func_ov002_020e8244.c:
+    complete
+    .text start:0x020e8244 end:0x020e8398
+
+src/func_ov002_020e8398.c:
+    complete
+    .text start:0x020e8398 end:0x020e84ec
+
+src/func_ov002_020e84ec.c:
+    complete
+    .text start:0x020e84ec end:0x020e8618
+
+src/func_ov002_020e8618.c:
+    complete
+    .text start:0x020e8618 end:0x020e86ec
+
+src/func_ov002_020e86ec.c:
+    complete
+    .text start:0x020e86ec end:0x020e88a8
+
+src/func_ov002_020e88a8.c:
+    complete
+    .text start:0x020e88a8 end:0x020e8abc
+
+src/func_ov002_020e8abc.c:
+    complete
+    .text start:0x020e8abc end:0x020e8c34
+
+src/func_ov002_020e8c34.c:
+    complete
+    .text start:0x020e8c34 end:0x020e8ca0
+
+src/_ZN9PowerStar13AddStarMarkerEv.cpp:
+    .text start:0x020e8ca0 end:0x020e8dd8
+
+src/func_ov002_020e8dd8.c:
+    complete
+    .text start:0x020e8dd8 end:0x020e8e80
+
+src/func_ov002_020e8e80.c:
+    complete
+    .text start:0x020e8e80 end:0x020e8edc
+
+src/func_ov002_020e8edc.c:
+    complete
+    .text start:0x020e8edc end:0x020e8ee8
+
+src/func_ov002_020e8ee8.c:
+    complete
+    .text start:0x020e8ee8 end:0x020e8ef0
+
+src/func_ov002_020e8ef0.cpp:
+    complete
+    .text start:0x020e8ef0 end:0x020e930c
+
+src/func_ov002_020e930c.c:
+    complete
+    .text start:0x020e930c end:0x020e9448
+
+src/func_ov002_020e9448.c:
+    complete
+    .text start:0x020e9448 end:0x020e9464
+
+src/func_ov002_020e9464.c:
+    complete
+    .text start:0x020e9464 end:0x020e947c
+
+src/func_ov002_020e947c.c:
+    .text start:0x020e947c end:0x020e9590
+
+src/func_ov002_020e9590.cpp:
+    complete
+    .text start:0x020e9590 end:0x020e9630
+
+src/func_ov002_020e9630.c:
+    complete
+    .text start:0x020e9630 end:0x020e96a0
+
+src/func_ov002_020e96a0.c:
+    complete
+    .text start:0x020e96a0 end:0x020e9804
+
+src/func_ov002_020e9804.cpp:
+    complete
+    .text start:0x020e9804 end:0x020e9840
+
+src/func_ov002_020e9840.c:
+    complete
+    .text start:0x020e9840 end:0x020e99e8
+
+src/func_ov002_020e99e8.c:
+    complete
+    .text start:0x020e99e8 end:0x020e9af4
+
+src/func_ov002_020e9af4.c:
+    complete
+    .text start:0x020e9af4 end:0x020e9d18
+
+src/func_ov002_020e9d18.c:
+    .text start:0x020e9d18 end:0x020ea06c
+
+src/func_ov002_020ea06c.cpp:
+    complete
+    .text start:0x020ea06c end:0x020ea100
+
+src/func_ov002_020ea100.cpp:
+    complete
+    .text start:0x020ea100 end:0x020ea3a4
+
+src/func_ov002_020ea3a4.cpp:
+    complete
+    .text start:0x020ea3a4 end:0x020ea410
+
+src/func_ov002_020ea410.c:
+    complete
+    .text start:0x020ea410 end:0x020ea420
+
+src/func_ov002_020ea420.c:
+    complete
+    .text start:0x020ea420 end:0x020ea7ac
+
+src/func_ov002_020ea7ac.c:
+    complete
+    .text start:0x020ea7ac end:0x020ea824
+
+src/func_ov002_020ea824.c:
+    complete
+    .text start:0x020ea824 end:0x020ea90c
+
+src/func_ov002_020ea90c.cpp:
+    complete
+    .text start:0x020ea90c end:0x020ea9d0
+
+src/func_ov002_020ea9d0.c:
+    complete
+    .text start:0x020ea9d0 end:0x020eab8c
+
+src/_ZN10StarMarker16OnPendingDestroyEv.cpp:
+    .text start:0x020eab8c end:0x020eabcc
+
+src/_ZN10StarMarker16CleanupResourcesEv.cpp:
+    .text start:0x020eabcc end:0x020eac18
+
+src/_ZN9PowerStar16CleanupResourcesEv.cpp:
+    .text start:0x020eac18 end:0x020eacb8
+
+src/_ZN10StarMarker6RenderEv.cpp:
+    complete
+    .text start:0x020eacb8 end:0x020eacf4
+
+src/_ZN9PowerStar6RenderEv.cpp:
+    complete
+    .text start:0x020eacf4 end:0x020ead90
+
+src/_ZN10StarMarker8BehaviorEv.cpp:
+    .text start:0x020ead90 end:0x020eb05c
+
+src/_ZN9PowerStar8BehaviorEv.cpp:
+    .text start:0x020eb05c end:0x020eb204
+
+src/_ZN10StarMarker13InitResourcesEv.cpp:
+    .text start:0x020eb204 end:0x020eb63c
+
+src/_ZN9PowerStar13InitResourcesEv.cpp:
+    complete
+    .text start:0x020eb63c end:0x020ebe5c
+
+src/StarCamera_Spawn.cpp:
+    complete
+    .text start:0x020ebe5c end:0x020ebe8c
+
+src/StarMarker_Spawn.c:
+    complete
+    .text start:0x020ebe8c end:0x020ebed4
+
+src/SilverStar_Spawn.c:
+    complete
+    .text start:0x020ebed4 end:0x020ebf30
+
+src/PowerStar_Spawn.c:
+    complete
+    .text start:0x020ebf30 end:0x020ebf8c
+
+src/_ZN4TreeD1Ev.cpp:
+    complete
+    .text start:0x020ebf8c end:0x020ebfcc
+
+src/_ZN4TreeD0Ev.cpp:
+    complete
+    .text start:0x020ebfcc end:0x020ec020
+
+src/_ZN4Tree16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020ec020 end:0x020ec0a0
+
+src/_ZN4Tree16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020ec0a0 end:0x020ec0a4
+
+src/_ZN4Tree6RenderEv.cpp:
+    complete
+    .text start:0x020ec0a4 end:0x020ec1d8
+
+src/_ZN4Tree8BehaviorEv.cpp:
+    complete
+    .text start:0x020ec1d8 end:0x020ec22c
+
+src/_ZN4Tree13InitResourcesEv.cpp:
+    .text start:0x020ec22c end:0x020ec32c
+
+src/Tree_Spawn.cpp:
+    complete
+    .text start:0x020ec32c end:0x020ec388
+
+src/func_ov002_020ec388.c:
+    .text start:0x020ec388 end:0x020ec3b8
+
+src/func_ov002_020ec3b8.c:
+    .text start:0x020ec3b8 end:0x020ec3fc
+
+src/func_ov002_020ec3fc.c:
+    complete
+    .text start:0x020ec3fc end:0x020ec404
+
+src/func_ov002_020ec404.c:
+    complete
+    .text start:0x020ec404 end:0x020ec408
+
+src/func_ov002_020ec408.c:
+    complete
+    .text start:0x020ec408 end:0x020ec410
+
+src/func_ov002_020ec410.c:
+    complete
+    .text start:0x020ec410 end:0x020ec4c4
+
+src/func_ov002_020ec4c4.c:
+    complete
+    .text start:0x020ec4c4 end:0x020ec534
+
+src/Warp_Spawn.c:
+    .text start:0x020ec534 end:0x020ec56c
+
+src/_ZN8YoshiEggD1Ev.c:
+    complete
+    .text start:0x020ec56c end:0x020ec5b4
+
+src/_ZN8YoshiEggD0Ev.c:
+    complete
+    .text start:0x020ec5b4 end:0x020ec610
+
+src/func_ov002_020ec610.c:
+    complete
+    .text start:0x020ec610 end:0x020ec628
+
+src/func_ov002_020ec628.c:
+    complete
+    .text start:0x020ec628 end:0x020ec640
+
+src/func_ov002_020ec640.c:
+    complete
+    .text start:0x020ec640 end:0x020ec654
+
+src/func_ov002_020ec654.c:
+    complete
+    .text start:0x020ec654 end:0x020ec670
+
+src/func_ov002_020ec670.c:
+    .text start:0x020ec670 end:0x020ec728
+
+src/func_ov002_020ec728.c:
+    complete
+    .text start:0x020ec728 end:0x020ec80c
+
+src/func_ov002_020ec80c.c:
+    complete
+    .text start:0x020ec80c end:0x020ec938
+
+src/func_ov002_020ec938.cpp:
+    complete
+    .text start:0x020ec938 end:0x020ec978
+
+src/func_ov002_020ec978.c:
+    complete
+    .text start:0x020ec978 end:0x020ec9c4
+
+src/func_ov002_020ec9c4.c:
+    complete
+    .text start:0x020ec9c4 end:0x020ecad4
+
+src/func_ov002_020ecad4.c:
+    complete
+    .text start:0x020ecad4 end:0x020ecb0c
+
+src/func_ov002_020ecb0c.c:
+    complete
+    .text start:0x020ecb0c end:0x020ecd18
+
+src/func_ov002_020ecd18.cpp:
+    complete
+    .text start:0x020ecd18 end:0x020ecf94
+
+src/func_ov002_020ecf94.c:
+    complete
+    .text start:0x020ecf94 end:0x020ecfc8
+
+src/func_ov002_020ecfc8.c:
+    complete
+    .text start:0x020ecfc8 end:0x020ed0d4
+
+src/func_ov002_020ed0d4.c:
+    complete
+    .text start:0x020ed0d4 end:0x020ed5b0
+
+src/func_ov002_020ed5b0.c:
+    complete
+    .text start:0x020ed5b0 end:0x020ed63c
+
+src/func_ov002_020ed63c.cpp:
+    complete
+    .text start:0x020ed63c end:0x020ed684
+
+src/func_ov002_020ed684.cpp:
+    complete
+    .text start:0x020ed684 end:0x020ed6cc
+
+src/func_ov002_020ed6cc.c:
+    complete
+    .text start:0x020ed6cc end:0x020ed738
+
+src/func_ov002_020ed738.cpp:
+    complete
+    .text start:0x020ed738 end:0x020ed7f8
+
+src/func_ov002_020ed7f8.c:
+    complete
+    .text start:0x020ed7f8 end:0x020ed998
+
+src/func_ov002_020ed998.cpp:
+    complete
+    .text start:0x020ed998 end:0x020edb3c
+
+src/func_ov002_020edb3c.cpp:
+    complete
+    .text start:0x020edb3c end:0x020edca4
+
+src/func_ov002_020edca4.c:
+    complete
+    .text start:0x020edca4 end:0x020eddc4
+
+src/func_ov002_020eddc4.c:
+    complete
+    .text start:0x020eddc4 end:0x020edf54
+
+src/_ZN8YoshiEgg16CleanupResourcesEv.cpp:
+    .text start:0x020edf54 end:0x020edf98
+
+src/_ZN8YoshiEgg6RenderEv.cpp:
+    .text start:0x020edf98 end:0x020ee010
+
+src/_ZN8YoshiEgg8BehaviorEv.cpp:
+    .text start:0x020ee010 end:0x020ee144
+
+src/_ZN8YoshiEgg13InitResourcesEv.c:
+    complete
+    .text start:0x020ee144 end:0x020ee3d8
+
+src/YoshiEgg_Spawn.c:
+    complete
+    .text start:0x020ee3d8 end:0x020ee42c
+
+src/_ZN8PlatformD2Ev.c:
+    complete
+    .text start:0x020ee42c end:0x020ee464
+
+src/_ZN8PlatformD0Ev.c:
+    .text start:0x020ee464 end:0x020ee4b0
+
+src/_ZN8Platform14KillByMegaCharER6Player.c:
+    complete
+    .text start:0x020ee4b0 end:0x020ee55c
+
+src/_ZN8Platform4KillEv.cpp:
+    complete
+    .text start:0x020ee55c end:0x020ee5d0
+
+src/func_ov002_020ee5d0.c:
+    complete
+    .text start:0x020ee5d0 end:0x020ee674
+
+src/_ZN8Platform20UpdateKillByMegaCharEsss5Fix12IiE.cpp:
+    .text start:0x020ee674 end:0x020ee7cc
+
+src/_ZN8Platform19UpdateClsnPosAndRotEv.cpp:
+    complete
+    .text start:0x020ee7cc end:0x020ee830
+
+src/_ZN8Platform21UpdateModelPosAndRotYEv.cpp:
+    .text start:0x020ee830 end:0x020ee870
+
+src/_ZN8Platform13IsClsnInRangeE5Fix12IiES1_.cpp:
+    .text start:0x020ee870 end:0x020ee934
+
+src/_ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_.cpp:
+    .text start:0x020ee934 end:0x020eea50
+
+src/_ZN8PlatformC2Ev.c:
+    complete
+    .text start:0x020eea50 end:0x020eea84
+
+src/func_ov002_020eea84.c:
+    complete
+    .text start:0x020eea84 end:0x020eeca8
+
+src/func_ov002_020eeca8.cpp:
+    complete
+    .text start:0x020eeca8 end:0x020eed24
+
+src/func_ov002_020eed24.cpp:
+    complete
+    .text start:0x020eed24 end:0x020eedc0
+
+src/func_ov002_020eedc0.cpp:
+    complete
+    .text start:0x020eedc0 end:0x020eee3c
+
+src/func_ov002_020eee3c.cpp:
+    complete
+    .text start:0x020eee3c end:0x020eeeb8
+
+src/func_ov002_020eeeb8.cpp:
+    complete
+    .text start:0x020eeeb8 end:0x020ef070
+
+src/func_ov002_020ef070.cpp:
+    complete
+    .text start:0x020ef070 end:0x020ef228
+
+src/func_ov002_020ef228.cpp:
+    complete
+    .text start:0x020ef228 end:0x020ef2a4
+
+src/func_ov002_020ef2a4.cpp:
+    complete
+    .text start:0x020ef2a4 end:0x020ef320
+
+src/_ZN8PathLiftD0Ev.c:
+    complete
+    .text start:0x020ef320 end:0x020ef390
+
+src/_ZN8PathLiftD2Ev.c:
+    complete
+    .text start:0x020ef390 end:0x020ef3ec
+
+src/func_ov002_020ef3ec.c:
+    complete
+    .text start:0x020ef3ec end:0x020ef3f0
+
+src/func_ov002_020ef3f0.c:
+    complete
+    .text start:0x020ef3f0 end:0x020ef408
+
+src/func_ov002_020ef408.c:
+    complete
+    .text start:0x020ef408 end:0x020ef57c
+
+src/func_ov002_020ef57c.c:
+    complete
+    .text start:0x020ef57c end:0x020ef670
+
+src/func_ov002_020ef670.c:
+    .text start:0x020ef670 end:0x020efa44
+
+src/func_ov002_020efa44.c:
+    complete
+    .text start:0x020efa44 end:0x020efa54
+
+src/func_ov002_020efa54.cpp:
+    complete
+    .text start:0x020efa54 end:0x020efaa0
+
+src/_ZN8PathLift12BaseBehaviorEv.cpp:
+    complete
+    .text start:0x020efaa0 end:0x020efaf0
+
+src/func_ov002_020efaf0.cpp:
+    .text start:0x020efaf0 end:0x020efbdc
+
+src/func_ov002_020efbdc.c:
+    complete
+    .text start:0x020efbdc end:0x020efc74
+
+src/func_ov002_020efc74.cpp:
+    complete
+    .text start:0x020efc74 end:0x020efcf4
+
+src/func_ov002_020efcf4.c:
+    complete
+    .text start:0x020efcf4 end:0x020efe68
+
+src/func_ov002_020efe68.c:
+    complete
+    .text start:0x020efe68 end:0x020efe7c
+
+src/func_ov002_020efe7c.c:
+    complete
+    .text start:0x020efe7c end:0x020efe9c
+
+src/func_ov002_020efe9c.c:
+    complete
+    .text start:0x020efe9c end:0x020efebc
+
+src/func_ov002_020efebc.c:
+    complete
+    .text start:0x020efebc end:0x020efedc
+
+src/func_ov002_020efedc.c:
+    complete
+    .text start:0x020efedc end:0x020eff04
+
+src/func_ov002_020eff04.cpp:
+    complete
+    .text start:0x020eff04 end:0x020eff18
+
+src/_ZN8PathLift9AfterClsnEv.cpp:
+    complete
+    .text start:0x020eff18 end:0x020eff90
+
+src/func_ov002_020eff90.cpp:
+    complete
+    .text start:0x020eff90 end:0x020effb8
+
+src/func_ov002_020effb8.c:
+    complete
+    .text start:0x020effb8 end:0x020f02c8
+
+src/func_ov002_020f02c8.c:
+    complete
+    .text start:0x020f02c8 end:0x020f030c
+
+src/func_ov002_020f030c.c:
+    complete
+    .text start:0x020f030c end:0x020f035c
+
+src/func_ov002_020f035c.c:
+    complete
+    .text start:0x020f035c end:0x020f03c4
+
+src/func_ov002_020f03c4.c:
+    .text start:0x020f03c4 end:0x020f03f4
+
+src/func_ov002_020f03f4.c:
+    .text start:0x020f03f4 end:0x020f0438
+
+src/func_ov002_020f0438.cpp:
+    complete
+    .text start:0x020f0438 end:0x020f051c
+
+src/func_ov002_020f051c.c:
+    .text start:0x020f051c end:0x020f05f4
+
+src/func_ov002_020f05f4.c:
+    complete
+    .text start:0x020f05f4 end:0x020f069c
+
+src/func_ov002_020f069c.c:
+    complete
+    .text start:0x020f069c end:0x020f06c0
+
+src/func_ov002_020f06c0.cpp:
+    .text start:0x020f06c0 end:0x020f07dc
+
+src/func_ov002_020f07dc.c:
+    complete
+    .text start:0x020f07dc end:0x020f085c
+
+src/InvisibleSecret_Spawn.c:
+    .text start:0x020f085c end:0x020f0894
+
+src/_ZN15InvisibleSecretD1Ev.cpp:
+    .text start:0x020f0894 end:0x020f08cc
+
+src/_ZN15InvisibleSecretD0Ev.c:
+    complete
+    .text start:0x020f08cc end:0x020f0918
+
+src/func_ov002_020f0918.c:
+    complete
+    .text start:0x020f0918 end:0x020f093c
+
+src/_ZN15InvisibleSecret16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020f093c end:0x020f0994
+
+src/_ZN15InvisibleSecret6RenderEv.cpp:
+    complete
+    .text start:0x020f0994 end:0x020f0a60
+
+src/_ZN15InvisibleSecret8BehaviorEv.cpp:
+    .text start:0x020f0a60 end:0x020f0bd4
+
+src/_ZN15InvisibleSecret13InitResourcesEv.cpp:
+    complete
+    .text start:0x020f0bd4 end:0x020f0d90
+
+src/Number_Spawn.c:
+    complete
+    .text start:0x020f0d90 end:0x020f0dd0
+
+src/_ZN9OneUpLogoD1Ev.cpp:
+    .text start:0x020f0dd0 end:0x020f0e08
+
+src/_ZN9OneUpLogoD0Ev.c:
+    complete
+    .text start:0x020f0e08 end:0x020f0e54
+
+src/func_ov002_020f0e54.c:
+    complete
+    .text start:0x020f0e54 end:0x020f0e78
+
+src/_ZN9OneUpLogo16CleanupResourcesEv.c:
+    complete
+    .text start:0x020f0e78 end:0x020f0ea8
+
+src/_ZN9OneUpLogo6RenderEv.cpp:
+    complete
+    .text start:0x020f0ea8 end:0x020f0f08
+
+src/_ZN9OneUpLogo8BehaviorEv.c:
+    complete
+    .text start:0x020f0f08 end:0x020f107c
+
+src/_ZN9OneUpLogo13InitResourcesEv.cpp:
+    complete
+    .text start:0x020f107c end:0x020f1170
+
+src/OneUpLogo_Spawn.c:
+    complete
+    .text start:0x020f1170 end:0x020f11b0
+
+src/func_ov002_020f11b0.c:
+    .text start:0x020f11b0 end:0x020f11f4
+
+src/func_ov002_020f11f4.c:
+    .text start:0x020f11f4 end:0x020f124c
+
+src/func_ov002_020f124c.c:
+    .text start:0x020f124c end:0x020f1290
+
+src/func_ov002_020f1290.cpp:
+    complete
+    .text start:0x020f1290 end:0x020f12c8
+
+src/func_ov002_020f12c8.c:
+    complete
+    .text start:0x020f12c8 end:0x020f1468
+
+src/func_ov002_020f1468.c:
+    complete
+    .text start:0x020f1468 end:0x020f1578
+
+src/func_ov002_020f1578.c:
+    complete
+    .text start:0x020f1578 end:0x020f15b8
+
+src/func_ov002_020f15b8.c:
+    complete
+    .text start:0x020f15b8 end:0x020f15cc
+
+src/BlueCoinSwitch_Spawn.c:
+    complete
+    .text start:0x020f15cc end:0x020f15fc
+
+src/_ZN14BlueCoinSwitchD1Ev.cpp:
+    .text start:0x020f15fc end:0x020f162c
+
+src/_ZN14BlueCoinSwitchD0Ev.c:
+    complete
+    .text start:0x020f162c end:0x020f1670
+
+src/_ZN12EnemySpawnerD1Ev.cpp:
+    .text start:0x020f1670 end:0x020f1694
+
+src/_ZN12EnemySpawnerD0Ev.c:
+    .text start:0x020f1694 end:0x020f16cc
+
+src/_ZN14BlueCoinSwitch16CleanupResourcesEv.cpp:
+    .text start:0x020f16cc end:0x020f16ec
+
+src/_ZN12EnemySpawner8BehaviorEv.cpp:
+    complete
+    .text start:0x020f16ec end:0x020f1760
+
+src/_ZN14BlueCoinSwitch8BehaviorEv.cpp:
+    .text start:0x020f1760 end:0x020f1814
+
+src/_ZN12EnemySpawner16CleanupResourcesEv.c:
+    complete
+    .text start:0x020f1814 end:0x020f1838
+
+src/_ZN12EnemySpawner13InitResourcesEv.cpp:
+    .text start:0x020f1838 end:0x020f1878
+
+src/_ZN14BlueCoinSwitch13InitResourcesEv.cpp:
+    complete
+    .text start:0x020f1878 end:0x020f1924
+
+src/EnemySpawner_Spawn.c:
+    complete
+    .text start:0x020f1924 end:0x020f1954
+
+src/EnemySwitchTag_Spawn.c:
+    complete
+    .text start:0x020f1954 end:0x020f198c
+
+src/_ZN14EnemySwitchTagD1Ev.cpp:
+    .text start:0x020f198c end:0x020f19b0
+
+src/_ZN14EnemySwitchTagD0Ev.c:
+    .text start:0x020f19b0 end:0x020f19e8
+
+src/_ZN14EnemySwitchTag16CleanupResourcesEv.c:
+    complete
+    .text start:0x020f19e8 end:0x020f19f0
+
+src/_ZN14EnemySwitchTag16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020f19f0 end:0x020f19f4
+
+src/_ZN14EnemySwitchTag6RenderEv.c:
+    complete
+    .text start:0x020f19f4 end:0x020f19fc
+
+src/_ZN14EnemySwitchTag8BehaviorEv.cpp:
+    .text start:0x020f19fc end:0x020f1ac4
+
+src/_ZN14EnemySwitchTag13InitResourcesEv.cpp:
+    .text start:0x020f1ac4 end:0x020f1b94
+
+src/AmbientSoundEffects_Spawn.c:
+    complete
+    .text start:0x020f1b94 end:0x020f1bc4
+
+src/_ZN19AmbientSoundEffectsD1Ev.cpp:
+    .text start:0x020f1bc4 end:0x020f1be8
+
+src/_ZN19AmbientSoundEffectsD0Ev.c:
+    .text start:0x020f1be8 end:0x020f1c20
+
+src/func_ov002_020f1c20.c:
+    complete
+    .text start:0x020f1c20 end:0x020f1c50
+
+src/_ZN19AmbientSoundEffects16CleanupResourcesEv.c:
+    complete
+    .text start:0x020f1c50 end:0x020f1c58
+
+src/_ZN19AmbientSoundEffects16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020f1c58 end:0x020f1c5c
+
+src/_ZN19AmbientSoundEffects6RenderEv.c:
+    complete
+    .text start:0x020f1c5c end:0x020f1c64
+
+src/_ZN19AmbientSoundEffects8BehaviorEv.cpp:
+    .text start:0x020f1c64 end:0x020f1eb4
+
+src/_ZN19AmbientSoundEffects13InitResourcesEv.cpp:
+    .text start:0x020f1eb4 end:0x020f1f40
+
+src/MugenBgm_Spawn.c:
+    complete
+    .text start:0x020f1f40 end:0x020f1f70
+
+src/_ZN8MugenBgmD1Ev.cpp:
+    .text start:0x020f1f70 end:0x020f1f94
+
+src/_ZN8MugenBgmD0Ev.c:
+    .text start:0x020f1f94 end:0x020f1fcc
+
+src/func_ov002_020f1fcc.c:
+    complete
+    .text start:0x020f1fcc end:0x020f20f4
+
+src/func_ov002_020f20f4.c:
+    complete
+    .text start:0x020f20f4 end:0x020f2210
+
+src/func_ov002_020f2210.c:
+    complete
+    .text start:0x020f2210 end:0x020f2340
+
+src/func_ov002_020f2340.cpp:
+    complete
+    .text start:0x020f2340 end:0x020f237c
+
+src/func_ov002_020f237c.c:
+    complete
+    .text start:0x020f237c end:0x020f23d0
+
+src/func_ov002_020f23d0.c:
+    complete
+    .text start:0x020f23d0 end:0x020f23f0
+
+src/func_ov002_020f23f0.c:
+    complete
+    .text start:0x020f23f0 end:0x020f2630
+
+src/func_ov002_020f2630.c:
+    complete
+    .text start:0x020f2630 end:0x020f26c4
+
+src/func_ov002_020f26c4.c:
+    complete
+    .text start:0x020f26c4 end:0x020f26d4
+
+src/func_ov002_020f26d4.c:
+    complete
+    .text start:0x020f26d4 end:0x020f26e0
+
+src/func_ov002_020f26e0.c:
+    complete
+    .text start:0x020f26e0 end:0x020f2790
+
+src/func_ov002_020f2790.c:
+    complete
+    .text start:0x020f2790 end:0x020f27e8
+
+src/func_ov002_020f27e8.c:
+    complete
+    .text start:0x020f27e8 end:0x020f2958
+
+src/func_ov002_020f2958.c:
+    complete
+    .text start:0x020f2958 end:0x020f2984
+
+src/func_ov002_020f2984.c:
+    complete
+    .text start:0x020f2984 end:0x020f2990
+
+src/func_ov002_020f2990.c:
+    complete
+    .text start:0x020f2990 end:0x020f2a48
+
+src/func_ov002_020f2a48.c:
+    complete
+    .text start:0x020f2a48 end:0x020f2a68
+
+src/func_ov002_020f2a68.c:
+    complete
+    .text start:0x020f2a68 end:0x020f2a78
+
+src/func_ov002_020f2a78.c:
+    complete
+    .text start:0x020f2a78 end:0x020f2a88
+
+src/func_ov002_020f2a88.c:
+    complete
+    .text start:0x020f2a88 end:0x020f2aec
+
+src/func_ov002_020f2aec.c:
+    complete
+    .text start:0x020f2aec end:0x020f2bf4
+
+src/func_ov002_020f2bf4.c:
+    complete
+    .text start:0x020f2bf4 end:0x020f2d0c
+
+src/func_ov002_020f2d0c.c:
+    complete
+    .text start:0x020f2d0c end:0x020f2d70
+
+src/func_ov002_020f2d70.c:
+    complete
+    .text start:0x020f2d70 end:0x020f2dd4
+
+src/func_ov002_020f2dd4.cpp:
+    complete
+    .text start:0x020f2dd4 end:0x020f2e30
+
+src/func_ov002_020f2e30.c:
+    complete
+    .text start:0x020f2e30 end:0x020f2ea0
+
+src/func_ov002_020f2ea0.c:
+    complete
+    .text start:0x020f2ea0 end:0x020f2eac
+
+src/func_ov002_020f2eac.c:
+    complete
+    .text start:0x020f2eac end:0x020f2f18
+
+src/func_ov002_020f2f18.c:
+    complete
+    .text start:0x020f2f18 end:0x020f2f64
+
+src/func_ov002_020f2f64.c:
+    complete
+    .text start:0x020f2f64 end:0x020f2f9c
+
+src/func_ov002_020f2f9c.c:
+    complete
+    .text start:0x020f2f9c end:0x020f30d4
+
+src/func_ov002_020f30d4.c:
+    complete
+    .text start:0x020f30d4 end:0x020f30f8
+
+src/func_ov002_020f30f8.c:
+    complete
+    .text start:0x020f30f8 end:0x020f32e4
+
+src/func_ov002_020f32e4.c:
+    complete
+    .text start:0x020f32e4 end:0x020f3310
+
+src/func_ov002_020f3310.cpp:
+    complete
+    .text start:0x020f3310 end:0x020f335c
+
+src/func_ov002_020f335c.c:
+    complete
+    .text start:0x020f335c end:0x020f340c
+
+src/func_ov002_020f340c.c:
+    complete
+    .text start:0x020f340c end:0x020f34bc
+
+src/func_ov002_020f34bc.c:
+    complete
+    .text start:0x020f34bc end:0x020f35e4
+
+src/func_ov002_020f35e4.c:
+    complete
+    .text start:0x020f35e4 end:0x020f3740
+
+src/func_ov002_020f3740.cpp:
+    complete
+    .text start:0x020f3740 end:0x020f378c
+
+src/func_ov002_020f378c.c:
+    complete
+    .text start:0x020f378c end:0x020f37a0
+
+src/func_ov002_020f37a0.cpp:
+    complete
+    .text start:0x020f37a0 end:0x020f37fc
+
+src/func_ov002_020f37fc.c:
+    complete
+    .text start:0x020f37fc end:0x020f3828
+
+src/func_ov002_020f3828.c:
+    complete
+    .text start:0x020f3828 end:0x020f3954
+
+src/func_ov002_020f3954.c:
+    complete
+    .text start:0x020f3954 end:0x020f396c
+
+src/func_ov002_020f396c.c:
+    complete
+    .text start:0x020f396c end:0x020f3978
+
+src/func_ov002_020f3978.cpp:
+    complete
+    .text start:0x020f3978 end:0x020f39ec
+
+src/func_ov002_020f39ec.c:
+    complete
+    .text start:0x020f39ec end:0x020f3ae8
+
+src/func_ov002_020f3ae8.c:
+    complete
+    .text start:0x020f3ae8 end:0x020f3ba0
+
+src/func_ov002_020f3ba0.c:
+    complete
+    .text start:0x020f3ba0 end:0x020f3d38
+
+src/func_ov002_020f3d38.c:
+    complete
+    .text start:0x020f3d38 end:0x020f3d98
+
+src/func_ov002_020f3d98.cpp:
+    complete
+    .text start:0x020f3d98 end:0x020f3de4
+
+src/func_ov002_020f40fc.c:
+    complete
+    .text start:0x020f40fc end:0x020f43cc
+
+src/func_ov002_020f4710.c:
+    complete
+    .text start:0x020f4710 end:0x020f4a2c
+
+src/func_ov002_020f4a2c.c:
+    complete
+    .text start:0x020f4a2c end:0x020f4d70
+
+src/func_ov002_020f4d70.c:
+    complete
+    .text start:0x020f4d70 end:0x020f5010
+
+src/func_ov002_020f5328.c:
+    complete
+    .text start:0x020f5328 end:0x020f55b4
+
+src/func_ov002_020f55b4.c:
+    complete
+    .text start:0x020f55b4 end:0x020f562c
+
+src/func_ov002_020f562c.cpp:
+    complete
+    .text start:0x020f562c end:0x020f5678
+
+src/func_ov002_020f5678.c:
+    complete
+    .text start:0x020f5678 end:0x020f569c
+
+src/func_ov002_020f569c.c:
+    complete
+    .text start:0x020f569c end:0x020f57c0
+
+src/func_ov002_020f57c0.c:
+    complete
+    .text start:0x020f57c0 end:0x020f5848
+
+src/func_ov002_020f5848.cpp:
+    complete
+    .text start:0x020f5848 end:0x020f5894
+
+src/func_ov002_020f5894.c:
+    complete
+    .text start:0x020f5894 end:0x020f5990
+
+src/func_ov002_020f5990.cpp:
+    complete
+    .text start:0x020f5990 end:0x020f5a6c
+
+src/func_ov002_020f5a6c.c:
+    complete
+    .text start:0x020f5a6c end:0x020f5a94
+
+src/func_ov002_020f5a94.c:
+    complete
+    .text start:0x020f5a94 end:0x020f5ad4
+
+src/func_ov002_020f5ad4.c:
+    complete
+    .text start:0x020f5ad4 end:0x020f5b24
+
+src/func_ov002_020f5b24.c:
+    complete
+    .text start:0x020f5b24 end:0x020f5b7c
+
+src/func_ov002_020f5b7c.c:
+    complete
+    .text start:0x020f5b7c end:0x020f5b80
+
+src/func_ov002_020f5b80.c:
+    complete
+    .text start:0x020f5b80 end:0x020f5b84
+
+src/func_ov002_020f5b84.c:
+    complete
+    .text start:0x020f5b84 end:0x020f5b88
+
+src/func_ov002_020f5b88.c:
+    complete
+    .text start:0x020f5b88 end:0x020f5b8c
+
+src/func_ov002_020f5b8c.c:
+    complete
+    .text start:0x020f5b8c end:0x020f5b98
+
+src/func_ov002_020f5b98.c:
+    complete
+    .text start:0x020f5b98 end:0x020f5bcc
+
+src/func_ov002_020f5bcc.c:
+    complete
+    .text start:0x020f5bcc end:0x020f5bf4
+
+src/func_ov002_020f5bf4.c:
+    complete
+    .text start:0x020f5bf4 end:0x020f5c40
+
+src/func_ov002_020f5c40.c:
+    complete
+    .text start:0x020f5c40 end:0x020f5c88
+
+src/func_ov002_020f5c88.c:
+    complete
+    .text start:0x020f5c88 end:0x020f5cd0
+
+src/func_ov002_020f5cd0.c:
+    complete
+    .text start:0x020f5cd0 end:0x020f5d34
+
+src/func_ov002_020f5d34.c:
+    complete
+    .text start:0x020f5d34 end:0x020f5dd8
+
+src/func_ov002_020f5dd8.cpp:
+    complete
+    .text start:0x020f5dd8 end:0x020f5e18
+
+src/func_ov002_020f5e18.c:
+    complete
+    .text start:0x020f5e18 end:0x020f5e38
+
+src/func_ov002_020f5e38.c:
+    complete
+    .text start:0x020f5e38 end:0x020f5e58
+
+src/func_ov002_020f5e58.c:
+    complete
+    .text start:0x020f5e58 end:0x020f5e78
+
+src/func_ov002_020f5e78.c:
+    complete
+    .text start:0x020f5e78 end:0x020f5e98
+
+src/func_ov002_020f5e98.c:
+    complete
+    .text start:0x020f5e98 end:0x020f5eb8
+
+src/func_ov002_020f5eb8.c:
+    complete
+    .text start:0x020f5eb8 end:0x020f5ed8
+
+src/func_ov002_020f5ed8.c:
+    complete
+    .text start:0x020f5ed8 end:0x020f5ee4
+
+src/func_ov002_020f5ee4.c:
+    complete
+    .text start:0x020f5ee4 end:0x020f5ef0
+
+src/func_ov002_020f5ef0.c:
+    complete
+    .text start:0x020f5ef0 end:0x020f5efc
+
+src/func_ov002_020f5efc.c:
+    complete
+    .text start:0x020f5efc end:0x020f5f0c
+
+src/func_ov002_020f5f0c.cpp:
+    complete
+    .text start:0x020f5f0c end:0x020f5f60
+
+src/func_ov002_020f5f60.c:
+    complete
+    .text start:0x020f5f60 end:0x020f5f8c
+
+src/func_ov002_020f5f8c.c:
+    complete
+    .text start:0x020f5f8c end:0x020f5fb8
+
+src/func_ov002_020f5fb8.c:
+    complete
+    .text start:0x020f5fb8 end:0x020f5fe4
+
+src/func_ov002_020f5fe4.c:
+    complete
+    .text start:0x020f5fe4 end:0x020f63a0
+
+src/func_ov002_020f63a0.c:
+    complete
+    .text start:0x020f63a0 end:0x020f63d4
+
+src/func_ov002_020f63d4.c:
+    complete
+    .text start:0x020f63d4 end:0x020f63f8
+
+src/func_ov002_020f63f8.c:
+    complete
+    .text start:0x020f63f8 end:0x020f6424
+
+src/func_ov002_020f6424.c:
+    complete
+    .text start:0x020f6424 end:0x020f6448
+
+src/func_ov002_020f6448.c:
+    complete
+    .text start:0x020f6448 end:0x020f64ac
+
+src/func_ov002_020f64ac.c:
+    complete
+    .text start:0x020f64ac end:0x020f6514
+
+src/func_ov002_020f6514.c:
+    complete
+    .text start:0x020f6514 end:0x020f65b8
+
+src/func_ov002_020f65b8.c:
+    complete
+    .text start:0x020f65b8 end:0x020f65ec
+
+src/func_ov002_020f65ec.c:
+    complete
+    .text start:0x020f65ec end:0x020f6618
+
+src/func_ov002_020f6618.cpp:
+    complete
+    .text start:0x020f6618 end:0x020f6778
+
+src/func_ov002_020f6778.cpp:
+    complete
+    .text start:0x020f6778 end:0x020f6870
+
+src/func_ov002_020f6870.cpp:
+    complete
+    .text start:0x020f6870 end:0x020f6960
+
+src/func_ov002_020f6960.cpp:
+    complete
+    .text start:0x020f6960 end:0x020f69a8
+
+src/func_ov002_020f69a8.cpp:
+    complete
+    .text start:0x020f69a8 end:0x020f6a00
+
+src/func_ov002_020f6a00.cpp:
+    complete
+    .text start:0x020f6a00 end:0x020f6a50
+
+src/func_ov002_020f6a50.c:
+    complete
+    .text start:0x020f6a50 end:0x020f6a9c
+
+src/func_ov002_020f6a9c.c:
+    complete
+    .text start:0x020f6a9c end:0x020f6ab8
+
+src/func_ov002_020f6ab8.c:
+    complete
+    .text start:0x020f6ab8 end:0x020f6ae4
+
+src/func_ov002_020f6ae4.c:
+    complete
+    .text start:0x020f6ae4 end:0x020f6b28
+
+src/func_ov002_020f6b28.c:
+    complete
+    .text start:0x020f6b28 end:0x020f6b4c
+
+src/func_ov002_020f6b4c.c:
+    complete
+    .text start:0x020f6b4c end:0x020f6bc0
+
+src/func_ov002_020f6bc0.c:
+    complete
+    .text start:0x020f6bc0 end:0x020f6c24
+
+src/func_ov002_020f6c24.c:
+    complete
+    .text start:0x020f6c24 end:0x020f6c34
+
+src/func_ov002_020f6c34.c:
+    complete
+    .text start:0x020f6c34 end:0x020f6c60
+
+src/func_ov002_020f6c60.c:
+    complete
+    .text start:0x020f6c60 end:0x020f6e48
+
+src/func_ov002_020f6e48.c:
+    complete
+    .text start:0x020f6e48 end:0x020f6f48
+
+src/func_ov002_020f6f48.c:
+    complete
+    .text start:0x020f6f48 end:0x020f7020
+
+src/func_ov002_020f7020.c:
+    complete
+    .text start:0x020f7020 end:0x020f7038
+
+src/func_ov002_020f7038.c:
+    complete
+    .text start:0x020f7038 end:0x020f71c4
+
+src/func_ov002_020f71c4.c:
+    complete
+    .text start:0x020f71c4 end:0x020f72bc
+
+src/func_ov002_020f72bc.c:
+    complete
+    .text start:0x020f72bc end:0x020f7384
+
+src/func_ov002_020f7384.c:
+    complete
+    .text start:0x020f7384 end:0x020f7410
+
+src/func_ov002_020f7410.c:
+    complete
+    .text start:0x020f7410 end:0x020f7538
+
+src/func_ov002_020f7538.c:
+    complete
+    .text start:0x020f7538 end:0x020f7780
+
+src/func_ov002_020f7780.c:
+    complete
+    .text start:0x020f7780 end:0x020f79c0
+
+src/func_ov002_020f79c0.c:
+    complete
+    .text start:0x020f79c0 end:0x020f7bb8
+
+src/func_ov002_020f7bb8.c:
+    complete
+    .text start:0x020f7bb8 end:0x020f7d74
+
+src/func_ov002_020f7d74.cpp:
+    .text start:0x020f7d74 end:0x020f8028
+
+src/_ZN8MugenBgm16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020f8028 end:0x020f80a8
+
+src/_ZN8MugenBgm16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020f80a8 end:0x020f80ac
+
+src/_ZN8MugenBgm6RenderEv.cpp:
+    complete
+    .text start:0x020f80ac end:0x020f81c4
+
+src/_ZN8MugenBgm8BehaviorEv.cpp:
+    .text start:0x020f81c4 end:0x020f83a4
+
+src/_ZN8MugenBgm13InitResourcesEv.cpp:
+    .text start:0x020f83a4 end:0x020f8808
+
+src/CutsceneObject_Spawn.c:
+    complete
+    .text start:0x020f8808 end:0x020f8838
+
+src/_ZN8FireballD1Ev.c:
+    complete
+    .text start:0x020f8858 end:0x020f8898
+
+src/_ZN8FireballD0Ev.c:
+    complete
+    .text start:0x020f8898 end:0x020f88ec
+
+src/func_ov002_020f88ec.c:
+    complete
+    .text start:0x020f88ec end:0x020f897c
+
+src/func_ov002_020f897c.c:
+    complete
+    .text start:0x020f897c end:0x020f8b24
+
+src/func_ov002_020f8b24.c:
+    complete
+    .text start:0x020f8b24 end:0x020f8c8c
+
+src/_ZN8Fireball6RenderEv.c:
+    complete
+    .text start:0x020f8c8c end:0x020f8c94
+
+src/_ZN8Fireball8BehaviorEv.cpp:
+    complete
+    .text start:0x020f8c94 end:0x020f9204
+
+src/_ZN8Fireball13InitResourcesEv.cpp:
+    .text start:0x020f9204 end:0x020f92e4
+
+src/func_ov002_020f92e4.c:
+    complete
+    .text start:0x020f92e4 end:0x020f9304
+
+src/Fireball_Spawn.c:
+    complete
+    .text start:0x020f9304 end:0x020f934c
+
+src/func_ov002_020f934c.c:
+    complete
+    .text start:0x020f934c end:0x020f9370
+
+src/func_ov002_020f9370.c:
+    .text start:0x020f9370 end:0x020f93a8
+
+src/func_ov002_020f93a8.cpp:
+    complete
+    .text start:0x020f93a8 end:0x020f9468
+
+src/func_ov002_020f9468.c:
+    complete
+    .text start:0x020f9468 end:0x020f94fc
+
+src/func_ov002_020f94fc.cpp:
+    complete
+    .text start:0x020f94fc end:0x020f95e0
+
+src/func_ov002_020f95e0.c:
+    complete
+    .text start:0x020f95e0 end:0x020f972c
+
+src/SoundObject_Spawn.c:
+    complete
+    .text start:0x020f972c end:0x020f975c
+
+src/_ZN7MinimapD1Ev.c:
+    .text start:0x020f975c end:0x020f978c
+
+src/_ZN7MinimapD0Ev.c:
+    .text start:0x020f978c end:0x020f97d0
+
+src/_ZN7Minimap21FixTHIPaintingRoomPosER7Vector3.cpp:
+    .text start:0x020f97d0 end:0x020f99a8
+
+src/_ZN7Minimap19UpdateLevelSpecificEv.cpp:
+    complete
+    .text start:0x020f99a8 end:0x020f9e8c
+
+src/_ZN7Minimap16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020f9e8c end:0x020f9e94
+
+src/_ZN7Minimap16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x020f9e94 end:0x020f9e98
+
+src/_ZN7Minimap6RenderEv.cpp:
+    complete
+    .text start:0x020f9e98 end:0x020fa690
+
+src/_ZN7Minimap8BehaviorEv.cpp:
+    complete
+    .text start:0x020fa690 end:0x020fb38c
+
+src/_ZN7Minimap13InitResourcesEv.cpp:
+    .text start:0x020fb38c end:0x020fb804
+
+src/_ZN7Minimap20GetPosFromMinimapPosER7Vector3S1_5Fix12IiEsS1_.cpp:
+    complete
+    .text start:0x020fb804 end:0x020fb85c
+
+src/_ZN7Minimap15GetPosOnMinimapER7Vector3S1_5Fix12IiEsS1_.cpp:
+    complete
+    .text start:0x020fb85c end:0x020fb8bc
+
+src/_ZN7MinimapC1Ev.c:
+    .text start:0x020fb8bc end:0x020fb8f8
+
+src/_ZN3HUDD1Ev.c:
+    .text start:0x020fb8f8 end:0x020fb928
+
+src/_ZN3HUDD0Ev.c:
+    .text start:0x020fb928 end:0x020fb96c
+
+src/_ZN3HUD15RenderTimeTimerEv.cpp:
+    .text start:0x020fb96c end:0x020fbdac
+
+src/_ZN3HUD15CalculateDigitsEt.c:
+    .text start:0x020fbdac end:0x020fbe38
+
+src/_ZN3HUD15RenderLifeCountEv.cpp:
+    .text start:0x020fbe38 end:0x020fc04c
+
+src/_ZN3HUD19RenderCameraButtonsEv.cpp:
+    complete
+    .text start:0x020fc04c end:0x020fc3c4
+
+src/_ZN3HUD17RenderSilverStarsEv.cpp:
+    complete
+    .text start:0x020fc3c4 end:0x020fc458
+
+src/_ZN3HUD15RenderStarCountEv.cpp:
+    .text start:0x020fc458 end:0x020fc77c
+
+src/_ZN3HUD14RenderRedCoinsEv.cpp:
+    complete
+    .text start:0x020fc77c end:0x020fc81c
+
+src/_ZN3HUD15RenderCoinCountEv.cpp:
+    .text start:0x020fc81c end:0x020fca18
+
+src/_ZN3HUD13RenderVsTimerEv.cpp:
+    complete
+    .text start:0x020fca18 end:0x020fce9c
+
+src/_ZN3HUD13UpdateVsTimerEv.cpp:
+    complete
+    .text start:0x020fce9c end:0x020fcfec
+
+src/_ZN3HUD17RenderHealthMeterEv.cpp:
+    .text start:0x020fcfec end:0x020fd218
+
+src/_ZN3HUD17UpdateHealthMeterEv.cpp:
+    .text start:0x020fd218 end:0x020fd5d4
+
+src/_ZN3HUD16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x020fd5d4 end:0x020fd5dc
+
+src/_ZN3HUD16OnPendingDestroyEv.cpp:
+    complete
+    .text start:0x020fd5dc end:0x020fd5e0
+
+src/_ZN3HUD6RenderEv.cpp:
+    complete
+    .text start:0x020fd5e0 end:0x020fd7a4
+
+src/_ZN3HUD8BehaviorEv.cpp:
+    complete
+    .text start:0x020fd7a4 end:0x020fda04
+
+src/_ZN3HUD13InitResourcesEv.cpp:
+    .text start:0x020fda04 end:0x020fe154
+
+src/_ZN3HUDC1Ev.c:
+    .text start:0x020fe154 end:0x020fe190
+
+src/_ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider.cpp:
+    .text start:0x020fe190 end:0x020fe33c
+
+src/_Z11LoadObjectsRN11LVL_Overlay8ObjTableEij.c:
+    complete
+    .text start:0x020fe33c end:0x020fe3cc
+
+src/_Z21LoadStarCameraObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe3cc end:0x020fe3e4
+
+src/_Z23LoadUnusedType13ObjectsRN11LVL_Overlay11ObjSubTableEij.c:
+    complete
+    .text start:0x020fe3e4 end:0x020fe3f8
+
+src/_Z23LoadMinimapScaleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe3f8 end:0x020fe40c
+
+src/_Z22LoadMinimapTileObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe40c end:0x020fe420
+
+src/_Z15LoadExitObjectsRN11LVL_Overlay11ObjSubTableEij.c:
+    complete
+    .text start:0x020fe420 end:0x020fe4f0
+
+src/_Z15LoadDoorObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe4f0 end:0x020fe5cc
+
+src/_Z14LoadFogObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe5cc end:0x020fe5e0
+
+src/_Z23LoadTeleportDestObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe5e0 end:0x020fe5f4
+
+src/_Z25LoadTeleportSourceObjectsRN11LVL_Overlay11ObjSubTableEij.c:
+    complete
+    .text start:0x020fe5f4 end:0x020fe690
+
+src/_Z15LoadViewObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe690 end:0x020fe6a4
+
+src/_Z15LoadPathObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe6a4 end:0x020fe6b8
+
+src/_Z19LoadPathNodeObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe6b8 end:0x020fe6c8
+
+src/_Z19LoadEntranceObjectsRN11LVL_Overlay11ObjSubTableEij.c:
+    complete
+    .text start:0x020fe6c8 end:0x020fe8ac
+
+src/_Z19LoadStandardObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe8ac end:0x020fe960
+
+src/_Z17LoadSimpleObjectsRN11LVL_Overlay11ObjSubTableEij.cpp:
+    complete
+    .text start:0x020fe960 end:0x020fea4c
+
+src/func_ov002_020fea4c.c:
+    complete
+    .text start:0x020fea4c end:0x020fea68
+
+src/func_ov002_020fea68.c:
+    complete
+    .text start:0x020fea68 end:0x020fea84
+
+src/_ZN11RaycastLine4Line3SetERK7Vector3S3_.c:
+    complete
+    .text start:0x020fea84 end:0x020feab8
+
+src/func_ov002_020feab8.c:
+    complete
+    .text start:0x020feab8 end:0x020feabc
+
+src/_ZN6BulletD1Ev.c:
+    complete
+    .text start:0x020feabc end:0x020feafc
+
+src/_ZN6BulletD0Ev.c:
+    complete
+    .text start:0x020feafc end:0x020feb50
+
+src/func_ov002_020feb50.cpp:
+    complete
+    .text start:0x020feb50 end:0x020fec94
+
+src/func_ov002_020fec94.c:
+    complete
+    .text start:0x020fec94 end:0x020fed18
+
+src/func_ov002_020fed18.c:
+    complete
+    .text start:0x020fed18 end:0x020fed2c
+
+src/func_ov002_020fed2c.cpp:
+    complete
+    .text start:0x020fed2c end:0x020fed7c
+
+src/func_ov002_020fed7c.c:
+    complete
+    .text start:0x020fed7c end:0x020fedf0
+
+src/_ZN6Bullet16CleanupResourcesEv.c:
+    complete
+    .text start:0x020fedf0 end:0x020fee14
+
+src/_ZN6Bullet16OnPendingDestroyEv.c:
+    complete
+    .text start:0x020fee14 end:0x020fee18
+
+src/_ZN6Bullet6RenderEv.cpp:
+    complete
+    .text start:0x020fee18 end:0x020fee44
+
+src/_ZN6Bullet8BehaviorEv.cpp:
+    .text start:0x020fee44 end:0x020feef4
+
+src/_ZN6Bullet13InitResourcesEv.cpp:
+    .text start:0x020feef4 end:0x020fefcc
+
+src/Bullet_Spawn.c:
+    complete
+    .text start:0x020fefcc end:0x020ff014
+
+src/__sinit_ov002_02100560.c:
+    .init start:0x02100560 end:0x02100938
+
+src/__sinit_ov002_02100938.c:
+    .init start:0x02100938 end:0x02100adc
+
+src/__sinit_ov002_02100adc.c:
+    .init start:0x02100adc end:0x02100c50
+
+src/__sinit_ov002_02100c50.c:
+    .init start:0x02100c50 end:0x02100d44
+
+src/__sinit_ov002_02100d44.c:
+    .init start:0x02100d44 end:0x02100e50
+
+src/__sinit_ov002_02100e50.c:
+    .init start:0x02100e50 end:0x02100ec4
+
+src/__sinit_ov002_02100ec4.c:
+    .init start:0x02100ec4 end:0x02100f84
+
+src/__sinit_ov002_02100f84.c:
+    .init start:0x02100f84 end:0x02101064
+
+src/__sinit_ov002_02101064.c:
+    .init start:0x02101064 end:0x02101478
+
+src/__sinit_ov002_02101478.c:
+    .init start:0x02101478 end:0x021014e4
+
+src/__sinit_ov002_021014e4.c:
+    .init start:0x021014e4 end:0x02101588
+
+src/__sinit_ov002_02101588.c:
+    .init start:0x02101588 end:0x02101738
+
+src/__sinit_ov002_02101738.c:
+    .init start:0x02101738 end:0x02101894
+
+src/__sinit_ov002_02101894.c:
+    .init start:0x02101894 end:0x02101900
+
+src/__sinit_ov002_02101900.c:
+    .init start:0x02101900 end:0x02101968
+
+src/__sinit_ov002_02101968.c:
+    .init start:0x02101968 end:0x021019d0
+
+src/__sinit_ov002_021019d0.c:
+    .init start:0x021019d0 end:0x02106e40
+
+src/__sinit_ov002_02106e40.c:
+    .init start:0x02106e40 end:0x02107118
+
+src/__sinit_ov002_02107118.c:
+    .init start:0x02107118 end:0x021071f4
+
+src/__sinit_ov002_021071f4.c:
+    .init start:0x021071f4 end:0x02107298
+
+src/__sinit_ov002_02107298.c:
+    .init start:0x02107298 end:0x02107304
+
+src/__sinit_ov002_02107304.c:
+    .init start:0x02107304 end:0x02107370
+
+src/__sinit_ov002_02107370.c:
+    .init start:0x02107370 end:0x02107f88
+
+src/__sinit_ov002_02107f88.c:
+    .init start:0x02107f88 end:0x0210804c
+
+src/__sinit_ov002_0210804c.c:
+    .init start:0x0210804c end:0x02108094
+
+src/__sinit_ov002_02108094.c:
+    .init start:0x02108094 end:0x021080d0

--- a/config/arm9/overlays/ov003/delinks.txt
+++ b/config/arm9/overlays/ov003/delinks.txt
@@ -3,3 +3,119 @@
     .ctor       start:0x020b1350 end:0x020b1350 kind:rodata align:4
     .data       start:0x020b1360 end:0x020b18a0 kind:data align:32
     .bss        start:0x020b18a0 end:0x020b18a0 kind:bss align:32
+src/func_ov003_020ad660.c:
+    .text start:0x020ad660 end:0x020ad69c
+
+src/func_ov003_020ad69c.c:
+    complete
+    .text start:0x020ad69c end:0x020ad6ec
+
+src/func_ov003_020ad6ec.c:
+    complete
+    .text start:0x020ad6ec end:0x020ad7a0
+
+src/func_ov003_020ad7a0.c:
+    complete
+    .text start:0x020ad7a0 end:0x020ad7a4
+
+src/func_ov003_020ad7a4.cpp:
+    .text start:0x020ad7a4 end:0x020ad814
+
+src/func_ov003_020ad814.cpp:
+    .text start:0x020ad814 end:0x020ada80
+
+src/func_ov003_020ada80.c:
+    complete
+    .text start:0x020ada80 end:0x020ada9c
+
+src/func_ov003_020ada9c.cpp:
+    complete
+    .text start:0x020ada9c end:0x020adc10
+
+src/func_ov003_020adc10.cpp:
+    complete
+    .text start:0x020adc10 end:0x020adc74
+
+src/func_ov003_020adc74.cpp:
+    complete
+    .text start:0x020adc74 end:0x020adcbc
+
+src/func_ov003_020adcbc.cpp:
+    complete
+    .text start:0x020adcbc end:0x020addfc
+
+src/func_ov003_020addfc.cpp:
+    complete
+    .text start:0x020addfc end:0x020ade54
+
+src/func_ov003_020ade54.c:
+    complete
+    .text start:0x020ade54 end:0x020adec0
+
+src/func_ov003_020adec0.c:
+    complete
+    .text start:0x020adec0 end:0x020adf50
+
+src/func_ov003_020adf50.c:
+    complete
+    .text start:0x020adf50 end:0x020adfc8
+
+src/func_ov003_020adfc8.cpp:
+    .text start:0x020adfc8 end:0x020ae0b0
+
+src/func_ov003_020ae0b0.c:
+    .text start:0x020ae0b0 end:0x020ae1a4
+
+src/func_ov003_020ae1a4.c:
+    .text start:0x020ae1a4 end:0x020ae238
+
+src/func_ov003_020ae238.c:
+    .text start:0x020ae238 end:0x020ae358
+
+src/func_ov003_020ae6f0.c:
+    complete
+    .text start:0x020ae6f0 end:0x020ae6f4
+
+src/func_ov003_020af86c.cpp:
+    .text start:0x020af86c end:0x020af8a0
+
+src/StarSelect_Spawn.cpp:
+    complete
+    .text start:0x020b04f0 end:0x020b0580
+
+src/func_ov003_020b0580.c:
+    .text start:0x020b0580 end:0x020b05bc
+
+src/func_ov003_020b05bc.c:
+    .text start:0x020b05bc end:0x020b060c
+
+src/func_ov003_020b060c.c:
+    complete
+    .text start:0x020b060c end:0x020b0730
+
+src/func_ov003_020b0730.c:
+    complete
+    .text start:0x020b0730 end:0x020b0810
+
+src/func_ov003_020b0810.c:
+    complete
+    .text start:0x020b0810 end:0x020b0814
+
+src/func_ov003_020b0814.cpp:
+    .text start:0x020b0814 end:0x020b0894
+
+src/func_ov003_020b0894.c:
+    complete
+    .text start:0x020b0894 end:0x020b0b34
+
+src/func_ov003_020b0b34.c:
+    complete
+    .text start:0x020b0b34 end:0x020b0b3c
+
+src/func_ov003_020b0b3c.c:
+    complete
+    .text start:0x020b0b3c end:0x020b1118
+
+src/func_ov003_020b1118.cpp:
+    complete
+    .text start:0x020b1118 end:0x020b117c

--- a/config/arm9/overlays/ov004/delinks.txt
+++ b/config/arm9/overlays/ov004/delinks.txt
@@ -4,3 +4,1077 @@
     .ctor       start:0x020b9de4 end:0x020b9df4 kind:rodata align:4
     .data       start:0x020b9e00 end:0x020beb60 kind:data align:32
     .bss        start:0x020beb60 end:0x020bfec0 kind:bss align:32
+src/func_ov004_020ad660.c:
+    complete
+    .text start:0x020ad660 end:0x020ad674
+
+src/GetGameLanguage.c:
+    complete
+    .text start:0x020ad674 end:0x020ad6f4
+
+src/func_ov004_020ad6f4.c:
+    complete
+    .text start:0x020ad6f4 end:0x020ad6fc
+
+src/func_ov004_020ad6fc.c:
+    complete
+    .text start:0x020ad6fc end:0x020ad79c
+
+src/func_ov004_020ad79c.c:
+    complete
+    .text start:0x020ad79c end:0x020ad878
+
+src/func_ov004_020ad878.c:
+    complete
+    .text start:0x020ad878 end:0x020ad8b8
+
+src/func_ov004_020ad8b8.c:
+    complete
+    .text start:0x020ad8b8 end:0x020ad90c
+
+src/func_ov004_020ad90c.c:
+    complete
+    .text start:0x020ad90c end:0x020ad940
+
+src/func_ov004_020ad940.cpp:
+    complete
+    .text start:0x020ad940 end:0x020ada20
+
+src/func_ov004_020ada20.c:
+    complete
+    .text start:0x020ada20 end:0x020ada40
+
+src/_ZN5Enemy20KillByInvincibleCharERK10Vector3_16R6Player.c:
+    complete
+    .text start:0x020ada40 end:0x020adafc
+
+src/func_ov004_020adafc.c:
+    .text start:0x020adafc end:0x020adb1c
+
+src/func_ov004_020adb1c.c:
+    complete
+    .text start:0x020adb1c end:0x020adbc0
+
+src/func_ov004_020adbc0.c:
+    .text start:0x020adbc0 end:0x020adbe0
+
+src/func_ov004_020adbe0.c:
+    .text start:0x020adbe0 end:0x020adc00
+
+src/func_ov004_020adc00.c:
+    .text start:0x020adc00 end:0x020adc1c
+
+src/func_ov004_020adc1c.c:
+    .text start:0x020adc1c end:0x020adc3c
+
+src/func_ov004_020adc3c.c:
+    complete
+    .text start:0x020adc3c end:0x020adc4c
+
+src/func_ov004_020adc4c.c:
+    complete
+    .text start:0x020adc4c end:0x020adc5c
+
+src/Ov004_Deallocate.c:
+    .text start:0x020adc5c end:0x020adc68
+
+src/func_ov004_020adc68.c:
+    .text start:0x020adc68 end:0x020adc74
+
+src/func_ov004_020adc74.c:
+    complete
+    .text start:0x020adc74 end:0x020adc80
+
+src/func_ov004_020adc80.c:
+    complete
+    .text start:0x020adc80 end:0x020adcc8
+
+src/func_ov004_020adcc8.cpp:
+    complete
+    .text start:0x020adcc8 end:0x020add88
+
+src/func_ov004_020add88.cpp:
+    complete
+    .text start:0x020add88 end:0x020addcc
+
+src/func_ov004_020addcc.c:
+    complete
+    .text start:0x020addcc end:0x020adeb0
+
+src/func_ov004_020adeb0.c:
+    complete
+    .text start:0x020adeb0 end:0x020adf2c
+
+src/func_ov004_020adf2c.cpp:
+    complete
+    .text start:0x020adf2c end:0x020adf70
+
+src/func_ov004_020adf70.c:
+    complete
+    .text start:0x020adf70 end:0x020adfc4
+
+src/func_ov004_020adfc4.c:
+    complete
+    .text start:0x020adfc4 end:0x020ae03c
+
+src/func_ov004_020ae03c.c:
+    complete
+    .text start:0x020ae03c end:0x020ae06c
+
+src/func_ov004_020ae06c.c:
+    complete
+    .text start:0x020ae06c end:0x020ae0a4
+
+src/func_ov004_020ae0a4.c:
+    complete
+    .text start:0x020ae0a4 end:0x020ae0d4
+
+src/func_ov004_020ae0d4.c:
+    complete
+    .text start:0x020ae0d4 end:0x020ae104
+
+src/func_ov004_020ae104.c:
+    complete
+    .text start:0x020ae104 end:0x020ae128
+
+src/func_ov004_020ae128.c:
+    complete
+    .text start:0x020ae128 end:0x020ae140
+
+src/func_ov004_020ae140.cpp:
+    complete
+    .text start:0x020ae140 end:0x020ae198
+
+src/func_ov004_020ae198.c:
+    complete
+    .text start:0x020ae198 end:0x020ae1a0
+
+src/func_ov004_020ae1a0.c:
+    complete
+    .text start:0x020ae1a0 end:0x020ae1a8
+
+src/func_ov004_020ae1a8.c:
+    complete
+    .text start:0x020ae1a8 end:0x020ae1cc
+
+src/func_ov004_020ae1cc.c:
+    complete
+    .text start:0x020ae1cc end:0x020ae1f0
+
+src/func_ov004_020ae1f0.c:
+    complete
+    .text start:0x020ae1f0 end:0x020ae20c
+
+src/func_ov004_020ae20c.c:
+    complete
+    .text start:0x020ae20c end:0x020ae274
+
+src/func_ov004_020ae274.c:
+    complete
+    .text start:0x020ae274 end:0x020ae2c8
+
+src/func_ov004_020ae2c8.cpp:
+    complete
+    .text start:0x020ae2c8 end:0x020ae330
+
+src/func_ov004_020ae330.c:
+    complete
+    .text start:0x020ae330 end:0x020ae3b4
+
+src/func_ov004_020ae3b4.c:
+    complete
+    .text start:0x020ae3b4 end:0x020ae5c4
+
+src/_ZN5Enemy12KillByAttackER5Actor.cpp:
+    .text start:0x020aea30 end:0x020aea78
+
+src/func_ov004_020aea78.cpp:
+    complete
+    .text start:0x020aea78 end:0x020aeb24
+
+src/func_ov004_020aeb24.cpp:
+    complete
+    .text start:0x020aeb24 end:0x020aeed8
+
+src/func_ov004_020aeed8.cpp:
+    .text start:0x020aeed8 end:0x020af04c
+
+src/func_ov004_020af04c.cpp:
+    .text start:0x020af04c end:0x020af094
+
+src/func_ov004_020af094.cpp:
+    .text start:0x020af094 end:0x020af27c
+
+src/func_ov004_020af27c.c:
+    complete
+    .text start:0x020af27c end:0x020af2f8
+
+src/func_ov004_020af2f8.cpp:
+    complete
+    .text start:0x020af2f8 end:0x020af5e0
+
+src/func_ov004_020af5e0.c:
+    complete
+    .text start:0x020af5e0 end:0x020af68c
+
+src/Hud_RenderSprite.cpp:
+    complete
+    .text start:0x020af68c end:0x020af770
+
+src/func_ov004_020af770.cpp:
+    complete
+    .text start:0x020af770 end:0x020af868
+
+src/func_ov004_020af868.cpp:
+    complete
+    .text start:0x020af868 end:0x020af948
+
+src/func_ov004_020af948.cpp:
+    complete
+    .text start:0x020af948 end:0x020afa20
+
+src/RenderOamMainScreen.cpp:
+    complete
+    .text start:0x020afa20 end:0x020afb20
+
+src/func_ov004_020afb20.cpp:
+    complete
+    .text start:0x020afb20 end:0x020afc18
+
+src/func_ov004_020afc18.cpp:
+    complete
+    .text start:0x020afc18 end:0x020afcf8
+
+src/DrawOamSprite.cpp:
+    complete
+    .text start:0x020afcf8 end:0x020afdd0
+
+src/func_ov004_020afdd0.cpp:
+    complete
+    .text start:0x020afdd0 end:0x020aff38
+
+src/func_ov004_020aff38.cpp:
+    complete
+    .text start:0x020aff38 end:0x020b0104
+
+src/RenderOamBothScreens.cpp:
+    complete
+    .text start:0x020b0104 end:0x020b023c
+
+src/func_ov004_020b023c.cpp:
+    complete
+    .text start:0x020b023c end:0x020b0380
+
+src/func_ov004_020b0380.cpp:
+    complete
+    .text start:0x020b0380 end:0x020b04c0
+
+src/func_ov004_020b04c0.c:
+    complete
+    .text start:0x020b04c0 end:0x020b04d0
+
+src/func_ov004_020b04d0.c:
+    complete
+    .text start:0x020b04d0 end:0x020b04e0
+
+src/func_ov004_020b04e0.c:
+    complete
+    .text start:0x020b04e0 end:0x020b04e8
+
+src/func_ov004_020b04e8.c:
+    complete
+    .text start:0x020b04e8 end:0x020b04ec
+
+src/func_ov004_020b04ec.c:
+    complete
+    .text start:0x020b04ec end:0x020b04f4
+
+src/func_ov004_020b04f4.cpp:
+    .text start:0x020b04f4 end:0x020b0618
+
+src/func_ov004_020b0618.c:
+    complete
+    .text start:0x020b0618 end:0x020b0620
+
+src/func_ov004_020b0620.cpp:
+    .text start:0x020b0620 end:0x020b0840
+
+src/func_ov004_020b0840.c:
+    complete
+    .text start:0x020b0840 end:0x020b08f0
+
+src/func_ov004_020b08f0.cpp:
+    complete
+    .text start:0x020b08f0 end:0x020b0930
+
+src/func_ov004_020b0930.cpp:
+    .text start:0x020b0930 end:0x020b0a38
+
+src/func_ov004_020b0a38.c:
+    complete
+    .text start:0x020b0a38 end:0x020b0a54
+
+src/func_ov004_020b0a54.c:
+    complete
+    .text start:0x020b0a54 end:0x020b0aa0
+
+src/FreeGfxSlotsById.c:
+    complete
+    .text start:0x020b0aa0 end:0x020b0b1c
+
+src/func_ov004_020b0b1c.c:
+    .text start:0x020b0b1c end:0x020b0cac
+
+src/func_ov004_020b0cac.c:
+    complete
+    .text start:0x020b0cac end:0x020b0d30
+
+src/func_ov004_020b0d30.c:
+    complete
+    .text start:0x020b0d30 end:0x020b0d8c
+
+src/func_ov004_020b0d8c.c:
+    complete
+    .text start:0x020b0d8c end:0x020b0de0
+
+src/func_ov004_020b0de0.c:
+    complete
+    .text start:0x020b0de0 end:0x020b0e84
+
+src/func_ov004_020b14f0.c:
+    complete
+    .text start:0x020b14f0 end:0x020b1710
+
+src/func_ov004_020b19f0.c:
+    complete
+    .text start:0x020b19f0 end:0x020b1a5c
+
+src/func_ov004_020b1a5c.c:
+    complete
+    .text start:0x020b1a5c end:0x020b1aec
+
+src/func_ov004_020b1aec.c:
+    complete
+    .text start:0x020b1aec end:0x020b1b08
+
+src/func_ov004_020b1b08.c:
+    complete
+    .text start:0x020b1b08 end:0x020b1b40
+
+src/func_ov004_020b1b40.c:
+    complete
+    .text start:0x020b1b40 end:0x020b1b78
+
+src/func_ov004_020b1b78.c:
+    complete
+    .text start:0x020b1b78 end:0x020b1ba0
+
+src/func_ov004_020b1ba0.c:
+    complete
+    .text start:0x020b1ba0 end:0x020b1bc8
+
+src/func_ov004_020b1bc8.c:
+    complete
+    .text start:0x020b1bc8 end:0x020b1c68
+
+src/func_ov004_020b1c68.c:
+    complete
+    .text start:0x020b1c68 end:0x020b1cf0
+
+src/func_ov004_020b1cf0.c:
+    complete
+    .text start:0x020b1cf0 end:0x020b1d60
+
+src/func_ov004_020b1d60.c:
+    complete
+    .text start:0x020b1d60 end:0x020b1de8
+
+src/func_ov004_020b1de8.c:
+    complete
+    .text start:0x020b1de8 end:0x020b1e34
+
+src/func_ov004_020b1e34.c:
+    complete
+    .text start:0x020b1e34 end:0x020b1e44
+
+src/func_ov004_020b1e44.c:
+    complete
+    .text start:0x020b1e44 end:0x020b1ea4
+
+src/func_ov004_020b1ea4.c:
+    complete
+    .text start:0x020b1ea4 end:0x020b2220
+
+src/func_ov004_020b2444.c:
+    complete
+    .text start:0x020b2444 end:0x020b2574
+
+src/func_ov004_020b2574.c:
+    complete
+    .text start:0x020b2574 end:0x020b265c
+
+src/func_ov004_020b265c.c:
+    complete
+    .text start:0x020b265c end:0x020b27f4
+
+src/func_ov004_020b27f4.c:
+    complete
+    .text start:0x020b27f4 end:0x020b2880
+
+src/func_ov004_020b2880.c:
+    complete
+    .text start:0x020b2880 end:0x020b290c
+
+src/func_ov004_020b290c.c:
+    complete
+    .text start:0x020b290c end:0x020b2980
+
+src/func_ov004_020b2980.c:
+    .text start:0x020b2980 end:0x020b298c
+
+src/func_ov004_020b298c.c:
+    complete
+    .text start:0x020b298c end:0x020b2990
+
+src/func_ov004_020b2990.c:
+    complete
+    .text start:0x020b2990 end:0x020b2994
+
+src/func_ov004_020b2994.c:
+    complete
+    .text start:0x020b2994 end:0x020b299c
+
+src/func_ov004_020b299c.c:
+    complete
+    .text start:0x020b299c end:0x020b29a0
+
+src/func_ov004_020b29a0.cpp:
+    complete
+    .text start:0x020b29a0 end:0x020b29c0
+
+src/func_ov004_020b29c0.cpp:
+    .text start:0x020b29c0 end:0x020b2a18
+
+src/func_ov004_020b2a18.cpp:
+    complete
+    .text start:0x020b2a18 end:0x020b2a84
+
+src/func_ov004_020b2a84.cpp:
+    .text start:0x020b2a84 end:0x020b2adc
+
+src/func_ov004_020b2adc.c:
+    complete
+    .text start:0x020b2adc end:0x020b2c58
+
+src/func_ov004_020b2c58.c:
+    complete
+    .text start:0x020b2c58 end:0x020b2c7c
+
+src/func_ov004_020b2c7c.c:
+    complete
+    .text start:0x020b2c7c end:0x020b2c80
+
+src/func_ov004_020b2c80.c:
+    complete
+    .text start:0x020b2c80 end:0x020b2c84
+
+src/func_ov004_020b2c84.c:
+    complete
+    .text start:0x020b2c84 end:0x020b2cb8
+
+src/func_ov004_020b2cb8.c:
+    .text start:0x020b2cb8 end:0x020b3194
+
+src/func_ov004_020b3194.c:
+    complete
+    .text start:0x020b3194 end:0x020b31b4
+
+src/func_ov004_020b31b4.cpp:
+    complete
+    .text start:0x020b31b4 end:0x020b321c
+
+src/func_ov004_020b321c.cpp:
+    complete
+    .text start:0x020b321c end:0x020b3278
+
+src/func_ov004_020b3278.cpp:
+    complete
+    .text start:0x020b3278 end:0x020b35d8
+
+src/func_ov004_020b35d8.c:
+    complete
+    .text start:0x020b35d8 end:0x020b3698
+
+src/func_ov004_020b3698.c:
+    complete
+    .text start:0x020b3698 end:0x020b369c
+
+src/func_ov004_020b369c.c:
+    complete
+    .text start:0x020b369c end:0x020b37c4
+
+src/func_ov004_020b37c4.cpp:
+    complete
+    .text start:0x020b37c4 end:0x020b37f0
+
+src/func_ov004_020b37f0.c:
+    complete
+    .text start:0x020b37f0 end:0x020b3834
+
+src/func_ov004_020b3834.c:
+    complete
+    .text start:0x020b3834 end:0x020b3888
+
+src/func_ov004_020b3888.c:
+    complete
+    .text start:0x020b3888 end:0x020b38ac
+
+src/func_ov004_020b38ac.c:
+    complete
+    .text start:0x020b38ac end:0x020b3978
+
+src/func_ov004_020b3978.cpp:
+    complete
+    .text start:0x020b3978 end:0x020b39a4
+
+src/func_ov004_020b39a4.c:
+    complete
+    .text start:0x020b39a4 end:0x020b3b38
+
+src/func_ov004_020b3b38.cpp:
+    complete
+    .text start:0x020b3b38 end:0x020b3c58
+
+src/func_ov004_020b3c58.c:
+    complete
+    .text start:0x020b3c58 end:0x020b3c9c
+
+src/func_ov004_020b3c9c.c:
+    complete
+    .text start:0x020b3c9c end:0x020b3cb8
+
+src/func_ov004_020b3cb8.c:
+    complete
+    .text start:0x020b3cb8 end:0x020b3e9c
+
+src/func_ov004_020b3e9c.c:
+    complete
+    .text start:0x020b3e9c end:0x020b4080
+
+src/func_ov004_020b4080.cpp:
+    complete
+    .text start:0x020b4080 end:0x020b40ac
+
+src/func_ov004_020b40ac.c:
+    complete
+    .text start:0x020b40ac end:0x020b40c0
+
+src/func_ov004_020b40c0.c:
+    complete
+    .text start:0x020b40c0 end:0x020b410c
+
+src/func_ov004_020b410c.c:
+    complete
+    .text start:0x020b410c end:0x020b4214
+
+src/func_ov004_020b4214.c:
+    complete
+    .text start:0x020b4214 end:0x020b422c
+
+src/func_ov004_020b422c.c:
+    complete
+    .text start:0x020b422c end:0x020b42c0
+
+src/func_ov004_020b42c0.c:
+    complete
+    .text start:0x020b42c0 end:0x020b433c
+
+src/func_ov004_020b433c.c:
+    complete
+    .text start:0x020b433c end:0x020b4360
+
+src/func_ov004_020b4360.c:
+    complete
+    .text start:0x020b4360 end:0x020b45c0
+
+src/func_ov004_020b45c0.c:
+    complete
+    .text start:0x020b45c0 end:0x020b4820
+
+src/func_ov004_020b4820.cpp:
+    complete
+    .text start:0x020b4820 end:0x020b484c
+
+src/func_ov004_020b484c.c:
+    complete
+    .text start:0x020b484c end:0x020b49b8
+
+src/func_ov004_020b49b8.c:
+    complete
+    .text start:0x020b49b8 end:0x020b49e4
+
+src/func_ov004_020b49e4.c:
+    complete
+    .text start:0x020b49e4 end:0x020b49f0
+
+src/func_ov004_020b49f0.c:
+    complete
+    .text start:0x020b49f0 end:0x020b4a1c
+
+src/func_ov004_020b4a1c.c:
+    complete
+    .text start:0x020b4a1c end:0x020b4a28
+
+src/func_ov004_020b4a28.c:
+    complete
+    .text start:0x020b4a28 end:0x020b4a40
+
+src/func_ov004_020b4a40.c:
+    complete
+    .text start:0x020b4a40 end:0x020b4a4c
+
+src/func_ov004_020b4a4c.c:
+    complete
+    .text start:0x020b4a4c end:0x020b4a64
+
+src/func_ov004_020b4a64.c:
+    complete
+    .text start:0x020b4a64 end:0x020b4a70
+
+src/func_ov004_020b4a70.c:
+    complete
+    .text start:0x020b4a70 end:0x020b4a7c
+
+src/func_ov004_020b4a7c.c:
+    complete
+    .text start:0x020b4a7c end:0x020b4aa0
+
+src/func_ov004_020b4aa0.c:
+    complete
+    .text start:0x020b4aa0 end:0x020b4aa4
+
+src/func_ov004_020b4aa4.c:
+    complete
+    .text start:0x020b4aa4 end:0x020b4b84
+
+src/func_ov004_020b4b84.c:
+    complete
+    .text start:0x020b4b84 end:0x020b4c30
+
+src/func_ov004_020b4c30.c:
+    complete
+    .text start:0x020b4c30 end:0x020b4cc4
+
+src/func_ov004_020b4cc4.c:
+    complete
+    .text start:0x020b4cc4 end:0x020b4d50
+
+src/func_ov004_020b4d50.c:
+    .text start:0x020b4d50 end:0x020b4dfc
+
+src/func_ov004_020b4dfc.c:
+    complete
+    .text start:0x020b4dfc end:0x020b4e78
+
+src/func_ov004_020b4e78.c:
+    complete
+    .text start:0x020b4e78 end:0x020b4f44
+
+src/func_ov004_020b4f44.c:
+    complete
+    .text start:0x020b4f44 end:0x020b4ff0
+
+src/func_ov004_020b4ff0.c:
+    complete
+    .text start:0x020b4ff0 end:0x020b506c
+
+src/func_ov004_020b506c.c:
+    complete
+    .text start:0x020b506c end:0x020b5108
+
+src/func_ov004_020b5108.c:
+    complete
+    .text start:0x020b5108 end:0x020b51e4
+
+src/func_ov004_020b51e4.c:
+    complete
+    .text start:0x020b51e4 end:0x020b51f0
+
+src/func_ov004_020b51f0.c:
+    complete
+    .text start:0x020b51f0 end:0x020b5288
+
+src/func_ov004_020b5288.cpp:
+    complete
+    .text start:0x020b5288 end:0x020b52b8
+
+src/func_ov004_020b52b8.c:
+    complete
+    .text start:0x020b52b8 end:0x020b52fc
+
+src/func_ov004_020b52fc.cpp:
+    complete
+    .text start:0x020b52fc end:0x020b5334
+
+src/func_ov004_020b5334.c:
+    complete
+    .text start:0x020b5334 end:0x020b5368
+
+src/func_ov004_020b5368.c:
+    complete
+    .text start:0x020b5368 end:0x020b53f0
+
+src/func_ov004_020b53f0.c:
+    complete
+    .text start:0x020b53f0 end:0x020b556c
+
+src/func_ov004_020b556c.cpp:
+    .text start:0x020b556c end:0x020b56c8
+
+src/func_ov004_020b56c8.c:
+    complete
+    .text start:0x020b56c8 end:0x020b5768
+
+src/func_ov004_020b5768.cpp:
+    complete
+    .text start:0x020b5768 end:0x020b586c
+
+src/func_ov004_020b586c.cpp:
+    complete
+    .text start:0x020b586c end:0x020b58c4
+
+src/func_ov004_020b58c4.cpp:
+    .text start:0x020b58c4 end:0x020b5a54
+
+src/func_ov004_020b5a54.cpp:
+    complete
+    .text start:0x020b5a54 end:0x020b5aac
+
+src/func_ov004_020b5aac.cpp:
+    .text start:0x020b5aac end:0x020b5c18
+
+src/func_ov004_020b5c18.cpp:
+    .text start:0x020b5c18 end:0x020b5d74
+
+src/func_ov004_020b5d74.c:
+    complete
+    .text start:0x020b5d74 end:0x020b5dd4
+
+src/func_ov004_020b5dd4.c:
+    complete
+    .text start:0x020b5dd4 end:0x020b5e40
+
+src/func_ov004_020b5e40.c:
+    complete
+    .text start:0x020b5e40 end:0x020b5ed0
+
+src/func_ov004_020b5ed0.c:
+    complete
+    .text start:0x020b5ed0 end:0x020b5f6c
+
+src/func_ov004_020b5f6c.cpp:
+    complete
+    .text start:0x020b5f6c end:0x020b612c
+
+src/func_ov004_020b612c.c:
+    complete
+    .text start:0x020b612c end:0x020b6234
+
+src/func_ov004_020b6234.cpp:
+    .text start:0x020b6234 end:0x020b6324
+
+src/func_ov004_020b6324.c:
+    complete
+    .text start:0x020b6324 end:0x020b63a0
+
+src/func_ov004_020b63a0.c:
+    complete
+    .text start:0x020b63a0 end:0x020b6430
+
+src/func_ov004_020b6430.c:
+    complete
+    .text start:0x020b6430 end:0x020b653c
+
+src/func_ov004_020b653c.c:
+    complete
+    .text start:0x020b653c end:0x020b65e4
+
+src/func_ov004_020b65e4.c:
+    complete
+    .text start:0x020b65e4 end:0x020b66d4
+
+src/func_ov004_020b66d4.c:
+    complete
+    .text start:0x020b66d4 end:0x020b67bc
+
+src/func_ov004_020b67bc.c:
+    complete
+    .text start:0x020b67bc end:0x020b67e0
+
+src/func_ov004_020b67e0.c:
+    complete
+    .text start:0x020b67e0 end:0x020b67e4
+
+src/func_ov004_020b67e4.c:
+    complete
+    .text start:0x020b67e4 end:0x020b67e8
+
+src/func_ov004_020b67e8.c:
+    complete
+    .text start:0x020b67e8 end:0x020b67f8
+
+src/func_ov004_020b67f8.c:
+    complete
+    .text start:0x020b67f8 end:0x020b6808
+
+src/func_ov004_020b6808.c:
+    complete
+    .text start:0x020b6808 end:0x020b682c
+
+src/func_ov004_020b682c.c:
+    complete
+    .text start:0x020b682c end:0x020b68e8
+
+src/func_ov004_020b68e8.c:
+    complete
+    .text start:0x020b68e8 end:0x020b6948
+
+src/func_ov004_020b6948.c:
+    complete
+    .text start:0x020b6948 end:0x020b6ad8
+
+src/func_ov004_020b6ad8.c:
+    complete
+    .text start:0x020b6ad8 end:0x020b6b40
+
+src/func_ov004_020b6b40.c:
+    complete
+    .text start:0x020b6b40 end:0x020b6c10
+
+src/func_ov004_020b6c10.c:
+    complete
+    .text start:0x020b6c10 end:0x020b6c9c
+
+src/func_ov004_020b6c9c.c:
+    complete
+    .text start:0x020b6c9c end:0x020b6d6c
+
+src/func_ov004_020b6d6c.c:
+    complete
+    .text start:0x020b6d6c end:0x020b6ddc
+
+src/func_ov004_020b6ddc.c:
+    complete
+    .text start:0x020b6ddc end:0x020b6f14
+
+src/func_ov004_020b6f14.c:
+    complete
+    .text start:0x020b6f14 end:0x020b6f88
+
+src/func_ov004_020b6f88.c:
+    complete
+    .text start:0x020b6f88 end:0x020b7020
+
+src/func_ov004_020b7020.c:
+    complete
+    .text start:0x020b7020 end:0x020b70b4
+
+src/func_ov004_020b70b4.c:
+    complete
+    .text start:0x020b70b4 end:0x020b7124
+
+src/func_ov004_020b7124.cpp:
+    complete
+    .text start:0x020b7124 end:0x020b724c
+
+src/func_ov004_020b724c.c:
+    complete
+    .text start:0x020b724c end:0x020b72d4
+
+src/func_ov004_020b72d4.cpp:
+    complete
+    .text start:0x020b72d4 end:0x020b743c
+
+src/func_ov004_020b743c.c:
+    complete
+    .text start:0x020b743c end:0x020b7460
+
+src/func_ov004_020b7460.c:
+    complete
+    .text start:0x020b7460 end:0x020b746c
+
+src/func_ov004_020b746c.cpp:
+    complete
+    .text start:0x020b746c end:0x020b7594
+
+src/func_ov004_020b7594.cpp:
+    complete
+    .text start:0x020b7594 end:0x020b75e4
+
+src/func_ov004_020b75e4.c:
+    complete
+    .text start:0x020b75e4 end:0x020b7744
+
+src/func_ov004_020b7744.c:
+    complete
+    .text start:0x020b7744 end:0x020b77b4
+
+src/func_ov004_020b77b4.cpp:
+    complete
+    .text start:0x020b77b4 end:0x020b7854
+
+src/func_ov004_020b7854.c:
+    complete
+    .text start:0x020b7854 end:0x020b78f4
+
+src/func_ov004_020b78f4.cpp:
+    complete
+    .text start:0x020b78f4 end:0x020b798c
+
+src/func_ov004_020b798c.c:
+    complete
+    .text start:0x020b798c end:0x020b79b0
+
+src/func_ov004_020b79b0.c:
+    complete
+    .text start:0x020b79b0 end:0x020b7a18
+
+src/func_ov004_020b7a18.cpp:
+    complete
+    .text start:0x020b7a18 end:0x020b7b20
+
+src/func_ov004_020b7b20.c:
+    complete
+    .text start:0x020b7b20 end:0x020b7b90
+
+src/func_ov004_020b7b90.c:
+    complete
+    .text start:0x020b7b90 end:0x020b7c04
+
+src/func_ov004_020b7c04.c:
+    complete
+    .text start:0x020b7c04 end:0x020b7cd0
+
+src/func_ov004_020b7cd0.cpp:
+    complete
+    .text start:0x020b7cd0 end:0x020b7e38
+
+src/func_ov004_020b7e38.c:
+    complete
+    .text start:0x020b7e38 end:0x020b7eac
+
+src/func_ov004_020b7eac.cpp:
+    complete
+    .text start:0x020b7eac end:0x020b7f5c
+
+src/func_ov004_020b7f5c.c:
+    complete
+    .text start:0x020b7f5c end:0x020b7fec
+
+src/func_ov004_020b7fec.cpp:
+    complete
+    .text start:0x020b7fec end:0x020b8098
+
+src/func_ov004_020b8098.c:
+    complete
+    .text start:0x020b8098 end:0x020b81f8
+
+src/func_ov004_020b81f8.c:
+    complete
+    .text start:0x020b81f8 end:0x020b8284
+
+src/func_ov004_020b8284.cpp:
+    complete
+    .text start:0x020b8284 end:0x020b83ac
+
+src/func_ov004_020b83ac.c:
+    complete
+    .text start:0x020b83ac end:0x020b841c
+
+src/func_ov004_020b841c.cpp:
+    complete
+    .text start:0x020b841c end:0x020b853c
+
+src/func_ov004_020b853c.c:
+    complete
+    .text start:0x020b853c end:0x020b8560
+
+src/func_ov004_020b8560.cpp:
+    complete
+    .text start:0x020b8560 end:0x020b8688
+
+src/func_ov004_020b8688.c:
+    complete
+    .text start:0x020b8688 end:0x020b8714
+
+src/func_ov004_020b8714.cpp:
+    complete
+    .text start:0x020b8714 end:0x020b8778
+
+src/func_ov004_020b8778.cpp:
+    complete
+    .text start:0x020b8778 end:0x020b87e0
+
+src/func_ov004_020b87e0.cpp:
+    .text start:0x020b87e0 end:0x020b8a70
+
+src/func_ov004_020b8a70.c:
+    complete
+    .text start:0x020b8a70 end:0x020b8a8c
+
+src/func_ov004_020b8a8c.c:
+    complete
+    .text start:0x020b8a8c end:0x020b8c18
+
+src/func_ov004_020b8c18.c:
+    complete
+    .text start:0x020b8c18 end:0x020b8dc0
+
+src/func_ov004_020b8dc0.c:
+    complete
+    .text start:0x020b8dc0 end:0x020b8ee0
+
+src/func_ov004_020b8ee0.c:
+    complete
+    .text start:0x020b8ee0 end:0x020b8f18
+
+src/func_ov004_020b8f18.cpp:
+    complete
+    .text start:0x020b8f18 end:0x020b8f78
+
+src/func_ov004_020b8f78.cpp:
+    complete
+    .text start:0x020b8f78 end:0x020b91fc
+
+src/func_ov004_020b91fc.c:
+    complete
+    .text start:0x020b91fc end:0x020b9220
+
+src/func_ov004_020b9220.c:
+    complete
+    .text start:0x020b9220 end:0x020b9280
+
+src/func_ov004_020b9280.c:
+    complete
+    .text start:0x020b9280 end:0x020b929c
+
+src/func_ov004_020b929c.c:
+    complete
+    .text start:0x020b929c end:0x020b92c4
+
+src/func_ov004_020b92c4.c:
+    complete
+    .text start:0x020b92c4 end:0x020b9430
+
+src/func_ov004_020b9430.c:
+    complete
+    .text start:0x020b9430 end:0x020b944c
+
+src/__sinit_ov004_020b948c.c:
+    .init start:0x020b948c end:0x020b955c
+
+src/__sinit_ov004_020b9ad0.c:
+    .init start:0x020b9ad0 end:0x020b9b24
+
+src/__sinit_ov004_020b9b24.c:
+    .init start:0x020b9b24 end:0x020b9de4

--- a/config/arm9/overlays/ov005/delinks.txt
+++ b/config/arm9/overlays/ov005/delinks.txt
@@ -3,3 +3,93 @@
     .ctor       start:0x020c2430 end:0x020c2430 kind:rodata align:4
     .data       start:0x020c2440 end:0x020c3020 kind:data align:32
     .bss        start:0x020c3020 end:0x020c3020 kind:bss align:32
+src/func_ov005_020bfec0.c:
+    .text start:0x020bfec0 end:0x020bfefc
+
+src/func_ov005_020bfefc.c:
+    complete
+    .text start:0x020bfefc end:0x020bff4c
+
+src/func_ov005_020bff4c.cpp:
+    complete
+    .text start:0x020bff4c end:0x020bffc8
+
+src/func_ov005_020bffc8.c:
+    complete
+    .text start:0x020bffc8 end:0x020bfff4
+
+src/func_ov005_020bfff4.c:
+    complete
+    .text start:0x020bfff4 end:0x020c0010
+
+src/func_ov005_020c0010.c:
+    complete
+    .text start:0x020c0010 end:0x020c0030
+
+src/func_ov005_020c0030.c:
+    complete
+    .text start:0x020c0030 end:0x020c007c
+
+src/func_ov005_020c007c.c:
+    complete
+    .text start:0x020c007c end:0x020c00b4
+
+src/func_ov005_020c00b4.c:
+    complete
+    .text start:0x020c00b4 end:0x020c00e4
+
+src/func_ov005_020c00e4.c:
+    complete
+    .text start:0x020c00e4 end:0x020c0140
+
+src/func_ov005_020c0140.c:
+    complete
+    .text start:0x020c0140 end:0x020c0250
+
+src/func_ov005_020c0250.cpp:
+    complete
+    .text start:0x020c0250 end:0x020c0378
+
+src/func_ov005_020c06cc.c:
+    complete
+    .text start:0x020c06cc end:0x020c0878
+
+src/func_ov005_020c0878.c:
+    complete
+    .text start:0x020c0878 end:0x020c0b00
+
+src/func_ov005_020c0b00.c:
+    complete
+    .text start:0x020c0b00 end:0x020c0b04
+
+src/func_ov005_020c0f38.c:
+    complete
+    .text start:0x020c0f38 end:0x020c1030
+
+src/func_ov005_020c1030.cpp:
+    complete
+    .text start:0x020c1030 end:0x020c1130
+
+src/func_ov005_020c1130.c:
+    complete
+    .text start:0x020c1130 end:0x020c14a0
+
+src/func_ov005_020c14a0.c:
+    complete
+    .text start:0x020c14a0 end:0x020c1654
+
+src/func_ov005_020c1654.c:
+    complete
+    .text start:0x020c1654 end:0x020c1688
+
+src/func_ov005_020c1688.c:
+    complete
+    .text start:0x020c1688 end:0x020c16e4
+
+src/func_ov005_020c1a20.c:
+    complete
+    .text start:0x020c1a20 end:0x020c21ec
+
+src/func_ov005_020c21ec.c:
+    complete
+    .text start:0x020c21ec end:0x020c2250

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -4,3 +4,7006 @@
     .ctor       start:0x0213356c end:0x021335e8 kind:rodata align:4
     .data       start:0x02133600 end:0x021402e0 kind:data align:32
     .bss        start:0x021402e0 end:0x021430a0 kind:bss align:32
+src/func_ov006_020bfec0.cpp:
+    complete
+    .text start:0x020bfec0 end:0x020bfff8
+
+src/func_ov006_020bfff8.cpp:
+    complete
+    .text start:0x020bfff8 end:0x020c0134
+
+src/Camera_UpdateMatrices.c:
+    complete
+    .text start:0x020c0134 end:0x020c0264
+
+src/func_ov006_020c0264.cpp:
+    .text start:0x020c0264 end:0x020c0304
+
+src/func_ov006_020c0304.c:
+    complete
+    .text start:0x020c0304 end:0x020c0364
+
+src/func_ov006_020c0364.c:
+    complete
+    .text start:0x020c0364 end:0x020c057c
+
+src/func_ov006_020c057c.cpp:
+    complete
+    .text start:0x020c057c end:0x020c06dc
+
+src/func_ov006_020c06dc.cpp:
+    complete
+    .text start:0x020c06dc end:0x020c07a0
+
+src/func_ov006_020c07a0.c:
+    complete
+    .text start:0x020c07a0 end:0x020c07e8
+
+src/func_ov006_020c07e8.cpp:
+    complete
+    .text start:0x020c07e8 end:0x020c092c
+
+src/func_ov006_020c092c.cpp:
+    complete
+    .text start:0x020c092c end:0x020c09f8
+
+src/func_ov006_020c09f8.c:
+    complete
+    .text start:0x020c09f8 end:0x020c0a48
+
+src/func_ov006_020c0a48.c:
+    .text start:0x020c0a48 end:0x020c0aa8
+
+src/func_ov006_020c0aa8.c:
+    complete
+    .text start:0x020c0aa8 end:0x020c0af8
+
+src/func_ov006_020c0af8.c:
+    complete
+    .text start:0x020c0af8 end:0x020c0b74
+
+src/func_ov006_020c0b74.c:
+    complete
+    .text start:0x020c0b74 end:0x020c0c80
+
+src/func_ov006_020c0c80.cpp:
+    complete
+    .text start:0x020c0c80 end:0x020c0ce8
+
+src/func_ov006_020c0ce8.c:
+    complete
+    .text start:0x020c0ce8 end:0x020c0d68
+
+src/func_ov006_020c0d68.cpp:
+    .text start:0x020c0d68 end:0x020c0df0
+
+src/func_ov006_020c0df0.cpp:
+    complete
+    .text start:0x020c0df0 end:0x020c0e8c
+
+src/func_ov006_020c0e8c.c:
+    complete
+    .text start:0x020c0e8c end:0x020c0efc
+
+src/func_ov006_020c0efc.c:
+    complete
+    .text start:0x020c0efc end:0x020c0f0c
+
+src/func_ov006_020c0f0c.c:
+    complete
+    .text start:0x020c0f0c end:0x020c0f9c
+
+src/func_ov006_020c0f9c.cpp:
+    complete
+    .text start:0x020c0f9c end:0x020c1164
+
+src/func_ov006_020c1164.c:
+    complete
+    .text start:0x020c1164 end:0x020c11c0
+
+src/func_ov006_020c11c0.cpp:
+    complete
+    .text start:0x020c11c0 end:0x020c1420
+
+src/func_ov006_020c1420.cpp:
+    .text start:0x020c1420 end:0x020c14bc
+
+src/func_ov006_020c14bc.cpp:
+    .text start:0x020c14bc end:0x020c1604
+
+src/func_ov006_020c1604.c:
+    complete
+    .text start:0x020c1604 end:0x020c16b4
+
+src/func_ov006_020c16b4.c:
+    complete
+    .text start:0x020c16b4 end:0x020c1718
+
+src/func_ov006_020c1718.c:
+    complete
+    .text start:0x020c1718 end:0x020c1760
+
+src/func_ov006_020c1760.c:
+    complete
+    .text start:0x020c1760 end:0x020c1764
+
+src/func_ov006_020c1764.cpp:
+    .text start:0x020c1764 end:0x020c1804
+
+src/func_ov006_020c1804.cpp:
+    .text start:0x020c1804 end:0x020c19d0
+
+src/func_ov006_020c19d0.cpp:
+    complete
+    .text start:0x020c19d0 end:0x020c1a88
+
+src/func_ov006_020c1a88.c:
+    complete
+    .text start:0x020c1a88 end:0x020c1c64
+
+src/func_ov006_020c1c64.c:
+    complete
+    .text start:0x020c1c64 end:0x020c1d80
+
+src/func_ov006_020c1d80.c:
+    complete
+    .text start:0x020c1d80 end:0x020c1eb4
+
+src/func_ov006_020c1eb4.c:
+    complete
+    .text start:0x020c1eb4 end:0x020c1ef8
+
+src/func_ov006_020c1ef8.c:
+    complete
+    .text start:0x020c1ef8 end:0x020c1f04
+
+src/func_ov006_020c1f04.c:
+    complete
+    .text start:0x020c1f04 end:0x020c1f4c
+
+src/func_ov006_020c1f4c.cpp:
+    complete
+    .text start:0x020c1f4c end:0x020c201c
+
+src/func_ov006_020c201c.cpp:
+    complete
+    .text start:0x020c201c end:0x020c2144
+
+src/func_ov006_020c2144.c:
+    complete
+    .text start:0x020c2144 end:0x020c2154
+
+src/func_ov006_020c2154.c:
+    complete
+    .text start:0x020c2154 end:0x020c21e4
+
+src/func_ov006_020c21e4.c:
+    complete
+    .text start:0x020c21e4 end:0x020c221c
+
+src/func_ov006_020c221c.c:
+    .text start:0x020c221c end:0x020c225c
+
+src/func_ov006_020c225c.c:
+    complete
+    .text start:0x020c225c end:0x020c2290
+
+src/func_ov006_020c2290.c:
+    complete
+    .text start:0x020c2290 end:0x020c22d8
+
+src/func_ov006_020c22d8.c:
+    complete
+    .text start:0x020c22d8 end:0x020c2300
+
+src/func_ov006_020c2300.c:
+    complete
+    .text start:0x020c2300 end:0x020c23a8
+
+src/func_ov006_020c23a8.cpp:
+    complete
+    .text start:0x020c23a8 end:0x020c2440
+
+src/func_ov006_020c2440.cpp:
+    complete
+    .text start:0x020c2440 end:0x020c24e4
+
+src/func_ov006_020c24e4.cpp:
+    complete
+    .text start:0x020c24e4 end:0x020c2594
+
+src/func_ov006_020c2594.c:
+    complete
+    .text start:0x020c2594 end:0x020c263c
+
+src/func_ov006_020c263c.c:
+    complete
+    .text start:0x020c263c end:0x020c2664
+
+src/func_ov006_020c2664.c:
+    complete
+    .text start:0x020c2664 end:0x020c26f4
+
+src/func_ov006_020c26f4.c:
+    complete
+    .text start:0x020c26f4 end:0x020c271c
+
+src/func_ov006_020c271c.c:
+    complete
+    .text start:0x020c271c end:0x020c27c4
+
+src/func_ov006_020c27c4.cpp:
+    complete
+    .text start:0x020c27c4 end:0x020c2848
+
+src/func_ov006_020c2848.cpp:
+    complete
+    .text start:0x020c2848 end:0x020c2924
+
+src/func_ov006_020c2924.cpp:
+    complete
+    .text start:0x020c2924 end:0x020c2984
+
+src/func_ov006_020c2984.c:
+    complete
+    .text start:0x020c2984 end:0x020c2994
+
+src/func_ov006_020c2994.c:
+    complete
+    .text start:0x020c2994 end:0x020c29dc
+
+src/func_ov006_020c29dc.cpp:
+    complete
+    .text start:0x020c29dc end:0x020c2b8c
+
+src/func_ov006_020c2b8c.cpp:
+    complete
+    .text start:0x020c2b8c end:0x020c2be8
+
+src/func_ov006_020c2be8.c:
+    complete
+    .text start:0x020c2be8 end:0x020c3050
+
+src/func_ov006_020c3050.c:
+    complete
+    .text start:0x020c3050 end:0x020c3288
+
+src/func_ov006_020c3288.c:
+    complete
+    .text start:0x020c3288 end:0x020c33dc
+
+src/func_ov006_020c33dc.c:
+    complete
+    .text start:0x020c33dc end:0x020c3528
+
+src/func_ov006_020c3528.cpp:
+    complete
+    .text start:0x020c3528 end:0x020c35a8
+
+src/func_ov006_020c35a8.cpp:
+    complete
+    .text start:0x020c35a8 end:0x020c35e8
+
+src/func_ov006_020c35e8.c:
+    complete
+    .text start:0x020c35e8 end:0x020c3754
+
+src/func_ov006_020c3754.c:
+    complete
+    .text start:0x020c3754 end:0x020c3884
+
+src/func_ov006_020c3884.c:
+    complete
+    .text start:0x020c3884 end:0x020c38ac
+
+src/func_ov006_020c38ac.c:
+    complete
+    .text start:0x020c38ac end:0x020c38b0
+
+src/func_ov006_020c38b0.c:
+    complete
+    .text start:0x020c38b0 end:0x020c3904
+
+src/func_ov006_020c3904.c:
+    complete
+    .text start:0x020c3904 end:0x020c3908
+
+src/func_ov006_020c3908.c:
+    complete
+    .text start:0x020c3908 end:0x020c395c
+
+src/func_ov006_020c395c.c:
+    complete
+    .text start:0x020c395c end:0x020c3990
+
+src/func_ov006_020c3990.c:
+    complete
+    .text start:0x020c3990 end:0x020c3ad8
+
+src/func_ov006_020c3ad8.c:
+    complete
+    .text start:0x020c3ad8 end:0x020c3adc
+
+src/func_ov006_020c3adc.c:
+    complete
+    .text start:0x020c3adc end:0x020c3b2c
+
+src/func_ov006_020c3b2c.c:
+    complete
+    .text start:0x020c3b2c end:0x020c3b80
+
+src/func_ov006_020c3b80.c:
+    complete
+    .text start:0x020c3b80 end:0x020c3bc8
+
+src/func_ov006_020c3bc8.c:
+    .text start:0x020c3bc8 end:0x020c3bf4
+
+src/func_ov006_020c3bf4.cpp:
+    complete
+    .text start:0x020c3bf4 end:0x020c3d18
+
+src/func_ov006_020c3d18.cpp:
+    complete
+    .text start:0x020c3d18 end:0x020c3d88
+
+src/func_ov006_020c3d88.cpp:
+    complete
+    .text start:0x020c3d88 end:0x020c3e54
+
+src/func_ov006_020c3e54.c:
+    complete
+    .text start:0x020c3e54 end:0x020c3e70
+
+src/func_ov006_020c3e70.cpp:
+    complete
+    .text start:0x020c3e70 end:0x020c3f54
+
+src/func_ov006_020c3f54.cpp:
+    complete
+    .text start:0x020c3f54 end:0x020c402c
+
+src/func_ov006_020c402c.c:
+    complete
+    .text start:0x020c402c end:0x020c4048
+
+src/func_ov006_020c4048.c:
+    complete
+    .text start:0x020c4048 end:0x020c4060
+
+src/func_ov006_020c4060.c:
+    complete
+    .text start:0x020c4060 end:0x020c40e8
+
+src/func_ov006_020c40e8.c:
+    complete
+    .text start:0x020c40e8 end:0x020c4148
+
+src/func_ov006_020c4148.c:
+    complete
+    .text start:0x020c4148 end:0x020c425c
+
+src/func_ov006_020c425c.c:
+    complete
+    .text start:0x020c425c end:0x020c42bc
+
+src/func_ov006_020c42bc.c:
+    complete
+    .text start:0x020c42bc end:0x020c44b4
+
+src/func_ov006_020c44b4.c:
+    complete
+    .text start:0x020c44b4 end:0x020c4684
+
+src/func_ov006_020c4684.c:
+    complete
+    .text start:0x020c4684 end:0x020c4710
+
+src/func_ov006_020c4710.c:
+    complete
+    .text start:0x020c4710 end:0x020c47d4
+
+src/func_ov006_020c47d4.c:
+    complete
+    .text start:0x020c47d4 end:0x020c49d8
+
+src/func_ov006_020c49d8.c:
+    complete
+    .text start:0x020c49d8 end:0x020c4c00
+
+src/func_ov006_020c4c00.c:
+    complete
+    .text start:0x020c4c00 end:0x020c4c54
+
+src/func_ov006_020c4c54.cpp:
+    complete
+    .text start:0x020c4c54 end:0x020c4cd8
+
+src/func_ov006_020c4cd8.cpp:
+    complete
+    .text start:0x020c4cd8 end:0x020c4d1c
+
+src/func_ov006_020c4d1c.c:
+    complete
+    .text start:0x020c4d1c end:0x020c4d20
+
+src/func_ov006_020c4d20.c:
+    complete
+    .text start:0x020c4d20 end:0x020c4d3c
+
+src/func_ov006_020c4d3c.c:
+    complete
+    .text start:0x020c4d3c end:0x020c4e8c
+
+src/func_ov006_020c4e8c.c:
+    complete
+    .text start:0x020c4e8c end:0x020c4f68
+
+src/func_ov006_020c4f68.c:
+    complete
+    .text start:0x020c4f68 end:0x020c4fa4
+
+src/func_ov006_020c4fa4.cpp:
+    complete
+    .text start:0x020c4fa4 end:0x020c5370
+
+src/func_ov006_020c5370.c:
+    complete
+    .text start:0x020c5370 end:0x020c53f8
+
+src/func_ov006_020c53f8.c:
+    complete
+    .text start:0x020c53f8 end:0x020c54f4
+
+src/func_ov006_020c54f4.c:
+    complete
+    .text start:0x020c54f4 end:0x020c5530
+
+src/func_ov006_020c5530.c:
+    complete
+    .text start:0x020c5530 end:0x020c561c
+
+src/func_ov006_020c561c.c:
+    complete
+    .text start:0x020c561c end:0x020c5658
+
+src/func_ov006_020c5658.c:
+    complete
+    .text start:0x020c5658 end:0x020c57d4
+
+src/func_ov006_020c57d4.c:
+    complete
+    .text start:0x020c57d4 end:0x020c5928
+
+src/func_ov006_020c5928.c:
+    complete
+    .text start:0x020c5928 end:0x020c5aa4
+
+src/func_ov006_020c5aa4.c:
+    complete
+    .text start:0x020c5aa4 end:0x020c5bf8
+
+src/func_ov006_020c5bf8.c:
+    complete
+    .text start:0x020c5bf8 end:0x020c5cf4
+
+src/func_ov006_020c5cf4.c:
+    complete
+    .text start:0x020c5cf4 end:0x020c5d28
+
+src/func_ov006_020c5d28.c:
+    complete
+    .text start:0x020c5d28 end:0x020c5ec8
+
+src/func_ov006_020c5ec8.c:
+    complete
+    .text start:0x020c5ec8 end:0x020c6088
+
+src/func_ov006_020c6088.c:
+    complete
+    .text start:0x020c6088 end:0x020c6188
+
+src/func_ov006_020c6188.c:
+    complete
+    .text start:0x020c6188 end:0x020c61c4
+
+src/func_ov006_020c61c4.c:
+    complete
+    .text start:0x020c61c4 end:0x020c6248
+
+src/func_ov006_020c6248.c:
+    complete
+    .text start:0x020c6248 end:0x020c627c
+
+src/func_ov006_020c627c.c:
+    complete
+    .text start:0x020c627c end:0x020c6348
+
+src/func_ov006_020c6348.c:
+    complete
+    .text start:0x020c6348 end:0x020c6378
+
+src/func_ov006_020c6378.c:
+    .text start:0x020c6378 end:0x020c63dc
+
+src/func_ov006_020c63dc.c:
+    complete
+    .text start:0x020c63dc end:0x020c6400
+
+src/func_ov006_020c6400.c:
+    complete
+    .text start:0x020c6400 end:0x020c64e4
+
+src/func_ov006_020c64e4.c:
+    complete
+    .text start:0x020c64e4 end:0x020c66bc
+
+src/func_ov006_020c66bc.c:
+    complete
+    .text start:0x020c66bc end:0x020c68f4
+
+src/func_ov006_020c68f4.c:
+    complete
+    .text start:0x020c68f4 end:0x020c6a9c
+
+src/func_ov006_020c6a9c.c:
+    complete
+    .text start:0x020c6a9c end:0x020c6ca4
+
+src/func_ov006_020c6ca4.c:
+    complete
+    .text start:0x020c6ca4 end:0x020c6e4c
+
+src/func_ov006_020c6e4c.cpp:
+    .text start:0x020c6e4c end:0x020c6f3c
+
+src/_ZN6Player18St_LevelEnter_MainEv.c:
+    complete
+    .text start:0x020c6f3c end:0x020c6f70
+
+src/func_ov006_020c6f70.c:
+    complete
+    .text start:0x020c6f70 end:0x020c6f8c
+
+src/func_ov006_020c6f8c.c:
+    complete
+    .text start:0x020c6f8c end:0x020c70d0
+
+src/func_ov006_020c70d0.c:
+    complete
+    .text start:0x020c70d0 end:0x020c712c
+
+src/func_ov006_020c712c.c:
+    complete
+    .text start:0x020c712c end:0x020c719c
+
+src/func_ov006_020c719c.c:
+    complete
+    .text start:0x020c719c end:0x020c72b4
+
+src/func_ov006_020c72b4.c:
+    complete
+    .text start:0x020c72b4 end:0x020c72c8
+
+src/func_ov006_020c72c8.c:
+    complete
+    .text start:0x020c72c8 end:0x020c72dc
+
+src/func_ov006_020c72dc.c:
+    complete
+    .text start:0x020c72dc end:0x020c7300
+
+src/func_ov006_020c7300.c:
+    complete
+    .text start:0x020c7300 end:0x020c7388
+
+src/func_ov006_020c7388.c:
+    complete
+    .text start:0x020c7388 end:0x020c7418
+
+src/func_ov006_020c7418.c:
+    complete
+    .text start:0x020c7418 end:0x020c7490
+
+src/func_ov006_020c7490.c:
+    complete
+    .text start:0x020c7490 end:0x020c7574
+
+src/func_ov006_020c7574.c:
+    complete
+    .text start:0x020c7574 end:0x020c762c
+
+src/func_ov006_020c762c.c:
+    complete
+    .text start:0x020c762c end:0x020c76d0
+
+src/func_ov006_020c76d0.c:
+    complete
+    .text start:0x020c76d0 end:0x020c76d8
+
+src/func_ov006_020c76d8.c:
+    complete
+    .text start:0x020c76d8 end:0x020c76e0
+
+src/func_ov006_020c76e0.cpp:
+    complete
+    .text start:0x020c76e0 end:0x020c7734
+
+src/func_ov006_020c7734.cpp:
+    complete
+    .text start:0x020c7734 end:0x020c7860
+
+src/func_ov006_020c7860.cpp:
+    complete
+    .text start:0x020c7860 end:0x020c78ec
+
+src/func_ov006_020c78ec.cpp:
+    complete
+    .text start:0x020c78ec end:0x020c79a8
+
+src/func_ov006_020c79a8.cpp:
+    .text start:0x020c79a8 end:0x020c7a30
+
+src/func_ov006_020c7a30.c:
+    complete
+    .text start:0x020c7a30 end:0x020c7ba4
+
+src/func_ov006_020c7ba4.c:
+    complete
+    .text start:0x020c7ba4 end:0x020c7c68
+
+src/func_ov006_020c802c.c:
+    complete
+    .text start:0x020c802c end:0x020c8048
+
+src/func_ov006_020c8048.c:
+    complete
+    .text start:0x020c8048 end:0x020c8084
+
+src/func_ov006_020c8084.cpp:
+    .text start:0x020c8084 end:0x020c814c
+
+src/func_ov006_020c814c.cpp:
+    complete
+    .text start:0x020c814c end:0x020c81e0
+
+src/func_ov006_020c81e0.c:
+    complete
+    .text start:0x020c81e0 end:0x020c8270
+
+src/func_ov006_020c8270.c:
+    complete
+    .text start:0x020c8270 end:0x020c833c
+
+src/func_ov006_020c833c.c:
+    complete
+    .text start:0x020c833c end:0x020c85a0
+
+src/func_ov006_020c85a0.c:
+    complete
+    .text start:0x020c85a0 end:0x020c85bc
+
+src/func_ov006_020c85bc.cpp:
+    complete
+    .text start:0x020c85bc end:0x020c862c
+
+src/func_ov006_020c862c.c:
+    complete
+    .text start:0x020c862c end:0x020c864c
+
+src/func_ov006_020c864c.c:
+    complete
+    .text start:0x020c864c end:0x020c8658
+
+src/func_ov006_020c8658.c:
+    complete
+    .text start:0x020c8658 end:0x020c8680
+
+src/func_ov006_020c8680.c:
+    complete
+    .text start:0x020c8680 end:0x020c8768
+
+src/func_ov006_020c8768.c:
+    complete
+    .text start:0x020c8768 end:0x020c87d0
+
+src/func_ov006_020c87d0.cpp:
+    complete
+    .text start:0x020c87d0 end:0x020c893c
+
+src/func_ov006_020c893c.cpp:
+    complete
+    .text start:0x020c893c end:0x020c8a04
+
+src/func_ov006_020c8a04.c:
+    complete
+    .text start:0x020c8a04 end:0x020c8a30
+
+src/func_ov006_020c8a30.c:
+    complete
+    .text start:0x020c8a30 end:0x020c8a64
+
+src/func_ov006_020c8a64.c:
+    complete
+    .text start:0x020c8a64 end:0x020c8a9c
+
+src/func_ov006_020c8a9c.c:
+    complete
+    .text start:0x020c8a9c end:0x020c8af4
+
+src/func_ov006_020c8af4.c:
+    complete
+    .text start:0x020c8af4 end:0x020c8ba8
+
+src/func_ov006_020c8ba8.cpp:
+    complete
+    .text start:0x020c8ba8 end:0x020c8c6c
+
+src/func_ov006_020c8c6c.c:
+    complete
+    .text start:0x020c8c6c end:0x020c8c78
+
+src/func_ov006_020c8c78.c:
+    complete
+    .text start:0x020c8c78 end:0x020c8da8
+
+src/func_ov006_020c8da8.c:
+    complete
+    .text start:0x020c8da8 end:0x020c8dcc
+
+src/func_ov006_020c8dcc.c:
+    complete
+    .text start:0x020c8dcc end:0x020c8dd0
+
+src/func_ov006_020c8dd0.c:
+    complete
+    .text start:0x020c8dd0 end:0x020c8dd4
+
+src/func_ov006_020c8dd4.c:
+    complete
+    .text start:0x020c8dd4 end:0x020c8ddc
+
+src/func_ov006_020c8ddc.c:
+    complete
+    .text start:0x020c8ddc end:0x020c8e80
+
+src/func_ov006_020c8e80.c:
+    complete
+    .text start:0x020c8e80 end:0x020c8e88
+
+src/func_ov006_020c8e88.c:
+    complete
+    .text start:0x020c8e88 end:0x020c8e90
+
+src/func_ov006_020c8e90.cpp:
+    complete
+    .text start:0x020c8e90 end:0x020c8ecc
+
+src/func_ov006_020c8ecc.cpp:
+    complete
+    .text start:0x020c8ecc end:0x020c8f20
+
+src/func_ov006_020c8f20.cpp:
+    .text start:0x020c8f20 end:0x020c9024
+
+src/func_ov006_020c9024.cpp:
+    complete
+    .text start:0x020c9024 end:0x020c905c
+
+src/func_ov006_020c905c.c:
+    complete
+    .text start:0x020c905c end:0x020c9098
+
+src/func_ov006_020c9098.c:
+    .text start:0x020c9098 end:0x020c91ac
+
+src/func_ov006_020c91ac.cpp:
+    complete
+    .text start:0x020c91ac end:0x020c94e0
+
+src/func_ov006_020c97bc.cpp:
+    complete
+    .text start:0x020c97bc end:0x020c9aa0
+
+src/func_ov006_020c9aa0.cpp:
+    complete
+    .text start:0x020c9aa0 end:0x020c9c8c
+
+src/func_ov006_020c9c8c.c:
+    .text start:0x020c9c8c end:0x020c9d7c
+
+src/func_ov006_020c9d7c.c:
+    complete
+    .text start:0x020c9d7c end:0x020c9e7c
+
+src/func_ov006_020c9e7c.c:
+    complete
+    .text start:0x020c9e7c end:0x020c9efc
+
+src/func_ov006_020c9efc.cpp:
+    .text start:0x020c9efc end:0x020c9fe4
+
+src/func_ov006_020c9fe4.cpp:
+    complete
+    .text start:0x020c9fe4 end:0x020ca070
+
+src/func_ov006_020ca070.cpp:
+    complete
+    .text start:0x020ca070 end:0x020ca2ec
+
+src/func_ov006_020ca2ec.c:
+    complete
+    .text start:0x020ca2ec end:0x020ca310
+
+src/func_ov006_020ca310.cpp:
+    complete
+    .text start:0x020ca310 end:0x020ca374
+
+src/func_ov006_020ca374.c:
+    complete
+    .text start:0x020ca374 end:0x020ca39c
+
+src/func_ov006_020ca39c.c:
+    complete
+    .text start:0x020ca39c end:0x020ca3a8
+
+src/func_ov006_020ca3a8.cpp:
+    .text start:0x020ca3a8 end:0x020ca430
+
+src/func_ov006_020ca430.c:
+    complete
+    .text start:0x020ca430 end:0x020ca604
+
+src/func_ov006_020ca604.cpp:
+    complete
+    .text start:0x020ca604 end:0x020ca78c
+
+src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp:
+    .text start:0x020ca78c end:0x020ca7b8
+
+src/func_ov006_020ca7b8.c:
+    complete
+    .text start:0x020ca7b8 end:0x020ca840
+
+src/func_ov006_020ca840.c:
+    complete
+    .text start:0x020ca840 end:0x020ca8e0
+
+src/func_ov006_020ca8e0.cpp:
+    complete
+    .text start:0x020ca8e0 end:0x020caa08
+
+src/func_ov006_020caa08.c:
+    complete
+    .text start:0x020caa08 end:0x020caadc
+
+src/func_ov006_020caadc.c:
+    complete
+    .text start:0x020caadc end:0x020cac30
+
+src/_ZN6Player12St_Null_InitEv.cpp:
+    complete
+    .text start:0x020cac30 end:0x020cac9c
+
+src/func_ov006_020cac9c.c:
+    complete
+    .text start:0x020cac9c end:0x020cad3c
+
+src/func_ov006_020cad3c.c:
+    complete
+    .text start:0x020cad3c end:0x020cae9c
+
+src/func_ov006_020cae9c.c:
+    complete
+    .text start:0x020cae9c end:0x020caf44
+
+src/func_ov006_020caf44.c:
+    complete
+    .text start:0x020caf44 end:0x020caf4c
+
+src/func_ov006_020caf4c.c:
+    complete
+    .text start:0x020caf4c end:0x020cafa4
+
+src/func_ov006_020cafa4.c:
+    complete
+    .text start:0x020cafa4 end:0x020cafac
+
+src/func_ov006_020cafac.c:
+    complete
+    .text start:0x020cafac end:0x020cafb4
+
+src/func_ov006_020cafb4.cpp:
+    complete
+    .text start:0x020cafb4 end:0x020cafdc
+
+src/func_ov006_020cafdc.cpp:
+    complete
+    .text start:0x020cafdc end:0x020cb030
+
+src/func_ov006_020cb030.cpp:
+    .text start:0x020cb030 end:0x020cb134
+
+src/func_ov006_020cb134.cpp:
+    complete
+    .text start:0x020cb134 end:0x020cb16c
+
+src/func_ov006_020cb16c.c:
+    complete
+    .text start:0x020cb16c end:0x020cb1a8
+
+src/func_ov006_020cb1a8.c:
+    .text start:0x020cb1a8 end:0x020cb2b4
+
+src/func_ov006_020cb2b4.c:
+    complete
+    .text start:0x020cb2b4 end:0x020cb528
+
+src/func_ov006_020cb528.c:
+    .text start:0x020cb528 end:0x020cb5c4
+
+src/func_ov006_020cb5c4.c:
+    complete
+    .text start:0x020cb5c4 end:0x020cb690
+
+src/func_ov006_020cb690.cpp:
+    .text start:0x020cb690 end:0x020cb72c
+
+src/func_ov006_020cb72c.c:
+    complete
+    .text start:0x020cb72c end:0x020cb814
+
+src/func_ov006_020cb814.c:
+    complete
+    .text start:0x020cb814 end:0x020cb838
+
+src/func_ov006_020cb838.cpp:
+    complete
+    .text start:0x020cb838 end:0x020cbaec
+
+src/func_ov006_020cbaec.cpp:
+    .text start:0x020cbaec end:0x020cbd7c
+
+src/func_ov006_020cbd7c.cpp:
+    complete
+    .text start:0x020cbd7c end:0x020cbfd8
+
+src/func_ov006_020cbfd8.cpp:
+    complete
+    .text start:0x020cbfd8 end:0x020cc198
+
+src/func_ov006_020cc198.c:
+    complete
+    .text start:0x020cc198 end:0x020cc2ac
+
+src/func_ov006_020cc2ac.c:
+    complete
+    .text start:0x020cc2ac end:0x020cc37c
+
+src/func_ov006_020cc37c.cpp:
+    complete
+    .text start:0x020cc37c end:0x020cc408
+
+src/func_ov006_020cc408.cpp:
+    complete
+    .text start:0x020cc408 end:0x020cc618
+
+src/func_ov006_020cc618.c:
+    complete
+    .text start:0x020cc618 end:0x020cc63c
+
+src/func_ov006_020cc63c.c:
+    complete
+    .text start:0x020cc63c end:0x020cc698
+
+src/func_ov006_020cc698.cpp:
+    complete
+    .text start:0x020cc698 end:0x020cc724
+
+src/func_ov006_020cc724.c:
+    complete
+    .text start:0x020cc724 end:0x020cc8c8
+
+src/func_ov006_020cc8c8.c:
+    complete
+    .text start:0x020cc8c8 end:0x020cc9b8
+
+src/func_ov006_020cc9b8.c:
+    complete
+    .text start:0x020cc9b8 end:0x020cc9fc
+
+src/func_ov006_020cc9fc.cpp:
+    .text start:0x020cc9fc end:0x020ccae0
+
+src/func_ov006_020ccae0.c:
+    complete
+    .text start:0x020ccae0 end:0x020ccc8c
+
+src/func_ov006_020ccc8c.cpp:
+    complete
+    .text start:0x020ccc8c end:0x020ccd04
+
+src/func_ov006_020ccd04.c:
+    complete
+    .text start:0x020ccd04 end:0x020ccd64
+
+src/func_ov006_020ccd64.c:
+    complete
+    .text start:0x020ccd64 end:0x020ccd78
+
+src/func_ov006_020ccd78.cpp:
+    complete
+    .text start:0x020ccd78 end:0x020cce0c
+
+src/func_ov006_020cce0c.c:
+    complete
+    .text start:0x020cce0c end:0x020ccfc8
+
+src/func_ov006_020ccfc8.cpp:
+    complete
+    .text start:0x020ccfc8 end:0x020cd12c
+
+src/func_ov006_020cd12c.c:
+    .text start:0x020cd12c end:0x020cd158
+
+src/func_ov006_020cd158.c:
+    complete
+    .text start:0x020cd158 end:0x020cd1e0
+
+src/func_ov006_020cd1e0.c:
+    complete
+    .text start:0x020cd1e0 end:0x020cd270
+
+src/func_ov006_020cd270.c:
+    complete
+    .text start:0x020cd270 end:0x020cd39c
+
+src/func_ov006_020cd39c.c:
+    complete
+    .text start:0x020cd39c end:0x020cd424
+
+src/func_ov006_020cd424.c:
+    complete
+    .text start:0x020cd424 end:0x020cd510
+
+src/func_ov006_020cd510.c:
+    complete
+    .text start:0x020cd510 end:0x020cd62c
+
+src/func_ov006_020cd62c.c:
+    complete
+    .text start:0x020cd62c end:0x020cd658
+
+src/func_ov006_020cd658.c:
+    complete
+    .text start:0x020cd658 end:0x020cd6d8
+
+src/func_ov006_020cd6d8.c:
+    complete
+    .text start:0x020cd6d8 end:0x020cd6f4
+
+src/func_ov006_020cd6f4.c:
+    complete
+    .text start:0x020cd6f4 end:0x020cd720
+
+src/func_ov006_020cd720.c:
+    complete
+    .text start:0x020cd720 end:0x020cd72c
+
+src/func_ov006_020cd72c.c:
+    complete
+    .text start:0x020cd72c end:0x020cd744
+
+src/func_ov006_020cd744.c:
+    complete
+    .text start:0x020cd744 end:0x020cd7b8
+
+src/func_ov006_020cd7b8.c:
+    complete
+    .text start:0x020cd7b8 end:0x020cd864
+
+src/func_ov006_020cd864.c:
+    complete
+    .text start:0x020cd864 end:0x020cd98c
+
+src/func_ov006_020cd98c.c:
+    complete
+    .text start:0x020cd98c end:0x020cd9b0
+
+src/func_ov006_020cd9b0.c:
+    complete
+    .text start:0x020cd9b0 end:0x020cdad0
+
+src/func_ov006_020cdad0.c:
+    complete
+    .text start:0x020cdad0 end:0x020cdaec
+
+src/func_ov006_020cdaec.c:
+    complete
+    .text start:0x020cdaec end:0x020cdc14
+
+src/func_ov006_020cdc14.c:
+    complete
+    .text start:0x020cdc14 end:0x020cdc38
+
+src/func_ov006_020cdc38.c:
+    complete
+    .text start:0x020cdc38 end:0x020cdc68
+
+src/func_ov006_020cdc68.c:
+    complete
+    .text start:0x020cdc68 end:0x020cdc8c
+
+src/func_ov006_020cdc8c.c:
+    complete
+    .text start:0x020cdc8c end:0x020cdce4
+
+src/func_ov006_020cdce4.c:
+    complete
+    .text start:0x020cdce4 end:0x020cdd08
+
+src/func_ov006_020cdd08.c:
+    complete
+    .text start:0x020cdd08 end:0x020cde28
+
+src/func_ov006_020cde28.c:
+    complete
+    .text start:0x020cde28 end:0x020cde4c
+
+src/func_ov006_020cde4c.c:
+    complete
+    .text start:0x020cde4c end:0x020cde7c
+
+src/func_ov006_020cde7c.c:
+    complete
+    .text start:0x020cde7c end:0x020cdea0
+
+src/func_ov006_020cdea0.c:
+    complete
+    .text start:0x020cdea0 end:0x020cdeec
+
+src/func_ov006_020cdeec.c:
+    complete
+    .text start:0x020cdeec end:0x020cdf1c
+
+src/func_ov006_020cdf1c.c:
+    complete
+    .text start:0x020cdf1c end:0x020cdf20
+
+src/func_ov006_020cdf20.c:
+    complete
+    .text start:0x020cdf20 end:0x020cdf3c
+
+src/func_ov006_020cdf3c.c:
+    complete
+    .text start:0x020cdf3c end:0x020ce0ac
+
+src/func_ov006_020ce0ac.cpp:
+    complete
+    .text start:0x020ce0ac end:0x020ce108
+
+src/func_ov006_020ce108.cpp:
+    complete
+    .text start:0x020ce108 end:0x020ce46c
+
+src/func_ov006_020ce46c.c:
+    complete
+    .text start:0x020ce46c end:0x020ce674
+
+src/func_ov006_020ce674.c:
+    complete
+    .text start:0x020ce674 end:0x020ce8a0
+
+src/func_ov006_020ce8a0.cpp:
+    complete
+    .text start:0x020ce8a0 end:0x020ce988
+
+src/func_ov006_020ce988.cpp:
+    complete
+    .text start:0x020ce988 end:0x020cea2c
+
+src/func_ov006_020cea2c.cpp:
+    complete
+    .text start:0x020cea2c end:0x020ceabc
+
+src/func_ov006_020ceabc.c:
+    complete
+    .text start:0x020ceabc end:0x020cecb4
+
+src/func_ov006_020cecb4.c:
+    complete
+    .text start:0x020cecb4 end:0x020cecc0
+
+src/func_ov006_020cecc0.cpp:
+    .text start:0x020cecc0 end:0x020ced84
+
+src/func_ov006_020ced84.c:
+    complete
+    .text start:0x020ced84 end:0x020cedf0
+
+src/func_ov006_020cedf0.c:
+    complete
+    .text start:0x020cedf0 end:0x020cee5c
+
+src/func_ov006_020cee5c.c:
+    complete
+    .text start:0x020cee5c end:0x020ceedc
+
+src/func_ov006_020ceedc.c:
+    complete
+    .text start:0x020ceedc end:0x020cef14
+
+src/func_ov006_020cef14.c:
+    complete
+    .text start:0x020cef14 end:0x020cefa4
+
+src/func_ov006_020cefa4.c:
+    complete
+    .text start:0x020cefa4 end:0x020cf040
+
+src/func_ov006_020cf040.c:
+    complete
+    .text start:0x020cf040 end:0x020cf124
+
+src/func_ov006_020cf124.c:
+    complete
+    .text start:0x020cf124 end:0x020cf2fc
+
+src/func_ov006_020cf758.cpp:
+    complete
+    .text start:0x020cf758 end:0x020cf790
+
+src/func_ov006_020cf790.c:
+    complete
+    .text start:0x020cf790 end:0x020cf804
+
+src/func_ov006_020cf804.c:
+    complete
+    .text start:0x020cf804 end:0x020cf820
+
+src/func_ov006_020cf820.c:
+    complete
+    .text start:0x020cf820 end:0x020cfa28
+
+src/func_ov006_020cfa28.c:
+    complete
+    .text start:0x020cfa28 end:0x020cfa44
+
+src/func_ov006_020cfa44.c:
+    complete
+    .text start:0x020cfa44 end:0x020cfc58
+
+src/func_ov006_020cfc58.c:
+    complete
+    .text start:0x020cfc58 end:0x020cfc74
+
+src/func_ov006_020d09e0.c:
+    complete
+    .text start:0x020d09e0 end:0x020d0ac0
+
+src/func_ov006_020d0ac0.c:
+    complete
+    .text start:0x020d0ac0 end:0x020d0b04
+
+src/func_ov006_020d0b04.c:
+    complete
+    .text start:0x020d0b04 end:0x020d0b2c
+
+src/func_ov006_020d0b2c.cpp:
+    complete
+    .text start:0x020d0b2c end:0x020d0b78
+
+src/func_ov006_020d0b78.c:
+    complete
+    .text start:0x020d0b78 end:0x020d0bd8
+
+src/func_ov006_020d0bd8.c:
+    complete
+    .text start:0x020d0bd8 end:0x020d0c38
+
+src/func_ov006_020d0fe4.c:
+    complete
+    .text start:0x020d0fe4 end:0x020d1008
+
+src/func_ov006_020d1008.c:
+    complete
+    .text start:0x020d1008 end:0x020d100c
+
+src/func_ov006_020d100c.c:
+    complete
+    .text start:0x020d100c end:0x020d1018
+
+src/func_ov006_020d1018.c:
+    complete
+    .text start:0x020d1018 end:0x020d10b8
+
+src/func_ov006_020d10b8.cpp:
+    .text start:0x020d10b8 end:0x020d116c
+
+src/func_ov006_020d116c.c:
+    complete
+    .text start:0x020d116c end:0x020d1170
+
+src/func_ov006_020d1170.c:
+    complete
+    .text start:0x020d1170 end:0x020d1188
+
+src/func_ov006_020d1188.c:
+    complete
+    .text start:0x020d1188 end:0x020d11a0
+
+src/func_ov006_020d11a0.cpp:
+    complete
+    .text start:0x020d11a0 end:0x020d122c
+
+src/func_ov006_020d1450.c:
+    complete
+    .text start:0x020d1450 end:0x020d14c0
+
+src/func_ov006_020d14c0.c:
+    complete
+    .text start:0x020d14c0 end:0x020d1958
+
+src/func_ov006_020d1958.cpp:
+    complete
+    .text start:0x020d1958 end:0x020d1a3c
+
+src/func_ov006_020d1a3c.cpp:
+    complete
+    .text start:0x020d1a3c end:0x020d1ba0
+
+src/func_ov006_020d2580.c:
+    complete
+    .text start:0x020d2580 end:0x020d25fc
+
+src/func_ov006_020d3624.cpp:
+    complete
+    .text start:0x020d3624 end:0x020d3668
+
+src/func_ov006_020d3668.cpp:
+    complete
+    .text start:0x020d3668 end:0x020d36a4
+
+src/func_ov006_020d452c.c:
+    complete
+    .text start:0x020d452c end:0x020d47f4
+
+src/func_ov006_020d48dc.cpp:
+    complete
+    .text start:0x020d48dc end:0x020d4b7c
+
+src/func_ov006_020d52f0.c:
+    complete
+    .text start:0x020d52f0 end:0x020d5384
+
+src/func_ov006_020d5384.cpp:
+    complete
+    .text start:0x020d5384 end:0x020d5924
+
+src/func_ov006_020d5924.cpp:
+    complete
+    .text start:0x020d5924 end:0x020d5974
+
+src/func_ov006_020d5974.cpp:
+    complete
+    .text start:0x020d5974 end:0x020d5a50
+
+src/func_ov006_020d5a50.c:
+    complete
+    .text start:0x020d5a50 end:0x020d5a54
+
+src/func_ov006_020d5a54.c:
+    complete
+    .text start:0x020d5a54 end:0x020d5a78
+
+src/func_ov006_020d5a78.c:
+    .text start:0x020d5a78 end:0x020d5ab0
+
+src/func_ov006_020d5ab0.cpp:
+    complete
+    .text start:0x020d5ab0 end:0x020d5b00
+
+src/func_ov006_020d5b00.c:
+    complete
+    .text start:0x020d5b00 end:0x020d5b10
+
+src/func_ov006_020d5b10.c:
+    complete
+    .text start:0x020d5b10 end:0x020d5c60
+
+src/func_ov006_020d5c60.c:
+    complete
+    .text start:0x020d5c60 end:0x020d5c88
+
+src/func_ov006_020d5c88.c:
+    complete
+    .text start:0x020d5c88 end:0x020d5d08
+
+src/func_ov006_020d5d08.c:
+    complete
+    .text start:0x020d5d08 end:0x020d5d90
+
+src/func_ov006_020d5d90.c:
+    complete
+    .text start:0x020d5d90 end:0x020d5dd4
+
+src/func_ov006_020d5dd4.c:
+    complete
+    .text start:0x020d5dd4 end:0x020d5dfc
+
+src/func_ov006_020d5dfc.cpp:
+    complete
+    .text start:0x020d5dfc end:0x020d5e1c
+
+src/func_ov006_020d5e1c.c:
+    .text start:0x020d5e1c end:0x020d5e3c
+
+src/func_ov006_020d5e3c.c:
+    .text start:0x020d5e3c end:0x020d5e5c
+
+src/func_ov006_020d5e5c.c:
+    .text start:0x020d5e5c end:0x020d5eb8
+
+src/func_ov006_020d5eb8.c:
+    complete
+    .text start:0x020d5eb8 end:0x020d5f28
+
+src/func_ov006_020d5f28.c:
+    complete
+    .text start:0x020d5f28 end:0x020d5f2c
+
+src/func_ov006_020d5f2c.c:
+    complete
+    .text start:0x020d5f2c end:0x020d5fd8
+
+src/func_ov006_020d5fd8.c:
+    .text start:0x020d5fd8 end:0x020d5fec
+
+src/func_ov006_020d5fec.cpp:
+    complete
+    .text start:0x020d5fec end:0x020d604c
+
+src/func_ov006_020d604c.c:
+    complete
+    .text start:0x020d604c end:0x020d6084
+
+src/_ZN6Player23St_InYoshiMouth_CleanupEv.cpp:
+    complete
+    .text start:0x020d6084 end:0x020d6098
+
+src/func_ov006_020d6098.c:
+    complete
+    .text start:0x020d6098 end:0x020d6100
+
+src/func_ov006_020d6100.c:
+    complete
+    .text start:0x020d6100 end:0x020d6170
+
+src/func_ov006_020d6170.c:
+    complete
+    .text start:0x020d6170 end:0x020d61dc
+
+src/func_ov006_020d61dc.c:
+    complete
+    .text start:0x020d61dc end:0x020d6264
+
+src/func_ov006_020d6264.c:
+    .text start:0x020d6264 end:0x020d6278
+
+src/func_ov006_020d6278.cpp:
+    complete
+    .text start:0x020d6278 end:0x020d62e0
+
+src/func_ov006_020d62e0.c:
+    complete
+    .text start:0x020d62e0 end:0x020d634c
+
+src/func_ov006_020d634c.c:
+    complete
+    .text start:0x020d634c end:0x020d63ac
+
+src/func_ov006_020d63ac.c:
+    complete
+    .text start:0x020d63ac end:0x020d63d4
+
+src/func_ov006_020d63d4.c:
+    complete
+    .text start:0x020d63d4 end:0x020d6454
+
+src/func_ov006_020d6454.c:
+    complete
+    .text start:0x020d6454 end:0x020d64c4
+
+src/func_ov006_020d64c4.c:
+    complete
+    .text start:0x020d64c4 end:0x020d64c8
+
+src/func_ov006_020d64c8.c:
+    complete
+    .text start:0x020d64c8 end:0x020d65b4
+
+src/func_ov006_020d65b4.c:
+    .text start:0x020d65b4 end:0x020d65c8
+
+src/func_ov006_020d65c8.cpp:
+    complete
+    .text start:0x020d65c8 end:0x020d6630
+
+src/func_ov006_020d6630.c:
+    complete
+    .text start:0x020d6630 end:0x020d669c
+
+src/func_ov006_020d669c.c:
+    complete
+    .text start:0x020d669c end:0x020d66c4
+
+src/func_ov006_020d66c4.cpp:
+    complete
+    .text start:0x020d66c4 end:0x020d672c
+
+src/func_ov006_020d672c.c:
+    .text start:0x020d672c end:0x020d6784
+
+src/func_ov006_020d6784.c:
+    .text start:0x020d6784 end:0x020d68a8
+
+src/func_ov006_020d68a8.c:
+    complete
+    .text start:0x020d68a8 end:0x020d69b8
+
+src/func_ov006_020d69b8.c:
+    complete
+    .text start:0x020d69b8 end:0x020d6b88
+
+src/func_ov006_020d6b88.c:
+    complete
+    .text start:0x020d6b88 end:0x020d6c90
+
+src/func_ov006_020d6c90.c:
+    complete
+    .text start:0x020d6c90 end:0x020d6d7c
+
+src/func_ov006_020d6d7c.c:
+    complete
+    .text start:0x020d6d7c end:0x020d6e8c
+
+src/func_ov006_020d6e8c.c:
+    complete
+    .text start:0x020d6e8c end:0x020d7524
+
+src/func_ov006_020d7524.c:
+    complete
+    .text start:0x020d7524 end:0x020d7604
+
+src/func_ov006_020d7604.c:
+    complete
+    .text start:0x020d7604 end:0x020d7778
+
+src/func_ov006_020d7778.c:
+    complete
+    .text start:0x020d7778 end:0x020d777c
+
+src/func_ov006_020d7958.c:
+    complete
+    .text start:0x020d7958 end:0x020d795c
+
+src/func_ov006_020d795c.c:
+    complete
+    .text start:0x020d795c end:0x020d7a84
+
+src/func_ov006_020d7a84.c:
+    complete
+    .text start:0x020d7a84 end:0x020d7c00
+
+src/func_ov006_020d7c00.cpp:
+    complete
+    .text start:0x020d7c00 end:0x020d7c4c
+
+src/func_ov006_020d7e7c.c:
+    complete
+    .text start:0x020d7e7c end:0x020d7edc
+
+src/func_ov006_020d7edc.c:
+    complete
+    .text start:0x020d7edc end:0x020d7f5c
+
+src/func_ov006_020d7f5c.c:
+    complete
+    .text start:0x020d7f5c end:0x020d816c
+
+src/func_ov006_020d816c.c:
+    complete
+    .text start:0x020d816c end:0x020d8324
+
+src/func_ov006_020d8324.c:
+    .text start:0x020d8324 end:0x020d836c
+
+src/func_ov006_020d836c.cpp:
+    complete
+    .text start:0x020d836c end:0x020d8408
+
+src/func_ov006_020d8904.c:
+    complete
+    .text start:0x020d8904 end:0x020d893c
+
+src/func_ov006_020d893c.c:
+    complete
+    .text start:0x020d893c end:0x020d89c4
+
+src/func_ov006_020d89c4.c:
+    complete
+    .text start:0x020d89c4 end:0x020d8af8
+
+src/func_ov006_020d8af8.c:
+    complete
+    .text start:0x020d8af8 end:0x020d8c88
+
+src/func_ov006_020d8c88.c:
+    complete
+    .text start:0x020d8c88 end:0x020d8cc4
+
+src/func_ov006_020d8cc4.cpp:
+    complete
+    .text start:0x020d8cc4 end:0x020d8d84
+
+src/func_ov006_020d8d84.c:
+    complete
+    .text start:0x020d8d84 end:0x020d8f34
+
+src/func_ov006_020d8f34.c:
+    complete
+    .text start:0x020d8f34 end:0x020d8f98
+
+src/func_ov006_020d8f98.cpp:
+    complete
+    .text start:0x020d8f98 end:0x020d8ff4
+
+src/func_ov006_020d8ff4.c:
+    complete
+    .text start:0x020d8ff4 end:0x020d9020
+
+src/func_ov006_020d9020.c:
+    complete
+    .text start:0x020d9020 end:0x020d904c
+
+src/func_ov006_020d904c.c:
+    complete
+    .text start:0x020d904c end:0x020d907c
+
+src/func_ov006_020d907c.c:
+    complete
+    .text start:0x020d907c end:0x020d9104
+
+src/func_ov006_020d9104.c:
+    complete
+    .text start:0x020d9104 end:0x020d9160
+
+src/func_ov006_020d9160.c:
+    complete
+    .text start:0x020d9160 end:0x020d91b0
+
+src/func_ov006_020d91b0.cpp:
+    complete
+    .text start:0x020d91b0 end:0x020d9244
+
+src/func_ov006_020d9244.c:
+    complete
+    .text start:0x020d9244 end:0x020d9574
+
+src/MgSortOrSplode_Spawn.c:
+    complete
+    .text start:0x020d9574 end:0x020d95a4
+
+src/func_ov006_020d95a4.cpp:
+    complete
+    .text start:0x020d95a4 end:0x020d9638
+
+src/func_ov006_020d9638.cpp:
+    .text start:0x020d9638 end:0x020d96e0
+
+src/func_ov006_020d96e0.c:
+    complete
+    .text start:0x020d96e0 end:0x020d96f0
+
+src/func_ov006_020d96f0.c:
+    complete
+    .text start:0x020d96f0 end:0x020d970c
+
+src/func_ov006_020d970c.c:
+    complete
+    .text start:0x020d970c end:0x020d978c
+
+src/func_ov006_020d978c.cpp:
+    complete
+    .text start:0x020d978c end:0x020d9998
+
+src/func_ov006_020d9998.c:
+    complete
+    .text start:0x020d9998 end:0x020d99a4
+
+src/func_ov006_020d99a4.c:
+    complete
+    .text start:0x020d99a4 end:0x020d99ec
+
+src/func_ov006_020d99ec.c:
+    complete
+    .text start:0x020d99ec end:0x020d9a14
+
+src/func_ov006_020d9a14.c:
+    complete
+    .text start:0x020d9a14 end:0x020d9bd0
+
+src/func_ov006_020d9bd0.c:
+    complete
+    .text start:0x020d9bd0 end:0x020d9bdc
+
+src/func_ov006_020d9bdc.c:
+    complete
+    .text start:0x020d9bdc end:0x020d9c5c
+
+src/func_ov006_020d9c5c.cpp:
+    complete
+    .text start:0x020d9c5c end:0x020da00c
+
+src/func_ov006_020da00c.cpp:
+    complete
+    .text start:0x020da00c end:0x020da0ac
+
+src/func_ov006_020da0ac.cpp:
+    complete
+    .text start:0x020da0ac end:0x020da154
+
+src/func_ov006_020da154.c:
+    complete
+    .text start:0x020da154 end:0x020da174
+
+src/func_ov006_020da420.c:
+    complete
+    .text start:0x020da420 end:0x020da4ac
+
+src/func_ov006_020da4ac.c:
+    complete
+    .text start:0x020da4ac end:0x020da5e8
+
+src/func_ov006_020da5e8.c:
+    complete
+    .text start:0x020da5e8 end:0x020da834
+
+src/func_ov006_020da834.c:
+    complete
+    .text start:0x020da834 end:0x020da860
+
+src/func_ov006_020da860.c:
+    complete
+    .text start:0x020da860 end:0x020da88c
+
+src/func_ov006_020da88c.c:
+    complete
+    .text start:0x020da88c end:0x020da8b8
+
+src/func_ov006_020da8b8.c:
+    complete
+    .text start:0x020da8b8 end:0x020da8e4
+
+src/func_ov006_020da8e4.c:
+    complete
+    .text start:0x020da8e4 end:0x020da974
+
+src/func_ov006_020da974.c:
+    complete
+    .text start:0x020da974 end:0x020da994
+
+src/func_ov006_020da994.c:
+    complete
+    .text start:0x020da994 end:0x020da9c4
+
+src/func_ov006_020da9c4.cpp:
+    .text start:0x020da9c4 end:0x020dabec
+
+src/func_ov006_020dabec.c:
+    complete
+    .text start:0x020dabec end:0x020dac34
+
+src/func_ov006_020db6ec.c:
+    complete
+    .text start:0x020db6ec end:0x020db720
+
+src/func_ov006_020db720.c:
+    .text start:0x020db720 end:0x020db9dc
+
+src/func_ov006_020db9dc.c:
+    .text start:0x020db9dc end:0x020dbaf0
+
+src/func_ov006_020dbaf0.cpp:
+    .text start:0x020dbaf0 end:0x020dbd54
+
+src/MgPicturePoker_Spawn.cpp:
+    complete
+    .text start:0x020dbd54 end:0x020dbe14
+
+src/func_ov006_020dbe14.c:
+    complete
+    .text start:0x020dbe14 end:0x020dbe30
+
+src/func_ov006_020dbe30.c:
+    complete
+    .text start:0x020dbe30 end:0x020dbe40
+
+src/func_ov006_020dbe40.c:
+    complete
+    .text start:0x020dbe40 end:0x020dbe64
+
+src/func_ov006_020dbe64.c:
+    .text start:0x020dbe64 end:0x020dbe9c
+
+src/func_ov006_020dbf7c.c:
+    complete
+    .text start:0x020dbf7c end:0x020dc154
+
+src/func_ov006_020dc154.c:
+    complete
+    .text start:0x020dc154 end:0x020dc1c4
+
+src/func_ov006_020dc1c4.c:
+    complete
+    .text start:0x020dc1c4 end:0x020dc26c
+
+src/func_ov006_020dc26c.c:
+    complete
+    .text start:0x020dc26c end:0x020dc294
+
+src/func_ov006_020dc294.c:
+    complete
+    .text start:0x020dc294 end:0x020dc298
+
+src/func_ov006_020dc298.cpp:
+    complete
+    .text start:0x020dc298 end:0x020dc2f8
+
+src/func_ov006_020dc2f8.c:
+    complete
+    .text start:0x020dc2f8 end:0x020dc334
+
+src/func_ov006_020dc334.c:
+    complete
+    .text start:0x020dc334 end:0x020dc348
+
+src/func_ov006_020dc348.c:
+    complete
+    .text start:0x020dc348 end:0x020dc370
+
+src/func_ov006_020dc370.c:
+    complete
+    .text start:0x020dc370 end:0x020dc3bc
+
+src/func_ov006_020dc3bc.c:
+    complete
+    .text start:0x020dc3bc end:0x020dc414
+
+src/func_ov006_020dc414.c:
+    complete
+    .text start:0x020dc414 end:0x020dc4b0
+
+src/func_ov006_020dc4b0.c:
+    complete
+    .text start:0x020dc4b0 end:0x020dc4c8
+
+src/func_ov006_020dc4c8.c:
+    complete
+    .text start:0x020dc4c8 end:0x020dc5c4
+
+src/func_ov006_020dc5c4.c:
+    complete
+    .text start:0x020dc5c4 end:0x020dc6d0
+
+src/func_ov006_020dc6d0.c:
+    complete
+    .text start:0x020dc6d0 end:0x020dc754
+
+src/func_ov006_020dc754.cpp:
+    complete
+    .text start:0x020dc754 end:0x020dc7b4
+
+src/func_ov006_020dc7b4.c:
+    complete
+    .text start:0x020dc7b4 end:0x020dc7fc
+
+src/func_ov006_020dc7fc.c:
+    complete
+    .text start:0x020dc7fc end:0x020dc814
+
+src/func_ov006_020dc814.c:
+    complete
+    .text start:0x020dc814 end:0x020dc870
+
+src/func_ov006_020dc870.c:
+    complete
+    .text start:0x020dc870 end:0x020dc900
+
+src/func_ov006_020dc900.c:
+    complete
+    .text start:0x020dc900 end:0x020dc960
+
+src/func_ov006_020dc960.c:
+    complete
+    .text start:0x020dc960 end:0x020dc99c
+
+src/func_ov006_020dc99c.c:
+    complete
+    .text start:0x020dc99c end:0x020dca04
+
+src/func_ov006_020dca04.c:
+    complete
+    .text start:0x020dca04 end:0x020dcb1c
+
+src/func_ov006_020dcb1c.c:
+    complete
+    .text start:0x020dcb1c end:0x020dcc48
+
+src/func_ov006_020dcc48.c:
+    complete
+    .text start:0x020dcc48 end:0x020dccb8
+
+src/func_ov006_020dccb8.c:
+    complete
+    .text start:0x020dccb8 end:0x020dcd74
+
+src/func_ov006_020dcd74.c:
+    .text start:0x020dcd74 end:0x020dce3c
+
+src/func_ov006_020dce3c.c:
+    complete
+    .text start:0x020dce3c end:0x020dcea8
+
+src/func_ov006_020dcea8.c:
+    complete
+    .text start:0x020dcea8 end:0x020dcffc
+
+src/func_ov006_020dcffc.c:
+    complete
+    .text start:0x020dcffc end:0x020dd000
+
+src/func_ov006_020dd000.c:
+    complete
+    .text start:0x020dd000 end:0x020dd0e0
+
+src/func_ov006_020dd2cc.cpp:
+    complete
+    .text start:0x020dd2cc end:0x020dd334
+
+src/func_ov006_020dd334.c:
+    complete
+    .text start:0x020dd334 end:0x020dd4b0
+
+src/func_ov006_020dd4b0.c:
+    complete
+    .text start:0x020dd4b0 end:0x020dd594
+
+src/func_ov006_020dd594.c:
+    complete
+    .text start:0x020dd594 end:0x020dd658
+
+src/func_ov006_020dd658.c:
+    complete
+    .text start:0x020dd658 end:0x020dd7bc
+
+src/func_ov006_020dd7bc.c:
+    complete
+    .text start:0x020dd7bc end:0x020dd7c0
+
+src/func_ov006_020dd7c0.c:
+    complete
+    .text start:0x020dd7c0 end:0x020dd880
+
+src/func_ov006_020dd880.c:
+    complete
+    .text start:0x020dd880 end:0x020dda94
+
+src/func_ov006_020dda94.c:
+    complete
+    .text start:0x020dda94 end:0x020ddca0
+
+src/func_ov006_020ddca0.c:
+    complete
+    .text start:0x020ddca0 end:0x020ddcf8
+
+src/func_ov006_020ddcf8.c:
+    complete
+    .text start:0x020ddcf8 end:0x020ddd6c
+
+src/func_ov006_020ddd6c.cpp:
+    complete
+    .text start:0x020ddd6c end:0x020dde28
+
+src/func_ov006_020dde28.c:
+    complete
+    .text start:0x020dde28 end:0x020ddeb0
+
+src/func_ov006_020ddeb0.cpp:
+    complete
+    .text start:0x020ddeb0 end:0x020ddf9c
+
+src/func_ov006_020de0e0.cpp:
+    complete
+    .text start:0x020de0e0 end:0x020de1d4
+
+src/func_ov006_020de1d4.c:
+    .text start:0x020de1d4 end:0x020de26c
+
+src/func_ov006_020de26c.cpp:
+    .text start:0x020de26c end:0x020de440
+
+src/func_ov006_020de440.cpp:
+    .text start:0x020de440 end:0x020de584
+
+src/func_ov006_020de584.c:
+    .text start:0x020de584 end:0x020de5ac
+
+src/func_ov006_020de5ac.c:
+    complete
+    .text start:0x020de5ac end:0x020de5b0
+
+src/func_ov006_020de5b0.c:
+    complete
+    .text start:0x020de5b0 end:0x020de63c
+
+src/func_ov006_020de63c.c:
+    complete
+    .text start:0x020de63c end:0x020de69c
+
+src/func_ov006_020de69c.cpp:
+    complete
+    .text start:0x020de69c end:0x020de704
+
+src/func_ov006_020de704.c:
+    complete
+    .text start:0x020de704 end:0x020de940
+
+src/MgCoincentration_Spawn.cpp:
+    complete
+    .text start:0x020de940 end:0x020de988
+
+src/func_ov006_020de988.cpp:
+    complete
+    .text start:0x020de988 end:0x020dea1c
+
+src/func_ov006_020dea1c.cpp:
+    .text start:0x020dea1c end:0x020deac4
+
+src/func_ov006_020deac4.c:
+    complete
+    .text start:0x020deac4 end:0x020deac8
+
+src/func_ov006_020deac8.c:
+    complete
+    .text start:0x020deac8 end:0x020deaf0
+
+src/func_ov006_020deaf0.c:
+    complete
+    .text start:0x020deaf0 end:0x020deb48
+
+src/func_ov006_020deb48.c:
+    complete
+    .text start:0x020deb48 end:0x020debb4
+
+src/func_ov006_020debb4.c:
+    complete
+    .text start:0x020debb4 end:0x020debfc
+
+src/func_ov006_020debfc.c:
+    complete
+    .text start:0x020debfc end:0x020dec3c
+
+src/func_ov006_020dec3c.c:
+    complete
+    .text start:0x020dec3c end:0x020dec5c
+
+src/func_ov006_020dec5c.c:
+    complete
+    .text start:0x020dec5c end:0x020dec88
+
+src/func_ov006_020dec88.cpp:
+    complete
+    .text start:0x020dec88 end:0x020ded00
+
+src/func_ov006_020ded00.c:
+    complete
+    .text start:0x020ded00 end:0x020ded84
+
+src/func_ov006_020ded84.c:
+    complete
+    .text start:0x020ded84 end:0x020dedfc
+
+src/func_ov006_020dedfc.c:
+    complete
+    .text start:0x020dedfc end:0x020deed8
+
+src/func_ov006_020deed8.c:
+    complete
+    .text start:0x020deed8 end:0x020def80
+
+src/func_ov006_020def80.c:
+    complete
+    .text start:0x020def80 end:0x020df024
+
+src/func_ov006_020df024.c:
+    complete
+    .text start:0x020df024 end:0x020df1bc
+
+src/func_ov006_020df1bc.c:
+    complete
+    .text start:0x020df1bc end:0x020df1c0
+
+src/func_ov006_020df1c0.cpp:
+    complete
+    .text start:0x020df1c0 end:0x020df28c
+
+src/func_ov006_020df28c.c:
+    complete
+    .text start:0x020df28c end:0x020df3bc
+
+src/func_ov006_020df3bc.c:
+    complete
+    .text start:0x020df3bc end:0x020df540
+
+src/func_ov006_020df540.c:
+    complete
+    .text start:0x020df540 end:0x020df5b8
+
+src/func_ov006_020df5b8.c:
+    .text start:0x020df5b8 end:0x020dfcd8
+
+src/func_ov006_020dfcd8.c:
+    complete
+    .text start:0x020dfcd8 end:0x020dfd48
+
+src/func_ov006_020dfd48.c:
+    complete
+    .text start:0x020dfd48 end:0x020dfed4
+
+src/func_ov006_020dfed4.c:
+    complete
+    .text start:0x020dfed4 end:0x020dfeec
+
+src/func_ov006_020dfeec.c:
+    complete
+    .text start:0x020dfeec end:0x020e0068
+
+src/func_ov006_020e0068.c:
+    complete
+    .text start:0x020e0068 end:0x020e0204
+
+src/func_ov006_020e0204.cpp:
+    .text start:0x020e0204 end:0x020e0308
+
+src/func_ov006_020e0308.cpp:
+    .text start:0x020e0308 end:0x020e0574
+
+src/func_ov006_020e0574.cpp:
+    complete
+    .text start:0x020e0574 end:0x020e0634
+
+src/func_ov006_020e0634.c:
+    complete
+    .text start:0x020e0634 end:0x020e0638
+
+src/func_ov006_020e0638.c:
+    complete
+    .text start:0x020e0638 end:0x020e065c
+
+src/func_ov006_020e065c.c:
+    .text start:0x020e065c end:0x020e0694
+
+src/func_ov006_020e0694.c:
+    complete
+    .text start:0x020e0694 end:0x020e071c
+
+src/func_ov006_020e071c.c:
+    complete
+    .text start:0x020e071c end:0x020e07b0
+
+src/func_ov006_020e07b0.c:
+    complete
+    .text start:0x020e07b0 end:0x020e0884
+
+src/func_ov006_020e0884.cpp:
+    complete
+    .text start:0x020e0884 end:0x020e091c
+
+src/func_ov006_020e091c.c:
+    complete
+    .text start:0x020e091c end:0x020e0a24
+
+src/func_ov006_020e0a24.c:
+    complete
+    .text start:0x020e0a24 end:0x020e0b64
+
+src/func_ov006_020e0b64.c:
+    complete
+    .text start:0x020e0b64 end:0x020e0ca0
+
+src/func_ov006_020e0ca0.c:
+    complete
+    .text start:0x020e0ca0 end:0x020e0d84
+
+src/func_ov006_020e0d84.cpp:
+    complete
+    .text start:0x020e0d84 end:0x020e0e18
+
+src/func_ov006_020e0e18.c:
+    complete
+    .text start:0x020e0e18 end:0x020e0edc
+
+src/func_ov006_020e0edc.c:
+    complete
+    .text start:0x020e0edc end:0x020e0ff0
+
+src/func_ov006_020e0ff0.c:
+    complete
+    .text start:0x020e0ff0 end:0x020e1100
+
+src/func_ov006_020e1100.c:
+    complete
+    .text start:0x020e1100 end:0x020e1214
+
+src/func_ov006_020e1214.cpp:
+    complete
+    .text start:0x020e1214 end:0x020e1264
+
+src/func_ov006_020e1264.c:
+    complete
+    .text start:0x020e1264 end:0x020e12d0
+
+src/func_ov006_020e12d0.cpp:
+    complete
+    .text start:0x020e12d0 end:0x020e13a4
+
+src/func_ov006_020e13a4.c:
+    complete
+    .text start:0x020e13a4 end:0x020e1554
+
+src/func_ov006_020e1554.c:
+    complete
+    .text start:0x020e1554 end:0x020e1608
+
+src/func_ov006_020e1608.c:
+    complete
+    .text start:0x020e1608 end:0x020e1680
+
+src/func_ov006_020e1680.c:
+    complete
+    .text start:0x020e1680 end:0x020e17f8
+
+src/_ZN6Player16St_WallJump_InitEv.cpp:
+    .text start:0x020e17f8 end:0x020e1854
+
+src/func_ov006_020e1b54.c:
+    complete
+    .text start:0x020e1b54 end:0x020e1c68
+
+src/func_ov006_020e1c68.c:
+    complete
+    .text start:0x020e1c68 end:0x020e1dc8
+
+src/func_ov006_020e269c.c:
+    complete
+    .text start:0x020e269c end:0x020e26f8
+
+src/func_ov006_020e26f8.c:
+    complete
+    .text start:0x020e26f8 end:0x020e285c
+
+src/func_ov006_020e285c.c:
+    complete
+    .text start:0x020e285c end:0x020e2868
+
+src/func_ov006_020e2868.c:
+    .text start:0x020e2868 end:0x020e2c08
+
+src/func_ov006_020e2c08.c:
+    complete
+    .text start:0x020e2c08 end:0x020e2dbc
+
+src/func_ov006_020e2dbc.c:
+    complete
+    .text start:0x020e2dbc end:0x020e2eb8
+
+src/func_ov006_020e2eb8.c:
+    complete
+    .text start:0x020e2eb8 end:0x020e2ebc
+
+src/func_ov006_020e2ebc.c:
+    complete
+    .text start:0x020e2ebc end:0x020e2f78
+
+src/func_ov006_020e2f78.c:
+    complete
+    .text start:0x020e2f78 end:0x020e3078
+
+src/func_ov006_020e3078.cpp:
+    complete
+    .text start:0x020e3078 end:0x020e3210
+
+src/func_ov006_020e3210.c:
+    complete
+    .text start:0x020e3210 end:0x020e3250
+
+src/func_ov006_020e3250.c:
+    complete
+    .text start:0x020e3250 end:0x020e3378
+
+src/func_ov006_020e3378.c:
+    complete
+    .text start:0x020e3378 end:0x020e3388
+
+src/func_ov006_020e3388.c:
+    complete
+    .text start:0x020e3388 end:0x020e3470
+
+src/func_ov006_020e3470.c:
+    complete
+    .text start:0x020e3470 end:0x020e34ec
+
+src/func_ov006_020e34ec.c:
+    complete
+    .text start:0x020e34ec end:0x020e3528
+
+src/func_ov006_020e3528.cpp:
+    complete
+    .text start:0x020e3528 end:0x020e3578
+
+src/func_ov006_020e3578.c:
+    .text start:0x020e3578 end:0x020e3820
+
+src/MgShuffleShell_Spawn.c:
+    .text start:0x020e3820 end:0x020e3854
+
+src/func_ov006_020e3854.c:
+    complete
+    .text start:0x020e3854 end:0x020e3878
+
+src/func_ov006_020e3878.c:
+    .text start:0x020e3878 end:0x020e38b0
+
+src/func_ov006_020e38b0.c:
+    complete
+    .text start:0x020e38b0 end:0x020e3948
+
+src/func_ov006_020e3948.c:
+    complete
+    .text start:0x020e3948 end:0x020e39e0
+
+src/func_ov006_020e39e0.c:
+    complete
+    .text start:0x020e39e0 end:0x020e3b9c
+
+src/func_ov006_020e3b9c.c:
+    complete
+    .text start:0x020e3b9c end:0x020e3bc4
+
+src/func_ov006_020e3bc4.c:
+    complete
+    .text start:0x020e3bc4 end:0x020e3c4c
+
+src/func_ov006_020e3c4c.c:
+    complete
+    .text start:0x020e3c4c end:0x020e3ce0
+
+src/func_ov006_020e3ce0.c:
+    complete
+    .text start:0x020e3ce0 end:0x020e3db4
+
+src/func_ov006_020e3db4.c:
+    complete
+    .text start:0x020e3db4 end:0x020e3e4c
+
+src/func_ov006_020e3e4c.c:
+    complete
+    .text start:0x020e3e4c end:0x020e3f54
+
+src/func_ov006_020e3f54.c:
+    complete
+    .text start:0x020e3f54 end:0x020e4094
+
+src/func_ov006_020e4094.c:
+    complete
+    .text start:0x020e4094 end:0x020e41d0
+
+src/func_ov006_020e41d0.c:
+    complete
+    .text start:0x020e41d0 end:0x020e42b4
+
+src/func_ov006_020e42b4.cpp:
+    complete
+    .text start:0x020e42b4 end:0x020e4348
+
+src/func_ov006_020e4348.c:
+    complete
+    .text start:0x020e4348 end:0x020e440c
+
+src/func_ov006_020e440c.c:
+    complete
+    .text start:0x020e440c end:0x020e4520
+
+src/func_ov006_020e4520.c:
+    complete
+    .text start:0x020e4520 end:0x020e4630
+
+src/func_ov006_020e4630.c:
+    complete
+    .text start:0x020e4630 end:0x020e4744
+
+src/func_ov006_020e4744.cpp:
+    complete
+    .text start:0x020e4744 end:0x020e4794
+
+src/func_ov006_020e4794.c:
+    complete
+    .text start:0x020e4794 end:0x020e4800
+
+src/func_ov006_020e4800.cpp:
+    complete
+    .text start:0x020e4800 end:0x020e48d4
+
+src/func_ov006_020e48d4.c:
+    complete
+    .text start:0x020e48d4 end:0x020e4a84
+
+src/func_ov006_020e4a84.c:
+    complete
+    .text start:0x020e4a84 end:0x020e4b00
+
+src/func_ov006_020e4b00.c:
+    complete
+    .text start:0x020e4b00 end:0x020e4b78
+
+src/func_ov006_020e4b78.c:
+    complete
+    .text start:0x020e4b78 end:0x020e4bd4
+
+src/func_ov006_020e4ed4.c:
+    complete
+    .text start:0x020e4ed4 end:0x020e4fe8
+
+src/func_ov006_020e4fe8.c:
+    complete
+    .text start:0x020e4fe8 end:0x020e507c
+
+src/func_ov006_020e507c.c:
+    complete
+    .text start:0x020e507c end:0x020e513c
+
+src/func_ov006_020e59b0.c:
+    complete
+    .text start:0x020e59b0 end:0x020e5a0c
+
+src/func_ov006_020e5a0c.c:
+    complete
+    .text start:0x020e5a0c end:0x020e5b70
+
+src/func_ov006_020e5b70.c:
+    complete
+    .text start:0x020e5b70 end:0x020e5b7c
+
+src/func_ov006_020e5b7c.c:
+    .text start:0x020e5b7c end:0x020e5e3c
+
+src/func_ov006_020e5e3c.c:
+    complete
+    .text start:0x020e5e3c end:0x020e5ffc
+
+src/func_ov006_020e5ffc.c:
+    complete
+    .text start:0x020e5ffc end:0x020e6118
+
+src/func_ov006_020e6118.c:
+    complete
+    .text start:0x020e6118 end:0x020e619c
+
+src/func_ov006_020e619c.c:
+    complete
+    .text start:0x020e619c end:0x020e61c0
+
+src/func_ov006_020e61c0.c:
+    complete
+    .text start:0x020e61c0 end:0x020e61c4
+
+src/func_ov006_020e61c4.c:
+    complete
+    .text start:0x020e61c4 end:0x020e628c
+
+src/func_ov006_020e628c.c:
+    complete
+    .text start:0x020e628c end:0x020e6354
+
+src/func_ov006_020e6354.cpp:
+    complete
+    .text start:0x020e6354 end:0x020e64e4
+
+src/func_ov006_020e64e4.c:
+    complete
+    .text start:0x020e64e4 end:0x020e6528
+
+src/func_ov006_020e6528.c:
+    complete
+    .text start:0x020e6528 end:0x020e667c
+
+src/func_ov006_020e667c.c:
+    complete
+    .text start:0x020e667c end:0x020e668c
+
+src/func_ov006_020e668c.c:
+    complete
+    .text start:0x020e668c end:0x020e6774
+
+src/func_ov006_020e6774.c:
+    complete
+    .text start:0x020e6774 end:0x020e67f0
+
+src/func_ov006_020e67f0.c:
+    complete
+    .text start:0x020e67f0 end:0x020e683c
+
+src/func_ov006_020e683c.cpp:
+    .text start:0x020e683c end:0x020e6894
+
+src/func_ov006_020e6894.c:
+    .text start:0x020e6894 end:0x020e6bf4
+
+src/func_ov006_020e6bf4.c:
+    .text start:0x020e6bf4 end:0x020e6c28
+
+src/_ZN17MgBounceAndPounceD1Ev.cpp:
+    complete
+    .text start:0x020e6c28 end:0x020e6c60
+
+src/_ZN17MgBounceAndPounceD0Ev.cpp:
+    complete
+    .text start:0x020e6c60 end:0x020e6cac
+
+src/func_ov006_020e6cac.c:
+    complete
+    .text start:0x020e6cac end:0x020e6d24
+
+src/func_ov006_020e6d24.cpp:
+    complete
+    .text start:0x020e6d24 end:0x020e6d8c
+
+src/func_ov006_020e6d8c.c:
+    complete
+    .text start:0x020e6d8c end:0x020e6d98
+
+src/func_ov006_020e6d98.c:
+    complete
+    .text start:0x020e6d98 end:0x020e6da4
+
+src/func_ov006_020e6da4.c:
+    complete
+    .text start:0x020e6da4 end:0x020e6db4
+
+src/func_ov006_020e6db4.c:
+    complete
+    .text start:0x020e6db4 end:0x020e6df0
+
+src/Sound_PlayBank1Panned.cpp:
+    complete
+    .text start:0x020e6df0 end:0x020e6e3c
+
+src/func_ov006_020e6e3c.c:
+    complete
+    .text start:0x020e6e3c end:0x020e6e4c
+
+src/func_ov006_020e6e4c.c:
+    complete
+    .text start:0x020e6e4c end:0x020e6e54
+
+src/func_ov006_020e6e54.c:
+    complete
+    .text start:0x020e6e54 end:0x020e6e78
+
+src/func_ov006_020e6e78.cpp:
+    .text start:0x020e6e78 end:0x020e6f60
+
+src/_ZN17MgBounceAndPounce21AfterCleanupResourcesEj.cpp:
+    .text start:0x020e6f60 end:0x020e700c
+
+src/_ZN17MgBounceAndPounce11AfterRenderEj.cpp:
+    .text start:0x020e700c end:0x020e7040
+
+src/_ZN17MgBounceAndPounce12BeforeRenderEv.cpp:
+    complete
+    .text start:0x020e7040 end:0x020e7074
+
+src/_ZN17MgBounceAndPounce14BeforeBehaviorEv.cpp:
+    .text start:0x020e7074 end:0x020e70c0
+
+src/_ZN17MgBounceAndPounce18AfterInitResourcesEj.cpp:
+    .text start:0x020e70c0 end:0x020e70e4
+
+src/_ZN17MgBounceAndPounce19BeforeInitResourcesEv.cpp:
+    .text start:0x020e70e4 end:0x020e7110
+
+src/func_ov006_020e7110.c:
+    complete
+    .text start:0x020e7110 end:0x020e7124
+
+src/func_ov006_020e7124.c:
+    .text start:0x020e7124 end:0x020e72c0
+
+src/func_ov006_020e72c0.c:
+    complete
+    .text start:0x020e72c0 end:0x020e73c4
+
+src/func_ov006_020e73c4.cpp:
+    complete
+    .text start:0x020e73c4 end:0x020e740c
+
+src/func_ov006_020e740c.c:
+    complete
+    .text start:0x020e740c end:0x020e7428
+
+src/func_ov006_020e7428.c:
+    complete
+    .text start:0x020e7428 end:0x020e7508
+
+src/func_ov006_020e7508.cpp:
+    complete
+    .text start:0x020e7508 end:0x020e759c
+
+src/func_ov006_020e759c.c:
+    complete
+    .text start:0x020e759c end:0x020e7660
+
+src/func_ov006_020e7660.cpp:
+    complete
+    .text start:0x020e7660 end:0x020e76e4
+
+src/func_ov006_020e76e4.c:
+    complete
+    .text start:0x020e76e4 end:0x020e777c
+
+src/func_ov006_020e777c.cpp:
+    complete
+    .text start:0x020e777c end:0x020e7818
+
+src/func_ov006_020e7818.c:
+    complete
+    .text start:0x020e7818 end:0x020e7910
+
+src/func_ov006_020e7910.c:
+    complete
+    .text start:0x020e7910 end:0x020e792c
+
+src/func_ov006_020e792c.c:
+    complete
+    .text start:0x020e792c end:0x020e7940
+
+src/func_ov006_020e7940.c:
+    complete
+    .text start:0x020e7940 end:0x020e794c
+
+src/func_ov006_020e794c.c:
+    complete
+    .text start:0x020e794c end:0x020e7954
+
+src/func_ov006_020e7954.c:
+    complete
+    .text start:0x020e7954 end:0x020e7a50
+
+src/func_ov006_020e7a50.cpp:
+    complete
+    .text start:0x020e7a50 end:0x020e7aac
+
+src/func_ov006_020e7aac.c:
+    complete
+    .text start:0x020e7aac end:0x020e7b0c
+
+src/func_ov006_020e7b0c.c:
+    complete
+    .text start:0x020e7b0c end:0x020e7b44
+
+src/func_ov006_020e7b44.cpp:
+    complete
+    .text start:0x020e7b44 end:0x020e7be8
+
+src/func_ov006_020e7be8.cpp:
+    complete
+    .text start:0x020e7be8 end:0x020e7cc0
+
+src/func_ov006_020e7cc0.cpp:
+    .text start:0x020e7cc0 end:0x020e7d7c
+
+src/func_ov006_020e7d7c.c:
+    complete
+    .text start:0x020e7d7c end:0x020e7de8
+
+src/func_ov006_020e7de8.c:
+    complete
+    .text start:0x020e7de8 end:0x020e7e74
+
+src/func_ov006_020e7e74.c:
+    complete
+    .text start:0x020e7e74 end:0x020e7f04
+
+src/func_ov006_020e7f04.cpp:
+    complete
+    .text start:0x020e7f04 end:0x020e7f5c
+
+src/func_ov006_020e7f5c.cpp:
+    complete
+    .text start:0x020e7f5c end:0x020e7fac
+
+src/func_ov006_020e7fac.c:
+    complete
+    .text start:0x020e7fac end:0x020e7fb0
+
+src/func_ov006_020e7fb0.c:
+    complete
+    .text start:0x020e7fb0 end:0x020e7fe8
+
+src/func_ov006_020e7fe8.cpp:
+    complete
+    .text start:0x020e7fe8 end:0x020e80d8
+
+src/func_ov006_020e80d8.cpp:
+    complete
+    .text start:0x020e80d8 end:0x020e814c
+
+src/func_ov006_020e814c.c:
+    complete
+    .text start:0x020e814c end:0x020e81a4
+
+src/func_ov006_020e81a4.c:
+    complete
+    .text start:0x020e81a4 end:0x020e81e0
+
+src/func_ov006_020e81e0.c:
+    complete
+    .text start:0x020e81e0 end:0x020e8214
+
+src/func_ov006_020e8214.c:
+    complete
+    .text start:0x020e8214 end:0x020e82c8
+
+src/func_ov006_020e82c8.c:
+    complete
+    .text start:0x020e82c8 end:0x020e82fc
+
+src/func_ov006_020e82fc.cpp:
+    complete
+    .text start:0x020e82fc end:0x020e8354
+
+src/func_ov006_020e8354.c:
+    complete
+    .text start:0x020e8354 end:0x020e83bc
+
+src/func_ov006_020e83bc.c:
+    complete
+    .text start:0x020e83bc end:0x020e84b8
+
+src/func_ov006_020e84b8.c:
+    complete
+    .text start:0x020e84b8 end:0x020e85f0
+
+src/func_ov006_020e85f0.c:
+    complete
+    .text start:0x020e85f0 end:0x020e8728
+
+src/func_ov006_020e8728.c:
+    complete
+    .text start:0x020e8728 end:0x020e8830
+
+src/func_ov006_020e8928.c:
+    complete
+    .text start:0x020e8928 end:0x020e8a44
+
+src/func_ov006_020e8a44.cpp:
+    complete
+    .text start:0x020e8a44 end:0x020e8aac
+
+src/func_ov006_020e8aac.c:
+    complete
+    .text start:0x020e8aac end:0x020e8b18
+
+src/func_ov006_020e8b18.c:
+    complete
+    .text start:0x020e8b18 end:0x020e8bd0
+
+src/func_ov006_020e8bd0.c:
+    complete
+    .text start:0x020e8bd0 end:0x020e8c74
+
+src/func_ov006_020e8c74.c:
+    complete
+    .text start:0x020e8c74 end:0x020e8cb0
+
+src/func_ov006_020e8cb0.c:
+    complete
+    .text start:0x020e8cb0 end:0x020e8d08
+
+src/func_ov006_020e8d08.cpp:
+    complete
+    .text start:0x020e8d08 end:0x020e8d7c
+
+src/func_ov006_020e8d7c.c:
+    complete
+    .text start:0x020e8d7c end:0x020e8e10
+
+src/func_ov006_020e8e10.cpp:
+    complete
+    .text start:0x020e8e10 end:0x020e8f14
+
+src/func_ov006_020e8f14.c:
+    complete
+    .text start:0x020e8f14 end:0x020e91a0
+
+src/func_ov006_020e91a0.c:
+    complete
+    .text start:0x020e91a0 end:0x020e9318
+
+src/func_ov006_020e9318.c:
+    complete
+    .text start:0x020e9318 end:0x020e9374
+
+src/func_ov006_020e9374.cpp:
+    complete
+    .text start:0x020e9374 end:0x020e93e8
+
+src/func_ov006_020e93e8.c:
+    complete
+    .text start:0x020e93e8 end:0x020e95a4
+
+src/func_ov006_020e95a4.c:
+    complete
+    .text start:0x020e95a4 end:0x020e95e4
+
+src/func_ov006_020e95e4.c:
+    complete
+    .text start:0x020e95e4 end:0x020e9670
+
+src/func_ov006_020e9670.c:
+    complete
+    .text start:0x020e9670 end:0x020e968c
+
+src/func_ov006_020e968c.c:
+    complete
+    .text start:0x020e968c end:0x020e96f4
+
+src/func_ov006_020e96f4.cpp:
+    complete
+    .text start:0x020e96f4 end:0x020e97b0
+
+src/func_ov006_020e97b0.c:
+    complete
+    .text start:0x020e97b0 end:0x020e984c
+
+src/func_ov006_020e984c.c:
+    complete
+    .text start:0x020e984c end:0x020e989c
+
+src/func_ov006_020e989c.cpp:
+    .text start:0x020e989c end:0x020e9b70
+
+src/func_ov006_020e9b70.cpp:
+    complete
+    .text start:0x020e9b70 end:0x020e9bbc
+
+src/func_ov006_020e9bbc.c:
+    complete
+    .text start:0x020e9bbc end:0x020e9c10
+
+src/func_ov006_020e9c10.c:
+    complete
+    .text start:0x020e9c10 end:0x020e9c20
+
+src/func_ov006_020e9c20.c:
+    .text start:0x020e9c20 end:0x020e9cec
+
+src/func_ov006_020e9cec.c:
+    .text start:0x020e9cec end:0x020e9d1c
+
+src/func_ov006_020e9d1c.cpp:
+    .text start:0x020e9d1c end:0x020e9e00
+
+src/func_ov006_020e9e00.cpp:
+    .text start:0x020e9e00 end:0x020e9e70
+
+src/func_ov006_020e9e70.cpp:
+    complete
+    .text start:0x020e9e70 end:0x020ea1f0
+
+src/MgPsycheOut_Spawn.cpp:
+    complete
+    .text start:0x020ea1f0 end:0x020ea280
+
+src/func_ov006_020ea280.c:
+    complete
+    .text start:0x020ea280 end:0x020ea2c8
+
+src/func_ov006_020ea2c8.cpp:
+    .text start:0x020ea2c8 end:0x020ea324
+
+src/func_ov006_020ea324.c:
+    complete
+    .text start:0x020ea324 end:0x020ea350
+
+src/func_ov006_020ea350.c:
+    complete
+    .text start:0x020ea350 end:0x020ea3d0
+
+src/func_ov006_020ea3d0.c:
+    .text start:0x020ea3d0 end:0x020ea5f0
+
+src/func_ov006_020ea5f0.c:
+    complete
+    .text start:0x020ea5f0 end:0x020ea658
+
+src/func_ov006_020ea658.c:
+    complete
+    .text start:0x020ea658 end:0x020ea670
+
+src/func_ov006_020ea670.c:
+    complete
+    .text start:0x020ea670 end:0x020ea71c
+
+src/func_ov006_020ea71c.c:
+    complete
+    .text start:0x020ea71c end:0x020ea81c
+
+src/func_ov006_020ea81c.c:
+    complete
+    .text start:0x020ea81c end:0x020ea8e0
+
+src/func_ov006_020ea8e0.c:
+    complete
+    .text start:0x020ea8e0 end:0x020ea914
+
+src/func_ov006_020eac38.c:
+    complete
+    .text start:0x020eac38 end:0x020eb018
+
+src/func_ov006_020eb018.cpp:
+    complete
+    .text start:0x020eb018 end:0x020eb0c8
+
+src/func_ov006_020eb0c8.cpp:
+    complete
+    .text start:0x020eb0c8 end:0x020eb1e0
+
+src/func_ov006_020eb1e0.c:
+    complete
+    .text start:0x020eb1e0 end:0x020eb31c
+
+src/func_ov006_020eb31c.cpp:
+    complete
+    .text start:0x020eb31c end:0x020eb3e4
+
+src/func_ov006_020eb3e4.c:
+    complete
+    .text start:0x020eb3e4 end:0x020eb558
+
+src/func_ov006_020eb558.cpp:
+    complete
+    .text start:0x020eb558 end:0x020eb610
+
+src/func_ov006_020eb610.cpp:
+    complete
+    .text start:0x020eb610 end:0x020eb768
+
+src/func_ov006_020eb768.c:
+    complete
+    .text start:0x020eb768 end:0x020eb7b0
+
+src/func_ov006_020eb7b0.c:
+    complete
+    .text start:0x020eb7b0 end:0x020eb7f8
+
+src/func_ov006_020eb7f8.c:
+    complete
+    .text start:0x020eb7f8 end:0x020eb8f0
+
+src/func_ov006_020eb8f0.cpp:
+    complete
+    .text start:0x020eb8f0 end:0x020eb9b0
+
+src/func_ov006_020eb9b0.c:
+    complete
+    .text start:0x020eb9b0 end:0x020eb9dc
+
+src/func_ov006_020eb9dc.c:
+    complete
+    .text start:0x020eb9dc end:0x020ebb40
+
+src/func_ov006_020ebb40.c:
+    complete
+    .text start:0x020ebb40 end:0x020ebc08
+
+src/func_ov006_020ebc08.c:
+    complete
+    .text start:0x020ebc08 end:0x020ebc7c
+
+src/func_ov006_020ebc7c.c:
+    complete
+    .text start:0x020ebc7c end:0x020ebd7c
+
+src/func_ov006_020ebd7c.c:
+    complete
+    .text start:0x020ebd7c end:0x020ebe6c
+
+src/func_ov006_020ebe6c.c:
+    complete
+    .text start:0x020ebe6c end:0x020ebeb4
+
+src/func_ov006_020ebeb4.c:
+    complete
+    .text start:0x020ebeb4 end:0x020ebf20
+
+src/func_ov006_020ebf20.c:
+    complete
+    .text start:0x020ebf20 end:0x020ec134
+
+src/func_ov006_020ec134.c:
+    complete
+    .text start:0x020ec134 end:0x020ec2bc
+
+src/func_ov006_020ec2bc.c:
+    complete
+    .text start:0x020ec2bc end:0x020ec458
+
+src/func_ov006_020ec458.c:
+    complete
+    .text start:0x020ec458 end:0x020ec4dc
+
+src/func_ov006_020ec6e8.c:
+    complete
+    .text start:0x020ec6e8 end:0x020ec84c
+
+src/func_ov006_020ec84c.c:
+    complete
+    .text start:0x020ec84c end:0x020ec93c
+
+src/func_ov006_020ec93c.c:
+    complete
+    .text start:0x020ec93c end:0x020ec9c0
+
+src/func_ov006_020ec9c0.c:
+    complete
+    .text start:0x020ec9c0 end:0x020ecb80
+
+src/func_ov006_020ecb80.c:
+    .text start:0x020ecb80 end:0x020ecba4
+
+src/func_ov006_020ecba4.c:
+    complete
+    .text start:0x020ecba4 end:0x020ecdb8
+
+src/func_ov006_020ecdb8.c:
+    complete
+    .text start:0x020ecdb8 end:0x020ecec8
+
+src/func_ov006_020ecec8.c:
+    complete
+    .text start:0x020ecec8 end:0x020ecee4
+
+src/func_ov006_020ecee4.c:
+    complete
+    .text start:0x020ecee4 end:0x020ed18c
+
+src/func_ov006_020ed18c.cpp:
+    .text start:0x020ed18c end:0x020ed270
+
+src/func_ov006_020ed270.c:
+    complete
+    .text start:0x020ed270 end:0x020ed274
+
+src/func_ov006_020ed274.c:
+    complete
+    .text start:0x020ed274 end:0x020ed300
+
+src/func_ov006_020ed300.c:
+    complete
+    .text start:0x020ed300 end:0x020ed328
+
+src/func_ov006_020ed328.c:
+    complete
+    .text start:0x020ed328 end:0x020ed32c
+
+src/func_ov006_020ed32c.c:
+    complete
+    .text start:0x020ed32c end:0x020ed34c
+
+src/func_ov006_020ed34c.c:
+    complete
+    .text start:0x020ed34c end:0x020ed40c
+
+src/func_ov006_020ed40c.c:
+    complete
+    .text start:0x020ed40c end:0x020ed494
+
+src/func_ov006_020ed494.c:
+    complete
+    .text start:0x020ed494 end:0x020ed81c
+
+src/func_ov006_020ed81c.c:
+    complete
+    .text start:0x020ed81c end:0x020ed844
+
+src/func_ov006_020ed844.cpp:
+    complete
+    .text start:0x020ed844 end:0x020ed8a4
+
+src/func_ov006_020ed8a4.c:
+    complete
+    .text start:0x020ed8a4 end:0x020eda48
+
+src/func_ov006_020eda48.c:
+    .text start:0x020eda48 end:0x020edb04
+
+src/func_ov006_020edb04.cpp:
+    .text start:0x020edb04 end:0x020edcb0
+
+src/func_ov006_020edcb0.c:
+    complete
+    .text start:0x020edcb0 end:0x020ede18
+
+src/MgWhichWiggler_Spawn.cpp:
+    complete
+    .text start:0x020ede18 end:0x020ede80
+
+src/func_ov006_020ede80.c:
+    complete
+    .text start:0x020ede80 end:0x020edec0
+
+src/func_ov006_020edec0.cpp:
+    complete
+    .text start:0x020edec0 end:0x020edf54
+
+src/func_ov006_020edf54.cpp:
+    .text start:0x020edf54 end:0x020edffc
+
+src/func_ov006_020edffc.c:
+    complete
+    .text start:0x020edffc end:0x020ee034
+
+src/func_ov006_020ee034.c:
+    complete
+    .text start:0x020ee034 end:0x020ee27c
+
+src/func_ov006_020ee27c.cpp:
+    complete
+    .text start:0x020ee27c end:0x020ee2c0
+
+src/func_ov006_020ee2c0.c:
+    complete
+    .text start:0x020ee2c0 end:0x020ee2c4
+
+src/func_ov006_020ee2c4.c:
+    .text start:0x020ee2c4 end:0x020ee3bc
+
+src/func_ov006_020ee3bc.c:
+    complete
+    .text start:0x020ee3bc end:0x020ee3ec
+
+src/func_ov006_020ee3ec.c:
+    complete
+    .text start:0x020ee3ec end:0x020ee44c
+
+src/func_ov006_020ee44c.c:
+    complete
+    .text start:0x020ee44c end:0x020ee4e0
+
+src/func_ov006_020ee4e0.c:
+    complete
+    .text start:0x020ee4e0 end:0x020ee508
+
+src/func_ov006_020ee508.c:
+    complete
+    .text start:0x020ee508 end:0x020ee598
+
+src/func_ov006_020ee598.c:
+    complete
+    .text start:0x020ee598 end:0x020ee5b8
+
+src/func_ov006_020ee5b8.c:
+    complete
+    .text start:0x020ee5b8 end:0x020ee658
+
+src/func_ov006_020ee658.c:
+    complete
+    .text start:0x020ee658 end:0x020ee690
+
+src/func_ov006_020ee690.cpp:
+    .text start:0x020ee690 end:0x020ee8dc
+
+src/func_ov006_020ee8dc.cpp:
+    .text start:0x020ee8dc end:0x020ee994
+
+src/MgBounceAndPounce_Spawn.cpp:
+    complete
+    .text start:0x020eeafc end:0x020eebe8
+
+src/func_ov006_020eebe8.cpp:
+    complete
+    .text start:0x020eebe8 end:0x020eec9c
+
+src/func_ov006_020eec9c.cpp:
+    .text start:0x020eec9c end:0x020eed64
+
+src/func_ov006_020eed64.c:
+    complete
+    .text start:0x020eed64 end:0x020eed68
+
+src/func_ov006_020eed68.c:
+    complete
+    .text start:0x020eed68 end:0x020eedc8
+
+src/func_ov006_020eedc8.c:
+    complete
+    .text start:0x020eedc8 end:0x020eee3c
+
+src/func_ov006_020eee3c.c:
+    complete
+    .text start:0x020eee3c end:0x020eeef4
+
+src/func_ov006_020eeef4.c:
+    complete
+    .text start:0x020eeef4 end:0x020eef40
+
+src/func_ov006_020eef40.c:
+    complete
+    .text start:0x020eef40 end:0x020eef58
+
+src/func_ov006_020eef58.c:
+    complete
+    .text start:0x020eef58 end:0x020eef90
+
+src/func_ov006_020eef90.c:
+    complete
+    .text start:0x020eef90 end:0x020eeff0
+
+src/func_ov006_020eeff0.c:
+    complete
+    .text start:0x020eeff0 end:0x020ef05c
+
+src/func_ov006_020ef05c.c:
+    complete
+    .text start:0x020ef05c end:0x020ef0d4
+
+src/func_ov006_020ef0d4.c:
+    complete
+    .text start:0x020ef0d4 end:0x020ef110
+
+src/func_ov006_020ef110.c:
+    complete
+    .text start:0x020ef110 end:0x020ef148
+
+src/func_ov006_020ef148.c:
+    complete
+    .text start:0x020ef148 end:0x020ef2b8
+
+src/func_ov006_020ef2b8.c:
+    complete
+    .text start:0x020ef2b8 end:0x020ef3e0
+
+src/func_ov006_020ef3e0.cpp:
+    complete
+    .text start:0x020ef3e0 end:0x020ef47c
+
+src/func_ov006_020ef47c.c:
+    complete
+    .text start:0x020ef47c end:0x020ef480
+
+src/func_ov006_020ef480.c:
+    complete
+    .text start:0x020ef480 end:0x020ef4ec
+
+src/func_ov006_020ef4ec.c:
+    complete
+    .text start:0x020ef4ec end:0x020ef580
+
+src/func_ov006_020ef580.c:
+    complete
+    .text start:0x020ef580 end:0x020ef5ac
+
+src/func_ov006_020ef768.c:
+    complete
+    .text start:0x020ef768 end:0x020ef794
+
+src/func_ov006_020ef794.c:
+    complete
+    .text start:0x020ef794 end:0x020ef7f8
+
+src/func_ov006_020ef7f8.c:
+    complete
+    .text start:0x020ef7f8 end:0x020ef834
+
+src/func_ov006_020ef834.cpp:
+    .text start:0x020ef834 end:0x020efa84
+
+src/func_ov006_020efa84.c:
+    complete
+    .text start:0x020efa84 end:0x020efaa8
+
+src/func_ov006_020efaa8.c:
+    complete
+    .text start:0x020efaa8 end:0x020efaf0
+
+src/_ZN8PathLift17BaseInitResourcesEv.c:
+    complete
+    .text start:0x020efaf0 end:0x020efc08
+
+src/func_ov006_020efc08.c:
+    complete
+    .text start:0x020efc08 end:0x020efc0c
+
+src/func_ov006_020efc0c.c:
+    complete
+    .text start:0x020efc0c end:0x020efc30
+
+src/func_ov006_020efc30.c:
+    .text start:0x020efc30 end:0x020efc68
+
+src/func_ov006_020efc68.c:
+    complete
+    .text start:0x020efc68 end:0x020efcf8
+
+src/func_ov006_020efcf8.c:
+    .text start:0x020efcf8 end:0x020efdac
+
+src/func_ov006_020efdac.c:
+    complete
+    .text start:0x020efdac end:0x020efdf0
+
+src/func_ov006_020efdf0.c:
+    complete
+    .text start:0x020efdf0 end:0x020eff20
+
+src/func_ov006_020eff20.c:
+    complete
+    .text start:0x020eff20 end:0x020effb8
+
+src/func_ov006_020effb8.c:
+    complete
+    .text start:0x020effb8 end:0x020f002c
+
+src/func_ov006_020f002c.c:
+    complete
+    .text start:0x020f002c end:0x020f0044
+
+src/func_ov006_020f0044.cpp:
+    complete
+    .text start:0x020f0044 end:0x020f00a4
+
+src/func_ov006_020f00a4.cpp:
+    complete
+    .text start:0x020f00a4 end:0x020f01d8
+
+src/func_ov006_020f01d8.c:
+    complete
+    .text start:0x020f01d8 end:0x020f0274
+
+src/func_ov006_020f0274.c:
+    .text start:0x020f0274 end:0x020f049c
+
+src/func_ov006_020f049c.c:
+    complete
+    .text start:0x020f049c end:0x020f04ec
+
+src/func_ov006_020f04ec.c:
+    complete
+    .text start:0x020f04ec end:0x020f05d8
+
+src/func_ov006_020f05d8.c:
+    complete
+    .text start:0x020f05d8 end:0x020f06fc
+
+src/func_ov006_020f06fc.c:
+    complete
+    .text start:0x020f06fc end:0x020f088c
+
+src/func_ov006_020f088c.c:
+    complete
+    .text start:0x020f088c end:0x020f0a6c
+
+src/func_ov006_020f0a6c.c:
+    complete
+    .text start:0x020f0a6c end:0x020f0ba0
+
+src/func_ov006_020f0ba0.cpp:
+    complete
+    .text start:0x020f0ba0 end:0x020f0bf0
+
+src/func_ov006_020f0bf0.c:
+    complete
+    .text start:0x020f0bf0 end:0x020f0d58
+
+src/func_ov006_020f0d58.cpp:
+    complete
+    .text start:0x020f0d58 end:0x020f0dd8
+
+src/func_ov006_020f0dd8.c:
+    complete
+    .text start:0x020f0dd8 end:0x020f0e28
+
+src/func_ov006_020f0e28.c:
+    .text start:0x020f0e28 end:0x020f0eac
+
+src/func_ov006_020f0eac.c:
+    complete
+    .text start:0x020f0eac end:0x020f0f7c
+
+src/func_ov006_020f0f7c.c:
+    complete
+    .text start:0x020f0f7c end:0x020f100c
+
+src/func_ov006_020f100c.c:
+    complete
+    .text start:0x020f100c end:0x020f10ec
+
+src/func_ov006_020f10ec.c:
+    complete
+    .text start:0x020f10ec end:0x020f120c
+
+src/func_ov006_020f120c.c:
+    complete
+    .text start:0x020f120c end:0x020f12c8
+
+src/func_ov006_020f12c8.c:
+    complete
+    .text start:0x020f12c8 end:0x020f1318
+
+src/func_ov006_020f1318.c:
+    complete
+    .text start:0x020f1318 end:0x020f13cc
+
+src/func_ov006_020f13cc.c:
+    complete
+    .text start:0x020f13cc end:0x020f15ac
+
+src/func_ov006_020f17fc.c:
+    .text start:0x020f17fc end:0x020f192c
+
+src/func_ov006_020f192c.c:
+    .text start:0x020f192c end:0x020f1a70
+
+src/func_ov006_020f1a70.c:
+    .text start:0x020f1a70 end:0x020f1b98
+
+src/func_ov006_020f1b98.c:
+    .text start:0x020f1b98 end:0x020f1cb4
+
+src/func_ov006_020f1cb4.c:
+    .text start:0x020f1cb4 end:0x020f1dbc
+
+src/func_ov006_020f1dbc.c:
+    complete
+    .text start:0x020f1dbc end:0x020f1e40
+
+src/func_ov006_020f1e40.c:
+    complete
+    .text start:0x020f1e40 end:0x020f1e58
+
+src/func_ov006_020f1e58.c:
+    complete
+    .text start:0x020f1e58 end:0x020f1e90
+
+src/func_ov006_020f1e90.cpp:
+    complete
+    .text start:0x020f1e90 end:0x020f1ef8
+
+src/func_ov006_020f1ef8.c:
+    complete
+    .text start:0x020f1ef8 end:0x020f1fcc
+
+src/func_ov006_020f1fcc.c:
+    complete
+    .text start:0x020f1fcc end:0x020f2224
+
+src/func_ov006_020f2cb8.c:
+    complete
+    .text start:0x020f2cb8 end:0x020f2e20
+
+src/func_ov006_020f2e20.c:
+    complete
+    .text start:0x020f2e20 end:0x020f2ec0
+
+src/func_ov006_020f2ec0.c:
+    complete
+    .text start:0x020f2ec0 end:0x020f300c
+
+src/func_ov006_020f300c.cpp:
+    complete
+    .text start:0x020f300c end:0x020f319c
+
+src/func_ov006_020f319c.c:
+    complete
+    .text start:0x020f319c end:0x020f31dc
+
+src/func_ov006_020f31dc.c:
+    .text start:0x020f31dc end:0x020f3260
+
+src/func_ov006_020f3260.c:
+    complete
+    .text start:0x020f3260 end:0x020f3294
+
+src/func_ov006_020f3294.c:
+    .text start:0x020f3294 end:0x020f33c0
+
+src/func_ov006_020f33c0.c:
+    complete
+    .text start:0x020f33c0 end:0x020f3414
+
+src/func_ov006_020f3414.cpp:
+    complete
+    .text start:0x020f3414 end:0x020f3460
+
+src/func_ov006_020f3460.c:
+    .text start:0x020f3460 end:0x020f3800
+
+src/MgWanted_Spawn.c:
+    .text start:0x020f3800 end:0x020f3834
+
+src/func_ov006_020f3834.cpp:
+    .text start:0x020f3834 end:0x020f3888
+
+src/func_ov006_020f3888.cpp:
+    .text start:0x020f3888 end:0x020f38f0
+
+src/func_ov006_020f38f0.c:
+    complete
+    .text start:0x020f38f0 end:0x020f392c
+
+src/func_ov006_020f392c.c:
+    complete
+    .text start:0x020f392c end:0x020f3964
+
+src/func_ov006_020f3964.c:
+    complete
+    .text start:0x020f3964 end:0x020f39c8
+
+src/func_ov006_020f39c8.c:
+    complete
+    .text start:0x020f39c8 end:0x020f39fc
+
+src/func_ov006_020f39fc.c:
+    complete
+    .text start:0x020f39fc end:0x020f3a10
+
+src/func_ov006_020f3a10.c:
+    complete
+    .text start:0x020f3a10 end:0x020f3a14
+
+src/func_ov006_020f3a14.c:
+    complete
+    .text start:0x020f3a14 end:0x020f3ba0
+
+src/func_ov006_020f3ba0.c:
+    complete
+    .text start:0x020f3ba0 end:0x020f3c0c
+
+src/func_ov006_020f3c0c.c:
+    .text start:0x020f3c0c end:0x020f3c90
+
+src/func_ov006_020f3c90.c:
+    complete
+    .text start:0x020f3c90 end:0x020f3d34
+
+src/func_ov006_020f3d34.cpp:
+    complete
+    .text start:0x020f3d34 end:0x020f3e68
+
+src/func_ov006_020f3f10.cpp:
+    complete
+    .text start:0x020f3f10 end:0x020f3f84
+
+src/func_ov006_020f3f84.c:
+    complete
+    .text start:0x020f3f84 end:0x020f411c
+
+src/func_ov006_020f411c.c:
+    complete
+    .text start:0x020f411c end:0x020f41ac
+
+src/func_ov006_020f41ac.c:
+    complete
+    .text start:0x020f41ac end:0x020f41b0
+
+src/func_ov006_020f41b0.c:
+    complete
+    .text start:0x020f41b0 end:0x020f4248
+
+src/func_ov006_020f4248.c:
+    complete
+    .text start:0x020f4248 end:0x020f43c0
+
+src/func_ov006_020f43c0.c:
+    complete
+    .text start:0x020f43c0 end:0x020f43c4
+
+src/func_ov006_020f43c4.c:
+    complete
+    .text start:0x020f43c4 end:0x020f456c
+
+src/func_ov006_020f456c.c:
+    complete
+    .text start:0x020f456c end:0x020f46ec
+
+src/func_ov006_020f46ec.cpp:
+    complete
+    .text start:0x020f46ec end:0x020f47d8
+
+src/func_ov006_020f47d8.c:
+    complete
+    .text start:0x020f47d8 end:0x020f4888
+
+src/func_ov006_020f4888.c:
+    .text start:0x020f4888 end:0x020f49ac
+
+src/func_ov006_020f49ac.c:
+    complete
+    .text start:0x020f49ac end:0x020f4a40
+
+src/func_ov006_020f4a40.c:
+    complete
+    .text start:0x020f4a40 end:0x020f4ad4
+
+src/func_ov006_020f4ad4.c:
+    complete
+    .text start:0x020f4ad4 end:0x020f4b30
+
+src/func_ov006_020f4b30.c:
+    complete
+    .text start:0x020f4b30 end:0x020f4bbc
+
+src/func_ov006_020f4bbc.c:
+    complete
+    .text start:0x020f4bbc end:0x020f4c38
+
+src/func_ov006_020f4c38.c:
+    complete
+    .text start:0x020f4c38 end:0x020f4cd8
+
+src/func_ov006_020f4cd8.c:
+    complete
+    .text start:0x020f4cd8 end:0x020f4f94
+
+src/func_ov006_020f4f94.c:
+    complete
+    .text start:0x020f4f94 end:0x020f50c0
+
+src/func_ov006_020f50c0.c:
+    complete
+    .text start:0x020f50c0 end:0x020f50f8
+
+src/func_ov006_020f50f8.cpp:
+    complete
+    .text start:0x020f50f8 end:0x020f5140
+
+src/func_ov006_020f5140.c:
+    complete
+    .text start:0x020f5140 end:0x020f5164
+
+src/func_ov006_020f5164.cpp:
+    complete
+    .text start:0x020f5164 end:0x020f51b0
+
+src/func_ov006_020f51b0.c:
+    complete
+    .text start:0x020f51b0 end:0x020f51f0
+
+src/func_ov006_020f51f0.c:
+    complete
+    .text start:0x020f51f0 end:0x020f523c
+
+src/func_ov006_020f523c.c:
+    complete
+    .text start:0x020f523c end:0x020f5250
+
+src/func_ov006_020f5250.c:
+    complete
+    .text start:0x020f5250 end:0x020f52c4
+
+src/func_ov006_020f52c4.c:
+    .text start:0x020f52c4 end:0x020f5324
+
+src/func_ov006_020f5324.c:
+    complete
+    .text start:0x020f5324 end:0x020f5388
+
+src/func_ov006_020f5388.cpp:
+    complete
+    .text start:0x020f5388 end:0x020f53e4
+
+src/func_ov006_020f53e4.cpp:
+    .text start:0x020f53e4 end:0x020f5504
+
+src/MgMemoryMatch_Spawn.c:
+    complete
+    .text start:0x020f5504 end:0x020f5564
+
+src/func_ov006_020f5564.cpp:
+    .text start:0x020f5564 end:0x020f55b8
+
+src/func_ov006_020f55b8.cpp:
+    .text start:0x020f55b8 end:0x020f5620
+
+src/func_ov006_020f5620.c:
+    complete
+    .text start:0x020f5620 end:0x020f565c
+
+src/func_ov006_020f565c.c:
+    complete
+    .text start:0x020f565c end:0x020f5694
+
+src/func_ov006_020f5694.c:
+    complete
+    .text start:0x020f5694 end:0x020f56f8
+
+src/func_ov006_020f56f8.c:
+    complete
+    .text start:0x020f56f8 end:0x020f572c
+
+src/func_ov006_020f572c.c:
+    complete
+    .text start:0x020f572c end:0x020f5740
+
+src/func_ov006_020f5740.c:
+    complete
+    .text start:0x020f5740 end:0x020f5744
+
+src/func_ov006_020f5744.c:
+    complete
+    .text start:0x020f5744 end:0x020f58d0
+
+src/func_ov006_020f58d0.c:
+    complete
+    .text start:0x020f58d0 end:0x020f593c
+
+src/func_ov006_020f593c.c:
+    .text start:0x020f593c end:0x020f59c0
+
+src/func_ov006_020f59c0.c:
+    complete
+    .text start:0x020f59c0 end:0x020f5a64
+
+src/func_ov006_020f5a64.cpp:
+    complete
+    .text start:0x020f5a64 end:0x020f5b98
+
+src/func_ov006_020f5c40.cpp:
+    complete
+    .text start:0x020f5c40 end:0x020f5cb4
+
+src/func_ov006_020f5cb4.c:
+    complete
+    .text start:0x020f5cb4 end:0x020f5de0
+
+src/func_ov006_020f5de0.c:
+    complete
+    .text start:0x020f5de0 end:0x020f5e70
+
+src/func_ov006_020f5e70.c:
+    complete
+    .text start:0x020f5e70 end:0x020f5e74
+
+src/func_ov006_020f5e74.c:
+    complete
+    .text start:0x020f5e74 end:0x020f5f0c
+
+src/func_ov006_020f5f0c.c:
+    complete
+    .text start:0x020f5f0c end:0x020f6084
+
+src/func_ov006_020f6084.c:
+    complete
+    .text start:0x020f6084 end:0x020f6088
+
+src/func_ov006_020f6088.c:
+    complete
+    .text start:0x020f6088 end:0x020f6230
+
+src/func_ov006_020f6230.c:
+    complete
+    .text start:0x020f6230 end:0x020f639c
+
+src/func_ov006_020f639c.c:
+    complete
+    .text start:0x020f639c end:0x020f6488
+
+src/func_ov006_020f6488.c:
+    complete
+    .text start:0x020f6488 end:0x020f6538
+
+src/func_ov006_020f6538.c:
+    .text start:0x020f6538 end:0x020f6678
+
+src/func_ov006_020f6678.c:
+    complete
+    .text start:0x020f6678 end:0x020f670c
+
+src/func_ov006_020f670c.c:
+    complete
+    .text start:0x020f670c end:0x020f67a0
+
+src/func_ov006_020f67a0.c:
+    complete
+    .text start:0x020f67a0 end:0x020f6830
+
+src/func_ov006_020f6830.c:
+    complete
+    .text start:0x020f6830 end:0x020f6904
+
+src/func_ov006_020f6a00.c:
+    complete
+    .text start:0x020f6a00 end:0x020f6a78
+
+src/func_ov006_020f6a78.c:
+    complete
+    .text start:0x020f6a78 end:0x020f6b00
+
+src/func_ov006_020f6b00.c:
+    complete
+    .text start:0x020f6b00 end:0x020f6b78
+
+src/func_ov006_020f6b78.c:
+    complete
+    .text start:0x020f6b78 end:0x020f6bf0
+
+src/func_ov006_020f6bf0.c:
+    complete
+    .text start:0x020f6bf0 end:0x020f6c90
+
+src/func_ov006_020f6c90.c:
+    complete
+    .text start:0x020f6c90 end:0x020f6f88
+
+src/func_ov006_020f6f88.c:
+    complete
+    .text start:0x020f6f88 end:0x020f7064
+
+src/func_ov006_020f7064.c:
+    complete
+    .text start:0x020f7064 end:0x020f7190
+
+src/func_ov006_020f7190.c:
+    complete
+    .text start:0x020f7190 end:0x020f71c8
+
+src/func_ov006_020f71c8.cpp:
+    complete
+    .text start:0x020f71c8 end:0x020f7210
+
+src/func_ov006_020f7210.c:
+    complete
+    .text start:0x020f7210 end:0x020f7234
+
+src/func_ov006_020f7234.cpp:
+    complete
+    .text start:0x020f7234 end:0x020f7280
+
+src/func_ov006_020f7280.c:
+    complete
+    .text start:0x020f7280 end:0x020f72c0
+
+src/func_ov006_020f72c0.c:
+    complete
+    .text start:0x020f72c0 end:0x020f730c
+
+src/func_ov006_020f730c.c:
+    complete
+    .text start:0x020f730c end:0x020f7320
+
+src/func_ov006_020f7320.c:
+    complete
+    .text start:0x020f7320 end:0x020f7394
+
+src/func_ov006_020f7394.c:
+    .text start:0x020f7394 end:0x020f73f4
+
+src/func_ov006_020f73f4.c:
+    complete
+    .text start:0x020f73f4 end:0x020f7458
+
+src/func_ov006_020f7458.cpp:
+    complete
+    .text start:0x020f7458 end:0x020f74b4
+
+src/func_ov006_020f74b4.cpp:
+    .text start:0x020f74b4 end:0x020f75d4
+
+src/MgMemoryMaster_Spawn.c:
+    complete
+    .text start:0x020f75d4 end:0x020f7634
+
+src/func_ov006_020f7634.cpp:
+    .text start:0x020f7634 end:0x020f76a8
+
+src/func_ov006_020f76a8.cpp:
+    .text start:0x020f76a8 end:0x020f7730
+
+src/func_ov006_020f7730.c:
+    complete
+    .text start:0x020f7730 end:0x020f7740
+
+src/func_ov006_020f7740.cpp:
+    complete
+    .text start:0x020f7740 end:0x020f7994
+
+src/func_ov006_020f7994.c:
+    complete
+    .text start:0x020f7994 end:0x020f7a00
+
+src/func_ov006_020f7a00.c:
+    complete
+    .text start:0x020f7a00 end:0x020f7a90
+
+src/func_ov006_020f7a90.c:
+    complete
+    .text start:0x020f7a90 end:0x020f7b10
+
+src/func_ov006_020f7b10.c:
+    complete
+    .text start:0x020f7b10 end:0x020f7b90
+
+src/func_ov006_020f7b90.c:
+    complete
+    .text start:0x020f7b90 end:0x020f7c10
+
+src/func_ov006_020f7c10.c:
+    .text start:0x020f7c10 end:0x020f7e2c
+
+src/func_ov006_020f7e2c.c:
+    complete
+    .text start:0x020f7e2c end:0x020f7ee4
+
+src/func_ov006_020f7ee4.cpp:
+    complete
+    .text start:0x020f7ee4 end:0x020f8154
+
+src/func_ov006_020f8154.c:
+    complete
+    .text start:0x020f8154 end:0x020f8224
+
+src/func_ov006_020f8224.c:
+    complete
+    .text start:0x020f8224 end:0x020f82d0
+
+src/func_ov006_020f82d0.c:
+    complete
+    .text start:0x020f82d0 end:0x020f8320
+
+src/func_ov006_020f8320.c:
+    complete
+    .text start:0x020f8320 end:0x020f84a8
+
+src/func_ov006_020f84a8.c:
+    complete
+    .text start:0x020f84a8 end:0x020f8540
+
+src/func_ov006_020f8540.c:
+    complete
+    .text start:0x020f8540 end:0x020f85b0
+
+src/func_ov006_020f85b0.cpp:
+    complete
+    .text start:0x020f85b0 end:0x020f869c
+
+src/func_ov006_020f869c.c:
+    .text start:0x020f869c end:0x020f8a3c
+
+src/func_ov006_020f8a3c.c:
+    .text start:0x020f8a3c end:0x020f8c68
+
+src/func_ov006_020f8c68.c:
+    .text start:0x020f8c68 end:0x020f8d08
+
+src/func_ov006_020f8d08.cpp:
+    .text start:0x020f8d08 end:0x020f8e44
+
+src/func_ov006_020f8e44.cpp:
+    complete
+    .text start:0x020f8e44 end:0x020f8ed8
+
+src/func_ov006_020f8ed8.c:
+    complete
+    .text start:0x020f8ed8 end:0x020f8ef4
+
+src/func_ov006_020f8ef4.cpp:
+    .text start:0x020f8ef4 end:0x020f8f68
+
+src/func_ov006_020f8f68.cpp:
+    .text start:0x020f8f68 end:0x020f8ff0
+
+src/func_ov006_020f8ff0.c:
+    complete
+    .text start:0x020f8ff0 end:0x020f9000
+
+src/func_ov006_020f9000.cpp:
+    complete
+    .text start:0x020f9000 end:0x020f94f4
+
+src/func_ov006_020f94f4.c:
+    complete
+    .text start:0x020f94f4 end:0x020f9560
+
+src/func_ov006_020f9560.c:
+    complete
+    .text start:0x020f9560 end:0x020f95f0
+
+src/func_ov006_020f95f0.c:
+    complete
+    .text start:0x020f95f0 end:0x020f9668
+
+src/func_ov006_020f9668.c:
+    complete
+    .text start:0x020f9668 end:0x020f96e0
+
+src/func_ov006_020f96e0.c:
+    complete
+    .text start:0x020f96e0 end:0x020f9760
+
+src/func_ov006_020f9760.c:
+    complete
+    .text start:0x020f9760 end:0x020f98dc
+
+src/func_ov006_020f98dc.c:
+    complete
+    .text start:0x020f98dc end:0x020f9994
+
+src/func_ov006_020f9994.c:
+    complete
+    .text start:0x020f9994 end:0x020f9bec
+
+src/func_ov006_020f9bec.c:
+    complete
+    .text start:0x020f9bec end:0x020f9cbc
+
+src/func_ov006_020f9cbc.c:
+    complete
+    .text start:0x020f9cbc end:0x020f9d68
+
+src/func_ov006_020f9d68.c:
+    complete
+    .text start:0x020f9d68 end:0x020f9db8
+
+src/func_ov006_020f9db8.c:
+    complete
+    .text start:0x020f9db8 end:0x020f9f40
+
+src/func_ov006_020f9f40.c:
+    complete
+    .text start:0x020f9f40 end:0x020f9fe0
+
+src/func_ov006_020f9fe0.c:
+    complete
+    .text start:0x020f9fe0 end:0x020f9ffc
+
+src/func_ov006_020f9ffc.cpp:
+    .text start:0x020f9ffc end:0x020fa13c
+
+src/func_ov006_020fa13c.c:
+    complete
+    .text start:0x020fa13c end:0x020fa3d0
+
+src/func_ov006_020fa4d4.cpp:
+    .text start:0x020fa4d4 end:0x020fa56c
+
+src/func_ov006_020fa56c.cpp:
+    .text start:0x020fa56c end:0x020fa6ac
+
+src/MgPairAGoneAndOn_Spawn.cpp:
+    complete
+    .text start:0x020fa6ac end:0x020fa740
+
+src/func_ov006_020fa740.c:
+    complete
+    .text start:0x020fa740 end:0x020fa75c
+
+src/func_ov006_020fa75c.c:
+    complete
+    .text start:0x020fa75c end:0x020fa780
+
+src/func_ov006_020fa780.c:
+    .text start:0x020fa780 end:0x020fa7b8
+
+src/func_ov006_020fa7b8.cpp:
+    .text start:0x020fa7b8 end:0x020fa844
+
+src/func_ov006_020fa844.c:
+    complete
+    .text start:0x020fa844 end:0x020fa924
+
+src/func_ov006_020fa924.c:
+    complete
+    .text start:0x020fa924 end:0x020fa9a0
+
+src/func_ov006_020fa9a0.c:
+    complete
+    .text start:0x020fa9a0 end:0x020fa9c8
+
+src/func_ov006_020fa9c8.c:
+    complete
+    .text start:0x020fa9c8 end:0x020faac8
+
+src/func_ov006_020faac8.c:
+    complete
+    .text start:0x020faac8 end:0x020fab70
+
+src/func_ov006_020fab70.c:
+    complete
+    .text start:0x020fab70 end:0x020fac48
+
+src/func_ov006_020fac48.c:
+    complete
+    .text start:0x020fac48 end:0x020fad34
+
+src/func_ov006_020fad34.cpp:
+    complete
+    .text start:0x020fad34 end:0x020fad90
+
+src/func_ov006_020fad90.c:
+    complete
+    .text start:0x020fad90 end:0x020fadfc
+
+src/func_ov006_020fadfc.c:
+    complete
+    .text start:0x020fadfc end:0x020fae20
+
+src/func_ov006_020fae20.c:
+    complete
+    .text start:0x020fae20 end:0x020fae90
+
+src/func_ov006_020fae90.c:
+    complete
+    .text start:0x020fae90 end:0x020faeec
+
+src/func_ov006_020faeec.c:
+    complete
+    .text start:0x020faeec end:0x020faf14
+
+src/func_ov006_020faf14.c:
+    complete
+    .text start:0x020faf14 end:0x020faf6c
+
+src/func_ov006_020faf6c.c:
+    complete
+    .text start:0x020faf6c end:0x020fb0fc
+
+src/func_ov006_020fb0fc.c:
+    complete
+    .text start:0x020fb0fc end:0x020fb1c4
+
+src/func_ov006_020fb1c4.c:
+    complete
+    .text start:0x020fb1c4 end:0x020fb230
+
+src/func_ov006_020fb45c.c:
+    complete
+    .text start:0x020fb45c end:0x020fb4e0
+
+src/func_ov006_020fb4e0.c:
+    complete
+    .text start:0x020fb4e0 end:0x020fb60c
+
+src/func_ov006_020fb60c.cpp:
+    complete
+    .text start:0x020fb60c end:0x020fb670
+
+src/func_ov006_020fb670.c:
+    complete
+    .text start:0x020fb670 end:0x020fb74c
+
+src/func_ov006_020fb74c.c:
+    complete
+    .text start:0x020fb74c end:0x020fb7e0
+
+src/func_ov006_020fb8fc.c:
+    complete
+    .text start:0x020fb8fc end:0x020fb97c
+
+src/func_ov006_020fb97c.c:
+    .text start:0x020fb97c end:0x020fba28
+
+src/func_ov006_020fba28.cpp:
+    complete
+    .text start:0x020fba28 end:0x020fba48
+
+src/func_ov006_020fba48.c:
+    complete
+    .text start:0x020fba48 end:0x020fba64
+
+src/func_ov006_020fba64.c:
+    complete
+    .text start:0x020fba64 end:0x020fbad4
+
+src/func_ov006_020fbad4.c:
+    complete
+    .text start:0x020fbad4 end:0x020fbb2c
+
+src/func_ov006_020fbb2c.c:
+    complete
+    .text start:0x020fbb2c end:0x020fbbe8
+
+src/func_ov006_020fbbe8.c:
+    complete
+    .text start:0x020fbbe8 end:0x020fbcb8
+
+src/func_ov006_020fbcb8.c:
+    complete
+    .text start:0x020fbcb8 end:0x020fbd38
+
+src/func_ov006_020fbd38.c:
+    complete
+    .text start:0x020fbd38 end:0x020fc144
+
+src/func_ov006_020fc144.c:
+    complete
+    .text start:0x020fc144 end:0x020fc1b4
+
+src/func_ov006_020fc1b4.c:
+    complete
+    .text start:0x020fc1b4 end:0x020fc1f8
+
+src/func_ov006_020fc1f8.c:
+    .text start:0x020fc1f8 end:0x020fc2ec
+
+src/func_ov006_020fc2ec.c:
+    complete
+    .text start:0x020fc2ec end:0x020fc500
+
+src/func_ov006_020fc500.c:
+    complete
+    .text start:0x020fc500 end:0x020fc718
+
+src/func_ov006_020fc7d0.cpp:
+    complete
+    .text start:0x020fc7d0 end:0x020fc844
+
+src/func_ov006_020fc844.c:
+    complete
+    .text start:0x020fc844 end:0x020fc8c0
+
+src/func_ov006_020fc9b0.c:
+    complete
+    .text start:0x020fc9b0 end:0x020fca1c
+
+src/func_ov006_020fca1c.c:
+    complete
+    .text start:0x020fca1c end:0x020fcb4c
+
+src/func_ov006_020fcd8c.c:
+    complete
+    .text start:0x020fcd8c end:0x020fce04
+
+src/func_ov006_020fce04.c:
+    complete
+    .text start:0x020fce04 end:0x020fcec4
+
+src/func_ov006_020fcec4.c:
+    complete
+    .text start:0x020fcec4 end:0x020fd088
+
+src/func_ov006_020fd088.c:
+    complete
+    .text start:0x020fd088 end:0x020fd17c
+
+src/func_ov006_020fd17c.c:
+    complete
+    .text start:0x020fd17c end:0x020fd2d8
+
+src/func_ov006_020fd894.c:
+    complete
+    .text start:0x020fd894 end:0x020fd9cc
+
+src/func_ov006_020fd9cc.c:
+    complete
+    .text start:0x020fd9cc end:0x020fda7c
+
+src/func_ov006_020fda7c.cpp:
+    complete
+    .text start:0x020fda7c end:0x020fdaf0
+
+src/func_ov006_020fe1a8.c:
+    complete
+    .text start:0x020fe1a8 end:0x020fe1d0
+
+src/func_ov006_020fe1d0.c:
+    complete
+    .text start:0x020fe1d0 end:0x020fe248
+
+src/func_ov006_020fe248.cpp:
+    complete
+    .text start:0x020fe248 end:0x020fe2bc
+
+src/func_ov006_020fe2bc.c:
+    complete
+    .text start:0x020fe2bc end:0x020fe2e4
+
+src/func_ov006_020fe2e4.c:
+    complete
+    .text start:0x020fe2e4 end:0x020fe394
+
+src/func_ov006_020fe750.c:
+    complete
+    .text start:0x020fe750 end:0x020fe90c
+
+src/func_ov006_020fe90c.c:
+    complete
+    .text start:0x020fe90c end:0x020fea54
+
+src/func_ov006_020fea54.c:
+    complete
+    .text start:0x020fea54 end:0x020fea70
+
+src/func_ov006_020feba8.c:
+    complete
+    .text start:0x020feba8 end:0x020fed58
+
+src/func_ov006_020fed58.c:
+    .text start:0x020fed58 end:0x020fedc4
+
+src/func_ov006_020fedc4.c:
+    complete
+    .text start:0x020fedc4 end:0x020fee24
+
+src/func_ov006_020fee24.c:
+    complete
+    .text start:0x020fee24 end:0x020fefc0
+
+src/MgBobOmbSquad_Spawn.c:
+    .text start:0x020ff3ec end:0x020ff420
+
+src/func_ov006_020ff420.c:
+    complete
+    .text start:0x020ff420 end:0x020ff444
+
+src/func_ov006_020ff444.c:
+    .text start:0x020ff444 end:0x020ff47c
+
+src/func_ov006_020ff47c.c:
+    complete
+    .text start:0x020ff47c end:0x020ff4ec
+
+src/func_ov006_020ff4ec.c:
+    complete
+    .text start:0x020ff4ec end:0x020ff534
+
+src/func_ov006_020ff534.c:
+    complete
+    .text start:0x020ff534 end:0x020ff690
+
+src/func_ov006_020ff690.c:
+    complete
+    .text start:0x020ff690 end:0x020ff8c8
+
+src/func_ov006_020ffde4.c:
+    complete
+    .text start:0x020ffde4 end:0x020fff54
+
+src/func_ov006_020fff54.c:
+    complete
+    .text start:0x020fff54 end:0x020fff84
+
+src/func_ov006_020fff84.cpp:
+    complete
+    .text start:0x020fff84 end:0x020fffec
+
+src/func_ov006_020fffec.c:
+    complete
+    .text start:0x020fffec end:0x02100058
+
+src/func_ov006_02100058.c:
+    complete
+    .text start:0x02100058 end:0x02100084
+
+src/func_ov006_02100084.c:
+    complete
+    .text start:0x02100084 end:0x02100140
+
+src/func_ov006_02100140.c:
+    complete
+    .text start:0x02100140 end:0x021001ac
+
+src/func_ov006_021001ac.c:
+    complete
+    .text start:0x021001ac end:0x02100278
+
+src/func_ov006_02100278.c:
+    complete
+    .text start:0x02100278 end:0x02100314
+
+src/func_ov006_02100314.c:
+    complete
+    .text start:0x02100314 end:0x02100380
+
+src/func_ov006_02100380.c:
+    complete
+    .text start:0x02100380 end:0x02100408
+
+src/func_ov006_02100408.c:
+    complete
+    .text start:0x02100408 end:0x02100488
+
+src/func_ov006_02100488.cpp:
+    complete
+    .text start:0x02100488 end:0x021004c0
+
+src/func_ov006_021004c0.c:
+    complete
+    .text start:0x021004c0 end:0x021004f4
+
+src/func_ov006_021004f4.c:
+    complete
+    .text start:0x021004f4 end:0x02100554
+
+src/func_ov006_02100554.c:
+    complete
+    .text start:0x02100554 end:0x0210068c
+
+src/func_ov006_0210068c.c:
+    complete
+    .text start:0x0210068c end:0x021006f4
+
+src/func_ov006_021006f4.c:
+    complete
+    .text start:0x021006f4 end:0x02100734
+
+src/func_ov006_02100734.c:
+    complete
+    .text start:0x02100734 end:0x0210076c
+
+src/func_ov006_021009b8.c:
+    complete
+    .text start:0x021009b8 end:0x02100b08
+
+src/func_ov006_02100b08.c:
+    complete
+    .text start:0x02100b08 end:0x02100bac
+
+src/func_ov006_02100bac.c:
+    complete
+    .text start:0x02100bac end:0x02100d90
+
+src/func_ov006_02100d90.c:
+    complete
+    .text start:0x02100d90 end:0x02100e3c
+
+src/func_ov006_02100e3c.c:
+    complete
+    .text start:0x02100e3c end:0x02100f7c
+
+src/func_ov006_02100f7c.c:
+    complete
+    .text start:0x02100f7c end:0x02101088
+
+src/func_ov006_02101088.c:
+    complete
+    .text start:0x02101088 end:0x02101148
+
+src/func_ov006_02101148.c:
+    complete
+    .text start:0x02101148 end:0x02101224
+
+src/func_ov006_02101224.c:
+    complete
+    .text start:0x02101224 end:0x021012cc
+
+src/func_ov006_021012cc.c:
+    complete
+    .text start:0x021012cc end:0x021016ec
+
+src/func_ov006_021016ec.c:
+    complete
+    .text start:0x021016ec end:0x021019e0
+
+src/func_ov006_021019e0.c:
+    complete
+    .text start:0x021019e0 end:0x02101af0
+
+src/func_ov006_02101af0.c:
+    complete
+    .text start:0x02101af0 end:0x02101e88
+
+src/func_ov006_02101e88.c:
+    complete
+    .text start:0x02101e88 end:0x021020c4
+
+src/func_ov006_021020c4.c:
+    complete
+    .text start:0x021020c4 end:0x02102274
+
+src/func_ov006_0210246c.cpp:
+    complete
+    .text start:0x0210246c end:0x021024e0
+
+src/func_ov006_021024e0.c:
+    .text start:0x021024e0 end:0x02102564
+
+src/func_ov006_02102564.c:
+    complete
+    .text start:0x02102564 end:0x0210258c
+
+src/func_ov006_0210258c.cpp:
+    complete
+    .text start:0x0210258c end:0x02102624
+
+src/func_ov006_02102624.c:
+    complete
+    .text start:0x02102624 end:0x0210265c
+
+src/func_ov006_0210265c.c:
+    complete
+    .text start:0x0210265c end:0x02102718
+
+src/func_ov006_02102718.c:
+    complete
+    .text start:0x02102718 end:0x021027e4
+
+src/func_ov006_021027e4.c:
+    complete
+    .text start:0x021027e4 end:0x02102864
+
+src/func_ov006_02102864.c:
+    complete
+    .text start:0x02102864 end:0x02102c3c
+
+src/func_ov006_02102c3c.c:
+    complete
+    .text start:0x02102c3c end:0x02102d6c
+
+src/func_ov006_02102d6c.c:
+    complete
+    .text start:0x02102d6c end:0x02102dbc
+
+src/func_ov006_02102dbc.c:
+    complete
+    .text start:0x02102dbc end:0x02102de4
+
+src/func_ov006_02102de4.c:
+    complete
+    .text start:0x02102de4 end:0x02102e8c
+
+src/func_ov006_02102e8c.cpp:
+    complete
+    .text start:0x02102e8c end:0x02102ef4
+
+src/func_ov006_02102ef4.c:
+    complete
+    .text start:0x02102ef4 end:0x02102f3c
+
+src/func_ov006_02102f3c.c:
+    complete
+    .text start:0x02102f3c end:0x02102fe8
+
+src/func_ov006_02103360.c:
+    complete
+    .text start:0x02103360 end:0x02103608
+
+src/func_ov006_02103608.c:
+    complete
+    .text start:0x02103608 end:0x0210371c
+
+src/func_ov006_0210371c.c:
+    complete
+    .text start:0x0210371c end:0x02103870
+
+src/func_ov006_02103870.c:
+    complete
+    .text start:0x02103870 end:0x0210397c
+
+src/func_ov006_0210397c.c:
+    complete
+    .text start:0x0210397c end:0x02103994
+
+src/func_ov006_02103994.c:
+    complete
+    .text start:0x02103994 end:0x02103ac0
+
+src/func_ov006_02103bfc.c:
+    complete
+    .text start:0x02103bfc end:0x02103cbc
+
+src/func_ov006_02103cbc.c:
+    .text start:0x02103cbc end:0x02103d28
+
+src/func_ov006_02103d28.c:
+    complete
+    .text start:0x02103d28 end:0x02103d78
+
+src/func_ov006_02103d78.c:
+    complete
+    .text start:0x02103d78 end:0x02103ed0
+
+src/func_ov006_02103ed0.c:
+    complete
+    .text start:0x02103ed0 end:0x02104258
+
+src/MgLakituLaunch_Spawn.c:
+    .text start:0x02104258 end:0x0210428c
+
+src/func_ov006_0210428c.c:
+    complete
+    .text start:0x0210428c end:0x021042b0
+
+src/func_ov006_021042b0.c:
+    .text start:0x021042b0 end:0x021042e8
+
+src/func_ov006_021042e8.c:
+    complete
+    .text start:0x021042e8 end:0x02104354
+
+src/func_ov006_02104354.c:
+    complete
+    .text start:0x02104354 end:0x0210446c
+
+src/func_ov006_0210446c.c:
+    complete
+    .text start:0x0210446c end:0x02104558
+
+src/func_ov006_02104558.c:
+    complete
+    .text start:0x02104558 end:0x02104580
+
+src/func_ov006_02104580.c:
+    complete
+    .text start:0x02104580 end:0x02104870
+
+src/func_ov006_02104870.c:
+    complete
+    .text start:0x02104870 end:0x021048b0
+
+src/func_ov006_021048b0.c:
+    complete
+    .text start:0x021048b0 end:0x021048e4
+
+src/func_ov006_021048e4.c:
+    complete
+    .text start:0x021048e4 end:0x02104920
+
+src/func_ov006_02104920.c:
+    complete
+    .text start:0x02104920 end:0x02104a10
+
+src/func_ov006_02104a10.cpp:
+    complete
+    .text start:0x02104a10 end:0x02104ac0
+
+src/func_ov006_02104ac0.c:
+    complete
+    .text start:0x02104ac0 end:0x02104ac4
+
+src/func_ov006_02104ac4.cpp:
+    complete
+    .text start:0x02104ac4 end:0x02104b24
+
+src/func_ov006_02104b24.c:
+    complete
+    .text start:0x02104b24 end:0x02104b4c
+
+src/func_ov006_02104b4c.c:
+    complete
+    .text start:0x02104b4c end:0x02104b5c
+
+src/func_ov006_02104b5c.c:
+    complete
+    .text start:0x02104b5c end:0x02104bac
+
+src/func_ov006_02104bac.c:
+    complete
+    .text start:0x02104bac end:0x02104bb0
+
+src/func_ov006_02104bb0.c:
+    complete
+    .text start:0x02104bb0 end:0x02104c08
+
+src/func_ov006_02104c08.c:
+    complete
+    .text start:0x02104c08 end:0x02104c60
+
+src/func_ov006_02104c60.cpp:
+    complete
+    .text start:0x02104c60 end:0x02104cfc
+
+src/func_ov006_02104cfc.c:
+    complete
+    .text start:0x02104cfc end:0x02104d44
+
+src/func_ov006_02104d44.c:
+    complete
+    .text start:0x02104d44 end:0x02104d94
+
+src/func_ov006_02104d94.c:
+    complete
+    .text start:0x02104d94 end:0x02104e70
+
+src/func_ov006_02104e70.c:
+    complete
+    .text start:0x02104e70 end:0x02104e80
+
+src/func_ov006_02104e80.c:
+    complete
+    .text start:0x02104e80 end:0x02104ea8
+
+src/func_ov006_02104ea8.c:
+    complete
+    .text start:0x02104ea8 end:0x02104eb8
+
+src/func_ov006_02104eb8.c:
+    complete
+    .text start:0x02104eb8 end:0x02104ec8
+
+src/func_ov006_02104ec8.c:
+    complete
+    .text start:0x02104ec8 end:0x02104ecc
+
+src/func_ov006_02104ecc.cpp:
+    complete
+    .text start:0x02104ecc end:0x02104fb4
+
+src/func_ov006_02104fb4.c:
+    complete
+    .text start:0x02104fb4 end:0x0210500c
+
+src/func_ov006_0210500c.c:
+    complete
+    .text start:0x0210500c end:0x0210508c
+
+src/func_ov006_0210508c.c:
+    complete
+    .text start:0x0210508c end:0x021050bc
+
+src/func_ov006_021050bc.cpp:
+    complete
+    .text start:0x021050bc end:0x02105118
+
+src/func_ov006_02105118.c:
+    complete
+    .text start:0x02105118 end:0x02105134
+
+src/func_ov006_02105134.c:
+    complete
+    .text start:0x02105134 end:0x021051dc
+
+src/func_ov006_021051dc.c:
+    .text start:0x021051dc end:0x021053a8
+
+src/func_ov006_02105670.c:
+    complete
+    .text start:0x02105670 end:0x02105730
+
+src/func_ov006_02105730.c:
+    complete
+    .text start:0x02105730 end:0x021057f0
+
+src/func_ov006_021057f0.cpp:
+    complete
+    .text start:0x021057f0 end:0x02105854
+
+src/func_ov006_02105854.c:
+    .text start:0x02105854 end:0x02105ab4
+
+src/func_ov006_02105ab4.c:
+    complete
+    .text start:0x02105ab4 end:0x02105c1c
+
+src/func_ov006_02105c1c.c:
+    complete
+    .text start:0x02105c1c end:0x02105c88
+
+src/func_ov006_02105c88.c:
+    complete
+    .text start:0x02105c88 end:0x02105d20
+
+src/func_ov006_02105d20.c:
+    complete
+    .text start:0x02105d20 end:0x02105de4
+
+src/func_ov006_02105de4.c:
+    .text start:0x02105de4 end:0x02106048
+
+src/func_ov006_02106048.c:
+    complete
+    .text start:0x02106048 end:0x02106080
+
+src/func_ov006_02106080.c:
+    .text start:0x02106080 end:0x02106168
+
+src/func_ov006_021063a0.cpp:
+    complete
+    .text start:0x021063a0 end:0x02106664
+
+src/func_ov006_02106664.c:
+    complete
+    .text start:0x02106664 end:0x02106758
+
+src/func_ov006_02106758.c:
+    complete
+    .text start:0x02106758 end:0x021067a4
+
+src/func_ov006_021067a4.c:
+    complete
+    .text start:0x021067a4 end:0x021068d8
+
+src/func_ov006_021068d8.c:
+    complete
+    .text start:0x021068d8 end:0x02106910
+
+src/func_ov006_02106910.c:
+    complete
+    .text start:0x02106910 end:0x02106a08
+
+src/func_ov006_02106a08.c:
+    complete
+    .text start:0x02106a08 end:0x02106aa8
+
+src/func_ov006_02106bac.c:
+    complete
+    .text start:0x02106bac end:0x02106bc0
+
+src/func_ov006_02106bc0.c:
+    complete
+    .text start:0x02106bc0 end:0x02106ca4
+
+src/func_ov006_02106eb8.cpp:
+    complete
+    .text start:0x02106eb8 end:0x02106f44
+
+src/func_ov006_02106f44.cpp:
+    complete
+    .text start:0x02106f44 end:0x02106fdc
+
+src/func_ov006_0210709c.cpp:
+    complete
+    .text start:0x0210709c end:0x0210713c
+
+src/func_ov006_0210713c.cpp:
+    complete
+    .text start:0x0210713c end:0x021071d4
+
+src/func_ov006_021071d4.c:
+    complete
+    .text start:0x021071d4 end:0x021071fc
+
+src/func_ov006_021071fc.c:
+    .text start:0x021071fc end:0x0210730c
+
+src/func_ov006_0210730c.c:
+    complete
+    .text start:0x0210730c end:0x02107358
+
+src/func_ov006_02107358.cpp:
+    .text start:0x02107358 end:0x021073b0
+
+src/func_ov006_021073b0.c:
+    complete
+    .text start:0x021073b0 end:0x02107858
+
+src/MgPuzzlePanelPuzzlePanic_Spawn.c:
+    .text start:0x02107858 end:0x0210788c
+
+src/func_ov006_0210788c.c:
+    complete
+    .text start:0x0210788c end:0x02107920
+
+src/func_ov006_02107920.cpp:
+    .text start:0x02107920 end:0x021079c8
+
+src/func_ov006_021079c8.c:
+    complete
+    .text start:0x021079c8 end:0x021079cc
+
+src/func_ov006_021079cc.c:
+    complete
+    .text start:0x021079cc end:0x02107a6c
+
+src/func_ov006_02107a6c.cpp:
+    complete
+    .text start:0x02107a6c end:0x02107b14
+
+src/func_ov006_02107b14.c:
+    complete
+    .text start:0x02107b14 end:0x02107b70
+
+src/func_ov006_02107b70.c:
+    complete
+    .text start:0x02107b70 end:0x02107b94
+
+src/func_ov006_02107b94.c:
+    complete
+    .text start:0x02107b94 end:0x02107c50
+
+src/func_ov006_02107c50.c:
+    complete
+    .text start:0x02107c50 end:0x02107d20
+
+src/func_ov006_02107d20.c:
+    complete
+    .text start:0x02107d20 end:0x02107d58
+
+src/func_ov006_02107d58.c:
+    complete
+    .text start:0x02107d58 end:0x02107d80
+
+src/func_ov006_02107d80.cpp:
+    complete
+    .text start:0x02107d80 end:0x02107db8
+
+src/func_ov006_02107db8.cpp:
+    complete
+    .text start:0x02107db8 end:0x02107ea8
+
+src/func_ov006_02107ea8.c:
+    complete
+    .text start:0x02107ea8 end:0x021082c4
+
+src/func_ov006_021082c4.c:
+    complete
+    .text start:0x021082c4 end:0x021082fc
+
+src/func_ov006_021082fc.c:
+    complete
+    .text start:0x021082fc end:0x02108508
+
+src/func_ov006_02108508.c:
+    complete
+    .text start:0x02108508 end:0x02108524
+
+src/func_ov006_02108524.c:
+    complete
+    .text start:0x02108524 end:0x0210858c
+
+src/func_ov006_0210858c.c:
+    complete
+    .text start:0x0210858c end:0x021085c0
+
+src/func_ov006_021085c0.c:
+    complete
+    .text start:0x021085c0 end:0x02108650
+
+src/func_ov006_02108650.c:
+    complete
+    .text start:0x02108650 end:0x02108b90
+
+src/func_ov006_02108cc0.c:
+    complete
+    .text start:0x02108cc0 end:0x02108d28
+
+src/func_ov006_02108e24.c:
+    complete
+    .text start:0x02108e24 end:0x02108f2c
+
+src/func_ov006_02108f2c.c:
+    .text start:0x02108f2c end:0x0210927c
+
+src/func_ov006_0210927c.c:
+    complete
+    .text start:0x0210927c end:0x021092a0
+
+src/func_ov006_021092a0.c:
+    complete
+    .text start:0x021092a0 end:0x021092e8
+
+src/func_ov006_021092e8.c:
+    complete
+    .text start:0x021092e8 end:0x0210935c
+
+src/func_ov006_0210935c.c:
+    complete
+    .text start:0x0210935c end:0x021094ac
+
+src/func_ov006_021094ac.c:
+    complete
+    .text start:0x021094ac end:0x02109530
+
+src/func_ov006_02109530.c:
+    complete
+    .text start:0x02109530 end:0x021095ac
+
+src/func_ov006_021095ac.c:
+    complete
+    .text start:0x021095ac end:0x021095cc
+
+src/func_ov006_021095cc.c:
+    .text start:0x021095cc end:0x021096c8
+
+src/func_ov006_021096c8.c:
+    complete
+    .text start:0x021096c8 end:0x0210980c
+
+src/func_ov006_0210980c.c:
+    complete
+    .text start:0x0210980c end:0x02109834
+
+src/func_ov006_02109834.c:
+    complete
+    .text start:0x02109834 end:0x02109aa0
+
+src/func_ov006_02109aa0.c:
+    complete
+    .text start:0x02109aa0 end:0x02109aac
+
+src/func_ov006_02109aac.c:
+    .text start:0x02109aac end:0x0210a194
+
+src/func_ov006_0210a194.cpp:
+    .text start:0x0210a194 end:0x0210a400
+
+src/MgMushroomRoulette_Spawn.cpp:
+    complete
+    .text start:0x0210a400 end:0x0210a4ac
+
+src/func_ov006_0210a4ac.c:
+    complete
+    .text start:0x0210a4ac end:0x0210a4b0
+
+src/func_ov006_0210a4b0.cpp:
+    complete
+    .text start:0x0210a4b0 end:0x0210a4e8
+
+src/func_ov006_0210a4e8.cpp:
+    complete
+    .text start:0x0210a4e8 end:0x0210a534
+
+src/func_ov006_0210a534.cpp:
+    complete
+    .text start:0x0210a534 end:0x0210a600
+
+src/func_ov006_0210a600.c:
+    complete
+    .text start:0x0210a600 end:0x0210a608
+
+src/func_ov006_0210a608.c:
+    complete
+    .text start:0x0210a608 end:0x0210a664
+
+src/func_ov006_0210a664.c:
+    complete
+    .text start:0x0210a664 end:0x0210a698
+
+src/func_ov006_0210a698.cpp:
+    .text start:0x0210a698 end:0x0210a6e4
+
+src/func_ov006_0210a6e4.cpp:
+    .text start:0x0210a6e4 end:0x0210a708
+
+src/func_ov006_0210a708.c:
+    .text start:0x0210a708 end:0x0210a8c0
+
+src/func_ov006_0210a8c0.c:
+    .text start:0x0210a8c0 end:0x0210a900
+
+src/func_ov006_0210a900.cpp:
+    .text start:0x0210a900 end:0x0210a954
+
+src/func_ov006_0210a954.cpp:
+    .text start:0x0210a954 end:0x0210a9a8
+
+src/func_ov006_0210a9a8.cpp:
+    .text start:0x0210a9a8 end:0x0210aa10
+
+src/func_ov006_0210aa10.c:
+    complete
+    .text start:0x0210aa10 end:0x0210aa3c
+
+src/func_ov006_0210aa3c.c:
+    complete
+    .text start:0x0210aa3c end:0x0210aa60
+
+src/func_ov006_0210aa60.cpp:
+    .text start:0x0210aa60 end:0x0210ab08
+
+src/func_ov006_0210ab08.c:
+    .text start:0x0210ab08 end:0x0210ab90
+
+src/func_ov006_0210ab90.c:
+    complete
+    .text start:0x0210ab90 end:0x0210ab94
+
+src/func_ov006_0210ab94.c:
+    complete
+    .text start:0x0210ab94 end:0x0210ac38
+
+src/func_ov006_0210ac38.c:
+    complete
+    .text start:0x0210ac38 end:0x0210ac3c
+
+src/func_ov006_0210ac3c.cpp:
+    complete
+    .text start:0x0210ac3c end:0x0210adac
+
+src/func_ov006_0210af64.c:
+    complete
+    .text start:0x0210af64 end:0x0210b1fc
+
+src/func_ov006_0210b1fc.c:
+    complete
+    .text start:0x0210b1fc end:0x0210b314
+
+src/func_ov006_0210b314.c:
+    .text start:0x0210b314 end:0x0210b648
+
+src/func_ov006_0210b648.c:
+    .text start:0x0210b648 end:0x0210bcb0
+
+src/func_ov006_0210bcb0.cpp:
+    .text start:0x0210bcb0 end:0x0210bdb0
+
+src/func_ov006_0210bdb0.cpp:
+    .text start:0x0210bdb0 end:0x0210c120
+
+src/func_ov006_0210c120.c:
+    complete
+    .text start:0x0210c120 end:0x0210c180
+
+src/func_ov006_0210c180.c:
+    complete
+    .text start:0x0210c180 end:0x0210c1a8
+
+src/func_ov006_0210c1a8.c:
+    complete
+    .text start:0x0210c1a8 end:0x0210c208
+
+src/func_ov006_0210c208.c:
+    complete
+    .text start:0x0210c208 end:0x0210c218
+
+src/func_ov006_0210c218.c:
+    complete
+    .text start:0x0210c218 end:0x0210c234
+
+src/func_ov006_0210c234.c:
+    complete
+    .text start:0x0210c234 end:0x0210c278
+
+src/func_ov006_0210c278.c:
+    complete
+    .text start:0x0210c278 end:0x0210c2b0
+
+src/func_ov006_0210c2b0.c:
+    complete
+    .text start:0x0210c2b0 end:0x0210c2c0
+
+src/func_ov006_0210c2c0.c:
+    complete
+    .text start:0x0210c2c0 end:0x0210c2d4
+
+src/func_ov006_0210c2d4.c:
+    .text start:0x0210c2d4 end:0x0210c354
+
+src/func_ov006_0210c354.c:
+    complete
+    .text start:0x0210c354 end:0x0210c374
+
+src/func_ov006_0210c374.cpp:
+    complete
+    .text start:0x0210c374 end:0x0210c410
+
+src/func_ov006_0210c410.c:
+    complete
+    .text start:0x0210c410 end:0x0210c478
+
+src/func_ov006_0210c478.c:
+    complete
+    .text start:0x0210c478 end:0x0210c4b8
+
+src/func_ov006_0210c4b8.c:
+    complete
+    .text start:0x0210c4b8 end:0x0210c4dc
+
+src/func_ov006_0210c4dc.c:
+    complete
+    .text start:0x0210c4dc end:0x0210c500
+
+src/func_ov006_0210c500.c:
+    complete
+    .text start:0x0210c500 end:0x0210c638
+
+src/func_ov006_0210c638.c:
+    complete
+    .text start:0x0210c638 end:0x0210c674
+
+src/func_ov006_0210c674.c:
+    complete
+    .text start:0x0210c674 end:0x0210c6c0
+
+src/_ZN3OAM7SECONDSE.cpp:
+    complete
+    .text start:0x0210c6c0 end:0x0210c9e0
+
+src/func_ov006_0210d1fc.cpp:
+    .text start:0x0210d1fc end:0x0210d6b8
+
+src/func_ov006_0210d6b8.cpp:
+    .text start:0x0210d6b8 end:0x0210d740
+
+src/func_ov006_0210d740.c:
+    complete
+    .text start:0x0210d740 end:0x0210d7e0
+
+src/func_ov006_0210d7e0.cpp:
+    .text start:0x0210d7e0 end:0x0210d894
+
+src/func_ov006_0210d894.c:
+    complete
+    .text start:0x0210d894 end:0x0210d898
+
+src/func_ov006_0210d898.c:
+    complete
+    .text start:0x0210d898 end:0x0210d8bc
+
+src/func_ov006_0210d8bc.c:
+    complete
+    .text start:0x0210d8bc end:0x0210d93c
+
+src/func_ov006_0210d93c.c:
+    complete
+    .text start:0x0210d93c end:0x0210dbb0
+
+src/func_ov006_0210dbb0.c:
+    complete
+    .text start:0x0210dbb0 end:0x0210ddf0
+
+src/func_ov006_0210ddf0.c:
+    complete
+    .text start:0x0210ddf0 end:0x0210e014
+
+src/func_ov006_0210e014.c:
+    complete
+    .text start:0x0210e014 end:0x0210e098
+
+src/func_ov006_0210e098.c:
+    complete
+    .text start:0x0210e098 end:0x0210e0d0
+
+src/func_ov006_0210e0d0.c:
+    complete
+    .text start:0x0210e0d0 end:0x0210e120
+
+src/func_ov006_0210e120.c:
+    complete
+    .text start:0x0210e120 end:0x0210e1fc
+
+src/func_ov006_0210e1fc.c:
+    complete
+    .text start:0x0210e1fc end:0x0210e364
+
+src/func_ov006_0210e364.c:
+    complete
+    .text start:0x0210e364 end:0x0210e3e8
+
+src/func_ov006_0210e3e8.c:
+    complete
+    .text start:0x0210e3e8 end:0x0210e460
+
+src/func_ov006_0210e460.c:
+    complete
+    .text start:0x0210e460 end:0x0210e480
+
+src/func_ov006_0210e480.c:
+    complete
+    .text start:0x0210e480 end:0x0210e4c8
+
+src/func_ov006_0210e4c8.c:
+    complete
+    .text start:0x0210e4c8 end:0x0210e4f4
+
+src/func_ov006_0210e4f4.c:
+    complete
+    .text start:0x0210e4f4 end:0x0210eca4
+
+src/func_ov006_0210eca4.c:
+    complete
+    .text start:0x0210eca4 end:0x0210ef48
+
+src/func_ov006_0210ef48.c:
+    complete
+    .text start:0x0210ef48 end:0x0210f564
+
+src/func_ov006_0210f914.c:
+    complete
+    .text start:0x0210f914 end:0x0210f998
+
+src/func_ov006_0210f998.c:
+    complete
+    .text start:0x0210f998 end:0x0210f9f8
+
+src/func_ov006_0210f9f8.c:
+    complete
+    .text start:0x0210f9f8 end:0x0210fa40
+
+src/func_ov006_0210fa40.c:
+    complete
+    .text start:0x0210fa40 end:0x0210fa6c
+
+src/func_ov006_0210fa6c.c:
+    complete
+    .text start:0x0210fa6c end:0x0210fb04
+
+src/func_ov006_0210fb04.c:
+    complete
+    .text start:0x0210fb04 end:0x0210fb58
+
+src/func_ov006_0210fb58.c:
+    complete
+    .text start:0x0210fb58 end:0x0210ff1c
+
+src/func_ov006_0210ff1c.c:
+    complete
+    .text start:0x0210ff1c end:0x021100a8
+
+src/func_ov006_021100a8.c:
+    complete
+    .text start:0x021100a8 end:0x02110154
+
+src/_ZN6Player7ST_WAITE.cpp:
+    complete
+    .text start:0x02110154 end:0x021101bc
+
+src/func_ov006_021101bc.cpp:
+    complete
+    .text start:0x021101bc end:0x02110244
+
+src/_ZN6Player6ST_OWLE.c:
+    complete
+    .text start:0x02110244 end:0x021104c0
+
+src/func_ov006_021104c0.c:
+    complete
+    .text start:0x021104c0 end:0x021106b4
+
+src/func_ov006_021106b4.c:
+    complete
+    .text start:0x021106b4 end:0x02110850
+
+src/func_ov006_02110850.c:
+    complete
+    .text start:0x02110850 end:0x02110874
+
+src/func_ov006_02110874.c:
+    complete
+    .text start:0x02110874 end:0x021108bc
+
+src/func_ov006_021108bc.c:
+    complete
+    .text start:0x021108bc end:0x02110928
+
+src/func_ov006_02110928.c:
+    complete
+    .text start:0x02110928 end:0x02110a20
+
+src/func_ov006_02110a20.c:
+    complete
+    .text start:0x02110a20 end:0x02110bb4
+
+src/func_ov006_02110bb4.c:
+    complete
+    .text start:0x02110bb4 end:0x02110bc0
+
+src/func_ov006_02110bc0.c:
+    complete
+    .text start:0x02110bc0 end:0x02110c08
+
+src/func_ov006_02110c08.c:
+    complete
+    .text start:0x02110c08 end:0x02110e28
+
+src/func_ov006_02110e28.c:
+    complete
+    .text start:0x02110e28 end:0x0211102c
+
+src/func_ov006_0211102c.c:
+    complete
+    .text start:0x0211102c end:0x02111144
+
+src/START_INTRO_MINIMAP_ZOOM.c:
+    complete
+    .text start:0x02111144 end:0x021111f0
+
+src/func_ov006_021111f0.c:
+    complete
+    .text start:0x021111f0 end:0x02111220
+
+src/func_ov006_02111220.c:
+    complete
+    .text start:0x02111220 end:0x02111268
+
+src/func_ov006_02111268.c:
+    complete
+    .text start:0x02111268 end:0x0211134c
+
+src/func_ov006_0211134c.c:
+    complete
+    .text start:0x0211134c end:0x02111560
+
+src/func_ov006_02111560.c:
+    complete
+    .text start:0x02111560 end:0x0211157c
+
+src/func_ov006_0211157c.c:
+    complete
+    .text start:0x0211157c end:0x021115c4
+
+src/func_ov006_021115c4.c:
+    complete
+    .text start:0x021115c4 end:0x021115cc
+
+src/func_ov006_021115cc.c:
+    complete
+    .text start:0x021115cc end:0x02111654
+
+src/func_ov006_02111654.c:
+    complete
+    .text start:0x02111654 end:0x021116f0
+
+src/func_ov006_021116f0.c:
+    complete
+    .text start:0x021116f0 end:0x02111750
+
+src/func_ov006_02111750.c:
+    complete
+    .text start:0x02111750 end:0x02111774
+
+src/func_ov006_02111774.c:
+    complete
+    .text start:0x02111774 end:0x021117bc
+
+src/func_ov006_021117bc.c:
+    complete
+    .text start:0x021117bc end:0x0211192c
+
+src/func_ov006_0211192c.c:
+    complete
+    .text start:0x0211192c end:0x02111b20
+
+src/func_ov006_02111b20.c:
+    complete
+    .text start:0x02111b20 end:0x02111b40
+
+src/func_ov006_02111b40.c:
+    complete
+    .text start:0x02111b40 end:0x02111b90
+
+src/func_ov006_02111b90.c:
+    complete
+    .text start:0x02111b90 end:0x02111d4c
+
+src/func_ov006_02111d4c.c:
+    complete
+    .text start:0x02111d4c end:0x02111d6c
+
+src/func_ov006_02111d6c.c:
+    complete
+    .text start:0x02111d6c end:0x02111d74
+
+src/func_ov006_02111d74.c:
+    complete
+    .text start:0x02111d74 end:0x02111dcc
+
+src/func_ov006_02111dcc.c:
+    complete
+    .text start:0x02111dcc end:0x02111df4
+
+src/func_ov006_02111df4.c:
+    complete
+    .text start:0x02111df4 end:0x02111e48
+
+src/func_ov006_02111e48.c:
+    complete
+    .text start:0x02111e48 end:0x02111e7c
+
+src/func_ov006_02111e7c.c:
+    complete
+    .text start:0x02111e7c end:0x02111e90
+
+src/func_ov006_02111e90.c:
+    complete
+    .text start:0x02111e90 end:0x02111ee8
+
+src/func_ov006_02111ee8.c:
+    complete
+    .text start:0x02111ee8 end:0x02111f8c
+
+src/func_ov006_02111f8c.cpp:
+    complete
+    .text start:0x02111f8c end:0x02112030
+
+src/func_ov006_02112030.c:
+    complete
+    .text start:0x02112030 end:0x021120d4
+
+src/func_ov006_021120d4.c:
+    complete
+    .text start:0x021120d4 end:0x02112190
+
+src/func_ov006_02112190.c:
+    complete
+    .text start:0x02112190 end:0x021122e0
+
+src/func_ov006_021122e0.c:
+    complete
+    .text start:0x021122e0 end:0x0211248c
+
+src/func_ov006_0211248c.c:
+    complete
+    .text start:0x0211248c end:0x02112504
+
+src/func_ov006_02112504.c:
+    complete
+    .text start:0x02112504 end:0x021126b4
+
+src/func_ov006_021126b4.c:
+    complete
+    .text start:0x021126b4 end:0x021128fc
+
+src/func_ov006_02112ad8.c:
+    .text start:0x02112ad8 end:0x02113c14
+
+src/func_ov006_02113c14.c:
+    complete
+    .text start:0x02113c14 end:0x02113e54
+
+src/func_ov006_02113e54.c:
+    complete
+    .text start:0x02113e54 end:0x02113f1c
+
+src/func_ov006_02113f1c.c:
+    complete
+    .text start:0x02113f1c end:0x02114458
+
+src/func_ov006_02114458.c:
+    complete
+    .text start:0x02114458 end:0x02114548
+
+src/func_ov006_02114548.c:
+    complete
+    .text start:0x02114548 end:0x02114590
+
+src/func_ov006_02114590.c:
+    complete
+    .text start:0x02114590 end:0x021146ac
+
+src/func_ov006_021146ac.c:
+    complete
+    .text start:0x021146ac end:0x021146cc
+
+src/func_ov006_021146cc.c:
+    complete
+    .text start:0x021146cc end:0x021146e0
+
+src/func_ov006_021146e0.c:
+    complete
+    .text start:0x021146e0 end:0x021146f4
+
+src/func_ov006_021146f4.c:
+    complete
+    .text start:0x021146f4 end:0x0211470c
+
+src/func_ov006_0211470c.c:
+    complete
+    .text start:0x0211470c end:0x02114720
+
+src/func_ov006_02114720.c:
+    complete
+    .text start:0x02114720 end:0x02114724
+
+src/func_ov006_02114724.c:
+    complete
+    .text start:0x02114724 end:0x02114738
+
+src/func_ov006_02114738.c:
+    complete
+    .text start:0x02114738 end:0x0211474c
+
+src/func_ov006_0211474c.c:
+    complete
+    .text start:0x0211474c end:0x021147ac
+
+src/func_ov006_021147ac.c:
+    complete
+    .text start:0x021147ac end:0x021147d0
+
+src/func_ov006_021147d0.c:
+    complete
+    .text start:0x021147d0 end:0x02114800
+
+src/func_ov006_02114b10.c:
+    complete
+    .text start:0x02114b10 end:0x02114c04
+
+src/func_ov006_02114c04.c:
+    complete
+    .text start:0x02114c04 end:0x02114dd0
+
+src/func_ov006_02114dd0.c:
+    complete
+    .text start:0x02114dd0 end:0x02114dfc
+
+src/func_ov006_02114dfc.c:
+    complete
+    .text start:0x02114dfc end:0x02114ec0
+
+src/func_ov006_02114ec0.c:
+    complete
+    .text start:0x02114ec0 end:0x02114f98
+
+src/func_ov006_02114f98.c:
+    complete
+    .text start:0x02114f98 end:0x02114fb4
+
+src/func_ov006_02114fb4.c:
+    complete
+    .text start:0x02114fb4 end:0x02114fd0
+
+src/func_ov006_02114fd0.c:
+    complete
+    .text start:0x02114fd0 end:0x02114fec
+
+src/func_ov006_02114fec.c:
+    complete
+    .text start:0x02114fec end:0x02115008
+
+src/func_ov006_02115008.c:
+    complete
+    .text start:0x02115008 end:0x02115024
+
+src/func_ov006_02115024.c:
+    complete
+    .text start:0x02115024 end:0x02115040
+
+src/func_ov006_02115040.c:
+    complete
+    .text start:0x02115040 end:0x02115060
+
+src/func_ov006_02115060.c:
+    complete
+    .text start:0x02115060 end:0x0211507c
+
+src/func_ov006_0211507c.c:
+    complete
+    .text start:0x0211507c end:0x02115150
+
+src/func_ov006_02115150.c:
+    complete
+    .text start:0x02115150 end:0x02115248
+
+src/func_ov006_02115480.c:
+    complete
+    .text start:0x02115480 end:0x02115598
+
+src/func_ov006_02115598.cpp:
+    complete
+    .text start:0x02115598 end:0x02115680
+
+src/func_ov006_02115680.c:
+    complete
+    .text start:0x02115680 end:0x021156f8
+
+src/func_ov006_021156f8.c:
+    complete
+    .text start:0x021156f8 end:0x02115830
+
+src/func_ov006_02115830.c:
+    complete
+    .text start:0x02115830 end:0x02115a5c
+
+src/func_ov006_02115a5c.c:
+    complete
+    .text start:0x02115a5c end:0x02115b0c
+
+src/func_ov006_02115b0c.c:
+    .text start:0x02115b0c end:0x021173c8
+
+src/func_ov006_02118488.c:
+    .text start:0x02118488 end:0x02118a8c
+
+src/func_ov006_02118a8c.cpp:
+    complete
+    .text start:0x02118a8c end:0x02118ae4
+
+src/func_ov006_02118ae4.c:
+    complete
+    .text start:0x02118ae4 end:0x02118b70
+
+src/func_ov006_0211944c.c:
+    complete
+    .text start:0x0211944c end:0x02119824
+
+src/MgBingoBallSlotsShot_Spawn.cpp:
+    complete
+    .text start:0x02119824 end:0x02119900
+
+src/func_ov006_02119900.c:
+    complete
+    .text start:0x02119900 end:0x02119904
+
+src/func_ov006_02119904.cpp:
+    .text start:0x02119904 end:0x02119958
+
+src/func_ov006_02119958.cpp:
+    .text start:0x02119958 end:0x021199c0
+
+src/func_ov006_021199c0.c:
+    complete
+    .text start:0x021199c0 end:0x02119a18
+
+src/func_ov006_02119a18.c:
+    complete
+    .text start:0x02119a18 end:0x02119a88
+
+src/func_ov006_02119a88.c:
+    complete
+    .text start:0x02119a88 end:0x02119aa8
+
+src/func_ov006_02119aa8.c:
+    complete
+    .text start:0x02119aa8 end:0x02119b00
+
+src/func_ov006_02119b00.c:
+    complete
+    .text start:0x02119b00 end:0x02119ba4
+
+src/func_ov006_02119ba4.c:
+    complete
+    .text start:0x02119ba4 end:0x02119bc4
+
+src/func_ov006_02119bc4.c:
+    complete
+    .text start:0x02119bc4 end:0x02119bdc
+
+src/func_ov006_02119bdc.cpp:
+    complete
+    .text start:0x02119bdc end:0x02119c74
+
+src/func_ov006_02119c74.c:
+    complete
+    .text start:0x02119c74 end:0x02119d50
+
+src/func_ov006_02119d50.c:
+    complete
+    .text start:0x02119d50 end:0x02119dc4
+
+src/func_ov006_02119dc4.c:
+    complete
+    .text start:0x02119dc4 end:0x02119e5c
+
+src/func_ov006_02119e5c.c:
+    complete
+    .text start:0x02119e5c end:0x02119eec
+
+src/func_ov006_02119eec.cpp:
+    complete
+    .text start:0x02119eec end:0x02119f3c
+
+src/func_ov006_02119f3c.c:
+    complete
+    .text start:0x02119f3c end:0x02119fb0
+
+src/func_ov006_02119fb0.c:
+    complete
+    .text start:0x02119fb0 end:0x0211a048
+
+src/func_ov006_0211a048.c:
+    complete
+    .text start:0x0211a048 end:0x0211a0d8
+
+src/func_ov006_0211a0d8.cpp:
+    complete
+    .text start:0x0211a0d8 end:0x0211a128
+
+src/func_ov006_0211a128.c:
+    complete
+    .text start:0x0211a128 end:0x0211a19c
+
+src/func_ov006_0211a19c.c:
+    complete
+    .text start:0x0211a19c end:0x0211a234
+
+src/func_ov006_0211a234.c:
+    complete
+    .text start:0x0211a234 end:0x0211a2c4
+
+src/func_ov006_0211a2c4.cpp:
+    complete
+    .text start:0x0211a2c4 end:0x0211a314
+
+src/func_ov006_0211a314.c:
+    complete
+    .text start:0x0211a314 end:0x0211a388
+
+src/func_ov006_0211a388.c:
+    complete
+    .text start:0x0211a388 end:0x0211a420
+
+src/func_ov006_0211a420.c:
+    complete
+    .text start:0x0211a420 end:0x0211a4b0
+
+src/func_ov006_0211a4b0.cpp:
+    complete
+    .text start:0x0211a4b0 end:0x0211a500
+
+src/func_ov006_0211a500.c:
+    complete
+    .text start:0x0211a500 end:0x0211a578
+
+src/func_ov006_0211a578.c:
+    complete
+    .text start:0x0211a578 end:0x0211a5ec
+
+src/func_ov006_0211a5ec.c:
+    complete
+    .text start:0x0211a5ec end:0x0211a648
+
+src/func_ov006_0211a648.cpp:
+    complete
+    .text start:0x0211a648 end:0x0211a698
+
+src/func_ov006_0211a698.c:
+    complete
+    .text start:0x0211a698 end:0x0211a69c
+
+src/func_ov006_0211a69c.c:
+    complete
+    .text start:0x0211a69c end:0x0211a714
+
+src/func_ov006_0211a714.c:
+    complete
+    .text start:0x0211a714 end:0x0211a7ac
+
+src/func_ov006_0211a7ac.cpp:
+    complete
+    .text start:0x0211a7ac end:0x0211a7fc
+
+src/func_ov006_0211a7fc.c:
+    complete
+    .text start:0x0211a7fc end:0x0211a910
+
+src/func_ov006_0211a910.c:
+    complete
+    .text start:0x0211a910 end:0x0211a9fc
+
+src/func_ov006_0211a9fc.c:
+    complete
+    .text start:0x0211a9fc end:0x0211aa44
+
+src/func_ov006_0211aa44.cpp:
+    complete
+    .text start:0x0211aa44 end:0x0211aa94
+
+src/func_ov006_0211aa94.c:
+    complete
+    .text start:0x0211aa94 end:0x0211ab0c
+
+src/func_ov006_0211ab0c.c:
+    complete
+    .text start:0x0211ab0c end:0x0211ab80
+
+src/func_ov006_0211ab80.c:
+    complete
+    .text start:0x0211ab80 end:0x0211abdc
+
+src/func_ov006_0211abdc.cpp:
+    complete
+    .text start:0x0211abdc end:0x0211ac2c
+
+src/func_ov006_0211ac2c.c:
+    complete
+    .text start:0x0211ac2c end:0x0211ac30
+
+src/func_ov006_0211ac30.c:
+    complete
+    .text start:0x0211ac30 end:0x0211ad00
+
+src/func_ov006_0211ad00.c:
+    complete
+    .text start:0x0211ad00 end:0x0211ad44
+
+src/func_ov006_0211ad44.cpp:
+    complete
+    .text start:0x0211ad44 end:0x0211ad94
+
+src/func_ov006_0211ad94.c:
+    complete
+    .text start:0x0211ad94 end:0x0211ae40
+
+src/func_ov006_0211ae40.c:
+    complete
+    .text start:0x0211ae40 end:0x0211aed0
+
+src/func_ov006_0211aed0.c:
+    complete
+    .text start:0x0211aed0 end:0x0211af60
+
+src/func_ov006_0211af60.cpp:
+    complete
+    .text start:0x0211af60 end:0x0211afb0
+
+src/func_ov006_0211afb0.c:
+    complete
+    .text start:0x0211afb0 end:0x0211b05c
+
+src/func_ov006_0211b05c.c:
+    complete
+    .text start:0x0211b05c end:0x0211b0ec
+
+src/func_ov006_0211b0ec.c:
+    complete
+    .text start:0x0211b0ec end:0x0211b17c
+
+src/func_ov006_0211b17c.cpp:
+    complete
+    .text start:0x0211b17c end:0x0211b1cc
+
+src/func_ov006_0211b1cc.c:
+    complete
+    .text start:0x0211b1cc end:0x0211b278
+
+src/func_ov006_0211b278.c:
+    complete
+    .text start:0x0211b278 end:0x0211b308
+
+src/func_ov006_0211b308.c:
+    complete
+    .text start:0x0211b308 end:0x0211b398
+
+src/func_ov006_0211b398.cpp:
+    complete
+    .text start:0x0211b398 end:0x0211b3e8
+
+src/func_ov006_0211b3e8.c:
+    complete
+    .text start:0x0211b3e8 end:0x0211b3ec
+
+src/func_ov006_0211b3ec.c:
+    complete
+    .text start:0x0211b3ec end:0x0211b4fc
+
+src/func_ov006_0211b4fc.c:
+    complete
+    .text start:0x0211b4fc end:0x0211b590
+
+src/func_ov006_0211b590.cpp:
+    complete
+    .text start:0x0211b590 end:0x0211b5e0
+
+src/func_ov006_0211b5e0.cpp:
+    complete
+    .text start:0x0211b5e0 end:0x0211b654
+
+src/func_ov006_0211b654.c:
+    complete
+    .text start:0x0211b654 end:0x0211b790
+
+src/func_ov006_0211b790.c:
+    complete
+    .text start:0x0211b790 end:0x0211b80c
+
+src/func_ov006_0211b80c.c:
+    complete
+    .text start:0x0211b80c end:0x0211b954
+
+src/func_ov006_0211b954.cpp:
+    complete
+    .text start:0x0211b954 end:0x0211b9c8
+
+src/func_ov006_0211b9c8.cpp:
+    complete
+    .text start:0x0211b9c8 end:0x0211ba88
+
+src/func_ov006_0211bbe0.c:
+    complete
+    .text start:0x0211bbe0 end:0x0211bc68
+
+src/func_ov006_0211bc68.c:
+    complete
+    .text start:0x0211bc68 end:0x0211bc8c
+
+src/func_ov006_0211bf44.c:
+    complete
+    .text start:0x0211bf44 end:0x0211c080
+
+src/func_ov006_0211c080.c:
+    complete
+    .text start:0x0211c080 end:0x0211c478
+
+src/func_ov006_0211c478.c:
+    complete
+    .text start:0x0211c478 end:0x0211c5b8
+
+src/func_ov006_0211c5b8.c:
+    complete
+    .text start:0x0211c5b8 end:0x0211c5d0
+
+src/func_ov006_0211c5d0.c:
+    .text start:0x0211c5d0 end:0x0211c6c4
+
+src/func_ov006_0211c6c4.c:
+    complete
+    .text start:0x0211c6c4 end:0x0211c720
+
+src/func_ov006_0211c720.c:
+    complete
+    .text start:0x0211c720 end:0x0211c984
+
+src/func_ov006_0211c984.c:
+    complete
+    .text start:0x0211c984 end:0x0211cb70
+
+src/MgBoomBox_Spawn.cpp:
+    complete
+    .text start:0x0211cb70 end:0x0211cbd0
+
+src/func_ov006_0211cbd0.c:
+    complete
+    .text start:0x0211cbd0 end:0x0211cbf4
+
+src/func_ov006_0211cbf4.c:
+    .text start:0x0211cbf4 end:0x0211cc2c
+
+src/func_ov006_0211cc2c.c:
+    complete
+    .text start:0x0211cc2c end:0x0211cc90
+
+src/func_ov006_0211cc90.c:
+    complete
+    .text start:0x0211cc90 end:0x0211cca8
+
+src/func_ov006_0211cca8.c:
+    complete
+    .text start:0x0211cca8 end:0x0211cd24
+
+src/func_ov006_0211cd24.c:
+    complete
+    .text start:0x0211cd24 end:0x0211ce90
+
+src/func_ov006_0211ce90.c:
+    complete
+    .text start:0x0211ce90 end:0x0211ce94
+
+src/func_ov006_0211ce94.c:
+    complete
+    .text start:0x0211ce94 end:0x0211cef4
+
+src/func_ov006_0211cef4.c:
+    complete
+    .text start:0x0211cef4 end:0x0211d018
+
+src/func_ov006_0211d018.c:
+    complete
+    .text start:0x0211d018 end:0x0211d0f8
+
+src/func_ov006_0211d0f8.c:
+    complete
+    .text start:0x0211d0f8 end:0x0211d224
+
+src/func_ov006_0211d224.c:
+    complete
+    .text start:0x0211d224 end:0x0211d368
+
+src/func_ov006_0211d368.c:
+    complete
+    .text start:0x0211d368 end:0x0211d4e8
+
+src/func_ov006_0211d4e8.c:
+    complete
+    .text start:0x0211d4e8 end:0x0211d5a8
+
+src/func_ov006_0211d5a8.cpp:
+    complete
+    .text start:0x0211d5a8 end:0x0211d608
+
+src/func_ov006_0211d608.c:
+    complete
+    .text start:0x0211d608 end:0x0211d688
+
+src/func_ov006_0211d688.c:
+    complete
+    .text start:0x0211d688 end:0x0211d69c
+
+src/func_ov006_0211d69c.c:
+    complete
+    .text start:0x0211d69c end:0x0211d75c
+
+src/func_ov006_0211d75c.c:
+    complete
+    .text start:0x0211d75c end:0x0211d7b0
+
+src/func_ov006_0211d7b0.c:
+    complete
+    .text start:0x0211d7b0 end:0x0211d7b4
+
+src/func_ov006_0211d7b4.c:
+    complete
+    .text start:0x0211d7b4 end:0x0211d7d8
+
+src/func_ov006_0211d7d8.c:
+    complete
+    .text start:0x0211d7d8 end:0x0211d7ec
+
+src/func_ov006_0211d7ec.c:
+    complete
+    .text start:0x0211d7ec end:0x0211d86c
+
+src/func_ov006_0211d86c.cpp:
+    complete
+    .text start:0x0211d86c end:0x0211d924
+
+src/func_ov006_0211d924.c:
+    complete
+    .text start:0x0211d924 end:0x0211dad0
+
+src/func_ov006_0211dad0.c:
+    complete
+    .text start:0x0211dad0 end:0x0211db7c
+
+src/func_ov006_0211db7c.c:
+    complete
+    .text start:0x0211db7c end:0x0211dce0
+
+src/func_ov006_0211dce0.c:
+    complete
+    .text start:0x0211dce0 end:0x0211dd0c
+
+src/func_ov006_0211dd0c.cpp:
+    complete
+    .text start:0x0211dd0c end:0x0211dd6c
+
+src/func_ov006_0211dd6c.c:
+    complete
+    .text start:0x0211dd6c end:0x0211ddb8
+
+src/func_ov006_0211ddb8.c:
+    complete
+    .text start:0x0211ddb8 end:0x0211ddcc
+
+src/func_ov006_0211ddcc.c:
+    complete
+    .text start:0x0211ddcc end:0x0211de54
+
+src/func_ov006_0211de54.c:
+    complete
+    .text start:0x0211de54 end:0x0211de7c
+
+src/func_ov006_0211de7c.c:
+    complete
+    .text start:0x0211de7c end:0x0211dec0
+
+src/func_ov006_0211dec0.c:
+    complete
+    .text start:0x0211dec0 end:0x0211e020
+
+src/func_ov006_0211e020.c:
+    complete
+    .text start:0x0211e020 end:0x0211e0c8
+
+src/func_ov006_0211e0c8.cpp:
+    complete
+    .text start:0x0211e0c8 end:0x0211e118
+
+src/func_ov006_0211e118.c:
+    complete
+    .text start:0x0211e118 end:0x0211e184
+
+src/func_ov006_0211e184.c:
+    complete
+    .text start:0x0211e184 end:0x0211e220
+
+src/func_ov006_0211e220.c:
+    complete
+    .text start:0x0211e220 end:0x0211e29c
+
+src/func_ov006_0211e29c.c:
+    complete
+    .text start:0x0211e29c end:0x0211e318
+
+src/func_ov006_0211e318.c:
+    complete
+    .text start:0x0211e318 end:0x0211e3e0
+
+src/func_ov006_0211e3e0.c:
+    complete
+    .text start:0x0211e3e0 end:0x0211e460
+
+src/func_ov006_0211e460.c:
+    complete
+    .text start:0x0211e460 end:0x0211e4e0
+
+src/func_ov006_0211e4e0.c:
+    complete
+    .text start:0x0211e4e0 end:0x0211e55c
+
+src/func_ov006_0211e55c.c:
+    complete
+    .text start:0x0211e55c end:0x0211e5cc
+
+src/func_ov006_0211e5cc.c:
+    complete
+    .text start:0x0211e5cc end:0x0211e658
+
+src/func_ov006_0211e658.c:
+    complete
+    .text start:0x0211e658 end:0x0211e72c
+
+src/func_ov006_0211e7d8.c:
+    complete
+    .text start:0x0211e7d8 end:0x0211e8a8
+
+src/func_ov006_0211e8a8.c:
+    complete
+    .text start:0x0211e8a8 end:0x0211ea70
+
+src/func_ov006_0211eb90.c:
+    complete
+    .text start:0x0211eb90 end:0x0211ebdc
+
+src/func_ov006_0211ee34.c:
+    complete
+    .text start:0x0211ee34 end:0x0211f040
+
+src/func_ov006_0211f040.cpp:
+    complete
+    .text start:0x0211f040 end:0x0211f0d0
+
+src/func_ov006_0211f0d0.c:
+    complete
+    .text start:0x0211f0d0 end:0x0211f1a4
+
+src/func_ov006_0211f1a4.c:
+    complete
+    .text start:0x0211f1a4 end:0x0211f224
+
+src/func_ov006_0211f224.c:
+    complete
+    .text start:0x0211f224 end:0x0211f34c
+
+src/func_ov006_0211f34c.c:
+    complete
+    .text start:0x0211f34c end:0x0211f454
+
+src/func_ov006_0211f454.c:
+    complete
+    .text start:0x0211f454 end:0x0211f51c
+
+src/func_ov006_0211f51c.c:
+    complete
+    .text start:0x0211f51c end:0x0211f554
+
+src/func_ov006_0211f554.c:
+    complete
+    .text start:0x0211f554 end:0x0211f5d4
+
+src/func_ov006_0211f5d4.c:
+    complete
+    .text start:0x0211f5d4 end:0x0211f664
+
+src/func_ov006_0211f664.c:
+    complete
+    .text start:0x0211f664 end:0x0211f6fc
+
+src/func_ov006_0211f6fc.cpp:
+    complete
+    .text start:0x0211f6fc end:0x0211f77c
+
+src/func_ov006_0211f77c.c:
+    .text start:0x0211f77c end:0x0211f9fc
+
+src/func_ov006_0211fb1c.c:
+    complete
+    .text start:0x0211fb1c end:0x0211fbf8
+
+src/func_ov006_0211fbf8.c:
+    complete
+    .text start:0x0211fbf8 end:0x0211fd44
+
+src/func_ov006_0211fd44.c:
+    .text start:0x0211fd44 end:0x0211fe78
+
+src/func_ov006_0211fe78.c:
+    complete
+    .text start:0x0211fe78 end:0x02120008
+
+src/func_ov006_02120008.c:
+    complete
+    .text start:0x02120008 end:0x021200a8
+
+src/func_ov006_021200a8.c:
+    complete
+    .text start:0x021200a8 end:0x021200cc
+
+src/func_ov006_021200cc.c:
+    complete
+    .text start:0x021200cc end:0x021200dc
+
+src/func_ov006_021200dc.c:
+    .text start:0x021200dc end:0x02120238
+
+src/func_ov006_02120238.c:
+    complete
+    .text start:0x02120238 end:0x02120248
+
+src/func_ov006_02120248.cpp:
+    .text start:0x02120248 end:0x02120348
+
+src/func_ov006_02120348.c:
+    complete
+    .text start:0x02120348 end:0x021203ac
+
+src/func_ov006_021203ac.cpp:
+    complete
+    .text start:0x021203ac end:0x021203fc
+
+src/func_ov006_021203fc.c:
+    .text start:0x021203fc end:0x021207a8
+
+src/MgHideAndBooSeek_Spawn.c:
+    .text start:0x021207a8 end:0x021207dc
+
+src/func_ov006_021207dc.c:
+    complete
+    .text start:0x021207dc end:0x02120880
+
+src/func_ov006_02120880.cpp:
+    .text start:0x02120880 end:0x02120938
+
+src/func_ov006_02120938.c:
+    complete
+    .text start:0x02120938 end:0x0212093c
+
+src/func_ov006_0212093c.c:
+    complete
+    .text start:0x0212093c end:0x021209ac
+
+src/func_ov006_021209ac.cpp:
+    complete
+    .text start:0x021209ac end:0x02120a18
+
+src/func_ov006_02120a18.c:
+    complete
+    .text start:0x02120a18 end:0x02120a44
+
+src/func_ov006_02120a44.c:
+    complete
+    .text start:0x02120a44 end:0x02120a54
+
+src/func_ov006_02120a54.c:
+    complete
+    .text start:0x02120a54 end:0x02120a64
+
+src/func_ov006_02120a64.c:
+    complete
+    .text start:0x02120a64 end:0x02120ab8
+
+src/func_ov006_02120ab8.c:
+    complete
+    .text start:0x02120ab8 end:0x02120b30
+
+src/func_ov006_02120b30.c:
+    complete
+    .text start:0x02120b30 end:0x02120b7c
+
+src/func_ov006_02120b7c.c:
+    complete
+    .text start:0x02120b7c end:0x02120bc8
+
+src/func_ov006_02120bc8.c:
+    complete
+    .text start:0x02120bc8 end:0x02120c08
+
+src/func_ov006_02120c08.c:
+    complete
+    .text start:0x02120c08 end:0x02120c40
+
+src/func_ov006_02120c40.c:
+    complete
+    .text start:0x02120c40 end:0x02120ca0
+
+src/func_ov006_02120ca0.c:
+    complete
+    .text start:0x02120ca0 end:0x02120d0c
+
+src/func_ov006_02120d0c.c:
+    complete
+    .text start:0x02120d0c end:0x02120d8c
+
+src/func_ov006_02120d8c.c:
+    complete
+    .text start:0x02120d8c end:0x02120da8
+
+src/func_ov006_02120da8.c:
+    complete
+    .text start:0x02120da8 end:0x02120f18
+
+src/func_ov006_02120f18.c:
+    complete
+    .text start:0x02120f18 end:0x0212101c
+
+src/func_ov006_0212101c.c:
+    complete
+    .text start:0x0212101c end:0x021211bc
+
+src/func_ov006_021211bc.c:
+    complete
+    .text start:0x021211bc end:0x021211e0
+
+src/func_ov006_021211e0.cpp:
+    complete
+    .text start:0x021211e0 end:0x021212e0
+
+src/func_ov006_021212e0.c:
+    complete
+    .text start:0x021212e0 end:0x021212fc
+
+src/func_ov006_021212fc.c:
+    .text start:0x021212fc end:0x021214f8
+
+src/func_ov006_021214f8.cpp:
+    .text start:0x021214f8 end:0x0212157c
+
+src/func_ov006_0212157c.c:
+    complete
+    .text start:0x0212157c end:0x02121750
+
+src/func_ov006_02121750.c:
+    complete
+    .text start:0x02121750 end:0x02121768
+
+src/func_ov006_02121768.c:
+    complete
+    .text start:0x02121768 end:0x02121774
+
+src/func_ov006_02121774.c:
+    complete
+    .text start:0x02121774 end:0x02121778
+
+src/func_ov006_02121778.c:
+    .text start:0x02121778 end:0x02121848
+
+src/func_ov006_02121848.c:
+    complete
+    .text start:0x02121848 end:0x021218c4
+
+src/func_ov006_021218c4.c:
+    complete
+    .text start:0x021218c4 end:0x021218fc
+
+src/func_ov006_021218fc.c:
+    complete
+    .text start:0x021218fc end:0x02121bc8
+
+src/func_ov006_02121bc8.cpp:
+    complete
+    .text start:0x02121bc8 end:0x02121cf4
+
+src/func_ov006_02121cf4.c:
+    complete
+    .text start:0x02121cf4 end:0x02121d64
+
+src/func_ov006_02121d64.cpp:
+    complete
+    .text start:0x02121d64 end:0x02121f04
+
+src/func_ov006_02121f04.c:
+    complete
+    .text start:0x02121f04 end:0x02121f70
+
+src/func_ov006_02121f70.c:
+    complete
+    .text start:0x02121f70 end:0x02121fa4
+
+src/func_ov006_02121fa4.c:
+    complete
+    .text start:0x02121fa4 end:0x02122198
+
+src/func_ov006_02122198.cpp:
+    .text start:0x02122198 end:0x0212231c
+
+src/func_ov006_0212231c.c:
+    complete
+    .text start:0x0212231c end:0x02122490
+
+src/MgTrampolineTime_Spawn.c:
+    complete
+    .text start:0x02122490 end:0x021225a8
+
+src/func_ov006_021225a8.c:
+    complete
+    .text start:0x021225a8 end:0x021225ac
+
+src/func_ov006_021225ac.c:
+    complete
+    .text start:0x021225ac end:0x021226b0
+
+src/func_ov006_021226b0.cpp:
+    .text start:0x021226b0 end:0x021227c8
+
+src/func_ov006_021227c8.cpp:
+    complete
+    .text start:0x021227c8 end:0x02122814
+
+src/func_ov006_02122814.cpp:
+    complete
+    .text start:0x02122814 end:0x0212287c
+
+src/func_ov006_0212287c.c:
+    complete
+    .text start:0x0212287c end:0x021228bc
+
+src/func_ov006_021228bc.cpp:
+    complete
+    .text start:0x021228bc end:0x02122a1c
+
+src/func_ov006_02122a1c.cpp:
+    complete
+    .text start:0x02122a1c end:0x02122a4c
+
+src/func_ov006_02122a4c.c:
+    complete
+    .text start:0x02122a4c end:0x02122ab8
+
+src/func_ov006_02122ab8.c:
+    complete
+    .text start:0x02122ab8 end:0x02122b24
+
+src/func_ov006_02122b24.c:
+    complete
+    .text start:0x02122b24 end:0x02122b88
+
+src/func_ov006_02122b88.c:
+    complete
+    .text start:0x02122b88 end:0x02122c04
+
+src/func_ov006_02122c04.c:
+    complete
+    .text start:0x02122c04 end:0x02122c68
+
+src/func_ov006_02122c68.cpp:
+    complete
+    .text start:0x02122c68 end:0x02122c90
+
+src/func_ov006_02122c90.c:
+    complete
+    .text start:0x02122c90 end:0x02122cb0
+
+src/func_ov006_02122cb0.c:
+    complete
+    .text start:0x02122cb0 end:0x02122e20
+
+src/func_ov006_02122e20.c:
+    complete
+    .text start:0x02122e20 end:0x02122f24
+
+src/func_ov006_02122f24.c:
+    complete
+    .text start:0x02122f24 end:0x021230c4
+
+src/func_ov006_021230c4.c:
+    complete
+    .text start:0x021230c4 end:0x021230e8
+
+src/func_ov006_021230e8.c:
+    complete
+    .text start:0x021230e8 end:0x0212318c
+
+src/func_ov006_0212318c.c:
+    complete
+    .text start:0x0212318c end:0x021231ac
+
+src/func_ov006_021231ac.c:
+    complete
+    .text start:0x021231ac end:0x02123340
+
+src/func_ov006_02123340.cpp:
+    .text start:0x02123340 end:0x02123428
+
+src/func_ov006_0212373c.c:
+    complete
+    .text start:0x0212373c end:0x021237c8
+
+src/func_ov006_021237c8.c:
+    complete
+    .text start:0x021237c8 end:0x0212382c
+
+src/func_ov006_0212382c.c:
+    complete
+    .text start:0x0212382c end:0x021238d0
+
+src/func_ov006_021238d0.c:
+    complete
+    .text start:0x021238d0 end:0x02123938
+
+src/func_ov006_02123b20.c:
+    complete
+    .text start:0x02123b20 end:0x02123b24
+
+src/func_ov006_02123b24.c:
+    .text start:0x02123b24 end:0x02123bf4
+
+src/func_ov006_02123bf4.cpp:
+    complete
+    .text start:0x02123bf4 end:0x02123c78
+
+src/func_ov006_02123c78.c:
+    complete
+    .text start:0x02123c78 end:0x02123cb4
+
+src/func_ov006_02124040.c:
+    complete
+    .text start:0x02124040 end:0x02124088
+
+src/func_ov006_02124088.c:
+    complete
+    .text start:0x02124088 end:0x02124228
+
+src/func_ov006_02124228.c:
+    complete
+    .text start:0x02124228 end:0x02124298
+
+src/func_ov006_02124298.c:
+    complete
+    .text start:0x02124298 end:0x021242cc
+
+src/func_ov006_021242cc.cpp:
+    .text start:0x021242cc end:0x021243ec
+
+src/func_ov006_021243ec.cpp:
+    .text start:0x021243ec end:0x021245a8
+
+src/func_ov006_021245a8.c:
+    complete
+    .text start:0x021245a8 end:0x0212471c
+
+src/func_ov006_021248a8.cpp:
+    .text start:0x021248a8 end:0x02124908
+
+src/func_ov006_02124908.c:
+    complete
+    .text start:0x02124908 end:0x0212497c
+
+src/func_ov006_0212497c.cpp:
+    .text start:0x0212497c end:0x02124a04
+
+src/func_ov006_02124a04.c:
+    complete
+    .text start:0x02124a04 end:0x02124a08
+
+src/func_ov006_02124a08.c:
+    complete
+    .text start:0x02124a08 end:0x02124ae4
+
+src/func_ov006_02124ae4.c:
+    complete
+    .text start:0x02124ae4 end:0x02124b58
+
+src/func_ov006_02124b58.c:
+    complete
+    .text start:0x02124b58 end:0x02124bb4
+
+src/func_ov006_02124bb4.c:
+    complete
+    .text start:0x02124bb4 end:0x02124cb4
+
+src/func_ov006_02124cb4.c:
+    complete
+    .text start:0x02124cb4 end:0x02124dc0
+
+src/func_ov006_02124dc0.c:
+    complete
+    .text start:0x02124dc0 end:0x02124e1c
+
+src/func_ov006_02124e1c.cpp:
+    complete
+    .text start:0x02124e1c end:0x02124ec4
+
+src/func_ov006_02124ec4.c:
+    complete
+    .text start:0x02124ec4 end:0x02124fd8
+
+src/func_ov006_02124fd8.c:
+    complete
+    .text start:0x02124fd8 end:0x021250e4
+
+src/func_ov006_021250e4.c:
+    complete
+    .text start:0x021250e4 end:0x02125248
+
+src/func_ov006_02125248.c:
+    complete
+    .text start:0x02125248 end:0x0212527c
+
+src/func_ov006_0212527c.cpp:
+    .text start:0x0212527c end:0x02125364
+
+src/func_ov006_02125364.c:
+    .text start:0x02125364 end:0x021253bc
+
+src/func_ov006_021253bc.c:
+    complete
+    .text start:0x021253bc end:0x021254c0
+
+src/func_ov006_021254c0.cpp:
+    complete
+    .text start:0x021254c0 end:0x0212551c
+
+src/func_ov006_0212551c.cpp:
+    .text start:0x0212551c end:0x021255f8
+
+src/MgLuckyStars_Spawn.cpp:
+    complete
+    .text start:0x021255f8 end:0x0212568c
+
+src/func_ov006_0212568c.cpp:
+    complete
+    .text start:0x0212568c end:0x0212573c
+
+src/func_ov006_0212573c.cpp:
+    .text start:0x0212573c end:0x02125800
+
+src/func_ov006_02125800.c:
+    complete
+    .text start:0x02125800 end:0x02125804
+
+src/func_ov006_02125804.c:
+    complete
+    .text start:0x02125804 end:0x02125890
+
+src/func_ov006_02125890.c:
+    complete
+    .text start:0x02125890 end:0x02125994
+
+src/func_ov006_02125994.c:
+    complete
+    .text start:0x02125994 end:0x021259d8
+
+src/func_ov006_021259d8.c:
+    complete
+    .text start:0x021259d8 end:0x02125bbc
+
+src/func_ov006_02125bbc.c:
+    complete
+    .text start:0x02125bbc end:0x02125cdc
+
+src/func_ov006_02125cdc.c:
+    .text start:0x02125cdc end:0x02125f68
+
+src/func_ov006_02126948.c:
+    complete
+    .text start:0x02126948 end:0x02126a98
+
+src/func_ov006_02126a98.c:
+    complete
+    .text start:0x02126a98 end:0x02126b4c
+
+src/func_ov006_021279b0.cpp:
+    complete
+    .text start:0x021279b0 end:0x02127d10
+
+src/func_ov006_02127d10.c:
+    .text start:0x02127d10 end:0x021283a4
+
+src/func_ov006_021283a4.c:
+    complete
+    .text start:0x021283a4 end:0x02128fb8
+
+src/func_ov006_02128fb8.c:
+    complete
+    .text start:0x02128fb8 end:0x021291b0
+
+src/func_ov006_021291b0.c:
+    complete
+    .text start:0x021291b0 end:0x021291d4
+
+src/func_ov006_021291d4.c:
+    complete
+    .text start:0x021291d4 end:0x021291f8
+
+src/func_ov006_021291f8.c:
+    complete
+    .text start:0x021291f8 end:0x0212921c
+
+src/func_ov006_0212921c.c:
+    complete
+    .text start:0x0212921c end:0x02129268
+
+src/func_ov006_02129268.c:
+    .text start:0x02129268 end:0x021295ac
+
+src/func_ov006_021295ac.cpp:
+    complete
+    .text start:0x021295ac end:0x0212968c
+
+src/func_ov006_0212968c.c:
+    complete
+    .text start:0x0212968c end:0x02129690
+
+src/func_ov006_02129690.c:
+    complete
+    .text start:0x02129690 end:0x0212972c
+
+src/func_ov006_0212972c.c:
+    complete
+    .text start:0x0212972c end:0x021297c0
+
+src/func_ov006_021297c0.c:
+    complete
+    .text start:0x021297c0 end:0x02129894
+
+src/func_ov006_02129894.cpp:
+    complete
+    .text start:0x02129894 end:0x0212992c
+
+src/func_ov006_0212992c.c:
+    complete
+    .text start:0x0212992c end:0x02129a34
+
+src/func_ov006_02129a34.c:
+    complete
+    .text start:0x02129a34 end:0x02129b74
+
+src/func_ov006_02129b74.c:
+    complete
+    .text start:0x02129b74 end:0x02129cb0
+
+src/func_ov006_02129cb0.c:
+    complete
+    .text start:0x02129cb0 end:0x02129d94
+
+src/func_ov006_02129d94.cpp:
+    complete
+    .text start:0x02129d94 end:0x02129e28
+
+src/func_ov006_02129e28.c:
+    complete
+    .text start:0x02129e28 end:0x02129eec
+
+src/func_ov006_02129eec.c:
+    complete
+    .text start:0x02129eec end:0x0212a000
+
+src/func_ov006_0212a000.c:
+    complete
+    .text start:0x0212a000 end:0x0212a110
+
+src/func_ov006_0212a110.c:
+    complete
+    .text start:0x0212a110 end:0x0212a224
+
+src/func_ov006_0212a224.cpp:
+    complete
+    .text start:0x0212a224 end:0x0212a274
+
+src/func_ov006_0212a274.c:
+    complete
+    .text start:0x0212a274 end:0x0212a2e0
+
+src/func_ov006_0212a2e0.cpp:
+    complete
+    .text start:0x0212a2e0 end:0x0212a3c0
+
+src/func_ov006_0212a3c0.c:
+    complete
+    .text start:0x0212a3c0 end:0x0212a520
+
+src/MgSnowballSlalom_Spawn.cpp:
+    complete
+    .text start:0x0212a520 end:0x0212a554
+
+src/func_ov006_0212a554.c:
+    complete
+    .text start:0x0212a554 end:0x0212a5c8
+
+src/func_ov006_0212a5c8.cpp:
+    .text start:0x0212a5c8 end:0x0212a650
+
+src/func_ov006_0212a650.c:
+    complete
+    .text start:0x0212a650 end:0x0212a654
+
+src/func_ov006_0212a654.c:
+    complete
+    .text start:0x0212a654 end:0x0212a764
+
+src/func_ov006_0212aa74.c:
+    complete
+    .text start:0x0212aa74 end:0x0212aacc
+
+src/func_ov006_0212aacc.c:
+    complete
+    .text start:0x0212aacc end:0x0212ac74
+
+src/func_ov006_0212ac74.c:
+    .text start:0x0212ac74 end:0x0212b480
+
+src/func_ov006_0212b480.c:
+    .text start:0x0212b480 end:0x0212b7f8
+
+src/func_ov006_0212b7f8.cpp:
+    complete
+    .text start:0x0212b7f8 end:0x0212b88c
+
+src/func_ov006_0212b88c.c:
+    complete
+    .text start:0x0212b88c end:0x0212b890
+
+src/__sinit_ov006_0212f4c4.c:
+    .init start:0x0212f4c4 end:0x0212f52c
+
+src/__sinit_ov006_0212f52c.c:
+    .init start:0x0212f52c end:0x0212f660
+
+src/__sinit_ov006_0212f660.c:
+    .init start:0x0212f660 end:0x0212f6b4
+
+src/__sinit_ov006_0212f6b4.c:
+    .init start:0x0212f6b4 end:0x0212fc7c
+
+src/__sinit_ov006_0212fc7c.c:
+    .init start:0x0212fc7c end:0x0212fd48
+
+src/__sinit_ov006_0212fd48.c:
+    .init start:0x0212fd48 end:0x021300b0
+
+src/__sinit_ov006_021300b0.c:
+    .init start:0x021300b0 end:0x0213014c
+
+src/__sinit_ov006_021303d0.c:
+    .init start:0x021303d0 end:0x021304ac
+
+src/__sinit_ov006_021304ac.c:
+    .init start:0x021304ac end:0x02130758
+
+src/__sinit_ov006_02130758.c:
+    .init start:0x02130758 end:0x02130a04
+
+src/__sinit_ov006_02130a04.c:
+    .init start:0x02130a04 end:0x02130a08
+
+src/__sinit_ov006_02130a08.c:
+    .init start:0x02130a08 end:0x02130df8
+
+src/__sinit_ov006_02130df8.c:
+    .init start:0x02130df8 end:0x02130e9c
+
+src/__sinit_ov006_02130e9c.c:
+    .init start:0x02130e9c end:0x02130f00
+
+src/__sinit_ov006_02130f00.c:
+    .init start:0x02130f00 end:0x02130f64
+
+src/__sinit_ov006_02130f64.c:
+    .init start:0x02130f64 end:0x021311c8
+
+src/__sinit_ov006_021318a0.c:
+    .init start:0x021318a0 end:0x0213195c
+
+src/__sinit_ov006_0213195c.c:
+    .init start:0x0213195c end:0x02131a38
+
+src/__sinit_ov006_02131a38.c:
+    .init start:0x02131a38 end:0x02131cd0
+
+src/__sinit_ov006_02131cd0.c:
+    .init start:0x02131cd0 end:0x02131fa4
+
+src/__sinit_ov006_02131fa4.c:
+    .init start:0x02131fa4 end:0x021322bc
+
+src/__sinit_ov006_021322bc.c:
+    .init start:0x021322bc end:0x02132894
+
+src/__sinit_ov006_02132894.c:
+    .init start:0x02132894 end:0x02132970
+
+src/__sinit_ov006_02132970.c:
+    .init start:0x02132970 end:0x02132f68
+
+src/__sinit_ov006_02132f68.c:
+    .init start:0x02132f68 end:0x0213322c
+
+src/__sinit_ov006_0213322c.c:
+    .init start:0x0213322c end:0x0213326c
+
+src/__sinit_ov006_0213326c.c:
+    .init start:0x0213326c end:0x021333e0
+
+src/__sinit_ov006_021333e0.c:
+    .init start:0x021333e0 end:0x0213356c

--- a/config/arm9/overlays/ov007/delinks.txt
+++ b/config/arm9/overlays/ov007/delinks.txt
@@ -3,3 +3,2072 @@
     .ctor       start:0x020d7db8 end:0x020d7db8 kind:rodata align:4
     .data       start:0x020d7dc0 end:0x02103340 kind:data align:32
     .bss        start:0x02103340 end:0x02104c40 kind:bss align:32
+src/func_ov007_020ad660.c:
+    complete
+    .text start:0x020ad660 end:0x020ada70
+
+src/func_ov007_020ada70.cpp:
+    complete
+    .text start:0x020ada70 end:0x020adb84
+
+src/func_ov007_020adb84.c:
+    complete
+    .text start:0x020adb84 end:0x020adbc8
+
+src/func_ov007_020adbc8.c:
+    complete
+    .text start:0x020adbc8 end:0x020adc08
+
+src/func_ov007_020adc08.c:
+    complete
+    .text start:0x020adc08 end:0x020add3c
+
+src/func_ov007_020add3c.c:
+    complete
+    .text start:0x020add3c end:0x020ade14
+
+src/func_ov007_020ade14.c:
+    complete
+    .text start:0x020ade14 end:0x020ade58
+
+src/func_ov007_020ade58.c:
+    complete
+    .text start:0x020ade58 end:0x020ae070
+
+src/func_ov007_020ae070.c:
+    complete
+    .text start:0x020ae070 end:0x020ae2d0
+
+src/func_ov007_020ae2d0.c:
+    complete
+    .text start:0x020ae2d0 end:0x020ae454
+
+src/func_ov007_020ae454.c:
+    complete
+    .text start:0x020ae454 end:0x020ae558
+
+src/func_ov007_020ae558.c:
+    complete
+    .text start:0x020ae558 end:0x020ae810
+
+src/func_ov007_020ae810.c:
+    complete
+    .text start:0x020ae810 end:0x020ae834
+
+src/func_ov007_020aea4c.c:
+    complete
+    .text start:0x020aea4c end:0x020aea6c
+
+src/func_ov007_020aea6c.c:
+    complete
+    .text start:0x020aea6c end:0x020aeaec
+
+src/func_ov007_020aeaec.c:
+    complete
+    .text start:0x020aeaec end:0x020aeb34
+
+src/func_ov007_020aeb34.c:
+    complete
+    .text start:0x020aeb34 end:0x020aebac
+
+src/func_ov007_020aebac.c:
+    complete
+    .text start:0x020aebac end:0x020aec00
+
+src/func_ov007_020aec00.c:
+    complete
+    .text start:0x020aec00 end:0x020aec94
+
+src/func_ov007_020aec94.c:
+    complete
+    .text start:0x020aec94 end:0x020aed98
+
+src/_ZN5EnemyC2Ev.cpp:
+    complete
+    .text start:0x020aed98 end:0x020aef78
+
+src/func_ov007_020aef78.c:
+    complete
+    .text start:0x020aef78 end:0x020aef84
+
+src/func_ov007_020aef84.c:
+    complete
+    .text start:0x020aef84 end:0x020aefb4
+
+src/func_ov007_020aefb4.c:
+    complete
+    .text start:0x020aefb4 end:0x020af0e4
+
+src/func_ov007_020af0e4.c:
+    complete
+    .text start:0x020af0e4 end:0x020af12c
+
+src/func_ov007_020af12c.c:
+    complete
+    .text start:0x020af12c end:0x020af1f4
+
+src/func_ov007_020af1f4.c:
+    complete
+    .text start:0x020af1f4 end:0x020af260
+
+src/func_ov007_020af260.c:
+    complete
+    .text start:0x020af260 end:0x020af34c
+
+src/func_ov007_020af34c.c:
+    complete
+    .text start:0x020af34c end:0x020af390
+
+src/func_ov007_020af390.c:
+    complete
+    .text start:0x020af390 end:0x020af434
+
+src/func_ov007_020af434.c:
+    complete
+    .text start:0x020af434 end:0x020af4dc
+
+src/func_ov007_020af4dc.c:
+    complete
+    .text start:0x020af4dc end:0x020af580
+
+src/func_ov007_020af580.c:
+    complete
+    .text start:0x020af580 end:0x020af59c
+
+src/func_ov007_020af59c.c:
+    complete
+    .text start:0x020af59c end:0x020af84c
+
+src/func_ov007_020af84c.c:
+    complete
+    .text start:0x020af84c end:0x020afc44
+
+src/func_ov007_020afc44.c:
+    complete
+    .text start:0x020afc44 end:0x020b01a4
+
+src/func_ov007_020b01a4.c:
+    complete
+    .text start:0x020b01a4 end:0x020b01f4
+
+src/func_ov007_020b01f4.c:
+    complete
+    .text start:0x020b01f4 end:0x020b0244
+
+src/func_ov007_020b0244.c:
+    complete
+    .text start:0x020b0244 end:0x020b0324
+
+src/func_ov007_020b0324.c:
+    complete
+    .text start:0x020b0324 end:0x020b0340
+
+src/func_ov007_020b0340.c:
+    complete
+    .text start:0x020b0340 end:0x020b0358
+
+src/func_ov007_020b0358.c:
+    complete
+    .text start:0x020b0358 end:0x020b0520
+
+src/func_ov007_020b0520.c:
+    complete
+    .text start:0x020b0520 end:0x020b0548
+
+src/func_ov007_020b0548.c:
+    complete
+    .text start:0x020b0548 end:0x020b066c
+
+src/func_ov007_020b066c.cpp:
+    complete
+    .text start:0x020b066c end:0x020b0834
+
+src/func_ov007_020b0834.c:
+    complete
+    .text start:0x020b0834 end:0x020b0a20
+
+src/func_ov007_020b0a20.c:
+    complete
+    .text start:0x020b0a20 end:0x020b0da0
+
+src/func_ov007_020b0da0.c:
+    complete
+    .text start:0x020b0da0 end:0x020b10dc
+
+src/func_ov007_020b10dc.c:
+    complete
+    .text start:0x020b10dc end:0x020b11bc
+
+src/func_ov007_020b11bc.c:
+    complete
+    .text start:0x020b11bc end:0x020b1224
+
+src/func_ov007_020b1224.c:
+    complete
+    .text start:0x020b1224 end:0x020b12e8
+
+src/func_ov007_020b12e8.c:
+    complete
+    .text start:0x020b12e8 end:0x020b131c
+
+src/func_ov007_020b131c.c:
+    complete
+    .text start:0x020b131c end:0x020b1390
+
+src/func_ov007_020b1390.c:
+    complete
+    .text start:0x020b1390 end:0x020b155c
+
+src/func_ov007_020b155c.c:
+    complete
+    .text start:0x020b155c end:0x020b1604
+
+src/func_ov007_020b1604.c:
+    complete
+    .text start:0x020b1604 end:0x020b166c
+
+src/func_ov007_020b166c.c:
+    complete
+    .text start:0x020b166c end:0x020b16f0
+
+src/func_ov007_020b16f0.c:
+    complete
+    .text start:0x020b16f0 end:0x020b1718
+
+src/func_ov007_020b1b4c.c:
+    complete
+    .text start:0x020b1b4c end:0x020b1b70
+
+src/func_ov007_020b1b70.c:
+    complete
+    .text start:0x020b1b70 end:0x020b1b74
+
+src/func_ov007_020b1b74.c:
+    complete
+    .text start:0x020b1b74 end:0x020b1cf0
+
+src/func_ov007_020b1cf0.c:
+    complete
+    .text start:0x020b1cf0 end:0x020b1f2c
+
+src/func_ov007_020b1f2c.c:
+    complete
+    .text start:0x020b1f2c end:0x020b1fa4
+
+src/func_ov007_020b1fa4.c:
+    complete
+    .text start:0x020b1fa4 end:0x020b20e8
+
+src/func_ov007_020b20e8.c:
+    complete
+    .text start:0x020b20e8 end:0x020b2160
+
+src/func_ov007_020b2160.c:
+    complete
+    .text start:0x020b2160 end:0x020b22e0
+
+src/func_ov007_020b22e0.c:
+    complete
+    .text start:0x020b22e0 end:0x020b2308
+
+src/func_ov007_020b2308.c:
+    complete
+    .text start:0x020b2308 end:0x020b2370
+
+src/func_ov007_020b2370.cpp:
+    complete
+    .text start:0x020b2370 end:0x020b2454
+
+src/func_ov007_020b2454.c:
+    complete
+    .text start:0x020b2454 end:0x020b257c
+
+src/func_ov007_020b257c.c:
+    complete
+    .text start:0x020b257c end:0x020b2614
+
+src/func_ov007_020b2614.c:
+    complete
+    .text start:0x020b2614 end:0x020b2728
+
+src/func_ov007_020b2728.c:
+    complete
+    .text start:0x020b2728 end:0x020b2764
+
+src/func_ov007_020b2764.c:
+    complete
+    .text start:0x020b2764 end:0x020b283c
+
+src/func_ov007_020b283c.c:
+    complete
+    .text start:0x020b283c end:0x020b2998
+
+src/func_ov007_020b2bd4.c:
+    complete
+    .text start:0x020b2bd4 end:0x020b2cdc
+
+src/func_ov007_020b2cdc.c:
+    complete
+    .text start:0x020b2cdc end:0x020b2cf0
+
+src/func_ov007_020b2cf0.c:
+    complete
+    .text start:0x020b2cf0 end:0x020b2e64
+
+src/func_ov007_020b2e64.c:
+    complete
+    .text start:0x020b2e64 end:0x020b3050
+
+src/func_ov007_020b3050.c:
+    complete
+    .text start:0x020b3050 end:0x020b30b0
+
+src/func_ov007_020b30b0.c:
+    complete
+    .text start:0x020b30b0 end:0x020b3190
+
+src/func_ov007_020b3190.c:
+    complete
+    .text start:0x020b3190 end:0x020b3360
+
+src/func_ov007_020b3360.c:
+    .text start:0x020b3360 end:0x020b3708
+
+src/func_ov007_020b3708.c:
+    complete
+    .text start:0x020b3708 end:0x020b3c54
+
+src/func_ov007_020b3c54.c:
+    complete
+    .text start:0x020b3c54 end:0x020b3d30
+
+src/func_ov007_020b3d30.cpp:
+    complete
+    .text start:0x020b3d30 end:0x020b3e04
+
+src/func_ov007_020b3e04.c:
+    complete
+    .text start:0x020b3e04 end:0x020b3e84
+
+src/func_ov007_020b3e84.c:
+    complete
+    .text start:0x020b3e84 end:0x020b3edc
+
+src/func_ov007_020b3edc.c:
+    complete
+    .text start:0x020b3edc end:0x020b3f20
+
+src/func_ov007_020b3f20.c:
+    complete
+    .text start:0x020b3f20 end:0x020b40c0
+
+src/func_ov007_020b40c0.c:
+    complete
+    .text start:0x020b40c0 end:0x020b4100
+
+src/func_ov007_020b4100.c:
+    complete
+    .text start:0x020b4100 end:0x020b413c
+
+src/func_ov007_020b413c.c:
+    complete
+    .text start:0x020b413c end:0x020b42d8
+
+src/func_ov007_020b42d8.c:
+    complete
+    .text start:0x020b42d8 end:0x020b43dc
+
+src/func_ov007_020b43dc.c:
+    complete
+    .text start:0x020b43dc end:0x020b4438
+
+src/func_ov007_020b4438.c:
+    complete
+    .text start:0x020b4438 end:0x020b4464
+
+src/func_ov007_020b4464.c:
+    complete
+    .text start:0x020b4464 end:0x020b44ec
+
+src/func_ov007_020b44ec.c:
+    complete
+    .text start:0x020b44ec end:0x020b45b0
+
+src/func_ov007_020b45b0.c:
+    complete
+    .text start:0x020b45b0 end:0x020b46b0
+
+src/func_ov007_020b4b5c.c:
+    complete
+    .text start:0x020b4b5c end:0x020b4bd4
+
+src/func_ov007_020b4bd4.cpp:
+    complete
+    .text start:0x020b4bd4 end:0x020b4c04
+
+src/func_ov007_020b4c04.c:
+    complete
+    .text start:0x020b4c04 end:0x020b5068
+
+src/func_ov007_020b5068.c:
+    complete
+    .text start:0x020b5068 end:0x020b50e8
+
+src/func_ov007_020b50e8.c:
+    complete
+    .text start:0x020b50e8 end:0x020b58e4
+
+src/func_ov007_020b58e4.c:
+    complete
+    .text start:0x020b58e4 end:0x020b5bf0
+
+src/func_ov007_020b5bf0.c:
+    complete
+    .text start:0x020b5bf0 end:0x020b5f64
+
+src/func_ov007_020b5f64.c:
+    complete
+    .text start:0x020b5f64 end:0x020b6134
+
+src/func_ov007_020b6134.cpp:
+    complete
+    .text start:0x020b6134 end:0x020b6208
+
+src/func_ov007_020b6208.c:
+    complete
+    .text start:0x020b6208 end:0x020b63e4
+
+src/func_ov007_020b63e4.c:
+    complete
+    .text start:0x020b63e4 end:0x020b647c
+
+src/func_ov007_020b647c.c:
+    complete
+    .text start:0x020b647c end:0x020b64a8
+
+src/func_ov007_020b64a8.c:
+    complete
+    .text start:0x020b64a8 end:0x020b6544
+
+src/func_ov007_020b6544.c:
+    complete
+    .text start:0x020b6544 end:0x020b65e0
+
+src/func_ov007_020b65e0.c:
+    complete
+    .text start:0x020b65e0 end:0x020b68e8
+
+src/func_ov007_020b68e8.c:
+    complete
+    .text start:0x020b68e8 end:0x020b693c
+
+src/func_ov007_020b693c.c:
+    complete
+    .text start:0x020b693c end:0x020b697c
+
+src/func_ov007_020b697c.c:
+    complete
+    .text start:0x020b697c end:0x020b69c4
+
+src/func_ov007_020b69c4.c:
+    complete
+    .text start:0x020b69c4 end:0x020b6a84
+
+src/func_ov007_020b6a84.c:
+    complete
+    .text start:0x020b6a84 end:0x020b6c54
+
+src/func_ov007_020b6c54.c:
+    complete
+    .text start:0x020b6c54 end:0x020b6cd0
+
+src/func_ov007_020b6cd0.c:
+    complete
+    .text start:0x020b6cd0 end:0x020b6d40
+
+src/func_ov007_020b6d40.c:
+    complete
+    .text start:0x020b6d40 end:0x020b6eb4
+
+src/func_ov007_020b6eb4.c:
+    complete
+    .text start:0x020b6eb4 end:0x020b6f4c
+
+src/func_ov007_020b6f4c.c:
+    complete
+    .text start:0x020b6f4c end:0x020b7040
+
+src/func_ov007_020b7040.c:
+    complete
+    .text start:0x020b7040 end:0x020b7090
+
+src/func_ov007_020b7090.c:
+    complete
+    .text start:0x020b7090 end:0x020b7138
+
+src/func_ov007_020b7138.c:
+    complete
+    .text start:0x020b7138 end:0x020b72a0
+
+src/func_ov007_020b72a0.c:
+    complete
+    .text start:0x020b72a0 end:0x020b72d8
+
+src/func_ov007_020b72d8.c:
+    complete
+    .text start:0x020b72d8 end:0x020b72fc
+
+src/func_ov007_020b72fc.c:
+    complete
+    .text start:0x020b72fc end:0x020b7320
+
+src/func_ov007_020b7320.c:
+    complete
+    .text start:0x020b7320 end:0x020b7364
+
+src/func_ov007_020b7364.c:
+    complete
+    .text start:0x020b7364 end:0x020b7384
+
+src/func_ov007_020b7384.c:
+    complete
+    .text start:0x020b7384 end:0x020b73b4
+
+src/func_ov007_020b73b4.c:
+    complete
+    .text start:0x020b73b4 end:0x020b7594
+
+src/func_ov007_020b7594.c:
+    complete
+    .text start:0x020b7594 end:0x020b7658
+
+src/func_ov007_020b7658.c:
+    complete
+    .text start:0x020b7658 end:0x020b7690
+
+src/func_ov007_020b7690.c:
+    complete
+    .text start:0x020b7690 end:0x020b76a0
+
+src/func_ov007_020b76a0.c:
+    complete
+    .text start:0x020b76a0 end:0x020b76c4
+
+src/func_ov007_020b76c4.c:
+    complete
+    .text start:0x020b76c4 end:0x020b7708
+
+src/func_ov007_020b7708.c:
+    complete
+    .text start:0x020b7708 end:0x020b7764
+
+src/func_ov007_020b7764.cpp:
+    complete
+    .text start:0x020b7764 end:0x020b77ac
+
+src/func_ov007_020b77ac.c:
+    complete
+    .text start:0x020b77ac end:0x020b782c
+
+src/func_ov007_020b782c.c:
+    complete
+    .text start:0x020b782c end:0x020b78d0
+
+src/func_ov007_020b78d0.c:
+    complete
+    .text start:0x020b78d0 end:0x020b7914
+
+src/func_ov007_020b7914.c:
+    complete
+    .text start:0x020b7914 end:0x020b7948
+
+src/func_ov007_020b7948.c:
+    complete
+    .text start:0x020b7948 end:0x020b797c
+
+src/func_ov007_020b797c.c:
+    complete
+    .text start:0x020b797c end:0x020b79c8
+
+src/func_ov007_020b79c8.c:
+    complete
+    .text start:0x020b79c8 end:0x020b79e4
+
+src/func_ov007_020b79e4.c:
+    complete
+    .text start:0x020b79e4 end:0x020b7a00
+
+src/func_ov007_020b7a00.c:
+    complete
+    .text start:0x020b7a00 end:0x020b7a34
+
+src/func_ov007_020b7a34.c:
+    complete
+    .text start:0x020b7a34 end:0x020b7a44
+
+src/func_ov007_020b7a44.c:
+    complete
+    .text start:0x020b7a44 end:0x020b7a78
+
+src/func_ov007_020b7a78.c:
+    complete
+    .text start:0x020b7a78 end:0x020b7d94
+
+src/func_ov007_020b7d94.c:
+    complete
+    .text start:0x020b7d94 end:0x020b7eec
+
+src/func_ov007_020b7eec.c:
+    complete
+    .text start:0x020b7eec end:0x020b8070
+
+src/func_ov007_020b8070.c:
+    complete
+    .text start:0x020b8070 end:0x020b8188
+
+src/func_ov007_020b84e8.c:
+    complete
+    .text start:0x020b84e8 end:0x020b84f4
+
+src/func_ov007_020b84f4.c:
+    complete
+    .text start:0x020b84f4 end:0x020b8500
+
+src/func_ov007_020b8500.c:
+    complete
+    .text start:0x020b8500 end:0x020b850c
+
+src/func_ov007_020b850c.c:
+    complete
+    .text start:0x020b850c end:0x020b8548
+
+src/func_ov007_020b8548.c:
+    complete
+    .text start:0x020b8548 end:0x020b8690
+
+src/func_ov007_020b8690.c:
+    complete
+    .text start:0x020b8690 end:0x020b8714
+
+src/func_ov007_020b8714.c:
+    complete
+    .text start:0x020b8714 end:0x020b883c
+
+src/func_ov007_020b883c.c:
+    complete
+    .text start:0x020b883c end:0x020b8860
+
+src/func_ov007_020b8860.c:
+    complete
+    .text start:0x020b8860 end:0x020b88c0
+
+src/func_ov007_020b88c0.c:
+    complete
+    .text start:0x020b88c0 end:0x020b8a78
+
+src/func_ov007_020b8a78.c:
+    complete
+    .text start:0x020b8a78 end:0x020b8b00
+
+src/func_ov007_020b8b00.c:
+    complete
+    .text start:0x020b8b00 end:0x020b8b80
+
+src/func_ov007_020b8b80.c:
+    complete
+    .text start:0x020b8b80 end:0x020b8cfc
+
+src/func_ov007_020b8cfc.c:
+    complete
+    .text start:0x020b8cfc end:0x020b8d48
+
+src/func_ov007_020b8d48.c:
+    complete
+    .text start:0x020b8d48 end:0x020b8ec0
+
+src/func_ov007_020b8ec0.c:
+    complete
+    .text start:0x020b8ec0 end:0x020b8f50
+
+src/func_ov007_020b8f50.c:
+    complete
+    .text start:0x020b8f50 end:0x020b8f64
+
+src/func_ov007_020b8f64.c:
+    complete
+    .text start:0x020b8f64 end:0x020b8f78
+
+src/func_ov007_020b8f78.c:
+    complete
+    .text start:0x020b8f78 end:0x020b8f8c
+
+src/func_ov007_020b8f8c.c:
+    complete
+    .text start:0x020b8f8c end:0x020b8fa0
+
+src/func_ov007_020b8fa0.c:
+    complete
+    .text start:0x020b8fa0 end:0x020b8fb4
+
+src/func_ov007_020b8fb4.c:
+    complete
+    .text start:0x020b8fb4 end:0x020b8fd4
+
+src/func_ov007_020b91b4.c:
+    .text start:0x020b91b4 end:0x020b9640
+
+src/func_ov007_020b9640.c:
+    complete
+    .text start:0x020b9640 end:0x020b9770
+
+src/func_ov007_020b9770.cpp:
+    complete
+    .text start:0x020b9770 end:0x020b9880
+
+src/func_ov007_020b9880.c:
+    complete
+    .text start:0x020b9880 end:0x020b9ca8
+
+src/func_ov007_020b9ca8.c:
+    complete
+    .text start:0x020b9ca8 end:0x020b9f0c
+
+src/func_ov007_020b9f0c.c:
+    complete
+    .text start:0x020b9f0c end:0x020b9fc0
+
+src/func_ov007_020b9fc0.c:
+    complete
+    .text start:0x020b9fc0 end:0x020ba05c
+
+src/func_ov007_020ba2e0.c:
+    complete
+    .text start:0x020ba2e0 end:0x020ba368
+
+src/func_ov007_020ba368.c:
+    complete
+    .text start:0x020ba368 end:0x020ba9bc
+
+src/func_ov007_020ba9bc.c:
+    complete
+    .text start:0x020ba9bc end:0x020baa10
+
+src/func_ov007_020baa10.c:
+    complete
+    .text start:0x020baa10 end:0x020bad8c
+
+src/func_ov007_020bad8c.c:
+    complete
+    .text start:0x020bad8c end:0x020bb09c
+
+src/func_ov007_020bb09c.c:
+    complete
+    .text start:0x020bb09c end:0x020bb4b0
+
+src/func_ov007_020bb4b0.c:
+    complete
+    .text start:0x020bb4b0 end:0x020bbc08
+
+src/func_ov007_020bbc08.c:
+    complete
+    .text start:0x020bbc08 end:0x020bbd24
+
+src/func_ov007_020bbd24.cpp:
+    .text start:0x020bbd24 end:0x020bbe60
+
+src/func_ov007_020bbe60.c:
+    complete
+    .text start:0x020bbe60 end:0x020bbf98
+
+src/func_ov007_020bbf98.c:
+    complete
+    .text start:0x020bbf98 end:0x020bbff0
+
+src/func_ov007_020bbff0.c:
+    complete
+    .text start:0x020bbff0 end:0x020bc02c
+
+src/func_ov007_020bc02c.c:
+    complete
+    .text start:0x020bc02c end:0x020bc2e4
+
+src/func_ov007_020bc2e4.c:
+    complete
+    .text start:0x020bc2e4 end:0x020bc32c
+
+src/func_ov007_020bc32c.c:
+    complete
+    .text start:0x020bc32c end:0x020bc374
+
+src/func_ov007_020bc374.c:
+    complete
+    .text start:0x020bc374 end:0x020bc3dc
+
+src/func_ov007_020bc3dc.c:
+    complete
+    .text start:0x020bc3dc end:0x020bc434
+
+src/func_ov007_020bc434.c:
+    complete
+    .text start:0x020bc434 end:0x020bc47c
+
+src/func_ov007_020bc47c.cpp:
+    complete
+    .text start:0x020bc47c end:0x020bc53c
+
+src/func_ov007_020bc53c.cpp:
+    complete
+    .text start:0x020bc53c end:0x020bc5fc
+
+src/func_ov007_020bc5fc.c:
+    complete
+    .text start:0x020bc5fc end:0x020bc658
+
+src/func_ov007_020bc658.c:
+    complete
+    .text start:0x020bc658 end:0x020bc6b4
+
+src/func_ov007_020bc6b4.c:
+    complete
+    .text start:0x020bc6b4 end:0x020bc6d4
+
+src/func_ov007_020bc6d4.c:
+    complete
+    .text start:0x020bc6d4 end:0x020bc7dc
+
+src/func_ov007_020bc7dc.c:
+    complete
+    .text start:0x020bc7dc end:0x020bc894
+
+src/func_ov007_020bc894.cpp:
+    complete
+    .text start:0x020bc894 end:0x020bc968
+
+src/func_ov007_020bc968.c:
+    complete
+    .text start:0x020bc968 end:0x020bc9c8
+
+src/func_ov007_020bc9c8.cpp:
+    complete
+    .text start:0x020bc9c8 end:0x020bca40
+
+src/func_ov007_020bca40.c:
+    complete
+    .text start:0x020bca40 end:0x020bcba8
+
+src/func_ov007_020bcba8.c:
+    complete
+    .text start:0x020bcba8 end:0x020bcdb8
+
+src/func_ov007_020bcdb8.cpp:
+    complete
+    .text start:0x020bcdb8 end:0x020bce70
+
+src/func_ov007_020bce70.cpp:
+    .text start:0x020bce70 end:0x020bcf90
+
+src/func_ov007_020bcf90.c:
+    .text start:0x020bcf90 end:0x020bd1c0
+
+src/func_ov007_020bd1c0.c:
+    complete
+    .text start:0x020bd1c0 end:0x020bd4a0
+
+src/func_ov007_020bd4a0.c:
+    complete
+    .text start:0x020bd4a0 end:0x020bd4e8
+
+src/func_ov007_020bd4e8.c:
+    complete
+    .text start:0x020bd4e8 end:0x020bd500
+
+src/func_ov007_020bd500.cpp:
+    complete
+    .text start:0x020bd500 end:0x020bd5a8
+
+src/func_ov007_020bd5a8.cpp:
+    complete
+    .text start:0x020bd5a8 end:0x020bd648
+
+src/func_ov007_020bd648.c:
+    complete
+    .text start:0x020bd648 end:0x020bd960
+
+src/func_ov007_020bd960.c:
+    complete
+    .text start:0x020bd960 end:0x020bd9e4
+
+src/func_ov007_020bd9e4.c:
+    complete
+    .text start:0x020bd9e4 end:0x020bda38
+
+src/func_ov007_020bda38.c:
+    complete
+    .text start:0x020bda38 end:0x020bda8c
+
+src/func_ov007_020bda8c.c:
+    complete
+    .text start:0x020bda8c end:0x020bdbcc
+
+src/func_ov007_020bdbcc.c:
+    complete
+    .text start:0x020bdbcc end:0x020bde2c
+
+src/func_ov007_020bde2c.c:
+    complete
+    .text start:0x020bde2c end:0x020bde70
+
+src/func_ov007_020bde70.c:
+    complete
+    .text start:0x020bde70 end:0x020bdeb0
+
+src/func_ov007_020bdeb0.c:
+    complete
+    .text start:0x020bdeb0 end:0x020bdebc
+
+src/func_ov007_020bdebc.c:
+    complete
+    .text start:0x020bdebc end:0x020bdf60
+
+src/func_ov007_020bdf60.c:
+    complete
+    .text start:0x020bdf60 end:0x020be00c
+
+src/func_ov007_020be00c.c:
+    complete
+    .text start:0x020be00c end:0x020be098
+
+src/func_ov007_020be098.c:
+    complete
+    .text start:0x020be098 end:0x020be0dc
+
+src/func_ov007_020be0dc.c:
+    complete
+    .text start:0x020be0dc end:0x020be3bc
+
+src/func_ov007_020be3bc.cpp:
+    complete
+    .text start:0x020be3bc end:0x020be47c
+
+src/func_ov007_020be47c.c:
+    complete
+    .text start:0x020be47c end:0x020be50c
+
+src/func_ov007_020be50c.c:
+    complete
+    .text start:0x020be50c end:0x020be684
+
+src/func_ov007_020be684.c:
+    complete
+    .text start:0x020be684 end:0x020be7a8
+
+src/func_ov007_020be7a8.c:
+    complete
+    .text start:0x020be7a8 end:0x020be850
+
+src/func_ov007_020be850.c:
+    complete
+    .text start:0x020be850 end:0x020be8b8
+
+src/func_ov007_020be8b8.c:
+    complete
+    .text start:0x020be8b8 end:0x020be964
+
+src/func_ov007_020be964.c:
+    complete
+    .text start:0x020be964 end:0x020be980
+
+src/func_ov007_020be980.c:
+    .text start:0x020be980 end:0x020be9ac
+
+src/func_ov007_020be9ac.c:
+    complete
+    .text start:0x020be9ac end:0x020bea44
+
+src/func_ov007_020bea44.cpp:
+    complete
+    .text start:0x020bea44 end:0x020beaa0
+
+src/func_ov007_020beaa0.c:
+    complete
+    .text start:0x020beaa0 end:0x020beb80
+
+src/func_ov007_020beb80.c:
+    complete
+    .text start:0x020beb80 end:0x020bed60
+
+src/func_ov007_020bed60.c:
+    complete
+    .text start:0x020bed60 end:0x020bee14
+
+src/func_ov007_020bee14.c:
+    complete
+    .text start:0x020bee14 end:0x020beeb0
+
+src/func_ov007_020bf304.c:
+    complete
+    .text start:0x020bf304 end:0x020bf428
+
+src/func_ov007_020bf428.c:
+    complete
+    .text start:0x020bf428 end:0x020bf57c
+
+src/func_ov007_020bf57c.c:
+    complete
+    .text start:0x020bf57c end:0x020bf630
+
+src/func_ov007_020bf630.c:
+    complete
+    .text start:0x020bf630 end:0x020bf690
+
+src/func_ov007_020bf690.c:
+    .text start:0x020bf690 end:0x020bf790
+
+src/func_ov007_020bf790.c:
+    complete
+    .text start:0x020bf790 end:0x020bfacc
+
+src/RequestScreenFade.c:
+    complete
+    .text start:0x020bfacc end:0x020bfaf0
+
+src/func_ov007_020bfaf0.cpp:
+    complete
+    .text start:0x020bfaf0 end:0x020bfbdc
+
+src/func_ov007_020bfbdc.c:
+    complete
+    .text start:0x020bfbdc end:0x020bfc54
+
+src/func_ov007_020bfc54.c:
+    complete
+    .text start:0x020bfc54 end:0x020bfcec
+
+src/func_ov007_020bfcec.c:
+    complete
+    .text start:0x020bfcec end:0x020bfd70
+
+src/func_ov007_020bfe4c.c:
+    complete
+    .text start:0x020bfe4c end:0x020bff38
+
+src/func_ov007_020bff38.c:
+    .text start:0x020bff38 end:0x020bffb8
+
+src/func_ov007_020bffb8.c:
+    complete
+    .text start:0x020bffb8 end:0x020c0078
+
+src/func_ov007_020c0078.c:
+    complete
+    .text start:0x020c0078 end:0x020c0128
+
+src/func_ov007_020c0128.cpp:
+    .text start:0x020c0128 end:0x020c020c
+
+src/func_ov007_020c020c.c:
+    complete
+    .text start:0x020c020c end:0x020c023c
+
+src/func_ov007_020c023c.c:
+    complete
+    .text start:0x020c023c end:0x020c0288
+
+src/func_ov007_020c0288.c:
+    complete
+    .text start:0x020c0288 end:0x020c02d8
+
+src/func_ov007_020c02d8.c:
+    complete
+    .text start:0x020c02d8 end:0x020c0308
+
+src/func_ov007_020c0308.c:
+    complete
+    .text start:0x020c0308 end:0x020c0354
+
+src/func_ov007_020c0354.c:
+    complete
+    .text start:0x020c0354 end:0x020c0384
+
+src/func_ov007_020c0384.c:
+    complete
+    .text start:0x020c0384 end:0x020c03b0
+
+src/func_ov007_020c03b0.c:
+    complete
+    .text start:0x020c03b0 end:0x020c05e4
+
+src/func_ov007_020c05e4.c:
+    complete
+    .text start:0x020c05e4 end:0x020c05f8
+
+src/func_ov007_020c05f8.c:
+    complete
+    .text start:0x020c05f8 end:0x020c0604
+
+src/func_ov007_020c0604.c:
+    complete
+    .text start:0x020c0604 end:0x020c0638
+
+src/func_ov007_020c0638.c:
+    complete
+    .text start:0x020c0638 end:0x020c076c
+
+src/func_ov007_020c076c.c:
+    complete
+    .text start:0x020c076c end:0x020c0a44
+
+src/func_ov007_020c0a44.c:
+    complete
+    .text start:0x020c0a44 end:0x020c0a9c
+
+src/func_ov007_020c0a9c.c:
+    .text start:0x020c0a9c end:0x020c0aa8
+
+src/func_ov007_020c0aa8.c:
+    complete
+    .text start:0x020c0aa8 end:0x020c0af4
+
+src/func_ov007_020c0af4.c:
+    complete
+    .text start:0x020c0af4 end:0x020c0b20
+
+src/func_ov007_020c0b20.c:
+    complete
+    .text start:0x020c0b20 end:0x020c0b78
+
+src/func_ov007_020c0b78.c:
+    complete
+    .text start:0x020c0b78 end:0x020c0d70
+
+src/func_ov007_020c0d70.c:
+    complete
+    .text start:0x020c0d70 end:0x020c0eb0
+
+src/func_ov007_020c0eb0.c:
+    complete
+    .text start:0x020c0eb0 end:0x020c1048
+
+src/func_ov007_020c1048.c:
+    complete
+    .text start:0x020c1048 end:0x020c105c
+
+src/func_ov007_020c105c.c:
+    .text start:0x020c105c end:0x020c1068
+
+src/func_ov007_020c1068.c:
+    complete
+    .text start:0x020c1068 end:0x020c108c
+
+src/Sprite_SetAnimation.c:
+    complete
+    .text start:0x020c108c end:0x020c10b0
+
+src/func_ov007_020c10b0.c:
+    complete
+    .text start:0x020c10b0 end:0x020c10ec
+
+src/func_ov007_020c10ec.c:
+    complete
+    .text start:0x020c10ec end:0x020c1180
+
+src/func_ov007_020c1180.cpp:
+    complete
+    .text start:0x020c1180 end:0x020c11ac
+
+src/func_ov007_020c11ac.c:
+    complete
+    .text start:0x020c11ac end:0x020c121c
+
+src/func_ov007_020c121c.c:
+    complete
+    .text start:0x020c121c end:0x020c12ac
+
+src/func_ov007_020c12ac.c:
+    complete
+    .text start:0x020c12ac end:0x020c1384
+
+src/func_ov007_020c1384.cpp:
+    complete
+    .text start:0x020c1384 end:0x020c13a4
+
+src/func_ov007_020c13a4.c:
+    complete
+    .text start:0x020c13a4 end:0x020c13f4
+
+src/func_ov007_020c13f4.c:
+    complete
+    .text start:0x020c13f4 end:0x020c1404
+
+src/func_ov007_020c1404.c:
+    complete
+    .text start:0x020c1404 end:0x020c1448
+
+src/func_ov007_020c1448.c:
+    complete
+    .text start:0x020c1448 end:0x020c14b8
+
+src/func_ov007_020c14b8.c:
+    complete
+    .text start:0x020c14b8 end:0x020c14d4
+
+src/func_ov007_020c14d4.c:
+    complete
+    .text start:0x020c14d4 end:0x020c1560
+
+src/func_ov007_020c1560.c:
+    complete
+    .text start:0x020c1560 end:0x020c15ec
+
+src/func_ov007_020c15ec.c:
+    complete
+    .text start:0x020c15ec end:0x020c1620
+
+src/func_ov007_020c1620.c:
+    .text start:0x020c1620 end:0x020c162c
+
+src/func_ov007_020c162c.c:
+    complete
+    .text start:0x020c162c end:0x020c16dc
+
+src/func_ov007_020c16dc.c:
+    complete
+    .text start:0x020c16dc end:0x020c17f4
+
+src/func_ov007_020c17f4.c:
+    complete
+    .text start:0x020c17f4 end:0x020c1804
+
+src/func_ov007_020c1804.c:
+    complete
+    .text start:0x020c1804 end:0x020c1814
+
+src/func_ov007_020c1814.c:
+    complete
+    .text start:0x020c1814 end:0x020c184c
+
+src/func_ov007_020c184c.c:
+    complete
+    .text start:0x020c184c end:0x020c19cc
+
+src/func_ov007_020c1d78.c:
+    complete
+    .text start:0x020c1d78 end:0x020c1d8c
+
+src/func_ov007_020c1d8c.c:
+    complete
+    .text start:0x020c1d8c end:0x020c1da0
+
+src/func_ov007_020c1da0.c:
+    complete
+    .text start:0x020c1da0 end:0x020c1db0
+
+src/func_ov007_020c1db0.c:
+    .text start:0x020c1db0 end:0x020c2018
+
+src/func_ov007_020c2018.c:
+    .text start:0x020c2018 end:0x020c2024
+
+src/func_ov007_020c2024.c:
+    complete
+    .text start:0x020c2024 end:0x020c2068
+
+src/func_ov007_020c2068.c:
+    complete
+    .text start:0x020c2068 end:0x020c2090
+
+src/func_ov007_020c2090.c:
+    complete
+    .text start:0x020c2090 end:0x020c20b8
+
+src/func_ov007_020c22a0.c:
+    complete
+    .text start:0x020c22a0 end:0x020c22f8
+
+src/func_ov007_020c22f8.c:
+    .text start:0x020c22f8 end:0x020c2304
+
+src/func_ov007_020c2304.c:
+    complete
+    .text start:0x020c2304 end:0x020c232c
+
+src/func_ov007_020c232c.c:
+    complete
+    .text start:0x020c232c end:0x020c2390
+
+src/func_ov007_020c2390.c:
+    complete
+    .text start:0x020c2390 end:0x020c2410
+
+src/func_ov007_020c2410.c:
+    .text start:0x020c2410 end:0x020c241c
+
+src/func_ov007_020c241c.c:
+    complete
+    .text start:0x020c241c end:0x020c249c
+
+src/func_ov007_020c249c.c:
+    complete
+    .text start:0x020c249c end:0x020c24d0
+
+src/func_ov007_020c24d0.c:
+    complete
+    .text start:0x020c24d0 end:0x020c25fc
+
+src/func_ov007_020c25fc.c:
+    complete
+    .text start:0x020c25fc end:0x020c26fc
+
+src/func_ov007_020c26fc.c:
+    complete
+    .text start:0x020c26fc end:0x020c27b4
+
+src/func_ov007_020c27b4.c:
+    complete
+    .text start:0x020c27b4 end:0x020c281c
+
+src/func_ov007_020c281c.c:
+    complete
+    .text start:0x020c281c end:0x020c28ac
+
+src/func_ov007_020c28ac.c:
+    complete
+    .text start:0x020c28ac end:0x020c29b4
+
+src/func_ov007_020c29b4.c:
+    complete
+    .text start:0x020c29b4 end:0x020c2a04
+
+src/func_ov007_020c2a04.c:
+    complete
+    .text start:0x020c2a04 end:0x020c2acc
+
+src/func_ov007_020c2acc.c:
+    complete
+    .text start:0x020c2acc end:0x020c2b38
+
+src/func_ov007_020c2b38.c:
+    complete
+    .text start:0x020c2b38 end:0x020c2b9c
+
+src/func_ov007_020c2b9c.c:
+    complete
+    .text start:0x020c2b9c end:0x020c2bf8
+
+src/func_ov007_020c2bf8.c:
+    complete
+    .text start:0x020c2bf8 end:0x020c2c68
+
+src/func_ov007_020c2c68.c:
+    complete
+    .text start:0x020c2c68 end:0x020c2d44
+
+src/func_ov007_020c2d44.c:
+    complete
+    .text start:0x020c2d44 end:0x020c2dfc
+
+src/func_ov007_020c2dfc.c:
+    complete
+    .text start:0x020c2dfc end:0x020c2e90
+
+src/func_ov007_020c2e90.c:
+    complete
+    .text start:0x020c2e90 end:0x020c2f14
+
+src/func_ov007_020c2f14.c:
+    complete
+    .text start:0x020c2f14 end:0x020c3054
+
+src/func_ov007_020c3054.c:
+    complete
+    .text start:0x020c3054 end:0x020c30ac
+
+src/func_ov007_020c30ac.c:
+    complete
+    .text start:0x020c30ac end:0x020c31e0
+
+src/func_ov007_020c31e0.c:
+    complete
+    .text start:0x020c31e0 end:0x020c32e8
+
+src/func_ov007_020c32e8.cpp:
+    complete
+    .text start:0x020c32e8 end:0x020c338c
+
+src/func_ov007_020c338c.c:
+    .text start:0x020c338c end:0x020c3398
+
+src/func_ov007_020c3398.c:
+    complete
+    .text start:0x020c3398 end:0x020c33d0
+
+src/func_ov007_020c33d0.cpp:
+    complete
+    .text start:0x020c33d0 end:0x020c3544
+
+src/func_ov007_020c3544.c:
+    .text start:0x020c3544 end:0x020c3550
+
+src/func_ov007_020c3550.c:
+    complete
+    .text start:0x020c3550 end:0x020c3598
+
+src/func_ov007_020c3598.c:
+    complete
+    .text start:0x020c3598 end:0x020c368c
+
+src/func_ov007_020c39f8.c:
+    complete
+    .text start:0x020c39f8 end:0x020c3abc
+
+src/func_ov007_020c3abc.c:
+    complete
+    .text start:0x020c3abc end:0x020c3ba8
+
+src/func_ov007_020c3ba8.c:
+    complete
+    .text start:0x020c3ba8 end:0x020c3bc8
+
+src/func_ov007_020c3bc8.c:
+    complete
+    .text start:0x020c3bc8 end:0x020c3be0
+
+src/func_ov007_020c3be0.c:
+    complete
+    .text start:0x020c3be0 end:0x020c3ce4
+
+src/func_ov007_020c3ce4.cpp:
+    complete
+    .text start:0x020c3ce4 end:0x020c3d1c
+
+src/_ZN6Player17St_EndingFly_MainEv.cpp:
+    complete
+    .text start:0x020c3d1c end:0x020c3d40
+
+src/func_ov007_020c3d40.c:
+    complete
+    .text start:0x020c3d40 end:0x020c3df4
+
+src/func_ov007_020c3df4.cpp:
+    complete
+    .text start:0x020c3df4 end:0x020c3e1c
+
+src/func_ov007_020c3e1c.c:
+    complete
+    .text start:0x020c3e1c end:0x020c3e2c
+
+src/func_ov007_020c3e2c.c:
+    complete
+    .text start:0x020c3e2c end:0x020c3e3c
+
+src/func_ov007_020c3e3c.c:
+    complete
+    .text start:0x020c3e3c end:0x020c3e4c
+
+src/func_ov007_020c3e4c.c:
+    complete
+    .text start:0x020c3e4c end:0x020c3e64
+
+src/func_ov007_020c3e64.c:
+    complete
+    .text start:0x020c3e64 end:0x020c3e7c
+
+src/func_ov007_020c3e7c.cpp:
+    complete
+    .text start:0x020c3e7c end:0x020c3ee8
+
+src/func_ov007_020c3ee8.c:
+    complete
+    .text start:0x020c3ee8 end:0x020c3f00
+
+src/func_ov007_020c3f00.c:
+    complete
+    .text start:0x020c3f00 end:0x020c3fe4
+
+src/func_ov007_020c3fe4.c:
+    complete
+    .text start:0x020c3fe4 end:0x020c4090
+
+src/func_ov007_020c4090.c:
+    complete
+    .text start:0x020c4090 end:0x020c40b4
+
+src/func_ov007_020c40b4.cpp:
+    complete
+    .text start:0x020c40b4 end:0x020c40d4
+
+src/func_ov007_020c40d4.cpp:
+    complete
+    .text start:0x020c40d4 end:0x020c4128
+
+src/func_ov007_020c4128.c:
+    complete
+    .text start:0x020c4128 end:0x020c41dc
+
+src/func_ov007_020c41dc.c:
+    complete
+    .text start:0x020c41dc end:0x020c421c
+
+src/func_ov007_020c421c.c:
+    complete
+    .text start:0x020c421c end:0x020c42f8
+
+src/func_ov007_020c42f8.c:
+    complete
+    .text start:0x020c42f8 end:0x020c4388
+
+src/func_ov007_020c4388.cpp:
+    complete
+    .text start:0x020c4388 end:0x020c43bc
+
+src/func_ov007_020c43bc.cpp:
+    complete
+    .text start:0x020c43bc end:0x020c44c4
+
+src/func_ov007_020c44c4.cpp:
+    complete
+    .text start:0x020c44c4 end:0x020c44e4
+
+src/func_ov007_020c44e4.c:
+    complete
+    .text start:0x020c44e4 end:0x020c4684
+
+src/func_ov007_020c4dfc.c:
+    complete
+    .text start:0x020c4dfc end:0x020c4e98
+
+src/func_ov007_020c4e98.c:
+    complete
+    .text start:0x020c4e98 end:0x020c4f50
+
+src/func_ov007_020c4f50.c:
+    complete
+    .text start:0x020c4f50 end:0x020c4fcc
+
+src/func_ov007_020c4fcc.cpp:
+    complete
+    .text start:0x020c4fcc end:0x020c5014
+
+src/func_ov007_020c5014.c:
+    complete
+    .text start:0x020c5014 end:0x020c510c
+
+src/func_ov007_020c510c.cpp:
+    complete
+    .text start:0x020c510c end:0x020c5188
+
+src/func_ov007_020c5188.c:
+    complete
+    .text start:0x020c5188 end:0x020c5490
+
+src/func_ov007_020c5490.c:
+    complete
+    .text start:0x020c5490 end:0x020c55bc
+
+src/func_ov007_020c55bc.c:
+    complete
+    .text start:0x020c55bc end:0x020c56bc
+
+src/func_ov007_020c56bc.c:
+    complete
+    .text start:0x020c56bc end:0x020c5854
+
+src/func_ov007_020c5854.c:
+    complete
+    .text start:0x020c5854 end:0x020c5948
+
+src/func_ov007_020c5948.c:
+    complete
+    .text start:0x020c5948 end:0x020c5a6c
+
+src/func_ov007_020c5a6c.cpp:
+    complete
+    .text start:0x020c5a6c end:0x020c5c14
+
+src/func_ov007_020c5c14.c:
+    complete
+    .text start:0x020c5c14 end:0x020c5d5c
+
+src/func_ov007_020c5d5c.c:
+    complete
+    .text start:0x020c5d5c end:0x020c5db0
+
+src/func_ov007_020c5db0.c:
+    complete
+    .text start:0x020c5db0 end:0x020c5dec
+
+src/func_ov007_020c5dec.cpp:
+    .text start:0x020c5dec end:0x020c5ef0
+
+src/func_ov007_020c5ef0.c:
+    complete
+    .text start:0x020c5ef0 end:0x020c5fc8
+
+src/func_ov007_020c5fc8.c:
+    complete
+    .text start:0x020c5fc8 end:0x020c6174
+
+src/func_ov007_020c6174.c:
+    complete
+    .text start:0x020c6174 end:0x020c62cc
+
+src/func_ov007_020c62cc.c:
+    complete
+    .text start:0x020c62cc end:0x020c6314
+
+src/func_ov007_020c6314.c:
+    complete
+    .text start:0x020c6314 end:0x020c64c4
+
+src/func_ov007_020c64c4.c:
+    complete
+    .text start:0x020c64c4 end:0x020c6550
+
+src/func_ov007_020c6550.c:
+    complete
+    .text start:0x020c6550 end:0x020c65bc
+
+src/func_ov007_020c65bc.c:
+    complete
+    .text start:0x020c65bc end:0x020c6684
+
+src/func_ov007_020c6684.c:
+    complete
+    .text start:0x020c6684 end:0x020c6724
+
+src/func_ov007_020c6724.c:
+    complete
+    .text start:0x020c6724 end:0x020c6784
+
+src/func_ov007_020c6784.c:
+    complete
+    .text start:0x020c6784 end:0x020c684c
+
+src/func_ov007_020c684c.c:
+    complete
+    .text start:0x020c684c end:0x020c690c
+
+src/func_ov007_020c690c.c:
+    complete
+    .text start:0x020c690c end:0x020c6af0
+
+src/func_ov007_020c6af0.c:
+    complete
+    .text start:0x020c6af0 end:0x020c6b58
+
+src/func_ov007_020c6b58.c:
+    complete
+    .text start:0x020c6b58 end:0x020c6d20
+
+src/func_ov007_020c6d20.c:
+    complete
+    .text start:0x020c6d20 end:0x020c6d90
+
+src/func_ov007_020c6d90.cpp:
+    complete
+    .text start:0x020c6d90 end:0x020c6e68
+
+src/func_ov007_020c704c.c:
+    complete
+    .text start:0x020c704c end:0x020c71c0
+
+src/func_ov007_020c71c0.c:
+    complete
+    .text start:0x020c71c0 end:0x020c7240
+
+src/func_ov007_020c7240.c:
+    complete
+    .text start:0x020c7240 end:0x020c72d0
+
+src/func_ov007_020c72d0.c:
+    complete
+    .text start:0x020c72d0 end:0x020c7348
+
+src/func_ov007_020c7348.c:
+    complete
+    .text start:0x020c7348 end:0x020c7368
+
+src/func_ov007_020c7368.c:
+    complete
+    .text start:0x020c7368 end:0x020c73f0
+
+src/func_ov007_020c73f0.c:
+    complete
+    .text start:0x020c73f0 end:0x020c7504
+
+src/func_ov007_020c7504.c:
+    complete
+    .text start:0x020c7504 end:0x020c7560
+
+src/func_ov007_020c7560.c:
+    complete
+    .text start:0x020c7560 end:0x020c7694
+
+src/func_ov007_020c7694.c:
+    complete
+    .text start:0x020c7694 end:0x020c775c
+
+src/func_ov007_020c775c.c:
+    complete
+    .text start:0x020c775c end:0x020c7804
+
+src/func_ov007_020c7804.c:
+    complete
+    .text start:0x020c7804 end:0x020c78b0
+
+src/func_ov007_020c78b0.c:
+    complete
+    .text start:0x020c78b0 end:0x020c78dc
+
+src/func_ov007_020c78dc.c:
+    complete
+    .text start:0x020c78dc end:0x020c798c
+
+src/func_ov007_020c798c.c:
+    .text start:0x020c798c end:0x020c7a84
+
+src/func_ov007_020c7a84.c:
+    complete
+    .text start:0x020c7a84 end:0x020c7b2c
+
+src/func_ov007_020c7b2c.c:
+    complete
+    .text start:0x020c7b2c end:0x020c7c60
+
+src/func_ov007_020c7c60.c:
+    complete
+    .text start:0x020c7c60 end:0x020c7d60
+
+src/func_ov007_020c8010.cpp:
+    complete
+    .text start:0x020c8010 end:0x020c806c
+
+src/func_ov007_020c806c.c:
+    complete
+    .text start:0x020c806c end:0x020c8098
+
+src/func_ov007_020c8098.c:
+    .text start:0x020c8098 end:0x020c80a4
+
+src/func_ov007_020c80a4.c:
+    complete
+    .text start:0x020c80a4 end:0x020c80c8
+
+src/func_ov007_020c80c8.c:
+    complete
+    .text start:0x020c80c8 end:0x020c81a0
+
+src/func_ov007_020c81a0.c:
+    complete
+    .text start:0x020c81a0 end:0x020c831c
+
+src/func_ov007_020c831c.c:
+    complete
+    .text start:0x020c831c end:0x020c83fc
+
+src/func_ov007_020c83fc.c:
+    complete
+    .text start:0x020c83fc end:0x020c8440
+
+src/func_ov007_020c8440.c:
+    .text start:0x020c8440 end:0x020c844c
+
+src/func_ov007_020c844c.c:
+    complete
+    .text start:0x020c844c end:0x020c8498
+
+src/func_ov007_020c8498.c:
+    complete
+    .text start:0x020c8498 end:0x020c8688
+
+src/func_ov007_020c8688.c:
+    complete
+    .text start:0x020c8688 end:0x020c86a8
+
+src/func_ov007_020c86a8.c:
+    complete
+    .text start:0x020c86a8 end:0x020c86c4
+
+src/func_ov007_020c86c4.c:
+    complete
+    .text start:0x020c86c4 end:0x020c8970
+
+src/func_ov007_020c8970.c:
+    .text start:0x020c8970 end:0x020c897c
+
+src/func_ov007_020c897c.c:
+    complete
+    .text start:0x020c897c end:0x020c8ac0
+
+src/func_ov007_020c8ac0.c:
+    complete
+    .text start:0x020c8ac0 end:0x020c8b04
+
+src/func_ov007_020c8b04.c:
+    .text start:0x020c8b04 end:0x020c8b10
+
+src/func_ov007_020c8b10.c:
+    complete
+    .text start:0x020c8b10 end:0x020c8b34
+
+src/func_ov007_020c8b34.c:
+    complete
+    .text start:0x020c8b34 end:0x020c8bc8
+
+src/func_ov007_020c8bc8.cpp:
+    complete
+    .text start:0x020c8bc8 end:0x020c8c88
+
+src/func_ov007_020c8c88.c:
+    complete
+    .text start:0x020c8c88 end:0x020c8de0
+
+src/func_ov007_020c8de0.c:
+    complete
+    .text start:0x020c8de0 end:0x020c8f58
+
+src/func_ov007_020c8f58.c:
+    .text start:0x020c8f58 end:0x020c8f64
+
+src/func_ov007_020c8f64.c:
+    complete
+    .text start:0x020c8f64 end:0x020c8f98
+
+src/func_ov007_020c8f98.c:
+    complete
+    .text start:0x020c8f98 end:0x020c9080
+
+src/func_ov007_020c9080.c:
+    .text start:0x020c9080 end:0x020c908c
+
+src/func_ov007_020c908c.c:
+    complete
+    .text start:0x020c908c end:0x020c90c0
+
+src/func_ov007_020c90c0.c:
+    complete
+    .text start:0x020c90c0 end:0x020c90f8
+
+src/func_ov007_020c90f8.c:
+    complete
+    .text start:0x020c90f8 end:0x020c9110
+
+src/func_ov007_020c9110.c:
+    complete
+    .text start:0x020c9110 end:0x020c9214
+
+src/func_ov007_020c9214.c:
+    .text start:0x020c9214 end:0x020c9268
+
+src/func_ov007_020c9268.c:
+    complete
+    .text start:0x020c9268 end:0x020c92a0
+
+src/func_ov007_020c92a0.c:
+    .text start:0x020c92a0 end:0x020c92ac
+
+src/func_ov007_020c92ac.c:
+    complete
+    .text start:0x020c92ac end:0x020c92d0
+
+src/func_ov007_020c92d0.c:
+    complete
+    .text start:0x020c92d0 end:0x020c934c
+
+src/func_ov007_020c934c.c:
+    complete
+    .text start:0x020c934c end:0x020c937c
+
+src/func_ov007_020c937c.c:
+    .text start:0x020c937c end:0x020c9388
+
+src/func_ov007_020c9388.c:
+    complete
+    .text start:0x020c9388 end:0x020c93b4
+
+src/func_ov007_020c93b4.c:
+    complete
+    .text start:0x020c93b4 end:0x020c93c4
+
+src/func_ov007_020c93c4.c:
+    complete
+    .text start:0x020c93c4 end:0x020c940c
+
+src/func_ov007_020c940c.c:
+    complete
+    .text start:0x020c940c end:0x020c9460
+
+src/func_ov007_020c9460.c:
+    .text start:0x020c9460 end:0x020c946c
+
+src/func_ov007_020c946c.c:
+    complete
+    .text start:0x020c946c end:0x020c94a0
+
+src/func_ov007_020c94a0.c:
+    complete
+    .text start:0x020c94a0 end:0x020c94e4
+
+src/func_ov007_020c94e4.c:
+    complete
+    .text start:0x020c94e4 end:0x020c951c
+
+src/func_ov007_020c951c.c:
+    complete
+    .text start:0x020c951c end:0x020c95fc
+
+src/func_ov007_020c95fc.c:
+    complete
+    .text start:0x020c95fc end:0x020c9688
+
+src/func_ov007_020c9988.c:
+    complete
+    .text start:0x020c9988 end:0x020c99d8
+
+src/func_ov007_020c99d8.c:
+    complete
+    .text start:0x020c99d8 end:0x020c9a2c
+
+src/func_ov007_020c9a2c.c:
+    complete
+    .text start:0x020c9a2c end:0x020c9a84
+
+src/func_ov007_020c9a84.c:
+    complete
+    .text start:0x020c9a84 end:0x020c9c24
+
+src/func_ov007_020c9c24.c:
+    complete
+    .text start:0x020c9c24 end:0x020c9d90
+
+src/func_ov007_020c9d90.c:
+    complete
+    .text start:0x020c9d90 end:0x020c9f10
+
+src/func_ov007_020c9f10.c:
+    complete
+    .text start:0x020c9f10 end:0x020c9fa0
+
+src/func_ov007_020c9fa0.cpp:
+    complete
+    .text start:0x020c9fa0 end:0x020ca010
+
+src/func_ov007_020ca010.c:
+    complete
+    .text start:0x020ca010 end:0x020ca1d4
+
+src/func_ov007_020ca1d4.c:
+    complete
+    .text start:0x020ca1d4 end:0x020ca26c
+
+src/func_ov007_020ca26c.c:
+    complete
+    .text start:0x020ca26c end:0x020ca2a8
+
+src/func_ov007_020ca2a8.c:
+    complete
+    .text start:0x020ca2a8 end:0x020ca308
+
+src/func_ov007_020ca308.c:
+    complete
+    .text start:0x020ca308 end:0x020ca578
+
+src/func_ov007_020ca578.c:
+    complete
+    .text start:0x020ca578 end:0x020ca5f0
+
+src/func_ov007_020ca5f0.c:
+    complete
+    .text start:0x020ca5f0 end:0x020ca86c
+
+src/func_ov007_020ca86c.c:
+    complete
+    .text start:0x020ca86c end:0x020caeac
+
+src/func_ov007_020cb3dc.c:
+    complete
+    .text start:0x020cb3dc end:0x020cb4b0
+
+src/func_ov007_020cba78.c:
+    complete
+    .text start:0x020cba78 end:0x020cbb04
+
+src/func_ov007_020cbb04.cpp:
+    complete
+    .text start:0x020cbb04 end:0x020cbbb0
+
+src/func_ov007_020cbf8c.c:
+    complete
+    .text start:0x020cbf8c end:0x020cc028
+
+src/func_ov007_020cc028.c:
+    .text start:0x020cc028 end:0x020cc070
+
+src/func_ov007_020cc070.c:
+    .text start:0x020cc070 end:0x020cc0cc
+
+src/func_ov007_020cc0cc.c:
+    complete
+    .text start:0x020cc0cc end:0x020cc0e4
+
+src/func_ov007_020cc0e4.c:
+    complete
+    .text start:0x020cc0e4 end:0x020cc0f4
+
+src/func_ov007_020cc0f4.c:
+    complete
+    .text start:0x020cc0f4 end:0x020cc110
+
+src/func_ov007_020cc110.c:
+    complete
+    .text start:0x020cc110 end:0x020cc118
+
+src/func_ov007_020cc118.c:
+    complete
+    .text start:0x020cc118 end:0x020cc168
+
+src/func_ov007_020cc168.c:
+    complete
+    .text start:0x020cc168 end:0x020cc2ac
+
+src/func_ov007_020cc2ac.c:
+    complete
+    .text start:0x020cc2ac end:0x020cc2b0
+
+src/func_ov007_020cc2b0.c:
+    complete
+    .text start:0x020cc2b0 end:0x020cc2cc
+
+src/func_ov007_020cc2cc.c:
+    .text start:0x020cc2cc end:0x020cc45c
+
+src/func_ov007_020cc45c.c:
+    complete
+    .text start:0x020cc45c end:0x020cc4c0
+
+src/func_ov007_020cc4c0.cpp:
+    .text start:0x020cc4c0 end:0x020cc600
+
+src/func_ov007_020cc600.c:
+    complete
+    .text start:0x020cc600 end:0x020cca68
+
+src/func_ov007_020cca68.c:
+    .text start:0x020cca68 end:0x020cca74
+
+src/func_ov007_020cca74.c:
+    .text start:0x020cca74 end:0x020cca80
+
+src/func_ov007_020cca80.c:
+    complete
+    .text start:0x020cca80 end:0x020cca98
+
+src/func_ov007_020cca98.c:
+    .text start:0x020cca98 end:0x020ccab4
+
+src/func_ov007_020ccab4.c:
+    .text start:0x020ccab4 end:0x020ccad0
+
+src/func_ov007_020ccad0.c:
+    complete
+    .text start:0x020ccad0 end:0x020ccb54

--- a/config/arm9/overlays/ov009/delinks.txt
+++ b/config/arm9/overlays/ov009/delinks.txt
@@ -4,3 +4,144 @@
     .ctor       start:0x02112b34 end:0x02112b44 kind:rodata align:4
     .data       start:0x02112b60 end:0x02113c20 kind:data align:32
     .bss        start:0x02113c20 end:0x02113ee0 kind:bss align:32
+src/_ZN4BirdD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111d8
+
+src/_ZN4BirdD0Ev.c:
+    complete
+    .text start:0x021111d8 end:0x02111224
+
+src/func_ov009_02111224.c:
+    complete
+    .text start:0x02111224 end:0x02111234
+
+src/func_ov009_02111234.cpp:
+    complete
+    .text start:0x02111234 end:0x0211145c
+
+src/func_ov009_021115d8.c:
+    complete
+    .text start:0x021115d8 end:0x021116ec
+
+src/func_ov009_021116ec.cpp:
+    complete
+    .text start:0x021116ec end:0x0211183c
+
+src/_ZN4Bird16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211183c end:0x0211186c
+
+src/_ZN4Bird16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211186c end:0x02111870
+
+src/_ZN4Bird6RenderEv.cpp:
+    complete
+    .text start:0x02111870 end:0x02111898
+
+src/_ZN4Bird8BehaviorEv.cpp:
+    complete
+    .text start:0x02111898 end:0x0211197c
+
+src/_ZN4Bird13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211197c end:0x02111a30
+
+src/Bird_Spawn.c:
+    complete
+    .text start:0x02111a30 end:0x02111a70
+
+src/func_ov009_02111a70.c:
+    .text start:0x02111a70 end:0x02111abc
+
+src/func_ov009_02111abc.c:
+    .text start:0x02111abc end:0x02111b1c
+
+src/func_ov009_02111b1c.cpp:
+    complete
+    .text start:0x02111b1c end:0x02111bd4
+
+src/func_ov009_02111bd4.cpp:
+    complete
+    .text start:0x02111bd4 end:0x02111c18
+
+src/func_ov009_02111c18.cpp:
+    complete
+    .text start:0x02111c18 end:0x02111c4c
+
+src/func_ov009_02111c4c.cpp:
+    complete
+    .text start:0x02111c4c end:0x02111c74
+
+src/func_ov009_02111c74.cpp:
+    complete
+    .text start:0x02111c74 end:0x02111d8c
+
+src/CastleWater_Spawn.c:
+    .text start:0x02111d8c end:0x02111dc4
+
+src/_ZN11CastleWaterD1Ev.c:
+    .text start:0x02111dc4 end:0x02111e08
+
+src/_ZN11CastleWaterD0Ev.c:
+    .text start:0x02111e08 end:0x02111e60
+
+src/_ZN11CastleWater16CleanupResourcesEv.cpp:
+    .text start:0x02111e60 end:0x02111ea4
+
+src/_ZN11CastleWater16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111ea4 end:0x02111ea8
+
+src/_ZN11CastleWater6RenderEv.cpp:
+    complete
+    .text start:0x02111ea8 end:0x02111ed0
+
+src/_ZN11CastleWater8BehaviorEv.cpp:
+    .text start:0x02111ed0 end:0x02111f40
+
+src/_ZN11CastleWater13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111f40 end:0x02112048
+
+src/DockPole_Spawn.c:
+    complete
+    .text start:0x02112048 end:0x02112078
+
+src/_ZN8DockPoleD1Ev.cpp:
+    .text start:0x02112078 end:0x021120a8
+
+src/_ZN8DockPoleD0Ev.c:
+    complete
+    .text start:0x021120a8 end:0x021120ec
+
+src/_ZN8DockPole16CleanupResourcesEv.c:
+    complete
+    .text start:0x021120ec end:0x0211211c
+
+src/_ZN8DockPole6RenderEv.cpp:
+    complete
+    .text start:0x0211211c end:0x02112144
+
+src/_ZN8DockPole8BehaviorEv.cpp:
+    complete
+    .text start:0x02112144 end:0x02112190
+
+src/_ZN8DockPole13InitResourcesEv.cpp:
+    .text start:0x02112190 end:0x021121f0
+
+src/Flag_Spawn.c:
+    complete
+    .text start:0x021121f0 end:0x02112228
+
+src/__sinit_ov009_02112458.c:
+    .init start:0x02112458 end:0x02112524
+
+src/__sinit_ov009_02112524.c:
+    .init start:0x02112524 end:0x02112a5c
+
+src/__sinit_ov009_02112a5c.c:
+    .init start:0x02112a5c end:0x02112ac8
+
+src/__sinit_ov009_02112ac8.c:
+    .init start:0x02112ac8 end:0x02112b34

--- a/config/arm9/overlays/ov010/delinks.txt
+++ b/config/arm9/overlays/ov010/delinks.txt
@@ -3,3 +3,133 @@
     .ctor       start:0x0211219c end:0x021121a8 kind:rodata align:4
     .data       start:0x021121c0 end:0x02112d00 kind:data align:32
     .bss        start:0x02112d00 end:0x02112d80 kind:bss align:32
+src/func_ov010_021111a0.c:
+    .text start:0x021111a0 end:0x021111ec
+
+src/func_ov010_021111ec.c:
+    .text start:0x021111ec end:0x0211124c
+
+src/func_ov010_0211124c.c:
+    complete
+    .text start:0x0211124c end:0x0211125c
+
+src/func_ov010_0211125c.c:
+    complete
+    .text start:0x0211125c end:0x02111284
+
+src/func_ov010_02111284.c:
+    complete
+    .text start:0x02111284 end:0x021112b4
+
+src/func_ov010_021112b4.c:
+    complete
+    .text start:0x021112b4 end:0x02111320
+
+src/func_ov010_02111320.c:
+    complete
+    .text start:0x02111320 end:0x0211139c
+
+src/func_ov010_0211139c.cpp:
+    complete
+    .text start:0x0211139c end:0x021113f0
+
+src/func_ov010_021113f0.c:
+    complete
+    .text start:0x021113f0 end:0x0211146c
+
+src/func_ov010_0211146c.c:
+    complete
+    .text start:0x0211146c end:0x02111554
+
+src/func_ov010_02111554.cpp:
+    .text start:0x02111554 end:0x021115a8
+
+src/func_ov010_021115a8.cpp:
+    complete
+    .text start:0x021115a8 end:0x021115e0
+
+src/func_ov010_021115e0.cpp:
+    complete
+    .text start:0x021115e0 end:0x02111654
+
+src/func_ov010_02111654.c:
+    complete
+    .text start:0x02111654 end:0x0211184c
+
+src/func_ov010_0211184c.c:
+    complete
+    .text start:0x0211184c end:0x02111984
+
+src/func_ov010_02111984.c:
+    complete
+    .text start:0x02111984 end:0x02111998
+
+src/Trap_Spawn.c:
+    .text start:0x02111998 end:0x021119d0
+
+src/_ZN4TrapD1Ev.cpp:
+    .text start:0x021119d0 end:0x02111a08
+
+src/_ZN4TrapD0Ev.c:
+    complete
+    .text start:0x02111a08 end:0x02111a54
+
+src/func_ov010_02111a54.c:
+    complete
+    .text start:0x02111a54 end:0x02111a94
+
+src/_ZN4Trap16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111a94 end:0x02111ab8
+
+src/_ZN4Trap6RenderEv.cpp:
+    complete
+    .text start:0x02111ab8 end:0x02111ae0
+
+src/_ZN4Trap8BehaviorEv.cpp:
+    .text start:0x02111ae0 end:0x02111d20
+
+src/_ZN4Trap13InitResourcesEv.cpp:
+    .text start:0x02111d20 end:0x02111dd0
+
+src/LightBeam_Spawn.c:
+    complete
+    .text start:0x02111dd0 end:0x02111e10
+
+src/_ZN13PeachPaintingD1Ev.cpp:
+    .text start:0x02111e10 end:0x02111e40
+
+src/_ZN13PeachPaintingD0Ev.c:
+    complete
+    .text start:0x02111e40 end:0x02111e84
+
+src/func_ov010_02111e84.c:
+    complete
+    .text start:0x02111e84 end:0x02111ec4
+
+src/_ZN13PeachPainting16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111ec4 end:0x02111ee8
+
+src/_ZN13PeachPainting6RenderEv.cpp:
+    complete
+    .text start:0x02111ee8 end:0x02111f28
+
+src/_ZN13PeachPainting8BehaviorEv.cpp:
+    .text start:0x02111f28 end:0x02111fc0
+
+src/_ZN13PeachPainting13InitResourcesEv.cpp:
+    .text start:0x02111fc0 end:0x02112004
+
+src/PeachPainting_Spawn.c:
+    complete
+    .text start:0x02112004 end:0x0211203c
+
+src/__sinit_ov010_0211203c.c:
+    .init start:0x0211203c end:0x0211211c
+
+src/__sinit_ov010_0211211c.c:
+    .init start:0x0211211c end:0x0211215c
+
+src/__sinit_ov010_0211215c.c:
+    .init start:0x0211215c end:0x0211219c

--- a/config/arm9/overlays/ov012/delinks.txt
+++ b/config/arm9/overlays/ov012/delinks.txt
@@ -4,3 +4,62 @@
     .ctor       start:0x02111b60 end:0x02111b68 kind:rodata align:4
     .data       start:0x02111b80 end:0x021124a0 kind:data align:32
     .bss        start:0x021124a0 end:0x02112500 kind:bss align:32
+src/func_ov012_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov012_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov012_0211123c.c:
+    complete
+    .text start:0x0211123c end:0x021112ec
+
+src/func_ov012_021112ec.c:
+    complete
+    .text start:0x021112ec end:0x02111324
+
+src/func_ov012_02111324.cpp:
+    complete
+    .text start:0x02111324 end:0x0211134c
+
+src/func_ov012_0211134c.cpp:
+    complete
+    .text start:0x0211134c end:0x02111370
+
+src/func_ov012_02111370.c:
+    complete
+    .text start:0x02111370 end:0x02111420
+
+src/SwitchPillar_Spawn.c:
+    complete
+    .text start:0x02111420 end:0x02111450
+
+src/_ZN12SwitchPillarD1Ev.c:
+    .text start:0x02111450 end:0x0211149c
+
+src/_ZN12SwitchPillarD0Ev.c:
+    .text start:0x0211149c end:0x021114fc
+
+src/_ZN12SwitchPillar16CleanupResourcesEv.cpp:
+    .text start:0x021114fc end:0x02111540
+
+src/_ZN12SwitchPillar6RenderEv.cpp:
+    complete
+    .text start:0x02111540 end:0x02111574
+
+src/_ZN12SwitchPillar8BehaviorEv.cpp:
+    .text start:0x02111574 end:0x0211164c
+
+src/_ZN12SwitchPillar13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211164c end:0x02111730
+
+src/BasementWater_Spawn.c:
+    complete
+    .text start:0x02111730 end:0x02111768
+
+src/__sinit_ov012_02111a88.c:
+    .init start:0x02111a88 end:0x02111af4
+
+src/__sinit_ov012_02111af4.c:
+    .init start:0x02111af4 end:0x02111b60

--- a/config/arm9/overlays/ov013/delinks.txt
+++ b/config/arm9/overlays/ov013/delinks.txt
@@ -4,3 +4,70 @@
     .ctor       start:0x02111760 end:0x02111768 kind:rodata align:4
     .data       start:0x02111780 end:0x02112280 kind:data align:32
     .bss        start:0x02112280 end:0x021122c0 kind:bss align:32
+src/func_ov013_021111a0.c:
+    complete
+    .text start:0x021111a0 end:0x021111d0
+
+src/func_ov013_021111d0.c:
+    .text start:0x021111d0 end:0x02111214
+
+src/func_ov013_02111214.c:
+    complete
+    .text start:0x02111214 end:0x02111238
+
+src/func_ov013_02111238.c:
+    complete
+    .text start:0x02111238 end:0x02111280
+
+src/func_ov013_02111280.cpp:
+    complete
+    .text start:0x02111280 end:0x021112a8
+
+src/func_ov013_021112a8.c:
+    complete
+    .text start:0x021112a8 end:0x0211133c
+
+src/func_ov013_0211133c.cpp:
+    .text start:0x0211133c end:0x02111384
+
+src/ClockPaintingPendulum_Spawn.c:
+    .text start:0x02111384 end:0x021113bc
+
+src/_ZN22ClockPaintingHandShortD1Ev.cpp:
+    .text start:0x021113bc end:0x021113ec
+
+src/_ZN22ClockPaintingHandShortD0Ev.c:
+    complete
+    .text start:0x021113ec end:0x02111430
+
+src/func_ov013_02111430.c:
+    complete
+    .text start:0x02111430 end:0x02111478
+
+src/_ZN22ClockPaintingHandShort16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02111478 end:0x021114a4
+
+src/_ZN22ClockPaintingHandShort6RenderEv.cpp:
+    complete
+    .text start:0x021114a4 end:0x021114cc
+
+src/_ZN22ClockPaintingHandShort8BehaviorEv.cpp:
+    .text start:0x021114cc end:0x021115cc
+
+src/_ZN22ClockPaintingHandShort13InitResourcesEv.cpp:
+    .text start:0x021115cc end:0x0211163c
+
+src/ClockPaintingHandShort_Spawn.c:
+    complete
+    .text start:0x0211163c end:0x02111674
+
+src/ClockPaintingHandLong_Spawn.c:
+    complete
+    .text start:0x02111674 end:0x021116ac
+
+src/__sinit_ov013_021116b8.c:
+    .init start:0x021116b8 end:0x021116f8
+
+src/__sinit_ov013_021116f8.c:
+    .init start:0x021116f8 end:0x02111760

--- a/config/arm9/overlays/ov014/delinks.txt
+++ b/config/arm9/overlays/ov014/delinks.txt
@@ -3,3 +3,167 @@
     .ctor       start:0x02113368 end:0x02113374 kind:rodata align:4
     .data       start:0x02113380 end:0x02114940 kind:data align:32
     .bss        start:0x02114940 end:0x021149e0 kind:bss align:32
+src/_ZN10ShutterBobD1Ev.c:
+    .text start:0x021111a0 end:0x021111f0
+
+src/_ZN10ShutterBobD0Ev.c:
+    .text start:0x021111f0 end:0x02111254
+
+src/_ZN10ShutterBob16CleanupResourcesEv.cpp:
+    .text start:0x02111254 end:0x02111268
+
+src/_ZN10ShutterBob8BehaviorEv.cpp:
+    .text start:0x02111268 end:0x02111294
+
+src/_ZN10ShutterBob13InitResourcesEv.cpp:
+    .text start:0x02111294 end:0x021112cc
+
+src/ShutterBob_Spawn.c:
+    .text start:0x021112cc end:0x02111308
+
+src/_ZN10ChainChompD1Ev.c:
+    complete
+    .text start:0x02111308 end:0x021113bc
+
+src/_ZN10ChainChompD0Ev.cpp:
+    .text start:0x021113bc end:0x02111484
+
+src/func_ov014_02111484.c:
+    complete
+    .text start:0x02111484 end:0x021114d8
+
+src/func_ov014_021114d8.c:
+    complete
+    .text start:0x021114d8 end:0x0211150c
+
+src/func_ov014_0211150c.c:
+    complete
+    .text start:0x0211150c end:0x021115c0
+
+src/func_ov014_021115c0.c:
+    complete
+    .text start:0x021115c0 end:0x021115ec
+
+src/func_ov014_021115ec.cpp:
+    complete
+    .text start:0x021115ec end:0x02111a6c
+
+src/func_ov014_02111a6c.cpp:
+    .text start:0x02111a6c end:0x02111af0
+
+src/func_ov014_02111af0.c:
+    complete
+    .text start:0x02111af0 end:0x02111b70
+
+src/func_ov014_02111b70.c:
+    complete
+    .text start:0x02111b70 end:0x02111ca8
+
+src/func_ov014_02111ca8.cpp:
+    complete
+    .text start:0x02111ca8 end:0x02111dc4
+
+src/func_ov014_02111dc4.cpp:
+    complete
+    .text start:0x02111dc4 end:0x02111e14
+
+src/func_ov014_02111e14.c:
+    complete
+    .text start:0x02111e14 end:0x02111e74
+
+src/func_ov014_02111e74.cpp:
+    .text start:0x02111e74 end:0x02111ebc
+
+src/func_ov014_02111ebc.cpp:
+    complete
+    .text start:0x02111ebc end:0x02111f08
+
+src/func_ov014_02111f08.cpp:
+    complete
+    .text start:0x02111f08 end:0x02111f54
+
+src/func_ov014_02111f54.cpp:
+    complete
+    .text start:0x02111f54 end:0x02111fb8
+
+src/func_ov014_02111fb8.c:
+    complete
+    .text start:0x02111fb8 end:0x02111fe0
+
+src/func_ov014_02111fe0.c:
+    complete
+    .text start:0x02111fe0 end:0x02112114
+
+src/func_ov014_02112114.c:
+    complete
+    .text start:0x02112114 end:0x021122dc
+
+src/func_ov014_021122dc.c:
+    complete
+    .text start:0x021122dc end:0x0211236c
+
+src/func_ov014_0211236c.c:
+    complete
+    .text start:0x0211236c end:0x0211250c
+
+src/func_ov014_0211250c.c:
+    complete
+    .text start:0x0211250c end:0x02112788
+
+src/func_ov014_02112788.c:
+    complete
+    .text start:0x02112788 end:0x0211294c
+
+src/_ZN10ChainChomp16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211294c end:0x02112994
+
+src/_ZN10ChainChomp6RenderEv.cpp:
+    complete
+    .text start:0x02112994 end:0x021129ec
+
+src/_ZN10ChainChomp8BehaviorEv.cpp:
+    complete
+    .text start:0x021129ec end:0x02112b14
+
+src/_ZN10ChainChomp13InitResourcesEv.cpp:
+    .text start:0x02112b14 end:0x02112d1c
+
+src/ChainChomp_Spawn.cpp:
+    .text start:0x02112d1c end:0x02112e0c
+
+src/_ZN15ChainChompFenceD1Ev.c:
+    .text start:0x02112e0c end:0x02112e50
+
+src/_ZN15ChainChompFenceD0Ev.c:
+    .text start:0x02112e50 end:0x02112ea8
+
+src/func_ov014_02112ea8.cpp:
+    .text start:0x02112ea8 end:0x02112f3c
+
+src/_ZN15ChainChompFence16CleanupResourcesEv.cpp:
+    .text start:0x02112f3c end:0x02112f80
+
+src/_ZN15ChainChompFence6RenderEv.cpp:
+    complete
+    .text start:0x02112f80 end:0x02112fc0
+
+src/_ZN15ChainChompFence8BehaviorEv.cpp:
+    complete
+    .text start:0x02112fc0 end:0x02112ffc
+
+src/_ZN15ChainChompFence13InitResourcesEv.cpp:
+    .text start:0x02112ffc end:0x0211307c
+
+src/ChainChompFence_Spawn.c:
+    complete
+    .text start:0x0211307c end:0x021130ac
+
+src/__sinit_ov014_021130ac.c:
+    .init start:0x021130ac end:0x02113118
+
+src/__sinit_ov014_02113118.c:
+    .init start:0x02113118 end:0x021132fc
+
+src/__sinit_ov014_021132fc.c:
+    .init start:0x021132fc end:0x02113368

--- a/config/arm9/overlays/ov015/delinks.txt
+++ b/config/arm9/overlays/ov015/delinks.txt
@@ -4,3 +4,274 @@
     .ctor       start:0x02113410 end:0x0211342c kind:rodata align:4
     .data       start:0x02113440 end:0x02114960 kind:data align:32
     .bss        start:0x02114960 end:0x02114b00 kind:bss align:32
+src/func_ov015_021111a0.c:
+    .text start:0x021111a0 end:0x021111d0
+
+src/func_ov015_021111d0.c:
+    .text start:0x021111d0 end:0x02111214
+
+src/func_ov015_02111214.c:
+    complete
+    .text start:0x02111214 end:0x02111254
+
+src/func_ov015_02111254.c:
+    complete
+    .text start:0x02111254 end:0x02111278
+
+src/func_ov015_02111278.cpp:
+    complete
+    .text start:0x02111278 end:0x021112a0
+
+src/func_ov015_021112a0.cpp:
+    .text start:0x021112a0 end:0x021112dc
+
+src/PoleBillboard_Spawn.c:
+    .text start:0x021112dc end:0x02111314
+
+src/_ZN13PoleBillboardD1Ev.c:
+    .text start:0x02111314 end:0x02111360
+
+src/_ZN13PoleBillboardD0Ev.c:
+    .text start:0x02111360 end:0x021113c0
+
+src/func_ov015_021113c0.cpp:
+    complete
+    .text start:0x021113c0 end:0x021113fc
+
+src/func_ov015_021113fc.c:
+    complete
+    .text start:0x021113fc end:0x02111408
+
+src/func_ov015_02111408.c:
+    complete
+    .text start:0x02111408 end:0x02111414
+
+src/func_ov015_02111414.c:
+    complete
+    .text start:0x02111414 end:0x021114f0
+
+src/func_ov015_0211166c.c:
+    complete
+    .text start:0x0211166c end:0x021116b4
+
+src/_ZN13PoleBillboard16CleanupResourcesEv.cpp:
+    .text start:0x021116b4 end:0x021116f8
+
+src/_ZN13PoleBillboard6RenderEv.cpp:
+    complete
+    .text start:0x021116f8 end:0x02111720
+
+src/KnockDownPlank_Spawn.c:
+    complete
+    .text start:0x02111b68 end:0x02111ba0
+
+src/_ZN14KnockDownPlankD1Ev.c:
+    .text start:0x02111ba0 end:0x02111be4
+
+src/_ZN14KnockDownPlankD0Ev.c:
+    .text start:0x02111be4 end:0x02111c3c
+
+src/func_ov015_02111c3c.cpp:
+    complete
+    .text start:0x02111c3c end:0x02111cb8
+
+src/func_ov015_02111cb8.cpp:
+    complete
+    .text start:0x02111cb8 end:0x02111ce0
+
+src/func_ov015_02111ce0.cpp:
+    complete
+    .text start:0x02111ce0 end:0x02111d28
+
+src/func_ov015_02111d28.c:
+    .text start:0x02111d28 end:0x02111d4c
+
+src/func_ov015_02111d4c.c:
+    complete
+    .text start:0x02111d4c end:0x02111d8c
+
+src/func_ov015_02111d8c.c:
+    complete
+    .text start:0x02111d8c end:0x02111d98
+
+src/func_ov015_02111d98.cpp:
+    .text start:0x02111d98 end:0x02111dd4
+
+src/func_ov015_02111dd4.c:
+    complete
+    .text start:0x02111dd4 end:0x02111df4
+
+src/func_ov015_02111df4.c:
+    complete
+    .text start:0x02111df4 end:0x02111e60
+
+src/func_ov015_02111e60.c:
+    complete
+    .text start:0x02111e60 end:0x02111e80
+
+src/func_ov015_02111e80.c:
+    complete
+    .text start:0x02111e80 end:0x02111ee0
+
+src/func_ov015_02111ee0.c:
+    complete
+    .text start:0x02111ee0 end:0x02111eec
+
+src/func_ov015_02111eec.c:
+    complete
+    .text start:0x02111eec end:0x02111f4c
+
+src/func_ov015_02111f4c.c:
+    complete
+    .text start:0x02111f4c end:0x02111f6c
+
+src/func_ov015_02111f6c.c:
+    complete
+    .text start:0x02111f6c end:0x02111fac
+
+src/func_ov015_02111fac.c:
+    complete
+    .text start:0x02111fac end:0x02111fb8
+
+src/func_ov015_02111fb8.c:
+    complete
+    .text start:0x02111fb8 end:0x02112004
+
+src/_ZN14KnockDownPlank16CleanupResourcesEv.cpp:
+    .text start:0x02112004 end:0x02112068
+
+src/_ZN14KnockDownPlank6RenderEv.cpp:
+    complete
+    .text start:0x02112068 end:0x02112090
+
+src/_ZN14KnockDownPlank8BehaviorEv.cpp:
+    complete
+    .text start:0x02112090 end:0x021120fc
+
+src/_ZN14KnockDownPlank13InitResourcesEv.cpp:
+    .text start:0x021120fc end:0x02112230
+
+src/MovingBarBig_Spawn.c:
+    complete
+    .text start:0x02112230 end:0x02112260
+
+src/MovingBarSmall_Spawn.c:
+    complete
+    .text start:0x02112260 end:0x02112290
+
+src/_ZN14MovingBarSmallD1Ev.c:
+    .text start:0x02112290 end:0x021122dc
+
+src/_ZN14MovingBarSmallD0Ev.c:
+    .text start:0x021122dc end:0x0211233c
+
+src/func_ov015_0211233c.cpp:
+    complete
+    .text start:0x0211233c end:0x021123a0
+
+src/func_ov015_021123a0.cpp:
+    complete
+    .text start:0x021123a0 end:0x021123c8
+
+src/func_ov015_021123c8.cpp:
+    complete
+    .text start:0x021123c8 end:0x02112464
+
+src/_ZN14MovingBarSmall16CleanupResourcesEv.cpp:
+    .text start:0x02112464 end:0x021124a8
+
+src/_ZN14MovingBarSmall6RenderEv.cpp:
+    complete
+    .text start:0x021124a8 end:0x021124d0
+
+src/_ZN14MovingBarSmall13InitResourcesEv.cpp:
+    .text start:0x0211269c end:0x021128e8
+
+src/func_ov015_021128e8.c:
+    complete
+    .text start:0x021128e8 end:0x021128f8
+
+src/func_ov015_021128f8.c:
+    complete
+    .text start:0x021128f8 end:0x0211290c
+
+src/TowerStep_Spawn.c:
+    complete
+    .text start:0x0211290c end:0x02112944
+
+src/_ZN9TowerStepD1Ev.c:
+    .text start:0x02112944 end:0x02112988
+
+src/_ZN9TowerStepD0Ev.c:
+    .text start:0x02112988 end:0x021129e0
+
+src/_ZN9TowerStep16CleanupResourcesEv.cpp:
+    .text start:0x021129e0 end:0x02112a24
+
+src/_ZN9TowerStep6RenderEv.cpp:
+    complete
+    .text start:0x02112a24 end:0x02112a4c
+
+src/_ZN9TowerStep8BehaviorEv.cpp:
+    .text start:0x02112a4c end:0x02112b04
+
+src/_ZN9TowerStep13InitResourcesEv.cpp:
+    complete
+    .text start:0x02112b04 end:0x02112ba0
+
+src/RotatingBridge_Spawn.c:
+    complete
+    .text start:0x02112ba0 end:0x02112bd0
+
+src/func_ov015_02112bd0.c:
+    .text start:0x02112bd0 end:0x02112c20
+
+src/func_ov015_02112c20.c:
+    .text start:0x02112c20 end:0x02112c84
+
+src/func_ov015_02112c84.c:
+    .text start:0x02112c84 end:0x02112c98
+
+src/func_ov015_02112c98.c:
+    complete
+    .text start:0x02112c98 end:0x02112cb8
+
+src/RotatingPlatformWf_Spawn.c:
+    .text start:0x02112cb8 end:0x02112cf4
+
+src/_ZN11FallBlockWfD1Ev.c:
+    .text start:0x02112cf4 end:0x02112d44
+
+src/_ZN11FallBlockWfD0Ev.c:
+    .text start:0x02112d44 end:0x02112da8
+
+src/_ZN11FallBlockWf16CleanupResourcesEv.c:
+    .text start:0x02112da8 end:0x02112dbc
+
+src/_ZN11FallBlockWf13InitResourcesEv.c:
+    .text start:0x02112dbc end:0x02112dd0
+
+src/FallBlockWf_Spawn.c:
+    complete
+    .text start:0x02112dd0 end:0x02112e0c
+
+src/__sinit_ov015_02112f9c.c:
+    .init start:0x02112f9c end:0x02112fdc
+
+src/__sinit_ov015_02112fdc.c:
+    .init start:0x02112fdc end:0x02113048
+
+src/__sinit_ov015_02113048.c:
+    .init start:0x02113048 end:0x02113264
+
+src/__sinit_ov015_02113264.c:
+    .init start:0x02113264 end:0x021132d0
+
+src/__sinit_ov015_021132d0.c:
+    .init start:0x021132d0 end:0x0211333c
+
+src/__sinit_ov015_0211333c.c:
+    .init start:0x0211333c end:0x021133a8
+
+src/__sinit_ov015_021133a8.c:
+    .init start:0x021133a8 end:0x02113410

--- a/config/arm9/overlays/ov016/delinks.txt
+++ b/config/arm9/overlays/ov016/delinks.txt
@@ -4,3 +4,192 @@
     .ctor       start:0x02113abc end:0x02113ad0 kind:rodata align:4
     .data       start:0x02113ae0 end:0x02114d20 kind:data align:32
     .bss        start:0x02114d20 end:0x02114ea0 kind:bss align:32
+src/_ZN5UnagiD1Ev.c:
+    complete
+    .text start:0x021111a0 end:0x02111208
+
+src/_ZN5UnagiD0Ev.cpp:
+    .text start:0x02111208 end:0x02111284
+
+src/func_ov016_02111284.c:
+    complete
+    .text start:0x02111284 end:0x02111534
+
+src/func_ov016_02111534.c:
+    complete
+    .text start:0x02111534 end:0x021115a4
+
+src/BookSwitch_Spawn.c:
+    complete
+    .text start:0x021115a4 end:0x021115c0
+
+src/func_ov016_021115c0.c:
+    complete
+    .text start:0x021115c0 end:0x02111718
+
+src/func_ov016_02111718.cpp:
+    complete
+    .text start:0x02111718 end:0x02111758
+
+src/func_ov016_02111758.cpp:
+    .text start:0x02111758 end:0x02111860
+
+src/func_ov016_02111860.cpp:
+    complete
+    .text start:0x02111860 end:0x021118b4
+
+src/func_ov016_021118b4.cpp:
+    .text start:0x021118b4 end:0x02111994
+
+src/func_ov016_02111994.cpp:
+    complete
+    .text start:0x02111994 end:0x021119ec
+
+src/func_ov016_021119ec.c:
+    complete
+    .text start:0x021119ec end:0x02111bac
+
+src/func_ov016_02111bac.cpp:
+    complete
+    .text start:0x02111bac end:0x02111bf0
+
+src/func_ov016_02111bf0.cpp:
+    complete
+    .text start:0x02111bf0 end:0x02111c40
+
+src/_ZN5Unagi16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111f38 end:0x02111f80
+
+src/_ZN5Unagi16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111f80 end:0x02111f84
+
+src/_ZN5Unagi6RenderEv.c:
+    complete
+    .text start:0x02111f84 end:0x02112010
+
+src/_ZN5Unagi8BehaviorEv.cpp:
+    .text start:0x02112010 end:0x021121c0
+
+src/_ZN5Unagi13InitResourcesEv.cpp:
+    .text start:0x021121c0 end:0x02112588
+
+src/Unagi_Spawn.c:
+    complete
+    .text start:0x02112588 end:0x0211260c
+
+src/_ZN6ShipUpD1Ev.c:
+    .text start:0x0211260c end:0x02112650
+
+src/_ZN6ShipUpD0Ev.c:
+    .text start:0x02112650 end:0x021126a8
+
+src/func_ov016_021126a8.c:
+    complete
+    .text start:0x021126a8 end:0x021126f0
+
+src/_ZN6ShipUp16CleanupResourcesEv.cpp:
+    .text start:0x021126f0 end:0x02112744
+
+src/_ZN6ShipUp6RenderEv.cpp:
+    complete
+    .text start:0x02112744 end:0x0211276c
+
+src/_ZN6ShipUp8BehaviorEv.cpp:
+    .text start:0x0211276c end:0x0211283c
+
+src/_ZN6ShipUp13InitResourcesEv.cpp:
+    .text start:0x0211283c end:0x021129a0
+
+src/ShipUp_Spawn.c:
+    complete
+    .text start:0x021129a0 end:0x021129d0
+
+src/ShipDown_Spawn.c:
+    complete
+    .text start:0x021129d0 end:0x02112a00
+
+src/func_ov016_02112a00.c:
+    .text start:0x02112a00 end:0x02112a44
+
+src/func_ov016_02112a44.c:
+    .text start:0x02112a44 end:0x02112a9c
+
+src/func_ov016_02112a9c.c:
+    complete
+    .text start:0x02112a9c end:0x02112ae4
+
+src/func_ov016_02112ae4.c:
+    .text start:0x02112ae4 end:0x02112b28
+
+src/func_ov016_02112b28.cpp:
+    complete
+    .text start:0x02112b28 end:0x02112b50
+
+src/func_ov016_02112b50.c:
+    complete
+    .text start:0x02112b50 end:0x02112e1c
+
+src/func_ov016_02112e1c.c:
+    complete
+    .text start:0x02112e1c end:0x02112ec4
+
+src/RockPillar_Spawn.c:
+    complete
+    .text start:0x02112ec4 end:0x02112ef4
+
+src/func_ov016_02112ef4.c:
+    .text start:0x02112ef4 end:0x02112f44
+
+src/func_ov016_02112f44.c:
+    .text start:0x02112f44 end:0x02112fa8
+
+src/func_ov016_02112fa8.c:
+    .text start:0x02112fa8 end:0x02112fbc
+
+src/FloatOnWaterPlatformJrb_Spawn.c:
+    .text start:0x02112fbc end:0x02112ff8
+
+src/_ZN23FloatOnWaterPlatformJrbD1Ev.c:
+    .text start:0x02112ff8 end:0x02113044
+
+src/_ZN23FloatOnWaterPlatformJrbD0Ev.c:
+    .text start:0x02113044 end:0x021130a4
+
+src/func_ov016_021130a4.c:
+    complete
+    .text start:0x021130a4 end:0x021130ec
+
+src/_ZN23FloatOnWaterPlatformJrb16CleanupResourcesEv.cpp:
+    .text start:0x021130ec end:0x02113130
+
+src/_ZN23FloatOnWaterPlatformJrb6RenderEv.cpp:
+    complete
+    .text start:0x02113130 end:0x02113158
+
+src/_ZN23FloatOnWaterPlatformJrb8BehaviorEv.c:
+    complete
+    .text start:0x02113158 end:0x02113434
+
+src/_ZN23FloatOnWaterPlatformJrb13InitResourcesEv.cpp:
+    .text start:0x02113434 end:0x02113510
+
+src/SlidingBox_Spawn.c:
+    complete
+    .text start:0x02113510 end:0x0211354c
+
+src/__sinit_ov016_021136ec.c:
+    .init start:0x021136ec end:0x021138bc
+
+src/__sinit_ov016_021138bc.c:
+    .init start:0x021138bc end:0x02113978
+
+src/__sinit_ov016_02113978.c:
+    .init start:0x02113978 end:0x021139e4
+
+src/__sinit_ov016_021139e4.c:
+    .init start:0x021139e4 end:0x02113a50
+
+src/__sinit_ov016_02113a50.c:
+    .init start:0x02113a50 end:0x02113abc

--- a/config/arm9/overlays/ov017/delinks.txt
+++ b/config/arm9/overlays/ov017/delinks.txt
@@ -4,3 +4,29 @@
     .ctor       start:0x021119f8 end:0x021119fc kind:rodata align:4
     .data       start:0x02111a00 end:0x02111c80 kind:data align:32
     .bss        start:0x02111c80 end:0x02111cc0 kind:bss align:32
+src/_ZN9ShipWaterD1Ev.c:
+    .text start:0x021111a0 end:0x021111ec
+
+src/_ZN9ShipWaterD0Ev.c:
+    .text start:0x021111ec end:0x0211124c
+
+src/_ZN9ShipWater16CleanupResourcesEv.cpp:
+    .text start:0x0211124c end:0x02111290
+
+src/_ZN9ShipWater6RenderEv.cpp:
+    complete
+    .text start:0x02111290 end:0x021112c4
+
+src/_ZN9ShipWater8BehaviorEv.cpp:
+    .text start:0x021112c4 end:0x021113c0
+
+src/_ZN9ShipWater13InitResourcesEv.c:
+    complete
+    .text start:0x021113c0 end:0x02111480
+
+src/ShipWater_Spawn.c:
+    complete
+    .text start:0x02111480 end:0x021114b8
+
+src/__sinit_ov017_0211198c.c:
+    .init start:0x0211198c end:0x021119f8

--- a/config/arm9/overlays/ov018/delinks.txt
+++ b/config/arm9/overlays/ov018/delinks.txt
@@ -4,3 +4,190 @@
     .ctor       start:0x02112e6c end:0x02112e78 kind:rodata align:4
     .data       start:0x02112e80 end:0x02113bc0 kind:data align:32
     .bss        start:0x02113bc0 end:0x02113cc0 kind:bss align:32
+src/func_ov018_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov018_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov018_0211123c.cpp:
+    complete
+    .text start:0x0211123c end:0x02111278
+
+src/func_ov018_02111278.cpp:
+    complete
+    .text start:0x02111278 end:0x021112fc
+
+src/func_ov018_021112fc.c:
+    complete
+    .text start:0x021112fc end:0x02111340
+
+src/func_ov018_02111340.cpp:
+    complete
+    .text start:0x02111340 end:0x02111368
+
+src/func_ov018_02111368.cpp:
+    complete
+    .text start:0x02111368 end:0x021116b4
+
+src/func_ov018_021116b4.cpp:
+    complete
+    .text start:0x021116b4 end:0x021117e8
+
+src/func_ov018_021117e8.cpp:
+    complete
+    .text start:0x021117e8 end:0x02111804
+
+src/func_ov018_02111804.c:
+    complete
+    .text start:0x02111804 end:0x02111818
+
+src/SkiLift_Spawn.c:
+    complete
+    .text start:0x02111818 end:0x02111848
+
+src/_ZN7SkiLiftD1Ev.cpp:
+    .text start:0x02111848 end:0x02111898
+
+src/_ZN7SkiLiftD0Ev.c:
+    complete
+    .text start:0x02111898 end:0x021118fc
+
+src/func_ov018_021118fc.c:
+    complete
+    .text start:0x021118fc end:0x02111968
+
+src/func_ov018_02111968.c:
+    complete
+    .text start:0x02111968 end:0x02111a48
+
+src/func_ov018_02111a48.c:
+    complete
+    .text start:0x02111a48 end:0x02111b3c
+
+src/func_ov018_02111b3c.c:
+    complete
+    .text start:0x02111b3c end:0x02111bf0
+
+src/func_ov018_02111bf0.c:
+    complete
+    .text start:0x02111bf0 end:0x02111d28
+
+src/func_ov018_02111d28.cpp:
+    .text start:0x02111d28 end:0x02111e28
+
+src/func_ov018_02111e28.cpp:
+    complete
+    .text start:0x02111e28 end:0x02111f1c
+
+src/func_ov018_02111f1c.cpp:
+    .text start:0x02111f1c end:0x02111fac
+
+src/func_ov018_02111fac.c:
+    complete
+    .text start:0x02111fac end:0x021121dc
+
+src/func_ov018_021121dc.cpp:
+    complete
+    .text start:0x021121dc end:0x02112234
+
+src/func_ov018_02112234.c:
+    complete
+    .text start:0x02112234 end:0x021122ec
+
+src/func_ov018_021122ec.c:
+    complete
+    .text start:0x021122ec end:0x0211235c
+
+src/func_ov018_0211235c.cpp:
+    complete
+    .text start:0x0211235c end:0x02112398
+
+src/func_ov018_02112398.cpp:
+    complete
+    .text start:0x02112398 end:0x021123d0
+
+src/func_ov018_021123d0.c:
+    complete
+    .text start:0x021123d0 end:0x021123ec
+
+src/_ZN7SkiLift16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x021123ec end:0x02112450
+
+src/_ZN7SkiLift16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02112450 end:0x02112454
+
+src/_ZN7SkiLift6RenderEv.cpp:
+    complete
+    .text start:0x02112454 end:0x02112480
+
+src/_ZN7SkiLift8BehaviorEv.cpp:
+    .text start:0x02112480 end:0x021124d0
+
+src/_ZN7SkiLift13InitResourcesEv.cpp:
+    .text start:0x021124d0 end:0x0211267c
+
+src/MotherPenguin_Spawn.c:
+    complete
+    .text start:0x0211267c end:0x021126d4
+
+src/func_ov018_021126d4.c:
+    complete
+    .text start:0x021126d4 end:0x021126f8
+
+src/func_ov018_021126f8.c:
+    .text start:0x021126f8 end:0x02112730
+
+src/func_ov018_02112730.cpp:
+    .text start:0x02112730 end:0x0211278c
+
+src/PowerStarCreate_Spawn.c:
+    complete
+    .text start:0x0211278c end:0x021127bc
+
+src/_ZN8IceSheetD1Ev.c:
+    .text start:0x021127bc end:0x02112800
+
+src/_ZN8IceSheetD0Ev.c:
+    .text start:0x02112800 end:0x02112858
+
+src/func_ov018_02112858.cpp:
+    complete
+    .text start:0x02112858 end:0x02112880
+
+src/func_ov018_02112880.cpp:
+    complete
+    .text start:0x02112880 end:0x021128e0
+
+src/func_ov018_021128e0.cpp:
+    complete
+    .text start:0x021128e0 end:0x02112924
+
+src/_ZN8IceSheet16CleanupResourcesEv.cpp:
+    .text start:0x02112924 end:0x02112968
+
+src/_ZN8IceSheet6RenderEv.cpp:
+    complete
+    .text start:0x02112968 end:0x02112990
+
+src/_ZN8IceSheet8BehaviorEv.cpp:
+    complete
+    .text start:0x02112990 end:0x021129c0
+
+src/_ZN8IceSheet13InitResourcesEv.cpp:
+    .text start:0x021129c0 end:0x02112a44
+
+src/IceSheet_Spawn.c:
+    complete
+    .text start:0x02112a44 end:0x02112a74
+
+src/__sinit_ov018_02112c14.c:
+    .init start:0x02112c14 end:0x02112c80
+
+src/__sinit_ov018_02112c80.cpp:
+    .init start:0x02112c80 end:0x02112e00
+
+src/__sinit_ov018_02112e00.c:
+    .init start:0x02112e00 end:0x02112e6c

--- a/config/arm9/overlays/ov019/delinks.txt
+++ b/config/arm9/overlays/ov019/delinks.txt
@@ -4,3 +4,142 @@
     .ctor       start:0x02112b64 end:0x02112b6c kind:rodata align:4
     .data       start:0x02112b80 end:0x02113460 kind:data align:32
     .bss        start:0x02113460 end:0x02113600 kind:bss align:32
+src/_ZN13RacingPenguinD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111f0
+
+src/_ZN13RacingPenguinD0Ev.c:
+    complete
+    .text start:0x021111f0 end:0x02111254
+
+src/func_ov019_02111254.c:
+    complete
+    .text start:0x02111254 end:0x0211127c
+
+src/func_ov019_0211127c.cpp:
+    complete
+    .text start:0x0211127c end:0x021112b8
+
+src/func_ov019_021112b8.c:
+    complete
+    .text start:0x021112b8 end:0x0211131c
+
+src/func_ov019_0211131c.c:
+    complete
+    .text start:0x0211131c end:0x021113b0
+
+src/func_ov019_021113b0.c:
+    complete
+    .text start:0x021113b0 end:0x0211140c
+
+src/func_ov019_0211140c.cpp:
+    complete
+    .text start:0x0211140c end:0x021114ec
+
+src/func_ov019_021114ec.cpp:
+    complete
+    .text start:0x021114ec end:0x02111558
+
+src/func_ov019_02111558.c:
+    complete
+    .text start:0x02111558 end:0x02111754
+
+src/func_ov019_02111754.cpp:
+    complete
+    .text start:0x02111754 end:0x021117a8
+
+src/func_ov019_021117a8.c:
+    complete
+    .text start:0x021117a8 end:0x02111904
+
+src/func_ov019_02111904.c:
+    complete
+    .text start:0x02111904 end:0x0211197c
+
+src/func_ov019_0211197c.c:
+    complete
+    .text start:0x0211197c end:0x02111d58
+
+src/func_ov019_02111d58.c:
+    complete
+    .text start:0x02111d58 end:0x02111dec
+
+src/func_ov019_02111dec.c:
+    complete
+    .text start:0x02111dec end:0x02111f54
+
+src/func_ov019_02111f54.c:
+    complete
+    .text start:0x02111f54 end:0x02111fec
+
+src/func_ov019_02111fec.c:
+    complete
+    .text start:0x02111fec end:0x0211213c
+
+src/func_ov019_0211213c.c:
+    complete
+    .text start:0x0211213c end:0x02112168
+
+src/func_ov019_02112168.c:
+    complete
+    .text start:0x02112168 end:0x021121f8
+
+src/func_ov019_021121f8.c:
+    complete
+    .text start:0x021121f8 end:0x02112268
+
+src/func_ov019_02112268.cpp:
+    complete
+    .text start:0x02112268 end:0x021122a4
+
+src/func_ov019_021122a4.cpp:
+    complete
+    .text start:0x021122a4 end:0x021122dc
+
+src/func_ov019_021122dc.c:
+    complete
+    .text start:0x021122dc end:0x021122f8
+
+src/_ZN13RacingPenguin16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x021122f8 end:0x0211235c
+
+src/_ZN13RacingPenguin16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211235c end:0x02112360
+
+src/_ZN13RacingPenguin6RenderEv.cpp:
+    complete
+    .text start:0x02112360 end:0x02112394
+
+src/_ZN13RacingPenguin8BehaviorEv.cpp:
+    .text start:0x02112394 end:0x021123d4
+
+src/_ZN13RacingPenguin13InitResourcesEv.cpp:
+    .text start:0x021123d4 end:0x021125bc
+
+src/RacingPenguin_Spawn.c:
+    complete
+    .text start:0x021125bc end:0x0211261c
+
+src/_ZN15IceSlideManagerD1Ev.cpp:
+    .text start:0x0211261c end:0x02112640
+
+src/_ZN15IceSlideManagerD0Ev.c:
+    .text start:0x02112640 end:0x02112678
+
+src/_ZN15IceSlideManager8BehaviorEv.cpp:
+    .text start:0x02112678 end:0x0211271c
+
+src/_ZN15IceSlideManager13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211271c end:0x0211274c
+
+src/IceSlideManager_Spawn.c:
+    complete
+    .text start:0x0211274c end:0x0211277c
+
+src/__sinit_ov019_021127a4.c:
+    .init start:0x021127a4 end:0x02112b14
+
+src/__sinit_ov019_02112b14.c:
+    .init start:0x02112b14 end:0x02112b64

--- a/config/arm9/overlays/ov020/delinks.txt
+++ b/config/arm9/overlays/ov020/delinks.txt
@@ -4,3 +4,178 @@
     .ctor       start:0x02113768 end:0x02113770 kind:rodata align:4
     .data       start:0x02113780 end:0x02114aa0 kind:data align:32
     .bss        start:0x02114aa0 end:0x02114b20 kind:bss align:32
+src/_ZN8BookShotD1Ev.c:
+    complete
+    .text start:0x021111a0 end:0x021111f0
+
+src/_ZN8BookShotD0Ev.c:
+    complete
+    .text start:0x021111f0 end:0x02111254
+
+src/_ZN15BookShotSpawnerD1Ev.cpp:
+    .text start:0x02111254 end:0x02111278
+
+src/_ZN15BookShotSpawnerD0Ev.c:
+    .text start:0x02111278 end:0x021112b0
+
+src/func_ov020_021112b0.c:
+    .text start:0x021112b0 end:0x02111340
+
+src/func_ov020_02111340.c:
+    complete
+    .text start:0x02111340 end:0x02111418
+
+src/func_ov020_02111418.cpp:
+    complete
+    .text start:0x02111418 end:0x021115ac
+
+src/func_ov020_021115ac.c:
+    complete
+    .text start:0x021115ac end:0x0211174c
+
+src/func_ov020_0211174c.c:
+    complete
+    .text start:0x0211174c end:0x021119dc
+
+src/func_ov020_021119dc.c:
+    complete
+    .text start:0x021119dc end:0x02111aa8
+
+src/func_ov020_02111aa8.c:
+    complete
+    .text start:0x02111aa8 end:0x02111b28
+
+src/func_ov020_02111b28.cpp:
+    complete
+    .text start:0x02111b28 end:0x02111c30
+
+src/func_ov020_02111c30.c:
+    complete
+    .text start:0x02111c30 end:0x02111ee0
+
+src/func_ov020_02111ee0.cpp:
+    complete
+    .text start:0x02111ee0 end:0x02111fc4
+
+src/func_ov020_02111fc4.cpp:
+    complete
+    .text start:0x02111fc4 end:0x02112080
+
+src/func_ov020_02112080.cpp:
+    complete
+    .text start:0x02112080 end:0x02112110
+
+src/func_ov020_02112110.cpp:
+    complete
+    .text start:0x02112110 end:0x0211216c
+
+src/func_ov020_0211216c.cpp:
+    complete
+    .text start:0x0211216c end:0x02112244
+
+src/_ZN8BookShot16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02112244 end:0x02112290
+
+src/_ZN15BookShotSpawner16CleanupResourcesEv.cpp:
+    .text start:0x02112290 end:0x021122c4
+
+src/_ZN8BookShot6RenderEv.cpp:
+    complete
+    .text start:0x021122c4 end:0x0211233c
+
+src/_ZN8BookShot8BehaviorEv.cpp:
+    .text start:0x0211233c end:0x02112418
+
+src/_ZN15BookShotSpawner8BehaviorEv.cpp:
+    complete
+    .text start:0x02112418 end:0x021124e4
+
+src/_ZN8BookShot13InitResourcesEv.cpp:
+    .text start:0x021124e4 end:0x02112768
+
+src/_ZN15BookShotSpawner13InitResourcesEv.cpp:
+    .text start:0x02112768 end:0x021127a4
+
+src/func_ov020_021127a4.cpp:
+    complete
+    .text start:0x021127a4 end:0x021127cc
+
+src/func_ov020_021127cc.c:
+    complete
+    .text start:0x021127cc end:0x021127f4
+
+src/func_ov020_021127f4.c:
+    complete
+    .text start:0x021127f4 end:0x02112850
+
+src/BookShotSpawner_Spawn.c:
+    complete
+    .text start:0x02112850 end:0x02112880
+
+src/Bookend_Spawn.c:
+    complete
+    .text start:0x02112880 end:0x021128dc
+
+src/BookShot_Spawn.c:
+    complete
+    .text start:0x021128dc end:0x02112938
+
+src/_ZN12HauntedChairD1Ev.cpp:
+    .text start:0x02112938 end:0x02112980
+
+src/_ZN12HauntedChairD0Ev.c:
+    complete
+    .text start:0x02112980 end:0x021129dc
+
+src/func_ov020_021129dc.c:
+    complete
+    .text start:0x021129dc end:0x02112b00
+
+src/func_ov020_02112b00.c:
+    complete
+    .text start:0x02112b00 end:0x02112e94
+
+src/func_ov020_02112e94.c:
+    complete
+    .text start:0x02112e94 end:0x021130c8
+
+src/func_ov020_021130c8.c:
+    complete
+    .text start:0x021130c8 end:0x02113148
+
+src/func_ov020_02113148.c:
+    complete
+    .text start:0x02113148 end:0x021131f8
+
+src/func_ov020_021131f8.c:
+    complete
+    .text start:0x021131f8 end:0x02113240
+
+src/func_ov020_02113240.cpp:
+    complete
+    .text start:0x02113240 end:0x021132d8
+
+src/_ZN12HauntedChair16CleanupResourcesEv.c:
+    complete
+    .text start:0x021132d8 end:0x021132fc
+
+src/_ZN12HauntedChair6RenderEv.cpp:
+    complete
+    .text start:0x021132fc end:0x02113324
+
+src/_ZN12HauntedChair8BehaviorEv.cpp:
+    .text start:0x02113324 end:0x021133b0
+
+src/_ZN12HauntedChair13InitResourcesEv.cpp:
+    .text start:0x021133b0 end:0x02113494
+
+src/HauntedChair_Spawn.c:
+    complete
+    .text start:0x02113494 end:0x021134e4
+
+src/__sinit_ov020_02113674.c:
+    .init start:0x02113674 end:0x0211372c
+
+src/__sinit_ov020_0211372c.c:
+    .init start:0x0211372c end:0x02113768

--- a/config/arm9/overlays/ov021/delinks.txt
+++ b/config/arm9/overlays/ov021/delinks.txt
@@ -4,3 +4,147 @@
     .ctor       start:0x02113734 end:0x02113740 kind:rodata align:4
     .data       start:0x02113760 end:0x021149a0 kind:data align:32
     .bss        start:0x021149a0 end:0x02114aa0 kind:bss align:32
+src/_ZN12WorkElevatorD1Ev.cpp:
+    complete
+    .text start:0x021111a0 end:0x02111214
+
+src/_ZN12WorkElevatorD0Ev.c:
+    complete
+    .text start:0x02111214 end:0x0211129c
+
+src/func_ov021_0211129c.c:
+    complete
+    .text start:0x0211129c end:0x02111434
+
+src/func_ov021_02111434.c:
+    .text start:0x02111434 end:0x021115dc
+
+src/_ZN12WorkElevator16CleanupResourcesEv.cpp:
+    .text start:0x021115dc end:0x02111650
+
+src/_ZN12WorkElevator6RenderEv.cpp:
+    complete
+    .text start:0x02111650 end:0x021116c8
+
+src/func_ov021_02111ec4.c:
+    complete
+    .text start:0x02111ec4 end:0x02111edc
+
+src/func_ov021_02111edc.cpp:
+    complete
+    .text start:0x02111edc end:0x02111f1c
+
+src/func_ov021_02111f1c.c:
+    complete
+    .text start:0x02111f1c end:0x02111f34
+
+src/func_ov021_02111f34.cpp:
+    complete
+    .text start:0x02111f34 end:0x02111f74
+
+src/func_ov021_02111f74.c:
+    complete
+    .text start:0x02111f74 end:0x02111f8c
+
+src/func_ov021_02111f8c.cpp:
+    complete
+    .text start:0x02111f8c end:0x02111fcc
+
+src/func_ov021_02111fcc.c:
+    complete
+    .text start:0x02111fcc end:0x02111fe4
+
+src/func_ov021_02111fe4.c:
+    complete
+    .text start:0x02111fe4 end:0x02112024
+
+src/func_ov021_02112024.cpp:
+    complete
+    .text start:0x02112024 end:0x02112128
+
+src/func_ov021_02112128.c:
+    complete
+    .text start:0x02112128 end:0x02112168
+
+src/WorkElevator_Spawn.cpp:
+    complete
+    .text start:0x02112168 end:0x021121e8
+
+src/_ZN11RollingRockD1Ev.c:
+    complete
+    .text start:0x021121e8 end:0x02112230
+
+src/_ZN11RollingRockD0Ev.c:
+    complete
+    .text start:0x02112230 end:0x0211228c
+
+src/func_ov021_0211228c.c:
+    complete
+    .text start:0x0211228c end:0x02112294
+
+src/func_ov021_02112294.c:
+    complete
+    .text start:0x02112294 end:0x021122fc
+
+src/func_ov021_021122fc.cpp:
+    complete
+    .text start:0x021122fc end:0x021123b0
+
+src/func_ov021_021123b0.c:
+    complete
+    .text start:0x021123b0 end:0x02112544
+
+src/func_ov021_02112544.cpp:
+    .text start:0x02112544 end:0x021127b4
+
+src/func_ov021_021127b4.c:
+    complete
+    .text start:0x021127b4 end:0x021127f8
+
+src/_ZN11RollingRock16CleanupResourcesEv.c:
+    complete
+    .text start:0x021127f8 end:0x0211281c
+
+src/_ZN11RollingRock6RenderEv.cpp:
+    complete
+    .text start:0x0211281c end:0x02112854
+
+src/_ZN11RollingRock8BehaviorEv.c:
+    complete
+    .text start:0x02112854 end:0x02112b2c
+
+src/_ZN11RollingRock13InitResourcesEv.cpp:
+    complete
+    .text start:0x02112b2c end:0x02112d64
+
+src/RollingRock_Spawn.c:
+    complete
+    .text start:0x02112d64 end:0x02112db4
+
+src/_ZN10ShutterHmcD1Ev.c:
+    .text start:0x02112db4 end:0x02112e04
+
+src/_ZN10ShutterHmcD0Ev.c:
+    .text start:0x02112e04 end:0x02112e68
+
+src/_ZN10ShutterHmc16CleanupResourcesEv.cpp:
+    .text start:0x02112e68 end:0x02112e7c
+
+src/_ZN10ShutterHmc8BehaviorEv.cpp:
+    complete
+    .text start:0x02112e7c end:0x02112ec0
+
+src/_ZN10ShutterHmc13InitResourcesEv.cpp:
+    .text start:0x02112ec0 end:0x02112ed4
+
+src/ShutterHmc_Spawn.c:
+    .text start:0x02112ed4 end:0x02112f10
+
+src/__sinit_ov021_02113500.c:
+    .init start:0x02113500 end:0x02113688
+
+src/__sinit_ov021_02113688.c:
+    .init start:0x02113688 end:0x021136c8
+
+src/__sinit_ov021_021136c8.c:
+    .init start:0x021136c8 end:0x02113734

--- a/config/arm9/overlays/ov022/delinks.txt
+++ b/config/arm9/overlays/ov022/delinks.txt
@@ -4,3 +4,285 @@
     .ctor       start:0x021130f8 end:0x02113120 kind:rodata align:4
     .data       start:0x02113140 end:0x02114500 kind:data align:32
     .bss        start:0x02114500 end:0x021146a0 kind:bss align:32
+src/func_ov022_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov022_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov022_0211123c.cpp:
+    complete
+    .text start:0x0211123c end:0x02111284
+
+src/func_ov022_02111284.cpp:
+    complete
+    .text start:0x02111284 end:0x021112ac
+
+src/func_ov022_021112ac.c:
+    complete
+    .text start:0x021112ac end:0x0211149c
+
+src/func_ov022_0211149c.c:
+    complete
+    .text start:0x0211149c end:0x02111558
+
+src/func_ov022_02111558.c:
+    complete
+    .text start:0x02111558 end:0x02111564
+
+src/func_ov022_02111564.c:
+    complete
+    .text start:0x02111564 end:0x02111578
+
+src/VolcanoRing_Spawn.c:
+    complete
+    .text start:0x02111578 end:0x021115a8
+
+src/func_ov022_021115a8.c:
+    .text start:0x021115a8 end:0x021115f8
+
+src/func_ov022_021115f8.c:
+    .text start:0x021115f8 end:0x0211165c
+
+src/func_ov022_0211165c.c:
+    .text start:0x0211165c end:0x02111670
+
+src/func_ov022_02111670.c:
+    complete
+    .text start:0x02111670 end:0x02111688
+
+src/RotatingPlatformLll_Spawn.c:
+    .text start:0x02111688 end:0x021116c4
+
+src/_ZN19RotatingPlatformLllD1Ev.c:
+    .text start:0x021116c4 end:0x02111708
+
+src/_ZN19RotatingPlatformLllD0Ev.c:
+    .text start:0x02111708 end:0x02111760
+
+src/_ZN19RotatingPlatformLll16CleanupResourcesEv.cpp:
+    .text start:0x02111760 end:0x021117a4
+
+src/_ZN19RotatingPlatformLll6RenderEv.cpp:
+    complete
+    .text start:0x021117a4 end:0x021117cc
+
+src/_ZN19RotatingPlatformLll8BehaviorEv.cpp:
+    .text start:0x021117cc end:0x02111870
+
+src/_ZN19RotatingPlatformLll13InitResourcesEv.cpp:
+    .text start:0x02111870 end:0x0211191c
+
+src/func_ov022_0211191c.cpp:
+    complete
+    .text start:0x0211191c end:0x0211193c
+
+src/func_ov022_0211193c.c:
+    complete
+    .text start:0x0211193c end:0x02111950
+
+src/FloatOnLavaPlatform_Spawn.c:
+    complete
+    .text start:0x02111950 end:0x02111980
+
+src/func_ov022_02111980.c:
+    .text start:0x02111980 end:0x021119c4
+
+src/func_ov022_021119c4.c:
+    .text start:0x021119c4 end:0x02111a1c
+
+src/func_ov022_02111a1c.c:
+    complete
+    .text start:0x02111a1c end:0x02111a64
+
+src/func_ov022_02111a64.c:
+    .text start:0x02111a64 end:0x02111aa8
+
+src/func_ov022_02111aa8.cpp:
+    complete
+    .text start:0x02111aa8 end:0x02111ad0
+
+src/func_ov022_02111ad0.c:
+    complete
+    .text start:0x02111ad0 end:0x02111bdc
+
+src/func_ov022_02111bdc.cpp:
+    .text start:0x02111bdc end:0x02111c7c
+
+src/LavaBridge_Spawn.c:
+    complete
+    .text start:0x02111c7c end:0x02111cac
+
+src/func_ov022_02111cac.c:
+    .text start:0x02111cac end:0x02111cf0
+
+src/func_ov022_02111cf0.c:
+    .text start:0x02111cf0 end:0x02111d48
+
+src/func_ov022_02111d48.c:
+    complete
+    .text start:0x02111d48 end:0x02111d90
+
+src/func_ov022_02111d90.c:
+    .text start:0x02111d90 end:0x02111dd4
+
+src/func_ov022_02111dd4.cpp:
+    complete
+    .text start:0x02111dd4 end:0x02111dfc
+
+src/func_ov022_02111dfc.c:
+    complete
+    .text start:0x02111dfc end:0x02111ea0
+
+src/func_ov022_02111ea0.cpp:
+    .text start:0x02111ea0 end:0x02111f3c
+
+src/LavaSeesaw_Spawn.c:
+    complete
+    .text start:0x02111f3c end:0x02111f6c
+
+src/_ZN21FloatingFloorLllSmallD1Ev.c:
+    .text start:0x02111f6c end:0x02111fbc
+
+src/_ZN21FloatingFloorLllSmallD0Ev.c:
+    .text start:0x02111fbc end:0x02112020
+
+src/_ZN21FloatingFloorLllSmall16CleanupResourcesEv.c:
+    complete
+    .text start:0x02112020 end:0x02112040
+
+src/_ZN21FloatingFloorLllSmall13InitResourcesEv.c:
+    complete
+    .text start:0x02112040 end:0x021120b8
+
+src/FloatingFloorLllSmall_Spawn.c:
+    .text start:0x021120b8 end:0x021120f4
+
+src/FloatingFloorLllBig_Spawn.c:
+    .text start:0x021120f4 end:0x02112130
+
+src/_ZN19FloatingFloorLllBigD1Ev.c:
+    .text start:0x02112130 end:0x02112174
+
+src/_ZN19FloatingFloorLllBigD0Ev.c:
+    .text start:0x02112174 end:0x021121cc
+
+src/_ZN19FloatingFloorLllBig16CleanupResourcesEv.cpp:
+    .text start:0x021121cc end:0x02112210
+
+src/_ZN19FloatingFloorLllBig6RenderEv.cpp:
+    complete
+    .text start:0x02112210 end:0x02112238
+
+src/_ZN19FloatingFloorLllBig8BehaviorEv.cpp:
+    complete
+    .text start:0x02112238 end:0x021122ac
+
+src/_ZN19FloatingFloorLllBig13InitResourcesEv.cpp:
+    .text start:0x021122ac end:0x02112350
+
+src/LavaPlank_Spawn.c:
+    complete
+    .text start:0x02112350 end:0x02112380
+
+src/func_ov022_02112380.c:
+    .text start:0x02112380 end:0x021123d0
+
+src/func_ov022_021123d0.c:
+    .text start:0x021123d0 end:0x02112434
+
+src/func_ov022_02112434.c:
+    .text start:0x02112434 end:0x02112448
+
+src/func_ov022_02112448.c:
+    .text start:0x02112448 end:0x0211245c
+
+src/FallBlockLll_Spawn.c:
+    .text start:0x0211245c end:0x02112498
+
+src/_ZN12FallBlockLllD1Ev.c:
+    .text start:0x02112498 end:0x021124e8
+
+src/_ZN12FallBlockLllD0Ev.c:
+    .text start:0x021124e8 end:0x0211254c
+
+src/_ZN12FallBlockLll16CleanupResourcesEv.cpp:
+    .text start:0x0211254c end:0x02112560
+
+src/_ZN12FallBlockLll8BehaviorEv.cpp:
+    complete
+    .text start:0x02112560 end:0x02112590
+
+src/_ZN12FallBlockLll13InitResourcesEv.cpp:
+    .text start:0x02112590 end:0x021125a4
+
+src/RollingLogLll_Spawn.c:
+    .text start:0x021125a4 end:0x021125e0
+
+src/_ZN13RollingLogLllD1Ev.cpp:
+    .text start:0x021125e0 end:0x02112610
+
+src/_ZN13RollingLogLllD0Ev.c:
+    complete
+    .text start:0x02112610 end:0x02112654
+
+src/func_ov022_02112654.cpp:
+    complete
+    .text start:0x02112654 end:0x021126ac
+
+src/func_ov022_021126ac.c:
+    complete
+    .text start:0x021126ac end:0x02112710
+
+src/func_ov022_02112710.c:
+    complete
+    .text start:0x02112710 end:0x02112790
+
+src/func_ov022_02112790.cpp:
+    complete
+    .text start:0x02112790 end:0x021127e0
+
+src/_ZN13RollingLogLll16CleanupResourcesEv.c:
+    complete
+    .text start:0x021127e0 end:0x02112800
+
+src/_ZN13RollingLogLll8BehaviorEv.cpp:
+    complete
+    .text start:0x02112800 end:0x021128b8
+
+src/_ZN13RollingLogLll13InitResourcesEv.cpp:
+    .text start:0x021128b8 end:0x02112918
+
+src/VolcanoFire_Spawn.c:
+    complete
+    .text start:0x02112918 end:0x02112950
+
+src/__sinit_ov022_02112ca8.c:
+    .init start:0x02112ca8 end:0x02112d14
+
+src/__sinit_ov022_02112d14.c:
+    .init start:0x02112d14 end:0x02112d80
+
+src/__sinit_ov022_02112d80.c:
+    .init start:0x02112d80 end:0x02112dec
+
+src/__sinit_ov022_02112dec.c:
+    .init start:0x02112dec end:0x02112e58
+
+src/__sinit_ov022_02112e58.c:
+    .init start:0x02112e58 end:0x02112ec0
+
+src/__sinit_ov022_02112ec0.c:
+    .init start:0x02112ec0 end:0x02112f78
+
+src/__sinit_ov022_02112f78.c:
+    .init start:0x02112f78 end:0x02112fe4
+
+src/__sinit_ov022_02112fe4.c:
+    .init start:0x02112fe4 end:0x02113050
+
+src/__sinit_ov022_02113050.c:
+    .init start:0x02113050 end:0x021130bc
+
+src/__sinit_ov022_021130bc.c:
+    .init start:0x021130bc end:0x021130f8

--- a/config/arm9/overlays/ov023/delinks.txt
+++ b/config/arm9/overlays/ov023/delinks.txt
@@ -4,3 +4,38 @@
     .ctor       start:0x02111b14 end:0x02111b18 kind:rodata align:4
     .data       start:0x02111b20 end:0x02112080 kind:data align:32
     .bss        start:0x02112080 end:0x021120c0 kind:bss align:32
+src/_ZN8SquasherD1Ev.c:
+    .text start:0x021111a0 end:0x021111ec
+
+src/_ZN8SquasherD0Ev.c:
+    .text start:0x021111ec end:0x0211124c
+
+src/func_ov023_0211124c.c:
+    complete
+    .text start:0x0211124c end:0x02111308
+
+src/func_ov023_02111308.c:
+    complete
+    .text start:0x02111308 end:0x02111350
+
+src/_ZN8Squasher16CleanupResourcesEv.cpp:
+    .text start:0x02111350 end:0x02111388
+
+src/_ZN8Squasher6RenderEv.cpp:
+    complete
+    .text start:0x02111388 end:0x021113b0
+
+src/_ZN8Squasher8BehaviorEv.c:
+    complete
+    .text start:0x021113b0 end:0x02111670
+
+src/_ZN8Squasher13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111670 end:0x02111728
+
+src/Squasher_Spawn.c:
+    complete
+    .text start:0x02111728 end:0x02111760
+
+src/__sinit_ov023_02111aa8.c:
+    .init start:0x02111aa8 end:0x02111b14

--- a/config/arm9/overlays/ov024/delinks.txt
+++ b/config/arm9/overlays/ov024/delinks.txt
@@ -4,3 +4,63 @@
     .ctor       start:0x02112874 end:0x02112878 kind:rodata align:4
     .data       start:0x02112880 end:0x02113960 kind:data align:32
     .bss        start:0x02113960 end:0x021139a0 kind:bss align:32
+src/_ZN10PyramidTopD1Ev.c:
+    .text start:0x021111a0 end:0x021111ec
+
+src/_ZN10PyramidTopD0Ev.c:
+    .text start:0x021111ec end:0x0211124c
+
+src/_ZN10PyramidTagD1Ev.cpp:
+    .text start:0x0211124c end:0x0211127c
+
+src/_ZN10PyramidTagD0Ev.c:
+    complete
+    .text start:0x0211127c end:0x021112c0
+
+src/func_ov024_021112c0.c:
+    complete
+    .text start:0x021112c0 end:0x02111350
+
+src/func_ov024_02111350.c:
+    complete
+    .text start:0x02111350 end:0x02111480
+
+src/func_ov024_02111480.cpp:
+    complete
+    .text start:0x02111480 end:0x021114c4
+
+src/func_ov024_021114c4.c:
+    complete
+    .text start:0x021114c4 end:0x02111504
+
+src/_ZN10PyramidTop16CleanupResourcesEv.cpp:
+    .text start:0x02111504 end:0x0211153c
+
+src/_ZN10PyramidTop6RenderEv.cpp:
+    complete
+    .text start:0x0211153c end:0x02111568
+
+src/_ZN10PyramidTop8BehaviorEv.cpp:
+    .text start:0x02111568 end:0x02111668
+
+src/_ZN10PyramidTag8BehaviorEv.cpp:
+    complete
+    .text start:0x02111668 end:0x021116ec
+
+src/_ZN10PyramidTop13InitResourcesEv.cpp:
+    .text start:0x021116ec end:0x021117c8
+
+src/_ZN10PyramidTag13InitResourcesEv.cpp:
+    complete
+    .text start:0x021117c8 end:0x0211183c
+
+src/PyramidTag_Spawn.c:
+    complete
+    .text start:0x0211183c end:0x02111874
+
+src/PyramidTop_Spawn.c:
+    complete
+    .text start:0x02111874 end:0x021118ac
+
+src/__sinit_ov024_02112808.c:
+    .init start:0x02112808 end:0x02112874

--- a/config/arm9/overlays/ov025/delinks.txt
+++ b/config/arm9/overlays/ov025/delinks.txt
@@ -4,3 +4,147 @@
     .ctor       start:0x02112b18 end:0x02112b28 kind:rodata align:4
     .data       start:0x02112b40 end:0x02113a60 kind:data align:32
     .bss        start:0x02113a60 end:0x02113b00 kind:bss align:32
+src/func_ov025_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov025_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov025_0211123c.cpp:
+    complete
+    .text start:0x0211123c end:0x021112e0
+
+src/func_ov025_021112e0.cpp:
+    complete
+    .text start:0x021112e0 end:0x02111344
+
+src/func_ov025_02111344.c:
+    complete
+    .text start:0x02111344 end:0x02111384
+
+src/func_ov025_02111384.cpp:
+    .text start:0x02111384 end:0x021113c8
+
+src/func_ov025_021113c8.cpp:
+    complete
+    .text start:0x021113c8 end:0x021113f0
+
+src/func_ov025_021113f0.c:
+    .text start:0x021113f0 end:0x021117dc
+
+src/func_ov025_021117dc.cpp:
+    .text start:0x021117dc end:0x02111898
+
+src/func_ov025_02111898.c:
+    complete
+    .text start:0x02111898 end:0x021118c8
+
+src/func_ov025_021118c8.c:
+    .text start:0x021118c8 end:0x02111928
+
+src/func_ov025_02111928.c:
+    .text start:0x02111928 end:0x0211199c
+
+src/func_ov025_0211199c.c:
+    complete
+    .text start:0x0211199c end:0x021119a4
+
+src/func_ov025_021119a4.cpp:
+    complete
+    .text start:0x021119a4 end:0x021119f4
+
+src/func_ov025_021119f4.c:
+    complete
+    .text start:0x021119f4 end:0x02111a84
+
+src/func_ov025_02111a84.cpp:
+    complete
+    .text start:0x02111a84 end:0x02111b64
+
+src/func_ov025_02111b64.cpp:
+    .text start:0x02111b64 end:0x02111c24
+
+src/func_ov025_02111c24.cpp:
+    complete
+    .text start:0x02111c24 end:0x02111cf4
+
+src/Grindel_Spawn.c:
+    .text start:0x02111cf4 end:0x02111d40
+
+src/_ZN11PyramidStepD1Ev.c:
+    .text start:0x02111d40 end:0x02111d8c
+
+src/_ZN11PyramidStepD0Ev.c:
+    .text start:0x02111d8c end:0x02111dec
+
+src/func_ov025_02111dec.cpp:
+    complete
+    .text start:0x02111dec end:0x02111e30
+
+src/func_ov025_02111e30.c:
+    complete
+    .text start:0x02111e30 end:0x02111e70
+
+src/_ZN11PyramidStep16CleanupResourcesEv.cpp:
+    .text start:0x02111e70 end:0x02111ea8
+
+src/_ZN11PyramidStep6RenderEv.cpp:
+    complete
+    .text start:0x02111ea8 end:0x02111ed4
+
+src/_ZN11PyramidStep8BehaviorEv.cpp:
+    .text start:0x02111ed4 end:0x02111fa0
+
+src/_ZN11PyramidStep13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111fa0 end:0x021120ac
+
+src/PyramidStep_Spawn.c:
+    complete
+    .text start:0x021120ac end:0x021120e4
+
+src/_ZN11PyramidLiftD1Ev.cpp:
+    .text start:0x021120e4 end:0x02112148
+
+src/_ZN11PyramidLiftD0Ev.c:
+    complete
+    .text start:0x02112148 end:0x021121c0
+
+src/_ZN11PyramidLift16CleanupResourcesEv.c:
+    complete
+    .text start:0x021121c0 end:0x021121fc
+
+src/_ZN11PyramidLift6RenderEv.cpp:
+    complete
+    .text start:0x021121fc end:0x02112288
+
+src/_ZN11PyramidLift8BehaviorEv.cpp:
+    complete
+    .text start:0x02112288 end:0x02112498
+
+src/_ZN11PyramidLift13InitResourcesEv.cpp:
+    .text start:0x02112498 end:0x021125bc
+
+src/func_ov025_021125bc.cpp:
+    complete
+    .text start:0x021125bc end:0x021125dc
+
+src/func_ov025_021125dc.c:
+    complete
+    .text start:0x021125dc end:0x021125f0
+
+src/PyramidLift_Spawn.cpp:
+    complete
+    .text start:0x021125f0 end:0x02112654
+
+src/__sinit_ov025_02112970.c:
+    .init start:0x02112970 end:0x021129dc
+
+src/__sinit_ov025_021129dc.c:
+    .init start:0x021129dc end:0x02112a44
+
+src/__sinit_ov025_02112a44.c:
+    .init start:0x02112a44 end:0x02112aac
+
+src/__sinit_ov025_02112aac.c:
+    .init start:0x02112aac end:0x02112b18

--- a/config/arm9/overlays/ov026/delinks.txt
+++ b/config/arm9/overlays/ov026/delinks.txt
@@ -4,3 +4,198 @@
     .ctor       start:0x02112da4 end:0x02112db8 kind:rodata align:4
     .data       start:0x02112dc0 end:0x02113ea0 kind:data align:32
     .bss        start:0x02113ea0 end:0x02113f80 kind:bss align:32
+src/func_ov026_021111a0.c:
+    .text start:0x021111a0 end:0x021111e0
+
+src/func_ov026_021111e0.c:
+    .text start:0x021111e0 end:0x02111234
+
+src/func_ov026_02111234.cpp:
+    complete
+    .text start:0x02111234 end:0x021112a4
+
+src/func_ov026_021112a4.c:
+    complete
+    .text start:0x021112a4 end:0x021112e4
+
+src/func_ov026_021112e4.c:
+    complete
+    .text start:0x021112e4 end:0x02111308
+
+src/func_ov026_02111308.cpp:
+    complete
+    .text start:0x02111308 end:0x02111330
+
+src/func_ov026_02111330.cpp:
+    complete
+    .text start:0x02111330 end:0x02111598
+
+src/func_ov026_02111598.cpp:
+    .text start:0x02111598 end:0x02111678
+
+src/func_ov026_02111678.c:
+    .text start:0x02111678 end:0x021116c8
+
+src/func_ov026_021116c8.c:
+    .text start:0x021116c8 end:0x0211170c
+
+src/func_ov026_0211170c.c:
+    .text start:0x0211170c end:0x02111764
+
+src/func_ov026_02111764.c:
+    .text start:0x02111764 end:0x021117a8
+
+src/func_ov026_021117a8.cpp:
+    complete
+    .text start:0x021117a8 end:0x021117d0
+
+src/func_ov026_021117d0.c:
+    complete
+    .text start:0x021117d0 end:0x021117d8
+
+src/func_ov026_021117d8.c:
+    complete
+    .text start:0x021117d8 end:0x02111888
+
+src/BowserShutter_Spawn.c:
+    complete
+    .text start:0x02111888 end:0x021118b8
+
+src/func_ov026_021118b8.c:
+    .text start:0x021118b8 end:0x021118fc
+
+src/func_ov026_021118fc.c:
+    .text start:0x021118fc end:0x02111954
+
+src/func_ov026_02111954.c:
+    .text start:0x02111954 end:0x02111998
+
+src/func_ov026_02111998.cpp:
+    complete
+    .text start:0x02111998 end:0x021119c0
+
+src/func_ov026_021119c0.c:
+    complete
+    .text start:0x021119c0 end:0x02111a70
+
+src/Submarine_Spawn.c:
+    complete
+    .text start:0x02111a70 end:0x02111aa0
+
+src/_ZN9SubmarineD1Ev.c:
+    complete
+    .text start:0x02111aa0 end:0x02111ad8
+
+src/_ZN9SubmarineD0Ev.c:
+    complete
+    .text start:0x02111ad8 end:0x02111b24
+
+src/func_ov026_02111b24.c:
+    complete
+    .text start:0x02111b24 end:0x02111cb4
+
+src/func_ov026_02111cb4.c:
+    complete
+    .text start:0x02111cb4 end:0x02111d4c
+
+src/func_ov026_02111d4c.cpp:
+    .text start:0x02111d4c end:0x02111ed8
+
+src/func_ov026_02111ed8.c:
+    complete
+    .text start:0x02111ed8 end:0x02111ee0
+
+src/func_ov026_02111ee0.cpp:
+    complete
+    .text start:0x02111ee0 end:0x02111f30
+
+src/func_ov026_02111f30.c:
+    complete
+    .text start:0x02111f30 end:0x02111fa4
+
+src/_ZN9Submarine16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111fa4 end:0x02111fd4
+
+src/_ZN9Submarine16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111fd4 end:0x02111fd8
+
+src/_ZN9Submarine6RenderEv.cpp:
+    complete
+    .text start:0x02111fd8 end:0x0211200c
+
+src/_ZN9Submarine8BehaviorEv.cpp:
+    .text start:0x0211200c end:0x021120ec
+
+src/_ZN9Submarine13InitResourcesEv.cpp:
+    .text start:0x021120ec end:0x021121bc
+
+src/Whirlpool_Spawn.c:
+    complete
+    .text start:0x021121bc end:0x021121fc
+
+src/_ZN12WaterSuctionD1Ev.c:
+    complete
+    .text start:0x021121fc end:0x02112234
+
+src/_ZN12WaterSuctionD0Ev.c:
+    complete
+    .text start:0x02112234 end:0x02112280
+
+src/func_ov026_02112280.c:
+    complete
+    .text start:0x02112280 end:0x021122b0
+
+src/func_ov026_021122b0.c:
+    complete
+    .text start:0x021122b0 end:0x021122cc
+
+src/func_ov026_021122cc.c:
+    complete
+    .text start:0x021122cc end:0x021122d4
+
+src/func_ov026_021122d4.cpp:
+    complete
+    .text start:0x021122d4 end:0x02112324
+
+src/func_ov026_02112324.c:
+    complete
+    .text start:0x02112324 end:0x02112328
+
+src/_ZN12WaterSuction16CleanupResourcesEv.c:
+    complete
+    .text start:0x02112328 end:0x02112330
+
+src/_ZN12WaterSuction16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02112330 end:0x02112334
+
+src/_ZN12WaterSuction6RenderEv.c:
+    complete
+    .text start:0x02112334 end:0x0211233c
+
+src/_ZN12WaterSuction8BehaviorEv.cpp:
+    .text start:0x0211233c end:0x021123c8
+
+src/_ZN12WaterSuction13InitResourcesEv.cpp:
+    .text start:0x021123c8 end:0x02112450
+
+src/WaterSuction_Spawn.c:
+    complete
+    .text start:0x02112450 end:0x02112490
+
+src/__sinit_ov026_02112b7c.c:
+    .init start:0x02112b7c end:0x02112bbc
+
+src/__sinit_ov026_02112bbc.c:
+    .init start:0x02112bbc end:0x02112c28
+
+src/__sinit_ov026_02112c28.c:
+    .init start:0x02112c28 end:0x02112c94
+
+src/__sinit_ov026_02112c94.c:
+    .init start:0x02112c94 end:0x02112d68
+
+src/__sinit_ov026_02112d68.c:
+    .init start:0x02112d68 end:0x02112da4

--- a/config/arm9/overlays/ov027/delinks.txt
+++ b/config/arm9/overlays/ov027/delinks.txt
@@ -4,3 +4,195 @@
     .ctor       start:0x02112fc4 end:0x02112fd4 kind:rodata align:4
     .data       start:0x02112fe0 end:0x02113be0 kind:data align:32
     .bss        start:0x02113be0 end:0x02113d20 kind:bss align:32
+src/_ZN10SlidingIceD1Ev.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/_ZN10SlidingIceD0Ev.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov027_0211123c.cpp:
+    complete
+    .text start:0x0211123c end:0x02111264
+
+src/_ZN10SlidingIce16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02111264 end:0x021112b4
+
+src/_ZN10SlidingIce6RenderEv.cpp:
+    complete
+    .text start:0x021112b4 end:0x02111304
+
+src/_ZN10SlidingIce8BehaviorEv.cpp:
+    complete
+    .text start:0x02111304 end:0x02111440
+
+src/_ZN10SlidingIce13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111440 end:0x02111564
+
+src/SlidingIce_Spawn.c:
+    complete
+    .text start:0x02111564 end:0x02111594
+
+src/SlidingIceSpawner_Spawn.c:
+    complete
+    .text start:0x02111594 end:0x021115c4
+
+src/func_ov027_021115c4.c:
+    .text start:0x021115c4 end:0x02111618
+
+src/func_ov027_02111618.c:
+    .text start:0x02111618 end:0x02111680
+
+src/func_ov027_02111680.c:
+    complete
+    .text start:0x02111680 end:0x021116f0
+
+src/func_ov027_021116f0.cpp:
+    .text start:0x021116f0 end:0x02111770
+
+src/func_ov027_02111770.c:
+    complete
+    .text start:0x02111770 end:0x0211181c
+
+src/func_ov027_0211181c.cpp:
+    complete
+    .text start:0x0211181c end:0x0211186c
+
+src/ChillBully_Spawn.c:
+    .text start:0x0211186c end:0x021118c8
+
+src/func_ov027_021118c8.c:
+    .text start:0x021118c8 end:0x02111924
+
+src/func_ov027_02111924.c:
+    .text start:0x02111924 end:0x02111994
+
+src/func_ov027_02111994.cpp:
+    complete
+    .text start:0x02111994 end:0x02111a28
+
+src/func_ov027_02111a28.c:
+    complete
+    .text start:0x02111a28 end:0x02111b2c
+
+src/func_ov027_02111b2c.cpp:
+    complete
+    .text start:0x02111b2c end:0x02111c48
+
+src/func_ov027_02111c48.c:
+    complete
+    .text start:0x02111c48 end:0x02111ca8
+
+src/func_ov027_02111ca8.cpp:
+    complete
+    .text start:0x02111ca8 end:0x02111cfc
+
+src/func_ov027_02111cfc.cpp:
+    complete
+    .text start:0x02111cfc end:0x02111d38
+
+src/func_ov027_02111d38.cpp:
+    complete
+    .text start:0x02111d38 end:0x02111d70
+
+src/func_ov027_02111d70.c:
+    complete
+    .text start:0x02111d70 end:0x02111d8c
+
+src/func_ov027_02111d8c.c:
+    complete
+    .text start:0x02111d8c end:0x02111dfc
+
+src/func_ov027_02111dfc.c:
+    complete
+    .text start:0x02111dfc end:0x02111e00
+
+src/func_ov027_02111e00.cpp:
+    complete
+    .text start:0x02111e00 end:0x02111e34
+
+src/func_ov027_02111e34.cpp:
+    .text start:0x02111e34 end:0x02111eb4
+
+src/func_ov027_02111eb4.cpp:
+    .text start:0x02111eb4 end:0x0211207c
+
+src/func_ov027_0211207c.c:
+    .text start:0x0211207c end:0x021120c4
+
+src/_ZN13SnowmanBreathD1Ev.cpp:
+    .text start:0x021120c4 end:0x02112104
+
+src/_ZN13SnowmanBreathD0Ev.cpp:
+    .text start:0x02112104 end:0x02112158
+
+src/func_ov027_02112158.c:
+    complete
+    .text start:0x02112158 end:0x02112170
+
+src/func_ov027_02112170.cpp:
+    complete
+    .text start:0x02112170 end:0x0211233c
+
+src/func_ov027_0211233c.cpp:
+    complete
+    .text start:0x0211233c end:0x021123b0
+
+src/func_ov027_021123b0.c:
+    complete
+    .text start:0x021123b0 end:0x02112424
+
+src/func_ov027_02112424.c:
+    complete
+    .text start:0x02112424 end:0x02112480
+
+src/func_ov027_02112480.cpp:
+    complete
+    .text start:0x02112480 end:0x021124e4
+
+src/func_ov027_021124e4.c:
+    complete
+    .text start:0x021124e4 end:0x021125a8
+
+src/func_ov027_021125a8.c:
+    complete
+    .text start:0x021125a8 end:0x02112618
+
+src/func_ov027_02112618.cpp:
+    complete
+    .text start:0x02112618 end:0x02112700
+
+src/_ZN13SnowmanBreath16CleanupResourcesEv.c:
+    complete
+    .text start:0x02112700 end:0x0211273c
+
+src/_ZN13SnowmanBreath16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211273c end:0x02112740
+
+src/_ZN13SnowmanBreath6RenderEv.cpp:
+    .text start:0x02112740 end:0x021127a4
+
+src/_ZN13SnowmanBreath8BehaviorEv.cpp:
+    .text start:0x021127a4 end:0x021129dc
+
+src/_ZN13SnowmanBreath13InitResourcesEv.cpp:
+    complete
+    .text start:0x021129dc end:0x02112ab4
+
+src/SnowmanBreath_Spawn.cpp:
+    complete
+    .text start:0x02112ab4 end:0x02112b14
+
+src/__sinit_ov027_02112cb0.c:
+    .init start:0x02112cb0 end:0x02112d1c
+
+src/__sinit_ov027_02112d1c.c:
+    .init start:0x02112d1c end:0x02112df8
+
+src/__sinit_ov027_02112df8.cpp:
+    .init start:0x02112df8 end:0x02112f70
+
+src/__sinit_ov027_02112f70.c:
+    .init start:0x02112f70 end:0x02112fc4

--- a/config/arm9/overlays/ov029/delinks.txt
+++ b/config/arm9/overlays/ov029/delinks.txt
@@ -4,3 +4,235 @@
     .ctor       start:0x02112e68 end:0x02112e88 kind:rodata align:4
     .data       start:0x02112ea0 end:0x02114220 kind:data align:32
     .bss        start:0x02114220 end:0x02114360 kind:bss align:32
+src/func_ov029_021111a0.c:
+    .text start:0x021111a0 end:0x021111f0
+
+src/func_ov029_021111f0.c:
+    .text start:0x021111f0 end:0x02111254
+
+src/func_ov029_02111254.c:
+    complete
+    .text start:0x02111254 end:0x02111340
+
+src/FloatOnWaterPlatformWdwSquare_Spawn.c:
+    .text start:0x02111340 end:0x0211137c
+
+src/_ZN29FloatOnWaterPlatformWdwSquareD1Ev.c:
+    .text start:0x0211137c end:0x021113c0
+
+src/_ZN29FloatOnWaterPlatformWdwSquareD0Ev.c:
+    .text start:0x021113c0 end:0x02111418
+
+src/_ZN29FloatOnWaterPlatformWdwSquare16CleanupResourcesEv.cpp:
+    .text start:0x02111418 end:0x0211145c
+
+src/_ZN29FloatOnWaterPlatformWdwSquare6RenderEv.cpp:
+    complete
+    .text start:0x0211145c end:0x02111484
+
+src/_ZN29FloatOnWaterPlatformWdwSquare8BehaviorEv.cpp:
+    .text start:0x02111484 end:0x021115f8
+
+src/_ZN29FloatOnWaterPlatformWdwSquare13InitResourcesEv.cpp:
+    complete
+    .text start:0x021115f8 end:0x021116c4
+
+src/func_ov029_021116c4.cpp:
+    complete
+    .text start:0x021116c4 end:0x021116e4
+
+src/func_ov029_021116e4.c:
+    complete
+    .text start:0x021116e4 end:0x021116f8
+
+src/ArrowLift_Spawn.c:
+    complete
+    .text start:0x021116f8 end:0x02111728
+
+src/_ZN9ArrowLiftD1Ev.cpp:
+    .text start:0x02111728 end:0x02111760
+
+src/_ZN9ArrowLiftD0Ev.c:
+    complete
+    .text start:0x02111760 end:0x021117ac
+
+src/func_ov029_021117ac.cpp:
+    complete
+    .text start:0x021117ac end:0x02111850
+
+src/func_ov029_02111850.cpp:
+    complete
+    .text start:0x02111850 end:0x021118c8
+
+src/func_ov029_021118c8.c:
+    complete
+    .text start:0x021118c8 end:0x02111908
+
+src/_ZN9ArrowLift16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111908 end:0x0211192c
+
+src/_ZN9ArrowLift6RenderEv.cpp:
+    complete
+    .text start:0x0211192c end:0x02111954
+
+src/_ZN9ArrowLift8BehaviorEv.cpp:
+    .text start:0x02111954 end:0x02111a04
+
+src/_ZN9ArrowLift13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111a04 end:0x02111a84
+
+src/WaterDiamond_Spawn.c:
+    complete
+    .text start:0x02111a84 end:0x02111ac4
+
+src/func_ov029_02111ac4.c:
+    .text start:0x02111ac4 end:0x02111b08
+
+src/func_ov029_02111b08.c:
+    .text start:0x02111b08 end:0x02111b60
+
+src/func_ov029_02111b60.c:
+    complete
+    .text start:0x02111b60 end:0x02111ba4
+
+src/func_ov029_02111ba4.cpp:
+    complete
+    .text start:0x02111ba4 end:0x02111bcc
+
+src/func_ov029_02111bcc.c:
+    complete
+    .text start:0x02111bcc end:0x02111d6c
+
+src/func_ov029_02111d6c.cpp:
+    .text start:0x02111d6c end:0x02111e40
+
+src/func_ov029_02111e40.cpp:
+    complete
+    .text start:0x02111e40 end:0x02111e60
+
+src/func_ov029_02111e60.c:
+    complete
+    .text start:0x02111e60 end:0x02111e74
+
+src/CageLift_Spawn.c:
+    complete
+    .text start:0x02111e74 end:0x02111ea4
+
+src/func_ov029_02111ea4.c:
+    .text start:0x02111ea4 end:0x02111ef4
+
+src/func_ov029_02111ef4.c:
+    .text start:0x02111ef4 end:0x02111f58
+
+src/func_ov029_02111f58.c:
+    complete
+    .text start:0x02111f58 end:0x02112044
+
+src/FloatOnWaterPlatformWdwRectangle_Spawn.c:
+    .text start:0x02112044 end:0x02112080
+
+src/_ZN32FloatOnWaterPlatformWdwRectangleD1Ev.c:
+    .text start:0x02112080 end:0x021120d0
+
+src/_ZN32FloatOnWaterPlatformWdwRectangleD0Ev.c:
+    .text start:0x021120d0 end:0x02112134
+
+src/_ZN32FloatOnWaterPlatformWdwRectangle16CleanupResourcesEv.c:
+    complete
+    .text start:0x02112134 end:0x02112148
+
+src/_ZN32FloatOnWaterPlatformWdwRectangle13InitResourcesEv.c:
+    complete
+    .text start:0x02112148 end:0x02112168
+
+src/RotatingPlatformWdw_Spawn.c:
+    .text start:0x02112168 end:0x021121a4
+
+src/_ZN19RotatingPlatformWdwD1Ev.c:
+    .text start:0x021121a4 end:0x021121f0
+
+src/_ZN19RotatingPlatformWdwD0Ev.c:
+    .text start:0x021121f0 end:0x02112250
+
+src/func_ov029_02112250.cpp:
+    complete
+    .text start:0x02112250 end:0x021122b4
+
+src/func_ov029_021122b4.c:
+    complete
+    .text start:0x021122b4 end:0x021122dc
+
+src/_ZN19RotatingPlatformWdw16CleanupResourcesEv.cpp:
+    .text start:0x021122dc end:0x02112320
+
+src/_ZN19RotatingPlatformWdw6RenderEv.cpp:
+    complete
+    .text start:0x02112320 end:0x02112354
+
+src/_ZN19RotatingPlatformWdw8BehaviorEv.cpp:
+    .text start:0x02112354 end:0x021124d0
+
+src/_ZN19RotatingPlatformWdw13InitResourcesEv.cpp:
+    .text start:0x021124d0 end:0x021125f8
+
+src/WDW_Water_Spawn.c:
+    complete
+    .text start:0x021125f8 end:0x02112630
+
+src/_ZN20SwitchActivatedPlankD1Ev.c:
+    .text start:0x02112630 end:0x0211267c
+
+src/_ZN20SwitchActivatedPlankD0Ev.c:
+    .text start:0x0211267c end:0x021126dc
+
+src/func_ov029_021126dc.c:
+    complete
+    .text start:0x021126dc end:0x02112710
+
+src/func_ov029_02112710.c:
+    complete
+    .text start:0x02112710 end:0x02112750
+
+src/_ZN20SwitchActivatedPlank16CleanupResourcesEv.cpp:
+    .text start:0x02112750 end:0x02112794
+
+src/_ZN20SwitchActivatedPlank6RenderEv.cpp:
+    complete
+    .text start:0x02112794 end:0x021127cc
+
+src/_ZN20SwitchActivatedPlank8BehaviorEv.cpp:
+    complete
+    .text start:0x021127cc end:0x021128b0
+
+src/_ZN20SwitchActivatedPlank13InitResourcesEv.cpp:
+    .text start:0x021128b0 end:0x02112964
+
+src/SwitchActivatedPlank_Spawn.c:
+    complete
+    .text start:0x02112964 end:0x0211299c
+
+src/__sinit_ov029_02112b38.c:
+    .init start:0x02112b38 end:0x02112ba4
+
+src/__sinit_ov029_02112ba4.c:
+    .init start:0x02112ba4 end:0x02112c10
+
+src/__sinit_ov029_02112c10.c:
+    .init start:0x02112c10 end:0x02112c4c
+
+src/__sinit_ov029_02112c4c.c:
+    .init start:0x02112c4c end:0x02112cb8
+
+src/__sinit_ov029_02112cb8.c:
+    .init start:0x02112cb8 end:0x02112d24
+
+src/__sinit_ov029_02112d24.c:
+    .init start:0x02112d24 end:0x02112d90
+
+src/__sinit_ov029_02112d90.c:
+    .init start:0x02112d90 end:0x02112dfc
+
+src/__sinit_ov029_02112dfc.c:
+    .init start:0x02112dfc end:0x02112e68

--- a/config/arm9/overlays/ov030/delinks.txt
+++ b/config/arm9/overlays/ov030/delinks.txt
@@ -4,3 +4,230 @@
     .ctor       start:0x02114dd0 end:0x02114ddc kind:rodata align:4
     .data       start:0x02114de0 end:0x02115c80 kind:data align:32
     .bss        start:0x02115c80 end:0x02115ec0 kind:bss align:32
+src/func_ov030_021111a0.c:
+    .text start:0x021111a0 end:0x021111ec
+
+src/func_ov030_021111ec.c:
+    .text start:0x021111ec end:0x0211124c
+
+src/func_ov030_0211124c.cpp:
+    complete
+    .text start:0x0211124c end:0x0211130c
+
+src/func_ov030_0211130c.c:
+    .text start:0x0211130c end:0x02111350
+
+src/func_ov030_02111350.cpp:
+    complete
+    .text start:0x02111350 end:0x02111384
+
+src/func_ov030_02111384.cpp:
+    .text start:0x02111384 end:0x02111410
+
+src/func_ov030_02111410.cpp:
+    complete
+    .text start:0x02111410 end:0x02111524
+
+src/UkikiCage_Spawn.c:
+    .text start:0x02111524 end:0x0211155c
+
+src/_ZN9UkikiCageD1Ev.c:
+    .text start:0x0211155c end:0x021115ac
+
+src/_ZN9UkikiCageD0Ev.c:
+    .text start:0x021115ac end:0x02111610
+
+src/_ZN9UkikiCage16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111610 end:0x02111624
+
+src/_ZN9UkikiCage8BehaviorEv.c:
+    complete
+    .text start:0x02111624 end:0x02111638
+
+src/_ZN9UkikiCage13InitResourcesEv.c:
+    complete
+    .text start:0x02111638 end:0x0211164c
+
+src/RollingLogTtm_Spawn.c:
+    .text start:0x0211164c end:0x02111688
+
+src/_ZN13RollingLogTtmD1Ev.cpp:
+    .text start:0x02111688 end:0x021116d0
+
+src/_ZN13RollingLogTtmD0Ev.c:
+    complete
+    .text start:0x021116d0 end:0x0211172c
+
+src/func_ov030_0211172c.c:
+    complete
+    .text start:0x0211172c end:0x02111734
+
+src/func_ov030_02111734.c:
+    complete
+    .text start:0x02111734 end:0x02111890
+
+src/func_ov030_02111890.c:
+    complete
+    .text start:0x02111890 end:0x02111908
+
+src/func_ov030_02111908.c:
+    complete
+    .text start:0x02111908 end:0x02111a00
+
+src/func_ov030_02111a00.c:
+    complete
+    .text start:0x02111a00 end:0x02111b20
+
+src/func_ov030_02111b20.c:
+    complete
+    .text start:0x02111b20 end:0x02111bc4
+
+src/func_ov030_02111bc4.c:
+    complete
+    .text start:0x02111bc4 end:0x02111dd0
+
+src/func_ov030_02111dd0.cpp:
+    complete
+    .text start:0x02111dd0 end:0x02111ea4
+
+src/func_ov030_02111ea4.cpp:
+    complete
+    .text start:0x02111ea4 end:0x02111f6c
+
+src/func_ov030_02111f6c.cpp:
+    complete
+    .text start:0x02111f6c end:0x02112094
+
+src/func_ov030_02112094.cpp:
+    complete
+    .text start:0x02112094 end:0x021122b0
+
+src/func_ov030_021122b0.cpp:
+    complete
+    .text start:0x021122b0 end:0x021123a4
+
+src/func_ov030_021123a4.cpp:
+    complete
+    .text start:0x021123a4 end:0x02112400
+
+src/func_ov030_02112400.cpp:
+    complete
+    .text start:0x02112400 end:0x02112560
+
+src/func_ov030_02112560.c:
+    complete
+    .text start:0x02112560 end:0x02112578
+
+src/func_ov030_02112578.c:
+    complete
+    .text start:0x02112578 end:0x02112a14
+
+src/func_ov030_02112a14.c:
+    complete
+    .text start:0x02112a14 end:0x02112a84
+
+src/func_ov030_02112a84.c:
+    complete
+    .text start:0x02112a84 end:0x02112c14
+
+src/func_ov030_02112c14.c:
+    complete
+    .text start:0x02112c14 end:0x02112da0
+
+src/func_ov030_02112da0.c:
+    complete
+    .text start:0x02112da0 end:0x02112ff8
+
+src/func_ov030_02112ff8.c:
+    .text start:0x02112ff8 end:0x02113094
+
+src/func_ov030_02113094.c:
+    complete
+    .text start:0x02113094 end:0x021132d4
+
+src/func_ov030_021132d4.cpp:
+    complete
+    .text start:0x021132d4 end:0x02113324
+
+src/func_ov030_0211360c.cpp:
+    complete
+    .text start:0x0211360c end:0x021136b0
+
+src/func_ov030_02113a80.cpp:
+    .text start:0x02113a80 end:0x02113b38
+
+src/func_ov030_02113b38.cpp:
+    complete
+    .text start:0x02113b38 end:0x02113be8
+
+src/func_ov030_02113be8.c:
+    complete
+    .text start:0x02113be8 end:0x02113d20
+
+src/func_ov030_02113d20.c:
+    complete
+    .text start:0x02113d20 end:0x02113fd8
+
+src/func_ov030_02113fd8.c:
+    complete
+    .text start:0x02113fd8 end:0x02113ff0
+
+src/func_ov030_02113ff0.cpp:
+    complete
+    .text start:0x02113ff0 end:0x02114124
+
+src/func_ov030_02114124.c:
+    complete
+    .text start:0x02114124 end:0x02114134
+
+src/func_ov030_02114134.cpp:
+    complete
+    .text start:0x02114134 end:0x02114170
+
+src/func_ov030_02114170.cpp:
+    complete
+    .text start:0x02114170 end:0x021141a8
+
+src/func_ov030_021141a8.c:
+    complete
+    .text start:0x021141a8 end:0x021141c4
+
+src/_ZN13RollingLogTtm16CleanupResourcesEv.c:
+    complete
+    .text start:0x021141c4 end:0x0211422c
+
+src/_ZN13RollingLogTtm16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211422c end:0x02114230
+
+src/_ZN13RollingLogTtm6RenderEv.cpp:
+    complete
+    .text start:0x02114230 end:0x02114278
+
+src/_ZN13RollingLogTtm8BehaviorEv.cpp:
+    .text start:0x02114278 end:0x02114378
+
+src/_ZN13RollingLogTtm13InitResourcesEv.cpp:
+    .text start:0x02114378 end:0x021145d4
+
+src/func_ov030_021145d4.c:
+    complete
+    .text start:0x021145d4 end:0x021145e0
+
+src/UkikiStar_Spawn.c:
+    complete
+    .text start:0x021145e0 end:0x02114638
+
+src/UkikiThief_Spawn.c:
+    complete
+    .text start:0x02114638 end:0x02114690
+
+src/__sinit_ov030_0211484c.c:
+    .init start:0x0211484c end:0x021148b8
+
+src/__sinit_ov030_021148b8.c:
+    .init start:0x021148b8 end:0x02114924
+
+src/__sinit_ov030_02114924.c:
+    .init start:0x02114924 end:0x02114dd0

--- a/config/arm9/overlays/ov031/delinks.txt
+++ b/config/arm9/overlays/ov031/delinks.txt
@@ -4,3 +4,44 @@
     .ctor       start:0x021114ec end:0x021114f0 kind:rodata align:4
     .data       start:0x02111500 end:0x02111a00 kind:data align:32
     .bss        start:0x02111a00 end:0x02111a60 kind:bss align:32
+src/_ZN25SlideDecorationSilverStarD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111d0
+
+src/_ZN25SlideDecorationSilverStarD0Ev.c:
+    complete
+    .text start:0x021111d0 end:0x02111214
+
+src/func_ov031_02111214.c:
+    complete
+    .text start:0x02111214 end:0x02111254
+
+src/_ZN25SlideDecorationSilverStar16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02111254 end:0x02111280
+
+src/_ZN25SlideDecorationSilverStar6RenderEv.cpp:
+    complete
+    .text start:0x02111280 end:0x021112a8
+
+src/_ZN25SlideDecorationSilverStar13InitResourcesEv.cpp:
+    complete
+    .text start:0x021112a8 end:0x02111344
+
+src/SlideDecorationBlueSmiley_Spawn.c:
+    complete
+    .text start:0x02111344 end:0x0211137c
+
+src/SlideDecorationOrangeSmiley_Spawn.c:
+    complete
+    .text start:0x0211137c end:0x021113b4
+
+src/SlideDecorationYellowStar_Spawn.c:
+    complete
+    .text start:0x021113b4 end:0x021113ec
+
+src/SlideDecorationSilverStar_Spawn.c:
+    complete
+    .text start:0x021113ec end:0x02111424
+
+src/__sinit_ov031_02111434.c:
+    .init start:0x02111434 end:0x021114ec

--- a/config/arm9/overlays/ov032/delinks.txt
+++ b/config/arm9/overlays/ov032/delinks.txt
@@ -4,3 +4,156 @@
     .ctor       start:0x02112e94 end:0x02112ea0 kind:rodata align:4
     .data       start:0x02112ec0 end:0x02113a40 kind:data align:32
     .bss        start:0x02113a40 end:0x02113b20 kind:bss align:32
+src/func_ov032_021111a0.c:
+    complete
+    .text start:0x021111a0 end:0x021111f0
+
+src/func_ov032_021111f0.c:
+    complete
+    .text start:0x021111f0 end:0x02111254
+
+src/func_ov032_02111254.c:
+    complete
+    .text start:0x02111254 end:0x02111350
+
+src/func_ov032_02111350.c:
+    complete
+    .text start:0x02111350 end:0x021113fc
+
+src/func_ov032_021113fc.cpp:
+    complete
+    .text start:0x021113fc end:0x02111620
+
+src/func_ov032_02111620.cpp:
+    complete
+    .text start:0x02111620 end:0x02111814
+
+src/func_ov032_02111814.c:
+    complete
+    .text start:0x02111814 end:0x02111830
+
+src/func_ov032_02111830.c:
+    complete
+    .text start:0x02111830 end:0x02111b50
+
+src/func_ov032_02111b50.c:
+    complete
+    .text start:0x02111b50 end:0x02111b9c
+
+src/func_ov032_02111b9c.cpp:
+    .text start:0x02111b9c end:0x02111d58
+
+src/func_ov032_02111d58.c:
+    complete
+    .text start:0x02111d58 end:0x02111d7c
+
+src/func_ov032_02111d7c.cpp:
+    complete
+    .text start:0x02111d7c end:0x02111dd8
+
+src/func_ov032_02111dd8.c:
+    complete
+    .text start:0x02111dd8 end:0x02111e24
+
+src/func_ov032_02111e24.c:
+    complete
+    .text start:0x02111e24 end:0x02111f9c
+
+src/func_ov032_02111f9c.c:
+    complete
+    .text start:0x02111f9c end:0x02111ff4
+
+src/func_ov032_02111ff4.cpp:
+    complete
+    .text start:0x02111ff4 end:0x02112044
+
+src/func_ov032_02112044.cpp:
+    complete
+    .text start:0x02112044 end:0x02112124
+
+src/func_ov032_02112124.c:
+    complete
+    .text start:0x02112124 end:0x02112160
+
+src/func_ov032_02112160.c:
+    complete
+    .text start:0x02112160 end:0x02112164
+
+src/func_ov032_02112164.cpp:
+    complete
+    .text start:0x02112164 end:0x021121b4
+
+src/func_ov032_021121b4.cpp:
+    complete
+    .text start:0x021121b4 end:0x021122dc
+
+src/func_ov032_021122dc.c:
+    complete
+    .text start:0x021122dc end:0x02112444
+
+src/func_ov032_02112444.c:
+    complete
+    .text start:0x02112444 end:0x0211244c
+
+src/func_ov032_0211244c.c:
+    complete
+    .text start:0x0211244c end:0x021124a8
+
+src/func_ov032_021124a8.c:
+    .text start:0x021124a8 end:0x021124ec
+
+src/func_ov032_021124ec.c:
+    .text start:0x021124ec end:0x02112544
+
+src/func_ov032_02112544.c:
+    complete
+    .text start:0x02112544 end:0x02112588
+
+src/func_ov032_02112588.cpp:
+    complete
+    .text start:0x02112588 end:0x021125b0
+
+src/func_ov032_021125b0.cpp:
+    complete
+    .text start:0x021125b0 end:0x021125d4
+
+src/func_ov032_021125d4.cpp:
+    complete
+    .text start:0x021125d4 end:0x02112668
+
+src/HugeCover_Spawn.c:
+    complete
+    .text start:0x02112668 end:0x02112698
+
+src/_ZN9HugeCoverD1Ev.c:
+    .text start:0x02112698 end:0x021126e4
+
+src/_ZN9HugeCoverD0Ev.c:
+    .text start:0x021126e4 end:0x02112744
+
+src/_ZN9HugeCover16CleanupResourcesEv.cpp:
+    .text start:0x02112744 end:0x02112788
+
+src/_ZN9HugeCover6RenderEv.cpp:
+    complete
+    .text start:0x02112788 end:0x021127bc
+
+src/_ZN9HugeCover8BehaviorEv.cpp:
+    .text start:0x021127bc end:0x021127f0
+
+src/_ZN9HugeCover13InitResourcesEv.cpp:
+    complete
+    .text start:0x021127f0 end:0x021128b8
+
+src/HugeWater_Spawn.c:
+    complete
+    .text start:0x021128b8 end:0x021128f0
+
+src/__sinit_ov032_02112c10.c:
+    .init start:0x02112c10 end:0x02112dbc
+
+src/__sinit_ov032_02112dbc.c:
+    .init start:0x02112dbc end:0x02112e28
+
+src/__sinit_ov032_02112e28.c:
+    .init start:0x02112e28 end:0x02112e94

--- a/config/arm9/overlays/ov033/delinks.txt
+++ b/config/arm9/overlays/ov033/delinks.txt
@@ -4,3 +4,63 @@
     .ctor       start:0x02111ac0 end:0x02111ac8 kind:rodata align:4
     .data       start:0x02111ae0 end:0x021124c0 kind:data align:32
     .bss        start:0x021124c0 end:0x02112520 kind:bss align:32
+src/func_ov033_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov033_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov033_0211123c.c:
+    complete
+    .text start:0x0211123c end:0x02111280
+
+src/func_ov033_02111280.c:
+    complete
+    .text start:0x02111280 end:0x021112c4
+
+src/func_ov033_021112c4.cpp:
+    complete
+    .text start:0x021112c4 end:0x021112ec
+
+src/func_ov033_021112ec.cpp:
+    complete
+    .text start:0x021112ec end:0x02111310
+
+src/func_ov033_02111310.cpp:
+    complete
+    .text start:0x02111310 end:0x021113a4
+
+src/TinyCover_Spawn.c:
+    complete
+    .text start:0x021113a4 end:0x021113d4
+
+src/_ZN9TinyCoverD1Ev.c:
+    .text start:0x021113d4 end:0x02111420
+
+src/_ZN9TinyCoverD0Ev.c:
+    .text start:0x02111420 end:0x02111480
+
+src/_ZN9TinyCover16CleanupResourcesEv.cpp:
+    .text start:0x02111480 end:0x021114c4
+
+src/_ZN9TinyCover6RenderEv.cpp:
+    complete
+    .text start:0x021114c4 end:0x021114f8
+
+src/_ZN9TinyCover8BehaviorEv.c:
+    complete
+    .text start:0x021114f8 end:0x021115bc
+
+src/_ZN9TinyCover13InitResourcesEv.cpp:
+    complete
+    .text start:0x021115bc end:0x02111690
+
+src/TinyWater_Spawn.c:
+    complete
+    .text start:0x02111690 end:0x021116c8
+
+src/__sinit_ov033_021119e8.c:
+    .init start:0x021119e8 end:0x02111a54
+
+src/__sinit_ov033_02111a54.c:
+    .init start:0x02111a54 end:0x02111ac0

--- a/config/arm9/overlays/ov034/delinks.txt
+++ b/config/arm9/overlays/ov034/delinks.txt
@@ -4,3 +4,138 @@
     .ctor       start:0x02114078 end:0x0211407c kind:rodata align:4
     .data       start:0x02114080 end:0x02114620 kind:data align:32
     .bss        start:0x02114620 end:0x021148e0 kind:bss align:32
+src/_ZN7WigglerD1Ev.c:
+    complete
+    .text start:0x021111a0 end:0x021112b0
+
+src/_ZN7WigglerD0Ev.c:
+    complete
+    .text start:0x021112b0 end:0x021113d4
+
+src/func_ov034_021113d4.c:
+    complete
+    .text start:0x021113d4 end:0x02111520
+
+src/func_ov034_02111520.c:
+    complete
+    .text start:0x02111520 end:0x02111588
+
+src/func_ov034_02111588.cpp:
+    complete
+    .text start:0x02111588 end:0x021115c0
+
+src/func_ov034_021115c0.c:
+    complete
+    .text start:0x021115c0 end:0x021115cc
+
+src/func_ov034_021115cc.cpp:
+    complete
+    .text start:0x021115cc end:0x02111720
+
+src/func_ov034_02111720.c:
+    complete
+    .text start:0x02111720 end:0x02111788
+
+src/func_ov034_02111788.cpp:
+    .text start:0x02111788 end:0x02111974
+
+src/func_ov034_02111974.c:
+    complete
+    .text start:0x02111974 end:0x021119ac
+
+src/func_ov034_021119ac.c:
+    complete
+    .text start:0x021119ac end:0x02111a0c
+
+src/func_ov034_02111a0c.cpp:
+    complete
+    .text start:0x02111a0c end:0x02111a64
+
+src/func_ov034_02111a64.c:
+    complete
+    .text start:0x02111a64 end:0x02111bb0
+
+src/func_ov034_02111bb0.c:
+    complete
+    .text start:0x02111bb0 end:0x02111c48
+
+src/func_ov034_02111c48.c:
+    complete
+    .text start:0x02111c48 end:0x02111e4c
+
+src/func_ov034_02111e4c.c:
+    complete
+    .text start:0x02111e4c end:0x02111e68
+
+src/func_ov034_02111e68.c:
+    complete
+    .text start:0x02111e68 end:0x02112020
+
+src/func_ov034_02112020.c:
+    complete
+    .text start:0x02112020 end:0x021120ac
+
+src/func_ov034_021120ac.cpp:
+    complete
+    .text start:0x021120ac end:0x02112270
+
+src/func_ov034_02112270.c:
+    complete
+    .text start:0x02112270 end:0x02112284
+
+src/func_ov034_02112284.c:
+    complete
+    .text start:0x02112284 end:0x02112330
+
+src/func_ov034_02112330.cpp:
+    complete
+    .text start:0x02112330 end:0x02112348
+
+src/func_ov034_02112348.c:
+    complete
+    .text start:0x02112348 end:0x02112484
+
+src/func_ov034_02112484.cpp:
+    complete
+    .text start:0x02112484 end:0x021125b8
+
+src/func_ov034_021125b8.cpp:
+    complete
+    .text start:0x021125b8 end:0x02112604
+
+src/func_ov034_02112604.cpp:
+    complete
+    .text start:0x02112604 end:0x02112650
+
+src/func_ov034_02112650.c:
+    complete
+    .text start:0x02112650 end:0x02112688
+
+src/func_ov034_02112688.c:
+    complete
+    .text start:0x02112688 end:0x02112874
+
+src/func_ov034_02112874.c:
+    complete
+    .text start:0x02112874 end:0x021129ec
+
+src/func_ov034_021129ec.c:
+    complete
+    .text start:0x021129ec end:0x02112a5c
+
+src/_ZN7Wiggler16CleanupResourcesEv.c:
+    complete
+    .text start:0x02112a5c end:0x02112af4
+
+src/_ZN7Wiggler6RenderEv.cpp:
+    complete
+    .text start:0x02112af4 end:0x02112b5c
+
+src/_ZN7Wiggler13InitResourcesEv.cpp:
+    .text start:0x0211323c end:0x021136a4
+
+src/Wiggler_Spawn.c:
+    .text start:0x021136a4 end:0x02113820
+
+src/__sinit_ov034_021138ec.c:
+    .init start:0x021138ec end:0x02114078

--- a/config/arm9/overlays/ov035/delinks.txt
+++ b/config/arm9/overlays/ov035/delinks.txt
@@ -4,3 +4,71 @@
     .ctor       start:0x02112028 end:0x02112030 kind:rodata align:4
     .data       start:0x02112040 end:0x02112c60 kind:data align:32
     .bss        start:0x02112c60 end:0x02112ce0 kind:bss align:32
+src/_ZN16RotatingCogSmallD1Ev.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/_ZN16RotatingCogSmallD0Ev.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/_ZN16RotatingCogSmall16CleanupResourcesEv.cpp:
+    .text start:0x0211123c end:0x021112c4
+
+src/_ZN16RotatingCogSmall6RenderEv.cpp:
+    complete
+    .text start:0x021112c4 end:0x021112ec
+
+src/_ZN16RotatingCogSmall8BehaviorEv.cpp:
+    complete
+    .text start:0x021112ec end:0x021114e0
+
+src/_ZN16RotatingCogSmall13InitResourcesEv.cpp:
+    .text start:0x021114e0 end:0x0211165c
+
+src/RotatingCogSmall_Spawn.c:
+    complete
+    .text start:0x0211165c end:0x0211168c
+
+src/func_ov035_0211168c.c:
+    complete
+    .text start:0x0211168c end:0x021116bc
+
+src/RotatingClockHand_Spawn.c:
+    complete
+    .text start:0x021116bc end:0x021116ec
+
+src/_ZN17RotatingClockHandD1Ev.c:
+    .text start:0x021116ec end:0x02111738
+
+src/_ZN17RotatingClockHandD0Ev.c:
+    .text start:0x02111738 end:0x02111798
+
+src/func_ov035_02111798.c:
+    complete
+    .text start:0x02111798 end:0x021118a8
+
+src/func_ov035_021118a8.c:
+    complete
+    .text start:0x021118a8 end:0x021118f0
+
+src/_ZN17RotatingClockHand16CleanupResourcesEv.cpp:
+    .text start:0x021118f0 end:0x02111934
+
+src/_ZN17RotatingClockHand6RenderEv.cpp:
+    complete
+    .text start:0x02111934 end:0x0211195c
+
+src/_ZN17RotatingClockHand8BehaviorEv.cpp:
+    .text start:0x0211195c end:0x02111a98
+
+src/_ZN17RotatingClockHand13InitResourcesEv.cpp:
+    .text start:0x02111a98 end:0x02111b98
+
+src/SpinningPlatform_Spawn.c:
+    complete
+    .text start:0x02111b98 end:0x02111bd0
+
+src/__sinit_ov035_02111f04.c:
+    .init start:0x02111f04 end:0x02111fc0
+
+src/__sinit_ov035_02111fc0.c:
+    .init start:0x02111fc0 end:0x02112028

--- a/config/arm9/overlays/ov036/delinks.txt
+++ b/config/arm9/overlays/ov036/delinks.txt
@@ -3,3 +3,209 @@
     .ctor       start:0x021129dc end:0x021129f8 kind:rodata align:4
     .data       start:0x02112a00 end:0x02114020 kind:data align:32
     .bss        start:0x02114020 end:0x021141e0 kind:bss align:32
+src/func_ov036_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov036_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov036_0211123c.c:
+    complete
+    .text start:0x0211123c end:0x02111284
+
+src/func_ov036_02111284.c:
+    .text start:0x02111284 end:0x021112c8
+
+src/func_ov036_021112c8.cpp:
+    complete
+    .text start:0x021112c8 end:0x021112f0
+
+src/func_ov036_021112f0.c:
+    complete
+    .text start:0x021112f0 end:0x0211137c
+
+src/func_ov036_0211137c.cpp:
+    .text start:0x0211137c end:0x02111414
+
+src/SwingingPlatform_Spawn.c:
+    complete
+    .text start:0x02111414 end:0x02111444
+
+src/func_ov036_02111444.c:
+    .text start:0x02111444 end:0x02111494
+
+src/func_ov036_02111494.c:
+    .text start:0x02111494 end:0x021114f8
+
+src/func_ov036_021114f8.c:
+    complete
+    .text start:0x021114f8 end:0x0211150c
+
+src/func_ov036_0211150c.c:
+    complete
+    .text start:0x0211150c end:0x02111544
+
+src/RotatingPlatformRr_Spawn.c:
+    .text start:0x02111544 end:0x02111580
+
+src/_ZN18RotatingPlatformRrD1Ev.cpp:
+    .text start:0x02111580 end:0x021115b0
+
+src/_ZN18RotatingPlatformRrD0Ev.c:
+    complete
+    .text start:0x021115b0 end:0x021115f4
+
+src/_ZN18RotatingPlatformRr16CleanupResourcesEv.c:
+    complete
+    .text start:0x021115f4 end:0x02111618
+
+src/func_ov036_02111618.c:
+    complete
+    .text start:0x02111618 end:0x0211169c
+
+src/_ZN18RotatingPlatformRr6RenderEv.cpp:
+    complete
+    .text start:0x0211169c end:0x021116c0
+
+src/_ZN18RotatingPlatformRr8BehaviorEv.cpp:
+    .text start:0x021116c0 end:0x02111854
+
+src/_ZN18RotatingPlatformRr13InitResourcesEv.cpp:
+    .text start:0x02111854 end:0x02111904
+
+src/ShipWing_Spawn.c:
+    complete
+    .text start:0x02111904 end:0x0211193c
+
+src/_ZN8ShipWingD1Ev.c:
+    .text start:0x0211193c end:0x02111988
+
+src/_ZN8ShipWingD0Ev.c:
+    .text start:0x02111988 end:0x021119e8
+
+src/_ZN8ShipWing16CleanupResourcesEv.cpp:
+    .text start:0x021119e8 end:0x02111a2c
+
+src/_ZN8ShipWing16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111a2c end:0x02111a30
+
+src/_ZN8ShipWing6RenderEv.cpp:
+    complete
+    .text start:0x02111a30 end:0x02111a64
+
+src/_ZN8ShipWing8BehaviorEv.cpp:
+    .text start:0x02111a64 end:0x02111bb8
+
+src/_ZN8ShipWing13InitResourcesEv.cpp:
+    .text start:0x02111bb8 end:0x02111ca4
+
+src/func_ov036_02111ca4.cpp:
+    complete
+    .text start:0x02111ca4 end:0x02111cc4
+
+src/func_ov036_02111cc4.c:
+    complete
+    .text start:0x02111cc4 end:0x02111cd8
+
+src/DonutBlock_Spawn.c:
+    complete
+    .text start:0x02111cd8 end:0x02111d14
+
+src/_ZN10DonutBlockD1Ev.c:
+    .text start:0x02111d14 end:0x02111d58
+
+src/_ZN10DonutBlockD0Ev.c:
+    .text start:0x02111d58 end:0x02111db0
+
+src/_ZN10DonutBlock16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02111db0 end:0x02111df8
+
+src/_ZN10DonutBlock6RenderEv.cpp:
+    complete
+    .text start:0x02111df8 end:0x02111e20
+
+src/_ZN10DonutBlock8BehaviorEv.cpp:
+    .text start:0x02111e20 end:0x02111eb0
+
+src/_ZN10DonutBlock13InitResourcesEv.cpp:
+    .text start:0x02111eb0 end:0x02111f5c
+
+src/ArmedRotatingPlatform_Spawn.c:
+    complete
+    .text start:0x02111f5c end:0x02111f8c
+
+src/_ZN21ArmedRotatingPlatformD1Ev.cpp:
+    complete
+    .text start:0x02111f8c end:0x0211200c
+
+src/_ZN21ArmedRotatingPlatformD0Ev.c:
+    complete
+    .text start:0x0211200c end:0x021120a0
+
+src/_ZN21ArmedRotatingPlatform16CleanupResourcesEv.cpp:
+    .text start:0x021120a0 end:0x021120b4
+
+src/_ZN21ArmedRotatingPlatform13InitResourcesEv.cpp:
+    .text start:0x021120b4 end:0x021120c8
+
+src/TrickyTriangles_Spawn.cpp:
+    complete
+    .text start:0x021120c8 end:0x02112158
+
+src/func_ov036_02112158.cpp:
+    complete
+    .text start:0x02112158 end:0x021121c8
+
+src/func_ov036_021121c8.cpp:
+    complete
+    .text start:0x021121c8 end:0x0211224c
+
+src/func_ov036_0211224c.cpp:
+    complete
+    .text start:0x0211224c end:0x021122c0
+
+src/func_ov036_021122c0.cpp:
+    complete
+    .text start:0x021122c0 end:0x02112318
+
+src/func_ov036_02112318.cpp:
+    complete
+    .text start:0x02112318 end:0x02112378
+
+src/func_ov036_02112378.cpp:
+    complete
+    .text start:0x02112378 end:0x021123c8
+
+src/func_ov036_021123c8.cpp:
+    complete
+    .text start:0x021123c8 end:0x0211244c
+
+src/func_ov036_0211244c.cpp:
+    .text start:0x0211244c end:0x02112538
+
+src/FlyingCarpet_Spawn.cpp:
+    complete
+    .text start:0x02112538 end:0x021125b0
+
+src/__sinit_ov036_021125b0.c:
+    .init start:0x021125b0 end:0x0211261c
+
+src/__sinit_ov036_0211261c.c:
+    .init start:0x0211261c end:0x02112688
+
+src/__sinit_ov036_02112688.c:
+    .init start:0x02112688 end:0x021126c8
+
+src/__sinit_ov036_021126c8.c:
+    .init start:0x021126c8 end:0x02112730
+
+src/__sinit_ov036_02112730.c:
+    .init start:0x02112730 end:0x0211279c
+
+src/__sinit_ov036_0211279c.c:
+    .init start:0x0211279c end:0x02112944
+
+src/__sinit_ov036_02112944.c:
+    .init start:0x02112944 end:0x021129dc

--- a/config/arm9/overlays/ov039/delinks.txt
+++ b/config/arm9/overlays/ov039/delinks.txt
@@ -3,3 +3,35 @@
     .ctor       start:0x021113f4 end:0x021113f8 kind:rodata align:4
     .data       start:0x02111400 end:0x021118e0 kind:data align:32
     .bss        start:0x021118e0 end:0x02111900 kind:bss align:32
+src/_ZN5CloudD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111d0
+
+src/_ZN5CloudD0Ev.c:
+    complete
+    .text start:0x021111d0 end:0x02111214
+
+src/func_ov039_02111214.c:
+    complete
+    .text start:0x02111214 end:0x02111254
+
+src/_ZN5Cloud16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111254 end:0x02111278
+
+src/_ZN5Cloud6RenderEv.cpp:
+    complete
+    .text start:0x02111278 end:0x021112a0
+
+src/_ZN5Cloud8BehaviorEv.c:
+    .text start:0x021112a0 end:0x0211132c
+
+src/_ZN5Cloud13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211132c end:0x0211137c
+
+src/Cloud_Spawn.c:
+    complete
+    .text start:0x0211137c end:0x021113b4
+
+src/__sinit_ov039_021113b4.c:
+    .init start:0x021113b4 end:0x021113f4

--- a/config/arm9/overlays/ov043/delinks.txt
+++ b/config/arm9/overlays/ov043/delinks.txt
@@ -3,3 +3,91 @@
     .ctor       start:0x02111ae8 end:0x02111af8 kind:rodata align:4
     .data       start:0x02111b00 end:0x021125e0 kind:data align:32
     .bss        start:0x021125e0 end:0x02112720 kind:bss align:32
+src/func_ov043_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov043_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov043_0211123c.c:
+    .text start:0x0211123c end:0x02111280
+
+src/func_ov043_02111280.cpp:
+    complete
+    .text start:0x02111280 end:0x021112a8
+
+src/func_ov043_021112a8.cpp:
+    complete
+    .text start:0x021112a8 end:0x02111320
+
+src/func_ov043_02111320.c:
+    complete
+    .text start:0x02111320 end:0x021113cc
+
+src/DiamondLift_Spawn.c:
+    complete
+    .text start:0x021113cc end:0x021113fc
+
+src/func_ov043_021113fc.c:
+    .text start:0x021113fc end:0x0211144c
+
+src/func_ov043_0211144c.c:
+    .text start:0x0211144c end:0x021114b0
+
+src/func_ov043_021114b0.c:
+    complete
+    .text start:0x021114b0 end:0x021114c4
+
+src/func_ov043_021114c4.c:
+    complete
+    .text start:0x021114c4 end:0x021114dc
+
+src/RickshawBdw_Spawn.c:
+    .text start:0x021114dc end:0x02111518
+
+src/_ZN11RickshawBdwD1Ev.c:
+    .text start:0x02111518 end:0x02111568
+
+src/_ZN11RickshawBdwD0Ev.c:
+    .text start:0x02111568 end:0x021115cc
+
+src/_ZN11RickshawBdw16CleanupResourcesEv.c:
+    complete
+    .text start:0x021115cc end:0x021115e0
+
+src/_ZN11RickshawBdw13InitResourcesEv.c:
+    complete
+    .text start:0x021115e0 end:0x021115f4
+
+src/RickshawPlatformBdw_Spawn.c:
+    .text start:0x021115f4 end:0x02111630
+
+src/_ZN19RickshawPlatformBdwD1Ev.cpp:
+    complete
+    .text start:0x02111630 end:0x021116b0
+
+src/_ZN19RickshawPlatformBdwD0Ev.c:
+    complete
+    .text start:0x021116b0 end:0x02111744
+
+src/_ZN19RickshawPlatformBdw16CleanupResourcesEv.cpp:
+    .text start:0x02111744 end:0x02111758
+
+src/_ZN19RickshawPlatformBdw13InitResourcesEv.cpp:
+    .text start:0x02111758 end:0x0211176c
+
+src/StairsBdw_Spawn.cpp:
+    complete
+    .text start:0x0211176c end:0x021117fc
+
+src/__sinit_ov043_021117fc.c:
+    .init start:0x021117fc end:0x02111868
+
+src/__sinit_ov043_02111868.c:
+    .init start:0x02111868 end:0x021118d4
+
+src/__sinit_ov043_021118d4.c:
+    .init start:0x021118d4 end:0x02111940
+
+src/__sinit_ov043_02111940.c:
+    .init start:0x02111940 end:0x02111ae8

--- a/config/arm9/overlays/ov044/delinks.txt
+++ b/config/arm9/overlays/ov044/delinks.txt
@@ -3,3 +3,32 @@
     .ctor       start:0x02111354 end:0x02111358 kind:rodata align:4
     .data       start:0x02111360 end:0x02111680 kind:data align:32
     .bss        start:0x02111680 end:0x021116a0 kind:bss align:32
+src/_ZN19OrangeBallBillboardD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111d0
+
+src/_ZN19OrangeBallBillboardD0Ev.c:
+    complete
+    .text start:0x021111d0 end:0x02111214
+
+src/func_ov044_02111214.c:
+    complete
+    .text start:0x02111214 end:0x02111254
+
+src/_ZN19OrangeBallBillboard16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111254 end:0x02111278
+
+src/_ZN19OrangeBallBillboard6RenderEv.cpp:
+    complete
+    .text start:0x02111278 end:0x021112a0
+
+src/_ZN19OrangeBallBillboard13InitResourcesEv.c:
+    complete
+    .text start:0x021112a0 end:0x021112dc
+
+src/OrangeBallBillboard_Spawn.c:
+    complete
+    .text start:0x021112dc end:0x02111314
+
+src/__sinit_ov044_02111314.c:
+    .init start:0x02111314 end:0x02111354

--- a/config/arm9/overlays/ov045/delinks.txt
+++ b/config/arm9/overlays/ov045/delinks.txt
@@ -4,3 +4,160 @@
     .ctor       start:0x0211242c end:0x02112444 kind:rodata align:4
     .data       start:0x02112460 end:0x02113180 kind:data align:32
     .bss        start:0x02113180 end:0x02113280 kind:bss align:32
+src/func_ov045_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov045_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov045_0211123c.c:
+    complete
+    .text start:0x0211123c end:0x02111274
+
+src/func_ov045_02111274.cpp:
+    complete
+    .text start:0x02111274 end:0x0211129c
+
+src/func_ov045_0211129c.c:
+    complete
+    .text start:0x0211129c end:0x021113ec
+
+src/func_ov045_021113ec.c:
+    complete
+    .text start:0x021113ec end:0x021114a8
+
+src/func_ov045_021114a8.cpp:
+    complete
+    .text start:0x021114a8 end:0x021114c8
+
+src/func_ov045_021114c8.c:
+    complete
+    .text start:0x021114c8 end:0x021114dc
+
+src/FireSeaElevator_Spawn.c:
+    complete
+    .text start:0x021114dc end:0x0211150c
+
+src/_ZN15FireSeaElevatorD1Ev.c:
+    .text start:0x0211150c end:0x02111558
+
+src/_ZN15FireSeaElevatorD0Ev.c:
+    .text start:0x02111558 end:0x021115b8
+
+src/_ZN15FireSeaElevator16CleanupResourcesEv.cpp:
+    .text start:0x021115b8 end:0x021115f0
+
+src/_ZN15FireSeaElevator6RenderEv.cpp:
+    complete
+    .text start:0x021115f0 end:0x02111618
+
+src/_ZN15FireSeaElevator8BehaviorEv.cpp:
+    .text start:0x02111618 end:0x02111738
+
+src/_ZN15FireSeaElevator13InitResourcesEv.cpp:
+    complete
+    .text start:0x02111738 end:0x02111808
+
+src/PoleLift_Spawn.c:
+    complete
+    .text start:0x02111808 end:0x02111840
+
+src/_ZN8PoleLiftD1Ev.cpp:
+    .text start:0x02111840 end:0x02111878
+
+src/_ZN8PoleLiftD0Ev.c:
+    complete
+    .text start:0x02111878 end:0x021118c4
+
+src/func_ov045_021118c4.cpp:
+    complete
+    .text start:0x021118c4 end:0x021118f8
+
+src/func_ov045_021118f8.c:
+    complete
+    .text start:0x021118f8 end:0x02111938
+
+src/_ZN8PoleLift16CleanupResourcesEv.cpp:
+    .text start:0x02111938 end:0x02111970
+
+src/_ZN8PoleLift16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111970 end:0x02111974
+
+src/_ZN8PoleLift6RenderEv.cpp:
+    complete
+    .text start:0x02111974 end:0x021119c0
+
+src/_ZN8PoleLift8BehaviorEv.cpp:
+    complete
+    .text start:0x021119c0 end:0x02111a30
+
+src/_ZN8PoleLift13InitResourcesEv.cpp:
+    .text start:0x02111a30 end:0x02111ad4
+
+src/ExtendingPlatform_Spawn.c:
+    complete
+    .text start:0x02111ad4 end:0x02111b14
+
+src/func_ov045_02111b14.c:
+    .text start:0x02111b14 end:0x02111b64
+
+src/func_ov045_02111b64.c:
+    .text start:0x02111b64 end:0x02111bc8
+
+src/func_ov045_02111bc8.c:
+    .text start:0x02111bc8 end:0x02111bdc
+
+src/func_ov045_02111bdc.c:
+    .text start:0x02111bdc end:0x02111bf4
+
+src/FloatingFloorBfs_Spawn.c:
+    .text start:0x02111bf4 end:0x02111c30
+
+src/_ZN16FloatingFloorBfsD1Ev.c:
+    .text start:0x02111c30 end:0x02111c80
+
+src/_ZN16FloatingFloorBfsD0Ev.c:
+    .text start:0x02111c80 end:0x02111ce4
+
+src/_ZN16FloatingFloorBfs16CleanupResourcesEv.c:
+    .text start:0x02111ce4 end:0x02111cf8
+
+src/_ZN16FloatingFloorBfs13InitResourcesEv.c:
+    .text start:0x02111cf8 end:0x02111d0c
+
+src/TiltingPlatformBfs_Spawn.c:
+    .text start:0x02111d0c end:0x02111d48
+
+src/_ZN12FallBlockBfsD1Ev.c:
+    .text start:0x02111d48 end:0x02111d98
+
+src/_ZN12FallBlockBfsD0Ev.c:
+    .text start:0x02111d98 end:0x02111dfc
+
+src/_ZN12FallBlockBfs16CleanupResourcesEv.c:
+    .text start:0x02111dfc end:0x02111e10
+
+src/_ZN12FallBlockBfs13InitResourcesEv.c:
+    .text start:0x02111e10 end:0x02111e24
+
+src/FallBlockBfs_Spawn.c:
+    .text start:0x02111e24 end:0x02111e60
+
+src/__sinit_ov045_021121a8.c:
+    .init start:0x021121a8 end:0x02112214
+
+src/__sinit_ov045_02112214.c:
+    .init start:0x02112214 end:0x02112280
+
+src/__sinit_ov045_02112280.c:
+    .init start:0x02112280 end:0x021122ec
+
+src/__sinit_ov045_021122ec.c:
+    .init start:0x021122ec end:0x02112358
+
+src/__sinit_ov045_02112358.c:
+    .init start:0x02112358 end:0x021123c0
+
+src/__sinit_ov045_021123c0.c:
+    .init start:0x021123c0 end:0x0211242c

--- a/config/arm9/overlays/ov047/delinks.txt
+++ b/config/arm9/overlays/ov047/delinks.txt
@@ -3,3 +3,83 @@
     .ctor       start:0x021119c4 end:0x021119d4 kind:rodata align:4
     .data       start:0x021119e0 end:0x021125e0 kind:data align:32
     .bss        start:0x021125e0 end:0x02112720 kind:bss align:32
+src/func_ov047_021111a0.c:
+    .text start:0x021111a0 end:0x021111f0
+
+src/func_ov047_021111f0.c:
+    .text start:0x021111f0 end:0x02111254
+
+src/func_ov047_02111254.c:
+    complete
+    .text start:0x02111254 end:0x02111268
+
+src/func_ov047_02111268.c:
+    complete
+    .text start:0x02111268 end:0x02111280
+
+src/RickshawBs_Spawn.c:
+    .text start:0x02111280 end:0x021112bc
+
+src/_ZN10RickshawBsD1Ev.c:
+    .text start:0x021112bc end:0x0211130c
+
+src/_ZN10RickshawBsD0Ev.c:
+    .text start:0x0211130c end:0x02111370
+
+src/_ZN10RickshawBs16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111370 end:0x02111384
+
+src/_ZN10RickshawBs13InitResourcesEv.c:
+    complete
+    .text start:0x02111384 end:0x021113bc
+
+src/func_ov047_021113bc.c:
+    .text start:0x021113bc end:0x021113f8
+
+src/func_ov047_021113f8.c:
+    .text start:0x021113f8 end:0x02111448
+
+src/func_ov047_02111448.c:
+    .text start:0x02111448 end:0x021114ac
+
+src/func_ov047_021114ac.c:
+    complete
+    .text start:0x021114ac end:0x021114c0
+
+src/func_ov047_021114c0.c:
+    complete
+    .text start:0x021114c0 end:0x021114d4
+
+src/RickshawPlatformBs_Spawn.c:
+    .text start:0x021114d4 end:0x02111510
+
+src/_ZN18RickshawPlatformBsD1Ev.c:
+    complete
+    .text start:0x02111510 end:0x02111590
+
+src/_ZN18RickshawPlatformBsD0Ev.c:
+    complete
+    .text start:0x02111590 end:0x02111624
+
+src/_ZN18RickshawPlatformBs16CleanupResourcesEv.cpp:
+    .text start:0x02111624 end:0x02111638
+
+src/_ZN18RickshawPlatformBs13InitResourcesEv.cpp:
+    .text start:0x02111638 end:0x0211164c
+
+src/StairsBs_Spawn.cpp:
+    complete
+    .text start:0x0211164c end:0x021116dc
+
+src/__sinit_ov047_021116dc.c:
+    .init start:0x021116dc end:0x02111748
+
+src/__sinit_ov047_02111748.c:
+    .init start:0x02111748 end:0x021117b4
+
+src/__sinit_ov047_021117b4.c:
+    .init start:0x021117b4 end:0x0211181c
+
+src/__sinit_ov047_0211181c.c:
+    .init start:0x0211181c end:0x021119c4

--- a/config/arm9/overlays/ov052/delinks.txt
+++ b/config/arm9/overlays/ov052/delinks.txt
@@ -4,3 +4,59 @@
     .ctor       start:0x02111c3c end:0x02111c44 kind:rodata align:4
     .data       start:0x02111c60 end:0x02112680 kind:data align:32
     .bss        start:0x02112680 end:0x021126e0 kind:bss align:32
+src/func_ov052_021111a0.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/func_ov052_021111e4.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/func_ov052_0211123c.c:
+    complete
+    .text start:0x0211123c end:0x02111284
+
+src/func_ov052_02111284.cpp:
+    complete
+    .text start:0x02111284 end:0x021112ac
+
+src/func_ov052_021112ac.c:
+    complete
+    .text start:0x021112ac end:0x02111348
+
+src/func_ov052_02111348.cpp:
+    complete
+    .text start:0x02111348 end:0x02111410
+
+src/func_ov052_02111410.c:
+    complete
+    .text start:0x02111410 end:0x02111440
+
+src/_ZN14SquarePathLiftD1Ev.c:
+    .text start:0x02111440 end:0x02111484
+
+src/_ZN14SquarePathLiftD0Ev.c:
+    .text start:0x02111484 end:0x021114dc
+
+src/_ZN14SquarePathLift16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x021114dc end:0x02111524
+
+src/_ZN14SquarePathLift6RenderEv.cpp:
+    complete
+    .text start:0x02111524 end:0x0211154c
+
+src/_ZN14SquarePathLift8BehaviorEv.cpp:
+    .text start:0x0211154c end:0x0211177c
+
+src/_ZN14SquarePathLift13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211177c end:0x02111830
+
+src/SquarePathLift_Spawn.c:
+    complete
+    .text start:0x02111830 end:0x02111868
+
+src/__sinit_ov052_02111b64.c:
+    .init start:0x02111b64 end:0x02111bd0
+
+src/__sinit_ov052_02111bd0.c:
+    .init start:0x02111bd0 end:0x02111c3c

--- a/config/arm9/overlays/ov055/delinks.txt
+++ b/config/arm9/overlays/ov055/delinks.txt
@@ -3,3 +3,50 @@
     .ctor       start:0x02111910 end:0x02111914 kind:rodata align:4
     .data       start:0x02111920 end:0x02111b60 kind:data align:32
     .bss        start:0x02111b60 end:0x02111b80 kind:bss align:32
+src/_ZN11MirrorLuigiD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111f8
+
+src/_ZN11MirrorLuigiD0Ev.c:
+    complete
+    .text start:0x021111f8 end:0x02111264
+
+src/func_ov055_02111264.c:
+    complete
+    .text start:0x02111264 end:0x02111288
+
+src/func_ov055_02111288.c:
+    complete
+    .text start:0x02111288 end:0x021112bc
+
+src/func_ov055_021112bc.c:
+    complete
+    .text start:0x021112bc end:0x021112c4
+
+src/func_ov055_021112c4.cpp:
+    complete
+    .text start:0x021112c4 end:0x02111318
+
+src/_ZN11MirrorLuigi16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111318 end:0x02111354
+
+src/_ZN11MirrorLuigi16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02111354 end:0x02111358
+
+src/_ZN11MirrorLuigi6RenderEv.cpp:
+    .text start:0x02111358 end:0x02111508
+
+src/_ZN11MirrorLuigi8BehaviorEv.cpp:
+    complete
+    .text start:0x02111508 end:0x02111674
+
+src/_ZN11MirrorLuigi13InitResourcesEv.cpp:
+    .text start:0x02111674 end:0x02111860
+
+src/MirrorLuigi_Spawn.cpp:
+    complete
+    .text start:0x02111860 end:0x021118d4
+
+src/__sinit_ov055_021118d4.c:
+    .init start:0x021118d4 end:0x02111910

--- a/config/arm9/overlays/ov056/delinks.txt
+++ b/config/arm9/overlays/ov056/delinks.txt
@@ -4,3 +4,30 @@
     .ctor       start:0x02112bb4 end:0x02112bb8 kind:rodata align:4
     .data       start:0x02112bc0 end:0x02113400 kind:data align:32
     .bss        start:0x02113400 end:0x02113440 kind:bss align:32
+src/_ZN17BigMovingIceBlockD1Ev.c:
+    .text start:0x021111a0 end:0x021111e4
+
+src/_ZN17BigMovingIceBlockD0Ev.c:
+    .text start:0x021111e4 end:0x0211123c
+
+src/_ZN17BigMovingIceBlock16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211123c end:0x02111284
+
+src/_ZN17BigMovingIceBlock6RenderEv.cpp:
+    complete
+    .text start:0x02111284 end:0x021112ac
+
+src/_ZN17BigMovingIceBlock8BehaviorEv.cpp:
+    .text start:0x021112ac end:0x021114e0
+
+src/_ZN17BigMovingIceBlock13InitResourcesEv.cpp:
+    complete
+    .text start:0x021114e0 end:0x02111594
+
+src/BigMovingIceBlock_Spawn.c:
+    complete
+    .text start:0x02111594 end:0x021115cc
+
+src/__sinit_ov056_02112b48.c:
+    .init start:0x02112b48 end:0x02112bb4

--- a/config/arm9/overlays/ov058/delinks.txt
+++ b/config/arm9/overlays/ov058/delinks.txt
@@ -2,3 +2,24 @@
     .ctor       start:0x021116e4 end:0x021116e4 kind:rodata align:4
     .data       start:0x02111700 end:0x02111b00 kind:data align:32
     .bss        start:0x02111b00 end:0x02111b00 kind:bss align:32
+src/_ZN15RecRoomCupboardD1Ev.cpp:
+    .text start:0x021111a0 end:0x021111e0
+
+src/_ZN15RecRoomCupboardD0Ev.cpp:
+    .text start:0x021111e0 end:0x02111234
+
+src/_ZN15RecRoomCupboard16CleanupResourcesEv.c:
+    complete
+    .text start:0x02111234 end:0x0211123c
+
+src/_ZN15RecRoomCupboard8BehaviorEv.cpp:
+    complete
+    .text start:0x0211123c end:0x0211161c
+
+src/_ZN15RecRoomCupboard13InitResourcesEv.c:
+    complete
+    .text start:0x0211161c end:0x02111688
+
+src/RecRoomCupboard_Spawn.cpp:
+    complete
+    .text start:0x02111688 end:0x021116e4

--- a/config/arm9/overlays/ov060/delinks.txt
+++ b/config/arm9/overlays/ov060/delinks.txt
@@ -4,3 +4,605 @@
     .ctor       start:0x0211a4bc end:0x0211a4d4 kind:rodata align:4
     .data       start:0x0211a4e0 end:0x0211abe0 kind:data align:32
     .bss        start:0x0211abe0 end:0x0211b240 kind:bss align:32
+src/_ZN6BowserD1Ev.cpp:
+    .text start:0x02111900 end:0x02111950
+
+src/_ZN6BowserD0Ev.c:
+    complete
+    .text start:0x02111950 end:0x021119b4
+
+src/_ZN10BowserTailD1Ev.cpp:
+    .text start:0x021119b4 end:0x021119e4
+
+src/_ZN10BowserTailD0Ev.c:
+    complete
+    .text start:0x021119e4 end:0x02111a28
+
+src/func_ov060_02111a28.cpp:
+    complete
+    .text start:0x02111a28 end:0x02111c68
+
+src/func_ov060_02111c68.c:
+    complete
+    .text start:0x02111c68 end:0x02111cc0
+
+src/func_ov060_02111cc0.cpp:
+    complete
+    .text start:0x02111cc0 end:0x02111f08
+
+src/func_ov060_02111f08.c:
+    complete
+    .text start:0x02111f08 end:0x02112350
+
+src/func_ov060_02112350.c:
+    complete
+    .text start:0x02112350 end:0x021123a0
+
+src/func_ov060_021123a0.c:
+    complete
+    .text start:0x021123a0 end:0x021123c8
+
+src/func_ov060_021123c8.c:
+    complete
+    .text start:0x021123c8 end:0x021123dc
+
+src/func_ov060_021123dc.c:
+    complete
+    .text start:0x021123dc end:0x02112434
+
+src/func_ov060_02112434.cpp:
+    complete
+    .text start:0x02112434 end:0x021125f0
+
+src/func_ov060_021125f0.c:
+    complete
+    .text start:0x021125f0 end:0x02112724
+
+src/func_ov060_02112724.c:
+    complete
+    .text start:0x02112724 end:0x021128c0
+
+src/func_ov060_021128c0.cpp:
+    complete
+    .text start:0x021128c0 end:0x02112ba8
+
+src/func_ov060_02112ba8.cpp:
+    complete
+    .text start:0x02112ba8 end:0x02112bfc
+
+src/func_ov060_02112bfc.c:
+    complete
+    .text start:0x02112bfc end:0x02112d48
+
+src/func_ov060_02112d48.c:
+    complete
+    .text start:0x02112d48 end:0x02112ddc
+
+src/func_ov060_02112ddc.cpp:
+    complete
+    .text start:0x02112ddc end:0x02112ee0
+
+src/func_ov060_02112ee0.cpp:
+    complete
+    .text start:0x02112ee0 end:0x021130c0
+
+src/func_ov060_021130c0.c:
+    complete
+    .text start:0x021130c0 end:0x02113260
+
+src/func_ov060_02113260.c:
+    complete
+    .text start:0x02113260 end:0x021132a4
+
+src/func_ov060_021132a4.c:
+    complete
+    .text start:0x021132a4 end:0x02113404
+
+src/func_ov060_02113404.c:
+    complete
+    .text start:0x02113404 end:0x021134ac
+
+src/func_ov060_021134ac.c:
+    complete
+    .text start:0x021134ac end:0x02113564
+
+src/func_ov060_02113564.c:
+    complete
+    .text start:0x02113564 end:0x021135fc
+
+src/func_ov060_021135fc.c:
+    complete
+    .text start:0x021135fc end:0x02113710
+
+src/func_ov060_02113710.c:
+    complete
+    .text start:0x02113710 end:0x02113740
+
+src/func_ov060_02113740.c:
+    complete
+    .text start:0x02113740 end:0x02113a94
+
+src/func_ov060_02113a94.c:
+    complete
+    .text start:0x02113a94 end:0x02113b5c
+
+src/func_ov060_02113b5c.cpp:
+    complete
+    .text start:0x02113b5c end:0x02113d20
+
+src/func_ov060_02113d20.cpp:
+    .text start:0x02113d20 end:0x02113d8c
+
+src/func_ov060_02113d8c.cpp:
+    complete
+    .text start:0x02113d8c end:0x02113fcc
+
+src/func_ov060_02113fcc.c:
+    complete
+    .text start:0x02113fcc end:0x02113ff4
+
+src/func_ov060_02113ff4.c:
+    complete
+    .text start:0x02113ff4 end:0x021140c0
+
+src/func_ov060_021142b4.c:
+    complete
+    .text start:0x021142b4 end:0x02114300
+
+src/func_ov060_02114300.c:
+    complete
+    .text start:0x02114300 end:0x021143b8
+
+src/func_ov060_021143b8.c:
+    complete
+    .text start:0x021143b8 end:0x021145a8
+
+src/func_ov060_021145a8.c:
+    complete
+    .text start:0x021145a8 end:0x021145d4
+
+src/func_ov060_021145d4.c:
+    complete
+    .text start:0x021145d4 end:0x0211469c
+
+src/func_ov060_0211469c.cpp:
+    complete
+    .text start:0x0211469c end:0x021146d0
+
+src/func_ov060_021146d0.c:
+    complete
+    .text start:0x021146d0 end:0x02114858
+
+src/func_ov060_02114858.c:
+    complete
+    .text start:0x02114858 end:0x02114b60
+
+src/func_ov060_02114b60.c:
+    complete
+    .text start:0x02114b60 end:0x02114d08
+
+src/func_ov060_02114d08.c:
+    complete
+    .text start:0x02114d08 end:0x02114e9c
+
+src/func_ov060_02114e9c.cpp:
+    complete
+    .text start:0x02114e9c end:0x02114f88
+
+src/func_ov060_02114f88.c:
+    complete
+    .text start:0x02114f88 end:0x02114ff8
+
+src/func_ov060_02114ff8.c:
+    complete
+    .text start:0x02114ff8 end:0x02115018
+
+src/func_ov060_02115018.c:
+    complete
+    .text start:0x02115018 end:0x02115060
+
+src/func_ov060_02115060.c:
+    complete
+    .text start:0x02115060 end:0x021150c4
+
+src/func_ov060_021150c4.c:
+    complete
+    .text start:0x021150c4 end:0x021150d0
+
+src/func_ov060_021150d0.cpp:
+    complete
+    .text start:0x021150d0 end:0x021151d4
+
+src/func_ov060_021151d4.c:
+    complete
+    .text start:0x021151d4 end:0x02115314
+
+src/func_ov060_02115314.c:
+    complete
+    .text start:0x02115314 end:0x021153f8
+
+src/func_ov060_021153f8.c:
+    complete
+    .text start:0x021153f8 end:0x021154e8
+
+src/func_ov060_021154e8.c:
+    complete
+    .text start:0x021154e8 end:0x02115518
+
+src/func_ov060_02115518.c:
+    complete
+    .text start:0x02115518 end:0x021156ec
+
+src/func_ov060_021156ec.c:
+    complete
+    .text start:0x021156ec end:0x02115718
+
+src/func_ov060_02115718.c:
+    complete
+    .text start:0x02115718 end:0x02115744
+
+src/func_ov060_02115744.c:
+    complete
+    .text start:0x02115744 end:0x0211577c
+
+src/func_ov060_0211577c.c:
+    complete
+    .text start:0x0211577c end:0x02115a30
+
+src/Bowser_IsAnimAtLastFrame.cpp:
+    complete
+    .text start:0x02115a30 end:0x02115a84
+
+src/func_ov060_02115a84.cpp:
+    complete
+    .text start:0x02115a84 end:0x02115b0c
+
+src/func_ov060_02115b0c.c:
+    complete
+    .text start:0x02115b0c end:0x02115b84
+
+src/func_ov060_02115b84.cpp:
+    complete
+    .text start:0x02115b84 end:0x02115c1c
+
+src/func_ov060_02115c1c.c:
+    complete
+    .text start:0x02115c1c end:0x02115d50
+
+src/func_ov060_02115d50.c:
+    complete
+    .text start:0x02115d50 end:0x02115d68
+
+src/func_ov060_02115d68.cpp:
+    complete
+    .text start:0x02115d68 end:0x02115e80
+
+src/_ZN6Bowser16CleanupResourcesEv.c:
+    complete
+    .text start:0x02115e80 end:0x02115f00
+
+src/_ZN10BowserTail16CleanupResourcesEv.c:
+    complete
+    .text start:0x02115f00 end:0x02115f08
+
+src/_ZN6Bowser16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02115f08 end:0x02115f0c
+
+src/_ZN6Bowser6RenderEv.cpp:
+    complete
+    .text start:0x02115f0c end:0x02115f5c
+
+src/_ZN10BowserTail6RenderEv.c:
+    complete
+    .text start:0x02115f5c end:0x02115f64
+
+src/_ZN6Bowser8BehaviorEv.cpp:
+    .text start:0x02115f64 end:0x02116078
+
+src/_ZN10BowserTail8BehaviorEv.cpp:
+    .text start:0x02116078 end:0x02116130
+
+src/_ZN6Bowser13InitResourcesEv.c:
+    complete
+    .text start:0x02116130 end:0x021163b4
+
+src/_ZN10BowserTail13InitResourcesEv.cpp:
+    complete
+    .text start:0x021163b4 end:0x021163f0
+
+src/BowserTail_Spawn.c:
+    complete
+    .text start:0x021163f0 end:0x02116428
+
+src/Bowser_Spawn.c:
+    complete
+    .text start:0x02116428 end:0x02116484
+
+src/_ZN10BowserFireD1Ev.c:
+    complete
+    .text start:0x02116484 end:0x021164c4
+
+src/_ZN10BowserFireD0Ev.c:
+    complete
+    .text start:0x021164c4 end:0x02116518
+
+src/func_ov060_02116518.c:
+    complete
+    .text start:0x02116518 end:0x02116740
+
+src/func_ov060_02116740.cpp:
+    complete
+    .text start:0x02116740 end:0x021167c8
+
+src/func_ov060_021167c8.c:
+    complete
+    .text start:0x021167c8 end:0x021167ec
+
+src/func_ov060_021167ec.c:
+    complete
+    .text start:0x021167ec end:0x021168c4
+
+src/func_ov060_021168c4.cpp:
+    .text start:0x021168c4 end:0x021169b0
+
+src/func_ov060_021169b0.c:
+    complete
+    .text start:0x021169b0 end:0x021169f8
+
+src/func_ov060_021169f8.c:
+    complete
+    .text start:0x021169f8 end:0x02116b18
+
+src/func_ov060_02116b18.c:
+    complete
+    .text start:0x02116b18 end:0x02116b68
+
+src/func_ov060_02116b68.c:
+    complete
+    .text start:0x02116b68 end:0x02116c68
+
+src/func_ov060_02116c68.c:
+    complete
+    .text start:0x02116c68 end:0x02116d78
+
+src/func_ov060_02116f74.c:
+    complete
+    .text start:0x02116f74 end:0x02116f90
+
+src/func_ov060_02116f90.c:
+    complete
+    .text start:0x02116f90 end:0x0211712c
+
+src/func_ov060_0211712c.c:
+    complete
+    .text start:0x0211712c end:0x021171e8
+
+src/func_ov060_021171e8.c:
+    complete
+    .text start:0x021171e8 end:0x0211722c
+
+src/func_ov060_0211722c.c:
+    complete
+    .text start:0x0211722c end:0x021172c8
+
+src/func_ov060_021172c8.c:
+    complete
+    .text start:0x021172c8 end:0x021172e0
+
+src/func_ov060_021172e0.cpp:
+    complete
+    .text start:0x021172e0 end:0x0211747c
+
+src/func_ov060_0211747c.c:
+    complete
+    .text start:0x0211747c end:0x02117624
+
+src/func_ov060_02117624.cpp:
+    complete
+    .text start:0x02117624 end:0x021176c4
+
+src/_ZN10BowserFire16CleanupResourcesEv.c:
+    complete
+    .text start:0x021176c4 end:0x021176cc
+
+src/_ZN10BowserFire6RenderEv.c:
+    complete
+    .text start:0x021176cc end:0x021176d4
+
+src/_ZN10BowserFire8BehaviorEv.cpp:
+    .text start:0x021176d4 end:0x02117790
+
+src/_ZN10BowserFire13InitResourcesEv.cpp:
+    complete
+    .text start:0x02117790 end:0x02117938
+
+src/BowserFire_Spawn.c:
+    complete
+    .text start:0x02117938 end:0x02117980
+
+src/_ZN18BowserFireSeaArenaD1Ev.c:
+    .text start:0x02117980 end:0x021179d4
+
+src/_ZN18BowserFireSeaArenaD0Ev.c:
+    .text start:0x021179d4 end:0x02117a3c
+
+src/func_ov060_02117a3c.c:
+    complete
+    .text start:0x02117a3c end:0x02117a64
+
+src/func_ov060_02117a64.c:
+    complete
+    .text start:0x02117a64 end:0x02117ae0
+
+src/func_ov060_02117ae0.c:
+    complete
+    .text start:0x02117ae0 end:0x02117b58
+
+src/_ZN18BowserFireSeaArena16CleanupResourcesEv.cpp:
+    .text start:0x02117b58 end:0x02117b9c
+
+src/_ZN18BowserFireSeaArena6RenderEv.cpp:
+    complete
+    .text start:0x02117b9c end:0x02117bc8
+
+src/_ZN18BowserFireSeaArena8BehaviorEv.cpp:
+    .text start:0x02117bc8 end:0x02117c30
+
+src/_ZN18BowserFireSeaArena13InitResourcesEv.cpp:
+    .text start:0x02117c30 end:0x02117cdc
+
+src/BowserFireSeaArena_Spawn.c:
+    complete
+    .text start:0x02117cdc end:0x02117d1c
+
+src/func_ov060_02117d1c.c:
+    .text start:0x02117d1c end:0x02117d60
+
+src/func_ov060_02117d60.c:
+    .text start:0x02117d60 end:0x02117db8
+
+src/func_ov060_02117db8.c:
+    complete
+    .text start:0x02117db8 end:0x021180e0
+
+src/func_ov060_021180e0.cpp:
+    complete
+    .text start:0x021180e0 end:0x021181b4
+
+src/func_ov060_021181b4.c:
+    complete
+    .text start:0x021181b4 end:0x021181e8
+
+src/func_ov060_021181e8.c:
+    complete
+    .text start:0x021181e8 end:0x0211822c
+
+src/func_ov060_0211822c.cpp:
+    complete
+    .text start:0x0211822c end:0x02118254
+
+src/func_ov060_02118254.cpp:
+    complete
+    .text start:0x02118254 end:0x021182b0
+
+src/func_ov060_021182b0.cpp:
+    .text start:0x021182b0 end:0x021183cc
+
+src/func_ov060_021183cc.c:
+    complete
+    .text start:0x021183cc end:0x021183f4
+
+src/func_ov060_021183f4.c:
+    complete
+    .text start:0x021183f4 end:0x02118408
+
+src/BowserSkyPlatform_Spawn.c:
+    complete
+    .text start:0x02118408 end:0x02118438
+
+src/_ZN17BowserSkyPlatformD1Ev.cpp:
+    .text start:0x02118438 end:0x02118470
+
+src/_ZN17BowserSkyPlatformD0Ev.c:
+    complete
+    .text start:0x02118470 end:0x021184bc
+
+src/func_ov060_021184bc.c:
+    complete
+    .text start:0x021184bc end:0x02118544
+
+src/func_ov060_02118544.c:
+    complete
+    .text start:0x02118544 end:0x021185c4
+
+src/func_ov060_021185c4.c:
+    complete
+    .text start:0x021185c4 end:0x02118690
+
+src/func_ov060_02118690.c:
+    complete
+    .text start:0x02118690 end:0x021186d8
+
+src/func_ov060_021186d8.c:
+    complete
+    .text start:0x021186d8 end:0x02118728
+
+src/func_ov060_02118728.c:
+    complete
+    .text start:0x02118728 end:0x02118834
+
+src/func_ov060_02118834.c:
+    complete
+    .text start:0x02118834 end:0x021188e8
+
+src/func_ov060_021188e8.c:
+    complete
+    .text start:0x021188e8 end:0x02118970
+
+src/func_ov060_02118970.c:
+    complete
+    .text start:0x02118970 end:0x02118ab0
+
+src/_ZN17BowserSkyPlatform16CleanupResourcesEv.c:
+    complete
+    .text start:0x02118ab0 end:0x02118ad4
+
+src/_ZN17BowserSkyPlatform6RenderEv.cpp:
+    complete
+    .text start:0x02118ad4 end:0x02118b2c
+
+src/_ZN17BowserSkyPlatform8BehaviorEv.cpp:
+    .text start:0x02118b2c end:0x02118bb4
+
+src/_ZN17BowserSkyPlatform13InitResourcesEv.cpp:
+    .text start:0x02118bb4 end:0x02118cbc
+
+src/SpikeBomb_Spawn.c:
+    complete
+    .text start:0x02118cbc end:0x02118cfc
+
+src/_ZN16BowserShockwavesD1Ev.c:
+    complete
+    .text start:0x02118cfc end:0x02118d64
+
+src/_ZN16BowserShockwavesD0Ev.c:
+    complete
+    .text start:0x02118d64 end:0x02118de0
+
+src/_ZN16BowserShockwaves16CleanupResourcesEv.c:
+    complete
+    .text start:0x02118de0 end:0x02118e1c
+
+src/_ZN16BowserShockwaves6RenderEv.cpp:
+    complete
+    .text start:0x02118e1c end:0x02118eb8
+
+src/_ZN16BowserShockwaves8BehaviorEv.cpp:
+    complete
+    .text start:0x02118eb8 end:0x02119004
+
+src/_ZN16BowserShockwaves13InitResourcesEv.cpp:
+    .text start:0x02119004 end:0x021191f4
+
+src/BowserShockwaves_Spawn.c:
+    complete
+    .text start:0x021191f4 end:0x02119264
+
+src/__sinit_ov060_021195dc.c:
+    .init start:0x021195dc end:0x02119df0
+
+src/__sinit_ov060_02119df0.c:
+    .init start:0x02119df0 end:0x02119f94
+
+src/__sinit_ov060_02119f94.c:
+    .init start:0x02119f94 end:0x0211a000
+
+src/__sinit_ov060_0211a000.c:
+    .init start:0x0211a000 end:0x0211a388
+
+src/__sinit_ov060_0211a388.c:
+    .init start:0x0211a388 end:0x0211a428
+
+src/__sinit_ov060_0211a428.c:
+    .init start:0x0211a428 end:0x0211a4bc

--- a/config/arm9/overlays/ov062/delinks.txt
+++ b/config/arm9/overlays/ov062/delinks.txt
@@ -4,3 +4,487 @@
     .ctor       start:0x0211d8cc end:0x0211d8e0 kind:rodata align:4
     .data       start:0x0211d900 end:0x0211dde0 kind:data align:32
     .bss        start:0x0211dde0 end:0x0211e1a0 kind:bss align:32
+src/_ZN7ChuckyaD1Ev.c:
+    complete
+    .text start:0x02115ee0 end:0x02115f28
+
+src/_ZN7ChuckyaD0Ev.c:
+    complete
+    .text start:0x02115f28 end:0x02115f84
+
+src/func_ov062_02115f84.c:
+    complete
+    .text start:0x02115f84 end:0x02116010
+
+src/func_ov062_02116010.c:
+    .text start:0x02116010 end:0x021161a8
+
+src/func_ov062_021161a8.c:
+    complete
+    .text start:0x021161a8 end:0x02116238
+
+src/func_ov062_02116238.c:
+    complete
+    .text start:0x02116238 end:0x02116274
+
+src/func_ov062_02116274.c:
+    complete
+    .text start:0x02116274 end:0x021162b8
+
+src/func_ov062_021162b8.cpp:
+    complete
+    .text start:0x021162b8 end:0x0211632c
+
+src/func_ov062_0211632c.cpp:
+    complete
+    .text start:0x0211632c end:0x02116368
+
+src/func_ov062_02116368.c:
+    complete
+    .text start:0x02116368 end:0x021163b0
+
+src/func_ov062_021163b0.c:
+    complete
+    .text start:0x021163b0 end:0x02116498
+
+src/func_ov062_02116498.c:
+    complete
+    .text start:0x02116498 end:0x021164e8
+
+src/func_ov062_021164e8.cpp:
+    .text start:0x021164e8 end:0x021165e0
+
+src/func_ov062_021165e0.c:
+    complete
+    .text start:0x021165e0 end:0x021165e8
+
+src/func_ov062_021165e8.c:
+    complete
+    .text start:0x021165e8 end:0x02116784
+
+src/func_ov062_02116784.c:
+    complete
+    .text start:0x02116784 end:0x021167c0
+
+src/func_ov062_021167c0.cpp:
+    complete
+    .text start:0x021167c0 end:0x02116850
+
+src/func_ov062_02116850.c:
+    complete
+    .text start:0x02116850 end:0x02116894
+
+src/func_ov062_02116894.cpp:
+    complete
+    .text start:0x02116894 end:0x02116980
+
+src/func_ov062_02116980.c:
+    complete
+    .text start:0x02116980 end:0x02116a08
+
+src/func_ov062_02116a08.c:
+    complete
+    .text start:0x02116a08 end:0x02116b80
+
+src/func_ov062_02116b80.cpp:
+    complete
+    .text start:0x02116b80 end:0x02116bf8
+
+src/func_ov062_02116bf8.c:
+    complete
+    .text start:0x02116bf8 end:0x02116c78
+
+src/func_ov062_02116c78.cpp:
+    complete
+    .text start:0x02116c78 end:0x02116cd8
+
+src/Chuckya_ChangeState.cpp:
+    complete
+    .text start:0x02116cd8 end:0x02116d28
+
+src/func_ov062_02116d28.cpp:
+    .text start:0x02116d28 end:0x02116dbc
+
+src/func_ov062_02116dbc.cpp:
+    complete
+    .text start:0x02116dbc end:0x02116e80
+
+src/func_ov062_02116e80.c:
+    complete
+    .text start:0x02116e80 end:0x02116edc
+
+src/func_ov062_02116edc.cpp:
+    complete
+    .text start:0x02116edc end:0x02116fc0
+
+src/_ZN7Chuckya16CleanupResourcesEv.c:
+    complete
+    .text start:0x02116fc0 end:0x02117020
+
+src/_ZN7Chuckya16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02117020 end:0x02117024
+
+src/_ZN7Chuckya6RenderEv.c:
+    complete
+    .text start:0x02117024 end:0x0211707c
+
+src/_ZN7Chuckya8BehaviorEv.cpp:
+    complete
+    .text start:0x0211707c end:0x02117334
+
+src/_ZN7Chuckya13InitResourcesEv.c:
+    complete
+    .text start:0x02117334 end:0x02117470
+
+src/func_ov062_02117470.c:
+    complete
+    .text start:0x02117470 end:0x02117478
+
+src/Chuckya_Spawn.c:
+    complete
+    .text start:0x02117478 end:0x021174cc
+
+src/_ZN5KoopaD1Ev.c:
+    complete
+    .text start:0x021174cc end:0x02117514
+
+src/_ZN5KoopaD0Ev.c:
+    complete
+    .text start:0x02117514 end:0x02117570
+
+src/func_ov062_02117570.cpp:
+    complete
+    .text start:0x02117570 end:0x021175c0
+
+src/func_ov062_021175c0.c:
+    complete
+    .text start:0x021175c0 end:0x02117724
+
+src/func_ov062_02117994.c:
+    complete
+    .text start:0x02117994 end:0x021179e4
+
+src/func_ov062_021179e4.cpp:
+    complete
+    .text start:0x021179e4 end:0x02117a3c
+
+src/func_ov062_02117a3c.cpp:
+    complete
+    .text start:0x02117a3c end:0x02117acc
+
+src/func_ov062_02117acc.c:
+    complete
+    .text start:0x02117acc end:0x02117b48
+
+src/func_ov062_02117b48.c:
+    complete
+    .text start:0x02117b48 end:0x02117b60
+
+src/func_ov062_02117b60.c:
+    complete
+    .text start:0x02117b60 end:0x02117b9c
+
+src/func_ov062_02117b9c.c:
+    complete
+    .text start:0x02117b9c end:0x02117bf4
+
+src/func_ov062_02117bf4.cpp:
+    complete
+    .text start:0x02117bf4 end:0x02117c98
+
+src/func_ov062_02117c98.c:
+    .text start:0x02117c98 end:0x02118004
+
+src/func_ov062_02118004.cpp:
+    .text start:0x02118004 end:0x02118058
+
+src/func_ov062_02118058.c:
+    complete
+    .text start:0x02118058 end:0x021180d4
+
+src/func_ov062_021180d4.c:
+    complete
+    .text start:0x021180d4 end:0x0211811c
+
+src/func_ov062_0211811c.c:
+    complete
+    .text start:0x0211811c end:0x021181a0
+
+src/func_ov062_021181a0.c:
+    complete
+    .text start:0x021181a0 end:0x02118258
+
+src/func_ov062_02118258.c:
+    complete
+    .text start:0x02118258 end:0x02118334
+
+src/func_ov062_02118334.c:
+    complete
+    .text start:0x02118334 end:0x021183e0
+
+src/func_ov062_021183e0.c:
+    complete
+    .text start:0x021183e0 end:0x02118588
+
+src/func_ov062_02118588.c:
+    complete
+    .text start:0x02118588 end:0x02118718
+
+src/func_ov062_02118718.c:
+    complete
+    .text start:0x02118718 end:0x02118a00
+
+src/func_ov062_02118a00.cpp:
+    complete
+    .text start:0x02118a00 end:0x02118a50
+
+src/func_ov062_02118a50.c:
+    complete
+    .text start:0x02118a50 end:0x02118b4c
+
+src/func_ov062_02118b4c.c:
+    complete
+    .text start:0x02118b4c end:0x02118cdc
+
+src/func_ov062_02118cdc.c:
+    complete
+    .text start:0x02118cdc end:0x02118de8
+
+src/func_ov062_02118de8.cpp:
+    complete
+    .text start:0x02118de8 end:0x02118f04
+
+src/_ZN5Koopa16CleanupResourcesEv.cpp:
+    .text start:0x02118f04 end:0x02118f80
+
+src/_ZN5Koopa16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02118f80 end:0x02118f84
+
+src/_ZN5Koopa6RenderEv.cpp:
+    .text start:0x02118f84 end:0x021190ec
+
+src/_ZN5Koopa8BehaviorEv.cpp:
+    .text start:0x021190ec end:0x02119420
+
+src/_ZN5Koopa13InitResourcesEv.cpp:
+    .text start:0x02119420 end:0x02119608
+
+src/func_ov062_02119608.cpp:
+    complete
+    .text start:0x02119608 end:0x02119628
+
+src/func_ov062_02119628.cpp:
+    complete
+    .text start:0x02119628 end:0x021196a8
+
+src/func_ov062_021196a8.c:
+    complete
+    .text start:0x021196a8 end:0x021196bc
+
+src/KoopaSmall_Spawn.c:
+    complete
+    .text start:0x021196bc end:0x0211970c
+
+src/Koopa_Spawn.c:
+    complete
+    .text start:0x0211970c end:0x0211975c
+
+src/_ZN13KoopaTheQuickD1Ev.c:
+    complete
+    .text start:0x0211975c end:0x021197a4
+
+src/_ZN13KoopaTheQuickD0Ev.c:
+    complete
+    .text start:0x021197a4 end:0x02119800
+
+src/func_ov062_02119800.cpp:
+    complete
+    .text start:0x02119800 end:0x02119954
+
+src/func_ov062_02119954.c:
+    complete
+    .text start:0x02119954 end:0x021199ac
+
+src/func_ov062_021199ac.c:
+    complete
+    .text start:0x021199ac end:0x02119af0
+
+src/func_ov062_02119af0.cpp:
+    .text start:0x02119af0 end:0x02119be0
+
+src/func_ov062_02119be0.c:
+    complete
+    .text start:0x02119be0 end:0x0211a0f0
+
+src/func_ov062_0211a0f0.c:
+    complete
+    .text start:0x0211a0f0 end:0x0211a168
+
+src/func_ov062_0211a168.c:
+    complete
+    .text start:0x0211a168 end:0x0211a1f4
+
+src/func_ov062_0211a1f4.c:
+    complete
+    .text start:0x0211a1f4 end:0x0211a740
+
+src/func_ov062_0211a740.cpp:
+    complete
+    .text start:0x0211a740 end:0x0211a9c4
+
+src/func_ov062_0211a9c4.c:
+    complete
+    .text start:0x0211a9c4 end:0x0211aac0
+
+src/func_ov062_0211aac0.c:
+    complete
+    .text start:0x0211aac0 end:0x0211ab50
+
+src/_ZN13KoopaTheQuick6RenderEv.cpp:
+    complete
+    .text start:0x0211ab50 end:0x0211ab88
+
+src/_ZN13KoopaTheQuick8BehaviorEv.cpp:
+    .text start:0x0211ab88 end:0x0211ac10
+
+src/_ZN13KoopaTheQuick16CleanupResourcesEv.cpp:
+    .text start:0x0211ac10 end:0x0211ac94
+
+src/_ZN13KoopaTheQuick13InitResourcesEv.cpp:
+    .text start:0x0211ac94 end:0x0211aee0
+
+src/KoopaTheQuick_Spawn.c:
+    complete
+    .text start:0x0211aee0 end:0x0211af38
+
+src/_ZN9KoopaFlagD1Ev.cpp:
+    .text start:0x0211af38 end:0x0211af70
+
+src/_ZN9KoopaFlagD0Ev.c:
+    complete
+    .text start:0x0211af70 end:0x0211afbc
+
+src/func_ov062_0211afbc.c:
+    complete
+    .text start:0x0211afbc end:0x0211b000
+
+src/_ZN9KoopaFlag16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211b000 end:0x0211b030
+
+src/_ZN9KoopaFlag6RenderEv.cpp:
+    complete
+    .text start:0x0211b030 end:0x0211b05c
+
+src/_ZN9KoopaFlag8BehaviorEv.cpp:
+    .text start:0x0211b05c end:0x0211b168
+
+src/_ZN9KoopaFlag13InitResourcesEv.cpp:
+    .text start:0x0211b168 end:0x0211b208
+
+src/KoopaFlag_Spawn.c:
+    complete
+    .text start:0x0211b208 end:0x0211b248
+
+src/_ZN6KleptoD1Ev.c:
+    complete
+    .text start:0x0211b248 end:0x0211b298
+
+src/_ZN6KleptoD0Ev.c:
+    complete
+    .text start:0x0211b298 end:0x0211b2fc
+
+src/func_ov062_0211b2fc.c:
+    complete
+    .text start:0x0211b2fc end:0x0211b3ac
+
+src/func_ov062_0211b3ac.cpp:
+    complete
+    .text start:0x0211b3ac end:0x0211b51c
+
+src/func_ov062_0211b51c.c:
+    complete
+    .text start:0x0211b51c end:0x0211b800
+
+src/func_ov062_0211b800.c:
+    complete
+    .text start:0x0211b800 end:0x0211b880
+
+src/func_ov062_0211b880.cpp:
+    .text start:0x0211b880 end:0x0211b8d8
+
+src/func_ov062_0211b8d8.cpp:
+    complete
+    .text start:0x0211b8d8 end:0x0211b930
+
+src/func_ov062_0211b930.cpp:
+    .text start:0x0211b930 end:0x0211ba84
+
+src/func_ov062_0211ba84.c:
+    complete
+    .text start:0x0211ba84 end:0x0211bc54
+
+src/func_ov062_0211bc54.cpp:
+    .text start:0x0211bc54 end:0x0211bd10
+
+src/func_ov062_0211c218.c:
+    complete
+    .text start:0x0211c218 end:0x0211c2f4
+
+src/func_ov062_0211c2f4.cpp:
+    .text start:0x0211c2f4 end:0x0211c594
+
+src/func_ov062_0211c594.c:
+    complete
+    .text start:0x0211c594 end:0x0211c658
+
+src/func_ov062_0211c658.cpp:
+    complete
+    .text start:0x0211c658 end:0x0211c6a8
+
+src/func_ov062_0211c6a8.c:
+    complete
+    .text start:0x0211c6a8 end:0x0211c8b0
+
+src/_ZN6Klepto16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211c8b0 end:0x0211c91c
+
+src/_ZN6Klepto16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211c91c end:0x0211c920
+
+src/_ZN6Klepto6RenderEv.cpp:
+    complete
+    .text start:0x0211c920 end:0x0211c94c
+
+src/_ZN6Klepto8BehaviorEv.cpp:
+    .text start:0x0211c94c end:0x0211cb4c
+
+src/_ZN6Klepto13InitResourcesEv.cpp:
+    .text start:0x0211cb4c end:0x0211ce78
+
+src/func_ov062_0211ce78.c:
+    complete
+    .text start:0x0211ce78 end:0x0211ce80
+
+src/Klepto_Spawn.c:
+    complete
+    .text start:0x0211ce80 end:0x0211ced8
+
+src/__sinit_ov062_0211cf30.c:
+    .init start:0x0211cf30 end:0x0211d2d8
+
+src/__sinit_ov062_0211d2d8.c:
+    .init start:0x0211d2d8 end:0x0211d4a0
+
+src/__sinit_ov062_0211d4a0.c:
+    .init start:0x0211d4a0 end:0x0211d690
+
+src/__sinit_ov062_0211d690.c:
+    .init start:0x0211d690 end:0x0211d6fc
+
+src/__sinit_ov062_0211d6fc.c:
+    .init start:0x0211d6fc end:0x0211d8cc

--- a/config/arm9/overlays/ov063/delinks.txt
+++ b/config/arm9/overlays/ov063/delinks.txt
@@ -4,3 +4,543 @@
     .ctor       start:0x0211e6fc end:0x0211e70c kind:rodata align:4
     .data       start:0x0211e720 end:0x0211edc0 kind:data align:32
     .bss        start:0x0211edc0 end:0x0211efe0 kind:bss align:32
+src/_ZN3BooD1Ev.c:
+    complete
+    .text start:0x02115ee0 end:0x02115f48
+
+src/_ZN3BooD0Ev.c:
+    complete
+    .text start:0x02115f48 end:0x02115fc4
+
+src/_ZN7BooCageD1Ev.c:
+    complete
+    .text start:0x02115fc4 end:0x0211600c
+
+src/_ZN7BooCageD0Ev.c:
+    complete
+    .text start:0x0211600c end:0x02116068
+
+src/_ZN10BigBooIconD1Ev.cpp:
+    .text start:0x02116068 end:0x0211608c
+
+src/_ZN10BigBooIconD0Ev.c:
+    complete
+    .text start:0x0211608c end:0x021160c4
+
+src/func_ov063_021160c4.c:
+    complete
+    .text start:0x021160c4 end:0x021160d4
+
+src/func_ov063_021160d4.c:
+    complete
+    .text start:0x021160d4 end:0x02116190
+
+src/func_ov063_02116190.c:
+    complete
+    .text start:0x02116190 end:0x02116244
+
+src/func_ov063_02116244.c:
+    complete
+    .text start:0x02116244 end:0x021162c8
+
+src/func_ov063_021162c8.cpp:
+    complete
+    .text start:0x021162c8 end:0x021163d0
+
+src/func_ov063_021163d0.c:
+    complete
+    .text start:0x021163d0 end:0x0211640c
+
+src/func_ov063_0211640c.c:
+    complete
+    .text start:0x0211640c end:0x021166ac
+
+src/func_ov063_021169c4.cpp:
+    complete
+    .text start:0x021169c4 end:0x02116a1c
+
+src/func_ov063_02116a1c.c:
+    complete
+    .text start:0x02116a1c end:0x02116bf0
+
+src/func_ov063_02116bf0.c:
+    complete
+    .text start:0x02116bf0 end:0x02116bf4
+
+src/func_ov063_02116bf4.c:
+    complete
+    .text start:0x02116bf4 end:0x02116d38
+
+src/func_ov063_02116d38.c:
+    complete
+    .text start:0x02116d38 end:0x02116d98
+
+src/func_ov063_02116d98.c:
+    complete
+    .text start:0x02116d98 end:0x02116dbc
+
+src/func_ov063_02116dbc.c:
+    complete
+    .text start:0x02116dbc end:0x02116df0
+
+src/func_ov063_02116df0.c:
+    complete
+    .text start:0x02116df0 end:0x02116e14
+
+src/func_ov063_02116e14.cpp:
+    complete
+    .text start:0x02116e14 end:0x02116f48
+
+src/func_ov063_02116f48.cpp:
+    .text start:0x02116f48 end:0x02116fac
+
+src/func_ov063_02116fac.c:
+    complete
+    .text start:0x02116fac end:0x021172a8
+
+src/func_ov063_021172a8.c:
+    complete
+    .text start:0x021172a8 end:0x02117364
+
+src/func_ov063_02117364.c:
+    complete
+    .text start:0x02117364 end:0x02117650
+
+src/func_ov063_02117650.c:
+    complete
+    .text start:0x02117650 end:0x0211776c
+
+src/func_ov063_0211776c.cpp:
+    complete
+    .text start:0x0211776c end:0x021177b0
+
+src/func_ov063_021177b0.c:
+    complete
+    .text start:0x021177b0 end:0x02117b0c
+
+src/func_ov063_02117b0c.c:
+    complete
+    .text start:0x02117b0c end:0x02117cdc
+
+src/func_ov063_02118458.c:
+    complete
+    .text start:0x02118458 end:0x0211873c
+
+src/func_ov063_0211873c.c:
+    complete
+    .text start:0x0211873c end:0x02118914
+
+src/func_ov063_02118914.c:
+    complete
+    .text start:0x02118914 end:0x021189f4
+
+src/func_ov063_021189f4.c:
+    complete
+    .text start:0x021189f4 end:0x02118b2c
+
+src/func_ov063_02118b2c.c:
+    complete
+    .text start:0x02118b2c end:0x02118b98
+
+src/func_ov063_02118b98.c:
+    .text start:0x02118b98 end:0x02118cd8
+
+src/func_ov063_02118cd8.c:
+    complete
+    .text start:0x02118cd8 end:0x02118ddc
+
+src/func_ov063_02118ddc.cpp:
+    complete
+    .text start:0x02118ddc end:0x02118e5c
+
+src/func_ov063_02118e5c.c:
+    complete
+    .text start:0x02118e5c end:0x02118ea0
+
+src/func_ov063_02118ea0.c:
+    complete
+    .text start:0x02118ea0 end:0x02118eac
+
+src/func_ov063_02118eac.c:
+    complete
+    .text start:0x02118eac end:0x02118f24
+
+src/func_ov063_02118f24.c:
+    complete
+    .text start:0x02118f24 end:0x02118f50
+
+src/func_ov063_02118f50.c:
+    complete
+    .text start:0x02118f50 end:0x02118f74
+
+src/func_ov063_02118f74.c:
+    complete
+    .text start:0x02118f74 end:0x02119074
+
+src/func_ov063_02119074.c:
+    complete
+    .text start:0x02119074 end:0x02119274
+
+src/func_ov063_02119274.c:
+    complete
+    .text start:0x02119274 end:0x021192d4
+
+src/func_ov063_021192d4.c:
+    complete
+    .text start:0x021192d4 end:0x0211934c
+
+src/func_ov063_0211934c.cpp:
+    complete
+    .text start:0x0211934c end:0x0211975c
+
+src/func_ov063_0211975c.cpp:
+    complete
+    .text start:0x0211975c end:0x02119870
+
+src/func_ov063_02119870.c:
+    complete
+    .text start:0x02119870 end:0x02119894
+
+src/func_ov063_02119894.c:
+    complete
+    .text start:0x02119894 end:0x02119960
+
+src/func_ov063_02119960.c:
+    complete
+    .text start:0x02119960 end:0x02119a2c
+
+src/func_ov063_02119a2c.c:
+    complete
+    .text start:0x02119a2c end:0x02119a50
+
+src/func_ov063_02119a50.c:
+    complete
+    .text start:0x02119a50 end:0x02119ab0
+
+src/func_ov063_02119ab0.c:
+    complete
+    .text start:0x02119ab0 end:0x02119b1c
+
+src/func_ov063_02119b1c.c:
+    complete
+    .text start:0x02119b1c end:0x02119b84
+
+src/func_ov063_02119b84.c:
+    complete
+    .text start:0x02119b84 end:0x02119bb0
+
+src/func_ov063_02119bb0.c:
+    complete
+    .text start:0x02119bb0 end:0x02119c18
+
+src/func_ov063_02119c18.c:
+    complete
+    .text start:0x02119c18 end:0x02119c58
+
+src/func_ov063_02119c58.cpp:
+    complete
+    .text start:0x02119c58 end:0x02119cc0
+
+src/func_ov063_02119cc0.c:
+    complete
+    .text start:0x02119cc0 end:0x02119e38
+
+src/func_ov063_02119e38.c:
+    complete
+    .text start:0x02119e38 end:0x0211a030
+
+src/func_ov063_0211a030.c:
+    complete
+    .text start:0x0211a030 end:0x0211a0a8
+
+src/func_ov063_0211a0a8.c:
+    complete
+    .text start:0x0211a0a8 end:0x0211a0dc
+
+src/func_ov063_0211a0dc.cpp:
+    .text start:0x0211a0dc end:0x0211a3d0
+
+src/func_ov063_0211a3d0.cpp:
+    complete
+    .text start:0x0211a3d0 end:0x0211a564
+
+src/func_ov063_0211a564.c:
+    complete
+    .text start:0x0211a564 end:0x0211a634
+
+src/func_ov063_0211a634.c:
+    complete
+    .text start:0x0211a634 end:0x0211a6f0
+
+src/func_ov063_0211a6f0.c:
+    complete
+    .text start:0x0211a6f0 end:0x0211a718
+
+src/func_ov063_0211a718.c:
+    complete
+    .text start:0x0211a718 end:0x0211a76c
+
+src/func_ov063_0211a76c.c:
+    complete
+    .text start:0x0211a76c end:0x0211a810
+
+src/func_ov063_0211a810.c:
+    complete
+    .text start:0x0211a810 end:0x0211a8a4
+
+src/func_ov063_0211a8a4.cpp:
+    complete
+    .text start:0x0211a8a4 end:0x0211a960
+
+src/func_ov063_0211a960.c:
+    complete
+    .text start:0x0211a960 end:0x0211a964
+
+src/func_ov063_0211a964.c:
+    complete
+    .text start:0x0211a964 end:0x0211aa34
+
+src/func_ov063_0211aa34.c:
+    complete
+    .text start:0x0211aa34 end:0x0211ab68
+
+src/func_ov063_0211ab68.c:
+    complete
+    .text start:0x0211ab68 end:0x0211ad00
+
+src/func_ov063_0211ad00.c:
+    complete
+    .text start:0x0211ad00 end:0x0211adb4
+
+src/func_ov063_0211adb4.c:
+    complete
+    .text start:0x0211adb4 end:0x0211adfc
+
+src/func_ov063_0211adfc.c:
+    complete
+    .text start:0x0211adfc end:0x0211ae1c
+
+src/_ZN7BooCage16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211ae1c end:0x0211ae40
+
+src/_ZN3Boo16CleanupResourcesEv.cpp:
+    .text start:0x0211ae40 end:0x0211af6c
+
+src/_ZN3Boo16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211af6c end:0x0211af70
+
+src/_ZN3Boo6RenderEv.cpp:
+    .text start:0x0211af70 end:0x0211b078
+
+src/_ZN7BooCage6RenderEv.cpp:
+    complete
+    .text start:0x0211b078 end:0x0211b0a4
+
+src/_ZN7BooCage8BehaviorEv.cpp:
+    complete
+    .text start:0x0211b888 end:0x0211b9bc
+
+src/_ZN3Boo13InitResourcesEv.c:
+    .text start:0x0211b9bc end:0x0211c35c
+
+src/_ZN7BooCage13InitResourcesEv.cpp:
+    .text start:0x0211c35c end:0x0211c444
+
+src/_ZN10BigBooIcon13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211c444 end:0x0211c480
+
+src/func_ov063_0211c480.cpp:
+    complete
+    .text start:0x0211c480 end:0x0211c4a0
+
+src/BigBooIcon_Spawn.c:
+    complete
+    .text start:0x0211c4a0 end:0x0211c4d0
+
+src/BooCage_Spawn.c:
+    complete
+    .text start:0x0211c4d0 end:0x0211c520
+
+src/BigBoo_Spawn.cpp:
+    complete
+    .text start:0x0211c520 end:0x0211c590
+
+src/Boo_Spawn.cpp:
+    complete
+    .text start:0x0211c590 end:0x0211c600
+
+src/_ZN12MansionStepsD1Ev.cpp:
+    .text start:0x0211c600 end:0x0211c638
+
+src/_ZN12MansionStepsD0Ev.c:
+    complete
+    .text start:0x0211c638 end:0x0211c684
+
+src/func_ov063_0211c684.c:
+    complete
+    .text start:0x0211c684 end:0x0211c6f8
+
+src/func_ov063_0211c6f8.cpp:
+    complete
+    .text start:0x0211c6f8 end:0x0211c770
+
+src/func_ov063_0211c770.c:
+    complete
+    .text start:0x0211c770 end:0x0211c7b0
+
+src/func_ov063_0211c7b0.c:
+    complete
+    .text start:0x0211c7b0 end:0x0211c82c
+
+src/func_ov063_0211c82c.c:
+    complete
+    .text start:0x0211c82c end:0x0211c89c
+
+src/func_ov063_0211c89c.c:
+    complete
+    .text start:0x0211c89c end:0x0211cae8
+
+src/func_ov063_0211cae8.c:
+    complete
+    .text start:0x0211cae8 end:0x0211cb54
+
+src/func_ov063_0211cb54.c:
+    complete
+    .text start:0x0211cb54 end:0x0211cc18
+
+src/func_ov063_0211cc18.c:
+    complete
+    .text start:0x0211cc18 end:0x0211cdec
+
+src/_ZN12MansionSteps16CleanupResourcesEv.cpp:
+    .text start:0x0211cdec end:0x0211ce30
+
+src/_ZN12MansionSteps16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211ce30 end:0x0211ce34
+
+src/_ZN12MansionSteps6RenderEv.cpp:
+    complete
+    .text start:0x0211ce34 end:0x0211ce74
+
+src/_ZN12MansionSteps8BehaviorEv.cpp:
+    .text start:0x0211ce74 end:0x0211cf00
+
+src/func_ov063_0211d270.cpp:
+    complete
+    .text start:0x0211d270 end:0x0211d28c
+
+src/func_ov063_0211d28c.c:
+    complete
+    .text start:0x0211d28c end:0x0211d2a0
+
+src/TrapDoor_Spawn.c:
+    complete
+    .text start:0x0211d2a0 end:0x0211d2e0
+
+src/MerryGoRound_Spawn.c:
+    complete
+    .text start:0x0211d2e0 end:0x0211d320
+
+src/Bookshelf_Spawn.c:
+    complete
+    .text start:0x0211d320 end:0x0211d360
+
+src/MansionSteps_Spawn.c:
+    complete
+    .text start:0x0211d360 end:0x0211d3a0
+
+src/_ZN12FallBlockBbhD1Ev.c:
+    .text start:0x0211d3a0 end:0x0211d3f0
+
+src/_ZN12FallBlockBbhD0Ev.c:
+    .text start:0x0211d3f0 end:0x0211d454
+
+src/_ZN12FallBlockBbh16CleanupResourcesEv.cpp:
+    .text start:0x0211d454 end:0x0211d468
+
+src/_ZN12FallBlockBbh13InitResourcesEv.cpp:
+    .text start:0x0211d468 end:0x0211d47c
+
+src/FallBlockBbh_Spawn.c:
+    .text start:0x0211d47c end:0x0211d4b8
+
+src/_ZN8MadPianoD1Ev.c:
+    complete
+    .text start:0x0211d4b8 end:0x0211d54c
+
+src/_ZN8MadPianoD0Ev.cpp:
+    complete
+    .text start:0x0211d54c end:0x0211d5f4
+
+src/func_ov063_0211d5f4.c:
+    complete
+    .text start:0x0211d5f4 end:0x0211d828
+
+src/func_ov063_0211d828.cpp:
+    complete
+    .text start:0x0211d828 end:0x0211d88c
+
+src/func_ov063_0211d88c.c:
+    complete
+    .text start:0x0211d88c end:0x0211d8cc
+
+src/func_ov063_0211d8cc.cpp:
+    complete
+    .text start:0x0211d8cc end:0x0211dba4
+
+src/func_ov063_0211dba4.c:
+    complete
+    .text start:0x0211dba4 end:0x0211dbb8
+
+src/func_ov063_0211dbb8.c:
+    complete
+    .text start:0x0211dbb8 end:0x0211dd78
+
+src/func_ov063_0211dd78.c:
+    complete
+    .text start:0x0211dd78 end:0x0211dd84
+
+src/func_ov063_0211dd84.c:
+    complete
+    .text start:0x0211dd84 end:0x0211ddac
+
+src/func_ov063_0211ddac.cpp:
+    complete
+    .text start:0x0211ddac end:0x0211ddf4
+
+src/func_ov063_0211ddf4.cpp:
+    complete
+    .text start:0x0211ddf4 end:0x0211de3c
+
+src/_ZN8MadPiano16CleanupResourcesEv.cpp:
+    .text start:0x0211de3c end:0x0211de8c
+
+src/_ZN8MadPiano6RenderEv.cpp:
+    complete
+    .text start:0x0211de8c end:0x0211deb8
+
+src/_ZN8MadPiano8BehaviorEv.cpp:
+    .text start:0x0211deb8 end:0x0211dfac
+
+src/_ZN8MadPiano13InitResourcesEv.cpp:
+    .text start:0x0211dfac end:0x0211e128
+
+src/MadPiano_Spawn.cpp:
+    complete
+    .text start:0x0211e128 end:0x0211e1c0
+
+src/__sinit_ov063_0211e29c.c:
+    .init start:0x0211e29c end:0x0211e3cc
+
+src/__sinit_ov063_0211e3cc.c:
+    .init start:0x0211e3cc end:0x0211e590
+
+src/__sinit_ov063_0211e590.c:
+    .init start:0x0211e590 end:0x0211e5fc
+
+src/__sinit_ov063_0211e5fc.c:
+    .init start:0x0211e5fc end:0x0211e6fc

--- a/config/arm9/overlays/ov064/delinks.txt
+++ b/config/arm9/overlays/ov064/delinks.txt
@@ -4,3 +4,629 @@
     .ctor       start:0x0211b72c end:0x0211b758 kind:rodata align:4
     .data       start:0x0211b760 end:0x0211c660 kind:data align:32
     .bss        start:0x0211c660 end:0x0211ca00 kind:bss align:32
+src/func_ov064_02115ee0.c:
+    complete
+    .text start:0x02115ee0 end:0x02115f28
+
+src/func_ov064_02115f28.c:
+    complete
+    .text start:0x02115f28 end:0x02115f84
+
+src/func_ov064_02115f84.c:
+    complete
+    .text start:0x02115f84 end:0x02115f98
+
+src/func_ov064_02115f98.c:
+    complete
+    .text start:0x02115f98 end:0x02116110
+
+src/func_ov064_02116110.cpp:
+    complete
+    .text start:0x02116110 end:0x0211616c
+
+src/func_ov064_0211616c.c:
+    complete
+    .text start:0x0211616c end:0x02116220
+
+src/func_ov064_02116220.c:
+    complete
+    .text start:0x02116220 end:0x02116348
+
+src/func_ov064_02116348.c:
+    complete
+    .text start:0x02116348 end:0x0211635c
+
+src/func_ov064_0211635c.c:
+    complete
+    .text start:0x0211635c end:0x02116360
+
+src/func_ov064_02116360.c:
+    complete
+    .text start:0x02116360 end:0x02116374
+
+src/func_ov064_02116374.cpp:
+    complete
+    .text start:0x02116374 end:0x021163bc
+
+src/func_ov064_021163bc.c:
+    complete
+    .text start:0x021163bc end:0x021163c0
+
+src/func_ov064_021163c0.cpp:
+    .text start:0x021163c0 end:0x02116460
+
+src/func_ov064_02116460.cpp:
+    .text start:0x02116460 end:0x02116560
+
+src/func_ov064_02116560.cpp:
+    complete
+    .text start:0x02116560 end:0x021165d4
+
+src/func_ov064_021165d4.c:
+    complete
+    .text start:0x021165d4 end:0x021165d8
+
+src/func_ov064_021165d8.cpp:
+    complete
+    .text start:0x021165d8 end:0x021166f0
+
+src/func_ov064_021166f0.c:
+    complete
+    .text start:0x021166f0 end:0x02116754
+
+src/func_ov064_02116754.cpp:
+    .text start:0x02116754 end:0x02116bac
+
+src/func_ov064_02116bac.cpp:
+    complete
+    .text start:0x02116bac end:0x02116ca0
+
+src/_ZN5Bully16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02116ca0 end:0x02116cf0
+
+src/_ZN5Bully6RenderEv.cpp:
+    complete
+    .text start:0x02116cf0 end:0x02116d1c
+
+src/func_ov064_02116d1c.cpp:
+    complete
+    .text start:0x02116d1c end:0x02116ec0
+
+src/func_ov064_02116ec0.cpp:
+    .text start:0x02116ec0 end:0x02117070
+
+src/_ZN5BullyD1Ev.c:
+    .text start:0x02117070 end:0x021170c4
+
+src/_ZN5BullyD0Ev.c:
+    .text start:0x021170c4 end:0x0211712c
+
+src/func_ov064_0211712c.c:
+    complete
+    .text start:0x0211712c end:0x02117140
+
+src/func_ov064_02117140.c:
+    complete
+    .text start:0x02117140 end:0x02117154
+
+src/func_ov064_02117154.c:
+    complete
+    .text start:0x02117154 end:0x02117168
+
+src/func_ov064_02117168.c:
+    complete
+    .text start:0x02117168 end:0x021171b0
+
+src/func_ov064_021171b0.c:
+    complete
+    .text start:0x021171b0 end:0x02117220
+
+src/func_ov064_02117220.cpp:
+    complete
+    .text start:0x02117220 end:0x02117310
+
+src/_ZN5Bully8BehaviorEv.c:
+    complete
+    .text start:0x02117310 end:0x02117424
+
+src/_ZN5Bully13InitResourcesEv.cpp:
+    .text start:0x02117424 end:0x02117444
+
+src/Bully_Spawn.c:
+    .text start:0x02117444 end:0x021174a0
+
+src/_ZN8BigBullyD1Ev.c:
+    .text start:0x021174a0 end:0x021174f4
+
+src/_ZN8BigBullyD0Ev.c:
+    .text start:0x021174f4 end:0x0211755c
+
+src/func_ov064_0211755c.c:
+    complete
+    .text start:0x0211755c end:0x021175cc
+
+src/func_ov064_021175cc.cpp:
+    .text start:0x021175cc end:0x0211764c
+
+src/_ZN8BigBully6RenderEv.cpp:
+    complete
+    .text start:0x0211764c end:0x02117684
+
+src/_ZN8BigBully8BehaviorEv.cpp:
+    .text start:0x02117684 end:0x02117784
+
+src/_ZN8BigBully13InitResourcesEv.cpp:
+    complete
+    .text start:0x02117784 end:0x0211791c
+
+src/BigBully_Spawn.c:
+    .text start:0x0211791c end:0x02117978
+
+src/func_ov064_02117978.c:
+    .text start:0x02117978 end:0x021179bc
+
+src/func_ov064_021179bc.c:
+    .text start:0x021179bc end:0x02117a14
+
+src/func_ov064_02117a14.cpp:
+    complete
+    .text start:0x02117a14 end:0x02117a44
+
+src/func_ov064_02117a44.cpp:
+    complete
+    .text start:0x02117a44 end:0x02117b8c
+
+src/func_ov064_02117b8c.c:
+    complete
+    .text start:0x02117b8c end:0x02117bdc
+
+src/func_ov064_02117bdc.c:
+    complete
+    .text start:0x02117bdc end:0x02117c24
+
+src/func_ov064_02117c24.c:
+    complete
+    .text start:0x02117c24 end:0x02117cc4
+
+src/func_ov064_02117cc4.c:
+    .text start:0x02117cc4 end:0x02117cfc
+
+src/func_ov064_02117cfc.cpp:
+    complete
+    .text start:0x02117cfc end:0x02117d24
+
+src/func_ov064_02117d24.c:
+    complete
+    .text start:0x02117d24 end:0x02117e44
+
+src/func_ov064_02117e44.cpp:
+    .text start:0x02117e44 end:0x02117fb4
+
+src/func_ov064_02117fb4.cpp:
+    complete
+    .text start:0x02117fb4 end:0x02117fd4
+
+src/func_ov064_02117fd4.c:
+    complete
+    .text start:0x02117fd4 end:0x02117fe8
+
+src/MetalNetLift_Spawn.c:
+    .text start:0x02117fe8 end:0x02118020
+
+src/_ZN12MetalNetLiftD1Ev.c:
+    .text start:0x02118020 end:0x02118070
+
+src/_ZN12MetalNetLiftD0Ev.c:
+    .text start:0x02118070 end:0x021180d4
+
+src/_ZN12MetalNetLift16CleanupResourcesEv.c:
+    complete
+    .text start:0x021180d4 end:0x021180e8
+
+src/_ZN12MetalNetLift13InitResourcesEv.c:
+    complete
+    .text start:0x021180e8 end:0x021180fc
+
+src/TiltingPlatformLll_Spawn.c:
+    .text start:0x021180fc end:0x02118138
+
+src/_ZN15RotatingFirebarD1Ev.c:
+    complete
+    .text start:0x02118138 end:0x02118194
+
+src/_ZN15RotatingFirebarD0Ev.c:
+    complete
+    .text start:0x02118194 end:0x02118204
+
+src/_ZN15RotatingFirebar16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02118204 end:0x0211824c
+
+src/_ZN15RotatingFirebar6RenderEv.cpp:
+    complete
+    .text start:0x0211824c end:0x02118274
+
+src/_ZN15RotatingFirebar8BehaviorEv.cpp:
+    .text start:0x02118274 end:0x02118480
+
+src/_ZN15RotatingFirebar13InitResourcesEv.cpp:
+    .text start:0x02118480 end:0x02118564
+
+src/RotatingFirebar_Spawn.cpp:
+    complete
+    .text start:0x02118564 end:0x021185c0
+
+src/_ZN10LavaBubbleD1Ev.c:
+    complete
+    .text start:0x021185c0 end:0x021185f8
+
+src/_ZN10LavaBubbleD0Ev.c:
+    complete
+    .text start:0x021185f8 end:0x02118644
+
+src/func_ov064_02118644.c:
+    complete
+    .text start:0x02118644 end:0x0211873c
+
+src/func_ov064_0211873c.c:
+    complete
+    .text start:0x0211873c end:0x02118760
+
+src/func_ov064_02118760.c:
+    complete
+    .text start:0x02118760 end:0x021187d0
+
+src/func_ov064_021187d0.c:
+    complete
+    .text start:0x021187d0 end:0x021187ec
+
+src/func_ov064_021187ec.cpp:
+    complete
+    .text start:0x021187ec end:0x0211883c
+
+src/_ZN10LavaBubble16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211883c end:0x02118844
+
+src/_ZN10LavaBubble16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02118844 end:0x02118848
+
+src/_ZN10LavaBubble6RenderEv.c:
+    complete
+    .text start:0x02118848 end:0x02118850
+
+src/_ZN10LavaBubble8BehaviorEv.cpp:
+    complete
+    .text start:0x02118850 end:0x021189d8
+
+src/_ZN10LavaBubble13InitResourcesEv.cpp:
+    .text start:0x021189d8 end:0x02118b08
+
+src/func_ov064_02118b08.c:
+    complete
+    .text start:0x02118b08 end:0x02118b10
+
+src/LavaBubble_Spawn.c:
+    complete
+    .text start:0x02118b10 end:0x02118b50
+
+src/_ZN19BowserPuzzleManagerD1Ev.c:
+    .text start:0x02118b50 end:0x02118b94
+
+src/_ZN19BowserPuzzleManagerD0Ev.c:
+    .text start:0x02118b94 end:0x02118bec
+
+src/func_ov064_02118bec.c:
+    complete
+    .text start:0x02118bec end:0x02118c10
+
+src/func_ov064_02118c10.c:
+    .text start:0x02118c10 end:0x02118c48
+
+src/func_ov064_02118c48.c:
+    complete
+    .text start:0x02118c48 end:0x02118cd4
+
+src/func_ov064_02118cd4.c:
+    complete
+    .text start:0x02118cd4 end:0x02118cec
+
+src/func_ov064_02118cec.c:
+    complete
+    .text start:0x02118cec end:0x02118d08
+
+src/func_ov064_02118d08.c:
+    complete
+    .text start:0x02118d08 end:0x02118d20
+
+src/func_ov064_02118d20.c:
+    complete
+    .text start:0x02118d20 end:0x02118d3c
+
+src/func_ov064_02118d3c.c:
+    complete
+    .text start:0x02118d3c end:0x02118da0
+
+src/func_ov064_02118da0.cpp:
+    complete
+    .text start:0x02118da0 end:0x02118e24
+
+src/func_ov064_02118e24.cpp:
+    complete
+    .text start:0x02118e24 end:0x02118ee4
+
+src/func_ov064_02118ee4.c:
+    complete
+    .text start:0x02118ee4 end:0x02118fa4
+
+src/func_ov064_02118fa4.cpp:
+    complete
+    .text start:0x02118fa4 end:0x02119010
+
+src/func_ov064_02119010.c:
+    complete
+    .text start:0x02119010 end:0x0211904c
+
+src/_ZN19BowserPuzzleManager16CleanupResourcesEv.cpp:
+    .text start:0x0211904c end:0x02119088
+
+src/_ZN19BowserPuzzleManager6RenderEv.cpp:
+    complete
+    .text start:0x02119088 end:0x021190b0
+
+src/_ZN19BowserPuzzleManager8BehaviorEv.cpp:
+    complete
+    .text start:0x021190b0 end:0x0211915c
+
+src/func_ov064_0211915c.c:
+    complete
+    .text start:0x0211915c end:0x021191a8
+
+src/_ZN19BowserPuzzleManager13InitResourcesEv.cpp:
+    .text start:0x021191a8 end:0x02119284
+
+src/func_ov064_02119284.c:
+    complete
+    .text start:0x02119284 end:0x0211929c
+
+src/func_ov064_0211929c.cpp:
+    complete
+    .text start:0x0211929c end:0x021192bc
+
+src/func_ov064_021192bc.c:
+    complete
+    .text start:0x021192bc end:0x021192d0
+
+src/BowserPuzzleManager_Spawn.c:
+    complete
+    .text start:0x021192d0 end:0x02119300
+
+src/BowserPuzzlePiece_Spawn.c:
+    complete
+    .text start:0x02119300 end:0x02119330
+
+src/_ZN17BowserPuzzlePieceD1Ev.c:
+    complete
+    .text start:0x02119330 end:0x02119368
+
+src/_ZN17BowserPuzzlePieceD0Ev.c:
+    complete
+    .text start:0x02119368 end:0x021193b4
+
+src/func_ov064_021193b4.c:
+    complete
+    .text start:0x021193b4 end:0x021197fc
+
+src/func_ov064_021197fc.cpp:
+    complete
+    .text start:0x021197fc end:0x0211982c
+
+src/func_ov064_0211982c.cpp:
+    complete
+    .text start:0x0211982c end:0x0211987c
+
+src/func_ov064_0211987c.c:
+    complete
+    .text start:0x0211987c end:0x02119880
+
+src/_ZN17BowserPuzzlePiece16CleanupResourcesEv.c:
+    complete
+    .text start:0x02119880 end:0x021198b0
+
+src/_ZN17BowserPuzzlePiece16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021198b0 end:0x021198b4
+
+src/_ZN17BowserPuzzlePiece6RenderEv.c:
+    complete
+    .text start:0x021198b4 end:0x021198bc
+
+src/_ZN17BowserPuzzlePiece8BehaviorEv.cpp:
+    complete
+    .text start:0x021198bc end:0x0211992c
+
+src/_ZN17BowserPuzzlePiece13InitResourcesEv.cpp:
+    .text start:0x0211992c end:0x02119a18
+
+src/JetStream_Spawn.c:
+    complete
+    .text start:0x02119a18 end:0x02119a58
+
+src/_ZN9WaterRingD1Ev.c:
+    complete
+    .text start:0x02119a58 end:0x02119aa0
+
+src/_ZN9WaterRingD0Ev.c:
+    complete
+    .text start:0x02119aa0 end:0x02119afc
+
+src/func_ov064_02119afc.cpp:
+    .text start:0x02119afc end:0x02119c60
+
+src/func_ov064_02119c60.c:
+    complete
+    .text start:0x02119c60 end:0x02119ce4
+
+src/func_ov064_02119ce4.c:
+    complete
+    .text start:0x02119ce4 end:0x02119d28
+
+src/func_ov064_02119d28.c:
+    complete
+    .text start:0x02119d28 end:0x02119ea0
+
+src/func_ov064_02119ea0.c:
+    complete
+    .text start:0x02119ea0 end:0x02119ecc
+
+src/func_ov064_02119ecc.cpp:
+    complete
+    .text start:0x02119ecc end:0x02119f1c
+
+src/func_ov064_02119f1c.cpp:
+    complete
+    .text start:0x02119f1c end:0x02119fa0
+
+src/_ZN9WaterRing16CleanupResourcesEv.c:
+    complete
+    .text start:0x02119fa0 end:0x02119fc4
+
+src/_ZN9WaterRing16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02119fc4 end:0x02119fc8
+
+src/_ZN9WaterRing6RenderEv.cpp:
+    complete
+    .text start:0x02119fc8 end:0x02119ffc
+
+src/_ZN9WaterRing8BehaviorEv.cpp:
+    .text start:0x02119ffc end:0x0211a090
+
+src/_ZN9WaterRing13InitResourcesEv.cpp:
+    .text start:0x0211a090 end:0x0211a1b0
+
+src/WaterRing_Spawn.c:
+    complete
+    .text start:0x0211a1b0 end:0x0211a200
+
+src/_ZN13TreasureChestD1Ev.cpp:
+    .text start:0x0211a200 end:0x0211a238
+
+src/_ZN13TreasureChestD0Ev.c:
+    complete
+    .text start:0x0211a238 end:0x0211a284
+
+src/func_ov064_0211a284.c:
+    complete
+    .text start:0x0211a284 end:0x0211a2c4
+
+src/func_ov064_0211a2c4.cpp:
+    complete
+    .text start:0x0211a2c4 end:0x0211a380
+
+src/func_ov064_0211a380.c:
+    complete
+    .text start:0x0211a380 end:0x0211a39c
+
+src/func_ov064_0211a39c.cpp:
+    .text start:0x0211a39c end:0x0211a49c
+
+src/func_ov064_0211a49c.c:
+    complete
+    .text start:0x0211a49c end:0x0211a4c4
+
+src/func_ov064_0211a6e0.c:
+    complete
+    .text start:0x0211a6e0 end:0x0211a6ec
+
+src/func_ov064_0211a6ec.cpp:
+    complete
+    .text start:0x0211a6ec end:0x0211a734
+
+src/func_ov064_0211a734.cpp:
+    complete
+    .text start:0x0211a734 end:0x0211a77c
+
+src/_ZN13TreasureChest16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211a77c end:0x0211a7c4
+
+src/_ZN13TreasureChest6RenderEv.cpp:
+    complete
+    .text start:0x0211a7c4 end:0x0211a7ec
+
+src/_ZN13TreasureChest8BehaviorEv.cpp:
+    .text start:0x0211a7ec end:0x0211a814
+
+src/_ZN13TreasureChest13InitResourcesEv.cpp:
+    complete
+    .text start:0x0211a814 end:0x0211a8f0
+
+src/TreasureChest_Spawn.c:
+    complete
+    .text start:0x0211a8f0 end:0x0211a930
+
+src/_ZN4ClamD1Ev.cpp:
+    .text start:0x0211a930 end:0x0211a968
+
+src/_ZN4ClamD0Ev.c:
+    complete
+    .text start:0x0211a968 end:0x0211a9b4
+
+src/func_ov064_0211a9b4.c:
+    complete
+    .text start:0x0211a9b4 end:0x0211a9f4
+
+src/_ZN4Clam16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211a9f4 end:0x0211aa30
+
+src/_ZN4Clam6RenderEv.cpp:
+    complete
+    .text start:0x0211aa30 end:0x0211aa58
+
+src/_ZN4Clam8BehaviorEv.c:
+    complete
+    .text start:0x0211aa58 end:0x0211acc4
+
+src/_ZN4Clam13InitResourcesEv.cpp:
+    .text start:0x0211acc4 end:0x0211ad70
+
+src/Clam_Spawn.c:
+    complete
+    .text start:0x0211ad70 end:0x0211adb0
+
+src/__sinit_ov064_0211ae00.c:
+    .init start:0x0211ae00 end:0x0211aee0
+
+src/__sinit_ov064_0211aee0.c:
+    .init start:0x0211aee0 end:0x0211afc0
+
+src/__sinit_ov064_0211afc0.c:
+    .init start:0x0211afc0 end:0x0211b078
+
+src/__sinit_ov064_0211b078.c:
+    .init start:0x0211b078 end:0x0211b0e4
+
+src/__sinit_ov064_0211b0e4.c:
+    .init start:0x0211b0e4 end:0x0211b150
+
+src/__sinit_ov064_0211b150.c:
+    .init start:0x0211b150 end:0x0211b1d4
+
+src/__sinit_ov064_0211b1d4.c:
+    .init start:0x0211b1d4 end:0x0211b4dc
+
+src/__sinit_ov064_0211b4dc.c:
+    .init start:0x0211b4dc end:0x0211b518
+
+src/__sinit_ov064_0211b518.c:
+    .init start:0x0211b518 end:0x0211b59c
+
+src/__sinit_ov064_0211b59c.c:
+    .init start:0x0211b59c end:0x0211b698
+
+src/__sinit_ov064_0211b698.c:
+    .init start:0x0211b698 end:0x0211b72c

--- a/config/arm9/overlays/ov065/delinks.txt
+++ b/config/arm9/overlays/ov065/delinks.txt
@@ -4,3 +4,535 @@
     .ctor       start:0x0211cae0 end:0x0211cb08 kind:rodata align:4
     .data       start:0x0211cb20 end:0x0211d600 kind:data align:32
     .bss        start:0x0211d600 end:0x0211da00 kind:bss align:32
+src/_ZN6SnufitD1Ev.c:
+    complete
+    .text start:0x02115ee0 end:0x02115f28
+
+src/_ZN6SnufitD0Ev.c:
+    complete
+    .text start:0x02115f28 end:0x02115f84
+
+src/func_ov065_02115f84.c:
+    complete
+    .text start:0x02115f84 end:0x02115ff0
+
+src/func_ov065_02115ff0.c:
+    .text start:0x02115ff0 end:0x021162c0
+
+src/func_ov065_021162c0.c:
+    complete
+    .text start:0x021162c0 end:0x02116328
+
+src/func_ov065_02116328.c:
+    complete
+    .text start:0x02116328 end:0x02116364
+
+src/func_ov065_02116364.c:
+    complete
+    .text start:0x02116364 end:0x02116588
+
+src/func_ov065_02116588.cpp:
+    complete
+    .text start:0x02116588 end:0x021165d8
+
+src/func_ov065_021165d8.cpp:
+    complete
+    .text start:0x021165d8 end:0x0211672c
+
+src/func_ov065_0211672c.c:
+    complete
+    .text start:0x0211672c end:0x02116744
+
+src/func_ov065_02116744.c:
+    complete
+    .text start:0x02116744 end:0x021168a8
+
+src/func_ov065_021168a8.cpp:
+    complete
+    .text start:0x021168a8 end:0x0211691c
+
+src/func_ov065_0211691c.cpp:
+    complete
+    .text start:0x0211691c end:0x0211696c
+
+src/func_ov065_0211696c.c:
+    complete
+    .text start:0x0211696c end:0x02116ae8
+
+src/_ZN6Snufit16CleanupResourcesEv.c:
+    complete
+    .text start:0x02116ae8 end:0x02116b30
+
+src/_ZN6Snufit16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02116b30 end:0x02116b34
+
+src/_ZN6Snufit6RenderEv.cpp:
+    complete
+    .text start:0x02116b34 end:0x02116b84
+
+src/_ZN6Snufit8BehaviorEv.cpp:
+    .text start:0x02116b84 end:0x02116e10
+
+src/_ZN6Snufit13InitResourcesEv.cpp:
+    .text start:0x02116e10 end:0x02116f0c
+
+src/func_ov065_02116f0c.c:
+    complete
+    .text start:0x02116f0c end:0x02116f14
+
+src/func_ov065_02116f14.cpp:
+    complete
+    .text start:0x02116f14 end:0x02116f40
+
+src/func_ov065_02116f40.c:
+    complete
+    .text start:0x02116f40 end:0x02116f48
+
+src/Snufit_Spawn.c:
+    complete
+    .text start:0x02116f48 end:0x02116f98
+
+src/_ZN5SwoopD1Ev.c:
+    complete
+    .text start:0x02116f98 end:0x02116fe8
+
+src/_ZN5SwoopD0Ev.c:
+    complete
+    .text start:0x02116fe8 end:0x0211704c
+
+src/func_ov065_0211704c.c:
+    .text start:0x0211704c end:0x02117404
+
+src/func_ov065_02117404.cpp:
+    complete
+    .text start:0x02117404 end:0x021175b0
+
+src/func_ov065_021175b0.c:
+    complete
+    .text start:0x021175b0 end:0x02117624
+
+src/func_ov065_02117624.c:
+    complete
+    .text start:0x02117624 end:0x021176fc
+
+src/func_ov065_021176fc.cpp:
+    complete
+    .text start:0x021176fc end:0x02117780
+
+src/func_ov065_02117780.c:
+    complete
+    .text start:0x02117780 end:0x021177e4
+
+src/func_ov065_021177e4.cpp:
+    .text start:0x021177e4 end:0x02117888
+
+src/func_ov065_02117888.c:
+    complete
+    .text start:0x02117888 end:0x021178fc
+
+src/func_ov065_021178fc.c:
+    complete
+    .text start:0x021178fc end:0x02117944
+
+src/func_ov065_02117944.cpp:
+    complete
+    .text start:0x02117944 end:0x02117994
+
+src/func_ov065_02117994.c:
+    complete
+    .text start:0x02117994 end:0x02117aa4
+
+src/_ZN5Swoop16CleanupResourcesEv.c:
+    complete
+    .text start:0x02117aa4 end:0x02117aec
+
+src/_ZN5Swoop16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02117aec end:0x02117af0
+
+src/_ZN5Swoop6RenderEv.cpp:
+    complete
+    .text start:0x02117af0 end:0x02117b64
+
+src/_ZN5Swoop8BehaviorEv.cpp:
+    .text start:0x02117b64 end:0x02117d80
+
+src/_ZN5Swoop13InitResourcesEv.cpp:
+    .text start:0x02117d80 end:0x02117eac
+
+src/func_ov065_02117eac.c:
+    complete
+    .text start:0x02117eac end:0x02117eb4
+
+src/func_ov065_02117eb4.cpp:
+    complete
+    .text start:0x02117eb4 end:0x02117ee0
+
+src/func_ov065_02117ee0.c:
+    complete
+    .text start:0x02117ee0 end:0x02117ee8
+
+src/Swoop_Spawn.c:
+    complete
+    .text start:0x02117ee8 end:0x02117f40
+
+src/_ZN6DorrieD1Ev.cpp:
+    complete
+    .text start:0x02117f40 end:0x02117fa8
+
+src/_ZN6DorrieD0Ev.cpp:
+    .text start:0x02117fa8 end:0x02118024
+
+src/_ZN9DorrieCapD1Ev.c:
+    complete
+    .text start:0x02118024 end:0x02118064
+
+src/_ZN9DorrieCapD0Ev.c:
+    complete
+    .text start:0x02118064 end:0x021180b8
+
+src/func_ov065_021180b8.c:
+    complete
+    .text start:0x021180b8 end:0x021180d4
+
+src/func_ov065_021180d4.c:
+    complete
+    .text start:0x021180d4 end:0x02118248
+
+src/func_ov065_02118248.cpp:
+    complete
+    .text start:0x02118248 end:0x021182e4
+
+src/func_ov065_021182e4.cpp:
+    complete
+    .text start:0x021182e4 end:0x021183c8
+
+src/func_ov065_021183c8.c:
+    complete
+    .text start:0x021183c8 end:0x02118634
+
+src/func_ov065_02118634.c:
+    complete
+    .text start:0x02118634 end:0x02118838
+
+src/func_ov065_02118c4c.c:
+    complete
+    .text start:0x02118c4c end:0x02118cc4
+
+src/func_ov065_02118cc4.c:
+    complete
+    .text start:0x02118cc4 end:0x02118d04
+
+src/_ZN6Dorrie16CleanupResourcesEv.cpp:
+    .text start:0x02118d04 end:0x02118d80
+
+src/_ZN6Dorrie6RenderEv.cpp:
+    complete
+    .text start:0x02118d80 end:0x02118da8
+
+src/_ZN9DorrieCap6RenderEv.cpp:
+    complete
+    .text start:0x02118da8 end:0x02118df0
+
+src/_ZN6Dorrie8BehaviorEv.cpp:
+    complete
+    .text start:0x02118df0 end:0x021190a8
+
+src/_ZN9DorrieCap8BehaviorEv.cpp:
+    .text start:0x021190a8 end:0x02119210
+
+src/func_ov065_02119210.c:
+    complete
+    .text start:0x02119210 end:0x02119228
+
+src/_ZN6Dorrie13InitResourcesEv.cpp:
+    .text start:0x02119228 end:0x021194e8
+
+src/_ZN9DorrieCap13InitResourcesEv.cpp:
+    .text start:0x021194e8 end:0x0211956c
+
+src/func_ov065_0211956c.c:
+    complete
+    .text start:0x0211956c end:0x02119594
+
+src/func_ov065_02119594.c:
+    complete
+    .text start:0x02119594 end:0x021195bc
+
+src/func_ov065_021195bc.c:
+    complete
+    .text start:0x021195bc end:0x021195d0
+
+src/func_ov065_021195d0.c:
+    complete
+    .text start:0x021195d0 end:0x021195e4
+
+src/func_ov065_021195e4.c:
+    complete
+    .text start:0x021195e4 end:0x021195ec
+
+src/DorrieCap_Spawn.c:
+    complete
+    .text start:0x021195ec end:0x02119634
+
+src/Dorrie_Spawn.cpp:
+    complete
+    .text start:0x02119634 end:0x021196bc
+
+src/func_ov065_021196bc.c:
+    complete
+    .text start:0x021196bc end:0x021196d8
+
+src/_ZN15TtcRotatingCubeD1Ev.c:
+    .text start:0x021196d8 end:0x0211972c
+
+src/_ZN15TtcRotatingCubeD0Ev.c:
+    .text start:0x0211972c end:0x02119794
+
+src/func_ov065_02119794.c:
+    complete
+    .text start:0x02119794 end:0x021198a0
+
+src/func_ov065_021198a0.cpp:
+    complete
+    .text start:0x021198a0 end:0x0211990c
+
+src/func_ov065_0211990c.c:
+    complete
+    .text start:0x0211990c end:0x02119984
+
+src/_ZN15TtcRotatingCube16CleanupResourcesEv.cpp:
+    .text start:0x02119984 end:0x021199fc
+
+src/_ZN15TtcRotatingCube6RenderEv.cpp:
+    complete
+    .text start:0x021199fc end:0x02119a50
+
+src/_ZN15TtcRotatingCube8BehaviorEv.cpp:
+    .text start:0x02119a50 end:0x02119c38
+
+src/_ZN15TtcRotatingCube13InitResourcesEv.cpp:
+    .text start:0x02119c38 end:0x02119ebc
+
+src/TtcRotatingPrism_Spawn.c:
+    complete
+    .text start:0x02119ebc end:0x02119efc
+
+src/TtcRotatingCube_Spawn.c:
+    complete
+    .text start:0x02119efc end:0x02119f3c
+
+src/func_ov065_02119f3c.c:
+    .text start:0x02119f3c end:0x02119f88
+
+src/func_ov065_02119f88.c:
+    .text start:0x02119f88 end:0x02119fe8
+
+src/func_ov065_02119fe8.cpp:
+    complete
+    .text start:0x02119fe8 end:0x0211a114
+
+src/func_ov065_0211a114.c:
+    complete
+    .text start:0x0211a114 end:0x0211a15c
+
+src/func_ov065_0211a15c.c:
+    .text start:0x0211a15c end:0x0211a1a0
+
+src/func_ov065_0211a1a0.cpp:
+    complete
+    .text start:0x0211a1a0 end:0x0211a1c8
+
+src/func_ov065_0211a1c8.c:
+    .text start:0x0211a1c8 end:0x0211a358
+
+src/func_ov065_0211a358.cpp:
+    .text start:0x0211a358 end:0x0211a45c
+
+src/func_ov065_0211a45c.c:
+    .text start:0x0211a45c end:0x0211a494
+
+src/_ZN20TtcConveyorBeltLargeD1Ev.c:
+    .text start:0x0211a494 end:0x0211a4e8
+
+src/_ZN20TtcConveyorBeltLargeD0Ev.c:
+    .text start:0x0211a4e8 end:0x0211a550
+
+src/func_ov065_0211a550.c:
+    complete
+    .text start:0x0211a550 end:0x0211a638
+
+src/_ZN20TtcConveyorBeltLarge16CleanupResourcesEv.cpp:
+    .text start:0x0211a638 end:0x0211a69c
+
+src/_ZN20TtcConveyorBeltLarge6RenderEv.cpp:
+    complete
+    .text start:0x0211a69c end:0x0211a6d0
+
+src/_ZN20TtcConveyorBeltLarge8BehaviorEv.cpp:
+    .text start:0x0211a6d0 end:0x0211a870
+
+src/_ZN20TtcConveyorBeltLarge13InitResourcesEv.cpp:
+    .text start:0x0211a870 end:0x0211aa38
+
+src/func_ov065_0211aa38.c:
+    complete
+    .text start:0x0211aa38 end:0x0211aacc
+
+src/func_ov065_0211aacc.c:
+    complete
+    .text start:0x0211aacc end:0x0211aae0
+
+src/TtcConveyorBeltLarge_Spawn.c:
+    complete
+    .text start:0x0211aae0 end:0x0211ab20
+
+src/TtcConveyorBeltSmall_Spawn.c:
+    complete
+    .text start:0x0211ab20 end:0x0211ab60
+
+src/func_ov065_0211ab60.c:
+    .text start:0x0211ab60 end:0x0211abac
+
+src/func_ov065_0211abac.c:
+    .text start:0x0211abac end:0x0211ac0c
+
+src/func_ov065_0211ac0c.c:
+    complete
+    .text start:0x0211ac0c end:0x0211ad04
+
+src/func_ov065_0211ad04.c:
+    .text start:0x0211ad04 end:0x0211ad48
+
+src/func_ov065_0211ad48.cpp:
+    complete
+    .text start:0x0211ad48 end:0x0211ad70
+
+src/func_ov065_0211ad70.c:
+    complete
+    .text start:0x0211ad70 end:0x0211ae08
+
+src/func_ov065_0211ae08.c:
+    complete
+    .text start:0x0211ae08 end:0x0211b1d4
+
+src/func_ov065_0211b1d4.cpp:
+    .text start:0x0211b1d4 end:0x0211b328
+
+src/TTC_MovingBar_Spawn.c:
+    .text start:0x0211b328 end:0x0211b360
+
+src/_ZN13TTC_MovingBarD1Ev.c:
+    .text start:0x0211b360 end:0x0211b3ac
+
+src/_ZN13TTC_MovingBarD0Ev.c:
+    .text start:0x0211b3ac end:0x0211b40c
+
+src/func_ov065_0211b40c.c:
+    complete
+    .text start:0x0211b40c end:0x0211b47c
+
+src/_ZN13TTC_MovingBar16CleanupResourcesEv.cpp:
+    .text start:0x0211b47c end:0x0211b4e0
+
+src/_ZN13TTC_MovingBar6RenderEv.cpp:
+    complete
+    .text start:0x0211b4e0 end:0x0211b508
+
+src/_ZN13TTC_MovingBar8BehaviorEv.cpp:
+    complete
+    .text start:0x0211b508 end:0x0211b640
+
+src/_ZN13TTC_MovingBar13InitResourcesEv.cpp:
+    .text start:0x0211b640 end:0x0211b780
+
+src/TtcRotatingTriangle_Spawn.c:
+    complete
+    .text start:0x0211b780 end:0x0211b7b8
+
+src/TtcRotatingGear_Spawn.c:
+    complete
+    .text start:0x0211b7b8 end:0x0211b7f0
+
+src/_ZN15TtcRotatingGearD1Ev.c:
+    .text start:0x0211b7f0 end:0x0211b834
+
+src/_ZN15TtcRotatingGearD0Ev.c:
+    .text start:0x0211b834 end:0x0211b88c
+
+src/_ZN15TtcRotatingGear16CleanupResourcesEv.cpp:
+    .text start:0x0211b88c end:0x0211b8d0
+
+src/_ZN15TtcRotatingGear6RenderEv.cpp:
+    complete
+    .text start:0x0211b8d0 end:0x0211b8f8
+
+src/_ZN15TtcRotatingGear8BehaviorEv.c:
+    complete
+    .text start:0x0211b8f8 end:0x0211ba88
+
+src/_ZN15TtcRotatingGear13InitResourcesEv.cpp:
+    .text start:0x0211ba88 end:0x0211bb7c
+
+src/TtcMovingCubeB_Spawn.c:
+    complete
+    .text start:0x0211bb7c end:0x0211bbac
+
+src/TtcMovingCubeA_Spawn.c:
+    complete
+    .text start:0x0211bbac end:0x0211bbdc
+
+src/_ZN14TtcMovingCubeAD1Ev.c:
+    .text start:0x0211bbdc end:0x0211bc28
+
+src/_ZN14TtcMovingCubeAD0Ev.c:
+    .text start:0x0211bc28 end:0x0211bc88
+
+src/func_ov065_0211bc88.cpp:
+    complete
+    .text start:0x0211bc88 end:0x0211bd20
+
+src/_ZN14TtcMovingCubeA16CleanupResourcesEv.cpp:
+    .text start:0x0211bd20 end:0x0211bd64
+
+src/_ZN14TtcMovingCubeA6RenderEv.cpp:
+    complete
+    .text start:0x0211bd64 end:0x0211bd8c
+
+src/_ZN14TtcMovingCubeA13InitResourcesEv.cpp:
+    .text start:0x0211bf04 end:0x0211c040
+
+src/TTC_MovingBeam_Spawn.c:
+    complete
+    .text start:0x0211c040 end:0x0211c078
+
+src/__sinit_ov065_0211c110.c:
+    .init start:0x0211c110 end:0x0211c2a8
+
+src/__sinit_ov065_0211c2a8.c:
+    .init start:0x0211c2a8 end:0x0211c440
+
+src/__sinit_ov065_0211c440.c:
+    .init start:0x0211c440 end:0x0211c660
+
+src/__sinit_ov065_0211c660.c:
+    .init start:0x0211c660 end:0x0211c76c
+
+src/__sinit_ov065_0211c76c.c:
+    .init start:0x0211c76c end:0x0211c7d8
+
+src/__sinit_ov065_0211c7d8.c:
+    .init start:0x0211c7d8 end:0x0211c890
+
+src/__sinit_ov065_0211c890.c:
+    .init start:0x0211c890 end:0x0211c8fc
+
+src/__sinit_ov065_0211c8fc.c:
+    .init start:0x0211c8fc end:0x0211c9b8
+
+src/__sinit_ov065_0211c9b8.c:
+    .init start:0x0211c9b8 end:0x0211ca74
+
+src/__sinit_ov065_0211ca74.c:
+    .init start:0x0211ca74 end:0x0211cae0

--- a/config/arm9/overlays/ov066/delinks.txt
+++ b/config/arm9/overlays/ov066/delinks.txt
@@ -3,3 +3,252 @@
     .ctor       start:0x0211abc0 end:0x0211abc4 kind:rodata align:4
     .data       start:0x0211abe0 end:0x0211ae00 kind:data align:32
     .bss        start:0x0211ae00 end:0x0211b100 kind:bss align:32
+src/_ZN6EyerokD1Ev.c:
+    complete
+    .text start:0x02115ee0 end:0x02115f84
+
+src/_ZN6EyerokD0Ev.c:
+    complete
+    .text start:0x02115f84 end:0x0211603c
+
+src/func_ov066_0211603c.c:
+    complete
+    .text start:0x0211603c end:0x021162e8
+
+src/func_ov066_021162e8.c:
+    complete
+    .text start:0x021162e8 end:0x0211632c
+
+src/func_ov066_0211632c.c:
+    complete
+    .text start:0x0211632c end:0x02116390
+
+src/func_ov066_02116390.c:
+    complete
+    .text start:0x02116390 end:0x021164ec
+
+src/func_ov066_021164ec.c:
+    complete
+    .text start:0x021164ec end:0x021165cc
+
+src/func_ov066_021165cc.c:
+    complete
+    .text start:0x021165cc end:0x021166c8
+
+src/func_ov066_021166c8.cpp:
+    .text start:0x021166c8 end:0x021168b0
+
+src/func_ov066_021168b0.c:
+    complete
+    .text start:0x021168b0 end:0x021168ec
+
+src/func_ov066_021168ec.c:
+    complete
+    .text start:0x021168ec end:0x02116a68
+
+src/func_ov066_02116a68.c:
+    complete
+    .text start:0x02116a68 end:0x02116ac4
+
+src/func_ov066_02116ac4.c:
+    complete
+    .text start:0x02116ac4 end:0x02116b78
+
+src/func_ov066_02116b78.c:
+    complete
+    .text start:0x02116b78 end:0x02116c6c
+
+src/func_ov066_02116c6c.c:
+    complete
+    .text start:0x02116c6c end:0x02116d14
+
+src/func_ov066_02116d14.cpp:
+    .text start:0x02116d14 end:0x02116db0
+
+src/func_ov066_02116db0.c:
+    .text start:0x02116db0 end:0x02117190
+
+src/func_ov066_02117190.c:
+    complete
+    .text start:0x02117190 end:0x021171b0
+
+src/func_ov066_021171b0.c:
+    complete
+    .text start:0x021171b0 end:0x021175bc
+
+src/func_ov066_021175bc.c:
+    complete
+    .text start:0x021175bc end:0x021175e8
+
+src/func_ov066_021175e8.c:
+    .text start:0x021175e8 end:0x02117bd0
+
+src/func_ov066_02117bd0.c:
+    complete
+    .text start:0x02117bd0 end:0x02117bf0
+
+src/func_ov066_02117bf0.c:
+    .text start:0x02117bf0 end:0x02118168
+
+src/func_ov066_02118168.c:
+    complete
+    .text start:0x02118168 end:0x02118188
+
+src/func_ov066_02118188.c:
+    .text start:0x02118188 end:0x021184c0
+
+src/func_ov066_021184c0.c:
+    complete
+    .text start:0x021184c0 end:0x021184e0
+
+src/func_ov066_021184e0.c:
+    complete
+    .text start:0x021184e0 end:0x021185e4
+
+src/func_ov066_021185e4.c:
+    complete
+    .text start:0x021185e4 end:0x02118604
+
+src/func_ov066_02118604.c:
+    complete
+    .text start:0x02118604 end:0x02118658
+
+src/func_ov066_02118658.c:
+    complete
+    .text start:0x02118658 end:0x02118678
+
+src/func_ov066_02118678.c:
+    complete
+    .text start:0x02118678 end:0x021187c8
+
+src/func_ov066_021187c8.cpp:
+    complete
+    .text start:0x021187c8 end:0x021188b0
+
+src/func_ov066_021188b0.c:
+    complete
+    .text start:0x021188b0 end:0x02118934
+
+src/func_ov066_02118934.c:
+    complete
+    .text start:0x02118934 end:0x02118954
+
+src/func_ov066_02118954.c:
+    complete
+    .text start:0x02118954 end:0x021189a0
+
+src/func_ov066_021189a0.c:
+    complete
+    .text start:0x021189a0 end:0x021189c0
+
+src/func_ov066_021189c0.c:
+    complete
+    .text start:0x021189c0 end:0x02118a30
+
+src/func_ov066_02118a30.c:
+    complete
+    .text start:0x02118a30 end:0x02118a50
+
+src/func_ov066_02118a50.c:
+    complete
+    .text start:0x02118a50 end:0x02118b08
+
+src/func_ov066_02118b08.c:
+    complete
+    .text start:0x02118b08 end:0x02118b28
+
+src/func_ov066_02118b28.c:
+    complete
+    .text start:0x02118b28 end:0x02118be0
+
+src/func_ov066_02118be0.c:
+    complete
+    .text start:0x02118be0 end:0x02118c00
+
+src/func_ov066_02118c00.c:
+    complete
+    .text start:0x02118c00 end:0x02118cb8
+
+src/func_ov066_02118cb8.c:
+    complete
+    .text start:0x02118cb8 end:0x02118cdc
+
+src/func_ov066_02118cdc.cpp:
+    complete
+    .text start:0x02118cdc end:0x02118de0
+
+src/func_ov066_02118de0.c:
+    complete
+    .text start:0x02118de0 end:0x02118e04
+
+src/func_ov066_02118e04.c:
+    complete
+    .text start:0x02118e04 end:0x0211901c
+
+src/func_ov066_0211901c.c:
+    complete
+    .text start:0x0211901c end:0x0211903c
+
+src/func_ov066_0211903c.c:
+    complete
+    .text start:0x0211903c end:0x02119348
+
+src/func_ov066_02119348.c:
+    complete
+    .text start:0x02119348 end:0x02119398
+
+src/func_ov066_02119398.cpp:
+    .text start:0x02119398 end:0x0211944c
+
+src/func_ov066_0211944c.c:
+    complete
+    .text start:0x0211944c end:0x02119454
+
+src/func_ov066_02119454.cpp:
+    complete
+    .text start:0x02119454 end:0x021194a4
+
+src/func_ov066_021194a4.cpp:
+    complete
+    .text start:0x021194a4 end:0x021194fc
+
+src/func_ov066_021194fc.cpp:
+    complete
+    .text start:0x021194fc end:0x02119654
+
+src/_ZN6Eyerok16CleanupResourcesEv.cpp:
+    .text start:0x02119654 end:0x021197a0
+
+src/_ZN6Eyerok16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021197a0 end:0x021197a4
+
+src/_ZN6Eyerok6RenderEv.cpp:
+    complete
+    .text start:0x021197a4 end:0x02119838
+
+src/_ZN6Eyerok8BehaviorEv.cpp:
+    complete
+    .text start:0x02119838 end:0x02119ce8
+
+src/_ZN6Eyerok13InitResourcesEv.cpp:
+    .text start:0x02119ce8 end:0x0211a2dc
+
+src/func_ov066_0211a2dc.c:
+    complete
+    .text start:0x0211a2dc end:0x0211a2e4
+
+src/func_ov066_0211a2e4.c:
+    complete
+    .text start:0x0211a2e4 end:0x0211a35c
+
+src/func_ov066_0211a35c.c:
+    complete
+    .text start:0x0211a35c end:0x0211a370
+
+src/Eyerok_Spawn.cpp:
+    complete
+    .text start:0x0211a370 end:0x0211a418
+
+src/__sinit_ov066_0211a418.c:
+    .init start:0x0211a418 end:0x0211abc0

--- a/config/arm9/overlays/ov070/delinks.txt
+++ b/config/arm9/overlays/ov070/delinks.txt
@@ -4,3 +4,364 @@
     .ctor       start:0x021230a4 end:0x021230b4 kind:rodata align:4
     .data       start:0x021230c0 end:0x02123500 kind:data align:32
     .bss        start:0x02123500 end:0x02123720 kind:bss align:32
+src/_ZN6FlyGuyD1Ev.c:
+    complete
+    .text start:0x0211f000 end:0x0211f048
+
+src/_ZN6FlyGuyD0Ev.c:
+    complete
+    .text start:0x0211f048 end:0x0211f0a4
+
+src/func_ov070_0211f0a4.cpp:
+    .text start:0x0211f0a4 end:0x0211f100
+
+src/func_ov070_0211f100.cpp:
+    .text start:0x0211f100 end:0x0211f368
+
+src/func_ov070_0211f368.cpp:
+    .text start:0x0211f368 end:0x0211f450
+
+src/func_ov070_0211f450.c:
+    complete
+    .text start:0x0211f450 end:0x0211f48c
+
+src/func_ov070_0211f48c.c:
+    complete
+    .text start:0x0211f48c end:0x0211f5f0
+
+src/func_ov070_0211f5f0.cpp:
+    .text start:0x0211f5f0 end:0x0211f62c
+
+src/func_ov070_0211f62c.c:
+    .text start:0x0211f62c end:0x0211f694
+
+src/func_ov070_0211f694.cpp:
+    complete
+    .text start:0x0211f694 end:0x0211f6e0
+
+src/func_ov070_0211f6e0.c:
+    complete
+    .text start:0x0211f6e0 end:0x0211fa80
+
+src/func_ov070_0211fa80.c:
+    complete
+    .text start:0x0211fa80 end:0x0211fae4
+
+src/func_ov070_0211fae4.c:
+    complete
+    .text start:0x0211fae4 end:0x0211fd60
+
+src/func_ov070_0211fd60.c:
+    complete
+    .text start:0x0211fd60 end:0x0211fd98
+
+src/func_ov070_0211fd98.c:
+    complete
+    .text start:0x0211fd98 end:0x0211ffa8
+
+src/func_ov070_0211ffa8.cpp:
+    complete
+    .text start:0x0211ffa8 end:0x02120020
+
+src/FlyGuy_ChangeState.cpp:
+    complete
+    .text start:0x02120020 end:0x02120070
+
+src/func_ov070_02120070.cpp:
+    complete
+    .text start:0x02120070 end:0x02120150
+
+src/_ZN6FlyGuy16CleanupResourcesEv.c:
+    complete
+    .text start:0x02120150 end:0x021201bc
+
+src/_ZN6FlyGuy16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021201bc end:0x021201c0
+
+src/_ZN6FlyGuy6RenderEv.cpp:
+    complete
+    .text start:0x021201c0 end:0x02120210
+
+src/_ZN6FlyGuy8BehaviorEv.cpp:
+    .text start:0x02120210 end:0x021203b4
+
+src/_ZN6FlyGuy13InitResourcesEv.cpp:
+    .text start:0x021203b4 end:0x021204e4
+
+src/func_ov070_021204e4.c:
+    complete
+    .text start:0x021204e4 end:0x021204ec
+
+src/func_ov070_021204ec.cpp:
+    complete
+    .text start:0x021204ec end:0x02120518
+
+src/func_ov070_02120518.c:
+    complete
+    .text start:0x02120518 end:0x02120520
+
+src/FlyGuy_Spawn.c:
+    complete
+    .text start:0x02120520 end:0x02120570
+
+src/_ZN3AmpD1Ev.cpp:
+    .text start:0x02120570 end:0x021205d0
+
+src/_ZN3AmpD0Ev.c:
+    complete
+    .text start:0x021205d0 end:0x02120644
+
+src/func_ov070_02120644.cpp:
+    complete
+    .text start:0x02120644 end:0x02120724
+
+src/func_ov070_02120724.c:
+    complete
+    .text start:0x02120724 end:0x021208a4
+
+src/func_ov070_021208a4.c:
+    complete
+    .text start:0x021208a4 end:0x02120910
+
+src/func_ov070_02120910.cpp:
+    complete
+    .text start:0x02120910 end:0x021209e4
+
+src/func_ov070_021209e4.cpp:
+    complete
+    .text start:0x021209e4 end:0x02120bf8
+
+src/func_ov070_02120bf8.cpp:
+    complete
+    .text start:0x02120bf8 end:0x02120cac
+
+src/func_ov070_02120cac.cpp:
+    complete
+    .text start:0x02120cac end:0x02120ce4
+
+src/func_ov070_02120ce4.c:
+    complete
+    .text start:0x02120ce4 end:0x02120d34
+
+src/func_ov070_02120d34.cpp:
+    complete
+    .text start:0x02120d34 end:0x02120d70
+
+src/func_ov070_02120d70.cpp:
+    complete
+    .text start:0x02120d70 end:0x02120da8
+
+src/func_ov070_02120da8.c:
+    complete
+    .text start:0x02120da8 end:0x02120dc4
+
+src/_ZN3Amp16CleanupResourcesEv.c:
+    complete
+    .text start:0x02120dc4 end:0x02120e20
+
+src/_ZN3Amp16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02120e20 end:0x02120e24
+
+src/_ZN3Amp6RenderEv.cpp:
+    complete
+    .text start:0x02120e24 end:0x02120e8c
+
+src/_ZN3Amp8BehaviorEv.cpp:
+    .text start:0x02120e8c end:0x02120eec
+
+src/_ZN3Amp13InitResourcesEv.cpp:
+    complete
+    .text start:0x02120eec end:0x021210ac
+
+src/Amp_Spawn.c:
+    complete
+    .text start:0x021210ac end:0x02121118
+
+src/_ZN10FlameChompD1Ev.cpp:
+    .text start:0x02121118 end:0x02121160
+
+src/_ZN10FlameChompD0Ev.c:
+    complete
+    .text start:0x02121160 end:0x021211bc
+
+src/func_ov070_021211bc.c:
+    complete
+    .text start:0x021211bc end:0x021211c4
+
+src/func_ov070_021211c4.cpp:
+    .text start:0x021211c4 end:0x02121298
+
+src/func_ov070_02121298.cpp:
+    complete
+    .text start:0x02121298 end:0x02121310
+
+src/func_ov070_02121310.cpp:
+    complete
+    .text start:0x02121310 end:0x021213cc
+
+src/func_ov070_021213cc.c:
+    complete
+    .text start:0x021213cc end:0x02121438
+
+src/func_ov070_02121438.cpp:
+    complete
+    .text start:0x02121438 end:0x021214f8
+
+src/func_ov070_021214f8.cpp:
+    complete
+    .text start:0x021214f8 end:0x02121548
+
+src/func_ov070_02121548.c:
+    complete
+    .text start:0x02121548 end:0x0212156c
+
+src/func_ov070_0212156c.c:
+    complete
+    .text start:0x0212156c end:0x021216b8
+
+src/func_ov070_021216b8.c:
+    complete
+    .text start:0x021216b8 end:0x02121710
+
+src/func_ov070_02121710.cpp:
+    complete
+    .text start:0x02121710 end:0x021217ac
+
+src/func_ov070_021217ac.c:
+    complete
+    .text start:0x021217ac end:0x0212180c
+
+src/func_ov070_0212180c.cpp:
+    complete
+    .text start:0x0212180c end:0x02121848
+
+src/func_ov070_02121848.cpp:
+    complete
+    .text start:0x02121848 end:0x02121880
+
+src/func_ov070_02121880.c:
+    complete
+    .text start:0x02121880 end:0x0212189c
+
+src/_ZN10FlameChomp16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212189c end:0x021218c0
+
+src/_ZN10FlameChomp16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021218c0 end:0x021218c4
+
+src/_ZN10FlameChomp6RenderEv.cpp:
+    complete
+    .text start:0x021218c4 end:0x021218f4
+
+src/_ZN10FlameChomp8BehaviorEv.cpp:
+    .text start:0x021218f4 end:0x02121914
+
+src/_ZN10FlameChomp13InitResourcesEv.cpp:
+    .text start:0x02121914 end:0x02121a64
+
+src/func_ov070_02121a64.c:
+    .text start:0x02121a64 end:0x02121ae0
+
+src/func_ov070_02121ae0.c:
+    complete
+    .text start:0x02121ae0 end:0x02121af8
+
+src/FlameChomp_Spawn.c:
+    complete
+    .text start:0x02121af8 end:0x02121b48
+
+src/_ZN14FlameChompFireD1Ev.cpp:
+    .text start:0x02121b48 end:0x02121b88
+
+src/_ZN14FlameChompFireD0Ev.c:
+    complete
+    .text start:0x02121b88 end:0x02121bdc
+
+src/func_ov070_02121bdc.c:
+    complete
+    .text start:0x02121bdc end:0x02121be4
+
+src/func_ov070_02121be4.cpp:
+    complete
+    .text start:0x02121be4 end:0x02121c8c
+
+src/func_ov070_02121c8c.c:
+    complete
+    .text start:0x02121c8c end:0x02121cbc
+
+src/func_ov070_02121cbc.c:
+    complete
+    .text start:0x02121cbc end:0x02121d50
+
+src/func_ov070_02121d50.cpp:
+    .text start:0x02121d50 end:0x02121e14
+
+src/func_ov070_02121e14.cpp:
+    complete
+    .text start:0x02121e14 end:0x02121eb0
+
+src/func_ov070_02121eb0.c:
+    complete
+    .text start:0x02121eb0 end:0x02121ef8
+
+src/func_ov070_02121ef8.c:
+    complete
+    .text start:0x02121ef8 end:0x02121f18
+
+src/func_ov070_02121f18.cpp:
+    complete
+    .text start:0x02121f18 end:0x02121fb0
+
+src/func_ov070_02121fb0.c:
+    complete
+    .text start:0x02121fb0 end:0x02121fd0
+
+src/func_ov070_02121fd0.cpp:
+    complete
+    .text start:0x02121fd0 end:0x0212200c
+
+src/func_ov070_0212200c.cpp:
+    complete
+    .text start:0x0212200c end:0x02122044
+
+src/func_ov070_02122044.c:
+    complete
+    .text start:0x02122044 end:0x02122060
+
+src/_ZN14FlameChompFire16CleanupResourcesEv.c:
+    complete
+    .text start:0x02122060 end:0x02122068
+
+src/_ZN14FlameChompFire16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02122068 end:0x0212206c
+
+src/_ZN14FlameChompFire6RenderEv.cpp:
+    complete
+    .text start:0x0212206c end:0x02122104
+
+src/_ZN14FlameChompFire8BehaviorEv.cpp:
+    .text start:0x02122104 end:0x02122124
+
+src/_ZN14FlameChompFire13InitResourcesEv.cpp:
+    .text start:0x02122124 end:0x021221fc
+
+src/FlameChompFire_Spawn.c:
+    complete
+    .text start:0x021221fc end:0x02122244
+
+src/__sinit_ov070_02122afc.c:
+    .init start:0x02122afc end:0x02122d80
+
+src/__sinit_ov070_02122d80.cpp:
+    .init start:0x02122d80 end:0x02122f30
+
+src/__sinit_ov070_02122f30.c:
+    .init start:0x02122f30 end:0x02123030
+
+src/__sinit_ov070_02123030.c:
+    .init start:0x02123030 end:0x021230a4

--- a/config/arm9/overlays/ov071/delinks.txt
+++ b/config/arm9/overlays/ov071/delinks.txt
@@ -4,3 +4,339 @@
     .ctor       start:0x02122b30 end:0x02122b40 kind:rodata align:4
     .data       start:0x02122b60 end:0x02122f80 kind:data align:32
     .bss        start:0x02122f80 end:0x02123100 kind:bss align:32
+src/_ZN10ScuttlebugD1Ev.cpp:
+    .text start:0x0211f000 end:0x0211f048
+
+src/_ZN10ScuttlebugD0Ev.c:
+    complete
+    .text start:0x0211f048 end:0x0211f0a4
+
+src/func_ov071_0211f0a4.c:
+    complete
+    .text start:0x0211f0a4 end:0x0211f0ac
+
+src/func_ov071_0211f0ac.c:
+    complete
+    .text start:0x0211f0ac end:0x0211f0b4
+
+src/func_ov071_0211f0b4.c:
+    complete
+    .text start:0x0211f0b4 end:0x0211f148
+
+src/func_ov071_0211f148.cpp:
+    .text start:0x0211f148 end:0x0211f29c
+
+src/func_ov071_0211f29c.cpp:
+    complete
+    .text start:0x0211f29c end:0x0211f498
+
+src/func_ov071_0211f498.c:
+    complete
+    .text start:0x0211f498 end:0x0211f524
+
+src/func_ov071_0211f524.cpp:
+    complete
+    .text start:0x0211f524 end:0x0211f694
+
+src/func_ov071_0211f694.c:
+    complete
+    .text start:0x0211f694 end:0x0211f6f8
+
+src/func_ov071_0211f6f8.cpp:
+    complete
+    .text start:0x0211f6f8 end:0x0211f7d4
+
+src/func_ov071_0211f7d4.c:
+    .text start:0x0211f7d4 end:0x0211f8d0
+
+src/func_ov071_0211f8d0.cpp:
+    complete
+    .text start:0x0211f8d0 end:0x0211fa54
+
+src/func_ov071_0211fa54.c:
+    complete
+    .text start:0x0211fa54 end:0x0211fb0c
+
+src/func_ov071_0211fb0c.c:
+    complete
+    .text start:0x0211fb0c end:0x0211fb24
+
+src/func_ov071_0211fb24.cpp:
+    .text start:0x0211fb24 end:0x0211fbf4
+
+src/func_ov071_0211fbf4.c:
+    complete
+    .text start:0x0211fbf4 end:0x0211fc60
+
+src/func_ov071_0211fc60.c:
+    complete
+    .text start:0x0211fc60 end:0x0211fcd4
+
+src/func_ov071_0211fcd4.c:
+    complete
+    .text start:0x0211fcd4 end:0x0211fd58
+
+src/func_ov071_0211fd58.cpp:
+    complete
+    .text start:0x0211fd58 end:0x0211fe38
+
+src/func_ov071_0211fe38.c:
+    complete
+    .text start:0x0211fe38 end:0x0211fee4
+
+src/func_ov071_0211fee4.cpp:
+    complete
+    .text start:0x0211fee4 end:0x0211ff84
+
+src/func_ov071_0211ff84.c:
+    complete
+    .text start:0x0211ff84 end:0x02120028
+
+src/func_ov071_02120028.c:
+    complete
+    .text start:0x02120028 end:0x02120130
+
+src/func_ov071_02120130.c:
+    complete
+    .text start:0x02120130 end:0x021201b4
+
+src/func_ov071_021201b4.cpp:
+    complete
+    .text start:0x021201b4 end:0x02120200
+
+src/func_ov071_02120200.c:
+    complete
+    .text start:0x02120200 end:0x02120278
+
+src/func_ov071_02120278.cpp:
+    complete
+    .text start:0x02120278 end:0x021202b4
+
+src/func_ov071_021202b4.cpp:
+    complete
+    .text start:0x021202b4 end:0x021202ec
+
+src/Scuttlebug_SetState.c:
+    complete
+    .text start:0x021202ec end:0x02120308
+
+src/_ZN10Scuttlebug16CleanupResourcesEv.c:
+    complete
+    .text start:0x02120308 end:0x02120338
+
+src/_ZN10Scuttlebug16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02120338 end:0x0212033c
+
+src/_ZN10Scuttlebug6RenderEv.cpp:
+    complete
+    .text start:0x0212033c end:0x02120398
+
+src/_ZN10Scuttlebug8BehaviorEv.cpp:
+    .text start:0x02120398 end:0x021203f8
+
+src/_ZN10Scuttlebug13InitResourcesEv.cpp:
+    .text start:0x021203f8 end:0x02120580
+
+src/func_ov071_02120580.cpp:
+    complete
+    .text start:0x02120580 end:0x02120618
+
+src/Scuttlebug_Spawn.c:
+    complete
+    .text start:0x02120618 end:0x02120668
+
+src/_ZN3MrID1Ev.cpp:
+    .text start:0x02120668 end:0x021206b0
+
+src/_ZN3MrID0Ev.c:
+    complete
+    .text start:0x021206b0 end:0x0212070c
+
+src/func_ov071_0212070c.c:
+    complete
+    .text start:0x0212070c end:0x02120860
+
+src/func_ov071_02120860.cpp:
+    complete
+    .text start:0x02120860 end:0x021209c8
+
+src/func_ov071_021209c8.cpp:
+    complete
+    .text start:0x021209c8 end:0x02120a20
+
+src/func_ov071_02120a20.c:
+    complete
+    .text start:0x02120a20 end:0x02120a48
+
+src/func_ov071_02120a48.cpp:
+    .text start:0x02120a48 end:0x02120b14
+
+src/func_ov071_02120b14.cpp:
+    complete
+    .text start:0x02120b14 end:0x02120c90
+
+src/func_ov071_02120c90.cpp:
+    complete
+    .text start:0x02120c90 end:0x02120d30
+
+src/func_ov071_0212110c.c:
+    complete
+    .text start:0x0212110c end:0x021211e0
+
+src/func_ov071_021214f4.c:
+    complete
+    .text start:0x021214f4 end:0x0212152c
+
+src/func_ov071_0212152c.c:
+    .text start:0x0212152c end:0x02121570
+
+src/func_ov071_02121570.c:
+    complete
+    .text start:0x02121570 end:0x021215c0
+
+src/func_ov071_021215c0.cpp:
+    complete
+    .text start:0x021215c0 end:0x021215fc
+
+src/func_ov071_021215fc.cpp:
+    complete
+    .text start:0x021215fc end:0x02121634
+
+src/func_ov071_02121634.c:
+    complete
+    .text start:0x02121634 end:0x02121650
+
+src/_ZN3MrI16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02121650 end:0x021216b4
+
+src/_ZN3MrI16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021216b4 end:0x021216b8
+
+src/_ZN3MrI6RenderEv.cpp:
+    complete
+    .text start:0x021216b8 end:0x021216ec
+
+src/_ZN3MrI8BehaviorEv.cpp:
+    complete
+    .text start:0x021216ec end:0x02121734
+
+src/BigMrI_Spawn.c:
+    complete
+    .text start:0x021219cc end:0x02121a1c
+
+src/MrI_Spawn.c:
+    complete
+    .text start:0x02121a1c end:0x02121a6c
+
+src/_ZN14MrI_ProjectileD1Ev.cpp:
+    .text start:0x02121a6c end:0x02121aac
+
+src/_ZN14MrI_ProjectileD0Ev.c:
+    complete
+    .text start:0x02121aac end:0x02121b00
+
+src/func_ov071_02121b00.c:
+    complete
+    .text start:0x02121b00 end:0x02121b08
+
+src/func_ov071_02121b08.c:
+    complete
+    .text start:0x02121b08 end:0x02121b50
+
+src/func_ov071_02121b50.c:
+    complete
+    .text start:0x02121b50 end:0x02121ba4
+
+src/func_ov071_02121ba4.cpp:
+    .text start:0x02121ba4 end:0x02121c6c
+
+src/func_ov071_02121c6c.cpp:
+    complete
+    .text start:0x02121c6c end:0x02121d08
+
+src/_ZN14MrI_Projectile16CleanupResourcesEv.c:
+    complete
+    .text start:0x02121d08 end:0x02121d10
+
+src/_ZN14MrI_Projectile16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02121d10 end:0x02121d14
+
+src/_ZN14MrI_Projectile6RenderEv.cpp:
+    complete
+    .text start:0x02121d14 end:0x02121d80
+
+src/_ZN14MrI_Projectile8BehaviorEv.cpp:
+    .text start:0x02121d80 end:0x02121eb4
+
+src/_ZN14MrI_Projectile13InitResourcesEv.cpp:
+    .text start:0x02121eb4 end:0x02121f9c
+
+src/MrI_Projectile_Spawn.c:
+    complete
+    .text start:0x02121f9c end:0x02121fe4
+
+src/_ZN6CoffinD1Ev.c:
+    .text start:0x02121fe4 end:0x02122028
+
+src/_ZN6CoffinD0Ev.c:
+    .text start:0x02122028 end:0x02122080
+
+src/func_ov071_02122080.c:
+    complete
+    .text start:0x02122080 end:0x021220c8
+
+src/func_ov071_021220c8.cpp:
+    .text start:0x021220c8 end:0x02122194
+
+src/func_ov071_02122194.c:
+    complete
+    .text start:0x02122194 end:0x021221bc
+
+src/func_ov071_021221bc.c:
+    complete
+    .text start:0x021221bc end:0x021223b0
+
+src/func_ov071_021223b0.c:
+    complete
+    .text start:0x021223b0 end:0x021223c8
+
+src/func_ov071_021223c8.cpp:
+    complete
+    .text start:0x021223c8 end:0x02122414
+
+src/func_ov071_02122414.cpp:
+    complete
+    .text start:0x02122414 end:0x02122460
+
+src/_ZN6Coffin16CleanupResourcesEv.cpp:
+    .text start:0x02122460 end:0x021224a4
+
+src/_ZN6Coffin6RenderEv.cpp:
+    complete
+    .text start:0x021224a4 end:0x021224cc
+
+src/_ZN6Coffin8BehaviorEv.cpp:
+    .text start:0x021224cc end:0x0212255c
+
+src/_ZN6Coffin13InitResourcesEv.cpp:
+    .text start:0x0212255c end:0x02122670
+
+src/Coffin_Spawn.c:
+    complete
+    .text start:0x02122670 end:0x021226a0
+
+src/__sinit_ov071_021226ac.c:
+    .init start:0x021226ac end:0x021228c8
+
+src/__sinit_ov071_021228c8.c:
+    .init start:0x021228c8 end:0x02122a1c
+
+src/__sinit_ov071_02122a1c.c:
+    .init start:0x02122a1c end:0x02122a64
+
+src/__sinit_ov071_02122a64.c:
+    .init start:0x02122a64 end:0x02122b30

--- a/config/arm9/overlays/ov072/delinks.txt
+++ b/config/arm9/overlays/ov072/delinks.txt
@@ -4,3 +4,360 @@
     .ctor       start:0x02122708 end:0x02122718 kind:rodata align:4
     .data       start:0x02122720 end:0x02122b20 kind:data align:32
     .bss        start:0x02122b20 end:0x02122de0 kind:bss align:32
+src/_ZN11SnowmanBodyD1Ev.cpp:
+    .text start:0x0211f000 end:0x0211f048
+
+src/_ZN11SnowmanBodyD0Ev.c:
+    complete
+    .text start:0x0211f048 end:0x0211f0a4
+
+src/func_ov072_0211f0a4.c:
+    complete
+    .text start:0x0211f0a4 end:0x0211f158
+
+src/func_ov072_0211f158.cpp:
+    complete
+    .text start:0x0211f158 end:0x0211f1dc
+
+src/func_ov072_0211f1dc.cpp:
+    complete
+    .text start:0x0211f1dc end:0x0211f280
+
+src/func_ov072_0211f280.c:
+    complete
+    .text start:0x0211f280 end:0x0211f330
+
+src/func_ov072_0211f330.c:
+    complete
+    .text start:0x0211f330 end:0x0211f3e4
+
+src/func_ov072_0211f3e4.c:
+    complete
+    .text start:0x0211f3e4 end:0x0211f48c
+
+src/func_ov072_0211f48c.cpp:
+    complete
+    .text start:0x0211f48c end:0x0211f578
+
+src/func_ov072_0211f578.c:
+    complete
+    .text start:0x0211f578 end:0x0211f598
+
+src/func_ov072_0211f598.c:
+    complete
+    .text start:0x0211f598 end:0x0211f63c
+
+src/func_ov072_0211f63c.c:
+    complete
+    .text start:0x0211f63c end:0x0211f65c
+
+src/func_ov072_0211f65c.cpp:
+    complete
+    .text start:0x0211f65c end:0x0211f804
+
+src/func_ov072_0211f804.c:
+    complete
+    .text start:0x0211f804 end:0x0211f81c
+
+src/func_ov072_0211f81c.cpp:
+    .text start:0x0211f81c end:0x0211f9c4
+
+src/func_ov072_0211f9c4.c:
+    complete
+    .text start:0x0211f9c4 end:0x0211fa08
+
+src/func_ov072_0211fa08.cpp:
+    complete
+    .text start:0x0211fa08 end:0x0211faf0
+
+src/func_ov072_0211faf0.c:
+    complete
+    .text start:0x0211faf0 end:0x0211fb14
+
+src/func_ov072_0211fb14.cpp:
+    complete
+    .text start:0x0211fb14 end:0x0211fb7c
+
+src/func_ov072_0211fb7c.c:
+    complete
+    .text start:0x0211fb7c end:0x0211fc3c
+
+src/func_ov072_0211fc3c.cpp:
+    complete
+    .text start:0x0211fc3c end:0x0211fc78
+
+src/func_ov072_0211fc78.cpp:
+    complete
+    .text start:0x0211fc78 end:0x0211fcb0
+
+src/func_ov072_0211fcb0.c:
+    complete
+    .text start:0x0211fcb0 end:0x0211fccc
+
+src/_ZN11SnowmanBody16CleanupResourcesEv.c:
+    complete
+    .text start:0x0211fccc end:0x0211fcf0
+
+src/_ZN11SnowmanBody16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0211fcf0 end:0x0211fcf4
+
+src/_ZN11SnowmanBody6RenderEv.cpp:
+    complete
+    .text start:0x0211fcf4 end:0x0211fd24
+
+src/_ZN11SnowmanBody8BehaviorEv.cpp:
+    .text start:0x0211fd24 end:0x0211fd54
+
+src/_ZN11SnowmanBody13InitResourcesEv.cpp:
+    .text start:0x0211fd54 end:0x0211fedc
+
+src/SnowmanBody_Spawn.c:
+    complete
+    .text start:0x0211fedc end:0x0211ff34
+
+src/_ZN11SnowmanHeadD1Ev.cpp:
+    .text start:0x0211ff34 end:0x0211ff7c
+
+src/_ZN11SnowmanHeadD0Ev.c:
+    complete
+    .text start:0x0211ff7c end:0x0211ffd8
+
+src/func_ov072_0211ffd8.c:
+    complete
+    .text start:0x0211ffd8 end:0x0212001c
+
+src/func_ov072_0212001c.c:
+    complete
+    .text start:0x0212001c end:0x02120180
+
+src/func_ov072_02120180.c:
+    complete
+    .text start:0x02120180 end:0x021201d4
+
+src/func_ov072_021201d4.c:
+    complete
+    .text start:0x021201d4 end:0x02120308
+
+src/func_ov072_02120308.c:
+    complete
+    .text start:0x02120308 end:0x02120358
+
+src/func_ov072_02120358.c:
+    complete
+    .text start:0x02120358 end:0x02120430
+
+src/func_ov072_02120430.c:
+    complete
+    .text start:0x02120430 end:0x02120450
+
+src/func_ov072_02120450.cpp:
+    .text start:0x02120450 end:0x02120514
+
+src/func_ov072_02120514.c:
+    complete
+    .text start:0x02120514 end:0x02120560
+
+src/func_ov072_02120560.cpp:
+    complete
+    .text start:0x02120560 end:0x0212059c
+
+src/func_ov072_0212059c.cpp:
+    complete
+    .text start:0x0212059c end:0x021205d4
+
+src/func_ov072_021205d4.c:
+    complete
+    .text start:0x021205d4 end:0x021205f0
+
+src/_ZN11SnowmanHead16CleanupResourcesEv.c:
+    complete
+    .text start:0x021205f0 end:0x02120634
+
+src/_ZN11SnowmanHead16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02120634 end:0x02120638
+
+src/_ZN11SnowmanHead6RenderEv.cpp:
+    complete
+    .text start:0x02120638 end:0x0212066c
+
+src/_ZN11SnowmanHead8BehaviorEv.cpp:
+    .text start:0x0212066c end:0x0212069c
+
+src/_ZN11SnowmanHead13InitResourcesEv.cpp:
+    .text start:0x0212069c end:0x021207d4
+
+src/SnowmanHead_Spawn.c:
+    complete
+    .text start:0x021207d4 end:0x02120824
+
+src/func_ov072_02120824.c:
+    .text start:0x02120824 end:0x02120874
+
+src/func_ov072_02120874.c:
+    .text start:0x02120874 end:0x021208d8
+
+src/func_ov072_021208d8.cpp:
+    complete
+    .text start:0x021208d8 end:0x02120980
+
+src/func_ov072_02120980.c:
+    complete
+    .text start:0x02120980 end:0x021209bc
+
+src/func_ov072_021209bc.c:
+    complete
+    .text start:0x021209bc end:0x021209c0
+
+src/func_ov072_021209c0.cpp:
+    complete
+    .text start:0x021209c0 end:0x02120a08
+
+src/func_ov072_02120a08.cpp:
+    complete
+    .text start:0x02120a08 end:0x02120a44
+
+src/func_ov072_02120a44.c:
+    complete
+    .text start:0x02120a44 end:0x02120c00
+
+src/func_ov072_02120c00.c:
+    .text start:0x02120c00 end:0x02120c58
+
+src/_ZN11BabyPenguinD1Ev.cpp:
+    .text start:0x02120c58 end:0x02120ca0
+
+src/_ZN11BabyPenguinD0Ev.c:
+    complete
+    .text start:0x02120ca0 end:0x02120cfc
+
+src/func_ov072_02120cfc.c:
+    complete
+    .text start:0x02120cfc end:0x02120d04
+
+src/func_ov072_02120d04.cpp:
+    complete
+    .text start:0x02120d04 end:0x02120ddc
+
+src/func_ov072_02120ddc.c:
+    complete
+    .text start:0x02120ddc end:0x02120e20
+
+src/func_ov072_02120e20.cpp:
+    complete
+    .text start:0x02120e20 end:0x02120e50
+
+src/func_ov072_02120e50.cpp:
+    complete
+    .text start:0x02120e50 end:0x02120f14
+
+src/func_ov072_02120f14.cpp:
+    complete
+    .text start:0x02120f14 end:0x02120fd4
+
+src/func_ov072_02120fd4.cpp:
+    complete
+    .text start:0x02120fd4 end:0x021210c4
+
+src/func_ov072_021210c4.cpp:
+    complete
+    .text start:0x021210c4 end:0x021212c0
+
+src/func_ov072_021212c0.cpp:
+    complete
+    .text start:0x021212c0 end:0x02121368
+
+src/func_ov072_02121368.c:
+    complete
+    .text start:0x02121368 end:0x021214dc
+
+src/func_ov072_021214dc.c:
+    complete
+    .text start:0x021214dc end:0x02121640
+
+src/func_ov072_02121640.c:
+    complete
+    .text start:0x02121640 end:0x02121670
+
+src/func_ov072_02121670.c:
+    complete
+    .text start:0x02121670 end:0x02121758
+
+src/func_ov072_02121758.c:
+    complete
+    .text start:0x02121758 end:0x021217ac
+
+src/func_ov072_021217ac.cpp:
+    .text start:0x021217ac end:0x02121890
+
+src/func_ov072_02121890.c:
+    complete
+    .text start:0x02121890 end:0x021218dc
+
+src/func_ov072_021218dc.cpp:
+    complete
+    .text start:0x021218dc end:0x02121a28
+
+src/func_ov072_02121a28.c:
+    complete
+    .text start:0x02121a28 end:0x02121a84
+
+src/func_ov072_02121a84.c:
+    complete
+    .text start:0x02121a84 end:0x02121c94
+
+src/func_ov072_02121c94.c:
+    complete
+    .text start:0x02121c94 end:0x02121cdc
+
+src/func_ov072_02121cdc.cpp:
+    complete
+    .text start:0x02121cdc end:0x02121d18
+
+src/func_ov072_02121d18.cpp:
+    complete
+    .text start:0x02121d18 end:0x02121d50
+
+src/func_ov072_02121d50.c:
+    complete
+    .text start:0x02121d50 end:0x02121d6c
+
+src/_ZN11BabyPenguin16CleanupResourcesEv.c:
+    complete
+    .text start:0x02121d6c end:0x02121db0
+
+src/_ZN11BabyPenguin16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02121db0 end:0x02121db4
+
+src/_ZN11BabyPenguin6RenderEv.cpp:
+    complete
+    .text start:0x02121db4 end:0x02121e08
+
+src/_ZN11BabyPenguin8BehaviorEv.cpp:
+    complete
+    .text start:0x02121e08 end:0x02121e84
+
+src/_ZN11BabyPenguin13InitResourcesEv.cpp:
+    .text start:0x02121e84 end:0x02121fa0
+
+src/func_ov072_02121fa0.c:
+    complete
+    .text start:0x02121fa0 end:0x02121fac
+
+src/BabyPenguin_Spawn.c:
+    complete
+    .text start:0x02121fac end:0x02121ffc
+
+src/__sinit_ov072_02122018.c:
+    .init start:0x02122018 end:0x021221f8
+
+src/__sinit_ov072_021221f8.c:
+    .init start:0x021221f8 end:0x02122350
+
+src/__sinit_ov072_02122350.c:
+    .init start:0x02122350 end:0x02122414
+
+src/__sinit_ov072_02122414.c:
+    .init start:0x02122414 end:0x02122708

--- a/config/arm9/overlays/ov073/delinks.txt
+++ b/config/arm9/overlays/ov073/delinks.txt
@@ -3,3 +3,273 @@
     .ctor       start:0x02122f34 end:0x02122f3c kind:rodata align:4
     .data       start:0x02122f40 end:0x02123280 kind:data align:32
     .bss        start:0x02123280 end:0x021234e0 kind:bss align:32
+src/_ZN11ChiefChillyD1Ev.c:
+    complete
+    .text start:0x0211f000 end:0x0211f098
+
+src/_ZN11ChiefChillyD0Ev.c:
+    complete
+    .text start:0x0211f098 end:0x0211f144
+
+src/func_ov073_0211f144.c:
+    complete
+    .text start:0x0211f144 end:0x0211f2c0
+
+src/func_ov073_0211f2c0.c:
+    complete
+    .text start:0x0211f2c0 end:0x0211f494
+
+src/func_ov073_0211f494.c:
+    complete
+    .text start:0x0211f494 end:0x0211f61c
+
+src/func_ov073_0211f61c.c:
+    complete
+    .text start:0x0211f61c end:0x0211fa74
+
+src/func_ov073_0211fa74.c:
+    complete
+    .text start:0x0211fa74 end:0x0211fbec
+
+src/func_ov073_0211fbec.c:
+    complete
+    .text start:0x0211fbec end:0x0211fbf4
+
+src/func_ov073_0211fbf4.cpp:
+    complete
+    .text start:0x0211fbf4 end:0x0211fc70
+
+src/func_ov073_0211fc70.c:
+    complete
+    .text start:0x0211fc70 end:0x0211fc78
+
+src/func_ov073_0211fc78.c:
+    complete
+    .text start:0x0211fc78 end:0x0211fe84
+
+src/func_ov073_0211fe84.c:
+    complete
+    .text start:0x0211fe84 end:0x0211fe8c
+
+src/func_ov073_0211fe8c.c:
+    complete
+    .text start:0x0211fe8c end:0x0212000c
+
+src/func_ov073_0212000c.cpp:
+    complete
+    .text start:0x0212000c end:0x0212005c
+
+src/func_ov073_0212005c.cpp:
+    complete
+    .text start:0x0212005c end:0x02120098
+
+src/func_ov073_02120098.cpp:
+    complete
+    .text start:0x02120098 end:0x021200e0
+
+src/func_ov073_021200e0.c:
+    complete
+    .text start:0x021200e0 end:0x02120390
+
+src/func_ov073_02120390.c:
+    complete
+    .text start:0x02120390 end:0x021203ac
+
+src/func_ov073_021203ac.c:
+    complete
+    .text start:0x021203ac end:0x021205f0
+
+src/func_ov073_021205f0.c:
+    complete
+    .text start:0x021205f0 end:0x02120610
+
+src/func_ov073_02120610.c:
+    complete
+    .text start:0x02120610 end:0x0212081c
+
+src/func_ov073_0212081c.c:
+    complete
+    .text start:0x0212081c end:0x02120844
+
+src/func_ov073_02120844.c:
+    complete
+    .text start:0x02120844 end:0x021208e4
+
+src/func_ov073_021208e4.c:
+    complete
+    .text start:0x021208e4 end:0x02120910
+
+src/func_ov073_02120910.c:
+    complete
+    .text start:0x02120910 end:0x02120ad8
+
+src/func_ov073_02120ad8.c:
+    complete
+    .text start:0x02120ad8 end:0x02120b78
+
+src/func_ov073_02120b78.c:
+    complete
+    .text start:0x02120b78 end:0x02120c08
+
+src/func_ov073_02120c08.c:
+    complete
+    .text start:0x02120c08 end:0x02120c7c
+
+src/func_ov073_02120c7c.cpp:
+    complete
+    .text start:0x02120c7c end:0x02120d80
+
+src/func_ov073_02120d80.cpp:
+    complete
+    .text start:0x02120d80 end:0x02120dec
+
+src/func_ov073_02120dec.c:
+    complete
+    .text start:0x02120dec end:0x02120e60
+
+src/func_ov073_02120e60.cpp:
+    complete
+    .text start:0x02120e60 end:0x02120ed0
+
+src/func_ov073_02120ed0.c:
+    complete
+    .text start:0x02120ed0 end:0x0212122c
+
+src/func_ov073_0212122c.c:
+    complete
+    .text start:0x0212122c end:0x0212128c
+
+src/func_ov073_0212128c.c:
+    complete
+    .text start:0x0212128c end:0x02121378
+
+src/func_ov073_02121378.c:
+    complete
+    .text start:0x02121378 end:0x02121388
+
+src/func_ov073_02121388.c:
+    complete
+    .text start:0x02121388 end:0x02121538
+
+src/func_ov073_02121538.cpp:
+    complete
+    .text start:0x02121538 end:0x0212157c
+
+src/ChiefChilly_ChangeState.cpp:
+    complete
+    .text start:0x0212157c end:0x021215cc
+
+src/func_ov073_021215cc.c:
+    complete
+    .text start:0x021215cc end:0x021217e0
+
+src/_ZN11ChiefChilly16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x021217e0 end:0x0212186c
+
+src/_ZN11ChiefChilly16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212186c end:0x02121870
+
+src/_ZN11ChiefChilly6RenderEv.cpp:
+    complete
+    .text start:0x02121870 end:0x021218a0
+
+src/_ZN11ChiefChilly8BehaviorEv.cpp:
+    complete
+    .text start:0x021218a0 end:0x02121ccc
+
+src/_ZN11ChiefChilly13InitResourcesEv.cpp:
+    .text start:0x02121ccc end:0x02121ec0
+
+src/func_ov073_02121ec0.c:
+    complete
+    .text start:0x02121ec0 end:0x02121ec8
+
+src/ChiefChilly_Spawn.cpp:
+    .text start:0x02121ec8 end:0x02121f90
+
+src/_ZN8CccArenaD1Ev.c:
+    .text start:0x02121f90 end:0x02121fd4
+
+src/_ZN8CccArenaD0Ev.c:
+    .text start:0x02121fd4 end:0x0212202c
+
+src/func_ov073_0212202c.c:
+    complete
+    .text start:0x0212202c end:0x02122034
+
+src/func_ov073_02122034.cpp:
+    complete
+    .text start:0x02122034 end:0x021220c0
+
+src/func_ov073_021220c0.c:
+    complete
+    .text start:0x021220c0 end:0x021221e0
+
+src/func_ov073_021221e0.c:
+    complete
+    .text start:0x021221e0 end:0x02122200
+
+src/func_ov073_02122200.cpp:
+    complete
+    .text start:0x02122200 end:0x021222c8
+
+src/func_ov073_021222c8.c:
+    complete
+    .text start:0x021222c8 end:0x021222ec
+
+src/func_ov073_021222ec.c:
+    complete
+    .text start:0x021222ec end:0x0212239c
+
+src/func_ov073_0212239c.c:
+    complete
+    .text start:0x0212239c end:0x021223a4
+
+src/func_ov073_021223a4.cpp:
+    complete
+    .text start:0x021223a4 end:0x021223f4
+
+src/func_ov073_021223f4.cpp:
+    complete
+    .text start:0x021223f4 end:0x02122464
+
+src/_ZN8CccArena16CleanupResourcesEv.cpp:
+    .text start:0x02122464 end:0x021224c8
+
+src/_ZN8CccArena6RenderEv.cpp:
+    complete
+    .text start:0x021224c8 end:0x021224f0
+
+src/_ZN8CccArena8BehaviorEv.cpp:
+    .text start:0x021224f0 end:0x02122578
+
+src/_ZN8CccArena13InitResourcesEv.cpp:
+    .text start:0x02122578 end:0x02122730
+
+src/func_ov073_02122730.c:
+    complete
+    .text start:0x02122730 end:0x021227d0
+
+src/func_ov073_021227d0.c:
+    complete
+    .text start:0x021227d0 end:0x021227e4
+
+src/CccSmallIce_Spawn.c:
+    complete
+    .text start:0x021227e4 end:0x02122814
+
+src/CccBigIce_Spawn.c:
+    complete
+    .text start:0x02122814 end:0x02122844
+
+src/CccArena_Spawn.c:
+    complete
+    .text start:0x02122844 end:0x02122874
+
+src/__sinit_ov073_02122874.c:
+    .init start:0x02122874 end:0x02122d48
+
+src/__sinit_ov073_02122d48.c:
+    .init start:0x02122d48 end:0x02122f34

--- a/config/arm9/overlays/ov074/delinks.txt
+++ b/config/arm9/overlays/ov074/delinks.txt
@@ -4,3 +4,201 @@
     .ctor       start:0x02122d70 end:0x02122d74 kind:rodata align:4
     .data       start:0x02122d80 end:0x02122fe0 kind:data align:32
     .bss        start:0x02122fe0 end:0x021231a0 kind:bss align:32
+src/_ZN8GoombossD1Ev.c:
+    complete
+    .text start:0x0211f000 end:0x0211f0a0
+
+src/_ZN8GoombossD0Ev.c:
+    complete
+    .text start:0x0211f0a0 end:0x0211f154
+
+src/func_ov074_0211f154.c:
+    complete
+    .text start:0x0211f154 end:0x0211f244
+
+src/func_ov074_0211f244.cpp:
+    complete
+    .text start:0x0211f244 end:0x0211f344
+
+src/func_ov074_0211f344.c:
+    complete
+    .text start:0x0211f344 end:0x0211f38c
+
+src/func_ov074_0211f38c.c:
+    complete
+    .text start:0x0211f38c end:0x0211f5b8
+
+src/func_ov074_0211f5b8.c:
+    complete
+    .text start:0x0211f5b8 end:0x0211fa08
+
+src/func_ov074_0211fa08.c:
+    complete
+    .text start:0x0211fa08 end:0x0211fa74
+
+src/func_ov074_0211fa74.c:
+    complete
+    .text start:0x0211fa74 end:0x0211fb84
+
+src/func_ov074_0211fb84.c:
+    complete
+    .text start:0x0211fb84 end:0x0211fbd0
+
+src/func_ov074_0211fbd0.c:
+    complete
+    .text start:0x0211fbd0 end:0x0211fc34
+
+src/func_ov074_0211fc34.c:
+    complete
+    .text start:0x0211fc34 end:0x0211fc38
+
+src/func_ov074_0211fc38.c:
+    complete
+    .text start:0x0211fc38 end:0x0211fd48
+
+src/func_ov074_0211fd48.c:
+    complete
+    .text start:0x0211fd48 end:0x0211fd74
+
+src/func_ov074_0211fd74.cpp:
+    .text start:0x0211fd74 end:0x0211ffac
+
+src/func_ov074_0211ffac.c:
+    complete
+    .text start:0x0211ffac end:0x0211ffcc
+
+src/func_ov074_0211ffcc.c:
+    complete
+    .text start:0x0211ffcc end:0x0212007c
+
+src/func_ov074_0212007c.c:
+    complete
+    .text start:0x0212007c end:0x02120080
+
+src/func_ov074_02120080.cpp:
+    complete
+    .text start:0x02120080 end:0x0212016c
+
+src/func_ov074_0212016c.c:
+    complete
+    .text start:0x0212016c end:0x0212018c
+
+src/func_ov074_0212018c.cpp:
+    complete
+    .text start:0x0212018c end:0x021201ec
+
+src/func_ov074_021201ec.c:
+    complete
+    .text start:0x021201ec end:0x021201f0
+
+src/func_ov074_021203e0.c:
+    complete
+    .text start:0x021203e0 end:0x021203e4
+
+src/func_ov074_021203e4.cpp:
+    complete
+    .text start:0x021203e4 end:0x0212042c
+
+src/func_ov074_0212042c.cpp:
+    complete
+    .text start:0x0212042c end:0x02120474
+
+src/func_ov074_02120474.cpp:
+    complete
+    .text start:0x02120474 end:0x021204c0
+
+src/func_ov074_021206c8.c:
+    complete
+    .text start:0x021206c8 end:0x021207b8
+
+src/func_ov074_021207b8.c:
+    complete
+    .text start:0x021207b8 end:0x02120808
+
+src/func_ov074_02120808.cpp:
+    complete
+    .text start:0x02120808 end:0x0212087c
+
+src/func_ov074_0212087c.c:
+    .text start:0x0212087c end:0x02120b24
+
+src/func_ov074_02120b24.c:
+    complete
+    .text start:0x02120b24 end:0x02120b90
+
+src/func_ov074_02120b90.c:
+    complete
+    .text start:0x02120b90 end:0x02120bb8
+
+src/func_ov074_02120bb8.c:
+    complete
+    .text start:0x02120bb8 end:0x02120d74
+
+src/func_ov074_02120d74.c:
+    complete
+    .text start:0x02120d74 end:0x02121270
+
+src/func_ov074_02121270.c:
+    complete
+    .text start:0x02121270 end:0x02121300
+
+src/func_ov074_02121300.cpp:
+    complete
+    .text start:0x02121300 end:0x02121380
+
+src/func_ov074_021216f4.c:
+    complete
+    .text start:0x021216f4 end:0x02121800
+
+src/func_ov074_0212195c.c:
+    complete
+    .text start:0x0212195c end:0x0212199c
+
+src/func_ov074_0212199c.c:
+    complete
+    .text start:0x0212199c end:0x02121a20
+
+src/func_ov074_02121a20.c:
+    complete
+    .text start:0x02121a20 end:0x02121a4c
+
+src/func_ov074_02121a4c.cpp:
+    complete
+    .text start:0x02121a4c end:0x02121abc
+
+src/_ZN8Goomboss16CleanupResourcesEv.cpp:
+    .text start:0x02121abc end:0x02121b70
+
+src/_ZN8Goomboss6RenderEv.cpp:
+    .text start:0x02121b70 end:0x02121bf0
+
+src/_ZN8Goomboss8BehaviorEv.cpp:
+    .text start:0x02121bf0 end:0x02121e98
+
+src/_ZN8Goomboss13InitResourcesEv.c:
+    .text start:0x02121e98 end:0x0212229c
+
+src/func_ov074_0212229c.c:
+    complete
+    .text start:0x0212229c end:0x021222e0
+
+src/func_ov074_021222e0.cpp:
+    complete
+    .text start:0x021222e0 end:0x021223bc
+
+src/func_ov074_021223bc.cpp:
+    complete
+    .text start:0x021223bc end:0x02122634
+
+src/func_ov074_02122634.cpp:
+    complete
+    .text start:0x02122634 end:0x02122764
+
+src/ExplosionGoomba_Spawn.cpp:
+    .text start:0x02122764 end:0x02122838
+
+src/Goomboss_Spawn.cpp:
+    .text start:0x02122838 end:0x0212290c
+
+src/__sinit_ov074_02122978.c:
+    .init start:0x02122978 end:0x02122d70

--- a/config/arm9/overlays/ov075/delinks.txt
+++ b/config/arm9/overlays/ov075/delinks.txt
@@ -4,3 +4,522 @@
     .ctor       start:0x0211c5a4 end:0x0211c5b0 kind:rodata align:4
     .data       start:0x0211c5c0 end:0x0211d380 kind:data align:32
     .bss        start:0x0211d380 end:0x0211d9c0 kind:bss align:32
+src/_ZN14UnknownVsEntryD1Ev.cpp:
+    .text start:0x02113ee0 end:0x02113f54
+
+src/_ZN14UnknownVsEntryD0Ev.c:
+    complete
+    .text start:0x02113f54 end:0x02113fdc
+
+src/func_ov075_02113fdc.c:
+    complete
+    .text start:0x02113fdc end:0x02114010
+
+src/func_ov075_02114010.c:
+    complete
+    .text start:0x02114010 end:0x021140e4
+
+src/func_ov075_021140e4.c:
+    complete
+    .text start:0x021140e4 end:0x021141b8
+
+src/func_ov075_021141b8.c:
+    complete
+    .text start:0x021141b8 end:0x02114218
+
+src/func_ov075_02114218.c:
+    complete
+    .text start:0x02114218 end:0x0211427c
+
+src/func_ov075_0211427c.c:
+    complete
+    .text start:0x0211427c end:0x021142fc
+
+src/func_ov075_021142fc.c:
+    complete
+    .text start:0x021142fc end:0x02114300
+
+src/func_ov075_02114300.cpp:
+    complete
+    .text start:0x02114300 end:0x02114390
+
+src/func_ov075_02114390.c:
+    complete
+    .text start:0x02114390 end:0x021143e4
+
+src/func_ov075_021143e4.cpp:
+    .text start:0x021143e4 end:0x02114560
+
+src/func_ov075_02114560.cpp:
+    complete
+    .text start:0x02114560 end:0x0211473c
+
+src/func_ov075_0211473c.cpp:
+    complete
+    .text start:0x0211473c end:0x0211478c
+
+src/func_ov075_0211478c.c:
+    complete
+    .text start:0x0211478c end:0x021147d4
+
+src/func_ov075_021147d4.cpp:
+    complete
+    .text start:0x021147d4 end:0x02114890
+
+src/func_ov075_02114890.c:
+    complete
+    .text start:0x02114890 end:0x02114894
+
+src/func_ov075_02114894.cpp:
+    complete
+    .text start:0x02114894 end:0x021148f0
+
+src/func_ov075_021148f0.c:
+    complete
+    .text start:0x021148f0 end:0x02114904
+
+src/func_ov075_02114904.c:
+    complete
+    .text start:0x02114904 end:0x02114988
+
+src/func_ov075_02114988.cpp:
+    complete
+    .text start:0x02114988 end:0x021149d0
+
+src/func_ov075_021149d0.c:
+    complete
+    .text start:0x021149d0 end:0x02114a58
+
+src/func_ov075_02114a58.c:
+    complete
+    .text start:0x02114a58 end:0x02114a6c
+
+src/func_ov075_02114a6c.c:
+    complete
+    .text start:0x02114a6c end:0x02114ac4
+
+src/func_ov075_02114ac4.cpp:
+    complete
+    .text start:0x02114ac4 end:0x02114b60
+
+src/func_ov075_02114b60.c:
+    complete
+    .text start:0x02114b60 end:0x02114be4
+
+src/func_ov075_02114be4.cpp:
+    complete
+    .text start:0x02114be4 end:0x02114cd8
+
+src/func_ov075_02114cd8.cpp:
+    .text start:0x02114cd8 end:0x02114ddc
+
+src/func_ov075_02114ddc.cpp:
+    .text start:0x02114ddc end:0x02114fa8
+
+src/func_ov075_02114fa8.c:
+    complete
+    .text start:0x02114fa8 end:0x0211505c
+
+src/func_ov075_0211505c.c:
+    complete
+    .text start:0x0211505c end:0x02115098
+
+src/func_ov075_02115098.c:
+    complete
+    .text start:0x02115098 end:0x02115134
+
+src/func_ov075_02115134.c:
+    complete
+    .text start:0x02115134 end:0x021151b4
+
+src/func_ov075_021151b4.c:
+    complete
+    .text start:0x021151b4 end:0x0211524c
+
+src/func_ov075_0211524c.c:
+    complete
+    .text start:0x0211524c end:0x02115290
+
+src/func_ov075_02115290.c:
+    complete
+    .text start:0x02115290 end:0x021152d4
+
+src/func_ov075_021152d4.cpp:
+    .text start:0x021152d4 end:0x02115388
+
+src/_ZN14UnknownVsEntry16CleanupResourcesEv.cpp:
+    .text start:0x02115388 end:0x021154cc
+
+src/_ZN14UnknownVsEntry6RenderEv.cpp:
+    complete
+    .text start:0x021154cc end:0x0211555c
+
+src/_ZN14UnknownVsEntry8BehaviorEv.cpp:
+    .text start:0x0211555c end:0x021156e0
+
+src/_ZN14UnknownVsEntry13InitResourcesEv.cpp:
+    .text start:0x021156e0 end:0x021159f4
+
+src/UnknownVsEntry_Spawn.cpp:
+    complete
+    .text start:0x021159f4 end:0x02115a88
+
+src/func_ov075_02115a88.c:
+    complete
+    .text start:0x02115a88 end:0x02115ab8
+
+src/func_ov075_02115ab8.cpp:
+    complete
+    .text start:0x02115ab8 end:0x02115b28
+
+src/func_ov075_02115b28.c:
+    complete
+    .text start:0x02115b28 end:0x02115bac
+
+src/func_ov075_02115bac.c:
+    complete
+    .text start:0x02115bac end:0x02115bc8
+
+src/func_ov075_02115bc8.c:
+    complete
+    .text start:0x02115bc8 end:0x02115bcc
+
+src/func_ov075_02115e1c.cpp:
+    complete
+    .text start:0x02115e1c end:0x02115e8c
+
+src/func_ov075_02115e8c.c:
+    complete
+    .text start:0x02115e8c end:0x0211601c
+
+src/func_ov075_0211601c.c:
+    complete
+    .text start:0x0211601c end:0x02116028
+
+src/func_ov075_02116028.c:
+    complete
+    .text start:0x02116028 end:0x02116030
+
+src/func_ov075_02116030.c:
+    complete
+    .text start:0x02116030 end:0x02116040
+
+src/func_ov075_02116040.c:
+    complete
+    .text start:0x02116040 end:0x021160b4
+
+src/func_ov075_021160b4.c:
+    complete
+    .text start:0x021160b4 end:0x021160dc
+
+src/func_ov075_021160dc.cpp:
+    complete
+    .text start:0x021160dc end:0x02116128
+
+src/func_ov075_02116ad4.c:
+    complete
+    .text start:0x02116ad4 end:0x02116c38
+
+src/func_ov075_02116c38.c:
+    complete
+    .text start:0x02116c38 end:0x02116c8c
+
+src/func_ov075_02116c8c.c:
+    complete
+    .text start:0x02116c8c end:0x02116ce4
+
+src/func_ov075_02116ce4.c:
+    complete
+    .text start:0x02116ce4 end:0x02116d40
+
+src/func_ov075_02116d40.c:
+    complete
+    .text start:0x02116d40 end:0x02116d9c
+
+src/func_ov075_02116d9c.c:
+    complete
+    .text start:0x02116d9c end:0x02116e00
+
+src/func_ov075_02116e00.c:
+    complete
+    .text start:0x02116e00 end:0x02116e44
+
+src/func_ov075_02116e44.c:
+    complete
+    .text start:0x02116e44 end:0x02116ebc
+
+src/func_ov075_02116ebc.c:
+    complete
+    .text start:0x02116ebc end:0x02116f40
+
+src/func_ov075_02116f40.cpp:
+    .text start:0x02116f40 end:0x0211705c
+
+src/func_ov075_021173a8.c:
+    complete
+    .text start:0x021173a8 end:0x02117590
+
+src/func_ov075_02117590.cpp:
+    .text start:0x02117590 end:0x0211763c
+
+src/func_ov075_0211763c.c:
+    complete
+    .text start:0x0211763c end:0x02117918
+
+src/func_ov075_02117918.c:
+    complete
+    .text start:0x02117918 end:0x02117ac4
+
+src/func_ov075_02117ac4.c:
+    complete
+    .text start:0x02117ac4 end:0x02117b58
+
+src/func_ov075_02117b58.cpp:
+    complete
+    .text start:0x02117b58 end:0x02117bc4
+
+src/func_ov075_02117bc4.c:
+    .text start:0x02117bc4 end:0x02117c0c
+
+src/func_ov075_02117c0c.c:
+    complete
+    .text start:0x02117c0c end:0x02117d80
+
+src/func_ov075_02117e84.c:
+    complete
+    .text start:0x02117e84 end:0x02117f5c
+
+src/func_ov075_02117f5c.c:
+    complete
+    .text start:0x02117f5c end:0x02117fe4
+
+src/func_ov075_02117fe4.c:
+    complete
+    .text start:0x02117fe4 end:0x02118248
+
+src/func_ov075_02118248.c:
+    complete
+    .text start:0x02118248 end:0x02118378
+
+src/func_ov075_02118378.c:
+    complete
+    .text start:0x02118378 end:0x021184b0
+
+src/func_ov075_021184b0.c:
+    complete
+    .text start:0x021184b0 end:0x0211867c
+
+src/func_ov075_021188b4.c:
+    complete
+    .text start:0x021188b4 end:0x02118a78
+
+src/func_ov075_02118a78.c:
+    complete
+    .text start:0x02118a78 end:0x02118a84
+
+src/func_ov075_02118a84.c:
+    complete
+    .text start:0x02118a84 end:0x02118bf8
+
+src/func_ov075_02118bf8.c:
+    complete
+    .text start:0x02118bf8 end:0x02118c80
+
+src/func_ov075_02118c80.cpp:
+    .text start:0x02118c80 end:0x02118cd0
+
+src/func_ov075_02118cd0.c:
+    complete
+    .text start:0x02118cd0 end:0x02118d1c
+
+src/func_ov075_02118d1c.c:
+    complete
+    .text start:0x02118d1c end:0x02118f38
+
+src/func_ov075_02118f38.c:
+    complete
+    .text start:0x02118f38 end:0x021190a4
+
+src/func_ov075_0211919c.c:
+    complete
+    .text start:0x0211919c end:0x021192bc
+
+src/func_ov075_021192bc.c:
+    complete
+    .text start:0x021192bc end:0x0211944c
+
+src/func_ov075_0211944c.c:
+    complete
+    .text start:0x0211944c end:0x021194e4
+
+src/func_ov075_021194e4.cpp:
+    .text start:0x021194e4 end:0x02119640
+
+src/func_ov075_02119640.c:
+    complete
+    .text start:0x02119640 end:0x021196d0
+
+src/func_ov075_021196d0.c:
+    complete
+    .text start:0x021196d0 end:0x0211977c
+
+src/func_ov075_0211977c.c:
+    complete
+    .text start:0x0211977c end:0x021197dc
+
+src/func_ov075_021197dc.c:
+    complete
+    .text start:0x021197dc end:0x021197e8
+
+src/func_ov075_021197e8.c:
+    complete
+    .text start:0x021197e8 end:0x02119918
+
+src/func_ov075_02119918.c:
+    complete
+    .text start:0x02119918 end:0x021199d8
+
+src/func_ov075_021199d8.cpp:
+    .text start:0x021199d8 end:0x02119b34
+
+src/func_ov075_02119b34.c:
+    complete
+    .text start:0x02119b34 end:0x02119c38
+
+src/func_ov075_02119c38.c:
+    complete
+    .text start:0x02119c38 end:0x02119cc0
+
+src/func_ov075_02119cc0.c:
+    complete
+    .text start:0x02119cc0 end:0x02119d3c
+
+src/func_ov075_02119d3c.c:
+    complete
+    .text start:0x02119d3c end:0x02119d78
+
+src/func_ov075_02119d78.c:
+    complete
+    .text start:0x02119d78 end:0x02119dc4
+
+src/func_ov075_0211a100.c:
+    complete
+    .text start:0x0211a100 end:0x0211a148
+
+src/func_ov075_0211a148.c:
+    complete
+    .text start:0x0211a148 end:0x0211a194
+
+src/func_ov075_0211a194.cpp:
+    complete
+    .text start:0x0211a194 end:0x0211a210
+
+src/func_ov075_0211a210.c:
+    complete
+    .text start:0x0211a210 end:0x0211a268
+
+src/func_ov075_0211a268.c:
+    complete
+    .text start:0x0211a268 end:0x0211a26c
+
+src/func_ov075_0211a26c.cpp:
+    .text start:0x0211a26c end:0x0211a2b8
+
+src/func_ov075_0211a2b8.cpp:
+    complete
+    .text start:0x0211a2b8 end:0x0211a410
+
+src/func_ov075_0211a410.cpp:
+    .text start:0x0211a410 end:0x0211a734
+
+src/func_ov075_0211a734.c:
+    complete
+    .text start:0x0211a734 end:0x0211a740
+
+src/func_ov075_0211a740.c:
+    complete
+    .text start:0x0211a740 end:0x0211a834
+
+src/func_ov075_0211a834.c:
+    complete
+    .text start:0x0211a834 end:0x0211a838
+
+src/func_ov075_0211a838.c:
+    complete
+    .text start:0x0211a838 end:0x0211a854
+
+src/func_ov075_0211a854.c:
+    complete
+    .text start:0x0211a854 end:0x0211a948
+
+src/func_ov075_0211aa00.c:
+    complete
+    .text start:0x0211aa00 end:0x0211aa94
+
+src/func_ov075_0211aa94.c:
+    complete
+    .text start:0x0211aa94 end:0x0211ab38
+
+src/func_ov075_0211ab38.c:
+    complete
+    .text start:0x0211ab38 end:0x0211abb0
+
+src/func_ov075_0211abb0.c:
+    complete
+    .text start:0x0211abb0 end:0x0211ad60
+
+src/func_ov075_0211ad60.c:
+    complete
+    .text start:0x0211ad60 end:0x0211addc
+
+src/func_ov075_0211addc.cpp:
+    complete
+    .text start:0x0211addc end:0x0211aea4
+
+src/func_ov075_0211aea4.c:
+    complete
+    .text start:0x0211aea4 end:0x0211aeb8
+
+src/func_ov075_0211aeb8.c:
+    complete
+    .text start:0x0211aeb8 end:0x0211af0c
+
+src/func_ov075_0211af0c.c:
+    complete
+    .text start:0x0211af0c end:0x0211af84
+
+src/func_ov075_0211af84.c:
+    complete
+    .text start:0x0211af84 end:0x0211afb0
+
+src/func_ov075_0211b1cc.c:
+    .text start:0x0211b1cc end:0x0211b260
+
+src/func_ov075_0211b260.c:
+    complete
+    .text start:0x0211b260 end:0x0211b3b8
+
+src/func_ov075_0211b3b8.c:
+    complete
+    .text start:0x0211b3b8 end:0x0211b3d8
+
+src/func_ov075_0211b3d8.cpp:
+    complete
+    .text start:0x0211b3d8 end:0x0211b418
+
+src/func_ov075_0211b418.cpp:
+    complete
+    .text start:0x0211b418 end:0x0211b458
+
+src/func_ov075_0211b458.cpp:
+    complete
+    .text start:0x0211b458 end:0x0211b524
+
+src/__sinit_ov075_0211b5e0.c:
+    .init start:0x0211b5e0 end:0x0211bb00
+
+src/__sinit_ov075_0211bb00.c:
+    .init start:0x0211bb00 end:0x0211c51c
+
+src/__sinit_ov075_0211c51c.c:
+    .init start:0x0211c51c end:0x0211c5a4

--- a/config/arm9/overlays/ov077/delinks.txt
+++ b/config/arm9/overlays/ov077/delinks.txt
@@ -4,3 +4,353 @@
     .ctor       start:0x021277cc end:0x021277d8 kind:rodata align:4
     .data       start:0x021277e0 end:0x02127b20 kind:data align:32
     .bss        start:0x02127b20 end:0x02127d40 kind:bss align:32
+src/_ZN6LakituD1Ev.cpp:
+    .text start:0x02123740 end:0x02123798
+
+src/_ZN6LakituD0Ev.c:
+    complete
+    .text start:0x02123798 end:0x02123804
+
+src/func_ov077_02123804.c:
+    complete
+    .text start:0x02123804 end:0x0212380c
+
+src/func_ov077_0212380c.c:
+    complete
+    .text start:0x0212380c end:0x02123814
+
+src/func_ov077_02123814.c:
+    complete
+    .text start:0x02123814 end:0x02123880
+
+src/func_ov077_02123880.c:
+    complete
+    .text start:0x02123880 end:0x021238bc
+
+src/func_ov077_021238bc.cpp:
+    complete
+    .text start:0x021238bc end:0x0212390c
+
+src/func_ov077_0212390c.cpp:
+    complete
+    .text start:0x0212390c end:0x02123a1c
+
+src/func_ov077_02123a1c.cpp:
+    complete
+    .text start:0x02123a1c end:0x02123a74
+
+src/func_ov077_02123a74.cpp:
+    complete
+    .text start:0x02123a74 end:0x02123c6c
+
+src/func_ov077_02123c6c.cpp:
+    .text start:0x02123c6c end:0x02123d40
+
+src/func_ov077_02123d40.cpp:
+    complete
+    .text start:0x02123d40 end:0x02123fcc
+
+src/func_ov077_02123fcc.c:
+    complete
+    .text start:0x02123fcc end:0x02124038
+
+src/func_ov077_02124038.cpp:
+    complete
+    .text start:0x02124038 end:0x02124118
+
+src/func_ov077_02124118.cpp:
+    complete
+    .text start:0x02124118 end:0x021241ac
+
+src/func_ov077_021241ac.c:
+    complete
+    .text start:0x021241ac end:0x021242f0
+
+src/func_ov077_021242f0.c:
+    complete
+    .text start:0x021242f0 end:0x02124394
+
+src/func_ov077_02124394.c:
+    complete
+    .text start:0x02124394 end:0x021243c0
+
+src/func_ov077_021243c0.cpp:
+    complete
+    .text start:0x021243c0 end:0x021244d4
+
+src/func_ov077_021244d4.cpp:
+    .text start:0x021244d4 end:0x02124564
+
+src/func_ov077_02124564.c:
+    complete
+    .text start:0x02124564 end:0x02124698
+
+src/func_ov077_02124698.c:
+    complete
+    .text start:0x02124698 end:0x02124718
+
+src/func_ov077_02124718.cpp:
+    complete
+    .text start:0x02124718 end:0x02124754
+
+src/func_ov077_02124754.cpp:
+    complete
+    .text start:0x02124754 end:0x0212478c
+
+src/func_ov077_0212478c.c:
+    complete
+    .text start:0x0212478c end:0x021247a8
+
+src/_ZN6Lakitu16CleanupResourcesEv.c:
+    complete
+    .text start:0x021247a8 end:0x02124824
+
+src/_ZN6Lakitu16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02124824 end:0x02124828
+
+src/_ZN6Lakitu6RenderEv.cpp:
+    complete
+    .text start:0x02124828 end:0x021248b8
+
+src/_ZN6Lakitu8BehaviorEv.cpp:
+    .text start:0x021248b8 end:0x02124908
+
+src/_ZN6Lakitu13InitResourcesEv.cpp:
+    .text start:0x02124908 end:0x02124aa4
+
+src/func_ov077_02124aa4.cpp:
+    complete
+    .text start:0x02124aa4 end:0x02124b04
+
+src/Lakitu_Spawn.c:
+    complete
+    .text start:0x02124b04 end:0x02124b64
+
+src/_ZN5SpinyD1Ev.cpp:
+    .text start:0x02124b64 end:0x02124bb4
+
+src/_ZN5SpinyD0Ev.c:
+    complete
+    .text start:0x02124bb4 end:0x02124c18
+
+src/func_ov077_02124c18.c:
+    complete
+    .text start:0x02124c18 end:0x02124c20
+
+src/func_ov077_02124c20.c:
+    complete
+    .text start:0x02124c20 end:0x02124c28
+
+src/func_ov077_02124c28.cpp:
+    complete
+    .text start:0x02124c28 end:0x02124ce4
+
+src/func_ov077_02124ce4.c:
+    complete
+    .text start:0x02124ce4 end:0x02124d08
+
+src/func_ov077_02124d08.cpp:
+    .text start:0x02124d08 end:0x02124eb0
+
+src/func_ov077_02124eb0.cpp:
+    complete
+    .text start:0x02124eb0 end:0x021250a8
+
+src/func_ov077_021250a8.cpp:
+    complete
+    .text start:0x021250a8 end:0x021251d0
+
+src/func_ov077_021251d0.cpp:
+    complete
+    .text start:0x021251d0 end:0x02125290
+
+src/func_ov077_02125290.c:
+    complete
+    .text start:0x02125290 end:0x02125304
+
+src/func_ov077_02125304.cpp:
+    complete
+    .text start:0x02125304 end:0x021253a4
+
+src/func_ov077_021253a4.cpp:
+    complete
+    .text start:0x021253a4 end:0x02125480
+
+src/func_ov077_02125480.cpp:
+    complete
+    .text start:0x02125480 end:0x02125550
+
+src/func_ov077_02125550.cpp:
+    .text start:0x02125550 end:0x021256b4
+
+src/func_ov077_021256b4.c:
+    complete
+    .text start:0x021256b4 end:0x02125830
+
+src/func_ov077_02125830.c:
+    complete
+    .text start:0x02125830 end:0x021258dc
+
+src/func_ov077_021258dc.c:
+    complete
+    .text start:0x021258dc end:0x02125908
+
+src/func_ov077_02125908.c:
+    complete
+    .text start:0x02125908 end:0x02125a0c
+
+src/func_ov077_02125a0c.c:
+    complete
+    .text start:0x02125a0c end:0x02125a54
+
+src/func_ov077_02125a54.c:
+    complete
+    .text start:0x02125a54 end:0x02125b1c
+
+src/func_ov077_02125b1c.cpp:
+    complete
+    .text start:0x02125b1c end:0x02125bb4
+
+src/func_ov077_02125bb4.c:
+    complete
+    .text start:0x02125bb4 end:0x02125dd4
+
+src/func_ov077_02125dd4.c:
+    complete
+    .text start:0x02125dd4 end:0x02125e20
+
+src/func_ov077_02125e20.cpp:
+    complete
+    .text start:0x02125e20 end:0x02125e5c
+
+src/func_ov077_02125e5c.cpp:
+    complete
+    .text start:0x02125e5c end:0x02125e94
+
+src/func_ov077_02125e94.c:
+    complete
+    .text start:0x02125e94 end:0x02125eb0
+
+src/_ZN5Spiny16CleanupResourcesEv.c:
+    complete
+    .text start:0x02125eb0 end:0x02125eec
+
+src/_ZN5Spiny16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02125eec end:0x02125ef0
+
+src/_ZN5Spiny6RenderEv.cpp:
+    complete
+    .text start:0x02125ef0 end:0x02125f68
+
+src/_ZN5Spiny8BehaviorEv.cpp:
+    complete
+    .text start:0x02125f68 end:0x02126058
+
+src/_ZN5Spiny13InitResourcesEv.cpp:
+    .text start:0x02126058 end:0x02126194
+
+src/func_ov077_02126194.cpp:
+    complete
+    .text start:0x02126194 end:0x021261f4
+
+src/Spiny_Spawn.c:
+    complete
+    .text start:0x021261f4 end:0x0212624c
+
+src/_ZN7HeaveHoD1Ev.c:
+    complete
+    .text start:0x0212624c end:0x0212629c
+
+src/_ZN7HeaveHoD0Ev.c:
+    complete
+    .text start:0x0212629c end:0x02126300
+
+src/func_ov077_02126300.c:
+    complete
+    .text start:0x02126300 end:0x02126528
+
+src/func_ov077_02126528.cpp:
+    complete
+    .text start:0x02126528 end:0x02126640
+
+src/func_ov077_02126640.cpp:
+    complete
+    .text start:0x02126640 end:0x02126758
+
+src/func_ov077_02126758.cpp:
+    complete
+    .text start:0x02126758 end:0x0212679c
+
+src/func_ov077_0212679c.c:
+    complete
+    .text start:0x0212679c end:0x02126930
+
+src/func_ov077_02126930.cpp:
+    complete
+    .text start:0x02126930 end:0x021269a8
+
+src/func_ov077_021269a8.cpp:
+    complete
+    .text start:0x021269a8 end:0x02126a04
+
+src/func_ov077_02126a04.c:
+    complete
+    .text start:0x02126a04 end:0x02126a50
+
+src/func_ov077_02126a50.c:
+    complete
+    .text start:0x02126a50 end:0x02126a84
+
+src/func_ov077_02126a84.c:
+    complete
+    .text start:0x02126a84 end:0x02126ad0
+
+src/func_ov077_02126ad0.c:
+    .text start:0x02126ad0 end:0x02126cd4
+
+src/func_ov077_02126cd4.cpp:
+    complete
+    .text start:0x02126cd4 end:0x02126d5c
+
+src/func_ov077_02126d5c.cpp:
+    complete
+    .text start:0x02126d5c end:0x02126dac
+
+src/func_ov077_02126dac.c:
+    complete
+    .text start:0x02126dac end:0x02126dec
+
+src/_ZN7HeaveHo16CleanupResourcesEv.c:
+    complete
+    .text start:0x02126dec end:0x02126e34
+
+src/_ZN7HeaveHo16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02126e34 end:0x02126e38
+
+src/_ZN7HeaveHo6RenderEv.cpp:
+    complete
+    .text start:0x02126e38 end:0x02126e88
+
+src/_ZN7HeaveHo8BehaviorEv.cpp:
+    complete
+    .text start:0x02126e88 end:0x0212706c
+
+src/_ZN7HeaveHo13InitResourcesEv.cpp:
+    complete
+    .text start:0x0212706c end:0x021271d4
+
+src/HeaveHo_Spawn.c:
+    complete
+    .text start:0x021271d4 end:0x02127230
+
+src/__sinit_ov077_02127240.c:
+    .init start:0x02127240 end:0x0212749c
+
+src/__sinit_ov077_0212749c.c:
+    .init start:0x0212749c end:0x021275fc
+
+src/__sinit_ov077_021275fc.c:
+    .init start:0x021275fc end:0x021277cc

--- a/config/arm9/overlays/ov078/delinks.txt
+++ b/config/arm9/overlays/ov078/delinks.txt
@@ -3,3 +3,204 @@
     .ctor       start:0x02126cd4 end:0x02126cd8 kind:rodata align:4
     .data       start:0x02126ce0 end:0x02126ee0 kind:data align:32
     .bss        start:0x02126ee0 end:0x02127140 kind:bss align:32
+src/_ZN10KingBobOmbD1Ev.c:
+    complete
+    .text start:0x02123740 end:0x02123798
+
+src/_ZN10KingBobOmbD0Ev.c:
+    complete
+    .text start:0x02123798 end:0x02123804
+
+src/func_ov078_02123804.c:
+    complete
+    .text start:0x02123804 end:0x02123864
+
+src/func_ov078_02123864.c:
+    complete
+    .text start:0x02123864 end:0x021238ac
+
+src/func_ov078_021238ac.c:
+    complete
+    .text start:0x021238ac end:0x02123a3c
+
+src/func_ov078_02123a3c.c:
+    complete
+    .text start:0x02123a3c end:0x02123aa0
+
+src/func_ov078_02123aa0.c:
+    complete
+    .text start:0x02123aa0 end:0x02123bc4
+
+src/func_ov078_02123bc4.cpp:
+    .text start:0x02123bc4 end:0x02123c20
+
+src/func_ov078_02123c20.cpp:
+    complete
+    .text start:0x02123c20 end:0x02123cf0
+
+src/func_ov078_02123cf0.cpp:
+    complete
+    .text start:0x02123cf0 end:0x02123d3c
+
+src/func_ov078_02123d3c.c:
+    complete
+    .text start:0x02123d3c end:0x02123eb8
+
+src/func_ov078_02123eb8.c:
+    complete
+    .text start:0x02123eb8 end:0x02123f1c
+
+src/func_ov078_02123f1c.cpp:
+    complete
+    .text start:0x02123f1c end:0x02123fb4
+
+src/func_ov078_02123fb4.cpp:
+    complete
+    .text start:0x02123fb4 end:0x02124000
+
+src/func_ov078_02124000.c:
+    complete
+    .text start:0x02124000 end:0x02124060
+
+src/func_ov078_02124060.cpp:
+    complete
+    .text start:0x02124060 end:0x021240a0
+
+src/func_ov078_021240a0.c:
+    .text start:0x021240a0 end:0x021243c0
+
+src/func_ov078_021243c0.cpp:
+    complete
+    .text start:0x021243c0 end:0x02124470
+
+src/func_ov078_02124470.c:
+    complete
+    .text start:0x02124470 end:0x021244d0
+
+src/func_ov078_021244d0.c:
+    complete
+    .text start:0x021244d0 end:0x02124520
+
+src/func_ov078_02124520.c:
+    complete
+    .text start:0x02124520 end:0x02124778
+
+src/func_ov078_02124778.cpp:
+    complete
+    .text start:0x02124778 end:0x021247bc
+
+src/func_ov078_021247bc.c:
+    complete
+    .text start:0x021247bc end:0x02124b40
+
+src/func_ov078_02124b40.c:
+    complete
+    .text start:0x02124b40 end:0x02124bc4
+
+src/func_ov078_02124bc4.cpp:
+    complete
+    .text start:0x02124bc4 end:0x02124c94
+
+src/func_ov078_02124c94.c:
+    complete
+    .text start:0x02124c94 end:0x02124cf4
+
+src/func_ov078_02124cf4.cpp:
+    .text start:0x02124cf4 end:0x02124e9c
+
+src/func_ov078_02124e9c.c:
+    complete
+    .text start:0x02124e9c end:0x02124f28
+
+src/func_ov078_02124f28.cpp:
+    complete
+    .text start:0x02124f28 end:0x021250d0
+
+src/func_ov078_021250d0.c:
+    complete
+    .text start:0x021250d0 end:0x021250f8
+
+src/func_ov078_021250f8.c:
+    complete
+    .text start:0x021250f8 end:0x02125350
+
+src/func_ov078_02125350.c:
+    complete
+    .text start:0x02125350 end:0x02125448
+
+src/func_ov078_02125448.c:
+    complete
+    .text start:0x02125448 end:0x02125734
+
+src/func_ov078_02125734.c:
+    complete
+    .text start:0x02125734 end:0x02125790
+
+src/func_ov078_02125790.cpp:
+    .text start:0x02125790 end:0x021258e4
+
+src/func_ov078_021258e4.c:
+    complete
+    .text start:0x021258e4 end:0x02125950
+
+src/func_ov078_02125950.cpp:
+    .text start:0x02125950 end:0x021259e4
+
+src/func_ov078_021259e4.c:
+    complete
+    .text start:0x021259e4 end:0x021259ec
+
+src/func_ov078_021259ec.c:
+    complete
+    .text start:0x021259ec end:0x02125bc8
+
+src/func_ov078_02125bc8.cpp:
+    .text start:0x02125bc8 end:0x02125c24
+
+src/func_ov078_02125c24.c:
+    complete
+    .text start:0x02125c24 end:0x02125c48
+
+src/KingBobOmb_SetState.cpp:
+    complete
+    .text start:0x02125c48 end:0x02125c98
+
+src/func_ov078_02125c98.cpp:
+    complete
+    .text start:0x02125c98 end:0x02125de0
+
+src/func_ov078_02125de0.c:
+    complete
+    .text start:0x02125de0 end:0x02125f8c
+
+src/func_ov078_02125f8c.cpp:
+    complete
+    .text start:0x02125f8c end:0x02125ff4
+
+src/_ZN10KingBobOmb16CleanupResourcesEv.c:
+    complete
+    .text start:0x02125ff4 end:0x021260a8
+
+src/_ZN10KingBobOmb16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021260a8 end:0x021260ac
+
+src/_ZN10KingBobOmb6RenderEv.cpp:
+    .text start:0x021260ac end:0x02126104
+
+src/_ZN10KingBobOmb8BehaviorEv.cpp:
+    .text start:0x02126104 end:0x02126368
+
+src/_ZN10KingBobOmb13InitResourcesEv.cpp:
+    .text start:0x02126368 end:0x021265f4
+
+src/func_ov078_021265f4.c:
+    complete
+    .text start:0x021265f4 end:0x021265fc
+
+src/KingBobOmb_Spawn.c:
+    complete
+    .text start:0x021265fc end:0x02126660
+
+src/__sinit_ov078_02126660.c:
+    .init start:0x02126660 end:0x02126cd4

--- a/config/arm9/overlays/ov079/delinks.txt
+++ b/config/arm9/overlays/ov079/delinks.txt
@@ -4,3 +4,264 @@
     .ctor       start:0x02127b88 end:0x02127b98 kind:rodata align:4
     .data       start:0x02127ba0 end:0x02128140 kind:data align:32
     .bss        start:0x02128140 end:0x021283a0 kind:bss align:32
+src/_ZN5WhompD1Ev.c:
+    complete
+    .text start:0x02123740 end:0x02123798
+
+src/_ZN5WhompD0Ev.c:
+    complete
+    .text start:0x02123798 end:0x02123804
+
+src/func_ov079_02123804.c:
+    complete
+    .text start:0x02123804 end:0x02123a8c
+
+src/func_ov079_02123a8c.cpp:
+    .text start:0x02123a8c end:0x02123b54
+
+src/func_ov079_02123b54.c:
+    complete
+    .text start:0x02123b54 end:0x02123b60
+
+src/func_ov079_02123b60.c:
+    complete
+    .text start:0x02123b60 end:0x02123bcc
+
+src/func_ov079_02123bcc.c:
+    complete
+    .text start:0x02123bcc end:0x02123d4c
+
+src/func_ov079_02123d4c.cpp:
+    complete
+    .text start:0x02123d4c end:0x02123e60
+
+src/func_ov079_02123e60.cpp:
+    .text start:0x02123e60 end:0x02123f34
+
+src/func_ov079_02123f34.c:
+    complete
+    .text start:0x02123f34 end:0x02124008
+
+src/func_ov079_02124008.c:
+    complete
+    .text start:0x02124008 end:0x02124188
+
+src/func_ov079_02124188.c:
+    complete
+    .text start:0x02124188 end:0x021243e0
+
+src/func_ov079_021243e0.c:
+    complete
+    .text start:0x021243e0 end:0x02124530
+
+src/func_ov079_02124530.c:
+    complete
+    .text start:0x02124530 end:0x02124638
+
+src/func_ov079_02124638.c:
+    complete
+    .text start:0x02124638 end:0x021246d8
+
+src/func_ov079_021246d8.c:
+    complete
+    .text start:0x021246d8 end:0x021246dc
+
+src/func_ov079_021246dc.c:
+    complete
+    .text start:0x021246dc end:0x021249f0
+
+src/func_ov079_021249f0.c:
+    complete
+    .text start:0x021249f0 end:0x02124b08
+
+src/func_ov079_02124b08.c:
+    complete
+    .text start:0x02124b08 end:0x02124dec
+
+src/func_ov079_02124dec.cpp:
+    complete
+    .text start:0x02124dec end:0x02124ed4
+
+src/func_ov079_02124ed4.c:
+    complete
+    .text start:0x02124ed4 end:0x02125058
+
+src/func_ov079_02125058.cpp:
+    complete
+    .text start:0x02125058 end:0x0212522c
+
+src/func_ov079_0212522c.c:
+    complete
+    .text start:0x0212522c end:0x02125240
+
+src/func_ov079_02125240.cpp:
+    .text start:0x02125240 end:0x0212538c
+
+src/func_ov079_0212538c.c:
+    complete
+    .text start:0x0212538c end:0x021254b4
+
+src/func_ov079_021254b4.c:
+    complete
+    .text start:0x021254b4 end:0x02125504
+
+src/func_ov079_02125504.c:
+    complete
+    .text start:0x02125504 end:0x021256d4
+
+src/func_ov079_021256d4.c:
+    complete
+    .text start:0x021256d4 end:0x021258fc
+
+src/func_ov079_021258fc.c:
+    complete
+    .text start:0x021258fc end:0x02125b44
+
+src/func_ov079_02125b44.c:
+    complete
+    .text start:0x02125b44 end:0x02125eb0
+
+src/_ZN5Whomp16CleanupResourcesEv.cpp:
+    .text start:0x02125eb0 end:0x02125f78
+
+src/_ZN5Whomp6RenderEv.cpp:
+    complete
+    .text start:0x02125f78 end:0x02125fcc
+
+src/_ZN5Whomp8BehaviorEv.cpp:
+    complete
+    .text start:0x02125fcc end:0x02126164
+
+src/_ZN5Whomp13InitResourcesEv.cpp:
+    .text start:0x02126164 end:0x02126588
+
+src/WhompKing_Spawn.c:
+    complete
+    .text start:0x02126588 end:0x021265e8
+
+src/Whomp_Spawn.c:
+    complete
+    .text start:0x021265e8 end:0x02126648
+
+src/_ZN10BulletBillD1Ev.c:
+    complete
+    .text start:0x02126648 end:0x02126698
+
+src/_ZN10BulletBillD0Ev.c:
+    complete
+    .text start:0x02126698 end:0x021266fc
+
+src/func_ov079_021266fc.c:
+    complete
+    .text start:0x021266fc end:0x02126704
+
+src/func_ov079_02126704.c:
+    complete
+    .text start:0x02126704 end:0x02126794
+
+src/func_ov079_02126794.cpp:
+    complete
+    .text start:0x02126794 end:0x0212682c
+
+src/func_ov079_0212682c.c:
+    complete
+    .text start:0x0212682c end:0x02126a18
+
+src/_ZN10BulletBill16CleanupResourcesEv.c:
+    complete
+    .text start:0x02126a18 end:0x02126a48
+
+src/_ZN10BulletBill6RenderEv.cpp:
+    complete
+    .text start:0x02126a48 end:0x02126a84
+
+src/_ZN10BulletBill8BehaviorEv.cpp:
+    complete
+    .text start:0x02126a84 end:0x02126c44
+
+src/_ZN10BulletBill13InitResourcesEv.c:
+    complete
+    .text start:0x02126c44 end:0x02126d64
+
+src/BulletBill_Spawn.c:
+    complete
+    .text start:0x02126d64 end:0x02126dbc
+
+src/func_ov079_02126dbc.c:
+    .text start:0x02126dbc end:0x02126e00
+
+src/func_ov079_02126e00.c:
+    .text start:0x02126e00 end:0x02126e58
+
+src/func_ov079_02126e58.cpp:
+    complete
+    .text start:0x02126e58 end:0x02126ecc
+
+src/func_ov079_02126ecc.cpp:
+    .text start:0x02126ecc end:0x02126f04
+
+src/func_ov079_02126f04.c:
+    complete
+    .text start:0x02126f04 end:0x02126f64
+
+src/func_ov079_02126f64.cpp:
+    complete
+    .text start:0x02126f64 end:0x02126f8c
+
+src/func_ov079_02126f8c.cpp:
+    .text start:0x02126f8c end:0x02127090
+
+src/func_ov079_02127090.cpp:
+    complete
+    .text start:0x02127090 end:0x021271b4
+
+src/BillBlaster_Spawn.c:
+    complete
+    .text start:0x021271b4 end:0x021271e4
+
+src/_ZN12FortressWallD1Ev.c:
+    .text start:0x021271e4 end:0x02127228
+
+src/_ZN12FortressWallD0Ev.c:
+    .text start:0x02127228 end:0x02127280
+
+src/func_ov079_02127280.cpp:
+    complete
+    .text start:0x02127280 end:0x021272e0
+
+src/func_ov079_021272e0.cpp:
+    complete
+    .text start:0x021272e0 end:0x02127300
+
+src/_ZN12FortressWall16CleanupResourcesEv.cpp:
+    .text start:0x02127300 end:0x02127364
+
+src/_ZN12FortressWall6RenderEv.cpp:
+    complete
+    .text start:0x02127364 end:0x021273a4
+
+src/_ZN12FortressWall8BehaviorEv.cpp:
+    .text start:0x021273a4 end:0x02127494
+
+src/_ZN12FortressWall13InitResourcesEv.cpp:
+    .text start:0x02127494 end:0x0212757c
+
+src/FortressWall_Spawn.c:
+    complete
+    .text start:0x0212757c end:0x021275ac
+
+src/FortressWallBreakable_Spawn.c:
+    complete
+    .text start:0x021275ac end:0x021275dc
+
+src/__sinit_ov079_02127618.c:
+    .init start:0x02127618 end:0x021279d4
+
+src/__sinit_ov079_021279d4.c:
+    .init start:0x021279d4 end:0x02127a10
+
+src/__sinit_ov079_02127a10.c:
+    .init start:0x02127a10 end:0x02127acc
+
+src/__sinit_ov079_02127acc.c:
+    .init start:0x02127acc end:0x02127b88

--- a/config/arm9/overlays/ov080/delinks.txt
+++ b/config/arm9/overlays/ov080/delinks.txt
@@ -4,3 +4,331 @@
     .ctor       start:0x02127f60 end:0x02127f6c kind:rodata align:4
     .data       start:0x02127f80 end:0x021283c0 kind:data align:32
     .bss        start:0x021283c0 end:0x02128860 kind:bss align:32
+src/_ZN9MontyMoleD1Ev.cpp:
+    .text start:0x02123740 end:0x02123778
+
+src/_ZN9MontyMoleD0Ev.c:
+    complete
+    .text start:0x02123778 end:0x021237c4
+
+src/_ZN13MontyMoleRockD1Ev.c:
+    complete
+    .text start:0x021237c4 end:0x02123804
+
+src/_ZN13MontyMoleRockD0Ev.c:
+    complete
+    .text start:0x02123804 end:0x02123858
+
+src/func_ov080_02123858.c:
+    complete
+    .text start:0x02123858 end:0x02123860
+
+src/func_ov080_02123860.c:
+    complete
+    .text start:0x02123860 end:0x02123924
+
+src/func_ov080_02123924.cpp:
+    complete
+    .text start:0x02123924 end:0x02123a34
+
+src/func_ov080_02123a34.cpp:
+    .text start:0x02123a34 end:0x02123c24
+
+src/func_ov080_02123c24.c:
+    complete
+    .text start:0x02123c24 end:0x02123ecc
+
+src/func_ov080_02123ecc.cpp:
+    .text start:0x02123ecc end:0x02123fcc
+
+src/func_ov080_02123fcc.cpp:
+    complete
+    .text start:0x02123fcc end:0x02124088
+
+src/func_ov080_02124088.cpp:
+    .text start:0x02124088 end:0x02124208
+
+src/func_ov080_02124208.c:
+    complete
+    .text start:0x02124208 end:0x02124360
+
+src/func_ov080_02124360.c:
+    .text start:0x02124360 end:0x021243d8
+
+src/func_ov080_021243d8.c:
+    complete
+    .text start:0x021243d8 end:0x02124418
+
+src/func_ov080_02124418.c:
+    complete
+    .text start:0x02124418 end:0x02124458
+
+src/_ZN9MontyMole16CleanupResourcesEv.c:
+    complete
+    .text start:0x02124458 end:0x021244b4
+
+src/_ZN13MontyMoleRock16CleanupResourcesEv.c:
+    complete
+    .text start:0x021244b4 end:0x021244d8
+
+src/_ZN9MontyMole6RenderEv.cpp:
+    complete
+    .text start:0x021244d8 end:0x02124500
+
+src/_ZN13MontyMoleRock6RenderEv.cpp:
+    complete
+    .text start:0x02124500 end:0x02124530
+
+src/_ZN9MontyMole8BehaviorEv.cpp:
+    complete
+    .text start:0x02124530 end:0x0212459c
+
+src/_ZN13MontyMoleRock8BehaviorEv.cpp:
+    .text start:0x0212459c end:0x0212478c
+
+src/_ZN9MontyMole13InitResourcesEv.cpp:
+    .text start:0x0212478c end:0x021248b4
+
+src/_ZN13MontyMoleRock13InitResourcesEv.cpp:
+    complete
+    .text start:0x021248b4 end:0x02124998
+
+src/MontyMoleRock_Spawn.c:
+    complete
+    .text start:0x02124998 end:0x021249e0
+
+src/MontyMole_Spawn.c:
+    complete
+    .text start:0x021249e0 end:0x02124a20
+
+src/_ZN11CrazedCrateD1Ev.cpp:
+    .text start:0x02124a20 end:0x02124a68
+
+src/_ZN11CrazedCrateD0Ev.c:
+    complete
+    .text start:0x02124a68 end:0x02124ac4
+
+src/func_ov080_02124ac4.c:
+    complete
+    .text start:0x02124ac4 end:0x02124acc
+
+src/func_ov080_02124acc.cpp:
+    complete
+    .text start:0x02124acc end:0x02124c3c
+
+src/func_ov080_02124c3c.cpp:
+    complete
+    .text start:0x02124c3c end:0x02124e60
+
+src/func_ov080_02124e60.c:
+    complete
+    .text start:0x02124e60 end:0x02124eb0
+
+src/func_ov080_02124eb0.c:
+    complete
+    .text start:0x02124eb0 end:0x02124edc
+
+src/func_ov080_02124edc.cpp:
+    complete
+    .text start:0x02124edc end:0x02124fec
+
+src/func_ov080_02124fec.c:
+    complete
+    .text start:0x02124fec end:0x0212500c
+
+src/func_ov080_0212500c.cpp:
+    complete
+    .text start:0x0212500c end:0x0212509c
+
+src/func_ov080_0212509c.c:
+    complete
+    .text start:0x0212509c end:0x021250c8
+
+src/func_ov080_021250c8.cpp:
+    complete
+    .text start:0x021250c8 end:0x02125104
+
+src/func_ov080_02125104.cpp:
+    complete
+    .text start:0x02125104 end:0x0212513c
+
+src/func_ov080_0212513c.c:
+    complete
+    .text start:0x0212513c end:0x02125158
+
+src/_ZN11CrazedCrate16CleanupResourcesEv.c:
+    complete
+    .text start:0x02125158 end:0x0212517c
+
+src/_ZN11CrazedCrate16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212517c end:0x02125180
+
+src/_ZN11CrazedCrate6RenderEv.cpp:
+    complete
+    .text start:0x02125180 end:0x021251cc
+
+src/_ZN11CrazedCrate8BehaviorEv.cpp:
+    .text start:0x021251cc end:0x021251ec
+
+src/_ZN11CrazedCrate13InitResourcesEv.cpp:
+    .text start:0x021251ec end:0x02125318
+
+src/func_ov080_02125318.cpp:
+    complete
+    .text start:0x02125318 end:0x021253b4
+
+src/CrazedCrate_Spawn.c:
+    complete
+    .text start:0x021253b4 end:0x02125404
+
+src/func_ov080_02125404.c:
+    complete
+    .text start:0x02125404 end:0x02125428
+
+src/func_ov080_02125428.c:
+    .text start:0x02125428 end:0x02125460
+
+src/func_ov080_0212555c.c:
+    complete
+    .text start:0x0212555c end:0x02125630
+
+src/func_ov080_02125630.cpp:
+    complete
+    .text start:0x02125630 end:0x021256f8
+
+src/func_ov080_021256f8.c:
+    complete
+    .text start:0x021256f8 end:0x02125940
+
+src/func_ov080_02125940.c:
+    complete
+    .text start:0x02125940 end:0x02125af0
+
+src/func_ov080_02125af0.c:
+    complete
+    .text start:0x02125af0 end:0x02125bb0
+
+src/func_ov080_02125bb0.c:
+    complete
+    .text start:0x02125bb0 end:0x02125cd4
+
+src/func_ov080_02125cd4.c:
+    .text start:0x02125cd4 end:0x02125d08
+
+src/func_ov080_02125d08.c:
+    complete
+    .text start:0x02125d08 end:0x02125d64
+
+src/func_ov080_02125d64.c:
+    complete
+    .text start:0x02125d64 end:0x02125de0
+
+src/func_ov080_02125de0.c:
+    complete
+    .text start:0x02125de0 end:0x02125f00
+
+src/func_ov080_02125f00.c:
+    complete
+    .text start:0x02125f00 end:0x02125fd0
+
+src/func_ov080_02125fd0.c:
+    complete
+    .text start:0x02125fd0 end:0x02126120
+
+src/func_ov080_02126120.c:
+    complete
+    .text start:0x02126120 end:0x02126124
+
+src/func_ov080_02126124.c:
+    complete
+    .text start:0x02126124 end:0x021261f4
+
+src/func_ov080_021264ec.c:
+    complete
+    .text start:0x021264ec end:0x021265ec
+
+src/func_ov080_021265ec.c:
+    .text start:0x021265ec end:0x0212677c
+
+src/func_ov080_0212677c.c:
+    complete
+    .text start:0x0212677c end:0x021269b8
+
+src/func_ov080_021269b8.c:
+    complete
+    .text start:0x021269b8 end:0x02126a54
+
+src/func_ov080_02126a54.c:
+    complete
+    .text start:0x02126a54 end:0x02126bfc
+
+src/func_ov080_02126bfc.c:
+    complete
+    .text start:0x02126bfc end:0x02126c1c
+
+src/func_ov080_02126c1c.c:
+    complete
+    .text start:0x02126c1c end:0x02126c20
+
+src/func_ov080_02126c20.cpp:
+    complete
+    .text start:0x02126c20 end:0x02126c60
+
+src/func_ov080_02126c60.cpp:
+    complete
+    .text start:0x02126c60 end:0x02126ca0
+
+src/func_ov080_02126ca0.cpp:
+    .text start:0x02126ca0 end:0x02126f8c
+
+src/Painting_Spawn.c:
+    complete
+    .text start:0x02126f8c end:0x02126fbc
+
+src/func_ov080_02126fbc.c:
+    .text start:0x02126fbc end:0x02127014
+
+src/func_ov080_02127014.c:
+    .text start:0x02127014 end:0x02127058
+
+src/func_ov080_02127058.c:
+    complete
+    .text start:0x02127058 end:0x02127094
+
+src/func_ov080_02127094.c:
+    complete
+    .text start:0x02127094 end:0x021270dc
+
+src/func_ov080_021270dc.c:
+    complete
+    .text start:0x021270dc end:0x02127124
+
+src/func_ov080_02127124.cpp:
+    complete
+    .text start:0x02127124 end:0x0212714c
+
+src/func_ov080_0212714c.c:
+    complete
+    .text start:0x0212714c end:0x021274ac
+
+src/func_ov080_021274ac.c:
+    complete
+    .text start:0x021274ac end:0x0212758c
+
+src/func_ov080_0212758c.c:
+    complete
+    .text start:0x0212758c end:0x02127658
+
+src/func_ov080_02127658.c:
+    complete
+    .text start:0x02127658 end:0x0212766c
+
+src/__sinit_ov080_021278c0.c:
+    .init start:0x021278c0 end:0x02127a60
+
+src/__sinit_ov080_02127a60.c:
+    .init start:0x02127a60 end:0x02127b2c
+
+src/__sinit_ov080_02127b2c.c:
+    .init start:0x02127b2c end:0x02127f60

--- a/config/arm9/overlays/ov081/delinks.txt
+++ b/config/arm9/overlays/ov081/delinks.txt
@@ -4,3 +4,427 @@
     .ctor       start:0x02128824 end:0x02128838 kind:rodata align:4
     .data       start:0x02128840 end:0x02128d60 kind:data align:32
     .bss        start:0x02128d60 end:0x02129000 kind:bss align:32
+src/_ZN9SpindriftD1Ev.c:
+    complete
+    .text start:0x02123740 end:0x02123788
+
+src/_ZN9SpindriftD0Ev.c:
+    complete
+    .text start:0x02123788 end:0x021237e4
+
+src/func_ov081_021237e4.c:
+    complete
+    .text start:0x021237e4 end:0x021237ec
+
+src/func_ov081_021237ec.cpp:
+    complete
+    .text start:0x021237ec end:0x02123910
+
+src/func_ov081_02123910.cpp:
+    .text start:0x02123910 end:0x02123b20
+
+src/func_ov081_02123b20.cpp:
+    complete
+    .text start:0x02123b20 end:0x02123bec
+
+src/_ZN9Spindrift16CleanupResourcesEv.c:
+    complete
+    .text start:0x02123bec end:0x02123c1c
+
+src/_ZN9Spindrift6RenderEv.cpp:
+    complete
+    .text start:0x02123c1c end:0x02123c6c
+
+src/_ZN9Spindrift8BehaviorEv.cpp:
+    .text start:0x02123c6c end:0x02123ed0
+
+src/_ZN9Spindrift13InitResourcesEv.cpp:
+    .text start:0x02123ed0 end:0x02123fd8
+
+src/func_ov081_02123fd8.cpp:
+    complete
+    .text start:0x02123fd8 end:0x02124038
+
+src/func_ov081_02124038.c:
+    complete
+    .text start:0x02124038 end:0x02124040
+
+src/Spindrift_Spawn.c:
+    complete
+    .text start:0x02124040 end:0x02124090
+
+src/_ZN10MrBlizzardD1Ev.c:
+    complete
+    .text start:0x02124090 end:0x021240d8
+
+src/_ZN10MrBlizzardD0Ev.c:
+    complete
+    .text start:0x021240d8 end:0x02124134
+
+src/func_ov081_02124134.c:
+    complete
+    .text start:0x02124134 end:0x0212423c
+
+src/func_ov081_0212423c.c:
+    complete
+    .text start:0x0212423c end:0x021243cc
+
+src/func_ov081_021243cc.cpp:
+    .text start:0x021243cc end:0x021245e8
+
+src/func_ov081_021245e8.c:
+    complete
+    .text start:0x021245e8 end:0x021246a0
+
+src/func_ov081_021246a0.c:
+    complete
+    .text start:0x021246a0 end:0x0212479c
+
+src/func_ov081_0212479c.cpp:
+    complete
+    .text start:0x0212479c end:0x02124894
+
+src/func_ov081_02124894.c:
+    complete
+    .text start:0x02124894 end:0x0212498c
+
+src/func_ov081_0212498c.c:
+    complete
+    .text start:0x0212498c end:0x021249f4
+
+src/func_ov081_021249f4.c:
+    complete
+    .text start:0x021249f4 end:0x02124b08
+
+src/func_ov081_02124b08.c:
+    complete
+    .text start:0x02124b08 end:0x02124b98
+
+src/func_ov081_02124b98.cpp:
+    .text start:0x02124b98 end:0x02124d14
+
+src/func_ov081_02124d14.cpp:
+    .text start:0x02124d14 end:0x02124d50
+
+src/func_ov081_02124d50.cpp:
+    complete
+    .text start:0x02124d50 end:0x02124dfc
+
+src/func_ov081_02124dfc.c:
+    complete
+    .text start:0x02124dfc end:0x02124e64
+
+src/func_ov081_02124e64.c:
+    complete
+    .text start:0x02124e64 end:0x02124ec0
+
+src/func_ov081_02124ec0.c:
+    complete
+    .text start:0x02124ec0 end:0x02124f20
+
+src/func_ov081_02124f20.cpp:
+    complete
+    .text start:0x02124f20 end:0x02124f7c
+
+src/func_ov081_02124f7c.c:
+    complete
+    .text start:0x02124f7c end:0x02125038
+
+src/func_ov081_02125038.cpp:
+    complete
+    .text start:0x02125038 end:0x02125068
+
+src/func_ov081_02125068.cpp:
+    .text start:0x02125068 end:0x021250c8
+
+src/func_ov081_021250c8.c:
+    complete
+    .text start:0x021250c8 end:0x02125200
+
+src/func_ov081_02125200.c:
+    complete
+    .text start:0x02125200 end:0x02125208
+
+src/func_ov081_02125208.c:
+    complete
+    .text start:0x02125208 end:0x0212538c
+
+src/func_ov081_0212538c.c:
+    complete
+    .text start:0x0212538c end:0x02125488
+
+src/func_ov081_02125488.cpp:
+    complete
+    .text start:0x02125488 end:0x021254d8
+
+src/func_ov081_021254d8.cpp:
+    complete
+    .text start:0x021254d8 end:0x021257b0
+
+src/_ZN10MrBlizzard16CleanupResourcesEv.c:
+    complete
+    .text start:0x021257b0 end:0x0212581c
+
+src/_ZN10MrBlizzard16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212581c end:0x02125820
+
+src/_ZN10MrBlizzard6RenderEv.cpp:
+    .text start:0x02125820 end:0x0212588c
+
+src/_ZN10MrBlizzard8BehaviorEv.cpp:
+    .text start:0x0212588c end:0x02125ba0
+
+src/_ZN10MrBlizzard13InitResourcesEv.cpp:
+    .text start:0x02125ba0 end:0x02125eb8
+
+src/func_ov081_02125eb8.c:
+    complete
+    .text start:0x02125eb8 end:0x02125ec0
+
+src/MrBlizzard_Spawn.c:
+    complete
+    .text start:0x02125ec0 end:0x02125f14
+
+src/_ZN8SnowballD1Ev.c:
+    complete
+    .text start:0x02125f14 end:0x02125f5c
+
+src/_ZN8SnowballD0Ev.c:
+    complete
+    .text start:0x02125f5c end:0x02125fb8
+
+src/func_ov081_02125fb8.c:
+    complete
+    .text start:0x02125fb8 end:0x021260fc
+
+src/func_ov081_021260fc.cpp:
+    complete
+    .text start:0x021260fc end:0x021261b8
+
+src/func_ov081_021261b8.c:
+    complete
+    .text start:0x021261b8 end:0x021261d4
+
+src/func_ov081_021261d4.cpp:
+    complete
+    .text start:0x021261d4 end:0x02126224
+
+src/func_ov081_02126224.c:
+    complete
+    .text start:0x02126224 end:0x02126298
+
+src/_ZN8Snowball16CleanupResourcesEv.c:
+    complete
+    .text start:0x02126298 end:0x021262bc
+
+src/_ZN8Snowball16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021262bc end:0x021262c0
+
+src/_ZN8Snowball6RenderEv.cpp:
+    complete
+    .text start:0x021262c0 end:0x021262ec
+
+src/_ZN8Snowball8BehaviorEv.cpp:
+    .text start:0x021262ec end:0x021263b8
+
+src/_ZN8Snowball13InitResourcesEv.cpp:
+    .text start:0x021263b8 end:0x021264b4
+
+src/Snowball_Spawn.c:
+    complete
+    .text start:0x021264b4 end:0x02126504
+
+src/_ZN8MoneybagD1Ev.cpp:
+    .text start:0x02126504 end:0x02126554
+
+src/_ZN8MoneybagD0Ev.c:
+    complete
+    .text start:0x02126554 end:0x021265b8
+
+src/func_ov081_021265b8.c:
+    complete
+    .text start:0x021265b8 end:0x021265c0
+
+src/func_ov081_021265c0.c:
+    complete
+    .text start:0x021265c0 end:0x021265c8
+
+src/func_ov081_021265c8.c:
+    complete
+    .text start:0x021265c8 end:0x02126700
+
+src/func_ov081_02126700.cpp:
+    complete
+    .text start:0x02126700 end:0x02126758
+
+src/func_ov081_02126758.cpp:
+    complete
+    .text start:0x02126758 end:0x02126950
+
+src/func_ov081_02126950.cpp:
+    complete
+    .text start:0x02126950 end:0x02126a20
+
+src/func_ov081_02126a20.cpp:
+    complete
+    .text start:0x02126a20 end:0x02126c20
+
+src/func_ov081_02126c20.cpp:
+    complete
+    .text start:0x02126c20 end:0x02126c8c
+
+src/func_ov081_02126c8c.cpp:
+    complete
+    .text start:0x02126c8c end:0x02126d64
+
+src/func_ov081_02126d64.c:
+    .text start:0x02126d64 end:0x02126e28
+
+src/func_ov081_02126e28.c:
+    complete
+    .text start:0x02126e28 end:0x02126fa4
+
+src/func_ov081_02126fa4.cpp:
+    complete
+    .text start:0x02126fa4 end:0x02127044
+
+src/func_ov081_02127044.c:
+    complete
+    .text start:0x02127044 end:0x02127070
+
+src/func_ov081_02127070.cpp:
+    .text start:0x02127070 end:0x02127134
+
+src/func_ov081_02127134.c:
+    complete
+    .text start:0x02127134 end:0x02127188
+
+src/func_ov081_02127188.c:
+    complete
+    .text start:0x02127188 end:0x021271e8
+
+src/func_ov081_021271e8.c:
+    complete
+    .text start:0x021271e8 end:0x02127240
+
+src/func_ov081_02127240.cpp:
+    complete
+    .text start:0x02127240 end:0x02127314
+
+src/func_ov081_02127314.cpp:
+    complete
+    .text start:0x02127314 end:0x02127398
+
+src/func_ov081_02127398.c:
+    complete
+    .text start:0x02127398 end:0x021273e8
+
+src/func_ov081_021273e8.c:
+    complete
+    .text start:0x021273e8 end:0x02127440
+
+src/func_ov081_02127440.cpp:
+    complete
+    .text start:0x02127440 end:0x021274c8
+
+src/func_ov081_021274c8.cpp:
+    complete
+    .text start:0x021274c8 end:0x02127558
+
+src/func_ov081_02127558.c:
+    complete
+    .text start:0x02127558 end:0x021276b0
+
+src/func_ov081_021276b0.cpp:
+    complete
+    .text start:0x021276b0 end:0x02127708
+
+src/func_ov081_02127708.cpp:
+    complete
+    .text start:0x02127708 end:0x02127744
+
+src/func_ov081_02127744.cpp:
+    complete
+    .text start:0x02127744 end:0x0212777c
+
+src/func_ov081_0212777c.c:
+    complete
+    .text start:0x0212777c end:0x02127798
+
+src/_ZN8Moneybag16CleanupResourcesEv.c:
+    complete
+    .text start:0x02127798 end:0x021277dc
+
+src/_ZN8Moneybag16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021277dc end:0x021277e0
+
+src/_ZN8Moneybag6RenderEv.cpp:
+    complete
+    .text start:0x021277e0 end:0x02127854
+
+src/_ZN8Moneybag8BehaviorEv.cpp:
+    .text start:0x02127854 end:0x021278a8
+
+src/_ZN8Moneybag13InitResourcesEv.cpp:
+    .text start:0x021278a8 end:0x02127a7c
+
+src/func_ov081_02127a7c.cpp:
+    complete
+    .text start:0x02127a7c end:0x02127adc
+
+src/Moneybag_Spawn.c:
+    complete
+    .text start:0x02127adc end:0x02127b34
+
+src/_ZN8IceBlockD1Ev.c:
+    .text start:0x02127b34 end:0x02127b80
+
+src/_ZN8IceBlockD0Ev.c:
+    .text start:0x02127b80 end:0x02127be0
+
+src/func_ov081_02127be0.cpp:
+    .text start:0x02127be0 end:0x02127ccc
+
+src/func_ov081_02127ccc.cpp:
+    complete
+    .text start:0x02127ccc end:0x02127cf4
+
+src/func_ov081_02127cf4.c:
+    complete
+    .text start:0x02127cf4 end:0x02127d98
+
+src/_ZN8IceBlock16CleanupResourcesEv.cpp:
+    .text start:0x02127d98 end:0x02127ddc
+
+src/_ZN8IceBlock6RenderEv.cpp:
+    complete
+    .text start:0x02127ddc end:0x02127e1c
+
+src/_ZN8IceBlock8BehaviorEv.cpp:
+    .text start:0x02127e1c end:0x02127ff0
+
+src/_ZN8IceBlock13InitResourcesEv.cpp:
+    complete
+    .text start:0x02127ff0 end:0x021280a0
+
+src/IceBlock_Spawn.c:
+    complete
+    .text start:0x021280a0 end:0x021280d8
+
+src/__sinit_ov081_021280e8.c:
+    .init start:0x021280e8 end:0x02128154
+
+src/__sinit_ov081_02128154.c:
+    .init start:0x02128154 end:0x021284b4
+
+src/__sinit_ov081_021284b4.c:
+    .init start:0x021284b4 end:0x021284f0
+
+src/__sinit_ov081_021284f0.c:
+    .init start:0x021284f0 end:0x021287b8
+
+src/__sinit_ov081_021287b8.c:
+    .init start:0x021287b8 end:0x02128824

--- a/config/arm9/overlays/ov084/delinks.txt
+++ b/config/arm9/overlays/ov084/delinks.txt
@@ -4,3 +4,403 @@
     .ctor       start:0x02130860 end:0x0213086c kind:rodata align:4
     .data       start:0x02130880 end:0x02130cc0 kind:data align:32
     .bss        start:0x02130cc0 end:0x02130ee0 kind:bss align:32
+src/_ZN6GoombaD1Ev.c:
+    complete
+    .text start:0x02129020 end:0x02129070
+
+src/_ZN6GoombaD0Ev.c:
+    complete
+    .text start:0x02129070 end:0x021290d4
+
+src/func_ov084_021290d4.c:
+    complete
+    .text start:0x021290d4 end:0x02129168
+
+src/func_ov084_02129168.cpp:
+    .text start:0x02129168 end:0x02129238
+
+src/func_ov084_02129238.cpp:
+    .text start:0x02129238 end:0x0212934c
+
+src/func_ov084_0212934c.c:
+    complete
+    .text start:0x0212934c end:0x02129498
+
+src/func_ov084_02129498.c:
+    complete
+    .text start:0x02129498 end:0x021294d0
+
+src/func_ov084_021294d0.cpp:
+    complete
+    .text start:0x021294d0 end:0x021296b0
+
+src/func_ov084_021296b0.c:
+    complete
+    .text start:0x021296b0 end:0x021296cc
+
+src/func_ov084_021296cc.c:
+    .text start:0x021296cc end:0x02129864
+
+src/func_ov084_02129864.c:
+    complete
+    .text start:0x02129864 end:0x021298d0
+
+src/func_ov084_021298d0.c:
+    complete
+    .text start:0x021298d0 end:0x02129a00
+
+src/func_ov084_02129a00.c:
+    .text start:0x02129a00 end:0x02129c9c
+
+src/func_ov084_02129c9c.c:
+    complete
+    .text start:0x02129c9c end:0x02129cf4
+
+src/func_ov084_02129cf4.c:
+    complete
+    .text start:0x02129cf4 end:0x02129ed4
+
+src/func_ov084_02129ed4.c:
+    .text start:0x02129ed4 end:0x0212a580
+
+src/func_ov084_0212a580.cpp:
+    .text start:0x0212a580 end:0x0212a6f8
+
+src/func_ov084_0212a6f8.c:
+    complete
+    .text start:0x0212a6f8 end:0x0212a774
+
+src/func_ov084_0212a774.c:
+    .text start:0x0212a774 end:0x0212aab0
+
+src/func_ov084_0212aab0.cpp:
+    complete
+    .text start:0x0212aab0 end:0x0212ab48
+
+src/func_ov084_0212ab48.c:
+    complete
+    .text start:0x0212ab48 end:0x0212abd4
+
+src/func_ov084_0212abd4.c:
+    complete
+    .text start:0x0212abd4 end:0x0212af74
+
+src/func_ov084_0212af74.c:
+    complete
+    .text start:0x0212af74 end:0x0212b2dc
+
+src/func_ov084_0212b2dc.c:
+    complete
+    .text start:0x0212b2dc end:0x0212b30c
+
+src/func_ov084_0212b30c.cpp:
+    complete
+    .text start:0x0212b30c end:0x0212b344
+
+src/func_ov084_0212b344.cpp:
+    .text start:0x0212b344 end:0x0212b510
+
+src/_ZN6Goomba16CleanupResourcesEv.cpp:
+    .text start:0x0212b510 end:0x0212b5b8
+
+src/_ZN6Goomba16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212b5b8 end:0x0212b5bc
+
+src/_ZN6Goomba6RenderEv.cpp:
+    .text start:0x0212b5bc end:0x0212b6ec
+
+src/_ZN6Goomba8BehaviorEv.cpp:
+    .text start:0x0212b6ec end:0x0212bc30
+
+src/_ZN6Goomba13InitResourcesEv.cpp:
+    .text start:0x0212bc30 end:0x0212bfc0
+
+src/func_ov084_0212bfc0.cpp:
+    complete
+    .text start:0x0212bfc0 end:0x0212bff8
+
+src/GoombaLarge_Spawn.c:
+    complete
+    .text start:0x0212bff8 end:0x0212c054
+
+src/GoombaSmall_Spawn.c:
+    complete
+    .text start:0x0212c054 end:0x0212c0b0
+
+src/Goomba_Spawn.c:
+    complete
+    .text start:0x0212c0b0 end:0x0212c10c
+
+src/_ZN11BobOmbBuddyD1Ev.cpp:
+    .text start:0x0212c10c end:0x0212c14c
+
+src/_ZN11BobOmbBuddyD0Ev.c:
+    complete
+    .text start:0x0212c14c end:0x0212c1a0
+
+src/func_ov084_0212c1a0.c:
+    complete
+    .text start:0x0212c1a0 end:0x0212c4a0
+
+src/func_ov084_0212c4a0.c:
+    complete
+    .text start:0x0212c4a0 end:0x0212c508
+
+src/func_ov084_0212c508.cpp:
+    .text start:0x0212c508 end:0x0212c89c
+
+src/func_ov084_0212c89c.c:
+    complete
+    .text start:0x0212c89c end:0x0212c8b0
+
+src/func_ov084_0212c8b0.cpp:
+    complete
+    .text start:0x0212c8b0 end:0x0212c92c
+
+src/func_ov084_0212c92c.cpp:
+    .text start:0x0212c92c end:0x0212c960
+
+src/func_ov084_0212c960.cpp:
+    complete
+    .text start:0x0212c960 end:0x0212c9a8
+
+src/func_ov084_0212c9a8.cpp:
+    complete
+    .text start:0x0212c9a8 end:0x0212c9f0
+
+src/func_ov084_0212c9f0.c:
+    complete
+    .text start:0x0212c9f0 end:0x0212ca60
+
+src/func_ov084_0212ca60.c:
+    complete
+    .text start:0x0212ca60 end:0x0212caa8
+
+src/func_ov084_0212caa8.c:
+    complete
+    .text start:0x0212caa8 end:0x0212cac0
+
+src/func_ov084_0212cac0.c:
+    complete
+    .text start:0x0212cac0 end:0x0212cae0
+
+src/func_ov084_0212cae0.c:
+    complete
+    .text start:0x0212cae0 end:0x0212ccb4
+
+src/func_ov084_0212ccb4.cpp:
+    complete
+    .text start:0x0212ccb4 end:0x0212cda0
+
+src/func_ov084_0212cda0.c:
+    complete
+    .text start:0x0212cda0 end:0x0212ce50
+
+src/func_ov084_0212ce50.cpp:
+    complete
+    .text start:0x0212ce50 end:0x0212cf10
+
+src/_ZN11BobOmbBuddy16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212cf10 end:0x0212cf40
+
+src/_ZN11BobOmbBuddy6RenderEv.cpp:
+    complete
+    .text start:0x0212cf40 end:0x0212cf6c
+
+src/_ZN11BobOmbBuddy8BehaviorEv.cpp:
+    .text start:0x0212cf6c end:0x0212d028
+
+src/_ZN11BobOmbBuddy13InitResourcesEv.cpp:
+    .text start:0x0212d028 end:0x0212d200
+
+src/BobOmbBuddy_Spawn.c:
+    complete
+    .text start:0x0212d200 end:0x0212d248
+
+src/_ZN19FirePiranhaPlantBigD1Ev.c:
+    complete
+    .text start:0x0212d248 end:0x0212d288
+
+src/_ZN19FirePiranhaPlantBigD0Ev.c:
+    complete
+    .text start:0x0212d288 end:0x0212d2dc
+
+src/func_ov084_0212d2dc.c:
+    complete
+    .text start:0x0212d2dc end:0x0212d42c
+
+src/func_ov084_0212d42c.c:
+    complete
+    .text start:0x0212d42c end:0x0212d560
+
+src/func_ov084_0212d560.c:
+    complete
+    .text start:0x0212d560 end:0x0212d564
+
+src/func_ov084_0212d564.c:
+    complete
+    .text start:0x0212d564 end:0x0212d86c
+
+src/func_ov084_0212d86c.c:
+    complete
+    .text start:0x0212d86c end:0x0212dc30
+
+src/func_ov084_0212dc30.c:
+    complete
+    .text start:0x0212dc30 end:0x0212ddbc
+
+src/func_ov084_0212ddbc.c:
+    complete
+    .text start:0x0212ddbc end:0x0212e010
+
+src/func_ov084_0212e010.cpp:
+    complete
+    .text start:0x0212e010 end:0x0212e4e0
+
+src/func_ov084_0212e4e0.c:
+    complete
+    .text start:0x0212e4e0 end:0x0212e554
+
+src/_ZN19FirePiranhaPlantBig16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0212e554 end:0x0212e5a8
+
+src/_ZN19FirePiranhaPlantBig6RenderEv.cpp:
+    complete
+    .text start:0x0212e5a8 end:0x0212e614
+
+src/_ZN19FirePiranhaPlantBig8BehaviorEv.cpp:
+    .text start:0x0212e614 end:0x0212e774
+
+src/_ZN19FirePiranhaPlantBig13InitResourcesEv.cpp:
+    complete
+    .text start:0x0212e774 end:0x0212e998
+
+src/func_ov084_0212e998.c:
+    complete
+    .text start:0x0212e998 end:0x0212e9d4
+
+src/func_ov084_0212e9d4.cpp:
+    complete
+    .text start:0x0212e9d4 end:0x0212e9f8
+
+src/func_ov084_0212e9f8.cpp:
+    complete
+    .text start:0x0212e9f8 end:0x0212ea18
+
+src/FirePiranhaPlant_Spawn.c:
+    complete
+    .text start:0x0212ea18 end:0x0212ea60
+
+src/FirePiranhaPlantSmall_Spawn.c:
+    complete
+    .text start:0x0212ea60 end:0x0212eaa8
+
+src/FirePiranhaPlantBig_Spawn.c:
+    complete
+    .text start:0x0212eaa8 end:0x0212eaf0
+
+src/_ZN12PiranhaPlantD1Ev.c:
+    complete
+    .text start:0x0212eaf0 end:0x0212eb48
+
+src/_ZN12PiranhaPlantD0Ev.c:
+    complete
+    .text start:0x0212eb48 end:0x0212ebb4
+
+src/func_ov084_0212ebb4.c:
+    complete
+    .text start:0x0212ebb4 end:0x0212ec04
+
+src/func_ov084_0212ec04.c:
+    complete
+    .text start:0x0212ec04 end:0x0212ec58
+
+src/func_ov084_0212ec58.c:
+    complete
+    .text start:0x0212ec58 end:0x0212ec60
+
+src/func_ov084_0212ec60.c:
+    complete
+    .text start:0x0212ec60 end:0x0212ef00
+
+src/func_ov084_0212ef00.c:
+    complete
+    .text start:0x0212ef00 end:0x0212f1d0
+
+src/func_ov084_0212f1d0.c:
+    complete
+    .text start:0x0212f1d0 end:0x0212f204
+
+src/func_ov084_0212f204.c:
+    complete
+    .text start:0x0212f204 end:0x0212f298
+
+src/func_ov084_0212f298.c:
+    complete
+    .text start:0x0212f298 end:0x0212f2dc
+
+src/func_ov084_0212f2dc.c:
+    complete
+    .text start:0x0212f2dc end:0x0212f33c
+
+src/func_ov084_0212f33c.cpp:
+    complete
+    .text start:0x0212f33c end:0x0212f460
+
+src/func_ov084_0212f460.c:
+    complete
+    .text start:0x0212f460 end:0x0212f588
+
+src/func_ov084_0212f588.cpp:
+    complete
+    .text start:0x0212f588 end:0x0212f630
+
+src/func_ov084_0212f630.cpp:
+    complete
+    .text start:0x0212f630 end:0x0212f6d8
+
+src/func_ov084_0212f6d8.c:
+    complete
+    .text start:0x0212f6d8 end:0x0212fa7c
+
+src/func_ov084_0212fa7c.c:
+    complete
+    .text start:0x0212fa7c end:0x0212fc10
+
+src/func_ov084_0212fc10.c:
+    .text start:0x0212fc10 end:0x0212fc84
+
+src/_ZN12PiranhaPlant16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0212fc84 end:0x0212fcd8
+
+src/_ZN12PiranhaPlant16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212fcd8 end:0x0212fcdc
+
+src/_ZN12PiranhaPlant6RenderEv.cpp:
+    complete
+    .text start:0x0212fcdc end:0x0212fd4c
+
+src/_ZN12PiranhaPlant8BehaviorEv.cpp:
+    .text start:0x0212fd4c end:0x0212feb4
+
+src/_ZN12PiranhaPlant13InitResourcesEv.cpp:
+    complete
+    .text start:0x0212feb4 end:0x02130110
+
+src/PiranhaPlant_Spawn.c:
+    complete
+    .text start:0x02130110 end:0x02130174
+
+src/__sinit_ov084_0213035c.c:
+    .init start:0x0213035c end:0x02130558
+
+src/__sinit_ov084_02130558.c:
+    .init start:0x02130558 end:0x02130654
+
+src/__sinit_ov084_02130654.c:
+    .init start:0x02130654 end:0x02130860

--- a/config/arm9/overlays/ov085/delinks.txt
+++ b/config/arm9/overlays/ov085/delinks.txt
@@ -4,3 +4,495 @@
     .ctor       start:0x0212fdf0 end:0x0212fe08 kind:rodata align:4
     .data       start:0x0212fe20 end:0x02130480 kind:data align:32
     .bss        start:0x02130480 end:0x02130880 kind:bss align:32
+src/_ZN4ToadD1Ev.cpp:
+    .text start:0x02129020 end:0x02129060
+
+src/_ZN4ToadD0Ev.c:
+    complete
+    .text start:0x02129060 end:0x021290b4
+
+src/func_ov085_021290b4.c:
+    complete
+    .text start:0x021290b4 end:0x021291ac
+
+src/func_ov085_021291ac.c:
+    complete
+    .text start:0x021291ac end:0x0212943c
+
+src/func_ov085_0212943c.cpp:
+    .text start:0x0212943c end:0x02129470
+
+src/func_ov085_02129470.cpp:
+    complete
+    .text start:0x02129470 end:0x021294f0
+
+src/func_ov085_021294f0.cpp:
+    complete
+    .text start:0x021294f0 end:0x02129524
+
+src/func_ov085_02129524.cpp:
+    complete
+    .text start:0x02129524 end:0x02129570
+
+src/func_ov085_02129570.cpp:
+    complete
+    .text start:0x02129570 end:0x021295bc
+
+src/func_ov085_021295bc.c:
+    complete
+    .text start:0x021295bc end:0x021297e8
+
+src/_ZN4Toad16CleanupResourcesEv.cpp:
+    .text start:0x021297e8 end:0x02129854
+
+src/_ZN4Toad6RenderEv.cpp:
+    complete
+    .text start:0x02129854 end:0x02129878
+
+src/_ZN4Toad13InitResourcesEv.c:
+    complete
+    .text start:0x02129a7c end:0x02129cd0
+
+src/Toad_Spawn.c:
+    complete
+    .text start:0x02129cd0 end:0x02129d18
+
+src/_ZN13PrincessPeachD1Ev.cpp:
+    .text start:0x02129d18 end:0x02129d60
+
+src/_ZN13PrincessPeachD0Ev.c:
+    complete
+    .text start:0x02129d60 end:0x02129dbc
+
+src/func_ov085_02129dbc.cpp:
+    .text start:0x02129dbc end:0x02129ebc
+
+src/func_ov085_02129ebc.cpp:
+    complete
+    .text start:0x02129ebc end:0x02129f8c
+
+src/func_ov085_02129f8c.c:
+    .text start:0x02129f8c end:0x02129fdc
+
+src/func_ov085_02129fdc.cpp:
+    complete
+    .text start:0x02129fdc end:0x0212a0b8
+
+src/func_ov085_0212a0b8.c:
+    complete
+    .text start:0x0212a0b8 end:0x0212a0e8
+
+src/func_ov085_0212a0e8.c:
+    complete
+    .text start:0x0212a0e8 end:0x0212a148
+
+src/func_ov085_0212a148.c:
+    complete
+    .text start:0x0212a148 end:0x0212a150
+
+src/func_ov085_0212a150.c:
+    complete
+    .text start:0x0212a150 end:0x0212a19c
+
+src/func_ov085_0212a19c.c:
+    complete
+    .text start:0x0212a19c end:0x0212a1d4
+
+src/func_ov085_0212a1d4.c:
+    complete
+    .text start:0x0212a1d4 end:0x0212a220
+
+src/func_ov085_0212a220.c:
+    complete
+    .text start:0x0212a220 end:0x0212a328
+
+src/func_ov085_0212a328.c:
+    complete
+    .text start:0x0212a328 end:0x0212a37c
+
+src/func_ov085_0212a37c.cpp:
+    complete
+    .text start:0x0212a37c end:0x0212a3ec
+
+src/func_ov085_0212a3ec.c:
+    complete
+    .text start:0x0212a3ec end:0x0212a430
+
+src/func_ov085_0212a430.cpp:
+    complete
+    .text start:0x0212a430 end:0x0212a46c
+
+src/func_ov085_0212a46c.cpp:
+    complete
+    .text start:0x0212a46c end:0x0212a4a4
+
+src/func_ov085_0212a4a4.c:
+    complete
+    .text start:0x0212a4a4 end:0x0212a4c0
+
+src/_ZN13PrincessPeach16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212a4c0 end:0x0212a504
+
+src/_ZN13PrincessPeach16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212a504 end:0x0212a508
+
+src/_ZN13PrincessPeach6RenderEv.cpp:
+    complete
+    .text start:0x0212a508 end:0x0212a52c
+
+src/_ZN13PrincessPeach8BehaviorEv.cpp:
+    .text start:0x0212a52c end:0x0212a588
+
+src/_ZN13PrincessPeach13InitResourcesEv.cpp:
+    .text start:0x0212a588 end:0x0212a684
+
+src/PrincessPeach_Spawn.c:
+    complete
+    .text start:0x0212a684 end:0x0212a6d4
+
+src/_ZN6RabbitD1Ev.c:
+    complete
+    .text start:0x0212a6d4 end:0x0212a724
+
+src/_ZN6RabbitD0Ev.c:
+    complete
+    .text start:0x0212a724 end:0x0212a788
+
+src/func_ov085_0212a788.c:
+    complete
+    .text start:0x0212a788 end:0x0212a828
+
+src/func_ov085_0212a828.cpp:
+    complete
+    .text start:0x0212a828 end:0x0212a904
+
+src/func_ov085_0212a904.c:
+    complete
+    .text start:0x0212a904 end:0x0212aaa4
+
+src/func_ov085_0212aaa4.c:
+    complete
+    .text start:0x0212aaa4 end:0x0212aaec
+
+src/func_ov085_0212aaec.c:
+    complete
+    .text start:0x0212aaec end:0x0212ac3c
+
+src/func_ov085_0212ac3c.c:
+    complete
+    .text start:0x0212ac3c end:0x0212ac4c
+
+src/func_ov085_0212ac4c.c:
+    complete
+    .text start:0x0212ac4c end:0x0212ad8c
+
+src/func_ov085_0212ad8c.c:
+    complete
+    .text start:0x0212ad8c end:0x0212ae08
+
+src/func_ov085_0212ae08.c:
+    complete
+    .text start:0x0212ae08 end:0x0212b3fc
+
+src/func_ov085_0212b3fc.c:
+    complete
+    .text start:0x0212b3fc end:0x0212b444
+
+src/func_ov085_0212b444.c:
+    complete
+    .text start:0x0212b444 end:0x0212b478
+
+src/func_ov085_0212b478.c:
+    complete
+    .text start:0x0212b478 end:0x0212b4b4
+
+src/func_ov085_0212b4b4.c:
+    complete
+    .text start:0x0212b4b4 end:0x0212b75c
+
+src/func_ov085_0212b75c.cpp:
+    complete
+    .text start:0x0212b75c end:0x0212b86c
+
+src/func_ov085_0212b86c.c:
+    complete
+    .text start:0x0212b86c end:0x0212b8a0
+
+src/func_ov085_0212b8a0.c:
+    complete
+    .text start:0x0212b8a0 end:0x0212b8dc
+
+src/func_ov085_0212bc14.c:
+    complete
+    .text start:0x0212bc14 end:0x0212bc78
+
+src/func_ov085_0212bc78.cpp:
+    complete
+    .text start:0x0212bc78 end:0x0212bcc8
+
+src/func_ov085_0212bcc8.c:
+    complete
+    .text start:0x0212bcc8 end:0x0212bdbc
+
+src/func_ov085_0212bdbc.cpp:
+    complete
+    .text start:0x0212bdbc end:0x0212bedc
+
+src/func_ov085_0212bedc.cpp:
+    .text start:0x0212bedc end:0x0212c004
+
+src/_ZN6Rabbit16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212c004 end:0x0212c070
+
+src/_ZN6Rabbit16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212c070 end:0x0212c074
+
+src/_ZN6Rabbit6RenderEv.cpp:
+    .text start:0x0212c074 end:0x0212c150
+
+src/func_ov085_0212c150.cpp:
+    complete
+    .text start:0x0212c150 end:0x0212c230
+
+src/_ZN6Rabbit8BehaviorEv.c:
+    complete
+    .text start:0x0212c230 end:0x0212c7fc
+
+src/_ZN6Rabbit13InitResourcesEv.cpp:
+    .text start:0x0212c7fc end:0x0212cc18
+
+src/func_ov085_0212cc18.c:
+    complete
+    .text start:0x0212cc18 end:0x0212cc2c
+
+src/Rabbit_Spawn.c:
+    complete
+    .text start:0x0212cc2c end:0x0212cc88
+
+src/_ZN9RabbitKeyD1Ev.c:
+    complete
+    .text start:0x0212cc88 end:0x0212ccc0
+
+src/_ZN9RabbitKeyD0Ev.c:
+    complete
+    .text start:0x0212ccc0 end:0x0212cd0c
+
+src/func_ov085_0212cd0c.cpp:
+    complete
+    .text start:0x0212cd0c end:0x0212cd80
+
+src/func_ov085_0212cd80.c:
+    complete
+    .text start:0x0212cd80 end:0x0212d038
+
+src/func_ov085_0212d038.c:
+    complete
+    .text start:0x0212d038 end:0x0212d108
+
+src/func_ov085_0212d108.c:
+    complete
+    .text start:0x0212d108 end:0x0212d24c
+
+src/func_ov085_0212d24c.c:
+    complete
+    .text start:0x0212d24c end:0x0212d268
+
+src/func_ov085_0212d268.cpp:
+    complete
+    .text start:0x0212d268 end:0x0212d2b8
+
+src/func_ov085_0212d2b8.cpp:
+    complete
+    .text start:0x0212d2b8 end:0x0212d374
+
+src/_ZN9RabbitKey16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212d374 end:0x0212d398
+
+src/_ZN9RabbitKey16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212d398 end:0x0212d39c
+
+src/_ZN9RabbitKey6RenderEv.cpp:
+    .text start:0x0212d39c end:0x0212d3ec
+
+src/_ZN9RabbitKey8BehaviorEv.cpp:
+    complete
+    .text start:0x0212d3ec end:0x0212d46c
+
+src/_ZN9RabbitKey13InitResourcesEv.cpp:
+    complete
+    .text start:0x0212d46c end:0x0212d4e8
+
+src/RabbitKey_Spawn.c:
+    complete
+    .text start:0x0212d4e8 end:0x0212d528
+
+src/_ZN9LakituBroD1Ev.c:
+    complete
+    .text start:0x0212d528 end:0x0212d578
+
+src/_ZN9LakituBroD0Ev.c:
+    complete
+    .text start:0x0212d578 end:0x0212d5dc
+
+src/func_ov085_0212d5dc.cpp:
+    complete
+    .text start:0x0212d5dc end:0x0212d724
+
+src/func_ov085_0212d724.c:
+    complete
+    .text start:0x0212d724 end:0x0212d73c
+
+src/func_ov085_0212d73c.c:
+    complete
+    .text start:0x0212d73c end:0x0212d8ec
+
+src/func_ov085_0212d8ec.c:
+    complete
+    .text start:0x0212d8ec end:0x0212d9b8
+
+src/func_ov085_0212d9b8.c:
+    complete
+    .text start:0x0212d9b8 end:0x0212db04
+
+src/func_ov085_0212db04.cpp:
+    complete
+    .text start:0x0212db04 end:0x0212dbdc
+
+src/func_ov085_0212dbdc.c:
+    complete
+    .text start:0x0212dbdc end:0x0212dcfc
+
+src/func_ov085_0212dcfc.c:
+    complete
+    .text start:0x0212dcfc end:0x0212dd10
+
+src/func_ov085_0212dd10.cpp:
+    complete
+    .text start:0x0212dd10 end:0x0212ddc4
+
+src/func_ov085_0212ddc4.cpp:
+    complete
+    .text start:0x0212ddc4 end:0x0212de5c
+
+src/func_ov085_0212de5c.cpp:
+    .text start:0x0212de5c end:0x0212df84
+
+src/func_ov085_0212df84.cpp:
+    .text start:0x0212df84 end:0x0212e078
+
+src/func_ov085_0212e078.cpp:
+    complete
+    .text start:0x0212e078 end:0x0212e180
+
+src/func_ov085_0212e180.c:
+    complete
+    .text start:0x0212e180 end:0x0212e19c
+
+src/func_ov085_0212e19c.c:
+    complete
+    .text start:0x0212e19c end:0x0212e2ec
+
+src/func_ov085_0212e2ec.c:
+    complete
+    .text start:0x0212e2ec end:0x0212e310
+
+src/func_ov085_0212e310.cpp:
+    .text start:0x0212e310 end:0x0212e480
+
+src/func_ov085_0212e480.c:
+    complete
+    .text start:0x0212e480 end:0x0212e4a4
+
+src/func_ov085_0212e4a4.c:
+    .text start:0x0212e4a4 end:0x0212e59c
+
+src/func_ov085_0212e59c.c:
+    complete
+    .text start:0x0212e59c end:0x0212e5ac
+
+src/func_ov085_0212e5ac.c:
+    complete
+    .text start:0x0212e5ac end:0x0212e720
+
+src/func_ov085_0212e720.c:
+    complete
+    .text start:0x0212e720 end:0x0212e728
+
+src/func_ov085_0212e728.cpp:
+    complete
+    .text start:0x0212e728 end:0x0212e778
+
+src/func_ov085_0212e778.cpp:
+    complete
+    .text start:0x0212e778 end:0x0212e858
+
+src/func_ov085_0212e858.c:
+    complete
+    .text start:0x0212e858 end:0x0212ea90
+
+src/_ZN9LakituBro16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212ea90 end:0x0212eacc
+
+src/_ZN9LakituBro16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0212eacc end:0x0212ead0
+
+src/_ZN9LakituBro6RenderEv.cpp:
+    complete
+    .text start:0x0212ead0 end:0x0212eb18
+
+src/_ZN9LakituBro8BehaviorEv.cpp:
+    .text start:0x0212eb18 end:0x0212ebec
+
+src/_ZN9LakituBro13InitResourcesEv.cpp:
+    .text start:0x0212ebec end:0x0212ed54
+
+src/LakituBro_Spawn.c:
+    complete
+    .text start:0x0212ed54 end:0x0212edac
+
+src/_ZN8WallSignD1Ev.c:
+    .text start:0x0212edac end:0x0212edf8
+
+src/_ZN8WallSignD0Ev.c:
+    .text start:0x0212edf8 end:0x0212ee58
+
+src/_ZN8WallSign16CleanupResourcesEv.c:
+    complete
+    .text start:0x0212ee58 end:0x0212ee7c
+
+src/_ZN8WallSign6RenderEv.cpp:
+    complete
+    .text start:0x0212ee7c end:0x0212eea4
+
+src/_ZN8WallSign13InitResourcesEv.cpp:
+    .text start:0x0212f1b0 end:0x0212f244
+
+src/WallSign_Spawn.c:
+    complete
+    .text start:0x0212f244 end:0x0212f27c
+
+src/__sinit_ov085_0212f2a8.c:
+    .init start:0x0212f2a8 end:0x0212f3a0
+
+src/__sinit_ov085_0212f3a0.c:
+    .init start:0x0212f3a0 end:0x0212f5ec
+
+src/__sinit_ov085_0212f5ec.c:
+    .init start:0x0212f5ec end:0x0212f9bc
+
+src/__sinit_ov085_0212f9bc.c:
+    .init start:0x0212f9bc end:0x0212fa40
+
+src/__sinit_ov085_0212fa40.c:
+    .init start:0x0212fa40 end:0x0212fdb0
+
+src/__sinit_ov085_0212fdb0.c:
+    .init start:0x0212fdb0 end:0x0212fdf0

--- a/config/arm9/overlays/ov089/delinks.txt
+++ b/config/arm9/overlays/ov089/delinks.txt
@@ -4,3 +4,80 @@
     .ctor       start:0x02132af4 end:0x02132af8 kind:rodata align:4
     .data       start:0x02132b00 end:0x02132c40 kind:data align:32
     .bss        start:0x02132c40 end:0x02132d40 kind:bss align:32
+src/_ZN3KeyD1Ev.c:
+    complete
+    .text start:0x02130f00 end:0x02130f50
+
+src/_ZN3KeyD0Ev.c:
+    complete
+    .text start:0x02130f50 end:0x02130fb4
+
+src/func_ov089_02130fb4.c:
+    .text start:0x02130fb4 end:0x021310cc
+
+src/UnloadKeyModels.cpp:
+    complete
+    .text start:0x021310cc end:0x02131114
+
+src/LoadKeyModels.cpp:
+    complete
+    .text start:0x02131114 end:0x0213115c
+
+src/func_ov089_0213115c.cpp:
+    complete
+    .text start:0x0213115c end:0x021311c0
+
+src/func_ov089_021311c0.c:
+    complete
+    .text start:0x021311c0 end:0x0213162c
+
+src/func_ov089_0213162c.c:
+    .text start:0x0213162c end:0x02131b18
+
+src/func_ov089_02131b18.c:
+    complete
+    .text start:0x02131b18 end:0x02131dcc
+
+src/func_ov089_02131dcc.c:
+    complete
+    .text start:0x02131dcc end:0x02131df4
+
+src/func_ov089_02131df4.c:
+    complete
+    .text start:0x02131df4 end:0x02131f04
+
+src/func_ov089_02131f04.cpp:
+    complete
+    .text start:0x02131f04 end:0x02131f4c
+
+src/func_ov089_02131f4c.c:
+    complete
+    .text start:0x02131f4c end:0x02131f54
+
+src/func_ov089_02131f54.cpp:
+    complete
+    .text start:0x02131f54 end:0x02132084
+
+src/_ZN3Key16CleanupResourcesEv.cpp:
+    .text start:0x02132084 end:0x021320f0
+
+src/_ZN3Key6RenderEv.cpp:
+    complete
+    .text start:0x021320f0 end:0x02132194
+
+src/_ZN3Key8BehaviorEv.cpp:
+    .text start:0x02132194 end:0x021324a4
+
+src/_ZN3Key13InitResourcesEv.cpp:
+    .text start:0x021324a4 end:0x021327d0
+
+src/LastStar_Spawn.c:
+    complete
+    .text start:0x021327d0 end:0x02132828
+
+src/Key_Spawn.c:
+    complete
+    .text start:0x02132828 end:0x02132880
+
+src/__sinit_ov089_021328d4.c:
+    .init start:0x021328d4 end:0x02132af4

--- a/config/arm9/overlays/ov090/delinks.txt
+++ b/config/arm9/overlays/ov090/delinks.txt
@@ -3,3 +3,273 @@
     .ctor       start:0x021340c4 end:0x021340d4 kind:rodata align:4
     .data       start:0x021340e0 end:0x02134480 kind:data align:32
     .bss        start:0x02134480 end:0x021345e0 kind:bss align:32
+src/_ZN7SkeeterD1Ev.c:
+    complete
+    .text start:0x02130f00 end:0x02130f40
+
+src/_ZN7SkeeterD0Ev.c:
+    complete
+    .text start:0x02130f40 end:0x02130f94
+
+src/func_ov090_02130f94.c:
+    complete
+    .text start:0x02130f94 end:0x021310b4
+
+src/func_ov090_021310b4.c:
+    .text start:0x021310b4 end:0x02131378
+
+src/func_ov090_02131378.cpp:
+    complete
+    .text start:0x02131378 end:0x021314a0
+
+src/func_ov090_021314a0.cpp:
+    complete
+    .text start:0x021314a0 end:0x02131584
+
+src/func_ov090_02131584.c:
+    complete
+    .text start:0x02131584 end:0x02131608
+
+src/func_ov090_02131608.cpp:
+    complete
+    .text start:0x02131608 end:0x02131648
+
+src/func_ov090_02131648.cpp:
+    complete
+    .text start:0x02131648 end:0x02131a74
+
+src/func_ov090_02131a74.cpp:
+    complete
+    .text start:0x02131a74 end:0x02131ac4
+
+src/func_ov090_02131ac4.cpp:
+    complete
+    .text start:0x02131ac4 end:0x02131b94
+
+src/func_ov090_02131b94.cpp:
+    complete
+    .text start:0x02131b94 end:0x02131c48
+
+src/func_ov090_02131c48.c:
+    complete
+    .text start:0x02131c48 end:0x02131db0
+
+src/func_ov090_02131db0.c:
+    complete
+    .text start:0x02131db0 end:0x02131e00
+
+src/func_ov090_02131e00.cpp:
+    complete
+    .text start:0x02131e00 end:0x02131e50
+
+src/func_ov090_02131e50.c:
+    complete
+    .text start:0x02131e50 end:0x02131edc
+
+src/_ZN7Skeeter16CleanupResourcesEv.c:
+    complete
+    .text start:0x02131edc end:0x02131f30
+
+src/_ZN7Skeeter16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02131f30 end:0x02131f34
+
+src/_ZN7Skeeter6RenderEv.cpp:
+    complete
+    .text start:0x02131f34 end:0x02131f88
+
+src/_ZN7Skeeter8BehaviorEv.cpp:
+    .text start:0x02131f88 end:0x0213235c
+
+src/_ZN7Skeeter13InitResourcesEv.cpp:
+    complete
+    .text start:0x0213235c end:0x02132618
+
+src/func_ov090_02132618.c:
+    complete
+    .text start:0x02132618 end:0x02132620
+
+src/func_ov090_02132620.cpp:
+    complete
+    .text start:0x02132620 end:0x0213264c
+
+src/func_ov090_0213264c.c:
+    complete
+    .text start:0x0213264c end:0x02132654
+
+src/Skeeter_Spawn.c:
+    complete
+    .text start:0x02132654 end:0x0213269c
+
+src/_ZN8MantaRayD1Ev.c:
+    complete
+    .text start:0x0213269c end:0x021326dc
+
+src/_ZN8MantaRayD0Ev.c:
+    complete
+    .text start:0x021326dc end:0x02132730
+
+src/func_ov090_02132730.cpp:
+    complete
+    .text start:0x02132730 end:0x021327e4
+
+src/func_ov090_021327e4.cpp:
+    complete
+    .text start:0x021327e4 end:0x02132a58
+
+src/func_ov090_02132a58.cpp:
+    complete
+    .text start:0x02132a58 end:0x02132ac4
+
+src/func_ov090_02132ac4.cpp:
+    complete
+    .text start:0x02132ac4 end:0x02132b14
+
+src/func_ov090_02132b14.c:
+    complete
+    .text start:0x02132b14 end:0x02132c1c
+
+src/_ZN8MantaRay16CleanupResourcesEv.c:
+    complete
+    .text start:0x02132c1c end:0x02132c64
+
+src/_ZN8MantaRay16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02132c64 end:0x02132c68
+
+src/_ZN8MantaRay6RenderEv.cpp:
+    complete
+    .text start:0x02132c68 end:0x02132c94
+
+src/_ZN8MantaRay8BehaviorEv.cpp:
+    complete
+    .text start:0x02132c94 end:0x02132e38
+
+src/_ZN8MantaRay13InitResourcesEv.cpp:
+    complete
+    .text start:0x02132e38 end:0x02132fe8
+
+src/MantaRay_Spawn.c:
+    complete
+    .text start:0x02132fe8 end:0x02133034
+
+src/_ZN10CheepCheepD1Ev.c:
+    complete
+    .text start:0x02133034 end:0x02133074
+
+src/_ZN10CheepCheepD0Ev.c:
+    complete
+    .text start:0x02133074 end:0x021330c8
+
+src/func_ov090_021330c8.cpp:
+    complete
+    .text start:0x021330c8 end:0x02133190
+
+src/func_ov090_02133190.c:
+    complete
+    .text start:0x02133190 end:0x021331c4
+
+src/func_ov090_021331c4.c:
+    complete
+    .text start:0x021331c4 end:0x02133200
+
+src/func_ov090_02133200.c:
+    complete
+    .text start:0x02133200 end:0x02133290
+
+src/func_ov090_02133290.c:
+    complete
+    .text start:0x02133290 end:0x021332e8
+
+src/func_ov090_021332e8.cpp:
+    complete
+    .text start:0x021332e8 end:0x02133338
+
+src/func_ov090_02133338.c:
+    complete
+    .text start:0x02133338 end:0x021333ac
+
+src/_ZN10CheepCheep16CleanupResourcesEv.c:
+    complete
+    .text start:0x021333ac end:0x021333dc
+
+src/_ZN10CheepCheep16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021333dc end:0x021333e0
+
+src/_ZN10CheepCheep6RenderEv.cpp:
+    complete
+    .text start:0x021333e0 end:0x02133430
+
+src/_ZN10CheepCheep8BehaviorEv.cpp:
+    .text start:0x02133430 end:0x02133530
+
+src/_ZN10CheepCheep13InitResourcesEv.cpp:
+    .text start:0x02133530 end:0x02133634
+
+src/CheepCheep_Spawn.c:
+    complete
+    .text start:0x02133634 end:0x0213367c
+
+src/_ZN5SharkD1Ev.c:
+    complete
+    .text start:0x0213367c end:0x021336bc
+
+src/_ZN5SharkD0Ev.c:
+    complete
+    .text start:0x021336bc end:0x02133710
+
+src/func_ov090_02133710.cpp:
+    complete
+    .text start:0x02133710 end:0x02133830
+
+src/func_ov090_02133830.c:
+    complete
+    .text start:0x02133830 end:0x0213387c
+
+src/func_ov090_0213387c.c:
+    complete
+    .text start:0x0213387c end:0x021338b4
+
+src/func_ov090_021338b4.cpp:
+    complete
+    .text start:0x021338b4 end:0x02133904
+
+src/func_ov090_02133904.c:
+    complete
+    .text start:0x02133904 end:0x02133978
+
+src/_ZN5Shark16CleanupResourcesEv.c:
+    complete
+    .text start:0x02133978 end:0x021339a8
+
+src/_ZN5Shark16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021339a8 end:0x021339ac
+
+src/_ZN5Shark6RenderEv.cpp:
+    complete
+    .text start:0x021339ac end:0x021339d8
+
+src/_ZN5Shark8BehaviorEv.cpp:
+    complete
+    .text start:0x021339d8 end:0x02133b98
+
+src/_ZN5Shark13InitResourcesEv.cpp:
+    .text start:0x02133b98 end:0x02133ca0
+
+src/Shark_Spawn.c:
+    complete
+    .text start:0x02133ca0 end:0x02133ce8
+
+src/__sinit_ov090_02133ce8.c:
+    .init start:0x02133ce8 end:0x02133ea8
+
+src/__sinit_ov090_02133ea8.c:
+    .init start:0x02133ea8 end:0x02133f4c
+
+src/__sinit_ov090_02133f4c.c:
+    .init start:0x02133f4c end:0x02134020
+
+src/__sinit_ov090_02134020.c:
+    .init start:0x02134020 end:0x021340c4

--- a/config/arm9/overlays/ov091/delinks.txt
+++ b/config/arm9/overlays/ov091/delinks.txt
@@ -4,3 +4,353 @@
     .ctor       start:0x02134b68 end:0x02134b80 kind:rodata align:4
     .data       start:0x02134ba0 end:0x02135440 kind:data align:32
     .bss        start:0x02135440 end:0x021356e0 kind:bss align:32
+src/_ZN25RotatingUpDownPlatformUtmD1Ev.c:
+    .text start:0x02130f00 end:0x02130f4c
+
+src/_ZN25RotatingUpDownPlatformUtmD0Ev.c:
+    .text start:0x02130f4c end:0x02130fac
+
+src/func_ov091_02130fac.cpp:
+    complete
+    .text start:0x02130fac end:0x02131070
+
+src/func_ov091_02131070.cpp:
+    .text start:0x02131070 end:0x021310fc
+
+src/func_ov091_021310fc.cpp:
+    .text start:0x021310fc end:0x02131160
+
+src/func_ov091_02131160.c:
+    complete
+    .text start:0x02131160 end:0x02131340
+
+src/func_ov091_02131340.c:
+    complete
+    .text start:0x02131340 end:0x02131388
+
+src/_ZN25RotatingUpDownPlatformUtm16CleanupResourcesEv.cpp:
+    .text start:0x02131388 end:0x02131408
+
+src/_ZN25RotatingUpDownPlatformUtm6RenderEv.cpp:
+    complete
+    .text start:0x02131408 end:0x02131468
+
+src/_ZN25RotatingUpDownPlatformUtm8BehaviorEv.cpp:
+    .text start:0x02131468 end:0x021318f0
+
+src/_ZN25RotatingUpDownPlatformUtm13InitResourcesEv.cpp:
+    .text start:0x021318f0 end:0x02131ba4
+
+src/RotatingUpDownPlatformUtm_Spawn.c:
+    complete
+    .text start:0x02131ba4 end:0x02131bdc
+
+src/RotatingUpDownPlatform_Spawn.c:
+    complete
+    .text start:0x02131bdc end:0x02131c14
+
+src/_ZN22RotatingUpDownPlatformD1Ev.c:
+    .text start:0x02131c14 end:0x02131c58
+
+src/_ZN22RotatingUpDownPlatformD0Ev.c:
+    .text start:0x02131c58 end:0x02131cb0
+
+src/func_ov091_02131cb0.c:
+    complete
+    .text start:0x02131cb0 end:0x02131db8
+
+src/func_ov091_02131db8.c:
+    complete
+    .text start:0x02131db8 end:0x02131ef0
+
+src/func_ov091_02131ef0.c:
+    complete
+    .text start:0x02131ef0 end:0x02131f9c
+
+src/func_ov091_02131f9c.c:
+    complete
+    .text start:0x02131f9c end:0x02132000
+
+src/func_ov091_02132000.c:
+    complete
+    .text start:0x02132000 end:0x0213209c
+
+src/_ZN22RotatingUpDownPlatform16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0213209c end:0x021320e0
+
+src/_ZN22RotatingUpDownPlatform6RenderEv.cpp:
+    complete
+    .text start:0x021320e0 end:0x02132108
+
+src/_ZN22RotatingUpDownPlatform8BehaviorEv.cpp:
+    .text start:0x02132108 end:0x0213220c
+
+src/_ZN22RotatingUpDownPlatform13InitResourcesEv.cpp:
+    .text start:0x0213220c end:0x02132360
+
+src/func_ov091_02132360.cpp:
+    complete
+    .text start:0x02132360 end:0x02132380
+
+src/func_ov091_02132380.c:
+    complete
+    .text start:0x02132380 end:0x02132394
+
+src/SquareMetalNetLift_Spawn.c:
+    complete
+    .text start:0x02132394 end:0x021323cc
+
+src/ArrowPathLift_Spawn.c:
+    complete
+    .text start:0x021323cc end:0x02132404
+
+src/_ZN17SlidingPlatformWfD1Ev.c:
+    .text start:0x02132404 end:0x02132448
+
+src/_ZN17SlidingPlatformWfD0Ev.c:
+    .text start:0x02132448 end:0x021324a0
+
+src/_ZN17SlidingPlatformWf16CleanupResourcesEv.cpp:
+    .text start:0x021324a0 end:0x02132504
+
+src/_ZN17SlidingPlatformWf6RenderEv.cpp:
+    complete
+    .text start:0x02132504 end:0x0213252c
+
+src/_ZN17SlidingPlatformWf8BehaviorEv.cpp:
+    .text start:0x0213252c end:0x021325d4
+
+src/_ZN17SlidingPlatformWf13InitResourcesEv.cpp:
+    .text start:0x021325d4 end:0x021327e8
+
+src/SlidingPlatformWf_Spawn.c:
+    complete
+    .text start:0x021327e8 end:0x02132818
+
+src/SlidingPlatformBfsRectangle_Spawn.c:
+    complete
+    .text start:0x02132818 end:0x02132848
+
+src/SlidingPlatformBfsSquare_Spawn.c:
+    complete
+    .text start:0x02132848 end:0x02132878
+
+src/SlidingPlatformRr_Spawn.c:
+    complete
+    .text start:0x02132878 end:0x021328a8
+
+src/SlidingPlatformBsLong_Spawn.c:
+    complete
+    .text start:0x021328a8 end:0x021328d8
+
+src/SlidingPlatformBsWide_Spawn.c:
+    complete
+    .text start:0x021328d8 end:0x02132908
+
+src/SlidingPlatformBdw_Spawn.c:
+    complete
+    .text start:0x02132908 end:0x02132938
+
+src/_ZN6ThwompD1Ev.c:
+    .text start:0x02132938 end:0x02132998
+
+src/_ZN6ThwompD0Ev.c:
+    .text start:0x02132998 end:0x02132a0c
+
+src/func_ov091_02132a0c.c:
+    complete
+    .text start:0x02132a0c end:0x02132a14
+
+src/func_ov091_02132a14.cpp:
+    complete
+    .text start:0x02132a14 end:0x02132ab0
+
+src/_ZN6Thwomp8BehaviorEv.cpp:
+    complete
+    .text start:0x02132ab0 end:0x02132c84
+
+src/_ZN6Thwomp13InitResourcesEv.cpp:
+    .text start:0x02132c84 end:0x02132cb8
+
+src/Thwomp_Spawn.c:
+    .text start:0x02132cb8 end:0x02132d04
+
+src/func_ov091_02132d04.c:
+    .text start:0x02132d04 end:0x02132d6c
+
+src/func_ov091_02132d6c.c:
+    .text start:0x02132d6c end:0x02132dc0
+
+src/func_ov091_02132dc0.cpp:
+    complete
+    .text start:0x02132dc0 end:0x02132e64
+
+src/func_ov091_02132e64.c:
+    complete
+    .text start:0x02132e64 end:0x02132e98
+
+src/func_ov091_02132e98.c:
+    complete
+    .text start:0x02132e98 end:0x02132f04
+
+src/func_ov091_02132f04.cpp:
+    complete
+    .text start:0x02132f04 end:0x02132ff4
+
+src/func_ov091_02132ff4.c:
+    complete
+    .text start:0x02132ff4 end:0x02133020
+
+src/func_ov091_02133020.c:
+    complete
+    .text start:0x02133020 end:0x02133098
+
+src/func_ov091_02133098.cpp:
+    complete
+    .text start:0x02133098 end:0x021331b8
+
+src/_ZN6Thwomp16CleanupResourcesEv.cpp:
+    .text start:0x021331b8 end:0x02133210
+
+src/_ZN6Thwomp6RenderEv.cpp:
+    complete
+    .text start:0x02133210 end:0x02133254
+
+src/func_ov091_02133254.cpp:
+    complete
+    .text start:0x02133254 end:0x021333fc
+
+src/func_ov091_021333fc.c:
+    .text start:0x021333fc end:0x02133440
+
+src/func_ov091_02133440.c:
+    .text start:0x02133440 end:0x02133498
+
+src/func_ov091_02133498.c:
+    complete
+    .text start:0x02133498 end:0x021334b8
+
+src/func_ov091_021334b8.cpp:
+    .text start:0x021334b8 end:0x021335d4
+
+src/func_ov091_021335d4.c:
+    complete
+    .text start:0x021335d4 end:0x02133648
+
+src/func_ov091_02133648.cpp:
+    complete
+    .text start:0x02133648 end:0x021336cc
+
+src/func_ov091_021336cc.c:
+    complete
+    .text start:0x021336cc end:0x02133710
+
+src/func_ov091_02133710.cpp:
+    complete
+    .text start:0x02133710 end:0x02133738
+
+src/func_ov091_02133738.cpp:
+    .text start:0x02133738 end:0x021338ac
+
+src/func_ov091_021338ac.c:
+    complete
+    .text start:0x021338ac end:0x02133938
+
+src/Stump_Spawn.c:
+    complete
+    .text start:0x02133938 end:0x02133968
+
+src/_ZN5StumpD1Ev.c:
+    complete
+    .text start:0x02133968 end:0x021339a8
+
+src/_ZN5StumpD0Ev.c:
+    complete
+    .text start:0x021339a8 end:0x021339fc
+
+src/func_ov091_021339fc.c:
+    .text start:0x021339fc end:0x02133c6c
+
+src/func_ov091_02133c6c.c:
+    complete
+    .text start:0x02133c6c end:0x02133d1c
+
+src/func_ov091_02133d1c.c:
+    complete
+    .text start:0x02133d1c end:0x02133d30
+
+src/func_ov091_02133d30.cpp:
+    complete
+    .text start:0x02133d30 end:0x02133f24
+
+src/func_ov091_02133f24.c:
+    complete
+    .text start:0x02133f24 end:0x02133f60
+
+src/func_ov091_02133f60.c:
+    complete
+    .text start:0x02133f60 end:0x0213400c
+
+src/func_ov091_0213400c.c:
+    complete
+    .text start:0x0213400c end:0x02134044
+
+src/func_ov091_02134044.cpp:
+    complete
+    .text start:0x02134044 end:0x02134094
+
+src/func_ov091_02134094.c:
+    complete
+    .text start:0x02134094 end:0x02134108
+
+src/_ZN5Stump16CleanupResourcesEv.cpp:
+    .text start:0x02134108 end:0x02134180
+
+src/_ZN5Stump16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02134180 end:0x02134184
+
+src/_ZN5Stump6RenderEv.cpp:
+    complete
+    .text start:0x02134184 end:0x021341ec
+
+src/_ZN5Stump8BehaviorEv.cpp:
+    .text start:0x021341ec end:0x02134324
+
+src/_ZN5Stump13InitResourcesEv.cpp:
+    .text start:0x02134324 end:0x02134484
+
+src/func_ov091_02134484.c:
+    complete
+    .text start:0x02134484 end:0x0213448c
+
+src/func_ov091_0213448c.c:
+    complete
+    .text start:0x0213448c end:0x02134498
+
+src/func_ov091_02134498.c:
+    complete
+    .text start:0x02134498 end:0x021344a0
+
+src/Fwoosh_Spawn.c:
+    complete
+    .text start:0x021344a0 end:0x021344e8
+
+src/__sinit_ov091_02134524.c:
+    .init start:0x02134524 end:0x021345dc
+
+src/__sinit_ov091_021345dc.c:
+    .init start:0x021345dc end:0x021346e8
+
+src/__sinit_ov091_021346e8.c:
+    .init start:0x021346e8 end:0x02134930
+
+src/__sinit_ov091_02134930.c:
+    .init start:0x02134930 end:0x021349c4
+
+src/__sinit_ov091_021349c4.c:
+    .init start:0x021349c4 end:0x02134a30
+
+src/__sinit_ov091_02134a30.c:
+    .init start:0x02134a30 end:0x02134b68

--- a/config/arm9/overlays/ov092/delinks.txt
+++ b/config/arm9/overlays/ov092/delinks.txt
@@ -4,3 +4,96 @@
     .ctor       start:0x02132210 end:0x02132214 kind:rodata align:4
     .data       start:0x02132220 end:0x02132540 kind:data align:32
     .bss        start:0x02132540 end:0x021325c0 kind:bss align:32
+src/_ZN6ToxBoxD1Ev.cpp:
+    complete
+    .text start:0x02130f00 end:0x02130f5c
+
+src/_ZN6ToxBoxD0Ev.cpp:
+    .text start:0x02130f5c end:0x02130fcc
+
+src/func_ov092_02130fcc.c:
+    complete
+    .text start:0x02130fcc end:0x02131010
+
+src/func_ov092_02131010.cpp:
+    complete
+    .text start:0x02131010 end:0x021311b0
+
+src/func_ov092_021311b0.cpp:
+    complete
+    .text start:0x021311b0 end:0x021313b0
+
+src/func_ov092_021313b0.cpp:
+    complete
+    .text start:0x021313b0 end:0x021314d0
+
+src/func_ov092_021314d0.c:
+    complete
+    .text start:0x021314d0 end:0x02131578
+
+src/func_ov092_02131578.c:
+    complete
+    .text start:0x02131578 end:0x021315ac
+
+src/func_ov092_021315ac.c:
+    complete
+    .text start:0x021315ac end:0x02131620
+
+src/func_ov092_02131620.c:
+    complete
+    .text start:0x02131620 end:0x02131650
+
+src/func_ov092_02131650.c:
+    complete
+    .text start:0x02131650 end:0x02131680
+
+src/func_ov092_02131680.c:
+    complete
+    .text start:0x02131680 end:0x021316b0
+
+src/func_ov092_021316b0.c:
+    complete
+    .text start:0x021316b0 end:0x021316d8
+
+src/func_ov092_021316d8.c:
+    complete
+    .text start:0x021316d8 end:0x02131878
+
+src/func_ov092_02131878.c:
+    complete
+    .text start:0x02131878 end:0x021319b0
+
+src/func_ov092_021319b0.cpp:
+    complete
+    .text start:0x021319b0 end:0x02131a88
+
+src/func_ov092_02131a88.cpp:
+    complete
+    .text start:0x02131a88 end:0x02131aec
+
+src/func_ov092_02131aec.cpp:
+    complete
+    .text start:0x02131aec end:0x02131bd8
+
+src/_ZN6ToxBox16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02131bd8 end:0x02131c1c
+
+src/_ZN6ToxBox6RenderEv.cpp:
+    complete
+    .text start:0x02131c1c end:0x02131c44
+
+src/_ZN6ToxBox8BehaviorEv.cpp:
+    complete
+    .text start:0x02131c44 end:0x02131da0
+
+src/_ZN6ToxBox13InitResourcesEv.c:
+    complete
+    .text start:0x02131da0 end:0x02132018
+
+src/ToxBox_Spawn.c:
+    complete
+    .text start:0x02132018 end:0x02132074
+
+src/__sinit_ov092_021320cc.c:
+    .init start:0x021320cc end:0x02132210

--- a/config/arm9/overlays/ov094/delinks.txt
+++ b/config/arm9/overlays/ov094/delinks.txt
@@ -3,3 +3,91 @@
     .ctor       start:0x021369b8 end:0x021369bc kind:rodata align:4
     .data       start:0x021369c0 end:0x02136ae0 kind:data align:32
     .bss        start:0x02136ae0 end:0x02136b80 kind:bss align:32
+src/_ZN10HootTheOwlD1Ev.c:
+    complete
+    .text start:0x02135700 end:0x02135748
+
+src/_ZN10HootTheOwlD0Ev.c:
+    complete
+    .text start:0x02135748 end:0x021357a4
+
+src/func_ov094_021357a4.c:
+    complete
+    .text start:0x021357a4 end:0x021358b4
+
+src/func_ov094_021358b4.cpp:
+    complete
+    .text start:0x021358b4 end:0x0213598c
+
+src/func_ov094_0213598c.cpp:
+    complete
+    .text start:0x0213598c end:0x021359d8
+
+src/func_ov094_021359d8.cpp:
+    complete
+    .text start:0x021359d8 end:0x02135bd4
+
+src/func_ov094_02135bd4.cpp:
+    complete
+    .text start:0x02135bd4 end:0x02135c28
+
+src/func_ov094_02135c28.c:
+    complete
+    .text start:0x02135c28 end:0x02135e64
+
+src/func_ov094_02135e64.cpp:
+    complete
+    .text start:0x02135e64 end:0x02135ee0
+
+src/func_ov094_02135ee0.cpp:
+    complete
+    .text start:0x02135ee0 end:0x02135fe0
+
+src/func_ov094_02135fe0.c:
+    complete
+    .text start:0x02135fe0 end:0x02136024
+
+src/func_ov094_02136024.c:
+    complete
+    .text start:0x02136024 end:0x02136150
+
+src/func_ov094_02136150.c:
+    complete
+    .text start:0x02136150 end:0x02136188
+
+src/func_ov094_02136188.cpp:
+    complete
+    .text start:0x02136188 end:0x021361d8
+
+src/func_ov094_021361d8.c:
+    complete
+    .text start:0x021361d8 end:0x021362e0
+
+src/func_ov094_021362e0.c:
+    complete
+    .text start:0x021362e0 end:0x021363e0
+
+src/_ZN10HootTheOwl16CleanupResourcesEv.c:
+    complete
+    .text start:0x021363e0 end:0x02136428
+
+src/_ZN10HootTheOwl16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02136428 end:0x0213642c
+
+src/_ZN10HootTheOwl6RenderEv.cpp:
+    complete
+    .text start:0x0213642c end:0x02136478
+
+src/_ZN10HootTheOwl8BehaviorEv.cpp:
+    .text start:0x02136478 end:0x02136634
+
+src/_ZN10HootTheOwl13InitResourcesEv.cpp:
+    .text start:0x02136634 end:0x02136798
+
+src/HootTheOwl_Spawn.c:
+    complete
+    .text start:0x02136798 end:0x021367e8
+
+src/__sinit_ov094_021367e8.c:
+    .init start:0x021367e8 end:0x021369b8

--- a/config/arm9/overlays/ov095/delinks.txt
+++ b/config/arm9/overlays/ov095/delinks.txt
@@ -4,3 +4,153 @@
     .ctor       start:0x021373b4 end:0x021373bc kind:rodata align:4
     .data       start:0x021373c0 end:0x02137780 kind:data align:32
     .bss        start:0x02137780 end:0x02137940 kind:bss align:32
+src/_ZN9SeesawBobD1Ev.c:
+    .text start:0x02135700 end:0x02135744
+
+src/_ZN9SeesawBobD0Ev.c:
+    .text start:0x02135744 end:0x0213579c
+
+src/func_ov095_0213579c.c:
+    complete
+    .text start:0x0213579c end:0x021357d8
+
+src/func_ov095_021357d8.c:
+    complete
+    .text start:0x021357d8 end:0x021358cc
+
+src/func_ov095_021358cc.c:
+    complete
+    .text start:0x021358cc end:0x0213597c
+
+src/func_ov095_0213597c.c:
+    complete
+    .text start:0x0213597c end:0x021359c4
+
+src/_ZN9SeesawBob16CleanupResourcesEv.cpp:
+    .text start:0x021359c4 end:0x02135a28
+
+src/_ZN9SeesawBob6RenderEv.cpp:
+    complete
+    .text start:0x02135a28 end:0x02135a50
+
+src/_ZN9SeesawBob8BehaviorEv.cpp:
+    complete
+    .text start:0x02135a50 end:0x02135b74
+
+src/_ZN9SeesawBob13InitResourcesEv.cpp:
+    .text start:0x02135b74 end:0x02135cdc
+
+src/func_ov095_02135cdc.c:
+    complete
+    .text start:0x02135cdc end:0x02135e90
+
+src/func_ov095_02135e90.c:
+    complete
+    .text start:0x02135e90 end:0x02135ea4
+
+src/SeesawRr_Spawn.c:
+    complete
+    .text start:0x02135ea4 end:0x02135ed4
+
+src/SeesawBsZigZag_Spawn.c:
+    complete
+    .text start:0x02135ed4 end:0x02135f04
+
+src/SeesawBsPlank_Spawn.c:
+    complete
+    .text start:0x02135f04 end:0x02135f34
+
+src/SeesawBfs_Spawn.c:
+    complete
+    .text start:0x02135f34 end:0x02135f64
+
+src/SeesawBdw_Spawn.c:
+    complete
+    .text start:0x02135f64 end:0x02135f94
+
+src/SeesawBob_Spawn.c:
+    complete
+    .text start:0x02135f94 end:0x02135fc4
+
+src/SeesawUtm_Spawn.c:
+    complete
+    .text start:0x02135fc4 end:0x02135ff4
+
+src/_ZN13UpDownLiftBbhD1Ev.c:
+    .text start:0x02135ff4 end:0x02136038
+
+src/_ZN13UpDownLiftBbhD0Ev.c:
+    .text start:0x02136038 end:0x02136090
+
+src/func_ov095_02136090.cpp:
+    complete
+    .text start:0x02136090 end:0x02136104
+
+src/func_ov095_02136104.cpp:
+    complete
+    .text start:0x02136104 end:0x02136178
+
+src/func_ov095_02136178.c:
+    complete
+    .text start:0x02136178 end:0x02136298
+
+src/func_ov095_02136298.cpp:
+    complete
+    .text start:0x02136298 end:0x02136368
+
+src/func_ov095_02136368.c:
+    complete
+    .text start:0x02136368 end:0x0213645c
+
+src/_ZN13UpDownLiftBbh16CleanupResourcesEv.cpp:
+    .text start:0x0213645c end:0x021364b0
+
+src/_ZN13UpDownLiftBbh6RenderEv.cpp:
+    complete
+    .text start:0x021364b0 end:0x021364d8
+
+src/_ZN13UpDownLiftBbh8BehaviorEv.cpp:
+    complete
+    .text start:0x021364d8 end:0x021365d8
+
+src/_ZN13UpDownLiftBbh13InitResourcesEv.cpp:
+    .text start:0x021365d8 end:0x02136764
+
+src/func_ov095_02136764.cpp:
+    complete
+    .text start:0x02136764 end:0x02136788
+
+src/func_ov095_02136788.c:
+    complete
+    .text start:0x02136788 end:0x0213679c
+
+src/UpDownLiftRr_Spawn.c:
+    complete
+    .text start:0x0213679c end:0x021367cc
+
+src/UpDownLiftHmc_Spawn.c:
+    complete
+    .text start:0x021367cc end:0x021367fc
+
+src/UpDownLiftBbh_Spawn.c:
+    complete
+    .text start:0x021367fc end:0x0213682c
+
+src/_ZN12FlamethrowerD1Ev.cpp:
+    .text start:0x0213682c end:0x02136884
+
+src/_ZN12FlamethrowerD0Ev.cpp:
+    .text start:0x02136884 end:0x021368f0
+
+src/_ZN12Flamethrower13InitResourcesEv.cpp:
+    .text start:0x02136d60 end:0x02136ed4
+
+src/Flamethrower_Spawn.cpp:
+    complete
+    .text start:0x02136ed4 end:0x02136f58
+
+src/__sinit_ov095_02136fe0.c:
+    .init start:0x02136fe0 end:0x0213722c
+
+src/__sinit_ov095_0213722c.c:
+    .init start:0x0213722c end:0x021373b4

--- a/config/arm9/overlays/ov096/delinks.txt
+++ b/config/arm9/overlays/ov096/delinks.txt
@@ -3,3 +3,187 @@
     .ctor       start:0x02137900 end:0x02137908 kind:rodata align:4
     .data       start:0x02137920 end:0x02137b20 kind:data align:32
     .bss        start:0x02137b20 end:0x02137be0 kind:bss align:32
+src/_ZN5PokeyD1Ev.cpp:
+    .text start:0x02135700 end:0x02135748
+
+src/_ZN5PokeyD0Ev.c:
+    complete
+    .text start:0x02135748 end:0x021357a4
+
+src/func_ov096_021357a4.c:
+    complete
+    .text start:0x021357a4 end:0x021357ac
+
+src/func_ov096_021357ac.c:
+    complete
+    .text start:0x021357ac end:0x021357b4
+
+src/func_ov096_021357b4.c:
+    complete
+    .text start:0x021357b4 end:0x02135800
+
+src/func_ov096_02135800.cpp:
+    complete
+    .text start:0x02135800 end:0x02135838
+
+src/func_ov096_02135838.c:
+    complete
+    .text start:0x02135838 end:0x0213585c
+
+src/func_ov096_0213585c.c:
+    complete
+    .text start:0x0213585c end:0x02135878
+
+src/func_ov096_02135878.cpp:
+    complete
+    .text start:0x02135878 end:0x021358c8
+
+src/func_ov096_021358c8.cpp:
+    complete
+    .text start:0x021358c8 end:0x02135948
+
+src/func_ov096_02135948.cpp:
+    .text start:0x02135948 end:0x02135e2c
+
+src/func_ov096_02135e2c.cpp:
+    complete
+    .text start:0x02135e2c end:0x02135efc
+
+src/func_ov096_02135efc.cpp:
+    complete
+    .text start:0x02135efc end:0x021360c4
+
+src/func_ov096_021360c4.cpp:
+    complete
+    .text start:0x021360c4 end:0x02136134
+
+src/func_ov096_02136134.cpp:
+    complete
+    .text start:0x02136134 end:0x02136264
+
+src/func_ov096_02136264.c:
+    complete
+    .text start:0x02136264 end:0x021363b4
+
+src/func_ov096_021363b4.c:
+    complete
+    .text start:0x021363b4 end:0x021363c4
+
+src/func_ov096_021363c4.c:
+    complete
+    .text start:0x021363c4 end:0x0213640c
+
+src/func_ov096_0213640c.c:
+    complete
+    .text start:0x0213640c end:0x02136434
+
+src/func_ov096_02136434.cpp:
+    .text start:0x02136434 end:0x02136534
+
+src/func_ov096_02136534.cpp:
+    complete
+    .text start:0x02136534 end:0x021365d4
+
+src/func_ov096_021365d4.c:
+    complete
+    .text start:0x021365d4 end:0x0213670c
+
+src/func_ov096_0213670c.c:
+    complete
+    .text start:0x0213670c end:0x02136754
+
+src/func_ov096_02136754.c:
+    complete
+    .text start:0x02136754 end:0x021368a4
+
+src/func_ov096_021368a4.c:
+    complete
+    .text start:0x021368a4 end:0x021368b4
+
+src/func_ov096_021368b4.cpp:
+    complete
+    .text start:0x021368b4 end:0x021368f0
+
+src/func_ov096_021368f0.cpp:
+    complete
+    .text start:0x021368f0 end:0x02136928
+
+src/func_ov096_02136928.c:
+    complete
+    .text start:0x02136928 end:0x02136944
+
+src/_ZN5Pokey16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x02136944 end:0x021369b0
+
+src/_ZN5Pokey16OnPendingDestroyEv.cpp:
+    .text start:0x021369b0 end:0x021369fc
+
+src/_ZN5Pokey6RenderEv.cpp:
+    complete
+    .text start:0x021369fc end:0x02136a50
+
+src/_ZN5Pokey8BehaviorEv.cpp:
+    .text start:0x02136a50 end:0x02136ab0
+
+src/_ZN5Pokey13InitResourcesEv.cpp:
+    complete
+    .text start:0x02136ab0 end:0x02136cd0
+
+src/func_ov096_02136cd0.c:
+    complete
+    .text start:0x02136cd0 end:0x02136d10
+
+src/PokeySegment_Spawn.c:
+    complete
+    .text start:0x02136d10 end:0x02136d60
+
+src/Pokey_Spawn.c:
+    complete
+    .text start:0x02136d60 end:0x02136db0
+
+src/_ZN7TornadoD1Ev.cpp:
+    .text start:0x02136db0 end:0x02136df8
+
+src/_ZN7TornadoD0Ev.c:
+    complete
+    .text start:0x02136df8 end:0x02136e54
+
+src/func_ov096_02136e54.c:
+    complete
+    .text start:0x02136e54 end:0x02136fd4
+
+src/func_ov096_02136fd4.c:
+    complete
+    .text start:0x02136fd4 end:0x02137088
+
+src/func_ov096_02137088.cpp:
+    .text start:0x02137088 end:0x021372c0
+
+src/func_ov096_021372c0.c:
+    complete
+    .text start:0x021372c0 end:0x021373e4
+
+src/_ZN7Tornado16CleanupResourcesEv.c:
+    complete
+    .text start:0x021373e4 end:0x02137414
+
+src/_ZN7Tornado6RenderEv.cpp:
+    complete
+    .text start:0x02137414 end:0x02137448
+
+src/_ZN7Tornado8BehaviorEv.cpp:
+    .text start:0x02137448 end:0x02137564
+
+src/_ZN7Tornado13InitResourcesEv.cpp:
+    .text start:0x02137564 end:0x021376bc
+
+src/Tornado_Spawn.c:
+    complete
+    .text start:0x021376bc end:0x0213770c
+
+src/__sinit_ov096_0213770c.c:
+    .init start:0x0213770c end:0x02137894
+
+src/__sinit_ov096_02137894.c:
+    .init start:0x02137894 end:0x02137900

--- a/config/arm9/overlays/ov098/delinks.txt
+++ b/config/arm9/overlays/ov098/delinks.txt
@@ -4,3 +4,359 @@
     .ctor       start:0x0213c33c end:0x0213c34c kind:rodata align:4
     .data       start:0x0213c360 end:0x0213c800 kind:data align:32
     .bss        start:0x0213c800 end:0x0213c960 kind:bss align:32
+src/_ZN14ArrowSignRightD1Ev.c:
+    .text start:0x02137be0 end:0x02137c2c
+
+src/_ZN14ArrowSignRightD0Ev.c:
+    .text start:0x02137c2c end:0x02137c8c
+
+src/func_ov098_02137c8c.c:
+    complete
+    .text start:0x02137c8c end:0x02137ccc
+
+src/func_ov098_02137ccc.cpp:
+    complete
+    .text start:0x02137ccc end:0x02137d40
+
+src/func_ov098_02137d40.cpp:
+    complete
+    .text start:0x02137d40 end:0x02137d80
+
+src/func_ov098_02137d80.c:
+    complete
+    .text start:0x02137d80 end:0x02137dbc
+
+src/_ZN14ArrowSignRight16CleanupResourcesEv.cpp:
+    .text start:0x02137dbc end:0x02137e20
+
+src/_ZN14ArrowSignRight6RenderEv.cpp:
+    complete
+    .text start:0x02137e20 end:0x02137e48
+
+src/_ZN14ArrowSignRight8BehaviorEv.cpp:
+    complete
+    .text start:0x02137e48 end:0x02137eec
+
+src/_ZN14ArrowSignRight13InitResourcesEv.cpp:
+    complete
+    .text start:0x02137eec end:0x02137fd0
+
+src/ArrowSignRight_Spawn.c:
+    complete
+    .text start:0x02137fd0 end:0x02138008
+
+src/ArrowSignLeft_Spawn.c:
+    complete
+    .text start:0x02138008 end:0x02138040
+
+src/_ZN5CrateD1Ev.cpp:
+    complete
+    .text start:0x02138040 end:0x021380bc
+
+src/_ZN5CrateD0Ev.c:
+    complete
+    .text start:0x021380bc end:0x0213814c
+
+src/func_ov098_0213814c.cpp:
+    complete
+    .text start:0x0213814c end:0x021381e8
+
+src/func_ov098_021381e8.c:
+    complete
+    .text start:0x021381e8 end:0x02138238
+
+src/func_ov098_02138238.c:
+    complete
+    .text start:0x02138238 end:0x02138318
+
+src/func_ov098_02138318.c:
+    complete
+    .text start:0x02138318 end:0x02138344
+
+src/func_ov098_02138344.cpp:
+    complete
+    .text start:0x02138344 end:0x02138484
+
+src/func_ov098_02138484.c:
+    complete
+    .text start:0x02138484 end:0x021384fc
+
+src/func_ov098_021384fc.cpp:
+    complete
+    .text start:0x021384fc end:0x021385e0
+
+src/func_ov098_021385e0.c:
+    complete
+    .text start:0x021385e0 end:0x02138734
+
+src/func_ov098_02138734.cpp:
+    complete
+    .text start:0x02138734 end:0x02138818
+
+src/func_ov098_02138818.c:
+    complete
+    .text start:0x02138818 end:0x021388bc
+
+src/func_ov098_021388bc.cpp:
+    complete
+    .text start:0x021388bc end:0x021389cc
+
+src/func_ov098_021389cc.c:
+    complete
+    .text start:0x021389cc end:0x021389f8
+
+src/func_ov098_021389f8.cpp:
+    complete
+    .text start:0x021389f8 end:0x02138b18
+
+src/func_ov098_02138b18.c:
+    complete
+    .text start:0x02138b18 end:0x02138b28
+
+src/Crate_SetState.cpp:
+    complete
+    .text start:0x02138b28 end:0x02138b70
+
+src/func_ov098_02138b70.cpp:
+    complete
+    .text start:0x02138b70 end:0x02138bb8
+
+src/func_ov098_02138bb8.cpp:
+    complete
+    .text start:0x02138bb8 end:0x02138bfc
+
+src/func_ov098_02138bfc.c:
+    complete
+    .text start:0x02138bfc end:0x02138ce0
+
+src/func_ov098_02138ce0.c:
+    complete
+    .text start:0x02138ce0 end:0x02138e08
+
+src/func_ov098_02138e08.c:
+    complete
+    .text start:0x02138e08 end:0x02138e6c
+
+src/func_ov098_02138e6c.cpp:
+    complete
+    .text start:0x02138e6c end:0x02139070
+
+src/func_ov098_02139070.c:
+    complete
+    .text start:0x02139070 end:0x021390ec
+
+src/func_ov098_021390ec.cpp:
+    .text start:0x021390ec end:0x02139228
+
+src/func_ov098_02139228.cpp:
+    .text start:0x02139228 end:0x021396a4
+
+src/func_ov098_021396a4.cpp:
+    complete
+    .text start:0x021396a4 end:0x021397c8
+
+src/func_ov098_021397c8.cpp:
+    complete
+    .text start:0x021397c8 end:0x02139850
+
+src/func_ov098_02139850.c:
+    complete
+    .text start:0x02139850 end:0x02139a50
+
+src/_ZN5Crate16CleanupResourcesEv.cpp:
+    .text start:0x02139a50 end:0x02139aa8
+
+src/_ZN5Crate6RenderEv.cpp:
+    complete
+    .text start:0x02139aa8 end:0x02139b0c
+
+src/_ZN5Crate8BehaviorEv.cpp:
+    .text start:0x02139b0c end:0x02139d14
+
+src/_ZN5Crate13InitResourcesEv.cpp:
+    .text start:0x02139d14 end:0x02139e44
+
+src/func_ov098_02139e44.cpp:
+    complete
+    .text start:0x02139e44 end:0x02139e64
+
+src/func_ov098_02139e64.c:
+    complete
+    .text start:0x02139e64 end:0x02139e78
+
+src/func_ov098_02139e78.c:
+    complete
+    .text start:0x02139e78 end:0x02139f04
+
+src/Crate_Spawn.cpp:
+    complete
+    .text start:0x02139f04 end:0x02139f70
+
+src/func_ov098_02139f70.c:
+    .text start:0x02139f70 end:0x02139fc8
+
+src/func_ov098_02139fc8.c:
+    .text start:0x02139fc8 end:0x0213a00c
+
+src/func_ov098_0213a00c.cpp:
+    complete
+    .text start:0x0213a00c end:0x0213a0a8
+
+src/func_ov098_0213a0a8.cpp:
+    complete
+    .text start:0x0213a0a8 end:0x0213a0e8
+
+src/func_ov098_0213a0e8.c:
+    complete
+    .text start:0x0213a0e8 end:0x0213a148
+
+src/func_ov098_0213a148.c:
+    complete
+    .text start:0x0213a148 end:0x0213a17c
+
+src/func_ov098_0213a17c.cpp:
+    complete
+    .text start:0x0213a17c end:0x0213a23c
+
+src/func_ov098_0213a23c.c:
+    complete
+    .text start:0x0213a23c end:0x0213a284
+
+src/func_ov098_0213a284.cpp:
+    complete
+    .text start:0x0213a284 end:0x0213a2cc
+
+src/func_ov098_0213a2cc.c:
+    complete
+    .text start:0x0213a2cc end:0x0213a314
+
+src/func_ov098_0213a314.cpp:
+    complete
+    .text start:0x0213a314 end:0x0213a36c
+
+src/func_ov098_0213a36c.cpp:
+    complete
+    .text start:0x0213a36c end:0x0213a794
+
+src/func_ov098_0213a794.cpp:
+    .text start:0x0213a794 end:0x0213a8e0
+
+src/func_ov098_0213a8e0.c:
+    complete
+    .text start:0x0213a8e0 end:0x0213a8ec
+
+src/func_ov098_0213a8ec.c:
+    complete
+    .text start:0x0213a8ec end:0x0213a900
+
+src/_ZN6CannonD1Ev.cpp:
+    .text start:0x0213a900 end:0x0213a938
+
+src/_ZN6CannonD0Ev.c:
+    complete
+    .text start:0x0213a938 end:0x0213a984
+
+src/func_ov098_0213a984.c:
+    complete
+    .text start:0x0213a984 end:0x0213aa28
+
+src/func_ov098_0213aa28.c:
+    complete
+    .text start:0x0213aa28 end:0x0213ad08
+
+src/func_ov098_0213ad08.c:
+    complete
+    .text start:0x0213ad08 end:0x0213ade8
+
+src/func_ov098_0213b0a4.cpp:
+    complete
+    .text start:0x0213b0a4 end:0x0213b15c
+
+src/func_ov098_0213b15c.cpp:
+    complete
+    .text start:0x0213b15c end:0x0213b1d8
+
+src/_ZN6Cannon16CleanupResourcesEv.c:
+    complete
+    .text start:0x0213b1d8 end:0x0213b214
+
+src/_ZN6Cannon6RenderEv.cpp:
+    complete
+    .text start:0x0213b214 end:0x0213b26c
+
+src/_ZN6Cannon8BehaviorEv.cpp:
+    complete
+    .text start:0x0213b26c end:0x0213b2d4
+
+src/_ZN6Cannon13InitResourcesEv.cpp:
+    .text start:0x0213b2d4 end:0x0213b43c
+
+src/Cannon_Spawn.c:
+    complete
+    .text start:0x0213b43c end:0x0213b47c
+
+src/_ZN9WaterBombD1Ev.c:
+    complete
+    .text start:0x0213b47c end:0x0213b4c4
+
+src/_ZN9WaterBombD0Ev.c:
+    complete
+    .text start:0x0213b4c4 end:0x0213b520
+
+src/func_ov098_0213b520.c:
+    complete
+    .text start:0x0213b520 end:0x0213b584
+
+src/func_ov098_0213b584.c:
+    complete
+    .text start:0x0213b584 end:0x0213b63c
+
+src/func_ov098_0213b63c.cpp:
+    complete
+    .text start:0x0213b63c end:0x0213b6e0
+
+src/func_ov098_0213b6e0.cpp:
+    complete
+    .text start:0x0213b6e0 end:0x0213b7e8
+
+src/func_ov098_0213b7e8.c:
+    complete
+    .text start:0x0213b7e8 end:0x0213b9d8
+
+src/func_ov098_0213b9d8.cpp:
+    complete
+    .text start:0x0213b9d8 end:0x0213bb1c
+
+src/func_ov098_0213bb1c.cpp:
+    complete
+    .text start:0x0213bb1c end:0x0213bb9c
+
+src/_ZN9WaterBomb16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0213bb9c end:0x0213bbe4
+
+src/_ZN9WaterBomb6RenderEv.cpp:
+    complete
+    .text start:0x0213bbe4 end:0x0213bc20
+
+src/_ZN9WaterBomb8BehaviorEv.cpp:
+    .text start:0x0213bc20 end:0x0213bd14
+
+src/_ZN9WaterBomb13InitResourcesEv.cpp:
+    .text start:0x0213bd14 end:0x0213bf10
+
+src/WaterBomb_Spawn.c:
+    complete
+    .text start:0x0213bf10 end:0x0213bf60
+
+src/__sinit_ov098_0213bf9c.c:
+    .init start:0x0213bf9c end:0x0213c058
+
+src/__sinit_ov098_0213c058.c:
+    .init start:0x0213c058 end:0x0213c214
+
+src/__sinit_ov098_0213c214.c:
+    .init start:0x0213c214 end:0x0213c2b4
+
+src/__sinit_ov098_0213c2b4.c:
+    .init start:0x0213c2b4 end:0x0213c33c

--- a/config/arm9/overlays/ov100/delinks.txt
+++ b/config/arm9/overlays/ov100/delinks.txt
@@ -4,3 +4,502 @@
     .ctor       start:0x02147de8 end:0x02147e04 kind:rodata align:4
     .data       start:0x02147e20 end:0x02148600 kind:data align:32
     .bss        start:0x02148600 end:0x02148a80 kind:bss align:32
+src/_ZN9ButterflyD1Ev.cpp:
+    .text start:0x02140d80 end:0x02140dd8
+
+src/_ZN9ButterflyD0Ev.c:
+    complete
+    .text start:0x02140dd8 end:0x02140e44
+
+src/func_ov100_02140e44.cpp:
+    complete
+    .text start:0x02140e44 end:0x0214109c
+
+src/func_ov100_0214109c.cpp:
+    .text start:0x0214109c end:0x0214117c
+
+src/func_ov100_0214117c.cpp:
+    .text start:0x0214117c end:0x021412d8
+
+src/func_ov100_021412d8.c:
+    complete
+    .text start:0x021412d8 end:0x02141470
+
+src/func_ov100_02141470.c:
+    complete
+    .text start:0x02141470 end:0x021415bc
+
+src/func_ov100_021415bc.c:
+    complete
+    .text start:0x021415bc end:0x02141800
+
+src/func_ov100_02141800.cpp:
+    complete
+    .text start:0x02141800 end:0x02141848
+
+src/func_ov100_02141848.c:
+    complete
+    .text start:0x02141848 end:0x02141988
+
+src/_ZN9Butterfly16CleanupResourcesEv.c:
+    complete
+    .text start:0x02141988 end:0x021419d0
+
+src/_ZN9Butterfly16OnPendingDestroyEv.c:
+    complete
+    .text start:0x021419d0 end:0x021419d4
+
+src/_ZN9Butterfly6RenderEv.cpp:
+    complete
+    .text start:0x021419d4 end:0x02141a40
+
+src/_ZN9Butterfly8BehaviorEv.cpp:
+    complete
+    .text start:0x02141a40 end:0x02141c6c
+
+src/_ZN9Butterfly13InitResourcesEv.cpp:
+    .text start:0x02141c6c end:0x02141ea4
+
+src/Butterfly_Spawn.c:
+    complete
+    .text start:0x02141ea4 end:0x02141f04
+
+src/_ZN15RollingIronBallD1Ev.c:
+    complete
+    .text start:0x02141f04 end:0x02141f4c
+
+src/_ZN15RollingIronBallD0Ev.c:
+    complete
+    .text start:0x02141f4c end:0x02141fa8
+
+src/func_ov100_02141fa8.c:
+    complete
+    .text start:0x02141fa8 end:0x02141fb0
+
+src/func_ov100_02141fb0.cpp:
+    .text start:0x02141fb0 end:0x02142130
+
+src/func_ov100_02142130.cpp:
+    complete
+    .text start:0x02142130 end:0x02142264
+
+src/func_ov100_02142264.cpp:
+    complete
+    .text start:0x02142264 end:0x0214233c
+
+src/func_ov100_0214233c.cpp:
+    complete
+    .text start:0x0214233c end:0x021424c0
+
+src/func_ov100_021424c0.c:
+    complete
+    .text start:0x021424c0 end:0x0214272c
+
+src/func_ov100_0214272c.cpp:
+    .text start:0x0214272c end:0x02142918
+
+src/func_ov100_02142918.cpp:
+    .text start:0x02142918 end:0x02142b90
+
+src/func_ov100_02142b90.c:
+    complete
+    .text start:0x02142b90 end:0x02142d1c
+
+src/_ZN15RollingIronBall16CleanupResourcesEv.cpp:
+    .text start:0x02142d1c end:0x02142d5c
+
+src/_ZN15RollingIronBall6RenderEv.cpp:
+    complete
+    .text start:0x02142d5c end:0x02142d98
+
+src/_ZN15RollingIronBall8BehaviorEv.cpp:
+    complete
+    .text start:0x02142d98 end:0x02142de0
+
+src/_ZN15RollingIronBall13InitResourcesEv.cpp:
+    .text start:0x02142de0 end:0x0214316c
+
+src/RollingIronBall_Spawn.c:
+    complete
+    .text start:0x0214316c end:0x021431c4
+
+src/_ZN14UnchainedChompD1Ev.cpp:
+    .text start:0x021431c4 end:0x02143290
+
+src/_ZN14UnchainedChompD0Ev.cpp:
+    complete
+    .text start:0x02143290 end:0x02143370
+
+src/func_ov100_02143370.cpp:
+    complete
+    .text start:0x02143370 end:0x0214344c
+
+src/func_ov100_0214344c.c:
+    complete
+    .text start:0x0214344c end:0x021435e8
+
+src/func_ov100_021435e8.cpp:
+    complete
+    .text start:0x021435e8 end:0x021437d4
+
+src/func_ov100_021437d4.c:
+    complete
+    .text start:0x021437d4 end:0x02143aa4
+
+src/func_ov100_02143aa4.c:
+    complete
+    .text start:0x02143aa4 end:0x02143ae0
+
+src/func_ov100_02143ae0.c:
+    complete
+    .text start:0x02143ae0 end:0x02143b18
+
+src/func_ov100_02143b18.cpp:
+    complete
+    .text start:0x02143b18 end:0x02143b68
+
+src/func_ov100_02143b68.cpp:
+    complete
+    .text start:0x02143b68 end:0x02143cb0
+
+src/_ZN14UnchainedChomp16CleanupResourcesEv.c:
+    complete
+    .text start:0x02143cb0 end:0x02143d08
+
+src/_ZN14UnchainedChomp16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02143d08 end:0x02143d0c
+
+src/_ZN14UnchainedChomp6RenderEv.cpp:
+    complete
+    .text start:0x02143d0c end:0x02143d64
+
+src/_ZN14UnchainedChomp8BehaviorEv.cpp:
+    .text start:0x02143d64 end:0x02144088
+
+src/_ZN14UnchainedChomp13InitResourcesEv.cpp:
+    complete
+    .text start:0x02144088 end:0x021442d4
+
+src/func_ov100_021442d4.c:
+    complete
+    .text start:0x021442d4 end:0x021442dc
+
+src/UnchainedChomp_Spawn.c:
+    .text start:0x021442dc end:0x021443f4
+
+src/func_ov100_021443f4.c:
+    .text start:0x021443f4 end:0x02144424
+
+src/func_ov100_02144424.c:
+    .text start:0x02144424 end:0x02144468
+
+src/func_ov100_02144468.c:
+    complete
+    .text start:0x02144468 end:0x021444e8
+
+src/func_ov100_021444e8.c:
+    complete
+    .text start:0x021444e8 end:0x02144528
+
+src/func_ov100_02144528.c:
+    complete
+    .text start:0x02144528 end:0x021446f8
+
+src/func_ov100_021446f8.c:
+    complete
+    .text start:0x021446f8 end:0x02144730
+
+src/func_ov100_02144730.cpp:
+    complete
+    .text start:0x02144730 end:0x0214491c
+
+src/func_ov100_0214491c.c:
+    complete
+    .text start:0x0214491c end:0x02144950
+
+src/func_ov100_02144950.c:
+    complete
+    .text start:0x02144950 end:0x021449c8
+
+src/func_ov100_021449c8.cpp:
+    complete
+    .text start:0x021449c8 end:0x02144a38
+
+src/func_ov100_02144a38.c:
+    complete
+    .text start:0x02144a38 end:0x02144bf4
+
+src/func_ov100_02144bf4.cpp:
+    complete
+    .text start:0x02144bf4 end:0x02144c64
+
+src/func_ov100_02144c64.c:
+    complete
+    .text start:0x02144c64 end:0x02144c6c
+
+src/func_ov100_02144c6c.c:
+    complete
+    .text start:0x02144c6c end:0x02144ccc
+
+src/func_ov100_02144ccc.c:
+    complete
+    .text start:0x02144ccc end:0x02144cf8
+
+src/func_ov100_02144cf8.c:
+    complete
+    .text start:0x02144cf8 end:0x02144f84
+
+src/func_ov100_02144f84.c:
+    complete
+    .text start:0x02144f84 end:0x02144fcc
+
+src/func_ov100_02144fcc.cpp:
+    .text start:0x02144fcc end:0x02145014
+
+src/func_ov100_02145014.c:
+    complete
+    .text start:0x02145014 end:0x02145070
+
+src/func_ov100_02145070.c:
+    complete
+    .text start:0x02145070 end:0x02145080
+
+src/func_ov100_02145080.c:
+    .text start:0x02145080 end:0x02145170
+
+src/func_ov100_02145170.c:
+    complete
+    .text start:0x02145170 end:0x021451c4
+
+src/func_ov100_021451c4.cpp:
+    complete
+    .text start:0x021451c4 end:0x021452e4
+
+src/func_ov100_021452e4.c:
+    complete
+    .text start:0x021452e4 end:0x02145370
+
+src/func_ov100_02145370.c:
+    complete
+    .text start:0x02145370 end:0x021453d8
+
+src/func_ov100_021453d8.cpp:
+    complete
+    .text start:0x021453d8 end:0x0214542c
+
+src/func_ov100_0214542c.cpp:
+    .text start:0x0214542c end:0x021454c4
+
+src/func_ov100_021454c4.c:
+    complete
+    .text start:0x021454c4 end:0x021454c8
+
+src/func_ov100_021454c8.cpp:
+    complete
+    .text start:0x021454c8 end:0x02145550
+
+src/func_ov100_02145550.cpp:
+    .text start:0x02145550 end:0x021455a0
+
+src/func_ov100_021455a0.c:
+    .text start:0x021455a0 end:0x0214589c
+
+src/Door_Spawn.c:
+    .text start:0x0214589c end:0x021458d4
+
+src/_ZN4DoorD1Ev.cpp:
+    .text start:0x021458d4 end:0x02145904
+
+src/_ZN4DoorD0Ev.c:
+    complete
+    .text start:0x02145904 end:0x02145948
+
+src/func_ov100_02145948.c:
+    complete
+    .text start:0x02145948 end:0x02145988
+
+src/func_ov100_02145988.cpp:
+    .text start:0x02145988 end:0x02145ab4
+
+src/func_ov100_02145ab4.cpp:
+    complete
+    .text start:0x02145ab4 end:0x02145b10
+
+src/func_ov100_02145b10.cpp:
+    complete
+    .text start:0x02145b10 end:0x02145b7c
+
+src/func_ov100_02145b7c.c:
+    complete
+    .text start:0x02145b7c end:0x02145b9c
+
+src/func_ov100_02145b9c.c:
+    complete
+    .text start:0x02145b9c end:0x02145c2c
+
+src/func_ov100_02145c2c.c:
+    complete
+    .text start:0x02145c2c end:0x02145c58
+
+src/func_ov100_02145c58.c:
+    complete
+    .text start:0x02145c58 end:0x02145e10
+
+src/func_ov100_02145e10.c:
+    complete
+    .text start:0x02145e10 end:0x02145e74
+
+src/func_ov100_02145e74.c:
+    complete
+    .text start:0x02145e74 end:0x02145f00
+
+src/func_ov100_02145f00.c:
+    complete
+    .text start:0x02145f00 end:0x02145f68
+
+src/func_ov100_02145f68.cpp:
+    complete
+    .text start:0x02145f68 end:0x02145fbc
+
+src/_ZN4Door16CleanupResourcesEv.c:
+    complete
+    .text start:0x02145fbc end:0x02145fe0
+
+src/_ZN4Door16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02145fe0 end:0x02145fe4
+
+src/_ZN4Door6RenderEv.c:
+    complete
+    .text start:0x02145fe4 end:0x021460dc
+
+src/_ZN4Door8BehaviorEv.cpp:
+    .text start:0x021460dc end:0x0214612c
+
+src/_ZN4Door13InitResourcesEv.cpp:
+    complete
+    .text start:0x0214612c end:0x021461d4
+
+src/StarDoor_Spawn.c:
+    complete
+    .text start:0x021461d4 end:0x0214620c
+
+src/_ZN4FishD1Ev.cpp:
+    .text start:0x0214620c end:0x0214623c
+
+src/_ZN4FishD0Ev.c:
+    complete
+    .text start:0x0214623c end:0x02146280
+
+src/func_ov100_02146280.c:
+    complete
+    .text start:0x02146280 end:0x0214629c
+
+src/func_ov100_0214629c.cpp:
+    .text start:0x0214629c end:0x0214639c
+
+src/func_ov100_0214639c.c:
+    complete
+    .text start:0x0214639c end:0x021463b0
+
+src/func_ov100_021463b0.cpp:
+    complete
+    .text start:0x021463b0 end:0x02146468
+
+src/func_ov100_02146468.c:
+    complete
+    .text start:0x02146468 end:0x021464f4
+
+src/func_ov100_021464f4.cpp:
+    complete
+    .text start:0x021464f4 end:0x02146640
+
+src/func_ov100_02146640.c:
+    complete
+    .text start:0x02146640 end:0x021467d4
+
+src/func_ov100_021467d4.c:
+    complete
+    .text start:0x021467d4 end:0x021467e8
+
+src/func_ov100_021467e8.cpp:
+    complete
+    .text start:0x021467e8 end:0x02146828
+
+src/func_ov100_02146828.c:
+    complete
+    .text start:0x02146828 end:0x02146a98
+
+src/_ZN4Fish16CleanupResourcesEv.cpp:
+    .text start:0x02146a98 end:0x02146b00
+
+src/_ZN4Fish16OnPendingDestroyEv.c:
+    complete
+    .text start:0x02146b00 end:0x02146b04
+
+src/_ZN4Fish6RenderEv.cpp:
+    complete
+    .text start:0x02146b04 end:0x02146b38
+
+src/_ZN4Fish8BehaviorEv.cpp:
+    .text start:0x02146b38 end:0x02146c68
+
+src/_ZN4Fish13InitResourcesEv.cpp:
+    .text start:0x02146c68 end:0x02146d38
+
+src/Fish_Spawn.cpp:
+    complete
+    .text start:0x02146d38 end:0x02146d7c
+
+src/func_ov100_02146d7c.cpp:
+    complete
+    .text start:0x02146d7c end:0x02146dec
+
+src/func_ov100_02146dec.cpp:
+    .text start:0x02146dec end:0x02146e70
+
+src/func_ov100_02146e70.c:
+    complete
+    .text start:0x02146e70 end:0x0214700c
+
+src/func_ov100_0214700c.c:
+    complete
+    .text start:0x0214700c end:0x02147054
+
+src/func_ov100_02147054.c:
+    .text start:0x02147054 end:0x021470a4
+
+src/func_ov100_021470a4.cpp:
+    .text start:0x021470a4 end:0x021470f4
+
+src/func_ov100_021470f4.cpp:
+    .text start:0x021470f4 end:0x021471e0
+
+src/func_ov100_021471e0.cpp:
+    .text start:0x021471e0 end:0x02147328
+
+src/PathLift_Spawn.cpp:
+    complete
+    .text start:0x02147328 end:0x021473a4
+
+src/__sinit_ov100_021473bc.c:
+    .init start:0x021473bc end:0x021474e8
+
+src/__sinit_ov100_021474e8.c:
+    .init start:0x021474e8 end:0x021475a4
+
+src/__sinit_ov100_021475a4.c:
+    .init start:0x021475a4 end:0x02147698
+
+src/__sinit_ov100_02147698.c:
+    .init start:0x02147698 end:0x02147a70
+
+src/__sinit_ov100_02147a70.c:
+    .init start:0x02147a70 end:0x02147bc0
+
+src/__sinit_ov100_02147bc0.c:
+    .init start:0x02147bc0 end:0x02147d7c
+
+src/__sinit_ov100_02147d7c.c:
+    .init start:0x02147d7c end:0x02147de8

--- a/config/arm9/overlays/ov102/delinks.txt
+++ b/config/arm9/overlays/ov102/delinks.txt
@@ -4,3 +4,436 @@
     .ctor       start:0x0214e0a0 end:0x0214e0b0 kind:rodata align:4
     .data       start:0x0214e0c0 end:0x0214e6e0 kind:data align:32
     .bss        start:0x0214e6e0 end:0x0214eaa0 kind:bss align:32
+src/_ZN13FortressTowerD1Ev.c:
+    .text start:0x02148a80 end:0x02148ac4
+
+src/_ZN13FortressTowerD0Ev.c:
+    .text start:0x02148ac4 end:0x02148b1c
+
+src/_ZN13FortressTower16CleanupResourcesEv.cpp:
+    .text start:0x02148b1c end:0x02148b80
+
+src/_ZN13FortressTower6RenderEv.cpp:
+    complete
+    .text start:0x02148b80 end:0x02148ba8
+
+src/_ZN13FortressTower8BehaviorEv.cpp:
+    complete
+    .text start:0x02148ba8 end:0x02148c94
+
+src/_ZN13FortressTower13InitResourcesEv.cpp:
+    .text start:0x02148c94 end:0x02148e9c
+
+src/RopeBarrier_Spawn.c:
+    complete
+    .text start:0x02148e9c end:0x02148ecc
+
+src/CgStairs_Spawn.c:
+    complete
+    .text start:0x02148ecc end:0x02148efc
+
+src/WarpPipe_Spawn.c:
+    complete
+    .text start:0x02148efc end:0x02148f2c
+
+src/FortressTower_Spawn.c:
+    complete
+    .text start:0x02148f2c end:0x02148f5c
+
+src/RockTriangle_Spawn.c:
+    complete
+    .text start:0x02148f5c end:0x02148f8c
+
+src/StaticRock_Spawn.c:
+    complete
+    .text start:0x02148f8c end:0x02148fbc
+
+src/_ZN13QuestionBlockD1Ev.c:
+    .text start:0x02148fbc end:0x02149010
+
+src/_ZN13QuestionBlockD0Ev.c:
+    .text start:0x02149010 end:0x02149078
+
+src/func_ov102_02149078.c:
+    complete
+    .text start:0x02149078 end:0x02149100
+
+src/func_ov102_02149100.c:
+    complete
+    .text start:0x02149100 end:0x02149220
+
+src/func_ov102_02149220.cpp:
+    .text start:0x02149220 end:0x02149288
+
+src/func_ov102_02149288.cpp:
+    complete
+    .text start:0x02149288 end:0x021492d4
+
+src/func_ov102_021492d4.c:
+    complete
+    .text start:0x021492d4 end:0x02149384
+
+src/func_ov102_02149384.cpp:
+    complete
+    .text start:0x02149384 end:0x021493dc
+
+src/func_ov102_021493dc.cpp:
+    complete
+    .text start:0x021493dc end:0x02149428
+
+src/func_ov102_02149428.c:
+    complete
+    .text start:0x02149428 end:0x02149478
+
+src/func_ov102_02149478.c:
+    complete
+    .text start:0x02149478 end:0x021494cc
+
+src/func_ov102_021494cc.c:
+    complete
+    .text start:0x021494cc end:0x0214953c
+
+src/func_ov102_0214953c.c:
+    complete
+    .text start:0x0214953c end:0x02149610
+
+src/func_ov102_02149610.cpp:
+    .text start:0x02149610 end:0x02149684
+
+src/func_ov102_02149684.c:
+    complete
+    .text start:0x02149684 end:0x021496a4
+
+src/func_ov102_021496a4.c:
+    complete
+    .text start:0x021496a4 end:0x02149710
+
+src/func_ov102_02149710.c:
+    complete
+    .text start:0x02149710 end:0x02149770
+
+src/func_ov102_02149770.c:
+    complete
+    .text start:0x02149770 end:0x021497c8
+
+src/func_ov102_021497c8.c:
+    complete
+    .text start:0x021497c8 end:0x02149820
+
+src/func_ov102_02149820.c:
+    complete
+    .text start:0x02149820 end:0x02149878
+
+src/func_ov102_02149878.c:
+    complete
+    .text start:0x02149878 end:0x021498c4
+
+src/func_ov102_021498c4.c:
+    complete
+    .text start:0x021498c4 end:0x021498e0
+
+src/func_ov102_02149c78.c:
+    complete
+    .text start:0x02149c78 end:0x02149ccc
+
+src/func_ov102_02149ccc.cpp:
+    complete
+    .text start:0x02149ccc end:0x02149d80
+
+src/func_ov102_02149d80.c:
+    complete
+    .text start:0x02149d80 end:0x02149da8
+
+src/func_ov102_02149da8.cpp:
+    complete
+    .text start:0x02149da8 end:0x02149df0
+
+src/func_ov102_02149df0.cpp:
+    complete
+    .text start:0x02149df0 end:0x02149e38
+
+src/func_ov102_02149e38.cpp:
+    complete
+    .text start:0x02149e38 end:0x02149ea4
+
+src/func_ov102_02149ea4.c:
+    complete
+    .text start:0x02149ea4 end:0x02149ff0
+
+src/func_ov102_02149ff0.c:
+    complete
+    .text start:0x02149ff0 end:0x0214a08c
+
+src/_ZN13QuestionBlock16CleanupResourcesEv.cpp:
+    .text start:0x0214a08c end:0x0214a2ac
+
+src/_ZN13QuestionBlock6RenderEv.cpp:
+    complete
+    .text start:0x0214a2ac end:0x0214a32c
+
+src/_ZN13QuestionBlock8BehaviorEv.cpp:
+    .text start:0x0214a32c end:0x0214a4a4
+
+src/_ZN13QuestionBlock13InitResourcesEv.c:
+    complete
+    .text start:0x0214a4a4 end:0x0214a7ec
+
+src/CapBlockWario_Spawn.c:
+    complete
+    .text start:0x0214a7ec end:0x0214a82c
+
+src/CapBlockLuigi_Spawn.c:
+    complete
+    .text start:0x0214a82c end:0x0214a86c
+
+src/CapBlockMario_Spawn.c:
+    complete
+    .text start:0x0214a86c end:0x0214a8ac
+
+src/ExclamationBlock_Spawn.c:
+    complete
+    .text start:0x0214a8ac end:0x0214a8ec
+
+src/QuestionBlock_Spawn.c:
+    complete
+    .text start:0x0214a8ec end:0x0214a92c
+
+src/ExclamationBlockVs_Spawn.c:
+    complete
+    .text start:0x0214a92c end:0x0214a96c
+
+src/_ZN6BobOmbD1Ev.c:
+    complete
+    .text start:0x0214a96c end:0x0214a9b4
+
+src/_ZN6BobOmbD0Ev.c:
+    complete
+    .text start:0x0214a9b4 end:0x0214aa10
+
+src/func_ov102_0214aa10.c:
+    complete
+    .text start:0x0214aa10 end:0x0214aa18
+
+src/func_ov102_0214aa18.cpp:
+    .text start:0x0214aa18 end:0x0214ab1c
+
+src/func_ov102_0214ab1c.c:
+    complete
+    .text start:0x0214ab1c end:0x0214ad14
+
+src/func_ov102_0214ad14.c:
+    complete
+    .text start:0x0214ad14 end:0x0214ad40
+
+src/func_ov102_0214ad40.c:
+    complete
+    .text start:0x0214ad40 end:0x0214adc8
+
+src/func_ov102_0214adc8.c:
+    complete
+    .text start:0x0214adc8 end:0x0214ae1c
+
+src/func_ov102_0214ae1c.c:
+    complete
+    .text start:0x0214ae1c end:0x0214b03c
+
+src/func_ov102_0214b03c.cpp:
+    complete
+    .text start:0x0214b03c end:0x0214b128
+
+src/func_ov102_0214b128.cpp:
+    complete
+    .text start:0x0214b128 end:0x0214b248
+
+src/func_ov102_0214b248.cpp:
+    .text start:0x0214b248 end:0x0214b384
+
+src/func_ov102_0214b384.c:
+    complete
+    .text start:0x0214b384 end:0x0214b3b8
+
+src/func_ov102_0214b3b8.c:
+    complete
+    .text start:0x0214b3b8 end:0x0214b3f0
+
+src/func_ov102_0214b3f0.c:
+    complete
+    .text start:0x0214b3f0 end:0x0214b444
+
+src/func_ov102_0214b444.cpp:
+    complete
+    .text start:0x0214b444 end:0x0214b53c
+
+src/func_ov102_0214b988.cpp:
+    .text start:0x0214b988 end:0x0214ba30
+
+src/func_ov102_0214ba30.cpp:
+    complete
+    .text start:0x0214ba30 end:0x0214baa0
+
+src/func_ov102_0214baa0.c:
+    complete
+    .text start:0x0214baa0 end:0x0214bbd8
+
+src/func_ov102_0214bbd8.c:
+    complete
+    .text start:0x0214bbd8 end:0x0214bc20
+
+src/func_ov102_0214bc20.c:
+    complete
+    .text start:0x0214bc20 end:0x0214bcc8
+
+src/func_ov102_0214bcc8.c:
+    complete
+    .text start:0x0214bcc8 end:0x0214bd20
+
+src/func_ov102_0214bd20.cpp:
+    complete
+    .text start:0x0214bd20 end:0x0214bd90
+
+src/func_ov102_0214bd90.c:
+    complete
+    .text start:0x0214bd90 end:0x0214be1c
+
+src/func_ov102_0214be1c.cpp:
+    complete
+    .text start:0x0214be1c end:0x0214beb4
+
+src/func_ov102_0214beb4.c:
+    complete
+    .text start:0x0214beb4 end:0x0214bf64
+
+src/func_ov102_0214bf64.cpp:
+    complete
+    .text start:0x0214bf64 end:0x0214c0b8
+
+src/func_ov102_0214c0b8.c:
+    complete
+    .text start:0x0214c0b8 end:0x0214c12c
+
+src/_ZN6BobOmb16CleanupResourcesEv.c:
+    complete
+    .text start:0x0214c12c end:0x0214c168
+
+src/_ZN6BobOmb6RenderEv.cpp:
+    complete
+    .text start:0x0214c168 end:0x0214c1bc
+
+src/_ZN6BobOmb8BehaviorEv.c:
+    .text start:0x0214c1bc end:0x0214c510
+
+src/_ZN6BobOmb13InitResourcesEv.cpp:
+    .text start:0x0214c510 end:0x0214c6e4
+
+src/func_ov102_0214c6e4.c:
+    complete
+    .text start:0x0214c6e4 end:0x0214c6f8
+
+src/BobOmb_Spawn.c:
+    complete
+    .text start:0x0214c6f8 end:0x0214c748
+
+src/_ZN10KoopaShellD1Ev.c:
+    complete
+    .text start:0x0214c748 end:0x0214c798
+
+src/_ZN10KoopaShellD0Ev.c:
+    complete
+    .text start:0x0214c798 end:0x0214c7fc
+
+src/func_ov102_0214c7fc.cpp:
+    complete
+    .text start:0x0214c7fc end:0x0214c84c
+
+src/func_ov102_0214c84c.c:
+    complete
+    .text start:0x0214c84c end:0x0214cbec
+
+src/func_ov102_0214cbec.cpp:
+    .text start:0x0214cbec end:0x0214ce60
+
+src/func_ov102_0214ce60.cpp:
+    .text start:0x0214ce60 end:0x0214cf4c
+
+src/func_ov102_0214cf4c.cpp:
+    complete
+    .text start:0x0214cf4c end:0x0214cf98
+
+src/func_ov102_0214cf98.cpp:
+    complete
+    .text start:0x0214cf98 end:0x0214cfe4
+
+src/func_ov102_0214cfe4.cpp:
+    complete
+    .text start:0x0214cfe4 end:0x0214d020
+
+src/func_ov102_0214d020.c:
+    complete
+    .text start:0x0214d020 end:0x0214d044
+
+src/func_ov102_0214d044.cpp:
+    complete
+    .text start:0x0214d044 end:0x0214d0bc
+
+src/func_ov102_0214d0bc.cpp:
+    complete
+    .text start:0x0214d0bc end:0x0214d114
+
+src/func_ov102_0214d114.c:
+    complete
+    .text start:0x0214d114 end:0x0214d148
+
+src/func_ov102_0214d148.cpp:
+    complete
+    .text start:0x0214d148 end:0x0214d1b0
+
+src/func_ov102_0214d1b0.c:
+    complete
+    .text start:0x0214d1b0 end:0x0214d1b8
+
+src/func_ov102_0214d1b8.c:
+    complete
+    .text start:0x0214d1b8 end:0x0214d1f8
+
+src/func_ov102_0214d1f8.cpp:
+    complete
+    .text start:0x0214d1f8 end:0x0214d248
+
+src/_ZN10KoopaShell16CleanupResourcesEv.cpp:
+    complete
+    .text start:0x0214d248 end:0x0214d274
+
+src/_ZN10KoopaShell16OnPendingDestroyEv.c:
+    complete
+    .text start:0x0214d274 end:0x0214d278
+
+src/_ZN10KoopaShell6RenderEv.cpp:
+    complete
+    .text start:0x0214d278 end:0x0214d2e8
+
+src/_ZN10KoopaShell8BehaviorEv.cpp:
+    complete
+    .text start:0x0214d2e8 end:0x0214d54c
+
+src/_ZN10KoopaShell13InitResourcesEv.cpp:
+    .text start:0x0214d54c end:0x0214d6a0
+
+src/func_ov102_0214d6a0.c:
+    complete
+    .text start:0x0214d6a0 end:0x0214d6b4
+
+src/KoopaShell_Spawn.c:
+    complete
+    .text start:0x0214d6b4 end:0x0214d70c
+
+src/__sinit_ov102_0214d714.c:
+    .init start:0x0214d714 end:0x0214d908
+
+src/__sinit_ov102_0214d908.c:
+    .init start:0x0214d908 end:0x0214de70
+
+src/__sinit_ov102_0214de70.c:
+    .init start:0x0214de70 end:0x0214dfac
+
+src/__sinit_ov102_0214dfac.c:
+    .init start:0x0214dfac end:0x0214e0a0

--- a/config/rombuild-exclude.txt
+++ b/config/rombuild-exclude.txt
@@ -1,0 +1,29 @@
+# Functions that cannot be carved into their own delink object, by symbol name.
+# tools/enroll.py skips these; their address ranges stay inside the module's gap
+# object, so the ROM build still covers them - just not from a separate file.
+# Lines starting with '#' are comments.
+
+# --- main: the 0x0206d9dc / 0x0206da28 secondary-entry-point cluster ---
+# func_0206ce90, func_0206cee0 and func_0206d868 arm_call 0x0206d9dc and 0x0206da28.
+# Neither address has a symbol: they are secondary entry points 0x10 bytes inside
+# func_0206d9cc and func_0206da18. dsd names such a target with a local label
+# (.L_0206d9dc), and a local label cannot be referenced from outside the object that
+# defines it:
+#   "Imported symbol .L_0206d9dc ... is local, it cannot be used in relocation"
+# So the callers and the targets must stay in one object. Excluding just the three
+# callers is not enough - carving any function between them splits the span - so the
+# whole run from the first caller to the last target stays in the gap.
+# Giving 0x0206d9dc and 0x0206da28 real symbols in config/arm9/symbols.txt would
+# recover all twelve.
+func_0206ce90
+func_0206cec0
+func_0206cee0
+func_0206cf7c
+func_0206cf98
+func_0206d32c
+func_0206d868
+func_0206d890
+func_0206d8c4
+func_0206d940
+func_0206d9cc
+func_0206da18

--- a/config/rombuild-versions.txt
+++ b/config/rombuild-versions.txt
@@ -1,0 +1,19 @@
+# Per-file mwccarm version overrides for the ROM build, as: <symbol> <version>.
+# tools/rombuild.py and tools/eligible.py compile these with the named version instead
+# of the default (see rombuild.VERSION).
+#
+# A function counts as matched if SOME toolchain version reproduces it, and match.py
+# sweeps a list - so a single-version link produces the wrong bytes for the ones
+# matched elsewhere, even though the source is correct.
+#
+# Regenerate with:
+#   python tools/rombuild_check.py --out build/bad.txt
+#   python tools/rombuild_versions.py build/bad.txt --write
+func_02062428 1.2/base
+func_0206a6d0 1.2/base
+func_ov006_020ded00 1.2/base
+func_ov006_02111e90 1.2/base
+func_ov013_021112a8 1.2/base
+func_ov015_02111e80 1.2/base
+func_ov081_02127558 1.2/base
+func_ov084_0212f460 1.2/base

--- a/mods/Player_ScaleByCharFactor.c
+++ b/mods/Player_ScaleByCharFactor.c
@@ -1,0 +1,14 @@
+// A deliberate divergence from the ROM, built into the game instead of
+// src/Player_ScaleByCharFactor.c. See notes/rom-build.md (M3).
+//
+// The retail function scales a value by the current character's factor in 4.12
+// fixed point. Shifting by 11 instead of 12 doubles the result. The instruction
+// count is unchanged, so the function still occupies its original 0x34 bytes and
+// nothing downstream of it moves.
+typedef int Fix12i;
+extern unsigned short data_ov002_020ff170[];
+Fix12i Player_ScaleByCharFactor(void*c, Fix12i a){
+  int idx = *(int*)((char*)c+8) & 0xff;
+  unsigned int t = data_ov002_020ff170[idx];
+  return (Fix12i)(((long long)a * (int)t + 0x800) >> 11);
+}

--- a/notes/rom-build.md
+++ b/notes/rom-build.md
@@ -1,0 +1,584 @@
+# Building a playable `.nds` from source
+
+**Goal.** Produce a bootable `build/sm64ds.nds` whose ARM9 code comes from *our* C
+wherever `src/` has a verified match, and from the ROM's delinked objects everywhere
+else. Then change a line of C, rebuild, and see the change in a running game.
+
+This is the "hybrid link" that ds-decomp is designed for. It does **not** require 100%
+matching first — at 97.9% of functions we can already source-build the overwhelming
+majority and let delinked gap objects supply the residue. Phase 1 of
+[`roadmap.md`](roadmap.md) ("`dsd rom build` turns the source back into the exact retail
+ROM") is the 100% version of the same pipeline; this document is the path to standing
+that pipeline up now.
+
+## Status
+
+**M0, M1, M2a and M2b are done. The built ROM boots and plays in melonDS.**
+`python tools/rombuild.py` produces a 16,777,216-byte `build/sm64ds.nds` in about a
+minute, with all 106 modules byte-identical to the ROM. **9,115 functions — 1,475,772
+code bytes, 66.7% of the project's total — are compiled from `src/` by mwccarm**; the
+rest of each module is supplied from delinked ROM bytes. All four milestones are complete. Results are recorded under each milestone below.
+
+```
+python tools/eligible.py             # classify: which files may be compiled in
+python tools/enroll.py --complete-list build/eligible-names.txt
+python tools/rombuild.py             # build and verify
+python tools/rombuild_check.py       # per-function byte diff, names any culprit
+python tools/rombuild_diag.py        # explain a mismatch: which symbol does it name?
+python tools/rombuild_versions.py build/bad.txt --write   # per-file compiler overrides
+```
+
+`rombuild.py` compiles exactly the files enrolled by a `complete` file entry in some
+`config/**/delinks.txt`; everything else comes from ROM bytes. Enrolling more source is
+therefore a config edit, not a code change. `--no-rom` stops after linking for fast
+iteration.
+
+**The compiler default is `2004/b56`** (`rombuild.VERSION`), with per-file exceptions in
+`config/rombuild-versions.txt`. The **linker** is always 1.2/sp2p3 (`LD_VERSION`) because
+the 2004 toolchain ships no `mwldarm`.
+
+## The pipeline
+
+```
+src/*.c|cpp  --mwccarm-->  build/src/*.o  ─┐
+                                           ├─ mwldarm ─> build/final_link.o (ELF)
+config/**/delinks.txt --dsd delink--> build/delinks/*.o  ─┘   + build/*.bin per region
+        │                                                          │
+        └──> dsd lcf ──> build/arm9.lcf + build/objects.txt        │
+                                                                   v
+                                        dsd rom config --elf build/final_link.o
+                                                                   │
+                                                                   v
+                                        dsd rom build ──> build/sm64ds.nds
+                                                                   │
+                                        dsd check modules ──> byte-diff vs retail
+```
+
+Commands (matching the reference dsd project, `DQIX/dqix-decomp`, adjusted for the
+0.11.0 CLI actually on disk):
+
+```
+dsd lcf        -c config/arm9/config.yaml            # writes arm9.lcf + objects.txt to build_path
+mwldarm  -proc arm946e -nostdlib -interworking -m Entry -map closure,unused \
+         -msgstyle gcc -nodead @build/objects.txt build/arm9.lcf -o build/final_link.o
+dsd rom config --elf build/final_link.o --config config/arm9/config.yaml
+dsd rom build  --config <generated rom config> --rom build/sm64ds.nds
+dsd check modules --config-path config/arm9/config.yaml --fail
+dsd check symbols --config-path config/arm9/config.yaml --elf-path build/final_link.o --fail
+```
+
+## What already exists
+
+| Piece | State |
+|---|---|
+| `dsd` (ds-decomp 0.11.0) | `tools/bin/dsd.exe` |
+| ROM extracted (`dsd rom extract`) | `extracted/dsd/` — header, banner, 2,072 asset files, arm7, arm9, overlays |
+| dsd project config | `config/arm9/config.yaml` + **106 modules** (main + itcm + dtcm + 103 overlays) of `symbols.txt` / `relocs.txt` / `delinks.txt` |
+| Delinked gap objects | `build/delinks/*.o` — **93**, because 13 overlays are empty and emit none |
+| Linker script + object list | `build/arm9.lcf`, `build/objects.txt` |
+| Compiler **and linker** | `tools/mwccarm/1.2/sp2p3/{mwccarm,mwldarm}.exe` |
+| Matched source | `src/` — 8,147 `.c` + 3,056 `.cpp`, one function per file |
+| Symbol → address map | `config/**/symbols.txt` (`name kind:function(arm,size=0x14) addr:0x...`) |
+
+At the time this plan was written nothing had ever been linked and `build/build/` was
+empty. M0 changed that.
+
+Coverage measured for this plan: **11,197 of 11,389** function symbols have a `src/`
+file; in the main module, 3,084 of 3,090.
+
+## `delinks.txt` file-entry syntax
+
+Verified by running dsd 0.11.0 against an isolated copy of the config. A *file entry* is
+an unindented path ending in `:`, followed by indented lines:
+
+```
+    .text       start:0x02004000 end:0x020736f4 kind:code align:32
+    ...
+src/AngleDiff.c:
+    complete
+    .text start:0x0203b0e8 end:0x0203b0fc
+```
+
+Two behaviours that matter, both confirmed empirically rather than assumed:
+
+- **`align:32` is not inherited.** dsd emitted the carved object with
+  `sh_addralign=4`, and the generated lcf places gap and file objects back-to-back with
+  no `ALIGN` directive between them, under `ALIGNALL(4)`. No `align:4` override needed.
+- **`complete` selects the object source.** With `complete`, `objects.txt` points at
+  `build\src\AngleDiff.o` — our compiled object. *Without* it, dsd emits
+  `build\delinks\src\AngleDiff.o` from ROM bytes and points there instead. That second
+  mode is what M2a below exploits.
+
+Gap objects reference a carved-out symbol as **weak undefined**, so a missing compiled
+object links silently to address 0 rather than erroring. `dsd check symbols` /
+`check modules` is the safety net here, not the linker.
+
+## Milestones
+
+### M0 — Baseline relink, zero source involved
+
+Link the 93 existing gap objects exactly as they are, build a ROM, and prove it is the
+retail game. This validates linker flags, the lcf dialect, `rom config`, `rom build`,
+and the ARM7/secure-area/CRC handling *before* any of our C is in the mix.
+
+**Settle path plumbing first (30 seconds, before interpreting any error).**
+`build/objects.txt` holds repo-root-relative paths (`build\delinks\...`), the lcf's
+MEMORY block writes `> build/arm9.bin`, but `config/arm9/config.yaml` expects built
+binaries at `../../build/build/arm9.bin`. Run mwldarm from the repo root, then `ls
+build/ build/build/` to see where the region binaries actually landed. Also
+`mkdir -p build/src build/build` up front.
+
+**Gate:** `dsd check modules --fail` green for all modules, and `build/sm64ds.nds` boots
+to the title screen in melonDS.
+
+**The gate is deliberately not "the .nds hashes equal the dump."** `arm9.yaml` says
+`compressed: true`, and `overlays.yaml` has `table_signed: true` plus per-overlay
+`compressed: true, signed: true` against `arm9/hmac_sha1_key.bin`. File-level identity
+therefore depends on dsd's BLZ compressor and HMAC re-signing being bit-exact, which is
+not what this milestone is testing. `check modules` compares decompressed modules
+against the `hash:` fields in `config.yaml` and is compression-independent. If the .nds
+differs while modules are green, that is the compression/signing story — record it and
+move on.
+
+Remaining unknowns to settle here, not guess:
+- Whether 1.2/sp2p3 `mwldarm.exe` accepts this lcf dialect (`AFTER`, `ALIGNALL`,
+  `WRITEW`). A parse error naming an lcf line would be fatal to the whole approach —
+  which is exactly why this milestone is first.
+- Where `dsd rom config` writes its output.
+- Whether `dsd rom build` needs `--arm7-bios`. The secure area is already plaintext
+  (`encrypted: false`), so probably not, but confirm.
+- Benign `dsd delink` warnings ("No module for relocation … to 0x01ff…") are expected:
+  unmodeled relocs leave raw ROM bytes in the slot, which is byte-preserving at fixed
+  addresses.
+
+ARM7 (`extracted/dsd/arm7/arm7.bin`) and the asset file image (`extracted/dsd/files/`
+plus `path_order.txt`) ride through `rom build` untouched. The `.sav` is emulator-created;
+nothing to do.
+
+#### M0 result — passed
+
+Every unknown resolved favourably on the first attempt:
+
+- **mwldarm 1.2/sp2p3 accepts the lcf dialect** — `AFTER`, `ALIGNALL`, `WRITEW` and all —
+  linking 93 gap objects with exit 0 and no diagnostics.
+- **The path question answered itself.** mwldarm resolves `@build/objects.txt` entries
+  against the CWD (repo root) and the MEMORY block's `> build/arm9.bin` against the lcf's
+  own directory, so the region binaries land in `build/build/` — exactly where
+  `config.yaml` expects them. Run mwldarm from the repo root and it just works.
+- `dsd lcf -c` writes both `build/arm9.lcf` and `build/objects.txt` from `build_path`.
+- `dsd rom config` writes `build/build/rom_config.yaml` (plus per-module yaml).
+- **`--arm7-bios` is not needed.** `dsd rom build` produced a full 16,777,216-byte ROM
+  without it.
+- `dsd check modules --fail`: all 106 modules OK, exit 0.
+
+And the .nds is much closer to the dump than the gate required: **107 differing bytes out
+of 16,777,216**, all metadata, in three groups —
+
+| Offset | Count | What |
+|---|---:|---|
+| `0x06152F` + `0x20`·n | 103 | overlay table entry flag byte, `3` → `1`. dsd compresses each overlay but does not re-apply the HMAC signature, so it clears the "signed" bit and the ARM9 loader skips verification. |
+| `0x00006C` | 2 | secure area CRC, zeroed (the area is already plaintext, `encrypted: false`). |
+| `0x00015E` | 2 | header CRC16, correctly recomputed for the changed header. |
+
+Every byte of code, data, and all 2,072 asset files is identical, and dsd's BLZ
+compressor reproduces the retail compressed streams exactly. The overlay-signature bit
+is the one thing to remember: **signature verification is off in every built ROM**, which
+is what makes overlay edits possible at all, but it also means a signing bug could never
+show up as a failure here.
+
+### M1 — One function from source
+
+`AngleDiff` is a verified-good pick: `config/arm9/symbols.txt:1513`
+(`kind:function(arm,size=0x14) addr:0x0203b0e8`), the next symbol is exactly adjacent at
+`0x0203b0fc`, `src/AngleDiff.c` is pure ALU with no literal pool, no data and no calls,
+and zero relocations originate inside it.
+
+1. Add its file entry (with `complete`) to `config/arm9/delinks.txt`.
+2. `dsd delink` — the main gap object splits, regenerated without that range.
+3. Compile with the canonical toolchain and flags (`1.2/sp2p3`, `-O4,p -enum int
+   -lang c99 -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc`,
+   `-i include/`) to `build/src/AngleDiff.o`.
+4. `dsd lcf`, link, `dsd rom config`, `dsd rom build`.
+
+**Gate:** `dsd check modules` still green — a byte-identical main module where one
+function's bytes came from our C.
+
+#### M1 result — passed
+
+`config/arm9/delinks.txt` grew the three-line entry; `dsd delink` split the single
+`_dsd_gap@main_7.o` into `_dsd_gap@main_8.o` (everything before) and `_dsd_gap@main_1.o`
+(everything after), and the generated lcf placed them back-to-back around ours:
+
+```
+_dsd_gap@main_8.o(.text)
+AngleDiff.o(.text)
+_dsd_gap@main_1.o(.text)
+```
+
+`objects.txt` names `build\src\AngleDiff.o` — confirming the object-path derivation is
+`build_path` + the delink file path with a `.o` extension. Linked ARM9 is byte-identical
+to the extracted one and `check modules` stays green.
+
+**Negative control.** Because gap objects reference carved-out symbols as *weak*
+undefined, a green build could in principle mean "our object was ignored". So a
+deliberately wrong `AngleDiff` (`return d + 1`, compiled into the same object slot
+without touching `src/`) was linked: the ROM changed, confirming our bytes are really the
+ones placed. It also demonstrated the cascade to respect at M3 — the extra instruction
+grew the function past its 0x14-byte slot, shifting every later address and re-pointing
+absolute pool words throughout the module, so **305,977** bytes of `arm9.bin` differed,
+starting well *before* the edited function. Restoring the real source returned the build
+to byte-identical. **A behaviour edit must keep the function's size unchanged.**
+
+Then flip **one deliberate interworking caller** (a function whose `BL` targets a Thumb
+SDK symbol; main alone has 26 Thumb functions) and observe whether mwldarm emits `BLX`
+or synthesizes a veneer. A new veneer adds bytes, and via the lcf's `AFTER()` chains
+that moves downstream overlay origins — so this is worth knowing at M1 with one file in
+play rather than at M2 with thousands.
+
+### M2a — All candidate file entries, no `complete`
+
+Land file entries for the whole candidate set **without** `complete`, so dsd supplies
+ROM-bytes objects for every one of them. The result is byte-identical *by construction*,
+which makes this a pure scale test: it proves `dsd delink`, `dsd lcf`, and an ~11,000-object
+`mwldarm` link survive before correctness is ever in play.
+
+Scale is friendlier than the raw file count suggests. Matched functions form only **210
+contiguous runs corpus-wide (7 in main)**, and gap-object count tracks run boundaries,
+not function count — main's `.text` has just 25 inter-function holes totalling 5,878
+bytes. Object count (~11k) is fixed by the one-function-per-file convention and cannot be
+coalesced at the `delinks.txt` level without merging TUs, which the repo layout forbids.
+If mwldarm chokes, the fallback is partial-linking runs into intermediate objects
+(`mwldarm -r`, unverified) or capping enrollment per module.
+
+Ramp per module: main first (3,084 entries, 7 runs) is the cleanest stress test.
+
+#### M2a result — passed
+
+`tools/enroll.py` generates the file entries; `config/rombuild-exclude.txt` records what
+cannot be carved and why. **11,090 entries** across 73 modules, **11,390 objects** in
+`build/objects.txt`, and `mwldarm` linked the lot in ~50 s wall clock for the whole
+pipeline. All 106 modules green; the packaged `.nds` is still exactly the same **107
+metadata bytes** away from the retail dump as at M0. Carving raised the gap-object count
+from 93 to 374 — still small, as predicted by the contiguous-run analysis.
+
+The scale worry was unfounded; what actually cost the iterations were three concrete
+discoveries, none of which show up at one-function scale:
+
+1. **A local label cannot cross an object boundary.** `func_0206ce90`, `func_0206cee0`
+   and `func_0206d868` `arm_call` 0x0206d9dc and 0x0206da28 — addresses with no symbol,
+   because they are *secondary entry points* 0x10 bytes inside `func_0206d9cc` and
+   `func_0206da18`. dsd names such a target `.L_0206d9dc` and then refuses:
+   `Imported symbol .L_0206d9dc … is local, it cannot be used in relocation`.
+   Excluding just the three callers does not help — the error simply moves to the gap
+   object, because carving any function *between* caller and target splits the span. The
+   whole 12-function run has to stay in one object. Giving those two addresses real
+   symbols in `symbols.txt` would recover all twelve.
+2. **Per-entry alignment cannot be overridden.** dsd rejects it outright:
+   `attribute 'align' should be omitted as it is inherited from this file's header`.
+   Carved code sections get 4-byte alignment, so a function that does not start
+   4-aligned — the thumb SDK stubs (`Div` at 0x0200406a, `IntrWait`, `CpuSet`, …) — is
+   padded up by the linker. That inserted 2 bytes at the very first entry and shifted
+   the entire module: main came out 32 bytes long with 497,337 differing bytes. **12
+   functions** are excluded on `addr % 4 != 0`.
+
+   This refines the M1 finding. Fable verified alignment was not inherited *for a
+   4-aligned ARM function*, which was true and is why M1 passed; the inherited-align
+   problem only bites where the address is not already 4-aligned.
+3. **The `// NONMATCHING` hatch must be honoured.** 84 files have a `src/` entry but are
+   explicitly not byte-matches, so they are candidates for neither mode.
+
+Final tally: 11,090 enrolled, 191 with no `src/` file, 84 NONMATCHING, 12 unaligned, 12
+in the secondary-entry-point cluster.
+
+### M2b — Eligibility flip
+
+Now flip `complete` on, per module, for files that pass a **whitelist**. A blacklist is
+the wrong shape here: the modules also carry `.exception`, `.exceptix`, `.init` and
+`.ctor` sections, and anything unexpected grows the module and shifts every later
+address.
+
+A file enrolls only if:
+
+- its object has **exactly one non-empty section, named `.text`**, holding **exactly one
+  defined global FUNC symbol** whose `st_size` equals the declared symbol size;
+- the symbol's address lies in a `.text` range — **not `.init`**. About **301 matched
+  functions live inside `.init` ranges**; their objects emit code into a section named
+  `.text`, so a file entry declaring `.init` would generate a `File.o(.init)` selector
+  that matches nothing. Hard-exclude them;
+- every undefined reference resolves to a real, addressed symbol;
+- a **fresh strict `linkcheck` pass** rates it VERIFIED — not BENIGN, not BLIND. The
+  corpus figures in [`link-verification.md`](link-verification.md) are from 7,180
+  matches on 2026-06-29 and `src/` now holds 11,203 files, so ~4,000 matches have never
+  been linkchecked and the 1,787 BLIND count is a floor. BENIGN matters because those 26
+  cases are exactly the veneer/twin/ARM→Thumb cases that `linkcheck` waves through for
+  *match* verification but that a real relink resolves differently — silently shifting
+  bytes instead of failing loudly.
+
+Why one `.text` section and not "no extra sections": `tools/linkcheck.py` documents that
+mwccarm emits **one `.text` section per function** within a TU, and the lcf's
+`File.o(.text)` selector places *all* of them. A multi-function TU (any C++ dtor emitting
+`D0`/`D1`/`D2` plus thunks) injects extra code at the wrong addresses even when no symbol
+name collides — and `-nodead` disables the dead-stripping that might otherwise hide it.
+
+Bisection on a mismatch starts at the **earliest module in the `AFTER()` partial order**
+(`build/arm9.lcf:5–109`): a size change in ov002 shifts the origins of ov008–ov102, so
+dozens of red modules mean "look upstream", not "dozens of bugs". Verdicts land in
+`build/rombuild-eligibility.json`.
+
+**Gate:** thousands of functions sourced from `src/`, `dsd check modules` still green,
+one-command reproducible build.
+
+#### M2b result — passed
+
+**7,916 functions are compiled from `src/` and every one of the 106 modules is still
+byte-identical to the ROM.** That is 1,346,916 code bytes, **60.9%** of the project's
+2,211,124. The `.nds` remains exactly 107 metadata bytes from the retail dump. Whole
+build: ~80 seconds.
+
+Four things got it there, and only the first was in the plan.
+
+**1. `-Cpp_exceptions off`.** The dominant blocker was not C++ TUs or BLIND symbols — it
+was `.exceptix`, on **8,520 of 11,090** candidates. mwccarm emits an exception-unwind
+index alongside almost every function and the match gate never noticed, because it only
+ever compares `.text`. A ROM link very much notices: duplicate content that grows the
+module and shifts every later address. Retail carries just 636 bytes of `.exceptix` in
+main, so the original build had them off too. The flag cleared the extra sections on
+**60 of 60** sampled files with **zero `.text` change**.
+
+**2. The default compiler is `2004/b56`, not `1.2/sp2p3`.** The repo pins 1.2/sp2p3 as
+canonical, but a function counts as matched if *any* swept version reproduces it, and a
+link has to pick one. Defaulting to the recovered 2004 build 0056
+(`notes/mwccarm-codegen.md` 6ai) reproduces strictly more of this corpus: eligibility
+7,466 → 7,923, and post-link mismatches **70 → 14**. Note b56 ships *only* `mwccarm.exe`,
+so `LD_VERSION` keeps the link on 1.2/sp2p3's `mwldarm` regardless.
+
+**3. Per-file version overrides.** `config/rombuild-versions.txt` names the exceptions;
+`tools/rombuild_versions.py` finds them by sweeping `match.py`'s version list over
+whatever `rombuild_check.py` reported. Seven functions match only under `1.2/base`.
+
+**4. Per-function diffing beats bisection.** Because eligibility requires the object's
+`.text` to equal the declared size exactly, no function can shift its neighbours, so
+every mismatch is *confined to the function that caused it*.
+`tools/rombuild_check.py` compares each source-built function against the ROM
+individually and names all the culprits from **one** build. No bisection, no walking the
+`AFTER()` order.
+
+##### What the first 70 mismatches turned out to be
+
+Worth recording, because the intuitive reading was wrong. Under the old 1.2/sp2p3
+default, 70 of 7,466 did not reproduce. Running them through the repo's own oracle split
+them cleanly:
+
+- **54 were not broken at all.** `tools/match.py` rejected them under 1.2/sp2p3 but
+  *every one* matched under `2004/b56`. They were version-divergent, not wrong — which
+  is what motivated flipping the default. Their last-touching commits are mostly the
+  `readable: strip N unnecessary compiler-steering no-op masks` passes, so those passes
+  appear to have re-verified under a different version than the ROM build was using.
+- **16 were genuine wrong relocation destinations** — the class the match gate
+  structurally cannot see, because it wildcards every relocated word, so a call to the
+  wrong function with the right shape reads as a match. `tools/rombuild_diag.py` decodes
+  each differing word and resolves both sides back to symbols, turning the byte diff into
+  "the source calls X, the ROM calls Y".
+
+Nine of the sixteen were mechanical symbol repoints, applied to `src/` and verified
+individually with `match.py` before the link confirmed them:
+
+| function | source named | ROM uses |
+|---|---|---|
+| `_ZN13PrincessPeach6RenderEv` | `CommonModel::Render` | `Model::Render` |
+| `_ZN7Tornado6RenderEv`, `_ZN9WaterRing6RenderEv` | `TextureSequence::Update` | `TextureTransformer::Update` |
+| `func_ov079_02126e58` | `Actor::DisappearPoofDustAt` | `Actor::PoofDustAt` |
+| `func_ov085_0212e778` | `…ApplyInPlaceToRotationXYZExt` | `…ApplyInPlaceToRotationZXYExt` |
+| `func_ov006_0211a048`, `func_ov006_0211a5ec` | wrong `data_ov006_*` base | the adjacent one |
+| `func_ov006_02120c08` | `func_ov006_020eed68` | `func_ov006_02120a64` |
+| `func_ov002_020f23d0` | the veneer `func_0203cbc0` | `Memory::operator_delete2` |
+
+The `XYZExt` → `ZXYExt` one is a genuine behavioural bug, not just a naming slip.
+
+##### The vtable off-by-8 — a real bug, found by review
+
+`_ZN11ShadowModelC1Ev` was initially filed above as a non-bug. It is not. The source
+wrote `thiz->vtable = _ZTV11ShadowModel + 2;` on a `u32[]`, i.e. **symbol + 8 bytes**,
+while the ROM's pool word is the symbol **+ 0**:
+
+| function | `_ZTV*` symbol | ROM pool word |
+|---|---|---|
+| `_ZN11ShadowModelC1Ev` | `0x0208e868` | `0x0208e868` (+0) |
+| `_ZN5ModelC1Ev` | `0x0208e90c` | `0x0208e90c` (+0) |
+| `_ZN5ModelC2Ev` | `0x0208e90c` | `0x0208e90c` (+0) |
+| `_ZN11CommonModelC1Ev` | `0x0208e8a4` | `0x0208e8a4` (+0) |
+
+The `+ 2` is the Itanium-ABI reflex (skip offset-to-top and RTTI), but this ABI points
+the vptr at the vtable base, so all four were storing a vptr 8 bytes too high — virtual
+dispatch through it would index the wrong slots. Three of the four were invisible to the
+ROM build only because they are blocked upstream on an unrelated unresolvable symbol.
+
+The match gate cannot see this: the pool word is a relocation, and `match.py` wildcards
+every relocated word, so all four "matched" byte-for-byte with the bug in place. Removing
+`+ 2` keeps them byte-matching and fixes the destination. **This is the single strongest
+argument for the ROM build as a gate** — it catches a class the byte oracle is blind to
+by construction.
+
+**Six remain, and all six are documented non-bugs:**
+
+- three (`_ZN5ModelD1Ev`, `_ZN5ModelD2Ev`, `_ZN14BlendModelAnimD1Ev`) call `_ZdlPv`
+  where the ROM goes through the 12-byte veneer at `0x0203cbc0`. That trampoline is the
+  standard `LDR ip,[pc]; BX ip; .word target` shape, and its target word is
+  **`0x0203cbf0` = `_ZdlPv`** —
+  the same callee the source names — passing *over* `_ZN6Memory16operator_delete2EPv` at
+  `0x0203cbcc`. So ROM and source call the identical function and only the route differs.
+  [`link-verification.md`](link-verification.md) is explicit that naming the real symbol
+  is correct and inserting a veneer is the linker's job. It is also unreachable: the
+  veneer is a pre-existing ROM function living in the gap object, and mwldarm only
+  synthesizes veneers it *needs* (out-of-range or interworking, neither of which applies
+  to an in-range ARM→ARM `BL`). No linker flag routes a call through another object's
+  existing trampoline. Left alone deliberately.
+- three (`_ZN11MirrorLuigiD1Ev`, `_ZN15RecRoomCupboardD0Ev`, `_ZN15RecRoomCupboardD1Ev`)
+  write `((Actor *)c)->~Actor()`, for which the compiler emits the D1 complete-object
+  destructor while the ROM calls the D2 base-object one. Only real inheritance would make
+  the compiler choose D2, so this is structural, not a rename — exactly the kind of work
+  the `readable/` C++-promotion branches do.
+- ~~one (`_ZN11ShadowModelC1Ev`) stores a vtable pointer that resolves elsewhere than
+  `_ZTV11ShadowModel`.~~ **This one was a real bug, not a non-bug** — see below.
+
+Why the rest are not source-built yet:
+
+| count | reason |
+|---:|---|
+| 1,972 | references a symbol name `config/**/symbols.txt` does not define — the BLIND matches. No address means nothing to link to, and gap objects import weakly, so it would silently resolve to 0. |
+| 711 | the object defines a different symbol than the file/config name (e.g. `src/func_ov091_02132a0c.c` defines `daDsn_c_OnAimedAtWithEgg`) — a src/config naming drift, likely recoverable by reconciling names. |
+| 70 | compiled `st_size` ≠ the size `symbols.txt` declares |
+| 301 | lives in a `.init` range, where a `File.o(.init)` selector would match nothing in an object whose code is in `.text` |
+| 88 | emits `.data` or `.bss` whose ROM address we do not know |
+| 13 | multiple `.text` sections — a multi-function TU |
+| 12 | fails to compile with the build flags |
+| 6 | the veneer / D1-vs-D2 cases above |
+
+### M2c — Reconcile the name mismatches
+
+The largest remaining bucket was 711 files whose object defined a different symbol than
+their filename. They turned out to share an annotation pair:
+
+```
+// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
+// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
+```
+
+The second name is recovered knowledge, usually from a vtable slot. **Nothing in the repo
+consumes either annotation** — no tool, no CI config, no doc mentions them — and the
+divergence quietly broke two things:
+
+- **`match.py` cannot verify these files at all.** Asked for the filename's symbol it
+  reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns
+  `MATCHING VERSIONS: none` for every one of them. Meanwhile `progress.py` counts them as
+  matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING`
+  hatch. **712 files, about 6% of `src/`, were being counted as matched while being
+  unverifiable by the repo's own gate.**
+- **The ROM link cannot use them.** Gap objects import a carved-out function by its
+  `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every
+  caller silently binding to address 0 instead of erroring.
+
+`tools/reconcile_names.py` renames the emitted function to the `@symbol` name, replaces
+the now-redundant `@emits` line with `// recovered name: <name>` so the recovered identity
+is preserved, and byte-verifies each file against the ROM before keeping the edit.
+
+**711 of 712 verified and were applied.** The one holdout, `func_ov022_021123d0`, declares
+its own symbol with a conflicting signature and needs a human. Of the 711, **699 reproduce
+under the build's default `2004/b56`** and only 12 need a `1.2/base` override — further
+evidence that b56 is the right default for this corpus.
+
+Eligibility went 7,914 → 8,374 and source-built functions 7,907 → **8,367** (60.9% →
+63.8% of code bytes). The gap between +711 renamed and +460 enrolled is files that were
+blocked by a second reason as well — a BLIND symbol, a size mismatch, an `.init` home.
+
+The opposite direction — adopting the recovered names into `config/**/symbols.txt` — is
+the better long-term move and is left deliberately undone: it changes the canonical symbol
+table and every reference to those names, which is a maintainer's call, not a build fix.
+
+### M2d — Resolve the BLIND references
+
+The next bucket was ~1,970 files referencing a name `config/**/symbols.txt` does not
+define. [`link-verification.md`](link-verification.md) calls these the BLIND matches and
+concludes "No static tool can verify those destinations; only a fuller symbol table
+would."
+
+That is true of a *static* tool, but the ROM build is not one. The function byte-matches,
+so the ROM's own linked word at the relocation slot **is** the destination: decode it (a
+`BL` target, or an `R_ARM_ABS32` pool word minus its addend) and look the address up.
+
+`tools/resolve_blind.py` does that per file and per relocation, which matters because the
+names come in two very different shapes and this handles both the same way:
+
+- **Shared names with one true target.** `_Z28_ZN13SharedFilePtr7ReleaseEvPv` (177 files)
+  is `_ZN13SharedFilePtr7ReleaseEv` — a double-mangling artifact, someone mangled an
+  already-mangled name. Same for `_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv`,
+  `_Z31_ZN16MeshColliderBase7DisableEvPv`, `_Z10DeallocatePv` → `Deallocate`.
+- **Per-file placeholders.** `G0` appears in 480 files and means **173 different
+  addresses**; `G1` 107, `G2` 142, `G3` 111, `VT1` 42. A global rename would be actively
+  wrong here — only per-file resolution works.
+
+Of 6,238 unresolvable references, **6,238 − 65 resolve to a real symbol**. The 65 that do
+not are mostly not addresses at all (`0x04000204` is a hardware register, `0x00000006` a
+constant), so nothing is renamed for them.
+
+Every rename is byte-verified before it is kept; a file that stops matching is reverted.
+1,227 files were renamed, eligibility went 8,374 → 9,124, and source-built functions
+8,367 → **9,115** (63.8% → 66.7% of code bytes).
+
+### M3 — Prove it is really our code
+
+Change a constant in a source-built function, rebuild, boot in melonDS, observe the
+difference, then revert and confirm the ROM returns to identical.
+
+**Overlay edits are fine after all.** The original worry was HMAC signing, but M0 showed
+dsd *clears* the per-overlay signed bit (the 103 flag bytes `3` → `1`), so the loader
+never verifies and an overlay edit loads normally — which the ov002 mod confirms in
+practice. Still worth knowing: a white screen with green `check modules` would point at
+the header CRCs (`extracted/dsd/header.yaml`), which `check modules` does not cover.
+
+**Gate:** a visible in-game change traced to a one-line C edit. This is the deliverable
+the whole exercise is for.
+
+#### M3 result — passed
+
+**The built ROM boots and plays.** melonDS 1.1 runs `build/sm64ds.nds` at a locked
+60/60 through title → "touch the picture" → main menu (3D Yoshi) → file select (castle
+flyover) → the opening cutscene → gameplay on the castle grounds, with the HUD, the
+touch-screen minimap, 2D and 3D all correct. No BIOS files and no `--arm7-bios` needed.
+
+**Intentional divergences live in `mods/`, not `src/`.** `src/` must byte-reproduce the
+ROM, so a modified function goes in `mods/<Symbol>.c` and the module's `delinks.txt`
+file entry points there instead. Switching between stock and modded is a one-word path
+edit; nothing else in the pipeline changes.
+
+`mods/Player_ScaleByCharFactor.c` (shift 12 → 11, doubling the scale factor) built
+cleanly and landed exactly as intended: **3 bytes changed**, both at the shift
+instructions, all inside the function, ov002's size unchanged at 394,048 bytes, so
+nothing downstream moved. Saved as `build/sm64ds-mod.nds`.
+
+**Confirmed in play.** A/B of `build/sm64ds-mod.nds` against `build/sm64ds.nds` shows the
+difference in the running game. `Player_ScaleByCharFactor` is called from 44 sites across
+ov002's player physics, so doubling it is felt in movement rather than seen in a still
+frame — which is why a screenshot comparison was the wrong instrument for it and playing
+was the right one.
+
+So the whole chain holds end to end: a one-operator edit in a C file, through mwccarm and
+mwldarm, into a linked overlay that is byte-identical everywhere except the three bytes
+that changed, packaged into a ROM that boots and plays differently. That is the
+deliverable.
+
+`mods/` is where an intentional divergence lives; `tools/enroll.py` prefers
+`mods/<symbol>.c` over `src/<symbol>.c` by file existence, so deleting the mod file
+reverts to stock and `python tools/rombuild.py` is green again.
+
+## Constraints
+
+- **Nothing ROM-derived is ever committed.** `build/`, `extracted/`, `*.nds`, `*.bin`
+  and `*.o` are already gitignored. The built ROM stays local, like the dump it came
+  from. Only `tools/rombuild.py`, the `delinks.txt` file entries, and this note are repo
+  content.
+- **`delinks.txt` edits are config, not matches**, and `AGENTS.md:49` keeps tooling and
+  config changes out of match batches — they go in their own PR.
+- **ARM7 is not decompiled** and passes through untouched.
+- **An emulator is required and is not installed.** melonDS is the accuracy reference;
+  DeSmuME also works.

--- a/tools/eligible.py
+++ b/tools/eligible.py
@@ -1,0 +1,186 @@
+"""Decide which enrolled functions may be compiled into the ROM (`complete`).
+
+A `src/` file byte-matches its function, but that is not sufficient to *link* it in
+place of the ROM's own bytes. The object has to occupy exactly the address range the
+file entry declares and contribute nothing else, or it shifts every later address in
+the module. So this is a whitelist, not a blacklist:
+
+  1. exactly one content section, named `.text` - mwccarm emits one `.text` section per
+     function, so a translation unit defining more than one function (any C++ dtor, which
+     emits D0/D1/D2 plus thunks) would place all of them, at addresses only one of which
+     is right;
+  2. exactly one defined global FUNC symbol, and its `st_size` equals the declared size;
+  3. no `.rodata` / `.data` / `.bss` / `.init` / `.ctor` content - the ROM's copy of that
+     data stays in the gap object, so ours would be a duplicate that grows the module;
+  4. the function lives in a `.text` range, not `.init`;
+  5. every undefined reference names a symbol that config/**/symbols.txt actually
+     defines - an invented name has no address, and because gap objects import
+     carved-out symbols *weakly* it would link silently to 0 rather than error.
+
+Passing all five means the object is a drop-in replacement for the ROM's bytes. Whether
+it is the *right* replacement is then settled by `dsd check modules`.
+
+Usage:
+    python tools/eligible.py                 # classify, write the pass list
+    python tools/eligible.py -j 16
+    python tools/eligible.py --verify        # also byte-check the built modules
+
+Writes build/rombuild-eligibility.json (per-file verdict + reason) and
+build/eligible-names.txt (the pass list, for `enroll.py --complete-list`).
+"""
+import argparse
+import collections
+import concurrent.futures
+import io
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+from elftools.elf.elffile import ELFFile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from enroll import candidates, CONFIG, REPO  # noqa: E402
+from rombuild import versions  # noqa: E402
+
+MW = REPO / "tools" / "mwccarm"
+LICENSE = MW / "license.dat"
+INCLUDE = REPO / "include"
+BUILD = REPO / "build"
+from rombuild import VERSION  # noqa: E402  (default compiler)
+# Imported, never copied: classifying with different flags than the build compiles with
+# would pass files the build then breaks on.
+from rombuild import CFLAGS  # noqa: E402
+
+ANYSYM = re.compile(r"^(\S+)\s+kind:")
+IGNORE_SECTIONS = (".comment", ".debug", ".line", ".note")
+
+
+def defined_symbols():
+    """Every symbol name config/**/symbols.txt declares, in any module."""
+    names = set()
+    for sym in CONFIG.rglob("symbols.txt"):
+        for line in sym.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = ANYSYM.match(line)
+            if m:
+                names.add(m.group(1))
+    return names
+
+
+def classify(job):
+    rel, name, addr, size, sec, known, version = job
+    src = REPO / rel
+    obj = BUILD / pathlib.Path(rel).with_suffix(".o")
+    obj.parent.mkdir(parents=True, exist_ok=True)
+    flags = CFLAGS
+    try:
+        if src.read_text(encoding="utf-8", errors="ignore").startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+    except OSError:
+        return rel, name, "unreadable source"
+
+    cmd = [*os.environ.get("MWCCARM_LAUNCHER", "").split(),
+           str(MW / version / "mwccarm.exe"), *flags.split(),
+           "-i", str(INCLUDE), "-c", str(src), "-o", str(obj)]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
+    if r.returncode != 0 or not obj.is_file():
+        return rel, name, "compile failed"
+
+    if sec != ".text":
+        return rel, name, f"lives in {sec}, not .text"
+
+    try:
+        elf = ELFFile(io.BytesIO(obj.read_bytes()))
+        content = []
+        for s in elf.iter_sections():
+            h = s.header
+            if h["sh_type"] not in ("SHT_PROGBITS", "SHT_NOBITS"):
+                continue
+            if h["sh_size"] == 0 or any(s.name.startswith(p) for p in IGNORE_SECTIONS):
+                continue
+            content.append(s.name)
+        # Section size, not just symbol size: a padded .text would place extra bytes and
+        # shift the module while st_size still looked right.
+        text_sh_size = next((s.header["sh_size"] for s in elf.iter_sections()
+                             if s.name == ".text" and s.header["sh_size"]), None)
+        if len(content) != 1 or content[0] != ".text":
+            extra = sorted(set(content) - {".text"})
+            if len(content) > 1 and not extra:
+                return rel, name, f"{len(content)} .text sections (multi-function TU)"
+            return rel, name, "extra sections: " + ",".join(extra or content)
+
+        symtab = elf.get_section_by_name(".symtab")
+        defined, undefined, other_defined = [], [], []
+        for s in symtab.iter_symbols():
+            info = s["st_info"]
+            if info["bind"] not in ("STB_GLOBAL", "STB_WEAK"):
+                continue
+            if s["st_shndx"] == "SHN_UNDEF":
+                if s.name:
+                    undefined.append(s.name)
+            elif info["type"] == "STT_FUNC":
+                defined.append((s.name, s["st_size"]))
+            elif info["type"] == "STT_OBJECT":
+                # A defined global object in the .text section would be placed too, and
+                # the FUNC-only count above would never notice it.
+                other_defined.append(s.name)
+
+        if text_sh_size is not None and text_sh_size != size:
+            return rel, name, f".text section 0x{text_sh_size:x} != declared 0x{size:x}"
+        if len(defined) != 1:
+            return rel, name, f"{len(defined)} defined global functions"
+        dname, dsize = defined[0]
+        if dname != name:
+            return rel, name, f"defines {dname}, expected {name}"
+        if dsize != size:
+            return rel, name, f"size 0x{dsize:x} != declared 0x{size:x}"
+        if other_defined:
+            return rel, name, "defines non-function globals: " + ",".join(other_defined[:3])
+        missing = sorted(set(undefined) - known)
+        if missing:
+            return rel, name, "unresolvable: " + ",".join(missing[:3])
+    except Exception as e:  # a malformed object is a fail, not a crash
+        return rel, name, f"elf error: {type(e).__name__}"
+    return rel, name, None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 8)
+    args = ap.parse_args()
+
+    known = defined_symbols()
+    cands, _ = candidates()
+    vers = versions()
+    jobs = [(rel, name, addr, size, sec, known, vers.get(name, VERSION))
+            for (_d, name, rel, addr, size, sec) in cands]
+    print(f"classifying {len(jobs)} enrolled functions with -j{args.jobs} ...")
+
+    results, reasons = [], collections.Counter()
+    done = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, name, reason in ex.map(classify, jobs):
+            results.append({"file": rel, "name": name, "reason": reason})
+            reasons["ELIGIBLE" if reason is None else reason.split(":")[0]] += 1
+            done += 1
+            if done % 2000 == 0:
+                print(f"  {done}/{len(jobs)}")
+
+    BUILD.mkdir(exist_ok=True)
+    (BUILD / "rombuild-eligibility.json").write_text(json.dumps(results, indent=1))
+    passed = [r["name"] for r in results if r["reason"] is None]
+    (BUILD / "eligible-names.txt").write_text("\n".join(sorted(passed)) + "\n")
+
+    print()
+    for k, v in reasons.most_common():
+        print(f"{v:7d}  {k}")
+    print(f"\neligible: {len(passed)} / {len(jobs)}")
+    print(f"wrote {BUILD / 'eligible-names.txt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/enroll.py
+++ b/tools/enroll.py
@@ -1,0 +1,212 @@
+"""Write `src/` file entries into config/**/delinks.txt so the ROM build can use them.
+
+Each entry carves an address range out of its module's gap object and hands it to a
+named file. Two modes, and the difference is one keyword:
+
+  rombytes  (default)  the entry has no `complete` line, so **dsd** supplies the object
+                       from the original ROM bytes. The build stays byte-identical by
+                       construction. This is the scale test: it proves dsd delink/lcf and
+                       an ~11k-object mwldarm link hold up before correctness is in play.
+
+  complete             the entry gets `complete`, so **mwccarm** compiles the source file
+                       and its output is what lands in the ROM. This is the real thing,
+                       and only files that pass the eligibility rules may use it.
+
+Entries already marked `complete` are preserved across runs unless --demote-all is given,
+so promoting a file is additive and re-running is idempotent.
+
+Usage:
+    python tools/enroll.py --dry-run              # what would change
+    python tools/enroll.py                        # rombytes for every candidate
+    python tools/enroll.py --complete-list f.txt  # promote the names in f.txt
+    python tools/enroll.py --clear                # back to bare global sections
+
+A candidate is a function symbol in config/**/symbols.txt that has a src/<name>.c[pp]
+without a `// NONMATCHING` hatch, a nonzero size, an unambiguous module, and an address
+fully inside one of that module's declared sections. See notes/rom-build.md.
+"""
+import argparse
+import collections
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CONFIG, SRC = REPO / "config", REPO / "src"
+# An intentional divergence from the ROM lives in mods/<symbol>.c and takes precedence
+# over src/<symbol>.c for that one function. Keeping it a file-existence rule (rather
+# than a hand-edited delinks.txt entry) is what makes regeneration idempotent: a mod
+# survives every enroll.py run, and deleting the file reverts to stock.
+MODS = REPO / "mods"
+
+SYM_RE = re.compile(
+    r"^(\S+)\s+kind:function\((arm|thumb),size=0x([0-9a-fA-F]+)\)\s+addr:0x([0-9a-fA-F]+)")
+SEC_RE = re.compile(
+    r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)\s+kind:(\S+)")
+
+
+def read_delinks(path):
+    """Split a delinks.txt into its global section header and its file entries.
+
+    Header = the leading indented section lines. A file entry is an unindented path
+    ending in ':' followed by indented lines; we only care whether `complete` is there.
+    """
+    header, entries, cur = [], {}, None
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not line.strip():
+            continue
+        if line[0].isspace():
+            if cur is None:
+                header.append(line.rstrip())
+            elif line.strip() == "complete":
+                entries[cur] = True
+        else:
+            cur = line.strip().rstrip(":")
+            entries.setdefault(cur, False)
+    return header, entries
+
+
+def sections(header):
+    out = []
+    for line in header:
+        m = SEC_RE.match(line)
+        if m:
+            out.append((m.group(1), int(m.group(2), 16), int(m.group(3), 16)))
+    return out
+
+
+EXCLUDE = REPO / "config" / "rombuild-exclude.txt"
+
+
+def excluded():
+    """Symbol names that must stay inside the gap object (see the file's comments)."""
+    if not EXCLUDE.is_file():
+        return set()
+    return {l.strip() for l in EXCLUDE.read_text(encoding="utf-8").splitlines()
+            if l.strip() and not l.startswith("#")}
+
+
+def candidates():
+    """(module_dir, name, srcpath, addr, size, section) for every eligible function."""
+    skip_names = excluded()
+    name_mods = collections.defaultdict(set)
+    mods = {}
+    for sym in sorted(CONFIG.rglob("symbols.txt")):
+        d = sym.parent
+        header, _ = read_delinks(d / "delinks.txt") if (d / "delinks.txt").is_file() else ([], {})
+        syms = []
+        for line in sym.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = SYM_RE.match(line)
+            if m:
+                syms.append((m.group(1), m.group(2), int(m.group(3), 16), int(m.group(4), 16)))
+                name_mods[m.group(1)].add(d.as_posix())
+        mods[d] = (sections(header), syms)
+
+    out, skipped = [], collections.Counter()
+    for d, (secs, syms) in mods.items():
+        for (name, mode, size, addr) in syms:
+            if name in skip_names:
+                skipped["on the exclude list"] += 1
+                continue
+            f = next((d2 / (name + e) for d2 in (MODS, SRC) for e in (".c", ".cpp")
+                      if (d2 / (name + e)).is_file()), None)
+            if f is None:
+                skipped["no src file"] += 1
+                continue
+            is_mod = f.parent == MODS
+            if is_mod:
+                skipped["intentional mod (mods/)"] += 1
+            if size == 0:
+                skipped["zero size"] += 1
+                continue
+            # A carved object's section alignment is inherited from the delinks.txt
+            # header and cannot be overridden per entry (dsd rejects `align:` there).
+            # dsd gives code sections 4-byte alignment, so a function that does not
+            # start 4-aligned - the thumb SDK stubs at 2-byte-aligned addresses - gets
+            # padded up by the linker, inserting bytes and shifting the whole module.
+            if addr % 4 != 0:
+                skipped["not 4-byte aligned (thumb stub)"] += 1
+                continue
+            # A 4-aligned Thumb function would slip past the alignment gate above and
+            # then be compiled as ARM; only the size check would bounce it. Be explicit.
+            if mode != "arm":
+                skipped["thumb function"] += 1
+                continue
+            # A mod is *meant* to diverge, so the not-a-byte-match hatch does not apply
+            # to it; every structural rule still does, because a mod that changes size
+            # or emits data would shift the module just as badly as a bad match would.
+            if not is_mod and "NONMATCHING" in f.read_text(encoding="utf-8", errors="ignore")[:200]:
+                skipped["NONMATCHING hatch"] += 1
+                continue
+            if len(name_mods[name]) > 1:
+                skipped["name in >1 module"] += 1
+                continue
+            sec = next((s for (s, lo, hi) in secs if lo <= addr and addr + size <= hi), None)
+            if sec is None:
+                skipped["no containing section"] += 1
+                continue
+            out.append((d, name, f.relative_to(REPO).as_posix(), addr, size, sec))
+    return out, skipped
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--complete-list", help="file of symbol names to mark `complete`")
+    ap.add_argument("--all-complete", action="store_true", help="mark every candidate `complete`")
+    ap.add_argument("--demote-all", action="store_true", help="drop existing `complete` marks")
+    ap.add_argument("--clear", action="store_true", help="remove all file entries")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    promote = set()
+    if args.complete_list:
+        promote = {l.strip() for l in pathlib.Path(args.complete_list).read_text().splitlines()
+                   if l.strip()}
+
+    cands, skipped = candidates()
+    bymod = collections.defaultdict(list)
+    for c in cands:
+        bymod[c[0]].append(c)
+
+    n_entries = n_complete = 0
+    touched = []
+    for d in sorted(CONFIG.rglob("symbols.txt")):
+        path = d.parent / "delinks.txt"
+        if not path.is_file():
+            continue
+        header, existing = read_delinks(path)
+        # Key the carried-over `complete` marks by symbol name, not path: a function
+        # that moved between src/ and mods/ is the same function and must keep its mark.
+        existing_by_name = {pathlib.Path(p2).stem: v for p2, v in existing.items()}
+        lines = list(header)
+
+        if not args.clear:
+            # Sorted by address: delink file entries are consumed in link order.
+            for (_d, name, rel, addr, size, sec) in sorted(bymod.get(d.parent, []), key=lambda x: x[3]):
+                done = (args.all_complete or name in promote
+                        or (existing_by_name.get(name, False) and not args.demote_all))
+                lines.append(f"{rel}:")
+                if done:
+                    lines.append("    complete")
+                    n_complete += 1
+                lines.append(f"    {sec} start:0x{addr:08x} end:0x{addr + size:08x}")
+                lines.append("")
+                n_entries += 1
+
+        text = "\n".join(lines).rstrip("\n") + "\n"
+        if text != path.read_text(encoding="utf-8", errors="ignore"):
+            touched.append(path.relative_to(REPO).as_posix())
+            if not args.dry_run:
+                path.write_text(text, encoding="utf-8", newline="\n")
+
+    print(f"candidates: {len(cands)}")
+    for k, v in skipped.most_common():
+        print(f"  skipped {v:6d}  {k}")
+    print(f"entries written: {n_entries}  ({n_complete} complete / "
+          f"{n_entries - n_complete} rom-bytes)")
+    print(f"delinks.txt files {'that would change' if args.dry_run else 'changed'}: {len(touched)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/reconcile_names.py
+++ b/tools/reconcile_names.py
@@ -1,0 +1,171 @@
+"""Make each `src/` file define the symbol its filename claims.
+
+Some files carry a pair of annotations:
+
+    // @symbol func_ov091_02132a0c        <- the symbol at this ROM address
+    // @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
+
+The second name is recovered knowledge (usually from a vtable slot), but nothing in the
+repo consumes either annotation, and the divergence breaks two things:
+
+  * `tools/match.py --func <filename stem>` reports "symbol not found in object", so the
+    byte oracle cannot verify the file at all - while `tools/progress.py` still counts it
+    as matched, because that only checks a `src/<name>.c` exists;
+  * the ROM link cannot use it. Gap objects import the carved-out function by its
+    `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves
+    every caller binding to address 0 rather than erroring.
+
+This renames the emitted function to the `@symbol` name, preserving the recovered name
+in a comment, and verifies each file byte-for-byte against the ROM before keeping the
+edit. A file that stops matching is reverted and reported.
+
+It deliberately does NOT do the opposite (adopt the recovered names into
+`config/**/symbols.txt`). That is the better long-term direction, but it changes the
+canonical symbol table and every reference to those names, so it is a maintainer's call.
+
+Usage:
+    python tools/reconcile_names.py             # report what would change
+    python tools/reconcile_names.py --apply
+"""
+import argparse
+import collections
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import match as M           # noqa: E402
+import modules as MOD       # noqa: E402
+from rombuild import VERSION as BUILD_VERSION  # noqa: E402
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC = REPO / "src"
+CONFIG = REPO / "config"
+
+SYMBOL_RE = re.compile(r"^// @symbol\s+(\S+)\s*$", re.M)
+EMITS_RE = re.compile(r"^// @emits\s+(\S+)\s*$", re.M)
+CFG_RE = re.compile(
+    r"^(\S+)\s+kind:function\((arm|thumb),size=0x([0-9a-fA-F]+)\)\s+addr:0x([0-9a-fA-F]+)")
+
+
+def symbol_info():
+    info = {}
+    for sp in sorted(CONFIG.rglob("symbols.txt")):
+        rel = sp.parent.relative_to(CONFIG).as_posix()
+        label = "arm9" if rel == "arm9" else rel.split("/")[-1]
+        for line in sp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = CFG_RE.match(line)
+            if m:
+                info.setdefault(m.group(1),
+                                (label, int(m.group(4), 16), int(m.group(3), 16)))
+    return info
+
+
+def rewrite(text, emits, symbol):
+    """Rename the emitted function, keeping the recovered name visible."""
+    new = re.sub(r"\b" + re.escape(emits) + r"\b", symbol, text)
+    # The @emits line now says the same thing as @symbol, which is noise. Replace it
+    # with an explicit note so the recovered identity is not lost.
+    new = EMITS_RE.sub(f"// recovered name: {emits}", new, count=1)
+    if emits not in new:
+        new = new.replace(f"// @symbol {symbol}",
+                          f"// @symbol {symbol}\n// recovered name: {emits}", 1)
+    return new
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    args = ap.parse_args()
+
+    info = symbol_info()
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+
+    jobs = []
+    skipped = collections.Counter()
+    for f in sorted(SRC.iterdir()):
+        if f.suffix not in (".c", ".cpp"):
+            continue
+        head = f.read_text(encoding="utf-8", errors="ignore")[:400]
+        ms, me = SYMBOL_RE.search(head), EMITS_RE.search(head)
+        if not ms or not me:
+            continue
+        symbol, emits = ms.group(1), me.group(1)
+        if symbol == emits:
+            skipped["already agree"] += 1
+            continue
+        if f.stem != symbol:
+            skipped["filename != @symbol"] += 1
+            continue
+        if symbol not in info:
+            skipped["@symbol not in config"] += 1
+            continue
+        text = f.read_text(encoding="utf-8", errors="ignore")
+        if not re.search(r"\b" + re.escape(emits) + r"\b", text):
+            skipped["@emits name absent from file"] += 1
+            continue
+        if re.search(r"\b" + re.escape(symbol) + r"\b", text.replace(f"@symbol {symbol}", "")):
+            skipped["@symbol already used in file"] += 1
+            continue
+        jobs.append((f, symbol, emits))
+
+    print(f"candidates: {len(jobs)}")
+    for k, v in skipped.most_common():
+        print(f"  skipped {v:5d}  {k}")
+
+    def work(job):
+        f, symbol, emits = job
+        label, addr, size = info[symbol]
+        original = f.read_text(encoding="utf-8", errors="ignore")
+        new = rewrite(original, emits, symbol)
+        f.write_text(new, encoding="utf-8", newline="\n")
+        flags = M.DEFAULT_FLAGS
+        if new.startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+        tgt = (M.target_bytes(addr, size) if label == "arm9"
+               else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"])
+               if label in mods else None)
+        verdict = "no module binary"
+        if tgt is not None:
+            # Build default first, so the reported version tells you whether the file
+            # needs a config/rombuild-versions.txt override, not just sweep order.
+            for v in [BUILD_VERSION] + [x for x in M.SWEEP if x != BUILD_VERSION]:
+                obj = M.compile_c(f, v, flags)
+                if obj is None:
+                    continue
+                code, relocs = M.extract_func(obj, symbol)
+                if code is None:
+                    continue
+                ok, _ = M.compare(tgt, code, relocs, verbose=False)
+                if ok:
+                    verdict = v
+                    break
+            else:
+                verdict = "no version matches"
+        if verdict.startswith("no ") or not args.apply:
+            f.write_text(original, encoding="utf-8", newline="\n")
+        return f.name, symbol, emits, verdict
+
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for r in ex.map(work, jobs):
+            results.append(r)
+
+    by_verdict = collections.Counter(r[3] for r in results)
+    print()
+    for k, v in by_verdict.most_common():
+        print(f"{v:6d}  {k}")
+    bad = [r for r in results if r[3].startswith("no ")]
+    if bad:
+        print(f"\n{len(bad)} did not verify and were left untouched:")
+        for (n, s, e, v) in bad[:10]:
+            print(f"  {n}: {e} -> {s} ({v})")
+    print("\n(dry run — pass --apply to keep the edits)" if not args.apply
+          else f"\napplied to {len(results) - len(bad)} file(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -181,7 +181,11 @@ def winning_object(name, addr, size, mod, candidate=None, include_dirs=()):
                 fd, tmp = tempfile.mkstemp(suffix=suf)
                 os.close(fd)
                 cfile = pathlib.Path(tmp)
-                cfile.write_text(src)
+                # encoding is not optional here: 42 files in src/ contain non-ASCII
+                # (arrows and box characters in codegen comments), and on Windows the
+                # default is cp1252, which raises UnicodeEncodeError and degrades the
+                # file's verdict to ERROR - which prepush_linkcheck treats as blocking.
+                cfile.write_text(src, encoding="utf-8")
             else:
                 cfile = source_path
             try:

--- a/tools/resolve_blind.py
+++ b/tools/resolve_blind.py
@@ -1,0 +1,243 @@
+"""Resolve invented symbol names to the address the ROM actually uses.
+
+[`link-verification.md`](../notes/link-verification.md) calls these the BLIND matches: a
+`src/` file references a name that carries no address — an invented placeholder like `G0`
+or `VT1`, or a plausible-looking name that is simply not in `config/**/symbols.txt`. No
+static check can verify where such a relocation points, and the ROM build cannot link the
+file at all, because the name resolves to nothing.
+
+But the destination is not actually unknown. The function byte-matches the ROM, so the
+ROM's own linked word at that relocation slot *is* the answer: decode it (a `BL` target,
+or an `R_ARM_ABS32` pool word minus its addend) and look the address up in `symbols.txt`.
+
+This does that per file and per relocation, so it handles both shapes uniformly: a head
+symbol shared by hundreds of files, and a per-file placeholder like `G0` that means a
+different address in every file.
+
+    unresolved   ->   the address the ROM links to   ->   the canonical symbol there
+
+Where a canonical symbol exists, the reference is renamed in `src/`. Where the address has
+no symbol at all, nothing is renamed and the address is reported — those need a name added
+to `symbols.txt`, which is a config decision rather than a source fix.
+
+Every edit is byte-verified against the ROM before it is kept.
+
+Usage:
+    python tools/resolve_blind.py                  # report only
+    python tools/resolve_blind.py --apply
+    python tools/resolve_blind.py --name G0        # just one unresolved symbol
+"""
+import argparse
+import bisect
+import collections
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import match as M              # noqa: E402
+import modules as MOD          # noqa: E402
+import reloc_audit as RA       # noqa: E402
+import linkcheck as LC         # noqa: E402
+from enroll import candidates, CONFIG, REPO  # noqa: E402
+from rombuild import CFLAGS, VERSION, versions  # noqa: E402
+
+SYM = re.compile(r"^(\S+)\s+kind:(\S+?)(?:\(([^)]*)\))?\s+addr:0x([0-9a-fA-F]+)")
+
+
+def symbol_tables():
+    """(exact address -> name, sorted spans) per module label, plus every known name."""
+    exact, spans, names = {}, [], set()
+    for sp in sorted(CONFIG.rglob("symbols.txt")):
+        rel = sp.parent.relative_to(CONFIG).as_posix()
+        label = "arm9" if rel == "arm9" else rel.split("/")[-1]
+        for line in sp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = SYM.match(line)
+            if not m:
+                continue
+            addr, name = int(m.group(4), 16), m.group(1)
+            names.add(name)
+            exact.setdefault((label, addr), name)
+            exact.setdefault((None, addr), name)
+            size = 0
+            if m.group(3):
+                sm = re.search(r"size=0x([0-9a-fA-F]+)", m.group(3))
+                if sm:
+                    size = int(sm.group(1), 16)
+            spans.append((addr, addr + max(size, 1), name, label))
+    spans.sort()
+    return exact, spans, names
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--name", help="only resolve this unresolved symbol")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    ap.add_argument("--show", type=int, default=20)
+    args = ap.parse_args()
+
+    exact, spans, known = symbol_tables()
+    starts = [s[0] for s in spans]
+    name_index = RA.build_name_index()
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+    vers = versions()
+    cands, _ = candidates()
+
+    def label_of(d):
+        rel = d.relative_to(CONFIG).as_posix()
+        return "arm9" if rel == "arm9" else rel.split("/")[-1]
+
+    def resolve_addr(addr, label):
+        n = exact.get((label, addr)) or exact.get((None, addr))
+        if n:
+            return n, 0
+        i = bisect.bisect_right(starts, addr) - 1
+        while i >= 0 and starts[i] > addr - 0x10000:
+            lo, hi, nm, lb = spans[i]
+            if lo <= addr < hi:
+                return nm, addr - lo
+            i -= 1
+        return None, None
+
+    def work(c):
+        d, name, rel, addr, size, sec = c
+        label = label_of(d)
+        src = REPO / rel
+        flags = CFLAGS
+        if src.read_text(encoding="utf-8", errors="ignore").startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+        obj = M.compile_c(src, vers.get(name, VERSION), flags)
+        if obj is None:
+            return None
+        try:
+            relocs = LC.func_relocs_typed(obj, name, name_index)
+        except Exception:
+            return None
+        if not relocs:
+            return None
+        blind = [r for r in relocs if r["addr"] is None and r["sym"] not in known]
+        if not blind:
+            return None
+        if label == "arm9":
+            code = M.target_bytes(addr, size)
+        elif label in mods:
+            code = M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"])
+        else:
+            return None
+        found = []
+        for r in blind:
+            if args.name and r["sym"] != args.name:
+                continue
+            o = r["off"]
+            if o + 4 > len(code):
+                continue
+            word = int.from_bytes(code[o:o + 4], "little")
+            if r["type"] in LC.BRANCH_TYPES:
+                off = word & 0xFFFFFF
+                if off & 0x800000:
+                    off -= 0x1000000
+                dest = (addr + o + 8 + off * 4) & 0xFFFFFFFF
+            elif r["type"] == LC.R_ARM_ABS32:
+                dest = (word - r.get("add", 0)) & 0xFFFFFFFF
+            else:
+                continue
+            canon, delta = resolve_addr(dest, label)
+            found.append((r["sym"], dest, canon, delta))
+        return (rel, name, label, found) if found else None
+
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for r in ex.map(work, cands):
+            if r:
+                results.append(r)
+
+    stats = collections.Counter()
+    mapping = collections.defaultdict(collections.Counter)
+    no_symbol = collections.Counter()
+    renamable = []
+    for (rel, name, label, found) in results:
+        subs = {}
+        for (sym, dest, canon, delta) in found:
+            if canon is None:
+                stats["address has no symbol"] += 1
+                no_symbol[f"0x{dest:08x} [{label}]"] += 1
+            elif delta == 0:
+                stats["resolves to a canonical symbol"] += 1
+                mapping[sym][canon] += 1
+                subs[sym] = canon
+            else:
+                stats["resolves inside a symbol (base+offset)"] += 1
+                mapping[sym][f"{canon}+0x{delta:x}"] += 1
+        if subs:
+            renamable.append((rel, name, label, subs))
+
+    print(f"files with an unresolvable reference: {len(results)}")
+    for k, v in stats.most_common():
+        print(f"  {v:6d}  {k}")
+    print(f"\nfiles where every unresolved name maps to a canonical symbol: {len(renamable)}")
+    print(f"\ntop unresolved names and what the ROM says they are:")
+    for sym, targets in sorted(mapping.items(), key=lambda kv: -sum(kv[1].values()))[:args.show]:
+        tot = sum(targets.values())
+        if len(targets) == 1:
+            print(f"  {tot:5d}x  {sym}  ->  {next(iter(targets))}")
+        else:
+            print(f"  {tot:5d}x  {sym}  ->  {len(targets)} different targets "
+                  f"(per-file placeholder): {', '.join(list(targets)[:3])}…")
+    if no_symbol:
+        print(f"\naddresses with no symbol at all ({sum(no_symbol.values())} refs, "
+              f"{len(no_symbol)} addresses) - these need a symbols.txt entry:")
+        for k, v in no_symbol.most_common(10):
+            print(f"  {v:5d}x  {k}")
+
+    if not args.apply:
+        print("\n(report only - pass --apply to rename and verify)")
+        return
+
+    def apply_one(job):
+        rel, name, label, subs = job
+        f = REPO / rel
+        original = f.read_text(encoding="utf-8", errors="ignore")
+        new = original
+        for old, canon in subs.items():
+            new = re.sub(r"\b" + re.escape(old) + r"\b", canon, new)
+        if new == original:
+            return rel, "unchanged"
+        f.write_text(new, encoding="utf-8", newline="\n")
+        flags = CFLAGS
+        if new.startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+        info = next(((a, s) for (d, n, r, a, s, _sec) in cands if r == rel), None)
+        ok = False
+        if info:
+            addr, size = info
+            tgt = (M.target_bytes(addr, size) if label == "arm9"
+                   else M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"]))
+            for v in [vers.get(name, VERSION)] + [x for x in M.SWEEP]:
+                o = M.compile_c(f, v, flags)
+                if o is None:
+                    continue
+                code, rl = M.extract_func(o, name)
+                if code is None:
+                    continue
+                ok, _ = M.compare(tgt, code, rl, verbose=False)
+                if ok:
+                    break
+        if not ok:
+            f.write_text(original, encoding="utf-8", newline="\n")
+            return rel, "reverted (stopped matching)"
+        return rel, "renamed"
+
+    outcome = collections.Counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for rel, o in ex.map(apply_one, renamable):
+            outcome[o] += 1
+    print()
+    for k, v in outcome.most_common():
+        print(f"{v:6d}  {k}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -1,0 +1,221 @@
+"""Build a playable .nds from source.
+
+Runs the whole ds-decomp link pipeline: every `src/` file enrolled in a
+`config/**/delinks.txt` file entry is compiled with mwccarm and linked by mwldarm
+into the module it belongs to; every address range NOT enrolled is supplied by a
+delinked gap object carrying the original ROM bytes. The result is packaged back
+into a bootable ROM.
+
+    dsd delink   -> build/delinks/*.o      (gap objects, ROM bytes)
+    mwccarm      -> build/src/*.o          (our C, one function per file)
+    dsd lcf      -> build/arm9.lcf + build/objects.txt
+    mwldarm      -> build/final_link.o     + build/build/*.bin per region
+    dsd rom config / rom build             -> build/sm64ds.nds
+    dsd check modules                      -> byte-diff every module vs the ROM
+
+A module is "green" when its linked bytes equal the retail module, so a green build
+with N functions enrolled is proof those N functions' source is the real thing.
+
+Usage:
+    python tools/rombuild.py                 # full build + verify
+    python tools/rombuild.py --no-rom        # link and verify, skip .nds packaging
+    python tools/rombuild.py --no-check      # skip the module byte-diff
+    python tools/rombuild.py -j 16           # parallel compiles
+
+See notes/rom-build.md for the milestones and the enrollment rules.
+"""
+import argparse
+import concurrent.futures
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+DSD = REPO / "tools" / "bin" / "dsd.exe"
+MW = REPO / "tools" / "mwccarm"
+LICENSE = MW / "license.dat"
+INCLUDE = REPO / "include"
+CONFIG = REPO / "config" / "arm9" / "config.yaml"
+BUILD = REPO / "build"
+
+# Default compiler for the ROM build. The repo pins 1.2/sp2p3 as the canonical
+# matching compiler, but the recovered 2004 build 0056 (notes/mwccarm-codegen.md 6ai)
+# reproduces strictly more of this corpus, so the build defaults to it and
+# config/rombuild-versions.txt carries the per-file exceptions.
+VERSION = "2004/b56"
+# 2004/b56 ships only mwccarm.exe - there is no mwldarm in it - so the link always
+# uses the 1.2/sp2p3 linker regardless of which compiler produced the objects.
+LD_VERSION = "1.2/sp2p3"
+# tools/match.py's DEFAULT_FLAGS, plus one addition the match gate never needed.
+# `-Cpp_exceptions off` suppresses the .exception/.exceptix unwind tables mwccarm
+# otherwise emits alongside almost every function. The match gate only ever compared
+# .text, so it never saw them; a ROM link does, and those sections would be duplicate
+# content that grows the module and shifts every later address. Retail carries just
+# 636 bytes of .exceptix in main, so the original build had them off too. Verified
+# not to perturb .text codegen (see notes/rom-build.md, M2b).
+CFLAGS = ("-O4,p -enum int -lang c99 -char signed -interworking "
+          "-proc arm946e -gccext,on -msgstyle gcc -Cpp_exceptions off")
+LDFLAGS = ("-proc arm946e -nostdlib -interworking -m Entry "
+           "-map closure,unused -msgstyle gcc -nodead")
+
+
+VERSIONS_FILE = REPO / "config" / "rombuild-versions.txt"
+
+
+def versions():
+    """symbol -> mwccarm version, for functions not matched under the default.
+
+    A function counts as matched if *some* toolchain version reproduces it, and
+    match.py sweeps a list - so a single-version link produces wrong bytes for the
+    ones matched elsewhere, even though the source is right. See the file's comments.
+    """
+    out = {}
+    if VERSIONS_FILE.is_file():
+        for line in VERSIONS_FILE.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                parts = line.split()
+                if len(parts) == 2:
+                    out[parts[0]] = parts[1]
+    return out
+
+
+def launcher():
+    """Wine prefix on the Linux build box; empty on native Windows (see match.py)."""
+    return os.environ.get("MWCCARM_LAUNCHER", "").split()
+
+
+def run(cmd, what, quiet_patterns=()):
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
+    out = "\n".join(l for l in (r.stdout + r.stderr).splitlines()
+                    if not any(p in l for p in quiet_patterns))
+    if r.returncode != 0:
+        print(f"!! {what} failed (exit {r.returncode})")
+        print(out[:4000])
+        sys.exit(1)
+    return out
+
+
+def enrolled():
+    """Every `src/` file carved out by a `complete` file entry in a delinks.txt.
+
+    A file entry is an unindented path ending in ':'; the indented lines that follow
+    hold `complete` and its section ranges. Without `complete`, dsd supplies the range
+    from ROM bytes instead, so the file is configured but not yet source-built.
+    """
+    files, path, saw_complete = [], None, False
+    for delinks in sorted((REPO / "config").rglob("delinks.txt")):
+        for line in delinks.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            if not line[0].isspace():
+                if path and saw_complete:
+                    files.append(path)
+                path = line.strip().rstrip(":") if line.rstrip().endswith(":") else None
+                saw_complete = False
+            elif line.strip() == "complete":
+                saw_complete = True
+        if path and saw_complete:
+            files.append(path)
+        path, saw_complete = None, False
+    return sorted(set(files))
+
+
+def compile_one(rel, vers=None):
+    """Compile one enrolled source file to the object path dsd's objects.txt names."""
+    src = REPO / rel
+    obj = BUILD / pathlib.Path(rel).with_suffix(".o")
+    obj.parent.mkdir(parents=True, exist_ok=True)
+    version = (vers or {}).get(pathlib.Path(rel).stem, VERSION)
+    flags = CFLAGS
+    # A leading //cpp marker means C++, matched to how match.py/fdiff compile it.
+    try:
+        if src.read_text(encoding="utf-8").startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+    except OSError:
+        pass
+    cmd = [*launcher(), str(MW / version / "mwccarm.exe"), *flags.split(),
+           "-i", str(INCLUDE), "-c", str(src), "-o", str(obj)]
+    r = subprocess.run(cmd, capture_output=True, text=True,
+                       env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
+    if r.returncode != 0 or not obj.is_file():
+        detail = "\n".join(s for s in (r.stdout.strip(), r.stderr.strip()) if s)
+        return rel, detail[:400]
+    return rel, None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 8)
+    ap.add_argument("--rom-out", default=str(BUILD / "sm64ds.nds"))
+    ap.add_argument("--no-rom", action="store_true", help="stop after linking")
+    ap.add_argument("--no-check", action="store_true", help="skip dsd check modules")
+    ap.add_argument("--arm7-bios", help="passed to dsd rom build if your dump needs it")
+    args = ap.parse_args()
+
+    for tool in (DSD, MW / VERSION / "mwccarm.exe", MW / LD_VERSION / "mwldarm.exe"):
+        if not tool.is_file():
+            sys.exit(f"missing {tool} - see notes/setup-mwccarm.md")
+    if not (REPO / "extracted" / "dsd" / "config.yaml").is_file():
+        sys.exit("no extracted ROM - run tools/unpack.py on your own dump first")
+
+    # Gap objects first: delinks.txt drives which ranges dsd carves out for us.
+    print("[1/6] dsd delink")
+    run([str(DSD), "delink", "-c", str(CONFIG)], "dsd delink",
+        quiet_patterns=("No module for relocation",))
+
+    print("[2/6] dsd lcf")
+    run([str(DSD), "lcf", "-c", str(CONFIG)], "dsd lcf")
+
+    srcs = enrolled()
+    vers = versions()
+    n_alt = sum(1 for s in srcs if pathlib.Path(s).stem in vers)
+    print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
+          + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
+    failures = []
+    if srcs:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+            for rel, err in ex.map(lambda s: compile_one(s, vers), srcs):
+                if err:
+                    failures.append((rel, err))
+    if failures:
+        print(f"!! {len(failures)} file(s) failed to compile:")
+        for rel, err in failures[:10]:
+            print(f"   {rel}: {err.splitlines()[0] if err else ''}")
+        sys.exit(1)
+
+    print("[4/6] mwldarm")
+    run([*launcher(), str(MW / LD_VERSION / "mwldarm.exe"), *LDFLAGS.split(),
+         f"@{BUILD / 'objects.txt'}", str(BUILD / "arm9.lcf"),
+         "-o", str(BUILD / "final_link.o")], "mwldarm")
+
+    if args.no_rom:
+        print("[5/6] skipped (--no-rom)")
+    else:
+        print("[5/6] dsd rom config + rom build")
+        run([str(DSD), "rom", "config", "--elf", str(BUILD / "final_link.o"),
+             "--config", str(CONFIG)], "dsd rom config")
+        cmd = [str(DSD), "rom", "build", "--config", str(BUILD / "build" / "rom_config.yaml"),
+               "--rom", args.rom_out]
+        if args.arm7_bios:
+            cmd += ["--arm7-bios", args.arm7_bios]
+        run(cmd, "dsd rom build", quiet_patterns=("Compressing arm9 overlay",))
+        print(f"      -> {args.rom_out}")
+
+    if args.no_check:
+        print("[6/6] skipped (--no-check)")
+        return
+    print("[6/6] dsd check modules")
+    out = run([str(DSD), "check", "modules", "-c", str(CONFIG), "--fail"],
+              "dsd check modules", quiet_patterns=(": OK",))
+    if out.strip():
+        print(out)
+    print(f"\nAll modules match the ROM. {len(srcs)} function(s) built from src/.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -1,0 +1,142 @@
+"""Byte-diff every source-built function against the ROM, one function at a time.
+
+`dsd check modules` answers "is this module identical?"; when the answer is no it does
+not say which function broke it. This does. Because an enrolled function's object is
+required to be exactly its declared size, nothing can shift its neighbours, so every
+mismatch is confined to the function that caused it and all of them can be found from a
+single build instead of bisecting.
+
+Usage:
+    python tools/rombuild_check.py                 # summary + the failing names
+    python tools/rombuild_check.py --out bad.txt   # write failures for enroll.py
+
+Feed the failures back with:
+    python tools/enroll.py --complete-list <eligible minus bad>
+"""
+import argparse
+import collections
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from enroll import read_delinks, sections, CONFIG, REPO  # noqa: E402
+
+BUILD = REPO / "build" / "build"
+EXTRACTED = REPO / "extracted" / "dsd"
+ENTRY_SEC = re.compile(r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)")
+
+
+def module_binaries(d):
+    """(built, retail) binary paths for a module config directory, or (None, None)."""
+    rel = d.relative_to(CONFIG).as_posix()
+    if rel == "arm9":
+        return BUILD / "arm9.bin", EXTRACTED / "arm9" / "arm9.bin"
+    if rel in ("arm9/itcm", "arm9/dtcm"):
+        n = rel.split("/")[-1]
+        return BUILD / f"{n}.bin", EXTRACTED / "arm9" / f"{n}.bin"
+    m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
+    if m:
+        return BUILD / f"arm9_{m.group(1)}.bin", EXTRACTED / "arm9_overlays" / f"{m.group(1)}.bin"
+    return None, None
+
+
+def complete_entries(path):
+    """[(srcpath, addr, end)] for entries marked `complete`."""
+    out, cur, done, sec = [], None, False, None
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not line.strip():
+            continue
+        if not line[0].isspace():
+            if cur and done and sec:
+                out.append((cur, *sec))
+            cur, done, sec = line.strip().rstrip(":"), False, None
+        elif cur is not None:
+            if line.strip() == "complete":
+                done = True
+            else:
+                m = ENTRY_SEC.match(line)
+                if m:
+                    sec = (int(m.group(2), 16), int(m.group(3), 16))
+    if cur and done and sec:
+        out.append((cur, *sec))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", help="write failing symbol names here")
+    ap.add_argument("--show", type=int, default=12)
+    args = ap.parse_args()
+
+    checked = bad = 0
+    intentional = []
+    failures, per_module = [], collections.Counter()
+    missing_bins = []
+
+    for sym in sorted(CONFIG.rglob("symbols.txt")):
+        d = sym.parent
+        dl = d / "delinks.txt"
+        if not dl.is_file():
+            continue
+        entries = complete_entries(dl)
+        if not entries:
+            continue
+        built_p, retail_p = module_binaries(d)
+        if not built_p or not built_p.is_file() or not retail_p.is_file():
+            missing_bins.append(d.relative_to(CONFIG).as_posix())
+            continue
+        header, _ = read_delinks(dl)
+        secs = sections(header)
+        if not secs:
+            continue
+        base = min(s[1] for s in secs)
+        built, retail = built_p.read_bytes(), retail_p.read_bytes()
+        label = d.relative_to(CONFIG).as_posix()
+        for (rel, addr, end) in entries:
+            lo, hi = addr - base, end - base
+            if hi > len(retail) or hi > len(built):
+                continue
+            # A mods/ entry is a deliberate divergence; differing from the ROM is the
+            # whole point, so it is reported separately and never counted as a failure.
+            if rel.startswith("mods/"):
+                if built[lo:hi] != retail[lo:hi]:
+                    intentional.append((pathlib.Path(rel).stem, label, addr,
+                                        sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)))
+                else:
+                    intentional.append((pathlib.Path(rel).stem, label, addr, 0))
+                continue
+            checked += 1
+            if built[lo:hi] != retail[lo:hi]:
+                bad += 1
+                name = pathlib.Path(rel).stem
+                nd = sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)
+                failures.append((label, name, addr, hi - lo, nd))
+                per_module[label] += 1
+
+    if intentional:
+        print(f"intentional divergences (mods/): {len(intentional)}")
+        for (n, label, addr, nd) in intentional:
+            state = f"{nd} byte(s) differ from the ROM" if nd else "!! identical to the ROM - the mod is NOT in the build"
+            print(f"  {n} ({label}, 0x{addr:08x}): {state}")
+        print()
+    print(f"source-built functions checked: {checked}")
+    print(f"                    reproducing: {checked - bad}")
+    print(f"                    mismatching: {bad}")
+    if missing_bins:
+        print(f"(no built binary for {len(missing_bins)} module(s): {missing_bins[:4]})")
+    if per_module:
+        print("\nmismatches by module:")
+        for k, v in per_module.most_common(12):
+            print(f"  {v:5d}  {k}")
+        print(f"\nfirst {min(args.show, len(failures))} mismatches:")
+        for (label, name, addr, size, nd) in failures[:args.show]:
+            print(f"  {label:26s} {name:44s} 0x{addr:08x} size 0x{size:<5x} {nd} bad bytes")
+    if args.out:
+        pathlib.Path(args.out).write_text("\n".join(sorted(n for _, n, _, _, _ in failures)) + "\n")
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rombuild_diag.py
+++ b/tools/rombuild_diag.py
@@ -1,0 +1,200 @@
+"""Explain why a source-built function does not reproduce the ROM.
+
+`rombuild_check.py` names the functions that differ; this says what is different about
+them. For every differing word it decodes both sides and, where the word is a branch or
+a pointer, resolves the address each side names back to a symbol. That turns a byte diff
+into a sentence: "the source calls X, the ROM calls Y".
+
+This is the wrong-relocation-destination class - the one the match gate cannot see,
+because `match.py` wildcards every word the candidate relocates, so a call to the wrong
+function with the right shape still reads as a match.
+
+Usage:
+    python tools/rombuild_diag.py                    # diagnose every mismatch
+    python tools/rombuild_diag.py --name func_...    # just one
+    python tools/rombuild_diag.py --summary          # counts by shape only
+"""
+import argparse
+import collections
+import pathlib
+import re
+import sys
+
+from capstone import Cs, CS_ARCH_ARM, CS_MODE_ARM
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from enroll import read_delinks, sections, CONFIG, REPO  # noqa: E402
+from rombuild_check import complete_entries, module_binaries  # noqa: E402
+
+SYM = re.compile(r"^(\S+)\s+kind:(\S+?)(?:\(([^)]*)\))?\s+addr:0x([0-9a-fA-F]+)")
+md = Cs(CS_ARCH_ARM, CS_MODE_ARM)
+
+
+SPANS = []   # sorted [(start, end, name, module)] - filled by symbol_index()
+
+
+def symbol_index():
+    """address -> [(name, module)], plus a sorted span table for base+addend lookups."""
+    idx = collections.defaultdict(list)
+    spans = []
+    for sp in sorted(CONFIG.rglob("symbols.txt")):
+        label = sp.parent.relative_to(CONFIG).as_posix()
+        for line in sp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = SYM.match(line)
+            if not m:
+                continue
+            addr = int(m.group(4), 16)
+            idx[addr].append((m.group(1), label))
+            size = 0
+            if m.group(3):
+                sm = re.search(r"size=0x([0-9a-fA-F]+)", m.group(3))
+                if sm:
+                    size = int(sm.group(1), 16)
+            spans.append((addr, addr + max(size, 1), m.group(1), label))
+    spans.sort()
+    SPANS[:] = spans
+    return idx
+
+
+def name_at(idx, addr, prefer, allow_offset=True):
+    """Resolve an address to a symbol, or to `symbol+0xN` for a base+addend pointer.
+
+    mwccarm emits every struct-field / array-element access as the symbol's base
+    address plus a nonzero addend, so an exact-address lookup misses most data
+    pointers. Falling back to the containing symbol is what makes a wrong *base*
+    distinguishable from a wrong *offset*.
+    """
+    hits = idx.get(addr)
+    if hits:
+        for (n, mod) in hits:
+            if mod == prefer:
+                return n
+        return hits[0][0] + (f" [{hits[0][1]}]" if len(hits) == 1 else " [ambiguous]")
+    if not allow_offset or not (0x01FF0000 <= addr < 0x02400000):
+        return None
+    import bisect
+    i = bisect.bisect_right(SPANS, (addr, float("inf"), "", "")) - 1
+    # walk back over shorter spans that start at the same place
+    while i >= 0:
+        start, end, n, mod = SPANS[i]
+        if start <= addr < end:
+            return f"{n}+0x{addr - start:x}" + ("" if mod == prefer else f" [{mod}]")
+        if start < addr - 0x4000:
+            break
+        i -= 1
+    return None
+
+
+def branch_target(word, pc):
+    """Decode an ARM B/BL/BLX at `pc`; return (mnemonic, target) or None."""
+    cond = (word >> 28) & 0xF
+    op = (word >> 24) & 0xF
+    if cond != 0xF and op in (0xA, 0xB):
+        off = word & 0xFFFFFF
+        if off & 0x800000:
+            off -= 0x1000000
+        return ("bl" if op == 0xB else "b"), (pc + 8 + off * 4) & 0xFFFFFFFF
+    if cond == 0xF and (word >> 25) & 0x7 == 0x5:      # BLX (immediate)
+        off = word & 0xFFFFFF
+        if off & 0x800000:
+            off -= 0x1000000
+        h = (word >> 24) & 1
+        return "blx", (pc + 8 + off * 4 + h * 2) & 0xFFFFFFFF
+    return None
+
+
+def dis(word, pc):
+    b = word.to_bytes(4, "little")
+    for i in md.disasm(b, pc):
+        return f"{i.mnemonic} {i.op_str}".strip()
+    return f".word 0x{word:08x}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--name")
+    ap.add_argument("--summary", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    idx = symbol_index()
+    shapes = collections.Counter()
+    repoint = collections.Counter()
+    shown = 0
+
+    for sp in sorted(CONFIG.rglob("symbols.txt")):
+        d = sp.parent
+        dl = d / "delinks.txt"
+        if not dl.is_file():
+            continue
+        entries = complete_entries(dl)
+        if not entries:
+            continue
+        built_p, retail_p = module_binaries(d)
+        if not built_p or not built_p.is_file() or not retail_p.is_file():
+            continue
+        header, _ = read_delinks(dl)
+        secs = sections(header)
+        if not secs:
+            continue
+        base = min(s[1] for s in secs)
+        built, retail = built_p.read_bytes(), retail_p.read_bytes()
+        label = d.relative_to(CONFIG).as_posix()
+
+        for (rel, addr, end) in entries:
+            name = pathlib.Path(rel).stem
+            if args.name and name != args.name:
+                continue
+            lo, hi = addr - base, end - base
+            if hi > len(retail) or hi > len(built) or built[lo:hi] == retail[lo:hi]:
+                continue
+            lines = []
+            for off in range(0, hi - lo, 4):
+                bw = int.from_bytes(built[lo + off:lo + off + 4], "little")
+                rw = int.from_bytes(retail[lo + off:lo + off + 4], "little")
+                if bw == rw:
+                    continue
+                pc = addr + off
+                bt, rt = branch_target(bw, pc), branch_target(rw, pc)
+                if bt and rt:
+                    bn = name_at(idx, bt[1], label) or f"0x{bt[1]:08x}"
+                    rn = name_at(idx, rt[1], label) or f"0x{rt[1]:08x}"
+                    if bt[0] != rt[0]:
+                        shapes[f"{bt[0]} vs {rt[0]} (interworking)"] += 1
+                        lines.append(f"    +0x{off:03x}  {bt[0]} {bn}   ROM: {rt[0]} {rn}")
+                    else:
+                        shapes["branch to a different symbol"] += 1
+                        repoint[f"{bn} -> {rn}"] += 1
+                        lines.append(f"    +0x{off:03x}  calls {bn}   ROM calls {rn}")
+                elif name_at(idx, bw, label) or name_at(idx, rw, label):
+                    bn = name_at(idx, bw, label) or f"0x{bw:08x}"
+                    rn = name_at(idx, rw, label) or f"0x{rw:08x}"
+                    shapes["pointer word to a different symbol"] += 1
+                    repoint[f"{bn} -> {rn}"] += 1
+                    lines.append(f"    +0x{off:03x}  .word {bn}   ROM: {rn}")
+                else:
+                    shapes["plain instruction/data difference"] += 1
+                    lines.append(f"    +0x{off:03x}  {dis(bw, pc)}   ROM: {dis(rw, pc)}")
+            if not args.summary:
+                print(f"{name}  ({label}, 0x{addr:08x}, {len(lines)} differing word(s))")
+                for l in lines[:8]:
+                    print(l)
+                if len(lines) > 8:
+                    print(f"    ... {len(lines) - 8} more")
+                print()
+            shown += 1
+            if args.limit and shown >= args.limit:
+                break
+
+    print("=== differing words by shape ===")
+    for k, v in shapes.most_common():
+        print(f"{v:6d}  {k}")
+    if repoint:
+        print("\n=== most common repoints (source -> what the ROM actually uses) ===")
+        for k, v in repoint.most_common(15):
+            print(f"{v:6d}  {k}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rombuild_versions.py
+++ b/tools/rombuild_versions.py
@@ -1,0 +1,136 @@
+"""Find which mwccarm version reproduces each function the ROM build got wrong.
+
+A function counts as matched in this repo if *some* toolchain version reproduces it -
+`tools/match.py` sweeps a list. A ROM link, though, compiles everything with one
+compiler, so a function matched under a different version links to the wrong bytes even
+though its source is perfectly correct.
+
+This takes the names `tools/rombuild_check.py` reported as mismatching, sweeps them
+through the versions `match.py` knows about, and writes the ones that match under a
+non-default version to config/rombuild-versions.txt. `rombuild.py` and `eligible.py`
+then compile those files with the named version.
+
+Anything that matches under no version is a genuine problem with the source (or with
+its relocation destinations) and is left out of the override file.
+
+Usage:
+    python tools/rombuild_check.py --out build/bad.txt
+    python tools/rombuild_versions.py build/bad.txt          # report
+    python tools/rombuild_versions.py build/bad.txt --write   # update the config
+"""
+import argparse
+import collections
+import concurrent.futures
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import match as M           # noqa: E402
+import modules as MOD       # noqa: E402
+from rombuild import CFLAGS, REPO, VERSION, VERSIONS_FILE, versions  # noqa: E402
+
+SYM = re.compile(
+    r"^(\S+)\s+kind:function\((arm|thumb),size=0x([0-9a-fA-F]+)\)\s+addr:0x([0-9a-fA-F]+)")
+
+HEADER = """\
+# Per-file mwccarm version overrides for the ROM build, as: <symbol> <version>.
+# tools/rombuild.py and tools/eligible.py compile these with the named version instead
+# of the default (see rombuild.VERSION).
+#
+# A function counts as matched if SOME toolchain version reproduces it, and match.py
+# sweeps a list - so a single-version link produces the wrong bytes for the ones
+# matched elsewhere, even though the source is correct.
+#
+# Regenerate with:
+#   python tools/rombuild_check.py --out build/bad.txt
+#   python tools/rombuild_versions.py build/bad.txt --write
+"""
+
+
+def symbol_info():
+    info = {}
+    for sp in sorted((REPO / "config").rglob("symbols.txt")):
+        rel = sp.parent.relative_to(REPO / "config").as_posix()
+        label = "arm9" if rel == "arm9" else rel.split("/")[-1]
+        for line in sp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = SYM.match(line)
+            if m:
+                info.setdefault(m.group(1),
+                                (label, int(m.group(4), 16), int(m.group(3), 16)))
+    return info
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("names", help="file of symbol names (from rombuild_check --out)")
+    ap.add_argument("--write", action="store_true", help="update config/rombuild-versions.txt")
+    ap.add_argument("-j", "--jobs", type=int, default=10)
+    args = ap.parse_args()
+
+    info = symbol_info()
+    mods = {("arm9" if m["name"] == "main" else m["name"]): m for m in MOD.modules()}
+    names = [l.strip() for l in pathlib.Path(args.names).read_text().split() if l.strip()]
+    # Try the default first so a file that already works never gets an override.
+    order = [VERSION] + [v for v in M.SWEEP if v != VERSION]
+
+    def sweep(n):
+        if n not in info:
+            return n, None
+        label, addr, size = info[n]
+        src = next((REPO / "src" / (n + e) for e in (".c", ".cpp")
+                    if (REPO / "src" / (n + e)).is_file()), None)
+        if src is None:
+            return n, None
+        # The build's flags, not match.py's defaults: sweeping with different flags
+        # than the link compiles with can bless a version the build then breaks on.
+        flags = CFLAGS
+        if src.read_text(encoding="utf-8", errors="ignore").startswith("//cpp"):
+            flags = flags.replace("-lang c99", "-lang c++")
+        if label == "arm9":
+            tgt = M.target_bytes(addr, size)
+        elif label in mods:
+            tgt = M.target_bytes(addr, size, mods[label]["bin"], mods[label]["base"])
+        else:
+            return n, None
+        for v in order:
+            obj = M.compile_c(src, v, flags)
+            if obj is None:
+                continue
+            code, relocs = M.extract_func(obj, n)
+            if code is None:
+                continue
+            ok, _ = M.compare(tgt, code, relocs, verbose=False)
+            if ok:
+                return n, v
+        return n, None
+
+    found, counts = {}, collections.Counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+        for n, v in ex.map(sweep, names):
+            counts[v or "no version reproduces it"] += 1
+            if v and v != VERSION:
+                found[n] = v
+
+    print(f"swept {len(names)} name(s); default is {VERSION}")
+    for k, v in counts.most_common():
+        print(f"  {v:5d}  {k}")
+
+    if args.write:
+        keep = dict(versions())
+        keep.update(found)
+        # Drop stale overrides that now build correctly under the default.
+        keep = {k: v for k, v in keep.items() if v != VERSION}
+        VERSIONS_FILE.write_text(
+            HEADER + "\n".join(f"{k} {v}" for k, v in sorted(keep.items())) + "\n",
+            encoding="utf-8", newline="\n")
+        print(f"\nwrote {VERSIONS_FILE.relative_to(REPO)} with {len(keep)} override(s)")
+    elif found:
+        print(f"\n{len(found)} would get an override (pass --write):")
+        for k, v in list(found.items())[:10]:
+            print(f"  {k} {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/split_prs.py
+++ b/tools/split_prs.py
@@ -1,0 +1,201 @@
+"""Split a large `src/` change into PR-sized branches the validate bot can chew.
+
+`validate` compiles every changed `src/*.c|*.cpp` on the build box and compares relocated
+bytes to the ROM. It is polled for at most ~20 minutes (`.github/workflows/pr-validate.yml`
+`120 * 10s`), so a batch has to finish inside that. Roughly 150-200 files is the working
+size.
+
+The split follows three rules, in priority order:
+
+  1. **One transformation per PR.** The rationale for a change is what a human reviews;
+     the per-file table validate posts is what checks it. Mixing a behavioural fix in with
+     a mechanical rename means the reviewer has to evaluate two arguments at once.
+  2. **Disjoint file sets.** Every file belongs to exactly one branch, each branched from
+     the base, so batches can be opened in any order and never conflict.
+  3. **Grouped by module, then chunked.** A red batch is then diagnosable and lines up
+     with how CLAIMS.md carves work. Small modules are packed together to avoid a long
+     tail of tiny PRs.
+
+Nothing is pushed. Branches are created locally; the `gh pr create` commands are printed
+for you to run.
+
+Usage:
+    python tools/split_prs.py                     # show the plan
+    python tools/split_prs.py --create            # create the local branches
+    python tools/split_prs.py --max-files 150
+"""
+import argparse
+import collections
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+CONFIG = REPO / "config"
+
+# Which commit introduced which kind of change, and how to describe it in a PR.
+TRANSFORMS = [
+    ("fixes", "Fix wrong relocation destinations",
+     """These change where a relocation points, not just what a name is spelled.
+Each was found by linking the function into the ROM and comparing the linked bytes:
+`tools/match.py` wildcards every relocated word, so a call to the wrong function with the
+right shape passes the byte gate. Each file still byte-matches after the fix."""),
+    ("names", "Make each file define the symbol its filename claims",
+     """Each file carried `// @symbol X` and `// @emits Y` with X != Y, so it defined a
+different symbol than its name. Nothing in the repo consumes either annotation, and
+`match.py --func <stem>` reports "symbol not found in object" — meaning the byte oracle
+could not verify these files at all, while `progress.py` counted them as matched because
+a `src/<name>.c` existed. The emitted function is renamed to the `@symbol` name and the
+recovered name kept as `// recovered name: Y`. Produced by `tools/reconcile_names.py`,
+byte-verified per file."""),
+    ("blind", "Resolve references to symbols that carry no address",
+     """Each file referenced a name `config/**/symbols.txt` does not define — the BLIND
+matches of `notes/link-verification.md`. The destination is recoverable: the function
+byte-matches, so the ROM's own linked word at the relocation slot is the answer. Decoded
+per file and per relocation, which matters because placeholders like `G0` mean a
+different address in almost every file. Produced by `tools/resolve_blind.py`,
+byte-verified per file."""),
+]
+
+SYMRE = re.compile(r"^(\S+)\s+kind:function")
+
+
+def module_of_stems():
+    out = {}
+    for sp in sorted(CONFIG.rglob("symbols.txt")):
+        rel = sp.parent.relative_to(CONFIG).as_posix()
+        label = "arm9" if rel == "arm9" else rel.split("/")[-1]
+        for line in sp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = SYMRE.match(line)
+            if m:
+                out.setdefault(m.group(1), label)
+    return out
+
+
+def git(*a, check=True):
+    r = subprocess.run(["git", *a], capture_output=True, text=True, cwd=REPO)
+    if check and r.returncode != 0:
+        sys.exit(f"git {' '.join(a)} failed:\n{r.stderr}")
+    return r.stdout.strip()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--max-files", type=int, default=175)
+    ap.add_argument("--prefix", default="rombuild")
+    ap.add_argument("--create", action="store_true", help="create the local branches")
+    args = ap.parse_args()
+
+    head = git("rev-parse", "HEAD")
+    changed = [f for f in git("diff", "--name-only", args.base, "HEAD", "--", "src/").splitlines() if f]
+    if not changed:
+        sys.exit("no src/ changes vs " + args.base)
+
+    # Attribute each file to the transformation that last touched it, so the sets are
+    # disjoint and each branch carries that file's final content. Walk commits
+    # newest-first; the first one that touched a file owns it.
+    owner = {}
+
+    def kind_of(subject):
+        s = subject.lower()
+        if "vtable" in s or "repoint" in s or "wrong relocation" in s:
+            return "fixes"
+        if "reconcile" in s or "filename" in s:
+            return "names"
+        if "blind" in s:
+            return "blind"
+        if "source-built" in s or "compile" in s:
+            return "fixes"   # the 9 repoints rode with a coverage commit
+        return None
+
+    for line in git("log", "--format=%H\x01%s", f"{args.base}..HEAD").splitlines():
+        sha, subject = line.split("\x01", 1)
+        k = kind_of(subject)
+        if not k:
+            continue
+        for f in git("show", "--name-only", "--format=", sha, "--", "src/").splitlines():
+            if f and f not in owner:
+                owner[f] = k
+
+    # A file changed vs the base that NONE of these commits touched came from something
+    # else on this branch - here, the fader-hierarchy .c -> .cpp promotions that arrived
+    # via the merge. That is separate work with its own review; it must not ride along.
+    foreign = [f for f in changed if f not in owner]
+    if foreign:
+        print(f"excluding {len(foreign)} file(s) changed by other work on this branch "
+              f"(e.g. {pathlib.Path(foreign[0]).name})\n")
+        changed = [f for f in changed if f in owner]
+
+    mods = module_of_stems()
+    plan = []
+    for key, title, body in TRANSFORMS:
+        files = sorted(f for f in changed if owner.get(f) == key)
+        if not files:
+            continue
+        bymod = collections.defaultdict(list)
+        for f in files:
+            bymod[mods.get(pathlib.Path(f).stem, "misc")].append(f)
+        # Big modules get their own batches; small ones are packed together.
+        batches, cur, curmods, pool = [], [], [], []
+        for mod, fs in sorted(bymod.items(), key=lambda kv: -len(kv[1])):
+            if len(fs) >= args.max_files:
+                # Full batches for the bulk; the remainder joins the packing pool rather
+                # than becoming a lopsided 20-file PR of its own.
+                whole = (len(fs) // args.max_files) * args.max_files
+                for i in range(0, whole, args.max_files):
+                    batches.append(([mod], fs[i:i + args.max_files]))
+                if fs[whole:]:
+                    pool.append((mod, fs[whole:]))
+                continue
+            pool.append((mod, fs))
+        for mod, fs in sorted(pool, key=lambda kv: -len(kv[1])):
+            if len(cur) + len(fs) > args.max_files and cur:
+                batches.append((curmods, cur))
+                cur, curmods = [], []
+            cur.extend(fs)
+            curmods.append(mod)
+        if cur:
+            batches.append((curmods, cur))
+        for i, (bmods, fs) in enumerate(batches, 1):
+            plan.append((key, title, body, i, len(batches), bmods, fs))
+
+    print(f"base: {args.base}   changed src files: {len(changed)}   max per PR: {args.max_files}")
+    print(f"total PRs: {len(plan)} (plus one for tools/config/notes, which must land first)\n")
+    for (key, title, _body, i, n, bmods, fs) in plan:
+        label = bmods[0] if len(bmods) == 1 else f"{len(bmods)} modules"
+        print(f"  {args.prefix}/{key}-{i:02d}  {len(fs):4d} files  {label:22s} {title}")
+
+    if not args.create:
+        print("\n(plan only — pass --create to make the local branches)")
+        return
+
+    start = git("rev-parse", "--abbrev-ref", "HEAD")
+    made = []
+    for (key, title, body, i, n, bmods, fs) in plan:
+        br = f"{args.prefix}/{key}-{i:02d}"
+        git("checkout", "-q", "-B", br, args.base)
+        # Take each file's final content from the working branch.
+        subprocess.run(["git", "checkout", head, "--", *fs], cwd=REPO, check=True,
+                       capture_output=True)
+        label = bmods[0] if len(bmods) == 1 else f"{len(bmods)} modules"
+        msg = (f"{title} ({len(fs)} files, {label}) [{i}/{n}]\n\n{body}\n\n"
+               f"Batch {i} of {n} for this transformation; the batches are disjoint and each\n"
+               f"branches from {args.base}, so they can be reviewed in any order.\n\n"
+               "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n"
+               "Claude-Session: https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi\n")
+        subprocess.run(["git", "commit", "-q", "-m", msg], cwd=REPO, check=True,
+                       capture_output=True)
+        made.append((br, title, len(fs)))
+    git("checkout", "-q", start)
+
+    print(f"\ncreated {len(made)} local branches. Nothing pushed. To open them:\n")
+    for (br, title, n) in made:
+        print(f"  git push -u origin {br} && gh pr create --base main --head {br} \\\n"
+              f"    --title \"{title} ({n} files)\" --body-file -")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stands up the link half of the toolchain. Until now the repo could verify a function byte-for-byte but had never linked anything: `build/build/` was empty and no ROM had ever been produced from the config.

`python tools/rombuild.py` now produces a bootable 16,777,216-byte ROM in ~80 seconds with **all 106 modules byte-identical to the retail dump**, and **9,115 functions (66.7% of code bytes) compiled from `src/` by mwccarm** rather than taken from the ROM. It boots and plays in melonDS.

### The pipeline

```
src/*.c|cpp --mwccarm--> build/src/*.o ─┐
                                        ├─ mwldarm ─> final_link.o + per-region .bin
config/**/delinks.txt --dsd delink--> gap objects ─┘
        └─> dsd lcf ─> arm9.lcf + objects.txt      ─> dsd rom config/build ─> .nds
                                                   ─> dsd check modules
```

Address ranges enrolled with `complete` are compiled from source; everything else is supplied by a delinked gap object carrying the original ROM bytes. So a green `check modules` with N functions enrolled is proof those N functions' source is the real thing.

| tool | what it does |
|---|---|
| `rombuild.py` | the whole pipeline in one command |
| `enroll.py` | writes `src/` file entries into `config/**/delinks.txt` |
| `eligible.py` | whitelist classifier — one `.text` section, one defined global FUNC of the declared size, no data/bss, no unresolvable references |
| `rombuild_check.py` | per-function byte diff against the ROM |
| `rombuild_diag.py` | explains a mismatch by resolving both sides back to symbols |
| `rombuild_versions.py` | finds which mwccarm version reproduces a function the build got wrong |
| `reconcile_names.py` / `resolve_blind.py` | the two source-side repair passes (their output is in separate PRs) |
| `split_prs.py` | splits a large `src/` change into validate-sized branches |

### Two decisions worth reviewing

**The compiler default is `2004/b56`, not `1.2/sp2p3`.** A function counts as matched if *any* swept version reproduces it, but a link has to pick one, and b56 reproduces strictly more of this corpus (eligibility 7,466 → 7,923; post-link mismatches 70 → 14). b56 ships no `mwldarm`, so `LD_VERSION` keeps the link on 1.2/sp2p3. Only **8 of 9,115** functions need a per-file override, in `config/rombuild-versions.txt`.

**`-Cpp_exceptions off` is in the build flags.** mwccarm emits `.exception`/`.exceptix` unwind tables alongside almost every function. The match gate never saw them because it only compares `.text`; a link does, and they are duplicate content that grows the module and shifts every later address. This blocked 8,520 of 11,090 candidates. Retail carries just 636 bytes of `.exceptix` in main, so the original build had them off too. Verified on 60 sampled files: extra sections cleared, `.text` byte-identical in every case.

### Also fixes a Windows bug in the existing gate

`reloc_audit.winning_object` wrote candidate source with pathlib's default encoding, so cp1252 raised `UnicodeEncodeError` on the **42 `src/` files containing non-ASCII** characters. That degraded their linkcheck verdict to `ERROR`, which `prepush_linkcheck` treats as blocking — a good file blocking a push for a reason unrelated to its bytes.

### Legal / hygiene

No ROM, no extracted asset, and no ROM-derived binary is added or referenced. `build/` and `extracted/` remain gitignored, and `.gitignore` now also covers the local ML/LoRA training work so it can never be swept into a match PR.

### Verification

`tools/prepush_linkcheck.py --range origin/main..HEAD` over the full change: **1,604 checked — 1,388 VERIFIED, 213 BLIND-n, 3 BENIGN, 0 blocking.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
