### PR TITLE
readable: promote Actor to a real C++ class deriving from ActorDerived

### DIFF
--- a/include/Actor.h
+++ b/include/Actor.h
@@ -30,13 +30,23 @@
  * function), and that copy collides with the one the module's gap object
  * supplies from ROM data. An override takes its base's slot wherever it is
  * declared, so putting ~Actor first costs nothing and makes it the key
- * function -- and nothing defines ~Actor as a C++ method, because the
- * destructor translation units are C files that never see this class. The
- * thirteen NEW virtuals still take 18..30 from their declaration order below,
- * because new slots append after the inherited table.
+ * function. The thirteen NEW virtuals still take 18..30 from their declaration
+ * order below, because new slots append after the inherited table.
  *
- * Only the root of a hierarchy is forced to pay that tax; include/ActorBase.h
- * has to keep InitResources out of its class for exactly this reason.
+ * What makes that safe is NOT that the destructor lives in a C translation
+ * unit -- src/_ZN5ActorD1Ev.cpp and _ZN5ActorD2Ev.cpp are C++ and do include
+ * this header; only _ZN5ActorD0Ev.c is C. The invariant is that all three
+ * define extern "C" free functions under the mangled names and none defines
+ * `Actor::~Actor`, so no TU is ever the key function's definition.
+ *
+ * The rule, stated precisely: the key function -- the first non-inline virtual
+ * declared -- must never be defined as a real method in any translation unit.
+ * Declaring the destructor first pins that role to TUs which by construction
+ * never will. include/ActorBase.h reaches the same end differently: it does
+ * declare InitResources (slot 0) in-class, but src/_ZN9ActorBase13InitResourcesEv.cpp
+ * deliberately defines it as an extern "C" free function rather than a method.
+ * Do not "fix" that file into a real method, and do not remove the declaration
+ * from ActorBase.h -- removing it would delete slot 0 and shift all 18 slots.
  *
  * Field NAMES are inferred from behaviour and cannot change codegen, so they are
  * safe to improve. Offsets, widths and vtable slots are pinned by the bytes.
