### PR TITLE
Fix five more callers left pointing at renamed callees

### DIFF
--- a/src/_ZN6Player16St_BurnFire_MainEv.cpp
+++ b/src/_ZN6Player16St_BurnFire_MainEv.cpp
@@ -31,7 +31,7 @@ extern void _ZN6Player7SetAnimEji5Fix12IiEj(char *c, unsigned int anim, int a, i
 extern int _ZNK6Player14GetBodyModelIDEjb(char *c, unsigned int a, int b);
 extern void ApproachAngle(short *cur, short target, int divisor, int band, int maxStep);
 extern void _Z14ApproachLinearRiii(int *cur, int target, int step);
-extern void func_ov002_020bedd4(char *c);
+extern void Player_AdvanceAnims(char *c);
 }
 
 extern "C" int _ZN6Player16St_BurnFire_MainEv(char *c)
@@ -135,6 +135,6 @@ extern "C" int _ZN6Player16St_BurnFire_MainEv(char *c)
     }
 
     _Z14ApproachLinearRiii((int *)(c + 0x98), speed, 0x1000);
-    func_ov002_020bedd4(c);
+    Player_AdvanceAnims(c);
     return 1;
 }

--- a/src/_ZN6Player19St_GroundPound_MainEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_MainEv.cpp
@@ -23,7 +23,7 @@ void _ZN12CylinderClsn5ClearEv(char* self);
 void _ZN12CylinderClsn6UpdateEv(char* self);
 void _ZN6Player11ChangeStateERNS_5StateE(char* self, void* state);
 int func_ov002_020d36d8(char* c, int arg);
-void func_ov002_020bedd4(char* self);
+void Player_AdvanceAnims(char* self);
 }
 
 extern void* data_0209f318;
@@ -146,6 +146,6 @@ extern "C" int _ZN6Player19St_GroundPound_MainEv(char* self)
         }
         func_ov002_020d36d8(self, 1);
     }
-    func_ov002_020bedd4(self);
+    Player_AdvanceAnims(self);
     return 1;
 }

--- a/src/func_02009e70.cpp
+++ b/src/func_02009e70.cpp
@@ -62,7 +62,7 @@ extern void func_0200b0fc(void *self, void *a, s32 b);
 extern void func_0200b990(void *self, void *a, s32 b);
 extern void func_0200c9e0(void *self, s32 *a, s32 *b);
 extern u32 func_02012790(u32 a);
-extern s32 func_020124c4(s32 a, s32 b, s32 c);
+extern s32 Sound_PlayIfNotActive(s32 a, s32 b, s32 c);
 
 extern void _ZN11RaycastLineC1Ev(void *t);
 extern void _ZN11RaycastLineD1Ev(void *t);
@@ -523,7 +523,7 @@ L_AE14:
     } else {
         data_0209b000 = 0;
         if (*(s32 *)(self + 0x154) & 0x60) {
-            *(s32 *)(self + 0x158) = func_020124c4(*(s32 *)(self + 0x158), 2, 0x43);
+            *(s32 *)(self + 0x158) = Sound_PlayIfNotActive(*(s32 *)(self + 0x158), 2, 0x43);
         }
     }
 L_TAIL:

--- a/src/func_02072168.c
+++ b/src/func_02072168.c
@@ -2,7 +2,7 @@
  * Bytecode-VM dispatcher for the wireless callback stream; sibling of func_020690b0.
  * s+8 = IP into the byte stream, s+4 = more-data flag, c+0x18 = data segment base,
  * c+0x1c = int[] locals table. Refill via func_02071910/02072dac/020731fc/02071864;
- * LEB128 operands via func_02071af8 (signed) / func_02071a50 (unsigned). Opcode bits:
+ * LEB128 operands via ReadSignedVarInt (signed) / func_02071a50 (unsigned). Opcode bits:
  * 0x20/0x40 select array-indexed vs base-relative operand source, 0x80 restores s+8
  * from the checkpoint; cases 0xc/0xf early-return when the IP reaches `end`.
  *
@@ -29,7 +29,7 @@ extern int func_02071910(char *c, char *s);
 extern void func_02072dac(int a, char *s);
 extern void func_020731fc(void);
 extern void func_02071864(char *c, char *s);
-extern unsigned char *func_02071af8(unsigned char *p, int *out);
+extern unsigned char *ReadSignedVarInt(unsigned char *p, int *out);
 extern unsigned char *func_02071a50(unsigned char *p, int *out);
 extern int func_01ffadf0(int a, int b);
 
