### PR TITLE
Detach eight misattributed symbols from Player.h

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -39,20 +39,23 @@ struct x;
 struct Player {
     u8  pad_000[0x8];
     s32 mParam;            /* 0x008 */
-    s32 unk_00c;            /* 0x00c */
-    u8  pad_010[0x20];
-    u8  unk_030;            /* 0x030 */
-    u8  pad_031[0x7];
-    s32 mModelAnim1;            /* 0x038 */
-    u8  pad_03c[0x20];
+    /* 0x00c..0x05b. unk_00c, unk_030 and mModelAnim1 used to be named in here.
+       Their only evidence was src/_ZN6Player6ST_OWLE.c, which is ov006 code
+       carrying a Player name -- it reads 0x08/0x0c as a fix12 2D coordinate
+       pair, which cannot be ActorBase's param1 and actorID. That file now uses
+       its own local struct, and nothing else referenced these three. */
+    u8  pad_00c[0x50];
     s32 mPosX;            /* 0x05c */
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0xc];
     u8  mCamSpacePos;            /* 0x074 */
     u8  pad_075[0x3];
-    u8  mModelAnim2;            /* 0x078 */
-    u8  pad_079[0x7];
+    /* 0x078..0x07f. mModelAnim2 used to be here; its only evidence was
+       src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp, ov006 constructor-
+       shaped code carrying a Player name. Player's own ModelAnims are at 0xf0
+       and 0x174. On a real Player 0x078 is Actor's mCamSpacePosY. */
+    u8  pad_078[0x8];
     s32 mScaleX;            /* 0x080 */
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */

--- a/src/_ZN6Player16St_WallJump_InitEv.cpp
+++ b/src/_ZN6Player16St_WallJump_InitEv.cpp
@@ -1,15 +1,21 @@
 //cpp
 // @symbol _ZN6Player16St_WallJump_InitEv
-/* recovered: named members + shared header, real C++ method, declarations from a shared header */
+/* NOT a Player method. ov006, 0x020e17f8.
+ *
+ * Reads this+0x4eb0, this+0x4eb4 and this+0x4ee5. sizeof(Player) is 0x768, so
+ * these are ~0x4700 bytes past the end of the object. Player.h currently
+ * carries a footnote about fields "far outside the object" -- this file is
+ * where that came from.
+ *
+ * Detached from Player.h; see _ZN6Player23St_InYoshiMouth_CleanupEv.cpp.
+ */
 #include "decl_common.h"
-/* recovered: named members + shared header, real C++ method */
-#include "Player.h"
-extern int func_ov004_020afdd0(int a,int b,int c,int d,int e);
+extern int func_ov004_020afdd0(int a, int b, int c, int d, int e);
 
-void Player::St_WallJump_Init()
+extern "C" void _ZN6Player16St_WallJump_InitEv(char *self)
 {
-  if(*(unsigned char*)(((char*)this)+0x4ee5)==0) return;
-  int x=*(int*)(((char*)this)+0x4eb0);
-  int y=*(int*)(((char*)this)+0x4eb4);
+  if(*(unsigned char*)(self+0x4ee5)==0) return;
+  int x=*(int*)(self+0x4eb0);
+  int y=*(int*)(self+0x4eb4);
   func_ov004_020afdd0((int)data_ov006_0213c2e4,(x>>12)-0x20,(y>>12)-8,-1,0);
 }

--- a/src/_ZN6Player17St_EndingFly_MainEv.cpp
+++ b/src/_ZN6Player17St_EndingFly_MainEv.cpp
@@ -1,13 +1,17 @@
 //cpp
 // @symbol _ZN6Player17St_EndingFly_MainEv
-/* recovered: named members + shared header, real C++ method */
-#include "Player.h"
+/* NOT a Player method. ov007, 0x020c3d1c -- the only ov007 symbol carrying a
+ * Player name. It reads no fields at all; it just calls a function pointer held
+ * in ov007 data, so nothing here identifies the object as a Player.
+ *
+ * Detached from Player.h; see _ZN6Player23St_InYoshiMouth_CleanupEv.cpp.
+ */
 extern "C" {
 typedef void (*FP)(void*);
 extern FP data_ov007_02103254;
-}
 
