### PR TITLE
Make each file define the symbol its filename claims (167 files) [02/05]

### DIFF
--- a/src/func_02005418.c
+++ b/src/func_02005418.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_02005418
-// @emits dScBoot_c_Behavior
+// recovered name: dScBoot_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Message.h"
 #include "decl_SaveData.h"
@@ -32,7 +32,7 @@ extern void func_02012790(int a);
 
 #pragma opt_common_subs off
 
-int dScBoot_c_Behavior(void *arg0)
+int func_02005418(void *arg0)
 {
     char *c = (char *)arg0;
     u16 h58, h5a;

--- a/src/func_02005a58.c
+++ b/src/func_02005a58.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScBoot_c.h"
-// @emits dScBoot_c_InitResources
+// recovered name: dScBoot_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScBoot_c::InitResources - recovered from vtable slot identity */
 extern void _ZN2GX12SetBankForBGEt(unsigned short b);
@@ -25,7 +25,7 @@ extern char data_0208ee44;
 extern char data_0209f5e8;
 extern void func_0201a2f8(void);
 extern unsigned char data_0209f1e8;
-int dScBoot_c_InitResources(char* c)
+int func_02005a58(char* c)
 {
     struct dScBoot_c *self = (struct dScBoot_c *)(void *)c;
     _ZN2GX15DisableAllBanksEv();

--- a/src/func_02014a20.c
+++ b/src/func_02014a20.c
@@ -1,13 +1,13 @@
 // @symbol func_02014a20
-// @emits dCcAcPos_c_GetOwnerID
+// recovered name: dCcAcPos_c_GetOwnerID
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_MovingCylinderClsn.h"
 /* recovered: renamed to Class_Method */
 /* dCcAcPos_c::GetOwnerID - recovered from vtable slot identity */
-/* dCcAcPos_c_GetOwnerID @ 0x2014a20 (arm9) -- tail-call veneer to _ZN18MovingCylinderClsn10GetOwnerIDEv (0x201493c).
+/* func_02014a20 @ 0x2014a20 (arm9) -- tail-call veneer to _ZN18MovingCylinderClsn10GetOwnerIDEv (0x201493c).
  * ldr ip, [pc]; bx ip; .word 0x201493c
  */
 
-void dCcAcPos_c_GetOwnerID(void) {
+void func_02014a20(void) {
     _ZN18MovingCylinderClsn10GetOwnerIDEv();
 }

--- a/src/func_020171c8.cpp
+++ b/src/func_020171c8.cpp
@@ -1,7 +1,7 @@
 //cpp
 // @symbol func_020171c8
-// @emits dFdDummy_c_SetForwardTime
+// recovered name: dFdDummy_c_SetForwardTime
 /* recovered: renamed to Class_Method */
 /* dFdDummy_c::SetForwardTime - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void m(); };
-extern "C" void dFdDummy_c_SetForwardTime(Base *c){ *(int*)((char*)c+8)=0x1000; c->m(); }
+extern "C" void func_020171c8(Base *c){ *(int*)((char*)c+8)=0x1000; c->m(); }

--- a/src/func_020171f0.cpp
+++ b/src/func_020171f0.cpp
@@ -1,7 +1,7 @@
 //cpp
 // @symbol func_020171f0
-// @emits dFdDummy_c_SetBackwardTime
+// recovered name: dFdDummy_c_SetBackwardTime
 /* recovered: renamed to Class_Method */
 /* dFdDummy_c::SetBackwardTime - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(); };
-extern "C" void dFdDummy_c_SetBackwardTime(Base *c){ *(int*)((char*)c+8)=-0x1000; c->m(); }
+extern "C" void func_020171f0(Base *c){ *(int*)((char*)c+8)=-0x1000; c->m(); }

--- a/src/func_0201721c.c
+++ b/src/func_0201721c.c
@@ -1,13 +1,13 @@
 // @symbol func_0201721c
-// @emits dFdDummy_c_AdvanceFade
+// recovered name: dFdDummy_c_AdvanceFade
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Fader.h"
 /* recovered: renamed to Class_Method */
 /* dFdDummy_c::AdvanceFade - recovered from vtable slot identity */
-/* dFdDummy_c_AdvanceFade @ 0x201721c (arm9) -- tail-call veneer to _ZN5Fader13AdvanceInterpEv (0x20175e8).
+/* func_0201721c @ 0x201721c (arm9) -- tail-call veneer to _ZN5Fader13AdvanceInterpEv (0x20175e8).
  * ldr ip, [pc]; bx ip; .word 0x20175e8
  */
 
-void dFdDummy_c_AdvanceFade(void) {
+void func_0201721c(void) {
     _ZN5Fader13AdvanceInterpEv();
 }

--- a/src/func_0202ecfc.c
+++ b/src/func_0202ecfc.c
@@ -1,7 +1,7 @@
 // @symbol func_0202ecfc
-// @emits dWipe_c_SetToStart
+// recovered name: dWipe_c_SetToStart
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dWipe_c::SetToStart - recovered from vtable slot identity */
-void dWipe_c_SetToStart(void *t) { func_02017610(t); }
+void func_0202ecfc(void *t) { func_02017610(t); }

--- a/src/func_0202ed08.c
+++ b/src/func_0202ed08.c
@@ -1,13 +1,13 @@
 // @symbol func_0202ed08
-// @emits dWipe_c_SetToEnd
+// recovered name: dWipe_c_SetToEnd
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_FaderBrightness.h"
 /* recovered: renamed to Class_Method */
 /* dWipe_c::SetToEnd - recovered from vtable slot identity */
-/* dWipe_c_SetToEnd @ 0x202ed08 (arm9) -- tail-call veneer to _ZN15FaderBrightness8SetToEndEv (0x201761c).
+/* func_0202ed08 @ 0x202ed08 (arm9) -- tail-call veneer to _ZN15FaderBrightness8SetToEndEv (0x201761c).
  * ldr ip, [pc]; bx ip; .word 0x201761c
  */
 
-void dWipe_c_SetToEnd(void) {
+void func_0202ed08(void) {
     _ZN15FaderBrightness8SetToEndEv();
 }

--- a/src/func_0202ed7c.cpp
+++ b/src/func_0202ed7c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_0202ed7c
-// @emits dWipe_c_IsBetweenStartAndEnd
+// recovered name: dWipe_c_IsBetweenStartAndEnd
 /* recovered: renamed to Class_Method */
 /* dWipe_c::IsBetweenStartAndEnd - recovered from vtable slot identity */
 struct FaderBrightness {
@@ -17,7 +17,7 @@ struct FaderBrightness {
 
 extern "C" int _ZN15FaderBrightness20IsBetweenStartAndEndEv(struct FaderBrightness *thiz);
 
-extern "C" int dWipe_c_IsBetweenStartAndEnd(struct FaderBrightness *thiz)
+extern "C" int func_0202ed7c(struct FaderBrightness *thiz)
 {
     if (thiz->field_14 == 1)
         return _ZN15FaderBrightness20IsBetweenStartAndEndEv(thiz);

--- a/src/func_0202eddc.c
+++ b/src/func_0202eddc.c
@@ -1,9 +1,9 @@
 #include "types.h"
 // @symbol func_0202eddc
-// @emits dWipe_c_IsAtEnd
+// recovered name: dWipe_c_IsAtEnd
 /* recovered: renamed to Class_Method */
 /* dWipe_c::IsAtEnd - recovered from vtable slot identity */
-/* dWipe_c_IsAtEnd - IsAtEnd wrapper.
+/* func_0202eddc - IsAtEnd wrapper.
  * Attempt 5: use explicit early-return structure to get beq+bgt branch pattern.
  * ROM: beq -> ret1 block (add sp,#4; mov r0,#1; ldm; bx), bgt -> ret0 block.
  */
@@ -21,7 +21,7 @@ struct MyFader {
     s32 interpVal;  /* 0x1c */
 };
 
-int dWipe_c_IsAtEnd(struct MyFader* self)
+int func_0202eddc(struct MyFader* self)
 {
     int result;
     if (self->type == 1)

--- a/src/func_0202ee38.c
+++ b/src/func_0202ee38.c
@@ -1,9 +1,9 @@
 #include "types.h"
 // @symbol func_0202ee38
-// @emits dWipe_c_IsAtStart
+// recovered name: dWipe_c_IsAtStart
 /* recovered: renamed to Class_Method */
 /* dWipe_c::IsAtStart - recovered from vtable slot identity */
-/* dWipe_c_IsAtStart - IsAtStart wrapper.
+/* func_0202ee38 - IsAtStart wrapper.
  * Attempt 1: same goto pattern as func_0202eddc. ROM structure:
  * if unk14==1: call IsAtStart, return result.
  * else if unk10==0: goto ret1 (return 1)
@@ -25,7 +25,7 @@ struct MyFader {
     s32 interpVal;  /* 0x1c */
 };
 
-int dWipe_c_IsAtStart(struct MyFader* self)
+int func_0202ee38(struct MyFader* self)
 {
     int result;
     if (self->type == 1)

--- a/src/func_0202f428.c
+++ b/src/func_0202f428.c
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dWipe_c.h"
-// @emits dWipe_c_AdvanceFade
+// recovered name: dWipe_c_AdvanceFade
 /* recovered: renamed to Class_Method */
 /* dWipe_c::AdvanceFade - recovered from vtable slot identity */
 extern void _ZN3G2x18SetBlendBrightnessEPVtts(unsigned short *p, unsigned short a, int b);
 
-void dWipe_c_AdvanceFade(char *obj)
+void func_0202f428(char *obj)
 {
     struct dWipe_c *self = (struct dWipe_c *)(void *)obj;
     if (self->unk_014 == 1) {

--- a/src/func_0202f708.c
+++ b/src/func_0202f708.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_0202f708
-// @emits dWipe_c_SetForwardTime
+// recovered name: dWipe_c_SetForwardTime
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -30,7 +30,7 @@ extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(unsigned int irq, void (*handler)(void
 extern void _ZN3IRQ10EnableIRQsEj(unsigned int irq);
 
 
-int dWipe_c_SetForwardTime(struct MyFader *self, u32 frames)
+int func_0202f708(struct MyFader *self, u32 frames)
 {
     if (self->state == 0 || self->state == 2) {
         int t;

--- a/src/func_0202f928.c
+++ b/src/func_0202f928.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_0202f928
-// @emits dWipe_c_SetBackwardTime
+// recovered name: dWipe_c_SetBackwardTime
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -32,7 +32,7 @@ struct MyFader {
     u32 unk24;      /* 0x24 */
 };
 
-int dWipe_c_SetBackwardTime(struct MyFader *self, u32 param_1, u32 param_2)
+int func_0202f928(struct MyFader *self, u32 param_1, u32 param_2)
 {
     s32 type, unk10;
 

--- a/src/func_02034d9c.c
+++ b/src/func_02034d9c.c
@@ -1,8 +1,8 @@
 // @symbol func_02034d9c
-// @emits dScMB_c_Render
+// recovered name: dScMB_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMB_c::Render - recovered from vtable slot identity */
-int dScMB_c_Render(void)
+int func_02034d9c(void)
 {
     return 1;
 }

--- a/src/func_02034da4.c
+++ b/src/func_02034da4.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_02034da4
-// @emits dScMB_c_Behavior
+// recovered name: dScMB_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -14,7 +14,7 @@ extern void func_02012790(int x);
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMB_c_Behavior(void *arg0)
+int func_02034da4(void *arg0)
 {
     char *self = (char *)arg0;
 

--- a/src/func_0203506c.c
+++ b/src/func_0203506c.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_0203506c
-// @emits dScMB_c_InitResources
+// recovered name: dScMB_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 #include "decl_common.h"
@@ -18,7 +18,7 @@ extern u8 data_0209d4a8[];
 extern u8 data_0208ee44[];
 extern u8 func_0201a2f8[];
 
-int dScMB_c_InitResources(void *arg0)
+int func_0203506c(void *arg0)
 {
     void *self = arg0;
     volatile u16 sp4;

--- a/src/func_ov002_020af2b0.c
+++ b/src/func_ov002_020af2b0.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov002_020af2b0
-// @emits OneUpMushroom_OnTurnIntoEgg
+// recovered name: OneUpMushroom_OnTurnIntoEgg
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* da1up_c::OnTurnIntoEgg - recovered from vtable slot identity */
-/* OneUpMushroom_OnTurnIntoEgg at 0x020af2b0
+/* func_ov002_020af2b0 at 0x020af2b0
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
  */
@@ -16,7 +16,7 @@ extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, struct Vec* v);
 extern void _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 a, u32 b, struct Vec* v, struct Vector3_16* rot, int e, int f);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void* thiz);
 
-void OneUpMushroom_OnTurnIntoEgg(char* c, int arg1)
+void func_ov002_020af2b0(char* c, int arg1)
 {
     int t = *(int*)(c + 0x384);
     if (t == 0xb) {

--- a/src/func_ov002_020af3a0.c
+++ b/src/func_ov002_020af3a0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020af3a0
-// @emits OneUpMushroom_OnYoshiTryEat
+// recovered name: OneUpMushroom_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* da1up_c::OnYoshiTryEat - recovered from vtable slot identity */
-int OneUpMushroom_OnYoshiTryEat(void)
+int func_ov002_020af3a0(void)
 {
     return 4;
 }

--- a/src/func_ov002_020afa50.c
+++ b/src/func_ov002_020afa50.c
@@ -1,11 +1,11 @@
 // @symbol func_ov002_020afa50
-// @emits dCapEnemy_c_Kill
+// recovered name: dCapEnemy_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dCapEnemy_c::Kill - recovered from vtable slot identity */
 
-void dCapEnemy_c_Kill(char *self) {
+void func_ov002_020afa50(char *self) {
     *(short *)(int)(((long long)(int)(self + 0x8e))) += 0xc00;
     func_ov002_020afa6c(self);
 }

--- a/src/func_ov002_020b0600.c
+++ b/src/func_ov002_020b0600.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020b0600
-// @emits daBar_c_OnYoshiTryEat
+// recovered name: daBar_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daBar_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daBar_c_OnYoshiTryEat(int *t)
+int *func_ov002_020b0600(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b0644.c
+++ b/src/func_ov002_020b0644.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b0644
-// @emits daBar_c_CleanupResources
+// recovered name: daBar_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daBar_c::CleanupResources - recovered from vtable slot identity */
-int daBar_c_CleanupResources(void)
+int func_ov002_020b0644(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b064c.c
+++ b/src/func_ov002_020b064c.c
@@ -1,7 +1,7 @@
 // @symbol func_ov002_020b064c
-// @emits daBar_c_OnPendingDestroy
+// recovered name: daBar_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daBar_c::OnPendingDestroy - recovered from vtable slot identity */
-void daBar_c_OnPendingDestroy(void)
+void func_ov002_020b064c(void)
 {
 }

--- a/src/func_ov002_020b0650.c
+++ b/src/func_ov002_020b0650.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b0650
-// @emits daBar_c_Render
+// recovered name: daBar_c_Render
 /* recovered: renamed to Class_Method */
 /* daBar_c::Render - recovered from vtable slot identity */
-int daBar_c_Render(void)
+int func_ov002_020b0650(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b0658.cpp
+++ b/src/func_ov002_020b0658.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov002_020b0658
-// @emits daBar_c_Behavior
+// recovered name: daBar_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daBar_c::Behavior - recovered from vtable slot identity */
 extern "C" {
 extern int _ZN12CylinderClsn5ClearEv(void*);
 extern int _ZN12CylinderClsn6UpdateEv(void*);
-int daBar_c_Behavior(char* c){
+int func_ov002_020b0658(char* c){
   _ZN12CylinderClsn5ClearEv(c+0xd4);
   _ZN12CylinderClsn6UpdateEv(c+0xd4);
   return 1;

--- a/src/func_ov002_020b067c.c
+++ b/src/func_ov002_020b067c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov002_020b067c
-// @emits daBar_c_InitResources
+// recovered name: daBar_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daBar_c::InitResources - recovered from vtable slot identity */
 extern void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(char* c, int a, int b, int d, int e);
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(char* thiz, char* actor, int b, int d, unsigned int e, unsigned int f);
 
-int daBar_c_InitResources(char* c)
+int func_ov002_020b067c(char* c)
 {
     int r5 = (((*(int*)(c + 8) & 0xff) - 0xa) * 0xa) << 0xc;
     int half;

--- a/src/func_ov002_020b2150.cpp
+++ b/src/func_ov002_020b2150.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020b2150
-// @emits VirtualDoor_Kill
+// recovered name: VirtualDoor_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void*);
 extern int _ZNK12WithMeshClsn10IsOnGroundEv(void*);
-void VirtualDoor_Kill(char* c){
+void func_ov002_020b2150(char* c){
   func_ov002_020b13e0(c);
   if(_ZNK12WithMeshClsn8IsOnWallEv(c+0x1ac)) *(int*)(c+0x98)=0;
   if(_ZNK12WithMeshClsn10IsOnGroundEv(c+0x1ac)){

--- a/src/func_ov002_020b2a34.c
+++ b/src/func_ov002_020b2a34.c
@@ -1,11 +1,11 @@
 // @symbol func_ov002_020b2a34
-// @emits Coin_OnTurnIntoEgg
+// recovered name: Coin_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daCoin_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-void Coin_OnTurnIntoEgg(char* c, char* p)
+void func_ov002_020b2a34(char* c, char* p)
 {
     int state = *(int*)(c + 0x3a0);
     if (state == 1) {

--- a/src/func_ov002_020b2a90.c
+++ b/src/func_ov002_020b2a90.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b2a90
-// @emits Coin_OnYoshiTryEat
+// recovered name: Coin_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Coin_OnYoshiTryEat(void)
+int func_ov002_020b2a90(void)
 {
     return 4;
 }

--- a/src/func_ov002_020b32c8.c
+++ b/src/func_ov002_020b32c8.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020b32c8
-// @emits daObjAbuku_c_OnYoshiTryEat
+// recovered name: daObjAbuku_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjAbuku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjAbuku_c_OnYoshiTryEat(int *t)
+int *func_ov002_020b32c8(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020b33dc.cpp
+++ b/src/func_ov002_020b33dc.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020b33dc
-// @emits daObjAbuku_c_Behavior
+// recovered name: daObjAbuku_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -16,7 +16,7 @@ extern "C" void* _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Ca
 extern "C" void _ZN12CylinderClsn5ClearEv(char* cl);
 extern "C" void _ZN12CylinderClsn6UpdateEv(char* cl);
 
-extern "C" int daObjAbuku_c_Behavior(char* self)
+extern "C" int func_ov002_020b33dc(char* self)
 {
     *(short*)(((int)self + 0x10c)) += 0x400;
     int v = *(volatile unsigned short*)(self + 0x10c);

--- a/src/func_ov002_020b3518.cpp
+++ b/src/func_ov002_020b3518.cpp
@@ -2,12 +2,12 @@
 // @symbol func_ov002_020b3518
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjAbuku_c.h"
-// @emits daObjAbuku_c_InitResources
+// recovered name: daObjAbuku_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjAbuku_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void*, void*, int, int, unsigned int, unsigned int);
-int daObjAbuku_c_InitResources(char* c){
+int func_ov002_020b3518(char* c){
     struct daObjAbuku_c *self = (struct daObjAbuku_c *)(void *)c;
   _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c+0xd4, c, 0x96000, 0x96000, 0x100002, 0);
   self->unk_10e=0x12c;

--- a/src/func_ov002_020b36b4.cpp
+++ b/src/func_ov002_020b36b4.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov002_020b36b4
-// @emits BigBrickBlock_OnHitByMegaChar
+// recovered name: BigBrickBlock_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void BigBrickBlock_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov002_020b36b4(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov002_020b36dc.cpp
+++ b/src/func_ov002_020b36dc.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov002_020b36dc
-// @emits BigBrickBlock_OnKicked
+// recovered name: BigBrickBlock_OnKicked
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnKicked - recovered from vtable slot identity */
 struct State { int pad[2]; int field8; };
@@ -17,7 +17,7 @@ struct Base {
     virtual void m();
 };
 
-extern "C" void BigBrickBlock_OnKicked(Base *self, struct State *st)
+extern "C" void func_ov002_020b36dc(Base *self, struct State *st)
 {
     int b1 = (int)(*(u16 *)((char *)self + 0xc) == 0x2e);
     int r1;

--- a/src/func_ov002_020b3788.cpp
+++ b/src/func_ov002_020b3788.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov002_020b3788
-// @emits BigBrickBlock_OnAttacked2
+// recovered name: BigBrickBlock_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnAttacked2 - recovered from vtable slot identity */
 struct Sub { virtual void v0(); };
 extern "C" {
-void BigBrickBlock_OnAttacked2(char *c, char *arg1){
+void func_ov002_020b3788(char *c, char *arg1){
   struct Vt { int dummy[0x7c/4]; void (*fn)(void*); };
   int b = (*(unsigned short*)(c+0xc) == 0x11);
   if (b) {

--- a/src/func_ov002_020b37ec.c
+++ b/src/func_ov002_020b37ec.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b37ec
-// @emits BigBrickBlock_OnAttacked1
+// recovered name: BigBrickBlock_OnAttacked1
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnAttacked1 - recovered from vtable slot identity */
-void BigBrickBlock_OnAttacked1(void *c) {
+void func_ov002_020b37ec(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int b = (int)(v == 0x11);
     if (b) return;

--- a/src/func_ov002_020b382c.cpp
+++ b/src/func_ov002_020b382c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020b382c
-// @emits BigBrickBlock_OnGroundPounded
+// recovered name: BigBrickBlock_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjBlockL_c::OnGroundPounded - recovered from vtable slot identity */
 struct Arg { char pad[8]; int f8; };
@@ -14,7 +14,7 @@ struct Obj {
   virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27();
   virtual void v28(); virtual void v29(); virtual void v30(); virtual void target();
 };
-extern "C" void BigBrickBlock_OnGroundPounded(Obj* o, Arg* a) {
+extern "C" void func_ov002_020b382c(Obj* o, Arg* a) {
   if (a->f8 == 3) return;
   int b = (*(unsigned short*)((char*)o+0xc) == 0x11);
   if (b != 0) {

--- a/src/func_ov002_020b38a0.c
+++ b/src/func_ov002_020b38a0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov002_020b38a0
-// @emits BigBrickBlock_Kill
+// recovered name: BigBrickBlock_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -14,7 +14,7 @@ extern void _ZN5Sound9PlayBank3EjRK7Vector3(u32 id, const struct Vector3 *v);
 extern void _ZN5Actor13SpawnSoundObjEj(char *thiz, u32 a);
 extern void _ZN9ActorBase18MarkForDestructionEv(char *thiz);
 
-void BigBrickBlock_Kill(char *c)
+void func_ov002_020b38a0(char *c)
 {
     struct Vector3 tmp[4];
     u32 kind;

--- a/src/func_ov002_020b4250.cpp
+++ b/src/func_ov002_020b4250.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov002_020b4250
-// @emits BigBrickBlock_AfterClsn
+// recovered name: BigBrickBlock_AfterClsn
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBlockL_c::AfterClsn - recovered from vtable slot identity */
 struct V3{int x,y,z;};
 extern "C" {
 void func_ov002_020b41b8(struct V3*, char*);
 int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, struct V3*, void*, int, int);
-void BigBrickBlock_AfterClsn(char* c){
+void func_ov002_020b4250(char* c){
   struct V3 v;
   func_ov002_020b41b8(&v, c);
   _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(0x115, 0, &v, 0, *(signed char*)(c+0xcc), -1);

--- a/src/func_ov002_020b4fc4.c
+++ b/src/func_ov002_020b4fc4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b4fc4
-// @emits QuestionSwitch_OnGroundPounded
+// recovered name: QuestionSwitch_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjHatenaSwitch_c::OnGroundPounded - recovered from vtable slot identity */
-void QuestionSwitch_OnGroundPounded(char *p)
+void func_ov002_020b4fc4(char *p)
 {
     p[1816] = 0;
 }

--- a/src/func_ov002_020b599c.c
+++ b/src/func_ov002_020b599c.c
@@ -1,7 +1,7 @@
 // @symbol func_ov002_020b599c
-// @emits BlueFlame_OnTurnIntoEgg
+// recovered name: BlueFlame_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daObjFire_c::OnTurnIntoEgg - recovered from vtable slot identity */
-void BlueFlame_OnTurnIntoEgg(void)
+void func_ov002_020b599c(void)
 {
 }

--- a/src/func_ov002_020b59a0.c
+++ b/src/func_ov002_020b59a0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b59a0
-// @emits BlueFlame_OnYoshiTryEat
+// recovered name: BlueFlame_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daObjFire_c::OnYoshiTryEat - recovered from vtable slot identity */
-int BlueFlame_OnYoshiTryEat(void)
+int func_ov002_020b59a0(void)
 {
     return 5;
 }

--- a/src/func_ov002_020b6d4c.c
+++ b/src/func_ov002_020b6d4c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov002_020b6d4c
-// @emits daObjLava_c_OnYoshiTryEat
+// recovered name: daObjLava_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *daObjLava_c_OnYoshiTryEat(int *t)
+int *func_ov002_020b6d4c(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020b6d84.c
+++ b/src/func_ov002_020b6d84.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov002_020b6d84
-// @emits daObjLava_c_Behavior
+// recovered name: daObjLava_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::Behavior - recovered from vtable slot identity */
 struct Vec3 {
@@ -20,7 +20,7 @@ struct Actor {
 extern struct Player* _ZN5Actor13ClosestPlayerEv(struct Actor* self);
 extern u32 func_02022c3c(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir);
 
-int daObjLava_c_Behavior(struct Actor* self) {
+int func_ov002_020b6d84(struct Actor* self) {
     struct Vec3* v = (struct Vec3*)(((int)_ZN5Actor13ClosestPlayerEv(self) + 0x5c));
     self->uniqueID = func_02022c3c(self->uniqueID, 0xb7, v->x, v->y, v->z, 0);
     return 1;

--- a/src/func_ov002_020b6dd0.c
+++ b/src/func_ov002_020b6dd0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b6dd0
-// @emits daObjLava_c_InitResources
+// recovered name: daObjLava_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjLava_c::InitResources - recovered from vtable slot identity */
-int daObjLava_c_InitResources(void)
+int func_ov002_020b6dd0(void)
 {
     return 1;
 }

--- a/src/func_ov002_020b7cdc.c
+++ b/src/func_ov002_020b7cdc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b7cdc
-// @emits PoppingLavaBubbles_Kill
+// recovered name: PoppingLavaBubbles_Kill
 /* recovered: renamed to Class_Method */
 /* daObjWaterfall_c::Kill - recovered from vtable slot identity */
-int PoppingLavaBubbles_Kill(int *p)
+int func_ov002_020b7cdc(int *p)
 {
     p[39] = 0; return 1;
 }

--- a/src/func_ov002_020b81e0.c
+++ b/src/func_ov002_020b81e0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020b81e0
-// @emits WaterfallMist_OnTurnIntoEgg
+// recovered name: WaterfallMist_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daObjMarioCap_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN6Player17SetNoControlStateEhih(char* p, unsigned char a, int b, unsigned char d);
@@ -9,7 +9,7 @@ extern void func_ov002_020b7f2c(char* c, void* p);
 extern void* data_ov002_0210de30[];
 extern int data_ov002_0210df54;
 
-void WaterfallMist_OnTurnIntoEgg(char* c, char* arg)
+void func_ov002_020b81e0(char* c, char* arg)
 {
     if (_ZN6Player17SetNoControlStateEhih(arg, 8, -1, 0) == 1) {
         _ZN6Player18SetNewHatCharacterEjjb(arg, *(int*)(c + 0x3f4) & 0xff, 1, 0);

--- a/src/func_ov002_020b8270.c
+++ b/src/func_ov002_020b8270.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b8270
-// @emits WaterfallMist_OnYoshiTryEat
+// recovered name: WaterfallMist_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daObjMarioCap_c::OnYoshiTryEat - recovered from vtable slot identity */
-int WaterfallMist_OnYoshiTryEat(char* c){
+int func_ov002_020b8270(char* c){
   if(*(int*)(c+0x3f0)==2) return 0;
   return 4;
 }

--- a/src/func_ov002_020b8c3c.c
+++ b/src/func_ov002_020b8c3c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020b8c3c
-// @emits daObjPushblock_c_OnYoshiTryEat
+// recovered name: daObjPushblock_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjPushblock_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjPushblock_c_OnYoshiTryEat(int *t)
+int *func_ov002_020b8c3c(int *t)
 {
     t[0] = (int)VT0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);

--- a/src/func_ov002_020b8d14.cpp
+++ b/src/func_ov002_020b8d14.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov002_020b8d14
-// @emits daObjPushblock_c_OnHitByMegaChar
+// recovered name: daObjPushblock_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void daObjPushblock_c_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov002_020b8d14(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov002_020b8d3c.c
+++ b/src/func_ov002_020b8d3c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov002_020b8d3c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjPushblock_c.h"
-// @emits daObjPushblock_c_OnPushed
+// recovered name: daObjPushblock_c_OnPushed
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::OnPushed - recovered from vtable slot identity */
-void daObjPushblock_c_OnPushed(char* r0, char* r1){
+void func_ov002_020b8d3c(char* r0, char* r1){
     struct daObjPushblock_c *self = (struct daObjPushblock_c *)(void *)r0;
   if(r1==0) return;
   self->unk_094=*(short*)(r1+0x8e);

--- a/src/func_ov002_020b8d68.c
+++ b/src/func_ov002_020b8d68.c
@@ -1,12 +1,12 @@
 // @symbol func_ov002_020b8d68
-// @emits daObjPushblock_c_CleanupResources
+// recovered name: daObjPushblock_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjPushblock_c_CleanupResources(void *t)
+int func_ov002_020b8d68(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov002_020b8dac.cpp
+++ b/src/func_ov002_020b8dac.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov002_020b8dac
-// @emits daObjPushblock_c_Render
+// recovered name: daObjPushblock_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjPushblock_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov002_020b8dac(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov002_020b8dd4.c
+++ b/src/func_ov002_020b8dd4.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjPushblock_c.h"
-// @emits daObjPushblock_c_Behavior
+// recovered name: daObjPushblock_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjPushblock_c::Behavior - recovered from vtable slot identity */
 typedef short s16;
@@ -29,7 +29,7 @@ extern int Vec3_Dist(Vector3 *a, Vector3 *b);
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, Vector3 *pos, unsigned int e);
 extern int Vec3_HorzDist(Vector3 *a, Vector3 *b);
 
-int daObjPushblock_c_Behavior(char *c)
+int func_ov002_020b8dd4(char *c)
 {
     struct daObjPushblock_c *self = (struct daObjPushblock_c *)(void *)c;
     Vector3 v;

--- a/src/func_ov002_020b8fe0.cpp
+++ b/src/func_ov002_020b8fe0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020b8fe0
-// @emits daObjPushblock_c_InitResources
+// recovered name: daObjPushblock_c_InitResources
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -29,7 +29,7 @@ extern "C" void _ZN13RaycastGroundD1Ev(RaycastGround *self);
 extern SharedFilePtr data_ov002_0210df9c;
 extern SharedFilePtr data_ov002_0210df94;
 
-extern "C" int daObjPushblock_c_InitResources(char *self)
+extern "C" int func_ov002_020b8fe0(char *self)
 {
     RaycastGround rg;
     V3 v;

--- a/src/func_ov002_020b9e04.c
+++ b/src/func_ov002_020b9e04.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020b9e04
-// @emits PushBlock_OnYoshiTryEat
+// recovered name: PushBlock_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daObjPowerUpItem_c::OnYoshiTryEat - recovered from vtable slot identity */
-int PushBlock_OnYoshiTryEat(void)
+int func_ov002_020b9e04(void)
 {
     return 5;
 }

--- a/src/func_ov002_020b9fec.c
+++ b/src/func_ov002_020b9fec.c
@@ -1,9 +1,9 @@
 // @symbol func_ov002_020b9fec
-// @emits StarSwitch_OnGroundPounded
+// recovered name: StarSwitch_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjSwitch_c::OnGroundPounded - recovered from vtable slot identity */
 extern int func_ov002_020ba4d8();
-void StarSwitch_OnGroundPounded(char* c){
+void func_ov002_020b9fec(char* c){
   if(*(int*)(c+0x340)!=0) return;
   func_ov002_020ba4d8(c,1);
 }

--- a/src/func_ov002_020ba4c0.c
+++ b/src/func_ov002_020ba4c0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020ba4c0
-// @emits PushBlock_Kill
+// recovered name: PushBlock_Kill
 /* recovered: renamed to Class_Method */
 /* daObjPowerUpItem_c::Kill - recovered from vtable slot identity */
-void PushBlock_Kill(char *p)
+void func_ov002_020ba4c0(char *p)
 {
     *(short *)(p + 0x338) = 0;
     *(char *)(p + 0x34f) = 5;

--- a/src/func_ov002_020bb23c.cpp
+++ b/src/func_ov002_020bb23c.cpp
@@ -1,10 +1,10 @@
 //cpp
 // @symbol func_ov002_020bb23c
-// @emits SignPost_OnAttacked1
+// recovered name: SignPost_OnAttacked1
 /* recovered: renamed to Class_Method */
 /* daObjTatefuda_c::OnAttacked1 - recovered from vtable slot identity */
 struct Base { virtual void v0();virtual void v1();virtual void v2();virtual void v3();virtual void v4();virtual void v5();virtual void v6();virtual void v7();virtual void v8();virtual void v9();virtual void v10();virtual void v11();virtual void v12();virtual void v13();virtual void v14();virtual void v15();virtual void v16();virtual void v17();virtual void v18();virtual void v19();virtual void v20();virtual void v21();virtual void v22();virtual void v23();virtual void v24();virtual void v25();virtual void v26();virtual void v27();virtual void v28();virtual void v29();virtual void v30(); virtual void M(); };
 struct Other { char p[0xc]; unsigned short id; };
-extern "C" void SignPost_OnAttacked1(Base* c, Other* o){
+extern "C" void func_ov002_020bb23c(Base* c, Other* o){
   int b=(o->id==0xce); if(b) c->M();
 }

--- a/src/func_ov002_020bb27c.c
+++ b/src/func_ov002_020bb27c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020bb27c
-// @emits SignPost_OnGroundPounded
+// recovered name: SignPost_OnGroundPounded
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjTatefuda_c::OnGroundPounded - recovered from vtable slot identity */
 typedef unsigned char u8;
@@ -13,7 +13,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
    emits `add rN, self, #off` + `ldr/str [rN]`. */
 #define LD(p) ((int)(((long long)(int)(p))))
 
-void SignPost_OnGroundPounded(char* self, char* arg){
+void func_ov002_020bb27c(char* self, char* arg){
   if (*(u8*)(self+0x58e) == 0) return;
   if (*(u8*)(self+0x58f) != 0) return;
   _ZN5Sound9PlayBank3EjRK7Vector3(0x62, (struct Vector3*)(self+0x74));

--- a/src/func_ov002_020bb374.cpp
+++ b/src/func_ov002_020bb374.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020bb374
-// @emits SignPost_OnHitByMegaChar
+// recovered name: SignPost_OnHitByMegaChar
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Platform.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void func_02012694(int a, void* b);
-void SignPost_OnHitByMegaChar(char* self, void* p){
+void func_ov002_020bb374(char* self, void* p){
   _ZN6Player16IncMegaKillCountEv(p);
   func_02012694(0x1d, self+0x74);
   _ZN8Platform14KillByMegaCharER6Player(self, p);

--- a/src/func_ov002_020bb3b8.cpp
+++ b/src/func_ov002_020bb3b8.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov002_020bb3b8
-// @emits SignPost_Kill
+// recovered name: SignPost_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjTatefuda_c::Kill - recovered from vtable slot identity */
-// SignPost_Kill at 0x020bb3b8
+// func_ov002_020bb3b8 at 0x020bb3b8
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 struct Vector3 { int x, y, z; };
 
@@ -14,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 int func_ov002_020bae9c(void* self);
 }
 
-extern "C" int SignPost_Kill(char* self);
-int SignPost_Kill(char* self) {
+extern "C" int func_ov002_020bb3b8(char* self);
+int func_ov002_020bb3b8(char* self) {
     Vector3 vec;
     Vector3 vec2;
     int x = *(int*)(self + 0x5c);

--- a/src/func_ov002_020bc444.c
+++ b/src/func_ov002_020bc444.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020bc444
-// @emits daObjWakame_c_OnYoshiTryEat
+// recovered name: daObjWakame_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWakame_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWakame_c_OnYoshiTryEat(int *t)
+int *func_ov002_020bc444(int *t)
 {
     t[0] = (int)VT0;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020bc4f8.cpp
+++ b/src/func_ov002_020bc4f8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov002_020bc4f8
-// @emits daObjWakame_c_Render
+// recovered name: daObjWakame_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjWakame_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjWakame_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov002_020bc4f8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov002_020bc520.c
+++ b/src/func_ov002_020bc520.c
@@ -1,9 +1,9 @@
 // @symbol func_ov002_020bc520
-// @emits daObjWakame_c_Behavior
+// recovered name: daObjWakame_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjWakame_c::Behavior - recovered from vtable slot identity */
 extern void _ZN9Animation7AdvanceEv(void *);
-int daObjWakame_c_Behavior(void *t)
+int func_ov002_020bc520(void *t)
 {
     _ZN9Animation7AdvanceEv((char *)t + 0x124);
     return 1;

--- a/src/func_ov002_020bc540.cpp
+++ b/src/func_ov002_020bc540.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov002_020bc540
-// @emits daObjWakame_c_InitResources
+// recovered name: daObjWakame_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelBase7SetFileEP8BMD_Fileii(char*, void*, int, int);
 extern void* _ZN9Animation8LoadFileER13SharedFilePtr(void*);
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char*, void*, int, int, unsigned int);
-int daObjWakame_c_InitResources(char* c){
+int func_ov002_020bc540(char* c){
   void* m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov002_0210e0dc);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);
   void* a = _ZN9Animation8LoadFileER13SharedFilePtr(data_ov002_0210e0d4);

--- a/src/func_ov002_020e8edc.c
+++ b/src/func_ov002_020e8edc.c
@@ -1,10 +1,10 @@
 // @symbol func_ov002_020e8edc
-// @emits PowerStar_OnTurnIntoEgg
+// recovered name: PowerStar_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daStar_c::OnTurnIntoEgg - recovered from vtable slot identity */
 
-void PowerStar_OnTurnIntoEgg(void) {
+void func_ov002_020e8edc(void) {
     func_ov002_020e8e80();
 }

--- a/src/func_ov002_020e8ee8.c
+++ b/src/func_ov002_020e8ee8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020e8ee8
-// @emits PowerStar_OnYoshiTryEat
+// recovered name: PowerStar_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daStar_c::OnYoshiTryEat - recovered from vtable slot identity */
-int PowerStar_OnYoshiTryEat(void)
+int func_ov002_020e8ee8(void)
 {
     return 4;
 }

--- a/src/func_ov002_020ec3b8.c
+++ b/src/func_ov002_020ec3b8.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020ec3b8
-// @emits daWarpkun_c_OnYoshiTryEat
+// recovered name: daWarpkun_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daWarpkun_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daWarpkun_c_OnYoshiTryEat(int *t)
+int *func_ov002_020ec3b8(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020ec3fc.c
+++ b/src/func_ov002_020ec3fc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020ec3fc
-// @emits daWarpkun_c_CleanupResources
+// recovered name: daWarpkun_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daWarpkun_c::CleanupResources - recovered from vtable slot identity */
-int daWarpkun_c_CleanupResources(void)
+int func_ov002_020ec3fc(void)
 {
     return 1;
 }

--- a/src/func_ov002_020ec404.c
+++ b/src/func_ov002_020ec404.c
@@ -1,7 +1,7 @@
 // @symbol func_ov002_020ec404
-// @emits daWarpkun_c_OnPendingDestroy
+// recovered name: daWarpkun_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daWarpkun_c::OnPendingDestroy - recovered from vtable slot identity */
-void daWarpkun_c_OnPendingDestroy(void)
+void func_ov002_020ec404(void)
 {
 }

--- a/src/func_ov002_020ec408.c
+++ b/src/func_ov002_020ec408.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020ec408
-// @emits daWarpkun_c_Render
+// recovered name: daWarpkun_c_Render
 /* recovered: renamed to Class_Method */
 /* daWarpkun_c::Render - recovered from vtable slot identity */
-int daWarpkun_c_Render(void)
+int func_ov002_020ec408(void)
 {
     return 1;
 }

--- a/src/func_ov002_020ec4c4.c
+++ b/src/func_ov002_020ec4c4.c
@@ -1,12 +1,12 @@
 // @symbol func_ov002_020ec4c4
-// @emits daWarpkun_c_InitResources
+// recovered name: daWarpkun_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daWarpkun_c::InitResources - recovered from vtable slot identity */
 
 typedef int Fix12i;
 extern int _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void *, Fix12i, Fix12i, Fix12i, Fix12i);
 extern int _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void *, void *, Fix12i, Fix12i, unsigned int, unsigned int);
-int daWarpkun_c_InitResources(void *c)
+int func_ov002_020ec4c4(void *c)
 {
   int v = *((int *) (((char *) c) + 8));
   int r = (((*((int *) (((char *) c) + 8))) & 0xf) + 1) << 0x12;

--- a/src/func_ov002_020ed0d4.c
+++ b/src/func_ov002_020ed0d4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020ed0d4
-// @emits daWarpkun_c_Kill
+// recovered name: daWarpkun_c_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -24,7 +24,7 @@ extern int data_020a0e68[];
 extern void* data_ov002_0210e6b0[];
 extern void* data_ov002_0210eb78[];
 
-void daWarpkun_c_Kill(char* self)
+void func_ov002_020ed0d4(char* self)
 {
     struct Vector3 in, out;
     char* com;

--- a/src/func_ov002_020f03f4.c
+++ b/src/func_ov002_020f03f4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020f03f4
-// @emits daSCoin_c_OnYoshiTryEat
+// recovered name: daSCoin_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_MovingCylinderClsn.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daSCoin_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daSCoin_c_OnYoshiTryEat(int *t)
+int *func_ov002_020f03f4(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0xd4);

--- a/src/func_ov002_020f06c0.cpp
+++ b/src/func_ov002_020f06c0.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daSCoin_c.h"
-// @emits daSCoin_c_Behavior
+// recovered name: daSCoin_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daSCoin_c::Behavior - recovered from vtable slot identity */
 class ActorBase {
@@ -22,7 +22,7 @@ public:
 };
 extern "C" unsigned char DecIfAbove0_Byte(unsigned char* p);
 
-extern "C" int daSCoin_c_Behavior(char *c)
+extern "C" int func_ov002_020f06c0(char *c)
 {
     struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
     if (self->unk_113) {

--- a/src/func_ov002_020f07dc.c
+++ b/src/func_ov002_020f07dc.c
@@ -1,13 +1,13 @@
 // @symbol func_ov002_020f07dc
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daSCoin_c.h"
-// @emits daSCoin_c_InitResources
+// recovered name: daSCoin_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daSCoin_c::InitResources - recovered from vtable slot identity */
 extern void _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(void* self, void* actor, int radius, int height, unsigned int flags, unsigned int vulnFlags);
 extern void _ZN5Model8LoadFileER13SharedFilePtr(void* fp);
 extern int data_ov002_0210d9a8;
-int daSCoin_c_InitResources(char* c){
+int func_ov002_020f07dc(char* c){
     struct daSCoin_c *self = (struct daSCoin_c *)(void *)c;
     _ZN18MovingCylinderClsn4InitEP5Actor5Fix12IiES3_jj(c + 0xd4, c, 0x64000, 0x40000, 0x800002, 0);
     self->unk_10d = *(unsigned int*)(c + 8) & 0xf;

--- a/src/func_ov002_020f11f4.c
+++ b/src/func_ov002_020f11f4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020f11f4
-// @emits daObjBC_Switch_c_OnYoshiTryEat
+// recovered name: daObjBC_Switch_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBC_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjBC_Switch_c_OnYoshiTryEat(int *t)
+int *func_ov002_020f11f4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov002_020f124c.c
+++ b/src/func_ov002_020f124c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov002_020f124c
-// @emits daObjBC_Switch_c_CleanupResources
+// recovered name: daObjBC_Switch_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjBC_Switch_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjBC_Switch_c_CleanupResources(void *t)
+int func_ov002_020f124c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov002_020f1290.cpp
+++ b/src/func_ov002_020f1290.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov002_020f1290
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjBC_Switch_c.h"
-// @emits daObjBC_Switch_c_Render
+// recovered name: daObjBC_Switch_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjBC_Switch_c::Render - recovered from vtable slot identity */
 struct Base {
@@ -14,7 +14,7 @@ struct Base {
     virtual void m(int);
 };
 
-extern "C" int daObjBC_Switch_c_Render(char *o) {
+extern "C" int func_ov002_020f1290(char *o) {
     struct daObjBC_Switch_c *self = (struct daObjBC_Switch_c *)(void *)o;
     if (self->unk_060 > self->unk_320) {
         Base *bp = (Base *)(o + 0xd4);

--- a/src/func_ov002_020f12c8.c
+++ b/src/func_ov002_020f12c8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov002_020f12c8
-// @emits daObjBC_Switch_c_Behavior
+// recovered name: daObjBC_Switch_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -16,7 +16,7 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern s32 _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, s32 a, s32 b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 
-s32 daObjBC_Switch_c_Behavior(void *arg0)
+s32 func_ov002_020f12c8(void *arg0)
 {
     char *c = (char *)arg0;
     u16 t;

--- a/src/func_ov002_020f1468.c
+++ b/src/func_ov002_020f1468.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjBC_Switch_c.h"
-// @emits daObjBC_Switch_c_InitResources
+// recovered name: daObjBC_Switch_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjBC_Switch_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
@@ -21,7 +21,7 @@ extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10C
 extern void func_020393c4(void* p, void* v);
 
 
-int daObjBC_Switch_c_InitResources(char* c)
+int func_ov002_020f1468(char* c)
 {
     struct daObjBC_Switch_c *self = (struct daObjBC_Switch_c *)(void *)c;
     void* bmd;

--- a/src/func_ov002_020f92e4.c
+++ b/src/func_ov002_020f92e4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov002_020f92e4
-// @emits Fireball_OnYoshiTryEat
+// recovered name: Fireball_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daFPknBall_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Fireball_OnYoshiTryEat(char *p)
+int func_ov002_020f92e4(char *p)
 {
     unsigned char b = *(unsigned char *)(p + 0x36d);
     if (b != 0 && b != 4)

--- a/src/func_ov002_020f9370.c
+++ b/src/func_ov002_020f9370.c
@@ -1,11 +1,11 @@
 // @symbol func_ov002_020f9370
-// @emits daSoundObj_c_OnYoshiTryEat
+// recovered name: daSoundObj_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daSoundObj_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *daSoundObj_c_OnYoshiTryEat(int *t)
+int *func_ov002_020f9370(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov002_020f94fc.cpp
+++ b/src/func_ov002_020f94fc.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daSoundObj_c.h"
-// @emits daSoundObj_c_Behavior
+// recovered name: daSoundObj_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daSoundObj_c::Behavior - recovered from vtable slot identity */
 struct C;
@@ -15,7 +15,7 @@ extern "C" {
 void _ZN9ActorBase18MarkForDestructionEv(C* c);
 void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int d, int f, bool g);
 
-int daSoundObj_c_Behavior(char* cc)
+int func_ov002_020f94fc(char* cc)
 {
     struct daSoundObj_c *self = (struct daSoundObj_c *)(void *)cc;
     C* c = (C*)cc;

--- a/src/func_ov002_020f95e0.c
+++ b/src/func_ov002_020f95e0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov002_020f95e0
-// @emits daSoundObj_c_InitResources
+// recovered name: daSoundObj_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern void *_ZN5Actor15FindWithActorIDEjPS_(unsigned int id, void *prev);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *thiz);
 extern void _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsigned int c, int d, int e);
 
-int daSoundObj_c_InitResources(void *self)
+int func_ov002_020f95e0(void *self)
 {
     char *c = (char *)self;
     void *a;

--- a/src/func_ov004_020ae128.c
+++ b/src/func_ov004_020ae128.c
@@ -1,11 +1,11 @@
 // @symbol func_ov004_020ae128
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_OnPushed
+// recovered name: dScMgBase_c_OnPushed
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnPushed - recovered from vtable slot identity */
 
-int dScMgBase_c_OnPushed(void *c) {
+int func_ov004_020ae128(void *c) {
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     return self->unk_4628 == 0;
 }

--- a/src/func_ov004_020ae140.cpp
+++ b/src/func_ov004_020ae140.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov004_020ae140
-// @emits dScMgBase_c_OnKicked
+// recovered name: dScMgBase_c_OnKicked
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnKicked - recovered from vtable slot identity */
 struct Obj {
@@ -16,9 +16,9 @@ struct Obj {
     virtual void method78();
 };
 
-extern "C" int dScMgBase_c_OnKicked(Obj* self);
+extern "C" int func_ov004_020ae140(Obj* self);
 
-int dScMgBase_c_OnKicked(Obj* self) {
+int func_ov004_020ae140(Obj* self) {
     void* base = (char*)self + 0x4000;
     int v2 = *(int*)((char*)base + 0x628);
     int v1 = *(int*)((char*)base + 0x62c);

--- a/src/func_ov004_020ae198.c
+++ b/src/func_ov004_020ae198.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020ae198
-// @emits dScMgBase_c_OnAttacked1
+// recovered name: dScMgBase_c_OnAttacked1
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAttacked1 - recovered from vtable slot identity */
-int dScMgBase_c_OnAttacked1(void)
+int func_ov004_020ae198(void)
 {
     return 1;
 }

--- a/src/func_ov004_020ae1a0.c
+++ b/src/func_ov004_020ae1a0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020ae1a0
-// @emits dScMgBase_c_OnAttacked2
+// recovered name: dScMgBase_c_OnAttacked2
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAttacked2 - recovered from vtable slot identity */
-int dScMgBase_c_OnAttacked2(void)
+int func_ov004_020ae1a0(void)
 {
     return 1;
 }

--- a/src/func_ov004_020aeed8.cpp
+++ b/src/func_ov004_020aeed8.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_OnAimedAtWithEggReturnVec
+// recovered name: dScMgBase_c_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
 extern "C" u8 data_0209d45c;
@@ -46,7 +46,7 @@ struct Obj {
     virtual int f68();
 };
 
-extern "C" void dScMgBase_c_OnAimedAtWithEggReturnVec(char* c)
+extern "C" void func_ov004_020aeed8(char* c)
 {
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     Obj* o = (Obj*)c;

--- a/src/func_ov004_020af04c.cpp
+++ b/src/func_ov004_020af04c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov004_020af04c
-// @emits dScMgBase_c_OnHitFromUnderneath
+// recovered name: dScMgBase_c_OnHitFromUnderneath
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -43,7 +43,7 @@ struct Obj : Base {
     char pad[0x4627];
 };
 
-extern "C" void dScMgBase_c_OnHitFromUnderneath(Obj *self) {
+extern "C" void func_ov004_020af04c(Obj *self) {
     func_02012e1c((char*)self);
     *(int*)((char*)self + 0x4628) = 0;
     func_ov004_020b91fc((char*)self + 0xf4);

--- a/src/func_ov004_020af094.cpp
+++ b/src/func_ov004_020af094.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov004_020af094
-// @emits dScMgBase_c_OnAimedAtWithEgg
+// recovered name: dScMgBase_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -52,7 +52,7 @@ struct Obj : Base {
     char pad[0x4700];
 };
 
-extern "C" void dScMgBase_c_OnAimedAtWithEgg(Obj *self)
+extern "C" void func_ov004_020af094(Obj *self)
 {
     char *c = (char *)self;
 

--- a/src/func_ov004_020af27c.c
+++ b/src/func_ov004_020af27c.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_OnHitByMegaChar
+// recovered name: dScMgBase_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnHitByMegaChar - recovered from vtable slot identity */
 
-void dScMgBase_c_OnHitByMegaChar(void *c)
+void func_ov004_020af27c(void *c)
 {
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     if (self->unk_4630 != 0) return;

--- a/src/func_ov004_020b04e0.c
+++ b/src/func_ov004_020b04e0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020b04e0
-// @emits dScMgBase_c_OnHitByCannonBlastedChar
+// recovered name: dScMgBase_c_OnHitByCannonBlastedChar
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
-int dScMgBase_c_OnHitByCannonBlastedChar(void)
+int func_ov004_020b04e0(void)
 {
     return 0;
 }

--- a/src/func_ov004_020b04e8.c
+++ b/src/func_ov004_020b04e8.c
@@ -1,7 +1,7 @@
 // @symbol func_ov004_020b04e8
-// @emits dScMgBase_c_OnPendingDestroy
+// recovered name: dScMgBase_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScMgBase_c_OnPendingDestroy(void)
+void func_ov004_020b04e8(void)
 {
 }

--- a/src/func_ov004_020b04ec.c
+++ b/src/func_ov004_020b04ec.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020b04ec
-// @emits dScMgBase_c_Render
+// recovered name: dScMgBase_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::Render - recovered from vtable slot identity */
-int dScMgBase_c_Render(void)
+int func_ov004_020b04ec(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b04f4.cpp
+++ b/src/func_ov004_020b04f4.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_BeforeRender
+// recovered name: dScMgBase_c_BeforeRender
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::BeforeRender - recovered from vtable slot identity */
 // NONMATCHING: register allocation (div=17). Logic verified correct vs ROM; not
@@ -18,7 +18,7 @@ extern "C" int _ZN5Scene12BeforeRenderEv(struct Scene *);
 
 struct Ent { char pad[0x1a]; s16 f; char pad2[4]; };
 
-extern "C" int dScMgBase_c_BeforeRender(void *c)
+extern "C" int func_ov004_020b04f4(void *c)
 {
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     int i;

--- a/src/func_ov004_020b0618.c
+++ b/src/func_ov004_020b0618.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020b0618
-// @emits dScMgBase_c_Behavior
+// recovered name: dScMgBase_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::Behavior - recovered from vtable slot identity */
-int dScMgBase_c_Behavior(void)
+int func_ov004_020b0618(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b0620.cpp
+++ b/src/func_ov004_020b0620.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov004_020b0620
-// @emits dScMgBase_c_BeforeBehavior
+// recovered name: dScMgBase_c_BeforeBehavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 #include "decl_common.h"
@@ -44,7 +44,7 @@ extern int data_0208ee44;
 
 
 #pragma opt_strength_reduction off
-extern "C" int dScMgBase_c_BeforeBehavior(char *self)
+extern "C" int func_ov004_020b0620(char *self)
 {
     int mode;
     unsigned short flags;

--- a/src/func_ov004_020b0840.c
+++ b/src/func_ov004_020b0840.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_AfterCleanupResources
+// recovered name: dScMgBase_c_AfterCleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::AfterCleanupResources - recovered from vtable slot identity */
 extern void func_ov004_020ad90c(void);
@@ -16,7 +16,7 @@ extern int data_0209b308[];
 extern int data_0209d4a8[];
 extern int data_ov004_020beb60[];
 
-void dScMgBase_c_AfterCleanupResources(char* c, int arg){
+void func_ov004_020b0840(char* c, int arg){
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
   if (arg == 2) {
     if (data_0209b308[4] == 0)

--- a/src/func_ov004_020b08f0.cpp
+++ b/src/func_ov004_020b08f0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov004_020b08f0
-// @emits dScMgBase_c_AfterInitResources
+// recovered name: dScMgBase_c_AfterInitResources
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::AfterInitResources - recovered from vtable slot identity */
 extern "C" {
@@ -21,7 +21,7 @@ struct Scene {
     void AfterInitResources(unsigned int flags);
 };
 
-extern "C" void dScMgBase_c_AfterInitResources(Scene* self, unsigned int flags) {
+extern "C" void func_ov004_020b08f0(Scene* self, unsigned int flags) {
     self->targetMethod();
     LoadFont(2);
     func_ov004_020ae330();

--- a/src/func_ov004_020b0930.cpp
+++ b/src/func_ov004_020b0930.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBase_c.h"
-// @emits dScMgBase_c_BeforeInitResources
+// recovered name: dScMgBase_c_BeforeInitResources
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::BeforeInitResources - recovered from vtable slot identity */
 struct Obj {
@@ -30,7 +30,7 @@ extern char data_0209f61c[];
 extern unsigned char data_0209d460[];
 extern unsigned char data_0209d458[];
 
-int dScMgBase_c_BeforeInitResources(char* c)
+int func_ov004_020b0930(char* c)
 {
     struct dScMgBase_c *self = (struct dScMgBase_c *)(void *)c;
     if (_ZN5Scene19BeforeInitResourcesEv(c) == 0) return 0;

--- a/src/func_ov004_020b27f4.c
+++ b/src/func_ov004_020b27f4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov004_020b27f4
-// @emits dScMgBase_c_AfterClsn
+// recovered name: dScMgBase_c_AfterClsn
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@ extern int GetGameLanguage(void);
 extern unsigned int LoadCompressedFileAt(int fileID, void *target);
 extern unsigned char data_0209d45c[];
 
-void dScMgBase_c_AfterClsn(void)
+void func_ov004_020b27f4(void)
 {
     int f;
     *(volatile unsigned short *)0x400000a = *(volatile unsigned short *)0x400000a & ~3;

--- a/src/func_ov004_020b2880.c
+++ b/src/func_ov004_020b2880.c
@@ -1,5 +1,5 @@
 // @symbol func_ov004_020b2880
-// @emits dScMgBase_c_Kill
+// recovered name: dScMgBase_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern unsigned int LoadCompressedFileAt(int fileID, void *target);
 extern void *_ZN3G2S12GetBG1ScrPtrEv(void);
 extern unsigned char data_0209d454[];
 
-void dScMgBase_c_Kill(void)
+void func_ov004_020b2880(void)
 {
     int f;
     *(volatile unsigned short *)0x400100a = (*(volatile unsigned short *)0x400100a & 0x43) | 0x10;

--- a/src/func_ov004_020b298c.c
+++ b/src/func_ov004_020b298c.c
@@ -1,7 +1,7 @@
 // @symbol func_ov004_020b298c
-// @emits dScMgBase_c_OnGroundPounded
+// recovered name: dScMgBase_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnGroundPounded - recovered from vtable slot identity */
-void dScMgBase_c_OnGroundPounded(void)
+void func_ov004_020b298c(void)
 {
 }

--- a/src/func_ov004_020b2990.c
+++ b/src/func_ov004_020b2990.c
@@ -1,7 +1,7 @@
 // @symbol func_ov004_020b2990
-// @emits dScMgBase_c_Virtual50
+// recovered name: dScMgBase_c_Virtual50
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::Virtual50 - recovered from vtable slot identity */
-void dScMgBase_c_Virtual50(void)
+void func_ov004_020b2990(void)
 {
 }

--- a/src/func_ov004_020b2994.c
+++ b/src/func_ov004_020b2994.c
@@ -1,8 +1,8 @@
 // @symbol func_ov004_020b2994
-// @emits dScMgBase_c_OnTurnIntoEgg
+// recovered name: dScMgBase_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnTurnIntoEgg - recovered from vtable slot identity */
-int dScMgBase_c_OnTurnIntoEgg(void)
+int func_ov004_020b2994(void)
 {
     return 1;
 }

--- a/src/func_ov004_020b299c.c
+++ b/src/func_ov004_020b299c.c
@@ -1,7 +1,7 @@
 // @symbol func_ov004_020b299c
-// @emits dScMgBase_c_OnYoshiTryEat
+// recovered name: dScMgBase_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* dScMgBase_c::OnYoshiTryEat - recovered from vtable slot identity */
-void dScMgBase_c_OnYoshiTryEat(void)
+void func_ov004_020b299c(void)
 {
 }

--- a/src/func_ov004_020b2a18.cpp
+++ b/src/func_ov004_020b2a18.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov004_020b2a18
-// @emits dScMgBase_c_OnYoshiTryEat_020b2a18
+// recovered name: dScMgBase_c_OnYoshiTryEat_020b2a18
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -14,7 +14,7 @@ extern void* data_ov004_020beb68;
 extern void* _ZTV5Stage;
 extern void* data_0208e4b8;
 extern Heap* data_020a0eac;
-void* dScMgBase_c_OnYoshiTryEat_020b2a18(void* self){
+void* func_ov004_020b2a18(void* self){
   char* t=(char*)self;
   *(void**)t = &data_ov004_020bc0c0;
   *(void**)&data_ov004_020beb68 = 0;

--- a/src/func_ov006_021243ec.cpp
+++ b/src/func_ov006_021243ec.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgTrampoline2_c.h"
-// @emits dScMgTrampoline2_c_InitResources
+// recovered name: dScMgTrampoline2_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScMgTrampoline2_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -37,7 +37,7 @@ struct Base {
     virtual void m48(int x);
 };
 
-extern "C" int dScMgTrampoline2_c_InitResources(char *base)
+extern "C" int func_ov006_021243ec(char *base)
 {
     struct dScMgTrampoline2_c *self = (struct dScMgTrampoline2_c *)(void *)base;
     s32 fov;

--- a/src/func_ov006_0212497c.cpp
+++ b/src/func_ov006_0212497c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0212497c
-// @emits dScMgBSC_c_OnYoshiTryEat
+// recovered name: dScMgBSC_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,8 +11,8 @@ extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void NullDestructor_0203d47c();
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgBSC_c_OnYoshiTryEat(char *c);
-void *dScMgBSC_c_OnYoshiTryEat(char *c) {
+void *func_ov006_0212497c(char *c);
+void *func_ov006_0212497c(char *c) {
     *(void ***)c = data_ov006_0213fec8;
     __destroy_arr(c + 0x51a8, 2, 8, (void*)&NullDestructor_0203d47c);
     func_ov006_020c1c64(c + 0x4f38);

--- a/src/func_ov006_02125248.c
+++ b/src/func_ov006_02125248.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBSC_c.h"
-// @emits dScMgBSC_c_OnGroundPounded
+// recovered name: dScMgBSC_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::OnGroundPounded - recovered from vtable slot identity */
 
-int dScMgBSC_c_OnGroundPounded(void *this) {
+int func_ov006_02125248(void *this) {
     struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)this;
     int x = self->unk_0b4;
     int v = x / 5;

--- a/src/func_ov006_0212527c.cpp
+++ b/src/func_ov006_0212527c.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBSC_c.h"
-// @emits dScMgBSC_c_OnTurnIntoEgg
+// recovered name: dScMgBSC_c_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" int func_ov006_020c1718(int* r0);
@@ -12,7 +12,7 @@ extern "C" void FreeGfxSlotsById(int arg);
 
 extern short data_ov004_020bf9e4;
 
-extern "C" int dScMgBSC_c_OnTurnIntoEgg(char* c, int mode)
+extern "C" int func_ov006_0212527c(char* c, int mode)
 {
     struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)c;
     int st;

--- a/src/func_ov006_02125364.c
+++ b/src/func_ov006_02125364.c
@@ -3,11 +3,11 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgBSC_c.h"
-// @emits dScMgBSC_c_OnYoshiTryEat_02125364
+// recovered name: dScMgBSC_c_OnYoshiTryEat_02125364
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov004_020b66d4(void);
-void dScMgBSC_c_OnYoshiTryEat_02125364(char* c, int mode){
+void func_ov006_02125364(char* c, int mode){
     struct dScMgBSC_c *self = (struct dScMgBSC_c *)(void *)c;
   if(mode != 4 && mode != 5 && mode == 3){
     self->unk_0b4 = func_ov004_020ad878();

--- a/src/func_ov006_021253bc.c
+++ b/src/func_ov006_021253bc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_021253bc
-// @emits dScMgBSC_c_Render
+// recovered name: dScMgBSC_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -25,7 +25,7 @@ typedef struct Obj {
     unsigned char b1[2];
 } Obj;
 
-int dScMgBSC_c_Render(Obj *self) {
+int func_ov006_021253bc(Obj *self) {
     int i;
 
     func_ov006_020c0aa8(&self->f4660);

--- a/src/func_ov006_021254c0.cpp
+++ b/src/func_ov006_021254c0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_021254c0
-// @emits dScMgBSC_c_Behavior
+// recovered name: dScMgBSC_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgBSC_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -9,7 +9,7 @@ extern "C" Entry data_ov006_02142f94[];
 struct C { char pad[0x51b8]; int idx; };
 extern "C" void func_ov004_020b65e4(void);
 extern "C" int func_ov006_020c19d0(void* p);
-extern "C" int dScMgBSC_c_Behavior(C* c) {
+extern "C" int func_ov006_021254c0(C* c) {
     (c->*(data_ov006_02142f94[c->idx].pmf))();
     func_ov004_020b65e4();
     func_ov006_020c19d0((char*)c + 0x4f38);

--- a/src/func_ov006_0212551c.cpp
+++ b/src/func_ov006_0212551c.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov006_0212551c
-// @emits dScMgBSC_c_InitResources
+// recovered name: dScMgBSC_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -15,7 +15,7 @@ extern u32 LoadCompressedFileAt(int fileID, void *target);
 extern int LoadFile(int handle);
 extern void func_ov006_020c0aa8(void *p);
 extern int func_ov006_020c1a88(void *p);
-int dScMgBSC_c_InitResources(void *self);
+int func_ov006_0212551c(void *self);
 }
 extern "C" void _ZN3GXS11LoadOBJPlttEPKvjj(void const *a, unsigned int b, unsigned int c);
 struct Obj {
@@ -26,7 +26,7 @@ struct Obj {
     virtual void v16();virtual void v17();virtual void v18(int x);
     char pad[0x10000];
 };
-int dScMgBSC_c_InitResources(void *self) {
+int func_ov006_0212551c(void *self) {
     Obj *o = (Obj *)self;
     char *c = (char *)self;
     int fh;

--- a/src/func_ov006_0212573c.cpp
+++ b/src/func_ov006_0212573c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0212573c
-// @emits dScMgSnowball_c_OnYoshiTryEat
+// recovered name: dScMgSnowball_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
@@ -12,8 +12,8 @@ extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void NullDestructor_0203d47c();
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgSnowball_c_OnYoshiTryEat(char *c);
-void *dScMgSnowball_c_OnYoshiTryEat(char *c) {
+void *func_ov006_0212573c(char *c);
+void *func_ov006_0212573c(char *c) {
     *(void ***)c = data_ov006_0214000c;
     __destroy_arr(c + 0xba14, 0x20, 0x24, (void*)&func_ov006_02125800);
     __destroy_arr(c + 0xb5d8, 0x80, 8, (void*)&NullDestructor_0203d47c);

--- a/src/func_ov006_02127d10.c
+++ b/src/func_ov006_02127d10.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgSnowball_c.h"
-// @emits dScMgSnowball_c_Render
+// recovered name: dScMgSnowball_c_Render
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::Render - recovered from vtable slot identity */
 #pragma opt_strength_reduction off
@@ -16,7 +16,7 @@ extern void func_ov004_020b2220(int a1, int a2, int a3, int a4, int a5, int a6, 
 extern s32 GetGameLanguage(void);
 
 
-int dScMgSnowball_c_Render(char *c)
+int func_ov006_02127d10(char *c)
 {
     struct dScMgSnowball_c *self = (struct dScMgSnowball_c *)(void *)c;
     int m[3];

--- a/src/func_ov006_021283a4.c
+++ b/src/func_ov006_021283a4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov006_021283a4
-// @emits dScMgSnowball_c_Behavior
+// recovered name: dScMgSnowball_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -41,7 +41,7 @@ struct SPS {
     int cc[3];
 };
 
-int dScMgSnowball_c_Behavior(char *c) {
+int func_ov006_021283a4(char *c) {
     int r5, r4;
     int idx, r3rec, r7, j;
     struct SPS s;

--- a/src/func_ov006_02128fb8.c
+++ b/src/func_ov006_02128fb8.c
@@ -4,14 +4,14 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgSnowball_c.h"
-// @emits dScMgSnowball_c_OnKicked
+// recovered name: dScMgSnowball_c_OnKicked
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::OnKicked - recovered from vtable slot identity */
 extern int func_ov004_020ae140(char *self);
 
 #define V (self->unk_ab6c >> 12)
 
-int dScMgSnowball_c_OnKicked(char *c)
+int func_ov006_02128fb8(char *c)
 {
     struct dScMgSnowball_c *self = (struct dScMgSnowball_c *)(void *)c;
     if (self->unk_4628 == 0) {

--- a/src/func_ov006_021291b0.c
+++ b/src/func_ov006_021291b0.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_021291b0
-// @emits dScMgSnowball_c_OnPushed
+// recovered name: dScMgSnowball_c_OnPushed
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::OnPushed - recovered from vtable slot identity */
-int dScMgSnowball_c_OnPushed(void *t) { return func_ov004_020ae128(t) != 0; }
+int func_ov006_021291b0(void *t) { return func_ov004_020ae128(t) != 0; }

--- a/src/func_ov006_021291d4.c
+++ b/src/func_ov006_021291d4.c
@@ -1,7 +1,7 @@
 // @symbol func_ov006_021291d4
-// @emits dScMgSnowball_c_OnAttacked2
+// recovered name: dScMgSnowball_c_OnAttacked2
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::OnAttacked2 - recovered from vtable slot identity */
-int dScMgSnowball_c_OnAttacked2(void *t) { return func_ov004_020ae1a0(t) != 0; }
+int func_ov006_021291d4(void *t) { return func_ov004_020ae1a0(t) != 0; }

--- a/src/func_ov006_021291f8.c
+++ b/src/func_ov006_021291f8.c
@@ -1,9 +1,9 @@
 // @symbol func_ov006_021291f8
-// @emits dScMgSnowball_c_CleanupResources
+// recovered name: dScMgSnowball_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::CleanupResources - recovered from vtable slot identity */
 extern void Ov004_Deallocate(void *p);
-int dScMgSnowball_c_CleanupResources(void *c) {
+int func_ov006_021291f8(void *c) {
     Ov004_Deallocate(*(void **)((char *)c + 0xabf4));
     return 1;
 }

--- a/src/func_ov006_0212921c.c
+++ b/src/func_ov006_0212921c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov006_0212921c
-// @emits dScMgSnowball_c_OnYoshiTryEat_0212921c
+// recovered name: dScMgSnowball_c_OnYoshiTryEat_0212921c
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgSnowball_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov006_02126a98(void* a);
-void dScMgSnowball_c_OnYoshiTryEat_0212921c(void* c, int i){
+void func_ov006_0212921c(void* c, int i){
   func_ov004_020adb1c(0);
   func_ov006_021279b0(c);
   if(i != 0x13) return;

--- a/src/func_ov006_02129268.c
+++ b/src/func_ov006_02129268.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_02129268
-// @emits dScMgSnowball_c_InitResources
+// recovered name: dScMgSnowball_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -27,7 +27,7 @@ extern int data_0208ee44;
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgSnowball_c_InitResources(void *arg0)
+int func_ov006_02129268(void *arg0)
 {
     u8 *r4 = (u8 *)arg0;
     void *buf;

--- a/src/func_ov006_0212a5c8.cpp
+++ b/src/func_ov006_0212a5c8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov006_0212a5c8
-// @emits dScMgFlower_c_OnYoshiTryEat
+// recovered name: dScMgFlower_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,8 +10,8 @@ extern int __destroy_arr(void*, int, int, void*);
 extern void _ZN8Particle10SysTrackerD1Ev(void *);
 extern void *data_ov006_0213e448[];
 extern void *data_020a0eac;
-void *dScMgFlower_c_OnYoshiTryEat(char *c);
-void *dScMgFlower_c_OnYoshiTryEat(char *c) {
+void *func_ov006_0212a5c8(char *c);
+void *func_ov006_0212a5c8(char *c) {
     *(void ***)c = data_ov006_02140140;
     func_ov006_020c3e70(c + 0x51f8);
     __destroy_arr(c + 0x4f38, 0x16, 0x20, (void*)&func_ov006_0212a650);

--- a/src/func_ov006_0212aa74.c
+++ b/src/func_ov006_0212aa74.c
@@ -1,10 +1,10 @@
 // @symbol func_ov006_0212aa74
-// @emits dScMgFlower_c_OnYoshiTryEat_0212aa74
+// recovered name: dScMgFlower_c_OnYoshiTryEat_0212aa74
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::OnYoshiTryEat - recovered from vtable slot identity */
-/* dScMgFlower_c_OnYoshiTryEat_0212aa74 at 0x0212aa74
+/* func_ov006_0212aa74 at 0x0212aa74
  *
  * Wraps a counter at this+0x5fe4 (increments while <= 0x14, else resets
  * to 0), then updates the sub-object at this+0x51f8 (func_ov006_020c3bc8)
@@ -17,7 +17,7 @@
  * block instead of folding into the this+0x5000 base and if-converting.
  */
 
-void dScMgFlower_c_OnYoshiTryEat_0212aa74(char *self)
+void func_ov006_0212aa74(char *self)
 {
     if (*(int *)(self + 0x5fe4) <= 0x14) {
         (*(volatile int *)(((long long)(int)(self + 0x5fe4))))++;

--- a/src/func_ov006_0212aacc.c
+++ b/src/func_ov006_0212aacc.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_0212aacc
-// @emits dScMgFlower_c_Render
+// recovered name: dScMgFlower_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -12,7 +12,7 @@ extern void func_ov004_020af770(void* a0, int a1, int a2, int a3, int a4, int a5
 
 struct S2 { int a, b; };
 
-int dScMgFlower_c_Render(char* self)
+int func_ov006_0212aacc(char* self)
 {
     int i;
     u8 (*barr)[0x20] = (u8 (*)[0x20])self;

--- a/src/func_ov006_0212ac74.c
+++ b/src/func_ov006_0212ac74.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMgFlower_c.h"
-// @emits dScMgFlower_c_Behavior
+// recovered name: dScMgFlower_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMgFlower_c::Behavior - recovered from vtable slot identity */
 typedef struct V2 {
@@ -33,7 +33,7 @@ extern u8 data_020a0deb[];
 #pragma opt_strength_reduction off
 #pragma opt_common_subs off
 
-int dScMgFlower_c_Behavior(char *c)
+int func_ov006_0212ac74(char *c)
 {
     struct dScMgFlower_c *self = (struct dScMgFlower_c *)(void *)c;
     int i;

--- a/src/func_ov006_0212b480.c
+++ b/src/func_ov006_0212b480.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov006_0212b480
-// @emits dScMgFlower_c_InitResources
+// recovered name: dScMgFlower_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -24,7 +24,7 @@ extern int data_0208ee44;
 extern u8 data_0209d45c;
 extern u8 data_0209d454;
 
-int dScMgFlower_c_InitResources(void *arg0)
+int func_ov006_0212b480(void *arg0)
 {
     char *c = (char *)arg0;
     int h;

--- a/src/func_ov064_02115f84.c
+++ b/src/func_ov064_02115f84.c
@@ -1,5 +1,5 @@
 // @symbol func_ov064_02115f84
-// @emits daBDonketu_c_OnAimedAtWithEgg
+// recovered name: daBDonketu_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBDonketu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 struct UnknownStruct {
@@ -12,7 +12,7 @@ struct Context {
     struct UnknownStruct* ptr;
 };
 
-int daBDonketu_c_OnAimedAtWithEgg(void* c) {
+int func_ov064_02115f84(void* c) {
     struct UnknownStruct* r1 = ((struct Context*)c)->ptr;
     int r0 = 0x14000;
     if (r1 != 0) {

--- a/src/func_ov064_021171b0.c
+++ b/src/func_ov064_021171b0.c
@@ -1,10 +1,10 @@
 // @symbol func_ov064_021171b0
-// @emits daDonketu_c_Kill
+// recovered name: daDonketu_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daDonketu_c::Kill - recovered from vtable slot identity */
-int daDonketu_c_Kill(char* self){
+int func_ov064_021171b0(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov064_02117220.cpp
+++ b/src/func_ov064_02117220.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov064_02117220
-// @emits daDonketu_c_AfterClsn
+// recovered name: daDonketu_c_AfterClsn
 /* recovered: shared common types, renamed to Class_Method */
 /* daDonketu_c::AfterClsn - recovered from vtable slot identity */
 typedef unsigned char u8; typedef signed char s8; typedef short s16;
@@ -12,7 +12,7 @@ struct Actor {
 Actor* Actor::Spawn(unsigned, unsigned, const Vector3&, const Vector3_16*, int, int);
 Actor* Actor::FindWithID(unsigned);
 extern "C" { extern int RandomIntInternal(void* seed); extern int data_0209e650; extern int func_ov064_0211616c(void* thiz); }
-extern "C" void daDonketu_c_AfterClsn(char* self) {
+extern "C" void func_ov064_02117220(char* self) {
     if (func_ov064_0211616c(self) == 0) return;
     int pz = *(int*)(self + 0x64);
     int py = *(int*)(self + 0x60) + 0x136000;

--- a/src/func_ov064_0211755c.c
+++ b/src/func_ov064_0211755c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov064_0211755c
-// @emits daBDonketu_c_Kill
+// recovered name: daBDonketu_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daBDonketu_c::Kill - recovered from vtable slot identity */
-int daBDonketu_c_Kill(char* self){
+int func_ov064_0211755c(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov064_021175cc.cpp
+++ b/src/func_ov064_021175cc.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daBDonketu_c.h"
-// @emits daBDonketu_c_AfterClsn
+// recovered name: daBDonketu_c_AfterClsn
 /* recovered: renamed to Class_Method */
 /* daBDonketu_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Actor14TriplePoofDustEv(void*);
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void*,void*,unsigned int,void*,unsigned int);
-int daBDonketu_c_AfterClsn(char* c){
+int func_ov064_021175cc(char* c){
     struct daBDonketu_c *self = (struct daBDonketu_c *)(void *)c;
   int r=func_ov064_0211616c(c);
   if(r==0) return r;

--- a/src/func_ov064_021179bc.c
+++ b/src/func_ov064_021179bc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov064_021179bc
-// @emits daObjFl_Amilift_c_OnYoshiTryEat
+// recovered name: daObjFl_Amilift_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Amilift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjFl_Amilift_c_OnYoshiTryEat(int *t)
+int *func_ov064_021179bc(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov064_02117cc4.c
+++ b/src/func_ov064_02117cc4.c
@@ -1,12 +1,12 @@
 // @symbol func_ov064_02117cc4
-// @emits daObjFl_Amilift_c_CleanupResources
+// recovered name: daObjFl_Amilift_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Amilift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjFl_Amilift_c_CleanupResources(void *t)
+int func_ov064_02117cc4(void *t)
 {
     _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);
     _ZN13SharedFilePtr7ReleaseEv(G0);

--- a/src/func_ov064_02117cfc.cpp
+++ b/src/func_ov064_02117cfc.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov064_02117cfc
-// @emits daObjFl_Amilift_c_Render
+// recovered name: daObjFl_Amilift_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjFl_Amilift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjFl_Amilift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov064_02117cfc(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov064_02117e44.cpp
+++ b/src/func_ov064_02117e44.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov064_02117e44
-// @emits daObjFl_Amilift_c_InitResources
+// recovered name: daObjFl_Amilift_c_InitResources
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_PathPtr.h"
 #include "decl_common.h"
@@ -33,7 +33,7 @@ extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResul
 
 struct V3 { int x, y, z; };
 
-extern "C" int daObjFl_Amilift_c_InitResources(char *self)
+extern "C" int func_ov064_02117e44(char *self)
 {
     BMD_File *bmd;
     KCL_File *kcl;

--- a/src/func_ov064_02118760.c
+++ b/src/func_ov064_02118760.c
@@ -1,12 +1,12 @@
 // @symbol func_ov064_02118760
-// @emits RotatingFirebar_AfterClsn
+// recovered name: RotatingFirebar_AfterClsn
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjFl_KomaU_c::AfterClsn - recovered from vtable slot identity */
 typedef unsigned int u32;
 struct Vector3 { int x, y, z; };
 struct Vector3_16 { short x, y, z; };
 void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 id, u32 p, const struct Vector3 *pos, const struct Vector3_16 *rot, int a, int b);
-int RotatingFirebar_AfterClsn(char *c)
+int func_ov064_02118760(char *c)
 {
   int yadj;
   int zcopy;

--- a/src/func_ov064_02118b08.c
+++ b/src/func_ov064_02118b08.c
@@ -1,8 +1,8 @@
 // @symbol func_ov064_02118b08
-// @emits LavaBubble_OnYoshiTryEat
+// recovered name: LavaBubble_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daBbl_c::OnYoshiTryEat - recovered from vtable slot identity */
-int LavaBubble_OnYoshiTryEat(void)
+int func_ov064_02118b08(void)
 {
     return 5;
 }

--- a/src/func_ov064_02118c10.c
+++ b/src/func_ov064_02118c10.c
@@ -1,11 +1,11 @@
 // @symbol func_ov064_02118c10
-// @emits daObjFl_Coin_c_OnYoshiTryEat
+// recovered name: daObjFl_Coin_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Coin_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *daObjFl_Coin_c_OnYoshiTryEat(int *t)
+int *func_ov064_02118c10(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov064_02118d3c.c
+++ b/src/func_ov064_02118d3c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov064_02118d3c
-// @emits LavaBubble_Kill
+// recovered name: LavaBubble_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daBbl_c::Kill - recovered from vtable slot identity */
 extern char *_ZN5Actor10FindWithIDEj(unsigned int id);
-void LavaBubble_Kill(char *c){
+void func_ov064_02118d3c(char *c){
   if (*(unsigned char*)(c+0x33a) != 0) {
     unsigned int id = *(unsigned int*)(c+0x320);
     if (id != 0) {

--- a/src/func_ov064_0211915c.c
+++ b/src/func_ov064_0211915c.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov064_0211915c
-// @emits daObjFl_Coin_c_Behavior
+// recovered name: daObjFl_Coin_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjFl_Coin_c::Behavior - recovered from vtable slot identity */
 extern int _ZN5Actor13DistToCPlayerEv(void *self);
 
-int daObjFl_Coin_c_Behavior(char *a)
+int func_ov064_0211915c(char *a)
 {
     switch (*(u8 *)(a + 0xd5)) {
     case 0:

--- a/src/func_ov064_02119284.c
+++ b/src/func_ov064_02119284.c
@@ -1,10 +1,10 @@
 // @symbol func_ov064_02119284
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjFl_Coin_c.h"
-// @emits daObjFl_Coin_c_InitResources
+// recovered name: daObjFl_Coin_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjFl_Coin_c::InitResources - recovered from vtable slot identity */
-int daObjFl_Coin_c_InitResources(char *p)
+int func_ov064_02119284(char *p)
 {
     struct daObjFl_Coin_c *self = (struct daObjFl_Coin_c *)(void *)p;
     self->unk_0d5 = 0;

--- a/src/func_ov064_02119ea0.c
+++ b/src/func_ov064_02119ea0.c
@@ -1,11 +1,11 @@
 // @symbol func_ov064_02119ea0
-// @emits BowserPuzzlePiece_Kill
+// recovered name: BowserPuzzlePiece_Kill
 /* recovered: renamed to Class_Method */
 /* daWater_Hakidasi_c::Kill - recovered from vtable slot identity */
 typedef signed short s16;
 typedef int s32;
 extern s32 _ZN5Actor18HorzAngleToCPlayerEv(void* self);
-s32 BowserPuzzlePiece_Kill(char* c) {
+s32 func_ov064_02119ea0(char* c) {
     *(s16*)(c + 0x100) = 0xc8;
     s32 angle = _ZN5Actor18HorzAngleToCPlayerEv(c);
     *(s16*)(c + 0x388) = (s16)angle;

--- a/src/func_ov064_0211a2c4.cpp
+++ b/src/func_ov064_0211a2c4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov064_0211a2c4
-// @emits WaterRing_Kill
+// recovered name: WaterRing_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daWater_Ring_c::Kill - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; };
@@ -9,7 +9,7 @@ struct Actor {
     void UntrackAndSpawnStar(signed char &a, unsigned int b, const Vector3 &c, unsigned int d);
 };
 
-extern "C" void WaterRing_Kill(char *thiz)
+extern "C" void func_ov064_0211a2c4(char *thiz)
 {
     Vector3 v;
     if (*(unsigned char*)(thiz + 0x173) == 0) return;

--- a/src/func_ov065_02116f0c.c
+++ b/src/func_ov065_02116f0c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov065_02116f0c
-// @emits Snufit_OnAimedAtWithEgg
+// recovered name: Snufit_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daYurei_Mucho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Snufit_OnAimedAtWithEgg(void)
+int func_ov065_02116f0c(void)
 {
     return 0;
 }

--- a/src/func_ov065_02116f14.cpp
+++ b/src/func_ov065_02116f14.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov065_02116f14
-// @emits Snufit_OnTurnIntoEgg
+// recovered name: Snufit_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daYurei_Mucho_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int Snufit_OnTurnIntoEgg(char *c, void *player) {
+int func_ov065_02116f14(char *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, (unsigned char)(*(unsigned char*)(c+0x10a)+1), 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov065_02116f40.c
+++ b/src/func_ov065_02116f40.c
@@ -1,8 +1,8 @@
 // @symbol func_ov065_02116f40
-// @emits Snufit_OnYoshiTryEat
+// recovered name: Snufit_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daYurei_Mucho_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Snufit_OnYoshiTryEat(void)
+int func_ov065_02116f40(void)
 {
     return 4;
 }

--- a/src/func_ov065_021177e4.cpp
+++ b/src/func_ov065_021177e4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov065_021177e4
-// @emits Snufit_Kill
+// recovered name: Snufit_Kill
 /* recovered: renamed to Class_Method */
 /* daYurei_Mucho_c::Kill - recovered from vtable slot identity */
 struct Vector3 {
@@ -14,10 +14,10 @@ extern "C" {
 extern P2 data_ov065_0211d6a0;
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *self, int file, int frame, int speed, unsigned int flags);
 extern void func_02012694(int id, void *pos);
-extern int Snufit_Kill(int *t);
+extern int func_ov065_021177e4(int *t);
 }
 
-int Snufit_Kill(int *t)
+int func_ov065_021177e4(int *t)
 {
     t[0x27] = -0x1000;
     t[0x28] = -0xa000;

--- a/src/func_ov065_02117eac.c
+++ b/src/func_ov065_02117eac.c
@@ -1,8 +1,8 @@
 // @symbol func_ov065_02117eac
-// @emits Swoop_OnAimedAtWithEgg
+// recovered name: Swoop_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBasabasa_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Swoop_OnAimedAtWithEgg(void)
+int func_ov065_02117eac(void)
 {
     return 0;
 }

--- a/src/func_ov065_02117eb4.cpp
+++ b/src/func_ov065_02117eb4.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov065_02117eb4
-// @emits Swoop_OnTurnIntoEgg
+// recovered name: Swoop_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daBasabasa_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int Swoop_OnTurnIntoEgg(char *c, void *player) {
+int func_ov065_02117eb4(char *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, (unsigned char)(*(unsigned char*)(c+0x10a)+1), 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov065_02117ee0.c
+++ b/src/func_ov065_02117ee0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov065_02117ee0
-// @emits Swoop_OnYoshiTryEat
+// recovered name: Swoop_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daBasabasa_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Swoop_OnYoshiTryEat(void)
+int func_ov065_02117ee0(void)
 {
     return 4;
 }

--- a/src/func_ov065_021195e4.c
+++ b/src/func_ov065_021195e4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov065_021195e4
-// @emits DorrieCap_OnYoshiTryEat
+// recovered name: DorrieCap_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daDossyCap_c::OnYoshiTryEat - recovered from vtable slot identity */
-int DorrieCap_OnYoshiTryEat(void)
+int func_ov065_021195e4(void)
 {
     return 4;
 }

--- a/src/func_ov065_02119f88.c
+++ b/src/func_ov065_02119f88.c
@@ -1,5 +1,5 @@
 // @symbol func_ov065_02119f88
-// @emits daObjCtMecha03_c_OnYoshiTryEat
+// recovered name: daObjCtMecha03_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjCtMecha03_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjCtMecha03_c_OnYoshiTryEat(int *t)
+int *func_ov065_02119f88(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x330);

--- a/src/func_ov065_0211a15c.c
+++ b/src/func_ov065_0211a15c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov065_0211a15c
-// @emits daObjCtMecha03_c_CleanupResources
+// recovered name: daObjCtMecha03_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha03_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjCtMecha03_c_CleanupResources(void *t)
+int func_ov065_0211a15c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov065_0211a1a0.cpp
+++ b/src/func_ov065_0211a1a0.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov065_0211a1a0
-// @emits daObjCtMecha03_c_Render
+// recovered name: daObjCtMecha03_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha03_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjCtMecha03_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov065_0211a1a0(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov065_0211a1c8.c
+++ b/src/func_ov065_0211a1c8.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjCtMecha03_c.h"
-// @emits daObjCtMecha03_c_Behavior
+// recovered name: daObjCtMecha03_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha03_c::Behavior - recovered from vtable slot identity */
 extern u16 DecIfAbove0_Short(u16* p);
@@ -18,7 +18,7 @@ extern int data_0209e650;
 
 #define I16(off) (*(short*)(((int)c + (off)) & 0xFFFFFFFFFFFFFFFFLL))
 
-int daObjCtMecha03_c_Behavior(char* c)
+int func_ov065_0211a1c8(char* c)
 {
     struct daObjCtMecha03_c *self = (struct daObjCtMecha03_c *)(void *)c;
     if (data_0209f2c0 != 3) {

--- a/src/func_ov065_0211a358.cpp
+++ b/src/func_ov065_0211a358.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov065_0211a358
-// @emits daObjCtMecha03_c_InitResources
+// recovered name: daObjCtMecha03_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -27,7 +27,7 @@ extern struct SharedFilePtr data_ov065_0211d894;
 extern unsigned char data_0209f2c0;
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 
-extern "C" int daObjCtMecha03_c_InitResources(char *self) {
+extern "C" int func_ov065_0211a358(char *self) {
     struct BMD_File *bmd;
     struct KCL_File *kcl;
     bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov065_0211d88c);

--- a/src/func_ov065_0211abac.c
+++ b/src/func_ov065_0211abac.c
@@ -1,5 +1,5 @@
 // @symbol func_ov065_0211abac
-// @emits daObjCtMecha05_c_OnYoshiTryEat
+// recovered name: daObjCtMecha05_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjCtMecha05_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjCtMecha05_c_OnYoshiTryEat(int *t)
+int *func_ov065_0211abac(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x33c);

--- a/src/func_ov065_0211ad04.c
+++ b/src/func_ov065_0211ad04.c
@@ -1,12 +1,12 @@
 // @symbol func_ov065_0211ad04
-// @emits daObjCtMecha05_c_CleanupResources
+// recovered name: daObjCtMecha05_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha05_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjCtMecha05_c_CleanupResources(void *t)
+int func_ov065_0211ad04(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov065_0211ad48.cpp
+++ b/src/func_ov065_0211ad48.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov065_0211ad48
-// @emits daObjCtMecha05_c_Render
+// recovered name: daObjCtMecha05_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha05_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjCtMecha05_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov065_0211ad48(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov065_0211ae08.c
+++ b/src/func_ov065_0211ae08.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjCtMecha05_c.h"
-// @emits daObjCtMecha05_c_Behavior
+// recovered name: daObjCtMecha05_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjCtMecha05_c::Behavior - recovered from vtable slot identity */
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void* self);
@@ -21,7 +21,7 @@ extern int data_0209e650;
 #define I32(off) (*(int*)(((int)c + (off))))
 #define I8(off)  (*(u8*)(((int)c + (off))))
 
-int daObjCtMecha05_c_Behavior(char* c)
+int func_ov065_0211ae08(char* c)
 {
     struct daObjCtMecha05_c *self = (struct daObjCtMecha05_c *)(void *)c;
     if (data_0209f2c0 == 3) {

--- a/src/func_ov065_0211b1d4.cpp
+++ b/src/func_ov065_0211b1d4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov065_0211b1d4
-// @emits daObjCtMecha05_c_InitResources
+// recovered name: daObjCtMecha05_c_InitResources
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -29,7 +29,7 @@ extern "C" unsigned char data_0209f2c0;
 
 struct V3 { int x, y, z; };
 
-extern "C" int daObjCtMecha05_c_InitResources(char *self)
+extern "C" int func_ov065_0211b1d4(char *self)
 {
     void *mf = ModelLoadFile(&data_ov065_0211d904);
     ((ModelBase*)(self + 0xd4))->SetFile((BMD_File*)mf, 1, -1);


### PR DESCRIPTION
Each file in this batch carried a pair of annotations recording that it defined a different symbol than its filename:

```c
// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
```

**Nothing in the repo consumes either annotation** — no tool, no CI config, no doc mentions them — and the divergence quietly broke two things:

**`match.py` cannot verify these files at all.** Asked for the filename's symbol it reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns `MATCHING VERSIONS: none` for every one. Meanwhile `progress.py` counts them as matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING` hatch. **712 files — about 6% of `src/` — were being counted as matched progress while being unverifiable by the repo's own gate.**

**The ROM link cannot use them either.** Gap objects import a carved-out function by its `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every caller silently binding to address 0 rather than erroring.

`tools/reconcile_names.py` (PR #941) renames the emitted function to the `@symbol` name and replaces the now-redundant `@emits` line with `// recovered name: <name>`, so the recovered identity — usually from a vtable slot — is preserved in the file. Each file is byte-verified against the ROM before the edit is kept; anything that stops matching is reverted.

711 of 712 verified and are split across these batches. The holdout, `func_ov022_021123d0`, declares its own symbol with a conflicting signature and is left for a human. 699 of the 711 reproduce under `2004/b56`; 12 need a `1.2/base` override, recorded in `config/rombuild-versions.txt`.

**The opposite direction is deliberately not taken here.** Adopting the recovered names into `config/**/symbols.txt` is the better long-term move, but it changes the canonical symbol table and every reference to those names — a maintainer's call, not a build fix.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
