### PR TITLE
Reconcile Player.h field names with Actor.h below 0xd0

### DIFF
--- a/include/Player.h
+++ b/include/Player.h
@@ -1,7 +1,18 @@
-/* AUTO-GENERATED from matched-function evidence by tools/gen_header.py
- * class Player: 234 matched functions, 195 evidenced fields.
- * Offsets/widths are observed, not guessed. Gaps are explicit padding.
- * Field NAMES are placeholders - renaming cannot change codegen. */
+/* Originally generated from matched-function evidence by tools/gen_header.py,
+ * now hand-maintained. Offsets and widths are observed, not guessed; gaps are
+ * explicit padding. Field NAMES cannot change codegen, so they are safe to
+ * improve -- but the OFFSETS and WIDTHS are pinned by the bytes.
+ *
+ * Player derives from Actor: ActorBase -> ActorDerived -> Actor -> Player.
+ * See notes/actor-vtables.md. That is not yet expressed here -- 0x000..0x0cf
+ * still duplicates Actor's layout inline rather than inheriting it, and the
+ * 31-slot vtable (_ZTV6Player, 0x0210a83c in ov002) is unrepresented. Fields
+ * below 0x0d0 are being reconciled with Actor.h/ActorBase.h so that the switch
+ * to real inheritance becomes a header change rather than a rewrite of 197
+ * files.
+ *
+ * sizeof(Player) is 0x768 -- _ZN6PlayerC3Ev asks operator new for exactly that.
+ */
 #ifndef PLAYER_H
 #define PLAYER_H
 #include "types.h"
@@ -49,29 +60,39 @@ struct Player {
     s32 mPosY;            /* 0x060 */
     s32 mPosZ;            /* 0x064 */
     u8  pad_068[0xc];
-    u8  mCamSpacePos;            /* 0x074 */
-    u8  pad_075[0x3];
-    /* 0x078..0x07f. mModelAnim2 used to be here; its only evidence was
-       src/_ZN6Player29TryExitCharacterDoorWithIntroEv.cpp, ov006 constructor-
-       shaped code carrying a Player name. Player's own ModelAnims are at 0xf0
-       and 0x174. On a real Player 0x078 is Actor's mCamSpacePosY. */
-    u8  pad_078[0x8];
+    /* 0x074..0x07f is a Vector3, not a byte plus padding: 13 files take
+       &mCamSpacePosX and cast it to Vector3* for Sound::PlayCharVoice and
+       friends. Named to match Actor.h, which decomposes the same bytes into
+       mCamSpacePosX / Y / Z. */
+    s32 mCamSpacePosX;      /* 0x074 */
+    s32 mCamSpacePosY;      /* 0x078 */
+    s32 mCamSpacePosZ;      /* 0x07c */
     s32 mScaleX;            /* 0x080 */
     s32 mScaleY;            /* 0x084 */
     s32 mScaleZ;            /* 0x088 */
-    s16 mAngX;            /* 0x08c */
+    s16 mAngleX;            /* 0x08c */
     s16 mAngleY;            /* 0x08e */
-    s16 mAngZ;            /* 0x090 */
-    s16 mPrevAngleX;            /* 0x092 */
-    s16 mTargetAngleY;            /* 0x094 */
-    s16 mPrevAngleZ;            /* 0x096 */
+    s16 mAngleZ;            /* 0x090 */
+    /* 0x092..0x097 is a prev-angle triple. 0x094 was called mTargetAngleY here
+       and mPrevAngleY in Actor.h; the two had to agree before Player can
+       inherit these bytes. Renamed to mPrevAngleY on the structural argument:
+       its siblings at 0x092 and 0x096 are unambiguously mPrevAngleX/Z, and
+       Player uses 0x094 exactly as it uses them -- `mPrevAngleY = mAngleY` to
+       save and `mAngleY = mPrevAngleY` to restore, mirroring
+       `mAngleX = mPrevAngleX`. It is also assigned from mDesiredAngleY, which
+       reads as a target, but a previous-angle slot being reused to stage a
+       desired angle is ordinary; a prev-triple with a target in the middle is
+       not. Names cannot change codegen, so this is reversible. */
+    s16 mPrevAngleX;        /* 0x092 */
+    s16 mPrevAngleY;        /* 0x094 */
+    s16 mPrevAngleZ;        /* 0x096 */
     s32 mHorzSpeed;            /* 0x098 */
     s32 mVertAccel;            /* 0x09c */
     s32 mTerminalVelocity;            /* 0x0a0 */
     u8  pad_0a4[0x4];
     s32 mVertSpeed;            /* 0x0a8 */
     u8  pad_0ac[0x4];
-    s32 unk_0b0;            /* 0x0b0 */
+    u32 mFlags;             /* 0x0b0 -- bitwise: `&= ~0x80`, `& 0x10` */
     u8  pad_0b4[0x18];
     s8  mAreaId;            /* 0x0cc */
     u8  pad_0cd[0x3];

--- a/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
+++ b/src/_ZN6Player11ChangeStateERNS_5StateE.cpp
@@ -79,8 +79,8 @@ extern "C" int _ZN6Player11ChangeStateERNS_5StateE(struct Player *self, State *n
     self->mIsInAirState = 0;
     self->unk_654 = 0;
 
-    self->mAngZ = 0;
-    self->mAngX = self->mAngZ;
+    self->mAngleZ = 0;
+    self->mAngleX = self->mAngleZ;
 
     self->mIsControlDisabled = 0;
     self->unk_6ec = 0;

--- a/src/_ZN6Player11St_Fly_InitEv.cpp
+++ b/src/_ZN6Player11St_Fly_InitEv.cpp
@@ -15,7 +15,7 @@ int Player::St_Fly_Init()
   mAngleYSpeed=0;
   mPrevAngleX=0;
   mPrevAngleZ=0;
-  mTargetAngleY=mAngleY;
+  mPrevAngleY=mAngleY;
   Player_ReleaseHeldActor(((char*)this));
   if(mStateStep==0){
     mVertSpeed=0x5d000;

--- a/src/_ZN6Player11St_Owl_MainEv.cpp
+++ b/src/_ZN6Player11St_Owl_MainEv.cpp
@@ -116,7 +116,7 @@ int Player::St_Owl_Main()
     if (_ZN6Player12FinishedAnimEv(((char*)this))) {
         _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x58, 0, 0x1000, 0);
     }
-    mTargetAngleY = mAngleY;
+    mPrevAngleY = mAngleY;
     Player_AdvanceAnims(((char*)this));
     return 1;
 }

--- a/src/_ZN6Player12St_Bonk_MainEv.cpp
+++ b/src/_ZN6Player12St_Bonk_MainEv.cpp
@@ -75,8 +75,8 @@ willhit:
 finishedanim:
     mStateWork = 0;
     if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
-        mTargetAngleY = mTargetAngleY + 0x8000;
-        mAngleY = mTargetAngleY;
+        mPrevAngleY = mPrevAngleY + 0x8000;
+        mAngleY = mPrevAngleY;
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         return 1;
     }