-void Player::St_EndingFly_Main()
+void _ZN6Player17St_EndingFly_MainEv(void *self)
 {
-  data_ov007_02103254(((void*)this));
+    data_ov007_02103254(self);
+}
 }

--- a/src/_ZN6Player23St_InYoshiMouth_CleanupEv.cpp
+++ b/src/_ZN6Player23St_InYoshiMouth_CleanupEv.cpp
@@ -1,11 +1,19 @@
 //cpp
 // @symbol _ZN6Player23St_InYoshiMouth_CleanupEv
-/* recovered: named members + shared header, real C++ method */
-#include "Player.h"
-
-
-void Player::St_InYoshiMouth_Cleanup()
+/* NOT a Player method, despite the name. ov006, 0x020d6084.
+ *
+ * sizeof(Player) is 0x768 (its allocating constructor _ZN6PlayerC3Ev asks
+ * operator new for exactly that). This function writes this+0x62ad and
+ * this+0x62af -- roughly 0x5b00 bytes past the end of the object. It is some
+ * other ov006 class that happens to sit at a shared RAM address; the Player
+ * name is a community label applied to the wrong overlay's bytes.
+ *
+ * Detached from Player.h so it stops contributing false evidence to that
+ * header. Kept under the mangled name because renaming the symbol is a config
+ * change; this commit is src-only.
+ */
+extern "C" void _ZN6Player23St_InYoshiMouth_CleanupEv(char *self)
 {
-    *(char *)(((char *)this) + 0x62ad) = 0;
-    *(char *)(((char *)this) + 0x62af) = 0;
+    *(char *)(self + 0x62ad) = 0;
+    *(char *)(self + 0x62af) = 0;
 }

--- a/src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp
+++ b/src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp
@@ -1,15 +1,28 @@
 //cpp
 // @symbol _ZN6Player29TryExitCharacterDoorWithIntroEv
-/* recovered: named members + shared header, vtable identified, real C++ method, declarations from a shared header */
+/* NOT a Player method, despite the name. ov006, 0x020ca78c.
+ *
+ * The shape is a constructor, not a state handler: it calls a base routine,
+ * stores a vptr into [this+0], then runs a member constructor at this+0x78.
+ * Player's own constructors are _ZN6PlayerC1Ev / C3Ev in ov002, and Player's
+ * ModelAnims live at 0xf0 and 0x174 -- not 0x78, which on a real Player is
+ * Actor's mCamSpacePosY.
+ *
+ * This file was the only evidence for Player.h's `mModelAnim2` at 0x078, so
+ * that field can now be dropped and the offset returned to Actor.
+ *
+ * The vptr it stores is the invented symbol VT0, which carries no address --
+ * a separate problem, left alone here.
+ *
+ * Detached from Player.h; see _ZN6Player23St_InYoshiMouth_CleanupEv.cpp.
+ */
 #include "decl_ModelAnim.h"
 #include "decl_common.h"
-/* recovered: named members + shared header, vtable identified, real C++ method */
-#include "Player.h"
 
-int * Player::TryExitCharacterDoorWithIntro()
+extern "C" int *_ZN6Player29TryExitCharacterDoorWithIntroEv(int *self)
 {
-    func_ov006_020cd6f4(((int *)this));
-    ((int *)this)[0] = (int)VT0;
-    _ZN9ModelAnimC1Ev((char *)&mModelAnim2);
-    return ((int *)this);
+    func_ov006_020cd6f4(self);
+    self[0] = (int)VT0;
+    _ZN9ModelAnimC1Ev((char *)self + 0x78);
+    return self;
 }

--- a/src/_ZN6Player6ST_OWLE.c
+++ b/src/_ZN6Player6ST_OWLE.c
@@ -1,13 +1,42 @@
 // @symbol _ZN6Player6ST_OWLE
