### PR TITLE
Add local asset catalog and message bank tools

### DIFF
--- a/notes/assets.md
+++ b/notes/assets.md
@@ -1,0 +1,82 @@
+# ROM assets: names, IDs, and local editing
+
+SM64DS stores most models, animations, collision, textures, messages, and sound
+data in NitroFS. `tools/unpack.py` extracts those named files locally under
+`extracted/`; `tools/rombuild.py` carries the filesystem and its `path_order.txt`
+back into a built ROM.
+
+The ROM and extracted payloads are copyrighted input, so they remain gitignored.
+The tools below generate their catalogs and editable exports under `build/`, which
+is also gitignored. Only the original parsers, generators, tests, and documentation
+belong in Git.
+
+## Build the local asset catalog
+
+```powershell
+python tools/asset_catalog.py generate sm64.nds
+python tools/asset_catalog.py references
+```
+
+The first command writes two deliberately separate ID layers:
+
+- `build/assets/files.tsv` and `build/generated/NitroFileId.h`: raw NitroFS IDs,
+  internal paths, formats, and sizes;
+- `build/assets/handles.tsv` and `build/generated/AssetHandle.h`: the 2,058
+  game-code handles initialized by overlay 0, resolved to their NitroFS files.
+
+That distinction matters. Calls such as `LoadFile(0x40a)` and the arguments used to
+construct `SharedFilePtr` are runtime handles, not FAT/FNT indices. The game maps
+handles below `0x8000` through the table at `data_ov000_020bd4b8`; confusing the two
+number spaces gives convincing but incorrect asset names. The source-reference
+report therefore resolves against `AssetHandle.h`, while `NitroFileId.h` is for
+low-level filesystem work.
+
+The second command writes `build/assets/references.tsv`. It finds literal IDs in
+known file-loading calls, resolves runtime handles, and proposes names for
+anonymous `SharedFilePtr` owners. Proposals are evidence for review, not automatic
+renames. Large values such as `0x9807` bypass that table and are reported as
+`encoded-or-unresolved` until their archive/flag semantics are proved; masking them
+into a plausible path would create false names.
+
+The generated headers are intentionally not added to the compiler path yet. Moving a
+matched source from a numeric literal to one of these names should be done only when
+the generated input is available to all validation environments and the function is
+reverified byte-identical.
+
+## Extract and rebuild messages
+
+The western `data/message/msg_data_*.bin` files are LZ77-compressed, BMG-shaped
+banks with a game-specific one-byte font. The runtime's matched message code shows
+the control grammar: `FD` is a line break, `FE` begins a command whose second byte
+is its total length, and `FF` ends the message. The character and icon map agrees
+with the long-standing
+[SM64DSe character table](https://github.com/Gota7/SM64DSe-Ultimate/blob/master/assets/basic_eur_us_chars.txt).
+
+```powershell
+python tools/message_bank.py extract `
+  extracted/dsd/files/data/message/msg_data_eng.bin `
+  -o build/messages/eng.json
+
+python tools/message_bank.py build build/messages/eng.json `
+  -o build/messages/msg_data_eng.bin
+
+python tools/message_bank.py roundtrip `
+  extracted/dsd/files/data/message/msg_data_eng.bin
+```
+
+The JSON uses normal readable text where the byte mapping is unambiguous. The
+following tokens make every other byte reversible:
+
+- `<icon:A>` and related names represent multi-byte controller glyphs;
+- `<cmd:FE05030002>` contains a complete length-prefixed runtime command;
+- `<glyph:D0>` preserves an unknown or ambiguous font byte.
+
+The export also keeps the original compressed stream. If no text changes, `build`
+returns it byte-for-byte. If text changes, the tool updates all INF1 offsets and
+section sizes, pads the bank like retail, and emits valid LZ10. An edited ROM is not
+expected to match retail; the exact path is there to prove that extraction itself is
+non-destructive.
+
+Japanese banks use a different multi-byte character map and are not accepted as
+readable text by this first tool version. Add that map explicitly before using this
+editor on a Japanese ROM; do not guess it from western data.

--- a/notes/assets.md
+++ b/notes/assets.md
@@ -31,12 +31,37 @@ number spaces gives convincing but incorrect asset names. The source-reference
 report therefore resolves against `AssetHandle.h`, while `NitroFileId.h` is for
 low-level filesystem work.
 
-The second command writes `build/assets/references.tsv`. It finds literal IDs in
-known file-loading calls, resolves runtime handles, and proposes names for
-anonymous `SharedFilePtr` owners. Proposals are evidence for review, not automatic
-renames. Large values such as `0x9807` bypass that table and are reported as
+The second command writes three review surfaces:
+
+- `build/assets/references.tsv` contains every literal loader call and its resolved
+  runtime asset, when known;
+- `build/assets/rename-candidates.tsv` groups anonymous globals and recovered
+  object-plus-offset fields, infers the `SharedFilePtr` payload type from the file
+  format, and records confidence, consumers, and blockers;
+- `build/assets/layout-candidates.tsv` correlates static initializers with named
+  actor directories that consume their resource globals.
+
+These are evidence for review, not automatic renames. A candidate is marked
+`high` only when one anonymous owner maps to one asset and the proposed name does
+not collide with another owner. Reused owners, duplicate names, and initializer
+files consumed by multiple actors are downgraded or blocked explicitly. Large
+values such as `0x9807` bypass the runtime table and remain
 `encoded-or-unresolved` until their archive/flag semantics are proved; masking them
 into a plausible path would create false names.
+
+The candidate data is especially useful for three cleanup passes that should
+remain independently reviewable:
+
+1. rename one-to-one resource globals and give them real `SharedFilePtr`
+   declarations;
+2. use object-plus-offset rows as field-name evidence after confirming the owning
+   class and layout;
+3. move `__sinit_*` sources next to the one named actor that consumes their
+   globals, without changing the symbol name.
+
+Do not bulk-apply the report. Asset paths are strong behavioral evidence, but they
+do not prove Nintendo's original C++ spelling. Promote a small batch, inspect all
+consumers, and run the normal affected-source, link, and ROM validation gates.
 
 The generated headers are intentionally not added to the compiler path yet. Moving a
 matched source from a numeric literal to one of these names should be done only when

--- a/tools/asset_catalog.py
+++ b/tools/asset_catalog.py
@@ -27,6 +27,8 @@ DEFAULT_HANDLES = REPO / "build" / "assets" / "handles.tsv"
 DEFAULT_FILE_HEADER = REPO / "build" / "generated" / "NitroFileId.h"
 DEFAULT_HANDLE_HEADER = REPO / "build" / "generated" / "AssetHandle.h"
 DEFAULT_REFERENCES = REPO / "build" / "assets" / "references.tsv"
+DEFAULT_CANDIDATES = REPO / "build" / "assets" / "rename-candidates.tsv"
+DEFAULT_LAYOUT_CANDIDATES = REPO / "build" / "assets" / "layout-candidates.tsv"
 
 # These two facts are independently visible in the target image and its matched
 # initializer, func_ov000_020aa420.  The path/pointer validation below turns a
@@ -44,6 +46,22 @@ KIND_BY_SUFFIX = {
     ".sdat": "sound-archive",
     ".bin": "data",
 }
+
+PAYLOAD_TYPE_BY_SUFFIX = {
+    ".bca": "BCA_File",
+    ".bmd": "BMD_File",
+    ".btp": "BTP_File",
+    ".kcl": "KCL_File",
+    ".narc": "NARC_File",
+    ".sdat": "SDAT_File",
+    ".bin": "binary data",
+}
+
+ANONYMOUS_DATA_RE = re.compile(r"data(?:_ov[0-9]+)?_[0-9a-fA-F]{8}")
+FIELD_OWNER_RE = re.compile(
+    r"(?P<base>[A-Za-z_][A-Za-z0-9_]*)\s*\+\s*"
+    r"(?P<offset>0[xX][0-9a-fA-F]+|[0-9]+)"
+)
 
 REFERENCE_CALLS = {
     "LoadFile": 0,
@@ -311,6 +329,36 @@ def suggested_owner_name(owner: str, asset) -> str:
     return "g" + camel + suffix
 
 
+def suggested_field_name(asset) -> str:
+    global_name = suggested_owner_name("data_00000000", asset)
+    return "m" + global_name[1:] if global_name else ""
+
+
+def anonymous_owner_symbol(owner: str) -> str:
+    """Extract a bare anonymous data symbol from a simple owner expression."""
+    matches = ANONYMOUS_DATA_RE.findall(owner)
+    if len(matches) != 1:
+        return ""
+    remainder = owner.replace(matches[0], "")
+    # Permit address-of and C-style casts, but no indexing or pointer arithmetic.
+    remainder = re.sub(r"\([^()]+\)", "", remainder)
+    return matches[0] if not remainder.strip(" \t&*") else ""
+
+
+def field_owner(owner: str) -> tuple[str, int] | None:
+    """Recognize a simple recovered object-plus-offset SharedFilePtr field."""
+    value = owner.strip()
+    while True:
+        stripped = re.sub(r"^\([^()]+\)\s*", "", value)
+        if stripped == value:
+            break
+        value = stripped
+    match = FIELD_OWNER_RE.fullmatch(value)
+    if not match:
+        return None
+    return match.group("base"), int(match.group("offset"), 0)
+
+
 def scan_references(src_root: pathlib.Path,
                     handles: list[AssetHandle]) -> list[dict[str, str]]:
     by_id = {asset.handle: asset for asset in handles}
@@ -352,6 +400,221 @@ def write_references(path: pathlib.Path, rows: list[dict[str, str]]) -> None:
         writer.writerows(rows)
 
 
+def _source_files(src_root: pathlib.Path) -> list[pathlib.Path]:
+    return sorted((*src_root.rglob("*.c"), *src_root.rglob("*.cpp")))
+
+
+def symbol_consumers(src_root: pathlib.Path, symbols: set[str]) -> dict[str, set[str]]:
+    """Find source consumers for candidate symbols in one linear source scan."""
+    consumers = {symbol: set() for symbol in symbols}
+    if not symbols:
+        return consumers
+    for path in _source_files(src_root):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        found = set(ANONYMOUS_DATA_RE.findall(text)) & symbols
+        if not found:
+            continue
+        source = path.relative_to(REPO).as_posix()
+        for symbol in found:
+            consumers[symbol].add(source)
+    return consumers
+
+
+def build_rename_candidates(rows: list[dict[str, str]], src_root: pathlib.Path) -> list[dict[str, str]]:
+    """Aggregate references into review-only global and struct-field candidates."""
+    resolved = [row for row in rows if row["status"] == "runtime-handle" and row["path"]]
+    global_groups: dict[str, list[dict[str, str]]] = collections.defaultdict(list)
+    field_rows = []
+    for row in resolved:
+        symbol = anonymous_owner_symbol(row["owner"])
+        if symbol:
+            global_groups[symbol].append(row)
+        elif field_owner(row["owner"]):
+            field_rows.append(row)
+
+    consumers = symbol_consumers(src_root, set(global_groups))
+    provisional = []
+    for symbol, group in sorted(global_groups.items()):
+        paths = sorted({row["path"] for row in group})
+        handles = sorted({row["raw_id"] for row in group})
+        sources = sorted({row["source"] for row in group})
+        assets = [AssetHandle(int(row["raw_id"], 0), 0, row["path"], 0) for row in group]
+        asset = assets[0]
+        suggested = suggested_owner_name(symbol, asset) if len(paths) == 1 else ""
+        blocker = "" if len(paths) == 1 else "owner maps to multiple asset paths"
+        provisional.append({
+            "candidate_kind": "global",
+            "current_name": symbol,
+            "suggested_name": suggested,
+            "confidence": "high" if suggested else "blocked",
+            "container_type": "SharedFilePtr",
+            "payload_type": PAYLOAD_TYPE_BY_SUFFIX.get(asset.suffix, "unknown"),
+            "asset_kind": asset.kind if len(paths) == 1 else "mixed",
+            "asset_paths": "; ".join(paths),
+            "runtime_handles": "; ".join(handles),
+            "references": str(len(group)),
+            "initializer_sources": "; ".join(sources),
+            "consumer_sources": "; ".join(sorted(consumers[symbol])),
+            "evidence": (
+                "literal runtime handle resolves to one asset and initializes this owner"
+                if len(paths) == 1 else
+                "the same owner is initialized with different resolved assets"
+            ),
+            "blocker": blocker,
+        })
+
+    name_counts = collections.Counter(
+        row["suggested_name"] for row in provisional if row["suggested_name"]
+    )
+    for row in provisional:
+        if row["suggested_name"] and name_counts[row["suggested_name"]] > 1:
+            row["confidence"] = "medium"
+            row["blocker"] = (
+                f"suggested name is shared by {name_counts[row['suggested_name']]} owners"
+            )
+
+    fields = []
+    for row in sorted(field_rows, key=lambda item: (item["source"], int(item["line"]))):
+        base, offset = field_owner(row["owner"])
+        asset = AssetHandle(int(row["raw_id"], 0), 0, row["path"], 0)
+        fields.append({
+            "candidate_kind": "field",
+            "current_name": f"{base}+0x{offset:x}",
+            "suggested_name": suggested_field_name(asset),
+            "confidence": "medium",
+            "container_type": "SharedFilePtr",
+            "payload_type": PAYLOAD_TYPE_BY_SUFFIX.get(asset.suffix, "unknown"),
+            "asset_kind": asset.kind,
+            "asset_paths": asset.path,
+            "runtime_handles": row["raw_id"],
+            "references": "1",
+            "initializer_sources": f"{row['source']}:{row['line']}",
+            "consumer_sources": "",
+            "evidence": "object-plus-offset field is initialized from a resolved runtime handle",
+            "blocker": "confirm the recovered base object's class and field layout",
+        })
+    return provisional + fields
+
+
+def write_rename_candidates(path: pathlib.Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = (
+        "candidate_kind", "current_name", "suggested_name", "confidence",
+        "container_type", "payload_type", "asset_kind", "asset_paths",
+        "runtime_handles", "references", "initializer_sources",
+        "consumer_sources", "evidence", "blocker",
+    )
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, delimiter="\t", fieldnames=fields,
+                                lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def resource_owner_from_source(source: str) -> tuple[str, str] | None:
+    """Return (owner, evidence kind) for a named resource consumer source."""
+    actor_match = re.match(r"src/actors/([^/]+)/", source)
+    if actor_match:
+        return actor_match.group(1), "actor-directory"
+
+    stem = pathlib.PurePosixPath(source).stem
+    mangled = re.match(r"_ZN([0-9]+)", stem)
+    if not mangled:
+        return None
+    length = int(mangled.group(1))
+    start = mangled.end()
+    owner = stem[start:start + length]
+    remainder = stem[start + length:]
+    if len(owner) != length:
+        return None
+    if not (remainder.startswith("13InitResourcesE") or
+            remainder.startswith("16CleanupResourcesE")):
+        return None
+    return owner, "mangled-resource-method"
+
+
+def build_layout_candidates(rows: list[dict[str, str]],
+                            rename_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Use resource-global consumers to suggest homes for static initializers."""
+    consumers = {
+        row["current_name"]: row["consumer_sources"].split("; ")
+        for row in rename_rows if row["candidate_kind"] == "global"
+    }
+    by_source: dict[str, list[dict[str, str]]] = collections.defaultdict(list)
+    for row in rows:
+        if (row["status"] == "runtime-handle" and row["path"] and
+                pathlib.PurePosixPath(row["source"]).name.startswith("__sinit_")):
+            by_source[row["source"]].append(row)
+
+    output = []
+    for source, group in sorted(by_source.items()):
+        if source.startswith("src/actors/"):
+            continue
+        owner_symbols = sorted(filter(None, {
+            anonymous_owner_symbol(row["owner"]) for row in group
+        }))
+        consumer_sources = sorted({
+            consumer
+            for symbol in owner_symbols
+            for consumer in consumers.get(symbol, [])
+            if consumer != source
+        })
+        owner_evidence = [
+            evidence for consumer in consumer_sources
+            if (evidence := resource_owner_from_source(consumer))
+        ]
+        actors = sorted({owner for owner, _kind in owner_evidence})
+        evidence_kinds = {kind for _owner, kind in owner_evidence}
+        asset_dirs = sorted({
+            str(pathlib.PurePosixPath(row["path"]).parent) for row in group
+        })
+        filename = pathlib.PurePosixPath(source).name
+        suggested = f"src/actors/{actors[0]}/{filename}" if len(actors) == 1 else ""
+        if len(actors) == 1:
+            confidence = (
+                "high" if "actor-directory" in evidence_kinds else "medium"
+            )
+            blocker = ""
+            evidence = (
+                "resource globals are consumed from one existing actor directory"
+                if confidence == "high" else
+                "resource globals are consumed by one mangled InitResources/CleanupResources class"
+            )
+        elif actors:
+            confidence = "blocked"
+            blocker = "resource globals are shared by multiple actor directories"
+            evidence = "consumer locations disagree on one actor owner"
+        else:
+            confidence = "review"
+            blocker = "no named actor consumer found"
+            evidence = "asset directories identify a subsystem but not a C++ owner"
+        output.append({
+            "current_path": source,
+            "suggested_path": suggested,
+            "confidence": confidence,
+            "actor": "; ".join(actors),
+            "asset_directories": "; ".join(asset_dirs),
+            "owners": "; ".join(owner_symbols),
+            "consumer_sources": "; ".join(consumer_sources),
+            "evidence": evidence,
+            "blocker": blocker,
+        })
+    return output
+
+
+def write_layout_candidates(path: pathlib.Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = (
+        "current_path", "suggested_path", "confidence", "actor",
+        "asset_directories", "owners", "consumer_sources", "evidence", "blocker",
+    )
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, delimiter="\t", fieldnames=fields,
+                                lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
 def cmd_generate(args) -> None:
     rom = pathlib.Path(args.rom)
     if not rom.is_file():
@@ -384,9 +647,20 @@ def cmd_references(args) -> None:
     handles = read_handles(args.handles)
     rows = scan_references(args.src, handles)
     write_references(args.output, rows)
+    candidates = build_rename_candidates(rows, args.src)
+    write_rename_candidates(args.candidates, candidates)
+    layouts = build_layout_candidates(rows, candidates)
+    write_layout_candidates(args.layouts, layouts)
     direct = sum(row["status"] == "runtime-handle" for row in rows)
+    high = sum(row["confidence"] == "high" for row in candidates)
+    medium = sum(row["confidence"] == "medium" for row in candidates)
+    blocked = sum(row["confidence"] == "blocked" for row in candidates)
+    layout_high = sum(row["confidence"] == "high" for row in layouts)
+    layout_medium = sum(row["confidence"] == "medium" for row in layouts)
     print(f"Found {len(rows):,} literal loader references ({direct:,} runtime handles)")
     print(f"  report: {args.output}")
+    print(f"  names : {args.candidates} ({high:,} high, {medium:,} medium, {blocked:,} blocked)")
+    print(f"  layout: {args.layouts} ({layout_high:,} high, {layout_medium:,} medium)")
 
 
 def main(argv=None) -> None:
@@ -405,6 +679,9 @@ def main(argv=None) -> None:
     references.add_argument("--handles", type=pathlib.Path, default=DEFAULT_HANDLES)
     references.add_argument("--src", type=pathlib.Path, default=REPO / "src")
     references.add_argument("--output", type=pathlib.Path, default=DEFAULT_REFERENCES)
+    references.add_argument("--candidates", type=pathlib.Path, default=DEFAULT_CANDIDATES)
+    references.add_argument("--layouts", type=pathlib.Path,
+                            default=DEFAULT_LAYOUT_CANDIDATES)
     references.set_defaults(func=cmd_references)
 
     args = parser.parse_args(argv)

--- a/tools/asset_catalog.py
+++ b/tools/asset_catalog.py
@@ -1,0 +1,415 @@
+"""Build a local NitroFS asset catalog and find source references to it.
+
+The ROM and generated outputs are intentionally local-only.  By default they land
+under build/, which is gitignored:
+
+    python tools/asset_catalog.py generate sm64.nds
+    python tools/asset_catalog.py references
+
+The generated C headers are deliberately not wired into matched source yet.  They
+are stable naming aids and a review surface; adopting constants belongs in a
+separately verified source/layout change.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO / "build" / "assets" / "files.tsv"
+DEFAULT_HANDLES = REPO / "build" / "assets" / "handles.tsv"
+DEFAULT_FILE_HEADER = REPO / "build" / "generated" / "NitroFileId.h"
+DEFAULT_HANDLE_HEADER = REPO / "build" / "generated" / "AssetHandle.h"
+DEFAULT_REFERENCES = REPO / "build" / "assets" / "references.tsv"
+
+# These two facts are independently visible in the target image and its matched
+# initializer, func_ov000_020aa420.  The path/pointer validation below turns a
+# wrong-version ROM into a hard failure instead of a plausible-looking catalog.
+OV000_HANDLE_TABLE_ADDRESS = 0x020BD4B8
+OV000_HANDLE_COUNT = 0x80A
+
+
+KIND_BY_SUFFIX = {
+    ".bca": "animation",
+    ".bmd": "model",
+    ".btp": "texture-sequence",
+    ".kcl": "collision",
+    ".narc": "archive",
+    ".sdat": "sound-archive",
+    ".bin": "data",
+}
+
+REFERENCE_CALLS = {
+    "LoadFile": 0,
+    "LoadFileAt": 0,
+    "LoadCompressedFileAt": 0,
+    "_ZN5Model14LoadAndSetFileEtii": 1,
+    "_ZN13SharedFilePtr9ConstructEj": 1,
+    "SharedFilePtr_Construct_TexSeq": 1,
+    # Matched constructor veneers.  Their recovered prototypes sometimes omit
+    # the second argument, but retail forwards it to func_02017e0c.
+    "func_020178cc": 1,
+    "func_02017a24": 1,
+    "func_02017ae4": 1,
+    "func_02017acc": 1,
+    "func_02017b4c": 1,
+    "func_02017e48": 1,
+    "func_02017e0c": 1,
+}
+
+
+@dataclass(frozen=True)
+class Asset:
+    file_id: int
+    path: str
+    size: int
+
+    @property
+    def suffix(self) -> str:
+        return pathlib.PurePosixPath(self.path).suffix.lower()
+
+    @property
+    def kind(self) -> str:
+        return KIND_BY_SUFFIX.get(self.suffix, "file")
+
+
+@dataclass(frozen=True)
+class AssetHandle:
+    handle: int
+    file_id: int
+    path: str
+    size: int
+
+    @property
+    def suffix(self) -> str:
+        return pathlib.PurePosixPath(self.path).suffix.lower()
+
+    @property
+    def kind(self) -> str:
+        return KIND_BY_SUFFIX.get(self.suffix, "file")
+
+
+def constant_base(path: str, prefix: str = "FILE_ID") -> str:
+    """Return a deterministic C identifier retaining the full path and suffix."""
+    value = re.sub(r"[^A-Za-z0-9]+", "_", path).strip("_").upper()
+    if not value or value[0].isdigit():
+        value = "FILE_" + value
+    return prefix + "_" + value
+
+
+def constants_for(entries, value_attr: str = "file_id",
+                  prefix: str = "FILE_ID") -> dict[int, str]:
+    """Assign stable names, suffixing only actual sanitizer collisions."""
+    bases = {}
+    for entry in entries:
+        bases.setdefault(constant_base(entry.path, prefix), []).append(entry)
+    result = {}
+    for base, group in bases.items():
+        for entry in group:
+            value = getattr(entry, value_attr)
+            result[value] = (
+                base if len(group) == 1 else f"{base}_ID_{value:04X}"
+            )
+    return result
+
+
+def handles_from_overlay(overlay, assets: list[Asset], *,
+                         table_address: int = OV000_HANDLE_TABLE_ADDRESS,
+                         count: int = OV000_HANDLE_COUNT) -> list[AssetHandle]:
+    """Read the game's handle -> path pointer table from decompressed overlay 0."""
+    by_path = {asset.path: asset for asset in assets}
+    table_offset = table_address - overlay.ramAddress
+    table_size = count * 4
+    if table_offset < 0 or table_offset + table_size > len(overlay.data):
+        raise ValueError("overlay 0 does not contain the expected asset-handle table")
+
+    handles = []
+    for handle in range(count):
+        entry_offset = table_offset + handle * 4
+        pointer = int.from_bytes(overlay.data[entry_offset:entry_offset + 4], "little")
+        string_offset = pointer - overlay.ramAddress
+        if string_offset < 0 or string_offset >= len(overlay.data):
+            raise ValueError(f"asset handle 0x{handle:04x} has an invalid path pointer")
+        end = overlay.data.find(0, string_offset)
+        if end < 0:
+            raise ValueError(f"asset handle 0x{handle:04x} has an unterminated path")
+        try:
+            asset_path = bytes(overlay.data[string_offset:end]).decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"asset handle 0x{handle:04x} has a non-ASCII path") from exc
+        asset = by_path.get(asset_path)
+        if asset is None:
+            raise ValueError(
+                f"asset handle 0x{handle:04x} names a missing NitroFS file: {asset_path}"
+            )
+        handles.append(AssetHandle(handle, asset.file_id, asset.path, asset.size))
+    return handles
+
+
+def catalogs_from_rom(path: pathlib.Path) -> tuple[list[Asset], list[AssetHandle]]:
+    try:
+        import ndspy.rom
+    except ImportError:
+        sys.exit("ndspy not installed. Run: pip install ndspy")
+
+    rom = ndspy.rom.NintendoDSRom.fromFile(str(path))
+    assets = []
+    for file_id, payload in enumerate(rom.files):
+        name = rom.filenames.filenameOf(file_id)
+        if name is not None:
+            assets.append(Asset(file_id, name.replace("\\", "/"), len(payload)))
+    try:
+        overlay = rom.loadArm9Overlays()[0]
+    except KeyError as exc:
+        raise ValueError("ROM has no ARM9 overlay 0") from exc
+    return assets, handles_from_overlay(overlay, assets)
+
+
+def write_manifest(path: pathlib.Path, assets: list[Asset]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        writer.writerow(("file_id", "hex_id", "path", "kind", "size"))
+        for asset in assets:
+            writer.writerow(
+                (asset.file_id, f"0x{asset.file_id:04x}", asset.path,
+                 asset.kind, asset.size)
+            )
+
+
+def read_manifest(path: pathlib.Path) -> list[Asset]:
+    with path.open(encoding="utf-8", newline="") as f:
+        rows = csv.DictReader(f, delimiter="\t")
+        return [Asset(int(row["file_id"]), row["path"], int(row["size"]))
+                for row in rows]
+
+
+def write_handles(path: pathlib.Path, handles: list[AssetHandle]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f, delimiter="\t", lineterminator="\n")
+        writer.writerow(("handle", "hex_handle", "file_id", "hex_file_id",
+                         "path", "kind", "size"))
+        for entry in handles:
+            writer.writerow((entry.handle, f"0x{entry.handle:04x}", entry.file_id,
+                             f"0x{entry.file_id:04x}", entry.path, entry.kind,
+                             entry.size))
+
+
+def read_handles(path: pathlib.Path) -> list[AssetHandle]:
+    with path.open(encoding="utf-8", newline="") as f:
+        rows = csv.DictReader(f, delimiter="\t")
+        return [AssetHandle(int(row["handle"]), int(row["file_id"]),
+                            row["path"], int(row["size"])) for row in rows]
+
+
+def write_header(path: pathlib.Path, entries, *, value_attr: str, prefix: str,
+                 enum_name: str, description: str) -> None:
+    names = constants_for(entries, value_attr, prefix)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    guard = "SM64DS_GENERATED_" + re.sub(r"[^A-Za-z0-9]", "_", enum_name).upper() + "_H"
+    lines = [
+        "/* Generated by tools/asset_catalog.py from a user-supplied ROM.",
+        f" * {description}",
+        " * Local build artifact: do not commit this file or ROM-derived data.",
+        " */",
+        f"#ifndef {guard}",
+        f"#define {guard}",
+        "",
+        f"enum {enum_name} {{",
+    ]
+    for entry in entries:
+        value = getattr(entry, value_attr)
+        lines.append(f"    {names[value]} = 0x{value:04x},")
+    lines.extend(("};", "", "#endif", ""))
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _balanced_calls(text: str):
+    names = "|".join(re.escape(name) for name in REFERENCE_CALLS)
+    pattern = re.compile(rf"\b({names})\s*\(")
+    for match in pattern.finditer(text):
+        depth = 1
+        i = match.end()
+        in_string = None
+        escaped = False
+        while i < len(text) and depth:
+            char = text[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == in_string:
+                    in_string = None
+            elif char in "\"'":
+                in_string = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            i += 1
+        if depth == 0:
+            yield match.group(1), match.start(), text[match.end():i - 1]
+
+
+def _split_args(args: str) -> list[str]:
+    out = []
+    start = 0
+    depth = 0
+    in_string = None
+    escaped = False
+    for i, char in enumerate(args):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == in_string:
+                in_string = None
+        elif char in "\"'":
+            in_string = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}" and depth:
+            depth -= 1
+        elif char == "," and depth == 0:
+            out.append(args[start:i].strip())
+            start = i + 1
+    out.append(args[start:].strip())
+    return out
+
+
+def _integer_literal(value: str) -> int | None:
+    value = value.strip()
+    match = re.fullmatch(r"(?:\([^)]+\)\s*)?(0[xX][0-9a-fA-F]+|[0-9]+)[uUlL]*", value)
+    return int(match.group(1), 0) if match else None
+
+
+def suggested_owner_name(owner: str, asset) -> str:
+    """Return a review candidate, never an automatic rename."""
+    if not re.fullmatch(r"&?(?:data|ov\w+)_?[A-Za-z0-9_]*", owner.strip()):
+        return ""
+    stem = pathlib.PurePosixPath(asset.path).stem
+    words = [word for word in re.split(r"[^A-Za-z0-9]+", stem) if word]
+    camel = "".join(word[:1].upper() + word[1:] for word in words)
+    suffix = {
+        "model": "ModelFile",
+        "animation": "AnimationFile",
+        "collision": "CollisionFile",
+        "texture-sequence": "TextureSequenceFile",
+        "archive": "ArchiveFile",
+        "sound-archive": "SoundArchiveFile",
+        "data": "DataFile",
+    }.get(asset.kind, "File")
+    return "g" + camel + suffix
+
+
+def scan_references(src_root: pathlib.Path,
+                    handles: list[AssetHandle]) -> list[dict[str, str]]:
+    by_id = {asset.handle: asset for asset in handles}
+    rows = []
+    for path in sorted((*src_root.rglob("*.c"), *src_root.rglob("*.cpp"))):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for callee, offset, raw_args in _balanced_calls(text):
+            args = _split_args(raw_args)
+            arg_index = REFERENCE_CALLS[callee]
+            if arg_index >= len(args):
+                continue
+            raw_id = _integer_literal(args[arg_index])
+            if raw_id is None:
+                continue
+            asset = by_id.get(raw_id)
+            line = text.count("\n", 0, offset) + 1
+            owner = args[0].strip() if arg_index > 0 and args else ""
+            rows.append({
+                "source": path.relative_to(REPO).as_posix(),
+                "line": str(line),
+                "callee": callee,
+                "raw_id": f"0x{raw_id:04x}",
+                "status": "runtime-handle" if asset else "encoded-or-unresolved",
+                "path": asset.path if asset else "",
+                "owner": owner,
+                "suggested_owner": suggested_owner_name(owner, asset) if asset else "",
+            })
+    return rows
+
+
+def write_references(path: pathlib.Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = ("source", "line", "callee", "raw_id", "status", "path",
+              "owner", "suggested_owner")
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, delimiter="\t", fieldnames=fields,
+                                lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def cmd_generate(args) -> None:
+    rom = pathlib.Path(args.rom)
+    if not rom.is_file():
+        sys.exit(f"ROM not found: {rom}")
+    try:
+        assets, handles = catalogs_from_rom(rom)
+    except ValueError as exc:
+        sys.exit(f"error: {exc}")
+    write_manifest(args.manifest, assets)
+    write_handles(args.handles, handles)
+    write_header(args.file_header, assets, value_attr="file_id",
+                 prefix="NITRO_FILE_ID", enum_name="NitroFileId",
+                 description="Raw NitroFS IDs; these are not game-code asset handles.")
+    write_header(args.handle_header, handles, value_attr="handle",
+                 prefix="ASSET_HANDLE", enum_name="AssetHandle",
+                 description="Game-code handles translated through overlay 0 at runtime.")
+    print(f"Cataloged {len(assets):,} named NitroFS files and {len(handles):,} runtime handles")
+    kinds = collections.Counter(asset.kind for asset in assets)
+    print("  kinds    : " + ", ".join(
+        f"{kind}={count:,}" for kind, count in sorted(kinds.items())
+    ))
+    print(f"  manifest: {args.manifest}")
+    print(f"  handles : {args.handles}")
+    print(f"  headers : {args.file_header}, {args.handle_header}")
+
+
+def cmd_references(args) -> None:
+    if not args.handles.is_file():
+        sys.exit(f"Handle catalog not found: {args.handles}\nRun the generate command first.")
+    handles = read_handles(args.handles)
+    rows = scan_references(args.src, handles)
+    write_references(args.output, rows)
+    direct = sum(row["status"] == "runtime-handle" for row in rows)
+    print(f"Found {len(rows):,} literal loader references ({direct:,} runtime handles)")
+    print(f"  report: {args.output}")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    generate = commands.add_parser("generate", help="write the local manifest and C header")
+    generate.add_argument("rom", help="user-supplied .nds ROM")
+    generate.add_argument("--manifest", type=pathlib.Path, default=DEFAULT_MANIFEST)
+    generate.add_argument("--handles", type=pathlib.Path, default=DEFAULT_HANDLES)
+    generate.add_argument("--file-header", type=pathlib.Path, default=DEFAULT_FILE_HEADER)
+    generate.add_argument("--handle-header", type=pathlib.Path, default=DEFAULT_HANDLE_HEADER)
+    generate.set_defaults(func=cmd_generate)
+
+    references = commands.add_parser("references", help="resolve literal asset IDs in src/")
+    references.add_argument("--handles", type=pathlib.Path, default=DEFAULT_HANDLES)
+    references.add_argument("--src", type=pathlib.Path, default=REPO / "src")
+    references.add_argument("--output", type=pathlib.Path, default=DEFAULT_REFERENCES)
+    references.set_defaults(func=cmd_references)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/message_bank.py
+++ b/tools/message_bank.py
@@ -1,0 +1,369 @@
+"""Extract and rebuild SM64DS message banks without losing unknown bytes.
+
+The JSON export uses readable text plus explicit tokens:
+
+* a literal newline is the game's 0xFD line break;
+* ``<cmd:FE...>`` preserves a complete length-prefixed command;
+* ``<icon:A>`` (and similar names) preserves a multi-byte button glyph;
+* ``<glyph:AB>`` preserves a byte with no safe textual spelling.
+
+Unchanged JSON rebuilds to the exact original compressed bytes.  After an edit,
+the rebuilt bank uses valid deterministic LZ10 compression.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import pathlib
+import re
+import struct
+import sys
+
+
+FORMAT = "sm64ds-message-bank-v1"
+TOKEN_RE = re.compile(r"<(cmd|icon|glyph):([^>]+)>")
+
+BASIC_CHARS = {
+    **{i: str(i) for i in range(10)},
+    **{0x0A + i: chr(ord("A") + i) for i in range(26)},
+    0x24: "┌", 0x25: "┘", 0x26: "?", 0x27: "!", 0x28: "~",
+    0x29: ",", 0x2A: "“", 0x2B: "”",
+    **{0x2D + i: chr(ord("a") + i) for i in range(26)},
+    0x47: "-", 0x48: ".", 0x49: "'", 0x4A: ":", 0x4B: ";",
+    0x4C: "&", 0x4D: " ", 0x4E: "/",
+}
+ICONS = {
+    bytes.fromhex("eeef"): "C",
+    bytes.fromhex("f0"): "S",
+    bytes.fromhex("f1"): "s",
+    bytes.fromhex("f2f3"): "D-PAD",
+    bytes.fromhex("f4f5"): "A",
+    bytes.fromhex("f6f7"): "B",
+    bytes.fromhex("f8f9"): "X",
+    bytes.fromhex("fafb"): "Y",
+}
+ICON_BYTES = {name: payload for payload, name in ICONS.items()}
+
+
+class MessageBankError(ValueError):
+    pass
+
+
+def _ndspy_lz10():
+    try:
+        import ndspy.lz10
+    except ImportError:
+        sys.exit("ndspy not installed. Run: pip install ndspy")
+    return ndspy.lz10
+
+
+def unpack_file(raw: bytes) -> tuple[bytes, bool]:
+    if raw.startswith(b"LZ77"):
+        return _ndspy_lz10().decompress(raw[4:]), True
+    if raw.startswith(b"GSEM1gmb"):
+        return raw, False
+    raise MessageBankError("not an SM64DS LZ77 or GSEM1gmb message bank")
+
+
+def _extended_char(code: int) -> str | None:
+    if not 0x50 <= code <= 0xCF:
+        return None
+    try:
+        return bytes((code + 0x30,)).decode("cp1252")
+    except UnicodeDecodeError:
+        return None
+
+
+def decode_message(payload: bytes) -> str:
+    if not payload or payload[-1] != 0xFF:
+        raise MessageBankError("message does not end in 0xFF")
+    out = []
+    i = 0
+    while i < len(payload) - 1:
+        code = payload[i]
+        if code == 0xFD:
+            out.append("\n")
+            i += 1
+        elif code == 0xFE:
+            if i + 1 >= len(payload):
+                raise MessageBankError("truncated 0xFE command")
+            length = payload[i + 1]
+            if length < 2 or i + length > len(payload) - 1:
+                raise MessageBankError(f"invalid 0xFE command length {length}")
+            command = payload[i:i + length]
+            out.append(f"<cmd:{command.hex().upper()}>")
+            i += length
+        else:
+            icon = next(((raw, name) for raw, name in ICONS.items()
+                         if payload.startswith(raw, i)), None)
+            if icon:
+                raw, name = icon
+                out.append(f"<icon:{name}>")
+                i += len(raw)
+                continue
+            char = BASIC_CHARS.get(code)
+            if char is None:
+                char = _extended_char(code)
+            if char is None or char in BASIC_CHARS.values():
+                # Basic spellings are canonical.  Duplicate extended spellings
+                # stay explicit so decode -> encode cannot silently change bytes.
+                if char is None or code not in BASIC_CHARS:
+                    out.append(f"<glyph:{code:02X}>")
+                else:
+                    out.append(char)
+            else:
+                out.append(char)
+            i += 1
+    return "".join(out)
+
+
+def _char_encoder() -> dict[str, int]:
+    result = {char: code for code, char in BASIC_CHARS.items()}
+    for code in range(0x50, 0xD0):
+        char = _extended_char(code)
+        if char is not None and char not in result:
+            result[char] = code
+    return result
+
+
+CHAR_ENCODER = _char_encoder()
+
+
+def encode_message(text: str) -> bytes:
+    out = bytearray()
+    i = 0
+    while i < len(text):
+        if text[i] == "\n":
+            out.append(0xFD)
+            i += 1
+            continue
+        if text[i] == "<":
+            token = TOKEN_RE.match(text, i)
+            if token is None:
+                raise MessageBankError(f"invalid token at character {i}")
+            kind, value = token.groups()
+            if kind == "cmd":
+                try:
+                    raw = bytes.fromhex(value)
+                except ValueError as exc:
+                    raise MessageBankError(f"invalid command hex at character {i}") from exc
+                if len(raw) < 2 or raw[0] != 0xFE or raw[1] != len(raw):
+                    raise MessageBankError("command token must start FE and contain its byte length")
+                out.extend(raw)
+            elif kind == "icon":
+                if value not in ICON_BYTES:
+                    raise MessageBankError(f"unknown icon {value!r}")
+                out.extend(ICON_BYTES[value])
+            else:
+                try:
+                    raw = bytes.fromhex(value)
+                except ValueError as exc:
+                    raise MessageBankError(f"invalid glyph hex at character {i}") from exc
+                if len(raw) != 1 or raw[0] in (0xFD, 0xFE, 0xFF):
+                    raise MessageBankError("glyph token must contain one non-control byte")
+                out.extend(raw)
+            i = token.end()
+            continue
+        code = CHAR_ENCODER.get(text[i])
+        if code is None:
+            raise MessageBankError(
+                f"character {text[i]!r} at {i} is not in the SM64DS western font"
+            )
+        out.append(code)
+        i += 1
+    out.append(0xFF)
+    return bytes(out)
+
+
+def _u16(data: bytes, offset: int) -> int:
+    return struct.unpack_from("<H", data, offset)[0]
+
+
+def _u32(data: bytes, offset: int) -> int:
+    return struct.unpack_from("<I", data, offset)[0]
+
+
+def parse_bank(raw: bytes, source_name: str = "") -> dict:
+    data, compressed = unpack_file(raw)
+    if len(data) < 0x38 or data[:8] != b"GSEM1gmb":
+        raise MessageBankError("invalid message bank header")
+    inf_offset = 0x20
+    if data[inf_offset:inf_offset + 4] != b"1FNI":
+        raise MessageBankError("missing INF1 section")
+    inf_size = _u32(data, inf_offset + 4)
+    count = _u16(data, inf_offset + 8)
+    entries_offset = inf_offset + 0x10
+    entries_end = entries_offset + count * 8
+    dat_offset = inf_offset + inf_size
+    if entries_end > dat_offset or data[dat_offset:dat_offset + 4] != b"1TAD":
+        raise MessageBankError("invalid INF1 size or missing DAT1 section")
+    text_base = dat_offset + 8
+
+    messages = []
+    previous_offset = -1
+    for index in range(count):
+        entry_offset = entries_offset + index * 8
+        string_offset = _u32(data, entry_offset)
+        if string_offset <= previous_offset:
+            raise MessageBankError("message offsets must be strictly increasing")
+        previous_offset = string_offset
+        start = text_base + string_offset
+        cursor = start
+        while cursor < len(data):
+            code = data[cursor]
+            if code == 0xFF:
+                cursor += 1
+                break
+            if code == 0xFE:
+                if cursor + 1 >= len(data) or data[cursor + 1] < 2:
+                    raise MessageBankError(f"invalid command in message {index}")
+                cursor += data[cursor + 1]
+            else:
+                cursor += 1
+        else:
+            raise MessageBankError(f"unterminated message {index}")
+        if index + 1 < count:
+            next_offset = _u32(data, entry_offset + 8)
+            if cursor != text_base + next_offset:
+                raise MessageBankError(f"gap or overlap after message {index}")
+        payload = data[start:cursor]
+        messages.append({
+            "index": index,
+            "info_hex": data[entry_offset + 4:entry_offset + 8].hex(),
+            "text": decode_message(payload),
+        })
+
+    first_offset = _u32(data, entries_offset) if count else 0
+    last_end = text_base + first_offset
+    if messages:
+        last_end = text_base + previous_offset + len(encode_message(messages[-1]["text"]))
+    return {
+        "format": FORMAT,
+        "source_name": source_name,
+        "compressed": compressed,
+        "source_sha256": hashlib.sha256(raw).hexdigest(),
+        "uncompressed_sha256": hashlib.sha256(data).hexdigest(),
+        "file_header_hex": data[:0x20].hex(),
+        "inf_header_hex": data[inf_offset:entries_offset].hex(),
+        "inf_padding_hex": data[entries_end:dat_offset].hex(),
+        "dat_header_hex": data[dat_offset:text_base].hex(),
+        "text_prefix_hex": data[text_base:text_base + first_offset].hex(),
+        "text_suffix_hex": data[last_end:].hex(),
+        "messages": messages,
+        # Kept last so opening the JSON shows readable messages, not a large
+        # preservation blob.  This is what makes an unchanged compressed build
+        # byte-identical even though generic LZ10 compressors choose other matches.
+        "original_file_base64": base64.b64encode(raw).decode("ascii"),
+    }
+
+
+def build_bank(document: dict) -> bytes:
+    if document.get("format") != FORMAT:
+        raise MessageBankError(f"unsupported format {document.get('format')!r}")
+    messages = document.get("messages")
+    if not isinstance(messages, list):
+        raise MessageBankError("messages must be a list")
+
+    header = bytearray.fromhex(document["file_header_hex"])
+    inf_header = bytearray.fromhex(document["inf_header_hex"])
+    inf_padding = bytes.fromhex(document["inf_padding_hex"])
+    dat_header = bytearray.fromhex(document["dat_header_hex"])
+    prefix = bytes.fromhex(document["text_prefix_hex"])
+    if len(header) != 0x20 or len(inf_header) != 0x10 or len(dat_header) != 8:
+        raise MessageBankError("invalid preserved header length")
+    if len(messages) != _u16(inf_header, 8):
+        raise MessageBankError("changing the message count is not supported")
+
+    entries = bytearray()
+    text_data = bytearray(prefix)
+    for expected_index, message in enumerate(messages):
+        if message.get("index") != expected_index:
+            raise MessageBankError("message indices must be contiguous and zero-based")
+        info = bytes.fromhex(message["info_hex"])
+        if len(info) != 4:
+            raise MessageBankError(f"message {expected_index} info_hex must be four bytes")
+        entries.extend(struct.pack("<I", len(text_data)))
+        entries.extend(info)
+        text_data.extend(encode_message(message["text"]))
+
+    inf_size = 0x10 + len(entries) + len(inf_padding)
+    struct.pack_into("<I", inf_header, 4, inf_size)
+    struct.pack_into("<H", inf_header, 8, len(messages))
+    dat_offset = len(header) + inf_size
+    body_without_tail = header + inf_header + entries + inf_padding + dat_header + text_data
+    suffix = bytes.fromhex(document["text_suffix_hex"])
+    result = bytearray(body_without_tail + suffix)
+    if len(result) % 32:
+        result.extend(b"\xff" * (-len(result) % 32))
+
+    # The retail western banks declare one byte beyond the decompressed payload.
+    # Preserve that quirk, but derive it from the source rather than hard-coding it.
+    original_data, _ = unpack_file(base64.b64decode(document["original_file_base64"]))
+    declared_delta = _u32(header, 8) - len(original_data)
+    struct.pack_into("<I", result, 8, len(result) + declared_delta)
+    struct.pack_into("<I", result, dat_offset + 4,
+                     len(result) - dat_offset + declared_delta)
+
+    uncompressed = bytes(result)
+    original = base64.b64decode(document["original_file_base64"])
+    if hashlib.sha256(uncompressed).hexdigest() == document.get("uncompressed_sha256"):
+        return original
+    if document.get("compressed"):
+        return b"LZ77" + _ndspy_lz10().compress(uncompressed)
+    return uncompressed
+
+
+def cmd_extract(args) -> None:
+    raw = args.bank.read_bytes()
+    document = parse_bank(raw, args.bank.name)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(document, ensure_ascii=False, indent=2) + "\n",
+                           encoding="utf-8")
+    print(f"Extracted {len(document['messages']):,} messages to {args.output}")
+
+
+def cmd_build(args) -> None:
+    document = json.loads(args.document.read_text(encoding="utf-8"))
+    raw = build_bank(document)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(raw)
+    print(f"Built {len(raw):,} bytes at {args.output}")
+
+
+def cmd_roundtrip(args) -> None:
+    raw = args.bank.read_bytes()
+    rebuilt = build_bank(parse_bank(raw, args.bank.name))
+    if rebuilt != raw:
+        sys.exit("round-trip mismatch")
+    print(f"EXACT: {args.bank} ({len(raw):,} bytes)")
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    extract = commands.add_parser("extract", help="write a lossless editable JSON file")
+    extract.add_argument("bank", type=pathlib.Path)
+    extract.add_argument("--output", "-o", type=pathlib.Path, required=True)
+    extract.set_defaults(func=cmd_extract)
+
+    build = commands.add_parser("build", help="build a bank from extracted JSON")
+    build.add_argument("document", type=pathlib.Path)
+    build.add_argument("--output", "-o", type=pathlib.Path, required=True)
+    build.set_defaults(func=cmd_build)
+
+    roundtrip = commands.add_parser("roundtrip", help="prove exact unchanged rebuilding")
+    roundtrip.add_argument("bank", type=pathlib.Path)
+    roundtrip.set_defaults(func=cmd_roundtrip)
+
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except (MessageBankError, KeyError, ValueError) as exc:
+        sys.exit(f"error: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_asset_catalog.py
+++ b/tools/test_asset_catalog.py
@@ -63,6 +63,101 @@ class AssetCatalogTests(unittest.TestCase):
         self.assertEqual(rows[0]["path"], "data/enemy/piano/piano.bmd")
         self.assertEqual(rows[1]["status"], "encoded-or-unresolved")
 
+    def test_candidates_include_global_field_and_actor_layout_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            src = root / "src"
+            init = src / "unnamed" / "ov063" / "__sinit_ov063_test.c"
+            actor = src / "actors" / "MadPiano" / "InitResources.cpp"
+            init.parent.mkdir(parents=True)
+            actor.parent.mkdir(parents=True)
+            init.write_text(
+                "void init(void) {\n"
+                "  func_02017acc(data_ov063_0211ef80, 0x40a);\n"
+                "  func_02017acc(t + 0x20, 0x40c);\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            actor.write_text(
+                "extern int data_ov063_0211ef80[];\n"
+                "void use(void) { Model_Load(data_ov063_0211ef80); }\n",
+                encoding="utf-8",
+            )
+            handles = [
+                AC.AssetHandle(0x40A, 0x25C, "data/enemy/piano/piano.bmd", 100),
+                AC.AssetHandle(0x40C, 0x25E,
+                               "data/enemy/piano/piano_attack.bca", 80),
+            ]
+            old_repo = AC.REPO
+            try:
+                AC.REPO = root
+                rows = AC.scan_references(src, handles)
+                candidates = AC.build_rename_candidates(rows, src)
+                layouts = AC.build_layout_candidates(rows, candidates)
+            finally:
+                AC.REPO = old_repo
+
+        global_row = next(row for row in candidates
+                          if row["candidate_kind"] == "global")
+        self.assertEqual(global_row["current_name"], "data_ov063_0211ef80")
+        self.assertEqual(global_row["suggested_name"], "gPianoModelFile")
+        self.assertEqual(global_row["confidence"], "high")
+        self.assertEqual(global_row["payload_type"], "BMD_File")
+        self.assertIn("src/actors/MadPiano/InitResources.cpp",
+                      global_row["consumer_sources"])
+
+        field_row = next(row for row in candidates
+                         if row["candidate_kind"] == "field")
+        self.assertEqual(field_row["current_name"], "t+0x20")
+        self.assertEqual(field_row["suggested_name"], "mPianoAttackAnimationFile")
+        self.assertEqual(field_row["confidence"], "medium")
+
+        self.assertEqual(len(layouts), 1)
+        self.assertEqual(layouts[0]["confidence"], "high")
+        self.assertEqual(
+            layouts[0]["suggested_path"],
+            "src/actors/MadPiano/__sinit_ov063_test.c",
+        )
+
+    def test_candidate_blocks_one_owner_with_multiple_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            src = root / "src"
+            src.mkdir()
+            (src / "sample.c").write_text(
+                "void f(void) {\n"
+                "  func_02017acc(data_ov047_02112658, 1);\n"
+                "  func_02017b4c(data_ov047_02112658, 2);\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            old_repo = AC.REPO
+            try:
+                AC.REPO = root
+                rows = AC.scan_references(src, [
+                    AC.AssetHandle(1, 10, "data/stage/a.bmd", 10),
+                    AC.AssetHandle(2, 11, "data/stage/b.kcl", 20),
+                ])
+                candidates = AC.build_rename_candidates(rows, src)
+            finally:
+                AC.REPO = old_repo
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["confidence"], "blocked")
+        self.assertEqual(candidates[0]["suggested_name"], "")
+        self.assertIn("multiple asset paths", candidates[0]["blocker"])
+
+    def test_mangled_resource_method_supplies_medium_confidence_layout_owner(self):
+        self.assertEqual(
+            AC.resource_owner_from_source(
+                "src/_ZN14QuestionSwitch13InitResourcesEv.cpp"
+            ),
+            ("QuestionSwitch", "mangled-resource-method"),
+        )
+        self.assertIsNone(
+            AC.resource_owner_from_source("src/_ZN7Message11DisplayTextEt.cpp")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_asset_catalog.py
+++ b/tools/test_asset_catalog.py
@@ -1,0 +1,68 @@
+import pathlib
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import asset_catalog as AC  # noqa: E402
+
+
+class AssetCatalogTests(unittest.TestCase):
+    def test_constant_keeps_path_and_extension(self):
+        self.assertEqual(
+            AC.constant_base("data/enemy/piano/piano.bmd"),
+            "FILE_ID_DATA_ENEMY_PIANO_PIANO_BMD",
+        )
+
+    def test_sanitizer_collisions_get_stable_id_suffixes(self):
+        assets = [AC.Asset(7, "a-b.bin", 1), AC.Asset(9, "a_b.bin", 2)]
+        self.assertEqual(AC.constants_for(assets), {
+            7: "FILE_ID_A_B_BIN_ID_0007",
+            9: "FILE_ID_A_B_BIN_ID_0009",
+        })
+
+    def test_runtime_handle_table_is_separate_from_nitrofs_ids(self):
+        base = 0x1000
+        data = bytearray(0x80)
+        table = 0x1010
+        paths = ((0x1040, b"data/a.bmd\0"), (0x1050, b"data/b.kcl\0"))
+        for index, (pointer, payload) in enumerate(paths):
+            data[table - base + index * 4:table - base + index * 4 + 4] = \
+                pointer.to_bytes(4, "little")
+            data[pointer - base:pointer - base + len(payload)] = payload
+        overlay = SimpleNamespace(ramAddress=base, data=data)
+        handles = AC.handles_from_overlay(overlay, [
+            AC.Asset(0x123, "data/a.bmd", 10),
+            AC.Asset(0x456, "data/b.kcl", 20),
+        ], table_address=table, count=2)
+        self.assertEqual([(h.handle, h.file_id) for h in handles],
+                         [(0, 0x123), (1, 0x456)])
+
+    def test_reference_scan_resolves_only_literal_direct_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "sample.c").write_text(
+                "void f(void) {\n"
+                "  LoadFile(0x25c);\n"
+                "  LoadFile(variable);\n"
+                "  LoadCompressedFileAt(0x9807, dst);\n"
+                "}\n",
+                encoding="utf-8",
+            )
+            old_repo = AC.REPO
+            try:
+                AC.REPO = root
+                rows = AC.scan_references(root, [
+                    AC.AssetHandle(0x25C, 0x123, "data/enemy/piano/piano.bmd", 100),
+                ])
+            finally:
+                AC.REPO = old_repo
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["status"], "runtime-handle")
+        self.assertEqual(rows[0]["path"], "data/enemy/piano/piano.bmd")
+        self.assertEqual(rows[1]["status"], "encoded-or-unresolved")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_message_bank.py
+++ b/tools/test_message_bank.py
@@ -1,0 +1,69 @@
+import base64
+import pathlib
+import struct
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import message_bank as MB  # noqa: E402
+
+
+def synthetic_bank() -> bytes:
+    messages = [
+        MB.encode_message("HELLO\nWORLD"),
+        MB.encode_message("Press <icon:A><cmd:FE05030002>"),
+    ]
+    header = bytearray(b"GSEM1gmb" + b"\0" * 24)
+    inf_padding = b"\0" * 16
+    inf_size = 0x10 + len(messages) * 8 + len(inf_padding)
+    inf = bytearray(b"1FNI" + struct.pack("<IHHI", inf_size, len(messages), 0x40, 0))
+    entries = bytearray()
+    text = bytearray(b"\xff")
+    for i, message in enumerate(messages):
+        entries += struct.pack("<I", len(text)) + bytes((i, 0, 2, 0))
+        text += message
+    dat = bytearray(b"1TAD" + b"\0" * 4)
+    result = header + inf + entries + inf_padding + dat + text
+    result += b"\xff" * (-len(result) % 32)
+    struct.pack_into("<I", result, 8, len(result) + 1)
+    dat_offset = 0x20 + inf_size
+    struct.pack_into("<I", result, dat_offset + 4, len(result) - dat_offset + 1)
+    return bytes(result)
+
+
+class MessageBankTests(unittest.TestCase):
+    def test_text_codec_is_lossless_for_controls_icons_and_unknowns(self):
+        raw = bytes.fromhex("114d2df4f5fdfe05030002d0ff")
+        text = MB.decode_message(raw)
+        self.assertEqual(text, "H a<icon:A>\n<cmd:FE05030002><glyph:D0>")
+        self.assertEqual(MB.encode_message(text), raw)
+
+    def test_uncompressed_bank_round_trips_exactly(self):
+        raw = synthetic_bank()
+        document = MB.parse_bank(raw, "synthetic.bin")
+        self.assertEqual(MB.build_bank(document), raw)
+        self.assertEqual(document["messages"][0]["text"], "HELLO\nWORLD")
+
+    def test_edit_rebuilds_offsets_and_remains_parseable(self):
+        raw = synthetic_bank()
+        document = MB.parse_bank(raw)
+        document["messages"][0]["text"] = "A MUCH LONGER LINE"
+        rebuilt = MB.build_bank(document)
+        reparsed = MB.parse_bank(rebuilt)
+        self.assertEqual(reparsed["messages"][0]["text"], "A MUCH LONGER LINE")
+        self.assertEqual(reparsed["messages"][1]["text"],
+                         "Press <icon:A><cmd:FE05030002>")
+
+    def test_bad_command_length_is_rejected(self):
+        with self.assertRaises(MB.MessageBankError):
+            MB.encode_message("<cmd:FE0701>")
+
+    def test_message_count_change_is_rejected(self):
+        document = MB.parse_bank(synthetic_bank())
+        document["messages"].pop()
+        with self.assertRaises(MB.MessageBankError):
+            MB.build_bank(document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- generate separate raw NitroFS and runtime asset-handle catalogs plus C-compatible headers from a user-supplied ROM
- resolve literal asset-loader calls and emit review-only naming candidates
- extract western SM64DS message banks to readable, lossless JSON and rebuild them
- document the local-only workflow and add focused tests

## Why

Game code uses a 2,058-entry overlay-0 handle table rather than raw NitroFS IDs. Keeping those namespaces separate prevents plausible but incorrect names while giving readable cleanup work a reproducible evidence trail. The message tool exposes text and control codes without committing ROM-derived data.

## Local proof

- `python -m unittest discover -s tools` — 86 passed, 2 skipped
- generated 2,072 named NitroFS files and 2,058 runtime handles from the target ROM
- resolved 1,461 of 1,852 literal loader references as runtime handles
- exact unchanged round-trip for ENG/FRN/GMN/ITL/SPN message banks
- edited ENG bank rebuilt and reparsed successfully

All manifests, generated headers, JSON exports, and binary outputs remain under gitignored `build/`; this PR contains only original tooling, tests, and documentation.