--- a/src/_ZN6Player12St_Land_MainEv.cpp
+++ b/src/_ZN6Player12St_Land_MainEv.cpp
@@ -50,7 +50,7 @@ int Player::St_Land_Main()
                 return 1;
             }
             if (_ZN6Player6IsAnimEj(((char*)this), 0x4e) != 0) {
-                mAngleY = mTargetAngleY;
+                mAngleY = mPrevAngleY;
             }
             int v = (mHeldObj != 0);
             if (v != 0) {
@@ -91,14 +91,14 @@ int Player::St_Land_Main()
             mAngleY = (s16)(mAngleY + 0x8000);
         }
         if ((*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0)
-            && AngleDiff(mAngleY, mTargetAngleY) >= 0x4000) {
+            && AngleDiff(mAngleY, mPrevAngleY) >= 0x4000) {
             if (AngleDiff(mDesiredAngleY, mAngleY) >= 0x4000) {
-                mAngleY = mTargetAngleY;
+                mAngleY = mPrevAngleY;
             } else {
                 mHorzSpeed = 0 - mHorzSpeed;
             }
         }
-        mTargetAngleY = mAngleY;
+        mPrevAngleY = mAngleY;
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211013c) != 0
             && mStateStep != 0

--- a/src/_ZN6Player12St_Talk_MainEv.cpp
+++ b/src/_ZN6Player12St_Talk_MainEv.cpp
@@ -93,7 +93,7 @@ int Player::St_Talk_Main()
             else
                 mStateStep = 7;
             mStateWork = 0;
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
             char* cam = data_0209f318;
             func_0200d81c(cam, mPlayerNo);
             *(u32*)(((int)cam + 0x154)) &= ~8;

