### PR TITLE
Resolve BLIND symbol references from the ROM's linked words (175 files) [02/06]

### DIFF
--- a/src/func_02008b08.c
+++ b/src/func_02008b08.c
@@ -1,7 +1,7 @@
 /* func_02008b08 @ 0x02008b08, size 0x44, ARM.
  * Camera member function: reads a per-mode target value from a global s16 table
  * (indexed by the global current-mode byte, stride 0x18, first field s16) and
- * eases the camera's s16 field at 0x19c toward that target via ApproachLinear2.
+ * eases the camera's s16 field at 0x19c toward that target via _Z15ApproachLinear2Rsss.
  * The step rate is 0xa0 when the target is nonzero, else 0x400.
  */
 
@@ -13,9 +13,9 @@ struct CameraModeEntry {
     char pad[0x16];
 };
 
-extern unsigned char CAMERA_MODE;                  /* 0x020a0e40 : current camera mode (u8) */
-extern struct CameraModeEntry CAMERA_MODE_TABLE[]; /* 0x0209f4a0 : table, stride 0x18 */
-extern int ApproachLinear2(s16 *counter, s16 dest, s16 step);
+extern unsigned char data_020a0e40;                  /* 0x020a0e40 : current camera mode (u8) */
+extern struct CameraModeEntry data_0209f4a0[]; /* 0x0209f4a0 : table, stride 0x18 */
+extern int _Z15ApproachLinear2Rsss(s16 *counter, s16 dest, s16 step);
 
 struct Camera {
     char pad0[0x19c];
@@ -23,6 +23,6 @@ struct Camera {
 };
 
 int func_02008b08(struct Camera *cam) {
-    s16 dest = CAMERA_MODE_TABLE[CAMERA_MODE].field_0x0;
-    return ApproachLinear2(&cam->field_0x19c, dest, dest != 0 ? 0xa0 : 0x400);
+    s16 dest = data_0209f4a0[data_020a0e40].field_0x0;
+    return _Z15ApproachLinear2Rsss(&cam->field_0x19c, dest, dest != 0 ? 0xa0 : 0x400);
 }

--- a/src/func_02009540.c
+++ b/src/func_02009540.c
@@ -3,7 +3,7 @@ struct Camera;
 extern int func_020091f8(struct Camera *, struct Camera *, int, int);
 extern void Vec3_RotateYAndTranslate(void *out, int src, short angle,
                                     const int *data);
-extern void ApproachLinear(void *dest, const void *src, int factor);
+extern void _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(void *dest, const void *src, int factor);
 extern void func_02009138(struct Camera *, int);
 extern const int data_02086ea8[];
 
@@ -30,8 +30,8 @@ int func_02009540(struct Camera *cam)
                              *(short *)((char *)cam + 0x186),
                              tmp_data);
 