-/* recovered: named members + shared header, declarations from a shared header */
+/* NOT a Player method, despite the name. ov006, 0x02110244.
+ *
+ * This is the file that contaminated include/Player.h. It reads 0x08 and 0x0c
+ * as a fix12 2D coordinate pair -- differencing them against another point and
+ * feeding the result to a distance helper. On a real Player those offsets are
+ * ActorBase's param1 and actorID/aliveState/shouldBeKilled, which cannot be a
+ * position. It is some other ov006 class at a shared RAM address.
+ *
+ * Because it was the only evidence for Player.h's `unk_00c` being an s32, and
+ * for `unk_030` and `mModelAnim1` existing at all, those fields can now be
+ * dropped from that header.
+ *
+ * It was also the ONLY C translation unit including Player.h, so with this
+ * detached the header can become C++-only and shed its #else branch -- the
+ * dual-branch shape that silently split in #980 when a rename landed on one
+ * side only.
+ *
+ * Kept under the mangled name because renaming the symbol is a config change;
+ * this commit is src-only.
+ */
 #include "decl_common.h"
-/* recovered: named members + shared header */
-#include "Player.h"
+
+/* Local layout: only what this function actually touches. */
+struct Owl {
+    char pad_000[0x8];
+    int  posX;              /* 0x08 -- fix12 */
+    int  posY;              /* 0x0c -- fix12 */
+    char pad_010[0x20];
+    unsigned char active;   /* 0x30 */
+    char pad_031[0x7];
+    int  state;             /* 0x38 */
+};
+
 struct S { int a, b; };
 
 extern int func_ov006_02114590(void *a0, struct S *p, struct S *q0, struct S *q1, struct S *q2);
 
