### PR TITLE
Make each file define the symbol its filename claims (172 files) [03/05]

### DIFF
--- a/src/func_ov003_020ad69c.c
+++ b/src/func_ov003_020ad69c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov003_020ad69c
-// @emits dScTitle_c_OnYoshiTryEat
+// recovered name: dScTitle_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void *data_020a0eac;
 
-int *dScTitle_c_OnYoshiTryEat(int *t)
+int *func_ov003_020ad69c(int *t)
 {
     t[0] = (int)data_ov003_020b1650;
     t[0] = (int)_ZTV5Stage;

--- a/src/func_ov003_020ad7a0.c
+++ b/src/func_ov003_020ad7a0.c
@@ -1,7 +1,7 @@
 // @symbol func_ov003_020ad7a0
-// @emits dScTitle_c_OnPendingDestroy
+// recovered name: dScTitle_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScTitle_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScTitle_c_OnPendingDestroy(void)
+void func_ov003_020ad7a0(void)
 {
 }

--- a/src/func_ov003_020ad7a4.cpp
+++ b/src/func_ov003_020ad7a4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov003_020ad7a4
-// @emits dScTitle_c_Render
+// recovered name: dScTitle_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern char data_0209e674[];
 }
 struct OamTmp { int x; };
 namespace OAM { void EnableSubOAM(OamTmp*); }
-extern "C" int dScTitle_c_Render(void)
+extern "C" int func_ov003_020ad7a4(void)
 {
     OamTmp tmp;
     OAM::EnableSubOAM(&tmp);

--- a/src/func_ov003_020ad814.cpp
+++ b/src/func_ov003_020ad814.cpp
@@ -1,12 +1,12 @@
 //cpp
 #include "types.h"
 // @symbol func_ov003_020ad814
-// @emits dScTitle_c_Behavior
+// recovered name: dScTitle_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScTitle_c::Behavior - recovered from vtable slot identity */
-/* dScTitle_c_Behavior @ 0x020ad814 (ov003, size 0x26c)
+/* func_ov003_020ad814 @ 0x020ad814 (ov003, size 0x26c)
  * Level-select cursor update: on confirm (or minigame-active flag) starts the
  * scene fade / loads the picked level from the 8-byte entry table at
  * data_ov003_020b1180; otherwise moves the cursor by row (+0x35) or column
@@ -37,7 +37,7 @@ extern void _ZN5Sound22StopLoadedMusic_Layer1Ej(u32 a);
 extern u16 DecIfAbove0_Short(u16 *p);
 extern void func_ov003_020ad6ec(char *c);
 
-int dScTitle_c_Behavior(char *c)
+int func_ov003_020ad814(char *c)
 {
     if (data_0209f5bc->v5()) {
         int r3 = 0;

--- a/src/func_ov003_020ada80.c
+++ b/src/func_ov003_020ada80.c
@@ -1,9 +1,9 @@
 // @symbol func_ov003_020ada80
-// @emits dScTitle_c_CleanupResources
+// recovered name: dScTitle_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScTitle_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void *);
-int dScTitle_c_CleanupResources(void *t)
+int func_ov003_020ada80(void *t)
 {
     _ZN5Sound21UnsetPlayerVoiceGroupEv(t);
     return 1;

--- a/src/func_ov003_020ada9c.cpp
+++ b/src/func_ov003_020ada9c.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov003_020ada9c
-// @emits dScTitle_c_InitResources
+// recovered name: dScTitle_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScTitle_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -31,7 +31,7 @@ namespace GX {
 namespace G2 { unsigned short *GetBG0ScrPtr(); }
 namespace Sound { void LoadInitialGroup(int); void LoadAndSetMusic_Layer1(int); }
 
-extern "C" int dScTitle_c_InitResources(int arg)
+extern "C" int func_ov003_020ada9c(int arg)
 {
     UnloadArchives();
     Enable3dEngines();

--- a/src/func_ov003_020ade54.c
+++ b/src/func_ov003_020ade54.c
@@ -1,5 +1,5 @@
 // @symbol func_ov003_020ade54
-// @emits dScStarSel_c_OnYoshiTryEat
+// recovered name: dScStarSel_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Model.h"
 #include "decl_common.h"
@@ -10,7 +10,7 @@ extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void _ZN9ActorBaseD2Ev(void*);
 extern void* data_020a0eac;
-int* dScStarSel_c_OnYoshiTryEat(int* t){
+int* func_ov003_020ade54(int* t){
   t[0]=(int)data_ov003_020b1704;
   __destroy_arr((char*)t+0x64, 2, 0x50, (void*)_ZN5ModelD1Ev);
   t[0]=(int)_ZTV5Stage;

--- a/src/func_ov003_020ae6f0.c
+++ b/src/func_ov003_020ae6f0.c
@@ -1,7 +1,7 @@
 // @symbol func_ov003_020ae6f0
-// @emits dScStarSel_c_OnPendingDestroy
+// recovered name: dScStarSel_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScStarSel_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScStarSel_c_OnPendingDestroy(void)
+void func_ov003_020ae6f0(void)
 {
 }

--- a/src/func_ov003_020af86c.cpp
+++ b/src/func_ov003_020af86c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov003_020af86c
-// @emits dScStarSel_c_CleanupResources
+// recovered name: dScStarSel_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ public:
 };
 
 
-extern "C" int dScStarSel_c_CleanupResources(void) {
+extern "C" int func_ov003_020af86c(void) {
     CleanCommonModelDataArr();
     Sound::UnsetPlayerVoiceGroup();
     unsigned short *p = (unsigned short *)0x4000304;

--- a/src/func_ov003_020b05bc.c
+++ b/src/func_ov003_020b05bc.c
@@ -1,12 +1,12 @@
 // @symbol func_ov003_020b05bc
-// @emits dScGameOver_c_OnYoshiTryEat
+// recovered name: dScGameOver_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: vtable identified, renamed to Class_Method */
 /* dScGameOver_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *);
 extern void *G0;
-int *dScGameOver_c_OnYoshiTryEat(int *t)
+int *func_ov003_020b05bc(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov003_020b0810.c
+++ b/src/func_ov003_020b0810.c
@@ -1,7 +1,7 @@
 // @symbol func_ov003_020b0810
-// @emits dScGameOver_c_OnPendingDestroy
+// recovered name: dScGameOver_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScGameOver_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScGameOver_c_OnPendingDestroy(void)
+void func_ov003_020b0810(void)
 {
 }

--- a/src/func_ov003_020b0814.cpp
+++ b/src/func_ov003_020b0814.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov003_020b0814
-// @emits dScGameOver_c_Render
+// recovered name: dScGameOver_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Stage.h"
 /* recovered: renamed to Class_Method */
@@ -15,8 +15,8 @@ extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
     bool32 sub, struct OamAttri *data, s32 x, s32 y,
     s32 palette, s32 priority, Fix12i scaleX, Fix12i scaleY,
     s32 rotation, s32 mode);