-    /* ApproachLinear(cam+0x120, tmp_vec, 0x8000) */
-    ApproachLinear((void *)((char *)cam + 0x120),
+    /* _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(cam+0x120, tmp_vec, 0x8000) */
+    _Z14ApproachLinearR7Vector3RKS_5Fix12IiE((void *)((char *)cam + 0x120),
                    (const void *)tmp_vec,
                    0x8000);
 

--- a/src/func_0200c394.c
+++ b/src/func_0200c394.c
@@ -6,7 +6,7 @@ extern int data_02087184, data_020871fc, data_02087224, data_0208733c, data_0208
 
 void Vec3_Sub(Vec3 *out, Vec3 *a, Vec3 *b);
 int LenVec3(Vec3 *v);
-int cstd_fdiv(int a, int b);
+int _ZN4cstd4fdivEii(int a, int b);
 void Vec3_MulScalarInPlace(Vec3 *v, int s);
 void Vec3_Add(Vec3 *out, Vec3 *a, Vec3 *b);
 void AddVec3(Vec3 *a, Vec3 *b, Vec3 *c);
@@ -67,7 +67,7 @@ body:
                     *(int *)(self + 0x12c) = (int)(((long long)*(int *)(self + 0x12c) * 0x1800 + 0x800) >> 12);
                 }
                 if (g == 0x2f && *(int *)(self + 0x12c) > 0xc0000) {
-                    int s = cstd_fdiv(0xc0000, *(int *)(self + 0x12c) << 1);
+                    int s = _ZN4cstd4fdivEii(0xc0000, *(int *)(self + 0x12c) << 1);
                     Vec3_MulScalarInPlace(&local, s);
                     Vec3_Add(&local2, a3, &local);
                     *(int *)(self + 0x120) = local2.x;

--- a/src/func_0200d7e0.c
+++ b/src/func_0200d7e0.c
@@ -1,17 +1,17 @@
 #include "types.h"
 /* func_0200d7e0 at 0x0200d7e0
- * Camera method: if playerID == CURR_PLAYER_ID, call Camera::ChangeState(state).
+ * Camera method: if playerID == data_0209f250, call Camera::ChangeState(state).
  */
 struct Camera_State;
 struct Camera;
 
-extern u8 CURR_PLAYER_ID;  /* 0x0209f250 */
-extern struct Camera_State gCameraState_0209b098;  /* 0x0209b098 */
+extern u8 data_0209f250;  /* 0x0209f250 */
+extern struct Camera_State data_0209b098;  /* 0x0209b098 */
 extern void _ZN6Camera11ChangeStateEPNS_5StateE(struct Camera *thiz, struct Camera_State *state); /* 0x0200cb70 */
 
 void func_0200d7e0(struct Camera *thiz, int playerID)
 {
-    if (playerID != (int)CURR_PLAYER_ID)
+    if (playerID != (int)data_0209f250)
         return;
-    _ZN6Camera11ChangeStateEPNS_5StateE(thiz, &gCameraState_0209b098);
+    _ZN6Camera11ChangeStateEPNS_5StateE(thiz, &data_0209b098);
 }

--- a/src/func_0200d81c.c
+++ b/src/func_0200d81c.c
@@ -1,17 +1,17 @@
 #include "types.h"
 /* func_0200d81c at 0x0200d81c
- * Camera method: if playerID == CURR_PLAYER_ID, call Camera::ChangeState(state).
+ * Camera method: if playerID == data_0209f250, call Camera::ChangeState(state).
  */
 struct Camera_State;
 struct Camera;
 
-extern u8 CURR_PLAYER_ID;  /* 0x0209f250 */
-extern struct Camera_State gCameraState_0209b008;  /* 0x0209b008 */
+extern u8 data_0209f250;  /* 0x0209f250 */
+extern struct Camera_State data_0209b008;  /* 0x0209b008 */
 extern void _ZN6Camera11ChangeStateEPNS_5StateE(struct Camera *thiz, struct Camera_State *state); /* 0x0200cb70 */
 
 void func_0200d81c(struct Camera *thiz, int playerID)
 {
-    if (playerID != (int)CURR_PLAYER_ID)
+    if (playerID != (int)data_0209f250)
         return;
-    _ZN6Camera11ChangeStateEPNS_5StateE(thiz, &gCameraState_0209b008);
+    _ZN6Camera11ChangeStateEPNS_5StateE(thiz, &data_0209b008);
 }

--- a/src/func_0200d8c8.c
+++ b/src/func_0200d8c8.c
@@ -28,7 +28,7 @@ void func_0200d8c8(struct Camera *cam, const struct Vector3 *v, int strength)
 	if (strength <= dist)
 		return;
 
-	Fix12i offset = (Fix12i)(((long long)cstd_fdiv(strength, dist) * 0x9000 + 0x800) >> 12);
+	Fix12i offset = (Fix12i)(((long long)_ZN4cstd4fdivEii(strength, dist) * 0x9000 + 0x800) >> 12);
 
 	if (offset <= cam->unk134)
 		return;

--- a/src/func_0200d954.c
+++ b/src/func_0200d954.c
@@ -1,5 +1,5 @@
 extern int func_02053200(int x);
-extern int Clipper_Func_020156DC(void *tab, int a, int b, int d, int e);
+extern int _ZN7Clipper13Func_020156DCEv(void *tab, int a, int b, int d, int e);
 extern short data_02082214[];
 extern int data_0209f43c;
 
@@ -8,5 +8,5 @@ void func_0200d954(char *c, short arg) {
     int j = i * 2;
     *(int *)(c + 0x104) = func_02053200(data_02082214[j]);
     *(int *)(c + 0x108) = func_02053200(data_02082214[j + 1]);
-    Clipper_Func_020156DC(&data_0209f43c, *(int *)(c + 0xf8), arg, *(int *)(c + 0xfc), *(int *)(c + 0x100));
+    _ZN7Clipper13Func_020156DCEv(&data_0209f43c, *(int *)(c + 0xf8), arg, *(int *)(c + 0xfc), *(int *)(c + 0x100));
 }

--- a/src/func_0200e4e4.c
+++ b/src/func_0200e4e4.c
@@ -13,11 +13,11 @@ typedef struct Actor Actor;
 
 extern Actor* _ZN5Actor5SpawnEjjRK7Vector3PK10Vector3_16ii(u32 actorID, u32 param1, const Vector3* pos, const Vector3_16* rot, s32 areaID, s32 deathTableID);
 
-extern u32 CUTSCENE_OBJECT_IDS[0x10]; /* 0x0209b2a4 */
+extern u32 data_0209b2a4[0x10]; /* 0x0209b2a4 */
 
 Actor* func_0200e4e4(u32 param1)
 {
-    u32* slot = CUTSCENE_OBJECT_IDS;
+    u32* slot = data_0209b2a4;
     s32 i = 0;
     for (;;) {
         if (*slot == 0) {

--- a/src/func_0200e55c.c
+++ b/src/func_0200e55c.c
@@ -7,10 +7,10 @@ struct Actor {
 };
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
-extern u32 CUTSCENE_OBJECT_IDS[];
+extern u32 data_0209b2a4[];
 
 struct Actor* func_0200e55c(u32 ownerID) {
-    u32* ids = CUTSCENE_OBJECT_IDS;
+    u32* ids = data_0209b2a4;
     int i = 0;
     struct Actor* a;
     do {

--- a/src/func_0200e6d8.c
+++ b/src/func_0200e6d8.c
@@ -7,19 +7,19 @@ struct Actor {
 };
 
 extern struct Actor* _ZN5Actor10FindWithIDEj(u32 id);
-extern u8 CURR_PLAYER_ID;
-extern struct Actor* PLAYER_ARR[];
-extern u32 KS_PLAYER_IDS[];
+extern u8 data_0209f250;
+extern struct Actor* data_0209f394[];
+extern u32 data_0209b284[];
 
 struct Actor* func_0200e6d8(u32 arg0) {
     struct Actor* player;
     struct Actor* result;
 
-    player = PLAYER_ARR[CURR_PLAYER_ID];
+    player = data_0209f394[data_0209f250];
     if (arg0 == player->param1) {
         result = player;
     } else {
-        result = _ZN5Actor10FindWithIDEj(KS_PLAYER_IDS[arg0]);
+        result = _ZN5Actor10FindWithIDEj(data_0209b284[arg0]);
     }
     return result;
 }

--- a/src/func_0200ee8c.c
+++ b/src/func_0200ee8c.c
@@ -1,8 +1,8 @@
 typedef signed char s8;
 typedef int s32;
 
-extern s8 STAR_OBTAINED_COPY;
-extern void* unkTable_020876e4[];
+extern s8 data_0209f224;
+extern void* data_020876e4[];
 
 extern s32 GetStarCameraSetting(s32 star);
 extern void RunKuppaScript(void* script);
@@ -12,7 +12,7 @@ void func_0200ee8c(s32 arg0)
     s32 idx;
     if (arg0 < 0)
     {
-        arg0 = GetStarCameraSetting((s32)STAR_OBTAINED_COPY);
+        arg0 = GetStarCameraSetting((s32)data_0209f224);
     }
-    RunKuppaScript(unkTable_020876e4[arg0]);
+    RunKuppaScript(data_020876e4[arg0]);
 }

--- a/src/func_0200f4f4.c
+++ b/src/func_0200f4f4.c
@@ -10,15 +10,15 @@ extern void _ZN2GX17SetBankForTexPlttEt(u16 val);
 extern void func_02045d9c(void);
 extern void InvMat4x3(Matrix4x3* dst, Matrix4x3* out);
 
-extern Matrix4x3 gMatrix_02082128;
-extern Matrix4x3 gMatrix_0209b3ec;
-extern Matrix4x3 gMatrix_0209b41c;
+extern Matrix4x3 data_02082128;
+extern Matrix4x3 data_0209b3ec;
+extern Matrix4x3 data_0209b41c;
 
 void func_0200f4f4(void) {
     Initialise3dGraphics(0);
     _ZN2GX13SetBankForTexEt(3);
     _ZN2GX17SetBankForTexPlttEt(0x30);
     func_02045d9c();
-    gMatrix_0209b3ec = gMatrix_02082128;
-    InvMat4x3(&gMatrix_0209b3ec, &gMatrix_0209b41c);
+    data_0209b3ec = data_02082128;
+    InvMat4x3(&data_0209b3ec, &data_0209b41c);
 }

--- a/src/func_02010844.c
+++ b/src/func_02010844.c
@@ -9,7 +9,7 @@ typedef struct {
     s32 z;   /* 0x08 */
 } Vector3;
 
-extern s16 SINE_TABLE[];
+extern s16 data_02082214[];
 
 extern s32 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
 extern s32 Vec3_HorzLen(Vector3* v);
@@ -23,6 +23,6 @@ s32 func_02010844(void* unused, Vector3* v, s16 angle)
     angle = (s16)(dir - angle);
     horzLen = Vec3_HorzLen(v);
     return _ZN4cstd5atan2E5Fix12IiES1_(
-        (s32)(((s64)horzLen * SINE_TABLE[((u16)angle >> 4) * 2 + 1] + 0x800) >> 12),
+        (s32)(((s64)horzLen * data_02082214[((u16)angle >> 4) * 2 + 1] + 0x800) >> 12),
         v->y);
 }

--- a/src/func_02011c8c.c
+++ b/src/func_02011c8c.c
@@ -13,11 +13,11 @@ typedef struct {
     s32 maxSeq;
 } SoundPlayerDefault;
 
-extern SoundPlayerDefault gSoundPlayerDefaults[10];  /* 0x0208e448 */
+extern SoundPlayerDefault data_0208e448[10];  /* 0x0208e448 */
 
 void func_02011c8c(void)
 {
     u32 i;
     for (i = 0; i < 10; i++)
-        _ZN5Sound6Player19SetPlayableSeqCountEii(gSoundPlayerDefaults[i].playerID, gSoundPlayerDefaults[i].maxSeq);
+        _ZN5Sound6Player19SetPlayableSeqCountEii(data_0208e448[i].playerID, data_0208e448[i].maxSeq);
 }

--- a/src/func_02012d64.c
+++ b/src/func_02012d64.c
@@ -10,17 +10,17 @@ typedef int s32;
 extern int _Z14ApproachLinearRiii(Fix12i *val, Fix12i target, Fix12i step); /* 0x0203ae58 */
 extern void func_02013524(void *fileRef, s32 vol, s32 mode);                /* 0x02013524 */
 
-extern s8   gMusicVolumeTarget;   /* 0x0208e42c */
-extern Fix12i gMusicVolumeStep;   /* 0x0209b494 */
-extern Fix12i MUSIC_VOLUME_LSL_12; /* 0x0209b490 */
-extern void *_ZN5Sound7FileRef5PTR_0E; /* data at 0x0209b4a0 */
+extern s8   data_0208e42c;   /* 0x0208e42c */
+extern Fix12i data_0209b494;   /* 0x0209b494 */
+extern Fix12i data_0209b490; /* 0x0209b490 */
+extern void *data_0209b4a0; /* data at 0x0209b4a0 */
 
 void func_02012d64(void)
 {
-    _Z14ApproachLinearRiii(&MUSIC_VOLUME_LSL_12,
-                           (Fix12i)((s32)gMusicVolumeTarget << 12),
-                           gMusicVolumeStep);
-    func_02013524(&_ZN5Sound7FileRef5PTR_0E,
-                  MUSIC_VOLUME_LSL_12 >> 12,
+    _Z14ApproachLinearRiii(&data_0209b490,
+                           (Fix12i)((s32)data_0208e42c << 12),
+                           data_0209b494);
+    func_02013524(&data_0209b4a0,
+                  data_0209b490 >> 12,
                   0);
 }

--- a/src/func_0201361c.c
+++ b/src/func_0201361c.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0201361c(int n) { G[18] |= 1 << n; }
+extern int data_0209caa0[];
+void func_0201361c(int n) { data_0209caa0[18] |= 1 << n; }

--- a/src/func_02013638.c
+++ b/src/func_02013638.c
@@ -1,2 +1,2 @@
-extern int G[];
-int func_02013638(int n) { return G[18] & (1 << n); }
+extern int data_0209caa0[];
+int func_02013638(int n) { return data_0209caa0[18] & (1 << n); }

--- a/src/func_02013944.c
+++ b/src/func_02013944.c
@@ -5,13 +5,13 @@ typedef struct FileSaveData {
     u32 flags2;
 } FileSaveData;
 
-extern FileSaveData SAVE_DATA;
+extern FileSaveData data_0209caa0;
 extern u32 _ZN8SaveData22NumGlowingRabbitsFoundEv(void);
 
 void func_02013944(void) {
     u32 count = _ZN8SaveData22NumGlowingRabbitsFoundEv();
-    SAVE_DATA.flags2 = SAVE_DATA.flags2 | (0x100000u << count);
+    data_0209caa0.flags2 = data_0209caa0.flags2 | (0x100000u << count);
     if ((s32)count >= 7) {
-        SAVE_DATA.flags1 = SAVE_DATA.flags1 | 0x80u;
+        data_0209caa0.flags1 = data_0209caa0.flags1 | 0x80u;
     }
 }

--- a/src/func_020139b8.c
+++ b/src/func_020139b8.c
@@ -1,5 +1,5 @@
 #include "types.h"
-/* SAVE_DATA layout (partial):
+/* data_0209caa0 layout (partial):
  *   0x04 = flags    (u32)
  *   0x41 = charID   (u8)
  */
@@ -10,13 +10,13 @@ typedef struct {
     u8 charID;       /* 0x41 */
 } SaveData;
 
-extern SaveData SAVE_DATA; /* 0x0209caa0 */
+extern SaveData data_0209caa0; /* 0x0209caa0 */
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void); /* 0x02013b5c */
 
 void func_020139b8(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return;
-    u8 id = SAVE_DATA.charID;
-    SAVE_DATA.flags &= ~(0x8000000u << id);
+    u8 id = data_0209caa0.charID;
+    data_0209caa0.flags &= ~(0x8000000u << id);
 }

--- a/src/func_02013a00.c
+++ b/src/func_02013a00.c
@@ -1,5 +1,5 @@
 #include "types.h"
-/* SAVE_DATA layout (partial):
+/* data_0209caa0 layout (partial):
  *   0x04 = flags    (u32)
  *   0x41 = charID   (u8)
  */
@@ -10,13 +10,13 @@ typedef struct {
     u8 charID;       /* 0x41 */
 } SaveData;
 
-extern SaveData SAVE_DATA; /* 0x0209caa0 */
+extern SaveData data_0209caa0; /* 0x0209caa0 */
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void); /* 0x02013b5c */
 
 void func_02013a00(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return;
-    u8 id = SAVE_DATA.charID;
-    SAVE_DATA.flags |= (0x8000000u << id);
+    u8 id = data_0209caa0.charID;
+    data_0209caa0.flags |= (0x8000000u << id);
 }

--- a/src/func_02013a44.c
+++ b/src/func_02013a44.c
@@ -10,11 +10,11 @@ struct SaveData {
 };
 
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void);
-extern struct SaveData SAVE_DATA;
+extern struct SaveData data_0209caa0;
 
 int func_02013a44(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return 0;
-    return SAVE_DATA.flags1 & (0x8000000u << SAVE_DATA.currentCharacter);
+    return data_0209caa0.flags1 & (0x8000000u << data_0209caa0.currentCharacter);
 }

--- a/src/func_02013a88.c
+++ b/src/func_02013a88.c
@@ -12,12 +12,12 @@ struct SaveData {
 
 extern int _ZN8SaveData16CanPlayerHaveCapEv(void);
 extern int func_020139b8(void);
-extern struct SaveData SAVE_DATA;
+extern struct SaveData data_0209caa0;
 
 void func_02013a88(void)
 {
     if (!_ZN8SaveData16CanPlayerHaveCapEv())
         return;
-    SAVE_DATA.flags1 = SAVE_DATA.flags1 & ~(0x1000000u << SAVE_DATA.currentCharacter);
+    data_0209caa0.flags1 = data_0209caa0.flags1 & ~(0x1000000u << data_0209caa0.currentCharacter);
     func_020139b8();
 }

--- a/src/func_02013c84.c
+++ b/src/func_02013c84.c
@@ -17,14 +17,14 @@ typedef struct SaveDataGlobal {
     u8 unk328;
 } SaveDataGlobal;
 
-extern void FUN_0205a61c(void* dst, void* src, u32 count);
+extern void CpuCopy8(void* dst, void* src, u32 count);
 extern int _ZN8SaveData8SaveFileEjP12FileSaveData(u32 fileID, struct FileSaveData* saveData);
-extern SaveDataGlobal SAVE_DATA; /* 0x0209caa0 */
+extern SaveDataGlobal data_0209caa0; /* 0x0209caa0 */
 
 int func_02013c84(u8 charID, struct FileSaveData* dest, s32 fileIndex, struct FileSaveData* src) {
-    FUN_0205a61c(dest, src, 0x44);
+    CpuCopy8(dest, src, 0x44);
     if (fileIndex < 0) {
-        SAVE_DATA.unk328 = charID;
+        data_0209caa0.unk328 = charID;
         return 1;
     }
     return _ZN8SaveData8SaveFileEjP12FileSaveData(fileIndex, src);

--- a/src/func_0201473c.c
+++ b/src/func_0201473c.c
@@ -1,9 +1,9 @@
 #include "types.h"
 extern s32 func_0206e3dc(char *buf, s32 size, u32 fmtAddr, u32 val);
 extern void nds_print(void *arg0, char *buf);
-extern char gPrintBuf[]; /* 0x0209cde8 */
+extern char data_0209cde8[]; /* 0x0209cde8 */
 void func_0201473c(void *arg0, u32 fmtAddr, u32 val)
 {
-    func_0206e3dc(gPrintBuf, 0x100, fmtAddr, val);
-    nds_print(arg0, gPrintBuf);
+    func_0206e3dc(data_0209cde8, 0x100, fmtAddr, val);
+    nds_print(arg0, data_0209cde8);
 }

--- a/src/func_02017060.c
+++ b/src/func_02017060.c
@@ -7,7 +7,7 @@
  * then Heap::Reallocate(gameHeap, ptr, new_size). Returns result. */
 struct Heap;
 
-extern struct Heap* gGameHeapPtr; /* at 0x020a0eac: Memory::gameHeapPtr */
+extern struct Heap* data_020a0ea0; /* at 0x020a0eac: Memory::gameHeapPtr */
 extern u32 _ZN4Heap7_SizeofEPv(struct Heap* heap, void* ptr);
 extern u32 func_020469e0(void* ptr);
 extern u32 _ZN4Heap10ReallocateEPvj(struct Heap* heap, void* ptr, u32 newSize);
@@ -16,7 +16,7 @@ u32 func_02017060(void* ptr)
 {
     if (!ptr)
         return 0;
-    struct Heap* heap = gGameHeapPtr;
+    struct Heap* heap = data_020a0ea0;
     _ZN4Heap7_SizeofEPv(heap, ptr);
     u32 newSize = func_020469e0(ptr);
     return _ZN4Heap10ReallocateEPvj(heap, ptr, newSize);

--- a/src/func_02017228.c
+++ b/src/func_02017228.c
@@ -10,13 +10,13 @@ struct Obj {
     void **vtable;   /* 0x00 */
 };
 
-extern void *vtable_02017228[];                       /* 0x0208ea6c */
+extern void *data_0208ea6c[];                       /* 0x0208ea6c */
 extern void _ZN5ColorD1Ev(struct Obj *thiz);          /* 0x02017574 */
 extern void _ZN6Memory16operator_delete2EPv(void *p); /* 0x0203cbcc */
 
 struct Obj *func_02017228(struct Obj *thiz)
 {
-    thiz->vtable = (void **)vtable_02017228;
+    thiz->vtable = (void **)data_0208ea6c;
     _ZN5ColorD1Ev(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;

--- a/src/func_02017254.c
+++ b/src/func_02017254.c
@@ -2,11 +2,11 @@
  * Single-vtable destructor: write own vtable, call base/helper destructor (0x02017574), return this.
  */
 struct Obj { void *vtable; };
-extern void *vtbl_func_02017254_obj[];
-extern void base_dtor_func_02017254_obj(struct Obj *thiz); /* 0x02017574 */
+extern void *data_0208ea6c[];
+extern void _ZN5ColorD1Ev(struct Obj *thiz); /* 0x02017574 */
 struct Obj *func_02017254(struct Obj *thiz)
 {
-    thiz->vtable = (void *)vtbl_func_02017254_obj;
-    base_dtor_func_02017254_obj(thiz);
+    thiz->vtable = (void *)data_0208ea6c;
+    _ZN5ColorD1Ev(thiz);
     return thiz;
 }

--- a/src/func_020177c4.c
+++ b/src/func_020177c4.c
@@ -1,2 +1,2 @@
-extern int VT[]; extern int func_02017838();
-int func_020177c4(int *x) { x[0] = (int)VT; func_02017838(x); return (int)x; }
+extern int data_0208eacc[]; extern int func_02017838();
+int func_020177c4(int *x) { x[0] = (int)data_0208eacc; func_02017838(x); return (int)x; }

--- a/src/func_02017838.c
+++ b/src/func_02017838.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_02017838(int *p) { p[0] = (int)G; }
+extern int data_0208eafc[];
+void func_02017838(int *p) { p[0] = (int)data_0208eafc; }

--- a/src/func_02017c24.c
+++ b/src/func_02017c24.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern u32 LAST_USED_FILE_ID;
+extern u32 data_0209d3bc;
 extern void _ZN6Memory10DeallocateEPv(void *ptr);
 
 struct Obj {
@@ -10,7 +10,7 @@ struct Obj {
 
 void func_02017c24(struct Obj *self)
 {
-    LAST_USED_FILE_ID = self->fileID;
+    data_0209d3bc = self->fileID;
     _ZN6Memory10DeallocateEPv(self->data);
     self->data = 0;
 }

--- a/src/func_02018770.c
+++ b/src/func_02018770.c
@@ -5,13 +5,13 @@
 
 typedef signed char s8;
 
-extern s8 unk_0208eb54; /* global state byte */
+extern s8 data_0208eb54; /* global state byte */
 extern void UnloadArchive(void);
 
 void func_02018770(void) {
-    if (unk_0208eb54 < 0) {
+    if (data_0208eb54 < 0) {
         return;
     }
     UnloadArchive();
-    unk_0208eb54 = -1;
+    data_0208eb54 = -1;
 }

--- a/src/func_02019018.c
+++ b/src/func_02019018.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int func_02019018(void) { return G; }
+extern unsigned char data_0208ee00;
+int func_02019018(void) { return data_0208ee00; }

--- a/src/func_02019780.c
+++ b/src/func_02019780.c
@@ -5,7 +5,7 @@ extern void func_0201a490(void);
 extern void func_02019ebc(void);
 extern void _ZN4Heap18InitializeRootHeapEv(void);
 extern void _ZN4Heap9SetNodeIDEj(void *heap, u32 id);
-extern void *_ZN6Memory11rootHeapPtrE;
+extern void *data_020a0e9c;
 
 void func_02019780(void)
 {
@@ -13,5 +13,5 @@ void func_02019780(void)
     func_0201a490();
     func_02019ebc();
     _ZN4Heap18InitializeRootHeapEv();
-    _ZN4Heap9SetNodeIDEj(*(void**)&_ZN6Memory11rootHeapPtrE, 1);
+    _ZN4Heap9SetNodeIDEj(*(void**)&data_020a0e9c, 1);
 }

--- a/src/func_0201a428.c
+++ b/src/func_0201a428.c
@@ -2,10 +2,10 @@
  * Destroys a heap referenced by global pointer and nulls the pointer.
  */
 
-extern void *gHeapPtr_0209d524; /* global: void* (Heap*) */
+extern void *data_0209d524; /* global: void* (Heap*) */
 extern void _ZN4Heap7DestroyEv(void *);
 
 void func_0201a428(void) {
-    _ZN4Heap7DestroyEv(gHeapPtr_0209d524);
-    gHeapPtr_0209d524 = 0;
+    _ZN4Heap7DestroyEv(data_0209d524);
+    data_0209d524 = 0;
 }

--- a/src/func_0201a4e4.c
+++ b/src/func_0201a4e4.c
@@ -2,15 +2,15 @@
 extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irqBit, void (*handler)(void));
 extern void _ZN3IRQ13VBlankHandlerEv(void);
 
-extern u16 unk_0209d4fc;
-extern u16 unk_0209d500;
-extern u8  unk_0209d4dc;
+extern u16 data_0209d4fc;
+extern u16 data_0209d500;
+extern u8  data_0209d4dc;
 
 /* func_0201a4e4 - initialize VBlank IRQ handler and clear some counters */
 void func_0201a4e4(void)
 {
-    unk_0209d4fc = 0;
-    unk_0209d500 = 0;
+    data_0209d4fc = 0;
+    data_0209d500 = 0;
     _ZN3IRQ13SetIRQHandlerEjPFvvE(1, _ZN3IRQ13VBlankHandlerEv);
-    unk_0209d4dc = 1;
+    data_0209d4dc = 1;
 }

--- a/src/func_0201adac.c
+++ b/src/func_0201adac.c
@@ -1,6 +1,6 @@
 #include "types.h"
 /* func_0201adac - calls Message::AddChar twice with font-encoded char and char+1.
- * Reads index from CURR_MSG_TEXT_CHAR bytes [3] and [4], looks up in gCharTable.
+ * Reads index from data_0209d6f4 bytes [3] and [4], looks up in data_0208ee6c.
  * Attempt 3: correct types - S* (not S**), AddChar(int), u16 idx, reversed load order.
  */
 extern void _ZN7Message7AddCharEc(int c);
@@ -12,12 +12,12 @@ struct MsgTextChar {
     u8 indexHi;  /* offset 3 */
     u8 indexLo;  /* offset 4 */
 };
-extern struct MsgTextChar* CURR_MSG_TEXT_CHAR;
-extern u8 gCharTable[];
+extern struct MsgTextChar* data_0209d6f4;
+extern u8 data_0208ee6c[];
 
 void func_0201adac(void) {
-    struct MsgTextChar* state = CURR_MSG_TEXT_CHAR;
+    struct MsgTextChar* state = data_0209d6f4;
     u16 idx = state->indexLo | (state->indexHi << 8);
-    _ZN7Message7AddCharEc(gCharTable[idx]);
-    _ZN7Message7AddCharEc((gCharTable[idx] + 1) & 0xff);
+    _ZN7Message7AddCharEc(data_0208ee6c[idx]);
+    _ZN7Message7AddCharEc((data_0208ee6c[idx] + 1) & 0xff);
 }

--- a/src/func_0201ef38.c
+++ b/src/func_0201ef38.c
@@ -1,2 +1,2 @@
-extern unsigned char G[];
-void func_0201ef38(void) { G[0] &= ~8; }
+extern unsigned char data_0209d45c[];
+void func_0201ef38(void) { data_0209d45c[0] &= ~8; }

--- a/src/func_020226fc.c
+++ b/src/func_020226fc.c
@@ -2,7 +2,7 @@
 struct ParticleCallback;
 struct ParticleSys;
 
-extern struct ParticleSys* volatile PARTICLE_SYS_TRACKER; /* 0x0209ee74 */
+extern struct ParticleSys* volatile data_0209ee74; /* 0x0209ee74 */
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 slot, u32 unk, Fix12i x, Fix12i y, Fix12i z, void* rot, struct ParticleCallback* callback);
@@ -15,17 +15,17 @@ void func_020226fc(Fix12i x, Fix12i y, Fix12i z, s16 arg3, s16 arg4)
     struct ParticleSys* sys4;
     u32 result;
 
-    sys1 = PARTICLE_SYS_TRACKER;
+    sys1 = data_0209ee74;
     *(s16*)((u8*)sys1 + 0x7ea) = arg3;
-    sys2 = PARTICLE_SYS_TRACKER;
+    sys2 = data_0209ee74;
     *(s16*)((u8*)sys2 + 0x7ec) = arg4;
-    sys3 = PARTICLE_SYS_TRACKER;
+    sys3 = data_0209ee74;
     result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)((u8*)sys3 + 0x7e0),
         0x50,
         x, y, z,
         0,
         (struct ParticleCallback*)((u8*)sys3 + 0x7e4));
-    sys4 = PARTICLE_SYS_TRACKER;
+    sys4 = data_0209ee74;
     *(u32*)((u8*)sys4 + 0x7e0) = result;
 }

--- a/src/func_02022774.c
+++ b/src/func_02022774.c
@@ -1,7 +1,7 @@
 #include "types.h"
-/* PARTICLE_SYS_TRACKER is a global SysTracker*, so it IS the base pointer.
+/* data_0209ee74 is a global SysTracker*, so it IS the base pointer.
    Each access reloads the global since it's not cached. */
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -10,12 +10,12 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void func_02022774(Fix12i x, Fix12i y, Fix12i z, s16 ang1, s16 ang2)
 {
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7da) = ang1;
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7dc) = ang2;
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x7d0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-        *(u32*)(PARTICLE_SYS_TRACKER + 0x7d0),
+    *(s16*)(data_0209ee74 + 0x7da) = ang1;
+    *(s16*)(data_0209ee74 + 0x7dc) = ang2;
+    *(u32*)(data_0209ee74 + 0x7d0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        *(u32*)(data_0209ee74 + 0x7d0),
         0x4f,
         x, y, z,
         (void*)0,
-        PARTICLE_SYS_TRACKER + 0x7d4);
+        data_0209ee74 + 0x7d4);
 }

--- a/src/func_020227ec.c
+++ b/src/func_020227ec.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,12 +8,12 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void func_020227ec(Fix12i x, Fix12i y, Fix12i z, s16 ang1, s16 ang2)
 {
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7ca) = ang1;
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7cc) = ang2;
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x7c0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-        *(u32*)(PARTICLE_SYS_TRACKER + 0x7c0),
+    *(s16*)(data_0209ee74 + 0x7ca) = ang1;
+    *(s16*)(data_0209ee74 + 0x7cc) = ang2;
+    *(u32*)(data_0209ee74 + 0x7c0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        *(u32*)(data_0209ee74 + 0x7c0),
         0x52,
         x, y, z,
         (void*)0,
-        PARTICLE_SYS_TRACKER + 0x7c4);
+        data_0209ee74 + 0x7c4);
 }