-int _ZN6Player6ST_OWLE(struct Player *self, struct S *v) {
+int _ZN6Player6ST_OWLE(struct Owl *self, struct S *v) {
     struct S d;
     struct S p, t1, t2, t3;
     struct S p2, t4, t5, t6;
@@ -16,35 +45,35 @@ int _ZN6Player6ST_OWLE(struct Player *self, struct S *v) {
     int yv, xv;
     int yv2, xv2;
 
-    if (self->unk_030 == 0)
+    if (self->active == 0)
         return 0;
     t = v->a;
     d.a = t;
     d.b = v->b;
-    d.a -= self->mParam;
-    d.b -= self->unk_00c;
-    if (self->mModelAnim1 <= 0) {
-        t = self->unk_00c;
+    d.a -= self->posX;
+    d.b -= self->posY;
+    if (self->state <= 0) {
+        t = self->posY;
         if (v->b >= t) {
             if (func_0203d5bc(&d.a) >= 0x190000)
                 return 0;
             return func_0203d5bc(&d.a) >= 0xc4000;
         }
-        if (v->a >= self->mParam - 0x14000 && v->a < self->mParam + 0x14000 &&
+        if (v->a >= self->posX - 0x14000 && v->a < self->posX + 0x14000 &&
             v->b >= t - 0xc000) {
-            if (v->a >= self->mParam - 0x14000 && v->a < self->mParam - 0xa000) {
+            if (v->a >= self->posX - 0x14000 && v->a < self->posX - 0xa000) {
                 p.a = v->a;
                 p.b = v->b;
-                yv = self->unk_00c - 0xc000;
-                xv = self->mParam - 0x14000;
+                yv = self->posY - 0xc000;
+                xv = self->posX - 0x14000;
                 t1.a = xv;
                 t1.b = yv;
-                yv = self->unk_00c - 0xc000;
-                xv = self->mParam - 0xa000;
+                yv = self->posY - 0xc000;
+                xv = self->posX - 0xa000;
                 t2.a = xv;
                 t2.b = yv;
-                yv = self->unk_00c - 0x1000;
-                xv = self->mParam - 0xa000;
+                yv = self->posY - 0x1000;
+                xv = self->posX - 0xa000;
                 t3.a = xv;
                 t3.b = yv;
                 r = func_ov006_02114590(((char *)self), &p, &t1, &t2, &t3);
@@ -53,19 +82,19 @@ int _ZN6Player6ST_OWLE(struct Player *self, struct S *v) {
             in1:
                 return 1;
             }
-            if (v->a >= self->mParam + 0xa000 && v->a < self->mParam + 0x16000) {
+            if (v->a >= self->posX + 0xa000 && v->a < self->posX + 0x16000) {
                 p2.a = v->a;
                 p2.b = v->b;
-                yv2 = self->unk_00c - 0xc000;
-                xv2 = self->mParam + 0x14000;
+                yv2 = self->posY - 0xc000;
+                xv2 = self->posX + 0x14000;
                 t4.a = xv2;
                 t4.b = yv2;
-                yv2 = self->unk_00c - 0xc000;
-                xv2 = self->mParam + 0xa000;
+                yv2 = self->posY - 0xc000;
+                xv2 = self->posX + 0xa000;
                 t5.a = xv2;
                 t5.b = yv2;
-                yv2 = self->unk_00c - 0x1000;
-                xv2 = self->mParam + 0xa000;
+                yv2 = self->posY - 0x1000;
+                xv2 = self->posX + 0xa000;
                 t6.a = xv2;
                 t6.b = yv2;
                 r = func_ov006_02114590(((char *)self), &p2, &t4, &t5, &t6);


### PR DESCRIPTION
Five `src/` files carry `_ZN6Player` names but are **not Player**. They are ov006 and ov007
code at shared RAM addresses — community labels applied to another class's bytes. Because
they included `Player.h` and had been promoted to real `Player::` methods, they were feeding
false fields back into that header.

## The yardstick

`sizeof(Player)` is **0x768** — its allocating constructor `_ZN6PlayerC3Ev` asks
`operator new` for exactly that. Against that:

| file | module | what it does |
|---|---|---|
| `_ZN6Player23St_InYoshiMouth_CleanupEv` | ov006 | writes `this+0x62ad`, `this+0x62af` — ~0x5b00 bytes past the object |
| `_ZN6Player16St_WallJump_InitEv` | ov006 | reads `this+0x4eb0`, `+0x4eb4`, `+0x4ee5` |
| `_ZN6Player29TryExitCharacterDoorWithIntroEv` | ov006 | constructor-shaped — base call, vptr store of the invented `VT0`, member ctor at `this+0x78` |
| `_ZN6Player6ST_OWLE` | ov006 | reads 0x08/0x0c as a **fix12 2D coordinate pair** |
| `_ZN6Player17St_EndingFly_MainEv` | ov007 | reads no fields; calls a function pointer in ov007 data |

`ST_OWLE` is the clearest: on a real Player, 0x08 and 0x0c are ActorBase's `param1` and
`actorID`/`aliveState`/`shouldBeKilled`. They cannot be a position. Player.h's footnote about
fields "far outside the object" traces to `St_WallJump_Init`.

Each is now an `extern "C"` free function — or in `ST_OWLE`'s case a local struct naming
0x08/0x0c as the coordinates they are. **All five still byte-match.**

## What that lets us delete

With them detached, four `Player.h` fields had no evidence left *and* no remaining
referencing includer: `unk_00c` (as s32), `unk_030`, `mModelAnim1`, `mModelAnim2`. They are
replaced by padding with the reasoning recorded inline.

That returns **0x078 to Actor**, where it is `mCamSpacePosY` — ~12 real Player files pass
`&mCamSpacePos` (0x74) as a `Vector3*` to Sound functions, so the vector needs its Y back.

## Two structural wins

`ST_OWLE.c` was the **only C translation unit** including `Player.h`. With it detached, zero
remain, so the header can become C++-only and drop its `#else` branch. Worth doing: the
dual-branch shape is exactly what silently split in #980, where a rename landed on the C++
side only and the merge still came out clean.

## Deliberately not here

Renaming `_ZN6Player*` to their real classes is a **config** change, and a PR touching config
and src together cannot validate itself. This stays src-only.

## Verification

- Player **212/247** — unchanged. The 35 failures are pre-existing near-misses, almost all
  size mismatches.
- `Player.h` includers **172/197**, consistent with 177/202 before: the five detached files
  left the includer set and still match on their own.
- Full ROM build: **9,116/9,116 reproducing, module fidelity 106/106 exact, PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
