### PR TITLE
arm9: land the five terminal-floor sources as declared drafts

### DIFF
--- a/src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii.cpp
+++ b/src/_ZN3OAM6RenderEbP7OamAttriiii5Fix12IiES3_ii.cpp
@@ -1,0 +1,252 @@
+//cpp
+// NONMATCHING (TERMINAL-FLOOR): functionally-verified C at the proven compiler floor.
+// OAM::Render(bool, OamAttr*, int, int, int, int, Fix12<int>, Fix12<int>, int, int)
+// @ 0x02020994 (arm9, size 0x690). 2 words diverge: one prologue filler transposition
+// (ldr fp,[sp,#0x8c] / str r0,[sp,#0x94] swapped at +0x38). A pre-body, parameter-count-
+// driven filler-zip tie-break, immune to all body-level source (notes 6ay); all owned
+// builds agree against the ROM. Order-only delta: functionally identical.
+// TU NOTE: the pragma offs below are unscoped; folding this file into a multi-function
+// TU requires scoped restores which change these bytes (6ay trap).
+#pragma opt_common_subs off
+#pragma opt_propagation off
+#pragma opt_loop_invariants off
+
+typedef signed char s8;
+typedef short s16;
+typedef unsigned short u16;
+typedef int s32;
+typedef unsigned int u32;
+typedef unsigned char u8;
+typedef long long s64;
+
+template <typename T> struct Fix12 { T val; };
+
+struct OamAttr { u32 a01; u16 a2; u16 a3; };
+struct OamEntry { u32 a01; u16 a2; u16 pad; };
+struct Matrix2x2 { int a, b, c, d; };
+
+extern "C" {
+extern u8 data_0209e660;
+extern int data_0209e664;
+extern int data_0209e668;
+extern int data_0209e66c;
+extern int data_0209e670;
+extern OamEntry data_0209e674[];
+extern OamEntry data_0209ea74[];
+extern s16 data_02082214[];
+}
+
+struct OAM {
+    static void Render(bool sub, OamAttr *attr, int xOff, int yOff, int palette, int priority,
+                       Fix12<int> scaleX, Fix12<int> scaleY, int rotation, int mode);
+    static u8 GetObjWidth(int shape, int size);
+    static u8 GetObjHeight(int shape, int size);
+    static int LoadAffineParams(OamAttr *attr, int *affCnt, Matrix2x2 *m);
+};
+
+namespace cstd { int fdiv(int num, int den); }
+
+void OAM::Render(bool sub, OamAttr *attr, int xOff, int yOff, int palette, int priority,
+                 Fix12<int> scaleX, Fix12<int> scaleY, int rotation, int mode)
+{
+    int priVal;
+    int palVal;
+    int *pCount;
+    int *pAff;
+    int sinIdx;
+    int cosIdx;
+    int mtxIdx;
+    int halfW;
+    int halfH;
+    s64 tcy;
+    s64 tsx;
+    s64 tsy;
+    s64 tcx;
+    int c100;
+    int c300;
+    int zero;
+    Matrix2x2 m;
+    int y;
+    int sxv;
+    int w;
+    int syv;
+    OamEntry *dst;
+    int x;
+    int om;
+
+    sxv = scaleX.val;
+    syv = scaleY.val;
+
+    if (!sub || data_0209e660 == 1) {
+        pCount = &data_0209e664;
+        dst = data_0209e674 + *pCount;
+        pAff = &data_0209e668;
+    } else {
+        pCount = &data_0209e670;
+        dst = data_0209ea74 + *pCount;
+        pAff = &data_0209e66c;
+    }
+
+    sinIdx = ((u16)(s16)rotation >> 4) * 2;
+    mtxIdx = (rotation >> 4) * 2;
+    cosIdx = sinIdx + 1;
+    zero = 0;
+    c300 = 0x300;
+    c100 = 0x100;
+
+    while (1) {
+        if (*pCount >= 0x80)
+            return;
+
+        {
+            int t = (int)((attr->a01 << 7) >> 23);
+            s8 u;
+            if (t >= 0x100)
+                t -= 0x200;
+            x = t;
+            u = *(s8 *)attr;
+            {
+            u32 a = attr->a01;
+            w = GetObjWidth((int)((a << 16) >> 30), (int)(a >> 30));
+            }
+        {
+        int h;
+        {
+            u32 a = attr->a01;
+            h = GetObjHeight((int)((a << 16) >> 30), (int)(a >> 30));
+        }
+        y = u;
+
+        if (sxv != 0x1000 || syv != 0x1000 || rotation != 0) {
+            x = (x + (w >> 1)) << 12;
+            y = (y + (h >> 1)) << 12;
+            halfW = w >> 1;
+            halfH = h >> 1;
+            if (sxv != 0x1000)
+                x = cstd::fdiv(x, sxv);
+            if (syv != 0x1000)
+                y = cstd::fdiv(y, syv);
+            if (rotation != 0) {
+                s16 s, c;
+                s = data_02082214[sinIdx];
+                c = data_02082214[cosIdx];
+                tcy = (s64)c * y;
+                tcx = (s64)c * x;
+                tsy = (s64)s * y;
+                tsx = (s64)s * x;
+                x = (((int)((tcx + 0x800) >> 12) - (int)((tsy + 0x800) >> 12)) >> 12) - halfW;
+                y = (((int)((tcy + 0x800) >> 12) + (int)((tsx + 0x800) >> 12)) >> 12) - halfH;
+            } else {
+                x = (x >> 12) - halfW;
+                y = (y >> 12) - halfH;
+            }
+            if (((attr->a01 << 22) >> 30) != 1) {
+                w <<= 1;
+                x -= halfW;
+                h <<= 1;
+                y -= halfH;
+            }
+        }
+
+        x += xOff;
+        y += yOff;
+
+        if (rotation != 0) {
+            if (w < h)
+                w = h;
+            if (x + w < 0 || x > 0x100) {
+                if (attr->a3 == 0xffff) return;
+                attr++;
+                continue;
+            }
+            if (y + w < 0 || y > 0xc0) {
+                if (attr->a3 == 0xffff) return;
+                attr++;
+                continue;
+            }
+        } else {
+            if (x + w < 0 || x > 0x100) {
+                if (attr->a3 == 0xffff) return;
+                attr++;
+                continue;
+            }
+            if (y + h < 0 || y > 0xc0) {
+                if (attr->a3 == 0xffff) return;
+                attr++;
+                continue;
+            }
+        }
+
+        }
+        }
+        if (palette == -1)
+            palVal = (int)((*(u32 *)&attr->a2 << 16) >> 28);
+        else
+            palVal = palette;
+        if (priority == -1)
+            priVal = (int)((*(u32 *)&attr->a2 << 20) >> 30);
+        else
+            priVal = priority;
+        if (mode > 0)
+            om = mode;
+        else
+            om = (int)((attr->a01 << 20) >> 30);
+
+        {
+            int aff;
+            u32 ipVal;
+            if (sxv != 0x1000 || syv != 0x1000 || rotation != 0) {
+                s16 c2 = data_02082214[mtxIdx + 1];
+                m.a = (c2 * sxv + 0x800) >> 12;
+                {
+                s16 s2 = data_02082214[mtxIdx];
+                m.b = (s2 * sxv + 0x800) >> 12;
+                m.c = -((s2 * syv + 0x800) >> 12);
+                }
+                m.d = (c2 * syv + 0x800) >> 12;
+                if (attr->a01 & 0x10000000) {
+                    m.a = -m.a;
+                    m.b = -m.b;
+                }
+                if (attr->a01 & 0x20000000) {
+                    m.c = -m.c;
+                    m.d = -m.d;
+                }
+                aff = LoadAffineParams((OamAttr *)(dst - *pCount), pAff, &m);
+                if (aff == -1) {
+                    if (attr->a3 == 0xffff) return;
+                    attr++;
+                    continue;
+                }
+                ipVal = (((attr->a01 << 22) >> 30) == 1) ? *(int *)&c100 : *(int *)&c300;
+            } else {
+                ipVal = attr->a01 & 0x30000000;
+                aff = *(int *)&zero;
+            }
+            {
+                u32 a23 = *(u32 *)&attr->a2;
+                u32 a01 = attr->a01;
+                u32 tile, bit13, maskbits;
+                tile = a23 << 22;
+                tile = tile >> 22;
+                w = (int)((a01 << 18) >> 31);
+                maskbits = a01 & 0xc000c000;
+                bit13 = (a01 << 19) >> 31;
+                if (ipVal == 0x100 || ipVal == 0x300) {
+                    if (om == 3)
+                        dst->a01 = ipVal | ((maskbits | ((y & 0xff) | (aff << 25) | (om << 10) | (bit13 << 12))) | ((x & 0x1ff) << 16));
+                    else
+                        dst->a01 = ipVal | ((maskbits | ((y & 0xff) | ((aff << 25) | (w << 13)) | (om << 10) | (bit13 << 12))) | ((x & 0x1ff) << 16));
+                } else if (om == 3)
+                    dst->a01 = ipVal | ((maskbits | ((y & 0xff) | (om << 10) | (bit13 << 12))) | ((x & 0x1ff) << 16));
+                else
+                    dst->a01 = ipVal | ((maskbits | ((y & 0xff) | (w << 13) | (om << 10) | (bit13 << 12))) | ((x & 0x1ff) << 16));
+                dst->a2 = (u16)((tile | (priVal << 10)) | (palVal << 12));
+            }
+        }
+        dst++;
+        *pCount = *pCount + 1;
+        if (attr->a3 == 0xffff) return;
+        attr++;
+    }
+}

