### PR TITLE
Make each file define the symbol its filename claims (175 files) [01/05]

### DIFF
--- a/src/func_ov006_020d10b8.cpp
+++ b/src/func_ov006_020d10b8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020d10b8
-// @emits dScMgAmida_c_OnYoshiTryEat
+// recovered name: dScMgAmida_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" void NullDestructor_0203d47c(void);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* dScMgAmida_c_OnYoshiTryEat(void* c) {
+extern "C" void* func_ov006_020d10b8(void* c) {
     *(int**)c = &data_ov006_0213b918;
     __destroy_arr((char*)c + 0x4768, 0x80, 0x18, (void*)&func_ov006_020d116c);
     __destroy_arr((char*)c + 0x4744, 4, 8, (void*)&NullDestructor_0203d47c);

--- a/src/func_ov006_020d11a0.cpp
+++ b/src/func_ov006_020d11a0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020d11a0
-// @emits dScMgAmida_c_Kill
+// recovered name: dScMgAmida_c_Kill
 /* recovered: renamed to Class_Method */
 /* dScMgAmida_c::Kill - recovered from vtable slot identity */
 extern "C" {
@@ -12,8 +12,8 @@ extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454;
 extern int data_ov006_0213b838[];
 }
-extern "C" void dScMgAmida_c_Kill(void);
-extern "C" void dScMgAmida_c_Kill(void) {
+extern "C" void func_ov006_020d11a0(void);
+extern "C" void func_ov006_020d11a0(void) {
     volatile unsigned short *reg = (volatile unsigned short*)0x400100a;
     int id;
     void *t;

--- a/src/func_ov006_020d52f0.c
+++ b/src/func_ov006_020d52f0.c
@@ -3,10 +3,10 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgAmida_c.h"
-// @emits dScMgAmida_c_OnYoshiTryEat_020d52f0
+// recovered name: dScMgAmida_c_OnYoshiTryEat_020d52f0
 /* recovered: renamed to Class_Method */
 /* dScMgAmida_c::OnYoshiTryEat - recovered from vtable slot identity */
-void dScMgAmida_c_OnYoshiTryEat_020d52f0(char *c, int arg)
+void func_ov006_020d52f0(char *c, int arg)
 {
     struct dScMgAmida_c *self = (struct dScMgAmida_c *)(void *)c;
     if (arg == 0) {

--- a/src/func_ov006_020d5384.cpp
+++ b/src/func_ov006_020d5384.cpp
@@ -3,7 +3,7 @@
 // @symbol func_ov006_020d5384
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgAmida_c.h"
-// @emits dScMgAmida_c_InitResources
+// recovered name: dScMgAmida_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgAmida_c::InitResources - recovered from vtable slot identity */
 struct Obj {
@@ -74,7 +74,7 @@ extern "C" {
     extern u8 data_0209d454;
 }
 
-extern "C" int dScMgAmida_c_InitResources(Obj *c)
+extern "C" int func_ov006_020d5384(Obj *c)
 {
     struct dScMgAmida_c *self = (struct dScMgAmida_c *)(void *)c;
     volatile u16 sp4;

--- a/src/func_ov006_020d5924.cpp
+++ b/src/func_ov006_020d5924.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov006_020d5924
-// @emits dScMgAmida_c_AfterCleanupResources
+// recovered name: dScMgAmida_c_AfterCleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgAmida_c::AfterCleanupResources - recovered from vtable slot identity */
 extern "C" { void* func_ov004_020b0840(void*, int); }
 namespace Memory { void Deallocate(void*); }
-extern "C" void* dScMgAmida_c_AfterCleanupResources(char* c, int r1){
+extern "C" void* func_ov006_020d5924(char* c, int r1){
   if(r1!=2) return c;
   Memory::Deallocate(*(void**)(c+0x4000+0x70c));
   Memory::Deallocate(*(void**)(c+0x4000+0x710));

--- a/src/func_ov006_020d5a78.c
+++ b/src/func_ov006_020d5a78.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020d5a78
-// @emits dScMgBomroom_c_OnYoshiTryEat
+// recovered name: dScMgBomroom_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBomroom_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgBomroom_c_OnYoshiTryEat(int *t)
+int *func_ov006_020d5a78(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020d9160.c
+++ b/src/func_ov006_020d9160.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020d9160
-// @emits dScMgBomroom_c_Render
+// recovered name: dScMgBomroom_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgBomroom_c::Render - recovered from vtable slot identity */
-int dScMgBomroom_c_Render(void* c){
+int func_ov006_020d9160(void* c){
   func_ov006_020d5dfc(c);
   func_ov006_020d6098(c);
   func_ov006_020d5e5c(c);

--- a/src/func_ov006_020d91b0.cpp
+++ b/src/func_ov006_020d91b0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020d91b0
-// @emits dScMgBomroom_c_Behavior
+// recovered name: dScMgBomroom_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgBomroom_c::Behavior - recovered from vtable slot identity */
 struct C;
@@ -9,7 +9,7 @@ extern "C" {
 extern PMF data_ov006_021416e0[];
 void func_ov006_020d5d08(char *c);
 void func_ov006_020d5b10(char *c);
-int dScMgBomroom_c_Behavior(char *c)
+int func_ov006_020d91b0(char *c)
 {
     if (*(unsigned short *)(c + 0x6200 + 0xf0) != 0) {
         unsigned short *t = (unsigned short *)(((int)c + 0x62f0));

--- a/src/func_ov006_020d9244.c
+++ b/src/func_ov006_020d9244.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020d9244
-// @emits dScMgBomroom_c_InitResources
+// recovered name: dScMgBomroom_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -19,7 +19,7 @@ extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *p, u16 a, u16 b, u16 c
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgBomroom_c_InitResources(void *arg0)
+int func_ov006_020d9244(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_020d9638.cpp
+++ b/src/func_ov006_020d9638.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020d9638
-// @emits dScMgCard_c_OnYoshiTryEat
+// recovered name: dScMgCard_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,8 +10,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgCard_c_OnYoshiTryEat(char *c);
-void *dScMgCard_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020d9638(char *c);
+void *func_ov006_020d9638(char *c) {
     *(void ***)c = data_ov006_0213bdb4;
     __destroy_arr(c + 0x5298, 5, 0x30, (void*)&func_ov006_020d96f0);
     __destroy_arr(c + 0x51a8, 5, 0x30, (void*)&func_ov006_020d96e0);

--- a/src/func_ov006_020da994.c
+++ b/src/func_ov006_020da994.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_020da994
-// @emits dScMgCard_c_CleanupResources
+// recovered name: dScMgCard_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::CleanupResources - recovered from vtable slot identity */
 extern int data_ov006_0214176c[];
 extern int data_ov006_02141768[];
 extern int data_ov006_02141770[];
-int dScMgCard_c_CleanupResources(void){
+int func_ov006_020da994(void){
   data_ov006_0214176c[0]=0;
   data_ov006_02141768[0]=0;
   data_ov006_02141770[0]=0;

--- a/src/func_ov006_020da9c4.cpp
+++ b/src/func_ov006_020da9c4.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCard_c.h"
-// @emits dScMgCard_c_Render
+// recovered name: dScMgCard_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::Render - recovered from vtable slot identity */
 struct Node {
@@ -20,7 +20,7 @@ extern "C" void func_ov006_020c1804(void *c);
 
 extern int data_ov006_02134028;
 
-extern "C" int dScMgCard_c_Render(char *c)
+extern "C" int func_ov006_020da9c4(char *c)
 {
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     int skip;

--- a/src/func_ov006_020dabec.c
+++ b/src/func_ov006_020dabec.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020dabec
-// @emits dScMgCard_c_Behavior
+// recovered name: dScMgCard_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void func_ov006_020c19d0(void*);
 extern void func_ov004_020b65e4(void*);
 
-int dScMgCard_c_Behavior(char* c){
+int func_ov006_020dabec(char* c){
   *(short*)(((int)c+0x5396)) += 1;
   func_ov006_020c19d0(c+0x4f38);
   func_ov004_020b65e4(func_ov006_020dac34(c));

--- a/src/func_ov006_020db6ec.c
+++ b/src/func_ov006_020db6ec.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCard_c.h"
-// @emits dScMgCard_c_OnGroundPounded
+// recovered name: dScMgCard_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnGroundPounded - recovered from vtable slot identity */
 
-int dScMgCard_c_OnGroundPounded(void *this) {
+int func_ov006_020db6ec(void *this) {
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)this;
     int x = self->unk_0b4;
     int v;

--- a/src/func_ov006_020db720.c
+++ b/src/func_ov006_020db720.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCard_c.h"
-// @emits dScMgCard_c_OnTurnIntoEgg
+// recovered name: dScMgCard_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnTurnIntoEgg - recovered from vtable slot identity */
 typedef short s16;
@@ -16,7 +16,7 @@ extern int _Z15ApproachLinear2Rsss(s16* r, s16 t, s16 s);
 extern s16 data_ov004_020bf9e4;
 extern void* func_020beb68;
 
-int dScMgCard_c_OnTurnIntoEgg(char* c)
+int func_ov006_020db720(char* c)
 {
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     switch (self->unk_5388) {

--- a/src/func_ov006_020db9dc.c
+++ b/src/func_ov006_020db9dc.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCard_c.h"
-// @emits dScMgCard_c_OnYoshiTryEat_020db9dc
+// recovered name: dScMgCard_c_OnYoshiTryEat_020db9dc
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_020c1604(char *c, int unused, short a2, int a3);
@@ -13,7 +13,7 @@ extern int data_ov006_0214176c;
 extern int data_ov006_02141768;
 extern int data_ov006_02141770;
 
-void dScMgCard_c_OnYoshiTryEat_020db9dc(char *c)
+void func_ov006_020db9dc(char *c)
 {
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     int i;

--- a/src/func_ov006_020dbaf0.cpp
+++ b/src/func_ov006_020dbaf0.cpp
@@ -5,10 +5,10 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCard_c.h"
-// @emits dScMgCard_c_InitResources
+// recovered name: dScMgCard_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgCard_c::InitResources - recovered from vtable slot identity */
-/* dScMgCard_c_InitResources @ 0x020dbaf0 (ov006, size 0x264)
+/* func_ov006_020dbaf0 @ 0x020dbaf0 (ov006, size 0x264)
  * Minigame graphics init: loads/decompresses the OBJ tiles+palettes for both
  * engines, sets blending, patches the OAM attr template list, spawns the two
  * rows of 5 slot sprites, and resets the shared counters.
@@ -61,7 +61,7 @@ extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile u16 *, int, int, int, int);
 extern void func_ov006_020c0aa8(char *);
 extern int func_ov006_020c1a88(char *);
 
-int dScMgCard_c_InitResources(char *c)
+int func_ov006_020dbaf0(char *c)
 {
     struct dScMgCard_c *self = (struct dScMgCard_c *)(void *)c;
     void *f7, *f6, *f5, *f4;

--- a/src/func_ov006_020dbe64.c
+++ b/src/func_ov006_020dbe64.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020dbe64
-// @emits dScMgCoin_c_OnYoshiTryEat
+// recovered name: dScMgCoin_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgCoin_c_OnYoshiTryEat(int *t)
+int *func_ov006_020dbe64(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020de5b0.c
+++ b/src/func_ov006_020de5b0.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCoin_c.h"
-// @emits dScMgCoin_c_OnYoshiTryEat_020de5b0
+// recovered name: dScMgCoin_c_OnYoshiTryEat_020de5b0
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void FreeGfxSlotsById(int n);
 extern int func_ov004_020adc1c(void);
-void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c);
-void dScMgCoin_c_OnYoshiTryEat_020de5b0(char *c){
+void func_ov006_020de5b0(char *c);
+void func_ov006_020de5b0(char *c){
     struct dScMgCoin_c *self = (struct dScMgCoin_c *)(void *)c;
     if (self->unk_51db != 0) {
         *(unsigned char*)(((int)c + 0x51da)) += 1;

--- a/src/func_ov006_020de63c.c
+++ b/src/func_ov006_020de63c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020de63c
-// @emits dScMgCoin_c_Render
+// recovered name: dScMgCoin_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::Render - recovered from vtable slot identity */
 void func_ov006_020dccb8(void *c);
@@ -13,7 +13,7 @@ void func_ov006_020dc870(void *c);
 void func_ov006_020dcea8(void *c);
 void func_ov006_020dcc48(void *c);
 
-int dScMgCoin_c_Render(void *c)
+int func_ov006_020de63c(void *c)
 {
     func_ov006_020dccb8(c);
     func_ov006_020dcd74(c);

--- a/src/func_ov006_020de69c.cpp
+++ b/src/func_ov006_020de69c.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov006_020de69c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCoin_c.h"
-// @emits dScMgCoin_c_Behavior
+// recovered name: dScMgCoin_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgCoin_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -14,9 +14,9 @@ void func_ov006_020dc754(void *c);
 void func_ov006_020dc298(void *c);
 void func_ov006_020dc900(void *c);
 void func_ov006_020dce3c(void *c);
-int dScMgCoin_c_Behavior(C *c);
+int func_ov006_020de69c(C *c);
 }
-int dScMgCoin_c_Behavior(C *c) {
+int func_ov006_020de69c(C *c) {
     struct dScMgCoin_c *self = (struct dScMgCoin_c *)(void *)c;
     int idx = self->unk_51c8;
     (c->*data_ov006_02141810[idx].pmf)();

--- a/src/func_ov006_020de704.c
+++ b/src/func_ov006_020de704.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020de704
-// @emits dScMgCoin_c_InitResources
+// recovered name: dScMgCoin_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -16,7 +16,7 @@ extern u8 data_0209d45c;
 extern u8 data_0209d454;
 extern int data_0208ee44;
 
-int dScMgCoin_c_InitResources(void *arg0) {
+int func_ov006_020de704(void *arg0) {
     char *c = (char*)arg0;
     int a, b, d;
 

--- a/src/func_ov006_020dea1c.cpp
+++ b/src/func_ov006_020dea1c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020dea1c
-// @emits dScMgCup_c_OnYoshiTryEat
+// recovered name: dScMgCup_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,8 +11,8 @@ extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void NullDestructor_0203d47c();
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgCup_c_OnYoshiTryEat(char *c);
-void *dScMgCup_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020dea1c(char *c);
+void *func_ov006_020dea1c(char *c) {
     *(void ***)c = data_ov006_0213c154;
     __destroy_arr(c + 0x53e8, 3, 8, (void*)&NullDestructor_0203d47c);
     __destroy_arr(c + 0x50e8, 0x20, 0x18, (void*)&func_ov006_020deac4);

--- a/src/func_ov006_020dfed4.c
+++ b/src/func_ov006_020dfed4.c
@@ -1,9 +1,9 @@
 // @symbol func_ov006_020dfed4
-// @emits dScMgCup_c_Virtual50
+// recovered name: dScMgCup_c_Virtual50
 /* recovered: renamed to Class_Method */
 /* dScMgCup_c::Virtual50 - recovered from vtable slot identity */
 extern void func_ov006_020c2594(void*);
 
-void dScMgCup_c_Virtual50(char* p) {
+void func_ov006_020dfed4(char* p) {
     func_ov006_020c2594(p + 0x4f38);
 }

--- a/src/func_ov006_020e0204.cpp
+++ b/src/func_ov006_020e0204.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e0204
-// @emits dScMgCup_c_Behavior
+// recovered name: dScMgCup_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -19,7 +19,7 @@ typedef struct Frame {
 extern "C" Frame *data_ov006_0213c0d8[];
 
 
-extern "C" int dScMgCup_c_Behavior(char *o)
+extern "C" int func_ov006_020e0204(char *o)
 {
     int i;
     (((C *)o)->*data_ov006_02141870[*(int *)(o + 0x5418)])();

--- a/src/func_ov006_020e0308.cpp
+++ b/src/func_ov006_020e0308.cpp
@@ -1,12 +1,12 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_020e0308
-// @emits dScMgCup_c_InitResources
+// recovered name: dScMgCup_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCup_c::InitResources - recovered from vtable slot identity */
-/* dScMgCup_c_InitResources @ 0x020e0308 (ov006, size 0x26c)
+/* func_ov006_020e0308 @ 0x020e0308 (ov006, size 0x26c)
  * Minigame sub-screen setup: configures sub BG1/BG2 control, loads the
  * board tiles/map/palette files, sets the touch UI margins, initializes
  * the three sliders from the table at data_ov006_0213c0a8, then calls
@@ -65,7 +65,7 @@ extern int _ZN3G2S12GetBG0ScrPtrEv(void);
 extern int _ZN3G2S12GetBG2ScrPtrEv(void);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(void *, unsigned int, unsigned int);
 
-int dScMgCup_c_InitResources(char *c)
+int func_ov006_020e0308(char *c)
 {
     void *f;
 

--- a/src/func_ov006_020e065c.c
+++ b/src/func_ov006_020e065c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020e065c
-// @emits dScMgCurling_c_OnYoshiTryEat
+// recovered name: dScMgCurling_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCurling_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgCurling_c_OnYoshiTryEat(int *t)
+int *func_ov006_020e065c(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020e3470.c
+++ b/src/func_ov006_020e3470.c
@@ -1,14 +1,14 @@
 // @symbol func_ov006_020e3470
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCurling_c.h"
-// @emits dScMgCurling_c_OnYoshiTryEat_020e3470
+// recovered name: dScMgCurling_c_OnYoshiTryEat_020e3470
 /* recovered: renamed to Class_Method */
 /* dScMgCurling_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_020e3388(void*);
 extern void func_ov006_020e3250(void*);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void*,unsigned short,unsigned short,unsigned short,unsigned short);
 extern int func_ov004_020adc1c(void);
-void dScMgCurling_c_OnYoshiTryEat_020e3470(unsigned char* c){
+void func_ov006_020e3470(unsigned char* c){
     struct dScMgCurling_c *self = (struct dScMgCurling_c *)(void *)c;
   self->unk_4eac=0;
   func_ov006_020e3388(c);

--- a/src/func_ov006_020e34ec.c
+++ b/src/func_ov006_020e34ec.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020e34ec
-// @emits dScMgCurling_c_Render
+// recovered name: dScMgCurling_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Player.h"
 #include "decl_common.h"
@@ -7,7 +7,7 @@
 /* dScMgCurling_c::Render - recovered from vtable slot identity */
 extern int func_ov004_020adc1c(char*);
 extern int func_ov004_020b19f0(int);
-int dScMgCurling_c_Render(char*c){
+int func_ov006_020e34ec(char*c){
   func_ov004_020b19f0(func_ov004_020adc1c(c));
   func_ov006_020e1554(c);
   func_ov006_020e1c68(c);

--- a/src/func_ov006_020e3528.cpp
+++ b/src/func_ov006_020e3528.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e3528
-// @emits dScMgCurling_c_Behavior
+// recovered name: dScMgCurling_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgCurling_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -8,7 +8,7 @@ struct Entry { PMF pmf[1]; };
 extern Entry data_ov006_02141950[];
 struct C { char pad[0x4eac]; int idx; };
 extern "C" int func_ov006_020e12d0(C*);
-extern "C" int dScMgCurling_c_Behavior(C* c){
+extern "C" int func_ov006_020e3528(C* c){
   int j = c->idx;
   (c->*data_ov006_02141950[j].pmf[0])();
   func_ov006_020e12d0(c);

--- a/src/func_ov006_020e3578.c
+++ b/src/func_ov006_020e3578.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020e3578
-// @emits dScMgCurling_c_InitResources
+// recovered name: dScMgCurling_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -23,7 +23,7 @@ extern int func_ov004_020adc1c(void);
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 
-int dScMgCurling_c_InitResources(char* self)
+int func_ov006_020e3578(char* self)
 {
     char* a = func_020adc74(&data_ov006_0213c394);
     char* b = func_020adc74(&data_ov006_0213c3b4);

--- a/src/func_ov006_020e3878.c
+++ b/src/func_ov006_020e3878.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020e3878
-// @emits dScMgCurling2_c_OnYoshiTryEat
+// recovered name: dScMgCurling2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCurling2_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgCurling2_c_OnYoshiTryEat(int *t)
+int *func_ov006_020e3878(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020e6774.c
+++ b/src/func_ov006_020e6774.c
@@ -1,14 +1,14 @@
 // @symbol func_ov006_020e6774
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgCurling2_c.h"
-// @emits dScMgCurling2_c_OnYoshiTryEat_020e6774
+// recovered name: dScMgCurling2_c_OnYoshiTryEat_020e6774
 /* recovered: renamed to Class_Method */
 /* dScMgCurling2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_020e668c(void*);
 extern void func_ov006_020e6528(void*);
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void*,unsigned short,unsigned short,unsigned short,unsigned short);
 extern int func_ov004_020adc1c(void);
-void dScMgCurling2_c_OnYoshiTryEat_020e6774(unsigned char* c){
+void func_ov006_020e6774(unsigned char* c){
     struct dScMgCurling2_c *self = (struct dScMgCurling2_c *)(void *)c;
   self->unk_5580=0;
   func_ov006_020e668c(c);

--- a/src/func_ov006_020e67f0.c
+++ b/src/func_ov006_020e67f0.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020e67f0
-// @emits dScMgCurling2_c_Render
+// recovered name: dScMgCurling2_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgCurling2_c::Render - recovered from vtable slot identity */
-int dScMgCurling2_c_Render(int c){
+int func_ov006_020e67f0(int c){
   extern int func_ov004_020adc1c();
   extern int func_ov004_020b19f0();
   func_ov004_020adc1c();

--- a/src/func_ov006_020e683c.cpp
+++ b/src/func_ov006_020e683c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e683c
-// @emits dScMgCurling2_c_Behavior
+// recovered name: dScMgCurling2_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 struct Ent{ int a; int b; };
 extern Ent data_ov006_02141a18[];
-int dScMgCurling2_c_Behavior(char* c){
+int func_ov006_020e683c(char* c){
   int idx=*(int*)(c+0x5000+0x580);
   Ent* e=&data_ov006_02141a18[idx];
   int adj=e->b;

--- a/src/func_ov006_020e6894.c
+++ b/src/func_ov006_020e6894.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020e6894
-// @emits dScMgCurling2_c_InitResources
+// recovered name: dScMgCurling2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -26,7 +26,7 @@ extern int func_ov004_020adc1c(void);
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 
-int dScMgCurling2_c_InitResources(char* self)
+int func_ov006_020e6894(char* self)
 {
     char* r6 = func_020adc74(&data_ov006_0213c5a0);
     void* f;

--- a/src/func_ov006_020e6cac.c
+++ b/src/func_ov006_020e6cac.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_020e6cac
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline2_c.h"
-// @emits dScMgTrampoline2_c_OnAimedAtWithEggReturnVec
+// recovered name: dScMgTrampoline2_c_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 void _ZN2GX15SetBankForSubBGEt(unsigned int);
@@ -13,7 +13,7 @@ void func_ov006_020e759c(void);
 extern unsigned char data_0209e660;
 extern unsigned char data_0209f5f8;
 
-void dScMgTrampoline2_c_OnAimedAtWithEggReturnVec(char *this) {
+void func_ov006_020e6cac(char *this) {
     struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)this;
     _ZN2GX15SetBankForSubBGEt(self->unk_0a0);
     _ZN2GX16SetBankForSubOBJEt(self->unk_4660);

--- a/src/func_ov006_020e6d24.cpp
+++ b/src/func_ov006_020e6d24.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov006_020e6d24
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline2_c.h"
-// @emits dScMgTrampoline2_c_OnAimedAtWithEgg
+// recovered name: dScMgTrampoline2_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern "C" {
@@ -15,9 +15,9 @@ void _ZN2GX16SetBankForSubOBJEt(unsigned short x);
 void func_ov004_020af094(void *c);
 extern void *data_ov006_02141a48[];
 extern unsigned char data_0209e660;
-void dScMgTrampoline2_c_OnAimedAtWithEgg(char *c);
+void func_ov006_020e6d24(char *c);
 }
-void dScMgTrampoline2_c_OnAimedAtWithEgg(char *c) {
+void func_ov006_020e6d24(char *c) {
     struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)c;
     func_ov006_020e73c4();
     _ZN3GXS11LoadOBJPlttEPKvjj(data_ov006_02141a48[0], 0x100, 0x100);

--- a/src/func_ov006_020e6d8c.c
+++ b/src/func_ov006_020e6d8c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020e6d8c
-// @emits dScMgTrampoline2_c_OnHitFromUnderneath
+// recovered name: dScMgTrampoline2_c_OnHitFromUnderneath
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnHitFromUnderneath - recovered from vtable slot identity */
-/* dScMgTrampoline2_c_OnHitFromUnderneath @ 0x20e6d8c (ov006) -- tail-call veneer to func_ov004_020af04c (co-loaded ov004). */
+/* func_ov006_020e6d8c @ 0x20e6d8c (ov006) -- tail-call veneer to func_ov004_020af04c (co-loaded ov004). */
 extern void func_ov004_020af04c(void);
 
-void dScMgTrampoline2_c_OnHitFromUnderneath(void) {
+void func_ov006_020e6d8c(void) {
     func_ov004_020af04c();
 }

--- a/src/func_ov006_020e6d98.c
+++ b/src/func_ov006_020e6d98.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020e6d98
-// @emits dScMgTrampoline2_c_OnHitByMegaChar
+// recovered name: dScMgTrampoline2_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnHitByMegaChar - recovered from vtable slot identity */
-/* dScMgTrampoline2_c_OnHitByMegaChar @ 0x20e6d98 (ov006) -- tail-call veneer to func_ov004_020af27c (co-loaded ov004). */
+/* func_ov006_020e6d98 @ 0x20e6d98 (ov006) -- tail-call veneer to func_ov004_020af27c (co-loaded ov004). */
 extern void func_ov004_020af27c(void);
 
-void dScMgTrampoline2_c_OnHitByMegaChar(void) {
+void func_ov006_020e6d98(void) {
     func_ov004_020af27c();
 }

--- a/src/func_ov006_020e6e4c.c
+++ b/src/func_ov006_020e6e4c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov006_020e6e4c
-// @emits dScMgTrampoline2_c_OnHitByCannonBlastedChar
+// recovered name: dScMgTrampoline2_c_OnHitByCannonBlastedChar
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
-int dScMgTrampoline2_c_OnHitByCannonBlastedChar(void)
+int func_ov006_020e6e4c(void)
 {
     return 2;
 }

--- a/src/func_ov006_020e6e54.c
+++ b/src/func_ov006_020e6e54.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_020e6e54
-// @emits dScMgJump2_c_OnPushed
+// recovered name: dScMgJump2_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::OnPushed - recovered from vtable slot identity */
-int dScMgJump2_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }
+int func_ov006_020e6e54(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_020e6e78.cpp
+++ b/src/func_ov006_020e6e78.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e6e78
-// @emits dScMgJump2_c_OnKicked
+// recovered name: dScMgJump2_c_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" void Camera_UpdateMatrices(int arg);
 
 extern unsigned char data_0209f5f8;
 
-extern "C" int dScMgJump2_c_OnKicked(char* self)
+extern "C" int func_ov006_020e6e78(char* self)
 {
     if (func_ov004_020ae140(self) == 0) return 0;
     if (*(int*)(self + 0x4628) == 0) {

--- a/src/func_ov006_020e72c0.c
+++ b/src/func_ov006_020e72c0.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline2_c.h"
-// @emits dScMgTrampoline2_c_Kill
+// recovered name: dScMgTrampoline2_c_Kill
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::Kill - recovered from vtable slot identity */
 int func_02053ea0(void);
@@ -20,7 +20,7 @@ void *_ZN3G2S12GetBG1ScrPtrEv(void);
 
 extern unsigned char data_0209d454;
 
-void dScMgTrampoline2_c_Kill(char *c) {
+void func_ov006_020e72c0(char *c) {
     struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)c;
   self->unk_4660 = func_02053ea0();
   _ZN2GX16SetBankForSubOBJEt(0x100);

--- a/src/func_ov006_020e76e4.c
+++ b/src/func_ov006_020e76e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020e76e4
-// @emits dScMg3DEsp_c_OnYoshiTryEat
+// recovered name: dScMg3DEsp_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_TextureTransformer.h"
@@ -9,7 +9,7 @@
 extern void _ZN8Particle10SysTrackerD1Ev(void*);
 extern int data_ov006_0213e448;
 extern void* data_020a0eac;
-void* dScMg3DEsp_c_OnYoshiTryEat(char* p){
+void* func_ov006_020e76e4(char* p){
   *(int*)p = (int)&data_ov006_0213c8c4;
   _ZN18TextureTransformerD1Ev(p + 0x51f4);
   func_ov006_020e80d8(p + 0x4fd8);

--- a/src/func_ov006_020e9c10.c
+++ b/src/func_ov006_020e9c10.c
@@ -1,12 +1,12 @@
 // @symbol func_ov006_020e9c10
-// @emits dScMg3DEsp_c_Virtual50
+// recovered name: dScMg3DEsp_c_Virtual50
 /* recovered: renamed to Class_Method */
 /* dScMg3DEsp_c::Virtual50 - recovered from vtable slot identity */
-/* dScMg3DEsp_c_Virtual50 at 0x020e9c10 - thunk: FreeGfxSlotsById(8) */
+/* func_ov006_020e9c10 at 0x020e9c10 - thunk: FreeGfxSlotsById(8) */
 
 extern int FreeGfxSlotsById(int a);
 
-int dScMg3DEsp_c_Virtual50(void)
+int func_ov006_020e9c10(void)
 {
     return FreeGfxSlotsById(8);
 }

--- a/src/func_ov006_020e9c20.c
+++ b/src/func_ov006_020e9c20.c
@@ -3,12 +3,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMg3DEsp_c.h"
-// @emits dScMg3DEsp_c_OnYoshiTryEat_020e9c20
+// recovered name: dScMg3DEsp_c_OnYoshiTryEat_020e9c20
 /* recovered: renamed to Class_Method */
 /* dScMg3DEsp_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern char* func_020beb68;
 
-void dScMg3DEsp_c_OnYoshiTryEat_020e9c20(char* c, int a)
+void func_ov006_020e9c20(char* c, int a)
 {
     struct dScMg3DEsp_c *self = (struct dScMg3DEsp_c *)(void *)c;
     func_ov006_020e984c(c);

--- a/src/func_ov006_020e9cec.c
+++ b/src/func_ov006_020e9cec.c
@@ -1,12 +1,12 @@
 // @symbol func_ov006_020e9cec
-// @emits dScMg3DEsp_c_CleanupResources
+// recovered name: dScMg3DEsp_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMg3DEsp_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int dScMg3DEsp_c_CleanupResources(void)
+int func_ov006_020e9cec(void)
 {
     _ZN13SharedFilePtr7ReleaseEv(G0);
     _ZN13SharedFilePtr7ReleaseEv(G1);

--- a/src/func_ov006_020e9d1c.cpp
+++ b/src/func_ov006_020e9d1c.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMg3DEsp_c.h"
-// @emits dScMg3DEsp_c_Render
+// recovered name: dScMg3DEsp_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMg3DEsp_c::Render - recovered from vtable slot identity */
 extern "C" void Camera_UpdateMatrices(char *c);
@@ -14,7 +14,7 @@ struct TextureTransformer { void Update(ModelComponents &m); };
 
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void vcall(int); };
 
-extern "C" int dScMg3DEsp_c_Render(char *c)
+extern "C" int func_ov006_020e9d1c(char *c)
 {
     struct dScMg3DEsp_c *self = (struct dScMg3DEsp_c *)(void *)c;
     func_ov006_020e81a4(c);

--- a/src/func_ov006_020e9e00.cpp
+++ b/src/func_ov006_020e9e00.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e9e00
-// @emits dScMg3DEsp_c_Behavior
+// recovered name: dScMg3DEsp_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -12,7 +12,7 @@ extern "C" PMF data_ov006_02141f2c[];
 extern "C" void func_ov006_020e8a44(C *self);
 extern "C" void _ZN9Animation7AdvanceEv(void *anim);
 
-extern "C" int dScMg3DEsp_c_Behavior(C *self)
+extern "C" int func_ov006_020e9e00(C *self)
 {
     char *f = (char *)self;
     int idx = *(int *)(f + 0x553c);

--- a/src/func_ov006_020e9e70.cpp
+++ b/src/func_ov006_020e9e70.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020e9e70
-// @emits dScMg3DEsp_c_InitResources
+// recovered name: dScMg3DEsp_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* dScMg3DEsp_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -43,7 +43,7 @@ struct Obj {
     virtual void v48(int arg);
 };
 
-extern "C" int dScMg3DEsp_c_InitResources(void* arg0)
+extern "C" int func_ov006_020e9e70(void* arg0)
 {
     char* c = (char*)arg0;
     M48 tmp;

--- a/src/func_ov006_020ea2c8.cpp
+++ b/src/func_ov006_020ea2c8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020ea2c8
-// @emits dScMgHanachan_c_OnYoshiTryEat
+// recovered name: dScMgHanachan_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ extern "C" void __destroy_arr(void* p, int a, int b, void* fn);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* dScMgHanachan_c_OnYoshiTryEat(void* c) {
+extern "C" void* func_ov006_020ea2c8(void* c) {
     *(int**)c = &data_ov006_0213cab8;
     __destroy_arr((char*)c + 0x4678, 0xf, 0x98, (void*)&func_ov006_020ea324);
     func_ov004_020b29c0(c);

--- a/src/func_ov006_020ecec8.c
+++ b/src/func_ov006_020ecec8.c
@@ -1,9 +1,9 @@
 // @symbol func_ov006_020ecec8
-// @emits dScMgHanachan_c_CleanupResources
+// recovered name: dScMgHanachan_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgHanachan_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int dScMgHanachan_c_CleanupResources(void *t)
+int func_ov006_020ecec8(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;

--- a/src/func_ov006_020ecee4.c
+++ b/src/func_ov006_020ecee4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020ecee4
-// @emits dScMgHanachan_c_Render
+// recovered name: dScMgHanachan_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -22,7 +22,7 @@ extern Pair data_ov006_0213ca3c;
 extern Pair data_ov006_0213ca34;
 extern Pair data_ov006_0213ca2c;
 
-int dScMgHanachan_c_Render(void *a0)
+int func_ov006_020ecee4(void *a0)
 {
     char *self = (char *)a0;
     int i;

--- a/src/func_ov006_020ed18c.cpp
+++ b/src/func_ov006_020ed18c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020ed18c
-// @emits dScMgHanachan_c_Behavior
+// recovered name: dScMgHanachan_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@
 struct C;
 typedef void (C::*PMF)();
 
-extern "C" int dScMgHanachan_c_Behavior(char *c)
+extern "C" int func_ov006_020ed18c(char *c)
 {
     data_ov006_02141fcc = data_ov006_02141fcc + 0x800;
     (((C *)c)->*(*(PMF *)(c + 0x4660)))();

--- a/src/func_ov006_020eda48.c
+++ b/src/func_ov006_020eda48.c
@@ -3,12 +3,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgHanachan_c.h"
-// @emits dScMgHanachan_c_OnYoshiTryEat_020eda48
+// recovered name: dScMgHanachan_c_OnYoshiTryEat_020eda48
 /* recovered: renamed to Class_Method */
 /* dScMgHanachan_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern char* func_020beb68;
 
-void dScMgHanachan_c_OnYoshiTryEat_020eda48(char* c, int state)
+void func_ov006_020eda48(char* c, int state)
 {
     struct dScMgHanachan_c *self = (struct dScMgHanachan_c *)(void *)c;
     if (state == 1) {

--- a/src/func_ov006_020edb04.cpp
+++ b/src/func_ov006_020edb04.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_020edb04
-// @emits dScMgHanachan_c_InitResources
+// recovered name: dScMgHanachan_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -23,7 +23,7 @@ struct Obj {
     int unkAC;
 };
 
-extern "C" int dScMgHanachan_c_InitResources(Obj *obj)
+extern "C" int func_ov006_020edb04(Obj *obj)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020edf54.cpp
+++ b/src/func_ov006_020edf54.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020edf54
-// @emits dScMgJump_c_OnYoshiTryEat
+// recovered name: dScMgJump_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_Player.h"
@@ -12,8 +12,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *_ZTV17MgBounceAndPounce[];
 extern void *data_020a0eac;
-void *dScMgJump_c_OnYoshiTryEat(char *c);
-void *dScMgJump_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020edf54(char *c);
+void *func_ov006_020edf54(char *c) {
     *(void ***)c = data_ov006_0213cbe4;
     __destroy_arr(c + 0x5294, 6, 0xf0, (void*)&_ZN6Player18St_LevelEnter_MainEv);
     __destroy_arr(c + 0x506c, 3, 0xb8, (void*)&func_ov006_020c893c);

--- a/src/func_ov006_020edffc.c
+++ b/src/func_ov006_020edffc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020edffc
-// @emits dScMgJump_c_CleanupResources
+// recovered name: dScMgJump_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void func_ov004_020ad90c(void);
 
-int dScMgJump_c_CleanupResources(void) {
+int func_ov006_020edffc(void) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov006_02142184);
     data_ov006_02142184 = 0;
     func_ov004_020ad90c();

--- a/src/func_ov006_020ee034.c
+++ b/src/func_ov006_020ee034.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020ee034
-// @emits dScMgJump_c_Render
+// recovered name: dScMgJump_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -17,7 +17,7 @@ extern void Matrix4x3_FromTranslation(void *m, int x, int y, int z);
 
 extern int data_020a0e68;
 
-int dScMgJump_c_Render(void *self)
+int func_ov006_020ee034(void *self)
 {
     char *c = (char *)self;
 

--- a/src/func_ov006_020ee27c.cpp
+++ b/src/func_ov006_020ee27c.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov006_020ee27c
-// @emits dScMgJump_c_Behavior
+// recovered name: dScMgJump_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgJump_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct C { char pad[0x5004]; PMF m; };
-extern "C" int dScMgJump_c_Behavior(C* c) { (c->*c->m)(); return 1; }
+extern "C" int func_ov006_020ee27c(C* c) { (c->*c->m)(); return 1; }

--- a/src/func_ov006_020ee690.cpp
+++ b/src/func_ov006_020ee690.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "dScMgJump_c.h"
-// @emits dScMgJump_c_InitResources
+// recovered name: dScMgJump_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* dScMgJump_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -50,7 +50,7 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int dScMgJump_c_InitResources(char *base)
+extern "C" int func_ov006_020ee690(char *base)
 {
     struct dScMgJump_c *self = (struct dScMgJump_c *)(void *)base;
     s32 idx;

--- a/src/func_ov006_020ee8dc.cpp
+++ b/src/func_ov006_020ee8dc.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgJump_c.h"
-// @emits dScMgJump_c_OnTurnIntoEgg
+// recovered name: dScMgJump_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgJump_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" short _Z15ApproachLinear2Rsss(short &r, short b, short c);
 extern "C" void func_02012790(int a0);
 
-extern "C" int dScMgJump_c_OnTurnIntoEgg(char *thiz, int sel)
+extern "C" int func_ov006_020ee8dc(char *thiz, int sel)
 {
     struct dScMgJump_c *self = (struct dScMgJump_c *)(void *)thiz;
     if (sel == 0) {

--- a/src/func_ov006_020eec9c.cpp
+++ b/src/func_ov006_020eec9c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020eec9c
-// @emits dScMgJump2_c_OnYoshiTryEat
+// recovered name: dScMgJump2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_Player.h"
@@ -12,8 +12,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *_ZTV17MgBounceAndPounce[];
 extern void *data_020a0eac;
-void *dScMgJump2_c_OnYoshiTryEat(char *c);
-void *dScMgJump2_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020eec9c(char *c);
+void *func_ov006_020eec9c(char *c) {
     *(void ***)c = data_ov006_0213ccfc;
     _ZN5ModelD1Ev(c + 0x5a14);
     __destroy_arr(c + 0x57d4, 0x10, 0x24, (void*)&func_ov006_020eed64);

--- a/src/func_ov006_020ef110.c
+++ b/src/func_ov006_020ef110.c
@@ -1,12 +1,12 @@
 // @symbol func_ov006_020ef110
-// @emits dScMgJump2_c_CleanupResources
+// recovered name: dScMgJump2_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *p);
 extern void func_ov004_020ad90c(void);
 extern void *data_ov006_021421b8;
 
-int dScMgJump2_c_CleanupResources(void) {
+int func_ov006_020ef110(void) {
     _ZN13SharedFilePtr7ReleaseEv(data_ov006_021421b8);
     data_ov006_021421b8 = 0;
     func_ov004_020ad90c();

--- a/src/func_ov006_020ef148.c
+++ b/src/func_ov006_020ef148.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020ef148
-// @emits dScMgJump2_c_Render
+// recovered name: dScMgJump2_c_Render
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -15,7 +15,7 @@ extern int data_020a0e68;
 struct M48 { int w[12]; };
 struct S3 { int a, b, c; };
 
-int dScMgJump2_c_Render(char* self)
+int func_ov006_020ef148(char* self)
 {
     struct S3 local;
     void* p;

--- a/src/func_ov006_020ef3e0.cpp
+++ b/src/func_ov006_020ef3e0.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov006_020ef3e0
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgJump2_c.h"
-// @emits dScMgJump2_c_Behavior
+// recovered name: dScMgJump2_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
@@ -13,9 +13,9 @@ extern "C" {
 unsigned int _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(unsigned int a, unsigned int b, Fix12 c, Fix12 d, Fix12 e, const Vector3_16f* f);
 void* _ZN8Particle6System12FromUniqueIDEj(unsigned int id);
 void func_ov006_020eef90(void);
-int dScMgJump2_c_Behavior(char *c);
+int func_ov006_020ef3e0(char *c);
 }
-int dScMgJump2_c_Behavior(char *c)
+int func_ov006_020ef3e0(char *c)
 {
     struct dScMgJump2_c *self = (struct dScMgJump2_c *)(void *)c;
     self->unk_5a6c =

--- a/src/func_ov006_020ef834.cpp
+++ b/src/func_ov006_020ef834.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgJump2_c.h"
-// @emits dScMgJump2_c_InitResources
+// recovered name: dScMgJump2_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -51,7 +51,7 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int dScMgJump2_c_InitResources(char *base)
+extern "C" int func_ov006_020ef834(char *base)
 {
     struct dScMgJump2_c *self = (struct dScMgJump2_c *)(void *)base;
     int a, b;

--- a/src/func_ov006_020efa84.c
+++ b/src/func_ov006_020efa84.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_020efa84
-// @emits dScMgJump2_c_OnTurnIntoEgg
+// recovered name: dScMgJump2_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-int dScMgJump2_c_OnTurnIntoEgg(void)
+int func_ov006_020efa84(void)
 {
     func_ov006_020c8a9c(0, 0);
     return 1;

--- a/src/func_ov006_020efaa8.c
+++ b/src/func_ov006_020efaa8.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020efaa8
-// @emits dScMgJump2_c_OnYoshiTryEat_020efaa8
+// recovered name: dScMgJump2_c_OnYoshiTryEat_020efaa8
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgJump2_c::OnYoshiTryEat - recovered from vtable slot identity */
-void dScMgJump2_c_OnYoshiTryEat_020efaa8(char* c){
+void func_ov006_020efaa8(char* c){
   func_ov006_020c72b4();
   func_ov006_020c719c(0, 0);
   data_ov006_02140328 = 3;

--- a/src/func_ov006_020efc30.c
+++ b/src/func_ov006_020efc30.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020efc30
-// @emits dScMgLuigi_c_OnYoshiTryEat
+// recovered name: dScMgLuigi_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgLuigi_c_OnYoshiTryEat(int *t)
+int *func_ov006_020efc30(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020efc68.c
+++ b/src/func_ov006_020efc68.c
@@ -1,13 +1,13 @@
 #include "types.h"
 // @symbol func_ov006_020efc68
-// @emits dScMgLuigi_c_AfterCleanupResources
+// recovered name: dScMgLuigi_c_AfterCleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::AfterCleanupResources - recovered from vtable slot identity */
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(unsigned int irq, void *handler);
 extern int func_ov004_020b0840(int a, int b);
-int dScMgLuigi_c_AfterCleanupResources(int a, int irq){
+int func_ov006_020efc68(int a, int irq){
     if(irq == 2 && _ZN3IRQ13GetIRQHandlerEj(2) == (void*)func_ov006_020efcf8){
         u16 ime;
         do {

--- a/src/func_ov006_020f3294.c
+++ b/src/func_ov006_020f3294.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020f3294
-// @emits dScMgLuigi_c_OnYoshiTryEat_020f3294
+// recovered name: dScMgLuigi_c_OnYoshiTryEat_020f3294
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern char *func_020beb68;
 extern unsigned char data_0209d45c;
 extern unsigned char data_0209d454;
 
-void dScMgLuigi_c_OnYoshiTryEat_020f3294(char *c, int arg1)
+void func_ov006_020f3294(char *c, int arg1)
 {
     char *p;
     int *q;

--- a/src/func_ov006_020f33c0.c
+++ b/src/func_ov006_020f33c0.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_020f33c0
-// @emits dScMgLuigi_c_Render
+// recovered name: dScMgLuigi_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::Render - recovered from vtable slot identity */
 extern int func_ov004_020b1e34(void* c, int a, int b, int d);
-int dScMgLuigi_c_Render(void* c) {
+int func_ov006_020f33c0(void* c) {
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
     func_ov006_020f04ec(c);
     func_ov006_020f01d8(c);

--- a/src/func_ov006_020f3414.cpp
+++ b/src/func_ov006_020f3414.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov006_020f3414
-// @emits dScMgLuigi_c_Behavior
+// recovered name: dScMgLuigi_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgLuigi_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern Entry data_ov006_02142234[];
 struct C { char pad[0x4f78]; int idx; };
-extern "C" int dScMgLuigi_c_Behavior(C* c) {
+extern "C" int func_ov006_020f3414(C* c) {
     int j = c->idx;
     (c->*data_ov006_02142234[j].pmf)();
     return 1;

--- a/src/func_ov006_020f3460.c
+++ b/src/func_ov006_020f3460.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_020f3460
-// @emits dScMgLuigi_c_InitResources
+// recovered name: dScMgLuigi_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -22,7 +22,7 @@ extern void Ov004_Deallocate(int a);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgLuigi_c_InitResources(void* arg0) {
+int func_ov006_020f3460(void* arg0) {
     char* c = (char*)arg0;
     char* b;
     volatile u16 sp8;

--- a/src/func_ov006_020f3888.cpp
+++ b/src/func_ov006_020f3888.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f3888
-// @emits dScMgMemory_c_OnYoshiTryEat
+// recovered name: dScMgMemory_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,8 +9,8 @@ extern "C" {
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgMemory_c_OnYoshiTryEat(char *c);
-void *dScMgMemory_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020f3888(char *c);
+void *func_ov006_020f3888(char *c) {
     *(void ***)c = data_ov006_0213d1b8;
     func_ov006_020c1c64(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_020f523c.c
+++ b/src/func_ov006_020f523c.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory_c.h"
-// @emits dScMgMemory_c_OnGroundPounded
+// recovered name: dScMgMemory_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgMemory_c::OnGroundPounded - recovered from vtable slot identity */
 
-int dScMgMemory_c_OnGroundPounded(char* p) {
+int func_ov006_020f523c(char* p) {
     struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)p;
     return func_ov004_020b63a0(self->unk_533b);
 }

--- a/src/func_ov006_020f5250.c
+++ b/src/func_ov006_020f5250.c
@@ -1,13 +1,13 @@
 // @symbol func_ov006_020f5250
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory_c.h"
-// @emits dScMgMemory_c_OnTurnIntoEgg
+// recovered name: dScMgMemory_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgMemory_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov006_020c1718(int* p);
 extern void FreeGfxSlotsById(int n);
 
-int dScMgMemory_c_OnTurnIntoEgg(char* c) {
+int func_ov006_020f5250(char* c) {
     struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)c;
     if (self->unk_5314 == 3 && self->unk_5318 == 0) {
         if (func_ov006_020c1718((int*)(c + 0x4f38)) == 0) return 0;

--- a/src/func_ov006_020f52c4.c
+++ b/src/func_ov006_020f52c4.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory_c.h"
-// @emits dScMgMemory_c_OnYoshiTryEat_020f52c4
+// recovered name: dScMgMemory_c_OnYoshiTryEat_020f52c4
 /* recovered: renamed to Class_Method */
 /* dScMgMemory_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void *o);
 extern char *func_020beb68;
 
-void dScMgMemory_c_OnYoshiTryEat_020f52c4(char *c)
+void func_ov006_020f52c4(char *c)
 {
     struct dScMgMemory_c *self = (struct dScMgMemory_c *)(void *)c;
     char *o;

--- a/src/func_ov006_020f5324.c
+++ b/src/func_ov006_020f5324.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020f5324
-// @emits dScMgMemory_c_Render
+// recovered name: dScMgMemory_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void func_ov006_020c0aa8(char*);
 extern void func_ov004_020b1bc8(char*, int, int, int);
 extern void func_ov006_020c1804(char*);
-int dScMgMemory_c_Render(char* c){
+int func_ov006_020f5324(char* c){
   func_ov006_020c0aa8(c + 0x4660);
   func_ov004_020b1bc8(c, 0xc, 0xc, 0);
   func_ov004_020b6430();

--- a/src/func_ov006_020f5388.cpp
+++ b/src/func_ov006_020f5388.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f5388
-// @emits dScMgMemory_c_Behavior
+// recovered name: dScMgMemory_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgMemory_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -9,7 +9,7 @@ extern "C" Entry data_ov006_021422dc[];
 struct C { char pad[0x5314]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int dScMgMemory_c_Behavior(C* c) {
+extern "C" int func_ov006_020f5388(C* c) {
     (c->*(data_ov006_021422dc[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_020f53e4.cpp
+++ b/src/func_ov006_020f53e4.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_020f53e4
-// @emits dScMgMemory_c_InitResources
+// recovered name: dScMgMemory_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -27,7 +27,7 @@ namespace GXS { void LoadOBJPltt(void const *, unsigned int, unsigned int); }
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-extern "C" int dScMgMemory_c_InitResources(char *self)
+extern "C" int func_ov006_020f53e4(char *self)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020f55b8.cpp
+++ b/src/func_ov006_020f55b8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f55b8
-// @emits dScMgMemory2_c_OnYoshiTryEat
+// recovered name: dScMgMemory2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,8 +9,8 @@ extern "C" {
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgMemory2_c_OnYoshiTryEat(char *c);
-void *dScMgMemory2_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020f55b8(char *c);
+void *func_ov006_020f55b8(char *c) {
     *(void ***)c = data_ov006_0213d4d4;
     func_ov006_020c1c64(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_020f730c.c
+++ b/src/func_ov006_020f730c.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory2_c.h"
-// @emits dScMgMemory2_c_OnGroundPounded
+// recovered name: dScMgMemory2_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgMemory2_c::OnGroundPounded - recovered from vtable slot identity */
 
-int dScMgMemory2_c_OnGroundPounded(char* p) {
+int func_ov006_020f730c(char* p) {
     struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)p;
     return func_ov004_020b63a0(self->unk_5409);
 }

--- a/src/func_ov006_020f7320.c
+++ b/src/func_ov006_020f7320.c
@@ -1,13 +1,13 @@
 // @symbol func_ov006_020f7320
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory2_c.h"
-// @emits dScMgMemory2_c_OnTurnIntoEgg
+// recovered name: dScMgMemory2_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgMemory2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int func_ov006_020c1718(int* p);
 extern void FreeGfxSlotsById(int n);
 
-int dScMgMemory2_c_OnTurnIntoEgg(char* c) {
+int func_ov006_020f7320(char* c) {
     struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)c;
     if (self->unk_53d4 == 3 && self->unk_53d8 == 0) {
         if (func_ov006_020c1718((int*)(c + 0x4f38)) == 0) return 0;

--- a/src/func_ov006_020f7394.c
+++ b/src/func_ov006_020f7394.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMemory2_c.h"
-// @emits dScMgMemory2_c_OnYoshiTryEat_020f7394
+// recovered name: dScMgMemory2_c_OnYoshiTryEat_020f7394
 /* recovered: renamed to Class_Method */
 /* dScMgMemory2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void *o);
 extern char *func_020beb68;
 
-void dScMgMemory2_c_OnYoshiTryEat_020f7394(char *c)
+void func_ov006_020f7394(char *c)
 {
     struct dScMgMemory2_c *self = (struct dScMgMemory2_c *)(void *)c;
     char *o;

--- a/src/func_ov006_020f73f4.c
+++ b/src/func_ov006_020f73f4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020f73f4
-// @emits dScMgMemory2_c_Render
+// recovered name: dScMgMemory2_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void func_ov006_020c0aa8(char*);
 extern void func_ov004_020b1bc8(char*, int, int, int);
 extern void func_ov006_020c1804(char*);
-int dScMgMemory2_c_Render(char* c){
+int func_ov006_020f73f4(char* c){
   func_ov006_020c0aa8(c + 0x4660);
   func_ov004_020b1bc8(c, 0xc, 0xc, 0);
   func_ov004_020b6430();

--- a/src/func_ov006_020f7458.cpp
+++ b/src/func_ov006_020f7458.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f7458
-// @emits dScMgMemory2_c_Behavior
+// recovered name: dScMgMemory2_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgMemory2_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -9,7 +9,7 @@ extern "C" Entry data_ov006_021423e0[];
 struct C { char pad[0x53d4]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int dScMgMemory2_c_Behavior(C* c) {
+extern "C" int func_ov006_020f7458(C* c) {
     (c->*(data_ov006_021423e0[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_020f74b4.cpp
+++ b/src/func_ov006_020f74b4.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_020f74b4
-// @emits dScMgMemory2_c_InitResources
+// recovered name: dScMgMemory2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -27,7 +27,7 @@ namespace GXS { void LoadOBJPltt(void const *, unsigned int, unsigned int); }
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-extern "C" int dScMgMemory2_c_InitResources(char *self)
+extern "C" int func_ov006_020f74b4(char *self)
 {
     void *a;
     void *b;

--- a/src/func_ov006_020f76a8.cpp
+++ b/src/func_ov006_020f76a8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f76a8
-// @emits dScMgMCarlo_c_OnYoshiTryEat
+// recovered name: dScMgMCarlo_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,8 +10,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgMCarlo_c_OnYoshiTryEat(char *c);
-void *dScMgMCarlo_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020f76a8(char *c);
+void *func_ov006_020f76a8(char *c) {
     *(void ***)c = data_ov006_0213d664;
     __destroy_arr(c + 0x51a8, 0x50, 0x30, (void*)&func_ov006_020f7730);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_020f85b0.cpp
+++ b/src/func_ov006_020f85b0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f85b0
-// @emits dScMgMCarlo_c_Render
+// recovered name: dScMgMCarlo_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo_c::Render - recovered from vtable slot identity */
 struct Node {
@@ -19,7 +19,7 @@ void func_ov006_020c1804(char* p);
 }
 extern Node* data_ov006_02142504;
 
-extern "C" int dScMgMCarlo_c_Render(char* c)
+extern "C" int func_ov006_020f85b0(char* c)
 {
     func_ov006_020c0aa8(c + 0x4660);
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);

--- a/src/func_ov006_020f869c.c
+++ b/src/func_ov006_020f869c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020f869c
-// @emits dScMgMCarlo_c_Behavior
+// recovered name: dScMgMCarlo_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -13,7 +13,7 @@ extern void func_ov006_020c19d0(void* c);
 extern char *func_020beb68;
 extern int data_ov006_0213d568;
 
-int dScMgMCarlo_c_Behavior(void* arg)
+int func_ov006_020f869c(void* arg)
 {
     unsigned char* c = (unsigned char*)arg;
 

--- a/src/func_ov006_020f8a3c.c
+++ b/src/func_ov006_020f8a3c.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo_c.h"
-// @emits dScMgMCarlo_c_OnTurnIntoEgg
+// recovered name: dScMgMCarlo_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern void FreeGfxSlotsById(int arg);
@@ -17,7 +17,7 @@ extern char* data_ov006_02142504;
 extern unsigned short data_ov004_020bf9e4;
 extern void* func_020beb68;
 
-int dScMgMCarlo_c_OnTurnIntoEgg(char* c)
+int func_ov006_020f8a3c(char* c)
 {
     struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     switch (self->unk_60a8) {

--- a/src/func_ov006_020f8c68.c
+++ b/src/func_ov006_020f8c68.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo_c.h"
-// @emits dScMgMCarlo_c_OnYoshiTryEat_020f8c68
+// recovered name: dScMgMCarlo_c_OnYoshiTryEat_020f8c68
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo_c::OnYoshiTryEat - recovered from vtable slot identity */
 void func_ov006_020f7c10(char* p);
@@ -11,7 +11,7 @@ void func_ov006_020c1604(char* c, int unused, short a2, int a3);
 void func_ov004_020b66d4(char* p);
 
 
-void dScMgMCarlo_c_OnYoshiTryEat_020f8c68(char* c)
+void func_ov006_020f8c68(char* c)
 {
     struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     func_ov006_020f7c10(c + 0x51a8);

--- a/src/func_ov006_020f8d08.cpp
+++ b/src/func_ov006_020f8d08.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo_c.h"
-// @emits dScMgMCarlo_c_InitResources
+// recovered name: dScMgMCarlo_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -28,7 +28,7 @@ struct Obj {
     virtual void v16(); virtual void v17(); virtual void v18(int x);
 };
 
-extern "C" int dScMgMCarlo_c_InitResources(char *c)
+extern "C" int func_ov006_020f8d08(char *c)
 {
     struct dScMgMCarlo_c *self = (struct dScMgMCarlo_c *)(void *)c;
     void *a;

--- a/src/func_ov006_020f8f68.cpp
+++ b/src/func_ov006_020f8f68.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_020f8f68
-// @emits dScMgMCarlo2_c_OnYoshiTryEat
+// recovered name: dScMgMCarlo2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,8 +10,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgMCarlo2_c_OnYoshiTryEat(char *c);
-void *dScMgMCarlo2_c_OnYoshiTryEat(char *c) {
+void *func_ov006_020f8f68(char *c);
+void *func_ov006_020f8f68(char *c) {
     *(void ***)c = data_ov006_0213d7e8;
     __destroy_arr(c + 0x51a8, 0x28, 0x30, (void*)&func_ov006_020f8ff0);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_020f9fe0.c
+++ b/src/func_ov006_020f9fe0.c
@@ -1,9 +1,9 @@
 // @symbol func_ov006_020f9fe0
-// @emits dScMgMCarlo2_c_CleanupResources
+// recovered name: dScMgMCarlo2_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo2_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int dScMgMCarlo2_c_CleanupResources(void *t)
+int func_ov006_020f9fe0(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;

--- a/src/func_ov006_020f9ffc.cpp
+++ b/src/func_ov006_020f9ffc.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo2_c.h"
-// @emits dScMgMCarlo2_c_Render
+// recovered name: dScMgMCarlo2_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo2_c::Render - recovered from vtable slot identity */
 struct Node {
@@ -20,7 +20,7 @@ extern "C" void func_ov006_020c1804(void *c);
 
 extern Node *data_ov006_02142578;
 
-extern "C" int dScMgMCarlo2_c_Render(char *c)
+extern "C" int func_ov006_020f9ffc(char *c)
 {
     struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
     short v;

--- a/src/func_ov006_020fa13c.c
+++ b/src/func_ov006_020fa13c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020fa13c
-// @emits dScMgMCarlo2_c_Behavior
+// recovered name: dScMgMCarlo2_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern int func_ov006_020c1718(void* p);
 extern void func_ov006_020c19d0(void* c);
 
 
-int dScMgMCarlo2_c_Behavior(void* arg)
+int func_ov006_020fa13c(void* arg)
 {
     unsigned char* c = (unsigned char*)arg;
 

--- a/src/func_ov006_020fa4d4.cpp
+++ b/src/func_ov006_020fa4d4.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo2_c.h"
-// @emits dScMgMCarlo2_c_OnYoshiTryEat_020fa4d4
+// recovered name: dScMgMCarlo2_c_OnYoshiTryEat_020fa4d4
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 extern void func_ov006_020c1604(char* c, int unused, short a2, void* a3);
-void dScMgMCarlo2_c_OnYoshiTryEat_020fa4d4(char* c) {
+void func_ov006_020fa4d4(char* c) {
     struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
   func_ov006_020f9760(c + 0x51a8);
   data_ov006_0213d6fc = 0;

--- a/src/func_ov006_020fa56c.cpp
+++ b/src/func_ov006_020fa56c.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgMCarlo2_c.h"
-// @emits dScMgMCarlo2_c_InitResources
+// recovered name: dScMgMCarlo2_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgMCarlo2_c::InitResources - recovered from vtable slot identity */
 extern "C" void func_ov006_0210a534(void *c);
@@ -40,7 +40,7 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int dScMgMCarlo2_c_InitResources(char *c)
+extern "C" int func_ov006_020fa56c(char *c)
 {
     struct dScMgMCarlo2_c *self = (struct dScMgMCarlo2_c *)(void *)c;
     int handle;

--- a/src/func_ov006_020fa780.c
+++ b/src/func_ov006_020fa780.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020fa780
-// @emits dScMgPachinko_c_OnYoshiTryEat
+// recovered name: dScMgPachinko_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgPachinko_c_OnYoshiTryEat(int *t)
+int *func_ov006_020fa780(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_020fed58.c
+++ b/src/func_ov006_020fed58.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020fed58
-// @emits dScMgPachinko_c_OnYoshiTryEat_020fed58
+// recovered name: dScMgPachinko_c_OnYoshiTryEat_020fed58
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko_c::OnYoshiTryEat - recovered from vtable slot identity */
-void dScMgPachinko_c_OnYoshiTryEat_020fed58(char *c, int n){
+void func_ov006_020fed58(char *c, int n){
     *(int*)(c+0x5000+0xc10) = 0;
     if(n == 9){
         *(int*)(c+0xbc) = *(int*)(c+0xbc) + 1;

--- a/src/func_ov006_020fedc4.c
+++ b/src/func_ov006_020fedc4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_020fedc4
-// @emits dScMgPachinko_c_Render
+// recovered name: dScMgPachinko_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko_c::Render - recovered from vtable slot identity */
 void func_ov006_020fba48(void *c);
@@ -13,7 +13,7 @@ void func_ov006_020fae20(void *c);
 void func_ov006_020fc144(void *c);
 void func_ov006_020fa7b8(void *c);
 
-int dScMgPachinko_c_Render(void *c)
+int func_ov006_020fedc4(void *c)
 {
     func_ov006_020fba48(c);
     func_ov006_020fba28(c);

--- a/src/func_ov006_020ff444.c
+++ b/src/func_ov006_020ff444.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_020ff444
-// @emits dScMgPachinko2_c_OnYoshiTryEat
+// recovered name: dScMgPachinko2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko2_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgPachinko2_c_OnYoshiTryEat(int *t)
+int *func_ov006_020ff444(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_02103cbc.c
+++ b/src/func_ov006_02103cbc.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_02103cbc
-// @emits dScMgPachinko2_c_OnYoshiTryEat_02103cbc
+// recovered name: dScMgPachinko2_c_OnYoshiTryEat_02103cbc
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko2_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void FreeGfxSlotsById(int n);
-void dScMgPachinko2_c_OnYoshiTryEat_02103cbc(char *c, int n){
+void func_ov006_02103cbc(char *c, int n){
     *(int*)(c+0x5000+0x660) = 0;
     if(n == 0x10){
         *(int*)(c+0xbc) = *(int*)(c+0xbc) + 1;

--- a/src/func_ov006_02103d28.c
+++ b/src/func_ov006_02103d28.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_02103d28
-// @emits dScMgPachinko2_c_Render
+// recovered name: dScMgPachinko2_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPachinko2_c::Render - recovered from vtable slot identity */
-int dScMgPachinko2_c_Render(void* c){
+int func_ov006_02103d28(void* c){
   func_ov006_021004c0(c);
   func_ov006_02100488(c);
   func_ov006_02102624(c);

--- a/src/func_ov006_02103ed0.c
+++ b/src/func_ov006_02103ed0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_02103ed0
-// @emits dScMgPachinko2_c_InitResources
+// recovered name: dScMgPachinko2_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -18,7 +18,7 @@ extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgPachinko2_c_InitResources(void *arg0)
+int func_ov006_02103ed0(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_021042b0.c
+++ b/src/func_ov006_021042b0.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_021042b0
-// @emits dScMgPanel_c_OnYoshiTryEat
+// recovered name: dScMgPanel_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPanel_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgPanel_c_OnYoshiTryEat(int *t)
+int *func_ov006_021042b0(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_021071fc.c
+++ b/src/func_ov006_021071fc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_021071fc
-// @emits dScMgPanel_c_OnYoshiTryEat_021071fc
+// recovered name: dScMgPanel_c_OnYoshiTryEat_021071fc
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -12,7 +12,7 @@ extern void func_ov006_02106168(char *p);
 extern char *func_020beb68;
 extern unsigned char data_0209d454;
 
-void dScMgPanel_c_OnYoshiTryEat_021071fc(char *self, int flag)
+void func_ov006_021071fc(char *self, int flag)
 {
     char *p;
 

--- a/src/func_ov006_0210730c.c
+++ b/src/func_ov006_0210730c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210730c
-// @emits dScMgPanel_c_Render
+// recovered name: dScMgPanel_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgPanel_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void* a, int b, int c, int d);
-int dScMgPanel_c_Render(void* c){
+int func_ov006_0210730c(void* c){
   func_ov004_020b1e34(c, 0xe0, 0x14, 1);
   func_ov006_02104d44(c);
   func_ov006_02104d94(c);

--- a/src/func_ov006_02107358.cpp
+++ b/src/func_ov006_02107358.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_02107358
-// @emits dScMgPanel_c_Behavior
+// recovered name: dScMgPanel_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 struct Ent{ int a; int b; };
 extern Ent data_ov006_02142888[];
-int dScMgPanel_c_Behavior(char* c){
+int func_ov006_02107358(char* c){
   int idx=*(int*)(c+0x4000+0xca8);
   Ent* e=&data_ov006_02142888[idx];
   int adj=e->b;

--- a/src/func_ov006_021073b0.c
+++ b/src/func_ov006_021073b0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_021073b0
-// @emits dScMgPanel_c_InitResources
+// recovered name: dScMgPanel_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -22,7 +22,7 @@ extern void func_ov006_02106168(void *p);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgPanel_c_InitResources(void *arg0)
+int func_ov006_021073b0(void *arg0)
 {
     char *c = (char *)arg0;
     char *b;

--- a/src/func_ov006_02107920.cpp
+++ b/src/func_ov006_02107920.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_02107920
-// @emits dScMgRoulette_c_OnYoshiTryEat
+// recovered name: dScMgRoulette_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
@@ -11,8 +11,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgRoulette_c_OnYoshiTryEat(char *c);
-void *dScMgRoulette_c_OnYoshiTryEat(char *c) {
+void *func_ov006_02107920(char *c);
+void *func_ov006_02107920(char *c) {
     *(void ***)c = data_ov006_0213e39c;
     _ZN5ModelD1Ev(c + 0x536c);
     _ZN5ModelD1Ev(c + 0x531c);

--- a/src/func_ov006_021095cc.c
+++ b/src/func_ov006_021095cc.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgRoulette_c.h"
-// @emits dScMgRoulette_c_OnYoshiTryEat_021095cc
+// recovered name: dScMgRoulette_c_OnYoshiTryEat_021095cc
 /* recovered: renamed to Class_Method */
 /* dScMgRoulette_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void);
 extern int *func_020beb68;
 
-void dScMgRoulette_c_OnYoshiTryEat_021095cc(char *this)
+void func_ov006_021095cc(char *this)
 {
     struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)this;
     int i;

--- a/src/func_ov006_021096c8.c
+++ b/src/func_ov006_021096c8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_021096c8
-// @emits dScMgRoulette_c_OnTurnIntoEgg
+// recovered name: dScMgRoulette_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern int func_ov006_020c1718(char *c);
 extern void func_ov004_020b56c8(void);
 extern u16 data_ov004_020bf9e4;
 
-int dScMgRoulette_c_OnTurnIntoEgg(char *self)
+int func_ov006_021096c8(char *self)
 {
     switch (*(s16 *)(self + 0x53e6)) {
     case 5:

--- a/src/func_ov006_0210980c.c
+++ b/src/func_ov006_0210980c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_0210980c
-// @emits dScMgRoulette_c_CleanupResources
+// recovered name: dScMgRoulette_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgRoulette_c::CleanupResources - recovered from vtable slot identity */
-int dScMgRoulette_c_CleanupResources(char *c){
+int func_ov006_0210980c(char *c){
   func_ov006_0210858c(c + 0x530c);
   return 1;
 }

--- a/src/func_ov006_02109834.c
+++ b/src/func_ov006_02109834.c
@@ -4,10 +4,10 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgRoulette_c.h"
-// @emits dScMgRoulette_c_Render
+// recovered name: dScMgRoulette_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgRoulette_c::Render - recovered from vtable slot identity */
-/* dScMgRoulette_c_Render @ 0x02109834 (ov006, size 0x26c)
+/* func_ov006_02109834 @ 0x02109834 (ov006, size 0x26c)
  * Race minigame frame update: updates the racers back-to-front, plays the
  * countdown beep (volume ramps over the last 3 seconds), shows the winner
  * banner with per-rank colors, and refreshes the board.
@@ -30,7 +30,7 @@ extern void Camera_UpdateMatrices(char *);
 extern void func_ov006_020c0aa8(char *);
 extern void func_ov006_020c1804(char *);
 
-int dScMgRoulette_c_Render(char *c)
+int func_ov006_02109834(char *c)
 {
     struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)c;
     func_ov004_020b1bc8(c, 0xc, 0xc, 0);

--- a/src/func_ov006_0210a194.cpp
+++ b/src/func_ov006_0210a194.cpp
@@ -5,10 +5,10 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgRoulette_c.h"
-// @emits dScMgRoulette_c_InitResources
+// recovered name: dScMgRoulette_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgRoulette_c::InitResources - recovered from vtable slot identity */
-/* dScMgRoulette_c_InitResources @ 0x0210a194 (ov006, size 0x26c)
+/* func_ov006_0210a194 @ 0x0210a194 (ov006, size 0x26c)
  * Minigame dual-screen graphics init: sets both sub BG layers, loads the
  * BG tiles/maps/palette and the shared OBJ tiles/palettes for both engines,
  * then initializes the board, cursor and slider objects.
@@ -50,7 +50,7 @@ extern void _ZN3GXS11LoadOBJPlttEPKvjj(void *, unsigned int, unsigned int);
 extern void func_ov006_020c0aa8(char *);
 extern int func_ov006_020c1a88(char *);
 
-int dScMgRoulette_c_InitResources(char *c)
+int func_ov006_0210a194(char *c)
 {
     struct dScMgRoulette_c *self = (struct dScMgRoulette_c *)(void *)c;
     void *f8, *f7, *f6, *f5;

--- a/src/func_ov006_0210a4e8.cpp
+++ b/src/func_ov006_0210a4e8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210a4e8
-// @emits dScMgSingle3DBase_c_OnYoshiTryEat
+// recovered name: dScMgSingle3DBase_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* dScMgSingle3DBase_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
@@ -9,7 +9,7 @@ extern int func_ov004_020b29c0(void*);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void*,void*);
 extern int data_ov006_0213e448[];
 extern void* data_020a0eac[];
-int dScMgSingle3DBase_c_OnYoshiTryEat(char* c){
+int func_ov006_0210a4e8(char* c){
   *(int*)c=(int)data_ov006_0213e448;
   _ZN8Particle10SysTrackerD1Ev(c+0x471c);
   func_ov004_020b29c0(c);

--- a/src/func_ov006_0210a600.c
+++ b/src/func_ov006_0210a600.c
@@ -1,8 +1,8 @@
 // @symbol func_ov006_0210a600
-// @emits dScMgFlower_c_OnHitByCannonBlastedChar
+// recovered name: dScMgFlower_c_OnHitByCannonBlastedChar
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
-int dScMgFlower_c_OnHitByCannonBlastedChar(void)
+int func_ov006_0210a600(void)
 {
     return 1;
 }

--- a/src/func_ov006_0210a608.c
+++ b/src/func_ov006_0210a608.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210a608
-// @emits dScMgFlower_c_AfterCleanupResources
+// recovered name: dScMgFlower_c_AfterCleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::AfterCleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020b0840(int a, int b);
-void dScMgFlower_c_AfterCleanupResources(int a, int b) {
+void func_ov006_0210a608(int a, int b) {
     if (b == 2) {
         *(volatile int*)0x40004c8 = 0x296a5800;
         *(volatile int*)0x40004cc = 0x7fff;

--- a/src/func_ov006_0210a664.c
+++ b/src/func_ov006_0210a664.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_0210a664
-// @emits dScMgFlower_c_BeforeRender
+// recovered name: dScMgFlower_c_BeforeRender
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Particle.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ struct Scene;
 
 extern Bool func_ov004_020b04f4(struct Scene* self);
 
-Bool dScMgFlower_c_BeforeRender(struct Scene* self)
+Bool func_ov006_0210a664(struct Scene* self)
 {
     if (!func_ov004_020b04f4(self))
         return 0;

--- a/src/func_ov006_0210a698.cpp
+++ b/src/func_ov006_0210a698.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210a698
-// @emits dScMgFlower_c_BeforeBehavior
+// recovered name: dScMgFlower_c_BeforeBehavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 extern unsigned int data_020a0db0;
 int _ZN8Particle10SysTracker6UpdateEv(void*);
-int dScMgFlower_c_BeforeBehavior(void* c){
+int func_ov006_0210a698(void* c){
   if(func_ov004_020b0620(c)==0) return 0;
   if(data_020a0db0 & 1)
     _ZN8Particle10SysTracker6UpdateEv((char*)c+0x471c);

--- a/src/func_ov006_0210a6e4.cpp
+++ b/src/func_ov006_0210a6e4.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov006_0210a6e4
-// @emits dScMgFlower_c_AfterInitResources
+// recovered name: dScMgFlower_c_AfterInitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::AfterInitResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN8Particle10SysTracker10InitialiseEv(void*);
-int dScMgFlower_c_AfterInitResources(void* c){
+int func_ov006_0210a6e4(void* c){
   func_ov004_020b08f0(c);
   return _ZN8Particle10SysTracker10InitialiseEv((char*)c+0x471c);
 }

--- a/src/func_ov006_0210a900.cpp
+++ b/src/func_ov006_0210a900.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210a900
-// @emits dScMgSlot1_c_OnYoshiTryEat
+// recovered name: dScMgSlot1_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 struct Heap;
 namespace Memory { void Deallocate(void* p, Heap* h); }
 extern Heap* data_020a0eac;
-extern "C" void* dScMgSlot1_c_OnYoshiTryEat(char* c) {
+extern "C" void* func_ov006_0210a900(char* c) {
     *(void**)c = &data_ov006_0213eb40;
     *(void**)(c + 0x4660) = &data_ov006_0213e5d4;
     *(void**)(c + 0x4660) = (void*)&func_020ad494;

--- a/src/func_ov006_0210a9a8.cpp
+++ b/src/func_ov006_0210a9a8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210a9a8
-// @emits dScMgSlot3_c_OnYoshiTryEat
+// recovered name: dScMgSlot3_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,8 +9,8 @@ extern "C" {
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgSlot3_c_OnYoshiTryEat(char *c);
-void *dScMgSlot3_c_OnYoshiTryEat(char *c) {
+void *func_ov006_0210a9a8(char *c);
+void *func_ov006_0210a9a8(char *c) {
     *(void ***)c = data_ov006_0213eaa8;
     func_ov006_020c21e4(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_0210aa10.c
+++ b/src/func_ov006_0210aa10.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210aa10
-// @emits dScMgSlot3_c_OnAimedAtWithEggReturnVec
+// recovered name: dScMgSlot3_c_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 
-void dScMgSlot3_c_OnAimedAtWithEggReturnVec(void* a)
+void func_ov006_0210aa10(void* a)
 {
     *(volatile unsigned short*)0x400000A = (*(volatile unsigned short*)0x400000A & 0x43) | 0x1118;
     func_ov004_020aeed8(a);

--- a/src/func_ov006_0210aa3c.c
+++ b/src/func_ov006_0210aa3c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210aa3c
-// @emits dScMgSlot3_c_OnAimedAtWithEgg
+// recovered name: dScMgSlot3_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 
-void dScMgSlot3_c_OnAimedAtWithEgg(void* a)
+void func_ov006_0210aa3c(void* a)
 {
     *(volatile unsigned short*)0x400000A = (*(volatile unsigned short*)0x400000A & 0x43) | 0x1000;
     func_ov004_020af094(a);

--- a/src/func_ov006_0210aa60.cpp
+++ b/src/func_ov006_0210aa60.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210aa60
-// @emits dScMgSlot3_c_AfterClsn
+// recovered name: dScMgSlot3_c_AfterClsn
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -16,7 +16,7 @@ extern "C" {
 
 extern unsigned char data_0209d45c;
 
-extern "C" void dScMgSlot3_c_AfterClsn(void)
+extern "C" void func_ov006_0210aa60(void)
 {
     int idx;
 

--- a/src/func_ov006_0210b314.c
+++ b/src/func_ov006_0210b314.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_0210b314
-// @emits dScMgSlot3_c_OnYoshiTryEat_0210b314
+// recovered name: dScMgSlot3_c_OnYoshiTryEat_0210b314
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern void func_02012790(unsigned int id);
 
 #pragma opt_strength_reduction off
 
-void dScMgSlot3_c_OnYoshiTryEat_0210b314(char *c, int mode)
+void func_ov006_0210b314(char *c, int mode)
 {
     if (mode == 3 || mode == 0x12) {
         *(int *)(c + 0xa8) = 0xc;

--- a/src/func_ov006_0210b648.c
+++ b/src/func_ov006_0210b648.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgSlot3_c.h"
-// @emits dScMgSlot3_c_Render
+// recovered name: dScMgSlot3_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgSlot3_c::Render - recovered from vtable slot identity */
 extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(int b, void *attr, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9);
@@ -22,7 +22,7 @@ extern char *data_ov006_0213e5ec[];
 
 #pragma opt_strength_reduction off
 
-int dScMgSlot3_c_Render(char *c)
+int func_ov006_0210b648(char *c)
 {
     struct dScMgSlot3_c *self = (struct dScMgSlot3_c *)(void *)c;
     int i, j;

--- a/src/func_ov006_0210bcb0.cpp
+++ b/src/func_ov006_0210bcb0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210bcb0
-// @emits dScMgSlot3_c_Behavior
+// recovered name: dScMgSlot3_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -25,7 +25,7 @@ extern unsigned char data_0209d45c;
 
 extern "C" int RandomIntInternal(int *seed);
 
-extern "C" int dScMgSlot3_c_Behavior(Obj *self) {
+extern "C" int func_ov006_0210bcb0(Obj *self) {
     int i;
     unsigned char t;
 

--- a/src/func_ov006_0210bdb0.cpp
+++ b/src/func_ov006_0210bdb0.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_0210bdb0
-// @emits dScMgSlot3_c_InitResources
+// recovered name: dScMgSlot3_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -50,7 +50,7 @@ struct Obj {
     virtual void m48(int a);
 };
 
-extern "C" int dScMgSlot3_c_InitResources(void *arg0)
+extern "C" int func_ov006_0210bdb0(void *arg0)
 {
     char *c = (char *)arg0;
 

--- a/src/func_ov006_0210c4b8.c
+++ b/src/func_ov006_0210c4b8.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210c4b8
-// @emits dScMgSlot1_c_OnHitFromUnderneath
+// recovered name: dScMgSlot1_c_OnHitFromUnderneath
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot1_c::OnHitFromUnderneath - recovered from vtable slot identity */
 extern void func_ov004_020af04c(void* self);
-void dScMgSlot1_c_OnHitFromUnderneath(void* c) {
+void func_ov006_0210c4b8(void* c) {
     func_ov004_020af04c(c);
     SetSubBg1Offset(0x100, 0);
 }

--- a/src/func_ov006_0210c4dc.c
+++ b/src/func_ov006_0210c4dc.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0210c4dc
-// @emits dScMgSlot1_c_OnHitByMegaChar
+// recovered name: dScMgSlot1_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSlot1_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void func_ov004_020af27c(void* c);
-void dScMgSlot1_c_OnHitByMegaChar(void* c) {
+void func_ov006_0210c4dc(void* c) {
     SetSubBg1Offset(0, 0);
     func_ov004_020af27c(c);
 }

--- a/src/func_ov006_0210c674.c
+++ b/src/func_ov006_0210c674.c
@@ -3,10 +3,10 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgSlot1_c.h"
-// @emits dScMgSlot1_c_OnYoshiTryEat_0210c674
+// recovered name: dScMgSlot1_c_OnYoshiTryEat_0210c674
 /* recovered: renamed to Class_Method */
 /* dScMgSlot1_c::OnYoshiTryEat - recovered from vtable slot identity */
-void dScMgSlot1_c_OnYoshiTryEat_0210c674(char* c, int i){
+void func_ov006_0210c674(char* c, int i){
     struct dScMgSlot1_c *self = (struct dScMgSlot1_c *)(void *)c;
   if(i == 4){
     self->unk_4706 = self->unk_4709;

--- a/src/func_ov006_0210d1fc.cpp
+++ b/src/func_ov006_0210d1fc.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_0210d1fc
-// @emits dScMgSlot1_c_InitResources
+// recovered name: dScMgSlot1_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -55,7 +55,7 @@ struct Obj {
     virtual void m48(int a);   /* vtable offset 0x48 */
 };
 
-extern "C" int dScMgSlot1_c_InitResources(void *arg0)
+extern "C" int func_ov006_0210d1fc(void *arg0)
 {
     char *c = (char *)arg0;
     volatile unsigned short fill;

--- a/src/func_ov006_0210d7e0.cpp
+++ b/src/func_ov006_0210d7e0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0210d7e0
-// @emits dScMgSmartball_c_OnYoshiTryEat
+// recovered name: dScMgSmartball_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" void NullDestructor_0203d47c(void);
 extern "C" void* data_020a0eac;
 struct Heap;
 namespace Memory { void Deallocate(void*, Heap*); }
-extern "C" void* dScMgSmartball_c_OnYoshiTryEat(void* c) {
+extern "C" void* func_ov006_0210d7e0(void* c) {
     *(int**)c = &data_ov006_0213eefc;
     __destroy_arr((char*)c + 0x599c, 0x40, 0x24, (void*)&func_ov006_0210d894);
     __destroy_arr((char*)c + 0x48d4, 0x10, 8, (void*)&NullDestructor_0203d47c);

--- a/src/func_ov006_021147ac.c
+++ b/src/func_ov006_021147ac.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_021147ac
-// @emits dScMgSmartball_c_OnPushed
+// recovered name: dScMgSmartball_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSmartball_c::OnPushed - recovered from vtable slot identity */
-int dScMgSmartball_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }
+int func_ov006_021147ac(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_02118488.c
+++ b/src/func_ov006_02118488.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_02118488
-// @emits dScMgSmartball_c_Behavior
+// recovered name: dScMgSmartball_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -15,7 +15,7 @@ extern unsigned char data_020a0e40;
 extern unsigned char data_020a0de8[];
 extern unsigned char data_020a0de9[];
 
-int dScMgSmartball_c_Behavior(void* arg)
+int func_ov006_02118488(void* arg)
 {
     char* c = (char*)arg;
     int vec[3];

--- a/src/func_ov006_02118a8c.cpp
+++ b/src/func_ov006_02118a8c.cpp
@@ -1,13 +1,13 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_02118a8c
-// @emits dScMgSmartball_c_OnYoshiTryEat_02118a8c
+// recovered name: dScMgSmartball_c_OnYoshiTryEat_02118a8c
 /* recovered: renamed to Class_Method */
 /* dScMgSmartball_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
 void func_ov006_02115b0c(void);
 void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void* p, u16 a, u16 b, u16 c, u16 d);
-void dScMgSmartball_c_OnYoshiTryEat_02118a8c(void){
+void func_ov006_02118a8c(void){
   func_ov006_02115b0c();
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4000050, 0, 0x18, 4, 0xa);
   _ZN3G2x13SetBlendAlphaEPVttttt((volatile void*)0x4001050, 0, 0x18, 4, 0xa);

--- a/src/func_ov006_02118ae4.c
+++ b/src/func_ov006_02118ae4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_02118ae4
-// @emits dScMgSmartball_c_Kill
+// recovered name: dScMgSmartball_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern unsigned int LoadCompressedFileAt(int fileID, void *target);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454[];
 
-void dScMgSmartball_c_Kill(void)
+void func_ov006_02118ae4(void)
 {
     int f;
     *(volatile unsigned short *)0x400100a = (*(volatile unsigned short *)0x400100a & 0x43) | 4;

--- a/src/func_ov006_0211944c.c
+++ b/src/func_ov006_0211944c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_0211944c
-// @emits dScMgSmartball_c_AfterCleanupResources
+// recovered name: dScMgSmartball_c_AfterCleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern void __destroy_arr(void *p, int a, int b, void *cb);
 extern void NullDestructor_0203d47c(void);
 extern void func_ov004_020b0840(char *c, int arg);
 
-void dScMgSmartball_c_AfterCleanupResources(char *c, int mode)
+void func_ov006_0211944c(char *c, int mode)
 {
     if (mode != 2)
         return;

--- a/src/func_ov006_02119958.cpp
+++ b/src/func_ov006_02119958.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_02119958
-// @emits dScMgSound_c_OnYoshiTryEat
+// recovered name: dScMgSound_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,8 +9,8 @@ extern "C" {
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgSound_c_OnYoshiTryEat(char *c);
-void *dScMgSound_c_OnYoshiTryEat(char *c) {
+void *func_ov006_02119958(char *c);
+void *func_ov006_02119958(char *c) {
     *(void ***)c = data_ov006_0213f844;
     func_ov006_020c3288(c + 0x4f38);
     *(void ***)c = data_ov006_0213e448;

--- a/src/func_ov006_0211c5b8.c
+++ b/src/func_ov006_0211c5b8.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_0211c5b8
-// @emits dScMgSound_c_Virtual50
+// recovered name: dScMgSound_c_Virtual50
 /* recovered: renamed to Class_Method */
 /* dScMgSound_c::Virtual50 - recovered from vtable slot identity */
 extern void func_ov006_020c2594(void *c);
 
-void dScMgSound_c_Virtual50(char *c)
+void func_ov006_0211c5b8(char *c)
 {
     func_ov006_020c2594(c + 0x4f38);
 }

--- a/src/func_ov006_0211c5d0.c
+++ b/src/func_ov006_0211c5d0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_0211c5d0
-// @emits dScMgSound_c_OnYoshiTryEat_0211c5d0
+// recovered name: dScMgSound_c_OnYoshiTryEat_0211c5d0
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@ extern void func_ov006_0211c478(int self);
 extern void func_ov006_0211c080(int self);
 
 
-void dScMgSound_c_OnYoshiTryEat_0211c5d0(int self, int r1)
+void func_ov006_0211c5d0(int self, int r1)
 {
     int *p;
     int *q;

--- a/src/func_ov006_0211c6c4.c
+++ b/src/func_ov006_0211c6c4.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0211c6c4
-// @emits dScMgSound_c_Render
+// recovered name: dScMgSound_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSound_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void* c, int a, int b, int d);
-int dScMgSound_c_Render(char* c) {
+int func_ov006_0211c6c4(char* c) {
     func_ov004_020b1e34(c, 0xe0, 0x14, 1);
     func_ov006_02119c74(c);
     func_ov006_02119bdc(c);

--- a/src/func_ov006_0211c720.c
+++ b/src/func_ov006_0211c720.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov006_0211c720
-// @emits dScMgSound_c_Behavior
+// recovered name: dScMgSound_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSound_c::Behavior - recovered from vtable slot identity */
-/* dScMgSound_c_Behavior @ 0x0211c720 (ov006, size 0x264)
+/* func_ov006_0211c720 @ 0x0211c720 (ov006, size 0x264)
  * Slot-machine style minigame state machine (state at +0x5608):
  * 0=init, 1=intro countdown (+0x5618), 2=result countdown (+0x5616) with
  * win/lose handling and 9999-capped win counter, 3=retry countdown.
@@ -15,7 +15,7 @@ extern char *data_ov004_020beb68;
 extern void FreeGfxSlotsById(int);
 extern void func_ov006_020c2594(char *);
 
-int dScMgSound_c_Behavior(char *c)
+int func_ov006_0211c720(char *c)
 {
     switch (*(int *)(c + 0x5608)) {
     case 0:

--- a/src/func_ov006_0211c984.c
+++ b/src/func_ov006_0211c984.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_0211c984
-// @emits dScMgSound_c_InitResources
+// recovered name: dScMgSound_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -19,7 +19,7 @@ extern void func_ov006_0211c080(void *p);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgSound_c_InitResources(void *arg0)
+int func_ov006_0211c984(void *arg0)
 {
     u8 *r7 = (u8 *)arg0;
     int r6, r5, r4;

--- a/src/func_ov006_0211cbf4.c
+++ b/src/func_ov006_0211cbf4.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_0211cbf4
-// @emits dScMgTeresa_c_OnYoshiTryEat
+// recovered name: dScMgTeresa_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *dScMgTeresa_c_OnYoshiTryEat(int *t)
+int *func_ov006_0211cbf4(int *t)
 {
     t[0] = (int)VT;
     func_ov004_020b29c0(t);

--- a/src/func_ov006_02120238.c
+++ b/src/func_ov006_02120238.c
@@ -1,12 +1,12 @@
 // @symbol func_ov006_02120238
-// @emits dScMgTeresa_c_Virtual50
+// recovered name: dScMgTeresa_c_Virtual50
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::Virtual50 - recovered from vtable slot identity */
-/* dScMgTeresa_c_Virtual50 at 0x02120238 - thunk: FreeGfxSlotsById(8) */
+/* func_ov006_02120238 at 0x02120238 - thunk: FreeGfxSlotsById(8) */
 
 extern int FreeGfxSlotsById(int a);
 
-int dScMgTeresa_c_Virtual50(void)
+int func_ov006_02120238(void)
 {
     return FreeGfxSlotsById(8);
 }

--- a/src/func_ov006_02120248.cpp
+++ b/src/func_ov006_02120248.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_02120248
-// @emits dScMgTeresa_c_OnYoshiTryEat_02120248
+// recovered name: dScMgTeresa_c_OnYoshiTryEat_02120248
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern "C" {
@@ -17,7 +17,7 @@ void Deallocate(void* ptr);
 }
 struct G2S { static char* GetBG0CharPtr(); };
 
-extern "C" void dScMgTeresa_c_OnYoshiTryEat_02120248(char* self, int reset)
+extern "C" void func_ov006_02120248(char* self, int reset)
 {
     volatile unsigned short val;
     if (reset == 0) {

--- a/src/func_ov006_02120348.c
+++ b/src/func_ov006_02120348.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_02120348
-// @emits dScMgTeresa_c_Render
+// recovered name: dScMgTeresa_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::Render - recovered from vtable slot identity */
 extern void func_ov004_020b1e34(void*, int, int, int);
-int dScMgTeresa_c_Render(void* c){
+int func_ov006_02120348(void* c){
   func_ov004_020b1e34(c, 0xe0, 0x14, 1);
   func_ov006_0211ddcc(c);
   func_ov006_0211e29c(c);

--- a/src/func_ov006_021203ac.cpp
+++ b/src/func_ov006_021203ac.cpp
@@ -2,14 +2,14 @@
 // @symbol func_ov006_021203ac
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTeresa_c.h"
-// @emits dScMgTeresa_c_Behavior
+// recovered name: dScMgTeresa_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgTeresa_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
 struct Entry { PMF pmf; };
 extern Entry data_ov006_02142eb0[];
 extern "C" int func_ov006_0211e4e0(C* c);
-extern "C" int dScMgTeresa_c_Behavior(C* c) {
+extern "C" int func_ov006_021203ac(C* c) {
     struct dScMgTeresa_c *self = (struct dScMgTeresa_c *)(void *)c;
     (c->*data_ov006_02142eb0[ self->unk_4be8 ].pmf)();
     func_ov006_0211e4e0(c);

--- a/src/func_ov006_021203fc.c
+++ b/src/func_ov006_021203fc.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_021203fc
-// @emits dScMgTeresa_c_InitResources
+// recovered name: dScMgTeresa_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -19,7 +19,7 @@ extern void _ZN3GXS10LoadBGPlttEPKvjj(const void *p, u32 a, u32 b);
 extern void _ZN3GXS11LoadOBJPlttEPKvjj(const void *p, u32 a, u32 b);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
-int dScMgTeresa_c_InitResources(char *self)
+int func_ov006_021203fc(char *self)
 {
   void *f1;
   void *f2;

--- a/src/func_ov006_02120880.cpp
+++ b/src/func_ov006_02120880.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_02120880
-// @emits dScMgTrampoline_c_OnYoshiTryEat
+// recovered name: dScMgTrampoline_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" int data_020a0eac;
 extern "C" void __destroy_arr(void *p, int a, int b, void (*fn)());
 extern "C" void _ZN8Particle10SysTrackerD1Ev(void *p);
 
-extern "C" void *dScMgTrampoline_c_OnYoshiTryEat(char *thiz)
+extern "C" void *func_ov006_02120880(char *thiz)
 {
     *(int**)thiz = &data_ov006_0213fb34;
     __destroy_arr(thiz + 0x5cd0, 5, 0x24, &func_ov006_02120938);

--- a/src/func_ov006_0212101c.c
+++ b/src/func_ov006_0212101c.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_0212101c
-// @emits dScMgTrampoline_c_OnAttacked2
+// recovered name: dScMgTrampoline_c_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnAttacked2 - recovered from vtable slot identity */
 typedef struct UnkObj UnkObj;
@@ -20,7 +20,7 @@ void func_02012718(void* a, int b);
 int func_02054d88(void);
 void MultiStore16(u16 val, void* dst, int nbytes);
 
-int dScMgTrampoline_c_OnAttacked2(char* self)
+int func_ov006_0212101c(char* self)
 {
     volatile u16 z;
     Vec2s v1;

--- a/src/func_ov006_021211bc.c
+++ b/src/func_ov006_021211bc.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_021211bc
-// @emits dScMgTrampoline_c_OnPushed
+// recovered name: dScMgTrampoline_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnPushed - recovered from vtable slot identity */
-int dScMgTrampoline_c_OnPushed(void *t) { return func_ov006_020e6e54(t) != 0; }
+int func_ov006_021211bc(void *t) { return func_ov006_020e6e54(t) != 0; }

--- a/src/func_ov006_021211e0.cpp
+++ b/src/func_ov006_021211e0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_021211e0
-// @emits dScMgTrampoline_c_OnKicked
+// recovered name: dScMgTrampoline_c_OnKicked
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnKicked - recovered from vtable slot identity */
 extern "C" {
@@ -10,7 +10,7 @@ int func_ov004_020b04c0(void);
 }
 extern "C" unsigned char data_0209d45c;
 
-extern "C" int dScMgTrampoline_c_OnKicked(char* self)
+extern "C" int func_ov006_021211e0(char* self)
 {
     if (!func_ov006_020e6e78(self))
         return 0;

--- a/src/func_ov006_021212e0.c
+++ b/src/func_ov006_021212e0.c
@@ -1,9 +1,9 @@
 // @symbol func_ov006_021212e0
-// @emits dScMgTrampoline_c_CleanupResources
+// recovered name: dScMgTrampoline_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::CleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void *);
-int dScMgTrampoline_c_CleanupResources(void *t)
+int func_ov006_021212e0(void *t)
 {
     func_ov004_020ad90c(t);
     return 1;

--- a/src/func_ov006_021212fc.c
+++ b/src/func_ov006_021212fc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_021212fc
-// @emits dScMgTrampoline_c_Render
+// recovered name: dScMgTrampoline_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern int RenderOamMainScreen(int a0, int a1, int a2, int a3, int a4);
 extern void func_ov004_020afdd0(void* a0, int a1, int a2, int a3, int a4);
 
 
-int dScMgTrampoline_c_Render(int self)
+int func_ov006_021212fc(int self)
 {
     int count;
     int a1v;

--- a/src/func_ov006_021214f8.cpp
+++ b/src/func_ov006_021214f8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_021214f8
-// @emits dScMgTrampoline_c_Behavior
+// recovered name: dScMgTrampoline_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -14,7 +14,7 @@ struct C {
 extern "C" {
 }
 
-extern "C" int dScMgTrampoline_c_Behavior(char *c)
+extern "C" int func_ov006_021214f8(char *c)
 {
     int saved = data_ov006_02140588;
     func_ov006_02120c40();

--- a/src/func_ov006_02121f70.c
+++ b/src/func_ov006_02121f70.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_02121f70
-// @emits dScMgTrampoline_c_OnTurnIntoEgg
+// recovered name: dScMgTrampoline_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int GetGameLanguage(void);
-int dScMgTrampoline_c_OnTurnIntoEgg(void)
+int func_ov006_02121f70(void)
 {
     func_ov006_020c8a9c(0, data_ov006_0213fb18[GetGameLanguage()]);
     return 1;

--- a/src/func_ov006_02121fa4.c
+++ b/src/func_ov006_02121fa4.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline_c.h"
-// @emits dScMgTrampoline_c_OnYoshiTryEat_02121fa4
+// recovered name: dScMgTrampoline_c_OnYoshiTryEat_02121fa4
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN3G2x13SetBlendAlphaEPVttttt(volatile void *reg,
@@ -16,7 +16,7 @@ extern void MultiStore16(unsigned short val, char *dst, int nbytes);
 extern volatile short data_020a0dbc[];
 extern int data_0209e650;
 
-void dScMgTrampoline_c_OnYoshiTryEat_02121fa4(char *o)
+void func_ov006_02121fa4(char *o)
 {
     struct dScMgTrampoline_c *self = (struct dScMgTrampoline_c *)(void *)o;
     volatile unsigned short fill;

--- a/src/func_ov006_02122198.cpp
+++ b/src/func_ov006_02122198.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline_c.h"
-// @emits dScMgTrampoline_c_InitResources
+// recovered name: dScMgTrampoline_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -39,7 +39,7 @@ struct Obj {
     virtual void m48(int a);
 };
 
-extern "C" int dScMgTrampoline_c_InitResources(char *base)
+extern "C" int func_ov006_02122198(char *base)
 {
     struct dScMgTrampoline_c *self = (struct dScMgTrampoline_c *)(void *)base;
     s32 fov;

--- a/src/func_ov006_021226b0.cpp
+++ b/src/func_ov006_021226b0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_021226b0
-// @emits dScMgTrampoline2_c_OnYoshiTryEat
+// recovered name: dScMgTrampoline2_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" int data_020a0eac;
 extern "C" void __destroy_arr(void *p, int a, int b, void (*fn)());
 extern "C" void _ZN8Particle10SysTrackerD1Ev(void *p);
 
-extern "C" void *dScMgTrampoline2_c_OnYoshiTryEat(char *thiz)
+extern "C" void *func_ov006_021226b0(char *thiz)
 {
     *(int**)thiz = &data_ov006_0213fc7c;
     __destroy_arr(thiz + 0x7ad0, 5, 0x24, &func_ov006_02120938);

--- a/src/func_ov006_02122f24.c
+++ b/src/func_ov006_02122f24.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_02122f24
-// @emits dScMgTrampoline2_c_OnAttacked2
+// recovered name: dScMgTrampoline2_c_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnAttacked2 - recovered from vtable slot identity */
 extern char* data_0209f5bc;
@@ -13,7 +13,7 @@ void func_02012718(void* a, int b);
 int func_02054d88(void);
 void MultiStore16(u16 val, char* dst, int nbytes);
 
-int dScMgTrampoline2_c_OnAttacked2(char* self)
+int func_ov006_02122f24(char* self)
 {
     u16 buf[5];
 

--- a/src/func_ov006_021230c4.c
+++ b/src/func_ov006_021230c4.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_021230c4
-// @emits dScMgTrampoline2_c_OnPushed
+// recovered name: dScMgTrampoline2_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnPushed - recovered from vtable slot identity */
-int dScMgTrampoline2_c_OnPushed(void *t) { return func_ov006_020e6e54(t) != 0; }
+int func_ov006_021230c4(void *t) { return func_ov006_020e6e54(t) != 0; }

--- a/src/func_ov006_021230e8.c
+++ b/src/func_ov006_021230e8.c
@@ -1,12 +1,12 @@
 // @symbol func_ov006_021230e8
-// @emits dScMgTrampoline2_c_OnKicked
+// recovered name: dScMgTrampoline2_c_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnKicked - recovered from vtable slot identity */
 extern unsigned char data_0209d45c[];
 
-int dScMgTrampoline2_c_OnKicked(void *thiz)
+int func_ov006_021230e8(void *thiz)
 {
     unsigned char *c = (unsigned char *)thiz;
     if (!func_ov006_020e6e78(c)) return 0;

--- a/src/func_ov006_0212318c.c
+++ b/src/func_ov006_0212318c.c
@@ -1,17 +1,17 @@
 // @symbol func_ov006_0212318c
-// @emits dScMgTrampoline2_c_CleanupResources
+// recovered name: dScMgTrampoline2_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::CleanupResources - recovered from vtable slot identity */
-/* dScMgTrampoline2_c_CleanupResources at 0x0212318c
+/* func_ov006_0212318c at 0x0212318c
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov006).
  */
 
 extern void func_ov004_020ad90c(void);
 
-int dScMgTrampoline2_c_CleanupResources(void)
+int func_ov006_0212318c(void)
 {
     func_ov006_020ceedc();
     func_ov004_020ad90c();

--- a/src/func_ov006_021231ac.c
+++ b/src/func_ov006_021231ac.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_021231ac
-// @emits dScMgTrampoline2_c_Render
+// recovered name: dScMgTrampoline2_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern void DrawOamSprite(void* a0, void* a1, int a2, void* a3);
 extern void RenderOamMainScreen(int a0, int a1, int a2, int a3, int a4);
 
 
-int dScMgTrampoline2_c_Render(char* self)
+int func_ov006_021231ac(char* self)
 {
     int m[3];
     int count;

--- a/src/func_ov006_02124298.c
+++ b/src/func_ov006_02124298.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_02124298
-// @emits dScMgTrampoline2_c_OnTurnIntoEgg
+// recovered name: dScMgTrampoline2_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int GetGameLanguage(void);
-int dScMgTrampoline2_c_OnTurnIntoEgg(void)
+int func_ov006_02124298(void)
 {
     func_ov006_020c8a9c(0, data_ov006_0213fc20[GetGameLanguage()]);
     return 1;

--- a/src/func_ov006_021242cc.cpp
+++ b/src/func_ov006_021242cc.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_021242cc
-// @emits dScMgTrampoline2_c_OnYoshiTryEat_021242cc
+// recovered name: dScMgTrampoline2_c_OnYoshiTryEat_021242cc
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -33,7 +33,7 @@ extern "C" void func_ov006_02124228(T *self);
 
 extern volatile s16 data_020a0dbc[];
 
-extern "C" void dScMgTrampoline2_c_OnYoshiTryEat_021242cc(T *self)
+extern "C" void func_ov006_021242cc(T *self)
 {
     _ZN3G2x13SetBlendAlphaEPVttttt((volatile void *)0x4000050, 1, 0x2e, 0x10, 0x10);
 


### PR DESCRIPTION
Each file in this batch carried a pair of annotations recording that it defined a different symbol than its filename:

```c
// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
```

**Nothing in the repo consumes either annotation** — no tool, no CI config, no doc mentions them — and the divergence quietly broke two things:

**`match.py` cannot verify these files at all.** Asked for the filename's symbol it reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns `MATCHING VERSIONS: none` for every one. Meanwhile `progress.py` counts them as matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING` hatch. **712 files — about 6% of `src/` — were being counted as matched progress while being unverifiable by the repo's own gate.**

**The ROM link cannot use them either.** Gap objects import a carved-out function by its `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every caller silently binding to address 0 rather than erroring.

`tools/reconcile_names.py` (PR #941) renames the emitted function to the `@symbol` name and replaces the now-redundant `@emits` line with `// recovered name: <name>`, so the recovered identity — usually from a vtable slot — is preserved in the file. Each file is byte-verified against the ROM before the edit is kept; anything that stops matching is reverted.

711 of 712 verified and are split across these batches. The holdout, `func_ov022_021123d0`, declares its own symbol with a conflicting signature and is left for a human. 699 of the 711 reproduce under `2004/b56`; 12 need a `1.2/base` override, recorded in `config/rombuild-versions.txt`.

**The opposite direction is deliberately not taken here.** Adopting the recovered names into `config/**/symbols.txt` is the better long-term move, but it changes the canonical symbol table and every reference to those names — a maintainer's call, not a build fix.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
