### PR TITLE
Clean up residue left by the launder-mask sweep (5 files)

### DIFF
--- a/src/_ZN14UnchainedChomp13InitResourcesEv.cpp
+++ b/src/_ZN14UnchainedChomp13InitResourcesEv.cpp
@@ -112,7 +112,7 @@ extern "C" int _ZN14UnchainedChomp13InitResourcesEv(unsigned char* thiz)
         pp.GetNode(*(Vector3*)(thiz + 0x5c), *(unsigned int*)(thiz + 0x6b4));
     }
 
-    /* u64-mask launder: materialize add r1,r4,#0x60; ldr/str [r1] for y += 0x64000 */
+    /* cast launder: materialize add r1,r4,#0x60; ldr/str [r1] for y += 0x64000 */
     *(int *)(((int)thiz + 0x60)) += 0x64000;
     *(int*)(thiz + 0x80) = 0x1000;
     *(int*)(thiz + 0x84) = 0x1000;

--- a/src/_ZN6Dorrie13InitResourcesEv.cpp
+++ b/src/_ZN6Dorrie13InitResourcesEv.cpp
@@ -63,7 +63,7 @@ int Dorrie::InitResources()
         unk_1194 = mPosX;
         unk_1198 = mPosY;
         unk_119c = mPosZ;
-        /* u64-mask launder: materialize add r2,sl,#0x5c; ldr/str [r2] */
+        /* cast launder: materialize add r2,sl,#0x5c; ldr/str [r2] */
         *(int*)(((int)((char*)this) + 0x5c)) += 0x7d0000;
     }
     _ZN12WithMeshClsn4InitEP5Actor5Fix12IiES3_P10Vector3_16S5_(

--- a/src/func_0200bb28.c
+++ b/src/func_0200bb28.c
@@ -17,9 +17,9 @@ extern s32 Math_Function_0203b14c(s32* p, s32 tgt, s32 rate, s32 lim, s32 step);
 extern s32 _Z14ApproachLinearR7Vector3RKS_5Fix12IiE(s32* v, s32* t, s32 rate);
 
 #define L0(p) ((s32)(((long long)(s32)(p))))
-#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p))ULL))
+#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p))))
 #define L2(p) ((s32)((((long long)(s32)(p)) | 0LL)))
-#define L3(p) ((s32)(((unsigned long long)(s32)(p))ULL))
+#define L3(p) ((s32)(((unsigned long long)(s32)(p))))
 
 
 

--- a/src/func_0205e3d4.c
+++ b/src/func_0205e3d4.c
@@ -13,10 +13,7 @@
      `mov r0, #0` above the two save loads.
    - The round-1 K read goes through a volatile pointer. Register pressure in
      the round-1 body is what keeps K[0] un-hoisted in the ROM; rounds 2..4
-     hoist their K into the preheader on their own.
-   - The Intermediate_Hash[1..4] updates use the u64 identity launder so each
-     one materializes its own base register (`add r3, ip, #4` etc.) instead of
-     folding into `[ip, #4]`. */
+     hoist their K into the preheader on their own. */
 
 typedef struct
 {

--- a/src/func_ov084_021298d0.cpp
+++ b/src/func_ov084_021298d0.cpp
@@ -32,8 +32,8 @@ int func_ov084_021298d0(char* c){
             }
         }
     }
-    /* u64-mask launder: force add r2,r5,#0x198 materialization (sibling ov084 idiom) */
-    *(int*)(((int)c + 0x198)ULL) |= 0x20000;
+    /* cast launder: force add r2,r5,#0x198 materialization (sibling ov084 idiom) */
+    *(int*)(((int)c + 0x198)) |= 0x20000;
     _ZN12CylinderClsn5ClearEv(c + 0x180);
     _ZN12CylinderClsn6UpdateEv(c + 0x180);
 


### PR DESCRIPTION
Follow-up on my own sweep (#900-912), which removed the non-load-bearing `& 0xFFFFFFFFFFFFFFFF` masks.

**Orphaned integer suffix.** The regex matched the mask but not a trailing `ULL`, so two sites kept a suffix hanging off a parenthesised expression:

```c
*(int*)(((int)c + 0x198)ULL) |= 0x20000;          // func_ov084_021298d0.cpp
#define L1(p) ((s32)(((unsigned long long)(unsigned int)(p))ULL))   // func_0200bb28.c
```

mwccarm accepts it and both files still byte-match, so nothing was broken, but it is meaningless syntax that reads like a typo.

**Comments describing a mask that is gone.** The same regex ran over comment text. Three comments still call the idiom a "u64-mask launder" when only the cast remains, and `func_0205e3d4.c` documented a launder that is no longer in the file at all. Reworded to "cast launder" where the cast still does the work; dropped the stale bullet.

I checked the wider blast radius before touching anything: of 56 files that mention laundering, most still use it via a `long long` cast, a `LAUNDER` macro, or `launder.h`, so their comments are accurate and untouched. Only these 5 needed anything.

All 5 re-verified: 4 VERIFIED, 1 BLIND, 0 WRONG.