### PR TITLE
Add full-ROM merge validation reports

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,8 +1,8 @@
-name: PR link validation
+name: PR validation
 
 # Uses pull_request_target so repo secrets (the relay token) are available even
 # for fork PRs. SAFE because this workflow never checks out or runs PR code — it
-# only sends the PR number + head sha to the relay. The actual compile/linkcheck
+# only sends the PR number + immutable head/base SHAs to the relay. The actual validation
 # happens on the self-hosted worker behind the maintainer's NAT, sandboxed there.
 on:
   pull_request_target:
@@ -36,11 +36,15 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
+          payload=$(jq -n --arg repo "$REPO" --argjson pr "$PR" \
+            --arg sha "$SHA" --arg baseSha "$BASE_SHA" \
+            '{repo:$repo,pr:$pr,sha:$sha,baseSha:$baseSha}')
           resp=$(curl -sS -X POST "$RELAY/api/pr-validate" \
             -H "X-Api-Key: $TOKEN" -H "Content-Type: application/json" \
-            -d "{\"repo\":\"$REPO\",\"pr\":$PR,\"sha\":\"$SHA\"}")
+            --data "$payload")
           echo "$resp"
           jobId=$(echo "$resp" | jq -r '.jobId // empty')
           if [ -z "$jobId" ]; then echo "relay did not return a jobId"; exit 1; fi