-int dScGameOver_c_Render(char *c);
-int dScGameOver_c_Render(char *c) {
+int func_ov003_020b0814(char *c);
+int func_ov003_020b0814(char *c) {
     int i;
     for (i = 0; i < 8; i++) {
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(

--- a/src/func_ov003_020b0b34.c
+++ b/src/func_ov003_020b0b34.c
@@ -1,8 +1,8 @@
 // @symbol func_ov003_020b0b34
-// @emits dScGameOver_c_CleanupResources
+// recovered name: dScGameOver_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* dScGameOver_c::CleanupResources - recovered from vtable slot identity */
-int dScGameOver_c_CleanupResources(void)
+int func_ov003_020b0b34(void)
 {
     return 1;
 }

--- a/src/func_ov003_020b0b3c.c
+++ b/src/func_ov003_020b0b3c.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov003_020b0b3c
-// @emits dScGameOver_c_InitResources
+// recovered name: dScGameOver_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -26,7 +26,7 @@ extern u8 data_0209d454;
 extern u8 data_0209f204;
 extern int data_0208ee44;
 
-int dScGameOver_c_InitResources(void *arg)
+int func_ov003_020b0b3c(void *arg)
 {
     char *c = (char *)arg;
     int f;

--- a/src/func_ov015_021111d0.c
+++ b/src/func_ov015_021111d0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov015_021111d0
-// @emits daObjBkBillboard_c_OnYoshiTryEat
+// recovered name: daObjBkBillboard_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBkBillboard_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjBkBillboard_c_OnYoshiTryEat(int *t)
+int *func_ov015_021111d0(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov015_02111278.cpp
+++ b/src/func_ov015_02111278.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov015_02111278
-// @emits daObjBkBillboard_c_Render
+// recovered name: daObjBkBillboard_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjBkBillboard_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjBkBillboard_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov015_02111278(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov015_021112a0.cpp
+++ b/src/func_ov015_021112a0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov015_021112a0
-// @emits daObjBkBillboard_c_InitResources
+// recovered name: daObjBkBillboard_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -17,7 +17,7 @@ struct ModelBase {
 };
 
 
-extern "C" int daObjBkBillboard_c_InitResources(char *c) {
+extern "C" int func_ov015_021112a0(char *c) {
     BMD_File *file = Model::LoadFile(*(SharedFilePtr *)&data_ov015_02114960);
     ((ModelBase *)(c + 0xd4))->SetFile(file, 1, -1);
     func_ov015_02111214(c);

--- a/src/func_ov015_021113c0.cpp
+++ b/src/func_ov015_021113c0.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov015_021113c0
-// @emits PoleBillboard_OnHitByMegaChar
+// recovered name: PoleBillboard_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjBk_Botaosi_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Player {
     void IncMegaKillCount();
 };
 
-extern "C" void PoleBillboard_OnHitByMegaChar(char *c, void *arg) {
+extern "C" void func_ov015_021113c0(char *c, void *arg) {
     unsigned char v = *(unsigned char *)(c + 0x397);
     if (v >= 2) return;
     ((Player *)arg)->IncMegaKillCount();

--- a/src/func_ov015_021113fc.c
+++ b/src/func_ov015_021113fc.c
@@ -1,13 +1,13 @@
 // @symbol func_ov015_021113fc
-// @emits PoleBillboard_OnKicked
+// recovered name: PoleBillboard_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjBk_Botaosi_c::OnKicked - recovered from vtable slot identity */
-/* PoleBillboard_OnKicked @ 0x21113fc (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
+/* func_ov015_021113fc @ 0x21113fc (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
  * ldr ip, [pc]; bx ip; .word 0x2111414
  */
 
-void PoleBillboard_OnKicked(void) {
+void func_ov015_021113fc(void) {
     func_ov015_02111414();
 }

--- a/src/func_ov015_02111408.c
+++ b/src/func_ov015_02111408.c
@@ -1,13 +1,13 @@
 // @symbol func_ov015_02111408
-// @emits PoleBillboard_OnAttacked2
+// recovered name: PoleBillboard_OnAttacked2
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjBk_Botaosi_c::OnAttacked2 - recovered from vtable slot identity */
-/* PoleBillboard_OnAttacked2 @ 0x2111408 (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
+/* func_ov015_02111408 @ 0x2111408 (ov015) -- tail-call veneer to func_ov015_02111414 (0x2111414).
  * ldr ip, [pc]; bx ip; .word 0x2111414
  */
 
-void PoleBillboard_OnAttacked2(void) {
+void func_ov015_02111408(void) {
     func_ov015_02111414();
 }

--- a/src/func_ov015_02111c3c.cpp
+++ b/src/func_ov015_02111c3c.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov015_02111c3c
-// @emits KnockDownPlank_Kill
+// recovered name: KnockDownPlank_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBk_Dossunbar_c::Kill - recovered from vtable slot identity */
-// KnockDownPlank_Kill at 0x02111c3c
+// func_ov015_02111c3c at 0x02111c3c
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov015).
 struct Vector3 { int x, y, z; };
 
@@ -14,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 void _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" void KnockDownPlank_Kill(char* self);
-void KnockDownPlank_Kill(char* self) {
+extern "C" void func_ov015_02111c3c(char* self);
+void func_ov015_02111c3c(char* self) {
     Vector3 vec;
     Vector3 vec2;
     vec.x = *(int*)(self + 0x5c);

--- a/src/func_ov015_02111cb8.cpp
+++ b/src/func_ov015_02111cb8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov015_02111cb8
-// @emits KnockDownPlank_OnHitByMegaChar
+// recovered name: KnockDownPlank_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjBk_Dossunbar_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void KnockDownPlank_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov015_02111cb8(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov015_02111d28.c
+++ b/src/func_ov015_02111d28.c
@@ -1,11 +1,11 @@
 // @symbol func_ov015_02111d28
-// @emits PoleBillboard_AfterClsn
+// recovered name: PoleBillboard_AfterClsn
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjBk_Botaosi_c::AfterClsn - recovered from vtable slot identity */
 
-void PoleBillboard_AfterClsn(char *self) {
+void func_ov015_02111d28(char *self) {
     *(int *)(self + 0xa4) = -0x14000;
     func_02012664(0xc3, self + 0x74);
 }

--- a/src/func_ov015_0211233c.cpp
+++ b/src/func_ov015_0211233c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov015_0211233c
-// @emits MovingBarSmall_Kill
+// recovered name: MovingBarSmall_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBk_Lift_c::Kill - recovered from vtable slot identity */
 extern "C" {
@@ -9,7 +9,7 @@ extern void _ZN5Actor10PoofDustAtERK7Vector3(void *self, void *v);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void *);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *);
 struct Vector3 { int x, y, z; };
-void MovingBarSmall_Kill(char *c)
+void func_ov015_0211233c(char *c)
 {
     struct Vector3 v;
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x48, *(int *)(c + 0x5c), *(int *)(c + 0x60), *(int *)(c + 0x64));

--- a/src/func_ov015_021123a0.cpp
+++ b/src/func_ov015_021123a0.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov015_021123a0
-// @emits MovingBarSmall_OnHitByMegaChar
+// recovered name: MovingBarSmall_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjBk_Lift_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void MovingBarSmall_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov015_021123a0(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov015_02112c20.c
+++ b/src/func_ov015_02112c20.c
@@ -1,5 +1,5 @@
 // @symbol func_ov015_02112c20
-// @emits daObjBk_Ukisima_c_OnYoshiTryEat
+// recovered name: daObjBk_Ukisima_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBk_Ukisima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjBk_Ukisima_c_OnYoshiTryEat(int *t)
+int *func_ov015_02112c20(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov015_02112c84.c
+++ b/src/func_ov015_02112c84.c
@@ -1,5 +1,5 @@
 // @symbol func_ov015_02112c84
-// @emits daObjBk_Ukisima_c_CleanupResources
+// recovered name: daObjBk_Ukisima_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@
 #pragma long_calls on
 extern char data_ov015_021147a4[];
 
-int daObjBk_Ukisima_c_CleanupResources(void *thisp)
+int func_ov015_02112c84(void *thisp)
 {
     return func_020b66a8(thisp, data_ov015_021147a4);
 }

--- a/src/func_ov015_02112c98.c
+++ b/src/func_ov015_02112c98.c
@@ -1,5 +1,5 @@
 // @symbol func_ov015_02112c98
-// @emits daObjBk_Ukisima_c_InitResources
+// recovered name: daObjBk_Ukisima_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b676c(unsigned char *self, struct Arg *a, short arg2);
 extern struct Arg data_ov015_021147a4;
 
-int daObjBk_Ukisima_c_InitResources(unsigned char *self)
+int func_ov015_02112c98(unsigned char *self)
 {
     return func_ov002_020b676c(self, &data_ov015_021147a4, data_ov015_02114794);
 }

--- a/src/func_ov018_021111e4.c
+++ b/src/func_ov018_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov018_021111e4
-// @emits daObjSm_Lift_c_OnYoshiTryEat
+// recovered name: daObjSm_Lift_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjSm_Lift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjSm_Lift_c_OnYoshiTryEat(int *t)
+int *func_ov018_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov018_0211123c.cpp
+++ b/src/func_ov018_0211123c.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov018_0211123c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjSm_Lift_c.h"
-// @emits daObjSm_Lift_c_OnHitByMegaChar
+// recovered name: daObjSm_Lift_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjSm_Lift_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Player {
@@ -13,7 +13,7 @@ struct Platform {
     void KillByMegaChar(Player &);
 };
 
-extern "C" void daObjSm_Lift_c_OnHitByMegaChar(char *c, void *p) {
+extern "C" void func_ov018_0211123c(char *c, void *p) {
     struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
     ((Player *)p)->IncMegaKillCount();
     ((Platform *)c)->KillByMegaChar(*(Player *)p);

--- a/src/func_ov018_02111340.cpp
+++ b/src/func_ov018_02111340.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov018_02111340
-// @emits daObjSm_Lift_c_Render
+// recovered name: daObjSm_Lift_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjSm_Lift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjSm_Lift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov018_02111340(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov018_02111368.cpp
+++ b/src/func_ov018_02111368.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov018_02111368
-// @emits daObjSm_Lift_c_Behavior
+// recovered name: daObjSm_Lift_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjSm_Lift_c::Behavior - recovered from vtable slot identity */
 typedef unsigned char u8;
@@ -38,7 +38,7 @@ extern s16 data_02082214[];
 struct Vector3 { int x, y, z; };
 struct PathPtrObj { int a, b; };
 
-extern "C" int daObjSm_Lift_c_Behavior(char* self)
+extern "C" int func_ov018_02111368(char* self)
 {
     struct PathPtrObj path;
     struct Vector3 nodeA, nodeB, diff, scaled;

--- a/src/func_ov018_021116b4.cpp
+++ b/src/func_ov018_021116b4.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov018_021116b4
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjSm_Lift_c.h"
-// @emits daObjSm_Lift_c_InitResources
+// recovered name: daObjSm_Lift_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjSm_Lift_c::InitResources - recovered from vtable slot identity */
 struct PathPtr { char b[8]; };
@@ -24,7 +24,7 @@ extern int data_ov018_02112f48[];
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
 extern int func_ov018_02111804[];
 
-int daObjSm_Lift_c_InitResources(char* c){
+int func_ov018_021116b4(char* c){
     struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
   self->unk_334 = *(int*)(c+8) & 0xff;
   if(self->unk_334 == 0xff) return 0;

--- a/src/func_ov018_021122ec.c
+++ b/src/func_ov018_021122ec.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjSm_Lift_c.h"
-// @emits daObjSm_Lift_c_AfterClsn
+// recovered name: daObjSm_Lift_c_AfterClsn
 /* recovered: renamed to Class_Method */
 /* daObjSm_Lift_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
 extern int _ZN15TextureSequence7SetFileER8BTP_Filei5Fix12IiEj(void*,int,int,int,unsigned int);
 extern int func_ov030_02113be8[];
-int daObjSm_Lift_c_AfterClsn(char* c){
+int func_ov018_021122ec(char* c){
     struct daObjSm_Lift_c *self = (struct daObjSm_Lift_c *)(void *)c;
   _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj((char*)c+0xd4, data_ov027_02113bf0[1], 0, 0x1000, 0);
   self->unk_130=0x1000;

--- a/src/func_ov018_021126f8.c
+++ b/src/func_ov018_021126f8.c
@@ -1,11 +1,11 @@
 // @symbol func_ov018_021126f8
-// @emits daSCre_c_OnYoshiTryEat
+// recovered name: daSCre_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daSCre_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *daSCre_c_OnYoshiTryEat(int *t)
+int *func_ov018_021126f8(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov018_02112730.cpp
+++ b/src/func_ov018_02112730.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov018_02112730
-// @emits daSCre_c_Behavior
+// recovered name: daSCre_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daSCre_c::Behavior - recovered from vtable slot identity */
 struct Vector3 { int x,y,z; };
@@ -10,7 +10,7 @@ struct Actor {
   static int Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
   void MarkForDestruction();
 };
-extern "C" int daSCre_c_Behavior(Actor* c){
+extern "C" int func_ov018_02112730(Actor* c){
   if (c->DistToCPlayer() < 0x64000) {
     Actor::Spawn(0xb2, (*(int*)((char*)c+8) & 0xf) | 0x40, *(Vector3*)((char*)c+0x5c), 0, *(signed char*)((char*)c+0xcc), -1);
   }

--- a/src/func_ov018_02112858.cpp
+++ b/src/func_ov018_02112858.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov018_02112858
-// @emits IceSheet_OnHitByMegaChar
+// recovered name: IceSheet_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjIceBoard_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void IceSheet_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov018_02112858(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov018_02112880.cpp
+++ b/src/func_ov018_02112880.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov018_02112880
-// @emits IceSheet_Kill
+// recovered name: IceSheet_Kill
 /* recovered: renamed to Class_Method */
 /* daObjIceBoard_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned, void*);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
-void IceSheet_Kill(char* c){
+void func_ov018_02112880(char* c){
   _ZN5Sound9PlayBank3EjRK7Vector3(0x41, c+0x74);
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x74, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x75, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));

--- a/src/func_ov018_021128e0.cpp
+++ b/src/func_ov018_021128e0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov018_021128e0
-// @emits IceSheet_OnGroundPounded
+// recovered name: IceSheet_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjIceBoard_c::OnGroundPounded - recovered from vtable slot identity */
 struct C {
@@ -14,7 +14,7 @@ struct C {
   virtual void p28(); virtual void p29(); virtual void p30(); virtual void f7c();
 };
 struct A { char pad[8]; int kind; };
-extern "C" void IceSheet_OnGroundPounded(C *c, A *a){
+extern "C" void func_ov018_021128e0(C *c, A *a){
   if(a == 0) return;
   if(a->kind != 2) return;
   c->f7c();

--- a/src/func_ov022_021115f8.c
+++ b/src/func_ov022_021115f8.c
@@ -1,5 +1,5 @@
 // @symbol func_ov022_021115f8
-// @emits daObjFl_Koma_D_c_OnYoshiTryEat
+// recovered name: daObjFl_Koma_D_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Koma_D_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjFl_Koma_D_c_OnYoshiTryEat(int *t)
+int *func_ov022_021115f8(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_0211165c.c
+++ b/src/func_ov022_0211165c.c
@@ -1,11 +1,11 @@
 // @symbol func_ov022_0211165c
-// @emits daObjFl_Koma_D_c_CleanupResources
+// recovered name: daObjFl_Koma_D_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Koma_D_c::CleanupResources - recovered from vtable slot identity */
 extern int data_ov022_02113da4[];
-int daObjFl_Koma_D_c_CleanupResources(void *self)
+int func_ov022_0211165c(void *self)
 {
     return func_020b66a8(self, data_ov022_02113da4);
 }

--- a/src/func_ov022_02111670.c
+++ b/src/func_ov022_02111670.c
@@ -1,5 +1,5 @@
 // @symbol func_ov022_02111670
-// @emits daObjFl_Koma_D_c_InitResources
+// recovered name: daObjFl_Koma_D_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjFl_Koma_D_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -7,7 +7,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b676c(unsigned char *self, struct Arg *a, short arg2);
 extern struct Arg data_ov022_02113da4;
 
-void daObjFl_Koma_D_c_InitResources(unsigned char *c)
+void func_ov022_02111670(unsigned char *c)
 {
     func_ov002_020b676c(c, &data_ov022_02113da4, 0x100);
 }

--- a/src/func_ov022_021119c4.c
+++ b/src/func_ov022_021119c4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov022_021119c4
-// @emits daObjFl_London_c_OnYoshiTryEat
+// recovered name: daObjFl_London_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_London_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjFl_London_c_OnYoshiTryEat(int *t)
+int *func_ov022_021119c4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_02111a64.c
+++ b/src/func_ov022_02111a64.c
@@ -1,12 +1,12 @@
 // @symbol func_ov022_02111a64
-// @emits daObjFl_London_c_CleanupResources
+// recovered name: daObjFl_London_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_London_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjFl_London_c_CleanupResources(void *t)
+int func_ov022_02111a64(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov022_02111aa8.cpp
+++ b/src/func_ov022_02111aa8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov022_02111aa8
-// @emits daObjFl_London_c_Render
+// recovered name: daObjFl_London_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjFl_London_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjFl_London_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov022_02111aa8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov022_02111ad0.c
+++ b/src/func_ov022_02111ad0.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjFl_London_c.h"
-// @emits daObjFl_London_c_Behavior
+// recovered name: daObjFl_London_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjFl_London_c::Behavior - recovered from vtable slot identity */
 extern unsigned char DecIfAbove0_Byte(unsigned char* p);
@@ -11,7 +11,7 @@ extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void* v);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* t, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* t);
 
-int daObjFl_London_c_Behavior(char* c)
+int func_ov022_02111ad0(char* c)
 {
     struct daObjFl_London_c *self = (struct daObjFl_London_c *)(void *)c;
     if (DecIfAbove0_Byte((unsigned char*)c + 0x31e) == 0) {

--- a/src/func_ov022_02111bdc.cpp
+++ b/src/func_ov022_02111bdc.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjFl_London_c.h"
-// @emits daObjFl_London_c_InitResources
+// recovered name: daObjFl_London_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjFl_London_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
@@ -27,7 +27,7 @@ extern CLPS_Block data_ov064_0211bb2c;
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int daObjFl_London_c_InitResources(char *c)
+extern "C" int func_ov022_02111bdc(char *c)
 {
     struct daObjFl_London_c *self = (struct daObjFl_London_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov022_02114580);

--- a/src/func_ov022_02111cf0.c
+++ b/src/func_ov022_02111cf0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov022_02111cf0
-// @emits daObjFl_Seesaw_c_OnYoshiTryEat
+// recovered name: daObjFl_Seesaw_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjFl_Seesaw_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjFl_Seesaw_c_OnYoshiTryEat(int *t)
+int *func_ov022_02111cf0(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov022_02111d90.c
+++ b/src/func_ov022_02111d90.c
@@ -1,12 +1,12 @@
 // @symbol func_ov022_02111d90
-// @emits daObjFl_Seesaw_c_CleanupResources
+// recovered name: daObjFl_Seesaw_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Seesaw_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjFl_Seesaw_c_CleanupResources(void *t)
+int func_ov022_02111d90(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov022_02111dd4.cpp
+++ b/src/func_ov022_02111dd4.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov022_02111dd4
-// @emits daObjFl_Seesaw_c_Render
+// recovered name: daObjFl_Seesaw_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjFl_Seesaw_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjFl_Seesaw_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov022_02111dd4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov022_02111dfc.c
+++ b/src/func_ov022_02111dfc.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjFl_Seesaw_c.h"
-// @emits daObjFl_Seesaw_c_Behavior
+// recovered name: daObjFl_Seesaw_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjFl_Seesaw_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
@@ -13,7 +13,7 @@ extern unsigned char DecIfAbove0_Byte(unsigned char* p);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char* c, Fix12 a, Fix12 b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(char* c);
 
-int daObjFl_Seesaw_c_Behavior(char* c) {
+int func_ov022_02111dfc(char* c) {
     struct daObjFl_Seesaw_c *self = (struct daObjFl_Seesaw_c *)(void *)c;
   func_020393a4((int*)(c+0x124), 0x650000);
   if (DecIfAbove0_Byte((unsigned char*)(c+0x320)) == 0) {

--- a/src/func_ov022_02111ea0.cpp
+++ b/src/func_ov022_02111ea0.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjFl_Seesaw_c.h"
-// @emits daObjFl_Seesaw_c_InitResources
+// recovered name: daObjFl_Seesaw_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjFl_Seesaw_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
@@ -27,7 +27,7 @@ extern CLPS_Block data_ov064_0211bacc;
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int daObjFl_Seesaw_c_InitResources(char *c)
+extern "C" int func_ov022_02111ea0(char *c)
 {
     struct daObjFl_Seesaw_c *self = (struct daObjFl_Seesaw_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov022_021145a8);

--- a/src/func_ov022_02112434.c
+++ b/src/func_ov022_02112434.c
@@ -1,10 +1,10 @@
 // @symbol func_ov022_02112434
-// @emits daObjFl_Fall_Block_c_CleanupResources
+// recovered name: daObjFl_Fall_Block_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Fall_Block_c::CleanupResources - recovered from vtable slot identity */
-int daObjFl_Fall_Block_c_CleanupResources(void *self)
+int func_ov022_02112434(void *self)
 {
     return func_0213a2cc(self, data_ov022_0211427c);
 }

--- a/src/func_ov022_02112448.c
+++ b/src/func_ov022_02112448.c
@@ -1,10 +1,10 @@
 // @symbol func_ov022_02112448
-// @emits daObjFl_Fall_Block_c_InitResources
+// recovered name: daObjFl_Fall_Block_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFl_Fall_Block_c::InitResources - recovered from vtable slot identity */
-int daObjFl_Fall_Block_c_InitResources(void *self)
+int func_ov022_02112448(void *self)
 {
     return func_0213a794(self, data_ov022_0211427c);
 }

--- a/src/func_ov022_021126ac.c
+++ b/src/func_ov022_021126ac.c
@@ -1,11 +1,11 @@
 // @symbol func_ov022_021126ac
-// @emits daObjFlMaruta_c_AfterClsn
+// recovered name: daObjFlMaruta_c_AfterClsn
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjFlMaruta_c::AfterClsn - recovered from vtable slot identity */
 extern int _ZN9ActorBase18MarkForDestructionEv(void *c);
-int daObjFlMaruta_c_AfterClsn(char *c) {
+int func_ov022_021126ac(char *c) {
     int a = *(int*)(c+0x60);
     int b = *(int*)(c+0x118);
     if (a < b) {

--- a/src/func_ov025_021111e4.c
+++ b/src/func_ov025_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov025_021111e4
-// @emits daDgr_c_OnYoshiTryEat
+// recovered name: daDgr_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daDgr_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daDgr_c_OnYoshiTryEat(int *t)
+int *func_ov025_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov025_02111384.cpp
+++ b/src/func_ov025_02111384.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov025_02111384
-// @emits daDgr_c_CleanupResources
+// recovered name: daDgr_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ void _ZN13SharedFilePtr7ReleaseEv(void* self);
 int _ZN16MeshColliderBase9IsEnabledEv(void* self);
 void _ZN16MeshColliderBase7DisableEv(void* self);
 extern int data_ov025_02113a68[];
-int daDgr_c_CleanupResources(char* c) {
+int func_ov025_02111384(char* c) {
   _ZN13SharedFilePtr7ReleaseEv(data_ov025_02113a68);
   _ZN13SharedFilePtr7ReleaseEv(data_ov036_02113a60);
   if (_ZN16MeshColliderBase9IsEnabledEv(c+0x124))

--- a/src/func_ov025_021113c8.cpp
+++ b/src/func_ov025_021113c8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov025_021113c8
-// @emits daDgr_c_Render
+// recovered name: daDgr_c_Render
 /* recovered: renamed to Class_Method */
 /* daDgr_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daDgr_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov025_021113c8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov025_021113f0.c
+++ b/src/func_ov025_021113f0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov025_021113f0
-// @emits daDgr_c_Behavior
+// recovered name: daDgr_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -16,7 +16,7 @@ extern s16 data_02082214[];
 
 #define LAUNDER(p) ((long long)(int)(p))
 
-int daDgr_c_Behavior(char *self)
+int func_ov025_021113f0(char *self)
 {
     s32 loc[6];
     s32 n;

--- a/src/func_ov025_021117dc.cpp
+++ b/src/func_ov025_021117dc.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov025_021117dc
-// @emits daDgr_c_InitResources
+// recovered name: daDgr_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -24,7 +24,7 @@ extern SharedFilePtr data_ov025_02113a60;
 extern CLPS_Block data_ov025_02112c28;
 extern int _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_;
 
-extern "C" int daDgr_c_InitResources(char* thiz)
+extern "C" int func_ov025_021117dc(char* thiz)
 {
     char* c = thiz;
     func_ov025_02111344(c);

--- a/src/func_ov025_02111928.c
+++ b/src/func_ov025_02111928.c
@@ -1,5 +1,5 @@
 // @symbol func_ov025_02111928
-// @emits daDkk_c_OnYoshiTryEat
+// recovered name: daDkk_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -10,7 +10,7 @@
 /* daDkk_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN15TextureSequenceD1Ev(void *);
 extern void *G0;
-int *daDkk_c_OnYoshiTryEat(int *t)
+int *func_ov025_02111928(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov025_0211199c.c
+++ b/src/func_ov025_0211199c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov025_0211199c
-// @emits daDkk_c_OnAimedAtWithEgg
+// recovered name: daDkk_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daDkk_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int daDkk_c_OnAimedAtWithEgg(void)
+int func_ov025_0211199c(void)
 {
     return 843776;
 }

--- a/src/func_ov025_02111b64.cpp
+++ b/src/func_ov025_02111b64.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov025_02111b64
-// @emits daDkk_c_Behavior
+// recovered name: daDkk_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void* p);
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* p, Fix12i a, Fix12i b);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void* p);
 
-extern "C" int daDkk_c_Behavior(char* thiz)
+extern "C" int func_ov025_02111b64(char* thiz)
 {
     char* c = thiz;
     switch (*(int*)(c + 0x398)) {

--- a/src/func_ov025_02111c24.cpp
+++ b/src/func_ov025_02111c24.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "daDkk_c.h"
-// @emits daDkk_c_InitResources
+// recovered name: daDkk_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* daDkk_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -14,7 +14,7 @@ extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void* self, voi
 extern int _ZN11RaycastLine10DetectClsnEv(void* self);
 extern void _ZN11RaycastLine10GetClsnPosEv(void* out, void* self);
 extern void _ZN11RaycastLineD1Ev(void* self);
-int daDkk_c_InitResources(char* c)
+int func_ov025_02111c24(char* c)
 {
     struct daDkk_c *self = (struct daDkk_c *)(void *)c;
     *(void**)(c + 0x320) = data_ov025_02113814;

--- a/src/func_ov026_021111e0.c
+++ b/src/func_ov026_021111e0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov026_021111e0
-// @emits daObjWlPolelift_c_OnYoshiTryEat
+// recovered name: daObjWlPolelift_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* daObjWlPolelift_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void *G0;
-int *daObjWlPolelift_c_OnYoshiTryEat(int *t)
+int *func_ov026_021111e0(int *t)
 {
     t[0] = (int)VT0;
     _ZN11ShadowModelD1Ev((char *)t + 0x188);

--- a/src/func_ov026_02111308.cpp
+++ b/src/func_ov026_02111308.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov026_02111308
-// @emits daObjWlPolelift_c_Render
+// recovered name: daObjWlPolelift_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjWlPolelift_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjWlPolelift_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov026_02111308(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_02111330.cpp
+++ b/src/func_ov026_02111330.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov026_02111330
-// @emits daObjWlPolelift_c_Behavior
+// recovered name: daObjWlPolelift_c_Behavior
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -30,7 +30,7 @@ extern "C" {
 struct RaycastGround { char pad[0x44]; s32 hitY; char pad2[8]; };
 
 
-extern "C" int daObjWlPolelift_c_Behavior(void* self)
+extern "C" int func_ov026_02111330(void* self)
 {
     u8* c = (u8*)self;
     Vector3 a, b, sub, rp, mul, rel;

--- a/src/func_ov026_02111598.cpp
+++ b/src/func_ov026_02111598.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov026_02111598
-// @emits daObjWlPolelift_c_InitResources
+// recovered name: daObjWlPolelift_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_PathPtr.h"
 #include "decl_common.h"
@@ -15,7 +15,7 @@ extern void _ZN7PathPtr6FromIDEj(void*, unsigned int);
 extern void _ZN25MovingCylinderClsnWithPos4InitEP5ActorRK7Vector35Fix12IiES6_jj(void*, void*, V3*, int, int, unsigned int, unsigned int);
 extern int data_0209caa0[];
 extern V3 data_ov032_02113a9c;
-int daObjWlPolelift_c_InitResources(char *c){
+int func_ov026_02111598(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov026_02113ea0);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   if((data_0209caa0[1] & 0x204) == 0) return 0;

--- a/src/func_ov026_0211170c.c
+++ b/src/func_ov026_0211170c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov026_0211170c
-// @emits daObjWlKoopaShutter_c_OnYoshiTryEat
+// recovered name: daObjWlKoopaShutter_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWlKoopaShutter_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWlKoopaShutter_c_OnYoshiTryEat(int *t)
+int *func_ov026_0211170c(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov026_02111764.c
+++ b/src/func_ov026_02111764.c
@@ -1,12 +1,12 @@
 // @symbol func_ov026_02111764
-// @emits daObjWlKoopaShutter_c_CleanupResources
+// recovered name: daObjWlKoopaShutter_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjWlKoopaShutter_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjWlKoopaShutter_c_CleanupResources(void *t)
+int func_ov026_02111764(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov026_021117a8.cpp
+++ b/src/func_ov026_021117a8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov026_021117a8
-// @emits daObjWlKoopaShutter_c_Render
+// recovered name: daObjWlKoopaShutter_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjWlKoopaShutter_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjWlKoopaShutter_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov026_021117a8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_021117d0.c
+++ b/src/func_ov026_021117d0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov026_021117d0
-// @emits daObjWlKoopaShutter_c_Behavior
+// recovered name: daObjWlKoopaShutter_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjWlKoopaShutter_c::Behavior - recovered from vtable slot identity */
-int daObjWlKoopaShutter_c_Behavior(void)
+int func_ov026_021117d0(void)
 {
     return 1;
 }

--- a/src/func_ov026_021117d8.c
+++ b/src/func_ov026_021117d8.c
@@ -1,5 +1,5 @@
 // @symbol func_ov026_021117d8
-// @emits daObjWlKoopaShutter_c_InitResources
+// recovered name: daObjWlKoopaShutter_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -12,7 +12,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void *, void *);
 extern char data_0209caa0[];
-int daObjWlKoopaShutter_c_InitResources(char *c){
+int func_ov026_021117d8(char *c){
   void *m = (void*)_ZN5Model8LoadFileER13SharedFilePtr(data_ov026_02113ebc);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4,(int)m,1,-1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov026_021118fc.c
+++ b/src/func_ov026_021118fc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov026_021118fc
-// @emits daObjWlSubmarine_c_OnYoshiTryEat
+// recovered name: daObjWlSubmarine_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWlSubmarine_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWlSubmarine_c_OnYoshiTryEat(int *t)
+int *func_ov026_021118fc(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov026_02111954.c
+++ b/src/func_ov026_02111954.c
@@ -1,12 +1,12 @@
 // @symbol func_ov026_02111954
-// @emits daObjWlSubmarine_c_CleanupResources
+// recovered name: daObjWlSubmarine_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjWlSubmarine_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjWlSubmarine_c_CleanupResources(void *t)
+int func_ov026_02111954(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov026_02111998.cpp
+++ b/src/func_ov026_02111998.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov026_02111998
-// @emits daObjWlSubmarine_c_Render
+// recovered name: daObjWlSubmarine_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjWlSubmarine_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjWlSubmarine_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov026_02111998(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov026_021119c0.c
+++ b/src/func_ov026_021119c0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov026_021119c0
-// @emits daObjWlSubmarine_c_InitResources
+// recovered name: daObjWlSubmarine_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -12,7 +12,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *, int, void *, int, int, void *);
 extern void _ZN16MeshColliderBase6EnableEP5Actor(void *, void *);
 extern char data_0209caa0[];
-int daObjWlSubmarine_c_InitResources(char *c){
+int func_ov026_021119c0(char *c){
   void *m = (void*)_ZN5Model8LoadFileER13SharedFilePtr(data_ov026_02113ee4);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4,(int)m,1,-1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov026_02111d4c.cpp
+++ b/src/func_ov026_02111d4c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov026_02111d4c
-// @emits daObjWlSubmarine_c_AfterClsn
+// recovered name: daObjWlSubmarine_c_AfterClsn
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -26,7 +26,7 @@ extern "C" void MulVec3Mat4x3(const Vector3* in, const void* m, Vector3* out);
 
 extern char data_020a0e68;
 
-extern "C" int daObjWlSubmarine_c_AfterClsn(char* c)
+extern "C" int func_ov026_02111d4c(char* c)
 {
     Player* pl = ((Actor*)c)->ClosestPlayer();
     if (pl != 0) {

--- a/src/func_ov026_021122b0.c
+++ b/src/func_ov026_021122b0.c
@@ -1,9 +1,9 @@
 // @symbol func_ov026_021122b0
-// @emits Submarine_Kill
+// recovered name: Submarine_Kill
 /* recovered: renamed to Class_Method */
 /* daWater_Tatumaki_c::Kill - recovered from vtable slot identity */
 extern void __sinit_ov045_02112280(void *);
-int Submarine_Kill(void *t)
+int func_ov026_021122b0(void *t)
 {
     __sinit_ov045_02112280(t);
     return 1;

--- a/src/func_ov027_0211123c.cpp
+++ b/src/func_ov027_0211123c.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov027_0211123c
-// @emits SlidingIce_OnHitByMegaChar
+// recovered name: SlidingIce_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjSlIceBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void SlidingIce_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov027_0211123c(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov027_02111618.c
+++ b/src/func_ov027_02111618.c
@@ -1,5 +1,5 @@
 // @symbol func_ov027_02111618
-// @emits daIDonketu_c_OnYoshiTryEat
+// recovered name: daIDonketu_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_ModelAnim.h"
 #include "decl_MovingCylinderClsn.h"
@@ -10,7 +10,7 @@
 /* daIDonketu_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void func_ov002_020aed18(void *);
 extern void *G0;
-int *daIDonketu_c_OnYoshiTryEat(int *t)
+int *func_ov027_02111618(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov027_02111680.c
+++ b/src/func_ov027_02111680.c
@@ -1,10 +1,10 @@
 // @symbol func_ov027_02111680
-// @emits daIDonketu_c_Kill
+// recovered name: daIDonketu_c_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daIDonketu_c::Kill - recovered from vtable slot identity */
-int daIDonketu_c_Kill(char* self){
+int func_ov027_02111680(char* self){
     if(*(unsigned short*)(self+0x100) < 0xa){
         *(int*)(self+0x98) = 0;
         int r = func_ov064_02116110(self, 0x700);

--- a/src/func_ov027_021116f0.cpp
+++ b/src/func_ov027_021116f0.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daIDonketu_c.h"
-// @emits daIDonketu_c_AfterClsn
+// recovered name: daIDonketu_c_AfterClsn
 /* recovered: renamed to Class_Method */
 /* daIDonketu_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Actor14TriplePoofDustEv(void*);
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(void*,void*,unsigned int,void*,unsigned int);
-int daIDonketu_c_AfterClsn(char* c){
+int func_ov027_021116f0(char* c){
     struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
   int r=func_ov064_0211616c(c);
   if(r==0) return r;

--- a/src/func_ov027_02111770.c
+++ b/src/func_ov027_02111770.c
@@ -1,7 +1,7 @@
 // @symbol func_ov027_02111770
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "daIDonketu_c.h"
-// @emits daIDonketu_c_Behavior
+// recovered name: daIDonketu_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daIDonketu_c::Behavior - recovered from vtable slot identity */
 extern int _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(char* c, char* a, char* b, unsigned int d);
@@ -10,7 +10,7 @@ struct V3 { int x, y, z; };
 extern void _ZN5Actor19UntrackAndSpawnStarERajRK7Vector3j(char* c, char* sc, unsigned int u, struct V3* v, unsigned int j);
 extern void _ZN9ActorBase18MarkForDestructionEv(char* c);
 extern int func_ov064_02116d1c(char* c);
-int daIDonketu_c_Behavior(char *c) {
+int func_ov027_02111770(char *c) {
     struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
     int r = _ZN5Enemy26UpdateKillByInvincibleCharER12WithMeshClsnR9ModelAnimj(c, c+0x174, c+0x110, 0);
     if (r != 0) {

--- a/src/func_ov027_0211181c.cpp
+++ b/src/func_ov027_0211181c.cpp
@@ -4,13 +4,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daIDonketu_c.h"
-// @emits daIDonketu_c_InitResources
+// recovered name: daIDonketu_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daIDonketu_c::InitResources - recovered from vtable slot identity */
 extern "C" {
 extern int func_ov064_02116ec0(void*);
 extern int _ZN5Actor9TrackStarEjj(void*, unsigned int, unsigned int);
-int daIDonketu_c_InitResources(char* c){
+int func_ov027_0211181c(char* c){
     struct daIDonketu_c *self = (struct daIDonketu_c *)(void *)c;
   self->unk_330 = (int)data_ov027_021138f4;
   int r = func_ov064_02116ec0(c);

--- a/src/func_ov027_02111924.c
+++ b/src/func_ov027_02111924.c
@@ -1,5 +1,5 @@
 // @symbol func_ov027_02111924
-// @emits daPgDfdr_c_OnYoshiTryEat
+// recovered name: daPgDfdr_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -11,7 +11,7 @@
 /* daPgDfdr_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN15TextureSequenceD1Ev(void *);
 extern void *G0;
-int *daPgDfdr_c_OnYoshiTryEat(int *t)
+int *func_ov027_02111924(int *t)
 {
     t[0] = (int)VT0;
     _ZN18MovingCylinderClsnD1Ev((char *)t + 0x398);

--- a/src/func_ov027_02111d8c.c
+++ b/src/func_ov027_02111d8c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov027_02111d8c
-// @emits daPgDfdr_c_CleanupResources
+// recovered name: daPgDfdr_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@ extern void _ZN13SharedFilePtr7ReleaseEv(void*);
 extern void* data_ov027_02113c7c;
 extern void* data_ov027_02113c94;
 extern void* data_ov027_02113c6c;
-int daPgDfdr_c_CleanupResources(char* c){
+int func_ov027_02111d8c(char* c){
   int i;
   _ZN13SharedFilePtr7ReleaseEv(&data_ov027_02113c7c);
   for(i=0;i<3;i++) _ZN13SharedFilePtr7ReleaseEv(data_ov035_02112ca4[i]);

--- a/src/func_ov027_02111dfc.c
+++ b/src/func_ov027_02111dfc.c
@@ -1,7 +1,7 @@
 // @symbol func_ov027_02111dfc
-// @emits daPgDfdr_c_OnPendingDestroy
+// recovered name: daPgDfdr_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daPgDfdr_c::OnPendingDestroy - recovered from vtable slot identity */
-void daPgDfdr_c_OnPendingDestroy(void)
+void func_ov027_02111dfc(void)
 {
 }

--- a/src/func_ov027_02111e00.cpp
+++ b/src/func_ov027_02111e00.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov027_02111e00
-// @emits daPgDfdr_c_Render
+// recovered name: daPgDfdr_c_Render
 /* recovered: renamed to Class_Method */
 /* daPgDfdr_c::Render - recovered from vtable slot identity */
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0x320]; Sub sub; };
 extern "C" void _ZN15TextureSequence6UpdateER15ModelComponents(void *, void *);
-extern "C" int daPgDfdr_c_Render(Base *c) { _ZN15TextureSequence6UpdateER15ModelComponents((char *)c + 0x384, (char *)c + 0x328); Sub *b = &c->sub; b->m(0); return 1; }
+extern "C" int func_ov027_02111e00(Base *c) { _ZN15TextureSequence6UpdateER15ModelComponents((char *)c + 0x384, (char *)c + 0x328); Sub *b = &c->sub; b->m(0); return 1; }

--- a/src/func_ov027_02111e34.cpp
+++ b/src/func_ov027_02111e34.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov027_02111e34
-// @emits daPgDfdr_c_Behavior
+// recovered name: daPgDfdr_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Player.h"
 #include "decl_common.h"
@@ -14,7 +14,7 @@ extern void _ZN12CylinderClsn5ClearEv(void* a);
 extern void _ZN12CylinderClsn6UpdateEv(void* a);
 extern void func_ov027_02111994(char* c);
 
-int daPgDfdr_c_Behavior(char* c){
+int func_ov027_02111e34(char* c){
   _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(c, 0, 0);
   func_ov027_02111cfc(c);
   if(_ZN6Player16IsInsideOfCannonEv(_ZN5Actor13ClosestPlayerEv(c))){

--- a/src/func_ov027_02111eb4.cpp
+++ b/src/func_ov027_02111eb4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov027_02111eb4
-// @emits daPgDfdr_c_InitResources
+// recovered name: daPgDfdr_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -29,7 +29,7 @@ extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vec
 
 struct RG { char pad[0x54]; };
 
-int daPgDfdr_c_InitResources(void *cc)
+int func_ov027_02111eb4(void *cc)
 {
     char *c = (char*)cc;
     int i;

--- a/src/func_ov072_0212001c.c
+++ b/src/func_ov072_0212001c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov072_0212001c
-// @emits SnowmanBody_Kill
+// recovered name: SnowmanBody_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daBgSnmBdy_c::Kill - recovered from vtable slot identity */
 struct Vec3 { int x, y, z; };
@@ -12,7 +12,7 @@ extern void *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned id, unsigned 
 extern void _ZN9Animation7AdvanceEv(void *anim);
 extern int _Z14ApproachLinearRsss(short *p, short to, short step);
 
-int SnowmanBody_Kill(char *c)
+int func_ov072_0212001c(char *c)
 {
     struct Vec3 v;
     unsigned char *st;

--- a/src/func_ov072_02120874.c
+++ b/src/func_ov072_02120874.c
@@ -1,5 +1,5 @@
 // @symbol func_ov072_02120874
-// @emits daBgSnwmn_c_OnYoshiTryEat
+// recovered name: daBgSnwmn_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -10,7 +10,7 @@
 extern void _ZN25MovingCylinderClsnWithPosD1Ev(void *);
 extern void _ZN15TextureSequenceD1Ev(void *);
 extern void *G0;
-int *daBgSnwmn_c_OnYoshiTryEat(int *t)
+int *func_ov072_02120874(int *t)
 {
     t[0] = (int)VT0;
     _ZN25MovingCylinderClsnWithPosD1Ev((char *)t + 0x1b0);

--- a/src/func_ov072_021209bc.c
+++ b/src/func_ov072_021209bc.c
@@ -1,7 +1,7 @@
 // @symbol func_ov072_021209bc
-// @emits daBgSnwmn_c_OnPendingDestroy
+// recovered name: daBgSnwmn_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daBgSnwmn_c::OnPendingDestroy - recovered from vtable slot identity */
-void daBgSnwmn_c_OnPendingDestroy(void)
+void func_ov072_021209bc(void)
 {
 }

--- a/src/func_ov072_021209c0.cpp
+++ b/src/func_ov072_021209c0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov072_021209c0
-// @emits daBgSnwmn_c_Render
+// recovered name: daBgSnwmn_c_Render
 /* recovered: renamed to Class_Method */
 /* daBgSnwmn_c::Render - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ extern int _ZN15TextureSequence6UpdateER15ModelComponents(void*, void*);
 }
 struct Sub { virtual int g0(); virtual int g1(); virtual int g2(); virtual int g3(); virtual int g4(); virtual int g5(void*); };
 extern "C" {
-int daBgSnwmn_c_Render(char* c){
+int func_ov072_021209c0(char* c){
   _ZN15TextureSequence6UpdateER15ModelComponents(c+0x174, c+0xdc);
   ((Sub*)(c+0xd4))->g5(c+0x80);
   ((Sub*)(c+0x124))->g5(c+0x80);

--- a/src/func_ov072_02120a08.cpp
+++ b/src/func_ov072_02120a08.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov072_02120a08
-// @emits daBgSnwmn_c_Behavior
+// recovered name: daBgSnwmn_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daBgSnwmn_c::Behavior - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; };
@@ -11,7 +11,7 @@ void _ZN12CylinderClsn5ClearEv(void *self);
 void _ZN12CylinderClsn6UpdateEv(void *self);
 }
 extern const Vector3 data_ov072_02122c70;
-extern "C" int daBgSnwmn_c_Behavior(char *c)
+extern "C" int func_ov072_02120a08(char *c)
 {
     _ZN9Animation7AdvanceEv(c + 0x174);
     _ZN25MovingCylinderClsnWithPos21SetPosRelativeToActorERK7Vector3(c + 0x1b0, &data_ov072_02122c70);

--- a/src/func_ov072_02120a44.c
+++ b/src/func_ov072_02120a44.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daBgSnwmn_c.h"
-// @emits daBgSnwmn_c_InitResources
+// recovered name: daBgSnwmn_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daBgSnwmn_c::InitResources - recovered from vtable slot identity */
 extern int IsStarCollectedInLevel(s8 levelID, int starID);
@@ -24,7 +24,7 @@ extern void _ZN13RaycastGroundD1Ev(void *self);
 
 extern int data_ov072_02122c70[];
 
-int daBgSnwmn_c_InitResources(char *c)
+int func_ov072_02120a44(char *c)
 {
     struct daBgSnwmn_c *self = (struct daBgSnwmn_c *)(void *)c;
     char rg[0x50];

--- a/src/func_ov072_02120cfc.c
+++ b/src/func_ov072_02120cfc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov072_02120cfc
-// @emits BabyPenguin_OnYoshiTryEat
+// recovered name: BabyPenguin_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daPgBby_c::OnYoshiTryEat - recovered from vtable slot identity */
-int BabyPenguin_OnYoshiTryEat(void)
+int func_ov072_02120cfc(void)
 {
     return 7;
 }

--- a/src/func_ov072_02121368.c
+++ b/src/func_ov072_02121368.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov072_02121368
-// @emits daBgSnwmn_c_Kill
+// recovered name: daBgSnwmn_c_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -10,7 +10,7 @@ extern int _ZN5Actor17DetectRaycastClsnER7Vector3S1_b(void *self, struct Vector3
 
 #define M(p) ((s64)(int)(p))
 
-int daBgSnwmn_c_Kill(char *self)
+int func_ov072_02121368(char *self)
 {
     struct Vector3 v;
     char *other;

--- a/src/func_ov072_02121fa0.c
+++ b/src/func_ov072_02121fa0.c
@@ -1,12 +1,12 @@
 // @symbol func_ov072_02121fa0
-// @emits BabyPenguin_OnTurnIntoEgg
+// recovered name: BabyPenguin_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daPgBby_c::OnTurnIntoEgg - recovered from vtable slot identity */
-/* BabyPenguin_OnTurnIntoEgg @ 0x2121fa0 (ov072) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+/* func_ov072_02121fa0 @ 0x2121fa0 (ov072) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void BabyPenguin_OnTurnIntoEgg(void) {
+void func_ov072_02121fa0(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov079_02123b54.c
+++ b/src/func_ov079_02123b54.c
@@ -1,12 +1,12 @@
 // @symbol func_ov079_02123b54
-// @emits Whomp_OnAimedAtWithEggReturnVec
+// recovered name: Whomp_OnAimedAtWithEggReturnVec
 /* recovered: renamed to Class_Method */
 /* daBtn_c::OnAimedAtWithEggReturnVec - recovered from vtable slot identity */
-/* Whomp_OnAimedAtWithEggReturnVec @ 0x2123b54 (ov079) -- tail-call veneer to func_ov079_02123d4c (0x2123d4c).
+/* func_ov079_02123b54 @ 0x2123b54 (ov079) -- tail-call veneer to func_ov079_02123d4c (0x2123d4c).
  * ldr ip, [pc]; bx ip; .word 0x2123d4c
  */
 extern void func_ov079_02123d4c(void);
 
-void Whomp_OnAimedAtWithEggReturnVec(void) {
+void func_ov079_02123b54(void) {
     func_ov079_02123d4c();
 }

--- a/src/func_ov079_02123b60.c
+++ b/src/func_ov079_02123b60.c
@@ -1,9 +1,9 @@
 // @symbol func_ov079_02123b60
-// @emits Whomp_OnAimedAtWithEgg
+// recovered name: Whomp_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBtn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern short data_02082214[];
-int Whomp_OnAimedAtWithEgg(char* c){
+int func_ov079_02123b60(char* c){
     int idx;
     if(*(unsigned char*)(c+0x414)!=0){
         idx = ((int)*(unsigned short*)(c+0x8c) >> 4);

--- a/src/func_ov079_02123e60.cpp
+++ b/src/func_ov079_02123e60.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov079_02123e60
-// @emits Whomp_OnHitByMegaChar
+// recovered name: Whomp_OnHitByMegaChar
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -13,7 +13,7 @@ extern void _ZN5Actor10PoofDustAtERK7Vector3(void* thiz, const Vector3& v);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* thiz);
 
-void Whomp_OnHitByMegaChar(char* c, void* player)
+void func_ov079_02123e60(char* c, void* player)
 {
     if (*(unsigned char*)(c + 0x414) != 0) return;
     if (*(int*)(c + 0x10c) == 8) return;

--- a/src/func_ov079_021266fc.c
+++ b/src/func_ov079_021266fc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov079_021266fc
-// @emits BulletBill_OnAimedAtWithEgg
+// recovered name: BulletBill_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daKlr_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int BulletBill_OnAimedAtWithEgg(void)
+int func_ov079_021266fc(void)
 {
     return 0;
 }

--- a/src/func_ov079_02126e00.c
+++ b/src/func_ov079_02126e00.c
@@ -1,5 +1,5 @@
 // @symbol func_ov079_02126e00
-// @emits daObjBkKillerdai_c_OnYoshiTryEat
+// recovered name: daObjBkKillerdai_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjBkKillerdai_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjBkKillerdai_c_OnYoshiTryEat(int *t)
+int *func_ov079_02126e00(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov079_02126ecc.cpp
+++ b/src/func_ov079_02126ecc.cpp
@@ -4,12 +4,12 @@
 #include "decl_Platform.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjBkKillerdai_c.h"
-// @emits daObjBkKillerdai_c_OnHitByMegaChar
+// recovered name: daObjBkKillerdai_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjBkKillerdai_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
-void daObjBkKillerdai_c_OnHitByMegaChar(char *c, void *p){
+void func_ov079_02126ecc(char *c, void *p){
     struct daObjBkKillerdai_c *self = (struct daObjBkKillerdai_c *)(void *)c;
   _ZN6Player16IncMegaKillCountEv(p);
   _ZN8Platform14KillByMegaCharER6Player(c, p);

--- a/src/func_ov079_02126f04.c
+++ b/src/func_ov079_02126f04.c
@@ -1,5 +1,5 @@
 // @symbol func_ov079_02126f04
-// @emits daObjBkKillerdai_c_CleanupResources
+// recovered name: daObjBkKillerdai_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@ extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void* data_ov079_02127f64[];
 extern void* data_ov079_02128300;
 extern void* data_ov079_021282f0;
-int daObjBkKillerdai_c_CleanupResources(char *t){
+int func_ov079_02126f04(char *t){
   if(_ZN16MeshColliderBase9IsEnabledEv(t+0x124))
     _ZN16MeshColliderBase7DisableEv(t+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov079_02127f64[0]);

--- a/src/func_ov079_02126f64.cpp
+++ b/src/func_ov079_02126f64.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov079_02126f64
-// @emits daObjBkKillerdai_c_Render
+// recovered name: daObjBkKillerdai_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjBkKillerdai_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjBkKillerdai_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov079_02126f64(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov079_02126f8c.cpp
+++ b/src/func_ov079_02126f8c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov079_02126f8c
-// @emits daObjBkKillerdai_c_Behavior
+// recovered name: daObjBkKillerdai_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBkKillerdai_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
@@ -27,7 +27,7 @@ Actor* Actor_s::ClosestPlayer();
 Actor* Actor_s::Spawn(unsigned int, unsigned int, const Vector3&, const Vector3_16*, int, int);
 int Platform::IsClsnInRange(Fix12, Fix12);
 
-extern "C" int daObjBkKillerdai_c_Behavior(char* c) {
+extern "C" int func_ov079_02126f8c(char* c) {
     Platform* self = (Platform*)c;
     if (self->UpdateKillByMegaChar(0x2000, 0, 0, 0xc8000))
         return 1;

--- a/src/func_ov079_02127090.cpp
+++ b/src/func_ov079_02127090.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov079_02127090
-// @emits daObjBkKillerdai_c_InitResources
+// recovered name: daObjBkKillerdai_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjBkKillerdai_c::InitResources - recovered from vtable slot identity */
 struct SharedFilePtr { int x; };
@@ -19,10 +19,10 @@ extern int data_ov079_02127f64[];
 extern signed char data_0209f2f8;
 extern int data_0209caa0[];
 extern unsigned char data_0209f220;
-int daObjBkKillerdai_c_InitResources(void *self);
+int func_ov079_02127090(void *self);
 }
 
-int daObjBkKillerdai_c_InitResources(void *self)
+int func_ov079_02127090(void *self)
 {
     char *c = (char*)self;
     void *m;

--- a/src/func_ov079_02127280.cpp
+++ b/src/func_ov079_02127280.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov079_02127280
-// @emits FortressWall_Kill
+// recovered name: FortressWall_Kill
 /* recovered: renamed to Class_Method */
 /* daObjBk_Kabe_c::Kill - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned, void*);
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned, int, int, int);
 extern void _ZN9ActorBase18MarkForDestructionEv(void*);
-void FortressWall_Kill(char* c){
+void func_ov079_02127280(char* c){
   _ZN5Sound9PlayBank3EjRK7Vector3(0xf, c+0x74);
   _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x121, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
   int b = (int)(*(unsigned short*)(c+0xc) == 0x30);

--- a/src/func_ov079_021272e0.cpp
+++ b/src/func_ov079_021272e0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov079_021272e0
-// @emits FortressWall_OnHitByCannonBlastedChar
+// recovered name: FortressWall_OnHitByCannonBlastedChar
 /* recovered: renamed to Class_Method */
 /* daObjBk_Kabe_c::OnHitByCannonBlastedChar - recovered from vtable slot identity */
 struct Base {
@@ -37,4 +37,4 @@ struct Base {
     virtual void v30();
     virtual void v31();
 };
-extern "C" void FortressWall_OnHitByCannonBlastedChar(Base *c) { c->v31(); }
+extern "C" void func_ov079_021272e0(Base *c) { c->v31(); }

--- a/src/func_ov080_02123858.c
+++ b/src/func_ov080_02123858.c
@@ -1,8 +1,8 @@
 // @symbol func_ov080_02123858
-// @emits MontyMole_OnAimedAtWithEgg
+// recovered name: MontyMole_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daChoropu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int MontyMole_OnAimedAtWithEgg(void)
+int func_ov080_02123858(void)
 {
     return 163840;
 }

--- a/src/func_ov080_02124ac4.c
+++ b/src/func_ov080_02124ac4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov080_02124ac4
-// @emits CrazedCrate_OnYoshiTryEat
+// recovered name: CrazedCrate_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daBttBk_c::OnYoshiTryEat - recovered from vtable slot identity */
-int CrazedCrate_OnYoshiTryEat(void)
+int func_ov080_02124ac4(void)
 {
     return 1;
 }

--- a/src/func_ov080_02124eb0.c
+++ b/src/func_ov080_02124eb0.c
@@ -1,9 +1,9 @@
 // @symbol func_ov080_02124eb0
-// @emits MontyMole_Kill
+// recovered name: MontyMole_Kill
 /* recovered: renamed to Class_Method */
 /* daChoropu_c::Kill - recovered from vtable slot identity */
 extern void _ZN12CylinderClsn5ClearEv(void *);
-int MontyMole_Kill(char *c)
+int func_ov080_02124eb0(char *c)
 {
     *(int *)(c + 0x98) = 0;
     _ZN12CylinderClsn5ClearEv((char *)c + 0x14c);

--- a/src/func_ov080_02125318.cpp
+++ b/src/func_ov080_02125318.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov080_02125318
-// @emits CrazedCrate_OnTurnIntoEgg
+// recovered name: CrazedCrate_OnTurnIntoEgg
 /* recovered: shared common types, renamed to Class_Method */
 /* daBttBk_c::OnTurnIntoEgg - recovered from vtable slot identity */
-// CrazedCrate_OnTurnIntoEgg at 0x02125318
+// func_ov080_02125318 at 0x02125318
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov080).
 struct Vector3 { int x, y, z; };
 
@@ -16,8 +16,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 void _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" void CrazedCrate_OnTurnIntoEgg(char* self, void* player);
-void CrazedCrate_OnTurnIntoEgg(char* self, void* player) {
+extern "C" void func_ov080_02125318(char* self, void* player);
+void func_ov080_02125318(char* self, void* player) {
     if (_ZN6Player15IsCollectingCapEv(player)) {
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, player, 5, 0);
     }

--- a/src/func_ov080_02125428.c
+++ b/src/func_ov080_02125428.c
@@ -1,11 +1,11 @@
 // @symbol func_ov080_02125428
-// @emits daPicGate_c_OnYoshiTryEat
+// recovered name: daPicGate_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::OnYoshiTryEat - recovered from vtable slot identity */
-int *daPicGate_c_OnYoshiTryEat(int *t)
+int *func_ov080_02125428(int *t)
 {
     t[0] = (int)VT;
     _ZN5ActorD2Ev(t);

--- a/src/func_ov080_02126124.c
+++ b/src/func_ov080_02126124.c
@@ -1,9 +1,9 @@
 #include "types.h"
 // @symbol func_ov080_02126124
-// @emits CrazedCrate_Kill
+// recovered name: CrazedCrate_Kill
 /* recovered: renamed to Class_Method */
 /* daBttBk_c::Kill - recovered from vtable slot identity */
-void CrazedCrate_Kill(u32* c){
+void func_ov080_02126124(u32* c){
   *(int*)((char*)c+0x140)=0;
   *(int*)((char*)c+0x144)=0;
   *(int*)((char*)c+0x148)=0;

--- a/src/func_ov080_02126bfc.c
+++ b/src/func_ov080_02126bfc.c
@@ -1,10 +1,10 @@
 // @symbol func_ov080_02126bfc
-// @emits daPicGate_c_CleanupResources
+// recovered name: daPicGate_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::CleanupResources - recovered from vtable slot identity */
 extern int func_0203cbc0(void *a);
 
-int daPicGate_c_CleanupResources(void *c)
+int func_ov080_02126bfc(void *c)
 {
     func_0203cbc0(*(void **)((char *)c + 0x1a0));
     return 1;

--- a/src/func_ov080_02126c1c.c
+++ b/src/func_ov080_02126c1c.c
@@ -1,7 +1,7 @@
 // @symbol func_ov080_02126c1c
-// @emits daPicGate_c_OnPendingDestroy
+// recovered name: daPicGate_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::OnPendingDestroy - recovered from vtable slot identity */
-void daPicGate_c_OnPendingDestroy(void)
+void func_ov080_02126c1c(void)
 {
 }

--- a/src/func_ov080_02126c20.cpp
+++ b/src/func_ov080_02126c20.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov080_02126c20
-// @emits daPicGate_c_Render
+// recovered name: daPicGate_c_Render
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::Render - recovered from vtable slot identity */
 struct C;
 typedef int (C::*PMF)();
 struct Entry { char pad[0x10]; PMF pmf; };
 struct C { char pad[0x1a4]; Entry *ep; };
-extern "C" int daPicGate_c_Render(C *c) {
+extern "C" int func_ov080_02126c20(C *c) {
   (c->*c->ep->pmf)();
   return 1;
 }

--- a/src/func_ov080_02126c60.cpp
+++ b/src/func_ov080_02126c60.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov080_02126c60
-// @emits daPicGate_c_Behavior
+// recovered name: daPicGate_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::Behavior - recovered from vtable slot identity */
 struct C;
 typedef int (C::*PMF)();
 struct Entry { char pad[0x8]; PMF pmf; };
 struct C { char pad[0x1a4]; Entry *ep; };
-extern "C" int daPicGate_c_Behavior(C *c) {
+extern "C" int func_ov080_02126c60(C *c) {
   (c->*c->ep->pmf)();
   return 1;
 }

--- a/src/func_ov080_02126ca0.cpp
+++ b/src/func_ov080_02126ca0.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daPicGate_c.h"
-// @emits daPicGate_c_InitResources
+// recovered name: daPicGate_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daPicGate_c::InitResources - recovered from vtable slot identity */
 struct C;
@@ -20,7 +20,7 @@ extern "C" void _ZN5Actor9SetRangesE5Fix12IiES1_S1_S1_(void* self, int a, int b,
 extern Disp data_ov080_02128628[];
 extern int data_0209caa0[];
 
-extern "C" int daPicGate_c_InitResources(char* c)
+extern "C" int func_ov080_02126ca0(char* c)
 {
     struct daPicGate_c *self = (struct daPicGate_c *)(void *)c;
     unsigned int m = (unsigned char)((*(unsigned int*)(c + 8) >> 0xd) & 3);

--- a/src/func_ov081_021237e4.c
+++ b/src/func_ov081_021237e4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_021237e4
-// @emits Spindrift_OnAimedAtWithEgg
+// recovered name: Spindrift_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daHuwa_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Spindrift_OnAimedAtWithEgg(void)
+int func_ov081_021237e4(void)
 {
     return 245760;
 }

--- a/src/func_ov081_02123fd8.cpp
+++ b/src/func_ov081_02123fd8.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov081_02123fd8
-// @emits Spindrift_OnTurnIntoEgg
+// recovered name: Spindrift_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daHuwa_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void Spindrift_OnTurnIntoEgg(void *self, void *p)
+void func_ov081_02123fd8(void *self, void *p)
 {
     if (!_ZN6Player15IsCollectingCapEv(p))
         _ZN6Player20RegisterEggCoinCountEjbb(p, 3, 0, 0);

--- a/src/func_ov081_02124038.c
+++ b/src/func_ov081_02124038.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_02124038
-// @emits Spindrift_OnYoshiTryEat
+// recovered name: Spindrift_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daHuwa_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Spindrift_OnYoshiTryEat(void)
+int func_ov081_02124038(void)
 {
     return 6;
 }

--- a/src/func_ov081_02124e64.c
+++ b/src/func_ov081_02124e64.c
@@ -1,12 +1,12 @@
 // @symbol func_ov081_02124e64
-// @emits Spindrift_Kill
+// recovered name: Spindrift_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daHuwa_c::Kill - recovered from vtable slot identity */
 extern int func_ov081_02125488();
 extern int data_ov081_02128e64[];
-int Spindrift_Kill(char *c){
+int func_ov081_02124e64(char *c){
   func_ov081_0212423c(c, 0);
   if(*(unsigned short*)(c+0x100)==0)
     func_ov081_02125488(c, data_ov081_02128e34);

--- a/src/func_ov081_02125eb8.c
+++ b/src/func_ov081_02125eb8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_02125eb8
-// @emits MrBlizzard_OnAimedAtWithEgg
+// recovered name: MrBlizzard_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daSnowman_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int MrBlizzard_OnAimedAtWithEgg(void)
+int func_ov081_02125eb8(void)
 {
     return 622592;
 }

--- a/src/func_ov081_021261b8.c
+++ b/src/func_ov081_021261b8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_021261b8
-// @emits MrBlizzard_Kill
+// recovered name: MrBlizzard_Kill
 /* recovered: renamed to Class_Method */
 /* daSnowman_c::Kill - recovered from vtable slot identity */
-int MrBlizzard_Kill(char *p)
+int func_ov081_021261b8(char *p)
 {
     *(int *)(p + 0x388) = 0;
     *(short *)(p + 0x100) = 200;

--- a/src/func_ov081_021265b8.c
+++ b/src/func_ov081_021265b8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_021265b8
-// @emits Moneybag_OnYoshiTryEat
+// recovered name: Moneybag_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daGmch_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Moneybag_OnYoshiTryEat(void)
+int func_ov081_021265b8(void)
 {
     return 6;
 }

--- a/src/func_ov081_021265c0.c
+++ b/src/func_ov081_021265c0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov081_021265c0
-// @emits Moneybag_OnAimedAtWithEgg
+// recovered name: Moneybag_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daGmch_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Moneybag_OnAimedAtWithEgg(void)
+int func_ov081_021265c0(void)
 {
     return 235520;
 }

--- a/src/func_ov081_021273e8.c
+++ b/src/func_ov081_021273e8.c
@@ -1,11 +1,11 @@
 // @symbol func_ov081_021273e8
-// @emits Snowball_Kill
+// recovered name: Snowball_Kill
 /* recovered: renamed to Class_Method */
 /* daSnowball_c::Kill - recovered from vtable slot identity */
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char*, void*, int, int, unsigned int);
 struct S2 { int w[2]; };
 extern struct S2 data_ov081_02128ee4;
-int Snowball_Kill(char *c) {
+int func_ov081_021273e8(char *c) {
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, (void*)data_ov081_02128ee4.w[1], 0x40000000, 0x1000, 0);
     *(int*)(c+0x130) = 0x1000;
     *(int*)(c+0x98) = 0;

--- a/src/func_ov081_02127a7c.cpp
+++ b/src/func_ov081_02127a7c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov081_02127a7c
-// @emits Moneybag_OnTurnIntoEgg
+// recovered name: Moneybag_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daGmch_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void Moneybag_OnTurnIntoEgg(void *self, void *p)
+void func_ov081_02127a7c(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 5, 0);

--- a/src/func_ov081_02127ccc.cpp
+++ b/src/func_ov081_02127ccc.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov081_02127ccc
-// @emits IceBlock_OnHitByMegaChar
+// recovered name: IceBlock_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjIceBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7(); virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11(); virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15(); virtual void v16(); virtual void v17(); virtual void v18(); virtual void v19(); virtual void v20(); virtual void v21(); virtual void v22(); virtual void v23(); virtual void v24(); virtual void v25(); virtual void v26(); virtual void v27(); virtual void v28(); virtual void v29(); virtual void v30(); virtual void m(); };
 extern "C" void _ZN6Player16IncMegaKillCountEv(int);
-extern "C" void IceBlock_OnHitByMegaChar(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }
+extern "C" void func_ov081_02127ccc(Base *c, int a) { _ZN6Player16IncMegaKillCountEv(a); c->m(); }

--- a/src/func_ov081_02127cf4.c
+++ b/src/func_ov081_02127cf4.c
@@ -1,10 +1,10 @@
 // @symbol func_ov081_02127cf4
-// @emits IceBlock_Kill
+// recovered name: IceBlock_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjIceBlock_c::Kill - recovered from vtable slot identity */
-/* IceBlock_Kill at 0x02127cf4
+/* func_ov081_02127cf4 at 0x02127cf4
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov081).
  */
@@ -13,7 +13,7 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int 
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const struct Vector3* vec);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* self);
 
-void IceBlock_Kill(char* c) {
+void func_ov081_02127cf4(char* c) {
   struct Vector3 vec;
   struct Vector3 vec2;
   _ZN5Sound9PlayBank3EjRK7Vector3(0x41, (const struct Vector3*)(c + 0x74));

--- a/src/func_ov091_02131070.cpp
+++ b/src/func_ov091_02131070.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov091_02131070
-// @emits RotatingUpDownPlatformUtm_Kill
+// recovered name: RotatingUpDownPlatformUtm_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjRotateUpdownLift_c::Kill - recovered from vtable slot identity */
 extern "C" {
@@ -10,7 +10,7 @@ namespace Particle { struct System { static System* NewSimple(unsigned int, int,
 struct Actor { void PoofDustAt(const Vector3&); };
 namespace Sound { void PlayBank3(unsigned int, const Vector3&); }
 struct MeshColliderBase { int IsEnabled(); void Disable(); };
-extern "C" void RotatingUpDownPlatformUtm_Kill(char* c){
+extern "C" void func_ov091_02131070(char* c){
     Particle::System::NewSimple(0xbb, *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64));
     Vector3 v = { *(int*)(c+0x5c), *(int*)(c+0x60), *(int*)(c+0x64) };
     ((Actor*)c)->PoofDustAt(v);

--- a/src/func_ov091_021310fc.cpp
+++ b/src/func_ov091_021310fc.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov091_021310fc
-// @emits RotatingUpDownPlatformUtm_OnHitByMegaChar
+// recovered name: RotatingUpDownPlatformUtm_OnHitByMegaChar
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Platform.h"
 /* recovered: renamed to Class_Method */
@@ -8,7 +8,7 @@
 extern "C" {
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void func_02012694(int a, void* b);
-void RotatingUpDownPlatformUtm_OnHitByMegaChar(char* self, void* p){
+void func_ov091_021310fc(char* self, void* p){
   unsigned short h = *(unsigned short*)(self+0xc);
   int eq = (h == 0x1e);
   if(eq) return;

--- a/src/func_ov091_02132a0c.c
+++ b/src/func_ov091_02132a0c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov091_02132a0c
-// @emits daDsn_c_OnAimedAtWithEgg
+// recovered name: daDsn_c_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daDsn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int daDsn_c_OnAimedAtWithEgg(void)
+int func_ov091_02132a0c(void)
 {
     return 843776;
 }

--- a/src/func_ov091_02133440.c
+++ b/src/func_ov091_02133440.c
@@ -1,5 +1,5 @@
 // @symbol func_ov091_02133440
-// @emits daObjPile_c_OnYoshiTryEat
+// recovered name: daObjPile_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjPile_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjPile_c_OnYoshiTryEat(int *t)
+int *func_ov091_02133440(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov091_021335d4.c
+++ b/src/func_ov091_021335d4.c
@@ -1,12 +1,12 @@
 // @symbol func_ov091_021335d4
-// @emits daObjPile_c_OnHitByMegaChar
+// recovered name: daObjPile_c_OnHitByMegaChar
 /* recovered: renamed to Class_Method */
 /* daObjPile_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void _ZN6Player16IncMegaKillCountEv(void*);
 extern void _ZN5Actor8PoofDustEv(void*);
 extern int func_02012694(int a, void* b);
 extern int func_ov091_021334b8(void* self, int b);
-void daObjPile_c_OnHitByMegaChar(char* self, void* arg)
+void func_ov091_021335d4(char* self, void* arg)
 {
     if (*(unsigned char*)(self + 0x320)) return;
     if (arg == 0) return;

--- a/src/func_ov091_02133648.cpp
+++ b/src/func_ov091_02133648.cpp
@@ -2,13 +2,13 @@
 // @symbol func_ov091_02133648
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjPile_c.h"
-// @emits daObjPile_c_OnGroundPounded
+// recovered name: daObjPile_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjPile_c::OnGroundPounded - recovered from vtable slot identity */
 extern "C" {
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* v);
 extern void func_ov091_021334b8(void* c, int f);
-void daObjPile_c_OnGroundPounded(char* c, void* arg){
+void func_ov091_02133648(char* c, void* arg){
     struct daObjPile_c *self = (struct daObjPile_c *)(void *)c;
   if(arg==0) return;
   if(self->unk_31e==0) return;

--- a/src/func_ov091_02133710.cpp
+++ b/src/func_ov091_02133710.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov091_02133710
-// @emits daObjPile_c_Render
+// recovered name: daObjPile_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjPile_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjPile_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov091_02133710(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov091_021338ac.c
+++ b/src/func_ov091_021338ac.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjPile_c.h"
-// @emits daObjPile_c_InitResources
+// recovered name: daObjPile_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjPile_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
@@ -13,7 +13,7 @@ extern int _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*,int,void*,Fix12,short,void*);
-int daObjPile_c_InitResources(char* c){
+int func_ov091_021338ac(char* c){
     struct daObjPile_c *self = (struct daObjPile_c *)(void *)c;
   int m = _ZN5Model8LoadFileER13SharedFilePtr(data_ov091_02135654);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, m, 1, -1);

--- a/src/func_ov091_02134484.c
+++ b/src/func_ov091_02134484.c
@@ -1,8 +1,8 @@
 // @symbol func_ov091_02134484
-// @emits Stump_OnAimedAtWithEgg
+// recovered name: Stump_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daHyuhyu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Stump_OnAimedAtWithEgg(void)
+int func_ov091_02134484(void)
 {
     return 126976;
 }

--- a/src/func_ov091_0213448c.c
+++ b/src/func_ov091_0213448c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov091_0213448c
-// @emits Stump_OnTurnIntoEgg
+// recovered name: Stump_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daHyuhyu_c::OnTurnIntoEgg - recovered from vtable slot identity */
-/* Stump_OnTurnIntoEgg @ 0x213448c (ov091) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+/* func_ov091_0213448c @ 0x213448c (ov091) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void Stump_OnTurnIntoEgg(void) {
+void func_ov091_0213448c(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov091_02134498.c
+++ b/src/func_ov091_02134498.c
@@ -1,8 +1,8 @@
 // @symbol func_ov091_02134498
-// @emits Stump_OnYoshiTryEat
+// recovered name: Stump_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daHyuhyu_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Stump_OnYoshiTryEat(void)
+int func_ov091_02134498(void)
 {
     return 4;
 }

--- a/src/func_ov100_02141fa8.c
+++ b/src/func_ov100_02141fa8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov100_02141fa8
-// @emits RollingIronBall_OnAimedAtWithEgg
+// recovered name: RollingIronBall_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daIbl_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int RollingIronBall_OnAimedAtWithEgg(void)
+int func_ov100_02141fa8(void)
 {
     return 532480;
 }

--- a/src/func_ov100_02142918.cpp
+++ b/src/func_ov100_02142918.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov100_02142918
-// @emits Butterfly_Kill
+// recovered name: Butterfly_Kill
 /* recovered: renamed to Class_Method */
 /* daBtfly_c::Kill - recovered from vtable slot identity */
 extern "C" {
@@ -27,7 +27,7 @@ void _ZN12CylinderClsn6UpdateEv(void* c);
 
 extern s16 data_02082214[];
 
-extern "C" void Butterfly_Kill(char* c)
+extern "C" void func_ov100_02142918(char* c)
 {
     int r;
     _ZN5Actor19MakeVanishLuigiWorkER12CylinderClsn(c, c + 0x374);

--- a/src/func_ov100_02143aa4.c
+++ b/src/func_ov100_02143aa4.c
@@ -1,11 +1,11 @@
 // @symbol func_ov100_02143aa4
-// @emits RollingIronBall_Kill
+// recovered name: RollingIronBall_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daIbl_c::Kill - recovered from vtable slot identity */
 extern void _ZN9Animation7AdvanceEv(void *);
-int RollingIronBall_Kill(char *c)
+int func_ov100_02143aa4(char *c)
 {
     *(int *)(c + 0x368) = 4096;
     _ZN9Animation7AdvanceEv((char *)c + 0x35c);

--- a/src/func_ov100_021442d4.c
+++ b/src/func_ov100_021442d4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov100_021442d4
-// @emits UnchainedChomp_OnAimedAtWithEgg
+// recovered name: UnchainedChomp_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daWanwan2_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int UnchainedChomp_OnAimedAtWithEgg(void)
+int func_ov100_021442d4(void)
 {
     return 0;
 }

--- a/src/func_ov100_02144424.c
+++ b/src/func_ov100_02144424.c
@@ -1,5 +1,5 @@
 // @symbol func_ov100_02144424
-// @emits daDoor_c_OnYoshiTryEat
+// recovered name: daDoor_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_ModelAnim.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daDoor_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daDoor_c_OnYoshiTryEat(int *t)
+int *func_ov100_02144424(int *t)
 {
     t[0] = (int)VT0;
     _ZN9ModelAnimD1Ev((char *)t + 0xd4);

--- a/src/func_ov100_0214542c.cpp
+++ b/src/func_ov100_0214542c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov100_0214542c
-// @emits daDoor_c_CleanupResources
+// recovered name: daDoor_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern Elem data_ov100_02148204[];
 extern "C" {
 extern void _ZN13SharedFilePtr7ReleaseEv(void* p);
 extern void* data_ov100_02148744;
-int daDoor_c_CleanupResources(char* c) {
+int func_ov100_0214542c(char* c) {
   int idx = *(int*)(c + 8);
   Elem* e = &data_ov100_02148204[idx];
   V* obj;

--- a/src/func_ov100_021454c4.c
+++ b/src/func_ov100_021454c4.c
@@ -1,7 +1,7 @@
 // @symbol func_ov100_021454c4
-// @emits daDoor_c_OnPendingDestroy
+// recovered name: daDoor_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* daDoor_c::OnPendingDestroy - recovered from vtable slot identity */
-void daDoor_c_OnPendingDestroy(void)
+void func_ov100_021454c4(void)
 {
 }

--- a/src/func_ov100_021454c8.cpp
+++ b/src/func_ov100_021454c8.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov100_021454c8
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daDoor_c.h"
-// @emits daDoor_c_Render
+// recovered name: daDoor_c_Render
 /* recovered: renamed to Class_Method */
 /* daDoor_c::Render - recovered from vtable slot identity */
 extern "C" {
@@ -10,7 +10,7 @@ extern unsigned char IsAreaShowing(int idx);
 }
 struct V1 { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct V2 { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void n(int); virtual void m(int); };
-extern "C" int daDoor_c_Render(char* c){
+extern "C" int func_ov100_021454c8(char* c){
     struct daDoor_c *self = (struct daDoor_c *)(void *)c;
   if(IsAreaShowing((char)self->unk_08c)==0){
     if(IsAreaShowing((char)self->unk_090)==0) goto done;

--- a/src/func_ov100_02145550.cpp
+++ b/src/func_ov100_02145550.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov100_02145550
-// @emits daDoor_c_Behavior
+// recovered name: daDoor_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daDoor_c::Behavior - recovered from vtable slot identity */
 struct Base {};
@@ -10,7 +10,7 @@ struct CallbackNode {
     PMF callback;
 };
 extern int func_ov100_02145370(char *c);
-extern "C" int daDoor_c_Behavior(char *c) {
+extern "C" int func_ov100_02145550(char *c) {
     int res = func_ov100_02145370(c);
     CallbackNode *node = *(CallbackNode**)((char*)c + 0x140);
     if (*(int*)&node->callback != 0) {

--- a/src/func_ov100_021455a0.c
+++ b/src/func_ov100_021455a0.c
@@ -1,7 +1,7 @@
 // @symbol func_ov100_021455a0
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daDoor_c.h"
-// @emits daDoor_c_InitResources
+// recovered name: daDoor_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daDoor_c::InitResources - recovered from vtable slot identity */
 enum { false, true };
@@ -48,7 +48,7 @@ extern int data_ov100_02148914;
 extern int data_ov100_021488b4;
 extern void func_ov100_021453d8(char *c, void *p, int a2);
 
-int daDoor_c_InitResources(char *c)
+int func_ov100_021455a0(char *c)
 {
     struct daDoor_c *self = (struct daDoor_c *)(void *)c;
     unsigned int idx;

--- a/src/func_ov100_021467d4.c
+++ b/src/func_ov100_021467d4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov100_021467d4
-// @emits Door_Kill
+// recovered name: Door_Kill
 /* recovered: renamed to Class_Method */
 /* daStarGate_c::Kill - recovered from vtable slot identity */
-void Door_Kill(unsigned char *p)
+void func_ov100_021467d4(unsigned char *p)
 {
     if (p[0x158] == 0)
         *(int *)(p + 0x14c) = 0;

--- a/src/func_ov100_02146dec.cpp
+++ b/src/func_ov100_02146dec.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov100_02146dec
-// @emits daObjPathLift_c_OnYoshiTryEat
+// recovered name: daObjPathLift_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -16,7 +16,7 @@ extern void* _ZTV17ExclamationSwitch[];
 extern void* data_020a0eac;
 
 
-void* daObjPathLift_c_OnYoshiTryEat(char* p){
+void* func_ov100_02146dec(char* p){
   *(void***)p = (void**)data_ov100_0214857c;
   _ZN11ShadowModelD1Ev(p+0x450);
   *(void***)p = (void**)data_ov002_0210af70;

--- a/src/func_ov100_02147054.c
+++ b/src/func_ov100_02147054.c
@@ -1,12 +1,12 @@
 // @symbol func_ov100_02147054
-// @emits daObjPathLift_c_CleanupResources
+// recovered name: daObjPathLift_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjPathLift_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjPathLift_c_CleanupResources(void *t)
+int func_ov100_02147054(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov100_021470a4.cpp
+++ b/src/func_ov100_021470a4.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjPathLift_c.h"
-// @emits daObjPathLift_c_Render
+// recovered name: daObjPathLift_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjPathLift_c::Render - recovered from vtable slot identity */
 struct Obj { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 extern "C" {
-int daObjPathLift_c_Render(char* c){
+int func_ov100_021470a4(char* c){
     struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
   unsigned short h = self->unk_428;
   if(h < 0x5a){

--- a/src/func_ov100_021470f4.cpp
+++ b/src/func_ov100_021470f4.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "daObjPathLift_c.h"
-// @emits daObjPathLift_c_Behavior
+// recovered name: daObjPathLift_c_Behavior
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjPathLift_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12i;
@@ -20,7 +20,7 @@ struct MeshColliderBase { int IsEnabled(); void Enable(void *a); };
 struct Platform3 { int IsClsnInRange(Fix12i a, int b); };
 extern unsigned char data_0209f2d8;
 
-extern "C" int daObjPathLift_c_Behavior(char* c)
+extern "C" int func_ov100_021470f4(char* c)
 {
     struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
     func_ov002_020efcf4(c);

--- a/src/func_ov100_021471e0.cpp
+++ b/src/func_ov100_021471e0.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "daObjPathLift_c.h"
-// @emits daObjPathLift_c_InitResources
+// recovered name: daObjPathLift_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjPathLift_c::InitResources - recovered from vtable slot identity */
 struct Actor;
@@ -32,7 +32,7 @@ extern int data_ov002_0210d9f0;
 extern void _ZN16MeshColliderBase16UpdatePosAndAngsERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern unsigned char data_0209f2d8;
 
-extern "C" int daObjPathLift_c_InitResources(char* c) {
+extern "C" int func_ov100_021471e0(char* c) {
     struct daObjPathLift_c *self = (struct daObjPathLift_c *)(void *)c;
   Vector3 pos;
   _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9f0);

--- a/src/func_ov102_021496a4.c
+++ b/src/func_ov102_021496a4.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov102_021496a4
-// @emits QuestionBlock_OnHitFromUnderneath
+// recovered name: QuestionBlock_OnHitFromUnderneath
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnHitFromUnderneath - recovered from vtable slot identity */
-void QuestionBlock_OnHitFromUnderneath(void *c, void *x) {
+void func_ov102_021496a4(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     *(int *)((char *)c + 0x9c) = -0x8000;
     *(int *)((char *)c + 0xa8) = 0x1e000;

--- a/src/func_ov102_02149710.c
+++ b/src/func_ov102_02149710.c
@@ -1,11 +1,11 @@
 // @symbol func_ov102_02149710
-// @emits QuestionBlock_OnHitByMegaChar
+// recovered name: QuestionBlock_OnHitByMegaChar
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern void _ZN6Player16IncMegaKillCountEv(void *p);
-void QuestionBlock_OnHitByMegaChar(void *c, void *player)
+void func_ov102_02149710(void *c, void *player)
 {
     if (*(int*)((char*)c+0x3e8) == 1) return;
     if (func_ov102_02149078(c) != 0) return;

--- a/src/func_ov102_02149770.c
+++ b/src/func_ov102_02149770.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov102_02149770
-// @emits QuestionBlock_OnKicked
+// recovered name: QuestionBlock_OnKicked
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnKicked - recovered from vtable slot identity */
-void QuestionBlock_OnKicked(void *c, void *x) {
+void func_ov102_02149770(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);
     if (r != 0) return;

--- a/src/func_ov102_021497c8.c
+++ b/src/func_ov102_021497c8.c
@@ -1,11 +1,11 @@
 // @symbol func_ov102_021497c8
-// @emits QuestionBlock_OnAttacked1
+// recovered name: QuestionBlock_OnAttacked1
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnAttacked1 - recovered from vtable slot identity */
 
-void QuestionBlock_OnAttacked1(void* self, void* arg) {
+void func_ov102_021497c8(void* self, void* arg) {
     int v = *(int*)((char*)self + 0x3e8);
     if (v == 1) return;
     if (func_ov102_02149078(self)) return;

--- a/src/func_ov102_02149820.c
+++ b/src/func_ov102_02149820.c
@@ -1,11 +1,11 @@
 #include "types.h"
 // @symbol func_ov102_02149820
-// @emits QuestionBlock_OnGroundPounded
+// recovered name: QuestionBlock_OnGroundPounded
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHatenaBlock_c::OnGroundPounded - recovered from vtable slot identity */
-void QuestionBlock_OnGroundPounded(void *c, void *x) {
+void func_ov102_02149820(void *c, void *x) {
     if (*(int *)((char *)c + 0x3e8) == 1) return;
     int r = func_ov102_02149078(c);
     if (r != 0) return;

--- a/src/func_ov102_0214aa10.c
+++ b/src/func_ov102_0214aa10.c
@@ -1,8 +1,8 @@
 // @symbol func_ov102_0214aa10
-// @emits BobOmb_OnAimedAtWithEgg
+// recovered name: BobOmb_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBmb_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int BobOmb_OnAimedAtWithEgg(void)
+int func_ov102_0214aa10(void)
 {
     return 204800;
 }

--- a/src/func_ov102_0214adc8.c
+++ b/src/func_ov102_0214adc8.c
@@ -1,5 +1,5 @@
 // @symbol func_ov102_0214adc8
-// @emits BobOmb_OnTurnIntoEgg
+// recovered name: BobOmb_OnTurnIntoEgg
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, void* pos);
 extern void GiveCoins(int who, int count);
 extern void _ZN6Player4HealEi(void* player, int amount);
-void BobOmb_OnTurnIntoEgg(void* thing, void* player)
+void func_ov102_0214adc8(void* thing, void* player)
 {
     unsigned char flag = *(unsigned char*)((char*)thing + 0x108);
     if (flag == 1) {

--- a/src/func_ov102_0214c6e4.c
+++ b/src/func_ov102_0214c6e4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov102_0214c6e4
-// @emits BobOmb_OnYoshiTryEat
+// recovered name: BobOmb_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daBmb_c::OnYoshiTryEat - recovered from vtable slot identity */
-int BobOmb_OnYoshiTryEat(unsigned char *p)
+int func_ov102_0214c6e4(unsigned char *p)
 {
     return p[263] == 0;
 }

--- a/src/func_ov102_0214cfe4.cpp
+++ b/src/func_ov102_0214cfe4.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov102_0214cfe4
-// @emits BobOmb_Kill
+// recovered name: BobOmb_Kill
 /* recovered: renamed to Class_Method */
 /* daBmb_c::Kill - recovered from vtable slot identity */
 extern "C" void _ZN5Actor8PoofDustEv(void *c);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void *c);
-extern "C" int BobOmb_Kill(char *c)
+extern "C" int func_ov102_0214cfe4(char *c)
 {
     int flags;
     int b;

--- a/src/func_ov102_0214d6a0.c
+++ b/src/func_ov102_0214d6a0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov102_0214d6a0
-// @emits KoopaShell_OnYoshiTryEat
+// recovered name: KoopaShell_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daShl_c::OnYoshiTryEat - recovered from vtable slot identity */
-int KoopaShell_OnYoshiTryEat(unsigned char *p)
+int func_ov102_0214d6a0(unsigned char *p)
 {
     return p[0x3c4] == 0 ? 6 : 5;
 }


### PR DESCRIPTION
Each file in this batch carried a pair of annotations recording that it defined a different symbol than its filename:

```c
// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
```

**Nothing in the repo consumes either annotation** — no tool, no CI config, no doc mentions them — and the divergence quietly broke two things:

**`match.py` cannot verify these files at all.** Asked for the filename's symbol it reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns `MATCHING VERSIONS: none` for every one. Meanwhile `progress.py` counts them as matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING` hatch. **712 files — about 6% of `src/` — were being counted as matched progress while being unverifiable by the repo's own gate.**

**The ROM link cannot use them either.** Gap objects import a carved-out function by its `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every caller silently binding to address 0 rather than erroring.

`tools/reconcile_names.py` (PR #941) renames the emitted function to the `@symbol` name and replaces the now-redundant `@emits` line with `// recovered name: <name>`, so the recovered identity — usually from a vtable slot — is preserved in the file. Each file is byte-verified against the ROM before the edit is kept; anything that stops matching is reverted.

711 of 712 verified and are split across these batches. The holdout, `func_ov022_021123d0`, declares its own symbol with a conflicting signature and is left for a human. 699 of the 711 reproduce under `2004/b56`; 12 need a `1.2/base` override, recorded in `config/rombuild-versions.txt`.

**The opposite direction is deliberately not taken here.** Adopting the recovered names into `config/**/symbols.txt` is the better long-term move, but it changes the canonical symbol table and every reference to those names — a maintainer's call, not a build fix.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