--- a/src/func_02022864.c
+++ b/src/func_02022864.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,12 +8,12 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void func_02022864(Fix12i x, Fix12i y, Fix12i z, s16 ang1, s16 ang2)
 {
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7ba) = ang1;
-    *(s16*)(PARTICLE_SYS_TRACKER + 0x7bc) = ang2;
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x7b0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-        *(u32*)(PARTICLE_SYS_TRACKER + 0x7b0),
+    *(s16*)(data_0209ee74 + 0x7ba) = ang1;
+    *(s16*)(data_0209ee74 + 0x7bc) = ang2;
+    *(u32*)(data_0209ee74 + 0x7b0) = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
+        *(u32*)(data_0209ee74 + 0x7b0),
         0x51,
         x, y, z,
         (void*)0,
-        PARTICLE_SYS_TRACKER + 0x7b4);
+        data_0209ee74 + 0x7b4);
 }

--- a/src/func_020228dc.c
+++ b/src/func_020228dc.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,13 +8,13 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 u32 func_020228dc(Fix12i x, Fix12i y, Fix12i z)
 {
-    char* base = PARTICLE_SYS_TRACKER;
+    char* base = data_0209ee74;
     u32 result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(base + 0x7a4),
         0x117,
         x, y, z,
         (void*)0,
         base + 0x7a8);
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x7a4) = result;
+    *(u32*)(data_0209ee74 + 0x7a4) = result;
     return result;
 }

--- a/src/func_0202293c.c
+++ b/src/func_0202293c.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,13 +8,13 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 u32 func_0202293c(Fix12i x, Fix12i y, Fix12i z)
 {
-    char* base = PARTICLE_SYS_TRACKER;
+    char* base = data_0209ee74;
     u32 result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(base + 0x798),
         0x118,
         x, y, z,
         (void*)0,
         base + 0x79c);
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x798) = result;
+    *(u32*)(data_0209ee74 + 0x798) = result;
     return result;
 }

--- a/src/func_020229f0.c
+++ b/src/func_020229f0.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,13 +8,13 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 u32 func_020229f0(Fix12i x, Fix12i y, Fix12i z)
 {
-    char* base = PARTICLE_SYS_TRACKER;
+    char* base = data_0209ee74;
     u32 result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(base + 0x780),
         0xc4,
         x, y, z,
         (void*)0,
         base + 0x784);
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x780) = result;
+    *(u32*)(data_0209ee74 + 0x780) = result;
     return result;
 }

--- a/src/func_02022a4c.c
+++ b/src/func_02022a4c.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,13 +8,13 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 u32 func_02022a4c(Fix12i x, Fix12i y, Fix12i z)
 {
-    char* base = PARTICLE_SYS_TRACKER;
+    char* base = data_0209ee74;
     u32 result = _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         *(u32*)(base + 0x774),
         0xdf,
         x, y, z,
         (void*)0,
         base + 0x76c);
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x774) = result;
+    *(u32*)(data_0209ee74 + 0x774) = result;
     return result;
 }

--- a/src/func_02022b04.c
+++ b/src/func_02022b04.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -8,11 +8,11 @@ extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8Callback
 
 void func_02022b04(Fix12i x, Fix12i y, Fix12i z)
 {
-    *(u32*)(PARTICLE_SYS_TRACKER + 0x75c) =
+    *(u32*)(data_0209ee74 + 0x75c) =
         _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
-            *(u32*)(PARTICLE_SYS_TRACKER + 0x75c),
+            *(u32*)(data_0209ee74 + 0x75c),
             0x61,
             x, y, z,
             (void*)0,
-            (void*)(PARTICLE_SYS_TRACKER + 0x760));
+            (void*)(data_0209ee74 + 0x760));
 }

--- a/src/func_02022c3c.c
+++ b/src/func_02022c3c.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -11,5 +11,5 @@ u32 func_02022c3c(
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (void*)(PARTICLE_SYS_TRACKER + 0x808));
+        (void*)(data_0209ee74 + 0x808));
 }

--- a/src/func_02022c80.c
+++ b/src/func_02022c80.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -11,5 +11,5 @@ u32 func_02022c80(
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (void*)(PARTICLE_SYS_TRACKER + 0x800));
+        (void*)(data_0209ee74 + 0x800));
 }

--- a/src/func_02022cbc.c
+++ b/src/func_02022cbc.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern char* PARTICLE_SYS_TRACKER;
+extern char* data_0209ee74;
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID,
@@ -11,5 +11,5 @@ u32 func_02022cbc(
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (void*)(PARTICLE_SYS_TRACKER + 0x7f8));
+        (void*)(data_0209ee74 + 0x7f8));
 }

--- a/src/func_02022d00.c
+++ b/src/func_02022d00.c
@@ -5,7 +5,7 @@
 struct ParticleCallback;
 struct ParticleSys;
 
-extern struct ParticleSys *PARTICLE_SYS_TRACKER; /* 0x0209ee74 */
+extern struct ParticleSys *data_0209ee74; /* 0x0209ee74 */
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z,
@@ -15,5 +15,5 @@ u32 func_02022d00(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, void
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (struct ParticleCallback *)((u8 *)PARTICLE_SYS_TRACKER + 0x7f4));
+        (struct ParticleCallback *)((u8 *)data_0209ee74 + 0x7f4));
 }

--- a/src/func_02022d44.c
+++ b/src/func_02022d44.c
@@ -5,7 +5,7 @@
 struct ParticleCallback;
 struct ParticleSys;
 
-extern struct ParticleSys *PARTICLE_SYS_TRACKER; /* 0x0209ee74 */
+extern struct ParticleSys *data_0209ee74; /* 0x0209ee74 */
 
 extern u32 _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
     u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z,
@@ -15,5 +15,5 @@ u32 func_02022d44(u32 uniqueID, u32 effectID, Fix12i x, Fix12i y, Fix12i z, void
 {
     return _ZN8Particle6System3NewEjj5Fix12IiES2_S2_PK11Vector3_16fPNS_8CallbackE(
         uniqueID, effectID, x, y, z, dir,
-        (struct ParticleCallback *)((u8 *)PARTICLE_SYS_TRACKER + 0x7f0));
+        (struct ParticleCallback *)((u8 *)data_0209ee74 + 0x7f0));
 }

--- a/src/func_020233f4.c
+++ b/src/func_020233f4.c
@@ -1,2 +1,2 @@
-extern char G[];
-void func_020233f4(void) { G[837] = 0; }
+extern char data_0209ee90[];
+void func_020233f4(void) { data_0209ee90[837] = 0; }

--- a/src/func_02023408.c
+++ b/src/func_02023408.c
@@ -1,2 +1,2 @@
-extern char G[];
-void func_02023408(void) { G[837] = 1; }
+extern char data_0209ee90[];
+void func_02023408(void) { data_0209ee90[837] = 1; }

--- a/src/func_0202a958.c
+++ b/src/func_0202a958.c
@@ -1,2 +1,2 @@
-extern short *G;
-int func_0202a958(void) { return G[11]; }
+extern short *data_0209f340;
+int func_0202a958(void) { return data_0209f340[11]; }

--- a/src/func_0202a96c.c
+++ b/src/func_0202a96c.c
@@ -1,2 +1,2 @@
-extern unsigned short *G;
-int func_0202a96c(void) { return G[7]; }
+extern unsigned short *data_0209f340;
+int func_0202a96c(void) { return data_0209f340[7]; }

--- a/src/func_0202a980.c
+++ b/src/func_0202a980.c
@@ -1,2 +1,2 @@
-extern unsigned short *G;
-int func_0202a980(void) { return G[6]; }
+extern unsigned short *data_0209f340;
+int func_0202a980(void) { return data_0209f340[6]; }