@@ -74,6 +78,7 @@ jobs:
           {
             echo "summary<<EOF"; jq -r '.summary // ""' result.json; echo "EOF"
             echo "details<<EOF"; jq -r '.details // ""' result.json; echo "EOF"
+            echo "reportMarkdown<<EOF"; jq -r '.reportMarkdown // ""' result.json; echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment result
@@ -82,21 +87,27 @@ jobs:
           STATUS: ${{ steps.poll.outputs.status }}
           SUMMARY: ${{ steps.poll.outputs.summary }}
           DETAILS: ${{ steps.poll.outputs.details }}
+          REPORT_MARKDOWN: ${{ steps.poll.outputs.reportMarkdown }}
         with:
           script: |
-            const { STATUS, SUMMARY, DETAILS } = process.env;
+            const { STATUS, SUMMARY, DETAILS, REPORT_MARKDOWN } = process.env;
             const icon = STATUS === 'Passed' ? '✅'
                        : STATUS === 'Failed' ? '❌'
                        : '⚠️';
             const marker = '<!-- pr-link-validation -->';
-            let body = `${marker}\n### ${icon} PR link validation — ${STATUS}\n\n${SUMMARY || ''}`;
+            let body = `${marker}\n### ${icon} PR validation — ${STATUS}\n\n${SUMMARY || ''}`;
+            if (REPORT_MARKDOWN && REPORT_MARKDOWN.trim()) {
+              body += `\n\n${REPORT_MARKDOWN.trim()}`;
+            }
             if (DETAILS && DETAILS.trim()) {
               // DETAILS is a markdown table from pr_linkcheck --md. Wrap it in a
               // <details> fold; the blank lines let GitHub render the markdown
               // inside (a code fence would show it as raw ASCII instead).
               body += `\n\n<details><summary>Per-file link-check detail</summary>\n\n${DETAILS.trim()}\n\n</details>`;
             }
-            body += `\n\n<sub>Each changed \`src/*.c|*.cpp\` is compiled and its relocated bytes compared to the binary data on a private build box. Passing requires every changed file to reproduce the ROM byte-for-byte with correct relocation targets — this catches WRONG-DEST relocations and non-reproducing near-misses that ledger-scoped linkcheck skips.</sub>`;
+            body += REPORT_MARKDOWN && REPORT_MARKDOWN.trim()
+              ? `\n\n<sub>The private worker commits a test merge, builds the stock ROM profile, compares every executable module, measures matched and source-built code, checks contributor lineage, and verifies affected relocations. The mod profile is opt-in and is not part of this merge gate.</sub>`
+              : `\n\n<sub>Each changed \`src/*.c|*.cpp\` is compiled and its relocated bytes compared to the binary data on a private build box. Passing requires every changed file to reproduce the ROM byte-for-byte with correct relocation targets — this catches WRONG-DEST relocations and non-reproducing near-misses that ledger-scoped linkcheck skips.</sub>`;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
@@ -107,7 +118,7 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
 
-      - name: Fail the check if validation failed
-        if: steps.poll.outputs.status == 'Failed'
+      - name: Fail the check unless validation passed
+        if: steps.poll.outputs.status != 'Passed'
         run: |
-          echo "PR link validation failed"; exit 1
+          echo "PR validation did not pass"; exit 1

--- a/notes/pr-validation.md
+++ b/notes/pr-validation.md
@@ -1,0 +1,50 @@
+# Full PR validation
+
+The merge gate should answer several different questions without compressing them into
+one misleading percentage:
+
+| Metric | Meaning | Gate |
+|---|---|---|
+| Matched functions and bytes | A verified-looking `src/` file exists for a configured ROM function | Must not regress |
+| Coverage denominator | Configured function count and code-byte universe | Must not change silently |
+| Source-built functions and bytes | Code actually linked from our translation units instead of a ROM gap object | Must not regress |
+| Module fidelity | Linked executable-module bytes equal retail | Stock head must pass, unless base and head have the same recorded pre-existing build failure |
+| Contributor lineage | The first matcher still owns a surviving match after moves/renames | Must not change or disappear |
+| Relocations | Affected source reproduces bytes and names the correct destinations | No WRONG or NO-REPRO |
+
+`tools/rombuild.py` emits the build/fidelity artifact. `tools/validate_merge.py` compares
+two committed revisions, combines the build artifacts with `pr_linkcheck` JSON, and emits
+both stable JSON and the Markdown table shown on a PR.
+
+## Private worker sequence
+
+The compiler and ROM remain on the private worker. For each relay job:
+
+1. Check out the requested `baseSha` and run
+   `python tools/rombuild.py --profile stock --report-json build/base-rom.json`.
+   The worker may cache this artifact by commit SHA.
+2. Create a temporary branch at `baseSha`, merge the requested PR head SHA, and
+   **commit the merge before measuring**. Attribution follows Git history; a staged but
+   uncommitted move has no lineage.
+3. Run `python tools/rombuild.py --profile stock --report-json build/head-rom.json`.
+4. Run `python tools/pr_linkcheck.py --base <baseSha> --json build/link.json --md build/link.md`.
+5. Run:
+
+   ```
+   python tools/validate_merge.py --base <baseSha> --head HEAD \
+     --require-merge-commit --expected-pr-head <headSha> \
+     --base-rom-report build/base-rom.json \
+     --head-rom-report build/head-rom.json --link-report build/link.json \
+     --out build/validate-report.json --markdown build/validate-report.md
+   ```
+
+6. Return `status`, `summary`, `details` (the existing per-file table), and the new
+   `reportMarkdown` field to the relay. The public GitHub workflow remains unable to run
+   PR code or access ROM material; it only renders the worker's result.
+
+A base failure is not hidden. If base and merge fail in the same phase with the same
+failure signature, the report shows a warning and permits a non-regressing PR. If a green
+base becomes red, or the failure changes, validation fails.
+
+The merge gate always uses the stock profile. `--profile mods` is a developer tool for
+building intentional experiments and is never accepted as reconstruction proof.

--- a/notes/rom-build.md
+++ b/notes/rom-build.md
@@ -22,7 +22,8 @@ rest of each module is supplied from delinked ROM bytes. All four milestones are
 ```
 python tools/eligible.py             # classify: which files may be compiled in
 python tools/enroll.py --complete-list build/eligible-names.txt
-python tools/rombuild.py             # build and verify
+python tools/rombuild.py             # build and verify the stock profile (default)
+python tools/rombuild.py --profile mods  # intentionally include mods/
 python tools/rombuild_check.py       # per-function byte diff, names any culprit
 python tools/rombuild_diag.py        # explain a mismatch: which symbol does it name?
 python tools/rombuild_versions.py build/bad.txt --write   # per-file compiler overrides
@@ -32,6 +33,27 @@ python tools/rombuild_versions.py build/bad.txt --write   # per-file compiler ov
 `config/**/delinks.txt`; everything else comes from ROM bytes. Enrolling more source is
 therefore a config edit, not a code change. `--no-rom` stops after linking for fast
 iteration.
+
+### Stock and mod profiles
+
+The tracked `delinks.txt` files may keep a convenient `mods/<symbol>.c` enrollment, but
+that no longer makes an ordinary build modded. `rombuild.py` generates a disposable
+config under `build/rombuild-config/`:
+
+- `--profile stock` is the default. Each `mods/<symbol>.c` entry is redirected in the
+  generated config to its verified `src/<symbol>.c` counterpart. If no verified source
+  counterpart exists, that range falls back to retail gap bytes. The tracked config and
+  the useful mod source are not edited.
+- `--profile mods` preserves explicit `mods/` entries and writes
+  `build/sm64ds-mod.nds`.
+
+Stock validation rejects every executable-module byte difference. Mod validation permits
+differences only inside the address ranges explicitly enrolled from `mods/`, and fails if
+an enrolled mod did not actually alter its range. Both profiles write structured reports:
+`build/rombuild-report.json` for stock and `build/rombuild-mod-report.json` for mods.
+The reports keep module fidelity separate from source reconstruction: the former answers
+"does the linked code reproduce retail?"; the latter answers "how many functions and
+code bytes in this output came from our source?"
 
 **The compiler default is `2004/b56`** (`rombuild.VERSION`), with per-file exceptions in
 `config/rombuild-versions.txt`. The **linker** is always 1.2/sp2p3 (`LD_VERSION`) because
@@ -547,9 +569,9 @@ flyover) → the opening cutscene → gameplay on the castle grounds, with the H
 touch-screen minimap, 2D and 3D all correct. No BIOS files and no `--arm7-bios` needed.
 
 **Intentional divergences live in `mods/`, not `src/`.** `src/` must byte-reproduce the
-ROM, so a modified function goes in `mods/<Symbol>.c` and the module's `delinks.txt`
-file entry points there instead. Switching between stock and modded is a one-word path
-edit; nothing else in the pipeline changes.
+ROM, so a modified function goes in `mods/<Symbol>.c`. Select it explicitly with
+`python tools/rombuild.py --profile mods`; the normal command remains stock even when a
+tracked `delinks.txt` entry points at that mod.
 
 `mods/Player_ScaleByCharFactor.c` (shift 12 → 11, doubling the scale factor) built
 cleanly and landed exactly as intended: **3 bytes changed**, both at the shift
@@ -567,9 +589,9 @@ mwldarm, into a linked overlay that is byte-identical everywhere except the thre
 that changed, packaged into a ROM that boots and plays differently. That is the
 deliverable.
 
-`mods/` is where an intentional divergence lives; `tools/enroll.py` prefers
-`mods/<symbol>.c` over `src/<symbol>.c` by file existence, so deleting the mod file
-reverts to stock and `python tools/rombuild.py` is green again.
+`mods/` is where an intentional divergence lives; `tools/enroll.py` may still prefer
+`mods/<symbol>.c` when regenerating tracked enrollment, while the generated stock build
+profile safely redirects it back to `src/<symbol>.c`.
 
 ## Constraints
 

--- a/tools/chaos_db_ci.py
+++ b/tools/chaos_db_ci.py
@@ -82,7 +82,7 @@ def _handle_from(name: str, email: str) -> str:
     return m.group(1) if m else (email.split("@")[0].lower() or name.strip())
 
 
-def first_matchers() -> dict[str, str]:
+def first_matchers(rev="HEAD") -> dict[str, str]:
     """{'src/name.ext': handle} crediting each currently-tracked file to the FIRST
     contributor to land the match it descends from. Credit belongs to whoever matched a
     function first; a later duplicate submission of the same function does not steal it.
@@ -104,7 +104,7 @@ def first_matchers() -> dict[str, str]:
     # degrade to delete+add and the mass-renamer wrongly inherits every matcher's credit.
     out = subprocess.run(
         ["git", "-c", "diff.renameLimit=0", "log", "--reverse", "--diff-filter=ADR", "-M",
-         "--format=%x01%an%x02%ae", "--name-status", "--", "src/"],
+         "--format=%x01%an%x02%ae", "--name-status", rev, "--", "src/"],
         cwd=REPO, capture_output=True, text=True, encoding="utf-8", errors="replace").stdout
     origin: dict[str, str] = {}   # live path -> author of the earliest add in its lineage
     handle = None
@@ -162,7 +162,7 @@ def first_matchers() -> dict[str, str]:
     return origin
 
 
-def match_finishers() -> dict[str, str]:
+def match_finishers(rev="HEAD") -> dict[str, str]:
     """{'src/name.ext': handle} crediting whoever FIRST turned a NONMATCHING draft into a
     real byte-match -- the person who actually matched the function.
 
@@ -190,7 +190,7 @@ def match_finishers() -> dict[str, str]:
     REC, FLD, SUB = "\x01", "\x02", "\x03"
     out = subprocess.run(
         ["git", "log", "--full-history", "--reverse",
-         f"--format={REC}%H{FLD}%an{SUB}%ae", "--name-status", "-M", "--", "src/"],
+         f"--format={REC}%H{FLD}%an{SUB}%ae", "--name-status", "-M", rev, "--", "src/"],
         cwd=REPO, capture_output=True, text=True, encoding="utf-8", errors="replace").stdout
 
     commits: list[tuple[str, str, list]] = []

--- a/tools/rombuild.py
+++ b/tools/rombuild.py
@@ -11,24 +11,26 @@ into a bootable ROM.
     dsd lcf      -> build/arm9.lcf + build/objects.txt
     mwldarm      -> build/final_link.o     + build/build/*.bin per region
     dsd rom config / rom build             -> build/sm64ds.nds
-    dsd check modules                      -> byte-diff every module vs the ROM
+    rombuild_check.py                      -> byte-diff every module vs the ROM
 
 A module is "green" when its linked bytes equal the retail module, so a green build
 with N functions enrolled is proof those N functions' source is the real thing.
 
 Usage:
-    python tools/rombuild.py                 # full build + verify
+    python tools/rombuild.py                 # stock ROM build + verify
+    python tools/rombuild.py --profile mods  # explicitly include mods/
     python tools/rombuild.py --no-rom        # link and verify, skip .nds packaging
-    python tools/rombuild.py --no-check      # skip the module byte-diff
+    python tools/rombuild.py --no-check      # skip fidelity analysis (unchecked output)
     python tools/rombuild.py -j 16           # parallel compiles
 
 See notes/rom-build.md for the milestones and the enrollment rules.
 """
 import argparse
 import concurrent.futures
+import hashlib
+import json
 import os
 import pathlib
-import shutil
 import subprocess
 import sys
 
@@ -37,8 +39,11 @@ DSD = REPO / "tools" / "bin" / "dsd.exe"
 MW = REPO / "tools" / "mwccarm"
 LICENSE = MW / "license.dat"
 INCLUDE = REPO / "include"
-CONFIG = REPO / "config" / "arm9" / "config.yaml"
+CONFIG_ROOT = REPO / "config" / "arm9"
 BUILD = REPO / "build"
+sys.path.insert(0, str(REPO / "tools"))
+import rombuild_check as RBC  # noqa: E402
+import rombuild_profile as RP  # noqa: E402
 
 # Default compiler for the ROM build. The repo pins 1.2/sp2p3 as the canonical
 # matching compiler, but the recovered 2004 build 0056 (notes/mwccarm-codegen.md 6ai)
@@ -87,19 +92,25 @@ def launcher():
     return os.environ.get("MWCCARM_LAUNCHER", "").split()
 
 
+class BuildError(RuntimeError):
+    def __init__(self, phase, returncode, output):
+        super().__init__(f"{phase} failed (exit {returncode})")
+        self.phase = phase
+        self.returncode = returncode
+        self.output = output
+
+
 def run(cmd, what, quiet_patterns=()):
     r = subprocess.run(cmd, capture_output=True, text=True,
                        env=dict(os.environ, LM_LICENSE_FILE=str(LICENSE)), cwd=REPO)
     out = "\n".join(l for l in (r.stdout + r.stderr).splitlines()
                     if not any(p in l for p in quiet_patterns))
     if r.returncode != 0:
-        print(f"!! {what} failed (exit {r.returncode})")
-        print(out[:4000])
-        sys.exit(1)
+        raise BuildError(what, r.returncode, out)
     return out
 
 
-def enrolled():
+def enrolled(config_root=CONFIG_ROOT):
     """Every `src/` file carved out by a `complete` file entry in a delinks.txt.
 
     A file entry is an unindented path ending in ':'; the indented lines that follow
@@ -107,7 +118,7 @@ def enrolled():
     from ROM bytes instead, so the file is configured but not yet source-built.
     """
     files, path, saw_complete = [], None, False
-    for delinks in sorted((REPO / "config").rglob("delinks.txt")):
+    for delinks in sorted(pathlib.Path(config_root).rglob("delinks.txt")):
         for line in delinks.read_text(encoding="utf-8").splitlines():
             if not line.strip():
                 continue
@@ -121,7 +132,28 @@ def enrolled():
         if path and saw_complete:
             files.append(path)
         path, saw_complete = None, False
-    return sorted(set(files))
+    checked = []
+    for rel in sorted(set(files)):
+        pure = pathlib.PurePosixPath(rel.replace("\\", "/"))
+        if (pure.is_absolute() or ".." in pure.parts or len(pure.parts) < 2
+                or pure.parts[0] not in ("src", "mods")
+                or pure.suffix not in (".c", ".cpp")):
+            raise BuildError("profile", 1, f"unsafe complete delinks source path: {rel}")
+        raw_target = REPO / pathlib.Path(*pure.parts)
+        target = raw_target.resolve()
+        try:
+            target.relative_to(REPO.resolve())
+        except ValueError:
+            raise BuildError("profile", 1, f"source path escapes repository: {rel}")
+        path_parts = (raw_target, *raw_target.parents)
+        crosses_symlink = any(
+            part.is_symlink() for part in path_parts
+            if part != REPO and REPO in part.parents
+        )
+        if not target.is_file() or crosses_symlink:
+            raise BuildError("profile", 1, f"missing or symlinked complete source: {rel}")
+        checked.append(pure.as_posix())
+    return checked
 
 
 def compile_one(rel, vers=None):
@@ -151,71 +183,128 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 8)
-    ap.add_argument("--rom-out", default=str(BUILD / "sm64ds.nds"))
+    ap.add_argument("--profile", choices=RP.PROFILES, default="stock",
+                    help="stock (default, verified src only) or mods (intentional divergences)")
+    ap.add_argument("--rom-out", default=None,
+                    help="output ROM (default build/sm64ds.nds or build/sm64ds-mod.nds)")
+    ap.add_argument("--report-json",
+                    help="structured report (default follows the selected profile)")
     ap.add_argument("--no-rom", action="store_true", help="stop after linking")
-    ap.add_argument("--no-check", action="store_true", help="skip dsd check modules")
+    ap.add_argument("--no-check", action="store_true",
+                    help="skip module/source fidelity analysis; report status is unchecked")
     ap.add_argument("--arm7-bios", help="passed to dsd rom build if your dump needs it")
     args = ap.parse_args()
 
-    for tool in (DSD, MW / VERSION / "mwccarm.exe", MW / LD_VERSION / "mwldarm.exe"):
-        if not tool.is_file():
-            sys.exit(f"missing {tool} - see notes/setup-mwccarm.md")
-    if not (REPO / "extracted" / "dsd" / "config.yaml").is_file():
-        sys.exit("no extracted ROM - run tools/unpack.py on your own dump first")
+    report_path = pathlib.Path(args.report_json or
+                               BUILD / ("rombuild-report.json" if args.profile == "stock"
+                                        else "rombuild-mod-report.json"))
+    rom_out = args.rom_out or str(BUILD / ("sm64ds.nds" if args.profile == "stock"
+                                          else "sm64ds-mod.nds"))
+    report = {"schemaVersion": 1, "profile": args.profile, "status": "running",
+              "romOut": rom_out, "phases": []}
 
-    # Gap objects first: delinks.txt drives which ranges dsd carves out for us.
-    print("[1/6] dsd delink")
-    run([str(DSD), "delink", "-c", str(CONFIG)], "dsd delink",
-        quiet_patterns=("No module for relocation",))
+    def save_report():
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report, indent=2) + "\n",
+                               encoding="utf-8", newline="\n")
 
-    print("[2/6] dsd lcf")
-    run([str(DSD), "lcf", "-c", str(CONFIG)], "dsd lcf")
+    try:
+        for tool in (DSD, MW / VERSION / "mwccarm.exe", MW / LD_VERSION / "mwldarm.exe"):
+            if not tool.is_file():
+                raise BuildError("preflight", 1,
+                                 f"missing {tool} - see notes/setup-mwccarm.md")
+        if not (REPO / "extracted" / "dsd" / "config.yaml").is_file():
+            raise BuildError("preflight", 1,
+                             "no extracted ROM - run tools/unpack.py on your own dump first")
+        profile = RP.prepare_profile(args.profile)
+        config_root = profile["configRoot"]
+        config_yaml = profile["configYaml"]
+        report["profileConfig"] = str(config_root.relative_to(REPO))
+        report["modReplacements"] = profile["modReplacements"]
+        report["modGapFallbacks"] = profile["modGapFallbacks"]
 
-    srcs = enrolled()
-    vers = versions()
-    n_alt = sum(1 for s in srcs if pathlib.Path(s).stem in vers)
-    print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
-          + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
-    failures = []
-    if srcs:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
-            for rel, err in ex.map(lambda s: compile_one(s, vers), srcs):
-                if err:
-                    failures.append((rel, err))
-    if failures:
-        print(f"!! {len(failures)} file(s) failed to compile:")
-        for rel, err in failures[:10]:
-            print(f"   {rel}: {err.splitlines()[0] if err else ''}")
-        sys.exit(1)
+        # Gap objects first: delinks.txt drives which ranges dsd carves out for us.
+        print(f"profile: {args.profile} ({len(profile['modReplacements'])} mod source replacement(s), "
+              f"{len(profile['modGapFallbacks'])} ROM-gap fallback(s))")
+        print("[1/6] dsd delink")
+        run([str(DSD), "delink", "-c", str(config_yaml)], "dsd delink",
+            quiet_patterns=("No module for relocation",))
+        report["phases"].append("dsd delink")
 
-    print("[4/6] mwldarm")
-    run([*launcher(), str(MW / LD_VERSION / "mwldarm.exe"), *LDFLAGS.split(),
-         f"@{BUILD / 'objects.txt'}", str(BUILD / "arm9.lcf"),
-         "-o", str(BUILD / "final_link.o")], "mwldarm")
+        print("[2/6] dsd lcf")
+        run([str(DSD), "lcf", "-c", str(config_yaml)], "dsd lcf")
+        report["phases"].append("dsd lcf")
 
-    if args.no_rom:
-        print("[5/6] skipped (--no-rom)")
-    else:
-        print("[5/6] dsd rom config + rom build")
-        run([str(DSD), "rom", "config", "--elf", str(BUILD / "final_link.o"),
-             "--config", str(CONFIG)], "dsd rom config")
-        cmd = [str(DSD), "rom", "build", "--config", str(BUILD / "build" / "rom_config.yaml"),
-               "--rom", args.rom_out]
-        if args.arm7_bios:
-            cmd += ["--arm7-bios", args.arm7_bios]
-        run(cmd, "dsd rom build", quiet_patterns=("Compressing arm9 overlay",))
-        print(f"      -> {args.rom_out}")
+        srcs = enrolled(config_root)
+        vers = versions()
+        n_alt = sum(1 for s in srcs if pathlib.Path(s).stem in vers)
+        report["enrolledFiles"] = len(srcs)
+        report["alternateToolchainFiles"] = n_alt
+        print(f"[3/6] mwccarm: {len(srcs)} enrolled source file(s), -j{args.jobs}"
+              + (f" ({n_alt} on an alternate toolchain version)" if n_alt else ""))
+        failures = []
+        if srcs:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as ex:
+                for rel, err in ex.map(lambda s: compile_one(s, vers), srcs):
+                    if err:
+                        failures.append((rel, err))
+        if failures:
+            detail = "\n".join(f"{rel}: {err}" for rel, err in failures[:10])
+            raise BuildError("mwccarm", 1, detail)
+        report["phases"].append("mwccarm")
 
-    if args.no_check:
-        print("[6/6] skipped (--no-check)")
-        return
-    print("[6/6] dsd check modules")
-    out = run([str(DSD), "check", "modules", "-c", str(CONFIG), "--fail"],
-              "dsd check modules", quiet_patterns=(": OK",))
-    if out.strip():
-        print(out)
-    print(f"\nAll modules match the ROM. {len(srcs)} function(s) built from src/.")
+        print("[4/6] mwldarm")
+        run([*launcher(), str(MW / LD_VERSION / "mwldarm.exe"), *LDFLAGS.split(),
+             f"@{BUILD / 'objects.txt'}", str(BUILD / "arm9.lcf"),
+             "-o", str(BUILD / "final_link.o")], "mwldarm")
+        report["phases"].append("mwldarm")
+
+        if args.no_rom:
+            print("[5/6] skipped (--no-rom)")
+        else:
+            print("[5/6] dsd rom config + rom build")
+            run([str(DSD), "rom", "config", "--elf", str(BUILD / "final_link.o"),
+                 "--config", str(config_yaml)], "dsd rom config")
+            cmd = [str(DSD), "rom", "build", "--config",
+                   str(BUILD / "build" / "rom_config.yaml"), "--rom", rom_out]
+            if args.arm7_bios:
+                cmd += ["--arm7-bios", args.arm7_bios]
+            run(cmd, "dsd rom build", quiet_patterns=("Compressing arm9 overlay",))
+            print(f"      -> {rom_out}")
+            report["phases"].append("dsd rom build")
+            rom_path = pathlib.Path(rom_out)
+            if not rom_path.is_absolute():
+                rom_path = REPO / rom_path
+            if rom_path.is_file():
+                report["romArtifact"] = {
+                    "path": str(rom_path),
+                    "bytes": rom_path.stat().st_size,
+                    "sha256": hashlib.sha256(rom_path.read_bytes()).hexdigest(),
+                }
+
+        if args.no_check:
+            print("[6/6] skipped (--no-check)")
+            report["status"] = "unchecked"
+            save_report()
+            return 0
+        print("[6/6] analyze module and source fidelity")
+        analysis = RBC.analyze(config_root, args.profile)
+        RBC.print_report(analysis)
+        report["analysis"] = analysis
+        report["status"] = "passed" if analysis["passed"] else "failed"
+        save_report()
+        return 0 if analysis["passed"] else 1
+    except (BuildError, RP.ProfileError) as exc:
+        phase = exc.phase if isinstance(exc, BuildError) else "profile"
+        output = exc.output if isinstance(exc, BuildError) else str(exc)
+        code = exc.returncode if isinstance(exc, BuildError) else 1
+        print(f"!! {phase} failed (exit {code})")
+        print(output[:4000])
+        report["status"] = "error"
+        report["failure"] = {"phase": phase, "returncode": code, "output": output[:4000]}
+        save_report()
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/rombuild_check.py
+++ b/tools/rombuild_check.py
@@ -1,20 +1,20 @@
-"""Byte-diff every source-built function against the ROM, one function at a time.
+"""Analyze a source-built ROM and emit human or machine-readable fidelity metrics.
 
-`dsd check modules` answers "is this module identical?"; when the answer is no it does
-not say which function broke it. This does. Because an enrolled function's object is
-required to be exactly its declared size, nothing can shift its neighbours, so every
-mismatch is confined to the function that caused it and all of them can be found from a
-single build instead of bisecting.
+``dsd check modules`` answers the binary gate.  This tool explains that answer and
+separates three quantities that must not be collapsed into one percentage:
+
+* module fidelity -- bytes in linked executable modules equal the retail modules;
+* source reconstruction -- function bytes produced from verified ``src/`` files;
+* intentional mods -- differing bytes confined to explicitly enrolled ``mods/`` ranges.
 
 Usage:
-    python tools/rombuild_check.py                 # summary + the failing names
-    python tools/rombuild_check.py --out bad.txt   # write failures for enroll.py
-
-Feed the failures back with:
-    python tools/enroll.py --complete-list <eligible minus bad>
+    python tools/rombuild_check.py
+    python tools/rombuild_check.py --json build/rombuild-report.json
+    python tools/rombuild_check.py --config-root build/rombuild-config/stock/arm9
 """
 import argparse
 import collections
+import json
 import pathlib
 import re
 import sys
@@ -24,27 +24,46 @@ from enroll import read_delinks, sections, CONFIG, REPO  # noqa: E402
 
 BUILD = REPO / "build" / "build"
 EXTRACTED = REPO / "extracted" / "dsd"
+DEFAULT_CONFIG_ROOT = CONFIG / "arm9"
 ENTRY_SEC = re.compile(r"^\s+(\.\S+)\s+start:0x([0-9a-fA-F]+)\s+end:0x([0-9a-fA-F]+)")
+FUNC_RE = re.compile(r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\)")
 
 
-def module_binaries(d):
-    """(built, retail) binary paths for a module config directory, or (None, None)."""
-    rel = d.relative_to(CONFIG).as_posix()
+def _arm9_relative(d, config_root):
+    """Module path relative to ARM9, accepting config/ or config/arm9 roots."""
+    rel = d.relative_to(config_root).as_posix()
     if rel == "arm9":
+        return "."
+    return rel.removeprefix("arm9/")
+
+
+def module_label(d, config_root):
+    rel = _arm9_relative(d, config_root)
+    if rel == ".":
+        return "arm9"
+    m = re.fullmatch(r"overlays/(ov\d+)", rel)
+    if m:
+        return m.group(1)
+    return rel
+
+
+def module_binaries(d, config_root=CONFIG):
+    """(built, retail) binary paths for a module config directory."""
+    rel = _arm9_relative(d, config_root)
+    if rel == ".":
         return BUILD / "arm9.bin", EXTRACTED / "arm9" / "arm9.bin"
-    if rel in ("arm9/itcm", "arm9/dtcm"):
-        n = rel.split("/")[-1]
-        return BUILD / f"{n}.bin", EXTRACTED / "arm9" / f"{n}.bin"
-    m = re.fullmatch(r"arm9/overlays/(ov\d+)", rel)
+    if rel in ("itcm", "dtcm"):
+        return BUILD / f"{rel}.bin", EXTRACTED / "arm9" / f"{rel}.bin"
+    m = re.fullmatch(r"overlays/(ov\d+)", rel)
     if m:
         return BUILD / f"arm9_{m.group(1)}.bin", EXTRACTED / "arm9_overlays" / f"{m.group(1)}.bin"
     return None, None
 
 
-def complete_entries(path):
-    """[(srcpath, addr, end)] for entries marked `complete`."""
+def complete_entries_text(text):
+    """Return ``[(path, address, end)]`` for entries carrying ``complete``."""
     out, cur, done, sec = [], None, False, None
-    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+    for line in text.splitlines():
         if not line.strip():
             continue
         if not line[0].isspace():
@@ -63,29 +82,58 @@ def complete_entries(path):
     return out
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--out", help="write failing symbol names here")
-    ap.add_argument("--show", type=int, default=12)
-    args = ap.parse_args()
+def complete_entries(path):
+    return complete_entries_text(path.read_text(encoding="utf-8", errors="ignore"))
 
-    checked = bad = 0
-    intentional = []
-    failures, per_module = [], collections.Counter()
+
+def _code_totals(config_root):
+    funcs = size = 0
+    for sym in sorted(config_root.rglob("symbols.txt")):
+        # Match the project's progress/Chaos Viewer universe: main + overlays.
+        # itcm/dtcm are still byte-checked as modules, but are not part of the
+        # published decompilation coverage denominator.
+        rel = _arm9_relative(sym.parent, config_root)
+        if rel != "." and not re.fullmatch(r"overlays/ov\d+", rel):
+            continue
+        for line in sym.read_text(encoding="utf-8", errors="ignore").splitlines():
+            m = FUNC_RE.match(line)
+            if m:
+                funcs += 1
+                size += int(m.group(2), 16)
+    return funcs, size
+
+
+def _diff_counts(built, retail, allowed=()):
+    common = min(len(built), len(retail))
+    differing = unexpected = 0
+    for i in range(common):
+        if built[i] == retail[i]:
+            continue
+        differing += 1
+        if not any(lo <= i < hi for lo, hi in allowed):
+            unexpected += 1
+    extra = abs(len(built) - len(retail))
+    return differing + extra, unexpected + extra
+
+
+def analyze(config_root=DEFAULT_CONFIG_ROOT, profile="stock"):
+    config_root = pathlib.Path(config_root).resolve()
+    failures, intentional, module_results = [], [], []
     missing_bins = []
+    per_module_bad = collections.Counter()
+    source_functions = source_bytes = mod_functions = mod_bytes = 0
+    reproducing = reproducing_bytes = bad = bad_function_bytes = differing_source_bytes = 0
 
-    for sym in sorted(CONFIG.rglob("symbols.txt")):
+    for sym in sorted(config_root.rglob("symbols.txt")):
         d = sym.parent
         dl = d / "delinks.txt"
         if not dl.is_file():
             continue
         entries = complete_entries(dl)
-        if not entries:
-            continue
-        built_p, retail_p = module_binaries(d)
+        built_p, retail_p = module_binaries(d, config_root)
+        label = module_label(d, config_root)
         if not built_p or not built_p.is_file() or not retail_p.is_file():
-            missing_bins.append(d.relative_to(CONFIG).as_posix())
+            missing_bins.append(label)
             continue
         header, _ = read_delinks(dl)
         secs = sections(header)
@@ -93,50 +141,145 @@ def main():
             continue
         base = min(s[1] for s in secs)
         built, retail = built_p.read_bytes(), retail_p.read_bytes()
-        label = d.relative_to(CONFIG).as_posix()
-        for (rel, addr, end) in entries:
-            lo, hi = addr - base, end - base
-            if hi > len(retail) or hi > len(built):
-                continue
-            # A mods/ entry is a deliberate divergence; differing from the ROM is the
-            # whole point, so it is reported separately and never counted as a failure.
-            if rel.startswith("mods/"):
-                if built[lo:hi] != retail[lo:hi]:
-                    intentional.append((pathlib.Path(rel).stem, label, addr,
-                                        sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)))
-                else:
-                    intentional.append((pathlib.Path(rel).stem, label, addr, 0))
-                continue
-            checked += 1
-            if built[lo:hi] != retail[lo:hi]:
-                bad += 1
-                name = pathlib.Path(rel).stem
-                nd = sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)
-                failures.append((label, name, addr, hi - lo, nd))
-                per_module[label] += 1
+        allowed_mod_ranges = [(addr - base, end - base) for rel, addr, end in entries
+                              if rel.startswith("mods/")]
+        module_diff, unexpected_diff = _diff_counts(built, retail, allowed_mod_ranges)
+        module_results.append({
+            "module": label,
+            "comparedBytes": max(len(built), len(retail)),
+            "differingBytes": module_diff,
+            "unexpectedDifferingBytes": unexpected_diff,
+            "exact": module_diff == 0,
+            "expectedOnly": unexpected_diff == 0,
+        })
 
-    if intentional:
-        print(f"intentional divergences (mods/): {len(intentional)}")
-        for (n, label, addr, nd) in intentional:
-            state = f"{nd} byte(s) differ from the ROM" if nd else "!! identical to the ROM - the mod is NOT in the build"
-            print(f"  {n} ({label}, 0x{addr:08x}): {state}")
+        for rel, addr, end in entries:
+            size = end - addr
+            is_mod = rel.startswith("mods/")
+            if is_mod:
+                mod_functions += 1
+                mod_bytes += size
+            else:
+                source_functions += 1
+                source_bytes += size
+            lo, hi = addr - base, end - base
+            if lo < 0 or hi > len(retail) or hi > len(built):
+                if not is_mod:
+                    bad += 1
+                    bad_function_bytes += size
+                    failures.append({"module": label, "name": pathlib.Path(rel).stem,
+                                     "addr": addr, "size": size,
+                                     "reason": "range outside built or retail module"})
+                continue
+            nd = sum(1 for x, y in zip(built[lo:hi], retail[lo:hi]) if x != y)
+            if is_mod:
+                intentional.append({"name": pathlib.Path(rel).stem, "module": label,
+                                    "addr": addr, "size": size, "differingBytes": nd})
+                continue
+            if nd:
+                bad += 1
+                bad_function_bytes += size
+                differing_source_bytes += nd
+                failures.append({"module": label, "name": pathlib.Path(rel).stem,
+                                 "addr": addr, "size": size, "differingBytes": nd})
+                per_module_bad[label] += 1
+            else:
+                reproducing += 1
+                reproducing_bytes += size
+
+    total_functions, total_code_bytes = _code_totals(config_root)
+    compared_module_bytes = sum(m["comparedBytes"] for m in module_results)
+    differing_module_bytes = sum(m["differingBytes"] for m in module_results)
+    unexpected_module_bytes = sum(m["unexpectedDifferingBytes"] for m in module_results)
+    compiled_functions = source_functions + mod_functions
+    compiled_bytes = source_bytes + mod_bytes
+    mods_applied = all(m["differingBytes"] > 0 for m in intentional) if intentional else True
+    passed = bool(module_results) and not bad and not missing_bins and not unexpected_module_bytes \
+        and (profile != "mods" or mods_applied)
+
+    return {
+        "schemaVersion": 1,
+        "profile": profile,
+        "passed": passed,
+        "moduleFidelity": {
+            "modulesChecked": len(module_results),
+            "modulesExact": sum(1 for m in module_results if m["exact"]),
+            "modulesExpectedOnly": sum(1 for m in module_results if m["expectedOnly"]),
+            "comparedBytes": compared_module_bytes,
+            "differingBytes": differing_module_bytes,
+            "unexpectedDifferingBytes": unexpected_module_bytes,
+            "percent": (100.0 * (compared_module_bytes - differing_module_bytes)
+                        / compared_module_bytes) if compared_module_bytes else 0.0,
+            "results": module_results,
+        },
+        "sourceBuild": {
+            "totalCodeFunctions": total_functions,
+            "totalCodeBytes": total_code_bytes,
+            "compiledFunctions": compiled_functions,
+            "compiledBytes": compiled_bytes,
+            "sourceFunctions": source_functions,
+            "sourceBytes": source_bytes,
+            "modFunctions": mod_functions,
+            "modBytes": mod_bytes,
+            "sourceBytesPercent": 100.0 * source_bytes / total_code_bytes if total_code_bytes else 0.0,
+            "reproducingFunctions": reproducing,
+            "reproducingBytes": reproducing_bytes,
+            "mismatchingFunctions": bad,
+            "mismatchingFunctionBytes": bad_function_bytes,
+            "differingSourceBytes": differing_source_bytes,
+        },
+        "intentionalMods": intentional,
+        "modsApplied": mods_applied,
+        "missingModuleBinaries": missing_bins,
+        "failures": failures,
+        "mismatchesByModule": dict(per_module_bad),
+    }
+
+
+def print_report(report, show=12):
+    sf, mf = report["sourceBuild"], report["moduleFidelity"]
+    if report["intentionalMods"]:
+        print(f"intentional divergences (mods/): {len(report['intentionalMods'])}")
+        for m in report["intentionalMods"]:
+            state = (f"{m['differingBytes']} byte(s) differ from the ROM" if m["differingBytes"]
+                     else "!! identical to the ROM - the mod is NOT in the build")
+            print(f"  {m['name']} ({m['module']}, 0x{m['addr']:08x}): {state}")
         print()
-    print(f"source-built functions checked: {checked}")
-    print(f"                    reproducing: {checked - bad}")
-    print(f"                    mismatching: {bad}")
-    if missing_bins:
-        print(f"(no built binary for {len(missing_bins)} module(s): {missing_bins[:4]})")
-    if per_module:
-        print("\nmismatches by module:")
-        for k, v in per_module.most_common(12):
-            print(f"  {v:5d}  {k}")
-        print(f"\nfirst {min(args.show, len(failures))} mismatches:")
-        for (label, name, addr, size, nd) in failures[:args.show]:
-            print(f"  {label:26s} {name:44s} 0x{addr:08x} size 0x{size:<5x} {nd} bad bytes")
+    print(f"source-built functions: {sf['sourceFunctions']:,}  "
+          f"({sf['sourceBytes']:,} / {sf['totalCodeBytes']:,} code bytes, "
+          f"{sf['sourceBytesPercent']:.2f}%)")
+    print(f"  reproducing: {sf['reproducingFunctions']:,}")
+    print(f"  mismatching: {sf['mismatchingFunctions']:,}")
+    print(f"module fidelity: {mf['modulesExact']}/{mf['modulesChecked']} exact, "
+          f"{mf['percent']:.6f}% of compared bytes")
+    if report["missingModuleBinaries"]:
+        print(f"missing module binaries: {report['missingModuleBinaries'][:8]}")
+    for f in report["failures"][:show]:
+        print(f"  {f['module']:26s} {f['name']:44s} 0x{f['addr']:08x} "
+              f"size 0x{f['size']:<5x} {f.get('differingBytes', f.get('reason'))}")
+    print(f"ROM-build analysis: {'PASS' if report['passed'] else 'FAIL'}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", help="write failing symbol names here")
+    ap.add_argument("--json", help="write the complete structured report")
+    ap.add_argument("--config-root", default=str(DEFAULT_CONFIG_ROOT),
+                    help="ARM9 config directory used for the build")
+    ap.add_argument("--profile", choices=("stock", "mods"), default="stock")
+    ap.add_argument("--show", type=int, default=12)
+    args = ap.parse_args()
+    report = analyze(args.config_root, args.profile)
+    print_report(report, args.show)
     if args.out:
-        pathlib.Path(args.out).write_text("\n".join(sorted(n for _, n, _, _, _ in failures)) + "\n")
-        print(f"\nwrote {args.out}")
+        pathlib.Path(args.out).write_text(
+            "\n".join(sorted(f["name"] for f in report["failures"])) + "\n",
+            encoding="utf-8", newline="\n")
+    if args.json:
+        pathlib.Path(args.json).write_text(
+            json.dumps(report, indent=2) + "\n", encoding="utf-8", newline="\n")
+    return 0 if report["passed"] else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/rombuild_profile.py
+++ b/tools/rombuild_profile.py
@@ -1,0 +1,180 @@
+"""Generate isolated ROM-build configs for stock and intentional-mod profiles.
+
+Tracked ``config/**/delinks.txt`` records the project's working enrollment state.  It
+may point at ``mods/<symbol>.c`` so an experiment is convenient to run, but that must
+not make the default correctness build differ from the retail ROM.  This module copies
+the ARM9 config tree under ignored ``build/rombuild-config/`` and, for the stock
+profile, redirects every mod entry to the matching verified ``src/`` translation unit.
+If no verified counterpart exists, the generated entry is demoted so dsd fills the
+range with original ROM bytes.
+
+Nothing under ``config/`` or ``mods/`` is changed.  The generated tree is disposable
+and can be handed directly to dsd, rombuild.py, and rombuild_check.py.
+"""
+import json
+import os
+import pathlib
+import re
+import shutil
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SOURCE_CONFIG = REPO / "config" / "arm9"
+BUILD = REPO / "build"
+sys.path.insert(0, str(REPO / "tools"))
+import srcpath as SP  # noqa: E402
+
+PROFILES = ("stock", "mods")
+PATH_LINE = re.compile(r"^(\s*(?:rom_config|build_path|delinks_path|object):\s+)(\S+)(\s*)$")
+CONFIG_REF_LINE = re.compile(r"^\s*(delinks|symbols|relocations):\s+(\S+)\s*$")
+
+
+class ProfileError(RuntimeError):
+    pass
+
+
+def _rewrite_config_paths(path, source_root, generated_root):
+    """Retarget paths that were relative to config/arm9 to the generated tree."""
+    lines = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = PATH_LINE.match(line)
+        if m and m.group(2).startswith("."):
+            target = (source_root / m.group(2)).resolve()
+            rel = pathlib.Path(os.path.relpath(target, generated_root)).as_posix()
+            line = f"{m.group(1)}{rel}{m.group(3)}"
+        lines.append(line)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def _inside(path, root):
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_generated_config(path, generated_root, repo, build):
+    """Reject config paths that could make dsd read or write outside known roots."""
+    expected = {
+        "rom_config": repo / "extracted" / "dsd" / "config.yaml",
+        "build_path": build,
+        "delinks_path": build / "delinks",
+    }
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = PATH_LINE.match(line)
+        if m:
+            key = m.group(1).strip().rstrip(":")
+            target = (generated_root / m.group(2)).resolve()
+            if key in expected and target != expected[key].resolve():
+                raise ProfileError(f"unsafe {key} path in config.yaml: {target}")
+            if key == "object" and not _inside(target, build / "build"):
+                raise ProfileError(f"unsafe module object path in config.yaml: {target}")
+            continue
+        ref = CONFIG_REF_LINE.match(line)
+        if ref:
+            target = (generated_root / ref.group(2)).resolve()
+            if not _inside(target, generated_root):
+                raise ProfileError(f"unsafe {ref.group(1)} path in config.yaml: {target}")
+
+
+def _stock_delinks(generated_root, repo):
+    """Keep every mod out of a stock link.
+
+    Prefer its verified ``src/`` counterpart. If one does not exist (or is explicitly
+    NONMATCHING), remove ``complete`` from the disposable entry so dsd supplies that
+    range from retail gap bytes instead.
+    """
+    saved = SP.set_root(repo)
+    replacements, gap_fallbacks = [], []
+    try:
+        for path in sorted(generated_root.rglob("delinks.txt")):
+            out = []
+            changed = False
+            demote_current = False
+            for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+                stripped = line.strip()
+                if line and not line[0].isspace() and stripped.startswith("mods/") \
+                        and stripped.endswith(":"):
+                    demote_current = False
+                    mod_rel = stripped[:-1]
+                    name = pathlib.PurePosixPath(mod_rel).stem
+                    src = SP.path_for(name)
+                    verified = (src is not None and
+                                "NONMATCHING" not in src.read_text(
+                                    encoding="utf-8", errors="ignore")[:200])
+                    if verified:
+                        src_rel = src.relative_to(repo).as_posix()
+                        line = f"{src_rel}:"
+                        replacements.append(
+                            {"name": name, "modPath": mod_rel, "srcPath": src_rel})
+                        changed = True
+                    else:
+                        demote_current = True
+                        gap_fallbacks.append({"name": name, "modPath": mod_rel,
+                                              "reason": "missing verified src counterpart"})
+                elif line and not line[0].isspace():
+                    demote_current = False
+                elif demote_current and stripped == "complete":
+                    changed = True
+                    continue
+                out.append(line)
+            if changed:
+                path.write_text("\n".join(out) + "\n", encoding="utf-8", newline="\n")
+    finally:
+        SP.set_root(saved[0])
+    return replacements, gap_fallbacks
+
+
+def prepare_profile(profile="stock", repo=REPO, source_config=SOURCE_CONFIG, build=BUILD):
+    """Return metadata for a fresh generated build profile.
+
+    ``configYaml`` and ``configRoot`` are pathlib paths.  The remaining fields are JSON
+    serializable and are also written beside the generated config for diagnostics.
+    """
+    if profile not in PROFILES:
+        raise ProfileError(f"unknown ROM-build profile {profile!r}; choose from {PROFILES}")
+    repo = pathlib.Path(repo).resolve()
+    source_config = pathlib.Path(source_config).resolve()
+    build = pathlib.Path(build).resolve()
+    if not (source_config / "config.yaml").is_file():
+        raise ProfileError(f"missing source config: {source_config / 'config.yaml'}")
+    symlinks = [p for p in source_config.rglob("*") if p.is_symlink()]
+    if symlinks:
+        raise ProfileError(f"config tree contains a symlink: {symlinks[0]}")
+
+    generated_root = build / "rombuild-config" / profile / "arm9"
+    profile_parent = generated_root.parent
+    if profile_parent.exists():
+        shutil.rmtree(profile_parent)
+    generated_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_config, generated_root)
+    _rewrite_config_paths(generated_root / "config.yaml", source_config, generated_root)
+    _validate_generated_config(generated_root / "config.yaml", generated_root, repo, build)
+    replacements, gap_fallbacks = (_stock_delinks(generated_root, repo)
+                                   if profile == "stock" else ([], []))
+
+    meta = {
+        "schemaVersion": 1,
+        "profile": profile,
+        "generated": True,
+        "configRoot": generated_root,
+        "configYaml": generated_root / "config.yaml",
+        "modReplacements": replacements,
+        "modGapFallbacks": gap_fallbacks,
+    }
+    serializable = {k: str(v) if isinstance(v, pathlib.Path) else v for k, v in meta.items()}
+    (profile_parent / "profile.json").write_text(
+        json.dumps(serializable, indent=2) + "\n", encoding="utf-8", newline="\n")
+    return meta
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--profile", choices=PROFILES, default="stock")
+    args = ap.parse_args()
+    result = prepare_profile(args.profile)
+    print(json.dumps({k: str(v) if isinstance(v, pathlib.Path) else v
+                      for k, v in result.items()}, indent=2))

--- a/tools/test_rombuild.py
+++ b/tools/test_rombuild.py
@@ -1,0 +1,58 @@
+"""ROM enrollment accepts only real C/C++ sources inside src/ or mods/."""
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import rombuild as RB  # noqa: E402
+
+
+class RomBuildEnrollment(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        self.config = self.repo / "config" / "arm9"
+        self.config.mkdir(parents=True)
+        (self.repo / "src").mkdir()
+        (self.repo / "src" / "Example.c").write_text(
+            "int Example(void) { return 0; }\n", encoding="utf-8")
+        self.old_repo = RB.REPO
+        RB.REPO = self.repo
+
+    def tearDown(self):
+        RB.REPO = self.old_repo
+        self.tmp.cleanup()
+
+    def write_entry(self, rel):
+        (self.config / "delinks.txt").write_text(
+            f"{rel}:\n"
+            "    complete\n"
+            "    .text start:0x02000000 end:0x02000004\n",
+            encoding="utf-8")
+
+    def test_enrolled_accepts_a_repo_source(self):
+        self.write_entry("src/Example.c")
+        self.assertEqual(RB.enrolled(self.config), ["src/Example.c"])
+
+    def test_enrolled_rejects_a_path_escape(self):
+        self.write_entry("../outside.c")
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.enrolled(self.config)
+        self.assertIn("unsafe complete", raised.exception.output)
+
+    def test_enrolled_rejects_a_missing_source(self):
+        self.write_entry("src/Missing.c")
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.enrolled(self.config)
+        self.assertIn("missing or symlinked", raised.exception.output)
+
+    def test_enrolled_rejects_non_source_paths(self):
+        self.write_entry("tools/Example.py")
+        with self.assertRaises(RB.BuildError) as raised:
+            RB.enrolled(self.config)
+        self.assertIn("unsafe complete", raised.exception.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_rombuild_check.py
+++ b/tools/test_rombuild_check.py
@@ -1,0 +1,80 @@
+"""Structured ROM metrics keep stock mismatches and intentional mods distinct."""
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import rombuild_check as RBC  # noqa: E402
+
+
+class RomBuildCheck(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        self.config = self.root / "config" / "arm9"
+        self.config.mkdir(parents=True)
+        self.built = self.root / "build"
+        self.retail = self.root / "retail"
+        self.built.mkdir()
+        (self.retail / "arm9").mkdir(parents=True)
+        self.old_build, self.old_extracted = RBC.BUILD, RBC.EXTRACTED
+        RBC.BUILD, RBC.EXTRACTED = self.built, self.retail
+        (self.config / "symbols.txt").write_text(
+            "Example kind:function(arm,size=0x4) addr:0x00001000\n"
+            "Other kind:function(arm,size=0x4) addr:0x00001004\n",
+            encoding="utf-8")
+        self.write_delinks("src/Example.c")
+        (self.retail / "arm9" / "arm9.bin").write_bytes(b"ABCDEFGH")
+        (self.built / "arm9.bin").write_bytes(b"ABCDEFGH")
+
+    def tearDown(self):
+        RBC.BUILD, RBC.EXTRACTED = self.old_build, self.old_extracted
+        self.tmp.cleanup()
+
+    def write_delinks(self, rel):
+        (self.config / "delinks.txt").write_text(
+            "    .text start:0x00001000 end:0x00001008 kind:code\n\n"
+            f"{rel}:\n"
+            "    complete\n"
+            "    .text start:0x00001000 end:0x00001004\n",
+            encoding="utf-8")
+
+    def test_stock_exact_reports_fidelity_and_source_coverage(self):
+        report = RBC.analyze(self.config, "stock")
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["percent"], 100.0)
+        self.assertEqual(report["sourceBuild"]["sourceFunctions"], 1)
+        self.assertEqual(report["sourceBuild"]["sourceBytes"], 4)
+        self.assertEqual(report["sourceBuild"]["sourceBytesPercent"], 50.0)
+
+    def test_module_paths_accept_config_or_arm9_as_the_root(self):
+        self.assertEqual(RBC.module_label(self.config, self.config), "arm9")
+        self.assertEqual(RBC.module_label(self.config, self.config.parent), "arm9")
+
+    def test_stock_rejects_any_module_difference(self):
+        (self.built / "arm9.bin").write_bytes(b"XBCDEFGH")
+        report = RBC.analyze(self.config, "stock")
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["unexpectedDifferingBytes"], 1)
+        self.assertEqual(report["sourceBuild"]["mismatchingFunctions"], 1)
+
+    def test_mods_allows_only_differences_inside_explicit_mod_range(self):
+        self.write_delinks("mods/Example.c")
+        (self.built / "arm9.bin").write_bytes(b"XBCDEFGH")
+        report = RBC.analyze(self.config, "mods")
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["differingBytes"], 1)
+        self.assertEqual(report["moduleFidelity"]["unexpectedDifferingBytes"], 0)
+        self.assertEqual(report["sourceBuild"]["modBytes"], 4)
+
+    def test_mods_rejects_difference_outside_mod_range(self):
+        self.write_delinks("mods/Example.c")
+        (self.built / "arm9.bin").write_bytes(b"ABCDXFGH")
+        report = RBC.analyze(self.config, "mods")
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["moduleFidelity"]["unexpectedDifferingBytes"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_rombuild_profile.py
+++ b/tools/test_rombuild_profile.py
@@ -1,0 +1,102 @@
+"""Stock/mod build profiles must stay disposable and make mods explicit."""
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import rombuild_profile as RP  # noqa: E402
+
+
+class RomBuildProfile(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        self.config = self.repo / "config" / "arm9"
+        self.config.mkdir(parents=True)
+        (self.repo / "src").mkdir()
+        (self.repo / "mods").mkdir()
+        (self.repo / "extracted" / "dsd").mkdir(parents=True)
+        (self.repo / "build" / "build").mkdir(parents=True)
+        (self.config / "config.yaml").write_text(
+            "rom_config: ../../extracted/dsd/config.yaml\n"
+            "build_path: ../../build\n"
+            "delinks_path: ../../build/delinks\n"
+            "main_module:\n"
+            "  object: ../../build/build/arm9.bin\n",
+            encoding="utf-8")
+        self.original_delinks = (
+            "    .text start:0x02000000 end:0x02000008 kind:code\n\n"
+            "mods/Example.c:\n"
+            "    complete\n"
+            "    .text start:0x02000000 end:0x02000004\n")
+        (self.config / "delinks.txt").write_text(self.original_delinks, encoding="utf-8")
+        (self.repo / "src" / "Example.c").write_text("int Example(void) { return 0; }\n")
+        (self.repo / "mods" / "Example.c").write_text("int Example(void) { return 1; }\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def prepare(self, profile):
+        return RP.prepare_profile(profile, self.repo, self.config, self.repo / "build")
+
+    def test_stock_redirects_mod_to_verified_source_without_touching_config(self):
+        result = self.prepare("stock")
+        generated = result["configRoot"]
+        text = (generated / "delinks.txt").read_text(encoding="utf-8")
+        self.assertIn("src/Example.c:", text)
+        self.assertNotIn("mods/Example.c:", text)
+        self.assertEqual((self.config / "delinks.txt").read_text(encoding="utf-8"),
+                         self.original_delinks)
+        self.assertEqual(result["modReplacements"], [{
+            "name": "Example", "modPath": "mods/Example.c", "srcPath": "src/Example.c"}])
+        self.assertEqual(result["modGapFallbacks"], [])
+
+    def test_generated_config_paths_still_resolve_to_original_targets(self):
+        generated = self.prepare("stock")["configRoot"]
+        values = {}
+        for line in (generated / "config.yaml").read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if ": " in stripped:
+                key, value = stripped.split(": ", 1)
+                values[key] = value
+        self.assertEqual((generated / values["rom_config"]).resolve(),
+                         self.repo / "extracted" / "dsd" / "config.yaml")
+        self.assertEqual((generated / values["build_path"]).resolve(), self.repo / "build")
+        self.assertEqual((generated / values["object"]).resolve(),
+                         self.repo / "build" / "build" / "arm9.bin")
+
+    def test_mods_profile_preserves_mod_entry(self):
+        result = self.prepare("mods")
+        text = (result["configRoot"] / "delinks.txt").read_text(encoding="utf-8")
+        self.assertIn("mods/Example.c:", text)
+        self.assertEqual(result["modReplacements"], [])
+
+    def test_stock_uses_rom_gap_without_a_verified_source_counterpart(self):
+        (self.repo / "src" / "Example.c").unlink()
+        result = self.prepare("stock")
+        text = (result["configRoot"] / "delinks.txt").read_text(encoding="utf-8")
+        self.assertIn("mods/Example.c:", text)
+        self.assertNotIn("complete", text)
+        self.assertEqual(result["modReplacements"], [])
+        self.assertEqual(result["modGapFallbacks"][0]["name"], "Example")
+
+    def test_stock_uses_rom_gap_for_a_nonmatching_counterpart(self):
+        (self.repo / "src" / "Example.c").write_text(
+            "// NONMATCHING\nint Example(void) { return 0; }\n")
+        result = self.prepare("stock")
+        text = (result["configRoot"] / "delinks.txt").read_text(encoding="utf-8")
+        self.assertNotIn("complete", text)
+        self.assertEqual(result["modGapFallbacks"][0]["name"], "Example")
+
+    def test_profile_rejects_config_path_escape(self):
+        config = self.config / "config.yaml"
+        config.write_text(config.read_text(encoding="utf-8").replace(
+            "../../extracted/dsd/config.yaml", "../../../../outside/config.yaml"),
+            encoding="utf-8")
+        with self.assertRaisesRegex(RP.ProfileError, "unsafe rom_config"):
+            self.prepare("stock")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -1,0 +1,141 @@
+"""PR reporting is revision-scoped so committed R100 moves preserve credit."""
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import validate_merge as VM  # noqa: E402
+
+
+def git(repo, *args, env=None):
+    merged_env = dict(os.environ)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(["git", "-C", str(repo), *args], check=True,
+                          capture_output=True, text=True, env=merged_env).stdout.strip()
+
+
+def commit(repo, message, login):
+    git(repo, "add", "-A")
+    git(repo, "-c", f"user.name={login}",
+        "-c", f"user.email={login}@users.noreply.github.com",
+        "commit", "-qm", message)
+    return git(repo, "rev-parse", "HEAD")
+
+
+class ValidateMerge(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        git(self.repo, "init", "-q", ".")
+        (self.repo / "src").mkdir()
+        config = self.repo / "config" / "arm9"
+        config.mkdir(parents=True)
+        (config / "symbols.txt").write_text(
+            "Example kind:function(arm,size=0x4) addr:0x02000000\n",
+            encoding="utf-8")
+        (config / "delinks.txt").write_text(
+            "    .text start:0x02000000 end:0x02000004 kind:code\n\n"
+            "src/Example.c:\n"
+            "    complete\n"
+            "    .text start:0x02000000 end:0x02000004\n",
+            encoding="utf-8")
+        (self.repo / "src" / "Example.c").write_text("int Example(void) { return 0; }\n")
+        self.base = commit(self.repo, "base", "alice")
+        self.base_branch = git(self.repo, "branch", "--show-current")
+        self.old_repo = VM.REPO
+        VM.REPO = self.repo
+
+    def tearDown(self):
+        VM.REPO = self.old_repo
+        self.tmp.cleanup()
+
+    def test_committed_perfect_move_preserves_counts_and_credit(self):
+        (self.repo / "src" / "nested").mkdir()
+        git(self.repo, "mv", "src/Example.c", "src/nested/Example.c")
+        config = self.repo / "config" / "arm9" / "delinks.txt"
+        config.write_text(config.read_text(encoding="utf-8").replace(
+            "src/Example.c:", "src/nested/Example.c:"), encoding="utf-8")
+        head = commit(self.repo, "move", "bob")
+        report = VM.build_report(self.base, head)
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["coverage"]["delta"]["matchedFunctions"], 0)
+        self.assertEqual(len(report["diff"]["perfectRenames"]), 1)
+        self.assertEqual(report["attribution"]["base"], report["attribution"]["head"])
+        self.assertEqual(report["attribution"]["added"], [])
+        self.assertEqual(report["attribution"]["changed"], [])
+        self.assertEqual(report["attribution"]["lost"], [])
+        self.assertEqual(report["attribution"]["head"]["alice"]["functions"], 1)
+
+    def test_nonmatching_is_read_from_requested_revision(self):
+        (self.repo / "src" / "Example.c").write_text(
+            "// NONMATCHING\nint Example(void) { return 0; }\n")
+        head = commit(self.repo, "mark draft", "bob")
+        self.assertEqual(VM.function_snapshot(self.base)["stats"]["matchedFunctions"], 1)
+        self.assertEqual(VM.function_snapshot(head)["stats"]["matchedFunctions"], 0)
+
+    def test_require_merge_commit_rejects_an_uncommitted_merge_shape(self):
+        with self.assertRaisesRegex(RuntimeError, "not a committed merge"):
+            VM.build_report(self.base, "HEAD", require_merge_commit=True)
+
+    def test_pr_linkcheck_grouped_json_is_flattened(self):
+        state = VM._link_state([{
+            "file": "src/Example.c",
+            "results": [{"sym": "Example", "verdict": "VERIFIED"},
+                        {"sym": "Thunk", "verdict": "BLIND-RELOC"}],
+        }])
+        self.assertEqual(state["checked"], 2)
+        self.assertEqual(state["tally"], {"VERIFIED": 1, "BLIND": 1})
+        self.assertEqual(state["blocking"], [])
+
+    def test_committed_test_merge_is_accepted_and_keeps_feature_author_credit(self):
+        git(self.repo, "switch", "-q", "-c", "feature")
+        (self.repo / "src" / "nested").mkdir()
+        git(self.repo, "mv", "src/Example.c", "src/nested/Example.c")
+        config = self.repo / "config" / "arm9" / "delinks.txt"
+        config.write_text(config.read_text(encoding="utf-8").replace(
+            "src/Example.c:", "src/nested/Example.c:"), encoding="utf-8")
+        feature = commit(self.repo, "feature move", "bob")
+        git(self.repo, "switch", "-q", self.base_branch)
+        git(self.repo, "-c", "user.name=maintainer",
+            "-c", "user.email=maintainer@users.noreply.github.com",
+            "merge", "--no-ff", "-qm", "test merge", "feature")
+        report = VM.build_report(
+            self.base, "HEAD", require_merge_commit=True, expected_pr_head=feature)
+        self.assertTrue(report["committedMerge"])
+        self.assertEqual(report["status"], "Passed")
+        self.assertEqual(report["attribution"]["head"]["alice"]["functions"], 1)
+        with self.assertRaisesRegex(RuntimeError, "second parent"):
+            VM.build_report(
+                self.base, "HEAD", require_merge_commit=True,
+                expected_pr_head=self.base)
+
+    def test_identical_base_failure_is_warning_but_changed_failure_blocks(self):
+        base_failure = {"status": "error", "failure": {
+            "phase": "mwldarm", "returncode": 1, "output": "undefined Existing"}}
+        same = VM.build_report(self.base, "HEAD", base_failure, base_failure)
+        self.assertEqual(same["status"], "Passed")
+        self.assertTrue(same["rom"]["sameBaselineFailure"])
+        changed_failure = {"status": "error", "failure": {
+            "phase": "mwldarm", "returncode": 1, "output": "undefined New"}}
+        changed = VM.build_report(self.base, "HEAD", base_failure, changed_failure)
+        self.assertEqual(changed["status"], "Failed")
+        self.assertIn("full-ROM validation failed", changed["reasons"])
+
+    def test_function_universe_change_is_not_hidden_as_percentage_progress(self):
+        symbols = self.repo / "config" / "arm9" / "symbols.txt"
+        symbols.write_text(
+            symbols.read_text(encoding="utf-8")
+            + "Other kind:function(arm,size=0x4) addr:0x02000004\n",
+            encoding="utf-8")
+        head = commit(self.repo, "change denominator", "bob")
+        report = VM.build_report(self.base, head)
+        self.assertEqual(report["status"], "Failed")
+        self.assertIn("function/byte coverage denominator changed", report["reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -1,0 +1,443 @@
+"""Build the machine-readable PR validation report for a committed test merge.
+
+The private worker owns the ROM and compiler.  Its orchestration is intentionally
+small: build/cache the committed base, create and commit the PR merge, run rombuild.py
+for both, run pr_linkcheck for the affected files, then call this tool with the JSON
+artifacts.  This tool supplies the stable policy and report schema used by CI.
+
+Coverage and attribution are read from Git *commits*, never the worktree.  That is
+load-bearing for path-only PRs: ``first_matchers`` follows committed rename lineage,
+while an uncommitted merge makes every new path appear to have no author.
+
+Example:
+    python tools/validate_merge.py --base origin/main --head HEAD \
+      --require-merge-commit --base-rom-report build/base-rom.json \
+      --head-rom-report build/head-rom.json --link-report build/link.json \
+      --out build/validate-report.json --markdown build/validate-report.md
+"""
+import argparse
+import collections
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "tools"))
+import chaos_db_ci as CHAOS  # noqa: E402
+import rombuild_check as RBC  # noqa: E402
+
+FUNC_RE = re.compile(
+    r"^(\S+)\s+kind:function\((?:arm|thumb),size=0x([0-9a-fA-F]+)\).*?addr:0x([0-9a-fA-F]+)")
+SOURCE_SUFFIXES = (".c", ".cpp")
+
+
+def _git(*args, allow=(0,), repo=None):
+    repo = REPO if repo is None else pathlib.Path(repo)
+    proc = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+    if proc.returncode not in allow:
+        raise RuntimeError(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def resolve_commit(rev):
+    return _git("rev-parse", "--verify", f"{rev}^{{commit}}").strip()
+
+
+def tree_paths(rev, prefix=None):
+    args = ["ls-tree", "-r", "--name-only", rev]
+    if prefix:
+        args += ["--", prefix]
+    return [p for p in _git(*args).splitlines() if p]
+
+
+def git_text(rev, path):
+    return _git("show", f"{rev}:{path}")
+
+
+def _module_from_symbols(path):
+    p = pathlib.PurePosixPath(path)
+    if p.as_posix() == "config/arm9/symbols.txt":
+        return "arm9"
+    m = re.fullmatch(r"config/arm9/overlays/(ov\d+)/symbols\.txt", p.as_posix())
+    return m.group(1) if m else None
+
+
+def _module_from_delinks(path):
+    if path == "config/arm9/delinks.txt":
+        return "arm9"
+    m = re.fullmatch(r"config/arm9/overlays/(ov\d+)/delinks\.txt", path)
+    return m.group(1) if m else None
+
+
+def function_snapshot(rev):
+    paths = tree_paths(rev)
+    sources = {}
+    for p in paths:
+        pp = pathlib.PurePosixPath(p)
+        if p.startswith("src/") and pp.suffix in SOURCE_SUFFIXES:
+            sources.setdefault(pp.stem, p)
+    grep = _git("grep", "-l", "-F", "NONMATCHING", rev, "--", "src/", allow=(0, 1))
+    # With a tree-ish, git prefixes each result with ``<rev>:``.  Keeping that
+    # prefix would make every historical NONMATCHING file look matched.
+    candidates = {line.split(":", 1)[1] if ":" in line else line
+                  for line in grep.splitlines()}
+    # Match progress.py and the rest of the repo's established hatch rule: the
+    # marker is a source header and is recognized in the first 200 characters.
+    nonmatching = {path for path in candidates
+                   if "NONMATCHING" in git_text(rev, path)[:200]}
+
+    records = {}
+    total_bytes = matched_bytes = 0
+    for path in paths:
+        module = _module_from_symbols(path)
+        if module is None:
+            continue
+        for line in git_text(rev, path).splitlines():
+            m = FUNC_RE.match(line)
+            if not m:
+                continue
+            name, size, addr = m.group(1), int(m.group(2), 16), int(m.group(3), 16)
+            key = f"{module}:0x{addr:08x}"
+            src = sources.get(name)
+            matched = bool(src and src not in nonmatching)
+            records[key] = {"id": key, "module": module, "addr": addr, "name": name,
+                            "size": size, "matched": matched, "srcPath": src}
+            total_bytes += size
+            if matched:
+                matched_bytes += size
+    matched = {k: r for k, r in records.items() if r["matched"]}
+    return {
+        "functions": records,
+        "matched": matched,
+        "stats": {
+            "totalFunctions": len(records),
+            "totalBytes": total_bytes,
+            "matchedFunctions": len(matched),
+            "matchedBytes": matched_bytes,
+            "matchedFunctionPercent": 100.0 * len(matched) / len(records) if records else 0.0,
+            "matchedBytePercent": 100.0 * matched_bytes / total_bytes if total_bytes else 0.0,
+        },
+    }
+
+
+def enrollment_snapshot(rev):
+    entries = {}
+    for path in tree_paths(rev, "config/arm9"):
+        module = _module_from_delinks(path)
+        if module is None:
+            continue
+        for rel, addr, end in RBC.complete_entries_text(git_text(rev, path)):
+            key = f"{module}:0x{addr:08x}-0x{end:08x}"
+            entries[key] = {"id": key, "module": module, "addr": addr, "end": end,
+                            "size": end - addr, "path": rel,
+                            "kind": "mod" if rel.startswith("mods/") else "src"}
+    src = {k: e for k, e in entries.items() if e["kind"] == "src"}
+    mods = {k: e for k, e in entries.items() if e["kind"] == "mod"}
+    return {"entries": entries, "source": src, "mods": mods,
+            "stats": {"sourceFunctions": len(src),
+                      "sourceBytes": sum(e["size"] for e in src.values()),
+                      "modFunctions": len(mods),
+                      "modBytes": sum(e["size"] for e in mods.values())}}
+
+
+def _json_at(rev, path):
+    try:
+        return json.loads(git_text(rev, path))
+    except (RuntimeError, json.JSONDecodeError):
+        return {}
+
+
+def attribution_snapshot(rev, functions):
+    old_repo = CHAOS.REPO
+    CHAOS.REPO = REPO
+    try:
+        first = CHAOS.first_matchers(rev)
+        finishers = CHAOS.match_finishers(rev)
+    finally:
+        CHAOS.REPO = old_repo
+    data = _json_at(rev, "attribution.json")
+    overrides = data.get("overrides", {}) if isinstance(data, dict) else {}
+    aliases = data.get("aliases", {}) if isinstance(data, dict) else {}
+
+    def canon(name):
+        return aliases.get(str(name).lower(), name)
+
+    by_function, counts, sizes = {}, collections.Counter(), collections.Counter()
+    for key, rec in functions["matched"].items():
+        path = rec["srcPath"]
+        author = overrides.get(path) or finishers.get(path) or first.get(path)
+        if not author:
+            continue
+        author = canon(author)
+        by_function[key] = author
+        counts[author] += 1
+        sizes[author] += rec["size"]
+    return {"byFunction": by_function,
+            "stats": {"attributedFunctions": len(by_function),
+                      "unattributedFunctions": len(functions["matched"]) - len(by_function)},
+            "contributors": {a: {"functions": counts[a], "bytes": sizes[a]}
+                             for a in sorted(counts)}}
+
+
+def diff_snapshot(base, head, head_paths):
+    rows, renames = [], []
+    for line in _git("diff", "--name-status", "-M100%", f"{base}..{head}", "--", "src/").splitlines():
+        parts = line.split("\t")
+        if not parts:
+            continue
+        row = {"status": parts[0]}
+        if parts[0].startswith("R") and len(parts) >= 3:
+            row.update(oldPath=parts[1], newPath=parts[2])
+            renames.append(row)
+        elif len(parts) >= 2:
+            row["path"] = parts[1]
+        rows.append(row)
+    leftovers = [r["oldPath"] for r in renames if r["oldPath"] in head_paths]
+    return {"files": rows, "perfectRenames": renames, "leftoverOldPaths": leftovers}
+
+
+def _load_json(path):
+    if not path:
+        return None
+    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+
+
+def _rom_state(report):
+    if report is None:
+        return {"available": False}
+    analysis = report.get("analysis", report)
+    passed = report.get("status") == "passed" if "status" in report else bool(analysis.get("passed"))
+    failure = report.get("failure")
+    signature = None
+    if failure:
+        payload = {"phase": failure.get("phase"),
+                   "returncode": failure.get("returncode"),
+                   "output": failure.get("output", "")}
+        signature = hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+    elif not passed and "moduleFidelity" in analysis:
+        payload = {"failures": analysis.get("failures", []),
+                   "missingModuleBinaries": analysis.get("missingModuleBinaries", []),
+                   "moduleResults": analysis.get("moduleFidelity", {}).get("results", [])}
+        signature = hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+    return {"available": True, "passed": passed, "signature": signature,
+            "analysis": analysis if "moduleFidelity" in analysis else None,
+            "failure": failure}
+
+
+def _link_state(rows):
+    flattened = []
+    for row in rows or []:
+        # pr_linkcheck's JSON is grouped per translation unit.  Accept already-flat
+        # rows too so the report schema is easy for another worker to produce.
+        if isinstance(row, dict) and "results" in row:
+            if row.get("results"):
+                for result in row["results"]:
+                    flattened.append({"file": row.get("file"), **result})
+            else:
+                flattened.append({"file": row.get("file"),
+                                  "verdict": row.get("worst") or
+                                  ("UNRESOLVED" if row.get("note") else "NONE")})
+        else:
+            flattened.append(row)
+    tally = collections.Counter()
+    blocking = []
+    for row in flattened:
+        verdict = str(row.get("verdict", "ERROR"))
+        bucket = "BLIND" if verdict.startswith("BLIND") else verdict
+        tally[bucket] += 1
+        if bucket in ("WRONG", "NO-REPRO", "ERROR"):
+            blocking.append(row)
+    return {"checked": len(flattened), "tally": dict(tally), "blocking": blocking,
+            "rows": flattened}
+
+
+def build_report(base, head, base_rom=None, head_rom=None, link_rows=None,
+                 require_merge_commit=False, expected_pr_head=None):
+    base_sha, head_sha = resolve_commit(base), resolve_commit(head)
+    parents = _git("rev-list", "--parents", "-n", "1", head_sha).split()
+    is_merge = len(parents) >= 3
+    if require_merge_commit and not is_merge:
+        raise RuntimeError(f"{head_sha[:12]} is not a committed merge")
+    if require_merge_commit and parents[1] != base_sha:
+        raise RuntimeError(
+            f"committed merge first parent {parents[1][:12]} is not base {base_sha[:12]}")
+    if expected_pr_head:
+        expected_head_sha = resolve_commit(expected_pr_head)
+        if not is_merge or parents[2] != expected_head_sha:
+            actual = parents[2][:12] if is_merge else "missing"
+            raise RuntimeError(
+                f"committed merge second parent {actual} is not PR head "
+                f"{expected_head_sha[:12]}")
+
+    bf, hf = function_snapshot(base_sha), function_snapshot(head_sha)
+    be, he = enrollment_snapshot(base_sha), enrollment_snapshot(head_sha)
+    ba, ha = attribution_snapshot(base_sha, bf), attribution_snapshot(head_sha, hf)
+    diff = diff_snapshot(base_sha, head_sha, set(tree_paths(head_sha, "src/")))
+
+    base_keys, head_keys = set(bf["matched"]), set(hf["matched"])
+    common_credit = set(ba["byFunction"]) & set(ha["byFunction"])
+    credit_changes = [{"id": k, "before": ba["byFunction"][k], "after": ha["byFunction"][k]}
+                      for k in sorted(common_credit)
+                      if ba["byFunction"][k] != ha["byFunction"][k]]
+    lost_credit = [{"id": k, "author": ba["byFunction"][k]}
+                   for k in sorted(set(ba["byFunction"]) - set(ha["byFunction"]))]
+    added_credit = [{"id": k, "author": ha["byFunction"][k]}
+                    for k in sorted(set(ha["byFunction"]) - set(ba["byFunction"]))]
+
+    base_rom_state, head_rom_state = _rom_state(base_rom), _rom_state(head_rom)
+    rom_regression = (base_rom_state.get("passed") is True
+                      and head_rom_state.get("passed") is not True)
+    same_baseline_failure = (base_rom_state.get("passed") is False
+                             and head_rom_state.get("passed") is False
+                             and base_rom_state.get("signature") is not None
+                             and base_rom_state.get("signature")
+                             == head_rom_state.get("signature"))
+    link = _link_state(link_rows)
+    reasons = []
+    if base_keys - head_keys:
+        reasons.append(f"lost {len(base_keys - head_keys)} matched function(s)")
+    if (hf["stats"]["totalFunctions"] != bf["stats"]["totalFunctions"]
+            or hf["stats"]["totalBytes"] != bf["stats"]["totalBytes"]):
+        reasons.append("function/byte coverage denominator changed")
+    if he["stats"]["sourceBytes"] < be["stats"]["sourceBytes"]:
+        reasons.append("source-built byte coverage decreased")
+    if credit_changes or lost_credit:
+        reasons.append("contributor attribution changed or was lost")
+    if ha["stats"]["unattributedFunctions"] > ba["stats"]["unattributedFunctions"]:
+        reasons.append("the merge introduced an unattributed matched function")
+    if diff["leftoverOldPaths"]:
+        reasons.append("old source paths remain after rename")
+    if link["blocking"]:
+        reasons.append(f"{len(link['blocking'])} blocking relocation verdict(s)")
+    if rom_regression:
+        reasons.append("full-ROM result regressed from the base commit")
+    if head_rom_state.get("available") and not head_rom_state.get("passed") \
+            and not same_baseline_failure:
+        reasons.append("full-ROM validation failed")
+
+    warnings = []
+    if same_baseline_failure:
+        warnings.append("base and merge share the same pre-existing ROM-build failure")
+    if link["tally"].get("BLIND"):
+        warnings.append(f"{link['tally']['BLIND']} linkcheck result(s) have unresolved relocations")
+    unresolved = sum(link["tally"].get(k, 0) for k in ("UNRESOLVED", "NO-SYM", "NONE"))
+    if unresolved:
+        warnings.append(f"{unresolved} affected source file(s) could not be fully link-checked")
+    if not head_rom_state.get("available"):
+        warnings.append("no head full-ROM report was supplied")
+
+    coverage_delta = {
+        "matchedFunctions": hf["stats"]["matchedFunctions"] - bf["stats"]["matchedFunctions"],
+        "matchedBytes": hf["stats"]["matchedBytes"] - bf["stats"]["matchedBytes"],
+        "sourceBuiltFunctions": he["stats"]["sourceFunctions"] - be["stats"]["sourceFunctions"],
+        "sourceBuiltBytes": he["stats"]["sourceBytes"] - be["stats"]["sourceBytes"],
+        "newMatchedFunctions": len(head_keys - base_keys),
+        "removedMatchedFunctions": len(base_keys - head_keys),
+    }
+    base_source_stats = dict(be["stats"])
+    head_source_stats = dict(he["stats"])
+    base_source_stats["sourceBytesPercent"] = (
+        100.0 * base_source_stats["sourceBytes"] / bf["stats"]["totalBytes"]
+        if bf["stats"]["totalBytes"] else 0.0)
+    head_source_stats["sourceBytesPercent"] = (
+        100.0 * head_source_stats["sourceBytes"] / hf["stats"]["totalBytes"]
+        if hf["stats"]["totalBytes"] else 0.0)
+    report = {
+        "schemaVersion": 1,
+        "status": "Failed" if reasons else "Passed",
+        "baseSha": base_sha,
+        "headSha": head_sha,
+        "committedMerge": is_merge,
+        "summary": "Validation failed: " + "; ".join(reasons) if reasons
+                   else "Committed merge introduces no reconstruction or attribution regression.",
+        "reasons": reasons,
+        "warnings": warnings,
+        "coverage": {"base": bf["stats"], "head": hf["stats"], "delta": coverage_delta},
+        "sourceBuild": {"base": base_source_stats, "head": head_source_stats},
+        "attribution": {"base": ba["contributors"], "head": ha["contributors"],
+                        "baseStats": ba["stats"], "headStats": ha["stats"],
+                        "added": added_credit, "changed": credit_changes,
+                        "lost": lost_credit},
+        "diff": diff,
+        "linkcheck": link,
+        "rom": {"base": base_rom_state, "head": head_rom_state,
+                "regression": rom_regression, "sameBaselineFailure": same_baseline_failure},
+    }
+    report["reportMarkdown"] = render_markdown(report)
+    return report
+
+
+def _signed(n):
+    return f"{n:+,}"
+
+
+def render_markdown(r):
+    c, s, l = r["coverage"], r["sourceBuild"], r["linkcheck"]
+    h, d = c["head"], c["delta"]
+    relocation_summary = ", ".join(
+        f"{v} {k}" for k, v in sorted(l["tally"].items())) or "no affected slots"
+    lines = ["### Full merge validation", "",
+             "| Check | Result |", "|---|---|",
+             f"| Committed test merge | {'yes' if r['committedMerge'] else 'no'} |",
+             f"| Matched functions | {h['matchedFunctions']:,} / {h['totalFunctions']:,} "
+             f"({h['matchedFunctionPercent']:.1f}%, {_signed(d['matchedFunctions'])}) |",
+             f"| Matched code bytes | {h['matchedBytes']:,} / {h['totalBytes']:,} "
+             f"({h['matchedBytePercent']:.1f}%, {_signed(d['matchedBytes'])}) |",
+             f"| Tracked source enrollment | {s['head']['sourceFunctions']:,} functions, "
+             f"{s['head']['sourceBytes']:,} bytes "
+             f"({s['head']['sourceBytesPercent']:.2f}%, {_signed(d['sourceBuiltBytes'])}) |",
+             f"| Perfect source moves | {len(r['diff']['perfectRenames'])} R100 |",
+             f"| Contributor credit | {len(r['attribution']['added'])} added, "
+             f"{len(r['attribution']['changed'])} changed, "
+             f"{len(r['attribution']['lost'])} lost |",
+             f"| Relocation check | {l['checked']} checked; {relocation_summary} |"]
+    head_rom = r["rom"]["head"]
+    if head_rom.get("analysis"):
+        mf = head_rom["analysis"]["moduleFidelity"]
+        sf = head_rom["analysis"]["sourceBuild"]
+        lines.append(f"| Module fidelity | {mf['modulesExact']}/{mf['modulesChecked']} exact; "
+                     f"{mf['percent']:.6f}% compared bytes |")
+        lines.append(f"| Code linked from verified source | {sf['sourceFunctions']:,} functions, "
+                     f"{sf['sourceBytes']:,} bytes ({sf['sourceBytesPercent']:.2f}%) |")
+    elif head_rom.get("failure"):
+        lines.append(f"| Full ROM build | {head_rom['failure'].get('phase')} failed |")
+    else:
+        lines.append("| Full ROM build | not supplied |")
+    if r["warnings"]:
+        lines += ["", "Warnings: " + "; ".join(r["warnings"]) + "."]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", required=True)
+    ap.add_argument("--head", default="HEAD")
+    ap.add_argument("--require-merge-commit", action="store_true")
+    ap.add_argument("--expected-pr-head",
+                    help="exact commit required as the merge's second parent")
+    ap.add_argument("--base-rom-report")
+    ap.add_argument("--head-rom-report")
+    ap.add_argument("--link-report")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--markdown")
+    args = ap.parse_args()
+    report = build_report(args.base, args.head, _load_json(args.base_rom_report),
+                          _load_json(args.head_rom_report), _load_json(args.link_report),
+                          args.require_merge_commit, args.expected_pr_head)
+    pathlib.Path(args.out).write_text(json.dumps(report, indent=2) + "\n",
+                                      encoding="utf-8", newline="\n")
+    if args.markdown:
+        pathlib.Path(args.markdown).write_text(report["reportMarkdown"] + "\n",
+                                               encoding="utf-8", newline="\n")
+    print(report["reportMarkdown"])
+    return 0 if report["status"] == "Passed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed

- make the default ROM build an explicit stock profile, with intentional `mods/` opt-in
- emit structured whole-ROM fidelity and source-reconstruction metrics
- compare exact committed base/merge revisions for match count, enrollment, R100 moves, attribution, relocations, and ROM fidelity
- submit `baseSha` and render the worker's `ReportMarkdown` in the PR comment

This is a tools/CI/docs-only change; it contains no match batch or `src/` edits.

## Validation

- `python -m unittest discover -s tools`: 75 passed, 2 skipped
- full stock ROM build: 9,116 sources, 0 mismatches, 106/106 modules exact
- generated report: 11,130 / 11,347 matched and 66.75% of code bytes linked from verified source
- workflow YAML parsed successfully
