### PR TITLE
validate_merge: a declared draft's NO-REPRO is not a blocking verdict

### DIFF
--- a/tools/test_validate_merge.py
+++ b/tools/test_validate_merge.py
@@ -91,6 +91,33 @@ class ValidateMerge(unittest.TestCase):
         self.assertEqual(state["tally"], {"VERIFIED": 1, "BLIND": 1})
         self.assertEqual(state["blocking"], [])
 
+    def test_declared_draft_no_repro_does_not_block(self):
+        # pr_linkcheck marks a self-declared NONMATCHING draft worst=DRAFT while
+        # its per-slot results still read NO-REPRO (#968). Flattening must keep
+        # the downgrade, or every PR that so much as renames a declared draft
+        # fails on a non-reproduction the gate already excused.
+        state = VM._link_state([{
+            "file": "src/_ZN5Model27LoadCompressedTextureToVramEPcjS0_.cpp",
+            "worst": "DRAFT",
+            "results": [{"sym": "_ZN5Model27LoadCompressedTextureToVramEPcjS0_",
+                         "verdict": "NO-REPRO"}],
+        }])
+        self.assertEqual(state["checked"], 1)
+        self.assertEqual(state["tally"], {"DRAFT": 1})
+        self.assertEqual(state["blocking"], [])
+
+    def test_draft_downgrade_does_not_shield_wrong_dest(self):
+        # The draft excuse covers non-reproduction only. A WRONG verdict on a
+        # declared draft still blocks: its call graph must be honest even if
+        # its bytes differ.
+        state = VM._link_state([{
+            "file": "src/Draft.c",
+            "worst": "DRAFT",
+            "results": [{"sym": "Draft", "verdict": "WRONG"}],
+        }])
+        self.assertEqual(state["tally"], {"WRONG": 1})
+        self.assertEqual(len(state["blocking"]), 1)
+
     def test_committed_test_merge_is_accepted_and_keeps_feature_author_credit(self):
         git(self.repo, "switch", "-q", "-c", "feature")
         (self.repo / "src" / "nested").mkdir()

--- a/tools/validate_merge.py
+++ b/tools/validate_merge.py
@@ -237,8 +237,18 @@ def _link_state(rows):
         # rows too so the report schema is easy for another worker to produce.
         if isinstance(row, dict) and "results" in row:
             if row.get("results"):
+                # pr_linkcheck downgrades a TU whose head declares NONMATCHING
+                # from NO-REPRO to worst=DRAFT (#968): a self-declared draft
+                # makes no claim to reproduce, so its non-reproduction is
+                # expected. That downgrade lives on the GROUP row only; the
+                # per-slot results still say NO-REPRO, so carry it down or the
+                # flattened tally re-blocks what pr_linkcheck already excused.
+                draft = row.get("worst") == "DRAFT"
                 for result in row["results"]:
-                    flattened.append({"file": row.get("file"), **result})
+                    flat = {"file": row.get("file"), **result}
+                    if draft and str(flat.get("verdict")) == "NO-REPRO":
+                        flat["verdict"] = "DRAFT"
+                    flattened.append(flat)
             else:
                 flattened.append({"file": row.get("file"),
                                   "verdict": row.get("worst") or


### PR DESCRIPTION
The full-merge gate from #979 re-blocks what #968 excused: `_link_state` flattens pr_linkcheck's grouped rows into per-slot verdicts, and the DRAFT downgrade only exists on the group row's `worst`. Any PR touching a self-declared NONMATCHING file then fails with "1 blocking relocation verdict(s)" over a non-reproduction the per-file table itself prints as "ok - declared draft". #981 hit this by renaming one.

The fix carries the downgrade onto the slots while flattening. WRONG on a draft still blocks, matching pr_linkcheck: the excuse covers non-reproduction only, a draft's call graph must stay honest.

Two tests added; `python -m unittest discover -s tools`: 77 passed, 2 skipped.