### PR TITLE
readable: promote ActorDerived to a real C++ class

### DIFF
--- a/include/ActorDerived.h
+++ b/include/ActorDerived.h
@@ -1,0 +1,43 @@
+#ifndef ACTORDERIVED_H
+#define ACTORDERIVED_H
+
+#include "ActorBase.h"
+
+/* The middle link of the actor hierarchy: ActorBase -> ActorDerived -> Actor.
+ * Actor is NOT a direct child of ActorBase. See notes/actor-vtables.md.
+ *
+ * _ZTV12ActorDerived (0x0208e4b8) is ActorBase's 18-slot table with exactly one
+ * functional override -- slot 2, AfterInitResources -- plus its own D1/D0 at
+ * slots 16/17. Every other slot still points at the ActorBase implementation.
+ * The class therefore adds NO new virtuals, which has a useful consequence.
+ *
+ * KEY FUNCTION. CW 1.2 emits the vtable into the TU that defines the first
+ * non-inline virtual declared in the class, and that copy collides with the one
+ * the module's gap object supplies from ROM data. include/ActorBase.h has to
+ * work around this by keeping InitResources out of the class entirely, because
+ * ActorBase is the root: all of its virtuals are new, so declaration order sets
+ * the slot indices and the destructor is pinned to 16/17.
+ *
+ * ActorDerived is not constrained that way. An override takes its base's slot
+ * whatever order it is declared in, so the destructor can be declared FIRST and
+ * become the key function. Nothing defines ~ActorDerived as a C++ method -- the
+ * destructor translation units are C files that never see this class -- so no
+ * TU is the key function's definition and no vtable is emitted. That is what
+ * lets AfterInitResources be a real method here.
+ *
+ * The rule generalises: only the root class pays the key-function tax.
+ */
+struct ActorDerived : ActorBase {
+    /* Declared first, deliberately -- see KEY FUNCTION above. Overrides slots
+       16 (D1) and 17 (D0); the position in this list does not affect that. */
+    virtual ~ActorDerived();
+
+    /* slot 2 -- marks the actor for destruction when init failed, then chains. */
+    virtual void AfterInitResources(u32 vfSuccess);
+
+    /* Static: no `this`. In the ROM this is a 0xc-byte veneer that tail-calls
+       0x02042ffc (ldr ip,[pc]; bx ip; .word), so it has no body of its own. */
+    static void Spawn(u32 actorID, ActorBase *parent, int a, int b);
+};
+
+#endif

--- a/src/_ZN12ActorDerived18AfterInitResourcesEj.c
+++ b/src/_ZN12ActorDerived18AfterInitResourcesEj.c
@@ -1,12 +1,22 @@
-#include "types.h"
-typedef struct ActorDerived { char pad[0]; } ActorDerived;
+//cpp
+// @symbol _ZN12ActorDerived18AfterInitResourcesEj
+/* ActorDerived::AfterInitResources(u32) at 0x02013ef4 -- vtable slot 2, the only
+ * functional override this class makes.
+ *
+ * If initialisation reported VS_FAIL (1) the actor is marked for destruction,
+ * and either way the ActorBase implementation runs afterwards.
+ *
+ * Kept as a .c filename with the //cpp marker rather than renamed to .cpp: the
+ * extension is what config/arm9/delinks.txt records, so renaming the file would
+ * turn a src-only change into a config change too.
+ */
+#include "ActorDerived.h"
 
-extern void _ZN9ActorBase18MarkForDestructionEv(ActorDerived* self);
-extern void _ZN9ActorBase18AfterInitResourcesEj(ActorDerived* self, u32 result);
+extern "C" void _ZN9ActorBase18AfterInitResourcesEj(ActorBase *self, u32 result);
 
