### PR TITLE
rombuild: re-run enroll.py so delinks matches what it generates

### DIFF
--- a/config/arm9/delinks.txt
+++ b/config/arm9/delinks.txt
@@ -69,6 +69,9 @@ src/func_02005ed8.c:
 src/_ZN8CapEnemy21DestroyIfCapNotNeededEv.cpp:
     .text start:0x02005f0c end:0x02005fa0
 
+src/_ZN8CapEnemy11GetCapStateEv.cpp:
+    .text start:0x02005fa0 end:0x02006054
+
 src/_ZN8CapEnemy15RespawnIfHasCapEv.cpp:
     .text start:0x02006054 end:0x020060f4
 
@@ -11655,6 +11658,9 @@ src/func_02071f88.c:
 src/func_02072014.c:
     complete
     .text start:0x02072014 end:0x02072168
+
+src/func_02072168.c:
+    .text start:0x02072168 end:0x020729f4
 
 src/func_020729f4.c:
     complete

--- a/config/arm9/overlays/ov002/delinks.txt
+++ b/config/arm9/overlays/ov002/delinks.txt
@@ -2981,6 +2981,9 @@ src/func_ov002_020d5338.cpp:
     complete
     .text start:0x020d5338 end:0x020d53ac
 
+src/_ZN6Player16St_BurnFire_MainEv.cpp:
+    .text start:0x020d53ac end:0x020d5750
+
 src/_ZN6Player16St_BurnFire_InitEv.cpp:
     complete
     .text start:0x020d5750 end:0x020d57d8
@@ -3074,6 +3077,9 @@ src/func_ov002_020d6998.cpp:
 
 src/func_ov002_020d6c60.cpp:
     .text start:0x020d6c60 end:0x020d6dac
+
+src/func_ov002_020d6dac.c:
+    .text start:0x020d6dac end:0x020d7030
 
 src/func_ov002_020d7030.cpp:
     complete
@@ -3461,6 +3467,9 @@ src/_ZN6Player22St_GroundPound_CleanupEv.cpp:
     complete
     .text start:0x020dd9e0 end:0x020dd9f8
 
+src/_ZN6Player19St_GroundPound_MainEv.cpp:
+    .text start:0x020dd9f8 end:0x020dddf0
+
 src/_ZN6Player19St_GroundPound_InitEv.cpp:
     .text start:0x020dddf0 end:0x020dde74
 
@@ -3572,6 +3581,9 @@ src/func_ov002_020df7f4.cpp:
 src/func_ov002_020df840.c:
     complete
     .text start:0x020df840 end:0x020df8f0
+
+src/func_ov002_020df8f0.c:
+    .text start:0x020df8f0 end:0x020dfdf0
 
 src/_ZN6Player11St_Fly_MainEv.cpp:
     .text start:0x020dfdf0 end:0x020e027c
@@ -3815,6 +3827,9 @@ src/func_ov002_020e4bb8.c:
 
 src/_ZN6Player8BehaviorEv.cpp:
     .text start:0x020e4d24 end:0x020e558c
+
+src/_ZN6Player13InitResourcesEv.cpp:
+    .text start:0x020e558c end:0x020e5948
 
 src/func_ov002_020e5948.c:
     complete

--- a/config/arm9/overlays/ov006/delinks.txt
+++ b/config/arm9/overlays/ov006/delinks.txt
@@ -1336,6 +1336,9 @@ src/func_ov006_020d11a0.cpp:
     complete
     .text start:0x020d11a0 end:0x020d122c
 
+src/func_ov006_020d122c.c:
+    .text start:0x020d122c end:0x020d1450
+
 src/func_ov006_020d1450.c:
     complete
     .text start:0x020d1450 end:0x020d14c0
@@ -1356,6 +1359,9 @@ src/func_ov006_020d2580.c:
     complete
     .text start:0x020d2580 end:0x020d25fc
 
+src/func_ov006_020d25fc.c:
+    .text start:0x020d25fc end:0x020d27dc
+
 src/func_ov006_020d3624.cpp:
     complete
     .text start:0x020d3624 end:0x020d3668