@@ -158,12 +168,12 @@ struct Actor {
     s32 mCamSpacePosY;
     s32 mCamSpacePosZ;
     u8  pad_080[0xc];
-    s16 unk_08c;
-    s16 unk_08e;
-    s16 unk_090;
-    s16 unk_092;
-    s16 unk_094;
-    s16 unk_096;
+    s16 mAngleX;            /* 0x08c */
+    s16 mAngleY;            /* 0x08e */
+    s16 mAngleZ;            /* 0x090 */
+    s16 mPrevAngleX;        /* 0x092 */
+    s16 mPrevAngleY;        /* 0x094 */
+    s16 mPrevAngleZ;        /* 0x096 */
     u8  unk_098;
     u8  pad_099[0x3];
     u8  unk_09c;

--- a/include/Actor.h
+++ b/include/Actor.h
@@ -1,37 +1,66 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class Actor: 72 matched functions, 34 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
 #ifndef ACTOR_H
 #define ACTOR_H
+
 #include "types.h"
 
-/* fwd */
+#ifdef __cplusplus
+#include "ActorDerived.h"
+#endif
+
+/* The base of every enemy and object class, 0x020100dc..0x020113e4.
+ *
+ * The chain is ActorBase -> ActorDerived -> Actor. Actor is NOT a direct child
+ * of ActorBase: Actor::Actor calls ActorBase::ActorBase, stores ActorDerived's
+ * vptr, then immediately overwrites it with its own. Two consecutive vptr
+ * stores is what an inlined intermediate-base constructor looks like. See
+ * notes/actor-vtables.md.
+ *
+ * LAYOUT. ActorBase occupies 0x00..0x4f, so Actor's own fields begin at 0x50.
+ * The generated header this replaces duplicated ActorBase's fields inline --
+ * uniqueID at 0x04, actorID at 0x0c -- instead of inheriting them, which is why
+ * it opened with pad_000[0x4] and a 0x42-byte gap.
+ *
+ * VTABLE. _ZTV5Actor (0x0208e3a4) has 31 slots. Actor overrides ten of the
+ * eighteen it inherits -- 1, 2, 4, 5, 7, 8, 10, 11 and the destructor at 16/17
+ * -- and appends thirteen of its own at 18..30. Slots 0, 3, 6, 9, 12, 13, 14
+ * and 15 still point at the ActorBase implementations.
+ *
+ * The destructor is declared FIRST on purpose. CW 1.2 emits the vtable into the
+ * TU defining the first non-inline virtual declared in the class (the key
+ * function), and that copy collides with the one the module's gap object
+ * supplies from ROM data. An override takes its base's slot wherever it is
+ * declared, so putting ~Actor first costs nothing and makes it the key
+ * function -- and nothing defines ~Actor as a C++ method, because the
+ * destructor translation units are C files that never see this class. The
+ * thirteen NEW virtuals still take 18..30 from their declaration order below,
+ * because new slots append after the inherited table.
+ *
+ * Only the root of a hierarchy is forced to pay that tax; include/ActorBase.h
+ * has to keep InitResources out of its class for exactly this reason.
+ *
+ * Field NAMES are inferred from behaviour and cannot change codegen, so they are
+ * safe to improve. Offsets, widths and vtable slots are pinned by the bytes.
+ */
+
+#ifdef __cplusplus
+
 struct Player;
 struct Vector3;
-struct a;
-struct b;
-struct player_;
-struct pos_;
-struct Actor {
-    u8  pad_000[0x4];
-    u8  unk_004;            /* 0x004 */
-    u8  pad_005[0x7];
-    u16 mActorID;            /* 0x00c */
-    u8  pad_00e[0x42];
+
+struct Actor : ActorDerived {
     s32 unk_050;            /* 0x050 */
     s32 unk_054;            /* 0x054 */
     u8  unk_058;            /* 0x058 */
     u8  pad_059[0x3];
-    s32 mPosX;            /* 0x05c */
-    s32 mPosY;            /* 0x060 */
-    s32 mPosZ;            /* 0x064 */
-    s32 unk_068;            /* 0x068 */
+    s32 mPosX;              /* 0x05c */
+    s32 mPosY;              /* 0x060 */
+    s32 mPosZ;              /* 0x064 */
+    s32 unk_068;            /* 0x068 -- previous position, copied from 0x5c..0x64 */
     s32 unk_06c;            /* 0x06c */
     s32 unk_070;            /* 0x070 */
-    s32 mCamSpacePosX;            /* 0x074 */
-    s32 mCamSpacePosY;            /* 0x078 */
-    s32 mCamSpacePosZ;            /* 0x07c */
+    s32 mCamSpacePosX;      /* 0x074 */
+    s32 mCamSpacePosY;      /* 0x078 */
+    s32 mCamSpacePosZ;      /* 0x07c */
     u8  pad_080[0xc];
     s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
@@ -51,24 +80,114 @@ struct Actor {
     u8  pad_0a9[0x3];
     u8  unk_0ac;            /* 0x0ac */
     u8  pad_0ad[0x3];
-    u32 mFlags;            /* 0x0b0 */
+    u32 mFlags;             /* 0x0b0 -- bit 0x10000 suppresses behaviour */
     s32 unk_0b4;            /* 0x0b4 */
-    s32 unk_0b8;            /* 0x0b8 */
+    s32 unk_0b8;            /* 0x0b8 -- clip radius; 0 skips the camera transform */
     s32 unk_0bc;            /* 0x0bc */
     s32 unk_0c0;            /* 0x0c0 */
     u8  unk_0c4;            /* 0x0c4 */
     u8  pad_0c5[0x7];
+    s8  mAreaId;            /* 0x0cc -- negative means "not area-bound" */
+    u8  pad_0cd[0x1];
+    s16 unk_0ce;            /* 0x0ce */
+
+    /* --- vtable. Declared first, see the header comment. Overrides slots
+           16 (D1) and 17 (D0); position here does not affect that. --- */
+    virtual ~Actor();
+
+    /* --- overrides of inherited slots. Each takes its base's index. --- */
+    virtual bool BeforeInitResources();                /* slot  1 */
+    virtual void AfterInitResources(u32 vfSuccess);    /* slot  2 */
+    virtual int  BeforeCleanupResources();             /* slot  4 */
+    virtual void AfterCleanupResources(u32 vfSuccess); /* slot  5 */
+    virtual int  BeforeBehavior();                     /* slot  7 */
+    virtual void AfterBehavior(u32 vfSuccess);         /* slot  8 */
+    virtual int  BeforeRender();                       /* slot 10 */
+    virtual void AfterRender(u32 vfSuccess);           /* slot 11 */
+
+    /* --- new slots, 18..30, in declaration order. Do not reorder. --- */
+    virtual int  OnYoshiTryEat();                      /* slot 18 */
+    virtual int  OnTurnIntoEgg(Player &player);        /* slot 19 */
+    virtual int  Virtual50();                          /* slot 20 -- vtable+0x50 */
+    virtual int  OnGroundPounded(Actor &other);        /* slot 21 */
+    virtual int  OnAttacked1(Actor &other);            /* slot 22 */
+    virtual int  OnAttacked2(Actor &other);            /* slot 23 */
+    virtual int  OnKicked(Actor &other);               /* slot 24 */
+    virtual int  OnPushed(Actor &other);               /* slot 25 */
+    virtual int  OnHitByCannonBlastedChar(Actor &other); /* slot 26 */
+    virtual int  OnHitByMegaChar(Player &player);      /* slot 27 */
+    virtual int  OnHitFromUnderneath(Actor &other);    /* slot 28 */
+    virtual int  OnAimedAtWithEgg();                   /* slot 29 */
+    virtual int  OnAimedAtWithEggReturnVec();          /* slot 30 */
+
+    /* --- non-virtual --- */
+    int  BumpedUnderneathByPlayer(Player &player);
+    int  GetSubtraction(short a, short b);
+    void HugeLandingDustAt(Vector3 &pos, bool b);
+    void LandingDustAt(Vector3 &pos, bool b);
+};
+
+#else
+
+/* Flat layout for the C translation units, which can express neither the base
+   class nor the virtual functions. 0x00..0x4f is ActorBase. */
+struct Actor {
+    void **vtable;          /* 0x000 */
+    u32 uniqueID;           /* 0x004 */
+    u32 param1;             /* 0x008 */
+    u16 actorID;            /* 0x00c */
+    u8  aliveState;         /* 0x00e */
+    u8  shouldBeKilled;     /* 0x00f */
+    u8  pad_010[0x4];       /* 0x010 */
+    u8  sceneNode[0x14];    /* 0x014 */
+    u8  behavNode[0x10];    /* 0x028 */
+    u8  renderNode[0x10];   /* 0x038 */
+    void *unk_048;          /* 0x048 */
+    void *heap;             /* 0x04c */
+    s32 unk_050;            /* 0x050 */
+    s32 unk_054;
+    u8  unk_058;
+    u8  pad_059[0x3];
+    s32 mPosX;              /* 0x05c */
+    s32 mPosY;
+    s32 mPosZ;
+    s32 unk_068;
+    s32 unk_06c;
+    s32 unk_070;
+    s32 mCamSpacePosX;      /* 0x074 */
+    s32 mCamSpacePosY;
+    s32 mCamSpacePosZ;
+    u8  pad_080[0xc];
+    s16 unk_08c;
+    s16 unk_08e;
+    s16 unk_090;
+    s16 unk_092;
+    s16 unk_094;
+    s16 unk_096;
+    u8  unk_098;
+    u8  pad_099[0x3];
+    u8  unk_09c;
+    u8  pad_09d[0x3];
+    u8  unk_0a0;
+    u8  pad_0a1[0x3];
+    u8  unk_0a4;
+    u8  pad_0a5[0x3];
+    u8  unk_0a8;
+    u8  pad_0a9[0x3];
+    u8  unk_0ac;
+    u8  pad_0ad[0x3];
+    u32 mFlags;             /* 0x0b0 */
+    s32 unk_0b4;
+    s32 unk_0b8;
+    s32 unk_0bc;
+    s32 unk_0c0;
+    u8  unk_0c4;
+    u8  pad_0c5[0x7];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x1];
     s16 unk_0ce;            /* 0x0ce */
-#ifdef __cplusplus
-    /* methods */
-    int BeforeBehavior();
-    int BumpedUnderneathByPlayer(Player & player_);
-    int GetSubtraction(short a, short b);
-    void HugeLandingDustAt(Vector3 & pos_, bool b);
-    void LandingDustAt(Vector3 & pos_, bool b);
-#endif
 };
+
+#endif /* __cplusplus */
 
 #endif

--- a/include/ActorDerived.h
+++ b/include/ActorDerived.h
@@ -11,21 +11,28 @@
  * slots 16/17. Every other slot still points at the ActorBase implementation.
  * The class therefore adds NO new virtuals, which has a useful consequence.
  *
- * KEY FUNCTION. CW 1.2 emits the vtable into the TU that defines the first
+ * KEY FUNCTION. CW 1.2 emits the vtable into the TU that DEFINES the first
  * non-inline virtual declared in the class, and that copy collides with the one
- * the module's gap object supplies from ROM data. include/ActorBase.h has to
- * work around this by keeping InitResources out of the class entirely, because
- * ActorBase is the root: all of its virtuals are new, so declaration order sets
- * the slot indices and the destructor is pinned to 16/17.
+ * the module's gap object supplies from ROM data.
  *
- * ActorDerived is not constrained that way. An override takes its base's slot
+ * The rule, stated precisely: the key function must never be defined as a real
+ * method in any translation unit. Its declaration in the class is required and
+ * harmless -- include/ActorBase.h does declare InitResources (slot 0) in-class,
+ * and removing it would delete a slot and shift the other seventeen. What
+ * ActorBase.h relies on is that src/_ZN9ActorBase13InitResourcesEv.cpp defines
+ * it as an extern "C" free function rather than a method.
+ *
+ * ActorDerived gets there more cheaply. An override takes its base's slot
  * whatever order it is declared in, so the destructor can be declared FIRST and
- * become the key function. Nothing defines ~ActorDerived as a C++ method -- the
- * destructor translation units are C files that never see this class -- so no
- * TU is the key function's definition and no vtable is emitted. That is what
- * lets AfterInitResources be a real method here.
+ * become the key function -- and ~ActorDerived is only ever defined as an
+ * extern "C" free function, in D0Ev.c and D1Ev.c, so no TU is the key
+ * function's definition. That is what lets AfterInitResources be a real method
+ * here.
  *
- * The rule generalises: only the root class pays the key-function tax.
+ * The generalisation: a class whose first-declared virtual is the destructor
+ * gets this for free, because destructors in this tree are never written as
+ * C++ methods. A root class cannot rely on that if its slot order forces some
+ * other virtual first.
  */
 struct ActorDerived : ActorBase {
     /* Declared first, deliberately -- see KEY FUNCTION above. Overrides slots

--- a/src/_ZN12ActorDerived18AfterInitResourcesEj.c
+++ b/src/_ZN12ActorDerived18AfterInitResourcesEj.c
@@ -12,11 +12,9 @@
  */
 #include "ActorDerived.h"
 
-extern "C" void _ZN9ActorBase18AfterInitResourcesEj(ActorBase *self, u32 result);
-
 void ActorDerived::AfterInitResources(u32 vfSuccess)
 {
     if (vfSuccess == 1)
         MarkForDestruction();
-    _ZN9ActorBase18AfterInitResourcesEj(this, vfSuccess);
+    ActorBase::AfterInitResources(vfSuccess);
 }

--- a/src/_ZN5Actor18AfterInitResourcesEj.c
+++ b/src/_ZN5Actor18AfterInitResourcesEj.c
@@ -1,10 +1,22 @@
-#include "types.h"
-typedef struct ActorDerived { char pad[0]; } ActorDerived;
+//cpp
+// @symbol _ZN5Actor18AfterInitResourcesEj
+/* Actor::AfterInitResources(u32) at 0x02011244 -- vtable slot 2.
+ *
+ * Chains to the ActorDerived implementation, then sets the three flag bits that
+ * suppress this actor until something clears them.
+ *
+ * Kept as a .c filename with the //cpp marker rather than renamed to .cpp:
+ * the extension is what config/arm9/delinks.txt records, so a rename would turn
+ * a src-only change into a config change too.
+ */
+#include "Actor.h"
 
-extern void _ZN12ActorDerived18AfterInitResourcesEj(ActorDerived *self, u32 result);
-
-void _ZN5Actor18AfterInitResourcesEj(char *self, u32 result)
+void Actor::AfterInitResources(u32 vfSuccess)
 {
-    _ZN12ActorDerived18AfterInitResourcesEj((ActorDerived *)self, result);
-    *(int *)(((long long)(int)(self + 0xb0))) |= 0x38;
+    ActorDerived::AfterInitResources(vfSuccess);
+    /* The (long long)(int) cast is a codegen launder, not a type conversion: the
+       ROM materialises the address into a register first (`add r1,r4,#0xb0`)
+       and then does the read-modify-write through it. Writing `mFlags |= 0x38`
+       folds the offset into the ldr/str and comes out 4 bytes short. */
+    *(u32 *)(long long)(int)&mFlags |= 0x38;
 }

--- a/src/_ZN5Actor22BeforeCleanupResourcesEv.c
+++ b/src/_ZN5Actor22BeforeCleanupResourcesEv.c
@@ -1,20 +1,17 @@
-typedef int s32;
+//cpp
+// @symbol _ZN5Actor22BeforeCleanupResourcesEv
+/* Actor::BeforeCleanupResources() at 0x02011220 -- vtable slot 4.
+ *
+ * Normalises the ActorBase result to 0 or 1.
+ *
+ * Kept as a .c filename with the //cpp marker; see the note in
+ * src/_ZN5Actor18AfterInitResourcesEj.c.
+ */
+#include "Actor.h"
 
-struct ActorBase {
-    char _pad[0x50];
-};
-
-struct Actor {
-    struct ActorBase base;
-    char _pad2[0x70];
-};
-
-extern s32 _ZN9ActorBase22BeforeCleanupResourcesEv(struct ActorBase *self);
-
-s32 _ZN5Actor22BeforeCleanupResourcesEv(struct Actor *self)
+int Actor::BeforeCleanupResources()
 {
-    s32 res = _ZN9ActorBase22BeforeCleanupResourcesEv((struct ActorBase*)self);
-    if (res != 0)
+    if (ActorBase::BeforeCleanupResources() != 0)
         return 1;
     return 0;
 }

--- a/src/_ZN5ActorC1Ev.cpp
+++ b/src/_ZN5ActorC1Ev.cpp
@@ -50,7 +50,7 @@ extern "C" void* _ZN5ActorC1Ev(struct Actor *self) {
   self->unk_0ce = data_0208e378;
   {
     void** base = *(void***)&data_020a4bb8;
-    int idx = self->mActorID;
+    int idx = self->actorID;
     char* s = (char*)base[idx];
     self->mFlags = *(int*)(s+8);
     {

--- a/src/_ZN5ActorC2Ev.cpp
+++ b/src/_ZN5ActorC2Ev.cpp
@@ -54,7 +54,7 @@ extern "C" void* _ZN5ActorC2Ev(struct Actor *self) {
     }
     self->mAreaId = data_0209b44c;
     self->unk_0ce = data_0208e378;
-    entry = (int*)(((int**)data_020a4bb8)[self->mActorID]);
+    entry = (int*)(((int**)data_020a4bb8)[self->actorID]);
     self->mFlags = entry[2];
     b = (data_0209f2d8 == 2);
     if (b != 0)

--- a/src/_ZN5ActorD0Ev.c
+++ b/src/_ZN5ActorD0Ev.c
@@ -11,9 +11,9 @@
  *   - return this
  *
  * Pool literals (relocations, wildcarded by matcher):
- *   0x0208e3a4 = data_0208e3a4
+ *   0x0208e3a4 = _ZTV5Actor
  *   0x0209b468 = global passed as first arg to the 0x0203b27c teardown
- *   0x0208e4b8 = data_0208e4b8
+ *   0x0208e4b8 = _ZTV12ActorDerived
  *   0x020a0eac = Memory::gameHeapPtr
  * Calls:
  *   0x0203b27c = teardown(global, &actorSub)   (unnamed)
@@ -29,8 +29,8 @@ struct Actor {
     /* Actor-specific subobject begins at 0x50 */
 };
 
-extern void *data_0208e3a4[];
-extern void *data_0208e4b8[];
+extern void *_ZTV5Actor[];
+extern void *_ZTV12ActorDerived[];
 
 extern void func_0203b27c(void *global, void *actorSub);   /* 0x0203b27c */
 extern void func_02044104(void *actorSub);                 /* 0x02044104 */
@@ -42,10 +42,10 @@ extern struct Heap *data_020a0eac;                      /* 0x020a0eac */
 
 struct Actor *_ZN5ActorD0Ev(struct Actor *thiz)
 {
-    thiz->vtable = (void *)data_0208e3a4;
+    thiz->vtable = (void *)_ZTV5Actor;
     func_0203b27c(&data_0209b468, (char *)thiz + 0x50);
     func_02044104((char *)thiz + 0x50);
-    thiz->vtable = (void *)data_0208e4b8;
+    thiz->vtable = (void *)_ZTV12ActorDerived;
     _ZN9ActorBaseD2Ev(thiz);
     _ZN6Memory10DeallocateEPvP4Heap(thiz, data_020a0eac);
     return thiz;

--- a/src/_ZN5ActorD1Ev.cpp
+++ b/src/_ZN5ActorD1Ev.cpp
@@ -5,15 +5,15 @@
 /* recovered: named members + shared header */
 #include "Actor.h"
 extern "C" {
-extern int data_0208e3a4[];
+extern int _ZTV5Actor[];
 extern int data_0209b468[];
-extern int data_0208e4b8[];
+extern int _ZTV12ActorDerived[];
 extern void _ZN9ActorBaseD2Ev(int c);
 int _ZN5ActorD1Ev(struct Actor *self) {
-  *(int*)((int)self) = (int)data_0208e3a4;
+  *(int*)((int)self) = (int)_ZTV5Actor;
   func_0203b27c((int)data_0209b468, ((int)self)+0x50);
   func_02044104((int)&self->unk_050);
-  *(int*)((int)self) = (int)data_0208e4b8;
+  *(int*)((int)self) = (int)_ZTV12ActorDerived;
   _ZN9ActorBaseD2Ev(((int)self));
   return ((int)self);
 }

--- a/src/_ZN5ActorD2Ev.cpp
+++ b/src/_ZN5ActorD2Ev.cpp
@@ -5,15 +5,15 @@
 /* recovered: named members + shared header */
 #include "Actor.h"
 extern "C" {
-extern int data_0208e3a4[];
+extern int _ZTV5Actor[];
 extern int data_0209b468[];
-extern int data_0208e4b8[];
+extern int _ZTV12ActorDerived[];
 extern void _ZN9ActorBaseD2Ev(int c);
 int _ZN5ActorD2Ev(struct Actor *self) {
-  *(int*)((int)self) = (int)data_0208e3a4;
+  *(int*)((int)self) = (int)_ZTV5Actor;
   func_0203b27c((int)data_0209b468, ((int)self)+0x50);
   func_02044104((int)&self->unk_050);
-  *(int*)((int)self) = (int)data_0208e4b8;
+  *(int*)((int)self) = (int)_ZTV12ActorDerived;
   _ZN9ActorBaseD2Ev(((int)self));
   return ((int)self);
 }


### PR DESCRIPTION
Phase 3 of the Actor hierarchy. **Stacked on #978** — until that merges, this PR shows its
commit too; the Phase 3 commit is `readable: promote Actor to a real C++ class…`.

`include/Actor.h` is now `struct Actor : ActorDerived` carrying all 31 slots of `_ZTV5Actor`,
replacing an auto-generated header that declared no base class, five non-virtual methods,
and nothing of the vtable.

**79/81 files byte-match, unchanged from before.** This is a structural change, not a
repair — worth stating plainly, since Phases 1 and 2 moved the match count and this one
doesn't. The two that don't reproduce (`BeforeBehavior`, which compiles 0x230 against a
0x240 target, and `GivePlayerCoins`) fail identically on main and are untouched here.

## Layout

The generated header duplicated ActorBase's fields inline — `uniqueID` at 0x04, `actorID` at
0x0c — rather than inheriting them, which is why it opened with `pad_000[0x4]` and a
0x42-byte gap. ActorBase occupies 0x00..0x4f, so Actor's own fields now start where they
actually start, at 0x50. Only the two constructors needed changing: they referenced
`mActorID`, the inline copy, now inherited as `actorID`.

## Vtable

Ten overrides of inherited slots (1, 2, 4, 5, 7, 8, 10, 11 and the destructor at 16/17) and
thirteen new ones appended at 18..30. Slots 0, 3, 6, 9, 12, 13, 14 and 15 still point at the
ActorBase implementations.

## The key-function question from #978, answered

#978 showed a derived class can declare its destructor first and avoid emitting a vtable
that collides with the gap object's ROM-supplied copy, because an override takes its base's
slot wherever it's declared.

Actor is the first class that **both overrides slots and appends new ones**, so it wasn't
obvious the trick survived — new slots take their indices from declaration order. It does.
`~Actor` is declared first, the thirteen new virtuals still land on 18..30, and the ROM
links clean. Verified rather than assumed.

## Two promotions

`Actor::AfterInitResources` chains to `ActorDerived::` then sets the suppression flags.
`Actor::BeforeCleanupResources` chains to `ActorBase::` and normalises to 0/1.

`AfterInitResources` keeps a codegen launder that's worth explaining, because the obvious
C++ is wrong:

```cpp
*(u32 *)(long long)(int)&mFlags |= 0x38;
```

The ROM materialises the field address into a register first (`add r1,r4,#0xb0`) and does
the read-modify-write through it. Writing `mFlags |= 0x38` folds the offset into the
ldr/str and comes out **4 bytes short**. The cast forces the original shape, so the field is
named and the bytes still match.

## Not promoted

Four of the cheapest-looking shims turn out to be 0xc-byte veneers
(`ldr ip,[pc]; bx ip; .word`) with no body at all, like `ActorDerived::Spawn`. The remaining
shim surface is smaller than a raw count suggests, but I have not audited it file by file —
so there is follow-up work here, and I'd rather say so than imply Actor is finished.

## Verification

- 79/81 byte-match under mwccarm 1.2/sp2p3, identical to the pre-change baseline.
- Full ROM build links, **9,115/9,115 source-built functions reproducing, 0 mismatching**.
  The only divergence is the intentional 3-byte `mods/Player_ScaleByCharFactor` change from
  #941, which is what makes `dsd check modules` flag overlay 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