--- a/src/_ZN6Player12St_Wait_MainEv.cpp
+++ b/src/_ZN6Player12St_Wait_MainEv.cpp
@@ -81,8 +81,8 @@ int Player::St_Wait_Main()
                 if (lvl0 != 0) {
                     int thr0 = (*(unsigned char*)(data_0209f4ae+idx0)!=2) ? 0x471 : 0x555;
                     if (lvl0 < thr0) {
-                        mTargetAngleY = mDesiredAngleY;
-                        mAngleY = mTargetAngleY;
+                        mPrevAngleY = mDesiredAngleY;
+                        mAngleY = mPrevAngleY;
                     }
                 }
                 {
@@ -106,8 +106,8 @@ int Player::St_Wait_Main()
             if (lvl10 != 0) {
                 int thr10 = (*(unsigned char*)(data_0209f4ae+idx10)!=2) ? 0x471 : 0x555;
                 if (lvl10 < thr10) {
-                    mTargetAngleY = mDesiredAngleY;
-                    mAngleY = mTargetAngleY;
+                    mPrevAngleY = mDesiredAngleY;
+                    mAngleY = mPrevAngleY;
                 }
             }
             {

--- a/src/_ZN6Player12St_Walk_InitEv.cpp
+++ b/src/_ZN6Player12St_Walk_InitEv.cpp
@@ -85,8 +85,8 @@ merge:
     if (func_ov002_020e3078(((char *)this), data_ov002_02110154) != 0) {
         unk_6b8 = 0x10;
         if (*(short *)((char *)&data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-            mTargetAngleY = mDesiredAngleY;
-            mAngleY = mTargetAngleY;
+            mPrevAngleY = mDesiredAngleY;
+            mAngleY = mPrevAngleY;
         }
         if (unk_6ed != 0) {
             unsigned int rnd = (unsigned int)RandomIntInternal(data_ov002_0210e160);

--- a/src/_ZN6Player12St_Walk_MainEv.cpp
+++ b/src/_ZN6Player12St_Walk_MainEv.cpp
@@ -36,20 +36,20 @@ int Player::St_Walk_Main()
     if (func_ov002_020d36d8(((char*)this), 0)) return 1;
 
     func_ov002_020d45c0(((char*)this));
-    short r5 = mTargetAngleY;
+    short r5 = mPrevAngleY;
     if (func_ov002_020d3b9c(((char*)this))) return 1;
 
     func_ov002_020d413c(((char*)this), r5);
 
     if (mHorzSpeed == 0) {
-        mAngleY = mTargetAngleY;
+        mAngleY = mPrevAngleY;
     } else {
-        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 4, 0x2000, 0x800);
+        ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 4, 0x2000, 0x800);
     }
 
     if (unk_6e0 != 0) {
         if (!_ZN6Player6IsAnimEj(((char*)this), 0x37)) {
-            int result = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePos), mHorzSpeed, 0);
+            int result = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePosX), mHorzSpeed, 0);
             mLoopingSoundHandle = result;
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {

--- a/src/_ZN6Player13St_Crawl_MainEv.cpp
+++ b/src/_ZN6Player13St_Crawl_MainEv.cpp
@@ -59,8 +59,8 @@ int Player::St_Crawl_Main()
             int r2v = Player_ScaleByCharFactor(((char*)this), 0x1000);
             a = func_ov002_020bf224(((char*)this), r4v, r2v);
             b = 0x1000;
-            ApproachAngle((s16*)((char*)&mTargetAngleY), mDesiredAngleY, 0x10, 0x2000, 0x100);
-            mAngleY = mTargetAngleY;
+            ApproachAngle((s16*)((char*)&mPrevAngleY), mDesiredAngleY, 0x10, 0x2000, 0x100);
+            mAngleY = mPrevAngleY;
             func_ov002_020c18b0(((char*)this), 0);
         } else {
             mHorzSpeed = 0;

--- a/src/_ZN6Player13St_Shell_MainEv.cpp
+++ b/src/_ZN6Player13St_Shell_MainEv.cpp
@@ -53,7 +53,7 @@ int Player::St_Shell_Main()
 
     if (_ZNK12WithMeshClsn8IsOnWallEv((void*)((char*)&mMeshClsn))) {
         int ang = _ZN4cstd5atan2E5Fix12IiES1_(unk_560, unk_568);
-        if (AngleDiff(ang, mTargetAngleY) > 0x6000) {
+        if (AngleDiff(ang, mPrevAngleY) > 0x6000) {
             if (func_02037e58((u32*)((char*)_ZNK12WithMeshClsn13GetWallResultEv((void*)((char*)&mMeshClsn)) + 4)) != 1) {
                 flag = 1;
             }
@@ -75,9 +75,9 @@ int Player::St_Shell_Main()
             target = mAngleY;
             accel = 0x18000;
         }
-        s16 angleSave = mTargetAngleY;
-        ApproachAngle((short*)((char*)&mTargetAngleY), target, 8, 0x800, 0x100);
-        mAngleY = mTargetAngleY;
+        s16 angleSave = mPrevAngleY;
+        ApproachAngle((short*)((char*)&mPrevAngleY), target, 8, 0x800, 0x100);
+        mAngleY = mPrevAngleY;
         func_ov002_020cc660(((char*)this), angleSave);
         {
             int spd = mHorzSpeed;

--- a/src/_ZN6Player14St_Cannon_MainEv.cpp
+++ b/src/_ZN6Player14St_Cannon_MainEv.cpp
@@ -37,14 +37,14 @@ int Player::St_Cannon_Main()
             break;
 
         char* p = data_0209f318;
-        mTargetAngleY = GetAngleToCamera(mPlayerNo) + 0x8000;
-        mAngleY = mTargetAngleY;
+        mPrevAngleY = GetAngleToCamera(mPlayerNo) + 0x8000;
+        mAngleY = mPrevAngleY;
 
         int ang = *(u16*)(p + 0x17e);
         int j = ang >> 4;
         mHorzSpeed = (int)(((long long)data_02082214[j * 2 + 1] * 0x64000 + 0x800) >> 12);
         mVertSpeed = (int)(((long long)data_02082214[j * 2] * 0x64000 + 0x800) >> 12);
-        mAngX = 0;
+        mAngleX = 0;
         mStateStep = 2;
         mOpacity = 0x1f;
         mIsBodyClsnEnabled = 1;
@@ -84,7 +84,7 @@ int Player::St_Cannon_Main()
         if (mVertSpeed >= 0)
             _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(mPosX, mPosY, mPosZ);
         if (mStateWork == 0)
-            mAngX = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed >> 8, mVertSpeed >> 8) - 0x4000;
+            mAngleX = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed >> 8, mVertSpeed >> 8) - 0x4000;
         Player_AdvanceAnims(((char*)this));
         // fall through
     case 3:

--- a/src/_ZN6Player14St_Crouch_InitEv.cpp
+++ b/src/_ZN6Player14St_Crouch_InitEv.cpp
@@ -14,7 +14,7 @@ extern int _ZN6Player7SetAnimEji5Fix12IiEj(void*,unsigned int,int,int,unsigned i
 int Player::St_Crouch_Init()
 {
   if(unk_6ed){
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x2e,(struct Vector3*)((char*)&mCamSpacePos));
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x2e,(struct Vector3*)((char*)&mCamSpacePosX));
   }
   mStateTimer=0x1e;
   if(*(unsigned short*)(data_0209f49c + data_020a0e40*0x18) & 2){
@@ -22,7 +22,7 @@ int Player::St_Crouch_Init()
   }
   if(mStateStep==0){
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x2d,0x40000000,0x1000,0);
-    mTargetAngleY=mAngleY;
+    mPrevAngleY=mAngleY;
   } else if(mStateStep==1){
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x2c,0,0x1000,0);
   }

--- a/src/_ZN6Player14St_OnWall_MainEv.cpp
+++ b/src/_ZN6Player14St_OnWall_MainEv.cpp
@@ -40,7 +40,7 @@ int Player::St_OnWall_Main()
     if (func_ov002_020c5244() != 0)
         return 1;
     if (func_ov002_020d36d8(((char*)this), 0) != 0) {
-        mTargetAngleY = mAngleY;
+        mPrevAngleY = mAngleY;
         return 1;
     }
     if ((mClsnFlags & 2) == 0) {
@@ -66,7 +66,7 @@ int Player::St_OnWall_Main()
             return 1;
         }
         _Z14ApproachLinearRsss((s16*)((char*)&mAngleY), (s16)a, 0x800);
-        mTargetAngleY = a;
+        mPrevAngleY = a;
         mHorzSpeed = func_ov002_020bf224(((char*)this), 0xa000, 0x2000);
         func_ov002_020eee3c(((char*)this) + 0x380, ((char*)this));
     } else {
@@ -86,10 +86,10 @@ int Player::St_OnWall_Main()
             _Z14ApproachLinearRsss((s16*)((char*)&mAngleY), (s16)a2, 0x800);
             u32 anim;
             if ((s16)a2 == (s16)(mDesiredAngleY + d)) {
-                mTargetAngleY = ang + 0x4000;
+                mPrevAngleY = ang + 0x4000;
                 anim = 0x5d;
             } else {
-                mTargetAngleY = ang - 0x4000;
+                mPrevAngleY = ang - 0x4000;
                 anim = 0x5c;
             }
             Fix12i spd = (Fix12i)(((s64)mHorzSpeed * 0x600 + 0x800) >> 12);

--- a/src/_ZN6Player14St_Thrown_MainEv.cpp
+++ b/src/_ZN6Player14St_Thrown_MainEv.cpp
@@ -33,12 +33,12 @@ int Player::St_Thrown_Main()
     switch (state) {
     case 0:
         if (mIsAirborne == 0) {
-            mAngX = 0;
+            mAngleX = 0;
             *(int*)(((int)((char*)this) + 0x2ec) & 0xFFFFFFFFFFFFFFFFULL) &= ~0x2000;
             func_ov002_020c06fc(((char*)this), 0x8000);
             if (mStateArg == 0) {
                 mStateArg = 1;
-                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, *(Vector3*)((char*)&mCamSpacePos));
+                _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, *(Vector3*)((char*)&mCamSpacePosX));
             }
             int r5 = func_ov002_020e2c84(((char*)this));
             if (r5 != 2 && mIsInShallowWater == 0) {
@@ -57,15 +57,15 @@ int Player::St_Thrown_Main()
                 return 1;
             }
         }
-        mAngleY = mTargetAngleY;
+        mAngleY = mPrevAngleY;
         mHorzSpeed = (int)(((long long)mHorzSpeed * 0xfae + 0x800) >> 12);
         if (mIsAirborne != 0) {
             int a = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed, mVertSpeed);
             s16 b = a - 0x4000;
             if (b > 0x3000) b = 0x3000;
-            mAngX = b;
+            mAngleX = b;
         } else {
-            _Z15ApproachLinear2Rsss((s16*)((char*)&mAngX), 0, 0x400);
+            _Z15ApproachLinear2Rsss((s16*)((char*)&mAngleX), 0, 0x400);
         }
         break;
     case 1:
@@ -76,7 +76,7 @@ int Player::St_Thrown_Main()
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
         }
         Player_AdvanceAnims(((char*)this));
         break;

