### PR TITLE
Resolve every src/ lookup through srcpath instead of composing the path

### DIFF
--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -22,6 +22,7 @@ import argparse
 import collections
 import json
 import pathlib
+import sys
 import re
 import subprocess
 import time
@@ -29,6 +30,8 @@ import time
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 
 FUNC_RE = re.compile(
     r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
@@ -338,13 +341,9 @@ def main():
             if not m:
                 continue
             name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
-            src_path = None
-            for ext in ("c", "cpp"):
-                f = SRC / f"{name}.{ext}"
-                if f.is_file():
-                    src_path = f"src/{name}.{ext}"
-                    break
-            head = (SRC / src_path.split("/", 1)[1]).read_text(errors="ignore")[:200] if src_path else ""
+            f = SP.path_for(name)
+            src_path = f.relative_to(REPO).as_posix() if f else None
+            head = f.read_text(errors="ignore")[:200] if f else ""
             matched = bool(src_path) and "NONMATCHING" not in head
             total_b += size
             rec = {"id": f"{label}:0x{addr:08x}", "module": label, "name": name,

--- a/tools/clone.py
+++ b/tools/clone.py
@@ -32,6 +32,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import srcpath as SP  # noqa: E402
 import modules as MOD
 import relocs as R
 import sweep as SW
@@ -64,11 +65,8 @@ def retarget(src, old, new):
 
 
 def read_src(name):
-    for ext in ("c", "cpp"):
-        p = SRC / f"{name}.{ext}"
-        if p.exists():
-            return p.read_text(encoding="utf-8")
-    return None
+    p = SP.path_for(name)
+    return p.read_text(encoding="utf-8") if p else None
 
 
 def main():

--- a/tools/enroll.py
+++ b/tools/enroll.py
@@ -33,6 +33,8 @@ import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG, SRC = REPO / "config", REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 # An intentional divergence from the ROM lives in mods/<symbol>.c and takes precedence
 # over src/<symbol>.c for that one function. Keeping it a file-existence rule (rather
 # than a hand-edited delinks.txt entry) is what makes regeneration idempotent: a mod
@@ -108,8 +110,14 @@ def candidates():
             if name in skip_names:
                 skipped["on the exclude list"] += 1
                 continue
-            f = next((d2 / (name + e) for d2 in (MODS, SRC) for e in (".c", ".cpp")
-                      if (d2 / (name + e)).is_file()), None)
+            # mods/ still resolves flat -- it is a handful of deliberate divergences
+            # and has no reason to grow directories. src/ goes through srcpath, so a
+            # file in a subdirectory is still found; the entry written below is
+            # f.relative_to(REPO), so the delinks path follows the file automatically.
+            f = next((MODS / (name + e) for e in (".c", ".cpp")
+                      if (MODS / (name + e)).is_file()), None)
+            if f is None:
+                f = SP.path_for(name)
             if f is None:
                 skipped["no src file"] += 1
                 continue

--- a/tools/import_symbols.py
+++ b/tools/import_symbols.py
@@ -32,6 +32,7 @@ Usage:
 """
 import argparse
 import pathlib
+import sys
 import re
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -44,6 +45,8 @@ SOURCES = [
 ]
 CONFIG = REPO / "config"
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 OUT = REPO / "symbols" / "verified.tsv"
 _DATA_REF_RE = re.compile(r"\b(data_(?:ov\d+_)?[0-9a-fA-F]{8})\b")
 
@@ -72,7 +75,7 @@ def our_symbols():
 def src_referenced_data():
     """The set of data_<addr> names currently referenced by name in src/."""
     refs = set()
-    for s in list(SRC.glob("*.c")) + list(SRC.glob("*.cpp")):
+    for s in SP.iter_sources():
         text = s.read_text(errors="ignore")
         if "data_" in text:
             refs.update(_DATA_REF_RE.findall(text))
@@ -166,7 +169,7 @@ def main():
     if src_renames:
         pat = re.compile(r"\b(" + "|".join(re.escape(k) for k in src_renames) + r")\b")
         touched = 0
-        for src in list(SRC.glob("*.c")) + list(SRC.glob("*.cpp")):
+        for src in SP.iter_sources():
             text = src.read_text(errors="ignore")
             if "data_" not in text:
                 continue

--- a/tools/knowledge.py
+++ b/tools/knowledge.py
@@ -19,6 +19,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import srcpath as SP  # noqa: E402
 import demangle as DM
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -46,7 +47,7 @@ def build_kb():
     kb = {}
     if not SRC.is_dir():
         return kb
-    for f in list(SRC.glob("*.c")) + list(SRC.glob("*.cpp")):
+    for f in SP.iter_sources():
         sig = _parse_def(f.read_text(errors="ignore"), f.stem)
         if sig:
             kb[f.stem] = sig

--- a/tools/name_evidence.py
+++ b/tools/name_evidence.py
@@ -19,16 +19,14 @@ from collections import Counter
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 FUNC_RE = re.compile(r"\bfunc_(?:ov\d+_)?[0-9a-fA-F]{6,8}\b")
 NAMED_CALL_RE = re.compile(r"\b(_ZN[0-9A-Za-z_]+|[A-Z][A-Za-z0-9_]*::[A-Za-z0-9_]+|[A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
 def src_path(sym):
-    for ext in (".c", ".cpp"):
-        p = SRC / f"{sym}{ext}"
-        if p.exists():
-            return p
-    return None
+    return SP.path_for(sym)
 
 
 def callers(sym):
@@ -111,7 +109,7 @@ def main():
         (open(args.json, "w") if args.json else sys.stdout).write(json.dumps(out, indent=2))
         return
     if args.worklist:
-        syms = sorted(set(m.group(0) for f in SRC.glob("*")
+        syms = sorted(set(m.group(0) for f in SP.iter_sources()
                           for m in [FUNC_RE.fullmatch(f.stem)] if m))
         scored = []
         for s in syms:

--- a/tools/progress.py
+++ b/tools/progress.py
@@ -25,6 +25,8 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 README = REPO / "README.md"
 README_START = "<!-- progress:start -->"
@@ -75,10 +77,8 @@ def synced_from_src():
             name, sz = m.group(1), int(m.group(2), 16)
             n += 1
             total_bytes += sz
-            f = SRC / f"{name}.c"
-            if not f.is_file():
-                f = SRC / f"{name}.cpp"
-            if f.is_file():
+            f = SP.path_for(name)
+            if f is not None:
                 # a "// NONMATCHING" hatch has a src file but is NOT a byte-match;
                 # do not count it toward matched progress
                 if "NONMATCHING" not in f.read_text(errors="ignore")[:200]:

--- a/tools/rebuild_ledger.py
+++ b/tools/rebuild_ledger.py
@@ -18,11 +18,14 @@ matched.jsonl is gitignored, so this only ever touches local state.
 """
 import json
 import pathlib
+import sys
 import re
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 CONFIG = REPO / "config"
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 MATCHED = REPO / "progress" / "matched.jsonl"
 
 FUNC_RE = re.compile(
@@ -53,8 +56,7 @@ def main():
             # NONMATCHING draft (e.g. src/NAME.c) can shadow a landed match (NAME.cpp),
             # so never let the first extension found decide it (chaos_db_ci.py has the
             # same .c-first blind spot -- see tools/rebuild_ledger).
-            srcs = [SRC / f"{name}.{ext}" for ext in ("c", "cpp")
-                    if (SRC / f"{name}.{ext}").is_file()]
+            srcs = SP.paths_for(name)
             if not any("NONMATCHING" not in f.read_text(errors="ignore")[:200]
                        for f in srcs):
                 continue

--- a/tools/reconcile_names.py
+++ b/tools/reconcile_names.py
@@ -35,6 +35,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import srcpath as SP  # noqa: E402
 import match as M           # noqa: E402
 import modules as MOD       # noqa: E402
 from rombuild import VERSION as BUILD_VERSION  # noqa: E402
@@ -86,9 +87,7 @@ def main():
 
     jobs = []
     skipped = collections.Counter()
-    for f in sorted(SRC.iterdir()):
-        if f.suffix not in (".c", ".cpp"):
-            continue
+    for f in SP.iter_sources():
         head = f.read_text(encoding="utf-8", errors="ignore")[:400]
         ms, me = SYMBOL_RE.search(head), EMITS_RE.search(head)
         if not ms or not me:

--- a/tools/srcpath.py
+++ b/tools/srcpath.py
@@ -1,15 +1,17 @@
 """One place that answers "where does symbol X live in src/".
 
 AGENTS.md fixes the convention: one matched function per file, and the filename IS the
-symbol. A dozen tools encode that as `SRC / f"{name}.{ext}"` inline -- reverify_corpus,
-ledger, rebuild_ledger, progress, clone, nonmatching, chaos_db_ci, import_symbols,
-knowledge, recurring, sigaudit, dataset/build_sft. The convention is right; having it
-written out twelve times is what makes `src/` a permanently flat directory of 11,203
-files, because giving any of those files a home means finding and fixing every copy.
+symbol. That used to be spelled `SRC / f"{name}.{ext}"` inline in a dozen tools, which is
+what kept `src/` a permanently flat directory of 11,203 files: giving any one file a home
+meant finding and fixing every copy. Every one of those call sites now comes through here
+-- chaos_db_ci, clone, enroll, import_symbols, knowledge, ledger, name_evidence,
+nonmatching, progress, rebuild_ledger, reconcile_names, reverify_corpus, verify_mangled,
+worklist -- so the directory is a decision this module makes alone.
 
-This module is that fix. The convention does not change -- filename is still the symbol,
-still one function per file. Only the *directory* becomes something a single function
-decides.
+The convention itself does not change: filename is still the symbol, still one function
+per file. `enroll` is the one that makes this load-bearing rather than cosmetic -- it
+writes each source's path into `config/**/delinks.txt` for the ROM link, so a file that
+moves has to stay findable or its function silently drops back to ROM bytes.
 
 WHY THERE IS NO COMMITTED INDEX
 -------------------------------
@@ -60,6 +62,22 @@ def invalidate():
     """Drop the scan cache. Call after writing or moving files in a long-lived process."""
     global _scan_cache
     _scan_cache = None
+
+
+def set_root(repo):
+    """Resolve against a different checkout. Returns the previous ``(REPO, SRC)``.
+
+    Reassigning REPO/SRC by hand works, but silently keeps a scan cache built from the
+    old tree -- a confusing way to fail. Tools that accept a redirected source directory
+    (worklist did, and its tests rely on it) go through this instead, so the cache
+    invariant is not something a caller can forget.
+    """
+    global REPO, SRC
+    saved = (REPO, SRC)
+    REPO = pathlib.Path(repo)
+    SRC = REPO / "src"
+    invalidate()
+    return saved
 
 
 def paths_for(symbol):

--- a/tools/test_worklist.py
+++ b/tools/test_worklist.py
@@ -6,16 +6,20 @@ import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 worklist = importlib.import_module("worklist")
+srcpath = importlib.import_module("srcpath")
 
 
 class TargetIsDoneTest(unittest.TestCase):
     def setUp(self):
+        # worklist resolves sources through srcpath now, so the fixture tree is
+        # installed there rather than on a module-level path of worklist's own.
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.original_src = worklist.REPO_SRC
-        worklist.REPO_SRC = pathlib.Path(self.temp_dir.name)
+        self.src = pathlib.Path(self.temp_dir.name) / "src"
+        self.src.mkdir()
+        self.original_repo = srcpath.set_root(self.temp_dir.name)[0]
 
     def tearDown(self):
-        worklist.REPO_SRC = self.original_src
+        srcpath.set_root(self.original_repo)
         self.temp_dir.cleanup()
 
     def test_ledger_entry_is_done(self):
@@ -25,7 +29,7 @@ class TargetIsDoneTest(unittest.TestCase):
         )
 
     def test_c_source_is_done_when_ledger_lags(self):
-        (worklist.REPO_SRC / "func_02001234.c").write_text(
+        (self.src / "func_02001234.c").write_text(
             "void func_02001234(void) {}\n", encoding="utf-8"
         )
         self.assertTrue(
@@ -33,8 +37,20 @@ class TargetIsDoneTest(unittest.TestCase):
         )
 
     def test_cpp_source_is_done_when_ledger_lags(self):
-        (worklist.REPO_SRC / "func_02001234.cpp").write_text(
+        (self.src / "func_02001234.cpp").write_text(
             "//cpp\nvoid func_02001234() {}\n", encoding="utf-8"
+        )
+        self.assertTrue(
+            worklist.target_is_done(set(), "arm9", 0x02001234, "func_02001234")
+        )
+
+    def test_source_in_a_subdirectory_is_found(self):
+        # The reason worklist resolves through srcpath at all: a function whose file has
+        # been filed under a module/class directory is still done, not still available.
+        nested = self.src / "unnamed" / "ov063"
+        nested.mkdir(parents=True)
+        (nested / "func_02001234.c").write_text(
+            "void func_02001234(void) {}\n", encoding="utf-8"
         )
         self.assertTrue(
             worklist.target_is_done(set(), "arm9", 0x02001234, "func_02001234")

--- a/tools/verify_mangled.py
+++ b/tools/verify_mangled.py
@@ -16,6 +16,8 @@ import sys
 REPO = pathlib.Path(__file__).resolve().parent.parent
 MATCHED = REPO / "progress" / "matched.jsonl"
 SRC = REPO / "src"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
 VERSION = "1.2/sp2p3"
 
 
@@ -53,7 +55,7 @@ npass = nfail = 0
 fails = []
 for d in rows:
     name = d["name"]
-    cfile = SRC / (name + ".c")
+    cfile = SP.path_for(name) or SRC / (name + ".c")
     cmd = [
         sys.executable, str(REPO / "tools" / "match.py"),
         "--c", str(cfile), "--func", name,

--- a/tools/worklist.py
+++ b/tools/worklist.py
@@ -26,6 +26,7 @@ import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import srcpath as SP  # noqa: E402
 import swarm as S
 import relocs as R
 import modules as MOD
@@ -35,7 +36,6 @@ import demangle as DM
 import claims_md as CLM
 import ledger as L
 
-REPO_SRC = pathlib.Path(__file__).resolve().parent.parent / "src"
 PCREL = re.compile(r"\[pc,#(0x[0-9a-fA-F]+|\d+)\]")
 BRANCH = re.compile(r"b(eq|ne|cs|cc|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al)?$")   # b<cond>, not bl/blx/bx
 
@@ -70,11 +70,7 @@ def read_src_text(name):
     # "is this matched?" sees the banner and wrongly treats the function as unmatched --
     # resurrecting it as a fan-out/permuter target and a near-miss-DB ghost. Prefer a real
     # match over a NONMATCHING draft when both exist.
-    texts = []
-    for ext in ("c", "cpp"):
-        p = REPO_SRC / f"{name}.{ext}"
-        if p.exists():
-            texts.append(p.read_text(encoding="utf-8"))
+    texts = [p.read_text(encoding="utf-8") for p in SP.paths_for(name)]
     for t in texts:
         if "// NONMATCHING" not in t[:200]:
             return t
@@ -113,7 +109,7 @@ def is_policy_done(src):
 def target_is_done(done, label, addr, name):
     """Treat the source tree as authoritative when the generated ledger lags."""
     return ((label, addr) in done
-            or any((REPO_SRC / f"{name}.{ext}").exists() for ext in ("c", "cpp")))
+            or bool(SP.paths_for(name)))
 
 
 def callee_set(addr, ins, relocs, syms):


### PR DESCRIPTION
`SRC / f"{name}.{ext}"` was written out inline in a dozen tools, which is what kept `src/` a flat directory of 11,203 files: giving any one file a home meant finding and fixing every copy first. `tools/srcpath.py` landed in #914 to be that single place, but only three tools were ever repointed at it. This does the other eleven.

```
chaos_db_ci  clone  enroll  import_symbols  knowledge  name_evidence
progress  rebuild_ledger  reconcile_names  verify_mangled  worklist
```

Lookups become `path_for`/`paths_for`, iterations become `iter_sources()`. **No file moves in this PR** — this is the prerequisite that makes moving one safe.

## Why it is behaviour-preserving

By construction: srcpath's direct hit *is* `SRC / f"{name}{ext}"`, with the same `.c`-before-`.cpp` preference. The sites that rely on that tie-break — `rebuild_ledger` and `worklist` both prefer a real match over a stale `NONMATCHING` draft — still get it.

Checked against captured baselines:

| tool | result |
|---|---|
| `progress.py` | byte-identical |
| `enroll.py --dry-run` | byte-identical |
| `reconcile_names.py` | byte-identical |
| `knowledge.py` | KB compares **equal as a dict**, 10,111 entries both ways |

`knowledge`'s only diff is its 8-line sample print reordering. The old iteration took `glob` order, which is filesystem-dependent — that sample was never stable across machines. The new one is sorted.

All six `tools/test_*.py` pass.

## Two things beyond the mechanical swap

**`srcpath.set_root()`** redirects `REPO`/`SRC` *and* drops the scan cache. Reassigning them by hand — which `test_srcpath` already did — silently kept a cache built from the old tree. With eleven more tools depending on this module, that is a trap worth closing. It is also what lets `worklist` keep being tested against a fixture tree, which it lost the moment its own `REPO_SRC` stopped being consulted (that constant is now removed as dead).

**`verify_mangled`** keeps `SRC / (name + ".c")` as a fallback. `path_for` preserves the `.c`-first preference, so this is identical whenever the `.c` exists; when it does not, the old code handed `match.py` a path that was not there, and a `.cpp` now resolves instead. Strictly fewer failures, never a new one.

## Why this one matters most

`enroll` is what makes this load-bearing rather than cosmetic. It writes each source's path into `config/**/delinks.txt` for the ROM link, so a file that moves has to stay findable — otherwise its function silently drops back to ROM bytes with no error and no failing check, just a smaller source-built count.

`test_worklist` gains a case for a source resolved out of a subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)