--- a/src/func_0202af80.c
+++ b/src/func_0202af80.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202af80(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f348[]; extern char data_0209f25c[];
+void func_0202af80(int a, int b) { data_0209f348[0] = a; data_0209f25c[0] = b; }

--- a/src/func_0202b044.c
+++ b/src/func_0202b044.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202b044(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f334[]; extern char data_0209f2e8[];
+void func_0202b044(int a, int b) { data_0209f334[0] = a; data_0209f2e8[0] = b; }

--- a/src/func_0202b060.c
+++ b/src/func_0202b060.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202b060(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f31c[]; extern char data_0209f258[];
+void func_0202b060(int a, int b) { data_0209f31c[0] = a; data_0209f258[0] = b; }

--- a/src/func_0202b090.c
+++ b/src/func_0202b090.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202b090(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f330[]; extern char data_0209f2d0[];
+void func_0202b090(int a, int b) { data_0209f330[0] = a; data_0209f2d0[0] = b; }

--- a/src/func_0202b0c4.c
+++ b/src/func_0202b0c4.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202b0c4(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f354[]; extern char data_0209f1f8[];
+void func_0202b0c4(int a, int b) { data_0209f354[0] = a; data_0209f1f8[0] = b; }

--- a/src/func_0202b0e0.c
+++ b/src/func_0202b0e0.c
@@ -1,2 +1,2 @@
-extern int A[]; extern char B[];
-void func_0202b0e0(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_0209f328[]; extern char data_0209f214[];
+void func_0202b0e0(int a, int b) { data_0209f328[0] = a; data_0209f214[0] = b; }

--- a/src/func_0202deac.c
+++ b/src/func_0202deac.c
@@ -1,7 +1,7 @@
 extern void _Z17LoadLevelOverlaysi(int levelID);
-extern unsigned char g0209f278;
+extern unsigned char data_0209f278;
 
 void func_0202deac(int levelID) {
     _Z17LoadLevelOverlaysi(levelID);
-    g0209f278 = 1;
+    data_0209f278 = 1;
 }

--- a/src/func_0202f2c4.c
+++ b/src/func_0202f2c4.c
@@ -1,8 +1,8 @@
 #include "types.h"
 extern int data_023c0000;
-extern u8 dat_0209f5fc;
-extern volatile u32 dat_0209f608;
-extern u8 dat_0209f648[];
+extern u8 data_0209f5fc;
+extern volatile u32 data_0209f608;
+extern u8 data_0209f648[];
 
 extern void func_0202f3a4(void);
 extern void MultiCopy_Int(void *src, void *dest, u32 size);
@@ -16,7 +16,7 @@ void func_0202f2c4(void)
     line = *(volatile u16 *)0x4000006 + 1;
 
     if (line >= 0xc0) {
-        if (dat_0209f5fc != 1) {
+        if (data_0209f5fc != 1) {
             func_0202f3a4();
         }
         return;
@@ -26,8 +26,8 @@ void func_0202f2c4(void)
         return;
     }
 
-    MultiCopy_Int(dat_0209f648 + dat_0209f608 * 0x300u + line * 4, (void *)0x4000040u, 4);
-    MultiCopy_Int(dat_0209f648 + dat_0209f608 * 0x300u + line * 4, (void *)0x4001040u, 4);
+    MultiCopy_Int(data_0209f648 + data_0209f608 * 0x300u + line * 4, (void *)0x4000040u, 4);
+    MultiCopy_Int(data_0209f648 + data_0209f608 * 0x300u + line * 4, (void *)0x4001040u, 4);
 
-    dat_0209f5fc = 0;
+    data_0209f5fc = 0;
 }

--- a/src/func_0202f3a4.c
+++ b/src/func_0202f3a4.c
@@ -1,17 +1,17 @@
 #include "types.h"
-extern u32 dat_0209f60c;          /* source index */
-extern volatile u32 dat_0209f608; /* working index */
-extern u8 dat_0209f648[];         /* table base (stride 0x300) */
-extern u8 dat_0209f5fc;           /* flag byte */
+extern u32 data_0209f60c;          /* source index */
+extern volatile u32 data_0209f608; /* working index */
+extern u8 data_0209f648[];         /* table base (stride 0x300) */
+extern u8 data_0209f5fc;           /* flag byte */
 
 extern void MultiCopy_Int(void* src, void* dest, u32 size);
 
 void func_0202f3a4(void)
 {
-    dat_0209f608 = dat_0209f60c;
-    MultiCopy_Int(dat_0209f648 + dat_0209f608 * 0x300u, (void*)0x04000040u, 4);
+    data_0209f608 = data_0209f60c;
+    MultiCopy_Int(data_0209f648 + data_0209f608 * 0x300u, (void*)0x04000040u, 4);
 
-    MultiCopy_Int(dat_0209f648 + dat_0209f608 * 0x300u, (void*)0x04001040u, 4);
+    MultiCopy_Int(data_0209f648 + data_0209f608 * 0x300u, (void*)0x04001040u, 4);
 
-    dat_0209f5fc = 1;
+    data_0209f5fc = 1;
 }

--- a/src/func_0202fb30.c
+++ b/src/func_0202fb30.c
@@ -1,7 +1,7 @@
 #include "types.h"
-extern void IRQ_DisableIRQs(u32 mask);
+extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 extern int func_02053c10(int enable);
-extern void IRQ_SetIRQHandler(u32 irq, void *handler);
+extern void _ZN3IRQ13SetIRQHandlerEjPFvvE(u32 irq, void *handler);
 
 struct Obj {
     char pad0[0x14];
@@ -15,9 +15,9 @@ void func_0202fb30(struct Obj *o)
 {
     u16 ime = *(volatile u16 *)0x4000208;
     *(volatile u16 *)0x4000208 = 0;
-    IRQ_DisableIRQs(2);
+    _ZN3IRQ11DisableIRQsEj(2);
     func_02053c10(0);
-    IRQ_SetIRQHandler(2, 0);
+    _ZN3IRQ13SetIRQHandlerEjPFvvE(2, 0);
     if (ime != 0) {
         u16 dead = *(volatile u16 *)0x4000208;
         *(volatile u16 *)0x4000208 = 1;

--- a/src/func_0202fbc8.c
+++ b/src/func_0202fbc8.c
@@ -13,14 +13,14 @@ struct Obj {
     unsigned char byte_f;   /* 0x0f */
 };
 
-extern void *vtable_0202fbc8[];                       /* 0x020926f0 */
+extern void *data_020926f0[];                       /* 0x020926f0 */
 extern void func_0202fb30(struct Obj *thiz);          /* 0x0202fb30 */
 extern void _ZN5ColorD1Ev(struct Obj *thiz);          /* 0x02017574 */
 extern void _ZN6Memory16operator_delete2EPv(void *p); /* 0x0203cbcc */
 
 struct Obj *func_0202fbc8(struct Obj *thiz)
 {
-    thiz->vtable = (void **)vtable_0202fbc8;
+    thiz->vtable = (void **)data_020926f0;
     if (thiz->byte_f == 1)
         func_0202fb30(thiz);
     _ZN5ColorD1Ev(thiz);

--- a/src/func_0202fc08.c
+++ b/src/func_0202fc08.c
@@ -11,14 +11,14 @@ struct Obj {
     unsigned char unkF; /* 0xf */
 };
 
-extern void *vtable_020926f0[];
+extern void *data_020926f0[];
 
 extern void func_0202fb30(struct Obj *thiz);    /* 0x0202fb30 */
 extern void *_ZN5ColorD1Ev(struct Obj *thiz);   /* 0x02017574 */
 
 struct Obj *func_0202fc08(struct Obj *thiz)
 {
-    thiz->vtable = (void **)vtable_020926f0;
+    thiz->vtable = (void **)data_020926f0;
     if (thiz->unkF == 1)
         func_0202fb30(thiz);
     _ZN5ColorD1Ev(thiz);

--- a/src/func_0202fd2c.c
+++ b/src/func_0202fd2c.c
@@ -1,2 +1,2 @@
-extern int A, B;
-void func_0202fd2c(void) { A = 0; B = 0; }
+extern int data_0209fc48, data_0209fc4c;
+void func_0202fd2c(void) { data_0209fc48 = 0; data_0209fc4c = 0; }

--- a/src/func_0203083c.c
+++ b/src/func_0203083c.c
@@ -1,5 +1,5 @@
 /* func_0203083c at 0x0203083c, size=0x6c
- * If DP_STATE is non-null, looks up an OamAttri* in a table indexed by
+ * If data_0209fc68 is non-null, looks up an OamAttri* in a table indexed by
  * func_0203d9f4(), then calls OAM::Render(false, oam, 8, 0xb8, ...).
  * Always calls empty stub func_02030838 at end.
  */
@@ -10,8 +10,8 @@ typedef int bool32;
 
 struct OamAttri { unsigned short attr0, attr1, attr2, attr3; };
 
-extern void *DP_STATE;             /* 0x0209fc68: global pointer, checked for non-null */
-extern struct OamAttri *unk_020927a0[];  /* 0x020927a0: table of OamAttri* */
+extern void *data_0209fc68;             /* 0x0209fc68: global pointer, checked for non-null */
+extern struct OamAttri *data_020927a0[];  /* 0x020927a0: table of OamAttri* */
 
 extern s32 func_0203d9f4(void);    /* 0x0203d9f4 */
 extern void func_02030838(void);   /* 0x02030838 (empty stub, bx lr) */
@@ -25,8 +25,8 @@ extern void _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
 
 void func_0203083c(void)
 {
-    if (DP_STATE != 0) {
-        struct OamAttri *oam = unk_020927a0[func_0203d9f4()];
+    if (data_0209fc68 != 0) {
+        struct OamAttri *oam = data_020927a0[func_0203d9f4()];
         _ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii(
             0, oam,
             8, 0xb8,

--- a/src/func_020313d8.c
+++ b/src/func_020313d8.c
@@ -1,5 +1,5 @@
 /* func_020313d8 - calls Message::AddChar twice with font-encoded char and char+1.
- * Reads index from CURR_MSG_TEXT_CHAR bytes [3] and [4], looks up in gCharTable.
+ * Reads index from data_0209fd0c bytes [3] and [4], looks up in data_02092810.
  * Attempt 3: correct types - S* (not S**), AddChar(int), u16 idx, reversed load order.
  */
 typedef unsigned char u8;
@@ -14,12 +14,12 @@ struct MsgTextChar {
     u8 indexHi;  /* offset 3 */
     u8 indexLo;  /* offset 4 */
 };
-extern struct MsgTextChar* CURR_MSG_TEXT_CHAR;
-extern u8 gCharTable[];
+extern struct MsgTextChar* data_0209fd0c;
+extern u8 data_02092810[];
 
 void func_020313d8(void) {
-    struct MsgTextChar* state = CURR_MSG_TEXT_CHAR;
+    struct MsgTextChar* state = data_0209fd0c;
     u16 idx = state->indexLo | (state->indexHi << 8);
-    _ZN7Message7AddCharEc(gCharTable[idx]);
-    _ZN7Message7AddCharEc((gCharTable[idx] + 1) & 0xff);
+    _ZN7Message7AddCharEc(data_02092810[idx]);
+    _ZN7Message7AddCharEc((data_02092810[idx] + 1) & 0xff);
 }

--- a/src/func_02034a78.c
+++ b/src/func_02034a78.c
@@ -3,10 +3,10 @@
  * Chain MultiBootScene -> Scene -> ActorDerived, with a FaderColor member
  * subobject at +0x50.  CW emits: most-derived vptr write, member dtor,
  * then the base-subobject vptr writes, then the lowest base dtor.
- *   0x020943c4 = _ZTV14MultiBootScene
+ *   0x020943c4 = data_020943c4
  *   bl 0x020175c4 = FaderColor::~FaderColor(this+0x50)
- *   0x02092680 = _ZTV5Scene
- *   0x0208e4b8 = _ZTV12ActorDerived
+ *   0x02092680 = _ZTV5Stage
+ *   0x0208e4b8 = data_0208e4b8
  *   bl 0x02043d48 = ActorBase::~ActorBase(this)
  *   return this;
  */
@@ -17,19 +17,19 @@ struct MultiBootScene {
     void **faderVtable;  /* 0x50: FaderColor member subobject */
 };
 
-extern void *_ZTV14MultiBootScene[];
-extern void *_ZTV5Scene[];
-extern void *_ZTV12ActorDerived[];
+extern void *data_020943c4[];
+extern void *_ZTV5Stage[];
+extern void *data_0208e4b8[];
 
 extern void _ZN10FaderColorD1Ev(void *fader);          /* 0x020175c4 */
 extern void _ZN9ActorBaseD2Ev(struct MultiBootScene *self); /* 0x02043d48 */
 
 struct MultiBootScene *func_02034a78(struct MultiBootScene *self)
 {
-    self->vtable = (void **)_ZTV14MultiBootScene;
+    self->vtable = (void **)data_020943c4;
     _ZN10FaderColorD1Ev((char *)self + 0x50);
-    self->vtable = (void **)_ZTV5Scene;
-    self->vtable = (void **)_ZTV12ActorDerived;
+    self->vtable = (void **)_ZTV5Stage;
+    self->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(self);
     return self;
 }

--- a/src/func_02034ac0.c
+++ b/src/func_02034ac0.c
@@ -1,24 +1,24 @@
 // @symbol func_02034ac0
-// @emits dScMB_c_OnYoshiTryEat
+// recovered name: dScMB_c_OnYoshiTryEat
 /* recovered: renamed to Class_Method */
 /* dScMB_c::OnYoshiTryEat - recovered from vtable slot identity */
 struct MultiBootScene { void **vtable; };
 struct Heap;
-extern void *_ZTV14MultiBootScene[];
-extern void *_ZTV5Scene[];
-extern void *_ZTV12ActorDerived[];
+extern void *data_020943c4[];
+extern void *_ZTV5Stage[];
+extern void *data_0208e4b8[];
 extern void _ZN10FaderColorD1Ev(void *thiz);
 extern void _ZN9ActorBaseD2Ev(struct MultiBootScene *thiz);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);
-extern struct Heap *_ZN6Memory11gameHeapPtrE;
+extern struct Heap *data_020a0eac;
 
-struct MultiBootScene *dScMB_c_OnYoshiTryEat(struct MultiBootScene *thiz)
+struct MultiBootScene *func_02034ac0(struct MultiBootScene *thiz)
 {
-    thiz->vtable = (void **)_ZTV14MultiBootScene;
+    thiz->vtable = (void **)data_020943c4;
     _ZN10FaderColorD1Ev((char *)thiz + 0x50);
-    thiz->vtable = (void **)_ZTV5Scene;
-    thiz->vtable = (void **)_ZTV12ActorDerived;
+    thiz->vtable = (void **)_ZTV5Stage;
+    thiz->vtable = (void **)data_0208e4b8;
     _ZN9ActorBaseD2Ev(thiz);
-    _ZN6Memory10DeallocateEPvP4Heap(thiz, _ZN6Memory11gameHeapPtrE);
+    _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;
 }

--- a/src/func_02034d70.c
+++ b/src/func_02034d70.c
@@ -1,14 +1,14 @@
 #include "types.h"
 // @symbol func_02034d70
-// @emits dScMB_c_CleanupResources
+// recovered name: dScMB_c_CleanupResources
 /* recovered: renamed to Class_Method, declarations from a shared header */
 #include "decl_Scene.h"
 /* recovered: renamed to Class_Method */
 /* dScMB_c::CleanupResources - recovered from vtable slot identity */
-extern void* SCENE_RELATED;  /* 0x0209d4a8 */
+extern void* data_0209d4a8;  /* 0x0209d4a8 */
 
-int dScMB_c_CleanupResources(void) {
-    SCENE_RELATED = 0;
+int func_02034d70(void) {
+    data_0209d4a8 = 0;
     _ZN5Scene20SetAndStopColorFaderEv();
     return 1;
 }

--- a/src/func_020354d0.c
+++ b/src/func_020354d0.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_020354d0(int *p) { p[0] = (int)G; }
+extern int data_020991d8[];
+void func_020354d0(int *p) { p[0] = (int)data_020991d8; }

--- a/src/func_020354e0.c
+++ b/src/func_020354e0.c
@@ -1,13 +1,13 @@
 /* Deleting (D0) virtual destructor: set vptr, then Memory::operator_delete2(this),
  * return this.  vtable @ 0x020991d8 (unnamed in reference; class unknown). */
-extern void *vtable_020991d8;
+extern void *data_020991d8;
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 struct Obj { void *vtable; };
 
 void *func_020354e0(struct Obj *self)
 {
-    self->vtable = &vtable_020991d8;
+    self->vtable = &data_020991d8;
     _ZN6Memory16operator_delete2EPv(self);
     return self;
 }

--- a/src/func_02035504.c
+++ b/src/func_02035504.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_02035504(int *p) { p[0] = (int)G; }
+extern int data_020991d8[];
+void func_02035504(int *p) { p[0] = (int)data_020991d8; }

--- a/src/func_020373b8.c
+++ b/src/func_020373b8.c
@@ -1,16 +1,16 @@
 struct WithMeshClsn { void **vtable; };
-extern void *_ZTV12WithMeshClsn[];
+extern void *data_02099204[];
 extern void _ZN11RaycastLineD1Ev(void *thiz);
 extern void _ZN10SphereClsnD1Ev(void *thiz);
-extern void WithMeshClsn_BaseDtor(struct WithMeshClsn *thiz);   /* base D2 @0x020354d0 */
+extern void func_020354d0(struct WithMeshClsn *thiz);   /* base D2 @0x020354d0 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 struct WithMeshClsn *func_020373b8(struct WithMeshClsn *thiz)
 {
-    thiz->vtable = (void **)_ZTV12WithMeshClsn;
+    thiz->vtable = (void **)data_02099204;
     _ZN11RaycastLineD1Ev((char *)thiz + 0x134);
     _ZN10SphereClsnD1Ev((char *)thiz + 0x20);
-    WithMeshClsn_BaseDtor(thiz);
+    func_020354d0(thiz);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;
 }

--- a/src/func_020374f0.c
+++ b/src/func_020374f0.c
@@ -1,12 +1,12 @@
 extern void func_020380ec(void *);
 extern void func_020354d0(void *);
 extern void _ZN6Memory16operator_delete2EPv(void *);
-extern int VT0[];
-extern int VT1[];
+extern int data_02099264[];
+extern int data_02099274[];
 int *func_020374f0(int *t)
 {
-    t[0] = (int)VT0;
-    *(int *)((char *)t + 0x10) = (int)VT1;
+    t[0] = (int)data_02099264;
+    *(int *)((char *)t + 0x10) = (int)data_02099274;
     func_020380ec((char *)t + 0x10);
     func_020354d0(t);
     _ZN6Memory16operator_delete2EPv(t);

--- a/src/func_02037710.c
+++ b/src/func_02037710.c
@@ -3,12 +3,12 @@ extern void func_ov002_020feab8(void *);
 extern void func_020380ec(void *);
 extern void func_020354d0(void *);
 extern void _ZN6Memory16operator_delete2EPv(void *);
-extern int VT0[];
-extern int VT1[];
+extern int data_020992a4[];
+extern int data_020992b4[];
 int *func_02037710(int *t)
 {
-    t[0] = (int)VT0;
-    *(int *)((char *)t + 0x10) = (int)VT1;
+    t[0] = (int)data_020992a4;
+    *(int *)((char *)t + 0x10) = (int)data_020992b4;
     func_0203ac50((char *)t + 0x64);
     func_ov002_020feab8((char *)t + 0x38);
     func_020380ec((char *)t + 0x10);

--- a/src/func_02037c40.c
+++ b/src/func_02037c40.c
@@ -21,9 +21,9 @@ struct Obj {
     void **vtable38;   /* 0x38 */
 };
 
-extern void *vtable_02099338[];
-extern void *vtable_02099348[];
-extern void *vtable_02099358[];
+extern void *data_02099338[];
+extern void *data_02099348[];
+extern void *data_02099358[];
 
 extern void _ZN10ClsnResultD1Ev(void *thiz);   /* 0x02038144 */
 extern void func_0203ac1c(void *thiz);          /* 0x0203ac1c */
@@ -33,9 +33,9 @@ extern void _ZN6Memory16operator_delete2EPv(void *ptr); /* 0x0203cbcc */
 
 struct Obj *func_02037c40(struct Obj *thiz)
 {
-    thiz->vtable = (void **)vtable_02099338;
-    thiz->vtable10 = (void **)vtable_02099348;
-    thiz->vtable38 = (void **)vtable_02099358;
+    thiz->vtable = (void **)data_02099338;
+    thiz->vtable10 = (void **)data_02099348;
+    thiz->vtable38 = (void **)data_02099358;
     _ZN10ClsnResultD1Ev((char *)thiz + 0xc4);
     _ZN10ClsnResultD1Ev((char *)thiz + 0x9c);
     _ZN10ClsnResultD1Ev((char *)thiz + 0x74);

--- a/src/func_020380ec.c
+++ b/src/func_020380ec.c
@@ -1,8 +1,8 @@
 extern void func_02037ee4(void *);
-extern int VT0[];
+extern int data_02099368[];
 int *func_020380ec(int *t)
 {
-    t[0] = (int)VT0;
+    t[0] = (int)data_02099368;
     func_02037ee4((char *)t + 0x4);
     return t;
 }

--- a/src/func_02038114.c
+++ b/src/func_02038114.c
@@ -9,14 +9,14 @@ struct Obj {
     void **vtable; /* 0x0 */
 };
 
-extern void *vtable_02099368[];
+extern void *data_02099368[];
 
 extern void func_02037ee4(void *sub);                    /* 0x02037ee4 */
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);  /* 0x0203cbcc */
 
 struct Obj *func_02038114(struct Obj *thiz)
 {
-    thiz->vtable = (void **)vtable_02099368;
+    thiz->vtable = (void **)data_02099368;
     func_02037ee4((char *)thiz + 4);
     _ZN6Memory16operator_delete2EPv(thiz);
     return thiz;

--- a/src/func_0203819c.c
+++ b/src/func_0203819c.c
@@ -1,10 +1,10 @@
 extern void func_02037f18(void *);
 extern void func_020380c0(void *);
-extern int VT0[];
+extern int data_02099368[];
 int *func_0203819c(int *t)
 {
     func_02037f18((char *)t + 0x4);
-    t[0] = (int)VT0;
+    t[0] = (int)data_02099368;
     func_020380c0(t);
     return t;
 }

--- a/src/func_0203ac1c.c
+++ b/src/func_0203ac1c.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203ac1c(int *p) { p[0] = (int)G; }
+extern int data_020994cc[];
+void func_0203ac1c(int *p) { p[0] = (int)data_020994cc; }

--- a/src/func_0203ac2c.c
+++ b/src/func_0203ac2c.c
@@ -1,13 +1,13 @@
 /* Deleting (D0) virtual destructor: set vptr, then Memory::operator_delete2(this),
  * return this.  vtable @ 0x020994cc (unnamed in reference; class unknown). */
-extern void *vtable_020994cc;
+extern void *data_020994cc;
 extern void _ZN6Memory16operator_delete2EPv(void *ptr);
 
 struct Obj { void *vtable; };
 
 void *func_0203ac2c(struct Obj *self)
 {
-    self->vtable = &vtable_020994cc;
+    self->vtable = &data_020994cc;
     _ZN6Memory16operator_delete2EPv(self);
     return self;
 }

--- a/src/func_0203ac50.c
+++ b/src/func_0203ac50.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203ac50(int *p) { p[0] = (int)G; }
+extern int data_020994cc[];
+void func_0203ac50(int *p) { p[0] = (int)data_020994cc; }

--- a/src/func_0203ac60.c
+++ b/src/func_0203ac60.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203ac60(int *p) { p[0] = (int)G; }
+extern int data_020994cc[];
+void func_0203ac60(int *p) { p[0] = (int)data_020994cc; }

--- a/src/func_0203ac70.c
+++ b/src/func_0203ac70.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203ac70(int *p) { p[0] = (int)G; }
+extern int data_020994cc[];
+void func_0203ac70(int *p) { p[0] = (int)data_020994cc; }

--- a/src/func_0203aca0.c
+++ b/src/func_0203aca0.c
@@ -1,2 +1,2 @@
-extern int A[]; extern int B[];
-void func_0203aca0(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_020a0d84[]; extern int data_020a0d8c[];
+void func_0203aca0(int a, int b) { data_020a0d84[0] = a; data_020a0d8c[0] = b; }

--- a/src/func_0203acbc.c
+++ b/src/func_0203acbc.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_0203acbc(void) { return G; }
+extern int data_020a0d88;
+int func_0203acbc(void) { return data_020a0d88; }

--- a/src/func_0203accc.c
+++ b/src/func_0203accc.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203accc(int v) { G[0] = v; }
+extern int data_020a0d88[];
+void func_0203accc(int v) { data_020a0d88[0] = v; }

--- a/src/func_0203b684.c
+++ b/src/func_0203b684.c
@@ -1,2 +1,2 @@
-extern int A, B;
-void func_0203b684(void) { A = 0; B = 0; }
+extern int data_020a0db0, data_020a0db4;
+void func_0203b684(void) { data_020a0db0 = 0; data_020a0db4 = 0; }

--- a/src/func_0203cc0c.c
+++ b/src/func_0203cc0c.c
@@ -1,10 +1,10 @@
 /* func_0203cc0c at 0x0203cc0c -- allocates from the default heap via
  * Heap::Allocate(unsigned) (mangled names referenced directly from C). */
 
-extern void* _ZN6Memory14defaultHeapPtrE;
+extern void* data_020a0ea0;
 extern void* _ZN4Heap8AllocateEj(void* heap, unsigned int size);
 
 void* func_0203cc0c(unsigned int size)
 {
-    return _ZN4Heap8AllocateEj(_ZN6Memory14defaultHeapPtrE, size);
+    return _ZN4Heap8AllocateEj(data_020a0ea0, size);
 }

--- a/src/func_0203d7b8.c
+++ b/src/func_0203d7b8.c
@@ -1,2 +1,2 @@
-extern unsigned short G;
-int func_0203d7b8(void) { return (G & 128) != 0; }
+extern unsigned short data_020a0f1c;
+int func_0203d7b8(void) { return (data_020a0f1c & 128) != 0; }

--- a/src/func_0203d854.c
+++ b/src/func_0203d854.c
@@ -1,2 +1,2 @@
-extern short G[];
-void func_0203d854(void) { G[0] = 0; }
+extern short data_020a0f30[];
+void func_0203d854(void) { data_020a0f30[0] = 0; }

--- a/src/func_0203d868.c
+++ b/src/func_0203d868.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-void func_0203d868(void) { G[6] |= 4096; }
+extern unsigned short data_020a1040[];
+void func_0203d868(void) { data_020a1040[6] |= 4096; }

--- a/src/func_0203d890.c
+++ b/src/func_0203d890.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int func_0203d890(void) { return G; }
+extern unsigned char data_020a0f08;
+int func_0203d890(void) { return data_020a0f08; }

--- a/src/func_0203d8d4.c
+++ b/src/func_0203d8d4.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203d8d4(void) { G[0] = 1; }
+extern int data_020a0f40[];
+void func_0203d8d4(void) { data_020a0f40[0] = 1; }

--- a/src/func_0203d8e8.c
+++ b/src/func_0203d8e8.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203d8e8(void) { G[0] = 1; }
+extern int data_020a0f70[];
+void func_0203d8e8(void) { data_020a0f70[0] = 1; }

--- a/src/func_0203d918.c
+++ b/src/func_0203d918.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-void func_0203d918(void) { G[6] |= 0x4000; }
+extern unsigned short data_020a1040[];
+void func_0203d918(void) { data_020a1040[6] |= 0x4000; }

--- a/src/func_0203da2c.c
+++ b/src/func_0203da2c.c
@@ -1,2 +1,2 @@
-extern char G[];
-void func_0203da2c(int v) { G[0] = v; }
+extern char data_020a0f04[];
+void func_0203da2c(int v) { data_020a0f04[0] = v; }

--- a/src/func_0203da3c.c
+++ b/src/func_0203da3c.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int func_0203da3c(void) { return G; }
+extern unsigned char data_020a0f04;
+int func_0203da3c(void) { return data_020a0f04; }

--- a/src/func_0203da9c.c
+++ b/src/func_0203da9c.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int func_0203da9c(void) { return G; }
+extern unsigned char data_020a0f10;
+int func_0203da9c(void) { return data_020a0f10; }

--- a/src/func_0203daac.c
+++ b/src/func_0203daac.c
@@ -1,2 +1,2 @@
-extern unsigned char G;
-int func_0203daac(void) { return G; }
+extern unsigned char data_02099e18;
+int func_0203daac(void) { return data_02099e18; }

--- a/src/func_0203dad4.c
+++ b/src/func_0203dad4.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_0203dad4(void) { return G; }
+extern int data_020a1040;
+int func_0203dad4(void) { return data_020a1040; }

--- a/src/func_0203dafc.c
+++ b/src/func_0203dafc.c
@@ -1,2 +1,2 @@
-extern short G[];
-void func_0203dafc(int v) { G[8] = v; }
+extern short data_020a1040[];
+void func_0203dafc(int v) { data_020a1040[8] = v; }

--- a/src/func_0203db3c.c
+++ b/src/func_0203db3c.c
@@ -1,2 +1,2 @@
-extern char G[];
-void func_0203db3c(int i, int v) { G[i] = v; }
+extern char data_020a1052[];
+void func_0203db3c(int i, int v) { data_020a1052[i] = v; }

--- a/src/func_0203f6a4.c
+++ b/src/func_0203f6a4.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_0203f6a4(int v) { G[0] = v; }
+extern int data_02099e20[];
+void func_0203f6a4(int v) { data_02099e20[0] = v; }

--- a/src/func_02040638.c
+++ b/src/func_02040638.c
@@ -6,12 +6,12 @@ typedef struct ObjWithField0a {
     u16 field0a;
 } ObjWithField0a;
 
-extern ObjWithField0a* UNK_020a0f44;   /* 0x020a0f44 - pointer to object */
-extern void*           UNK_020a1064;   /* 0x020a1064 - copy destination buffer */
-extern u16             UNK_020a0f20;   /* 0x020a0f20 - counter */
+extern ObjWithField0a* data_020a0f44;   /* 0x020a0f44 - pointer to object */
+extern void*           data_020a1064;   /* 0x020a1064 - copy destination buffer */
+extern u16             data_020a0f20;   /* 0x020a0f20 - counter */
 
 void func_02040638(void) {
-    MultiCopy_Int(&UNK_020a1064, UNK_020a0f44, 0x40);
-    UNK_020a0f20 = UNK_020a0f20 + 1;
-    UNK_020a0f44->field0a = UNK_020a0f20;
+    MultiCopy_Int(&data_020a1064, data_020a0f44, 0x40);
+    data_020a0f20 = data_020a0f20 + 1;
+    data_020a0f44->field0a = data_020a0f20;
 }

--- a/src/func_02040704.c
+++ b/src/func_02040704.c
@@ -1,2 +1,2 @@
-extern unsigned short G;
-int func_02040704(void) { return G; }
+extern unsigned short data_020a0f24;
+int func_02040704(void) { return data_020a0f24; }

--- a/src/func_02040714.c
+++ b/src/func_02040714.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02040714(void) { return G; }
+extern int data_020a0f94;
+int func_02040714(void) { return data_020a0f94; }

--- a/src/func_02040a5c.c
+++ b/src/func_02040a5c.c
@@ -6,11 +6,11 @@ typedef struct {
     u32 field_b50;
 } UnkStruct_020a3fc0;
 
-extern UnkStruct_020a3fc0 unk_020a3fc0;
+extern UnkStruct_020a3fc0 data_020a3fc0;
 
 void func_02040a5c(u32 val)
 {
     u32 saved = _ZN3IRQ7DisableEv();
-    unk_020a3fc0.field_b50 = val & ~1u;
+    data_020a3fc0.field_b50 = val & ~1u;
     _ZN3IRQ7RestoreEj(saved);
 }

--- a/src/func_02040a84.c
+++ b/src/func_02040a84.c
@@ -1,2 +1,2 @@
-extern int G[];
-int func_02040a84(void) { return G[726]; }
+extern int data_020a3fc0[];
+int func_02040a84(void) { return data_020a3fc0[726]; }

--- a/src/func_02040a94.c
+++ b/src/func_02040a94.c
@@ -1,2 +1,2 @@
-extern int G[];
-int func_02040a94(void) { return G[3]; }
+extern int data_020a1fc0[];
+int func_02040a94(void) { return data_020a1fc0[3]; }

--- a/src/func_0204175c.c
+++ b/src/func_0204175c.c
@@ -4,9 +4,9 @@ static volatile u32 * const REG_IE = (volatile u32 *)0x04000210;
 static volatile u32 * const REG_IF = (volatile u32 *)0x04000214;
 
 /* Globals */
-extern void (*gGameCardHandlerPtr)(void *);  /* *0x0209a03c */
-extern void *gGameCardHandlerArg;            /* 0x02099e24 */
-extern u32   gGameCardSentinel;              /* 0x020a0f38 */
+extern void (*data_0209a03c)(void *);  /* *0x0209a03c */
+extern void *data_02099e24;            /* 0x02099e24 */
+extern u32   data_020a0f38;              /* 0x020a0f38 */
 
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
@@ -25,8 +25,8 @@ void func_0204175c(void)
     if ((iflags & 0x80000) && !(ie & 0x80000))
     {
         _ZN3IRQ10EnableIRQsEj(0x80000);
-        gGameCardHandlerPtr(&gGameCardHandlerArg);
-        gGameCardSentinel = 0x80000000;
+        data_0209a03c(&data_02099e24);
+        data_020a0f38 = 0x80000000;
     }
 
     _ZN3IRQ7RestoreEj(state);

--- a/src/func_020441bc.c
+++ b/src/func_020441bc.c
@@ -1,2 +1,2 @@
-extern int G[];
-int func_020441bc(int i) { return G[i]; }
+extern int data_02082178[];
+int func_020441bc(int i) { return data_02082178[i]; }

--- a/src/func_02045a50.c
+++ b/src/func_02045a50.c
@@ -1,6 +1,6 @@
 #include "types.h"
-extern u32 gTexPlttCur;    /* 0x020a4bcc */
-extern u32 gTexPlttEnd;    /* 0x020a4bd8 */
+extern u32 data_020a4bcc;    /* 0x020a4bcc */
+extern u32 data_020a4bd8;    /* 0x020a4bd8 */
 
 extern void Crash(void);
 extern void _ZN2GX16BeginLoadTexPlttEv(void);
@@ -12,17 +12,17 @@ u32 func_02045a50(const void *src, u32 size)
     u32 slot;
     u32 end;
 
-    slot = gTexPlttCur;
-    end  = gTexPlttEnd;
+    slot = data_020a4bcc;
+    end  = data_020a4bd8;
 
     if (slot + size > end)
         Crash();
 
-    gTexPlttEnd -= (size + 0xf) & 0xfff0;
+    data_020a4bd8 -= (size + 0xf) & 0xfff0;
 
     _ZN2GX16BeginLoadTexPlttEv();
-    _ZN2GX11LoadTexPlttEPKvjj(src, gTexPlttEnd, size);
+    _ZN2GX11LoadTexPlttEPKvjj(src, data_020a4bd8, size);
     _ZN2GX14EndLoadTexPlttEv();
 
-    return gTexPlttEnd;
+    return data_020a4bd8;
 }

--- a/src/func_02045ad8.c
+++ b/src/func_02045ad8.c
@@ -1,6 +1,6 @@
 #include "types.h"
-extern u32 gTexPlttCur;    /* 0x020a4bcc */
-extern u32 gTexPlttEnd;    /* 0x020a4bd8 */
+extern u32 data_020a4bcc;    /* 0x020a4bcc */
+extern u32 data_020a4bd8;    /* 0x020a4bd8 */
 
 extern void Crash(void);
 extern void _ZN2GX16BeginLoadTexPlttEv(void);
@@ -12,18 +12,18 @@ u32 func_02045ad8(const void *src, u32 size)
     u32 slot;
     u32 end;
 
-    slot = gTexPlttCur;
-    end  = gTexPlttEnd;
+    slot = data_020a4bcc;
+    end  = data_020a4bd8;
 
     if (slot + size > end)
         Crash();
 
     _ZN2GX16BeginLoadTexPlttEv();
-    _ZN2GX11LoadTexPlttEPKvjj(src, gTexPlttCur, size);
+    _ZN2GX11LoadTexPlttEPKvjj(src, data_020a4bcc, size);
     _ZN2GX14EndLoadTexPlttEv();
 
-    slot = gTexPlttCur;
-    gTexPlttCur = slot + ((size + 0xf) & 0xfff0);
+    slot = data_020a4bcc;
+    data_020a4bcc = slot + ((size + 0xf) & 0xfff0);
 
     return slot;
 }

--- a/src/func_02045ce0.c
+++ b/src/func_02045ce0.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02045ce0(void) { return G; }
+extern int data_020a4bd8;
+int func_02045ce0(void) { return data_020a4bd8; }

--- a/src/func_02045cf0.c
+++ b/src/func_02045cf0.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02045cf0(void) { return G; }
+extern int data_020a4bcc;
+int func_02045cf0(void) { return data_020a4bcc; }

--- a/src/func_02045d00.c
+++ b/src/func_02045d00.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02045d00(void) { return G; }
+extern int data_020a4bdc;
+int func_02045d00(void) { return data_020a4bdc; }

--- a/src/func_02045d10.c
+++ b/src/func_02045d10.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02045d10(void) { return G; }
+extern int data_020a4bc8;
+int func_02045d10(void) { return data_020a4bc8; }

--- a/src/func_02049c48.c
+++ b/src/func_02049c48.c
@@ -5,11 +5,11 @@ extern void _ZN3IRQ7RestoreEj(unsigned int);
 extern void MultiStore16(unsigned short val, void* dest, unsigned int size);
 extern void func_0205a8c4(int val);
 
-extern int gCurrentOwner;       // linked to 0x020a4c64
-extern unsigned short gTable[];  // linked to 0x020a4c70
+extern int data_020a4c64;       // linked to 0x020a4c64
+extern unsigned short data_020a4c70[];  // linked to 0x020a4c70
 
 void func_02049c48(int self) {
-    int currentOwner = gCurrentOwner;
+    int currentOwner = data_020a4c64;
     volatile unsigned short tmp;
     unsigned int savedIRQ;
     if (self == currentOwner)
@@ -19,8 +19,8 @@ void func_02049c48(int self) {
     }
     savedIRQ = _ZN3IRQ7DisableEv();
     tmp = 0;
-    MultiStore16(tmp, gTable, 0xc0);
-    gCurrentOwner = self;
+    MultiStore16(tmp, data_020a4c70, 0xc0);
+    data_020a4c64 = self;
     _ZN3IRQ7RestoreEj(savedIRQ);
     if (self == 1) {
         func_0205a8c4(0x3000);

--- a/src/func_0204d9f0.c
+++ b/src/func_0204d9f0.c
@@ -11,13 +11,13 @@ extern void NormalizeVec3(const struct Vector3* src, struct Vector3* dst);
 
 void func_0204d9f0(struct Vector3* out)
 {
-    s32 s = LCG_STATE_0204d9f0;
+    s32 s = data_020a4d30;
     s32 r1 = (s32)((unsigned int)s * 0x5eedf715u + 0x1b0cb173u);
-    LCG_STATE_0204d9f0 = r1;
+    data_020a4d30 = r1;
     out->x = r1 >> 8;
-    s = LCG_STATE_0204d9f0;
+    s = data_020a4d30;
     s32 r2 = (s32)((unsigned int)s * 0x5eedf715u + 0x1b0cb173u);
-    LCG_STATE_0204d9f0 = r2;
+    data_020a4d30 = r2;
     out->y = r2 >> 8;
     out->z = 0;
     NormalizeVec3(out, out);

--- a/src/func_0204f2d4.c
+++ b/src/func_0204f2d4.c
@@ -7,8 +7,8 @@ struct HeapObj {
     HeapAllocator* unk8;
 };
 
-extern HeapAllocator gHeapList0;
-extern HeapAllocator gHeapList1;
+extern HeapAllocator data_020a4d60;
+extern HeapAllocator data_020a4d54;
 
 extern void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(HeapAllocator* list, HeapAllocator* item);
 extern void _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(HeapAllocator* list, HeapAllocator* item);
@@ -27,7 +27,7 @@ void func_0204f2d4(HeapObj* obj) {
         *(HeapAllocator**)((u8*)obj->unk8 + 0xc) = 0;
         obj->unk8 = 0;
     }
-    _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(&gHeapList0, (HeapAllocator*)obj);
-    _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(&gHeapList1, (HeapAllocator*)obj);
+    _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(&data_020a4d60, (HeapAllocator*)obj);
+    _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(&data_020a4d54, (HeapAllocator*)obj);
     *(u8*)((u8*)obj + 0x2c) = 0;
 }

--- a/src/func_0204f400.c
+++ b/src/func_0204f400.c
@@ -19,19 +19,19 @@ extern HeapAllocator* _ZN18NestedHeapIterator4NextEP13HeapAllocator(NestedHeapIt
 extern void _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(NestedHeapIteratorT* iter, HeapAllocator* pos, HeapAllocator* node);
 
 // The global NestedHeapIterator struct at 0x020a4d60
-extern NestedHeapIteratorT gHeapList;
+extern NestedHeapIteratorT data_020a4d60;
 
 void func_0204f400(HeapAllocator* self) {
     HeapAllocator* cur;
-    cur = _ZN18NestedHeapIterator4NextEP13HeapAllocator(&gHeapList, 0);
+    cur = _ZN18NestedHeapIterator4NextEP13HeapAllocator(&data_020a4d60, 0);
     if (cur != 0) {
         for (;;) {
             if (self->sortKey < cur->sortKey)
                 break;
-            cur = _ZN18NestedHeapIterator4NextEP13HeapAllocator(&gHeapList, cur);
+            cur = _ZN18NestedHeapIterator4NextEP13HeapAllocator(&data_020a4d60, cur);
             if (cur == 0)
                 break;
         }
     }
-    _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(&gHeapList, cur, self);
+    _ZN18NestedHeapIterator5AddAtEP13HeapAllocatorS1_(&data_020a4d60, cur, self);
 }

--- a/src/func_0204f504.c
+++ b/src/func_0204f504.c
@@ -28,10 +28,10 @@ extern HeapAllocator* _ZN18NestedHeapIterator4NextEP13HeapAllocator(NestedHeapIt
 extern void _ZN18NestedHeapIterator6RemoveEP13HeapAllocator(NestedHeapIteratorT* iter, HeapAllocator* node);
 
 // Array at 0x020a4d6c
-extern IndexEntry gHeapTable[];
+extern IndexEntry data_020a4d6c[];
 
 void* func_0204f504(int index, void* unk) {
-    IndexEntry* entry = &gHeapTable[index];
+    IndexEntry* entry = &data_020a4d6c[index];
     HeapAllocator* first = _ZN18NestedHeapIterator4NextEP13HeapAllocator(&entry->iter, 0);
     if (first == 0)
         return 0;

--- a/src/func_02050950.c
+++ b/src/func_02050950.c
@@ -1,2 +1,2 @@
-extern int A, B;
-void func_02050950(void) { A = 0; B = 0; }
+extern int data_020a55fc, data_020a5634;
+void func_02050950(void) { data_020a55fc = 0; data_020a5634 = 0; }

--- a/src/func_02050d2c.c
+++ b/src/func_02050d2c.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02050d2c(void) { return G; }
+extern int data_020a5bb8;
+int func_02050d2c(void) { return data_020a5bb8; }

--- a/src/func_02050d3c.c
+++ b/src/func_02050d3c.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02050d3c(int v) { int old = G; G = v; return old; }
+extern int data_020a5bb8;
+int func_02050d3c(int v) { int old = data_020a5bb8; data_020a5bb8 = v; return old; }

--- a/src/func_020520a4.c
+++ b/src/func_020520a4.c
@@ -4,7 +4,7 @@ typedef struct NestedHeapIterator {
     int unk[8];
 } NestedHeapIterator;
 
-extern NestedHeapIterator gNestedHeapIter;  /* 0x020a5bbc */
+extern NestedHeapIterator data_020a5bbc;  /* 0x020a5bbc */
 
 extern u32  _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 state);
@@ -15,6 +15,6 @@ void func_020520a4(HeapAllocator *node)
     u32 state;
 
     state = _ZN3IRQ7DisableEv();
-    _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(&gNestedHeapIter, node);
+    _ZN18NestedHeapIterator7AddLastEP13HeapAllocator(&data_020a5bbc, node);
     _ZN3IRQ7RestoreEj(state);
 }

--- a/src/func_02053ea0.c
+++ b/src/func_02053ea0.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-int func_02053ea0(void) { return G[10]; }
+extern unsigned short data_020a6088[];
+int func_02053ea0(void) { return data_020a6088[10]; }

--- a/src/func_02053eb0.c
+++ b/src/func_02053eb0.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-int func_02053eb0(void) { return G[9]; }
+extern unsigned short data_020a6088[];
+int func_02053eb0(void) { return data_020a6088[9]; }

--- a/src/func_02053ec0.c
+++ b/src/func_02053ec0.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-int func_02053ec0(void) { return G[5]; }
+extern unsigned short data_020a6088[];
+int func_02053ec0(void) { return data_020a6088[5]; }

--- a/src/func_02053ed0.c
+++ b/src/func_02053ed0.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-int func_02053ed0(void) { return G[4]; }
+extern unsigned short data_020a6088[];
+int func_02053ed0(void) { return data_020a6088[4]; }

--- a/src/func_020541b8.c
+++ b/src/func_020541b8.c
@@ -4,7 +4,7 @@
  * the global VRAM register, then calls Vram__Map with those bits.
  * Returns the original bits value.
  */
-extern u16 gVramReg;  /* at 0x020a6088 */
+extern u16 data_020a6088;  /* at 0x020a6088 */
 extern void Vram__Map(u16 bits);
 
 u16 func_020541b8(u16 *bankBitsPtr)
@@ -13,7 +13,7 @@ u16 func_020541b8(u16 *bankBitsPtr)
 
     bits = *bankBitsPtr;
     *bankBitsPtr = 0;
-    gVramReg = gVramReg | bits;
+    data_020a6088 = data_020a6088 | bits;
     Vram__Map(bits);
     return bits;
 }

--- a/src/func_02055fb4.c
+++ b/src/func_02055fb4.c
@@ -2,7 +2,7 @@
 /* func_02055fb4 at 0x02055fb4 (likely _ZN3GXS11LoadBG3CharEPKvjj)
  * Loads BG3 char data using DMA if a channel is assigned, else CPU copy.
  */
-extern u32 RENDER_DMA_CHANNEL;
+extern u32 data_02099fd0;
 
 extern void *_ZN3G2S13GetBG3CharPtrEv(void);
 extern void DMASyncWordTransfer(u32 ch, const void *src, void *dst, u32 size);
@@ -11,8 +11,8 @@ extern void MultiCopy_Int(const void *src, void *dst, u32 size);
 void func_02055fb4(const void *src, u32 offset, u32 size)
 {
     void *charPtr = _ZN3G2S13GetBG3CharPtrEv();
-    if (RENDER_DMA_CHANNEL != (u32)-1)
-        DMASyncWordTransfer(RENDER_DMA_CHANNEL, src, (char *)charPtr + offset, size);
+    if (data_02099fd0 != (u32)-1)
+        DMASyncWordTransfer(data_02099fd0, src, (char *)charPtr + offset, size);
     else
         MultiCopy_Int(src, (char *)charPtr + offset, size);
 }

--- a/src/func_02056014.c
+++ b/src/func_02056014.c
@@ -3,7 +3,7 @@
  * Uses DMA channel if available, else CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void *func_02054d88(void);
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 void func_02056014(const void *src, unsigned int offset, unsigned int count)
 {
     void *base = func_02054d88();
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (char *)base + offset, count);
     } else {

--- a/src/func_02056074.c
+++ b/src/func_02056074.c
@@ -3,7 +3,7 @@
  * Uses DMA channel if available, else CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void *_ZN3G2S13GetBG2CharPtrEv(void);
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 void func_02056074(const void *src, unsigned int offset, unsigned int count)
 {
     void *base = _ZN3G2S13GetBG2CharPtrEv();
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (char *)base + offset, count);
     } else {

--- a/src/func_020560d4.c
+++ b/src/func_020560d4.c
@@ -2,7 +2,7 @@
 /* func_020560d4 at 0x020560d4 (likely _ZN3GXS11LoadBG2CharEPKvjj)
  * Loads BG2 char data using DMA if a channel is assigned, else CPU copy.
  */
-extern u32 RENDER_DMA_CHANNEL;
+extern u32 data_02099fd0;
 
 extern void *_ZN2G213GetBG2CharPtrEv(void);
 extern void DMASyncWordTransfer(u32 ch, const void *src, void *dst, u32 size);
@@ -11,8 +11,8 @@ extern void MultiCopy_Int(const void *src, void *dst, u32 size);
 void func_020560d4(const void *src, u32 offset, u32 size)
 {
     void *charPtr = _ZN2G213GetBG2CharPtrEv();
-    if (RENDER_DMA_CHANNEL != (u32)-1)
-        DMASyncWordTransfer(RENDER_DMA_CHANNEL, src, (char *)charPtr + offset, size);
+    if (data_02099fd0 != (u32)-1)
+        DMASyncWordTransfer(data_02099fd0, src, (char *)charPtr + offset, size);
     else
         MultiCopy_Int(src, (char *)charPtr + offset, size);
 }

--- a/src/func_020562b4.c
+++ b/src/func_020562b4.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern u32 gDmaChannel;
+extern u32 data_02099fd0;
 
 extern void *_ZN3G2S12GetBG3ScrPtrEv(void);
 extern void DMASyncHalfTransfer(u32 channel, const void *src, void *dst, u32 count);
@@ -11,7 +11,7 @@ void func_020562b4(const void *src, u32 offset, u32 count)
     u32 ch;
 
     bgPtr = _ZN3G2S12GetBG3ScrPtrEv();
-    ch = gDmaChannel;
+    ch = data_02099fd0;
     if (ch != (u32)~0)
         DMASyncHalfTransfer(ch, src, (char *)bgPtr + offset, count);
     else

--- a/src/func_02056314.c
+++ b/src/func_02056314.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern s32 RENDER_DMA_CHANNEL;
+extern s32 data_02099fd0;
 
 void *_ZN2G212GetBG3ScrPtrEv(void);
 void DMASyncHalfTransfer(s32 channel, void *dst, void *src, u32 len);
@@ -7,7 +7,7 @@ void MultiCopyHalf(void *dst, void *src, u32 len);
 
 void func_02056314(void *dst, u32 offset, u32 len) {
     void *ip = _ZN2G212GetBG3ScrPtrEv();
-    s32 chan = RENDER_DMA_CHANNEL;
+    s32 chan = data_02099fd0;
     if (chan != -1) {
         DMASyncHalfTransfer(chan, dst, (char *)ip + offset, len);
     } else {

--- a/src/func_02056374.c
+++ b/src/func_02056374.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern u32 gDmaChannel;
+extern u32 data_02099fd0;
 
 extern void *_ZN3G2S12GetBG2ScrPtrEv(void);
 extern void DMASyncHalfTransfer(u32 channel, const void *src, void *dst, u32 count);
@@ -11,7 +11,7 @@ void func_02056374(const void *src, u32 offset, u32 count)
     u32 ch;
 
     bgPtr = _ZN3G2S12GetBG2ScrPtrEv();
-    ch = gDmaChannel;
+    ch = data_02099fd0;
     if (ch != (u32)~0)
         DMASyncHalfTransfer(ch, src, (char *)bgPtr + offset, count);
     else

--- a/src/func_020563d4.c
+++ b/src/func_020563d4.c
@@ -1,5 +1,5 @@
 #include "types.h"
-extern u32 gDmaChannel;
+extern u32 data_02099fd0;
 
 extern void *_ZN2G212GetBG2ScrPtrEv(void);
 extern void DMASyncHalfTransfer(u32 channel, const void *src, void *dst, u32 count);
@@ -11,7 +11,7 @@ void func_020563d4(const void *src, u32 offset, u32 count)
     u32 ch;
 
     bgPtr = _ZN2G212GetBG2ScrPtrEv();
-    ch = gDmaChannel;
+    ch = data_02099fd0;
     if (ch != (u32)~0)
         DMASyncHalfTransfer(ch, src, (char *)bgPtr + offset, count);
     else

--- a/src/func_02056434.c
+++ b/src/func_02056434.c
@@ -2,12 +2,12 @@ extern volatile unsigned char* _ZN3G2S12GetBG1ScrPtrEv(void);
 extern void DMASyncHalfTransfer(int channel, const void* src, volatile void* dst, int count);
 extern void MultiCopyHalf(const void* src, volatile void* dst, int count);
 
-extern int RENDER_DMA_CHANNEL;
+extern int data_02099fd0;
 
 void func_02056434(const void* src, int offset, int count)
 {
     volatile unsigned char* ptr = _ZN3G2S12GetBG1ScrPtrEv();
-    int ch = RENDER_DMA_CHANNEL;
+    int ch = data_02099fd0;
     if (ch != -1)
     {
         DMASyncHalfTransfer(ch, src, ptr + offset, count);

--- a/src/func_02056494.c
+++ b/src/func_02056494.c
@@ -2,12 +2,12 @@ extern volatile unsigned char* _ZN2G212GetBG1ScrPtrEv(void);
 extern void DMASyncHalfTransfer(int channel, const void* src, volatile void* dst, int count);
 extern void MultiCopyHalf(const void* src, volatile void* dst, int count);
 
-extern int RENDER_DMA_CHANNEL;
+extern int data_02099fd0;
 
 void func_02056494(const void* src, int offset, int count)
 {
     volatile unsigned char* ptr = _ZN2G212GetBG1ScrPtrEv();
-    int ch = RENDER_DMA_CHANNEL;
+    int ch = data_02099fd0;
     if (ch != -1)
     {
         DMASyncHalfTransfer(ch, src, ptr + offset, count);

--- a/src/func_020564f4.c
+++ b/src/func_020564f4.c
@@ -2,12 +2,12 @@ extern volatile unsigned char* _ZN3G2S12GetBG0ScrPtrEv(void);
 extern void DMASyncHalfTransfer(int channel, const void* src, volatile void* dst, int count);
 extern void MultiCopyHalf(const void* src, volatile void* dst, int count);
 
-extern int RENDER_DMA_CHANNEL;
+extern int data_02099fd0;
 
 void func_020564f4(const void* src, int offset, int count)
 {
     volatile unsigned char* ptr = _ZN3G2S12GetBG0ScrPtrEv();
-    int ch = RENDER_DMA_CHANNEL;
+    int ch = data_02099fd0;
     if (ch != -1)
     {
         DMASyncHalfTransfer(ch, src, ptr + offset, count);

--- a/src/func_02056554.c
+++ b/src/func_02056554.c
@@ -2,12 +2,12 @@ extern volatile unsigned char* _ZN2G212GetBG0ScrPtrEv(void);
 extern void DMASyncHalfTransfer(int channel, const void* src, volatile void* dst, int count);
 extern void MultiCopyHalf(const void* src, volatile void* dst, int count);
 
-extern int RENDER_DMA_CHANNEL;
+extern int data_02099fd0;
 
 void func_02056554(const void* src, int offset, int count)
 {
     volatile unsigned char* ptr = _ZN2G212GetBG0ScrPtrEv();
-    int ch = RENDER_DMA_CHANNEL;
+    int ch = data_02099fd0;
     if (ch != -1)
     {
         DMASyncHalfTransfer(ch, src, ptr + offset, count);

--- a/src/func_020565b4.c
+++ b/src/func_020565b4.c
@@ -3,7 +3,7 @@
  * Uses DMA channel if available, else CPU copy.
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
 extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
@@ -12,7 +12,7 @@ extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 
 void func_020565b4(const void *src, unsigned int offset, unsigned int count)
 {
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     unsigned int base = 0x6600000;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (void *)(base + offset), count);

--- a/src/func_02056674.c
+++ b/src/func_02056674.c
@@ -4,14 +4,14 @@
  * Destination 0x07000400 is a NDS texture slot VRAM address (ARM9 view).
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
 extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 
 void func_02056674(const void *src, unsigned int offset, unsigned int count)
 {
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (void *)(0x07000400 + offset), count);
     } else {

--- a/src/func_020566dc.c
+++ b/src/func_020566dc.c
@@ -4,14 +4,14 @@
  * Destination 0x07000000 is a NDS texture slot VRAM base address (ARM9 view).
  */
 
-extern unsigned int RENDER_DMA_CHANNEL;
+extern unsigned int data_02099fd0;
 
 extern void DMASyncWordTransfer(unsigned int channel, const void *src, void *dst, unsigned int count);
 extern void MultiCopy_Int(const void *src, void *dst, unsigned int count);
 
 void func_020566dc(const void *src, unsigned int offset, unsigned int count)
 {
-    unsigned int channel = RENDER_DMA_CHANNEL;
+    unsigned int channel = data_02099fd0;
     if (channel != (unsigned int)-1) {
         DMASyncWordTransfer(channel, src, (void *)(0x7000000 + offset), count);
     } else {

--- a/src/func_02056e4c.c
+++ b/src/func_02056e4c.c
@@ -5,14 +5,14 @@ struct TimerIRQEntry {
     u32 arg;        /* +8 */
 };
 
-extern struct TimerIRQEntry gTimerIRQTable[];  /* 0x020a60f4 */
+extern struct TimerIRQEntry data_020a60f4[];  /* 0x020a60f4 */
 
 extern void _ZN3IRQ10EnableIRQsEj(u32 mask);
 
 void func_02056e4c(u32 idx, u32 handler, u32 arg)
 {
-    gTimerIRQTable[idx].handler = handler;
-    gTimerIRQTable[idx].arg = arg;
+    data_020a60f4[idx].handler = handler;
+    data_020a60f4[idx].arg = arg;
     _ZN3IRQ10EnableIRQsEj(1u << (idx + 3));
-    gTimerIRQTable[idx].active = 1;
+    data_020a60f4[idx].active = 1;
 }

--- a/src/func_02056e98.c
+++ b/src/func_02056e98.c
@@ -5,15 +5,15 @@ struct DMAIRQEntry {
     u32 arg;        /* +8 */
 };
 
-extern struct DMAIRQEntry gDMAIRQTable[];   /* 0x020a60c4 */
+extern struct DMAIRQEntry data_020a60c4[];   /* 0x020a60c4 */
 
 extern u32 _ZN3IRQ10EnableIRQsEj(u32 mask);
 
 void func_02056e98(u32 idx, u32 handler, u32 arg)
 {
     u32 mask = 1u << (idx + 8);
-    gDMAIRQTable[idx].handler = handler;
-    gDMAIRQTable[idx].arg = arg;
+    data_020a60c4[idx].handler = handler;
+    data_020a60c4[idx].arg = arg;
     u32 prev_ie = _ZN3IRQ10EnableIRQsEj(mask);
-    gDMAIRQTable[idx].active = prev_ie & (1u << (idx + 8));
+    data_020a60c4[idx].active = prev_ie & (1u << (idx + 8));
 }

--- a/src/func_02057000.c
+++ b/src/func_02057000.c
@@ -1,2 +1,2 @@
-extern short G[];
-void func_02057000(void) { G[0] = 0; }
+extern short data_023c0000[];
+void func_02057000(void) { data_023c0000[0] = 0; }

--- a/src/func_02057198.c
+++ b/src/func_02057198.c
@@ -9,7 +9,7 @@ extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ10RestoreAllEj(u32 state);
 extern void _ZN3IRQ7RestoreEj(u32 state);
 
-static u32 AtomicSwap(u32 val, LockObj *addr);
+static u32 func_0205a74c(u32 val, LockObj *addr);
 
 u32 func_02057198(u32 val, LockObj *addr, void (*cleanupFn)(void), u32 useAll)
 {
@@ -21,7 +21,7 @@ u32 func_02057198(u32 val, LockObj *addr, void (*cleanupFn)(void), u32 useAll)
     else
         state = _ZN3IRQ7DisableEv();
 
-    old = AtomicSwap(val, addr);
+    old = func_0205a74c(val, addr);
     if (old == 0)
     {
         if (cleanupFn)

--- a/src/func_02057e48.c
+++ b/src/func_02057e48.c
@@ -7,13 +7,13 @@ typedef struct {
     u32 unk10;
 } IRQState;
 
-extern IRQState gIRQState; // 0x020a6134
+extern IRQState data_020a6134; // 0x020a6134
 
 u32 func_02057e48(u32 newVal) {
     u32 r5 = newVal;
     u32 saved = _ZN3IRQ7DisableEv();
-    u32 r4 = gIRQState.unk10;
-    gIRQState.unk10 = r5;
+    u32 r4 = data_020a6134.unk10;
+    data_020a6134.unk10 = r5;
     _ZN3IRQ7RestoreEj(saved);
     return r4;
 }

--- a/src/func_0205950c.c
+++ b/src/func_0205950c.c
@@ -3,14 +3,14 @@ extern void _ZN4CP159EnableMPUEv(void);
 extern void _ZN4CP1510DisableMPUEv(void);
 
 typedef void (*MPUFunc)(u32*, u32);
-extern MPUFunc gMPUCallback;
-extern u32 gMPUCallbackArg;
-extern u32 gMPUCallbackData;
+extern MPUFunc data_020a63a0;
+extern u32 data_020a63a4;
+extern u32 data_020a63ac;
 
 void func_0205950c(void)
 {
     MPUFunc f;
-    f = gMPUCallback;
+    f = data_020a63a0;
     if (f == 0)
         return;
     asm {
@@ -21,9 +21,9 @@ void func_0205950c(void)
     }
     _ZN4CP159EnableMPUEv();
     {
-        u32 a1 = gMPUCallbackArg;
-        MPUFunc fn = (MPUFunc)gMPUCallback;
-        u32* a0 = &gMPUCallbackData;
+        u32 a1 = data_020a63a4;
+        MPUFunc fn = (MPUFunc)data_020a63a0;
+        u32* a0 = &data_020a63ac;
         fn(a0, a1);
     }
     _ZN4CP1510DisableMPUEv();

--- a/src/func_02059578.c
+++ b/src/func_02059578.c
@@ -1,2 +1,2 @@
-extern int A[]; extern int B[];
-void func_02059578(int a, int b) { A[0] = a; B[0] = b; }
+extern int data_020a63a0[]; extern int data_020a63a4[];
+void func_02059578(int a, int b) { data_020a63a0[0] = a; data_020a63a4[0] = b; }

--- a/src/func_02059bb0.c
+++ b/src/func_02059bb0.c
@@ -1,2 +1,2 @@
-extern unsigned short G;
-int func_02059bb0(void) { return G; }
+extern unsigned short data_020a6440;
+int func_02059bb0(void) { return data_020a6440; }

--- a/src/func_02059bc0.c
+++ b/src/func_02059bc0.c
@@ -2,15 +2,15 @@
 extern void func_02059624(u32 bit);
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 
-extern volatile u16 gCtrl0;    /* 0x020a6440 */
-extern u32 gData0[2];          /* 0x020a6444 */
+extern volatile u16 data_020a6440;    /* 0x020a6440 */
+extern u32 data_020a6444[2];          /* 0x020a6444 */
 
 void func_02059bc0(void) {
-    if (gCtrl0 != 0)
+    if (data_020a6440 != 0)
         return;
-    gCtrl0 = 1;
+    data_020a6440 = 1;
     func_02059624(1);
-    u32 *data = gData0;
+    u32 *data = data_020a6444;
     data[0] = 0;
     data[1] = 0;
     _ZN3IRQ11DisableIRQsEj(0x10);

--- a/src/func_02059cb4.c
+++ b/src/func_02059cb4.c
@@ -1,14 +1,14 @@
 #include "types.h"
 extern void _ZN3IRQ11DisableIRQsEj(u32 mask);
 
-extern volatile u16 gCtrl1;    /* 0x020a644c */
-extern u32 gData2[2];          /* 0x020a6450 */
+extern volatile u16 data_020a644c;    /* 0x020a644c */
+extern u32 data_020a6450[2];          /* 0x020a6450 */
 
 void func_02059cb4(void) {
-    if (gCtrl1 != 0)
+    if (data_020a644c != 0)
         return;
-    u32 *data = gData2;
-    gCtrl1 = 1;
+    u32 *data = data_020a6450;
+    data_020a644c = 1;
     data[0] = 0;
     data[1] = 0;
     _ZN3IRQ11DisableIRQsEj(4);

--- a/src/func_0205d23c.c
+++ b/src/func_0205d23c.c
@@ -4,7 +4,7 @@ struct Node {
     struct Node *next;
 };
 
-extern struct Node *gNodeList_020a8048;
+extern struct Node *data_020a8048;
 
 void *func_0205d304(void);
 u32 _ZN3IRQ7DisableEv(void);
@@ -13,7 +13,7 @@ void _ZN3IRQ7RestoreEj(u32 state);
 struct Node *func_0205d23c(void) {
     void *r5 = func_0205d304();
     u32 irqState = _ZN3IRQ7DisableEv();
-    struct Node *r4 = gNodeList_020a8048;
+    struct Node *r4 = data_020a8048;
     while (r4 != 0 && r4->key != r5) {
         r4 = r4->next;
     }

--- a/src/func_0205db88.c
+++ b/src/func_0205db88.c
@@ -8,9 +8,9 @@ struct Obj {
     char data[1];
 };
 
-extern struct Storage gStorage_020a8064;
-extern struct Storage gStorage_020a806c;
-extern struct Obj gObj_0209a7d8;
+extern struct Storage data_020a8064;
+extern struct Storage data_020a806c;
+extern struct Obj data_0209a7d8;
 
 u32 func_0205e904(u32 newVal);
 u32 func_0205de9c(struct Obj *obj, void *a, void *b);
@@ -23,13 +23,13 @@ void func_0205db88(u32 r0, void *r1, void *r2) {
     void *r7 = r1;
     void *r6 = r2;
     if (r0 == 0) {
-        r5 = &gStorage_020a8064;
+        r5 = &data_020a8064;
     } else {
-        r5 = &gStorage_020a806c;
+        r5 = &data_020a806c;
     }
     if (r7 != 0 && r0 == 0) {
         u32 r4 = func_0205e904(1);
-        if (!func_0205de9c(&gObj_0209a7d8, r7, r6)) {
+        if (!func_0205de9c(&data_0209a7d8, r7, r6)) {
             Crash();
         }
         func_0205e904(r4);

--- a/src/func_0205e088.c
+++ b/src/func_0205e088.c
@@ -1,11 +1,11 @@
 struct Pair { void *a; int b; };
 
-extern int someGlobal;
+extern int data_020a8074;
 
 void func_0205e088(struct Pair *dst, char *src)
 {
     struct Pair v;
-    v.a = &someGlobal;
+    v.a = &data_020a8074;
     v.b = *(int*)(src + 0x18);
     *dst = v;
 }

--- a/src/func_0205e904.c
+++ b/src/func_0205e904.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_0205e904(int v) { int old = G; G = v; return old; }
+extern int data_020a80c4;
+int func_0205e904(int v) { int old = data_020a80c4; data_020a80c4 = v; return old; }

--- a/src/func_0205edc8.c
+++ b/src/func_0205edc8.c
@@ -1,2 +1,2 @@
-extern unsigned short G[];
-int func_0205edc8(void) { return G[6]; }
+extern unsigned short data_020a80cc[];
+int func_0205edc8(void) { return data_020a80cc[6]; }

--- a/src/func_0205ff20.c
+++ b/src/func_0205ff20.c
@@ -2,16 +2,16 @@
 extern u32 _ZN3IRQ7DisableEv(void);
 extern void _ZN3IRQ7RestoreEj(u32 prev);
 
-extern u32 gFlag;  /* 0x020a8114 */
+extern u32 data_020a8114;  /* 0x020a8114 */
 
 u32 func_0205ff20(void) {
     u32 saved = _ZN3IRQ7DisableEv();
-    u32 r2 = gFlag;
+    u32 r2 = data_020a8114;
     if (r2 != 0) {
         _ZN3IRQ7RestoreEj(saved);
         return 0;
     }
-    gFlag = 1;
+    data_020a8114 = 1;
     _ZN3IRQ7RestoreEj(saved);
     return 1;
 }

--- a/src/func_0206045c.c
+++ b/src/func_0206045c.c
@@ -1,2 +1,2 @@
-extern int *G;
-int func_0206045c(void) { return G[1]; }
+extern int *data_020a8760;
+int func_0206045c(void) { return data_020a8760[1]; }

--- a/src/func_02060470.c
+++ b/src/func_02060470.c
@@ -1,2 +1,2 @@
-extern int *G;
-int func_02060470(void) { return G[0]; }
+extern int *data_020a8760;
+int func_02060470(void) { return data_020a8760[0]; }

--- a/src/func_02060918.c
+++ b/src/func_02060918.c
@@ -23,8 +23,8 @@ extern struct S8180 data_020a8180;
 extern char data_020a8780;
 extern struct S6134 data_020a6134;
 
-extern u32 IRQ_Disable(void);
-extern void IRQ_Restore(u32);
+extern u32 _ZN3IRQ7DisableEv(void);
+extern void _ZN3IRQ7RestoreEj(u32);
 
 void OS_SleepThread(void *p);
 void func_02059f58(int a);
@@ -40,7 +40,7 @@ void func_02060918(u32 a0, u32 a1, u32 a2, u32 a3, u32 a4, u32 a5, int a6)
     char *cb = &data_020a8780;
     u32 mask;
 
-    mask = IRQ_Disable();
+    mask = _ZN3IRQ7DisableEv();
     while (t->f34 & 4) {
         OS_SleepThread(&t->fd4);
     }
@@ -48,7 +48,7 @@ void func_02060918(u32 a0, u32 a1, u32 a2, u32 a3, u32 a4, u32 a5, int a6)
         u32 *p34 = (u32 *)(((int)t + 0x34));
         *p34 |= 4;
     }
-    IRQ_Restore(mask);
+    _ZN3IRQ7RestoreEj(mask);
 
     t->f24 = a0;
     t->f18 = a1;

--- a/src/func_02060a30.c
+++ b/src/func_02060a30.c
@@ -6,10 +6,10 @@ typedef struct {
     void (*vtable)(void *);
 } SomeObj;
 
-extern SomeObj gObj2;  /* 0x020a8780 */
+extern SomeObj data_020a8780;  /* 0x020a8780 */
 
 void func_02060a30(void) {
-    SomeObj *obj = &gObj2;
+    SomeObj *obj = &data_020a8780;
     if (func_02060ebc(obj)) {
         obj->vtable(obj);
     }

--- a/src/func_02065a74.c
+++ b/src/func_02065a74.c
@@ -1,2 +1,2 @@
-extern int G;
-int func_02065a74(void) { return G; }
+extern int data_0209a074;
+int func_02065a74(void) { return data_0209a074; }

--- a/src/func_02065a84.c
+++ b/src/func_02065a84.c
@@ -1,3 +1,3 @@
 /* func_02065a84 - store a word to a global: *g = x */
-extern int data_02065a84_g;
-void func_02065a84(int x) { data_02065a84_g = x; }
+extern int data_0209a074;
+void func_02065a84(int x) { data_0209a074 = x; }

--- a/src/func_02065ad0.c
+++ b/src/func_02065ad0.c
@@ -1,2 +1,2 @@
-extern int G[];
-void func_02065ad0(int v) { G[0] = v; }
+extern int data_020a94d0[];
+void func_02065ad0(int v) { data_020a94d0[0] = v; }


### PR DESCRIPTION
Each file in this batch referenced a name `config/**/symbols.txt` does not define. [`notes/link-verification.md`](../blob/main/notes/link-verification.md) calls these the **BLIND** matches and concludes:

> No static tool can verify those destinations; only a fuller symbol table would.

That holds for a static tool — but the ROM build is not one. **The function byte-matches, so the ROM's own linked word at the relocation slot *is* the destination.** Decode it (a `BL` target, or an `R_ARM_ABS32` pool word minus its addend) and look the address up.

`tools/resolve_blind.py` (PR #941) does this per file and per relocation, which matters because the names come in two shapes that need opposite treatment:

**Shared names with one true target** — mostly double-mangling artifacts, where an already-mangled name was mangled again:

| refs | invented name | what the ROM links to |
|---:|---|---|
| 177 | `_Z28_ZN13SharedFilePtr7ReleaseEvPv` | `_ZN13SharedFilePtr7ReleaseEv` |
| 78 | `_Z39_ZN9Animation8LoadFileER13SharedFilePtrPv` | `_ZN9Animation8LoadFileER13SharedFilePtr` |
| 70 | `_Z31_ZN16MeshColliderBase7DisableEvPv` | `_ZN16MeshColliderBase7DisableEv` |
| 68 | `_Z33_ZN16MeshColliderBase9IsEnabledEvPv` | `_ZN16MeshColliderBase9IsEnabledEv` |
| 36 | `_Z10DeallocatePv` | `Deallocate` |

**Per-file placeholders**, where a global rename would be actively *wrong*: `G0` appears in 480 files and means **173 different addresses**; `G2` in 143 files means 142 different addresses; `G1` 107, `G3` 111, `VT1` 42. Only per-file resolution is correct here.

Of 6,238 unresolvable references, all but 65 resolve to a real symbol. The 65 are mostly not addresses at all (`0x04000204` is a hardware register, `0x00000006` a constant), so nothing is renamed for them and those files keep their unresolved reference.

Every rename is byte-verified against the ROM before being kept; a file that stops matching is reverted untouched.

This closes most of the residual blind spot that note describes, and it does so from data already in the ROM rather than from new symbol-table work.

Verified with `tools/prepush_linkcheck.py` across the whole change: 1,604 checked, 0 blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZipJbjwrhPze4qsoKGyi