--- a/src/_ZN6Player15St_DeadPit_MainEv.cpp
+++ b/src/_ZN6Player15St_DeadPit_MainEv.cpp
@@ -48,7 +48,7 @@ int Player::St_DeadPit_Main()
         break;
     case 3: {
         func_ov002_020c0108(((char*)this), 0);
-        u32 snd = _ZN5Sound8PlayLongEjjjRK7Vector3j(mLoopingSoundHandle, 0, 0x10a, (int*)((char*)&mCamSpacePos), 0);
+        u32 snd = _ZN5Sound8PlayLongEjjjRK7Vector3j(mLoopingSoundHandle, 0, 0x10a, (int*)((char*)&mCamSpacePosX), 0);
         int* p = (int*)(((long long)(int)((char*)&mSinkDepth)));
         mLoopingSoundHandle = snd;
         *p += 0x5000;
@@ -60,7 +60,7 @@ int Player::St_DeadPit_Main()
                 *p += 0x2000;
                 if (mStateArg == 0) {
                     if (mSinkDepth >= 0x64) {
-                        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x25, (int*)((char*)&mCamSpacePos));
+                        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x25, (int*)((char*)&mCamSpacePosX));
                         mStateArg = 1;
                     }
                 }

--- a/src/_ZN6Player15St_Grabbed_InitEv.cpp
+++ b/src/_ZN6Player15St_Grabbed_InitEv.cpp
@@ -14,7 +14,7 @@ int Player::St_Grabbed_Init()
   *(int*)(int)(((unsigned long long)(int)((char*)&mBodyClsnFlags)) & 0xFFFFFFFFFFFFFFFFull) |= 2;
   mIsBodyClsnEnabled = 0;
   unk_716 = 1;
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, (void*)((char*)&mCamSpacePos));
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 6, (void*)((char*)&mCamSpacePosX));
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x71, 0, 0x1000, 0);
   unk_717 = 1;
   mStateStep = 0;

--- a/src/_ZN6Player15St_Hurt_CleanupEv.cpp
+++ b/src/_ZN6Player15St_Hurt_CleanupEv.cpp
@@ -8,6 +8,6 @@
 
 int Player::St_Hurt_Cleanup()
 {
-    *(unsigned int *)(((long long)(int)((char *)&unk_0b0))) &= ~0x80;
+    *(unsigned int *)(((long long)(int)((char *)&mFlags))) &= ~0x80;
     return 1;
 }

--- a/src/_ZN6Player15St_Swallow_MainEv.cpp
+++ b/src/_ZN6Player15St_Swallow_MainEv.cpp
@@ -36,9 +36,9 @@ int Player::St_Swallow_Main()
         int b = (*(unsigned short*)((char*)p360 + 0xc) == 0xbf);
         if (b == 0) goto L653c;
     }
-    *(short*)((char*)p360 + 0x8c) = mAngX;
+    *(short*)((char*)p360 + 0x8c) = mAngleX;
     *(short*)((char*)p360 + 0x8e) = mAngleY;
-    *(short*)((char*)p360 + 0x90) = mAngZ;
+    *(short*)((char*)p360 + 0x90) = mAngleZ;
     func_ov002_020d5ab4(*(void**)((char*)&mObjInMouth));
     _ZN5Sound13PlayCharVoiceEjjRK7Vector3(0, 0x100, ((char*)this) + 0x74);
     goto L65e4;

--- a/src/_ZN6Player16St_BackFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_BackFlip_InitEv.cpp
@@ -26,7 +26,7 @@ int Player::St_BackFlip_Init()
   if (*(int*)((char*)&mParam)==1) *(int*)((char*)&mVertSpeed)=0x4c000;
   func_ov002_020e2ad0(((void*)this));
   *(int*)((char*)&mHorzSpeed)=0x10000;
-  *(short*)((char*)&mTargetAngleY) = *(short*)((char*)&mAngleY) + 0x8000;
+  *(short*)((char*)&mPrevAngleY) = *(short*)((char*)&mAngleY) + 0x8000;
   func_ov002_020e25f0(((void*)this), 0);
   return 1;
 }

--- a/src/_ZN6Player16St_BurnLava_InitEv.cpp
+++ b/src/_ZN6Player16St_BurnLava_InitEv.cpp
@@ -26,6 +26,6 @@ int Player::St_BurnLava_Init()
     mStateArg=0;
   }
   func_ov002_020d91e0(((char*)this),0x300,1);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x23,(struct Vector3*)((char*)&mCamSpacePos));
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x23,(struct Vector3*)((char*)&mCamSpacePosX));
   return 1;
 }

--- a/src/_ZN6Player16St_DebugFly_MainEv.cpp
+++ b/src/_ZN6Player16St_DebugFly_MainEv.cpp
@@ -23,7 +23,7 @@ int Player::St_DebugFly_Main()
     mClsnFlags = 0;
 
     if (*(s16 *)(data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
-        mTargetAngleY = mDesiredAngleY;
+        mPrevAngleY = mDesiredAngleY;
         mHorzSpeed = func_ov002_020bf224((int)((char *)this), 0x50000, 0);
     }
 

--- a/src/_ZN6Player16St_SideFlip_InitEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_InitEv.cpp
@@ -25,7 +25,7 @@ int Player::St_SideFlip_Init()
   *(int*)((char*)&mVertSpeed)=0x3e000;
   func_ov002_020e2ad0(((void*)this));
   _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), 0x4d, 0x40000000, 0x1000, 0);
-  *(short*)((char*)&mTargetAngleY) = *(short*)((char*)&mDesiredAngleY);
+  *(short*)((char*)&mPrevAngleY) = *(short*)((char*)&mDesiredAngleY);
   *(short*)((char*)&mAngleY) = *(short*)((char*)&mDesiredAngleY) + 0x8000;
   func_ov002_020e25f0(((void*)this), 0);
   return 1;