@@ -54,7 +54,7 @@ void func_02072168(char *c, char *s, char *end) {
         switch (op & 0x1f) {
         case 1: {
             int v0;
-            func_02071af8(p + 1, &v0);
+            ReadSignedVarInt(p + 1, &v0);
             (*(int *)(((long long)(int)(s + 8)) & 0xFFFFFFFFFFFFFFFFLL)) += v0;
             break;
         }
@@ -62,7 +62,7 @@ void func_02072168(char *c, char *s, char *end) {
             int v0;
             unsigned char *q;
             int fp;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             ((F2)fp)((int)(*(char **)(c + 0x18) + v0), neg1);
             *(unsigned char **)(s + 8) = q + 4;
@@ -78,7 +78,7 @@ void func_02072168(char *c, char *s, char *end) {
             int t;
             fl = op & 0x40;
             fl = fl ? fl : fl;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v1);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -99,7 +99,7 @@ void func_02072168(char *c, char *s, char *end) {
             int a;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -119,7 +119,7 @@ void func_02072168(char *c, char *s, char *end) {
             int fp;
             int n;
             int b;
-            q = func_02071a50(func_02071a50(func_02071af8(p + 1, &v0), &v1), &v2);
+            q = func_02071a50(func_02071a50(ReadSignedVarInt(p + 1, &v0), &v1), &v2);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             b = (int)(*(char **)(c + 0x18) + v0);
@@ -144,7 +144,7 @@ void func_02072168(char *c, char *s, char *end) {
             int a;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v1);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -165,7 +165,7 @@ void func_02072168(char *c, char *s, char *end) {
             int a;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v1);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -187,8 +187,8 @@ void func_02072168(char *c, char *s, char *end) {
             int t;
             int a;
             fl = op & 0x20;
-            q = func_02071af8(
-                func_02071af8(func_02071af8(p + 1, &v0), &v1), &v2);
+            q = ReadSignedVarInt(
+                ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1), &v2);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if ((op & 0x40) != 0)
@@ -219,7 +219,7 @@ void func_02072168(char *c, char *s, char *end) {
             fl = op & 0x20;
             fl = fl ? fl : fl;
             q = func_02071a50(
-                func_02071a50(func_02071af8(func_02071af8(p + 1, &v0), &v1), &v2), &v3);
+                func_02071a50(ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1), &v2), &v3);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -246,7 +246,7 @@ void func_02072168(char *c, char *s, char *end) {
             int a;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -267,7 +267,7 @@ void func_02072168(char *c, char *s, char *end) {
             int t;
             int a;
             fl = op & 0x20;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v1);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if ((op & 0x40) != 0)
@@ -290,7 +290,7 @@ void func_02072168(char *c, char *s, char *end) {
             unsigned char *q;
             if (end == (char *)p)
                 return;
-            q = func_02071af8(func_02071a50(p + 5, &v0), &v1);
+            q = ReadSignedVarInt(func_02071a50(p + 5, &v0), &v1);
             *(unsigned char **)(s + 8) = q;
             break;
         }
@@ -299,7 +299,7 @@ void func_02072168(char *c, char *s, char *end) {
             unsigned char *q;
             char *e;
             int fp;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             e = *(char **)(c + 0x18) + v0;
             fp = *(int *)(e + 8);
             if (fp != 0) {
@@ -318,7 +318,7 @@ void func_02072168(char *c, char *s, char *end) {
             unsigned char *q;
             if (end == (char *)p)
                 return;
-            q = func_02071af8(func_02071a50(func_02071a50(p + 1, &v0), &v1), &v2);
+            q = ReadSignedVarInt(func_02071a50(func_02071a50(p + 1, &v0), &v1), &v2);
             *(unsigned char **)(s + 8) = q + v0 * 4;
             break;
         }
@@ -334,9 +334,9 @@ void func_02072168(char *c, char *s, char *end) {
             int a;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v1);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v1);
             k = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
-            q = func_02071af8(q + 4, &v2);
+            q = ReadSignedVarInt(q + 4, &v2);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -361,9 +361,9 @@ void func_02072168(char *c, char *s, char *end) {
             int b;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(func_02071af8(p + 1, &v0), &v2);
+            q = ReadSignedVarInt(ReadSignedVarInt(p + 1, &v0), &v2);
             fl2 = *q++ & 0x20;
-            q = func_02071af8(func_02071af8(q, &v1), &v3);
+            q = ReadSignedVarInt(ReadSignedVarInt(q, &v1), &v3);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             if (fl != 0)
@@ -391,10 +391,10 @@ void func_02072168(char *c, char *s, char *end) {
             int n;
             fl = op & 0x20;
             fl = fl ? fl : fl;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             fl2 = *q++ & 0x20;
             fl2 = fl2 ? fl2 : fl2;
-            q = func_02071a50(func_02071af8(q, &v1), &v2);
+            q = func_02071a50(ReadSignedVarInt(q, &v1), &v2);
             fp = q[0] | (q[1] << 8) | (q[2] << 16) | (q[3] << 24);
             adv = q + 4;
             {
@@ -422,7 +422,7 @@ void func_02072168(char *c, char *s, char *end) {
         case 0x13: {
             int v0;
             unsigned char *q;
-            q = func_02071af8(p + 1, &v0);
+            q = ReadSignedVarInt(p + 1, &v0);
             *(unsigned char **)(s + 8) = q;
             break;
         }

--- a/src/func_ov006_020d4b7c.c
+++ b/src/func_ov006_020d4b7c.c
@@ -12,10 +12,10 @@ void func_ov006_020d1a3c(char *c);
 void func_ov006_020d1958(char *c);
 void func_ov006_020d1ba0(char *c);
 void func_ov006_020d27dc(char *c);
-void func_ov004_020b0aa0(int a);
+void FreeGfxSlotsById(int a);
 void func_ov004_020adb1c(int a);
 void func_ov004_020b0a54(int a);
-int func_0203d614(int *v);
+int Vec2_Len(int *v);
 int func_0203d434(int *v);
 void func_0203d630(int *v, int m);
 int RandomIntInternal(int *seed);
@@ -159,7 +159,7 @@ extern "C" int func_ov006_020d4b7c(char *c)
         if (I(0x53c4) > 0) {
             IA(0x53c4) -= 1;
             if (I(0x53c4) <= 0) {
-                func_ov004_020b0aa0(0xd);
+                FreeGfxSlotsById(0xd);
                 if (B(0xc4) == 0) {
                     B(0xc3) = 1;
                     B(0xc4) = 1;
@@ -224,7 +224,7 @@ extern "C" int func_ov006_020d4b7c(char *c)
             if (BP(p, 0x477c) != 0) {
                 IAP(p, 0x4768) += IP(p, 0x4770);
                 IAP(p, 0x476c) += IP(p, 0x4774);
-                t = func_0203d614(vp) * 7 / 8;
+                t = Vec2_Len(vp) * 7 / 8;
                 if (func_0203d434(vp) != 0)
                     func_0203d630(vp, t);
                 *(int*)AT(p, 0x4778) = *(int*)AT(p, 0x4778) + 1;


### PR DESCRIPTION
Same class as #971, found by sweeping for it after that PR landed.

The function-name pass (#891-899) renamed these symbols in `config` and in their defining files, but five call sites kept the old spelling:

| old | new | where |
|---|---|---|
| `func_ov002_020bedd4` | `Player_AdvanceAnims` | `St_BurnFire_MainEv.cpp`, `St_GroundPound_MainEv.cpp` |
| `func_ov004_020b0aa0` | `FreeGfxSlotsById` | `func_ov006_020d4b7c.c` |
| `func_020124c4` | `Sound_PlayIfNotActive` | `func_02009e70.cpp` |
| `func_02071af8` | `ReadSignedVarInt` | `func_02072168.c` |
| `func_0203d614` | `Vec2_Len` | `func_ov006_020d4b7c.c` |

Each would fail the ROM link with `Undefined : "func_..."` exactly as #971 showed.

**Worth noting for the future:** four of the five files landed *after* the rename pass, so they were written against names that had already gone. The old spellings survive in near-miss DB rows and local trees, so this will keep recurring until those are refreshed. A cheap guard would be a check that every `func_<addr>` referenced in `src/` still exists in `config`; I can add one if that seems worth it.

Relocations are address-based, so no bytes change. Verified 4 VERIFIED; `func_02009e70.cpp` stays NO-REPRO exactly as it was before this change, being a declared NONMATCHING TERMINAL-FLOOR draft from #969 (the gate reports it `ok(drf)` under #968).