@@ -1371,6 +1377,9 @@ src/func_ov006_020d452c.c:
 src/func_ov006_020d48dc.cpp:
     complete
     .text start:0x020d48dc end:0x020d4b7c
+
+src/func_ov006_020d4b7c.c:
+    .text start:0x020d4b7c end:0x020d52f0
 
 src/func_ov006_020d52f0.c:
     complete
@@ -1582,6 +1591,9 @@ src/func_ov006_020d7604.c:
 src/func_ov006_020d7778.c:
     complete
     .text start:0x020d7778 end:0x020d777c
+
+src/func_ov006_020d777c.c:
+    .text start:0x020d777c end:0x020d7958
 
 src/func_ov006_020d7958.c:
     complete
@@ -3304,6 +3316,9 @@ src/func_ov006_020ef4ec.c:
 src/func_ov006_020ef580.c:
     complete
     .text start:0x020ef580 end:0x020ef5ac
+
+src/func_ov006_020ef5ac.c:
+    .text start:0x020ef5ac end:0x020ef768
 
 src/func_ov006_020ef768.c:
     complete
@@ -5535,6 +5550,9 @@ src/func_ov006_021126b4.c:
     complete
     .text start:0x021126b4 end:0x021128fc
 
+src/func_ov006_021128fc.c:
+    .text start:0x021128fc end:0x02112ad8
+
 src/func_ov006_02112ad8.c:
     .text start:0x02112ad8 end:0x02113c14
 
@@ -6626,6 +6644,9 @@ src/func_ov006_02123c78.c:
     complete
     .text start:0x02123c78 end:0x02123cb4
 
+src/func_ov006_02123cb4.c:
+    .text start:0x02123cb4 end:0x02124040
+
 src/func_ov006_02124040.c:
     complete
     .text start:0x02124040 end:0x02124088
@@ -6971,6 +6992,12 @@ src/__sinit_ov006_02130f00.c:
 
 src/__sinit_ov006_02130f64.c:
     .init start:0x02130f64 end:0x021311c8
+
+src/__sinit_ov006_021311c8.c:
+    .init start:0x021311c8 end:0x021314e4
+
+src/__sinit_ov006_021314e4.c:
+    .init start:0x021314e4 end:0x021318a0
 
 src/__sinit_ov006_021318a0.c:
     .init start:0x021318a0 end:0x0213195c


### PR DESCRIPTION
16 functions matched since the last enroll run were never carved out, so `enroll.py --dry-run` on main reports **3 files would change**. That makes the tool non-idempotent against the committed tree, and every future run drags the same noise into an unrelated diff — which is exactly what happened while preparing #975.

Pure additions, no promotions. Entries stay at **11,097 with 9,116 complete / 1,981 rom-bytes**, and the ROM is byte-identical:

```
d0e015bb26cbc78706268aede9af44c7164903a35e443fe8afba877586da3b08
```

`dsd check modules` is green everywhere except ov002, which fails identically before and after — the intentional `mods/Player_ScaleByCharFactor.c` divergence.

## Why these 16 are not also promoted to `complete`

This is the part worth reading. `eligible.py` says **9,135** of the 11,097 pass its five structural rules — 19 more than are currently compiled. **Promoting all 19 breaks the build:** ARM9 main, ov055 and ov058 all fail `dsd check modules`.

Six of the nineteen are destructors:

```
_ZN5ModelD1Ev  _ZN5ModelD2Ev  _ZN14BlendModelAnimD1Ev
_ZN11MirrorLuigiD1Ev  _ZN15RecRoomCupboardD0Ev  _ZN15RecRoomCupboardD1Ev
```

That is precisely the case **rule 1 exists to reject** — a dtor translation unit emits D0/D1/D2 plus thunks, "at addresses only one of which is right". They pass it anyway. Excluding those six makes ov055 and ov058 green, so that much is confirmed.

**ARM9 still fails with the six excluded**, so at least one of its three remaining additions (`CleanCommonModelDataArr`, `_ZN8CapEnemy11GetCapStateEv`, `func_020313d8`) is bad for a different reason. And ov002's four cannot be judged at all while the mod makes that module fail either way.

So the eligibility whitelist currently admits objects that do not link correctly, and it wants narrowing before anything else is promoted. That is a separate change; this PR only restores idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)