--- a/src/_ZN6Player16St_SideFlip_MainEv.cpp
+++ b/src/_ZN6Player16St_SideFlip_MainEv.cpp
@@ -44,7 +44,7 @@ int Player::St_SideFlip_Main()
             u16 r0v = *(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18);
             if (r0v & 0x400) {
                 if (_ZN6Player7IsStateERNS_5StateE(((char*)this), data_ov002_0211052c)) {
-                    mTargetAngleY = mAngleY;
+                    mPrevAngleY = mAngleY;
                 }
             }
             if (func_ov002_020e2664(((char*)this))) {

--- a/src/_ZN6Player16St_Teleport_MainEv.cpp
+++ b/src/_ZN6Player16St_Teleport_MainEv.cpp
@@ -47,7 +47,7 @@ int Player::St_Teleport_Main()
             mPosZ = tz;
             mAreaId = obj->param & 0xf;
             mAngleY = ((obj->param >> 4) & 0xf) << 12;
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
             mGroundY = 0x80000000;
             unk_64c = 0x80000000;
             func_02035860(((char*)this) + 0x380, ((char*)this) + 0x5c);

--- a/src/_ZN6Player16St_WallJump_MainEv.cpp
+++ b/src/_ZN6Player16St_WallJump_MainEv.cpp
@@ -26,7 +26,7 @@ int Player::St_WallJump_Main()
   } else {
     if (*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 0x400) {
       if (_ZN6Player7IsStateERNS_5StateE(((void*)this), data_ov002_0211052c)) {
-        *(short*)((char*)&mTargetAngleY) = *(short*)((char*)&mAngleY);
+        *(short*)((char*)&mPrevAngleY) = *(short*)((char*)&mAngleY);
       }
     }
     if (func_ov002_020e2664(((void*)this))) return 1;

--- a/src/_ZN6Player17St_ButtSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_ButtSlide_MainEv.cpp
@@ -74,8 +74,8 @@ int Player::St_ButtSlide_Main()
         func_ov002_020dcafc(((char*)this));
         break;
     case 1:
-        mAngZ = 0;
-        mAngX = mAngZ;
+        mAngleZ = 0;
+        mAngleX = mAngleZ;
         if (mIsAirborne == 0) {
             if (mLandSoundPlayed == 0) {
                 mLandSoundPlayed = 1;
@@ -100,11 +100,11 @@ int Player::St_ButtSlide_Main()
         }
         break;
     case 2:
-        mAngZ = 0;
-        mAngX = mAngZ;
+        mAngleZ = 0;
+        mAngleX = mAngleZ;
         if (mStateWork == 0) {
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x42, 0x40000000, 0x1000, 0);
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
             mStateWork = 1;
         } else if (_ZN6Player12FinishedAnimEv(((char*)this)) != 0) {
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);

--- a/src/_ZN6Player17St_Headstand_MainEv.cpp
+++ b/src/_ZN6Player17St_Headstand_MainEv.cpp
@@ -52,7 +52,7 @@ int Player::St_Headstand_Main()
             *p = *p + mAngleYSpeed;
         }
         if (*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) {
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_02110724);
             return 1;
         }

--- a/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_InitEv.cpp
@@ -13,6 +13,6 @@ int Player::St_HoldHeavy_Init()
 {
   mStateWork=0;
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), data_ov002_020ff254[mStateWork], 0x40000000, 0x1000, 0);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x12, (struct Vector3*)((char*)&mCamSpacePos));
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x12, (struct Vector3*)((char*)&mCamSpacePosX));
   return 1;
 }

--- a/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldHeavy_MainEv.cpp
@@ -77,7 +77,7 @@ int Player::St_HoldHeavy_Main()
         {
             s16 t = *(s16*)((char*)data_0209f4a0 + off);
             if (t != 0) {
-                ApproachAngle((short*)((char*)&mTargetAngleY), mDesiredAngleY, 8, 0x1000, 0x400);
+                ApproachAngle((short*)((char*)&mPrevAngleY), mDesiredAngleY, 8, 0x1000, 0x400);
                 var_r1 = data_ov002_020ff1d0[mParam];
             }
         }
@@ -96,11 +96,11 @@ int Player::St_HoldHeavy_Main()
     }
 
     if (mHorzSpeed == 0) {
-        mAngleY = mTargetAngleY;
+        mAngleY = mPrevAngleY;
     } else if (mParam == 1) {
-        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 0x10, 0x1000, 0x100);
+        ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 0x10, 0x1000, 0x100);
     } else {
-        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x400);
+        ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 8, 0x2000, 0x400);
     }
 
     if (mHorzSpeed == 0) {

--- a/src/_ZN6Player17St_HoldLight_MainEv.cpp
+++ b/src/_ZN6Player17St_HoldLight_MainEv.cpp
@@ -51,7 +51,7 @@ int Player::St_HoldLight_Main()
                 if (func_ov002_020e0ccc(((char*)this), *(short**)((char*)&mHeldObj))) {
                     return 1;
                 }
-                mTargetAngleY = mAngleY;
+                mPrevAngleY = mAngleY;
                 mHorzSpeed = 0;
                 mStateStep = 1;
             } else {
@@ -84,10 +84,10 @@ int Player::St_HoldLight_Main()
     if (*(s16*)((char*)data_0209f4a0 + data_020a0e40 * 0x18) != 0) {
         s16 t = mDesiredAngleY;
         if (mStateArg != 0) {
-            mTargetAngleY = t;
+            mPrevAngleY = t;
             mStateArg = 0;
         }
-        ApproachAngle((short*)((char*)&mTargetAngleY), t, 4, 0x2000, 0x800);
+        ApproachAngle((short*)((char*)&mPrevAngleY), t, 4, 0x2000, 0x800);
         var_r4 = data_ov002_020ff1c0[mParam];
     }
 
@@ -102,9 +102,9 @@ int Player::St_HoldLight_Main()
     mStateArg = 0;
     if (mHorzSpeed == 0) {
         mStateArg = 1;
-        mAngleY = mTargetAngleY;
+        mAngleY = mPrevAngleY;
     } else {
-        ApproachAngle((short*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x800);
+        ApproachAngle((short*)((char*)&mAngleY), mPrevAngleY, 8, 0x2000, 0x800);
     }
 
     func_ov002_020d4d88(((char*)this), var_r4, 0x1000);

--- a/src/_ZN6Player17St_HurtWater_MainEv.cpp
+++ b/src/_ZN6Player17St_HurtWater_MainEv.cpp
@@ -25,8 +25,8 @@ int Player::St_HurtWater_Main()
   _Z14ApproachLinearRiii((int*)((char*)&mVertSpeed),t,0x800);
   if(_ZN6Player12FinishedAnimEv(((char*)this))){
     if((mStateStep&1)==0){
-      mTargetAngleY=mTargetAngleY+0x8000;
-      mAngleY=mTargetAngleY;
+      mPrevAngleY=mPrevAngleY+0x8000;
+      mAngleY=mPrevAngleY;
     }
     if(_ZN6Player9GetHealthEv(((char*)this))){
       if(mIsMetal==0)

--- a/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeGrab_InitEv.cpp
@@ -11,10 +11,10 @@ int Player::St_LedgeGrab_Init()
 {
   if(mStateStep){
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x20,0x40000000,0x1000,0);
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x1a,(void*)((char*)&mCamSpacePos));
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x1a,(void*)((char*)&mCamSpacePosX));
   } else {
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x23,0x40000000,0x1000,0);
-    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x17,(void*)((char*)&mCamSpacePos));
+    _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x17,(void*)((char*)&mCamSpacePosX));
   }
   return 1;
 }

--- a/src/_ZN6Player17St_LedgeHang_InitEv.cpp
+++ b/src/_ZN6Player17St_LedgeHang_InitEv.cpp
@@ -16,7 +16,7 @@ int Player::St_LedgeHang_Init()
     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x21, 0, 0x1000, 0);
   }
   *(unsigned short*)(((char*)this)+0x600+0xa6) = 2;