--- a/src/_ZN5Model27LoadCompressedTextureToVramEPcjPc.cpp
+++ b/src/_ZN5Model27LoadCompressedTextureToVramEPcjPc.cpp
@@ -1,7 +1,10 @@
 //cpp
-// NONMATCHING: different op / idiom (div=14). Logic verified correct vs ROM; not
-// byte-matchable from C at mwccarm 1.2/sp2p3 (see notes/matching-style.md).
-// Counts as decompiled, not matched.
+// NONMATCHING (TERMINAL-FLOOR): functionally-verified C at the proven compiler floor.
+// Model::LoadCompressedTextureToVram @ 0x02045b58 (arm9, size 0xb8). 5 words diverge:
+// the allocator build delta from PR #957 -- ROM gives sumA a fresh register and colors
+// sumB onto the just-freed one; every owned build reuses the dying operand register.
+// 17-probe pass, flags, versions, value/address launders all closed (notes 6ay, DB row).
+// Register-choice-only delta: functionally identical. Supersedes the older 13-div draft.
 extern "C" {
 extern unsigned int data_020a4be8;
 extern unsigned int data_020a4bc8;
@@ -12,6 +15,7 @@ void _ZN2GX12BeginLoadTexEv();
 void _ZN2GX7LoadTexEPKvjj(const void*, unsigned int, unsigned int);
 void _ZN2GX10EndLoadTexEv();
 
+#pragma opt_common_subs off
 void _ZN5Model27LoadCompressedTextureToVramEPcjPc(char* src, unsigned int size, char* dst){
   if ((data_020a4be8 - data_020a4bc8) < size) Crash();
   _ZN2GX12BeginLoadTexEv();
@@ -20,7 +24,7 @@ void _ZN5Model27LoadCompressedTextureToVramEPcjPc(char* src, unsigned int size, 
   _ZN2GX7LoadTexEPKvjj(dst, data_020a4be0, size >> 1);
   data_020a4be4 += size >> 1;
   _ZN2GX10EndLoadTexEv();
-  data_020a4bc8 += size;
-  data_020a4be0 += size >> 1;
+  *(volatile unsigned int*)&data_020a4bc8 += size;
+  *(volatile unsigned int*)&data_020a4be0 += size >> 1;
 }
 }

--- a/src/_ZN5Stage13InitResourcesEv.cpp
+++ b/src/_ZN5Stage13InitResourcesEv.cpp
@@ -1,0 +1,430 @@
+//cpp
+// NONMATCHING (TERMINAL-FLOOR): functionally-verified C at the proven compiler floor.
+// Stage::InitResources @ 0x0202cc0c (arm9, size 0xa84). 4 words diverge: one arg-register
+// phi coalesce (bank web colored r1 vs ROM r2 at +0x524, one shared merge copy). Identical
+// on every owned build; pragmas, siblings, flags, launders, TU composition, goto-pin CFG
+// all closed (notes 6av/6ay, DB row). Register-rename-only delta: functionally identical.
+typedef unsigned char u8;
+typedef signed char s8;
+typedef unsigned short u16;
+typedef short s16;
+typedef unsigned int u32;
+typedef int s32;
+
+struct Stage {
+    int InitResources();
+};
+
+extern "C" {
+extern u8 data_0209f2d8;
+extern u8 data_0208a0e0;
+extern u8 data_0209f21c;
+extern u8 data_0209f250;
+extern s8 data_02092110;
+extern s8 data_0209f2c4;
+extern s8 data_0209f2f8;
+extern u8 data_0209f26c;
+extern s32 data_0209f34c;
+extern s32 data_0209f4f8[3][16];
+extern u8 data_0209f30c[16];
+extern u8 data_0209f310[16];
+extern s16 data_0209f358[16];
+extern u8 data_0209f2fc;
+extern s8 data_02092124;
+extern s8 data_02092118;
+extern u8 data_0209f264;
+extern u8 data_0209f268;
+extern u8 data_0209f220;
+extern u8 data_0209f1f0;
+extern s8 data_02092120;
+extern void *data_0209f314;
+extern s32 data_0209f32c;
+extern s8 data_0209f274;
+extern s8 data_0209f2bc;
+extern s16 data_0209f304;
+extern s16 data_0209f308;
+extern s32 data_0209f40c[12];
+extern s32 data_0209f3e8[9];
+extern s32 data_0209f3a4[8];
+extern u8 data_0209f1f8;
+extern u8 data_0209f2d0;
+extern u8 data_0209f258;
+extern u8 data_0209f2e8;
+extern u8 data_0209f25c;
+extern s32 data_0209f338;
+extern s32 data_02092134;
+extern u8 data_02075769[];
+extern s8 data_0207576a[];
+extern void *data_020756f0[12];
+extern u16 data_02075600[7];
+extern u16 data_020755f0[7];
+extern u16 data_020755e0[7];
+extern s32 data_0209f324;
+extern s32 data_02092208[];
+extern s32 data_0209f340;
+extern s32 data_0208ee44;
+extern s32 data_0209caa0[];
+extern void *data_0209f394[];
+extern u8 data_0209d454;
+extern void *data_0209d4a8;
+extern s32 data_0209f3c4;
+extern u8 data_0209f204;
+extern s32 data_0209b454;
+extern void *data_020a0eac;
+extern s32 data_0209fc48;
+extern s32 data_0209fc68;
+extern s16 data_0209f300;
+extern u8 data_0209f284;
+extern u8 data_0209f2d4;
+extern u8 data_0209f20c;
+extern u8 data_0209f290;
+extern u8 data_0209d45c;
+extern u8 data_0209f294;
+extern s32 data_0209cee8;
+extern s32 data_0209cef0;
+extern u8 data_02092778;
+extern s32 data_0209e650;
+extern u8 data_0209f208;
+extern s32 data_0209f344;
+extern char data_02075720[][0xC];
+
+void Enable3dEngines(void);
+void ResetInput(void);
+int SublevelToLevel(int i);
+void UnloadArchive(int i);
+void LoadTextNarcs(void);
+int LoadArchive(int idx);
+void Initialise3dGraphics(int arg);
+void InitialiseVramGlobals(void);
+void func_02039218(void);
+void ResetKuppaScript(void);
+int GetSoundGroupID(int level);
+void LoadDebugFont(void);
+int IsLevelInsideCastle(int level);
+int IsLevelTinyHugeIslandOutside(int level);
+int func_020308a8(void);
+int func_0203da9c(void);
+int func_0203da3c(void);
+u32 func_0203dad4(void);
+void func_0203b9b4(int *p, int v);
+void *func_02073470(int a, int b, int c, void *ctor, void *dtor);
+void func_ov001_020ab2e4(void);
+void _ZN9FaderWipeC1Ev(void *thiz);
+void _ZN9FaderWipeD1Ev(void *thiz);
+
+void _ZN5Sound6Player19SetPlayableSeqCountEii(int a, int b);
+void _ZN5Scene20Initialise3dGraphicsEv(void);
+void *_ZN4Heap10SetDefaultEv(void *self);
+void _ZN2GX15DisableAllBanksEv(void);
+void _ZN5Stage12SetVramBanksEv(void);
+void _ZN2GX15SetGraphicsModeEiii(int a, int b, int c);
+void _ZN3GXS15SetGraphicsModeEi(int a);
+void _ZN2GX6DispOnEv(void);
+void _Z17LoadLevelOverlaysi(int level);
+void _ZN5Sound19LoadGroupAndSetBankEii(int a, int b);
+void _ZN5Stage14LoadGraphics2DEbi(int b, int level);
+void *_ZN5Model8LoadFileER13SharedFilePtr(void *sfp);
+void _ZN9FaderWipe14LoadAndSetFileEt(int thiz, u16 fileID);
+void _ZN5Stage9LoadModelEv(void *thiz);
+void _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider(void *ov, u32 flags, void *mc);
+void _ZN5Sound22LoadAndSetMusic_Layer1Ei(int x);
+int _ZN5Sound8SetMusicEjj(u32 a, u32 b);
+void _ZN5Stage7LoadFogEv(void *thiz);
+void _ZN5Stage23LoadTextureTransformersEv(void *thiz);
+void _ZN5Stage10LoadSkyboxEv(void *thiz);
+void _ZN8Particle10SysTracker10InitialiseEv(void *thiz);
+void _ZN11ShadowModel8CleanAllEv(void);
+}
+
+int Stage::InitResources()
+{
+    Stage *thiz = this;
+
+    if (*(s32*)((char*)thiz + 0x9c4) == 0) {
+        u8 modeByte = data_0209f2d8;
+        int v0 = (modeByte == 1) ? 1 : 0;
+        if (v0) {
+            _ZN5Sound6Player19SetPlayableSeqCountEii(2, 5);
+            int n = 3;
+            _ZN5Sound6Player19SetPlayableSeqCountEii(n, n);
+        }
+        _ZN5Scene20Initialise3dGraphicsEv();
+        Enable3dEngines();
+        data_0209f21c = data_0208a0e0;
+        data_0209f250 = (u8)func_0203da9c();
+        ResetInput();
+        data_0209f2c4 = 0;
+
+        int temp_r4 = SublevelToLevel(data_02092110);
+        int temp_r0 = SublevelToLevel(data_0209f2f8);
+        u32 bits = ((u8)data_02092110 + 0xDC) & 0xFF;
+        int v1 = 0;
+        if (bits <= 0xD) {
+            if ((1 << bits) & 0x2A15)
+                v1 = 1;
+        }
+        modeByte = data_0209f2d8;
+        int b1 = (modeByte == 1) ? 1 : 0;
+
+        if (b1 || data_0209f26c == 2 || v1 || temp_r4 == 0x1D || temp_r4 != temp_r0) {
+            int r8 = 0;
+            data_0209f34c = 0;
+            do {
+                int r7 = 0;
+                do {
+                    data_0209f4f8[r8][r7] = 0;
+                    r7 += 1;
+                } while (r7 < 0x10);
+                r8 += 1;
+            } while (r8 < 3);
+
+            if ((s32)data_0209f21c > 0) {
+                int count = data_0209f21c;
+                int idx = 0;
+                u8 *p1 = data_0209f30c;
+                u8 *p2 = data_0209f310;
+                int sl = (modeByte == 1) ? 1 : 0;
+                u8 f26c = data_0209f26c;
+                do {
+                    if (sl || (v1 == 0 && f26c != 1)) {
+                        data_0209f358[idx] = 0;
+                    }
+                    *p1 = 0;
+                    *p2 = 0;
+                    idx += 1;
+                    p1 += 1;
+                    p2 += 1;
+                } while (idx < count);
+            }
+        }
+
+        data_0209f2fc = data_0209f26c;
+        if (data_0209f2fc == 1) {
+            data_02092124 = data_0209f2f8;
+            data_02092118 = -1;
+        }
+
+        s8 prevLevel = data_0209f2f8;
+        data_0209f2f8 = data_02092110;
+        data_0209f264 = data_0209f268;
+        data_0209f220 = data_0209f1f0;
+        data_02092120 = -1;
+        data_0209f314 = (void*)((char*)thiz + 0x8bc);
+        data_0209f32c = 0x80000000;
+        data_0209f274 = 0;
+        SublevelToLevel(data_0209f2f8);
+
+        s32 archiveIdx = 0xBF;
+        if (data_0209f2f8 == 0x33) archiveIdx = 2;
+        else if (data_0209f2f8 == 0x2B) archiveIdx = 3;
+        else if (data_0209f2f8 == 0x1D) archiveIdx = 4;
+        else if (data_0209f2f8 == 0x2A) archiveIdx = 5;
+
+        u32 r7_2 = 2;
+        do {
+            if (r7_2 != (u32)archiveIdx) {
+                UnloadArchive(r7_2);
+            }
+            r7_2 += 1;
+        } while (r7_2 <= 5);
+
+        LoadTextNarcs();
+        LoadArchive(0);
+        if (data_0209f2f8 == 1) {
+            void *saved = _ZN4Heap10SetDefaultEv(data_020a0eac);
+            LoadArchive(7);
+            _ZN4Heap10SetDefaultEv(saved);
+        }
+        if (archiveIdx != 0xBF) {
+            LoadArchive(archiveIdx);
+        }
+
+        Initialise3dGraphics(0x1F);
+        _ZN2GX15DisableAllBanksEv();
+        _ZN5Stage12SetVramBanksEv();
+
+        volatile u32 *p0 = (volatile u32*)0x04000000;
+        volatile u32 *p1 = (volatile u32*)0x04001000;
+        *p0 &= 0xFFCFFFEF;
+        *p1 &= 0xFFCFFFEF;
+        int one = 1;
+        _ZN2GX15SetGraphicsModeEiii(one, 0, one);
+        _ZN3GXS15SetGraphicsModeEi(3);
+        *p0 = (*p0 & ~0x38000000) | 0x08000000;
+        *(volatile u16*)0x04000304 = (*(volatile u16*)0x04000304 & 0xFFFFFDF1) | 0x20E;
+        _ZN2GX6DispOnEv();
+        *p1 |= 0x10000;
+        InitialiseVramGlobals();
+
+        volatile u16 *pVram = (volatile u16*)0x0400000A;
+        *pVram = *pVram & ~3;
+        *pVram = (*pVram & 0x43) | 0x1F1C;
+        *pVram = *pVram & ~0x40;
+        data_0209d454 = 0x18;
+        data_0209f204 = 0;
+        data_0209d4a8 = (void*)&data_0209f3c4;
+        data_0209b454 = 0;
+        func_02039218();
+        ResetKuppaScript();
+
+        int v0_3 = (data_0209f2d8 == 1) ? 1 : 0;
+        if (v0_3 == 0) goto L_zero304;
+        data_0209f2bc = 3;
+        data_0209f304 = 0x28;
+        data_0209f308 = 0;
+        goto L_after304;
+L_zero304:
+        data_0209f2bc = 0;
+        data_0209f304 = 0;
+L_after304:
+        ;
+
+        {
+            int i;
+            for (i = 0; i < 0xC; i++) {
+                data_0209f40c[i] = 0;
+            }
+        }
+        {
+            int i;
+            for (i = 0; i < 9; i++) {
+                data_0209f3e8[i] = 0;
+            }
+        }
+        func_ov001_020ab2e4();
+        {
+            int i;
+            for (i = 0; i < 8; i++) {
+                data_0209f3a4[i] = 0;
+            }
+        }
+
+        data_0209f1f8 = 0;
+        data_0209f2d0 = 0;
+        data_0209f258 = 0;
+        data_0209f2e8 = 0;
+        data_0209f25c = 0;
+        data_0209f338 = 0;
+        data_02092134 = 0x44444444;
+        _Z17LoadLevelOverlaysi(data_0209f2f8);
+
+        int v0_4 = (data_0209f2d8 == 2) ? 1 : 0;
+        if (v0_4 == 0) {
+            s8 level2 = *(s8*)(unsigned)(((unsigned long long)(unsigned)&data_0209f2f8) & ~0ULL);
+            int soundGroup = 0;
+            u8 bank = 0x36;
+            if (data_0209f220 == 2) {
+                if (level2 == 1 || level2 == 0x33) soundGroup = 0x2B;
+                else if (level2 == 0x1D) soundGroup = 0x2E;
+                else if (level2 == 0x2A) soundGroup = 0x2C;
+                else if (level2 == 0x2B) soundGroup = 0x2D;
+            }
+            if (soundGroup == 0) {
+                soundGroup = GetSoundGroupID(level2);
+                bank = level2 * 3;
+                bank = data_02075769[bank];
+            }
+            _ZN5Sound19LoadGroupAndSetBankEii(soundGroup, bank);
+        }
+
+        *(volatile u16*)0x04000008 = (*(volatile u16*)0x04000008 & ~3) | 2;
+        int v0_6 = (data_0209f2d8 == 1) ? 1 : 0;
+        _ZN5Stage14LoadGraphics2DEbi(v0_6, data_0209f2f8);
+
+        {
+            u32 i;
+            for (i = 0; i < 0xC; i++) {
+                _ZN5Model8LoadFileER13SharedFilePtr(data_020756f0[i]);
+            }
+        }
+
+        int v0_7 = (data_0209f2d8 == 1) ? 1 : 0;
+        u16 *faderTbl;
+        if (v0_7 && archiveIdx != 0xBF) {
+            faderTbl = data_02075600;
+        } else if (data_0209f2f8 == 5) {
+            faderTbl = data_020755f0;
+        } else {
+            faderTbl = data_020755e0;
+        }
+
+        data_0209f324 = (s32)func_02073470(7, 0x60, 8, (void*)&_ZN9FaderWipeC1Ev, (void*)&_ZN9FaderWipeD1Ev);
+        int r8_4 = 0;
+        int r7_3 = 0;
+        do {
+            _ZN9FaderWipe14LoadAndSetFileEt(data_0209f324 + r7_3, faderTbl[r8_4]);
+            r8_4 += 1;
+            r7_3 += 0x60;
+        } while (r8_4 < 7);
+
+        data_0209f340 = data_02092208[data_0209f2f8];
+        _ZN5Stage9LoadModelEv(thiz);
+        data_0208ee44 = 2;
+        _ZN5Stage18LoadClsnAndObjectsER11LVL_OverlayjR12MeshCollider((void*)data_0209f340, data_0209f264, (char*)thiz + 0x91c);
+
+        int v0_8 = (data_0209f2d8 == 1) ? 1 : 0;
+        if (v0_8 == 0) {
+            int nofc = (data_0209fc48 != 0) ? 1 : 0;
+            if (nofc == 0) {
+                if (!IsLevelInsideCastle(data_0209f2f8) || !IsLevelInsideCastle(prevLevel)) {
+                    if (!IsLevelTinyHugeIslandOutside(data_0209f2f8) || !IsLevelTinyHugeIslandOutside(prevLevel)) {
+                        if (data_0209f2f8 != 2 || (data_0209caa0[2] & 0x200)) {
+                            _ZN5Sound22LoadAndSetMusic_Layer1Ei(data_0207576a[data_0209f2f8 * 3]);
+                            u8 sndIdx = data_0209f250;
+                            if (((u8*)data_0209f394[sndIdx])[0x6ff] != 0) {
+                                _ZN5Sound8SetMusicEjj(sndIdx, 0x33);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (func_0203da3c() != 2 && archiveIdx != 0xBF) {
+            UnloadArchive(archiveIdx);
+        }
+        LoadDebugFont();
+        _ZN5Stage7LoadFogEv(thiz);
+        _ZN5Stage23LoadTextureTransformersEv(thiz);
+        _ZN5Stage10LoadSkyboxEv(thiz);
+        data_0209cef0 = 1;
+        _ZN8Particle10SysTracker10InitialiseEv((char*)thiz + 0x50);
+
+        u8 f2fc = data_0209f2fc;
+        data_0209f284 = 0;
+        data_0209f290 = 0;
+        data_0209f294 = 0;
+        data_0209f300 = 0;
+        if (f2fc != 1) {
+            data_0209f2d4 = 0;
+            data_0209f20c = 0;
+        }
+        data_0209d45c = 0x11;
+
+        *p0 = (*p0 & ~0x1F00) | 0x1100;
+        int v0_9 = (data_0209f2d8 == 2) ? 1 : 0;
+        if (v0_9 == 0) {
+            *p1 = (*p1 & ~0x1F00) | (data_0209d454 << 8);
+        }
+        data_0209cee8 = 0;
+        _ZN11ShadowModel8CleanAllEv();
+        data_02092110 = -1;
+
+        if (data_0209fc68 != 0) {
+            *(s32*)((char*)thiz + 0x9c4) = 1;
+        }
+    }
+
+    if (*(s32*)((char*)thiz + 0x9c4) != 0) {
+        if (func_020308a8() == 0)
+            return -1;
+    }
+
+    data_02092778 = 0;
+    func_0203b9b4(&data_0209e650, func_0203dad4());
+    data_0209f208 = 0;
+    u32 idx = func_0203dad4() % 6;
+    data_0209f344 = (s32)&data_02075720[idx];
+
+    return 1;
+}

--- a/src/func_02009e70.cpp
+++ b/src/func_02009e70.cpp
@@ -1,0 +1,533 @@
+//cpp
+// NONMATCHING (TERMINAL-FLOOR): functionally-verified C at the proven compiler floor.
+// func_02009e70 @ 0x02009e70 (arm9, size 0x109c). 96 words diverge, ALL register-identity
+// swaps (88) or same-multiset reorderings (8): zero wrong opcodes, immediates, or branches,
+// semantics verified instruction-by-instruction 2026-08-01. Eight clusters, every one a
+// coloring/scheduling build delta; every source axis is closed (notes 6ay, DB row has the
+// full closed-axis list). Not byte-matchable without the NITRO V0.5-V0.6.1 compiler.
+// For recomp/port purposes this file is complete: the compiled code is functionally
+// identical to the ROM, differing only in register names and instruction order.
+extern "C" {
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef short s16;
+typedef int s32;
+typedef unsigned int u32;
+typedef long long s64;
+typedef unsigned long long u64;
+
+struct Vector3 { s32 x, y, z; };
+
+struct CamMode {
+    s32 nearDist;   /* 0x00 */
+    s32 farDist;    /* 0x04 */
+    s32 f08;
+    s32 f0c;
+    s32 f10;
+    s32 f14;
+    s32 f18;
+    s32 f1c;        /* 0x1c */
+    s32 f20;        /* 0x20 */
+    u16 f24;
+    u16 flags;      /* 0x26 */
+};
+
+extern s16 Vec3_HorzAngle(const struct Vector3 *a, const struct Vector3 *b);
+extern s16 Vec3_VertAngle(const struct Vector3 *a, const struct Vector3 *b);
+extern void Vec3_Sub(struct Vector3 *out, const struct Vector3 *a, const struct Vector3 *b);
+extern void Vec3_Add(struct Vector3 *out, const struct Vector3 *a, const struct Vector3 *b);
+extern s32 Vec3_HorzLen(const struct Vector3 *v);
+extern s32 LenVec3(const struct Vector3 *v);
+extern void SubVec3(struct Vector3 *a, struct Vector3 *b, struct Vector3 *c);
+extern void Vec3_MulScalarInPlace(s32 *v, s32 s);
+extern s32 *Vec3_AsrInPlace(s32 *v, s32 sh);
+extern void Vec3_RotateYAndTranslate(s32 *out, s32 *in, s16 angle, s32 *src);
+extern s32 Math_Function_0203b14c(s32 *p, s32 tgt, s32 rate, s32 lim, s32 step);
+extern s32 ApproachAngle(s16 *cur, s32 target, s32 div, s32 band, s32 step);
+extern s32 AngleDiff(s32 a, s32 b);
+extern s32 _ZN4cstd5atan2E5Fix12IiES1_(s32 y, s32 x);
+extern s32 _ZN4cstd4fdivEii(s32 a, s32 b);
+extern s32 _ZN4cstd4sqrtEy(u64 v);
+extern u32 func_020093f4(void *p, s32 x);
+extern u32 func_020093d4(void *p, s32 x);
+extern s32 func_02009374(void *self);
+extern s32 func_02008cb4(void *self);
+extern void func_0200897c(void *self, void *arg);
+extern s32 func_0200c66c(void *self, struct Vector3 *pos, void *out2, void *out1, void *out3);
+extern s32 func_0200bec4(void *self, struct Vector3 *v, s32 a2, struct CamMode *mode, s32 a4);
+extern void func_0200bb28(void *self, void *a);
+extern void func_0200b798(void *self, void *a, s32 b);
+extern void func_0200b590(void *self, void *a, s32 b);
+extern void func_0200b0fc(void *self, void *a, s32 b);
+extern void func_0200b990(void *self, void *a, s32 b);
+extern void func_0200c9e0(void *self, s32 *a, s32 *b);
+extern u32 func_02012790(u32 a);
+extern s32 func_020124c4(s32 a, s32 b, s32 c);
+
+extern void _ZN11RaycastLineC1Ev(void *t);
+extern void _ZN11RaycastLineD1Ev(void *t);
+extern void _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(void *t, const struct Vector3 *a, const struct Vector3 *b, void *actor);
+extern s32 _ZN11RaycastLine10DetectClsnEv(void *t);
+extern void _ZN11RaycastLine10GetClsnPosEv(struct Vector3 *out, void *t);
+extern void _ZN13RaycastGroundC1Ev(void *t);
+extern void _ZN13RaycastGroundD1Ev(void *t);
+extern void _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(void *t, const struct Vector3 *p, void *actor);
+extern s32 _ZN13RaycastGround10DetectClsnEv(void *t);
+extern void _ZN4BgCh19StartDetectingWaterEv(void *t);
+extern void _ZNK11SurfaceInfo12CopyNormalToER7Vector3(void *t, struct Vector3 *out);
+
+extern s16 data_02082214[];
+extern u8 data_020a0e40;
+extern u16 data_0209f49c[];
+extern u16 data_0209f49e[];
+extern u8 data_0209f2d8;
+extern signed char data_0209f2f8;
+extern s32 data_0209f32c;
+extern s32 data_0209b000;
+
+extern struct CamMode data_02086fcc;
+extern struct CamMode data_02086ff4;
+extern struct CamMode data_0208706c;
+extern struct CamMode data_02087094;
+extern struct CamMode data_020870e4;
+extern struct CamMode data_0208710c;
+extern struct CamMode data_020871ac;
+extern struct CamMode data_020871d4;
+extern struct CamMode data_0208724c;
+extern struct CamMode data_0208733c;
+extern struct CamMode data_020873dc;
+extern struct CamMode data_02087404;
+extern struct CamMode data_0208742c;
+extern struct CamMode data_0208747c;
+extern struct CamMode data_020874cc;
+
+static inline int CheckMode(void) { return data_0209f2d8 == 1; }
+
+#define L0(p) ((s32)(((long long)(s32)(p)) & 0xFFFFFFFFFFFFFFFFLL))
+#define FXMUL(a, b) ((s32)((((s64)(a)) * (b) + 0x800) >> 12))
+#define FXMULC(a, b) ((s32)((((s64)(a)) * (s64)(b) + 0x800) >> 12))
+
+#pragma opt_common_subs off
+s32 func_02009e70(char *self)
+{
+    s32 sp04;
+    s32 sp08;
+    s32 sp0c;
+    s32 sp10;
+    s32 sp14;
+    u16 sp18;
+    struct CamMode *sp1c;
+    u8 *sp20;
+    s32 sp24;
+    s32 sp28;
+    s32 sp2c;
+    s32 sp30;
+    struct Vector3 sp34;
+    struct Vector3 sp40;
+    struct Vector3 sp4c;
+    struct Vector3 sp58;
+    struct Vector3 sp64;
+    struct Vector3 sp70;
+    struct Vector3 sp7c;
+    struct Vector3 sp88;
+    struct Vector3 sp94;
+    struct Vector3 spa0;
+    struct Vector3 spac;
+    struct Vector3 spb8;
+    struct Vector3 spc4;
+    char spd0[0x78];
+    char sp148[0x54];
+    s32 r7;
+    s32 r6;
+    s32 fl;
+    s32 sb;
+    s32 r4;
+    s32 t1;
+    s32 sba;
+    s32 sl;
+    s32 r5;
+    s32 fp;
+    u32 r7h;
+    struct CamMode *m;
+    s32 t0;
+
+    if (*(s32 *)(self + 0x110) == 0) {
+        *(s16 *)(self + 0x17c) = Vec3_HorzAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
+        goto L_TAIL;
+    }
+
+    sp1c = (*(s32 *)(self + 0x154) & 0x100) ? &data_0208747c : *(struct CamMode **)(self + 0x13c);
+    Vec3_Sub(&sp34, (struct Vector3 *)(*(char **)(self + 0x110) + 0x5c), (struct Vector3 *)(self + 0x98));
+    {
+        struct Vector3 *q = (struct Vector3 *)L0(*(char **)(self + 0x110) + 0x5c);
+        *(s32 *)(self + 0x98) = q->x;
+        *(s32 *)(self + 0x9c) = q->y;
+        *(s32 *)(self + 0xa0) = q->z;
+    }
+    r7 = Vec3_HorzLen(&sp34);
+    sp20 = 0;
+    sp24 = 0;
+    if (*(s32 *)(self + 0x118) != 0) {
+        struct Vector3 *q;
+        sp24 = 1;
+        *(s32 *)(self + 0x114) = 0;
+        q = (struct Vector3 *)L0(*(char **)(self + 0x118) + 0x5c);
+        *(s32 *)(self + 0x120) = q->x;
+        *(s32 *)(self + 0x124) = q->y;
+        *(s32 *)(self + 0x128) = q->z;
+        *(s32 *)(self + 0x12c) = 0xdfe60;
+    }
+    r6 = func_0200c66c(self, (struct Vector3 *)(self + 0x98), &sp20, &sp1c, &sp24);
+    r4 = 0;
+    if (sp24 != 0) {
+        r4 = 0x1000;
+        SubVec3((struct Vector3 *)(self + 0x120), (struct Vector3 *)(self + 0x98), (struct Vector3 *)(self + 0x120));
+    }
+    Math_Function_0203b14c((s32 *)(self + 0x130), r4, 0x100, 0x80, 0x10);
+    sb = 0;
+
+    fl = sp1c->flags;
+    r4 = sp1c->f1c;
+    r5 = sp1c->f20;
+    if ((fl & 1) == 0 && (*(s32 *)(self + 0x154) & 2) != 0) {
+        r4 = FXMULC(r4, 0x1800);
+        r5 = FXMULC(r5, 0x1800);
+    }
+    if (CheckMode() && (fl & 2) != 0 && func_02009374(self) != 0) {
+        r4 = FXMULC(r4, 0x14cc);
+        r5 = FXMULC(r5, 0x14cc);
+    }
+    if (*(s32 *)(self + 0x154) & 0x80) {
+        r4 = FXMULC(r4, 0x1800);
+        r5 = FXMULC(r5, 0x1800);
+    }
+    t0 = *(s32 *)(self + 0x12c) - r4;
+    fp = func_020093f4(self, r4 + FXMUL(t0, *(s32 *)(self + 0x130)));
+    if (sp24 != 0) {
+        sl = fp;
+    } else {
+        if (r5 < 0) r5 = -r5;
+        sl = func_020093f4(self, r5);
+    }
+    sp04 = func_0200bec4(self, (struct Vector3 *)(self + 0x98), r6, sp1c, r7);
+    r5 = *(u16 *)((char *)data_0209f49e + data_020a0e40 * 0x18) & 0x4300;
+    if (*(s32 *)(self + 0x118) != 0) {
+        *(s16 *)(self + 0x17c) = Vec3_HorzAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
+        goto L_AE14;
+    }
+    if (sp1c == &data_0208733c) {
+        func_0200bb28(self, sp20);
+        r5 = 0;
+        goto L_AE14;
+    }
+    if (sp1c == &data_020873dc) {
+        func_0200b798(self, sp20, r6);
+        goto L_AE14;
+    }
+    if (*(s32 *)(self + 0x154) & 0x400) goto L_AE14;
+    if (sp1c == &data_02087404) {
+        func_0200b590(self, sp20, r6);
+        goto L_AE14;
+    }
+    if (sp1c == &data_0208742c) {
+        func_0200b0fc(self, sp20, r6);
+        goto L_AE14;
+    }
+    *(u32 *)L0(self + 0x154) |= 0x1000;
+    sp08 = func_020093f4(self, sp1c->nearDist);
+    sp0c = func_020093f4(self, sp1c->farDist);
+    if (sp20 != 0 && sp20[0] == 2) {
+        if (sp20[1] == 0) {
+            s32 tx = *(s16 *)(sp20 + 2) << 12;
+            s32 tz = *(s16 *)(sp20 + 6) << 12;
+            s32 ty = *(s16 *)(sp20 + 4) << 12;
+            *(s32 *)(self + 0x8c) = tx;
+            *(s32 *)(self + 0x90) = ty;
+            *(s32 *)(self + 0x94) = tz;
+        } else {
+            s16 a = (s16)(*(s16 *)(sp20 + 0xa) + 0x8000);
+            if (*(s16 *)(self + 0x186) != a) {
+                *(s16 *)(self + 0x186) = a;
+                *(u8 *)(self + 0x1a6) = 1;
+            }
+        }
+    } else {
+        if (*(u8 *)(self + 0x1a6) == 0) {
+            *(s16 *)L0(self + 0x186) += 0x8000;
+        }
+    }
+    Vec3_Sub(&sp40, (struct Vector3 *)(self + 0x8c), (struct Vector3 *)(self + 0x80));
+    sp28 = LenVec3(&sp40);
+    sp10 = 0x80000000;
+    {
+        s32 ty = *(s32 *)(self + 0x9c);
+        s32 tz = *(s32 *)(self + 0xa0);
+        s32 tx = *(s32 *)(self + 0x98);
+        sp4c.x = tx;
+        sp4c.y = ty + 0x3e8000;
+        sp4c.z = tz;
+    }
+    r4 = 0x7fffffff;
+    sb = *(s32 *)(self + 0x9c) + 0x82500;
+    _ZN11RaycastLineC1Ev(spd0);
+    func_0200897c(self, spd0);
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(spd0, (struct Vector3 *)(self + 0x98), &sp4c, 0);
+    if (_ZN11RaycastLine10DetectClsnEv(spd0) != 0) {
+        _ZN11RaycastLine10GetClsnPosEv(&sp94, spd0);
+        r4 = sp94.y - 0x80000;
+        if (r4 < sb) r4 = sb;
+    }
+    if (*(s32 *)(self + 0x154) & 0x100) goto L_A534;
+    if ((sp1c->flags & 8) == 0) goto L_A534;
+    {
+        s32 tz = *(s32 *)(self + 0xa0);
+        s32 tx = *(s32 *)(self + 0x98);
+        sp58.x = tx;
+        sp58.y = sb;
+        sp58.z = tz;
+    }
+    if (sb > r4) goto L_A534;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(spd0, &sp58, (struct Vector3 *)(self + 0x8c), 0);
+    if (_ZN11RaycastLine10DetectClsnEv(spd0) == 0) goto L_A534;
+    _ZNK11SurfaceInfo12CopyNormalToER7Vector3(spd0 + 0x14, &sp64);
+    _ZN11RaycastLine10GetClsnPosEv(&spa0, spd0);
+    *(s32 *)(self + 0xe0) = spa0.x;
+    *(s32 *)(self + 0xe4) = spa0.y;
+    *(s32 *)(self + 0xe8) = spa0.z;
+    *(s32 *)(self + 0xec) = sp64.x;
+    *(s32 *)(self + 0xf0) = sp64.y;
+    *(s32 *)(self + 0xf4) = sp64.z;
+    t0 = sp64.y;
+    if (t0 < 0) t0 = -t0;
+    if (t0 > 0xb50) {
+        *(u32 *)L0(self + 0x154) |= 0x80200;
+        goto L_A534;
+    }
+    _ZN11RaycastLine10GetClsnPosEv(&sp70, spd0);
+    sba = (s16)(_ZN4cstd5atan2E5Fix12IiES1_(sp64.x, sp64.z) + 0x8000);
+    t1 = *(u8 *)(self + 0x1a6);
+    t0 = (s16)(sba - *(s16 *)(self + 0x17c));
+    if (t0 < 0) t0 = 0x4000; else t0 = -0x4000;
+    sba = (s16)(sba + t0);
+    if (t1 != 0) {
+        if (AngleDiff(sba, *(s16 *)(self + 0x186)) >= 0x4000) sba = *(s16 *)(self + 0x186);
+    }
+    *(s16 *)(self + 0x186) = sba;
+    *(u8 *)(self + 0x1a6) = 1;
+    t0 = (s16)(*(s16 *)(self + 0x17c) - *(s16 *)(self + 0x186));
+    if (r5 & 0x200) t0 = (s16)(-t0);
+    if (t0 > 0) r5 = 0;
+    *(u32 *)L0(self + 0x154) |= 0x40000;
+L_A534:
+    if (r5 != 0) {
+        if (r5 & 0x4000) func_02012790(0x1a);
+        *(u8 *)(self + 0x1a6) = 0;
+    } else {
+        if (*(u8 *)(self + 0x1a6) == 0) {
+            r5 = *(u16 *)((char *)data_0209f49c + data_020a0e40 * 0x18) & 0x4300;
+        }
+    }
+    if (*(s32 *)(self + 0x154) & 0x100) {
+        if (sp28 > (s32)func_020093f4(self, 0xdfe60)) *(u32 *)L0(self + 0x154) &= ~0x100;
+    }
+    if (r5 != 0) goto L_A5F8;
+    if (*(u16 *)(self + 0x1a0) != 0) goto L_A5F8;
+    if (*(u8 *)(self + 0x1a6) != 0) goto L_A5F8;
+    if (r7 <= sp08) goto L_A5F8;
+    sb = sp28;
+    if (sb < fp) goto L_A5F8;
+    if (sb > sp0c) goto L_AA6C;
+
+L_A5F8:
+    sb = *(s16 *)(self + 0x17c);
+    *(s16 *)(self + 0x17c) = Vec3_HorzAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
+    if (r5 != 0) goto L_A628;
+    if (*(u16 *)(self + 0x1a0) == 0) goto L_A6FC;
+L_A628:
+    if (r5 & 0x4000) goto L_A640;
+    if (*(u16 *)(self + 0x1a0) == 0) goto L_A6A8;
+L_A640:
+    if (r5 != 0) {
+        *(s16 *)(self + 0x19e) = *(s16 *)(*(char **)(self + 0x110) + 0x8e) + 0x8000;
+    }
+    *(u16 *)(self + 0x1a0) = ApproachAngle((s16 *)(self + 0x17c), *(s16 *)(self + 0x19e), 4, 0x800, 0x400) != 0;
+    if (*(u16 *)(self + 0x1a0) != 0) *(u32 *)L0(self + 0x154) |= 0x60;
+    goto L_A6F4;
+L_A6A8:
+    if (r5 & 0x200) {
+        *(s16 *)L0(self + 0x17c) -= 0x400;
+        *(u32 *)L0(self + 0x154) |= 0x20;
+    } else {
+        *(s16 *)L0(self + 0x17c) += 0x400;
+        *(u32 *)L0(self + 0x154) |= 0x40;
+    }
+L_A6F4:
+    r5 = 0;
+    goto L_A814;
+L_A6FC:
+    if (*(u8 *)(self + 0x1a6) != 0) {
+        if (ApproachAngle((s16 *)(self + 0x17c), *(s16 *)(self + 0x186), 0x10, 0x200, 0x100) == 0)
+            *(u8 *)(self + 0x1a6) = 0;
+        goto L_A814;
+    }
+    m = sp1c;
+    if (m == &data_020871ac || m == &data_020871d4) {
+        func_0200b990(self, sp20, r7);
+        goto L_A814;
+    }
+    if (sp24 != 0) goto L_A814;
+    if (m == &data_0208724c)
+        t0 = *(s16 *)(*(char **)(self + 0x110) + 0x94);
+    else
+        t0 = *(s16 *)(*(char **)(self + 0x110) + 0x8e);
+    t0 = (s16)(t0 + 0x8000);
+    if (m == &data_020874cc) {
+        *(s16 *)(self + 0x17c) = t0 + *(s16 *)(self + 0x184);
+        goto L_A814;
+    }
+    if (sp28 > sp0c) goto L_A7DC;
+    ApproachAngle((s16 *)(self + 0x17c), t0, 0x14, 0x600, 0x28);
+    goto L_A814;
+L_A7DC:
+    if (m->flags & 0x100) {
+        *(s16 *)(self + 0x17c) = sb;
+        goto L_A814;
+    }
+    if (r7 > sp08) goto L_A814;
+    ApproachAngle((s16 *)(self + 0x17c), t0, 0x14, 0x64, 0x28);
+
+L_A814:
+    sp14 = sp28;
+    if (sp28 <= sl) goto L_A984;
+    if (r7 == 0) goto L_A94C;
+    if (sp1c != &data_02086fcc) goto L_A94C;
+    sb = _ZN4cstd5atan2E5Fix12IiES1_(sp34.y, Vec3_HorzLen(&sp34));
+    if (sb < -0x3f80) sb = -0x3f80;
+    else if (sb > 0x3f80) sb = 0x3f80;
+    fp = Vec3_HorzLen(&sp40);
+    sp18 = _ZN4cstd5atan2E5Fix12IiES1_(-sp40.y, fp);
+    ApproachAngle((s16 *)&sp18, sb, 0x20, 0x800, 0);
+    t0 = (sp18 >> 4) * 2;
+    sp40.y = FXMUL(sp28, -data_02082214[t0]);
+    t0 = _ZN4cstd4fdivEii(FXMUL(sp28, data_02082214[t0 + 1]), fp);
+    sp40.x = FXMUL(sp40.x, t0);
+    sp40.z = FXMUL(sp40.z, t0);
+L_A94C:
+    Math_Function_0203b14c(&sp28, sl, 0x400, r7 + 0x20000, 0x100);
+    Vec3_MulScalarInPlace((s32 *)&sp40, _ZN4cstd4fdivEii(sp28, sp14));
+    goto L_AA34;
+L_A984:
+    if (sp28 >= fp) goto L_AA34;
+    Math_Function_0203b14c(&sp28, fp, 0x400, r7 + 0x20000, 0x100);
+    r7 = _ZN4cstd4sqrtEy((u64)((s64)sp28 * sp28 - (s64)sp40.y * sp40.y));
+    t0 = _ZN4cstd4fdivEii(r7, Vec3_HorzLen(&sp40));
+    sp40.x = FXMUL(sp40.x, t0);
+    sp40.z = FXMUL(sp40.z, t0);
+    *(s16 *)L0(self + 0x188) -= *(s16 *)(self + 0x17c) - sb;
+L_AA34:
+    t0 = Vec3_HorzLen(&sp40);
+    if (t0 < 0x1000) t0 = 0x1000;
+    sp40.z = t0;
+    sp40.x = 0;
+    Vec3_RotateYAndTranslate((s32 *)(self + 0x8c), (s32 *)(self + 0x80), *(s16 *)(self + 0x17c), (s32 *)&sp40);
+    goto L_AAD0;
+L_AA6C:
+    if (sb > sl) {
+        Math_Function_0203b14c(&sp28, sl, 0x400, r7 + 0x20000, 0x100);
+        Vec3_MulScalarInPlace((s32 *)&sp40, _ZN4cstd4fdivEii(sp28, sb));
+        Vec3_Add(&spac, (struct Vector3 *)(self + 0x80), &sp40);
+        *(s32 *)(self + 0x8c) = spac.x;
+        *(s32 *)(self + 0x90) = spac.y;
+        *(s32 *)(self + 0x94) = spac.z;
+    }
+L_AAD0:
+    if (func_02008cb4(self) != 0) {
+        if (*(s32 *)(self + 0x154) & 0x60) {
+            r5 = 1;
+            *(u32 *)L0(self + 0x154) &= ~0x60;
+        }
+    }
+    {
+        s32 ty = *(s32 *)(self + 0x90) + 0x100000;
+        s32 tz = *(s32 *)(self + 0x94);
+        s32 tx = *(s32 *)(self + 0x8c);
+        sp4c.x = tx;
+        sp4c.y = ty;
+        sp4c.z = tz;
+    }
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(spd0, (struct Vector3 *)(self + 0x8c), &sp4c, 0);
+    if (_ZN11RaycastLine10DetectClsnEv(spd0) != 0) {
+        _ZN11RaycastLine10GetClsnPosEv(&spb8, spd0);
+        sp4c.y = spb8.y;
+        if (r4 > spb8.y - 0x80000) r4 = spb8.y - 0x80000;
+    }
+    Vec3_Add(&sp7c, (struct Vector3 *)(self + 0x8c), (struct Vector3 *)(self + 0x80));
+    Vec3_AsrInPlace((s32 *)&sp7c, 1);
+    sp88.x = sp7c.x;
+    sp88.y = sp7c.y + 0x100000;
+    sp88.z = sp7c.z;
+    _ZN11RaycastLine13SetObjAndLineERK7Vector3S2_P5Actor(spd0, &sp7c, &sp88, 0);
+    if (_ZN11RaycastLine10DetectClsnEv(spd0) != 0) {
+        _ZN11RaycastLine10GetClsnPosEv(&spc4, spd0);
+        sp88.y = spc4.y - 0x80000;
+        if (r4 > sp88.y) r4 = sp88.y;
+    }
+    sb = *(s32 *)(self + 0x9c);
+    _ZN13RaycastGroundC1Ev(sp148);
+    *(s32 *)(sp148 + 0x4c) = 0x5dc000;
+    func_0200897c(self, sp148);
+    _ZN13RaycastGround12SetObjAndPosERK7Vector3P5Actor(sp148, &sp4c, 0);
+    if (sp1c > &data_02086fcc) _ZN4BgCh19StartDetectingWaterEv(sp148);
+    if (_ZN13RaycastGround10DetectClsnEv(sp148) != 0) sb = *(s32 *)(sp148 + 0x44);
+    if (sp1c == &data_02086ff4) {
+        if (sb < data_0209f32c) sb = data_0209f32c;
+        r7h = sb + 0x64000;
+        goto L_AD94;
+    }
+    r7h = sb;
+    if (sb < r6) r7h = r6;
+    r7h = r7h + func_020093d4(self, (r6 - sp04) + ((*(s32 *)(self + 0x154) & 2) ? 0x1e8000 : 0x138000));
+    if (sp1c->flags & 0x80) {
+        if (*(s32 *)(self + 0x90) > (s32)r7h) r7h = *(s32 *)(self + 0x90);
+    }
+    sp2c = sp1c->f08;
+    sp30 = sp1c->f0c;
+    func_0200c9e0(self, &sp2c, &sp30);
+    sp40.y = r7h - *(s32 *)(self + 0x84);
+    if (sp1c == &data_0208706c && sp34.y < 0) t0 = 0xa49;
+    else t0 = sp2c;
+    r6 = FXMUL(sp28, t0);
+    t0 = FXMUL(sp30, sp28);
+    if (sp40.y < r6) r7h = *(s32 *)(self + 0x84) + r6;
+    else if (sp40.y > t0) r7h = *(s32 *)(self + 0x84) + t0;
+    if (data_0209f2f8 == 0x26) {
+        if (*(s32 *)(self + 0x90) < sb + 0x25bc8) *(s32 *)(self + 0x90) = sb + 0x25bc8;
+    }
+    if (r4 < sb + 0x25bc8) r4 = sp4c.y;
+    if (sb + 0x25bc8 > (s32)0x80000000) sp10 = sb + 0x25bc8;
+L_AD94:
+    if (sp1c == &data_02087094) goto L_ADD4;
+    if (sp1c == &data_020870e4) goto L_ADD4;
+    if (sp1c == &data_0208710c) goto L_ADD4;
+    if ((s32)r7h < sp10) r7h = sp10;
+    else if ((s32)r7h > r4) r7h = r4;
+L_ADD4:
+    Math_Function_0203b14c((s32 *)(self + 0x90), r7h, 0x300, 0x14000, 0x100);
+    *(s16 *)(self + 0x17c) = Vec3_HorzAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
+    _ZN13RaycastGroundD1Ev(sp148);
+    _ZN11RaycastLineD1Ev(spd0);
+L_AE14:
+    if (r5 != 0) {
+        if (data_0209b000 == 0) func_02012790(0xe);
+        data_0209b000 = r5;
+    } else {
+        data_0209b000 = 0;
+        if (*(s32 *)(self + 0x154) & 0x60) {
+            *(s32 *)(self + 0x158) = func_020124c4(*(s32 *)(self + 0x158), 2, 0x43);
+        }
+    }
+L_TAIL:
+    *(s16 *)(self + 0x17e) = Vec3_VertAngle((struct Vector3 *)(self + 0x80), (struct Vector3 *)(self + 0x8c));
+    return 1;
+}
+}

--- a/src/func_0202ffec.c
+++ b/src/func_0202ffec.c
@@ -1,0 +1,37 @@
+// NONMATCHING (TERMINAL-FLOOR): functionally-verified C at the proven compiler floor.
+// func_0202ffec @ 0x0202ffec (arm9, size 0x1d8). Quaternion product. 2 words diverge:
+// two smull operand-slot swaps (+0x14, +0x50) -- mwccarm puts the second-emitted load in
+// Rm, the ROM pins the matrix operand. ~800 spellings, the real permuter (6512 candidates),
+// flags, versions, launders all closed (notes 6ay, DB row). Operand-order-only delta:
+// functionally identical (multiplication is commutative).
+typedef signed int s32;
+
+struct Quat {
+    s32 x;
+    s32 y;
+    s32 z;
+    s32 w;
+};
+
+/* Fix12 multiply. P casts both operands; Q casts only the first and lets the
+   second promote -- the two spellings give different value numbers, and the
+   m3*v0 term needs Q to reproduce the ROM's v0/v3 register assignment. */
+#define P(a, b) ((s32)((((long long)(a) * (long long)(b)) + 0x800) >> 12))
+#define Q(a, b) ((s32)(((long long)(a) * (b) + 0x800) >> 12))
+
+void func_0202ffec(struct Quat *m, struct Quat *v, struct Quat *out)
+{
+    s32 m0 = m->x;
+    s32 m1 = m->y;
+    s32 m2 = m->z;
+    s32 m3 = m->w;
+    s32 v0 = v->x;
+    s32 v1 = v->y;
+    s32 v2 = v->z;
+    s32 v3 = v->w;
+
+    out->x = P(v2, m1) + (Q(m3, v0) + P(v3, m0)) - P(m2, v1);
+    out->y = P(m2, v0) + (P(m3, v1) + P(m1, v3)) - P(m0, v2);
+    out->z = P(m0, v1) + (P(m3, v2) + P(m2, v3)) - P(m1, v0);
+    out->w = P(m3, v3) - P(m0, v0) - P(m1, v1) - P(m2, v2);
+}


### PR DESCRIPTION
Lands the functionally-verified C for the five terminal floors (notes 6ay) so the tree is 100% source-covered for arm9. Every divergence in these five is register choice or instruction order only; semantics verified (func_02009e70 word-by-word: 88 register swaps, 8 reorderings, zero wrong opcodes/immediates/branches). Matched counts are untouched: all five carry NONMATCHING (TERMINAL-FLOOR) banners and remain counted as unmatched. LoadCompressedTextureToVram's stale 13-div draft is replaced by the current 5-div floor source (same-commit .c -> .cpp rename).

Divergence counts re-verified at landing: 96 / 4 / 2 / 2 / 5 on 1.2/sp2p3. Local pr_linkcheck: all five report "ok(drf)" under #968's declared-draft rule.

Note for the validate check: this PR needs the build box to have synced #968 (the declared-draft gate rule). If the check reports NO-REPRO on these files, that is the pre-#968 gate, not a real failure.