### PR TITLE
tools: register the TCM autoloads, and stop the strict-reloc gate passing vacuously

### DIFF
--- a/tools/bank_harvest.py
+++ b/tools/bank_harvest.py
@@ -66,6 +66,14 @@ def main():
             # the byte oracle wildcards reloc slots; refuse a candidate whose
             # relocations point somewhere other than config/**/relocs.txt records
             bad = RA.gate_wrong_dests(obj, name, L.norm_addr(addr), size, module)
+            if bad is None:
+                # gate_wrong_dests returns None when it could not check at all -- an
+                # unknown module ID, or the symbol missing from the object. None is
+                # falsy, so this used to fall through `if bad:` and bank the candidate
+                # as strict-verified having verified nothing.
+                rejected.append((name, "reloc-destination check could not run "
+                                       f"(module {module!r} unknown, or symbol absent)"))
+                continue
             if bad:
                 rejected.append((name, f"WRONG-DEST reloc: {bad[0]['cand']} "
                                        f"({bad[0]['cand_addr']}) != config {bad[0]['cfg']}"))

--- a/tools/match.py
+++ b/tools/match.py
@@ -273,10 +273,22 @@ def main():
             try:
                 rows, missing = RA.check_destinations(obj, args.func, args.addr, args.size,
                                                       args.module, name_index, config_relocs, sym_index)
-                bad = [r for r in (rows or []) if r["verdict"] == "WRONG-DEST"]
             except Exception as e:
+                # Also not a pass. This used to print "skipped" and leave ok True, so
+                # any exception in the check silently produced a verified match -- the
+                # same defect as the unknown-module path below, by a different route.
+                rows, missing = None, f"reloc-destination check raised: {e}"
+            # rows is None means the check could not run at all -- an unknown --module
+            # spelling, or the symbol missing from the object. Both used to fall through
+            # `rows or []` to an empty `bad` and report a clean strict-reloc pass having
+            # verified nothing, which is worse than not offering the flag. Fail instead.
+            if rows is None:
+                ok = False
+                print(f"  {v}: bytes match but the reloc-destination check could not run "
+                      f"-- NOT a verified match: {missing}")
                 bad = []
