### PR TITLE
readable: promote ActorBase to a real polymorphic C++ class

### DIFF
--- a/include/ActorBase.h
+++ b/include/ActorBase.h
@@ -1,46 +1,122 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class ActorBase: 21 matched functions, 8 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef ACTORBASE_H
 #define ACTORBASE_H
+
 #include "types.h"
 
-/* fwd */
-struct a;
-struct vfSuccess_;
-struct ActorBase {
-    u8  pad_000[0xe];
-    u8  unk_00e;            /* 0x00e */
-    u8  mMarkedForDestruction;            /* 0x00f */
-    u8  unk_010;            /* 0x010 */
-    u8  pad_011[0x2];
-    u8  unk_013;            /* 0x013 */
-    u8  pad_014[0x4];
-    s32 unk_018;            /* 0x018 */
-    u8  pad_01c[0xc];
-    u8  unk_028;            /* 0x028 */
-    u8  pad_029[0xf];
-    u8  unk_038;            /* 0x038 */
-    u8  pad_039[0xf];
-    s32 unk_048;            /* 0x048 */
+/* The root of the actor hierarchy, 0x02043494..0x02043e04.
+ *
+ * The chain is ActorBase -> ActorDerived -> Actor. See notes/actor-vtables.md;
+ * Actor is NOT a direct child of this class.
+ *
+ * LAYOUT is read out of the ROM, not guessed. ActorBase::ActorBase stores its
+ * vptr with `str r1, [r4]`, so the vptr is at 0x0. The same constructor does
+ * `add r5, r4, #0x14` and passes r5 to SceneNode::SceneNode, then writes an
+ * owner back-pointer with `str r4, [r5, #0x10]` -- which pins sceneNode at 0x14
+ * and makes it 0x14 bytes, not the 0x10 that ActorBase__SceneNode.h describes.
+ * It then initialises two identical 0x10-byte nodes at r5+0x14 (0x28) and
+ * r5+0x24 (0x38), the two the destructor tears down in reverse order.
+ *
+ * VTABLE ORDER is read directly out of _ZTV9ActorBase (0x02099edc, 18 slots).
+ * Every slot resolves to a named function, so no inference was needed here --
+ * unlike include/Fader.h. Two consequences, both easy to get wrong:
+ *
+ *   * The destructor is at slots 16/17, NOT 0/1. Slot index follows declaration
+ *     order, so ~ActorBase must be declared AFTER OnHeapCreated. Copying the
+ *     Fader header shape, where the destructor comes first, shifts sixteen slots
+ *     and silently changes every virtual call in the tree.
+ *
+ *   * AfterCleanupResources dispatches through vtable+0x40. That is slot 16, the
+ *     D1 destructor -- not OnPendingDestroy, which is slot 12 (vtable+0x30, the
+ *     slot MarkForDestruction uses). It destructs and then deallocates; calling
+ *     that OnPendingDestroy would describe a leak.
+ *
+ * Field NAMES are inferred from behaviour and cannot change codegen, so they are
+ * safe to improve. Offsets, widths and vtable slots are pinned by the bytes.
+ */
+
 #ifdef __cplusplus
-    /* methods */
-    bool BeforeInitResources();
-    bool OnHeapCreated();
-    int BeforeBehavior();
-    int BeforeCleanupResources();
-    int BeforeRender();
-    s32 Behavior();
-    s32 CleanupResources();
-    s32 InitResources();
-    s32 Render();
-    void AfterBehavior(unsigned int vfSuccess_);
-    void AfterInitResources(unsigned int a);
-    void AfterRender(unsigned int vfSuccess_);
-    void MarkForDestruction();
-    void OnPendingDestroy();
-#endif
+
+/* 0x14 bytes: four words plus the owner back-pointer the constructor writes. */
+struct ActorBase_SceneNode {
+    s32 unk_000;
+    s32 unk_004;
+    s32 unk_008;
+    s32 unk_00c;
+    void *owner;        /* 0x10 -- the containing ActorBase */
 };
+
+/* 0x10 bytes. Two per ActorBase; the destructor tears them down through
+   0x020440e8 in reverse order. */
+struct ActorBase_ProcessingListNode {
+    u8 raw[0x10];
+};
+
+struct ActorBase {
+    /* 0x00 is the vptr, placed implicitly by the first virtual declaration. */
+    u32 uniqueID;                             /* 0x04 -- post-incremented global */
+    u32 param1;                               /* 0x08 */
+    u16 actorID;                              /* 0x0c */
+    u8  aliveState;                           /* 0x0e -- 2 means already dying */
+    u8  shouldBeKilled;                       /* 0x0f */
+    u8  unk_010;                              /* 0x10 */
+    u8  unk_011;                              /* 0x11 */
+    u8  unk_012;                              /* 0x12 */
+    u8  unk_013;                              /* 0x13 -- bits 1 and 3 from spawn flags */
+    ActorBase_SceneNode sceneNode;            /* 0x14 */
+    ActorBase_ProcessingListNode behavNode;   /* 0x28 */
+    ActorBase_ProcessingListNode renderNode;  /* 0x38 */
+    void *unk_048;                            /* 0x48 */
+    void *heap;                               /* 0x4c -- Heap*, owned */
+
+    /* --- vtable, in _ZTV9ActorBase order. Do not reorder. --- */
+    virtual s32  InitResources();                      /* slot  0 */
+    virtual bool BeforeInitResources();                /* slot  1 */
+    virtual void AfterInitResources(u32 vfSuccess);    /* slot  2 */
+    virtual s32  CleanupResources();                   /* slot  3 */
+    virtual int  BeforeCleanupResources();             /* slot  4 */
+    virtual void AfterCleanupResources(u32 vfSuccess); /* slot  5 */
+    virtual s32  Behavior();                           /* slot  6 */
+    virtual int  BeforeBehavior();                     /* slot  7 */
+    virtual void AfterBehavior(u32 vfSuccess);         /* slot  8 */
+    virtual s32  Render();                             /* slot  9 */
+    virtual int  BeforeRender();                       /* slot 10 */
+    virtual void AfterRender(u32 vfSuccess);           /* slot 11 */
+    virtual void OnPendingDestroy();                   /* slot 12 -- vtable+0x30 */
+    virtual int  Virtual34(u32 a, u32 b);              /* slot 13 -- vtable+0x34 */
+    virtual int  Virtual38(u32 a, u32 b);              /* slot 14 -- vtable+0x38 */
+    virtual bool OnHeapCreated();                      /* slot 15 -- vtable+0x3c */
+    virtual ~ActorBase();                              /* slots 16 (D1), 17 (D0) */
+
+    /* --- non-virtual --- */
+    void MarkForDestruction();
+    /* operator new is deliberately NOT declared here. CW 1.2 rejects an in-class
+       declaration of it ("illegal 'operator' declaration"), and it is neither
+       virtual nor layout-affecting, so src/_ZN9ActorBasenwEj.cpp defines it
+       under its mangled name instead. */
+};
+
+#else
+
+/* The same object for the C translation units, which cannot express the virtual
+   functions, so the vptr the compiler would place is written out explicitly. */
+struct ActorBase {
+    void **vtable;          /* 0x00 */
+    u32 uniqueID;           /* 0x04 */
+    u32 param1;             /* 0x08 */
+    u16 actorID;            /* 0x0c */
+    u8  aliveState;         /* 0x0e */
+    u8  shouldBeKilled;     /* 0x0f */
+    u8  unk_010;            /* 0x10 */
+    u8  unk_011;            /* 0x11 */
+    u8  unk_012;            /* 0x12 */
+    u8  unk_013;            /* 0x13 */
+    u8  sceneNode[0x14];    /* 0x14 */
+    u8  behavNode[0x10];    /* 0x28 */
+    u8  renderNode[0x10];   /* 0x38 */
+    void *unk_048;          /* 0x48 */
+    void *heap;             /* 0x4c */
+};
+
+#endif /* __cplusplus */
 
 #endif

--- a/src/_ZN9ActorBase12BeforeRenderEv.cpp
+++ b/src/_ZN9ActorBase12BeforeRenderEv.cpp
@@ -5,7 +5,7 @@
 #include "ActorBase.h"
 int ActorBase::BeforeRender()
 {
-  if(mMarkedForDestruction!=0) goto ret0;
+  if(shouldBeKilled!=0) goto ret0;
   if((unk_013&8)==0) goto ret1;
 ret0:
   return 0;

--- a/src/_ZN9ActorBase13InitResourcesEv.cpp
+++ b/src/_ZN9ActorBase13InitResourcesEv.cpp
@@ -1,17 +1,27 @@
 //cpp
 // @symbol _ZN9ActorBase13InitResourcesEv
-/* recovered: named members + shared header, real C++ method */
-#include "ActorBase.h"
-/* ActorBase::InitResources() at 0x02043c80 -- vtable slot 0, one-time setup.
- * Base ActorBase does nothing and returns VS_FAIL (1); leaf classes override
- * slot 0 to load models/anims/collision.
+/* ActorBase::InitResources() at 0x02043c80 -- vtable slot 0. Base does nothing
+ * and returns VS_FAIL (1); leaf classes override slot 0 to load models, anims
+ * and collision.
+ *
+ * Deliberately defined WITHOUT including ActorBase.h, i.e. not as a real
+ * `s32 ActorBase::InitResources()`. InitResources is the first virtual declared
+ * in the class, which makes it the key function: CW 1.2 emits the vtable into
+ * whichever TU defines it. The vtable is already supplied as ROM data by the
+ * module's gap object, so a real method definition here makes the ROM link fail
+ * with
+ *
+ *     mwldarm.exe: Multiply-defined: "virtual table for ActorBase"
+ *
+ * include/Fader.h avoids this only by accident -- its first declared virtual is
+ * the destructor, and the destructor TUs are C files that never see the class,
+ * so no TU is ever the key function's definition. ActorBase cannot copy that,
+ * because its destructor is pinned to slots 16/17 and cannot be declared first.
+ *
+ * Keeping this one function out of the class is what leaves the other 24 free to
+ * be real methods.
  */
-
-typedef int s32;
-
-struct ActorBase;
-
-s32 ActorBase::InitResources()
+extern "C" int _ZN9ActorBase13InitResourcesEv(void)
 {
     return 1; /* VS_FAIL */
 }

--- a/src/_ZN9ActorBase14BeforeBehaviorEv.cpp
+++ b/src/_ZN9ActorBase14BeforeBehaviorEv.cpp
@@ -5,7 +5,7 @@
 #include "ActorBase.h"
 int ActorBase::BeforeBehavior()
 {
-  if(mMarkedForDestruction!=0) goto ret0;
+  if(shouldBeKilled!=0) goto ret0;
   if((unk_013&2)==0) goto ret1;
 ret0:
   return 0;

--- a/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
+++ b/src/_ZN9ActorBase18AfterInitResourcesEj.cpp
@@ -14,5 +14,5 @@ void ActorBase::AfterInitResources(unsigned int a)
   volatile int* p=data_02099f24; bool b=(p[0]==3); if(b){ *(bool*)((char*)&unk_010)=true; return; }
   func_0204405c(data_020a4b78, ((char*)this)+0x28);
   func_0204405c(data_020a4b98, ((char*)this)+0x38);
-  *(bool*)((char*)&unk_00e)=true;
+  *(bool*)((char*)&aliveState)=true;
 }

--- a/src/_ZN9ActorBase18MarkForDestructionEv.cpp
+++ b/src/_ZN9ActorBase18MarkForDestructionEv.cpp
@@ -6,9 +6,9 @@
 
 void ActorBase::MarkForDestruction()
 {
-  if(mMarkedForDestruction!=0) return;
-  unsigned char b = (unk_00e==2);
+  if(shouldBeKilled!=0) return;
+  unsigned char b = (aliveState==2);
   if(b!=0) return;
-  mMarkedForDestruction=1;
-  (*(void(**)(unsigned char*))(*(unsigned int*)((unsigned char *)this)+0x30))(((unsigned char *)this));
+  shouldBeKilled=1;
+  OnPendingDestroy();   /* vtable+0x30 = slot 12 */
 }

--- a/src/_ZN9ActorBase21AfterCleanupResourcesEj.c
+++ b/src/_ZN9ActorBase21AfterCleanupResourcesEj.c
@@ -1,3 +1,4 @@
+//cpp
 #include "types.h"
 /* ActorBase::AfterCleanupResources(u32 vfSuccess) at 0x02043b2c
  *
@@ -6,7 +7,7 @@
  *   func_0203b27c(&gGlobalB, &this->behavNode);   (this+0x28)
  *   if (this->unk4C) Heap::_Destroy(this->unk4C);
  *   if (this->unk48) func_02044334(this->unk48);
- *   this->OnPendingDestroy();                      virtual call at vtable+0x40
+ *   this->~ActorBase();                            virtual call at vtable+0x40
  *   Memory::Deallocate(this, Memory::gameHeapPtr);
  *
  * NOTE: compiled as C++ (the virtual-call codegen `mov r0,r4; ldr r1,[r0]`
@@ -46,7 +47,9 @@ struct ActorBase {
   virtual void v4(); virtual void v5(); virtual void v6(); virtual void v7();
   virtual void v8(); virtual void v9(); virtual void v10(); virtual void v11();
   virtual void v12(); virtual void v13(); virtual void v14(); virtual void v15();
-  virtual void OnPendingDestroy();  /* index 16 -> vtable +0x40 */
+  virtual void Destructor();        /* index 16 -> vtable+0x40 = ~ActorBase (D1).
+                                       NOT OnPendingDestroy, which is slot 12 /
+                                       vtable+0x30 -- see notes/actor-vtables.md. */
   virtual void AfterCleanupResources(u32 vfSuccess);
 };
 
@@ -56,6 +59,6 @@ void ActorBase::AfterCleanupResources(u32 vfSuccess) {
   func_0203b27c(&gGlobalB, &this->behavNode);
   if (this->unk4C) Heap_Destroy(this->unk4C);
   if (this->unk48) func_02044334(this->unk48);
-  this->OnPendingDestroy();
+  this->Destructor();   /* ~ActorBase, then free below */
   Memory_Deallocate(this, Memory_gameHeapPtr);
 }

--- a/src/_ZN9ActorBase22BeforeCleanupResourcesEv.cpp
+++ b/src/_ZN9ActorBase22BeforeCleanupResourcesEv.cpp
@@ -7,11 +7,11 @@
 
 int ActorBase::BeforeCleanupResources()
 {
-  int v=unk_048;
+  int v=(int)unk_048;
   if(v!=0){
     if(func_0204424c(v)==0) goto ret0;
   }
-  if(unk_018==0) goto ret1;
+  if(sceneNode.unk_004==0) goto ret1;
 ret0:
   return 0;
 ret1:

--- a/src/_ZN9ActorBaseD1Ev.c
+++ b/src/_ZN9ActorBaseD1Ev.c
@@ -3,9 +3,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "ActorBase.h"
+extern void *_ZTV9ActorBase[];   /* 0x02099edc */
 int *_ZN9ActorBaseD1Ev(struct ActorBase *self) {
-    ((int *)self)[0] = (int)VT0;
-    func_020440e8((char *)&self->unk_038);
-    func_020440e8((char *)&self->unk_028);
+    ((int *)self)[0] = (int)_ZTV9ActorBase;
+    func_020440e8((char *)&self->renderNode);
+    func_020440e8((char *)&self->behavNode);
     return ((int *)self);
 }

--- a/src/_ZN9ActorBaseD2Ev.c
+++ b/src/_ZN9ActorBaseD2Ev.c
@@ -3,9 +3,10 @@
 #include "decl_common.h"
 /* recovered: named members + shared header */
 #include "ActorBase.h"
+extern void *_ZTV9ActorBase[];   /* 0x02099edc */
 int *_ZN9ActorBaseD2Ev(struct ActorBase *self) {
-    ((int *)self)[0] = (int)VT0;
-    func_020440e8((char *)&self->unk_038);
-    func_020440e8((char *)&self->unk_028);
+    ((int *)self)[0] = (int)_ZTV9ActorBase;
+    func_020440e8((char *)&self->renderNode);
+    func_020440e8((char *)&self->behavNode);
     return ((int *)self);
 }


### PR DESCRIPTION
Phase 1 of the Actor hierarchy work, on top of #972's vtable names.

`include/ActorBase.h` was auto-generated placeholder — `pad_000[0xe]`, eight `unk_` fields,
fourteen **non-virtual** method declarations, and no representation of the 18-slot vtable.
It is now hand-written from `_ZTV9ActorBase`, with the evidence for each claim in the header.

**All 25 ActorBase files byte-match. Before this, 5 of 25 did.**

## Layout is read, not guessed

The constructor stores the vptr with `str r1, [r4]` (vptr at 0x0), does `add r5, r4, #0x14`
before calling `SceneNode::SceneNode`, then writes an owner back-pointer with
`str r4, [r5, #0x10]` — pinning `sceneNode` at 0x14 and making it 0x14 bytes, not the 0x10
that `ActorBase__SceneNode.h` describes.

## Three things fixed

**`MarkForDestruction` dispatched by hand:**

```c
(*(void(**)(unsigned char*))(*(unsigned int*)this + 0x30))(this);
```

That is now `OnPendingDestroy()`, and it still reproduces — end-to-end evidence the slot
order is right rather than merely plausible.

**`AfterCleanupResources` had slot 16 labelled `OnPendingDestroy`.** The ROM says slot 16 is
`~ActorBase` (D1); `OnPendingDestroy` is slot 12 at `vtable+0x30`, the slot
`MarkForDestruction` uses. The function destructs and *then* deallocates, so the old name
described a leak that isn't there. It was also a `.c` file containing C++ with no `//cpp`
marker, so every tool compiled it as C99 and it silently failed to reproduce — and it isn't
enrolled `complete`, which is why the ROM build never noticed.

**`Virtual34` and `Virtual38` each carried a local stub class** with sixteen dummy virtuals,
purely to force the vptr layout. The shared header replaces both.

## The key-function constraint

`InitResources` is deliberately **not** a real method. It is the first virtual declared,
which makes it the key function, and CW 1.2 emits the vtable into whichever TU defines it —
colliding with the copy the module's gap object supplies from ROM data:

```
mwldarm.exe: Multiply-defined: "virtual table for ActorBase"
mwldarm.exe: Previously defined in _dsd_gap@main_36.o
```

`include/Fader.h` avoids this only by accident: its first declared virtual is the
destructor, and its destructor TUs are C files that never see the class, so no TU is ever
the key function's definition. `ActorBase` cannot copy that — its destructor is pinned to
slots 16/17. Keeping this one function out of the class is what leaves the other 24 free to
be real methods. `ActorDerived` and `Actor` will each need the same treatment.

Worth noting: the byte gate was green at 25/25 the whole time this was broken. Only the
full link saw it.

## A declaration-shape trap

`decl_common.h` declares `VT0` as `extern int VT0[]` but `data_02099edc` as a scalar
`extern int`. Swapping one name for the other turns `(int)X` from an address into a *load of
its contents*, adding 8 bytes to both destructors. They now declare
`extern void *_ZTV9ActorBase[]` locally. This will recur on every vtable reference in
Phases 2 and 3.

## Verification

- 25/25 byte-match under mwccarm 1.2/sp2p3.
- Full ROM build links, **9,115/9,115 source-built functions reproducing, 0 mismatching**.
  The only divergence is the intentional 3-byte `mods/Player_ScaleByCharFactor` change
  from #941, which is what makes `dsd check modules` flag overlay 2.

Next is `ActorDerived` (4 files), which must precede `Actor` — see notes/actor-vtables.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
