### PR TITLE
Fix the ROM link: func_0205402c was renamed DisableVramBanks

### DIFF
--- a/src/func_02053f08.c
+++ b/src/func_02053f08.c
@@ -1,11 +1,11 @@
 /* func_02053f08 @ 0x02053f08 -- clear BG ext-palette enable bit in sub-engine
- * DISPCNT, then disable the VRAM bank assignment via func_0205402c. */
+ * DISPCNT, then disable the VRAM bank assignment via DisableVramBanks. */
 #include "nitro/hw/registers.h"
 
-extern u16 func_0205402c(u16 *bankBitsPtr);
+extern u16 DisableVramBanks(u16 *bankBitsPtr);
 extern u16 data_020a609e;
 
 u16 func_02053f08(void) {
     REG_DISPCNT_SUB &= ~DISPLAY_CONTROL_BG_EXT_PALETTE;
-    return func_0205402c(&data_020a609e);
+    return DisableVramBanks(&data_020a609e);
 }


### PR DESCRIPTION
`src/func_02053f08.c` calls `func_0205402c`, which no longer exists — 0x0205402c is now
`DisableVramBanks` in `config/arm9/symbols.txt`. One line plus its declaration and comment.

## Why nothing caught it

The file compiles and byte-matches either way, so `match.py` and the per-file PR gate both
pass it. Only the full ROM link notices:

```
mwldarm.exe: Undefined : "func_0205402c"
mwldarm.exe: Referenced from "func_02053f08" in func_02053f08.o
mwldarm.exe: alert: Link failed.
```

This is the wrong-callee-name class from #942 again. The reference *is* the relocated pool
word at +0x20, and `match.py` wildcards every relocated word, so the byte oracle
structurally cannot see which name it resolves to:

```
+0x20 | 2c400502 andeq r4, r5, #0x2c | 00000000 | reloc (wildcard)
```

`eligible.py`'s "every undefined reference is defined in config" rule did run — at
enrollment time, and it passed then. The file was edited afterwards (#863) and kept its
`complete` marker in `delinks.txt`. Nothing re-checks after enrollment.

## Scope

I scanned all 9,116 enrolled files for the same drift. This is the only one.

## Verification

`match.py` reproduces the function byte-for-byte under 1.2/sp2p3, unchanged from before.

The full ROM build now completes end to end — **9,115 / 9,115 source-built functions
reproduce, 0 mismatching**. The single reported divergence is the intentional 3-byte
`mods/Player_ScaleByCharFactor.c` change from #941, which is what makes
`dsd check modules` flag overlay 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
