### PR TITLE
Resolve BLIND symbol references from the ROM's linked words (175 files) [01/06]

### DIFF
--- a/src/ChangeArea.c
+++ b/src/ChangeArea.c
@@ -1,14 +1,14 @@
 typedef signed char s8;
 
-extern s8 AREA_ID;
+extern s8 data_02092120;
 
 extern void HideArea(void);
 extern void ShowArea(int areaID);
 
 void ChangeArea(int areaID)
 {
-    if (AREA_ID >= 0)
+    if (data_02092120 >= 0)
         HideArea();
-    AREA_ID = (s8)areaID;
+    data_02092120 = (s8)areaID;
     ShowArea(areaID);
 }

--- a/src/CleanCommonModelDataArr.c
+++ b/src/CleanCommonModelDataArr.c
@@ -1,13 +1,13 @@
 /* CleanCommonModelDataArr at 0x02016df8
  *
- * Frees every entry of the global commonModelDataArr, then resets the
+ * Frees every entry of the global data_0209cefc, then resets the
  * count and a related global to zero.
- *   for (i = 0; i < numCommonModelData; i++) {
+ *   for (i = 0; i < data_0209cef8; i++) {
  *       if (arr[i].unk8) operator delete(arr[i].unk8);          (0x0203cbc0 -> _ZdlPv)
  *       if (arr[i].unk4) Memory::operator_delete2(arr[i].unk4); (0x0203cbcc)
  *   }
- *   numCommonModelData = 0;
- *   DAT_0209cef0 = 0;
+ *   data_0209cef8 = 0;
+ *   data_0209cef0 = 0;
  */
 
 struct CommonModelDataEntry {
@@ -16,19 +16,19 @@ struct CommonModelDataEntry {
     void *unk8;   /* 0x8: freed via operator delete */
 };
 
-extern int numCommonModelData;                  /* 0x0209cef8 */
-extern struct CommonModelDataEntry commonModelDataArr[]; /* 0x0209cefc (array base) */
-extern void *DAT_0209cef0;                       /* 0x0209cef0 */
+extern int data_0209cef8;                  /* 0x0209cef8 */
+extern struct CommonModelDataEntry data_0209cefc[]; /* 0x0209cefc (array base) */
+extern void *data_0209cef0;                       /* 0x0209cef0 */
 
 extern void _ZdlPv(void *ptr);
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 void CleanCommonModelDataArr(void)
 {
-    struct CommonModelDataEntry *e = &commonModelDataArr[0];
+    struct CommonModelDataEntry *e = &data_0209cefc[0];
     int i = 0;
 
-    if (numCommonModelData > 0) {
+    if (data_0209cef8 > 0) {
         do {
             if (e->unk8)
                 _ZdlPv(e->unk8);
@@ -36,9 +36,9 @@ void CleanCommonModelDataArr(void)
                 _ZN6Memory16operator_delete2EPv(e->unk4);
             i++;
             e++;
-        } while (i < numCommonModelData);
+        } while (i < data_0209cef8);
     }
 
-    numCommonModelData = 0;
-    DAT_0209cef0 = 0;
+    data_0209cef8 = 0;
+    data_0209cef0 = 0;
 }

--- a/src/ContinueKuppaScriptIfNecessary.c
+++ b/src/ContinueKuppaScriptIfNecessary.c
@@ -5,7 +5,7 @@ extern int data_0209caa0[];
 extern int data_02087c00;
 extern int data_0209fc48;
 
-extern void Sound_LoadInitialGroup(int);
+extern void _ZN5Sound16LoadInitialGroupEi(int);
 extern void CollectStarInLevel(signed char levelID, int starID);
 extern void DisableSoundPlayersForCredits(void);
 extern void RunKuppaScript(int);
@@ -16,7 +16,7 @@ int ContinueKuppaScriptIfNecessary(void)
     if (g == 0) return 0;
     if (g == (int)&data_02089608) {
         *(unsigned char *)&data_0209f2d8 = 2;
-        Sound_LoadInitialGroup(0x26);
+        _ZN5Sound16LoadInitialGroupEi(0x26);
         data_0209caa0[1] &= ~0x204;
         CollectStarInLevel(7, 1);
         CollectStarInLevel(8, 1);

--- a/src/Crash.c
+++ b/src/Crash.c
@@ -5,14 +5,14 @@ extern void _ZN3IRQ7DisableEv(void);
 extern void _ZN4CP1516WaitForInterruptEv(void);
 extern void func_0201a03c(u32 r0, u32 r1);
 
-extern u8 gCrashedFlag; // 0x0209d4d8
+extern u8 data_0209d4d8; // 0x0209d4d8
 
 void Crash(void) {
     _ZN3IRQ7DisableEv();
-    if (gCrashedFlag == 0) {
+    if (data_0209d4d8 == 0) {
         u32 r0 = 0;
         u32 r1 = 0;
-        gCrashedFlag = 1;
+        data_0209d4d8 = 1;
         func_0201a03c(r0, r1);
     }
     for (;;) {

--- a/src/DeathTable_ClearBit.c
+++ b/src/DeathTable_ClearBit.c
@@ -1,14 +1,14 @@
 #include "types.h"
 // DeathTable_ClearBit: clears the bit in the actor death table for the given deathTableID
-extern s8 LEVEL_ID;
-extern u32 ACTOR_DEATH_TABLE_ARR[];
+extern s8 data_0209f2f8;
+extern u32 data_0209f4f8[];
 
 extern s32 GetLevelPart(s32 level);
 
 void DeathTable_ClearBit(s32 id) {
     if (id < 0) return;
-    s32 level = GetLevelPart((s32)LEVEL_ID);
-    u32* table = ACTOR_DEATH_TABLE_ARR + (level << 4);
+    s32 level = GetLevelPart((s32)data_0209f2f8);
+    u32* table = data_0209f4f8 + (level << 4);
     u32 bitMask = ~(1u << (id & 0x1f));
     s32 word = id >> 5;
     table[word] = table[word] & bitMask;

--- a/src/DeathTable_GetBit.c
+++ b/src/DeathTable_GetBit.c
@@ -1,14 +1,14 @@
 #include "types.h"
 // DeathTable_GetBit: gets the bit from the actor death table for the given deathTableID
-extern s8 LEVEL_ID;
-extern u32 ACTOR_DEATH_TABLE_ARR[];
+extern s8 data_0209f2f8;
+extern u32 data_0209f4f8[];
 
 extern s32 GetLevelPart(s32 level);
 
 u32 DeathTable_GetBit(s32 id) {
     if (id < 0) return 0;
-    s32 level = GetLevelPart((s32)LEVEL_ID);
-    u32* table = ACTOR_DEATH_TABLE_ARR + (level << 4);
+    s32 level = GetLevelPart((s32)data_0209f2f8);
+    u32* table = data_0209f4f8 + (level << 4);
     s32 word = id >> 5;
     s32 bit = id & 0x1f;
     u32 bitMask = 1u << bit;

--- a/src/DeathTable_SetBit.c
+++ b/src/DeathTable_SetBit.c
@@ -1,14 +1,14 @@
 #include "types.h"
 // DeathTable_SetBit: sets the bit in the actor death table for the given deathTableID
-extern s8 LEVEL_ID;
-extern u32 ACTOR_DEATH_TABLE_ARR[];
+extern s8 data_0209f2f8;
+extern u32 data_0209f4f8[];
 
 extern s32 GetLevelPart(s32 level);
 
 void DeathTable_SetBit(s32 id) {
     if (id < 0) return;
-    s32 level = GetLevelPart((s32)LEVEL_ID);
-    u32* table = ACTOR_DEATH_TABLE_ARR + (level << 4);
+    s32 level = GetLevelPart((s32)data_0209f2f8);
+    u32* table = data_0209f4f8 + (level << 4);
     s32 word = id >> 5;
     u32 val = table[word];
     u32 bitMask = 1u << (id & 0x1f);

--- a/src/DisableSoundPlayersForCredits.c
+++ b/src/DisableSoundPlayersForCredits.c
@@ -13,7 +13,7 @@ typedef struct {
     s32 maxSeq;
 } SoundPlayerDefault;
 
-extern SoundPlayerDefault gSoundPlayerDefaults[10];  /* 0x0208e448 */
+extern SoundPlayerDefault data_0208e448[10];  /* 0x0208e448 */
 
 void DisableSoundPlayersForCredits(void)
 {
@@ -21,5 +21,5 @@ void DisableSoundPlayersForCredits(void)
     s32 zero;
     zero = 0;
     for (i = 0; i < 10; i++)
-        _ZN5Sound6Player19SetPlayableSeqCountEii(gSoundPlayerDefaults[i].playerID, zero);
+        _ZN5Sound6Player19SetPlayableSeqCountEii(data_0208e448[i].playerID, zero);
 }

--- a/src/ExitMinigameMenu.c
+++ b/src/ExitMinigameMenu.c
@@ -2,17 +2,17 @@
 /* ExitMinigameMenu at 0x0202ad78
  * Exits the minigame menu, either returning to rec room or fading to main menu.
  */
-extern u8 RETURN_TO_REC_ROOM;  /* 0x0209f298 */
-extern u8 LEVEL_ID;            /* 0x0209f2f8 */
+extern u8 data_0209f298;  /* 0x0209f298 */
+extern u8 data_0209f2f8;            /* 0x0209f2f8 */
 
 extern void LoadLevelNoReturn(u32 actorID, u32 param, u32 arg2, u32 arg3);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 actorID, u32 param, u16 fadeColor);
 
 void ExitMinigameMenu(void)
 {
-    if (RETURN_TO_REC_ROOM) {
+    if (data_0209f298) {
         LoadLevelNoReturn(0x32, 4, 1, 0);
-        LEVEL_ID = 6;
+        data_0209f2f8 = 6;
         _ZN5Scene14StartSceneFadeEjjt(3, 0, 0x7fff);
     } else {
         _ZN5Scene14StartSceneFadeEjjt(1, 0, 0);

--- a/src/FUN_02029ab0.c
+++ b/src/FUN_02029ab0.c
@@ -12,16 +12,16 @@ typedef struct WipeTable {
     WipeEntry entries[1];
 } WipeTable;
 
-extern WipeTable* WIPES;                    /* 0x0209f324 */
-extern WipeEntry* KS_FADER;                 /* 0x0209d4b0 */
-extern u8 CAMERA_SAVED_LOOK_AT_RELATED;    /* 0x0209f274 */
+extern WipeTable* data_0209f324;                    /* 0x0209f324 */
+extern WipeEntry* data_0209d4b0;                 /* 0x0209d4b0 */
+extern u8 data_0209f274;    /* 0x0209f274 */
 
 void FUN_02029ab0(void) {
     WipeEntry* entry;
     _ZN5Scene20SetAndStopColorFaderEv();
-    entry = &WIPES->entries[0];
-    KS_FADER = entry;
+    entry = &data_0209f324->entries[0];
+    data_0209d4b0 = entry;
     entry->field4 = 0xc00;
     entry->field8 = 0;
-    CAMERA_SAVED_LOOK_AT_RELATED = 1;
+    data_0209f274 = 1;
 }

--- a/src/GetOwnerLanguage.c
+++ b/src/GetOwnerLanguage.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int GetOwnerLanguage(void) { return G; }
+extern unsigned char data_020a0f00;
+int GetOwnerLanguage(void) { return data_020a0f00; }

--- a/src/GetSoundMode.c
+++ b/src/GetSoundMode.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int GetSoundMode(void) { return G; }
+extern unsigned char data_0209d4b4;
+int GetSoundMode(void) { return data_0209d4b4; }

--- a/src/GetTeleportDestObj.c
+++ b/src/GetTeleportDestObj.c
@@ -1,3 +1,3 @@
 struct Obj { int a; int b; };
-extern struct Obj* G;
-struct Obj* GetTeleportDestObj(int i) { return G + i; }
+extern struct Obj* data_0209f330;
+struct Obj* GetTeleportDestObj(int i) { return data_0209f330 + i; }

--- a/src/HitDeathPlane.c
+++ b/src/HitDeathPlane.c
@@ -3,7 +3,7 @@
  * Handles player hitting a death plane: either restarts (SetNextLevel) or
  * triggers a scene fade, then always exits with StartExitFaderWipe.
  */
-extern s8 NUM_LIVES[];
+extern s8 data_0209f2f4[];
 
 extern void SetNextLevel(void);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
@@ -11,7 +11,7 @@ extern void StartExitFaderWipe(u32 a);
 
 void HitDeathPlane(int arg)
 {
-    if (NUM_LIVES[0] != 0 || arg == 0)
+    if (data_0209f2f4[0] != 0 || arg == 0)
         SetNextLevel();
     else
         _ZN5Scene14StartSceneFadeEjjt(8, 0, 0);

--- a/src/IsCannonOpen.c
+++ b/src/IsCannonOpen.c
@@ -1,2 +1,2 @@
-extern int G[];
-int IsCannonOpen(int n) { return G[4] & (1 << n); }
+extern int data_0209caa0[];
+int IsCannonOpen(int n) { return data_0209caa0[4] & (1 << n); }

--- a/src/KillPlayer.c
+++ b/src/KillPlayer.c
@@ -3,7 +3,7 @@
  * Kills the player: if lives remain, go to next level with reason 2,
  * otherwise trigger a game-over scene fade.  Then plays death sound.
  */
-extern s8 NUM_LIVES[];
+extern s8 data_0209f2f4[];
 
 extern void SetNextLevel(u32 reason);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
@@ -12,7 +12,7 @@ extern void func_02012790(u32 soundID);
 
 void KillPlayer(void)
 {
-    if (NUM_LIVES[0] != 0)
+    if (data_0209f2f4[0] != 0)
         SetNextLevel(2);
     else
         _ZN5Scene14StartSceneFadeEjjt(8, 0, 0);

--- a/src/LoadBlueCoinModel.c
+++ b/src/LoadBlueCoinModel.c
@@ -1,12 +1,12 @@
 typedef struct { int unk[1]; } SharedFilePtr;
 
-extern SharedFilePtr COIN_BLUE_POLY4_MODEL_PTR;   /* 0x0210da00 */
-extern SharedFilePtr COIN_BLUE_POLY32_MODEL_PTR;  /* 0x0210d9c8 */
+extern SharedFilePtr data_ov002_0210da00;   /* 0x0210da00 */
+extern SharedFilePtr data_ov002_0210d9c8;  /* 0x0210d9c8 */
 
 extern void _ZN5Model8LoadFileER13SharedFilePtr(SharedFilePtr* ptr); /* 0x02017a3c */
 
 void LoadBlueCoinModel(void)
 {
-    _ZN5Model8LoadFileER13SharedFilePtr(&COIN_BLUE_POLY4_MODEL_PTR);
-    _ZN5Model8LoadFileER13SharedFilePtr(&COIN_BLUE_POLY32_MODEL_PTR);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210da00);
+    _ZN5Model8LoadFileER13SharedFilePtr(&data_ov002_0210d9c8);
 }

--- a/src/LoadDebugFont.c
+++ b/src/LoadDebugFont.c
@@ -3,12 +3,12 @@ extern void _ZN2GX11LoadBG1CharEPKvjj(const void *src, u32 offset, u32 size);
 extern void _ZN2GX10LoadBGPlttEPKvjj(const void *src, u32 offset, u32 size);
 extern void func_02023408(void);
 
-extern const void *g_0208a178;
-extern const void *g_0208c178;
+extern const void *data_0208a178;
+extern const void *data_0208c178;
 
 void LoadDebugFont(void)
 {
-    _ZN2GX11LoadBG1CharEPKvjj(&g_0208a178, 0, 0x2000);
-    _ZN2GX10LoadBGPlttEPKvjj(&g_0208c178, 0x1a0, 0x60);
+    _ZN2GX11LoadBG1CharEPKvjj(&data_0208a178, 0, 0x2000);
+    _ZN2GX10LoadBGPlttEPKvjj(&data_0208c178, 0x1a0, 0x60);
     func_02023408();
 }

--- a/src/LoadFont3D.c
+++ b/src/LoadFont3D.c
@@ -6,8 +6,8 @@ extern void MultiCopy_Int(void* src, void* dest, u32 size);
 extern void DecompressLZ16(void* src, void* dest);
 extern void _ZN7Message10LoadTextVSEv(void);
 
-extern u8 CONNECTION_ERROR;
-extern s16 dat_0209fce8;
+extern u8 data_0209fc9c;
+extern s16 data_0209fce8;
 
 void LoadFont3D(void)
 {
@@ -25,6 +25,6 @@ void LoadFont3D(void)
 
     _ZN7Message10LoadTextVSEv();
 
-    CONNECTION_ERROR = 0;
-    dat_0209fce8 = -1;
+    data_0209fc9c = 0;
+    data_0209fce8 = -1;
 }

--- a/src/LoadLevelNoReturn.c
+++ b/src/LoadLevelNoReturn.c
@@ -1,12 +1,12 @@
 #include "types.h"
 extern void LoadLevel(u32 levelID, u32 arg1, u32 arg2, u32 arg3, u32 arg4);
 
-extern s8 RETURN_LEVEL_ID;
-extern s8 CHECKPOINT_LEVEL_ID;
+extern s8 data_0209211c;
+extern s8 data_02092118;
 
 void LoadLevelNoReturn(u32 levelID, u32 arg1, u32 arg2, u32 arg3)
 {
     LoadLevel(levelID, arg1, arg2, arg3, (u32)-1);
-    RETURN_LEVEL_ID = -1;
-    CHECKPOINT_LEVEL_ID = -1;
+    data_0209211c = -1;
+    data_02092118 = -1;
 }

--- a/src/Matrix4x3_ApplyInPlaceToScale.c
+++ b/src/Matrix4x3_ApplyInPlaceToScale.c
@@ -6,12 +6,12 @@ typedef int Fix12i;
 
 struct Matrix4x3 { char data[0x30]; };
 
-extern void Matrix4x3_FromScale(struct Matrix4x3 *mF, Fix12i x, Fix12i y, Fix12i z) __attribute__((long_call, target("thumb")));
+extern void func_020527e8(struct Matrix4x3 *mF, Fix12i x, Fix12i y, Fix12i z) __attribute__((long_call, target("thumb")));
 extern void MulMat4x3Mat4x3(const struct Matrix4x3 *m1, const struct Matrix4x3 *m0, struct Matrix4x3 *mF);
 
 void Matrix4x3_ApplyInPlaceToScale(struct Matrix4x3 *mF, Fix12i x, Fix12i y, Fix12i z)
 {
     struct Matrix4x3 tmp;
-    Matrix4x3_FromScale(&tmp, x, y, z);
+    func_020527e8(&tmp, x, y, z);
     MulMat4x3Mat4x3(&tmp, mF, mF);
 }

--- a/src/OS_SleepThread.c
+++ b/src/OS_SleepThread.c
@@ -10,7 +10,7 @@ struct NodeMgr {
     struct Node *node;
 };
 
-extern struct NodeMgr *gNodeMgrP_020a612c;
+extern struct NodeMgr *data_020a612c;
 
 u32 _ZN3IRQ7DisableEv(void);
 void _ZN3IRQ7RestoreEj(u32 state);
@@ -18,7 +18,7 @@ void func_02057f54(void);
 
 void OS_SleepThread(u16 *self) {
     u32 r4 = _ZN3IRQ7DisableEv();
-    struct Node *r2 = gNodeMgrP_020a612c->node;
+    struct Node *r2 = data_020a612c->node;
     if (self != 0) {
         u32 r0 = 1 << r2->unk6c;
         u16 r1 = *self;

--- a/src/OS_WakeupThread.c
+++ b/src/OS_WakeupThread.c
@@ -11,7 +11,7 @@ struct Manager {
     struct Node *first;
 };
 
-extern struct Manager gManager_0x020a6134;
+extern struct Manager data_020a6134;
 
 u32 _ZN3IRQ7DisableEv(void);
 void _ZN3IRQ7RestoreEj(u32 state);
@@ -21,7 +21,7 @@ void OS_WakeupThread(u16 *self) {
     u32 r4 = _ZN3IRQ7DisableEv();
     u32 mask = *self;
     if (mask != 0) {
-        struct Node *node = gManager_0x020a6134.first;
+        struct Node *node = data_020a6134.first;
         if (node != 0) {
             u32 r1 = 1;
             do {

--- a/src/OpenCannon.c
+++ b/src/OpenCannon.c
@@ -1,2 +1,2 @@
-extern int G[];
-void OpenCannon(int n) { G[4] |= 1 << n; }
+extern int data_0209caa0[];
+void OpenCannon(int n) { data_0209caa0[4] |= 1 << n; }

--- a/src/PrepareVsMode.c
+++ b/src/PrepareVsMode.c
@@ -3,8 +3,8 @@
  * Sets up VS mode: marks current game mode, initializes player globals,
  * starts a scene fade, then sets save data default values.
  */
-extern unsigned char CURRENT_GAMEMODE[];
-extern unsigned char SAVE_DATA[];
+extern unsigned char data_0209f2d8[];
+extern unsigned char data_0209caa0[];
 
 extern void SetPlayerGlobals(void);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
@@ -12,8 +12,8 @@ extern void _ZN8SaveData16SetDefaultValuesEP12FileSaveData(void *saveData);
 
 void PrepareVsMode(void)
 {
-    CURRENT_GAMEMODE[0] = 1;
+    data_0209f2d8[0] = 1;
     SetPlayerGlobals();
     _ZN5Scene14StartSceneFadeEjjt(3, 0, 0x7fff);
-    _ZN8SaveData16SetDefaultValuesEP12FileSaveData((void *)SAVE_DATA);
+    _ZN8SaveData16SetDefaultValuesEP12FileSaveData((void *)data_0209caa0);
 }

--- a/src/SetBg0Offset.c
+++ b/src/SetBg0Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetBg0Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d468[]; extern short data_0209d46c[];
+void SetBg0Offset(int a, int b) { data_0209d468[0] = a; data_0209d46c[0] = b; }

--- a/src/SetBg1Offset.c
+++ b/src/SetBg1Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetBg1Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d4a4[]; extern short data_0209d4a0[];
+void SetBg1Offset(int a, int b) { data_0209d4a4[0] = a; data_0209d4a0[0] = b; }

--- a/src/SetBg2Offset.c
+++ b/src/SetBg2Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetBg2Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d49c[]; extern short data_0209d478[];
+void SetBg2Offset(int a, int b) { data_0209d49c[0] = a; data_0209d478[0] = b; }

--- a/src/SetBg3Offset.c
+++ b/src/SetBg3Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetBg3Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d48c[]; extern short data_0209d490[];
+void SetBg3Offset(int a, int b) { data_0209d48c[0] = a; data_0209d490[0] = b; }

--- a/src/SetPlayerGlobals.c
+++ b/src/SetPlayerGlobals.c
@@ -1,22 +1,22 @@
 #include "types.h"
 // SetPlayerGlobals - initializes player globals: lives, health, controller mode
-extern u8 NUM_LIVES;
-extern u16 HEALTH_ARR[];
-extern u8 SAVE_DATA[];
-extern signed char NEXT_HAT_CHARACTER;
-extern u8 UNK_YOSHI_EGG_RELATED;
+extern u8 data_0209f2f4;
+extern u16 data_02092144[];
+extern u8 data_0209caa0[];
+extern signed char data_02092114;
+extern u8 data_0209f254;
 
 extern void InitControllerMode(s32 playerIdx, s32 healthVal);
 
 void SetPlayerGlobals(void) {
-    NUM_LIVES = 4;
+    data_0209f2f4 = 4;
     s32 i = 0;
     do {
-        u8 healthVal = SAVE_DATA[0x42];
-        HEALTH_ARR[i] = 0x880;
+        u8 healthVal = data_0209caa0[0x42];
+        data_02092144[i] = 0x880;
         InitControllerMode(i, healthVal);
         i++;
     } while (i < 4);
-    NEXT_HAT_CHARACTER = -1;
-    UNK_YOSHI_EGG_RELATED = 0;
+    data_02092114 = -1;
+    data_0209f254 = 0;
 }

--- a/src/SetStarMarker.c
+++ b/src/SetStarMarker.c
@@ -1,2 +1,2 @@
-extern int A[]; extern unsigned char B[];
-void SetStarMarker(int i, int v1, int v2) { A[i] = v1; B[i] = v2; }
+extern int data_0209f40c[]; extern unsigned char data_0209f37c[];
+void SetStarMarker(int i, int v1, int v2) { data_0209f40c[i] = v1; data_0209f37c[i] = v2; }

--- a/src/SetSubBg0Offset.c
+++ b/src/SetSubBg0Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetSubBg0Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d494[]; extern short data_0209d498[];
+void SetSubBg0Offset(int a, int b) { data_0209d494[0] = a; data_0209d498[0] = b; }

--- a/src/SetSubBg1Offset.c
+++ b/src/SetSubBg1Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetSubBg1Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d484[]; extern short data_0209d480[];
+void SetSubBg1Offset(int a, int b) { data_0209d484[0] = a; data_0209d480[0] = b; }

--- a/src/SetSubBg2Offset.c
+++ b/src/SetSubBg2Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetSubBg2Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d47c[]; extern short data_0209d470[];
+void SetSubBg2Offset(int a, int b) { data_0209d47c[0] = a; data_0209d470[0] = b; }

--- a/src/SetSubBg3Offset.c
+++ b/src/SetSubBg3Offset.c
@@ -1,2 +1,2 @@
-extern short A[]; extern short B[];
-void SetSubBg3Offset(int a, int b) { A[0] = a; B[0] = b; }
+extern short data_0209d474[]; extern short data_0209d488[];
+void SetSubBg3Offset(int a, int b) { data_0209d474[0] = a; data_0209d488[0] = b; }

--- a/src/StartFile.c
+++ b/src/StartFile.c
@@ -1,14 +1,14 @@
 #include "types.h"
 /* StartFile at 0x0202ae88
  * Starts a single-player game file: clears gamemode, loads level, sets player globals,
- * copies current character to NEXT_HAT_CHARACTER_ARR, sets player count to 1,
+ * copies current character to data_02092128, sets player count to 1,
  * clears star-obtained/level flags, then starts a scene fade.
  */
-extern u8 CURRENT_GAMEMODE[];
-extern u8 SAVE_DATA[];
-extern u8 NEXT_HAT_CHARACTER_ARR[];
-extern u8 LEVEL_OF_LAST_COLLECTED_STAR[];
-extern u8 STAR_OBTAINED[];
+extern u8 data_0209f2d8[];
+extern u8 data_0209caa0[];
+extern u8 data_02092128[];
+extern u8 data_02092124[];
+extern u8 data_0209f228[];
 
 extern void LoadLevelNoReturn(s8 levelID, u8 entranceID, s8 starID, u8 returnState);
 extern void SetPlayerGlobals(void);
@@ -17,12 +17,12 @@ extern void _ZN5Scene14StartSceneFadeEjjt(u32 a, u32 b, u16 c);
 
 void StartFile(s8 levelID, u8 entranceID)
 {
-    CURRENT_GAMEMODE[0] = 0;
+    data_0209f2d8[0] = 0;
     LoadLevelNoReturn(levelID, entranceID, 1, 0);
     SetPlayerGlobals();
-    NEXT_HAT_CHARACTER_ARR[0] = SAVE_DATA[0x41];
+    data_02092128[0] = data_0209caa0[0x41];
     SetNumPlayers(1);
-    LEVEL_OF_LAST_COLLECTED_STAR[0] = 6;
-    STAR_OBTAINED[0] = 0;
+    data_02092124[0] = 6;
+    data_0209f228[0] = 0;
     _ZN5Scene14StartSceneFadeEjjt(3, 0, 0x7fff);
 }

--- a/src/StartIntroCutscene.c
+++ b/src/StartIntroCutscene.c
@@ -1,6 +1,6 @@
 typedef int s32;
 
-extern void* INTRO_CUTSCENE;
+extern void* data_020890a0;
 
 extern void _ZN5Sound16LoadInitialGroupEi(s32 group);
 extern void RunKuppaScript(void* script);
@@ -8,5 +8,5 @@ extern void RunKuppaScript(void* script);
 void StartIntroCutscene(void)
 {
     _ZN5Sound16LoadInitialGroupEi(0x25);
-    RunKuppaScript(&INTRO_CUTSCENE);
+    RunKuppaScript(&data_020890a0);
 }

--- a/src/StartMinigameMenu.c
+++ b/src/StartMinigameMenu.c
@@ -2,14 +2,14 @@
 /* StartMinigameMenu at 0x0202adf4
  * Starts the minigame menu scene. r0 controls whether to return to rec room after.
  */
-extern u8 RETURN_TO_REC_ROOM;  /* 0x0209f298 */
+extern u8 data_0209f298;  /* 0x0209f298 */
 
 extern void _ZN5Scene20SetAndStopColorFaderEv(void);
 extern void _ZN5Scene14StartSceneFadeEjjt(u32 actorID, u32 param, u16 fadeColor);
 
 void StartMinigameMenu(u8 returnToRecRoom)
 {
-    RETURN_TO_REC_ROOM = returnToRecRoom;
+    data_0209f298 = returnToRecRoom;
     _ZN5Scene20SetAndStopColorFaderEv();
     _ZN5Scene14StartSceneFadeEjjt(5, 0, 0x7fff);
 }

--- a/src/UnloadBlueCoinModel.c
+++ b/src/UnloadBlueCoinModel.c
@@ -3,11 +3,11 @@ struct SharedFilePtr { u32 data[4]; };
 
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 
-extern struct SharedFilePtr BlueCoinModelFile1;
-extern struct SharedFilePtr BlueCoinModelFile2;
+extern struct SharedFilePtr data_ov002_0210da00;
+extern struct SharedFilePtr data_ov002_0210d9c8;
 
 void UnloadBlueCoinModel(void)
 {
-    _ZN13SharedFilePtr7ReleaseEv(&BlueCoinModelFile1);
-    _ZN13SharedFilePtr7ReleaseEv(&BlueCoinModelFile2);
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210da00);
+    _ZN13SharedFilePtr7ReleaseEv(&data_ov002_0210d9c8);
 }

--- a/src/WM_GetSystemWork.c
+++ b/src/WM_GetSystemWork.c
@@ -1,2 +1,2 @@
-extern int G;
-int WM_GetSystemWork(void) { return G; }
+extern int data_020a89ac;
+int WM_GetSystemWork(void) { return data_020a89ac; }

--- a/src/_Z13CopyToViewMatPK9Matrix4x3.c
+++ b/src/_Z13CopyToViewMatPK9Matrix4x3.c
@@ -3,11 +3,11 @@ typedef struct {
     s32 m[12]; /* 4x3 matrix, 48 bytes */
 } Matrix4x3;
 
-extern Matrix4x3 VIEW_MATRIX_ASR_3;
-extern Matrix4x3 INV_VIEW_MATRIX_ASR_3;
+extern Matrix4x3 data_0209b3ec;
+extern Matrix4x3 data_0209b41c;
 extern void InvMat4x3(Matrix4x3* dst, Matrix4x3* inv);
 
 void _Z13CopyToViewMatPK9Matrix4x3(const Matrix4x3* src) {
-    VIEW_MATRIX_ASR_3 = *src;
-    InvMat4x3(&VIEW_MATRIX_ASR_3, &INV_VIEW_MATRIX_ASR_3);
+    data_0209b3ec = *src;
+    InvMat4x3(&data_0209b3ec, &data_0209b41c);
 }

--- a/src/_Z19UnloadLevelOverlaysi.c
+++ b/src/_Z19UnloadLevelOverlaysi.c
@@ -4,17 +4,17 @@
 
 typedef int s32;
 
-extern s32 LOADED_LEVEL_OVL_ID; /* 0x02092130 */
+extern s32 data_02092130; /* 0x02092130 */
 
 extern void UnloadOverlay(s32 ovID); /* 0x02017f34 */
 extern void _Z26LoadOrUnloadObjectOverlaysPFviEi(void (*func)(s32), s32 levelID); /* 0x0202df70 */
 
 void _Z19UnloadLevelOverlaysi(s32 levelID)
 {
-    if (LOADED_LEVEL_OVL_ID != -1)
+    if (data_02092130 != -1)
     {
-        UnloadOverlay(LOADED_LEVEL_OVL_ID);
-        LOADED_LEVEL_OVL_ID = -1;
+        UnloadOverlay(data_02092130);
+        data_02092130 = -1;
     }
     _Z26LoadOrUnloadObjectOverlaysPFviEi(UnloadOverlay, levelID);
 }

--- a/src/_ZN10ClsnResultC1Ev.c
+++ b/src/_ZN10ClsnResultC1Ev.c
@@ -5,7 +5,7 @@
 #include "ClsnResult.h"
 int *_ZN10ClsnResultC1Ev(struct ClsnResult *self) {
     func_02037f18((char *)&self->unk_004);
-    ((int *)self)[0] = (int)VT0;
+    ((int *)self)[0] = (int)data_02099368;
     func_020380c0(((int *)self));
     return ((int *)self);
 }

--- a/src/_ZN10ClsnResultD1Ev.c
+++ b/src/_ZN10ClsnResultD1Ev.c
@@ -4,7 +4,7 @@
 /* recovered: named members + shared header */
 #include "ClsnResult.h"
 int *_ZN10ClsnResultD1Ev(struct ClsnResult *self) {
-    ((int *)self)[0] = (int)VT0;
+    ((int *)self)[0] = (int)data_02099368;
     func_02037ee4((char *)&self->unk_004);
     return ((int *)self);
 }

--- a/src/_ZN10FaderColorD0Ev.c
+++ b/src/_ZN10FaderColorD0Ev.c
@@ -1,5 +1,5 @@
 /* FaderColor::~FaderColor (deleting / D0) at 0x02017598
- *   [this+0] = _ZTV10FaderColor (0x0208eb2c)
+ *   [this+0] = data_0208eb2c (0x0208eb2c)
  *   bl 0x020177c4 = FaderColor::~FaderColor (D2/base)
  *   bl 0x0203cbcc = Memory::operator_delete2(this)
  * returns this.
@@ -9,15 +9,15 @@ struct FaderColor {
     void **vtable; /* 0x0 */
 };
 
-extern void *_ZTV10FaderColor[];
+extern void *data_0208eb2c[];
 
-extern void *FaderColorD2(struct FaderColor *thiz);          /* 0x020177c4 */
+extern void *func_020177c4(struct FaderColor *thiz);          /* 0x020177c4 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);      /* 0x0203cbcc */
 
 struct FaderColor *_ZN10FaderColorD0Ev(struct FaderColor *thiz)
 {
-    thiz->vtable = (void **)_ZTV10FaderColor;
-    FaderColorD2(thiz);
+    thiz->vtable = (void **)data_0208eb2c;
+    func_020177c4(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/_ZN10FaderColorD1Ev.c
+++ b/src/_ZN10FaderColorD1Ev.c
@@ -7,12 +7,12 @@
  * (ARM C++ dtor ABI). The u16 color member at 0xc needs no teardown.
  */
 
-extern int _ZTV10FaderColor[];     /* vtable for FaderColor */
+extern int data_0208eb2c[];     /* vtable for FaderColor */
 extern int func_020177c4(int *self); /* base-subobject destructor */
 
 int _ZN10FaderColorD1Ev(int *self)
 {
-    self[0] = (int)_ZTV10FaderColor;  /* +0x00 vptr */
+    self[0] = (int)data_0208eb2c;  /* +0x00 vptr */
     func_020177c4(self);
     return (int)self;
 }

--- a/src/_ZN11CommonModel6RenderEPK7Vector3.c
+++ b/src/_ZN11CommonModel6RenderEPK7Vector3.c
@@ -1,5 +1,5 @@
 /* CommonModel::Render at 0x02016104
- * Multiplies this->mat4x3 by VIEW_MATRIX_ASR_3 into a stack-local temp matrix,
+ * Multiplies this->mat4x3 by data_0209b3ec into a stack-local temp matrix,
  * then calls ModelComponents::Render(temp, scale).
  */
 
@@ -21,13 +21,13 @@ struct CommonModel {
     struct Matrix4x3 mat4x3; /* 0x0c */
 };
 
-extern struct Matrix4x3 VIEW_MATRIX_ASR_3;  /* 0x0209b3ec */
+extern struct Matrix4x3 data_0209b3ec;  /* 0x0209b3ec */
 extern void MulMat4x3Mat4x3(const struct Matrix4x3 *m1, const struct Matrix4x3 *m0, struct Matrix4x3 *mF); /* 0x02052914 */
 extern void _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(struct ModelComponents *thiz, struct Matrix4x3 *mat, const struct Vector3 *scale); /* 0x020443c8 */
 
 void _ZN11CommonModel6RenderEPK7Vector3(struct CommonModel *thiz, const struct Vector3 *scale)
 {
     struct Matrix4x3 temp;
-    MulMat4x3Mat4x3(&thiz->mat4x3, &VIEW_MATRIX_ASR_3, &temp);
+    MulMat4x3Mat4x3(&thiz->mat4x3, &data_0209b3ec, &temp);
     _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(thiz->data, &temp, scale);
 }

--- a/src/_ZN11CommonModel9DoSetFileEPcii.c
+++ b/src/_ZN11CommonModel9DoSetFileEPcii.c
@@ -17,14 +17,14 @@ struct CommonModel {
     char mat4x3[0x30];
 };
 
-extern struct ModelComponents* Func_02016e70(void* file);
+extern struct ModelComponents* func_02016e70(void* file);
 extern void _ZN15ModelComponents21UpdateVertsUsingBonesEv(struct ModelComponents* data);
 extern void _ZN11CommonModel13Func_020160ACEj(struct CommonModel* thiz, u32 arg0);
 extern void _ZN11CommonModel13Func_0201609CEj(struct CommonModel* thiz, u32 arg0);
 
 s32 _ZN11CommonModel9DoSetFileEPcii(struct CommonModel* thiz, void* file, s32 arg1, s32 arg2)
 {
-    thiz->data = Func_02016e70(file);
+    thiz->data = func_02016e70(file);
     if (thiz->data == (void*)0)
         return 0;
     _ZN15ModelComponents21UpdateVertsUsingBonesEv(thiz->data);

--- a/src/_ZN11CommonModelC1Ev.c
+++ b/src/_ZN11CommonModelC1Ev.c
@@ -20,14 +20,14 @@ struct CommonModel {
 };
 
 extern u32 _ZTV11CommonModel[];
-extern struct Matrix4x3 _ZN9Matrix3x38IDENTITYE;
+extern struct Matrix4x3 data_02082128;
 extern void _ZN9ModelBaseC1Ev(struct ModelBase *thiz);
 
 struct CommonModel *_ZN11CommonModelC1Ev(struct CommonModel *thiz)
 {
     _ZN9ModelBaseC1Ev((struct ModelBase *)thiz);
-    thiz->vtable = _ZTV11CommonModel + 2;
+    thiz->vtable = _ZTV11CommonModel;
     thiz->data = 0;
-    thiz->mat4x3 = _ZN9Matrix3x38IDENTITYE;
+    thiz->mat4x3 = data_02082128;
     return thiz;
 }

--- a/src/_ZN11CommonModelD1Ev.c
+++ b/src/_ZN11CommonModelD1Ev.c
@@ -2,11 +2,11 @@
  * Single-vtable destructor: write own vtable, call ModelBase::~ModelBase (D2 @0x020170b8), return this.
  */
 struct Obj { void *vtable; };
-extern void *vtbl_CommonModel[];
-extern void ModelBase_dtor(struct Obj *thiz); /* 0x020170b8 */
+extern void *_ZTV11CommonModel[];
+extern void _ZN9ModelBaseD2Ev(struct Obj *thiz); /* 0x020170b8 */
 struct Obj *_ZN11CommonModelD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_CommonModel;
-    ModelBase_dtor(thiz);
+    thiz->vtable = (void *)_ZTV11CommonModel;
+    _ZN9ModelBaseD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN11ShadowModelD0Ev.c
+++ b/src/_ZN11ShadowModelD0Ev.c
@@ -5,7 +5,7 @@ struct ShadowModel {
     struct ShadowModel *next;   /* 0x24 */
 };
 extern void *_ZTV11ShadowModel[];
-extern struct ShadowModel *SHADOW_MODEL_LIST_HEAD;   /* 0x0209cef4 */
+extern struct ShadowModel *data_0209cef4;   /* 0x0209cef4 */
 extern void _ZN9ModelBaseD2Ev(struct ShadowModel *thiz);
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
@@ -15,8 +15,8 @@ struct ShadowModel *_ZN11ShadowModelD0Ev(struct ShadowModel *thiz)
 
     if (thiz->prev)
         thiz->prev->next = thiz->next;
-    else if (SHADOW_MODEL_LIST_HEAD == thiz)
-        SHADOW_MODEL_LIST_HEAD = thiz->next;
+    else if (data_0209cef4 == thiz)
+        data_0209cef4 = thiz->next;
 
     if (thiz->next)
         thiz->next->prev = thiz->prev;

--- a/src/_ZN11ShadowModelD1Ev.c
+++ b/src/_ZN11ShadowModelD1Ev.c
@@ -21,22 +21,22 @@ struct ShadowModel {
     struct ShadowModel *next; /* 0x24 */
 };
 
-extern void *vtbl_ShadowModel[];
-extern struct ShadowModel *gShadowModelListHead; /* 0x0209cef4 */
-extern void ModelBase_dtor(struct ShadowModel *thiz); /* 0x020170b8 */
+extern void *_ZTV11ShadowModel[];
+extern struct ShadowModel *data_0209cef4; /* 0x0209cef4 */
+extern void _ZN9ModelBaseD2Ev(struct ShadowModel *thiz); /* 0x020170b8 */
 
 struct ShadowModel *_ZN11ShadowModelD1Ev(struct ShadowModel *thiz)
 {
     struct ShadowModel *prev;
     struct ShadowModel *next;
 
-    thiz->vtable = (void *)vtbl_ShadowModel;
+    thiz->vtable = (void *)_ZTV11ShadowModel;
 
     prev = thiz->prev;
     if (prev) {
         prev->next = thiz->next;
-    } else if (gShadowModelListHead == thiz) {
-        gShadowModelListHead = thiz->next;
+    } else if (data_0209cef4 == thiz) {
+        data_0209cef4 = thiz->next;
     }
 
     next = thiz->next;
@@ -47,6 +47,6 @@ struct ShadowModel *_ZN11ShadowModelD1Ev(struct ShadowModel *thiz)
     thiz->prev = 0;
     thiz->next = 0;
 
-    ModelBase_dtor(thiz);
+    _ZN9ModelBaseD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN12ActorDerivedD0Ev.c
+++ b/src/_ZN12ActorDerivedD0Ev.c
@@ -1,14 +1,14 @@
 struct ActorDerived { void **vtable; };
 struct Heap;
-extern void *_ZTV12ActorDerived[];
+extern void *data_0208e4b8[];
 extern void _ZN9ActorBaseD2Ev(struct ActorDerived *thiz);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);
-extern struct Heap *_ZN6Memory11gameHeapPtrE;
+extern struct Heap *data_020a0eac;
 
 struct ActorDerived *_ZN12ActorDerivedD0Ev(struct ActorDerived *thiz)
 {
-    thiz->vtable = (void **)_ZTV12ActorDerived;
+    thiz->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
-    _ZN6Memory10DeallocateEPvP4Heap(thiz, _ZN6Memory11gameHeapPtrE);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;
 }

--- a/src/_ZN12ActorDerivedD1Ev.c
+++ b/src/_ZN12ActorDerivedD1Ev.c
@@ -4,11 +4,11 @@
  * Base dtor call target: 0x02043d48
  */
 struct Obj { void *vtable; };
-extern void *vtbl_ActorDerived[];
-extern void base_dtor_ActorDerived(struct Obj *thiz); /* 0x02043d48 */
+extern void *data_0208e4b8[];
+extern void _ZN9ActorBaseD2Ev(struct Obj *thiz); /* 0x02043d48 */
 struct Obj *_ZN12ActorDerivedD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_ActorDerived;
-    base_dtor_ActorDerived(thiz);
+    thiz->vtable = (void *)data_0208e4b8;
+    _ZN9ActorBaseD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN12CylinderClsnD0Ev.c
+++ b/src/_ZN12CylinderClsnD0Ev.c
@@ -1,4 +1,4 @@
-extern void *_ZTV12CylinderClsn;
+extern void *data_0208e6ec;
 extern void *func_02014fa4(void *self);
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
@@ -8,7 +8,7 @@ struct CylinderClsn {
 
 void *_ZN12CylinderClsnD0Ev(struct CylinderClsn *self)
 {
-    self->vtable = &_ZTV12CylinderClsn;
+    self->vtable = &data_0208e6ec;
     func_02014fa4(self);
     _ZN6Memory16operator_delete2EPv(self);
     return self;

--- a/src/_ZN12CylinderClsnD1Ev.c
+++ b/src/_ZN12CylinderClsnD1Ev.c
@@ -6,12 +6,12 @@
  * the base subobject destructor (func_02014fa4). Returns this.
  */
 
-extern int _ZTV12CylinderClsn[];   // vtable (wildcard reloc, not byte-verified)
+extern int data_0208e6ec[];   // vtable (wildcard reloc, not byte-verified)
 extern void func_02014fa4(void* self); // base subobject destructor
 
 void* _ZN12CylinderClsnD1Ev(void* self)
 {
-    *(int*)self = (int)_ZTV12CylinderClsn; // set vptr
+    *(int*)self = (int)data_0208e6ec; // set vptr
     func_02014fa4(self);
     return self;
 }

--- a/src/_ZN12CylinderClsnD2Ev.c
+++ b/src/_ZN12CylinderClsnD2Ev.c
@@ -6,12 +6,12 @@
  * base subobject destructor (func_02014fa4). Returns this.
  */
 
-extern int _ZTV12CylinderClsn[];   // vtable (wildcard reloc, not byte-verified)
+extern int data_0208e6ec[];   // vtable (wildcard reloc, not byte-verified)
 extern void func_02014fa4(void* self); // base subobject destructor
 
 void* _ZN12CylinderClsnD2Ev(void* self)
 {
-    *(int*)self = (int)_ZTV12CylinderClsn; // set vptr
+    *(int*)self = (int)data_0208e6ec; // set vptr
     func_02014fa4(self);
     return self;
 }

--- a/src/_ZN12MeshColliderC1Ev.c
+++ b/src/_ZN12MeshColliderC1Ev.c
@@ -10,7 +10,7 @@ extern void _ZN16MeshColliderBaseC2Ev(struct MeshColliderBase* self);
 
 extern void func_02038228(u32* obj);
 
-extern void* MeshCollider_vtable;
+extern void* _ZTV12MeshCollider;
 
 struct MeshCollider {
     void* vtable;                 /* 0x00 */
@@ -23,7 +23,7 @@ struct MeshCollider {
 struct MeshCollider* _ZN12MeshColliderC1Ev(struct MeshCollider* self)
 {
     _ZN16MeshColliderBaseC2Ev((struct MeshColliderBase*)self);
-    self->vtable = &MeshCollider_vtable;
+    self->vtable = &_ZTV12MeshCollider;
     func_02038228(&self->fld24);
     self->fld20 = 0;
     return self;

--- a/src/_ZN12WithMeshClsnD1Ev.c
+++ b/src/_ZN12WithMeshClsnD1Ev.c
@@ -15,14 +15,14 @@ struct WithMeshClsn {
     void **raycastVtable;     /* 0x134: RaycastLine member subobject */
 };
 
-extern void *vtable_020373f8[];                          /* 0x02099204 */
+extern void *data_02099204[];                          /* 0x02099204 */
 extern void _ZN11RaycastLineD1Ev(void *raycast);        /* 0x02037764 */
 extern void _ZN10SphereClsnD1Ev(void *sphere);          /* 0x02037cb0 */
 extern void func_020354d0(struct WithMeshClsn *self); /* 0x020354d0 (base dtor) */
 
 struct WithMeshClsn *_ZN12WithMeshClsnD1Ev(struct WithMeshClsn *self)
 {
-    self->vtable = (void **)vtable_020373f8;
+    self->vtable = (void **)data_02099204;
     _ZN11RaycastLineD1Ev((char *)self + 0x134);
     _ZN10SphereClsnD1Ev((char *)self + 0x20);
     func_020354d0(self);

--- a/src/_ZN13RaycastGroundD1Ev.c
+++ b/src/_ZN13RaycastGroundD1Ev.c
@@ -4,8 +4,8 @@
 /* recovered: named members + shared header */
 #include "RaycastGround.h"
 int *_ZN13RaycastGroundD1Ev(struct RaycastGround *self) {
-    ((int *)self)[0] = (int)VT0;
-    *(int *)((char *)&self->unk_010) = (int)VT1;
+    ((int *)self)[0] = (int)data_02099264;
+    *(int *)((char *)&self->unk_010) = (int)data_02099274;
     func_020380ec((char *)&self->unk_010);
     func_020354d0(((int *)self));
     return ((int *)self);

--- a/src/_ZN14BlendModelAnim11UpdateVertsEv.c
+++ b/src/_ZN14BlendModelAnim11UpdateVertsEv.c
@@ -1,6 +1,6 @@
 #include "types.h"
 /* BlendModelAnim::UpdateVerts at 0x02016578, size=0x4c
- * Updates bones, then calls Func_0204531c(data, unk64) (blend) or UpdateVertsUsingBones based on unk64.
+ * Updates bones, then calls func_0204531c(data, unk64) (blend) or UpdateVertsUsingBones based on unk64.
  */
 struct ModelComponents {
     void* modelFile;
@@ -27,7 +27,7 @@ struct BlendModelAnim {
 };
 
 extern void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(struct ModelComponents* data, void* file, s32 frame);
-extern void Func_0204531c(struct ModelComponents* data, s32 unk64);
+extern void func_0204531c(struct ModelComponents* data, s32 unk64);
 extern void _ZN15ModelComponents21UpdateVertsUsingBonesEv(struct ModelComponents* data);
 
 void _ZN14BlendModelAnim11UpdateVertsEv(struct BlendModelAnim* thiz)
@@ -36,7 +36,7 @@ void _ZN14BlendModelAnim11UpdateVertsEv(struct BlendModelAnim* thiz)
     _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(&thiz->data, thiz->file, (u32)(currFrame << 4) >> 0x10);
     if (thiz->unk64 < 0x1000)
     {
-        Func_0204531c(&thiz->data, thiz->unk64);
+        func_0204531c(&thiz->data, thiz->unk64);
     }
     else
     {

--- a/src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.c
+++ b/src/_ZN14BlendModelAnim9Virtual10ER9Matrix4x3.c
@@ -29,7 +29,7 @@ struct BlendModelAnim {
 };
 
 extern void _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(struct ModelComponents* data, void* file, s32 frame);
-extern void Func_0204531c(struct ModelComponents* data, s32 unk64);
+extern void func_0204531c(struct ModelComponents* data, s32 unk64);
 extern void _ZN5Model9Virtual10ER9Matrix4x3(struct BlendModelAnim* thiz, struct Matrix4x3* mat);
 
 void _ZN14BlendModelAnim9Virtual10ER9Matrix4x3(struct BlendModelAnim* thiz, struct Matrix4x3* mat)
@@ -38,7 +38,7 @@ void _ZN14BlendModelAnim9Virtual10ER9Matrix4x3(struct BlendModelAnim* thiz, stru
     _ZN15ModelComponents11UpdateBonesEP8BCA_Filei(&thiz->data, thiz->file, (u32)(currFrame << 4) >> 0x10);
     if (thiz->unk64 < 0x1000)
     {
-        Func_0204531c(&thiz->data, thiz->unk64);
+        func_0204531c(&thiz->data, thiz->unk64);
     }
     else
     {

--- a/src/_ZN15FaderBrightnessD0Ev.c
+++ b/src/_ZN15FaderBrightnessD0Ev.c
@@ -1,5 +1,5 @@
 /* FaderBrightness::~FaderBrightness (deleting / D0) at 0x020177e8
- *   [this+0] = _ZTV15FaderBrightness (0x0208eacc)
+ *   [this+0] = data_0208eacc (0x0208eacc)
  *   bl 0x02017838 = FaderBrightness::~FaderBrightness (D2/base)
  *   bl 0x0203cbcc = Memory::operator_delete2(this)
  * returns this.
@@ -9,15 +9,15 @@ struct FaderBrightness {
     void **vtable; /* 0x0 */
 };
 
-extern void *_ZTV15FaderBrightness[];
+extern void *data_0208eacc[];
 
-extern void *FaderBrightnessD2(struct FaderBrightness *thiz);  /* 0x02017838 */
+extern void *func_02017838(struct FaderBrightness *thiz);  /* 0x02017838 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);        /* 0x0203cbcc */
 
 struct FaderBrightness *_ZN15FaderBrightnessD0Ev(struct FaderBrightness *thiz)
 {
-    thiz->vtable = (void **)_ZTV15FaderBrightness;
-    FaderBrightnessD2(thiz);
+    thiz->vtable = (void **)data_0208eacc;
+    func_02017838(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/_ZN15FaderBrightnessD1Ev.c
+++ b/src/_ZN15FaderBrightnessD1Ev.c
@@ -7,12 +7,12 @@
  * (ARM C++ dtor ABI). FaderBrightness adds no members of its own.
  */
 
-extern int _ZTV15FaderBrightness[]; /* vtable for FaderBrightness */
+extern int data_0208eacc[]; /* vtable for FaderBrightness */
 extern int func_02017838(int *self);  /* base (Fader) subobject destructor */
 
 int _ZN15FaderBrightnessD1Ev(int *self)
 {
-    self[0] = (int)_ZTV15FaderBrightness;  /* +0x00 vptr */
+    self[0] = (int)data_0208eacc;  /* +0x00 vptr */
     func_02017838(self);
     return (int)self;
 }

--- a/src/_ZN15MaterialChangerD1Ev.c
+++ b/src/_ZN15MaterialChangerD1Ev.c
@@ -9,10 +9,10 @@
  * Call target: 0x02015cb4
  */
 struct Obj { void *vtable; };
-extern void base_dtor_MaterialChanger(struct Obj *thiz); /* 0x02015cb4 */
+extern void _ZN9AnimationD2Ev(struct Obj *thiz); /* 0x02015cb4 */
 struct Obj *_ZN15MaterialChangerD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_MaterialChanger;
-    base_dtor_MaterialChanger(thiz);
+    thiz->vtable = (void *)_ZTV15MaterialChanger;
+    _ZN9AnimationD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN18MovingMeshColliderD0Ev.c
+++ b/src/_ZN18MovingMeshColliderD0Ev.c
@@ -11,13 +11,13 @@ struct MovingMeshCollider {
 
 extern void *_ZTV18MovingMeshCollider[];
 
-extern void *MovingMeshColliderD2(struct MovingMeshCollider *thiz);  /* 0x020397fc */
+extern void *func_020397fc(struct MovingMeshCollider *thiz);  /* 0x020397fc */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);              /* 0x0203cbcc */
 
 struct MovingMeshCollider *_ZN18MovingMeshColliderD0Ev(struct MovingMeshCollider *thiz)
 {
     thiz->vtable = (void **)_ZTV18MovingMeshCollider;
-    MovingMeshColliderD2(thiz);
+    func_020397fc(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/_ZN18NestedHeapIterator10FindNestedEPv.c
+++ b/src/_ZN18NestedHeapIterator10FindNestedEPv.c
@@ -21,10 +21,10 @@ struct HeapAllocator {
 
 extern struct HeapAllocator* _ZN18NestedHeapIterator19RecursiveFindNestedEPv(
     struct NestedHeapIterator* self, void* ptr);
-extern struct NestedHeapIterator _ZN6Memory16rootHeapIteratorE;
+extern struct NestedHeapIterator data_020a4d38;
 
 struct NestedHeapIterator* _ZN18NestedHeapIterator10FindNestedEPv(void* ptr) {
-    struct NestedHeapIterator* root = &_ZN6Memory16rootHeapIteratorE;
+    struct NestedHeapIterator* root = &data_020a4d38;
     struct HeapAllocator* found = _ZN18NestedHeapIterator19RecursiveFindNestedEPv(root, ptr);
     if (found) {
         return &found->nestedHeapIt;

--- a/src/_ZN18TextureTransformerD1Ev.c
+++ b/src/_ZN18TextureTransformerD1Ev.c
@@ -9,10 +9,10 @@
  * Call target: 0x02015cb4
  */
 struct Obj { void *vtable; };
-extern void base_dtor_TextureTransformer(struct Obj *thiz); /* 0x02015cb4 */
+extern void _ZN9AnimationD2Ev(struct Obj *thiz); /* 0x02015cb4 */
 struct Obj *_ZN18TextureTransformerD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_TextureTransformer;
-    base_dtor_TextureTransformer(thiz);
+    thiz->vtable = (void *)_ZTV18TextureTransformer;
+    _ZN9AnimationD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN19CylinderClsnWithPosD1Ev.c
+++ b/src/_ZN19CylinderClsnWithPosD1Ev.c
@@ -9,10 +9,10 @@
  * Base dtor call target: 0x02015058
  */
 struct Obj { void *vtable; };
-extern void base_dtor_CylinderClsnWithPos(struct Obj *thiz); /* 0x02015058 */
+extern void _ZN12CylinderClsnD2Ev(struct Obj *thiz); /* 0x02015058 */
 struct Obj *_ZN19CylinderClsnWithPosD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_CylinderClsnWithPos;
-    base_dtor_CylinderClsnWithPos(thiz);
+    thiz->vtable = (void *)_ZTV19CylinderClsnWithPos;
+    _ZN12CylinderClsnD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE.c
+++ b/src/_ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE.c
@@ -6,10 +6,10 @@ typedef struct ExtendingMeshCollider {
     Fix12i invScaleY;
 } ExtendingMeshCollider;
 
-extern Fix12i cstd_reciprocal(Fix12i x);
+extern Fix12i func_02053200(Fix12i x);
 
 void _ZN21ExtendingMeshCollider9SetScaleYE5Fix12IiE(ExtendingMeshCollider* this, Fix12i newScaleY) {
     this->scaleY = newScaleY;
     if (this->scaleY == 0) return;
-    this->invScaleY = cstd_reciprocal(this->scaleY);
+    this->invScaleY = func_02053200(this->scaleY);
 }

--- a/src/_ZN21ExtendingMeshColliderD0Ev.c
+++ b/src/_ZN21ExtendingMeshColliderD0Ev.c
@@ -11,13 +11,13 @@ struct ExtendingMeshCollider {
 
 extern void *_ZTV21ExtendingMeshCollider[];
 
-extern void *ExtendingMeshColliderD2(struct ExtendingMeshCollider *thiz); /* 0x0203a420 */
+extern void *func_0203a420(struct ExtendingMeshCollider *thiz); /* 0x0203a420 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);                   /* 0x0203cbcc */
 
 struct ExtendingMeshCollider *_ZN21ExtendingMeshColliderD0Ev(struct ExtendingMeshCollider *thiz)
 {
     thiz->vtable = (void **)_ZTV21ExtendingMeshCollider;
-    ExtendingMeshColliderD2(thiz);
+    func_0203a420(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/_ZN2GX10EndLoadTexEv.c
+++ b/src/_ZN2GX10EndLoadTexEv.c
@@ -1,21 +1,21 @@
 #include "types.h"
-extern s32 RENDER_DMA_CHANNEL;    /* 0x02099fd0 */
-extern u32 GX_texBank;            /* 0x020a60b8 */
-extern u32 GX_texSlotA;           /* 0x020a60ac */
-extern u32 GX_texSlotB;           /* 0x020a60bc */
-extern u32 GX_texSlotC;           /* 0x020a60c0 */
+extern s32 data_02099fd0;    /* 0x02099fd0 */
+extern u32 data_020a60b8;            /* 0x020a60b8 */
+extern u32 data_020a60ac;           /* 0x020a60ac */
+extern u32 data_020a60bc;           /* 0x020a60bc */
+extern u32 data_020a60c0;           /* 0x020a60c0 */
 
 extern void func_02059fa8(s32 channel);
 extern void _ZN2GX13SetBankForTexEt(u32 tex);
 
 void _ZN2GX10EndLoadTexEv(void)
 {
-    if (RENDER_DMA_CHANNEL != -1) {
-        func_02059fa8(RENDER_DMA_CHANNEL);
+    if (data_02099fd0 != -1) {
+        func_02059fa8(data_02099fd0);
     }
-    _ZN2GX13SetBankForTexEt(GX_texBank);
-    GX_texSlotC = 0;
-    GX_texSlotB = 0;
-    GX_texSlotA = 0;
-    GX_texBank  = 0;
+    _ZN2GX13SetBankForTexEt(data_020a60b8);
+    data_020a60c0 = 0;
+    data_020a60bc = 0;
+    data_020a60ac = 0;
+    data_020a60b8  = 0;
 }

--- a/src/_ZN2GX10LoadBGPlttEPKvjj.c
+++ b/src/_ZN2GX10LoadBGPlttEPKvjj.c
@@ -4,10 +4,10 @@
 extern void DMASyncHalfTransfer(int channel, const void* src, void* dest, unsigned int count);
 extern void MultiCopyHalf(const void* src, void* dest, unsigned int count);
 
-extern int gDMAChannel;
+extern int data_02099fd0;
 
 void _ZN2GX10LoadBGPlttEPKvjj(const void* src, unsigned int offset, unsigned int size) {
-    int channel = gDMAChannel;
+    int channel = data_02099fd0;
     if (channel != -1) {
         DMASyncHalfTransfer(channel, src, (void*)(offset + 0x05000000), size);
     } else {

--- a/src/_ZN2GX11LoadBG0CharEPKvjj.c
+++ b/src/_ZN2GX11LoadBG0CharEPKvjj.c
@@ -3,7 +3,7 @@
  * Calls G2::GetBG0CharPtr()-equivalent (0x2054efc) to get base, then DMA or CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void *func_02054efc(void);
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 void _ZN2GX11LoadBG0CharEPKvjj(const void *src, unsigned int offset, unsigned int count)
 {
     void *base = func_02054efc();
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (char *)base + offset, count);
     } else {

--- a/src/_ZN2GX11LoadBG1CharEPKvjj.c
+++ b/src/_ZN2GX11LoadBG1CharEPKvjj.c
@@ -3,7 +3,7 @@
  * Calls G2::GetBG1CharPtr()-equivalent (0x2054ea8) to get base, then DMA or CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void *func_02054ea8(void);
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 void _ZN2GX11LoadBG1CharEPKvjj(const void *src, unsigned int offset, unsigned int count)
 {
     void *base = func_02054ea8();
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (char *)base + offset, count);
     } else {

--- a/src/_ZN2GX11LoadOBJPlttEPKvjj.c
+++ b/src/_ZN2GX11LoadOBJPlttEPKvjj.c
@@ -5,10 +5,10 @@ extern void DMASyncHalfTransfer(int channel, const void* src, void* dest, unsign
 extern void MultiCopyHalf(const void* src, void* dest, unsigned int count);
 
 // The global at 0x02099fd0: DMA channel number (or -1)
-extern int gDMAChannel;
+extern int data_02099fd0;
 
 void _ZN2GX11LoadOBJPlttEPKvjj(const void* src, unsigned int offset, unsigned int size) {
-    int channel = gDMAChannel;
+    int channel = data_02099fd0;
     if (channel != -1) {
         DMASyncHalfTransfer(channel, src, (void*)((char*)0x05000200 + offset), size);
     } else {

--- a/src/_ZN2GX11LoadTexPlttEPKvjj.c
+++ b/src/_ZN2GX11LoadTexPlttEPKvjj.c
@@ -1,25 +1,25 @@
 #include "types.h"
 /* GX::LoadTexPltt at 0x02056924
  * Loads a texture palette into VRAM. If a DMA channel is configured
- * (RENDER_DMA_CHANNEL != -1), uses async DMA; otherwise uses MultiCopy_Int.
+ * (data_02099fd0 != -1), uses async DMA; otherwise uses MultiCopy_Int.
  *
  * Globals:
- *   RENDER_DMA_CHANNEL (0x02099fd0): s32 DMA channel number, -1 if none
- *   GX_texPlttSlotBase (0x020a60b0): u32 palette VRAM base address value
+ *   data_02099fd0 (0x02099fd0): s32 DMA channel number, -1 if none
+ *   data_020a60b0 (0x020a60b0): u32 palette VRAM base address value
  *
  * Unknown callee at 0x02059fd0 is a DMA transfer function:
  *   func_02059fd0(dmaChannel, src, dest, size, 0, 0)
  */
-extern u32 GX_texPlttSlotBase;   /* 0x020a60b0: palette VRAM base address */
-extern s32 RENDER_DMA_CHANNEL;   /* 0x02099fd0: DMA channel (-1 if none) */
+extern u32 data_020a60b0;   /* 0x020a60b0: palette VRAM base address */
+extern s32 data_02099fd0;   /* 0x02099fd0: DMA channel (-1 if none) */
 
 extern void MultiCopy_Int(const void *src, void *dst, u32 size);  /* 0x0205a490 */
 extern void func_02059fd0(s32 dmaChannel, const void *src, void *dst, u32 size, u32 arg4, u32 arg5);
 
 void _ZN2GX11LoadTexPlttEPKvjj(const void *src, u32 destSlotAddr, u32 size)
 {
-    void *dest = (void *)(GX_texPlttSlotBase + destSlotAddr);
-    s32 dmaCh = RENDER_DMA_CHANNEL;
+    void *dest = (void *)(data_020a60b0 + destSlotAddr);
+    s32 dmaCh = data_02099fd0;
     if (dmaCh != -1) {
         func_02059fd0(dmaCh, src, dest, size, 0, 0);
     } else {

--- a/src/_ZN2GX14EndLoadTexPlttEv.c
+++ b/src/_ZN2GX14EndLoadTexPlttEv.c
@@ -1,17 +1,17 @@
 #include "types.h"
-extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
-extern u32 GXi_SavedTexPlttBankB; /* 0x020a60b4 */
-extern u32 GXi_SavedTexPlttBankA; /* 0x020a60b0 */
+extern u32 data_02099fd0;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
+extern u32 data_020a60b4; /* 0x020a60b4 */
+extern u32 data_020a60b0; /* 0x020a60b0 */
 
 extern void func_02059fa8(u32 dmaId);
 extern void _ZN2GX17SetBankForTexPlttEt(u32 bank);
 
 void _ZN2GX14EndLoadTexPlttEv(void) {
-    u32 dmaId = GXi_DmaId;
+    u32 dmaId = data_02099fd0;
     if (dmaId != (u32)-1) {
         func_02059fa8(dmaId);
     }
-    _ZN2GX17SetBankForTexPlttEt(GXi_SavedTexPlttBankB);
-    GXi_SavedTexPlttBankB = 0;
-    GXi_SavedTexPlttBankA = 0;
+    _ZN2GX17SetBankForTexPlttEt(data_020a60b4);
+    data_020a60b4 = 0;
+    data_020a60b0 = 0;
 }

--- a/src/_ZN2GX15SetBankForSubBGEt.c
+++ b/src/_ZN2GX15SetBankForSubBGEt.c
@@ -5,17 +5,17 @@ struct VramReg
   u16 pad[8];
   u16 f12;
 };
-extern struct VramReg gVramReg;
+extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);
 void _ZN2GX15SetBankForSubBGEt(u16 x)
 {
   int s = (int) x;
   int new_var;
   unsigned int notx = ~((unsigned int) x);
-  u16 old = gVramReg.f12;
-  new_var = notx & (gVramReg.w0 | old);
-  gVramReg.f12 = x;
-  gVramReg.w0 = new_var;
+  u16 old = data_020a6088.f12;
+  new_var = notx & (data_020a6088.w0 | old);
+  data_020a6088.f12 = x;
+  data_020a6088.w0 = new_var;
   if (s <= 0x80)
   {
     if (s >= 0x80)
@@ -42,6 +42,6 @@ void _ZN2GX15SetBankForSubBGEt(u16 x)
   *((volatile unsigned char *) 0x4000248) = 0x81;
 
   done:
-  Vram__Map(gVramReg.w0);
+  Vram__Map(data_020a6088.w0);
 
 }

--- a/src/_ZN2GX16SetBankForSubOBJEt.c
+++ b/src/_ZN2GX16SetBankForSubOBJEt.c
@@ -1,14 +1,14 @@
 #include "types.h"
 struct VramReg { u16 w0; u16 pad[9]; u16 f14; };
-extern struct VramReg gVramReg;
+extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);
 void _ZN2GX16SetBankForSubOBJEt(u16 x){
-    gVramReg.w0 = (gVramReg.w0 | gVramReg.f14) & ~x;
-    gVramReg.f14 = x;
+    data_020a6088.w0 = (data_020a6088.w0 | data_020a6088.f14) & ~x;
+    data_020a6088.f14 = x;
     switch (x) {
     case 0: break;
     case 8: *(volatile unsigned char*)0x4000243 = 0x84; break;
     case 0x100: *(volatile unsigned char*)0x4000249 = 0x82; break;
     }
-    Vram__Map(gVramReg.w0);
+    Vram__Map(data_020a6088.w0);
 }

--- a/src/_ZN2GX17SetBankForTexPlttEt.c
+++ b/src/_ZN2GX17SetBankForTexPlttEt.c
@@ -1,10 +1,10 @@
 #include "types.h"
 struct VramReg { u16 w0; u16 pad[4]; u16 fa; };
-extern struct VramReg gVramReg;
+extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);
 void _ZN2GX17SetBankForTexPlttEt(u16 x){
-    gVramReg.w0 = ~x & (gVramReg.w0 | gVramReg.fa);
-    gVramReg.fa = x;
+    data_020a6088.w0 = ~x & (data_020a6088.w0 | data_020a6088.fa);
+    data_020a6088.fa = x;
     switch (x) {
     case 0x40:
         *(volatile unsigned char*)0x4000246 = 0x83;
@@ -23,5 +23,5 @@ void _ZN2GX17SetBankForTexPlttEt(u16 x){
     case 0:
         break;
     }
-    Vram__Map(gVramReg.w0);
+    Vram__Map(data_020a6088.w0);
 }

--- a/src/_ZN2GX22SetBankForSubBGExtPlttEt.c
+++ b/src/_ZN2GX22SetBankForSubBGExtPlttEt.c
@@ -1,11 +1,11 @@
 #include "types.h"
 struct VramReg { u16 w0; u16 pad[0xa]; u16 f16; };
-extern struct VramReg gVramReg;
+extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);
 void _ZN2GX22SetBankForSubBGExtPlttEt(u16 x){
-    gVramReg.w0 = (gVramReg.w0 | gVramReg.f16) & ~x;
-    gVramReg.f16 = x;
+    data_020a6088.w0 = (data_020a6088.w0 | data_020a6088.f16) & ~x;
+    data_020a6088.f16 = x;
     if (x != 0) { if (x == 0x80) { *(volatile unsigned int*)0x4001000 |= 0x40000000; *(volatile unsigned char*)0x4000248 = 0x82; } }
     else { *(volatile unsigned int*)0x4001000 &= ~0x40000000; }
-    Vram__Map(gVramReg.w0);
+    Vram__Map(data_020a6088.w0);
 }

--- a/src/_ZN2GX23SetBankForSubOBJExtPlttEt.c
+++ b/src/_ZN2GX23SetBankForSubOBJExtPlttEt.c
@@ -1,11 +1,11 @@
 #include "types.h"
 struct VramReg { u16 w0; u16 pad[0xb]; u16 f18; };
-extern struct VramReg gVramReg;
+extern struct VramReg data_020a6088;
 extern void Vram__Map(u16 bits);
 void _ZN2GX23SetBankForSubOBJExtPlttEt(u16 x){
-    gVramReg.w0 = (gVramReg.w0 | gVramReg.f18) & ~x;
-    gVramReg.f18 = x;
+    data_020a6088.w0 = (data_020a6088.w0 | data_020a6088.f18) & ~x;
+    data_020a6088.f18 = x;
     if (x != 0) { if (x == 0x100) { *(volatile unsigned int*)0x4001000 |= 0x80000000; *(volatile unsigned char*)0x4000249 = 0x83; } }
     else { *(volatile unsigned int*)0x4001000 &= ~0x80000000; }
-    Vram__Map(gVramReg.w0);
+    Vram__Map(data_020a6088.w0);
 }

--- a/src/_ZN2GX7LoadOBJEPKvjj.c
+++ b/src/_ZN2GX7LoadOBJEPKvjj.c
@@ -3,7 +3,7 @@
  * Uses DMA channel if available, else CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
 extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 
 void _ZN2GX7LoadOBJEPKvjj(const void *src, unsigned int offset, unsigned int count)
 {
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     unsigned int base = 0x6400000;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (void *)(base + offset), count);

--- a/src/_ZN3GXS10LoadBGPlttEPKvjj.c
+++ b/src/_ZN3GXS10LoadBGPlttEPKvjj.c
@@ -4,10 +4,10 @@
 extern void DMASyncHalfTransfer(int channel, const void* src, void* dest, unsigned int count);
 extern void MultiCopyHalf(const void* src, void* dest, unsigned int count);
 
-extern int gDMAChannel;
+extern int data_02099fd0;
 
 void _ZN3GXS10LoadBGPlttEPKvjj(const void* src, unsigned int offset, unsigned int size) {
-    int channel = gDMAChannel;
+    int channel = data_02099fd0;
     if (channel != -1) {
         DMASyncHalfTransfer(channel, src, (void*)((char*)0x05000400 + offset), size);
     } else {

--- a/src/_ZN3GXS11LoadBG0CharEPKvjj.c
+++ b/src/_ZN3GXS11LoadBG0CharEPKvjj.c
@@ -2,7 +2,7 @@
 /* _ZN3GXS11LoadBG0CharEPKvjj at 0x020561f4
  * Loads BG0 char data using DMA if a channel is assigned, else CPU copy.
  */
-extern u32 RENDER_DMA_CHANNEL;
+extern u32 data_02099fd0;
 
 extern void *_ZN3G2S13GetBG0CharPtrEv(void);
 extern void DMASyncWordTransfer(u32 ch, const void *src, void *dst, u32 size);
@@ -11,8 +11,8 @@ extern void MultiCopy_Int(const void *src, void *dst, u32 size);
 void _ZN3GXS11LoadBG0CharEPKvjj(const void *src, u32 offset, u32 size)
 {
     void *charPtr = _ZN3G2S13GetBG0CharPtrEv();
-    if (RENDER_DMA_CHANNEL != (u32)-1)
-        DMASyncWordTransfer(RENDER_DMA_CHANNEL, src, (char *)charPtr + offset, size);
+    if (data_02099fd0 != (u32)-1)
+        DMASyncWordTransfer(data_02099fd0, src, (char *)charPtr + offset, size);
     else
         MultiCopy_Int(src, (char *)charPtr + offset, size);
 }

--- a/src/_ZN3GXS11LoadBG1CharEPKvjj.c
+++ b/src/_ZN3GXS11LoadBG1CharEPKvjj.c
@@ -3,7 +3,7 @@
  * Calls G2S::GetBG1CharPtr() to get base pointer, then DMA or CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void *_ZN3G2S13GetBG1CharPtrEv(void);
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 void _ZN3GXS11LoadBG1CharEPKvjj(const void *src, unsigned int offset, unsigned int count)
 {
     void *base = _ZN3G2S13GetBG1CharPtrEv();
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (char *)base + offset, count);
     } else {

--- a/src/_ZN3GXS11LoadOBJPlttEPKvjj.c
+++ b/src/_ZN3GXS11LoadOBJPlttEPKvjj.c
@@ -5,10 +5,10 @@ extern void DMASyncHalfTransfer(int channel, const void* src, void* dest, unsign
 extern void MultiCopyHalf(const void* src, void* dest, unsigned int count);
 
 // The global at 0x02099fd0: DMA channel number (or -1)
-extern int gDMAChannel;
+extern int data_02099fd0;
 
 void _ZN3GXS11LoadOBJPlttEPKvjj(const void* src, unsigned int offset, unsigned int size) {
-    int channel = gDMAChannel;
+    int channel = data_02099fd0;
     if (channel != -1) {
         DMASyncHalfTransfer(channel, src, (void*)((char*)0x05000600 + offset), size);
     } else {

--- a/src/_ZN3GXS13LoadBGExtPlttEPKvjj.c
+++ b/src/_ZN3GXS13LoadBGExtPlttEPKvjj.c
@@ -1,17 +1,17 @@
 #include "types.h"
 /* DMA transfer function for GX (nitroSDK internal) */
-extern void FUN_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
+extern void func_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
 extern void MultiCopy_Int(const void* src, void* dst, u32 count);
 
 /* GX sub-screen BG extended palette base address */
 #define GXS_BG_EXT_PLTT_BASE 0x06898000u
 
-extern u32 GXi_DmaId;   /* RENDER_DMA_CHANNEL: 0x02099fd0 */
+extern u32 data_02099fd0;   /* RENDER_DMA_CHANNEL: 0x02099fd0 */
 
 void _ZN3GXS13LoadBGExtPlttEPKvjj(const void* src, u32 destSlotAddr, u32 size) {
-    u32 dmaId = GXi_DmaId;
+    u32 dmaId = data_02099fd0;
     if (dmaId != (u32)-1) {
-        FUN_02059fd0(dmaId, src, (void*)(destSlotAddr + GXS_BG_EXT_PLTT_BASE), size, 0, 0);
+        func_02059fd0(dmaId, src, (void*)(destSlotAddr + GXS_BG_EXT_PLTT_BASE), size, 0, 0);
     } else {
         MultiCopy_Int(src, (void*)(destSlotAddr + GXS_BG_EXT_PLTT_BASE), size);
     }

--- a/src/_ZN3GXS14LoadOBJExtPlttEPKvjj.c
+++ b/src/_ZN3GXS14LoadOBJExtPlttEPKvjj.c
@@ -1,17 +1,17 @@
 #include "types.h"
 /* DMA transfer function for GX (nitroSDK internal) */
-extern void FUN_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
+extern void func_02059fd0(u32 dmaId, const void* src, void* dst, u32 size, u32 unk0, u32 unk1);
 extern void MultiCopy_Int(const void* src, void* dst, u32 count);
 
 /* GX sub-screen OBJ extended palette base address (VRAM-D slot B) */
 #define GXS_OBJ_EXT_PLTT_BASE 0x068a0000u
 
-extern u32 GXi_DmaId;   /* RENDER_DMA_CHANNEL: 0x02099fd0 */
+extern u32 data_02099fd0;   /* RENDER_DMA_CHANNEL: 0x02099fd0 */
 
 void _ZN3GXS14LoadOBJExtPlttEPKvjj(const void* src, u32 destSlotAddr, u32 size) {
-    u32 dmaId = GXi_DmaId;
+    u32 dmaId = data_02099fd0;
     if (dmaId != (u32)-1) {
-        FUN_02059fd0(dmaId, src, (void*)(destSlotAddr + GXS_OBJ_EXT_PLTT_BASE), size, 0, 0);
+        func_02059fd0(dmaId, src, (void*)(destSlotAddr + GXS_OBJ_EXT_PLTT_BASE), size, 0, 0);
     } else {
         MultiCopy_Int(src, (void*)(destSlotAddr + GXS_OBJ_EXT_PLTT_BASE), size);
     }

--- a/src/_ZN3GXS16EndLoadBGExtPlttEv.c
+++ b/src/_ZN3GXS16EndLoadBGExtPlttEv.c
@@ -1,15 +1,15 @@
 #include "types.h"
-extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
-extern u32 GXi_SavedSubBGExtPlttBank; /* saved bank: 0x020a60a4 */
+extern u32 data_02099fd0;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
+extern u32 data_020a60a4; /* saved bank: 0x020a60a4 */
 
 extern void func_02059fa8(u32 dmaId);
 extern void _ZN2GX22SetBankForSubBGExtPlttEt(u32 bank);
 
 void _ZN3GXS16EndLoadBGExtPlttEv(void) {
-    u32 dmaId = GXi_DmaId;
+    u32 dmaId = data_02099fd0;
     if (dmaId != (u32)-1) {
         func_02059fa8(dmaId);
     }
-    _ZN2GX22SetBankForSubBGExtPlttEt(GXi_SavedSubBGExtPlttBank);
-    GXi_SavedSubBGExtPlttBank = 0;
+    _ZN2GX22SetBankForSubBGExtPlttEt(data_020a60a4);
+    data_020a60a4 = 0;
 }

--- a/src/_ZN3GXS17EndLoadOBJExtPlttEv.c
+++ b/src/_ZN3GXS17EndLoadOBJExtPlttEv.c
@@ -1,15 +1,15 @@
 #include "types.h"
-extern u32 GXi_DmaId;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
-extern u32 GXi_SavedSubOBJExtPlttBank; /* saved bank: 0x020a60a8 */
+extern u32 data_02099fd0;  /* RENDER_DMA_CHANNEL: 0x02099fd0 */
+extern u32 data_020a60a8; /* saved bank: 0x020a60a8 */
 
 extern void func_02059fa8(u32 dmaId);
 extern void _ZN2GX23SetBankForSubOBJExtPlttEt(u32 bank);
 
 void _ZN3GXS17EndLoadOBJExtPlttEv(void) {
-    u32 dmaId = GXi_DmaId;
+    u32 dmaId = data_02099fd0;
     if (dmaId != (u32)-1) {
         func_02059fa8(dmaId);
     }
-    _ZN2GX23SetBankForSubOBJExtPlttEt(GXi_SavedSubOBJExtPlttBank);
-    GXi_SavedSubOBJExtPlttBank = 0;
+    _ZN2GX23SetBankForSubOBJExtPlttEt(data_020a60a8);
+    data_020a60a8 = 0;
 }

--- a/src/_ZN3OAM12EnableSubOAMEv.c
+++ b/src/_ZN3OAM12EnableSubOAMEv.c
@@ -1,6 +1,6 @@
 
-extern char G[];
+extern char data_0209e660[];
 unsigned int _ZN3OAM12EnableSubOAMEv(void)
 {
-  G[0] = (long) 0;
+  data_0209e660[0] = (long) 0;
 }

--- a/src/_ZN3OAM5FlushEv.c
+++ b/src/_ZN3OAM5FlushEv.c
@@ -1,12 +1,12 @@
 #include "types.h"
 extern void _ZN4CP1527FlushAndInvalidateDataCacheEjj(u32 addr, u32 size);
 
-extern u32 _ZN3OAM10bufferMainE;
-extern u32 unk_0209ea74;
+extern u32 data_0209e674;
+extern u32 data_0209ea74;
 
 /* OAM::Flush - flush main and sub OAM DMA buffers from data cache */
 void _ZN3OAM5FlushEv(void)
 {
-    _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)&_ZN3OAM10bufferMainE, 0x400);
-    _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)&unk_0209ea74, 0x400);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)&data_0209e674, 0x400);
+    _ZN4CP1527FlushAndInvalidateDataCacheEjj((u32)&data_0209ea74, 0x400);
 }

--- a/src/_ZN4Heap18InitializeGameHeapEjPS_.c
+++ b/src/_ZN4Heap18InitializeGameHeapEjPS_.c
@@ -15,8 +15,8 @@ struct ExpandingHeap {
 };
 
 extern struct ExpandingHeap* _ZN4Heap19CreateExpandingHeapEjPS_i(u32 size, struct Heap* root, s32 align);
-extern struct ExpandingHeap* _ZN6Memory11gameHeapPtrE;
+extern struct ExpandingHeap* data_020a0eac;
 
 void _ZN4Heap18InitializeGameHeapEjPS_(u32 size, struct Heap* root) {
-    _ZN6Memory11gameHeapPtrE = _ZN4Heap19CreateExpandingHeapEjPS_i(size, root, 4);
+    data_020a0eac = _ZN4Heap19CreateExpandingHeapEjPS_i(size, root, 4);
 }

--- a/src/_ZN4Heap20RestoreFromTemporaryEv.c
+++ b/src/_ZN4Heap20RestoreFromTemporaryEv.c
@@ -3,11 +3,11 @@
 typedef void Heap;
 
 extern Heap* _ZN6Memory14defaultHeapPtrE;
-extern Heap* _ZN6Memory10tmpHeapPtrE;
+extern Heap* data_020a0ea8;
 
 extern Heap* _ZN4Heap10SetDefaultEv(Heap* self);
 
 void _ZN4Heap20RestoreFromTemporaryEv(void) {
-    _ZN4Heap10SetDefaultEv(_ZN6Memory10tmpHeapPtrE);
-    _ZN6Memory10tmpHeapPtrE = (Heap*)0;
+    _ZN4Heap10SetDefaultEv(data_020a0ea8);
+    data_020a0ea8 = (Heap*)0;
 }

--- a/src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c
+++ b/src/_ZN4Heap23SetupSolidHeapAsDefaultEjPS_i.c
@@ -5,8 +5,8 @@
 
 typedef void Heap;
 
-extern Heap* _ZN6Memory14defaultHeapPtrE;
-extern Heap* _ZN6Memory10tmpHeapPtrE;
+extern Heap* data_020a0ea0;
+extern Heap* data_020a0ea8;
 
 extern Heap* _ZN4Heap15CreateSolidHeapEjPS_i(unsigned int size, Heap* root, int align);
 extern Heap* _ZN4Heap10SetDefaultEv(Heap* self);
@@ -14,7 +14,7 @@ extern Heap* _ZN4Heap10SetDefaultEv(Heap* self);
 void* _ZN4Heap23SetupSolidHeapAsDefaultEjPS_i(unsigned int size, Heap* root, int align) {
     Heap* heap = _ZN4Heap15CreateSolidHeapEjPS_i(size, root, align);
     if (!heap) return (void*)0;
-    _ZN6Memory10tmpHeapPtrE = _ZN6Memory14defaultHeapPtrE;
+    data_020a0ea8 = data_020a0ea0;
     _ZN4Heap10SetDefaultEv(heap);
     return heap;
 }

--- a/src/_ZN4HeapD0Ev.c
+++ b/src/_ZN4HeapD0Ev.c
@@ -1,4 +1,4 @@
-extern void *_ZTV4Heap;
+extern void *data_02099d90;
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 struct Heap {
@@ -7,7 +7,7 @@ struct Heap {
 
 void *_ZN4HeapD0Ev(struct Heap *self)
 {
-    self->vtable = &_ZTV4Heap;
+    self->vtable = &data_02099d90;
     _ZN6Memory16operator_delete2EPv(self);
     return self;
 }

--- a/src/_ZN4HeapD1Ev.c
+++ b/src/_ZN4HeapD1Ev.c
@@ -5,13 +5,13 @@
  * A trivial destructor whose only effect is to reset the object's vtable pointer
  * (at offset 0x00) back to Heap's own vtable. Returns void.
  *
- * _ZTV4Heap is the Itanium vtable symbol for Heap. The stored address is a
+ * data_02099d90 is the Itanium vtable symbol for Heap. The stored address is a
  * pooled wildcard reloc, so the extern name is not byte-verified -- it is named
  * by convention. */
 
-extern int _ZTV4Heap[]; /* vtable for Heap */
+extern int data_02099d90[]; /* vtable for Heap */
 
 void _ZN4HeapD1Ev(int *self)
 {
-    self[0] = (int)_ZTV4Heap; /* reset vptr at +0x00 */
+    self[0] = (int)data_02099d90; /* reset vptr at +0x00 */
 }

--- a/src/_ZN4HeapD2Ev.c
+++ b/src/_ZN4HeapD2Ev.c
@@ -6,13 +6,13 @@
  * (at offset 0x00) back to Heap's own vtable before the base subobject is torn
  * down. Returns void.
  *
- * _ZTV4Heap is the Itanium vtable symbol for Heap. The stored address is a
+ * data_02099d90 is the Itanium vtable symbol for Heap. The stored address is a
  * pooled wildcard reloc, so the extern name is not byte-verified -- it is named
  * by convention. */
 
-extern int _ZTV4Heap[]; /* vtable for Heap */
+extern int data_02099d90[]; /* vtable for Heap */
 
 void _ZN4HeapD2Ev(int *self)
 {
-    self[0] = (int)_ZTV4Heap; /* reset vptr at +0x00 */
+    self[0] = (int)data_02099d90; /* reset vptr at +0x00 */
 }

--- a/src/_ZN4ViewD0Ev.c
+++ b/src/_ZN4ViewD0Ev.c
@@ -2,7 +2,7 @@
  *
  * vtable chain View -> ActorDerived:
  *   0x02092720 = _ZTV4View
- *   0x0208e4b8 = _ZTV12ActorDerived
+ *   0x0208e4b8 = data_0208e4b8
  *   bl 0x02043d48 = ActorBase::~ActorBase
  *   bl 0x0203c1e8 = Memory::Deallocate(this, *gameHeapPtr)
  *   return this;
@@ -12,17 +12,17 @@ struct View { void **vtable; /* 0x0 */ };
 struct Heap;
 
 extern void *_ZTV4View[];
-extern void *_ZTV12ActorDerived[];
+extern void *data_0208e4b8[];
 
 extern void _ZN9ActorBaseD2Ev(struct View *self);              /* 0x02043d48 */
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap); /* 0x0203c1e8 */
-extern struct Heap *_ZN6Memory11gameHeapPtrE;                  /* 0x020a0eac */
+extern struct Heap *data_020a0eac;                  /* 0x020a0eac */
 
 struct View *_ZN4ViewD0Ev(struct View *self)
 {
     self->vtable = (void **)_ZTV4View;
-    self->vtable = (void **)_ZTV12ActorDerived;
+    self->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(self);
-    _ZN6Memory10DeallocateEPvP4Heap(self, _ZN6Memory11gameHeapPtrE);
+    _ZN6Memory10DeallocateEPvP4Heap(self, data_020a0eac);
     return self;
 }

--- a/src/_ZN4ViewD1Ev.c
+++ b/src/_ZN4ViewD1Ev.c
@@ -1,5 +1,5 @@
 extern void *_ZTV4View;
-extern void *_ZTV12ActorDerived;
+extern void *data_0208e4b8;
 extern void *_ZN9ActorBaseD2Ev(void *self);
 
 struct View {
@@ -9,7 +9,7 @@ struct View {
 void *_ZN4ViewD1Ev(struct View *self)
 {
     self->vtable = &_ZTV4View;
-    self->vtable = &_ZTV12ActorDerived;
+    self->vtable = &data_0208e4b8;
     _ZN9ActorBaseD2Ev(self);
     return self;
 }

--- a/src/_ZN5Actor13DistToCPlayerEv.c
+++ b/src/_ZN5Actor13DistToCPlayerEv.c
@@ -13,10 +13,10 @@ typedef int Fix12i; /* 20.12 fixed-point */
 struct Actor;
 
 extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
-extern Fix12i gClosestPlayerDist; /* @ 0x0208e380 */
+extern Fix12i data_0208e380; /* @ 0x0208e380 */
 
 Fix12i _ZN5Actor13DistToCPlayerEv(struct Actor *self)
 {
     _ZN5Actor13ClosestPlayerEv();
-    return gClosestPlayerDist;
+    return data_0208e380;
 }

--- a/src/_ZN5Actor14FarthestPlayerEv.c
+++ b/src/_ZN5Actor14FarthestPlayerEv.c
@@ -12,10 +12,10 @@
 struct Actor;
 
 extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
-extern struct Actor *gFarthestPlayer; /* @ 0x0209b450 */
+extern struct Actor *data_0209b450; /* @ 0x0209b450 */
 
 struct Actor *_ZN5Actor14FarthestPlayerEv(struct Actor *self)
 {
     _ZN5Actor13ClosestPlayerEv();
-    return gFarthestPlayer;
+    return data_0209b450;
 }

--- a/src/_ZN5Actor15IsPlayerInRangeE5Fix12IiES1_S1_i.c
+++ b/src/_ZN5Actor15IsPlayerInRangeE5Fix12IiES1_S1_i.c
@@ -14,7 +14,7 @@ struct Actor {
 /* Resolved callees (symbols/verified.tsv):
  *   0x02010ad8 = Actor::ClosestPlayer()
  *   0x0203cfdc = Vec3_Dist(const Vector3&, const Vector3&) */
-extern struct Actor *Actor_ClosestPlayer(void);
+extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 
 int _ZN5Actor15IsPlayerInRangeE5Fix12IiES1_S1_i(struct Actor *self, Fix12i posX, Fix12i posY, Fix12i posZ, int maxDist) {
@@ -22,6 +22,6 @@ int _ZN5Actor15IsPlayerInRangeE5Fix12IiES1_S1_i(struct Actor *self, Fix12i posX,
     pos.x = posX;
     pos.y = posY;
     pos.z = posZ;
-    struct Actor *closest = Actor_ClosestPlayer();
+    struct Actor *closest = _ZN5Actor13ClosestPlayerEv();
     return Vec3_Dist(&pos, &closest->pos) < (maxDist << 12);
 }

--- a/src/_ZN5Actor15IsPlayerInRangeERK7Vector3i.c
+++ b/src/_ZN5Actor15IsPlayerInRangeERK7Vector3i.c
@@ -14,10 +14,10 @@ struct Actor {
 /* Resolved callees (symbols/verified.tsv):
  *   0x02010ad8 = Actor::ClosestPlayer()                  -> _ZN5Actor13ClosestPlayerEv
  *   0x0203cfdc = Vec3_Dist(const Vector3&, const Vector3&) -> Vec3_Dist */
-extern struct Actor *Actor_ClosestPlayer(void);
+extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 
 int _ZN5Actor15IsPlayerInRangeERK7Vector3i(struct Actor *self, const struct Vector3 *pos, int maxDist) {
-    struct Actor *closest = Actor_ClosestPlayer();
+    struct Actor *closest = _ZN5Actor13ClosestPlayerEv();
     return Vec3_Dist(pos, &closest->pos) < (maxDist << 12);
 }

--- a/src/_ZN5Actor15IsPlayerInRangeEi.c
+++ b/src/_ZN5Actor15IsPlayerInRangeEi.c
@@ -14,10 +14,10 @@ struct Actor {
 /* Resolved callees (symbols/verified.tsv):
  *   0x02010ad8 = Actor::ClosestPlayer()
  *   0x0203cfdc = Vec3_Dist(const Vector3&, const Vector3&) */
-extern struct Actor *Actor_ClosestPlayer(void);
+extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 
 int _ZN5Actor15IsPlayerInRangeEi(struct Actor *self, int maxDist) {
-    struct Actor *closest = Actor_ClosestPlayer();
+    struct Actor *closest = _ZN5Actor13ClosestPlayerEv();
     return Vec3_Dist(&self->pos, &closest->pos) < (maxDist << 12);
 }

--- a/src/_ZN5Actor18ClosestWithActorIDEj.c
+++ b/src/_ZN5Actor18ClosestWithActorIDEj.c
@@ -14,7 +14,7 @@ struct Actor {
 /* Resolved callees (symbols/verified.tsv):
  *   0x02010ef0 = Actor::FindWithActorID(u32 actorID, Actor* searchStart)
  *   0x0203cfdc = Vec3_Dist(const Vector3&, const Vector3&) */
-extern struct Actor *Actor_FindWithActorID(unsigned int actorID, struct Actor *searchStart);
+extern struct Actor *_ZN5Actor15FindWithActorIDEjPS_(unsigned int actorID, struct Actor *searchStart);
 extern Fix12i Vec3_Dist(const struct Vector3 *a, const struct Vector3 *b);
 
 struct Actor *_ZN5Actor18ClosestWithActorIDEj(struct Actor *self, unsigned int actorID) {
@@ -23,7 +23,7 @@ struct Actor *_ZN5Actor18ClosestWithActorIDEj(struct Actor *self, unsigned int a
     Fix12i closestDist = 0x7fffffff;
 
     for (;;) {
-        actor = Actor_FindWithActorID(actorID, actor);
+        actor = _ZN5Actor15FindWithActorIDEjPS_(actorID, actor);
         if (!actor)
             break;
         if (actor != self) {

--- a/src/_ZN5Actor18HorzAngleToCPlayerEv.c
+++ b/src/_ZN5Actor18HorzAngleToCPlayerEv.c
@@ -22,10 +22,10 @@ struct Actor {
 
 extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern struct Actor *gClosestPlayer; /* @ 0x0209b458 */
+extern struct Actor *data_0209b458; /* @ 0x0209b458 */
 
 s16 _ZN5Actor18HorzAngleToCPlayerEv(struct Actor *self)
 {
     _ZN5Actor13ClosestPlayerEv();
-    return Vec3_HorzAngle(&self->pos, &gClosestPlayer->pos);
+    return Vec3_HorzAngle(&self->pos, &data_0209b458->pos);
 }

--- a/src/_ZN5Actor18HorzAngleToFPlayerEv.c
+++ b/src/_ZN5Actor18HorzAngleToFPlayerEv.c
@@ -22,10 +22,10 @@ struct Actor {
 
 extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern struct Actor *gFarthestPlayer; /* @ 0x0209b450 */
+extern struct Actor *data_0209b450; /* @ 0x0209b450 */
 
 s16 _ZN5Actor18HorzAngleToFPlayerEv(struct Actor *self)
 {
     _ZN5Actor13ClosestPlayerEv();
-    return Vec3_HorzAngle(&self->pos, &gFarthestPlayer->pos);
+    return Vec3_HorzAngle(&self->pos, &data_0209b450->pos);
 }

--- a/src/_ZN5Actor23HorzAngleToCPlayerOrAngEv.c
+++ b/src/_ZN5Actor23HorzAngleToCPlayerOrAngEv.c
@@ -26,14 +26,14 @@ struct Actor {
 
 extern struct Actor *_ZN5Actor13ClosestPlayerEv(void);
 extern s16 Vec3_HorzAngle(const struct Vector3 *v0, const struct Vector3 *v1);
-extern struct Actor *gClosestPlayer; /* @ 0x0209b458 */
+extern struct Actor *data_0209b458; /* @ 0x0209b458 */
 
 s16 _ZN5Actor23HorzAngleToCPlayerOrAngEv(struct Actor *self)
 {
     struct Actor *player;
 
     _ZN5Actor13ClosestPlayerEv();
-    player = gClosestPlayer;
+    player = data_0209b458;
     if (player == 0)
         return self->ang.y;
 

--- a/src/_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii.c
+++ b/src/_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii.c
@@ -7,12 +7,12 @@ struct Vector3_16 { short x, y, z; };
 typedef struct ActorBase ActorBase;
 extern ActorBase *func_02010e78(const struct Vector3 *pos, const struct Vector3_16 *rot, s8 areaID, s16 deathTableID);
 extern ActorBase *_ZN12ActorDerived5SpawnEjP9ActorBaseii(u32 actorID, ActorBase *parent, u32 param1, s32 flags);
-extern ActorBase *gActorListHead; /* 0x0209f5c0 */
+extern ActorBase *data_0209f5c0; /* 0x0209f5c0 */
 ActorBase *_ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(
     u32 actorID, u32 param1,
     const struct Vector3 *pos, const struct Vector3_16 *rot,
     s8 areaID, s16 deathTableID)
 {
     func_02010e78(pos, rot, areaID, deathTableID);
-    return _ZN12ActorDerived5SpawnEjP9ActorBaseii(actorID, gActorListHead, param1, 2);
+    return _ZN12ActorDerived5SpawnEjP9ActorBaseii(actorID, data_0209f5c0, param1, 2);
 }

--- a/src/_ZN5ActorD0Ev.c
+++ b/src/_ZN5ActorD0Ev.c
@@ -11,9 +11,9 @@
  *   - return this
  *
  * Pool literals (relocations, wildcarded by matcher):
- *   0x0208e3a4 = _ZTV5Actor
+ *   0x0208e3a4 = data_0208e3a4
  *   0x0209b468 = global passed as first arg to the 0x0203b27c teardown
- *   0x0208e4b8 = _ZTV12ActorDerived
+ *   0x0208e4b8 = data_0208e4b8
  *   0x020a0eac = Memory::gameHeapPtr
  * Calls:
  *   0x0203b27c = teardown(global, &actorSub)   (unnamed)
@@ -29,24 +29,24 @@ struct Actor {
     /* Actor-specific subobject begins at 0x50 */
 };
 
-extern void *_ZTV5Actor[];
-extern void *_ZTV12ActorDerived[];
+extern void *data_0208e3a4[];
+extern void *data_0208e4b8[];
 
-extern void Actor_TeardownA(void *global, void *actorSub);   /* 0x0203b27c */
-extern void Actor_TeardownB(void *actorSub);                 /* 0x02044104 */
+extern void func_0203b27c(void *global, void *actorSub);   /* 0x0203b27c */
+extern void func_02044104(void *actorSub);                 /* 0x02044104 */
 extern void _ZN9ActorBaseD2Ev(struct Actor *thiz);           /* 0x02043d48 */
-extern void Memory_Deallocate(void *ptr, struct Heap *heap); /* 0x0203c1e8 */
+extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap); /* 0x0203c1e8 */
 
-extern void *Actor_TeardownGlobal;                           /* 0x0209b468 */
-extern struct Heap *Memory_gameHeapPtr;                      /* 0x020a0eac */
+extern void *data_0209b468;                           /* 0x0209b468 */
+extern struct Heap *data_020a0eac;                      /* 0x020a0eac */
 
 struct Actor *_ZN5ActorD0Ev(struct Actor *thiz)
 {
-    thiz->vtable = (void *)_ZTV5Actor;
-    Actor_TeardownA(&Actor_TeardownGlobal, (char *)thiz + 0x50);
-    Actor_TeardownB((char *)thiz + 0x50);
-    thiz->vtable = (void *)_ZTV12ActorDerived;
+    thiz->vtable = (void *)data_0208e3a4;
+    func_0203b27c(&data_0209b468, (char *)thiz + 0x50);
+    func_02044104((char *)thiz + 0x50);
+    thiz->vtable = (void *)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
-    Memory_Deallocate(thiz, Memory_gameHeapPtr);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;
 }

--- a/src/_ZN5ColorD1Ev.c
+++ b/src/_ZN5ColorD1Ev.c
@@ -3,12 +3,12 @@
  * destructor (func_020177c4), and returns self (ARM C++ dtor ABI).
  */
 
-extern int _ZTV5Color[];           /* vtable for Color */
+extern int data_0208eb2c[];           /* vtable for Color */
 extern int func_020177c4(int *self); /* base-subobject destructor */
 
 int _ZN5ColorD1Ev(int *self)
 {
-    self[0] = (int)_ZTV5Color;  /* +0x00 vptr */
+    self[0] = (int)data_0208eb2c;  /* +0x00 vptr */
     func_020177c4(self);
     return (int)self;
 }

--- a/src/_ZN5Event6GetBitEj.c
+++ b/src/_ZN5Event6GetBitEj.c
@@ -1,15 +1,15 @@
 #include "types.h"
 /* Event::GetBit(u32 bit) at 0x02029ee0
  * Free function in namespace Event (no `this`). Returns nonzero if bit `bit`
- * is set in the global event bitfield EVENT_FIELD. Declared in SM64DS_2.h:
+ * is set in the global event bitfield data_0209f34c. Declared in SM64DS_2.h:
  *   namespace Event { u32 GetBit(u32 bit); ... }
  *
- * Reloc resolves to EVENT_FIELD at 0x0209f34c (symbols.txt: data_0209f34c).
+ * Reloc resolves to data_0209f34c at 0x0209f34c (symbols.txt: data_0209f34c).
  * The `1 << n` shift is load-bearing.
  */
-extern s32 EVENT_FIELD; /* 0x0209f34c */
+extern s32 data_0209f34c; /* 0x0209f34c */
 
 s32 _ZN5Event6GetBitEj(u32 bit)
 {
-    return EVENT_FIELD & (1 << bit);
+    return data_0209f34c & (1 << bit);
 }

--- a/src/_ZN5Event6SetBitEj.c
+++ b/src/_ZN5Event6SetBitEj.c
@@ -1,15 +1,15 @@
 #include "types.h"
 /* Event::SetBit(u32 bit) at 0x02029ec4
  * Free function in namespace Event (no `this`). Sets bit `bit` in the global
- * event bitfield EVENT_FIELD. Declared in SM64DS_2.h:
+ * event bitfield data_0209f34c. Declared in SM64DS_2.h:
  *   namespace Event { void SetBit(u32 bit); ... }
  *
- * Reloc resolves to EVENT_FIELD at 0x0209f34c (symbols.txt: data_0209f34c).
+ * Reloc resolves to data_0209f34c at 0x0209f34c (symbols.txt: data_0209f34c).
  * The `1 << n` shift is load-bearing.
  */
-extern s32 EVENT_FIELD; /* 0x0209f34c */
+extern s32 data_0209f34c; /* 0x0209f34c */
 
 void _ZN5Event6SetBitEj(u32 bit)
 {
-    EVENT_FIELD |= 1 << bit;
+    data_0209f34c |= 1 << bit;
 }

--- a/src/_ZN5FaderD1Ev.c
+++ b/src/_ZN5FaderD1Ev.c
@@ -6,9 +6,9 @@
  * (slot 0x0) and returns. The currInterp/speed Fix12i members need no teardown.
  */
 
-extern int _ZTV5Fader[];  /* vtable for Fader */
+extern int data_0208eafc[];  /* vtable for Fader */
 
 void _ZN5FaderD1Ev(int *self)
 {
-    self[0] = (int)_ZTV5Fader;  /* +0x00 vptr */
+    self[0] = (int)data_0208eafc;  /* +0x00 vptr */
 }

--- a/src/_ZN5Model17LoadTextureToVramEPcj.c
+++ b/src/_ZN5Model17LoadTextureToVramEPcj.c
@@ -9,7 +9,7 @@ u32 _ZN5Model17LoadTextureToVramEPcj(char* texData, u32 size) {
     u32 vramOffset = _ZN5Model13GetVramOffsetEj(size);
     _ZN2GX12BeginLoadTexEv();
     _ZN2GX7LoadTexEPKvjj((const void*)texData, vramOffset, size);
-    VRAM_Tex_Size += size;
+    data_020a4be4 += size;
     _ZN2GX10EndLoadTexEv();
     return vramOffset;
 }

--- a/src/_ZN5Model6RenderEPK7Vector3.c
+++ b/src/_ZN5Model6RenderEPK7Vector3.c
@@ -1,5 +1,5 @@
 /* Model::Render at 0x02016b78
- * Multiplies this->mat4x3 by VIEW_MATRIX_ASR_3 into a stack-local temp matrix,
+ * Multiplies this->mat4x3 by data_0209b3ec into a stack-local temp matrix,
  * then calls ModelComponents::Render(&this->data, temp, scale).
  */
 
@@ -26,13 +26,13 @@ struct Model {
     struct Matrix4x3 *unkMatPtr; /* 0x4c */
 };
 
-extern struct Matrix4x3 VIEW_MATRIX_ASR_3;  /* 0x0209b3ec */
+extern struct Matrix4x3 data_0209b3ec;  /* 0x0209b3ec */
 extern void MulMat4x3Mat4x3(const struct Matrix4x3 *m1, const struct Matrix4x3 *m0, struct Matrix4x3 *mF); /* 0x02052914 */
 extern void _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(struct ModelComponents *thiz, struct Matrix4x3 *mat, const struct Vector3 *scale); /* 0x020443c8 */
 
 void _ZN5Model6RenderEPK7Vector3(struct Model *thiz, const struct Vector3 *scale)
 {
     struct Matrix4x3 temp;
-    MulMat4x3Mat4x3(&thiz->mat4x3, &VIEW_MATRIX_ASR_3, &temp);
+    MulMat4x3Mat4x3(&thiz->mat4x3, &data_0209b3ec, &temp);
     _ZN15ModelComponents6RenderEP9Matrix4x3P7Vector3(&thiz->data, &temp, scale);
 }

--- a/src/_ZN5ModelC1Ev.c
+++ b/src/_ZN5ModelC1Ev.c
@@ -30,14 +30,14 @@ struct Model {
 };
 
 extern u32 _ZTV5Model[];
-extern struct Matrix4x3 _ZN9Matrix3x38IDENTITYE;
+extern struct Matrix4x3 data_02082128;
 extern void _ZN9ModelBaseC1Ev(struct ModelBase *thiz);
 
 struct Model *_ZN5ModelC1Ev(struct Model *thiz)
 {
     _ZN9ModelBaseC1Ev((struct ModelBase *)thiz);
-    thiz->vtable = _ZTV5Model + 2;
+    thiz->vtable = _ZTV5Model;
     thiz->unkMatPtr = 0;
-    thiz->mat4x3 = _ZN9Matrix3x38IDENTITYE;
+    thiz->mat4x3 = data_02082128;
     return thiz;
 }

--- a/src/_ZN5ModelC2Ev.c
+++ b/src/_ZN5ModelC2Ev.c
@@ -29,14 +29,14 @@ struct Model {
 };
 
 extern u32 _ZTV5Model[];
-extern struct Matrix4x3 _ZN9Matrix3x38IDENTITYE;
+extern struct Matrix4x3 data_02082128;
 extern void _ZN9ModelBaseC1Ev(struct ModelBase *thiz);
 
 struct Model *_ZN5ModelC2Ev(struct Model *thiz)
 {
     _ZN9ModelBaseC1Ev((struct ModelBase *)thiz);
-    thiz->vtable = _ZTV5Model + 2;
+    thiz->vtable = _ZTV5Model;
     thiz->unkMatPtr = 0;
-    thiz->mat4x3 = _ZN9Matrix3x38IDENTITYE;
+    thiz->mat4x3 = data_02082128;
     return thiz;
 }

--- a/src/_ZN5Scene14StartSceneFadeEjjt.c
+++ b/src/_ZN5Scene14StartSceneFadeEjjt.c
@@ -11,10 +11,10 @@ struct FaderColor {
     u16 color;        // 0xc
 };
 
-extern struct FaderColor DEFAULT_SCENE_FADER;
+extern struct FaderColor data_0209f5e8;
 
 void _ZN5Scene14StartSceneFadeEjjt(u32 actorID, u32 param, u16 fadeColor) {
     if (_ZN5Scene15SetSceneToSpawnEjj(actorID, param)) {
-        DEFAULT_SCENE_FADER.color = fadeColor;
+        data_0209f5e8.color = fadeColor;
     }
 }

--- a/src/_ZN5Scene19ResetFadersAndSoundEv.c
+++ b/src/_ZN5Scene19ResetFadersAndSoundEv.c
@@ -3,21 +3,21 @@ typedef struct ActorBase { char pad[0]; } ActorBase;
 typedef struct FaderBrightness { char pad[0]; } FaderBrightness;
 typedef struct Scene { char pad[0]; } Scene;
 
-extern ActorBase* ROOT_ACTOR_BASE;
-extern FaderBrightness DEFAULT_SCENE_FADER;
-extern u32 DAT_0209f1e4;
+extern ActorBase* data_0209f5c0;
+extern FaderBrightness data_0209f5e8;
+extern u32 data_0209f1e4;
 
 extern int _ZN9ActorBase19BeforeInitResourcesEv(Scene* self);
 extern void _ZN5Scene9SetFadersEP15FaderBrightness(FaderBrightness* f);
 extern void func_02011b7c(void);
 
 int _ZN5Scene19ResetFadersAndSoundEv(Scene* self) {
-    ROOT_ACTOR_BASE = (ActorBase*)self;
+    data_0209f5c0 = (ActorBase*)self;
     if (_ZN9ActorBase19BeforeInitResourcesEv(self) == 0) {
         return 0;
     }
-    _ZN5Scene9SetFadersEP15FaderBrightness(&DEFAULT_SCENE_FADER);
-    DAT_0209f1e4 = 0;
+    _ZN5Scene9SetFadersEP15FaderBrightness(&data_0209f5e8);
+    data_0209f1e4 = 0;
     func_02011b7c();
     return 1;
 }

--- a/src/_ZN5Scene20SetAndStopColorFaderEv.c
+++ b/src/_ZN5Scene20SetAndStopColorFaderEv.c
@@ -4,10 +4,10 @@ typedef struct FaderBrightness {
     u32 state;  /* offset 8 */
 } FaderBrightness;
 
-extern FaderBrightness DEFAULT_SCENE_FADER;
+extern FaderBrightness data_0209f5e8;
 extern void _ZN5Scene9SetFadersEP15FaderBrightness(FaderBrightness* f);
 
 void _ZN5Scene20SetAndStopColorFaderEv(void) {
-    _ZN5Scene9SetFadersEP15FaderBrightness(&DEFAULT_SCENE_FADER);
-    DEFAULT_SCENE_FADER.state = 0;
+    _ZN5Scene9SetFadersEP15FaderBrightness(&data_0209f5e8);
+    data_0209f5e8.state = 0;
 }

--- a/src/_ZN5Scene22BeforeCleanupResourcesEv.c
+++ b/src/_ZN5Scene22BeforeCleanupResourcesEv.c
@@ -6,12 +6,12 @@ struct Scene {
 extern int _ZN9ActorBase22BeforeCleanupResourcesEv(struct Scene *thiz);
 extern void func_02011974(void *arg);
 
-extern void *g_0209b53c;
+extern void *data_0209b53c;
 
 int _ZN5Scene22BeforeCleanupResourcesEv(struct Scene *thiz)
 {
     if (!_ZN9ActorBase22BeforeCleanupResourcesEv(thiz))
         return 0;
-    func_02011974(&g_0209b53c);
+    func_02011974(&data_0209b53c);
     return 1;
 }

--- a/src/_ZN5SceneD1Ev.c
+++ b/src/_ZN5SceneD1Ev.c
@@ -1,5 +1,5 @@
-extern void *_ZTV5Scene;
-extern void *_ZTV12ActorDerived;
+extern void *_ZTV5Stage;
+extern void *data_0208e4b8;
 extern void *_ZN9ActorBaseD2Ev(void *self);
 
 struct Scene {
@@ -8,8 +8,8 @@ struct Scene {
 
 void *_ZN5SceneD1Ev(struct Scene *self)
 {
-    self->vtable = &_ZTV5Scene;
-    self->vtable = &_ZTV12ActorDerived;
+    self->vtable = &_ZTV5Stage;
+    self->vtable = &data_0208e4b8;
     _ZN9ActorBaseD2Ev(self);
     return self;
 }

--- a/src/_ZN5SceneD2Ev.c
+++ b/src/_ZN5SceneD2Ev.c
@@ -1,6 +1,6 @@
-extern void *_ZTV9BootScene;
-extern void *_ZTV5Scene;
-extern void *_ZTV12ActorDerived;
+extern void *data_02091528;
+extern void *_ZTV5Stage;
+extern void *data_0208e4b8;
 extern void *_ZN9ActorBaseD2Ev(void *self);
 
 struct Scene {
@@ -9,9 +9,9 @@ struct Scene {
 
 void *_ZN5SceneD2Ev(struct Scene *self)
 {
-    self->vtable = &_ZTV9BootScene;
-    self->vtable = &_ZTV5Scene;
-    self->vtable = &_ZTV12ActorDerived;
+    self->vtable = &data_02091528;
+    self->vtable = &_ZTV5Stage;
+    self->vtable = &data_0208e4b8;
     _ZN9ActorBaseD2Ev(self);
     return self;
 }

--- a/src/_ZN5Sound21UnsetPlayerVoiceGroupEv.c
+++ b/src/_ZN5Sound21UnsetPlayerVoiceGroupEv.c
@@ -8,9 +8,9 @@
  * raw data_0209b478 label.
  */
 
-extern unsigned char PLAYER_VOICE_GROUP; /* 0x0209b478 */
+extern unsigned char data_0209b478; /* 0x0209b478 */
 
 void _ZN5Sound21UnsetPlayerVoiceGroupEv(void)
 {
-    PLAYER_VOICE_GROUP = 0;
+    data_0209b478 = 0;
 }

--- a/src/_ZN5Stage10LoadSkyboxEv.c
+++ b/src/_ZN5Stage10LoadSkyboxEv.c
@@ -13,7 +13,7 @@ extern void* _Znwj(u32 size);
 extern void* _ZN5ModelC1Ev(void* this);
 extern void _ZN5Model14LoadAndSetFileEtii(void* this, u16 fileID, s32 a, s32 b);
 
-extern u16 gSkyboxFileTable[];
+extern u16 data_02075620[];
 
 void _ZN5Stage10LoadSkyboxEv(Stage* self) {
     u32 skyboxID = _ZN5Stage11GetSkyboxIDEv(self);
@@ -23,6 +23,6 @@ void _ZN5Stage10LoadSkyboxEv(Stage* self) {
         model = (Model*)_ZN5ModelC1Ev(model);
     }
     self->skyboxModel = model;
-    u16 fileID = gSkyboxFileTable[skyboxID - 1];
+    u16 fileID = data_02075620[skyboxID - 1];
     _ZN5Model14LoadAndSetFileEtii(self->skyboxModel, fileID, 0, 2);
 }

--- a/src/_ZN5StageD0Ev.c
+++ b/src/_ZN5StageD0Ev.c
@@ -1,14 +1,14 @@
 struct Stage { void **vtable; };
 struct Heap;
 extern void *data_020921c0[];  /* the table this dtor actually installs; not _ZTV5Stage (0x02092680) */
-extern void *_ZTV5Scene[];
-extern void *_ZTV12ActorDerived[];
+extern void *_ZTV5Stage[];
+extern void *data_0208e4b8[];
 extern void _ZN12MeshColliderD1Ev(void *thiz);
 extern void _ZN5ModelD1Ev(void *thiz);
 extern void _ZN8Particle10SysTrackerD1Ev(void *thiz);
 extern void _ZN9ActorBaseD2Ev(struct Stage *thiz);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);
-extern struct Heap *_ZN6Memory11gameHeapPtrE;
+extern struct Heap *data_020a0eac;
 
 struct Stage *_ZN5StageD0Ev(struct Stage *thiz)
 {
@@ -16,9 +16,9 @@ struct Stage *_ZN5StageD0Ev(struct Stage *thiz)
     _ZN12MeshColliderD1Ev((char *)thiz + 0x91c);
     _ZN5ModelD1Ev((char *)thiz + 0x86c);
     _ZN8Particle10SysTrackerD1Ev((char *)thiz + 0x50);
-    thiz->vtable = (void **)_ZTV5Scene;
-    thiz->vtable = (void **)_ZTV12ActorDerived;
+    thiz->vtable = (void **)_ZTV5Stage;
+    thiz->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
-    _ZN6Memory10DeallocateEPvP4Heap(thiz, _ZN6Memory11gameHeapPtrE);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;
 }

--- a/src/_ZN5StageD2Ev.c
+++ b/src/_ZN5StageD2Ev.c
@@ -1,7 +1,7 @@
 struct Stage { void **vtable; };
 extern void *data_020921c0[];  /* the table this dtor actually installs; not _ZTV5Stage (0x02092680) */
-extern void *_ZTV5Scene[];
-extern void *_ZTV12ActorDerived[];
+extern void *_ZTV5Stage[];
+extern void *data_0208e4b8[];
 extern void _ZN12MeshColliderD1Ev(void *thiz);
 extern void _ZN5ModelD1Ev(void *thiz);
 extern void _ZN8Particle10SysTrackerD1Ev(void *thiz);
@@ -13,8 +13,8 @@ struct Stage *_ZN5StageD2Ev(struct Stage *thiz)
     _ZN12MeshColliderD1Ev((char *)thiz + 0x91c);
     _ZN5ModelD1Ev((char *)thiz + 0x86c);
     _ZN8Particle10SysTrackerD1Ev((char *)thiz + 0x50);
-    thiz->vtable = (void **)_ZTV5Scene;
-    thiz->vtable = (void **)_ZTV12ActorDerived;
+    thiz->vtable = (void **)_ZTV5Stage;
+    thiz->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN6CameraC1Ev.c
+++ b/src/_ZN6CameraC1Ev.c
@@ -11,7 +11,7 @@ typedef struct {
     Matrix4x3 mat; /* offset 0x50 */
 } Camera;
 
-extern u32 _ZTV12ActorDerived;
+extern u32 data_0208e4b8;
 extern u32 _ZTV4View;
 extern u32 _ZTV6Camera;
 
@@ -23,7 +23,7 @@ Camera* _ZN6CameraC1Ev(Camera* this) {
     this = _ZN9ActorBasenwEj(0x1a8);
     if (this != 0) {
         _ZN9ActorBaseC1Ev(this);
-        this->vtable = &_ZTV12ActorDerived;
+        this->vtable = &data_0208e4b8;
         this->vtable = &_ZTV4View;
         Matrix4x3_LoadIdentity(&this->mat);
         this->vtable = &_ZTV6Camera;

--- a/src/_ZN6CameraD0Ev.c
+++ b/src/_ZN6CameraD0Ev.c
@@ -16,19 +16,19 @@ struct Heap;
  *   0x0203c1e8 = Memory::Deallocate(void*, Heap*)
  *   0x020a0eac = Memory::gameHeapPtr    (Heap*)
  * The three vtable literals are _ZTV6Camera / _ZTV4View / _ZTV12ActorDerived. */
-extern void ActorBaseDtor(struct Camera *self);                 /* _ZN9ActorBaseD2Ev */
-extern void Memory_Deallocate(void *ptr, struct Heap *heap);    /* _ZN6Memory10DeallocateEPvP4Heap */
+extern void _ZN9ActorBaseD2Ev(struct Camera *self);                 /* _ZN9ActorBaseD2Ev */
+extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);    /* _ZN6Memory10DeallocateEPvP4Heap */
 
-extern void *Camera_vtable;        /* _ZTV6Camera        */
-extern void *View_vtable;          /* _ZTV4View          */
-extern void *ActorDerived_vtable;  /* _ZTV12ActorDerived */
-extern struct Heap *Memory_gameHeapPtr; /* _ZN6Memory11gameHeapPtrE */
+extern void *_ZTV6Camera;        /* _ZTV6Camera        */
+extern void *_ZTV4View;          /* _ZTV4View          */
+extern void *data_0208e4b8;  /* _ZTV12ActorDerived */
+extern struct Heap *data_020a0eac; /* _ZN6Memory11gameHeapPtrE */
 
 struct Camera *_ZN6CameraD0Ev(struct Camera *self) {
-    self->vtable = &Camera_vtable;
-    self->vtable = &View_vtable;
-    self->vtable = &ActorDerived_vtable;
-    ActorBaseDtor(self);
-    Memory_Deallocate(self, Memory_gameHeapPtr);
+    self->vtable = &_ZTV6Camera;
+    self->vtable = &_ZTV4View;
+    self->vtable = &data_0208e4b8;
+    _ZN9ActorBaseD2Ev(self);
+    _ZN6Memory10DeallocateEPvP4Heap(self, data_020a0eac);
     return self;
 }

--- a/src/_ZN6CameraD1Ev.c
+++ b/src/_ZN6CameraD1Ev.c
@@ -4,7 +4,7 @@
  *   Camera : View : ActorDerived : ActorBase
  *     0x02086f84 = _ZTV6Camera
  *     0x02092720 = _ZTV4View
- *     0x0208e4b8 = _ZTV12ActorDerived
+ *     0x0208e4b8 = data_0208e4b8
  *   bl 0x02043d48 = _ZN9ActorBaseD2Ev (ActorBase::~ActorBase)
  *
  * CodeWarrior virtual-destructor codegen: as the dtor runs, the vptr at
@@ -20,7 +20,7 @@ struct Camera {
 /* Vtable symbols (relocations are wildcarded by the matcher). */
 extern void *_ZTV6Camera[];
 extern void *_ZTV4View[];
-extern void *_ZTV12ActorDerived[];
+extern void *data_0208e4b8[];
 
 /* Immediate base destructor. */
 extern void _ZN9ActorBaseD2Ev(struct Camera *thiz);
@@ -29,7 +29,7 @@ struct Camera *_ZN6CameraD1Ev(struct Camera *thiz)
 {
     thiz->vtable = (void **)_ZTV6Camera;
     thiz->vtable = (void **)_ZTV4View;
-    thiz->vtable = (void **)_ZTV12ActorDerived;
+    thiz->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
     return thiz;
 }

--- a/src/_ZN6Memory8AllocateEjiP4Heap.c
+++ b/src/_ZN6Memory8AllocateEjiP4Heap.c
@@ -10,11 +10,11 @@ struct Heap {
 };
 
 extern void* _ZN4Heap8AllocateEji(struct Heap* self, u32 size, s32 align);
-extern struct Heap* _ZN6Memory14defaultHeapPtrE;
+extern struct Heap* data_020a0ea0;
 
 void* _ZN6Memory8AllocateEjiP4Heap(u32 size, s32 align, struct Heap* heap) {
     if (!heap) {
-        heap = _ZN6Memory14defaultHeapPtrE;
+        heap = data_020a0ea0;
     }
     return _ZN4Heap8AllocateEji(heap, size, align);
 }

--- a/src/_ZN7Message11PrepareTalkEv.c
+++ b/src/_ZN7Message11PrepareTalkEv.c
@@ -3,12 +3,12 @@
  * Message::PrepareTalk - ducks music volume to 0x40 at rate 0xc999/4096,
  * sets the "in talk" flag at 0x0209d664 to 1.
  */
-extern u8 unk_0209d664;  /* 0x0209d664 */
+extern u8 data_0209d664;  /* 0x0209d664 */
 
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, Fix12i speed);
 
 void _ZN7Message11PrepareTalkEv(void)
 {
     _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x40, 0x0000c999);
-    unk_0209d664 = 1;
+    data_0209d664 = 1;
 }

--- a/src/_ZN7Message7EndTalkEv.c
+++ b/src/_ZN7Message7EndTalkEv.c
@@ -3,12 +3,12 @@
  * Message::EndTalk - restores music volume to 0x7f at rate 0x64cc/4096,
  * clears the "in talk" flag at 0x0209d664.
  */
-extern u8 unk_0209d664;  /* 0x0209d664 */
+extern u8 data_0209d664;  /* 0x0209d664 */
 
 extern void _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(u32 vol, Fix12i speed);
 
 void _ZN7Message7EndTalkEv(void)
 {
     _ZN5Sound17ChangeMusicVolumeEj5Fix12IiE(0x7f, 0x000064cc);
-    unk_0209d664 = 0;
+    data_0209d664 = 0;
 }

--- a/src/_ZN8CapEnemy14UnloadCapModelEv.c
+++ b/src/_ZN8CapEnemy14UnloadCapModelEv.c
@@ -8,11 +8,11 @@ struct SharedFilePtr { u16 fileID; u8 numRefs; char* filePtr; };
 
 extern void _ZN13SharedFilePtr7ReleaseEv(struct SharedFilePtr *self);
 
-extern struct SharedFilePtr *CapModelFiles[6];
+extern struct SharedFilePtr *data_ov002_020ff028[6];
 
 void _ZN8CapEnemy14UnloadCapModelEv(struct CapEnemy *this)
 {
     s32 idx = this->capID & 7;
     if (idx >= 6) return;
-    _ZN13SharedFilePtr7ReleaseEv(CapModelFiles[idx]);
+    _ZN13SharedFilePtr7ReleaseEv(data_ov002_020ff028[idx]);
 }

--- a/src/_ZN8CapEnemyC2Ev.c
+++ b/src/_ZN8CapEnemyC2Ev.c
@@ -23,15 +23,15 @@ struct CapEnemy {
     struct CapIcon capIcon;  /* 0x164 */
 };
 
-extern u32 _ZTV8CapEnemy[];
+extern u32 data_ov002_02108284[];
 extern void _ZN5EnemyC2Ev(struct CapEnemy*);
 extern void _ZN5ModelC1Ev(struct Model*);
-extern void _ZN7CapIconC1Ev(struct CapIcon*);
+extern void data_ov000_020ab3c4(struct CapIcon*);
 
 struct CapEnemy* _ZN8CapEnemyC2Ev(struct CapEnemy* this) {
     _ZN5EnemyC2Ev(this);
-    this->vtable = (u32)_ZTV8CapEnemy;
+    this->vtable = (u32)data_ov002_02108284;
     _ZN5ModelC1Ev(&this->capModel);
-    _ZN7CapIconC1Ev(&this->capIcon);
+    data_ov000_020ab3c4(&this->capIcon);
     return this;
 }

--- a/src/_ZN8CapEnemyD2Ev.c
+++ b/src/_ZN8CapEnemyD2Ev.c
@@ -1,7 +1,7 @@
 /* CapEnemy::~CapEnemy (D2/base) at 0x0200651c
  *
  * CapEnemy : Enemy.  Members: capModel (Model) @0x114, capIcon (CapIcon) @0x164.
- *   [this+0] = _ZTV8CapEnemy (0x02108284)
+ *   [this+0] = data_ov002_02108284 (0x02108284)
  *   CapIcon::~CapIcon(this+0x164)         (0x020ab3a0)
  *   Model::~Model(this+0x114)             (0x02016d20, D1)
  *   Enemy::~Enemy(this)                   (0x020aed18, base dtor)
@@ -15,16 +15,16 @@ struct CapEnemy {
     char capIcon[0x1c];     /* 0x164 */
 };
 
-extern void *_ZTV8CapEnemy[];
+extern void *data_ov002_02108284[];
 
-extern void _ZN7CapIconD2Ev(void *icon);             /* 0x020ab3a0 */
+extern void func_ov001_020ab3a0(void *icon);             /* 0x020ab3a0 */
 extern void *_ZN5ModelD1Ev(void *model);             /* 0x02016d20 */
 extern void *func_ov002_020aed18(struct CapEnemy *thiz);   /* 0x020aed18 */
 
 struct CapEnemy *_ZN8CapEnemyD2Ev(struct CapEnemy *thiz)
 {
-    thiz->vtable = (void **)_ZTV8CapEnemy;
-    _ZN7CapIconD2Ev(thiz->capIcon);
+    thiz->vtable = (void **)data_ov002_02108284;
+    func_ov001_020ab3a0(thiz->capIcon);
     _ZN5ModelD1Ev(thiz->capModel);
     func_ov002_020aed18(thiz);
     return thiz;

--- a/src/_ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb.c
+++ b/src/_ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb.c
@@ -29,7 +29,7 @@ typedef struct ParticleSys {
     ParticleList particleList; /* 0x08 */
 } ParticleSys;
 
-extern s32 WATER_HEIGHT;
+extern s32 data_0209f32c;
 
 extern int _ZN8Particle14SimpleCallback8OnUpdateERNS_6SystemEb(void* cb, ParticleSys* sys, int active);
 
@@ -39,7 +39,7 @@ int _ZN8Particle22FitWaterSimpleCallback8OnUpdateERNS_6SystemEb(void* cb, Partic
     Particle* p;
 
     p = sys->particleList.first;
-    waterAsr3 = WATER_HEIGHT >> 3;
+    waterAsr3 = data_0209f32c >> 3;
     if (p != 0)
     {
         do

--- a/src/_ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj.c
+++ b/src/_ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -9,7 +9,7 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 u32 _ZN8Particle6System10NewWeatherEjj5Fix12IiES2_S2_PK11Vector3_16fj(
     u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, const void* dir, u8 numWeatherEffectsNow)
 {
-    char* callback = PARTICLE_SYS_TRACKER + 0x810;
+    char* callback = data_0209ee74 + 0x810;
     *(u8*)(callback + 4) = numWeatherEffectsNow;
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir, (void*)callback);

--- a/src/_ZN8Particle6System12FromUniqueIDEj.c
+++ b/src/_ZN8Particle6System12FromUniqueIDEj.c
@@ -14,12 +14,12 @@ struct ParticleSysEntry {
     void* system; // at +0xc: pointer to the Particle::System
 };
 
-extern struct ParticleSysTracker* PARTICLE_SYS_TRACKER;
+extern struct ParticleSysTracker* data_0209ee74;
 
 extern struct ParticleSysEntry* _ZNK8Particle10SysTracker8Contents8FindDataEj(void* contents, u32 uniqueID);
 
 void* _ZN8Particle6System12FromUniqueIDEj(u32 uniqueID) {
     struct ParticleSysEntry* entry = _ZNK8Particle10SysTracker8Contents8FindDataEj(
-        (unsigned char*)PARTICLE_SYS_TRACKER + 8, uniqueID);
+        (unsigned char*)data_0209ee74 + 8, uniqueID);
     return entry->system;
 }

--- a/src/_ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_.c
+++ b/src/_ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,11 +8,11 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void _ZN8Particle6System12NewBigSplashE5Fix12IiES2_S2_(Fix12i x, Fix12i y, Fix12i z)
 {
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x768) =
+    *(u32*)(data_0209ee74 + 0x768) =
         _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-            *(u32*)(PARTICLE_SYS_TRACKER + 0x768),
+            *(u32*)(data_0209ee74 + 0x768),
             0xdd,
             x, y, z,
             (void*)0,
-            (void*)(PARTICLE_SYS_TRACKER + 0x76c));
+            (void*)(data_0209ee74 + 0x76c));
 }

--- a/src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c
+++ b/src/_ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -11,5 +11,5 @@ u32 _ZN8Particle6System17NewUnkCallback818Ejj5Fix12IiES2_S2_PK11Vector3_16f(
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (void*)(PARTICLE_SYS_TRACKER + 0x818));
+        (void*)(data_0209ee74 + 0x818));
 }

--- a/src/_ZN8Particle6System9NewRippleE5Fix12IiES2_S2_.c
+++ b/src/_ZN8Particle6System9NewRippleE5Fix12IiES2_S2_.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,13 +8,13 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 u32 _ZN8Particle6System9NewRippleE5Fix12IiES2_S2_(Fix12i x, Fix12i y, Fix12i z)
 {
-    char* base = PARTICLE_SYS_TRACKER;
+    char* base = data_0209ee74;
     u32 result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(base + 0x78c),
         0x109,
         x, y, z,
         (void*)0,
         base + 0x790);
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x78c) = result;
+    *(u32*)(data_0209ee74 + 0x78c) = result;
     return result;
 }

--- a/src/_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_.c
+++ b/src/_ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_.c
@@ -9,7 +9,7 @@ struct ParticleSysTracker {
     void* manager; // at +4
 };
 
-extern struct ParticleSysTracker* PARTICLE_SYS_TRACKER;
+extern struct ParticleSysTracker* data_0209ee74;
 extern void* _ZN8Particle7Manager9AddSystemEiR7Vector3(void* mgr, u32 uniqueID, Vector3* pos);
 
 void* _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 uniqueID, s32 x, s32 y, s32 z) {
@@ -20,6 +20,6 @@ void* _ZN8Particle6System9NewSimpleEj5Fix12IiES2_S2_(u32 uniqueID, s32 x, s32 y,
     pos.x = xv;
     pos.y = yv;
     pos.z = zv;
-    void* mgr = PARTICLE_SYS_TRACKER->manager;
+    void* mgr = data_0209ee74->manager;
     return _ZN8Particle7Manager9AddSystemEiR7Vector3(mgr, uniqueID, &pos);
 }

--- a/src/_ZN8Particle7Texture12AllocTexVramEjb.c
+++ b/src/_ZN8Particle7Texture12AllocTexVramEjb.c
@@ -7,8 +7,8 @@
 #include "Particle__Texture.h"
 u32 _ZN8Particle7Texture12AllocTexVramEjb(u32 size, int isTexel4x4) {
     if (isTexel4x4) {
-        u32 old = unk_0209ee88;
-        unk_0209ee88 = old + size;
+        u32 old = data_0209ee88;
+        data_0209ee88 = old + size;
         return old;
     } else {
         return _ZN5Model13GetVramOffsetEj(size);

--- a/src/_ZN8SaveData13GetCoinRecordEj.c
+++ b/src/_ZN8SaveData13GetCoinRecordEj.c
@@ -11,9 +11,9 @@
  * symbol is not yet in symbols.txt (wildcard pooled-global reloc, so this
  * extern name is not byte-verified). Kept as a named u8[] over data_0209cad2.
  */
-extern u8 SAVE_DATA_COIN_RECORDS[]; /* &SAVE_DATA.coinRecords[0], 0x0209cad2 */
+extern u8 data_0209cad2[]; /* &SAVE_DATA.coinRecords[0], 0x0209cad2 */
 
 u8 _ZN8SaveData13GetCoinRecordEj(u32 courseID)
 {
-    return SAVE_DATA_COIN_RECORDS[courseID];
+    return data_0209cad2[courseID];
 }

--- a/src/_ZN8SaveData13PlayerLoseCapEv.c
+++ b/src/_ZN8SaveData13PlayerLoseCapEv.c
@@ -10,11 +10,11 @@ struct SaveData {
 };
 
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void);
-extern struct SaveData SAVE_DATA;
+extern struct SaveData data_0209caa0;
 
 void _ZN8SaveData13PlayerLoseCapEv(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return;
-    SAVE_DATA.flags1 = SAVE_DATA.flags1 | (0x1000000u << SAVE_DATA.currentCharacter);
+    data_0209caa0.flags1 = data_0209caa0.flags1 | (0x1000000u << data_0209caa0.currentCharacter);
 }

--- a/src/_ZN8SaveData15SaveCurrentFileEv.c
+++ b/src/_ZN8SaveData15SaveCurrentFileEv.c
@@ -4,15 +4,15 @@
  */
 struct MinigameSaveData { char data[0x2e4]; };
 
-extern u8 SAVE_DATA[];               /* 0x0209caa0 */
-extern struct MinigameSaveData SAVE_MG_DATA;  /* 0x0209cae4 = &SAVE_DATA[0x44] */
+extern u8 data_0209caa0[];               /* 0x0209caa0 */
+extern struct MinigameSaveData data_0209cae4;  /* 0x0209cae4 = &data_0209caa0[0x44] */
 
 extern int _ZN8SaveData8SaveFileEjP12FileSaveData(u32 fileID, u8* data);
 extern int _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(struct MinigameSaveData* data);
 
 int _ZN8SaveData15SaveCurrentFileEv(void)
 {
-    if (!_ZN8SaveData8SaveFileEjP12FileSaveData(SAVE_DATA[0x328], SAVE_DATA))
+    if (!_ZN8SaveData8SaveFileEjP12FileSaveData(data_0209caa0[0x328], data_0209caa0))
         return 0;
-    return _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(&SAVE_MG_DATA);
+    return _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(&data_0209cae4);
 }

--- a/src/_ZN8SaveData16EraseAllSaveDataEv.c
+++ b/src/_ZN8SaveData16EraseAllSaveDataEv.c
@@ -4,7 +4,7 @@
  * Returns OR of all operation results (0 = all succeeded).
  */
 
-extern unsigned char SAVE_DATA[];
+extern unsigned char data_0209caa0[];
 extern u32 _ZN8SaveData13EraseSaveFileEjPc(u32 fileID, char *saveArea);
 extern void _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData(void *mgData);
 extern u32 _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(void *mgData);
@@ -12,9 +12,9 @@ extern u32 _ZN8SaveData13SaveMinigamesEP16MinigameSaveData(void *mgData);
 u32 _ZN8SaveData16EraseAllSaveDataEv(void)
 {
     u32 r4;
-    r4 = _ZN8SaveData13EraseSaveFileEjPc(0, (char *)SAVE_DATA);
-    r4 |= _ZN8SaveData13EraseSaveFileEjPc(1, (char *)SAVE_DATA);
-    r4 |= _ZN8SaveData13EraseSaveFileEjPc(2, (char *)SAVE_DATA);
-    _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData((void *)(SAVE_DATA + 0x44));
-    return r4 | _ZN8SaveData13SaveMinigamesEP16MinigameSaveData((void *)(SAVE_DATA + 0x44));
+    r4 = _ZN8SaveData13EraseSaveFileEjPc(0, (char *)data_0209caa0);
+    r4 |= _ZN8SaveData13EraseSaveFileEjPc(1, (char *)data_0209caa0);
+    r4 |= _ZN8SaveData13EraseSaveFileEjPc(2, (char *)data_0209caa0);
+    _ZN8SaveData18SetDefaultValuesMgEP16MinigameSaveData((void *)(data_0209caa0 + 0x44));
+    return r4 | _ZN8SaveData13SaveMinigamesEP16MinigameSaveData((void *)(data_0209caa0 + 0x44));
 }

--- a/src/_ZN8SaveData16HasPlayerLostCapEv.c
+++ b/src/_ZN8SaveData16HasPlayerLostCapEv.c
@@ -10,11 +10,11 @@ struct SaveData {
 };
 
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void);
-extern struct SaveData SAVE_DATA;
+extern struct SaveData data_0209caa0;
 
 int _ZN8SaveData16HasPlayerLostCapEv(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return 0;
-    return SAVE_DATA.flags1 & (0x1000000u << SAVE_DATA.currentCharacter);
+    return data_0209caa0.flags1 & (0x1000000u << data_0209caa0.currentCharacter);
 }

--- a/src/_ZN8SaveData17SetCharacterIntroEi.c
+++ b/src/_ZN8SaveData17SetCharacterIntroEi.c
@@ -3,11 +3,11 @@
 #include "SaveData.h"
 /* SaveData::SetCharacterIntro(s32 character) at 0x02013910
  * Static method (no `this`); marks an intro/flag bit as seen.
- * Sets bit `character` in the u32 SAVE_DATA.flags2 (the FileSaveData word at
+ * Sets bit `character` in the u32 data_0209caa0.flags2 (the FileSaveData word at
  * +0x8). Per Save.h flags2: bit 0 = Mario intro, bit 1 = Luigi intro,
  * bit 2 = Wario intro, ... etc.
  *
- * The reloc resolves to SAVE_DATA base 0x0209caa0; flags2 is the word at
+ * The reloc resolves to data_0209caa0 base 0x0209caa0; flags2 is the word at
  * index [2] (offset +0x8). The friendly symbol is not yet in symbols.txt
  * (wildcard pooled-global reloc, name not byte-verified). The [2] index and
  * `1 << n` shift are load-bearing -- changing either breaks the match.
@@ -15,9 +15,9 @@
 
 typedef int s32;
 
-extern s32 SAVE_DATA[]; /* &SAVE_DATA as s32[]; [2] == flags2, base 0x0209caa0 */
+extern s32 data_0209caa0[]; /* &data_0209caa0 as s32[]; [2] == flags2, base 0x0209caa0 */
 
 void _ZN8SaveData17SetCharacterIntroEi(s32 character)
 {
-    SAVE_DATA[2] |= 1 << character; /* flags2 |= 1 << character */
+    data_0209caa0[2] |= 1 << character; /* flags2 |= 1 << character */
 }

--- a/src/_ZN8SaveData19IsCharacterUnlockedEj.c
+++ b/src/_ZN8SaveData19IsCharacterUnlockedEj.c
@@ -4,17 +4,17 @@
 #include "SaveData.h"
 /* SaveData::IsCharacterUnlocked(u32 character) at 0x0201392c
  * Static method (no `this`); returns nonzero if the character's bit is set.
- * Tests bit `character` in the u32 SAVE_DATA.flags2 (the FileSaveData word at
+ * Tests bit `character` in the u32 data_0209caa0.flags2 (the FileSaveData word at
  * +0x8). Mirrors SetCharacterIntro. See Save.h flags2.
  *
- * The reloc resolves to SAVE_DATA base 0x0209caa0; flags2 is index [2]
+ * The reloc resolves to data_0209caa0 base 0x0209caa0; flags2 is index [2]
  * (offset +0x8). Friendly symbol not yet in symbols.txt (wildcard pooled
  * reloc, name not byte-verified). The [2] index and `1 << n` shift are
  * load-bearing.
  */
-extern s32 SAVE_DATA[]; /* &SAVE_DATA as s32[]; [2] == flags2, base 0x0209caa0 */
+extern s32 data_0209caa0[]; /* &data_0209caa0 as s32[]; [2] == flags2, base 0x0209caa0 */
 
 s32 _ZN8SaveData19IsCharacterUnlockedEj(u32 character)
 {
-    return SAVE_DATA[2] & (1 << character); /* flags2 & (1 << character) */
+    return data_0209caa0[2] & (1 << character); /* flags2 & (1 << character) */
 }

--- a/src/_ZN9ActorBaseD0Ev.c
+++ b/src/_ZN9ActorBaseD0Ev.c
@@ -3,7 +3,7 @@
  * ActorBase is the root class; no base dtor to chain to. It destroys its two
  * ProcessingListNode members (renderNode @0x38, behavNode @0x28, reverse order)
  * then frees itself.
- *   [this+0] = _ZTV9ActorBase (0x02099edc)
+ *   [this+0] = data_02099edc (0x02099edc)
  *   ProcessingListNode::~ProcessingListNode(this+0x38)   (0x020440e8)
  *   ProcessingListNode::~ProcessingListNode(this+0x28)
  *   Memory::Deallocate(this, Memory::gameHeapPtr)        (0x0203c1e8)
@@ -19,17 +19,17 @@ struct ActorBase {
     char renderNode[0x10];  /* 0x38 */
 };
 
-extern void *_ZTV9ActorBase[];
+extern void *data_02099edc[];
 
-extern void _ZN18ProcessingListNodeD2Ev(void *node);   /* 0x020440e8 */
+extern void func_020440e8(void *node);   /* 0x020440e8 */
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap); /* 0x0203c1e8 */
-extern struct Heap *_ZN6Memory11gameHeapPtrE;          /* 0x020a0eac */
+extern struct Heap *data_020a0eac;          /* 0x020a0eac */
 
 struct ActorBase *_ZN9ActorBaseD0Ev(struct ActorBase *thiz)
 {
-    thiz->vtable = (void **)_ZTV9ActorBase;
-    _ZN18ProcessingListNodeD2Ev(thiz->renderNode);
-    _ZN18ProcessingListNodeD2Ev(thiz->behavNode);
-    _ZN6Memory10DeallocateEPvP4Heap(thiz, _ZN6Memory11gameHeapPtrE);
+    thiz->vtable = (void **)data_02099edc;
+    func_020440e8(thiz->renderNode);
+    func_020440e8(thiz->behavNode);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;
 }

--- a/src/_ZN9AnimationD1Ev.c
+++ b/src/_ZN9AnimationD1Ev.c
@@ -6,9 +6,9 @@
  * (slot 0x0) and returns. The three Fix12i members need no teardown.
  */
 
-extern int _ZTV9Animation[];  /* vtable for Animation */
+extern int data_0208e7e4[];  /* vtable for Animation */
 
 void _ZN9AnimationD1Ev(int *self)
 {
-    self[0] = (int)_ZTV9Animation;  /* +0x00 vptr */
+    self[0] = (int)data_0208e7e4;  /* +0x00 vptr */
 }

--- a/src/_ZN9AnimationD2Ev.c
+++ b/src/_ZN9AnimationD2Ev.c
@@ -6,9 +6,9 @@
  * (slot 0x0) and returns. The three Fix12i members need no teardown.
  */
 
-extern int _ZTV9Animation[];  /* vtable for Animation */
+extern int data_0208e7e4[];  /* vtable for Animation */
 
 void _ZN9AnimationD2Ev(int *self)
 {
-    self[0] = (int)_ZTV9Animation;  /* +0x00 vptr */
+    self[0] = (int)data_0208e7e4;  /* +0x00 vptr */
 }

--- a/src/_ZN9FaderWipeC1Ev.c
+++ b/src/_ZN9FaderWipeC1Ev.c
@@ -12,18 +12,18 @@ struct FaderWipe {
     struct Model model;/* 0x10 */
 };
 
-extern u32 _ZTV5Fader[];
-extern u32 _ZTV15FaderBrightness[];
-extern u32 _ZTV10FaderColor[];
+extern u32 data_0208eafc[];
+extern u32 data_0208eacc[];
+extern u32 data_0208eb2c[];
 extern u32 _ZTV9FaderWipe[];
 extern void _ZN5ModelC1Ev(struct Model*);
 
 struct FaderWipe* _ZN9FaderWipeC1Ev(struct FaderWipe* this) {
-    this->vtable = (u32*)_ZTV5Fader;
-    this->vtable = (u32*)_ZTV15FaderBrightness;
+    this->vtable = (u32*)data_0208eafc;
+    this->vtable = (u32*)data_0208eacc;
     this->currInterp = 0x1000;
     this->speed = 0;
-    this->vtable = (u32*)_ZTV10FaderColor;
+    this->vtable = (u32*)data_0208eb2c;
     this->color = 0;
     this->vtable = (u32*)_ZTV9FaderWipe;
     _ZN5ModelC1Ev(&this->model);

--- a/src/_ZN9FaderWipeD0Ev.c
+++ b/src/_ZN9FaderWipeD0Ev.c
@@ -1,14 +1,14 @@
 struct FaderWipe { void **vtable; };
 extern void *_ZTV9FaderWipe[];
 extern void _ZN5ModelD1Ev(void *thiz);
-extern void _ZN10FaderColorD2Ev(struct FaderWipe *thiz);   /* base subobject dtor @0x02017574 */
+extern void _ZN5ColorD1Ev(struct FaderWipe *thiz);   /* base subobject dtor @0x02017574 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 struct FaderWipe *_ZN9FaderWipeD0Ev(struct FaderWipe *thiz)
 {
     thiz->vtable = (void **)_ZTV9FaderWipe;
     _ZN5ModelD1Ev((char *)thiz + 0x10);
-    _ZN10FaderColorD2Ev(thiz);
+    _ZN5ColorD1Ev(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/_ZN9ModelBaseD0Ev.c
+++ b/src/_ZN9ModelBaseD0Ev.c
@@ -1,6 +1,6 @@
 /* ModelBase::~ModelBase (D0/deleting) at 0x020170e8
  *
- *   [this+0]  = _ZTV9ModelBase (0x0208e87c)
+ *   [this+0]  = data_0208e87c (0x0208e87c)
  *   ptr = this->unk4; if (ptr) Deallocate(ptr);
  *   Memory::operator_delete2(this);
  *   return this;
@@ -11,13 +11,13 @@ struct ModelBase {
     void *unk4;      /* 0x04 */
 };
 
-extern void *_ZTV9ModelBase[];
+extern void *data_0208e87c[];
 extern void Deallocate(void *ptr);                  /* 0x02018144 */
 extern void _ZN6Memory16operator_delete2EPv(void *p); /* 0x0203cbcc */
 
 struct ModelBase *_ZN9ModelBaseD0Ev(struct ModelBase *thiz)
 {
-    thiz->vtable = (void **)_ZTV9ModelBase;
+    thiz->vtable = (void **)data_0208e87c;
     if (thiz->unk4)
         Deallocate(thiz->unk4);
     _ZN6Memory16operator_delete2EPv(thiz);

--- a/src/_ZN9ModelBaseD1Ev.c
+++ b/src/_ZN9ModelBaseD1Ev.c
@@ -6,13 +6,13 @@ struct ModelBase {
     void *vtable; /* 0x00 */
     void *res;    /* 0x04 */
 };
-extern void *vtbl_ModelBase[];
-extern void ModelBase_FreeRes(void *res); /* 0x02018144 */
+extern void *data_0208e87c[];
+extern void Deallocate(void *res); /* 0x02018144 */
 struct ModelBase *_ZN9ModelBaseD1Ev(struct ModelBase *thiz)
 {
-    thiz->vtable = (void *)vtbl_ModelBase;
+    thiz->vtable = (void *)data_0208e87c;
     if (thiz->res != 0) {
-        ModelBase_FreeRes(thiz->res);
+        Deallocate(thiz->res);
     }
     return thiz;
 }

--- a/src/_ZN9ModelBaseD2Ev.c
+++ b/src/_ZN9ModelBaseD2Ev.c
@@ -6,13 +6,13 @@ struct ModelBase {
     void *vtable; /* 0x00 */
     void *res;    /* 0x04 */
 };
-extern void *vtbl_ModelBase[];
-extern void ModelBase_FreeRes(void *res); /* 0x02018144 */
+extern void *data_0208e87c[];
+extern void Deallocate(void *res); /* 0x02018144 */
 struct ModelBase *_ZN9ModelBaseD2Ev(struct ModelBase *thiz)
 {
-    thiz->vtable = (void *)vtbl_ModelBase;
+    thiz->vtable = (void *)data_0208e87c;
     if (thiz->res != 0) {
-        ModelBase_FreeRes(thiz->res);
+        Deallocate(thiz->res);
     }
     return thiz;
 }

--- a/src/__sinit_02074e0c.c
+++ b/src/__sinit_02074e0c.c
@@ -1,10 +1,10 @@
 extern void func_0201aa18();
 extern void func_020731dc();
-extern int G0[];
-extern int G1[];
-extern int G2[];
+extern int data_0209d574[];
+extern int func_0201aaec[];
+extern int data_0209d528[];
 void __sinit_02074e0c(void)
 {
-    func_0201aa18(G0);
-    func_020731dc(G0, G1, G2);
+    func_0201aa18(data_0209d574);
+    func_020731dc(data_0209d574, func_0201aaec, data_0209d528);
 }

--- a/src/__sinit_02074f80.c
+++ b/src/__sinit_02074f80.c
@@ -1,10 +1,10 @@
 extern void func_0202fc40();
 extern void func_020731dc();
-extern int G0[];
-extern int G1[];
-extern int G2[];
+extern int data_0209f61c[];
+extern int func_0202fc08[];
+extern int data_0209f610[];
 void __sinit_02074f80(void)
 {
-    func_0202fc40(G0);
-    func_020731dc(G0, G1, G2);
+    func_0202fc40(data_0209f61c);
+    func_020731dc(data_0209f61c, func_0202fc08, data_0209f610);
 }

--- a/src/__sinit_02074fe4.c
+++ b/src/__sinit_02074fe4.c
@@ -1,10 +1,10 @@
 extern void func_02037eec();
 extern void func_020731dc();
-extern int G0[];
-extern int G1[];
-extern int G2[];
+extern int data_020a0cec[];
+extern int func_02037ee8[];
+extern int data_020a0ce0[];
 void __sinit_02074fe4(void)
 {
-    func_02037eec(G0);
-    func_020731dc(G0, G1, G2);
+    func_02037eec(data_020a0cec);
+    func_020731dc(data_020a0cec, func_02037ee8, data_020a0ce0);
 }

--- a/src/__sinit_0207501c.c
+++ b/src/__sinit_0207501c.c
@@ -1,10 +1,10 @@
 extern void _ZN11RaycastLineC1Ev();
 extern void func_020731dc();
-extern int G0[];
-extern int G1[];
-extern int G2[];
+extern int data_020a0d0c[];
+extern int _ZN11RaycastLineD1Ev[];
+extern int data_020a0d00[];
 void __sinit_0207501c(void)
 {
-    _ZN11RaycastLineC1Ev(G0);
-    func_020731dc(G0, G1, G2);
+    _ZN11RaycastLineC1Ev(data_020a0d0c);
+    func_020731dc(data_020a0d0c, _ZN11RaycastLineD1Ev, data_020a0d00);
 }

--- a/src/__sinit_020750ec.c
+++ b/src/__sinit_020750ec.c
@@ -1,10 +1,10 @@
 extern void func_020731dc();
-extern int G0[];
-extern int G1[];
-extern int G2[];
+extern int data_020a0ec8[];
+extern int NullDestructor_0203d47c[];
+extern int data_020a0ed0[];
 void __sinit_020750ec(void)
 {
-    G0[0] = 0;
-    G0[1] = 0;
-    func_020731dc(G0, G1, G2);
+    data_020a0ec8[0] = 0;
+    data_020a0ec8[1] = 0;
+    func_020731dc(data_020a0ec8, NullDestructor_0203d47c, data_020a0ed0);
 }

--- a/src/__sinit_0207511c.c
+++ b/src/__sinit_0207511c.c
@@ -1,11 +1,11 @@
 extern void func_020731dc();
-extern short G0[];
-extern int G1[];
-extern int G2[];
+extern short data_020a0edc[];
+extern int func_02011508[];
+extern int data_020a0ee4[];
 void __sinit_0207511c(void)
 {
-    G0[0] = 0;
-    G0[1] = 0;
-    G0[2] = 0;
-    func_020731dc(G0, G1, G2);
+    data_020a0edc[0] = 0;
+    data_020a0edc[1] = 0;
+    data_020a0edc[2] = 0;
+    func_020731dc(data_020a0edc, func_02011508, data_020a0ee4);
 }

--- a/src/func_02005000.c
+++ b/src/func_02005000.c
@@ -2,8 +2,8 @@
 extern s32 ApproachAngle(s16 *target, s16 from, s16 start, s16 speed, s16 max);
 extern void func_02009e70(void *self);
 typedef struct CameraDef CameraDef;
-extern CameraDef CAM_DEF_A; /* at 0x020874cc */
-extern CameraDef CAM_DEF_B; /* at 0x020874f4 */
+extern CameraDef data_020874cc; /* at 0x020874cc */
+extern CameraDef data_020874f4; /* at 0x020874f4 */
 typedef struct Camera Camera;
 struct Camera {
     char _pad0[0x13c];
@@ -13,10 +13,10 @@ struct Camera {
 };
 void func_02005000(Camera *self)
 {
-    if (self->defaultCamDef == &CAM_DEF_A)
+    if (self->defaultCamDef == &data_020874cc)
     {
         if (!ApproachAngle(&self->field_184, 0, 8, 0x2000, 0x400))
-            self->defaultCamDef = &CAM_DEF_B;
+            self->defaultCamDef = &data_020874f4;
     }
     func_02009e70(self);
 }

--- a/src/func_02005348.c
+++ b/src/func_02005348.c
@@ -1,5 +1,5 @@
 
-extern unsigned short *G2S_GetBG1ScrPtr(void);
+extern unsigned short *_ZN3G2S12GetBG1ScrPtrEv(void);
 void func_02005348(void *self)
 {
   unsigned char *s = (unsigned char *) self;
@@ -20,7 +20,7 @@ void func_02005348(void *self)
       v = 0x1000;
     }
     v = (unsigned short) v;
-    base = (unsigned short *) (((char *) G2S_GetBG1ScrPtr()) + 0x4c0);
+    base = (unsigned short *) (((char *) _ZN3G2S12GetBG1ScrPtrEv()) + 0x4c0);
     new_var = v;
     row = base + (i * 0x10);
     for (j = 0; j < 0x10; j++)

--- a/src/func_020071e0.c
+++ b/src/func_020071e0.c
@@ -1,7 +1,7 @@
 #include "types.h"
 typedef struct { int x, y, z; } Vec3;
 
-extern void ApproachLinear(int *val, int target, int step);
+extern void _Z14ApproachLinearRiii(int *val, int target, int step);
 extern void Vec3_RotateYAndTranslate(Vec3 *out, const Vec3 *trans, short ang, const Vec3 *add);
 extern void func_02007c9c(const Vec3 *v0, const Vec3 *v1, int *outDist, short *outVertAng, short *outHorzAng);
 extern void func_02007c14(Vec3 *res, const Vec3 *trans, int mag, short ang, short angY);
@@ -12,7 +12,7 @@ int func_020071e0(char *self) {
     Vec3 va, vb;
     int dist;
     short ang, angY;
-    ApproachLinear((int*)(self + 0x170), 0x5a000, 0x2800);
+    _Z14ApproachLinearRiii((int*)(self + 0x170), 0x5a000, 0x2800);
     {
         char *o = *(char**)(self + 0x110);
         short a = (short)(*(short*)(o + 0x8e) + 0x8000);
@@ -21,7 +21,7 @@ int func_020071e0(char *self) {
         Vec3_RotateYAndTranslate(&vb, trans, a, (const Vec3*)(self + 0xbc));
     }
     func_02007c9c(&va, (const Vec3*)(self + 0x8c), &dist, &ang, &angY);
-    ApproachLinear(&dist, 0, *(int*)(self + 0x170));
+    _Z14ApproachLinearRiii(&dist, 0, *(int*)(self + 0x170));
     func_02007c14((Vec3*)(self + 0x8c), &va, dist, ang, angY);
     func_02007cec(self + 0x8c, &va, 0x28);
     func_02007d0c((Vec3*)(self + 0x80), &vb, 0x800, 0xccc, 0x800);

--- a/src/func_020074e8.c
+++ b/src/func_020074e8.c
@@ -1,7 +1,7 @@
-extern void ApproachLinear(int *dest, int a, int b);
+extern void _Z14ApproachLinearRiii(int *dest, int a, int b);
 
 int func_020074e8(struct Obj *o) {
-    ApproachLinear((int *)((char *)o + 0xb8), -0x28000, 0x2000);
+    _Z14ApproachLinearRiii((int *)((char *)o + 0xb8), -0x28000, 0x2000);
     *(int *)((char *)o + 0xb0) = -0x5000;
     return 1;
 }

--- a/src/func_02007c14.c
+++ b/src/func_02007c14.c
@@ -1,6 +1,6 @@
 /* func_02007c14 @ 0x02007c14, size 0x88, ARM.
  * Builds an offset vector from a magnitude and an angle: takes a Fix12i
- * magnitude `mag` and an angle `ang`, looks up sin/cos in SINE_TABLE, and
+ * magnitude `mag` and an angle `ang`, looks up sin/cos in data_02082214, and
  * forms the local vector {0, mag*Sin, mag*Cos} (Fix12 multiply, round
  * 0x800>>12), then rotates that by `angY` about Y and translates by `trans`,
  * writing the result to `res` via Vec3_RotateYAndTranslate.
@@ -12,7 +12,7 @@ typedef struct Vector3 {
     Fix12i x, y, z;
 } Vector3;
 
-extern const short SINE_TABLE[]; /* interleaved sin/cos pairs @ 0x02082214 */
+extern const short data_02082214[]; /* interleaved sin/cos pairs @ 0x02082214 */
 
 extern void Vec3_RotateYAndTranslate(Vector3 *res, const Vector3 *trans,
                                      short angY, const Vector3 *v);
@@ -23,7 +23,7 @@ void func_02007c14(Vector3 *res, const Vector3 *trans, Fix12i mag,
     unsigned idx = (unsigned short)ang >> 4;
 
     v.x = 0;
-    v.y = (int)(((long long)mag * SINE_TABLE[idx * 2] + 0x800) >> 12);
-    v.z = (int)(((long long)mag * SINE_TABLE[idx * 2 + 1] + 0x800) >> 12);
+    v.y = (int)(((long long)mag * data_02082214[idx * 2] + 0x800) >> 12);
+    v.z = (int)(((long long)mag * data_02082214[idx * 2 + 1] + 0x800) >> 12);
     Vec3_RotateYAndTranslate(res, trans, angY, &v);
 }

--- a/src/func_0200840c.c
+++ b/src/func_0200840c.c
@@ -1,11 +1,11 @@
 struct Camera;
 
 extern short ReadUnalignedShort(unsigned char *p);
-extern short ApproachLinear2(short *ref, short a, short b);
+extern short _Z15ApproachLinear2Rsss(short *ref, short a, short b);
 
 int func_0200840c(struct Camera *cam, const char *data) {
     short v1 = ReadUnalignedShort((unsigned char *)data);
     short v2 = ReadUnalignedShort((unsigned char *)data + 2);
-    ApproachLinear2((short *)((char *)cam + 0x17a), v1, v2);
+    _Z15ApproachLinear2Rsss((short *)((char *)cam + 0x17a), v1, v2);
     return 1;
 }


### PR DESCRIPTION
Each file in this batch referenced a name `config/**/symbols.txt` does not define. [`notes/link-verification.md`](../blob/main/notes/link-verification.md) calls these the **BLIND** matches and concludes:

> No static tool can verify those destinations; only a fuller symbol table would.

That holds for a static tool — but the ROM build is not one. **The function byte-matches, so the ROM's own linked word at the relocation slot *is* the destination.** Decode it (a `BL` target, or an `R_ARM_ABS32` pool word minus its addend) and look the address up.

`tools/resolve_blind.py` (PR #941) does this per file and per relocation, which matters because the names come in two shapes that need opposite treatment:

**Shared names with one true target** — mostly double-mangling artifacts, where an already-mangled name was mangled again:

| refs | invented name | what the ROM links to |
|---:|---|---|
| 177 | `_Z28_ZN13SharedFilePtr7ReleaseEvPv` | `_ZN13SharedFilePtr7ReleaseEv` |
| 78 | `_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv` | `_ZN9Animation8LoadFileER13SharedFilePtr` |
| 70 | `_Z31_ZN16MeshColliderBase7DisableEvPv` | `_ZN16MeshColliderBase7DisableEv` |
| 68 | `_Z33_ZN16MeshColliderBase9IsEnabledEvPv` | `_ZN16MeshColliderBase9IsEnabledEv` |
| 36 | `_Z10DeallocatePv` | `Deallocate` |

**Per-file placeholders**, where a global rename would be actively *wrong*: `G0` appears in 480 files and means **173 different addresses**; `G2` in 143 files means 142 different addresses; `G1` 107, `G3` 111, `VT1` 42. Only per-file resolution is correct here.

Of 6,238 unresolvable references, all but 65 resolve to a real symbol. The 65 are mostly not addresses at all (`0x04000204` is a hardware register, `0x00000006` a constant), so nothing is renamed for them and those files keep their unresolved reference.

Every rename is byte-verified against the ROM before being kept; a file that stops matching is reverted untouched.

This closes most of the residual blind spot that note describes, and it does so from data already in the ROM rather than from new symbol-table work.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