-                print(f"  {v}: (reloc-destination check skipped: {e})")
+            else:
+                bad = [r for r in rows if r["verdict"] == "WRONG-DEST"]
             if bad:
                 ok = False
                 print(f"  {v}: bytes match but {len(bad)} reloc destination(s) WRONG -- "

--- a/tools/modules.py
+++ b/tools/modules.py
@@ -1,14 +1,30 @@
-"""Module registry: main ARM9 + every overlay.
+"""Module registry: main ARM9, both TCM autoloads, and every overlay.
 
 Each module has its own binary, RAM base address, symbols, and relocs. Overlays
 can share a base address (they occupy the same memory slot at different times),
 so anything that records matches must key by (module, addr), never addr alone.
+
+The autoloads (itcm, dtcm) were missing here until 2026-08-01, and their absence
+was invisible rather than noisy: linkcheck's `_ranges()` never contained them, so
+a slot at 0x01ff.... resolved to no module and pr_linkcheck reported NONE -- zero
+slots checked, which reads exactly like "clean". The whole of arm9/itcm sat at
+0 of 41 matched partly because nothing in the verification stack could see it.
+See notes/itcm.md.
+
+Their images come from build/build/, not extracted/, because that is where
+config/arm9/config.yaml points dsd at them (`object: ../../build/build/itcm.bin`);
+there is no extracted/itcm.bin. Both directories are dsd extract output and both
+are gitignored, so neither is more canonical than the other -- but config.yaml is
+the source of truth for which file is which module, so follow it. Missing files
+are skipped rather than raising, so a checkout with no build/ still gets a usable
+registry, just without the autoloads.
 """
 import pathlib
 import re
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 EXTRACTED = REPO / "extracted"
+BUILD = REPO / "build" / "build"
 CFG = REPO / "config" / "arm9"
 ARM9_BASE = 0x02004000
 
@@ -36,6 +52,17 @@ def modules():
     """All modules as dicts: {name, syms, relocs, bin, base}."""
     mods = [{"name": "main", "syms": CFG / "symbols.txt", "relocs": CFG / "relocs.txt",
              "bin": EXTRACTED / "arm9_dec.bin", "base": ARM9_BASE}]
+    for name in ("itcm", "dtcm"):
+        d = CFG / name
+        syms = d / "symbols.txt"
+        b = BUILD / f"{name}.bin"
+        if not (b.is_file() and syms.is_file()):
+            continue
+        base = _overlay_base(syms)      # same derivation: the module's lowest symbol
+        if base is None:
+            continue
+        mods.append({"name": name, "syms": syms, "relocs": d / "relocs.txt",
+                     "bin": b, "base": base})
     for d in sorted((CFG / "overlays").glob("ov*")):
         syms = d / "symbols.txt"
         b = EXTRACTED / "overlays" / f"overlay_{int(d.name[2:]):04d}.bin"

--- a/tools/nearmiss_db.py
+++ b/tools/nearmiss_db.py
@@ -451,8 +451,17 @@ def bank_matches(args):
             # point somewhere other than the config/**/relocs.txt records
             import reloc_audit as RA
             _, obj = S.oracle_check(r["c_source"], r["name"], bytes.fromhex(r["target_hex"]))
-            bad = (RA.gate_wrong_dests(obj, r["name"], L.norm_addr(r["addr"]),
-                                       r["size"], r["module"]) if obj else None)
+            # No object, or gate_wrong_dests returning None (unknown module ID / symbol
+            # absent), both mean the relocation check did not run. None is falsy, so
+            # this used to fall through `if bad:` and bank the draft as strict-verified
+            # having verified nothing. Refuse instead.
+            bad = RA.gate_wrong_dests(obj, r["name"], L.norm_addr(r["addr"]),
+                                      r["size"], r["module"]) if obj else None
+            if bad is None:
+                print(f"  SKIP {r['name']}: bytes match but the reloc-destination check "
+                      f"could not run (no object, module {r['module']!r} unknown, "
+                      f"or symbol absent)")
+                continue
             if bad:
                 print(f"  SKIP {r['name']}: bytes match but {len(bad)} reloc "
                       f"destination(s) WRONG (e.g. {bad[0]['cand']} != {bad[0]['cfg']})")

--- a/tools/reloc_audit.py
+++ b/tools/reloc_audit.py
@@ -276,17 +276,38 @@ def classify(cand_name, cand_mod, cand_addr, cfg, sym_index):
     return "WRONG-DEST"
 
 
+def known_modules():
+    """Normalized module IDs that actually have a relocs file.
+
+    The authority for "is this a real module", so a caller cannot verify against a
+    module ID that does not exist. Cheap enough to recompute; the paths are globbed
+    once per call and no file is read."""
+    return {m for m, _path in R.iter_reloc_files(include_itcm_dtcm=True)}
+
+
 def check_destinations(obj, sym, addr, size, mod, name_index, config_relocs, sym_index):
     """Per-reloc destination verdicts for an in-hand object. Shared by the audit
     and the match gate (match.py --strict-relocs).
 
     Returns (rows, missing) where rows is a list of dicts (one per object reloc in
     the function) and missing is the count of config relocs the candidate lacks.
-    Returns (None, reason) if the function symbol isn't in the object."""
+    Returns (None, reason) if the function symbol isn't in the object, or if `mod`
+    is not a module this repo has relocations for.
+
+    That second case used to fall through to an empty cfgmap, which is the most
+    dangerous possible failure for a gate: every reloc classified against cfg=None,
+    nothing came back WRONG-DEST, and the caller reported a clean strict-reloc pass
+    having checked nothing. A wrong callee under `--module arm9/itcm` (the path-style
+    spelling; the module ID is `itcm`) verified as a MATCH. Refuse the spelling
+    instead -- an unknown module is a caller bug, not an empty result."""
+    normalized = R.normalize_module(mod)
+    if normalized not in known_modules():
+        return None, (f"unknown module {mod!r} (normalizes to {normalized!r}); "
+                      f"expected one of arm9, itcm, dtcm, ovNNN")
     dests, size_or_reason = object_reloc_dests(obj, sym, name_index)
     if dests is None:
         return None, size_or_reason
-    cfgmap = config_relocs.get(R.normalize_module(mod), {})
+    cfgmap = config_relocs.get(normalized, {})
     cand_offsets = {o for o, *_ in dests}
     rows = []
     for o, symname, cmod, caddr in dests:

--- a/tools/test_reloc_audit_modules.py
+++ b/tools/test_reloc_audit_modules.py
@@ -1,0 +1,83 @@
+"""The strict-reloc gate must refuse a module ID it does not recognise.
+
+Regression test for a silent false pass: check_destinations looked its module up
+with `config_relocs.get(normalize_module(mod), {})`, so a misspelled module
+(`arm9/itcm` for `itcm` -- the config *path* rather than the module ID) produced an
+empty map, classified every relocation against cfg=None, returned no WRONG-DEST
+rows, and let match.py --strict-relocs report a verified match. A deliberately
+wrong callee passed that way.
+
+These tests need no compiler and no ROM: the module check runs before the object
+is parsed, which is also why an empty object is a valid argument here.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import reloc_audit as RA  # noqa: E402
+
+
+def _check(module):
+    """check_destinations with everything but the module stubbed out."""
+    return RA.check_destinations(b"", "some_symbol", 0x01ffd920, 0x5c, module,
+                                 name_index={}, config_relocs={}, sym_index={})
+
+
+def test_known_modules_covers_the_real_ones():
+    known = RA.known_modules()
+    assert "arm9" in known
+    assert "itcm" in known
+    assert "dtcm" in known
+    assert any(m.startswith("ov") for m in known)
+
+
+def test_path_style_module_is_rejected():
+    """The exact spelling that caused the false pass."""
+    rows, reason = _check("arm9/itcm")
+    assert rows is None
+    assert "unknown module" in reason
+    assert "arm9/itcm" in reason
+
+
+def test_other_unknown_spellings_are_rejected():
+    for bad in ("arm9/overlays/ov002", "bogus", "overlay2", ""):
+        rows, reason = _check(bad)
+        assert rows is None, f"{bad!r} should be rejected"
+        assert "unknown module" in reason
+
+
+def test_known_modules_get_past_the_module_check():
+    """A real module ID must NOT be rejected for being unknown. It then reaches the
+    object parse, which on our empty object either raises or returns some other
+    reason -- both prove the module check let it through."""
+    for good in ("itcm", "arm9", "main", "ov002", "overlay(2)"):
+        try:
+            rows, reason = _check(good)
+        except Exception:
+            continue        # got past the module check and into the ELF parse
+        assert rows is None, f"{good!r} unexpectedly parsed an empty object"
+        assert "unknown module" not in reason, f"{good!r} was wrongly rejected: {reason}"
+
+
+def test_gate_wrong_dests_signals_cannot_check_with_none():
+    """The contract the three call sites depend on: None means "did not check",
+    [] means "checked, all destinations agree". They are not interchangeable, and
+    None is falsy -- which is how the false pass got into all three."""
+    assert RA.gate_wrong_dests(b"", "some_symbol", 0x01ffd920, 0x5c, "arm9/itcm") is None
+
+
+def test_no_caller_treats_a_none_gate_result_as_clean():
+    """Guard against the defect reappearing: every `gate_wrong_dests` call site must
+    test `is None` before the plain truthiness check."""
+    import re
+    root = pathlib.Path(__file__).resolve().parent
+    for path in sorted(root.glob("*.py")):
+        if path.name.startswith("test_") or path.name == "reloc_audit.py":
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "gate_wrong_dests" not in text:
+            continue
+        assert re.search(r"\bbad\s+is\s+None\b", text), (
+            f"{path.name} calls gate_wrong_dests but never checks `bad is None`; "
+            f"a None result would be treated as 'no wrong destinations'")


### PR DESCRIPTION
Two defects in the verification tooling, both of which let a check claim more than it verified. Found while matching in `arm9/itcm`; split out so the matching work can be reviewed separately, and because ITCM matches are not checkable at all without this.

## 1. The TCM autoloads were not in the module registry

`modules()` enumerated `main` plus the overlays and stopped there. `itcm` and `dtcm` are autoloads that `config/arm9/config.yaml` has always declared, and they were absent, so everything built on `modules()` inherited the blind spot.

The failure mode was silence rather than error. `linkcheck`'s `_ranges()` never contained them, so a slot at `0x01ff….` resolved to no module and `pr_linkcheck` reported **`NONE`** — zero slots checked — which on a results line sits next to `ok` and reads like it. `arm9/itcm` sitting at 0 of 41 matched is partly downstream of that.

The autoload images come from `build/build/`, not `extracted/`: there is no `extracted/itcm.bin`, and `config.yaml` is what names each module's object. Missing files are skipped rather than raising — verified against a checkout whose `build/` was genuinely absent, where `modules()` returns 91 entries, omits the autoloads, and does not throw.

## 2. The strict-reloc gate reported a pass when it had checked nothing

`reloc_audit.check_destinations` resolved its module with `config_relocs.get(normalize_module(mod), {})`, so an unrecognised module ID produced an empty map, classified every relocation against `cfg=None`, returned no `WRONG-DEST` rows, and let the caller report a clean strict-reloc pass over nothing.

The spelling that surfaced it was `--module arm9/itcm` — the config *path* rather than the module ID, which is `itcm`. Under it, a deliberately wrong callee verified as a `MATCH`.

`known_modules()` is now the authority for "is this a real module", and an unrecognised ID is refused before the object is parsed — which also makes it testable with no compiler and no ROM.

`gate_wrong_dests` already documented the contract: `None` means "could not check", `[]` means "checked, all destinations agree". `None` is falsy, so all three call sites fell through `if bad:` and treated it as clean:

| caller | what "could not check" used to do |
|---|---|
| `match.py` | report a verified match |
| `bank_harvest.py` | **bank the candidate into the ledger** |
| `nearmiss_db.py` | **bank the draft as a match** |

All three now refuse. `match.py` additionally stops swallowing exceptions from the check into a pass — that path printed `reloc-destination check skipped` and left the match reported as verified, which is the same defect by another route.

## Verification

- Six new tests, none needing a compiler or ROM, including a guard that greps every `gate_wrong_dests` call site for an `is None` test so this cannot reappear. The four targeted ones fail against the pre-fix code. Suite: **81 passed, 2 skipped** (was 75).
- The stricter gate run against already-matched functions that carry relocations: **24 of 24 in arm9**, **9 of 10** across ten different overlays.

The single failure is **not** from this change. `ov058 _ZN15RecRoomCupboardD1Ev` is a real pre-existing `WRONG-DEST` — it relocates to `_ZN5ActorD1Ev` (`0x02011374`) where config records `0x020112c8` — and reproduces identically with this commit's tools reverted. It looks like fallout from the recent Actor/Player symbol work and deserves attention on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011geKcos2TuNYwHEXV9Ye7d