### PR TITLE
Make each file define the symbol its filename claims (5 files) [05/05]

### DIFF
--- a/src/func_ov021_0211228c.c
+++ b/src/func_ov021_0211228c.c
@@ -1,8 +1,8 @@
 // @symbol func_ov021_0211228c
-// @emits RollingRock_OnAimedAtWithEgg
+// recovered name: RollingRock_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daGrock_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int RollingRock_OnAimedAtWithEgg(void)
+int func_ov021_0211228c(void)
 {
     return 0;
 }

--- a/src/func_ov066_0211a2dc.c
+++ b/src/func_ov066_0211a2dc.c
@@ -1,8 +1,8 @@
 // @symbol func_ov066_0211a2dc
-// @emits Eyerok_OnAimedAtWithEgg
+// recovered name: Eyerok_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daIwante_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int Eyerok_OnAimedAtWithEgg(void)
+int func_ov066_0211a2dc(void)
 {
     return 163840;
 }

--- a/src/func_ov078_021265f4.c
+++ b/src/func_ov078_021265f4.c
@@ -1,8 +1,8 @@
 // @symbol func_ov078_021265f4
-// @emits KingBobOmb_OnAimedAtWithEgg
+// recovered name: KingBobOmb_OnAimedAtWithEgg
 /* recovered: renamed to Class_Method */
 /* daBombking_c::OnAimedAtWithEgg - recovered from vtable slot identity */
-int KingBobOmb_OnAimedAtWithEgg(void)
+int func_ov078_021265f4(void)
 {
     return 1024000;
 }

--- a/src/func_ov095_021357d8.c
+++ b/src/func_ov095_021357d8.c
@@ -1,6 +1,6 @@
 #include "types.h"
 // @symbol func_ov095_021357d8
-// @emits SeesawBob_OnGroundPounded
+// recovered name: SeesawBob_OnGroundPounded
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_common.h"
 /* recovered: renamed to Class_Method */
@@ -10,7 +10,7 @@ extern int Vec3_Dist(void *a, void *b);
 extern s16 Vec3_HorzAngle(void *a, void *b);
 extern s16 data_02082214[];
 
-void SeesawBob_OnGroundPounded(char *a, char *b)
+void func_ov095_021357d8(char *a, char *b)
 {
     char *b5c = b + 0x5c;
     int dist = Vec3_Dist(a + 0x5c, b5c);

--- a/src/func_ov095_02136298.cpp
+++ b/src/func_ov095_02136298.cpp
@@ -1,6 +1,6 @@
 //cpp
 // @symbol func_ov095_02136298
-// @emits SeesawBob_AfterClsn
+// recovered name: SeesawBob_AfterClsn
 /* recovered: shared common types, renamed to Class_Method */
 /* daObjSeesaw_c::AfterClsn - recovered from vtable slot identity */
 extern "C" {
@@ -8,7 +8,7 @@ struct Vector3 { int x, y, z; };
 extern unsigned int _ZN5Sound8PlayLongEjjjRK7Vector3j(unsigned int a, unsigned int b, unsigned int d, const Vector3& v, unsigned int e);
 extern void _Z14ApproachLinearRiii(int& x, int target, int step);
 
-void SeesawBob_AfterClsn(char* c)
+void func_ov095_02136298(char* c)
 {
     *(unsigned int*)(c + 0x340) = _ZN5Sound8PlayLongEjjjRK7Vector3j(
         *(unsigned int*)(c + 0x340), 3, 0x82, *(Vector3*)(c + 0x74), 0);


### PR DESCRIPTION
Each file in this batch carried a pair of annotations recording that it defined a different symbol than its filename:

```c
// @symbol func_ov091_02132a0c        <- the symbol at this ROM address
// @emits  daDsn_c_OnAimedAtWithEgg   <- what the C actually defines
```

**Nothing in the repo consumes either annotation** — no tool, no CI config, no doc mentions them — and the divergence quietly broke two things:

**`match.py` cannot verify these files at all.** Asked for the filename's symbol it reports `symbol 'func_ov091_02132a0c' not found in object`, so the byte oracle returns `MATCHING VERSIONS: none` for every one. Meanwhile `progress.py` counts them as matched, because it only checks that a `src/<name>.c` exists without a `NONMATCHING` hatch. **712 files — about 6% of `src/` — were being counted as matched progress while being unverifiable by the repo's own gate.**

**The ROM link cannot use them either.** Gap objects import a carved-out function by its `symbols.txt` name as a *weak* undefined, so a differently-named definition leaves every caller silently binding to address 0 rather than erroring.

`tools/reconcile_names.py` (PR #941) renames the emitted function to the `@symbol` name and replaces the now-redundant `@emits` line with `// recovered name: <name>`, so the recovered identity — usually from a vtable slot — is preserved in the file. Each file is byte-verified against the ROM before the edit is kept; anything that stops matching is reverted.

711 of 712 verified and are split across these batches. The holdout, `func_ov022_021123d0`, declares its own symbol with a conflicting signature and is left for a human. 699 of the 711 reproduce under `2004/b56`; 12 need a `1.2/base` override, recorded in `config/rombuild-versions.txt`.

**The opposite direction is deliberately not taken here.** Adopting the recovered names into `config/**/symbols.txt` is the better long-term move, but it changes the canonical symbol table and every reference to those names — a maintainer's call, not a build fix.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
