### PR TITLE
Allow cold full-ROM validation to finish

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -euo pipefail
           status=""
-          for i in $(seq 1 120); do   # up to ~20 min (120 * 10s)
+          for i in $(seq 1 240); do   # up to ~40 min (240 * 10s)
             r=$(curl -sS "$RELAY/api/pr-validate/$JOB" -H "X-Api-Key: $TOKEN")
             status=$(echo "$r" | jq -r '.status // empty')
             case "$status" in


### PR DESCRIPTION
Full stock-ROM validation takes about 581 seconds per phase on the production worker's 2-CPU cap. A cold base plus merged-head validation therefore has too little margin inside the current 20-minute Actions polling window.\n\nThis extends only the relay polling window to 40 minutes; the worker remains responsible for enforcing its own per-command timeout.