-  mTargetAngleY = mAngleY;
+  mPrevAngleY = mAngleY;
   mVertSpeed = 0;
   mHorzSpeed = 0;
   mIsAirborne = 0;

--- a/src/_ZN6Player17St_NoControl_MainEv.cpp
+++ b/src/_ZN6Player17St_NoControl_MainEv.cpp
@@ -25,7 +25,7 @@ int Player::St_NoControl_Main()
     if (mode == 0 || mode == 1 || (mode == 0x11 && mStateStep != 0x18)) {
         if (func_0200ee68() == 0) {
             mAngleY = GetAngleToCamera(mPlayerNo);
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
         }
     }
 

--- a/src/_ZN6Player17St_PunchKick_MainEv.cpp
+++ b/src/_ZN6Player17St_PunchKick_MainEv.cpp
@@ -70,9 +70,9 @@ int Player::St_PunchKick_Main()
             if (mPunchKickStep != 2)
                 mHorzSpeed = 0;
 
-            if (mTargetAngleY != mAngleY) {
+            if (mPrevAngleY != mAngleY) {
                 mHorzSpeed = 0;
-                mTargetAngleY = mAngleY;
+                mPrevAngleY = mAngleY;
             }
 
             {
@@ -80,7 +80,7 @@ int Player::St_PunchKick_Main()
                 s16 val = *(s16*)((char*)data_0209f4a0 + idx2 * 0x18);
                 if (val == 0 && mPunchKickStep == 2) {
                     _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x52, 0x40000000, 0x1000, 0);
-                    mTargetAngleY = mAngleY;
+                    mPrevAngleY = mAngleY;
                     mHorzSpeed = 0;
                 }
             }

--- a/src/_ZN6Player17St_SlideKick_MainEv.cpp
+++ b/src/_ZN6Player17St_SlideKick_MainEv.cpp
@@ -47,7 +47,7 @@ int Player::St_SlideKick_Main()
     goto L1d8;
 
 L88:
-    mTargetAngleY = mAngleY;
+    mPrevAngleY = mAngleY;
     mStateStep = 1;
     _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021104e4);
     goto L1d8;

--- a/src/_ZN6Player17St_SlopeJump_MainEv.cpp
+++ b/src/_ZN6Player17St_SlopeJump_MainEv.cpp
@@ -20,7 +20,7 @@ int Player::St_SlopeJump_Main()
     _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211013c);
   }
   if(*(unsigned short*)((char*)data_0209f49e + data_020a0e40[0]*0x18) & 1){
-    mTargetAngleY=mAngleY;
+    mPrevAngleY=mAngleY;
     if(mIsMega==0){
       if(mParam==3){
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_02110034);

--- a/src/_ZN6Player17St_WallSlide_MainEv.cpp
+++ b/src/_ZN6Player17St_WallSlide_MainEv.cpp
@@ -33,7 +33,7 @@ int Player::St_WallSlide_Main()
     {
       _ZN8Particle20RunningSlidingDustAtE5Fix12IiES1_S1_(*((int *) ((char *)&mPosX)), *((int *) ((char *)&mPosY)), *((int *) ((char *)&mPosZ)));
     }
-    *((int *) ((char *)&mLoopingSoundHandle)) = func_0201226c(*((int *) ((char *)&mLoopingSoundHandle)), 0, (*((int *) ((char *)&mGroundSoundType))) + 0xe2, (int) ((char *)&mCamSpacePos), *((int *) ((char *)&mHorzSpeed)), 0);
+    *((int *) ((char *)&mLoopingSoundHandle)) = func_0201226c(*((int *) ((char *)&mLoopingSoundHandle)), 0, (*((int *) ((char *)&mGroundSoundType))) + 0xe2, (int) ((char *)&mCamSpacePosX), *((int *) ((char *)&mHorzSpeed)), 0);
     if ((*((unsigned short *) (&data_0209f49e[data_020a0e40 * 0x18]))) & 2)
     {
       char *p = ((char *)this) + 0x600;

--- a/src/_ZN6Player18St_LevelEnter_InitEv.cpp
+++ b/src/_ZN6Player18St_LevelEnter_InitEv.cpp
@@ -59,7 +59,7 @@ int Player::St_LevelEnter_Init()
     mJumpComboStage = 0;
     mHorzSpeed = 0;
     mStateArg = 0;
-    mTargetAngleY = mAngleY;
+    mPrevAngleY = mAngleY;
     mStateWork = 0;
     _ZN13RaycastGroundC1Ev(&rg);
 

--- a/src/_ZN6Player18St_TurnAround_MainEv.cpp
+++ b/src/_ZN6Player18St_TurnAround_MainEv.cpp
@@ -36,7 +36,7 @@ int Player::St_TurnAround_Main()
         angle = (s16)(raw + 0x8000);
         sel = (mHorzSpeed < 0) ? 0x1800 : 0x8000;
         r5v = func_ov002_020bf56c(((char*)this), sel);
-        ApproachAngle((s16*)((char*)&mTargetAngleY), angle, 0x10, 0x1000, 0x200);
+        ApproachAngle((s16*)((char*)&mPrevAngleY), angle, 0x10, 0x1000, 0x200);
         tmp = Player_ScaleByCharFactor(((char*)this), 0x28000);
         _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), -tmp, r5v);
     } else {
@@ -44,7 +44,7 @@ int Player::St_TurnAround_Main()
         return 1;
     }
 
-    ApproachAngle((s16*)((char*)&mAngleY), mTargetAngleY, 8, 0x2000, 0x800);
+    ApproachAngle((s16*)((char*)&mAngleY), mPrevAngleY, 8, 0x2000, 0x800);
 
     if ((*(u16*)((char*)data_0209f49e + data_020a0e40 * 0x18) & 2) != 0) {
         _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_021101e4);
@@ -59,7 +59,7 @@ int Player::St_TurnAround_Main()
         }
     } else {
         func_ov002_020bf88c(((char*)this));
-        mLoopingSoundHandle = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePos), mHorzSpeed, 0);
+        mLoopingSoundHandle = func_0201226c(mLoopingSoundHandle, 0, mGroundSoundType + 0xe2, (int)((char*)&mCamSpacePosX), mHorzSpeed, 0);
     }
 
     Player_AdvanceAnims(((char*)this));

--- a/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
+++ b/src/_ZN6Player19St_CrazedCrate_InitEv.cpp
@@ -22,7 +22,7 @@ int Player::St_CrazedCrate_Init()
   mLandSoundPlayed = 0;
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x43, 0x40000000, 0x1000, 0);
   func_ov002_020e0f38(((char*)this), mJumpComboStage);
-  mTargetAngleY = mAngleY;
+  mPrevAngleY = mAngleY;
   *(int*)(((long long)(int)((char*)&mBodyClsnFlags))) |= 0x20;
   return 1;
 }