-void _ZN12ActorDerived18AfterInitResourcesEj(ActorDerived* self, u32 result) {
-    if (result == 1) {
-        _ZN9ActorBase18MarkForDestructionEv(self);
-    }
-    _ZN9ActorBase18AfterInitResourcesEj(self, result);
+void ActorDerived::AfterInitResources(u32 vfSuccess)
+{
+    if (vfSuccess == 1)
+        MarkForDestruction();
+    _ZN9ActorBase18AfterInitResourcesEj(this, vfSuccess);
 }

--- a/src/_ZN12ActorDerivedD0Ev.c
+++ b/src/_ZN12ActorDerivedD0Ev.c
@@ -1,13 +1,13 @@
 struct ActorDerived { void **vtable; };
 struct Heap;
-extern void *data_0208e4b8[];
+extern void *_ZTV12ActorDerived[];   /* 0x0208e4b8 */
 extern void _ZN9ActorBaseD2Ev(struct ActorDerived *thiz);
 extern void _ZN6Memory10DeallocateEPvP4Heap(void *ptr, struct Heap *heap);
 extern struct Heap *data_020a0eac;
 
 struct ActorDerived *_ZN12ActorDerivedD0Ev(struct ActorDerived *thiz)
 {
-    thiz->vtable = (void **)data_0208e4b8;
+    thiz->vtable = (void **)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(thiz);
     _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;

--- a/src/_ZN12ActorDerivedD1Ev.c
+++ b/src/_ZN12ActorDerivedD1Ev.c
@@ -4,11 +4,11 @@
  * Base dtor call target: 0x02043d48
  */
 struct Obj { void *vtable; };
-extern void *data_0208e4b8[];
+extern void *_ZTV12ActorDerived[];   /* 0x0208e4b8 */
 extern void _ZN9ActorBaseD2Ev(struct Obj *thiz); /* 0x02043d48 */
 struct Obj *_ZN12ActorDerivedD1Ev(struct Obj *thiz)
 {
-    thiz->vtable = (void *)data_0208e4b8;
+    thiz->vtable = (void *)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(thiz);
     return thiz;
 }


### PR DESCRIPTION
Phase 2 of the Actor hierarchy, on top of #974. Adds `include/ActorDerived.h` — the middle
link of `ActorBase -> ActorDerived -> Actor`, which had no header at all.

**All 4 files byte-match.**

## The key-function tax is narrower than #974 claimed

#974 said `ActorDerived` and `Actor` would each need their slot-0 function held outside the
class, the way `ActorBase` keeps `InitResources` out. That's wrong, and worth correcting
before Phase 3 is built on it.

`_ZTV12ActorDerived` (0x0208e4b8) is ActorBase's 18-slot table with exactly one functional
override — slot 2 — plus its own D1/D0 at 16/17. The class adds **no new virtuals**. An
override takes its base's slot regardless of where it's declared, so the destructor can be
declared **first** and become the key function. Nothing defines `~ActorDerived` as a C++
method — the destructor TUs are C files that never see the class — so no TU is the key
function's definition, no vtable is emitted, and there's no collision with the gap object's
ROM-supplied copy.

That is exactly the escape hatch `include/Fader.h` gets by accident, and it *does* apply
here. `ActorBase` couldn't use it only because it's the root: all its virtuals are new, so
declaration order sets the slot indices and the destructor is pinned to 16/17.

**The rule generalises: only the root class pays the key-function tax.**

## What that buys

`AfterInitResources` is a real method:

```cpp
void ActorDerived::AfterInitResources(u32 vfSuccess)
{
    if (vfSuccess == 1)
        MarkForDestruction();
    _ZN9ActorBase18AfterInitResourcesEj(this, vfSuccess);
}
```

It was previously a free function over a `typedef struct ActorDerived { char pad[0]; }`
fake struct.

## Two smaller points

`AfterInitResources` keeps its `.c` filename with a `//cpp` marker rather than being renamed
to `.cpp`. The extension is what `config/arm9/delinks.txt` records, so a rename would turn a
src-only change into a config change too — the combination that can't validate itself on the
build box.

The destructors now reference `_ZTV12ActorDerived` (#972) instead of `data_0208e4b8`, kept
in array form so the cast yields an address. Per #974, a scalar declaration would emit a
load of the contents instead and add 8 bytes.

`Spawn` is left alone: at 0xc bytes it's a veneer that tail-calls 0x02042ffc
(`ldr ip,[pc]; bx ip; .word`), so there's no body to promote. It's declared `static` in the
header because it takes no `this`.

## Verification

- 4/4 byte-match under mwccarm 1.2/sp2p3.
- Full ROM build links, **9,115/9,115 source-built functions reproducing, 0 mismatching**.
  The only divergence is the intentional 3-byte `mods/Player_ScaleByCharFactor` change from
  #941, which is what makes `dsd check modules` flag overlay 2.

Next is `Actor` — 81 files. It overrides ten slots *and* appends thirteen new ones (18–30),
so the new virtuals take their indices from declaration order while the destructor stays an
override at 16/17. I expect it can declare the destructor first and dodge the key-function
problem the same way, but that gets verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
