### PR TITLE
Make each file define the symbol its filename claims (174 files) [04/05]

### DIFF
--- a/src/func_ov005_020bfefc.c
+++ b/src/func_ov005_020bfefc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov005_020bfefc
-// @emits dScMiniGm_c_OnYoshiTryEat
+// recovered name: dScMiniGm_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ extern int _ZTV5Stage[];
 extern int data_0208e4b8[];
 extern void *data_020a0eac;
 
-int *dScMiniGm_c_OnYoshiTryEat(int *t)
+int *func_ov005_020bfefc(int *t)
 {
     t[0] = (int)data_ov005_020c2490;
     t[0] = (int)_ZTV5Stage;

--- a/src/func_ov005_020c0b00.c
+++ b/src/func_ov005_020c0b00.c
@@ -1,7 +1,7 @@
 // @symbol func_ov005_020c0b00
-// @emits dScMiniGm_c_OnPendingDestroy
+// recovered name: dScMiniGm_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScMiniGm_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScMiniGm_c_OnPendingDestroy(void)
+void func_ov005_020c0b00(void)
 {
 }

--- a/src/func_ov005_020c14a0.c
+++ b/src/func_ov005_020c14a0.c
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScMiniGm_c.h"
-// @emits dScMiniGm_c_Behavior
+// recovered name: dScMiniGm_c_Behavior
 /* recovered: renamed to Class_Method */
 /* dScMiniGm_c::Behavior - recovered from vtable slot identity */
 
@@ -18,7 +18,7 @@ extern unsigned char data_0209b300;
 extern int data_0209e650;
 extern unsigned char data_0209b304;
 
-int dScMiniGm_c_Behavior(char* c) {
+int func_ov005_020c14a0(char* c) {
     struct dScMiniGm_c *self = (struct dScMiniGm_c *)(void *)c;
     if ((data_020a0e5a[data_020a0e40 << 1] & 0xfff) != 0) {
         func_02012790(0xe);

--- a/src/func_ov005_020c1654.c
+++ b/src/func_ov005_020c1654.c
@@ -1,11 +1,11 @@
 // @symbol func_ov005_020c1654
-// @emits dScMiniGm_c_CleanupResources
+// recovered name: dScMiniGm_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScMiniGm_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void);
-int dScMiniGm_c_CleanupResources(int c)
+int func_ov005_020c1654(int c)
 {
     if (data_0208a174[0] >= 0) {
         func_ov005_020c0030(c);

--- a/src/func_ov005_020c1a20.c
+++ b/src/func_ov005_020c1a20.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov005_020c1a20
-// @emits dScMiniGm_c_InitResources
+// recovered name: dScMiniGm_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 #include "decl_common.h"
@@ -43,7 +43,7 @@ typedef struct Entry {
 
 extern Entry data_ov005_020c24d8[];
 
-int dScMiniGm_c_InitResources(void *arg0)
+int func_ov005_020c1a20(void *arg0)
 {
     char *c = (char *)arg0;
     int i, j;

--- a/src/func_ov007_020cc070.c
+++ b/src/func_ov007_020cc070.c
@@ -1,12 +1,12 @@
 // @symbol func_ov007_020cc070
-// @emits dScDSMT_c_OnYoshiTryEat
+// recovered name: dScDSMT_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: vtable identified, renamed to Class_Method */
 /* dScDSMT_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void _ZN9ActorBaseD2Ev(void *);
 extern void *G0;
-int *dScDSMT_c_OnYoshiTryEat(int *t)
+int *func_ov007_020cc070(int *t)
 {
     t[0] = (int)VT0;
     func_02017254((char *)t + 0x54);

--- a/src/func_ov007_020cc2ac.c
+++ b/src/func_ov007_020cc2ac.c
@@ -1,7 +1,7 @@
 // @symbol func_ov007_020cc2ac
-// @emits dScDSMT_c_OnPendingDestroy
+// recovered name: dScDSMT_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScDSMT_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScDSMT_c_OnPendingDestroy(void)
+void func_ov007_020cc2ac(void)
 {
 }

--- a/src/func_ov007_020cc2b0.c
+++ b/src/func_ov007_020cc2b0.c
@@ -1,10 +1,10 @@
 // @symbol func_ov007_020cc2b0
-// @emits dScDSMT_c_Render
+// recovered name: dScDSMT_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* dScDSMT_c::Render - recovered from vtable slot identity */
-int dScDSMT_c_Render(void *t)
+int func_ov007_020cc2b0(void *t)
 {
     func_ov007_020b7040(t);
     return 1;

--- a/src/func_ov007_020cc2cc.c
+++ b/src/func_ov007_020cc2cc.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov007_020cc2cc
-// @emits dScDSMT_c_Behavior
+// recovered name: dScDSMT_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Heap.h"
 #include "decl_Scene.h"
@@ -16,7 +16,7 @@ extern void StartMinigameMenu(u8 returnToRecRoom);
 extern char* data_0209b33c;
 extern char data_0209caa0;
 
-int dScDSMT_c_Behavior(char* c)
+int func_ov007_020cc2cc(char* c)
 {
     int result;
 

--- a/src/func_ov007_020cc45c.c
+++ b/src/func_ov007_020cc45c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov007_020cc45c
-// @emits dScDSMT_c_CleanupResources
+// recovered name: dScDSMT_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 #include "decl_common.h"
@@ -10,7 +10,7 @@ extern void func_0203cbc0(void* a);
 extern int data_0209d4a8;
 extern void* data_0209b33c;
 
-int dScDSMT_c_CleanupResources(void) {
+int func_ov007_020cc45c(void) {
     data_0209d4a8 = 0;
     _ZN5Scene20SetAndStopColorFaderEv();
     data_0209b340[0] = func_ov007_020b6f4c();

--- a/src/func_ov007_020cc4c0.cpp
+++ b/src/func_ov007_020cc4c0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov007_020cc4c0
-// @emits dScDSMT_c_InitResources
+// recovered name: dScDSMT_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -25,7 +25,7 @@ extern unsigned char data_0209f1e0;
 extern int data_0209d4a8;
 extern int data_0208ee44;
 
-extern "C" int dScDSMT_c_InitResources(char *self)
+extern "C" int func_ov007_020cc4c0(char *self)
 {
     if (data_0209f1e0 != 0)
         data_0209b340[1] = 1;

--- a/src/func_ov009_02111abc.c
+++ b/src/func_ov009_02111abc.c
@@ -1,5 +1,5 @@
 // @symbol func_ov009_02111abc
-// @emits daObjMcWater_c_OnYoshiTryEat
+// recovered name: daObjMcWater_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjMcWater_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjMcWater_c_OnYoshiTryEat(int *t)
+int *func_ov009_02111abc(int *t)
 {
     t[0] = (int)VT0;
     _ZN18TextureTransformerD1Ev((char *)t + 0x320);

--- a/src/func_ov009_02111bd4.cpp
+++ b/src/func_ov009_02111bd4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov009_02111bd4
-// @emits daObjMcWater_c_CleanupResources
+// recovered name: daObjMcWater_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::CleanupResources - recovered from vtable slot identity */
 extern "C" {
@@ -9,7 +9,7 @@ int _ZN16MeshColliderBase9IsEnabledEv(void*);
 int _ZN16MeshColliderBase7DisableEv(void*);
 extern int data_ov009_02113c68[];
 extern int data_ov009_02113c70[];
-int daObjMcWater_c_CleanupResources(char* c){
+int func_ov009_02111bd4(char* c){
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c68);
   _ZN13SharedFilePtr7ReleaseEv((void*)data_ov009_02113c70);
   if(_ZN16MeshColliderBase9IsEnabledEv(c+0x124))

--- a/src/func_ov009_02111c18.cpp
+++ b/src/func_ov009_02111c18.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov009_02111c18
-// @emits daObjMcWater_c_Render
+// recovered name: daObjMcWater_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::Render - recovered from vtable slot identity */
 struct Sub { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Base { char pad[0xd4]; Sub sub; };
 extern "C" void _ZN18TextureTransformer6UpdateER15ModelComponents(void *, void *);
-extern "C" int daObjMcWater_c_Render(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }
+extern "C" int func_ov009_02111c18(Base *c) { _ZN18TextureTransformer6UpdateER15ModelComponents((char *)c + 0x320, (char *)c + 0xdc); Sub *b = &c->sub; b->m(0); return 1; }

--- a/src/func_ov009_02111c4c.cpp
+++ b/src/func_ov009_02111c4c.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov009_02111c4c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjMcWater_c.h"
-// @emits daObjMcWater_c_Behavior
+// recovered name: daObjMcWater_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::Behavior - recovered from vtable slot identity */
 class Animation {
@@ -10,7 +10,7 @@ public:
 void Advance();
 };
 
-extern "C" int daObjMcWater_c_Behavior(char *r0) {
+extern "C" int func_ov009_02111c4c(char *r0) {
     struct daObjMcWater_c *self = (struct daObjMcWater_c *)(void *)r0;
 self->unk_32c = 0x1000;
 ((Animation *)(r0 + 0x320))->Advance();

--- a/src/func_ov009_02111c74.cpp
+++ b/src/func_ov009_02111c74.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov009_02111c74
-// @emits daObjMcWater_c_InitResources
+// recovered name: daObjMcWater_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjMcWater_c::InitResources - recovered from vtable slot identity */
 typedef short s16;
@@ -26,7 +26,7 @@ extern struct SharedFilePtr data_ov009_02113c70;
 extern struct CLPS_Block data_ov009_02112c38;
 extern int data_0209f32c;
 
-int daObjMcWater_c_InitResources(char *self){
+int func_ov009_02111c74(char *self){
     int b = (int)(data_0209f2d8 == 1);
     if (b == 0) {
         if (*(int*)((char*)&data_0209caa0 + 8) & 0x80000) {

--- a/src/func_ov010_021111ec.c
+++ b/src/func_ov010_021111ec.c
@@ -1,5 +1,5 @@
 // @symbol func_ov010_021111ec
-// @emits daObjC1_Trap_c_OnYoshiTryEat
+// recovered name: daObjC1_Trap_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjC1_Trap_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjC1_Trap_c_OnYoshiTryEat(int *t)
+int *func_ov010_021111ec(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0x320);

--- a/src/func_ov010_02111554.cpp
+++ b/src/func_ov010_02111554.cpp
@@ -1,13 +1,13 @@
 //cpp
 // @symbol func_ov010_02111554
-// @emits daObjC1_Trap_c_CleanupResources
+// recovered name: daObjC1_Trap_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::CleanupResources - recovered from vtable slot identity */
 extern "C" void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern "C" char data_ov025_02112d08[];
-extern "C" int daObjC1_Trap_c_CleanupResources(char *self){
+extern "C" int func_ov010_02111554(char *self){
   if(_ZN16MeshColliderBase9IsEnabledEv(self+0x124)){
     _ZN16MeshColliderBase7DisableEv(self+0x124);
   }

--- a/src/func_ov010_021115a8.cpp
+++ b/src/func_ov010_021115a8.cpp
@@ -2,13 +2,13 @@
 // @symbol func_ov010_021115a8
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjC1_Trap_c.h"
-// @emits daObjC1_Trap_c_Render
+// recovered name: daObjC1_Trap_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::Render - recovered from vtable slot identity */
 extern "C" {
 struct A { char pad[0x320]; };
 struct B { virtual void m0(); virtual void m1(); virtual void m2(); virtual void m3(); virtual void m4(); virtual void m5(bool); };
-int daObjC1_Trap_c_Render(char* c){
+int func_ov010_021115a8(char* c){
     struct daObjC1_Trap_c *self = (struct daObjC1_Trap_c *)(void *)c;
   if(self->unk_3ab == 0){
     ((B*)(c+0x320))->m5(false);

--- a/src/func_ov010_021115e0.cpp
+++ b/src/func_ov010_021115e0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov010_021115e0
-// @emits daObjC1_Trap_c_Behavior
+// recovered name: daObjC1_Trap_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjC1_Trap_c::Behavior - recovered from vtable slot identity */
 struct C; typedef void (C::*PMF)();
@@ -9,8 +9,8 @@ extern "C" void func_ov010_0211146c(void* c);
 extern "C" void func_ov010_021113f0(void* c);
 extern PMF data_ov010_02112d28[];
 
-extern "C" int daObjC1_Trap_c_Behavior(C* c);
-extern "C" int daObjC1_Trap_c_Behavior(C* c)
+extern "C" int func_ov010_021115e0(C* c);
+extern "C" int func_ov010_021115e0(C* c)
 {
     char* p = (char*)c;
     if (*(unsigned char*)(p + 0x3ab)) {

--- a/src/func_ov010_02111654.c
+++ b/src/func_ov010_02111654.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method, RTTI class fields named */
 #include "daObjC1_Trap_c.h"
-// @emits daObjC1_Trap_c_InitResources
+// recovered name: daObjC1_Trap_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjC1_Trap_c::InitResources - recovered from vtable slot identity */
 
@@ -19,7 +19,7 @@ extern void _ZN16MeshColliderBase6EnableEP5Actor(void* p, void* a);
 
 extern short data_02082214[];
 
-int daObjC1_Trap_c_InitResources(char* c)
+int func_ov010_02111654(char* c)
 {
     struct daObjC1_Trap_c *self = (struct daObjC1_Trap_c *)(void *)c;
     self->unk_3aa = 0;

--- a/src/func_ov012_021111e4.c
+++ b/src/func_ov012_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov012_021111e4
-// @emits daObjC0_Switch_c_OnYoshiTryEat
+// recovered name: daObjC0_Switch_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjC0_Switch_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjC0_Switch_c_OnYoshiTryEat(int *t)
+int *func_ov012_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov012_0211123c.c
+++ b/src/func_ov012_0211123c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov012_0211123c
-// @emits daObjC0_Switch_c_OnGroundPounded
+// recovered name: daObjC0_Switch_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjC0_Switch_c::OnGroundPounded - recovered from vtable slot identity */
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(char* t);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char* t);
 extern char* _ZN5Actor15FindWithActorIDEjPS_(unsigned int id, char* prev);
 extern int data_0209caa0[];
-void daObjC0_Switch_c_OnGroundPounded(char* c) {
+void func_ov012_0211123c(char* c) {
     int* q;
     char* p;
     if (*(unsigned char*)(c+0x31e)) return;

--- a/src/func_ov012_02111324.cpp
+++ b/src/func_ov012_02111324.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov012_02111324
-// @emits daObjC0_Switch_c_Render
+// recovered name: daObjC0_Switch_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjC0_Switch_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjC0_Switch_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov012_02111324(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov012_0211134c.cpp
+++ b/src/func_ov012_0211134c.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov012_0211134c
-// @emits daObjC0_Switch_c_Behavior
+// recovered name: daObjC0_Switch_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjC0_Switch_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int daObjC0_Switch_c_Behavior(void *c) {
+extern "C" int func_ov012_0211134c(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov012_02111370.c
+++ b/src/func_ov012_02111370.c
@@ -1,5 +1,5 @@
 // @symbol func_ov012_02111370
-// @emits daObjC0_Switch_c_InitResources
+// recovered name: daObjC0_Switch_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -13,7 +13,7 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int data_0209caa0[];
 
-int daObjC0_Switch_c_InitResources(char* c){
+int func_ov012_02111370(char* c){
   void* mdl;
   void* kcl;
   mdl = _ZN5Model8LoadFileER13SharedFilePtr(data_ov012_021124a8);

--- a/src/func_ov013_021111d0.c
+++ b/src/func_ov013_021111d0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov013_021111d0
-// @emits daObjClockHuriko_c_OnYoshiTryEat
+// recovered name: daObjClockHuriko_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -7,7 +7,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjClockHuriko_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjClockHuriko_c_OnYoshiTryEat(int *t)
+int *func_ov013_021111d0(int *t)
 {
     t[0] = (int)VT0;
     _ZN5ModelD1Ev((char *)t + 0xd4);

--- a/src/func_ov013_02111280.cpp
+++ b/src/func_ov013_02111280.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov013_02111280
-// @emits daObjClockHuriko_c_Render
+// recovered name: daObjClockHuriko_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjClockHuriko_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjClockHuriko_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov013_02111280(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov013_021112a8.c
+++ b/src/func_ov013_021112a8.c
@@ -1,12 +1,12 @@
 // @symbol func_ov013_021112a8
-// @emits daObjClockHuriko_c_Behavior
+// recovered name: daObjClockHuriko_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjClockHuriko_c::Behavior - recovered from vtable slot identity */
 void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int, void*);
 void func_ov013_02111238(char* t);
 extern signed char data_02092110[];
 
-int daObjClockHuriko_c_Behavior(char* c)
+int func_ov013_021112a8(char* c)
 {
     if (data_02092110[0] <= 0) {
         short* p90 = (short*)(c + 0x90);

--- a/src/func_ov013_0211133c.cpp
+++ b/src/func_ov013_0211133c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov013_0211133c
-// @emits daObjClockHuriko_c_InitResources
+// recovered name: daObjClockHuriko_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ extern "C" {
 extern void* _ZN5Model8LoadFileER13SharedFilePtr(void*);
 extern void _ZN9ModelBase7SetFileEP8BMD_Fileii(void*, void*, int, int);
 extern int __sinit_ov045_02112280[];
-int daObjClockHuriko_c_InitResources(char *c){
+int func_ov013_0211133c(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)__sinit_ov045_02112280);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   data_ov054_02111238(c);

--- a/src/func_ov016_02112a44.c
+++ b/src/func_ov016_02112a44.c
@@ -1,5 +1,5 @@
 // @symbol func_ov016_02112a44
-// @emits daObjKi_Hasira_c_OnYoshiTryEat
+// recovered name: daObjKi_Hasira_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKi_Hasira_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKi_Hasira_c_OnYoshiTryEat(int *t)
+int *func_ov016_02112a44(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov016_02112ae4.c
+++ b/src/func_ov016_02112ae4.c
@@ -1,12 +1,12 @@
 // @symbol func_ov016_02112ae4
-// @emits daObjKi_Hasira_c_CleanupResources
+// recovered name: daObjKi_Hasira_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjKi_Hasira_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjKi_Hasira_c_CleanupResources(void *t)
+int func_ov016_02112ae4(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov016_02112b28.cpp
+++ b/src/func_ov016_02112b28.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov016_02112b28
-// @emits daObjKi_Hasira_c_Render
+// recovered name: daObjKi_Hasira_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjKi_Hasira_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjKi_Hasira_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov016_02112b28(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov016_02112e1c.c
+++ b/src/func_ov016_02112e1c.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjKi_Hasira_c.h"
-// @emits daObjKi_Hasira_c_InitResources
+// recovered name: daObjKi_Hasira_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKi_Hasira_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
@@ -15,7 +15,7 @@ extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern int _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, Fix12, short, void*);
 extern int _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(unsigned int, unsigned int, void*, void*, int, int);
 
-int daObjKi_Hasira_c_InitResources(char* c) {
+int func_ov016_02112e1c(char* c) {
     struct daObjKi_Hasira_c *self = (struct daObjKi_Hasira_c *)(void *)c;
   void* mdl;
   void* kcl;

--- a/src/func_ov016_02112f44.c
+++ b/src/func_ov016_02112f44.c
@@ -1,5 +1,5 @@
 // @symbol func_ov016_02112f44
-// @emits daObjKi_Ita_c_OnYoshiTryEat
+// recovered name: daObjKi_Ita_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKi_Ita_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKi_Ita_c_OnYoshiTryEat(int *t)
+int *func_ov016_02112f44(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov016_02112fa8.c
+++ b/src/func_ov016_02112fa8.c
@@ -1,11 +1,11 @@
 // @symbol func_ov016_02112fa8
-// @emits daObjKi_Ita_c_InitResources
+// recovered name: daObjKi_Ita_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjKi_Ita_c::InitResources - recovered from vtable slot identity */
 
-int daObjKi_Ita_c_InitResources(void *self)
+int func_ov016_02112fa8(void *self)
 {
     return func_020b5e58(self, &data_ov016_02114b8c);
 }

--- a/src/func_ov020_021127a4.cpp
+++ b/src/func_ov020_021127a4.cpp
@@ -1,10 +1,10 @@
 //cpp
 // @symbol func_ov020_021127a4
-// @emits BookShot_OnAimedAtWithEgg
+// recovered name: BookShot_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBook_c::OnAimedAtWithEgg - recovered from vtable slot identity */
 extern "C" {
-int BookShot_OnAimedAtWithEgg(char* c){
+int func_ov020_021127a4(char* c){
   int eq = (*(unsigned short*)(c+0xc)==0x147);
   if(eq) return 0;
   return 0x19000;

--- a/src/func_ov020_021127cc.c
+++ b/src/func_ov020_021127cc.c
@@ -1,7 +1,7 @@
 // @symbol func_ov020_021127cc
-// @emits BookShot_OnYoshiTryEat
+// recovered name: BookShot_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daBook_c::OnYoshiTryEat - recovered from vtable slot identity */
-int BookShot_OnYoshiTryEat(char* c){
+int func_ov020_021127cc(char* c){
   unsigned int b = *(unsigned short*)(c+0xc)==0x147; return b ? 2 : 0;
 }

--- a/src/func_ov029_021111f0.c
+++ b/src/func_ov029_021111f0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov029_021111f0
-// @emits daObjWcObj01_c_OnYoshiTryEat
+// recovered name: daObjWcObj01_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWcObj01_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWcObj01_c_OnYoshiTryEat(int *t)
+int *func_ov029_021111f0(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov029_02111b08.c
+++ b/src/func_ov029_02111b08.c
@@ -1,5 +1,5 @@
 // @symbol func_ov029_02111b08
-// @emits daObjWc_Obj05_c_OnYoshiTryEat
+// recovered name: daObjWc_Obj05_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWc_Obj05_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWc_Obj05_c_OnYoshiTryEat(int *t)
+int *func_ov029_02111b08(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov029_02111ba4.cpp
+++ b/src/func_ov029_02111ba4.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov029_02111ba4
-// @emits daObjWc_Obj05_c_Render
+// recovered name: daObjWc_Obj05_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjWc_Obj05_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjWc_Obj05_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov029_02111ba4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov029_02111bcc.c
+++ b/src/func_ov029_02111bcc.c
@@ -2,7 +2,7 @@
 // @symbol func_ov029_02111bcc
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjWc_Obj05_c.h"
-// @emits daObjWc_Obj05_c_Behavior
+// recovered name: daObjWc_Obj05_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjWc_Obj05_c::Behavior - recovered from vtable slot identity */
 extern void func_020393a4(int* p, int v);
@@ -12,7 +12,7 @@ extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void* self, int a, int b);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void* self);
 extern void _ZN18MovingMeshCollider9TransformERK9Matrix4x3s(void* self, void* mat, s16 s);
 
-int daObjWc_Obj05_c_Behavior(u8* thiz)
+int func_ov029_02111bcc(u8* thiz)
 {
     struct daObjWc_Obj05_c *self = (struct daObjWc_Obj05_c *)(void *)thiz;
     func_020393a4((int*)(thiz + 0x124), 0x250000);

--- a/src/func_ov029_02111d6c.cpp
+++ b/src/func_ov029_02111d6c.cpp
@@ -4,7 +4,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjWc_Obj05_c.h"
-// @emits daObjWc_Obj05_c_InitResources
+// recovered name: daObjWc_Obj05_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjWc_Obj05_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -18,7 +18,7 @@ extern void func_020393d4(void* p, void* v);
 extern void func_020393c4(void* p, void* v);
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_(void);
 
-int daObjWc_Obj05_c_InitResources(char* c)
+int func_ov029_02111d6c(char* c)
 {
     struct daObjWc_Obj05_c *self = (struct daObjWc_Obj05_c *)(void *)c;
     void* f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov029_0211428c);

--- a/src/func_ov029_02111ef4.c
+++ b/src/func_ov029_02111ef4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov029_02111ef4
-// @emits daObjWcObj06_c_OnYoshiTryEat
+// recovered name: daObjWcObj06_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjWcObj06_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjWcObj06_c_OnYoshiTryEat(int *t)
+int *func_ov029_02111ef4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov030_021111ec.c
+++ b/src/func_ov030_021111ec.c
@@ -1,5 +1,5 @@
 // @symbol func_ov030_021111ec
-// @emits daObjHmBskt_c_OnYoshiTryEat
+// recovered name: daObjHmBskt_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -9,7 +9,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjHmBskt_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjHmBskt_c_OnYoshiTryEat(int *t)
+int *func_ov030_021111ec(int *t)
 {
     t[0] = (int)VT0;
     _ZN12WithMeshClsnD1Ev((char *)t + 0x320);

--- a/src/func_ov030_0211130c.c
+++ b/src/func_ov030_0211130c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov030_0211130c
-// @emits daObjHmBskt_c_CleanupResources
+// recovered name: daObjHmBskt_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjHmBskt_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjHmBskt_c_CleanupResources(void *t)
+int func_ov030_0211130c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov030_02111350.cpp
+++ b/src/func_ov030_02111350.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov030_02111350
-// @emits daObjHmBskt_c_Render
+// recovered name: daObjHmBskt_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjHmBskt_c::Render - recovered from vtable slot identity */
 struct Obj { virtual void f0(); virtual void f1(); virtual void f2(); virtual void f3(); virtual void f4(); virtual void m(int); };
 extern "C" void _ZN8Platform21UpdateModelPosAndRotYEv(void*);
 extern "C" void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
-extern "C" int daObjHmBskt_c_Render(char *c){
+extern "C" int func_ov030_02111350(char *c){
   _ZN8Platform21UpdateModelPosAndRotYEv(c);
   _ZN8Platform19UpdateClsnPosAndRotEv(c);
   ((Obj*)(c+0xd4))->m(0);

--- a/src/func_ov030_02111384.cpp
+++ b/src/func_ov030_02111384.cpp
@@ -4,12 +4,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjHmBskt_c.h"
-// @emits daObjHmBskt_c_Behavior
+// recovered name: daObjHmBskt_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjHmBskt_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform21IsClsnInRangeOnScreenE5Fix12IiES1_(char *c, int a, int b);
 extern "C" void _ZN5Actor9UpdatePosEP12CylinderClsn(char *c, char *clsn);
-extern "C" int daObjHmBskt_c_Behavior(char *c) {
+extern "C" int func_ov030_02111384(char *c) {
     struct daObjHmBskt_c *self = (struct daObjHmBskt_c *)(void *)c;
     volatile int dummy[4];
     (void)&dummy;

--- a/src/func_ov030_02111410.cpp
+++ b/src/func_ov030_02111410.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov030_02111410
-// @emits daObjHmBskt_c_InitResources
+// recovered name: daObjHmBskt_c_InitResources
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjHmBskt_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
@@ -21,7 +21,7 @@ extern struct SharedFilePtr data_ov030_02115c88;
 extern struct SharedFilePtr data_ov030_02115c80;
 extern struct CLPS_Block data_ov030_02114ee4;
 
-int daObjHmBskt_c_InitResources(char *self){
+int func_ov030_02111410(char *self){
     struct BMD_File *bmd = _ZN5Model8LoadFileER13SharedFilePtr(data_ov030_02115c88);
     _ZN9ModelBase7SetFileEP8BMD_Fileii(self + 0xd4, bmd, 1, -1);
     *(int*)(self + 0x9c) = 0;

--- a/src/func_ov030_0211172c.c
+++ b/src/func_ov030_0211172c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov030_0211172c
-// @emits RollingLogTtm_OnYoshiTryEat
+// recovered name: RollingLogTtm_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daMky_c::OnYoshiTryEat - recovered from vtable slot identity */
-int RollingLogTtm_OnYoshiTryEat(void)
+int func_ov030_0211172c(void)
 {
     return 7;
 }

--- a/src/func_ov030_02112a14.c
+++ b/src/func_ov030_02112a14.c
@@ -1,14 +1,14 @@
 // @symbol func_ov030_02112a14
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjHmMaruta_c.h"
-// @emits daObjHmMaruta_c_AfterClsn
+// recovered name: daObjHmMaruta_c_AfterClsn
 /* recovered: renamed to Class_Method */
 /* daObjHmMaruta_c::AfterClsn - recovered from vtable slot identity */
 extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void *m, void *f, int i, int fix, unsigned int j);
 extern void _ZN7PathPtr6FromIDEj(void *p, unsigned int id);
 struct G { void *a; void *b; };
 extern struct G data_ov030_02115d18;
-int daObjHmMaruta_c_AfterClsn(char *c) {
+int func_ov030_02112a14(char *c) {
     struct daObjHmMaruta_c *self = (struct daObjHmMaruta_c *)(void *)c;
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0xd4, data_ov030_02115d18.b, 0, 0x1000, 0);
     self->unk_130 = 0x1000;

--- a/src/func_ov030_021145d4.c
+++ b/src/func_ov030_021145d4.c
@@ -1,12 +1,12 @@
 // @symbol func_ov030_021145d4
-// @emits RollingLogTtm_OnTurnIntoEgg
+// recovered name: RollingLogTtm_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daMky_c::OnTurnIntoEgg - recovered from vtable slot identity */
-/* RollingLogTtm_OnTurnIntoEgg @ 0x21145d4 (ov030) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
+/* func_ov030_021145d4 @ 0x21145d4 (ov030) -- tail-call veneer to _ZN9ActorBase18MarkForDestructionEv (0x2043824).
  * ldr ip, [pc]; bx ip; .word 0x2043824
  */
 extern void _ZN9ActorBase18MarkForDestructionEv(void);
 
-void RollingLogTtm_OnTurnIntoEgg(void) {
+void func_ov030_021145d4(void) {
     _ZN9ActorBase18MarkForDestructionEv();
 }

--- a/src/func_ov032_021124ec.c
+++ b/src/func_ov032_021124ec.c
@@ -1,5 +1,5 @@
 // @symbol func_ov032_021124ec
-// @emits daObjTdFuta_c_OnYoshiTryEat
+// recovered name: daObjTdFuta_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjTdFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjTdFuta_c_OnYoshiTryEat(int *t)
+int *func_ov032_021124ec(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov032_02112588.cpp
+++ b/src/func_ov032_02112588.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov032_02112588
-// @emits daObjTdFuta_c_Render
+// recovered name: daObjTdFuta_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjTdFuta_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjTdFuta_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov032_02112588(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov032_021125b0.cpp
+++ b/src/func_ov032_021125b0.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov032_021125b0
-// @emits daObjTdFuta_c_Behavior
+// recovered name: daObjTdFuta_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjTdFuta_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int daObjTdFuta_c_Behavior(void *c) {
+extern "C" int func_ov032_021125b0(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov032_021125d4.cpp
+++ b/src/func_ov032_021125d4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov032_021125d4
-// @emits daObjTdFuta_c_InitResources
+// recovered name: daObjTdFuta_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -13,7 +13,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern int _ZN5Event6GetBitEj(unsigned int);
-int daObjTdFuta_c_InitResources(char *c){
+int func_ov032_021125d4(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov032_02113ad4);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov033_021111e4.c
+++ b/src/func_ov033_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov033_021111e4
-// @emits daObjTtFuta_c_OnYoshiTryEat
+// recovered name: daObjTtFuta_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjTtFuta_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjTtFuta_c_OnYoshiTryEat(int *t)
+int *func_ov033_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov033_0211123c.c
+++ b/src/func_ov033_0211123c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov033_0211123c
-// @emits daObjTtFuta_c_OnGroundPounded
+// recovered name: daObjTtFuta_c_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjTtFuta_c::OnGroundPounded - recovered from vtable slot identity */
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int a, int x, int y, int z);
@@ -7,7 +7,7 @@ extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int a, void *v);
 extern void _ZN5Event6SetBitEj(unsigned int b);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *c);
 
-void daObjTtFuta_c_OnGroundPounded(char *self, char *other)
+void func_ov033_0211123c(char *self, char *other)
 {
     int *v = (int *)(((int)other + 0x5c));
     _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(0x28, v[0], v[1], v[2]);

--- a/src/func_ov033_021112c4.cpp
+++ b/src/func_ov033_021112c4.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov033_021112c4
-// @emits daObjTtFuta_c_Render
+// recovered name: daObjTtFuta_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjTtFuta_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjTtFuta_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov033_021112c4(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov033_021112ec.cpp
+++ b/src/func_ov033_021112ec.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov033_021112ec
-// @emits daObjTtFuta_c_Behavior
+// recovered name: daObjTtFuta_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjTtFuta_c::Behavior - recovered from vtable slot identity */
 extern "C" int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, int a, int b);
 
-extern "C" int daObjTtFuta_c_Behavior(void *c) {
+extern "C" int func_ov033_021112ec(void *c) {
     _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(c, 0, 0);
     return 1;
 }

--- a/src/func_ov033_02111310.cpp
+++ b/src/func_ov033_02111310.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov033_02111310
-// @emits daObjTtFuta_c_InitResources
+// recovered name: daObjTtFuta_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -13,7 +13,7 @@ extern void _ZN8Platform19UpdateClsnPosAndRotEv(void*);
 extern void* _ZN12MeshCollider8LoadFileER13SharedFilePtr(void*);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void*, void*, void*, int, short, void*);
 extern int _ZN5Event6GetBitEj(unsigned int);
-int daObjTtFuta_c_InitResources(char *c){
+int func_ov033_02111310(char *c){
   void *f = _ZN5Model8LoadFileER13SharedFilePtr((void*)data_ov033_021124c8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);
   _ZN8Platform21UpdateModelPosAndRotYEv(c);

--- a/src/func_ov036_021111e4.c
+++ b/src/func_ov036_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov036_021111e4
-// @emits daObjRcBuranko_c_OnYoshiTryEat
+// recovered name: daObjRcBuranko_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjRcBuranko_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjRcBuranko_c_OnYoshiTryEat(int *t)
+int *func_ov036_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov036_02111284.c
+++ b/src/func_ov036_02111284.c
@@ -1,12 +1,12 @@
 // @symbol func_ov036_02111284
-// @emits daObjRcBuranko_c_CleanupResources
+// recovered name: daObjRcBuranko_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjRcBuranko_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjRcBuranko_c_CleanupResources(void *t)
+int func_ov036_02111284(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov036_021112c8.cpp
+++ b/src/func_ov036_021112c8.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov036_021112c8
-// @emits daObjRcBuranko_c_Render
+// recovered name: daObjRcBuranko_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjRcBuranko_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjRcBuranko_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov036_021112c8(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov036_021112f0.c
+++ b/src/func_ov036_021112f0.c
@@ -1,14 +1,14 @@
 // @symbol func_ov036_021112f0
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjRcBuranko_c.h"
-// @emits daObjRcBuranko_c_Behavior
+// recovered name: daObjRcBuranko_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjRcBuranko_c::Behavior - recovered from vtable slot identity */
 extern int func_ov036_0211123c(char *t);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(char *c, int a, int b);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(char *c);
 
-int daObjRcBuranko_c_Behavior(char *c)
+int func_ov036_021112f0(char *c)
 {
     struct daObjRcBuranko_c *self = (struct daObjRcBuranko_c *)(void *)c;
     if (self->unk_090 < 0) {

--- a/src/func_ov036_0211137c.cpp
+++ b/src/func_ov036_0211137c.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov036_0211137c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjRcBuranko_c.h"
-// @emits daObjRcBuranko_c_InitResources
+// recovered name: daObjRcBuranko_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjRcBuranko_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12;
@@ -26,7 +26,7 @@ extern "C" void func_ov036_0211123c(char *t);
 extern "C" void func_020393d4(int *p, int v);
 extern "C" void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 
-extern "C" int daObjRcBuranko_c_InitResources(char *c)
+extern "C" int func_ov036_0211137c(char *c)
 {
     struct daObjRcBuranko_c *self = (struct daObjRcBuranko_c *)(void *)c;
     BMD_File *f = Model::LoadFile(data_ov036_02114028);

--- a/src/func_ov036_02111494.c
+++ b/src/func_ov036_02111494.c
@@ -1,5 +1,5 @@
 // @symbol func_ov036_02111494
-// @emits daObjRc_Kaitendai_c_OnYoshiTryEat
+// recovered name: daObjRc_Kaitendai_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjRc_Kaitendai_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjRc_Kaitendai_c_OnYoshiTryEat(int *t)
+int *func_ov036_02111494(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov036_021114f8.c
+++ b/src/func_ov036_021114f8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov036_021114f8
-// @emits daObjRc_Kaitendai_c_CleanupResources
+// recovered name: daObjRc_Kaitendai_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjRc_Kaitendai_c::CleanupResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b66a8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov036_02113b2c;
 
-int daObjRc_Kaitendai_c_CleanupResources(u8 *self)
+int func_ov036_021114f8(u8 *self)
 {
     return func_ov002_020b66a8(self, &data_ov036_02113b2c);
 }

--- a/src/func_ov036_0211150c.c
+++ b/src/func_ov036_0211150c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov036_0211150c
-// @emits daObjRc_Kaitendai_c_InitResources
+// recovered name: daObjRc_Kaitendai_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern int data_ov036_02113b2c;
 extern int func_ov002_020b676c(int *self, void *arg, int val);
 
-int daObjRc_Kaitendai_c_InitResources(int *self)
+int func_ov036_0211150c(int *self)
 {
     short v;
     v = data_ov036_02113b18;

--- a/src/func_ov043_021111e4.c
+++ b/src/func_ov043_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov043_021111e4
-// @emits daObjKm1_Ukishima_c_OnYoshiTryEat
+// recovered name: daObjKm1_Ukishima_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm1_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm1_Ukishima_c_OnYoshiTryEat(int *t)
+int *func_ov043_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov043_0211123c.c
+++ b/src/func_ov043_0211123c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov043_0211123c
-// @emits daObjKm1_Ukishima_c_CleanupResources
+// recovered name: daObjKm1_Ukishima_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Ukishima_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern int G0[];
-int daObjKm1_Ukishima_c_CleanupResources(void *t)
+int func_ov043_0211123c(void *t)
 {
     if (_ZN16MeshColliderBase9IsEnabledEv((char *)t + 0x124)) {
         _ZN16MeshColliderBase7DisableEv((char *)t + 0x124);

--- a/src/func_ov043_02111280.cpp
+++ b/src/func_ov043_02111280.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov043_02111280
-// @emits daObjKm1_Ukishima_c_Render
+// recovered name: daObjKm1_Ukishima_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Ukishima_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjKm1_Ukishima_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov043_02111280(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov043_021112a8.cpp
+++ b/src/func_ov043_021112a8.cpp
@@ -2,7 +2,7 @@
 // @symbol func_ov043_021112a8
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjKm1_Ukishima_c.h"
-// @emits daObjKm1_Ukishima_c_Behavior
+// recovered name: daObjKm1_Ukishima_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Ukishima_c::Behavior - recovered from vtable slot identity */
 extern "C" {
@@ -11,7 +11,7 @@ extern void _ZN5Actor9UpdatePosEP12CylinderClsn(void *self, void *clsn);
 extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *, int, int);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *);
-int daObjKm1_Ukishima_c_Behavior(char *c)
+int func_ov043_021112a8(char *c)
 {
     struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
     if (!DecIfAbove0_Byte((unsigned char *)(c + 0x31e))) {

--- a/src/func_ov043_02111320.c
+++ b/src/func_ov043_02111320.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjKm1_Ukishima_c.h"
-// @emits daObjKm1_Ukishima_c_InitResources
+// recovered name: daObjKm1_Ukishima_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Ukishima_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *f);
@@ -14,7 +14,7 @@ extern int _ZN12MeshCollider8LoadFileER13SharedFilePtr(void *f);
 extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10CLPS_Block(void *p, int kcl, void *mtx, int fix, short s, void *clps);
 extern void func_020393d4(void *p, int v);
 extern int _ZN16MeshColliderBase21UpdatePosWithVelocityERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-int daObjKm1_Ukishima_c_InitResources(char *c){
+int func_ov043_02111320(char *c){
     struct daObjKm1_Ukishima_c *self = (struct daObjKm1_Ukishima_c *)(void *)c;
   int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov047_021125e8);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);

--- a/src/func_ov043_0211144c.c
+++ b/src/func_ov043_0211144c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov043_0211144c
-// @emits daObjKm1_Kurumajiku_c_OnYoshiTryEat
+// recovered name: daObjKm1_Kurumajiku_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm1_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm1_Kurumajiku_c_OnYoshiTryEat(int *t)
+int *func_ov043_0211144c(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov043_021114b0.c
+++ b/src/func_ov043_021114b0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov043_021114b0
-// @emits daObjKm1_Kurumajiku_c_CleanupResources
+// recovered name: daObjKm1_Kurumajiku_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov043_02112344;
 
-int daObjKm1_Kurumajiku_c_CleanupResources(u8 *self)
+int func_ov043_021114b0(u8 *self)
 {
     return func_ov002_020b6ac8(self, &data_ov043_02112344);
 }

--- a/src/func_ov043_021114c4.c
+++ b/src/func_ov043_021114c4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov043_021114c4
-// @emits daObjKm1_Kurumajiku_c_InitResources
+// recovered name: daObjKm1_Kurumajiku_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm1_Kurumajiku_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -7,7 +7,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b6c54(unsigned char *self, char **arg, unsigned int actorID);
 extern struct Arg data_ov043_02112344;
 
-void daObjKm1_Kurumajiku_c_InitResources(unsigned char *c)
+void func_ov043_021114c4(unsigned char *c)
 {
     func_ov002_020b6c54(c, (char **)&data_ov043_02112344, 0x88u);
 }

--- a/src/func_ov045_021111e4.c
+++ b/src/func_ov045_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov045_021111e4
-// @emits daObjKm2_Agaru_c_OnYoshiTryEat
+// recovered name: daObjKm2_Agaru_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm2_Agaru_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm2_Agaru_c_OnYoshiTryEat(int *t)
+int *func_ov045_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov045_02111274.cpp
+++ b/src/func_ov045_02111274.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov045_02111274
-// @emits daObjKm2_Agaru_c_Render
+// recovered name: daObjKm2_Agaru_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjKm2_Agaru_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjKm2_Agaru_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov045_02111274(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov045_0211129c.c
+++ b/src/func_ov045_0211129c.c
@@ -1,13 +1,13 @@
 // @symbol func_ov045_0211129c
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjKm2_Agaru_c.h"
-// @emits daObjKm2_Agaru_c_Behavior
+// recovered name: daObjKm2_Agaru_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjKm2_Agaru_c::Behavior - recovered from vtable slot identity */
 extern int _ZN8Platform21UpdateModelPosAndRotYEv(void *c);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *c, int a, int b);
 extern int _ZN8Platform19UpdateClsnPosAndRotEv(void *c);
-int daObjKm2_Agaru_c_Behavior(char *c)
+int func_ov045_0211129c(char *c)
 {
     struct daObjKm2_Agaru_c *self = (struct daObjKm2_Agaru_c *)(void *)c;
     switch (self->unk_327) {

--- a/src/func_ov045_021113ec.c
+++ b/src/func_ov045_021113ec.c
@@ -3,7 +3,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjKm2_Agaru_c.h"
-// @emits daObjKm2_Agaru_c_InitResources
+// recovered name: daObjKm2_Agaru_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm2_Agaru_c::InitResources - recovered from vtable slot identity */
 extern int _ZN5Model8LoadFileER13SharedFilePtr(void *f);
@@ -15,7 +15,7 @@ extern void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEsR10C
 extern void func_020393d4(void *p, int v);
 extern void func_020393c4(void *p, int v);
 extern int _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_[];
-int daObjKm2_Agaru_c_InitResources(char *c){
+int func_ov045_021113ec(char *c){
     struct daObjKm2_Agaru_c *self = (struct daObjKm2_Agaru_c *)(void *)c;
   int f = _ZN5Model8LoadFileER13SharedFilePtr(data_ov045_02113188);
   _ZN9ModelBase7SetFileEP8BMD_Fileii(c+0xd4, f, 1, -1);

--- a/src/func_ov045_02111b64.c
+++ b/src/func_ov045_02111b64.c
@@ -1,5 +1,5 @@
 // @symbol func_ov045_02111b64
-// @emits daObjKm2_Ukishima_c_OnYoshiTryEat
+// recovered name: daObjKm2_Ukishima_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm2_Ukishima_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm2_Ukishima_c_OnYoshiTryEat(int *t)
+int *func_ov045_02111b64(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov045_02111bc8.c
+++ b/src/func_ov045_02111bc8.c
@@ -1,10 +1,10 @@
 // @symbol func_ov045_02111bc8
-// @emits daObjKm2_Ukishima_c_CleanupResources
+// recovered name: daObjKm2_Ukishima_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjKm2_Ukishima_c::CleanupResources - recovered from vtable slot identity */
-int daObjKm2_Ukishima_c_CleanupResources(void *self)
+int func_ov045_02111bc8(void *self)
 {
     return func_020b6424(self, data_ov045_02112f08);
 }

--- a/src/func_ov045_02111bdc.c
+++ b/src/func_ov045_02111bdc.c
@@ -1,10 +1,10 @@
 // @symbol func_ov045_02111bdc
-// @emits daObjKm2_Ukishima_c_InitResources
+// recovered name: daObjKm2_Ukishima_c_InitResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daObjKm2_Ukishima_c::InitResources - recovered from vtable slot identity */
-int daObjKm2_Ukishima_c_InitResources(void *self)
+int func_ov045_02111bdc(void *self)
 {
     return func_020b6584(self, data_ov045_02112f08, 0xf50);
 }

--- a/src/func_ov047_021111f0.c
+++ b/src/func_ov047_021111f0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov047_021111f0
-// @emits daObjKm3_Kurumajiku_c_OnYoshiTryEat
+// recovered name: daObjKm3_Kurumajiku_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm3_Kurumajiku_c_OnYoshiTryEat(int *t)
+int *func_ov047_021111f0(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov047_02111254.c
+++ b/src/func_ov047_02111254.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov047_02111254
-// @emits daObjKm3_Kurumajiku_c_CleanupResources
+// recovered name: daObjKm3_Kurumajiku_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::CleanupResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b6ac8(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112258;
 
-int daObjKm3_Kurumajiku_c_CleanupResources(u8 *self)
+int func_ov047_02111254(u8 *self)
 {
     return func_ov002_020b6ac8(self, &data_ov047_02112258);
 }

--- a/src/func_ov047_02111268.c
+++ b/src/func_ov047_02111268.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov047_02111268
-// @emits daObjKm3_Kurumajiku_c_InitResources
+// recovered name: daObjKm3_Kurumajiku_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kurumajiku_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b6c54(u8 *self, struct Arg *arg, unsigned int actorID);
 extern struct Arg data_ov047_02112258;
 
-int daObjKm3_Kurumajiku_c_InitResources(u8 *self)
+int func_ov047_02111268(u8 *self)
 {
     return func_ov002_020b6c54(self, &data_ov047_02112258, 0x97);
 }

--- a/src/func_ov047_02111448.c
+++ b/src/func_ov047_02111448.c
@@ -1,5 +1,5 @@
 // @symbol func_ov047_02111448
-// @emits daObjKm3_Kuruma_c_OnYoshiTryEat
+// recovered name: daObjKm3_Kuruma_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjKm3_Kuruma_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjKm3_Kuruma_c_OnYoshiTryEat(int *t)
+int *func_ov047_02111448(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov047_021114ac.c
+++ b/src/func_ov047_021114ac.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov047_021114ac
-// @emits daObjKm3_Kuruma_c_CleanupResources
+// recovered name: daObjKm3_Kuruma_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kuruma_c::CleanupResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b68b0(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112408;
 
-int daObjKm3_Kuruma_c_CleanupResources(u8 *self)
+int func_ov047_021114ac(u8 *self)
 {
     return func_ov002_020b68b0(self, &data_ov047_02112408);
 }

--- a/src/func_ov047_021114c0.c
+++ b/src/func_ov047_021114c0.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov047_021114c0
-// @emits daObjKm3_Kuruma_c_InitResources
+// recovered name: daObjKm3_Kuruma_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjKm3_Kuruma_c::InitResources - recovered from vtable slot identity */
 struct Arg { void *m[3]; };
@@ -8,7 +8,7 @@ struct Arg { void *m[3]; };
 extern int func_ov002_020b6958(u8 *self, struct Arg *arg);
 extern struct Arg data_ov047_02112408;
 
-int daObjKm3_Kuruma_c_InitResources(u8 *self)
+int func_ov047_021114c0(u8 *self)
 {
     return func_ov002_020b6958(self, &data_ov047_02112408);
 }

--- a/src/func_ov052_021111e4.c
+++ b/src/func_ov052_021111e4.c
@@ -1,5 +1,5 @@
 // @symbol func_ov052_021111e4
-// @emits daObjEmmLog_c_OnYoshiTryEat
+// recovered name: daObjEmmLog_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daObjEmmLog_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daObjEmmLog_c_OnYoshiTryEat(int *t)
+int *func_ov052_021111e4(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov052_0211123c.c
+++ b/src/func_ov052_0211123c.c
@@ -1,12 +1,12 @@
 // @symbol func_ov052_0211123c
-// @emits daObjEmmLog_c_CleanupResources
+// recovered name: daObjEmmLog_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daObjEmmLog_c::CleanupResources - recovered from vtable slot identity */
 extern int _ZN16MeshColliderBase9IsEnabledEv();
 extern int _ZN16MeshColliderBase7DisableEv();
 extern int _ZN13SharedFilePtr7ReleaseEv();
 extern int *data_ov056_021124d4[];
-int daObjEmmLog_c_CleanupResources(char *c){
+int func_ov052_0211123c(char *c){
   if(_ZN16MeshColliderBase9IsEnabledEv((char*)c+0x124))
     _ZN16MeshColliderBase7DisableEv((char*)c+0x124);
   _ZN13SharedFilePtr7ReleaseEv(data_ov056_021124d4[0]);

--- a/src/func_ov052_02111284.cpp
+++ b/src/func_ov052_02111284.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov052_02111284
-// @emits daObjEmmLog_c_Render
+// recovered name: daObjEmmLog_c_Render
 /* recovered: renamed to Class_Method */
 /* daObjEmmLog_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daObjEmmLog_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov052_02111284(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov052_021112ac.c
+++ b/src/func_ov052_021112ac.c
@@ -1,7 +1,7 @@
 // @symbol func_ov052_021112ac
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daObjEmmLog_c.h"
-// @emits daObjEmmLog_c_Behavior
+// recovered name: daObjEmmLog_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daObjEmmLog_c::Behavior - recovered from vtable slot identity */
 typedef int Fix12;
@@ -10,7 +10,7 @@ extern void _ZN8Platform21UpdateModelPosAndRotYEv(void *self);
 extern void _ZN8Platform19UpdateClsnPosAndRotEv(void *self);
 extern int _ZN8Platform13IsClsnInRangeE5Fix12IiES1_(void *self, Fix12 a, int b);
 extern short data_02082214[];
-int daObjEmmLog_c_Behavior(char *c)
+int func_ov052_021112ac(char *c)
 {
     struct daObjEmmLog_c *self = (struct daObjEmmLog_c *)(void *)c;
     func_020393a4((int*)(c + 0x124), 0x600000);

--- a/src/func_ov052_02111348.cpp
+++ b/src/func_ov052_02111348.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov052_02111348
-// @emits daObjEmmLog_c_InitResources
+// recovered name: daObjEmmLog_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daObjEmmLog_c::InitResources - recovered from vtable slot identity */
 typedef int Fix12i;
@@ -21,7 +21,7 @@ extern "C" void _ZN18MovingMeshCollider7SetFileEP8KCL_FileRK9Matrix4x35Fix12IiEs
 struct DataT { SharedFilePtr* a; SharedFilePtr* b; CLPS_Block* c; };
 extern DataT data_ov052_021124d4;
 
-extern "C" int daObjEmmLog_c_InitResources(char* thiz)
+extern "C" int func_ov052_02111348(char* thiz)
 {
     char* c = thiz;
     {

--- a/src/func_ov060_021169b0.c
+++ b/src/func_ov060_021169b0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov060_021169b0
-// @emits Bowser_Kill
+// recovered name: Bowser_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_WithMeshClsn.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern int RandomIntInternal(int* seed);
 extern int data_0209e650;
 
-void Bowser_Kill(char* thiz) {
+void func_ov060_021169b0(char* thiz) {
     *(int*)(thiz + 0xa8) = 0x1e000;
     *(int*)(thiz + 0x98) = 0xf000;
     *(short*)(thiz + 0x376) = (unsigned int)RandomIntInternal(&data_0209e650) >> 16;

--- a/src/func_ov060_02117d60.c
+++ b/src/func_ov060_02117d60.c
@@ -1,5 +1,5 @@
 // @symbol func_ov060_02117d60
-// @emits daKpa3Bg_c_OnYoshiTryEat
+// recovered name: daKpa3Bg_c_OnYoshiTryEat
 /* recovered: vtable identified, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_Model.h"
@@ -8,7 +8,7 @@
 /* recovered: vtable identified, renamed to Class_Method */
 /* daKpa3Bg_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern void *G0;
-int *daKpa3Bg_c_OnYoshiTryEat(int *t)
+int *func_ov060_02117d60(int *t)
 {
     t[0] = (int)VT0;
     t[0] = (int)VT1;

--- a/src/func_ov060_021181e8.c
+++ b/src/func_ov060_021181e8.c
@@ -3,13 +3,13 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "daKpa3Bg_c.h"
-// @emits daKpa3Bg_c_CleanupResources
+// recovered name: daKpa3Bg_c_CleanupResources
 /* recovered: renamed to Class_Method */
 /* daKpa3Bg_c::CleanupResources - recovered from vtable slot identity */
 extern void _ZN13SharedFilePtr7ReleaseEv(void *);
 extern void *data_ov060_02119514[];
 extern void *data_ov060_0211953c[];
-int daKpa3Bg_c_CleanupResources(char *c)
+int func_ov060_021181e8(char *c)
 {
     struct daKpa3Bg_c *self = (struct daKpa3Bg_c *)(void *)c;
     _ZN16MeshColliderBase7DisableEv(c + 0x124);

--- a/src/func_ov060_0211822c.cpp
+++ b/src/func_ov060_0211822c.cpp
@@ -1,8 +1,8 @@
 //cpp
 // @symbol func_ov060_0211822c
-// @emits daKpa3Bg_c_Render
+// recovered name: daKpa3Bg_c_Render
 /* recovered: renamed to Class_Method */
 /* daKpa3Bg_c::Render - recovered from vtable slot identity */
 struct Base { virtual void v0(); virtual void v1(); virtual void v2(); virtual void v3(); virtual void v4(); virtual void m(int); };
 struct Derived { char pad[0xd4]; Base base; };
-extern "C" int daKpa3Bg_c_Render(Derived *d) { Base *b = &d->base; b->m(0); return 1; }
+extern "C" int func_ov060_0211822c(Derived *d) { Base *b = &d->base; b->m(0); return 1; }

--- a/src/func_ov060_02118254.cpp
+++ b/src/func_ov060_02118254.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov060_02118254
-// @emits daKpa3Bg_c_Behavior
+// recovered name: daKpa3Bg_c_Behavior
 /* recovered: renamed to Class_Method */
 /* daKpa3Bg_c::Behavior - recovered from vtable slot identity */
 struct C;
@@ -15,7 +15,7 @@ struct C {
     unsigned char pad2[2];
     unsigned char flag;
 };
-extern "C" int daKpa3Bg_c_Behavior(C* c) {
+extern "C" int func_ov060_02118254(C* c) {
     (c->*(data_ov060_0211b1ac[c->idx].pmf))();
     _ZN8Platform21UpdateModelPosAndRotYEv(c);
     _ZN8Platform19UpdateClsnPosAndRotEv(c);

--- a/src/func_ov060_021182b0.cpp
+++ b/src/func_ov060_021182b0.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov060_021182b0
-// @emits daKpa3Bg_c_InitResources
+// recovered name: daKpa3Bg_c_InitResources
 /* recovered: renamed to Class_Method */
 /* daKpa3Bg_c::InitResources - recovered from vtable slot identity */
 struct BMD_File; struct KCL_File; struct Actor; struct Matrix4x3;
@@ -27,8 +27,8 @@ extern "C" CLPS_Block* data_ov060_0211a980[];
 extern void _ZN16MeshColliderBase22UpdatePosWithTransformERS_P5ActorR10ClsnResultR7Vector3P10Vector3_16S8_();
 extern "C" void func_ov060_021183f4();
 
-extern "C" int daKpa3Bg_c_InitResources(char* self);
-int daKpa3Bg_c_InitResources(char* self)
+extern "C" int func_ov060_021182b0(char* self);
+int func_ov060_021182b0(char* self)
 {
     int idx = *(int*)(self + 8) & 0xf;
     *(unsigned char*)(self + 0x329) = (unsigned char)idx;

--- a/src/func_ov062_02117470.c
+++ b/src/func_ov062_02117470.c
@@ -1,8 +1,8 @@
 // @symbol func_ov062_02117470
-// @emits Chuckya_OnAimedAtWithEgg
+// recovered name: Chuckya_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daHolhei_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Chuckya_OnAimedAtWithEgg(void)
+int func_ov062_02117470(void)
 {
     return 827392;
 }

--- a/src/func_ov062_02119608.cpp
+++ b/src/func_ov062_02119608.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov062_02119608
-// @emits Koopa_OnAimedAtWithEgg
+// recovered name: Koopa_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daNknk_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-extern "C" int Koopa_OnAimedAtWithEgg(void *c) {
+extern "C" int func_ov062_02119608(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xcb) r = 1; else r = 0;

--- a/src/func_ov062_02119628.cpp
+++ b/src/func_ov062_02119628.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov062_02119628
-// @emits Koopa_OnTurnIntoEgg
+// recovered name: Koopa_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daNknk_c::OnTurnIntoEgg - recovered from vtable slot identity */
-/* Koopa_OnTurnIntoEgg at 0x02119628 (ov062), size 0x80
+/* func_ov062_02119628 at 0x02119628 (ov062), size 0x80
  * Matched byte-for-byte with mwccarm 1.2/sp2p3.
  * flags: -O4,p -enum int -lang c++ -char signed -interworking -proc arm946e -gccext,on -msgstyle gcc
  */
@@ -21,7 +21,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, bool b, bool c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char b, unsigned int n);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void Koopa_OnTurnIntoEgg(Actor *c, void *player) {
+void func_ov062_02119628(Actor *c, void *player) {
 #pragma optimize_for_size on
     if (c->f108 == 3) {
         if (c->Slot18() == 6 && _ZN6Player15IsCollectingCapEv(player) == 0) {

--- a/src/func_ov062_021196a8.c
+++ b/src/func_ov062_021196a8.c
@@ -1,8 +1,8 @@
 // @symbol func_ov062_021196a8
-// @emits Koopa_OnYoshiTryEat
+// recovered name: Koopa_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daNknk_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Koopa_OnYoshiTryEat(char* c){
+int func_ov062_021196a8(char* c){
   if(*(int*)(c+0x394)==0) return 6;
   return 5;
 }

--- a/src/func_ov062_0211a740.cpp
+++ b/src/func_ov062_0211a740.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov062_0211a740
-// @emits Koopa_Kill
+// recovered name: Koopa_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daNknk_c::Kill - recovered from vtable slot identity */
 typedef short s16;
@@ -23,7 +23,7 @@ extern int data_ov062_0211e034[];
 extern s8 data_0209f2f8;
 extern u8 data_0209d684;
 extern char data_0209d4c8[];
-extern "C" void Koopa_Kill(char* c)
+extern "C" void func_ov062_0211a740(char* c)
 {
     switch (*(u8*)(c + 0x390)) {
     case 0:

--- a/src/func_ov062_0211ba84.c
+++ b/src/func_ov062_0211ba84.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov062_0211ba84
-// @emits KoopaFlag_Kill
+// recovered name: KoopaFlag_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -18,7 +18,7 @@ extern void *data_ov062_0211e17c;
 extern signed char data_0209f2f8;
 extern int data_020a0e68[];
 
-int KoopaFlag_Kill(char *c)
+int func_ov062_0211ba84(char *c)
 {
     Vector3 v;
     Vector3 t;

--- a/src/func_ov062_0211ce78.c
+++ b/src/func_ov062_0211ce78.c
@@ -1,8 +1,8 @@
 // @symbol func_ov062_0211ce78
-// @emits Klepto_OnAimedAtWithEgg
+// recovered name: Klepto_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daJango_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Klepto_OnAimedAtWithEgg(void)
+int func_ov062_0211ce78(void)
 {
     return 458752;
 }

--- a/src/func_ov063_021160c4.c
+++ b/src/func_ov063_021160c4.c
@@ -1,7 +1,7 @@
 // @symbol func_ov063_021160c4
-// @emits Boo_OnAimedAtWithEgg
+// recovered name: Boo_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daTrs_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Boo_OnAimedAtWithEgg(void* c) {
+int func_ov063_021160c4(void* c) {
     return *(int *)((char *)c + 0x18c) / 2;
 }

--- a/src/func_ov063_0211c480.cpp
+++ b/src/func_ov063_0211c480.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov063_0211c480
-// @emits Boo_OnYoshiTryEat
+// recovered name: Boo_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daTrs_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern "C" int Boo_OnYoshiTryEat(void *c) {
+extern "C" int func_ov063_0211c480(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xd1) r = 1; else r = 0;

--- a/src/func_ov063_0211c7b0.c
+++ b/src/func_ov063_0211c7b0.c
@@ -1,11 +1,11 @@
 // @symbol func_ov063_0211c7b0
-// @emits BooCage_Kill
+// recovered name: BooCage_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
 /* daTBasket_c::Kill - recovered from vtable slot identity */
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int c, void *v, unsigned int e);
-void BooCage_Kill(char *c) {
+void func_ov063_0211c7b0(char *c) {
     short *t;
     if (*(unsigned char*)(c + 0x150) != 0) {
         *(short*)(c + 0x100 + 0x3a) = 0;

--- a/src/func_ov070_021204e4.c
+++ b/src/func_ov070_021204e4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov070_021204e4
-// @emits FlyGuy_OnAimedAtWithEgg
+// recovered name: FlyGuy_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daPropeller_Heyho_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int FlyGuy_OnAimedAtWithEgg(void)
+int func_ov070_021204e4(void)
 {
     return 176128;
 }

--- a/src/func_ov070_021204ec.cpp
+++ b/src/func_ov070_021204ec.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov070_021204ec
-// @emits FlyGuy_OnTurnIntoEgg
+// recovered name: FlyGuy_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daPropeller_Heyho_c::OnTurnIntoEgg - recovered from vtable slot identity */
 class Player;
@@ -11,7 +11,7 @@ void GivePlayerCoins(Player &player, unsigned char count, unsigned int unknown);
 void KillAndTrackInDeathTable();
 };
 
-extern "C" void FlyGuy_OnTurnIntoEgg(char *c, void *player) {
+extern "C" void func_ov070_021204ec(char *c, void *player) {
 Actor *r4 = (Actor *)c;
 unsigned char r2 = ((unsigned char *)r4)[0x10a];
 r4->GivePlayerCoins(*(Player *)player, r2 + 1, 0);

--- a/src/func_ov070_02120518.c
+++ b/src/func_ov070_02120518.c
@@ -1,8 +1,8 @@
 // @symbol func_ov070_02120518
-// @emits FlyGuy_OnYoshiTryEat
+// recovered name: FlyGuy_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daPropeller_Heyho_c::OnYoshiTryEat - recovered from vtable slot identity */
-int FlyGuy_OnYoshiTryEat(void)
+int func_ov070_02120518(void)
 {
     return 5;
 }

--- a/src/func_ov070_021211bc.c
+++ b/src/func_ov070_021211bc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov070_021211bc
-// @emits FlameChomp_OnYoshiTryEat
+// recovered name: FlameChomp_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daKrpa_c::OnYoshiTryEat - recovered from vtable slot identity */
-int FlameChomp_OnYoshiTryEat(void)
+int func_ov070_021211bc(void)
 {
     return 5;
 }

--- a/src/func_ov070_02121438.cpp
+++ b/src/func_ov070_02121438.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov070_02121438
-// @emits Amp_Kill
+// recovered name: Amp_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
@@ -11,7 +11,7 @@ extern void _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(void* thiz, void* f, int
 extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int n, int a, int b, int c);
 }
 
-extern "C" int Amp_Kill(char* c)
+extern "C" int func_ov070_02121438(char* c)
 {
     _ZN5Sound9PlayBank0EjRK7Vector3(9, *(Vector3*)(c + 0x74));
     int* p_b0 = (int*)(((int)c + 0xb0));

--- a/src/func_ov070_02121bdc.c
+++ b/src/func_ov070_02121bdc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov070_02121bdc
-// @emits FlameChompFire_OnYoshiTryEat
+// recovered name: FlameChompFire_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daKpFr_c::OnYoshiTryEat - recovered from vtable slot identity */
-int FlameChompFire_OnYoshiTryEat(void)
+int func_ov070_02121bdc(void)
 {
     return 5;
 }

--- a/src/func_ov070_02121fb0.c
+++ b/src/func_ov070_02121fb0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov070_02121fb0
-// @emits FlameChomp_Kill
+// recovered name: FlameChomp_Kill
 /* recovered: renamed to Class_Method */
 /* daKrpa_c::Kill - recovered from vtable slot identity */
-int FlameChomp_Kill(char *p)
+int func_ov070_02121fb0(char *p)
 {
     *(int *)(p + 0x98) = 40960;
     *(char *)(p + 0x32c) = 105;

--- a/src/func_ov071_0211f0a4.c
+++ b/src/func_ov071_0211f0a4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov071_0211f0a4
-// @emits Scuttlebug_OnYoshiTryEat
+// recovered name: Scuttlebug_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daSpd_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Scuttlebug_OnYoshiTryEat(void)
+int func_ov071_0211f0a4(void)
 {
     return 6;
 }

--- a/src/func_ov071_0211f0ac.c
+++ b/src/func_ov071_0211f0ac.c
@@ -1,8 +1,8 @@
 // @symbol func_ov071_0211f0ac
-// @emits Scuttlebug_OnAimedAtWithEgg
+// recovered name: Scuttlebug_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daSpd_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Scuttlebug_OnAimedAtWithEgg(void)
+int func_ov071_0211f0ac(void)
 {
     return 204800;
 }

--- a/src/func_ov071_02120580.cpp
+++ b/src/func_ov071_02120580.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov071_02120580
-// @emits Scuttlebug_OnTurnIntoEgg
+// recovered name: Scuttlebug_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daSpd_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -9,7 +9,7 @@ extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void* a, void* p, unsigned cha
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void* p, unsigned int n, int b1, int b2);
 extern void Scuttlebug_SetState(void* a, int idx);
 extern void _ZN9ActorBase18MarkForDestructionEv(void* a);
-void Scuttlebug_OnTurnIntoEgg(char* a, void* p) {
+void func_ov071_02120580(char* a, void* p) {
   volatile int force_stack;
   int *bp;
   int t;

--- a/src/func_ov071_021214f4.c
+++ b/src/func_ov071_021214f4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov071_021214f4
-// @emits Scuttlebug_Kill
+// recovered name: Scuttlebug_Kill
 /* recovered: renamed to Class_Method */
 /* daSpd_c::Kill - recovered from vtable slot identity */
-int Scuttlebug_Kill(char* c) {
+int func_ov071_021214f4(char* c) {
     *(unsigned char*)(c+0x212) = 0xf0;
     *(unsigned char*)(c+0x213) = 0;
     *(int*)(c+0x1f4) = 0;

--- a/src/func_ov071_02121b00.c
+++ b/src/func_ov071_02121b00.c
@@ -1,8 +1,8 @@
 // @symbol func_ov071_02121b00
-// @emits MrI_Projectile_OnYoshiTryEat
+// recovered name: MrI_Projectile_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daEyBm_c::OnYoshiTryEat - recovered from vtable slot identity */
-int MrI_Projectile_OnYoshiTryEat(void)
+int func_ov071_02121b00(void)
 {
     return 4;
 }

--- a/src/func_ov073_02121ec0.c
+++ b/src/func_ov073_02121ec0.c
@@ -1,8 +1,8 @@
 // @symbol func_ov073_02121ec0
-// @emits ChiefChilly_OnAimedAtWithEgg
+// recovered name: ChiefChilly_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daKing_Donketu_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int ChiefChilly_OnAimedAtWithEgg(void)
+int func_ov073_02121ec0(void)
 {
     return 409600;
 }

--- a/src/func_ov073_02122200.cpp
+++ b/src/func_ov073_02122200.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov073_02122200
-// @emits ChiefChilly_Kill
+// recovered name: ChiefChilly_Kill
 /* recovered: renamed to Class_Method */
 /* daKing_Donketu_c::Kill - recovered from vtable slot identity */
 typedef short s16;
@@ -12,7 +12,7 @@ extern "C" unsigned short DecIfAbove0_Short(unsigned short* p);
 extern "C" void _ZN9ActorBase18MarkForDestructionEv(void* a);
 extern int data_02092138;
 
-extern "C" int ChiefChilly_Kill(char* thiz)
+extern "C" int func_ov073_02122200(char* thiz)
 {
     char* c = thiz;
     _ZN5Actor9UpdatePosEP12CylinderClsn(c, 0);

--- a/src/func_ov073_021223f4.cpp
+++ b/src/func_ov073_021223f4.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov073_021223f4
-// @emits CccArena_Kill
+// recovered name: CccArena_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjEwbIce_c::Kill - recovered from vtable slot identity */
-// CccArena_Kill at 0x021223f4
+// func_ov073_021223f4 at 0x021223f4
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov073).
 struct Vector3 { int x, y, z; };
 extern "C" {
@@ -11,8 +11,8 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int 
 extern void _ZN5Actor10PoofDustAtERK7Vector3(void* self, const Vector3& vec);
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 }
-extern "C" void CccArena_Kill(char* c);
-void CccArena_Kill(char* c) {
+extern "C" void func_ov073_021223f4(char* c);
+void func_ov073_021223f4(char* c) {
     Vector3 vec;
     Vector3 vec2;
     vec.x = *(int*)(c + 0x5c);

--- a/src/func_ov075_02115b28.c
+++ b/src/func_ov075_02115b28.c
@@ -1,5 +1,5 @@
 // @symbol func_ov075_02115b28
-// @emits dScEntry_c_OnYoshiTryEat
+// recovered name: dScEntry_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ extern int data_0208e4b8[];
 extern void __destroy_arr(void*, int, int, void*);
 extern void _ZN9ActorBaseD2Ev(void*);
 extern void* data_020a0eac;
-int* dScEntry_c_OnYoshiTryEat(int* t){
+int* func_ov075_02115b28(int* t){
   t[0]=(int)data_ov075_0211d304;
   __destroy_arr((char*)t+0x1b4, 4, 0x2c, (void*)func_ov075_02115bc8);
   __destroy_arr((char*)t+0x70, 9, 0x24, (void*)func_ov075_02115bac);

--- a/src/func_ov075_0211a210.c
+++ b/src/func_ov075_0211a210.c
@@ -1,5 +1,5 @@
 // @symbol func_ov075_0211a210
-// @emits dScEntry_c_CleanupResources
+// recovered name: dScEntry_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -7,7 +7,7 @@
 extern void func_020308b4(signed char levelID);
 extern void *data_0209d4a8;
 extern void _ZN5Sound21UnsetPlayerVoiceGroupEv(void);
-int dScEntry_c_CleanupResources(signed char levelID)
+int func_ov075_0211a210(signed char levelID)
 {
     func_020308b4(levelID);
     if (data_0209b2e8 != (void *)0) {

--- a/src/func_ov075_0211a268.c
+++ b/src/func_ov075_0211a268.c
@@ -1,7 +1,7 @@
 // @symbol func_ov075_0211a268
-// @emits dScEntry_c_OnPendingDestroy
+// recovered name: dScEntry_c_OnPendingDestroy
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::OnPendingDestroy - recovered from vtable slot identity */
-void dScEntry_c_OnPendingDestroy(void)
+void func_ov075_0211a268(void)
 {
 }

--- a/src/func_ov075_0211a26c.cpp
+++ b/src/func_ov075_0211a26c.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov075_0211a26c
-// @emits dScEntry_c_Render
+// recovered name: dScEntry_c_Render
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -9,7 +9,7 @@ struct C;
 typedef void (C::*PMF)();
 struct C { char pad[0x64]; PMF pp[1]; };
 extern "C" {
-int dScEntry_c_Render(C *c){
+int func_ov075_0211a26c(C *c){
   if(*(int*)&c->pp[0]!=0){
     PMF *p = c->pp;
     (c->**p)();

--- a/src/func_ov075_0211a2b8.cpp
+++ b/src/func_ov075_0211a2b8.cpp
@@ -1,7 +1,7 @@
 //cpp
 #include "types.h"
 // @symbol func_ov075_0211a2b8
-// @emits dScEntry_c_Behavior
+// recovered name: dScEntry_c_Behavior
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -37,7 +37,7 @@ struct Self {
     u8 f285;
 };
 
-extern "C" int dScEntry_c_Behavior(Self *c)
+extern "C" int func_ov075_0211a2b8(Self *c)
 {
     char *cc = (char *)c;
 

--- a/src/func_ov075_0211a410.cpp
+++ b/src/func_ov075_0211a410.cpp
@@ -5,7 +5,7 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScEntry_c.h"
-// @emits dScEntry_c_InitResources
+// recovered name: dScEntry_c_InitResources
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::InitResources - recovered from vtable slot identity */
 extern "C" {
@@ -44,7 +44,7 @@ extern u8 data_0209f4ae[];
 extern void* data_0209d4a8;
 extern s32 data_0208ee44;
 
-extern "C" int dScEntry_c_InitResources(char* c)
+extern "C" int func_ov075_0211a410(char* c)
 {
     struct dScEntry_c *self = (struct dScEntry_c *)(void *)c;
     Enable3dEngines();

--- a/src/func_ov075_0211a734.c
+++ b/src/func_ov075_0211a734.c
@@ -1,12 +1,12 @@
 // @symbol func_ov075_0211a734
-// @emits dScEntry_c_BeforeInitResources
+// recovered name: dScEntry_c_BeforeInitResources
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::BeforeInitResources - recovered from vtable slot identity */
-/* dScEntry_c_BeforeInitResources @ 0x211a734 (ov075) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
+/* func_ov075_0211a734 @ 0x211a734 (ov075) -- tail-call veneer to _ZN5Scene19ResetFadersAndSoundEv (0x202e66c).
  * ldr ip, [pc]; bx ip; .word 0x202e66c
  */
 extern void _ZN5Scene19ResetFadersAndSoundEv(void);
 
-void dScEntry_c_BeforeInitResources(void) {
+void func_ov075_0211a734(void) {
     _ZN5Scene19ResetFadersAndSoundEv();
 }

--- a/src/func_ov075_0211b1cc.c
+++ b/src/func_ov075_0211b1cc.c
@@ -3,12 +3,12 @@
 #include "decl_common.h"
 /* recovered: renamed to Class_Method, RTTI class fields named */
 #include "dScEntry_c.h"
-// @emits dScEntry_c_OnYoshiTryEat_0211b1cc
+// recovered name: dScEntry_c_OnYoshiTryEat_0211b1cc
 /* recovered: renamed to Class_Method */
 /* dScEntry_c::OnYoshiTryEat - recovered from vtable slot identity */
 extern unsigned short DecIfAbove0_Short(unsigned short* p);
 struct E { char pad[8]; int r8; int rc; char pad2[8]; };
-void dScEntry_c_OnYoshiTryEat_0211b1cc(char* c) {
+void func_ov075_0211b1cc(char* c) {
     struct dScEntry_c *self = (struct dScEntry_c *)(void *)c;
   int i;
   if (DecIfAbove0_Short((unsigned short*)(c + 0xa2)) == 0) return;

--- a/src/func_ov077_02123804.c
+++ b/src/func_ov077_02123804.c
@@ -1,8 +1,8 @@
 // @symbol func_ov077_02123804
-// @emits Lakitu_OnYoshiTryEat
+// recovered name: Lakitu_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daJgm_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Lakitu_OnYoshiTryEat(void)
+int func_ov077_02123804(void)
 {
     return 6;
 }

--- a/src/func_ov077_0212380c.c
+++ b/src/func_ov077_0212380c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov077_0212380c
-// @emits Lakitu_OnAimedAtWithEgg
+// recovered name: Lakitu_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daJgm_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Lakitu_OnAimedAtWithEgg(void)
+int func_ov077_0212380c(void)
 {
     return 245760;
 }

--- a/src/func_ov077_02124aa4.cpp
+++ b/src/func_ov077_02124aa4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov077_02124aa4
-// @emits Lakitu_OnTurnIntoEgg
+// recovered name: Lakitu_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daJgm_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN5Actor24KillAndTrackInDeathTableEv(void *self);
-void Lakitu_OnTurnIntoEgg(void *self, void *p)
+void func_ov077_02124aa4(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 5, 0);

--- a/src/func_ov077_02124c18.c
+++ b/src/func_ov077_02124c18.c
@@ -1,8 +1,8 @@
 // @symbol func_ov077_02124c18
-// @emits Spiny_OnYoshiTryEat
+// recovered name: Spiny_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daTgz_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Spiny_OnYoshiTryEat(void)
+int func_ov077_02124c18(void)
 {
     return 6;
 }

--- a/src/func_ov077_02124c20.c
+++ b/src/func_ov077_02124c20.c
@@ -1,8 +1,8 @@
 // @symbol func_ov077_02124c20
-// @emits Spiny_OnAimedAtWithEgg
+// recovered name: Spiny_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daTgz_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Spiny_OnAimedAtWithEgg(void)
+int func_ov077_02124c20(void)
 {
     return 122880;
 }

--- a/src/func_ov077_021258dc.c
+++ b/src/func_ov077_021258dc.c
@@ -1,9 +1,9 @@
 // @symbol func_ov077_021258dc
-// @emits Lakitu_Kill
+// recovered name: Lakitu_Kill
 /* recovered: renamed to Class_Method */
 /* daJgm_c::Kill - recovered from vtable slot identity */
 extern void _ZN12CylinderClsn5ClearEv(void *);
-int Lakitu_Kill(char *c)
+int func_ov077_021258dc(char *c)
 {
     *(int *)(c + 0x98) = 0;
     _ZN12CylinderClsn5ClearEv((char *)c + 0x1b0);

--- a/src/func_ov077_02126194.cpp
+++ b/src/func_ov077_02126194.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov077_02126194
-// @emits Spiny_OnTurnIntoEgg
+// recovered name: Spiny_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daTgz_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ extern int _ZN6Player15IsCollectingCapEv(void *p);
 extern void _ZN6Player20RegisterEggCoinCountEjbb(void *p, unsigned int a, char b, char c);
 extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(void *self, void *p, unsigned char n, unsigned int u);
 extern void _ZN9ActorBase18MarkForDestructionEv(void *self);
-void Spiny_OnTurnIntoEgg(void *self, void *p)
+void func_ov077_02126194(void *self, void *p)
 {
     if (_ZN6Player15IsCollectingCapEv(p))
         _ZN5Actor15GivePlayerCoinsER6Playerhj(self, p, 1, 0);

--- a/src/func_ov077_02126640.cpp
+++ b/src/func_ov077_02126640.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov077_02126640
-// @emits Spiny_Kill
+// recovered name: Spiny_Kill
 /* recovered: renamed to Class_Method */
 /* daTgz_c::Kill - recovered from vtable slot identity */
 struct Vector3 { int x, y, z; Vector3() {} };
@@ -16,7 +16,7 @@ extern int data_ov077_02127a5c[3];
 extern int data_ov077_02127cf8;
 }
 
-extern "C" int Spiny_Kill(char *c)
+extern "C" int func_ov077_02126640(char *c)
 {
     Vector3 v;
     char *a;

--- a/src/func_ov084_0212b30c.cpp
+++ b/src/func_ov084_0212b30c.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov084_0212b30c
-// @emits Goomba_OnAimedAtWithEgg
+// recovered name: Goomba_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daKrb_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-extern "C" int Goomba_OnAimedAtWithEgg(char *c) {
+extern "C" int func_ov084_0212b30c(char *c) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     int b = (v == (unsigned short)0xc8) ? 1 : 0;
     if (b) return 0x41000;

--- a/src/func_ov084_0212b344.cpp
+++ b/src/func_ov084_0212b344.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov084_0212b344
-// @emits Goomba_OnTurnIntoEgg
+// recovered name: Goomba_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daKrb_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
@@ -39,7 +39,7 @@ struct Obj {
     virtual int GetState();
 };
 
-extern "C" void Goomba_OnTurnIntoEgg(char *self, char *player)
+extern "C" void func_ov084_0212b344(char *self, char *player)
 {
     Obj *o = (Obj *)self;
     int b5, b4;

--- a/src/func_ov084_0212bfc0.cpp
+++ b/src/func_ov084_0212bfc0.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov084_0212bfc0
-// @emits Goomba_OnYoshiTryEat
+// recovered name: Goomba_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daKrb_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern "C" int Goomba_OnYoshiTryEat(char *c) {
+extern "C" int func_ov084_0212bfc0(char *c) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     int b = (v == (unsigned short)0xc8) ? 1 : 0;
     if (b) return 0x6;

--- a/src/func_ov084_0212c4a0.c
+++ b/src/func_ov084_0212c4a0.c
@@ -1,9 +1,9 @@
 // @symbol func_ov084_0212c4a0
-// @emits Goomba_Kill
+// recovered name: Goomba_Kill
 /* recovered: renamed to Class_Method */
 /* daKrb_c::Kill - recovered from vtable slot identity */
 extern void* _ZN5Actor15FindWithActorIDEjPS_(unsigned int, void*);
-void Goomba_Kill(char* r5) {
+void func_ov084_0212c4a0(char* r5) {
     void* r1;
     r1 = _ZN5Actor15FindWithActorIDEjPS_(0xe, 0);
     while (r1) {

--- a/src/func_ov084_0212e998.c
+++ b/src/func_ov084_0212e998.c
@@ -1,8 +1,8 @@
 // @symbol func_ov084_0212e998
-// @emits FirePiranhaPlantBig_OnAimedAtWithEgg
+// recovered name: FirePiranhaPlantBig_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daFPkn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int FirePiranhaPlantBig_OnAimedAtWithEgg(void* c) {
+int func_ov084_0212e998(void* c) {
     int flags = *(int*)((char*)c + 0x18c);
     if (flags & 1) {
         return *(int*)((char*)c + 0x204) * 100;

--- a/src/func_ov084_0212e9d4.cpp
+++ b/src/func_ov084_0212e9d4.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov084_0212e9d4
-// @emits FirePiranhaPlantBig_OnTurnIntoEgg
+// recovered name: FirePiranhaPlantBig_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daFPkn_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 int _ZN5Actor15GivePlayerCoinsER6Playerhj(void *thisp, void *player, unsigned char count, unsigned int z);
 int _ZN5Actor24KillAndTrackInDeathTableEv(void *thisp);
-int FirePiranhaPlantBig_OnTurnIntoEgg(void *c, void *player) {
+int func_ov084_0212e9d4(void *c, void *player) {
     _ZN5Actor15GivePlayerCoinsER6Playerhj(c, player, 1, 0);
     return _ZN5Actor24KillAndTrackInDeathTableEv(c);
 }

--- a/src/func_ov084_0212e9f8.cpp
+++ b/src/func_ov084_0212e9f8.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov084_0212e9f8
-// @emits FirePiranhaPlantBig_OnYoshiTryEat
+// recovered name: FirePiranhaPlantBig_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daFPkn_c::OnYoshiTryEat - recovered from vtable slot identity */
-extern "C" int FirePiranhaPlantBig_OnYoshiTryEat(void *c) {
+extern "C" int func_ov084_0212e9f8(void *c) {
     unsigned short v = *(unsigned short*)((char*)c + 0xc);
     int r;
     if (v == 0xfc) r = 1; else r = 0;

--- a/src/func_ov084_0212ec58.c
+++ b/src/func_ov084_0212ec58.c
@@ -1,8 +1,8 @@
 // @symbol func_ov084_0212ec58
-// @emits PiranhaPlant_OnAimedAtWithEgg
+// recovered name: PiranhaPlant_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daPkn_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int PiranhaPlant_OnAimedAtWithEgg(void)
+int func_ov084_0212ec58(void)
 {
     return 286720;
 }

--- a/src/func_ov084_0212fa7c.c
+++ b/src/func_ov084_0212fa7c.c
@@ -1,5 +1,5 @@
 // @symbol func_ov084_0212fa7c
-// @emits FirePiranhaPlantBig_Kill
+// recovered name: FirePiranhaPlantBig_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Animation.h"
 #include "decl_common.h"
@@ -16,7 +16,7 @@ extern int _ZN5Sound7PlaySubEjjj5Fix12IiEb(unsigned int a, unsigned int b, unsig
 
 extern int *data_ov084_02130df4;
 
-void FirePiranhaPlantBig_Kill(char *c) {
+void func_ov084_0212fa7c(char *c) {
     *(unsigned char *)(c + 0x45c) = 1;
     if (_ZN9Animation8FinishedEv(c + 0x160) || _ZNK9Animation12WillHitFrameEi(c + 0x160, 0)) {
         _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c + 0x110, (BCA_File *)((int *)&data_ov084_02130df4)[1], 0, 0x1000, 0);

--- a/src/func_ov085_0212b4b4.c
+++ b/src/func_ov085_0212b4b4.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov085_0212b4b4
-// @emits PrincessPeach_Kill
+// recovered name: PrincessPeach_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -20,7 +20,7 @@ extern int _ZN4cstd4fdivEii(int a, int b);
 extern void Vec3_MulScalar(Vector3 *out, const Vector3 *v, int s);
 extern void SubVec3(Vector3 *a, Vector3 *b, Vector3 *c);
 extern int _ZNK12WithMeshClsn8IsOnWallEv(void *);
-int PrincessPeach_Kill(char *c)
+int func_ov085_0212b4b4(char *c)
 {
   void *pl;
   char pathptr[8];

--- a/src/func_ov085_0212cc18.c
+++ b/src/func_ov085_0212cc18.c
@@ -1,8 +1,8 @@
 // @symbol func_ov085_0212cc18
-// @emits Rabbit_OnYoshiTryEat
+// recovered name: Rabbit_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daMip_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Rabbit_OnYoshiTryEat(unsigned char *c) {
+int func_ov085_0212cc18(unsigned char *c) {
   unsigned char v = c[0x107];
   if (v != 0) return 0;
   return 7;

--- a/src/func_ov085_0212e480.c
+++ b/src/func_ov085_0212e480.c
@@ -1,8 +1,8 @@
 // @symbol func_ov085_0212e480
-// @emits RabbitKey_Kill
+// recovered name: RabbitKey_Kill
 /* recovered: renamed to Class_Method */
 /* daObj_Mip_Key_c::Kill - recovered from vtable slot identity */
-int RabbitKey_Kill(char *p)
+int func_ov085_0212e480(char *p)
 {
     *(int *)(p + 0x64) = 2457600;
     *(int *)(p + 0x2c8) = 0;

--- a/src/func_ov089_02131f04.cpp
+++ b/src/func_ov089_02131f04.cpp
@@ -1,12 +1,12 @@
 //cpp
 // @symbol func_ov089_02131f04
-// @emits Key_OnTurnIntoEgg
+// recovered name: Key_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daObjKey_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern "C" {
 extern int func_ov089_02131df4(void *c, int a);
 extern int func_ov089_02131dcc(void *c, int a);
-int Key_OnTurnIntoEgg(char *c, int a){
+int func_ov089_02131f04(char *c, int a){
   int h=*(unsigned short*)(c+0xc); int eq; if(h==0x11a) eq=1; else eq=0;
   if(eq) return func_ov089_02131df4(c,a); return func_ov089_02131dcc(c,a);
 }

--- a/src/func_ov089_02131f4c.c
+++ b/src/func_ov089_02131f4c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov089_02131f4c
-// @emits Key_OnYoshiTryEat
+// recovered name: Key_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daObjKey_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Key_OnYoshiTryEat(void)
+int func_ov089_02131f4c(void)
 {
     return 4;
 }

--- a/src/func_ov090_02132618.c
+++ b/src/func_ov090_02132618.c
@@ -1,8 +1,8 @@
 // @symbol func_ov090_02132618
-// @emits Skeeter_OnAimedAtWithEgg
+// recovered name: Skeeter_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daMenbo_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Skeeter_OnAimedAtWithEgg(void)
+int func_ov090_02132618(void)
 {
     return 131072;
 }

--- a/src/func_ov090_02132620.cpp
+++ b/src/func_ov090_02132620.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov090_02132620
-// @emits Skeeter_OnTurnIntoEgg
+// recovered name: Skeeter_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daMenbo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 class Player;
@@ -11,7 +11,7 @@ void GivePlayerCoins(Player &player, unsigned char count, unsigned int unknown);
 void KillAndTrackInDeathTable();
 };
 
-extern "C" void Skeeter_OnTurnIntoEgg(char *c, void *player) {
+extern "C" void func_ov090_02132620(char *c, void *player) {
 Actor *r4 = (Actor *)c;
 unsigned char r2 = ((unsigned char *)r4)[0x10a];
 r4->GivePlayerCoins(*(Player *)player, r2 + 1, 0);

--- a/src/func_ov090_0213264c.c
+++ b/src/func_ov090_0213264c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov090_0213264c
-// @emits Skeeter_OnYoshiTryEat
+// recovered name: Skeeter_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daMenbo_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Skeeter_OnYoshiTryEat(void)
+int func_ov090_0213264c(void)
 {
     return 4;
 }

--- a/src/func_ov090_021327e4.cpp
+++ b/src/func_ov090_021327e4.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov090_021327e4
-// @emits Skeeter_Kill
+// recovered name: Skeeter_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daMenbo_c::Kill - recovered from vtable slot identity */
 typedef short s16;
@@ -19,7 +19,7 @@ void func_02012790(u32 a);
 void* _ZN5Actor11SpawnNumberERK7Vector3jbtPS_(void* self, const Vector3& v, u32 n, int b, u16 t, void* p);
 }
 
-extern "C" int Skeeter_Kill(char* c)
+extern "C" int func_ov090_021327e4(char* c)
 {
     void* o;
     Vector3 num1;

--- a/src/func_ov090_02133200.c
+++ b/src/func_ov090_02133200.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov090_02133200
-// @emits MantaRay_Kill
+// recovered name: MantaRay_Kill
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -11,7 +11,7 @@ extern int ApproachAngle(s16* angle, int target, int invFactor, int maxDelta, in
 extern int func_ov090_021332e8(void* c, void* p);
 
 
-int MantaRay_Kill(char* c)
+int func_ov090_02133200(char* c)
 {
     if (Vec3_Dist(c + 0x5c, c + 0x374) > 0x3e8000) {
         *(u16*)(c + 0x100) = 0x32;

--- a/src/func_ov090_0213387c.c
+++ b/src/func_ov090_0213387c.c
@@ -1,10 +1,10 @@
 // @symbol func_ov090_0213387c
-// @emits CheepCheep_Kill
+// recovered name: CheepCheep_Kill
 /* recovered: renamed to Class_Method */
 /* daPukupuku_c::Kill - recovered from vtable slot identity */
 extern int _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(char* anim, void* file, int a, int b, unsigned int u);
 extern int data_ov090_021345ac[];
-int CheepCheep_Kill(char *c) {
+int func_ov090_0213387c(char *c) {
     _ZN9ModelAnim7SetAnimEP8BCA_Filei5Fix12IiEj(c+0x30c, *(void**)((char*)data_ov090_021345ac+4), 0, 0x1000, 0);
     return 1;
 }

--- a/src/func_ov096_021357a4.c
+++ b/src/func_ov096_021357a4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov096_021357a4
-// @emits Pokey_OnYoshiTryEat
+// recovered name: Pokey_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daSanbo_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Pokey_OnYoshiTryEat(void)
+int func_ov096_021357a4(void)
 {
     return 4;
 }

--- a/src/func_ov096_021357ac.c
+++ b/src/func_ov096_021357ac.c
@@ -1,8 +1,8 @@
 // @symbol func_ov096_021357ac
-// @emits Pokey_OnAimedAtWithEgg
+// recovered name: Pokey_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daSanbo_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Pokey_OnAimedAtWithEgg(void)
+int func_ov096_021357ac(void)
 {
     return 245760;
 }

--- a/src/func_ov096_02136cd0.c
+++ b/src/func_ov096_02136cd0.c
@@ -1,5 +1,5 @@
 // @symbol func_ov096_02136cd0
-// @emits Pokey_OnTurnIntoEgg
+// recovered name: Pokey_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daSanbo_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN5Actor15GivePlayerCoinsER6Playerhj(char *c, char *player, unsigned char r2, unsigned int r3);
@@ -7,7 +7,7 @@ extern void _ZN9ActorBase18MarkForDestructionEv(char *c);
 
 enum Bool { FALSE, TRUE };
 
-void Pokey_OnTurnIntoEgg(char *c, char *player) {
+void func_ov096_02136cd0(char *c, char *player) {
     unsigned short v = *(unsigned short*)(c + 0xc);
     enum Bool flag = (enum Bool)(v == 0xf0);
     if (flag) {

--- a/src/func_ov098_02137ccc.cpp
+++ b/src/func_ov098_02137ccc.cpp
@@ -1,9 +1,9 @@
 //cpp
 // @symbol func_ov098_02137ccc
-// @emits ArrowSignRight_Kill
+// recovered name: ArrowSignRight_Kill
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjYajirusi_c::Kill - recovered from vtable slot identity */
-// ArrowSignRight_Kill at 0x020bb3b8
+// func_ov098_02137ccc at 0x020bb3b8
 // Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov002).
 struct Vector3 { int x, y, z; };
 
@@ -14,8 +14,8 @@ void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const Vector3& pos);
 int _ZN9ActorBase18MarkForDestructionEv(void* self);
 }
 
-extern "C" int ArrowSignRight_Kill(char* self);
-int ArrowSignRight_Kill(char* self) {
+extern "C" int func_ov098_02137ccc(char* self);
+int func_ov098_02137ccc(char* self) {
     Vector3 vec;
     Vector3 vec2;
     int x = *(int*)(self + 0x5c);

--- a/src/func_ov098_02137d40.cpp
+++ b/src/func_ov098_02137d40.cpp
@@ -1,11 +1,11 @@
 //cpp
 // @symbol func_ov098_02137d40
-// @emits ArrowSignRight_OnAttacked1
+// recovered name: ArrowSignRight_OnAttacked1
 /* recovered: renamed to Class_Method */
 /* daObjYajirusi_c::OnAttacked1 - recovered from vtable slot identity */
 struct VT{ int (*f[64])(void*); };
 struct O{ VT* vt; };
-extern "C" void ArrowSignRight_OnAttacked1(O* c, char* o){
+extern "C" void func_ov098_02137d40(O* c, char* o){
     unsigned r = (*(unsigned short*)(o+0xc) == 0xce) ? 1u : 0u;
     if(r == 0) return;
     c->vt->f[0x7c/4](c);

--- a/src/func_ov098_02137d80.c
+++ b/src/func_ov098_02137d80.c
@@ -1,12 +1,12 @@
 // @symbol func_ov098_02137d80
-// @emits ArrowSignRight_OnHitByMegaChar
+// recovered name: ArrowSignRight_OnHitByMegaChar
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Platform.h"
 /* recovered: renamed to Class_Method */
 /* daObjYajirusi_c::OnHitByMegaChar - recovered from vtable slot identity */
 extern int func_02012694();
 extern void _ZN6Player16IncMegaKillCountEv(void*);
-void ArrowSignRight_OnHitByMegaChar(void* a, void* b){
+void func_ov098_02137d80(void* a, void* b){
   _ZN6Player16IncMegaKillCountEv(b);
   func_02012694(0x1e,(char*)a+0x74);
   _ZN8Platform14KillByMegaCharER6Player(a,b);

--- a/src/func_ov098_02138318.c
+++ b/src/func_ov098_02138318.c
@@ -1,8 +1,8 @@
 // @symbol func_ov098_02138318
-// @emits ArrowSignRight_AfterClsn
+// recovered name: ArrowSignRight_AfterClsn
 /* recovered: renamed to Class_Method */
 /* daObjYajirusi_c::AfterClsn - recovered from vtable slot identity */
-void ArrowSignRight_AfterClsn(char *c)
+void func_ov098_02138318(char *c)
 {
     *(int *)(c + 0x5f0) = 0;
     *(int *)(c + 0x5f4) = 0;

--- a/src/func_ov098_02139070.c
+++ b/src/func_ov098_02139070.c
@@ -1,11 +1,11 @@
 // @symbol func_ov098_02139070
-// @emits Crate_Kill
+// recovered name: Crate_Kill
 /* recovered: shared common types, renamed to Class_Method, declarations from a shared header */
 #include "decl_Actor.h"
 #include "decl_common.h"
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjBlockS_c::Kill - recovered from vtable slot identity */
-/* Crate_Kill at 0x02139070
+/* func_ov098_02139070 at 0x02139070
  *
  * Matched byte-for-byte with mwccarm 1.2/sp2p3 (ov098).
  */
@@ -14,7 +14,7 @@ extern void _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(unsigned int id, int 
 extern void _ZN5Sound9PlayBank3EjRK7Vector3(unsigned int id, const struct Vector3* pos);
 extern void Crate_SetState(char* c, int i);
 
-void Crate_Kill(char* self) {
+void func_ov098_02139070(char* self) {
     struct Vector3 vec;
     struct Vector3 vec2;
     int x, y, z;

--- a/src/func_ov098_02139e44.cpp
+++ b/src/func_ov098_02139e44.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov098_02139e44
-// @emits Crate_OnGroundPounded
+// recovered name: Crate_OnGroundPounded
 /* recovered: renamed to Class_Method */
 /* daObjBlockS_c::OnGroundPounded - recovered from vtable slot identity */
 struct Base {
@@ -37,4 +37,4 @@ struct Base {
     virtual void v30();
     virtual void v31();
 };
-extern "C" void Crate_OnGroundPounded(Base *c) { c->v31(); }
+extern "C" void func_ov098_02139e44(Base *c) { c->v31(); }

--- a/src/func_ov098_02139e64.c
+++ b/src/func_ov098_02139e64.c
@@ -1,8 +1,8 @@
 // @symbol func_ov098_02139e64
-// @emits Crate_OnYoshiTryEat
+// recovered name: Crate_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* daObjBlockS_c::OnYoshiTryEat - recovered from vtable slot identity */
-int Crate_OnYoshiTryEat(unsigned char *c) {
+int func_ov098_02139e64(unsigned char *c) {
   unsigned char v = c[0x606];
   if (v != 0) return 0;
   return 6;

--- a/src/func_ov098_02139e78.c
+++ b/src/func_ov098_02139e78.c
@@ -1,5 +1,5 @@
 // @symbol func_ov098_02139e78
-// @emits Crate_OnTurnIntoEgg
+// recovered name: Crate_OnTurnIntoEgg
 /* recovered: renamed to Class_Method */
 /* daObjBlockS_c::OnTurnIntoEgg - recovered from vtable slot identity */
 extern int _ZN6Player15IsCollectingCapEv(char* player);
@@ -7,7 +7,7 @@ extern void _ZN5Actor15GivePlayerCoinsER6Playerhj(char* self, char* player, unsi
 extern void _ZN6Player20RegisterEggCoinCountEjbb(char* player, unsigned int n, char b1, char b2);
 extern void Crate_SetState(char* c, int i);
 
-void Crate_OnTurnIntoEgg(char* r5, char* r4){
+void func_ov098_02139e78(char* r5, char* r4){
   if (_ZN6Player15IsCollectingCapEv(r4)) {
     if (*(unsigned char*)(r5 + 0x607) != 1) {
       _ZN5Actor15GivePlayerCoinsER6Playerhj(r5, r4, 3, 0);

--- a/src/func_ov098_0213b7e8.c
+++ b/src/func_ov098_0213b7e8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov098_0213b7e8
-// @emits Cannon_Kill
+// recovered name: Cannon_Kill
 /* recovered: renamed to Class_Method */
 /* daCnn_c::Kill - recovered from vtable slot identity */
 extern int _Z14ApproachLinearRiii(int *v, int step, int rate);
@@ -9,7 +9,7 @@ extern int _ZN4cstd4fdivEii(int a, int b);
 extern char *_ZN5Actor13ClosestPlayerEv(char *self);
 extern short Vec3_HorzAngle(const void *v0, const void *v1);
 
-void Cannon_Kill(char *c)
+void func_ov098_0213b7e8(char *c)
 {
     int state = *(int *)(c + 0x3c0);
     if (state == 0) {


### PR DESCRIPTION
Each file in this batch carried a pair of annotations recording that it defined a different symbol than its filename:

```c
// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
```

**Nothing in the repo consumes either annotation** — no tool, no CI config, no doc mentions them — and the divergence quietly broke two things:

**`match.py` cannot verify these files at all.** Asked for the filename's symbol it reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns `MATCHING VERSIONS: none` for every one. Meanwhile `progress.py` counts them as matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING` hatch. **712 files — about 6% of `src/` — were being counted as matched progress while being unverifiable by the repo's own gate.**

**The ROM link cannot use them either.** Gap objects import a carved-out function by its `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every caller silently binding to address 0 rather than erroring.

`tools/reconcile_names.py` (PR #941) renames the emitted function to the `@symbol` name and replaces the now-redundant `@emits` line with `// recovered name: <name>`, so the recovered identity — usually from a vtable slot — is preserved in the file. Each file is byte-verified against the ROM before the edit is kept; anything that stops matching is reverted.

711 of 712 verified and are split across these batches. The holdout, `func_ov022_021123d0`, declares its own symbol with a conflicting signature and is left for a human. 699 of the 711 reproduce under `2004/b56`; 12 need a `1.2/base` override, recorded in `config/rombuild-versions.txt`.

**The opposite direction is deliberately not taken here.** Adopting the recovered names into `config/**/symbols.txt` is the better long-term move, but it changes the canonical symbol table and every reference to those names — a maintainer's call, not a build fix.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