--- a/src/_ZN6Player19St_GroundPound_InitEv.cpp
+++ b/src/_ZN6Player19St_GroundPound_InitEv.cpp
@@ -14,7 +14,7 @@ int Player::St_GroundPound_Init()
   *(char*)((char*)&mJumpComboStage)=0;
   *(int*)((char*)&mVertSpeed)=0;
   *(int*)((char*)&mHorzSpeed)=0;
-  *(short*)((char*)&mTargetAngleY)=*(short*)((char*)&mAngleY);
+  *(short*)((char*)&mPrevAngleY)=*(short*)((char*)&mAngleY);
   anim=0x3b;
   if (*(unsigned char*)((char*)&mIsMega)) anim=0xa3;
   _ZN6Player7SetAnimEji5Fix12IiEj(((void*)this), anim, 0x40000000, 0x1000, 0);

--- a/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
+++ b/src/_ZN6Player19St_TornadoSpin_InitEv.cpp
@@ -21,6 +21,6 @@ int Player::St_TornadoSpin_Init()
   mLandSoundPlayed=0;
   func_0200d6b4(*(void**)data_0209f318, mPlayerNo);
   mAttachOffsetY=mPosY - *(int*)(mAttachedActor+0x60);
-  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x26,(void*)((char*)&mCamSpacePos));
+  _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter,0x26,(void*)((char*)&mCamSpacePosX));
   return 1;
 }

--- a/src/_ZN6Player20St_StomachSlide_MainEv.cpp
+++ b/src/_ZN6Player20St_StomachSlide_MainEv.cpp
@@ -142,8 +142,8 @@ int Player::St_StomachSlide_Main()
         return 1;
 
     case 2:
-        mAngZ = 0;
-        mAngX = mAngZ;
+        mAngleZ = 0;
+        mAngleX = mAngleZ;
         if (mStateStep == 0) {
             void* light = *(void**)((char*)&mHeldObj);
             int haveLight = (light != 0);
@@ -163,7 +163,7 @@ int Player::St_StomachSlide_Main()
             } else {
                 _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0x3e, 0x40000000, 0x1000, 0);
             }
-            mTargetAngleY = mAngleY;
+            mPrevAngleY = mAngleY;
             {
                 u8* p = (u8*)(((long long)(int)((char*)&mStateStep)));
                 *p = (u8)(*p + 1);
@@ -184,7 +184,7 @@ end:
         s16 v = _ZN4cstd5atan2E5Fix12IiES1_(mHorzSpeed >> 8, mVertSpeed >> 8) - 0x4000;
         if (v < 0) v = 0;
         if (v >= 0x2aaa) v = 0x2aaa;
-        _Z15ApproachLinear2Rsss((short*)((char*)&mAngX), v, 0x200);
+        _Z15ApproachLinear2Rsss((short*)((char*)&mAngleX), v, 0x200);
     }
     Player_AdvanceAnims(((char*)this));
     mStateArg = mSlideType;

--- a/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
+++ b/src/_ZN6Player21St_SmallLaunchUp_InitEv.cpp
@@ -17,8 +17,8 @@ int Player::St_SmallLaunchUp_Init()
   _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this),0x56,0,0x1000,0);
   mVertSpeed=0x2a000;
   mHorzSpeed=0;
-  mAngX=mPrevAngleX;
-  mAngleY=mTargetAngleY;
-  mAngZ=mPrevAngleZ;
+  mAngleX=mPrevAngleX;
+  mAngleY=mPrevAngleY;
+  mAngleZ=mPrevAngleZ;
   return 1;
 }

--- a/src/_ZN6Player21St_StuckInGround_MainEv.cpp
+++ b/src/_ZN6Player21St_StuckInGround_MainEv.cpp
@@ -49,7 +49,7 @@ int Player::St_StuckInGround_Main()
             }
         }
         if (_ZN6Player12FinishedAnimEv(((char*)this))) {
-            mAngleY = mTargetAngleY;
+            mAngleY = mPrevAngleY;
             _ZN6Player11ChangeStateERNS_5StateE(((char*)this), data_ov002_0211013c);
         }
         break;

--- a/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
+++ b/src/_ZN6Player22St_GrabBowserTail_MainEv.cpp
@@ -86,9 +86,9 @@ int Player::St_GrabBowserTail_Main()
                 func_02012694(0xb4, ((char*)this) + 0x74);
             s16 sp = mAngleYSpeed;
             if (sp >= 0)
-                mAngX = -sp;
+                mAngleX = -sp;
             else
-                mAngX = sp;
+                mAngleX = sp;
         }
         break;
     case 2:

--- a/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
+++ b/src/_ZN6Player22St_SwingPlayer_CleanupEv.cpp
@@ -10,6 +10,6 @@ int Player::St_SwingPlayer_Cleanup()
   if (p) {
     *(unsigned int*)(((long long)(int)(p + 0xb0))) &= ~0x800;
   }
-  mTargetAngleY = mAngleY;
+  mPrevAngleY = mAngleY;
   return 1;
 }

--- a/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
+++ b/src/_ZN6Player24St_MetalWaterGround_MainEv.cpp
@@ -51,11 +51,11 @@ int Player::St_MetalWaterGround_Main()
     func_ov002_020cd190(((char*)this));
     int approach = 0;
     if(*(short*)((char*)&data_0209f4a0 + data_020a0e40 * 0x18) != 0){
-        ApproachAngle((short*)((char*)&mTargetAngleY), mDesiredAngleY, 8, 0x1000, 0x80);
+        ApproachAngle((short*)((char*)&mPrevAngleY), mDesiredAngleY, 8, 0x1000, 0x80);
         approach = func_ov002_020bf224(((char*)this), 0x14000, 0x1000);
     }
     _Z14ApproachLinearRiii((int*)((char*)&mHorzSpeed), approach, 0x1000);
-    mAngleY = mTargetAngleY;
+    mAngleY = mPrevAngleY;
     if(mIsMega != 0){
         if(mHorzSpeed == 0){
             _ZN6Player7SetAnimEji5Fix12IiEj(((char*)this), 0xa0, 0, 0x1000, 0);
@@ -84,7 +84,7 @@ int Player::St_MetalWaterGround_Main()
         *(int*)(anim + 0xc) = r5;
         if(_ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 4) != 0
            || _ZNK9Animation12WillHitFrameEi((void*)(*(char**)(((char*)this) + _ZNK6Player14GetBodyModelIDEjb(((char*)this), (unsigned char)mParam, 0) * 4 + 0xdc) + 0x50), 0x13) != 0){
-            func_0201251c(0, 0xaa, (void*)((char*)&mCamSpacePos), mHorzSpeed);
+            func_0201251c(0, 0xaa, (void*)((char*)&mCamSpacePosX), mHorzSpeed);
         }
     }
     Player_AdvanceAnims(((char*)this));

--- a/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
+++ b/src/_ZN6Player4HurtERK7Vector3j5Fix12IiEjjj.cpp
@@ -94,9 +94,9 @@ L9c:
     if (AngleDiff(self->mAngleY, ang) > 0x4000) {
         *(u8*)(((long long)(int)((char*)&self->mStateStep))) += 1;
     }
-    self->mTargetAngleY = ang + 0x8000;
+    self->mPrevAngleY = ang + 0x8000;
     if (self->mStateStep & 1) {
-        self->mAngleY = self->mTargetAngleY;
+        self->mAngleY = self->mPrevAngleY;
     } else {
         self->mAngleY = ang;
     }

--- a/src/_ZN6Player6RenderEv.cpp
+++ b/src/_ZN6Player6RenderEv.cpp
@@ -55,7 +55,7 @@ int Player::Render()
     }
     if (mOpacity == 0)
         return 1;
-    if (!(unk_0b0 & 0x10)) {
+    if (!(mFlags & 0x10)) {
         char* bodyMdl;
         int i;
         bodyMdl = *(char**)(((char*)this) + 0xdc + _ZNK6Player14GetBodyModelIDEjb(((char*)this), unk_6db, 1) * 4);

--- a/src/_ZN6Player8BehaviorEv.cpp
+++ b/src/_ZN6Player8BehaviorEv.cpp
@@ -206,14 +206,14 @@ after_player_slot:
         mPeakY = mPosY;
 
     if (mIsAirborne == 0 && mIsFallScreaming != 0) {
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, (const Vector3 *)((char *)&mCamSpacePos));
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x2e, (const Vector3 *)((char *)&mCamSpacePosX));
         mIsFallScreaming = 0;
     }
     if (mIsAirborne != 0 && mIsFallScreaming == 0
         && _ZN6Player7IsStateERNS_5StateE(((char *)this), &data_ov002_02110454) == 0
         && (mPeakY - mPosY) > 0x47e000) {
         mIsFallScreaming = 1;
-        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x1d, (const Vector3 *)((char *)&mCamSpacePos));
+        _ZN5Sound13PlayCharVoiceEjjRK7Vector3(mCharacter, 0x1d, (const Vector3 *)((char *)&mCamSpacePosX));
     }
 
     if (mIsInShallowWater != 0 && mIsUnderwater == 0 && mIsAirborne == 0)

--- a/src/_ZN6Player8BlowAwayEs.cpp
+++ b/src/_ZN6Player8BlowAwayEs.cpp
@@ -12,7 +12,7 @@ void Player::BlowAway(short v)
 {
   if(mIsMetal) return;
   if(mIsBalloon) return;
-  mTargetAngleY=v;
+  mPrevAngleY=v;
   mAngleY=(short)(v+0x8000);
   _ZN6Player11ChangeStateERNS_5StateE(((char*)this),data_ov002_0211037c);
 }


### PR DESCRIPTION
Reconciles `Player.h`'s field names with `Actor.h` / `ActorBase.h` below 0x0d0, so that
switching Player to real inheritance later is a header change rather than a rewrite of ~200
files. **Stacked on #987.**

Names cannot change codegen, so this is byte-neutral by construction — but it is not
mechanical, and each rename below is backed by how the bytes are actually used.

## The five reconciliations

| offset | was | now | evidence |
|---|---|---|---|
| 0x074–0x07f | `u8 mCamSpacePos` + `pad_075[3]` + `pad_078[8]` | `mCamSpacePosX/Y/Z` (s32 ×3) | **13 files** take `&mCamSpacePos` and cast it to `Vector3*` for `Sound::PlayCharVoice` and friends. It is a vector, not a byte followed by padding — and Actor.h already decomposed the same bytes correctly. |
| 0x08c | `mAngX` | `mAngleX` | Actor.h's name, adopted in #976 |
| 0x090 | `mAngZ` | `mAngleZ` | same |
| 0x094 | `mTargetAngleY` | `mPrevAngleY` | see below |
| 0x0b0 | `s32 unk_0b0` | `u32 mFlags` | used as `unk_0b0 &= ~0x80` and `if (!(unk_0b0 & 0x10))` — a flags word, and Actor.h already had the better name |

54 consumer files plus the header.

## The 0x094 judgement call

This one is a genuine naming judgement, so the reasoning is recorded in the header rather
than left implicit — including the counter-argument.

**For `mPrevAngleY`:** its siblings at 0x092 and 0x096 are unambiguously `mPrevAngleX` and
`mPrevAngleZ`, making it the Y of a prev-angle triple. Player uses 0x094 exactly as it uses
those two — `mPrevAngleY = mAngleY` to save and `mAngleY = mPrevAngleY` to restore,
mirroring `mAngleX = mPrevAngleX`.

**Against:** it is also assigned from `mDesiredAngleY`, which reads as a target rather than a
history value.

I went with `mPrevAngleY` because a previous-angle slot being reused to stage a desired angle
is ordinary, whereas a prev-triple with a target in the middle is not. It affects 41 files
and is fully reversible, so if the maintainers read it the other way it is a one-line header
change plus a rename.

## Direction is not uniform — which is why this is split out

The reconciliation is bidirectional. `mFlags` above goes Player→Actor's name, but two other
offsets go the other way and are deliberately **not** in this PR:

- **0x080–0x088** — Player names `mScaleX/Y/Z`; Actor.h has a bare `pad_080[0xc]`.
- **0x098–0x0a8** — Player has `mHorzSpeed`, `mVertAccel`, `mTerminalVelocity`, `mVertSpeed`
  as `s32` with real evidence (BooCage and MadPiano write `-0x4000` / `-0x46000`, fix12
  gravity and terminal velocity); Actor.h has them as `u8` placeholders.

Those belong in the inheritance PR, not here. `Actor.h`'s versions currently have **zero
consumers** — nothing compiles against them — so changing them today would be unverifiable
by any gate. The moment Player inherits those bytes, 62 files using `mHorzSpeed` and 49 using
`mVertSpeed` resolve through `Actor.h`, and a wrong width fails loudly and immediately.

Put the change where something can check it.

## Header banner

`Player.h` no longer claims to be auto-generated with placeholder names. That had stopped
being true, and leaving it would invite someone to regenerate the file and silently discard
this work. It now records what is still missing: the class does not yet derive from Actor,
0x000..0x0cf still duplicates Actor's layout inline, and the 31-slot vtable is unrepresented.

## Verification

- Player **212/247** — unchanged from before this PR. The 35 failures are pre-existing
  near-misses, almost all size mismatches.
- `Player.h` includers **172/197** — unchanged.
- Full ROM build: **9,116/9,116 reproducing, module fidelity 106/106 exact, PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
